### PR TITLE
fix(#3676): JS-host Symbol.for / well-known symbol reads return the canonical i32 id

### DIFF
--- a/plan/issues/3676-symbol-host-i32-rep.md
+++ b/plan/issues/3676-symbol-host-i32-rep.md
@@ -1,0 +1,210 @@
+---
+id: 3676
+title: "JS-host Symbol.for / well-known-symbol value reads return externref, not the canonical i32 symbol id — React 19 emits a valid module that cannot instantiate"
+status: done
+sprint: current
+created: 2026-07-26
+updated: 2026-07-26
+completed: 2026-07-26
+assignee: ttraenkler/opus-dev
+priority: high
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen, runtime
+goal: dogfood
+related: [2610, 2792, 2866, 3085, 1467, 2163]
+origin: "React 19 dogfood — react.production.js compiled to a valid 45,739-byte module with 132 correct exports but threw TypeError at __module_init"
+# The growth is overwhelmingly explanatory comment, not logic. The three edits
+# are: one boolean predicate + a widened disjunct (property-access-dispatch),
+# one import-name/ValType swap + one static-type-gated branch
+# (call-namespace-static), and two new host imports (runtime). runtime.ts also
+# LOSES ~40 lines to the `_resolveSymbolCache` extraction, which de-duplicates
+# three copies of the well-known seeding block; the net +64 is the two new
+# import handlers and the comments explaining why the seeding had to be shared.
+loc-budget-allow:
+  - src/runtime.ts
+  - src/codegen/expressions/call-namespace-static.ts
+  - src/codegen/property-access-dispatch.ts
+func-budget-allow:
+  - src/runtime.ts::resolveImport
+  - src/codegen/expressions/call-namespace-static.ts::compileNamespaceStaticCall
+  - src/codegen/property-access-dispatch.ts::tryIdentifierNamespaceAndStaticReceiverRead
+---
+
+# #3676 — JS-host symbol producers must yield the canonical i32 symbol id
+
+## Symptom
+
+Compiling React 19.2.6's production CJS build
+(`node_modules/react/cjs/react.production.js`) with
+`{ allowJs: true, skipSemanticDiagnostics: true, emulateNode: true }` emitted a
+**valid** Wasm module — `WebAssembly.validate` returned `true`, 137 exports,
+zero compile errors — that **could not be instantiated**:
+
+```
+TypeError: Cannot convert a Symbol value to a number
+    at Number (<anonymous>)
+    at <anonymous> (src/runtime.ts:14009:16)     <- __unbox_number, `return Number(v)`
+    at fn (src/runtime.ts:14853:27)              <- host-call wrapper
+    at __module_init (wasm-function[158])
+```
+
+React's first statement is twelve chained `Symbol.for(...)` initializers plus
+`MAYBE_ITERATOR_SYMBOL = Symbol.iterator`.
+
+`runtime.ts`'s `__unbox_number` is **correct** and was not changed: per #1434 it
+deliberately lets the TypeError propagate, because `Number(Symbol())` must throw
+per §7.1.4. The defect was that something called it on a Symbol at all.
+
+## Root cause — a representation split, not an initializer bug
+
+The compiler represents a symbol **value** as an **i32 id** everywhere:
+
+- `mapTsTypeToWasm` (`src/checker/type-mapper.ts:80`) maps `symbol` → `{ kind: "i32" }`
+- `compileSymbolCall` (`src/codegen/literals.ts:1917`) — i.e. `Symbol()` — returns
+  an unbranded `{ kind: "i32" }` counter
+- `__box_symbol` is the i32 → host-Symbol bridge, pre-seeding ids 1..14 with the
+  genuine well-known symbols
+
+Two producers disagreed **under the default JS-host target only** and handed
+back an `externref` instead:
+
+| #   | producer                        | site                               | returned                                         |
+| --- | ------------------------------- | ---------------------------------- | ------------------------------------------------ |
+| D1  | `Symbol.<wellKnown>` value read | `property-access-dispatch.ts:1673` | `externref` via `__get_builtin` + `__extern_get` |
+| D2  | `Symbol.for(key)`               | `call-namespace-static.ts:365`     | `externref` via the `__symbol_for` host import   |
+
+Landing that `externref` in a `symbol`-typed **i32** slot makes `coerceType`
+bridge it with `__unbox_number` — literally `Number(Symbol())`. Because
+module-scope initializers execute in `__module_init`, the module compiled
+cleanly and died at instantiate.
+
+Direct evidence, `var S = Symbol.for("x")`:
+
+```wat
+(global $__mod_S (mut i32) (i32.const 0))
+(func $__module_init
+    global.get 0
+    call 0            ;; __symbol_for  : (externref) -> externref
+    call 1            ;; __unbox_number: (externref) -> f64   <-- throws here
+    i32.trunc_sat_f64_s
+    global.set 3)
+```
+
+For D1 the pre-existing code comment asserted the two lowerings were
+"observationally identical" in gc/host mode. **That claim was false** — they
+return different ValTypes (`externref` vs `i32`), which is precisely the bug.
+
+### It was NOT confined to the initializer path
+
+The initial pin suggested a module-scope-initializer defect, because
+`export function g(){ var S = Symbol.for("x"); }` appeared to pass. That row was
+**vacuous**: the local was never read. Once read
+(`S === Symbol.for("k")`), the function-local case failed identically. The
+discriminator is not "initializer vs assignment" but **"does a `symbol`-typed
+slot ever receive one of these two producers' values"**. `var S; S = Symbol.for(...)`
+survives only because an initializer-less `var` is typed `any` → `externref`, so
+no coercion happens.
+
+## Fix
+
+Put both producers on the **same, already-exercised footing as `Symbol()`**. No
+new representation is introduced; an inconsistent one is removed.
+
+1. **D1** (`src/codegen/property-access-dispatch.ts`) — defer to the downstream
+   `i32.const <id>` constant emitter for `Symbol.<wellKnown>` in **both** modes,
+   not just standalone. Scoped strictly to `Symbol.<wellKnown>`: the Math/Number
+   f64 constants and `<Ctor>.length`/`.name` keep their standalone-only defer, so
+   host-mode bytes for those are unchanged. Identity across the boundary already
+   holds because `__box_symbol` pre-seeds ids 1..14.
+
+2. **D2** (`src/codegen/expressions/call-namespace-static.ts` + `src/runtime.ts`) —
+   `Symbol.for(key)` returns the canonical i32 id via a new
+   `__symbol_for_id(externref) -> i32` host import. Ids are allocated
+   **negative**, provably disjoint from the well-knowns (1..15) and from the
+   in-module `__symbol_counter` global (starts at 100, only ascends). Each id is
+   registered into the **same** per-instance `symbolCache` that `__box_symbol`
+   reads, so identity round-trips in both directions. §20.4.2.2 step 1
+   (`ToString(key)`) is preserved by letting the host's real `Symbol.for` perform
+   the coercion.
+
+3. **`Symbol.keyFor`** follows the representation via `__symbol_keyFor_id(i32)`,
+   gated on the argument being statically a symbol — mirroring the identical
+   static-type gate #3085 added for `String(sym)`. Coercing an i32 to `externref`
+   there would box it with `__box_number` (the unbranded-i32 hazard #2792
+   describes) and hand `Symbol.keyFor` a Number.
+
+4. **`_resolveSymbolCache`** extracted in `src/runtime.ts`. This is load-bearing,
+   not cosmetic: the well-known seeding guard is `size === 0`, and
+   `__symbol_for_id` is now a _second_ writer of that map. Left inline, React's
+   twelve `Symbol.for` calls would populate the cache **before** the first
+   `__box_symbol`, making it non-empty, so the well-known seeding would be
+   skipped forever and `__box_symbol(1)` would return `Symbol("wasm_1")` instead
+   of the real `Symbol.iterator`. Seeding through one shared helper makes the
+   order irrelevant. (Also de-duplicates a third inline copy in `__new_Symbol`.)
+
+## Test Results
+
+`tests/issue-3676-symbol-host-i32-rep.test.ts` — 24 cases.
+
+|                  | merge base `5805049`      | with fix                 |
+| ---------------- | ------------------------- | ------------------------ |
+| tests/issue-3676 | **13 failed** / 11 passed | **24 passed** / 0 failed |
+
+The 11 that pass on the merge base are the **regression sentinels** — they pass
+on both sides by construction, which is what makes them able to catch an
+over-broad fix (`Symbol()` uniqueness, declare-then-assign,
+`Symbol('d').description`, array for-of, custom `[Symbol.iterator]` protocol,
+well-known distinctness).
+
+Adjacent suites (`symbol-iterator-protocol`, `symbol-async-iterator`,
+`issue-2610`, `issue-1732`, `issue-1830`, `issue-2161`, `issue-2378`,
+`issue-1916`): 70 passed / 2 failed — and those same 2
+(`symbol-async-iterator` › `for await...of with let binding` / `with
+accumulation`) fail **identically on the merge base**. Verified by reverting.
+
+### React 19 — verified by reverting
+
+|                                        | merge base                                                   | with fix                            |
+| -------------------------------------- | ------------------------------------------------------------ | ----------------------------------- |
+| compiles                               | yes, 46,449 bytes                                            | yes, 46,339 bytes                   |
+| instantiates                           | **no** — `TypeError` at `__module_init` (wasm-function[158]) | **yes**, 137 exports (136 callable) |
+| `createElement("div", {id:"a"}, "hi")` | unreachable                                                  | returns an object                   |
+| `isValidElement(<that element>)`       | unreachable                                                  | **1**                               |
+| `isValidElement({}) / (null) / ("s")`  | unreachable                                                  | **0 / 0 / 0**                       |
+
+`isValidElement` is the load-bearing row: it is React's **own** check of
+`$$typeof === REACT_ELEMENT_TYPE`, i.e. of the very `Symbol.for` value this
+change repairs, and it discriminates (three negatives return 0), so it is not
+vacuous.
+
+## What this does NOT fix (honest scope)
+
+**React instantiates; React does not "work".** Three separate walls remain, all
+outside this change:
+
+1. **Host→module Symbol direction is still broken.** Passing a host object
+   carrying a real JS Symbol _into_ the module
+   (`isValidElement({ $$typeof: Symbol.for("react.transitional.element") })`)
+   throws the same `__unbox_number` TypeError. This change fixed the
+   **producer** side (module-internal symbols); the **inbound** `externref` host
+   Symbol → i32 id bridge does not exist. `type-coercion.ts:1741` has exactly
+   this bridge but gated `(ctx.standalone || ctx.wasi) && to.symbol === true`,
+   and `mapTsTypeToWasm` deliberately does not set the `symbol` brand (#2792).
+   Closing this is the #2610 symbol-as-any value-rep work — a value-substrate
+   change, deliberately not attempted here.
+
+2. **`Object.getOwnPropertySymbols(o)` → a symbol slot** throws the same
+   TypeError. Same class, same missing inbound bridge; **pre-existing and
+   source-independent** — it fails identically for `Symbol()` and `Symbol.for()`
+   on the merge base. Verified by reverting.
+
+3. **Returned objects are opaque to the host.** `Object.keys(element)` is `[]`,
+   `element.type` / `element.$$typeof` read `undefined` — the element is a
+   WasmGC struct, not a host-readable object. Separate struct↔host interop axis.
+   `React.version` (a non-function export) is likewise `undefined`, and
+   `Children` is missing.
+
+`useState()` throwing outside a renderer is **correct** React behaviour (no
+dispatcher installed), not a defect.

--- a/src/codegen/expressions/call-namespace-static.ts
+++ b/src/codegen/expressions/call-namespace-static.ts
@@ -360,17 +360,32 @@ export function compileNamespaceStaticCall(
         fctx.body.push({ op: "call", funcIdx: forIdx });
         return { kind: "i32" };
       }
+      // (#3676) JS-host mode: return the module's CANONICAL i32 symbol id, not a
+      // raw host Symbol. A symbol VALUE is an i32 id everywhere else in the
+      // compiler — `mapTsTypeToWasm` maps `symbol` → i32 and the sibling
+      // producer `compileSymbolCall` (`Symbol()`) returns an unbranded
+      // `{ kind: "i32" }`. `Symbol.for` was the outlier returning `externref`,
+      // so a `symbol`-typed slot (module global, local, param) received an
+      // externref and `coerceType` bridged it with `__unbox_number` — literally
+      // `Number(Symbol())`, a guaranteed TypeError (§7.1.4) at `__module_init`.
+      // That is why React 19, whose very first statement is twelve chained
+      // `Symbol.for(...)` initializers, emitted a valid module that could not be
+      // instantiated. Returning i32 here puts `Symbol.for` on exactly the same,
+      // already-exercised footing as `Symbol()`: no new representation is
+      // introduced, an inconsistent one is removed. `__symbol_for_id` registers
+      // the id in the same per-instance cache `__box_symbol` reads, so identity
+      // survives a round trip through the host in both directions.
       const keyType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
       if (keyType && keyType.kind !== "externref") coerceType(ctx, fctx, keyType, { kind: "externref" });
-      const funcIdx = ensureLateImport(ctx, "__symbol_for", [{ kind: "externref" }], [{ kind: "externref" }]);
+      const funcIdx = ensureLateImport(ctx, "__symbol_for_id", [{ kind: "externref" }], [{ kind: "i32" }]);
       flushLateImportShifts(ctx, fctx);
       if (funcIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx });
-        return { kind: "externref" };
+        return { kind: "i32" };
       }
       fctx.body.push({ op: "drop" });
-      fctx.body.push({ op: "ref.null.extern" });
-      return { kind: "externref" };
+      fctx.body.push({ op: "i32.const", value: 0 });
+      return { kind: "i32" };
     }
     if (symMethod === "keyFor" && expr.arguments.length >= 1) {
       // (#2163) No-JS-host mode: the symbol is an i32 id; the native registry
@@ -382,6 +397,27 @@ export function compileNamespaceStaticCall(
         if (symType && symType.kind !== "i32") coerceType(ctx, fctx, symType, { kind: "i32" });
         fctx.body.push({ op: "call", funcIdx: keyForIdx });
         return { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx };
+      }
+      // (#3676) JS-host mode: when the argument is STATICALLY a symbol it is an
+      // i32 id (see the `Symbol.for` note above and `compileSymbolCall`), so
+      // resolve it through the id-keyed host helper. Coercing an i32 to
+      // `externref` here would box it with `__box_number` — the unbranded-i32
+      // hazard #2792 describes — and hand `Symbol.keyFor` a Number. Mirrors the
+      // identical static-type gate #3085 added for `String(sym)`.
+      // A non-symbol / `any` argument keeps the original externref path, where
+      // the host `Symbol.keyFor` produces the spec TypeError itself.
+      if (ctx.oracle.staticJsTypeOf(expr.arguments[0]!) === "symbol") {
+        const symIdType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "i32" });
+        if (symIdType && symIdType.kind !== "i32") coerceType(ctx, fctx, symIdType, { kind: "i32" });
+        const keyForIdIdx = ensureLateImport(ctx, "__symbol_keyFor_id", [{ kind: "i32" }], [{ kind: "externref" }]);
+        flushLateImportShifts(ctx, fctx);
+        if (keyForIdIdx !== undefined) {
+          fctx.body.push({ op: "call", funcIdx: keyForIdIdx });
+          return { kind: "externref" };
+        }
+        fctx.body.push({ op: "drop" });
+        fctx.body.push({ op: "ref.null.extern" });
+        return { kind: "externref" };
       }
       const symType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
       if (symType && symType.kind !== "externref") coerceType(ctx, fctx, symType, { kind: "externref" });

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -1667,10 +1667,28 @@ export function tryIdentifierNamespaceAndStaticReceiverRead(
     // `f64.const`, Number.MAX_SAFE_INTEGER → `f64.const`, Symbol.iterator →
     // `i32.const`), this shortcut would pre-empt that native lowering and turn a
     // compilable program into a hard refusal. Skip it for those (builtin, prop)
-    // pairs so control reaches the constant emitter. gc/host is unaffected
-    // (`__get_builtin` is a real host import there and the early shortcut +
-    // the later constant handler are observationally identical for these reads).
-    const deferToNativeConstant = ctx.standalone && hasNativeBuiltinConstantHandler(builtinName, propName);
+    // pairs so control reaches the constant emitter.
+    //
+    // (#3676) The trailing "gc/host is unaffected … observationally identical"
+    // claim that used to sit here was WRONG for `Symbol.<wellKnown>`, and it is
+    // the reason a module-scope `var S = Symbol.iterator` could not instantiate
+    // under the default JS-host target. The two lowerings are NOT
+    // interchangeable: the `__get_builtin`/`__extern_get` shortcut yields an
+    // `externref` (a real host Symbol) while the downstream constant emitter
+    // yields `i32.const <id>`. The compiler's canonical symbol VALUE
+    // representation is the i32 id — `mapTsTypeToWasm` maps `symbol` → i32 and
+    // `compileSymbolCall` returns an unbranded i32 counter — so the externref
+    // gets coerced into the i32 slot through `__unbox_number`, i.e. literally
+    // `Number(Symbol.iterator)`, which throws TypeError §7.1.4 at
+    // `__module_init`. Fold well-known symbol reads to their i32 id in BOTH
+    // modes so producer and slot agree. Identity across the host boundary is
+    // preserved because `__box_symbol` pre-seeds ids 1..14 with the genuine
+    // well-known symbols. Scoped to `Symbol.<wellKnown>` only — the Math/Number
+    // f64 constants and `<Ctor>.length`/`.name` keep their standalone-only
+    // defer, so host-mode bytes for those are unchanged.
+    const deferToWellKnownSymbolId = builtinName === "Symbol" && getWellKnownSymbolId(propName) !== undefined;
+    const deferToNativeConstant =
+      deferToWellKnownSymbolId || (ctx.standalone && hasNativeBuiltinConstantHandler(builtinName, propName));
     if (ctx.standalone && BUILTIN_CTOR_NAMES.has(builtinName) && !isShadowed && !deferToNativeConstant) {
       // (#2175 S1) `<Builtin>.prototype` as a value → the native `$NativeProto`
       // object (host-free), for builtins with a registered brand. This is the

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3760,6 +3760,47 @@ const _symbolIdToKeys: Map<number, { wasm: string; sym: symbol }> = new Map([
 ]);
 
 /**
+ * (#3676) Resolve the per-instance symbol-id → JS Symbol cache, seeding the
+ * well-known ids on first use.
+ *
+ * Extracted from `__box_symbol` because it now has a SECOND consumer
+ * (`__symbol_for_id`), and the seeding guard is `size === 0`. Left inline, a
+ * `Symbol.for(...)` call that ran before the first `__box_symbol` would put an
+ * entry in the map, making it non-empty, so the well-known seeding would be
+ * skipped forever and `__box_symbol(1)` would hand back `Symbol("wasm_1")`
+ * instead of the real `Symbol.iterator`. React's module init does exactly that
+ * ordering (twelve `Symbol.for` calls on line 12 before anything else), so this
+ * is a live hazard, not a theoretical one. Seeding through one shared helper
+ * makes the order irrelevant.
+ *
+ * Seeds ids 1..14 exactly as the original inline block did — id 15
+ * (`@@matchAll`) was NOT seeded there and is deliberately still not, to keep
+ * this a pure refactor of the existing behaviour.
+ */
+function _resolveSymbolCache(instanceState?: InstanceState): Map<number, symbol> {
+  const symbolCache =
+    instanceState?.symbolCache ??
+    (instanceState ? (instanceState.symbolCache = new Map<number, symbol>()) : new Map<number, symbol>());
+  if (symbolCache.size === 0) {
+    symbolCache.set(1, Symbol.iterator);
+    symbolCache.set(2, Symbol.hasInstance);
+    symbolCache.set(3, Symbol.toPrimitive);
+    symbolCache.set(4, Symbol.toStringTag);
+    symbolCache.set(5, Symbol.species);
+    symbolCache.set(6, Symbol.isConcatSpreadable);
+    symbolCache.set(7, Symbol.match);
+    symbolCache.set(8, Symbol.replace);
+    symbolCache.set(9, Symbol.search);
+    symbolCache.set(10, Symbol.split);
+    symbolCache.set(11, Symbol.unscopables);
+    symbolCache.set(12, Symbol.asyncIterator);
+    symbolCache.set(13, _disposeSym);
+    symbolCache.set(14, _asyncDisposeSym);
+  }
+  return symbolCache;
+}
+
+/**
  * Resolve a class from a namespace path (#1044).
  * For Node builtins like `import * as http from 'http'`, resolves `http.Server`
  * by trying: deps override → require(root)[className].
@@ -6828,6 +6869,13 @@ interface InstanceState {
   symbolCache?: Map<number, symbol>;
   /** symbol id → user-registered description (`null` = Symbol() w/ no desc). */
   symbolDescRegistry?: Map<number, string | null>;
+  /**
+   * (#3676) `Symbol.for` registry key → the i32 id the compiled module uses for
+   * that registered symbol. Ids are allocated NEGATIVE so they can never
+   * collide with the well-known ids (1..15) or with the in-module
+   * `__symbol_counter` global, which starts at 100 and only ever ascends.
+   */
+  symbolForIds?: Map<string, number>;
   /** legacy RegExp static state (`RegExp.$1` etc.) — per instance, not shared. */
   legacyRegExpState?: LegacyRegExpState;
   /** user-class name → registered subclass constructors (#1933 retention leak). */
@@ -9343,25 +9391,7 @@ assert._isSameValue = isSameValue;
         // #1933 — per-instance symbol cache (was module-level `_symbolCache`,
         // reset per buildImports → clobbered concurrent instances). Falls back
         // to a local map when no instanceState is threaded (legacy callers).
-        const symbolCache =
-          instanceState?.symbolCache ??
-          (instanceState ? (instanceState.symbolCache = new Map<number, symbol>()) : new Map<number, symbol>());
-        if (symbolCache.size === 0) {
-          symbolCache.set(1, Symbol.iterator);
-          symbolCache.set(2, Symbol.hasInstance);
-          symbolCache.set(3, Symbol.toPrimitive);
-          symbolCache.set(4, Symbol.toStringTag);
-          symbolCache.set(5, Symbol.species);
-          symbolCache.set(6, Symbol.isConcatSpreadable);
-          symbolCache.set(7, Symbol.match);
-          symbolCache.set(8, Symbol.replace);
-          symbolCache.set(9, Symbol.search);
-          symbolCache.set(10, Symbol.split);
-          symbolCache.set(11, Symbol.unscopables);
-          symbolCache.set(12, Symbol.asyncIterator);
-          symbolCache.set(13, _disposeSym);
-          symbolCache.set(14, _asyncDisposeSym);
-        }
+        const symbolCache = _resolveSymbolCache(instanceState);
         const symbolDescRegistry =
           instanceState?.symbolDescRegistry ??
           (instanceState
@@ -11704,6 +11734,58 @@ assert._isSameValue = isSameValue;
       // itself performs ToString, so forwarding a real Symbol primitive
       // reproduces the spec throw; other values stringify normally.
       if (name === "__symbol_for") return (key: any): any => Symbol.for(key);
+      // (#3676) `Symbol.for(key)` returning the module's CANONICAL i32 symbol
+      // id rather than a raw host Symbol.
+      //
+      // The compiler represents a symbol VALUE as an i32 id everywhere:
+      // `mapTsTypeToWasm` maps `symbol` → i32, and `compileSymbolCall`
+      // (`Symbol()`) returns an unbranded i32 counter. `__symbol_for` was the
+      // one producer handing back an `externref`, so `var S = Symbol.for("x")`
+      // stored an externref into an i32 slot — coerced via `__unbox_number`,
+      // i.e. `Number(Symbol())`, which throws TypeError §7.1.4 during
+      // `__module_init`. That single mismatch is what stopped React 19 (twelve
+      // `Symbol.for` calls on its first line) from instantiating at all.
+      //
+      // Ids are allocated NEGATIVE and are provably disjoint from every other
+      // id source: well-knowns occupy 1..15 and the in-module `__symbol_counter`
+      // global starts at 100 and only ascends. Each id is registered into the
+      // SAME per-instance `symbolCache` that `__box_symbol` reads, so boxing the
+      // id back across the boundary yields the genuine registry symbol and
+      // `Symbol.for(k) === Symbol.for(k)` holds in both directions.
+      // §20.4.2.2 step 1 (`stringKey = ? ToString(key)`) is preserved by letting
+      // `Symbol.for` itself perform the coercion — a Symbol key still throws.
+      if (name === "__symbol_for_id") {
+        const symbolCache = _resolveSymbolCache(instanceState);
+        const symbolForIds =
+          instanceState?.symbolForIds ??
+          (instanceState ? (instanceState.symbolForIds = new Map<string, number>()) : new Map<string, number>());
+        return (key: any): number => {
+          // ToString FIRST (spec order, and it may throw); key the map on the
+          // coerced string so `Symbol.for(1)` and `Symbol.for("1")` agree.
+          const sym = Symbol.for(key);
+          const k = sym.description as string;
+          let id = symbolForIds.get(k);
+          if (id === undefined) {
+            id = -(symbolForIds.size + 1);
+            symbolForIds.set(k, id);
+            symbolCache.set(id, sym);
+          }
+          return id;
+        };
+      }
+      // (#3676) `Symbol.keyFor(sym)` taking the canonical i32 symbol id.
+      // Companion to `__symbol_for_id`: resolves the id back through the shared
+      // per-instance cache and applies the real `Symbol.keyFor`, so an
+      // unregistered symbol (well-known, or one made by `Symbol()`) still yields
+      // `undefined` per §20.4.2.6. An id with no cache entry never came from
+      // this instance's registry, so it is likewise `undefined`.
+      if (name === "__symbol_keyFor_id") {
+        const symbolCache = _resolveSymbolCache(instanceState);
+        return (id: number): any => {
+          const sym = symbolCache.get(id);
+          return sym === undefined ? undefined : Symbol.keyFor(sym);
+        };
+      }
       // Symbol.keyFor(sym) — reverse lookup in global registry (#965, #1342)
       // Spec §20.4.2.6: returns the key string for registered symbols, or
       // `undefined` for any other symbol. Returning `null` (the previous
@@ -11772,25 +11854,7 @@ assert._isSameValue = isSameValue;
       // symbol preserves identity/description) then `Object()` it into a wrapper
       // object. `Symbol.prototype.description` already unwraps such wrappers.
       if (name === "__new_Symbol") {
-        const symbolCache =
-          instanceState?.symbolCache ??
-          (instanceState ? (instanceState.symbolCache = new Map<number, symbol>()) : new Map<number, symbol>());
-        if (symbolCache.size === 0) {
-          symbolCache.set(1, Symbol.iterator);
-          symbolCache.set(2, Symbol.hasInstance);
-          symbolCache.set(3, Symbol.toPrimitive);
-          symbolCache.set(4, Symbol.toStringTag);
-          symbolCache.set(5, Symbol.species);
-          symbolCache.set(6, Symbol.isConcatSpreadable);
-          symbolCache.set(7, Symbol.match);
-          symbolCache.set(8, Symbol.replace);
-          symbolCache.set(9, Symbol.search);
-          symbolCache.set(10, Symbol.split);
-          symbolCache.set(11, Symbol.unscopables);
-          symbolCache.set(12, Symbol.asyncIterator);
-          symbolCache.set(13, _disposeSym);
-          symbolCache.set(14, _asyncDisposeSym);
-        }
+        const symbolCache = _resolveSymbolCache(instanceState);
         const symbolDescRegistry =
           instanceState?.symbolDescRegistry ??
           (instanceState

--- a/tests/issue-3676-symbol-host-i32-rep.test.ts
+++ b/tests/issue-3676-symbol-host-i32-rep.test.ts
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3676 — JS-host symbol VALUE producers must yield the canonical i32 symbol id.
+ *
+ * The compiler represents a symbol value as an i32 id everywhere: `mapTsTypeToWasm`
+ * maps `symbol` → i32 and `compileSymbolCall` (`Symbol()`) returns an unbranded
+ * i32 counter. Two producers disagreed under the default JS-host target and
+ * handed back an `externref` instead:
+ *
+ *   1. `Symbol.for(key)`          → `__symbol_for` host import (externref)
+ *   2. `Symbol.<wellKnown>` value → `__get_builtin` + `__extern_get` (externref)
+ *
+ * Landing an externref in a `symbol`-typed i32 slot makes `coerceType` bridge it
+ * with `__unbox_number` — literally `Number(Symbol())` — which throws TypeError
+ * per §7.1.4. Because module-scope initializers run in `__module_init`, the
+ * module compiled to a VALID binary that could not be instantiated at all.
+ *
+ * This is the defect that stopped React 19's production CJS build from
+ * instantiating: its first statement is twelve chained `Symbol.for(...)`
+ * initializers plus `MAYBE_ITERATOR_SYMBOL = Symbol.iterator`.
+ *
+ * NOTE ON TEST PATH: a bare `compile()` does NOT reproduce this — compilation
+ * succeeds and emits a valid module. The failure is only observable at
+ * INSTANTIATE time, so every case here must go through a helper that actually
+ * instantiates with the real host imports.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { instantiateWasm } from "../src/runtime-instantiate.js";
+import { compileAndRunHost } from "./helpers/compile.js";
+
+/**
+ * Instantiate the way the shipping runtime does — via `instantiateWasm`, which
+ * prefers the native `wasm:js-string` builtins and only falls back to the JS
+ * polyfill. `compileAndRunHost` calls `WebAssembly.instantiate` directly, so it
+ * always takes the polyfill path. That difference is invisible for everything
+ * else in this file, but the custom-`@@iterator` sentinel below only works on
+ * the native-builtin path (on BOTH the merge base and this branch), so it must
+ * be exercised through the runtime's own helper to mean anything.
+ */
+async function compileAndRunNativeStrings(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    new Uint8Array(result.binary),
+    imports.env,
+    imports.string_constants,
+    (imports as unknown as { string_constants16?: Record<string, WebAssembly.Global> }).string_constants16,
+  );
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#3676 Symbol.for / well-known symbols use the canonical i32 id (JS-host)", () => {
+  describe("module-scope initializers instantiate", () => {
+    // The regression proper: each of these threw
+    // "Cannot convert a Symbol value to a number" from __module_init.
+    it("var S = Symbol.for(k)", async () => {
+      const e = await compileAndRunHost(`
+        var S = Symbol.for("k");
+        export function g(): number { return S === Symbol.for("k") ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("const S = Symbol.for(k)", async () => {
+      const e = await compileAndRunHost(`
+        const S = Symbol.for("k");
+        export function g(): number { return S === Symbol.for("k") ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("let S = Symbol.for(k)", async () => {
+      const e = await compileAndRunHost(`
+        let S = Symbol.for("k");
+        export function g(): number { return S === Symbol.for("k") ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("multi-declarator list (the React shape)", async () => {
+      // React: `var REACT_ELEMENT_TYPE = Symbol.for("..."), REACT_PORTAL_TYPE = ...`
+      const e = await compileAndRunHost(`
+        var A = Symbol.for("react.transitional.element"),
+            B = Symbol.for("react.portal"),
+            C = Symbol.iterator;
+        export function distinct(): number { return A !== B ? 1 : 0; }
+        export function stable(): number { return A === Symbol.for("react.transitional.element") ? 1 : 0; }
+        export function iter(): number { return C === Symbol.iterator ? 1 : 0; }
+      `);
+      expect(e.distinct!()).toBe(1);
+      expect(e.stable!()).toBe(1);
+      expect(e.iter!()).toBe(1);
+    });
+
+    it("var S = Symbol.iterator", async () => {
+      const e = await compileAndRunHost(`
+        var S = Symbol.iterator;
+        export function g(): number { return S === Symbol.iterator ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("var S = Symbol.asyncIterator", async () => {
+      const e = await compileAndRunHost(`
+        var S = Symbol.asyncIterator;
+        export function g(): number { return S === Symbol.asyncIterator ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+  });
+
+  describe("reads of a symbol binding (not just the store)", () => {
+    // These were the rows that made the defect broader than "module initializer":
+    // a function-LOCAL `var S = Symbol.for(...)` also failed, but only once S was
+    // actually READ. A probe that declared S and never used it passed vacuously.
+    it("function-local Symbol.for, compared against the same key", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { const S = Symbol.for("k"); return S === Symbol.for("k") ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("function-local Symbol.for, compared against a different key", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { const S = Symbol.for("k"); return S === Symbol.for("q") ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(0);
+    });
+
+    it("typeof a Symbol.for binding is 'symbol'", async () => {
+      const e = await compileAndRunHost(`
+        var S = Symbol.for("k");
+        export function g(): number { return typeof S === "symbol" ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+  });
+
+  describe("registry semantics survive the representation change", () => {
+    it("Symbol.keyFor(Symbol.for(k)) === k", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { return Symbol.keyFor(Symbol.for("k")) === "k" ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("Symbol.keyFor through a module global", async () => {
+      const e = await compileAndRunHost(`
+        var S = Symbol.for("kk");
+        export function g(): number { return Symbol.keyFor(S) === "kk" ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("Symbol.keyFor of an UNregistered symbol is undefined", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { return Symbol.keyFor(Symbol("k")) === undefined ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("Symbol.keyFor of a well-known symbol is undefined", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { return Symbol.keyFor(Symbol.iterator) === undefined ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("Symbol.for(k).description === k", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { return Symbol.for("d").description === "d" ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("String(Symbol.for(k)) is the descriptive string", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { return String(Symbol.for("s")) === "Symbol(s)" ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("a Symbol.for value works as a property key", async () => {
+      const e = await compileAndRunHost(`
+        var A = Symbol.for("a"), B = Symbol.for("b");
+        export function g(): number { const o: any = {}; o[A] = 1; o[B] = 2; return o[A] * 10 + o[B]; }
+      `);
+      expect(e.g!()).toBe(12);
+    });
+  });
+
+  describe("REGRESSION SENTINELS — shapes that already worked must keep working", () => {
+    // An over-broad fix that changed these is a net loss, so they are asserted
+    // explicitly rather than assumed.
+    it("SENTINEL: module-scope Symbol() still instantiates and is unique", async () => {
+      const e = await compileAndRunHost(`
+        var A = Symbol("k"), B = Symbol("k");
+        export function same(): number { return A === A ? 1 : 0; }
+        export function distinct(): number { return A === B ? 1 : 0; }
+      `);
+      expect(e.same!()).toBe(1);
+      expect(e.distinct!()).toBe(0);
+    });
+
+    it("SENTINEL: declare-then-assign still works", async () => {
+      const e = await compileAndRunHost(`
+        var S: any;
+        S = Symbol.for("k");
+        export function g(): number { return S === Symbol.for("k") ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("SENTINEL: Symbol('d').description still round-trips", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { return Symbol("d").description === "d" ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(1);
+    });
+
+    it("SENTINEL: for-of over an array still uses @@iterator", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { let t = 0; for (const v of [1, 2, 3]) t += v; return t; }
+      `);
+      expect(e.g!()).toBe(6);
+    });
+
+    it("SENTINEL: a user object's [Symbol.iterator] protocol still drives for-of", async () => {
+      // This is the sharpest sentinel for the well-known-symbol half of the
+      // change: a user object keyed by `[Symbol.iterator]` must still be found
+      // by for-of after `Symbol.<wellKnown>` value reads stopped going through
+      // `__get_builtin`. Run on the native-builtin instantiation path — see
+      // `compileAndRunNativeStrings`.
+      const e = await compileAndRunNativeStrings(`
+        const o = {
+          [Symbol.iterator]() {
+            let i = 0;
+            return { next() { return i < 3 ? { value: ++i, done: false } : { value: undefined, done: true }; } };
+          },
+        };
+        export function g(): number { let t = 0; for (const v of o as any) t += v; return t; }
+      `);
+      expect(e.g!()).toBe(6);
+    });
+
+    it("SENTINEL: distinct well-known symbols stay distinct", async () => {
+      const e = await compileAndRunHost(`
+        export function g(): number { return (Symbol.iterator as any) === (Symbol.asyncIterator as any) ? 1 : 0; }
+      `);
+      expect(e.g!()).toBe(0);
+    });
+
+    // NOTE: the §20.4.2.2 step-1 "Symbol key makes ToString throw" branch is
+    // deliberately NOT asserted here. Reaching it requires the argument's
+    // STATIC type to be `symbol`, which `Symbol.for(key: string)` rejects — any
+    // cast wide enough to compile (`as any` / `as never`) also defeats the
+    // `isSymbolType` gate that selects the branch, so the test would only ever
+    // exercise the cast. That branch sits ABOVE the code this change touches
+    // and is byte-for-byte untouched by it.
+  });
+
+  describe("lowering shape (guards against a silent revert to the externref path)", () => {
+    it("Symbol.iterator folds to a constant id, with no __get_builtin round trip", async () => {
+      const r = await compile(`var S = Symbol.iterator; export function g(): number { return 1; }`, {
+        emitWat: true,
+      } as never);
+      const wat = (r as unknown as { wat: string }).wat;
+      expect(wat).toContain("$__module_init");
+      // Positive: the module-init store must be a folded constant.
+      expect(wat).toMatch(/\$__module_init[\s\S]*?i32\.const 1[\s\S]*?global\.set/);
+      // Negative: the two host imports of the broken lowering must be gone.
+      expect(wat).not.toContain("__get_builtin");
+      expect(wat).not.toContain("__unbox_number");
+    });
+
+    it("Symbol.for uses the id-returning host import, not __unbox_number", async () => {
+      const r = await compile(`var S = Symbol.for("k"); export function g(): number { return 1; }`, {
+        emitWat: true,
+      } as never);
+      const wat = (r as unknown as { wat: string }).wat;
+      expect(wat).toContain("__symbol_for_id");
+      expect(wat).not.toContain("__unbox_number");
+    });
+  });
+});


### PR DESCRIPTION
## Symptom

React 19.2.6's production CJS build compiled to a **valid** 46 KB module with 137 correct exports — `WebAssembly.validate` returned `true`, zero compile errors — that **could not be instantiated**:

```
TypeError: Cannot convert a Symbol value to a number
    at Number (<anonymous>)          <- __unbox_number
    at __module_init (wasm-function[158])
```

React's first statement is twelve chained `Symbol.for(...)` initializers plus `MAYBE_ITERATOR_SYMBOL = Symbol.iterator`.

`__unbox_number` is **correct** and unchanged — per #1434 it deliberately lets the TypeError propagate, because `Number(Symbol())` must throw per §7.1.4. The bug was calling it on a Symbol at all.

## Root cause — a representation split, not an initializer bug

The compiler represents a symbol **value** as an **i32 id** everywhere: `mapTsTypeToWasm` maps `symbol` → i32, and `compileSymbolCall` (`Symbol()`) returns an unbranded i32 counter. Two producers disagreed **under the JS-host target only** and returned an `externref`:

| producer                        | site                               | returned                                         |
| ------------------------------- | ---------------------------------- | ------------------------------------------------ |
| `Symbol.<wellKnown>` value read | `property-access-dispatch.ts:1673` | `externref` via `__get_builtin` + `__extern_get` |
| `Symbol.for(key)`               | `call-namespace-static.ts:365`     | `externref` via `__symbol_for`                   |

Landing that externref in a `symbol`-typed i32 slot made `coerceType` bridge it with `__unbox_number`. Module-scope initializers run in `__module_init`, so the module compiled cleanly and died at instantiate:

```wat
(func $__module_init
    global.get 0
    call 0            ;; __symbol_for  : (externref) -> externref
    call 1            ;; __unbox_number: (externref) -> f64   <-- throws
    i32.trunc_sat_f64_s
    global.set 3)
```

The D1 site carried a comment asserting the two lowerings were "observationally identical" in gc/host mode. That claim was **false** — they return different ValTypes, which is the bug.

**Not confined to the initializer path.** A function-local `var S = Symbol.for(...)` fails too, but only once `S` is **read** — a probe that declares and never reads it passes vacuously.

## Fix

Puts both producers on the same, **already-exercised** footing as `Symbol()`. No new representation is introduced; an inconsistent one is removed.

- Fold `Symbol.<wellKnown>` to `i32.const <id>` in **both** modes (was standalone-only). Identity holds because `__box_symbol` pre-seeds ids 1..14. Scoped to `Symbol` only, so Math/Number constant bytes are unchanged.
- `Symbol.for` returns the canonical id via a new `__symbol_for_id` host import, allocating **negative** ids — provably disjoint from the well-knowns (1..15) and the `__symbol_counter` global (starts at 100, only ascends) — registered into the same per-instance cache `__box_symbol` reads.
- `Symbol.keyFor` follows via `__symbol_keyFor_id`, gated on the argument being statically a symbol (mirrors the #3085 gate for `String(sym)`).
- `_resolveSymbolCache` extracted. **Load-bearing, not cosmetic**: the well-known seeding guard is `size === 0` and `__symbol_for_id` is now a second writer, so React's twelve `Symbol.for` calls would otherwise leave the map non-empty and `__box_symbol(1)` would return `Symbol("wasm_1")` instead of the real `Symbol.iterator`.

## Verification — by reverting, not by controls

`tests/issue-3676-symbol-host-i32-rep.test.ts`, 24 cases:

|                  | merge base                | with fix                 |
| ---------------- | ------------------------- | ------------------------ |
| tests/issue-3676 | **13 failed** / 11 passed | **24 passed** / 0 failed |

The 11 base-passing cases are the **regression sentinels** — passing on both sides is exactly what lets them catch an over-broad fix (`Symbol()` uniqueness, declare-then-assign, `.description`, array for-of, custom `[Symbol.iterator]` protocol, well-known distinctness).

**React 19, unmodified:**

|                                        | merge base                         | with fix               |
| -------------------------------------- | ---------------------------------- | ---------------------- |
| instantiates                           | **no** — TypeError at `__module_init` | **yes**, 137 exports   |
| `createElement("div", {id:"a"}, "hi")` | unreachable                        | returns an object      |
| `isValidElement(<that element>)`       | unreachable                        | **1**                  |
| `isValidElement({}) / (null) / ("s")`  | unreachable                        | **0 / 0 / 0**          |

`isValidElement` is the load-bearing row: it is React's **own** check of `$$typeof === REACT_ELEMENT_TYPE`, i.e. of the very `Symbol.for` value this change repairs, and it discriminates, so it is not vacuous.

Adjacent symbol suites (8 files): 70 passed / 2 failed — those same 2 fail **identically on the merge base**. Verified by reverting.

Gates run locally: `tsc --noEmit` (exit 0), `lint`, `format:check`, `check:oracle-ratchet`, `check:loc-budget`, `check:func-budget`, `check:coercion-sites`, `check:test-vacuity-shapes`, `check:issue-ids`.

## Scope — honest

**React instantiates; React does not "work".** Three walls remain, all outside this change and all pre-existing:

1. **Inbound host-Symbol → i32 bridge is still missing.** Passing a host object carrying a real JS Symbol _into_ the module throws the same TypeError. This PR fixed the **producer** side; the inbound direction is the #2610 symbol-as-any value-rep work (`type-coercion.ts:1741` has the bridge but gated `(standalone || wasi) && to.symbol`, and #2792 deliberately does not set that brand). Not attempted here.
2. **`Object.getOwnPropertySymbols(o)` → a symbol slot** throws identically — same class, and pre-existing/source-independent (fails for both `Symbol()` and `Symbol.for()` on the merge base).
3. **Returned objects are opaque to the host** — `Object.keys(element)` is `[]`. Separate struct↔host interop axis.

`useState()` throwing outside a renderer is **correct** React behaviour, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
