### PR TITLE
feat(#2928): link the standalone runtime-eval provider into the Test262 runner (E6)

### DIFF
--- a/plan/issues/2928-bytecode-interpreter-core-standalone-eval.md
+++ b/plan/issues/2928-bytecode-interpreter-core-standalone-eval.md
@@ -104,7 +104,10 @@ Global-scope evaluation only, deliberately excluding direct-eval scope capture
 - [x] An AOT function calls an interpreted function and vice versa with identical
       boxed-value identity (a `ref.eq` round-trip test).
 - [ ] ≥ 30 test262 eval-positive / Function-positive cases pass under the
-      standalone target.
+      standalone target. (Measured 2026-07-27 after E6 runner wiring: **11
+      attributable** official `eval-code` flips, 0 regressions — see the
+      "Official Test262 `eval-code` measurement" section for the named files
+      and the measured blockers for the rest.)
 - [x] A no-eval module stays within 5% of the current size floor; an
       eval-enabled module documents one measured parser+interpreter size figure.
 - [x] Opcode-set ADR committed under `docs/adr/`.
@@ -484,6 +487,70 @@ Two measurement traps found and fixed/recorded on the way:
    provider-side `__runtime_indirect_eval` returns instantly for the same
    bodies when called with JS carriers, so the pathology is in the
    native-carrier execution path.
+
+## Official Test262 `eval-code` measurement (E6 wiring, 2026-07-27)
+
+Three same-session arms on the same machine, same authoritative command
+(TEST262_TARGET=standalone, TEST262_PATH_FILTER='language/eval-code/',
+COMPILER_POOL_SIZE=2, TEST262_WORKERS=2, --official-scope-only), all with
+`TEST262_IT_TIMEOUT_MS=600000` (see finding 1 above — without it the branch
+arm silently loses 202 of its 816 rows):
+
+| Arm                                            | Run ID          | pass | fail | CE  | compile_timeout |
+| ---------------------------------------------- | --------------- | ---: | ---: | --: | --------------: |
+| control — `main` @ `81dbcad3b`                 | 20260727-020133 |  106 |  670 |  40 |               0 |
+| branch @ `4ac14aacb` + provider                | 20260727-013447 |  117 |  627 |  40 |              32 |
+| branch + `TEST262_DISABLE_RUNTIME_EVAL_PROVIDER=1` | 20260727-021328 |  106 |  670 |  40 |               0 |
+
+- The control **exactly reproduces the 2026-07-26 handoff baseline**
+  (106/816 = 105 standard + 1 annexB) — instrument validated.
+- The kill-switch arm is **status-identical to the control on all 816
+  files** — removing the provider injection alone reverts every delta, so
+  every delta is attributable to the linked interpreter route.
+- **11 files flip fail→pass (11 of the ≥30 acceptance bar), 0 regressions:**
+  - `test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js`
+  - `test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js`
+  - `test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js`
+  - `test/annexB/language/eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js`
+  - `test/language/eval-code/indirect/block-decl-strict.js`
+  - `test/language/eval-code/indirect/export.js`
+  - `test/language/eval-code/indirect/import.js`
+  - `test/language/eval-code/indirect/non-string-object.js`
+  - `test/language/eval-code/indirect/non-string-primitive.js`
+  - `test/language/eval-code/indirect/parse-failure-6.js`
+  - `test/language/eval-code/indirect/var-env-func-strict.js`
+
+  These are exactly the cases the Phase-1 interpreter can already decide:
+  correct SyntaxError refusal of invalid eval code (parse-failure, import/
+  export declarations, skip-early-err), strict/block-scoping negatives, and
+  §19.2.1's non-string pass-through.
+
+**Why the remaining candidates are blocked (measured on the branch arm, not
+estimated).** 595/816 are direct-eval files — out of scope by design
+(#2929). Of the 221 indirect files: 33 pass (22 pre-existing + 11 new),
+32 hang (→ `compile_timeout`; the annexB function-in-if emit hang recorded
+in finding 2), and 156 still fail with this signature breakdown:
+
+| count | blocking cause (verbatim signature class)                              |
+| ----: | ---------------------------------------------------------------------- |
+|    42 | `interp/emitter: unsupported in Phase 1: statement SwitchStatement`     |
+|    34 | `ReferenceError: assert is not defined` (interp global env cannot see the AOT module's harness globals) |
+|    18 | `ReferenceError: fnGlobalObject is not defined` (same bridging class)   |
+|     8 | `interp/emitter: unsupported ... ForOfStatement`                        |
+|     8 | `interp/emitter: unsupported ... ForInStatement`                        |
+|     8 | `SyntaxError: NaN` (error-message rendering defect in the thrown path)  |
+|    38 | assorted semantic gaps (SameValue mismatches, missing expected throws, null-property access) |
+
+So the two biggest levers toward the ≥30 bar are interpreter-side, not
+packaging-side: (a) AOT↔interp **global-binding bridging** (52 files fail
+purely because eval'd code can't resolve `assert`/harness globals), and
+(b) Phase-1 statement coverage (**SwitchStatement** alone gates 42, for-of/
+for-in another 16) plus the **if-statement hang/slowness** family (32 hangs;
+~27 s even for `if (false) ;`). The acceptance box stays unchecked; the E6
+packaging seam itself is done and measured working.
+
+Artifacts: `benchmarks/results/test262-standalone-results-20260727-{020133,013447,021328}.jsonl`
+(local machine; copies retained in the session workspace `.tmp/e6-*.jsonl`).
 
 ## Coercion-sites allowance (`src/codegen/expressions/eval-inline.ts`)
 

--- a/plan/issues/2928-bytecode-interpreter-core-standalone-eval.md
+++ b/plan/issues/2928-bytecode-interpreter-core-standalone-eval.md
@@ -434,6 +434,57 @@ lexical capture remains #2929 and is not part of this handoff.
 5. Check the Test262 acceptance box only after at least 30 named official
    source files pass because of the linked interpreter route.
 
+## Implementation findings (E6 Test262-runner provider link, 2026-07-27)
+
+The ordinary standalone Test262 lane now links the runtime-eval provider.
+The wiring is deliberately thin and lives at the distribution seam, not in
+the compiler:
+
+- `scripts/runtime-eval-provider.mjs` — ONE shared source assembly (pinned
+  Acorn tarball via `tests/dogfood/setup-acorn.mjs` + import-clean
+  `src/interp/*` + the export wrapper proven by
+  `tests/issue-2928-runtime-link.test.ts`), the provider compile options,
+  a disk cache keyed by (source, options, compiler-bundle hash), and
+  fresh-per-test namespace instantiation.
+  `tests/interp/runtime-acorn-package-probe.mjs` consumes the same assembly,
+  so the artifact the harness proves and the artifact the runner links are
+  byte-identical (re-verified: 14/14 canaries, 2,513,425 bytes).
+- `scripts/build-runtime-eval-provider.mjs` — idempotent prebuild wired into
+  `run-test262-vitest.sh` for `TEST262_TARGET=standalone`. It canary-verifies
+  (eval/function/30-body corpus) BEFORE caching; a provider that cannot
+  evaluate `1 + 2` can never be published. Build cost ~71–81 s; cache hit
+  <1 s.
+- `scripts/test262-worker.mjs` — the standalone path goes Module-first; when
+  `WebAssembly.Module.imports()` names `js2wasm:runtime-eval`, the worker
+  links a FRESH provider instance (per-test isolation; instance ≈ 0.4 s,
+  Module compile ≈ 27 ms, once per worker). **Cache miss degrades to the
+  exact status quo** (unresolved import → LinkError): workers never compile
+  the provider, because Acorn compilation takes minutes and the pool kills
+  jobs at 30 s. `TEST262_DISABLE_RUNTIME_EVAL_PROVIDER=1` is the attribution
+  kill-switch — it byte-restores pre-wiring behavior for A/B runs.
+- CI chunk shards see a cache miss and keep status-quo behavior; publishing
+  the provider artifact for CI (through #2527 packaging) is follow-up work.
+
+Two measurement traps found and fixed/recorded on the way:
+
+1. **The authoritative command under-reports its own denominator on this
+   branch.** The per-test vitest timeout was a hardcoded 90 s that also
+   measures POOL-QUEUE wait. Once the provider made the annexB eval bodies
+   actually execute (slow — see finding 2), queued tests blew the 90 s and
+   vitest killed them WITHOUT a jsonl row: 202 of 816 files simply vanished
+   from the results (a file that PASSES in isolation was among the missing).
+   Fixed: `TEST262_IT_TIMEOUT_MS` env override (default unchanged at 90 s, CI
+   byte-identical); measurement sweeps pass it explicitly.
+2. **Newly-reachable interpreter executions are pathologically slow or hang**
+   (interpreter-side, out of E6 scope, needs its own issue): an eval body of
+   `if (false) ;` takes ~27 s before throwing through the linked route;
+   `if (false) ; else function f() { ... }` (the annexB function-in-if
+   family, ~100 files) never terminates and eats the 30 s pool timeout.
+   Simple bodies (`1 + 2`, `var`, `function f(){} f()`) run in <1 s. The
+   provider-side `__runtime_indirect_eval` returns instantly for the same
+   bodies when called with JS carriers, so the pathology is in the
+   native-carrier execution path.
+
 ## Coercion-sites allowance (`src/codegen/expressions/eval-inline.ts`)
 
 `pnpm run check:coercion-sites` fired on this change-set:

--- a/scripts/build-runtime-eval-provider.mjs
+++ b/scripts/build-runtime-eval-provider.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2928 E6 — prebuild the standalone runtime-eval provider into .test262-cache.
+//
+// Idempotent: exits fast when the cache already holds a provider for the
+// current (source, compile options, compiler bundle) key. On a build, the
+// provider is verified with its own canaries BEFORE it is cached — a provider
+// that cannot evaluate "1 + 2" through the real Acorn parse must never be
+// published, or every dynamic-eval test would fail with an opaque link result.
+//
+// Invoked by scripts/run-test262-vitest.sh when TEST262_TARGET=standalone
+// (after the compiler bundle is built, so ./compiler-bundle.mjs exists). Can
+// also be run manually: NODE_OPTIONS=--max-old-space-size=3072 node
+// scripts/build-runtime-eval-provider.mjs
+
+import {
+  RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS,
+  buildRuntimeEvalProviderSource,
+  computeCompilerBundleHash,
+  defaultRuntimeEvalProviderCacheDir,
+  instantiateRuntimeEvalNamespace,
+  readCachedRuntimeEvalProvider,
+  runtimeEvalProviderCacheKey,
+  runtimeEvalProviderCachePath,
+  writeCachedRuntimeEvalProvider,
+} from "./runtime-eval-provider.mjs";
+
+async function loadCompile() {
+  try {
+    const bundle = await import("./compiler-bundle.mjs");
+    if (typeof bundle.compile === "function") return { compile: bundle.compile, origin: "compiler-bundle.mjs" };
+  } catch {}
+  // Dev convenience: `node --import tsx scripts/build-runtime-eval-provider.mjs`
+  try {
+    const src = await import("../src/index.ts");
+    if (typeof src.compile === "function") return { compile: src.compile, origin: "src/index.ts (tsx)" };
+  } catch {}
+  throw new Error(
+    "no compiler available — build scripts/compiler-bundle.mjs first (run-test262-vitest.sh does), " +
+      "or run under tsx (`node --import tsx scripts/build-runtime-eval-provider.mjs`)",
+  );
+}
+
+function verifyProvider(binary) {
+  const module = new WebAssembly.Module(binary);
+  const imports = WebAssembly.Module.imports(module);
+  if (imports.length !== 0) {
+    throw new Error(
+      `provider must have ZERO imports, found: ${imports.map((i) => `${i.module}::${i.name}`).join(", ")}`,
+    );
+  }
+  const instance = new WebAssembly.Instance(module, {});
+  const checks = [
+    ["__runtime_eval_canary", 3],
+    ["__runtime_function_canary", 3],
+    ["__runtime_positive_corpus_canary", 30],
+  ];
+  for (const [name, expected] of checks) {
+    const fn = instance.exports[name];
+    if (typeof fn !== "function") throw new Error(`provider export ${name} missing`);
+    const actual = fn();
+    if (actual !== expected) throw new Error(`provider canary ${name} returned ${actual}, expected ${expected}`);
+  }
+  // The linkable namespace itself must exist.
+  const ns = instantiateRuntimeEvalNamespace(module);
+  for (const name of ["__runtime_new_function", "__runtime_indirect_eval"]) {
+    if (typeof ns[name] !== "function") throw new Error(`provider namespace export ${name} missing`);
+  }
+}
+
+async function main() {
+  const cacheDir = defaultRuntimeEvalProviderCacheDir();
+  const source = buildRuntimeEvalProviderSource();
+  const bundleHash = computeCompilerBundleHash();
+  const key = runtimeEvalProviderCacheKey(source, bundleHash);
+  const path = runtimeEvalProviderCachePath(cacheDir, key);
+
+  const cached = readCachedRuntimeEvalProvider(cacheDir, key);
+  if (cached) {
+    console.log(
+      `[runtime-eval-provider] cache HIT — key ${key} (bundle ${bundleHash}), ${cached.length} bytes at ${path}`,
+    );
+    return;
+  }
+
+  const { compile, origin } = await loadCompile();
+  console.log(
+    `[runtime-eval-provider] cache MISS — compiling provider (key ${key}, bundle ${bundleHash}, compiler: ${origin}, source ${source.length} chars) ...`,
+  );
+  const startMs = Date.now();
+  const result = await compile(source, { ...RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS });
+  const compileMs = Date.now() - startMs;
+  if (!result.success || !result.binary || result.binary.length === 0) {
+    const detail = (result.errors ?? [])
+      .filter((e) => e.severity === "error" || e.severity === undefined)
+      .slice(0, 5)
+      .map((e) => e.message ?? String(e))
+      .join("; ");
+    throw new Error(`provider compile FAILED after ${compileMs}ms: ${detail || "unknown"}`);
+  }
+  verifyProvider(result.binary);
+  const written = writeCachedRuntimeEvalProvider(cacheDir, key, result.binary);
+  console.log(
+    `[runtime-eval-provider] built + canary-verified in ${compileMs}ms — ${result.binary.length} bytes at ${written}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(`[runtime-eval-provider] FAILED: ${err?.stack ?? err}`);
+  process.exit(1);
+});

--- a/scripts/run-test262-vitest.sh
+++ b/scripts/run-test262-vitest.sh
@@ -175,6 +175,18 @@ fi
 "$ESBUILD_BIN" src/runtime.ts --bundle --platform=node --format=esm \
   --outfile=scripts/runtime-bundle.mjs --external:typescript --external:binaryen 2>&1 | tail -1
 
+# ── Prebuild the standalone runtime-eval provider (#2928 E6) ─────
+# Standalone modules that use dynamic eval / new Function link a core-Wasm
+# `js2wasm:runtime-eval` provider (Acorn + interpreter, compiled by js2wasm
+# itself). Build it ONCE here — the pool workers only load the cached binary
+# (compiling Acorn takes minutes; the per-test pool timeout is 30s). Idempotent:
+# cache hit exits in <1s. The cache lives in the shared .test262-cache, so
+# subsequent runs on the same compiler bundle skip the build entirely.
+if [ "$TEST262_TARGET" = "standalone" ]; then
+  echo "Prebuilding runtime-eval provider (#2928 E6)..."
+  NODE_OPTIONS="--max-old-space-size=3072" node scripts/build-runtime-eval-provider.mjs
+fi
+
 # ── Prepare result files ─────────────────────────────────────────
 # Vitest writes to timestamped ${RESULT_PREFIX}-results-YYYYMMDD-HHMMSS.jsonl directly.
 # RUN_TIMESTAMP env var tells test262-shared.ts which filename to use.

--- a/scripts/runtime-eval-provider.mjs
+++ b/scripts/runtime-eval-provider.mjs
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2928 E6 — shared standalone runtime-eval provider: source assembly, compile
+// options, disk cache, and instantiation helpers.
+//
+// The provider is ONE ordered-initializer source unit: the pinned Acorn entry
+// module (tests/dogfood/setup-acorn.mjs — committed tarball, sha1-verified) +
+// the import-clean interpreter sources (src/interp/*) + the
+// `js2wasm:runtime-eval` export wrapper proven end-to-end by
+// tests/issue-2928-runtime-link.test.ts and
+// tests/interp/runtime-acorn-package-probe.mjs.
+//
+// Consumers:
+//   - scripts/build-runtime-eval-provider.mjs — prebuilds + canary-verifies the
+//     provider binary into .test262-cache (invoked by run-test262-vitest.sh for
+//     TEST262_TARGET=standalone).
+//   - scripts/test262-worker.mjs — on a standalone test whose compiled module
+//     imports `js2wasm:runtime-eval`, loads the CACHED binary and links a fresh
+//     provider instance. Cache miss = status quo (unresolved import, the same
+//     LinkError as before this wiring) — the worker NEVER compiles the provider
+//     itself (Acorn compilation takes minutes; the pool kills jobs at 30s).
+//   - tests/interp/runtime-acorn-package-probe.mjs — the dedicated harness
+//     probe, now consuming the SAME source assembly so the tested artifact and
+//     the distributed artifact cannot drift.
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { setupAcorn } from "../tests/dogfood/setup-acorn.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+
+/** Core-Wasm provider namespace owned by #2928/#2527 (mirrors
+ *  RUNTIME_EVAL_IMPORT_MODULE in src/codegen/expressions/eval-inline.ts). */
+export const RUNTIME_EVAL_IMPORT_MODULE = "js2wasm:runtime-eval";
+
+/** Provider compile options — the runtime library is an internal subcompile and
+ *  retains the explicit legacy fallback policy used by the eval subcompile. */
+export const RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS = Object.freeze({
+  experimentalIR: false,
+  fileName: "runtime-eval-provider.ts",
+  skipSemanticDiagnostics: true,
+  target: "standalone",
+});
+
+/** Import-clean interpreter sources, in initializer order. */
+const INTERP_FILES = [
+  "types.ts",
+  "opcodes.ts",
+  "encoder.ts",
+  "runtime-ops.ts",
+  "emitter.ts",
+  "loop.ts",
+  "dynamic-function.ts",
+];
+
+function stripModuleSyntax(source) {
+  return source
+    .replace(/^import[\s\S]*?;\n/gm, "")
+    .replace(/^export \{[^;]+;\n/gm, "")
+    .replace(/\bexport (?=(?:type|interface|class|const|function)\b)/g, "");
+}
+
+// The export wrapper: the published `parse(nativeString, optionsObject) ->
+// ESTree $Object` seam feeds `createDynamicFunction` / `executeIndirectEval`;
+// provider exceptions cross the module boundary in the `[ok, value]` result
+// envelope (see emitRuntimeEvalResultUnwrap in eval-inline.ts). The three
+// canaries are the build-time positive control: a provider that cannot
+// evaluate "1 + 2" is refused before it is ever cached.
+const PROVIDER_EXPORT_WRAPPER = `
+      function runtimeEvalResult(ok: boolean, value: any): any {
+        const result: any[] = [ok, value];
+        return result;
+      }
+
+      export function __runtime_new_function(
+        paramString: any,
+        bodyString: any,
+        globalObject: any
+      ): any {
+        try {
+          return runtimeEvalResult(
+            true,
+            createDynamicFunction(
+              parse,
+              String(paramString),
+              String(bodyString),
+              globalObject
+            )
+          );
+        } catch (error) {
+          return runtimeEvalResult(false, error);
+        }
+      }
+
+      export function __runtime_indirect_eval(
+        source: any,
+        globalObject: any
+      ): any {
+        try {
+          return runtimeEvalResult(
+            true,
+            executeIndirectEval(parse, source, globalObject)
+          );
+        } catch (error) {
+          return runtimeEvalResult(false, error);
+        }
+      }
+
+      export function __runtime_eval_canary(): number {
+        return executeIndirectEval(parse, "1 + 2", {}) as number;
+      }
+
+      export function __runtime_function_canary(): number {
+        const fn = createDynamicFunction(
+          parse,
+          "a,b",
+          "return a + b",
+          {}
+        );
+        return fn(1, 2) as number;
+      }
+
+      export function __runtime_positive_corpus_canary(): number {
+        // Thirty Phase-1-positive bodies drawn from the Test262-shaped corpus
+        // in differential.test.ts. Every case parses through the real Acorn
+        // artifact and executes in the self-compiled interpreter.
+        const sources: string[] = [
+          "1 + 2",
+          "1 + 2 * 3 - 4 / 2",
+          "17 % 5",
+          "-3 + 4",
+          "var r = 0; if (5 > 3) r = 1; r",
+          "var r = 0; if (3 >= 3) r = 1; r",
+          "var r = 0; if (1 != 2) r = 1; r",
+          "var r = 0; if (1 !== '1') r = 1; r",
+          "12",
+          "var x = 1; x = x + 41; x",
+          "let a = 1, b = 2; a + b",
+          "var x = 5; x * 2",
+          "var x = 7; x -= 2; x",
+          "var x = 2; x *= 3; x",
+          "8 / 2",
+          "9 % 4",
+          "var o = { a: 1, b: 2 }; o.a + o.b",
+          "var o = {}; var k = 'z'; o[k] = 9; o[k]",
+          "var o = { a: 10, b: 30 }; o.a + o.b",
+          "function add(a, b) { return a + b; } add(4, 5)",
+          "function twice(n) { return n * 2; } twice(4)",
+          "function square(x) { return x * x; } square(6)",
+          "function multiply(a, b) { return a * b; } multiply(6, 7)",
+          "var g = 0; function inc() { g = g + 1; return g; } inc(); inc(); inc()",
+          "var r = 0; try { throw 42; } catch (e) { r = e + 1; } r",
+          "var r = 0; try { throw 10; } catch (e) { r = e + 1; } r",
+          "function boom() { throw 7; } var r = 0; try { boom(); } catch (e) { r = e; } r",
+          "var r = 0; try { throw new Error('x'); } catch (e) { r = 1; } r",
+          "Number('4') + Number()",
+          "Math.max(3, 7, 2) + Math.min(3, 7, 2) + Math.abs(-5) + Math.floor(2.9) + Math.ceil(2.1)",
+        ];
+        const expected: number[] = [
+          3, 5, 2, 1, 1, 1, 1, 1, 12, 42,
+          3, 10, 5, 6, 4, 1, 3, 9, 40, 9,
+          8, 36, 42, 3, 43, 11, 7, 1, 4, 19,
+        ];
+        for (let i = 0; i < sources.length; i += 1) {
+          try {
+            const actual = executeIndirectEval(parse, sources[i], {});
+            if (actual !== expected[i]) return -(i + 1);
+          } catch (error) {
+            return -(1001 + i);
+          }
+        }
+        return sources.length;
+      }
+    `;
+
+/**
+ * Assemble the full provider source (Acorn + interpreter + export wrapper) as
+ * one ordered-initializer unit. Reads the pinned Acorn artifact via
+ * setupAcorn() (extracts the committed tarball on first use) and the
+ * interpreter sources from src/interp relative to the repo root this module
+ * lives in.
+ */
+export function buildRuntimeEvalProviderSource() {
+  const { entryModulePath } = setupAcorn();
+  const acorn = stripModuleSyntax(readFileSync(entryModulePath, "utf8"));
+  const interpreter = INTERP_FILES.map((name) =>
+    stripModuleSyntax(readFileSync(join(REPO_ROOT, "src", "interp", name), "utf8")),
+  );
+  return [acorn, ...interpreter, PROVIDER_EXPORT_WRAPPER].join("\n");
+}
+
+/**
+ * Compiler-bundle hash, mirroring the worker's cache-key discipline (#1521):
+ * TEST262_BUNDLE_HASH env first, then sha256 of the built compiler bundle.
+ * The provider cache key folds this in so a provider compiled by an older
+ * compiler is never linked against modules from a newer one.
+ */
+export function computeCompilerBundleHash() {
+  const fromEnv = process.env.TEST262_BUNDLE_HASH;
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+  for (const file of ["compiler-bundle.mjs", "index.js"]) {
+    try {
+      const buf = readFileSync(join(HERE, file));
+      return createHash("sha256").update(buf).digest("hex").slice(0, 16);
+    } catch {}
+  }
+  return "no-bundle";
+}
+
+/** Cache key: provider source + compile options + compiler bundle hash. */
+export function runtimeEvalProviderCacheKey(source, bundleHash) {
+  return createHash("sha256")
+    .update(JSON.stringify(RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS))
+    .update(" ")
+    .update(bundleHash ?? "")
+    .update(" ")
+    .update(source)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/** Default provider cache directory (shared .test262-cache next to scripts/). */
+export function defaultRuntimeEvalProviderCacheDir() {
+  return join(REPO_ROOT, ".test262-cache");
+}
+
+export function runtimeEvalProviderCachePath(cacheDir, key) {
+  return join(cacheDir, `runtime-eval-provider-${key}.wasm`);
+}
+
+/** Read the cached provider binary, or null when absent. */
+export function readCachedRuntimeEvalProvider(cacheDir, key) {
+  const path = runtimeEvalProviderCachePath(cacheDir, key);
+  try {
+    return readFileSync(path);
+  } catch {
+    return null;
+  }
+}
+
+/** Atomically (tmp + rename) publish a provider binary into the cache. */
+export function writeCachedRuntimeEvalProvider(cacheDir, key, binary) {
+  mkdirSync(cacheDir, { recursive: true });
+  const path = runtimeEvalProviderCachePath(cacheDir, key);
+  const tmp = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmp, binary);
+  try {
+    renameSync(tmp, path);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {}
+    if (!existsSync(path)) throw err;
+  }
+  return path;
+}
+
+/**
+ * Instantiate a FRESH provider instance (per-test isolation — the interpreter
+ * roots dynamic functions at global env records) and return the import
+ * namespace the user module links against.
+ */
+export function instantiateRuntimeEvalNamespace(providerModule) {
+  const instance = new WebAssembly.Instance(providerModule, {});
+  return {
+    __runtime_new_function: instance.exports.__runtime_new_function,
+    __runtime_indirect_eval: instance.exports.__runtime_indirect_eval,
+  };
+}

--- a/scripts/test262-worker.mjs
+++ b/scripts/test262-worker.mjs
@@ -23,6 +23,17 @@ import { negativeCompileErrorMatches, negativeCompileSucceededVerdict } from "./
 // runner that was missing the tryNativeExnRender step.
 import { safeStringifyThrown, tryNativeExnRender } from "./lib/wasm-exn-render.mjs";
 import { SANDBOX_GLOBAL_NAMES } from "./test262-sandbox-globals.mjs";
+// (#2928 E6) Standalone runtime-eval provider — cached-binary loading + fresh
+// per-test namespace instantiation for `js2wasm:runtime-eval` imports.
+import {
+  RUNTIME_EVAL_IMPORT_MODULE,
+  buildRuntimeEvalProviderSource,
+  computeCompilerBundleHash,
+  defaultRuntimeEvalProviderCacheDir,
+  instantiateRuntimeEvalNamespace,
+  readCachedRuntimeEvalProvider,
+  runtimeEvalProviderCacheKey,
+} from "./runtime-eval-provider.mjs";
 
 // ── Bundle hash (#1521) ────────────────────────────────────────────────
 // Each cache entry written below carries a `bundle_hash` field. When the
@@ -49,6 +60,48 @@ function computeBundleHash() {
   return "no-bundle";
 }
 const BUNDLE_HASH = computeBundleHash();
+
+// ── Standalone runtime-eval provider (#2928 E6) ────────────────────────
+// A standalone module whose ONLY dynamic-code dependency is the core-Wasm
+// `js2wasm:runtime-eval` namespace links against a separately compiled
+// Acorn+interpreter provider. The provider binary is PREBUILT into
+// .test262-cache by scripts/build-runtime-eval-provider.mjs (wired into
+// run-test262-vitest.sh for TEST262_TARGET=standalone); the worker only ever
+// LOADS the cached binary — compiling Acorn takes minutes and the pool kills
+// jobs at 30s, so a cache miss deliberately degrades to the status quo
+// (unresolved import → LinkError), never an in-worker compile.
+// TEST262_DISABLE_RUNTIME_EVAL_PROVIDER=1 is the measurement kill-switch:
+// it restores the exact pre-wiring behavior for A/B attribution runs.
+let runtimeEvalProviderModule; // undefined = untried, null = unavailable
+let runtimeEvalProviderNoteShown = false;
+function getRuntimeEvalProviderModule() {
+  if (runtimeEvalProviderModule !== undefined) return runtimeEvalProviderModule;
+  runtimeEvalProviderModule = null;
+  if (process.env.TEST262_DISABLE_RUNTIME_EVAL_PROVIDER === "1") return null;
+  try {
+    const source = buildRuntimeEvalProviderSource();
+    const key = runtimeEvalProviderCacheKey(source, computeCompilerBundleHash());
+    const binary = readCachedRuntimeEvalProvider(defaultRuntimeEvalProviderCacheDir(), key);
+    if (!binary) {
+      if (!runtimeEvalProviderNoteShown) {
+        runtimeEvalProviderNoteShown = true;
+        console.error(
+          `[test262-worker] runtime-eval provider cache MISS (key ${key}) — standalone dynamic-eval ` +
+            `tests keep failing at link; prebuild with scripts/build-runtime-eval-provider.mjs`,
+        );
+      }
+      return null;
+    }
+    runtimeEvalProviderModule = new WebAssembly.Module(binary);
+  } catch (err) {
+    if (!runtimeEvalProviderNoteShown) {
+      runtimeEvalProviderNoteShown = true;
+      console.error(`[test262-worker] runtime-eval provider unavailable: ${err?.message ?? err}`);
+    }
+    runtimeEvalProviderModule = null;
+  }
+  return runtimeEvalProviderModule;
+}
 
 // (#3441) The sandbox-globals list is now the single shared source in
 // scripts/test262-sandbox-globals.mjs — imported by BOTH this worker and
@@ -1769,8 +1822,25 @@ process.on("message", async (msg) => {
     }
 
     try {
-      const wasmResult = await WebAssembly.instantiate(result.binary, importObj);
-      instance = wasmResult.instance;
+      if (target === "standalone") {
+        // (#2928 E6) Module-first so the import list is inspectable before
+        // instantiation. A synchronous CompileError here lands in the same
+        // catch arm as the old binary-form instantiate — classification is
+        // unchanged. When the module links `js2wasm:runtime-eval`, supply a
+        // FRESH provider instance (per-test isolation: the interpreter roots
+        // dynamic functions at global env records).
+        const wasmModule = new WebAssembly.Module(result.binary);
+        if (WebAssembly.Module.imports(wasmModule).some((imp) => imp.module === RUNTIME_EVAL_IMPORT_MODULE)) {
+          const providerModule = getRuntimeEvalProviderModule();
+          if (providerModule) {
+            importObj[RUNTIME_EVAL_IMPORT_MODULE] = instantiateRuntimeEvalNamespace(providerModule);
+          }
+        }
+        instance = await WebAssembly.instantiate(wasmModule, importObj);
+      } else {
+        const wasmResult = await WebAssembly.instantiate(result.binary, importObj);
+        instance = wasmResult.instance;
+      }
     } catch (err) {
       const execMs = performance.now() - execStart;
       // Real Wasm compile/link failures stay as compile_error. A throw from

--- a/tests/interp/runtime-acorn-package-probe.mjs
+++ b/tests/interp/runtime-acorn-package-probe.mjs
@@ -4,158 +4,24 @@
 // unit. This gives the provider exactly one ordered initializer without relying
 // on compileMulti's current per-source initializer ownership (#3525), and keeps
 // ESTree objects inside the provider rather than exposing them as a link ABI.
-
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+//
+// The source assembly + compile options now live in
+// scripts/runtime-eval-provider.mjs (the E6 distribution seam consumed by the
+// Test262 runner), so the artifact this probe validates and the artifact the
+// runner links are one and the same — they cannot drift.
 
 import { compile } from "../../src/index.ts";
-import { setupAcorn } from "../dogfood/setup-acorn.mjs";
-
-const INTERP_FILES = [
-  "types.ts",
-  "opcodes.ts",
-  "encoder.ts",
-  "runtime-ops.ts",
-  "emitter.ts",
-  "loop.ts",
-  "dynamic-function.ts",
-];
-
-function stripModuleSyntax(source) {
-  return source
-    .replace(/^import[\s\S]*?;\n/gm, "")
-    .replace(/^export \{[^;]+;\n/gm, "")
-    .replace(/\bexport (?=(?:type|interface|class|const|function)\b)/g, "");
-}
-
-function providerSource() {
-  const { entryModulePath } = setupAcorn();
-  const acorn = stripModuleSyntax(readFileSync(entryModulePath, "utf8"));
-  const interpreter = INTERP_FILES.map((name) => stripModuleSyntax(readFileSync(resolve("src/interp", name), "utf8")));
-
-  return [
-    acorn,
-    ...interpreter,
-    `
-      function runtimeEvalResult(ok: boolean, value: any): any {
-        const result: any[] = [ok, value];
-        return result;
-      }
-
-      export function __runtime_new_function(
-        paramString: any,
-        bodyString: any,
-        globalObject: any
-      ): any {
-        try {
-          return runtimeEvalResult(
-            true,
-            createDynamicFunction(
-              parse,
-              String(paramString),
-              String(bodyString),
-              globalObject
-            )
-          );
-        } catch (error) {
-          return runtimeEvalResult(false, error);
-        }
-      }
-
-      export function __runtime_indirect_eval(
-        source: any,
-        globalObject: any
-      ): any {
-        try {
-          return runtimeEvalResult(
-            true,
-            executeIndirectEval(parse, source, globalObject)
-          );
-        } catch (error) {
-          return runtimeEvalResult(false, error);
-        }
-      }
-
-      export function __runtime_eval_canary(): number {
-        return executeIndirectEval(parse, "1 + 2", {}) as number;
-      }
-
-      export function __runtime_function_canary(): number {
-        const fn = createDynamicFunction(
-          parse,
-          "a,b",
-          "return a + b",
-          {}
-        );
-        return fn(1, 2) as number;
-      }
-
-      export function __runtime_positive_corpus_canary(): number {
-        // Thirty Phase-1-positive bodies drawn from the Test262-shaped corpus
-        // in differential.test.ts. Every case parses through the real Acorn
-        // artifact and executes in the self-compiled interpreter.
-        const sources: string[] = [
-          "1 + 2",
-          "1 + 2 * 3 - 4 / 2",
-          "17 % 5",
-          "-3 + 4",
-          "var r = 0; if (5 > 3) r = 1; r",
-          "var r = 0; if (3 >= 3) r = 1; r",
-          "var r = 0; if (1 != 2) r = 1; r",
-          "var r = 0; if (1 !== '1') r = 1; r",
-          "12",
-          "var x = 1; x = x + 41; x",
-          "let a = 1, b = 2; a + b",
-          "var x = 5; x * 2",
-          "var x = 7; x -= 2; x",
-          "var x = 2; x *= 3; x",
-          "8 / 2",
-          "9 % 4",
-          "var o = { a: 1, b: 2 }; o.a + o.b",
-          "var o = {}; var k = 'z'; o[k] = 9; o[k]",
-          "var o = { a: 10, b: 30 }; o.a + o.b",
-          "function add(a, b) { return a + b; } add(4, 5)",
-          "function twice(n) { return n * 2; } twice(4)",
-          "function square(x) { return x * x; } square(6)",
-          "function multiply(a, b) { return a * b; } multiply(6, 7)",
-          "var g = 0; function inc() { g = g + 1; return g; } inc(); inc(); inc()",
-          "var r = 0; try { throw 42; } catch (e) { r = e + 1; } r",
-          "var r = 0; try { throw 10; } catch (e) { r = e + 1; } r",
-          "function boom() { throw 7; } var r = 0; try { boom(); } catch (e) { r = e; } r",
-          "var r = 0; try { throw new Error('x'); } catch (e) { r = 1; } r",
-          "Number('4') + Number()",
-          "Math.max(3, 7, 2) + Math.min(3, 7, 2) + Math.abs(-5) + Math.floor(2.9) + Math.ceil(2.1)",
-        ];
-        const expected: number[] = [
-          3, 5, 2, 1, 1, 1, 1, 1, 12, 42,
-          3, 10, 5, 6, 4, 1, 3, 9, 40, 9,
-          8, 36, 42, 3, 43, 11, 7, 1, 4, 19,
-        ];
-        for (let i = 0; i < sources.length; i += 1) {
-          try {
-            const actual = executeIndirectEval(parse, sources[i], {});
-            if (actual !== expected[i]) return -(i + 1);
-          } catch (error) {
-            return -(1001 + i);
-          }
-        }
-        return sources.length;
-      }
-    `,
-  ].join("\n");
-}
+import {
+  RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS,
+  buildRuntimeEvalProviderSource,
+} from "../../scripts/runtime-eval-provider.mjs";
 
 function describeDiagnostic(diagnostic) {
   return diagnostic?.messageText ?? diagnostic?.message ?? String(diagnostic);
 }
 
 async function main() {
-  const provider = await compile(providerSource(), {
-    experimentalIR: false,
-    fileName: "runtime-eval-acorn-provider.ts",
-    skipSemanticDiagnostics: true,
-    target: "standalone",
-  });
+  const provider = await compile(buildRuntimeEvalProviderSource(), { ...RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS });
   const user = await compile(
     `
       function dynamic(value: string): string {

--- a/tests/issue-2928-e6-provider-cache.test.ts
+++ b/tests/issue-2928-e6-provider-cache.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2928 E6 — the shared runtime-eval provider seam: source assembly and the
+ * disk cache the Test262 runner links from. The HEAVY end-to-end proof (real
+ * Acorn compile + link + canaries) lives in
+ * tests/issue-2928-runtime-acorn.test.ts; this file covers the cheap
+ * distribution plumbing so a drift (renamed export, broken strip, cache
+ * key/path instability) fails fast without a multi-minute compile.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  RUNTIME_EVAL_IMPORT_MODULE,
+  buildRuntimeEvalProviderSource,
+  readCachedRuntimeEvalProvider,
+  runtimeEvalProviderCacheKey,
+  runtimeEvalProviderCachePath,
+  writeCachedRuntimeEvalProvider,
+} from "../scripts/runtime-eval-provider.mjs";
+
+describe("#2928 E6 — runtime-eval provider seam", () => {
+  it("assembles the provider as one import-clean source unit with the published exports", () => {
+    const source = buildRuntimeEvalProviderSource();
+    // The published `js2wasm:runtime-eval` surface.
+    expect(source).toContain("function __runtime_new_function(");
+    expect(source).toContain("function __runtime_indirect_eval(");
+    // The interpreter entry points behind it.
+    expect(source).toContain("function createDynamicFunction(");
+    expect(source).toContain("function executeIndirectEval(");
+    // Build-time positive controls must be present so the prebuild can refuse
+    // a broken provider before caching it.
+    expect(source).toContain("function __runtime_eval_canary(");
+    expect(source).toContain("function __runtime_positive_corpus_canary(");
+    // Module syntax must be stripped — the provider is ONE ordered-initializer
+    // unit, not a module graph.
+    expect(source).not.toMatch(/^import /m);
+    expect(source).not.toMatch(/^export \{/m);
+  });
+
+  it("namespace constant matches the codegen import module", () => {
+    expect(RUNTIME_EVAL_IMPORT_MODULE).toBe("js2wasm:runtime-eval");
+  });
+
+  it("cache key is stable and sensitive to source + bundle hash", () => {
+    const a = runtimeEvalProviderCacheKey("source-a", "bundle-1");
+    expect(runtimeEvalProviderCacheKey("source-a", "bundle-1")).toBe(a);
+    expect(runtimeEvalProviderCacheKey("source-b", "bundle-1")).not.toBe(a);
+    expect(runtimeEvalProviderCacheKey("source-a", "bundle-2")).not.toBe(a);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("cache write + read round-trips atomically", () => {
+    const dir = mkdtempSync(join(tmpdir(), "runtime-eval-provider-test-"));
+    try {
+      const key = runtimeEvalProviderCacheKey("round-trip", "bundle");
+      expect(readCachedRuntimeEvalProvider(dir, key)).toBeNull();
+      const payload = Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+      const written = writeCachedRuntimeEvalProvider(dir, key, payload);
+      expect(written).toBe(runtimeEvalProviderCachePath(dir, key));
+      const back = readCachedRuntimeEvalProvider(dir, key);
+      expect(back).not.toBeNull();
+      expect(Buffer.compare(back!, payload)).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -187,6 +187,15 @@ function getCachePaths(wrappedSource: string): { wasmPath: string; metaPath: str
 
 const POOL_SIZE = parseInt(process.env.COMPILER_POOL_SIZE || String(Math.max(1, availableParallelism() - 1)), 10);
 
+// (#2928 E6) Per-test vitest timeout. The 90s default measures POOL-QUEUE WAIT
+// as well as the test's own run: when a slow cluster occupies every pool worker
+// (e.g. interpreter-linked eval tests hitting the 30s pool timeout back to
+// back), queued tests blow this limit and vitest kills them WITHOUT a jsonl
+// row — the run silently under-reports its own denominator (measured: 202 of
+// 816 eval-code rows missing at 2 workers). Raise via env for slow-cluster
+// sweeps; the default stays 90s so CI behavior is unchanged.
+const IT_TIMEOUT_MS = parseInt(process.env.TEST262_IT_TIMEOUT_MS || "90000", 10);
+
 let pool: CompilerPool | null = null;
 
 // ── Compile-timeout retry (#1589) ──────────────────────────────────
@@ -1277,7 +1286,7 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
               metadataFromWorkerResult(r, false),
             );
           },
-          90_000,
+          IT_TIMEOUT_MS,
         );
       }
     });


### PR DESCRIPTION
## What

Wires the #2928 runtime-eval provider (pinned Acorn + interpreter, compiled by js2wasm itself) into the ordinary standalone Test262 packaging path, and reports the measured official `eval-code` result.

- `scripts/runtime-eval-provider.mjs` — ONE shared source assembly (pinned Acorn tarball + import-clean `src/interp/*` + the export wrapper proven by `tests/issue-2928-runtime-link.test.ts`), provider compile options, disk cache keyed by (source, options, compiler-bundle hash), fresh-per-test namespace instantiation. `tests/interp/runtime-acorn-package-probe.mjs` now consumes the same assembly, so the proven artifact and the linked artifact cannot drift (re-verified: 14/14 canaries, byte-identical 2,513,425-byte provider).
- `scripts/build-runtime-eval-provider.mjs` — idempotent prebuild, wired into `run-test262-vitest.sh` for `TEST262_TARGET=standalone`. Canary-verifies (eval/function/30-body corpus) BEFORE caching. Build ~71–81 s once; cache hit <1 s.
- `scripts/test262-worker.mjs` — standalone path goes Module-first; a module importing `js2wasm:runtime-eval` links a fresh provider instance. **Cache miss degrades to the exact status quo** (LinkError) — workers never compile the provider (pool kills jobs at 30 s). `TEST262_DISABLE_RUNTIME_EVAL_PROVIDER=1` is the attribution kill-switch.
- `tests/test262-shared.ts` — `TEST262_IT_TIMEOUT_MS` env override for the per-test vitest timeout (default unchanged at 90 s, CI byte-identical). The 90 s hardcode also measures pool-queue wait; with the provider linked, the slow interpreter cluster congested the 2-worker pool and vitest killed 202 of 816 queued tests WITHOUT a jsonl row — the sweep silently under-reported its own denominator.
- CI chunk shards see a cache miss and keep status-quo behavior; publishing the provider for CI (through #2527 packaging) is follow-up work.

## Measured result (three same-session arms, same authoritative command)

| arm | pass | fail | CE | compile_timeout |
|---|---:|---:|---:|---:|
| control — main @ 81dbcad3b | 106 | 670 | 40 | 0 |
| branch + provider | **117** | 627 | 40 | 32 |
| branch + kill-switch | 106 | 670 | 40 | 0 |

- Control exactly reproduces the #3686 handoff baseline (106/816).
- Kill-switch arm is status-identical to control on all 816 files → **all 11 fail→pass flips (and the 32 fail→compile_timeout) are attributable to the linked interpreter route**. 0 regressions.
- 11 < 30, so the issue's Test262 acceptance box stays **unchecked**; measured per-signature blockers for the rest (52 harness-global bridging, 42 SwitchStatement, 32 if-statement hang, 16 for-of/for-in — all interpreter-side) are recorded in the issue file.

Issue: plan/issues/2928-bytecode-interpreter-core-standalone-eval.md (stays `in-progress` — this is the E6 slice of an XL umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)