### PR TITLE
fix(compiler): don't hard-fail TS2345 from a JS default-value inferred param

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -19,6 +19,11 @@ import { assertCodegenRegistrationsComplete } from "./codegen/shared.js";
 import { isFatalCodegenDiagnostic } from "./codegen/context/errors.js";
 import type { WasmModule } from "./ir/types.js";
 import {
+  findSmallestNodeAtPosition,
+  isBindingPatternFalsePositive,
+  isJsDefaultInferredParamFalsePositive,
+} from "./compiler/argument-diagnostics.js";
+import {
   buildImportManifest,
   checkJsTypeCoverage,
   DOWNGRADE_DIAG_CODES,
@@ -111,65 +116,6 @@ const HARD_TS_DIAG_CODES = new Set([
   1213, // "Identifier expected. 'X' is a reserved word in strict mode. Class definitions are automatically in strict mode."
   1214, // "Identifier expected. 'X' is a reserved word in strict mode. Modules are automatically in strict mode."
 ]);
-
-/**
- * #862: TypeScript infers `function f([,])` as `function f([,]: [any?])` — a tuple type.
- * A call site like `f(generator)` then trips TS2345 even though, in JS/TS at runtime,
- * a binding-pattern parameter destructures any iterable per ECMA-262 §13.3.3.6
- * (IteratorBindingInitialization). Suppress 2345 when the target parameter uses an
- * array/object binding pattern and lacks an explicit type annotation — the inferred
- * tuple type is a TypeScript fiction that does not reflect runtime semantics.
- */
-function isBindingPatternFalsePositive(diag: ts.Diagnostic, checker: ts.TypeChecker): boolean {
-  if (diag.code !== 2345) return false;
-  const file = diag.file;
-  if (!file || diag.start === undefined) return false;
-  const pos = diag.start;
-  function findNode(node: ts.Node): ts.Node | undefined {
-    if (pos < node.getStart(file) || pos >= node.getEnd()) return undefined;
-    let found: ts.Node = node;
-    node.forEachChild((child) => {
-      const inner = findNode(child);
-      if (inner) found = inner;
-    });
-    return found;
-  }
-  let n: ts.Node | undefined = findNode(file);
-  while (n && !ts.isCallExpression(n) && !ts.isNewExpression(n)) {
-    n = n.parent;
-  }
-  if (!n || !(ts.isCallExpression(n) || ts.isNewExpression(n))) return false;
-  const args = n.arguments;
-  if (!args) return false;
-  let argIdx = -1;
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i]!;
-    if (pos >= a.getStart(file) && pos < a.getEnd()) {
-      argIdx = i;
-      break;
-    }
-  }
-  if (argIdx < 0) return false;
-  const sig = checker.getResolvedSignature(n);
-  if (!sig) return false;
-  const paramDecl = sig.getDeclaration()?.parameters?.[argIdx];
-  if (!paramDecl) return false;
-  if (paramDecl.type) return false; // explicit annotation — respect it
-  return ts.isArrayBindingPattern(paramDecl.name) || ts.isObjectBindingPattern(paramDecl.name);
-}
-
-function findSmallestNodeAtPosition(file: ts.SourceFile, pos: number): ts.Node | undefined {
-  function visit(node: ts.Node): ts.Node | undefined {
-    if (pos < node.getStart(file) || pos >= node.getEnd()) return undefined;
-    let found: ts.Node = node;
-    node.forEachChild((child) => {
-      const inner = visit(child);
-      if (inner) found = inner;
-    });
-    return found;
-  }
-  return visit(file);
-}
 
 function isDescendantOf(node: ts.Node, ancestor: ts.Node): boolean {
   let current: ts.Node | undefined = node;
@@ -544,6 +490,7 @@ function isInOperatorOperandDiagnostic(diag: ts.Diagnostic): boolean {
 function isHardTypeScriptDiagnostic(diag: ts.Diagnostic, checker?: ts.TypeChecker): boolean {
   if (diag.category !== 1 || !HARD_TS_DIAG_CODES.has(diag.code)) return false;
   if (checker && isBindingPatternFalsePositive(diag, checker)) return false;
+  if (checker && isJsDefaultInferredParamFalsePositive(diag, checker)) return false;
   if (checker && isGuardedNullablePrimitiveDiagnostic(diag, checker)) return false;
   if (isProxyHandlerTrapDiagnostic(diag)) return false;
   if (isInOperatorOperandDiagnostic(diag)) return false;

--- a/src/compiler/argument-diagnostics.ts
+++ b/src/compiler/argument-diagnostics.ts
@@ -1,0 +1,114 @@
+/**
+ * Classification of TS2345 ("Argument of type 'X' is not assignable to
+ * parameter of type 'Y'") diagnostics that are TypeScript fictions rather than
+ * real runtime type errors.
+ *
+ * TS2345 is a HARD diagnostic in `src/compiler.ts` — one occurrence aborts the
+ * compile before codegen runs. That is correct when the author stated a type
+ * and the call site violates it, but wrong when the "declared" type was only
+ * inferred by TypeScript from a shape that carries no runtime meaning. The
+ * predicates here identify those inferred-type cases.
+ */
+import ts from "typescript";
+
+/**
+ * Find the smallest node in `file` containing `pos`.
+ */
+export function findSmallestNodeAtPosition(file: ts.SourceFile, pos: number): ts.Node | undefined {
+  function visit(node: ts.Node): ts.Node | undefined {
+    if (pos < node.getStart(file) || pos >= node.getEnd()) return undefined;
+    let found: ts.Node = node;
+    node.forEachChild((child) => {
+      const inner = visit(child);
+      if (inner) found = inner;
+    });
+    return found;
+  }
+  return visit(file);
+}
+
+/**
+ * Resolve the parameter an argument-assignability diagnostic (TS2345) is
+ * complaining about: locate the argument node at `diag.start`, walk up to its
+ * enclosing call/new expression, resolve the signature, and return the
+ * parameter in that position.
+ *
+ * Returns undefined when any step fails, or when the parameter carries an
+ * explicit type annotation — an annotation is the author's stated intent, so a
+ * mismatch against it is never a false positive.
+ */
+function resolveUnannotatedArgumentParameter(
+  diag: ts.Diagnostic,
+  checker: ts.TypeChecker,
+): ts.ParameterDeclaration | undefined {
+  const file = diag.file;
+  if (!file || diag.start === undefined) return undefined;
+  const pos = diag.start;
+  let n: ts.Node | undefined = findSmallestNodeAtPosition(file, pos);
+  while (n && !ts.isCallExpression(n) && !ts.isNewExpression(n)) {
+    n = n.parent;
+  }
+  if (!n || !(ts.isCallExpression(n) || ts.isNewExpression(n))) return undefined;
+  const args = n.arguments;
+  if (!args) return undefined;
+  let argIdx = -1;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (pos >= a.getStart(file) && pos < a.getEnd()) {
+      argIdx = i;
+      break;
+    }
+  }
+  if (argIdx < 0) return undefined;
+  const paramDecl = checker.getResolvedSignature(n)?.getDeclaration()?.parameters?.[argIdx];
+  if (!paramDecl || paramDecl.type) return undefined; // explicit annotation — respect it
+  return paramDecl;
+}
+
+/**
+ * #862: TypeScript infers `function f([,])` as `function f([,]: [any?])` — a tuple type.
+ * A call site like `f(generator)` then trips TS2345 even though, in JS/TS at runtime,
+ * a binding-pattern parameter destructures any iterable per ECMA-262 §13.3.3.6
+ * (IteratorBindingInitialization). Suppress 2345 when the target parameter uses an
+ * array/object binding pattern and lacks an explicit type annotation — the inferred
+ * tuple type is a TypeScript fiction that does not reflect runtime semantics.
+ */
+export function isBindingPatternFalsePositive(diag: ts.Diagnostic, checker: ts.TypeChecker): boolean {
+  if (diag.code !== 2345) return false;
+  const paramDecl = resolveUnannotatedArgumentParameter(diag, checker);
+  if (!paramDecl) return false;
+  return ts.isArrayBindingPattern(paramDecl.name) || ts.isObjectBindingPattern(paramDecl.name);
+}
+
+/** `.js` / `.mjs` / `.cjs` / `.jsx` — a file with no TypeScript annotations available. */
+const JS_SOURCE_FILE_RE = /\.[cm]?jsx?$/i;
+
+/**
+ * TypeScript infers an unannotated JS parameter's type from its default-value
+ * initializer: `function f(prerelease = "")` becomes `prerelease: string`. A
+ * call site passing anything wider then trips TS2345 even though the body may
+ * handle the wider type explicitly — TypeScript's own shipped bundle does
+ * exactly this in `semver.ts`:
+ *
+ * ```js
+ * constructor(major, minor = 0, patch = 0, prerelease = "", build = "") {
+ *   const prereleaseArray = prerelease ? isArray(prerelease) ? prerelease : prerelease.split(".") : emptyArray;
+ * ```
+ *
+ * …called as `new Version(0, 0, 0, ["0"])`. The original `.ts` source declares
+ * `prerelease?: string | readonly string[]`, but that annotation is erased in
+ * the published JS, so the checker sees only the `""` default.
+ *
+ * In a JS file the inferred type is a TypeScript fiction with no runtime
+ * meaning, so it must not gate codegen. Scoped to JS source files and to
+ * parameters that have an initializer, no explicit annotation, and no JSDoc
+ * type tag (JSDoc is the JS author's stated intent — respect it, same as an
+ * annotation).
+ */
+export function isJsDefaultInferredParamFalsePositive(diag: ts.Diagnostic, checker: ts.TypeChecker): boolean {
+  if (diag.code !== 2345) return false;
+  if (!diag.file || !JS_SOURCE_FILE_RE.test(diag.file.fileName)) return false;
+  const paramDecl = resolveUnannotatedArgumentParameter(diag, checker);
+  if (!paramDecl?.initializer) return false;
+  return !ts.getJSDocParameterTags(paramDecl).some((tag) => tag.typeExpression !== undefined);
+}

--- a/tests/js-default-inferred-param-ts2345.test.ts
+++ b/tests/js-default-inferred-param-ts2345.test.ts
@@ -1,0 +1,94 @@
+/**
+ * TS2345 false positive: parameter type inferred from a JS default value.
+ *
+ * TypeScript infers an unannotated JS parameter's type from its default-value
+ * initializer, so `function f(prerelease = "")` becomes `prerelease: string`.
+ * A call site passing anything wider trips TS2345 — and because 2345 is in
+ * HARD_TS_DIAG_CODES, that single diagnostic aborted the whole compile before
+ * codegen ever ran.
+ *
+ * The shape below is reduced from TypeScript's own shipped bundle
+ * (`node_modules/typescript/lib/_tsc.js`, `src/compiler/semver.ts`), which was
+ * the first hard blocker when compiling the `typescript` npm package: the
+ * original `.ts` source declares `prerelease?: string | readonly string[]`, but
+ * that annotation is erased in the published JS, leaving only the `""` default.
+ *
+ * In a JS file the inferred type is a TypeScript fiction with no runtime
+ * meaning, so it must not gate codegen. An explicit annotation or a JSDoc type
+ * tag IS the author's stated intent and stays hard.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const errorText = (r: Awaited<ReturnType<typeof compile>>) =>
+  r.errors.map((e) => `${e.message} @ ${e.line}:${e.column}`).join("; ");
+
+describe("TS2345 on a JS parameter typed from its default value", () => {
+  it("does not block codegen for the semver.ts shape from the tsc bundle", async () => {
+    const result = await compile(
+      `
+      function isArray(v) { return Object.prototype.toString.call(v) === "[object Array]"; }
+      class Version {
+        constructor(major, minor = 0, patch = 0, prerelease = "") {
+          this.major = major;
+          this.minor = minor;
+          this.patch = patch;
+          this.prerelease = prerelease ? (isArray(prerelease) ? prerelease : prerelease.split(".")) : [];
+        }
+      }
+      export function run() {
+        const v = new Version(1, 2, 3, ["0"]);
+        return v.prerelease.length;
+      }
+    `,
+      { allowJs: true, fileName: "semver.js" },
+    );
+
+    expect(result.success, `Compile failed: ${errorText(result)}`).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+
+  it("stays hard when the JS parameter carries a JSDoc type tag", async () => {
+    const result = await compile(
+      `
+      /**
+       * @param {string} prerelease
+       */
+      function tag(prerelease = "") { return prerelease; }
+      export function run() { return tag(["0"]); }
+    `,
+      { allowJs: true, fileName: "jsdoc.js" },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((e) => e.code === 2345)).toBe(true);
+  });
+
+  it("stays hard for an annotated parameter in a TypeScript file", async () => {
+    const result = await compile(
+      `
+      function tag(prerelease: string = ""): string { return prerelease; }
+      export function run(): string { return tag(["0"]); }
+    `,
+      { fileName: "annotated.ts" },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((e) => e.code === 2345)).toBe(true);
+  });
+
+  it("stays hard for a default-typed parameter in a TypeScript file", async () => {
+    // Same inference, but in .ts the author chose not to annotate and TS's
+    // inference is meaningful — js2wasm is a TypeScript compiler, so respect it.
+    const result = await compile(
+      `
+      function tag(prerelease = "") { return prerelease; }
+      export function run() { return tag(["0"]); }
+    `,
+      { fileName: "inferred.ts" },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((e) => e.code === 2345)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

TS2345 ("Argument of type 'X' is not assignable to parameter of type 'Y'") is in `HARD_TS_DIAG_CODES`, so a single occurrence aborts the compile before codegen runs — `success: false`, zero-byte binary. That is correct when the author declared a type and the call site violates it, but wrong when the "declared" type was only *inferred* from something with no runtime meaning.

TypeScript infers an unannotated JS parameter's type from its default-value initializer, so `function f(prerelease = "")` becomes `prerelease: string`. TypeScript's own shipped bundle hits this in `semver.ts`:

```js
constructor(major, minor = 0, patch = 0, prerelease = "", build = "") {
  const prereleaseArray = prerelease
    ? isArray(prerelease) ? prerelease : prerelease.split(".")
    : emptyArray;
```

…called as `new Version(0, 0, 0, ["0"])`. The original `.ts` source declares `prerelease?: string | readonly string[]`, but that annotation is erased on publish, so the checker sees only the `""` default — while the body explicitly handles the array case.

### Change

New `isJsDefaultInferredParamFalsePositive` suppressor, wired into `isHardTypeScriptDiagnostic`. It fires only when the target parameter:

- is in a **JS** source file (`.js` / `.mjs` / `.cjs` / `.jsx`),
- has an **initializer**, and
- carries **neither an explicit annotation nor a JSDoc type tag**.

Both of the latter are the author's stated intent and stay hard. Mirrors the existing #862 binding-pattern suppressor in rationale and placement.

### Scope

- **`.ts` files are unaffected** — there the author chose not to annotate and TypeScript's inference is meaningful; js2wasm is a TypeScript compiler and respects it.
- **No test262 impact.** The runner passes `skipSemanticDiagnostics: true` (`tests/test262-runner.ts:4153`), so semantic diagnostics are empty and TS2345 never reaches that path.

### Refactor

Moves the TS2345 classification cluster out of the `src/compiler.ts` driver into a new `src/compiler/argument-diagnostics.ts`, deduplicating the argument → parameter resolution that the binding-pattern suppressor open-coded (it carried its own copy of `findSmallestNodeAtPosition`). Net **-53 LOC** in the driver, which is also how `check:loc-budget` is satisfied — no allowance requested.

### Verification

| Check | Result |
|---|---|
| New tests (4, `tests/js-default-inferred-param-ts2345.test.ts`) | pass; target case verified to **fail without the fix** |
| `tsc --noEmit` | clean |
| equivalence gate | 1610 passing, **no new regressions** |
| lint / prettier | clean |
| `check:loc-budget`, `check:func-budget`, `check:oracle-ratchet`, `check:test262-hard-errors` | pass |

Pre-existing on this branch and **not** caused by this change (verified identical with the change stashed): `check:godfiles` failures in `src/codegen/index.ts` / `src/codegen/object-runtime.ts`, and 3 failures in `tests/error-reporting.test.ts`.

The equivalence gate also reports 3 baseline failures now passing (`Math.pow`, `Symbol`). Those are pre-existing drift, not from this change — the suppressor only fires on `.js` files with unannotated params, and those parameters are annotated in `lib.d.ts`. The baseline is left unratcheted rather than folding an unrelated win into this PR.

### Context

Found while probing how far the compiler gets on the `typescript` npm package (#1058 / #1579). This removes one wall on the single-source `compile()` path; `compileProject` already tolerated TS2345 via its `allowJs` suppression. It does **not** unblock the tsc bundle — that still fails on a separate single codegen error, `Unsupported statement: LastStatement` (the one `debugger;` at `_tsc.js:1279`, which the WasmGC backend has no arm for while the linear backend handles it as a no-op).

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: this is an attestation for a human contributor to make, not an agent. The template notes internal/org-member PRs skip the CLA check automatically. -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kEqkoB4FKKtW3q9G6zFoY

---
_Generated by [Claude Code](https://claude.ai/code/session_014kEqkoB4FKKtW3q9G6zFoY)_