### PR TITLE
fix(#3714): private brand check (#x in obj) throws TypeError for non-object receivers

### DIFF
--- a/plan/issues/3714-private-brand-check-null-receiver.md
+++ b/plan/issues/3714-private-brand-check-null-receiver.md
@@ -21,6 +21,15 @@ related: [3690]
 # god-file drift.
 loc-budget-allow:
   - src/runtime.ts
+# compileInOperator grew because the new not-an-object throw check is
+# inlined at its one call site rather than factored out (it needs fctx/ctx
+# plus the already-computed externCopy/brandLocal, so extracting a helper
+# would mean threading 4-5 params for a single-caller function). resolveImport
+# is the same shared big-dispatch-table pattern __extern_is_undefined and
+# every other single-arg host import already lives in.
+func-budget-allow:
+  - src/codegen/binary-ops-in.ts::compileInOperator
+  - src/runtime.ts::resolveImport
 ---
 
 # #3714 — `#field in obj` with `obj === null` should throw a catchable TypeError

--- a/plan/issues/3714-private-brand-check-null-receiver.md
+++ b/plan/issues/3714-private-brand-check-null-receiver.md
@@ -1,10 +1,11 @@
 ---
 id: 3714
 title: "Private brand check (#x in obj) on a null receiver does not throw a catchable TypeError"
-status: ready
+status: done
 sprint: current
 created: 2026-07-27
 updated: 2026-07-27
+completed: 2026-07-27
 priority: low
 horizon: s
 feasibility: medium
@@ -36,55 +37,69 @@ try {
 }
 ```
 
-## Symptom
+## Symptom (before fix)
 
 - V8: `true\nfalse\ntrue`
 - js2wasm: `true\nfalse` (third line never printed)
 
-The first two brand-check cases (own instance → `true`, unrelated plain
-object → `false`) already match — see #3690's `private-fields/01-fields.js`
-through `04-accessors.js`, all matching. Per spec, the ergonomic
-brand-check form `#x in obj` must return `false` for any non-`Box`
-*object*, but throw a `TypeError` when `obj` is not an object at all (e.g.
-`null`/`undefined`/a primitive). js2wasm appears to either trap
-uncatchably or silently swallow the case rather than raising a JS-catchable
-`TypeError`, so the `try`/`catch` never logs its line — worth checking
-whether this shares a root cause with other brand-check-vs-uncatchable-trap
-issues (`tests/issue-private-access-brand.test.ts` fixed an analogous
-`.call(nonInstance)` case).
+## Root cause
 
-## Repro file
+ECMA-262 §13.10.1 step 5 (`RelationalExpression : PrivateIdentifier in
+ShiftExpression`): *"If `rval` is not an Object, throw a TypeError
+exception."* — verified empirically against real Node 22 that this applies
+to `null`, `undefined`, and every primitive, not just `null`.
+`src/codegen/binary-ops-in.ts` carried a comment claiming the opposite
+("no throw, even when obj isn't an object"), which was itself wrong.
 
-`tests/differential/corpus/private-fields/05-brand-checks.js` (see #3690).
+`emitPrivateBrandPredicate` (`src/codegen/expressions/helpers.ts`)
+implements the check as a single `ref.test $declaringClassStruct`, which is
+correct for "does obj have this brand" but `ref.test` evaluates to `0` for
+ANY non-matching anyref (including `null` and boxed primitives) — every
+non-instance receiver, object or not, silently became `false` with no
+distinction and no throw.
 
-## Root cause (investigated 2026-07-27)
+## Fix
 
-Confirmed the spec detail first, since a comment in the codebase disagrees
-with it: ECMA-262 §13.10.1 step 5 (`RelationalExpression : PrivateIdentifier
-in ShiftExpression`) says *"If `rval` is not an Object, throw a TypeError
-exception."* — verified empirically against real Node 22 too: `#v in x`
-throws `TypeError` for `x` = `null`, `undefined`, a number, a string, AND a
-boolean, not just `null`. `src/codegen/binary-ops-in.ts` (lines 32-36)
-carries a comment claiming the opposite — *"the result is `true` iff `obj`
-carries the brand... and `false` otherwise (no throw, even when obj isn't
-an object)"* — which is incorrect per spec and per real-engine behavior;
-worth fixing that comment regardless of the runtime fix.
+`ref.test` alone can't distinguish "a real object of the wrong class" from
+"not an object at all" — Wasm has no visibility into what an opaque
+externref (the receiver's static type for an untyped/`any` parameter, the
+common case here) actually wraps once it crosses the JS-host boundary.
+Added a new JS-host import, `__extern_is_object` (`src/runtime.ts`),
+implementing ECMA-262's `Type(x) is Object` directly (`v !== null &&
+(typeof v === "object" || typeof v === "function")` — deliberately NOT
+`typeof v === "object"` alone, which is `true` for `null` too).
 
-The actual runtime gap: `emitPrivateBrandPredicate`
-(`src/codegen/expressions/helpers.ts`) implements the check as a single
-`ref.test $declaringClassStruct` — which is correct for "does obj have this
-brand" but `ref.test` simply evaluates to `0` for ANY non-matching anyref
-(including `null` and boxed primitives), so every non-instance receiver —
-object or not — silently becomes `false` with no distinction and no throw.
+`src/codegen/binary-ops-in.ts`'s private-identifier branch now: stashes a
+raw copy of the externref receiver before `any.convert_extern`, and if the
+`ref.test`-based brand predicate comes back `false`, calls
+`__extern_is_object` on that raw copy. If it says "not an object," emits a
+catchable `TypeError` throw (via the existing `emitThrowTypeError` /
+`pushBody`/`popBody` nesting pattern); otherwise falls through to the
+existing `false` result (correct object, just the wrong class).
 
-**Not fixed here.** A correct fix needs a runtime "is this anyref value a
-JS object" classification that `ref.test` alone can't provide (it can only
-ask "is this a *specific* struct type", not "is this *any* struct/array,
-i.e. not null/i31/primitive-boxed") — needs to correctly cover js2wasm's
-existing value representations (i31-boxed small ints, `undefined`'s
-tag-1-externref-not-null-externref encoding per `type-coercion.ts`'s
-`__extern_is_undefined`, wasm:js-string values, etc.), which is more
-surface area than the fix's `low` priority justified investigating deeper
-in this pass. The two already-passing brand-check cases (own instance,
-unrelated plain object) cover the common path; this residual gap is the
-non-object-receiver edge specifically.
+Scoped to the JS-host fast path only (guarded by `!ctx.standalone &&
+!ctx.wasi`), per the dual-mode architecture principle — standalone has no
+host to delegate to, so it keeps its pre-existing (still spec-incomplete,
+but not regressed) false-no-throw behavior for the non-object case. A
+Wasm-native standalone fix is a separate, deferred follow-up.
+
+## Verification
+
+- New repro (own instance / wrong-class object / null / undefined / number
+  / string, all six cases): matches V8 exactly.
+- `private-fields/05-brand-checks.js` in the #3690 differential corpus: now
+  matches (private-fields category 5/5, up from 4/5).
+- Zero regressions across ~380 tests spanning private fields, brand checks,
+  the `in` operator, and class-value tests (`tests/private-class-members.test.ts`,
+  `tests/class-static-private-this.test.ts`,
+  `tests/issue-2563-privatefield-global-shift.test.ts`,
+  `tests/in-operator-edge-cases.test.ts`, plus 20+ other `issue-*.test.ts`
+  files) — every failure encountered was independently confirmed
+  pre-existing on `main` (unrelated to this change) by re-running the same
+  suites with the fix stashed out.
+- One test needed correcting, not preserving: `tests/issue-1348.test.ts`'s
+  "private in is a brand check and does not throw on wrong receiver" test
+  asserted `Box.isBox(null)` returns falsy — the exact same spec
+  misunderstanding this issue fixes in the compiler. Updated to assert the
+  correct behavior (own instance → `true`, wrong-class object → `false`,
+  `null` → catchable `TypeError`).

--- a/plan/issues/3714-private-brand-check-null-receiver.md
+++ b/plan/issues/3714-private-brand-check-null-receiver.md
@@ -15,6 +15,12 @@ language_feature: n/a
 goal: property-model
 origin: "#3690 — new tests/differential/corpus/private-fields/05-brand-checks.js surfaced this on first run"
 related: [3690]
+# The +8 lines are the new `__extern_is_object` host import (implementation
+# + the comment explaining why it's not just `typeof v === "object"`, per
+# #3714's Root cause section below). Genuinely new runtime surface, not
+# god-file drift.
+loc-budget-allow:
+  - src/runtime.ts
 ---
 
 # #3714 — `#field in obj` with `obj === null` should throw a catchable TypeError

--- a/src/codegen/binary-ops-in.ts
+++ b/src/codegen/binary-ops-in.ts
@@ -10,7 +10,8 @@
  * change (prove-emit-identity IDENTICAL across gc/standalone/wasi).
  */
 import { ts } from "../ts-api.js";
-import type { ValType } from "../ir/types.js";
+import type { Instr, ValType } from "../ir/types.js";
+import { popBody, pushBody } from "./context/bodies.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import {
@@ -25,15 +26,31 @@ import { coerceType, compileExpression, flushLateImportShifts } from "./shared.j
 import { inRhsIsExclusivelyPrimitive } from "./binary-ops.js";
 
 /**
+ * (#3714) `emitThrowTypeError` pushes directly onto `fctx.body`; to nest its
+ * throw sequence inside an `if` branch's `then:` instruction array, redirect
+ * `fctx.body` to a scratch array via `pushBody`/`popBody`, capture what it
+ * emitted, and hand that back as a plain `Instr[]`.
+ */
+function buildThrowTypeErrorBranch(ctx: CodegenContext, fctx: FunctionContext, message: string): Instr[] {
+  const saved = pushBody(fctx);
+  emitThrowTypeError(ctx, fctx, message);
+  const throwInstrs = fctx.body;
+  popBody(fctx, saved);
+  return throwInstrs;
+}
+
+/**
  * Compile a `key in obj` binary expression (op === InKeyword). Reads only the
  * codegen context, function context, and the expression node. Always returns.
  */
 export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): InnerResult {
   // #1365 — `#x in obj` is a RUNTIME brand check, not a compile-time
   // property-name lookup. Per ES2022 §12.10.3 (RelationalExpression :
-  // PrivateIdentifier `in` ShiftExpression), the result is `true` iff
+  // PrivateIdentifier `in` ShiftExpression) step 5, the result is `true` iff
   // `obj` carries the brand of the class that lexically declared `#x`,
-  // and `false` otherwise (no throw, even when obj isn't an object).
+  // `false` when `obj` is a DIFFERENT object, and a **TypeError** when `obj`
+  // is not an Object at all (verified against real V8/Node: `null`,
+  // `undefined`, and every primitive throw, not just `null` — #3714).
   //
   // Today the generic `in` path returns a compile-time `i32.const` based
   // on whether the receiver type's struct happens to have `__priv_<name>`
@@ -51,12 +68,68 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
       // the brand predicate can combine structural ref.test with class-tag
       // ancestry.
       const objResult = compileExpression(ctx, fctx, expr.right);
-      if (objResult?.kind === "externref") {
+      const receiverIsExternref = objResult?.kind === "externref";
+      // (#3714) When the receiver's static type is externref (the common
+      // case for an untyped/`any` parameter), a WasmGC `ref.test` alone
+      // cannot distinguish "a real object of the wrong class" (should stay
+      // `false`) from "not an object at all" (should throw). Stash a raw
+      // copy of the externref BEFORE `any.convert_extern` so the JS-host
+      // fast-path check below can ask the host directly — Wasm has no
+      // visibility into what an opaque externref wraps. A statically-typed
+      // receiver (already known to be a struct/array/etc.) skips this
+      // entirely: it's always an Object, no runtime ambiguity to resolve.
+      let externCopy: number | undefined;
+      if (receiverIsExternref && !ctx.standalone && !ctx.wasi) {
+        externCopy = allocTempLocal(fctx, { kind: "externref" });
+        fctx.body.push({ op: "local.tee", index: externCopy });
+      }
+      if (receiverIsExternref) {
         fctx.body.push({ op: "any.convert_extern" });
       }
       const tmpAny = allocTempLocal(fctx, { kind: "anyref" });
       fctx.body.push({ op: "local.set", index: tmpAny });
       emitPrivateBrandPredicate(ctx, fctx, tmpAny, declared.className, declared.structTypeIdx);
+      const isObjectIdx =
+        externCopy !== undefined
+          ? ensureLateImport(ctx, "__extern_is_object", [{ kind: "externref" }], [{ kind: "i32" }])
+          : undefined;
+      if (externCopy !== undefined && isObjectIdx !== undefined) {
+        const externCopyLocal: number = externCopy;
+        const brandLocal = allocTempLocal(fctx, { kind: "i32" });
+        fctx.body.push({ op: "local.set", index: brandLocal });
+        fctx.body.push({ op: "local.get", index: brandLocal });
+        fctx.body.push({ op: "i32.eqz" }); // brand check came back false
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: externCopyLocal },
+            { op: "call", funcIdx: isObjectIdx },
+            { op: "i32.eqz" }, // and the receiver is not an Object at all
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: buildThrowTypeErrorBranch(
+                ctx,
+                fctx,
+                "Cannot use 'in' operator to search for private field in a non-object",
+              ),
+              else: [],
+            },
+          ],
+          else: [],
+        });
+        fctx.body.push({ op: "local.get", index: brandLocal });
+        releaseTempLocal(fctx, brandLocal);
+        releaseTempLocal(fctx, externCopyLocal);
+      } else if (externCopy !== undefined) {
+        // Defensive: `ensureLateImport` failed (should not happen for a
+        // brand-new import name). The brand predicate's i32 is already on
+        // the stack from `emitPrivateBrandPredicate` above — just release
+        // the unused externref copy and fall back to the pre-existing
+        // false-no-throw behavior rather than failing the compile.
+        releaseTempLocal(fctx, externCopy);
+      }
       releaseTempLocal(fctx, tmpAny);
       return { kind: "i32" };
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -9336,6 +9336,14 @@ assert._isSameValue = isSameValue;
           return v.toLocaleString();
         };
       if (name === "__extern_is_undefined") return (v: any) => (v === undefined ? 1 : 0);
+      // (#3714) ECMA-262 Type(x) is Object — used by the private-field
+      // brand-check (`#x in obj`, §12.10.3 step 5) to distinguish "a real
+      // object of the wrong class" (false, no throw) from "not an object at
+      // all" (TypeError) when a WasmGC `ref.test` alone can't see past an
+      // opaque externref. Deliberately NOT `typeof v === "object"` alone —
+      // that's `true` for `null` too, but `null` is not an ECMAScript Object.
+      if (name === "__extern_is_object")
+        return (v: any) => (v !== null && (typeof v === "object" || typeof v === "function") ? 1 : 0);
       // (#1328) Array.isArray on an externref value (e.g. a RegExp match
       // result returned from the host). The compile-time type can't decide
       // this for `externref`, so defer to the real spec predicate.

--- a/tests/issue-1348.test.ts
+++ b/tests/issue-1348.test.ts
@@ -170,11 +170,24 @@ describe("#1348 class static initialization and private fields", () => {
     expect(ex.test()).toBe(42);
   });
 
-  it("private in is a brand check and does not throw on wrong receiver", async () => {
+  it("private in is a brand check: false for a wrong-class object, TypeError for a non-object", async () => {
+    // (#3714) `#x in obj` per ES2022 §12.10.3 step 5: `false` for any object
+    // that isn't an `A` instance, but a **TypeError** when `obj` isn't an
+    // Object at all (verified against real V8/Node — `null` throws, it does
+    // not silently evaluate to `false`). This test previously asserted the
+    // opposite for `null` ("does not throw on wrong receiver"); that was the
+    // same spec misreading #3714 found and fixed in binary-ops-in.ts.
     const ex = await compileToWasm(`
       class A {
         #x: number = 1;
         has(o: any): boolean { return #x in o; }
+        hasCaught(o: any): number {
+          try {
+            return #x in o ? 1 : 0;
+          } catch (e) {
+            return e instanceof TypeError ? 2 : 3;
+          }
+        }
       }
       class B {
         #x: number = 2;
@@ -182,10 +195,10 @@ describe("#1348 class static initialization and private fields", () => {
       export function test(): number {
         const a = new A();
         const b = new B();
-        return (a.has(a) ? 1 : 0) + (a.has(b) ? 10 : 0) + (a.has(null) ? 100 : 0);
+        return (a.has(a) ? 1 : 0) + (a.has(b) ? 10 : 0) + a.hasCaught(null) * 100;
       }
     `);
-    expect(ex.test()).toBe(1);
+    expect(ex.test()).toBe(201);
   });
 
   it("private field read rejects unrelated class with the same private name", async () => {


### PR DESCRIPTION
## Description

Fixes #3714, found by the #3690 differential corpus (`tests/differential/corpus/private-fields/05-brand-checks.js`).

ECMA-262 §13.10.1 step 5 requires `#x in obj` to throw a `TypeError` when `obj` is not an Object at all (verified against real Node: `null`, `undefined`, and every primitive all throw, not just `null`) — distinct from returning `false` for a real object of the wrong class. `binary-ops-in.ts` carried a comment claiming the opposite ("no throw, even when obj isn't an object"), which was itself incorrect; `emitPrivateBrandPredicate`'s `ref.test` can only ask "is this a specific struct type," so every non-matching anyref collapsed to `false` with no distinction.

**Fix**: Wasm has no visibility into what an opaque externref wraps once it crosses the JS-host boundary, so this adds a JS-host fast path — a new `__extern_is_object` import implementing `Type(x) is Object` directly, called only when the `ref.test`-based brand predicate comes back `false`. If the receiver isn't an object at all, throw a catchable `TypeError`; otherwise fall through to the existing `false` result. Scoped to JS-host mode only (guarded on `!standalone && !wasi`) per the dual-mode architecture principle — standalone keeps its prior (still spec-incomplete but not regressed) behavior, deferred as follow-up work.

`tests/issue-1348.test.ts` asserted the same wrong spec reading this issue fixes (`Box.isBox(null)` expected falsy, not a throw) — corrected rather than preserved.

**Verification**: zero regressions across ~380 tests spanning private fields, brand checks, the `in` operator, and class-value tests. Every failure encountered while testing was independently confirmed pre-existing on `main` (unrelated to this change) by re-running the same suites with the fix stashed out. The #3690 differential corpus's `private-fields` category is now 5/5 (up from 4/5).

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdciSGoMA9bs8AWhQ1tyPh)_