### PR TITLE
docs(#3713): root-cause nested object-literal-method closure bug (found via Symbol.iterator, but general)

### DIFF
--- a/plan/issues/3713-custom-symbol-iterator-object-protocol.md
+++ b/plan/issues/3713-custom-symbol-iterator-object-protocol.md
@@ -1,24 +1,24 @@
 ---
 id: 3713
-title: "Plain object with a custom [Symbol.iterator]() method is not iterated correctly by spread/for-of"
+title: "Nested object-literal-method closure over an enclosing method's local reads the default value, not the captured one (surfaced via custom Symbol.iterator)"
 status: ready
 sprint: current
 created: 2026-07-27
 updated: 2026-07-27
-priority: medium
-horizon: m
-feasibility: medium
+priority: high
+horizon: l
+feasibility: hard
 task_type: bugfix
-area: codegen, runtime
-language_feature: iterators
+area: codegen
+language_feature: closures
 goal: iterator-protocol
 origin: "#3690 — new tests/differential/corpus/builtins/19-symbol-iterator.js surfaced this on first run"
 related: [3690]
 ---
 
-# #3713 — Custom `[Symbol.iterator]()` on a plain object literal doesn't drive spread/for-of
+# #3713 — Nested object-literal-method closures over an enclosing method's local silently read the default value
 
-## Repro
+## Original repro (via #3690)
 
 ```js
 const range = {
@@ -34,73 +34,125 @@ const range = {
     };
   },
 };
-console.log([...range].join(","));
+console.log([...range].join(","));   // V8: "1,2,3", js2wasm: ""
 let total = 0;
 for (const n of range) total += n;
-console.log(total);
+console.log(total);                  // V8: 6, js2wasm: 0
 ```
 
-## Symptom
+## Investigation (2026-07-27) — narrowed far past the original "Symbol.iterator" framing
 
-- V8: `1,2,3\n6`
-- js2wasm: `0\n0`
+Started by tracing the actual runtime values crossing the `__iterator`
+host-import boundary (`src/runtime.ts`) with instrumented imports. This
+ruled out the original hypothesis ("`__iterator` receives an empty
+placeholder instead of `range`"): `range` **does** cross correctly as an
+opaque wrapped WasmGC struct (`[Object: null prototype] {}` is just how
+Node's console renders that — `Object.keys`/`obj[Symbol.iterator]` return
+nothing because plain JS reflection can't see into an opaque externref,
+not because the struct itself is empty). Compiled exports like
+`__call_@@iterator` (a purpose-built accessor for exactly this case) DO
+correctly find and invoke the object literal's `[Symbol.iterator]()`
+method on the real struct.
 
-Both the spread (`[...range]`) and `for-of` consumption produce empty/zero
-results, as if `range` is treated as an empty iterable rather than invoking
-the computed `[Symbol.iterator]()` method and driving its returned
-`{next()}` protocol object. Built-in iterables (arrays, generator objects
-per #3690's `generators/02-for-of.js`, which matches) already work — the
-gap is specifically a **user-defined** iterable via a computed
-`[Symbol.iterator]` method on an object literal.
+Manually driving the chain (`__call_@@iterator` → `__sget_next` →
+`__call_fn_0` → `__sget_value`/`__sget_done`) narrowed the actual defect
+to one field: `{value: current++, done: false}`'s `done` comes back
+correct (`false`); `value` comes back `0` instead of `1`.
 
-## Repro file
+**This has nothing to do with `Symbol.iterator`, computed keys, or
+iterators at all.** Isolated to a minimal repro with none of those:
 
-`tests/differential/corpus/builtins/19-symbol-iterator.js` (see #3690).
-
-## Root cause (investigated 2026-07-27) — narrowed to a specific wrong value, not a missing feature
-
-Traced with instrumented host imports (wrapped `__iterator` in
-`buildImports` to log its argument at the exact call site both the spread
-and the for-of loop reach). **The generic host-delegated iterator path
-(`src/codegen/statements/loops.ts` `compileForOfIterator`, the `__iterator`
-/ `__iterator_next` host imports in `src/runtime.ts`) IS being invoked** —
-confirmed the compiled program imports and calls `__iterator` exactly
-twice (once for the spread, once for the for-of). But the value passed to
-it is **not `range`**:
-
+```js
+const range = {
+  makeIter() {
+    const current = 42;
+    return {
+      next() {
+        return current;
+      },
+    };
+  },
+};
+range.makeIter().next(); // V8: 42, js2wasm: 0
 ```
-TRACE __iterator called with: [Object: null prototype] {} keys: [] hasSymbolIterator: false
-```
 
-Both call sites pass an **empty placeholder object** — no `from`, `to`,
-`[Symbol.iterator]`, nothing — instead of the actual compiled `range`
-value. So this is not "the runtime doesn't know how to call a custom
-iterator" (the `__iterator` runtime fallback for opaque WasmGC structs —
-`_isWasmStruct(obj)` → `exports["__call_@@iterator"]` — looks like it's
-designed for exactly this case, per `src/runtime.ts` around line 13161).
-The bug is upstream: **whatever compiles `range` (an object literal with a
-computed `[Symbol.iterator]()` method key, no explicit type annotation —
-TS infers a concrete struct type for it since there's no contextual
-`any`/`unknown`) and coerces it to externref before the `__iterator` call
-is producing/passing a fresh empty object instead of the real one.**
+Systematically bisected which shape triggers it:
 
-Two candidate sites for whoever picks this up, not yet disambiguated:
+| shape | result |
+| --- | --- |
+| standalone function → nested object-literal method closes over outer `let` | **42 (works)** |
+| object-literal method → nested ARROW function closes over outer `let` | **42 (works)** |
+| object-literal method → nested object-literal method closes over outer `let`/`const` | **0 (broken)** |
+| object-literal method, no nested closure at all | **42 (works, sanity check)** |
 
-1. `src/codegen/literals.ts` `compileObjectLiteralAsExternref` (or whatever
-   builds the struct/`$Object` for `range`) may be dropping ALL properties
-   when a computed well-known-symbol method key is present, rather than
-   just skipping the unsupported key.
-2. The for-of/spread "coerce struct to externref" step in
-   `compileForOfIterator` / the spread-element codegen may be pushing an
-   unrelated freshly-constructed placeholder onto the stack instead of the
-   actual compiled `range` expression result.
+The trigger is specifically: **an object-literal method-shorthand
+(`next() {...}`, not an arrow) nested inside the return value of ANOTHER
+object-literal method, closing over the outer method's local.**
 
-Distinguishing which requires adding raw WAT/bytecode-level tracing rather
-than JS-level `console.log` instrumentation (the wrong value is already
-wrong by the time it reaches the `env.__iterator` import boundary), which
-is a next step, not something completed here.
+## Root cause, precisely — cross-invocation state leak in capture promotion
 
-**Not fixed here** — narrowed considerably (exact wrong value identified,
-two concrete candidate emission sites named) but the precise site needs
-one more investigation pass before a safe patch. Left `status: ready` since
-this is scoped enough for a focused follow-up, unlike #3710-#3712.
+`src/codegen/literals.ts`'s `compileObjectLiteralForStruct` calls
+`promoteAccessorCapturesToGlobals` (`src/codegen/closures.ts`) once per
+object-literal method to promote any enclosing-scope locals the method's
+body references into module globals (object-literal methods are compiled
+as free-standing Wasm functions, not true closures, so a captured local
+has to become a global the method function can read).
+
+Direct instrumentation (`console.error` at entry/exit of the promotion
+call, comparing `fctx.body.length` before/after) proved
+`compileObjectLiteralForStruct` runs **twice** for the exact same object
+literal in this repro shape. First run: `capturedGlobals.has("current")`
+is `false`, so the promotion correctly emits `local.get 1; global.set 8`
+(copying `current`'s actual runtime value into the new global) — `fctx.body.length`
+grows 8 → 12. Second run: `capturedGlobals.has("current")` is
+now **`true`** (leftover from the first run — `ctx.capturedGlobals` was
+never reset between the two invocations), so the promotion loop's own
+`if (ctx.capturedGlobals.has(name)) continue;` guard (correctly meant to
+avoid double-registering the SAME global) skips re-emitting the
+value-copy too — `fctx.body.length` stays at 8, **unchanged**. Whichever
+compiled function actually ships is the one missing the copy instruction,
+so the promoted global keeps its bare default init (`f64.const 0`) forever
+— reads as `0`, matching the observed symptom exactly.
+
+Traced the "why compiled twice" one level further: it is **not** the
+struct's placeholder-method pre-registration pass (`src/codegen/index.ts`
+~line 7159, "Pre-register placeholder functions for callable properties")
+— that pass only stubs empty function bodies into `funcMap` for
+forward-reference resolution; it never calls
+`compileObjectLiteralForStruct` or touches `capturedGlobals`. The actual
+second invocation site is still unidentified — `generateModule` only
+calls into codegen once from `compiler.ts`, so the duplicate call must
+originate somewhere inside a deeper codegen path (possibly the two-pass
+front-end architecture — direct-AST vs IR, `docs/architecture/codegen-axes.md`
+— re-attempting the same literal, or a legitimate "sibling literal /
+per-literal-fork" re-entry per the `#1557` comments in the same file that
+did NOT reset shared promotion state this time).
+
+**Not fixed here.** This is architecturally significant, not a local
+patch:
+- The trigger site (why the object literal compiles twice) needs
+  identifying before a fix can be scoped — reset-on-every-call would be
+  wrong if OTHER call sites intentionally rely on `capturedGlobals`
+  surviving across sibling-literal forks (the `#1557` per-literal-funcIdx
+  mechanism in the same file suggests exactly that kind of intentional
+  sharing exists elsewhere).
+- A correct fix likely needs the promotion to distinguish "already
+  promoted AND already copied for THIS specific compiled function" from
+  "already promoted for a DIFFERENT invocation of the same literal" —
+  more than a one-line change.
+- Blast radius unknown: any object-literal method returning a nested
+  object-literal method that closes over the outer method's state could
+  be affected (not just iterators) — worth a broader test sweep once a
+  fix is scoped, not something to guess-patch under time pressure.
+
+## Acceptance criteria (for whoever picks this up)
+
+- [ ] `range.makeIter().next()` (the minimal repro above) returns `42`.
+- [ ] The original `Symbol.iterator` repro matches V8: `"1,2,3"` / `6`.
+- [ ] `private-fields/05-brand-checks.js`... n/a (unrelated); re-run the
+      #3690 differential corpus and confirm `builtins/19-symbol-iterator.js`
+      now matches.
+- [ ] Identify and document why `compileObjectLiteralForStruct` runs twice
+      for this shape, and whether that's by design (then the fix is in
+      state isolation) or a separate bug (then fix the double-compile
+      itself).


### PR DESCRIPTION
## Description

**No code fix in this PR** — investigation only, updating #3713's issue file with a much deeper, precise root cause than its original filing. Opening it as a PR (rather than pushing straight to the issue file on `main`) so it goes through the same review/CI path as the other #3690-derived fixes.

Started by tracing the original repro (`[Symbol.iterator]()` on a plain object literal) at the runtime boundary. That ruled out the original hypothesis — `__iterator`'s host import genuinely does receive the real object (just displayed oddly by Node's console for opaque WasmGC structs) and `__call_@@iterator` correctly invokes the method. Manually driving the iterator-result chain narrowed the actual defect to a single field read returning `0` instead of the correct value.

Bisecting away every iterator-specific detail found the real trigger has **nothing to do with `Symbol.iterator` or iterators**: an object-literal method returning a *nested* object-literal method (not an arrow function) that closes over the outer method's local reads `0` instead of the captured value. Standalone functions and nested arrow functions in the same position both work fine.

Root-caused precisely via instrumented tracing (`console.error` at the capture-promotion call site, comparing emitted-instruction counts before/after): `compileObjectLiteralForStruct` (`src/codegen/literals.ts`) compiles the same object literal **twice** in this shape. The first pass correctly promotes the captured local to a module global and emits the value-copy instruction. The second pass finds `ctx.capturedGlobals` already has the entry (leftover from the first pass — never reset) and skips re-emitting the copy via its own "already promoted, don't double-register" guard. Whichever compiled function ships is missing the copy, so the promoted global keeps its bare default init (`0`) forever.

**Why not fixed here**: the trigger for the double-compile is still unidentified (ruled out the struct's placeholder-method pre-registration pass in `src/codegen/index.ts`). A correct fix needs to distinguish "already promoted for THIS compiled function" from "already promoted for a different invocation of the same literal" — without breaking the intentional per-literal-fork state sharing the `#1557` mechanism in the same file already relies on. Genuinely architectural, not a local patch, and the blast radius (any nested object-literal-method closure, not just iterators) is worth a broader sweep once a fix is scoped.

Full investigation trail, minimal repro, and bisection table are in the issue file.

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdciSGoMA9bs8AWhQ1tyPh)_