### PR TITLE
docs(#3720,#3721): file 2 compiler bugs found probing 3 more real npm packages

### DIFF
--- a/plan/issues/3720-mustache-late-import-index-shift-iswhitespace.md
+++ b/plan/issues/3720-mustache-late-import-index-shift-iswhitespace.md
@@ -1,0 +1,114 @@
+---
+id: 3720
+title: "Late-import index-shift crash compiling mustache@4.2.0's isWhitespace (RegExp.prototype.test.call indirection) — new #2043-class occurrence"
+status: ready
+sprint: current
+created: 2026-07-27
+updated: 2026-07-27
+priority: medium
+horizon: m
+feasibility: hard
+reasoning_effort: medium
+task_type: bugfix
+area: codegen, emit
+language_feature: compiler-internals
+goal: core-semantics
+origin: "ad-hoc probe of 3 more single-bundled-file npm packages (dayjs/mustache/diff), same shape as the acorn/marked dogfood pattern"
+related: [2043, 1710, 3716]
+---
+
+# #3720 — mustache compile crash: late-import index-shift in `isWhitespace`
+
+## Repro
+
+Pin: `mustache@4.2.0`, entry `mustache.js` (single self-contained UMD
+bundle, zero runtime deps, 772 lines — same "single pre-bundled dist file"
+shape as acorn/marked).
+
+```bash
+npm pack mustache@4.2.0
+tar -xzf mustache-4.2.0.tgz
+```
+
+```ts
+import { compile } from "./src/index.js";
+import { readFileSync } from "node:fs";
+const src = readFileSync("package/mustache.js", "utf-8");
+const result = await compile(src, { fileName: "mustache.js", skipSemanticDiagnostics: true });
+```
+
+Throws (does not return `success: false` — the emit step itself throws):
+
+```
+Binary emit error: RangeError: Codegen error: local index out of range — 3
+(valid: [0, 2)) at function 'isWhitespace'. This is the late-import
+index-shift class (#2043): a captured index went stale across a deferred
+flushLateImportShifts/addUnionImports/addStringImports shift, or a map
+lookup failed and baked -1/undefined. Re-resolve the index by name AFTER
+the last shift, or make the producer refuse loudly.
+```
+
+Stack: `emitBinaryWithSourceMapUnguarded` → `emitBinary` → `runPipeline` →
+`compileSourceSync` (`src/compiler.ts:1452`).
+
+## Offending source (mustache.js:61-64)
+
+```js
+var regExpTest = RegExp.prototype.test;
+function testRegExp (re, string) {
+  return regExpTest.call(re, string);
+}
+
+var nonSpaceRe = /\S/;
+function isWhitespace (string) {
+  return !testRegExp(nonSpaceRe, string);
+}
+```
+
+`isWhitespace` calls `testRegExp`, which invokes `RegExp.prototype.test`
+indirectly via `.call()` (a module-level `var` capturing the unbound
+method) rather than `re.test(string)` directly. That indirection is likely
+what triggers a late-added import (regex test intrinsic, or a `.call`
+dispatch helper) whose function index gets captured before a later
+shift (`addUnionImports`/`addStringImports`/`flushLateImportShifts`) moves
+it, and nothing re-resolves it by name afterward — exactly the failure
+mode #2043's own emit-time validation was built to catch loudly instead of
+silently emitting corrupt Wasm (see `CLAUDE.md` "addUnionImports": late
+import addition shifts function indices, and `ctx.currentFunc.body` must
+also be shifted).
+
+## Relationship to #2043
+
+**#2043 is `status: done`** — it added the always-on emit-time index
+validation that makes this failure LOUD (a clear `RangeError` naming the
+function and the bug class) instead of silently producing an invalid
+binary. It did not, and could not, retroactively fix every future producer
+that captures a stale index — this is a **new occurrence of the bug
+class** in a producer #2043 didn't touch, caught live by real-world code
+(mustache) exercising an indirect-`.call()`-through-a-captured-unbound-
+method pattern that the existing equivalence/test262 suites apparently
+don't cover.
+
+## Scope
+
+- [ ] Identify which specific late import (or emitter/temp-local
+      allocation) inside the codegen path for `isWhitespace`
+      (`RegExp.prototype.test.call(re, string)` pattern) captures a
+      pre-shift index.
+- [ ] Fix the producer to re-resolve by name after the last shift, per
+      #2043's own prescribed remedy, rather than caching the raw index
+      across a shift boundary.
+- [ ] Minimal repro reduced from the above (a standalone `.ts`/`.js` file
+      with just the `testRegExp`/`isWhitespace` pattern) for a fast
+      regression test.
+- [ ] Re-run mustache compile — expect `compile.success: true` (or a clean
+      `success: false` with real diagnostics, not a thrown `RangeError`).
+
+## Acceptance criteria
+
+- [ ] Minimal repro (isolated `.call()`-indirection-through-captured-
+      unbound-prototype-method pattern) compiles without throwing.
+- [ ] mustache@4.2.0's `mustache.js` compiles (`compile()` does not throw;
+      `success` is `true` or a clean diagnostic-only failure).
+- [ ] No regression in existing #2043-related pins
+      (`tests/issue-2043-*.test.ts` if present, or equivalent).

--- a/plan/issues/3721-diff-package-false-ts-syntax-errors.md
+++ b/plan/issues/3721-diff-package-false-ts-syntax-errors.md
@@ -1,0 +1,127 @@
+---
+id: 3721
+title: "diff@9.0.0's dist/diff.js rejected with TS8010/8017 'can only be used in TypeScript files' — false positive, real tsc reports zero errors on the same file"
+status: ready
+sprint: current
+created: 2026-07-27
+updated: 2026-07-27
+priority: medium
+horizon: m
+feasibility: hard
+reasoning_effort: medium
+task_type: bugfix
+area: checker
+language_feature: n/a
+goal: core-semantics
+origin: "ad-hoc probe of 3 more single-bundled-file npm packages (dayjs/mustache/diff), same shape as the acorn/marked dogfood pattern"
+related: [3717, 1710, 3716]
+---
+
+# #3721 — diff@9.0.0 false-positive TS syntax errors
+
+## Repro
+
+Pin: `diff@9.0.0`, entry `dist/diff.js` (self-contained UMD bundle, 2313
+lines, zero `require()` calls — same "single pre-bundled dist file" shape
+as acorn/marked; note the package's own `main`/`module` fields point at a
+multi-file `libcjs`/`libesm` source tree, but `dist/diff.js` is the
+pre-rolled bundle, same relationship as acorn's `dist/acorn.mjs`).
+
+```bash
+npm pack diff@9.0.0
+tar -xzf diff-9.0.0.tgz
+```
+
+```ts
+import { compile } from "./src/index.js";
+import { readFileSync } from "node:fs";
+const src = readFileSync("package/dist/diff.js", "utf-8");
+const result = await compile(src, { fileName: "diff.js", skipSemanticDiagnostics: true });
+// result.success === false, result.binary.length === 0
+// result.errors:
+//   TS8017 "Signature declarations can only be used in TypeScript files." @ line 1, col 1
+//   TS8010 "Type annotations can only be used in TypeScript files."       @ line 1, col 1  (x3)
+```
+
+All 4 diagnostics report `line: 1, column: 1` — a suspicious uniform
+position that looks like a fallback/default rather than a real located
+error.
+
+## This is confirmed a FALSE POSITIVE, not real content
+
+Ran the exact same file through real `tsc` directly (not js2wasm),
+matching js2wasm's own `allowJs` handling:
+
+```bash
+npx tsc --noEmit --allowJs --checkJs false --target es2022 --lib es2022 package/dist/diff.js
+```
+
+Zero errors on the file itself (only unrelated `@types/node` ambient-lib
+resolution noise, nothing referencing `diff.js`). Also grepped the file
+directly for any construct that could produce TS8010/8017 (parameter type
+annotations `(x: T)`, `interface`, `declare`, `readonly`, generic
+`function<T>`, ambient overload signatures ending in `;` with no body) —
+**none found**. The file is plain ES2015+ JS (UMD wrapper, `class`
+syntax), nothing TS-only.
+
+## What's been ruled out as the cause
+
+js2wasm has a known mechanism where a synthesized **TS source prelude**
+(`injectProcessStdinPrelude` / `injectIteratorStaticsPrelude`,
+`src/compiler.ts` around line 1287, `#2752`) gets prepended ahead of a
+`.js`-named user file and the combined unit must be parsed under
+`ts.ScriptKind.TS` (`forceTsGrammar`) or the prelude's own TS syntax gets
+rejected with these exact same codes (8010/8017) — that was the leading
+hypothesis. Traced both injectors' trigger conditions
+(`src/process-stdin-prelude.ts:179-189`,
+`src/iterator-statics-prelude.ts:162-182`):
+
+- `injectProcessStdinPrelude` requires both literal substrings `"process"`
+  and `"stdin"` present. `diff.js` contains `"process"` (in comments/an
+  identifier, e.g. `processIndex`) but **never** `"stdin"` — the cheap
+  pre-check short-circuits, `injected: false`.
+- `injectIteratorStaticsPrelude` requires the literal substring
+  `"Iterator"` (present — once, in a comment: `dist/diff.js:1516` "Iterator
+  that traverses...") AND one of `HELPERS = ["zip", "zipKeyed", "concat",
+  "from"]` (near-certainly present somewhere in a 111 KB bundle — "concat"
+  and "from" are common). This passes the cheap pre-check, but the
+  injector then does a real AST walk (`findIteratorHelperAccesses`)
+  looking for actual `Iterator.<helper>` property-access expressions —
+  diff.js has no real `Iterator.zip`/`.from`/etc. call sites (only the
+  unrelated comment), so `accesses.length === 0` and it should correctly
+  return `injected: false`.
+
+Both injectors *appear* to correctly no-op for this file based on reading
+their trigger logic — **not independently confirmed at runtime** (no
+instrumentation/breakpoint was added to verify `forceTsGrammar` is
+actually `false` for this compile). That verification step, plus checking
+whether some OTHER code path (a diagnostic-collection pass distinct from
+the main emit path — e.g. a `analyzeSource`/checker-layer parse that
+doesn't thread the same `forceTsGrammar` decision made in
+`compiler.ts:1293`) is where the mismatch actually happens, is the
+concrete next step.
+
+## Scope
+
+- [ ] Instrument/trace the actual `compile()` call for this file to
+      confirm whether `forceTsGrammar` and the resulting `scriptKind` are
+      what's expected (`false` / `ts.ScriptKind.JS`) at every parse site
+      that runs for a single-source compile — not just the main emit path.
+- [ ] If `forceTsGrammar` is correctly `false` throughout: find what other
+      mechanism is misclassifying real JS syntax in this file as TS-only
+      (the uniform `line:1,col:1` position across all 4 diagnostics is a
+      strong clue — likely a diagnostic-position-mapping bug, possibly
+      related to `PositionMap` used by the prelude-injection system even
+      when no prelude was actually inserted).
+- [ ] Minimal repro reduced from the 2313-line bundle (bisect which
+      specific construct near the file's `class Diff { diff(...) {`
+      opening, or elsewhere, trips this) — not yet attempted here.
+- [ ] Re-run — expect `compile.success: true` (or a legitimate diagnostic
+      unrelated to TS-syntax-in-JS-file).
+
+## Acceptance criteria
+
+- [ ] Root cause identified with a minimal (non-111KB) repro.
+- [ ] `diff@9.0.0`'s `dist/diff.js` compiles without the false TS8010/8017
+      diagnostics.
+- [ ] A regression test pins the minimal repro.


### PR DESCRIPTION
## Description

Ad-hoc survey of 3 more single-bundled-file, zero-runtime-dep npm packages — same shape as the acorn/marked dogfood pattern (`tests/dogfood/`) — to see what currently compiles beyond the two committed harnesses. Not a new committed harness itself, just a probe + findings write-up (mirrors how #3715 was filed from the marked investigation).

| package | shape | result |
|---|---|---|
| **dayjs@1.11.21** (`dayjs.min.js`) | date library, minified single bundle, zero deps | ✅ compiles, validates, instantiates clean |
| **mustache@4.2.0** (`mustache.js`) | templating engine, single UMD bundle, zero deps | ❌ crashes at emit — filed **#3720** |
| **diff@9.0.0** (`dist/diff.js`) | text-diff library, single UMD bundle, zero deps | ❌ false-positive rejection — filed **#3721** |

### #3720 — mustache: late-import index-shift crash

A new occurrence of the `#2043` (done) late-import index-shift bug class, triggered by `isWhitespace`'s indirect `RegExp.prototype.test.call(re, string)` pattern:

```
Codegen error: local index out of range — 3 (valid: [0, 2)) at function 'isWhitespace'.
This is the late-import index-shift class (#2043)...
```

`#2043` made this fail loudly instead of silently corrupting the binary — it caught this correctly, but the underlying producer bug in this specific code shape was never fixed. Root cause not found here (no fix in this PR); filed with full repro for whoever picks it up.

### #3721 — diff.js: false-positive TS syntax errors

Rejected with `TS8010`/`TS8017` "Type annotations/Signature declarations can only be used in TypeScript files" — confirmed a genuine false positive: real `tsc` reports **zero** errors on the identical file. Traced and ruled out the known TS-source-prelude-injection mechanism (#2752) as the cause by checking both injectors' trigger conditions against the actual file content. Root cause still open; documented what's ruled out so the next investigation doesn't redo that work.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdciSGoMA9bs8AWhQ1tyPh)_