### PR TITLE
fix(#3722): await-as-label check false-positives on ternary await branches

### DIFF
--- a/plan/issues/3722-await-ternary-label-false-positive.md
+++ b/plan/issues/3722-await-ternary-label-false-positive.md
@@ -16,6 +16,11 @@ language_feature: async-await
 goal: core-semantics
 origin: "found re-testing marked (#3715/#3716) with skipSemanticDiagnostics to see if it unblocks the same way #3717 unblocked acorn"
 related: [3715, 3716, 3717, 1068]
+loc-budget-allow:
+  # The isInTernary guard mirrors the existing yield-as-label check +10 LOC
+  # to src/compiler/early-errors/node-checks.ts's baseline (1866 -> 1876).
+  # Same file, same kind of grant as #3714's brand-check fix.
+  - src/compiler/early-errors/node-checks.ts
 ---
 
 # #3722 — `cond ? await x() : y` false-flagged as `await:` label

--- a/plan/issues/3722-await-ternary-label-false-positive.md
+++ b/plan/issues/3722-await-ternary-label-false-positive.md
@@ -21,6 +21,10 @@ loc-budget-allow:
   # to src/compiler/early-errors/node-checks.ts's baseline (1866 -> 1876).
   # Same file, same kind of grant as #3714's brand-check fix.
   - src/compiler/early-errors/node-checks.ts
+func-budget-allow:
+  # Same +10 LOC lands inside runNodeChecks itself (1785 -> 1795) since the
+  # await-as-label check is one branch inside that single dispatch function.
+  - src/compiler/early-errors/node-checks.ts::runNodeChecks
 ---
 
 # #3722 — `cond ? await x() : y` false-flagged as `await:` label

--- a/plan/issues/3722-await-ternary-label-false-positive.md
+++ b/plan/issues/3722-await-ternary-label-false-positive.md
@@ -1,0 +1,88 @@
+---
+id: 3722
+title: "Fix: await-as-label early-error false positive on `cond ? await x() : y` ternaries"
+status: done
+sprint: current
+created: 2026-07-27
+updated: 2026-07-27
+completed: 2026-07-27
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: checker
+language_feature: async-await
+goal: core-semantics
+origin: "found re-testing marked (#3715/#3716) with skipSemanticDiagnostics to see if it unblocks the same way #3717 unblocked acorn"
+related: [3715, 3716, 3717, 1068]
+---
+
+# #3722 — `cond ? await x() : y` false-flagged as `await:` label
+
+## How this was found
+
+Re-tested `marked@18.0.2` after #3717 (acorn's `skipSemanticDiagnostics`
+fix). Marked is still blocked by #3715 (evolving array types) under normal
+compilation, but compiling with `skipSemanticDiagnostics: true` (to see if
+it would unblock the same way it did for acorn) surfaced a DIFFERENT,
+real, previously-invisible bug: 5 diagnostics, all
+`'await' is not allowed as a label identifier in this context`, all
+pointing at the same construct.
+
+## Root cause
+
+`src/compiler/early-errors/node-checks.ts` — the await-as-label check
+(originally added for #1068, which correctly allows `await:` as a real
+label in *non*-async functions) flags any `AwaitExpression` immediately
+followed by `:` while inside an async function, **without excluding the
+case where that colon is a ternary's separator**, not a label colon:
+
+```js
+i.hooks ? await i.hooks.preprocess(n) : n
+//                                    ^ this colon — misread as a label colon
+```
+
+The sibling check for `yield` (same file, ~200 lines below) already has
+exactly this exclusion (`isInTernary`, checking whether the node's parent
+is a `ConditionalExpression`) — it was added there but never backported to
+`await`'s copy of the same check. A clear copy-paste divergence.
+
+Confirmed with exact source positions from marked's bundle — all 5 hits
+are `cond ? await obj.method(...) : fallback` shapes (e.g. `lib/marked.esm.js`
+line 75: `i.hooks?await i.hooks.preprocess(n):n`, `...await i.hooks.provideLexer(e):e?x.lex:x.lexInline`, etc.), each a legitimate async/sync
+dual-path pattern.
+
+## Fix
+
+Mirror the `yield` check's `isInTernary` guard onto the `await` check
+(`src/compiler/early-errors/node-checks.ts`, the "Also check await: label
+pattern" block): don't flag if the `AwaitExpression`'s parent (or
+grandparent through one layer of parens) is a `ConditionalExpression`.
+
+## Verification
+
+- New test `tests/issue-3722-await-ternary-label-false-positive.test.ts`
+  (4 cases): ternary-with-await true/false branches execute correctly, a
+  member/call-chain shape (closer to marked's real code) compiles, and a
+  genuine `await:` label inside an async function (no ternary) is still
+  correctly rejected as an error.
+- Re-ran `mustache`-adjacent (`tests/issue-1068.test.ts`,
+  `tests/labeled-loops.test.ts`, `tests/issue-2877.test.ts`) — no
+  regressions; pre-existing failures in `issue-2877`/`labeled-loops`
+  confirmed identical with the fix stashed out (unrelated: an IR
+  `SyntaxError` class gap and a `string_constants` import-wiring
+  environment issue, respectively).
+- Does **not** unblock marked's normal (non-`skipSemanticDiagnostics`)
+  compile — #3715 (evolving array types) still gates it earlier in the
+  pipeline. This fix only becomes externally visible once #3715 lands (or
+  when `skipSemanticDiagnostics: true` is used), but is a real, standalone
+  bug independent of that.
+
+## Acceptance criteria
+
+- [x] `cond ? await x() : y` inside an async function compiles and runs
+      correctly for both branches.
+- [x] A genuine `await:` label (no ternary) inside an async function is
+      still rejected.
+- [x] No regressions in existing await/yield/label test suites.

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -1361,12 +1361,22 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
         ctx.addError(node, "'await' is not allowed as an identifier in this context");
       }
     }
-    // Also check await: label pattern (TS parses await: as AwaitExpression + colon)
+    // Also check await: label pattern (TS parses await: as AwaitExpression + colon).
+    // Don't flag if the await is inside a ConditionalExpression (ternary ? await x : y)
+    // — the trailing colon there is the ternary's, not a label colon (mirrors the
+    // identical yield-as-label guard below).
     if (isInsideAsyncFunction(node) || isInsideClassStaticBlock(node)) {
       const endPos = node.end;
       const afterText = ctx.sourceFile.text.substring(endPos, endPos + 5).trimStart();
       if (afterText.startsWith(":")) {
-        ctx.addError(node, "'await' is not allowed as a label identifier in this context");
+        const isInTernary =
+          node.parent &&
+          (ts.isConditionalExpression(node.parent) ||
+            // Also check grandparent for nested parens: (await x) ? await y : await z
+            (ts.isParenthesizedExpression(node.parent) && ts.isConditionalExpression(node.parent.parent)));
+        if (!isInTernary) {
+          ctx.addError(node, "'await' is not allowed as a label identifier in this context");
+        }
       }
     }
     // ES spec: ClassStaticBlockBody: "It is a Syntax Error if ContainsAwait

--- a/tests/issue-3722-await-ternary-label-false-positive.test.ts
+++ b/tests/issue-3722-await-ternary-label-false-positive.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #3722 — the await-as-label early-error check (src/compiler/early-errors/
+// node-checks.ts) flagged ANY AwaitExpression immediately followed by `:` as
+// an invalid label, without excluding the case where that `:` is a ternary's
+// separator (`cond ? await expr : else`) rather than a label colon. The
+// sibling yield-as-label check already carried this exact exclusion; await's
+// check was missing it. Found compiling marked@18.0.2's bundled
+// marked.esm.js, which uses this pattern for its async/sync dual code path
+// (e.g. `i.hooks ? await i.hooks.preprocess(n) : n`).
+
+async function instantiate(src: string): Promise<Record<string, (...a: unknown[]) => unknown>> {
+  const result = await compile(src);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;
+  if (imports.setExports) imports.setExports(exports as Record<string, Function>);
+  return exports;
+}
+
+describe("#3722 — await in a ternary's consequent branch is not a label", () => {
+  it("`cond ? await x() : y` compiles and runs (true branch)", async () => {
+    const exports = await instantiate(`
+      async function fetchIt(): Promise<number> { return 7; }
+      export async function pick(useAsync: boolean): Promise<number> {
+        return useAsync ? await fetchIt() : 3;
+      }
+    `);
+    expect(exports.pick(1)).toBe(7);
+  });
+
+  it("`cond ? await x() : y` compiles and runs (false branch)", async () => {
+    const exports = await instantiate(`
+      async function fetchIt(): Promise<number> { return 7; }
+      export async function pick(useAsync: boolean): Promise<number> {
+        return useAsync ? await fetchIt() : 3;
+      }
+    `);
+    expect(exports.pick(0)).toBe(3);
+  });
+
+  it("a member/call expression after await inside a ternary compiles", async () => {
+    const result = await compile(`
+      async function fetchIt(n: number): Promise<number> { return n + 1; }
+      const hooks = { preprocess: fetchIt };
+      export async function run(useHooks: boolean, n: number): Promise<number> {
+        return useHooks ? await hooks.preprocess(n) : n;
+      }
+    `);
+    expect(
+      result.success,
+      `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+    ).toBe(true);
+  });
+
+  it("a genuine await-as-label (no ternary) is still a real error", async () => {
+    const result = await compile(`
+      export async function foo(): Promise<number> {
+        await: for (let i = 0; i < 1; i++) {}
+        return 1;
+      }
+    `);
+    expect(result.success).toBe(false);
+    expect(result.errors.some((e) => /await.*not allowed/i.test(e.message))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

`cond ? await x() : y` inside an async function was misread as an `await:` label — the ternary's own colon mistaken for a label colon:

```
'await' is not allowed as a label identifier in this context
```

Root cause: `src/compiler/early-errors/node-checks.ts`'s await-as-label check (added for #1068, which correctly allows `await:` as a real label in *non*-async functions) flags any `AwaitExpression` immediately followed by `:` while inside an async function, without excluding the case where that colon is a ternary's separator rather than a label colon. The sibling check for `yield` (same file, ~200 lines below) already has exactly this exclusion (`isInTernary`, checking whether the node's parent is a `ConditionalExpression`) — it was never backported to `await`'s copy of the same check. A clear copy-paste divergence.

**Found by**: re-testing `marked@18.0.2` (#3715/#3716) with `skipSemanticDiagnostics: true` to see if it would unblock the same way that flag unblocked acorn (#3717). It surfaced this distinct bug instead — 5 hits, all `cond ? await obj.method(...) : fallback` shapes in marked's real async/sync dual-path code (e.g. `i.hooks ? await i.hooks.preprocess(n) : n`).

### Fix

Mirror the `yield` check's `isInTernary` guard onto the `await` check.

### Scope note

This does **not** itself unblock marked's normal compile — #3715 (evolving array types, still open/unfixed) gates it earlier in the pipeline. This is a real, independent, verified bug regardless, and will matter once #3715 lands (or for any other real-world code hitting this shape).

## Verification

- New test `tests/issue-3722-await-ternary-label-false-positive.test.ts` (4 cases): ternary-with-await true/false branches execute correctly, a member/call-chain shape (closer to marked's real code) compiles, and a genuine `await:` label inside an async function (no ternary) is still correctly rejected as an error.
- Re-ran `tests/issue-1068.test.ts`, `tests/labeled-loops.test.ts`, `tests/issue-2877.test.ts` — no regressions; the two pre-existing failures in the latter two (unrelated: an IR `SyntaxError` class gap, and a `string_constants` import-wiring environment issue) confirmed identical with the fix stashed out.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdciSGoMA9bs8AWhQ1tyPh)_