### PR TITLE
fix(ci #1216): let allow_performance_regressions unstick the auto-commit too

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -184,11 +184,19 @@ jobs:
       # GH013 the way a GITHUB_TOKEN push is.
       #
       # Guards (same intent as the original #1216 design):
-      #   - Only on `push: main` (not pull_request, not workflow_dispatch).
-      #     The actor check excludes the bot itself to avoid commit loops.
+      #   - `push: main` (not pull_request). The actor check excludes the
+      #     bot itself to avoid commit loops.
       #   - Skip if the benchmark diff reported regressions — promoting
       #     "regressed" numbers would mask real perf regressions instead
-      #     of catching them.
+      #     of catching them. `workflow_dispatch` with
+      #     `allow_performance_regressions: true` is the one-time manual
+      #     override for the case where the guard itself is what's stuck
+      #     (a stale committed baseline makes every push look regressed,
+      #     so the auto-commit can never fire to refresh it — see the
+      #     2026-07-27 incident where 5 days of drift made every push
+      #     trip the diff). Same override input the hard-fail step already
+      #     used on `workflow_dispatch`; this just extends it to also
+      #     unblock the auto-commit.
       #   - Defer (exit 0, no error) while the merge queue is non-empty —
       #     any push to main, even `[skip ci]`, makes GitHub rebuild every
       #     queued merge group (see #1951, the same reasoning
@@ -201,10 +209,12 @@ jobs:
       #     retriggering the workflow.
       - name: Auto-commit refreshed baseline (#1216)
         if: |
-          github.event_name == 'push' &&
           github.ref == 'refs/heads/main' &&
           github.actor != 'github-actions[bot]' &&
-          steps.benchmark_diff.outputs.regressions != 'true'
+          (
+            (github.event_name == 'push' && steps.benchmark_diff.outputs.regressions != 'true') ||
+            (github.event_name == 'workflow_dispatch' && inputs.allow_performance_regressions)
+          )
         env:
           MAIN_DEPLOY_KEY: ${{ secrets.MAIN_DEPLOY_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Follow-up to #3700. That PR fixed the mechanical problem (GH013-blocked push), but every push to `main` since it merged has correctly **skipped** the auto-commit anyway: the benchmark diff reports a regression against the 5-day-stale committed baseline.

Confirmed via two CI runs 3.5 hours apart (20:14 and 23:52 UTC), numbers nearly identical both times — not noise:

| benchmark | committed baseline (2026-07-24) | current main | delta |
|---|---|---|---|
| `loop.ts` | wasm 311µs | wasm ~12,800µs | ~41x slower |
| `array.ts` | wasm 22µs | wasm ~79µs | ~3.5x slower |
| `fib.ts` | ratio 2.11x | ratio 2.48x | +17% (improved) |

That's a real, separate perf question worth investigating on its own (tracking issue to follow) — but it also exposes a bootstrap problem in the auto-commit guard: once the baseline is stale enough, *every* future push looks "regressed" relative to it, so the skip-on-regression guard can never let a first catch-up commit through to re-anchor the baseline. It's stuck skipping itself forever.

This PR extends the existing `workflow_dispatch` `allow_performance_regressions` input (already used to override the hard-fail step on manual dispatch) to also let the auto-commit step fire, so a maintainer can force one manual baseline refresh via `workflow_dispatch` to unfreeze the landing page immediately, independent of investigating the regression itself.

Scope is limited to `.github/workflows/benchmark-refresh.yml`; no application/compiler source changed.

## CLA

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — CLA check is skipped automatically per repo policy. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_