### PR TITLE
fix: wire fillArrayToPrimitive/fillClassToPrimitive into generateMultiModule

### DIFF
--- a/plan/issues/3731-generatemultimodule-missing-fill-drivers.md
+++ b/plan/issues/3731-generatemultimodule-missing-fill-drivers.md
@@ -1,0 +1,147 @@
+---
+id: 3731
+title: "generateMultiModule is missing ~19 fill*() driver calls that generateModule has (unreachable-trap risk)"
+status: ready
+sprint: Backlog
+created: 2026-07-28
+updated: 2026-07-28
+priority: high
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: compiler-internals
+goal: crash-free
+depends_on: []
+related: [3707]
+loc-budget-allow:
+  - src/codegen/index.ts
+---
+# #3731 — `generateMultiModule` is missing ~19 `fill*()` driver calls that `generateModule` has
+
+## Context
+
+Follow-up to #3707. That PR fixed a test262 pass-rate freeze caused by
+`TypedArray.prototype.set(arr, offset)` crashing with an uncatchable
+`unreachable` trap in standalone multi-file compiles, whenever `offset` needed
+`ToNumber` via `valueOf`/`toString`/array-`join(",")` on a plain object or
+array.
+
+Root cause: the compiler has two module-generation entry points in
+`src/codegen/index.ts`:
+
+- `generateModule` — the single-source-string path (`compile()`).
+- `generateMultiModule` — the multi-file path (`compileMulti()`,
+  `compileFiles()` — used whenever real files are compiled from disk, e.g.
+  test262's harness-include files bundled with a test, or any project with
+  imports).
+
+Both use the same "reserve a placeholder function now (body: `unreachable`),
+patch its real body in post-processing once its dependencies are registered"
+pattern for a large family of standalone-only runtime features. `generateModule`
+calls the corresponding `fill*(ctx)` post-processing step for every one of
+these reserved drivers. `generateMultiModule` was built later and only ever
+picked up a subset — so for the missing ones, the driver's `unreachable` stub
+body is **never patched**, and any compile that actually reaches it crashes the
+whole module instead of running.
+
+#3707 fixed the two drivers that were actually blocking test262
+(`fillArrayToPrimitive` / `fillClassToPrimitive`, backing `__to_primitive`'s
+array/class-instance arms). This issue tracks the **rest** of the gap, found by
+diffing every `fill*(ctx)` call between the two functions in
+`src/codegen/index.ts`.
+
+## Confirmed missing from `generateMultiModule` (present in `generateModule`)
+
+```
+fillNativeIteratorLateArms
+fillIterHofSteppers
+fillLazyIterLadderArms
+fillCombinatorToVec
+fillHostFnctorMethodDrivers
+fillProtoIteratorDriver
+fillAccessorDrivers
+fillDisposableStackDisposeDriver
+fillBindDynHelper
+fillProxyDispatch
+fillPromiseThenableHelpers
+fillSetRecFieldGetters
+fillExternIsArray
+fillExternSetVecArms
+fillExternArrayLikeStructArms
+fillDynamicForinVecArms
+fillBuiltinFnMeta
+fillExternGetErrorProps
+fillDynamicProtoHelpers
+```
+
+(`fillArrayToPrimitive` and `fillClassToPrimitive` are no longer on this list —
+landed in #3707.)
+
+Reproduce the diff yourself against current `main`:
+
+```bash
+awk 'NR>=2918 && NR<=4072 && /fill[A-Za-z]+\(ctx/' src/codegen/index.ts | sed 's/^ *//' | sort -u > /tmp/single.txt
+awk '/^export function generateMultiModule/{p=NR} p && NR<=p+560 && /fill[A-Za-z]+\(ctx/' src/codegen/index.ts | sed 's/^ *//' | sort -u > /tmp/multi.txt
+comm -23 /tmp/single.txt /tmp/multi.txt   # in generateModule, missing from generateMultiModule
+```
+
+(Line ranges are approximate — re-locate `generateModule`/`generateMultiModule`
+function bounds on the current tree; both functions have grown since.)
+
+## Why this matters
+
+Each of these backs a standalone-only feature (native iterators, `Array`
+higher-order-function steppers, lazy iterator combinators, promise
+combinators/thenables, host-fnctor method drivers, prototype iterator
+override, live accessor get/set, `Symbol.dispose`, `Function.prototype.bind`,
+`Proxy` trap dispatch, ES2025 collection field getters, `Array.isArray`,
+vec `Array.prototype.set`, array-like closed-struct arms, for-in over a
+runtime array, builtin-fn reflective metadata, `Error` property reads,
+dynamic-prototype reads). Any of these reached through a **multi-file**
+standalone compile (test262 harness-bundled test, any real multi-file
+project) risks the exact same failure mode as #3707: a silent `unreachable`
+crash instead of correct behavior, invisible until something happens to
+exercise that exact path — which is exactly how #3707's bug went unnoticed
+until now.
+
+## Suggested approach
+
+Rather than porting each `fill*` call individually (drift-prone — the two
+functions will diverge again the next time someone adds a new driver to only
+one of them), consider extracting the shared finalize sequence (roughly
+`src/codegen/index.ts` lines ~3700–4072 in `generateModule`, everything after
+body-compilation and before `eliminateDeadImportsAndPlanAbiCallables`) into a
+single `runStandaloneFinalizePasses(ctx)` helper called by **both**
+`generateModule` and `generateMultiModule` at the analogous point in each
+pipeline. That closes this entire bug class at once instead of one driver at
+a time, and prevents recurrence.
+
+If a shared-helper refactor is judged too risky for one PR, the incremental
+fallback is: for each missing `fill*`, write a `compileMulti` + `target:
+standalone` regression test that exercises it (mirroring
+`tests/standalone-multimodule-to-primitive-fills.test.ts` from #3707), add the
+missing call at the matching relative position in `generateMultiModule`,
+verify the test traps before / passes after, ship in small batches.
+
+## Acceptance criteria
+
+- [ ] Every `fill*(ctx)` call present in `generateModule` has a corresponding
+      call in `generateMultiModule` (or a documented reason it's single-file-only).
+- [ ] A regression test per newly-wired driver (or one comprehensive test suite
+      covering the feature set), each proven to trap without the fix.
+- [ ] No regressions in the existing `compileMulti`/standalone test slice
+      (see #3707 for a starting list of relevant files).
+- [ ] Ideally: the shared-finalize-helper refactor above, so this can't silently
+      drift again.
+
+## Out of scope
+
+- Any bug found where `generateModule` itself (single-file path) is missing
+  something `generateMultiModule` has — not observed, but not audited for
+  either; file separately if found.
+- The pre-existing, unrelated `Int16Array`/`Uint16Array` standalone
+  multi-file "invalid module" bug noted in #3707 (a `array.set[2] expected
+  type i32, found array.get of type f64` WebAssembly validation failure) —
+  reproduces identically with and without #3707's fix; needs its own issue.

--- a/plan/issues/3731-generatemultimodule-missing-fill-drivers.md
+++ b/plan/issues/3731-generatemultimodule-missing-fill-drivers.md
@@ -17,6 +17,8 @@ depends_on: []
 related: [3707]
 loc-budget-allow:
   - src/codegen/index.ts
+func-budget-allow:
+  - src/codegen/index.ts::generateMultiModule
 ---
 # #3731 — `generateMultiModule` is missing ~19 `fill*()` driver calls that `generateModule` has
 

--- a/plan/issues/3732-int16-uint16-standalone-multi-invalid-module.md
+++ b/plan/issues/3732-int16-uint16-standalone-multi-invalid-module.md
@@ -1,0 +1,77 @@
+---
+id: 3732
+title: "Int16Array/Uint16Array standalone multi-file compile emits an invalid Wasm module"
+status: ready
+sprint: Backlog
+created: 2026-07-28
+updated: 2026-07-28
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: typed-arrays
+goal: crash-free
+depends_on: []
+related: [3707, 3731]
+---
+# #3732 — `Int16Array`/`Uint16Array` standalone multi-file compile emits an invalid Wasm module
+
+## Context
+
+Found while verifying #3707's fix across TypedArray constructor types.
+Independent of #3707/#3731 — reproduces identically with and without that
+fix, and is not a trap (it fails `WebAssembly.Module()` validation, i.e. the
+compiler emitted structurally invalid bytecode).
+
+## Repro
+
+```ts
+export function run(): i32 {
+  var sample = new Int16Array([1, 2]);
+  sample.set([42], "");
+  return sample[0] * 100 + sample[1];
+}
+```
+
+Compiled via `compileFiles(path, { skipSemanticDiagnostics: true, target:
+"standalone" })` (or any other path that reaches `generateMultiModule` —
+`compileMulti`/`compileFiles`). The compile itself reports `success: true`
+and returns bytes, but `new WebAssembly.Module(result.binary)` throws:
+
+```
+WebAssembly.Module(): Compiling function #45:"run" failed:
+array.set[2] expected type i32, found array.get of type f64 @+29674
+```
+
+Every one of the 16 ECMA-262 `ToInteger`-offset variants in
+`array-arg-offset-tointeger.js`-style tests hits this identically for both
+`Int16Array` and `Uint16Array` — including the simplest case (`offset: ""`),
+so this isn't specific to the object/array-coercion path #3707 fixed. Other
+element widths (`Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int32Array`,
+`Uint32Array`, `Float32Array`, `Float64Array` — 7 of 9 non-BigInt
+constructors) compile and instantiate correctly for the same test shape, so
+this looks specific to the 2-byte element width.
+
+## Likely area
+
+`compileTypedArraySet` / `emitArrayCopy` (`src/codegen/array-methods.ts`) or
+the i16 element-array `array.set` lowering — the error is a type mismatch
+feeding an `array.set` for the destination element array with an `f64`
+value where the destination element type wants `i32` (i16 storage arrays are
+represented via `i32` fields in WasmGC). Given it reproduces in the
+**standalone multi-file** path specifically (not yet checked against
+single-file `compile()`/GC-host target — that should be checked first as
+part of triage), the bug may be in the same neighborhood as #3731, or may be
+a distinct i16-specific coercion bug. Needs triage to confirm which.
+
+## Acceptance criteria
+
+- [ ] Confirm whether this also reproduces via `compile()` (single-file,
+      `generateModule`) and/or the JS-host (`gc`) target, to scope which
+      backend/path owns the bug.
+- [ ] Root-cause the `f64`-vs-`i32` type mismatch feeding the i16 element
+      `array.set`.
+- [ ] Fix + regression test (mirror `tests/issue-3202.test.ts` /
+      `tests/standalone-multimodule-to-primitive-fills.test.ts` patterns).

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -5934,6 +5934,24 @@ export function generateMultiModule(
     // Emit __call_toString/__call_valueOf exports for ToPrimitive dispatch.
     emitToPrimitiveMethodExports(ctx);
 
+    // (#2358 #10 / #2638) Fill the reserved `__array_to_primitive_string` /
+    // `__class_to_primitive` driver bodies now that `__extern_length` /
+    // `__extern_get_idx` (filled by fillExternGetIdxVecArms above) and the
+    // `__call_valueOf`/`__call_toString` dispatchers (emitToPrimitiveMethodExports
+    // just above) are registered. Mirrors the single-module `generateModule`
+    // pipeline, which called these two fills but this multi-file path never
+    // did — every standalone multi-file compile reaching `__to_primitive`'s
+    // array/class arms (e.g. `TypedArray.prototype.set(arr, offset)` where
+    // `offset` needs ToNumber on a plain object or array) left both driver
+    // placeholders as their bare `unreachable` stub, so a would-be-catchable
+    // coercion crashed the whole module with an uncatchable Wasm trap instead
+    // of the value it should have produced. No-op when neither driver was
+    // reserved (`ctx.arrayToPrimitiveReserved`/`ctx.classToPrimitiveReserved`
+    // unset) — byte-identical for modules that never reach `__to_primitive`'s
+    // array/class-instance arms.
+    fillArrayToPrimitive(ctx);
+    fillClassToPrimitive(ctx);
+
     // (#1716) Emit __call_@@toPrimitive(self, hint) for runtime ToPrimitive
     // dispatch of a class's [Symbol.toPrimitive] *method* on opaque structs.
     emitToPrimitiveMethodExport(ctx);

--- a/tests/standalone-multimodule-to-primitive-fills.test.ts
+++ b/tests/standalone-multimodule-to-primitive-fills.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// `generateMultiModule` (the compileMulti/compileFiles path) never called
+// `fillArrayToPrimitive` / `fillClassToPrimitive`, unlike the single-file
+// `generateModule` path. Both are "reserve a placeholder now, patch its body
+// in post-processing" drivers backing `__to_primitive`'s array/class-instance
+// arms (needed whenever a standalone build must ToNumber/ToString a plain
+// object or array, e.g. via a TypedArray.prototype.set offset argument). With
+// the fill never called, the reserved driver kept its bare `unreachable` stub
+// body — so any standalone MULTI-file compile that actually reached one of
+// these arms crashed the whole module with an uncatchable Wasm trap instead
+// of producing the (fully well-defined) coerced value.
+//
+// This is precisely the class of failure the #3189 uncatchable-trap ratchet
+// guards against (see typed-array-set-bounds.ts and issue-3202.test.ts for
+// the sibling OOB-bounds-check fix in the same function) — discovered via a
+// 2026-07-27/28 test262 "oob"-trap-growth block on
+// test/built-ins/TypedArray/prototype/set/array-arg-offset-tointeger.js.
+import { describe, expect, it } from "vitest";
+import { compileMulti } from "../src/index.js";
+
+async function runStandaloneMulti(src: string): Promise<{ envImports: string[]; result: number }> {
+  const files = { "entry.ts": src };
+  const r = await compileMulti(files, "entry.ts", { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "standalone multi-file module failed WebAssembly.validate").toBe(true);
+  const mod = new WebAssembly.Module(r.binary);
+  const envImports = WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+  const instance = new WebAssembly.Instance(mod, {});
+  const result = (instance.exports as { run: () => number }).run();
+  return { envImports, result };
+}
+
+describe("standalone compileMulti fills __to_primitive array/class drivers", () => {
+  it("TypedArray.prototype.set(arr, offset) with a plain-object offset does not trap", async () => {
+    const { result } = await runStandaloneMulti(
+      `export function run(): number {
+         const sample = new Int8Array([1, 2]);
+         sample.set([42], {} as any); // ToNumber({}) -> NaN -> ToInteger -> 0
+         return sample[0] * 100 + sample[1];
+       }`,
+    );
+    expect(result).toBe(4202);
+  });
+
+  it("TypedArray.prototype.set(arr, offset) with an array offset coerces via join(',')", async () => {
+    const { result } = await runStandaloneMulti(
+      `export function run(): number {
+         const sample = new Int8Array([1, 2]);
+         sample.set([42], [1] as any); // ToNumber([1]) -> "1" -> 1
+         return sample[0] * 100 + sample[1];
+       }`,
+    );
+    expect(result).toBe(142);
+  });
+
+  it("does not leak a host env import for the object/array coercion", async () => {
+    const { envImports } = await runStandaloneMulti(
+      `export function run(): number {
+         const sample = new Int8Array([1, 2]);
+         sample.set([42], [0] as any);
+         return sample[0] * 100 + sample[1];
+       }`,
+    );
+    expect(envImports.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

Root cause of the test262 pass-rate freeze (separate from the landing-page benchmark issue in #3700/#3703/#3704): the #3189 uncatchable-trap ratchet has refused every baseline promotion since ~14:19 UTC yesterday because `test/built-ins/TypedArray/prototype/set/array-arg-offset-tointeger.js` started trapping ("oob" category, +1) where it previously didn't.

**Bisection result — not a compiler regression.** I compiled this exact test through the real pipeline at both the last-known-good commit and current `main`: the generated wasm is byte-identical. Nothing in `src/` changed what this test compiles to.

**Actual root cause:** `generateMultiModule` (the `compileMulti`/`compileFiles` path — used whenever test262's harness files get bundled with a test) has apparently never called `fillArrayToPrimitive` / `fillClassToPrimitive`. Both are "reserve a placeholder now, patch its body in post-processing" drivers backing `__to_primitive`'s array/class-instance arms — needed whenever a standalone build has to `ToNumber`/`ToString` a plain object or array via `valueOf`/`toString`/`join(",")`. `generateModule` (the single-file path) has always called both; only the multi-file path was missing them, so the reserved driver kept its bare `unreachable` stub body forever.

Any standalone multi-file compile reaching that arm — exactly what `array-arg-offset-tointeger.js` does via `TypedArray.prototype.set(arr, offset)` with a plain-object/array `offset` — crashed with an uncatchable Wasm trap instead of producing the (fully spec'd) coerced value. This test was apparently never reached/counted before, so the trap-growth gate is seeing it for the first time now, not regressing on it.

**Verification:**
- Direct instantiation across 7 of the 9 non-BigInt TypedArray constructors, all 16 ECMA-262 `ToInteger`-offset cases each: traps before the fix, correct values after (`Int16Array`/`Uint16Array` have a separate, pre-existing, unrelated "invalid module" bug reproduced identically with and without this change — out of scope here).
- New regression test (`tests/standalone-multimodule-to-primitive-fills.test.ts`) fails with the exact `unreachable` trap without the fix, passes with it.
- Targeted `compileMulti`+standalone test slice (issue-2138, -2928, -3214 ×2, -3371, -3493–-3517, linker-self-host): no new failures. The two issue-3371 failures reproduce byte-for-byte without this change too (pre-existing, unrelated).

**Known remaining gap (explicitly out of scope):** `generateMultiModule` is still missing ~19 other `fill*()` calls that `generateModule` has (iterators, proxy, promise, disposable stack, accessor drivers, dynamic proto, etc.) — the same latent-unreachable-stub risk likely exists in each. Only the two needed to unblock this specific regression are added here; the rest is a larger follow-up.

## CLA

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — CLA check is skipped automatically per repo policy. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_