### PR TITLE
fix(#3735): re-scope trap-growth-allow into a test262-paths-matched diff

### DIFF
--- a/plan/issues/3735-typedarray-set-array-offset-tointeger-oob-reclassification.md
+++ b/plan/issues/3735-typedarray-set-array-offset-tointeger-oob-reclassification.md
@@ -55,6 +55,15 @@ This issue exists only to carry the `trap-growth-allow` declaration so the
 #3189 ratchet does not permanently freeze the landing-page baseline over a
 change that is a net improvement (-4 traps overall).
 
+## Scoping note (this PR)
+
+This PR merged as docs-only (no `src/**`/test262-paths files touched), so
+`test262-sharded.yml`'s `push` trigger path-filter skipped it entirely —
+`promote-baseline` never ran against this commit and never read the
+declaration above. Re-touching this file in a follow-up PR that also
+touches `scripts/diff-test262.ts` so the declaration lands in a diff that
+actually triggers the workflow.
+
 ## Acceptance criteria
 
 - [x] `trap-growth-allow` declared and verified by `check-baseline-trap-growth.ts`'s

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -297,6 +297,12 @@ export const ORACLE_REBASE_DRIFT_TOLERANCE = 25;
 //     before and independent of this gate in BOTH branches — an allowance
 //     never excuses a new trap.
 export const REGRESSIONS_ALLOW_KEY = "regressions-allow";
+// (#3735) A docs-only PR (touching only plan/issues/**) never triggers
+// test262-sharded.yml's push run at all (path-filtered out), so a
+// trap-growth-allow declared there is invisible to promote-baseline's
+// change-scoping (which reads only the triggering commit's OWN HEAD^1..HEAD
+// diff) — the declaration must land in a PR that also touches a
+// test262-paths-matched file (e.g. this one) to actually be read.
 export const TRAP_GROWTH_ALLOW_KEY = "trap-growth-allow";
 
 export interface RegressionsAllowance {


### PR DESCRIPTION
## Summary

- #3709 landed the `trap-growth-allow` declaration (for the #3707 `null_deref`→`oob` reclassification, see #3735/#3736) as a **docs-only** PR — it only touched `plan/issues/**`.
- `test262-sharded.yml`'s `push` trigger has a `paths:` filter restricted to `src/**` and a handful of config/script files; `plan/issues/**` is not in it. So #3709's merge **never triggered `promote-baseline` at all**.
- `promote-baseline`'s change-scoping (`resolveChangeBase`) reads only the *triggering commit's own* `HEAD^1..HEAD` diff — so even once some future `src/**`-touching PR does trigger the workflow, that run has no way to see #3709's declaration; it's several commits back in history and outside its diff.
- Net effect: `promote-baseline` stays frozen on the `oob` trap-growth refusal indefinitely, regardless of #3709 having merged.
- Fix: touch `scripts/diff-test262.ts` (in the path filter) alongside re-touching #3735's issue file in the **same diff**, so this PR's own merge triggers `promote-baseline` with the declaration actually visible to it. Also documents the gap inline as a comment for future declarations.

## Test plan

- [x] `trap-growth-allow` frontmatter unchanged from #3735's original (still targets `test/built-ins/TypedArray/prototype/set/array-arg-offset-tointeger.js`, count 1).
- [ ] Next `promote-baseline` run (triggered by this PR's own merge) reads this PR's diff, finds the declaration, and successfully promotes (verified by CI, not locally reproducible).

---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_