### PR TITLE
Rewrite ToInt32 as IEEE-754 bit decomposition to avoid V8 tiering stall (#3739)

### DIFF
--- a/plan/issues/3739-toint32-float-modulo-v8-tiering.md
+++ b/plan/issues/3739-toint32-float-modulo-v8-tiering.md
@@ -1,0 +1,115 @@
+---
+id: 3739
+title: "ToInt32's float-based modulo-reduction (f64.div/f64.floor) never tiers up in V8 — landing-page loop.ts benchmark showed ~37x wasm-vs-js slowdown"
+status: done
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+completed: 2026-07-28
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: codegen
+language_feature: bitwise-operators
+goal: performance
+depends_on: []
+related: [3707, 3733, 3734]
+loc-budget-allow:
+  - src/ir/lower.ts
+  - src/codegen/binary-ops.ts
+func-budget-allow:
+  - src/ir/lower.ts::lowerIrFunctionBody
+---
+# #3739 — ToInt32's float-based modulo reduction never tiers up in V8
+
+## Context
+
+After landing #3707/#3709-#3711 (unfreezing the test262 landing-page pass
+rate), the landing-page `loop.ts`/`array.ts` wasm-vs-js benchmark chart
+showed a catastrophic ~28-37x wasm-slower-than-js ratio for `loop.ts`
+(`s = (s + i) | 0`, 1,000,000 iterations) and a smaller ~2.6-3x ratio for
+`array.ts`. The user reported this as "a catastrophic array and loop
+regression in the host lane" and asked for investigation + fix.
+
+## Investigation
+
+`array.ts`'s ~2.6-3x ratio is real but modest, already correctly diagnosed
+in #3734 (generic `__vec_push` externref-boxing dispatch overhead) — not
+addressed here, tracked separately.
+
+`loop.ts`'s ~28-37x ratio was bisected all the way down to a **V8/Node
+engine tiering limitation**, confirmed with a 100%-handwritten WAT module
+with zero connection to the compiler:
+
+- Pure f64 accumulator loop (no ToInt32 at all): ~1.4ms/call, tiers up
+  normally across repeated calls.
+- Add the float-based modulo-reduction ToInt32 needs
+  (`f64.trunc`/`f64.div`/`f64.floor`/`f64.mul`/`f64.sub`/`i32.trunc_sat_f64_u`
+  — required because WasmGC has no direct f64→i32-mod-2^32 instruction):
+  ~17.3ms/call, **never improves across 15+ repeated calls** — V8 never
+  tiers this function up to its optimizing compiler; it stays at baseline
+  (Liftoff) speed indefinitely.
+- Isolating instruction-by-instruction: `f64.floor` alone (no trunc/div/mul)
+  already costs ~2.4ms/iteration-batch of overhead vs. plain f64 add; the
+  full modulo-reduction chain (minus the final i32 conversion) costs ~8.4ms.
+- This reproduces byte-for-byte identically with the OLD (pre-session) and
+  current compiler source — it is **not a regression introduced by any
+  recent PR**, simply never visible before because the whole benchmark
+  pipeline was frozen/stale until #3700-#3704 unfroze it this session.
+
+## Fix
+
+Replaced the float-based modulo reduction with IEEE-754 bit decomposition
+(sign/exponent/significand extraction + direct shifting), matching how
+native JS engines implement ToInt32 in C++. Avoids `f64.floor`/`f64.div`
+entirely — only `i64.reinterpret_f64`, integer shifts/and/or, and
+`i32.wrap_i64`.
+
+Two independent call sites needed the fix:
+
+1. `emitToInt32` (`src/codegen/binary-ops.ts`) — the legacy AST-direct
+   codegen path.
+2. `emitJsToInt32`'s fast branch (`src/ir/lower.ts`) — the IR path, generic
+   over `BackendEmitter<S>` and shared across WasmGC, linear (WASI), bytecode,
+   and Porffor backends. The fast bit-manipulation path only fires when
+   `S = Instr[]` (WasmGC and linear both use this sink type — confirmed via
+   `linear-emitter.ts`'s pass-through `emitBinary`/`emitUnary`/
+   `emitNumericConversion`, which push the identical raw `Instr` either
+   backend would need). Bytecode is already excluded from `js.bitwise` ops
+   entirely by an earlier legality check. **Porffor keeps the old portable
+   float-based algorithm** — its expression-tree sink doesn't model i64
+   bit-cast/shift ops, and extending it to do so (adding `i64` as a first-class
+   type across Porffor's `binaryOp()`/`emitUnary()` dispatch) is out of scope
+   here; the branch on `Array.isArray(out)` in `emitJsToInt32` cleanly
+   preserves Porffor's existing behavior unchanged.
+
+## Results
+
+- Landing-page `loop.ts` benchmark: wasm went from ~17.3ms → ~8.4ms per
+  1M-iteration call (~2x faster) in local sandbox measurement. Still doesn't
+  fully tier up to the sub-millisecond speed of a pure-i32/pure-f64 loop
+  (isolated handwritten-WAT testing shows the branch-heavy bit-decomposition
+  itself also resists full V8 tiering, just far less severely than the
+  float-modulo version) — chasing that last mile would need deeper
+  V8-specific tuning, judged out of scope for this fix.
+- Correctness: 500,000+ fuzz cases plus hand-picked edge cases (NaN,
+  ±Infinity, ±0, subnormals, exact `2^31`/`2^32` boundaries, `Number.MAX_VALUE`,
+  `Number.MIN_VALUE`, large fractional values) verified byte-identical to
+  native JS `ToInt32` across both the `|`/`^`-with-zero fast path and the
+  general bitwise-op path (`&`, `<<`, `>>`, `>>>`).
+- No regressions: existing `tests/bitwise.test.ts` reproduces its pre-existing
+  environment-only failure identically with/without this change (confirmed
+  via `git stash`); one pre-existing, unrelated equivalence-test failure
+  (`arguments-nested-and-loops.test.ts`) also reproduces identically via
+  `git stash` — not caused by this change.
+
+## Out of scope / follow-ups
+
+- Extending the bit-manipulation fast path to the Porffor backend (would
+  need i64 support added to Porffor's own IR/type system).
+- `array.ts`'s `__vec_push` dispatch overhead — tracked in #3734.
+- Further V8-tiering optimization for `loop.ts` beyond this fix (unclear
+  payoff, and unclear whether it reproduces in real browsers vs. this
+  sandbox's specific V8/Node build).

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -2883,36 +2883,118 @@ export function compileI64BinaryOp(
 }
 
 /**
- * Emit JS ToInt32: reduce f64 modulo 2^32 then truncate to i32.
- * Handles NaN→0, Infinity→0, and large values that wrap.
+ * Emit JS ToInt32 via IEEE-754 bit decomposition (sign/exponent/significand),
+ * matching how native JS engines implement it in C++. Deliberately avoids
+ * f64.floor/f64.div: a handwritten-Wasm bisection (#3739) found that the
+ * floor-based modulo-reduction sequence this replaced never gets tiered up
+ * by V8 in a tight loop (stuck at Liftoff baseline speed indefinitely,
+ * ~12x slower than an equivalent pure-f64 loop with no floor at all) — an
+ * engine limitation, not a codegen bug, but avoidable here since ToInt32
+ * doesn't need floor: the exponent already tells us exactly which bits of
+ * the significand land in the low 32 bits of floor(|x|).
  * Stack: [f64] → [i32]
  */
 export function emitToInt32(fctx: FunctionContext): void {
-  // JS ToInt32 algorithm:
-  //   if NaN/Infinity/0 → 0
-  //   n = sign(x) * floor(abs(x))
-  //   int32bit = n mod 2^32
-  //   if int32bit >= 2^31 → int32bit - 2^32
+  // ECMA-262 ToInt32 (7.1.6): NaN/±0/±Infinity → 0; else
+  // int32bit = (sign(x) * floor(abs(x))) mod 2^32, wrapped to signed range.
   //
-  // In wasm: x - floor(x / 2^32) * 2^32, then trunc_sat
-  // For values in i32 range, trunc_sat alone works. We only need the
-  // modulo reduction for out-of-range values.
-  // Step 1: truncate fractional part toward zero (JS ToInt32 does this first)
-  // Step 2: x - floor(x / 2^32) * 2^32 → maps to [0, 2^32)
-  // Step 3: trunc_sat_f64_u gives correct bit pattern
-  // NaN/Infinity: trunc(NaN)=NaN, Inf-Inf=NaN, trunc_sat_u(NaN)=0. Correct.
-  fctx.body.push({ op: "f64.trunc" });
-  const tmp = allocTempLocal(fctx, { kind: "f64" });
-  fctx.body.push({ op: "local.tee", index: tmp });
-  fctx.body.push({ op: "local.get", index: tmp });
-  fctx.body.push({ op: "f64.const", value: 4294967296 });
-  fctx.body.push({ op: "f64.div" });
-  fctx.body.push({ op: "f64.floor" });
-  fctx.body.push({ op: "f64.const", value: 4294967296 });
-  fctx.body.push({ op: "f64.mul" });
-  fctx.body.push({ op: "f64.sub" });
-  fctx.body.push({ op: "i32.trunc_sat_f64_u" });
-  releaseTempLocal(fctx, tmp);
+  // bits = i64 reinterpret of x. biasedExp = bits[62:52]; e = biasedExp - 1023
+  // (unbiased exponent — negative for |x|<1 and denormals; 1024 for NaN/Inf,
+  // both of which fall out of the valid window below and yield 0 for free).
+  // significand = 53-bit magnitude (mantissa | implicit leading bit).
+  //
+  // floor(|x|)'s bit `k` is significand's bit `k - (e - 52)`. Only bits
+  // [0,31] of floor(|x|) mod 2^32 matter, so:
+  //   e < 0 or e > 83  → those bits are always 0 (either |x|<1, or the
+  //                       significand's bits all sit at position >=32)
+  //   e >= 52          → shift significand LEFT by (e-52); only 0..31 needed
+  //   0 <= e < 52      → shift significand RIGHT (u) by (52-e), truncating
+  //                       the fractional bits, matching floor()
+  // i32.wrap_i64 keeps exactly the low 32 bits either way. Negate at the end
+  // if x's sign bit was set (two's-complement wraparound negation is correct
+  // ToInt32 behavior — no separate overflow case to handle).
+  const bits = allocTempLocal(fctx, { kind: "i64" });
+  const e = allocTempLocal(fctx, { kind: "i64" });
+  const significand = allocTempLocal(fctx, { kind: "i64" });
+  const magnitude = allocTempLocal(fctx, { kind: "i64" });
+
+  fctx.body.push({ op: "i64.reinterpret_f64" });
+  fctx.body.push({ op: "local.set", index: bits });
+
+  fctx.body.push({ op: "local.get", index: bits });
+  fctx.body.push({ op: "i64.const", value: 52n });
+  fctx.body.push({ op: "i64.shr_u" });
+  fctx.body.push({ op: "i64.const", value: 0x7ffn });
+  fctx.body.push({ op: "i64.and" });
+  fctx.body.push({ op: "i64.const", value: 1023n });
+  fctx.body.push({ op: "i64.sub" });
+  fctx.body.push({ op: "local.set", index: e });
+
+  fctx.body.push({ op: "local.get", index: bits });
+  fctx.body.push({ op: "i64.const", value: 0xfffffffffffffn });
+  fctx.body.push({ op: "i64.and" });
+  fctx.body.push({ op: "i64.const", value: 0x10000000000000n });
+  fctx.body.push({ op: "i64.or" });
+  fctx.body.push({ op: "local.set", index: significand });
+
+  const shiftLeft: Instr[] = [
+    { op: "local.get", index: significand },
+    { op: "local.get", index: e },
+    { op: "i64.const", value: 52n },
+    { op: "i64.sub" },
+    { op: "i64.shl" },
+  ];
+  const shiftRight: Instr[] = [
+    { op: "local.get", index: significand },
+    { op: "i64.const", value: 52n },
+    { op: "local.get", index: e },
+    { op: "i64.sub" },
+    { op: "i64.shr_u" },
+  ];
+  fctx.body.push({ op: "local.get", index: e });
+  fctx.body.push({ op: "i64.const", value: 0n });
+  fctx.body.push({ op: "i64.ge_s" });
+  fctx.body.push({ op: "local.get", index: e });
+  fctx.body.push({ op: "i64.const", value: 83n });
+  fctx.body.push({ op: "i64.le_s" });
+  fctx.body.push({ op: "i32.and" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i64" } as ValType },
+    then: [
+      { op: "local.get", index: e },
+      { op: "i64.const", value: 52n },
+      { op: "i64.ge_s" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i64" } as ValType },
+        then: shiftLeft,
+        else: shiftRight,
+      },
+    ],
+    else: [{ op: "i64.const", value: 0n }],
+  });
+  fctx.body.push({ op: "local.set", index: magnitude });
+
+  fctx.body.push({ op: "local.get", index: bits });
+  fctx.body.push({ op: "i64.const", value: 0n });
+  fctx.body.push({ op: "i64.lt_s" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } as ValType },
+    then: [
+      { op: "i32.const", value: 0 },
+      { op: "local.get", index: magnitude },
+      { op: "i32.wrap_i64" },
+      { op: "i32.sub" },
+    ],
+    else: [{ op: "local.get", index: magnitude }, { op: "i32.wrap_i64" }],
+  });
+
+  releaseTempLocal(fctx, bits);
+  releaseTempLocal(fctx, e);
+  releaseTempLocal(fctx, significand);
+  releaseTempLocal(fctx, magnitude);
 }
 
 /**

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -926,6 +926,27 @@ export function lowerIrFunctionBody<S, Slot>(
     }
     return jsBitwiseTmpIdx;
   };
+  // (#3739) Lazily-allocated i64 scratch pool for `emitJsToInt32`'s fast
+  // bit-manipulation path (WasmGC/linear only — see that function). Kept
+  // separate from `jsBitwiseTmpIdx` (f64) since the fast path doesn't use it.
+  let jsBitwiseI64Scratch: { bits: number; e: number; significand: number; magnitude: number } | null = null;
+  const ensureJsBitwiseI64Scratch = (): { bits: number; e: number; significand: number; magnitude: number } => {
+    if (jsBitwiseI64Scratch === null) {
+      const alloc = (name: string): number => {
+        const idx = func.params.length + locals.length;
+        const type: ValType = { kind: "i64" };
+        locals.push({ name, type, logicalType: { kind: "val", val: type } });
+        return idx;
+      };
+      jsBitwiseI64Scratch = {
+        bits: alloc("$js_bitwise_i64_bits"),
+        e: alloc("$js_bitwise_i64_e"),
+        significand: alloc("$js_bitwise_i64_significand"),
+        magnitude: alloc("$js_bitwise_i64_magnitude"),
+      };
+    }
+    return jsBitwiseI64Scratch;
+  };
   const ensureJsBitwiseScratch = (rhsIsI32: boolean): { rhs: number; tmp: number } => {
     const tmp = ensureJsBitwiseTmp();
     if (rhsIsI32) {
@@ -1268,7 +1289,7 @@ export function lowerIrFunctionBody<S, Slot>(
           emitValue(instr.lhs, out);
           if (!lhsIsI32) {
             coerceToF64ForBitwise(instr.lhs, out);
-            emitJsToInt32(emitter, out, ensureJsBitwiseTmp());
+            emitJsToInt32(emitter, out, ensureJsBitwiseTmp(), ensureJsBitwiseI64Scratch);
           }
           if (!resultIsI32) {
             emitter.emitNumericConversion("f64.convert_i32_s", out);
@@ -1303,11 +1324,11 @@ export function lowerIrFunctionBody<S, Slot>(
           // Stack: [lhs, rhs]
           emitter.emitLocalSet(rhsSlot, out);
           // Stack: [lhs]; rhsSlot holds rhs.
-          if (!lhsIsI32) emitJsToInt32(emitter, out, tmpSlot);
+          if (!lhsIsI32) emitJsToInt32(emitter, out, tmpSlot, ensureJsBitwiseI64Scratch);
           // Stack: [lhs_i32]
           emitter.emitLocalGet(rhsSlot, out);
           // Stack: [lhs_i32, rhs]
-          if (!rhsIsI32) emitJsToInt32(emitter, out, tmpSlot);
+          if (!rhsIsI32) emitJsToInt32(emitter, out, tmpSlot, ensureJsBitwiseI64Scratch);
           // Stack: [lhs_i32, rhs_i32]
           emitter.emitI32Bitwise(jsBitwiseToI32(instr.op), out);
           // `>>>` returns a Uint32; everything else is Int32. Convert
@@ -3811,7 +3832,102 @@ function jsBitwiseToI32(
 // stream, while non-Wasm sinks can represent the same composite semantics
 // without observing raw Wasm instructions. Bytecode legality continues to
 // reject the js.bitwise family before any of these primitives are called.
-function emitJsToInt32<S>(emitter: BackendEmitter<S>, out: S, tmpLocalIdx: number): void {
+//
+// (#3739) `S = Instr[]` (WasmGC and linear both use this sink type — see
+// `linear-emitter.ts`'s own comment on `emitBinary` for the shared-sink
+// rationale) takes a FAST bit-manipulation path instead: a handwritten-Wasm
+// bisection found the float-based algorithm below (f64.div/f64.floor/f64.mul)
+// never gets tiered up by V8 in a tight loop — stuck at baseline-interpreter
+// speed indefinitely, ~12x slower than an equivalent pure-f64 loop with no
+// floor at all. The bit-manipulation version (decompose the f64's IEEE-754
+// sign/exponent/significand and shift directly) avoids f64.floor entirely;
+// see `emitToInt32` in `src/codegen/binary-ops.ts` for the byte-identical
+// algorithm with full derivation comments (kept here without re-deriving to
+// avoid drift — the two are intentionally the same instruction sequence).
+// Non-Instr[] sinks (Porffor) keep the portable float-based algorithm: Porffor
+// doesn't model i64 bit-cast/shift ops in its expression tree, and extending
+// it to do so is out of scope here (see plan/issues/3739 for the follow-up).
+function emitJsToInt32<S>(
+  emitter: BackendEmitter<S>,
+  out: S,
+  tmpLocalIdx: number,
+  allocI64Scratch: () => { bits: number; e: number; significand: number; magnitude: number },
+): void {
+  if (Array.isArray(out)) {
+    const wasmOut = out as Instr[];
+    const { bits, e, significand, magnitude } = allocI64Scratch();
+    wasmOut.push({ op: "i64.reinterpret_f64" }, { op: "local.set", index: bits });
+    wasmOut.push(
+      { op: "local.get", index: bits },
+      { op: "i64.const", value: 52n },
+      { op: "i64.shr_u" },
+      { op: "i64.const", value: 0x7ffn },
+      { op: "i64.and" },
+      { op: "i64.const", value: 1023n },
+      { op: "i64.sub" },
+      { op: "local.set", index: e },
+    );
+    wasmOut.push(
+      { op: "local.get", index: bits },
+      { op: "i64.const", value: 0xfffffffffffffn },
+      { op: "i64.and" },
+      { op: "i64.const", value: 0x10000000000000n },
+      { op: "i64.or" },
+      { op: "local.set", index: significand },
+    );
+    const shiftLeft: Instr[] = [
+      { op: "local.get", index: significand },
+      { op: "local.get", index: e },
+      { op: "i64.const", value: 52n },
+      { op: "i64.sub" },
+      { op: "i64.shl" },
+    ];
+    const shiftRight: Instr[] = [
+      { op: "local.get", index: significand },
+      { op: "i64.const", value: 52n },
+      { op: "local.get", index: e },
+      { op: "i64.sub" },
+      { op: "i64.shr_u" },
+    ];
+    wasmOut.push(
+      { op: "local.get", index: e },
+      { op: "i64.const", value: 0n },
+      { op: "i64.ge_s" },
+      { op: "local.get", index: e },
+      { op: "i64.const", value: 83n },
+      { op: "i64.le_s" },
+      { op: "i32.and" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i64" } },
+        then: [
+          { op: "local.get", index: e },
+          { op: "i64.const", value: 52n },
+          { op: "i64.ge_s" },
+          { op: "if", blockType: { kind: "val", type: { kind: "i64" } }, then: shiftLeft, else: shiftRight },
+        ],
+        else: [{ op: "i64.const", value: 0n }],
+      },
+      { op: "local.set", index: magnitude },
+    );
+    wasmOut.push(
+      { op: "local.get", index: bits },
+      { op: "i64.const", value: 0n },
+      { op: "i64.lt_s" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "i32.const", value: 0 },
+          { op: "local.get", index: magnitude },
+          { op: "i32.wrap_i64" },
+          { op: "i32.sub" },
+        ],
+        else: [{ op: "local.get", index: magnitude }, { op: "i32.wrap_i64" }],
+      },
+    );
+    return;
+  }
   // Stack: [f64]
   emitter.emitUnary("f64.trunc", out);
   // Stack: [f64_trunc]

--- a/tests/issue-3733-bitor-zero-fast-path.test.ts
+++ b/tests/issue-3733-bitor-zero-fast-path.test.ts
@@ -33,14 +33,14 @@ function count(haystack: string, needle: string): number {
 describe("#3733 — bitwise-with-literal-zero fast path", () => {
   it("`x | 0` runs ToInt32 exactly once (on `x`), not twice (once per operand)", async () => {
     const w = await wat(`export function run(x: number): number { return x | 0; }`);
-    // The full emitJsToInt32/emitToInt32 sequence divides and floors by
-    // 2^32 for the modulo-reduction step. The dynamic operand `x` still
-    // legitimately needs this (real ToInt32 wraparound is observable), so
-    // it appears exactly ONCE — the fast path's entire point is that the
-    // constant-zero operand's ToInt32 (which would make it TWICE) is
-    // elided.
-    expect(count(w, "f64.div")).toBe(1);
-    expect(count(w, "f64.floor")).toBe(1);
+    // (#3739) emitJsToInt32's fast path decomposes the f64's IEEE-754 bits
+    // instead of the old div/floor modulo-reduction — i64.reinterpret_f64 is
+    // its first instruction, so counting it pins "ToInt32 runs once, not
+    // twice" the same way the old f64.div count did. The dynamic operand `x`
+    // still legitimately needs it (real ToInt32 wraparound is observable);
+    // the fast path's entire point is that the constant-zero operand's
+    // ToInt32 (which would make it TWICE) is elided.
+    expect(count(w, "i64.reinterpret_f64")).toBe(1);
     // No bitwise instruction either — `x | 0` is emitted as pure ToInt32(x),
     // not `ToInt32(x) | ToInt32(0)`.
     expect(w).not.toContain("i32.or");
@@ -48,8 +48,7 @@ describe("#3733 — bitwise-with-literal-zero fast path", () => {
 
   it("`x ^ 0` gets the same identity fast path", async () => {
     const w = await wat(`export function run(x: number): number { return x ^ 0; }`);
-    expect(count(w, "f64.div")).toBe(1);
-    expect(count(w, "f64.floor")).toBe(1);
+    expect(count(w, "i64.reinterpret_f64")).toBe(1);
     expect(w).not.toContain("i32.xor");
   });
 

--- a/tests/issue-3739-toint32-bitmanip.test.ts
+++ b/tests/issue-3739-toint32-bitmanip.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3739 — ToInt32 (used by every bitwise op and the `|0`/`^0` fast path)
+// used a float-based modulo-reduction (f64.div/f64.floor/f64.mul/f64.sub) to
+// wrap values into the i32 range. A handwritten-Wasm bisection found V8 never
+// tiers this up to its optimizing compiler in a tight loop — stuck at
+// baseline speed indefinitely, ~12x slower than an equivalent pure-f64 loop
+// with no floor at all (the landing-page `loop.ts` benchmark's catastrophic
+// wasm-vs-js ratio). Replaced with IEEE-754 bit decomposition (sign/exponent/
+// significand shifting), matching how native JS engines implement it in C++
+// — avoids f64.floor entirely. Two independent call sites needed the fix:
+// `emitToInt32` (src/codegen/binary-ops.ts, the legacy AST-direct path) and
+// `emitJsToInt32`'s fast branch (src/ir/lower.ts, WasmGC/linear only — the
+// Porffor backend keeps the old portable algorithm, see that function's
+// comment for why). This file exercises both entry points.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { compileAndRunBuildImports as compileAndRun } from "./helpers/compile.js";
+
+async function wat(src: string): Promise<string> {
+  const r = await compile(src, { skipSemanticDiagnostics: true, emitWat: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  return r.wat;
+}
+
+const EDGE_CASES = [
+  0,
+  -0,
+  1,
+  -1,
+  1.5,
+  -1.5,
+  1.9,
+  -1.9,
+  0.5,
+  -0.5,
+  0.4,
+  -0.4,
+  2147483647,
+  2147483648,
+  -2147483648,
+  -2147483649,
+  4294967295,
+  4294967296,
+  4294967297,
+  -4294967295,
+  -4294967296,
+  8589934591,
+  8589934592,
+  8589934593,
+  NaN,
+  Infinity,
+  -Infinity,
+  1e300,
+  -1e300,
+  1e21,
+  -1e21,
+  5e-10,
+  -5e-10,
+  Number.MAX_SAFE_INTEGER,
+  -Number.MAX_SAFE_INTEGER,
+  Number.MAX_VALUE,
+  -Number.MAX_VALUE,
+  Number.MIN_VALUE,
+  -Number.MIN_VALUE, // smallest denormal
+  2 ** 32 + 5,
+  2 ** 32 - 5,
+  -(2 ** 32) + 5,
+  -(2 ** 32) - 5,
+  2 ** 31,
+  2 ** 31 - 1,
+  -(2 ** 31),
+  -(2 ** 31) - 1,
+  0.9999999999,
+  -0.9999999999,
+  123456789.98765433,
+  1073741824.5,
+];
+
+describe("#3739 — bit-manipulation ToInt32 correctness", () => {
+  it("compiled `x | 0` uses the bit-manipulation path (no f64.floor at all)", async () => {
+    const w = await wat(`export function run(x: number): number { return x | 0; }`);
+    expect(w).toContain("i64.reinterpret_f64");
+    expect(w).not.toContain("f64.floor");
+    expect(w).not.toContain("f64.div");
+  });
+
+  it("`x | 0` matches native ToInt32 for all edge cases", async () => {
+    const e = await compileAndRun(`export function run(x: number): number { return x | 0; }`);
+    for (const c of EDGE_CASES) {
+      expect(e.run(c), `ToInt32(${c})`).toBe(c | 0);
+    }
+  });
+
+  it("general (non-fast-path) bitwise ops still coerce both operands correctly", async () => {
+    const e = await compileAndRun(`
+      export function band(a: number, b: number): number { return a & b; }
+      export function bshl(a: number, b: number): number { return a << b; }
+      export function bshrS(a: number, b: number): number { return a >> b; }
+      export function bshrU(a: number, b: number): number { return a >>> b; }
+    `);
+    for (const a of EDGE_CASES) {
+      for (const b of [0, 1, 2, 31, 32, -1, 5.9, NaN, Infinity]) {
+        expect(e.band(a, b), `${a} & ${b}`).toBe(a & b);
+        expect(e.bshl(a, b), `${a} << ${b}`).toBe(a << b);
+        expect(e.bshrS(a, b), `${a} >> ${b}`).toBe(a >> b);
+        expect(e.bshrU(a, b), `${a} >>> ${b}`).toBe(a >>> b);
+      }
+    }
+  });
+
+  it("fuzz: random magnitudes and exponent ranges match native ToInt32 (2000 cases)", async () => {
+    const e = await compileAndRun(`export function run(x: number): number { return x | 0; }`);
+    for (let i = 0; i < 2000; i++) {
+      const kind = Math.random();
+      let v: number;
+      if (kind < 0.3) v = (Math.random() - 0.5) * 2 ** (Math.random() * 100);
+      else if (kind < 0.6) v = Math.floor((Math.random() - 0.5) * 2 ** 34);
+      else v = (Math.random() - 0.5) * 20;
+      expect(e.run(v), `ToInt32(${v})`).toBe(v | 0);
+    }
+  });
+
+  it("tight accumulator loop matches JS semantics exactly (mirrors the loop.ts landing-page benchmark)", async () => {
+    const e = await compileAndRun(`
+      export function run(): number {
+        let s = 0;
+        for (let i = 0; i < 1000000; i++) s = (s + i) | 0;
+        return s;
+      }
+    `);
+    let expected = 0;
+    for (let i = 0; i < 1000000; i++) expected = (expected + i) | 0;
+    expect(e.run()).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #3739 — the landing-page `loop.ts` wasm-vs-js benchmark showed a catastrophic ~28-37x slowdown. Root-caused via handwritten WAT bisection (bypassing the compiler entirely) to a V8/Node engine tiering limitation: the float-based ToInt32 modulo-reduction (`f64.trunc`/`f64.div`/`f64.floor`/`f64.mul`/`f64.sub`/`i32.trunc_sat_f64_u`) never tiers up past V8's baseline compiler in a tight loop, regardless of warmup call count. This is **not a regression from any recent PR** — it reproduces identically against old and current compiler source, and was simply never visible before because the benchmark pipeline was frozen/stale until this session's earlier PRs unfroze it. (`array.ts`'s smaller ~2.6-3x regression is real but separate, already tracked in #3734 — not addressed here.)

Replaces the float-based modulo reduction with direct IEEE-754 bit decomposition (sign/exponent/significand extraction via `i64.reinterpret_f64` + shifts), matching how native JS engines implement `ToInt32` in C++, and avoiding `f64.floor`/`f64.div` entirely. Two independent call sites needed the fix:

- `emitToInt32` (`src/codegen/binary-ops.ts`) — the legacy AST-direct codegen path.
- `emitJsToInt32`'s fast branch (`src/ir/lower.ts`) — the IR path, which is what the real `loop.ts` benchmark actually compiles through. Scoped to `S = Instr[]` sinks only (WasmGC + linear/WASI backends); the Porffor backend keeps the old portable float-based algorithm unchanged, since its expression-tree sink doesn't model i64 bit-cast/shift ops and extending it is out of scope here.

Locally the `loop.ts` benchmark improved ~2x (17.3ms → 8.4ms per 1M-iteration call). It still doesn't fully tier up to the sub-millisecond speed of a pure-i32/pure-f64 loop — isolated handwritten-WAT testing shows the branch-heavy bit-decomposition itself also resists some V8 tiering, just far less severely than the float-modulo version. Chasing that last mile is judged out of scope (see the issue file's "Out of scope" section).

Carries `loc-budget-allow`/`func-budget-allow` grants in the issue file for the two files/function that grew past budget thresholds.

## Test plan

- New `tests/issue-3739-toint32-bitmanip.test.ts`: WAT-level check (no `f64.floor`/`f64.div` emitted), 51 hand-picked edge cases (NaN/±Infinity/±0/subnormals/exact 2^31/2^32 boundaries/`Number.MAX_VALUE`/`Number.MIN_VALUE`), general bitwise-op correctness (`&`, `<<`, `>>`, `>>>` with operand fuzzing), 2000-case random fuzz, and the exact million-iteration accumulator loop from the landing-page benchmark — all verified byte-identical to native JS `ToInt32`.
- Updated `tests/issue-3733-bitor-zero-fast-path.test.ts`'s stale instruction-count assertions (`f64.div`/`f64.floor` counts → `i64.reinterpret_f64` count, same "runs once not twice" invariant).
- `tests/equivalence/ts-wasm-equivalence.test.ts` (29 tests) passes.
- `tests/bitwise.test.ts` reproduces its pre-existing sandbox-only `string_constants` import failure identically with/without this change (confirmed via `git stash`) — unrelated to this PR.
- `node scripts/check-loc-budget.mjs` and `node scripts/check-func-budget.mjs` both pass with the granted allowances.
- `npx biome lint` clean on all changed files.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_