### PR TITLE
fix(codegen): treat `debugger;` as a no-op instead of an unsupported statement

### DIFF
--- a/src/codegen/statements.ts
+++ b/src/codegen/statements.ts
@@ -279,6 +279,15 @@ function compileStatementInner(ctx: CodegenContext, fctx: FunctionContext, stmt:
     return;
   }
 
+  // `debugger;` — no-op. Per ECMA-262 §13.16, DebuggerStatement evaluation may
+  // trigger a breakpoint if an implementation-defined debugging facility is
+  // available, and otherwise "has no observable effect". Wasm exposes no such
+  // facility, so eliding it is spec-correct rather than a silent drop. The
+  // linear backend already treats it this way (src/codegen-linear/index.ts).
+  if (stmt.kind === ts.SyntaxKind.DebuggerStatement) {
+    return;
+  }
+
   // Class member nodes that can leak into compileStatement when iterating
   // class body or constructor body — treat as no-ops since field initializers
   // are handled separately in compileClassBodies (index.ts).

--- a/tests/debugger-statement.test.ts
+++ b/tests/debugger-statement.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `debugger;` is a no-op statement, not an unsupported one.
+ *
+ * Per ECMA-262 §13.16, evaluating a DebuggerStatement may trigger a breakpoint
+ * if an implementation-defined debugging facility is available, and otherwise
+ * "has no observable effect". Wasm exposes no such facility, so eliding it is
+ * spec-correct. The linear backend already did this
+ * (`src/codegen-linear/index.ts`); the WasmGC backend fell through to
+ * `Unsupported statement: LastStatement` (SyntaxKind.LastStatement === 260 ===
+ * DebuggerStatement) and failed the whole compile.
+ *
+ * This was the first hard codegen blocker when compiling the `typescript` npm
+ * package (#1058 / #1579): `node_modules/typescript/lib/_tsc.js` contains
+ * exactly one `debugger;`, at line 1279, and that single statement aborted a
+ * 6.2 MB bundle.
+ */
+import { describe, expect, it } from "vitest";
+import { compileAndRunResultObject as compileAndRun } from "./helpers/compile.js";
+import { compile } from "../src/index.js";
+
+describe("debugger statement", () => {
+  it("is elided inside a function without disturbing surrounding statements", async () => {
+    const r = await compileAndRun(`
+      export function test(): number {
+        let x = 1;
+        debugger;
+        x = x + 1;
+        return x;
+      }
+    `);
+    expect(r.success, r.error).toBe(true);
+    expect(r.result).toBe(2);
+  });
+
+  it("does not break control flow inside a loop body", async () => {
+    const r = await compileAndRun(`
+      export function test(): number {
+        let s = 0;
+        for (let i = 0; i < 4; i++) {
+          debugger;
+          s = s + i;
+        }
+        return s;
+      }
+    `);
+    expect(r.success, r.error).toBe(true);
+    expect(r.result).toBe(6);
+  });
+
+  it("is elided in a conditional branch without collapsing the branch", async () => {
+    const r = await compileAndRun(`
+      export function test(): number {
+        let n = 0;
+        if (n === 0) {
+          debugger;
+          n = 10;
+        } else {
+          n = 20;
+        }
+        return n;
+      }
+    `);
+    expect(r.success, r.error).toBe(true);
+    expect(r.result).toBe(10);
+  });
+
+  it("compiles at top level", async () => {
+    const result = await compile(
+      `
+      debugger;
+      export function run(): number { return 7; }
+    `,
+      { fileName: "top.ts" },
+    );
+    expect(result.success, result.errors[0]?.message).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+
+  it("compiles in a JS source file (the tsc-bundle shape)", async () => {
+    const result = await compile(
+      `
+      export function run() {
+        debugger;
+        return 42;
+      }
+    `,
+      { allowJs: true, fileName: "bundle.js" },
+    );
+    expect(result.success, result.errors[0]?.message).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

The WasmGC backend had no arm for `DebuggerStatement`, so it fell through to the `Unsupported statement: LastStatement` fallthrough in `src/codegen/statements.ts` and failed the entire compile.

(The message named an alias rather than the statement because `ts.SyntaxKind.LastStatement === 260 === ts.SyntaxKind.DebuggerStatement` — reverse enum mapping picks the alias, which is why the error reads as an unfamiliar node kind.)

Per **ECMA-262 §13.16**, evaluating a DebuggerStatement may trigger a breakpoint if an implementation-defined debugging facility is available, and otherwise *"has no observable effect"*. Wasm exposes no such facility, so eliding it is spec-correct rather than a silent drop. The **linear backend already treated it this way** (`src/codegen-linear/index.ts`) — this brings WasmGC to parity, adding the arm next to the existing `EmptyStatement` no-op.

### Impact

One `debugger;` anywhere in a module aborted that entire module. This was the first hard codegen blocker when compiling the `typescript` npm package (#1058 / #1579): `node_modules/typescript/lib/_tsc.js` carries exactly one, at line 1279, and that single statement took down the whole 6.2 MB bundle.

### Verification

| Check | Result |
|---|---|
| New tests (5, `tests/debugger-statement.test.ts`) | pass |
| `tsc --noEmit` | clean |
| equivalence gate | 1611 passing, **no new regressions** |
| lint / prettier | clean |
| `check:loc-budget`, `check:func-budget`, `check:oracle-ratchet`, `check:stack-balance`, `check:test262-hard-errors` | pass |

The tests cover `debugger;` in a function body, a loop body, a conditional branch, at top level, and in a JS source file (the tsc-bundle shape). Three of them assert **runtime** results rather than just successful compilation, so an elision that disturbed surrounding control flow (collapsing a branch, breaking a loop) would fail rather than pass silently.

### What this unblocks, and what it does not

With this fix the tsc-bundle slices get past checking and codegen and into **binary emit**, where they hit a separate, deeper bug:

```
Binary emit error: RangeError: Codegen error: local index out of range — 2 (valid: [0, 1))
at function 'log'. This is the late-import index-shift class (#2043)...
```

Bisected to a bounded input: the minimal reproducing slice is **148 statements / 68 KB**, where statement 148 is the `((Debug2) => {` IIFE at `_tsc.js:1212` (TypeScript's `Debug` namespace); statement 147 is clean. That is tracked separately — it is a different and substantially harder class, not something to bolt onto this change.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: this is an attestation for a human contributor to make, not an agent. The template notes internal/org-member PRs skip the CLA check automatically. -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kEqkoB4FKKtW3q9G6zFoY

---
_Generated by [Claude Code](https://claude.ai/code/session_014kEqkoB4FKKtW3q9G6zFoY)_