### PR TITLE
feat(#3743): CompileOptions.emitWatOnlyFunctions for targeted WAT debug dumps

### DIFF
--- a/plan/issues/3743-emit-wat-only-functions-debug-dump.md
+++ b/plan/issues/3743-emit-wat-only-functions-debug-dump.md
@@ -1,0 +1,64 @@
+---
+id: 3743
+title: "CompileOptions.emitWatOnlyFunctions — targeted WAT debug dumps for huge compileProject graphs"
+status: done
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+completed: 2026-07-28
+priority: low
+horizon: s
+feasibility: easy
+reasoning_effort: low
+task_type: tooling
+area: codegen
+language_feature: n/a
+goal: npm-library-support
+origin: "surfaced while diagnosing #3672's ESLint Linter compileProject validation failure — needed to inspect one function's WAT out of a 4800+-function, 10.5MB-binary module and full emitWat() threw 'Invalid string length'"
+related: [3672]
+loc-budget-allow:
+  - src/compiler.ts
+---
+
+# #3743 — targeted `emitWat` function filter
+
+## Problem
+
+`emitWat(mod)` builds the entire module's WAT text as one giant
+`lines.join("\n")`. On large `compileProject` graphs (e.g. ESLint's
+`Linter` entry, ~4800+ functions / 10.5MB binary) that throws `RangeError:
+Invalid string length` — there is no way to recover WAT for even a single
+function of interest (e.g. the one named in a
+`WebAssembly.Module()` validation error) without the full-module build
+succeeding first.
+
+This surfaced directly while diagnosing #3672: the validation error named
+one closure function, but there was no way to dump just that function's
+WAT to inspect the bad instruction sequence.
+
+## What changed
+
+- `src/emit/wat.ts` — `emitWat(mod, opts?)` takes an optional
+  `{ onlyFunctions?: Set<string> }`; when set, function formatting is
+  filtered to just those Wasm names (types/imports/globals still emitted
+  for context).
+- `src/index.ts` — `CompileOptions.emitWatOnlyFunctions?: string[]`, a
+  debug-only knob threaded through to `emitWat`.
+- `src/compiler.ts` — `runPipeline` passes
+  `options.emitWatOnlyFunctions` through as the `onlyFunctions` set when
+  present.
+
+## Scope
+
+Pure diagnostic tooling — no codegen/runtime behavior change when the new
+option is unset (existing full-module `emitWat` callers are unaffected).
+Does not fix any compiler bug itself; #3672's actual blocker (a
+cross-module identifier-identity collision) was fixed separately.
+
+## Acceptance criteria
+
+- [x] `emitWat` accepts an optional function-name filter without changing
+      default (unset) behavior.
+- [x] `CompileOptions.emitWatOnlyFunctions` threads through
+      `runPipeline`'s existing `emitWat` call site.
+- [x] `tsc --noEmit` clean; loc/func budget gates clean.

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1088,7 +1088,10 @@ function runPipeline(input: PipelineInput): CompileResult {
   let wat = "";
   if (emitWatOutput) {
     try {
-      wat = emitWat(mod);
+      wat = emitWat(
+        mod,
+        options.emitWatOnlyFunctions ? { onlyFunctions: new Set(options.emitWatOnlyFunctions) } : undefined,
+      );
     } catch (e) {
       pushSourceAnchoredDiagnostic(
         errors,

--- a/src/emit/wat.ts
+++ b/src/emit/wat.ts
@@ -117,7 +117,7 @@ export function escapeWatString(s: string): string {
 }
 
 /** Emit a WAT text representation of the IR module */
-export function emitWat(mod: WasmModule): string {
+export function emitWat(mod: WasmModule, opts?: { onlyFunctions?: Set<string> }): string {
   const lines: string[] = [];
   const indent = (depth: number) => "  ".repeat(depth);
   const inlineableTypes = computeInlineableTypes(mod);
@@ -197,6 +197,7 @@ export function emitWat(mod: WasmModule): string {
 
   for (let i = 0; i < mod.functions.length; i++) {
     const f = mod.functions[i]!;
+    if (opts?.onlyFunctions && !opts.onlyFunctions.has(f.name)) continue;
     lines.push(formatFunction(f, i + numImportFuncs, mod, inlineableTypes));
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,6 +279,16 @@ export interface ImportPolicy {
 export interface CompileOptions {
   /** Emit WAT debug output (default: true) */
   emitWat?: boolean;
+  /**
+   * Debug-only: when set, WAT emission only formats functions whose Wasm
+   * name is in this set (plus types/imports/globals for context), skipping
+   * the rest. Full-module `emitWat` can throw "Invalid string length" on
+   * very large graphs (multi-thousand-function compileProject outputs);
+   * this lets a caller recover just the function(s) it actually needs to
+   * inspect (e.g. the one named in a WebAssembly.Module() validation
+   * error) without paying for or risking the full-module string build.
+   */
+  emitWatOnlyFunctions?: string[];
   /** Module name (for debugging) */
   moduleName?: string;
   /** Generate source map (default: false) */


### PR DESCRIPTION
## Description

`emitWat(mod)` builds an entire module's WAT text as one giant
`lines.join("\n")`. On very large `compileProject` graphs (e.g. ESLint's
`Linter` entry: 4800+ functions, 10.5MB binary) this throws `RangeError:
Invalid string length` — there was no way to recover WAT for even a single
function of interest (e.g. the one named in a `WebAssembly.Module()`
validation error) without the full-module build succeeding first.

This surfaced while diagnosing #3672's ESLint `Linter` compileProject
validation failure — the validator error named one closure function, but
there was no way to dump just that function's WAT to inspect the bad
instruction sequence. That issue's actual blocker (a cross-module
identifier-identity collision between same-named bare identifiers across
the ESLint package graph) was fixed separately by another session; this
tooling addition stands on its own as an independently useful debugging
aid for any future large-graph WAT-inspection need.

- `src/emit/wat.ts` — `emitWat(mod, opts?)` takes an optional
  `{ onlyFunctions?: Set<string> }`; when set, function formatting is
  filtered to just those Wasm names (types/imports/globals still emitted
  for context).
- `src/index.ts` — `CompileOptions.emitWatOnlyFunctions?: string[]`, a
  debug-only knob threaded through to `emitWat`.
- `src/compiler.ts` — `runPipeline` passes `options.emitWatOnlyFunctions`
  through as the `onlyFunctions` set when present.
- `plan/issues/3743-emit-wat-only-functions-debug-dump.md` — new issue
  file tracking this change (with a `loc-budget-allow` grant for the
  +3 LOC in `src/compiler.ts`).

No behavior change when the new option is unset — existing full-module
`emitWat` callers are unaffected.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdciSGoMA9bs8AWhQ1tyPh)_