### PR TITLE
docs(plan): file #3742 — corrupt `log` body blocking the tsc bundle

### DIFF
--- a/plan/issues/3742-tsc-bundle-log-corrupt-body-local-and-func-index.md
+++ b/plan/issues/3742-tsc-bundle-log-corrupt-body-local-and-func-index.md
@@ -1,0 +1,151 @@
+---
+id: 3742
+title: "tsc bundle: `log` emitted with a corrupt body — local index 2 in a 1-slot frame plus an out-of-range callee index (2097200)"
+status: ready
+created: 2026-07-28
+updated: 2026-07-28
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen, emit
+goal: self-hosting-dogfood
+sprint: Backlog
+related: [1058, 1579, 2043]
+labels: [self-host, typescript, codegen, index-shift]
+---
+
+# #3742 — `log` emitted with a corrupt body (bad local index + bad callee index)
+
+## Symptom
+
+Compiling a prefix of TypeScript's shipped `tsc` bundle fails in **binary emit**:
+
+```text
+Binary emit error: RangeError: Codegen error: local index out of range — 2
+(valid: [0, 1)) at function 'log'. This is the late-import index-shift class (#2043):
+a captured index went stale across a deferred flushLateImportShifts/addUnionImports/
+addStringImports shift, or a map lookup failed and baked -1/undefined.
+```
+
+The `#2043` text is the emitter's generic guess for this error family, not a
+confirmed diagnosis — see "What the evidence actually shows" below.
+
+## Reproduction
+
+Bounded and deterministic. The input is a prefix of
+`node_modules/typescript/lib/_tsc.js` (TypeScript 5.9.3) cut at a top-level
+statement boundary:
+
+```ts
+import ts from "typescript";
+import fs from "node:fs";
+import { compileProject } from "../src/index.js";
+
+const src = fs.readFileSync("node_modules/typescript/lib/_tsc.js", "utf8");
+const sf = ts.createSourceFile("f.js", src, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+fs.writeFileSync("/tmp/b148.js", src.slice(0, sf.statements[147].end)); // first 148 statements
+await compileProject("/tmp/b148.js", { allowJs: true });
+```
+
+- **148 statements (68 KB) reproduces. 147 does not.** Bisected.
+- Statement 148 is the `((Debug2) => {` IIFE at `_tsc.js:1212` — TypeScript's
+  `Debug` namespace, which contains the `log` function.
+- Requires the **#3714** `debugger;` fix to be reachable at all; before that,
+  the compile died earlier on `Unsupported statement: LastStatement`.
+
+**Hand-reduction did not reproduce.** Three standalone reductions of the
+namespace/function-merge shape (function reassigned to an object via an IIFE
+argument, with and without the inner IIFE) all compile cleanly. This is
+consistent with the failure needing enough surrounding module context — the
+68 KB slice is currently the smallest known input.
+
+## What the evidence actually shows
+
+Instrumenting `emitBinaryWithSourceMapUnguarded` (`src/emit/binary.ts:508-513`)
+to dump the offending function at emit time:
+
+```text
+name=log  typeIdx=7  params=1  locals=0  maxLocalUsed=2  bodyLen=5
+type  = {kind:"func", params:[{kind:"externref"}], results:[]}
+body  = [ {op:"local.get", index:2},
+          {op:"f64.const", value:3},
+          {op:"call", funcIdx:23},
+          {op:"local.get", index:0},
+          {op:"call", funcIdx:2097200} ]
+```
+
+The source being compiled is:
+
+```js
+function logMessage(level, s) {
+  if (Debug2.loggingHost && shouldLog(level)) { Debug2.loggingHost.log(level, s); }
+}
+function log(s) { logMessage(3 /* Info */, s); }
+Debug2.log = log;
+```
+
+Three separate observations, which together suggest this is **not** simply a
+shifted index:
+
+1. **The body is genuinely `log`'s.** The `f64.const 3` is the
+   `3 /* Info */` argument to `logMessage`. So the body was not swapped in
+   from some other function.
+2. **`local.get 2` cannot be right for this frame.** `log(s)` has 1 parameter
+   and 0 declared locals, and `typeIdx=7` correctly resolves to
+   `func(externref) -> ()`. The signature and the body disagree about the
+   frame size: the body was built expecting **≥3 slots**.
+3. **`call funcIdx=2097200` is wildly out of range** and is the more alarming
+   half. `2097200 = 0x200030`. It does not match any obvious sentinel
+   (`-1`, `undefined`, `2^21 = 2097152` is 48 short). The local-index error is
+   simply the one the validator happens to reach first — fixing only the local
+   indices would leave a garbage callee index behind it.
+
+Only **one** `log`-prefixed function reaches emit at all (`logMessage`,
+`log2`, `_log.log`, `_log.error` etc. are absent), so entry
+reservation/dedup around the merged function-plus-namespace binding is the
+natural place to look first.
+
+## Why the `#2043` attribution is unconfirmed
+
+`failIndex` (`src/emit/binary.ts:221`) hard-codes the late-import-shift
+explanation into every index-range message. That may be right here, but the
+corrupt callee index and the ≥3-slot frame point at least as strongly at the
+**reserved-bodyless-entry** path in `compileStatement`
+(`src/codegen/statements.ts:255-266`, `hasReservedBodylessEntry` /
+`compileNestedFunctionDeclaration(..., { reuseReservedEntry })`), where a body
+can be compiled against one frame/entry and attached to another. Confirm
+before assuming the shift is the cause.
+
+## Suggested next steps
+
+1. Dump the module immediately **before** and **after** each
+   `flushLateImportShifts` / `addUnionImports` / `addStringImports` pass and
+   diff `log`'s body. If the body is already corrupt before any shift, #2043
+   is ruled out and the reserved-entry path is the culprit.
+2. Identify what `funcIdx=2097200` is — a real shifted index, an
+   uninitialized read, or an encoder-side corruption. This is the strongest
+   single lead.
+3. Determine which calling convention produced a ≥3-slot frame for a 1-param
+   function (closure `env` + `this` prepended is the obvious candidate) and
+   why the registered type index describes the plain form.
+
+## Acceptance criteria
+
+- [ ] The 148-statement slice compiles to a **validating** Wasm module.
+- [ ] A regression test pins the shape (ideally a reduced case; the slice
+      itself is too large to commit — a fixture-generating test that slices
+      the installed `typescript` package is acceptable).
+- [ ] No new equivalence or test262 regressions.
+- [ ] If the root cause is *not* the late-import shift, `failIndex`'s
+      hard-coded `#2043` message is amended so it stops mis-attributing this
+      family.
+
+## Context
+
+Found while measuring how far the compiler gets on the `typescript` npm
+package (#1058 self-host stress test, #1579 Tier-0 survey). Walls cleared so
+far on that path: the TS2345 JS-default-inferred-param false positive
+(#3695), and `debugger;` as an unsupported statement (#3714). This is the
+next one.


### PR DESCRIPTION
## Description

Files **#3742**, the next wall on the `typescript` npm package path (#1058 / #1579), reached once #3714 cleared `debugger;`. Docs-only — one new issue file, no source changes.

The point of the issue is that the investigation is already done, so whoever picks it up does not start from a one-line error string.

### What was found

Compiling a prefix of `_tsc.js` now fails in **binary emit**. Instrumenting the emitter shows:

```text
name=log  typeIdx=7  params=1  locals=0  maxLocalUsed=2
type  = func(externref) -> ()          ← signature is CORRECT
body  = local.get 2                    ← out of range (the reported error)
        f64.const 3                    ← the `3 /* Info */` arg, so this IS log's own body
        call funcIdx=23
        local.get 0
        call funcIdx=2097200           ← out-of-range callee index (0x200030)
```

Three things this establishes:

1. The body genuinely belongs to `log` — it was not swapped in from another function.
2. The signature resolves correctly; the **body** was built expecting a ≥3-slot frame.
3. **The out-of-range callee index is the bigger problem.** The local-index error is just what the validator reaches first — fixing only the local indices would leave a corrupt `call` behind it.

### Reproduction

Bisected to a bounded input: **148 statements / 68 KB** of `_tsc.js` fails, **147 passes**. Statement 148 is the `((Debug2) => {` IIFE at `_tsc.js:1212` (TypeScript's `Debug` namespace).

A negative result is recorded too: three hand-reductions of the namespace/function-merge shape **do not** reproduce, so the 68 KB slice is currently the smallest known input and nobody needs to repeat that attempt.

### One thing worth flagging beyond this issue

`failIndex` (`src/emit/binary.ts:221`) **hard-codes** the "late-import index-shift class (#2043)" explanation into *every* index-range message, regardless of cause. That attribution may be wrong here — the corrupt callee index and the frame-size mismatch point at least as strongly at the reserved-bodyless-entry path in `compileStatement` (`src/codegen/statements.ts`, `hasReservedBodylessEntry` / `reuseReservedEntry`).

The issue records this as **unconfirmed** rather than repeating it as fact, and makes "amend the message if the shift is ruled out" an acceptance criterion — otherwise the misattribution will keep sending investigators down the wrong path.

### Housekeeping

- Issue id allocated via `node scripts/claim-issue.mjs --allocate` (reserved #3742), not hand-picked.
- The allocator warned that its **open-PR scan failed** (`gh` unauthenticated in this container), so it allocated against `main` ∪ reservations only. `check:issue-ids:against-main` passes; the `check-issue-ids --against-open-prs` CI gate is the backstop for an in-flight collision.
- `status: ready`, `sprint: Backlog` — deliberately not `sprint: current`, since scheduling it into the live TaskList is a tech-lead/PO call, not mine.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: this is an attestation for a human contributor to make, not an agent. The template notes internal/org-member PRs skip the CLA check automatically. -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kEqkoB4FKKtW3q9G6zFoY

---
_Generated by [Claude Code](https://claude.ai/code/session_014kEqkoB4FKKtW3q9G6zFoY)_