### PR TITLE
Document #3741: IR path lacks legacy's i32-coerced-local promotion

### DIFF
--- a/plan/issues/3741-i32-loop-accumulator-ir-inference.md
+++ b/plan/issues/3741-i32-loop-accumulator-ir-inference.md
@@ -1,0 +1,247 @@
+---
+id: 3741
+title: "IR path has no equivalent to legacy's #1120 i32-coerced-local promotion — loop.ts benchmark accumulator pattern still 16x slower under IR than legacy"
+status: ready
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+priority: medium
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: performance
+area: ir
+language_feature: bitwise-operators
+goal: performance
+depends_on: []
+related: [3707, 3733, 3734, 3739]
+---
+
+# #3741 — IR path lacks legacy's i32-coerced-local promotion (no-box i32 loop accumulators)
+
+## Context
+
+Follow-up to #3739 (ToInt32 bit-manipulation rewrite, merged as #3713). After
+that fix, the landing-page `loop.ts` benchmark (`let s = 0; for (let i = 0; i
+< 1000000; i++) s = (s + i) | 0;`) improved ~2x (17.3ms → ~6.6ms per call in
+local sandbox measurement) but still doesn't approach the speed of a pure-i32
+loop. Investigating why led to a much bigger finding.
+
+## The finding
+
+Compiling the exact same source with `experimentalIR: false` (forcing the
+**legacy** AST-direct codegen path) produces:
+
+```wat
+(func $run (result f64)
+  (local $s i32)
+  (local $i i32)
+  i32.const 0
+  local.set 0
+  i32.const 0
+  local.set 1
+  (block (loop
+    local.get 1
+    i32.const 1000000
+    i32.lt_s
+    i32.eqz
+    br_if 1
+    (block local.get 0 local.get 1 i32.add local.set 0)
+    local.get 1 i32.const 1 i32.add local.set 1
+    br 0
+  ))
+  local.get 0
+  f64.convert_i32_s
+  return
+)
+```
+
+Zero ToInt32 calls, zero float arithmetic in the loop body — pure `i32.add`
+and `i32.lt_s`. Benchmarked directly: **legacy 0.41ms vs IR 6.6ms — a 16x
+gap**, far larger than what #3739's ToInt32 fix alone can close. The
+`loop.ts` benchmark compiles through the **IR path** by default (confirmed
+via `.wat` local-naming and via the presence of #3739's `$js_bitwise_i64_*`
+scratch locals, which only exist in `src/ir/lower.ts`'s `emitJsToInt32`
+Instr[] fast path) — so IR-compiled code never gets this optimization.
+
+**Root cause**: legacy has a dedicated, already-shipped, already-hardened
+analysis — `collectI32CoercedLocals` (#1120, refined by #1236) in
+`src/codegen/function-body.ts:182-603` — that proves a `let`/`const` local is
+always int32-range (every write is bitwise-coerced, e.g. `x = (x + y) | 0`,
+or is an in-range integer literal) and promotes its Wasm storage from f64 to
+native i32. A sibling analysis, `detectI32LoopVar` in
+`src/codegen/statements/loop-analysis.ts:20-78`, does the same for the
+canonical `for (let i = INT; i < …; i++)` counter shape. **Neither has an IR
+equivalent.** `src/ir/from-ast.ts`'s `lowerVarDecl` (~line 2202) hardcodes
+`irVal({kind:"f64"})` as the default hint for any un-annotated `number`
+local, and IR's selector (`src/ir/select.ts`'s `isPhase1TypeNode`) actively
+*rejects* an explicit `: i32` type-alias annotation from IR eligibility
+(demotes the whole function to legacy) — so today an i32-accumulator loop
+inside an otherwise-IR-eligible function simply never gets the promotion
+either way.
+
+This is **not** a duplicate of `src/ir/propagate.ts` (#1131 Phase 2's lattice
+type-propagation system) — that module infers param/return types for
+*unannotated* functions so they can become IR-eligible at all (e.g. proving
+`function fib(n) {...}` is `(number) -> number`). It doesn't touch local
+no-box storage representation within an already-eligible function's body,
+which is the problem here.
+
+## What was attempted (reverted — not committed, see below)
+
+A first implementation attempt threaded a new `i32CoercedLocals:
+ReadonlySet<string>` through `LowerCtx` (mirroring the existing
+`mutatedLets` field/pattern exactly), computed once per function via the
+**unmodified, reused** legacy `collectI32CoercedLocals(fn)` — zero duplicated
+analysis logic, matching the precedent already set by #2766's reuse of
+`isIncreasingStep`/`loopBodyMutatesIndexOrArray` from the same
+`loop-analysis.ts` module. Four small, targeted edits made the exact
+benchmark loop compile with i32 `s`/`i` locals:
+
+1. **`lowerVarDecl`** (`from-ast.ts:~2222`): when no more-specific hint
+   applies (no explicit annotation, no empty-array inference, no module
+   binding), check `cx.i32CoercedLocals.has(name)` (regular locals) or
+   `detectI32LoopVar(d.parent.parent)` (for-loop counters, found via
+   `d.parent` = `VariableDeclarationList`, `.parent.parent` = the enclosing
+   `ForStatement` when the declaration is a for-loop's init clause) and hint
+   `i32` instead of defaulting to `f64`.
+2. **`lowerExpr`'s numeric-literal case** (`from-ast.ts:~2704`): this
+   hardcoded `f64.const` regardless of the `hint` parameter — the injection
+   point above was inert without this. Fixed to emit `i32.const` when the
+   hint is i32 AND the literal is an in-range integer (mirrors
+   `collectI32CoercedLocals`'s own `isI32SafeExpr` range check); any
+   out-of-range/fractional literal against an i32 hint still falls through
+   to f64, surfacing as a clean mismatch at the hint's consumption site
+   rather than silently miscompiling.
+3. **General binary-op operand lowering** (`from-ast.ts`'s `lowerBinary`,
+   ~line 7756): both operands were unconditionally hinted f64. Changed to
+   lower LHS first, inspect its resolved type, and hint RHS as i32 when LHS
+   resolved to i32 — makes `i < 1000000` (i32 loop counter vs literal) lower
+   both sides consistently. Confirmed this dual-i32 path is genuinely
+   supported for **comparisons and bitwise ops** (`lowerBinary` already has
+   `if (!isF64 && !isI32) requireF64(...)` gates for `<`/`<=`/`>`/`>=` and
+   `&`/`|`/`^`/`<<`/`>>`/`>>>`).
+4. **`coerceReturnValue`** (`from-ast.ts:~5831`): found and fixed a real
+   latent bug this surfaced — a promoted i32 local returned into a declared
+   `f64` result was never widened. The function's own comment ("native
+   scalar returns already line up via the hint") was an invariant that held
+   *only* because no un-annotated local could previously resolve to
+   anything but f64; #3741 breaks that invariant. Fixed by reusing the
+   existing `coerceIrNumeric` helper (already used elsewhere for exactly
+   this i32→f64 widen, `f64.convert_i32_s`) instead of the unconditional
+   pass-through.
+
+**This much was tested clean**: full `tests/equivalence/ts-wasm-equivalence.test.ts`
+(29 tests), `tests/ir-propagate-i32.test.ts` (32 tests), and
+`tests/ir-let-const-equivalence.test.ts` (12 tests, including the exact
+`const y = 1; return y;` case that exposed the return-coercion gap) all
+passed after all four fixes above.
+
+### Why it was reverted anyway
+
+A broader sweep (`tests/ir-algorithms-cluster.test.ts`,
+`tests/ir-vec-new-fixed.test.ts`, plus 8 other `tests/ir-*.test.ts` files)
+surfaced **13 new failures** (verified via `git stash` A/B against the same
+suite on unmodified `main` — baseline has exactly 5 pre-existing, unrelated
+failures; with the WIP diff applied it was 18). All 13 new failures are
+`i32CoercedLocals`/`detectI32LoopVar` promoting a loop counter or
+accumulator that ANOTHER, not-yet-audited consumption site still assumes is
+f64 — the exact same class of bug `coerceReturnValue` had, recurring at
+other call sites this session didn't reach:
+
+- `#2856 C1` — early value return from inside a while/for loop
+- `#2856 C2` — `arr[i] = v` element stores (in-place swap / growing store)
+- `#2856 C3` — module-scope Map storage-slot type tracking (mixed IR-writer
+  / legacy-reader)
+- `#2856 C4` — constructed-vec reads inside for/while bodies, nested
+  loops+do-while
+- `#2856` whole-component claim tracking (`algorithms.ts`, "zero demotions")
+- `#1804 (6e)/(6f)` — vec reads inside while/for loops (`Phase 1 requires
+  matching operand types for '<'` — the SAME comparison-operand-hint gap
+  fixed for the benchmark's own condition, recurring in a different
+  loop/array-index pairing my LHS-drives-RHS fix didn't cover)
+
+This confirms the "hint is advisory; an already-lowered value's ACTUAL type
+just passes through unconverted at each consumption site" pattern is used
+pervasively across `from-ast.ts` (array indexing, closures/captures, Map
+storage slots, and almost certainly more not yet exercised by any existing
+test) — not just at the 4 sites patched above. Promoting a local's `IrType`
+from f64 to i32 is therefore not a locally-contained change; it's a
+cross-cutting change to a ~9,000-line file whose full consumption-site
+surface isn't enumerable without a systematic audit (grep every
+`cx.builder.typeOf`/type-equality check against an assumed-f64 local, or add
+a debug assertion that fires on any i32-vs-f64 mismatch and run the full
+suite to enumerate hits).
+
+Given the correctness stakes (a wrong answer, not a crash — exactly the
+class of bug #1236 already burned the codebase on once) and that this is a
+widely-shared, foundational dispatch file, continuing to patch failures
+one-by-one without that systematic audit was judged too risky to land in
+one session. **The IR edits were reverted; nothing from this attempt is
+committed.** The 4-point sequence above is preserved here as a validated
+starting point for whoever picks this up next — re-applying it should
+reproduce the same 13 failures immediately as a checklist, not a surprise.
+
+## A harder blocker found independently: `+`/`-`/`*` are deliberately f64-only in IR
+
+Even with every consumption-site gap above fixed, `s + i` itself cannot
+compute as native `i32.add` through the *general* binary-op path: IR's
+`lowerBinary` unconditionally calls `requireF64(isF64, "+", ...)` for
+`+`/`-`/`*` (`from-ast.ts:~7910/7915/7920`) — comparisons and bitwise ops
+already have an `if (!isF64 && !isI32) requireF64(...)` escape hatch, but
+arithmetic does not. This is not an oversight: it's the IR-level analogue of
+legacy's own #1236 guard (`collectI32CoercedLocals`'s `isI32SafeExpr`
+explicitly excludes `+`/`-`/`*` from the safe-to-promote set, with a
+detailed comment on why — raw i32 arithmetic on i32-safe operands can still
+be wrong if the *sum itself* isn't immediately re-truncated, because Wasm
+`i32.add` wraps while a plain `f64.add` widens without truncating).
+
+For the specific pattern that matters (`(a + b) | 0` or similar — a bitwise
+wrapper immediately following the arithmetic), native `i32.add` IS
+bit-exact equivalent to `ToInt32(f64_add(a, b))` when `a`/`b` are already
+int32-range (two's-complement wraparound addition and `(a+b) mod 2^32`
+signed-reinterpreted are the same operation) — this is exactly what
+legacy's own codegen does (confirmed: legacy's `.wat` output above never
+computes `s + i` as a standalone f64 op at all; the `|0` wrapper's codegen
+recognizes both operands are i32 and emits `i32.add` directly, never
+exposing bare i32 arithmetic as a general capability).
+
+**Recommendation for a future attempt**: don't extend the general `+`/`-`/`*`
+lowering to accept i32 operands (reopens the #1236 risk broadly). Instead,
+add a narrowly-scoped **fused pattern** — recognize `(expr op expr) | 0` (or
+`^0`, or other bitwise-wrapping context) at the bitwise-operator lowering
+site specifically, and when the inner arithmetic's operands are BOTH already
+i32-typed, emit `i32.add`/`i32.sub`/`i32.mul` directly for that fused unit
+only — never as a standalone, generally-reachable i32 arithmetic op. This
+mirrors the existing #3733 `x | 0` identity fast path (already special-cases
+the immediate operand of `|0`) one level deeper.
+
+## Recommended alternative strategy for a future session
+
+Given the consumption-site blast radius, retyping a local's *global*
+`IrType` (visible to every consumer in the function) is the wrong lever.
+Consider instead a **scoped shadow representation**: keep the local's
+`IrType` as f64 everywhere (unchanged for every existing consumer — return,
+array stores, Map slots, closures, all keep working exactly as today), and
+only within a provably self-contained hot region (a `for`/`while` loop body
+where the accumulator is written exclusively via the bitwise-wrapped pattern
+and never escapes to a call/closure/property-store mid-loop) maintain an
+*additional*, loop-scoped i32 shadow slot — converting f64↔i32 exactly once
+at loop entry and loop exit, never changing what any other part of the
+function sees. This is architecturally closer to a register-allocator
+"rematerialize as i32 for this region" optimization than a type-system
+change, and would avoid resurrecting the cross-cutting consumption-site
+audit entirely — at the cost of needing a new "does this variable escape
+the loop" analysis (a smaller, more contained problem than auditing every
+existing IR consumer).
+
+## Out of scope / follow-ups
+
+- The Porffor backend (separate value representation, no i64/i32 native
+  arithmetic support per #3739's investigation) — not applicable to this
+  local-storage question either way.
+- `array.ts`'s `__vec_push` dispatch overhead — tracked in #3734, unrelated.
+- A systematic audit of every `from-ast.ts` consumption site that currently
+  assumes "un-annotated locals are always f64" — needed regardless of which
+  strategy (global retype vs. scoped shadow) a future attempt takes, unless
+  the scoped-shadow strategy above sidesteps it entirely by construction.


### PR DESCRIPTION
## Description

Docs-only follow-up to #3739/#3713. While investigating why the `loop.ts` landing-page benchmark still doesn't reach native-loop speed after the ToInt32 bit-manipulation fix, found that legacy AST-direct codegen already has a no-box i32 local promotion (`collectI32CoercedLocals`, #1120/#1236) that the IR path has no equivalent of — confirmed via direct A/B compile (`experimentalIR: false` vs default): the exact same benchmark source is **16x faster under legacy (0.41ms) than IR (6.6ms)**.

Attempted a first implementation (threading an `i32CoercedLocals` set through `LowerCtx`, reusing the existing legacy analysis unchanged, plus 3 supporting fixes for numeric-literal hints, comparison-operand hint matching, and a real latent return-coercion bug it surfaced). Got the exact benchmark loop compiling with native i32 locals and passing the equivalence/IR-propagation/let-const test suites — but a broader sweep across `tests/ir-*.test.ts` surfaced **13 new failures** (array element stores, early returns from loops, module-scope Map storage-slot typing, vec reads inside loops) once locals could resolve to i32 instead of always f64. Verified via `git stash` A/B against the same suite that these are new, not pre-existing.

This confirmed the change has a much wider consumption-site blast radius across `from-ast.ts` than the injection points I directly touched — retyping a local's `IrType` is visible everywhere that local is consumed, and "hint is advisory, an already-lowered value's actual type just passes through unconverted" turns out to be a pervasive pattern in this file, not isolated to the sites I found and fixed. Given the correctness stakes (silently wrong values, not crashes — exactly the class of bug #1236 already burned this codebase on once) and that a systematic audit of every consumption site wasn't feasible in one session, **reverted the code change** rather than land it partially verified.

This PR is the issue file only (`plan/issues/3741-i32-loop-accumulator-ir-inference.md`) — it documents: the root cause, the validated 4-point injection sequence (with exact file/line pointers), the 13 known failure sites as a checklist for whoever re-attempts this, an independently-found architectural blocker (IR's `+`/`-`/`*` are deliberately f64-only, mirroring legacy's own #1236 guard — native i32 arithmetic needs a narrowly-scoped `(a+b)|0`-fused pattern, not a general capability), and a recommended alternative strategy (a loop-scoped i32 "shadow" representation instead of a global local retype, to avoid the consumption-site audit entirely).

## Test plan

- No functional code changed — this PR adds only a markdown issue file.
- The investigation itself was tested at each step: `tests/equivalence/ts-wasm-equivalence.test.ts` (29), `tests/ir-propagate-i32.test.ts` (32), and `tests/ir-let-const-equivalence.test.ts` (12) all passed against the WIP implementation before the broader sweep found the 13 new failures documented in the issue.
- `git stash` A/B confirmed the 13 failures are new (baseline has exactly 5 pre-existing, unrelated failures in the same files).

---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_