### PR TITLE
Correct #3734: array.ts slowdown is the IR-vs-legacy gap from #3741, not generic dispatch

### DIFF
--- a/plan/issues/3734-array-push-generic-dispatch-overhead.md
+++ b/plan/issues/3734-array-push-generic-dispatch-overhead.md
@@ -1,6 +1,6 @@
 ---
 id: 3734
-title: "Array.prototype.push on a statically-typed number[] goes through the generic externref __vec_push dispatcher instead of a monomorphic fast path"
+title: "array.ts landing-page benchmark: IR compiles .push() to a non-inlined helper call while legacy fully inlines it — same IR-vs-legacy gap as #3739/#3741, not a generic-dispatch problem"
 status: ready
 sprint: Backlog
 created: 2026-07-28
@@ -14,9 +14,9 @@ area: codegen
 language_feature: arrays
 goal: performance
 depends_on: []
-related: [3704, 3733]
+related: [3704, 3733, 3739, 3741]
 ---
-# #3734 — statically-typed `number[]` push routes through the generic `__vec_push` dispatcher
+# #3734 — `array.ts` push loop: IR emits a non-inlined helper call, legacy fully inlines
 
 ## Context
 
@@ -34,7 +34,83 @@ export function bench_array(): number {
 }
 ```
 
-## Findings
+## Original diagnosis (below) was based on the wrong code path — corrected 2026-07-28
+
+The original write-up (kept below for the record) inspected `.wat` output
+and concluded `.push()` on a statically-typed `number[]` was routing through
+the generic, `any`-receiver `__vec_push` dispatcher (externref-boxing +
+`ref.test` chain, `src/codegen/expressions/call-receiver-method.ts` lines
+~3298-3406, the "#2784 S3 Native-vec-aware method dispatch" block). **That
+block only fires for `any`/externref receivers whose concrete vec type is
+NOT statically known** (its own comment: "a reconstructed-fnctor `T[]` field
+read as externref"). `arr: number[]` in the benchmark has a statically known
+type, so it **never reaches that dispatcher at all** — the original
+diagnosis inspected the wrong branch.
+
+### What's actually happening
+
+Direct investigation (compiling the exact benchmark source and comparing
+`experimentalIR: false` vs the default IR path — the same method used for
+#3739/#3741) found this is **the same "IR path lacks legacy's optimization"
+gap already documented in #3741**, just showing up on `.push()`/array
+codegen instead of ToInt32/loop-counters:
+
+- **Legacy already has a fully monomorphic, fully-inlined push fast path**:
+  `compileArrayPush` in `src/codegen/array-methods.ts` (line 2938) — direct
+  `struct.get`/`array.len`/`array.new_default`+`array.copy` (amortized
+  growth)/`array.set`/`struct.set`, zero externref boxing, zero `ref.test`,
+  and (being emitted inline into the caller's body, not a separate function)
+  zero call overhead.
+- **IR lowers `.push()` to a call into a separate, shared helper function**
+  instead: `src/ir/from-ast.ts` (~line 5037, the "#2856 element-store
+  helper" comment) emits `cx.builder.emitCall(irIntrinsicFuncRef("__vec_elem_set_<N>"), [recv, lenI32, val], null)`
+  — reusing the SAME helper plain `arr[i] = v` index-assignment uses. The
+  helper's body (materialized elsewhere) is structurally almost identical to
+  legacy's inline sequence (same growth-check/`array.new_default`/`array.copy`
+  shape) — but it's a genuine `call`, once per `.push()`, 10,000 times in
+  this benchmark, not inlined into the loop body.
+- Measured directly (same source, `-O4` applied both ways, matching the real
+  benchmark's settings): **legacy ~95-140µs, tight; IR ~225-450µs and
+  visibly noisy (some runs spike to 1000-1400µs)**. The noise pattern mirrors
+  the V8-tiering instability documented for `loop.ts` in #3739 — not just
+  raw instruction-count overhead.
+
+### An experiment that only partially worked (not landed)
+
+Tried the cheap, low-risk fix first: raise Binaryen's inlining thresholds
+(`setFlexibleInlineMaxSize`/`setOneCallerInlineMaxSize`/`setAlwaysInlineMaxSize`)
+so `wasm-opt -O4` inlines `__vec_elem_set_<N>` automatically at its (many)
+call sites, no compiler source changes needed. This is safe in principle
+(inlining is semantics-preserving) and would have been a very contained fix
+if it had fully worked. It only helped partially — IR's measured time
+dropped to ~225-500µs but the gap to legacy and the run-to-run noise both
+persisted — meaning the overhead isn't purely "missing inlining"; something
+about the call-boundary/value-shape itself (plausibly the same f64⇄i32
+conversion-at-boundary pattern #3739/#3741 found, or the same tiering
+sensitivity) is also in play. Not committed — reverted after the experiment.
+
+### Point 2 from the original write-up (loop-invariant `arr.length` read) is unaffected by this correction
+
+That observation (the sum loop's `for (i = 0; i < arr.length; i++)`
+re-reading the length field every iteration instead of being hoisted) is
+still accurate and still low-priority/optional — untouched by this
+correction, kept for completeness.
+
+## Recommendation
+
+Don't treat this as an isolated "add a monomorphic push fast path" fix — the
+generic dispatcher it originally blamed isn't involved. This is the same
+underlying architecture gap as #3741 (IR systematically re-derives, via
+non-inlined shared helpers and f64-default representations, work legacy
+already does inline/natively) manifesting on `.push()`/array codegen.
+Whoever picks this up should read #3741 first — the two are almost
+certainly best solved together (or by the same underlying mechanism,
+whatever that turns out to be), not as separate one-off patches per
+benchmark.
+
+---
+
+## Original write-up (2026-07-28, before the above correction)
 
 Compiled (`-O`, JS-host/GC target) and inspected the `.wat`. Two separate
 observations, in order of suspected impact:
@@ -55,18 +131,9 @@ Every `.push()` call site compiles to a call into a single shared
    when capacity is exhausted, `array.set`, length-field bump) for whichever
    branch matched.
 
-For `arr: number[]` the element type (`f64`) and the vec's concrete struct
-type are **both known statically at the call site** — there's no need to
-box to externref or runtime-dispatch at all. A monomorphic fast path could
-compile directly to: `struct.get` (data array + length), the same
-amortized-doubling growth check, `array.set`, length bump — no boxing, no
-`ref.test` chain, likely 1 direct call (or fully inlined) instead of a
-generic multi-way dispatch.
-
-The growth strategy itself (`array.new_default` sized via `max(cap*2, cap+1)`
-+ `array.copy`) looks correct/amortized-O(1) — this is NOT an accidental
-O(n²) push loop. The suspected cost is strictly the per-call polymorphic
-dispatch overhead × 10,000 calls.
+**(Corrected above: this generic dispatcher does not apply to a
+statically-typed `number[]` receiver — this description is accurate for the
+`any`-receiver case only.)**
 
 ### 2. The sum loop re-reads `arr.length` (a `struct.get`) every iteration
 
@@ -80,45 +147,23 @@ though nothing in the loop body can change `arr`'s length. This is a single
 cheap instruction per iteration (not a call), so likely much smaller impact
 than #1 — flagged for completeness, lower priority than the push dispatch.
 
-## Suggested approach
-
-1. **Triage first**: measure the two effects independently (e.g. a
-   standalone micro-benchmark that isolates just the push loop vs just the
-   sum loop) to confirm #1 dominates before investing in it — don't assume
-   without measuring.
-2. For #1: add a codegen fast path for `.push()` (and likely the sibling
-   `.pop()`/direct-index-write cases already handled elsewhere) when the
-   receiver's array element type is statically known at the call site,
-   bypassing `__vec_push`'s externref-boxing + `ref.test` dispatch chain
-   entirely — emit the growth-check + `array.set` + length-bump sequence
-   inline (matching the pattern `__vec_push` already implements for its
-   matched arm), or a per-element-type monomorphic helper the call site
-   dispatches to directly by static type instead of by runtime `ref.test`.
-3. For #2 (much smaller / optional): consider a loop-invariant-length-read
-   optimization for the common `for (i = 0; i < arr.length; i++)` shape when
-   the loop body is provably non-mutating of `arr`'s length — likely a
-   peephole/LICM-style pass rather than a special case, and correctness-sensitive
-   (must not hoist across any mutation, including via aliasing/closures)
-   enough that it may not be worth the risk relative to its small payoff.
-
 ## Acceptance criteria
 
-- [ ] Confirm via isolated micro-benchmarks which of the two effects (or
-      both) actually dominates the measured slowdown before implementing.
-- [ ] `.push()` on a statically-known-element-type array no longer routes
-      through externref-boxing + `ref.test` dispatch.
+- [ ] Read #3741 first — this is very likely the same root cause / same fix.
+- [ ] `array.ts`'s IR-compiled `.push()` loop matches (or comes close to)
+      legacy's speed for the same source, under the same `-O4` settings the
+      real landing-page benchmark uses.
 - [ ] Equivalence tests pass, including polymorphic/`any`-typed array push
-      call sites (must still work — this is an *additional* fast path, not
-      a replacement for the generic dispatcher, which any-typed/mixed arrays
-      still need).
+      call sites and the existing #2856 element-store IR tests (must still
+      work — any fix here must not regress the shared `__vec_elem_set_<N>`
+      helper's other caller, plain `arr[i] = v`).
 - [ ] Re-run the playground benchmark generator and confirm `array.ts`'s
-      wasm time improves materially.
+      wasm time improves materially and stops being noisy (check std-dev,
+      not just mean — the noise itself is diagnostic).
 
 ## Out of scope
 
-- This issue is analysis + a suggested approach, not a landed fix — the
-  push-dispatch fast path is a genuine codegen feature addition (new
-  monomorphic emission path + call-site type-based selection), non-trivial
-  and regression-risky enough that it should get its own dedicated
-  implementation + review pass rather than being rushed alongside #3733's
-  narrower ToInt32 fix.
+- This issue is analysis, not a landed fix — regression-risky enough
+  (touches IR call-lowering / shared helper emission) that it should get
+  its own dedicated implementation + review pass, very likely combined with
+  #3741 rather than attempted separately.


### PR DESCRIPTION
## Description

Docs-only correction to #3734. That issue blamed the landing-page `array.ts` benchmark's slowdown on the generic externref `__vec_push` dispatcher (the `any`-receiver `ref.test`-chain path in `call-receiver-method.ts`). That diagnosis inspected the wrong code path: that dispatcher only fires for receivers whose concrete vec type isn't statically known — `arr: number[]` never reaches it.

Investigated directly (same method used for #3739/#3741 — compile with `experimentalIR: false` vs the default IR path, compare `.wat` and measured timing):

- Legacy already has a fully monomorphic, fully-**inlined** push fast path (`compileArrayPush` in `array-methods.ts`) — no boxing, no `ref.test`, no call overhead at all.
- IR lowers `.push()` to a `call` into a separate, shared, non-inlined helper (`__vec_elem_set_<N>`, also used by plain `arr[i] = v`).
- Measured with `-O4` (matching the real benchmark settings): legacy ~100µs tight; IR ~225-450µs and visibly noisy (spikes to 1000µs+) — the noise pattern mirrors the same V8-tiering instability #3739 found for `loop.ts`.
- Tried the cheap fix first: raising Binaryen's inlining thresholds so `wasm-opt` auto-inlines the helper. Only partially helped — didn't close the gap or remove the noise, so it isn't purely a missing-inlining problem. Not landed, reverted after the experiment.

This is the same underlying "IR path lacks legacy's optimizations for hot numeric/array loops" gap already documented in #3741, not an isolated push-dispatch fix — corrected the issue file to point whoever picks it up at #3741 first rather than re-deriving a narrower, already-wrong-premised fix.

## Test plan

- No functional code changed — this PR updates only the `plan/issues/3734-*.md` markdown file (keeps the original write-up inline, marked as corrected, for the historical record).
- The investigation was verified locally: `experimentalIR: false` vs default timing comparison under `-O4`, and a Binaryen inlining-threshold experiment (reverted, not part of this PR's diff).

---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_