### PR TITLE
fix(bench): call %PrepareFunctionForOptimization before %OptimizeFunctionOnNextCall

### DIFF
--- a/scripts/generate-playground-benchmark-sidebar.mjs
+++ b/scripts/generate-playground-benchmark-sidebar.mjs
@@ -82,19 +82,12 @@ const BENCHMARKS = [
 //                               `--always-turbofan`.
 //   --no-concurrent-recompilation
 //                               forces TurboFan compilation onto the main
-//                               thread instead of a background thread. CI's
-//                               Node v26 V8 build hit a fatal internal
-//                               assertion ("Check failed:
-//                               CheckMarkedForManualOptimization") when
-//                               `%OptimizeFunctionOnNextCall` raced a
-//                               concurrent background recompile job V8 had
-//                               already queued on its own for a hot,
-//                               deeply-recursive function (fib.ts's `fib`
-//                               calling itself ~2.7M times before the
-//                               benchmark's own outer call completes) --
-//                               didn't reproduce locally (older V8), but this
-//                               flag removes the race entirely rather than
-//                               chasing a version-specific timing window.
+//                               thread instead of a background thread —
+//                               defense-in-depth for determinism (no
+//                               background-thread timing variance in when a
+//                               compile actually completes relative to the
+//                               calling code). NOT what fixes the fatal
+//                               crash below; see `buildWarmJsFactorySource`.
 const JS_WARM_FLAGS = ["--allow-natives-syntax", "--no-concurrent-recompilation"];
 
 // V8 startup flag that skips Liftoff (the single-pass Wasm baseline
@@ -122,6 +115,14 @@ function buildJsFactorySource(source, exportName) {
 // run under `--allow-natives-syntax` (JS_WARM_FLAGS), so this is only used
 // for the artifact written for the child process, never for the in-process
 // smoke test (the parent isn't launched with that flag).
+//
+// `%PrepareFunctionForOptimization` MUST be called before
+// `%OptimizeFunctionOnNextCall` — V8's `CanOptimizeFunction` unconditionally
+// CHECKs `ManualOptimizationTable::IsMarkedForManualOptimization` outside
+// fuzzing mode (`src/runtime/runtime-test.cc`) and V8_Fatal()s ("Check
+// failed: CheckMarkedForManualOptimization") if the function was never
+// registered. Omitting this call happened to not crash on this sandbox's
+// older V8 build but reliably crashed CI's Node v26 build on fib.ts.
 function buildWarmJsFactorySource(source, exportName) {
   const transpiled = ts.transpileModule(stripImportsAndExports(source), {
     compilerOptions: {
@@ -129,7 +130,7 @@ function buildWarmJsFactorySource(source, exportName) {
       module: ts.ModuleKind.None,
     },
   }).outputText;
-  return `${transpiled}\n${exportName}();\n%OptimizeFunctionOnNextCall(${exportName});\n${exportName}();\nreturn { ${exportName} };`;
+  return `${transpiled}\n%PrepareFunctionForOptimization(${exportName});\n${exportName}();\n%OptimizeFunctionOnNextCall(${exportName});\n${exportName}();\nreturn { ${exportName} };`;
 }
 
 function median(values) {


### PR DESCRIPTION
## Description

#3730's `--no-concurrent-recompilation` did **not** actually fix the V8 fatal crash on `fib.ts` — confirmed directly: the very next `Refresh Benchmarks` run after #3730 merged hit the identical crash (`Check failed: CheckMarkedForManualOptimization`) with that flag already applied.

Read V8's actual source (`CanOptimizeFunction` in `src/runtime/runtime-test.cc`) to find the real cause: `%OptimizeFunctionOnNextCall` unconditionally `CHECK`s `ManualOptimizationTable::IsMarkedForManualOptimization` outside fuzzing mode, and calls `V8_Fatal()` if the target function was never registered via `%PrepareFunctionForOptimization` first. This has nothing to do with concurrency — the check fires identically whether recompilation is concurrent or synchronous, which is exactly why #3730's flag had no effect. `buildWarmJsFactorySource`'s generated JS (added in #3726) called `%OptimizeFunctionOnNextCall` directly without ever calling `%PrepareFunctionForOptimization` — it happened not to crash on this sandbox's older V8 build, but reliably crashed CI's Node v26 build.

Fixed by adding the required `%PrepareFunctionForOptimization(fn)` call before the existing sequence, matching the mandatory pattern V8's own test suites use everywhere this intrinsic appears. Left `--no-concurrent-recompilation` in place as a harmless determinism defense-in-depth measure, and corrected the code comments to reflect the actual root cause instead of the earlier (wrong) concurrency-race theory.

## Test plan

- Verified locally: full generator run (all 4 benchmarks including `fib.ts`) succeeds end to end.
- `npx biome lint scripts --diagnostic-level=error` — clean.

## CLA

Internal/org-member PR — CLA check is skipped automatically.

- [ ] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_