### PR TITLE
chore(#3756): refresh npm-compat data after #3753 landed, confirm scaling issue unaffected

### DIFF
--- a/benchmarks/results/npm-compat.json
+++ b/benchmarks/results/npm-compat.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-28T12:15:19.610Z",
+  "generatedAt": "2026-07-28T14:37:32.809Z",
   "note": "Only packages with a committed, reproducible tests/dogfood/*-harness.mjs are listed. mustache (#3720), diff (#3721), and dayjs (#3747) were probed ad-hoc and surfaced real bugs but have no committed harness yet.",
   "packages": [
     {
@@ -10,7 +10,7 @@
       "shape": "esm-direct",
       "compile": {
         "success": true,
-        "durationMs": 35218,
+        "durationMs": 28340,
         "errorCount": 0,
         "binaryBytes": 596610,
         "categories": {}
@@ -28,11 +28,11 @@
       },
       "perf": {
         "sampleOp": "parse(own 226KB dist bundle)",
-        "wasmUs": 6746717.585,
-        "nodeUs": 18216.244999994524,
-        "wasmStdUs": 569299.8665617505,
-        "nodeStdUs": 2879.4930425771936,
-        "ratio": 0.002700015936711915,
+        "wasmUs": 6214971.531799994,
+        "nodeUs": 15288.137799990363,
+        "wasmStdUs": 208274.35427490805,
+        "nodeStdUs": 866.406171122399,
+        "ratio": 0.002459888628896515,
         "warmupRounds": 2,
         "measuredRounds": 9
       },
@@ -51,7 +51,7 @@
       "shape": "esm-direct",
       "compile": {
         "success": false,
-        "durationMs": 1669,
+        "durationMs": 1292,
         "errorCount": 64,
         "binaryBytes": 0,
         "categories": {
@@ -109,7 +109,7 @@
       "shape": "esm-driver-epilogue",
       "compile": {
         "success": true,
-        "durationMs": 448,
+        "durationMs": 312,
         "errorCount": 0,
         "binaryBytes": 7905,
         "categories": {}
@@ -126,11 +126,11 @@
       },
       "perf": {
         "sampleOp": "op_mixed_all_kinds",
-        "wasmUs": 38.94746578648218,
-        "nodeUs": 0.19274375354236523,
-        "wasmStdUs": 1.7171935788385917,
-        "nodeStdUs": 0.4884818906367938,
-        "ratio": 0.004948813732811915,
+        "wasmUs": 37.805664478182095,
+        "nodeUs": 0.1818245110123526,
+        "wasmStdUs": 2.312647765992195,
+        "nodeStdUs": 0.008531962475355178,
+        "ratio": 0.0048094515338378665,
         "warmupRounds": 2,
         "measuredRounds": 9
       },
@@ -149,7 +149,7 @@
       "shape": "esm-direct",
       "compile": {
         "success": true,
-        "durationMs": 639,
+        "durationMs": 564,
         "errorCount": 9,
         "binaryBytes": 17569,
         "categories": {
@@ -177,11 +177,11 @@
       },
       "perf": {
         "sampleOp": "parseCookie(8-pair header)",
-        "wasmUs": 436.0232056277044,
-        "nodeUs": 0.8756720779203605,
-        "wasmStdUs": 86.9280083809816,
-        "nodeStdUs": 0.07705462137474296,
-        "ratio": 0.002008315306658351,
+        "wasmUs": 401.9859283054733,
+        "nodeUs": 0.8369040968342297,
+        "wasmStdUs": 46.322671286609484,
+        "nodeStdUs": 0.08388455814051107,
+        "ratio": 0.0020819238632608494,
         "warmupRounds": 2,
         "measuredRounds": 9
       },

--- a/plan/issues/3756-acorn-parse-superlinear-scaling.md
+++ b/plan/issues/3756-acorn-parse-superlinear-scaling.md
@@ -50,6 +50,33 @@ Real-world confirmation: parsing acorn's own actual 226KB
 **~6.7 seconds** compiled vs **~17ms** native — a ≈400x gap, consistent
 with the scaling table's high end.
 
+## Verified against #3753's fix after it landed (2026-07-28)
+
+#3753 (fnctor string-field typing, the "tokenizer axis" constant-factor
+fix referenced below) merged as `loopdive/js2@d4cb839a` shortly after
+this issue was filed. Re-measured on top of it, same methodology
+(calibrated median-of-9 via `scripts/generate-npm-compat-report.mjs`):
+
+| | before #3753 | after #3753 |
+| --- | ---: | ---: |
+| full acorn dist parse, compiled | ~6.75s | ~6.21s |
+| full acorn dist parse, native | ~18.2ms | ~15.3ms |
+| **ratio** | **~370x** | **~407x** |
+
+The ratio did not improve — if anything it's flat/noisy in the same
+range. This is expected, not a sign #3753 didn't work: #3753 fixed a
+per-access constant-factor cost (verified ~8% faster absolute wasm time
+here), but at 226KB of real input the super-linear term this issue
+documents dominates the total so completely that shaving a constant
+factor off is invisible in the ratio. The synthetic repeated-snippet
+scaling table (above) still shows the same shape post-fix — every point
+dropped in absolute time (~30% faster), but the ratio still visibly
+grows with input size (28x at 4.9KB → 336x at 313KB) — confirming the
+scaling problem is untouched and is the dominant cost at real-file
+scale. Do not expect any future constant-factor fix on the "tokenizer
+axis" pattern to move this issue's numbers — only fixing the
+super-linear operation itself will.
+
 ## What's already known (related, but NOT the same finding)
 
 `plan/issues/3739` / the loopdive/js2#3715 PR (fnctor field typing,

--- a/website/public/benchmarks/results/npm-compat.json
+++ b/website/public/benchmarks/results/npm-compat.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-28T12:15:19.610Z",
+  "generatedAt": "2026-07-28T14:37:32.809Z",
   "note": "Only packages with a committed, reproducible tests/dogfood/*-harness.mjs are listed. mustache (#3720), diff (#3721), and dayjs (#3747) were probed ad-hoc and surfaced real bugs but have no committed harness yet.",
   "packages": [
     {
@@ -10,7 +10,7 @@
       "shape": "esm-direct",
       "compile": {
         "success": true,
-        "durationMs": 35218,
+        "durationMs": 28340,
         "errorCount": 0,
         "binaryBytes": 596610,
         "categories": {}
@@ -28,11 +28,11 @@
       },
       "perf": {
         "sampleOp": "parse(own 226KB dist bundle)",
-        "wasmUs": 6746717.585,
-        "nodeUs": 18216.244999994524,
-        "wasmStdUs": 569299.8665617505,
-        "nodeStdUs": 2879.4930425771936,
-        "ratio": 0.002700015936711915,
+        "wasmUs": 6214971.531799994,
+        "nodeUs": 15288.137799990363,
+        "wasmStdUs": 208274.35427490805,
+        "nodeStdUs": 866.406171122399,
+        "ratio": 0.002459888628896515,
         "warmupRounds": 2,
         "measuredRounds": 9
       },
@@ -51,7 +51,7 @@
       "shape": "esm-direct",
       "compile": {
         "success": false,
-        "durationMs": 1669,
+        "durationMs": 1292,
         "errorCount": 64,
         "binaryBytes": 0,
         "categories": {
@@ -109,7 +109,7 @@
       "shape": "esm-driver-epilogue",
       "compile": {
         "success": true,
-        "durationMs": 448,
+        "durationMs": 312,
         "errorCount": 0,
         "binaryBytes": 7905,
         "categories": {}
@@ -126,11 +126,11 @@
       },
       "perf": {
         "sampleOp": "op_mixed_all_kinds",
-        "wasmUs": 38.94746578648218,
-        "nodeUs": 0.19274375354236523,
-        "wasmStdUs": 1.7171935788385917,
-        "nodeStdUs": 0.4884818906367938,
-        "ratio": 0.004948813732811915,
+        "wasmUs": 37.805664478182095,
+        "nodeUs": 0.1818245110123526,
+        "wasmStdUs": 2.312647765992195,
+        "nodeStdUs": 0.008531962475355178,
+        "ratio": 0.0048094515338378665,
         "warmupRounds": 2,
         "measuredRounds": 9
       },
@@ -149,7 +149,7 @@
       "shape": "esm-direct",
       "compile": {
         "success": true,
-        "durationMs": 639,
+        "durationMs": 564,
         "errorCount": 9,
         "binaryBytes": 17569,
         "categories": {
@@ -177,11 +177,11 @@
       },
       "perf": {
         "sampleOp": "parseCookie(8-pair header)",
-        "wasmUs": 436.0232056277044,
-        "nodeUs": 0.8756720779203605,
-        "wasmStdUs": 86.9280083809816,
-        "nodeStdUs": 0.07705462137474296,
-        "ratio": 0.002008315306658351,
+        "wasmUs": 401.9859283054733,
+        "nodeUs": 0.8369040968342297,
+        "wasmStdUs": 46.322671286609484,
+        "nodeStdUs": 0.08388455814051107,
+        "ratio": 0.0020819238632608494,
         "warmupRounds": 2,
         "measuredRounds": 9
       },


### PR DESCRIPTION
## Description

The committed `benchmarks/results/npm-compat.json` was generated at
`2026-07-28T12:15:19Z`, about 24 minutes *before* #3715/#3753 (fnctor
string-field typing — "6.6x on the tokenizer axis") merged as
`d4cb839a`. That fix is exactly the acorn-tokenizer perf work from
earlier in this session, so the published ~370x acorn perf ratio looked
stale/wrong sitting next to a landed perf fix.

Regenerated against current `main` and confirmed directly, rather than
assuming: the ratio is **unchanged** (~407x, within measurement noise)
even though #3753 measurably helped in absolute terms (compiled wasm
time for the full 226KB acorn-self-parse dropped ~8%; `durationMs`
compile times also faster across all 4 packages, consistent with real,
general improvements from that PR). Re-ran the #3756 synthetic scaling
benchmark on top of the fix too: every point is faster in absolute time
post-fix (~30% across the board), but the ratio still visibly **grows**
with input size (28x at 4.9KB → 336x at 313KB) — same shape as before
the fix.

This isn't a contradiction: #3753 fixed a constant-factor cost on a
narrow field-access pattern (verified via a small synthetic
microbenchmark, projected ~9.5x→~1.4x on THAT axis). #3756's
super-linear scaling problem is a different, unfixed issue that only
shows up at real-file scale and completely dominates the total once
the input is large enough — so a genuine, real constant-factor win can
be invisible in the ratio at 226KB while still being a real
improvement in absolute terms.

### Changes

- `benchmarks/results/npm-compat.json` +
  `website/public/benchmarks/results/npm-compat.json` — refreshed data
  (both mirrors, verified identical).
- `plan/issues/3756-acorn-parse-superlinear-scaling.md` — added a
  "Verified against #3753's fix after it landed" section documenting
  this exact before/after comparison, so a future reader doesn't mistake
  the unchanged ratio for a regression or measurement fluke.

## Verification

- `npx tsc --noEmit` clean.
- `check:loc-budget` / `check:func-budget` clean (no `src/` changes).
- `check:issue-ids:against-main` / `check:issue-spec-coverage` clean.
- Confirmed `benchmarks/results/npm-compat.json` and its website mirror
  are byte-identical.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdciSGoMA9bs8AWhQ1tyPh)_