### PR TITLE
fix(#3632): enforce folded eval Script early errors

### DIFF
--- a/src/codegen/expressions/eval-early-errors.ts
+++ b/src/codegen/expressions/eval-early-errors.ts
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Bounded Script early-error validation for statically folded eval bodies
+ * (#3632). The foreign SourceFile has no checker bindings, so this pass covers
+ * only rules whose answer is fully syntactic. Unsupported node kinds remain
+ * the responsibility of eval-inline's conservative dynamic-eval fallback.
+ */
+import { ts } from "../../ts-api.js";
+
+const STRICT_RESERVED_WORDS = new Set([
+  "implements",
+  "interface",
+  "let",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "static",
+  "yield",
+]);
+const STRICT_BINDING_NAMES = new Set(["eval", "arguments"]);
+
+/** Return the first early-error message, or undefined when the body is valid. */
+export function foldedEvalEarlyError(sourceFile: ts.SourceFile, scriptIsStrict: boolean): string | undefined {
+  let error: string | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (error !== undefined) return;
+
+    if (ts.isContinueStatement(node) && !evalContinueTargetExists(node)) {
+      error = node.label
+        ? `Undefined continue target '${node.label.text}' in eval Script`
+        : "Continue statement is not inside an iteration statement in eval Script";
+      return;
+    }
+    if (ts.isBreakStatement(node) && !evalBreakTargetExists(node)) {
+      error = node.label
+        ? `Undefined break target '${node.label.text}' in eval Script`
+        : "Break statement is not inside an iteration or switch statement in eval Script";
+      return;
+    }
+
+    const strict = scriptIsStrict || evalNodeHasStrictScope(node);
+    if (strict) {
+      if (ts.isIdentifier(node)) {
+        if (STRICT_RESERVED_WORDS.has(node.text) && strictReservedIdentifierIsInvalid(node)) {
+          error = `'${node.text}' is reserved in strict eval code`;
+          return;
+        }
+        if (STRICT_BINDING_NAMES.has(node.text) && identifierIsBindingName(node)) {
+          error = `Binding '${node.text}' is not allowed in strict eval code`;
+          return;
+        }
+      }
+
+      if (ts.isBinaryExpression(node) && isAssignmentOperator(node.operatorToken.kind)) {
+        const restricted = restrictedAssignmentTarget(node.left);
+        if (restricted !== undefined) {
+          error = `Assignment to '${restricted}' is not allowed in strict eval code`;
+          return;
+        }
+      }
+
+      if (
+        (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+        (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)
+      ) {
+        const restricted = restrictedAssignmentTarget(node.operand);
+        if (restricted !== undefined) {
+          error = `Update of '${restricted}' is not allowed in strict eval code`;
+          return;
+        }
+      }
+
+      if (isFunctionLikeWithParameters(node)) {
+        const names = new Set<string>();
+        for (const param of node.parameters) {
+          const duplicate = firstDuplicateBindingName(param.name, names);
+          if (duplicate !== undefined) {
+            error = `Duplicate parameter name '${duplicate}' in strict eval code`;
+            return;
+          }
+        }
+      }
+
+      if (ts.isNumericLiteral(node)) {
+        const raw = node.getText(sourceFile);
+        if (/^0[0-9]+$/.test(raw) && !/^0[xXoObB]/.test(raw)) {
+          error = "Legacy octal literals are not allowed in strict eval code";
+          return;
+        }
+      }
+    }
+
+    node.forEachChild(visit);
+  };
+
+  sourceFile.forEachChild(visit);
+  return error;
+}
+
+function evalNodeHasStrictScope(node: ts.Node): boolean {
+  for (let current: ts.Node | undefined = node; current && !ts.isSourceFile(current); current = current.parent) {
+    if (ts.isClassDeclaration(current) || ts.isClassExpression(current)) return true;
+    if (isFunctionLikeWithParameters(current) && current.body && ts.isBlock(current.body)) {
+      if (hasUseStrictDirective(current.body.statements)) return true;
+    }
+  }
+  return false;
+}
+
+function hasUseStrictDirective(statements: readonly ts.Statement[]): boolean {
+  for (const statement of statements) {
+    if (!ts.isExpressionStatement(statement) || !ts.isStringLiteral(statement.expression)) return false;
+    if (statement.expression.text === "use strict") return true;
+  }
+  return false;
+}
+
+function strictReservedIdentifierIsInvalid(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (!parent) return true;
+  if (ts.isPropertyAccessExpression(parent) && parent.name === node) return false;
+  if (
+    (ts.isPropertyAssignment(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isPropertyDeclaration(parent) ||
+      ts.isGetAccessorDeclaration(parent) ||
+      ts.isSetAccessorDeclaration(parent)) &&
+    parent.name === node
+  ) {
+    return false;
+  }
+  if (ts.isLabeledStatement(parent) && parent.label === node) return false;
+  if ((ts.isBreakStatement(parent) || ts.isContinueStatement(parent)) && parent.label === node) return false;
+  return true;
+}
+
+function identifierIsBindingName(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  return Boolean(
+    parent &&
+    ((ts.isVariableDeclaration(parent) && parent.name === node) ||
+      (ts.isParameter(parent) && parent.name === node) ||
+      (ts.isFunctionDeclaration(parent) && parent.name === node) ||
+      (ts.isFunctionExpression(parent) && parent.name === node) ||
+      (ts.isClassDeclaration(parent) && parent.name === node) ||
+      (ts.isClassExpression(parent) && parent.name === node) ||
+      (ts.isBindingElement(parent) && parent.name === node) ||
+      (ts.isCatchClause(parent) && parent.variableDeclaration?.name === node)),
+  );
+}
+
+function firstDuplicateBindingName(name: ts.BindingName, seen: Set<string>): string | undefined {
+  if (ts.isIdentifier(name)) {
+    if (seen.has(name.text)) return name.text;
+    seen.add(name.text);
+    return undefined;
+  }
+  for (const element of name.elements) {
+    if (!ts.isBindingElement(element)) continue;
+    const duplicate = firstDuplicateBindingName(element.name, seen);
+    if (duplicate !== undefined) return duplicate;
+  }
+  return undefined;
+}
+
+function isFunctionLikeWithParameters(
+  node: ts.Node,
+): node is
+  | ts.FunctionDeclaration
+  | ts.FunctionExpression
+  | ts.ArrowFunction
+  | ts.MethodDeclaration
+  | ts.ConstructorDeclaration
+  | ts.GetAccessorDeclaration
+  | ts.SetAccessorDeclaration {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isConstructorDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node)
+  );
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
+}
+
+function restrictedAssignmentTarget(expr: ts.Expression): string | undefined {
+  let target = expr;
+  while (ts.isParenthesizedExpression(target)) target = target.expression;
+  return ts.isIdentifier(target) && STRICT_BINDING_NAMES.has(target.text) ? target.text : undefined;
+}
+
+function isEvalIterationStatement(node: ts.Node): boolean {
+  return (
+    ts.isForStatement(node) ||
+    ts.isForInStatement(node) ||
+    ts.isForOfStatement(node) ||
+    ts.isWhileStatement(node) ||
+    ts.isDoStatement(node)
+  );
+}
+
+function isEvalFunctionBoundary(node: ts.Node): boolean {
+  return isFunctionLikeWithParameters(node) || ts.isClassStaticBlockDeclaration(node);
+}
+
+function labelTargetsIteration(statement: ts.Statement): boolean {
+  let target = statement;
+  while (ts.isLabeledStatement(target)) target = target.statement;
+  return isEvalIterationStatement(target);
+}
+
+function evalContinueTargetExists(node: ts.ContinueStatement): boolean {
+  const label = node.label?.text;
+  for (let current: ts.Node | undefined = node.parent; current && !ts.isSourceFile(current); current = current.parent) {
+    if (isEvalFunctionBoundary(current)) return false;
+    if (label !== undefined) {
+      if (ts.isLabeledStatement(current) && current.label.text === label) {
+        return labelTargetsIteration(current.statement);
+      }
+    } else if (isEvalIterationStatement(current)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function evalBreakTargetExists(node: ts.BreakStatement): boolean {
+  const label = node.label?.text;
+  for (let current: ts.Node | undefined = node.parent; current && !ts.isSourceFile(current); current = current.parent) {
+    if (isEvalFunctionBoundary(current)) return false;
+    if (label !== undefined) {
+      if (ts.isLabeledStatement(current) && current.label.text === label) return true;
+    } else if (isEvalIterationStatement(current) || ts.isSwitchStatement(current)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/codegen/expressions/eval-inline.ts
+++ b/src/codegen/expressions/eval-inline.ts
@@ -33,6 +33,8 @@ import { compileAndEmitToString } from "../coercion-engine.js";
 import { compileStringLiteral } from "../string-ops.js";
 import { emitThrowJsError, noJsHost } from "./helpers.js";
 import { reportError } from "../context/errors.js";
+import { isStrictContext } from "../helpers/is-strict-function.js";
+import { foldedEvalEarlyError } from "./eval-early-errors.js";
 
 /**
  * Synthetic file name for the foreign `SourceFile` an inlined `eval("<literal>")`
@@ -418,10 +420,29 @@ export function tryStaticEvalInline(
   // is an internal field on SourceFile, so access it through a cast.
   const parseDiag = (sf as unknown as { parseDiagnostics?: readonly ts.Diagnostic[] }).parseDiagnostics;
   if (parseDiag && parseDiag.length > 0) {
-    return undefined;
+    emitThrowJsError(ctx, fctx, "SyntaxError", "Invalid eval source");
+    return { kind: "externref" };
   }
 
   const stmts = sf.statements;
+
+  // PerformEval parses the string as a fresh Script and applies that Script's
+  // early errors before executing any statement. The foreign AST splice used
+  // to skip that phase entirely: strict-only names compiled as ordinary
+  // identifiers, and an orphan break/continue acquired the CALLER's loop when
+  // its statements were spliced there. A direct eval also inherits strictness
+  // from its caller; indirect eval does not.
+  //
+  // Keep this deliberately bounded to the rules needed by the folded surface.
+  // Unsupported AST kinds still take allNodesInlineSupported's existing
+  // dynamic-eval fallback below.
+  const bodyIsStrict = evalBodyHasUseStrictDirective(stmts);
+  const evalIsStrict = bodyIsStrict || (allowConstBindings && isStrictContext(expr, ctx.inferModuleStrictArguments));
+  const earlyError = foldedEvalEarlyError(sf, evalIsStrict);
+  if (earlyError !== undefined) {
+    emitThrowJsError(ctx, fctx, "SyntaxError", earlyError);
+    return { kind: "externref" };
+  }
 
   // Empty program — eval returns undefined.
   if (stmts.length === 0) {
@@ -443,7 +464,6 @@ export function tryStaticEvalInline(
   // `eval`/`arguments` throws) that the AST splice does NOT enforce — so
   // function declarations in a strict body keep bailing to the dynamic path
   // (host eval enforces them).  See `allNodesInlineSupported` / #2923 park fix.
-  const bodyIsStrict = evalBodyHasUseStrictDirective(stmts);
   if (!allNodesInlineSupported(sf, bodyIsStrict)) {
     return undefined;
   }

--- a/src/runtime-eval.ts
+++ b/src/runtime-eval.ts
@@ -414,9 +414,11 @@ export function createEvalShim(options: EvalShimOptions = {}): (src: any, isDire
  * uses the SAME machinery as {@link createEvalShim} (js2wasm's own
  * `compileSourceSync`, a fresh child module, `buildImports` auto-fill, and an
  * LRU cache), but instead of evaluating an expression and returning its value,
- * it compiles the body as an EXPORTED function and returns that export directly
- * — a real JS-callable function the PARENT module can invoke (unlike the
- * eval-path's child-module closure, whose type identity the parent can't cast).
+ * it compiles the body as an EXPORTED function and returns a JS-callable wrapper
+ * around that export. The wrapper also unwraps the child's private Wasm
+ * exception tag so user throws retain their JS identity in the parent module
+ * (unlike the eval-path's child-module closure, whose type identity the parent
+ * can't cast).
  *
  * The compiler lowers a dynamic host-mode `new Function` to
  * `__extern_new_function(paramString, bodyString)`, where `paramString` is the
@@ -425,7 +427,7 @@ export function createEvalShim(options: EvalShimOptions = {}): (src: any, isDire
 export function createNewFunctionShim(options: EvalShimOptions = {}): (params: any, body: any) => any {
   const filename = options.filename ?? "__new_function__.js";
   const FN_CACHE_MAX = 256;
-  // key (`${params} ${body}`) → the callable wasm export.
+  // key (`${params} ${body}`) → the callable child-export wrapper.
   const fnCache = new Map<string, Function>();
   const fnNegCache = new Map<string, SyntaxError>();
 
@@ -510,13 +512,40 @@ export function createNewFunctionShim(options: EvalShimOptions = {}): (params: a
       autoSetExports(instance.exports as Record<string, Function>);
     }
 
-    const fn = (instance.exports as Record<string, unknown>).__new_fn;
+    const childExports = instance.exports as Record<string, unknown>;
+    const fn = childExports.__new_fn;
     if (typeof fn !== "function") {
       throw new SyntaxError("new Function: compiled module did not export the constructed function");
     }
+    // A user throw from the child export crosses the JS API boundary as a
+    // WebAssembly.Exception. Re-expose its externref payload so the parent
+    // module observes the original JS value (not the transport envelope).
+    // This matters for folded eval early errors in a constructed function:
+    // `assert.throws(SyntaxError, () => new Function(... )())` must see the
+    // SyntaxError instance carried by the child's `__exn` tag.
+    const callable = function (this: unknown, ...args: unknown[]): unknown {
+      try {
+        return Reflect.apply(fn, this, args);
+      } catch (error) {
+        const WasmException = (WebAssembly as unknown as { Exception?: Function }).Exception;
+        if (typeof WasmException === "function" && error instanceof WasmException) {
+          const tag = childExports.__exn_tag ?? childExports.__tag;
+          if (tag !== undefined) {
+            let payload: unknown;
+            try {
+              payload = (error as { getArg(tag: unknown, index: number): unknown }).getArg(tag, 0);
+            } catch {
+              throw error;
+            }
+            throw payload;
+          }
+        }
+        throw error;
+      }
+    };
     if (fnCache.size >= FN_CACHE_MAX) fnCache.delete(fnCache.keys().next().value!);
-    fnCache.set(key, fn as Function);
-    return fn;
+    fnCache.set(key, callable);
+    return callable;
   };
 }
 

--- a/tests/issue-3632-eval-early-errors.test.ts
+++ b/tests/issue-3632-eval-early-errors.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { createNewFunctionShim } from "../src/runtime-eval.js";
+import { ts } from "../src/ts-api.js";
+import { foldedEvalEarlyError } from "../src/codegen/expressions/eval-early-errors.js";
+
+const LANES = [
+  { name: "host", target: undefined },
+  { name: "standalone", target: "standalone" as const },
+];
+
+async function compileAndRun(
+  source: string,
+  target: "standalone" | undefined,
+  inferModuleStrictArguments = true,
+): Promise<{ imports: string[]; value: number; warnings: string[] }> {
+  const result = await compile(source, {
+    target,
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return {
+    imports: result.imports.map((entry) => `${entry.module}::${entry.name}`),
+    value: (instance.exports as { test(): number }).test(),
+    warnings: result.errors.filter((error) => error.severity === "warning").map((error) => error.message),
+  };
+}
+
+function parsedEval(source: string): ts.SourceFile {
+  return ts.createSourceFile("<eval>.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+}
+
+describe("#3632 folded eval Script early errors", () => {
+  it.each(LANES)(
+    "$name emits catchable SyntaxErrors at the eval call site",
+    { timeout: 30_000 },
+    async ({ target }) => {
+      const result = await compileAndRun(
+        `
+        export function test(): number {
+          let caught = 0;
+          try { eval("'use strict'; var public = 1;"); } catch (e) {
+            if (!(e instanceof SyntaxError)) return -1;
+            caught++;
+          }
+          try { eval("var eval;"); } catch (e) {
+            if (!(e instanceof SyntaxError)) return -2;
+            caught++;
+          }
+          try { eval("'use strict'; arguments = 1;"); } catch (e) {
+            if (!(e instanceof SyntaxError)) return -3;
+            caught++;
+          }
+          try { eval("'use strict'; function f(a, a) {}"); } catch (e) {
+            if (!(e instanceof SyntaxError)) return -4;
+            caught++;
+          }
+          try { eval("'use strict'; var octal = 010;"); } catch (e) {
+            if (!(e instanceof SyntaxError)) return -5;
+            caught++;
+          }
+          OUTER: while (true) {
+            try { eval("break OUTER;"); } catch (e) {
+              if (!(e instanceof SyntaxError)) return -6;
+              caught++;
+            }
+            try { eval("continue OUTER;"); } catch (e) {
+              if (!(e instanceof SyntaxError)) return -7;
+              caught++;
+            }
+            break;
+          }
+          return caught;
+        }
+      `,
+        target,
+      );
+
+      expect(result.value).toBe(7);
+      expect(result.imports.some((name) => /__extern_eval|js2wasm:runtime-eval/.test(name))).toBe(false);
+      expect(result.warnings.some((message) => /dynamic eval is not supported/.test(message))).toBe(false);
+      if (target === "standalone") expect(result.imports).toEqual([]);
+    },
+  );
+
+  it.each(LANES)("$name preserves valid sloppy names and Script-local control targets", async ({ target }) => {
+    const result = await compileAndRun(
+      `
+        export function test(): number {
+          const direct = eval("var public = 1; 3");
+          const indirect = (0, eval)("var public = 2; 4");
+          const loop = eval("while (true) { break; } 5");
+          const labelled = eval("LOCAL: { break LOCAL; } 6");
+          return direct + indirect + loop + labelled;
+        }
+      `,
+      target,
+      false,
+    );
+
+    expect(result.value).toBe(18);
+    expect(result.imports.some((name) => /__extern_eval|js2wasm:runtime-eval/.test(name))).toBe(false);
+    if (target === "standalone") expect(result.imports).toEqual([]);
+  });
+
+  it("preserves the SyntaxError identity across a host new Function child boundary", () => {
+    const fn = createNewFunctionShim()("a", "'use strict'; eval('public = 1;');");
+    expect(() => fn()).toThrow(SyntaxError);
+  });
+
+  it("keeps property names legal while rejecting orphan control statements", () => {
+    expect(foldedEvalEarlyError(parsedEval(`"use strict"; ({ public: 1 }).public;`), true)).toBeUndefined();
+    expect(foldedEvalEarlyError(parsedEval(`LOCAL: while (true) { continue LOCAL; }`), false)).toBeUndefined();
+    expect(foldedEvalEarlyError(parsedEval(`break CALLER;`), false)).toMatch(/Undefined break target/);
+    expect(foldedEvalEarlyError(parsedEval(`continue CALLER;`), false)).toMatch(/Undefined continue target/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3632.

- validate statically folded eval Scripts before lowering for strict
  reserved/binding names, restricted assignments and updates, duplicate strict
  parameters, legacy octals, and Script-local `break`/`continue` targets
- inherit strictness for direct eval while keeping indirect eval independent,
  and emit a catchable `SyntaxError` at the eval call site for both host and
  standalone output
- unwrap a constructed child module's exported Wasm exception tag so the
  original `SyntaxError` identity survives the host `new Function` boundary
- keep completion-value behavior unchanged; #3631 remains separate

## Measured Test262 impact

Maintained authoritative runner, exact 16 ES5 rows listed in the issue,
measured locally against base `08ca0b11` and the candidate. The PR was then
rebased to `c8a4dc14` (the only intervening file change was
`plan/issues/3734-array-push-generic-dispatch-overhead.md`) and the candidate
lanes were rerun at `bcda76cb` with the same results:

| lane | baseline | candidate | actual fail→pass | pass→fail |
| --- | ---: | ---: | ---: | ---: |
| host | 2/16 | **16/16** | **14** | **0** |
| standalone | 2/16 | **15/16** | **13** | **0** |

The standalone residual is
`language/directive-prologue/10.1.1-30-s.js` (fail→fail): it executes direct
eval through the separately linked `new Function` interpreter, outside this
folded-eval slice. Its residual TypeError signature is reported, not counted as
a flip.

## Verification

- `pnpm run typecheck`
- `pnpm vitest run tests/issue-3632-eval-early-errors.test.ts tests/issue-2923-eval-const-broaden.test.ts --reporter=dot`
  — 23/23
- exact 16-row Test262 host lane — 16/16
- exact 16-row canonical standalone provider lane — 15/16, one documented
  fail→fail residual
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- stack-balance fixup gate
- codegen fallback telemetry gate
- test vacuity-shape gate
- `pnpm run check:issue-spec-coverage`

## CLA

- [x] I have read and agree to the CLA
