### PR TITLE
feat(ir): own runtime and intrinsic providers in Program ABI

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -5,12 +5,12 @@ status: in-progress
 assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
-branch: codex/3520-c11-import-callables
-pr: 3679
-last_merged_pr: 3677
+branch: codex/3520-c12-callable-providers
+pr: 3739
+last_merged_pr: 3679
 sprint: current
 created: 2026-07-21
-updated: 2026-07-26
+updated: 2026-07-28
 priority: critical
 horizon: l
 complexity: L
@@ -1585,6 +1585,62 @@ not semantic provider ownership or R1. Dual-mode runtime/intrinsic providers,
 inherited accessors, static and externref/Promise-host support helpers, Program
 ABI type/class-layout entries, exports and remaining alias families, and the
 production `LegacyAbiAdapter` cutover still remain before R2 can start.
+
+### 2026-07-28 runtime/intrinsic callable-provider continuation
+
+The continuation on `codex/3520-c12-callable-providers` moves every
+runtime/intrinsic callable that crosses the WasmGC IR resolver into a
+compilation-wide exact-provider sidecar and the production Program ABI:
+
+- the resolver still performs the existing mode-specific provider selection
+  exactly once, including lazy helper materialization. It immediately captures
+  the selected `Import` or `WasmFunction` object under the structural
+  runtime/intrinsic binding key; later resolutions follow that exact object
+  through live import shifts or stable defined-function handles without
+  consulting `funcMap` or scanning a display name;
+- provider discovery remains lazy, so helper allocation order and the
+  compatibility pipeline's side effects do not move. Planning is delayed until
+  dead-import and type compaction settle. Imports observed only while lowering
+  an IR candidate that later withdraws are discarded with that candidate;
+  retained provider keys are then sorted and assigned deterministic
+  entry-source-owned identities;
+- a provider that points at an already planned import, source body, or support
+  callable becomes an exact ABI alias. Otherwise the lexically first semantic
+  provider for an allocator object owns its locator and any additional
+  runtime/intrinsic identities alias it. One structural provider changing
+  allocator ownership is a typed invariant; and
+- `intrinsic` is now explicit Program ABI callable provenance rather than
+  being collapsed into runtime/import provenance.
+
+Production coverage proves defined `Math_sin` and `__fmod` providers, and the
+dual-mode `__ir_string_compare` binding: host mode aliases the retained
+`env.string_compare` import while native-string mode owns the exact
+`__str_compare` definition. Planner coverage reverses discovery order,
+deliberately relabels references, shifts imports after observation, shares one
+defined object across runtime/intrinsic identities, and rejects provider
+rebinding. A withdrawal regression proves a candidate-only provider import can
+be removed without manufacturing a required ABI entry.
+
+The focused provider matrix passes **6/6**. The sharded #3520 matrix reports
+**247 passing / 1 failing across 43 files**; the sole failure is the existing
+linear inventory-count assertion in
+`issue-3520-context-integration.test.ts`, and an untouched `origin/main`
+control reproduces it exactly. The #2138 multi-source matrix passes **6/6**,
+and the linear/cross-backend/constructor matrix passes **43/43**. Strict
+TypeScript, scoped lint/Prettier, diff, LOC/function budget, dead-export,
+checker-oracle, issue-spec, and fallback gates pass. Hybrid readiness remains
+**31 IR-emitted / 6 typed Unsupported / 0 Invariants across 37 terminal
+units**, with all 37 legacy bodies still emitted. Full equivalence reports
+**1,611 passing / 32 known failing / 0 new regressions**; four baseline rows
+now pass and the shared baseline remains unchanged.
+
+C12 removes the generic runtime/intrinsic resolver's repeated name/index
+ownership, but it does not yet remove the compatibility provider-selection
+step that chooses the first exact object. Inherited accessors, static and
+externref/Promise-host support helpers, Program ABI type/class-layout entries,
+exports and remaining alias families, and production `LegacyAbiAdapter`
+replacement of `funcMap`, `structMap`, module-array, and name scans still
+remain before R1 can close.
 
 ### R1a validation evidence
 

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -13,6 +13,7 @@ import { getOrRegisterVecType, registerNativeStringTypes } from "../registry/typ
 import { nativeLiteralRegExpEngineConfig } from "../regexp-standalone.js";
 import { createFallbackCounts } from "../fallback-telemetry.js";
 import type { ProgramAbiSession } from "../program-abi-session.js";
+import { ProgramAbiCallableProviderRegistry } from "../program-abi-provider-planning.js";
 import type { CodegenContext, CodegenOptions } from "./types.js";
 
 export function createCodegenContext(
@@ -362,6 +363,9 @@ export function createCodegenContext(
     nodeBuiltinGlobals: new Map(),
     jsxRuntime: options?.jsxRuntime,
   };
+  if (programAbiSession) {
+    ctx.programAbiCallableProviders = new ProgramAbiCallableProviderRegistry(programAbiSession, ctx);
+  }
 
   // (#2083) Pre-register the `externref` + `f64` vec struct types up front for
   // type-index stability (every module reserves these slots regardless of

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1052,6 +1052,7 @@ export interface FunctionContext {
 export interface CodegenContext {
   mod: WasmModule;
   programAbiSession?: import("../program-abi-session.js").ProgramAbiSession;
+  programAbiCallableProviders?: import("../program-abi-provider-planning.js").ProgramAbiCallableProviderRegistry;
   checker: ts.TypeChecker;
   /** True when the single-file input is an ECMAScript Module goal. Script-goal
    * module init uses the host global object for top-level `this`; module goal

--- a/src/codegen/program-abi-import-planning.ts
+++ b/src/codegen/program-abi-import-planning.ts
@@ -283,6 +283,7 @@ export function planProgramAbiCallableImports(ctx: CodegenContext): ReadonlyMap<
 export function eliminateDeadImportsAndPlanAbiCallables(ctx: CodegenContext): void {
   eliminateDeadImports(ctx.mod, ctx);
   planProgramAbiCallableImports(ctx);
+  ctx.programAbiCallableProviders?.planRetained();
 }
 
 /**

--- a/src/codegen/program-abi-provider-planning.ts
+++ b/src/codegen/program-abi-provider-planning.ts
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { irCallableBindingKey } from "../ir/callable-bindings.js";
+import { createIrBindingId, type IrBindingId, type IrSourceId } from "../ir/identity.js";
+import { ProgramAbiInvariantError } from "../ir/program-abi.js";
+import type { IrFuncRef } from "../ir/nodes.js";
+import type { FuncTypeDef, Import, WasmFunction, WasmModule } from "../ir/types.js";
+import { definedFuncAt, definedFuncHandleOf, isImportFuncIdx } from "./func-space.js";
+import type { CodegenContext } from "./context/types.js";
+import type { ProgramAbiSession, ProgramAbiSlotLocator } from "./program-abi-session.js";
+import {
+  canonicalProgramAbiCallableTypeContract,
+  cloneProgramAbiCallableTypeContract,
+} from "./program-abi-signatures.js";
+
+const PROGRAM_ABI_PROVIDER_ROLE_ORDINAL = 5;
+
+type ProviderBinding = Extract<IrFuncRef["binding"], { readonly kind: "runtime" | "intrinsic" }>;
+type ProviderLocator =
+  | { readonly kind: "import-function"; readonly value: Import }
+  | { readonly kind: "defined-function"; readonly value: WasmFunction };
+
+interface ObservedProvider {
+  readonly binding: ProviderBinding;
+  readonly structuralReferenceKey: string;
+  readonly locator: ProviderLocator;
+}
+
+function providerError(message: string): ProgramAbiInvariantError {
+  return new ProgramAbiInvariantError("callable-provider-mismatch", message);
+}
+
+function callableLocatorAt(ctx: CodegenContext, index: number): ProviderLocator {
+  if (!Number.isSafeInteger(index) || index < 0) {
+    throw providerError(`callable provider resolved to invalid function index ${index}`);
+  }
+  if (isImportFuncIdx(ctx, index)) {
+    let importIndex = 0;
+    for (const imported of ctx.mod.imports) {
+      if (imported.desc.kind !== "func") continue;
+      if (importIndex++ === index) return Object.freeze({ kind: "import-function", value: imported });
+    }
+  }
+  const defined = definedFuncAt(ctx, index);
+  if (!defined) {
+    throw providerError(
+      `callable provider handle ${index} is outside the current import/definition allocator population`,
+    );
+  }
+  return Object.freeze({ kind: "defined-function", value: defined });
+}
+
+function currentCallableIndex(ctx: CodegenContext, locator: ProviderLocator): number | undefined {
+  let importIndex = 0;
+  for (const imported of ctx.mod.imports) {
+    if (imported.desc.kind !== "func") continue;
+    if (locator.kind === "import-function" && imported === locator.value) return importIndex;
+    importIndex++;
+  }
+  if (locator.kind === "import-function") return undefined;
+  return definedFuncHandleOf(ctx, locator.value);
+}
+
+function callableSignature(module: WasmModule, locator: ProviderLocator): FuncTypeDef {
+  let typeIdx: number;
+  if (locator.kind === "import-function") {
+    if (locator.value.desc.kind !== "func") {
+      throw providerError("import-function provider locator no longer carries a function descriptor");
+    }
+    typeIdx = locator.value.desc.typeIdx;
+  } else {
+    typeIdx = locator.value.typeIdx;
+  }
+  const signature = module.types[typeIdx];
+  if (!signature || signature.kind !== "func") {
+    throw providerError(`${locator.kind} callable provider references non-function or missing type ${String(typeIdx)}`);
+  }
+  return signature;
+}
+
+function canonicalEntrySource(session: ProgramAbiSession): IrSourceId {
+  const entrySources = session.inventory.sources.filter((source) => source.kind === "entry");
+  if (entrySources.length !== 1) {
+    throw new ProgramAbiInvariantError(
+      "unknown-order-anchor",
+      `callable-provider ABI planning requires exactly one canonical entry source, found ${entrySources.length}`,
+    );
+  }
+  return entrySources[0]!.id;
+}
+
+function sameLocator(left: ProviderLocator, right: ProviderLocator): boolean {
+  return left.kind === right.kind && left.value === right.value;
+}
+
+/**
+ * Compilation-wide exact provider sidecar for runtime/intrinsic references.
+ *
+ * Resolution records the allocator object selected by the compatibility
+ * provider layer, not its transient numeric index. Final planning is delayed
+ * until dead-import/type compaction has settled. At that boundary a semantic
+ * provider aliases an already-owned callable locator when possible, otherwise
+ * the lexically first structural provider key becomes the locator owner.
+ */
+export class ProgramAbiCallableProviderRegistry {
+  private readonly observed = new Map<string, ObservedProvider>();
+  private plannedValue: ReadonlyMap<string, IrBindingId> | undefined;
+
+  constructor(
+    readonly session: ProgramAbiSession,
+    readonly ctx: CodegenContext,
+  ) {
+    session.assertModule(ctx.mod);
+  }
+
+  /**
+   * Return the current slot for an already observed provider.
+   *
+   * Exact object lookup follows import shifts without consulting funcMap or
+   * scanning display names. Undefined means this structural provider has not
+   * crossed the compatibility selection boundary yet.
+   */
+  resolveCurrentIndex(ref: IrFuncRef): number | undefined {
+    const binding = this.requireProviderBinding(ref);
+    const structuralReferenceKey = irCallableBindingKey(binding);
+    const observed = this.observed.get(structuralReferenceKey);
+    if (!observed) return undefined;
+    const index = currentCallableIndex(this.ctx, observed.locator);
+    if (index === undefined) {
+      throw providerError(`callable provider ${structuralReferenceKey} lost its exact allocator object`);
+    }
+    return index;
+  }
+
+  /**
+   * Capture one compatibility-selected provider as an exact allocator object.
+   *
+   * Repeated observations must resolve the same structural binding to the same
+   * object. Compatibility labels are deliberately excluded from the key.
+   */
+  observe(ref: IrFuncRef, index: number): number {
+    if (this.plannedValue) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        `cannot observe callable provider ${ref.name} after provider ABI planning`,
+      );
+    }
+    const binding = this.requireProviderBinding(ref);
+    const structuralReferenceKey = irCallableBindingKey(binding);
+    const locator = callableLocatorAt(this.ctx, index);
+    const existing = this.observed.get(structuralReferenceKey);
+    if (existing && !sameLocator(existing.locator, locator)) {
+      throw providerError(
+        `callable provider ${structuralReferenceKey} changed allocator ownership between resolutions`,
+      );
+    }
+    if (!existing) {
+      this.observed.set(
+        structuralReferenceKey,
+        Object.freeze({
+          binding: Object.freeze({ ...binding }),
+          structuralReferenceKey,
+          locator,
+        }),
+      );
+    }
+    return this.resolveCurrentIndex(ref)!;
+  }
+
+  /**
+   * Plan every observed provider against the settled post-DCE module layout.
+   *
+   * Existing import/source/support locator owners remain canonical. Otherwise
+   * one deterministic provider entry owns the object and any additional
+   * semantic bindings become exact callable aliases.
+   */
+  planRetained(): ReadonlyMap<string, IrBindingId> {
+    if (this.plannedValue) return this.plannedValue;
+    const entrySourceId = canonicalEntrySource(this.session);
+    const entries = [...this.observed.values()]
+      .filter((provider) => {
+        if (currentCallableIndex(this.ctx, provider.locator) !== undefined) return true;
+        // Resolver observation precedes the ABI-parity withdrawal boundary.
+        // When a candidate falls back, DCE legitimately removes an import
+        // used only by its discarded IR body. That provider never enters the
+        // final ABI. Defined helpers are not eliminated by this pipeline; a
+        // missing definition still means allocator ownership was corrupted.
+        if (provider.locator.kind === "import-function") return false;
+        throw providerError(`callable provider ${provider.structuralReferenceKey} lost its defined allocator object`);
+      })
+      .sort((left, right) =>
+        left.structuralReferenceKey < right.structuralReferenceKey
+          ? -1
+          : left.structuralReferenceKey > right.structuralReferenceKey
+            ? 1
+            : 0,
+      );
+    const planned = new Map<string, IrBindingId>();
+
+    for (let ordinal = 0; ordinal < entries.length; ordinal++) {
+      const provider = entries[ordinal]!;
+      const signature = cloneProgramAbiCallableTypeContract(callableSignature(this.ctx.mod, provider.locator));
+      const bindingId = createIrBindingId({
+        ownerId: entrySourceId,
+        domain: "callable",
+        role: `${provider.binding.kind}-provider`,
+        ordinal,
+      });
+      const canonicalOwner = this.session.locatorBindingId(provider.locator.value);
+      const common = {
+        id: bindingId,
+        structuralOrder: this.session.structuralOrder.forSource(entrySourceId, {
+          domain: "callable" as const,
+          roleOrdinal: PROGRAM_ABI_PROVIDER_ROLE_ORDINAL,
+          derivedOrdinal: ordinal,
+        }),
+        structuralReferenceKey: provider.structuralReferenceKey,
+        displayName: provider.binding.symbol,
+        intent: {
+          kind: "callable" as const,
+          origin: provider.binding.kind,
+          signature: canonicalProgramAbiCallableTypeContract(signature),
+        },
+      };
+      if (canonicalOwner) {
+        this.session.ensurePlan({
+          ...common,
+          slotPolicy: "alias",
+          aliasOf: canonicalOwner,
+        });
+      } else {
+        this.session.ensurePlan({
+          ...common,
+          slotPolicy: "required",
+          slotSpace: "function",
+        });
+        this.session.attachLocator(bindingId, provider.locator as ProgramAbiSlotLocator);
+      }
+      this.session.registerCallableTypeContract(bindingId, signature);
+      this.session.registerStructuralReference(bindingId, provider.structuralReferenceKey);
+      planned.set(provider.structuralReferenceKey, bindingId);
+    }
+
+    this.plannedValue = planned;
+    return planned;
+  }
+
+  private requireProviderBinding(ref: IrFuncRef): ProviderBinding {
+    if (ref.binding.kind !== "runtime" && ref.binding.kind !== "intrinsic") {
+      throw new TypeError("program ABI callable-provider registry requires a runtime or intrinsic reference");
+    }
+    return ref.binding;
+  }
+}

--- a/src/codegen/program-abi-session.ts
+++ b/src/codegen/program-abi-session.ts
@@ -645,6 +645,11 @@ export class ProgramAbiSession {
     return locator !== undefined && (allocatorObject === undefined || locatorObject(locator) === allocatorObject);
   }
 
+  /** Return the canonical ABI binding that already owns an exact allocator object. */
+  locatorBindingId(allocatorObject: object): IrBindingId | undefined {
+    return this.locatorOwners.get(allocatorObject);
+  }
+
   registerStructuralReference(id: IrBindingId, key: string): void {
     this.assertOpen(`register structural reference for ${id}`);
     this.assertStructuralReference(id, key, true);

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -3121,6 +3121,10 @@ function makeResolver(
   // (#2949 slice 3) One dynamic-lowering handle per resolver (undefined =
   // not yet built; null = mode has no dynamic op lowering).
   let dynamicLoweringMemo: IrDynamicLowering | null | undefined;
+  const bindCallableProvider = (ref: IrFuncRef, index: number): number =>
+    ref.binding.kind === "runtime" || ref.binding.kind === "intrinsic"
+      ? (ctx.programAbiCallableProviders?.observe(ref, index) ?? index)
+      : index;
   return {
     resolveFunc(ref: IrFuncRef): number {
       if (process.env.JS2WASM_TEST_INJECT_IR_RESOLVER_FAILURE === "function") {
@@ -3188,13 +3192,19 @@ function makeResolver(
           `ir/integration: exact function import ${ref.binding.module}.${ref.binding.field} lost its allocator object`,
         );
       }
+      if (ref.binding.kind === "runtime" || ref.binding.kind === "intrinsic") {
+        const exactProviderIdx = ctx.programAbiCallableProviders?.resolveCurrentIndex(ref);
+        if (exactProviderIdx !== undefined) return exactProviderIdx;
+      }
       // #2945 — `%` lowers to a call of the Wasm-native exact-fmod helper.
       // Materialize it on demand: `ensureFmod` is idempotent (funcMap-cached)
       // and appends a DEFINED function (never an import), so no existing
       // funcIdx shifts — same append-only discipline as the IR's own closure
       // functions. On-demand keeps the helper out of modules that never use
       // `%` (parity with legacy, which also emits it lazily).
-      if (ref.binding.kind === "intrinsic" && ref.binding.symbol === FMOD_FN) return ensureFmod(ctx);
+      if (ref.binding.kind === "intrinsic" && ref.binding.symbol === FMOD_FN) {
+        return bindCallableProvider(ref, ensureFmod(ctx));
+      }
       // (#2856 C2) `__vec_elem_set_<vecTypeIdx>` — element-store helper with
       // full legacy grow semantics. Materialized on demand, same append-only
       // defined-function discipline as `ensureFmod` (never an import, no
@@ -3205,7 +3215,7 @@ function makeResolver(
         if (helperIdx === null) {
           throw new Error(`ir/integration: cannot materialize ${ref.name} (not a recognisable vec struct)`);
         }
-        return helperIdx;
+        return bindCallableProvider(ref, helperIdx);
       }
       // (#3156) Guarded charCodeAt helpers — materialized on demand, same
       // append-only defined-function discipline as ensureFmod (never an
@@ -3220,14 +3230,14 @@ function makeResolver(
         if (helperIdx === null) {
           throw new Error(`ir/integration: cannot materialize ${ref.name} (wasm:js-string builtins not registered)`);
         }
-        return helperIdx;
+        return bindCallableProvider(ref, helperIdx);
       }
       if (ref.binding.kind === "intrinsic" && ref.binding.symbol === NATIVE_CHARCODEAT_FN) {
         const helperIdx = ensureNativeCharCodeAtHelper(ctx);
         if (helperIdx === null) {
           throw new Error(`ir/integration: cannot materialize ${ref.name} (native-string helpers unavailable)`);
         }
-        return helperIdx;
+        return bindCallableProvider(ref, helperIdx);
       }
       // (#3167) String relational compare helper. Resolve mode-appropriately:
       //   native/WASI → the `__str_compare` defined helper (idempotently
@@ -3247,15 +3257,17 @@ function makeResolver(
           // Re-resolve by name against the post-shift function table (the
           // helper map's captured index can predate later import inserts).
           for (let i = 0; i < ctx.mod.functions.length; i++) {
-            if (ctx.mod.functions[i]!.name === "__str_compare") return ctx.numImportFuncs + i;
+            if (ctx.mod.functions[i]!.name === "__str_compare") {
+              return bindCallableProvider(ref, ctx.numImportFuncs + i);
+            }
           }
-          return helperIdx;
+          return bindCallableProvider(ref, helperIdx);
         }
         const hostIdx = ctx.funcMap.get("string_compare");
         if (hostIdx === undefined) {
           throw new Error(`ir/integration: cannot resolve ${ref.name} (host string_compare import not registered)`);
         }
-        return hostIdx;
+        return bindCallableProvider(ref, hostIdx);
       }
       const adapterName =
         ref.binding.kind === "runtime" || ref.binding.kind === "intrinsic"
@@ -3264,7 +3276,7 @@ function makeResolver(
             ? ref.binding.field
             : ref.name;
       const idx = ctx.funcMap.get(adapterName);
-      if (idx !== undefined) return idx;
+      if (idx !== undefined) return bindCallableProvider(ref, idx);
       // Slice 6 part 4 (#1183): native-string helpers (`__str_charAt`,
       // `__str_concat`, `__str_equals`, `__str_flatten`, etc.) are
       // registered in `ctx.nativeStrHelpers`, not `ctx.funcMap`. The
@@ -3274,14 +3286,14 @@ function makeResolver(
       // `computeStringBackend`'s rationale for the host string ops).
       for (let i = 0; i < ctx.mod.functions.length; i++) {
         if (ctx.mod.functions[i]!.name === adapterName) {
-          return ctx.numImportFuncs + i;
+          return bindCallableProvider(ref, ctx.numImportFuncs + i);
         }
       }
       // Last fallback: the (potentially stale) helpers map. Used when
       // a name doesn't appear in `ctx.mod.functions` because it's a
       // host import rather than a defined helper.
       const helperIdx = ctx.nativeStrHelpers.get(adapterName);
-      if (helperIdx !== undefined) return helperIdx;
+      if (helperIdx !== undefined) return bindCallableProvider(ref, helperIdx);
       throw new IrInvariantError("unknown-function-ref", "lower", `ir/integration: unknown function ref "${ref.name}"`);
     },
     resolveGlobal(ref: IrGlobalRef): number {

--- a/src/ir/program-abi.ts
+++ b/src/ir/program-abi.ts
@@ -38,7 +38,7 @@ export interface ProgramAbiDerivedUnitRecord {
 export type ProgramAbiIntent =
   | {
       readonly kind: "callable";
-      readonly origin: "source" | "import" | "runtime" | "support";
+      readonly origin: "source" | "import" | "runtime" | "intrinsic" | "support";
       readonly signature: ProgramAbiCallableSignature;
       readonly unitId?: IrUnitId;
       readonly classId?: IrClassId;
@@ -198,7 +198,8 @@ export type ProgramAbiInvariantCode =
   | "ambiguous-type-remap"
   | "type-remap-mismatch"
   | "missing-required-locator"
-  | "eliminated-required-locator";
+  | "eliminated-required-locator"
+  | "callable-provider-mismatch";
 
 export class ProgramAbiInvariantError extends Error {
   constructor(

--- a/tests/issue-3520-callable-provider-abi.test.ts
+++ b/tests/issue-3520-callable-provider-abi.test.ts
@@ -1,0 +1,286 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { generateModule } from "../src/codegen/index.js";
+import { planProgramAbiCallableImports } from "../src/codegen/program-abi-import-planning.js";
+import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
+import { irCallableBindingKey, irIntrinsicFuncRef, irRuntimeFuncRef } from "../src/ir/callable-bindings.js";
+import { buildIrUnitInventory } from "../src/ir/identity.js";
+import { IR_STRING_COMPARE_FN } from "../src/ir/from-ast.js";
+import { ProgramAbiInvariantError } from "../src/ir/program-abi.js";
+import {
+  createEmptyModule,
+  type FuncTypeDef,
+  type Import,
+  type WasmFunction,
+  type WasmModule,
+} from "../src/ir/types.js";
+import { ts } from "../src/ts-api.js";
+
+// Register the codegen expression/statement delegates used by generateModule.
+import "../src/codegen/expressions.js";
+
+const F64_TO_F64: FuncTypeDef = {
+  kind: "func",
+  params: [{ kind: "f64" }],
+  results: [{ kind: "f64" }],
+};
+
+function source(fileName = "/repo/entry.ts"): ts.SourceFile {
+  return ts.createSourceFile(fileName, "export function main() {}", ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function fixture(module: WasmModule) {
+  const entryFile = source();
+  const inventory = buildIrUnitInventory([entryFile], { entrySource: entryFile });
+  const session = new ProgramAbiSession(inventory, module);
+  const ctx = createCodegenContext(module, {} as ts.TypeChecker, undefined, session);
+  ctx.numImportFuncs = module.imports.filter((value) => value.desc.kind === "func").length;
+  const providers = ctx.programAbiCallableProviders;
+  if (!providers) throw new Error("missing callable-provider registry");
+  return { ctx, providers, session };
+}
+
+function functionImport(module: string, name: string, typeIdx: number): Import {
+  return { module, name, desc: { kind: "func", typeIdx } };
+}
+
+function definedFunction(name: string, typeIdx: number): WasmFunction {
+  return {
+    name,
+    typeIdx,
+    locals: [],
+    body: [{ op: "f64.const", value: 0 }],
+    exported: false,
+  };
+}
+
+function providerFixture(reverseObservation: boolean) {
+  const module = createEmptyModule();
+  module.types.push(F64_TO_F64);
+  const runtimeImport = functionImport("env", "Math_sin", 0);
+  const intrinsicFunction = definedFunction("__fmod", 0);
+  module.imports.push(runtimeImport);
+  module.functions.push(intrinsicFunction);
+  const { ctx, providers, session } = fixture(module);
+  const runtimeRef = irRuntimeFuncRef("Math_sin", "__misleading_runtime_label");
+  const intrinsicRef = irIntrinsicFuncRef("__fmod", "__misleading_intrinsic_label");
+
+  const observations = reverseObservation
+    ? ([
+        [intrinsicRef, 1],
+        [runtimeRef, 0],
+      ] as const)
+    : ([
+        [runtimeRef, 0],
+        [intrinsicRef, 1],
+      ] as const);
+  for (const [ref, index] of observations) providers.observe(ref, index);
+
+  // Shift every prior function index without touching either provider object.
+  const lateImport = functionImport("late", "before-providers", 0);
+  module.imports.unshift(lateImport);
+  ctx.numImportFuncs++;
+  expect(providers.resolveCurrentIndex(irRuntimeFuncRef("Math_sin", "another-label"))).toBe(1);
+  expect(providers.resolveCurrentIndex(irIntrinsicFuncRef("__fmod", "another-label"))).toBe(2);
+
+  planProgramAbiCallableImports(ctx);
+  const providerIds = providers.planRetained();
+  const publication = session.publish(module);
+  return {
+    intrinsicFunction,
+    intrinsicRef,
+    module,
+    providerIds,
+    publication,
+    runtimeImport,
+    runtimeRef,
+    session,
+  };
+}
+
+describe("#3520 runtime/intrinsic callable-provider Program ABI", () => {
+  it("tracks exact provider objects through shifts and plans deterministic provider identities", () => {
+    const forward = providerFixture(false);
+    const reverse = providerFixture(true);
+    const runtimeKey = irCallableBindingKey(forward.runtimeRef.binding);
+    const intrinsicKey = irCallableBindingKey(forward.intrinsicRef.binding);
+
+    expect([...forward.providerIds]).toEqual([...reverse.providerIds]);
+    expect([...forward.providerIds.keys()]).toEqual([intrinsicKey, runtimeKey].sort());
+
+    const runtimeId = forward.providerIds.get(runtimeKey)!;
+    const intrinsicId = forward.providerIds.get(intrinsicKey)!;
+    expect(runtimeId).not.toBe(intrinsicId);
+    expect(forward.session.getDraft(runtimeId)).toMatchObject({
+      structuralReferenceKey: runtimeKey,
+      displayName: "Math_sin",
+      slotPolicy: "alias",
+      intent: {
+        kind: "callable",
+        origin: "runtime",
+      },
+    });
+    expect(forward.session.getDraft(intrinsicId)).toMatchObject({
+      structuralReferenceKey: intrinsicKey,
+      displayName: "__fmod",
+      slotPolicy: "required",
+      slotSpace: "function",
+      intent: {
+        kind: "callable",
+        origin: "intrinsic",
+      },
+    });
+    expect(forward.session.hasLocator(runtimeId)).toBe(false);
+    expect(forward.session.hasLocator(intrinsicId, forward.intrinsicFunction)).toBe(true);
+    expect(forward.publication.abi.resolveFinalIndex(runtimeId)).toEqual({ space: "function", index: 1 });
+    expect(forward.publication.abi.resolveFinalIndex(intrinsicId)).toEqual({ space: "function", index: 2 });
+    expect(forward.module.imports[1]).toBe(forward.runtimeImport);
+    expect(forward.module.functions[0]).toBe(forward.intrinsicFunction);
+  });
+
+  it("makes one deterministic provider own a shared object and aliases every other semantic binding", () => {
+    const module = createEmptyModule();
+    module.types.push(F64_TO_F64);
+    const shared = definedFunction("shared-provider", 0);
+    module.functions.push(shared);
+    const { providers, session } = fixture(module);
+    const runtimeRef = irRuntimeFuncRef("runtime-shared");
+    const intrinsicRef = irIntrinsicFuncRef("intrinsic-shared");
+
+    providers.observe(runtimeRef, 0);
+    providers.observe(intrinsicRef, 0);
+    const ids = providers.planRetained();
+    const runtimeId = ids.get(irCallableBindingKey(runtimeRef.binding))!;
+    const intrinsicId = ids.get(irCallableBindingKey(intrinsicRef.binding))!;
+    const publication = session.publish(module);
+
+    expect(session.hasLocator(intrinsicId, shared)).toBe(true);
+    expect(session.hasLocator(runtimeId)).toBe(false);
+    expect(publication.abi.canonicalId(runtimeId)).toBe(intrinsicId);
+    expect(publication.abi.resolveFinalIndex(runtimeId)).toEqual({ space: "function", index: 0 });
+    expect(publication.abi.resolveFinalIndex(intrinsicId)).toEqual({ space: "function", index: 0 });
+  });
+
+  it("rejects one structural provider changing allocator ownership", () => {
+    const module = createEmptyModule();
+    module.types.push(F64_TO_F64);
+    module.functions.push(definedFunction("first", 0), definedFunction("second", 0));
+    const { providers } = fixture(module);
+    const ref = irRuntimeFuncRef("provider", "first-label");
+    providers.observe(ref, 0);
+
+    expect(() => providers.observe(irRuntimeFuncRef("provider", "second-label"), 1)).toThrowError(
+      expect.objectContaining<ProgramAbiInvariantError>({ code: "callable-provider-mismatch" }),
+    );
+  });
+
+  it("discards a dead import observed only by an IR candidate that later withdrew", () => {
+    const module = createEmptyModule();
+    module.types.push(F64_TO_F64);
+    module.imports.push(functionImport("env", "__candidate_only", 0));
+    const { ctx, providers, session } = fixture(module);
+    const ref = irRuntimeFuncRef("__candidate_only");
+    providers.observe(ref, 0);
+
+    // Mirror dead-import elimination after the candidate's body is withdrawn:
+    // no final Wasm body refers to this import, so it is absent from the
+    // retained callable population and must not become a required ABI entry.
+    module.imports = [];
+    ctx.numImportFuncs = 0;
+    expect(planProgramAbiCallableImports(ctx).size).toBe(0);
+    expect(providers.planRetained().size).toBe(0);
+    expect(session.publish(module).abi.entries()).toEqual([]);
+  });
+
+  it("publishes production Math and remainder providers without compatibility labels owning their slots", () => {
+    const ast = analyzeSource(
+      `
+        export function main(a: number, b: number): number {
+          return Math.sin(a) + (a % b);
+        }
+      `,
+      "callable-provider-abi.ts",
+    );
+    const result = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+    expect(result.irCompiledFuncs).toContain("main");
+    expect(result.irPostClaimErrors).toEqual([]);
+    expect(result.programAbi).toBeDefined();
+
+    for (const ref of [irRuntimeFuncRef("Math_sin"), irIntrinsicFuncRef("__fmod")]) {
+      const key = irCallableBindingKey(ref.binding);
+      const entries = result.programAbi!.abi.entries().filter((entry) => entry.structuralReferenceKey === key);
+      expect(entries).toHaveLength(1);
+      const entry = entries[0]!;
+      expect(entry).toMatchObject({
+        structuralReferenceKey: key,
+        displayName: ref.binding.symbol,
+        intent: {
+          kind: "callable",
+          origin: ref.binding.kind,
+        },
+      });
+      const finalIndex = result.programAbi!.abi.resolveFinalIndex(entry.id);
+      expect(finalIndex).toEqual(expect.objectContaining({ space: "function" }));
+    }
+  });
+
+  it("binds one string-compare intrinsic to the mode-selected import or definition", () => {
+    const sourceText = `
+      export function main(left: string, right: string): boolean {
+        return left < right;
+      }
+    `;
+    const host = generateModule(analyzeSource(sourceText, "provider-host.ts"), {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const native = generateModule(analyzeSource(sourceText, "provider-native.ts"), {
+      experimentalIR: true,
+      nativeStrings: true,
+      trackIrOutcomes: true,
+    });
+    for (const result of [host, native]) {
+      const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+      expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+      expect(result.irCompiledFuncs).toContain("main");
+      expect(result.irPostClaimErrors).toEqual([]);
+    }
+
+    const key = irCallableBindingKey(irIntrinsicFuncRef(IR_STRING_COMPARE_FN, "misleading-label").binding);
+    const hostEntry = host.programAbi!.abi.entries().find((entry) => entry.structuralReferenceKey === key);
+    const nativeEntry = native.programAbi!.abi.entries().find((entry) => entry.structuralReferenceKey === key);
+    expect(hostEntry).toMatchObject({
+      displayName: IR_STRING_COMPARE_FN,
+      slotPolicy: "alias",
+      intent: { kind: "callable", origin: "intrinsic" },
+    });
+    expect(nativeEntry).toMatchObject({
+      displayName: IR_STRING_COMPARE_FN,
+      slotPolicy: "required",
+      slotSpace: "function",
+      intent: { kind: "callable", origin: "intrinsic" },
+    });
+
+    const hostIndex = host.programAbi!.abi.resolveFinalIndex(hostEntry!.id);
+    const nativeIndex = native.programAbi!.abi.resolveFinalIndex(nativeEntry!.id);
+    expect(hostIndex).toEqual(expect.objectContaining({ space: "function" }));
+    expect(nativeIndex).toEqual(expect.objectContaining({ space: "function" }));
+    if (!hostIndex || hostIndex.space !== "function" || !nativeIndex || nativeIndex.space !== "function") {
+      throw new Error("missing mode-selected string compare provider");
+    }
+    const hostImport = host.module.imports.filter((value) => value.desc.kind === "func")[hostIndex.index];
+    const nativeImportCount = native.module.imports.filter((value) => value.desc.kind === "func").length;
+    const nativeFunction = native.module.functions[nativeIndex.index - nativeImportCount];
+    expect(hostImport).toMatchObject({ module: "env", name: "string_compare", desc: { kind: "func" } });
+    expect(nativeFunction?.name).toBe("__str_compare");
+  });
+});


### PR DESCRIPTION
## Summary

- capture every runtime/intrinsic callable selected by the WasmGC IR resolver as an exact `Import` or `WasmFunction` object
- resolve repeated provider references through that allocator object across import shifts and stable defined-function handles
- plan retained providers deterministically after dead-import/type compaction, aliasing existing import/source/support locator owners where possible
- discard candidate-only import observations when an IR body withdraws before final ABI publication
- record `intrinsic` as explicit Program ABI callable provenance
- update the #3520 markdown tracker with C12 scope, evidence, and remaining R1 work

## Why

Runtime and intrinsic `IrFuncRef` values were structurally identified in IR,
but their backend resolution still repeatedly consulted `ctx.funcMap`,
defined-function name scans, and helper side maps. That left compatibility
labels and transient numeric indices in the ownership path and prevented the
whole-program ABI from representing dual-mode providers.

This change preserves existing provider selection and lazy helper order, then
captures its exact allocator result. Final ABI planning happens only after
DCE, so withdrawn IR candidates cannot manufacture required provider imports.

## Validation

- provider regression matrix: 6/6
- focused provider/import/session/multi-source matrix: 37/37
- #3520 matrix: 247 passing / 1 pre-existing failure across 43 files; the failing linear inventory-count assertion reproduces on untouched `origin/main`
- linear/cross-backend/constructor matrix: 43/43
- `pnpm run typecheck`
- scoped Biome lint and Prettier
- LOC and function budgets
- dead-export and checker-oracle ratchets
- `pnpm run check:ir-fallbacks -- --verbose`
- `pnpm run check:ir-only -- --policy=hybrid`: READY, 31 emitted / 6 typed unsupported / 0 invariants
- full equivalence: 1,611 passing / 32 known failing / 0 new regressions; baseline unchanged

No local Test262 shard was run.
