### PR TITLE
fix(#2666): guard nullish member bases before key coercion

### DIFF
--- a/plan/issues/2666-es3-member-ref-eval-order-compound-assign-incdec.md
+++ b/plan/issues/2666-es3-member-ref-eval-order-compound-assign-incdec.md
@@ -2,9 +2,9 @@
 id: 2666
 title: "≤ES3: member-reference base[prop] evaluation order in compound-assignment and prefix/postfix ++/-- (ToPropertyKey once, left-before-right)"
 status: in-progress
-assignee: ttraenkler/dev-2046
+assignee: ttraenkler/codex-es5-2666
 created: 2026-06-25
-updated: 2026-06-25
+updated: 2026-07-28
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -153,3 +153,35 @@ read-modify-write member paths (compound assignment AND `++`/`--`) evaluate and
 `ToPropertyKey` the computed key before checking the base is coercible. Fixing
 that one ordering is worth **~30 further ≤ES3 tests** on top of #3486's 11, and
 would take the ≤ES3 metadata bucket from 241/273 to ~271/273.
+
+## Current-main remeasurement (2026-07-28, Codex)
+
+Reproduced the exact 30-file residual on fresh `origin/main` using the
+authoritative original-harness runner, in both directions:
+
+| lane       | pass | fail | compile error | total |
+| ---------- | ---: | ---: | ------------: | ----: |
+| host       |    0 |   30 |             0 |    30 |
+| standalone |    0 |   30 |             0 |    30 |
+
+The host lane reaches the second assertion and reports
+`Expected a TypeError but got a Test262Error`, confirming that ToPropertyKey
+still observes the key object before RequireObjectCoercible rejects the nullish
+base. The standalone lane is layered behind an earlier user-constructor
+identity mismatch (`Expected a undefined but got a different error constructor
+with the same name`), so a correct ordering change is not assumed to flip its
+visible verdict; the post-fix two-direction comparison must report that split.
+
+Post-fix measurement over the same 30 files:
+
+| lane       | before | after | measured flips |
+| ---------- | -----: | ----: | -------------: |
+| host       |   0/30 | 30/30 |        **+30** |
+| standalone |   0/30 |  0/30 |          **0** |
+
+The standalone failures retain the exact earlier constructor-identity message;
+none advance far enough to score the second assertion. A host-free focused
+probe independently verifies that the standalone lowering evaluates the raw
+key expression, rejects the undefined base with a TypeError, and observes
+neither ToPropertyKey nor the RHS. This is a layered no-visible-flip result, not
+an extrapolated standalone win.

--- a/src/codegen/expressions/computed-member-reference.ts
+++ b/src/codegen/expressions/computed-member-reference.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Shared lowering for the computed portion of a member Reference used by
+ * read-modify-write expressions (`base[key] op= rhs`, `base[key]++`, etc.).
+ */
+import { ts } from "../../ts-api.js";
+import type { Instr } from "../../ir/types.js";
+import { allocLocal } from "../context/locals.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { ensureObjectRuntime } from "../object-runtime.js";
+import { compileExpression } from "../shared.js";
+import { emitThrowTypeError } from "./helpers.js";
+import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
+
+/**
+ * (#2666) ToPropertyKey §7.1.19, applied exactly once to the key externref on
+ * the stack. The resulting primitive string or preserved Symbol is safe to
+ * reuse for both the read and the write.
+ */
+export function emitToPropertyKeyOnce(ctx: CodegenContext, fctx: FunctionContext): void {
+  if (ctx.standalone) {
+    ensureObjectRuntime(ctx);
+    flushLateImportShifts(ctx, fctx);
+    const tpkIdx = ctx.funcMap.get("__to_property_key");
+    if (tpkIdx !== undefined) fctx.body.push({ op: "call", funcIdx: tpkIdx });
+    return;
+  }
+  const tpkIdx = ensureLateImport(ctx, "__to_property_key", [{ kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  if (tpkIdx !== undefined) fctx.body.push({ op: "call", funcIdx: tpkIdx });
+}
+
+/**
+ * §13.3.3 / §13.15.2 — after the raw key expression is evaluated, GetValue of
+ * the member Reference rejects a nullish base before ToPropertyKey observes
+ * the key value.
+ */
+function emitBaseCoercibilityGuard(ctx: CodegenContext, fctx: FunctionContext, baseLocal: number): void {
+  const emitTypeErrorBranch = (): Instr[] => {
+    const start = fctx.body.length;
+    emitThrowTypeError(ctx, fctx, "Cannot read properties of null or undefined (computed assignment target)");
+    return fctx.body.splice(start);
+  };
+
+  fctx.body.push({ op: "local.get", index: baseLocal });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: emitTypeErrorBranch(),
+    else: [],
+  });
+
+  const isUndefinedIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+  flushLateImportShifts(ctx, fctx);
+  if (isUndefinedIdx !== undefined) {
+    fctx.body.push({ op: "local.get", index: baseLocal });
+    fctx.body.push({ op: "call", funcIdx: isUndefinedIdx });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: emitTypeErrorBranch(),
+      else: [],
+    });
+  }
+}
+
+/**
+ * Evaluate and save a computed key, guard the already-evaluated base, then
+ * coerce the key exactly once. This preserves the required order:
+ *
+ *   base → raw key expression → RequireObjectCoercible(base) → ToPropertyKey
+ */
+export function compileComputedMemberKeyAfterBaseGuard(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  baseLocal: number,
+  keyExpression: ts.Expression,
+  localPrefix: string,
+): number | null {
+  const keyResult = compileExpression(ctx, fctx, keyExpression, { kind: "externref" });
+  if (!keyResult) return null;
+
+  const keyLocal = allocLocal(fctx, `${localPrefix}_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: keyLocal });
+  emitBaseCoercibilityGuard(ctx, fctx, baseLocal);
+  fctx.body.push({ op: "local.get", index: keyLocal });
+  emitToPropertyKeyOnce(ctx, fctx);
+  fctx.body.push({ op: "local.set", index: keyLocal });
+  return keyLocal;
+}

--- a/src/codegen/expressions/operator-assignment.ts
+++ b/src/codegen/expressions/operator-assignment.ts
@@ -47,10 +47,10 @@ import {
   emitWebCompatCallAssignmentTarget,
   getFuncParamTypes,
 } from "./helpers.js";
+import { compileComputedMemberKeyAfterBaseGuard, emitToPropertyKeyOnce } from "./computed-member-reference.js";
 import { ensureLateImport, flushLateImportShifts, patchStructNewForAddedField } from "./late-imports.js";
 import { emitMappedArgParamSync } from "./logical-ops.js";
 import { resolveStructNameForExpr } from "./misc.js";
-import { ensureObjectRuntime } from "../object-runtime.js";
 import {
   compileStringBuilderAppend,
   emitStringBuilderAppendCodeUnit,
@@ -2683,38 +2683,6 @@ function compilePropertyCompoundAssignmentExternref(
 }
 
 /**
- * (#2666) ToPropertyKey §7.1.19, applied EXACTLY ONCE to the key externref on
- * the stack, leaving the coerced key externref on the stack. For a member
- * read-modify-write (`o[key] op= rhs`, `o[key]++`) the LHS Reference is
- * evaluated once (§13.15.2 / §13.4), so the key's ToPropertyKey must fire once —
- * but the raw key flows to both `__extern_get` and `__extern_set`, each of which
- * ToPropertyKeys internally, double-firing a side-effecting `toString`/`valueOf`.
- * Coercing here once yields a primitive (string) or a preserved Symbol, which is
- * idempotent under the host's internal ToPropertyKey (string→string,
- * symbol→symbol) so the subsequent get/set do not re-coerce.
- *
- * HOST mode: the `__to_property_key` JS import wraps `_toPropertyKey` (§7.1.19,
- * Symbol-preserving). STANDALONE: the native `__to_property_key` helper
- * (object-runtime.ts) — ensure the object runtime so it is emitted.
- */
-export function emitToPropertyKeyOnce(ctx: CodegenContext, fctx: FunctionContext): void {
-  if (ctx.standalone) {
-    ensureObjectRuntime(ctx);
-    flushLateImportShifts(ctx, fctx);
-    const tpkIdx = ctx.funcMap.get("__to_property_key");
-    if (tpkIdx !== undefined) {
-      fctx.body.push({ op: "call", funcIdx: tpkIdx });
-    }
-    return;
-  }
-  const tpkIdx = ensureLateImport(ctx, "__to_property_key", [{ kind: "externref" }], [{ kind: "externref" }]);
-  flushLateImportShifts(ctx, fctx);
-  if (tpkIdx !== undefined) {
-    fctx.body.push({ op: "call", funcIdx: tpkIdx });
-  }
-}
-
-/**
  * Compile compound assignment on an element access target: arr[i] += value
  * Handles both vec structs (arrays) and plain structs (bracket notation).
  */
@@ -2750,23 +2718,14 @@ function compileElementCompoundAssignment(
     });
     fctx.body.push({ op: "local.set", index: objLocal });
 
-    // Compile key as externref and save to local
-    const keyResult = compileExpression(ctx, fctx, target.argumentExpression, {
-      kind: "externref",
-    });
-    if (!keyResult) return null;
-    // (#2666) ToPropertyKey ONCE (§7.1.19): a read-modify-write
-    // (`o[key] op= rhs`) evaluates the LHS Reference once (§13.15.2), so the
-    // key's ToPropertyKey must fire once. The raw key flows to BOTH
-    // __extern_get and __extern_set, each of which ToPropertyKeys internally —
-    // coercing a side-effecting key object twice. Coerce here once; the stored
-    // primitive (string / preserved Symbol) is idempotent under the host's
-    // internal ToPropertyKey, so no second `toString`.
-    emitToPropertyKeyOnce(ctx, fctx);
-    const keyLocal = allocLocal(fctx, `__cmpd_ekey_${fctx.locals.length}`, {
-      kind: "externref",
-    });
-    fctx.body.push({ op: "local.set", index: keyLocal });
+    const keyLocal = compileComputedMemberKeyAfterBaseGuard(
+      ctx,
+      fctx,
+      objLocal,
+      target.argumentExpression,
+      "__cmpd_ekey",
+    );
+    if (keyLocal === null) return null;
 
     // Read current value: __extern_get(obj, key) -> externref
     fctx.body.push({ op: "local.get", index: objLocal });

--- a/src/codegen/expressions/unary-updates.ts
+++ b/src/codegen/expressions/unary-updates.ts
@@ -44,7 +44,7 @@ import {
   getFuncParamTypes,
 } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
-import { emitToPropertyKeyOnce } from "./operator-assignment.js";
+import { compileComputedMemberKeyAfterBaseGuard } from "./computed-member-reference.js";
 import { emitMappedArgParamSync } from "./logical-ops.js";
 import { resolveStructName } from "./misc.js";
 
@@ -352,24 +352,8 @@ function emitExternrefElementIncDec(
   f64Op: "f64.add" | "f64.sub",
   mode: "prefix" | "postfix",
 ): ValType | null {
-  // §13.3.3: base already evaluated; evaluate the key expression (side effects),
-  // then ToPropertyKey ONCE (reference formation, before the null-base check).
-  const keyResult = compileExpression(ctx, fctx, keyExpr, { kind: "externref" });
-  if (!keyResult) return null;
-  emitToPropertyKeyOnce(ctx, fctx);
-  const keyLocal = allocLocal(fctx, `__incdec_ekey_${fctx.locals.length}`, { kind: "externref" });
-  fctx.body.push({ op: "local.set", index: keyLocal });
-
-  // RequireObjectCoercible: a wasm-null base throws TypeError before the update.
-  // (Shift-safe: emit the throw into the real body so emitThrowTypeError's
-  // late-import bookkeeping patches prior instrs, then splice into the if-then —
-  // #1720.)
-  fctx.body.push({ op: "local.get", index: baseLocal });
-  fctx.body.push({ op: "ref.is_null" });
-  const throwStart = fctx.body.length;
-  emitThrowTypeError(ctx, fctx, "TypeError: Cannot read properties of null (update target)");
-  const thenBody = fctx.body.splice(throwStart);
-  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: thenBody });
+  const keyLocal = compileComputedMemberKeyAfterBaseGuard(ctx, fctx, baseLocal, keyExpr, "__incdec_ekey");
+  if (keyLocal === null) return null;
 
   // Read current: __extern_get(base, key) -> externref (slot-consistent via _safeGet).
   fctx.body.push({ op: "local.get", index: baseLocal });

--- a/tests/issue-2666.test.ts
+++ b/tests/issue-2666.test.ts
@@ -22,7 +22,79 @@ async function run(body: string): Promise<any> {
   return wrapExports(instance.exports, { signatures: result.exportSignatures });
 }
 
+async function runStandalone(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const result = await compile(src, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  } as any);
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.imports).toEqual([]);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
 describe("#2666 — base[prop] compound-assign ToPropertyKey once + eval order", () => {
+  it("evaluates the key expression, then rejects a null base before ToPropertyKey or the RHS", async () => {
+    const exp = await run(
+      `var keyCalls = 0; var toStringCalls = 0; var rhsCalls = 0;
+       var base: any = null;
+       function key(): any {
+         keyCalls++;
+         return { toString() { toStringCalls++; return "x"; } };
+       }
+       function rhs(): number { rhsCalls++; return 2; }
+       var isTypeError = 0;
+       try { base[key()] *= rhs(); } catch (e) { isTypeError = e instanceof TypeError ? 1 : 0; }
+       return keyCalls * 1000 + toStringCalls * 100 + rhsCalls * 10 + isTypeError;`,
+    );
+    expect(exp.test()).toBe(1001);
+  });
+
+  it("rejects an undefined base before ToPropertyKey or the RHS", async () => {
+    const exp = await run(
+      `var toStringCalls = 0; var rhsCalls = 0;
+       var base: any = undefined;
+       var key: any = { toString() { toStringCalls++; return "x"; } };
+       function rhs(): number { rhsCalls++; return 2; }
+       var isTypeError = 0;
+       try { base[key] += rhs(); } catch (e) { isTypeError = e instanceof TypeError ? 1 : 0; }
+       return toStringCalls * 100 + rhsCalls * 10 + isTypeError;`,
+    );
+    expect(exp.test()).toBe(1);
+  });
+
+  it("applies the same nullish-base ordering to computed-key update expressions", async () => {
+    const exp = await run(
+      `var keyCalls = 0; var toStringCalls = 0;
+       var base: any = null;
+       function key(): any {
+         keyCalls++;
+         return { toString() { toStringCalls++; return "x"; } };
+       }
+       var isTypeError = 0;
+       try { ++base[key()]; } catch (e) { isTypeError = e instanceof TypeError ? 1 : 0; }
+       return keyCalls * 100 + toStringCalls * 10 + isTypeError;`,
+    );
+    expect(exp.test()).toBe(101);
+  });
+
+  it("preserves the nullish-base ordering in the host-free standalone lowering", async () => {
+    await expect(
+      runStandalone(
+        `var toStringCalls = 0; var rhsCalls = 0;
+         var base: any = undefined;
+         var key: any = { toString() { toStringCalls++; return "x"; } };
+         function rhs(): number { rhsCalls++; return 2; }
+         var isTypeError = 0;
+         try { base[key] += rhs(); } catch (e) { isTypeError = e instanceof TypeError ? 1 : 0; }
+         return toStringCalls * 100 + rhsCalls * 10 + isTypeError;`,
+      ),
+    ).resolves.toBe(1);
+  });
+
   it("a side-effecting computed key is ToPropertyKey'd exactly ONCE", async () => {
     const exp = await run(
       `var n = 0; var o: any = { x: 1 };


### PR DESCRIPTION
## What changed

- Extracted shared computed-member Reference lowering for compound assignment and prefix/postfix update expressions.
- Preserved the required order: evaluate the base, evaluate the raw key expression, run `RequireObjectCoercible(base)`, then apply `ToPropertyKey(key)` exactly once.
- Added host and host-free standalone regressions for null/undefined bases, key-expression side effects, skipped key coercion, skipped RHS evaluation, and catchable `TypeError` identity.
- Recorded the exact two-lane measurement in the issue plan.

## Root cause

The computed read-modify-write paths applied `ToPropertyKey` before checking whether the already-evaluated base was nullish. That allowed a key object's `toString`/`valueOf` exception to escape ahead of the required base-null `TypeError`. The key expression itself must still be evaluated first, so the fix saves its raw value, guards the base, and only then coerces the key.

## Measured Test262 result

Exact 30-file `S11.13.2_A7.*_T{1,2}` plus prefix/postfix increment/decrement `A6_T{1,2}` slice, authoritative original-harness runner:

- Host: **0/30 → 30/30** (**+30 measured flips**).
- Standalone: **0/30 → 0/30** (**0 visible flips**). All 30 retain the same earlier user-constructor identity failure and do not reach this slice's second assertion. A dedicated host-free probe verifies the corrected ordering and zero host imports.

## Validation

- 84/84 scoped and adjacent Vitest cases pass.
- `pnpm run typecheck`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- Prettier check and `git diff --check`
- One adjacent `issue-2709` suite has four `super[super()]` TypeScript/IR compile failures; the identical 4/7 result was reproduced on the untouched base commit, so they are pre-existing and outside this path.

Implements the current #2666 ordering residual. The standalone constructor-identity blocker remains separate.
