### PR TITLE
fix(#3420): copy argument extras at the ABI prefix

### DIFF
--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -2692,16 +2692,16 @@ export function emitArgumentsVecBody(
     });
   }
 
-  // If extras is non-null, copy extras into arr starting at offset numArgs.
-  fctx.body.push({ op: "local.get", index: extrasLocal });
-  fctx.body.push({ op: "ref.is_null" });
+  // Copy non-empty extras after the ABI-supplied formal prefix, not every declared parameter (#3420).
+  fctx.body.push({ op: "local.get", index: extrasLenLocal });
+  fctx.body.push({ op: "i32.eqz" });
   fctx.body.push({
     op: "if",
     blockType: { kind: "empty" },
     then: [],
     else: [
       { op: "local.get", index: arrTmp },
-      { op: "i32.const", value: numArgs },
+      { op: "local.get", index: argcLocal },
       { op: "local.get", index: extrasLocal },
       { op: "ref.as_non_null" },
       { op: "struct.get", typeIdx: vti, fieldIdx: 1 },

--- a/tests/issue-3420-species-result-store.test.ts
+++ b/tests/issue-3420-species-result-store.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const CASES = [
+  "built-ins/Array/prototype/filter/target-array-with-non-writable-property.js",
+  "built-ins/Array/prototype/map/target-array-with-non-writable-property.js",
+] as const;
+
+async function runArgumentsProbe(target: "gc" | "standalone"): Promise<number> {
+  const result: any = await compile(
+    `
+function inspect(a: any, b: any, c?: any, d?: any): number {
+  return arguments.length * 10 + (arguments[2] === 7 ? 1 : 0);
+}
+export function test(): number {
+  return inspect({}, 0, 7);
+}
+`,
+    {
+      fileName: "issue-3420-arguments-extras-offset.ts",
+      target,
+      skipSemanticDiagnostics: true,
+    },
+  );
+  expect(result.success, result.errors?.map((error: any) => error.message).join("\n")).toBe(true);
+  const imports = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.__setExports?.(instance.exports);
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#3420 arguments extras offset", () => {
+  for (const target of ["gc", "standalone"] as const) {
+    it(`copies optional extras after the supplied formal prefix (${target})`, async () => {
+      expect(await runArgumentsProbe(target)).toBe(31);
+    });
+  }
+
+  for (const relativePath of CASES) {
+    it(`passes the authoritative host case: ${relativePath}`, async () => {
+      const result = await runTest262File(resolve("test262/test", relativePath), "issue-3420", 30_000);
+      expect(result.status, result.error).toBe("pass");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- copy overflow arguments into `arguments` after the ABI-supplied formal prefix
- guard the copy by the actual extras length
- add direct host/standalone ABI coverage plus the two authoritative Array species regressions

## Root cause

Calls may supply fewer positional arguments than the callee declares and carry later values in `__extras_argv`. The arguments-object prologue allocated the logical supplied length but appended extras after every declared parameter, so optional-argument calls could execute `array.copy` past the backing array before entering the function body.

Refs #3420.

## Conformance impact

- JS-host exact cases: 0/2 → 2/2
- standalone exact cases: 0/2 → 0/2; the out-of-bounds trap is removed, exposing the remaining standalone own-property semantic failure
- direct optional/extras ABI probe: passes in both JS-host and standalone
- broader arguments regression comparison: no new failures versus latest `origin/main`

## Validation

- `pnpm exec vitest run tests/issue-3420-species-result-store.test.ts` (4/4)
- `pnpm run typecheck`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- `git diff --check`
