### PR TITLE
fix(arguments): clear deleted strict arguments slots

### DIFF
--- a/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
+++ b/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
@@ -18,9 +18,28 @@ loc-budget-allow:
   - src/codegen/typeof-delete.ts
   - src/ir/select.ts
 created: 2026-06-26
-updated: 2026-07-26
+updated: 2026-07-28
 ---
 
+> **Strict-rerun residual (2026-07-28, codex-2726).** The authoritative
+> original-harness runner exposed one remaining group (e) gap that the earlier
+> focused wrapper did not cover: `11.4.1-4.a-17` passed its sloppy execution but
+> failed the required strict rerun in both host/gc and standalone. Strict
+> functions use an _unmapped_ arguments object, so they intentionally have no
+> `mappedArgsInfo`; the generic property-delete path reported success but could
+> not clear the opaque vec-backed slot. The delete lowering now preserves that
+> generic result (including descriptor refusal), and on success clears a
+> statically indexed unmapped-arguments slot to canonical `undefined`.
+>
+> Same-SHA authoritative A/B: the 69-file delete directory moves host
+> **59→60** and standalone **51→52**, with exactly
+> `11.4.1-4.a-17` flipping in each lane and no reverse flips. Across all 26
+> Test262 files containing direct `delete arguments[...]`, host moves **7→12**
+> and standalone **5→10** (five exact fail→pass flips per lane, zero
+> pass→fail). The remaining standalone-only `11.4.1-5-a-27-s` failure is still
+> the separately owned `preventExtensions`/strict-assignment gap, not delete
+> semantics.
+>
 > **Final resolution (2026-07-26, codex-2726).** Group **(b)** is now **4/4**:
 > the two structural residuals `S11.4.1_A3.1` and
 > `S11.4.1_A3.3_T1` pass in both host/gc and standalone. The implementation

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -25,7 +25,7 @@ import { emitExternrefDestructureGuard } from "./destructuring-params.js";
 import { buildThrowJsErrorInstrs, type JsErrorKind } from "./js-errors.js";
 import { compileStandaloneRegExpLiteral } from "./regexp-standalone.js";
 import { addImport } from "./registry/imports.js";
-import { addFuncType } from "./registry/types.js";
+import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureAnyHelpers, isAnyValue } from "./shared.js";
 import { compileStringLiteral } from "./string-ops.js";
@@ -249,6 +249,93 @@ function emitStructDeleteOutcome(
     });
   }
   fctx.body.push({ op: "local.get", index: resLocal });
+}
+
+/**
+ * A strict or non-simple-parameter function has an *unmapped* `arguments`
+ * object, so it intentionally has no `mappedArgsInfo`. Its backing value is
+ * still the same externref vec used by mapped arguments. The generic
+ * `__delete_property` path records the successful deletion (and honors any
+ * descriptor-sidecar refusal), but it cannot clear the opaque vec slot; a
+ * subsequent compiled `arguments[i]` read therefore still sees the old value.
+ *
+ * Consume the generic delete result and, on success, clear a statically-known
+ * in-bounds vec slot to the canonical `undefined` value. Leave the result on
+ * the stack for the caller's normal strict-delete check.
+ */
+function emitPropertyDeleteWithUnmappedArgumentsWriteback(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  inner: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  delIdx: number,
+): void {
+  fctx.body.push({ op: "call", funcIdx: delIdx });
+  if (
+    fctx.mappedArgsInfo ||
+    !ts.isElementAccessExpression(inner) ||
+    !ts.isIdentifier(inner.expression) ||
+    inner.expression.text !== "arguments"
+  ) {
+    return;
+  }
+
+  const idxArg = inner.argumentExpression;
+  const idxText = ts.isNumericLiteral(idxArg) ? idxArg.text : ts.isStringLiteral(idxArg) ? idxArg.text : undefined;
+  const argIndex = idxText !== undefined ? Number(idxText) : NaN;
+  if (!Number.isInteger(argIndex) || argIndex < 0) return;
+
+  const argsLocalIdx = fctx.localMap.get("arguments");
+  if (argsLocalIdx === undefined) return;
+  const argsType =
+    argsLocalIdx < fctx.params.length
+      ? fctx.params[argsLocalIdx]?.type
+      : fctx.locals[argsLocalIdx - fctx.params.length]?.type;
+  if (!argsType || (argsType.kind !== "ref" && argsType.kind !== "ref_null")) return;
+
+  const vecTypeIdx = argsType.typeIdx;
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) return;
+
+  const resultLocal = allocLocal(fctx, `__del_args_res_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.set", index: resultLocal });
+  emitUndefined(ctx, fctx);
+  const undefLocal = allocLocal(fctx, `__del_args_undef_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: undefLocal });
+
+  const clearIfInBounds: Instr[] = [
+    { op: "local.get", index: argsLocalIdx },
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+    { op: "i32.const", value: argIndex },
+    { op: "i32.gt_u" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: argsLocalIdx },
+        { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+        { op: "i32.const", value: argIndex },
+        { op: "local.get", index: undefLocal },
+        { op: "array.set", typeIdx: arrTypeIdx },
+      ],
+      else: [],
+    },
+  ];
+
+  fctx.body.push({ op: "local.get", index: resultLocal });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then:
+      argsType.kind === "ref_null"
+        ? [
+            { op: "local.get", index: argsLocalIdx },
+            { op: "ref.is_null" },
+            { op: "if", blockType: { kind: "empty" }, then: [], else: clearIfInBounds },
+          ]
+        : clearIfInBounds,
+    else: [],
+  });
+  fctx.body.push({ op: "local.get", index: resultLocal });
 }
 
 /**
@@ -773,7 +860,7 @@ export function compileDeleteExpression(
     }
     fctx.body.push({ op: "local.get", index: recvLocal });
     fctx.body.push({ op: "local.get", index: keyLocal });
-    fctx.body.push({ op: "call", funcIdx: delIdx });
+    emitPropertyDeleteWithUnmappedArgumentsWriteback(ctx, fctx, inner, delIdx);
     // (#2703) Strict mode: a failed delete (result 0 — a non-configurable own
     // property) is a TypeError instead of a `false` result (§13.5.1.2 step 6.b).
     emitStrictDeleteCheck(ctx, fctx, expr);

--- a/tests/issue-2726-mapped-args-delete.test.ts
+++ b/tests/issue-2726-mapped-args-delete.test.ts
@@ -22,13 +22,18 @@ import { buildImports } from "../src/runtime.js";
 // (strict), so `inferModuleStrictArguments: false` restores the script-goal
 // sloppy strictness the test262 harness uses for `noStrict` tests.
 
-async function run(source: string): Promise<unknown> {
-  const result = await compile(source, { inferModuleStrictArguments: false });
+async function run(source: string, target?: "standalone"): Promise<unknown> {
+  const result = await compile(source, { inferModuleStrictArguments: false, ...(target ? { target } : {}) });
   if (!result.success) {
     throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
   }
-  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const imports = target ? {} : buildImports(result.imports, undefined, result.stringPool);
   const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  if (!target) {
+    (imports as ReturnType<typeof buildImports>).setExports?.(
+      instance.exports as Record<string, (...a: unknown[]) => unknown>,
+    );
+  }
   return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
 }
 
@@ -77,5 +82,25 @@ describe("#2726 (e) — delete arguments[i] on a mapped configurable index", () 
         return foo(1, 2);
       }`;
     expect(await run(src)).toBe(1);
+  });
+
+  const strictUnmappedSource = `
+    export function test(): number {
+      function foo(a, b) {
+        "use strict";
+        var d = delete arguments[0];
+        if (d !== true) return 10;
+        if (arguments[0] !== undefined) return 20;
+        return 1;
+      }
+      return foo(1, 2);
+    }`;
+
+  it("clears a strict unmapped arguments slot after delete (host)", async () => {
+    expect(await run(strictUnmappedSource)).toBe(1);
+  });
+
+  it("clears a strict unmapped arguments slot after delete (standalone)", async () => {
+    expect(await run(strictUnmappedSource, "standalone")).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- preserve the generic property-delete result for strict/unmapped `arguments` objects
- clear a successfully deleted literal-index vec slot so subsequent reads observe canonical `undefined`
- add focused host and standalone regressions and document the measured residual resolution

## Root cause

Strict functions intentionally omit `mappedArgsInfo`, but their `arguments`
object still uses the same opaque vec backing as mapped arguments. The generic
delete path correctly reported success and handled descriptor refusal, yet it
could not clear that backing slot. A following compiled `arguments[i]` read
therefore still returned the deleted value.

## Validation

- `pnpm exec vitest run tests/issue-2726-mapped-args-delete.test.ts --maxWorkers=1` — 5/5 pass
- `pnpm run typecheck`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- same-SHA authoritative A/B, all 69 `language/expressions/delete` files:
  - host: 59 → 60 pass
  - standalone: 51 → 52 pass
  - zero pass→fail regressions
- same-SHA authoritative A/B, all 26 Test262 files containing direct
  `delete arguments[...]`:
  - host: 7 → 12 pass
  - standalone: 5 → 10 pass
  - five exact fail→pass flips per lane, zero pass→fail regressions
- post-rebase authoritative delete matrix: host 60/69, standalone 52/69

The remaining standalone-only `11.4.1-5-a-27-s` failure is the separately
owned `preventExtensions`/strict-assignment gap, not delete semantics.
