### PR TITLE
fix(standalone): lower propertyHelper Array uncurry aliases

### DIFF
--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -995,7 +995,7 @@ function emitDynViewMethodTwoArm(
   fctx: FunctionContext,
   propAccess: ts.PropertyAccessExpression | ts.ElementAccessExpression,
   callExpr: ts.CallExpression,
-  receiverType: ts.Type,
+  receiverType: ts.Type | undefined,
   methodName: string,
   expectedType: ValType | undefined,
 ): ValType | null | undefined | typeof VOID_RESULT {
@@ -1121,7 +1121,7 @@ export function compileArrayMethodCall(
   fctx: FunctionContext,
   propAccess: ts.PropertyAccessExpression | ts.ElementAccessExpression,
   callExpr: ts.CallExpression,
-  receiverType: ts.Type,
+  receiverType: ts.Type | undefined,
   overrideMethodName?: string,
   expectedType?: ValType,
   skipDynViewWrap = false,
@@ -1186,8 +1186,8 @@ export function compileArrayMethodCall(
 
   const receiverExpr = propAccess.expression;
   const arrInfo =
-    resolveArrayInfo(ctx, receiverType) ??
-    resolveArrayInfoFromWasmType(ctx, inferExpressionWasmType(ctx, fctx, receiverExpr, false));
+    (receiverType === undefined ? null : resolveArrayInfo(ctx, receiverType)) ??
+    resolveArrayInfoFromWasmType(ctx, inferExpressionWasmType(ctx, fctx, receiverExpr, receiverType === undefined));
   if (!arrInfo) return undefined;
 
   let { vecTypeIdx, arrTypeIdx, elemType } = arrInfo;

--- a/src/codegen/expressions/call-object-builtins.ts
+++ b/src/codegen/expressions/call-object-builtins.ts
@@ -1,12 +1,14 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * Semantic lowering for stored Object builtins and uncurried Object prototype
- * methods. Metadata reads still observe the canonical builtin closure; only
- * invocation is routed to the same provider as the direct spelling.
+ * Semantic lowering for stored Object builtins and statically-known uncurried
+ * prototype methods. Metadata reads still observe the canonical builtin
+ * closure; only invocation is routed to the same provider as the direct
+ * spelling.
  */
 import type { ValType } from "../../ir/types.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
-import { resolveStoredObjectStaticMethod, resolveUncurriedObjectPrototypeMethod } from "../object-builtin-effects.js";
+import { compileArrayMethodCall } from "../array-methods.js";
+import { resolveStoredObjectStaticMethod, resolveUncurriedBuiltinPrototypeMethod } from "../object-builtin-effects.js";
 import { compileObjectDefineProperties, compileObjectDefineProperty } from "../object-ops.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression } from "../shared.js";
@@ -105,13 +107,36 @@ export function tryCompileStoredObjectBuiltinCall(
     return emitStoredObjectIntrospectionCall(ctx, fctx, expr, storedObjectStatic);
   }
 
-  const uncurriedObjectMethod = resolveUncurriedObjectPrototypeMethod(ctx.oracle, expr.expression);
-  if (uncurriedObjectMethod === undefined) return undefined;
+  const uncurriedMethod = resolveUncurriedBuiltinPrototypeMethod(ctx.oracle, expr.expression);
+  if (uncurriedMethod === undefined) return undefined;
+  if (uncurriedMethod.builtin === "Array") {
+    // (#3571) propertyHelper's `__push`/`__join` aliases are immutable builtin
+    // identities. Compile `alias(receiver, ...args)` exactly as
+    // `receiver.push/join(...args)`, preserving argument order while avoiding
+    // the incomplete generic Function.call → builtin-method carrier chain.
+    const receiver = expr.arguments[0];
+    if (!receiver) return undefined;
+    const propAccess = ts.factory.createPropertyAccessExpression(receiver, uncurriedMethod.method);
+    ts.setTextRange(propAccess, expr);
+    (propAccess as { parent: ts.Node }).parent = expr.parent;
+    const call = ts.factory.createCallExpression(propAccess, undefined, expr.arguments.slice(1));
+    ts.setTextRange(call, expr);
+    (call as { parent: ts.Node }).parent = expr.parent;
+    return compileArrayMethodCall(
+      ctx,
+      fctx,
+      propAccess,
+      call,
+      ctx.checker.getTypeAtLocation(receiver),
+      uncurriedMethod.method,
+    );
+  }
+
   const externRef: ValType = { kind: "externref" };
   emitExternrefArgument(ctx, fctx, expr, 0, externRef);
-  if (uncurriedObjectMethod === "valueOf") return externRef;
+  if (uncurriedMethod.method === "valueOf") return externRef;
   emitExternrefArgument(ctx, fctx, expr, 1, externRef);
-  const helperName = uncurriedObjectMethod === "hasOwnProperty" ? "__hasOwnProperty" : "__propertyIsEnumerable";
+  const helperName = uncurriedMethod.method === "hasOwnProperty" ? "__hasOwnProperty" : "__propertyIsEnumerable";
   const boolType: ValType = { kind: "i32", boolean: true };
   const helperIdx = ensureLateImport(ctx, helperName, [externRef, externRef], [boolType]);
   flushLateImportShifts(ctx, fctx);

--- a/src/codegen/expressions/call-object-builtins.ts
+++ b/src/codegen/expressions/call-object-builtins.ts
@@ -116,20 +116,15 @@ export function tryCompileStoredObjectBuiltinCall(
     // the incomplete generic Function.call → builtin-method carrier chain.
     const receiver = expr.arguments[0];
     if (!receiver) return undefined;
+    const receiverFact = ctx.oracle.typeFactOf(receiver);
+    if (receiverFact.kind !== "array" && receiverFact.kind !== "tuple") return undefined;
     const propAccess = ts.factory.createPropertyAccessExpression(receiver, uncurriedMethod.method);
     ts.setTextRange(propAccess, expr);
     (propAccess as { parent: ts.Node }).parent = expr.parent;
     const call = ts.factory.createCallExpression(propAccess, undefined, expr.arguments.slice(1));
     ts.setTextRange(call, expr);
     (call as { parent: ts.Node }).parent = expr.parent;
-    return compileArrayMethodCall(
-      ctx,
-      fctx,
-      propAccess,
-      call,
-      ctx.checker.getTypeAtLocation(receiver),
-      uncurriedMethod.method,
-    );
+    return compileArrayMethodCall(ctx, fctx, propAccess, call, undefined, uncurriedMethod.method);
   }
 
   const externRef: ValType = { kind: "externref" };

--- a/src/codegen/object-builtin-effects.ts
+++ b/src/codegen/object-builtin-effects.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * Static resolution for Object builtin values captured in locals.
+ * Static resolution for builtin values captured in locals.
  *
  * Keeping this analysis separate from call lowering lets declaration-time
  * representation selection and expression-time semantic routing agree on the
@@ -38,10 +38,20 @@ export function calleeIsBoundFunctionVar(oracle: TypeOracle, expr: ts.Expression
   return resolveBoundFunctionInitializer(oracle, expr) !== undefined;
 }
 
-export function resolveUncurriedObjectPrototypeMethod(
+export type UncurriedBuiltinPrototypeMethod =
+  | { builtin: "Array"; method: "join" | "push" }
+  | { builtin: "Object"; method: "hasOwnProperty" | "propertyIsEnumerable" | "valueOf" };
+
+/**
+ * Resolve the exact immutable `Function.prototype.call.bind(Builtin.prototype.m)`
+ * aliases used by test262's propertyHelper. Invocation can then reuse the
+ * corresponding native direct-call lowering instead of the incomplete generic
+ * standalone builtin-method carrier.
+ */
+export function resolveUncurriedBuiltinPrototypeMethod(
   oracle: TypeOracle,
   expr: ts.Expression,
-): "hasOwnProperty" | "propertyIsEnumerable" | "valueOf" | undefined {
+): UncurriedBuiltinPrototypeMethod | undefined {
   const init = resolveBoundFunctionInitializer(oracle, expr);
   if (!init || !ts.isPropertyAccessExpression(init.expression) || init.expression.name.text !== "bind") {
     return undefined;
@@ -63,13 +73,22 @@ export function resolveUncurriedObjectPrototypeMethod(
     !ts.isPropertyAccessExpression(target) ||
     !ts.isPropertyAccessExpression(target.expression) ||
     target.expression.name.text !== "prototype" ||
-    !ts.isIdentifier(target.expression.expression) ||
-    target.expression.expression.text !== "Object"
+    !ts.isIdentifier(target.expression.expression)
   ) {
     return undefined;
   }
+  const builtin = target.expression.expression.text;
   const method = target.name.text;
-  return method === "hasOwnProperty" || method === "propertyIsEnumerable" || method === "valueOf" ? method : undefined;
+  if (builtin === "Array" && (method === "join" || method === "push")) {
+    return { builtin, method };
+  }
+  if (
+    builtin === "Object" &&
+    (method === "hasOwnProperty" || method === "propertyIsEnumerable" || method === "valueOf")
+  ) {
+    return { builtin, method };
+  }
+  return undefined;
 }
 
 export type StoredObjectStaticMethod =

--- a/tests/issue-3571-standalone-uncurrythis.test.ts
+++ b/tests/issue-3571-standalone-uncurrythis.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3571 — test262's propertyHelper.js stores these two uncurryThis helpers:
+//
+//   __push = Function.prototype.call.bind(Array.prototype.push)
+//   __join = Function.prototype.call.bind(Array.prototype.join)
+//
+// Standalone could construct the bound-function carrier, but invoking it lost
+// the Array builtin target and null-dereferenced. The compiler now recognizes
+// that exact immutable builtin identity and invokes the existing native Array
+// lowering on the first call argument. These checks observe results and
+// mutations; merely compiling is not considered a pass.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, {
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.success ? "" : result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(
+    WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).filter((entry) => entry.module === "env"),
+  ).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+const PROPERTY_HELPER_BINDINGS = `
+  var __push: any = Function.prototype.call.bind(Array.prototype.push);
+  var __join: any = Function.prototype.call.bind(Array.prototype.join);
+`;
+
+describe("#3571 standalone propertyHelper uncurryThis dispatch", () => {
+  it("uncurried push mutates the receiver and returns its new length", async () => {
+    expect(
+      await runStandalone(`
+        ${PROPERTY_HELPER_BINDINGS}
+        export function test(): number {
+          var values: any[] = [];
+          var firstLength: any = __push(values, "first");
+          var secondLength: any = __push(values, "second");
+          if (firstLength !== 1 || secondLength !== 2) return 10;
+          if (values.length !== 2) return 11;
+          if (values[0] !== "first" || values[1] !== "second") return 12;
+          return 1;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("uncurried join observes the receiver and separator", async () => {
+    expect(
+      await runStandalone(`
+        ${PROPERTY_HELPER_BINDINGS}
+        export function test(): number {
+          return __join(["a", "b"], ";") === "a;b" ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("the propertyHelper failure-accumulation shape is no longer vacuous", async () => {
+    expect(
+      await runStandalone(`
+        ${PROPERTY_HELPER_BINDINGS}
+        export function test(): number {
+          var failures: any[] = [];
+          __push(failures, "expected 1 but got 2");
+          if (failures.length !== 1) return 10;
+          return __join(failures, "; ") === "expected 1 but got 2" ? 1 : 11;
+        }
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- recognize the immutable `Function.prototype.call.bind(Array.prototype.push)` and `join` aliases used by Test262 `propertyHelper.js`
- route those calls through the existing native standalone array-method lowering
- keep the host lane unchanged and preserve standalone modules with zero `env` imports

## Measured impact

On an 11-case focused two-lane probe:

- host: 11/11 -> 11/11
- standalone: 2/11 -> 7/11
- the five intended `push`/`join` and failure-accumulation cases now pass

On the exact 149-test ES5 cohort whose standalone failures entered `verifyProperty`:

- standalone status: 149 fail -> fail, with 0 regressions
- 146/149 failures change from an uncatchable null-pointer runtime trap to an actionable `Test262Error` describing the remaining descriptor mismatch
- 3/149 remain unchanged because of a pre-existing array out-of-bounds failure
- host status: 52 pass -> pass and 97 fail -> fail, with 0 status or error-signature changes

This deliberately exposes the next descriptor-semantics failures rather than claiming them as Test262 passes.

## Validation

- `pnpm exec vitest run tests/issue-3571-standalone-uncurrythis.test.ts tests/issue-3479.test.ts tests/issue-1712-reflection-identity.test.ts tests/issue-3603-vec-mirror-writeback.test.ts` (46 passed)
- `pnpm run typecheck`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- Prettier check and `git diff --check`
- new regression coverage asserts zero standalone `env` imports
