### PR TITLE
feat(ir): own retained type and class layout ABI

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -6,7 +6,7 @@ assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
 branch: codex/3520-c13-type-class-abi
-pr: 3739
+pr: 3746
 last_merged_pr: 3679
 sprint: current
 created: 2026-07-21
@@ -1647,7 +1647,7 @@ remain before R1 can close.
 
 ### 2026-07-28 retained type and class-layout continuation
 
-The stacked continuation on `codex/3520-c13-type-class-abi` makes the complete
+The continuation on `codex/3520-c13-type-class-abi` makes the complete
 post-DCE Wasm type population and every inventoried class explicit in the
 production Program ABI:
 

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -5,7 +5,7 @@ status: in-progress
 assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
-branch: codex/3520-c12-callable-providers
+branch: codex/3520-c13-type-class-abi
 pr: 3739
 last_merged_pr: 3679
 sprint: current
@@ -82,6 +82,7 @@ files:
   - src/position-map.ts
   - src/process-stdin-prelude.ts
   - src/codegen/class-member-keys.ts
+  - src/codegen/class-layout-registration.ts
   - src/codegen/context/types.ts
   - src/codegen/context/create-context.ts
   - src/codegen/dead-elimination.ts
@@ -90,6 +91,7 @@ files:
   - src/codegen/program-abi-planning.ts
   - src/codegen/program-abi-signatures.ts
   - src/codegen/program-abi-session.ts
+  - src/codegen/program-abi-type-planning.ts
   - src/codegen/ir-first-gate.ts
   - src/codegen/ir-class-shapes.ts
   - src/codegen/ir-overlay-identity.ts
@@ -135,6 +137,7 @@ files:
   - tests/issue-3520-support-callable-abi.test.ts
   - tests/issue-3520-class-support-callable-abi.test.ts
   - tests/issue-3520-class-method-alias-abi.test.ts
+  - tests/issue-3520-type-class-abi.test.ts
   - tests/issue-3520-program-abi-import-callable-planning.test.ts
   - tests/issue-3520-imported-callable-abi.test.ts
   - tests/issue-2856-calendar-residuals.test.ts
@@ -1641,6 +1644,57 @@ externref/Promise-host support helpers, Program ABI type/class-layout entries,
 exports and remaining alias families, and production `LegacyAbiAdapter`
 replacement of `funcMap`, `structMap`, module-array, and name scans still
 remain before R1 can close.
+
+### 2026-07-28 retained type and class-layout continuation
+
+The stacked continuation on `codex/3520-c13-type-class-abi` makes the complete
+post-DCE Wasm type population and every inventoried class explicit in the
+production Program ABI:
+
+- class collection records the exact allocator `TypeDef` beside its exact
+  `IrClassId` before DCE. The existing session-owned type cells follow that
+  object through the complete type-layout remap, so final class slots are
+  resolved from allocator identity rather than `structMap`, a debug name, or a
+  captured raw type index;
+- finalization assigns every retained type object exactly one required
+  `type`-space owner. Exact class layouts retain class-owned entries; all other
+  function, struct, array, recursive-group, and subtype definitions receive
+  deterministic entry-source-owned type identities in final allocator order;
+- every inventoried class receives a class intent. Classes with a live WasmGC
+  layout own its exact type cell, while ambient or otherwise unallocated
+  classes remain explicit slotless intentions rather than disappearing from
+  the whole-program inventory;
+- the canonical type/layout contract excludes cosmetic Wasm debug names but
+  retains value brands, field names/order/mutability/presence metadata,
+  inheritance indices, finality, and nested recursive shapes. Publication
+  rematerializes the contract from the exact final type object after DCE; and
+- legacy class-expression collection can allocate the same exact declaration
+  twice under compatibility names. The structurally last live compatibility
+  allocation becomes the single class-owned slot, while every superseded
+  allocator object remains independently cataloged as a generic retained type.
+  One `IrClassId` is therefore never duplicated or silently rebound.
+
+The focused production/type-contract matrix passes **4/4**. The sharded #3520
+matrix reports **251 passing / 1 failing across 44 files**; the sole failure is
+the unchanged linear inventory-count spy assertion in
+`issue-3520-context-integration.test.ts`, reproduced on the exact C12/current-
+main control. The #2138 multi-source matrix passes **6/6**, and the broad
+class/inheritance/accessor, linear, and 29-case cross-backend matrix is green.
+Strict TypeScript, Prettier, scoped Biome lint, diff, LOC/function budget,
+dead-export, checker-oracle, issue-spec, and fallback gates pass. Hybrid
+readiness remains **31 IR-emitted / 6 typed Unsupported / 0 Invariants across
+37 terminal units**, with all 37 legacy bodies still emitted. The eight-shard
+equivalence gate reports **1,611 passing / 32 known failing / 0 new
+regressions**; four baseline rows now pass and the shared baseline remains
+unchanged.
+
+C13 closes final retained type-slot and class-layout population, not R1.
+Inherited accessors, static and externref/Promise-host support helpers,
+remaining imported globals, exports and public aliases, and production
+`LegacyAbiAdapter` replacement of `funcMap`, `structMap`, module-array, and
+display-name scans still remain before R1 can close. This slice populates the
+class/type authority but deliberately does not yet reroute existing
+`structMap` consumers through it.
 
 ### R1a validation evidence
 

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -20,6 +20,7 @@ import { isStandalonePromiseActive } from "./async-scheduler.js"; // (#2637 B2) 
 import { emitAsyncGenerator, isAsyncGenDriveCandidate } from "./async-frame.js";
 import { genBodyReferencesThis, genBodyReferencesSuper, emitCachedFuncClosureAccess } from "./closures.js"; // (#3132 / #3123 fnctor parent closure)
 import { classMemberFuncKey, fnctorAncestorOfClass } from "./class-member-keys.js"; // (#1983 / #3123)
+import { commitClassStructLayout } from "./class-layout-registration.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 import { absoluteFuncIndex } from "../emit/resolve-layout.js"; // (#1916 S3b) resolve handles for order-stable declaredFuncRefs sort
 import { getOrAssignClassNewTargetId } from "./new-target.js"; // (#2023)
@@ -915,8 +916,7 @@ export function collectClassDeclaration(
   if (parentStructTypeIdx !== undefined) {
     structDef.superTypeIdx = parentStructTypeIdx;
   }
-  ctx.mod.types[structTypeIdx] = structDef;
-  ctx.structFields.set(className, fields);
+  commitClassStructLayout(ctx, decl, className, structTypeIdx, structDef, fields);
 
   // Register a prototype singleton global (externref, lazily initialized)
   // Used by ClassName.prototype and Object.getPrototypeOf(instance).

--- a/src/codegen/class-layout-registration.ts
+++ b/src/codegen/class-layout-registration.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import type { FieldDef, StructTypeDef } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+
+/**
+ * Install one completed class struct and expose that exact allocator object to
+ * the structural ABI sidecar at the same ownership boundary.
+ */
+export function commitClassStructLayout(
+  ctx: CodegenContext,
+  declaration: ts.ClassDeclaration | ts.ClassExpression,
+  displayName: string,
+  typeIndex: number,
+  type: StructTypeDef,
+  fields: FieldDef[],
+): void {
+  ctx.mod.types[typeIndex] = type;
+  ctx.structFields.set(displayName, fields);
+  if (ctx.programAbiSession && !ctx.programAbiTypes) {
+    throw new TypeError(`program ABI class layout ${displayName} has no planning identity context`);
+  }
+  ctx.programAbiTypes?.observeClass(declaration, displayName, type);
+}

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -7,6 +7,7 @@
  */
 import { ts } from "../../ts-api.js";
 import type { WasmModule } from "../../ir/types.js";
+import type { IrPlanningIdentityContext } from "../../ir/planning-identity.js";
 import { TsCheckerOracle } from "../../checker/oracle.js";
 import { UsageInference } from "../../checker/usage-inference.js";
 import { getOrRegisterVecType, registerNativeStringTypes } from "../registry/types.js";
@@ -14,6 +15,7 @@ import { nativeLiteralRegExpEngineConfig } from "../regexp-standalone.js";
 import { createFallbackCounts } from "../fallback-telemetry.js";
 import type { ProgramAbiSession } from "../program-abi-session.js";
 import { ProgramAbiCallableProviderRegistry } from "../program-abi-provider-planning.js";
+import { ProgramAbiTypeRegistry } from "../program-abi-type-planning.js";
 import type { CodegenContext, CodegenOptions } from "./types.js";
 
 export function createCodegenContext(
@@ -21,6 +23,7 @@ export function createCodegenContext(
   checker: ts.TypeChecker,
   options?: CodegenOptions,
   programAbiSession?: ProgramAbiSession,
+  irPlanningIdentityContext?: IrPlanningIdentityContext,
 ): CodegenContext {
   programAbiSession?.assertModule(mod);
   // #1524 — strict-mode default policy. WASI builds enforce the dual-mode
@@ -47,6 +50,7 @@ export function createCodegenContext(
   const ctx: CodegenContext = {
     mod,
     programAbiSession,
+    irPlanningIdentityContext,
     checker,
     sourceIsModule: false,
     // (#1930) THE type-query boundary. New codegen code MUST prefer
@@ -365,6 +369,9 @@ export function createCodegenContext(
   };
   if (programAbiSession) {
     ctx.programAbiCallableProviders = new ProgramAbiCallableProviderRegistry(programAbiSession, ctx);
+    if (irPlanningIdentityContext) {
+      ctx.programAbiTypes = new ProgramAbiTypeRegistry(programAbiSession, ctx, irPlanningIdentityContext);
+    }
   }
 
   // (#2083) Pre-register the `externref` + `f64` vec struct types up front for

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1053,6 +1053,8 @@ export interface CodegenContext {
   mod: WasmModule;
   programAbiSession?: import("../program-abi-session.js").ProgramAbiSession;
   programAbiCallableProviders?: import("../program-abi-provider-planning.js").ProgramAbiCallableProviderRegistry;
+  programAbiTypes?: import("../program-abi-type-planning.js").ProgramAbiTypeRegistry;
+  irPlanningIdentityContext?: import("../../ir/planning-identity.js").IrPlanningIdentityContext;
   checker: ts.TypeChecker;
   /** True when the single-file input is an ECMAScript Module goal. Script-goal
    * module init uses the host global object for top-level `this`; module goal

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2945,7 +2945,7 @@ export function generateModule(
   const programAbiSession = irPlanningIdentityContext
     ? new ProgramAbiSession(irPlanningIdentityContext.inventory, mod)
     : undefined;
-  const ctx = createCodegenContext(mod, ast.checker, options, programAbiSession);
+  const ctx = createCodegenContext(mod, ast.checker, options, programAbiSession, irPlanningIdentityContext);
   const sourceFileInternal = ast.sourceFile as ts.SourceFile & { externalModuleIndicator?: ts.Node };
   ctx.sourceIsModule = sourceFileInternal.externalModuleIndicator !== undefined;
   recordSourceGlobalEnvironment(ctx, ast.sourceFile);
@@ -5536,7 +5536,7 @@ export function generateMultiModule(
   const programAbiSession = irPlanningIdentityContext
     ? new ProgramAbiSession(irPlanningIdentityContext.inventory, mod)
     : undefined;
-  const ctx = createCodegenContext(mod, multiAst.checker, options, programAbiSession);
+  const ctx = createCodegenContext(mod, multiAst.checker, options, programAbiSession, irPlanningIdentityContext);
   // Multi-file compilation is linked through import/export module records.
   ctx.sourceIsModule = true;
   try {

--- a/src/codegen/program-abi-import-planning.ts
+++ b/src/codegen/program-abi-import-planning.ts
@@ -284,6 +284,7 @@ export function eliminateDeadImportsAndPlanAbiCallables(ctx: CodegenContext): vo
   eliminateDeadImports(ctx.mod, ctx);
   planProgramAbiCallableImports(ctx);
   ctx.programAbiCallableProviders?.planRetained();
+  ctx.programAbiTypes?.planRetained();
 }
 
 /**

--- a/src/codegen/program-abi-session.ts
+++ b/src/codegen/program-abi-session.ts
@@ -12,6 +12,7 @@ import {
 } from "../ir/program-abi.js";
 import {
   canonicalProgramAbiCallableTypeContract,
+  canonicalProgramAbiTypeDef,
   canonicalProgramAbiValType,
   cloneProgramAbiCallableTypeContract,
   cloneProgramAbiValType,
@@ -1174,6 +1175,15 @@ export class ProgramAbiSession {
           mutable: contract.mutable,
         },
       });
+    }
+    if ((draft.intent.kind === "type" || draft.intent.kind === "class") && draft.slotPolicy === "required") {
+      const locator = this.locators.get(draft.id);
+      if (locator?.kind !== "type-cell" || locator.cell.current === null) return draft;
+      const shapeKey = canonicalProgramAbiTypeDef(locator.cell.current);
+      return cloneDraft({
+        ...draft,
+        intent: draft.intent.kind === "type" ? { ...draft.intent, shapeKey } : { ...draft.intent, layoutKey: shapeKey },
+      } as ProgramAbiDraft);
     }
     return draft;
   }

--- a/src/codegen/program-abi-signatures.ts
+++ b/src/codegen/program-abi-signatures.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import type { ProgramAbiCallableSignature } from "../ir/program-abi.js";
-import type { ValType } from "../ir/types.js";
+import type { FieldDef, TypeDef, ValType } from "../ir/types.js";
 
 export interface ProgramAbiCallableTypeContract {
   readonly params: readonly ValType[];
@@ -41,6 +41,62 @@ export function canonicalProgramAbiValType(type: ValType): string {
     default:
       return JSON.stringify({ kind: type.kind });
   }
+}
+
+function canonicalProgramAbiField(field: FieldDef): object {
+  return {
+    name: field.name,
+    type: canonicalProgramAbiValType(field.type),
+    mutable: field.mutable,
+    ...(field.jsBoolean === true ? { jsBoolean: true as const } : {}),
+    ...(field.presenceTracked === true ? { presenceTracked: true as const } : {}),
+  };
+}
+
+function canonicalProgramAbiTypeDefValue(type: TypeDef): object {
+  switch (type.kind) {
+    case "func":
+      return {
+        kind: type.kind,
+        params: type.params.map(canonicalProgramAbiValType),
+        results: type.results.map(canonicalProgramAbiValType),
+      };
+    case "struct":
+      return {
+        kind: type.kind,
+        fields: type.fields.map(canonicalProgramAbiField),
+        superTypeIdx: type.superTypeIdx ?? null,
+        final: type.final === true,
+      };
+    case "array":
+      return {
+        kind: type.kind,
+        element: canonicalProgramAbiValType(type.element),
+        mutable: type.mutable,
+      };
+    case "rec":
+      return {
+        kind: type.kind,
+        types: type.types.map(canonicalProgramAbiTypeDefValue),
+      };
+    case "sub":
+      return {
+        kind: type.kind,
+        superType: type.superType,
+        final: type.final,
+        type: canonicalProgramAbiTypeDefValue(type.type),
+      };
+  }
+}
+
+/**
+ * Canonical semantic Wasm type/layout contract.
+ *
+ * Debug names are deliberately excluded. Field names remain because class and
+ * structural-object property offsets are part of the compiler's layout ABI.
+ */
+export function canonicalProgramAbiTypeDef(type: TypeDef): string {
+  return JSON.stringify(canonicalProgramAbiTypeDefValue(type));
 }
 
 export function canonicalProgramAbiCallableTypeContract(

--- a/src/codegen/program-abi-type-planning.ts
+++ b/src/codegen/program-abi-type-planning.ts
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import { irClassTypeRef, irSupportTypeRef, irTypeBindingKey } from "../ir/abi-bindings.js";
+import type { IrBindingId, IrClassId, IrSourceId } from "../ir/identity.js";
+import type { IrPlanningIdentityContext } from "../ir/planning-identity.js";
+import { ProgramAbiInvariantError } from "../ir/program-abi.js";
+import type { StructTypeDef, TypeDef } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { requireIrClassShapeClassId } from "./ir-class-shapes.js";
+import { canonicalProgramAbiTypeDef } from "./program-abi-signatures.js";
+import type { ProgramAbiSession, ProgramAbiTypeCell } from "./program-abi-session.js";
+
+const PROGRAM_ABI_TYPE_ROLE = Object.freeze({
+  retainedModuleType: 0,
+  classLayout: 0,
+} as const);
+
+interface ProgramAbiClassLayoutObservation {
+  readonly classId: IrClassId;
+  readonly displayName: string;
+  readonly cell: ProgramAbiTypeCell;
+}
+
+function canonicalEntrySource(session: ProgramAbiSession): IrSourceId {
+  const entrySources = session.inventory.sources.filter((source) => source.kind === "entry");
+  if (entrySources.length !== 1) {
+    throw new ProgramAbiInvariantError(
+      "unknown-order-anchor",
+      `type ABI planning requires exactly one canonical entry source, found ${entrySources.length}`,
+    );
+  }
+  return entrySources[0]!.id;
+}
+
+/**
+ * Compilation-wide exact type/class-layout sidecar.
+ *
+ * Class collection observes allocator objects before DCE, while final planning
+ * happens after compaction. This is important for class expressions: legacy
+ * codegen may allocate the same exact declaration more than once under
+ * compatibility names, but one structural class ID must select the final live
+ * compatibility owner. Every superseded allocator type still receives its own
+ * generic retained-type entry.
+ */
+export class ProgramAbiTypeRegistry {
+  private readonly classes = new Map<IrClassId, ProgramAbiClassLayoutObservation[]>();
+  private planned = false;
+
+  constructor(
+    readonly session: ProgramAbiSession,
+    readonly ctx: CodegenContext,
+    readonly identityContext: IrPlanningIdentityContext,
+  ) {
+    session.assertModule(ctx.mod);
+    if (identityContext.inventory !== session.inventory) {
+      throw new ProgramAbiInvariantError(
+        "context-session-mismatch",
+        "Program ABI type registry and planning context do not share one inventory",
+      );
+    }
+  }
+
+  /** Capture one exact class layout allocation before DCE can replace it. */
+  observeClass(
+    declaration: ts.ClassDeclaration | ts.ClassExpression,
+    displayName: string,
+    type: StructTypeDef,
+  ): IrClassId {
+    if (this.planned) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        `cannot observe class layout ${displayName} after retained type planning`,
+      );
+    }
+    const classId = requireIrClassShapeClassId(declaration, this.identityContext);
+    const cell = this.session.typeCellFor(type) ?? this.session.createTypeCell(type);
+    const observations = this.classes.get(classId) ?? [];
+    const previous = observations.at(-1);
+    if (previous?.cell !== cell || previous.displayName !== displayName) {
+      observations.push(Object.freeze({ classId, displayName, cell }));
+      this.classes.set(classId, observations);
+    }
+    return classId;
+  }
+
+  /** Plan all source classes plus every retained allocator type after DCE. */
+  planRetained(): void {
+    if (this.planned) return;
+    this.planned = true;
+
+    for (const classRecord of this.session.inventory.classes) {
+      const observations = this.classes.get(classRecord.id) ?? [];
+      const live = observations.filter((observation) => observation.cell.current !== null);
+      const canonical = live.at(-1);
+      if (canonical) {
+        const current = canonical.cell.current;
+        if (!current || current.kind !== "struct") {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `class ${classRecord.id} no longer owns a retained struct layout`,
+          );
+        }
+        this.planClass(classRecord.id, canonical.displayName, current, canonical.cell);
+      } else {
+        this.planSlotlessClass(classRecord.id, classRecord.displayName);
+      }
+    }
+
+    const entrySourceId = canonicalEntrySource(this.session);
+    for (let finalIndex = 0; finalIndex < this.ctx.mod.types.length; finalIndex++) {
+      const type = this.ctx.mod.types[finalIndex]!;
+      const cell = this.session.typeCellFor(type) ?? this.session.createTypeCell(type);
+      if (this.session.locatorBindingId(cell)) continue;
+      this.planRetainedType(entrySourceId, finalIndex, type, cell);
+    }
+  }
+
+  private planClass(classId: IrClassId, displayName: string, type: StructTypeDef, cell: ProgramAbiTypeCell): void {
+    const ref = irClassTypeRef(classId, displayName);
+    const structuralReferenceKey = irTypeBindingKey(ref.binding);
+    this.session.ensurePlan({
+      id: ref.binding.bindingId,
+      structuralOrder: this.session.structuralOrder.forClass(classId, {
+        domain: "class",
+        roleOrdinal: PROGRAM_ABI_TYPE_ROLE.classLayout,
+      }),
+      structuralReferenceKey,
+      displayName,
+      slotPolicy: "required",
+      slotSpace: "type",
+      intent: {
+        kind: "class",
+        classId,
+        layoutKey: canonicalProgramAbiTypeDef(type),
+      },
+    });
+    this.session.registerStructuralReference(ref.binding.bindingId, structuralReferenceKey);
+    this.attachTypeLocator(ref.binding.bindingId, cell);
+  }
+
+  private planSlotlessClass(classId: IrClassId, displayName: string): void {
+    const ref = irClassTypeRef(classId, displayName);
+    const structuralReferenceKey = irTypeBindingKey(ref.binding);
+    this.session.ensurePlan({
+      id: ref.binding.bindingId,
+      structuralOrder: this.session.structuralOrder.forClass(classId, {
+        domain: "class",
+        roleOrdinal: PROGRAM_ABI_TYPE_ROLE.classLayout,
+      }),
+      structuralReferenceKey,
+      displayName,
+      slotPolicy: "none",
+      intent: {
+        kind: "class",
+        classId,
+        layoutKey: "unallocated",
+      },
+    });
+    this.session.registerStructuralReference(ref.binding.bindingId, structuralReferenceKey);
+  }
+
+  private planRetainedType(
+    entrySourceId: IrSourceId,
+    finalIndex: number,
+    type: TypeDef,
+    cell: ProgramAbiTypeCell,
+  ): void {
+    const ref = irSupportTypeRef(entrySourceId, "retained-module-type", `type#${finalIndex}`, finalIndex);
+    const structuralReferenceKey = irTypeBindingKey(ref.binding);
+    this.session.ensurePlan({
+      id: ref.binding.bindingId,
+      structuralOrder: this.session.structuralOrder.forSource(entrySourceId, {
+        domain: "type",
+        roleOrdinal: PROGRAM_ABI_TYPE_ROLE.retainedModuleType,
+        derivedOrdinal: finalIndex,
+      }),
+      structuralReferenceKey,
+      displayName: type.kind === "rec" ? `type#${finalIndex}` : (type.name ?? `type#${finalIndex}`),
+      slotPolicy: "required",
+      slotSpace: "type",
+      intent: {
+        kind: "type",
+        shapeKey: canonicalProgramAbiTypeDef(type),
+      },
+    });
+    this.session.registerStructuralReference(ref.binding.bindingId, structuralReferenceKey);
+    this.attachTypeLocator(ref.binding.bindingId, cell);
+  }
+
+  private attachTypeLocator(bindingId: IrBindingId, cell: ProgramAbiTypeCell): void {
+    if (!this.session.hasLocator(bindingId, cell)) {
+      this.session.attachLocator(bindingId, { kind: "type-cell", cell });
+    }
+  }
+}

--- a/tests/issue-3520-type-class-abi.test.ts
+++ b/tests/issue-3520-type-class-abi.test.ts
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { generateModule } from "../src/codegen/index.js";
+import { canonicalProgramAbiTypeDef, canonicalProgramAbiValType } from "../src/codegen/program-abi-signatures.js";
+import { irClassTypeRef } from "../src/ir/abi-bindings.js";
+import { buildIrUnitInventory, type IrClassId, type IrUnitInventory } from "../src/ir/identity.js";
+import type { StructTypeDef } from "../src/ir/types.js";
+
+// Register the codegen expression/statement delegates used by generateModule.
+import "../src/codegen/expressions.js";
+
+function exactClassId(inventory: IrUnitInventory, name: string): IrClassId {
+  const matches = inventory.classes.filter((candidate) => candidate.displayName === name);
+  if (matches.length !== 1) {
+    throw new Error(`expected one exact class ${name}, found ${matches.length}`);
+  }
+  return matches[0]!.id;
+}
+
+describe("#3520 production Program ABI type and class-layout planning", () => {
+  it("publishes every retained type exactly once and binds class layouts by exact class ID", () => {
+    const source = `
+      class Base {
+        value: number;
+        constructor(value: number) { this.value = value; }
+        read(): number { return this.value; }
+      }
+      class Child extends Base {
+        label: string = "child";
+        read(): number { return super.read() + this.label.length; }
+      }
+      export function main(): number { return new Child(7).read(); }
+    `;
+    const ast = analyzeSource(source, "type-class-abi.ts");
+    const inventory = buildIrUnitInventory([ast.sourceFile], {
+      entrySource: ast.sourceFile,
+      checker: ast.checker,
+    });
+    const classIds = {
+      base: exactClassId(inventory, "Base"),
+      child: exactClassId(inventory, "Child"),
+    };
+    const result = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+    expect(result.programAbi).toBeDefined();
+
+    const publication = result.programAbi!;
+    const typeEntries = publication.abi
+      .entries()
+      .filter(
+        (entry) =>
+          entry.slotPolicy === "required" &&
+          entry.slotSpace === "type" &&
+          (entry.intent.kind === "type" || entry.intent.kind === "class"),
+      );
+    expect(typeEntries).toHaveLength(result.module.types.length);
+
+    const finalTypeIndices = typeEntries.map((entry) => {
+      const finalIndex = publication.abi.resolveFinalIndex(entry.id);
+      expect(finalIndex).toEqual(expect.objectContaining({ space: "type" }));
+      if (!finalIndex || finalIndex.space !== "type") {
+        throw new Error(`missing final type slot for ${entry.id}`);
+      }
+      const finalType = result.module.types[finalIndex.index];
+      if (!finalType) throw new Error(`missing final type object ${finalIndex.index}`);
+      const shapeKey =
+        entry.intent.kind === "type"
+          ? entry.intent.shapeKey
+          : entry.intent.kind === "class"
+            ? entry.intent.layoutKey
+            : undefined;
+      expect(shapeKey).toBe(canonicalProgramAbiTypeDef(finalType));
+      return finalIndex.index;
+    });
+    expect([...finalTypeIndices].sort((left, right) => left - right)).toEqual(
+      result.module.types.map((_, index) => index),
+    );
+
+    for (const [name, classId] of [
+      ["Base", classIds.base],
+      ["Child", classIds.child],
+    ] as const) {
+      const ref = irClassTypeRef(classId, name);
+      const entry = publication.abi.get(ref.binding.bindingId);
+      expect(entry).toMatchObject({
+        id: ref.binding.bindingId,
+        displayName: name,
+        slotPolicy: "required",
+        slotSpace: "type",
+        intent: {
+          kind: "class",
+          classId,
+        },
+      });
+      if (!entry || entry.intent.kind !== "class") {
+        throw new Error(`missing exact class-layout ABI entry for ${name}`);
+      }
+      const finalIndex = publication.abi.resolveFinalIndex(entry.id);
+      if (!finalIndex || finalIndex.space !== "type") {
+        throw new Error(`missing exact class-layout slot for ${name}`);
+      }
+      const finalType = result.module.types[finalIndex.index];
+      expect(finalType).toEqual(expect.objectContaining({ kind: "struct", name }));
+      expect(entry.intent.layoutKey).toBe(canonicalProgramAbiTypeDef(finalType!));
+    }
+
+    const baseEntry = publication.abi.get(irClassTypeRef(classIds.base, "Base").binding.bindingId);
+    const childEntry = publication.abi.get(irClassTypeRef(classIds.child, "Child").binding.bindingId);
+    const baseIndex = baseEntry ? publication.abi.resolveFinalIndex(baseEntry.id)?.index : undefined;
+    const childIndex = childEntry ? publication.abi.resolveFinalIndex(childEntry.id)?.index : undefined;
+    expect(baseIndex).not.toBe(childIndex);
+    const childType = childIndex === undefined ? undefined : result.module.types[childIndex];
+    expect((childType as StructTypeDef | undefined)?.superTypeIdx).toBe(baseIndex);
+  });
+
+  it("excludes debug names but retains property offsets and branded value semantics in shape keys", () => {
+    const base: StructTypeDef = {
+      kind: "struct",
+      name: "DebugA",
+      fields: [
+        {
+          name: "flag",
+          type: { kind: "i32", boolean: true },
+          mutable: true,
+          jsBoolean: true,
+        },
+      ],
+      final: true,
+    };
+    const relabelled: StructTypeDef = {
+      ...base,
+      name: "DebugB",
+      fields: base.fields.map((field) => ({ ...field, type: { ...field.type } })),
+    };
+    const differentField: StructTypeDef = {
+      ...relabelled,
+      fields: relabelled.fields.map((field) => ({ ...field, name: "other" })),
+    };
+
+    expect(canonicalProgramAbiTypeDef(base)).toBe(canonicalProgramAbiTypeDef(relabelled));
+    expect(canonicalProgramAbiTypeDef(base)).not.toBe(canonicalProgramAbiTypeDef(differentField));
+    const canonical = JSON.parse(canonicalProgramAbiTypeDef(base)) as {
+      fields: Array<{ type: string; jsBoolean?: boolean }>;
+    };
+    expect(canonical.fields[0]).toEqual({
+      type: canonicalProgramAbiValType({ kind: "i32", boolean: true }),
+      name: "flag",
+      mutable: true,
+      jsBoolean: true,
+    });
+  });
+
+  it("gives a multiply collected class expression one exact class owner and catalogs its legacy duplicate", () => {
+    const source = `
+      const C = class {
+        value: number;
+        constructor(value: number) { this.value = value; }
+        read(): number { return this.value; }
+      };
+      export function main(): number { return new C(9).read(); }
+    `;
+    const ast = analyzeSource(source, "class-expression-type-abi.ts");
+    const inventory = buildIrUnitInventory([ast.sourceFile], {
+      entrySource: ast.sourceFile,
+      checker: ast.checker,
+    });
+    expect(inventory.classes).toHaveLength(1);
+    const classId = inventory.classes[0]!.id;
+    const result = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+    expect(result.programAbi).toBeDefined();
+
+    const publication = result.programAbi!;
+    const classEntries = publication.abi
+      .entries()
+      .filter((entry) => entry.intent.kind === "class" && entry.intent.classId === classId);
+    expect(classEntries).toHaveLength(1);
+    expect(classEntries[0]).toMatchObject({
+      slotPolicy: "required",
+      slotSpace: "type",
+      intent: {
+        kind: "class",
+        classId,
+      },
+    });
+    const classIndex = publication.abi.resolveFinalIndex(classEntries[0]!.id);
+    if (!classIndex || classIndex.space !== "type") {
+      throw new Error("missing exact class-expression layout slot");
+    }
+    const canonicalLayout = result.module.types[classIndex.index];
+    expect(canonicalLayout).toEqual(
+      expect.objectContaining({
+        kind: "struct",
+        name: expect.stringMatching(/^__anonClass_/),
+      }),
+    );
+
+    const legacyDuplicateIndices = result.module.types
+      .map((type, index) => ({ type, index }))
+      .filter(
+        ({ type, index }) =>
+          index !== classIndex.index &&
+          type.kind === "struct" &&
+          (type.name === "C" || type.name.startsWith("__anonClass_")),
+      )
+      .map(({ index }) => index);
+    expect(legacyDuplicateIndices.length).toBeGreaterThan(0);
+    for (const duplicateIndex of legacyDuplicateIndices) {
+      const genericOwner = publication.abi.entries().find((entry) => {
+        if (entry.intent.kind !== "type") return false;
+        return publication.abi.resolveFinalIndex(entry.id)?.index === duplicateIndex;
+      });
+      expect(genericOwner).toMatchObject({
+        slotPolicy: "required",
+        slotSpace: "type",
+        intent: { kind: "type" },
+      });
+    }
+  });
+
+  it("keeps an ambient class explicit as a slotless layout intention", () => {
+    const source = `
+      declare class HostValue {
+        readonly value: number;
+      }
+      export function main(): number { return 1; }
+    `;
+    const ast = analyzeSource(source, "ambient-class-type-abi.ts");
+    const inventory = buildIrUnitInventory([ast.sourceFile], {
+      entrySource: ast.sourceFile,
+      checker: ast.checker,
+    });
+    const classId = exactClassId(inventory, "HostValue");
+    const result = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+    expect(result.programAbi).toBeDefined();
+
+    const entry = result.programAbi!.abi.get(irClassTypeRef(classId, "HostValue").binding.bindingId);
+    expect(entry).toMatchObject({
+      displayName: "HostValue",
+      slotPolicy: "none",
+      intent: {
+        kind: "class",
+        classId,
+        layoutKey: "unallocated",
+      },
+    });
+    expect(entry ? result.programAbi!.abi.resolveFinalIndex(entry.id) : undefined).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- observe exact class type objects before DCE and follow them through Program ABI type cells
- publish every retained post-compaction type slot plus slotless intentions for unallocated classes
- canonicalize final class/type contracts and preserve structural ownership across duplicate legacy class-expression allocations

## Validation

- `pnpm run typecheck`
- focused C13 matrix: 4/4
- sharded #3520 matrix: 251 passing / 1 unchanged mainline-control failure across 44 files
- #2138 multi-source matrix: 6/6
- broad class, inheritance, accessor, linear, and 29-case cross-backend matrix: green
- IR fallback gate: zero unintended, post-claim, or module-level increase
- IR-only hybrid readiness: 31 emitted / 6 typed Unsupported / 0 Invariants across 37 terminal units
- equivalence: 1,611 passing / 32 known failing / 0 new regressions

Continues the Program ABI migration from merged PR #3739. The remaining work is tracked in `plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md`.
