### PR TITLE
fix(string): distinguish NaN from omitted split limits

### DIFF
--- a/plan/issues/3761-string-split-nan-limit.md
+++ b/plan/issues/3761-string-split-nan-limit.md
@@ -1,0 +1,56 @@
+---
+id: 3761
+title: "String.prototype.split explicit NaN limit is mistaken for omission"
+status: done
+created: 2026-07-28
+updated: 2026-07-28
+completed: 2026-07-28
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: bug
+area: codegen
+es_edition: ES5
+language_feature: string-prototype-split
+goal: test262-conformance
+assignee: ttraenkler/codex-es5-string-split
+related: [1441, 2125]
+---
+
+# #3761 — distinguish explicit NaN from an omitted split limit
+
+## Problem
+
+The host ABI pads a missing `String.prototype.split` limit with `NaN`, then
+removes a trailing `NaN` before invoking the JavaScript host method. An explicit
+`NaN` is therefore also removed, despite ES5 requiring `ToUint32(NaN) = 0`.
+
+The ES5 test
+`built-ins/String/prototype/split/call-split-l-na-n-instance-is-string-hello.js`
+returns three pieces instead of an empty array in the host lane.
+
+## Fix
+
+Use `-1` as the omitted-limit ABI sentinel. `ToUint32(-1)` is `2^32 - 1`, so
+an explicit `-1` and an omitted limit are observably equivalent for split,
+while an explicit `NaN` remains available for the host method to coerce to zero.
+
+## Acceptance criteria
+
+- Explicit `NaN` returns an empty result in host and standalone modes.
+- Omitted and explicit `-1` limits remain unbounded.
+- The exact ES5 test flips to pass in the host lane.
+- The 70-test non-RegExp ES5 split partition has no pass-to-fail regressions.
+
+## Measured result
+
+Local-vs-local A/B at `origin/main@a790605025acb28065bd9de63a84e0f72b8bd360`:
+
+- Host non-RegExp ES5 split partition: **56/70 → 57/70**, with the exact NaN
+  limit test as the sole fail-to-pass flip and zero regressions.
+- Standalone non-RegExp ES5 split partition: **35/70 → 35/70**, with zero
+  changes and zero regressions. The standalone helper already computes the
+  correct empty length for explicit NaN; that test remains red only because a
+  subsequent out-of-bounds element read returns `null` rather than `undefined`,
+  a separate array/value-representation residual.
+- Focused split tests: **23/23 pass** across #3761, #1441, and #2125.

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -2662,16 +2662,15 @@ export function compileReceiverMethodCall(
               fctx.body.push({ op: "ref.null.extern" });
             }
           } else if (pt.kind === "f64") {
-            // #1441 — `split` uses NaN as the "limit was not provided"
-            // sentinel. ToUint32(NaN) === 0 would produce `[]` if the runtime
-            // passed it through verbatim, so the `string_method` host shim
-            // strips a trailing NaN limit before invoking the JS method.
+            // #3761 — `split` uses -1 for omission so explicit NaN still
+            // reaches host ToUint32(NaN) === 0.
             // #2002 — includes/startsWith/endsWith likewise use NaN for an
             // omitted position so the host shim drops it and the JS method
             // applies its spec default (0 for includes/startsWith, length
             // for endsWith) instead of ToInteger(NaN)=0.
             if (method === "split" || method === "includes" || method === "startsWith" || method === "endsWith") {
-              fctx.body.push({ op: "f64.const", value: Number.NaN });
+              const sentinel = method === "split" ? -1 : Number.NaN;
+              fctx.body.push({ op: "f64.const", value: sentinel });
             } else {
               fctx.body.push({ op: "f64.const", value: 0 });
             }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6130,9 +6130,9 @@ export const STRING_METHODS: Record<string, { params: ValType[]; result: ValType
     params: [{ kind: "f64" }, { kind: "externref" }],
     result: { kind: "externref" },
   },
-  // split: separator (externref) + limit (f64, NaN sentinel for "no limit" — #1441).
-  // The host runtime in `string_method` detects NaN and calls `split(sep)` without
-  // the limit so the spec default 2^32-1 applies (instead of ToUint32(NaN) === 0).
+  // split: separator (externref) + limit (f64, -1 sentinel for "no limit" — #3761).
+  // The host runtime in `string_method` detects -1 and calls `split(sep)` without
+  // the limit. An explicit NaN must remain distinct: ToUint32(NaN) is 0.
   split: { params: [{ kind: "externref" }, { kind: "f64" }], result: { kind: "externref" } },
   match: { params: [{ kind: "externref" }], result: { kind: "externref" } },
   search: { params: [{ kind: "externref" }], result: { kind: "f64" } },

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7881,21 +7881,21 @@ function resolveImport(
         } else {
           args = a.map(coerce);
         }
-        // #1441 — `split` uses NaN as the "limit was not provided" sentinel.
-        // ToUint32(NaN) is 0, which would produce an empty array; per spec
-        // (22.1.3.21 step 8) a missing limit means 2^32 - 1, so we drop the
-        // trailing NaN and let the JS host apply the default.
+        // #3761 — split uses -1 for omission/2^32 - 1; explicit NaN remains ToUint32(NaN) = 0.
         // #2002 — includes/startsWith/endsWith use NaN as the "position not
         // provided" sentinel for the same reason: a trailing NaN means the
         // arg was omitted, so drop it and let the JS method apply its spec
         // default (0 for includes/startsWith, length for endsWith) instead of
         // ToInteger(NaN)=0.
-        if (
-          (method === "split" || method === "includes" || method === "startsWith" || method === "endsWith") &&
-          args.length >= 2
-        ) {
+        if (args.length >= 2) {
           const last = args[args.length - 1];
-          if (typeof last === "number" && Number.isNaN(last)) {
+          const omitLast =
+            method === "split"
+              ? last === -1
+              : (method === "includes" || method === "startsWith" || method === "endsWith") &&
+                typeof last === "number" &&
+                Number.isNaN(last);
+          if (omitLast) {
             args.pop();
           }
         }

--- a/tests/issue-3761-string-split-nan-limit.test.ts
+++ b/tests/issue-3761-string-split-nan-limit.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3761 — host String.prototype.split used NaN as the ABI sentinel for an
+ * omitted limit. That made split(separator, NaN) indistinguishable from
+ * split(separator), even though ToUint32(NaN) is 0 and the former must return
+ * an empty array. The omitted-limit sentinel is now -1; ToUint32(-1) is the
+ * same unbounded 2^32 - 1 limit, so the collision is behaviorally harmless.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string, target?: "standalone"): Promise<number> {
+  const result = await compile(`export function test(): number { ${source} }`, {
+    fileName: "test.ts",
+    target,
+  });
+  expect(result.success, result.errors?.[0]?.message ?? "compile failed").toBe(true);
+  const imports = target === "standalone" ? {} : buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  if (target !== "standalone") {
+    (imports as ReturnType<typeof buildImports>).setExports?.(instance.exports as WebAssembly.Exports);
+  }
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#3761 String.prototype.split NaN limit", () => {
+  it("host: explicit NaN is ToUint32(NaN) = 0, not an omitted limit", async () => {
+    expect(await run(`return "hello".split("l", NaN).length;`)).toBe(0);
+  });
+
+  it("host: an omitted limit remains unbounded", async () => {
+    expect(await run(`return "hello".split("l").length;`)).toBe(3);
+  });
+
+  it("host: explicit -1 remains equivalent to the 2^32 - 1 limit", async () => {
+    expect(await run(`return "hello".split("l", -1).length;`)).toBe(3);
+  });
+
+  it("standalone: explicit NaN remains an empty result", async () => {
+    expect(await run(`return "hello".split("l", NaN).length;`, "standalone")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- use `-1` instead of `NaN` as the host ABI sentinel for an omitted `String.prototype.split` limit
- preserve explicit `NaN` so the host applies `ToUint32(NaN) = 0`
- cover omitted, explicit `NaN`, and explicit `-1` limits in host and standalone modes

## Measured conformance

Local-vs-local A/B on `origin/main@a790605025acb28065bd9de63a84e0f72b8bd360`, excluding RegExp and `Symbol.split` cases:

- host: **56/70 → 57/70**; one fail-to-pass flip, zero regressions
- standalone: **35/70 → 35/70**; zero changes, zero regressions

The host flip is:

- `built-ins/String/prototype/split/call-split-l-na-n-instance-is-string-hello.js`

Standalone already computes the correct empty length for explicit `NaN`; the exact test remains red because its subsequent out-of-bounds element read returns `null` instead of `undefined`, a separate array/value-representation residual.

## Verification

- `pnpm exec vitest run tests/issue-3761-string-split-nan-limit.test.ts tests/issue-1441.test.ts tests/issue-2125.test.ts` — 23/23 passed
- `pnpm run typecheck`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- `pnpm run check:issues`
- targeted Prettier check

Plan issue: #3761
