### PR TITLE
fix(string): preserve replace coercion order (#3762)

### DIFF
--- a/plan/issues/3762-es5-string-replace-coercion-order.md
+++ b/plan/issues/3762-es5-string-replace-coercion-order.md
@@ -1,0 +1,47 @@
+---
+id: 3762
+title: "ES5 String.prototype.replace searchValue/replaceValue coercion order"
+status: in-progress
+created: 2026-07-28
+priority: high
+task_type: bugfix
+area: runtime
+goal: es5
+es_edition: 5
+assignee: ttraenkler/codex-es5-string-replace
+sprint: current
+loc-budget-allow:
+  - src/runtime.ts
+---
+
+# #3762 — ES5 `String.prototype.replace` coercion order
+
+## Problem
+
+The host bridge eagerly coerces a Wasm-struct `replaceValue` before invoking
+the native `String.prototype.replace` algorithm. ES5 requires coercing
+`searchValue` first, so a throwing `replaceValue.toString` incorrectly wins
+over a throwing `searchValue.toString`.
+
+The current-main authoritative Test262 failures are:
+
+- `S15.5.4.11_A1_T11.js`
+- `S15.5.4.11_A1_T12.js`
+
+Both report `inreplaceValue` where the expected abrupt completion is
+`insearchValue`.
+
+## Fix
+
+Pass positively identified data-struct arguments to the native algorithm as
+host proxies instead of eagerly applying `ToPrimitive`. Other argument shapes,
+including function replacers, keep their existing behavior so this bounded
+slice does not overlap the RegExp/function-replacer lane.
+
+## Acceptance criteria
+
+- Both ES5 Test262 cases pass in the host lane.
+- Function-replacer and RegExp cases retain their baseline status.
+- The surrounding `String.prototype.replace` corpus has no regressions.
+- Standalone remains unchanged; dynamic object search values are explicitly
+  refused by its existing `#1474` symbol-protocol boundary.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7744,7 +7744,24 @@ function _wrapRawCallableHostValue(
 ): any {
   if (!_isWasmStruct(value)) return value;
   const callable = _maybeWrapCallableUnknownArity(value, callbackState);
-  return callable !== value ? callable : _wrapForHost(value, exports);
+  return callable !== value ? callable : _wrapForHost(value, exports ?? callbackState?.getExports());
+}
+
+function _deferStringDataArg(
+  value: any,
+  callbackState: { getExports: () => Record<string, Function> | undefined } | undefined,
+  fallback: (value: any) => any,
+): any {
+  const exports = callbackState?.getExports();
+  const isData = exports?.__is_data_struct as ((value: any) => number) | undefined;
+  if (_isWasmStruct(value) && typeof isData === "function") {
+    try {
+      if (isData(value) === 1) return _wrapForHost(value, exports);
+    } catch {
+      /* fall through to the pre-existing coercion path */
+    }
+  }
+  return fallback(value);
 }
 
 /** Build the live-method fallback used when raw lookup returns a JS callable. */
@@ -7877,7 +7894,7 @@ function resolveImport(
           } else {
             wrapped = first;
           }
-          args = [wrapped, ...a.slice(1).map(coerce)];
+          args = [wrapped, ...a.slice(1).map((value) => _deferStringDataArg(value, callbackState, coerce))];
         } else {
           args = a.map(coerce);
         }

--- a/tests/issue-3762.test.ts
+++ b/tests/issue-3762.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source, {
+    fileName: "issue-3762.ts",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as unknown as { test: () => unknown }).test();
+}
+
+describe("#3762 — String.prototype.replace coercion order", { timeout: 30_000 }, () => {
+  it("coerces searchValue before a non-callable replaceValue", async () => {
+    const result = await run(`
+      export function test(): number {
+        const searchValue: any = {
+          toString: function(): string { throw "search"; },
+        };
+        const replaceValue: any = {
+          toString: function(): string { throw "replacement"; },
+        };
+        try {
+          "subject".replace(searchValue, replaceValue);
+        } catch (error) {
+          if (error === "search") return 1;
+          if (error === "replacement") return 2;
+        }
+        return 0;
+      }
+    `);
+    expect(result).toBe(1);
+  });
+
+  for (const file of ["S15.5.4.11_A1_T11.js", "S15.5.4.11_A1_T12.js"]) {
+    it(`passes the ES5 Test262 case ${file}`, async () => {
+      const result = await runTest262File(
+        resolve("test262/test/built-ins/String/prototype/replace", file),
+        "built-ins/String",
+      );
+      expect(result.status, result.error).toBe("pass");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- defer host coercion for positively identified data-struct replacement arguments until native `String.prototype.replace` reaches the spec step
- preserve the existing RegExp/function-replacer path so this slice does not overlap that lane
- add a direct regression plus the two authoritative ES5 Test262 cases

## Measured conformance impact

Local-vs-local A/B at `a790605025acb28065bd9de63a84e0f72b8bd360` using `runTest262File`:

- ES5 `String.prototype.replace` host: 24/38 -> 26/38; exactly `S15.5.4.11_A1_T11.js` and `S15.5.4.11_A1_T12.js` flip fail -> pass
- ES5 standalone: 17 pass / 5 fail / 16 compile-error out of 38 -> unchanged
- full 55-file host directory: 25 pass / 19 fail / 11 compile-error -> 27 pass / 17 fail / 11 compile-error
- full 55-file standalone directory: 22 pass / 11 fail / 22 compile-error -> unchanged
- zero regressions; every non-target host status/error row and every standalone status/error row is identical to the control

## Validation

- `pnpm exec vitest run tests/issue-3762.test.ts --reporter=dot` (3/3)
- `pnpm run typecheck`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- Prettier and `git diff --check`

Plan issue: #3762.