### PR TITLE
fix(strings): coerce standalone String wrapper data

### DIFF
--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -86,9 +86,35 @@ function isNativeStringMode(mode: CoercionMode): boolean {
  */
 export type ToStringHint = "string" | "default";
 
+type ToStringStaticType = ts.Type | TypeFact;
+
+function isCheckerType(type: ToStringStaticType): type is ts.Type {
+  return typeof (type as ts.Type).flags === "number";
+}
+
+function isStaticStringType(type: ToStringStaticType): boolean {
+  if (isCheckerType(type)) return isStringType(type);
+  return type.kind === "string" || (type.kind === "builtin" && type.name === "String");
+}
+
+function isStaticBooleanType(type: ToStringStaticType): boolean {
+  return isCheckerType(type) ? isBooleanType(type) : type.kind === "boolean";
+}
+
+function isStaticNullType(type: ToStringStaticType): boolean {
+  return isCheckerType(type) ? (type.flags & ts.TypeFlags.Null) !== 0 : type.kind === "null";
+}
+
+function isStaticUndefinedType(type: ToStringStaticType): boolean {
+  return isCheckerType(type)
+    ? (type.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0
+    : type.kind === "undefined" || type.kind === "void";
+}
+
 /**
  * Emit `ToString(operand)` for an operand that has ALREADY been compiled to the
- * top of the value stack with ValType `valType` and static TS type `tsType`.
+ * top of the value stack with ValType `valType` and static checker/oracle type
+ * fact `staticType`.
  *
  * This is the consolidated cascade the expression-based ToString copies shared:
  *   void            → "undefined"
@@ -117,7 +143,7 @@ export function emitToString(
   ctx: CodegenContext,
   fctx: FunctionContext,
   valType: ValType | null,
-  tsType: ts.Type,
+  staticType: ToStringStaticType,
   hint: ToStringHint,
 ): ValType {
   const mode = coercionMode(ctx);
@@ -131,14 +157,14 @@ export function emitToString(
 
   // ── string-typed ref passthrough (native modes only — a native string-typed
   //    substitution is already an $AnyString/NativeString ref) ──
-  if (native && (valType.kind === "ref" || valType.kind === "ref_null") && isStringType(tsType)) {
+  if (native && (valType.kind === "ref" || valType.kind === "ref_null") && isStaticStringType(staticType)) {
     return valType;
   }
 
   // ── i32 boolean → "true"/"false" ──
   // Honour the boolean brand on the ValType (#2016/#2030: i32 predicates carry
   // `boolean: true`) as well as the static TS type.
-  if (valType.kind === "i32" && (isBooleanType(tsType) || (valType as { boolean?: true }).boolean)) {
+  if (valType.kind === "i32" && (isStaticBooleanType(staticType) || (valType as { boolean?: true }).boolean)) {
     emitBoolToString(ctx, fctx);
     return native ? nativeStringType(ctx) : { kind: "externref" };
   }
@@ -172,8 +198,8 @@ export function emitToString(
 
   // ── externref ──
   if (valType.kind === "externref") {
-    const isNull = (tsType.flags & ts.TypeFlags.Null) !== 0;
-    const isUndef = (tsType.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0;
+    const isNull = isStaticNullType(staticType);
+    const isUndef = isStaticUndefinedType(staticType);
     if (isNull) {
       fctx.body.push({ op: "drop" });
       pushStringLiteral(ctx, fctx, "null");
@@ -184,7 +210,7 @@ export function emitToString(
       pushStringLiteral(ctx, fctx, "undefined");
       return native ? nativeStringType(ctx) : { kind: "externref" };
     }
-    if (isStringType(tsType)) {
+    if (isStaticStringType(staticType)) {
       // A real string externref — already concat-ready.
       return { kind: "externref" };
     }

--- a/src/codegen/declarations/import-collector.ts
+++ b/src/codegen/declarations/import-collector.ts
@@ -512,14 +512,14 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
       }
     }
   }
-  // String(expr) calls need number_toString
+  // String(expr) and native new String(expr) need number_toString for ToString.
   if (
-    ts.isCallExpression(node) &&
+    (ts.isCallExpression(node) || ((ctx.standalone || ctx.wasi) && ts.isNewExpression(node))) &&
     ts.isIdentifier(node.expression) &&
     node.expression.text === "String" &&
-    node.arguments.length >= 1
+    (node.arguments?.length ?? 0) >= 1
   ) {
-    const argType = ctx.checker.getTypeAtLocation(node.arguments[0]!);
+    const argType = ctx.checker.getTypeAtLocation(node.arguments![0]!);
     if (isNumberType(argType) || !isStringType(argType)) {
       state.primitiveNeeded.add("number_toString");
     }

--- a/src/codegen/expressions/new-builtin-globals.ts
+++ b/src/codegen/expressions/new-builtin-globals.ts
@@ -18,6 +18,7 @@ import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
 import { addUnionImports, getArrTypeIdxFromVec, getOrRegisterVecType, typedArrayVecStorage } from "../index.js";
 import { coercionPlan } from "../coercion-plan.js";
+import { emitToString } from "../coercion-engine.js";
 import { emitTaViewConstruct, emitTaViewConstructWindowed } from "../dataview-native.js";
 import { emitNativeDateParse } from "../date-parse-native.js";
 import { compileObjectLiteralAsExternref } from "../literals.js";
@@ -49,6 +50,28 @@ import {
 
 /** Sentinel: the `new` target is not one of the built-in global constructors. */
 export const NEW_GLOBAL_FALLTHROUGH = Symbol("new-builtin-global-fallthrough");
+
+/**
+ * Emit the argument stored in a String wrapper's [[StringData]] slot.
+ * Returns true when a statically-known Symbol emitted a terminal TypeError.
+ */
+function emitStringWrapperValue(ctx: CodegenContext, fctx: FunctionContext, value: ts.Expression): boolean {
+  if (!noJsHost(ctx)) {
+    compileExpression(ctx, fctx, value, { kind: "externref" });
+    return false;
+  }
+  if (ctx.oracle.staticJsTypeOf(value) === "symbol") {
+    const valueType = compileExpression(ctx, fctx, value);
+    if (valueType !== null) fctx.body.push({ op: "drop" });
+    emitThrowTypeError(ctx, fctx, "Cannot convert a Symbol value to a string");
+    return true;
+  }
+  const valueFact = ctx.oracle.typeFactOf(value);
+  const valueType = compileExpression(ctx, fctx, value);
+  const stringType = emitToString(ctx, fctx, valueType, valueFact, "string");
+  if (stringType.kind !== "externref") coerceType(ctx, fctx, stringType, { kind: "externref" });
+  return false;
+}
 
 export function tryCompileBuiltinGlobalNew(
   ctx: CodegenContext,
@@ -161,7 +184,7 @@ export function tryCompileBuiltinGlobalNew(
         // new String(x) → create real JS String wrapper object via __new_String host import
         // (typeof new String("") === "object", not "string")
         if (args.length >= 1) {
-          compileExpression(ctx, fctx, args[0]!, { kind: "externref" });
+          if (emitStringWrapperValue(ctx, fctx, args[0]!)) return { kind: "externref" };
         } else {
           const emptyStrResult = compileStringLiteral(ctx, fctx, "");
           if (!emptyStrResult) {

--- a/tests/issue-2742-charcodeat-new-string.test.ts
+++ b/tests/issue-2742-charcodeat-new-string.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, {
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.imports).toEqual([]);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#2742 new String(value) standalone ToString coercion", () => {
+  it("charCodeAt reads the decimal text of a numeric wrapper", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          return new String(42).charCodeAt(function () {}());
+        }
+      `),
+    ).toBe(52);
+  });
+
+  it("stores string data for boolean and null inputs", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const a = new String(true);
+          const b = new String(null);
+          return a.charCodeAt(0) * 1000 + b.charCodeAt(0);
+        }
+      `),
+    ).toBe(116110);
+  });
+
+  it("runs object ToString before storing the wrapper data", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const value: any = {
+            toString() {
+              return "xy";
+            }
+          };
+          return new String(value).charCodeAt(0);
+        }
+      `),
+    ).toBe(120);
+  });
+
+  it("preserves already-string and omitted values", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const a = new String("A");
+          const b = new String();
+          return a.charCodeAt(0) + b.length;
+        }
+      `),
+    ).toBe(65);
+  });
+
+  it("throws TypeError for a Symbol input", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          try {
+            new String(Symbol("x"));
+            return 0;
+          } catch (error) {
+            return error instanceof TypeError ? 1 : 2;
+          }
+        }
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- coerce standalone/WASI `new String(value)` arguments with `ToString` before storing `[[StringData]]`
- pre-register numeric string formatting for native String constructor arguments
- cover primitive, object, omitted, and Symbol constructor inputs in standalone mode

## ES5 Test262 delta

Authoritative original-harness `S15.5.4.5_*` cohort (19 tests):

- host: 16/19 -> 16/19
- standalone: 12/19 -> 13/19
- gains: `S15.5.4.5_A1_T9.js`
- losses: none

## Validation

- `pnpm exec vitest run tests/issue-2742-charcodeat-new-string.test.ts tests/issue-2160-wrapper-strmethod-standalone.test.ts tests/issue-3216.test.ts tests/issue-3118-new-object-primitive.test.ts --reporter=dot` (27 passed)
- `pnpm run typecheck`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- `pnpm run check:coercion-sites`
- `pnpm run check:pushraw`

An unrelated `codePointAt.call("ABC", 9)` assertion in `tests/issue-2875-slice2-num.test.ts` fails identically on the branch and an isolated `origin/main` control (9 passed, 1 failed).
