### PR TITLE
feat(ir): own the complete global ABI space

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -5,7 +5,7 @@ status: in-progress
 assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
-branch: codex/3520-c13-type-class-abi
+branch: codex/3520-c14-global-abi
 pr: 3746
 last_merged_pr: 3679
 sprint: current
@@ -88,6 +88,7 @@ files:
   - src/codegen/dead-elimination.ts
   - src/codegen/func-space.ts
   - src/codegen/program-abi-import-planning.ts
+  - src/codegen/program-abi-global-planning.ts
   - src/codegen/program-abi-planning.ts
   - src/codegen/program-abi-signatures.ts
   - src/codegen/program-abi-session.ts
@@ -138,6 +139,7 @@ files:
   - tests/issue-3520-class-support-callable-abi.test.ts
   - tests/issue-3520-class-method-alias-abi.test.ts
   - tests/issue-3520-type-class-abi.test.ts
+  - tests/issue-3520-global-population-abi.test.ts
   - tests/issue-3520-program-abi-import-callable-planning.test.ts
   - tests/issue-3520-imported-callable-abi.test.ts
   - tests/issue-2856-calendar-residuals.test.ts
@@ -1695,6 +1697,55 @@ remaining imported globals, exports and public aliases, and production
 display-name scans still remain before R1 can close. This slice populates the
 class/type authority but deliberately does not yet reroute existing
 `structMap` consumers through it.
+
+### 2026-07-28 complete retained global-space continuation
+
+The stacked continuation on `codex/3520-c14-global-abi` makes the complete
+final Wasm global index space explicit in the production Program ABI:
+
+- finalization walks exact retained import-global objects followed by exact
+  defined `GlobalDef` objects, matching Wasm global-index order without reading
+  `moduleGlobals`, a compatibility name, or a captured raw index;
+- a source, runtime, cache, or string-constant global that already has a
+  semantic ABI owner keeps that owner. Every remaining allocator object
+  receives one deterministic entry-source-owned global binding, so the
+  complete final global space is a bijection rather than a selected subset;
+- generic retained import identities preserve the exact module/field payload
+  but use a distinct structural role. A compatibility duplicate therefore
+  cannot collide with a semantic imported-global binding even when both share
+  a spelling and ordinal;
+- duplicate import spellings remain distinct allocator-owned slots and make
+  the legacy reverse lookup explicitly ambiguous. Reusing one allocator object
+  in two final slots is a typed invariant rather than first- or last-wins
+  behavior; and
+- every newly cataloged global retains its structured value type, mutability,
+  exact allocator locator, and post-type-compaction contract. Publication
+  resolves the object against the final module only after the index spaces
+  settle.
+
+The focused global-population matrix passes **4/4**. The sharded #3520 matrix
+reports **255 passing / 1 failing across 45 files**; the sole failure is the
+unchanged linear inventory-count spy assertion in
+`issue-3520-context-integration.test.ts`. The exact C13 control reproduces the
+same failure. Strict TypeScript, scoped Biome/Prettier, diff, LOC/function
+budget, dead-export, checker-oracle, issue-spec, and fallback gates pass.
+The focused class/accessor/externref/Promise/cross-backend matrix passes
+**85/85**, the #2138 multi-source matrix passes **6/6**, and linear integration
+passes **3/3**.
+Hybrid readiness remains **READY** at **31 IR-emitted / 6 typed Unsupported /
+0 Invariants across 37 terminal units**, with all 37 legacy bodies still
+emitted. The eight-shard equivalence gate reports **1,611 passing / 32 known
+failing / 0 new regressions**; four baseline rows now pass and the shared
+baseline remains unchanged. The four direct class runtime suites retain the
+exact C13 control's **23/23** missing-`string_constants` host-fixture failures,
+so they are not C14 regressions.
+
+C14 closes complete imported and defined global-slot population, not R1.
+Inherited accessors, static and externref/Promise-host support helpers, exports
+and public aliases, production consumers of the populated class/type/global
+authorities, and the `LegacyAbiAdapter` replacement of direct `funcMap`,
+`structMap`, module-array, and display-name scans still remain before R1 can
+close.
 
 ### R1a validation evidence
 

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -6,7 +6,7 @@ assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
 branch: codex/3520-c14-global-abi
-pr: 3746
+pr: 3752
 last_merged_pr: 3679
 sprint: current
 created: 2026-07-21

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -15,6 +15,7 @@ import { nativeLiteralRegExpEngineConfig } from "../regexp-standalone.js";
 import { createFallbackCounts } from "../fallback-telemetry.js";
 import type { ProgramAbiSession } from "../program-abi-session.js";
 import { ProgramAbiCallableProviderRegistry } from "../program-abi-provider-planning.js";
+import { ProgramAbiGlobalRegistry } from "../program-abi-global-planning.js";
 import { ProgramAbiTypeRegistry } from "../program-abi-type-planning.js";
 import type { CodegenContext, CodegenOptions } from "./types.js";
 
@@ -369,6 +370,7 @@ export function createCodegenContext(
   };
   if (programAbiSession) {
     ctx.programAbiCallableProviders = new ProgramAbiCallableProviderRegistry(programAbiSession, ctx);
+    ctx.programAbiGlobals = new ProgramAbiGlobalRegistry(programAbiSession, ctx);
     if (irPlanningIdentityContext) {
       ctx.programAbiTypes = new ProgramAbiTypeRegistry(programAbiSession, ctx, irPlanningIdentityContext);
     }

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1053,6 +1053,7 @@ export interface CodegenContext {
   mod: WasmModule;
   programAbiSession?: import("../program-abi-session.js").ProgramAbiSession;
   programAbiCallableProviders?: import("../program-abi-provider-planning.js").ProgramAbiCallableProviderRegistry;
+  programAbiGlobals?: import("../program-abi-global-planning.js").ProgramAbiGlobalRegistry;
   programAbiTypes?: import("../program-abi-type-planning.js").ProgramAbiTypeRegistry;
   irPlanningIdentityContext?: import("../../ir/planning-identity.js").IrPlanningIdentityContext;
   checker: ts.TypeChecker;

--- a/src/codegen/program-abi-global-planning.ts
+++ b/src/codegen/program-abi-global-planning.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { irGlobalBindingKey, irRetainedImportGlobalRef, irSupportGlobalRef } from "../ir/abi-bindings.js";
+import type { IrSourceId } from "../ir/identity.js";
+import type { IrGlobalRef } from "../ir/nodes.js";
+import { ProgramAbiInvariantError } from "../ir/program-abi.js";
+import type { GlobalDef, Import, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { canonicalProgramAbiValType } from "./program-abi-signatures.js";
+import type { ProgramAbiSession, ProgramAbiSlotLocator } from "./program-abi-session.js";
+
+const PROGRAM_ABI_RETAINED_GLOBAL_ROLE = 5;
+const RETAINED_MODULE_GLOBAL_ROLE = "retained-module-global";
+type ProgramAbiGlobalLocator = Extract<ProgramAbiSlotLocator, { readonly kind: "defined-global" | "import-global" }>;
+
+function displayName(name: string, finalIndex: number): string {
+  return name.length > 0 ? name : `global#${finalIndex}`;
+}
+
+/**
+ * Final global-space population owner.
+ *
+ * Exact source/runtime globals and string-constant imports may already have a
+ * semantic Program ABI owner. This registry preserves those owners and
+ * catalogs every remaining allocator object after all global allocation and
+ * import shifts have settled. The result is a total one-to-one projection of
+ * the final Wasm global index space without consulting moduleGlobals or names.
+ */
+export class ProgramAbiGlobalRegistry {
+  private planned = false;
+
+  constructor(
+    readonly session: ProgramAbiSession,
+    readonly ctx: CodegenContext,
+  ) {
+    session.assertModule(ctx.mod);
+  }
+
+  planRetained(): void {
+    if (this.planned) return;
+    this.planned = true;
+
+    const entrySources = this.session.inventory.sources.filter((source) => source.kind === "entry");
+    if (entrySources.length !== 1) {
+      throw new ProgramAbiInvariantError(
+        "unknown-order-anchor",
+        `global ABI planning requires exactly one canonical entry source, found ${entrySources.length}`,
+      );
+    }
+    const entrySourceId = entrySources[0]!.id;
+    const seen = new Set<object>();
+    let finalIndex = 0;
+
+    for (const value of this.ctx.mod.imports) {
+      if (value.desc.kind !== "global") continue;
+      this.assertUniqueAllocatorObject(seen, value, finalIndex);
+      if (!this.session.locatorBindingId(value)) {
+        const name = displayName(value.name, finalIndex);
+        const ref = irRetainedImportGlobalRef(entrySourceId, value.module, value.name, name, finalIndex);
+        this.planGlobal(entrySourceId, ref, finalIndex, value.desc.type, value.desc.mutable, {
+          kind: "import-global",
+          value,
+        });
+      }
+      finalIndex++;
+    }
+
+    if (finalIndex !== this.ctx.numImportGlobals) {
+      throw new ProgramAbiInvariantError(
+        "slot-locator-space-mismatch",
+        `global ABI planning found ${finalIndex} imported globals but the context records ${this.ctx.numImportGlobals}`,
+      );
+    }
+
+    for (const value of this.ctx.mod.globals) {
+      this.assertUniqueAllocatorObject(seen, value, finalIndex);
+      if (!this.session.locatorBindingId(value)) {
+        const name = displayName(value.name, finalIndex);
+        const ref = irSupportGlobalRef(entrySourceId, RETAINED_MODULE_GLOBAL_ROLE, name, finalIndex);
+        this.planGlobal(entrySourceId, ref, finalIndex, value.type, value.mutable, {
+          kind: "defined-global",
+          value,
+        });
+      }
+      finalIndex++;
+    }
+  }
+
+  private planGlobal(
+    entrySourceId: IrSourceId,
+    ref: IrGlobalRef,
+    finalIndex: number,
+    type: ValType,
+    mutable: boolean,
+    locator: ProgramAbiGlobalLocator,
+  ): void {
+    const structuralReferenceKey = irGlobalBindingKey(ref.binding);
+    this.session.ensurePlan({
+      id: ref.binding.bindingId,
+      structuralOrder: this.session.structuralOrder.forSource(entrySourceId, {
+        domain: "global",
+        roleOrdinal: PROGRAM_ABI_RETAINED_GLOBAL_ROLE,
+        derivedOrdinal: finalIndex,
+      }),
+      structuralReferenceKey,
+      displayName: ref.name,
+      slotPolicy: "required",
+      slotSpace: "global",
+      intent: {
+        kind: "global",
+        origin: ref.binding.kind === "import" ? "import" : "support",
+        valueType: canonicalProgramAbiValType(type),
+        mutable,
+      },
+    });
+    this.session.registerGlobalTypeContract(ref.binding.bindingId, type, mutable);
+    this.session.registerStructuralReference(ref.binding.bindingId, structuralReferenceKey);
+    this.session.attachLocator(ref.binding.bindingId, locator);
+  }
+
+  private assertUniqueAllocatorObject(seen: Set<object>, value: Import | GlobalDef, finalIndex: number): void {
+    if (seen.has(value)) {
+      throw new ProgramAbiInvariantError(
+        "duplicate-slot-locator",
+        `global allocator object appears more than once in final global space at index ${finalIndex}`,
+      );
+    }
+    seen.add(value);
+  }
+}

--- a/src/codegen/program-abi-import-planning.ts
+++ b/src/codegen/program-abi-import-planning.ts
@@ -284,6 +284,7 @@ export function eliminateDeadImportsAndPlanAbiCallables(ctx: CodegenContext): vo
   eliminateDeadImports(ctx.mod, ctx);
   planProgramAbiCallableImports(ctx);
   ctx.programAbiCallableProviders?.planRetained();
+  ctx.programAbiGlobals?.planRetained();
   ctx.programAbiTypes?.planRetained();
 }
 

--- a/src/ir/abi-bindings.ts
+++ b/src/ir/abi-bindings.ts
@@ -122,6 +122,36 @@ export function irImportGlobalRef(
   });
 }
 
+/**
+ * Catalog one retained import-global allocator slot not already owned by a
+ * semantic import binding.
+ *
+ * The distinct role prevents a compatibility-only duplicate import from
+ * colliding with a semantic `irImportGlobalRef` that happens to share both its
+ * module/field spelling and ordinal.
+ */
+export function irRetainedImportGlobalRef(
+  ownerId: IrBindingOwnerId,
+  module: string,
+  field: string,
+  adapterName: string,
+  ordinal: number,
+): IrGlobalRef {
+  const checkedModule = requireNonEmpty(module, "retained global import module");
+  const checkedField = requireString(field, "retained global import field");
+  return globalRef(adapterName, {
+    kind: "import",
+    bindingId: createIrBindingId({
+      ownerId: requireNonEmpty(ownerId, "retained global import owner identity") as IrBindingOwnerId,
+      domain: "global",
+      role: `retained-import:${checkedModule}:${checkedField}`,
+      ordinal,
+    }),
+    module: checkedModule,
+    field: checkedField,
+  });
+}
+
 /** Reference compiler runtime state through an exact program binding. */
 export function irRuntimeGlobalRef(
   ownerId: IrBindingOwnerId,

--- a/tests/issue-3520-global-population-abi.test.ts
+++ b/tests/issue-3520-global-population-abi.test.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { generateModule } from "../src/codegen/index.js";
+import { planProgramAbiStringConstantImport } from "../src/codegen/program-abi-import-planning.js";
+import { canonicalProgramAbiValType } from "../src/codegen/program-abi-signatures.js";
+import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
+import { addImport } from "../src/codegen/registry/imports.js";
+import { irImportGlobalRef } from "../src/ir/abi-bindings.js";
+import { buildIrUnitInventory } from "../src/ir/identity.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import { ts } from "../src/ts-api.js";
+
+// Register the codegen expression/statement delegates used by generateModule.
+import "../src/codegen/expressions.js";
+
+function fixture() {
+  const sourceFile = ts.createSourceFile(
+    "/repo/global-population.ts",
+    "export function main() {}",
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
+  const module = createEmptyModule();
+  const session = new ProgramAbiSession(inventory, module);
+  const ctx = createCodegenContext(module, {} as ts.TypeChecker, {}, session);
+  return { ctx, inventory, module, session };
+}
+
+describe("#3520 complete production Program ABI global population", () => {
+  it("publishes every final imported and defined global exactly once", () => {
+    const source = `
+      let state = 1;
+      class Box {
+        value: number = 2;
+        read(): number { return this.value; }
+      }
+      export function main(): number {
+        const property = "value";
+        return state + new Box().read() + property.length;
+      }
+    `;
+    const ast = analyzeSource(source, "global-population.ts");
+    const result = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      nativeStrings: false,
+    });
+    const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+    expect(result.programAbi).toBeDefined();
+
+    const importedGlobals = result.module.imports.filter(
+      (value): value is typeof value & { desc: Extract<typeof value.desc, { kind: "global" }> } =>
+        value.desc.kind === "global",
+    );
+    const finalGlobals = [
+      ...importedGlobals.map((value) => ({ type: value.desc.type, mutable: value.desc.mutable })),
+      ...result.module.globals.map((value) => ({ type: value.type, mutable: value.mutable })),
+    ];
+    const globalEntries = result
+      .programAbi!.abi.entries()
+      .filter(
+        (entry) => entry.slotPolicy === "required" && entry.slotSpace === "global" && entry.intent.kind === "global",
+      );
+    expect(globalEntries).toHaveLength(finalGlobals.length);
+
+    const finalIndices = globalEntries.map((entry) => {
+      const finalIndex = result.programAbi!.abi.resolveFinalIndex(entry.id);
+      expect(finalIndex).toEqual(expect.objectContaining({ space: "global" }));
+      if (!finalIndex || finalIndex.space !== "global") {
+        throw new Error(`missing final global slot for ${entry.id}`);
+      }
+      const global = finalGlobals[finalIndex.index];
+      if (!global) throw new Error(`missing final global object ${finalIndex.index}`);
+      expect(entry.intent).toMatchObject({
+        kind: "global",
+        valueType: canonicalProgramAbiValType(global.type),
+        mutable: global.mutable,
+      });
+      return finalIndex.index;
+    });
+    expect([...finalIndices].sort((left, right) => left - right)).toEqual(finalGlobals.map((_, index) => index));
+    expect(
+      globalEntries.filter((entry) => entry.intent.kind === "global" && entry.intent.origin === "import"),
+    ).toHaveLength(importedGlobals.length);
+    expect(globalEntries.some((entry) => entry.intent.kind === "global" && entry.intent.origin === "source")).toBe(
+      true,
+    );
+    expect(globalEntries.some((entry) => entry.intent.kind === "global" && entry.intent.origin === "support")).toBe(
+      true,
+    );
+  });
+
+  it("keeps duplicate import spellings as distinct allocator-owned slots", () => {
+    const { ctx, module, session } = fixture();
+    const first = addImport(ctx, "host", "same", {
+      kind: "global",
+      type: { kind: "externref" },
+      mutable: false,
+    });
+    const second = addImport(ctx, "host", "same", {
+      kind: "global",
+      type: { kind: "externref" },
+      mutable: false,
+    });
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(first).not.toBe(second);
+
+    ctx.programAbiGlobals!.planRetained();
+    ctx.indexSpaceFrozen = true;
+    const publication = session.publish(module);
+    const entries = publication.abi
+      .entries()
+      .filter((entry) => entry.intent.kind === "global" && entry.intent.origin === "import");
+    expect(entries).toHaveLength(2);
+    expect(new Set(entries.map((entry) => entry.id)).size).toBe(2);
+    expect(
+      entries
+        .map((entry) => publication.abi.resolveFinalIndex(entry.id)?.index)
+        .sort((left, right) => (left ?? -1) - (right ?? -1)),
+    ).toEqual([0, 1]);
+    expect(() => publication.legacy.resolveUniqueLegacyName("global", "same")).toThrow(
+      /matches 2 canonical structural owners/,
+    );
+  });
+
+  it("rejects one allocator object occupying two final global slots", () => {
+    const { ctx, module } = fixture();
+    const shared = {
+      module: "host",
+      name: "shared",
+      desc: {
+        kind: "global" as const,
+        type: { kind: "externref" as const },
+        mutable: false,
+      },
+    };
+    module.imports.push(shared, shared);
+    ctx.numImportGlobals = 2;
+
+    expect(() => ctx.programAbiGlobals!.planRetained()).toThrow(/allocator object appears more than once/);
+  });
+
+  it("keeps a generic duplicate distinct from a semantically planned import at the same ordinal", () => {
+    const { ctx, inventory, module, session } = fixture();
+    const first = addImport(ctx, "string_constants", "same", {
+      kind: "global",
+      type: { kind: "externref" },
+      mutable: false,
+    });
+    const semantic = addImport(ctx, "string_constants", "same", {
+      kind: "global",
+      type: { kind: "externref" },
+      mutable: false,
+    });
+    expect(first).toBeDefined();
+    expect(semantic).toBeDefined();
+    planProgramAbiStringConstantImport(ctx, semantic!, 0);
+
+    ctx.programAbiGlobals!.planRetained();
+    ctx.indexSpaceFrozen = true;
+    const publication = session.publish(module);
+    const entries = publication.abi
+      .entries()
+      .filter((entry) => entry.intent.kind === "global" && entry.intent.origin === "import");
+    expect(entries).toHaveLength(2);
+    expect(new Set(entries.map((entry) => entry.id)).size).toBe(2);
+    const entrySource = inventory.sources.find((source) => source.kind === "entry");
+    if (!entrySource) throw new Error("missing entry source");
+    const semanticRef = irImportGlobalRef(entrySource.id, "string_constants", "same", "__str_0", 0);
+    expect(session.hasLocator(semanticRef.binding.bindingId, semantic!)).toBe(true);
+    expect(publication.abi.resolveFinalIndex(semanticRef.binding.bindingId)).toEqual({ space: "global", index: 1 });
+  });
+});


### PR DESCRIPTION
## Summary

- publish every retained imported and defined global exactly once through the production Program ABI
- preserve existing semantic source/runtime/string-constant owners while structurally cataloging the remaining allocator objects
- keep duplicate import spellings distinct, reject repeated allocator objects, and avoid `moduleGlobals` or display-name resolution

## Validation

- `pnpm run typecheck`
- focused global population: 4/4
- sharded #3520 matrix: 255 passing / 1 unchanged C13-control failure across 45 files
- focused class/accessor/externref/Promise/cross-backend matrix: 85/85
- #2138 multi-source: 6/6
- hybrid IR-only readiness: READY, 31 emitted / 6 typed Unsupported / 0 Invariants
- equivalence: 1,611 passing / 32 known failing / 0 new regressions
- LOC/function budget, dead-export, oracle, issue-spec, lint, formatting, and fallback gates: passed

Stacked on #3746. Remaining R1 work is tracked in `plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md`.
