### PR TITLE
fix(string): preserve lastIndexOf NaN position default

### DIFF
--- a/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
+++ b/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
@@ -5,7 +5,7 @@ status: in-progress
 assignee: ttraenkler/opus-loop-d
 sprint: current
 created: 2026-06-27
-updated: 2026-07-26
+updated: 2026-07-28
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -21,16 +21,20 @@ depends_on: []
 # regression repair also needs source rest-parameter metadata and one narrow
 # emitted classifier: the generic host dispatcher cannot materialize a rest vec,
 # so the runtime must classify that source shape before exposing the closure.
+# PR #3753 keeps lastIndexOf's method-specific NaN fallback beside the shared
+# native-string integer-argument lowering.
 loc-budget-allow:
   - src/runtime.ts
   - src/codegen/closure-exports.ts
   - src/codegen/closures/arrow-phases.ts
   - src/codegen/context/types.ts
   - src/codegen/index.ts
+  - src/codegen/string-ops.ts
 func-budget-allow:
   - src/runtime.ts::resolveImport
   - src/codegen/index.ts::generateModule
   - src/codegen/index.ts::generateMultiModule
+  - src/codegen/string-ops.ts::compileNativeStringMethodCall
 ---
 # #2742 — String.prototype generic-receiver `ToString(this)` coercion
 
@@ -269,3 +273,16 @@ Validation after merging current `main` (`f7d1187fa2c79e0153731308200ebb2c6cac27
 - Exact controls: the three dominant identity regressions pass;
   `proxy-keys.js` reports `missing_builtin` (“not a function”), with no
   `illegal_cast`.
+
+## `lastIndexOf` NaN-position residual (PR #3753, 2026-07-28)
+
+Standalone lowering now preserves `lastIndexOf`'s from-end sentinel when a
+position expression coerces to `NaN` or `undefined`. Other integer-indexed
+String methods retain their ordinary NaN-to-zero behavior.
+
+Exact local-vs-local Test262 A/B on base `c5bd4631724afa`:
+
+- JS-host directory: 19/25 → 19/25; ES5 subset: 15/21 → 15/21.
+- Standalone directory: 15/25 → 17/25; ES5 subset: 11/21 → 13/21.
+- Fail→pass: `S15.5.4.8_A1_T10.js` and `S15.5.4.8_A4_T3.js`.
+- Pass→fail: none. Every remaining failure kept the same normalized signature.

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -2236,7 +2236,12 @@ function tryThrowOnBigIntOrSymbolArg(ctx: CodegenContext, fctx: FunctionContext,
  * Returns true when emission succeeded (caller continues building the
  * arg list); false when an unreachable throw was emitted instead.
  */
-function compileStringIntegerArg(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): void {
+function compileStringIntegerArg(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+  nanFallback = 0,
+): void {
   if (tryThrowOnBigIntOrSymbolArg(ctx, fctx, arg)) {
     // After unreachable, the wasm stack is polymorphic — but we still
     // push a sentinel i32 so the (unreached) call site reads cleanly.
@@ -2257,8 +2262,10 @@ function compileStringIntegerArg(ctx: CodegenContext, fctx: FunctionContext, arg
   if (noJsHost(ctx)) {
     const argType = compileExpression(ctx, fctx, arg);
     if (!argType) {
-      // void → undefined → ToNumber NaN → ToIntegerOrInfinity 0.
-      fctx.body.push({ op: "i32.const", value: 0 });
+      // void → undefined → ToNumber NaN. Most integer-indexed methods map
+      // NaN to 0; lastIndexOf supplies its spec-specific +∞ sentinel so the
+      // reverse search starts from the end.
+      fctx.body.push({ op: "i32.const", value: nanFallback });
       return;
     }
     if (argType.kind === "i64") {
@@ -2279,14 +2286,15 @@ function compileStringIntegerArg(ctx: CodegenContext, fctx: FunctionContext, arg
       kind: "f64",
     });
     fctx.body.push({ op: "local.set", index: fTmp });
-    // ToIntegerOrInfinity: NaN → 0, else trunc toward zero (±∞ saturates).
+    // ToIntegerOrInfinity: NaN → the caller's method-specific fallback, else
+    // trunc toward zero (±∞ saturates).
     fctx.body.push({ op: "local.get", index: fTmp });
     fctx.body.push({ op: "local.get", index: fTmp });
     fctx.body.push({ op: "f64.ne" }); // self != self ⇒ NaN
     fctx.body.push({
       op: "if",
       blockType: { kind: "val", type: { kind: "i32" } },
-      then: [{ op: "i32.const", value: 0 }],
+      then: [{ op: "i32.const", value: nanFallback }],
       else: [{ op: "local.get", index: fTmp }, { op: "i32.trunc_sat_f64_s" }],
     });
     return;
@@ -2440,14 +2448,19 @@ export function compileNativeStringMethodCall(
     fctx.body.push({ op: "local.set", index: local });
     return local;
   };
-  const compileIntegerValueToLocal = (value: ts.Expression | undefined, fallback: number, name: string): number => {
+  const compileIntegerValueToLocal = (
+    value: ts.Expression | undefined,
+    fallback: number,
+    name: string,
+    nanFallback = 0,
+  ): number => {
     const local = allocLocal(fctx, `${name}_${fctx.locals.length}`, {
       kind: "i32",
     });
     // Explicit `undefined` is spec-equivalent to an absent arg → use the
     // method's default sentinel rather than coercing undefined → 0 (#2124).
     if (value && !isStaticUndefinedArg(value)) {
-      compileStringIntegerArg(ctx, fctx, value);
+      compileStringIntegerArg(ctx, fctx, value, nanFallback);
     } else {
       fctx.body.push({ op: "i32.const", value: fallback });
     }
@@ -2757,7 +2770,12 @@ export function compileNativeStringMethodCall(
     // maps explicit `undefined`; map explicit `NaN` here too (#2124).
     const fromArg = expr.arguments[1];
     const fromIsNaN = fromArg !== undefined && ts.isIdentifier(fromArg) && fromArg.text === "NaN";
-    const fromLocal = compileIntegerValueToLocal(fromIsNaN ? undefined : fromArg, 0x7fffffff, "__str_lastIndexOf_from");
+    const fromLocal = compileIntegerValueToLocal(
+      fromIsNaN ? undefined : fromArg,
+      0x7fffffff,
+      "__str_lastIndexOf_from",
+      0x7fffffff,
+    );
     const funcIdx = ctx.nativeStrHelpers.get("__str_lastIndexOf")!;
     fctx.body.push({ op: "local.get", index: receiverLocal });
     fctx.body.push({ op: "local.get", index: searchLocal });

--- a/tests/issue-2742-string-lastindexof-residual.test.ts
+++ b/tests/issue-2742-string-lastindexof-residual.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ES5 String.prototype.lastIndexOf position coercion residual.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(source: string, target?: "standalone"): Promise<number> {
+  const result = await compile(source, {
+    target,
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  if (target === "standalone") {
+    expect(result.imports ?? []).toEqual([]);
+  }
+  const imports = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const setExports = (imports as { __setExports?: (exports: WebAssembly.Exports) => void }).__setExports;
+  if (setExports) setExports(instance.exports);
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2742 String.prototype.lastIndexOf standalone position coercion", () => {
+  const nanPositionSource = `export function test(): number {
+    const search = { toString: function () { return "AB"; } };
+    const position = { valueOf: function () { return NaN; } };
+    return "ABBABABAB".lastIndexOf(search, position);
+  }`;
+
+  it("keeps the existing JS-host object-to-NaN behavior", async () => {
+    expect(await run(nanPositionSource)).toBe(7);
+  });
+
+  it("searches from the end for an object-to-NaN position in standalone", async () => {
+    expect(await run(nanPositionSource, "standalone")).toBe(7);
+  });
+
+  it("searches from the end when OrdinaryToPrimitive produces undefined", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const position = { valueOf: function () { return {}; }, toString: function () {} };
+          return "ABBABABAB".lastIndexOf("AB", position);
+        }`,
+        "standalone",
+      ),
+    ).toBe(7);
+  });
+
+  it("does not change indexOf's NaN-to-zero position rule", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const position = { valueOf: function () { return NaN; } };
+          return "ABBABABAB".indexOf("AB", position);
+        }`,
+        "standalone",
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve the standalone `String.prototype.lastIndexOf` from-end default when position coercion produces `NaN` or `undefined`
- keep the shared `NaN`-to-zero rule unchanged for other integer-indexed string methods
- add focused host/standalone object-coercion regressions and an `indexOf` control

## Conformance impact

- standalone directory: 15/25 → 17/25
- standalone ES5 cohort: 11/21 → 13/21
- newly passing: `S15.5.4.8_A1_T10.js`, `S15.5.4.8_A4_T3.js`
- JS-host directory unchanged at 19/25; JS-host ES5 cohort unchanged at 15/21

## Validation

- `pnpm exec vitest run tests/issue-2742-string-lastindexof-residual.test.ts --reporter=verbose`
- `pnpm run typecheck`
- exact Test262 `built-ins/String/prototype/lastIndexOf` in JS-host and standalone lanes

Follow-up to #2742.

Agent: Codex
