### PR TITLE
fix(array): return undefined for standalone reference OOB reads

### DIFF
--- a/plan/issues/3761-string-split-nan-limit.md
+++ b/plan/issues/3761-string-split-nan-limit.md
@@ -1,0 +1,56 @@
+---
+id: 3761
+title: "String.prototype.split explicit NaN limit is mistaken for omission"
+status: done
+created: 2026-07-28
+updated: 2026-07-28
+completed: 2026-07-28
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: bug
+area: codegen
+es_edition: ES5
+language_feature: string-prototype-split
+goal: test262-conformance
+assignee: ttraenkler/codex-es5-string-split
+related: [1441, 2125]
+---
+
+# #3761 — distinguish explicit NaN from an omitted split limit
+
+## Problem
+
+The host ABI pads a missing `String.prototype.split` limit with `NaN`, then
+removes a trailing `NaN` before invoking the JavaScript host method. An explicit
+`NaN` is therefore also removed, despite ES5 requiring `ToUint32(NaN) = 0`.
+
+The ES5 test
+`built-ins/String/prototype/split/call-split-l-na-n-instance-is-string-hello.js`
+returns three pieces instead of an empty array in the host lane.
+
+## Fix
+
+Use `-1` as the omitted-limit ABI sentinel. `ToUint32(-1)` is `2^32 - 1`, so
+an explicit `-1` and an omitted limit are observably equivalent for split,
+while an explicit `NaN` remains available for the host method to coerce to zero.
+
+## Acceptance criteria
+
+- Explicit `NaN` returns an empty result in host and standalone modes.
+- Omitted and explicit `-1` limits remain unbounded.
+- The exact ES5 test flips to pass in the host lane.
+- The 70-test non-RegExp ES5 split partition has no pass-to-fail regressions.
+
+## Measured result
+
+Local-vs-local A/B at `origin/main@a790605025acb28065bd9de63a84e0f72b8bd360`:
+
+- Host non-RegExp ES5 split partition: **56/70 → 57/70**, with the exact NaN
+  limit test as the sole fail-to-pass flip and zero regressions.
+- Standalone non-RegExp ES5 split partition: **35/70 → 35/70**, with zero
+  changes and zero regressions. The standalone helper already computes the
+  correct empty length for explicit NaN; that test remains red only because a
+  subsequent out-of-bounds element read returns `null` rather than `undefined`,
+  a separate array/value-representation residual.
+- Focused split tests: **23/23 pass** across #3761, #1441, and #2125.

--- a/plan/issues/3764-standalone-reference-array-oob-undefined.md
+++ b/plan/issues/3764-standalone-reference-array-oob-undefined.md
@@ -1,0 +1,60 @@
+---
+id: 3764
+title: "Standalone reference-array OOB reads expose null instead of undefined"
+status: complete
+assignee: ttraenkler/codex-es5-array-oob
+sprint: current
+created: 2026-07-28
+priority: high
+horizon: m
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: arrays, strings
+goal: es5
+related: [2106, 2760, 2773, 3761]
+# The new SAFE read helper and its two call-site dispatches belong to the
+# existing hybrid OOB policy in property-access.ts; moving them would split
+# representation selection from the element-access lowering that consumes it.
+loc-budget-allow:
+  - src/codegen/property-access.ts
+func-budget-allow:
+  - src/codegen/property-access.ts::compileElementAccessBody
+---
+
+# #3764 — standalone reference-array OOB reads expose null instead of undefined
+
+## Problem
+
+The hybrid OOB policy widens number, boolean, and symbol array reads to
+`externref`, but leaves WasmGC reference carriers such as standalone
+`string[]` on their nullable typed result. An out-of-bounds read therefore
+produces a null reference, which becomes JavaScript `null` rather than the
+standalone `$undefined` singleton.
+
+This is visible in the ES5 split case from #3761: both the actual and expected
+arrays are empty, but comparing `actual[0]` with `expected[0]` fails because the
+native-string result carrier produces null on OOB.
+
+## Implementation
+
+- Add a call-site-owned SAFE OOB reader for `ref` / `ref_null` array elements.
+- Convert a present element to `externref`.
+- Return the real undefined value for an OOB index and for a nullable in-bounds
+  hole.
+- Keep typed arrays, subviews, array-method internals, RegExp match exotics, and
+  proven-in-bounds reads on their existing representations.
+
+## Verification
+
+- Direct host and standalone `string[]` probes distinguish OOB from null.
+- The authoritative ES5 `split("l", NaN)` test passes in standalone.
+- The focused #3761/#3764 suite passes 7/7.
+- Same-SHA standalone split-directory A/B improves 68/120 to 72/120:
+  four exact failures become passes with no losses or other status changes.
+- Same-SHA host split-directory A/B remains 63/120 with no status changes. The
+  single concurrent-run ambiguity was rerun in isolated processes and produced
+  the same compile error on both revisions.
+- The broader selected array/string regression set remains 184/196; the same
+  12 known failures reproduce on the baseline parent revision.
+- Typecheck, formatting, and LOC/function budget gates pass.

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -2662,16 +2662,15 @@ export function compileReceiverMethodCall(
               fctx.body.push({ op: "ref.null.extern" });
             }
           } else if (pt.kind === "f64") {
-            // #1441 — `split` uses NaN as the "limit was not provided"
-            // sentinel. ToUint32(NaN) === 0 would produce `[]` if the runtime
-            // passed it through verbatim, so the `string_method` host shim
-            // strips a trailing NaN limit before invoking the JS method.
+            // #3761 — `split` uses -1 for omission so explicit NaN still
+            // reaches host ToUint32(NaN) === 0.
             // #2002 — includes/startsWith/endsWith likewise use NaN for an
             // omitted position so the host shim drops it and the JS method
             // applies its spec default (0 for includes/startsWith, length
             // for endsWith) instead of ToInteger(NaN)=0.
             if (method === "split" || method === "includes" || method === "startsWith" || method === "endsWith") {
-              fctx.body.push({ op: "f64.const", value: Number.NaN });
+              const sentinel = method === "split" ? -1 : Number.NaN;
+              fctx.body.push({ op: "f64.const", value: sentinel });
             } else {
               fctx.body.push({ op: "f64.const", value: 0 });
             }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6130,9 +6130,9 @@ export const STRING_METHODS: Record<string, { params: ValType[]; result: ValType
     params: [{ kind: "f64" }, { kind: "externref" }],
     result: { kind: "externref" },
   },
-  // split: separator (externref) + limit (f64, NaN sentinel for "no limit" — #1441).
-  // The host runtime in `string_method` detects NaN and calls `split(sep)` without
-  // the limit so the spec default 2^32-1 applies (instead of ToUint32(NaN) === 0).
+  // split: separator (externref) + limit (f64, -1 sentinel for "no limit" — #3761).
+  // The host runtime in `string_method` detects -1 and calls `split(sep)` without
+  // the limit. An explicit NaN must remain distinct: ToUint32(NaN) is 0.
   split: { params: [{ kind: "externref" }, { kind: "f64" }], result: { kind: "externref" } },
   match: { params: [{ kind: "externref" }], result: { kind: "externref" } },
   search: { params: [{ kind: "externref" }], result: { kind: "f64" } },

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -3392,6 +3392,77 @@ function emitPlainArrayUndefinedOobGet(
 }
 
 /**
+ * SAFE plain-array OOB read for a WasmGC reference element. The typed carrier
+ * cannot encode the standalone `$undefined` singleton, so widen the unproven
+ * read to externref: a present non-null element is converted at the boundary,
+ * while an OOB index (and a nullable in-bounds hole) returns JS `undefined`.
+ *
+ * Like the primitive sibling above, this is call-site-owned. Array-method,
+ * subview, typed-array, and proven-in-bounds reads retain their existing
+ * representation and byte path.
+ *
+ * Stack in:  [arrayref(non-null $arr), i32 index]
+ * Stack out: [externref]
+ */
+function emitReferenceArrayUndefinedOobGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arrTypeIdx: number,
+  elementType: Extract<ValType, { kind: "ref" | "ref_null" }>,
+  lengthBoundInstrs?: Instr[],
+): void {
+  const idxLocal = allocLocal(fctx, `__oobr_idx_${fctx.locals.length}`, { kind: "i32" });
+  const arrLocal = allocLocal(fctx, `__oobr_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "local.set", index: idxLocal });
+  fctx.body.push({ op: "local.set", index: arrLocal });
+
+  // Materialise the singleton before constructing detached branch bodies so
+  // any late helper registration and function-index shift happens in-order.
+  emitUndefined(ctx, fctx);
+  const undefLocal = allocLocal(fctx, `__oobr_undef_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: undefLocal });
+
+  const valueLocal =
+    elementType.kind === "ref_null" ? allocLocal(fctx, `__oobr_value_${fctx.locals.length}`, elementType) : undefined;
+  const presentValue: Instr[] =
+    valueLocal === undefined
+      ? [
+          { op: "local.get", index: arrLocal },
+          { op: "local.get", index: idxLocal },
+          { op: "array.get", typeIdx: arrTypeIdx },
+          { op: "extern.convert_any" },
+        ]
+      : [
+          { op: "local.get", index: arrLocal },
+          { op: "local.get", index: idxLocal },
+          { op: "array.get", typeIdx: arrTypeIdx },
+          { op: "local.tee", index: valueLocal },
+          { op: "ref.is_null" },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: [{ op: "local.get", index: undefLocal }],
+            else: [{ op: "local.get", index: valueLocal }, { op: "extern.convert_any" }],
+          },
+        ];
+
+  fctx.body.push({ op: "local.get", index: idxLocal });
+  if (lengthBoundInstrs) {
+    fctx.body.push(...lengthBoundInstrs.map((instr) => ({ ...instr })));
+  } else {
+    fctx.body.push({ op: "local.get", index: arrLocal });
+    fctx.body.push({ op: "array.len" });
+  }
+  fctx.body.push({ op: "i32.lt_u" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "externref" } },
+    then: presentValue,
+    else: [{ op: "local.get", index: undefLocal }],
+  });
+}
+
+/**
  * (#2798 — hybrid type-soundness audit Row 9) SAFE typed-array OOB read: push the
  * in-bounds element **boxed to a JS number externref**, or JS `undefined` when
  * the index is out of bounds (the *view length* is the bound, per the
@@ -4934,9 +5005,9 @@ export function compileElementAccessBody(
     // semantics; deferred). This F1 slice widens the PRIMITIVE element kinds the
     // type-aware box (#2785) can box correctly — `number[]` (f64), `boolean[]`
     // (branded i32), and `symbol[]` (branded i32, #2792) — via `f1ElementBoxType`
-    // below. Other `i32` elements (packed-number / other handle reps),
-    // object-element (`ref`) arrays, and externref (`any[]`/`string[]`) keep their
-    // typed result and are deferred (`f1BoxType === null`).
+    // below. Other `i32` elements (packed-number / other handle reps) and
+    // externref elements keep the shared-helper path; WasmGC `ref` / `ref_null`
+    // elements use the dedicated reference-array widen below.
     const isRegexMatchVec = typeDef.fields.length >= 4 && typeDef.fields[2]?.name === "index";
     const numericHint = expectedType?.kind === "f64" || expectedType?.kind === "i32";
     const taClass = classifyTypedArrayType(ctx.checker.getTypeAtLocation(expr.expression), ctx.checker);
@@ -5021,10 +5092,13 @@ export function compileElementAccessBody(
       // the number 1, regressing the standalone map tests); #2792 completes the
       // `symbol[]` arm now that a native standalone `__box_symbol` exists (a symbol
       // handle boxed as `__box_number` would surface a Number). Packed-number /
-      // other i32 / object / externref elements stay deferred (`f1BoxType ===
-      // null`) and fall through to the unchanged shared-helper read below
-      // (bounds-checked, never traps).
+      // other i32 / externref elements stay deferred (`f1BoxType === null`) and
+      // fall through to the shared-helper read below; WasmGC `ref` / `ref_null`
+      // elements use the dedicated reference-array widen immediately below.
       emitPlainArrayUndefinedOobGet(ctx, fctx, arrTypeIdx, arrDef.element, f1BoxType, vecLenBoundInstrs);
+      return { kind: "externref" };
+    } else if (oobUndefined && (arrDef.element.kind === "ref" || arrDef.element.kind === "ref_null")) {
+      emitReferenceArrayUndefinedOobGet(ctx, fctx, arrTypeIdx, arrDef.element, vecLenBoundInstrs);
       return { kind: "externref" };
     } else if (oobUndefinedTypedArray) {
       // (#2798 Row 9) Typed-array OOB → JS `undefined`, in-bounds → the element
@@ -5126,10 +5200,14 @@ export function compileElementAccessBody(
     // element's SEMANTIC type (`f1BoxTypeArr`: `{f64}` number[] → `__box_number`,
     // `{i32, boolean}` boolean[] → `__box_boolean`, `{i32, symbol}` symbol[] →
     // `__box_symbol`). Bounds-eliminated reads above keep the unboxed fast path.
-    // Packed-number / other i32 / object / externref elements stay deferred
-    // (`f1BoxTypeArr === null`) and fall through to the unchanged shared-helper
-    // read below. See the full note at the vec-struct call site above.
+    // Packed-number / other i32 / externref elements stay deferred
+    // (`f1BoxTypeArr === null`) and fall through to the shared-helper read
+    // below; WasmGC `ref` / `ref_null` elements use the dedicated widen
+    // immediately below. See the full note at the vec-struct call site above.
     emitPlainArrayUndefinedOobGet(ctx, fctx, typeIdx, typeDef.element, f1BoxTypeArr);
+    return { kind: "externref" };
+  } else if (oobUndefinedArr && (typeDef.element.kind === "ref" || typeDef.element.kind === "ref_null")) {
+    emitReferenceArrayUndefinedOobGet(ctx, fctx, typeIdx, typeDef.element);
     return { kind: "externref" };
   } else if (oobUndefinedTypedArrayArr) {
     // (#2798 Row 9) Typed-array OOB → JS `undefined`, in-bounds → the element

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7881,21 +7881,21 @@ function resolveImport(
         } else {
           args = a.map(coerce);
         }
-        // #1441 — `split` uses NaN as the "limit was not provided" sentinel.
-        // ToUint32(NaN) is 0, which would produce an empty array; per spec
-        // (22.1.3.21 step 8) a missing limit means 2^32 - 1, so we drop the
-        // trailing NaN and let the JS host apply the default.
+        // #3761 — split uses -1 for omission/2^32 - 1; explicit NaN remains ToUint32(NaN) = 0.
         // #2002 — includes/startsWith/endsWith use NaN as the "position not
         // provided" sentinel for the same reason: a trailing NaN means the
         // arg was omitted, so drop it and let the JS method apply its spec
         // default (0 for includes/startsWith, length for endsWith) instead of
         // ToInteger(NaN)=0.
-        if (
-          (method === "split" || method === "includes" || method === "startsWith" || method === "endsWith") &&
-          args.length >= 2
-        ) {
+        if (args.length >= 2) {
           const last = args[args.length - 1];
-          if (typeof last === "number" && Number.isNaN(last)) {
+          const omitLast =
+            method === "split"
+              ? last === -1
+              : (method === "includes" || method === "startsWith" || method === "endsWith") &&
+                typeof last === "number" &&
+                Number.isNaN(last);
+          if (omitLast) {
             args.pop();
           }
         }

--- a/tests/issue-3761-string-split-nan-limit.test.ts
+++ b/tests/issue-3761-string-split-nan-limit.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3761 — host String.prototype.split used NaN as the ABI sentinel for an
+ * omitted limit. That made split(separator, NaN) indistinguishable from
+ * split(separator), even though ToUint32(NaN) is 0 and the former must return
+ * an empty array. The omitted-limit sentinel is now -1; ToUint32(-1) is the
+ * same unbounded 2^32 - 1 limit, so the collision is behaviorally harmless.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string, target?: "standalone"): Promise<number> {
+  const result = await compile(`export function test(): number { ${source} }`, {
+    fileName: "test.ts",
+    target,
+  });
+  expect(result.success, result.errors?.[0]?.message ?? "compile failed").toBe(true);
+  const imports = target === "standalone" ? {} : buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  if (target !== "standalone") {
+    (imports as ReturnType<typeof buildImports>).setExports?.(instance.exports as WebAssembly.Exports);
+  }
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#3761 String.prototype.split NaN limit", () => {
+  it("host: explicit NaN is ToUint32(NaN) = 0, not an omitted limit", async () => {
+    expect(await run(`return "hello".split("l", NaN).length;`)).toBe(0);
+  });
+
+  it("host: an omitted limit remains unbounded", async () => {
+    expect(await run(`return "hello".split("l").length;`)).toBe(3);
+  });
+
+  it("host: explicit -1 remains equivalent to the 2^32 - 1 limit", async () => {
+    expect(await run(`return "hello".split("l", -1).length;`)).toBe(3);
+  });
+
+  it("standalone: explicit NaN remains an empty result", async () => {
+    expect(await run(`return "hello".split("l", NaN).length;`, "standalone")).toBe(0);
+  });
+});

--- a/tests/issue-3764-reference-array-oob-undefined.test.ts
+++ b/tests/issue-3764-reference-array-oob-undefined.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const EXACT_CASE = "built-ins/String/prototype/split/call-split-l-na-n-instance-is-string-hello.js";
+
+async function runReferenceArrayProbe(target?: "standalone"): Promise<number> {
+  const result: any = await compile(
+    `
+export function test(): number {
+  var values = ["present"];
+  if (values[0] !== "present") return 10;
+  if (values[1] !== undefined) return 11;
+
+  var empty = new String("hello").split("l", NaN);
+  if (empty.length !== 0) return 12;
+  return empty[0] === undefined ? 1 : 13;
+}
+`,
+    {
+      fileName: "issue-3764-reference-array-oob-undefined.ts",
+      target,
+      skipSemanticDiagnostics: true,
+    },
+  );
+  expect(result.success, result.errors?.map((error: any) => error.message).join("\n")).toBe(true);
+  if (target === "standalone") expect(result.importObject).toEqual({});
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#3764 reference-array OOB reads", () => {
+  it("returns undefined in host mode", async () => {
+    expect(await runReferenceArrayProbe()).toBe(1);
+  });
+
+  it("returns the standalone undefined singleton", async () => {
+    expect(await runReferenceArrayProbe("standalone")).toBe(1);
+  });
+
+  it("passes the authoritative standalone ES5 split case", async () => {
+    const result = await runTest262File(resolve("test262/test", EXACT_CASE), "issue-3764", 30_000, "standalone");
+    expect(result.status, result.error).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

- widen unproven WasmGC `ref` / `ref_null` plain-array reads to `externref`
- return the standalone `undefined` singleton for out-of-bounds reads and nullable holes
- preserve existing typed-array, subview, RegExp-match, and proven-in-bounds paths
- add direct host/standalone probes and the authoritative ES5 `split("l", NaN)` regression

## Root cause

The hybrid array OOB policy handled primitive and externref carriers, but left
WasmGC reference arrays on their nullable typed result. A standalone `string[]`
out-of-bounds read therefore surfaced `null` instead of JavaScript `undefined`.

## Verification

- focused #3761/#3764 suite: 7/7
- standalone `String.prototype.split` A/B: 68/120 → 72/120
- four exact failure-to-pass flips, zero losses or other status changes
- host split A/B: unchanged at 63/120
- broader selected array/string suite: 184/196 with the same 12 known failures on the parent baseline
- typecheck
- Prettier
- LOC and function budget gates

## Dependency

This PR depends on #3747 and currently contains its commit because the parent
head is a fork-only branch that GitHub cannot select as an upstream base.
Review the top commit for this change:
`fix(array): return undefined for standalone reference OOB reads`.
