### PR TITLE
fix(string): preserve hoisted undefined indexOf searches (#3763)

### DIFF
--- a/plan/issues/3763-string-indexof-undefined-search.md
+++ b/plan/issues/3763-string-indexof-undefined-search.md
@@ -1,0 +1,73 @@
+---
+id: 3763
+title: "String.prototype.indexOf host path conflates an undefined search argument with null"
+status: done
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+completed: 2026-07-28
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: string-methods
+goal: test262-conformance
+assignee: "ttraenkler/codex-es5-string-indexof"
+related: [205, 2598, 2599]
+# loc-budget-allow justification: the two-line call-receiver dispatch hook is
+# irreducible wiring; all proof and emission logic lives in the dedicated
+# string-indexof-undefined subsystem module.
+loc-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts
+# func-budget-allow justification: compileReceiverMethodCall gains only the
+# one-line indexOf-specific delegation; the proof/emission body is extracted.
+func-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
+---
+
+# #3763 — preserve undefined for `String.prototype.indexOf`
+
+## Root cause
+
+The classic JS-host string-method lowering compiled `indexOf`'s search
+argument directly into the import's `externref` slot. The Wasm representation
+of an uninitialised `var` collapsed to `ref.null.extern`, so the host received
+JavaScript `null`.
+`String.prototype.indexOf` consequently searched for `"null"` instead of
+applying `ToString(undefined)` and searching for `"undefined"`.
+
+The bounded fix proves the first read of an uninitialised hoisted `var` before
+its declaration. It evaluates the expression once, discards the representation
+placeholder, and passes the host's existing `__get_undefined` value. A preceding
+use makes the proof decline to the existing dynamic path.
+
+This is scoped only to `String.prototype.indexOf` in the classic host lane.
+Standalone already preserves these search values through its native ToString
+coercion cascade. Other string methods and RegExp lowering are unchanged.
+
+## Measured conformance
+
+On the explicit ES5 `built-ins/String/prototype/indexOf` cohort (34 files):
+
+- host: 29 pass / 5 fail before → 30 pass / 4 fail after; the exact
+  `S15.5.4.7_A1_T6.js` hoisted-var case is the sole flip;
+- standalone: 26 pass / 8 fail before and after.
+
+Across the full 47-file `indexOf` directory, host moves from 34 pass / 13 fail
+to 35 pass / 12 fail; standalone remains 30 pass / 17 fail. After excluding
+the sole target flip, the status/error signature hashes are identical in both
+cohorts and lanes (zero regressions and zero fail-to-fail drift).
+
+`S15.5.4.7_A1_T8.js` and `S15.5.4.7_A1_T9.js` remain failures because their
+receiver-side `String(object)` / String-wrapper coercion is independently
+wrong. They are not counted as search-argument wins.
+
+## Validation
+
+- direct host regressions for a hoisted `var` and a preceding-write non-fold
+  guard;
+- exact Test262 `S15.5.4.7_A1_T6.js` regression;
+- same-SHA local host/standalone A/B over the explicit ES5 cohort and full
+  `indexOf` directory, including fail-to-fail signature comparison.

--- a/src/checker/oracle.ts
+++ b/src/checker/oracle.ts
@@ -120,6 +120,13 @@ export interface TypeOracle {
    * single assignment and therefore must not narrow the query to `const`.
    */
   variableInitializerOf(id: ts.Node): ts.Expression | undefined;
+  /**
+   * Variable declaration for a plain identifier binding. Returning the AST
+   * declaration (rather than the checker Symbol) keeps binding-identity
+   * queries inside the oracle boundary while allowing callers to inspect
+   * declaration syntax such as `var` versus `let`/`const`.
+   */
+  variableDeclarationOf(id: ts.Node): ts.VariableDeclaration | undefined;
 }
 
 /** Builtins with first-class compiler handling (mirrors type-mapper's set —
@@ -305,14 +312,18 @@ export class TsCheckerOracle implements TypeOracle {
   }
 
   variableInitializerOf(id: ts.Node): ts.Expression | undefined {
+    return this.variableDeclarationOf(id)?.initializer;
+  }
+
+  variableDeclarationOf(id: ts.Node): ts.VariableDeclaration | undefined {
     try {
       if (!ts.isIdentifier(id)) return undefined;
       const sym = this.checker.getSymbolAtLocation(id);
       const decl = sym?.valueDeclaration;
-      if (!decl || !ts.isVariableDeclaration(decl) || !decl.initializer || !ts.isIdentifier(decl.name)) {
+      if (!decl || !ts.isVariableDeclaration(decl) || !ts.isIdentifier(decl.name)) {
         return undefined;
       }
-      return decl.initializer;
+      return decl;
     } catch {
       return undefined;
     }

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -95,6 +95,7 @@ import {
   emitBoolToString,
   isStaticUndefinedArg,
 } from "../string-ops.js";
+import { tryCompileIndexOfHoistedUndefinedSearch } from "../string-indexof-undefined.js";
 import { emitSymbolToString } from "../symbol-native.js";
 import { ensureTaMapFilterHelper } from "../ta-hof-map-filter.js";
 import { ensureUint8ToBase64, ensureUint8ToHex } from "../uint8-codec.js";
@@ -119,7 +120,7 @@ import {
   noJsHost,
   wasmFuncReturnsVoid,
 } from "./helpers.js";
-import { emitUndefined, ensureLateImport, flushLateImportShifts } from "./late-imports.js";
+import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { resolveStructName } from "./misc.js";
 import {
   BUILTIN_CLASS_NAMES,
@@ -2602,6 +2603,7 @@ export function compileReceiverMethodCall(
           }
           continue;
         }
+        if (method === "indexOf" && ai === 0 && tryCompileIndexOfHoistedUndefinedSearch(ctx, fctx, args[ai]!)) continue;
         if (ai < userParamCount) {
           const expectedArgType = paramTypes?.[ai + 1]; // +1 for self param
           const argResult = compileExpression(ctx, fctx, args[ai]!, expectedArgType);

--- a/src/codegen/string-indexof-undefined.ts
+++ b/src/codegen/string-indexof-undefined.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { ts } from "../ts-api.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { compileExpression } from "./shared.js";
+import { emitUndefined } from "./expressions/late-imports.js";
+
+/**
+ * #3763 — compile the legacy ES5 `indexOf(x); var x;` search value as actual
+ * JavaScript `undefined`.
+ *
+ * TypeScript types the uninitialised hoisted binding as `any`, while the Wasm
+ * externref representation otherwise collapses it to JS `null`. The proof is
+ * deliberately narrow: the declaration must follow this first use, have no
+ * initializer, and be a `var`. Any preceding use makes the helper decline.
+ */
+export function tryCompileIndexOfHoistedUndefinedSearch(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+): boolean {
+  let value = arg;
+  while (
+    ts.isParenthesizedExpression(value) ||
+    ts.isAsExpression(value) ||
+    ts.isNonNullExpression(value) ||
+    ts.isTypeAssertionExpression(value)
+  ) {
+    value = value.expression;
+  }
+  if (!ts.isIdentifier(value) || value.text === "undefined") return false;
+
+  const declaration = ctx.oracle.variableDeclarationOf(value);
+  if (!declaration || declaration.initializer) return false;
+  if (!ts.isVariableDeclarationList(declaration.parent)) return false;
+  if ((declaration.parent.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) !== 0) return false;
+
+  const sourceFile = arg.getSourceFile();
+  const before = arg.getStart(sourceFile);
+  if (declaration.getStart(sourceFile) <= before) return false;
+  let hasPrecedingUse = false;
+  const visit = (node: ts.Node): void => {
+    if (hasPrecedingUse || node.getStart(sourceFile) >= before) return;
+    if (ts.isIdentifier(node) && ctx.oracle.variableDeclarationOf(node) === declaration) {
+      hasPrecedingUse = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (hasPrecedingUse) return false;
+
+  const argResult = compileExpression(ctx, fctx, arg);
+  if (argResult) fctx.body.push({ op: "drop" });
+  emitUndefined(ctx, fctx);
+  return true;
+}

--- a/tests/issue-3763-string-indexof-undefined-search.test.ts
+++ b/tests/issue-3763-string-indexof-undefined-search.test.ts
@@ -1,0 +1,48 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { runTest262File } from "./test262-runner.ts";
+
+async function runGc(source: string): Promise<unknown> {
+  // The Test262 harness shape exercises the legacy receiver-method lowering
+  // fixed by #3763. Pin it here so small probe functions are not claimed by
+  // the separate experimental-IR string-call path.
+  const result = await compile(source, { experimentalIR: false, skipSemanticDiagnostics: true } as never);
+  if (!result.success) throw new Error(result.errors?.[0]?.message ?? "compile failed");
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#3763 String.prototype.indexOf undefined search coercion", () => {
+  it("passes an uninitialised hoisted var as actual undefined", async () => {
+    expect(
+      await runGc(`
+        export function test(): number {
+          return "undefined".indexOf(search);
+          var search;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("does not fold an uninitialised var after a preceding write", async () => {
+    expect(
+      await runGc(`
+        export function test(): number {
+          search = null;
+          return "null".indexOf(search);
+          var search;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("passes the exact ES5 hoisted-var Test262 case", async () => {
+    const result = await runTest262File(
+      resolve("test262/test/built-ins/String/prototype/indexOf/S15.5.4.7_A1_T6.js"),
+      "issue-3763",
+      45_000,
+    );
+    expect(result.status, result.error).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

- preserve a first read of an uninitialised hoisted `var` as actual JavaScript `undefined` when it is the search argument to `String.prototype.indexOf`
- decline the proof when the declaration precedes the read or any earlier use exists
- keep the change isolated to classic host `indexOf`; standalone, other string methods, and RegExp lowering are unchanged
- add direct regression coverage and the exact ES5 Test262 case

## Root cause

The classic JS-host string-method lowering compiled the search argument directly into an `externref` slot. For `indexOf(x); var x;`, TypeScript types `x` as `any`, while the Wasm representation collapsed its runtime value to JS `null`. The host therefore searched for `"null"` instead of applying `ToString(undefined)` and searching for `"undefined"`.

The new helper proves only the bounded hoisted-first-read shape, evaluates it once, drops the representation placeholder, and emits the existing real host `undefined` sentinel.

## Measured Test262 impact

Same-runner, same-SHA A/B against `origin/main` `86ee61421e982d61db0fa4898e6a4db1a66ce767`:

| Cohort | Control | Candidate |
| --- | --- | --- |
| ES5 host (34) | 29 pass / 5 fail | 30 pass / 4 fail |
| ES5 standalone (34) | 26 pass / 8 fail | 26 pass / 8 fail |
| Full indexOf host (47) | 34 pass / 13 fail | 35 pass / 12 fail |
| Full indexOf standalone (47) | 30 pass / 17 fail | 30 pass / 17 fail |

The sole flip is `S15.5.4.7_A1_T6.js`. After excluding that target, control and candidate status/error signature hashes are identical in every cohort/lane:

- ES5 host: `1bdb2e5e358cb1d6d810bff2706bc9479f4ab516ba20cceac3748032f5c90e33`
- full host: `fad91466745d4a44b5a31735b826f83efa5f12f72160bbd7b087f0a492b9d951`
- ES5 standalone: `85141bc0bc0b68ca15ea8683756e484705c5456c8743a4405eb70e797d5ba0f0`
- full standalone: `a8369f8c6ef474f1ae01f96a44ad3407981e06e3384246582dcefaab2d08247c`

Zero regressions and zero fail-to-fail signature drift. `T8`/`T9` remain failures due to independent receiver-side object/String-wrapper coercion and are not claimed here.

## Validation

- `pnpm exec vitest run tests/issue-3763-string-indexof-undefined-search.test.ts tests/issue-2598-2599-string-arg-tostring.test.ts` — 28/28 pass
- `pnpm run typecheck`
- focused Biome lint and Prettier checks
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- issue ID collision checks against latest main and open PRs
