### PR TITLE
fix(string): support transferred substring calls standalone

### DIFF
--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -33,6 +33,7 @@ import {
 } from "./native-proto.js";
 import { pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
 import { emitThrowTypeError } from "./expressions/helpers.js";
+import { buildThrowJsErrorInstrs } from "./js-errors.js";
 import { emitDataViewProtoMemberBody } from "./dataview-native.js"; // (#3173) reflective DataView member bodies
 import { emitDateProtoMemberBody } from "./expressions/builtins.js"; // (#3219) reflective Date getter bodies
 import { emitDateReflectiveSetterBody } from "./date-reflective-setters.js"; // (#3174) reflective Date setter/toISOString bodies
@@ -832,6 +833,9 @@ function emitStringRequireObjectCoercible(ctx: CodegenContext, fctx: FunctionCon
  */
 function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, member: string): ValType | null {
   const IN_SCOPE = new Set(["charAt", "at", "charCodeAt", "codePointAt"]);
+  // `substring` has two integer bounds and returns a string, so it needs its own
+  // body rather than the single-position index-accessor path below.
+  if (member === "substring") return emitStringSubstringMemberBody(ctx, fctx);
   // (#2875 slice 3a) The number-returning search family — `indexOf` /
   // `lastIndexOf` — has a DIFFERENT closure ABI from the index accessors
   // (param 2 is the search STRING, not an integer position; the optional
@@ -1065,6 +1069,94 @@ function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, m
       { op: "extern.convert_any" },
     ],
   });
+  return { kind: "externref" };
+}
+
+/**
+ * Native body for a reflective `String.prototype.substring` closure.
+ * Closure ABI: `this` = param 1, start = param 2, end = param 3. Preserve the
+ * spec's observable coercion order: RequireObjectCoercible(this), ToString(this),
+ * ToInteger(start), then ToInteger(end). An absent/undefined end uses the same
+ * MAX_INT sentinel as the direct-call path and is clamped to the receiver length
+ * by `__str_substring`; the core also implements substring's bound swap.
+ */
+function emitStringSubstringMemberBody(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
+  ensureNativeStringHelpers(ctx);
+  // Generic substring is deliberately callable on arrays and wrapper objects.
+  // Their ToString path needs the object runtime's ToPrimitive(string) ladder
+  // (array join, wrapper [[PrimitiveValue]], user toString), not the terminal
+  // "[object Object]" fallback of a raw anyref conversion.
+  ensureObjectRuntime(ctx);
+  ensureStringRocUndefinedNative(ctx, fctx);
+
+  // Register the only late import before fetching helper indices. The actual
+  // argument conversions are emitted later, after ToString(this), by
+  // `unboxArgToI32`; this up-front registration prevents their calls from
+  // shifting already-emitted function indices.
+  ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
+  flushLateImportShifts(ctx, fctx);
+
+  const anyToStrIdx = ensureAnyToStringHelper(ctx);
+  const toPrimitiveIdx = ctx.funcMap.get("__to_primitive");
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  const substringIdx = ctx.nativeStrHelpers.get("__str_substring");
+  if (toPrimitiveIdx === undefined || flattenIdx === undefined || substringIdx === undefined) {
+    return emitProtoMemberBodyRefusal(ctx, fctx, "String", "substring");
+  }
+
+  emitStringRequireObjectCoercible(ctx, fctx, "substring");
+
+  // S = ToString(this).
+  // `__any_to_string` intentionally has a printable Symbol fallback for
+  // diagnostic/property-name paths. The abstract ToString operation used by
+  // String.prototype methods must instead reject Symbols.
+  if (ctx.symbolTypeIdx >= 0) {
+    const symbolThrow = buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot convert a Symbol value to a string", {
+      flush: fctx,
+    });
+    fctx.body.push({ op: "local.get", index: 1 });
+    fctx.body.push({ op: "any.convert_extern" });
+    fctx.body.push({ op: "ref.test", typeIdx: ctx.symbolTypeIdx });
+    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: symbolThrow, else: [] });
+  }
+  fctx.body.push({ op: "local.get", index: 1 });
+  addStringConstantGlobal(ctx, "string");
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, "string"));
+  fctx.body.push({ op: "call", funcIdx: toPrimitiveIdx });
+  fctx.body.push({ op: "any.convert_extern" });
+  fctx.body.push({ op: "call", funcIdx: anyToStrIdx });
+  fctx.body.push({ op: "call", funcIdx: flattenIdx });
+  const flatLocal = allocLocal(fctx, `__str_pm_substring_${fctx.locals.length}`, flatStringType(ctx));
+  fctx.body.push({ op: "local.set", index: flatLocal });
+
+  // ToIntegerOrInfinity(start/end). `i32.trunc_sat_f64_s` supplies the integer
+  // conversion used by the existing reflective string method bodies.
+  const startLocal = unboxArgToI32(ctx, fctx, 2);
+  const endLocal = unboxArgToI32(ctx, fctx, 3);
+
+  // The reflective closure ABI pads an omitted end with null; canonical
+  // standalone `undefined` is a distinct sentinel, so recognize both.
+  fctx.body.push({ op: "local.get", index: 3 });
+  fctx.body.push({ op: "ref.is_null" });
+  const isUndefIdx = undefinedSingletonActive(ctx) ? ctx.funcMap.get("__extern_is_undefined") : undefined;
+  if (isUndefIdx !== undefined) {
+    fctx.body.push({ op: "local.get", index: 3 });
+    fctx.body.push({ op: "call", funcIdx: isUndefIdx });
+    fctx.body.push({ op: "i32.or" });
+  }
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [{ op: "i32.const", value: 0x7fffffff }],
+    else: [{ op: "local.get", index: endLocal }],
+  });
+  fctx.body.push({ op: "local.set", index: endLocal });
+
+  fctx.body.push({ op: "local.get", index: flatLocal });
+  fctx.body.push({ op: "local.get", index: startLocal });
+  fctx.body.push({ op: "local.get", index: endLocal });
+  fctx.body.push({ op: "call", funcIdx: substringIdx });
+  fctx.body.push({ op: "extern.convert_any" });
   return { kind: "externref" };
 }
 

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -33,7 +33,6 @@ import {
 } from "./native-proto.js";
 import { pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
 import { emitThrowTypeError } from "./expressions/helpers.js";
-import { buildThrowJsErrorInstrs } from "./js-errors.js";
 import { emitDataViewProtoMemberBody } from "./dataview-native.js"; // (#3173) reflective DataView member bodies
 import { emitDateProtoMemberBody } from "./expressions/builtins.js"; // (#3219) reflective Date getter bodies
 import { emitDateReflectiveSetterBody } from "./date-reflective-setters.js"; // (#3174) reflective Date setter/toISOString bodies
@@ -53,6 +52,7 @@ import {
 } from "./native-strings.js";
 import { COLLECTION_KIND, MAP_LAYOUT, ensureMapHelpers } from "./map-runtime.js"; // (#3171) size getter
 import { emitReceiverBrandCheck } from "./receiver-brand.js"; // (#3171) shared brand preamble
+import { emitStringSubstringMemberBody } from "./string-proto-substring.js";
 
 /**
  * `Array.prototype`'s own enumerable+non-enumerable method names (ES2024
@@ -821,9 +821,7 @@ function emitStringRequireObjectCoercible(ctx: CodegenContext, fctx: FunctionCon
  * (`emitReflectiveNativeProtoClosureCall`, calls.ts) work instead of falling
  * through to the legacy `.call` that drops `thisArg` and returns 0.
  *
- * Slice 1 wires the index-accessor family (`charAt`, `at`); other members return
- * a catchable-TypeError refusal (`null` → the reflective call falls through
- * unchanged, so behaviour for un-wired members is byte-identical to today).
+ * Slice 1 wires the index-accessor family; unwired members keep their existing catchable-TypeError fallback.
  *
  * Funcidx/type-index discipline: the ONLY late-import adder here is
  * `unboxArgToI32` (its `__unbox_number`); it runs FIRST (mirroring
@@ -833,8 +831,6 @@ function emitStringRequireObjectCoercible(ctx: CodegenContext, fctx: FunctionCon
  */
 function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, member: string): ValType | null {
   const IN_SCOPE = new Set(["charAt", "at", "charCodeAt", "codePointAt"]);
-  // `substring` has two integer bounds and returns a string, so it needs its own
-  // body rather than the single-position index-accessor path below.
   if (member === "substring") return emitStringSubstringMemberBody(ctx, fctx);
   // (#2875 slice 3a) The number-returning search family — `indexOf` /
   // `lastIndexOf` — has a DIFFERENT closure ABI from the index accessors
@@ -1069,94 +1065,6 @@ function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, m
       { op: "extern.convert_any" },
     ],
   });
-  return { kind: "externref" };
-}
-
-/**
- * Native body for a reflective `String.prototype.substring` closure.
- * Closure ABI: `this` = param 1, start = param 2, end = param 3. Preserve the
- * spec's observable coercion order: RequireObjectCoercible(this), ToString(this),
- * ToInteger(start), then ToInteger(end). An absent/undefined end uses the same
- * MAX_INT sentinel as the direct-call path and is clamped to the receiver length
- * by `__str_substring`; the core also implements substring's bound swap.
- */
-function emitStringSubstringMemberBody(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
-  ensureNativeStringHelpers(ctx);
-  // Generic substring is deliberately callable on arrays and wrapper objects.
-  // Their ToString path needs the object runtime's ToPrimitive(string) ladder
-  // (array join, wrapper [[PrimitiveValue]], user toString), not the terminal
-  // "[object Object]" fallback of a raw anyref conversion.
-  ensureObjectRuntime(ctx);
-  ensureStringRocUndefinedNative(ctx, fctx);
-
-  // Register the only late import before fetching helper indices. The actual
-  // argument conversions are emitted later, after ToString(this), by
-  // `unboxArgToI32`; this up-front registration prevents their calls from
-  // shifting already-emitted function indices.
-  ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
-  flushLateImportShifts(ctx, fctx);
-
-  const anyToStrIdx = ensureAnyToStringHelper(ctx);
-  const toPrimitiveIdx = ctx.funcMap.get("__to_primitive");
-  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
-  const substringIdx = ctx.nativeStrHelpers.get("__str_substring");
-  if (toPrimitiveIdx === undefined || flattenIdx === undefined || substringIdx === undefined) {
-    return emitProtoMemberBodyRefusal(ctx, fctx, "String", "substring");
-  }
-
-  emitStringRequireObjectCoercible(ctx, fctx, "substring");
-
-  // S = ToString(this).
-  // `__any_to_string` intentionally has a printable Symbol fallback for
-  // diagnostic/property-name paths. The abstract ToString operation used by
-  // String.prototype methods must instead reject Symbols.
-  if (ctx.symbolTypeIdx >= 0) {
-    const symbolThrow = buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot convert a Symbol value to a string", {
-      flush: fctx,
-    });
-    fctx.body.push({ op: "local.get", index: 1 });
-    fctx.body.push({ op: "any.convert_extern" });
-    fctx.body.push({ op: "ref.test", typeIdx: ctx.symbolTypeIdx });
-    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: symbolThrow, else: [] });
-  }
-  fctx.body.push({ op: "local.get", index: 1 });
-  addStringConstantGlobal(ctx, "string");
-  fctx.body.push(...stringConstantExternrefInstrs(ctx, "string"));
-  fctx.body.push({ op: "call", funcIdx: toPrimitiveIdx });
-  fctx.body.push({ op: "any.convert_extern" });
-  fctx.body.push({ op: "call", funcIdx: anyToStrIdx });
-  fctx.body.push({ op: "call", funcIdx: flattenIdx });
-  const flatLocal = allocLocal(fctx, `__str_pm_substring_${fctx.locals.length}`, flatStringType(ctx));
-  fctx.body.push({ op: "local.set", index: flatLocal });
-
-  // ToIntegerOrInfinity(start/end). `i32.trunc_sat_f64_s` supplies the integer
-  // conversion used by the existing reflective string method bodies.
-  const startLocal = unboxArgToI32(ctx, fctx, 2);
-  const endLocal = unboxArgToI32(ctx, fctx, 3);
-
-  // The reflective closure ABI pads an omitted end with null; canonical
-  // standalone `undefined` is a distinct sentinel, so recognize both.
-  fctx.body.push({ op: "local.get", index: 3 });
-  fctx.body.push({ op: "ref.is_null" });
-  const isUndefIdx = undefinedSingletonActive(ctx) ? ctx.funcMap.get("__extern_is_undefined") : undefined;
-  if (isUndefIdx !== undefined) {
-    fctx.body.push({ op: "local.get", index: 3 });
-    fctx.body.push({ op: "call", funcIdx: isUndefIdx });
-    fctx.body.push({ op: "i32.or" });
-  }
-  fctx.body.push({
-    op: "if",
-    blockType: { kind: "val", type: { kind: "i32" } },
-    then: [{ op: "i32.const", value: 0x7fffffff }],
-    else: [{ op: "local.get", index: endLocal }],
-  });
-  fctx.body.push({ op: "local.set", index: endLocal });
-
-  fctx.body.push({ op: "local.get", index: flatLocal });
-  fctx.body.push({ op: "local.get", index: startLocal });
-  fctx.body.push({ op: "local.get", index: endLocal });
-  fctx.body.push({ op: "call", funcIdx: substringIdx });
-  fctx.body.push({ op: "extern.convert_any" });
   return { kind: "externref" };
 }
 

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -14,6 +14,11 @@ import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
 import { addUnionImports } from "./registry/imports.js";
 import { buildClosureRefTestArms, collectClosureBaseWrapperTypeIdxs } from "./closure-classifier.js";
 import { CLOSURE_ARITY_FIELD_IDX, getFuncRefWrapperRootTypeIdx } from "./closures/funcref-wrapper-types.js";
+import {
+  buildTransferredSubstringCallInstrs,
+  collectTransferredSubstringReceivers,
+  resolveClosureBaseWrapperTypeIdx,
+} from "./closures/transferred-native-proto.js";
 import { ensureArgcGlobal, ensureCurrentThisGlobal, ensureExtrasArgvGlobal } from "./statements/nested-declarations.js";
 import { ensureAnyToExternHelper, isAnyValue } from "./any-helpers.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
@@ -225,23 +230,7 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
   // selected it. Shared signature wrappers are distinct children, not
   // canonicalized peers; only the permanently-open root admits every shared
   // signature wrapper for the initial ref.test + struct.get.
-  if (baseWrapperIdx === undefined) {
-    for (const [typeIdx] of ctx.closureInfoByTypeIdx) {
-      const typeDef = mod.types[typeIdx];
-      if (typeDef && typeDef.kind === "struct" && typeDef.superTypeIdx === -1) {
-        baseWrapperIdx = typeIdx;
-        break;
-      }
-    }
-  }
-  if (baseWrapperIdx === undefined) {
-    for (const [typeIdx] of ctx.closureInfoByTypeIdx) {
-      if (ctx.closureInfoByTypeIdx.get(typeIdx)!.paramTypes.length === arity) {
-        baseWrapperIdx = typeIdx;
-        break;
-      }
-    }
-  }
+  baseWrapperIdx = resolveClosureBaseWrapperTypeIdx(ctx, arity, baseWrapperIdx);
   if (baseWrapperIdx === undefined) return;
 
   addUnionImports(ctx);
@@ -550,25 +539,9 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
     selfTypeIdx: number;
     closureArity: number;
   }[] = [];
-  // Native-prototype method closures carry an INTERNAL leading receiver param
-  // in addition to their user-visible arguments. The ordinary dispatcher below
-  // treats every closure param as a user argument, so a transferred
-  // `String.prototype.substring` value stored on an object can never match the
-  // arity-2 method bridge: its lifted signature has three params
-  // (`this,start,end`). Keep this residual substring fix exact by recognizing
-  // only its metadata singleton here; the special arm below threads the method
-  // call's separate `thisVal` into that internal slot.
-  const substringReceiverEntries: { typeIdx: number; funcTypeIdx: number }[] = [];
+  const substringReceiverEntries = collectTransferredSubstringReceivers(ctx, arity);
 
   for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
-    if (
-      arity === 2 &&
-      info.paramTypes.length === 3 &&
-      ctx.nativeProtoReceiverClosureStructTypes?.has(typeIdx) &&
-      ctx.builtinFnMetaByTypeIdx?.get(typeIdx)?.name === "substring"
-    ) {
-      substringReceiverEntries.push({ typeIdx, funcTypeIdx: info.funcTypeIdx });
-    }
     if (info.paramTypes.length > arity) continue;
     const typeDef = mod.types[typeIdx];
     if (!typeDef || typeDef.kind !== "struct") continue;
@@ -593,23 +566,7 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
   }
   if (entries.length === 0 && substringReceiverEntries.length === 0) return;
 
-  if (baseWrapperIdx === undefined) {
-    for (const [typeIdx] of ctx.closureInfoByTypeIdx) {
-      const typeDef = mod.types[typeIdx];
-      if (typeDef && typeDef.kind === "struct" && typeDef.superTypeIdx === -1) {
-        baseWrapperIdx = typeIdx;
-        break;
-      }
-    }
-  }
-  if (baseWrapperIdx === undefined) {
-    for (const [typeIdx] of ctx.closureInfoByTypeIdx) {
-      if (ctx.closureInfoByTypeIdx.get(typeIdx)!.paramTypes.length === arity) {
-        baseWrapperIdx = typeIdx;
-        break;
-      }
-    }
-  }
+  baseWrapperIdx = resolveClosureBaseWrapperTypeIdx(ctx, arity, baseWrapperIdx);
   if (baseWrapperIdx === undefined) return;
 
   addUnionImports(ctx);
@@ -644,48 +601,15 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
   body.push({ op: "local.get", index: 0 });
   body.push({ op: "global.set", index: currentThisGlobalIdx });
 
-  // A builtin-meta `ref.test` is only a FAMILY guard because the meta structs
-  // are structurally equivalent. Check immutable `bfnid` as well, then invoke
-  // the substring closure with `(self, thisVal, start, end)`. Returning from the
-  // arm requires restoring `__current_this`, just like the common tail.
-  for (const special of substringReceiverEntries) {
-    body.push(
-      { op: "local.get", index: anyLocal },
-      { op: "ref.test", typeIdx: special.typeIdx },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [
-          { op: "local.get", index: anyLocal },
-          { op: "ref.cast", typeIdx: special.typeIdx },
-          { op: "struct.get", typeIdx: special.typeIdx, fieldIdx: 3 },
-          { op: "i32.const", value: special.typeIdx },
-          { op: "i32.eq" },
-          {
-            op: "if",
-            blockType: { kind: "empty" },
-            then: [
-              { op: "local.get", index: anyLocal },
-              { op: "ref.cast", typeIdx: special.typeIdx },
-              { op: "local.get", index: 0 },
-              { op: "local.get", index: 2 },
-              { op: "local.get", index: 3 },
-              { op: "local.get", index: anyLocal },
-              { op: "ref.cast", typeIdx: special.typeIdx },
-              { op: "struct.get", typeIdx: special.typeIdx, fieldIdx: 0 },
-              { op: "ref.cast", typeIdx: special.funcTypeIdx },
-              { op: "call_ref", typeIdx: special.funcTypeIdx },
-              { op: "local.set", index: resultSaveLocal },
-              { op: "local.get", index: prevThisLocal },
-              { op: "global.set", index: currentThisGlobalIdx },
-              { op: "local.get", index: resultSaveLocal },
-              { op: "return" },
-            ],
-          },
-        ],
-      },
-    );
-  }
+  body.push(
+    ...buildTransferredSubstringCallInstrs(
+      substringReceiverEntries,
+      anyLocal,
+      resultSaveLocal,
+      prevThisLocal,
+      currentThisGlobalIdx,
+    ),
+  );
 
   let funcrefDispatch: Instr[] = [{ op: "ref.null.extern" }];
   // (#3673 round 10) per-entry callBody capture for the arity-bucketed

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -540,6 +540,7 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
   // #1712 per-shape extraction note in emitClosureCallExportN).
   const funcLocal = totalParams + 2;
   const prevThisLocal = totalParams + 3;
+  const resultSaveLocal = prevThisLocal + 1;
 
   let baseWrapperIdx: number | undefined;
   const seenFuncTypeIdx = new Set<number>();
@@ -549,8 +550,25 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
     selfTypeIdx: number;
     closureArity: number;
   }[] = [];
+  // Native-prototype method closures carry an INTERNAL leading receiver param
+  // in addition to their user-visible arguments. The ordinary dispatcher below
+  // treats every closure param as a user argument, so a transferred
+  // `String.prototype.substring` value stored on an object can never match the
+  // arity-2 method bridge: its lifted signature has three params
+  // (`this,start,end`). Keep this residual substring fix exact by recognizing
+  // only its metadata singleton here; the special arm below threads the method
+  // call's separate `thisVal` into that internal slot.
+  const substringReceiverEntries: { typeIdx: number; funcTypeIdx: number }[] = [];
 
   for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
+    if (
+      arity === 2 &&
+      info.paramTypes.length === 3 &&
+      ctx.nativeProtoReceiverClosureStructTypes?.has(typeIdx) &&
+      ctx.builtinFnMetaByTypeIdx?.get(typeIdx)?.name === "substring"
+    ) {
+      substringReceiverEntries.push({ typeIdx, funcTypeIdx: info.funcTypeIdx });
+    }
     if (info.paramTypes.length > arity) continue;
     const typeDef = mod.types[typeIdx];
     if (!typeDef || typeDef.kind !== "struct") continue;
@@ -573,7 +591,7 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
       });
     }
   }
-  if (entries.length === 0) return;
+  if (entries.length === 0 && substringReceiverEntries.length === 0) return;
 
   if (baseWrapperIdx === undefined) {
     for (const [typeIdx] of ctx.closureInfoByTypeIdx) {
@@ -625,6 +643,49 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
   body.push({ op: "local.set", index: prevThisLocal });
   body.push({ op: "local.get", index: 0 });
   body.push({ op: "global.set", index: currentThisGlobalIdx });
+
+  // A builtin-meta `ref.test` is only a FAMILY guard because the meta structs
+  // are structurally equivalent. Check immutable `bfnid` as well, then invoke
+  // the substring closure with `(self, thisVal, start, end)`. Returning from the
+  // arm requires restoring `__current_this`, just like the common tail.
+  for (const special of substringReceiverEntries) {
+    body.push(
+      { op: "local.get", index: anyLocal },
+      { op: "ref.test", typeIdx: special.typeIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: anyLocal },
+          { op: "ref.cast", typeIdx: special.typeIdx },
+          { op: "struct.get", typeIdx: special.typeIdx, fieldIdx: 3 },
+          { op: "i32.const", value: special.typeIdx },
+          { op: "i32.eq" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: anyLocal },
+              { op: "ref.cast", typeIdx: special.typeIdx },
+              { op: "local.get", index: 0 },
+              { op: "local.get", index: 2 },
+              { op: "local.get", index: 3 },
+              { op: "local.get", index: anyLocal },
+              { op: "ref.cast", typeIdx: special.typeIdx },
+              { op: "struct.get", typeIdx: special.typeIdx, fieldIdx: 0 },
+              { op: "ref.cast", typeIdx: special.funcTypeIdx },
+              { op: "call_ref", typeIdx: special.funcTypeIdx },
+              { op: "local.set", index: resultSaveLocal },
+              { op: "local.get", index: prevThisLocal },
+              { op: "global.set", index: currentThisGlobalIdx },
+              { op: "local.get", index: resultSaveLocal },
+              { op: "return" },
+            ],
+          },
+        ],
+      },
+    );
+  }
 
   let funcrefDispatch: Instr[] = [{ op: "ref.null.extern" }];
   // (#3673 round 10) per-entry callBody capture for the arity-bucketed
@@ -859,7 +920,6 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
   // Reuse `prevThisLocal` is not safe since we still need its contents;
   // use `anyLocal` is also not safe (externref vs anyref). Add a dedicated
   // result-save slot at index `prevThisLocal + 1`.
-  const resultSaveLocal = prevThisLocal + 1;
   body.push({ op: "local.set", index: resultSaveLocal });
   body.push({ op: "local.get", index: prevThisLocal });
   body.push({ op: "global.set", index: currentThisGlobalIdx });

--- a/src/codegen/closures/transferred-native-proto.ts
+++ b/src/codegen/closures/transferred-native-proto.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr } from "../../ir/types.js";
+import type { CodegenContext } from "../context/types.js";
+
+export interface TransferredNativeReceiverEntry {
+  typeIdx: number;
+  funcTypeIdx: number;
+}
+
+/**
+ * Native-prototype closures carry an internal receiver before user arguments.
+ * Keep the residual arity-2 bridge exact to the substring metadata singleton.
+ */
+export function collectTransferredSubstringReceivers(
+  ctx: CodegenContext,
+  arity: number,
+): TransferredNativeReceiverEntry[] {
+  if (arity !== 2) return [];
+  const entries: TransferredNativeReceiverEntry[] = [];
+  for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
+    if (
+      info.paramTypes.length === 3 &&
+      ctx.nativeProtoReceiverClosureStructTypes?.has(typeIdx) &&
+      ctx.builtinFnMetaByTypeIdx?.get(typeIdx)?.name === "substring"
+    ) {
+      entries.push({ typeIdx, funcTypeIdx: info.funcTypeIdx });
+    }
+  }
+  return entries;
+}
+
+export function resolveClosureBaseWrapperTypeIdx(
+  ctx: CodegenContext,
+  arity: number,
+  initial: number | undefined,
+): number | undefined {
+  if (initial !== undefined) return initial;
+  for (const [typeIdx] of ctx.closureInfoByTypeIdx) {
+    const typeDef = ctx.mod.types[typeIdx];
+    if (typeDef && typeDef.kind === "struct" && typeDef.superTypeIdx === -1) return typeIdx;
+  }
+  for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
+    if (info.paramTypes.length === arity) return typeIdx;
+  }
+  return undefined;
+}
+
+/**
+ * Build the special method-call arm that supplies `(self, thisVal, start, end)`.
+ * The structural ref.test is only a family guard, so immutable bfnid is checked
+ * before invocation. The saved current-this value is restored before return.
+ */
+export function buildTransferredSubstringCallInstrs(
+  entries: TransferredNativeReceiverEntry[],
+  anyLocal: number,
+  resultSaveLocal: number,
+  prevThisLocal: number,
+  currentThisGlobalIdx: number,
+): Instr[] {
+  const body: Instr[] = [];
+  for (const entry of entries) {
+    body.push(
+      { op: "local.get", index: anyLocal },
+      { op: "ref.test", typeIdx: entry.typeIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: anyLocal },
+          { op: "ref.cast", typeIdx: entry.typeIdx },
+          { op: "struct.get", typeIdx: entry.typeIdx, fieldIdx: 3 },
+          { op: "i32.const", value: entry.typeIdx },
+          { op: "i32.eq" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: anyLocal },
+              { op: "ref.cast", typeIdx: entry.typeIdx },
+              { op: "local.get", index: 0 },
+              { op: "local.get", index: 2 },
+              { op: "local.get", index: 3 },
+              { op: "local.get", index: anyLocal },
+              { op: "ref.cast", typeIdx: entry.typeIdx },
+              { op: "struct.get", typeIdx: entry.typeIdx, fieldIdx: 0 },
+              { op: "ref.cast", typeIdx: entry.funcTypeIdx },
+              { op: "call_ref", typeIdx: entry.funcTypeIdx },
+              { op: "local.set", index: resultSaveLocal },
+              { op: "local.get", index: prevThisLocal },
+              { op: "global.set", index: currentThisGlobalIdx },
+              { op: "local.get", index: resultSaveLocal },
+              { op: "return" },
+            ],
+          },
+        ],
+      },
+    );
+  }
+  return body;
+}

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -373,6 +373,11 @@ export function ensureExternrefToNumberProvider(ctx: CodegenContext, fctx: Funct
   return unboxIdx;
 }
 
+/** Look up the canonical ToPrimitive provider after its owning runtime is ready. */
+export function getToPrimitiveProvider(ctx: CodegenContext): number | undefined {
+  return ctx.funcMap.get("__to_primitive");
+}
+
 /**
  * Append `ToBoolean(value)` (§7.1.2 → i32, 1 = truthy) for a value of ValType
  * `valType` already on the stack into `sink`. The consolidation of the two

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -2308,6 +2308,11 @@ export function compileReceiverMethodCall(
     !isStringType(receiverType) &&
     !receiverIsCaughtErrorStringRead(ctx, propAccess.expression) &&
     !receiverIsNativeStringValType(ctx, fctx, propAccess.expression) &&
+    // A transferred `String.prototype.substring` installed as an own/prototype
+    // method must run with the non-string receiver as `this`. The guarded native
+    // string fast path would instead reject that receiver and return null before
+    // the dynamic property call can reach the stored closure.
+    !(propAccess.name.text === "substring" && sourceHasMethodReassignment(ctx, propAccess.expression, "substring")) &&
     receiverMayBeNativeStringAtRuntime(ctx, propAccess.expression)
   ) {
     const guarded = compileGuardedNativeStringMethodCall(ctx, fctx, expr, propAccess, propAccess.name.text);

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -2290,7 +2290,6 @@ export function compileReceiverMethodCall(
   // known STRING_METHODS name (+`charCodeAt`/`substr`, which have dedicated
   // native arms but are not in the table), native-string mode, and an
   // `any`/unknown receiver NOT already handled by the static string arms below.
-  //
   // (#3673) `substr` is Annex-B and deliberately absent from `STRING_METHODS`
   // (that table doubles as the JS-host `string_<method>` import manifest), but
   // `compileNativeStringMethodCall` HAS a native `__str_substr` arm. Without
@@ -2308,10 +2307,6 @@ export function compileReceiverMethodCall(
     !isStringType(receiverType) &&
     !receiverIsCaughtErrorStringRead(ctx, propAccess.expression) &&
     !receiverIsNativeStringValType(ctx, fctx, propAccess.expression) &&
-    // A transferred `String.prototype.substring` installed as an own/prototype
-    // method must run with the non-string receiver as `this`. The guarded native
-    // string fast path would instead reject that receiver and return null before
-    // the dynamic property call can reach the stored closure.
     !(propAccess.name.text === "substring" && sourceHasMethodReassignment(ctx, propAccess.expression, "substring")) &&
     receiverMayBeNativeStringAtRuntime(ctx, propAccess.expression)
   ) {

--- a/src/codegen/string-proto-substring.ts
+++ b/src/codegen/string-proto-substring.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { allocLocal } from "./context/locals.js";
+import { undefinedSingletonActive } from "./any-helpers.js";
+import { ensureExternrefToNumberProvider, getToPrimitiveProvider } from "./coercion-engine.js";
+import { emitThrowTypeError } from "./expressions/helpers.js";
+import { buildThrowJsErrorInstrs } from "./js-errors.js";
+import { emitBrandCheckTypeError } from "./native-proto.js";
+import {
+  ensureAnyToStringHelper,
+  ensureNativeStringHelpers,
+  flatStringType,
+  stringConstantExternrefInstrs,
+} from "./native-strings.js";
+import { ensureObjectRuntime } from "./object-runtime.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { flushLateImportShifts } from "./shared.js";
+
+function emitRefusal(ctx: CodegenContext, fctx: FunctionContext): null {
+  emitThrowTypeError(ctx, fctx, "String.prototype.substring is not yet implemented in --target standalone");
+  return null;
+}
+
+function emitRequireObjectCoercible(ctx: CodegenContext, fctx: FunctionContext): void {
+  const rocThrow: Instr[] = [];
+  emitBrandCheckTypeError(ctx, rocThrow, "String.prototype.substring called on null or undefined");
+  fctx.body.push({ op: "local.get", index: 1 }, { op: "ref.is_null" });
+  const isUndefIdx = undefinedSingletonActive(ctx) ? ctx.funcMap.get("__extern_is_undefined") : undefined;
+  if (isUndefIdx !== undefined) {
+    fctx.body.push({ op: "local.get", index: 1 }, { op: "call", funcIdx: isUndefIdx }, { op: "i32.or" });
+  }
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rocThrow });
+}
+
+function unboxBoundToI32(ctx: CodegenContext, fctx: FunctionContext, paramIdx: number): number {
+  const local = allocLocal(fctx, `__pm_arg_${fctx.locals.length}`, { kind: "i32" });
+  const unboxIdx = ensureExternrefToNumberProvider(ctx, fctx);
+  fctx.body.push({ op: "local.get", index: paramIdx });
+  if (unboxIdx !== undefined) {
+    fctx.body.push({ op: "call", funcIdx: unboxIdx }, { op: "i32.trunc_sat_f64_s" });
+  } else {
+    fctx.body.push({ op: "drop" }, { op: "i32.const", value: 0 });
+  }
+  fctx.body.push({ op: "local.set", index: local });
+  return local;
+}
+
+/**
+ * Native body for a reflective `String.prototype.substring` closure.
+ * Closure ABI: `this` = param 1, start = param 2, end = param 3. The body
+ * preserves receiver/bound coercion order and delegates clamping plus swapped
+ * bounds to the existing native substring core.
+ */
+export function emitStringSubstringMemberBody(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
+  ensureNativeStringHelpers(ctx);
+  ensureObjectRuntime(ctx);
+  if (undefinedSingletonActive(ctx)) flushLateImportShifts(ctx, fctx);
+
+  // Register the only late import before fetching helper indices. Bound
+  // conversions happen after ToString(this), preserving observable order.
+  ensureExternrefToNumberProvider(ctx, fctx);
+
+  const anyToStrIdx = ensureAnyToStringHelper(ctx);
+  const toPrimitiveIdx = getToPrimitiveProvider(ctx);
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  const substringIdx = ctx.nativeStrHelpers.get("__str_substring");
+  if (toPrimitiveIdx === undefined || flattenIdx === undefined || substringIdx === undefined) {
+    return emitRefusal(ctx, fctx);
+  }
+
+  emitRequireObjectCoercible(ctx, fctx);
+
+  // The abstract ToString operation rejects Symbols, unlike the printable
+  // fallback intentionally provided by __any_to_string.
+  if (ctx.symbolTypeIdx >= 0) {
+    const symbolThrow = buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot convert a Symbol value to a string", {
+      flush: fctx,
+    });
+    fctx.body.push(
+      { op: "local.get", index: 1 },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: ctx.symbolTypeIdx },
+      { op: "if", blockType: { kind: "empty" }, then: symbolThrow, else: [] },
+    );
+  }
+  fctx.body.push({ op: "local.get", index: 1 });
+  addStringConstantGlobal(ctx, "string");
+  fctx.body.push(
+    ...stringConstantExternrefInstrs(ctx, "string"),
+    { op: "call", funcIdx: toPrimitiveIdx },
+    { op: "any.convert_extern" },
+    { op: "call", funcIdx: anyToStrIdx },
+    { op: "call", funcIdx: flattenIdx },
+  );
+  const flatLocal = allocLocal(fctx, `__str_pm_substring_${fctx.locals.length}`, flatStringType(ctx));
+  fctx.body.push({ op: "local.set", index: flatLocal });
+
+  const startLocal = unboxBoundToI32(ctx, fctx, 2);
+  const endLocal = unboxBoundToI32(ctx, fctx, 3);
+
+  // The reflective ABI pads an omitted end with null; canonical standalone
+  // undefined is a distinct sentinel, so recognize both.
+  fctx.body.push({ op: "local.get", index: 3 }, { op: "ref.is_null" });
+  const isUndefIdx = undefinedSingletonActive(ctx) ? ctx.funcMap.get("__extern_is_undefined") : undefined;
+  if (isUndefIdx !== undefined) {
+    fctx.body.push({ op: "local.get", index: 3 }, { op: "call", funcIdx: isUndefIdx }, { op: "i32.or" });
+  }
+  fctx.body.push(
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [{ op: "i32.const", value: 0x7fffffff }],
+      else: [{ op: "local.get", index: endLocal }],
+    },
+    { op: "local.set", index: endLocal },
+    { op: "local.get", index: flatLocal },
+    { op: "local.get", index: startLocal },
+    { op: "local.get", index: endLocal },
+    { op: "call", funcIdx: substringIdx },
+    { op: "extern.convert_any" },
+  );
+  return { kind: "externref" };
+}

--- a/tests/issue-2742-string-substring-residual.test.ts
+++ b/tests/issue-2742-string-substring-residual.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ES5 String.prototype.substring reflective generic-receiver residual.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, {
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  expect(result.imports ?? []).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2742 String.prototype.substring reflective generic receiver", () => {
+  it("supports a direct reflective call", async () => {
+    expect(
+      await run(`export function test(): number {
+        const value: any = String.prototype.substring.call({}, 8, 0);
+        return value === "[object " ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("stringifies an array receiver and coerces string bounds", async () => {
+    expect(
+      await run(`export function test(): number {
+        const value: any = [1, 2, 3, 4, 5];
+        value.substring = String.prototype.substring;
+        return value.substring("4", "5") === "3" ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("defaults an omitted end bound to the string length", async () => {
+    expect(
+      await run(`export function test(): number {
+        const value: any = new Boolean(false);
+        value.substring = String.prototype.substring;
+        return value.substring(true) === "alse" ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("preserves substring's swapped-bound behavior", async () => {
+    expect(
+      await run(`export function test(): number {
+        const value: any = {};
+        value.substring = String.prototype.substring;
+        return value.substring(8, 0) === "[object " ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a host-free reflective String.prototype.substring body with ES5 receiver and bound coercion
- preserve dynamic dispatch when substring is transferred to generic receivers
- thread the separate method receiver through the arity-2 closure bridge
- reject Symbol receivers during abstract ToString conversion

## Conformance
Same-SHA A/B at 86ee61421e982d61db0fa4898e6a4db1a66ce767:
- standalone ES5 substring: 22/41 pass, 18 fail, 1 CE -> 28/41 pass, 12 fail, 1 CE
- standalone full substring directory: 25/46 -> 32/46
- host ES5 substring: unchanged at 35/41; full directory unchanged at 40/46
- zero pass-to-fail transitions across all 46 substring cases

## Validation
- focused standalone regression suite: 4/4 pass, zero imports
- pnpm run typecheck
- adjacent string regression selection: 50/52, with the same two unrelated pre-existing failures reproduced on the baseline SHA
- rebased onto latest origin/main and re-ran focused suite plus typecheck

Agent: Codex