### PR TITLE
fix(bench): assert the warm chart's JS lane really is on the optimizing tier

### DIFF
--- a/scripts/generate-playground-benchmark-sidebar.mjs
+++ b/scripts/generate-playground-benchmark-sidebar.mjs
@@ -260,10 +260,16 @@ async function measureBenchmark(entry) {
     `--imports=${importsPath}`,
     `--export=${entry.exportName}`,
   ]);
+  // `--expect-tier=optimized` makes the child ASSERT that V8 kept the function
+  // on its optimizing tier across the whole measurement, rather than assuming
+  // it. A warm chart whose JS side quietly fell back to baseline reports a
+  // slow JS baseline, which flatters the wasm:js ratio — a silent wrong number
+  // is worse here than a loud failure.
   const jsResult = runChild(JS_WARM_FLAGS, [
     `--lane=js`,
     `--js-source=${jsSourcePath}`,
     `--export=${entry.exportName}`,
+    `--expect-tier=optimized`,
   ]);
 
   const wasmSamplesUs = wasmResult.samplesUs;
@@ -279,6 +285,10 @@ async function measureBenchmark(entry) {
     mode: "warm",
     jsFlags: JS_WARM_FLAGS,
     wasmFlags: WASM_WARM_FLAGS,
+    // Recorded so the published JSON carries evidence the JS side really was
+    // measured on the optimizing tier, instead of that being an unverifiable
+    // assumption of the chart.
+    jsOptStatus: jsResult.optStatusAfter ?? "unavailable",
     wasmUs: median(wasmSamplesUs),
     jsUs: median(jsSamplesUs),
     wasmStdUs: stddev(wasmSamplesUs),

--- a/scripts/no-jit-bench-child.mjs
+++ b/scripts/no-jit-bench-child.mjs
@@ -42,6 +42,36 @@ function parseArgs(argv) {
   return out;
 }
 
+// V8 `%GetOptimizationStatus` bit positions we care about (src/runtime/
+// runtime-test.cc). Only the ones this harness asserts on are named.
+const OPT_STATUS_BITS = { optimized: 1 << 4, maglev: 1 << 5, turbofan: 1 << 6, baseline: 1 << 15 };
+
+/**
+ * Read V8's optimization status for `fn`, or `null` when unavailable.
+ *
+ * Built through `new Function` on purpose: this file is shared with the
+ * COLD ("no-jit") lane, which runs under `--jitless` WITHOUT
+ * `--allow-natives-syntax`. A literal `%GetOptimizationStatus(...)` here
+ * would be a parse error in that lane before any guard could run, so the
+ * natives syntax only ever materialises lazily, inside a try/catch, in a
+ * process that enabled it.
+ */
+function readOptStatus(fn) {
+  try {
+    return new Function("f", "return %GetOptimizationStatus(f);")(fn);
+  } catch {
+    return null; // --allow-natives-syntax not enabled: nothing to assert.
+  }
+}
+
+function describeOptStatus(status) {
+  if (status === null) return "unavailable";
+  const on = Object.entries(OPT_STATUS_BITS)
+    .filter(([, mask]) => status & mask)
+    .map(([name]) => name);
+  return on.length ? `${status} (${on.join(",")})` : `${status} (none)`;
+}
+
 function calibrate(fn) {
   let iters = 0;
   const t0 = performance.now();
@@ -105,13 +135,46 @@ async function main() {
   const measuredRounds = 9;
   for (let i = 0; i < warmupRounds; i++) timeIt(fn, iters);
 
+  // `--expect-tier=optimized` (warm lane only) turns the harness's central
+  // assumption into an assertion. Without it a silently-mis-tiered run still
+  // produces a plausible-looking number and publishes it — which is exactly
+  // how the landing page came to report a JS baseline ~14x slower than the
+  // same source measured optimized, with no signal that anything was wrong.
+  // Sampled BEFORE and AFTER the measured rounds: the observed failure is not
+  // "never optimized" but tier OSCILLATION during measurement (a median
+  // between tiers with ~30% variance), which a single up-front check misses.
+  const expectTier = args["expect-tier"];
+  const optStatusBefore = expectTier ? readOptStatus(fn) : null;
+
   const samplesUs = [];
   for (let i = 0; i < measuredRounds; i++) {
     const us = (timeIt(fn, iters) / iters) * 1000;
     samplesUs.push(us);
   }
 
-  process.stdout.write(JSON.stringify({ samplesUs, iters }) + "\n");
+  const optStatusAfter = expectTier ? readOptStatus(fn) : null;
+
+  if (expectTier === "optimized" && optStatusBefore !== null) {
+    const isOpt = (s) => (s & OPT_STATUS_BITS.optimized) !== 0;
+    if (!isOpt(optStatusBefore) || !isOpt(optStatusAfter)) {
+      throw new Error(
+        `expected '${exportName}' to stay on V8's optimizing tier for the whole ` +
+          `measurement, but status was ${describeOptStatus(optStatusBefore)} before ` +
+          `and ${describeOptStatus(optStatusAfter)} after the measured rounds. ` +
+          `The reported timings would not represent optimized-tier speed.`,
+      );
+    }
+  }
+
+  process.stdout.write(
+    JSON.stringify({
+      samplesUs,
+      iters,
+      ...(expectTier
+        ? { optStatusBefore: describeOptStatus(optStatusBefore), optStatusAfter: describeOptStatus(optStatusAfter) }
+        : {}),
+    }) + "\n",
+  );
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Description

The warm chart **assumed** `%OptimizeFunctionOnNextCall` put the JS side on TurboFan and reported whatever timing fell out. When that assumption silently fails, the chart publishes a slow JS baseline — which flatters the wasm:js ratio — with no signal anything is wrong. That has been happening on CI.

### Evidence

CI published `loop.ts` as **js = 5290 µs ± 1566 µs (30% variance)**. The identical source on this box, verified optimized, runs at **~374 µs**. Pinning tiers locally shows 5290 µs isn't *any* single tier:

| tier (pinned locally) | median |
|---|---|
| TurboFan (optimizing) | 620 µs |
| Maglev only | 9,091 µs |
| Sparkplug (baseline) | 8,441 µs |
| Ignition (interpreter) | 19,433 µs |
| **CI published** | **5,290 µs ± 1,566** |

A value between tiers with 30% variance — sitting next to a wasm lane whose variance is 0.02% — is a function **oscillating** between optimized and baseline mid-measurement.

## The fix

Adds `--expect-tier=optimized` (warm lane only). The child reads V8's `%GetOptimizationStatus` **before and after** the measured rounds and throws if the function isn't on the optimizing tier at both points. Sampling both ends is the point: the failure mode is oscillation, not "never optimized", so a single up-front check would pass and still publish a wrong number. The observed status is also recorded into the published JSON as `jsOptStatus`, so the chart carries evidence rather than an unverifiable assumption.

The natives-syntax probe is built lazily via `new Function` inside a try/catch because `no-jit-bench-child.mjs` is **shared** with the cold lane, which runs under `--jitless` *without* `--allow-natives-syntax` — a literal `%GetOptimizationStatus` would be a parse error there before any guard could run. The cold lane passes no `--expect-tier` and is unaffected.

## Test plan

Verified three ways:

1. **Passes** on a genuinely optimized run — reports `optStatusBefore/After: "81 (optimized,turbofan)"`.
2. **Fails loudly** when the tier is pinned to baseline (`--no-turbofan --no-maglev`): `expected 'bench_loop' to stay on V8's optimizing tier … status was 32771 (baseline) before and 32771 (baseline) after`. A guard that can't fail is decorative, so this case is the important one.
3. **Cold lane unchanged** — `--jitless --no-opt` with no `--expect-tier` still succeeds and emits the same JSON shape.

Full generator run end-to-end: all four benchmarks report `jsOptStatus: 81 (optimized,turbofan)`.

## Note on what the chart will show

With the JS baseline now verified, the numbers change sharply from what CI published — `loop.ts` is **0.04x (22x slower)**, not the ~parity the chart showed. That gap is real, is the one #3740 fixes (7.63 ms → 0.394 ms, matching legacy), and was previously hidden by the mis-tiered baseline. The chart will look worse before it looks better, because it will finally be honest.

## CLA

Internal/org-member PR — CLA check is skipped automatically.

- [ ] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_