### PR TITLE
fix(bind): throw for standalone non-callable targets

### DIFF
--- a/plan/issues/3767-standalone-function-bind-iscallable.md
+++ b/plan/issues/3767-standalone-function-bind-iscallable.md
@@ -1,0 +1,71 @@
+---
+id: 3767
+title: "Standalone Function.prototype.bind.call: eager IsCallable TypeError for literal targets"
+status: done
+completed: 2026-07-28
+assignee: ttraenkler/codex-es5-bind-iscallable
+created: 2026-07-28
+updated: 2026-07-28
+priority: high
+feasibility: easy
+task_type: bug
+area: codegen
+es_edition: ES5
+language_feature: function-bind
+goal: test262-conformance
+sprint: current
+loc-budget-allow:
+  - src/codegen/expressions/calls.ts
+---
+
+# #3767 — Standalone `Function.prototype.bind.call` IsCallable guard
+
+## Problem
+
+ES5 §15.3.4.5 step 2 requires `Function.prototype.bind` to throw a
+`TypeError` when its target is not callable. Current ECMAScript
+§20.2.3.2 step 2 retains the same rule.
+
+The gc/host lane delegates the indirect
+`Function.prototype.bind.call(target, ...)` shape to the native host and gets
+that guard for free. Standalone has no host implementation for the fallback:
+literal non-callable targets silently return, so ten authoritative ES5 tests
+fail even though their host counterparts pass.
+
+## Exact slice
+
+- `15.3.4.5-2-{10,11,12,13,14,15}.js`
+- `S15.3.4.5_A{13,14,15,16}.js`
+
+Fresh `origin/main@f5268a605631aa` authoritative `es5id` cohort:
+
+- host: 66 pass / 80
+- standalone: 27 pass / 80
+
+## Scope and acceptance
+
+- Intercept only the syntactic
+  `Function.prototype.bind.call(<statically non-callable literal>, ...)`
+  shape under `target: "standalone"`.
+- Evaluate all outer call arguments once, left-to-right, before the throw.
+- Emit a native catchable `TypeError`.
+- Leave callable carriers, dynamic identifiers, direct/user-defined `.bind`,
+  gc/host, wasi, property-helper Array aliases, constructors, and bound
+  function property semantics unchanged.
+- All ten scoped ES5 tests pass in standalone with zero host or standalone
+  regressions in the 80-file paired A/B cohort.
+
+## Results
+
+Paired local-vs-local A/B from the same
+`origin/main@f5268a605631aabc5abdf20695e9be2931d0e562`:
+
+- host: 66/80 → 66/80; zero status changes and zero Wasm-SHA changes
+- standalone: 27/80 → 37/80; +10 / −0
+- standalone Wasm changed for exactly the ten scoped files; the other 70 were
+  byte-identical
+
+Focused `tests/issue-3767.test.ts` covers all literal target classes, the
+identifier-held RegExp shape, left-to-right argument evaluation before the
+throw, native `TypeError` identity, zero imports, and the callable indirect
+bind path.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2112,6 +2112,98 @@ function countSpecLength(params: ts.NodeArray<ts.ParameterDeclaration>): number 
 }
 
 /**
+ * (#3767) Conservative syntax-only proof that the receiver supplied to
+ * `Function.prototype.bind.call(receiver, ...)` cannot have [[Call]].
+ *
+ * Keep identifiers and other runtime values dynamic: standalone's native
+ * closure carriers are callable even though their TypeScript surface can be
+ * `any`/object-like. The literals below, however, are unconditionally
+ * non-callable ECMAScript values. Transparent TypeScript wrappers do not
+ * change that fact.
+ */
+function isStaticallyNonCallableBindTarget(ctx: CodegenContext, fctx: FunctionContext, value: ts.Expression): boolean {
+  let target = value;
+  while (
+    ts.isParenthesizedExpression(target) ||
+    ts.isAsExpression(target) ||
+    ts.isTypeAssertionExpression(target) ||
+    ts.isSatisfiesExpression(target) ||
+    ts.isNonNullExpression(target)
+  ) {
+    target = target.expression;
+  }
+  const literalNonCallable =
+    target.kind === ts.SyntaxKind.NullKeyword ||
+    target.kind === ts.SyntaxKind.TrueKeyword ||
+    target.kind === ts.SyntaxKind.FalseKeyword ||
+    target.kind === ts.SyntaxKind.RegularExpressionLiteral ||
+    ts.isNumericLiteral(target) ||
+    ts.isBigIntLiteral(target) ||
+    ts.isStringLiteralLike(target) ||
+    ts.isObjectLiteralExpression(target) ||
+    ts.isArrayLiteralExpression(target) ||
+    (ts.isIdentifier(target) && target.text === "undefined" && !fctx.localMap.has("undefined"));
+  if (literalNonCallable) return true;
+
+  // Test262's ES5 RegExp case first binds `/x/` to `var re` and then passes
+  // `re`. The oracle's nominal builtin classification preserves that exact
+  // proof without following arbitrary mutable initializers or treating a
+  // generic object/`any` value as non-callable.
+  return ts.isIdentifier(target) && ctx.oracle.builtinReceiverOf(target) === "RegExp";
+}
+
+/**
+ * Compile `Function.prototype.bind.call(target, thisArg, ...args)`.
+ * Callable targets reshape to the ordinary `.bind` path. Under standalone,
+ * statically non-callable targets take the #3767 eager TypeError guard before
+ * the general hostless `.call` fallback can silently return.
+ */
+function tryCompileIndirectFunctionBindCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+): InnerResult | undefined {
+  if (
+    propAccess.name.text !== "call" ||
+    !ts.isPropertyAccessExpression(propAccess.expression) ||
+    propAccess.expression.name.text !== "bind" ||
+    !ts.isPropertyAccessExpression(propAccess.expression.expression) ||
+    propAccess.expression.expression.name.text !== "prototype" ||
+    !ts.isIdentifier(propAccess.expression.expression.expression) ||
+    propAccess.expression.expression.expression.text !== "Function" ||
+    expr.arguments.length < 1
+  ) {
+    return undefined;
+  }
+
+  const fnExpr = expr.arguments[0]!;
+  // ES5 §15.3.4.5 step 2 / current §20.2.3.2 step 2: IsCallable(Target)
+  // false must throw TypeError. Outer-call arguments are evaluated first.
+  if (ctx.standalone && isStaticallyNonCallableBindTarget(ctx, fctx, fnExpr)) {
+    for (const arg of expr.arguments) {
+      const argType = compileExpression(ctx, fctx, arg);
+      if (argType !== null) fctx.body.push({ op: "drop" });
+    }
+    emitThrowTypeError(ctx, fctx, "Function.prototype.bind called on non-callable");
+    fctx.body.push({ op: "ref.null.extern" });
+    return { kind: "externref" };
+  }
+
+  // Preserve #1337's conservative callable-only reshape. Dynamic targets
+  // continue through the general `.call` path.
+  const fnTsType = ctx.checker.getTypeAtLocation(fnExpr);
+  if ((fnTsType?.getCallSignatures?.()?.length ?? 0) === 0) return undefined;
+  const reshapedArgs = expr.arguments.slice(1);
+  const reshapedProp = ts.factory.createPropertyAccessExpression(fnExpr as ts.LeftHandSideExpression, "bind");
+  ts.setTextRange(reshapedProp, propAccess);
+  const reshapedCall = ts.factory.createCallExpression(reshapedProp, undefined, reshapedArgs);
+  ts.setTextRange(reshapedCall, expr);
+  (reshapedCall as any).parent = expr.parent;
+  return compileCallExpression(ctx, fctx, reshapedCall as ts.CallExpression);
+}
+
+/**
  * (#1632a) Compile `target.bind(thisArg, ...partialArgs)` to a
  * `__bind_function(target, thisArg, argsArray, nameHint, lengthHint)` host
  * import call. The host delegates to `Function.prototype.bind.apply(wrapped,
@@ -6237,42 +6329,8 @@ function compileCallExpression(
       if (callResult !== undefined) return callResult;
     }
 
-    // (#1337) Function.prototype.bind.call(fn, thisArg, ...args) reshape.
-    // Mirrors the #1596 reshape for Function.prototype.{apply,call}.call: rewrite
-    // to `fn.bind(thisArg, ...args)` so the existing #1632a bind dispatch fires
-    // and routes through __bind_function instead of leaking to the host's
-    // Function.prototype.bind on a wasm-struct receiver ("Bind must be called
-    // on a function"). Only the outer `.call` form is matched —
-    // `Function.prototype.bind.apply(fn, [thisArg, ...args])` is rare.
-    //
-    // Narrowing: only fires when the `fn` target has TS call signatures.
-    // This preserves the legacy "Function.prototype.bind.call(undefined, ...)
-    // throws TypeError" behaviour for spec tests like S15.3.4.5_A13 — the
-    // bind dispatch only intercepts callable receivers; non-callable
-    // targets fall through to the legacy host path which throws correctly.
-    if (
-      propAccess.name.text === "call" &&
-      ts.isPropertyAccessExpression(propAccess.expression) &&
-      propAccess.expression.name.text === "bind" &&
-      ts.isPropertyAccessExpression(propAccess.expression.expression) &&
-      propAccess.expression.expression.name.text === "prototype" &&
-      ts.isIdentifier(propAccess.expression.expression.expression) &&
-      propAccess.expression.expression.expression.text === "Function" &&
-      expr.arguments.length >= 1
-    ) {
-      const fnExpr = expr.arguments[0]!;
-      const fnTsType = ctx.checker.getTypeAtLocation(fnExpr);
-      const fnHasCallSig = (fnTsType?.getCallSignatures?.()?.length ?? 0) > 0;
-      if (fnHasCallSig) {
-        const reshapedArgs = expr.arguments.slice(1);
-        const reshapedProp = ts.factory.createPropertyAccessExpression(fnExpr as ts.LeftHandSideExpression, "bind");
-        ts.setTextRange(reshapedProp, propAccess);
-        const reshapedCall = ts.factory.createCallExpression(reshapedProp, undefined, reshapedArgs);
-        ts.setTextRange(reshapedCall, expr);
-        (reshapedCall as any).parent = expr.parent;
-        return compileCallExpression(ctx, fctx, reshapedCall as ts.CallExpression);
-      }
-    }
+    const indirectBind = tryCompileIndirectFunctionBindCall(ctx, fctx, expr, propAccess);
+    if (indirectBind !== undefined) return indirectBind;
 
     // Handle fn.bind(thisArg, ...partialArgs).
     //

--- a/tests/issue-3767.test.ts
+++ b/tests/issue-3767.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-3767.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors?.map((error) => error.message).join("\n")).toBe(true);
+  const module = new WebAssembly.Module(result.binary);
+  expect(WebAssembly.Module.imports(module)).toEqual([]);
+  const instance = await WebAssembly.instantiate(module, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#3767 standalone Function.prototype.bind IsCallable guard", () => {
+  it("throws TypeError for every statically non-callable ES5 target shape", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          let score = 0;
+          try { Function.prototype.bind.call(undefined, {}); } catch (e) {
+            if (e instanceof TypeError) score += 1;
+          }
+          try { Function.prototype.bind.call(null, {}); } catch (e) {
+            if (e instanceof TypeError) score += 2;
+          }
+          try { Function.prototype.bind.call(false, {}); } catch (e) {
+            if (e instanceof TypeError) score += 4;
+          }
+          try { Function.prototype.bind.call(1, {}); } catch (e) {
+            if (e instanceof TypeError) score += 8;
+          }
+          try { Function.prototype.bind.call("x", {}); } catch (e) {
+            if (e instanceof TypeError) score += 16;
+          }
+          try { Function.prototype.bind.call({}, {}); } catch (e) {
+            if (e instanceof TypeError) score += 32;
+          }
+          try { Function.prototype.bind.call(/x/, undefined); } catch (e) {
+            if (e instanceof TypeError) score += 64;
+          }
+          var re = /y/;
+          try { Function.prototype.bind.call(re, undefined); } catch (e) {
+            if (e instanceof TypeError) score += 128;
+          }
+          return score;
+        }`),
+    ).toBe(255);
+  });
+
+  it("evaluates thisArg and bound arguments in source order before throwing", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          let order = 0;
+          function mark(n: number): object {
+            order = order * 10 + n;
+            return {};
+          }
+          try {
+            Function.prototype.bind.call({}, mark(1), mark(2));
+          } catch (e) {
+            return e instanceof TypeError && order === 12 ? 1 : -order;
+          }
+          return 0;
+        }`),
+    ).toBe(1);
+  });
+
+  it("keeps the callable indirect-bind path intact", async () => {
+    expect(
+      await run(`
+        function add(a: number, b: number): number { return a + b; }
+        export function test(): number {
+          const add3 = Function.prototype.bind.call(add, undefined, 3);
+          return add3(4);
+        }`),
+    ).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

- add the ES5 IsCallable guard for literal targets in the standalone Function.prototype.bind.call path
- emit a native catchable TypeError after evaluating outer-call arguments left-to-right
- preserve callable, dynamic, direct/user-defined bind, host, wasi, constructor, and property-helper behavior
- add focused regression coverage and plan issue #3767

## Conformance

Same-SHA local A/B from origin/main@f5268a605631aa over all 80 Function.prototype.bind tests carrying es5id metadata:

- host: 66/80 -> 66/80; zero status or Wasm-SHA changes
- standalone: 27/80 -> 37/80; +10 / -0
- only the ten scoped standalone binaries changed; the other 70 were byte-identical

## Validation

- pnpm exec vitest run tests/issue-3767.test.ts
- pnpm run typecheck
- pnpm run check:ir-fallbacks
- pnpm run check:oracle-ratchet
- pnpm run check:loc-budget
- pnpm run check:func-budget
- focused Biome lint
- issue ID and done-status integrity gates

The neighboring #3140 suite remains 5/6 on both the untouched base and this branch; its stale non-callable-any expectation failure is pre-existing and outside this static indirect-call slice.