### PR TITLE
fix(object): reject primitive Object.create prototypes standalone

### DIFF
--- a/plan/issues/3768-standalone-object-create-prototype-validation.md
+++ b/plan/issues/3768-standalone-object-create-prototype-validation.md
@@ -1,0 +1,67 @@
+---
+id: 3768
+title: "standalone Object.create accepts primitive prototype arguments"
+status: ready
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+priority: medium
+horizon: s
+complexity: S
+feasibility: high
+task_type: bugfix
+area: codegen
+language_feature: object-create
+es_edition: es5
+goal: es5
+assignee: ttraenkler/codex-es5-object-create-proto-validation
+---
+
+# Standalone `Object.create` prototype validation
+
+## Problem
+
+The standalone `Object.create` helper treated every non-object externref carrier
+like `null`. As a result, statically known primitive prototype arguments created
+a null-prototype object instead of throwing the `TypeError` required by ES5
+§15.2.3.5.
+
+On `origin/main` at `3cb6b8ac6f3649e05a24ed51fb7347bb33795669`,
+the exact ES5 `built-ins/Object/create` lane passed 240/314 in host mode and
+158/314 in standalone mode. Four standalone failures formed this disjoint root:
+
+- `15.2.3.5-1.js` (`0`)
+- `15.2.3.5-1-1.js` (`undefined`)
+- `15.2.3.5-1-3.js` (`true`)
+- `15.2.3.5-1-4.js` (`2`)
+
+## Scope
+
+Validate statically known primitive first arguments at the `Object.create`
+entrypoint in standalone mode, preserving argument evaluation and continuing to
+accept `null`.
+
+This slice intentionally excludes dynamic primitive carriers, second-argument
+property descriptors, generic `Object.defineProperty`/`Object.defineProperties`
+behavior, and general prototype-chain behavior.
+
+## Acceptance
+
+- All four targeted ES5 cases pass in standalone mode.
+- The host lane remains unchanged.
+- `Object.create(null)` continues to work.
+- Focused regression tests cover the thrown error and argument side effects.
+- The full `built-ins/Object/create` comparison has zero pass-to-fail
+  transitions in either target.
+
+## Result
+
+On the same compiler SHA and with the same authoritative runner:
+
+- standalone exact ES5 lane: 158/314 → 162/314
+- standalone full directory: 162/320 → 166/320
+- host exact ES5 lane: unchanged at 240/314
+- host full directory: unchanged at 246/320
+- status changes: exactly the four targeted fail-to-pass transitions
+- regressions: zero pass-to-fail transitions and zero residual
+  error-signature changes in either target

--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -1927,6 +1927,29 @@ export function compileBuiltinStaticCall(
   ) {
     const arg0 = expr.arguments[0]!;
 
+    // ES5 §15.2.3.5 step 1: the requested [[Prototype]] must be an Object
+    // or null. The standalone native helper can only see an externref carrier;
+    // it historically treated every non-$Object carrier like null, so
+    // statically known primitive arguments silently created a null-prototype
+    // object instead of throwing. Preserve argument evaluation, then emit a
+    // catchable TypeError before entering the lenient native helper.
+    if (noJsHost(ctx)) {
+      const protoTag = ctx.oracle.staticJsTypeOf(arg0);
+      if (
+        protoTag === "number" ||
+        protoTag === "string" ||
+        protoTag === "boolean" ||
+        protoTag === "bigint" ||
+        protoTag === "symbol" ||
+        protoTag === "undefined"
+      ) {
+        const argType = compileExpression(ctx, fctx, arg0);
+        if (argType) fctx.body.push({ op: "drop" });
+        emitThrowTypeError(ctx, fctx, "Object prototype may only be an Object or null");
+        return { kind: "externref" };
+      }
+    }
+
     // Object.create(Foo.prototype) → struct.new with default fields (Wasm-native fast path)
     if (ts.isPropertyAccessExpression(arg0) && ts.isIdentifier(arg0.expression) && arg0.name.text === "prototype") {
       const protoClassName = arg0.expression.text;

--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -94,6 +94,7 @@ import { compileStringLiteral } from "../string-ops.js";
 import { ensureStringRawHelper } from "../string-raw.js";
 import { defaultValueInstrs, pushDefaultValue } from "../type-coercion.js";
 import { compileMathCall } from "./builtins.js";
+import { tryCompileObjectCreateStaticPrototype } from "./call-object-builtins.js";
 import { emitLazyProtoGet } from "./extern.js";
 import { buildThrowJsErrorInstrs, emitThrowTypeError, noJsHost } from "./helpers.js";
 import { emitUndefined, ensureGetUndefined, ensureLateImport, flushLateImportShifts } from "./late-imports.js";
@@ -1927,45 +1928,8 @@ export function compileBuiltinStaticCall(
   ) {
     const arg0 = expr.arguments[0]!;
 
-    // ES5 §15.2.3.5 step 1: the requested [[Prototype]] must be an Object
-    // or null. The standalone native helper can only see an externref carrier;
-    // it historically treated every non-$Object carrier like null, so
-    // statically known primitive arguments silently created a null-prototype
-    // object instead of throwing. Preserve argument evaluation, then emit a
-    // catchable TypeError before entering the lenient native helper.
-    if (noJsHost(ctx)) {
-      const protoTag = ctx.oracle.staticJsTypeOf(arg0);
-      if (
-        protoTag === "number" ||
-        protoTag === "string" ||
-        protoTag === "boolean" ||
-        protoTag === "bigint" ||
-        protoTag === "symbol" ||
-        protoTag === "undefined"
-      ) {
-        const argType = compileExpression(ctx, fctx, arg0);
-        if (argType) fctx.body.push({ op: "drop" });
-        emitThrowTypeError(ctx, fctx, "Object prototype may only be an Object or null");
-        return { kind: "externref" };
-      }
-    }
-
-    // Object.create(Foo.prototype) → struct.new with default fields (Wasm-native fast path)
-    if (ts.isPropertyAccessExpression(arg0) && ts.isIdentifier(arg0.expression) && arg0.name.text === "prototype") {
-      const protoClassName = arg0.expression.text;
-      if (ctx.classSet.has(protoClassName)) {
-        const structTypeIdx = ctx.structMap.get(protoClassName);
-        const fields = ctx.structFields.get(protoClassName);
-        if (structTypeIdx !== undefined && fields) {
-          // Push default values for all fields, then struct.new
-          for (const field of fields) {
-            pushDefaultValue(fctx, field.type, ctx);
-          }
-          fctx.body.push({ op: "struct.new", typeIdx: structTypeIdx });
-          return { kind: "ref", typeIdx: structTypeIdx };
-        }
-      }
-    }
+    const staticPrototype = tryCompileObjectCreateStaticPrototype(ctx, fctx, arg0);
+    if (staticPrototype !== undefined) return staticPrototype;
 
     // Host import path: Object.create(null) and Object.create(proto[, descriptors])
     // Object.create(null) → empty object with null prototype

--- a/src/codegen/expressions/call-object-builtins.ts
+++ b/src/codegen/expressions/call-object-builtins.ts
@@ -10,8 +10,49 @@ import { resolveStoredObjectStaticMethod, resolveUncurriedObjectPrototypeMethod 
 import { compileObjectDefineProperties, compileObjectDefineProperty } from "../object-ops.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression } from "../shared.js";
+import { pushDefaultValue } from "../type-coercion.js";
+import { emitThrowTypeError, noJsHost } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { ts } from "../../ts-api.js";
+
+export function tryCompileObjectCreateStaticPrototype(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+): InnerResult | undefined {
+  // ES5 §15.2.3.5 step 1: the requested [[Prototype]] must be an Object
+  // or null. The standalone native helper can only see an externref carrier;
+  // reject statically known primitives after preserving argument evaluation.
+  if (noJsHost(ctx)) {
+    const protoTag = ctx.oracle.staticJsTypeOf(arg);
+    if (
+      protoTag === "number" ||
+      protoTag === "string" ||
+      protoTag === "boolean" ||
+      protoTag === "bigint" ||
+      protoTag === "symbol" ||
+      protoTag === "undefined"
+    ) {
+      const argType = compileExpression(ctx, fctx, arg);
+      if (argType) fctx.body.push({ op: "drop" });
+      emitThrowTypeError(ctx, fctx, "Object prototype may only be an Object or null");
+      return { kind: "externref" };
+    }
+  }
+
+  // Object.create(Foo.prototype) → struct.new with default fields (Wasm-native fast path)
+  if (ts.isPropertyAccessExpression(arg) && ts.isIdentifier(arg.expression) && arg.name.text === "prototype") {
+    const protoClassName = arg.expression.text;
+    const structTypeIdx = ctx.structMap.get(protoClassName);
+    const fields = ctx.structFields.get(protoClassName);
+    if (ctx.classSet.has(protoClassName) && structTypeIdx !== undefined && fields) {
+      for (const field of fields) pushDefaultValue(fctx, field.type, ctx);
+      fctx.body.push({ op: "struct.new", typeIdx: structTypeIdx });
+      return { kind: "ref", typeIdx: structTypeIdx };
+    }
+  }
+  return undefined;
+}
 
 function emitExternrefArgument(
   ctx: CodegenContext,

--- a/tests/issue-3768-object-create-proto-validation.test.ts
+++ b/tests/issue-3768-object-create-proto-validation.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3768 — ES5 Object.create prototype-argument validation in standalone mode.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, {
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  expect(result.imports ?? []).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#3768 Object.create prototype validation", () => {
+  it("throws TypeError for a numeric prototype after evaluating it", async () => {
+    expect(
+      await run(`export function test(): number {
+        let evaluated = 0;
+        try {
+          Object.create((evaluated++, 1));
+          return 10;
+        } catch (error) {
+          if (!(error instanceof TypeError)) return 11;
+          return evaluated === 1 ? 1 : 12;
+        }
+      }`),
+    ).toBe(1);
+  });
+
+  it("rejects other statically known primitive prototypes", async () => {
+    expect(
+      await run(`export function test(): number {
+        const values: any[] = [true, "proto", undefined];
+        for (let i = 0; i < values.length; i++) {
+          try {
+            if (i === 0) Object.create(true);
+            else if (i === 1) Object.create("proto");
+            else Object.create(undefined);
+            return 20 + i;
+          } catch (error) {
+            if (!(error instanceof TypeError)) return 30 + i;
+          }
+        }
+        return 1;
+      }`),
+    ).toBe(1);
+  });
+
+  it("continues to accept null as a prototype", async () => {
+    expect(
+      await run(`export function test(): number {
+        const value: any = Object.create(null);
+        return Object.getPrototypeOf(value) === null ? 1 : 40;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- reject statically known primitive first arguments to Object.create in standalone mode with a catchable TypeError
- preserve prototype-argument evaluation and continue accepting null
- add focused regression coverage and the #3768 lane record

## Scope boundary

This is limited to Object.create first-argument validation. It does not change dynamic primitive carriers, second-argument descriptors, generic Object.defineProperty/Object.defineProperties behavior, or general prototype-chain semantics.

## Conformance evidence

Same-SHA local-vs-local Object/create lane:

- standalone exact ES5: 158/314 -> 162/314
- standalone full directory: 162/320 -> 166/320
- host exact ES5: unchanged at 240/314
- host full directory: unchanged at 246/320
- exactly four fail-to-pass transitions: 15.2.3.5-1.js, 15.2.3.5-1-1.js, 15.2.3.5-1-3.js, 15.2.3.5-1-4.js
- zero pass-to-fail transitions and zero residual error-signature changes in either target

## Validation

- pnpm exec vitest run tests/issue-3768-object-create-proto-validation.test.ts tests/issue-1462.test.ts tests/issue-3274-slice3.test.ts tests/issue-1898.test.ts --reporter=dot (24/24)
- pnpm run typecheck
- authoritative host and standalone built-ins/Object/create Test262 lanes

Plan issue: 3768

Agent: Codex
