### PR TITLE
perf: pin the `__dc_*_g` guard mechanism — neither the ref.test nor the arm size (issue #3754 S2)

### DIFF
--- a/plan/issues/3754-method-axis-dispatch-gap.md
+++ b/plan/issues/3754-method-axis-dispatch-gap.md
@@ -183,7 +183,57 @@ the test itself but the two-armed `if` around it defeating inlining of the
 trampoline at the call site — worth confirming before choosing an approach,
 because it changes which fix is right.
 
-### A sound approach that does NOT need general LICM
+### Three experiments, and what they actually pin (2026-07-28)
+
+| shape of the guarded trampoline                | method |
+| ---------------------------------------------- | -----: |
+| today: `ref.test` + inlined legacy else arm     |  0.950 |
+| guard removed entirely (twin arm unconditional) |  0.424 |
+| guard KEPT, else arm shrunk to `unreachable`    |  0.420 |
+| guard KEPT, else arm lifted to a `call $..._slow` | 0.954 |
+
+Read together these are decisive, and they rule out the two obvious fixes:
+
+1. **It is not the `ref.test`, and not the branch.** Keeping both while making
+   the else arm `unreachable` recovers the entire win (0.420 vs 0.424).
+2. **It is not the arm's SIZE either.** Lifting the legacy sequence into its own
+   `__dc_<F>_<m>_<n>_slow` function — implemented, verified emitting a 30-line
+   trampoline whose else arm is a single forwarding call — recovers **nothing**
+   (0.954). That change was written, measured, and reverted rather than landed:
+   it is sound and it works, but shipping a no-op complexity increase is worse
+   than not shipping it.
+
+So the cost is the **presence of a second reachable call** in the trampoline.
+With `unreachable` the function has exactly one call and the engine inlines it
+into the hot loop; with any real fallback — inline or out-of-line — it has two
+and does not. Moving the fallback around inside the function cannot fix that.
+
+### What the fix therefore has to be
+
+The fallback must leave the hot function ENTIRELY, which means the call site
+must be able to choose the **unguarded** `__dc_<F>_<m>_<n>` trampoline. That in
+turn requires the receiver-flow verdict to be a PROOF rather than an inference —
+today it is explicitly not one. `provenReceiverClass` says so in as many words:
+"Soundness does not rest on it — the emitted `ref.test` does."
+
+The verdict is close, though. `analyzeReceiverFlow`'s `source: "new-binding"`
+already means "initialised from `new F(…)` and never written after", and pass 3
+withdraws on `=`, `delete` and `++`/`--`. To promote that to a proof, pass 3
+must also withdraw on the write forms it currently misses:
+
+- compound assignment (`p += …`, and every other assignment-operator token),
+- destructuring assignment targets (`[p] = …`, `({p} = …)`),
+- `for (p of …)` / `for (p in …)` loop bindings.
+
+Plus one check the analysis does not make today: a constructor that explicitly
+returns an object makes `new F(…)` yield something other than `$__fnctor_F`, so
+an unguarded `ref.cast` would trap. Admission must require the class's
+constructor to have no object-returning `return`.
+
+With those closed, `source === "new-binding"` is sound to lower unguarded, and
+no loop-invariant code motion is needed at all.
+
+### The superseded approach (kept for the reasoning)
 
 The guard exists because a receiver-flow verdict (#3685) is a whole-program
 *inference*, so an unguarded `ref.cast` would turn imprecision into a trap.


### PR DESCRIPTION
## Description

Docs-only. This PR records a measurement round that **falsified two candidate fixes before either shipped**, and leaves the third precisely specified.

Stacked on #3734 (the numeric-return twin), which it depends on for the baseline.

### Three experiments on the guarded `__dc_*_g` trampoline

Same container, interleaved, checksums matching, `numeric` flat throughout:

| shape of the guarded trampoline | method |
| --- | ---: |
| today: `ref.test` + inlined legacy else arm | 0.950 ms |
| guard removed entirely | 0.424 ms |
| guard KEPT, else arm shrunk to `unreachable` | 0.420 ms |
| guard KEPT, else arm lifted to `call $..._slow` | 0.954 ms |

Read together these rule out both obvious fixes:

1. **Not the `ref.test`, not the branch.** Keeping both while making the else arm `unreachable` recovers the entire win (0.420 vs 0.424 unguarded).
2. **Not the arm's size either.** Lifting the legacy sequence into its own `__dc_<F>_<m>_<n>_slow` function — implemented, verified emitting a 30-line trampoline whose else arm is a single forwarding call — recovers **nothing** (0.954).

The cost is the **presence of a second reachable call**. With `unreachable` the trampoline has exactly one call and the engine inlines it into the hot loop; with any real fallback — inline or out-of-line — it has two and does not. Moving the fallback around inside the function cannot fix that.

### Why the `_slow` lift is not in this diff

It was written, verified correct, measured, and **reverted**. It is sound and it works; it is also a no-op complexity increase, and shipping one of those is worse than shipping nothing. The reasoning is recorded in the issue so the next person doesn't rebuild it.

### What the fix has to be

The fallback must leave the hot function entirely, so the call site must be able to choose the **unguarded** trampoline. That requires the receiver-flow verdict to be a proof rather than an inference — today it explicitly is not; `provenReceiverClass` says "Soundness does not rest on it — the emitted `ref.test` does."

It is close, though. `source: "new-binding"` already means "initialised from `new F(…)` and never written after", and pass 3 withdraws on `=`, `delete`, `++`/`--`. To promote it to a proof, pass 3 must also withdraw on the write forms it misses — compound assignment, destructuring assignment targets, `for-of`/`for-in` bindings — plus admission must exclude a class whose constructor can explicitly return an object (which would make `new F(…)` yield something other than `$__fnctor_F`, and an unguarded `ref.cast` trap).

With those closed, `source === "new-binding"` lowers unguarded and **no LICM pass is needed at all**.

## Verification

Docs-only — no source changes; both experiments reverted (`git diff` against the parent touches one issue file). `check:issues` passes.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_013rC8ahHETYHdMDfkG4xBKE)_