### PR TITLE
fix(array): preserve inherited filter array semantics

### DIFF
--- a/plan/issues/3772-es5-filter-result-array.md
+++ b/plan/issues/3772-es5-filter-result-array.md
@@ -1,0 +1,92 @@
+---
+id: 3772
+title: "ES5 inherited Array.prototype.filter result identity"
+status: in-review
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+assignee: ttraenkler/codex-es5-filter-result-array
+priority: high
+task_type: bug
+area: standalone, arrays, test262
+goal: es5-conformance
+loc-budget-allow:
+  - src/codegen/object-runtime.ts
+---
+
+# #3772 — ES5 inherited `Array.prototype.filter` result identity
+
+## Scope
+
+Fix standalone dispatch for a function-constructor instance whose live
+`F.prototype` is an Array:
+
+```js
+F.prototype = new Array(1, 2, 3);
+function F() {}
+var value = new F();
+value.length = false;
+var result = value.filter(callback);
+```
+
+The primary Test262 slice is:
+
+- `built-ins/Array/prototype/filter/15.4.4.20-6-2.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-3.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-4.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-5.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-6.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-7.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-8.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-10-3.js`
+
+The implementation also retains inherited indexed reads when the instance
+shadows the prototype Array's `length` with a positive value.
+
+## Root cause
+
+The fixed-arity closed-method dispatcher classified every non-`$Object`,
+non-vector receiver of a method named `filter` as an Iterator-helper receiver.
+A raw `__fnctor_F` instance therefore called `__iter_lazy_filter` and produced a
+`$LazyIterHelper`; `Array.isArray(result)` was false and `result.length` was 0.
+
+This was not an Array branding defect: the generic borrowed-filter path already
+returned `$ObjVec`, and `$ObjVec` was already recognized by `Array.isArray`.
+
+## Implementation
+
+- Extend the native Array HOF brand predicate with exact live prototype
+  provenance: `receiver is __fnctor_F` and `F.prototype` is a native Array
+  carrier.
+- Keep the original instance as the HOF receiver so own `length` shadowing and
+  callback arguments remain correct.
+- On an own indexed-property miss, make standalone fnctor array-like readers
+  continue at the live `F.prototype` global. This preserves inherited elements
+  for positive-length cases.
+- Leave custom and non-Array function prototypes on the ordinary method lookup
+  path.
+
+## Test results
+
+Same-SHA local-vs-local measurement at
+`origin/main@f5268a605631aabc5abdf20695e9be2931d0e562`, using the authoritative
+`runTest262File` runner across all 217 `15.4.4.20*.js` files:
+
+- standalone: 129/217 → 139/217
+  - 10 exact fail-to-pass transitions
+  - zero pass-to-fail transitions
+  - the eight primary Array-result identity cases pass
+  - `15.4.4.20-9-c-i-15.js` and `15.4.4.20-9-c-i-21.js` additionally pass
+    because inherited numeric elements are now visible
+- host: 166 pass / 48 fail / 3 runner errors in both arms
+  - zero status transitions
+
+Focused and adjacent validation:
+
+- 64 passing / 1 skipped across six Vitest files
+- `pnpm run typecheck`
+- `pnpm run check:oracle-ratchet`
+- `pnpm run check:loc-budget`
+- `pnpm run check:func-budget`
+- issue ID and issue-spec coverage gates
+- scoped Prettier check

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -53,6 +53,7 @@ import { addUnionImportsViaRegistry } from "./shared.js";
 import { ensureArgcGlobal } from "./statements/nested-declarations.js"; // (#3673 round 13) direct-call argc preset
 import { CLOSURE_ARITY_FIELD_IDX, getFuncRefWrapperRootTypeIdx } from "./closures/funcref-wrapper-types.js"; // (#3673 round 13) under-application gate
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2 read chokepoint / S3b stable-regime minting)
+import { buildFnctorArrayHofTargetTest } from "./fnctor-array-prototype.js";
 
 /**
  * (#2583) The callback-free, argument-taking array search/predicate methods
@@ -1207,12 +1208,9 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
           ...((isReduceForm ? [{ op: "i32.const", value: arity >= 2 ? 1 : 0 }] : []) satisfies Instr[]), // hasInit
           { op: "call", funcIdx: hofFuncIdx },
         ];
+        const arrayHofTargetTest = buildFnctorArrayHofTargetTest(ctx, anyLocalIdx, ctx.vecBaseTypeIdx, objVecTypeIdx);
         current = [
-          { op: "local.get", index: anyLocalIdx },
-          { op: "ref.test", typeIdx: ctx.vecBaseTypeIdx },
-          { op: "local.get", index: anyLocalIdx },
-          { op: "ref.test", typeIdx: objVecTypeIdx },
-          { op: "i32.or" },
+          ...arrayHofTargetTest,
           {
             op: "if",
             blockType: { kind: "val", type: { kind: "externref" } },

--- a/src/codegen/fnctor-array-prototype.ts
+++ b/src/codegen/fnctor-array-prototype.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Standalone Array-prototype provenance for raw function-constructor instances.
+ *
+ * A reconstructed `new F()` can flow as a raw `__fnctor_F` carrier while the
+ * live value assigned to `F.prototype` is held in a module global. These small
+ * finalize-time builders let the method dispatcher and array-like readers agree
+ * that an Array-valued prototype supplies Array methods and inherited indices.
+ */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+
+/** Build the runtime predicate for a vec, ObjVec, or fnctor with an Array prototype. */
+export function buildFnctorArrayHofTargetTest(
+  ctx: CodegenContext,
+  receiverAnyLocal: number,
+  vecBaseTypeIdx: number,
+  objVecTypeIdx: number,
+): Instr[] {
+  const test: Instr[] = [
+    { op: "local.get", index: receiverAnyLocal },
+    { op: "ref.test", typeIdx: vecBaseTypeIdx },
+    { op: "local.get", index: receiverAnyLocal },
+    { op: "ref.test", typeIdx: objVecTypeIdx },
+    { op: "i32.or" },
+  ];
+  for (const [fnctorName, protoGlobalIdx] of ctx.fnctorPrototypeObject) {
+    const fnctorTypeIdx = ctx.structMap.get(`__fnctor_${fnctorName}`);
+    if (fnctorTypeIdx === undefined) continue;
+    test.push(
+      { op: "local.get", index: receiverAnyLocal },
+      { op: "ref.test", typeIdx: fnctorTypeIdx },
+      { op: "global.get", index: protoGlobalIdx },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: vecBaseTypeIdx },
+      { op: "global.get", index: protoGlobalIdx },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: objVecTypeIdx },
+      { op: "i32.or" },
+      { op: "i32.and" },
+      { op: "i32.or" },
+    );
+  }
+  return test;
+}
+
+/** Resolve `__fnctor_F` to the live `F.prototype` global, if one was materialized. */
+export function fnctorPrototypeGlobalForStruct(ctx: CodegenContext, structName: string): number | undefined {
+  return structName.startsWith("__fnctor_")
+    ? ctx.fnctorPrototypeObject.get(structName.slice("__fnctor_".length))
+    : undefined;
+}
+
+/** Read and box an own closed-struct index, or return the supplied undefined miss. */
+export function closedStructIndexValue(
+  receiverAnyLocal: number,
+  typeIdx: number,
+  fieldIdx: number,
+  box: Instr[] | null,
+  ordinaryMiss: Instr[],
+): Instr[] {
+  return box === null
+    ? ordinaryMiss
+    : [
+        { op: "local.get", index: receiverAnyLocal },
+        { op: "ref.cast", typeIdx },
+        { op: "struct.get", typeIdx, fieldIdx },
+        ...box,
+      ];
+}
+
+/** Continue an indexed Get miss at the live fnctor prototype. */
+export function fnctorGetIndexMiss(
+  protoGlobalIdx: number | undefined,
+  getIdxFuncIdx: number | undefined,
+  indexLocal: number,
+  ordinaryMiss: Instr[],
+): Instr[] {
+  return protoGlobalIdx !== undefined && getIdxFuncIdx !== undefined
+    ? [
+        { op: "global.get", index: protoGlobalIdx },
+        { op: "local.get", index: indexLocal },
+        { op: "call", funcIdx: getIdxFuncIdx },
+      ]
+    : ordinaryMiss;
+}
+
+/** Seed an indexed HasProperty result from the live fnctor prototype. */
+export function fnctorHasIndexSeed(
+  protoGlobalIdx: number | undefined,
+  hasIdxFuncIdx: number | undefined,
+  indexLocal: number,
+): Instr[] {
+  return protoGlobalIdx !== undefined && hasIdxFuncIdx !== undefined
+    ? [
+        { op: "global.get", index: protoGlobalIdx },
+        { op: "local.get", index: indexLocal },
+        { op: "call", funcIdx: hasIdxFuncIdx },
+      ]
+    : [{ op: "i32.const", value: 0 }];
+}

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -104,6 +104,7 @@ import { buildObjectDescriptorHelpers } from "./object-runtime-descriptors.js";
 import { isOpenDescriptorShape } from "./property-descriptor-shape.js";
 import { buildObjectEnumerationHelpers } from "./object-runtime-enumeration.js"; // (#3274 wave-B) enumeration/array-like/object-static helper builders
 import { buildObjectPrototypeHelpers } from "./object-runtime-prototype.js"; // (#3274 wave-B) prototype-chain helper builders
+import * as fnctorArray from "./fnctor-array-prototype.js";
 import { isSyntheticStructName } from "./emit-helpers.js";
 import { orderNamesByInsertion } from "./struct-field-exports.js";
 // (#3265) Proxy dispatch subsystem extracted to a sibling module (subtask of
@@ -7660,6 +7661,7 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
   };
   const seen = new Set<number>();
   const cands: ArrayLikeCand[] = [];
+  const fnctorProtoGlobals = new Map<number, number>();
   for (const [structName, fields] of ctx.structFields) {
     const typeIdx = ctx.structMap.get(structName);
     if (typeIdx === undefined || seen.has(typeIdx)) continue;
@@ -7698,6 +7700,8 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
       numericFields.push({ n, fieldIdx: i, fieldType: f.type });
     }
     seen.add(typeIdx);
+    const protoGlobalIdx = fnctorArray.fnctorPrototypeGlobalForStruct(ctx, structName);
+    if (protoGlobalIdx !== undefined) fnctorProtoGlobals.set(typeIdx, protoGlobalIdx);
     cands.push({ typeIdx, lengthFieldIdx, lengthFieldType: fields[lengthFieldIdx]!.type, numericFields });
   }
   if (cands.length === 0) return;
@@ -7828,11 +7832,12 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
   // ── __extern_get_idx arms (params: 1=idx f64; locals: 2=any) ──
   if (getIdxFn && hasPreamble(getIdxFn)) {
     const arms: Instr[] = [];
+    const getIdxSelfIdx = ctx.funcMap.get("__extern_get_idx");
     for (const cand of cands) {
       const fieldChecks: Instr[] = [];
       for (const nf of cand.numericFields) {
         const box = boxClosedStructFieldToExternref(ctx, nf.fieldType);
-        if (box === null) continue; // unboxable field kind — reads as a miss
+        const ownValue = fnctorArray.closedStructIndexValue(2, cand.typeIdx, nf.fieldIdx, box, idxMiss());
         fieldChecks.push(
           { op: "local.get", index: 1 },
           { op: "f64.const", value: nf.n },
@@ -7842,24 +7847,20 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
           {
             op: "if",
             blockType: { kind: "empty" },
-            then: [
-              { op: "local.get", index: 2 },
-              { op: "ref.cast", typeIdx: cand.typeIdx },
-              { op: "struct.get", typeIdx: cand.typeIdx, fieldIdx: nf.fieldIdx },
-              ...box,
-              { op: "return" },
-            ],
+            then: [...ownValue, { op: "return" }],
           },
         );
       }
-      if (fieldChecks.length === 0) continue; // no indexable fields — fall-through miss is identical
+      const protoGlobalIdx = fnctorProtoGlobals.get(cand.typeIdx);
+      const inheritedMiss = fnctorArray.fnctorGetIndexMiss(protoGlobalIdx, getIdxSelfIdx, 1, idxMiss());
+      if (fieldChecks.length === 0 && protoGlobalIdx === undefined) continue;
       arms.push(
         { op: "local.get", index: 2 },
         { op: "ref.test", typeIdx: cand.typeIdx },
         {
           op: "if",
           blockType: { kind: "empty" },
-          then: [...fieldChecks, ...idxMiss(), { op: "return" }],
+          then: [...fieldChecks, ...inheritedMiss, { op: "return" }],
         },
       );
     }
@@ -7869,11 +7870,13 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
   // ── __extern_has_idx arms (params: 1=idx f64; locals: 2=any) ──
   if (hasIdxFn && hasPreamble(hasIdxFn)) {
     const arms: Instr[] = [];
+    const hasIdxSelfIdx = ctx.funcMap.get("__extern_has_idx");
     for (const cand of cands) {
-      if (cand.numericFields.length === 0) continue; // fall-through 0 is identical
-      const orChain: Instr[] = [{ op: "i32.const", value: 0 }];
+      const protoGlobalIdx = fnctorProtoGlobals.get(cand.typeIdx);
+      if (cand.numericFields.length === 0 && protoGlobalIdx === undefined) continue;
+      const hasChain = fnctorArray.fnctorHasIndexSeed(protoGlobalIdx, hasIdxSelfIdx, 1);
       for (const nf of cand.numericFields) {
-        orChain.push(
+        hasChain.push(
           { op: "local.get", index: 1 },
           { op: "f64.const", value: nf.n },
           { op: "f64.eq" },
@@ -7886,7 +7889,7 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
         {
           op: "if",
           blockType: { kind: "empty" },
-          then: [...orChain, { op: "return" }],
+          then: [...hasChain, { op: "return" }],
         },
       );
     }

--- a/tests/issue-3772-filter-result-array.test.ts
+++ b/tests/issue-3772-filter-result-array.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+type Lane = "host" | "standalone";
+
+async function run(source: string, lane: Lane): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-3772.ts",
+    target: lane === "standalone" ? "standalone" : undefined,
+    skipSemanticDiagnostics: true,
+    deferTopLevelInit: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+
+  if (lane === "standalone") {
+    expect(
+      WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).filter((entry) => entry.module === "env"),
+    ).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    const exports = instance.exports as Record<string, WebAssembly.ExportValue>;
+    (exports.__module_init as (() => void) | undefined)?.();
+    return (exports.test as () => number)();
+  }
+
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    new Uint8Array(result.binary),
+    imports.env,
+    imports.string_constants,
+    imports.string_constants16,
+  );
+  const exports = instance.exports as Record<string, WebAssembly.ExportValue>;
+  imports.setExports?.(exports);
+  (exports.__module_init as (() => void) | undefined)?.();
+  return (exports.test as () => number)();
+}
+
+const inheritedFilterSource = `
+  foo.prototype = new Array(1, 2, 3);
+  function foo() {}
+  var f: any = new foo();
+  f.length = false;
+  function cb() {}
+  var a: any = f.filter(cb);
+
+  export function test(): number {
+    return (Array.isArray(a) ? 10 : 0) + a.length;
+  }
+`;
+
+describe("#3772 — generic filter results retain the Array brand", () => {
+  it.each<Lane>(["host", "standalone"])("%s: inherited filter returns an empty Array", async (lane) => {
+    await expect(run(inheritedFilterSource, lane)).resolves.toBe(10);
+  });
+
+  it("standalone: the same fnctor receiver works through an explicit borrowed filter", async () => {
+    await expect(
+      run(
+        `
+          foo.prototype = new Array(1, 2, 3);
+          function foo() {}
+          var f: any = new foo();
+          f.length = false;
+          var a: any = Array.prototype.filter.call(f, function cb() {});
+
+          export function test(): number {
+            return (Array.isArray(a) ? 10 : 0) + a.length;
+          }
+        `,
+        "standalone",
+      ),
+    ).resolves.toBe(10);
+  });
+
+  it("standalone: direct inherited filter observes a prototype element when length is reduced", async () => {
+    await expect(
+      run(
+        `
+          foo.prototype = new Array(11, 22, 33);
+          function foo() {}
+          var f: any = new foo();
+          f.length = 1;
+          var a: any = f.filter(function cb() { return true; });
+
+          export function test(): number {
+            return (Array.isArray(a) ? 100 : 0) + a.length * 10 + a[0];
+          }
+        `,
+        "standalone",
+      ),
+    ).resolves.toBe(121);
+  });
+
+  it("standalone: the explicit borrowed-filter result is also branded as an Array", async () => {
+    await expect(
+      run(
+        `
+          export function test(): number {
+            const receiver: any = { 0: 1, 1: 2, length: 2 };
+            const result: any = Array.prototype.filter.call(receiver, (value: number) => value > 0);
+            return Array.isArray(result) ? 1 : 0;
+          }
+        `,
+        "standalone",
+      ),
+    ).resolves.toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- recognize raw function-constructor instances whose live prototype is an Array as native Array HOF receivers
- keep the original receiver so own `length` shadowing remains observable
- continue standalone indexed `Get` and `HasProperty` misses through the live function prototype, preserving inherited elements
- keep custom and non-Array prototypes on the ordinary dispatch path

## Root cause

A reconstructed `new F()` can remain a raw `__fnctor_F` carrier while
`F.prototype` is stored separately in a live module global. The fixed-arity
method dispatcher therefore classified `value.filter(callback)` as an
Iterator-helper call instead of an Array HOF call, producing `$LazyIterHelper`
rather than an Array. Array-like indexed readers also stopped at the raw
instance, so inherited numeric elements were invisible.

## Measured Test262 impact

Same-SHA local-vs-local measurement at
`origin/main@f5268a605631aabc5abdf20695e9be2931d0e562`, using
`runTest262File` across all 217
`built-ins/Array/prototype/filter/15.4.4.20*.js` files:

- standalone: **129/217 → 139/217**
- exact transitions: **10 fail → pass, 0 pass → fail**
- host: **166 pass / 48 fail / 3 runner errors** in both arms, with zero status transitions

The standalone gains are `15.4.4.20-10-3.js`,
`15.4.4.20-6-{2..8}.js`, `15.4.4.20-9-c-i-15.js`, and
`15.4.4.20-9-c-i-21.js`.

## Validation

- focused and adjacent Vitest selection: 64 passed / 1 skipped across six files
- `pnpm run typecheck`
- `pnpm run check:oracle-ratchet`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- `pnpm run check:ir-fallbacks`
- dead-export, issue ID/spec/integrity, Test262 vacuity-shape, Biome lint, Prettier, and diff gates

Plan issue: 3772

Agent: Codex
