### PR TITLE
fix(standalone): preserve reified builtin function length (#3424)

### DIFF
--- a/plan/issues/3424-reified-builtin-meta-reflective-read.md
+++ b/plan/issues/3424-reified-builtin-meta-reflective-read.md
@@ -1,10 +1,11 @@
 ---
 id: 3424
 title: "Reified builtin-value `.name`/`.length` reflective reads mis-dispatch when statics share a wrapper signature"
-status: backlog
-sprint: Backlog
+status: in-progress
+sprint: current
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-28
+assignee: ttraenkler/codex-es5-regexp-meta-canonicalization
 priority: medium
 horizon: m
 feasibility: medium
@@ -13,6 +14,8 @@ area: codegen
 language_feature: builtins
 goal: standalone-mode
 related: [2963, 2933, 2896, 2984]
+loc-budget-allow:
+  - src/codegen/property-access-dispatch.ts
 origin: "Surfaced during #2963 Tier 2a (Number.is* first-class values) by opus-dev-b, 2026-07-18"
 ---
 
@@ -97,3 +100,30 @@ values (`property-access.ts`, `builtin-fn-meta.ts` `builtinFnMetaByTypeIdx`)
 — specifically how the exact meta subtype of an `any`-typed reified value
 is recovered at runtime (a chain of `ref.test`s against every registered
 meta subtype, most-derived first, is the sound shape).
+
+## Resolution (2026-07-28)
+
+PR #3646 had already fixed the shared-wrapper `.name` collision by adding an
+immutable exact builtin-function identity to every metadata closure. A fresh
+current-main audit therefore narrowed the remaining gap to `.length`: the
+standalone `any`/`unknown` property-access path bypassed
+`__builtinfn_get_meta` and always called the array-like `__extern_length`
+helper, which returns `0` for closure values.
+
+The standalone-only numeric length reader now:
+
+1. guards the reified value against the common closure-wrapper root;
+2. asks the finalize-filled `__builtinfn_get_meta(value, "length")` helper for
+   the exact identity's spec arity;
+3. preserves the prior `0` result for a plain user closure or a deleted
+   builtin `length`; and
+4. keeps the native-string and generic array/object fallbacks unchanged.
+
+Regression coverage co-extracts six builtins across two shared wrapper
+signatures, including four `[externref] -> i32` values, and asserts every
+`.name`, every `.length`, deletion semantics, and zero host imports.
+
+The fixed RegExp getter matrix remains 30/34. Its four current-main failures
+(`dotAll`/`unicodeSets`/`hasIndices` own-property descriptors and the
+`unicodeSets` boolean value) are distinct descriptor/value roots and are not
+claimed by this metadata canonicalization slice.

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -60,7 +60,7 @@ import {
 import { popBody, pushBody } from "./context/bodies.js";
 import { classMemberFuncKey, resolveMethodOwnerClass } from "./class-member-keys.js";
 import { definedFuncAt } from "./func-space.js";
-import { emitCachedMethodClosureAccess, emitFuncRefAsClosure } from "./closures.js";
+import { emitCachedMethodClosureAccess, emitFuncRefAsClosure, getFuncRefWrapperRootTypeIdx } from "./closures.js";
 import { emitLazyClassObjectGet, emitLazyProtoGet } from "./expressions/extern.js";
 import { emitLazyNativeProtoGet } from "./native-proto.js";
 import { addStringConstantGlobal, localGlobalIdx } from "./registry/imports.js";
@@ -2158,6 +2158,82 @@ export function tryPrototypeMethodAndArityReads(
   return PA_FALLTHROUGH;
 }
 
+/**
+ * (#3424) Emit the standalone numeric `.length` read for an `any`/`unknown`
+ * receiver already compiled to externref. Reified builtin function values are
+ * closure-root subtypes, so consult their exact finalize-filled metadata before
+ * preserving the legacy `__extern_length` fallback for non-closures.
+ */
+function emitStandaloneAnyLength(ctx: CodegenContext, fctx: FunctionContext): ValType {
+  const closureRootIdx = getFuncRefWrapperRootTypeIdx(ctx);
+  ensureLateImport(ctx, "__extern_length", [{ kind: "externref" }], [{ kind: "f64" }]);
+  if (closureRootIdx !== undefined) {
+    ensureLateImport(
+      ctx,
+      "__builtinfn_get_meta",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
+    addStringConstantGlobal(ctx, "length");
+  }
+  flushLateImportShifts(ctx, fctx);
+
+  const lenFn = ctx.funcMap.get("__extern_length");
+  const bfnGetMetaFn = ctx.funcMap.get("__builtinfn_get_meta");
+  const unboxNumberFn = ctx.funcMap.get("__unbox_number");
+  const genericLength = (recvExternLocal: number): Instr[] =>
+    lenFn !== undefined
+      ? [{ op: "local.get", index: recvExternLocal }, { op: "call", funcIdx: lenFn }, { op: "i32.trunc_sat_f64_s" }]
+      : [{ op: "i32.const", value: 0 }];
+  const guardedLength = (recvExternLocal: number): Instr[] => {
+    if (closureRootIdx === undefined || bfnGetMetaFn === undefined || unboxNumberFn === undefined) {
+      return genericLength(recvExternLocal);
+    }
+    const metaLocal = allocLocal(fctx, `__bfn_len_meta_${fctx.locals.length}`, { kind: "externref" });
+    return [
+      { op: "local.get", index: recvExternLocal },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: closureRootIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "local.get", index: recvExternLocal },
+          ...stringConstantExternrefInstrs(ctx, "length"),
+          { op: "call", funcIdx: bfnGetMetaFn },
+          { op: "local.tee", index: metaLocal },
+          { op: "ref.is_null" },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [{ op: "i32.const", value: 0 }],
+            else: [
+              { op: "local.get", index: metaLocal },
+              { op: "call", funcIdx: unboxNumberFn },
+              { op: "i32.trunc_sat_f64_s" },
+            ],
+          },
+        ],
+        else: genericLength(recvExternLocal),
+      },
+    ];
+  };
+
+  if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+    emitGuardedNativeStringLength(ctx, fctx, guardedLength);
+  } else if (closureRootIdx !== undefined && bfnGetMetaFn !== undefined && unboxNumberFn !== undefined) {
+    const recvExternLocal = allocLocal(fctx, `__bfn_len_recv_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: recvExternLocal }, ...guardedLength(recvExternLocal));
+  } else if (lenFn !== undefined) {
+    fctx.body.push({ op: "call", funcIdx: lenFn }, { op: "i32.trunc_sat_f64_s" });
+  } else {
+    fctx.body.push({ op: "drop" }, { op: "i32.const", value: 0 });
+  }
+  if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
+  return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+}
+
 export function tryLengthAndNameReads(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -2693,40 +2769,7 @@ export function tryLengthAndNameReads(
           if (exprResult.kind !== "externref") {
             coerceType(ctx, fctx, exprResult, { kind: "externref" });
           }
-          const lenFn = ensureLateImport(ctx, "__extern_length", [{ kind: "externref" }], [{ kind: "f64" }]);
-          flushLateImportShifts(ctx, fctx);
-          // (#2576, extends #2187) The `any`/unknown value may actually be a
-          // native `$AnyString` (object string-value read, generator yield read,
-          // catch binding, indexed element read). `__extern_length` reads
-          // $ObjVec/array length and returns 0 for a bare string, so guard with
-          // `ref.test $AnyString` first: a string hit reads `$AnyString.len`
-          // (field 0); the miss falls to the existing `__extern_length`
-          // array/$ObjVec reader. Always computes an i32 length, converted to f64
-          // once below in !fast mode. sd-3's `receiverIsNativeStringValType` arm
-          // (above) already handles the bare-identifier-with-string-ref-local
-          // case; this covers the opaque-externref cases it cannot see statically.
-          if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
-            emitGuardedNativeStringLength(ctx, fctx, (recvExternLocal) =>
-              lenFn !== undefined
-                ? [
-                    { op: "local.get", index: recvExternLocal },
-                    { op: "call", funcIdx: lenFn },
-                    { op: "i32.trunc_sat_f64_s" },
-                  ]
-                : [{ op: "i32.const", value: 0 }],
-            );
-            if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
-            return ctx.fast ? { kind: "i32" } : { kind: "f64" };
-          }
-          if (lenFn !== undefined) {
-            fctx.body.push({ op: "call", funcIdx: lenFn });
-            if (ctx.fast) fctx.body.push({ op: "i32.trunc_sat_f64_s" });
-            return ctx.fast ? { kind: "i32" } : { kind: "f64" };
-          }
-          // No helper available — drop and yield 0.
-          fctx.body.push({ op: "drop" });
-          fctx.body.push({ op: ctx.fast ? "i32.const" : "f64.const", value: 0 });
-          return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+          return emitStandaloneAnyLength(ctx, fctx);
         }
       }
     }

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -2174,20 +2174,20 @@ function emitStandaloneAnyLength(ctx: CodegenContext, fctx: FunctionContext): Va
       [{ kind: "externref" }, { kind: "externref" }],
       [{ kind: "externref" }],
     );
-    ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
     addStringConstantGlobal(ctx, "length");
   }
+  const metaLengthToI32 =
+    closureRootIdx === undefined ? undefined : coercionInstrs(ctx, { kind: "externref" }, { kind: "i32" }, fctx);
   flushLateImportShifts(ctx, fctx);
 
   const lenFn = ctx.funcMap.get("__extern_length");
   const bfnGetMetaFn = ctx.funcMap.get("__builtinfn_get_meta");
-  const unboxNumberFn = ctx.funcMap.get("__unbox_number");
   const genericLength = (recvExternLocal: number): Instr[] =>
     lenFn !== undefined
       ? [{ op: "local.get", index: recvExternLocal }, { op: "call", funcIdx: lenFn }, { op: "i32.trunc_sat_f64_s" }]
       : [{ op: "i32.const", value: 0 }];
   const guardedLength = (recvExternLocal: number): Instr[] => {
-    if (closureRootIdx === undefined || bfnGetMetaFn === undefined || unboxNumberFn === undefined) {
+    if (closureRootIdx === undefined || bfnGetMetaFn === undefined || metaLengthToI32 === undefined) {
       return genericLength(recvExternLocal);
     }
     const metaLocal = allocLocal(fctx, `__bfn_len_meta_${fctx.locals.length}`, { kind: "externref" });
@@ -2208,11 +2208,7 @@ function emitStandaloneAnyLength(ctx: CodegenContext, fctx: FunctionContext): Va
             op: "if",
             blockType: { kind: "val", type: { kind: "i32" } },
             then: [{ op: "i32.const", value: 0 }],
-            else: [
-              { op: "local.get", index: metaLocal },
-              { op: "call", funcIdx: unboxNumberFn },
-              { op: "i32.trunc_sat_f64_s" },
-            ],
+            else: [{ op: "local.get", index: metaLocal }, ...metaLengthToI32],
           },
         ],
         else: genericLength(recvExternLocal),
@@ -2222,7 +2218,7 @@ function emitStandaloneAnyLength(ctx: CodegenContext, fctx: FunctionContext): Va
 
   if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
     emitGuardedNativeStringLength(ctx, fctx, guardedLength);
-  } else if (closureRootIdx !== undefined && bfnGetMetaFn !== undefined && unboxNumberFn !== undefined) {
+  } else if (closureRootIdx !== undefined && bfnGetMetaFn !== undefined && metaLengthToI32 !== undefined) {
     const recvExternLocal = allocLocal(fctx, `__bfn_len_recv_${fctx.locals.length}`, { kind: "externref" });
     fctx.body.push({ op: "local.set", index: recvExternLocal }, ...guardedLength(recvExternLocal));
   } else if (lenFn !== undefined) {

--- a/tests/issue-3424-builtin-meta-length.test.ts
+++ b/tests/issue-3424-builtin-meta-length.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+describe("#3424 standalone reified builtin metadata", () => {
+  it("keeps same-signature names exact and reads each spec arity", async () => {
+    const result = await compile(
+      `
+        export function names(): number {
+          const keys: any = Object.keys;
+          const ownKeys: any = Reflect.ownKeys;
+          const isArray: any = Array.isArray;
+          const isFinite: any = Number.isFinite;
+          const isInteger: any = Number.isInteger;
+          const isSafeInteger: any = Number.isSafeInteger;
+          return keys.name === "keys"
+            && ownKeys.name === "ownKeys"
+            && isArray.name === "isArray"
+            && isFinite.name === "isFinite"
+            && isInteger.name === "isInteger"
+            && isSafeInteger.name === "isSafeInteger"
+            ? 1
+            : 0;
+        }
+
+        export function lengths(): number {
+          const keys: any = Object.keys;
+          const ownKeys: any = Reflect.ownKeys;
+          const isArray: any = Array.isArray;
+          const isFinite: any = Number.isFinite;
+          const isInteger: any = Number.isInteger;
+          const isSafeInteger: any = Number.isSafeInteger;
+          return (keys.length === 1 ? 1 : 0)
+            + (ownKeys.length === 1 ? 2 : 0)
+            + (isArray.length === 1 ? 4 : 0)
+            + (isFinite.length === 1 ? 8 : 0)
+            + (isInteger.length === 1 ? 16 : 0)
+            + (isSafeInteger.length === 1 ? 32 : 0);
+        }
+
+        export function deleteLength(): number {
+          const fn: any = Number.isInteger;
+          const before = fn.length;
+          const deleted = delete fn.length;
+          return before === 1 && deleted && fn.length === 0 ? 1 : 0;
+        }
+      `,
+      { fileName: "issue-3424.ts", target: "standalone", skipSemanticDiagnostics: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.imports).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    const exports = instance.exports as Record<string, () => number>;
+    expect(exports.names!()).toBe(1);
+    expect(exports.lengths!()).toBe(63);
+    expect(exports.deleteLength!()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- route standalone `any`/`unknown` `.length` reads on closure-root values through the finalize-filled builtin metadata helper
- preserve the existing native-string, array-like, plain-closure, and deleted-`length` behavior
- add host-free regression coverage for six co-extracted builtins across two shared wrapper signatures

## Root cause

PR #3646 already fixed the original same-signature `.name` collision with exact builtin identity. The remaining `.length` path still bypassed that canonical metadata and called `__extern_length`, whose array-like fallback returns `0` for closure values.

The new guard asks `__builtinfn_get_meta(value, "length")` only for closure-root values, unboxes the exact spec arity when present, and otherwise retains the previous fallback.

## A/B and scope

- current `origin/main`: four audited reified statics kept exact names but each returned `.length === 0`
- this branch: all four return the spec arity `1`; the permanent six-value shared-signature test passes
- the audited RegExp getter matrix remains 30/34; the four existing descriptor/`unicodeSets` value failures are separate roots and deliberately excluded

## Validation

- `pnpm exec vitest run tests/issue-3424-builtin-meta-length.test.ts tests/issue-2896.test.ts tests/issue-1712-reflection-identity.test.ts tests/issue-2885.test.ts --reporter=verbose` — 38/38
- `pnpm run typecheck`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- `pnpm run check:oracle-ratchet`
- `pnpm run check:pushraw`
- `prove-emit-identity` against exact `origin/main@f5268a605631aabc5abdf20695e9be2931d0e562` — IDENTICAL 60/60

Closes #3424
