### PR TITLE
fix(json): resolve pure static stringify space values

### DIFF
--- a/plan/issues/3769-standalone-json-static-space.md
+++ b/plan/issues/3769-standalone-json-static-space.md
@@ -1,0 +1,68 @@
+---
+id: 3769
+title: "standalone JSON.stringify rejects pure boxed and ignored static space values"
+status: done
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+completed: 2026-07-28
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: json
+goal: standalone
+assignee: "ttraenkler/codex-es5-json-space"
+parent: 3176
+related: [2166, 3176]
+---
+
+# #3769 — resolve pure static JSON.stringify space values
+
+## Measured residual
+
+The completed `codex/3176-json-residual` patch is already on `origin/main`
+through merged PR #3661, so it must not be republished. A fresh standalone
+`built-ins/JSON/**` run on `f5268a605631aa` measures 85 pass / 165 total.
+
+The smallest disjoint cohort is three `JSON.stringify` space tests:
+
+- `stringify/space-number-range.js`;
+- `stringify/space-number-float.js`;
+- `stringify/space-wrong-type.js`.
+
+All three are compile errors on the measured base.
+
+## Root cause and fix
+
+The existing native JSON codec already implements indentation, clamping, and
+truncation. Its compile-time `space` resolver only recognizes primitive number
+and string syntax, however, so it treats pure inline Number wrappers and
+spec-ignored non-number/string values as unresolved and routes them to the
+standalone refusal.
+
+Extend that resolver to:
+
+- unwrap pure inline ambient `new Number(<numeric literal>)` values;
+- classify pure Boolean wrappers, `Symbol()`, null/boolean literals, and an
+  empty object literal as the spec's ignored compact-gap case;
+- retain the refusal for dynamic or effectful expressions.
+
+The runtime codec and host path remain unchanged.
+
+## Validation
+
+- exact three Test262 targets flip from compile error to pass in standalone;
+- the complete eight-file `stringify/space-*` cohort moves from 2/8 to 5/8,
+  with no other status change;
+- the complete 165-file standalone JSON cohort moves from 85/165 to 88/165.
+  Excluding the three intended flips, the sorted
+  `file/status/error_category/error_signature` fingerprint remains
+  `f006b6e0257e1183203d3e7c443c58842addf283684fbc4e3dd9076f72d264b7`
+  in both arms;
+- focused host coverage passes. The exact host `space-*` cohort remains 7/8;
+  its pre-existing `space-wrong-type.js` assertion failure is outside this
+  standalone-only route;
+- typecheck, lint/format, oracle ratchet, and structural gates pass.

--- a/src/codegen/json-standalone.ts
+++ b/src/codegen/json-standalone.ts
@@ -11,6 +11,7 @@ import { ts } from "../ts-api.js";
 import type { ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitUndefined } from "./expressions/late-imports.js";
+import { resolvesToAmbientGlobal } from "./expressions/new-super.js";
 import { compileStringLiteral } from "./string-ops.js";
 
 type JsonStaticValue = null | boolean | number | string | JsonStaticValue[] | { [key: string]: JsonStaticValue };
@@ -57,12 +58,20 @@ function staticStringValue(ctx: CodegenContext, expr: ts.Expression, seen = new 
 /**
  * #2166 — resolve a `JSON.stringify` `space` argument (3rd parameter) to a
  * compile-time number or string, so the static stringify path can produce the
- * indented form. Returns `undefined` when the value isn't statically known
- * (caller then refuses / keeps the compact form gate). Per §25.5.2 only the
- * first 10 characters of a string space (or `min(10, floor(n))` for a number)
- * are used; JS's own `JSON.stringify` applies that, so we just forward.
+ * indented form. `null` is the internal "ignore this pure value" result for
+ * statically-known non-Number/non-String shapes; `undefined` means unresolved
+ * and keeps the caller on its refusal path. Per §25.5.2 only the first 10
+ * characters of a string space (or `min(10, floor(n))` for a number) are used.
  */
-export function staticSpaceValue(ctx: CodegenContext, expr: ts.Expression): number | string | undefined {
+export function staticSpaceValue(ctx: CodegenContext, expr: ts.Expression): number | string | null | undefined {
+  return staticSpaceValueInner(ctx, expr, true);
+}
+
+function staticSpaceValueInner(
+  ctx: CodegenContext,
+  expr: ts.Expression,
+  allowInlineNumberWrapper: boolean,
+): number | string | null | undefined {
   const cur = unwrapTransparentExpression(expr);
   if (ts.isNumericLiteral(cur)) return Number(cur.text.replace(/_/g, ""));
   if (ts.isPrefixUnaryExpression(cur) && ts.isNumericLiteral(cur.operand)) {
@@ -71,9 +80,46 @@ export function staticSpaceValue(ctx: CodegenContext, expr: ts.Expression): numb
     if (cur.operator === ts.SyntaxKind.PlusToken) return n;
   }
   if (ts.isStringLiteral(cur) || ts.isNoSubstitutionTemplateLiteral(cur)) return cur.text;
+  if (ts.isNewExpression(cur) && ts.isIdentifier(cur.expression) && resolvesToAmbientGlobal(ctx, cur.expression)) {
+    if (cur.expression.text === "Number" && allowInlineNumberWrapper) {
+      if ((cur.arguments?.length ?? 0) === 0) return 0;
+      if (cur.arguments?.length === 1) {
+        const primitive = staticSpaceValueInner(ctx, cur.arguments[0]!, false);
+        if (typeof primitive === "number") return primitive;
+      }
+      return undefined;
+    }
+    if (
+      cur.expression.text === "Boolean" &&
+      cur.arguments?.length === 1 &&
+      (cur.arguments[0]!.kind === ts.SyntaxKind.TrueKeyword || cur.arguments[0]!.kind === ts.SyntaxKind.FalseKeyword)
+    ) {
+      return null;
+    }
+  }
+  if (
+    ts.isCallExpression(cur) &&
+    ts.isIdentifier(cur.expression) &&
+    cur.expression.text === "Symbol" &&
+    cur.arguments.length === 0 &&
+    resolvesToAmbientGlobal(ctx, cur.expression)
+  ) {
+    return null;
+  }
+  if (
+    cur.kind === ts.SyntaxKind.NullKeyword ||
+    cur.kind === ts.SyntaxKind.TrueKeyword ||
+    cur.kind === ts.SyntaxKind.FalseKeyword ||
+    (ts.isObjectLiteralExpression(cur) && cur.properties.length === 0)
+  ) {
+    return null;
+  }
   if (ts.isIdentifier(cur)) {
     const init = constInitializerForIdentifier(ctx, cur);
-    if (init) return staticSpaceValue(ctx, init);
+    // Primitive const bindings stay foldable. Do not fold a Number wrapper
+    // reached through a binding: its valueOf/toString methods can be mutated
+    // before JSON.stringify observes it.
+    if (init) return staticSpaceValueInner(ctx, init, false);
   }
   return undefined;
 }
@@ -85,7 +131,8 @@ export function staticSpaceValue(ctx: CodegenContext, expr: ts.Expression): numb
  * gap that produces no indentation (the dynamic-graph codec then serialises
  * compactly). The caller passes the gap to `__json_stringify_root_indent`.
  */
-export function jsonGapFromStaticSpace(space: number | string): string {
+export function jsonGapFromStaticSpace(space: number | string | null): string {
+  if (space === null) return "";
   if (typeof space === "number") {
     if (!Number.isFinite(space)) return "";
     const n = Math.min(10, Math.floor(space));
@@ -230,13 +277,13 @@ export function tryEmitJsonStringifyStatic(
   // #2166: resolve a static `space` (number or string) and forward to JS's own
   // JSON.stringify, which applies the §25.5.2 clamping/indentation rules. A
   // dynamic space falls back to the caller's refusal.
-  let space: number | string | undefined;
+  let space: number | string | null | undefined;
   if (spaceArg !== undefined) {
     space = staticSpaceValue(ctx, spaceArg);
     if (space === undefined) return undefined;
   }
 
-  const serialized = space === undefined ? JSON.stringify(value) : JSON.stringify(value, null, space);
+  const serialized = space === undefined || space === null ? JSON.stringify(value) : JSON.stringify(value, null, space);
   if (serialized === undefined) return undefined;
   return compileStringLiteral(ctx, fctx, serialized);
 }

--- a/tests/issue-3769-json-static-space.test.ts
+++ b/tests/issue-3769-json-static-space.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+type Target = "gc" | "standalone";
+
+async function run(source: string, target: Target): Promise<number> {
+  const result = await compile(source, {
+    ...(target === "standalone" ? { target: "standalone" as const } : {}),
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  if (target === "standalone") expect(result.imports).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  return (instance.exports.test as () => number)();
+}
+
+describe.each<Target>(["gc", "standalone"])("#3769 JSON.stringify static space coercion (%s)", (target) => {
+  it("clamps a pure boxed numeric space like its primitive value", async () => {
+    expect(
+      await run(
+        `
+          var value = { a: { b: 1 } };
+          export function test(): number {
+            return JSON.stringify(value, null, new Number(-5)) === JSON.stringify(value, null, 0) &&
+              JSON.stringify(value, null, new Number(100)) === JSON.stringify(value, null, 10) ? 1 : 0;
+          }
+        `,
+        target,
+      ),
+    ).toBe(1);
+  });
+
+  it("truncates a pure boxed fractional space like its primitive value", async () => {
+    expect(
+      await run(
+        `
+          var value = { a: { b: 1 } };
+          export function test(): number {
+            return JSON.stringify(value, null, new Number(5.11111)) === JSON.stringify(value, null, 5) ? 1 : 0;
+          }
+        `,
+        target,
+      ),
+    ).toBe(1);
+  });
+
+  it("ignores pure non-number and non-string space values", async () => {
+    expect(
+      await run(
+        `
+          var value = { a: { b: 1 } };
+          export function test(): number {
+            var compact = JSON.stringify(value);
+            return compact === JSON.stringify(value, null, null) &&
+              compact === JSON.stringify(value, null, true) &&
+              compact === JSON.stringify(value, null, new Boolean(false)) &&
+              compact === JSON.stringify(value, null, Symbol()) &&
+              compact === JSON.stringify(value, null, {}) ? 1 : 0;
+          }
+        `,
+        target,
+      ),
+    ).toBe(1);
+  });
+});
+
+it("keeps a bound mutable Number wrapper on the dynamic refusal path", async () => {
+  const result = await compile(
+    `
+      var value = { a: 1 };
+      const space = new Number(1);
+      space.valueOf = function () { return 4; };
+      export function test(): number {
+        return JSON.stringify(value, null, space).length;
+      }
+    `,
+    { target: "standalone", skipSemanticDiagnostics: true },
+  );
+  expect(result.success).toBe(false);
+  expect(result.errors.some((error) => error.message.includes("#1599"))).toBe(true);
+});


### PR DESCRIPTION
## Summary

- fold pure inline ambient `Number` wrappers for standalone `JSON.stringify(..., space)`
- recognize pure non-number/string `space` values as the spec-ignored compact-gap case
- preserve refusal for bound mutable wrappers and other dynamic expressions
- record completed standalone plan issue #3769; the older #3176 residual patch is already on main through merged PR #3661

## Conformance

- full standalone `built-ins/JSON/**`: **85/165 → 88/165**
- exact `stringify/space-*` cohort: **2/8 → 5/8**
- only the three intended targets change status:
  - `space-number-range.js`
  - `space-number-float.js`
  - `space-wrong-type.js`
- residual fingerprint excluding those targets is identical in both arms
- host `space-*` remains **7/8** in both branch and clean-main control; its existing `space-wrong-type.js` assertion failure is outside the standalone route

## Validation

- `pnpm exec vitest run tests/issue-3769-json-static-space.test.ts --reporter=dot` (7/7)
- relevant #2166 regression subset (19/19)
- `pnpm run typecheck`
- Biome + Prettier
- oracle ratchet, LOC/function budgets, IR fallback gate
- issue ID checks against workspace, main, and open PRs

Ready for review.