### PR TITLE
fix(regexp): preserve standalone flag getter booleans

### DIFF
--- a/plan/issues/3770-standalone-regexp-boolean-getter-brand.md
+++ b/plan/issues/3770-standalone-regexp-boolean-getter-brand.md
@@ -1,0 +1,54 @@
+---
+id: 3770
+title: "Standalone RegExp flag getters lose the boolean value brand"
+status: in-review
+assignee: ttraenkler/codex-es5-regexp-boolean-getters
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+priority: high
+horizon: m
+feasibility: easy
+task_type: bugfix
+area: standalone, regexp, test262
+language_feature: regexp
+goal: es5-conformance
+related: [1914, 2016, 2030, 2175, 3424]
+---
+
+# #3770 — standalone RegExp flag getters lose the boolean value brand
+
+## Problem
+
+The standalone RegExp reflection path lowers flag getters to an `i32`
+predicate, but reports that value as an unbranded numeric `i32`. Most flag
+properties are declared as booleans by the TypeScript library, which can mask
+the lost runtime brand at a later boxing boundary. `RegExp.prototype.unicodeSets`
+is not declared in the configured library, so `/./.unicodeSets` crosses the
+Test262 assertion boundary as the number `0` instead of the boolean `false`.
+
+## Implementation
+
+Mark the result of the shared RegExp flag-getter lowering as a boolean-valued
+`i32`. This preserves `false` and `true` when the value is boxed for an untyped
+call, without changing the flag bitfield calculation, RegExp descriptors,
+getter brand checks, cross-realm behavior, or UnicodeSets matching semantics.
+
+## Verification
+
+- Same-SHA six-file RegExp `this-val-regexp.js` getter cohort:
+  - host stays 6/6;
+  - standalone improves 5/6 to 6/6;
+  - the only status change is
+    `prototype/unicodeSets/this-val-regexp.js` from fail to pass (+1/-0).
+- The isolated-process eight-file UnicodeSets getter-metadata cohort keeps host
+  at 4/8 and improves standalone from 5/8 to 6/8. The descriptor and cross-realm
+  failures retain their exact baseline signatures, confirming that those
+  separate roots are unchanged.
+- The focused #3770 tests pass 2/2, including both Boolean values crossing an
+  untyped call boundary and the maintained Test262 case.
+- Related RegExp reflection tests pass 19/19 (#1914 and #2876). The #3192 suite
+  remains 5/6 on both revisions because its pre-existing DataView case fails in
+  IR class discovery before reaching RegExp lowering.
+- Typecheck, Prettier, scoped Biome lint, oracle, LOC/function budgets, IR
+  fallback/IR-only/adoption, codegen fallback, and issue-integrity gates pass.

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -3594,7 +3594,7 @@ export function emitRegExpReflectionFieldRead(
   fctx.body.push({ op: "i32.and" });
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "i32.ne" });
-  return { kind: "i32" };
+  return { kind: "i32", boolean: true };
 }
 
 /**

--- a/tests/issue-3770-regexp-boolean-getters.test.ts
+++ b/tests/issue-3770-regexp-boolean-getters.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-3770.js",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.imports).toEqual([]);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#3770 standalone RegExp boolean getters", { timeout: 60_000 }, () => {
+  it("preserves false and true as booleans across an untyped call boundary", async () => {
+    expect(
+      await runStandalone(`
+        function classify(value) {
+          if (value === false) return 0;
+          if (value === true) return 1;
+          if (value === 0) return 2;
+          if (value === 1) return 3;
+          return 4;
+        }
+
+        export function test() {
+          if (classify(/./.unicodeSets) !== 0) return 1;
+          if (classify(/./v.unicodeSets) !== 1) return 2;
+          return 0;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("passes the maintained Test262 UnicodeSets getter case", async () => {
+    const result = await runTest262File(
+      resolve("test262/test/built-ins/RegExp/prototype/unicodeSets/this-val-regexp.js"),
+      "built-ins/RegExp",
+      45_000,
+      "standalone",
+    );
+    expect(result.status, result.error ?? result.reason).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

- brand the shared standalone RegExp flag-getter i32 result as a JavaScript boolean
- preserve false and true when a getter value crosses an untyped call boundary
- add focused issue #3770 and maintained Test262 coverage

## Same-SHA Test262 A/B

Control and candidate are based on origin/main c5bd4631724afa8476edeb4e5e1d1f30e5f09c93.

- canonical six-file this-val-regexp getter cohort, host: 6/6 -> 6/6
- canonical six-file this-val-regexp getter cohort, standalone: 5/6 -> 6/6
- exact flip: prototype/unicodeSets/this-val-regexp.js fail -> pass
- transition split: +1 pass / -0 pass; no other status or error-signature changes

The isolated-process eight-file UnicodeSets getter-metadata cohort stays 4/8 host and improves 5/8 -> 6/8 standalone. Its descriptor and cross-realm failures retain their exact baseline signatures, so those remain separate roots.

## Verification

- focused #3770: 2/2
- related RegExp reflection #1914 + #2876: 19/19
- typecheck
- oracle, LOC, and function budgets
- IR fallback, IR-only hybrid, IR adoption, and codegen fallback
- Prettier and scoped Biome lint
- issue-ID against-main/open-PR, issue-spec, and issue-integrity gates

The #3192 DataView case remains a baseline-identical IR class-discovery failure and does not reach this RegExp path.