### PR TITLE
fix(bench): force TurboFan on the JS lane (--no-maglev)

### DIFF
--- a/scripts/generate-playground-benchmark-sidebar.mjs
+++ b/scripts/generate-playground-benchmark-sidebar.mjs
@@ -88,7 +88,21 @@ const BENCHMARKS = [
 //                               compile actually completes relative to the
 //                               calling code). NOT what fixes the fatal
 //                               crash below; see `buildWarmJsFactorySource`.
-const JS_WARM_FLAGS = ["--allow-natives-syntax", "--no-concurrent-recompilation"];
+//   --no-maglev                 makes TurboFan the ONLY optimizing tier, so
+//                               `%OptimizeFunctionOnNextCall` cannot settle on
+//                               Maglev (V8's mid-tier) and call it done.
+//                               Maglev defaults OFF on Node 22 but ON on Node
+//                               26, so the same source tiered to TurboFan
+//                               locally and to Maglev on CI — which is why the
+//                               chart's JS baseline read ~5290us there against
+//                               ~374us here, flattering every wasm:js ratio.
+//                               The #3759 tier assertion caught this exactly:
+//                               CI reported status 41 (isFunction, maybeDeopted,
+//                               maglev) with the `optimized` bit CLEAR. A "warm"
+//                               chart should mean peak optimized tier, so pin it
+//                               rather than accept whichever tier the engine's
+//                               defaults happen to pick this release.
+const JS_WARM_FLAGS = ["--allow-natives-syntax", "--no-concurrent-recompilation", "--no-maglev"];
 
 // V8 startup flag that skips Liftoff (the single-pass Wasm baseline
 // compiler) entirely and compiles straight to TurboFan. This is the Wasm-side


### PR DESCRIPTION
## Description

#3759's tier assertion fired on its **very first CI run** and named the cause exactly:

```
expected 'bench_fib' to stay on V8's optimizing tier for the whole measurement,
but status was 41 (maglev) before and 41 (maglev) after the measured rounds.
```

Status `41` = `isFunction | maybeDeopted | maglev`, with the `optimized` bit **clear**. So on CI, `%OptimizeFunctionOnNextCall` was tiering up to **Maglev** — V8's mid-tier optimizing compiler — not TurboFan.

### Root cause: a per-release default, not our code

Maglev is **off** by default on Node 22 (this sandbox: `--maglev … default: --no-maglev`) and **on** by default on Node 26 (CI). Identical source therefore reached TurboFan locally and only Maglev on CI — which is why the chart's JS baseline read **~5290 µs** there against **~374 µs** here, inflating the JS side and flattering every wasm:js ratio on the landing page.

This also **corrects the guess in #3759's own description**: the CI number was not a function oscillating between tiers, it was steadily on the mid-tier. Maglev simply sits between Sparkplug and TurboFan, which is why it presented as an in-between value with no matching pinned tier.

## The fix

Adds `--no-maglev` so TurboFan is the only optimizing tier available and the intrinsic cannot settle for Maglev. A "warm" chart should mean *peak* optimized tier — pin it rather than inherit whichever tier the engine's defaults pick this release, which is the same lesson as the `--always-turbofan` removal earlier in this chain.

The assertion itself is **unchanged**. It correctly rejected Maglev and is what caught this; weakening it to accept Maglev would have re-hidden the bug.

## Test plan

- All four benchmarks report `jsOptStatus: "81 (optimized,turbofan)"` with the flag added.
- Timings unchanged where TurboFan was already reached (~367 µs vs ~364 µs on `loop.ts`), confirming the flag costs nothing locally.
- `npx biome lint scripts --diagnostic-level=error` — clean.

## Note

The failing run meant the auto-commit step never ran, so the committed `playground-benchmark-sidebar.json` still holds the old, Maglev-derived numbers. That's the right outcome — stale beats wrong — and it refreshes once this lands.

## CLA

Internal/org-member PR — CLA check is skipped automatically.

- [ ] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_