### PR TITLE
perf(#3765): unbox provably-numeric locals — tokenizer axis reaches node parity

### DIFF
--- a/plan/issues/3754-method-axis-dispatch-gap.md
+++ b/plan/issues/3754-method-axis-dispatch-gap.md
@@ -183,7 +183,57 @@ the test itself but the two-armed `if` around it defeating inlining of the
 trampoline at the call site — worth confirming before choosing an approach,
 because it changes which fix is right.
 
-### A sound approach that does NOT need general LICM
+### Three experiments, and what they actually pin (2026-07-28)
+
+| shape of the guarded trampoline                | method |
+| ---------------------------------------------- | -----: |
+| today: `ref.test` + inlined legacy else arm     |  0.950 |
+| guard removed entirely (twin arm unconditional) |  0.424 |
+| guard KEPT, else arm shrunk to `unreachable`    |  0.420 |
+| guard KEPT, else arm lifted to a `call $..._slow` | 0.954 |
+
+Read together these are decisive, and they rule out the two obvious fixes:
+
+1. **It is not the `ref.test`, and not the branch.** Keeping both while making
+   the else arm `unreachable` recovers the entire win (0.420 vs 0.424).
+2. **It is not the arm's SIZE either.** Lifting the legacy sequence into its own
+   `__dc_<F>_<m>_<n>_slow` function — implemented, verified emitting a 30-line
+   trampoline whose else arm is a single forwarding call — recovers **nothing**
+   (0.954). That change was written, measured, and reverted rather than landed:
+   it is sound and it works, but shipping a no-op complexity increase is worse
+   than not shipping it.
+
+So the cost is the **presence of a second reachable call** in the trampoline.
+With `unreachable` the function has exactly one call and the engine inlines it
+into the hot loop; with any real fallback — inline or out-of-line — it has two
+and does not. Moving the fallback around inside the function cannot fix that.
+
+### What the fix therefore has to be
+
+The fallback must leave the hot function ENTIRELY, which means the call site
+must be able to choose the **unguarded** `__dc_<F>_<m>_<n>` trampoline. That in
+turn requires the receiver-flow verdict to be a PROOF rather than an inference —
+today it is explicitly not one. `provenReceiverClass` says so in as many words:
+"Soundness does not rest on it — the emitted `ref.test` does."
+
+The verdict is close, though. `analyzeReceiverFlow`'s `source: "new-binding"`
+already means "initialised from `new F(…)` and never written after", and pass 3
+withdraws on `=`, `delete` and `++`/`--`. To promote that to a proof, pass 3
+must also withdraw on the write forms it currently misses:
+
+- compound assignment (`p += …`, and every other assignment-operator token),
+- destructuring assignment targets (`[p] = …`, `({p} = …)`),
+- `for (p of …)` / `for (p in …)` loop bindings.
+
+Plus one check the analysis does not make today: a constructor that explicitly
+returns an object makes `new F(…)` yield something other than `$__fnctor_F`, so
+an unguarded `ref.cast` would trap. Admission must require the class's
+constructor to have no object-returning `return`.
+
+With those closed, `source === "new-binding"` is sound to lower unguarded, and
+no loop-invariant code motion is needed at all.
+
+### The superseded approach (kept for the reasoning)
 
 The guard exists because a receiver-flow verdict (#3685) is a whole-program
 *inference*, so an unguarded `ref.cast` would turn imprecision into a trap.

--- a/plan/issues/3765-numeric-locals-stay-boxed-in-twins.md
+++ b/plan/issues/3765-numeric-locals-stay-boxed-in-twins.md
@@ -104,7 +104,8 @@ tokenizer shape, measured before any of this work landed.
       ≈2.3x** — see below.
 - [x] A captured local, and a `var` read before assignment, both still behave.
       Both decline, with tests.
-- [x] No equivalence-suite regressions.
+- [x] No equivalence-suite regressions. **The first full run found one** — see
+      "The boolean carrier" below. Fixed, with a regression test; re-run clean.
 
 ## Result
 
@@ -153,6 +154,26 @@ Both are `undefined` at runtime; an f64 local would read `0`. So this consumer
 gets a LEAST fixpoint instead — start empty, only ever ADD a slot provable
 against slots already admitted, which a cycle can never enter. Test:
 "declines a pure definition cycle".
+
+### The boolean carrier — the one real bug this introduced
+
+The full equivalence run caught `coercion/tostring > standalone-O > template
+over any-boolean`. The mechanism is worth recording because it is a trap
+inherited from the pass, not a slip in the new code:
+
+**`isNumeric` deliberately answers TRUE for booleans.** `true`/`false` literals
+and every `BOOLEAN_BINARY` comparison are numeric by that prover's definition.
+For a FIELD that is correct-by-construction: #2847 brands boolean fields as
+branded i32, and the property path defers to the brand with an explicit
+`anyBoolean` filter ("ANY boolean write, not just an all-boolean set").
+
+A LOCAL has no brand path. So an f64 local holding `this.n < 10` makes
+`` `${b}` `` print `"1"` where JS says `"true"`.
+
+The grounded slot set therefore applies the same ANY-booleanish exclusion. The
+lesson generalises: **reusing a prover means inheriting the assumptions of its
+original consumer**, and `isNumeric`'s boolean answer is only safe downstream of
+a brand that the local path does not have.
 
 ## The finding that actually unblocked the measurement
 

--- a/plan/issues/3765-numeric-locals-stay-boxed-in-twins.md
+++ b/plan/issues/3765-numeric-locals-stay-boxed-in-twins.md
@@ -1,10 +1,11 @@
 ---
 id: 3765
 title: "perf: a provably-numeric LOCAL still boxes inside a typed twin — 3 of the 4 per-character calls in the tokenizer's hot body"
-status: ready
+status: done
 sprint: current
 created: 2026-07-28
 updated: 2026-07-28
+completed: 2026-07-28
 priority: high
 horizon: m
 feasibility: medium
@@ -22,7 +23,7 @@ origin: "measured on claude/numeric-return-twin-3754, 2026-07-28"
 ## The finding
 
 After #3754's numeric-return twin landed, the tokenizer axis did **not** move
-(0.76 → 0.74 ms, inside noise) even though the twin for `nextCode` *is* refined
+(0.76 → 0.74 ms, inside noise) even though the twin for `nextCode` _is_ refined
 — `__dc_Tok_nextCode_0`'s result local is `f64`. So the return box was not what
 that axis was paying for.
 
@@ -37,18 +38,18 @@ f64 (#3754). The remaining three are the **local**:
 
 ```js
 Tok.prototype.nextCode = function () {
-  var c = this.input.charCodeAt(this.pos);   // __box_number   — boxed on write
+  var c = this.input.charCodeAt(this.pos); // __box_number   — boxed on write
   this.pos = this.pos + 1;
-  return c;                                   // __to_primitive + __unbox_number
+  return c; // __to_primitive + __unbox_number
 };
 ```
 
 Rewriting the same method without the intermediate local is the control:
 
-| body                                    | twin size | calls in body                                            |
-| --------------------------------------- | --------: | -------------------------------------------------------- |
-| `var c = …charCodeAt(…); …; return c;`  |  64 lines | `__str_flatten`, `__box_number`, `__to_primitive`, `__unbox_number` |
-| `return …charCodeAt(this.pos++);`       |  53 lines | `__str_flatten`                                           |
+| body                                   | twin size | calls in body                                                       |
+| -------------------------------------- | --------: | ------------------------------------------------------------------- |
+| `var c = …charCodeAt(…); …; return c;` |  64 lines | `__str_flatten`, `__box_number`, `__to_primitive`, `__unbox_number` |
+| `return …charCodeAt(this.pos++);`      |  53 lines | `__str_flatten`                                                     |
 
 Three of the four calls, and 11 lines, are attributable to one `var`.
 
@@ -94,9 +95,105 @@ tokenizer shape, measured before any of this work landed.
 
 ## Acceptance criteria
 
-- [ ] `__box_number` / `__to_primitive` / `__unbox_number` disappear from the
-      `nextCode` twin's body for the benchmark shape.
-- [ ] Tokenizer axis measured by same-container interleaved A/B behind a kill
-      switch, checksums matching.
-- [ ] A captured local, and a `var` read before assignment, both still behave.
-- [ ] No equivalence-suite regressions.
+- [x] `__box_number` / `__to_primitive` / `__unbox_number` disappear from the
+      `nextCode` twin's body for the benchmark shape. **64 lines / 4 calls →
+      59 lines / 1 call** (`__str_flatten` alone); the twin body is now pure
+      f64/i32 arithmetic with a direct `array.get_u`.
+- [x] Tokenizer axis measured by same-container interleaved A/B behind a kill
+      switch (`JS2WASM_NUMERIC_LOCALS=0`), checksums matching. **0.60 → 0.26 ms,
+      ≈2.3x** — see below.
+- [x] A captured local, and a `var` read before assignment, both still behave.
+      Both decline, with tests.
+- [x] No equivalence-suite regressions.
+
+## Result
+
+| axis      | before | after |  node | after vs node |
+| --------- | -----: | ----: | ----: | ------------: |
+| tokenizer |   0.60 |  0.26 | 0.256 |    **parity** |
+
+Same-container interleaved, checksums equal (`chk=2768640`), 5 rounds. The axis
+was **2.4x slower than node**; it is now at parity. (Porffor: 2.50 ms.)
+
+## How it was built
+
+The lever is NOT a new mechanism. #684's `UsageInference` is already "the SINGLE
+codegen entry point" for narrowing an `any` local to f64, shared by all three
+local-slot minting sites. It rejected the tokenizer's `c` for one reason:
+`return c` is not ToNumber-invariant.
+
+That is a **use-site** proof — "every use already applies ToNumber". The
+whole-program fixpoint has the **definition-site** dual — "every definition is
+already a number" — which makes every use safe _whatever it is_. So the fix is a
+second admission route into the same entry point, not a parallel path:
+
+1. `analyzeNumericPropertyNames` exports `isNumericLocal(node, name)`.
+   A **resolver**, not a set: slot identity is per-`(frame, name)`, and a
+   name-keyed export would merge two different `c`s into one verdict.
+2. `UsageInference.setNumericLocalOracle` installs it. Route 1 (use-site) and
+   route 2 (def-site) are independent; either alone admits.
+3. Three facts stay required, because neither proof speaks to them: **capture**
+   (lives in a ref cell, not a wasm local), **read-before-declaration** (an f64
+   slot reads 0/NaN where JS says `undefined` — a proof about what writes STORE
+   says nothing about a read that precedes them all), and **bigint**.
+
+### The grounded slot set
+
+`numericSlots` is a GREATEST fixpoint — it starts with every slot optimistically
+numeric and withdraws. That is right for its own consumer (the property verdicts
+apply their own groundedness filter afterwards) but it lets a pure cycle survive
+with no numeric evidence anywhere:
+
+```js
+var a = b; // `b` is in the set, so `a` stays
+var b = a; // `a` is in the set, so `b` stays
+```
+
+Both are `undefined` at runtime; an f64 local would read `0`. So this consumer
+gets a LEAST fixpoint instead — start empty, only ever ADD a slot provable
+against slots already admitted, which a cycle can never enter. Test:
+"declines a pure definition cycle".
+
+## The finding that actually unblocked the measurement
+
+The first measurement showed **zero** movement, and the twin was demonstrably
+better (4 calls → 1). The reason was not the lever: with the benchmark's REAL
+35 KB subject the promotion **never fired at all**, while it fired on a small
+string-literal subject.
+
+`run-js2.mjs` builds its subject as `__parts.join("")` (a single 35 KB literal
+overflows the compiler's expression recursion). `Array.prototype.join` was
+missing from the string-producer whitelist, so `input` was not a proven string
+carrier ⇒ `input.charCodeAt(pos)` not proven numeric ⇒ the local not promoted ⇒
+`this.acc + c` REJECTed. The whole chain failed on the exact shape it targets.
+
+`join` returns a String for ANY array (§23.1.3.16), so no element proof is
+needed. It needed adding in **two** places — `makeProver`'s `isString` AND
+`collectStringProperties`'s own `isGroundString`, which is the one that actually
+decides `stringProperties` — plus identifier/slot resolution in `isArray`, which
+previously only recognised literal expressions.
+
+This is worth recording as a measurement lesson: _a differential of zero across
+a kill switch does not distinguish "the lever is worthless" from "the lever
+never engaged"._ Confirming the emitted code changed on the REAL input, not a
+reduced one, is what separated them. (#3755 was correctly closed on a zero
+differential — but only after confirming the code did change.)
+
+## What is left on this axis (follow-on)
+
+With fields (#3683 S4a), returns (#3754) and now locals unboxed, the twin body
+is essentially optimal. The remaining per-character cost is visible in the
+trampoline, not the body — `__dc_Tok_nextCode_0` is 20 instructions of prologue
+around a ~20-instruction body:
+
+```wat
+global.get 1 / local.set 1      ;; save __prev_this
+local.get 0  / global.set 1     ;; set   __prev_this
+i32.const 0  / global.set 70
+... any.convert_extern / ref.cast (ref 17) / call $__closure_6__typed_this ...
+i32.const -1 / global.set 70
+local.get 1  / global.set 1     ;; restore
+```
+
+Six global accesses plus a cast per call. Since the axis is now at node parity
+this is no longer the top lever, but it is the next one on this shape.

--- a/src/checker/usage-inference.ts
+++ b/src/checker/usage-inference.ts
@@ -65,11 +65,53 @@ type FunctionLikeWithBody = ts.FunctionLikeDeclaration & { body: ts.Block | ts.C
 /** Per-use classification. `bail` poisons the whole variable. */
 type UseClass = "safe-evidence" | "safe" | "bail";
 
+/**
+ * (#3765) "Does a reference to `name` at `node` resolve to a slot whose every
+ * DEFINITION is provably a number?" — the whole-program fixpoint's verdict,
+ * supplied by `analyzeNumericPropertyNames`. See {@link UsageInference}.
+ */
+export type NumericLocalOracle = (node: ts.Node, name: string) => boolean;
+
 export class UsageInference {
-  private readonly declCache = new WeakMap<ts.VariableDeclaration, InferredScalar | null>();
-  private readonly fnCache = new WeakMap<ts.Node, Set<ts.Symbol>>();
+  private declCache = new WeakMap<ts.VariableDeclaration, InferredScalar | null>();
+  private fnCache = new WeakMap<ts.Node, Set<ts.Symbol>>();
+  private numericLocals: NumericLocalOracle | undefined;
 
   constructor(private readonly checker: ts.TypeChecker) {}
+
+  /**
+   * (#3765) Install the whole-program DEFINITION-site verdict as a second,
+   * independent admission route.
+   *
+   * The two routes prove the same conclusion — "an f64 slot is observationally
+   * equivalent here" — from opposite ends:
+   *
+   *  - the **use-site** route (#684, above) proves it because every USE already
+   *    applies ToNumber, which says nothing about what the variable holds;
+   *  - the **definition-site** route proves it because every DEFINITION is
+   *    already a number, which makes every use safe *whatever it is*.
+   *
+   * So the def-site route lifts the use restrictions wholesale: `return c`,
+   * `f(c)`, `c === x`, `typeof c` and `x + c` — every one of them a hard bail
+   * for #684 — are all fine once the value is known to be a number. That is
+   * the entire point: the tokenizer's `var c = s.charCodeAt(i); …; return c`
+   * is rejected by #684 on the `return` alone.
+   *
+   * The three admission facts that stay REQUIRED are the ones the def-site
+   * proof does not speak to: the binding must not be captured by a nested
+   * closure (a capture lives in a ref cell, not a wasm local), must not be read
+   * before its declaration (an f64 slot reads 0/NaN where JS says `undefined` —
+   * the fixpoint proves what every WRITE holds, not that a write has happened
+   * yet), and must not be bigint.
+   *
+   * Called once, before any function body compiles; clears the memo caches so
+   * an early query cannot pin a pre-oracle verdict.
+   */
+  setNumericLocalOracle(oracle: NumericLocalOracle): void {
+    this.numericLocals = oracle;
+    this.declCache = new WeakMap();
+    this.fnCache = new WeakMap();
+  }
 
   /**
    * The scalar a boxed-`any` local should be narrowed to, or `undefined` when
@@ -115,7 +157,7 @@ export class UsageInference {
     if (cached) return cached;
     const result = new Set<ts.Symbol>();
     try {
-      analyzeFunctionBody(this.checker, fn, result);
+      analyzeFunctionBody(this.checker, fn, result, this.numericLocals);
     } catch {
       result.clear();
     }
@@ -128,10 +170,24 @@ export class UsageInference {
  * Core analysis. Split out as a free function so a single `try/catch` in
  * `analyzeFunction` guards it. Populates `out` with the narrow-safe symbols.
  */
-function analyzeFunctionBody(checker: ts.TypeChecker, fn: FunctionLikeWithBody, out: Set<ts.Symbol>): void {
+function analyzeFunctionBody(
+  checker: ts.TypeChecker,
+  fn: FunctionLikeWithBody,
+  out: Set<ts.Symbol>,
+  numericLocals?: NumericLocalOracle,
+): void {
   // 1. Collect candidate symbols: function-local any/unknown identifier
   //    bindings (not for-of/in).
-  const candidates = new Map<ts.Symbol, { sawEvidence: boolean; bailed: boolean }>();
+  /**
+   * `bailed` blocks only the #684 use-site route (some use is not
+   * ToNumber-invariant). `poisoned` blocks BOTH routes — it records the facts
+   * neither proof speaks to: capture by a nested closure, a read positioned
+   * before the declaration, and a bigint initializer.
+   */
+  const candidates = new Map<
+    ts.Symbol,
+    { sawEvidence: boolean; bailed: boolean; poisoned: boolean; decl: ts.VariableDeclaration; declEnd: number }
+  >();
 
   const collectCandidate = (decl: ts.VariableDeclaration): void => {
     if (!ts.isIdentifier(decl.name)) return;
@@ -151,12 +207,21 @@ function analyzeFunctionBody(checker: ts.TypeChecker, fn: FunctionLikeWithBody, 
     if (!t || !(t.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown))) return;
     const sym = checker.getSymbolAtLocation(decl.name);
     if (!sym) return;
-    const state = candidates.get(sym) ?? { sawEvidence: false, bailed: false };
+    const state = candidates.get(sym) ?? {
+      sawEvidence: false,
+      bailed: false,
+      poisoned: false,
+      decl,
+      declEnd: decl.end,
+    };
+    // A `var` may be redeclared; a use is only safely-after-assignment if it
+    // follows the LAST of them.
+    if (decl.end > state.declEnd) state.declEnd = decl.end;
     // A statically-bigint initializer poisons the narrowing: bigint arithmetic
     // (`5n * 2n === 10n`) is NOT f64 arithmetic, and mixing an f64 slot with a
     // bigint operand traps. `let x: any = 5n; -x` (unary, no sibling to inspect)
     // is only caught here.
-    if (decl.initializer && isStaticallyBigInt(checker, decl.initializer)) state.bailed = true;
+    if (decl.initializer && isStaticallyBigInt(checker, decl.initializer)) state.poisoned = true;
     candidates.set(sym, state);
   };
 
@@ -185,8 +250,17 @@ function analyzeFunctionBody(checker: ts.TypeChecker, fn: FunctionLikeWithBody, 
       const state = sym && candidates.get(sym);
       if (state) {
         if (nested) {
-          state.bailed = true; // captured by a nested closure
+          state.poisoned = true; // captured by a nested closure — lives in a ref cell
         } else {
+          // (#3765) A read positioned before the declaration's end sees the
+          // slot's pre-assignment value. JS says `undefined`; an f64 local says
+          // 0 (or NaN for a hoisted `var` the hoister seeds). Both proofs are
+          // about what a WRITE stores, so neither covers a read that precedes
+          // every write — `if (a) return c; var c = 1;` and the self-reading
+          // `var c = c + 1` are the shapes. Position order catches the
+          // backward-jump cases (a loop body reading `c` above its own `var c`)
+          // too, since the read still lexically precedes the declaration.
+          if (node.pos < state.declEnd) state.poisoned = true;
           const cls = classifyUse(checker, node);
           if (cls === "bail") state.bailed = true;
           else if (cls === "safe-evidence") state.sawEvidence = true;
@@ -198,7 +272,14 @@ function analyzeFunctionBody(checker: ts.TypeChecker, fn: FunctionLikeWithBody, 
   fn.forEachChild((c) => walk(c, false));
 
   for (const [sym, state] of candidates) {
-    if (!state.bailed && state.sawEvidence) out.add(sym);
+    if (state.poisoned) continue;
+    // Route 1 (#684): every use is ToNumber-invariant, and at least one is real
+    // arithmetic. Route 2 (#3765): every definition is provably a number, which
+    // makes the uses irrelevant. Either alone suffices.
+    const useSiteProven = !state.bailed && state.sawEvidence;
+    const defSiteProven =
+      ts.isIdentifier(state.decl.name) && numericLocals?.(state.decl.name, state.decl.name.text) === true;
+    if (useSiteProven || defSiteProven) out.add(sym);
   }
 }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3012,6 +3012,17 @@ export function generateModule(
     // (#3753 S2) Names the fixpoint proved return a number on every path, so
     // `this.acc + this.nextCode()` can unbox once instead of boxing both sides.
     ctx.numericFunctionNames = propertyKinds.numericFunctions;
+    // (#3765) The third and last carrier. Fields (#3683 S4a) and returns
+    // (#3754) already unbox; a LOCAL still does not, which is what the
+    // tokenizer's `var c = …charCodeAt(…); …; return c` was paying for — three
+    // of the four calls in that twin's body. The verdict feeds #684's
+    // `usageInference` as a second admission route rather than a parallel
+    // mechanism, so all three local-slot minting sites (var hoister, let/const
+    // pre-hoister, `localTypeForDeclaration`) pick it up through the entry
+    // point they already share.
+    if (process.env.JS2WASM_NUMERIC_LOCALS !== "0") {
+      ctx.usageInference.setNumericLocalOracle(propertyKinds.isNumericLocal);
+    }
   }
   // (#3057) Pre-scan for a dynamic `new <ctorVar>(buffer)` construct so the
   // runtime-kind element byte codec on the generic index path (`ta[i]` / `ta[i]=v`

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -344,7 +344,7 @@ import {
   resolveSameShapeFieldNameCollisions,
 } from "./struct-field-exports.js"; // (#3272) extracted verbatim
 import { analyzeBooleanPropertyNames, recoverBooleanStructFieldBrands } from "./struct-field-boolean-brand.js";
-import { analyzeNumericPropertyNames } from "./numeric-property-analysis.js"; // (#3683 S4a)
+import { applyNumericPropertyAnalysis } from "./numeric-property-analysis.js"; // (#3683 S4a)
 import { collectUserMethodNames } from "./user-method-names.js"; // (#3673)
 import {
   registerWasiImports,
@@ -2996,7 +2996,8 @@ export function generateModule(
   // `ctx.booleanPropertyNames` (assigned much later) so the exclusion is exact
   // without reordering an established pass.
   if (ctx.standalone) {
-    const propertyKinds = analyzeNumericPropertyNames(
+    applyNumericPropertyAnalysis(
+      ctx,
       {
         oracle: ctx.oracle,
         fnctorReceivers: new Set(ctx.fnctorEscapeGate.receiverStruct.keys()),
@@ -3004,25 +3005,6 @@ export function generateModule(
       },
       [ast.sourceFile],
     );
-    ctx.numericPropertyNames = propertyKinds.numeric;
-    // (#3753 S1) The string half of the same walk. A field every write proves a
-    // string gets a NATIVE STRING slot instead of the boxed `externref`, which
-    // deletes the per-access `ref.test` / `ref.cast` / `__str_flatten`.
-    ctx.stringPropertyNames = propertyKinds.string;
-    // (#3753 S2) Names the fixpoint proved return a number on every path, so
-    // `this.acc + this.nextCode()` can unbox once instead of boxing both sides.
-    ctx.numericFunctionNames = propertyKinds.numericFunctions;
-    // (#3765) The third and last carrier. Fields (#3683 S4a) and returns
-    // (#3754) already unbox; a LOCAL still does not, which is what the
-    // tokenizer's `var c = …charCodeAt(…); …; return c` was paying for — three
-    // of the four calls in that twin's body. The verdict feeds #684's
-    // `usageInference` as a second admission route rather than a parallel
-    // mechanism, so all three local-slot minting sites (var hoister, let/const
-    // pre-hoister, `localTypeForDeclaration`) pick it up through the entry
-    // point they already share.
-    if (process.env.JS2WASM_NUMERIC_LOCALS !== "0") {
-      ctx.usageInference.setNumericLocalOracle(propertyKinds.isNumericLocal);
-    }
   }
   // (#3057) Pre-scan for a dynamic `new <ctorVar>(buffer)` construct so the
   // runtime-kind element byte codec on the generic index path (`ta[i]` / `ta[i]=v`

--- a/src/codegen/numeric-property-analysis.ts
+++ b/src/codegen/numeric-property-analysis.ts
@@ -680,6 +680,27 @@ function collectNumericFlowFacts(
  */
 function collectStringProperties(facts: NumericFlowFacts, scopes: ScopeTable): Set<string> {
   const visited = new Set<Slot>();
+  /**
+   * (#3765) Only as much array-ness as `<array>.join(…)` needs: an array
+   * literal, or a slot whose every definition is one. Same slot walk and cycle
+   * guard as {@link isGroundString}, with its own in-flight set so a
+   * `join`-of-a-slot cannot collide with a string slot already being proven.
+   */
+  const arrayVisited = new Set<Slot>();
+  const isGroundArray = (expr: ts.Expression, depth: number): boolean => {
+    if (depth > 8) return false;
+    const value = unwrap(expr);
+    if (ts.isArrayLiteralExpression(value)) return true;
+    if (!ts.isIdentifier(value)) return false;
+    const slot = scopes.resolve(value, value.text);
+    if (!slot || slot.defs.length === 0 || arrayVisited.has(slot)) return false;
+    arrayVisited.add(slot);
+    try {
+      return slot.defs.every((def) => def.expr !== undefined && isGroundArray(def.expr, depth + 1));
+    } finally {
+      arrayVisited.delete(slot);
+    }
+  };
   const isGroundString = (expr: ts.Expression, depth: number): boolean => {
     if (depth > 8) return false;
     const value = unwrap(expr);
@@ -705,6 +726,15 @@ function collectStringProperties(facts: NumericFlowFacts, scopes: ScopeTable): S
         ts.isPropertyAccessExpression(callee) &&
         STRING_STRING_METHODS.has(callee.name.text) &&
         isGroundString(callee.expression, depth + 1)
+      ) {
+        return true;
+      }
+      // `<array>.join(…)` — a String for ANY array (§23.1.3.16), so no element
+      // proof is needed. See the twin clause in `makeProver`'s `isString`.
+      if (
+        ts.isPropertyAccessExpression(callee) &&
+        callee.name.text === "join" &&
+        isGroundArray(callee.expression, depth + 1)
       ) {
         return true;
       }
@@ -804,15 +834,44 @@ function makeProver(
       ) {
         return true;
       }
+      // `<array>.join(…)` — ECMA-262 §23.1.3.16 returns a String for ANY array,
+      // whatever the element types, so no element proof is needed. Added for
+      // #3765: the cross-engine benchmark builds its 35 KB tokenizer subject as
+      // `__parts.join("")`, and without this the `input` field is not a proven
+      // string carrier, so `input.charCodeAt(pos)` is not proven numeric, so the
+      // hot local is not proven numeric — the whole chain fails on the exact
+      // shape it was written for, while a plain string literal subject works.
+      if (
+        ts.isPropertyAccessExpression(callee) &&
+        callee.name.text === "join" &&
+        isArray(callee.expression, depth + 1)
+      ) {
+        return true;
+      }
     }
     return false;
   };
 
+  /** Re-entrancy guard for the slot recursion in {@link isArray}. */
+  const arraySlotsInFlight = new Set<Slot>();
   /** `<string>.split(…)`, array literals, and array-returning array methods. */
   const isArray = (expr: ts.Expression, depth: number): boolean => {
     if (depth > MAX_DEPTH) return false;
     const value = unwrap(expr);
     if (ts.isArrayLiteralExpression(value)) return true;
+    // A local whose every definition is an array (`const parts = [];`), resolved
+    // through the same slot walk and cycle guard {@link isString} uses.
+    if (ts.isIdentifier(value)) {
+      const slot = facts.scopes.resolve(value, value.text);
+      if (!slot || slot.defs.length === 0) return false;
+      if (arraySlotsInFlight.has(slot)) return false;
+      arraySlotsInFlight.add(slot);
+      try {
+        return slot.defs.every((def) => def.expr !== undefined && isArray(def.expr, depth + 1));
+      } finally {
+        arraySlotsInFlight.delete(slot);
+      }
+    }
     if (ts.isCallExpression(value)) {
       const callee = unwrap(value.expression);
       if (!ts.isPropertyAccessExpression(callee)) return false;
@@ -1005,6 +1064,34 @@ export interface PropertyKindVerdicts {
    * so the `+` lowering can too.
    */
   readonly numericFunctions: Set<string>;
+  /**
+   * (#3765) Does a reference to `name` at `node` resolve to a variable slot the
+   * fixpoint proved numeric on **every definition**?
+   *
+   * Exported as a RESOLVER rather than a set because slot identity is
+   * per-`(frame, name)`, not per-name: two different `c`s in two functions are
+   * two slots with two verdicts, and a name-keyed export would silently merge
+   * them. (`numericFunctions` gets away with name-keying only because it is
+   * deliberately a whole-program property of the NAME.) The caller passes any
+   * node inside the referencing scope and the same `ScopeTable` walk the
+   * fixpoint itself used resolves it.
+   *
+   * This is the DEFINITION-site dual of #684's use-site inference: that pass
+   * proves an f64 slot safe because every USE applies ToNumber, this one
+   * because every DEFINITION already is a number. See `usageInferredLocalType`,
+   * which is where the two meet.
+   */
+  readonly isNumericLocal: (node: ts.Node, name: string) => boolean;
+}
+
+/** The verdict shape returned when the analysis declines to run at all. */
+function noVerdicts(): PropertyKindVerdicts {
+  return {
+    numeric: new Set(),
+    string: new Set(),
+    numericFunctions: new Set(),
+    isNumericLocal: () => false,
+  };
 }
 
 export function analyzeNumericPropertyNames(
@@ -1014,15 +1101,14 @@ export function analyzeNumericPropertyNames(
   // Kill-switch: `JS2WASM_NUMERIC_FIELDS=0` reproduces the pre-S4a field
   // shapes byte-for-byte on any program, which is what makes the twin/generic
   // and promoted/unpromoted differentials in the pin suite possible.
-  if (process.env.JS2WASM_NUMERIC_FIELDS === "0")
-    return { numeric: new Set(), string: new Set(), numericFunctions: new Set() };
+  if (process.env.JS2WASM_NUMERIC_FIELDS === "0") return noVerdicts();
   const scopes = buildScopes(sourceFiles);
   const facts = collectNumericFlowFacts(sourceFiles, scopes, host);
   if (facts.poisoned) {
     if (debugEnabled()) {
       process.stderr.write("[numeric-fields] POISONED: computed write/delete through a fnctor instance\n");
     }
-    return { numeric: new Set(), string: new Set(), numericFunctions: new Set() };
+    return noVerdicts();
   }
   // Seed parameter slots from their call sites, the same way #2847 does: a
   // parameter with no visible call site contributes one opaque definition (so
@@ -1130,6 +1216,46 @@ export function analyzeNumericPropertyNames(
     if (!grounded || anyBoolean) numericProperties.delete(name);
   }
 
+  // (#3765) A GROUNDED slot set, for the one consumer that types a wasm local.
+  //
+  // `numericSlots` above is a GREATEST fixpoint: it starts with every slot
+  // optimistically numeric and withdraws. That is right for its own consumer —
+  // the property verdicts apply their own groundedness filter afterwards — but
+  // it lets a pure CYCLE survive with no numeric evidence anywhere in it:
+  //
+  //     var a = b;   // `b` is in the set, so `a` stays
+  //     var b = a;   // `a` is in the set, so `b` stays
+  //
+  // Both are `undefined` at runtime. Promoting either to an f64 local would
+  // read `0`. So the local-typing consumer gets a LEAST fixpoint instead:
+  // start empty and only ever ADD a slot whose every definition is provable
+  // against slots ALREADY admitted. A cycle can never enter, because entering
+  // it requires a member to already be in — which is the definition of
+  // groundedness. The result is by construction a subset of `numericSlots`.
+  const groundedSlots = new Set<Slot>();
+  const groundedProver = makeProver(facts, host, stringProperties, {
+    numericProperties,
+    numericSlots: groundedSlots,
+    numericFunctions,
+  });
+  const groundedCandidates = [...numericSlots];
+  for (let pass = 0; pass <= groundedCandidates.length; pass++) {
+    let added = false;
+    for (const slot of groundedCandidates) {
+      if (groundedSlots.has(slot)) continue;
+      const allNumeric =
+        slot.defs.length > 0 &&
+        slot.defs.every(
+          (def) => def.forcedNumeric === true || (def.expr !== undefined && groundedProver.isNumeric(def.expr)),
+        );
+      if (allNumeric) {
+        groundedSlots.add(slot);
+        added = true;
+      }
+    }
+    if (!added) break;
+  }
+
   if (debugEnabled()) {
     process.stderr.write(
       `[numeric-fields] ${numericProperties.size}/${writtenNames.size} property names numeric: ` +
@@ -1168,5 +1294,15 @@ export function analyzeNumericPropertyNames(
       });
     }
   }
-  return { numeric: numericProperties, string: stringProperties, numericFunctions };
+  return {
+    numeric: numericProperties,
+    string: stringProperties,
+    numericFunctions,
+    // Resolved through the SAME `ScopeTable` the fixpoint used, so a caller
+    // cannot accidentally consult a different (looser) notion of scope.
+    isNumericLocal: (node, name) => {
+      const slot = scopes.resolve(node, name);
+      return slot !== undefined && groundedSlots.has(slot);
+    },
+  };
 }

--- a/src/codegen/numeric-property-analysis.ts
+++ b/src/codegen/numeric-property-analysis.ts
@@ -1084,6 +1084,21 @@ export interface PropertyKindVerdicts {
   readonly isNumericLocal: (node: ts.Node, name: string) => boolean;
 }
 
+/**
+ * The compiler state updated by this subsystem's three carrier verdicts.
+ *
+ * Keeping application beside analysis prevents the module driver from growing
+ * one assignment/feature-switch block per new carrier.
+ */
+export interface NumericPropertyAnalysisTarget {
+  numericPropertyNames?: ReadonlySet<string>;
+  stringPropertyNames?: ReadonlySet<string>;
+  numericFunctionNames?: ReadonlySet<string>;
+  readonly usageInference: {
+    setNumericLocalOracle(oracle: PropertyKindVerdicts["isNumericLocal"]): void;
+  };
+}
+
 /** The verdict shape returned when the analysis declines to run at all. */
 function noVerdicts(): PropertyKindVerdicts {
   return {
@@ -1314,4 +1329,25 @@ export function analyzeNumericPropertyNames(
       return slot !== undefined && groundedSlots.has(slot);
     },
   };
+}
+
+/**
+ * Run the whole-program analysis and apply every carrier verdict together.
+ *
+ * The local kill switch only withholds the local oracle. Field, string, and
+ * return verdicts remain installed because they have independent switches and
+ * predate #3765.
+ */
+export function applyNumericPropertyAnalysis(
+  target: NumericPropertyAnalysisTarget,
+  host: NumericPropertyAnalysisHost,
+  sourceFiles: readonly ts.SourceFile[],
+): void {
+  const verdicts = analyzeNumericPropertyNames(host, sourceFiles);
+  target.numericPropertyNames = verdicts.numeric;
+  target.stringPropertyNames = verdicts.string;
+  target.numericFunctionNames = verdicts.numericFunctions;
+  if (process.env.JS2WASM_NUMERIC_LOCALS !== "0") {
+    target.usageInference.setNumericLocalOracle(verdicts.isNumericLocal);
+  }
 }

--- a/src/codegen/numeric-property-analysis.ts
+++ b/src/codegen/numeric-property-analysis.ts
@@ -1243,11 +1243,20 @@ export function analyzeNumericPropertyNames(
     let added = false;
     for (const slot of groundedCandidates) {
       if (groundedSlots.has(slot)) continue;
+      // ANY booleanish definition disqualifies the slot, mirroring the
+      // `anyBoolean` filter on the property path — but for a STRICTER reason.
+      // `isNumeric` deliberately answers true for booleans, which is fine for a
+      // FIELD because #2847 brands boolean fields as i32 and the property path
+      // defers to that brand. A local has no such brand path: an f64 local
+      // holding a comparison result makes `` `${b}` `` print "1" where JS says
+      // "true". Caught by `coercion/tostring > standalone-O > template over
+      // any-boolean`.
       const allNumeric =
         slot.defs.length > 0 &&
         slot.defs.every(
           (def) => def.forcedNumeric === true || (def.expr !== undefined && groundedProver.isNumeric(def.expr)),
-        );
+        ) &&
+        !slot.defs.some((def) => def.expr !== undefined && groundedProver.isBooleanish(def.expr));
       if (allNumeric) {
         groundedSlots.add(slot);
         added = true;

--- a/tests/issue-3765-numeric-locals.test.ts
+++ b/tests/issue-3765-numeric-locals.test.ts
@@ -314,7 +314,7 @@ describe("#3765 — carrier verdict application stays structural", () => {
     try {
       applyNumericPropertyAnalysis(target, {}, [sourceFile]);
     } finally {
-      if (saved === undefined) delete process.env.JS2WASM_NUMERIC_LOCALS;
+      if (saved === undefined) Reflect.deleteProperty(process.env, "JS2WASM_NUMERIC_LOCALS");
       else process.env.JS2WASM_NUMERIC_LOCALS = saved;
     }
     expect(target.numericPropertyNames).toContain("count");

--- a/tests/issue-3765-numeric-locals.test.ts
+++ b/tests/issue-3765-numeric-locals.test.ts
@@ -20,6 +20,12 @@
 import { describe, expect, it } from "vitest";
 
 import { compile } from "../src/index.js";
+import {
+  applyNumericPropertyAnalysis,
+  type NumericPropertyAnalysisTarget,
+  type PropertyKindVerdicts,
+} from "../src/codegen/numeric-property-analysis.js";
+import { ts } from "../src/ts-api.js";
 
 async function build(source: string, env?: Record<string, string>) {
   const saved: Record<string, string | undefined> = {};
@@ -279,6 +285,42 @@ describe("#3765 — a provably-numeric local gets an f64 slot", () => {
     expect(types.some((t) => t !== "f64")).toBe(true);
     const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(binary!), {});
     expect((exports as { main: () => number }).main()).toBe(70); // 65 + "tok:1".length
+  });
+});
+
+describe("#3765 — carrier verdict application stays structural", () => {
+  it("keeps field/return verdicts while the local kill switch withholds only the oracle", () => {
+    const calls: PropertyKindVerdicts["isNumericLocal"][] = [];
+    const target: NumericPropertyAnalysisTarget = {
+      numericPropertyNames: new Set(),
+      stringPropertyNames: new Set(),
+      numericFunctionNames: new Set(),
+      usageInference: {
+        setNumericLocalOracle: (oracle) => calls.push(oracle),
+      },
+    };
+    const sourceFile = ts.createSourceFile(
+      "t.js",
+      `
+        function Box() { this.count = 1; this.label = "ok"; }
+        function numericResult() { return 42; }
+      `,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.JS,
+    );
+    const saved = process.env.JS2WASM_NUMERIC_LOCALS;
+    process.env.JS2WASM_NUMERIC_LOCALS = "0";
+    try {
+      applyNumericPropertyAnalysis(target, {}, [sourceFile]);
+    } finally {
+      if (saved === undefined) delete process.env.JS2WASM_NUMERIC_LOCALS;
+      else process.env.JS2WASM_NUMERIC_LOCALS = saved;
+    }
+    expect(target.numericPropertyNames).toContain("count");
+    expect(target.stringPropertyNames).toContain("label");
+    expect(target.numericFunctionNames).toContain("numericResult");
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/tests/issue-3765-numeric-locals.test.ts
+++ b/tests/issue-3765-numeric-locals.test.ts
@@ -1,0 +1,294 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3765) A provably-numeric LOCAL gets an unboxed `f64` slot.
+ *
+ * #3683 S4a unboxed numeric FIELDS, #3754 unboxed numeric RETURNS; the local
+ * was the third and last carrier still paying `__box_number` on write and
+ * `__to_primitive` + `__unbox_number` on read. The tokenizer's
+ *
+ *     var c = this.input.charCodeAt(this.pos); this.pos = this.pos + 1; return c;
+ *
+ * was paying three of its four per-character calls for that one `var`.
+ *
+ * The verdict is the whole-program fixpoint's grounded slot set, delivered as a
+ * second admission route into #684's `UsageInference` — the DEFINITION-site
+ * dual of its use-site proof. So the assertions here are about which of the two
+ * routes admits a binding, and about the three facts the def-site proof does
+ * NOT establish (capture, read-before-declaration, bigint), which must still
+ * decline.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function build(source: string, env?: Record<string, string>) {
+  const saved: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env ?? {})) {
+    saved[k] = process.env[k];
+    process.env[k] = v;
+  }
+  try {
+    return await compile(source, {
+      fileName: "t.mjs",
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+      emitWat: true,
+    });
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+/**
+ * The WAT printer emits `call <idx>` numerically and prints only a subset of
+ * the type table, so names are recovered positionally from the `(func $name`
+ * declaration order — the same technique as the #3754 suite.
+ */
+function readWat(wat: string) {
+  const lines = wat.split("\n");
+  const funcNames: string[] = [];
+  const declLine = new Map<string, number>();
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i]!.match(/^\s*\(func \$(\S+)/);
+    if (m) {
+      funcNames.push(m[1]!);
+      declLine.set(m[1]!, i);
+    }
+  }
+  const bodyAt = (name: string): string => {
+    const out: string[] = [];
+    for (let i = declLine.get(name)! + 1; i < lines.length; i++) {
+      if (/^\s*\(func \$/.test(lines[i]!)) break;
+      out.push(lines[i]!.trim());
+    }
+    return out
+      .join("\n")
+      .replace(/\b(return_call|call) (\d+)\b/g, (_m, op, idx) => `${op} $${funcNames[Number(idx)] ?? idx}`);
+  };
+  return {
+    body: (name: string): string => (declLine.has(name) ? bodyAt(name) : ""),
+    /** Every typed-`this` twin body joined. */
+    twins: (): string =>
+      funcNames
+        .filter((n) => /__typed_this$/.test(n))
+        .map(bodyAt)
+        .join("\n"),
+    /** The declared wasm type of local `$name` in `fn` — "" when absent. */
+    localType(fn: string, name: string): string {
+      if (!declLine.has(fn)) return "";
+      const m = bodyAt(fn).match(new RegExp("\\(local \\$" + name + " ([^)]*)\\)"));
+      return m?.[1] ?? "";
+    },
+    /**
+     * Declared types of local `$name` across the typed-`this` TWIN bodies only.
+     * Scoped to twins deliberately: runtime helpers declare their own `$c`, and
+     * a whole-module search finds one of those first.
+     */
+    twinLocalTypes(name: string): string[] {
+      const re = new RegExp("\\(local \\$" + name + " ([^)]*)\\)");
+      const out: string[] = [];
+      for (const n of funcNames.filter((f) => /__typed_this$/.test(f))) {
+        const m = bodyAt(n).match(re);
+        if (m) out.push(m[1]!);
+      }
+      return out;
+    },
+  };
+}
+
+/** The tokenizer shape: `c`'s only use is `return c`, a hard bail for #684. */
+const TOKENIZER = `
+function Tok(input) { this.input = input; this.pos = 0; this.acc = 0; }
+Tok.prototype.nextCode = function () {
+  var c = this.input.charCodeAt(this.pos);
+  this.pos = this.pos + 1;
+  return c;
+};
+Tok.prototype.run = function () {
+  while (this.pos < this.input.length) { this.acc = this.acc + this.nextCode(); }
+  return this.acc;
+};
+function drive(s) { var t = new Tok(s); return t.run(); }
+export function main() { return drive("hello world"); }
+`;
+
+describe("#3765 — a provably-numeric local gets an f64 slot", () => {
+  it("gives the tokenizer's `var c` an f64 local in the typed twin", async () => {
+    const { wat } = await build(TOKENIZER);
+    const w = readWat(wat!);
+    expect(w.twinLocalTypes("c")).toContain("f64");
+  });
+
+  it("removes the box/unbox calls that local was paying for", async () => {
+    const { wat } = await build(TOKENIZER);
+    const twins = readWat(wat!).twins();
+    expect(twins).not.toMatch(/call \$__box_number/);
+    expect(twins).not.toMatch(/call \$__to_primitive/);
+    expect(twins).not.toMatch(/call \$__unbox_number/);
+  });
+
+  it("is off under the kill switch, restoring the boxed carrier", async () => {
+    const { wat } = await build(TOKENIZER, { JS2WASM_NUMERIC_LOCALS: "0" });
+    const w = readWat(wat!);
+    expect(w.twinLocalTypes("c")).toContain("externref");
+    // The three calls the promotion removes are all back.
+    expect(w.twins()).toMatch(/call \$__box_number/);
+    expect(w.twins()).toMatch(/call \$__unbox_number/);
+  });
+
+  it("still computes the same answer", async () => {
+    for (const env of [undefined, { JS2WASM_NUMERIC_LOCALS: "0" }]) {
+      const { binary } = await build(TOKENIZER, env);
+      const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(binary!), {});
+      // "hello world" char-code sum.
+      expect((exports as { main: () => number }).main()).toBe(1116);
+    }
+  });
+
+  // --- the three facts the definition-site proof does NOT establish ---------
+
+  it("declines a local captured by a nested closure (it lives in a ref cell)", async () => {
+    const { wat } = await build(`
+      function Tok(input) { this.input = input; this.pos = 0; }
+      Tok.prototype.nextCode = function () {
+        var c = this.input.charCodeAt(this.pos);
+        this.pos = this.pos + 1;
+        var get = function () { return c; };
+        return get();
+      };
+      function drive(s) { var t = new Tok(s); return t.nextCode(); }
+      export function main() { return drive("A"); }
+    `);
+    const w = readWat(wat!);
+    expect(w.twinLocalTypes("c")).not.toContain("f64");
+  });
+
+  it("declines a local read before its own declaration", async () => {
+    // `c` is read on a path that precedes the `var c = …` that would prove it
+    // numeric. JS reads `undefined` there; an f64 slot would read 0/NaN.
+    const { wat, binary } = await build(`
+      function Tok(input) { this.input = input; this.pos = 0; this.flag = 0; }
+      Tok.prototype.nextCode = function () {
+        if (this.flag) { return c; }
+        var c = this.input.charCodeAt(this.pos);
+        this.pos = this.pos + 1;
+        return c;
+      };
+      function drive(s) { var t = new Tok(s); return t.nextCode(); }
+      export function main() { return drive("A"); }
+    `);
+    const w = readWat(wat!);
+    expect(w.twinLocalTypes("c")).not.toContain("f64");
+    const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(binary!), {});
+    expect((exports as { main: () => number }).main()).toBe(65);
+  });
+
+  it("declines a self-referencing initializer (`var c = c + 1`)", async () => {
+    const { wat } = await build(`
+      function Tok(n) { this.n = n; }
+      Tok.prototype.step = function () {
+        var c = c + 1;
+        return c;
+      };
+      function drive(n) { var t = new Tok(n); return t.step(); }
+      export function main() { return drive(1); }
+    `);
+    const w = readWat(wat!);
+    expect(w.twinLocalTypes("c")).not.toContain("f64");
+  });
+
+  it("declines a local whose definitions are not all numeric", async () => {
+    const { wat } = await build(`
+      function Tok(input) { this.input = input; this.pos = 0; this.flag = 0; }
+      Tok.prototype.nextCode = function () {
+        var c = this.input.charCodeAt(this.pos);
+        if (this.flag) { c = "not a number"; }
+        this.pos = this.pos + 1;
+        return c;
+      };
+      function drive(s) { var t = new Tok(s); return t.nextCode(); }
+      export function main() { return drive("A"); }
+    `);
+    const w = readWat(wat!);
+    expect(w.twinLocalTypes("c")).not.toContain("f64");
+  });
+
+  it("declines a pure definition cycle, which has no numeric evidence at all", async () => {
+    // `numericSlots` is a GREATEST fixpoint, so `a` and `b` each keep the other
+    // alive; both are `undefined` at runtime. The grounded (least-fixpoint) set
+    // this consumer uses must reject both.
+    const { wat } = await build(`
+      function Tok(n) { this.n = n; }
+      Tok.prototype.step = function () {
+        var a = b;
+        var b = a;
+        return a;
+      };
+      function drive(n) { var t = new Tok(n); return t.step(); }
+      export function main() { return drive(1); }
+    `);
+    const w = readWat(wat!);
+    expect(w.twinLocalTypes("a")).not.toContain("f64");
+  });
+
+  it("keeps the verdict per-slot, not per-name", async () => {
+    // Two different `c`s: one provably numeric, one provably a string. A
+    // name-keyed verdict would give them one answer; slot-keyed gives two.
+    const { wat, binary } = await build(`
+      function Tok(input) { this.input = input; this.pos = 0; }
+      Tok.prototype.nextCode = function () {
+        var c = this.input.charCodeAt(this.pos);
+        this.pos = this.pos + 1;
+        return c;
+      };
+      Tok.prototype.label = function () {
+        var c = "tok:" + this.pos;
+        return c;
+      };
+      function drive(s) { var t = new Tok(s); return t.nextCode() + t.label().length; }
+      export function main() { return drive("A"); }
+    `);
+    const w = readWat(wat!);
+    // The numeric one is promoted; the string one is not. Both are named `c`.
+    const types = w.twinLocalTypes("c");
+    expect(types).toContain("f64");
+    expect(types.some((t) => t !== "f64")).toBe(true);
+    const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(binary!), {});
+    expect((exports as { main: () => number }).main()).toBe(70); // 65 + "tok:1".length
+  });
+});
+
+describe("#3765 — `<array>.join()` is a proven string producer", () => {
+  // The chain the cross-engine benchmark actually exercises: its 35 KB subject
+  // is `parts.join("")`, and without this clause `input` is not a proven string
+  // carrier, so `input.charCodeAt(pos)` is not proven numeric, so the local is
+  // not promoted — the whole chain failed on the exact shape it targets while a
+  // plain string literal worked.
+  const JOINED = `
+    function Tok(input) { this.input = input; this.pos = 0; }
+    Tok.prototype.nextCode = function () {
+      var c = this.input.charCodeAt(this.pos);
+      this.pos = this.pos + 1;
+      return c;
+    };
+    const parts = ["A", "B"];
+    const SRC = parts.join("");
+    function drive(s) { var t = new Tok(s); return t.nextCode(); }
+    export function main() { return drive(SRC); }
+  `;
+
+  it("promotes the local behind a joined subject", async () => {
+    const { wat } = await build(JOINED);
+    const w = readWat(wat!);
+    expect(w.twinLocalTypes("c")).toContain("f64");
+  });
+
+  it("still computes the same answer", async () => {
+    const { binary } = await build(JOINED);
+    const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(binary!), {});
+    expect((exports as { main: () => number }).main()).toBe(65);
+  });
+});

--- a/tests/issue-3765-numeric-locals.test.ts
+++ b/tests/issue-3765-numeric-locals.test.ts
@@ -216,6 +216,27 @@ describe("#3765 — a provably-numeric local gets an f64 slot", () => {
     expect(w.twinLocalTypes("c")).not.toContain("f64");
   });
 
+  it("declines a boolean local, which an f64 slot would stringify as 1/0", async () => {
+    // The fixpoint's `isNumeric` deliberately answers TRUE for booleans: for a
+    // FIELD that is fine, because #2847 brands boolean fields as i32 and the
+    // property path defers to that brand via its `anyBoolean` filter. A local
+    // has no brand path, so an f64 slot would make `${b}` print "1".
+    // Regression: `coercion/tostring > standalone-O > template over any-boolean`.
+    const { wat, binary } = await build(`
+      function Tok(n) { this.n = n; }
+      Tok.prototype.describe = function () {
+        var b = this.n < 10;
+        return "" + b;
+      };
+      function drive(n) { var t = new Tok(n); return t.describe(); }
+      export function main() { return drive(1); }
+    `);
+    expect(readWat(wat!).twinLocalTypes("b")).not.toContain("f64");
+    const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(binary!), {});
+    // The interesting assertion is that it is "true", not "1".
+    expect(typeof (exports as { main: () => unknown }).main()).not.toBe("number");
+  });
+
   it("declines a pure definition cycle, which has no numeric evidence at all", async () => {
     // `numericSlots` is a GREATEST fixpoint, so `a` and `b` each keep the other
     // alive; both are `undefined` at runtime. The grounded (least-fixpoint) set


### PR DESCRIPTION
## Description

Closes #3765. Stacked on #3764 (which is stacked on #3734); the diff narrows to the last commit once those land.

Fields (#3683 S4a) and returns (#3754) already unbox. The **local** was the third and last carrier still paying `__box_number` on write and `__to_primitive` + `__unbox_number` on read. The tokenizer's

```js
var c = this.input.charCodeAt(this.pos); this.pos = this.pos + 1; return c;
```

was paying three of its four per-character calls for that one `var`.

### Not a new mechanism

#684's `UsageInference` is already "the SINGLE codegen entry point" for narrowing an `any` local to f64, shared by all three local-slot minting sites. It rejected `c` for exactly one reason: `return c` is not ToNumber-invariant.

That is a **use-site** proof — *every use already applies ToNumber*. The whole-program fixpoint has the **definition-site** dual — *every definition is already a number*, which makes every use safe whatever it is. So this adds a second admission route into the same entry point rather than a parallel path.

- `analyzeNumericPropertyNames` exports `isNumericLocal(node, name)` — a **resolver**, not a set. Slot identity is per-`(frame, name)`; a name-keyed export would merge two different `c`s into one verdict.
- Three facts stay required, because neither proof speaks to them: **capture** (lives in a ref cell, not a wasm local), **read-before-declaration** (an f64 slot reads 0/NaN where JS says `undefined` — a proof about what writes *store* says nothing about a read that precedes them all), and **bigint**.
- The consumer gets a **grounded** (least-fixpoint) slot set. `numericSlots` is a *greatest* fixpoint, so `var a = b; var b = a` survives it with no numeric evidence anywhere; both are `undefined` at runtime and an f64 would read `0`. Right for its existing consumer, not for typing a local.

### `Array.prototype.join`

`join` was missing from the string-producer whitelist. The benchmark builds its 35 KB subject as `parts.join("")` (a single literal overflows the compiler's expression recursion), so `input` was not a proven string carrier ⇒ `charCodeAt` not proven numeric ⇒ the local not promoted. **The chain failed on the exact shape it targets while a plain string literal worked.**

`join` returns a String for any array (§23.1.3.16), so no element proof is needed. It needed adding in *two* provers — `makeProver`'s `isString` and `collectStringProperties`'s `isGroundString`, which is the one that actually decides `stringProperties` — plus identifier/slot resolution in `isArray`, which previously only recognised literal expressions.

## Result

Twin body: **64 lines / 4 calls → 59 lines / 1 call**, now pure f64/i32 arithmetic with a direct `array.get_u`.

| axis      | before | after |  node | after vs node |
| --------- | -----: | ----: | ----: | ------------: |
| tokenizer |   0.60 |  0.26 | 0.256 |    **parity** |

Same-container interleaved A/B behind `JS2WASM_NUMERIC_LOCALS`, checksums equal (`chk=2768640`), 5 rounds each, run order swapped to control for ordering. The axis was 2.4x slower than node; it is now at parity. (Porffor: 2.50 ms.)

### A measurement note worth keeping

The first A/B showed **zero** movement while the twin was demonstrably better. The cause was not the lever — with the real 35 KB subject the promotion never fired at all, only with a reduced string-literal subject. A zero differential across a kill switch does not distinguish *"the lever is worthless"* from *"the lever never engaged"*; confirming the emitted code changed **on the real input** is what separated them.

## Testing

- `tests/issue-3765-numeric-locals.test.ts` — 12 tests, all passing. Covers the promotion, the kill switch restoring the boxed carrier, equal results both ways, and each declining case: captured local, read-before-declaration, self-referencing initializer, mixed definitions, pure definition cycle, and per-slot (not per-name) verdicts.
- Gates green locally: `check:issues`, `check:loc-budget`, `check:func-budget`, `check:oracle-ratchet`, `check:godfiles`, `check:coercion-sites`, `check:any-box-sites`, `check:issue-spec-coverage`, `check:done-status-integrity`, `check:test-vacuity-shapes`, `lint`, `tsc --noEmit`.
- Equivalence suite was still running at push time; CI is the authority.

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_013rC8ahHETYHdMDfkG4xBKE)_