### PR TITLE
fix(json): throw on rawJSON Symbol coercion

### DIFF
--- a/plan/issues/3771-standalone-json-rawjson-symbol-tostring.md
+++ b/plan/issues/3771-standalone-json-rawjson-symbol-tostring.md
@@ -1,0 +1,91 @@
+---
+id: 3771
+title: "standalone JSON.rawJSON does not throw TypeError for Symbol text"
+status: done
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+completed: 2026-07-28
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: json
+goal: es5-conformance
+assignee: "ttraenkler/codex-json-rawjson-symbol"
+parent: 3176
+related: [3176, 3769]
+---
+
+# #3771 — JSON.rawJSON Symbol ToString
+
+## Measured residual
+
+Fresh latest-main measurement on `d3bdf7cfc5612e` shows:
+
+- host JSON: 108/165 pass;
+- standalone JSON: 85/165 pass;
+- host `rawJSON/**`: 7/10 pass;
+- standalone `rawJSON/**`: 8/10 pass.
+
+`rawJSON/invalid-JSON-text.js` passes in host mode but fails standalone because
+`JSON.rawJSON(Symbol("123"))` does not throw the `TypeError` required by
+ECMA-262 §25.5.3 step 1 and §7.1.17.
+
+PR #3767 changes only the static `JSON.stringify(..., space)` resolver and does
+not overlap this runtime coercion path. Historical #3176 rawJSON branches carry
+no unmerged Symbol-coercion fix.
+
+## Root cause and fix
+
+The pure-Wasm `__json_rawjson` helper performs its own representation-neutral
+ToString dispatch. Native `$Symbol` carriers currently fall through to the
+generic object string, which is rejected later as invalid JSON. That produces
+the wrong exception class and also misses the coercion boundary.
+
+Recognize `$Symbol` in the runtime ToString dispatch and throw the existing
+in-module `TypeError` before JSON parsing. Keep the guard inside the runtime
+helper so direct Symbols, erased `any` values, and container reads share the
+same behavior.
+
+## Validation
+
+Same-SHA local-v-local A/B against `d3bdf7cfc5612e`:
+
+- exact `rawJSON/invalid-JSON-text.js`: host pass → pass; standalone fail → pass;
+- complete host JSON cohort: 108/165 → 108/165, zero verdict changes;
+- complete standalone JSON cohort: 85/165 → 86/165, with the exact target as
+  the sole status change and zero pass → fail transitions;
+- `rawJSON/**`: host remains 7/10; standalone moves 8/10 → 9/10;
+- excluding the target, standalone status fingerprint
+  `a31606c0c15edda7f21ff0e205264ecb6eabd4c32b6492b652382393be927404`
+  and raw error fingerprint
+  `adb5718a40396e378615b411ed1f868e92b746c7e3dd5b42308ec214b1175856`
+  are identical in both arms;
+- excluding the target, host status fingerprint
+  `80adb41fd2c2489c8fc057d9a6e4d626bd0dc02832c2308343b29d8218f29f74`
+  is identical. Ten already-failing host rows differ only by the optional
+  runner prefix `strict rerun: `; an independent clean-main A/A rerun
+  reproduces that prefix loss. Removing only that verified runner prefix gives
+  the identical detailed fingerprint
+  `5ca46c567b6772a70e11c51119f513876967961a85154f57aafd46d8aad2bf42`.
+
+Focused and structural validation:
+
+- `tests/issue-3771-json-rawjson-symbol.test.ts`: 3/3 pass, including direct,
+  erased-local, erased-array, exact Test262, correct exception identity, and an
+  empty WebAssembly import table;
+- combined #3771/#3176/#2166 JSON run: 89 pass, 1 skip, 1 failure. The only
+  failure (`#2166` replacer returning undefined) reproduces unchanged on clean
+  latest main;
+- typecheck, Biome lint, and Prettier pass;
+- oracle ratchet, coercion-site, LOC, and function budgets pass without
+  allowances;
+- IR fallback and IR-only hybrid identity/readiness gates pass;
+- dead-export, pushRaw, stack-balance, codegen-fallback, AnyValue box-site,
+  speculative-rollback, harness compile-work, IR-adoption, and verdict-oracle
+  gates pass;
+- issue integrity, issue-spec coverage, against-main ID, and against-open-PR ID
+  gates pass; #3771 collides with none of the 20 open PRs adding issue files.

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -57,7 +57,7 @@ import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { reserveReplacerDriver, reserveReviverDriver, reserveToJsonDriver } from "./accessor-driver.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
-
+import { buildRawJsonSymbolToStringGuard, prepareRawJsonSymbolToString } from "./json-rawjson-symbol.js";
 const EQ_HEAP_TYPE = -19; // signed LEB128 → 0x6d → TYPE.eq (for ref.null any/eq)
 
 /**
@@ -2860,7 +2860,7 @@ export function emitJsonRawJson(ctx: CodegenContext): number {
   ensureNativeStringHelpers(ctx);
   const rt = ensureObjectRuntime(ctx);
   emitNativeNumberFormat(ctx, new Set(["number_toString"]));
-  emitWasiErrorConstructor(ctx, "SyntaxError", 1);
+  prepareRawJsonSymbolToString(ctx);
   const parseTextIdx = emitJsonParseText(ctx);
 
   const i32: ValType = { kind: "i32" };
@@ -2910,8 +2910,8 @@ export function emitJsonRawJson(ctx: CodegenContext): number {
     //   $__box_number_struct → number_toString(value)
     //   $__box_boolean_struct→ "true" / "false"
     //   $AnyValue             → tag-dispatch its primitive payload
-    //   else (object/array/symbol/undefined) → "[object Object]", which the
-    //        parser below rejects → SyntaxError (matching §25.5.3).
+    //   $Symbol → TypeError; other unsupported refs → "[object Object]", which
+    //   the parser below rejects → SyntaxError (matching §25.5.3).
     { op: "local.get", index: R_V },
     { op: "ref.is_null" },
     {
@@ -2921,7 +2921,7 @@ export function emitJsonRawJson(ctx: CodegenContext): number {
       else: [
         { op: "local.get", index: R_V },
         { op: "any.convert_extern" },
-        { op: "local.tee", index: R_ANY },
+        ...buildRawJsonSymbolToStringGuard(ctx, R_ANY),
         { op: "ref.test", typeIdx: anyStrTypeIdx },
         {
           op: "if",

--- a/src/codegen/json-rawjson-symbol.ts
+++ b/src/codegen/json-rawjson-symbol.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { ensureSymbolCarrier } from "./symbol-native.js";
+
+const SYMBOL_TO_STRING_ERROR = "Cannot convert a Symbol value to a string";
+
+/**
+ * Register the error and Symbol-carrier dependencies before the rawJSON parser
+ * captures its function/type indices.
+ */
+export function prepareRawJsonSymbolToString(ctx: CodegenContext): void {
+  emitWasiErrorConstructor(ctx, "SyntaxError", 1);
+  emitWasiErrorConstructor(ctx, "TypeError", 1);
+  ensureSymbolCarrier(ctx);
+}
+
+/**
+ * Continue a rawJSON ToString dispatch whose externref has just been converted
+ * to anyref. The returned sequence preserves that value for the next dispatch
+ * arm, but throws the shared in-module TypeError first when it is a $Symbol.
+ */
+export function buildRawJsonSymbolToStringGuard(ctx: CodegenContext, anyLocal: number): Instr[] {
+  addStringConstantGlobal(ctx, SYMBOL_TO_STRING_ERROR);
+  const symbolTypeIdx = ctx.symbolTypeIdx;
+  const typeErrorCtorIdx = ctx.funcMap.get("__new_TypeError")!;
+  const exnTagIdx = ensureExnTag(ctx);
+
+  return [
+    { op: "local.tee", index: anyLocal },
+    { op: "ref.test", typeIdx: symbolTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...stringConstantExternrefInstrs(ctx, SYMBOL_TO_STRING_ERROR),
+        { op: "call", funcIdx: typeErrorCtorIdx },
+        { op: "throw", tagIdx: exnTagIdx },
+        { op: "unreachable" },
+      ],
+    },
+    { op: "local.get", index: anyLocal },
+  ];
+}

--- a/tests/issue-3771-json-rawjson-symbol.test.ts
+++ b/tests/issue-3771-json-rawjson-symbol.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+async function compileStandalone(src: string) {
+  const result = await compile(src, { target: "standalone" });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const module = await WebAssembly.compile(result.binary);
+  expect(WebAssembly.Module.imports(module)).toEqual([]);
+  const instance = await WebAssembly.instantiate(module, {});
+  return instance.exports as Record<string, () => number>;
+}
+
+describe("#3771 JSON.rawJSON Symbol ToString (standalone)", () => {
+  it("throws TypeError for direct and representation-erased Symbol values", async () => {
+    const exports = await compileStandalone(`
+      function catchesTypeError(value: any): number {
+        try {
+          JSON.rawJSON(value);
+          return 0;
+        } catch (error) {
+          return error instanceof TypeError ? 1 : 2;
+        }
+      }
+
+      export function direct(): number {
+        return catchesTypeError(Symbol("123"));
+      }
+
+      export function erasedLocal(): number {
+        const value: any = Symbol("123");
+        return catchesTypeError(value);
+      }
+
+      export function erasedArrayRead(): number {
+        const values: any[] = [Symbol("123")];
+        return catchesTypeError(values[0]);
+      }
+    `);
+
+    expect(exports.direct!()).toBe(1);
+    expect(exports.erasedLocal!()).toBe(1);
+    expect(exports.erasedArrayRead!()).toBe(1);
+  });
+
+  it("keeps non-Symbol validation behavior unchanged", async () => {
+    const exports = await compileStandalone(`
+      function catchesSyntaxError(value: any): number {
+        try {
+          JSON.rawJSON(value);
+          return 0;
+        } catch (error) {
+          return error instanceof SyntaxError ? 1 : 2;
+        }
+      }
+
+      export function undefinedValue(): number {
+        return catchesSyntaxError(undefined);
+      }
+
+      export function objectValue(): number {
+        return catchesSyntaxError({});
+      }
+
+      export function arrayValue(): number {
+        return catchesSyntaxError([]);
+      }
+
+      export function validNumber(): number {
+        return JSON.isRawJSON(JSON.rawJSON(123)) ? 1 : 0;
+      }
+    `);
+
+    expect(exports.undefinedValue!()).toBe(1);
+    expect(exports.objectValue!()).toBe(1);
+    expect(exports.arrayValue!()).toBe(1);
+    expect(exports.validNumber!()).toBe(1);
+  });
+
+  it("passes the exact Test262 regression", async () => {
+    const result = await runTest262File(
+      resolve("test262/test/built-ins/JSON/rawJSON/invalid-JSON-text.js"),
+      "built-ins/JSON",
+      30_000,
+      "standalone",
+    );
+    expect(result.status, result.error).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

- detect native Symbol carriers at the standalone JSON.rawJSON ToString boundary
- throw the existing in-module TypeError before JSON parsing, including for erased any and array-carried values
- keep the oversized JSON codec function at its baseline size by isolating the guard in a small helper
- record completed issue #3771

## Conformance

Latest-main same-SHA local-v-local A/B on d3bdf7cfc5612e:

- full host built-ins/JSON: 108/165 -> 108/165, zero verdict changes
- full standalone built-ins/JSON: 85/165 -> 86/165
- sole standalone change: rawJSON/invalid-JSON-text.js fail -> pass
- rawJSON standalone: 8/10 -> 9/10; host remains 7/10
- zero pass -> fail transitions
- all 164 non-target standalone status and raw-error fingerprints are identical
- host non-target status and canonical-error fingerprints are identical; ten raw diagnostics differ only by the runner optional strict rerun prefix, reproduced by clean-main A/A

## Validation

- issue-3771 focused tests: 3/3
- broader JSON suite: 89 pass, 1 skip, 1 pre-existing #2166 failure reproduced on clean main
- typecheck, lint, and formatting
- oracle and coercion ratchets
- LOC and function budgets without allowances
- IR fallback and IR-only hybrid readiness
- dead-export, pushRaw, stack-balance, codegen-fallback, AnyValue box-site, speculative-rollback, harness-work, IR-adoption, and verdict-oracle gates
- issue integrity, probe coverage, done-status, against-main ID, and against-open-PR ID gates

Ready for review.