### PR TITLE
refactor(ir): own module initializer callables structurally (#3520)

### DIFF
--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -154,7 +154,13 @@ async, adoption-owner, and broader-corpus coverage closure named above.
    actual compile outcomes.
 6. **Runtime is rewired, not copied.** Shared coercion/string/object/collection/
    regex/async behavior stays single-sourced behind semantic IR intents.
-7. **Deletion follows reachability.** No direct handler is removed until the
+7. **Optimizations migrate before deletion.** Every reachable direct handler
+   must have its correctness behavior and optimization decisions inventoried.
+   Each optimization needs an IR lowering/pass owner plus differential
+   output-shape or performance evidence where semantic equivalence alone would
+   miss a regression. An unmapped optimization blocks deletion; it is never
+   silently discarded as cleanup.
+8. **Deletion follows reachability.** No direct handler is removed until the
    new gate proves it unreachable in every supported policy/backend and the
    #3090 audit confirms the call edge is gone.
 
@@ -179,6 +185,10 @@ async, adoption-owner, and broader-corpus coverage closure named above.
       graph are unreachable and deleted. The refreshed #3090 report records
       zero frontend-only survivors and separately records retained runtime/
       substrate code.
+- [ ] The direct-handler retirement inventory maps every behavior and
+      optimization to an IR lowering, pass, runtime semantic intent, or
+      explicit Unsupported outcome. Differential Wasm-shape and performance
+      gates show that deletion does not silently drop legacy optimizations.
 - [ ] Equivalence, cross-backend, linear, typecheck, lint/format, loc/dead-
       export, full Test262, standalone-floor, and artifact-validity gates pass
       on the final merged result.

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -86,6 +86,7 @@ files:
   - src/codegen/context/types.ts
   - src/codegen/context/create-context.ts
   - src/codegen/dead-elimination.ts
+  - src/codegen/declarations.ts
   - src/codegen/func-space.ts
   - src/codegen/program-abi-class-callable-planning.ts
   - src/codegen/program-abi-callable-planning.ts
@@ -93,6 +94,7 @@ files:
   - src/codegen/program-abi-finalization.ts
   - src/codegen/program-abi-import-planning.ts
   - src/codegen/program-abi-global-planning.ts
+  - src/codegen/program-abi-module-init-planning.ts
   - src/codegen/program-abi-planning.ts
   - src/codegen/program-abi-signatures.ts
   - src/codegen/program-abi-session.ts
@@ -144,6 +146,7 @@ files:
   - tests/issue-3520-support-callable-abi.test.ts
   - tests/issue-3520-class-support-callable-abi.test.ts
   - tests/issue-3520-class-method-alias-abi.test.ts
+  - tests/issue-3520-module-init-callable-abi.test.ts
   - tests/issue-3520-type-class-abi.test.ts
   - tests/issue-3520-global-population-abi.test.ts
   - tests/issue-3520-callable-export-population-abi.test.ts
@@ -1939,6 +1942,80 @@ identity, not R1. Production consumers must still route through the populated
 callable/global/type/class authorities, and `LegacyAbiAdapter` must become the
 only name-keyed boundary by replacing direct `funcMap`, `structMap`,
 `moduleGlobals`, module-array, and display-name scans before R1 can close.
+
+### 2026-07-28 exact module-initializer callable continuation
+
+The stacked continuation on `codex/3520-c18-module-init-abi` removes
+display-name lookup from compiler-created module-initializer allocation,
+IR-patch resolution, startup wiring, and initialization guards:
+
+- every compiler-created initializer is allocated through a stable function
+  handle and recorded in an exact sidecar even when Program ABI telemetry is
+  disabled. IR integration resolves the preallocated body from its
+  source-qualified module-init unit instead of scanning for
+  `__module_init`;
+- the single-source retained initializer owns the exact module-init unit
+  binding and final callable slot. A same-named user function owns its separate
+  top-level-function binding and can no longer steal the IR patch, startup
+  target, or public initializer alias;
+- the sidecar follows allocator handles through IR body replacement and
+  dead-layout finalization. Startup guards compare the exact function object,
+  so a user-authored `__module_init` remains an ordinary exported/user
+  callable; and
+- the current multi-source frontend still emits cumulative initializer passes.
+  Until R5 replaces that behavior with one prepared whole-program unit, every
+  physical pass receives an explicit entry-source support identity and ordinal
+  rather than an invented source-unit owner. Existing first-pass guard/start
+  behavior and final public alias selection are preserved byte-for-byte.
+
+The three-test anti-vacuity fixture proves the same-name IR-emitted case, an
+Unsupported direct-body case, and two ordered multi-source passes at runtime.
+The exact C17 parent rejects the collision fixture because both callables
+attach to the user function; C18 assigns two exact required bindings and
+distinct final slots, preserves the user result `99`, and runs the synthetic
+initializer once to produce the expected top-level state. The focused suite
+passes **3/3**, and the combined callable-population/module-init suite passes
+**8/8**.
+
+The sharded #3520 plus #2138 migration matrix reports **272 passing / 1 known
+failing across 50 files**. The sole failure is the inherited linear
+inventory-count spy assertion already reproduced on C12-C17. The adjacent
+module-init/startup/ABI matrix adds no branch-specific failure; two optional
+test262.fyi fixtures are unavailable because that local corpus/submodule is
+not installed.
+
+For a non-collision numeric module, the exact C17 parent and C18 emit identical
+bytes in all four checked modes: host
+`cc43eff221a66ea95123b273ff2fabd3e3e8e6045d072696fdebd0d21d2bf8c0`,
+deferred host
+`722a2a8038937ed145c483b3336e8711eb20dddcc0910972bf0a214bb1ea354e`,
+standalone
+`903c9b027532c47c856c6f13fc76f68ca1a4ebee0c3a17408d918e70c1f72ea6`,
+and WASI
+`a4033b7b395844fc1cb421e26c232a671d0dd56d276230df978b966788aa5afc`.
+
+Strict TypeScript, formatting/diff, scoped lint, LOC/function budget,
+dead-export, godfile, checker-oracle, issue-spec, test-vacuity,
+verdict-oracle, done-status, and issue-index consistency gates pass. Hybrid
+readiness remains **READY** at **31 IR-emitted / 6 typed Unsupported / 0
+Invariants across 37 terminal units**, while strict IR-only correctly remains
+not ready because all 37 legacy bodies are still emitted. The six typed
+blockers are four async/call-graph selection units and two static class-member
+builds. The fallback ratchet reports no unintended, post-claim, or
+module-level increase.
+
+The supported eight-shard equivalence gate reports **1,611 passing / 32 known
+failing / 0 new regressions**; four baseline rows now pass and the shared
+baseline remains unchanged. No local Test262 corpus run was performed, and
+neither `benchmarks/results/test262-run.log` nor
+`scripts/equivalence-baseline.json` is changed.
+
+C18 closes structural ownership and resolution for current module-initializer
+allocators, not R1 or R5. Remaining R1 production consumers still include
+direct `funcMap`, `structMap`, `moduleGlobals`, module-array, and display-name
+joins outside the module-init seam. Multi-source compile-once initialization
+and body-ownership changes remain explicitly deferred to the prepared-program
+R2-R5 cutover.
 
 ### R1a validation evidence
 

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -5,8 +5,8 @@ status: in-progress
 assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
-branch: codex/3520-c17-host-class-abi
-pr: 3770
+branch: codex/3520-c18-module-init-abi
+pr: 3774
 last_merged_pr: 3679
 sprint: current
 created: 2026-07-21

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -19,6 +19,7 @@ import { ProgramAbiCallableRegistry } from "../program-abi-callable-planning.js"
 import { ProgramAbiExportRegistry } from "../program-abi-export-planning.js";
 import { ProgramAbiCallableProviderRegistry } from "../program-abi-provider-planning.js";
 import { ProgramAbiGlobalRegistry } from "../program-abi-global-planning.js";
+import { ProgramAbiModuleInitCallableRegistry } from "../program-abi-module-init-planning.js";
 import { ProgramAbiTypeRegistry } from "../program-abi-type-planning.js";
 import type { CodegenContext, CodegenOptions } from "./types.js";
 
@@ -371,6 +372,11 @@ export function createCodegenContext(
     nodeBuiltinGlobals: new Map(),
     jsxRuntime: options?.jsxRuntime,
   };
+  ctx.programAbiModuleInitCallables = new ProgramAbiModuleInitCallableRegistry(
+    ctx,
+    programAbiSession,
+    irPlanningIdentityContext,
+  );
   if (programAbiSession) {
     ctx.programAbiCallableProviders = new ProgramAbiCallableProviderRegistry(programAbiSession, ctx);
     ctx.programAbiCallables = new ProgramAbiCallableRegistry(programAbiSession, ctx);

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1052,6 +1052,7 @@ export interface FunctionContext {
 export interface CodegenContext {
   mod: WasmModule;
   programAbiSession?: import("../program-abi-session.js").ProgramAbiSession;
+  programAbiModuleInitCallables?: import("../program-abi-module-init-planning.js").ProgramAbiModuleInitCallableRegistry;
   programAbiCallableProviders?: import("../program-abi-provider-planning.js").ProgramAbiCallableProviderRegistry;
   programAbiClassCallables?: import("../program-abi-class-callable-planning.js").ProgramAbiClassCallableRegistry;
   programAbiCallables?: import("../program-abi-callable-planning.js").ProgramAbiCallableRegistry;

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -89,7 +89,8 @@ import { isArrayProtoIteratorAssignTarget } from "./expressions/proto-override.j
 import { isFnctorPrototypeAssignTarget } from "./expressions/fnctor-prototype.js";
 import { compileExpression, compileStatement } from "./shared.js";
 import { expandLinearU8ParamTypes } from "./linear-uint8-signatures.js";
-import { definedFuncAt } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
+import { definedFuncAt, mintDefinedFunc } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
+import { pushProgramAbiModuleInitCallable } from "./program-abi-module-init-planning.js";
 import { inferStandaloneRegExpMatchGlobalType } from "./regexp-standalone.js";
 
 // ── Extracted subsystems (#3268) — re-exported for external consumers ─────
@@ -2712,12 +2713,11 @@ export function compileDeclarations(
     // instantiation, before `setExports`) enumerates zero keys. Exporting it and
     // letting the host call it after `setExports` is symmetric with the
     // standalone/WASI `_start` model and gives the diff-test HOST lane the same
-    // fully-wired runtime the standalone lane has. The export's func index is
-    // shifted alongside every other export by the late-import shift logic.
+    // fully-wired runtime; late-import shifting keeps its function index aligned with every other export.
     const exportModuleInit = ctx.deferTopLevelInit && !ctx.wasi;
     const initTypeIdx = addFuncType(ctx, [], [], "__module_init_type");
-    const initFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({
+    const initFuncIdx = mintDefinedFunc(ctx);
+    pushProgramAbiModuleInitCallable(ctx, sourceFile, initFuncIdx, {
       name: "__module_init",
       typeIdx: initTypeIdx,
       locals: compiledInitFctx.locals,

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4195,16 +4195,11 @@ function finalizeInModuleInitFlag(ctx: CodegenContext): void {
   ctx.inModuleInitGlobalIdx = flagIdx;
   for (const r of reads) (r as { index: number }).index = flagIdx;
 
-  // Wrap __module_init (when present): flag = 1 for the body, 0 on completion.
-  let initArrayIdx = -1;
-  for (let i = 0; i < ctx.mod.functions.length; i++) {
-    if (ctx.mod.functions[i]!.name === "__module_init") {
-      initArrayIdx = i;
-      break;
-    }
-  }
-  if (initArrayIdx < 0) return;
-  const initFn = ctx.mod.functions[initArrayIdx]!;
+  // Wrap the exact compiler-created initializer (when present): flag = 1 for
+  // the body, 0 on completion. Preserve the legacy multi-source first-pass
+  // choice until R5 replaces cumulative initializer emission.
+  const initFn = ctx.programAbiModuleInitCallables?.firstFunction();
+  if (!initFn) return;
   initFn.body = [
     { op: "i32.const", value: 1 },
     { op: "global.set", index: flagIdx },
@@ -4217,16 +4212,11 @@ function finalizeInModuleInitFlag(ctx: CodegenContext): void {
 function applyModuleInitGuard(ctx: CodegenContext): void {
   if (ctx.moduleInitGuardApplied) return;
 
-  // Locate __module_init.
-  let initArrayIdx = -1;
-  for (let i = 0; i < ctx.mod.functions.length; i++) {
-    if (ctx.mod.functions[i]!.name === "__module_init") {
-      initArrayIdx = i;
-      break;
-    }
-  }
-  if (initArrayIdx < 0) return; // no module init — nothing to guard
-  const initFuncIdx = ctx.numImportFuncs + initArrayIdx;
+  // Resolve the exact compiler-created initializer. Preserve the legacy
+  // multi-source first-pass choice until R5 owns graph aggregation.
+  const initFn = ctx.programAbiModuleInitCallables?.firstFunction();
+  const initFuncIdx = ctx.programAbiModuleInitCallables?.firstHandle();
+  if (!initFn || initFuncIdx === undefined) return; // no module init — nothing to guard
 
   // 1. __init_done global + self-guard prologue on __module_init.
   const doneGlobalIdx = nextModuleGlobalIdx(ctx);
@@ -4236,7 +4226,6 @@ function applyModuleInitGuard(ctx: CodegenContext): void {
     mutable: true,
     init: [{ op: "i32.const", value: 0 }],
   });
-  const initFn = ctx.mod.functions[initArrayIdx]!;
   initFn.body = [
     { op: "global.get", index: doneGlobalIdx },
     { op: "if", blockType: { kind: "empty" }, then: [{ op: "return" }] },
@@ -4249,7 +4238,7 @@ function applyModuleInitGuard(ctx: CodegenContext): void {
   //    __module_init itself). Idempotency makes repeated entry calls safe.
   for (const fn of ctx.mod.functions) {
     if (!fn.exported) continue;
-    if (fn.name === "__module_init") continue;
+    if (fn === initFn) continue;
     fn.body = [{ op: "call", funcIdx: initFuncIdx }, ...fn.body];
   }
 
@@ -4350,12 +4339,7 @@ function addWasiStartExport(ctx: CodegenContext): void {
   // No callable exported `main` → wrap `__module_init`, which carries all
   // top-level code (including any top-level call to a non-exported `main`).
   if (targetIdx === undefined) {
-    for (let i = 0; i < ctx.mod.functions.length; i++) {
-      if (ctx.mod.functions[i]!.name === "__module_init") {
-        targetIdx = ctx.numImportFuncs + i;
-        break;
-      }
-    }
+    targetIdx = ctx.programAbiModuleInitCallables?.firstHandle();
   }
 
   if (targetIdx !== undefined) {

--- a/src/codegen/program-abi-finalization.ts
+++ b/src/codegen/program-abi-finalization.ts
@@ -18,6 +18,7 @@ export function eliminateDeadLayoutAndPlanProgramAbi(ctx: CodegenContext): void 
   planProgramAbiCallableImports(ctx);
   ctx.programAbiCallableProviders?.planRetained();
   ctx.programAbiClassCallables?.planRetained();
+  ctx.programAbiModuleInitCallables?.planRetained();
   ctx.programAbiCallables?.planRetained();
   ctx.programAbiGlobals?.planRetained();
   ctx.programAbiExports?.planRetained();

--- a/src/codegen/program-abi-module-init-planning.ts
+++ b/src/codegen/program-abi-module-init-planning.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { irSupportFuncRef, irUnitCallableBindingId, irUnitFuncRef } from "../ir/callable-bindings.js";
+import type { IrSourceId, IrUnitId } from "../ir/identity.js";
+import type { IrPlanningIdentityContext } from "../ir/planning-identity.js";
+import { ProgramAbiInvariantError } from "../ir/program-abi.js";
+import type { FuncHandle, FuncTypeDef, WasmFunction } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt, pushDefinedFunc } from "./func-space.js";
+import {
+  planProgramAbiSupportCallable,
+  planProgramAbiUnitCallable,
+  PROGRAM_ABI_CALLABLE_ROLE,
+} from "./program-abi-planning.js";
+import type { ProgramAbiSession } from "./program-abi-session.js";
+
+const LEGACY_MODULE_INIT_PASS_ROLE = "legacy-module-init-pass";
+
+interface ModuleInitCallableObservation {
+  readonly ordinal: number;
+  readonly unitId?: IrUnitId;
+  readonly funcIdx: FuncHandle;
+}
+
+/** Push and structurally observe one compiler-created module initializer. */
+export function pushProgramAbiModuleInitCallable(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  funcIdx: FuncHandle,
+  func: WasmFunction,
+): void {
+  pushDefinedFunc(ctx, funcIdx, func);
+  const registry = ctx.programAbiModuleInitCallables;
+  if (!registry) {
+    throw new ProgramAbiInvariantError(
+      "context-session-mismatch",
+      "module initializer was allocated without its structural registry",
+    );
+  }
+  registry.observe(sourceFile, funcIdx);
+}
+
+function canonicalEntrySource(session: ProgramAbiSession): IrSourceId {
+  const entries = session.inventory.sources.filter((source) => source.kind === "entry");
+  if (entries.length !== 1) {
+    throw new ProgramAbiInvariantError(
+      "unknown-order-anchor",
+      `module-init ABI planning requires exactly one canonical entry source, found ${entries.length}`,
+    );
+  }
+  return entries[0]!.id;
+}
+
+function functionSignature(ctx: CodegenContext, func: WasmFunction): FuncTypeDef {
+  const signature = ctx.mod.types[func.typeIdx];
+  if (!signature || signature.kind !== "func") {
+    throw new ProgramAbiInvariantError(
+      "type-remap-mismatch",
+      `module initializer ${func.name} references non-function or missing type ${func.typeIdx}`,
+    );
+  }
+  return signature;
+}
+
+/**
+ * Exact allocator sidecar for compiler-created module initializers.
+ *
+ * The sidecar exists even without a Program ABI session so startup wiring and
+ * the compatibility overlay never rediscover an initializer by display name.
+ * With an identity inventory, a single semantic module-init unit owns the final
+ * allocator object. The legacy multi-source pipeline emits progressively
+ * cumulative initializer functions; those temporary physical passes receive
+ * explicit source support identities until R5 replaces them with one prepared
+ * whole-program unit.
+ */
+export class ProgramAbiModuleInitCallableRegistry {
+  private readonly observations: ModuleInitCallableObservation[] = [];
+  private planned = false;
+
+  constructor(
+    readonly ctx: CodegenContext,
+    readonly session?: ProgramAbiSession,
+    readonly identityContext?: IrPlanningIdentityContext,
+  ) {
+    session?.assertModule(ctx.mod);
+    if (!session && identityContext) {
+      throw new ProgramAbiInvariantError(
+        "context-session-mismatch",
+        "module-init ABI registry cannot accept a planning identity context without a Program ABI session",
+      );
+    }
+    if (session && identityContext && identityContext.inventory !== session.inventory) {
+      throw new ProgramAbiInvariantError(
+        "context-session-mismatch",
+        "module-init ABI registry and planning context do not share one inventory",
+      );
+    }
+  }
+
+  observe(sourceFile: ts.SourceFile, funcIdx: FuncHandle): void {
+    if (this.planned) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        "cannot observe a module initializer after retained module-init planning",
+      );
+    }
+    const func = definedFuncAt(this.ctx, funcIdx);
+    if (!func) {
+      throw new ProgramAbiInvariantError(
+        "missing-required-locator",
+        `module initializer has no exact defined function for handle ${funcIdx}`,
+      );
+    }
+    if (this.identityContext && !this.identityContext.sourceIdBySourceFile.has(sourceFile)) {
+      throw new ProgramAbiInvariantError(
+        "unknown-order-anchor",
+        `module initializer source ${sourceFile.fileName} is absent from the planning inventory`,
+      );
+    }
+    const unitId = this.identityContext?.moduleInitUnitIdBySourceFile.get(sourceFile);
+    this.observations.push(
+      Object.freeze({
+        ordinal: this.observations.length,
+        ...(unitId === undefined ? {} : { unitId }),
+        funcIdx,
+      }),
+    );
+  }
+
+  /** First compiler-created initializer, preserving the legacy multi-source startup choice. */
+  firstFunction(): WasmFunction | undefined {
+    const observation = this.observations[0];
+    return observation ? definedFuncAt(this.ctx, observation.funcIdx) : undefined;
+  }
+
+  firstHandle(): FuncHandle | undefined {
+    const observation = this.observations[0];
+    return observation && definedFuncAt(this.ctx, observation.funcIdx) ? observation.funcIdx : undefined;
+  }
+
+  /** Exact preallocated function object for one selected source module-init unit. */
+  functionForUnit(unitId: IrUnitId): WasmFunction | undefined {
+    const observation = this.observations.filter((candidate) => candidate.unitId === unitId).at(-1);
+    return observation ? definedFuncAt(this.ctx, observation.funcIdx) : undefined;
+  }
+
+  handleForUnit(unitId: IrUnitId): FuncHandle | undefined {
+    const observation = this.observations.filter((candidate) => candidate.unitId === unitId).at(-1);
+    return observation && definedFuncAt(this.ctx, observation.funcIdx) ? observation.funcIdx : undefined;
+  }
+
+  /** Assign semantic owners before generic retained-callable population. */
+  planRetained(): void {
+    if (this.planned) return;
+    this.planned = true;
+    const { session, identityContext } = this;
+    if (!session || !identityContext) return;
+
+    const liveObservations = this.observations.flatMap((observation) => {
+      const func = definedFuncAt(this.ctx, observation.funcIdx);
+      return func ? [{ observation, func }] : [];
+    });
+    const moduleInitUnitIds = [...identityContext.moduleInitUnitIdBySourceId.values()];
+    const exactUnitId = moduleInitUnitIds.length === 1 ? moduleInitUnitIds[0] : undefined;
+    const exactObservation = exactUnitId ? liveObservations.at(-1)?.observation : undefined;
+    const entrySourceId = canonicalEntrySource(session);
+
+    for (const { observation, func } of liveObservations) {
+      if (exactUnitId && observation === exactObservation) {
+        this.planExactUnit(exactUnitId, func);
+        continue;
+      }
+      const ref = irSupportFuncRef(entrySourceId, LEGACY_MODULE_INIT_PASS_ROLE, func.name, observation.ordinal);
+      const bindingId =
+        ref.binding.kind === "support"
+          ? planProgramAbiSupportCallable(this.ctx, {
+              ref,
+              anchor: { kind: "source", sourceId: entrySourceId },
+              role: LEGACY_MODULE_INIT_PASS_ROLE,
+              roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.moduleInit,
+              derivedOrdinal: observation.ordinal,
+              signature: functionSignature(this.ctx, func),
+              func,
+            })
+          : undefined;
+      if (ref.binding.kind !== "support" || bindingId !== ref.binding.bindingId) {
+        throw new ProgramAbiInvariantError(
+          "invalid-binding-reference",
+          `legacy module-init pass ${observation.ordinal} was not accepted by Program ABI planning`,
+        );
+      }
+    }
+  }
+
+  private planExactUnit(unitId: IrUnitId, func: WasmFunction): void {
+    const session = this.session!;
+    const bindingId = irUnitCallableBindingId(unitId);
+    if (session.hasPlan(bindingId)) {
+      if (!session.hasLocator(bindingId, func)) {
+        throw new ProgramAbiInvariantError(
+          "duplicate-slot-locator",
+          `module-init unit ${unitId} is not attached to its exact allocator object`,
+        );
+      }
+      return;
+    }
+    const planned = planProgramAbiUnitCallable(this.ctx, {
+      ref: irUnitFuncRef({ unitId, name: func.name }),
+      signature: functionSignature(this.ctx, func),
+      func,
+    });
+    if (planned !== bindingId) {
+      throw new ProgramAbiInvariantError(
+        "missing-source-unit",
+        `retained module initializer was not accepted for exact unit ${unitId}`,
+      );
+    }
+  }
+}

--- a/src/codegen/program-abi-planning.ts
+++ b/src/codegen/program-abi-planning.ts
@@ -18,6 +18,7 @@ export const PROGRAM_ABI_CALLABLE_ROLE = Object.freeze({
   classConstructorInit: 2,
   classMethodAdapter: 3,
   classHostConstructor: 4,
+  moduleInit: 5,
   retainedModuleFunction: 6,
 } as const);
 

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -621,8 +621,8 @@ export function compileIrPathFunctions(
     readonly classMember?: boolean;
     /**
      * (#3142 Slice 2) The synthetic `<module-init>` unit. Its target slot is
-     * the legacy `__module_init` function (located by NAME at Phase 3 — it
-     * is never in `ctx.funcMap`), patched in place with the same typeIdx
+     * the legacy module-initializer function (resolved from its exact source
+     * unit through the allocator registry), patched in place with the same typeIdx
      * parity guard class members use. Never allocated a fresh slot.
      */
     readonly moduleInit?: boolean;
@@ -956,7 +956,7 @@ export function compileIrPathFunctions(
   // Integration-time gates (each throws → the whole unit demotes to the
   // legacy body, which is ALWAYS still emitted — module-init is never in the
   // IR-first skip set):
-  //   - the legacy `__module_init` slot must exist (legacy may drop
+  //   - the exact legacy module-init slot must exist (legacy may drop
   //     side-effect-free statements and emit nothing — then there is nothing
   //     to patch and nothing to gain),
   //   - no static class initializers / live-func-binding seeds (legacy
@@ -970,11 +970,11 @@ export function compileIrPathFunctions(
   const moduleInitOwner = moduleInitClaim ? requireTerminalOwner(MODULE_INIT_UNIT_NAME) : undefined;
   if (moduleInitClaim && moduleInitOwner && !unsupportedHostDateOwners.has(moduleInitOwner.unitId)) {
     try {
-      if (!ctx.mod.functions.some((f) => f.name === "__module_init")) {
+      if (!ctx.programAbiModuleInitCallables?.functionForUnit(moduleInitOwner.unitId)) {
         throw new IrUnsupportedError(
           "module-init-legacy-coupling",
           "build",
-          "module-init: no legacy __module_init slot to patch (legacy collected no init statements)",
+          "module-init: no exact legacy initializer slot to patch (legacy collected no init statements)",
         );
       }
       if (ctx.staticInitExprs.length > 0) {
@@ -1663,10 +1663,7 @@ export function compileIrPathFunctions(
   };
   const legacyArtifactFuncIdx = (entry: BuiltFn): number | undefined =>
     entry.moduleInit
-      ? (() => {
-          const local = ctx.mod.functions.findIndex((candidate) => candidate.name === "__module_init");
-          return local >= 0 ? ctx.numImportFuncs + local : undefined;
-        })()
+      ? ctx.programAbiModuleInitCallables?.handleForUnit(entry.artifactUnitId)
       : ctx.funcMap.get(entry.name);
   const hasPreallocatedArtifactSlot = (entry: BuiltFn): boolean =>
     (originalArtifactUnitIds.has(entry.artifactUnitId) && !entry.synthesized) ||
@@ -1692,8 +1689,8 @@ export function compileIrPathFunctions(
     // legacy `class-bodies.ts` pass (`ctorFuncIdx` / `methodFuncIdx`).
     // Don't allocate a new slot — Phase 3 will patch the existing one.
     if (entry.classMember) continue;
-    // (#3142 Slice 2) The module-init unit patches the legacy
-    // `__module_init` slot (located by name at Phase 3) — never a fresh one.
+    // (#3142 Slice 2) The module-init unit patches its exact legacy
+    // allocator slot from the source-unit registry — never a fresh one.
     if (entry.moduleInit) continue;
     if (ctx.irUnitFuncMap.has(entry.artifactUnitId)) continue;
     const namedIdx = ctx.funcMap.get(entry.name);
@@ -2127,9 +2124,9 @@ export function compileIrPathFunctions(
       if (process.env.JS2WASM_TEST_INJECT_IR_PHASE_THROW === "lower-synthetic" && entry.synthesized) {
         throw new Error("injected synthetic lower failure");
       }
-      // (#3142 Slice 2) The module-init unit's slot is the legacy
-      // `__module_init` function — located by NAME (it is never in
-      // `ctx.funcMap`; the slot was pushed directly by compileDeclarations).
+      // (#3142 Slice 2) The module-init unit's slot is its exact legacy
+      // allocator function (it is never in `ctx.funcMap`; the slot was
+      // registered structurally by compileDeclarations).
       const funcIdx = artifactFuncIdx(entry);
       if (funcIdx === undefined) {
         markOwnerInvariant(

--- a/tests/issue-3520-module-init-callable-abi.test.ts
+++ b/tests/issue-3520-module-init-callable-abi.test.ts
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeMultiSource, analyzeSource } from "../src/checker/index.js";
+import { generateModule, generateMultiModule } from "../src/codegen/index.js";
+import { canonicalProgramAbiCallableTypeContract } from "../src/codegen/program-abi-signatures.js";
+import { compile, compileMulti, type CompileResult } from "../src/index.js";
+import { irSupportFuncRef, irUnitCallableBindingId } from "../src/ir/callable-bindings.js";
+import { buildIrUnitInventory, type IrUnitInventory } from "../src/ir/identity.js";
+import type { ProgramAbiPlanEntry } from "../src/ir/program-abi.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+// Register the codegen expression/statement delegates used by generateModule.
+import "../src/codegen/expressions.js";
+
+const COLLISION_SOURCE = `
+  let total: number = 1;
+  total += 2;
+
+  function __module_init(): number {
+    return 99;
+  }
+
+  export function callUserInitializer(): number {
+    return __module_init();
+  }
+
+  export function readTotal(): number {
+    return total;
+  }
+`;
+
+function exactUnit(inventory: IrUnitInventory, kind: string, displayName: string) {
+  const matches = inventory.allUnits.filter((unit) => unit.kind === kind && unit.displayName === displayName);
+  if (matches.length !== 1) {
+    throw new Error(`expected one ${kind} ${displayName}, found ${matches.length}`);
+  }
+  return matches[0]!;
+}
+
+function requiredCallable(entries: readonly ProgramAbiPlanEntry[], bindingId: string): ProgramAbiPlanEntry {
+  const entry = entries.find((candidate) => candidate.id === bindingId);
+  if (!entry) throw new Error(`missing callable ABI entry ${bindingId}`);
+  expect(entry).toMatchObject({
+    slotPolicy: "required",
+    slotSpace: "function",
+    intent: { kind: "callable" },
+  });
+  return entry;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, WebAssembly.ExportValue>> {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    result.binary,
+    imports.env,
+    imports.string_constants,
+    imports.string_constants16,
+  );
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, WebAssembly.ExportValue>;
+}
+
+describe("#3520 module-init callable Program ABI ownership", () => {
+  it("keeps a same-named user function distinct from the exact IR-patched initializer", async () => {
+    const ast = analyzeSource(COLLISION_SOURCE, "module-init-collision.ts");
+    const inventory = buildIrUnitInventory([ast.sourceFile], {
+      entrySource: ast.sourceFile,
+      checker: ast.checker,
+    });
+    const moduleInit = exactUnit(inventory, "module-init", "<module-init>");
+    const userInit = exactUnit(inventory, "top-level-function", "__module_init");
+    const generated = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      deferTopLevelInit: true,
+    });
+
+    const hardErrors = generated.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+    expect(generated.irPostClaimErrors).toEqual([]);
+    expect(generated.irCompiledFuncs).toContain("<module-init>");
+    expect(generated.irOutcomes?.find((outcome) => outcome.unitId === moduleInit.id)).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: true,
+      irBodyEmitted: true,
+    });
+    expect(generated.programAbi).toBeDefined();
+
+    const entries = generated.programAbi!.abi.entries();
+    const moduleBindingId = irUnitCallableBindingId(moduleInit.id);
+    const userBindingId = irUnitCallableBindingId(userInit.id);
+    const moduleEntry = requiredCallable(entries, moduleBindingId);
+    const userEntry = requiredCallable(entries, userBindingId);
+    expect(moduleEntry).toMatchObject({
+      displayName: "__module_init",
+      intent: { kind: "callable", origin: "source", unitId: moduleInit.id },
+    });
+    expect(userEntry).toMatchObject({
+      displayName: "__module_init",
+      intent: { kind: "callable", origin: "source", unitId: userInit.id },
+    });
+
+    const moduleSlot = generated.programAbi!.abi.resolveFinalIndex(moduleBindingId);
+    const userSlot = generated.programAbi!.abi.resolveFinalIndex(userBindingId);
+    expect(moduleSlot).toEqual(expect.objectContaining({ space: "function" }));
+    expect(userSlot).toEqual(expect.objectContaining({ space: "function" }));
+    expect(moduleSlot).not.toEqual(userSlot);
+
+    if (!moduleSlot || moduleSlot.space !== "function") throw new Error("missing module-init function slot");
+    const importCount = generated.module.imports.filter((candidate) => candidate.desc.kind === "func").length;
+    const moduleFunction = generated.module.functions[moduleSlot.index - importCount];
+    const signature = moduleFunction ? generated.module.types[moduleFunction.typeIdx] : undefined;
+    if (!moduleFunction || !signature || signature.kind !== "func") {
+      throw new Error("missing exact module-init function");
+    }
+    expect(moduleEntry.intent).toMatchObject({
+      kind: "callable",
+      signature: canonicalProgramAbiCallableTypeContract(signature),
+    });
+
+    const publicInit = entries.find(
+      (entry) => entry.intent.kind === "export" && entry.intent.externalName === "__module_init",
+    );
+    expect(publicInit).toMatchObject({ slotPolicy: "alias", aliasOf: moduleBindingId });
+    expect(generated.programAbi!.abi.resolveFinalIndex(publicInit!.id)).toEqual(moduleSlot);
+
+    const runtime = await compile(COLLISION_SOURCE, {
+      fileName: "module-init-collision.ts",
+      experimentalIR: true,
+      deferTopLevelInit: true,
+    });
+    const exports = await instantiate(runtime);
+    expect((exports.callUserInitializer as () => number)()).toBe(99);
+    (exports.__module_init as () => void)();
+    expect((exports.readTotal as () => number)()).toBe(3);
+    expect((exports.callUserInitializer as () => number)()).toBe(99);
+  });
+
+  it("owns the exact retained direct initializer when IR reports Unsupported", async () => {
+    const source = `
+      let greeting: string = "hi";
+      greeting = greeting + "!";
+      function __module_init(): number { return 41; }
+      export function callUserInitializer(): number { return __module_init(); }
+      export function readGreeting(): string { return greeting; }
+    `;
+    const ast = analyzeSource(source, "module-init-direct-collision.ts");
+    const inventory = buildIrUnitInventory([ast.sourceFile], {
+      entrySource: ast.sourceFile,
+      checker: ast.checker,
+    });
+    const moduleInit = exactUnit(inventory, "module-init", "<module-init>");
+    const generated = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      deferTopLevelInit: true,
+    });
+    const hardErrors = generated.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+    expect(generated.irOutcomes?.find((outcome) => outcome.unitId === moduleInit.id)).toMatchObject({
+      kind: "unsupported",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+
+    const bindingId = irUnitCallableBindingId(moduleInit.id);
+    const entry = requiredCallable(generated.programAbi!.abi.entries(), bindingId);
+    expect(entry).toMatchObject({
+      displayName: "__module_init",
+      intent: { kind: "callable", origin: "source", unitId: moduleInit.id },
+    });
+
+    const runtime = await compile(source, {
+      fileName: "module-init-direct-collision.ts",
+      experimentalIR: true,
+      deferTopLevelInit: true,
+    });
+    const exports = await instantiate(runtime);
+    expect((exports.callUserInitializer as () => number)()).toBe(41);
+    (exports.__module_init as () => void)();
+    expect((exports.readGreeting as () => string)()).toBe("hi!");
+    expect((exports.callUserInitializer as () => number)()).toBe(41);
+  });
+
+  it("classifies cumulative multi-source initializer passes without inventing one source owner", async () => {
+    const files = {
+      "dependency.ts": `
+        export var dependencyRuns: number = 0;
+        dependencyRuns += 1;
+      `,
+      "entry.ts": `
+        import { dependencyRuns } from "./dependency.ts";
+        var entryRuns: number = 0;
+        entryRuns += 1;
+        export function score(): number { return dependencyRuns * 10 + entryRuns; }
+      `,
+    };
+    const ast = analyzeMultiSource(files, "entry.ts");
+    const inventory = buildIrUnitInventory(ast.sourceFiles, {
+      entrySource: ast.entryFile,
+      checker: ast.checker,
+    });
+    expect([...inventory.terminalUnits].filter((unit) => unit.kind === "module-init")).toHaveLength(2);
+    const entrySourceId = inventory.sources.find((source) => source.kind === "entry")!.id;
+    const generated = generateMultiModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      deferTopLevelInit: true,
+    });
+    const hardErrors = generated.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+
+    const entries = generated.programAbi!.abi.entries();
+    const passEntries = [0, 1].map((ordinal) => {
+      const ref = irSupportFuncRef(entrySourceId, "legacy-module-init-pass", "__module_init", ordinal);
+      if (ref.binding.kind !== "support") throw new Error("expected module-init support reference");
+      return requiredCallable(entries, ref.binding.bindingId);
+    });
+    expect(passEntries).toEqual([
+      expect.objectContaining({
+        displayName: "__module_init",
+        intent: expect.objectContaining({ kind: "callable", origin: "support", sourceId: entrySourceId }),
+      }),
+      expect.objectContaining({
+        displayName: "__module_init",
+        intent: expect.objectContaining({ kind: "callable", origin: "support", sourceId: entrySourceId }),
+      }),
+    ]);
+    expect(passEntries.map((entry) => generated.programAbi!.abi.resolveFinalIndex(entry.id))).toEqual([
+      expect.objectContaining({ space: "function" }),
+      expect.objectContaining({ space: "function" }),
+    ]);
+
+    const publicInit = entries.find(
+      (entry) => entry.intent.kind === "export" && entry.intent.externalName === "__module_init",
+    );
+    expect(generated.programAbi!.abi.resolveFinalIndex(publicInit!.id)).toEqual(
+      generated.programAbi!.abi.resolveFinalIndex(passEntries[1]!.id),
+    );
+
+    const runtime = await compileMulti(files, "entry.ts", {
+      experimentalIR: true,
+      deferTopLevelInit: true,
+    });
+    const exports = await instantiate(runtime);
+    expect((exports.score as () => number)()).toBe(0);
+    (exports.__module_init as () => void)();
+    expect((exports.score as () => number)()).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary

- allocate and track compiler-created module initializers through stable function handles and exact source-qualified Program ABI ownership
- remove `__module_init` display-name scans from IR patch resolution, startup wiring, initialization guards, and WASI fallback selection
- keep same-named user functions distinct, and give current multi-source cumulative initializer passes explicit support identities until R5 owns aggregation
- record optimization parity as a required condition for retiring direct handlers

## Why

The IR overlay previously rediscovered the compiler initializer by display name. A user-authored `__module_init` could therefore collide with the synthetic initializer and receive the wrong IR patch, guard, export alias, or startup role. This change attaches those operations to the exact allocator object and source unit while leaving R1 routing and body-emission behavior unchanged.

This is stacked on #3770 (`codex/3520-c17-host-class-abi`).

## Validation

- focused module-init ownership/runtime suite: 3/3
- callable-population plus module-init suite: 8/8
- sharded #3520 plus #2138 migration matrix: 272 passing / 1 inherited known failing across 50 files
- exact C17 anti-vacuity control rejects the collision fixture; this branch assigns distinct required bindings/final slots and executes both callables correctly
- non-collision host, deferred-host, standalone, and WASI output is byte-identical to the exact C17 parent
- hybrid readiness: READY, 31 IR-emitted / 6 typed Unsupported / 0 Invariants across 37 terminal units
- strict IR-only remains expected-red: 6 Unsupported units and all 37 legacy bodies still emitted
- fallback ratchet: no unintended, post-claim, or module-level increase
- eight-shard equivalence: 1,611 passing / 32 known failing / 0 new regressions; four baseline rows now pass
- TypeScript, Prettier/diff, scoped Biome lint, LOC/function budgets, dead exports, godfiles, checker oracle, issue-spec, vacuity, verdict-oracle, done-status, and issue-index gates pass

No local Test262 corpus run was performed. `benchmarks/results/test262-run.log` and `scripts/equivalence-baseline.json` are unchanged.
