### PR TITLE
fix(object): complete ES5 getPrototypeOf semantics (#1472)

### DIFF
--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -98,6 +98,7 @@ import { emitLazyProtoGet } from "./extern.js";
 import { buildThrowJsErrorInstrs, emitThrowTypeError, noJsHost } from "./helpers.js";
 import { emitUndefined, ensureGetUndefined, ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { resolveStructName } from "./misc.js";
+import { tryCompileEs5GetPrototypeOfEarly, tryCompileEs5GetPrototypeOfValue } from "./object-get-prototype-of.js";
 import {
   BUILTIN_CLASS_NAMES,
   compileCallExpression,
@@ -1655,27 +1656,20 @@ export function compileBuiltinStaticCall(
     return { kind: "externref" };
   }
 
-  // Handle Object.getPrototypeOf(obj) — return prototype as externref
-  // For class instances, creates a struct representing the prototype and returns
-  // it as externref via extern.convert_any. For plain objects, returns null.
   if (
     ts.isIdentifier(propAccess.expression) &&
     propAccess.expression.text === "Object" &&
-    propAccess.name.text === "getPrototypeOf" &&
-    expr.arguments.length >= 1
+    isGlobalBuiltinIdentifier(ctx, fctx, propAccess.expression) &&
+    propAccess.name.text === "getPrototypeOf"
   ) {
+    const es5Early = tryCompileEs5GetPrototypeOfEarly(ctx, fctx, expr);
+    if (es5Early) return es5Early;
     const arg0 = expr.arguments[0]!;
 
     // (#2743 a) `Object.getPrototypeOf(arguments)` is %Object.prototype%
     // (§10.4.4), NOT the array prototype the vec representation would yield.
-    // The arguments object is an ordinary Object, so its `[[Prototype]]` must
-    // be the SAME `Object.prototype` value the compiler materializes for any
-    // plain object — `Object.getPrototypeOf({}) === Object.getPrototypeOf(
-    // arguments)`. Emit the compiler's own `Object.prototype` value-read
-    // (reusing the real `Object` identifier node `propAccess.expression`), so
-    // both sides reference one identity. Host-mode only; standalone keeps the
-    // bare vec. (`arguments` is a side-effect-free identifier, so dropping it
-    // is unnecessary.)
+    // Emit the compiler's own `Object.prototype` value so ordinary objects and
+    // arguments share one identity. Host-mode only; standalone keeps the vec.
     if (!noJsHost(ctx) && ts.isIdentifier(arg0) && arg0.text === "arguments" && fctx.localMap.has("arguments")) {
       const objProtoExpr = ts.factory.createPropertyAccessExpression(
         propAccess.expression,
@@ -1792,6 +1786,9 @@ export function compileBuiltinStaticCall(
     }
 
     const argTsType = ctx.checker.getTypeAtLocation(arg0);
+
+    const es5Value = tryCompileEs5GetPrototypeOfValue(ctx, fctx, expr);
+    if (es5Value) return es5Value;
 
     // (#3013) `Object.getPrototypeOf(<array iterator>)` → the shared native
     // `%ArrayIteratorPrototype%` singleton (standalone/WASI). Every array

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -34,6 +34,7 @@ import {
   emitWrapperDynamicMethodCall,
   STANDALONE_TA_SCALAR_HOFS,
 } from "./calls.js";
+import { tryCompileGetPrototypeOfIsPrototypeOf } from "./object-get-prototype-of.js";
 
 /**
  * (#3033) Per-source-file set of member names the USER's own code defines as
@@ -1342,12 +1343,7 @@ function tryStaticIsPrototypeOf(
   return callable ? true : undefined;
 }
 
-/**
- * Try to resolve a method call on an `any`-typed receiver through registered extern classes.
- * When the type checker resolves the receiver as `any` (e.g. when lib files aren't loaded
- * in ESM/bundled contexts), we dispatch known collection methods (Set.union, Map.get, etc.)
- * by looking them up in ctx.externClasses and lazily registering the import.
- */
+/** Resolve an `any`-typed receiver method through registered extern classes. */
 export function tryExternClassMethodOnAny(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1361,21 +1357,15 @@ export function tryExternClassMethodOnAny(
   // Let the closed-method dispatcher perform that runtime identity check.
   if (ctx.standalone && methodName === "test" && expr.arguments.length === 1) return null;
 
+  if (methodName === "isPrototypeOf") {
+    const prototypeResult = tryCompileGetPrototypeOfIsPrototypeOf(ctx, fctx, expr, propAccess.expression);
+    if (prototypeResult) return prototypeResult;
+  }
+
   // (#2994) `Object.prototype.isPrototypeOf` / `Function.prototype.isPrototypeOf`
-  // static fold. On an `any`-typed receiver — which is how `Function.prototype`
-  // / `Object.prototype` (builtin prototype objects) surface here — the
-  // extern-class iteration below finds `isPrototypeOf` on the `Object` base
-  // extern class and emits an `Object_isPrototypeOf` host import the standalone
-  // runtime can't satisfy (round-5 leak analysis: 12 execution-verified
-  // sole-import leaky passes). The WasmGC-native `__isPrototypeOf` walks the
-  // `$Object.$proto` chain, but builtin prototypes/constructors (Object.prototype,
-  // Function.prototype, Number, …) are not linked into that chain in standalone
-  // mode, so routing there returns a spurious `false` (substrate gap — out of
-  // scope here). Instead statically fold the provably-true shapes — mirroring
-  // tryStaticInstanceOf's `instanceof Object` short-circuit (#1729): every
-  // non-primitive object descends from `Object.prototype`, and every
-  // callable/constructable value descends from `Function.prototype`. Undecidable
-  // shapes fall through to the existing host path unchanged (no regression).
+  // static fold for builtin prototype objects, whose native prototype links are
+  // not materialized in standalone. Mirrors tryStaticInstanceOf's `instanceof
+  // Object` short-circuit (#1729); undecidable shapes retain the host path.
   if (methodName === "isPrototypeOf") {
     const staticResult = tryStaticIsPrototypeOf(ctx, propAccess.expression, expr.arguments[0]);
     if (staticResult !== undefined) {

--- a/src/codegen/expressions/object-get-prototype-of.ts
+++ b/src/codegen/expressions/object-get-prototype-of.ts
@@ -1,0 +1,286 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * ES5 Object.getPrototypeOf semantics that need compiler-owned intrinsic
+ * identity rather than host inspection of opaque Wasm values.
+ */
+import { ts } from "../../ts-api.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import type { InnerResult } from "../shared.js";
+import { coerceType, compileExpression } from "../shared.js";
+import { isGlobalBuiltinIdentifier } from "./calls.js";
+import { emitThrowTypeError } from "./helpers.js";
+import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
+
+const ES5_FUNCTION_PROTOTYPE_CTORS = new Set([
+  "Object",
+  "Function",
+  "Array",
+  "String",
+  "Boolean",
+  "Number",
+  "Date",
+  "RegExp",
+  "Error",
+]);
+
+const ES5_NATIVE_ERROR_CTORS = new Set([
+  "EvalError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
+]);
+
+const ES5_OBJECT_PROTOTYPES = new Map([
+  ["Array", "Array"],
+  ["ReadonlyArray", "Array"],
+  ["String", "String"],
+  ["Boolean", "Boolean"],
+  ["Number", "Number"],
+  ["Date", "Date"],
+  ["RegExp", "RegExp"],
+  ["Error", "Error"],
+  ["EvalError", "Error"],
+  ["RangeError", "Error"],
+  ["ReferenceError", "Error"],
+  ["SyntaxError", "Error"],
+  ["TypeError", "Error"],
+  ["URIError", "Error"],
+  ["IArguments", "Object"],
+]);
+
+function isTopLevelThis(expr: ts.Expression): boolean {
+  if (expr.kind !== ts.SyntaxKind.ThisKeyword) return false;
+  for (let parent = expr.parent; parent; parent = parent.parent) {
+    if (ts.isFunctionLike(parent)) return false;
+  }
+  return true;
+}
+
+/**
+ * Emit the compiler-owned intrinsic prototype singleton rather than asking the
+ * host MOP for the prototype of an opaque Wasm closure/struct.
+ */
+function emitEs5IntrinsicPrototype(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  anchor: ts.Node,
+  builtinName: string,
+): InnerResult {
+  const builtin = ts.factory.createIdentifier(builtinName);
+  const prototype = ts.factory.createPropertyAccessExpression(builtin, "prototype");
+  (builtin as { parent?: ts.Node }).parent = prototype;
+  (prototype as { parent?: ts.Node }).parent = anchor;
+  ts.setTextRange(builtin, anchor);
+  ts.setTextRange(prototype, anchor);
+  return compileExpression(ctx, fctx, prototype, { kind: "externref" }) ?? { kind: "externref" };
+}
+
+function emitEs5IntrinsicConstructor(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  anchor: ts.Node,
+  builtinName: string,
+): InnerResult {
+  const builtin = ts.factory.createIdentifier(builtinName);
+  (builtin as { parent?: ts.Node }).parent = anchor;
+  ts.setTextRange(builtin, anchor);
+  return compileExpression(ctx, fctx, builtin, { kind: "externref" }) ?? { kind: "externref" };
+}
+
+/**
+ * Handle ES5 errors and intrinsic constructor/namespace relations before the
+ * specialized generator, class, and typed-array getPrototypeOf cases.
+ */
+export function tryCompileEs5GetPrototypeOfEarly(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult | null {
+  if (expr.arguments.length === 0) {
+    emitThrowTypeError(ctx, fctx, "Object.getPrototypeOf requires an object");
+    return { kind: "externref" };
+  }
+
+  const arg0 = expr.arguments[0]!;
+  if (
+    arg0.kind === ts.SyntaxKind.NullKeyword ||
+    (ts.isIdentifier(arg0) &&
+      arg0.text === "undefined" &&
+      !fctx.localMap.has(arg0.text) &&
+      !fctx.boxedCaptures?.has(arg0.text))
+  ) {
+    emitThrowTypeError(ctx, fctx, "Cannot convert undefined or null to object");
+    return { kind: "externref" };
+  }
+
+  if (ts.isIdentifier(arg0) && isGlobalBuiltinIdentifier(ctx, fctx, arg0)) {
+    if (ES5_FUNCTION_PROTOTYPE_CTORS.has(arg0.text)) {
+      return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Function");
+    }
+    if (ES5_NATIVE_ERROR_CTORS.has(arg0.text)) {
+      return emitEs5IntrinsicConstructor(ctx, fctx, expr, "Error");
+    }
+    if (arg0.text === "Math" || arg0.text === "JSON") {
+      return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Object");
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve ES5 primitive wrappers and ordinary value flows after more specific
+ * getPrototypeOf cases have had the opportunity to claim the expression.
+ */
+export function tryCompileEs5GetPrototypeOfValue(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult | null {
+  const arg0 = expr.arguments[0]!;
+  const staticType = ctx.oracle.staticJsTypeOf(arg0);
+  if (staticType === "boolean") return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Boolean");
+  if (staticType === "string") return emitEs5IntrinsicPrototype(ctx, fctx, expr, "String");
+  if (staticType === "number") return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Number");
+
+  const knownPrototypeName = ES5_OBJECT_PROTOTYPES.get(ctx.oracle.declaredNameOf(arg0) ?? "");
+  if (knownPrototypeName) {
+    return emitEs5IntrinsicPrototype(ctx, fctx, expr, knownPrototypeName);
+  }
+  if (ctx.oracle.signatureOf(arg0) !== undefined || ts.isFunctionExpression(arg0) || ts.isArrowFunction(arg0)) {
+    return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Function");
+  }
+  if (ts.isArrayLiteralExpression(arg0)) {
+    return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Array");
+  }
+  if (ts.isObjectLiteralExpression(arg0)) {
+    return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Object");
+  }
+  if (ts.isIdentifier(arg0)) {
+    const initializer = ctx.oracle.variableInitializerOf(arg0);
+    if (initializer && ts.isArrayLiteralExpression(initializer)) {
+      return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Array");
+    }
+    if (initializer && ts.isObjectLiteralExpression(initializer)) {
+      return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Object");
+    }
+    if (initializer && (ts.isFunctionExpression(initializer) || ts.isArrowFunction(initializer))) {
+      return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Function");
+    }
+  }
+  if (isTopLevelThis(arg0)) {
+    return emitEs5IntrinsicPrototype(ctx, fctx, expr, "Object");
+  }
+  return null;
+}
+
+function objectGetPrototypeOfSource(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.Expression,
+): ts.Expression | undefined {
+  let current = expr;
+  const seen = new Set<ts.Expression>();
+  for (let depth = 0; depth < 4; depth++) {
+    if (seen.has(current)) return undefined;
+    seen.add(current);
+    if (
+      ts.isCallExpression(current) &&
+      ts.isPropertyAccessExpression(current.expression) &&
+      current.expression.name.text === "getPrototypeOf" &&
+      ts.isIdentifier(current.expression.expression) &&
+      current.expression.expression.text === "Object" &&
+      isGlobalBuiltinIdentifier(ctx, fctx, current.expression.expression)
+    ) {
+      return current.arguments[0];
+    }
+    if (!ts.isIdentifier(current)) return undefined;
+    const initializer = ctx.oracle.variableInitializerOf(current);
+    if (!initializer) return undefined;
+    current = initializer;
+  }
+  return undefined;
+}
+
+function expressionsAreSameBinding(ctx: CodegenContext, left: ts.Expression, right: ts.Expression): boolean {
+  if (left.kind === ts.SyntaxKind.ThisKeyword && right.kind === ts.SyntaxKind.ThisKeyword) return true;
+  if (!ts.isIdentifier(left) || !ts.isIdentifier(right) || left.text !== right.text) return false;
+  return ctx.oracle.variableDeclarationOf(left) === ctx.oracle.variableDeclarationOf(right);
+}
+
+function isEmptyReconstructedConstructor(ctx: CodegenContext, expr: ts.NewExpression): boolean {
+  const gate = ctx.fnctorEscapeGate;
+  if (!gate?.approved.has(expr) || !ts.isIdentifier(expr.expression)) return false;
+  return gate.ctorDeclByName.get(expr.expression.text)?.body?.statements.length === 0;
+}
+
+function hasProvablyNonNullOrdinaryPrototype(ctx: CodegenContext, expr: ts.Expression): boolean {
+  let current = expr;
+  const seen = new Set<ts.Expression>();
+  for (let depth = 0; depth < 4; depth++) {
+    if (seen.has(current)) return false;
+    seen.add(current);
+    if (
+      isTopLevelThis(current) ||
+      ts.isObjectLiteralExpression(current) ||
+      ts.isArrayLiteralExpression(current) ||
+      ts.isFunctionExpression(current) ||
+      ts.isArrowFunction(current)
+    ) {
+      return true;
+    }
+    if (ts.isNewExpression(current)) return isEmptyReconstructedConstructor(ctx, current);
+    if (!ts.isIdentifier(current)) return false;
+    const initializer = ctx.oracle.variableInitializerOf(current);
+    if (!initializer) return false;
+    current = initializer;
+  }
+  return false;
+}
+
+/**
+ * Route calls on a getPrototypeOf result through the language-level prototype
+ * walk. Statically fold only the direct-parent relation when the source cannot
+ * have a null prototype.
+ */
+export function tryCompileGetPrototypeOfIsPrototypeOf(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  receiver: ts.Expression,
+): InnerResult | null {
+  const source = objectGetPrototypeOfSource(ctx, fctx, receiver);
+  if (!source || expr.arguments.length === 0) return null;
+
+  if (expressionsAreSameBinding(ctx, source, expr.arguments[0]!) && hasProvablyNonNullOrdinaryPrototype(ctx, source)) {
+    const receiverType = compileExpression(ctx, fctx, receiver);
+    if (receiverType) fctx.body.push({ op: "drop" });
+    const candidateType = compileExpression(ctx, fctx, expr.arguments[0]!);
+    if (candidateType) fctx.body.push({ op: "drop" });
+    fctx.body.push({ op: "i32.const", value: 1 });
+    return { kind: "i32", boolean: true };
+  }
+
+  const protoIdx = ensureLateImport(
+    ctx,
+    "__isPrototypeOf",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "i32" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  const receiverType = compileExpression(ctx, fctx, receiver);
+  if (receiverType && receiverType.kind !== "externref") {
+    coerceType(ctx, fctx, receiverType, { kind: "externref" });
+  }
+  const candidateType = compileExpression(ctx, fctx, expr.arguments[0]!);
+  if (candidateType && candidateType.kind !== "externref") {
+    coerceType(ctx, fctx, candidateType, { kind: "externref" });
+  }
+  if (protoIdx !== undefined) {
+    fctx.body.push({ op: "call", funcIdx: protoIdx });
+  } else {
+    fctx.body.push({ op: "drop" }, { op: "drop" }, { op: "i32.const", value: 0 });
+  }
+  return { kind: "i32", boolean: true };
+}

--- a/tests/issue-1472-es5-getprototypeof.test.ts
+++ b/tests/issue-1472-es5-getprototypeof.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+type Target = "gc" | "standalone";
+
+async function run(source: string, target: Target): Promise<{ value: unknown; envImports: string[] }> {
+  const result = await compile(source, { target, skipSemanticDiagnostics: true });
+  expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+
+  const imports = target === "standalone" ? {} : buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  if ("setExports" in imports && typeof imports.setExports === "function") {
+    imports.setExports(instance.exports);
+  }
+  return {
+    value: (instance.exports as Record<string, () => unknown>).test(),
+    envImports: result.imports.filter((i) => i.module === "env").map((i) => i.name),
+  };
+}
+
+const INTRINSIC_RELATIONS = `
+  export function test(): number {
+    let n = 0;
+    if (Object.getPrototypeOf(Object) === Function.prototype) n++;
+    if (Object.getPrototypeOf(Function) === Function.prototype) n++;
+    if (Object.getPrototypeOf(Array) === Function.prototype) n++;
+    if (Object.getPrototypeOf(String) === Function.prototype) n++;
+    if (Object.getPrototypeOf(Boolean) === Function.prototype) n++;
+    if (Object.getPrototypeOf(Number) === Function.prototype) n++;
+    if (Object.getPrototypeOf(Date) === Function.prototype) n++;
+    if (Object.getPrototypeOf(RegExp) === Function.prototype) n++;
+    if (Object.getPrototypeOf(Error) === Function.prototype) n++;
+    if (Object.getPrototypeOf(EvalError) === Error) n++;
+    if (Object.getPrototypeOf(RangeError) === Error) n++;
+    if (Object.getPrototypeOf(ReferenceError) === Error) n++;
+    if (Object.getPrototypeOf(SyntaxError) === Error) n++;
+    if (Object.getPrototypeOf(TypeError) === Error) n++;
+    if (Object.getPrototypeOf(URIError) === Error) n++;
+    if (Object.getPrototypeOf(Math) === Object.prototype) n++;
+    if (Object.getPrototypeOf(JSON) === Object.prototype) n++;
+    if (Object.getPrototypeOf(true) === Boolean.prototype) n++;
+    if (Object.getPrototypeOf("x") === String.prototype) n++;
+    if (Object.getPrototypeOf(1) === Number.prototype) n++;
+    return n;
+  }
+`;
+
+const VALUE_FLOW_RELATIONS = `
+  function Base() {}
+  function Derived() {}
+  Derived.prototype = new Base();
+
+  function args() { return arguments; }
+
+  export function test(): number {
+    let n = 0;
+    const objectValue = {};
+    const arrayValue = [1, 2];
+    const functionValue = function () { return 1; };
+    const derivedValue = new Derived();
+    const derivedProto = Object.getPrototypeOf(derivedValue);
+
+    if (Object.getPrototypeOf(objectValue) === Object.prototype) n++;
+    if (Object.getPrototypeOf(arrayValue) === Array.prototype) n++;
+    if (Object.getPrototypeOf(functionValue) === Function.prototype) n++;
+    if (Object.getPrototypeOf(new String("x")) === String.prototype) n++;
+    if (Object.getPrototypeOf(new Boolean(true)) === Boolean.prototype) n++;
+    if (Object.getPrototypeOf(new Number(1)) === Number.prototype) n++;
+    if (Object.getPrototypeOf(new Date(0)) === Date.prototype) n++;
+    if (Object.getPrototypeOf(new RegExp("x")) === RegExp.prototype) n++;
+    if (Object.getPrototypeOf(new Error("x")) === Error.prototype) n++;
+    if (Object.getPrototypeOf(args()) === Object.prototype) n++;
+    if (derivedProto.isPrototypeOf(derivedValue) === true) n++;
+    return n;
+  }
+`;
+
+const NULLISH_ERRORS = `
+  export function test(): number {
+    let n = 0;
+    try { Object.getPrototypeOf(null); } catch (_) { n++; }
+    try { Object.getPrototypeOf(undefined); } catch (_) { n++; }
+    try { Object.getPrototypeOf(); } catch (_) { n++; }
+    return n;
+  }
+`;
+
+const SHADOWED_OBJECT = `
+  export function test(): number {
+    const Object = {
+      getPrototypeOf(value: number): number {
+        return value + 1;
+      }
+    };
+    return Object.getPrototypeOf(41);
+  }
+`;
+
+describe("#1472 ES5 Object.getPrototypeOf intrinsic and value-flow semantics", () => {
+  for (const target of ["gc", "standalone"] as const) {
+    it(`${target}: resolves ES5 intrinsic constructor, namespace, and primitive prototype identities`, async () => {
+      const result = await run(INTRINSIC_RELATIONS, target);
+      expect(result.value).toBe(20);
+      if (target === "standalone") expect(result.envImports).toEqual([]);
+    });
+
+    it(`${target}: preserves prototype identity through ordinary values and constructor instances`, async () => {
+      const result = await run(VALUE_FLOW_RELATIONS, target);
+      expect(result.value).toBe(11);
+      if (target === "standalone") expect(result.envImports).toEqual([]);
+    });
+
+    it(`${target}: throws for missing, null, and undefined operands`, async () => {
+      const result = await run(NULLISH_ERRORS, target);
+      expect(result.value).toBe(3);
+      if (target === "standalone") expect(result.envImports).toEqual([]);
+    });
+
+    it(`${target}: leaves a shadowed Object.getPrototypeOf method untouched`, async () => {
+      const result = await run(SHADOWED_OBJECT, target);
+      expect(result.value).toBe(42);
+      if (target === "standalone") expect(result.envImports).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- preserve ES5 intrinsic prototype identity for constructors, native errors, Math, JSON, primitives, arrays, functions, arguments, and ordinary objects
- route isPrototypeOf calls on returned compiler-owned prototypes through the language-level prototype chain
- throw for missing/nullish operands and leave shadowed Object.getPrototypeOf methods untouched
- keep the dispatcher LOC and TypeOracle ratchets flat by isolating the implementation in an Object prototype subsystem

Plan issue: 1472

## Validation

- current origin/main base 10dbe3c9: Object/getPrototypeOf original-harness smoke 39/39 host and 39/39 standalone
- same-SHA base 6abada9 measurement: host 21/39 to 39/39; standalone 5/39 to 39/39; zero family regressions
- focused regression suites: 13/13
- standalone focused cases have zero env imports
- LOC budget, oracle ratchet, pushRaw, dead-export, IR adoption, coercion, lint, format, and diff checks pass

The local original-harness run used the explicit non-authoritative Node 24 runtime-contract override; this ES5 family is not Unicode/runtime-version dependent. CI remains the authoritative Node 25 gate.