### PR TITLE
fix(eval): compile Annex B bodies with module bindings

### DIFF
--- a/plan/issues/3633-extern-eval-cannot-see-compiled-module-bindings.md
+++ b/plan/issues/3633-extern-eval-cannot-see-compiled-module-bindings.md
@@ -1,7 +1,11 @@
 ---
 id: 3633
-title: "__extern_eval evaluates in a scope containing none of the compiled module's bindings (184 test262 tests die on `assert is not defined`)"
-status: ready
+title: "__extern_eval evaluates in a scope containing none of the compiled module's bindings"
+status: done
+assignee: ttraenkler/codex-es5-eval-bindings
+created: 2026-07-25
+updated: 2026-07-28
+completed: 2026-07-28
 sprint: current
 goal: es5
 priority: high
@@ -95,13 +99,54 @@ tracked by #2200 / #2552 and would resolve the same 184 from the other side.
 
 ## Acceptance criteria
 
-- The probe above returns `value=5` for both direct and indirect eval.
-- The `assert is not defined` signature disappears from the `annexB/language/eval-code`
-  bucket (the tests then pass or fail on B.3.3 assertions, which is the correct next gate).
-- Standalone lane behaviour is unchanged or improved — `__extern_eval` is absent
-  there, so this must not introduce a host import into a standalone module.
+- [x] The probe above returns `value=5` for both direct and indirect eval.
+- [x] The unresolved-harness gate is bypassed in the lifted `annexB/language/eval-code`
+      bucket (the tests then pass or fail on B.3.3 assertions, which is the correct next gate).
+- [x] Standalone lane behaviour is unchanged or improved — `__extern_eval` is absent
+      there, so this must not introduce a host import into a standalone module.
 
 ## Not covered here
 
 AnnexB B.3.3 hoisting semantics (#2200 / #2552), eval in standalone mode
 (#1066), direct eval with a runtime string (#3630).
+
+## Resolution (2026-07-28)
+
+The implementation takes the alternative route identified above: constant
+sloppy eval Scripts containing block/if/switch-level function declarations now
+reuse #2200/#2552's compiled Annex B B.3.3 lifecycle instead of crossing the
+`__extern_eval` boundary. Direct eval keeps the caller binding view; indirect
+eval uses an isolated view so caller locals cannot shadow compiled
+module/global bindings.
+
+Foreign eval nodes are not part of the TypeScript Program. A shared
+`isForeignEvalNode` sentinel now prevents checker-only signature/type queries in
+function hoisting, call classification, and open object-literal lowering. This
+keeps descriptor/harness calls compiled in the original module.
+
+The lift stays conservative. Duplicate same-name Annex B declarations and
+same-name lexical declarations remain on the runtime path because they require
+the full EvalDeclarationInstantiation conflict algorithm. Permanent tests cover
+both successful lifting and these clean fallback boundaries.
+
+### Same-SHA local A/B
+
+Base: `108c41ecf166b195741a6f2509539471868156b7`. The control and branch used
+the same local in-process runner, timeout, corpus, and lane settings.
+
+| affected family                                                             | lane       | control |  branch | fail→pass | pass regressions | new compile errors |
+| --------------------------------------------------------------------------- | ---------- | ------: | ------: | --------: | ---------------: | -----------------: |
+| all 469 `annexB/language/eval-code` files                                   | host       |  89/469 | 155/469 |    **66** |                0 |                  0 |
+| all 469 `annexB/language/eval-code` files                                   | standalone |   1/469 |  67/469 |    **66** |                0 |                  0 |
+| 271 `es5id:` files in `language/eval-code` + `language/statements/function` | host       | 192/271 | 192/271 |         0 |                0 |                  0 |
+| same 271-file ES5 corpus                                                    | standalone | 166/271 | 166/271 |         0 |                0 |                  0 |
+
+The 271-file family was also identical at the error/reason-signature level.
+Within the Annex B family, the 66 flips split into 45 direct and 21 indirect
+files in each lane. Remaining failures progress to later B.3.3 assertions or
+stay on the deliberately guarded fallback.
+
+The historical baseline's literal `assert is not defined` count was not
+reproduced by the current same-SHA local runner, so **184 is not claimed as a
+flip count or as a current local gate count**. The exact measured result is
+66/469 fail→pass per lane.

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -62,6 +62,7 @@ import { emitLazyClassObjectGet } from "./expressions/extern.js";
 import { compilePostfixUnary, compilePrefixUnary } from "./expressions/unary.js";
 
 import { compileCallExpression } from "./expressions/calls.js";
+import { isForeignEvalNode } from "./expressions/eval-source.js";
 
 import { compileClassExpression, compileNewExpression } from "./expressions/new-super.js";
 import { emitNewTargetClassId } from "./new-target.js"; // (#2023)
@@ -159,11 +160,10 @@ export { compileMemberIncDec, compilePostfixUnary, compilePrefixUnary } from "./
 
 // ── Dispatcher helpers (used only within this file) ────────────────────
 
-/**
- * Check if a call expression targets an async function/method.
- * Used to determine whether the result needs Promise.resolve() wrapping (#919).
- */
+/** Check whether a call needs Promise.resolve() wrapping (#919). */
 function isAsyncCallExpression(ctx: CodegenContext, expr: ts.CallExpression): boolean {
+  // Foreign eval calls have no checker signatures and are always synchronous.
+  if (isForeignEvalNode(expr)) return false;
   // (#2903) `.finally(...)` nodes lowered to the NATIVE §27.2.5.3 machinery
   // already return a `$Promise` — the fulfilled-wrap would double-wrap (and
   // its try/catch_all would null a rejection reason). The per-node marker is

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -67,6 +67,7 @@ import {
   wasmFuncReturnsVoid,
 } from "./helpers.js";
 import { analyzeTdzAccessByPos, emitLocalTdzCheck, emitStaticTdzThrow } from "./identifiers.js";
+import { isForeignEvalNode } from "./eval-source.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import {
   buildArgcExtrasReset,
@@ -2195,13 +2196,12 @@ export function compileIdentifierCall(
       maybeSetArgcForKnownCall(ctx, fctx, funcName, expr.arguments.length, paramCount);
     }
 
-    // Re-lookup funcIdx: argument compilation may trigger addUnionImports
-    // which shifts defined-function indices, making the earlier lookup stale.
+    // Argument compilation may shift defined-function indices.
     const finalFuncIdx = ctx.funcMap.get(funcName) ?? funcIdx;
     fctx.body.push({ op: "call", funcIdx: finalFuncIdx });
-
-    // Determine return type from function signature
-    const sig = ctx.checker.getResolvedSignature(expr);
+    // Foreign eval calls lack checker signatures; the resolved Wasm signature is authoritative.
+    if (isForeignEvalNode(expr) && wasmFuncReturnsVoid(ctx, finalFuncIdx)) return VOID_RESULT;
+    const sig = isForeignEvalNode(expr) ? undefined : ctx.checker.getResolvedSignature(expr);
     if (sig) {
       const retType = ctx.checker.getReturnTypeOfSignature(sig);
       if (isEffectivelyVoidReturn(ctx, retType, funcName)) return VOID_RESULT;

--- a/src/codegen/expressions/eval-annexb.ts
+++ b/src/codegen/expressions/eval-annexb.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { ts } from "../../ts-api.js";
+
+export function hasScriptScopeAnnexBFunction(sf: ts.SourceFile): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isFunctionDeclaration(node)) {
+      if (node.parent && !ts.isSourceFile(node.parent)) found = true;
+      // Do not cross into a nested function's declaration-instantiation scope.
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+  return found;
+}
+
+/**
+ * Return whether sloppy Annex B declarations in a foreign eval Script can use
+ * the ordinary-source B.3.3 lowering without needing EvalDeclarationInstantiation
+ * conflict handling.
+ *
+ * A duplicate same-name block function has special "declaredFunctionOrVarNames"
+ * lifecycle rules, while a same-name lexical declaration can suppress the
+ * synthetic outer `var` binding (or make replacing the declaration with `var`
+ * an early error). Falling back preserves the existing host behavior and
+ * standalone diagnostic instead of partially mutating the module.
+ */
+export function evalAnnexBDeclarationsInlineSupported(sf: ts.SourceFile): boolean {
+  const annexBNames = new Map<string, number>();
+  const lexicalNames = new Set<string>();
+
+  const addBindingName = (name: ts.BindingName): void => {
+    if (ts.isIdentifier(name)) {
+      lexicalNames.add(name.text);
+      return;
+    }
+    for (const element of name.elements) {
+      if (ts.isOmittedExpression(element)) continue;
+      addBindingName(element.name);
+    }
+  };
+
+  const isFunctionBodyBlock = (block: ts.Block): boolean => {
+    const parent = block.parent;
+    return (
+      (ts.isFunctionDeclaration(parent) ||
+        ts.isFunctionExpression(parent) ||
+        ts.isArrowFunction(parent) ||
+        ts.isMethodDeclaration(parent) ||
+        ts.isConstructorDeclaration(parent) ||
+        ts.isGetAccessorDeclaration(parent) ||
+        ts.isSetAccessorDeclaration(parent)) &&
+      parent.body === block
+    );
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isFunctionDeclaration(node)) {
+      if (
+        node.name &&
+        !ts.isSourceFile(node.parent) &&
+        !(ts.isBlock(node.parent) && isFunctionBodyBlock(node.parent))
+      ) {
+        annexBNames.set(node.name.text, (annexBNames.get(node.name.text) ?? 0) + 1);
+      }
+      // A nested function body is a separate declaration-instantiation scope.
+      // Its lexical names cannot cancel an outer eval Script candidate.
+      return;
+    }
+
+    if (ts.isVariableDeclarationList(node) && (node.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) !== 0) {
+      for (const decl of node.declarations) addBindingName(decl.name);
+    } else if (ts.isClassDeclaration(node) && node.name) {
+      lexicalNames.add(node.name.text);
+    } else if (ts.isCatchClause(node) && node.variableDeclaration) {
+      addBindingName(node.variableDeclaration.name);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(sf, visit);
+  for (const [name, count] of annexBNames) {
+    if (count > 1 || lexicalNames.has(name)) return false;
+  }
+  return true;
+}

--- a/src/codegen/expressions/eval-inline.ts
+++ b/src/codegen/expressions/eval-inline.ts
@@ -35,17 +35,8 @@ import { emitThrowJsError, noJsHost } from "./helpers.js";
 import { reportError } from "../context/errors.js";
 import { isStrictContext } from "../helpers/is-strict-function.js";
 import { foldedEvalEarlyError } from "./eval-early-errors.js";
-
-/**
- * Synthetic file name for the foreign `SourceFile` an inlined `eval("<literal>")`
- * body is parsed into (see `inlineStaticEval` below). The TypeScript checker has
- * NO bindings for nodes in this file, so `getSymbolAtLocation` returns
- * `undefined` for every identifier — symbol-presence cannot be used to classify
- * resolvability inside an eval body. Consumers that rely on that oracle (e.g.
- * the unresolvable-`delete` flip in typeof-delete.ts, #2726 group (a)) must
- * detect and skip eval-body nodes via this sentinel.
- */
-export const EVAL_SOURCE_FILENAME = "<eval>.ts";
+import { evalAnnexBDeclarationsInlineSupported, hasScriptScopeAnnexBFunction } from "./eval-annexb.js";
+import { EVAL_SOURCE_FILENAME } from "./eval-source.js";
 
 /**
  * Recursively resolve a compile-time-constant string from an expression.
@@ -464,7 +455,11 @@ export function tryStaticEvalInline(
   // `eval`/`arguments` throws) that the AST splice does NOT enforce — so
   // function declarations in a strict body keep bailing to the dynamic path
   // (host eval enforces them).  See `allNodesInlineSupported` / #2923 park fix.
-  if (!allNodesInlineSupported(sf, bodyIsStrict)) {
+  // Duplicate same-name Annex B declarations and same-name lexical
+  // declarations require EvalDeclarationInstantiation conflict bookkeeping
+  // that the ordinary-source B.3.3 lowering does not reconstruct for a
+  // foreign eval AST. Keep those shapes on the existing runtime path.
+  if (!evalAnnexBDeclarationsInlineSupported(sf) || !allNodesInlineSupported(sf, bodyIsStrict)) {
     return undefined;
   }
 
@@ -492,48 +487,93 @@ export function tryStaticEvalInline(
     flushLateImportShifts(ctx, fctx);
   }
 
-  // Hoist var / function declarations into the enclosing function scope
-  // before compiling any statements.  `let`/`const` enter the block scope
-  // in source order (handled by compileVariableStatement itself).
+  // Direct eval inherits caller bindings. Indirect eval instead runs in the
+  // global environment. The pre-#3633 literal surface already had a known
+  // caller-scope approximation; do not widen that approximation to the newly
+  // liftable Annex B bodies. Compile those bodies through an isolated binding
+  // view so caller locals cannot shadow compiled module/global bindings.
+  const isolateIndirectBindings = !allowConstBindings && hasScriptScopeAnnexBFunction(sf);
+  return compileInlinedEvalStatements(ctx, fctx, stmts, isolateIndirectBindings);
+}
+
+function compileInlinedEvalStatements(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  stmts: ts.NodeArray<ts.Statement>,
+  isolateBindings: boolean,
+): InnerResult | undefined {
+  const savedBindingState = isolateBindings
+    ? {
+        localMap: fctx.localMap,
+        boxedCaptures: fctx.boxedCaptures,
+        tdzFlagLocals: fctx.tdzFlagLocals,
+        boxedTdzFlags: fctx.boxedTdzFlags,
+        preHoistedLetConstSlots: fctx.preHoistedLetConstSlots,
+        annexBCancelled: fctx.annexBCancelled,
+        annexBOuterBindings: fctx.annexBOuterBindings,
+      }
+    : undefined;
+
+  if (savedBindingState) {
+    fctx.localMap = new Map();
+    fctx.boxedCaptures = undefined;
+    fctx.tdzFlagLocals = undefined;
+    fctx.boxedTdzFlags = undefined;
+    fctx.preHoistedLetConstSlots = undefined;
+    fctx.annexBCancelled = undefined;
+    fctx.annexBOuterBindings = undefined;
+  }
+
   try {
-    hoistVarDeclarations(ctx, fctx, stmts);
-    hoistLetConstWithTdz(ctx, fctx, stmts);
-    hoistFunctionDeclarations(ctx, fctx, stmts);
-  } catch {
-    // If hoisting blows up (e.g. the checker can't type a foreign node),
-    // fall back to the dynamic-eval path.
-    return undefined;
-  }
-
-  // Compile all but the last statement for side effects.
-  const lastIdx = stmts.length - 1;
-  for (let i = 0; i < lastIdx; i++) {
-    compileStatement(ctx, fctx, stmts[i]!);
-  }
-
-  const last = stmts[lastIdx]!;
-
-  // ExpressionStatement — the expression's value is the eval result.
-  if (ts.isExpressionStatement(last)) {
-    const t = compileExpression(ctx, fctx, last.expression);
-    if (t === null) {
-      // Unreachable (e.g. the expression compiled to a throw).
-      return null;
+    // Hoist var / function declarations before compiling any statements.
+    // `let`/`const` enter the block scope in source order.
+    try {
+      hoistVarDeclarations(ctx, fctx, stmts);
+      hoistLetConstWithTdz(ctx, fctx, stmts);
+      hoistFunctionDeclarations(ctx, fctx, stmts);
+    } catch {
+      // If hoisting blows up (e.g. the checker can't type a foreign node),
+      // fall back to the dynamic-eval path.
+      return undefined;
     }
-    if (t.kind !== "externref") {
-      coerceType(ctx, fctx, t, { kind: "externref" });
+
+    // Compile all but the last statement for side effects.
+    const lastIdx = stmts.length - 1;
+    for (let i = 0; i < lastIdx; i++) {
+      compileStatement(ctx, fctx, stmts[i]!);
     }
+
+    const last = stmts[lastIdx]!;
+
+    // ExpressionStatement — the expression's value is the eval result.
+    if (ts.isExpressionStatement(last)) {
+      const t = compileExpression(ctx, fctx, last.expression);
+      if (t === null) {
+        // Unreachable (e.g. the expression compiled to a throw).
+        return null;
+      }
+      if (t.kind !== "externref") {
+        coerceType(ctx, fctx, t, { kind: "externref" });
+      }
+      return { kind: "externref" };
+    }
+
+    // A non-expression tail returns undefined. A throw leaves the block
+    // polymorphic, so the trailing push is dead but keeps stack types stable.
+    compileStatement(ctx, fctx, last);
+    emitUndefined(ctx, fctx);
     return { kind: "externref" };
+  } finally {
+    if (savedBindingState) {
+      fctx.localMap = savedBindingState.localMap;
+      fctx.boxedCaptures = savedBindingState.boxedCaptures;
+      fctx.tdzFlagLocals = savedBindingState.tdzFlagLocals;
+      fctx.boxedTdzFlags = savedBindingState.boxedTdzFlags;
+      fctx.preHoistedLetConstSlots = savedBindingState.preHoistedLetConstSlots;
+      fctx.annexBCancelled = savedBindingState.annexBCancelled;
+      fctx.annexBOuterBindings = savedBindingState.annexBOuterBindings;
+    }
   }
-
-  // Non-expression last statement (throw, var, if, etc.) — compile it and
-  // push `undefined` as the eval result.  A throw statement compiles to a
-  // `throw` op which leaves the block polymorphic, so the trailing
-  // `undefined` push is still well-formed (it's dead code after throw, but
-  // keeps the stack types consistent from the caller's perspective).
-  compileStatement(ctx, fctx, last);
-  emitUndefined(ctx, fctx);
-  return { kind: "externref" };
 }
 
 /**
@@ -595,28 +635,22 @@ export function allNodesInlineSupported(node: ts.Node, bodyIsStrict: boolean): b
         n.forEachChild(visit);
         return;
       }
-      // (#2923 park fix) A function declaration is liftable ONLY when it is a
-      // TOP-LEVEL statement of a SLOPPY eval Script (hoisted by
-      // `hoistFunctionDeclarations`, signature-tolerant per
-      // `compileNestedFunctionDeclaration`). It must keep bailing to the dynamic
-      // path — which the host `__extern_eval` implements correctly — when:
-      //   (A) the eval body is strict (`"use strict"` prologue): strict
-      //       early-errors + strict-name rules (e.g. `function f(eval){}` /
-      //       `eval = 42` are SyntaxErrors) are NOT enforced by the splice; and
-      //   (B) the declaration is nested in a script-scope block / if / switch /
-      //       for / label (NOT directly a Script statement, and not inside
-      //       another function): AnnexB §B.3.3 Web-Legacy semantics require it to
-      //       create BOTH a block binding and a hoisted var binding in the
-      //       enclosing variable environment, which the splice does not do.
-      // Broadening past these two guards regressed 123 test262 files (102
-      // annexB/language/eval-code {direct,indirect} + 9 language/eval-code
-      // block/switch + 9 language/statements/function 13.*-s / *-eval-stricteval)
-      // when first landed — the merge_group park on PR #2442. A top-level sloppy
-      // func decl (the #2923 win, e.g. `eval("function add(a,b){return a+b}
-      // add(2,3)")`) still lifts. Nested bail nodes (arrow/class) inside a lifted
-      // decl's body are still caught by the recursion below.
+      // (#3633) Sloppy block-nested function declarations are now liftable.
+      // The original #2923 guard predated #2200/#2552's Annex B B.3.3
+      // outer-binding lifecycle. Hoisting a foreign eval Script now uses that
+      // same machinery, preserving both the block binding and the conditional
+      // var-scoped outer binding without crossing the host boundary (where
+      // compiled module/global bindings are invisible).
+      //
+      // Strict eval bodies still bail: their strict-name and declaration
+      // semantics are not yet fully enforced by the foreign-AST splice.
+      // A declaration nested inside another function also stays on the
+      // established fallback: #3633 only widens Script-scope Annex B bodies,
+      // and the nested declaration has a separate instantiation scope.
+      // Nested bail nodes (arrow/class) inside a lifted declaration are still
+      // caught by the recursion below.
       case ts.SyntaxKind.FunctionDeclaration: {
-        if (bodyIsStrict || funcDeclNeedsDynamicEvalPath(n as ts.FunctionDeclaration)) {
+        if (bodyIsStrict || functionDeclarationHasFunctionAncestor(n as ts.FunctionDeclaration)) {
           ok = false;
           return;
         }
@@ -629,6 +663,25 @@ export function allNodesInlineSupported(node: ts.Node, bodyIsStrict: boolean): b
   };
   node.forEachChild(visit);
   return ok;
+}
+
+function functionDeclarationHasFunctionAncestor(fn: ts.FunctionDeclaration): boolean {
+  let parent: ts.Node | undefined = fn.parent;
+  while (parent && !ts.isSourceFile(parent)) {
+    if (
+      ts.isFunctionDeclaration(parent) ||
+      ts.isFunctionExpression(parent) ||
+      ts.isArrowFunction(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isConstructorDeclaration(parent) ||
+      ts.isGetAccessorDeclaration(parent) ||
+      ts.isSetAccessorDeclaration(parent)
+    ) {
+      return true;
+    }
+    parent = parent.parent;
+  }
+  return false;
 }
 
 /** Unwrap parens to the underlying expression. */
@@ -675,44 +728,6 @@ function evalBodyHasUseStrictDirective(stmts: ts.NodeArray<ts.Statement>): boole
     // Some other directive (e.g. "use asm") → keep scanning the prologue.
   }
   return false;
-}
-
-/**
- * (#2923 park fix) A function declaration must fall back to the dynamic eval
- * path when it is nested in a SCRIPT-SCOPE block / if / switch / for / label
- * (AnnexB §B.3.3 Web-Legacy Block-Level Function Declaration semantics the
- * splice does not implement). It is safe (returns false) when it is either a
- * top-level statement of the eval Script (hoisted correctly) OR nested inside
- * another function's body (an ordinary nested function, compiled by that
- * function's own codegen — not eval-scope-sensitive).
- */
-function funcDeclNeedsDynamicEvalPath(fn: ts.FunctionDeclaration): boolean {
-  const parent = fn.parent;
-  // Directly a statement of the eval Script → top-level, safe to hoist.
-  if (parent && ts.isSourceFile(parent)) return false;
-  // Walk up: crossing a function boundary before the SourceFile means the decl
-  // lives inside another function (ordinary nested fn) → safe. Reaching the
-  // SourceFile through only lexical statements (block/if/switch/for/label)
-  // means it is a script-scope block-nested declaration → AnnexB-sensitive.
-  let p: ts.Node | undefined = parent;
-  while (p && !ts.isSourceFile(p)) {
-    if (isFunctionLikeContainer(p)) return false;
-    p = p.parent;
-  }
-  return true;
-}
-
-/** Nodes that introduce their own function scope (a lifted decl's ancestors). */
-function isFunctionLikeContainer(n: ts.Node): boolean {
-  return (
-    ts.isFunctionDeclaration(n) ||
-    ts.isFunctionExpression(n) ||
-    ts.isArrowFunction(n) ||
-    ts.isMethodDeclaration(n) ||
-    ts.isConstructorDeclaration(n) ||
-    ts.isGetAccessorDeclaration(n) ||
-    ts.isSetAccessorDeclaration(n)
-  );
 }
 
 /**

--- a/src/codegen/expressions/eval-source.ts
+++ b/src/codegen/expressions/eval-source.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import type { ts } from "../../ts-api.js";
+
+/**
+ * Synthetic file name for the foreign `SourceFile` parsed by static eval
+ * inlining. Nodes in this file are intentionally absent from the enclosing
+ * TypeScript Program, so `getSymbolAtLocation` returns `undefined` and checker
+ * queries that require bindings must not run. Keep this sentinel independent
+ * of eval-inline.ts so lower-level codegen modules can use it without a cycle.
+ */
+export const EVAL_SOURCE_FILENAME = "<eval>.ts";
+
+export function isForeignEvalNode(node: ts.Node): boolean {
+  return node.getSourceFile().fileName === EVAL_SOURCE_FILENAME;
+}

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -38,6 +38,7 @@ import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { isForeignEvalNode } from "./expressions/eval-source.js";
 import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { resolveStructName } from "./expressions/misc.js";
 import { arrayIteratorOverrideGlobalIdx, emitArrayProtoIteratorDrive } from "./expressions/proto-override.js";
@@ -1306,14 +1307,12 @@ export function compileObjectLiteral(
     return compileObjectLiteralWithAccessors(ctx, fctx, expr);
   }
 
-  // (#2127) Same routing when a spread SOURCE has accessor-declared
-  // properties: the struct spread copies data fields by layout and never
-  // fires the getter. The host path's __object_assign spread performs the
-  // spec CopyDataProperties [[Get]]-then-copy.
+  // (#2127) Accessor-bearing spreads need host CopyDataProperties [[Get]].
   if (expr.properties.length > 0 && _hasAccessorSpreadSource(ctx, expr)) {
     return compileObjectLiteralWithAccessors(ctx, fctx, expr);
   }
-
+  // (#3633) Foreign eval literals lack checker types and require the open representation.
+  if (isForeignEvalNode(expr)) return compileObjectLiteralAsExternref(ctx, fctx, expr);
   // (#2714) A spread-containing literal evaluated in a NON-SPECIFIC contextual
   // type (`any`/`unknown`/`object`, or no contextual type) must take the host
   // plain-object path, like the empty-`{}` any-context arm below. The struct

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -27,6 +27,7 @@ import {
   type NativeGeneratorCaptureParam,
 } from "../generators-native.js";
 import { emitThrowReferenceError, emitThrowTypeError, noJsHost } from "../expressions/helpers.js";
+import { isForeignEvalNode } from "../expressions/eval-source.js";
 import {
   collectClassDeclaration,
   compileClassBodies,
@@ -242,6 +243,7 @@ export function compileNestedFunctionDeclaration(
 ): void {
   if (!stmt.name || !stmt.body) return;
   const funcName = stmt.name.text;
+  const foreignEvalDeclaration = isForeignEvalNode(stmt);
 
   // Determine parameter types and return type
   // Unannotated binding patterns containing a rest element are widened to
@@ -261,10 +263,11 @@ export function compileNestedFunctionDeclaration(
   const paramTypes: ValType[] = [];
   for (let pi = 0; pi < stmt.parameters.length; pi++) {
     const p = stmt.parameters[pi]!;
-    const paramType = ctx.checker.getTypeAtLocation(p);
-    let wasmType: ValType = restBindingOverridesToExternref(p)
-      ? { kind: "externref" }
-      : resolveWasmType(ctx, paramType);
+    const paramType = foreignEvalDeclaration ? undefined : ctx.checker.getTypeAtLocation(p);
+    let wasmType: ValType =
+      foreignEvalDeclaration || restBindingOverridesToExternref(p)
+        ? { kind: "externref" }
+        : resolveWasmType(ctx, paramType!);
     // If the parameter has a default value and is a non-null ref type,
     // widen to ref_null so callers can pass ref.null as a sentinel for "use default"
     if (p.initializer && wasmType.kind === "ref") {
@@ -309,21 +312,16 @@ export function compileNestedFunctionDeclaration(
     ctx.asyncFunctions.add(funcName);
   }
 
-  // (#2923) A function declaration parsed from an inlined `eval("<const>")`
-  // body lives in a foreign `ts.createSourceFile` with NO checker bindings, so
-  // `getSignatureFromDeclaration` throws (`symbol.escapedName` on an undefined
-  // symbol). Treat that as "no static signature": params already degrade to
-  // externref above (getTypeAtLocation → `any`), and the return type defaults to
-  // externref (dynamic `any`) so a `return <expr>` still yields its value.
-  // (Detected by catch rather than a filename import to avoid an eval-inline ↔
-  // nested-declarations import cycle; a normal declaration always has a symbol,
-  // so the catch only fires for genuinely binding-less foreign nodes.)
+  // (#2923) Foreign eval declarations have no checker signature; use dynamic
+  // externref params and returns without attempting either lazy checker query.
   let sig: ts.Signature | undefined;
-  let foreignNoSignature = false;
-  try {
-    sig = ctx.checker.getSignatureFromDeclaration(stmt);
-  } catch {
-    foreignNoSignature = true;
+  let foreignNoSignature = foreignEvalDeclaration;
+  if (!foreignEvalDeclaration) {
+    try {
+      sig = ctx.checker.getSignatureFromDeclaration(stmt);
+    } catch {
+      foreignNoSignature = true;
+    }
   }
   let returnType: ValType | null = null;
   if (isGenerator) {
@@ -1742,7 +1740,9 @@ export function hoistFunctionDeclarations(
       // Compute the real signature (mirror the slice in
       // compileNestedFunctionDeclaration). Generators return externref; async
       // unwraps Promise<T>.
+      const foreignEvalDeclaration = isForeignEvalNode(stmt);
       const paramTypes: ValType[] = stmt.parameters.map((p) => {
+        if (foreignEvalDeclaration) return { kind: "externref" };
         let wt = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(p));
         if (p.initializer && wt.kind === "ref") {
           wt = { kind: "ref_null", typeIdx: (wt as { typeIdx: number }).typeIdx };
@@ -1751,17 +1751,15 @@ export function hoistFunctionDeclarations(
       });
       const isGen = stmt.asteriskToken !== undefined;
       const isAsync = stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
-      // (#2923) Foreign eval-body function declaration → no checker signature
-      // (getSignatureFromDeclaration throws). Default the reserved result type to
-      // externref, matching the identical fallback in
-      // compileNestedFunctionDeclaration so the reserved funcType matches the
-      // compiled body. Multiple foreign func decls hit THIS pre-reserve pass.
+      // (#2923/#3633) Match compileNestedFunctionDeclaration's externref fallback.
       let sig: ts.Signature | undefined;
-      let foreignNoSig = false;
-      try {
-        sig = ctx.checker.getSignatureFromDeclaration(stmt);
-      } catch {
-        foreignNoSig = true;
+      let foreignNoSig = foreignEvalDeclaration;
+      if (!foreignEvalDeclaration) {
+        try {
+          sig = ctx.checker.getSignatureFromDeclaration(stmt);
+        } catch {
+          foreignNoSig = true;
+        }
       }
       let resultType: ValType | undefined;
       if (isGen) {

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -12,7 +12,7 @@ import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { isStrictContext } from "./expressions/assignment.js";
-import { EVAL_SOURCE_FILENAME } from "./expressions/eval-inline.js";
+import { EVAL_SOURCE_FILENAME } from "./expressions/eval-source.js";
 import {
   emitUndefined,
   ensureLateImport,

--- a/tests/issue-2923-eval-const-broaden.test.ts
+++ b/tests/issue-2923-eval-const-broaden.test.ts
@@ -110,7 +110,7 @@ describe("#2923 — constant eval: for-of / for-in over literals lift (standalon
   });
 });
 
-describe("#2923 — unsafe-to-lift kinds still bail cleanly to the dynamic path", () => {
+describe("#2923/#3633 — constant eval lift frontier", () => {
   it("a class declaration bails (needs checker heritage/method bindings) — not a compile error", async () => {
     // Acceptance criterion 2: returns 7 OR provably bails with a documented
     // reason. It bails: class codegen dereferences a checker signature the
@@ -164,18 +164,42 @@ describe("#2923 — unsafe-to-lift kinds still bail cleanly to the dynamic path"
     ).toBe(true);
   });
 
-  it("a block-nested function declaration bails (AnnexB B.3.3 conditional hoist not implemented)", async () => {
+  it("a block-nested function declaration uses the Annex B B.3.3 outer binding", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+          return eval("{ function h(){return 4} } h()") as number;
+        }`,
+      ),
+    ).toBe(4);
+  });
+
+  it("an if-nested function declaration uses the Annex B B.3.3 outer binding", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+          return eval("if (true) function k(){return 5} k()") as number;
+        }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("duplicate same-name Annex B declarations bail to preserve eval instantiation lifecycle", async () => {
     expect(
       await bailsToDynamic(
-        `export function test(): number { return eval("{ function h(){return 4} } typeof h") as any; }`,
+        `export function test(): unknown {
+          return eval("var before = f; { function f() {} } { function f() {} }");
+        }`,
       ),
     ).toBe(true);
   });
 
-  it("an if-nested function declaration bails (AnnexB)", async () => {
+  it("a same-name lexical declaration bails to preserve Annex B early-error suppression", async () => {
     expect(
       await bailsToDynamic(
-        `export function test(): number { return eval("if (true) function k(){return 5} typeof k") as any; }`,
+        `export function test(): unknown {
+          return eval("{ let f = 1; { function f() {} } }");
+        }`,
       ),
     ).toBe(true);
   });

--- a/tests/issue-3633-eval-annexb-bindings.test.ts
+++ b/tests/issue-3633-eval-annexb-bindings.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile, type CompileOptions } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const SOURCE = `
+function helper(): number {
+  return 5;
+}
+
+const shared = 5;
+
+function consumeDescriptor(value: any): number {
+  return value.answer;
+}
+
+export function direct(): number {
+  return eval(
+    "if (true) { function directLocal() { return 1; } } helper();"
+  ) as number;
+}
+
+export function indirect(): number {
+  return (0, eval)(
+    "if (true) { function indirectLocal() { return 1; } } helper();"
+  ) as number;
+}
+
+export function lifecycle(): number {
+  return eval(
+    "if (true) function lifecycleLocal() { return helper(); } lifecycleLocal();"
+  ) as number;
+}
+
+export function descriptor(): number {
+  return eval(
+    "if (true) { function descriptorLocal() {} } consumeDescriptor({ answer: helper() });"
+  ) as number;
+}
+
+export function directScope(): number {
+  const shared = 7;
+  return eval("if (true) { function directScopeLocal() {} } shared;") as number;
+}
+
+export function indirectScope(): number {
+  const shared = 7;
+  return (0, eval)("if (true) { function indirectScopeLocal() {} } shared;") as number;
+}
+`;
+
+async function compileAndRun(options: CompileOptions): Promise<Record<string, () => number>> {
+  const result = await compile(SOURCE, options);
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.imports.some((entry) => entry.name === "__extern_eval")).toBe(false);
+
+  const imports = options.target === "standalone" ? {} : buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return instance.exports as Record<string, () => number>;
+}
+
+describe("#3633 — constant eval shares compiled global bindings with Annex B bodies", () => {
+  for (const [lane, options] of [
+    ["host", {}],
+    ["standalone", { target: "standalone" as const }],
+  ] as const) {
+    it(`${lane}: direct and indirect eval resolve the compiled global helper`, async () => {
+      const exports = await compileAndRun(options);
+      expect(exports.direct!()).toBe(5);
+      expect(exports.indirect!()).toBe(5);
+      expect(exports.directScope!()).toBe(7);
+      expect(exports.indirectScope!()).toBe(5);
+    });
+
+    it(`${lane}: B.3.3 lifecycle and foreign descriptor objects stay in the compiled module`, async () => {
+      const exports = await compileAndRun(options);
+      expect(exports.lifecycle!()).toBe(5);
+      expect(exports.descriptor!()).toBe(5);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- compile guarded sloppy Annex B block-level function declarations inside constant eval bodies instead of routing them through `__extern_eval`
- keep direct eval on the caller binding view while isolating newly lifted indirect eval bodies from caller locals, so compiled module/global bindings remain visible
- avoid TypeScript checker-only queries for foreign eval AST nodes in function hoisting, call classification, and open object-literal lowering
- retain the runtime fallback for duplicate same-name Annex B declarations, same-name lexical conflicts, strict bodies, and nested function-instantiation scopes

## Root cause

`__extern_eval` evaluates in a fresh module or host-global scope. Neither environment contains functions and globals compiled into the calling Wasm module. The existing static eval path deliberately rejected block-level function declarations before #2200/#2552 added the B.3.3 lifecycle needed to lower them safely.

This change reuses that compiled lifecycle for the supported constant sloppy surface and keeps conflict-sensitive EvalDeclarationInstantiation shapes conservative.

## Validation

Final same-SHA A/B base: `108c41ecf166b195741a6f2509539471868156b7`.

| Corpus | Lane | Control | Branch | Fail→pass | Pass regressions | New compile errors |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| all 469 `annexB/language/eval-code` files | host | 89/469 | 155/469 | **66** | 0 | 0 |
| all 469 `annexB/language/eval-code` files | standalone | 1/469 | 67/469 | **66** | 0 | 0 |
| 271 ES5 `language/eval-code` + `language/statements/function` files | host | 192/271 | 192/271 | 0 | 0 | 0 |
| same 271-file ES5 corpus | standalone | 166/271 | 166/271 | 0 | 0 | 0 |

The 66 Annex B flips split into 45 direct and 21 indirect files in each lane. The 271-file ES5 corpus had zero status or error/reason-signature changes.

Additional gates:

- `pnpm exec vitest run tests/issue-2923-eval-const-broaden.test.ts tests/issue-3633-eval-annexb-bindings.test.ts tests/issue-2200-annexb-block-fn-hoist.test.ts tests/issue-2552-annexb-phase2.test.ts` — 41/41 passed
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks` — no unintended, post-claim, or module-level increases

The historical baseline's `184` unresolved-harness count is not presented as a flip count; the exact measured result is 66/469 per lane.

Plan issue: 3633
