### PR TITLE
fix(bench): calibrate the optimized-tier signature instead of hardcoding V8 bits

### DIFF
--- a/plan/issues/3777-warm-bench-js-lane-degrades-on-node26.md
+++ b/plan/issues/3777-warm-bench-js-lane-degrades-on-node26.md
@@ -1,0 +1,98 @@
+---
+id: 3777
+title: "warm-chart JS lane runs ~15x slower through the benchmark harness than the same source at top level — Node 26 only, and it degrades DURING the measured rounds"
+status: ready
+sprint: current
+created: 2026-07-28
+updated: 2026-07-28
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: tooling
+goal: performance
+depends_on: []
+related: [3724, 3726, 3730, 3732, 3759, 3769]
+---
+
+# #3777 — warm-chart JS lane degrades ~15x on Node 26, inside the harness only
+
+## Summary
+
+The landing-page "warm speed" chart's **JS baseline is inflated on CI**, which
+flatters every wasm:js ratio it publishes. The function is genuinely
+TurboFan-optimized (verified — see below), so this is **not** the tiering
+problem #3759/#3769 chased. It is specific to the harness path *and* to
+Node 26.
+
+Same source, same engine, tier verified in both cases:
+
+| measured via                                   | Node 22 | Node 26      |
+| ---------------------------------------------- | ------- | ------------ |
+| plain top-level script                          | 310 µs  | 349 µs       |
+| **`scripts/no-jit-bench-child.mjs`** (the chart) | 323 µs  | **5107 µs**  |
+
+Node 22 shows no gap. Node 26 shows ~15x. CI runs Node 26, which is why the
+published `loop.ts` JS figure has been ~5290 µs while the same source measured
+~350 µs anywhere else.
+
+## It is not the tier, and not the factory
+
+- **Not the tier.** `%GetOptimizationStatus` reports the calibrated
+  optimized signature both before and after the measured rounds. (The earlier
+  "maglev" reading in #3769 was a decoding bug — bit positions shift between
+  V8 releases; see that PR's revert note.)
+- **Not `new Function`.** Loading through the factory and optimizing *inside*
+  it (what the harness does) vs. returning a plain function and optimizing it
+  from the caller's scope both measure ~338 µs on Node 26 in isolation.
+
+## The real tell: it degrades mid-measurement
+
+`calibrate(fn)` derives its iteration count by running the function for 100 ms.
+On the failing runs it returns `iters = 882`, which back-solves to roughly
+**340 µs per call** — i.e. *calibration saw the fast function*. The measured
+rounds that follow then report **5107 µs per call** for the same function in
+the same process.
+
+So the function starts fast and becomes slow partway through. The harness makes
+~10,000 calls in total (80 warm-ups + ~294 during calibrate + 11 rounds × 882),
+against ~90 in a direct probe — so the trigger is plausibly call-count or
+duration dependent, and a short probe cannot reproduce it.
+
+## Why it matters
+
+The chart's whole purpose is an honest wasm-vs-JS ratio. An inflated JS
+baseline biases every row in wasm's favour, and it is invisible without
+cross-checking against a second measurement path. It also means any
+wasm-vs-JS conclusion drawn from the published chart on Node 26 — including
+recent `loop.ts` and `array.ts` comparisons — should be re-derived once this
+is fixed.
+
+## Suggested investigation
+
+1. Log `%GetOptimizationStatus` per measured round (not just before/after) to
+   find the exact round where it changes, and whether a deopt/re-opt cycle is
+   visible.
+2. Try `--trace-deopt` / `--trace-opt` on the child under Node 26 to name the
+   deopt reason.
+3. Bisect the harness protocol: does it reproduce with fewer rounds? With
+   `calibrate` skipped and a fixed `iters`? With the warm-up loop removed?
+   That isolates whether it is call-count, wall-time, or protocol-shape driven.
+4. Check whether the wasm lane has the analogue (its variance is ~0.02%, which
+   suggests not, but it should be confirmed rather than assumed).
+
+## Acceptance criteria
+
+- [ ] The harness and a plain top-level script agree within noise on Node 26
+      for the same source, as they already do on Node 22.
+- [ ] Root cause named (deopt reason, or protocol interaction), not just
+      worked around.
+- [ ] The published chart's JS column is re-derived and the wasm:js ratios
+      restated.
+
+## Provenance
+
+Found while fixing #3769's incorrect maglev diagnosis. A real Node 26 was
+downloaded to this sandbox to reproduce CI's engine directly; every number
+above is measured on both runtimes side by side rather than inferred.

--- a/scripts/generate-playground-benchmark-sidebar.mjs
+++ b/scripts/generate-playground-benchmark-sidebar.mjs
@@ -88,21 +88,19 @@ const BENCHMARKS = [
 //                               compile actually completes relative to the
 //                               calling code). NOT what fixes the fatal
 //                               crash below; see `buildWarmJsFactorySource`.
-//   --no-maglev                 makes TurboFan the ONLY optimizing tier, so
-//                               `%OptimizeFunctionOnNextCall` cannot settle on
-//                               Maglev (V8's mid-tier) and call it done.
-//                               Maglev defaults OFF on Node 22 but ON on Node
-//                               26, so the same source tiered to TurboFan
-//                               locally and to Maglev on CI — which is why the
-//                               chart's JS baseline read ~5290us there against
-//                               ~374us here, flattering every wasm:js ratio.
-//                               The #3759 tier assertion caught this exactly:
-//                               CI reported status 41 (isFunction, maybeDeopted,
-//                               maglev) with the `optimized` bit CLEAR. A "warm"
-//                               chart should mean peak optimized tier, so pin it
-//                               rather than accept whichever tier the engine's
-//                               defaults happen to pick this release.
-const JS_WARM_FLAGS = ["--allow-natives-syntax", "--no-concurrent-recompilation", "--no-maglev"];
+//
+// NOTE — `--no-maglev` was added here (#3769) on the theory that CI's JS lane
+// was settling on Maglev, and has been REMOVED: that diagnosis was wrong and
+// the flag was inert. The evidence for "maglev" was the #3759 assertion
+// reporting status 41, decoded with `%GetOptimizationStatus` bit positions
+// hardcoded from Node 22. Those positions shift between V8 releases
+// (`kOptimized` 1<<4 -> 1<<3, `kTurboFanned` 1<<6 -> 1<<5), so on Node 26
+// status 41 is actually isFunction|OPTIMIZED|TURBOFANNED — correctly tiered
+// all along. Verified by running the same probe on a real Node 26: with AND
+// without `--no-maglev` the status is identical (41) and the timing is
+// identical (~344us), i.e. the flag changed nothing. The child now calibrates
+// the optimized signature in-process instead of hardcoding bits.
+const JS_WARM_FLAGS = ["--allow-natives-syntax", "--no-concurrent-recompilation"];
 
 // V8 startup flag that skips Liftoff (the single-pass Wasm baseline
 // compiler) entirely and compiles straight to TurboFan. This is the Wasm-side

--- a/scripts/no-jit-bench-child.mjs
+++ b/scripts/no-jit-bench-child.mjs
@@ -42,10 +42,6 @@ function parseArgs(argv) {
   return out;
 }
 
-// V8 `%GetOptimizationStatus` bit positions we care about (src/runtime/
-// runtime-test.cc). Only the ones this harness asserts on are named.
-const OPT_STATUS_BITS = { optimized: 1 << 4, maglev: 1 << 5, turbofan: 1 << 6, baseline: 1 << 15 };
-
 /**
  * Read V8's optimization status for `fn`, or `null` when unavailable.
  *
@@ -64,12 +60,54 @@ function readOptStatus(fn) {
   }
 }
 
-function describeOptStatus(status) {
+/**
+ * Derive "what does an optimized function look like on THIS V8" empirically,
+ * by optimizing a throwaway reference function the exact same way the
+ * benchmark factory does and diffing its status before/after.
+ *
+ * Hardcoding `%GetOptimizationStatus` bit positions does not survive a V8
+ * upgrade. The positions shifted by one between Node 22 and Node 26 —
+ * `kOptimized` moved 1<<4 -> 1<<3 and `kTurboFanned` 1<<6 -> 1<<5 — so a
+ * table written against Node 22 decoded Node 26's perfectly TurboFan-optimized
+ * status (41) as "maglev, not optimized" and failed a run that was in fact
+ * correctly tiered. Verified directly on both runtimes:
+ *
+ *   after %OptimizeFunctionOnNextCall   Node 22: bits 0,4,6   Node 26: bits 0,3,5
+ *   after %OptimizeMaglevOnNextCall     Node 22: n/a          Node 26: bits 0,3,4
+ *
+ * Calibrating in-process needs no table and cannot drift: the bits that
+ * appear when the reference is optimized ARE the bits that mean "optimized
+ * the way we asked for" on whatever V8 is running. Maglev is still rejected,
+ * because a Maglev-tiered function lacks the reference's TurboFan bit.
+ */
+function calibrateOptimizedMask() {
+  const reference = () => {
+    let s = 0;
+    for (let i = 0; i < 1000; i++) s = (s + i) | 0;
+    return s;
+  };
+  try {
+    const prepare = new Function("f", "%PrepareFunctionForOptimization(f);");
+    const optimize = new Function("f", "%OptimizeFunctionOnNextCall(f);");
+    prepare(reference);
+    reference();
+    const before = readOptStatus(reference);
+    optimize(reference);
+    reference();
+    const after = readOptStatus(reference);
+    if (before === null || after === null) return null;
+    // Bits gained by optimizing == this V8's "optimized" signature.
+    const gained = after & ~before;
+    return gained === 0 ? null : gained;
+  } catch {
+    return null;
+  }
+}
+
+function describeOptStatus(status, mask) {
   if (status === null) return "unavailable";
-  const on = Object.entries(OPT_STATUS_BITS)
-    .filter(([, mask]) => status & mask)
-    .map(([name]) => name);
-  return on.length ? `${status} (${on.join(",")})` : `${status} (none)`;
+  if (!mask) return `${status}`;
+  return `${status} (${(status & mask) === mask ? "matches" : "MISSING"} optimized-signature ${mask})`;
 }
 
 function calibrate(fn) {
@@ -137,13 +175,11 @@ async function main() {
 
   // `--expect-tier=optimized` (warm lane only) turns the harness's central
   // assumption into an assertion. Without it a silently-mis-tiered run still
-  // produces a plausible-looking number and publishes it — which is exactly
-  // how the landing page came to report a JS baseline ~14x slower than the
-  // same source measured optimized, with no signal that anything was wrong.
-  // Sampled BEFORE and AFTER the measured rounds: the observed failure is not
-  // "never optimized" but tier OSCILLATION during measurement (a median
-  // between tiers with ~30% variance), which a single up-front check misses.
+  // produces a plausible-looking number and publishes it, with no signal that
+  // anything is wrong. Sampled BEFORE and AFTER the measured rounds so a
+  // mid-measurement deopt is caught, not just a never-optimized start.
   const expectTier = args["expect-tier"];
+  const optimizedMask = expectTier ? calibrateOptimizedMask() : null;
   const optStatusBefore = expectTier ? readOptStatus(fn) : null;
 
   const samplesUs = [];
@@ -154,13 +190,14 @@ async function main() {
 
   const optStatusAfter = expectTier ? readOptStatus(fn) : null;
 
-  if (expectTier === "optimized" && optStatusBefore !== null) {
-    const isOpt = (s) => (s & OPT_STATUS_BITS.optimized) !== 0;
+  if (expectTier === "optimized" && optStatusBefore !== null && optimizedMask !== null) {
+    const isOpt = (s) => (s & optimizedMask) === optimizedMask;
     if (!isOpt(optStatusBefore) || !isOpt(optStatusAfter)) {
       throw new Error(
         `expected '${exportName}' to stay on V8's optimizing tier for the whole ` +
-          `measurement, but status was ${describeOptStatus(optStatusBefore)} before ` +
-          `and ${describeOptStatus(optStatusAfter)} after the measured rounds. ` +
+          `measurement, but status was ${describeOptStatus(optStatusBefore, optimizedMask)} before ` +
+          `and ${describeOptStatus(optStatusAfter, optimizedMask)} after the measured rounds ` +
+          `(reference signature calibrated in-process: ${optimizedMask}). ` +
           `The reported timings would not represent optimized-tier speed.`,
       );
     }
@@ -171,7 +208,11 @@ async function main() {
       samplesUs,
       iters,
       ...(expectTier
-        ? { optStatusBefore: describeOptStatus(optStatusBefore), optStatusAfter: describeOptStatus(optStatusAfter) }
+        ? {
+            optimizedMask,
+            optStatusBefore: describeOptStatus(optStatusBefore, optimizedMask),
+            optStatusAfter: describeOptStatus(optStatusAfter, optimizedMask),
+          }
         : {}),
     }) + "\n",
   );


### PR DESCRIPTION
## Description

#3759's tier guard hardcoded `%GetOptimizationStatus` bit positions read off **Node 22**. Those positions **shift between V8 releases** — `kOptimized` moves `1<<4` → `1<<3` and `kTurboFanned` `1<<6` → `1<<5` between Node 22 and Node 26. So on CI (Node 26) the guard decoded status `41` — which is actually `isFunction|OPTIMIZED|TURBOFANNED`, a **correctly TurboFan-tiered** function — as "maglev, not optimized", and failed **every** benchmark-refresh run since it landed. The landing page has been frozen on stale data as a result.

Verified by downloading a real Node 26 into the sandbox and running the probe on both:

```
after %OptimizeFunctionOnNextCall   Node 22: bits 0,4,6   Node 26: bits 0,3,5
after %OptimizeMaglevOnNextCall     Node 22: n/a          Node 26: bits 0,3,4
```

## The fix

The child now **derives** the signature in-process: it optimizes a throwaway reference function exactly the way the benchmark factory does, and takes the bits that appear as *this* V8's meaning of "optimized the way we asked". No table, nothing to drift on the next upgrade. Maglev is still rejected, because a Maglev-tiered function lacks the reference's TurboFan bit.

Also **removes `--no-maglev`**, which I added in #3769 on that wrong diagnosis. Proven inert: on Node 26, with and without it, the status is identical (`41`) and the timing is identical (~344 µs).

## Test plan

Verified four ways, on **both** runtimes:

| case | result |
|---|---|
| properly optimized, Node 26 | ✅ passes, mask `40` |
| properly optimized, Node 22 | ✅ passes, mask `80` — adapts automatically |
| `%OptimizeMaglevOnNextCall`, Node 26 | ✅ **fails** (`25 (MISSING optimized-signature 40)`) — guard still works |
| cold `--jitless` lane | ✅ unaffected, no `--expect-tier` |

Plus the full generator now runs clean end-to-end under **Node 26, the actual CI engine**.

## Files #3777 — a separate bug this surfaced

While validating on the real CI engine I found something the tier fix does *not* address:

| loop.ts JS, same source, tier-verified both | Node 22 | Node 26 |
|---|---|---|
| plain top-level script | 310 µs | 349 µs |
| **through the harness (what the chart uses)** | 323 µs | **5107 µs** |

~15x slower through the harness, **Node 26 only**, while staying tier-verified throughout. And `calibrate()` demonstrably saw the *fast* function first — it derived `iters=882`, which back-solves to ~340 µs/call — so it degrades **mid-measurement**. Not the tier, and not `new Function` (both isolate clean at ~338 µs).

This inflates the published JS baseline and flatters every wasm:js ratio, so any wasm-vs-JS conclusion drawn from the chart on Node 26 should be re-derived once #3777 is fixed. Filed with the full evidence rather than rushed into this PR.

## CLA

Internal/org-member PR — CLA check is skipped automatically.

- [ ] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_