### PR TITLE
fix(regexp): guard quantified empty backreferences

### DIFF
--- a/plan/issues/3774-standalone-regexp-backref-empty-progress.md
+++ b/plan/issues/3774-standalone-regexp-backref-empty-progress.md
@@ -1,0 +1,79 @@
+---
+id: 3774
+title: "Standalone RegExp quantified empty backreferences exhaust the step limit"
+status: in-review
+created: 2026-07-28
+priority: high
+task_type: bugfix
+area: codegen
+goal: es5
+es_edition: 5
+assignee: ttraenkler/codex-es5-regexp-backref-progress
+sprint: current
+related: [1539, 1912, 1959]
+---
+
+# #3774 — Standalone RegExp quantified empty-backreference progress
+
+## Problem
+
+The RegExp compiler classifies every backreference as non-nullable. A
+backreference can instead match empty when its capture did not participate or
+when the participating capture spans zero input units. Quantifying that
+backreference therefore omits the existing `PROGRESS` guard and repeatedly
+matches at the same input position until the standalone VM exhausts its step
+limit.
+
+The two current-main ES5 Test262 failures in this root-cause family are:
+
+- `built-ins/RegExp/S15.10.2.5_A1_T5.js`
+- `built-ins/RegExp/S15.10.2.9_A1_T5.js`
+
+Both exercise `/(a*)b\1+/`. Host passes 2/2; standalone fails 0/2 with
+`RangeError: regular expression step limit exceeded`.
+
+## Specification
+
+ECMAScript 2026
+[RepeatMatcher §22.2.2.3.1](https://tc39.es/ecma262/2026/multipage/text-processing.html#sec-repeatmatcher)
+rejects a further repetition after the minimum has been satisfied when the
+iteration did not advance its end index. Its accompanying note names
+`/(a*)b\1+/.exec("baaaac")` and requires the result `["b", ""]`.
+
+[BackreferenceMatcher §22.2.2.7.2](https://tc39.es/ecma262/2026/multipage/text-processing.html#sec-backreferencematcher)
+continues without consuming input for an unset capture and uses the captured
+range length otherwise, which can also be zero.
+
+## Fix
+
+Conservatively classify backreferences as nullable. This reuses the progress
+instruction added by #1959 for quantified nullable bodies. Over-approximation
+only adds a cheap comparison for quantified backreferences; consuming
+backreferences continue repeating while their input position advances.
+
+## Acceptance criteria
+
+- Both ES5 Test262 cases pass in standalone and remain passing in host.
+- The TypeScript reference VM and standalone Wasm return the spec result.
+- A consuming quantified-backreference control remains greedy.
+- The complete classified ES5 RegExp cohort has no regressions or non-target
+  status/error-signature drift in same-SHA A/B measurement.
+
+## Verification
+
+Control and candidate use exact `origin/main@108c41ecf166b195741a6f2509539471868156b7`.
+The classified ES5 RegExp union contains 500 files: 499 occur in the canonical
+host baseline and all 500 occur in the canonical standalone baseline.
+
+- Same-SHA local host union: 466/500 → 466/500, zero status or non-pass
+  signature changes. Restricting to the 499-file canonical host membership is
+  465/499 → 465/499.
+- Same-SHA local standalone: 406/500 → 408/500.
+- Exact transitions: the two listed tests change from step-limit failure to
+  pass. There are zero pass losses and zero other status/signature changes.
+- Refreshed canonical baseline records classify host as 467/499 and standalone
+  as 405/500; these artifact counts are reported separately from the
+  local-vs-local A/B.
+- Focused and related #1912/#1959 tests pass 81/81.
+- Typecheck, scoped format/lint, LOC/function budgets, oracle ratchet, pushRaw,
+  dead-export, IR-adoption, codegen-fallback, and coercion-site gates pass.

--- a/src/codegen/regex/compile.ts
+++ b/src/codegen/regex/compile.ts
@@ -534,10 +534,11 @@ export function canMatchEmpty(node: ReNode): boolean {
     case "udot":
     case "class":
     case "cpclass":
-    case "backref":
-      // backref to an unset group matches empty, but a set group may consume;
-      // treat as consuming — the guard is only skipped when DEFINITELY non-empty.
       return false;
+    case "backref":
+      // An unset capture matches empty, and a participating capture may itself
+      // span zero input units. Conservatively guard quantified backreferences.
+      return true;
     case "bol":
     case "eol":
     case "wordBoundary":

--- a/tests/issue-3774-regexp-backref-empty-progress.test.ts
+++ b/tests/issue-3774-regexp-backref-empty-progress.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3774 — quantified backreferences to empty captures must stop repeating once
+ * their minimum is satisfied. RepeatMatcher §22.2.2.3.1 explicitly uses
+ * `/(a*)b\1+/` as the empty-progress example.
+ */
+import { describe, expect, it } from "vitest";
+import { compilePattern } from "../src/codegen/regex/compile.js";
+import { search } from "../src/codegen/regex/vm.js";
+import { compile } from "../src/index.js";
+
+describe("#3774 quantified empty-backreference progress", () => {
+  it("matches the spec example in the reference VM", () => {
+    const compiled = compilePattern("(a*)b\\1+", 0);
+    const match = search(compiled.prog, compiled.classTable, compiled.nGroups, "baaaac", 0, false, compiled.nScratch);
+
+    expect(match).not.toBeNull();
+    expect(Array.from(match!.slice(0, 4))).toEqual([0, 1, 0, 0]);
+  });
+
+  it("matches the spec example in standalone Wasm", async () => {
+    const source = `
+      const match = /(a*)b\\1+/.exec("baaaac")!;
+      export function wholeLength(): number { return match[0]!.length; }
+      export function captureLength(): number { return match[1]!.length; }
+    `;
+    const result = await compile(source, { fileName: "test.ts", target: "standalone" });
+    expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
+    const module = await WebAssembly.compile(result.binary);
+    expect(WebAssembly.Module.imports(module)).toEqual([]);
+    const instance = await WebAssembly.instantiate(module, {});
+    const exports = instance.exports as { wholeLength(): number; captureLength(): number };
+
+    expect(exports.wholeLength()).toBe(1);
+    expect(exports.captureLength()).toBe(0);
+  });
+
+  it("keeps consuming backreference repetitions greedy", async () => {
+    const source = `
+      const match = /(a)b\\1+/.exec("abaaac")!;
+      export function wholeLength(): number { return match[0]!.length; }
+    `;
+    const result = await compile(source, { fileName: "test.ts", target: "standalone" });
+    expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+
+    expect((instance.exports as { wholeLength(): number }).wholeLength()).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

- classify RegExp backreferences as nullable when deciding whether quantified loops need the existing `PROGRESS` guard
- stop zero-width repetitions such as `/(a*)b\1+/` after their minimum has been satisfied
- add reference-VM, host-free standalone Wasm, consuming-control, and issue #3774 coverage

## Root cause

A backreference was treated as definitely consuming by `canMatchEmpty`. Backreferences instead match no input when their capture is unset or when the participating capture spans zero input units. A quantified empty backreference therefore omitted the RepeatMatcher progress guard and looped until the standalone RegExp step limit.

ECMAScript 2026 RepeatMatcher §22.2.2.3.1 explicitly names `/(a*)b\1+/.exec("baaaac")` and requires `["b", ""]`. BackreferenceMatcher §22.2.2.7.2 also permits unset and zero-length captures.

## Same-SHA ES5 RegExp A/B

Control and candidate are based on exact `origin/main@108c41ecf166b195741a6f2509539471868156b7`.

- classified union: 500 files (499 canonical host members, 500 standalone)
- local host union: 466/500 → 466/500; zero status or non-pass signature changes
- local host canonical membership: 465/499 → 465/499
- local standalone: 406/500 → 408/500
- exact transitions: `S15.10.2.5_A1_T5.js` and `S15.10.2.9_A1_T5.js`, both step-limit FAIL → PASS
- zero pass losses and zero other status/signature drift

The separately refreshed canonical baseline records classify host as 467/499 and standalone as 405/500; those artifact counts are not substituted for the local-vs-local A/B.

## Verification

- focused + related #1912/#1959: 81/81
- Test262 target family: host 2/2 → 2/2; standalone 0/2 → 2/2
- full same-SHA ES5 RegExp A/B above
- typecheck, full/scoped lint and format
- LOC/function budgets, oracle ratchet, pushRaw
- IR fallback, IR-only hybrid, IR adoption, dead exports, stack balance
- harness compile budget, codegen fallback, any-box, speculative rollback, coercion sites
- required guard suite: 182 passed / 4 skipped
- host-import, regression-gate, IR allocation, issue-ID/spec/integrity gates

Closes #3774
