### PR TITLE
refactor(ir): assign structural ownership to typed-this twins

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -5,9 +5,8 @@ status: in-progress
 assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
-branch: codex/3520-c27-nested-function-abi
-pr: 3797
-last_merged_pr: 3792
+branch: codex/3520-c28-typed-this-abi
+last_merged_pr: 3797
 sprint: current
 created: 2026-07-21
 updated: 2026-07-29
@@ -2497,6 +2496,36 @@ C27 closes exact retained ownership for nested function declarations, not R1.
 Typed-`this` twins and other support callables, remaining class/type consumers,
 and module-array or display-name scans must still move behind structural
 authorities before R1 can close.
+
+### 2026-07-29 typed-this twin callable ownership continuation
+
+The continuation on `codex/3520-c28-typed-this-abi` gives every admitted
+typed-`this` twin its own structural Program ABI owner:
+
+- the original function-expression body keeps the callable binding derived
+  from its exact source `IrUnitId`, while the optimized twin receives a
+  separate `typed-this-twin` support binding anchored beneath that same unit;
+- twin observation happens atomically with allocator publication, and final
+  ownership is selected only after DCE. A removed twin creates no required ABI
+  slot, while a retained twin is resolved from its exact `WasmFunction` object
+  rather than its generated `__typed_this` label; and
+- admission, the second optimized compilation, receiver-param specialization,
+  numeric field/return/local promotion, arity padding, direct-call
+  devirtualization, guard-shim construction, and the generic fallback body are
+  unchanged.
+
+The production fixture proves the generic body and admitted twin finalize to
+two different function slots while the standalone program still returns the
+expected value. The focused source-callable and complete typed-`this`
+optimization matrix passes **103/103 across eight files**. Strict TypeScript
+and changed-file Biome lint pass. The hybrid IR-only readiness lane remains
+**READY** at **31 emitted / 6 typed Unsupported / 0 Invariants across 37
+terminal units**, with all 37 legacy bodies still emitted.
+
+C28 closes exact ownership for the typed-`this` twin family, not R1. Other
+support callables, remaining class/type consumers, and module-array or
+display-name scans must still move behind structural authorities before R1
+can close.
 
 ### R1a validation evidence
 

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -6,6 +6,7 @@ assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
 branch: codex/3520-c28-typed-this-abi
+pr: 3798
 last_merged_pr: 3797
 sprint: current
 created: 2026-07-21
@@ -2499,7 +2500,8 @@ authorities before R1 can close.
 
 ### 2026-07-29 typed-this twin callable ownership continuation
 
-The continuation on `codex/3520-c28-typed-this-abi` gives every admitted
+The continuation on `codex/3520-c28-typed-this-abi`
+([PR #3798](https://github.com/loopdive/js2/pull/3798)) gives every admitted
 typed-`this` twin its own structural Program ABI owner:
 
 - the original function-expression body keeps the callable binding derived

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -19,7 +19,7 @@ import { isVoidType, unwrapPromiseType, isPromiseType } from "../checker/type-ma
 import type { FieldDef, Instr, LocalDef, StructTypeDef, ValType } from "../ir/types.js";
 import { isStandalonePromiseActive } from "./async-scheduler.js"; // (#2867 Gap 1) native-$Promise carrier gate
 import { definedFuncAt, funcSignatureOf, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2 read chokepoint / S3b stable-regime minting)
-import { pushProgramAbiNestedCallable } from "./program-abi-source-callable-planning.js";
+import { pushProgramAbiNestedCallable, pushProgramAbiTypedThisTwin } from "./program-abi-source-callable-planning.js";
 import { inLiveShiftRange } from "../emit/resolve-layout.js"; // (#1916 S3b) manual import-shift must skip stable handles
 import { addStringConstantGlobal } from "./registry/imports.js"; // (#2025)
 import { stringConstantExternrefInstrs } from "./native-strings.js"; // (#2025)
@@ -2800,7 +2800,7 @@ export function compileArrowAsClosure(
         ctx.liveBodies.delete(twin.liftedFctx.body);
       } else {
         const twinFuncIdx = mintDefinedFunc(ctx);
-        pushDefinedFunc(ctx, twinFuncIdx, {
+        pushProgramAbiTypedThisTwin(ctx, arrow, twinFuncIdx, {
           name: twinName,
           typeIdx: twin.liftedFuncTypeIdx,
           locals: twin.liftedFctx.locals,

--- a/src/codegen/program-abi-planning.ts
+++ b/src/codegen/program-abi-planning.ts
@@ -20,6 +20,7 @@ export const PROGRAM_ABI_CALLABLE_ROLE = Object.freeze({
   classHostConstructor: 4,
   moduleInit: 5,
   retainedModuleFunction: 6,
+  typedThisTwin: 7,
 } as const);
 
 export const PROGRAM_ABI_GLOBAL_ROLE = Object.freeze({

--- a/src/codegen/program-abi-source-callable-planning.ts
+++ b/src/codegen/program-abi-source-callable-planning.ts
@@ -1,14 +1,18 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
-import { irUnitCallableBindingId, irUnitFuncRef } from "../ir/callable-bindings.js";
-import type { IrUnitId } from "../ir/identity.js";
+import { irSupportFuncRef, irUnitCallableBindingId, irUnitFuncRef } from "../ir/callable-bindings.js";
+import type { IrBindingId, IrUnitId } from "../ir/identity.js";
 import type { IrPlanningIdentityContext } from "../ir/planning-identity.js";
 import { ProgramAbiInvariantError } from "../ir/program-abi.js";
 import type { FuncHandle, FuncTypeDef, WasmFunction } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import type { CodegenContext } from "./context/types.js";
 import { definedFuncAt, pushDefinedFunc } from "./func-space.js";
-import { planProgramAbiUnitCallable } from "./program-abi-planning.js";
+import {
+  planProgramAbiSupportCallable,
+  planProgramAbiUnitCallable,
+  PROGRAM_ABI_CALLABLE_ROLE,
+} from "./program-abi-planning.js";
 import type { ProgramAbiSession } from "./program-abi-session.js";
 
 interface SourceCallableObservation {
@@ -16,6 +20,15 @@ interface SourceCallableObservation {
   readonly displayName: string;
   readonly funcIdx: FuncHandle;
 }
+
+interface SourceSupportCallableObservation {
+  readonly bindingId: IrBindingId;
+  readonly unitId: IrUnitId;
+  readonly displayName: string;
+  readonly func: WasmFunction;
+}
+
+const TYPED_THIS_TWIN_ROLE = "typed-this-twin";
 
 type SourceCallableDeclaration =
   | ts.FunctionDeclaration
@@ -74,6 +87,25 @@ export function pushProgramAbiNestedCallable(
   registry.observe(declaration, funcIdx);
 }
 
+/** Push and structurally observe one admitted typed-`this` support twin atomically. */
+export function pushProgramAbiTypedThisTwin(
+  ctx: CodegenContext,
+  declaration: ts.FunctionExpression | ts.ArrowFunction,
+  funcIdx: FuncHandle,
+  func: WasmFunction,
+): void {
+  pushDefinedFunc(ctx, funcIdx, func);
+  if (!ts.isFunctionExpression(declaration)) {
+    throw new ProgramAbiInvariantError(
+      "missing-source-unit",
+      `typed-this twin ${func.name} does not have a function-expression source owner`,
+    );
+  }
+  const registry = ctx.programAbiSourceCallables;
+  if (!registry?.identityContext?.unitIdByDeclaration.has(declaration)) return;
+  registry.observeTypedThisTwin(declaration, funcIdx);
+}
+
 /** Push and structurally observe one nested function declaration atomically. */
 export function pushProgramAbiNestedFunctionDeclaration(
   ctx: CodegenContext,
@@ -129,6 +161,7 @@ function expectedSourceCallableUnitKind(declaration: SourceCallableDeclaration):
  */
 export class ProgramAbiSourceCallableRegistry {
   private readonly observations = new Map<IrUnitId, SourceCallableObservation[]>();
+  private readonly supports = new Map<IrBindingId, SourceSupportCallableObservation[]>();
   private planned = false;
 
   constructor(
@@ -157,6 +190,52 @@ export class ProgramAbiSourceCallableRegistry {
 
   observeNestedFunctionDeclaration(declaration: ts.FunctionDeclaration, funcIdx: FuncHandle): IrUnitId | undefined {
     return this.observeWithExpectedKind(declaration, funcIdx, "nested-function");
+  }
+
+  observeTypedThisTwin(declaration: ts.FunctionExpression, funcIdx: FuncHandle): IrBindingId | undefined {
+    if (this.planned) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        "cannot observe a typed-this twin after retained source-callable planning",
+      );
+    }
+    const func = definedFuncAt(this.ctx, funcIdx);
+    if (!func) {
+      throw new ProgramAbiInvariantError(
+        "missing-required-locator",
+        `typed-this twin has no exact defined function for handle ${funcIdx}`,
+      );
+    }
+    const identityContext = this.identityContext;
+    if (!identityContext) return undefined;
+    const unitId = identityContext.unitIdByDeclaration.get(declaration);
+    const unit = unitId === undefined ? undefined : identityContext.unitByUnitId.get(unitId);
+    if (
+      unitId === undefined ||
+      !unit ||
+      unit.kind !== "function-expression" ||
+      identityContext.declarationByUnitId.get(unitId) !== declaration
+    ) {
+      throw new ProgramAbiInvariantError(
+        "missing-source-unit",
+        `typed-this twin ${func.name} has no consistent exact function-expression inventory owner`,
+      );
+    }
+    const ref = irSupportFuncRef(unitId, TYPED_THIS_TWIN_ROLE, func.name);
+    if (ref.binding.kind !== "support") {
+      throw new ProgramAbiInvariantError(
+        "invalid-binding-reference",
+        `typed-this twin ${func.name} did not produce a support binding`,
+      );
+    }
+    const bindingId = ref.binding.bindingId;
+    const observations = this.supports.get(bindingId) ?? [];
+    const previous = observations.at(-1);
+    if (previous?.func !== func || previous.displayName !== func.name) {
+      observations.push(Object.freeze({ bindingId, unitId, displayName: func.name, func }));
+      this.supports.set(bindingId, observations);
+    }
+    return bindingId;
   }
 
   private observeWithExpectedKind(
@@ -253,6 +332,36 @@ export class ProgramAbiSourceCallableRegistry {
         throw new ProgramAbiInvariantError(
           "missing-source-unit",
           `retained source callable ${canonical.observation.displayName} was not accepted for exact unit ${unitId}`,
+        );
+      }
+    }
+
+    const live = new Set(this.ctx.mod.functions);
+    for (const [bindingId, observations] of this.supports) {
+      const canonical = observations.filter((observation) => live.has(observation.func)).at(-1);
+      if (!canonical) continue;
+      if (session.hasPlan(bindingId)) {
+        if (!session.hasLocator(bindingId, canonical.func)) {
+          throw new ProgramAbiInvariantError(
+            "duplicate-slot-locator",
+            `retained typed-this twin ${canonical.displayName} is not the exact allocator owned by ${bindingId}`,
+          );
+        }
+        continue;
+      }
+      const ref = irSupportFuncRef(canonical.unitId, TYPED_THIS_TWIN_ROLE, canonical.displayName);
+      const plannedBindingId = planProgramAbiSupportCallable(this.ctx, {
+        ref,
+        anchor: { kind: "unit", unitId: canonical.unitId },
+        role: TYPED_THIS_TWIN_ROLE,
+        roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.typedThisTwin,
+        signature: functionSignature(this.ctx, canonical.func),
+        func: canonical.func,
+      });
+      if (plannedBindingId !== bindingId) {
+        throw new ProgramAbiInvariantError(
+          "invalid-binding-reference",
+          `retained typed-this twin ${canonical.displayName} was not accepted for ${bindingId}`,
         );
       }
     }

--- a/tests/issue-3520-source-callable-abi.test.ts
+++ b/tests/issue-3520-source-callable-abi.test.ts
@@ -1,13 +1,14 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { analyzeMultiSource, analyzeSource } from "../src/checker/index.js";
 import { generateModule, generateMultiModule } from "../src/codegen/index.js";
 import { compile, compileMulti, type CompileResult } from "../src/index.js";
-import { irUnitCallableBindingId } from "../src/ir/callable-bindings.js";
+import { irSupportFuncRef, irUnitCallableBindingId } from "../src/ir/callable-bindings.js";
 import { buildIrUnitInventory, type IrUnitInventory, type IrUnitRecord } from "../src/ir/identity.js";
 import type { ProgramAbiPlanEntry } from "../src/ir/program-abi.js";
+import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
 import { buildImports, instantiateWasm } from "../src/runtime.js";
 
 // Register the codegen expression/statement delegates used by generateModule.
@@ -211,6 +212,65 @@ describe("#3520 source callable Program ABI ownership", () => {
     });
     const exports = await instantiate(runtime);
     expect((exports.run as (value: number) => number)(7)).toBe(22);
+  });
+
+  it("owns an admitted typed-this twin as support beneath its exact function expression", async () => {
+    const source = `
+      var P = function P(n) { this.pos = n; this.acc = 0; };
+      var pp = P.prototype;
+      pp.step = function (k) {
+        this.pos = this.pos + k;
+        return this.pos;
+      };
+      var p = new P(3);
+      export function test(): number { return p.step(4); }
+    `;
+    const ast = analyzeSource(source, "source-callable-typed-this-twin.ts");
+    const inventory = buildIrUnitInventory([ast.sourceFile], {
+      entrySource: ast.sourceFile,
+      checker: ast.checker,
+    });
+    const expression = exactUnit(inventory, "function-expression", "<anonymous-function>");
+
+    const publish = vi.spyOn(ProgramAbiSession.prototype, "publish");
+    const runtime = await compile(source, {
+      fileName: "source-callable-typed-this-twin.ts",
+      experimentalIR: true,
+      target: "standalone",
+      skipSemanticDiagnostics: true,
+    });
+    const publication = publish.mock.instances.at(-1)?.publication;
+    publish.mockRestore();
+    expect(runtime.success, runtime.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(runtime.wat).toMatch(/__typed_this/);
+    expect(publication).toBeDefined();
+
+    const bodyBindingId = irUnitCallableBindingId(expression.id);
+    const twinRef = irSupportFuncRef(expression.id, "typed-this-twin", "diagnostic-name-is-not-identity");
+    if (twinRef.binding.kind !== "support") throw new Error("missing typed-this support reference");
+    const twinBindingId = twinRef.binding.bindingId;
+    const entries = publication!.abi.entries();
+    const body = requiredCallable(entries, bodyBindingId);
+    expect(body.intent).toMatchObject({ kind: "callable", origin: "source", unitId: expression.id });
+    expect(entries.find((entry) => entry.id === twinBindingId)).toMatchObject({
+      id: twinBindingId,
+      displayName: expect.stringMatching(/__typed_this$/),
+      slotPolicy: "required",
+      slotSpace: "function",
+      intent: {
+        kind: "callable",
+        origin: "support",
+        unitId: expression.id,
+      },
+    });
+    const bodySlot = publication!.abi.resolveFinalIndex(bodyBindingId);
+    const twinSlot = publication!.abi.resolveFinalIndex(twinBindingId);
+    expect(bodySlot).toEqual(expect.objectContaining({ space: "function" }));
+    expect(twinSlot).toEqual(expect.objectContaining({ space: "function" }));
+    expect(twinSlot).not.toEqual(bodySlot);
+
+    const exports = await instantiate(runtime);
+    expect((exports.test as () => number)()).toBe(7);
   });
 
   it("owns a retained direct host-callback body by its exact arrow unit", () => {


### PR DESCRIPTION
## Summary
- publish retained typed-this twins as source-unit-anchored Program ABI support callables
- keep each original function-expression body on its distinct canonical source callable binding
- preserve twin admission, direct-call devirtualization, numeric refinements, arity padding, guard shims, and generic fallback behavior
- update the markdown R1 tracker with C28 status and evidence

## Validation
- 103/103 focused source-callable and typed-this optimization tests
- pnpm run typecheck
- pnpm run lint
- pnpm run format:check
- pnpm run check:ir-fallbacks
- pnpm run check:ir-only -- --policy=hybrid (READY: 31 emitted, 6 typed Unsupported, 0 Invariants)
- LOC/function budgets, dead-export, godfile, oracle-ratchet, and IR-adoption gates

Tracks plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md.