### PR TITLE
refactor(ir): own direct function-value artifacts structurally

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -6,6 +6,7 @@ assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
 branch: codex/3520-c29-function-value-abi
+pr: 3799
 last_merged_pr: 3798
 sprint: current
 created: 2026-07-21

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -5,9 +5,8 @@ status: in-progress
 assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
-branch: codex/3520-c28-typed-this-abi
-pr: 3798
-last_merged_pr: 3797
+branch: codex/3520-c29-function-value-abi
+last_merged_pr: 3798
 sprint: current
 created: 2026-07-21
 updated: 2026-07-29
@@ -110,6 +109,8 @@ files:
   - src/codegen/ir-overlay-outcomes.ts
   - src/codegen/ir-overlay-safety.ts
   - src/codegen/closures.ts
+  - src/codegen/closures/funcref-as-closure.ts
+  - src/codegen/closures/method-trampolines.ts
   - src/codegen/index.ts
   - src/codegen/stdlib-selfhost.ts
   - docs/ir/ir-contract.md
@@ -2528,6 +2529,51 @@ C28 closes exact ownership for the typed-`this` twin family, not R1. Other
 support callables, remaining class/type consumers, and module-array or
 display-name scans must still move behind structural authorities before R1
 can close.
+
+### 2026-07-29 direct function-value ownership continuation
+
+The continuation on `codex/3520-c29-function-value-abi` moves retained direct
+function-value wrapper artifacts behind their source unit's Program ABI owner:
+
+- capture-free direct values keep the existing lazy module-global singleton.
+  The exact trampoline and cache `GlobalDef` are now observed as one pair and
+  published under `function-value-trampoline` and `function-value-cache`
+  bindings derived from the target declaration's `IrUnitId`;
+- capturing nested declarations keep their activation-local, first-dynamic-read
+  memoization. Their shared module trampoline receives the same unit-derived
+  callable owner, while no module cache binding is invented; and
+- an already prepared C8 singleton is reused only when its callable and global
+  locators are the exact retained allocator objects. Finalization does not
+  recompute its pre-DCE signature contract. Post-inventory helpers, imports,
+  class adapters, and synthetic-name collision fallbacks remain on generic
+  compatibility planning.
+
+The implementation does not change wrapper types, trampoline bodies,
+`ref.func` enrollment, pending signature rebuilding, constructibility,
+capture boxing, TDZ flags, closure identity, direct `call_ref` selection, or
+lazy cache instructions. The focused source-callable suite passes **13/13**,
+including runtime identity and calls for both capture-free and capturing
+nested declarations. The C8 production support-callable suite passes **2/2**,
+the function-value planner suite passes **10/10**, and the #2976 closure
+identity suite passes **4/4**. The #3270 closure-split control is **6/7** on
+both this branch and the exact landed C28 base; its existing IR-fallback
+diagnostic for a bare nested-function reference is unchanged.
+
+The required expected-green migration matrix passes **98/98 across 11 files**,
+and cross-backend differential validation passes **29/29**. The full
+equivalence gate reports **1,611 passing / 32 current failures / 36 known
+baseline failures**, with zero new regressions and four baseline failures now
+passing; the baseline is intentionally unchanged. Strict TypeScript, Biome
+lint, formatting, LOC, godfile, dead-export, oracle-ratchet, and IR-adoption
+gates pass. Hybrid IR-only readiness remains **READY** at **31 emitted / 6
+typed Unsupported / 0 Invariants across 37 terminal units**, with all 37
+legacy bodies still emitted. Neither the equivalence baseline nor the
+Test262 run log is changed.
+
+C29 closes exact retained ownership for direct source function-value
+trampolines and capture-free cache globals, not R1. Other support callable
+families, remaining class/type consumers, and module-array or display-name
+scans must still move behind structural authorities before R1 can close.
 
 ### R1a validation evidence
 

--- a/src/codegen/closures/funcref-as-closure.ts
+++ b/src/codegen/closures/funcref-as-closure.ts
@@ -15,6 +15,7 @@ import { allocLocal, getLocalType } from "../context/locals.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { getOrRegisterRefCellType } from "../index.js";
 import { mintDefinedFunc, pushDefinedFunc } from "../func-space.js";
+import { observeProgramAbiFunctionValue } from "../program-abi-source-callable-planning.js";
 import {
   closureArityField,
   getFuncSignature,
@@ -365,6 +366,7 @@ export function emitFuncRefAsClosure(
       body: trampolineBody,
       exported: false,
     });
+    observeProgramAbiFunctionValue(ctx, funcIdx, trampolineFuncIdx);
     ctx.funcMap.set(trampolineName, trampolineFuncIdx);
 
     // Register closureInfo so array method callbacks can use call_ref

--- a/src/codegen/closures/method-trampolines.ts
+++ b/src/codegen/closures/method-trampolines.ts
@@ -31,6 +31,7 @@ import {
   getOrCreateFuncRefWrapperTypes,
 } from "./funcref-wrapper-types.js";
 import { emitFuncRefAsClosure } from "./funcref-as-closure.js";
+import { observeProgramAbiFunctionValue } from "../program-abi-source-callable-planning.js";
 
 /**
  * (#2015) Build the `this`-slot prologue for an object-method trampoline.
@@ -833,6 +834,7 @@ export function ensureFuncClosureSingleton(
     ctx.funcClosureGlobals.set(funcName, cacheGlobalIdx);
   }
 
+  observeProgramAbiFunctionValue(ctx, funcIdx, trampolineFuncIdx, cacheGlobalIdx);
   return { cacheGlobalIdx, trampolineFuncIdx, closureStructTypeIdx: structTypeIdx };
 }
 

--- a/src/codegen/program-abi-source-callable-planning.ts
+++ b/src/codegen/program-abi-source-callable-planning.ts
@@ -1,24 +1,28 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
+import { irSupportGlobalRef } from "../ir/abi-bindings.js";
 import { irSupportFuncRef, irUnitCallableBindingId, irUnitFuncRef } from "../ir/callable-bindings.js";
 import type { IrBindingId, IrUnitId } from "../ir/identity.js";
 import type { IrPlanningIdentityContext } from "../ir/planning-identity.js";
 import { ProgramAbiInvariantError } from "../ir/program-abi.js";
-import type { FuncHandle, FuncTypeDef, WasmFunction } from "../ir/types.js";
+import type { FuncHandle, FuncTypeDef, GlobalDef, WasmFunction } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import type { CodegenContext } from "./context/types.js";
 import { definedFuncAt, pushDefinedFunc } from "./func-space.js";
 import {
+  planProgramAbiFunctionValue,
   planProgramAbiSupportCallable,
   planProgramAbiUnitCallable,
   PROGRAM_ABI_CALLABLE_ROLE,
 } from "./program-abi-planning.js";
 import type { ProgramAbiSession } from "./program-abi-session.js";
+import { localGlobalIdx } from "./registry/imports.js";
 
 interface SourceCallableObservation {
   readonly unitId: IrUnitId;
   readonly displayName: string;
   readonly funcIdx: FuncHandle;
+  readonly func: WasmFunction;
 }
 
 interface SourceSupportCallableObservation {
@@ -28,7 +32,15 @@ interface SourceSupportCallableObservation {
   readonly func: WasmFunction;
 }
 
+interface SourceFunctionValueObservation {
+  readonly unitId: IrUnitId;
+  readonly trampoline: WasmFunction;
+  readonly cacheGlobal?: GlobalDef;
+}
+
 const TYPED_THIS_TWIN_ROLE = "typed-this-twin";
+const FUNCTION_VALUE_TRAMPOLINE_ROLE = "function-value-trampoline";
+const FUNCTION_VALUE_CACHE_ROLE = "function-value-cache";
 
 type SourceCallableDeclaration =
   | ts.FunctionDeclaration
@@ -130,6 +142,37 @@ export function pushProgramAbiNestedFunctionDeclaration(
   registry.observeNestedFunctionDeclaration(declaration, funcIdx);
 }
 
+/**
+ * Structurally observe one retained direct function-value trampoline and its
+ * optional singleton cache.
+ *
+ * Capturing nested declarations memoize the closure instance in an activation
+ * local and therefore have no module-global cache. Capture-free direct values
+ * keep the existing lazy module-global singleton pair.
+ */
+export function observeProgramAbiFunctionValue(
+  ctx: CodegenContext,
+  targetFuncIdx: FuncHandle,
+  trampolineFuncIdx: FuncHandle,
+  cacheGlobalIdx?: number,
+): void {
+  const registry = ctx.programAbiSourceCallables;
+  if (!registry) {
+    throw new ProgramAbiInvariantError(
+      "context-session-mismatch",
+      "function-value trampoline was allocated without its structural registry",
+    );
+  }
+  const cacheGlobal = cacheGlobalIdx === undefined ? undefined : ctx.mod.globals[localGlobalIdx(ctx, cacheGlobalIdx)];
+  if (cacheGlobalIdx !== undefined && !cacheGlobal) {
+    throw new ProgramAbiInvariantError(
+      "missing-required-locator",
+      `function-value cache has no exact defined global for index ${cacheGlobalIdx}`,
+    );
+  }
+  registry.observeFunctionValue(targetFuncIdx, trampolineFuncIdx, cacheGlobal);
+}
+
 function functionSignature(ctx: CodegenContext, func: WasmFunction): FuncTypeDef {
   const signature = ctx.mod.types[func.typeIdx];
   if (!signature || signature.kind !== "func") {
@@ -162,6 +205,7 @@ function expectedSourceCallableUnitKind(declaration: SourceCallableDeclaration):
 export class ProgramAbiSourceCallableRegistry {
   private readonly observations = new Map<IrUnitId, SourceCallableObservation[]>();
   private readonly supports = new Map<IrBindingId, SourceSupportCallableObservation[]>();
+  private readonly functionValues = new Map<IrUnitId, SourceFunctionValueObservation[]>();
   private planned = false;
 
   constructor(
@@ -238,6 +282,41 @@ export class ProgramAbiSourceCallableRegistry {
     return bindingId;
   }
 
+  observeFunctionValue(
+    targetFuncIdx: FuncHandle,
+    trampolineFuncIdx: FuncHandle,
+    cacheGlobal?: GlobalDef,
+  ): IrUnitId | undefined {
+    if (this.planned) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        "cannot observe a function-value trampoline after retained source-callable planning",
+      );
+    }
+    const target = definedFuncAt(this.ctx, targetFuncIdx);
+    const trampoline = definedFuncAt(this.ctx, trampolineFuncIdx);
+    if (!target || !trampoline) return undefined;
+
+    const unitId = this.unitForFunction(target);
+    if (unitId === undefined) return undefined;
+    if (cacheGlobal === undefined && !trampoline.name.startsWith("__fn_tramp_")) {
+      throw new ProgramAbiInvariantError(
+        "invalid-binding-reference",
+        `function-value trampoline ${trampoline.name} has no recognized direct-wrapper identity`,
+      );
+    }
+
+    const observations = this.functionValues.get(unitId) ?? [];
+    const previous = observations.at(-1);
+    if (previous?.trampoline !== trampoline || previous.cacheGlobal !== cacheGlobal) {
+      observations.push(
+        Object.freeze(cacheGlobal === undefined ? { unitId, trampoline } : { unitId, trampoline, cacheGlobal }),
+      );
+      this.functionValues.set(unitId, observations);
+    }
+    return unitId;
+  }
+
   private observeWithExpectedKind(
     declaration: SourceCallableDeclaration,
     funcIdx: FuncHandle,
@@ -283,7 +362,7 @@ export class ProgramAbiSourceCallableRegistry {
     const observations = this.observations.get(unitId) ?? [];
     const previous = observations.at(-1);
     if (previous?.funcIdx !== funcIdx || previous.displayName !== func.name) {
-      observations.push(Object.freeze({ unitId, displayName: func.name, funcIdx }));
+      observations.push(Object.freeze({ unitId, displayName: func.name, funcIdx, func }));
       this.observations.set(unitId, observations);
     }
     return unitId;
@@ -299,6 +378,27 @@ export class ProgramAbiSourceCallableRegistry {
     return observation && definedFuncAt(this.ctx, observation.funcIdx) ? observation.funcIdx : undefined;
   }
 
+  private unitForFunction(func: WasmFunction): IrUnitId | undefined {
+    let match: IrUnitId | undefined;
+    for (const [unitId, observations] of this.observations) {
+      if (
+        !observations.some(
+          (observation) => observation.func === func || definedFuncAt(this.ctx, observation.funcIdx) === func,
+        )
+      ) {
+        continue;
+      }
+      if (match !== undefined && match !== unitId) {
+        throw new ProgramAbiInvariantError(
+          "duplicate-slot-locator",
+          `source function ${func.name} was observed beneath multiple exact source units`,
+        );
+      }
+      match = unitId;
+    }
+    return match;
+  }
+
   /** Assign exact source-unit owners before generic retained callable planning. */
   planRetained(): void {
     if (this.planned) return;
@@ -306,6 +406,7 @@ export class ProgramAbiSourceCallableRegistry {
     const { session, identityContext } = this;
     if (!session || !identityContext) return;
 
+    const live = new Set(this.ctx.mod.functions);
     for (const [unitId, observations] of this.observations) {
       const canonical = observations
         .map((observation) => ({ observation, func: definedFuncAt(this.ctx, observation.funcIdx) }))
@@ -336,7 +437,75 @@ export class ProgramAbiSourceCallableRegistry {
       }
     }
 
-    const live = new Set(this.ctx.mod.functions);
+    const liveGlobals = new Set(this.ctx.mod.globals);
+    for (const [unitId, observations] of this.functionValues) {
+      const canonical = observations
+        .filter(
+          (observation) =>
+            live.has(observation.trampoline) &&
+            (observation.cacheGlobal === undefined || liveGlobals.has(observation.cacheGlobal)),
+        )
+        .at(-1);
+      if (!canonical) continue;
+
+      const trampoline = irSupportFuncRef(unitId, FUNCTION_VALUE_TRAMPOLINE_ROLE, canonical.trampoline.name);
+      if (trampoline.binding.kind !== "support") {
+        throw new ProgramAbiInvariantError(
+          "invalid-binding-reference",
+          `function-value trampoline ${canonical.trampoline.name} did not produce a support binding`,
+        );
+      }
+      const cacheGlobal = canonical.cacheGlobal
+        ? irSupportGlobalRef(unitId, FUNCTION_VALUE_CACHE_ROLE, canonical.cacheGlobal.name)
+        : undefined;
+      if (session.hasPlan(trampoline.binding.bindingId)) {
+        if (!session.hasLocator(trampoline.binding.bindingId, canonical.trampoline)) {
+          throw new ProgramAbiInvariantError(
+            "duplicate-slot-locator",
+            `retained function-value trampoline ${canonical.trampoline.name} is not the exact allocator owned by ${trampoline.binding.bindingId}`,
+          );
+        }
+        if (
+          cacheGlobal &&
+          (!session.hasPlan(cacheGlobal.binding.bindingId) ||
+            !session.hasLocator(cacheGlobal.binding.bindingId, canonical.cacheGlobal!))
+        ) {
+          throw new ProgramAbiInvariantError(
+            "duplicate-slot-locator",
+            `retained function-value cache ${canonical.cacheGlobal!.name} is not the exact allocator owned by ${cacheGlobal.binding.bindingId}`,
+          );
+        }
+        continue;
+      }
+      if (cacheGlobal) {
+        const planned = planProgramAbiFunctionValue(
+          this.ctx,
+          {
+            target: irUnitFuncRef({ unitId, name: this.observations.get(unitId)?.at(-1)?.displayName ?? "source" }),
+            trampoline,
+            cacheGlobal,
+          },
+          canonical.trampoline,
+          canonical.cacheGlobal!,
+        );
+        if (!planned) {
+          throw new ProgramAbiInvariantError(
+            "invalid-binding-reference",
+            `retained function-value singleton ${canonical.trampoline.name} was not accepted for exact unit ${unitId}`,
+          );
+        }
+      } else {
+        planProgramAbiSupportCallable(this.ctx, {
+          ref: trampoline,
+          anchor: { kind: "unit", unitId },
+          role: FUNCTION_VALUE_TRAMPOLINE_ROLE,
+          roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.functionValueTrampoline,
+          signature: functionSignature(this.ctx, canonical.trampoline),
+          func: canonical.trampoline,
+        });
+      }
+    }
+
     for (const [bindingId, observations] of this.supports) {
       const canonical = observations.filter((observation) => live.has(observation.func)).at(-1);
       if (!canonical) continue;

--- a/tests/issue-3520-source-callable-abi.test.ts
+++ b/tests/issue-3520-source-callable-abi.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { analyzeMultiSource, analyzeSource } from "../src/checker/index.js";
 import { generateModule, generateMultiModule } from "../src/codegen/index.js";
 import { compile, compileMulti, type CompileResult } from "../src/index.js";
+import { irSupportGlobalRef } from "../src/ir/abi-bindings.js";
 import { irSupportFuncRef, irUnitCallableBindingId } from "../src/ir/callable-bindings.js";
 import { buildIrUnitInventory, type IrUnitInventory, type IrUnitRecord } from "../src/ir/identity.js";
 import type { ProgramAbiPlanEntry } from "../src/ir/program-abi.js";
@@ -415,6 +416,96 @@ describe("#3520 source callable Program ABI ownership", () => {
     });
     const exports = await instantiate(runtime);
     expect((exports.run as (value: number) => number)(7)).toBe(30);
+  });
+
+  it("owns direct function-value trampolines and preserves their cache strategy", async () => {
+    const source = `
+      export function captureFree(value: number): number {
+        function increment(input: number): number { return input + 1; }
+        const first = increment;
+        const second = increment;
+        return first === second ? first(value) : -100;
+      }
+      export function capturing(value: number): number {
+        let bias = 3;
+        function addBias(input: number): number { return input + bias; }
+        const first = addBias;
+        const second = addBias;
+        return first === second ? second(value) : -100;
+      }
+    `;
+    const ast = analyzeSource(source, "source-callable-function-values.ts");
+    const inventory = buildIrUnitInventory([ast.sourceFile], {
+      entrySource: ast.sourceFile,
+      checker: ast.checker,
+    });
+    const captureFree = exactUnit(inventory, "nested-function", "increment");
+    const capturing = exactUnit(inventory, "nested-function", "addBias");
+
+    const generated = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const hardErrors = generated.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+    const publication = generated.programAbi!;
+    const entries = publication.abi.entries();
+
+    const captureFreeTrampoline = irSupportFuncRef(
+      captureFree.id,
+      "function-value-trampoline",
+      "diagnostic-capture-free-trampoline",
+    );
+    const capturingTrampoline = irSupportFuncRef(
+      capturing.id,
+      "function-value-trampoline",
+      "diagnostic-capturing-trampoline",
+    );
+    for (const [unit, ref] of [
+      [captureFree, captureFreeTrampoline],
+      [capturing, capturingTrampoline],
+    ] as const) {
+      const entry = entries.find((candidate) => candidate.id === ref.binding.bindingId);
+      expect(entry).toMatchObject({
+        id: ref.binding.bindingId,
+        slotPolicy: "required",
+        slotSpace: "function",
+        intent: {
+          kind: "callable",
+          origin: "support",
+          unitId: unit.id,
+        },
+      });
+      expect(publication.abi.resolveFinalIndex(ref.binding.bindingId)).toEqual(
+        expect.objectContaining({ space: "function" }),
+      );
+    }
+
+    const cache = irSupportGlobalRef(captureFree.id, "function-value-cache", "diagnostic-capture-free-cache");
+    expect(entries.find((candidate) => candidate.id === cache.binding.bindingId)).toMatchObject({
+      id: cache.binding.bindingId,
+      displayName: "__fn_closure_increment",
+      slotPolicy: "required",
+      slotSpace: "global",
+      intent: {
+        kind: "global",
+        origin: "support",
+        mutable: true,
+      },
+    });
+    expect(publication.abi.resolveFinalIndex(cache.binding.bindingId)).toEqual(
+      expect.objectContaining({ space: "global" }),
+    );
+    const capturingCache = irSupportGlobalRef(capturing.id, "function-value-cache", "diagnostic-capturing-cache");
+    expect(entries.some((candidate) => candidate.id === capturingCache.binding.bindingId)).toBe(false);
+
+    const runtime = await compile(source, {
+      fileName: "source-callable-function-values.ts",
+      experimentalIR: true,
+    });
+    const exports = await instantiate(runtime);
+    expect((exports.captureFree as (value: number) => number)(7)).toBe(8);
+    expect((exports.capturing as (value: number) => number)(7)).toBe(10);
   });
 
   it("keeps eager class-order reservations on the nested declaration's exact slot", async () => {


### PR DESCRIPTION
## Summary

- publish retained direct function-value trampolines through unit-derived Program ABI bindings
- pair capture-free trampolines with their existing lazy cache globals while preserving activation-local memoization for capturing nested closures
- reuse preplanned C8 singleton contracts only when exact callable/global allocator objects match
- update the markdown IR migration tracker with the C29 continuation and evidence

No body selection, wrapper type, trampoline instruction, capture/TDZ behavior, constructibility, closure identity, direct call_ref optimization, fallback classification, or baseline is changed.

## Validation

- expected-green IR migration matrix: 98/98 across 11 files
- final focused ownership/planner rerun: 25/25
- cross-backend differential: 29/29
- full equivalence: 1,611 passing, 32 current failures, 36 known baseline failures, 0 new regressions, 4 baseline failures now passing (baseline unchanged)
- hybrid IR-only readiness: READY, 31 emitted / 6 typed Unsupported / 0 Invariants / 37 terminal units
- IR fallback ratchet: no unintended, post-claim, or module-level increase
- typecheck, lint, format, LOC, godfile, dead-export, oracle-ratchet, and IR-adoption gates: green

Known-base controls:
- #3270 closure split: 6/7 on both this branch and landed C28 base
- #3214 imported HOF: 19/20 on both this branch and landed C28 base

Neither scripts/equivalence-baseline.json nor benchmarks/results/test262-run.log is changed.