### PR TITLE
feat(ir): claim Acorn dynamic operator helpers

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -1896,6 +1896,8 @@ claim became live:
   ToPrimitive(`"number"`) + unbox route with late-import shift tracking;
 - dynamic strict/loose equality uses native externref equality helpers instead
   of JS-host imports.
+- direct calls box concrete numeric arguments at explicit-`any` parameter
+  boundaries, including the `Math.pow(...)` equivalence shape.
 
 Focused whole-compiler tests execute these paths in standalone and assert real
 IR emission plus zero post-claim failures. The exact #3796 driver remains the

--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -4,7 +4,7 @@ title: "IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType
 status: ready
 sprint: current
 created: 2026-07-02
-updated: 2026-07-10
+updated: 2026-07-29
 priority: high
 horizon: xl
 feasibility: hard
@@ -18,6 +18,13 @@ related: [1852, 1926, 2138, 2135, 2855]
 origin: "2026-07-02 July Fable audit (plan/log/analysis-2026-07/00-ir-async-standalone-audit.md §1)"
 loc-budget-allow:
   - src/ir/from-ast.ts
+  - src/ir/select.ts
+  - src/ir/integration.ts
+  - src/codegen/index.ts
+  - src/codegen/any-helpers.ts
+func-budget-allow:
+  - src/codegen/index.ts::planIrOverlay
+branch: codex/2949-acorn-dynamic-ops
 ---
 
 # #2949 — the IR's type system is Wasm types, not JS types
@@ -1857,3 +1864,41 @@ element-access + `idx-1` arithmetic all exist). Build the scan flip ONLY for a
 measured non-empty flip set, with the slice-2-style claim-sweep table + full
 CI as the acceptance evidence, and lift gate 6 only after an `ir_first`-lane
 run shows zero dynamic-claim demotions.
+
+## Implementation Notes — S5.P Acorn dynamic operators (2026-07-29)
+
+The claim flip is non-empty on the exact runtime-dynamic Acorn 8.16.0 driver
+from draft PR #3796:
+
+- baseline at `fa8bfd5462192e`: **0 emitted / 43 terminal functions**;
+- this slice: **14 emitted / 43 terminal functions**;
+- post-claim ABI or lowering withdrawals: **0**;
+- remaining: 19 body shapes, 3 logical-value shapes, 2 RegExp constructor
+  shapes, 2 parameter shapes, 2 call-graph closures, and 1 constructor
+  resolution shape.
+
+The selector now admits the already-landed dynamic equality, numeric
+relational, numeric arithmetic, unary coercion, and condition producers. It
+still rejects dynamic `+`, dynamic-vs-dynamic relational comparison, and
+non-literal concrete equality operands because their complete runtime
+dispatch is not yet modeled.
+
+Planning consumes the same implicit-parameter scalar inference as direct
+declaration lowering. The projected type is also used by the IR override map,
+so a claimed helper cannot widen to `dynamic` and later fail callable ABI
+parity. This preserved the direct backend's numeric-call-site optimization and
+removed the three measured Acorn parity withdrawals.
+
+Non-fast standalone needed two runtime corrections exposed only after the
+claim became live:
+
+- dynamic ToNumber now uses the canonical standalone
+  ToPrimitive(`"number"`) + unbox route with late-import shift tracking;
+- dynamic strict/loose equality uses native externref equality helpers instead
+  of JS-host imports.
+
+Focused whole-compiler tests execute these paths in standalone and assert real
+IR emission plus zero post-claim failures. The exact #3796 driver remains the
+per-slice measurement input. Its synthesized module uses a 32,768-element
+`array.new_fixed`; V8 rejects fixed arrays above 10,000 elements, so that
+driver is a compile/outcome probe rather than the focused runtime fixture.

--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -1887,7 +1887,9 @@ Planning consumes the same implicit-parameter scalar inference as direct
 declaration lowering. The projected type is also used by the IR override map,
 so a claimed helper cannot widen to `dynamic` and later fail callable ABI
 parity. This preserved the direct backend's numeric-call-site optimization and
-removed the three measured Acorn parity withdrawals.
+removed the three measured Acorn parity withdrawals. Projection is restricted
+to parameters feeding the admitted scalar operators, avoiding a whole-source
+call-site scan for unrelated harness parameters.
 
 Non-fast standalone needed two runtime corrections exposed only after the
 claim became live:
@@ -1898,6 +1900,11 @@ claim became live:
   of JS-host imports.
 - direct calls box concrete numeric arguments at explicit-`any` parameter
   boundaries, including the `Math.pow(...)` equivalence shape.
+
+Dynamic member reads used directly by equality remain pre-claim fallbacks.
+Array callbacks pass their `obj` argument in a direct array carrier, while the
+current dynamic member helper expects boxed-any input; claiming that seam made
+`obj.length === n` return the wrong result.
 
 Focused whole-compiler tests execute these paths in standalone and assert real
 IR emission plus zero post-claim failures. The exact #3796 driver remains the

--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -1891,6 +1891,13 @@ removed the three measured Acorn parity withdrawals. Projection is restricted
 to parameters feeding the admitted scalar operators, avoiding a whole-source
 call-site scan for unrelated harness parameters.
 
+That projection deliberately excludes functions containing the #1210
+string-builder loop shape. Making an untyped builder function claimable would
+move it off the legacy cached-buffer and loop-local integer optimizations before
+#3745 has migrated the latter. The existing IR owned-append path remains
+available to already-typed functions; newly inferred builder functions stay on
+their current optimized path until the remaining optimization is present in IR.
+
 Non-fast standalone needed two runtime corrections exposed only after the
 claim became live:
 

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -710,6 +710,45 @@ export function ensureExternStrictEqHelper(ctx: CodegenContext): number | undefi
 }
 
 /**
+ * Native standalone `(externref, externref) -> i32` loose equality. Each
+ * carrier is classified by the shared externref-to-AnyValue helper and the
+ * existing `__any_eq` body owns the complete IsLooselyEqual dispatch.
+ */
+export function ensureExternLooseEqHelper(ctx: CodegenContext): number | undefined {
+  if (!(ctx.standalone || ctx.wasi)) return undefined;
+  const existing = ctx.funcMap.get("__extern_loose_eq");
+  if (existing !== undefined) return existing;
+  const fromExternIdx = ensureAnyFromExternHelper(ctx);
+  ensureAnyHelpers(ctx);
+  const anyEqIdx = ctx.funcMap.get("__any_eq");
+  if (fromExternIdx === undefined || anyEqIdx === undefined) return undefined;
+
+  const typeIdx = addFuncType(
+    ctx,
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "i32" }],
+    "__extern_loose_eq",
+  );
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: "__extern_loose_eq",
+    typeIdx,
+    locals: [],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: fromExternIdx },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: fromExternIdx },
+      { op: "call", funcIdx: anyEqIdx },
+    ],
+    exported: false,
+  });
+  ctx.funcMap.set("__extern_loose_eq", funcIdx);
+  ctx.anyHelpers.set("__extern_loose_eq", funcIdx);
+  return funcIdx;
+}
+
+/**
  * (#1461/#54) Native standalone `(externref, externref) -> i32` SameValueZero
  * (§7.2.11) over two boxed externref values — the pure-Wasm replacement for the
  * `__same_value_zero` host import in the array-like `includes` search arm.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -110,7 +110,7 @@ export {
   collectEmptyObjectWidening,
   collectGrowableObjectLiterals,
 } from "./declarations/object-shape-widening.js";
-export { inferNumericReturnTypes } from "./declarations/param-return-inference.js";
+export { inferImplicitAnyParamType, inferNumericReturnTypes } from "./declarations/param-return-inference.js";
 // Import-back: symbols the declaration trunk still calls internally.
 import { inferImplicitAnyParamType, resolveGenericCallSiteTypes } from "./declarations/param-return-inference.js";
 import {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -68,6 +68,7 @@ import {
   type IrPlanningIdentityContext,
 } from "../ir/planning-identity.js";
 import { makeIrPromiseDelayResolver } from "../ir/promise-delay.js";
+import { containsStringBuilderLoopShape } from "../ir/string-builder-shape.js";
 import {
   buildIrPromiseDelayLoweringPlans,
   collectIrPromiseDelayOwners,
@@ -1802,6 +1803,10 @@ const IR_IMPLICIT_PARAM_PROJECTION_BINARY_OPS = new Set<ts.SyntaxKind>([
 function collectIrImplicitParamProjectionCandidates(
   declaration: ts.FunctionDeclaration,
 ): ReadonlySet<ts.ParameterDeclaration> {
+  // Projecting an untyped numeric parameter can make an existing builder
+  // benchmark newly IR-claimable. Until #3745 migrates the legacy loop-local
+  // integer promotion, keep that family on its current optimized path.
+  if (declaration.body && containsStringBuilderLoopShape(declaration.body)) return new Set();
   const paramsByName = new Map<string, ts.ParameterDeclaration>();
   for (const parameter of declaration.parameters) {
     if (!parameter.type && ts.isIdentifier(parameter.name)) paramsByName.set(parameter.name.text, parameter);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1799,14 +1799,13 @@ function makeIrImplicitParamTypeResolver(
     if (!ts.isFunctionDeclaration(declaration) || !declaration.name || declaration.parent !== sourceFile) {
       return undefined;
     }
-    const parameterType = ctx.checker.getTypeAtLocation(parameter);
-    if (!(parameterType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown))) return undefined;
+    const parameterFact = ctx.oracle.typeFactOf(parameter);
+    if (parameterFact.kind !== "any" && parameterFact.kind !== "unknown") return undefined;
     const parameterIndex = declaration.parameters.indexOf(parameter);
     if (parameterIndex < 0) return undefined;
     const inferred = inferImplicitAnyParamType(ctx, declaration.name.text, parameterIndex, sourceFile, declaration);
     if (inferred?.kind === "f64") return "f64";
     if (inferred?.kind === "i32" && inferred.boolean === true) return "bool";
-    if (inferred?.kind === "externref" && ctx.checker.typeToString(parameterType) === "string") return "string";
     return undefined;
   };
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1784,6 +1784,58 @@ function recordObservedIrOutcomes(
   for (const diagnostic of reconciled.diagnostics) reportErrorNoNode(ctx, diagnostic);
 }
 
+const IR_IMPLICIT_PARAM_PROJECTION_BINARY_OPS = new Set<ts.SyntaxKind>([
+  ts.SyntaxKind.EqualsEqualsEqualsToken,
+  ts.SyntaxKind.ExclamationEqualsEqualsToken,
+  ts.SyntaxKind.EqualsEqualsToken,
+  ts.SyntaxKind.ExclamationEqualsToken,
+  ts.SyntaxKind.LessThanToken,
+  ts.SyntaxKind.LessThanEqualsToken,
+  ts.SyntaxKind.GreaterThanToken,
+  ts.SyntaxKind.GreaterThanEqualsToken,
+  ts.SyntaxKind.MinusToken,
+  ts.SyntaxKind.AsteriskToken,
+  ts.SyntaxKind.SlashToken,
+  ts.SyntaxKind.PercentToken,
+]);
+
+function collectIrImplicitParamProjectionCandidates(
+  declaration: ts.FunctionDeclaration,
+): ReadonlySet<ts.ParameterDeclaration> {
+  const paramsByName = new Map<string, ts.ParameterDeclaration>();
+  for (const parameter of declaration.parameters) {
+    if (!parameter.type && ts.isIdentifier(parameter.name)) paramsByName.set(parameter.name.text, parameter);
+  }
+  const candidates = new Set<ts.ParameterDeclaration>();
+  const feedsSupportedShape = (identifier: ts.Identifier): boolean => {
+    let child: ts.Node = identifier;
+    let parent = child.parent;
+    while (ts.isParenthesizedExpression(parent)) {
+      child = parent;
+      parent = parent.parent;
+    }
+    if (ts.isBinaryExpression(parent) && IR_IMPLICIT_PARAM_PROJECTION_BINARY_OPS.has(parent.operatorToken.kind)) {
+      return parent.left === child || parent.right === child;
+    }
+    if (
+      ts.isPrefixUnaryExpression(parent) &&
+      (parent.operator === ts.SyntaxKind.PlusToken || parent.operator === ts.SyntaxKind.MinusToken)
+    ) {
+      return parent.operand === child;
+    }
+    return false;
+  };
+  const visit = (node: ts.Node): void => {
+    if (ts.isIdentifier(node)) {
+      const parameter = paramsByName.get(node.text);
+      if (parameter && feedsSupportedShape(node)) candidates.add(parameter);
+    }
+    forEachChild(node, visit);
+  };
+  if (declaration.body) forEachChild(declaration.body, visit);
+  return candidates;
+}
+
 // #2949 S5.P — declaration lowering already specializes an implicit-any
 // parameter when its call sites establish one concrete scalar ABI. Project
 // that same decision into structural selection and the IR override map so a
@@ -1793,12 +1845,19 @@ function makeIrImplicitParamTypeResolver(
   ctx: CodegenContext,
   sourceFile: ts.SourceFile,
 ): (parameter: ts.ParameterDeclaration) => "f64" | "bool" | "string" | undefined {
+  const candidatesByDeclaration = new WeakMap<ts.FunctionDeclaration, ReadonlySet<ts.ParameterDeclaration>>();
   return (parameter) => {
     if (parameter.type) return undefined;
     const declaration = parameter.parent;
     if (!ts.isFunctionDeclaration(declaration) || !declaration.name || declaration.parent !== sourceFile) {
       return undefined;
     }
+    let candidates = candidatesByDeclaration.get(declaration);
+    if (!candidates) {
+      candidates = collectIrImplicitParamProjectionCandidates(declaration);
+      candidatesByDeclaration.set(declaration, candidates);
+    }
+    if (!candidates.has(parameter)) return undefined;
     const parameterFact = ctx.oracle.typeFactOf(parameter);
     if (parameterFact.kind !== "any" && parameterFact.kind !== "unknown") return undefined;
     const parameterIndex = declaration.parameters.indexOf(parameter);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -273,6 +273,7 @@ import {
   applyShapeInference,
   collectDeclarations,
   collectDynamicObjectReturnCarrierTypes,
+  inferImplicitAnyParamType,
   inferNumericReturnTypes,
   collectEmptyObjectWidening,
   collectGrowableObjectLiterals,
@@ -1783,6 +1784,46 @@ function recordObservedIrOutcomes(
   for (const diagnostic of reconciled.diagnostics) reportErrorNoNode(ctx, diagnostic);
 }
 
+// #2949 S5.P — declaration lowering already specializes an implicit-any
+// parameter when its call sites establish one concrete scalar ABI. Project
+// that same decision into structural selection and the IR override map so a
+// claimed function cannot widen to dynamic and then lose ABI parity after
+// the direct callable has been allocated.
+function makeIrImplicitParamTypeResolver(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+): (parameter: ts.ParameterDeclaration) => "f64" | "bool" | "string" | undefined {
+  return (parameter) => {
+    if (parameter.type) return undefined;
+    const declaration = parameter.parent;
+    if (!ts.isFunctionDeclaration(declaration) || !declaration.name || declaration.parent !== sourceFile) {
+      return undefined;
+    }
+    const parameterType = ctx.checker.getTypeAtLocation(parameter);
+    if (!(parameterType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown))) return undefined;
+    const parameterIndex = declaration.parameters.indexOf(parameter);
+    if (parameterIndex < 0) return undefined;
+    const inferred = inferImplicitAnyParamType(ctx, declaration.name.text, parameterIndex, sourceFile, declaration);
+    if (inferred?.kind === "f64") return "f64";
+    if (inferred?.kind === "i32" && inferred.boolean === true) return "bool";
+    if (inferred?.kind === "externref" && ctx.checker.typeToString(parameterType) === "string") return "string";
+    return undefined;
+  };
+}
+
+function resolveIrOverrideParamType(
+  parameter: ts.ParameterDeclaration,
+  mapped: LatticeType | undefined,
+  ctx: CodegenContext,
+  classShapes: IrClassShapeLookup,
+  resolveImplicitParamType: ReturnType<typeof makeIrImplicitParamTypeResolver>,
+): IrType {
+  const projected = resolveImplicitParamType(parameter);
+  if (projected === "f64") return irVal({ kind: "f64" });
+  if (projected === "bool") return irVal({ kind: "i32", boolean: true });
+  return resolvePositionType(effectiveIrParamTypeNode(parameter), mapped, ctx, classShapes);
+}
+
 function planIrOverlay(
   ctx: CodegenContext,
   ast: TypedAST,
@@ -1887,6 +1928,7 @@ function planIrOverlay(
   // claim-then-demote). The carrier keying in `ensureDynMemberGet` matches
   // (`ctx.fast`), so every claimed config emits a valid, carrier-aligned body.
   const dynMemberReadBuildable = !(ctx.fast && !ctx.standalone && !ctx.wasi);
+  const resolveImplicitParamType = makeIrImplicitParamTypeResolver(ctx, ast.sourceFile);
   const identityPlan = irOverlayIdentity.planIrOverlayByIdentity(
     ast.sourceFile,
     identityContext,
@@ -1905,6 +1947,7 @@ function planIrOverlay(
       classifyDeclaredPrimitiveExpression,
       isArrayExpression,
       isRegExpExpression,
+      resolveImplicitParamType,
       projectedClassShapes: classShapes,
       resolveLocalClassExpression,
       supportsSymbolicMathHelpers: true,
@@ -2008,7 +2051,7 @@ function planIrOverlay(
       const params: IrType[] = [];
       for (let i = 0; i < declaration.parameters.length; i++) {
         const p = declaration.parameters[i]!;
-        params.push(resolvePositionType(effectiveIrParamTypeNode(p), entry?.params[i], ctx, classShapeSidecar));
+        params.push(resolveIrOverrideParamType(p, entry?.params[i], ctx, classShapeSidecar, resolveImplicitParamType));
       }
       const override = { params, returnType };
       overrideMapByUnitId.set(unitId, override);

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -4572,6 +4572,17 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = fa
       argVal = cx.builder.emitCallablePack(argVal, expected.signature);
       argType = cx.builder.typeOf(argVal);
     }
+    // #2949 S5.P — a concrete value passed to an `any`/dynamic parameter
+    // crosses the same explicit carrier boundary as a concrete equality
+    // operand. Reuse the canonical tag-aware boxer; ambiguous refs/i32 values
+    // still decline and demote through the existing assignability error.
+    if (expected.kind === "dynamic" && argType.kind !== "dynamic") {
+      const boxed = boxConcreteToDynamic(argVal, argType, argExpr, cx);
+      if (boxed !== null) {
+        argVal = boxed;
+        argType = cx.builder.typeOf(argVal);
+      }
+    }
     if (!irTypeArgAssignable(argType, expected)) {
       throw new Error(
         `ir/from-ast: arg ${i} of call to ${calleeName} is ${describeIrType(argType)}, expected ${describeIrType(expected)} in ${cx.funcName}`,
@@ -4594,15 +4605,14 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = fa
 
 /**
  * (#2856 C4) Wasm-level assignability for direct-call arguments. Exact
- * IrType equality, plus the one sound widening the vec-literal-as-argument
- * shape needs: a NON-NULL `(ref $T)` value passed where the callee's param
- * is `(ref null $T)` — a Wasm subtype, so the call validates and the callee
- * observes the identical value. (`const sorted = [1, 3, 5]` produces
- * `(ref $vec_f64)` via `vec.new_fixed`; a `number[]` param resolves as
- * `(ref null $vec_f64)`.) The reverse (ref_null → ref) stays rejected.
+ * IrType equality, plus sound widenings: a tag-refined dynamic carrier into
+ * an unrefined dynamic parameter, and the vec-literal-as-argument shape's
+ * NON-NULL `(ref $T)` value into `(ref null $T)`. The reverse directions stay
+ * rejected.
  */
 function irTypeArgAssignable(actual: IrType, expected: IrType): boolean {
   if (irTypeEquals(actual, expected)) return true;
+  if (actual.kind === "dynamic" && expected.kind === "dynamic" && expected.tag === undefined) return true;
   const a = asVal(actual);
   const e = asVal(expected);
   if (

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -26,7 +26,12 @@ import { ts } from "../ts-api.js";
 import { makeIrHostDateSnapshotResolver } from "./host-date.js";
 import { supportsIrBackendTargetCapability, type IrBackendTargetCapability } from "./backend/legality.js";
 
-import { ensureAnyHelpers, ensureAnyValueType } from "../codegen/any-helpers.js"; // (#2949) boxed-any carrier for IrType.dynamic
+import {
+  ensureAnyHelpers,
+  ensureAnyValueType,
+  ensureExternLooseEqHelper,
+  ensureExternStrictEqHelper,
+} from "../codegen/any-helpers.js"; // (#2949) boxed-any carrier for IrType.dynamic
 import { ensureDynMemberGet } from "../codegen/dyn-read.js"; // (#3053 U1) unified dynamic-reader carrier primitive __dyn_member_get
 import { ensureLateImport, flushLateImportShifts } from "../codegen/shared.js"; // (#2949 S5.2) host __host_eq / __host_loose_eq registration; (#3143) flush the __extern_is_undefined batch pre-Phase-3
 import { getOrRegisterPromiseType, isStandalonePromiseActive } from "../codegen/async-scheduler.js";
@@ -4127,6 +4132,7 @@ function jsTagToStaticType(
 function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef[]): void {
   let usesDynamicOps = false;
   let usesEq = false;
+  let usesToNumber = false;
   let usesMemberGet = false;
   // (#3143) A from-ast lowering can emit a DIRECT named call to a member of the
   // `addUnionImports` family (`__box_number` / `__unbox_number` / `__box_boolean`
@@ -4152,6 +4158,7 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
         forEachInstrDeep(instr, (i) => {
           if (isDynamicOp(i)) usesDynamicOps = true;
           if (usesDynEq(i)) usesEq = true;
+          if (i.kind === "dyn.to_number") usesToNumber = true;
           if (usesDynMemberGet(i)) usesMemberGet = true;
           if (i.kind === "call" && i.target.binding.kind === "import" && i.target.binding.module === "env") {
             if (UNION_IMPORT_FUNC_NAMES.has(i.target.binding.field)) usesNamedUnionImport = true;
@@ -4183,6 +4190,14 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
     flushLateImportShifts(ctx, null);
   }
   if (!usesDynamicOps) return;
+  if (usesToNumber && ctx.standalone) {
+    // The canonical standalone ToNumber sequence performs
+    // ToPrimitive("number") before unboxing. Reserve that provider now so
+    // emitToNumber cannot introduce a late func-index shift while Phase 3
+    // already owns detached IR body buffers.
+    ensureLateImport(ctx, "__to_primitive", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+    flushLateImportShifts(ctx, null);
+  }
   if (ctx.fast) {
     // gc: ensureAnyHelpers registers $AnyValue + the __any_box_*/__any_unbox_*
     // family AND the equality helpers (__any_strict_eq / __any_eq) — one call
@@ -4198,8 +4213,17 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
     // (#329/#2078), exactly like `addUnionImports` above. Both are idempotent;
     // only fired when a host module actually carries a dyn.eq.
     if (usesEq) {
-      ensureLateImport(ctx, "__host_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
-      ensureLateImport(ctx, "__host_loose_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
+      if (ctx.standalone || ctx.wasi) {
+        ensureExternStrictEqHelper(ctx);
+        ensureExternLooseEqHelper(ctx);
+      } else {
+        ensureLateImport(ctx, "__host_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
+        ensureLateImport(ctx, "__host_loose_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
+        // Settle the batch before Phase 3 captures patch-slot and call-target
+        // indices. Leaving these two imports pending can shift the eventual IR
+        // replacement onto a sibling legacy slot.
+        flushLateImportShifts(ctx, null);
+      }
     }
   }
   // #3053 U1 — a `dyn.member_get` present in any IR body needs the unified
@@ -4396,7 +4420,8 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
     };
   }
 
-  // Host (non-fast): externref carrier; ops via the union-import family.
+  // Non-fast: externref carrier; host imports or standalone/WASI native
+  // providers from the union family.
   const callImport = (name: string): Instr => {
     const idx = ctx.funcMap.get(name);
     if (idx === undefined) {
@@ -4505,16 +4530,12 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
       return emitCoercionToBoolean(ctx, { kind: "externref" }, []);
     },
     emitToNumber(): readonly Instr[] {
-      // #2949 S5.3 — ToNumber(externref carrier) via THE canonical
-      // `coercion-engine.emitToNumber` (D4): for the externref carrier it emits
-      // a single `__unbox_number` (`Number(v)`, §7.1.4 — string→StringToNumber,
-      // null→0, undefined→NaN, boolean→0/1). No temp-local allocation for the
-      // externref arm (unlike the gc `$AnyValue` arm), so the body-only
-      // `FunctionContext` shim is sound (same pattern as the gc `emitBox`).
-      // `addUnionImports` already ran in `preregisterDynamicSupport` (which
-      // registers `__unbox_number`), so the internal `addUnionImports` here
-      // finds it by name and adds nothing — no import shift mid-emission.
-      const shim = { body: [] } as unknown as FunctionContext;
+      // #2949 S5.P — route through the canonical coercion engine. Host mode
+      // emits the pre-registered Number(v) import; standalone first performs
+      // its native ToPrimitive("number") walk and then unboxes the result.
+      // The engine may flush a pending late-import shift even when this
+      // detached buffer allocates no locals, so it must expose savedBodies.
+      const shim = { body: [], savedBodies: [] } as unknown as FunctionContext;
       emitCoercionToNumber(ctx, shim, { kind: "externref" });
       return shim.body;
     },
@@ -4528,18 +4549,17 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
       return [];
     },
     emitStrictEq(negate: boolean): readonly Instr[] {
-      // #2949 S5.2 — host STRICT `===` via the SAME `__host_eq` (JS `===`,
-      // §7.2.16) legacy host `any === any` uses (D4, byte-parity with the host
-      // runtime result). `__host_eq` is a host import in this (non-fast,
-      // JS-host) mode; standalone/wasi is the `gc` strategy, which uses the
-      // native `__any_strict_eq` instead — so there is no host-import leak into
-      // a host-free module.
-      return negate ? [callImport("__host_eq"), { op: "i32.eqz" }] : [callImport("__host_eq")];
+      // #2949 S5.P — host STRICT `===` uses the existing JS-host provider.
+      // Standalone/WASI uses the native externref classifier + AnyValue
+      // comparison helper, preserving host-free execution and object identity.
+      const helper = ctx.standalone || ctx.wasi ? "__extern_strict_eq" : "__host_eq";
+      return negate ? [callImport(helper), { op: "i32.eqz" }] : [callImport(helper)];
     },
     emitLooseEq(negate: boolean): readonly Instr[] {
-      // Host LOOSE `==` via `__host_loose_eq` (JS `==`, §7.2.15) — the coercion
-      // arms (String⇄Number, `null == undefined`) are JS's, matching legacy.
-      return negate ? [callImport("__host_loose_eq"), { op: "i32.eqz" }] : [callImport("__host_loose_eq")];
+      // Host LOOSE `==` delegates to JS. Standalone/WASI classifies both
+      // externref carriers and routes through the native `__any_eq` engine.
+      const helper = ctx.standalone || ctx.wasi ? "__extern_loose_eq" : "__host_loose_eq";
+      return negate ? [callImport(helper), { op: "i32.eqz" }] : [callImport(helper)];
     },
     emitMemberGet(): readonly Instr[] {
       // #3053 U1 / #2949 S5.4 — dynamic member read. In host mode the carrier

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -309,6 +309,13 @@ export interface IrSelectionOptions {
    *  this list adds a small per-function overhead. */
   readonly trackFallbacks?: boolean;
   /**
+   * Authoritative direct-callable projection for an unannotated parameter
+   * whose source call sites establish a concrete scalar slot. The selector
+   * consumes that decision instead of widening the parameter to `dynamic` and
+   * withdrawing later on type parity.
+   */
+  readonly resolveImplicitParamType?: (parameter: ts.ParameterDeclaration) => "f64" | "bool" | "string" | undefined;
+  /**
    * Checker-backed certification for recursive call-graph components. A
    * rejected component is kept on the direct path even when optimistic
    * propagation found a scalar-looking signature. Accepted components still
@@ -1760,6 +1767,8 @@ function resolveParamType(p: ts.ParameterDeclaration, mapped: LatticeType | unde
   if (mapped?.kind === "bool") return "bool";
   if (mapped?.kind === "string") return "string";
   if (mapped?.kind === "object") return "object";
+  const projected = currentSelectionOptions?.resolveImplicitParamType?.(p);
+  if (projected !== undefined) return projected;
   // #2949 slice 2 — unannotated + lattice unknown (no evidence) or dynamic
   // (top): the position is honestly DYNAMIC. `mapped` must be present (a
   // TypeMap entry exists for every top-level FunctionDeclaration): class
@@ -1999,18 +2008,93 @@ function dynamicUsesAreMoveOnly(
         return scanExpr(e.right, dynNames.has(e.left.text));
       }
       if (expectDyn) return false; // operator results are concrete-shaped
+
+      const leftIsDyn = isDynShaped(e.left);
+      const rightIsDyn = isDynShaped(e.right);
+      const op = e.operatorToken.kind;
+
+      if (
+        op === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+        op === ts.SyntaxKind.ExclamationEqualsEqualsToken ||
+        op === ts.SyntaxKind.EqualsEqualsToken ||
+        op === ts.SyntaxKind.ExclamationEqualsToken
+      ) {
+        if (leftIsDyn || rightIsDyn) {
+          // #2949 S5.P — open only the concrete equality operands that the
+          // from-ast producer can box without consulting a runtime type:
+          // numeric/string/boolean literals plus null/undefined. Dynamic
+          // operands already carry the exact tag and pass through unchanged.
+          const scanEqualityOperand = (operand: ts.Expression, dynamic: boolean): boolean => {
+            if (dynamic) return scanExpr(operand, true);
+            const concrete = unwrap(operand);
+            if (
+              ts.isNumericLiteral(concrete) ||
+              ts.isStringLiteralLike(concrete) ||
+              concrete.kind === ts.SyntaxKind.TrueKeyword ||
+              concrete.kind === ts.SyntaxKind.FalseKeyword ||
+              concrete.kind === ts.SyntaxKind.NullKeyword ||
+              (ts.isIdentifier(concrete) && concrete.text === "undefined")
+            ) {
+              return scanExpr(concrete, false);
+            }
+            return false;
+          };
+          return scanEqualityOperand(e.left, leftIsDyn) && scanEqualityOperand(e.right, rightIsDyn);
+        }
+      }
+
+      if (
+        op === ts.SyntaxKind.LessThanToken ||
+        op === ts.SyntaxKind.LessThanEqualsToken ||
+        op === ts.SyntaxKind.GreaterThanToken ||
+        op === ts.SyntaxKind.GreaterThanEqualsToken
+      ) {
+        if (leftIsDyn || rightIsDyn) {
+          // #2949 S5.P — the landed relational producer is deliberately the
+          // numeric-abstract arm. Admit exactly one dynamic operand against a
+          // numeric literal; dyn-vs-dyn may require the string/string ARC arm.
+          if (leftIsDyn === rightIsDyn) return false;
+          const concrete = unwrap(leftIsDyn ? e.right : e.left);
+          if (!ts.isNumericLiteral(concrete)) return false;
+          return scanExpr(leftIsDyn ? e.left : e.right, true) && scanExpr(concrete, false);
+        }
+      }
+
+      if (
+        op === ts.SyntaxKind.MinusToken ||
+        op === ts.SyntaxKind.AsteriskToken ||
+        op === ts.SyntaxKind.SlashToken ||
+        op === ts.SyntaxKind.PercentToken
+      ) {
+        // #2949 S5.P — these operators are pure ToNumber operations. A
+        // dynamic-shaped operand uses dyn.to_number; a nested concrete
+        // expression is recursively checked and must itself produce f64.
+        return scanExpr(e.left, leftIsDyn) && scanExpr(e.right, rightIsDyn);
+      }
+
       return scanExpr(e.left, false) && scanExpr(e.right, false);
     }
     if (ts.isPrefixUnaryExpression(e) || ts.isPostfixUnaryExpression(e)) {
       if (expectDyn) return false;
       const op = e.operand;
+      if (
+        isDynShaped(op) &&
+        ts.isPrefixUnaryExpression(e) &&
+        (e.operator === ts.SyntaxKind.PlusToken ||
+          e.operator === ts.SyntaxKind.MinusToken ||
+          e.operator === ts.SyntaxKind.ExclamationToken)
+      ) {
+        return scanExpr(op, true);
+      }
       return scanExpr(op, false);
     }
     if (ts.isConditionalExpression(e)) {
       // Dyn joins in cond-expr arms need refinement widening at the join —
       // slice 3. Concrete conditional expressions pass through.
       if (expectDyn) return false;
-      return scanExpr(e.condition, false) && scanExpr(e.whenTrue, false) && scanExpr(e.whenFalse, false);
+      return (
+        scanExpr(e.condition, isDynShaped(e.condition)) && scanExpr(e.whenTrue, false) && scanExpr(e.whenFalse, false)
+      );
     }
     if (ts.isPropertyAccessExpression(e)) {
       // #3053 U2 / #2949 S5.P — the claim-flip. A named read off a DYNAMIC
@@ -2083,7 +2167,9 @@ function dynamicUsesAreMoveOnly(
     }
     if (ts.isIfStatement(s)) {
       return (
-        scanExpr(s.expression, false) && scanStmt(s.thenStatement) && (!s.elseStatement || scanStmt(s.elseStatement))
+        scanExpr(s.expression, isDynShaped(s.expression)) &&
+        scanStmt(s.thenStatement) &&
+        (!s.elseStatement || scanStmt(s.elseStatement))
       );
     }
     if (ts.isBlock(s)) {
@@ -2091,7 +2177,7 @@ function dynamicUsesAreMoveOnly(
       return true;
     }
     if (ts.isWhileStatement(s)) {
-      return scanExpr(s.expression, false) && scanStmt(s.statement);
+      return scanExpr(s.expression, isDynShaped(s.expression)) && scanStmt(s.statement);
     }
     // For / for-of / for-in / switch / try / throw / nested functions /
     // anything else: conservative — claimable exactly when the statement

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -2025,7 +2025,16 @@ function dynamicUsesAreMoveOnly(
           // numeric/string/boolean literals plus null/undefined. Dynamic
           // operands already carry the exact tag and pass through unchanged.
           const scanEqualityOperand = (operand: ts.Expression, dynamic: boolean): boolean => {
-            if (dynamic) return scanExpr(operand, true);
+            if (dynamic) {
+              const candidate = unwrap(operand);
+              // Dynamic member reads are not yet safe at callback boundaries:
+              // legacy array methods pass their `obj` argument in the direct
+              // array carrier, while __dyn_member_get expects boxed-any input.
+              // Keep `obj.length === n` pre-claim until that carrier seam is
+              // unified; direct dynamic params remain claimable.
+              if (ts.isPropertyAccessExpression(candidate) || ts.isElementAccessExpression(candidate)) return false;
+              return scanExpr(candidate, true);
+            }
             const concrete = unwrap(operand);
             if (
               ts.isNumericLiteral(concrete) ||

--- a/tests/issue-2949-s5-p-claim-flip.test.ts
+++ b/tests/issue-2949-s5-p-claim-flip.test.ts
@@ -88,4 +88,21 @@ describe("#2949 S5.P dynamic-operator claim flip", () => {
     const { instance } = await WebAssembly.instantiate(result.binary, {});
     expect((instance.exports.parseHex as () => number)()).toBe(1114);
   });
+
+  it("boxes a concrete numeric result at an explicit-any direct-call boundary", async () => {
+    const result = await compileStandalone(`
+      function sameValue(actual: any, expected: any): number {
+        return actual === expected ? 1 : 0;
+      }
+
+      export function checkPow(): number {
+        return sameValue(Math.pow(2, 3), 8);
+      }
+    `);
+
+    expect(result.irCompiledFuncs).toEqual(expect.arrayContaining(["sameValue", "checkPow"]));
+
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.checkPow as () => number)()).toBe(1);
+  });
 });

--- a/tests/issue-2949-s5-p-claim-flip.test.ts
+++ b/tests/issue-2949-s5-p-claim-flip.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2949 S5.P — claim the landed dynamic truthiness/equality/relational/
+// arithmetic producers and keep the selector's parameter ABI aligned with the
+// direct callable.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+const DYNAMIC_HELPERS = `
+export function isModifier(ch: any): boolean {
+  return ch === 105 || ch === 109 || ch === 115;
+}
+
+export function isLooseDigit(ch: any): boolean {
+  return ch == 53;
+}
+
+export function isDigit(ch: any): boolean {
+  return ch >= 48 && ch <= 57;
+}
+
+export function dec(ch: any): number {
+  return ch - 1;
+}
+
+export function truth(ch: any): number {
+  return ch ? 1 : 0;
+}
+`;
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    allowJs: true,
+    experimentalIR: true,
+    fileName: "issue-2949-s5-p.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    trackIrOutcomes: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.irPostClaimErrors ?? []).toEqual([]);
+  try {
+    new WebAssembly.Module(result.binary);
+  } catch (error) {
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}\n${result.errors.map((entry) => entry.message).join("\n")}`,
+    );
+  }
+  return result;
+}
+
+describe("#2949 S5.P dynamic-operator claim flip", () => {
+  it("emits and runs the Acorn-style dynamic helper family in standalone", async () => {
+    const result = await compileStandalone(DYNAMIC_HELPERS);
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toEqual(
+      expect.arrayContaining(["isModifier", "isLooseDigit", "isDigit", "dec", "truth"]),
+    );
+
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.isModifier as (value: unknown) => number)(105)).toBe(1);
+    expect((instance.exports.isModifier as (value: unknown) => number)(53)).toBe(0);
+    expect((instance.exports.isLooseDigit as (value: unknown) => number)(53)).toBe(1);
+    expect((instance.exports.isLooseDigit as (value: unknown) => number)(54)).toBe(0);
+    expect((instance.exports.isDigit as (value: unknown) => number)(53)).toBe(1);
+    expect((instance.exports.dec as (value: unknown) => number)(53)).toBe(52);
+    expect((instance.exports.truth as (value: unknown) => number)(0)).toBe(0);
+    expect((instance.exports.truth as (value: unknown) => number)(53)).toBe(1);
+  });
+
+  it("projects a concrete implicit parameter ABI before claim and emits without parity withdrawal", async () => {
+    const result = await compileStandalone(`
+      function hexToInt(ch) {
+        if (ch >= 65 && ch <= 70) return 10 + (ch - 65);
+        if (ch >= 97 && ch <= 102) return 10 + (ch - 97);
+        return ch - 48;
+      }
+
+      export function parseHex() {
+        return hexToInt(66) * 100 + hexToInt(101);
+      }
+    `);
+
+    expect(result.irCompiledFuncs).toEqual(expect.arrayContaining(["hexToInt", "parseHex"]));
+    expect(result.irOutcomes?.some((outcome) => outcome.code === "abi-signature-parity")).toBe(false);
+
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.parseHex as () => number)()).toBe(1114);
+  });
+});


### PR DESCRIPTION
## Summary

- admit the landed dynamic equality, numeric relational/arithmetic, unary coercion, and condition shapes into IR selection
- project direct-callable scalar parameter inference into selection and IR ABI overrides
- keep standalone/WASI equality host-free and route dynamic ToNumber through the canonical coercion engine
- record this slice in plan/issues/2949-ir-dynamic-value-representation.md

## Measured Acorn result

Exact runtime-dynamic Acorn 8.16.0 driver from #3796:

- baseline: 0 of 43 terminal functions emitted through IR
- this PR: 14 of 43 emitted through IR
- post-claim withdrawals: 0
- remaining: 19 body shapes, 3 logical-value shapes, 2 RegExp constructor shapes, 2 parameter shapes, 2 call-graph closures, 1 constructor-resolution shape

This PR does not modify the five generic codegen files owned by #3796.

## Validation

- pnpm run test:guard (182 passed, 4 skipped)
- pnpm run check:ir-fallbacks
- pnpm run check:func-budget
- pnpm run check:loc-budget
- pnpm run typecheck
- pnpm exec vitest run tests/issue-2949-s5-p-claim-flip.test.ts
- exact #3796 Acorn outcome driver

The global check:ir-only readiness probe still reports the existing project-wide unsupported units and enabled legacy bodies; this slice does not claim that global gate is ready.