### PR TITLE
feat(ir): project implicit indexed parameter ABIs (#2949)

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -24,7 +24,7 @@ loc-budget-allow:
   - src/codegen/any-helpers.ts
 func-budget-allow:
   - src/codegen/index.ts::planIrOverlay
-branch: codex/2949-acorn-direct-member-equality
+branch: codex/2949-acorn-implicit-array-param
 ---
 
 # #2949 — the IR's type system is Wasm types, not JS types
@@ -1965,3 +1965,46 @@ IR emission plus zero post-claim failures. The exact #3796 driver remains the
 per-slice measurement input. Its synthesized module uses a 32,768-element
 `array.new_fixed`; V8 rejects fixed arrays above 10,000 elements, so that
 driver is a compile/outcome probe rather than the focused runtime fixture.
+
+## Implementation Notes — implicit indexed-parameter ABI (2026-07-29)
+
+Acorn's untyped `isInAstralSet(code, set)` now emits through IR. Direct
+declaration lowering already infers `set` as the exact
+`ref null __vec_f64` carrier from its call sites. Planning now reuses that
+exact `IrType` instead of reducing the decision to a scalar-only label.
+Projection remains restricted to `__vec_*` / `__arr_*` carriers; incidental
+anonymous object shapes are not admitted.
+
+Two selector seams were required by the exact source:
+
+- the dynamic `code` parameter is compared with the proven numeric local
+  `pos` inside a `for` loop, so the existing dynamic-to-number relational
+  lowering is admitted for proven f64 counterparts and the dynamic-use scan
+  now descends through ordinary `for` statements;
+- `isIdentifierStart` and `isIdentifierChar` remain on the direct path because
+  of their RegExp constructors. Standalone caller closure is relaxed only when
+  every untyped parameter has a production-certified projection and at least
+  one is an indexed carrier. Their already-emitted calls therefore keep the
+  exact direct callable ABI while the leaf body moves to IR.
+
+The unchanged #3796 runtime-dynamic compile/outcome driver moves from 16 to
+**17 emitted functions out of 43**, with `isInAstralSet` added and zero
+post-claim withdrawals. Remaining terminal blockers are:
+
+- 15 body-shape rejections;
+- 3 parameter-type rejections;
+- 3 logical-value rejections;
+- 2 RegExp-constructor rejections;
+- 2 call-graph closures;
+- 1 constructor-resolution rejection.
+
+The slice does not touch the direct-backend files owned by draft PR #3796.
+
+Validation for this slice:
+
+- exact #3796 driver: 17/43 emitted, zero post-claim withdrawals;
+- focused implicit-parameter and IR guard suites: 26/26 pass;
+- broader curated guard matrix: 182 pass, 4 skipped;
+- equivalence matrix: 8/8 shards, zero new regressions;
+- typecheck, lint, fallback/adoption/oracle, LOC, function-budget, harness
+  compile-budget, and linear-IR gates pass.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1829,6 +1829,10 @@ function collectIrImplicitParamProjectionCandidates(
     ) {
       return parent.operand === child;
     }
+    if (ts.isPropertyAccessExpression(parent) && parent.expression === child) {
+      return parent.name.text === "length";
+    }
+    if (ts.isElementAccessExpression(parent) && parent.expression === child) return true;
     return false;
   };
   const visit = (node: ts.Node): void => {
@@ -1843,14 +1847,19 @@ function collectIrImplicitParamProjectionCandidates(
 }
 
 // #2949 S5.P — declaration lowering already specializes an implicit-any
-// parameter when its call sites establish one concrete scalar ABI. Project
+// parameter when its call sites establish one concrete ABI. Project
 // that same decision into structural selection and the IR override map so a
 // claimed function cannot widen to dynamic and then lose ABI parity after
 // the direct callable has been allocated.
+interface IrImplicitParamProjection {
+  readonly kind: "f64" | "bool" | "string" | "object" | "dynamic";
+  readonly type: IrType;
+}
+
 function makeIrImplicitParamTypeResolver(
   ctx: CodegenContext,
   sourceFile: ts.SourceFile,
-): (parameter: ts.ParameterDeclaration) => "f64" | "bool" | "string" | "dynamic" | undefined {
+): (parameter: ts.ParameterDeclaration) => IrImplicitParamProjection | undefined {
   const candidatesByDeclaration = new WeakMap<ts.FunctionDeclaration, ReadonlySet<ts.ParameterDeclaration>>();
   return (parameter) => {
     if (parameter.type) return undefined;
@@ -1869,17 +1878,27 @@ function makeIrImplicitParamTypeResolver(
     const parameterIndex = declaration.parameters.indexOf(parameter);
     if (parameterIndex < 0) return undefined;
     const callSites = inferParamTypeFromCallSites(ctx, declaration.name.text, parameterIndex, sourceFile);
-    if (callSites.sawCallSite && callSites.type === null) return "dynamic";
+    if (callSites.sawCallSite && callSites.type === null) {
+      return { kind: "dynamic", type: irDynamic() };
+    }
     const inferred = inferImplicitAnyParamType(ctx, declaration.name.text, parameterIndex, sourceFile, declaration);
-    if (inferred?.kind === "f64") return "f64";
-    if (inferred?.kind === "i32" && inferred.boolean === true) return "bool";
+    if (inferred?.kind === "f64") return { kind: "f64", type: irVal(inferred) };
+    if (inferred?.kind === "i32" && inferred.boolean === true) {
+      return { kind: "bool", type: irVal(inferred) };
+    }
     if (
       inferred?.kind === "ref" &&
       ctx.nativeStrings &&
       ctx.anyStrTypeIdx >= 0 &&
       inferred.typeIdx === ctx.anyStrTypeIdx
     ) {
-      return "string";
+      return { kind: "string", type: { kind: "string" } };
+    }
+    if (inferred?.kind === "ref" || inferred?.kind === "ref_null") {
+      const structName = ctx.typeIdxToStructName.get(inferred.typeIdx);
+      if (structName?.startsWith("__vec_") || structName?.startsWith("__arr_")) {
+        return { kind: "object", type: irVal(inferred) };
+      }
     }
     return undefined;
   };
@@ -1893,16 +1912,13 @@ function resolveIrOverrideParamType(
   resolveImplicitParamType: ReturnType<typeof makeIrImplicitParamTypeResolver>,
 ): IrType {
   const projected = resolveImplicitParamType(parameter);
-  if (projected === "f64") return irVal({ kind: "f64" });
-  if (projected === "bool") return irVal({ kind: "i32", boolean: true });
-  if (projected === "string") return { kind: "string" };
   // Keep the established numeric parity-withdrawal path (#3551): lattice f64
   // may still form the speculative IR view, and the patch-time ABI guard then
   // withdraws the complete caller cluster if legacy kept the param dynamic.
   // Nonnumeric mapped kinds cannot lower polymorphic equality soundly before
   // that guard (the #3471 string failure), so those retain the direct dynamic
   // ABI in the IR view.
-  if (projected === "dynamic" && mapped?.kind !== "f64") return irDynamic();
+  if (projected && !(projected.kind === "dynamic" && mapped?.kind === "f64")) return projected.type;
   return resolvePositionType(effectiveIrParamTypeNode(parameter), mapped, ctx, classShapes);
 }
 
@@ -2011,6 +2027,16 @@ function planIrOverlay(
   // (`ctx.fast`), so every claimed config emits a valid, carrier-aligned body.
   const dynMemberReadBuildable = !(ctx.fast && !ctx.standalone && !ctx.wasi);
   const resolveImplicitParamType = makeIrImplicitParamTypeResolver(ctx, ast.sourceFile);
+  const legacyCallerAbiIsProjected = (declaration: ts.FunctionDeclaration): boolean => {
+    let hasIndexedCarrier = false;
+    for (const parameter of declaration.parameters) {
+      if (effectiveIrParamTypeNode(parameter)) continue;
+      const projection = resolveImplicitParamType(parameter);
+      if (!projection) return false;
+      if (projection.kind === "object") hasIndexedCarrier = true;
+    }
+    return hasIndexedCarrier;
+  };
   const identityPlan = irOverlayIdentity.planIrOverlayByIdentity(
     ast.sourceFile,
     identityContext,
@@ -2037,7 +2063,8 @@ function planIrOverlay(
       classifyDeclaredPrimitiveExpression,
       isArrayExpression,
       isRegExpExpression,
-      resolveImplicitParamType,
+      resolveImplicitParamType: (parameter) => resolveImplicitParamType(parameter)?.kind,
+      legacyCallerAbiIsProjected,
       projectedClassShapes: classShapes,
       resolveLocalClassExpression,
       supportsSymbolicMathHelpers: true,

--- a/src/ir/select-identity.ts
+++ b/src/ir/select-identity.ts
@@ -102,6 +102,15 @@ interface IndexedClass {
   readonly declaration: ts.ClassDeclaration;
 }
 
+function legacyCallerAbiIsProjectedForIdentity(
+  options: IrIdentitySelectionOptions,
+  functions: ReadonlyArray<IndexedFunction>,
+  unitId: IrUnitId,
+): boolean {
+  const declaration = functions.find(({ unit }) => unit.unitId === unitId)?.declaration;
+  return declaration !== undefined && options.legacyCallerAbiIsProjected?.(declaration) === true;
+}
+
 interface IdentityCallGraph {
   readonly callers: ReadonlyMap<IrUnitId, ReadonlySet<IrUnitId>>;
   readonly callees: ReadonlyMap<IrUnitId, ReadonlySet<IrUnitId>>;
@@ -679,8 +688,11 @@ export function planIrCompilationByIdentity(
     while (changed) {
       changed = false;
       for (const unitId of [...claimed.keys()]) {
+        const legacyCallerAbiIsProjected = legacyCallerAbiIsProjectedForIdentity(options, functions, unitId);
         const unsafeCaller =
-          demoteOnLegacyCaller && [...(graph.callers.get(unitId) ?? [])].some((caller) => !claimed.has(caller));
+          demoteOnLegacyCaller &&
+          !legacyCallerAbiIsProjected &&
+          [...(graph.callers.get(unitId) ?? [])].some((caller) => !claimed.has(caller));
         const unsafeCallee = [...(graph.callees.get(unitId) ?? [])].some((callee) => !claimed.has(callee));
         if (!unsafeCaller && !unsafeCallee) continue;
         claimed.delete(unitId);

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -317,7 +317,13 @@ export interface IrSelectionOptions {
    */
   readonly resolveImplicitParamType?: (
     parameter: ts.ParameterDeclaration,
-  ) => "f64" | "bool" | "string" | "dynamic" | undefined;
+  ) => "f64" | "bool" | "string" | "object" | "dynamic" | undefined;
+  /**
+   * Standalone/WASI normally close claims over local callers. A production
+   * planner may exempt a callee when its direct callable and IR overlay share
+   * one fully certified ABI, making a legacy caller's pre-emitted call safe.
+   */
+  readonly legacyCallerAbiIsProjected?: (declaration: ts.FunctionDeclaration) => boolean;
   /**
    * Checker-backed certification for recursive call-graph components. A
    * rejected component is kept on the direct path even when optimistic
@@ -562,6 +568,15 @@ function bodyHasAsyncOutOfIrScope(body: ts.Node): boolean {
 }
 
 const EMPTY: IrSelection = { funcs: new Set<string>() };
+
+function legacyCallerAbiIsProjected(
+  options: IrSelectionOptions | undefined,
+  declarations: ReadonlyMap<string, ts.FunctionDeclaration>,
+  name: string,
+): boolean {
+  const declaration = declarations.get(name);
+  return declaration !== undefined && options?.legacyCallerAbiIsProjected?.(declaration) === true;
+}
 
 export function planIrCompilation(
   sourceFile: ts.SourceFile,
@@ -976,8 +991,8 @@ export function planIrCompilation(
     for (const name of [...claimed]) {
       const myCallees = callees.get(name) ?? new Set<string>();
       let safe = true;
-      // Caller-direction demotion remains only in standalone/wasi (#2858).
-      if (demoteOnLegacyCaller) {
+      // Standalone/WASI keep caller closure unless production certifies one exact ABI.
+      if (demoteOnLegacyCaller && !legacyCallerAbiIsProjected(options, declByName, name)) {
         const myCallers = callers.get(name) ?? new Set<string>();
         for (const c of myCallers) {
           if (!claimed.has(c)) {
@@ -2197,10 +2212,13 @@ function dynamicUsesAreMoveOnly(
         if (leftIsDyn || rightIsDyn) {
           // #2949 S5.P — the landed relational producer is deliberately the
           // numeric-abstract arm. Admit exactly one dynamic operand against a
-          // numeric literal; dyn-vs-dyn may require the string/string ARC arm.
+          // proven numeric expression; dyn-vs-dyn may require the
+          // string/string ARC arm. A concrete f64 counterpart makes the ARC
+          // numeric by construction, so locals such as Acorn's `pos > code`
+          // are as safe as numeric literals.
           if (leftIsDyn === rightIsDyn) return false;
           const concrete = unwrap(leftIsDyn ? e.right : e.left);
-          if (!ts.isNumericLiteral(concrete)) return false;
+          if (!expressionIsProvenNumber(concrete)) return false;
           return scanExpr(leftIsDyn ? e.left : e.right, true) && scanExpr(concrete, false);
         }
       }
@@ -2324,6 +2342,12 @@ function dynamicUsesAreMoveOnly(
     if (ts.isWhileStatement(s)) {
       return scanExpr(s.expression, isDynShaped(s.expression)) && scanStmt(s.statement);
     }
+    if (ts.isForStatement(s)) {
+      if (s.initializer && subtreeTouchesDynamic(s.initializer, dynNames)) return false;
+      if (s.condition && !scanExpr(s.condition, isDynShaped(s.condition))) return false;
+      if (s.incrementor && !scanExpr(s.incrementor, false)) return false;
+      return scanStmt(s.statement);
+    }
     if (ts.isForInStatement(s)) {
       return (
         currentSelectionOptions?.isDynamicForInReceiver?.(s.expression) === true &&
@@ -2332,7 +2356,7 @@ function dynamicUsesAreMoveOnly(
         scanStmt(s.statement)
       );
     }
-    // For / for-of / switch / try / throw / nested functions /
+    // For-of / switch / try / throw / nested functions /
     // anything else: conservative — claimable exactly when the statement
     // doesn't touch a dynamic value at all.
     return !subtreeTouchesDynamic(s, dynNames);

--- a/tests/issue-2949-implicit-array-param.test.ts
+++ b/tests/issue-2949-implicit-array-param.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2949 — an untyped parameter whose call sites agree on one native vec
+// carrier must use that exact ABI in both the direct callable and the IR
+// overlay. Acorn's isInAstralSet helper is the measured runtime-dynamic case.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+describe("#2949 — implicit array parameter projection", () => {
+  it("emits the Acorn isInAstralSet helper without ABI withdrawal", async () => {
+    const result = await compile(
+      `
+        function isInAstralSet(code, set) {
+          var pos = 0x10000;
+          for (var i = 0; i < set.length; i += 2) {
+            pos += set[i];
+            if (pos > code) return false;
+            pos += set[i + 1];
+            if (pos >= code) return true;
+          }
+          return false;
+        }
+
+        export function callAstral(code: any, set: number[]): boolean {
+          return new RegExp("x").test("x") && isInAstralSet(code, set);
+        }
+      `,
+      {
+        allowJs: true,
+        experimentalIR: true,
+        fileName: "issue-2949-implicit-array-param.ts",
+        skipSemanticDiagnostics: true,
+        target: "standalone",
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs ?? [], JSON.stringify(result.irOutcomes, null, 2)).toContain("isInAstralSet");
+    expect(result.irCompiledFuncs ?? []).not.toContain("callAstral");
+    expect(result.irOutcomes?.some((outcome) => outcome.code === "abi-signature-parity")).toBe(false);
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- project exact inferred vector and array carriers into IR parameter types
- admit proven numeric dynamic comparisons inside ordinary for loops
- keep standalone legacy-caller closure unless the complete implicit ABI is certified and includes an indexed carrier
- add focused runtime coverage for Acorn isInAstralSet

## Acorn migration result

The unchanged runtime-dynamic #3796 compile/outcome driver advances from 16 to 17 of 43 reachable functions emitted through IR. isInAstralSet is the added function, with zero post-claim withdrawals.

Remaining terminal blockers: 15 body-shape, 3 parameter-type, 3 logical-value, 2 RegExp-constructor, 2 call-graph closure, and 1 constructor-resolution.

## Validation

- focused implicit-parameter and IR guard suites: 26/26
- curated guard matrix: 182 pass, 4 skipped
- equivalence matrix: all 8 shards, zero new regressions
- typecheck, lint, formatting, fallback/adoption/oracle, LOC, function-budget, harness compile-budget, and linear-IR gates

## Coordination

This PR does not touch the direct-backend files owned by draft PR #3796. Its typed-receiver, argc-frame, numeric-switch, and RegExp dispatch parity requirements remain unchanged.