### PR TITLE
fix(ir #3784): type the no-box number-local gate so it demotes instead of hard-failing

### DIFF
--- a/plan/issues/3784-unboxed-number-local-gate-hard-errors.md
+++ b/plan/issues/3784-unboxed-number-local-gate-hard-errors.md
@@ -1,0 +1,145 @@
+---
+id: 3784
+title: "#2782/#2790's no-box number-local gate threw a PLAIN Error, so its documented demote-to-legacy became a HARD compile error — latent until #3783 claimed function-local `var`s, then ordinary untyped JS stopped compiling on every target"
+status: done
+completed: 2026-07-29
+sprint: current
+created: 2026-07-29
+updated: 2026-07-29
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: correctness
+area: codegen
+language_feature: variables
+goal: backend-agnostic-ir
+depends_on: []
+related: [2782, 2790, 3341, 3519, 3565, 3783, 3795]
+# `from-ast.ts` +4: the two extra `IrUnsupportedError` constructor arguments
+# (code + stage) and a two-line comment recording why the throw must be typed.
+# The throw has to stay at the gate — it IS the gate's verdict — so this cannot
+# move to a subsystem module. Trimmed from an initial +11 by moving the full
+# rationale into `outcomes.ts` (next to the #3565 siblings) and this file; the
+# residual 4 lines are the fix itself.
+loc-budget-allow:
+  - src/ir/from-ast.ts
+---
+
+# #3784 — a documented demotion that was really a hard error
+
+## Summary
+
+`function g(s) { var c = s.charCodeAt(0); return f(c); }` — an untyped
+parameter, i.e. ordinary JavaScript — **did not compile at all** on current
+`main`. Not a fallback, not a warning: `success: false`, **zero-byte binary**,
+on `standalone`, `gc` and the default JS-host target alike.
+
+```
+Codegen error: IR path failed for g: ir/from-ast: local 'c' is bound as an
+unboxed f64 but its TS type is not provably a pure number — ... demote to the
+SAFE boxed legacy lowering in g (#2782/#2790) [IR-FALLBACK]
+```
+
+Read the message: it _asks for a demotion_ and then fails the build.
+
+## Root cause — the throw was untyped
+
+`lowerVarDecl`'s #2782/#2790 no-box NUMBER-local proof gate
+(`src/ir/from-ast.ts`) states its own contract:
+
+> anything unprovable — `any` / `unknown` / a MIXED `number | string` union —
+> demotes to the SAFE boxed legacy lowering (which carries the dynamic tag)
+
+But it raised a **plain `new Error(...)`**. `classifyIrFailure`
+(`src/ir/outcomes.ts`) buckets any untyped throw as
+`{ kind: "invariant", code: "unexpected-internal-throw" }`, and
+`formatIrPathFallbackDiagnostic` (`src/codegen/index.ts:1602`) makes
+`kind === "invariant"` a **hard** `Codegen error`. So the demotion channel was
+never entered; the gate's documented safe path was unreachable by construction.
+
+**This is a known class, and this is its fifth site.** #3565 already retyped
+"DESIGNED demote-to-legacy sites that #3341/#3519 silently promoted to hard
+`invariant` compile errors, contradicting their own documented contracts" —
+four codes: `element-store-unsupported`, `element-access-unsupported`,
+`return-type-legacy-coupling`, `compound-assign-unsupported`. This gate is the
+same mistake once more.
+
+## Why it surfaced now — #3783
+
+The bug is older than #3783, but **latent**: before it, the IR selector did not
+claim functions containing function-local `var` declarations, so the gate was
+not reached for them. `89015a58d` _"feat(ir): adopt function-local var
+declarations"_ (#3783, merged as PR #3802) made the selector claim them — and a
+claimed function that throws fails **post-claim**, where there is no fallback.
+
+Bisected, `git bisect run` over 67 revisions:
+
+| commit                                           | result                   |
+| ------------------------------------------------ | ------------------------ |
+| `3cb92d271` (parent)                             | compiles (682 KB WAT)    |
+| **`89015a58d`** _adopt function-local var decls_ | **`wat=0`, build fails** |
+
+`let` was affected identically — the gate is per-binding, not per-keyword, so
+"function-local `var`" names the _trigger_, not the blast radius.
+
+## Blast radius, measured on `main` before the fix
+
+| source shape                                      | before   | after |
+| ------------------------------------------------- | -------- | ----- |
+| `var c = s.charCodeAt(0)` → passed to a helper    | **FAIL** | OK    |
+| `var c = s.charCodeAt(0)` used inline             | **FAIL** | OK    |
+| `var c = s` (parameter is `any`)                  | **FAIL** | OK    |
+| `let c = s.charCodeAt(0)` → helper (same shape)   | **FAIL** | OK    |
+| `var n = s.length`                                | **FAIL** | OK    |
+| `var c = 5` (in-range literal — provably numeric) | OK       | OK    |
+
+Five of six. The surviving case is the one where the TS type _is_ provably a
+pure number, which is exactly the gate working as intended.
+
+## Why CI was green anyway
+
+No test covered the shape. It was caught only because **PR #3795** added a test
+asserting a grounded numeric-local proof reaches an untyped helper parameter
+(`tests/issue-3765-numeric-locals.test.ts`) — that test failed, and the failure
+was initially read as #3795's own. It is not: the repro reproduces on `main`
+with #3795 nowhere in the tree.
+
+This is the load-bearing lesson. A gate whose safe path is unreachable is
+invisible to a green suite; only a test that exercises the _unprovable_ branch
+can see it. The three #3565 sites had the same profile.
+
+## Fix
+
+Throw the typed `IrUnsupportedError` the demotion channel expects, under a new
+`IrUnsupportedCode`:
+
+- `src/ir/outcomes.ts` — add `"unboxed-number-local-unprovable"` to
+  `IrUnsupportedCode`, documented alongside the #3565 siblings.
+- `src/ir/from-ast.ts` — the gate throws
+  `new IrUnsupportedError("unboxed-number-local-unprovable", "build", …)`
+  instead of `new Error(…)`. Message text unchanged.
+
+`kind: "unsupported"` is not hard, so the function demotes to the boxed legacy
+body — the behaviour the comment promised since #2782. A genuine builder desync
+still raises `invariant` and still hard-fails; nothing widens.
+
+## Validation
+
+- **The six shapes above** compile, and **five run correctly against real JS**
+  (compiled → instantiated → compared: `charCodeAt`→helper, inline, `any` param,
+  `.length`, `let`). Compiling is not the bar; the demoted body must be right.
+- `tests/issue-3765-numeric-locals.test.ts` + `tests/issue-3783-ir-function-local-var.test.ts`
+  — 20/20 pass (#3783's own adoption suite is unaffected).
+- `scripts/equivalence-gate.mjs` — no new regressions.
+- `tsc --noEmit` clean.
+
+## Follow-up
+
+`classifyIrFailure`'s untyped-throw default is `invariant`, i.e. **fail hard**.
+That is the right default for a real desync, but it means every future
+demote-to-legacy site is one forgotten error class away from becoming a build
+failure — five sites have now made exactly this mistake (#3341/#3519 ×3, plus
+this one). Worth a gate: no `throw new Error` in `src/ir/from-ast.ts`, forcing
+an explicit choice between `IrUnsupportedError` and `IrInvariantError`. Filed
+as a note here rather than scope-creeping this fix.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -2667,7 +2667,11 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
       cx.emptyArrayInference.isResolvedVectorExpression(d.initializer);
     if (!scalarVecValue && !proveUnboxedNumberLocal(d.name, inferred, cx)) {
       const boundKind = asVal(inferred)?.kind === "i32" ? "i32" : "f64";
-      throw new Error(
+      // (#3784) Typed `unsupported`, never a plain `Error` — an untyped throw is
+      // classified `invariant` and hard-fails, defeating the demotion below.
+      throw new IrUnsupportedError(
+        "unboxed-number-local-unprovable",
+        "build",
         `ir/from-ast: local '${name}' is bound as an unboxed ${boundKind} but its TS type is not ` +
           `provably a pure number${boundKind === "i32" ? " or boolean" : ""} — keeping the no-box ` +
           `number representation is unsound (the ${boundKind} Wasm kind conflates number / boolean / ` +

--- a/src/ir/outcomes.ts
+++ b/src/ir/outcomes.ts
@@ -44,6 +44,19 @@ export type IrUnsupportedCode =
   //     to a non-f64 (e.g. an externref generator value): the numeric coercion
   //     is legacy-only. Measured casualty: tests/issue-2079 (a for-of over a
   //     generator, `s += v`) hard-erroring where legacy compiles+runs (=3).
+  // A FIFTH site in this same class, found 2026-07-29 (#3784):
+  //   - `unboxed-number-local-unprovable` — the #2782/#2790 no-box NUMBER-local
+  //     proof gate in `lowerVarDecl` (from-ast.ts). Its own comment states the
+  //     contract: "anything unprovable — `any` / `unknown` / a MIXED
+  //     `number | string` union — demotes to the SAFE boxed legacy lowering".
+  //     It threw a PLAIN `Error`, so `classifyIrFailure` bucketed it as
+  //     `unexpected-internal-throw` and the documented demotion became a hard
+  //     compile error. Latent until #3783 adopted function-local `var`s into the
+  //     IR path: that made the selector CLAIM functions whose locals reach this
+  //     gate, so `function g(s){ var c = s.charCodeAt(0); return f(c); }` — an
+  //     `any`-typed receiver, i.e. ordinary untyped JS — stopped compiling at
+  //     all (empty binary) on every target. `let` was equally affected.
+  | "unboxed-number-local-unprovable"
   | "element-store-unsupported"
   | "element-access-unsupported"
   | "return-type-legacy-coupling"

--- a/tests/issue-3784-unboxed-local-demotes.test.ts
+++ b/tests/issue-3784-unboxed-local-demotes.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3784) The #2782/#2790 no-box NUMBER-local proof gate must DEMOTE, not fail
+ * the build.
+ *
+ * The gate's own comment promises that an unprovable local type — `any`,
+ * `unknown`, a mixed `number | string` union — "demotes to the SAFE boxed
+ * legacy lowering". It threw a PLAIN `Error`, which `classifyIrFailure` buckets
+ * as `invariant/unexpected-internal-throw` and `formatIrPathFallbackDiagnostic`
+ * reports as a HARD `Codegen error`. So the promised safe path was unreachable
+ * by construction.
+ *
+ * Latent until #3783 adopted function-local `var` declarations: that made the
+ * selector CLAIM these functions, and a claimed function's throw fails
+ * POST-claim, where no fallback exists. Result on `main`: ordinary untyped JS
+ * produced a zero-byte binary on every target.
+ *
+ * These assertions are deliberately about OUTCOMES (does it build, does it
+ * compute the right answer), not about the emitted instruction mix. An
+ * instruction-mix assertion cannot see this bug — the failure is that there is
+ * no output at all.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function build(source: string, target: "standalone" | "gc" = "standalone") {
+  return await compile(source, {
+    fileName: "t.mjs",
+    skipSemanticDiagnostics: true,
+    target,
+    emitWat: true,
+  });
+}
+
+async function run(source: string): Promise<number> {
+  const r = await build(source);
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(r.binary.length).toBeGreaterThan(0);
+  const instance = await WebAssembly.instantiate(await WebAssembly.compile(r.binary), {});
+  return (instance.exports as { main: () => number }).main();
+}
+
+/**
+ * Each entry is a shape whose local is bound to an `any`-typed initializer, so
+ * the gate cannot prove a pure number and must demote. Every one of these
+ * failed to compile on `main` at 16c11237d.
+ */
+const SHAPES: ReadonlyArray<{ name: string; source: string; expected: number }> = [
+  {
+    name: "`var` from an any-typed method call, passed to an untyped helper",
+    source: `function f(c){return c>=65&&c<=90;}
+             function g(s){var c=s.charCodeAt(0); return f(c);}
+             export function main(){return g("A");}`,
+    expected: 1,
+  },
+  {
+    name: "`var` from an any-typed method call, used inline",
+    source: `function g(s){var c=s.charCodeAt(0); return c>=65&&c<=90;}
+             export function main(){return g("z");}`,
+    expected: 0,
+  },
+  {
+    name: "`var` initialized directly from an any-typed parameter",
+    source: `function f(c){return c>=0;}
+             function g(s){var c=s; return f(c);}
+             export function main(){return g(-3);}`,
+    expected: 0,
+  },
+  {
+    name: "`var` from `.length` on an any-typed receiver",
+    source: `function f(n){return n*2;}
+             function g(s){var n=s.length; return f(n);}
+             export function main(){return g("abcd");}`,
+    expected: 8,
+  },
+  {
+    // `let`, not `var` — the gate is per-binding, so #3783's "function-local
+    // var" adoption named the trigger, not the blast radius.
+    name: "`let` in the same shape (not just `var`)",
+    source: `function f(c){return c+1;}
+             function g(s){let c=s.charCodeAt(1); return f(c);}
+             export function main(){return g("AB");}`,
+    expected: 67,
+  },
+];
+
+describe("#3784 — an unprovable numeric local demotes to legacy instead of failing the build", () => {
+  for (const { name, source, expected } of SHAPES) {
+    it(`compiles and computes the JS answer: ${name}`, async () => {
+      expect(await run(source)).toBe(expected);
+    });
+  }
+
+  it("emits a non-empty binary on every target, not just standalone", async () => {
+    const source = `function f(c){return c>=0;}
+                    function g(s){var c=s.charCodeAt(0); return f(c);}
+                    export function main(){return g("A");}`;
+    for (const target of ["standalone", "gc"] as const) {
+      const r = await build(source, target);
+      expect(r.success, `target=${target}: ${r.errors.map((e) => e.message).join("; ")}`).toBe(true);
+      expect(r.binary.length, `target=${target} produced an empty binary`).toBeGreaterThan(0);
+    }
+  });
+
+  it("reports no HARD `Codegen error` for the demoted function", async () => {
+    const r = await build(`function f(c){return c>=0;}
+                           function g(s){var c=s.charCodeAt(0); return f(c);}
+                           export function main(){return g("A");}`);
+    // A demotion may legitimately surface as a WARNING; what must not appear is
+    // the hard-error prefix `formatIrPathFallbackDiagnostic` adds for
+    // `kind === "invariant"`.
+    expect(r.errors.filter((e) => e.severity === "error")).toEqual([]);
+  });
+
+  it("still promotes a local whose TS type IS provably a pure number", async () => {
+    // The gate is not being weakened — an in-range numeric literal still
+    // satisfies the proof and keeps the no-box representation.
+    expect(
+      await run(`function f(c){return c>=0;}
+                      function g(){var c=5; return f(c);}
+                      export function main(){return g();}`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

`function g(s) { var c = s.charCodeAt(0); return f(c); }` — an untyped parameter, i.e. ordinary JavaScript — **did not compile at all** on `main`. Not a fallback, not a warning: `success: false` and a **zero-byte binary**, on `standalone`, `gc` and the default JS-host target alike.

```
Codegen error: IR path failed for g: ir/from-ast: local 'c' is bound as an unboxed f64
but its TS type is not provably a pure number — ... demote to the SAFE boxed legacy
lowering in g (#2782/#2790) [IR-FALLBACK]
```

Read the message: it *asks for a demotion* and then fails the build.

### Root cause — the throw was untyped

The #2782/#2790 no-box NUMBER-local proof gate in `lowerVarDecl` documents its own contract: *"anything unprovable — `any` / `unknown` / a MIXED `number | string` union — demotes to the SAFE boxed legacy lowering."* It raised a **plain `new Error(...)`**. `classifyIrFailure` buckets any untyped throw as `invariant/unexpected-internal-throw`, and `formatIrPathFallbackDiagnostic` (`src/codegen/index.ts:1602`) renders `kind === "invariant"` as a hard `Codegen error`. The demotion channel was never entered — the documented safe path was unreachable by construction.

**This is the fifth site in the class #3565 named:** *"DESIGNED demote-to-legacy sites that #3341/#3519 silently promoted to hard `invariant` compile errors, contradicting their own documented contracts."*

### Why it surfaced now

Older than #3783, but **latent**: the selector previously did not claim functions containing function-local `var` declarations, so the gate was never reached for them. Bisected with `git bisect run` over 67 revisions:

| commit | result |
| --- | --- |
| `3cb92d271` (parent) | compiles, 682 KB WAT |
| **`89015a58d`** *feat(ir): adopt function-local var declarations* (PR #3802) | **`wat=0`, build fails** |

A claimed function that throws fails **post-claim**, where no fallback exists. `let` is affected identically — the gate is per-binding, so "function-local `var`" names the *trigger*, not the blast radius.

### Fix

- `src/ir/outcomes.ts` — new `IrUnsupportedCode` `"unboxed-number-local-unprovable"`, documented beside its #3565 siblings.
- `src/ir/from-ast.ts` — the gate throws `IrUnsupportedError` instead of `Error`. **Message text unchanged.**

`kind: "unsupported"` is not hard, so the function demotes to the boxed legacy body — the behaviour promised since #2782. A genuine builder desync still raises `invariant` and still hard-fails; nothing widens.

## Measurements

Measured on `main` at `16c11237d`, before → after:

| source shape | before | after |
| --- | --- | --- |
| `var c = s.charCodeAt(0)` → helper | **FAIL** | OK |
| `var c = s.charCodeAt(0)` inline | **FAIL** | OK |
| `var c = s` (param is `any`) | **FAIL** | OK |
| `let c = s.charCodeAt(0)` → helper | **FAIL** | OK |
| `var n = s.length` | **FAIL** | OK |
| `var c = 5` (provably numeric) | OK | OK |

Five of six. The survivor is the case where the TS type *is* provably a pure number — the gate working as intended, and evidence the proof is not weakened.

Compiling is not the bar, so all five were also instantiated and their results compared against **real JS**: `wasm=1/js=true`, `0/false`, `0/false`, `8/8`, `67/67`.

## Validation

- **`scripts/equivalence-gate.mjs`: exit 0 — "No new equivalence regressions."** 32 failing / 1611 passing against a 36-known-failure baseline. It additionally reports **4 baseline failures that now PASS** (`issue-1197 :: i32 element specialization for number[]`, `math-pow-test262-pattern`, and two `symbol-basic` entries). Deliberately **not** ratcheted: #3775 already established those entries pass in isolation on both lanes and look suite-order-dependent, so tightening the baseline on them would make CI stricter for no benefit.
- **New `tests/issue-3784-unboxed-local-demotes.test.ts`** — 8 tests. Asserts *outcomes* (builds, computes the JS answer, on both targets, no hard error, and the provable case still promotes) rather than an instruction mix: an instruction-mix assertion **cannot** see this bug, because the failure is that there is no output at all.
- `tests/issue-3765-numeric-locals.test.ts` + `tests/issue-3783-ir-function-local-var.test.ts` + the new file — **28/28 pass**. #3783's own adoption suite is unaffected.
- 13 quality gates green: `loc-budget`, `func-budget`, `issues`, `issue-ids`, `done-status-integrity`, `codegen-fallbacks`, `stack-balance`, `any-box-sites`, `coercion-sites`, `dead-exports`, `oracle-ratchet`, `pushraw`, `godfiles`.
- `tsc --noEmit` clean; prettier clean.

### Budget allowance

`loc-budget-allow: src/ir/from-ast.ts` (+4) is granted in the issue frontmatter with justification: the two extra `IrUnsupportedError` arguments plus a two-line comment. The throw must stay at the gate — it *is* the gate's verdict — so it cannot move to a subsystem module. Trimmed from an initial +11 by relocating the rationale into `outcomes.ts` and the issue file.

## Note on how this was found

PR #3795's `quality` failure was initially read as its own. It is not — #3795 merely added a test that exercises the *unprovable* branch. The repro reproduces on `main` with #3795 nowhere in the tree. A gate whose safe path is unreachable is invisible to a green suite, which is why all five sites in this class went unnoticed. **This unblocks #3795.**

Follow-up recorded in the issue rather than scope-crept here: `classifyIrFailure`'s untyped-throw default is `invariant` (fail hard). Correct for a real desync, but it means every demote-to-legacy site is one forgotten error class away from becoming a build failure — five have now made exactly this mistake. A gate banning bare `throw new Error` in `src/ir/from-ast.ts` would force the explicit choice.

## CLA

Internal/org-member PR — CLA check is skipped automatically.

- [x] I have read and agree to the CLA