### PR TITLE
fix(bench #3785): keep the timing wrapper out of the benchmark it times

### DIFF
--- a/plan/issues/3777-warm-bench-js-lane-degrades-on-node26.md
+++ b/plan/issues/3777-warm-bench-js-lane-degrades-on-node26.md
@@ -1,10 +1,11 @@
 ---
 id: 3777
 title: "warm-chart JS lane runs ~15x slower through the benchmark harness than the same source at top level — Node 26 only, and it degrades DURING the measured rounds"
-status: ready
+status: done
+completed: 2026-07-29
 sprint: current
 created: 2026-07-28
-updated: 2026-07-28
+updated: 2026-07-29
 priority: high
 horizon: m
 feasibility: medium
@@ -13,7 +14,7 @@ task_type: performance
 area: tooling
 goal: performance
 depends_on: []
-related: [3724, 3726, 3730, 3732, 3759, 3769]
+related: [3724, 3726, 3730, 3732, 3759, 3769, 3781, 3785]
 ---
 
 # #3777 — warm-chart JS lane degrades ~15x on Node 26, inside the harness only
@@ -23,15 +24,15 @@ related: [3724, 3726, 3730, 3732, 3759, 3769]
 The landing-page "warm speed" chart's **JS baseline is inflated on CI**, which
 flatters every wasm:js ratio it publishes. The function is genuinely
 TurboFan-optimized (verified — see below), so this is **not** the tiering
-problem #3759/#3769 chased. It is specific to the harness path *and* to
+problem #3759/#3769 chased. It is specific to the harness path _and_ to
 Node 26.
 
 Same source, same engine, tier verified in both cases:
 
-| measured via                                   | Node 22 | Node 26      |
-| ---------------------------------------------- | ------- | ------------ |
-| plain top-level script                          | 310 µs  | 349 µs       |
-| **`scripts/no-jit-bench-child.mjs`** (the chart) | 323 µs  | **5107 µs**  |
+| measured via                                     | Node 22 | Node 26     |
+| ------------------------------------------------ | ------- | ----------- |
+| plain top-level script                           | 310 µs  | 349 µs      |
+| **`scripts/no-jit-bench-child.mjs`** (the chart) | 323 µs  | **5107 µs** |
 
 Node 22 shows no gap. Node 26 shows ~15x. CI runs Node 26, which is why the
 published `loop.ts` JS figure has been ~5290 µs while the same source measured
@@ -43,7 +44,7 @@ published `loop.ts` JS figure has been ~5290 µs while the same source measured
   optimized signature both before and after the measured rounds. (The earlier
   "maglev" reading in #3769 was a decoding bug — bit positions shift between
   V8 releases; see that PR's revert note.)
-- **Not `new Function`.** Loading through the factory and optimizing *inside*
+- **Not `new Function`.** Loading through the factory and optimizing _inside_
   it (what the harness does) vs. returning a plain function and optimizing it
   from the caller's scope both measure ~338 µs on Node 26 in isolation.
 
@@ -51,7 +52,7 @@ published `loop.ts` JS figure has been ~5290 µs while the same source measured
 
 `calibrate(fn)` derives its iteration count by running the function for 100 ms.
 On the failing runs it returns `iters = 882`, which back-solves to roughly
-**340 µs per call** — i.e. *calibration saw the fast function*. The measured
+**340 µs per call** — i.e. _calibration saw the fast function_. The measured
 rounds that follow then report **5107 µs per call** for the same function in
 the same process.
 
@@ -84,12 +85,37 @@ is fixed.
 
 ## Acceptance criteria
 
-- [ ] The harness and a plain top-level script agree within noise on Node 26
-      for the same source, as they already do on Node 22.
-- [ ] Root cause named (deopt reason, or protocol interaction), not just
-      worked around.
-- [ ] The published chart's JS column is re-derived and the wasm:js ratios
-      restated.
+- [x] The harness and a plain top-level script agree within noise on Node 26
+      for the same source, as they already do on Node 22. (369.8 µs vs 368.4 µs;
+      drift ratio 1.01x.)
+- [x] Root cause named, not worked around: V8 tiers up the harness's own
+      `timeIt` wrapper and INLINES the subject into it, so the hot loop runs as
+      the wrapper's Maglev code while the subject's TurboFan code goes unused.
+- [x] The published chart's JS column is re-derived and the ratios restated —
+      `loop.ts` JS is ~370 µs, not ~5290 µs, which makes wasm 1.09x SLOWER
+      there rather than far ahead. See #3785.
+
+## RESOLVED 2026-07-29 — see #3785
+
+Fixed by pinning the measurement scaffolding out of the optimizing tiers
+(`%NeverOptimizeFunction` on `timeIt`/`calibrate`) plus a calibration-vs-median
+drift guard, in `scripts/no-jit-bench-child.mjs`.
+
+Two corrections this investigation forced, recorded in #3785 in full:
+
+- **It was never a deopt.** Hypothesis 1 below ("find the exact round where it
+  changes, and whether a deopt/re-opt cycle is visible") was the right
+  experiment and it returned a negative: the subject's status is a constant `41`
+  (`optimized|turbofanned`) for every single round. The status that moves is
+  `timeIt`'s.
+- **#3781's removal of `--no-maglev` was wrong.** That flag was load-bearing
+  after all — not for the reason #3769 gave, but because it prevents `timeIt`
+  from being Maglev-compiled. #3781 called it inert on the basis of a top-level
+  probe, which never reaches the round-1 cliff.
+
+Item 4 below (does the wasm lane have the analogue?) is answered by the fix
+rather than by measurement: the pin is lane-agnostic, so the wasm lane is
+protected whether or not it was ever affected.
 
 ## Provenance
 

--- a/plan/issues/3785-timing-wrapper-inlined-into-benchmark-subject.md
+++ b/plan/issues/3785-timing-wrapper-inlined-into-benchmark-subject.md
@@ -1,0 +1,167 @@
+---
+id: 3785
+title: "#3777 root cause: V8 tiers up the harness's own `timeIt` wrapper and INLINES the benchmark into it, so the hot loop runs as the wrapper's mid-tier code — 15x on Node 26, while the subject reports `optimized` throughout"
+status: done
+completed: 2026-07-29
+sprint: current
+created: 2026-07-29
+updated: 2026-07-29
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: tooling
+goal: performance
+depends_on: []
+related: [3724, 3726, 3730, 3732, 3759, 3769, 3777, 3781]
+---
+
+# #3785 — the timing wrapper became part of the thing being timed
+
+Closes #3777.
+
+## The measurement
+
+Same source, same tier-verified subject, one run each:
+
+| measured via                                     | Node 22 | Node 26     |
+| ------------------------------------------------ | ------- | ----------- |
+| plain top-level script                           | 470 µs  | 368 µs      |
+| **`scripts/no-jit-bench-child.mjs`** (the chart) | 473 µs  | **5616 µs** |
+
+Per-round instrumentation of the real child on Node 26 localises it exactly:
+
+```
+calibrated iters=810 (implies ~370us/call)   fn=41  timeIt=65
+warmup 0: 373.6us                            fn=41  timeIt=65
+warmup 1: 367.0us                            fn=41  timeIt=65
+round 0:  369.3us                            fn=41  timeIt=2097217   <- marked for opt
+round 1: 5625.6us                            fn=41  timeIt=25        <- Maglev
+round 2: 5662.7us                            fn=41  timeIt=25
+...
+```
+
+Everything is fast — calibration, both warmups, **and measured round 0**. The
+cliff lands on round 1, and it lands on `timeIt`'s status, not the subject's.
+
+## Root cause
+
+`timeIt(fn, iters)` is the harness's own timing wrapper. By round 1 it has been
+called enough times (2 warmup + 1 measured) for V8 to tier it up. On Node 26 it
+becomes **Maglev** (`25` = `isFunction | OPTIMIZED | MAGLEVVED`) and **inlines
+`fn` into itself**. From that point the 1M-iteration loop executes as _Maglev_
+code belonging to the wrapper — while `bench_loop`'s own TurboFan code object
+(`41` = `isFunction | OPTIMIZED | TURBOFANNED`) sits there, correct and unused.
+
+So the subject was optimized the whole time. It just wasn't what ran.
+
+**This is why #3759's tier assertion could not catch it.** That guard
+interrogates the SUBJECT — `%GetOptimizationStatus(fn)` — and the subject was
+never the problem. A guard pointed at the wrong function is indistinguishable
+from no guard.
+
+Node 22 is unaffected because Maglev is default-**off** there; Node 26 has it
+default-**on**, and CI runs Node 26.
+
+## Correcting the record on #3769 and #3781
+
+- **#3769 added `--no-maglev`.** Its stated reason was wrong: it claimed
+  `bench_loop` was tiering to Maglev. It was not — status 41 is TurboFan, and
+  #3781 was right that the hardcoded bit table had misdecoded it. But the
+  **flag was load-bearing**, for a reason nobody had identified: it stops
+  **`timeIt`** from being Maglev-compiled.
+- **#3781 removed `--no-maglev`** on the grounds that it was "inert — identical
+  status and timing." The status half was right. The **timing half was wrong**:
+  that check was run against a top-level probe, not through the harness, so it
+  never reached round 1 where the cliff is. Verified here, same child, Node 26:
+
+  |                    | rounds                                                           |
+  | ------------------ | ---------------------------------------------------------------- |
+  | with `--no-maglev` | 372.9 370.0 372.8 368.2 368.9 385.5 373.1 369.1 366.8            |
+  | without            | 373.6 367.0 **5625.6 5662.7 5641.5 5629.9 5600.3 5610.6 5587.3** |
+
+The lesson is narrow and worth keeping: _a flag proven inert by one measurement
+path is not proven inert._ The probe has to exercise the protocol that exhibits
+the bug.
+
+## Fix — pin the scaffolding, not the engine
+
+Restoring `--no-maglev` would work. It is the wrong instrument: it treats one
+tier's symptom, needs a startup flag on every lane, and configures the JS lane
+onto a tier setup no real browser has — while the chart's whole claim is
+"this is what optimized JS does."
+
+Instead, `scripts/no-jit-bench-child.mjs`:
+
+1. **`neverOptimize(timeIt, calibrate)`** — `%NeverOptimizeFunction` on the
+   measurement scaffolding, before it is ever called. The wrapper can no longer
+   be tiered up, so it can no longer inline the subject; the subject runs its
+   own code. Fixes the mechanism, covers the wasm lane and any future tier for
+   free, and needs no flag. Best-effort behind `new Function` + try/catch, since
+   the COLD lane runs `--jitless` without `--allow-natives-syntax` (where there
+   is no tier to opt out of anyway).
+2. **A calibration-vs-median drift guard.** Calibration is an _independent_
+   measurement path — it calls `fn` directly, never through `timeIt` — so the
+   two disagreeing is evidence the wrapper is interfering, whatever the cause.
+   Threshold 4x: ordinary CI variance runs under 2x, the bug is 12–15x. Skipped
+   when `iters` hits its floor of 10, where the clamp breaks the arithmetic.
+
+The drift guard is the part that generalises. #3777's own notes already
+contained the decisive clue — _"`calibrate` saw the fast function"_ — but
+nothing compared the two numbers, so it stayed an observation instead of a
+failure.
+
+## Validation
+
+**The fix, both runtimes, warm JS lane:**
+
+|         | median   | calibration | drift |
+| ------- | -------- | ----------- | ----- |
+| Node 22 | 489.3 µs | 482.8 µs    | 1.01x |
+| Node 26 | 369.8 µs | 366.6 µs    | 1.01x |
+
+Node 26 now agrees with its top-level figure (369.8 vs 368.4) — the 15x is gone.
+
+**Positive control — the guard must be able to fail.** Same fixed child with
+only the `neverOptimize` call commented out:
+
+```
+Error: measurement instability for 'bench_loop': calibration implied ~445.7us/call
+but the measured median is 5596.4us/call (12.6x). ... the timing wrapper is
+affecting what is being measured (see #3777)
+exit=1
+```
+
+**Cold lane unaffected** (`--jitless`, no natives syntax, no `--expect-tier`):
+Node 22 drift 1.04x, Node 26 drift 1.07x. `neverOptimize` no-ops silently.
+
+**Full generator** runs clean end-to-end under Node 26 — the actual CI engine —
+covering the wasm lane, exit 0:
+
+| benchmark   | wasm      | js        | honest ratio          |
+| ----------- | --------- | --------- | --------------------- |
+| `fib.ts`    | 3984.9 µs | 9992.6 µs | wasm 2.51x faster     |
+| `loop.ts`   | 404.2 µs  | 369.8 µs  | **wasm 1.09x SLOWER** |
+| `string.ts` | 5.7 µs    | 5.5 µs    | parity                |
+| `array.ts`  | 46.6 µs   | 65.8 µs   | wasm 1.41x faster     |
+
+`loop.ts` is the headline correction: with the JS baseline no longer inflated,
+wasm is **slightly behind** JS there, not far ahead. (Sandbox hardware, so the
+absolute values are not CI's — the point is the ratio's sign and order of
+magnitude, which the inflated baseline had inverted.)
+
+These regenerated `playground-benchmark-sidebar.json` files are deliberately
+**not** committed here: they are this machine's numbers, and
+`benchmark-refresh.yml` owns that artifact on `main`.
+
+## Consequence for the published chart
+
+The JS baseline has been inflated on every Node 26 refresh, so **every
+wasm:js ratio the landing page has shown was flattering wasm**. Those ratios
+should be re-read from the first refresh after this lands, not carried over.
+Specifically: `loop.ts`'s real Node 26 JS figure is ~368 µs, not ~5290 µs.
+
+This does not touch the wasm-side gains from #3740/#3741 and #3775/#3734 —
+those were measured on a fixed harness on one machine and stand on their own.
+It changes the _denominator_ they were compared against.

--- a/scripts/no-jit-bench-child.mjs
+++ b/scripts/no-jit-bench-child.mjs
@@ -110,6 +110,37 @@ function describeOptStatus(status, mask) {
   return `${status} (${(status & mask) === mask ? "matches" : "MISSING"} optimized-signature ${mask})`;
 }
 
+/**
+ * (#3777) Keep a measurement wrapper OUT of the optimizing tiers.
+ *
+ * `timeIt` is scaffolding, not the subject. Left optimizable, V8 eventually
+ * tiers it up and INLINES `fn` into it — and then the hot loop executes as the
+ * wrapper's code, not as the code the subject actually has. On Node 26 that
+ * turned the warm `loop.ts` JS lane from ~370 us into ~5615 us per call
+ * (measured), because Maglev claimed `timeIt` and ran the inlined 1M-iteration
+ * body at mid-tier speed while `bench_loop`'s own TurboFan code object sat
+ * unused. `%GetOptimizationStatus(fn)` stayed 41 (optimized|turbofanned)
+ * throughout, which is exactly why the #3759 tier assertion could not see it:
+ * it interrogates the SUBJECT, and the subject was never the problem.
+ *
+ * Pinning the wrapper is preferable to pinning the engine (`--no-maglev`,
+ * #3769): it fixes the mechanism rather than one tier's symptom, needs no
+ * startup flag, keeps the JS lane on the same tier configuration a real browser
+ * has, and covers the wasm lane and any future tier for free.
+ *
+ * Best-effort: needs `--allow-natives-syntax`, which the COLD lane does not
+ * enable (it runs `--jitless`, where there is no tier to opt out of anyway), so
+ * a failure here is silently fine.
+ */
+function neverOptimize(...fns) {
+  try {
+    const pin = new Function("f", "%NeverOptimizeFunction(f);");
+    for (const fn of fns) pin(fn);
+  } catch {
+    // no natives syntax (cold lane) — nothing to pin.
+  }
+}
+
 function calibrate(fn) {
   let iters = 0;
   const t0 = performance.now();
@@ -164,11 +195,19 @@ async function main() {
       ? await loadJsFn(args["js-source"], exportName)
       : await loadWasmFn(args.wasm, args.imports, exportName);
 
+  // (#3777) Pin the scaffolding before it is ever called, so no tier-up can
+  // fuse the subject into the timer. See `neverOptimize`.
+  neverOptimize(timeIt, calibrate);
+
   // Warmup pass mirrors the in-process sidebar generator to avoid a cold-call
   // outlier dominating the first measured sample.
   for (let i = 0; i < 80; i++) fn();
 
+  const calibrateStart = performance.now();
   const iters = calibrate(fn);
+  // Per-call cost implied by calibration, i.e. by a code path that has NOT yet
+  // run through `timeIt`. Cross-checked against the measured median below.
+  const calibratedUsPerCall = ((performance.now() - calibrateStart) / (iters / 3)) * 1000;
   const warmupRounds = 2;
   const measuredRounds = 9;
   for (let i = 0; i < warmupRounds; i++) timeIt(fn, iters);
@@ -203,10 +242,39 @@ async function main() {
     }
   }
 
+  // (#3777) Cross-check the measured median against calibration.
+  //
+  // The tier assertion above interrogates the SUBJECT, so it is blind to a
+  // wrapper-side artifact: on Node 26 the subject reported `optimized` for the
+  // entire run while the measured rounds were 15x slower than calibration had
+  // just observed. Calibration is an INDEPENDENT measurement path — it calls
+  // `fn` directly, never through `timeIt` — so disagreement between the two is
+  // evidence that something about the measurement changed, whatever the cause
+  // (a new tier, a different inlining decision, a deopt the mask cannot see).
+  //
+  // Threshold is deliberately loose: CI runners are noisy and calibration is a
+  // shorter sample, so ordinary variance runs well under 2x. 4x catches the
+  // 15x class without flagging drift. Skipped when `iters` hit its floor of 10,
+  // where the clamp breaks the implied-per-call arithmetic.
+  const measuredMedianUs = [...samplesUs].sort((a, b) => a - b)[Math.floor(samplesUs.length / 2)];
+  const driftRatio = calibratedUsPerCall > 0 ? measuredMedianUs / calibratedUsPerCall : 1;
+  if (iters > 10 && driftRatio > 4) {
+    throw new Error(
+      `measurement instability for '${exportName}': calibration implied ` +
+        `~${calibratedUsPerCall.toFixed(1)}us/call but the measured median is ` +
+        `${measuredMedianUs.toFixed(1)}us/call (${driftRatio.toFixed(1)}x). Calibration calls the ` +
+        `subject directly while the measured rounds go through 'timeIt', so a gap this large means ` +
+        `the timing wrapper is affecting what is being measured (see #3777) — not that the subject ` +
+        `is slow. The reported timings would not represent the subject's speed.`,
+    );
+  }
+
   process.stdout.write(
     JSON.stringify({
       samplesUs,
       iters,
+      calibratedUsPerCall,
+      driftRatio,
       ...(expectTier
         ? {
             optimizedMask,


### PR DESCRIPTION
## Description

Closes #3777.

On Node 26 the warm chart's JS lane measured **~5616 µs/call through the harness** while the same source measured **~368 µs at top level**, tier-verified throughout. Per-round instrumentation of the real child localises it exactly:

```
calibrated iters=810 (implies ~370us/call)   fn=41  timeIt=65
warmup 0: 373.6us                            fn=41  timeIt=65
warmup 1: 367.0us                            fn=41  timeIt=65
round 0:  369.3us                            fn=41  timeIt=2097217   <- marked for opt
round 1: 5625.6us                            fn=41  timeIt=25        <- Maglev
round 2: 5662.7us                            fn=41  timeIt=25
```

Calibration, both warmups **and measured round 0** are fast. The cliff lands on round 1 — and it lands on **`timeIt`'s** status, not the subject's.

### Root cause

`timeIt` is the harness's own timing wrapper. By round 1 it has been called enough times to tier up; on Node 26 it becomes **Maglev** (`25` = `isFunction|OPTIMIZED|MAGLEVVED`) and **inlines the subject into itself**. The 1M-iteration loop then executes as the *wrapper's* mid-tier code, while `bench_loop`'s own TurboFan code object (`41`) sits there correct and unused.

The subject was optimized the whole time. It just wasn't what ran.

**This is why #3759's tier assertion could not catch it** — that guard interrogates the SUBJECT, and the subject was never the problem. A guard pointed at the wrong function is indistinguishable from no guard.

Node 22 is unaffected (Maglev default-**off**); Node 26 has it default-**on**, and CI runs Node 26.

### Two corrections to the record

- **#3769's `--no-maglev` was load-bearing after all** — not for the reason it gave (it claimed the *subject* tiered to Maglev; it didn't), but because it prevents **`timeIt`** from being Maglev-compiled.
- **#3781 removed it as "inert — identical status and timing."** The status half was right (41 is TurboFan; the old bit table misdecoded it). The **timing half was wrong**: that check ran a top-level probe, which never reaches the round-1 cliff. Verified here, same child, Node 26:

  | | rounds |
  |---|---|
  | with `--no-maglev` | 372.9 370.0 372.8 368.2 368.9 385.5 373.1 369.1 366.8 |
  | without | 373.6 367.0 **5625.6 5662.7 5641.5 5629.9 5600.3 5610.6 5587.3** |

  *A flag proven inert by one measurement path is not proven inert.*

### Fix — pin the scaffolding, not the engine

Restoring `--no-maglev` would work, but it treats one tier's symptom, needs a startup flag on every lane, and puts the JS lane on a tier configuration no real browser has — while the chart's whole claim is "this is what optimized JS does." Instead:

1. **`neverOptimize(timeIt, calibrate)`** — `%NeverOptimizeFunction` on the measurement scaffolding, before it is ever called. It can no longer be tiered up, so it can no longer inline the subject. Lane-agnostic and flag-free, so it covers the wasm lane and any future tier for free. Best-effort behind `new Function` + try/catch, since the cold lane runs `--jitless` without `--allow-natives-syntax` (where there's no tier to opt out of anyway).
2. **A calibration-vs-median drift guard.** Calibration is an *independent* measurement path — it calls the subject directly, never through `timeIt` — so disagreement is evidence the wrapper is interfering, whatever the cause. Threshold 4x (ordinary CI variance is under 2x; the bug is 12–15x), skipped when `iters` hits its floor of 10.

The drift guard is the part that generalises. #3777's own notes already held the decisive clue — *"`calibrate` saw the fast function"* — but nothing compared the two numbers, so it stayed an observation instead of a failure.

## Measurements

**After the fix, warm JS lane:**

| | median | calibration | drift |
|---|---|---|---|
| Node 22 | 489.3 µs | 482.8 µs | 1.01x |
| Node 26 | 369.8 µs | 366.6 µs | 1.01x |

Node 26 now agrees with its top-level figure (369.8 vs 368.4) — the 15x is gone.

**Full generator, exit 0 under Node 26 (the actual CI engine), covering the wasm lane:**

| benchmark | wasm | js | honest ratio |
|---|---|---|---|
| `fib.ts` | 3984.9 µs | 9992.6 µs | wasm 2.51x faster |
| `loop.ts` | 404.2 µs | 369.8 µs | **wasm 1.09x SLOWER** |
| `string.ts` | 5.7 µs | 5.5 µs | parity |
| `array.ts` | 46.6 µs | 65.8 µs | wasm 1.41x faster |

`loop.ts` is the headline correction: with the JS baseline no longer inflated, wasm is **slightly behind** JS there rather than far ahead. Sandbox hardware, so absolutes aren't CI's — the point is that the inflated baseline had inverted the ratio's sign.

## Validation

- **Positive control — the guard must be able to fail.** Same fixed child with *only* the `neverOptimize` call commented out:

  ```
  Error: measurement instability for 'bench_loop': calibration implied ~445.7us/call
  but the measured median is 5596.4us/call (12.6x). ... the timing wrapper is
  affecting what is being measured (see #3777)
  exit=1
  ```

- **Cold lane unaffected** (`--jitless`, no natives syntax, no `--expect-tier`): Node 22 drift 1.04x, Node 26 drift 1.07x. `neverOptimize` no-ops silently.
- Full generator end-to-end under Node 26: exit 0.
- `check:loc-budget`, `check:func-budget`, `check:issues`, `check:issue-ids`, `check:done-status-integrity` green. `biome lint scripts` clean; prettier clean.

Node 26 was reproduced against a real `v26.5.0` build downloaded into the sandbox, not inferred from Node 22 behaviour.

## Not committed here

The regenerated `playground-benchmark-sidebar.json` files are deliberately excluded — they are this machine's numbers, and `benchmark-refresh.yml` owns that artifact on `main`. The first refresh after this lands produces the corrected chart.

## Consequence

Every wasm:js ratio the landing page has published on Node 26 was flattering wasm, so those ratios should be re-read after the next refresh rather than carried over. The wasm-side gains from #3740/#3741 and #3775/#3734 are unaffected — this changes the *denominator* they were compared against, not them.

## CLA

Internal/org-member PR — CLA check is skipped automatically.

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_