### PR TITLE
feat(ir): share unique module var scalars (#2949)

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -24,7 +24,7 @@ loc-budget-allow:
   - src/codegen/any-helpers.ts
 func-budget-allow:
   - src/codegen/index.ts::planIrOverlay
-branch: codex/2949-acorn-implicit-array-param
+branch: codex/2949-acorn-module-var-scalars
 ---
 
 # #2949 — the IR's type system is Wasm types, not JS types
@@ -2008,3 +2008,42 @@ Validation for this slice:
 - equivalence matrix: 8/8 shards, zero new regressions;
 - typecheck, lint, fallback/adoption/oracle, LOC, function-budget, harness
   compile-budget, and linear-IR gates pass.
+
+## Implementation Notes — unique module `var` scalars (2026-07-30)
+
+Acorn's `functionFlags(async, generator)` now emits through IR. Its scope-bit
+constants are unique top-level `var` declarations rather than lexical
+bindings. The module-binding resolver now admits exactly numeric and boolean
+`var` declarations in ES modules when the checker resolves one non-merged,
+non-repeated declaration. Reads and writes reuse the existing allocator-owned
+legacy module global; scripts, repeated declarations, and non-scalar values
+remain outside this capability.
+
+The helper's implicit boolean parameters are used only as ternary conditions.
+That use is now eligible for the same direct-declaration inference projection
+used by the callable ABI. Standalone caller closure is relaxed for an
+all-boolean projected parameter set, while the existing indexed-carrier
+exemption remains unchanged. The patch-time ABI guard still owns final parity.
+
+The unchanged #3796 runtime-dynamic compile/outcome driver moves from 17 to
+**18 emitted functions out of 43**, with `functionFlags` added and zero
+post-claim withdrawals. The terminal blocker census becomes:
+
+- 14 body-shape rejections;
+- 3 parameter-type rejections;
+- 3 logical-value rejections;
+- 2 RegExp-constructor rejections;
+- 2 call-graph closures;
+- 1 constructor-resolution rejection.
+
+The slice does not touch the direct-backend files owned by draft PR #3796.
+
+Validation for this slice:
+
+- exact #3796 driver: 18/43 emitted, zero post-claim withdrawals;
+- focused module-var and prior #2949/ABI guards: 29/29 pass;
+- module-binding matrix: 53 pass, with the same 2 stale assertions reproduced
+  on current main;
+- equivalence matrix: 8/8 shards, zero new regressions;
+- typecheck, fallback/adoption/oracle, linear-IR, LOC, function-budget, and
+  harness compile-budget gates pass.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1833,6 +1833,7 @@ function collectIrImplicitParamProjectionCandidates(
       return parent.name.text === "length";
     }
     if (ts.isElementAccessExpression(parent) && parent.expression === child) return true;
+    if (ts.isConditionalExpression(parent) && parent.condition === child) return true;
     return false;
   };
   const visit = (node: ts.Node): void => {
@@ -2029,13 +2030,17 @@ function planIrOverlay(
   const resolveImplicitParamType = makeIrImplicitParamTypeResolver(ctx, ast.sourceFile);
   const legacyCallerAbiIsProjected = (declaration: ts.FunctionDeclaration): boolean => {
     let hasIndexedCarrier = false;
+    let hasBooleanProjection = false;
+    let allProjectionsAreBoolean = true;
     for (const parameter of declaration.parameters) {
       if (effectiveIrParamTypeNode(parameter)) continue;
       const projection = resolveImplicitParamType(parameter);
       if (!projection) return false;
       if (projection.kind === "object") hasIndexedCarrier = true;
+      if (projection.kind === "bool") hasBooleanProjection = true;
+      else allProjectionsAreBoolean = false;
     }
-    return hasIndexedCarrier;
+    return hasIndexedCarrier || (hasBooleanProjection && allProjectionsAreBoolean);
   };
   const identityPlan = irOverlayIdentity.planIrOverlayByIdentity(
     ast.sourceFile,

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -644,6 +644,7 @@ function directTopLevelDeclaration(node: ts.Identifier, checker: ts.TypeChecker)
   if (!symbol) return undefined;
   const sourceFile = node.getSourceFile();
   const candidates = [symbol.valueDeclaration, ...(symbol.declarations ?? [])];
+  const directDeclarations = new Set<ts.VariableDeclaration>();
   for (const candidate of candidates) {
     if (!candidate || !ts.isVariableDeclaration(candidate)) continue;
     if (candidate.getSourceFile() !== sourceFile) continue;
@@ -652,12 +653,28 @@ function directTopLevelDeclaration(node: ts.Identifier, checker: ts.TypeChecker)
     if (!ts.isVariableDeclarationList(list)) continue;
     const statement = list.parent;
     if (!ts.isVariableStatement(statement) || statement.parent !== sourceFile) continue;
-    // Capability C is intentionally lexical-binding-only. Module `var`
-    // hoisting has wider aliasing rules and stays on the legacy path.
-    if (!(list.flags & ts.NodeFlags.Let) && !(list.flags & ts.NodeFlags.Const)) continue;
-    return candidate;
+    directDeclarations.add(candidate);
   }
-  return undefined;
+  if (directDeclarations.size !== 1) return undefined;
+  const declaration = [...directDeclarations][0]!;
+  const list = declaration.parent as ts.VariableDeclarationList;
+  if (list.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) return declaration;
+
+  // #2949 Acorn follow-up — a unique top-level `var` in an ES module has one
+  // checker identity and one legacy `__mod_*` slot, so scalar reads/writes can
+  // share that slot with IR just like `let`. Reject scripts and merged/repeated
+  // declarations: their hoisting/global-alias rules are wider than this exact
+  // source-owned capability.
+  if (!ts.isExternalModule(sourceFile)) return undefined;
+  const declaredType = checker.getTypeAtLocation(declaration.name);
+  if ((declaredType.flags & (ts.TypeFlags.NumberLike | ts.TypeFlags.BooleanLike)) === 0) return undefined;
+  const sameSourceDeclarations = new Set(
+    candidates.filter(
+      (candidate): candidate is ts.Declaration =>
+        candidate !== undefined && candidate.getSourceFile() === sourceFile && !ts.isExportSpecifier(candidate),
+    ),
+  );
+  return sameSourceDeclarations.size === 1 && sameSourceDeclarations.has(declaration) ? declaration : undefined;
 }
 
 function localVariableDeclaration(node: ts.Identifier, checker: ts.TypeChecker): ts.VariableDeclaration | undefined {
@@ -1135,12 +1152,13 @@ export function makeIrLegacyModuleBindingResolver(
     ) {
       return { kind: "unsupported", declaration };
     }
-    const mutable = (list.flags & ts.NodeFlags.Let) !== 0;
+    const isModuleVar = (list.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0;
+    const mutable = isModuleVar || (list.flags & ts.NodeFlags.Let) !== 0;
     if (writeValue !== undefined && !mutable) return { kind: "unsupported", declaration };
 
     const declaredType = checker.getTypeAtLocation(declaration.name);
     let valueKind = scalarKind(declaredType, options);
-    if (!valueKind && options.allowHostExterns) {
+    if (!valueKind && !isModuleVar && options.allowHostExterns) {
       const className = externClassNameForType(declaredType, checker, options);
       if (className) {
         valueKind = { kind: "extern", className };

--- a/tests/issue-2949-module-var-scalars.test.ts
+++ b/tests/issue-2949-module-var-scalars.test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2949 — Acorn emits parser scope flags as unique top-level `var` scalars.
+// Their IR readers must share the exact legacy module-global slots.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+describe("#2949 — Acorn module var scalars", () => {
+  it("emits functionFlags through IR while its caller remains on the direct path", async () => {
+    const result = await compile(
+      `
+        var SCOPE_FUNCTION = 2;
+        var SCOPE_ASYNC = 4;
+        var SCOPE_GENERATOR = 8;
+
+        function functionFlags(async, generator) {
+          return SCOPE_FUNCTION |
+            (async ? SCOPE_ASYNC : 0) |
+            (generator ? SCOPE_GENERATOR : 0);
+        }
+
+        export function callFlags(async: boolean, generator: boolean): number {
+          return new RegExp("x").test("x")
+            ? functionFlags(async, generator)
+            : -1;
+        }
+      `,
+      {
+        allowJs: true,
+        experimentalIR: true,
+        fileName: "issue-2949-module-var-scalars.ts",
+        skipSemanticDiagnostics: true,
+        target: "standalone",
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs ?? [], JSON.stringify(result.irOutcomes, null, 2)).toContain("functionFlags");
+    expect(result.irCompiledFuncs ?? []).not.toContain("callFlags");
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    const callFlags = instance.exports.callFlags as (async: number, generator: number) => number;
+    expect(callFlags(0, 0)).toBe(2);
+    expect(callFlags(1, 0)).toBe(6);
+    expect(callFlags(1, 1)).toBe(14);
+  });
+
+  it("keeps repeated var declarations outside the exact module binding capability", async () => {
+    const result = await compile(
+      `
+        var FLAG = 2;
+        var FLAG;
+        export function readFlag(): number { return FLAG; }
+      `,
+      {
+        allowJs: true,
+        experimentalIR: true,
+        fileName: "issue-2949-module-var-repeated.ts",
+        skipSemanticDiagnostics: true,
+        target: "standalone",
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("readFlag");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps ordinary numeric var storage on the direct path in fast mode", async () => {
+    const result = await compile(
+      `
+        var FLAG = 2;
+        export function readFlag(): number { return FLAG; }
+      `,
+      {
+        allowJs: true,
+        experimentalIR: true,
+        fast: true,
+        fileName: "issue-2949-module-var-fast.ts",
+        skipSemanticDiagnostics: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("readFlag");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- share unique numeric and boolean top-level var bindings through the allocator-owned legacy module global
- exclude scripts, repeated or merged declarations, non-scalar values, and representation-incompatible fast numbers
- project implicit booleans used as ternary conditions into the callable ABI
- allow the exact all-boolean projected ABI across a legacy caller

## Acorn migration result

The unchanged runtime-dynamic #3796 compile/outcome driver advances from 17 to 18 of 43 reachable functions emitted through IR. functionFlags is the added function, with zero post-claim withdrawals.

Remaining terminal blockers: 14 body-shape, 3 parameter-type, 3 logical-value, 2 RegExp-constructor, 2 call-graph closure, and 1 constructor-resolution.

## Validation

- focused module-var and prior #2949/ABI guards: 29/29
- module-binding matrix: 53 pass; the same 2 stale assertions reproduce on current main
- equivalence matrix: all 8 shards, zero new regressions
- exact Acorn driver after rebase: 18/43, zero withdrawals
- typecheck, lint, fallback/adoption/oracle, linear-IR, LOC, function-budget, and harness compile-budget gates

## Coordination

This PR does not touch the direct-backend files owned by draft PR #3796. Its typed-receiver, argc-frame, numeric-switch, and RegExp dispatch parity requirements remain unchanged.