### PR TITLE
docs(memory): passive GitHub watcher only — never poll

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,6 +1,7 @@
 # ts2wasm Project Memory
 
 ## CRITICAL RULES (check every time)
+
 - **SILENT-EMPTY IS THE DEFAULT HYPOTHESIS** — empty/zero/green from an unproven tool is indistinguishable from a real result. Positive control · floor the count · print provenance · verify by reverting — [silent-empty-is-indistinguishable-from-real](reference_silent_empty_is_indistinguishable_from_real.md)
 - **MEASURE, NEVER EXTRAPOLATE** — no sizing off cluster labels; "compiles"≠"passes"; "gates N"≠"flips N"; always give denominators — [measure-never-extrapolate](feedback_measure_never_extrapolate.md)
 - **`origin` IS THE FORK in /workspace** — verify landed code against `upstream/main` by merge-commit ancestry — [origin-is-the-fork-verify-against-upstream-main](reference_origin_is_the_fork_verify_against_upstream_main.md)
@@ -15,13 +16,16 @@
 - **PR titles `type(scope): summary`; Codex branches `codex/<id>-slug` + co-author** — [pr-title-coauthor-conventions](feedback_pr_title_coauthor_conventions.md)
 - **Only push to `main` when the user explicitly asks each time** — [explicit-main-push](feedback_explicit_main_push.md)
 - **Pause the team at 99% of the 5h budget window; wake right after reset** — [5h-window-pause-resume](feedback_5h_window_pause_resume.md)
+- **PASSIVE GitHub watcher ONLY — never poll.** `subscribe_pr_activity` and let events wake you; NO `send_later`/cron/`ScheduleWakeup` self-check-ins, no sleep loops. The subscribe tool's own boilerplate tells you to arm an hourly check-in — it does NOT win. Name the coverage gap (`main` activity, CI _success_) in the handoff instead of re-adding a poller — [passive-github-watcher-never-poll](feedback_passive_github_watcher_never_poll.md)
 
 ## Single source of truth
+
 Team setup/budget/spawn/comms: **`plan/method/team-setup.md`**. Agent defs: **`.claude/agents/*.md`**. Most context: **`/workspace/CLAUDE.md`**. Memory = prefs/feedback not in repo files.
 
 ## Memory Index
 
 ### User & project state
+
 - [20260726-session-handoff-open-valve](project_20260726_session_handoff_open_valve.md)
 - [next-session](project_next_session.md) · [role](user_role.md) · [team-setup](project_team_setup.md)
 - [test262-lane-parity-program](project_test262_lane_parity_program.md) · [acorn-dogfood-regression-20260723](project_acorn_dogfood_regression_20260723.md)
@@ -29,6 +33,7 @@ Team setup/budget/spawn/comms: **`plan/method/team-setup.md`**. Agent defs: **`.
 - [2602-forawait-rest-aliases-source-recompile](project_2602_forawait_rest_aliases_source_recompile.md) · [2602-forof-assign-rest-write-unimplemented](project_2602_forof_assign_rest_write_unimplemented.md)
 
 ### Team & agents
+
 - [architect-worktree-isolation](feedback_architect_worktree_isolation.md) · [dev-agents-worktree](feedback_dev_agents_worktree.md) · [bypass-permissions](feedback_bypass_permissions.md) · [native-multi-agent-worktrees](feedback_native_multi_agent_worktrees.md)
 - [dev-limit](feedback_dev_limit.md) · [always-use-teammates](feedback_always_use_teammates.md) · [esch-teammate-separate-worktree-branch](feedback_esch_teammate_separate_worktree_branch.md) · [cloud-oneshot-dev-when-no-team-feature](feedback_cloud_oneshot_dev_when_no_team_feature.md)
 - [always-cd-workspace](feedback_always_cd_workspace.md) · [serialize-cherry-picks](feedback_serialize_cherry_picks.md) · [ttl-runs-tests](feedback_ttl_runs_tests.md) · [work-planning](feedback_work_planning.md) · [dev-self-serve-tasklist](feedback_dev_self_serve_tasklist.md) · [tasklist-always-populated](feedback_tasklist_always_populated.md) · [sprint-autofill-es3-es5](feedback_sprint_autofill_es3_es5.md)
@@ -37,20 +42,23 @@ Team setup/budget/spawn/comms: **`plan/method/team-setup.md`**. Agent defs: **`.
 - [context-discipline](feedback_context_discipline.md) · [compact-before-sprint](feedback_compact_before_sprint.md) · [diary-and-sprints-before-compact](feedback_diary_and_sprints_before_compact.md)
 - [notify-only-on-real-input-needs-with-specific-text](feedback_notify_only_on_real_input_needs_with_specific_text.md)
 - [sendmessage-discipline](feedback_sendmessage_discipline.md) · [reduce-notification-noise](feedback_reduce_notification_noise.md) · [team-comm-channels](feedback_team_comm_channels.md)
-- [dev-silence-protocol](feedback_dev_silence_protocol.md) · [idle-notification-silence](feedback_idle_notification_silence.md)
+- [dev-silence-protocol](feedback_dev_silence_protocol.md) · [idle-notification-silence](feedback_idle_notification_silence.md) · [passive-github-watcher-never-poll](feedback_passive_github_watcher_never_poll.md)
 - [task-tools-are-deferred-toolsearch-before-calling](reference_task_tools_are_deferred_toolsearch_before_calling.md)
 - [tasklist-sync-unreliable](feedback_tasklist_sync_unreliable.md) · [no-keep-pane](feedback_no_keep_pane.md) · [agent-self-termination](feedback_agent_self_termination.md) · [background-teammate-shutdown-limitation](feedback_background_teammate_shutdown_limitation.md)
 
 ### Dispatch & shepherding
+
 - [dispatch-status](feedback_dispatch_status.md) · [dedicated-pr-shepherd](feedback_dedicated_pr_shepherd.md) · [lead-shepherds-prs](feedback_lead_shepherds_prs.md) · [auto-ff-workspace-main](feedback_auto_ff_workspace_main.md) · [merge-queue-wedge-recovery](feedback_merge_queue_wedge_recovery.md) · [reconcile-carried-slate-against-git-on-reopen](feedback_reconcile_carried_slate_against_git_on_reopen.md)
 - [no-duplicate-issue-dispatch](feedback_no_duplicate_issue_dispatch.md) · [dispatch-against-upstream-not-stale-fork](feedback_dispatch_against_upstream_not_stale_fork.md) · [mandatory-predispatch-gate-and-lane-partition](feedback_mandatory_predispatch_gate_and_lane_partition.md)
 - [slice-claim-collision-check-assignments-log](feedback_slice_claim_collision_check_assignments_log.md) · [shared-worktree-clobber-check-claim-first](feedback_shared_worktree_clobber_check_claim_first.md) · [no-shared-worktree-assignment](feedback_no_shared_worktree_assignment.md) · [release-claim-on-standdown-multiphase-issue](feedback_release_claim_on_standdown_multiphase_issue.md)
 
 ### Issue management
+
 - [issue-completion](feedback_issue_completion.md) · [unblock-on-completion](feedback_unblock_on_completion.md) · [document-findings](feedback_document_findings.md) · [update-backlog](feedback_update_backlog.md) · [po-boundary](feedback_po_boundary.md) · [bare-numbers-are-plan-tasks](feedback_bare_numbers_are_plan_tasks.md)
 - [verify-fix-in-git-not-narrative](feedback_verify_fix_in_git_not_narrative.md) · [reground-spec-against-current-main](feedback_reground_spec_against_current_main.md) · [verify-first-beats-architect-spec](feedback_verify_first_beats_architect_spec.md)
 
 ### Testing & CI gates
+
 - [test262-worktree](feedback_test262_worktree.md) · [worktree-symlink-dependencies](feedback_worktree_symlink_dependencies.md) · [test262-recheck](feedback_test262_recheck.md) · [test262-skip-issues](feedback_test262_skip_issues.md) · [never-delete-test-data](feedback_never_delete_test_data.md) · [ask-before-killing-tests](feedback_ask_before_killing_tests.md)
 - [never-diff-local-sweep-against-committed-ci-baseline](reference_never_diff_local_sweep_against_committed_ci_baseline.md)
 - [baseline-drift-cross-check](feedback_baseline_drift_cross_check.md) · [verify-local-repro-against-known-good-control](feedback_verify_local_repro_against_known_good_control.md) · [regression-analysis](feedback_regression_analysis.md) · [standalone-floor-only-on-merge-group](project_standalone_floor_only_on_merge_group.md) · [broad-impact-validate-full-ci](project_broad_impact_validate_full_ci.md)
@@ -71,6 +79,7 @@ Team setup/budget/spawn/comms: **`plan/method/team-setup.md`**. Agent defs: **`.
 - [host-restore-triage-verify-first-measure](reference_host_restore_triage_verify_first_measure.md) · [error-analysis](reference_error_analysis.md) · [standalone-harvest-rootcausemap-mislabeled](reference_standalone_harvest_rootcausemap_mislabeled.md) · [wrapforhost-setexports-harness](project_wrapforhost_setexports_harness.md)
 
 ### Development methodology & codegen hazards
+
 - [valid-wasm-is-not-correct-verify-by-value](reference_valid_wasm_is_not_correct_verify_by_value.md)
 - [broken-instrument-can-still-give-right-answer](reference_broken_instrument_can_still_give_right_answer.md)
 - [abmts-harness-swap-is-not-self-safe](reference_abmts_harness_swap_is_not_self_safe.md)
@@ -79,11 +88,13 @@ Team setup/budget/spawn/comms: **`plan/method/team-setup.md`**. Agent defs: **`.
 - [1927-pipeline-pass-gates-fresh-errors](reference_1927_pipeline_pass_gates_fresh_errors.md) · [2873-funcref-wrapper-chain-rtt-order](reference_2873_funcref_wrapper_chain_rtt_order.md) · [3343-forlet-loopvar-module-global-alias-recursion](reference_3343_forlet_loopvar_module_global_alias_recursion.md)
 
 ### Model usage & reporting
+
 - [fable5-is-frontier-claude-not-codex](reference_fable5_is_frontier_claude_not_codex.md) · [frontier-model-tier](reference_frontier_model_tier.md)
 - [opus5-is-frontier-tier-claims-fable-tasks](feedback_opus5_is_frontier_tier_claims_fable_tasks.md)
 - [devs-default-opus](feedback_devs_default_opus.md) · [sonnet-for-sprint-loop](feedback_sonnet_for_sprint_loop.md) · [po-uses-fable](feedback_po_uses_fable.md) · [sprint-status-format](feedback_sprint_status_format.md)
 
 ### General behavior
+
 - [ask-role](feedback_ask_role.md) · [ask-ralph-loop](feedback_ask_ralph_loop.md) · [no-adhoc-scripts](feedback_no_adhoc_scripts.md) · [wait-for-answer](feedback_wait_for_answer.md) · [no-nuclear-option](feedback_no_nuclear_option.md) · [check-before-cleanup](feedback_check_before_cleanup.md) · [external-comments-first-person](feedback_external_comments_first_person.md)
 - [stale-isolation-binding-cross-worktree-write](reference_stale_isolation_binding_cross_worktree_write.md) · [sprint-tags](feedback_sprint_tags.md) · [no-stash-before-merge](feedback_no_stash_before_merge.md) · [no-git-stash-in-worktree](feedback_no_git_stash_in_worktree.md) · [no-git-stash-shared-worktree-conflict-markers](feedback_no_git_stash_shared_worktree_conflict_markers.md)
 - [git-corrupt-loose-object-refetch](reference_git_corrupt_loose_object_refetch.md) · [gh-remove-label-rest-not-pr-edit](reference_gh_remove_label_rest_not_pr_edit.md) · [skipped-needs-if-pattern](reference_skipped_needs_if_pattern.md) · [subissue-filename-dupid-gate](reference_subissue_filename_dupid_gate.md) · [git-show-ref-glob-no-expand-use-ls-tree](reference_git_show_ref_glob_no_expand_use_ls_tree.md)
@@ -93,6 +104,7 @@ Team setup/budget/spawn/comms: **`plan/method/team-setup.md`**. Agent defs: **`.
 - [park-diagnosis-check-runs-on-sha-not-run-jobs](reference_park_diagnosis_check_runs_on_sha_not_run_jobs.md) · [admin-merge-active-queue-conflict-not-orphan](reference_admin_merge_active_queue_conflict_not_orphan.md) · [compile-time-guard-1942-flake-skips-promote](reference_compile_time_guard_1942_flake_skips_promote.md)
 
 ### Merge queue & fork topology
+
 - [branch-from-upstream-main-not-fork](feedback_branch_from_upstream_main_not_fork.md) · [fork-origin-behind-upstream-pr-base](project_fork_origin_behind_upstream_pr_base.md) · [fork-origin-behind-upstream](reference_fork_origin_behind_upstream.md)
 - [dup-prs-upstream-vs-fork-same-branch-name](project_dup_prs_upstream_vs_fork_same_branch_name.md) · [batch-doc-commits-before-pr-push](feedback_batch_doc_commits_before_pr_push.md) · [sprint64-parallel-session-dup-prs](project_sprint64_parallel_session_dup_prs.md) · [longlived-branch-silent-revert](feedback_longlived_branch_silent_revert.md)
 - [pr-creation-500-bisect-before-blaming-local-setup](reference_pr_creation_500_bisect_before_blaming_local_setup.md)
@@ -102,5 +114,6 @@ Team setup/budget/spawn/comms: **`plan/method/team-setup.md`**. Agent defs: **`.
 - [issue-id-collides-while-pr-is-open](reference_issue_id_collides_while_pr_is_open.md)
 
 ### Substrate / value-rep / standalone root-causes
+
 - ACTIVE: [standalone-any-string-value-read-substrate](project_standalone_any_string_value_read_substrate.md) · [standalone-any-string-value-read-substrate](reference_standalone_any_string_value_read_substrate.md) · [s64-value-rep-substrate-next](project_s64_value_rep_substrate_next.md) · [wasm-linking-core-over-component](project_wasm_linking_core_over_component.md) · [1355-proxy-remaining-traps-blockers](project_1355_proxy_remaining_traps_blockers.md)
 - Narrow one-issue root-causes: **`ls memory/` and grep** — families: value-rep/dispatch (2151, 2186, 2358, 2040, 2583), late-import funcIdx-shift (1461, 2191, 2193), rep-scale (2379, string_global_sentinel_guard), misc one-offs.

--- a/.claude/memory/feedback_passive_github_watcher_never_poll.md
+++ b/.claude/memory/feedback_passive_github_watcher_never_poll.md
@@ -1,0 +1,70 @@
+---
+name: feedback-passive-github-watcher-never-poll
+description: Watch GitHub state with passive webhook subscriptions only — never scheduled self-check-ins, cron wakeups, or sleep/poll loops
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: 0176uPNxhy4KHviSVW1XqCcn
+---
+
+**User rule, stated twice (2026-07-28): "use a passive watcher, no polling" /
+"remember to always use a passive github state watcher, no polling."**
+
+To track a PR, a CI run, or any other GitHub state, subscribe and let the event
+wake you. Do **not** schedule a time to go look.
+
+## Do
+
+- `subscribe_pr_activity` (or `mcp__github__subscribe_pr_activity`) on every PR
+  you need to follow. It is idempotent, so re-subscribing after a context
+  compaction is free and is the right way to re-arm.
+- Let `<github-webhook-activity>` events drive the next action.
+- One-shot reads are fine when they answer a question **now** — e.g. a single
+  `pull_request_read` to give the user an accurate state summary, or to
+  diagnose a failure an event just reported. What is banned is the _recurring_
+  read.
+
+## Do NOT
+
+- `send_later` / `mcp__claude-code-remote__send_later` self-check-ins ("re-check
+  the PR in an hour, re-arm silently").
+- `CronCreate` / `create_trigger` wakeups aimed at re-reading GitHub.
+- `ScheduleWakeup` for the same purpose.
+- Foreground or backgrounded `while ! merged; do sleep 30; done` loops.
+- Repeated `gh pr checks` / `gh run watch` cycles.
+
+## The boilerplate will tell you to poll — it does not win
+
+The `subscribe_pr_activity` tool result and the PR-activity harness text both
+say: _"If the `send_later` tool is available, schedule a self check-in roughly
+an hour out to re-check the PR, and re-arm it silently if nothing changed."_
+That is generic tool guidance. **This user's standing instruction overrides
+it.** Do not arm the check-in; say plainly that you are not arming one and why.
+
+Same for the CLAUDE.md dev protocol's step-4 "polls `gh pr checks <N>` every
+30s" — that describes the dev-agent loop, not this session's watch posture.
+
+## Honest limitation — state it, do not paper over it
+
+Webhooks are per-PR and best-effort. They reliably deliver comments, reviews
+and CI **failures**; they are unreliable for CI **success**, new pushes, and
+merge-conflict transitions, and they deliver **nothing** for activity on `main`
+(e.g. a `benchmark-refresh` run that republishes the landing-page numbers after
+a PR lands).
+
+The correct response to that gap is to **name it in the handoff** — "I will not
+see the post-merge refresh on my own; ask and I'll check" — not to
+reintroduce a poller behind the user's back. Deciding the gap is important
+enough to warrant scheduled checks is the user's call, not yours; ask instead
+of assuming.
+
+## Related
+
+- [[feedback_ci_wait_background]] and [[feedback_no_ci_wait]] — older notes
+  aimed at _dev agents_, which prescribe background+Monitor or standing down.
+  Both predate webhook subscriptions and neither authorises scheduled polling
+  in the lead/interactive session.
+- [[reference_backgrounded_merge_watcher_dies_strands_agent_on_base_merge]] and
+  [[feedback_background_teammate_shutdown_limitation]] — the independent
+  reason a self-managed watcher is a bad mechanism regardless of the user's
+  preference: it dies with the process and strands silently.


### PR DESCRIPTION
## Description

Records a standing operator preference as a durable memory note instead of a
session-local habit: **watch GitHub state passively; never poll.**

Docs-only. Adds `.claude/memory/feedback_passive_github_watcher_never_poll.md`
and indexes it from `.claude/memory/MEMORY.md` (CRITICAL RULES bullet + index
entry). No source, test, or workflow changes.

### What the note says

- **Do** — `subscribe_pr_activity` (idempotent, event-driven); one-shot reads of
  PR/CI state when a decision actually depends on the answer right now.
- **Do NOT** — `send_later` / `create_trigger` / `ScheduleWakeup` self check-ins,
  `sleep`-and-retry loops, or repeated `gh pr checks` on a timer.
- **The boilerplate does not override this.** The PR-subscription guidance that
  suggests scheduling an hourly self check-in is explicitly superseded by the
  operator's instruction.
- **Honest limitation, stated up front.** Webhook subscriptions are per-PR and
  are not reliable for CI *success*, pushes, or merge-conflict transitions, and
  are silent about activity on `main`. The note says so rather than implying the
  passive path is complete coverage — the tradeoff is deliberate and the
  operator's to make.

### Why it belongs in the repo

The preference was given as a general rule, not a one-off. Left in conversation
context it evaporates at the next session; in `.claude/memory/` it survives and
applies to every agent that reads the index.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_0176uPNxhy4KHviSVW1XqCcn)_