### PR TITLE
feat(ir): lower recursive boolean predicates

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -2047,3 +2047,42 @@ Validation for this slice:
 - equivalence matrix: 8/8 shards, zero new regressions;
 - typecheck, fallback/adoption/oracle, linear-IR, LOC, function-budget, and
   harness compile-budget gates pass.
+
+## Implementation Notes — recursive boolean results with a dynamic ABI (2026-07-30)
+
+Acorn's `isLocalVariableAccess` and `isPrivateFieldAccess` now emit through IR.
+Both are unannotated recursive predicates: their declared callable ABI remains
+dynamic, but every return expression is a boolean composition of comparisons
+and direct self-recursion.
+
+The selector proves that closed return family without changing the signature.
+The dynamic-use scan then admits only boolean `&&` / `||` operands, including a
+dynamic self-call result. AST-to-IR lowers those operands through `dyn.truthy`,
+keeps short-circuit control flow, and boxes the concrete i32 result with the
+Boolean tag at the dynamic return boundary. A mixed-value logical expression
+such as `value || 42` remains `logical-value-unsupported`.
+
+The unchanged #3796 runtime-dynamic compile/outcome driver moves from 18 to
+**20 emitted functions out of 43**, adding `isLocalVariableAccess` and
+`isPrivateFieldAccess` with zero post-claim withdrawals. The terminal blocker
+census becomes:
+
+- 14 body-shape rejections;
+- 4 parameter-type rejections;
+- 1 logical-value rejection;
+- 2 RegExp-constructor rejections;
+- 1 call-graph closure;
+- 1 constructor-resolution rejection.
+
+Draft PR #3808 independently adds grounded implicit-any numeric-local inference
+to AST-to-IR. Its `from-ast.ts` changes are line-disjoint from this slice; the
+first branch to rebase must retain both. Its closed fixed outer token-table
+representation and specialized proven `Parser.options` open-object reads are
+also IR parity requirements for retiring the direct path.
+
+Validation for this slice:
+
+- exact #3796 driver: 20/43 emitted, zero post-claim withdrawals;
+- focused recursive-boolean and prior #2949 claim-flip suites pass;
+- mixed-value logical fallback is pinned;
+- typecheck and the standard IR gates pass.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1363,7 +1363,7 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
       throw new Error(`ir/from-ast: Phase 1 return must have an expression in ${cx.funcName}`);
     }
     const v = lowerExpr(stmt.expression, cx, cx.returnType);
-    const vCoerced = coerceReturnValue(v, cx);
+    const vCoerced = coerceReturnValue(v, cx, stmt.expression);
     cx.builder.terminate({ kind: "return", values: [vCoerced] });
     return;
   }
@@ -6175,8 +6175,17 @@ function coerceYieldValueToExternref(value: IrValueId, cx: LowerCtx): IrValueId 
  * All other cases (matching kinds, already-externref values, non-externref
  * declared results) pass through unchanged.
  */
-function coerceReturnValue(value: IrValueId, cx: LowerCtx): IrValueId {
+function coerceReturnValue(value: IrValueId, cx: LowerCtx, sourceExpression?: ts.Expression): IrValueId {
   const declared = cx.returnType;
+  if (declared?.kind === "dynamic") {
+    const actual = cx.builder.typeOf(value);
+    if (actual.kind === "dynamic") return value;
+    if (sourceExpression) {
+      const boxed = boxConcreteToDynamic(value, actual, sourceExpression, cx);
+      if (boxed !== null) return boxed;
+    }
+    throw new Error(`ir/from-ast: concrete return needs a dynamic box in ${cx.funcName}`);
+  }
   // (#2856 C3) externref value into a NUMBER (f64) declared result —
   // `return hit;` where `hit = cache.get(n)` is the externref Map_get
   // result. Unbox through `__unbox_number`, exactly what legacy emits for
@@ -7427,7 +7436,7 @@ function lowerEarlyReturn(stmt: ts.ReturnStatement, cx: LowerCtx): void {
     throw new Error(`ir/from-ast: early bare return in non-void function in ${cx.funcName}`);
   }
   const v = lowerExpr(stmt.expression, cx, cx.returnType);
-  cx.builder.emitEarlyReturn(coerceReturnValue(v, cx));
+  cx.builder.emitEarlyReturn(coerceReturnValue(v, cx, stmt.expression));
 }
 
 /**
@@ -8694,9 +8703,11 @@ function lowerLogicalAndOr(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: Low
   const isAnd = op === ts.SyntaxKind.AmpersandAmpersandToken;
   const opName = isAnd ? "&&" : "||";
 
-  const lhs = lowerExpr(expr.left, cx, irVal({ kind: "i32" }));
-  const lhsType = cx.builder.typeOf(lhs);
-  if (asVal(lhsType)?.kind !== "i32") {
+  const rawLhs = lowerExpr(expr.left, cx, irVal({ kind: "i32" }));
+  const lhsType = cx.builder.typeOf(rawLhs);
+  const lhs =
+    lhsType.kind === "dynamic" ? cx.builder.emitDynTruthy(rawLhs) : asVal(lhsType)?.kind === "i32" ? rawLhs : null;
+  if (lhs === null) {
     throw new Error(`ir/from-ast: operator '${opName}' requires bool operands in ${cx.funcName}`);
   }
 
@@ -8708,7 +8719,15 @@ function lowerLogicalAndOr(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: Low
   const rhsCx: LowerCtx = { ...cx, scope: new Map(skippedScope) };
   let rhs!: IrValueId;
   const rhsBody = cx.builder.collectBodyInstrs(() => {
-    rhs = lowerExpr(expr.right, rhsCx, resultType);
+    const rawRhs = lowerExpr(expr.right, rhsCx, resultType);
+    const rhsType = cx.builder.typeOf(rawRhs);
+    if (rhsType.kind === "dynamic") {
+      rhs = cx.builder.emitDynTruthy(rawRhs);
+    } else if (asVal(rhsType)?.kind === "i32") {
+      rhs = rawRhs;
+    } else {
+      throw new Error(`ir/from-ast: operator '${opName}' requires bool operands in ${cx.funcName}`);
+    }
   });
   if (asVal(cx.builder.typeOf(rhs))?.kind !== "i32") {
     throw new Error(`ir/from-ast: operator '${opName}' requires bool operands in ${cx.funcName}`);
@@ -9006,9 +9025,10 @@ function boxConcreteToDynamic(v: IrValueId, t: IrType, operand: ts.Expression, c
   }
   const tv = asVal(t);
   if (!tv) return null;
-  // Boolean literal (`true`/`false`) → tag-4 box; without the refinement the i32
-  // would box as a NUMBER and `dyn === true` would fail against a boxed boolean.
-  if (operand.kind === ts.SyntaxKind.TrueKeyword || operand.kind === ts.SyntaxKind.FalseKeyword) {
+  // Proven boolean i32 → tag-4 box; without the refinement the i32 would box
+  // as a NUMBER and recursive boolean helpers would lose their value family at
+  // the dynamic return boundary.
+  if (tv.kind === "i32" && expressionIsDefinitelyBoolean(operand)) {
     return cx.builder.emitBox(v, irDynamic(JsTag.Boolean));
   }
   // Numeric literal or an f64-typed value → number box (f64 hosts only the
@@ -9020,6 +9040,33 @@ function boxConcreteToDynamic(v: IrValueId, t: IrType, operand: ts.Expression, c
   // here — demote rather than risk a wrong tag. S5.P can refine with the
   // checker (isProvablyBoolean) when it opens the scan.
   return null;
+}
+
+function expressionIsDefinitelyBoolean(expression: ts.Expression): boolean {
+  const candidate = peelParensExpr(expression);
+  if (candidate.kind === ts.SyntaxKind.TrueKeyword || candidate.kind === ts.SyntaxKind.FalseKeyword) return true;
+  if (ts.isPrefixUnaryExpression(candidate) && candidate.operator === ts.SyntaxKind.ExclamationToken) return true;
+  if (ts.isBinaryExpression(candidate)) {
+    const op = candidate.operatorToken.kind;
+    return (
+      op === ts.SyntaxKind.LessThanToken ||
+      op === ts.SyntaxKind.LessThanEqualsToken ||
+      op === ts.SyntaxKind.GreaterThanToken ||
+      op === ts.SyntaxKind.GreaterThanEqualsToken ||
+      op === ts.SyntaxKind.EqualsEqualsToken ||
+      op === ts.SyntaxKind.ExclamationEqualsToken ||
+      op === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+      op === ts.SyntaxKind.ExclamationEqualsEqualsToken ||
+      op === ts.SyntaxKind.InstanceOfKeyword ||
+      op === ts.SyntaxKind.InKeyword ||
+      op === ts.SyntaxKind.AmpersandAmpersandToken ||
+      op === ts.SyntaxKind.BarBarToken
+    );
+  }
+  if (ts.isConditionalExpression(candidate)) {
+    return expressionIsDefinitelyBoolean(candidate.whenTrue) && expressionIsDefinitelyBoolean(candidate.whenFalse);
+  }
+  return false;
 }
 
 /**

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1126,6 +1126,12 @@ let currentIrSafeVarDeclarationLists: ReadonlySet<ts.VariableDeclarationList> = 
 let currentSelectionOptions: IrSelectionOptions | undefined;
 let currentLocalClassDeclarations: ReadonlyMap<string, ts.ClassDeclaration> = new Map();
 let currentClaimClassName: string | null = null;
+// #2949 Acorn follow-up — the current top-level function's return expressions
+// may be provably boolean even while its unannotated JS callable ABI remains
+// dynamic. This proof types direct self-recursion inside `&&` / `||` without
+// changing the legacy-visible signature.
+let currentSubjectFunctionName: string | null = null;
+let currentSubjectReturnsBoolean = false;
 let currentClassBindings = new Map<string, string>();
 let currentCallableArities = new Map<string, number>();
 let currentCallableReturnClasses = new Map<string, string>();
@@ -1277,11 +1283,65 @@ function prepareDynamicEqualitySubject(fn: IrClaimableSubject, isMethod: boolean
   currentSubjectIsModuleInit = false;
   currentDynMemberEqualitySubject = !isMethod && ts.isFunctionDeclaration(fn) ? fn : null;
   currentDynEqualityBoxableParamNames = new Set<string>();
+  currentSubjectFunctionName = !isMethod && ts.isFunctionDeclaration(fn) && fn.name !== undefined ? fn.name.text : null;
+  currentSubjectReturnsBoolean =
+    currentSubjectFunctionName !== null &&
+    fn.body !== undefined &&
+    functionReturnsOnlyBooleanExpressions(fn.body, currentSubjectFunctionName);
 }
 
 function recordDynamicParamKind(name: string, kind: ResolvedKind, dynamicNames: Set<string>): void {
   if (kind === "dynamic") dynamicNames.add(name);
   else if (kind === "f64" || kind === "bool" || kind === "string") currentDynEqualityBoxableParamNames.add(name);
+}
+
+/**
+ * Prove a function's return expressions boolean under the coinductive
+ * assumption that direct self-recursion returns the same family. The callable
+ * ABI stays dynamic; this proof only permits boolean use inside the body and a
+ * tag-correct box at the return boundary.
+ */
+function functionReturnsOnlyBooleanExpressions(body: ts.Block, selfName: string): boolean {
+  let sawReturn = false;
+  let accepted = true;
+  const visit = (node: ts.Node): void => {
+    if (!accepted) return;
+    if (node !== body && isFunctionLike(node)) return;
+    if (ts.isReturnStatement(node)) {
+      sawReturn = true;
+      if (!node.expression || !expressionIsBooleanWithSelfRecursion(node.expression, selfName)) accepted = false;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(body, visit);
+  return sawReturn && accepted;
+}
+
+function expressionIsBooleanWithSelfRecursion(expression: ts.Expression, selfName: string): boolean {
+  const candidate = unwrapProjectionExpression(expression);
+  if (candidate.kind === ts.SyntaxKind.TrueKeyword || candidate.kind === ts.SyntaxKind.FalseKeyword) return true;
+  if (ts.isPrefixUnaryExpression(candidate) && candidate.operator === ts.SyntaxKind.ExclamationToken) return true;
+  if (ts.isBinaryExpression(candidate)) {
+    const op = candidate.operatorToken.kind;
+    if (isComparisonResultOperator(op)) return true;
+    if (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken) {
+      return (
+        expressionIsBooleanWithSelfRecursion(candidate.left, selfName) &&
+        expressionIsBooleanWithSelfRecursion(candidate.right, selfName)
+      );
+    }
+    return false;
+  }
+  if (ts.isConditionalExpression(candidate)) {
+    return (
+      expressionIsBooleanWithSelfRecursion(candidate.whenTrue, selfName) &&
+      expressionIsBooleanWithSelfRecursion(candidate.whenFalse, selfName)
+    );
+  }
+  return (
+    ts.isCallExpression(candidate) && ts.isIdentifier(candidate.expression) && candidate.expression.text === selfName
+  );
 }
 
 /** Collect direct identifier mutations in one function body. */
@@ -2160,16 +2220,21 @@ function dynamicUsesAreMoveOnly(
       return true;
     }
     if (ts.isBinaryExpression(e)) {
+      const leftIsDyn = isDynShaped(e.left);
+      const rightIsDyn = isDynShaped(e.right);
+      const op = e.operatorToken.kind;
+      if (
+        currentSubjectReturnsBoolean &&
+        (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken)
+      ) {
+        return scanExpr(e.left, leftIsDyn) && scanExpr(e.right, rightIsDyn);
+      }
       // Plain assignment re-binds; scan the RHS against the LHS's dyn-ness.
       if (e.operatorToken.kind === ts.SyntaxKind.EqualsToken && ts.isIdentifier(e.left)) {
         if (expectDyn) return false; // assignment-as-value in a dyn position — slice 3
         return scanExpr(e.right, dynNames.has(e.left.text));
       }
       if (expectDyn) return false; // operator results are concrete-shaped
-
-      const leftIsDyn = isDynShaped(e.left);
-      const rightIsDyn = isDynShaped(e.right);
-      const op = e.operatorToken.kind;
 
       if (
         op === ts.SyntaxKind.EqualsEqualsEqualsToken ||
@@ -5537,6 +5602,16 @@ function declaredExpressionHasExactFamily(
   expected: "boolean" | "string",
   scope: ReadonlySet<string>,
 ): boolean {
+  const candidate = unwrapProjectionExpression(expression);
+  if (
+    expected === "boolean" &&
+    currentSubjectReturnsBoolean &&
+    currentSubjectFunctionName !== null &&
+    !scope.has(currentSubjectFunctionName) &&
+    expressionIsBooleanWithSelfRecursion(candidate, currentSubjectFunctionName)
+  ) {
+    return true;
+  }
   const classifier = currentSelectionOptions?.classifyDeclaredPrimitiveExpression;
   const classified = classifier?.(expression);
   if (classified !== undefined) return classified === expected;

--- a/tests/issue-2949-recursive-boolean-dynamic.test.ts
+++ b/tests/issue-2949-recursive-boolean-dynamic.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+const recursivePredicate = `
+export function recursive(node: any): any {
+  return node.type === "Leaf" ||
+    node.type === "Wrap" && recursive(node.expression);
+}
+`;
+
+describe("#2949 recursive boolean results with a dynamic ABI", () => {
+  it.each(["gc", "standalone"] as const)("emits the predicate through IR on the %s target", async (target) => {
+    const result = await compile(recursivePredicate, {
+      fileName: "recursive-boolean.ts",
+      target,
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toContain("recursive");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("preserves recursive true, short-circuit, and false results through the host dynamic carrier", async () => {
+    const result = await compile(recursivePredicate, {
+      fileName: "recursive-boolean-runtime.ts",
+      target: "gc",
+      trackIrOutcomes: true,
+    });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toContain("recursive");
+
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+    const recursive = instance.exports.recursive as (node: unknown) => unknown;
+    expect(recursive({ type: "Leaf" })).toBe(true);
+    expect(recursive({ type: "Wrap", expression: { type: "Leaf" } })).toBe(true);
+    expect(recursive({ type: "Wrap", expression: { type: "Other" } })).toBe(false);
+  });
+
+  it("keeps mixed-value logical results on the legacy path", async () => {
+    const result = await compile(`export function mixed(value: any): any { return value || 42; }`, {
+      fileName: "mixed-logical.ts",
+      trackIrOutcomes: true,
+    });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irOutcomes?.find((outcome) => outcome.displayName === "mixed")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      code: "logical-value-unsupported",
+      irBodyEmitted: false,
+      legacyBodyEmitted: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- prove direct self-recursive boolean return families while preserving the dynamic callable ABI
- lower dynamic boolean operands through IR truthiness and box Boolean-tagged dynamic returns
- move Acorn isLocalVariableAccess and isPrivateFieldAccess onto IR while keeping mixed-value logical expressions on the direct path
- record the post-merge 20/43 Acorn census and #3808 integration requirements in plan/issues/2949-ir-dynamic-value-representation.md

## Validation

- focused #2949 suites: 7/7
- exact Acorn runtime-dynamic census: 20/43 emitted, zero withdrawals
- equivalence gate: 8/8 shards, zero new regressions
- IR fallback, adoption, oracle, linear-IR, LOC, function, and harness compile-budget gates
- typecheck and lint

## Coordination

Draft PR #3808 owns line-disjoint numeric-local inference changes in src/ir/from-ast.ts and will rebase after this lands. Its Acorn representation optimizations remain required IR parity.