### PR TITLE
feat(ir): lower ambient String.fromCharCode

### DIFF
--- a/plan/issues/3787-ir-string-fromcharcode.md
+++ b/plan/issues/3787-ir-string-fromcharcode.md
@@ -1,0 +1,79 @@
+---
+id: 3787
+title: "IR ambient String.fromCharCode lowering"
+status: done
+completed: 2026-07-30
+sprint: current
+created: 2026-07-30
+updated: 2026-07-30
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: ir
+language_feature: builtins
+goal: ir-full-coverage
+depends_on: [2949]
+related: [2122, 2601, 2875]
+assignee: ttraenkler/codex-ir-string-fromcharcode
+branch: codex/3787-ir-string-fromcharcode
+loc-budget-allow:
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/from-ast.ts::lowerMethodCall
+  - src/ir/integration.ts::compileIrPathFunctions
+  - src/ir/integration.ts::makeFromAstResolver
+  - src/ir/select.ts::isPhase1Expr
+  - src/ir/select.ts::isPhase1StatementListInScope
+---
+
+# #3787 — lower ambient `String.fromCharCode` through IR
+
+## Problem
+
+Acorn's `codePointToString` helper is otherwise IR-shaped, but both of its
+return arms call the ambient static builtin `String.fromCharCode`. The selector
+treats the ambient `String` receiver as an external call, leaving the function
+on the legacy body path.
+
+## Scope
+
+- Claim only the exact, unshadowed ambient `String.fromCharCode(...)` identity.
+- Admit zero or more non-spread arguments whose numeric representation is
+  proven by the checker/IR selector.
+- Preserve left-to-right argument evaluation and variadic concatenation.
+- Use `env.String_fromCharCode(f64)` in the host lane.
+- Use `__str_fromCharCode(i32)` in native/standalone lanes after the exact
+  ToUint16 modulo fold already used by direct codegen.
+- Reuse the existing f64-slot compound-assignment lowering at body top level,
+  which is the second masked shape in Acorn's `codePointToString` helper.
+- Keep coercion-general, spread, `String.fromCodePoint`, and shadowed bindings
+  on legacy.
+
+## Acceptance criteria
+
+- [x] Host and standalone runtime tests cover zero, one, and multiple args.
+- [x] Standalone tests cover large, negative, fractional, NaN, and infinity
+      ToUint16 behavior.
+- [x] A shadowed `String` binding is not selected.
+- [x] Acorn's exact runtime-dynamic driver moves from 20/43 to 21/43
+      IR-emitted reachable functions with no withdrawals.
+- [x] Focused tests, typecheck, IR fallback ratchet, and equivalence gate pass.
+
+## Completion evidence
+
+- Exact unchanged Acorn runtime-dynamic driver: 21 emitted of 43 reachable
+  functions; `codePointToString` is newly emitted; body-shape residuals fall
+  from 14 to 13; no post-claim withdrawals.
+- Focused #3787 suite: 6/6 passing across host and standalone.
+- Existing early-return/guard suites: 18/18 passing.
+- Typecheck and IR fallback ratchet pass; the ratchet reports no unintended,
+  module-level, or post-claim increases.
+- Equivalence gate: 1,611 passing, no new regressions. Four baseline failures
+  now pass.
+- Existing unrelated baseline: the standalone `String.fromCodePoint` surrogate
+  length assertion in `tests/issue-2122.test.ts` fails identically on merged
+  main. The `fromCharCode` cases in that file pass.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -308,6 +308,20 @@ export interface IrFromAstResolver {
    */
   stringForOfPlan?(): "char-loop" | "iter-host";
   /**
+   * #3787 — mode-selected target and numeric ABI for the exact ambient
+   * `String.fromCharCode(...)` static call.
+   *
+   * The helper is unary in both modes; from-ast preserves the variadic JS
+   * surface by invoking it once per argument and concatenating the resulting
+   * one-code-unit strings from left to right. Native helpers take i32 after
+   * an exact ToUint16 fold; the host import takes f64 and performs ToUint16
+   * in JS. `null` keeps resolver-less/unsupported backends on legacy.
+   */
+  stringFromCharCodePlan?(): {
+    readonly funcName: string;
+    readonly argumentRep: "i32" | "f64";
+  } | null;
+  /**
    * #2952 slice 5 — mode-selected runtime symbols for dynamic for-in.
    * Both plans share the same externref/i32 ABI and preserve the #2964
    * snapshot ordering plus per-visit liveness semantics.
@@ -468,6 +482,13 @@ export interface IrFromAstResolver {
   isDirectModuleBinding?(node: ts.Identifier): boolean;
   /** True when the identifier resolves to an ambient declaration-file symbol. */
   isAmbientBinding?(node: ts.Identifier): boolean;
+  /**
+   * #3787 checker identity for the global String constructor. JavaScript
+   * inputs compiled without lib declarations may leave the identifier
+   * unresolved; the production resolver treats that as the global only when
+   * no source declaration owns the name.
+   */
+  isAmbientStringBinding?(node: ts.Identifier): boolean;
 }
 
 export interface AstToIrOptions {
@@ -1089,6 +1110,21 @@ function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void 
         ts.isElementAccessExpression(s.expression.left)
       ) {
         lowerElementStore(s.expression.left, s.expression.right, cx);
+        continue;
+      }
+      // #3787 / #2856 — a body-level compound assignment followed by a
+      // return has the same slot semantics as the already-supported form
+      // inside loop/body buffers. Reuse the shared lowering instead of
+      // requiring the assignment to be nested in a block-owning statement.
+      if (
+        ts.isBinaryExpression(s.expression) &&
+        (s.expression.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken ||
+          s.expression.operatorToken.kind === ts.SyntaxKind.MinusEqualsToken ||
+          s.expression.operatorToken.kind === ts.SyntaxKind.AsteriskEqualsToken ||
+          s.expression.operatorToken.kind === ts.SyntaxKind.SlashEqualsToken) &&
+        ts.isIdentifier(s.expression.left)
+      ) {
+        lowerCompoundAssignment(s.expression.left, s.expression.operatorToken.kind, s.expression.right, cx);
         continue;
       }
       throw new Error(`ir/from-ast: unsupported ExpressionStatement shape in ${cx.funcName}`);
@@ -5152,6 +5188,88 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
       throw new Error(`ir/from-ast: Object.defineProperty helper produced no result (${cx.funcName})`);
     }
     return result;
+  }
+
+  // #3787 — exact ambient String.fromCharCode(...). Intercept before receiver
+  // lowering because the ambient `String` constructor has no Phase-1 value
+  // representation. The selector admits only numeric, non-spread arguments;
+  // keep the checks here too so direct lowerer callers cannot bypass them.
+  if (
+    receiverIdentifier?.text === "String" &&
+    methodName === "fromCharCode" &&
+    !receiverIsDirectModuleBinding &&
+    cx.scope.get("String") === undefined &&
+    (cx.resolver?.isAmbientStringBinding?.(receiverIdentifier) ??
+      cx.resolver?.isAmbientBinding?.(receiverIdentifier) !== false)
+  ) {
+    if (expr.arguments.some(ts.isSpreadElement)) {
+      throw new IrUnsupportedError(
+        "method-call-unsupported",
+        "build",
+        `ir/from-ast: String.fromCharCode spread is not supported (${cx.funcName})`,
+      );
+    }
+    const plan = cx.resolver?.stringFromCharCodePlan?.() ?? null;
+    if (plan === null) {
+      throw new IrUnsupportedError(
+        "method-call-unsupported",
+        "build",
+        `ir/from-ast: String.fromCharCode provider unavailable (${cx.funcName})`,
+      );
+    }
+
+    if (expr.arguments.length === 0) return cx.builder.emitStringConst("");
+    let result: IrValueId | null = null;
+    for (const argument of expr.arguments) {
+      const numeric = lowerExpr(argument, cx, irVal({ kind: "f64" }));
+      const numericType = asVal(cx.builder.typeOf(numeric));
+      if (numericType?.kind !== "f64" && numericType?.kind !== "i32") {
+        throw new IrUnsupportedError(
+          "operand-coercion-unsupported",
+          "build",
+          `ir/from-ast: String.fromCharCode argument is not numeric (${cx.funcName})`,
+        );
+      }
+
+      let code = numeric;
+      if (plan.argumentRep === "i32" && numericType.kind === "f64") {
+        // ECMA-262 ToUint16 in the f64 domain:
+        //   t = trunc(x)
+        //   m = t - floor(t / 65536) * 65536
+        // NaN and ±Infinity propagate to NaN, which trunc_sat maps to zero.
+        // A bare trunc_sat would saturate before the helper's low-16 mask and
+        // miscompile values outside the signed-i32 range.
+        const truncated = cx.builder.emitUnary("f64.trunc", numeric, irVal({ kind: "f64" }));
+        const quotient = cx.builder.emitBinary(
+          "f64.div",
+          truncated,
+          cx.builder.emitConst({ kind: "f64", value: 65536 }, irVal({ kind: "f64" })),
+          irVal({ kind: "f64" }),
+        );
+        const floored = cx.builder.emitUnary("f64.floor", quotient, irVal({ kind: "f64" }));
+        const wrapped = cx.builder.emitBinary(
+          "f64.sub",
+          truncated,
+          cx.builder.emitBinary(
+            "f64.mul",
+            floored,
+            cx.builder.emitConst({ kind: "f64", value: 65536 }, irVal({ kind: "f64" })),
+            irVal({ kind: "f64" }),
+          ),
+          irVal({ kind: "f64" }),
+        );
+        code = cx.builder.emitUnary("i32.trunc_sat_f64_s", wrapped, irVal({ kind: "i32" }));
+      } else if (plan.argumentRep === "f64" && numericType.kind === "i32") {
+        code = cx.builder.emitUnary("f64.convert_i32_s", numeric, irVal({ kind: "f64" }));
+      }
+
+      const part = cx.builder.emitCall(irRuntimeFuncRef(plan.funcName), [code], { kind: "string" });
+      if (part === null) {
+        throw new Error(`ir/from-ast: String.fromCharCode helper produced no result (${cx.funcName})`);
+      }
+      result = result === null ? part : cx.builder.emitStringConcat(result, part);
+    }
+    return result!;
   }
 
   if (

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -282,6 +282,26 @@ export interface IrTypeOverrideMap {
   get(name: string): { readonly params: readonly IrType[]; readonly returnType: IrType | null } | undefined;
 }
 
+function makeAmbientStringBindingPredicate(checker: ts.TypeChecker): (node: ts.Identifier) => boolean {
+  return (node) => {
+    try {
+      const symbol = checker.getSymbolAtLocation(node);
+      // allowJs programs can omit lib declarations entirely. An unresolved
+      // `String` is the global constructor; every source-owned shadow has a
+      // source declaration and is rejected by the branch below.
+      if (!symbol) return true;
+      const declarations = [symbol.valueDeclaration, ...(symbol.declarations ?? [])].filter(
+        (declaration): declaration is ts.Declaration => declaration !== undefined,
+      );
+      return (
+        declarations.length > 0 && declarations.every((declaration) => declaration.getSourceFile().isDeclarationFile)
+      );
+    } catch {
+      return false;
+    }
+  };
+}
+
 export function compileIrPathFunctions(
   ctx: CodegenContext,
   sourceFile: ts.SourceFile,
@@ -394,6 +414,7 @@ export function compileIrPathFunctions(
   const classifyDeclaredPrimitiveExpression = makeIrDeclaredPrimitiveExpressionClassifier(ctx.checker);
   const isArrayExpression = makeIrArrayExpressionPredicate(ctx.checker);
   const isRegExpExpression = makeIrRegExpExpressionPredicate(ctx.checker);
+  const isAmbientStringBinding = makeAmbientStringBindingPredicate(ctx.checker);
   const selected =
     selection ??
     planIrCompilation(sourceFile, {
@@ -405,6 +426,7 @@ export function compileIrPathFunctions(
       classifyDeclaredPrimitiveExpression,
       isArrayExpression,
       isRegExpExpression,
+      isAmbientStringBinding,
       supportsSymbolicMathHelpers: true,
       supportsLiteralStringReplace: true,
       supportsHostStringArrayLiterals: jsHostExterns && !ctx.nativeStrings,
@@ -2847,6 +2869,7 @@ function externResultClassName(
 }
 
 function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModuleBindingResolver): IrFromAstResolver {
+  const isAmbientStringBinding = makeAmbientStringBindingPredicate(ctx.checker);
   return {
     objectDefinePropertyTarget() {
       if (ctx.standalone || ctx.wasi || ctx.strictNoHostImports) return null;
@@ -2918,6 +2941,11 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
         indexArgRep: (native ? "i32" : "f64") as "i32" | "f64",
         padOmitted: (native ? "native-slice-len" : "host") as "native-slice-len" | "host",
       };
+    },
+    stringFromCharCodePlan() {
+      return ctx.nativeStrings
+        ? { funcName: "__str_fromCharCode", argumentRep: "i32" as const }
+        : { funcName: "String_fromCharCode", argumentRep: "f64" as const };
     },
     resolveString(): ValType {
       if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
@@ -3077,6 +3105,7 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
     isAmbientBinding(node: ts.Identifier): boolean {
       return moduleBindingResolver?.isAmbientBinding(node) === true;
     },
+    isAmbientStringBinding,
     // (#2856) Variant selection for `console.<m>(arg)` — the SAME checker
     // predicates as the legacy `collectConsoleImports` registration scan
     // (string → bool → number → externref, in that order), so the import

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -502,6 +502,12 @@ export interface IrSelectionOptions {
     capability: "host-date-snapshot" | "host-regexp-constructor" | "host-object-define-property",
   ) => boolean;
   /**
+   * #3787 exact global String-constructor identity. This is separate from the
+   * declaration-file-only ambient predicate because allowJs programs can be
+   * compiled without lib declarations, leaving a genuine global unresolved.
+   */
+  readonly isAmbientStringBinding?: (node: ts.Identifier) => boolean;
+  /**
    * (#2856 async-delay slice) Exact checker-certified
    * `new Promise<number>((resolve) => { setTimeout(...); })` construction.
    * Omitted by bare-selector and host-free/M0 callers, so generic arrow/new
@@ -1185,6 +1191,11 @@ let currentDirectOnlyDynMemberEqualityFunctions: ReadonlySet<ts.FunctionDeclarat
 let currentDirectOnlyDynMemberEqualityFunctionsReady = false;
 let currentDynMemberEqualitySubject: ts.FunctionDeclaration | null = null;
 let currentDynEqualityBoxableParamNames = new Set<string>();
+// Grounded parameter families from the propagation map. The checker sees an
+// unannotated allowJs parameter as `any`, but the IR ABI may already have
+// proved it f64 from every call edge. Coercion-sensitive builtin selectors
+// need that exact proof instead of consulting checker syntax alone.
+let currentNumericParamNames = new Set<string>();
 
 /** @internal Configure the shared predicates for an exact structural selector run. */
 export function configureIrStructuralSelectorPredicates(
@@ -1283,6 +1294,7 @@ function prepareDynamicEqualitySubject(fn: IrClaimableSubject, isMethod: boolean
   currentSubjectIsModuleInit = false;
   currentDynMemberEqualitySubject = !isMethod && ts.isFunctionDeclaration(fn) ? fn : null;
   currentDynEqualityBoxableParamNames = new Set<string>();
+  currentNumericParamNames = new Set<string>();
   currentSubjectFunctionName = !isMethod && ts.isFunctionDeclaration(fn) && fn.name !== undefined ? fn.name.text : null;
   currentSubjectReturnsBoolean =
     currentSubjectFunctionName !== null &&
@@ -1292,7 +1304,10 @@ function prepareDynamicEqualitySubject(fn: IrClaimableSubject, isMethod: boolean
 
 function recordDynamicParamKind(name: string, kind: ResolvedKind, dynamicNames: Set<string>): void {
   if (kind === "dynamic") dynamicNames.add(name);
-  else if (kind === "f64" || kind === "bool" || kind === "string") currentDynEqualityBoxableParamNames.add(name);
+  else if (kind === "f64" || kind === "bool" || kind === "string") {
+    currentDynEqualityBoxableParamNames.add(name);
+    if (kind === "f64") currentNumericParamNames.add(name);
+  }
 }
 
 /**
@@ -2613,6 +2628,31 @@ function isPhase1StatementListInScope(
           return shapeNo("nontail-elemstore-idx", lhs.argumentExpression);
         if (!isPhase1Expr(s.expression.right, scope, localClasses))
           return shapeNo("nontail-elemstore-rhs", s.expression.right);
+        continue;
+      }
+      // #3787 / #2856 — top-level-in-body compound assignment. The body
+      // statement dispatcher already admitted and lowered this exact slot
+      // shape; mirror it here for `<early return>; x -= n; return ...`.
+      if (
+        ts.isBinaryExpression(s.expression) &&
+        (s.expression.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken ||
+          s.expression.operatorToken.kind === ts.SyntaxKind.MinusEqualsToken ||
+          s.expression.operatorToken.kind === ts.SyntaxKind.AsteriskEqualsToken ||
+          s.expression.operatorToken.kind === ts.SyntaxKind.SlashEqualsToken) &&
+        ts.isIdentifier(s.expression.left)
+      ) {
+        if (isUnrepresentableModuleBinding(s.expression.left)) {
+          return shapeNo("nontail-module-storage-unrepresentable", s.expression);
+        }
+        if (currentModuleBindingResolver?.(s.expression.left) && !currentSubjectIsModuleInit) {
+          return shapeNo("nontail-module-compound", s.expression);
+        }
+        if (!scope.has(s.expression.left.text)) return shapeNo("nontail-compound-scope", s.expression.left);
+        if (projectionBindingMutationIsUnsupported(s.expression.left.text, s.expression)) return false;
+        if (!isPhase1Expr(s.expression.right, scope, localClasses)) {
+          return shapeNo("nontail-compound-rhs", s.expression.right);
+        }
+        clearProjectionBinding(s.expression.left.text);
         continue;
       }
       // (#2856) Catch-all for ExpressionStatements outside the accepted set:
@@ -4725,6 +4765,7 @@ function expressionIsProvenNumber(expr: ts.Expression, seen = new Set<ts.Variabl
   const candidate = unwrapPhase1Parens(expr);
   if (ts.isNumericLiteral(candidate)) return true;
   if (ts.isIdentifier(candidate)) {
+    if (currentNumericParamNames.has(candidate.text)) return true;
     // The module-binding resolver has already proved the shared slot and all
     // of its writes numeric. Do not re-audit the declaration initializer as a
     // local alias: host-produced numeric initializers such as
@@ -4787,6 +4828,13 @@ function selectorSeesAmbientBinding(node: ts.Identifier): boolean {
   return (
     currentSelectionOptions?.isAmbientBinding?.(node) === true ||
     currentModuleBindingResolver?.isAmbientBinding(node) === true
+  );
+}
+
+function selectorSeesAmbientStringBinding(node: ts.Identifier): boolean {
+  return (
+    currentSelectionOptions?.isAmbientStringBinding?.(node) === true ||
+    (currentSelectionOptions?.isAmbientStringBinding === undefined && selectorSeesAmbientBinding(node))
   );
 }
 
@@ -6014,6 +6062,22 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
       ) {
         return shapeNo("expr-math-call-shape", expr);
       }
+      // #3787 — exact ambient String.fromCharCode(...). Each argument is
+      // lowered independently through the mode-selected unary helper, then
+      // concatenated left-to-right. The numeric proof is required because
+      // this first IR slice does not implement the builtin's general ToNumber
+      // coercion. Zero arguments are valid and produce the empty string.
+      if (
+        ts.isIdentifier(expr.expression.expression) &&
+        expr.expression.expression.text === "String" &&
+        expr.expression.name.text === "fromCharCode" &&
+        selectorSeesAmbientStringBinding(expr.expression.expression) &&
+        !scope.has("String")
+      ) {
+        return expr.arguments.every(
+          (arg) => !ts.isSpreadElement(arg) && expressionIsProvenNumber(arg) && isPhase1Expr(arg, scope, localClasses),
+        );
+      }
       // ES5 Object.defineProperty — an exact ambient static call is a
       // symbolic host-helper operation, not an instance method on a value
       // named `Object`. Reject shadowed bindings and host-free targets before
@@ -6923,6 +6987,16 @@ export function buildLocalCallGraph(
             selectorSeesAmbientBinding(node.expression.expression) &&
             currentSelectionOptions?.supportsBackendCapability?.("host-object-define-property") !== false &&
             node.arguments.length === 3
+          ) {
+            for (const a of node.arguments) visit(a);
+            return;
+          }
+          if (
+            ts.isIdentifier(node.expression.expression) &&
+            node.expression.expression.text === "String" &&
+            node.expression.name.text === "fromCharCode" &&
+            selectorSeesAmbientStringBinding(node.expression.expression) &&
+            node.arguments.every((argument) => !ts.isSpreadElement(argument))
           ) {
             for (const a of node.arguments) visit(a);
             return;

--- a/tests/issue-3787-ir-string-fromcharcode.test.ts
+++ b/tests/issue-3787-ir-string-fromcharcode.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+const HOST_SOURCE = `
+export function empty(): string {
+  return String.fromCharCode();
+}
+
+export function single(code: number): string {
+  return String.fromCharCode(code);
+}
+
+export function pair(a: number, b: number): string {
+  return String.fromCharCode(a, b);
+}
+`;
+
+describe("#3787 IR ambient String.fromCharCode", () => {
+  it.each(["gc", "standalone"] as const)("emits exact ambient calls through IR on %s", async (target) => {
+    const result = await compile(HOST_SOURCE, {
+      fileName: "ir-from-char-code.ts",
+      target,
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toEqual(
+      expect.arrayContaining(["empty", "single", "pair"]),
+    );
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("preserves zero, one, and variadic results in the host lane", async () => {
+    const result = await compile(HOST_SOURCE, {
+      fileName: "ir-from-char-code-host.ts",
+      target: "gc",
+      trackIrOutcomes: true,
+    });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+    const exports = instance.exports as {
+      empty: () => string;
+      single: (code: number) => string;
+      pair: (a: number, b: number) => string;
+    };
+    expect(exports.empty()).toBe("");
+    expect(exports.single(65)).toBe("A");
+    expect(exports.pair(65, 90)).toBe("AZ");
+    expect(exports.pair(0x10041, 0x10042)).toBe("AB");
+  });
+
+  it("applies exact ToUint16 before the native helper", async () => {
+    const result = await compile(
+      `
+      export function code(value: number): number {
+        return String.fromCharCode(value).charCodeAt(0);
+      }
+      `,
+      {
+        fileName: "ir-from-char-code-standalone.ts",
+        target: "standalone",
+        trackIrOutcomes: true,
+      },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toContain("code");
+    expect(result.imports ?? []).toEqual([]);
+
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    const code = (instance.exports as { code: (value: number) => number }).code;
+    expect(code(65.9)).toBe(65);
+    expect(code(4_294_967_361)).toBe(65);
+    expect(code(-65_535.75)).toBe(1);
+    expect(code(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(code(Number.NaN)).toBe(0);
+  });
+
+  it("uses the propagated numeric ABI for Acorn's unannotated helper shape", async () => {
+    const result = await compile(
+      `
+      function codePointToString(code) {
+        if (code <= 0xFFFF) { return String.fromCharCode(code); }
+        code -= 0x10000;
+        return String.fromCharCode((code >> 10) + 0xD800, (code & 1023) + 0xDC00);
+      }
+      /** @param {number} value @returns {string} */
+      export function codePoint(value) {
+        return codePointToString(value);
+      }
+      `,
+      {
+        allowJs: true,
+        skipSemanticDiagnostics: true,
+        fileName: "ir-from-char-code-acorn.mjs",
+        target: "gc",
+        trackIrOutcomes: true,
+      },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toContain("codePointToString");
+
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+    const codePoint = (instance.exports as { codePoint: (value: number) => string }).codePoint;
+    expect(codePoint(0x41)).toBe("A");
+    expect(codePoint(0x1f600)).toBe("😀");
+  });
+
+  it("does not claim a shadowed String binding as the ambient builtin", async () => {
+    const result = await compile(
+      `
+      export function shadowed(value: number): string {
+        const String = { fromCharCode(code: number): string { return code === 65 ? "local" : "other"; } };
+        return String.fromCharCode(value);
+      }
+      `,
+      {
+        fileName: "ir-from-char-code-shadowed.ts",
+        target: "gc",
+        trackIrOutcomes: true,
+      },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("shadowed");
+  });
+});


### PR DESCRIPTION
## Summary

- lower exact ambient `String.fromCharCode(...)` calls through IR in host and native-string modes
- preserve zero/one/variadic behavior and exact native ToUint16 modulo semantics
- reuse propagated numeric parameter evidence and the existing compound-assignment slot path to move Acorn `codePointToString` onto IR
- track completion in `plan/issues/3787-ir-string-fromcharcode.md`

## Migration result

The unchanged runtime-dynamic Acorn census advances from 20/43 to 21/43 IR-emitted reachable functions. `codePointToString` is newly emitted, body-shape residuals drop from 14 to 13, and there are no post-claim withdrawals.

## Verification

- focused and early-return/guard regression suites: 24/24 pass
- TypeScript typecheck: pass
- IR fallback ratchet: pass, no increases or post-claim demotions
- equivalence gate: 1,611 pass, no new regressions; four baseline failures now pass
- exact Acorn runtime-dynamic census: 21/43, zero withdrawals

Existing baseline note: standalone `String.fromCodePoint(97, 0x1F600).length` in `tests/issue-2122.test.ts` fails identically on merged main (returns 2 vs the old UTF-16-length expectation 3). The `fromCharCode` cases in that suite pass, and this PR does not change `fromCodePoint`.