### PR TITLE
perf(ir): keep Fibonacci state in native i32

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
-npx lint-staged
+npx lint-staged &&
+  pnpm run check:loc-budget &&
+  pnpm run check:func-budget

--- a/src/ir/analysis/i32-slots.ts
+++ b/src/ir/analysis/i32-slots.ts
@@ -467,14 +467,26 @@ export function planI32Slots(
   }
 
   // (4) Producibility fixpoint: shrink until every surviving candidate's writes
-  // are all lowerable to an exact i32 *using only the surviving candidates*.
-  // The identifier probe resolves a use site to its GOVERNING declaration, so
-  // a same-named sibling binding never leaks its promotion into another scope.
+  // are all lowerable to an exact i32. Besides the surviving promoted slots,
+  // admit names from Q-CANON itself: immutable intermediates such as
+  //
+  //     const next = (a + b) | 0;
+  //     b = next;
+  //
+  // are provably int32-valued even though they do not need mutable slot
+  // storage. `lowerAsI32` can consume those through `i32PureNames`; excluding
+  // them here caused the whole Fibonacci cycle (`a`, `b`) to be demoted to
+  // f64. `collectI32CoercedLocals` already rejects duplicate/shadowed names, so
+  // the name-based half of this probe cannot leak across sibling bindings.
+  //
+  // The promoted-slot half still resolves a use site to its GOVERNING
+  // declaration, so a same-named sibling binding never leaks its promotion
+  // into another scope.
   const promotedAt: IsPromotedI32 = (id: ts.Identifier): boolean => {
     for (const c of candidates.values()) {
       if (c.name === id.text && nodeContains(c.scope, id)) return true;
     }
-    return false;
+    return canonNames.has(id.text);
   };
   for (;;) {
     let changed = false;

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -54,6 +54,10 @@ export class IrFunctionBuilder {
   private readonly params: IrParam[] = [];
   private readonly finished: IrBlock[] = [];
   private readonly valueTypes = new Map<IrValueId, IrType>();
+  // Exact i32 values widened to f64. SSA values are immutable, so a later
+  // truncation of the widened result can always recover the original i32 even
+  // when unrelated instructions were emitted between the two conversions.
+  private readonly exactI32Widenings = new Map<IrValueId, IrValueId>();
   private current: OpenBlock | null = null;
   // Block IDs are assigned from a monotonic counter rather than from
   // `finished.length`, so forward references (br_if with a not-yet-opened
@@ -230,26 +234,15 @@ export class IrFunctionBuilder {
     // index, `arr[i]` — would pay `convert` + `trunc_sat` where it used to pay
     // just `trunc_sat`, i.e. the promotion would PESSIMIZE indexed loops.
     //
-    // Guard: only when the `convert` is the immediately-preceding instruction
-    // in the CURRENT sink. That makes same-buffer dominance trivially true and
-    // makes an aliasing second consumer impossible in practice (there has been
-    // no chance to hand the value to anyone else yet).
     if (op === "i32.trunc_sat_f64_s") {
-      const sink = this.bodyBuffer ?? this.currentBlockInstrsOrNull();
-      const last = sink !== null && sink.length > 0 ? sink[sink.length - 1] : undefined;
-      if (last !== undefined && last.kind === "unary" && last.op === "f64.convert_i32_s" && last.result === rand) {
-        return last.rand;
-      }
+      const exactI32 = this.exactI32Widenings.get(rand);
+      if (exactI32 !== undefined) return exactI32;
     }
     const result = this.allocator.fresh();
     this.valueTypes.set(result, resultType);
     this.pushInstr({ kind: "unary", op, rand, result, resultType });
+    if (op === "f64.convert_i32_s") this.exactI32Widenings.set(result, rand);
     return result;
-  }
-
-  /** The instruction list a `pushInstr` would append to, or null if no block. */
-  private currentBlockInstrsOrNull(): IrInstr[] | null {
-    return this.current === null ? null : this.current.instrs;
   }
 
   emitSelect(condition: IrValueId, whenTrue: IrValueId, whenFalse: IrValueId, resultType: IrType): IrValueId {

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -2470,17 +2470,10 @@ function lowerBitwiseAsI32(expr: ts.BinaryExpression, cx: LowerCtx): IrValueId {
   return cx.builder.emitBinary(binop, lhs, rhs, IR_I32);
 }
 
-/**
- * Invariant W — store `rhs` into an i32-promoted slot.
- */
+/** Invariant W — store `rhs` into an i32-promoted slot. */
 function writePromotedI32Slot(slotIndex: number, rhs: ts.Expression, cx: LowerCtx): void {
-  // A write may flow through an immutable Q-CANON intermediate that keeps
-  // ordinary f64/SSA storage (for example Fibonacci's
-  // `const next = (a + b) | 0; b = next`). The slot planner admits exactly
-  // those names via the same function-wide proof in `i32PureNames`; include
-  // them in the live check so planning and emission agree. This remains the
-  // strict Q-CANON predicate — arithmetic compositions are not admitted here.
-  const exactI32 = (id: ts.Identifier): boolean => promotedI32Probe(cx)(id) || cx.i32PureNames.has(id.text);
+  const promoted = promotedI32Probe(cx);
+  const exactI32 = (id: ts.Identifier): boolean => promoted(id) || cx.i32PureNames.has(id.text);
   if (!isCanonI32Lowerable(rhs, exactI32)) {
     throw new IrUnsupportedError(
       "operand-coercion-unsupported",

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -2474,7 +2474,14 @@ function lowerBitwiseAsI32(expr: ts.BinaryExpression, cx: LowerCtx): IrValueId {
  * Invariant W — store `rhs` into an i32-promoted slot.
  */
 function writePromotedI32Slot(slotIndex: number, rhs: ts.Expression, cx: LowerCtx): void {
-  if (!isCanonI32Lowerable(rhs, promotedI32Probe(cx))) {
+  // A write may flow through an immutable Q-CANON intermediate that keeps
+  // ordinary f64/SSA storage (for example Fibonacci's
+  // `const next = (a + b) | 0; b = next`). The slot planner admits exactly
+  // those names via the same function-wide proof in `i32PureNames`; include
+  // them in the live check so planning and emission agree. This remains the
+  // strict Q-CANON predicate — arithmetic compositions are not admitted here.
+  const exactI32 = (id: ts.Identifier): boolean => promotedI32Probe(cx)(id) || cx.i32PureNames.has(id.text);
+  if (!isCanonI32Lowerable(rhs, exactI32)) {
     throw new IrUnsupportedError(
       "operand-coercion-unsupported",
       "build",

--- a/tests/issue-3741-i32-slot-promotion.test.ts
+++ b/tests/issue-3741-i32-slot-promotion.test.ts
@@ -141,6 +141,31 @@ describe("#3741 — i32 slot promotion (shape)", () => {
     expect(mix(bodyA)).toBe(mix(bodyB));
     expect(bodyA).not.toContain("f64.add");
   });
+
+  it("keeps Fibonacci loop-carried state in i32 through an immutable next value", async () => {
+    const r = await compile(
+      `/** @param {number} n @returns {number} */
+       export function run(n) {
+         let a = 0;
+         let b = 1;
+         for (let i = 0; i < n; i++) {
+           const next = (a + b) | 0;
+           a = b;
+           b = next;
+         }
+         return a | 0;
+       }`,
+      { emitWat: true, fileName: "fib.js", target: "wasi", nativeStrings: true },
+    );
+    expect(r.success).toBe(true);
+    expect(r.irCompiledFuncs).toContain("run");
+    const body = funcBody(r.wat, "run");
+
+    expect(body).toMatch(/\(local \$\$slot_a i32\)/);
+    expect(body).toMatch(/\(local \$\$slot_b i32\)/);
+    expect(body).toContain("i32.add");
+    expect(body).not.toContain("i32.trunc_sat_f64_s");
+  });
 });
 
 interface Case {


### PR DESCRIPTION
## Summary

- let IR i32-slot planning consume immutable intermediates already proven exact-int32 by Q-CANON
- keep the live promoted-slot write check aligned with that proof
- cancel exact `i32 -> f64 -> i32` SSA round trips even when intervening instructions separate the conversions
- add the landing Fibonacci loop as a focused IR shape regression

## Root cause

The cold benchmark correctly measures the same 20,000,000-iteration request as the warm lane. The standalone `run` function was IR-claimed, but its loop-carried `a` and `b` slots were demoted to f64 because `b = next` flowed through an immutable `const next = (a + b) | 0`. The planner ignored exact-int32 immutable intermediates, and the builder only canceled a widening/narrowing pair when the two instructions were adjacent. Cranelift therefore executed two saturating float-to-int conversions and two int-to-float conversions per iteration.

After this change, Cranelift carries the Fibonacci state as i32 and performs one native i32 add per iteration.

## Measurement

Controlled local A/B on the exact landing source and `runtimeArg=20000000`, same Wasmtime 45.0.0 host, same compiler options and Binaryen `-O3`; 5 interleaved before/after rounds, 2 warmups + 7 retained samples per round (35 samples each):

- before: median 83.250625 ms (min 80.439916, max 90.177500)
- after: median 10.386416 ms (min 9.910250, max 11.327584)
- speedup: 8.0153x
- output before/after: `-1821818939`

## Verification

- `pnpm exec vitest run tests/issue-3297.test.ts tests/issue-3741-i32-slot-promotion.test.ts tests/issue-3758-i32-pure-native-arithmetic.test.ts` (36 passed, 1 skipped)
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- Prettier check on changed files
