### PR TITLE
feat(ir): bridge standalone native RegExp tests (#3791)

### DIFF
--- a/plan/issues/3791-ir-native-regexp-test.md
+++ b/plan/issues/3791-ir-native-regexp-test.md
@@ -19,20 +19,25 @@ related: [2949, 3507, 3780]
 assignee: ttraenkler/codex-ir-regexp
 branch: codex/3791-ir-native-regexp-test
 files:
+  - src/codegen/index.ts
   - src/codegen/regexp-runtime-contract.ts
   - src/codegen/regexp-standalone.ts
+  - src/ir/backend/legality.ts
   - src/ir/from-ast.ts
   - src/ir/integration.ts
   - src/ir/module-bindings.ts
   - src/ir/select.ts
   - tests/issue-3791-ir-native-regexp-test.test.ts
 loc-budget-allow:
+  - src/codegen/index.ts
   - src/ir/from-ast.ts
   - src/ir/integration.ts
   - src/ir/module-bindings.ts
   - src/ir/select.ts
 func-budget-allow:
+  - src/codegen/index.ts::planIrOverlay
   - src/ir/from-ast.ts::lowerMethodCall
+  - src/ir/integration.ts::compileIrPathFunctions
   - src/ir/integration.ts::makeFromAstResolver
   - src/ir/select.ts::isPhase1Expr
 ---
@@ -59,6 +64,8 @@ the existing brand semantics.
   top-level RegExp initialized from compile-time strings.
 - Exclude reassigned bindings and global/sticky carriers whose shared
   `lastIndex` state would require wider IR modeling.
+- Restrict bridged globals to `var` declarations until the IR read carries
+  the module lexical TDZ guard.
 - Load the real legacy-allocated externref module global and call the existing
   in-module `__regexp_test_carrier` helper.
 - Preserve native-string representation by externalizing the subject at the
@@ -67,6 +74,9 @@ the existing brand semantics.
   exact direct-call vec arguments. Reject reassigned and alias-initialized
   bindings, and require the allocator-owned global ValType to match the
   callee's planned vec ABI.
+- Require a selector-visible numeric-vec callee ABI and keep this bridge off
+  in fast-array configurations. Target or ABI mismatches remain ordinary
+  pre-claim fallbacks.
 - Do not touch the direct-backend Acorn performance files.
 
 ## Baseline and newly exposed dependency
@@ -99,8 +109,11 @@ represents that dependency without making module arrays general IR values.
       and all four identifier helpers.
 - [x] Focused fallback coverage keeps reassigned and global/sticky RegExp
       carriers on direct codegen.
+- [x] Destructuring assignment, for-of destructuring, object-rest assignment,
+      lexical TDZ, WASI, and fast-array configurations stay on direct codegen.
 - [x] Focused coverage admits only an exact stable numeric-array module global
-      at a direct-call vec boundary and rejects reassigned/alias initializers.
+      at a proven numeric-vec direct-call boundary and rejects any-parameter,
+      reassigned, and alias-initialized shapes.
 - [x] Exact Acorn measurement reaches 27/43 with checksum 422, zero imports,
       and zero withdrawals.
 - [x] Typecheck, IR fallback ratchet, formatting, function budget, and focused

--- a/plan/issues/3791-ir-native-regexp-test.md
+++ b/plan/issues/3791-ir-native-regexp-test.md
@@ -1,0 +1,107 @@
+---
+id: 3791
+title: "IR standalone native RegExp test bridge"
+status: in-progress
+sprint: current
+created: 2026-07-30
+updated: 2026-07-30
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: ir
+es_edition: multi
+language_feature: regexp
+goal: ir-full-coverage
+depends_on: [3790]
+related: [2949, 3507, 3780]
+assignee: ttraenkler/codex-ir-regexp
+branch: codex/3791-ir-native-regexp-test
+files:
+  - src/codegen/regexp-runtime-contract.ts
+  - src/codegen/regexp-standalone.ts
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/module-bindings.ts
+  - src/ir/select.ts
+  - tests/issue-3791-ir-native-regexp-test.test.ts
+loc-budget-allow:
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/module-bindings.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/from-ast.ts::lowerMethodCall
+  - src/ir/integration.ts::makeFromAstResolver
+  - src/ir/select.ts::isPhase1Expr
+---
+
+# #3791 — carry standalone native RegExp tests through IR
+
+## Problem
+
+After #3790, Acorn's exact runtime-dynamic standalone build emits 23 of 43
+reachable functions through IR. `isIdentifierStart` and `isIdentifierChar`
+remain direct-codegen functions because their non-ASCII branches call `.test`
+on stable top-level native RegExp carriers. Their
+`isRegExpIdentifierStart`/`isRegExpIdentifierPart` wrappers then remain out by
+call-graph closure.
+
+The native RegExp engine and its `$NativeRegExp`-first carrier helper already
+exist. The missing piece is a narrow IR bridge to the real module-global
+carrier, without reconstructing the RegExp, adding a host import, or bypassing
+the existing brand semantics.
+
+## Scope
+
+- Admit only one-argument `.test(subject)` on a checker-resolved, stable
+  top-level RegExp initialized from compile-time strings.
+- Exclude reassigned bindings and global/sticky carriers whose shared
+  `lastIndex` state would require wider IR modeling.
+- Load the real legacy-allocated externref module global and call the existing
+  in-module `__regexp_test_carrier` helper.
+- Preserve native-string representation by externalizing the subject at the
+  helper ABI boundary; add no JS host import.
+- Represent the newly exposed stable numeric-array module globals only as
+  exact direct-call vec arguments. Reject reassigned and alias-initialized
+  bindings, and require the allocator-owned global ValType to match the
+  callee's planned vec ABI.
+- Do not touch the direct-backend Acorn performance files.
+
+## Baseline and newly exposed dependency
+
+The #3790 parent measures 23/43 emitted, checksum 422, zero imports, and zero
+post-claim withdrawals.
+
+The RegExp bridge first passed its focused 4/4 emission and runtime test, but
+the exact Acorn census stayed at 23/43. Removing the RegExp refusal exposed a
+second selector barrier in both leaf bodies:
+`astralIdentifierStartCodes`/`astralIdentifierCodes` were exact module numeric
+vecs passed to the already-emitted `isInAstralSet`, but the IR could not read
+those module globals. The direct-call-only numeric-vec projection in this slice
+represents that dependency without making module arrays general IR values.
+
+## Result
+
+- The unchanged runtime-dynamic standalone Acorn driver emits 27 of 43
+  reachable functions through IR.
+- Newly emitted: `isIdentifierStart`, `isIdentifierChar`,
+  `isRegExpIdentifierStart`, and `isRegExpIdentifierPart`.
+- One exact runtime iteration returns checksum 422 with zero Wasm imports and
+  zero post-claim withdrawals.
+- The bridge uses the existing native RegExp carrier and helper; it does not
+  cache or precompute the benchmark result.
+
+## Acceptance criteria
+
+- [x] Focused standalone execution covers two static native RegExp carriers
+      and all four identifier helpers.
+- [x] Focused fallback coverage keeps reassigned and global/sticky RegExp
+      carriers on direct codegen.
+- [x] Focused coverage admits only an exact stable numeric-array module global
+      at a direct-call vec boundary and rejects reassigned/alias initializers.
+- [x] Exact Acorn measurement reaches 27/43 with checksum 422, zero imports,
+      and zero withdrawals.
+- [x] Typecheck, IR fallback ratchet, formatting, function budget, and focused
+      tests pass.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1712,6 +1712,7 @@ function prepareHostDateSnapshotPreflight(
       backend: "wasmgc",
       target: ctx.wasi ? "wasi" : ctx.standalone ? "standalone" : "gc",
       allowHostImports: !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports),
+      fast: ctx.fast,
     },
     "host-date-snapshot",
   );
@@ -1978,6 +1979,7 @@ function planIrOverlay(
         backend: "wasmgc",
         target: ctx.wasi ? "wasi" : ctx.standalone ? "standalone" : "gc",
         allowHostImports: jsHostExterns,
+        fast: ctx.fast,
       },
       capability,
     );
@@ -2028,6 +2030,13 @@ function planIrOverlay(
   // (`ctx.fast`), so every claimed config emits a valid, carrier-aligned body.
   const dynMemberReadBuildable = !(ctx.fast && !ctx.standalone && !ctx.wasi);
   const resolveImplicitParamType = makeIrImplicitParamTypeResolver(ctx, ast.sourceFile);
+  const implicitParamUsesNumericVecAbi = (parameter: ts.ParameterDeclaration): boolean => {
+    const projection = resolveImplicitParamType(parameter);
+    if (projection?.kind !== "object") return false;
+    const valueType = asVal(projection.type);
+    if (valueType?.kind !== "ref" && valueType?.kind !== "ref_null") return false;
+    return ctx.typeIdxToStructName.get(valueType.typeIdx) === "__vec_f64";
+  };
   const legacyCallerAbiIsProjected = (declaration: ts.FunctionDeclaration): boolean => {
     let hasIndexedCarrier = false;
     let hasBooleanProjection = false;
@@ -2089,6 +2098,7 @@ function planIrOverlay(
       isArrayExpression,
       isRegExpExpression,
       resolveImplicitParamType: (parameter) => resolveImplicitParamType(parameter)?.kind,
+      implicitParamUsesNumericVecAbi,
       legacyCallerAbiIsProjected,
       projectedClassShapes: classShapes,
       resolveLocalClassExpression,

--- a/src/codegen/regexp-runtime-contract.ts
+++ b/src/codegen/regexp-runtime-contract.ts
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * In-module native RegExp carrier ABI shared by legacy codegen and IR.
+ *
+ * This is a defined Wasm helper, never a host import. Its receiver-first ABI
+ * preserves the `$NativeRegExp` brand check before any user-method dispatch.
+ */
+export const STANDALONE_REGEXP_CARRIER_TEST_HELPER = "__regexp_test_carrier";

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -82,6 +82,7 @@ import { compileStringLiteral } from "./string-ops.js";
 import { nativeStringRepr } from "./builtin-scaffold.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { addFuncType } from "./registry/types.js";
+import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "./regexp-runtime-contract.js";
 
 export const STANDALONE_REGEXP_ABI_VERSION = 1;
 
@@ -171,7 +172,6 @@ export function hasStandaloneRegExpEngine(state: StandaloneRegExpEngineState): b
 }
 
 const STANDALONE_REGEXP_STRUCT_NAME = "__StandaloneRegExp";
-export const STANDALONE_REGEXP_CARRIER_TEST_HELPER = "__regexp_test_carrier";
 // g/i/y from Phase 2a, m/s from 2c, d/u/v from 2d (#1911 — `d` does not
 // change MATCHING semantics; the `.indices` result surface is #1914's lane;
 // u/v code-point atoms resolve via compile-time host enumeration, Slice B).

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -18,7 +18,9 @@ export type IrBackendKind = "wasmgc" | "linear" | "bytecode" | "porffor";
 export type IrBackendTargetCapability =
   | "host-date-snapshot"
   | "host-regexp-constructor"
-  | "host-object-define-property";
+  | "host-object-define-property"
+  | "standalone-native-regexp-test-carrier"
+  | "legacy-numeric-array-global";
 
 /**
  * The target facts needed by pre-claim capability checks. Keep this smaller
@@ -29,6 +31,8 @@ export interface IrBackendTargetProfile {
   readonly backend: IrBackendKind;
   readonly target: "gc" | "linear" | "standalone" | "wasi";
   readonly allowHostImports: boolean;
+  /** Legacy fast-array storage has a distinct ABI not yet represented in IR. */
+  readonly fast?: boolean;
 }
 
 /**
@@ -50,6 +54,10 @@ export function supportsIrBackendTargetCapability(
       return profile.backend === "wasmgc" && profile.target === "gc" && profile.allowHostImports;
     case "host-object-define-property":
       return profile.backend === "wasmgc" && profile.target === "gc" && profile.allowHostImports;
+    case "standalone-native-regexp-test-carrier":
+      return profile.backend === "wasmgc" && profile.target === "standalone" && !profile.allowHostImports;
+    case "legacy-numeric-array-global":
+      return profile.backend === "wasmgc" && profile.fast !== true;
   }
 }
 

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -48,6 +48,7 @@ import {
   IR_DYN_METHOD_CALL_1_FN,
 } from "../codegen/dyn-ops.js";
 import { FMOD_FN } from "../codegen/fmod.js"; // #2945 — `%` lowers to a call of the shared exact-fmod helper
+import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "../codegen/regexp-runtime-contract.js";
 // (#1373b C-1) Leaf-module async helpers (no codegen/index cycle).
 import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "../codegen/async-static.js";
 import { evaluateConstantCondition } from "../codegen/statements/control-flow.js";
@@ -493,6 +494,19 @@ export interface IrFromAstResolver {
    * module declarations return undefined.
    */
   resolveModuleBinding?(node: ts.Identifier, writeValue?: ts.Expression): ModuleBindingGlobal | undefined;
+  /**
+   * #3791 — exact standalone native RegExp `.test` bridge. The receiver is
+   * the real legacy module-global carrier; the helper is an in-module defined
+   * function with the canonical receiver-first externref ABI.
+   */
+  standaloneRegExpTestPlan?(
+    receiver: ts.Expression,
+  ): { readonly receiverGlobal: IrGlobalRef; readonly funcName: string } | null;
+  /** #3791 exact stable module numeric vec at a direct-call boundary. */
+  staticNumericArrayRead?(
+    expression: ts.Expression,
+    expected: IrType,
+  ): { readonly globalRef: IrGlobalRef; readonly type: IrType } | null;
   /** True for any checker-owned top-level lexical, including unsupported reps. */
   isDirectModuleBinding?(node: ts.Identifier): boolean;
   /** True when the identifier resolves to an ambient declaration-file symbol. */
@@ -4678,7 +4692,11 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = fa
   for (let i = 0; i < expandedArgExprs.length; i++) {
     const argExpr = expandedArgExprs[i]!;
     const expected = calleeSig.params[i]!;
-    let argVal = lowerExpr(argExpr, cx, expected);
+    const staticNumericArray = cx.resolver?.staticNumericArrayRead?.(argExpr, expected) ?? null;
+    let argVal =
+      staticNumericArray === null
+        ? lowerExpr(argExpr, cx, expected)
+        : cx.builder.emitGlobalGet(staticNumericArray.globalRef, staticNumericArray.type);
     let argType = cx.builder.typeOf(argVal);
     // #3214 B0 — source-function callable params use externref, while closure
     // literals remain compiler-owned root-carrier refs. Cross that boundary
@@ -5191,6 +5209,39 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
   const receiverIdentifier = ts.isIdentifier(expr.expression.expression) ? expr.expression.expression : undefined;
   const receiverIsDirectModuleBinding =
     receiverIdentifier !== undefined && cx.resolver?.isDirectModuleBinding?.(receiverIdentifier) === true;
+
+  // #3791 — standalone native RegExp `.test` on one exact, stable top-level
+  // carrier. Keep the real legacy module global as the receiver (no duplicate
+  // construction/cache), externalize the native subject string, then call the
+  // established `$NativeRegExp`-first carrier helper. The selector admits
+  // only this one-argument form and the resolver repeats the source proof.
+  if (methodName === "test" && expr.arguments.length === 1 && !ts.isSpreadElement(expr.arguments[0]!)) {
+    const plan = cx.resolver?.standaloneRegExpTestPlan?.(expr.expression.expression) ?? null;
+    if (plan !== null) {
+      if (plan.funcName !== STANDALONE_REGEXP_CARRIER_TEST_HELPER) {
+        throw new Error(`ir/from-ast: unexpected standalone RegExp test helper ${plan.funcName}`);
+      }
+      const receiver = cx.builder.emitGlobalGet(plan.receiverGlobal, irVal({ kind: "externref" }));
+      const subject = lowerExpr(expr.arguments[0]!, cx, { kind: "string" });
+      if (cx.builder.typeOf(subject).kind !== "string") {
+        throw new IrUnsupportedError(
+          "operand-coercion-unsupported",
+          "build",
+          `ir/from-ast: standalone RegExp.test subject is not a proven string (${cx.funcName})`,
+        );
+      }
+      const subjectExtern = cx.builder.emitCoerceToExternref(subject);
+      const result = cx.builder.emitCall(
+        irRuntimeFuncRef(plan.funcName),
+        [receiver, subjectExtern],
+        irVal({ kind: "i32", boolean: true }),
+      );
+      if (result === null) {
+        throw new Error(`ir/from-ast: standalone RegExp.test helper returned void (${cx.funcName})`);
+      }
+      return result;
+    }
+  }
 
   // ES5 Object.defineProperty — route an exact ambient static call through
   // the same full ToPropertyDescriptor helper as legacy codegen. Keeping the

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -69,6 +69,8 @@ import {
   nativeStringLiteralInstrs,
   type StringEncoding,
 } from "../codegen/native-strings.js";
+import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "../codegen/regexp-runtime-contract.js";
+import { ensureStandaloneRegExpCarrierTestHelper } from "../codegen/regexp-standalone.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../codegen/registry/imports.js";
 import {
   planProgramAbiSupportCallableAlias,
@@ -156,6 +158,8 @@ import {
   type IrLegacyModuleBindingResolver,
   type IrModuleBindingIdentity,
   type IrModuleBindingResolver,
+  type IrStaticNumericArrayPlan,
+  type IrStaticRegExpTestPlan,
 } from "./module-bindings.js";
 import {
   lowerIrFunctionToWasm,
@@ -169,6 +173,7 @@ import {
   type IrUnionLowering,
 } from "./lower.js";
 import {
+  asVal,
   forEachInstrDeep, // (#2949 slice 3) deep instr walk for preregisterDynamicSupport
   irTypeEquals,
   type IrClassMemberKind,
@@ -2887,9 +2892,135 @@ function resolveDynamicCarrier(ctx: CodegenContext): ValType {
   return { kind: "externref" };
 }
 
+function resolveStandaloneRegExpTestGlobal(ctx: CodegenContext, plan: IrStaticRegExpTestPlan): IrGlobalRef {
+  if (
+    plan.globalBindingId === undefined ||
+    plan.sourceId === undefined ||
+    plan.declarationOrdinal === undefined ||
+    !ts.isIdentifier(plan.declaration.name)
+  ) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "build",
+      "standalone RegExp test plan has no exact structural module-global identity",
+    );
+  }
+  const name = plan.declaration.name.text;
+  const globalName = `__mod_${name}`;
+  const observed = ctx.programAbiGlobals?.moduleBinding(plan.declaration);
+  let global: GlobalDef | undefined;
+  if (ctx.programAbiGlobals) {
+    if (!observed || observed.displayName !== name) {
+      throw new IrInvariantError(
+        "unknown-global-ref",
+        "build",
+        `standalone RegExp carrier '${name}' has no allocator-owned module global`,
+      );
+    }
+    global = observed.value;
+  } else {
+    const globalIdx = ctx.moduleGlobals.get(name);
+    global = globalIdx === undefined ? undefined : ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
+  }
+  if (!global || global.name !== globalName || global.type.kind !== "externref") {
+    throw new IrInvariantError(
+      "abi-type-index-mismatch",
+      "build",
+      `standalone RegExp carrier ${globalName} is not the legacy externref module slot`,
+    );
+  }
+  const ref = irSourceGlobalRef(plan.globalBindingId, globalName);
+  planProgramAbiGlobal(ctx, {
+    ref,
+    anchor: { kind: "source", sourceId: plan.sourceId },
+    roleOrdinal: PROGRAM_ABI_GLOBAL_ROLE.moduleValue,
+    derivedOrdinal: plan.declarationOrdinal,
+    global,
+  });
+  return ref;
+}
+
+function sameExactValType(left: ValType, right: ValType): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "ref" || left.kind === "ref_null") {
+    return right.kind === left.kind && left.typeIdx === right.typeIdx;
+  }
+  return true;
+}
+
+function resolveStaticNumericArrayGlobal(
+  ctx: CodegenContext,
+  plan: IrStaticNumericArrayPlan,
+  expected: IrType,
+): { readonly globalRef: IrGlobalRef; readonly type: IrType } {
+  const expectedVal = asVal(expected);
+  if (
+    plan.globalBindingId === undefined ||
+    plan.sourceId === undefined ||
+    plan.declarationOrdinal === undefined ||
+    !ts.isIdentifier(plan.declaration.name) ||
+    expectedVal === null ||
+    (expectedVal.kind !== "ref" && expectedVal.kind !== "ref_null")
+  ) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "build",
+      "static numeric array direct-call plan has no exact ref-typed structural identity",
+    );
+  }
+  const name = plan.declaration.name.text;
+  const globalName = `__mod_${name}`;
+  const observed = ctx.programAbiGlobals?.moduleBinding(plan.declaration);
+  let global: GlobalDef | undefined;
+  if (ctx.programAbiGlobals) {
+    if (!observed || observed.displayName !== name) {
+      throw new IrInvariantError(
+        "unknown-global-ref",
+        "build",
+        `static numeric array '${name}' has no allocator-owned module global`,
+      );
+    }
+    global = observed.value;
+  } else {
+    const globalIdx = ctx.moduleGlobals.get(name);
+    global = globalIdx === undefined ? undefined : ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
+  }
+  if (!global || global.name !== globalName || !sameExactValType(global.type, expectedVal)) {
+    throw new IrInvariantError(
+      "abi-type-index-mismatch",
+      "build",
+      `static numeric array ${globalName} does not match the direct callee's vec ABI`,
+    );
+  }
+  const globalRef = irSourceGlobalRef(plan.globalBindingId, globalName);
+  planProgramAbiGlobal(ctx, {
+    ref: globalRef,
+    anchor: { kind: "source", sourceId: plan.sourceId },
+    roleOrdinal: PROGRAM_ABI_GLOBAL_ROLE.moduleValue,
+    derivedOrdinal: plan.declarationOrdinal,
+    global,
+  });
+  return { globalRef, type: expected };
+}
+
 function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModuleBindingResolver): IrFromAstResolver {
   const isAmbientStringBinding = makeAmbientStringBindingPredicate(ctx.checker);
   return {
+    standaloneRegExpTestPlan(receiver: ts.Expression) {
+      if (!ctx.standalone || ctx.wasi || !moduleBindingResolver) return null;
+      const plan = moduleBindingResolver.staticRegExpTestPlan(receiver);
+      if (!plan) return null;
+      ensureStandaloneRegExpCarrierTestHelper(ctx);
+      return {
+        receiverGlobal: resolveStandaloneRegExpTestGlobal(ctx, plan),
+        funcName: STANDALONE_REGEXP_CARRIER_TEST_HELPER,
+      };
+    },
+    staticNumericArrayRead(expression: ts.Expression, expected: IrType) {
+      if (!moduleBindingResolver) return null;
+      const plan = moduleBindingResolver.staticNumericArrayPlan(expression);
+      return plan ? resolveStaticNumericArrayGlobal(ctx, plan, expected) : null;
+    },
     objectDefinePropertyTarget() {
       if (ctx.standalone || ctx.wasi || ctx.strictNoHostImports) return null;
       return irImportFuncRef("env", "__defineProperty_desc");

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -333,6 +333,7 @@ export function compileIrPathFunctions(
         backend: "wasmgc",
         target: ctx.wasi ? "wasi" : ctx.standalone ? "standalone" : "gc",
         allowHostImports: jsHostExterns,
+        fast: ctx.fast,
       },
       capability,
     );
@@ -431,6 +432,16 @@ export function compileIrPathFunctions(
   const isArrayExpression = makeIrArrayExpressionPredicate(ctx.checker);
   const isRegExpExpression = makeIrRegExpExpressionPredicate(ctx.checker);
   const isAmbientStringBinding = makeAmbientStringBindingPredicate(ctx.checker);
+  const implicitParamUsesNumericVecAbi = (parameter: ts.ParameterDeclaration): boolean => {
+    if (parameter.type || !overrides) return false;
+    const declaration = parameter.parent;
+    if (!ts.isFunctionDeclaration(declaration) || !declaration.name) return false;
+    const index = declaration.parameters.indexOf(parameter);
+    const expected = index < 0 ? undefined : overrides.get(declaration.name.text)?.params[index];
+    const valueType = expected ? asVal(expected) : null;
+    if (valueType?.kind !== "ref" && valueType?.kind !== "ref_null") return false;
+    return ctx.typeIdxToStructName.get(valueType.typeIdx) === "__vec_f64";
+  };
   const selected =
     selection ??
     planIrCompilation(sourceFile, {
@@ -443,6 +454,7 @@ export function compileIrPathFunctions(
       isArrayExpression,
       isRegExpExpression,
       isAmbientStringBinding,
+      implicitParamUsesNumericVecAbi,
       supportsSymbolicMathHelpers: true,
       supportsLiteralStringReplace: true,
       supportsHostStringArrayLiterals: jsHostExterns && !ctx.nativeStrings,
@@ -3005,9 +3017,19 @@ function resolveStaticNumericArrayGlobal(
 
 function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModuleBindingResolver): IrFromAstResolver {
   const isAmbientStringBinding = makeAmbientStringBindingPredicate(ctx.checker);
+  const supportsBackendCapability = (capability: IrBackendTargetCapability): boolean =>
+    supportsIrBackendTargetCapability(
+      {
+        backend: "wasmgc",
+        target: ctx.wasi ? "wasi" : ctx.standalone ? "standalone" : "gc",
+        allowHostImports: !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports),
+        fast: ctx.fast,
+      },
+      capability,
+    );
   return {
     standaloneRegExpTestPlan(receiver: ts.Expression) {
-      if (!ctx.standalone || ctx.wasi || !moduleBindingResolver) return null;
+      if (!supportsBackendCapability("standalone-native-regexp-test-carrier") || !moduleBindingResolver) return null;
       const plan = moduleBindingResolver.staticRegExpTestPlan(receiver);
       if (!plan) return null;
       ensureStandaloneRegExpCarrierTestHelper(ctx);
@@ -3017,7 +3039,14 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
       };
     },
     staticNumericArrayRead(expression: ts.Expression, expected: IrType) {
-      if (!moduleBindingResolver) return null;
+      const expectedValue = asVal(expected);
+      if (
+        !supportsBackendCapability("legacy-numeric-array-global") ||
+        !moduleBindingResolver ||
+        (expectedValue?.kind !== "ref" && expectedValue?.kind !== "ref_null")
+      ) {
+        return null;
+      }
       const plan = moduleBindingResolver.staticNumericArrayPlan(expression);
       return plan ? resolveStaticNumericArrayGlobal(ctx, plan, expected) : null;
     },

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -585,6 +585,29 @@ export type IrModuleBindingInspection =
   | { readonly kind: "unsupported"; readonly declaration: ts.VariableDeclaration }
   | { readonly kind: "not-direct" };
 
+/**
+ * Exact top-level native RegExp carrier that can be consumed by the standalone
+ * IR bridge. The binding stays outside the general module-value projection:
+ * only `.test(subject)` receives this proof, and the real legacy-allocated
+ * externref global remains the receiver at runtime.
+ */
+export interface IrStaticRegExpTestPlan {
+  readonly declaration: ts.VariableDeclaration;
+  readonly pattern: string;
+  readonly flags: string;
+  /** Structural fields are present on the identity-aware production resolver. */
+  readonly globalBindingId?: IrBindingId;
+  readonly sourceId?: IrSourceId;
+  readonly declarationOrdinal?: number;
+}
+
+export interface IrStaticNumericArrayPlan {
+  readonly declaration: ts.VariableDeclaration;
+  readonly globalBindingId?: IrBindingId;
+  readonly sourceId?: IrSourceId;
+  readonly declarationOrdinal?: number;
+}
+
 interface IrModuleBindingResolverSurface<TIdentity, TInspection> {
   (node: ts.Identifier, writeValue?: ts.Expression): TIdentity | undefined;
   /**
@@ -609,6 +632,13 @@ interface IrModuleBindingResolverSurface<TIdentity, TInspection> {
   readonly supportsHostNumberToString: boolean;
   /** Prove an initializer/RHS matches the binding's actual IR representation. */
   readonly bindingValueMatches: (node: ts.Identifier, value: ts.Expression) => boolean;
+  /**
+   * Prove an exact source-owned static RegExp carrier for standalone `.test`.
+   * General RegExp values remain unsupported module bindings.
+   */
+  readonly staticRegExpTestPlan: (node: ts.Expression) => IrStaticRegExpTestPlan | undefined;
+  /** Exact stable top-level numeric array used at a direct-call vec boundary. */
+  readonly staticNumericArrayPlan: (node: ts.Expression) => IrStaticNumericArrayPlan | undefined;
 }
 
 export interface IrLegacyModuleBindingResolver extends IrModuleBindingResolverSurface<
@@ -1131,6 +1161,157 @@ function writeValueMatches(
   return targetKind.kind !== "i32" || (valueKind.kind === "i32" && valueKind.semantic === targetKind.semantic);
 }
 
+function exactTopLevelVariableDeclaration(
+  node: ts.Identifier,
+  checker: ts.TypeChecker,
+): ts.VariableDeclaration | undefined {
+  const symbol = checker.getSymbolAtLocation(node);
+  if (!symbol) return undefined;
+  const sourceFile = node.getSourceFile();
+  const candidates = [symbol.valueDeclaration, ...(symbol.declarations ?? [])];
+  const declarations = new Set(
+    candidates.filter(
+      (candidate): candidate is ts.VariableDeclaration =>
+        candidate !== undefined &&
+        ts.isVariableDeclaration(candidate) &&
+        candidate.getSourceFile() === sourceFile &&
+        ts.isIdentifier(candidate.name) &&
+        ts.isVariableDeclarationList(candidate.parent) &&
+        ts.isVariableStatement(candidate.parent.parent) &&
+        candidate.parent.parent.parent === sourceFile,
+    ),
+  );
+  return declarations.size === 1 ? [...declarations][0] : undefined;
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
+}
+
+function identifierIsWritten(node: ts.Identifier): boolean {
+  let target: ts.Node = node;
+  let parent = target.parent;
+  while (
+    (ts.isParenthesizedExpression(parent) && parent.expression === target) ||
+    (ts.isArrayLiteralExpression(parent) && parent.elements.includes(target as ts.Expression)) ||
+    (ts.isObjectLiteralExpression(parent) && parent.properties.includes(target as ts.ObjectLiteralElementLike)) ||
+    (ts.isPropertyAssignment(parent) && parent.initializer === target) ||
+    (ts.isShorthandPropertyAssignment(parent) && parent.name === target) ||
+    (ts.isSpreadElement(parent) && parent.expression === target)
+  ) {
+    target = parent;
+    parent = target.parent;
+  }
+  if (ts.isBinaryExpression(parent) && parent.left === target && isAssignmentOperator(parent.operatorToken.kind)) {
+    return true;
+  }
+  if (
+    (ts.isPrefixUnaryExpression(parent) || ts.isPostfixUnaryExpression(parent)) &&
+    (parent.operator === ts.SyntaxKind.PlusPlusToken || parent.operator === ts.SyntaxKind.MinusMinusToken)
+  ) {
+    return true;
+  }
+  return (ts.isForInStatement(parent) || ts.isForOfStatement(parent)) && parent.initializer === node;
+}
+
+function sourceBindingIsStable(checker: ts.TypeChecker, declaration: ts.VariableDeclaration): boolean {
+  if (!ts.isIdentifier(declaration.name)) return false;
+  const symbol = checker.getSymbolAtLocation(declaration.name);
+  if (!symbol) return false;
+  let stable = true;
+  const visit = (node: ts.Node): void => {
+    if (!stable) return;
+    if (ts.isIdentifier(node) && checker.getSymbolAtLocation(node) === symbol && identifierIsWritten(node)) {
+      stable = false;
+      return;
+    }
+    node.forEachChild(visit);
+  };
+  declaration.getSourceFile().forEachChild(visit);
+  return stable;
+}
+
+function staticStringFromExpression(
+  checker: ts.TypeChecker,
+  expression: ts.Expression,
+  seen: Set<ts.VariableDeclaration>,
+): string | undefined {
+  const value = unwrapParens(expression);
+  if (ts.isStringLiteralLike(value)) return value.text;
+  if (ts.isNoSubstitutionTemplateLiteral(value)) return value.text;
+  if (ts.isBinaryExpression(value) && value.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    const left = staticStringFromExpression(checker, value.left, new Set(seen));
+    if (left === undefined) return undefined;
+    const right = staticStringFromExpression(checker, value.right, new Set(seen));
+    return right === undefined ? undefined : left + right;
+  }
+  if (!ts.isIdentifier(value)) return undefined;
+  const declaration = exactTopLevelVariableDeclaration(value, checker);
+  if (!declaration?.initializer || seen.has(declaration) || !sourceBindingIsStable(checker, declaration)) {
+    return undefined;
+  }
+  const nextSeen = new Set(seen);
+  nextSeen.add(declaration);
+  return staticStringFromExpression(checker, declaration.initializer, nextSeen);
+}
+
+function staticRegExpInitializer(
+  checker: ts.TypeChecker,
+  initializer: ts.Expression,
+): { readonly pattern: string; readonly flags: string } | undefined {
+  const value = unwrapParens(initializer);
+  if (value.kind === ts.SyntaxKind.RegularExpressionLiteral) {
+    const text = value.getText();
+    const lastSlash = text.lastIndexOf("/");
+    if (lastSlash <= 0) return undefined;
+    return { pattern: text.slice(1, lastSlash), flags: text.slice(lastSlash + 1) };
+  }
+  if (!ts.isNewExpression(value) && !ts.isCallExpression(value)) return undefined;
+  if (!ts.isIdentifier(value.expression) || value.expression.text !== "RegExp") return undefined;
+  const constructorSymbol = checker.getSymbolAtLocation(value.expression);
+  if (
+    constructorSymbol &&
+    (constructorSymbol.declarations ?? []).some((declaration) => !declaration.getSourceFile().isDeclarationFile)
+  ) {
+    return undefined;
+  }
+  const args = value.arguments ?? [];
+  if (args.length < 1 || args.length > 2 || args.some(ts.isSpreadElement)) return undefined;
+  const pattern = staticStringFromExpression(checker, args[0]!, new Set());
+  if (pattern === undefined) return undefined;
+  const flags = args[1] === undefined ? "" : staticStringFromExpression(checker, args[1], new Set());
+  if (flags === undefined || flags.includes("g") || flags.includes("y")) return undefined;
+  return { pattern, flags };
+}
+
+function makeStaticRegExpTestPlan(checker: ts.TypeChecker, node: ts.Expression): IrStaticRegExpTestPlan | undefined {
+  if (!ts.isIdentifier(node)) return undefined;
+  const declaration = exactTopLevelVariableDeclaration(node, checker);
+  if (!declaration?.initializer || !sourceBindingIsStable(checker, declaration)) {
+    return undefined;
+  }
+  const initializer = staticRegExpInitializer(checker, declaration.initializer);
+  return initializer ? { declaration, ...initializer } : undefined;
+}
+
+function makeStaticNumericArrayPlan(
+  checker: ts.TypeChecker,
+  node: ts.Expression,
+): IrStaticNumericArrayPlan | undefined {
+  if (!ts.isIdentifier(node)) return undefined;
+  const declaration = exactTopLevelVariableDeclaration(node, checker);
+  if (
+    !declaration?.initializer ||
+    !ts.isArrayLiteralExpression(unwrapParens(declaration.initializer)) ||
+    !sourceBindingIsStable(checker, declaration)
+  ) {
+    return undefined;
+  }
+  const type = checker.getTypeAtLocation(declaration.name);
+  const element = type.getNumberIndexType();
+  return element && (element.flags & ts.TypeFlags.NumberLike) !== 0 ? { declaration } : undefined;
+}
+
 export function makeIrLegacyModuleBindingResolver(
   checker: ts.TypeChecker,
   options: IrModuleBindingResolverOptions,
@@ -1286,6 +1467,20 @@ export function makeIrLegacyModuleBindingResolver(
         return false;
       }
     },
+    staticRegExpTestPlan(node: ts.Expression): IrStaticRegExpTestPlan | undefined {
+      try {
+        return makeStaticRegExpTestPlan(checker, node);
+      } catch {
+        return undefined;
+      }
+    },
+    staticNumericArrayPlan(node: ts.Expression): IrStaticNumericArrayPlan | undefined {
+      try {
+        return makeStaticNumericArrayPlan(checker, node);
+      } catch {
+        return undefined;
+      }
+    },
   });
 }
 
@@ -1307,10 +1502,10 @@ export function makeIrModuleBindingResolver(
   if (!identityContext) return legacy;
 
   const ownerAt = (node: ts.Node): IrUnitId => requireIrPlanningOwnerUnitId(identityContext, node);
-  const bindingIdentity = (
-    identity: IrLegacyModuleBindingIdentity,
+  const bindingLocation = (
+    declaration: ts.VariableDeclaration,
   ): Pick<IrModuleBindingIdentity, "globalBindingId" | "tdzBindingId" | "sourceId" | "declarationOrdinal"> => {
-    const sourceFile = identity.declaration.getSourceFile();
+    const sourceFile = declaration.getSourceFile();
     const sourceId = requireIrPlanningSourceId(identityContext, sourceFile);
     if (identityContext.sourceFileBySourceId.get(sourceId) !== sourceFile) {
       return planningInvariant(
@@ -1322,8 +1517,8 @@ export function makeIrModuleBindingResolver(
     let found = false;
     for (const statement of sourceFile.statements) {
       if (!ts.isVariableStatement(statement)) continue;
-      for (const declaration of statement.declarationList.declarations) {
-        if (declaration === identity.declaration) {
+      for (const candidate of statement.declarationList.declarations) {
+        if (candidate === declaration) {
           found = true;
           break;
         }
@@ -1344,6 +1539,10 @@ export function makeIrModuleBindingResolver(
       declarationOrdinal,
     };
   };
+  const bindingIdentity = (
+    identity: IrLegacyModuleBindingIdentity,
+  ): Pick<IrModuleBindingIdentity, "globalBindingId" | "tdzBindingId" | "sourceId" | "declarationOrdinal"> =>
+    bindingLocation(identity.declaration);
   const inspectDirectBinding = (node: ts.Identifier, writeValue?: ts.Expression): IrModuleBindingInspection => {
     const ownerUnitId = ownerAt(node);
     const inspected = legacy.inspectDirectBinding(node, writeValue);
@@ -1395,6 +1594,16 @@ export function makeIrModuleBindingResolver(
       ownerAt(node);
       return legacy.bindingValueMatches(node, value);
     },
+    staticRegExpTestPlan(node: ts.Expression): IrStaticRegExpTestPlan | undefined {
+      ownerAt(node);
+      const plan = legacy.staticRegExpTestPlan(node);
+      return plan ? { ...plan, ...bindingLocation(plan.declaration) } : undefined;
+    },
+    staticNumericArrayPlan(node: ts.Expression): IrStaticNumericArrayPlan | undefined {
+      ownerAt(node);
+      const plan = legacy.staticNumericArrayPlan(node);
+      return plan ? { ...plan, ...bindingLocation(plan.declaration) } : undefined;
+    },
   });
 }
 
@@ -1442,5 +1651,7 @@ export function projectIrModuleBindingResolverToLegacy(
     scalarExpressionFamily: (expr: ts.Expression) => resolver.scalarExpressionFamily(expr),
     supportsHostNumberToString: resolver.supportsHostNumberToString,
     bindingValueMatches: (node: ts.Identifier, value: ts.Expression) => resolver.bindingValueMatches(node, value),
+    staticRegExpTestPlan: (node: ts.Expression) => resolver.staticRegExpTestPlan(node),
+    staticNumericArrayPlan: (node: ts.Expression) => resolver.staticNumericArrayPlan(node),
   });
 }

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -1197,7 +1197,8 @@ function identifierIsWritten(node: ts.Identifier): boolean {
     (ts.isObjectLiteralExpression(parent) && parent.properties.includes(target as ts.ObjectLiteralElementLike)) ||
     (ts.isPropertyAssignment(parent) && parent.initializer === target) ||
     (ts.isShorthandPropertyAssignment(parent) && parent.name === target) ||
-    (ts.isSpreadElement(parent) && parent.expression === target)
+    (ts.isSpreadElement(parent) && parent.expression === target) ||
+    (ts.isSpreadAssignment(parent) && parent.expression === target)
   ) {
     target = parent;
     parent = target.parent;
@@ -1211,7 +1212,14 @@ function identifierIsWritten(node: ts.Identifier): boolean {
   ) {
     return true;
   }
-  return (ts.isForInStatement(parent) || ts.isForOfStatement(parent)) && parent.initializer === node;
+  return (ts.isForInStatement(parent) || ts.isForOfStatement(parent)) && parent.initializer === target;
+}
+
+function isVarModuleDeclaration(declaration: ts.VariableDeclaration): boolean {
+  return (
+    ts.isVariableDeclarationList(declaration.parent) &&
+    (declaration.parent.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0
+  );
 }
 
 function sourceBindingIsStable(checker: ts.TypeChecker, declaration: ts.VariableDeclaration): boolean {
@@ -1287,7 +1295,11 @@ function staticRegExpInitializer(
 function makeStaticRegExpTestPlan(checker: ts.TypeChecker, node: ts.Expression): IrStaticRegExpTestPlan | undefined {
   if (!ts.isIdentifier(node)) return undefined;
   const declaration = exactTopLevelVariableDeclaration(node, checker);
-  if (!declaration?.initializer || !sourceBindingIsStable(checker, declaration)) {
+  if (
+    !declaration?.initializer ||
+    !isVarModuleDeclaration(declaration) ||
+    !sourceBindingIsStable(checker, declaration)
+  ) {
     return undefined;
   }
   const initializer = staticRegExpInitializer(checker, declaration.initializer);
@@ -1302,6 +1314,7 @@ function makeStaticNumericArrayPlan(
   const declaration = exactTopLevelVariableDeclaration(node, checker);
   if (
     !declaration?.initializer ||
+    !isVarModuleDeclaration(declaration) ||
     !ts.isArrayLiteralExpression(unwrapParens(declaration.initializer)) ||
     !sourceBindingIsStable(checker, declaration)
   ) {

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -5784,7 +5784,7 @@ function isNumericArrayTypeNode(node: ts.TypeNode): boolean {
 
 function directCallParamUsesNumericVecAbi(
   call: ts.CallExpression,
-  argumentIndex: number,
+  parameterIndex: number,
   scope: ReadonlySet<string>,
 ): boolean {
   if (!ts.isIdentifier(call.expression)) return false;
@@ -5796,7 +5796,7 @@ function directCallParamUsesNumericVecAbi(
     return false;
   }
   const declaration = currentDynScanDecls?.get(call.expression.text);
-  const parameter = declaration?.parameters[argumentIndex];
+  const parameter = declaration?.parameters[parameterIndex];
   if (!parameter || !ts.isIdentifier(parameter.name)) return false;
   const type = effectiveIrParamTypeNode(parameter);
   return type
@@ -6541,8 +6541,8 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         }
       }
     }
-    for (let argumentIndex = 0; argumentIndex < expr.arguments.length; argumentIndex++) {
-      const arg = expr.arguments[argumentIndex]!;
+    let parameterIndex = 0;
+    for (const arg of expr.arguments) {
       // Slice 8a (#1169g): accept `f(...source)` where the spread source
       // is an ArrayLiteralExpression with no nested spread. The lowerer
       // expands this at compile time into individual call arguments
@@ -6551,15 +6551,20 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
       // type) are deferred — they'd require runtime arity expansion
       // which the IR doesn't model in slice 8a.
       if (ts.isSpreadElement(arg)) {
-        if (!isStaticSpreadSource(arg.expression, scope, localClasses)) return false;
+        const spreadSource = arg.expression;
+        if (!ts.isArrayLiteralExpression(spreadSource) || !isStaticSpreadSource(spreadSource, scope, localClasses)) {
+          return false;
+        }
+        parameterIndex += spreadSource.elements.length;
         continue;
       }
+      const currentParameterIndex = parameterIndex++;
       // #3791 follow-up dependency — an exact stable top-level numeric array
       // may cross only a direct-call boundary. The callee's planned vec ABI
       // remains authoritative; the builder rechecks its real global ValType.
       if (
         currentSelectionOptions?.supportsBackendCapability?.("legacy-numeric-array-global") === true &&
-        directCallParamUsesNumericVecAbi(expr, argumentIndex, scope) &&
+        directCallParamUsesNumericVecAbi(expr, currentParameterIndex, scope) &&
         currentModuleBindingResolver?.staticNumericArrayPlan(arg) !== undefined
       ) {
         continue;

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -6190,6 +6190,26 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         currentSelectionOptions?.isRegExpExpression?.(expr.expression.expression) === true &&
         currentSelectionOptions.supportsBackendCapability?.("host-regexp-constructor") === false
       ) {
+        // #3791 — host-free `.test` is claimable only for an exact stable
+        // top-level static RegExp whose real legacy externref carrier can be
+        // loaded and passed to the in-module native helper. This deliberately
+        // bypasses the generic receiver walk: the binding is not a general IR
+        // module value, and `.exec`, g/y stateful carriers, reassigned
+        // bindings, non-string subjects, and all other shapes keep the
+        // established target-capability refusal.
+        const nativePlan =
+          expr.expression.name.text === "test"
+            ? currentModuleBindingResolver?.staticRegExpTestPlan(expr.expression.expression)
+            : undefined;
+        if (
+          nativePlan !== undefined &&
+          expr.arguments.length === 1 &&
+          !ts.isSpreadElement(expr.arguments[0]!) &&
+          (expressionIsProvenString(expr.arguments[0]!) ||
+            currentSelectionOptions?.classifyPrimitiveExpression?.(expr.arguments[0]!) === "string")
+        ) {
+          return isPhase1Expr(expr.arguments[0]!, scope, localClasses);
+        }
         return capabilityNo("regexp-constructor-unsupported", "expr-regexp-method-target", expr);
       }
       // (#1371) Whitelist `Math.<unary>(arg)` for a small set of f64-mapped
@@ -6485,6 +6505,10 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         if (!isStaticSpreadSource(arg.expression, scope, localClasses)) return false;
         continue;
       }
+      // #3791 follow-up dependency — an exact stable top-level numeric array
+      // may cross only a direct-call boundary. The callee's planned vec ABI
+      // remains authoritative; the builder rechecks its real global ValType.
+      if (currentModuleBindingResolver?.staticNumericArrayPlan(arg) !== undefined) continue;
       if (!isPhase1Expr(arg, scope, localClasses)) return false;
     }
     return true;

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -319,6 +319,12 @@ export interface IrSelectionOptions {
     parameter: ts.ParameterDeclaration,
   ) => "f64" | "bool" | "string" | "object" | "dynamic" | undefined;
   /**
+   * Exact legacy callable-ABI proof for an unannotated parameter projected as
+   * the ordinary non-fast numeric vec. General object/any evidence is not
+   * sufficient for the module numeric-array direct-call bridge.
+   */
+  readonly implicitParamUsesNumericVecAbi?: (parameter: ts.ParameterDeclaration) => boolean;
+  /**
    * Standalone/WASI normally close claims over local callers. A production
    * planner may exempt a callee when its direct callable and IR overlay share
    * one fully certified ABI, making a legacy caller's pre-emitted call safe.
@@ -502,7 +508,12 @@ export interface IrSelectionOptions {
    * even if its checker shape is otherwise exact.
    */
   readonly supportsBackendCapability?: (
-    capability: "host-date-snapshot" | "host-regexp-constructor" | "host-object-define-property",
+    capability:
+      | "host-date-snapshot"
+      | "host-regexp-constructor"
+      | "host-object-define-property"
+      | "standalone-native-regexp-test-carrier"
+      | "legacy-numeric-array-global",
   ) => boolean;
   /**
    * #3787 exact global String-constructor identity. This is separate from the
@@ -5757,6 +5768,42 @@ function knownCallableArity(expression: ts.Expression, scope: ReadonlySet<string
   return undefined;
 }
 
+function isNumericArrayTypeNode(node: ts.TypeNode): boolean {
+  if (ts.isTypeOperatorNode(node) && node.operator === ts.SyntaxKind.ReadonlyKeyword) {
+    return isNumericArrayTypeNode(node.type);
+  }
+  if (ts.isArrayTypeNode(node)) return node.elementType.kind === ts.SyntaxKind.NumberKeyword;
+  return (
+    ts.isTypeReferenceNode(node) &&
+    ts.isIdentifier(node.typeName) &&
+    (node.typeName.text === "Array" || node.typeName.text === "ReadonlyArray") &&
+    node.typeArguments?.length === 1 &&
+    node.typeArguments[0]!.kind === ts.SyntaxKind.NumberKeyword
+  );
+}
+
+function directCallParamUsesNumericVecAbi(
+  call: ts.CallExpression,
+  argumentIndex: number,
+  scope: ReadonlySet<string>,
+): boolean {
+  if (!ts.isIdentifier(call.expression)) return false;
+  if (
+    scope.has(call.expression.text) ||
+    currentNestedFunctionNames.has(call.expression.text) ||
+    currentLexicalValueBindingNames.has(call.expression.text)
+  ) {
+    return false;
+  }
+  const declaration = currentDynScanDecls?.get(call.expression.text);
+  const parameter = declaration?.parameters[argumentIndex];
+  if (!parameter || !ts.isIdentifier(parameter.name)) return false;
+  const type = effectiveIrParamTypeNode(parameter);
+  return type
+    ? isNumericArrayTypeNode(type)
+    : currentSelectionOptions?.implicitParamUsesNumericVecAbi?.(parameter) === true;
+}
+
 type ObviousSelectorValueFamily = "number" | "boolean" | "string" | "reference" | "nullish";
 
 function obviousSelectorValueFamily(
@@ -6198,7 +6245,8 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         // bindings, non-string subjects, and all other shapes keep the
         // established target-capability refusal.
         const nativePlan =
-          expr.expression.name.text === "test"
+          expr.expression.name.text === "test" &&
+          currentSelectionOptions?.supportsBackendCapability?.("standalone-native-regexp-test-carrier") === true
             ? currentModuleBindingResolver?.staticRegExpTestPlan(expr.expression.expression)
             : undefined;
         if (
@@ -6493,7 +6541,8 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         }
       }
     }
-    for (const arg of expr.arguments) {
+    for (let argumentIndex = 0; argumentIndex < expr.arguments.length; argumentIndex++) {
+      const arg = expr.arguments[argumentIndex]!;
       // Slice 8a (#1169g): accept `f(...source)` where the spread source
       // is an ArrayLiteralExpression with no nested spread. The lowerer
       // expands this at compile time into individual call arguments
@@ -6508,7 +6557,13 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
       // #3791 follow-up dependency — an exact stable top-level numeric array
       // may cross only a direct-call boundary. The callee's planned vec ABI
       // remains authoritative; the builder rechecks its real global ValType.
-      if (currentModuleBindingResolver?.staticNumericArrayPlan(arg) !== undefined) continue;
+      if (
+        currentSelectionOptions?.supportsBackendCapability?.("legacy-numeric-array-global") === true &&
+        directCallParamUsesNumericVecAbi(expr, argumentIndex, scope) &&
+        currentModuleBindingResolver?.staticNumericArrayPlan(arg) !== undefined
+      ) {
+        continue;
+      }
       if (!isPhase1Expr(arg, scope, localClasses)) return false;
     }
     return true;

--- a/tests/issue-3791-ir-native-regexp-test.test.ts
+++ b/tests/issue-3791-ir-native-regexp-test.test.ts
@@ -230,6 +230,35 @@ describe("#3791 standalone native RegExp.test IR bridge", () => {
     expect((instance.exports.run as () => number)()).toBe(1);
   });
 
+  it("accounts for preceding static-spread elements before proving the vec parameter", async () => {
+    const result = await compile(
+      `
+      var values = [9];
+      function target(head: number, set: number[], tail: any): number {
+        return 1;
+      }
+      function read(): number {
+        return target(...[1, [2]], values);
+      }
+      export function run(): number {
+        return read();
+      }
+      `,
+      {
+        fileName: "issue-3791-numeric-array-spread-offset.ts",
+        target: "standalone",
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs ?? []).not.toContain("read");
+    expect(result.irOutcomes?.find((outcome) => outcome.displayName === "read")).toEqual(
+      expect.objectContaining({ kind: "unsupported", stage: "select" }),
+    );
+  });
+
   it.each([
     ["standalone fast", { target: "standalone" as const, fast: true }],
     ["gc fast", { target: "gc" as const, fast: true }],

--- a/tests/issue-3791-ir-native-regexp-test.test.ts
+++ b/tests/issue-3791-ir-native-regexp-test.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+const SOURCE = `
+var nonAsciiStartChars = "\\u00aa\\u00b5\\u00ba\\u00c0-\\u00d6";
+var nonAsciiStart = new RegExp("[" + nonAsciiStartChars + "]");
+var nonAsciiPart = new RegExp("[" + nonAsciiStartChars + "\\u0300-\\u036f]");
+
+function isIdentifierStart(code: number): boolean {
+  return code >= 0xaa && nonAsciiStart.test(String.fromCharCode(code));
+}
+
+function isIdentifierChar(code: number): boolean {
+  return code >= 0xaa && nonAsciiPart.test(String.fromCharCode(code));
+}
+
+function isRegExpIdentifierStart(code: number): boolean {
+  return isIdentifierStart(code) || code === 0x24 || code === 0x5f;
+}
+
+function isRegExpIdentifierPart(code: number): boolean {
+  return isIdentifierChar(code) || code === 0x24 || code === 0x5f;
+}
+
+export function run(): number {
+  if (!isIdentifierStart(0xaa) || isIdentifierStart(0x41)) return 0;
+  if (!isIdentifierChar(0x0301) || isIdentifierChar(0x41)) return 0;
+  if (!isRegExpIdentifierStart(0x24)) return 0;
+  if (!isRegExpIdentifierPart(0x5f)) return 0;
+  return 1;
+}
+`;
+
+describe("#3791 standalone native RegExp.test IR bridge", () => {
+  it("loads the existing native carrier and emits the identifier helpers through IR", async () => {
+    const result = await compile(SOURCE, {
+      fileName: "issue-3791-ir-native-regexp-test.ts",
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toEqual(
+      expect.arrayContaining([
+        "isIdentifierStart",
+        "isIdentifierChar",
+        "isRegExpIdentifierStart",
+        "isRegExpIdentifierPart",
+      ]),
+    );
+
+    const module = await WebAssembly.compile(result.binary);
+    expect(WebAssembly.Module.imports(module)).toEqual([]);
+    const instance = await WebAssembly.instantiate(module, {});
+    expect((instance.exports.run as () => number)()).toBe(1);
+  });
+
+  it("keeps reassigned and stateful RegExp carriers on the legacy path", async () => {
+    const result = await compile(
+      `
+      var reassigned = new RegExp("a");
+      reassigned = new RegExp("b");
+      var destructured = new RegExp("a");
+      [destructured] = [new RegExp("c")];
+      var stateful = new RegExp("a", "g");
+      function reassignedTest(value: string): boolean {
+        return reassigned.test(value);
+      }
+      function destructuredTest(value: string): boolean {
+        return destructured.test(value);
+      }
+      function statefulTest(value: string): boolean {
+        return stateful.test(value);
+      }
+      export function run() {
+        return reassignedTest("b") && statefulTest("a") ? 1 : 0;
+      }
+      `,
+      {
+        fileName: "issue-3791-ir-native-regexp-test-fallbacks.ts",
+        target: "standalone",
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("reassignedTest");
+    expect(result.irCompiledFuncs ?? []).not.toContain("destructuredTest");
+    expect(result.irCompiledFuncs ?? []).not.toContain("statefulTest");
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.run as () => number)()).toBe(1);
+  });
+
+  it("projects only exact stable numeric-array globals at direct-call boundaries", async () => {
+    const stable = await compile(
+      `
+      var stableSet = [3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181];
+
+      function includesValue(value, set) {
+        var position = 0;
+        for (var index = 0; index < set.length; index += 2) {
+          position += set[index];
+          if (position > value) return false;
+          position += set[index + 1];
+          if (position >= value) return true;
+        }
+        return false;
+      }
+      function usesStable(value) {
+        return includesValue(value, stableSet);
+      }
+      function groundAbi(value: any, set: number[]): boolean {
+        return includesValue(value, set);
+      }
+      export function run() {
+        return usesStable(5) && groundAbi(5, stableSet) ? 1 : 0;
+      }
+      `,
+      {
+        fileName: "issue-3791-static-numeric-array-call.ts",
+        target: "standalone",
+        trackIrOutcomes: true,
+        allowJs: true,
+        skipSemanticDiagnostics: true,
+        optimize: 4,
+      },
+    );
+
+    expect(stable.success, stable.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(stable.irPostClaimErrors ?? []).toEqual([]);
+    expect(stable.irCompiledFuncs ?? []).toContain("usesStable");
+    const { instance } = await WebAssembly.instantiate(stable.binary, {});
+    expect((instance.exports.run as () => number)()).toBe(1);
+
+    const fallback = await compile(
+      `
+      var reassignedSet = [1];
+      reassignedSet = [2];
+      var sourceSet = [13];
+      var aliasedSet = sourceSet;
+      function read(value, set) {
+        return set[0] === value;
+      }
+      function usesReassigned(value) {
+        return read(value, reassignedSet);
+      }
+      function usesAlias(value) {
+        return read(value, aliasedSet);
+      }
+      export function run() {
+        return usesReassigned(2) && usesAlias(13) ? 1 : 0;
+      }
+      `,
+      {
+        fileName: "issue-3791-static-numeric-array-fallbacks.mjs",
+        target: "standalone",
+        trackIrOutcomes: true,
+        allowJs: true,
+        skipSemanticDiagnostics: true,
+      },
+    );
+    expect(fallback.success, fallback.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(fallback.irCompiledFuncs ?? []).not.toContain("usesReassigned");
+    expect(fallback.irCompiledFuncs ?? []).not.toContain("usesAlias");
+  });
+});

--- a/tests/issue-3791-ir-native-regexp-test.test.ts
+++ b/tests/issue-3791-ir-native-regexp-test.test.ts
@@ -25,7 +25,9 @@ function isRegExpIdentifierPart(code: number): boolean {
 
 export function run(): number {
   if (!isIdentifierStart(0xaa) || isIdentifierStart(0x41)) return 0;
+  if (isIdentifierStart(0xd7)) return 0;
   if (!isIdentifierChar(0x0301) || isIdentifierChar(0x41)) return 0;
+  if (isIdentifierChar(0x0370)) return 0;
   if (!isRegExpIdentifierStart(0x24)) return 0;
   if (!isRegExpIdentifierPart(0x5f)) return 0;
   return 1;
@@ -82,6 +84,7 @@ describe("#3791 standalone native RegExp.test IR bridge", () => {
         fileName: "issue-3791-ir-native-regexp-test-fallbacks.ts",
         target: "standalone",
         trackIrOutcomes: true,
+        skipSemanticDiagnostics: true,
       },
     );
 
@@ -91,12 +94,41 @@ describe("#3791 standalone native RegExp.test IR bridge", () => {
     expect(result.irCompiledFuncs ?? []).not.toContain("statefulTest");
     const { instance } = await WebAssembly.instantiate(result.binary, {});
     expect((instance.exports.run as () => number)()).toBe(1);
+
+    const destructuringWrites = await compile(
+      `
+      var forOfDestructured = new RegExp("a");
+      for ([forOfDestructured] of [[new RegExp("d")]]) break;
+      var objectRest = new RegExp("a");
+      ({ ...objectRest } = { replacement: new RegExp("e") });
+      function forOfDestructuredTest(value: string): boolean {
+        return forOfDestructured.test(value);
+      }
+      function objectRestTest(value: string): boolean {
+        return objectRest.test(value);
+      }
+      export function run(): number {
+        return 1;
+      }
+      `,
+      {
+        fileName: "issue-3791-ir-native-regexp-test-destructuring-writes.ts",
+        target: "standalone",
+        trackIrOutcomes: true,
+        skipSemanticDiagnostics: true,
+      },
+    );
+    expect(destructuringWrites.success, destructuringWrites.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(destructuringWrites.irPostClaimErrors ?? []).toEqual([]);
+    expect(destructuringWrites.irCompiledFuncs ?? []).not.toContain("forOfDestructuredTest");
+    expect(destructuringWrites.irCompiledFuncs ?? []).not.toContain("objectRestTest");
   });
 
   it("projects only exact stable numeric-array globals at direct-call boundaries", async () => {
     const stable = await compile(
       `
       var stableSet = [3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181];
+      var secondStableSet = [2, 7, 11, 19];
 
       function includesValue(value, set) {
         var position = 0;
@@ -111,11 +143,14 @@ describe("#3791 standalone native RegExp.test IR bridge", () => {
       function usesStable(value) {
         return includesValue(value, stableSet);
       }
+      function usesSecondStable(value) {
+        return includesValue(value, secondStableSet);
+      }
       function groundAbi(value: any, set: number[]): boolean {
         return includesValue(value, set);
       }
       export function run() {
-        return usesStable(5) && groundAbi(5, stableSet) ? 1 : 0;
+        return usesStable(5) && usesSecondStable(2) && groundAbi(5, stableSet) ? 1 : 0;
       }
       `,
       {
@@ -131,6 +166,7 @@ describe("#3791 standalone native RegExp.test IR bridge", () => {
     expect(stable.success, stable.errors.map((error) => error.message).join("\n")).toBe(true);
     expect(stable.irPostClaimErrors ?? []).toEqual([]);
     expect(stable.irCompiledFuncs ?? []).toContain("usesStable");
+    expect(stable.irCompiledFuncs ?? []).toContain("usesSecondStable");
     const { instance } = await WebAssembly.instantiate(stable.binary, {});
     expect((instance.exports.run as () => number)()).toBe(1);
 
@@ -164,5 +200,149 @@ describe("#3791 standalone native RegExp.test IR bridge", () => {
     expect(fallback.success, fallback.errors.map((error) => error.message).join("\n")).toBe(true);
     expect(fallback.irCompiledFuncs ?? []).not.toContain("usesReassigned");
     expect(fallback.irCompiledFuncs ?? []).not.toContain("usesAlias");
+  });
+
+  it("rejects a numeric-array global when the direct callee parameter is any", async () => {
+    const result = await compile(
+      `
+      var values = [1];
+      function takesAny(value: any): number {
+        return value[0];
+      }
+      function read(): number {
+        return takesAny(values);
+      }
+      export function run(): number {
+        return read();
+      }
+      `,
+      {
+        fileName: "issue-3791-numeric-array-any-param.ts",
+        target: "standalone",
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs ?? []).not.toContain("read");
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.run as () => number)()).toBe(1);
+  });
+
+  it.each([
+    ["standalone fast", { target: "standalone" as const, fast: true }],
+    ["gc fast", { target: "gc" as const, fast: true }],
+  ])("keeps numeric-array globals on direct codegen for %s", async (_label, mode) => {
+    const result = await compile(
+      `
+      var values = [1];
+      function first(input: number[]): number {
+        return input.slice(0)[0];
+      }
+      function read(): number {
+        return first(values);
+      }
+      export function run(): number {
+        return read();
+      }
+      `,
+      {
+        ...mode,
+        fileName: "issue-3791-fast-numeric-array.ts",
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs ?? []).not.toContain("read");
+    const module = await WebAssembly.compile(result.binary);
+    if (mode.target === "standalone") {
+      const instance = await WebAssembly.instantiate(module, {});
+      expect((instance.exports.run as () => number)()).toBe(1);
+    }
+  });
+
+  it("admits the native RegExp carrier only for standalone, not WASI", async () => {
+    const wasi = await compile(SOURCE, {
+      fileName: "issue-3791-ir-native-regexp-test-wasi.ts",
+      target: "wasi",
+      trackIrOutcomes: true,
+    });
+
+    expect(wasi.success, wasi.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(wasi.irPostClaimErrors ?? []).toEqual([]);
+    expect(wasi.irCompiledFuncs ?? []).not.toContain("isIdentifierStart");
+    expect(wasi.irCompiledFuncs ?? []).not.toContain("isIdentifierChar");
+    expect(wasi.irCompiledFuncs ?? []).not.toContain("isRegExpIdentifierStart");
+    expect(wasi.irCompiledFuncs ?? []).not.toContain("isRegExpIdentifierPart");
+  });
+
+  it("keeps lexical module arrays on the TDZ-aware legacy path", async () => {
+    const source = `
+      var observed = readBeforeInit();
+      const late = [1];
+      function first(input: number[]): number {
+        return input[0];
+      }
+      function readBeforeInit(): number {
+        return first(late);
+      }
+      export function run(): number {
+        return observed;
+      }
+    `;
+    const [legacy, ir] = await Promise.all([
+      compile(source, {
+        fileName: "issue-3791-numeric-array-tdz-legacy.ts",
+        target: "standalone",
+        experimentalIR: false,
+      }),
+      compile(source, {
+        fileName: "issue-3791-numeric-array-tdz-ir.ts",
+        target: "standalone",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      }),
+    ]);
+
+    expect(legacy.success, legacy.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(ir.success, ir.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(ir.irPostClaimErrors ?? []).toEqual([]);
+    expect(ir.irCompiledFuncs ?? []).not.toContain("readBeforeInit");
+    await expect(WebAssembly.instantiate(legacy.binary, {})).rejects.toBeDefined();
+    await expect(WebAssembly.instantiate(ir.binary, {})).rejects.toBeDefined();
+
+    const regexpSource = `
+      var observed = readRegExpBeforeInit();
+      const lateRegExp = new RegExp("a");
+      function readRegExpBeforeInit(): number {
+        return lateRegExp.test("a") ? 1 : 0;
+      }
+      export function run(): number {
+        return observed;
+      }
+    `;
+    const [legacyRegExp, irRegExp] = await Promise.all([
+      compile(regexpSource, {
+        fileName: "issue-3791-regexp-tdz-legacy.ts",
+        target: "standalone",
+        experimentalIR: false,
+      }),
+      compile(regexpSource, {
+        fileName: "issue-3791-regexp-tdz-ir.ts",
+        target: "standalone",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      }),
+    ]);
+
+    expect(legacyRegExp.success, legacyRegExp.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(irRegExp.success, irRegExp.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(irRegExp.irPostClaimErrors ?? []).toEqual([]);
+    expect(irRegExp.irCompiledFuncs ?? []).not.toContain("readRegExpBeforeInit");
+    await expect(WebAssembly.instantiate(legacyRegExp.binary, {})).rejects.toBeDefined();
+    await expect(WebAssembly.instantiate(irRegExp.binary, {})).rejects.toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- load exact stable module RegExp carriers through Program ABI and reuse the native RegExp carrier helper from IR
- project stable numeric-array module globals only at proven direct-call vec ABI boundaries
- reject reassigned, TDZ-sensitive, stateful RegExp, fast-array, target-mismatched, any-parameter, alias, and spread-offset-unsafe cases before IR claims
- preserve native brand semantics, the real module globals, and zero-import standalone output

## Migration result

The unchanged runtime-dynamic Acorn driver moves from 23/43 to 27/43 IR-emitted reachable functions. Newly emitted functions are isIdentifierStart, isIdentifierChar, isRegExpIdentifierStart, and isRegExpIdentifierPart.

Runtime evidence: checksum 422, zero Wasm imports, zero post-claim withdrawals.

## Validation

- focused and adjacent Vitest suites: 47/47
- exact runtime-dynamic Acorn driver: 27/43, checksum 422, zero imports, zero withdrawals
- TypeScript typecheck
- IR fallback ratchet
- Prettier check
- LOC and function budget gates

Tracks plan/issues/3791-ir-native-regexp-test.md.