### PR TITLE
refactor(ir): own vec host bridges structurally (#3520 C30)

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -106,6 +106,7 @@ files:
   - src/codegen/property-access.ts
   - src/codegen/closed-method-dispatch.ts
   - src/codegen/vec-access-exports.ts
+  - src/runtime.ts
   - src/codegen/ir-first-gate.ts
   - src/codegen/ir-class-shapes.ts
   - src/codegen/ir-overlay-identity.ts
@@ -170,6 +171,7 @@ files:
   - tests/issue-2856-calendar-residuals.test.ts
   - tests/issue-1899-funcidx-authority.test.ts
 loc-budget-allow:
+  - src/runtime.ts
   - src/codegen/declarations.ts
   - src/codegen/statements/nested-declarations.ts
   - src/codegen/context/types.ts
@@ -2595,9 +2597,20 @@ host bridges behind one entry-source-owned structural family:
   handles, so late-import shifts cannot redirect selection through a generated
   name; and
 - `funcMap` remains a compatibility publication only when the helper label is
-  unoccupied. A same-labelled non-exported source function remains a distinct
-  callable and still executes as the source target, while the array read and
-  mutation seams call the structural vec helpers.
+  unoccupied. Physical exports use the reserved
+  `__js2_vec_host_bridge_<ordinal>` namespace, with a deterministic `$` suffix
+  on collision. Free suffix gaps are filled with helper aliases through one
+  slot beyond the last occupied suffix, so the runtime can select the final
+  function in the contiguous family without mistaking a preserved user export
+  for the helper. The runtime projects those physical helpers onto an internal
+  logical-name view without changing the raw public exports. A user can export
+  all six historical helper labels and still retain those exact names and
+  bodies while runtime array reads, wrapping, and mutation use the structural
+  helpers; and
+- structural observation, body filling, and physical publication are
+  correctness-critical. Their failures now abort compilation before physical
+  bridge publication instead of returning a successful module containing
+  placeholder bodies.
 
 The exact five-entry `SINGLE_HOST_ENTRIES` census was run in fresh processes
 against `origin/main` at `e541b9d56c766c` and this continuation, using
@@ -2610,14 +2623,19 @@ measurement keeps routing and body outcomes unchanged at **37 terminal /
 30 emitted / 7 Unsupported / 0 Invariants / 37 legacy bodies / 30 IR
 bodies**.
 
-The focused C30 suite passes **4/4**. It proves all six source-anchored IDs,
-fixed ordinals and final slots; zero vec support publication for an array-free
-module; reserve-to-fill allocator-object identity; the same-label runtime
-collision; tracked/untracked binary equality; and stable routing/outcome
-telemetry. The adjacent callable-planning, #2083, #3272, #3637, #2927, and
-#3311 matrix passes **50/50 across six files**. The IR fallback ratchet,
-function budget, strict TypeScript, and the exact census pass without changing
-the equivalence baseline or Test262 run log.
+The focused C30 suite passes **7/7**. It proves all six source-anchored IDs,
+fixed ordinals, direct final-slot object identity, and zero vec support
+publication for an array-free module; reserve-to-fill allocator-object
+identity survives a forced late-import increase and subsequent dead-import
+compaction; all six public-label collisions preserve the user exports while a
+runtime E2E asserts push length, intermediate length/value, pop value, final
+length, and wrapped returned-array values; forced ABI observation failure
+produces a compile error with no physical exports; tracked/untracked binaries
+are equal with IR enabled; and routing/outcome telemetry remains stable. The
+adjacent callable-planning, #2083, #3272, #3637, #2927, and #3311 matrix
+passes **50/50 across six files**. The IR fallback ratchet, function budget,
+strict TypeScript, and the exact census pass without changing the equivalence
+baseline or Test262 run log.
 
 C30 closes exact retained ownership for the six core vec host bridges, not R1.
 Other support callable families and remaining module-array or display-name

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -103,6 +103,9 @@ files:
   - src/codegen/program-abi-signatures.ts
   - src/codegen/program-abi-session.ts
   - src/codegen/program-abi-type-planning.ts
+  - src/codegen/property-access.ts
+  - src/codegen/closed-method-dispatch.ts
+  - src/codegen/vec-access-exports.ts
   - src/codegen/ir-first-gate.ts
   - src/codegen/ir-class-shapes.ts
   - src/codegen/ir-overlay-identity.ts
@@ -152,6 +155,7 @@ files:
   - tests/issue-3520-program-abi-callable-planning.test.ts
   - tests/issue-3520-program-abi-type-remap.test.ts
   - tests/issue-3520-support-callable-abi.test.ts
+  - tests/issue-3520-vec-support-callable-abi.test.ts
   - tests/issue-3520-class-support-callable-abi.test.ts
   - tests/issue-3520-class-integration-callable-abi.test.ts
   - tests/issue-3520-class-method-alias-abi.test.ts
@@ -2575,6 +2579,49 @@ C29 closes exact retained ownership for direct source function-value
 trampolines and capture-free cache globals, not R1. Other support callable
 families, remaining class/type consumers, and module-array or display-name
 scans must still move behind structural authorities before R1 can close.
+
+### 2026-07-30 vec host-bridge callable ownership continuation
+
+The continuation on `codex/3520-c30-vec-host-bridge` moves the six core vec
+host bridges behind one entry-source-owned structural family:
+
+- `__vec_len`, `__vec_get`, `__is_vec`, `__vec_mut_supported`, `__vec_push`,
+  and `__vec_pop` publish `vec-host-bridge` support bindings at fixed ordinals
+  0 through 5 beneath the canonical entry source. Their callable ordering role
+  is the next reserved role after `typedThisTwin`;
+- reservation allocates all six helpers as one batch and observes the exact
+  `WasmFunction` objects only after every allocation succeeds. Final body
+  filling and compile-time calls resolve those objects through their current
+  handles, so late-import shifts cannot redirect selection through a generated
+  name; and
+- `funcMap` remains a compatibility publication only when the helper label is
+  unoccupied. A same-labelled non-exported source function remains a distinct
+  callable and still executes as the source target, while the array read and
+  mutation seams call the structural vec helpers.
+
+The exact five-entry `SINGLE_HOST_ENTRIES` census was run in fresh processes
+against `origin/main` at `e541b9d56c766c` and this continuation, using
+`readFileSync(entry) -> analyzeSource(source, entry) ->
+generateModule(ast, { experimentalIR: true, trackIrOutcomes: true })`.
+Defined functions remain **166 → 166**. Generic
+`retained-module-function` rows move **101 → 77**, exactly matching the
+**24** vec bridge rows present across four of the five entries. The same
+measurement keeps routing and body outcomes unchanged at **37 terminal /
+30 emitted / 7 Unsupported / 0 Invariants / 37 legacy bodies / 30 IR
+bodies**.
+
+The focused C30 suite passes **4/4**. It proves all six source-anchored IDs,
+fixed ordinals and final slots; zero vec support publication for an array-free
+module; reserve-to-fill allocator-object identity; the same-label runtime
+collision; tracked/untracked binary equality; and stable routing/outcome
+telemetry. The adjacent callable-planning, #2083, #3272, #3637, #2927, and
+#3311 matrix passes **50/50 across six files**. The IR fallback ratchet,
+function budget, strict TypeScript, and the exact census pass without changing
+the equivalence baseline or Test262 run log.
+
+C30 closes exact retained ownership for the six core vec host bridges, not R1.
+Other support callable families and remaining module-array or display-name
+consumers must still move behind structural authorities before R1 can close.
 
 ### R1a validation evidence
 

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -2597,16 +2597,17 @@ host bridges behind one entry-source-owned structural family:
   handles, so late-import shifts cannot redirect selection through a generated
   name; and
 - `funcMap` remains a compatibility publication only when the helper label is
-  unoccupied. Physical exports use the reserved
-  `__js2_vec_host_bridge_<ordinal>` namespace, with a deterministic `$` suffix
-  on collision. Free suffix gaps are filled with helper aliases through one
-  slot beyond the last occupied suffix, so the runtime can select the final
-  function in the contiguous family without mistaking a preserved user export
-  for the helper. The runtime projects those physical helpers onto an internal
-  logical-name view without changing the raw public exports. A user can export
-  all six historical helper labels and still retain those exact names and
-  bodies while runtime array reads, wrapping, and mutation use the structural
-  helpers; and
+  unoccupied. The historical logical export is also the zero-overhead runtime
+  fast path. A physical export is added only when a user already owns that
+  logical export, using the short reserved `$v<ordinal>` namespace with a
+  deterministic `$` suffix on collision. Free suffix gaps are filled with
+  helper aliases through one slot beyond the last occupied suffix, so the
+  runtime can select the final function in the contiguous family without
+  mistaking a preserved user export for the helper. The runtime projects
+  collision-only physical helpers onto an internal logical-name view without
+  changing the raw public exports. A user can export all six historical helper
+  labels and still retain those exact names and bodies while runtime array
+  reads, wrapping, and mutation use the structural helpers; and
 - structural observation, body filling, and physical publication are
   correctness-critical. Their failures now abort compilation before physical
   bridge publication instead of returning a successful module containing
@@ -2623,19 +2624,30 @@ measurement keeps routing and body outcomes unchanged at **37 terminal /
 30 emitted / 7 Unsupported / 0 Invariants / 37 legacy bodies / 30 IR
 bodies**.
 
+The size follow-up compares raw binaries from `origin/main` at
+`10f40b6458c6c`, PR head `11abdfd6b544`, and the collision-only alias
+implementation. Three representative helper-using modules measure
+**1,065 / 1,340 / 1,569 bytes** on main, **1,222 / 1,497 / 1,726 bytes** at
+the PR head, and **1,065 / 1,340 / 1,569 bytes** after the follow-up. The
+deterministic **+157 bytes per module** is therefore eliminated rather than
+traded for a shorter always-present duplicate namespace. Ordinary modules
+publish zero `$v<ordinal>` physical aliases; only an actual public-label
+collision pays for its affected short family.
+
 The focused C30 suite passes **7/7**. It proves all six source-anchored IDs,
 fixed ordinals, direct final-slot object identity, and zero vec support
 publication for an array-free module; reserve-to-fill allocator-object
 identity survives a forced late-import increase and subsequent dead-import
 compaction; all six public-label collisions preserve the user exports while a
 runtime E2E asserts push length, intermediate length/value, pop value, final
-length, and wrapped returned-array values; forced ABI observation failure
-produces a compile error with no physical exports; tracked/untracked binaries
-are equal with IR enabled; and routing/outcome telemetry remains stable. The
-adjacent callable-planning, #2083, #3272, #3637, #2927, and #3311 matrix
-passes **50/50 across six files**. The IR fallback ratchet, function budget,
-strict TypeScript, and the exact census pass without changing the equivalence
-baseline or Test262 run log.
+length, and wrapped returned-array values; sparse short-namespace collisions
+retain six distinct terminal structural helpers; forced ABI observation
+failure produces a compile error with no physical exports; tracked/untracked
+binaries are equal with IR enabled; and routing/outcome telemetry remains
+stable. The adjacent callable-planning, #2083, #3272, #3637, #2927, and #3311
+matrix passes **50/50 across six files**. The IR fallback ratchet, function
+budget, strict TypeScript, and the exact census pass without changing the
+equivalence baseline or Test262 run log.
 
 C30 closes exact retained ownership for the six core vec host bridges, not R1.
 Other support callable families and remaining module-array or display-name

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -2599,15 +2599,16 @@ host bridges behind one entry-source-owned structural family:
 - `funcMap` remains a compatibility publication only when the helper label is
   unoccupied. The historical logical export is also the zero-overhead runtime
   fast path. A physical export is added only when a user already owns that
-  logical export, using the short reserved `$v<ordinal>` namespace with a
+  logical export or occupies its exact short `$v<ordinal>` family, using a
   deterministic `$` suffix on collision. Free suffix gaps are filled with
   helper aliases through one slot beyond the last occupied suffix, so the
   runtime can select the final function in the contiguous family without
-  mistaking a preserved user export for the helper. The runtime projects
-  collision-only physical helpers onto an internal logical-name view without
-  changing the raw public exports. A user can export all six historical helper
-  labels and still retain those exact names and bodies while runtime array
-  reads, wrapping, and mutation use the structural helpers; and
+  mistaking a preserved user export for the helper. Runtime projection first
+  requires the historical logical export, preventing an array-free user
+  `$v<ordinal>` from fabricating an internal vec helper. A user can export all
+  six historical helper labels or all six short prefixes and still retain
+  those exact names and bodies while runtime array reads, wrapping, and
+  mutation use the structural helpers; and
 - structural observation, body filling, and physical publication are
   correctness-critical. Their failures now abort compilation before physical
   bridge publication instead of returning a successful module containing
@@ -2631,23 +2632,26 @@ implementation. Three representative helper-using modules measure
 the PR head, and **1,065 / 1,340 / 1,569 bytes** after the follow-up. The
 deterministic **+157 bytes per module** is therefore eliminated rather than
 traded for a shorter always-present duplicate namespace. Ordinary modules
-publish zero `$v<ordinal>` physical aliases; only an actual public-label
-collision pays for its affected short family.
+publish zero `$v<ordinal>` physical aliases; only an actual logical-label or
+exact short-family collision pays for its affected short family.
 
-The focused C30 suite passes **7/7**. It proves all six source-anchored IDs,
+The focused C30 suite passes **9/9**. It proves all six source-anchored IDs,
 fixed ordinals, direct final-slot object identity, and zero vec support
 publication for an array-free module; reserve-to-fill allocator-object
 identity survives a forced late-import increase and subsequent dead-import
 compaction; all six public-label collisions preserve the user exports while a
 runtime E2E asserts push length, intermediate length/value, pop value, final
 length, and wrapped returned-array values; sparse short-namespace collisions
-retain six distinct terminal structural helpers; forced ABI observation
-failure produces a compile error with no physical exports; tracked/untracked
-binaries are equal with IR enabled; and routing/outcome telemetry remains
-stable. The adjacent callable-planning, #2083, #3272, #3637, #2927, and #3311
-matrix passes **50/50 across six files**. The IR fallback ratchet, function
-budget, strict TypeScript, and the exact census pass without changing the
-equivalence baseline or Test262 run log.
+retain six distinct terminal structural helpers; all-six prefix-only
+collisions terminate in the structural helpers while preserving wrapped
+`[7, 8, 3]` and fieldless-class `{}` behavior; an array-free `$v0` spoof
+creates no historical logical helper and preserves the helper-free fieldless
+fallback; forced ABI observation failure produces a compile error with no
+physical exports; tracked/untracked binaries are equal with IR enabled; and
+routing/outcome telemetry remains stable. The adjacent callable-planning,
+#2083, #3272, #3637, #2927, and #3311 matrix passes **50/50 across six files**.
+The IR fallback ratchet, function budget, strict TypeScript, and the exact
+census pass without changing the equivalence baseline or Test262 run log.
 
 C30 closes exact retained ownership for the six core vec host bridges, not R1.
 Other support callable families and remaining module-array or display-name

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -54,6 +54,7 @@ import { ensureArgcGlobal } from "./statements/nested-declarations.js"; // (#367
 import { CLOSURE_ARITY_FIELD_IDX, getFuncRefWrapperRootTypeIdx } from "./closures/funcref-wrapper-types.js"; // (#3673 round 13) under-application gate
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2 read chokepoint / S3b stable-regime minting)
 import { buildFnctorArrayHofTargetTest } from "./fnctor-array-prototype.js";
+import { resolveVecHostBridgeHelper } from "./vec-access-exports.js";
 
 /**
  * (#2583) The callback-free, argument-taking array search/predicate methods
@@ -202,11 +203,10 @@ export function reserveClosedMethodDispatch(ctx: CodegenContext, methodName: str
   // (#2927) For the in-place array MUTATION methods (`push`/`pop`), register the
   // native `$__vec_base` brand-arm deps NOW so the fill only READS funcMap
   // (#1719): the `$__vec_base` supertype and `__box_number` (push returns an i32
-  // length that the arm boxes). The carrier-generic `__vec_push` / `__vec_pop`
-  // helper is reserved by the CALL SITE (`calls.ts`, which already imports
+  // length that the arm boxes). The carrier-generic helper is reserved by the
+  // CALL SITE (`calls.ts`, which already imports
   // `reserveVecMethodHelper` from `../index.js` — importing it here would form an
-  // eval-time circular-import cycle: `index.ts` imports this module for
-  // `fillClosedMethodDispatch`). Standalone/wasi only.
+  // eval-time circular-import cycle). Standalone/wasi only.
   if ((ctx.standalone || ctx.wasi) && VEC_MUTATE_METHODS.has(methodName) && isVecMutateForm(methodName, arity)) {
     getOrRegisterVecBaseType(ctx);
     addUnionImportsViaRegistry(ctx); // __box_number for the push new-length result
@@ -994,8 +994,8 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
     // never fires standalone). Route to the carrier-generic `__vec_push` /
     // `__vec_pop` helpers (reserved at reserve-time; body filled in the finalize
     // vec-export pass).
-    const vecPushIdx = ctx.funcMap.get("__vec_push");
-    const vecPopIdx = ctx.funcMap.get("__vec_pop");
+    const vecPushIdx = resolveVecHostBridgeHelper(ctx, "push");
+    const vecPopIdx = resolveVecHostBridgeHelper(ctx, "pop");
     const wantVecMutArm =
       (ctx.standalone || ctx.wasi) &&
       VEC_MUTATE_METHODS.has(methodName) &&

--- a/src/codegen/program-abi-callable-planning.ts
+++ b/src/codegen/program-abi-callable-planning.ts
@@ -1,16 +1,35 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { irSupportFuncRef } from "../ir/callable-bindings.js";
-import type { IrSourceId } from "../ir/identity.js";
+import type { IrBindingId, IrSourceId } from "../ir/identity.js";
 import { ProgramAbiInvariantError } from "../ir/program-abi.js";
-import type { FuncTypeDef, Import, WasmFunction } from "../ir/types.js";
+import type { FuncHandle, FuncTypeDef, Import, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt, definedFuncHandleOf } from "./func-space.js";
 import { planProgramAbiSupportCallable, PROGRAM_ABI_CALLABLE_ROLE } from "./program-abi-planning.js";
 import type { ProgramAbiSession } from "./program-abi-session.js";
 
 const RETAINED_MODULE_FUNCTION_ROLE = "retained-module-function";
 
-function canonicalEntrySource(session: ProgramAbiSession): IrSourceId {
+export interface ProgramAbiEntrySourceSupportObservation {
+  readonly role: string;
+  readonly roleOrdinal: number;
+  readonly derivedOrdinal: number;
+  readonly displayName: string;
+  readonly funcIdx: FuncHandle;
+}
+
+interface ObservedEntrySourceSupport {
+  readonly bindingId: IrBindingId;
+  readonly sourceId: IrSourceId;
+  readonly role: string;
+  readonly roleOrdinal: number;
+  readonly derivedOrdinal: number;
+  readonly displayName: string;
+  readonly func: WasmFunction;
+}
+
+export function canonicalProgramAbiEntrySource(session: ProgramAbiSession): IrSourceId {
   const entrySources = session.inventory.sources.filter((source) => source.kind === "entry");
   if (entrySources.length !== 1) {
     throw new ProgramAbiInvariantError(
@@ -41,6 +60,7 @@ function functionSignature(ctx: CodegenContext, func: WasmFunction): FuncTypeDef
  * space total without consulting funcMap or a function name.
  */
 export class ProgramAbiCallableRegistry {
+  private readonly entrySourceSupports = new Map<IrBindingId, ObservedEntrySourceSupport>();
   private planned = false;
 
   constructor(
@@ -50,11 +70,133 @@ export class ProgramAbiCallableRegistry {
     session.assertModule(ctx.mod);
   }
 
+  /**
+   * Atomically capture a complete entry-source support family by exact
+   * allocator objects.
+   *
+   * Every observation is validated before the sidecar changes, so a partially
+   * allocated family can never leak into final ABI planning. Labels are
+   * diagnostic only; role plus fixed derived ordinal supply identity.
+   */
+  observeEntrySourceSupports(observations: readonly ProgramAbiEntrySourceSupportObservation[]): void {
+    if (this.planned) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        "cannot observe entry-source support callables after retained callable planning",
+      );
+    }
+    const sourceId = canonicalProgramAbiEntrySource(this.session);
+    const prepared: ObservedEntrySourceSupport[] = [];
+    const batchIds = new Set<IrBindingId>();
+    for (const observation of observations) {
+      if (!Number.isSafeInteger(observation.derivedOrdinal) || observation.derivedOrdinal < 0) {
+        throw new ProgramAbiInvariantError(
+          "unknown-order-anchor",
+          `entry-source support ${observation.displayName} has invalid derived ordinal ${observation.derivedOrdinal}`,
+        );
+      }
+      const func = definedFuncAt(this.ctx, observation.funcIdx);
+      if (!func) {
+        throw new ProgramAbiInvariantError(
+          "missing-required-locator",
+          `entry-source support ${observation.displayName} has no exact defined function for handle ${observation.funcIdx}`,
+        );
+      }
+      const ref = irSupportFuncRef(sourceId, observation.role, observation.displayName, observation.derivedOrdinal);
+      if (ref.binding.kind !== "support") {
+        throw new ProgramAbiInvariantError(
+          "invalid-binding-reference",
+          `entry-source support ${observation.displayName} did not produce a support binding`,
+        );
+      }
+      const bindingId = ref.binding.bindingId;
+      if (batchIds.has(bindingId)) {
+        throw new ProgramAbiInvariantError("duplicate-slot-locator", `entry-source support batch repeats ${bindingId}`);
+      }
+      batchIds.add(bindingId);
+      const existing = this.entrySourceSupports.get(bindingId);
+      if (
+        existing &&
+        (existing.func !== func ||
+          existing.roleOrdinal !== observation.roleOrdinal ||
+          existing.displayName !== observation.displayName)
+      ) {
+        throw new ProgramAbiInvariantError(
+          "duplicate-slot-locator",
+          `entry-source support ${bindingId} was observed with contradictory allocator ownership`,
+        );
+      }
+      prepared.push(
+        Object.freeze({
+          bindingId,
+          sourceId,
+          role: observation.role,
+          roleOrdinal: observation.roleOrdinal,
+          derivedOrdinal: observation.derivedOrdinal,
+          displayName: observation.displayName,
+          func,
+        }),
+      );
+    }
+    for (const observation of prepared) {
+      if (!this.entrySourceSupports.has(observation.bindingId)) {
+        this.entrySourceSupports.set(observation.bindingId, observation);
+      }
+    }
+  }
+
+  /**
+   * Resolve one observed entry-source support binding to its current handle.
+   *
+   * Exact object lookup follows late-import shifts and DCE without consulting
+   * `funcMap` or scanning generated function labels.
+   */
+  handleForEntrySourceSupport(role: string, derivedOrdinal: number): FuncHandle | undefined {
+    const sourceId = canonicalProgramAbiEntrySource(this.session);
+    const ref = irSupportFuncRef(sourceId, role, "diagnostic-only", derivedOrdinal);
+    if (ref.binding.kind !== "support") return undefined;
+    const observation = this.entrySourceSupports.get(ref.binding.bindingId);
+    return observation ? definedFuncHandleOf(this.ctx, observation.func) : undefined;
+  }
+
   planRetained(): void {
     if (this.planned) return;
     this.planned = true;
 
-    const entrySourceId = canonicalEntrySource(this.session);
+    const entrySourceId = canonicalProgramAbiEntrySource(this.session);
+    const live = new Set(this.ctx.mod.functions);
+    const supportObservations = [...this.entrySourceSupports.values()]
+      .filter((observation) => live.has(observation.func))
+      .sort(
+        (left, right) =>
+          left.roleOrdinal - right.roleOrdinal ||
+          left.derivedOrdinal - right.derivedOrdinal ||
+          (left.bindingId < right.bindingId ? -1 : left.bindingId > right.bindingId ? 1 : 0),
+      );
+    for (const observation of supportObservations) {
+      const ref = irSupportFuncRef(
+        observation.sourceId,
+        observation.role,
+        observation.displayName,
+        observation.derivedOrdinal,
+      );
+      const plannedBindingId = planProgramAbiSupportCallable(this.ctx, {
+        ref,
+        anchor: { kind: "source", sourceId: observation.sourceId },
+        role: observation.role,
+        roleOrdinal: observation.roleOrdinal,
+        derivedOrdinal: observation.derivedOrdinal,
+        signature: functionSignature(this.ctx, observation.func),
+        func: observation.func,
+      });
+      if (plannedBindingId !== observation.bindingId) {
+        throw new ProgramAbiInvariantError(
+          "invalid-binding-reference",
+          `entry-source support ${observation.displayName} was not accepted for ${observation.bindingId}`,
+        );
+      }
+    }
+
     const seen = new Set<object>();
     let finalIndex = 0;
 

--- a/src/codegen/program-abi-planning.ts
+++ b/src/codegen/program-abi-planning.ts
@@ -21,6 +21,7 @@ export const PROGRAM_ABI_CALLABLE_ROLE = Object.freeze({
   moduleInit: 5,
   retainedModuleFunction: 6,
   typedThisTwin: 7,
+  vecHostBridge: 8,
 } as const);
 
 export const PROGRAM_ABI_GLOBAL_ROLE = Object.freeze({

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -60,6 +60,7 @@ import {
   typedArrayPackedSignedness,
   typedArrayVecStorage,
 } from "./index.js";
+import { resolveVecHostBridgeHelper } from "./vec-access-exports.js";
 import { emitJsonStringifyValue } from "./json-codec-native.js";
 import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
 import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
@@ -4421,14 +4422,13 @@ export function compileElementAccessBody(
       const recvLocal = allocLocal(fctx, `__nve_recv_${fctx.locals.length}`, { kind: "externref" });
       fctx.body.push({ op: "local.set", index: recvLocal });
       // (#3007) index → f64 → idxLocal, compiled BEFORE the fast-path funcIdxs are
-      // captured. A computed index (`a[a.length - 1]`) lowers its own dynamic
-      // reads, which can register late imports and shift every DEFINED-function
+      // captured. A computed index lowers reads that can register late imports and shift every DEFINED-function
       // index — including `__vec_get`. The pre-#3007 order captured `__vec_get`
       // BEFORE this compile, so the index's imports left it stale; the desynced
       // `then` arm emitted an invalid instruction stream (`f64.convert_i32_s` on
       // the externref receiver → "expected i32, found externref", invalid Wasm).
-      // Resolving the imports and `__vec_get` AFTER the index compile (single
-      // flush) keeps every funcIdx live through emission. For a non-import-adding
+      // Resolving imports and `__vec_get` AFTER the index compile (single flush)
+      // keeps every funcIdx live through emission. For a non-import-adding
       // index (e.g. a literal) the import order is identical, so valid output is
       // byte-for-byte unchanged.
       compileExpression(ctx, fctx, expr.argumentExpression, { kind: "f64" });
@@ -4442,7 +4442,7 @@ export function compileElementAccessBody(
       );
       const boxNumIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
       flushLateImportShifts(ctx, fctx);
-      const vgIdx = ctx.funcMap.get("__vec_get") ?? reserveVecMethodHelper(ctx, "get");
+      const vgIdx = resolveVecHostBridgeHelper(ctx, "get") ?? reserveVecMethodHelper(ctx, "get");
       if (vgIdx !== undefined && extGetIdx !== undefined && boxNumIdx !== undefined) {
         // isVec = OR of ref.test over the registered vec carriers.
         const anyTmp = allocLocal(fctx, `__nve_any_${fctx.locals.length}`, { kind: "anyref" } as ValType);
@@ -4535,8 +4535,8 @@ export function compileElementAccessBody(
         [{ kind: "externref" }],
       );
       flushLateImportShifts(ctx, fctx);
-      const vgIdx = ctx.funcMap.get("__vec_get") ?? reserveVecMethodHelper(ctx, "get");
-      const vlIdx = ctx.funcMap.get("__vec_len") ?? reserveVecMethodHelper(ctx, "len");
+      const vgIdx = resolveVecHostBridgeHelper(ctx, "get") ?? reserveVecMethodHelper(ctx, "get");
+      const vlIdx = resolveVecHostBridgeHelper(ctx, "len") ?? reserveVecMethodHelper(ctx, "len");
       if (unboxIdx !== undefined && extGetIdx !== undefined && vgIdx !== undefined && vlIdx !== undefined) {
         const idxF64 = allocLocal(fctx, `__dyn_idxf_${fctx.locals.length}`, { kind: "f64" });
         const idxI32 = allocLocal(fctx, `__dyn_idxi_${fctx.locals.length}`, { kind: "i32" });

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -156,9 +156,10 @@ function ensureVecHostBridgeAllocations(ctx: CodegenContext): ReadonlyMap<VecHos
 /**
  * Publish collision-safe physical exports after every user export is known.
  *
- * The historical logical name is the zero-overhead fast path. A physical
- * alias is emitted only when a user export already owns that logical name, so
- * ordinary modules retain the pre-migration export section byte-for-byte.
+ * The historical logical name is the zero-overhead fast path. Physical aliases
+ * are emitted only when a user owns that logical name or already occupies the
+ * exact short family, so ordinary modules retain the pre-migration export
+ * section byte-for-byte.
  */
 function publishVecHostBridgeExports(ctx: CodegenContext): void {
   const allocations = ensureVecHostBridgeAllocations(ctx);
@@ -169,17 +170,19 @@ function publishVecHostBridgeExports(ctx: CodegenContext): void {
     if (!allocation || funcIdx === undefined) {
       throw new Error(`cannot publish vec host bridge ${definition.kind} without its exact allocator object`);
     }
-    if (!occupied.has(definition.name)) {
+    const physicalBase = vecHostBridgePhysicalExportBase(definition.kind);
+    let maxOccupiedSuffix = -1;
+    for (const name of occupied) {
+      if (!name.startsWith(physicalBase)) continue;
+      const suffix = name.slice(physicalBase.length);
+      if (/^\$*$/.test(suffix)) maxOccupiedSuffix = Math.max(maxOccupiedSuffix, suffix.length);
+    }
+    const logicalNameOccupied = occupied.has(definition.name);
+    if (!logicalNameOccupied) {
       exportFunc(ctx.mod, definition.name, funcIdx);
       occupied.add(definition.name);
-    } else {
-      const physicalBase = vecHostBridgePhysicalExportBase(definition.kind);
-      let maxOccupiedSuffix = -1;
-      for (const name of occupied) {
-        if (!name.startsWith(physicalBase)) continue;
-        const suffix = name.slice(physicalBase.length);
-        if (/^\$*$/.test(suffix)) maxOccupiedSuffix = Math.max(maxOccupiedSuffix, suffix.length);
-      }
+    }
+    if (logicalNameOccupied || maxOccupiedSuffix >= 0) {
       // Fill every free gap through one slot beyond the last occupied suffix.
       // This preserves colliding user exports while leaving a contiguous run
       // whose final function is always the structural helper. The runtime can

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -8,20 +8,20 @@
 // finalize passes and re-exports `reserveVecMethodHelper` for its compile-time
 // callers (calls.ts, property-access.ts, closed-method-dispatch.ts).
 
-import { ts } from "../ts-api.js";
 import type { FuncHandle, Instr, ValType, WasmFunction } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import { undefinedExternInstrs } from "./any-helpers.js"; // (#3315)
+import { ensureHoleType } from "./array-holes.js";
 import type { CodegenContext } from "./context/types.js";
+import { exportFunc } from "./emit-helpers.js";
+import { ensureGetUndefined } from "./expressions/late-imports.js";
+import { definedFuncAt, definedFuncHandleOf } from "./func-space.js";
+import { PROGRAM_ABI_CALLABLE_ROLE } from "./program-abi-planning.js";
 import { addUnionImports } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
-import { emitVecDefineWritebackExports } from "./vec-define-writeback.js";
-import { ensureGetUndefined } from "./expressions/late-imports.js";
-import { ensureHoleType } from "./array-holes.js";
-import { undefinedExternInstrs } from "./any-helpers.js"; // (#3315)
-import { UNDEF_F64_BITS } from "./value-tags.js"; // (#3315)
-import { definedFuncAt, definedFuncHandleOf } from "./func-space.js";
 import { flushLateImportShifts } from "./shared.js";
-import { exportFunc } from "./emit-helpers.js";
-import { PROGRAM_ABI_CALLABLE_ROLE } from "./program-abi-planning.js";
+import { UNDEF_F64_BITS } from "./value-tags.js"; // (#3315)
+import { emitVecDefineWritebackExports } from "./vec-define-writeback.js";
 
 export const VEC_HOST_BRIDGE_ROLE = "vec-host-bridge";
 
@@ -100,12 +100,18 @@ function vecHostBridgeDefinition(kind: VecHostBridgeKind): VecHostBridgeDefiniti
   return definition;
 }
 
+/** Reserved physical export namespace consumed by the JS runtime adapter. */
+export function vecHostBridgePhysicalExportBase(kind: VecHostBridgeKind): string {
+  return `__js2_vec_host_bridge_${vecHostBridgeDefinition(kind).ordinal}`;
+}
+
 /**
  * Reserve all six core vec host bridges as one exact allocator-owned family.
  *
  * The family is allocated in fixed ordinal order and only then published to
- * the Program ABI registry. `funcMap` remains a best-effort compatibility
- * alias: an existing same-labelled source callable is never overwritten.
+ * the Program ABI registry. Export publication is delayed until every source
+ * export is known. `funcMap` remains a best-effort compatibility alias: an
+ * existing same-labelled source callable is never overwritten.
  */
 function ensureVecHostBridgeAllocations(ctx: CodegenContext): ReadonlyMap<VecHostBridgeKind, VecHostBridgeAllocation> {
   const existing = vecHostBridgeAllocations.get(ctx);
@@ -127,10 +133,9 @@ function ensureVecHostBridgeAllocations(ctx: CodegenContext): ReadonlyMap<VecHos
       typeIdx,
       locals: [],
       body: [...definition.placeholder],
-      exported: true,
+      exported: false,
     } as WasmFunction;
     ctx.mod.functions.push(func);
-    exportFunc(ctx.mod, definition.name, funcIdx);
     if (!ctx.funcMap.has(definition.name)) ctx.funcMap.set(definition.name, funcIdx);
     allocations.set(definition.kind, Object.freeze({ definition, func }));
     observations.push({
@@ -146,6 +151,47 @@ function ensureVecHostBridgeAllocations(ctx: CodegenContext): ReadonlyMap<VecHos
   const published = new Map(allocations);
   vecHostBridgeAllocations.set(ctx, published);
   return published;
+}
+
+/**
+ * Publish collision-safe physical exports after every user export is known.
+ *
+ * The runtime always consumes the reserved physical namespace. The historical
+ * logical name remains as a compatibility alias only when it is unoccupied,
+ * so a user export keeps its requested external name.
+ */
+function publishVecHostBridgeExports(ctx: CodegenContext): void {
+  const allocations = ensureVecHostBridgeAllocations(ctx);
+  const occupied = new Set(ctx.mod.exports.map((entry) => entry.name));
+  for (const definition of VEC_HOST_BRIDGE_DEFINITIONS) {
+    const allocation = allocations.get(definition.kind);
+    const funcIdx = allocation ? definedFuncHandleOf(ctx, allocation.func) : undefined;
+    if (!allocation || funcIdx === undefined) {
+      throw new Error(`cannot publish vec host bridge ${definition.kind} without its exact allocator object`);
+    }
+    const physicalBase = vecHostBridgePhysicalExportBase(definition.kind);
+    let maxOccupiedSuffix = -1;
+    for (const name of occupied) {
+      if (!name.startsWith(physicalBase)) continue;
+      const suffix = name.slice(physicalBase.length);
+      if (/^\$*$/.test(suffix)) maxOccupiedSuffix = Math.max(maxOccupiedSuffix, suffix.length);
+    }
+    // Fill every free gap through one slot beyond the last occupied suffix.
+    // This preserves colliding user exports while leaving a contiguous run
+    // whose final function is always the structural helper. The runtime can
+    // therefore recover the exact helper without a name side table.
+    for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
+      const physicalName = `${physicalBase}${"$".repeat(suffixLength)}`;
+      if (occupied.has(physicalName)) continue;
+      exportFunc(ctx.mod, physicalName, funcIdx);
+      occupied.add(physicalName);
+    }
+    if (!occupied.has(definition.name)) {
+      exportFunc(ctx.mod, definition.name, funcIdx);
+      occupied.add(definition.name);
+    }
+    allocation.func.exported = true;
+  }
 }
 
 /** Resolve a core vec bridge from its exact allocator object. */
@@ -270,11 +316,12 @@ export function emitVecAccessExports(ctx: CodegenContext): void {
   ) {
     return;
   }
-  try {
-    _emitVecAccessExportsInner(ctx);
-  } catch {
-    // Non-fatal: if emission fails, the iterator fallback just won't work
-  }
+  // Structural observation and body filling are correctness-critical. A
+  // failure must abort compilation; swallowing it would publish callable
+  // placeholders whose signatures are valid but whose behavior is fabricated.
+  ensureVecHostBridgeAllocations(ctx);
+  _emitVecAccessExportsInner(ctx);
+  publishVecHostBridgeExports(ctx);
 }
 
 /** Mutation-capable vec carriers, keyed by physical backing-array shape. */
@@ -329,8 +376,6 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
     ensureGetUndefined(ctx);
     flushLateImportShifts(ctx, null);
   }
-  ensureVecHostBridgeAllocations(ctx);
-
   // __vec_len(externref) -> i32
   {
     // local 0 = externref param, local 1 = anyref converted

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -102,7 +102,7 @@ function vecHostBridgeDefinition(kind: VecHostBridgeKind): VecHostBridgeDefiniti
 
 /** Reserved physical export namespace consumed by the JS runtime adapter. */
 export function vecHostBridgePhysicalExportBase(kind: VecHostBridgeKind): string {
-  return `__js2_vec_host_bridge_${vecHostBridgeDefinition(kind).ordinal}`;
+  return `$v${vecHostBridgeDefinition(kind).ordinal}`;
 }
 
 /**
@@ -156,9 +156,9 @@ function ensureVecHostBridgeAllocations(ctx: CodegenContext): ReadonlyMap<VecHos
 /**
  * Publish collision-safe physical exports after every user export is known.
  *
- * The runtime always consumes the reserved physical namespace. The historical
- * logical name remains as a compatibility alias only when it is unoccupied,
- * so a user export keeps its requested external name.
+ * The historical logical name is the zero-overhead fast path. A physical
+ * alias is emitted only when a user export already owns that logical name, so
+ * ordinary modules retain the pre-migration export section byte-for-byte.
  */
 function publishVecHostBridgeExports(ctx: CodegenContext): void {
   const allocations = ensureVecHostBridgeAllocations(ctx);
@@ -169,26 +169,27 @@ function publishVecHostBridgeExports(ctx: CodegenContext): void {
     if (!allocation || funcIdx === undefined) {
       throw new Error(`cannot publish vec host bridge ${definition.kind} without its exact allocator object`);
     }
-    const physicalBase = vecHostBridgePhysicalExportBase(definition.kind);
-    let maxOccupiedSuffix = -1;
-    for (const name of occupied) {
-      if (!name.startsWith(physicalBase)) continue;
-      const suffix = name.slice(physicalBase.length);
-      if (/^\$*$/.test(suffix)) maxOccupiedSuffix = Math.max(maxOccupiedSuffix, suffix.length);
-    }
-    // Fill every free gap through one slot beyond the last occupied suffix.
-    // This preserves colliding user exports while leaving a contiguous run
-    // whose final function is always the structural helper. The runtime can
-    // therefore recover the exact helper without a name side table.
-    for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
-      const physicalName = `${physicalBase}${"$".repeat(suffixLength)}`;
-      if (occupied.has(physicalName)) continue;
-      exportFunc(ctx.mod, physicalName, funcIdx);
-      occupied.add(physicalName);
-    }
     if (!occupied.has(definition.name)) {
       exportFunc(ctx.mod, definition.name, funcIdx);
       occupied.add(definition.name);
+    } else {
+      const physicalBase = vecHostBridgePhysicalExportBase(definition.kind);
+      let maxOccupiedSuffix = -1;
+      for (const name of occupied) {
+        if (!name.startsWith(physicalBase)) continue;
+        const suffix = name.slice(physicalBase.length);
+        if (/^\$*$/.test(suffix)) maxOccupiedSuffix = Math.max(maxOccupiedSuffix, suffix.length);
+      }
+      // Fill every free gap through one slot beyond the last occupied suffix.
+      // This preserves colliding user exports while leaving a contiguous run
+      // whose final function is always the structural helper. The runtime can
+      // therefore recover the exact helper without a name side table.
+      for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
+        const physicalName = `${physicalBase}${"$".repeat(suffixLength)}`;
+        if (occupied.has(physicalName)) continue;
+        exportFunc(ctx.mod, physicalName, funcIdx);
+        occupied.add(physicalName);
+      }
     }
     allocation.func.exported = true;
   }

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -9,7 +9,7 @@
 // callers (calls.ts, property-access.ts, closed-method-dispatch.ts).
 
 import { ts } from "../ts-api.js";
-import type { Instr, ValType } from "../ir/types.js";
+import type { FuncHandle, Instr, ValType, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { addUnionImports } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
@@ -18,9 +18,164 @@ import { ensureGetUndefined } from "./expressions/late-imports.js";
 import { ensureHoleType } from "./array-holes.js";
 import { undefinedExternInstrs } from "./any-helpers.js"; // (#3315)
 import { UNDEF_F64_BITS } from "./value-tags.js"; // (#3315)
-import { definedFuncAt } from "./func-space.js";
+import { definedFuncAt, definedFuncHandleOf } from "./func-space.js";
 import { flushLateImportShifts } from "./shared.js";
 import { exportFunc } from "./emit-helpers.js";
+import { PROGRAM_ABI_CALLABLE_ROLE } from "./program-abi-planning.js";
+
+export const VEC_HOST_BRIDGE_ROLE = "vec-host-bridge";
+
+export type VecHostBridgeKind = "len" | "get" | "is-vec" | "mut-supported" | "push" | "pop";
+
+interface VecHostBridgeDefinition {
+  readonly kind: VecHostBridgeKind;
+  readonly name: string;
+  readonly ordinal: number;
+  readonly params: readonly ValType[];
+  readonly results: readonly ValType[];
+  readonly placeholder: readonly Instr[];
+}
+
+interface VecHostBridgeAllocation {
+  readonly definition: VecHostBridgeDefinition;
+  readonly func: WasmFunction;
+}
+
+const VEC_HOST_BRIDGE_DEFINITIONS: readonly VecHostBridgeDefinition[] = Object.freeze([
+  Object.freeze({
+    kind: "len",
+    name: "__vec_len",
+    ordinal: 0,
+    params: Object.freeze([{ kind: "externref" } as ValType]),
+    results: Object.freeze([{ kind: "i32" } as ValType]),
+    placeholder: Object.freeze([{ op: "i32.const", value: 0 } as Instr]),
+  }),
+  Object.freeze({
+    kind: "get",
+    name: "__vec_get",
+    ordinal: 1,
+    params: Object.freeze([{ kind: "externref" } as ValType, { kind: "i32" } as ValType]),
+    results: Object.freeze([{ kind: "externref" } as ValType]),
+    placeholder: Object.freeze([{ op: "ref.null.extern" } as Instr]),
+  }),
+  Object.freeze({
+    kind: "is-vec",
+    name: "__is_vec",
+    ordinal: 2,
+    params: Object.freeze([{ kind: "externref" } as ValType]),
+    results: Object.freeze([{ kind: "i32" } as ValType]),
+    placeholder: Object.freeze([{ op: "i32.const", value: 0 } as Instr]),
+  }),
+  Object.freeze({
+    kind: "mut-supported",
+    name: "__vec_mut_supported",
+    ordinal: 3,
+    params: Object.freeze([{ kind: "externref" } as ValType]),
+    results: Object.freeze([{ kind: "i32" } as ValType]),
+    placeholder: Object.freeze([{ op: "i32.const", value: 0 } as Instr]),
+  }),
+  Object.freeze({
+    kind: "push",
+    name: "__vec_push",
+    ordinal: 4,
+    params: Object.freeze([{ kind: "externref" } as ValType, { kind: "externref" } as ValType]),
+    results: Object.freeze([{ kind: "i32" } as ValType]),
+    placeholder: Object.freeze([{ op: "i32.const", value: 0 } as Instr]),
+  }),
+  Object.freeze({
+    kind: "pop",
+    name: "__vec_pop",
+    ordinal: 5,
+    params: Object.freeze([{ kind: "externref" } as ValType]),
+    results: Object.freeze([{ kind: "externref" } as ValType]),
+    placeholder: Object.freeze([{ op: "ref.null.extern" } as Instr]),
+  }),
+]);
+
+const vecHostBridgeAllocations = new WeakMap<CodegenContext, ReadonlyMap<VecHostBridgeKind, VecHostBridgeAllocation>>();
+
+function vecHostBridgeDefinition(kind: VecHostBridgeKind): VecHostBridgeDefinition {
+  const definition = VEC_HOST_BRIDGE_DEFINITIONS.find((candidate) => candidate.kind === kind);
+  if (!definition) throw new Error(`unknown vec host bridge kind ${kind}`);
+  return definition;
+}
+
+/**
+ * Reserve all six core vec host bridges as one exact allocator-owned family.
+ *
+ * The family is allocated in fixed ordinal order and only then published to
+ * the Program ABI registry. `funcMap` remains a best-effort compatibility
+ * alias: an existing same-labelled source callable is never overwritten.
+ */
+function ensureVecHostBridgeAllocations(ctx: CodegenContext): ReadonlyMap<VecHostBridgeKind, VecHostBridgeAllocation> {
+  const existing = vecHostBridgeAllocations.get(ctx);
+  if (existing) return existing;
+
+  const allocations = new Map<VecHostBridgeKind, VecHostBridgeAllocation>();
+  const observations: {
+    role: string;
+    roleOrdinal: number;
+    derivedOrdinal: number;
+    displayName: string;
+    funcIdx: FuncHandle;
+  }[] = [];
+  for (const definition of VEC_HOST_BRIDGE_DEFINITIONS) {
+    const typeIdx = addFuncType(ctx, [...definition.params], [...definition.results], `$${definition.name}_type`);
+    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const func = {
+      name: definition.name,
+      typeIdx,
+      locals: [],
+      body: [...definition.placeholder],
+      exported: true,
+    } as WasmFunction;
+    ctx.mod.functions.push(func);
+    exportFunc(ctx.mod, definition.name, funcIdx);
+    if (!ctx.funcMap.has(definition.name)) ctx.funcMap.set(definition.name, funcIdx);
+    allocations.set(definition.kind, Object.freeze({ definition, func }));
+    observations.push({
+      role: VEC_HOST_BRIDGE_ROLE,
+      roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.vecHostBridge,
+      derivedOrdinal: definition.ordinal,
+      displayName: definition.name,
+      funcIdx,
+    });
+  }
+
+  ctx.programAbiCallables?.observeEntrySourceSupports(observations);
+  const published = new Map(allocations);
+  vecHostBridgeAllocations.set(ctx, published);
+  return published;
+}
+
+/** Resolve a core vec bridge from its exact allocator object. */
+export function resolveVecHostBridgeHelper(ctx: CodegenContext, kind: VecHostBridgeKind): FuncHandle | undefined {
+  const definition = vecHostBridgeDefinition(kind);
+  const programAbiHandle = ctx.programAbiCallables?.handleForEntrySourceSupport(
+    VEC_HOST_BRIDGE_ROLE,
+    definition.ordinal,
+  );
+  if (programAbiHandle !== undefined) return programAbiHandle;
+  const allocation = vecHostBridgeAllocations.get(ctx)?.get(kind);
+  return allocation ? definedFuncHandleOf(ctx, allocation.func) : undefined;
+}
+
+function requireVecHostBridgeAllocation(ctx: CodegenContext, kind: VecHostBridgeKind): VecHostBridgeAllocation {
+  const allocation = ensureVecHostBridgeAllocations(ctx).get(kind);
+  if (!allocation) throw new Error(`missing vec host bridge allocation ${kind}`);
+  return allocation;
+}
+
+function fillVecHostBridge(
+  ctx: CodegenContext,
+  kind: VecHostBridgeKind,
+  locals: { name: string; type: ValType }[],
+  body: Instr[],
+): void {
+  const allocation = requireVecHostBridgeAllocation(ctx, kind);
+  allocation.func.locals = locals;
+  allocation.func.body = body;
+}
 
 /**
  * (#3311) The native-string vec carrier. `string[]` under nativeStrings /
@@ -61,25 +216,9 @@ export function nativeStrVecElemTypeIdx(ctx: CodegenContext, vecTypeIdx: number)
  * place (fill-or-build in `_emitVecAccessExportsInner`). Idempotent.
  */
 export function reserveVecMethodHelper(ctx: CodegenContext, kind: "push" | "pop" | "get" | "len"): number {
-  const name =
-    kind === "push" ? "__vec_push" : kind === "pop" ? "__vec_pop" : kind === "len" ? "__vec_len" : "__vec_get";
-  const existing = ctx.funcMap.get(name);
-  if (existing !== undefined) return existing;
-  const typeIdx =
-    kind === "push"
-      ? addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }], "$__vec_push_type")
-      : kind === "pop"
-        ? addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }], "$__vec_pop_type")
-        : kind === "len"
-          ? addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$__vec_len_type")
-          : addFuncType(ctx, [{ kind: "externref" }, { kind: "i32" }], [{ kind: "externref" }], "$__vec_get_type");
-  const idx = ctx.numImportFuncs + ctx.mod.functions.length;
-  // Placeholder body must match the declared result type.
-  const placeholder: Instr[] =
-    kind === "push" || kind === "len" ? [{ op: "i32.const", value: 0 }] : [{ op: "ref.null.extern" }];
-  ctx.mod.functions.push({ name, typeIdx, locals: [], body: placeholder, exported: true } as any);
-  exportFunc(ctx.mod, name, idx);
-  ctx.funcMap.set(name, idx);
+  ensureVecHostBridgeAllocations(ctx);
+  const idx = resolveVecHostBridgeHelper(ctx, kind);
+  if (idx === undefined) throw new Error(`reserved vec host bridge ${kind} lost its exact allocator object`);
   // Mark that the finalize vec-export pass must run (so the placeholder gets filled
   // even in a module that otherwise wouldn't emit vec helpers).
   ctx.usesVecValue = true;
@@ -190,10 +329,9 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
     ensureGetUndefined(ctx);
     flushLateImportShifts(ctx, null);
   }
+  ensureVecHostBridgeAllocations(ctx);
 
   // __vec_len(externref) -> i32
-  const lenTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$__vec_len_type");
-  const lenFuncIdx = ctx.numImportFuncs + mod.functions.length;
   {
     // local 0 = externref param, local 1 = anyref converted
     const body: Instr[] = [];
@@ -228,42 +366,10 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
     }
     body.push(...current);
 
-    // (#2773) FILL-or-build. The dynamic-index native-vec element read
-    // (property-access.ts) reserves a `__vec_len` placeholder before this
-    // finalize pass (so it can bake the length-guard call at compile time); fill
-    // it in place if reserved, else push a fresh definition.
-    const reservedLen = ctx.funcMap.get("__vec_len");
-    if (reservedLen !== undefined) {
-      const fn = definedFuncAt(ctx, reservedLen)! as {
-        locals: { name: string; type: ValType }[];
-        body: Instr[];
-      };
-      fn.locals = [{ name: "__any", type: { kind: "anyref" } as ValType }];
-      fn.body = body;
-    } else {
-      mod.functions.push({
-        name: "__vec_len",
-        typeIdx: lenTypeIdx,
-        locals: [{ name: "__any", type: { kind: "anyref" } }],
-        body,
-        exported: true,
-      } as any);
-      mod.exports.push({
-        name: "__vec_len",
-        desc: { kind: "func", index: lenFuncIdx },
-      });
-      ctx.funcMap.set("__vec_len", lenFuncIdx);
-    }
+    fillVecHostBridge(ctx, "len", [{ name: "__any", type: { kind: "anyref" } }], body);
   }
 
   // __vec_get(externref, i32) -> externref
-  const getTypeIdx = addFuncType(
-    ctx,
-    [{ kind: "externref" }, { kind: "i32" }],
-    [{ kind: "externref" }],
-    "$__vec_get_type",
-  );
-  const getFuncIdx = ctx.numImportFuncs + mod.functions.length;
   {
     // local 0 = externref param (vec), local 1 = i32 param (index), local 2 = anyref
     const body: Instr[] = [];
@@ -476,28 +582,7 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
     if (usedF64Scratch) {
       getLocals.push({ name: "__f64_scratch", type: { kind: "f64" } as ValType });
     }
-    // (#2784 S3) FILL-or-build (see __vec_push). The native-vec element-read guard
-    // (property-access.ts) reserves a `__vec_get` placeholder before this finalize
-    // pass; fill it in place if reserved.
-    const reservedGet = ctx.funcMap.get("__vec_get");
-    if (reservedGet !== undefined) {
-      const fn = definedFuncAt(ctx, reservedGet)! as { locals: typeof getLocals; body: Instr[] };
-      fn.locals = getLocals;
-      fn.body = body;
-    } else {
-      mod.functions.push({
-        name: "__vec_get",
-        typeIdx: getTypeIdx,
-        locals: getLocals,
-        body,
-        exported: true,
-      } as any);
-      mod.exports.push({
-        name: "__vec_get",
-        desc: { kind: "func", index: getFuncIdx },
-      });
-      ctx.funcMap.set("__vec_get", getFuncIdx);
-    }
+    fillVecHostBridge(ctx, "get", getLocals, body);
   }
 
   // (#1712) Generic host-side vec MUTATORS. Compiled acorn mutates instance
@@ -522,8 +607,6 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
   // closure capture struct — the runtime's callable-wrapping paths consult
   // this export to veto bridging a vec into a JS function.
   {
-    const isVecTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$__is_vec_type");
-    const isVecFuncIdx = ctx.numImportFuncs + mod.functions.length;
     const body: Instr[] = [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "local.set", index: 1 }];
     let current: Instr[] = [{ op: "i32.const", value: 0 }, { op: "return" }];
     for (let i = vecEntries.length - 1; i >= 0; i--) {
@@ -540,20 +623,11 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       ];
     }
     body.push(...current);
-    mod.functions.push({
-      name: "__is_vec",
-      typeIdx: isVecTypeIdx,
-      locals: [{ name: "__any", type: { kind: "anyref" } }],
-      body,
-      exported: true,
-    } as any);
-    exportFunc(mod, "__is_vec", isVecFuncIdx);
+    fillVecHostBridge(ctx, "is-vec", [{ name: "__any", type: { kind: "anyref" } }], body);
   }
 
   // __vec_mut_supported(externref) -> i32 (1 = push/pop cover this vec's elem kind)
   {
-    const supTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$__vec_mut_supported_type");
-    const supFuncIdx = ctx.numImportFuncs + mod.functions.length;
     const body: Instr[] = [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "local.set", index: 1 }];
     let current: Instr[] = [{ op: "i32.const", value: 0 }, { op: "return" }];
     for (let i = mutEntries.length - 1; i >= 0; i--) {
@@ -570,25 +644,11 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       ];
     }
     body.push(...current);
-    mod.functions.push({
-      name: "__vec_mut_supported",
-      typeIdx: supTypeIdx,
-      locals: [{ name: "__any", type: { kind: "anyref" } }],
-      body,
-      exported: true,
-    } as any);
-    exportFunc(mod, "__vec_mut_supported", supFuncIdx);
+    fillVecHostBridge(ctx, "mut-supported", [{ name: "__any", type: { kind: "anyref" } }], body);
   }
 
   // __vec_push(externref vec, externref value) -> i32 (new length, or -1 unsupported)
   {
-    const pushTypeIdx = addFuncType(
-      ctx,
-      [{ kind: "externref" }, { kind: "externref" }],
-      [{ kind: "i32" }],
-      "$__vec_push_type",
-    );
-    const pushFuncIdx = ctx.numImportFuncs + mod.functions.length;
     // locals: 2 = anyref converted; per-arm typed locals appended below
     const locals: { name: string; type: ValType }[] = [{ name: "__any", type: { kind: "anyref" } }];
     const body: Instr[] = [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "local.set", index: 2 }];
@@ -710,34 +770,12 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       ];
     }
     body.push(...current);
-    // (#2784 S3) FILL-or-build. The native-vec method dispatch (calls.ts) compiles
-    // BEFORE this finalize pass, so it RESERVES a `__vec_push` placeholder up front
-    // (`reserveVecMethodHelper`) and bakes that funcIdx. If reserved, fill the
-    // placeholder's body in place (index/export already set at reserve); else build
-    // fresh and register in funcMap (shift-tracked) so a same-pass lookup resolves.
-    const reservedPush = ctx.funcMap.get("__vec_push");
-    if (reservedPush !== undefined) {
-      const fn = definedFuncAt(ctx, reservedPush)! as { locals: typeof locals; body: Instr[] };
-      fn.locals = locals;
-      fn.body = body;
-    } else {
-      mod.functions.push({
-        name: "__vec_push",
-        typeIdx: pushTypeIdx,
-        locals,
-        body,
-        exported: true,
-      } as any);
-      exportFunc(mod, "__vec_push", pushFuncIdx);
-      ctx.funcMap.set("__vec_push", pushFuncIdx);
-    }
+    fillVecHostBridge(ctx, "push", locals, body);
   }
 
   // __vec_pop(externref) -> externref (boxed last element; null.extern when
   // empty or unsupported — callers gate on __vec_mut_supported to tell apart)
   {
-    const popTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }], "$__vec_pop_type");
-    const popFuncIdx = ctx.numImportFuncs + mod.functions.length;
     const locals: { name: string; type: ValType }[] = [{ name: "__any", type: { kind: "anyref" } }];
     const body: Instr[] = [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "local.set", index: 1 }];
     let current: Instr[] = [{ op: "ref.null.extern" }, { op: "return" }];
@@ -815,23 +853,7 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       ];
     }
     body.push(...current);
-    // (#2784 S3) FILL-or-build (see __vec_push above).
-    const reservedPop = ctx.funcMap.get("__vec_pop");
-    if (reservedPop !== undefined) {
-      const fn = definedFuncAt(ctx, reservedPop)! as { locals: typeof locals; body: Instr[] };
-      fn.locals = locals;
-      fn.body = body;
-    } else {
-      mod.functions.push({
-        name: "__vec_pop",
-        typeIdx: popTypeIdx,
-        locals,
-        body,
-        exported: true,
-      } as any);
-      exportFunc(mod, "__vec_pop", popFuncIdx);
-      ctx.funcMap.set("__vec_pop", popFuncIdx);
-    }
+    fillVecHostBridge(ctx, "pop", locals, body);
   }
 
   // (#3116) __vec_set_elem / __vec_set_len — array-exotic [[DefineOwnProperty]]

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -989,6 +989,7 @@ const _VEC_HOST_BRIDGE_EXPORTS = [
 function _vecHostBridgeExportView<T extends Record<string, any>>(exports: T): T {
   let view: T | undefined;
   for (const [logicalName, physicalBase] of _VEC_HOST_BRIDGE_EXPORTS) {
+    if (!Object.prototype.hasOwnProperty.call(exports, logicalName)) continue;
     let physicalName = physicalBase;
     let helper: unknown;
     while (Object.prototype.hasOwnProperty.call(exports, physicalName)) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -973,18 +973,18 @@ function _rethrowIfProxyOrRevoked(e: any, obj: any): void {
 }
 
 const _VEC_HOST_BRIDGE_EXPORTS = [
-  ["__vec_len", "__js2_vec_host_bridge_0"],
-  ["__vec_get", "__js2_vec_host_bridge_1"],
-  ["__is_vec", "__js2_vec_host_bridge_2"],
-  ["__vec_mut_supported", "__js2_vec_host_bridge_3"],
-  ["__vec_push", "__js2_vec_host_bridge_4"],
-  ["__vec_pop", "__js2_vec_host_bridge_5"],
+  ["__vec_len", "$v0"],
+  ["__vec_get", "$v1"],
+  ["__is_vec", "$v2"],
+  ["__vec_mut_supported", "$v3"],
+  ["__vec_push", "$v4"],
+  ["__vec_pop", "$v5"],
 ] as const;
 
 /**
- * Resolve the compiler-owned vec bridge namespace without replacing a user's
- * same-labelled public export. The compiler appends `$` until it finds a free
- * physical name, so the helper is the final function in each contiguous run.
+ * Resolve a collision-only compiler vec bridge without replacing a user's
+ * same-labelled public export. The logical export is already authoritative
+ * when no physical family exists.
  */
 function _vecHostBridgeExportView<T extends Record<string, any>>(exports: T): T {
   let view: T | undefined;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -972,6 +972,41 @@ function _rethrowIfProxyOrRevoked(e: any, obj: any): void {
   if (_isRevokedProxyError(e) || _isUserProxy(obj)) throw e;
 }
 
+const _VEC_HOST_BRIDGE_EXPORTS = [
+  ["__vec_len", "__js2_vec_host_bridge_0"],
+  ["__vec_get", "__js2_vec_host_bridge_1"],
+  ["__is_vec", "__js2_vec_host_bridge_2"],
+  ["__vec_mut_supported", "__js2_vec_host_bridge_3"],
+  ["__vec_push", "__js2_vec_host_bridge_4"],
+  ["__vec_pop", "__js2_vec_host_bridge_5"],
+] as const;
+
+/**
+ * Resolve the compiler-owned vec bridge namespace without replacing a user's
+ * same-labelled public export. The compiler appends `$` until it finds a free
+ * physical name, so the helper is the final function in each contiguous run.
+ */
+function _vecHostBridgeExportView<T extends Record<string, any>>(exports: T): T {
+  let view: T | undefined;
+  for (const [logicalName, physicalBase] of _VEC_HOST_BRIDGE_EXPORTS) {
+    let physicalName = physicalBase;
+    let helper: unknown;
+    while (Object.prototype.hasOwnProperty.call(exports, physicalName)) {
+      helper = exports[physicalName];
+      physicalName += "$";
+    }
+    if (typeof helper !== "function" || exports[logicalName] === helper) continue;
+    view ??= Object.create(exports) as T;
+    Object.defineProperty(view, logicalName, {
+      value: helper,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  }
+  return view ?? exports;
+}
+
 // (#3673) Memoized classification for `_isWasmStruct`. The predicate is on the
 // hot path of EVERY boundary helper (`__extern_get`/`_safeGet`/`_safeSet` call
 // it several times per crossing), and the original probe-set-and-catch
@@ -15291,7 +15326,7 @@ export function buildImports(
   // Always provide setExports — needed for callbacks, native string marshaling,
   // and struct field getter discovery (__sget_*).
   result.setExports = (exports: Record<string, Function>) => {
-    wasmExports = exports;
+    wasmExports = _vecHostBridgeExportView(exports);
     // (#1712) Replay operations parked during the module START function (see
     // pendingExportsDeferred above) now that struct introspection exports
     // are reachable.
@@ -15436,7 +15471,7 @@ export function wrapExports(
   const callFn1 = rawExports.__call_fn_1 as ((closure: any, arg: any) => any) | undefined;
   // #1504: marshal by default; `marshal: false` keeps raw WasmGC handles.
   const marshal: "copy" | false = options?.marshal === false ? false : "copy";
-  const exportsForMarshal = rawExports as unknown as Record<string, Function>;
+  const exportsForMarshal = _vecHostBridgeExportView(rawExports as unknown as Record<string, Function>);
   // (#1700) Vec allocator + byte-writer for Uint8Array args. Either may be
   // undefined, in which case the wrapper falls back
   // to passing the arg through unchanged.

--- a/tests/issue-3520-vec-support-callable-abi.test.ts
+++ b/tests/issue-3520-vec-support-callable-abi.test.ts
@@ -82,6 +82,47 @@ const ALL_PUBLIC_COLLISION_SOURCE = `
   }
 `;
 
+const PREFIX_ONLY_COLLISION_SOURCE = `
+  export function $v0(): number { return 201; }
+  export function $v1(): number { return 202; }
+  export function $v2(): number { return 203; }
+  export function $v3(): number { return 204; }
+  export function $v4(): number { return 205; }
+  export function $v5(): number { return 206; }
+
+  class Empty {
+    m(): number { return 1; }
+  }
+
+  export function mkInstance(): Empty {
+    return new Empty();
+  }
+
+  export function dynamicPush(values: any, value: any): any {
+    return values.push(value);
+  }
+
+  export function echo(values: any): any {
+    return values;
+  }
+
+  export function returnedValues(): number[] {
+    return [7, 8];
+  }
+`;
+
+const ARRAY_FREE_PHYSICAL_SPOOF_SOURCE = `
+  export function $v0(): number { return 701; }
+
+  class Empty {
+    m(): number { return 1; }
+  }
+
+  export function mkInstance(): Empty {
+    return new Empty();
+  }
+`;
+
 function generate(source: string, fileName: string, trackIrOutcomes = true) {
   const ast = analyzeSource(source, fileName);
   return {
@@ -242,6 +283,45 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
     expect(finalValues.length).toBe(2);
     expect(finalValues).toEqual([7, 8]);
     expect(wrapped.returnedValues()).toEqual([7, 8]);
+  });
+
+  it("terminates all six prefix-only physical families with the structural helper", async () => {
+    const runtime = await compile(PREFIX_ONLY_COLLISION_SOURCE, {
+      fileName: "vec-helper-prefix-only-collisions.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const rawExports = await instantiate(runtime);
+    for (const [index, bridge] of VEC_BRIDGES.entries()) {
+      const physicalBase = vecHostBridgePhysicalExportBase(bridge.kind);
+      expect((rawExports[physicalBase] as () => number)()).toBe(201 + index);
+      expect(rawExports[`${physicalBase}$`]).toBe(rawExports[bridge.name]);
+      expect(rawExports[`${physicalBase}$$`]).toBeUndefined();
+    }
+    expect(Object.keys(rawExports).filter(isVecHostBridgePhysicalExport)).toHaveLength(12);
+
+    const wrapped = wrapExports(rawExports);
+    const rawValues = (rawExports.returnedValues as () => unknown)();
+    expect((rawExports.dynamicPush as (values: unknown, value: number) => number)(rawValues, 3)).toBe(3);
+    expect(wrapped.echo(rawValues)).toEqual([7, 8, 3]);
+    expect(wrapped.mkInstance()).toEqual({});
+  });
+
+  it("does not project an array-free user physical prefix into a logical vec helper", async () => {
+    const runtime = await compile(ARRAY_FREE_PHYSICAL_SPOOF_SOURCE, {
+      fileName: "vec-helper-array-free-physical-spoof.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const rawExports = await instantiate(runtime);
+    expect((rawExports.$v0 as () => number)()).toBe(701);
+    for (const bridge of VEC_BRIDGES) {
+      expect(rawExports[bridge.name]).toBeUndefined();
+    }
+    expect(Object.keys(rawExports).filter(isVecHostBridgePhysicalExport)).toEqual(["$v0"]);
+
+    const wrapped = wrapExports(rawExports);
+    expect(typeof wrapped.mkInstance()).toBe("function");
   });
 
   it("aborts compilation when structural vec ABI observation fails", () => {

--- a/tests/issue-3520-vec-support-callable-abi.test.ts
+++ b/tests/issue-3520-vec-support-callable-abi.test.ts
@@ -7,19 +7,20 @@ import { describe, expect, it, vi } from "vitest";
 
 import { SINGLE_HOST_ENTRIES } from "../scripts/check-ir-only.js";
 import { analyzeSource } from "../src/checker/index.js";
+import { definedFuncAt } from "../src/codegen/func-space.js";
 import { generateModule } from "../src/codegen/index.js";
 import { ProgramAbiCallableRegistry } from "../src/codegen/program-abi-callable-planning.js";
-import { definedFuncAt } from "../src/codegen/func-space.js";
 import {
-  resolveVecHostBridgeHelper,
   VEC_HOST_BRIDGE_ROLE,
   type VecHostBridgeKind,
+  resolveVecHostBridgeHelper,
+  vecHostBridgePhysicalExportBase,
 } from "../src/codegen/vec-access-exports.js";
-import { compile, type CompileResult } from "../src/index.js";
+import { type CompileResult, compile } from "../src/index.js";
 import { irSupportFuncRef } from "../src/ir/callable-bindings.js";
 import { buildIrUnitInventory } from "../src/ir/identity.js";
 import type { WasmFunction } from "../src/ir/types.js";
-import { buildImports, instantiateWasm } from "../src/runtime.js";
+import { buildImports, instantiateWasm, wrapExports } from "../src/runtime.js";
 
 // Register the codegen expression/statement delegates used by generateModule.
 import "../src/codegen/expressions.js";
@@ -44,6 +45,33 @@ const ARRAY_SOURCE = `
     values.push(1);
     values.pop();
     return values[0] + __vec_get(values, 0);
+  }
+`;
+
+const ALL_PUBLIC_COLLISION_SOURCE = `
+  export function __vec_len(): number { return 101; }
+  export function __vec_get(): number { return 102; }
+  export function __is_vec(): number { return 103; }
+  export function __vec_mut_supported(): number { return 104; }
+  export function __vec_push(): number { return 105; }
+  export function __vec_pop(): number { return 106; }
+  export function __js2_vec_host_bridge_0(): number { return 901; }
+  export function __js2_vec_host_bridge_0$$(): number { return 902; }
+
+  export function dynamicPush(values: any, value: any): any {
+    return values.push(value);
+  }
+
+  export function dynamicPop(values: any): any {
+    return values.pop();
+  }
+
+  export function echo(values: any): any {
+    return values;
+  }
+
+  export function returnedValues(): number[] {
+    return [7, 8];
   }
 `;
 
@@ -146,39 +174,148 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
         bridge.kind === "get" || bridge.kind === "pop" ? [{ op: "ref.null.extern" }] : [{ op: "i32.const", value: 0 }],
       );
       expect(resolveVecHostBridgeHelper(registry!.ctx, bridge.kind)).toBe(handle);
+      const entrySource = registry!.session.inventory.sources.find((source) => source.kind === "entry");
+      if (!entrySource) throw new Error("missing registry entry source");
+      const ref = irSupportFuncRef(entrySource.id, VEC_HOST_BRIDGE_ROLE, bridge.name, bridge.ordinal);
+      if (ref.binding.kind !== "support") throw new Error(`missing ${bridge.name} support reference`);
+      const slot = result.programAbi!.abi.resolveFinalIndex(ref.binding.bindingId);
+      if (!slot || slot.space !== "function") throw new Error(`missing ${bridge.name} final slot`);
+      const importCount = result.module.imports.filter((candidate) => candidate.desc.kind === "func").length;
+      expect(result.module.functions[slot.index - importCount]).toBe(func);
     }
   });
 
-  it("emits no vec bridge for an array-free module and preserves a same-labelled source callable", async () => {
+  it("emits no vec bridge for an array-free module", () => {
     const arrayFree = generate(`export function main(): number { return 1; }`, "vec-array-free.ts").result;
     expect(
       arrayFree.module.functions.filter((func) => VEC_BRIDGES.some((bridge) => bridge.name === func.name)),
     ).toEqual([]);
     expect(arrayFree.programAbi!.abi.entries().filter((entry) => entry.id.includes(VEC_HOST_BRIDGE_ROLE))).toEqual([]);
+  });
 
-    const runtime = await compile(ARRAY_SOURCE, {
-      fileName: "vec-helper-label-collision.ts",
+  it("preserves all six same-labelled public exports while the runtime uses physical vec bridges", async () => {
+    const runtime = await compile(ALL_PUBLIC_COLLISION_SOURCE, {
+      fileName: "vec-helper-public-collisions.ts",
       experimentalIR: true,
       trackIrOutcomes: true,
     });
-    const exports = await instantiate(runtime);
-    expect((exports.main as () => number)()).toBe(140);
-    expect(runtime.wat?.match(/\(func \$__vec_get/g)).toHaveLength(2);
+    const rawExports = await instantiate(runtime);
+    expect((rawExports.__js2_vec_host_bridge_0 as () => number)()).toBe(901);
+    expect((rawExports["__js2_vec_host_bridge_0$$"] as () => number)()).toBe(902);
+    for (const [index, bridge] of VEC_BRIDGES.entries()) {
+      expect((rawExports[bridge.name] as () => number)()).toBe(101 + index);
+      let physicalName = vecHostBridgePhysicalExportBase(bridge.kind);
+      let physicalHelper: WebAssembly.ExportValue | undefined;
+      while (Object.prototype.hasOwnProperty.call(rawExports, physicalName)) {
+        physicalHelper = rawExports[physicalName];
+        physicalName += "$";
+      }
+      expect(physicalHelper).toEqual(expect.any(Function));
+      expect(physicalHelper).not.toBe(rawExports[bridge.name]);
+    }
+
+    const wrapped = wrapExports(rawExports);
+    const rawValues = (rawExports.returnedValues as () => unknown)();
+    expect((rawExports.dynamicPush as (values: unknown, value: number) => number)(rawValues, 3)).toBe(3);
+    const intermediate = wrapped.echo(rawValues);
+    expect(intermediate.length).toBe(3);
+    expect(intermediate[2]).toBe(3);
+    expect((rawExports.dynamicPop as (values: unknown) => number)(rawValues)).toBe(3);
+    const finalValues = wrapped.echo(rawValues);
+    expect(finalValues.length).toBe(2);
+    expect(finalValues).toEqual([7, 8]);
+    expect(wrapped.returnedValues()).toEqual([7, 8]);
+  });
+
+  it("aborts compilation when structural vec ABI observation fails", () => {
+    const observe = vi
+      .spyOn(ProgramAbiCallableRegistry.prototype, "observeEntrySourceSupports")
+      .mockImplementation(() => {
+        throw new Error("forced vec observation failure");
+      });
+    try {
+      const { result } = generate(ARRAY_SOURCE, "vec-observation-failure.ts");
+      expect(result.errors.filter((error) => error.severity !== "warning")).not.toEqual([]);
+      expect(result.errors.map((error) => error.message).join("\n")).toMatch(/forced vec observation failure/);
+      expect(result.module.exports.filter((entry) => entry.name.startsWith("__js2_vec_host_bridge_"))).toEqual([]);
+    } finally {
+      observe.mockRestore();
+    }
+  });
+
+  it("keeps captured bridge objects through late-import shifts and dead-import compaction", () => {
+    let registry: ProgramAbiCallableRegistry | undefined;
+    let observedImportCount = -1;
+    let reserved: readonly WasmFunction[] = [];
+    const handleImportCounts: number[] = [];
+    const originalObserve = ProgramAbiCallableRegistry.prototype.observeEntrySourceSupports;
+    const originalHandle = ProgramAbiCallableRegistry.prototype.handleForEntrySourceSupport;
+    const observe = vi
+      .spyOn(ProgramAbiCallableRegistry.prototype, "observeEntrySourceSupports")
+      .mockImplementation(function (observations) {
+        registry = this;
+        observedImportCount = this.ctx.numImportFuncs;
+        reserved = observations.map((observation) => {
+          const func = definedFuncAt(this.ctx, observation.funcIdx);
+          if (!func) throw new Error(`missing reserved helper ${observation.displayName}`);
+          return func;
+        });
+        return originalObserve.call(this, observations);
+      });
+    const handle = vi
+      .spyOn(ProgramAbiCallableRegistry.prototype, "handleForEntrySourceSupport")
+      .mockImplementation(function (role, ordinal) {
+        handleImportCounts.push(this.ctx.numImportFuncs);
+        return originalHandle.call(this, role, ordinal);
+      });
+    let result: ReturnType<typeof generate>["result"];
+    try {
+      result = generate(
+        `
+          export function first(values: any): number { return values.push(1); }
+          export function later(value: any): any { return value.missing; }
+          export function stringLater(value: string): boolean { return value.includes("x"); }
+          export function last(values: any): any { return values[0]; }
+        `,
+        "vec-late-import-compaction.ts",
+      ).result;
+    } finally {
+      handle.mockRestore();
+      observe.mockRestore();
+    }
+
+    const finalImportCount = result.module.imports.filter((candidate) => candidate.desc.kind === "func").length;
+    expect(Math.max(...handleImportCounts)).toBeGreaterThan(observedImportCount);
+    expect(finalImportCount).toBeLessThan(Math.max(...handleImportCounts));
+    expect(reserved).toHaveLength(6);
+    expect(registry).toBeDefined();
+    const entrySource = registry!.session.inventory.sources.find((source) => source.kind === "entry");
+    if (!entrySource) throw new Error("missing registry entry source");
+    for (const [index, bridge] of VEC_BRIDGES.entries()) {
+      const func = reserved[index]!;
+      const ref = irSupportFuncRef(entrySource.id, VEC_HOST_BRIDGE_ROLE, bridge.name, bridge.ordinal);
+      if (ref.binding.kind !== "support") throw new Error(`missing ${bridge.name} support reference`);
+      const slot = result.programAbi!.abi.resolveFinalIndex(ref.binding.bindingId);
+      if (!slot || slot.space !== "function") throw new Error(`missing ${bridge.name} final slot`);
+      expect(result.module.functions[slot.index - finalImportCount]).toBe(func);
+      expect(result.module.functions).toContain(func);
+    }
   });
 
   it("keeps tracked output and IR routing stable while the five-entry census moves only the 24 vec rows", async () => {
     const untracked = await compile(ARRAY_SOURCE, {
       fileName: "vec-tracking-parity.ts",
-      experimentalIR: false,
+      experimentalIR: true,
     });
     const tracked = await compile(ARRAY_SOURCE, {
       fileName: "vec-tracking-parity.ts",
-      experimentalIR: false,
+      experimentalIR: true,
       trackIrOutcomes: true,
     });
     expect(tracked.success, tracked.errors.map((error) => error.message).join("\n")).toBe(true);
     expect(tracked.binary).toEqual(untracked.binary);
-    expect(tracked.irOutcomes).toEqual([]);
+    expect(tracked.irOutcomes?.map((outcome) => outcome.kind)).toEqual(["emitted", "unsupported"]);
+    expect(untracked.irOutcomes).toBeUndefined();
 
     const routed = generate(ARRAY_SOURCE, "vec-routing.ts", true).result;
     const unreported = generate(ARRAY_SOURCE, "vec-routing.ts", false).result;

--- a/tests/issue-3520-vec-support-callable-abi.test.ts
+++ b/tests/issue-3520-vec-support-callable-abi.test.ts
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { SINGLE_HOST_ENTRIES } from "../scripts/check-ir-only.js";
+import { analyzeSource } from "../src/checker/index.js";
+import { generateModule } from "../src/codegen/index.js";
+import { ProgramAbiCallableRegistry } from "../src/codegen/program-abi-callable-planning.js";
+import { definedFuncAt } from "../src/codegen/func-space.js";
+import {
+  resolveVecHostBridgeHelper,
+  VEC_HOST_BRIDGE_ROLE,
+  type VecHostBridgeKind,
+} from "../src/codegen/vec-access-exports.js";
+import { compile, type CompileResult } from "../src/index.js";
+import { irSupportFuncRef } from "../src/ir/callable-bindings.js";
+import { buildIrUnitInventory } from "../src/ir/identity.js";
+import type { WasmFunction } from "../src/ir/types.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+// Register the codegen expression/statement delegates used by generateModule.
+import "../src/codegen/expressions.js";
+
+const VEC_BRIDGES: readonly {
+  kind: VecHostBridgeKind;
+  name: string;
+  ordinal: number;
+}[] = [
+  { kind: "len", name: "__vec_len", ordinal: 0 },
+  { kind: "get", name: "__vec_get", ordinal: 1 },
+  { kind: "is-vec", name: "__is_vec", ordinal: 2 },
+  { kind: "mut-supported", name: "__vec_mut_supported", ordinal: 3 },
+  { kind: "push", name: "__vec_push", ordinal: 4 },
+  { kind: "pop", name: "__vec_pop", ordinal: 5 },
+];
+
+const ARRAY_SOURCE = `
+  function __vec_get(_value: any, _index: number): number { return 99; }
+  export function main(): number {
+    const values: any = [41];
+    values.push(1);
+    values.pop();
+    return values[0] + __vec_get(values, 0);
+  }
+`;
+
+function generate(source: string, fileName: string, trackIrOutcomes = true) {
+  const ast = analyzeSource(source, fileName);
+  return {
+    ast,
+    result: generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes,
+    }),
+  };
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, WebAssembly.ExportValue>> {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    result.binary,
+    imports.env,
+    imports.string_constants,
+    imports.string_constants16,
+  );
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, WebAssembly.ExportValue>;
+}
+
+describe("#3520 vec host-bridge Program ABI ownership", () => {
+  it("publishes all six bridges beneath the entry source with fixed ordinals and exact final slots", () => {
+    const { ast, result } = generate(ARRAY_SOURCE, "vec-host-bridge.ts");
+    const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+    expect(hardErrors, hardErrors.map((error) => error.message).join("\n")).toEqual([]);
+    expect(result.programAbi).toBeDefined();
+
+    const inventory = buildIrUnitInventory([ast.sourceFile], {
+      entrySource: ast.sourceFile,
+      checker: ast.checker,
+    });
+    const entrySource = inventory.sources.find((source) => source.kind === "entry");
+    if (!entrySource) throw new Error("missing entry source");
+
+    const entries = result.programAbi!.abi.entries();
+    const importCount = result.module.imports.filter((candidate) => candidate.desc.kind === "func").length;
+    for (const bridge of VEC_BRIDGES) {
+      const ref = irSupportFuncRef(entrySource.id, VEC_HOST_BRIDGE_ROLE, bridge.name, bridge.ordinal);
+      if (ref.binding.kind !== "support") throw new Error(`missing ${bridge.name} support reference`);
+      const entry = entries.find((candidate) => candidate.id === ref.binding.bindingId);
+      expect(entry).toMatchObject({
+        id: ref.binding.bindingId,
+        displayName: bridge.name,
+        slotPolicy: "required",
+        slotSpace: "function",
+        intent: {
+          kind: "callable",
+          origin: "support",
+          sourceId: entrySource.id,
+        },
+      });
+      const slot = result.programAbi!.abi.resolveFinalIndex(ref.binding.bindingId);
+      expect(slot).toEqual(expect.objectContaining({ space: "function" }));
+      if (!slot || slot.space !== "function") throw new Error(`missing ${bridge.name} final slot`);
+      expect(result.module.functions[slot.index - importCount]?.name).toBe(bridge.name);
+    }
+
+    const genericVecRows = entries.filter(
+      (entry) =>
+        entry.id.includes("retained-module-function") &&
+        VEC_BRIDGES.some((bridge) => bridge.name === entry.displayName),
+    );
+    expect(genericVecRows).toEqual([]);
+  });
+
+  it("keeps the exact reserved allocator objects through final body filling", () => {
+    let registry: ProgramAbiCallableRegistry | undefined;
+    let reserved: readonly WasmFunction[] = [];
+    const original = ProgramAbiCallableRegistry.prototype.observeEntrySourceSupports;
+    const observe = vi
+      .spyOn(ProgramAbiCallableRegistry.prototype, "observeEntrySourceSupports")
+      .mockImplementation(function (observations) {
+        registry = this;
+        reserved = observations.map((observation) => {
+          const func = definedFuncAt(this.ctx, observation.funcIdx);
+          if (!func) throw new Error(`missing reserved helper ${observation.displayName}`);
+          return func;
+        });
+        return original.call(this, observations);
+      });
+    const { result } = generate(ARRAY_SOURCE, "vec-reserve-fill.ts");
+    observe.mockRestore();
+
+    expect(reserved).toHaveLength(6);
+    expect(registry).toBeDefined();
+    for (const [index, bridge] of VEC_BRIDGES.entries()) {
+      const func = reserved[index]!;
+      const handle = registry!.handleForEntrySourceSupport(VEC_HOST_BRIDGE_ROLE, bridge.ordinal);
+      expect(handle).toBeDefined();
+      expect(handle === undefined ? undefined : definedFuncAt(registry!.ctx, handle)).toBe(func);
+      expect(result.module.functions).toContain(func);
+      expect(func.body).not.toEqual(
+        bridge.kind === "get" || bridge.kind === "pop" ? [{ op: "ref.null.extern" }] : [{ op: "i32.const", value: 0 }],
+      );
+      expect(resolveVecHostBridgeHelper(registry!.ctx, bridge.kind)).toBe(handle);
+    }
+  });
+
+  it("emits no vec bridge for an array-free module and preserves a same-labelled source callable", async () => {
+    const arrayFree = generate(`export function main(): number { return 1; }`, "vec-array-free.ts").result;
+    expect(
+      arrayFree.module.functions.filter((func) => VEC_BRIDGES.some((bridge) => bridge.name === func.name)),
+    ).toEqual([]);
+    expect(arrayFree.programAbi!.abi.entries().filter((entry) => entry.id.includes(VEC_HOST_BRIDGE_ROLE))).toEqual([]);
+
+    const runtime = await compile(ARRAY_SOURCE, {
+      fileName: "vec-helper-label-collision.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+    const exports = await instantiate(runtime);
+    expect((exports.main as () => number)()).toBe(140);
+    expect(runtime.wat?.match(/\(func \$__vec_get/g)).toHaveLength(2);
+  });
+
+  it("keeps tracked output and IR routing stable while the five-entry census moves only the 24 vec rows", async () => {
+    const untracked = await compile(ARRAY_SOURCE, {
+      fileName: "vec-tracking-parity.ts",
+      experimentalIR: false,
+    });
+    const tracked = await compile(ARRAY_SOURCE, {
+      fileName: "vec-tracking-parity.ts",
+      experimentalIR: false,
+      trackIrOutcomes: true,
+    });
+    expect(tracked.success, tracked.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(tracked.binary).toEqual(untracked.binary);
+    expect(tracked.irOutcomes).toEqual([]);
+
+    const routed = generate(ARRAY_SOURCE, "vec-routing.ts", true).result;
+    const unreported = generate(ARRAY_SOURCE, "vec-routing.ts", false).result;
+    expect(unreported.irCompiledFuncs).toEqual(routed.irCompiledFuncs);
+    expect(routed.irOutcomes?.map((outcome) => outcome.kind)).toEqual(["emitted", "unsupported"]);
+    expect(unreported.irOutcomes).toBeUndefined();
+    expect(unreported.module.functions).toHaveLength(routed.module.functions.length);
+
+    let definedFunctions = 0;
+    let genericRows = 0;
+    let vecRows = 0;
+    for (const entry of SINGLE_HOST_ENTRIES) {
+      const source = readFileSync(resolve(entry), "utf8");
+      const ast = analyzeSource(source, entry);
+      const result = generateModule(ast, {
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      const hardErrors = result.errors.filter((error) => error.severity !== "warning");
+      expect(hardErrors, `${entry}\n${hardErrors.map((error) => error.message).join("\n")}`).toEqual([]);
+      definedFunctions += result.module.functions.length;
+      const entries = result.programAbi!.abi.entries();
+      genericRows += entries.filter((candidate) => candidate.id.includes("retained-module-function")).length;
+      vecRows += entries.filter((candidate) => candidate.id.includes(VEC_HOST_BRIDGE_ROLE)).length;
+    }
+    expect({ definedFunctions, genericRows, vecRows }).toEqual({
+      definedFunctions: 166,
+      genericRows: 77,
+      vecRows: 24,
+    });
+  });
+});

--- a/tests/issue-3520-vec-support-callable-abi.test.ts
+++ b/tests/issue-3520-vec-support-callable-abi.test.ts
@@ -38,6 +38,13 @@ const VEC_BRIDGES: readonly {
   { kind: "pop", name: "__vec_pop", ordinal: 5 },
 ];
 
+function isVecHostBridgePhysicalExport(name: string): boolean {
+  return VEC_BRIDGES.some((bridge) => {
+    const base = vecHostBridgePhysicalExportBase(bridge.kind);
+    return name.startsWith(base) && /^\$*$/.test(name.slice(base.length));
+  });
+}
+
 const ARRAY_SOURCE = `
   function __vec_get(_value: any, _index: number): number { return 99; }
   export function main(): number {
@@ -55,8 +62,8 @@ const ALL_PUBLIC_COLLISION_SOURCE = `
   export function __vec_mut_supported(): number { return 104; }
   export function __vec_push(): number { return 105; }
   export function __vec_pop(): number { return 106; }
-  export function __js2_vec_host_bridge_0(): number { return 901; }
-  export function __js2_vec_host_bridge_0$$(): number { return 902; }
+  export function $v0(): number { return 901; }
+  export function $v0$$(): number { return 902; }
 
   export function dynamicPush(values: any, value: any): any {
     return values.push(value);
@@ -142,6 +149,7 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
         VEC_BRIDGES.some((bridge) => bridge.name === entry.displayName),
     );
     expect(genericVecRows).toEqual([]);
+    expect(result.module.exports.filter((entry) => isVecHostBridgePhysicalExport(entry.name))).toEqual([]);
   });
 
   it("keeps the exact reserved allocator objects through final body filling", () => {
@@ -200,19 +208,28 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
       trackIrOutcomes: true,
     });
     const rawExports = await instantiate(runtime);
-    expect((rawExports.__js2_vec_host_bridge_0 as () => number)()).toBe(901);
-    expect((rawExports["__js2_vec_host_bridge_0$$"] as () => number)()).toBe(902);
+    expect((rawExports.$v0 as () => number)()).toBe(901);
+    expect((rawExports["$v0$$"] as () => number)()).toBe(902);
+    const terminalPhysicalNames = new Set<string>();
+    const physicalHelpers = new Set<WebAssembly.ExportValue>();
     for (const [index, bridge] of VEC_BRIDGES.entries()) {
       expect((rawExports[bridge.name] as () => number)()).toBe(101 + index);
       let physicalName = vecHostBridgePhysicalExportBase(bridge.kind);
       let physicalHelper: WebAssembly.ExportValue | undefined;
+      let terminalPhysicalName: string | undefined;
       while (Object.prototype.hasOwnProperty.call(rawExports, physicalName)) {
         physicalHelper = rawExports[physicalName];
+        terminalPhysicalName = physicalName;
         physicalName += "$";
       }
       expect(physicalHelper).toEqual(expect.any(Function));
       expect(physicalHelper).not.toBe(rawExports[bridge.name]);
+      expect(terminalPhysicalName).toBeDefined();
+      terminalPhysicalNames.add(terminalPhysicalName!);
+      physicalHelpers.add(physicalHelper!);
     }
+    expect(terminalPhysicalNames.size).toBe(6);
+    expect(physicalHelpers.size).toBe(6);
 
     const wrapped = wrapExports(rawExports);
     const rawValues = (rawExports.returnedValues as () => unknown)();
@@ -237,7 +254,7 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
       const { result } = generate(ARRAY_SOURCE, "vec-observation-failure.ts");
       expect(result.errors.filter((error) => error.severity !== "warning")).not.toEqual([]);
       expect(result.errors.map((error) => error.message).join("\n")).toMatch(/forced vec observation failure/);
-      expect(result.module.exports.filter((entry) => entry.name.startsWith("__js2_vec_host_bridge_"))).toEqual([]);
+      expect(result.module.exports.filter((entry) => isVecHostBridgePhysicalExport(entry.name))).toEqual([]);
     } finally {
       observe.mockRestore();
     }


### PR DESCRIPTION
## Summary

- reserve and fill the six core vec host helpers through exact allocator objects and fixed entry-source Program ABI identities
- move 24 rows out of generic retained-module-function ownership into the vec-host-bridge structural family
- preserve same-labelled user exports through a collision-safe physical helper namespace
- make structural observation, body filling, and physical publication fail compilation instead of leaving placeholder helpers
- route runtime vector reads, discrimination, wrapping, push, and pop through the exact physical helpers

## Migration result

The five-entry census keeps 166 defined functions while generic retained rows fall from 101 to 77 and 24 vec-host-bridge rows become structurally owned. Current main-relative IR routing remains behaviorally unchanged at 37 terminal units, 31 IR-emitted, 6 typed unsupported, 0 invariants, and 37 temporary legacy bodies.

This closes C30 ownership for the six core vec bridges; it does not claim that all #3520 Program ABI consumers are retired.

## Validation

- focused and adjacent Vitest suites after rebase: 52/52
- strict TypeScript, Biome lint, and Prettier
- IR fallback ratchet
- LOC and function budgets
- dead-export, oracle-ratchet, and IR-adoption gates
- hybrid IR readiness census: 31 emitted / 6 unsupported / 0 invariants

The current godfile profile reports the two already-landed #3820 index.ts growth points; this branch has no src/codegen/index.ts diff from main.

Tracks the C30 continuation in plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md.