### PR TITLE
refactor(ir): seal Program ABI plans before final binding (#3521)

### DIFF
--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -309,3 +309,23 @@ The PR report must include inventory and outcome denominators, a per-unit
 direct/IR emission table, the old-allowlist vs Prepared delta, all post-Prepared
 failure injections, and proof that no in-scope placeholder or compile-twice
 unit shipped. “IR emitted” without `directBodyEmissions: 0` is not acceptance.
+
+## 2026-07-30 Program ABI session-seal prerequisite
+
+The bounded `3521:program-abi-session-seal` slice separates
+`ProgramAbiSession` into an explicit deterministic `sealPlan()` boundary and a
+later `bindAndPublish()` boundary. The existing `publish()` API remains a
+behavior-preserving wrapper over both phases, so production routing is
+unchanged.
+
+After sealing, new ABI drafts, derived units, contracts, locators, and
+structural-reference registrations are rejected. Exact function/global
+locator replacement, type-layout remapping, provisional index resolution, and
+final binding remain available until publication. Focused coverage proves
+late-plan rejection, post-seal function replacement, late-import index shifts,
+post-seal type-cell DCE remapping, exact final-index binding on the originally
+sealed `ProgramAbiMap`, and one-shot publication.
+
+This is a prerequisite seam only. Prepared free-function ownership, terminal
+component outcomes, support-intent collection, and direct/IR emission
+accounting remain for the main R2 implementation.

--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -30,6 +30,7 @@ files:
   - src/ir/from-ast.ts
   - src/ir/lower.ts
   - src/ir/backend/legality.ts
+  - src/codegen/program-abi-session.ts
   - src/codegen/context/types.ts
   - src/codegen/context/create-context.ts
   - src/codegen/declarations.ts
@@ -37,6 +38,8 @@ files:
   - src/index.ts
   - src/compiler.ts
   - tests/issue-3521-prepared-ir-program.test.ts
+loc-budget-allow:
+  - src/codegen/program-abi-session.ts
 ---
 
 # #3521 — IR-only R2: prepare-before-emit free-function ownership
@@ -321,10 +324,17 @@ unchanged.
 After sealing, new ABI drafts, derived units, contracts, locators, and
 structural-reference registrations are rejected. Exact function/global
 locator replacement, type-layout remapping, provisional index resolution, and
-final binding remain available until publication. Focused coverage proves
-late-plan rejection, post-seal function replacement, late-import index shifts,
-post-seal type-cell DCE remapping, exact final-index binding on the originally
-sealed `ProgramAbiMap`, and one-shot publication.
+final binding remain available until publication. `sealPlan()` exposes only a
+frozen read-only view; the bind-capable `ProgramAbiMap` is rebuilt privately
+from frozen structural intentions and the current post-DCE type sidecars.
+Final locators, indices, and collisions are validated into a temporary set
+before any index is committed or a publication becomes observable.
+
+Focused coverage proves late-plan and missing-locator rejection, post-seal
+function replacement, callable/global/type-cell DCE remapping, late-import
+index shifts, capability-safe sealed views, atomic failure on a later missing
+locator, exact final-index binding, post-publication closure, and one-shot
+publication.
 
 This is a prerequisite seam only. Prepared free-function ownership, terminal
 component outcomes, support-intent collection, and direct/IR emission

--- a/src/codegen/program-abi-session.ts
+++ b/src/codegen/program-abi-session.ts
@@ -409,7 +409,7 @@ export interface PublishedProgramAbi {
   readonly legacy: LegacyAbiAdapter;
 }
 
-type SessionState = "open" | "publishing" | "published" | "failed";
+type SessionState = "planning" | "sealing" | "sealed" | "binding" | "published" | "failed";
 
 function validOrdinal(value: number): boolean {
   return Number.isSafeInteger(value) && value >= 0;
@@ -580,7 +580,8 @@ export class ProgramAbiSession {
   private readonly typeCellsByObject = new Map<TypeDef, MutableProgramAbiTypeCell>();
   private readonly callableTypeContracts = new Map<IrBindingId, ProgramAbiCallableTypeContract>();
   private readonly globalTypeContracts = new Map<IrBindingId, ProgramAbiGlobalTypeContract>();
-  private state: SessionState = "open";
+  private state: SessionState = "planning";
+  private sealedAbi: ProgramAbiMap | undefined;
   private publishedValue: PublishedProgramAbi | undefined;
   readonly structuralOrder: ProgramAbiStructuralOrder;
 
@@ -628,7 +629,7 @@ export class ProgramAbiSession {
    * equivalent at the structural contract level.
    */
   ensurePlan(draft: ProgramAbiDraft): void {
-    this.assertOpen(`ensure plan ${draft.id}`);
+    this.assertPlanning(`ensure plan ${draft.id}`);
     const existing = this.drafts.get(draft.id);
     if (!existing) {
       this.plan(draft);
@@ -653,12 +654,12 @@ export class ProgramAbiSession {
   }
 
   registerStructuralReference(id: IrBindingId, key: string): void {
-    this.assertOpen(`register structural reference for ${id}`);
+    this.assertPlanning(`register structural reference for ${id}`);
     this.assertStructuralReference(id, key, true);
   }
 
   plan(draft: ProgramAbiDraft): void {
-    this.assertOpen(`plan ${draft.id}`);
+    this.assertPlanning(`plan ${draft.id}`);
     if (this.drafts.has(draft.id)) {
       throw new ProgramAbiInvariantError("duplicate-session-draft", `ABI draft ${draft.id} was planned more than once`);
     }
@@ -703,7 +704,7 @@ export class ProgramAbiSession {
   }
 
   registerDerivedUnit(record: ProgramAbiDerivedUnitRecord): void {
-    this.assertOpen(`register derived unit ${record.id}`);
+    this.assertPlanning(`register derived unit ${record.id}`);
     if (this.derivedUnits.has(record.id)) {
       throw new ProgramAbiInvariantError(
         "duplicate-derived-unit",
@@ -726,7 +727,7 @@ export class ProgramAbiSession {
     id: IrBindingId,
     signature: Pick<FuncTypeDef, "params" | "results"> | ProgramAbiCallableTypeContract,
   ): void {
-    this.assertOpen(`register callable type contract for ${id}`);
+    this.assertPlanning(`register callable type contract for ${id}`);
     const draft = this.drafts.get(id);
     if (!draft || draft.intent.kind !== "callable") {
       throw new ProgramAbiInvariantError(
@@ -761,7 +762,7 @@ export class ProgramAbiSession {
 
   /** Retain one structured global storage contract through type compaction. */
   registerGlobalTypeContract(id: IrBindingId, type: ValType, mutable: boolean): void {
-    this.assertOpen(`register global type contract for ${id}`);
+    this.assertPlanning(`register global type contract for ${id}`);
     const draft = this.drafts.get(id);
     if (
       !draft ||
@@ -791,7 +792,7 @@ export class ProgramAbiSession {
   }
 
   createTypeCell(type: TypeDef): ProgramAbiTypeCell {
-    this.assertOpen("create a type cell");
+    this.assertPlanning("create a type cell");
     if (this.typeCellsByObject.has(type)) {
       throw new ProgramAbiInvariantError(
         "duplicate-type-cell",
@@ -813,7 +814,7 @@ export class ProgramAbiSession {
    * publish then rejects a required slot rather than guessing by type name.
    */
   remapTypeCell(cell: ProgramAbiTypeCell, replacement: TypeDef | null): void {
-    this.assertOpen("remap a type cell");
+    this.assertLayoutMutable("remap a type cell");
     if (!this.typeCells.has(cell)) {
       throw new ProgramAbiInvariantError("foreign-type-cell", "type cell belongs to another ABI session");
     }
@@ -836,7 +837,7 @@ export class ProgramAbiSession {
    * remap reports reject instead of silently attaching to another cell.
    */
   remapTypeObjects(remaps: Iterable<readonly [TypeDef, TypeDef | null]>): void {
-    this.assertOpen("remap type objects");
+    this.assertLayoutMutable("remap type objects");
     const pending = [...remaps];
     const previousObjects = new Set<TypeDef>();
     const replacementOwners = new Map<TypeDef, MutableProgramAbiTypeCell>();
@@ -891,7 +892,7 @@ export class ProgramAbiSession {
    * validated and remapped before any session-owned state changes.
    */
   applyTypeLayoutRemap(layout: ProgramAbiTypeLayoutRemap): void {
-    this.assertOpen("apply a type layout remap");
+    this.assertLayoutMutable("apply a type layout remap");
     const { previousTypes, nextTypes, targetsByOldIndex } = layout;
     if (this.module.types !== previousTypes || targetsByOldIndex.length !== previousTypes.length) {
       throw new ProgramAbiInvariantError(
@@ -979,7 +980,7 @@ export class ProgramAbiSession {
   }
 
   attachLocator(id: IrBindingId, locator: ProgramAbiSlotLocator): void {
-    this.assertOpen(`attach slot locator for ${id}`);
+    this.assertPlanning(`attach slot locator for ${id}`);
     const draft = this.drafts.get(id);
     if (!draft) {
       throw new ProgramAbiInvariantError("unknown-locator-binding", `slot locator targets unplanned ABI draft ${id}`);
@@ -1040,7 +1041,7 @@ export class ProgramAbiSession {
     module: WasmModule = this.module,
   ): number {
     this.assertModule(module);
-    this.assertStructuralReference(id, structuralReferenceKey, this.state === "open");
+    this.assertStructuralReference(id, structuralReferenceKey, this.state === "planning");
     if (this.state === "published") {
       const finalIndex = this.publishedValue!.abi.resolveFinalIndex(id);
       if (!finalIndex || finalIndex.space !== expectedSpace) {
@@ -1051,7 +1052,7 @@ export class ProgramAbiSession {
       }
       return finalIndex.index;
     }
-    this.assertOpen(`resolve current slot for ${id}`);
+    this.assertLayoutMutable(`resolve current slot for ${id}`);
     const canonical = this.canonicalDraft(id);
     if (canonical.slotPolicy !== "required" || canonical.slotSpace !== expectedSpace) {
       throw new ProgramAbiInvariantError(
@@ -1076,20 +1077,23 @@ export class ProgramAbiSession {
   }
 
   /**
-   * Build, seal, bind, and complete the ABI exactly once.
+   * Materialize and seal the deterministic ABI intention map without binding
+   * any concrete ModuleAssembler indices.
    *
-   * A failed publish closes the session too: callers must fix the producer and
-   * rebuild the compilation instead of mutating a partially observed plan.
+   * Planning producers are closed after this boundary. Exact allocator
+   * locators may still follow body replacement or layout compaction before
+   * final binding.
    */
-  publish(module: WasmModule): PublishedProgramAbi {
+  sealPlan(module: WasmModule = this.module): ProgramAbiMap {
     this.assertModule(module);
-    if (this.state !== "open") {
+    if (this.state === "sealed" || this.state === "published") return this.sealedAbi!;
+    if (this.state !== "planning") {
       throw new ProgramAbiInvariantError(
-        "session-publish-once",
-        `ProgramAbiSession publish was already attempted (${this.state})`,
+        "session-closed",
+        `ProgramAbiSession planning cannot be sealed from state ${this.state}`,
       );
     }
-    this.state = "publishing";
+    this.state = "sealing";
     try {
       const abi = new ProgramAbiMap(this.inventory, [...this.derivedUnits.values()]);
       const drafts = [...this.drafts.values()].sort((a, b) => compareDrafts(this.sourceOrderById, a, b));
@@ -1108,8 +1112,45 @@ export class ProgramAbiSession {
         } as ProgramAbiPlanEntry);
       }
       abi.sealPlan();
+      this.sealedAbi = abi;
+      this.state = "sealed";
+      return abi;
+    } catch (error) {
+      this.state = "failed";
+      throw error;
+    }
+  }
 
+  /**
+   * Resolve the sealed plan against the module's final exact object layout,
+   * bind every required index, and publish the compatibility view once.
+   */
+  bindAndPublish(module: WasmModule = this.module): PublishedProgramAbi {
+    this.assertModule(module);
+    if (this.state !== "sealed") {
+      throw new ProgramAbiInvariantError(
+        this.state === "planning" ? "planning-not-sealed" : "session-publish-once",
+        `ProgramAbiSession final binding requires a sealed unpublished plan (${this.state})`,
+      );
+    }
+    this.state = "binding";
+    try {
+      const abi = this.sealedAbi!;
       for (const entry of abi.entries()) {
+        const draft = this.drafts.get(entry.id);
+        if (!draft) {
+          throw new ProgramAbiInvariantError(
+            "unknown-binding",
+            `sealed ABI binding ${entry.id} no longer has its session draft`,
+          );
+        }
+        const finalizedDraft = this.materializeTypeContract(draft, module);
+        if (!intentsEqual(entry.intent, finalizedDraft.intent)) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `ABI binding ${entry.id} changed its sealed type contract before final binding`,
+          );
+        }
         if (entry.slotPolicy !== "required") continue;
         const locator = this.locators.get(entry.id);
         if (!locator) {
@@ -1135,6 +1176,25 @@ export class ProgramAbiSession {
       this.state = "failed";
       throw error;
     }
+  }
+
+  /**
+   * Compatibility wrapper that seals planning and publishes final bindings in
+   * one call.
+   *
+   * A failed seal or publication closes the session: callers must fix the
+   * producer and rebuild instead of mutating a partially observed plan.
+   */
+  publish(module: WasmModule): PublishedProgramAbi {
+    this.assertModule(module);
+    if (this.state !== "planning" && this.state !== "sealed") {
+      throw new ProgramAbiInvariantError(
+        "session-publish-once",
+        `ProgramAbiSession publish was already attempted (${this.state})`,
+      );
+    }
+    this.sealPlan(module);
+    return this.bindAndPublish(module);
   }
 
   private materializeTypeContract(draft: ProgramAbiDraft, module: WasmModule): ProgramAbiDraft {
@@ -1264,11 +1324,20 @@ export class ProgramAbiSession {
     }
   }
 
-  private assertOpen(action: string): void {
-    if (this.state !== "open") {
+  private assertPlanning(action: string): void {
+    if (this.state !== "planning") {
       throw new ProgramAbiInvariantError(
         "session-closed",
         `cannot ${action} after ProgramAbiSession left planning state (${this.state})`,
+      );
+    }
+  }
+
+  private assertLayoutMutable(action: string): void {
+    if (this.state !== "planning" && this.state !== "sealed") {
+      throw new ProgramAbiInvariantError(
+        "session-closed",
+        `cannot ${action} after ProgramAbiSession left the layout phase (${this.state})`,
       );
     }
   }
@@ -1328,7 +1397,7 @@ export class ProgramAbiSession {
     previous: T,
     replacement: T,
   ): void {
-    this.assertOpen(`replace slot locator for ${id}`);
+    this.assertLayoutMutable(`replace slot locator for ${id}`);
     const draft = this.drafts.get(id);
     if (!draft) {
       throw new ProgramAbiInvariantError("unknown-locator-binding", `slot locator targets unplanned ABI draft ${id}`);

--- a/src/codegen/program-abi-session.ts
+++ b/src/codegen/program-abi-session.ts
@@ -7,6 +7,7 @@ import {
   ProgramAbiInvariantError,
   ProgramAbiMap,
   type ProgramAbiDerivedUnitRecord,
+  type ProgramAbiFinalIndex,
   type ProgramAbiPlanEntry,
   type ProgramAbiSlotSpace,
 } from "../ir/program-abi.js";
@@ -409,6 +410,17 @@ export interface PublishedProgramAbi {
   readonly legacy: LegacyAbiAdapter;
 }
 
+/**
+ * Read-only evidence that the session's structural intentions were validated
+ * and sealed. Final-index mutation remains private to ProgramAbiSession.
+ */
+export interface SealedProgramAbiPlan {
+  readonly planningSealed: true;
+  entries(): readonly ProgramAbiPlanEntry[];
+  get(id: IrBindingId): ProgramAbiPlanEntry | undefined;
+  canonicalId(id: IrBindingId): IrBindingId;
+}
+
 type SessionState = "planning" | "sealing" | "sealed" | "binding" | "published" | "failed";
 
 function validOrdinal(value: number): boolean {
@@ -559,6 +571,25 @@ function compareDrafts(
   );
 }
 
+function createSealedProgramAbiPlanView(
+  abi: ProgramAbiMap,
+  currentEntries: () => readonly ProgramAbiPlanEntry[],
+): SealedProgramAbiPlan {
+  const canonicalIds = new Map(abi.entries().map((entry) => [entry.id, abi.canonicalId(entry.id)] as const));
+  return Object.freeze({
+    planningSealed: true as const,
+    entries: currentEntries,
+    get: (id: IrBindingId) => currentEntries().find((entry) => entry.id === id),
+    canonicalId: (id: IrBindingId) => {
+      const canonicalId = canonicalIds.get(id);
+      if (canonicalId === undefined) {
+        throw new ProgramAbiInvariantError("unknown-binding", `binding ${id} was not planned`);
+      }
+      return canonicalId;
+    },
+  });
+}
+
 /**
  * Compilation-owned mutable staging area for ProgramAbiMap.
  *
@@ -581,7 +612,8 @@ export class ProgramAbiSession {
   private readonly callableTypeContracts = new Map<IrBindingId, ProgramAbiCallableTypeContract>();
   private readonly globalTypeContracts = new Map<IrBindingId, ProgramAbiGlobalTypeContract>();
   private state: SessionState = "planning";
-  private sealedAbi: ProgramAbiMap | undefined;
+  private sealedDrafts: readonly ProgramAbiDraft[] | undefined;
+  private sealedPlanView: SealedProgramAbiPlan | undefined;
   private publishedValue: PublishedProgramAbi | undefined;
   readonly structuralOrder: ProgramAbiStructuralOrder;
 
@@ -1084,9 +1116,9 @@ export class ProgramAbiSession {
    * locators may still follow body replacement or layout compaction before
    * final binding.
    */
-  sealPlan(module: WasmModule = this.module): ProgramAbiMap {
+  sealPlan(module: WasmModule = this.module): SealedProgramAbiPlan {
     this.assertModule(module);
-    if (this.state === "sealed" || this.state === "published") return this.sealedAbi!;
+    if (this.state === "sealed" || this.state === "published") return this.sealedPlanView!;
     if (this.state !== "planning") {
       throw new ProgramAbiInvariantError(
         "session-closed",
@@ -1095,26 +1127,23 @@ export class ProgramAbiSession {
     }
     this.state = "sealing";
     try {
-      const abi = new ProgramAbiMap(this.inventory, [...this.derivedUnits.values()]);
       const drafts = [...this.drafts.values()].sort((a, b) => compareDrafts(this.sourceOrderById, a, b));
-      const denseOrderBySource = new Map<IrSourceId, number>();
-      for (const queuedDraft of drafts) {
-        const draft = this.materializeTypeContract(queuedDraft, module);
-        const { structuralOrder, ...planned } = draft;
-        const declarationOrder = denseOrderBySource.get(structuralOrder.sourceId) ?? 0;
-        denseOrderBySource.set(structuralOrder.sourceId, declarationOrder + 1);
-        abi.plan({
-          ...planned,
-          order: {
-            sourceOrder: this.sourceOrderById.get(structuralOrder.sourceId)!,
-            declarationOrder,
-          },
-        } as ProgramAbiPlanEntry);
+      const abi = this.buildSealedAbi(drafts, module);
+      for (const entry of abi.entries()) {
+        if (entry.slotPolicy === "required" && !this.locators.has(entry.id)) {
+          throw new ProgramAbiInvariantError(
+            "missing-required-locator",
+            `required ABI binding ${entry.id} has no allocator locator at the planning seal`,
+          );
+        }
       }
-      abi.sealPlan();
-      this.sealedAbi = abi;
+      this.sealedDrafts = Object.freeze([...drafts]);
+      const view = createSealedProgramAbiPlanView(abi, () =>
+        this.buildSealedAbi(this.sealedDrafts!, this.module).entries(),
+      );
+      this.sealedPlanView = view;
       this.state = "sealed";
-      return abi;
+      return view;
     } catch (error) {
       this.state = "failed";
       throw error;
@@ -1135,22 +1164,13 @@ export class ProgramAbiSession {
     }
     this.state = "binding";
     try {
-      const abi = this.sealedAbi!;
+      const abi = this.buildSealedAbi(this.sealedDrafts!, module);
+      const pendingBindings: Array<{
+        readonly id: IrBindingId;
+        readonly finalIndex: ProgramAbiFinalIndex;
+      }> = [];
+      const pendingOwners = new Map<string, IrBindingId>();
       for (const entry of abi.entries()) {
-        const draft = this.drafts.get(entry.id);
-        if (!draft) {
-          throw new ProgramAbiInvariantError(
-            "unknown-binding",
-            `sealed ABI binding ${entry.id} no longer has its session draft`,
-          );
-        }
-        const finalizedDraft = this.materializeTypeContract(draft, module);
-        if (!intentsEqual(entry.intent, finalizedDraft.intent)) {
-          throw new ProgramAbiInvariantError(
-            "type-remap-mismatch",
-            `ABI binding ${entry.id} changed its sealed type contract before final binding`,
-          );
-        }
         if (entry.slotPolicy !== "required") continue;
         const locator = this.locators.get(entry.id);
         if (!locator) {
@@ -1159,11 +1179,22 @@ export class ProgramAbiSession {
             `required ABI binding ${entry.id} has no allocator locator`,
           );
         }
-        abi.bindFinalIndex(entry.id, {
+        const finalIndex: ProgramAbiFinalIndex = Object.freeze({
           space: entry.slotSpace,
           index: this.resolveLocator(module, entry.id, locator),
         });
+        const key = `${finalIndex.space}:${finalIndex.index}`;
+        const previousOwner = pendingOwners.get(key);
+        if (previousOwner !== undefined) {
+          throw new ProgramAbiInvariantError(
+            "final-index-collision",
+            `bindings ${previousOwner} and ${entry.id} cannot share non-alias index ${key}`,
+          );
+        }
+        pendingOwners.set(key, entry.id);
+        pendingBindings.push(Object.freeze({ id: entry.id, finalIndex }));
       }
+      for (const binding of pendingBindings) abi.bindFinalIndex(binding.id, binding.finalIndex);
       abi.finishBinding();
       const publication = Object.freeze({
         abi,
@@ -1195,6 +1226,26 @@ export class ProgramAbiSession {
     }
     this.sealPlan(module);
     return this.bindAndPublish(module);
+  }
+
+  private buildSealedAbi(drafts: readonly ProgramAbiDraft[], module: WasmModule): ProgramAbiMap {
+    const abi = new ProgramAbiMap(this.inventory, [...this.derivedUnits.values()]);
+    const denseOrderBySource = new Map<IrSourceId, number>();
+    for (const queuedDraft of drafts) {
+      const draft = this.materializeTypeContract(queuedDraft, module);
+      const { structuralOrder, ...planned } = draft;
+      const declarationOrder = denseOrderBySource.get(structuralOrder.sourceId) ?? 0;
+      denseOrderBySource.set(structuralOrder.sourceId, declarationOrder + 1);
+      abi.plan({
+        ...planned,
+        order: {
+          sourceOrder: this.sourceOrderById.get(structuralOrder.sourceId)!,
+          declarationOrder,
+        },
+      } as ProgramAbiPlanEntry);
+    }
+    abi.sealPlan();
+    return abi;
   }
 
   private materializeTypeContract(draft: ProgramAbiDraft, module: WasmModule): ProgramAbiDraft {

--- a/tests/issue-3521-prepared-ir-program.test.ts
+++ b/tests/issue-3521-prepared-ir-program.test.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import { ProgramAbiSession, type ProgramAbiDraft } from "../src/codegen/program-abi-session.js";
+import { buildIrUnitInventory, createIrBindingId, type IrBindingId } from "../src/ir/identity.js";
+import { ProgramAbiInvariantError, type ProgramAbiInvariantCode } from "../src/ir/program-abi.js";
+import { createEmptyModule, type TypeDef, type WasmFunction } from "../src/ir/types.js";
+import { ts } from "../src/ts-api.js";
+
+const VOID_SIGNATURE = Object.freeze({
+  params: Object.freeze([]),
+  results: Object.freeze([]),
+});
+
+function expectInvariant(action: () => unknown, code: ProgramAbiInvariantCode): void {
+  let caught: unknown;
+  try {
+    action();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(ProgramAbiInvariantError);
+  expect((caught as ProgramAbiInvariantError).code).toBe(code);
+}
+
+function fixture() {
+  const sourceFile = ts.createSourceFile(
+    "/repo/session-seal.ts",
+    "export function value(): number { return 1; }",
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
+  const unit = inventory.allUnits.find((candidate) => candidate.kind === "top-level-function");
+  if (!unit) throw new Error("missing function inventory unit");
+  return { inventory, sourceId: inventory.sources[0]!.id, unit };
+}
+
+function functionDraft(
+  session: ProgramAbiSession,
+  id: IrBindingId,
+  unitId: ReturnType<typeof fixture>["unit"]["id"],
+  structuralReferenceKey: string,
+): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: session.structuralOrder.forUnit(unitId, {
+      domain: "callable",
+      roleOrdinal: 0,
+    }),
+    displayName: "value",
+    structuralReferenceKey,
+    slotPolicy: "required",
+    slotSpace: "function",
+    intent: {
+      kind: "callable",
+      origin: "source",
+      signature: VOID_SIGNATURE,
+      unitId,
+    },
+  };
+}
+
+function wasmFunction(name: string): WasmFunction {
+  return { name, typeIdx: 0, locals: [], body: [], exported: false };
+}
+
+describe("#3521 Program ABI plan sealing", () => {
+  it("seals intentions before exact replacement and binds the final shifted function index once", () => {
+    const { inventory, sourceId, unit } = fixture();
+    const module = createEmptyModule();
+    module.types.push({ kind: "func", name: "$void", params: [], results: [] });
+    const original = wasmFunction("value$planned");
+    module.functions.push(original);
+
+    const session = new ProgramAbiSession(inventory, module);
+    const bindingId = createIrBindingId({ ownerId: unit.id, domain: "callable", role: "body" });
+    const referenceKey = `unit|${unit.id}|body`;
+    session.plan(functionDraft(session, bindingId, unit.id, referenceKey));
+    session.registerCallableTypeContract(bindingId, VOID_SIGNATURE);
+    session.attachLocator(bindingId, { kind: "defined-function", value: original });
+
+    const sealed = session.sealPlan(module);
+    expect(sealed.planningSealed).toBe(true);
+    expect(sealed.resolveFinalIndex(bindingId)).toBeUndefined();
+    expect(session.sealPlan(module)).toBe(sealed);
+
+    const lateBinding = createIrBindingId({ ownerId: sourceId, domain: "support", role: "late" });
+    expectInvariant(
+      () =>
+        session.plan({
+          id: lateBinding,
+          structuralOrder: session.structuralOrder.forSource(sourceId, {
+            domain: "support",
+            roleOrdinal: 0,
+          }),
+          displayName: "late",
+          slotPolicy: "none",
+          intent: { kind: "support", role: "late" },
+        }),
+      "session-closed",
+    );
+
+    const replacement = wasmFunction("value$emitted");
+    module.functions[0] = replacement;
+    session.replaceDefinedFunctionLocator(bindingId, original, replacement);
+
+    module.imports.push({
+      module: "env",
+      name: "late_import",
+      desc: { kind: "func", typeIdx: 0 },
+    });
+    expect(session.resolveCurrentIndex(bindingId, "function", referenceKey, module)).toBe(1);
+
+    const publication = session.bindAndPublish(module);
+    expect(publication.abi).toBe(sealed);
+    expect(publication.abi.resolveFinalIndex(bindingId)).toEqual({ space: "function", index: 1 });
+    expect(session.publication).toBe(publication);
+    expect(session.resolveCurrentIndex(bindingId, "function", referenceKey, module)).toBe(1);
+    expectInvariant(() => session.bindAndPublish(module), "session-publish-once");
+    expectInvariant(() => session.publish(module), "session-publish-once");
+  });
+
+  it("allows an exact type-cell DCE remap after sealing and binds only the retained object", () => {
+    const { inventory, sourceId } = fixture();
+    const module = createEmptyModule();
+    const removed: TypeDef = { kind: "struct", name: "$Removed", fields: [] };
+    const planned: TypeDef = { kind: "struct", name: "$Record$planned", fields: [] };
+    module.types.push(removed, planned);
+
+    const session = new ProgramAbiSession(inventory, module);
+    const bindingId = createIrBindingId({ ownerId: sourceId, domain: "type", role: "record" });
+    const referenceKey = `type|${bindingId}`;
+    session.plan({
+      id: bindingId,
+      structuralOrder: session.structuralOrder.forSource(sourceId, {
+        domain: "type",
+        roleOrdinal: 0,
+      }),
+      displayName: "$Record",
+      structuralReferenceKey: referenceKey,
+      slotPolicy: "required",
+      slotSpace: "type",
+      intent: { kind: "type", shapeKey: "struct:record" },
+    });
+    const cell = session.createTypeCell(planned);
+    session.attachLocator(bindingId, { kind: "type-cell", cell });
+
+    const sealed = session.sealPlan(module);
+    const retained: TypeDef = { kind: "struct", name: "$Record$retained", fields: [] };
+    session.remapTypeCell(cell, retained);
+    module.types = [retained];
+
+    expect(session.resolveCurrentIndex(bindingId, "type", referenceKey, module)).toBe(0);
+    const publication = session.bindAndPublish(module);
+    expect(publication.abi).toBe(sealed);
+    expect(publication.abi.resolveFinalIndex(bindingId)).toEqual({ space: "type", index: 0 });
+  });
+});

--- a/tests/issue-3521-prepared-ir-program.test.ts
+++ b/tests/issue-3521-prepared-ir-program.test.ts
@@ -1,10 +1,25 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { describe, expect, it } from "vitest";
+import {
+  canonicalProgramAbiCallableTypeContract,
+  canonicalProgramAbiValType,
+} from "../src/codegen/program-abi-signatures.js";
 import { ProgramAbiSession, type ProgramAbiDraft } from "../src/codegen/program-abi-session.js";
-import { buildIrUnitInventory, createIrBindingId, type IrBindingId } from "../src/ir/identity.js";
+import {
+  buildIrUnitInventory,
+  createDerivedIrUnitId,
+  createIrBindingId,
+  type IrBindingId,
+} from "../src/ir/identity.js";
 import { ProgramAbiInvariantError, type ProgramAbiInvariantCode } from "../src/ir/program-abi.js";
-import { createEmptyModule, type TypeDef, type WasmFunction } from "../src/ir/types.js";
+import {
+  createEmptyModule,
+  type FuncTypeDef,
+  type GlobalDef,
+  type TypeDef,
+  type WasmFunction,
+} from "../src/ir/types.js";
 import { ts } from "../src/ts-api.js";
 
 const VOID_SIGNATURE = Object.freeze({
@@ -26,15 +41,20 @@ function expectInvariant(action: () => unknown, code: ProgramAbiInvariantCode): 
 function fixture() {
   const sourceFile = ts.createSourceFile(
     "/repo/session-seal.ts",
-    "export function value(): number { return 1; }",
+    "export function value(): number { return 1; } function other(): number { return 2; }",
     ts.ScriptTarget.Latest,
     true,
     ts.ScriptKind.TS,
   );
   const inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
-  const unit = inventory.allUnits.find((candidate) => candidate.kind === "top-level-function");
-  if (!unit) throw new Error("missing function inventory unit");
-  return { inventory, sourceId: inventory.sources[0]!.id, unit };
+  const unit = inventory.allUnits.find(
+    (candidate) => candidate.kind === "top-level-function" && candidate.displayName === "value",
+  );
+  const otherUnit = inventory.allUnits.find(
+    (candidate) => candidate.kind === "top-level-function" && candidate.displayName === "other",
+  );
+  if (!unit || !otherUnit) throw new Error("missing function inventory unit");
+  return { inventory, sourceId: inventory.sources[0]!.id, unit, otherUnit };
 }
 
 function functionDraft(
@@ -83,8 +103,19 @@ describe("#3521 Program ABI plan sealing", () => {
 
     const sealed = session.sealPlan(module);
     expect(sealed.planningSealed).toBe(true);
-    expect(sealed.resolveFinalIndex(bindingId)).toBeUndefined();
     expect(session.sealPlan(module)).toBe(sealed);
+    expect("bindFinalIndex" in sealed).toBe(false);
+    expect("finishBinding" in sealed).toBe(false);
+    expect(() =>
+      (
+        sealed as typeof sealed & {
+          bindFinalIndex(id: IrBindingId, value: { space: "function"; index: number }): void;
+        }
+      ).bindFinalIndex(bindingId, { space: "function", index: 99 }),
+    ).toThrow(TypeError);
+    const sealedEntry = sealed.get(bindingId)!;
+    expect(Object.isFrozen(sealedEntry)).toBe(true);
+    expect(Reflect.set(sealedEntry, "displayName", "tampered")).toBe(false);
 
     const lateBinding = createIrBindingId({ ownerId: sourceId, domain: "support", role: "late" });
     expectInvariant(
@@ -101,6 +132,34 @@ describe("#3521 Program ABI plan sealing", () => {
         }),
       "session-closed",
     );
+    expectInvariant(
+      () => session.ensurePlan(functionDraft(session, bindingId, unit.id, referenceKey)),
+      "session-closed",
+    );
+    expectInvariant(() => session.registerStructuralReference(bindingId, referenceKey), "session-closed");
+    const derivedId = createDerivedIrUnitId({
+      parentId: unit.id,
+      role: "lifted-closure",
+      ordinal: 0,
+    });
+    expectInvariant(
+      () =>
+        session.registerDerivedUnit({
+          id: derivedId,
+          parentId: unit.id,
+          terminalOwnerId: unit.terminalOwnerId,
+          sourceId: unit.sourceId,
+          role: "lifted-closure",
+          ordinal: 0,
+        }),
+      "session-closed",
+    );
+    expectInvariant(() => session.registerCallableTypeContract(bindingId, VOID_SIGNATURE), "session-closed");
+    expectInvariant(() => session.createTypeCell({ kind: "struct", name: "$Late", fields: [] }), "session-closed");
+    expectInvariant(
+      () => session.attachLocator(bindingId, { kind: "defined-function", value: original }),
+      "session-closed",
+    );
 
     const replacement = wasmFunction("value$emitted");
     module.functions[0] = replacement;
@@ -114,10 +173,18 @@ describe("#3521 Program ABI plan sealing", () => {
     expect(session.resolveCurrentIndex(bindingId, "function", referenceKey, module)).toBe(1);
 
     const publication = session.bindAndPublish(module);
-    expect(publication.abi).toBe(sealed);
+    expect(publication.abi).not.toBe(sealed);
     expect(publication.abi.resolveFinalIndex(bindingId)).toEqual({ space: "function", index: 1 });
     expect(session.publication).toBe(publication);
     expect(session.resolveCurrentIndex(bindingId, "function", referenceKey, module)).toBe(1);
+    expectInvariant(
+      () => session.replaceDefinedFunctionLocator(bindingId, replacement, wasmFunction("post-publish")),
+      "session-closed",
+    );
+    expectInvariant(
+      () => session.remapTypeObject(module.types[0]!, { kind: "func", name: "$other", params: [], results: [] }),
+      "session-closed",
+    );
     expectInvariant(() => session.bindAndPublish(module), "session-publish-once");
     expectInvariant(() => session.publish(module), "session-publish-once");
   });
@@ -154,7 +221,159 @@ describe("#3521 Program ABI plan sealing", () => {
 
     expect(session.resolveCurrentIndex(bindingId, "type", referenceKey, module)).toBe(0);
     const publication = session.bindAndPublish(module);
-    expect(publication.abi).toBe(sealed);
+    expect(publication.abi).not.toBe(sealed);
     expect(publication.abi.resolveFinalIndex(bindingId)).toEqual({ space: "type", index: 0 });
+  });
+
+  it("re-materializes callable and global type-index contracts after a post-seal layout remap", () => {
+    const { inventory, sourceId, unit } = fixture();
+    const module = createEmptyModule();
+    const removed: TypeDef = { kind: "struct", name: "$Removed", fields: [] };
+    const payload: TypeDef = { kind: "struct", name: "$Payload$planned", fields: [] };
+    const callableType: FuncTypeDef = {
+      kind: "func",
+      name: "$callable$planned",
+      params: [{ kind: "ref", typeIdx: 1 }],
+      results: [{ kind: "ref_null", typeIdx: 1 }],
+    };
+    module.types.push(removed, payload, callableType);
+    const callable = wasmFunction("value$planned");
+    callable.typeIdx = 2;
+    const global: GlobalDef = {
+      name: "state$planned",
+      type: { kind: "ref_null", typeIdx: 1 },
+      mutable: true,
+      init: [{ op: "ref.null", typeIdx: 1 }],
+    };
+    module.functions.push(callable);
+    module.globals.push(global);
+
+    const session = new ProgramAbiSession(inventory, module);
+    const callableId = createIrBindingId({ ownerId: unit.id, domain: "callable", role: "body" });
+    const globalId = createIrBindingId({ ownerId: sourceId, domain: "global", role: "state" });
+    session.plan({
+      id: callableId,
+      structuralOrder: session.structuralOrder.forUnit(unit.id, {
+        domain: "callable",
+        roleOrdinal: 0,
+      }),
+      displayName: "value",
+      slotPolicy: "required",
+      slotSpace: "function",
+      intent: {
+        kind: "callable",
+        origin: "source",
+        signature: canonicalProgramAbiCallableTypeContract(callableType),
+        unitId: unit.id,
+      },
+    });
+    session.registerCallableTypeContract(callableId, callableType);
+    session.attachLocator(callableId, { kind: "defined-function", value: callable });
+    session.plan({
+      id: globalId,
+      structuralOrder: session.structuralOrder.forSource(sourceId, {
+        domain: "global",
+        roleOrdinal: 0,
+      }),
+      displayName: "state",
+      slotPolicy: "required",
+      slotSpace: "global",
+      intent: {
+        kind: "global",
+        origin: "source",
+        valueType: canonicalProgramAbiValType(global.type),
+        mutable: true,
+      },
+    });
+    session.registerGlobalTypeContract(globalId, global.type, global.mutable);
+    session.attachLocator(globalId, { kind: "defined-global", value: global });
+
+    const sealed = session.sealPlan(module);
+    const sealedCallableIntent = sealed.get(callableId)!.intent;
+    const sealedGlobalIntent = sealed.get(globalId)!.intent;
+    expect(sealedCallableIntent.kind === "callable" ? sealedCallableIntent.signature.params : []).toEqual([
+      '{"kind":"ref","typeIdx":1}',
+    ]);
+    expect(sealedGlobalIntent.kind === "global" ? sealedGlobalIntent.valueType : "").toBe(
+      '{"kind":"ref_null","typeIdx":1}',
+    );
+
+    const finalPayload: TypeDef = { kind: "struct", name: "$Payload$final", fields: [] };
+    const finalCallableType: FuncTypeDef = {
+      kind: "func",
+      name: "$callable$final",
+      params: [{ kind: "ref", typeIdx: 0 }],
+      results: [{ kind: "ref_null", typeIdx: 0 }],
+    };
+    const previousTypes = module.types;
+    const nextTypes = [finalPayload, finalCallableType];
+    session.applyTypeLayoutRemap({
+      previousTypes,
+      nextTypes,
+      targetsByOldIndex: [null, 0, 1],
+    });
+    module.types = nextTypes;
+    callable.typeIdx = 1;
+    global.type = { kind: "ref_null", typeIdx: 0 };
+    global.init = [{ op: "ref.null", typeIdx: 0 }];
+
+    const remappedCallableIntent = sealed.get(callableId)!.intent;
+    const remappedGlobalIntent = sealed.get(globalId)!.intent;
+    expect(remappedCallableIntent.kind === "callable" ? remappedCallableIntent.signature.params : []).toEqual([
+      '{"kind":"ref","typeIdx":0}',
+    ]);
+    expect(remappedGlobalIntent.kind === "global" ? remappedGlobalIntent.valueType : "").toBe(
+      '{"kind":"ref_null","typeIdx":0}',
+    );
+
+    const publication = session.bindAndPublish(module);
+    expect(publication.abi.get(callableId)?.intent).toEqual(remappedCallableIntent);
+    expect(publication.abi.get(globalId)?.intent).toEqual(remappedGlobalIntent);
+    expect(publication.abi.resolveFinalIndex(callableId)).toEqual({ space: "function", index: 0 });
+    expect(publication.abi.resolveFinalIndex(globalId)).toEqual({ space: "global", index: 0 });
+  });
+
+  it("rejects unsealed binding and atomically fails a required draft without its planning locator", () => {
+    const { inventory, unit } = fixture();
+    const module = createEmptyModule();
+    module.types.push({ kind: "func", name: "$void", params: [], results: [] });
+    const session = new ProgramAbiSession(inventory, module);
+    expectInvariant(() => session.bindAndPublish(module), "planning-not-sealed");
+
+    const bindingId = createIrBindingId({ ownerId: unit.id, domain: "callable", role: "body" });
+    session.plan(functionDraft(session, bindingId, unit.id, `unit|${unit.id}|body`));
+    expectInvariant(() => session.sealPlan(module), "missing-required-locator");
+    expect(session.publication).toBeUndefined();
+    expectInvariant(
+      () => session.attachLocator(bindingId, { kind: "defined-function", value: wasmFunction("late") }),
+      "session-closed",
+    );
+    expectInvariant(() => session.sealPlan(module), "session-closed");
+    expectInvariant(() => session.publish(module), "session-publish-once");
+  });
+
+  it("validates every final locator before committing any index when a later entry was eliminated", () => {
+    const { inventory, unit, otherUnit } = fixture();
+    const module = createEmptyModule();
+    module.types.push({ kind: "func", name: "$void", params: [], results: [] });
+    const first = wasmFunction("first");
+    const second = wasmFunction("second");
+    module.functions.push(first, second);
+
+    const session = new ProgramAbiSession(inventory, module);
+    const firstId = createIrBindingId({ ownerId: unit.id, domain: "callable", role: "body" });
+    const secondId = createIrBindingId({ ownerId: otherUnit.id, domain: "callable", role: "body" });
+    session.plan(functionDraft(session, firstId, unit.id, `unit|${unit.id}|body`));
+    session.plan(functionDraft(session, secondId, otherUnit.id, `unit|${otherUnit.id}|body`));
+    session.attachLocator(firstId, { kind: "defined-function", value: first });
+    session.attachLocator(secondId, { kind: "defined-function", value: second });
+    const sealed = session.sealPlan(module);
+
+    module.functions = [first];
+    expectInvariant(() => session.bindAndPublish(module), "eliminated-required-locator");
+    expect(session.publication).toBeUndefined();
+    expect("resolveFinalIndex" in sealed).toBe(false);
+    expectInvariant(() => session.bindAndPublish(module), "session-publish-once");
+    expectInvariant(() => session.publish(module), "session-publish-once");
   });
 });


### PR DESCRIPTION
## Summary

- split ProgramAbiSession publication into an explicit deterministic plan seal and a later final-index binding phase
- keep publish() as the behavior-compatible wrapper, so production routing and generated output remain unchanged
- expose only a frozen read-only SealedProgramAbiPlan after sealing; final-index mutation stays private
- rebuild callable, global, and type contracts from post-DCE remap sidecars before publication
- validate all final locators, indices, and collisions before committing any binding
- reject missing required locators atomically at seal time and reject all late planning intentions

## IR retirement role

This is the first narrow #3521 preparation slice. It establishes the ABI half of the prepare-before-emit boundary without flipping IR-only routing or claiming free-function body ownership. The larger PreparedIrProgram extraction remains sequenced behind the remaining #3520 structural consumers and the central IR integration work.

## Validation

- 25 Program ABI test files, 112/112 tests
- adversarial second review passed after fixing real callable/global DCE remapping, external binding capability, partial binding, and locator-completeness defects
- TypeScript typecheck
- Prettier check
- IR fallback ratchet
- LOC and function budgets
- markdown issue consistency and optimization-retirement ledger checks

Tracks the session-seal continuation in plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md.