### PR TITLE
feat(ir): emit retained Acorn parser wrappers

### DIFF
--- a/plan/issues/3793-ir-acorn-retained-parser-wrappers.md
+++ b/plan/issues/3793-ir-acorn-retained-parser-wrappers.md
@@ -81,6 +81,8 @@ general conversion of function values or closures.
       and execute with their required receiver.
 - [x] Negative tests keep reassigned, aliased, generic, and receiver-ambiguous
       retained targets on direct codegen.
+- [x] Concrete-result dispatcher calls and arguments without a proven bridge
+      are rejected before claim, with zero post-claim withdrawals.
 - [x] The unchanged exact Acorn driver reports its measured emitted-name
       count, checksum 422, zero imports, and zero post-claim withdrawals.
 - [x] All 27 previously emitted Acorn names remain emitted.
@@ -94,6 +96,10 @@ general conversion of function values or closures.
   `parseExpressionAt`, and `tokenizer`; none of the previous 27 withdrew.
 - Runtime remains checksum 422 with zero Wasm imports and zero post-claim
   withdrawals.
+- Adversarial ABI coverage keeps typed string-result wrappers on direct
+  codegen because the closed dispatcher still returns boxed dynamic, and
+  rejects boolean-parameter wrappers before claim because their unbranded i32
+  argument has no proven box at this bridge.
 - A same-host paired measurement recorded 49.415 ms/op for this slice versus
   49.954 ms/op for its #3791 parent (about 1.1% faster). The migration win is
   the three additional IR bodies; the runtime delta is small enough to treat as

--- a/plan/issues/3793-ir-acorn-retained-parser-wrappers.md
+++ b/plan/issues/3793-ir-acorn-retained-parser-wrappers.md
@@ -1,0 +1,104 @@
+---
+id: 3793
+title: "IR retained Acorn parser wrapper projection"
+status: done
+sprint: current
+created: 2026-07-30
+updated: 2026-07-30
+priority: high
+horizon: s
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: ir
+es_edition: multi
+language_feature: functions
+goal: ir-full-coverage
+parent: 3522
+depends_on: [3791]
+related: [3583]
+assignee: ttraenkler/codex-ir-parser-wrappers
+branch: codex/3793-ir-acorn-retained-parser-wrappers
+files:
+  - src/ir/select.ts
+  - src/ir/from-ast.ts
+  - src/ir/module-bindings.ts
+  - src/ir/integration.ts
+  - src/codegen/index.ts
+  - tests/issue-3793-ir-acorn-retained-parser-wrappers.test.ts
+loc-budget-allow:
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/module-bindings.ts
+  - src/ir/select.ts
+  - src/codegen/index.ts
+func-budget-allow:
+  - src/codegen/index.ts::makeIrImplicitParamTypeResolver
+  - src/codegen/index.ts::planIrOverlay
+  - src/ir/from-ast.ts::lowerMethodCall
+  - src/ir/from-ast.ts::lowerCall
+  - src/ir/integration.ts::compileIrPathFunctions
+  - src/ir/integration.ts::makeFromAstResolver
+  - src/ir/module-bindings.ts::buildModuleBindings
+  - src/ir/select.ts::dynamicUsesAreMoveOnly
+  - src/ir/select.ts::isPhase1Expr
+---
+
+# #3793 — project retained Acorn parser wrapper targets into IR
+
+## Problem
+
+After #3791, Acorn's exact runtime-dynamic standalone build emits 27 of 43
+reachable functions through IR. The public module wrappers `parse`,
+`parseExpressionAt`, and `tokenizer` remain direct because their exact static
+targets are retained module `FunctionExpression` values rather than ordinary
+function declarations.
+
+The retained closure identity and receiver semantics already exist in the
+direct path. The IR needs a narrow projection of those exact targets, not a
+general conversion of function values or closures.
+
+## Scope
+
+- Resolve only stable retained module `FunctionExpression` values whose exact
+  target is known before IR selection.
+- Preserve the existing retained closure identity rather than synthesizing a
+  second callable.
+- Preserve call receiver semantics. In particular, `Parser.parse` contains
+  `new this(...)`; it must not be rewritten into or invoked as a bare call.
+- Keep aliases, reassigned bindings, polymorphic/generic retained closures,
+  and receiver-ambiguous calls on direct codegen. Captures remain owned by the
+  retained direct FunctionExpression body; the IR wrapper must preserve that
+  existing closure rather than copy it.
+- Preserve the #3808 numeric-local, closed-token-table, and
+  `Parser.options` representation decisions.
+- Do not claim the called `FunctionExpression` bodies are IR-emitted or that
+  their direct bodies can be retired.
+
+## Acceptance criteria
+
+- [x] Focused positive tests prove exact retained module wrapper targets emit
+      and execute with their required receiver.
+- [x] Negative tests keep reassigned, aliased, generic, and receiver-ambiguous
+      retained targets on direct codegen.
+- [x] The unchanged exact Acorn driver reports its measured emitted-name
+      count, checksum 422, zero imports, and zero post-claim withdrawals.
+- [x] All 27 previously emitted Acorn names remain emitted.
+- [x] Focused and adjacent tests, typecheck, formatting, IR fallback ratchet,
+      and function/LOC budget gates pass.
+
+## Result
+
+- The exact runtime-dynamic Acorn driver emits 30 of 43 reachable functions
+  through IR, up from 27 of 43. The new names are `parse`,
+  `parseExpressionAt`, and `tokenizer`; none of the previous 27 withdrew.
+- Runtime remains checksum 422 with zero Wasm imports and zero post-claim
+  withdrawals.
+- A same-host paired measurement recorded 49.415 ms/op for this slice versus
+  49.954 ms/op for its #3791 parent (about 1.1% faster). The migration win is
+  the three additional IR bodies; the runtime delta is small enough to treat as
+  neutral.
+- Focused proof: `tests/issue-3793-ir-acorn-retained-parser-wrappers.test.ts`.
+  Adjacent coverage: #3791, #3790, and #1712 focused suites.
+- The retained method FunctionExpression bodies and closed dispatcher remain
+  direct-codegen-owned. This slice does not retire that path.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1887,7 +1887,7 @@ function makeIrImplicitParamTypeResolver(
             argument &&
             ts.isIdentifier(argument) &&
             ts.isIdentifier(candidate.name) &&
-            ctx.checker.getSymbolAtLocation(argument) === ctx.checker.getSymbolAtLocation(candidate.name)
+            ctx.oracle.valueDeclarationOf(argument) === ctx.oracle.valueDeclarationOf(candidate.name)
           ) {
             projected.add(candidate);
           }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -81,6 +81,7 @@ import {
   makeIrModuleBindingResolver,
   makeIrPrimitiveExpressionClassifier,
   makeIrRegExpExpressionPredicate,
+  type IrModuleBindingResolver,
 } from "../ir/module-bindings.js"; // (#2856 Capability C)
 import { asyncEngineWouldActivate } from "./async-activation.js"; // (#1373b C-1)
 import { unwrapPromiseTypeNode } from "./async-static.js"; // (#1373b C-1)
@@ -1861,6 +1862,7 @@ interface IrImplicitParamProjection {
 function makeIrImplicitParamTypeResolver(
   ctx: CodegenContext,
   sourceFile: ts.SourceFile,
+  moduleBindingResolver?: IrModuleBindingResolver,
 ): (parameter: ts.ParameterDeclaration) => IrImplicitParamProjection | undefined {
   const candidatesByDeclaration = new WeakMap<ts.FunctionDeclaration, ReadonlySet<ts.ParameterDeclaration>>();
   return (parameter) => {
@@ -1872,6 +1874,26 @@ function makeIrImplicitParamTypeResolver(
     let candidates = candidatesByDeclaration.get(declaration);
     if (!candidates) {
       candidates = collectIrImplicitParamProjectionCandidates(declaration);
+      const onlyStatement = declaration.body?.statements.length === 1 ? declaration.body.statements[0] : undefined;
+      const returned = onlyStatement && ts.isReturnStatement(onlyStatement) ? onlyStatement.expression : undefined;
+      const returnedCall = returned && ts.isCallExpression(returned) ? returned : undefined;
+      const retainedPlan = returnedCall ? moduleBindingResolver?.retainedFunctionMethodPlan(returnedCall) : undefined;
+      if (retainedPlan && returnedCall) {
+        const projected = new Set(candidates);
+        for (let index = 0; index < declaration.parameters.length; index++) {
+          const argument = returnedCall.arguments[index];
+          const candidate = declaration.parameters[index]!;
+          if (
+            argument &&
+            ts.isIdentifier(argument) &&
+            ts.isIdentifier(candidate.name) &&
+            ctx.checker.getSymbolAtLocation(argument) === ctx.checker.getSymbolAtLocation(candidate.name)
+          ) {
+            projected.add(candidate);
+          }
+        }
+        candidates = projected;
+      }
       candidatesByDeclaration.set(declaration, candidates);
     }
     if (!candidates.has(parameter)) return undefined;
@@ -2029,7 +2051,7 @@ function planIrOverlay(
   // claim-then-demote). The carrier keying in `ensureDynMemberGet` matches
   // (`ctx.fast`), so every claimed config emits a valid, carrier-aligned body.
   const dynMemberReadBuildable = !(ctx.fast && !ctx.standalone && !ctx.wasi);
-  const resolveImplicitParamType = makeIrImplicitParamTypeResolver(ctx, ast.sourceFile);
+  const resolveImplicitParamType = makeIrImplicitParamTypeResolver(ctx, ast.sourceFile, resolveModuleBinding);
   const implicitParamUsesNumericVecAbi = (parameter: ts.ParameterDeclaration): boolean => {
     const projection = resolveImplicitParamType(parameter);
     if (projection?.kind !== "object") return false;
@@ -2038,6 +2060,18 @@ function planIrOverlay(
     return ctx.typeIdxToStructName.get(valueType.typeIdx) === "__vec_f64";
   };
   const legacyCallerAbiIsProjected = (declaration: ts.FunctionDeclaration): boolean => {
+    const onlyStatement = declaration.body?.statements.length === 1 ? declaration.body.statements[0] : undefined;
+    const returned = onlyStatement && ts.isReturnStatement(onlyStatement) ? onlyStatement.expression : undefined;
+    if (
+      returned &&
+      ts.isCallExpression(returned) &&
+      resolveModuleBinding?.retainedFunctionMethodPlan(returned) !== undefined
+    ) {
+      // #3793 — the exact retained wrapper uses the existing receiver-first
+      // externref dispatcher and the implicit-param resolver above projects
+      // every wrapper argument from the same direct declaration ABI.
+      return true;
+    }
     let hasIndexedCarrier = false;
     let hasBooleanProjection = false;
     let allProjectionsAreBoolean = true;

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -502,6 +502,13 @@ export interface IrFromAstResolver {
   standaloneRegExpTestPlan?(
     receiver: ts.Expression,
   ): { readonly receiverGlobal: IrGlobalRef; readonly funcName: string } | null;
+  /**
+   * #3793 — existing retained function-object module carrier plus its live
+   * receiver-preserving closed method dispatcher.
+   */
+  retainedFunctionMethodPlan?(
+    call: ts.CallExpression,
+  ): { readonly receiverGlobal: IrGlobalRef; readonly funcName: string } | null;
   /** #3791 exact stable module numeric vec at a direct-call boundary. */
   staticNumericArrayRead?(
     expression: ts.Expression,
@@ -5209,6 +5216,44 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
   const receiverIdentifier = ts.isIdentifier(expr.expression.expression) ? expr.expression.expression : undefined;
   const receiverIsDirectModuleBinding =
     receiverIdentifier !== undefined && cx.resolver?.isDirectModuleBinding?.(receiverIdentifier) === true;
+
+  // #3793 — Acorn's public wrappers call static properties on the retained
+  // `Parser` function object. Load the exact existing module carrier and
+  // route through the already-reserved closed method dispatcher. That keeps
+  // the receiver live (`Parser.parse` uses `new this(...)`) and deliberately
+  // does not turn the assigned FunctionExpression into a bare direct call.
+  const retainedMethod = cx.resolver?.retainedFunctionMethodPlan?.(expr) ?? null;
+  if (retainedMethod !== null) {
+    const receiver = cx.builder.emitGlobalGet(retainedMethod.receiverGlobal, irVal({ kind: "externref" }));
+    const args: IrValueId[] = [receiver];
+    for (const argument of expr.arguments) {
+      if (ts.isSpreadElement(argument)) {
+        throw new IrUnsupportedError(
+          "method-call-unsupported",
+          "build",
+          `ir/from-ast: retained function method spread is unsupported (${cx.funcName})`,
+        );
+      }
+      const value = lowerExpr(argument, cx, irDynamic());
+      const type = cx.builder.typeOf(value);
+      const scalar = asVal(type);
+      const carrier =
+        scalar?.kind === "f64" || scalar?.kind === "i32" ? boxConcreteToDynamic(value, type, argument, cx) : value;
+      if (carrier === null) {
+        throw new IrUnsupportedError(
+          "operand-coercion-unsupported",
+          "build",
+          `ir/from-ast: retained function method scalar argument has no dynamic box (${cx.funcName})`,
+        );
+      }
+      args.push(cx.builder.typeOf(carrier).kind === "dynamic" ? carrier : cx.builder.emitCoerceToExternref(carrier));
+    }
+    const result = cx.builder.emitCall(irRuntimeFuncRef(retainedMethod.funcName), args, irDynamic());
+    if (result === null) {
+      throw new Error(`ir/from-ast: retained function method returned void (${cx.funcName})`);
+    }
+    return result;
+  }
 
   // #3791 — standalone native RegExp `.test` on one exact, stable top-level
   // carrier. Keep the real legacy module global as the receiver (no duplicate

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -158,6 +158,7 @@ import {
   type IrLegacyModuleBindingResolver,
   type IrModuleBindingIdentity,
   type IrModuleBindingResolver,
+  type IrRetainedFunctionMethodPlan,
   type IrStaticNumericArrayPlan,
   type IrStaticRegExpTestPlan,
 } from "./module-bindings.js";
@@ -2952,6 +2953,86 @@ function resolveStandaloneRegExpTestGlobal(ctx: CodegenContext, plan: IrStaticRe
   return ref;
 }
 
+function resolveRetainedFunctionMethod(
+  ctx: CodegenContext,
+  plan: IrRetainedFunctionMethodPlan,
+): { readonly receiverGlobal: IrGlobalRef; readonly funcName: string } {
+  if (
+    plan.receiverUnitId === undefined ||
+    plan.methodUnitId === undefined ||
+    plan.receiverGlobalBindingId === undefined ||
+    plan.receiverSourceId === undefined ||
+    plan.receiverDeclarationOrdinal === undefined ||
+    !ts.isIdentifier(plan.receiverDeclaration.name) ||
+    plan.receiverDeclaration.name.text !== plan.receiverName
+  ) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "build",
+      "retained function method plan has no exact structural function-expression identity",
+    );
+  }
+
+  const globalName = `__mod_${plan.receiverName}`;
+  const observed = ctx.programAbiGlobals?.moduleBinding(plan.receiverDeclaration);
+  let receiverGlobalDef: GlobalDef | undefined;
+  if (ctx.programAbiGlobals) {
+    if (!observed || observed.displayName !== plan.receiverName) {
+      throw new IrInvariantError(
+        "unknown-global-ref",
+        "build",
+        `retained function receiver ${plan.receiverName} has no allocator-owned module global`,
+      );
+    }
+    receiverGlobalDef = observed.value;
+  } else {
+    const globalIdx = ctx.moduleGlobals.get(plan.receiverName);
+    receiverGlobalDef = globalIdx === undefined ? undefined : ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
+  }
+  if (
+    !receiverGlobalDef ||
+    receiverGlobalDef.name !== globalName ||
+    receiverGlobalDef.type.kind !== "externref" ||
+    !receiverGlobalDef.mutable
+  ) {
+    throw new IrInvariantError(
+      "unknown-global-ref",
+      "build",
+      `retained function receiver ${plan.receiverName} is not the legacy externref module slot`,
+    );
+  }
+  const receiverGlobal = irSourceGlobalRef(plan.receiverGlobalBindingId, globalName);
+  planProgramAbiGlobal(ctx, {
+    ref: receiverGlobal,
+    anchor: { kind: "source", sourceId: plan.receiverSourceId },
+    roleOrdinal: PROGRAM_ABI_GLOBAL_ROLE.moduleValue,
+    derivedOrdinal: plan.receiverDeclarationOrdinal,
+    global: receiverGlobalDef,
+  });
+
+  const funcName = `__call_m_${plan.methodName}_${plan.arity}`;
+  const dispatcherIdx = ctx.funcMap.get(funcName);
+  const dispatcher = dispatcherIdx === undefined ? undefined : definedFuncAt(ctx, dispatcherIdx);
+  const signature = dispatcher ? ctx.mod.types[dispatcher.typeIdx] : undefined;
+  if (
+    !dispatcher ||
+    dispatcher.name !== funcName ||
+    !signature ||
+    signature.kind !== "func" ||
+    signature.params.length !== plan.arity + 1 ||
+    signature.params.some((param) => param.kind !== "externref") ||
+    signature.results.length !== 1 ||
+    signature.results[0]?.kind !== "externref"
+  ) {
+    throw new IrInvariantError(
+      "abi-type-index-mismatch",
+      "build",
+      `retained ${plan.receiverName}.${plan.methodName} dispatcher does not have the exact receiver-first externref ABI`,
+    );
+  }
+  return { receiverGlobal, funcName };
+}
+
 function sameExactValType(left: ValType, right: ValType): boolean {
   if (left.kind !== right.kind) return false;
   if (left.kind === "ref" || left.kind === "ref_null") {
@@ -3028,6 +3109,17 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
       capability,
     );
   return {
+    retainedFunctionMethodPlan(call: ts.CallExpression) {
+      if (
+        !supportsBackendCapability("standalone-native-regexp-test-carrier") ||
+        !supportsBackendCapability("legacy-numeric-array-global") ||
+        !moduleBindingResolver
+      ) {
+        return null;
+      }
+      const plan = moduleBindingResolver.retainedFunctionMethodPlan(call);
+      return plan ? resolveRetainedFunctionMethod(ctx, plan) : null;
+    },
     standaloneRegExpTestPlan(receiver: ts.Expression) {
       if (!supportsBackendCapability("standalone-native-regexp-test-carrier") || !moduleBindingResolver) return null;
       const plan = moduleBindingResolver.staticRegExpTestPlan(receiver);

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -1306,6 +1306,23 @@ function matchingRetainedMethodAssignment(
     : undefined;
 }
 
+/**
+ * Prove that a retained-call argument can cross the receiver-first dynamic
+ * dispatcher bridge without a build-time representation guess.
+ *
+ * Dynamic values pass through, numbers and strings have canonical boxes, and
+ * reference values use the established externalization path. Boolean values
+ * deliberately remain excluded: their i32 carrier is ambiguous at this seam
+ * unless the lowerer also receives an exact boolean-brand proof.
+ */
+function retainedMethodArgumentIsBridgeable(checker: ts.TypeChecker, argument: ts.Expression): boolean {
+  const type = checker.getTypeAtLocation(unwrapParens(argument));
+  if ((type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0) return true;
+  if ((type.flags & (ts.TypeFlags.NumberLike | ts.TypeFlags.StringLike)) !== 0) return true;
+  if ((type.flags & (ts.TypeFlags.Object | ts.TypeFlags.NonPrimitive)) !== 0) return true;
+  return false;
+}
+
 function makeRetainedFunctionMethodPlan(
   checker: ts.TypeChecker,
   call: ts.CallExpression,
@@ -1318,6 +1335,9 @@ function makeRetainedFunctionMethodPlan(
     !ts.isIdentifier(call.expression.name) ||
     call.arguments.some(ts.isSpreadElement)
   ) {
+    return undefined;
+  }
+  if (call.arguments.some((argument) => !retainedMethodArgumentIsBridgeable(checker, argument))) {
     return undefined;
   }
   const receiver = call.expression.expression;

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -608,6 +608,28 @@ export interface IrStaticNumericArrayPlan {
   readonly declarationOrdinal?: number;
 }
 
+/**
+ * Exact retained function-object receiver plus one directly assigned method.
+ *
+ * This is intentionally not a direct-call plan: lowering must still perform a
+ * live receiver-preserving method dispatch so `Parser.parse` observes
+ * `this === Parser` and later property writes remain visible.
+ */
+export interface IrRetainedFunctionMethodPlan {
+  readonly receiverDeclaration: ts.VariableDeclaration;
+  readonly receiverTarget: ts.FunctionExpression;
+  readonly methodTarget: ts.FunctionExpression;
+  readonly receiverName: string;
+  readonly methodName: string;
+  readonly arity: number;
+  /** Structural fields are present on the identity-aware production resolver. */
+  readonly receiverUnitId?: IrUnitId;
+  readonly methodUnitId?: IrUnitId;
+  readonly receiverGlobalBindingId?: IrBindingId;
+  readonly receiverSourceId?: IrSourceId;
+  readonly receiverDeclarationOrdinal?: number;
+}
+
 interface IrModuleBindingResolverSurface<TIdentity, TInspection> {
   (node: ts.Identifier, writeValue?: ts.Expression): TIdentity | undefined;
   /**
@@ -639,6 +661,8 @@ interface IrModuleBindingResolverSurface<TIdentity, TInspection> {
   readonly staticRegExpTestPlan: (node: ts.Expression) => IrStaticRegExpTestPlan | undefined;
   /** Exact stable top-level numeric array used at a direct-call vec boundary. */
   readonly staticNumericArrayPlan: (node: ts.Expression) => IrStaticNumericArrayPlan | undefined;
+  /** Exact retained function-object method call whose receiver must stay live. */
+  readonly retainedFunctionMethodPlan: (call: ts.CallExpression) => IrRetainedFunctionMethodPlan | undefined;
 }
 
 export interface IrLegacyModuleBindingResolver extends IrModuleBindingResolverSurface<
@@ -1239,6 +1263,112 @@ function sourceBindingIsStable(checker: ts.TypeChecker, declaration: ts.Variable
   return stable;
 }
 
+function matchingRetainedMethodAssignment(
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  receiverSymbol: ts.Symbol,
+  methodName: string,
+): ts.BinaryExpression | undefined {
+  const writes: ts.BinaryExpression[] = [];
+  let unsupportedWrite = false;
+  const visit = (node: ts.Node): void => {
+    if (unsupportedWrite) return;
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.name.text === methodName &&
+      checker.getSymbolAtLocation(node.expression) === receiverSymbol
+    ) {
+      const parent = node.parent;
+      if (
+        ts.isBinaryExpression(parent) &&
+        parent.left === node &&
+        parent.operatorToken.kind === ts.SyntaxKind.EqualsToken
+      ) {
+        writes.push(parent);
+      } else if (
+        (ts.isBinaryExpression(parent) && parent.left === node && isAssignmentOperator(parent.operatorToken.kind)) ||
+        ((ts.isPrefixUnaryExpression(parent) || ts.isPostfixUnaryExpression(parent)) &&
+          (parent.operator === ts.SyntaxKind.PlusPlusToken || parent.operator === ts.SyntaxKind.MinusMinusToken)) ||
+        (ts.isDeleteExpression(parent) && parent.expression === node)
+      ) {
+        unsupportedWrite = true;
+        return;
+      }
+    }
+    node.forEachChild(visit);
+  };
+  sourceFile.forEachChild(visit);
+  if (unsupportedWrite || writes.length !== 1) return undefined;
+  const assignment = writes[0]!;
+  return ts.isExpressionStatement(assignment.parent) && assignment.parent.parent === sourceFile
+    ? assignment
+    : undefined;
+}
+
+function makeRetainedFunctionMethodPlan(
+  checker: ts.TypeChecker,
+  call: ts.CallExpression,
+): IrRetainedFunctionMethodPlan | undefined {
+  if (
+    call.questionDotToken ||
+    call.typeArguments?.length ||
+    !ts.isPropertyAccessExpression(call.expression) ||
+    !ts.isIdentifier(call.expression.expression) ||
+    !ts.isIdentifier(call.expression.name) ||
+    call.arguments.some(ts.isSpreadElement)
+  ) {
+    return undefined;
+  }
+  const receiver = call.expression.expression;
+  const receiverDeclaration = exactTopLevelVariableDeclaration(receiver, checker);
+  const receiverTarget = receiverDeclaration?.initializer ? unwrapParens(receiverDeclaration.initializer) : undefined;
+  if (
+    !receiverDeclaration ||
+    !receiverTarget ||
+    !ts.isFunctionExpression(receiverTarget) ||
+    !isVarModuleDeclaration(receiverDeclaration) ||
+    !sourceBindingIsStable(checker, receiverDeclaration)
+  ) {
+    return undefined;
+  }
+  const receiverSymbol = checker.getSymbolAtLocation(receiver);
+  if (!receiverSymbol || checker.getSymbolAtLocation(receiverDeclaration.name) !== receiverSymbol) return undefined;
+  const methodName = call.expression.name.text;
+  const assignment = matchingRetainedMethodAssignment(
+    checker,
+    receiverDeclaration.getSourceFile(),
+    receiverSymbol,
+    methodName,
+  );
+  const methodTarget = assignment ? unwrapParens(assignment.right) : undefined;
+  if (
+    !methodTarget ||
+    !ts.isFunctionExpression(methodTarget) ||
+    methodTarget.asteriskToken ||
+    methodTarget.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) ||
+    methodTarget.typeParameters?.length ||
+    call.arguments.length !== methodTarget.parameters.length ||
+    methodTarget.parameters.some(
+      (parameter) =>
+        !ts.isIdentifier(parameter.name) ||
+        parameter.dotDotDotToken !== undefined ||
+        parameter.questionToken !== undefined ||
+        parameter.initializer !== undefined,
+    )
+  ) {
+    return undefined;
+  }
+  return {
+    receiverDeclaration,
+    receiverTarget,
+    methodTarget,
+    receiverName: receiver.text,
+    methodName,
+    arity: call.arguments.length,
+  };
+}
+
 function staticStringFromExpression(
   checker: ts.TypeChecker,
   expression: ts.Expression,
@@ -1494,6 +1624,13 @@ export function makeIrLegacyModuleBindingResolver(
         return undefined;
       }
     },
+    retainedFunctionMethodPlan(call: ts.CallExpression): IrRetainedFunctionMethodPlan | undefined {
+      try {
+        return makeRetainedFunctionMethodPlan(checker, call);
+      } catch {
+        return undefined;
+      }
+    },
   });
 }
 
@@ -1617,6 +1754,33 @@ export function makeIrModuleBindingResolver(
       const plan = legacy.staticNumericArrayPlan(node);
       return plan ? { ...plan, ...bindingLocation(plan.declaration) } : undefined;
     },
+    retainedFunctionMethodPlan(call: ts.CallExpression): IrRetainedFunctionMethodPlan | undefined {
+      ownerAt(call);
+      const plan = legacy.retainedFunctionMethodPlan(call);
+      if (!plan) return undefined;
+      const receiverUnitId = identityContext.unitIdByDeclaration.get(plan.receiverTarget);
+      const methodUnitId = identityContext.unitIdByDeclaration.get(plan.methodTarget);
+      if (
+        receiverUnitId === undefined ||
+        methodUnitId === undefined ||
+        identityContext.declarationByUnitId.get(receiverUnitId) !== plan.receiverTarget ||
+        identityContext.declarationByUnitId.get(methodUnitId) !== plan.methodTarget
+      ) {
+        return planningInvariant(
+          "missing-unit-declaration",
+          `retained ${plan.receiverName}.${plan.methodName} call has no exact function-expression identity`,
+        );
+      }
+      const receiverLocation = bindingLocation(plan.receiverDeclaration);
+      return {
+        ...plan,
+        receiverUnitId,
+        methodUnitId,
+        receiverGlobalBindingId: receiverLocation.globalBindingId,
+        receiverSourceId: receiverLocation.sourceId,
+        receiverDeclarationOrdinal: receiverLocation.declarationOrdinal,
+      };
+    },
   });
 }
 
@@ -1666,5 +1830,6 @@ export function projectIrModuleBindingResolverToLegacy(
     bindingValueMatches: (node: ts.Identifier, value: ts.Expression) => resolver.bindingValueMatches(node, value),
     staticRegExpTestPlan: (node: ts.Expression) => resolver.staticRegExpTestPlan(node),
     staticNumericArrayPlan: (node: ts.Expression) => resolver.staticNumericArrayPlan(node),
+    retainedFunctionMethodPlan: (call: ts.CallExpression) => resolver.retainedFunctionMethodPlan(call),
   });
 }

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1700,7 +1700,7 @@ function whyNotIrClaimable(
   // yield machinery has no dynamic arm yet.
   // -------------------------------------------------------------------------
   if (dynNames.size > 0 && isGenerator) return "param-type-not-resolvable";
-  if (dynNames.size > 0 || isDynamicReturn) {
+  if (dynNames.size > 0 || isDynamicReturn || containsRetainedFunctionMethodCall(body)) {
     if (!dynamicUsesAreMoveOnly(fn, dynNames, isDynamicReturn, typeMap)) {
       return dynNames.size > 0 ? "param-type-not-resolvable" : "return-type-not-resolvable";
     }
@@ -2185,6 +2185,30 @@ function concreteDynamicAssignmentOperandIsBuildable(candidate: ts.Expression): 
     concreteDynamicAssignmentOperandIsBuildable(candidate.whenTrue) &&
     concreteDynamicAssignmentOperandIsBuildable(candidate.whenFalse)
   );
+}
+
+/**
+ * True when the current body contains a #3793 retained method call.
+ *
+ * Such calls always use the boxed-dynamic closed-dispatch ABI, so they must
+ * run through {@link dynamicUsesAreMoveOnly} even when the enclosing
+ * declaration has no dynamic parameter/result. The scan then proves both the
+ * result position and every argument bridge before the selector claims the
+ * function.
+ */
+function containsRetainedFunctionMethodCall(body: ts.Block): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (node !== body && isFunctionLike(node)) return;
+    if (ts.isCallExpression(node) && currentModuleBindingResolver?.retainedFunctionMethodPlan(node) !== undefined) {
+      found = true;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(body, visit);
+  return found;
 }
 
 /**

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -2240,6 +2240,13 @@ function dynamicUsesAreMoveOnly(
       return calleeReturnIsDynamic(e.expression.text, typeMap);
     }
     if (
+      ts.isCallExpression(e) &&
+      ts.isPropertyAccessExpression(e.expression) &&
+      currentModuleBindingResolver?.retainedFunctionMethodPlan(e) !== undefined
+    ) {
+      return true;
+    }
+    if (
       currentDynamicRuntimeBuildable &&
       ts.isCallExpression(e) &&
       ts.isPropertyAccessExpression(e.expression) &&
@@ -2297,6 +2304,20 @@ function dynamicUsesAreMoveOnly(
       return dynNames.has(e.text) === expectDyn;
     }
     if (ts.isCallExpression(e)) {
+      const retainedMethod = currentModuleBindingResolver?.retainedFunctionMethodPlan(e);
+      if (retainedMethod !== undefined) {
+        if (!expectDyn || e.arguments.length !== retainedMethod.arity) return false;
+        for (const argument of e.arguments) {
+          if (ts.isSpreadElement(argument)) return false;
+          const dynamic = isDynShaped(argument);
+          if (dynamic) {
+            if (!scanExpr(argument, true)) return false;
+          } else if (!scanExpr(argument, false)) {
+            return false;
+          }
+        }
+        return true;
+      }
       if (
         currentDynamicRuntimeBuildable &&
         ts.isPropertyAccessExpression(e.expression) &&
@@ -6231,6 +6252,25 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         isPristineEs5IntrinsicIsFrozenCall(expr, (node) => selectorSeesAmbientBinding(node) && !scope.has(node.text))
       ) {
         return true;
+      }
+      // #3793 — exact retained function-object wrappers such as Acorn's
+      // `parse(...) { return Parser.parse(...) }`. The checker resolver proves
+      // the stable `var Parser = function Parser(...) {}` carrier and its one
+      // direct top-level `Parser.parse = function parse(...) {}` assignment.
+      // This is a live method call, never a bare call to the assigned body:
+      // lowering uses the existing closed dispatcher so `new this(...)`,
+      // retained closure identity, and later property reads stay unchanged.
+      if (
+        currentSelectionOptions?.supportsBackendCapability?.("standalone-native-regexp-test-carrier") === true &&
+        currentSelectionOptions.supportsBackendCapability?.("legacy-numeric-array-global") === true
+      ) {
+        const retainedMethod = currentModuleBindingResolver?.retainedFunctionMethodPlan(expr);
+        if (retainedMethod !== undefined) {
+          for (const arg of expr.arguments) {
+            if (ts.isSpreadElement(arg) || !isPhase1Expr(arg, scope, localClasses)) return false;
+          }
+          return true;
+        }
       }
       if (
         (expr.expression.name.text === "test" || expr.expression.name.text === "exec") &&

--- a/tests/issue-3793-ir-acorn-retained-parser-wrappers.test.ts
+++ b/tests/issue-3793-ir-acorn-retained-parser-wrappers.test.ts
@@ -99,4 +99,50 @@ describe("#3793 retained function-object parser wrappers", () => {
     }
     expect((instance.exports.run as () => number)()).toBe(11);
   });
+
+  it("keeps a typed string-result wrapper on direct codegen without a post-claim withdrawal", async () => {
+    const { result, instance } = await compileStandalone(
+      `
+      var Factory = function Factory() {};
+      Factory.method = function method(value: string): string {
+        return value;
+      };
+
+      function wrapper(value: string): string {
+        return Factory.method(value);
+      }
+
+      export function run() {
+        return wrapper("abc").length;
+      }
+      `,
+      "issue-3793-retained-parser-wrapper-string-result.ts",
+    );
+
+    expect(result.irCompiledFuncs ?? [], JSON.stringify(result.irOutcomes, null, 2)).not.toContain("wrapper");
+    expect((instance.exports.run as () => number)()).toBe(3);
+  });
+
+  it("rejects an unboxable boolean wrapper argument before the IR claim", async () => {
+    const { result, instance } = await compileStandalone(
+      `
+      var Factory = function Factory() {};
+      Factory.method = function method(value: boolean): any {
+        return value ? 7 : 3;
+      };
+
+      function wrapper(value: boolean): any {
+        return Factory.method(value);
+      }
+
+      export function run(): number {
+        return wrapper(true);
+      }
+      `,
+      "issue-3793-retained-parser-wrapper-boolean-argument.ts",
+    );
+
+    expect(result.irCompiledFuncs ?? [], JSON.stringify(result.irOutcomes, null, 2)).not.toContain("wrapper");
+    expect((instance.exports.run as () => number)()).toBe(7);
+  });
 });

--- a/tests/issue-3793-ir-acorn-retained-parser-wrappers.test.ts
+++ b/tests/issue-3793-ir-acorn-retained-parser-wrappers.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function compileStandalone(source: string, fileName: string) {
+  const result = await compile(source, {
+    fileName,
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+    trackIrOutcomes: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.irPostClaimErrors ?? []).toEqual([]);
+  const module = await WebAssembly.compile(result.binary);
+  expect(WebAssembly.Module.imports(module)).toEqual([]);
+  return { result, instance: await WebAssembly.instantiate(module, {}) };
+}
+
+describe("#3793 retained function-object parser wrappers", () => {
+  it("emits all three Acorn wrapper shapes while preserving the Parser receiver", async () => {
+    const { result, instance } = await compileStandalone(
+      `
+      var Parser = function Parser(value) {
+        this.value = value;
+      };
+      Parser.prototype.read = function read() {
+        return this.value;
+      };
+      Parser.parse = function parse(value) {
+        return new this(value).read();
+      };
+      Parser.parseExpressionAt = function parseExpressionAt(value, position, options) {
+        return new this(value + position + options).read();
+      };
+      Parser.tokenizer = function tokenizer(value, options) {
+        return new this(value + options).read();
+      };
+
+      function parse(value) {
+        return Parser.parse(value);
+      }
+      function parseExpressionAt(value, position, options) {
+        return Parser.parseExpressionAt(value, position, options);
+      }
+      function tokenizer(value, options) {
+        return Parser.tokenizer(value, options);
+      }
+
+      export function run() {
+        return parse(37) + parseExpressionAt(10, 2, 3) + tokenizer(40, 2);
+      }
+      `,
+      "issue-3793-retained-parser-wrappers.mjs",
+    );
+
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toEqual(
+      expect.arrayContaining(["parse", "parseExpressionAt", "tokenizer"]),
+    );
+    expect((instance.exports.run as () => number)()).toBe(94);
+  });
+
+  it("keeps aliases, receiver writes, duplicate method writes, and computed calls on direct codegen", async () => {
+    const { result, instance } = await compileStandalone(
+      `
+      var Stable = function Stable(value) { this.value = value; };
+      Stable.parse = function parse(value) { return value; };
+      var Alias = Stable;
+
+      var Reassigned = function Reassigned(value) { this.value = value; };
+      Reassigned.parse = function parse(value) { return value; };
+      Reassigned = Stable;
+
+      var Duplicate = function Duplicate(value) { this.value = value; };
+      Duplicate.parse = function parse(value) { return value; };
+      Duplicate.parse = function parseAgain(value) { return value + 1; };
+
+      function aliasWrapper(value) {
+        return Alias.parse(value);
+      }
+      function reassignedWrapper(value) {
+        return Reassigned.parse(value);
+      }
+      function duplicateWrapper(value) {
+        return Duplicate.parse(value);
+      }
+      function computedWrapper(value) {
+        return Stable["parse"](value);
+      }
+
+      export function run() {
+        return aliasWrapper(1) + reassignedWrapper(2) + duplicateWrapper(3) + computedWrapper(4);
+      }
+      `,
+      "issue-3793-retained-parser-wrapper-fallbacks.mjs",
+    );
+
+    for (const name of ["aliasWrapper", "reassignedWrapper", "duplicateWrapper", "computedWrapper"]) {
+      expect(result.irCompiledFuncs ?? [], JSON.stringify(result.irOutcomes, null, 2)).not.toContain(name);
+    }
+    expect((instance.exports.run as () => number)()).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary

- Emit Acorn's retained public parser wrappers `parse`, `parseExpressionAt`, and `tokenizer` through IR.
- Preserve the existing retained FunctionExpression identity and receiver-first closed dispatch, including `new this(...)` behavior.
- Reject concrete-result and unboxable argument ABIs before IR claim so typed string results and ambiguous boolean arguments stay safely on direct codegen.

## Migration result

- Exact runtime-dynamic Acorn adoption: 27/43 to 30/43 IR-emitted reachable functions.
- Checksum: 422.
- Wasm imports: zero.
- Post-claim withdrawals: zero.
- Paired same-host runtime: 49.415 ms/op versus 49.954 ms/op on the #3791 parent, effectively neutral.

This migrates the three wrapper bodies only. Their retained method FunctionExpression targets and the closed dispatcher remain direct-codegen-owned, so this PR does not claim legacy-body retirement.

## Validation

- Focused and adjacent Vitest: 20/20 after rebase.
- Independent adversarial review: typed-result and boolean-argument findings fixed and re-reviewed with no remaining findings.
- Typecheck.
- IR fallback ratchet.
- LOC and function budgets.
- Issue ID and issue-spec coverage.
- Focused formatting and diff checks.

Tracks `plan/issues/3793-ir-acorn-retained-parser-wrappers.md`.
