### PR TITLE
refactor(ir): own closure host bridges structurally

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -100,6 +100,7 @@ files:
   - src/codegen/program-abi-module-init-planning.ts
   - src/codegen/program-abi-source-callable-planning.ts
   - src/codegen/program-abi-planning.ts
+  - src/codegen/closure-exports.ts
   - src/codegen/program-abi-signatures.ts
   - src/codegen/program-abi-session.ts
   - src/codegen/program-abi-type-planning.ts
@@ -117,6 +118,7 @@ files:
   - src/codegen/closures/funcref-as-closure.ts
   - src/codegen/closures/method-trampolines.ts
   - src/codegen/index.ts
+  - src/runtime.ts
   - src/codegen/stdlib-selfhost.ts
   - docs/ir/ir-contract.md
   - docs/ir/ir-module.schema.json
@@ -160,6 +162,7 @@ files:
   - tests/issue-3520-class-support-callable-abi.test.ts
   - tests/issue-3520-class-integration-callable-abi.test.ts
   - tests/issue-3520-class-method-alias-abi.test.ts
+  - tests/issue-3520-closure-host-bridge-abi.test.ts
   - tests/issue-3520-module-init-callable-abi.test.ts
   - tests/issue-3520-source-callable-abi.test.ts
   - tests/issue-3520-type-class-abi.test.ts
@@ -171,7 +174,7 @@ files:
   - tests/issue-2856-calendar-residuals.test.ts
   - tests/issue-1899-funcidx-authority.test.ts
 loc-budget-allow:
-  - src/runtime.ts
+  - src/codegen/closure-exports.ts
   - src/codegen/declarations.ts
   - src/codegen/statements/nested-declarations.ts
   - src/codegen/context/types.ts
@@ -181,6 +184,7 @@ loc-budget-allow:
   - src/ir/nodes.ts
   - src/ir/verify.ts
   - src/ir/backend/porffor/assembler.ts
+  - src/runtime.ts
 # R1 must resolve exact checker declarations to the one authoritative identity
 # inventory. TypeOracle deliberately does not expose ts.Symbol/ts.Type objects,
 # so these two structural joins remain reviewed raw-checker boundaries until
@@ -2675,7 +2679,10 @@ role:
   at the current Program ABI-resolved handle. The public labels, exported
   signatures, dispatcher bodies, method-receiver save/restore behavior,
   `funcMap` compatibility entries, closure classifier semantics, and #2083
-  closure-free gating remain unchanged; and
+  closure-free gating remain unchanged. When a user owns a logical helper name
+  or its reserved `$cN` physical prefix, codegen preserves every user export
+  and publishes the exact helper at the terminal free physical suffix. The JS
+  runtime projects that helper only into its internal export view; and
 - tracked and untracked compilation use the same allocator-object lookup.
   Tracking adds only structural ownership metadata and does not allocate,
   relabel, or rebuild a helper.
@@ -2690,13 +2697,18 @@ C30's independently measured 24 vec rows, the same total becomes the intended
 `closure-host-bridge` rows. Routing and body outcomes remain **37 terminal / 30
 emitted / 7 Unsupported / 0 Invariants / 37 legacy bodies / 30 IR bodies**.
 
-The focused C31 suite passes **7/7**. It proves every fixed ID and public label,
+The focused C31 suite passes **9/9**. It proves every fixed ID and public label,
 the absence of a second generic callable owner, exact final-slot object
 resolution across a forced late import and dead-slot compaction, zero bridge
 rows for a closure-free module, tracked/untracked byte equality, direct closure
 identity/call behavior, method receiver identity, conditional rest
-classification, and the five-entry census. The adjacent #2083 and closure
-dispatch/runtime matrix passes **36/36 across six files** in addition to C31.
+classification, collision-safe logical and physical export ownership, and the
+five-entry census. A closure-free user `__is_closure` plus `$cf` prefix remains
+public but cannot fabricate runtime closure discovery, so a fieldless class
+instance still crosses `wrapExports` as an object. The adjacent #2083 and
+closure dispatch/runtime matrix passes **81/82 across twelve files** in
+addition to C31; the one #1308 boolean result expectation also fails unchanged
+on the independent C30 worktree and is not introduced by C31.
 
 C31 closes exact retained ownership for this bounded closure host-dispatch
 family, not R1. Higher-arity method dispatchers, other support callable

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -2683,11 +2683,13 @@ role:
   or its reserved `$cN` physical prefix, codegen preserves every user export
   and publishes the exact helper at the terminal free physical suffix. One
   immutable compiler-authored i32 manifest records exactly which helpers were
-  emitted, and a collision-safe empty Wasm table authenticates that metadata as
-  compiler-owned rather than a user name/value convention. The JS runtime uses
-  that metadata, never user-controlled name cardinality, and composes closure
-  and vec projections from the same raw export object into one internal view;
-  and
+  emitted. A collision-safe empty Wasm table authenticates that metadata as
+  compiler-owned rather than a user name/value convention, while a 17-slot
+  funcref table binds every set bit to the exact compiler helper object. The JS
+  runtime proves the manifest is an immutable i32 through Wasm import
+  validation, rejects reserved bits and malformed tables, never falls back to
+  a user logical export, and composes closure and vec projections from the same
+  raw export object into one internal view; and
 - tracked and untracked compilation use the same allocator-object lookup.
   Tracking adds only structural ownership metadata and does not allocate,
   relabel, or rebuild a helper.
@@ -2700,7 +2702,7 @@ closure manifest adds no callable and does not change the structural row
 counts. Routing and body outcomes remain **37 terminal / 30 emitted / 7
 Unsupported / 0 Invariants / 37 legacy bodies / 30 IR bodies**.
 
-The focused C31 suite passes **10/10**. It proves every fixed ID and public label,
+The focused C31 suite passes **11/11**. It proves every fixed ID and public label,
 the absence of a second generic callable owner, exact final-slot object
 resolution across a forced late import and dead-slot compaction, zero bridge
 rows for a closure-free module, tracked/untracked byte equality, direct closure
@@ -2710,8 +2712,10 @@ five-entry census. Simultaneous vec and closure logical/physical/manifest
 collisions resolve through both `buildImports().setExports` and `wrapExports`.
 A closure-free forged `__is_closure` + `__call_fn_0` + `$cf` family remains
 public but cannot fabricate runtime closure discovery, so a fieldless class
-instance still crosses `wrapExports` as an object. The adjacent #2083 and
-vec/closure dispatch-runtime matrix passes **94/94 across thirteen files**,
+instance still crosses `wrapExports` as an object. Missing compiler aliases,
+non-empty markers, mutable-i32 or f64 manifests, and reserved availability bits
+also fail closed for a real compiled boxed class. The adjacent #2083 and
+vec/closure dispatch-runtime matrix passes **95/95 across thirteen files**,
 including the focused C30 and C31 structural-ownership suites.
 
 C31 closes exact retained ownership for this bounded closure host-dispatch

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -2686,10 +2686,11 @@ role:
   emitted. A collision-safe empty Wasm table authenticates that metadata as
   compiler-owned rather than a user name/value convention, while a 17-slot
   funcref table binds every set bit to the exact compiler helper object. The JS
-  runtime proves the manifest is an immutable i32 through Wasm import
-  validation, rejects reserved bits and malformed tables, never falls back to
-  a user logical export, and composes closure and vec projections from the same
-  raw export object into one internal view; and
+  runtime proves the manifest is an immutable i32 and both tables have exact
+  `funcref` element types and `0..0` / `17..17` limits through Wasm import
+  validation. It rejects reserved bits, externref or malformed tables, never
+  falls back to a user logical export, and composes closure and vec projections
+  from the same raw export object into one internal view; and
 - tracked and untracked compilation use the same allocator-object lookup.
   Tracking adds only structural ownership metadata and does not allocate,
   relabel, or rebuild a helper.
@@ -2714,9 +2715,11 @@ A closure-free forged `__is_closure` + `__call_fn_0` + `$cf` family remains
 public but cannot fabricate runtime closure discovery, so a fieldless class
 instance still crosses `wrapExports` as an object. Missing compiler aliases,
 non-empty markers, mutable-i32 or f64 manifests, and reserved availability bits
-also fail closed for a real compiled boxed class. The adjacent #2083 and
-vec/closure dispatch-runtime matrix passes **95/95 across thirteen files**,
-including the focused C30 and C31 structural-ownership suites.
+also fail closed for a real compiled boxed class. An externref table containing
+matching JS helper functions is rejected even when its length, availability,
+and terminal aliases otherwise match. The adjacent #2083 and vec/closure
+dispatch-runtime matrix passes **95/95 across thirteen files**, including the
+focused C30 and C31 structural-ownership suites.
 
 C31 closes exact retained ownership for this bounded closure host-dispatch
 family, not R1. Higher-arity method dispatchers, other support callable

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -2681,34 +2681,38 @@ role:
   `funcMap` compatibility entries, closure classifier semantics, and #2083
   closure-free gating remain unchanged. When a user owns a logical helper name
   or its reserved `$cN` physical prefix, codegen preserves every user export
-  and publishes the exact helper at the terminal free physical suffix. The JS
-  runtime projects that helper only into its internal export view; and
+  and publishes the exact helper at the terminal free physical suffix. One
+  immutable compiler-authored i32 manifest records exactly which helpers were
+  emitted, and a collision-safe empty Wasm table authenticates that metadata as
+  compiler-owned rather than a user name/value convention. The JS runtime uses
+  that metadata, never user-controlled name cardinality, and composes closure
+  and vec projections from the same raw export object into one internal view;
+  and
 - tracked and untracked compilation use the same allocator-object lookup.
   Tracking adds only structural ownership metadata and does not allocate,
   relabel, or rebuild a helper.
 
-The exact five-entry `SINGLE_HOST_ENTRIES` census was run with one fresh process
-per entry against `origin/main` at `9d2289ac6ef3a9` plus C31. It reports **166**
-defined functions, **75** generic `retained-module-function` rows, and exactly
-**26** `closure-host-bridge` rows across the two emitting entries. This is the
-one-for-one **101 → 75** generic-row move from current main. When combined with
-C30's independently measured 24 vec rows, the same total becomes the intended
-**77 → 51** generic move with **24** `vec-host-bridge` and **26**
-`closure-host-bridge` rows. Routing and body outcomes remain **37 terminal / 30
-emitted / 7 Unsupported / 0 Invariants / 37 legacy bodies / 30 IR bodies**.
+The exact five-entry `SINGLE_HOST_ENTRIES` census was run against C30 main at
+`c462d0216e3925` plus C31. It reports **166** defined functions, **51** generic
+`retained-module-function` rows, exactly **24** `vec-host-bridge` rows, and
+exactly **26** `closure-host-bridge` rows across the emitting entries. The
+closure manifest adds no callable and does not change the structural row
+counts. Routing and body outcomes remain **37 terminal / 30 emitted / 7
+Unsupported / 0 Invariants / 37 legacy bodies / 30 IR bodies**.
 
-The focused C31 suite passes **9/9**. It proves every fixed ID and public label,
+The focused C31 suite passes **10/10**. It proves every fixed ID and public label,
 the absence of a second generic callable owner, exact final-slot object
 resolution across a forced late import and dead-slot compaction, zero bridge
 rows for a closure-free module, tracked/untracked byte equality, direct closure
 identity/call behavior, method receiver identity, conditional rest
 classification, collision-safe logical and physical export ownership, and the
-five-entry census. A closure-free user `__is_closure` plus `$cf` prefix remains
+five-entry census. Simultaneous vec and closure logical/physical/manifest
+collisions resolve through both `buildImports().setExports` and `wrapExports`.
+A closure-free forged `__is_closure` + `__call_fn_0` + `$cf` family remains
 public but cannot fabricate runtime closure discovery, so a fieldless class
 instance still crosses `wrapExports` as an object. The adjacent #2083 and
-closure dispatch/runtime matrix passes **81/82 across twelve files** in
-addition to C31; the one #1308 boolean result expectation also fails unchanged
-on the independent C30 worktree and is not introduced by C31.
+vec/closure dispatch-runtime matrix passes **94/94 across thirteen files**,
+including the focused C30 and C31 structural-ownership suites.
 
 C31 closes exact retained ownership for this bounded closure host-dispatch
 family, not R1. Higher-arity method dispatchers, other support callable

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -2657,6 +2657,52 @@ C30 closes exact retained ownership for the six core vec host bridges, not R1.
 Other support callable families and remaining module-array or display-name
 consumers must still move behind structural authorities before R1 can close.
 
+### 2026-07-30 closure host-bridge callable ownership continuation
+
+The C31 continuation on `codex/3520-c31-closure-host-bridge` moves the bounded
+host-visible closure dispatcher family behind one entry-source-owned structural
+role:
+
+- direct `__call_fn_0` through `__call_fn_4` use fixed
+  `closure-host-bridge` ordinals 0 through 4, method
+  `__call_fn_method_0` through `__call_fn_method_5` use ordinals 5 through 10,
+  `__closure_arity` uses 11, and `__is_closure` uses 12. The optional
+  `__closure_has_rest` classifier uses ordinal 13 only in modules that actually
+  emit it. Higher method dispatchers remain on generic retained ownership in
+  this bounded slice;
+- each existing helper body is first materialized as one exact
+  `WasmFunction`, then planned under the canonical entry source and published
+  at the current Program ABI-resolved handle. The public labels, exported
+  signatures, dispatcher bodies, method-receiver save/restore behavior,
+  `funcMap` compatibility entries, closure classifier semantics, and #2083
+  closure-free gating remain unchanged; and
+- tracked and untracked compilation use the same allocator-object lookup.
+  Tracking adds only structural ownership metadata and does not allocate,
+  relabel, or rebuild a helper.
+
+The exact five-entry `SINGLE_HOST_ENTRIES` census was run with one fresh process
+per entry against `origin/main` at `9d2289ac6ef3a9` plus C31. It reports **166**
+defined functions, **75** generic `retained-module-function` rows, and exactly
+**26** `closure-host-bridge` rows across the two emitting entries. This is the
+one-for-one **101 → 75** generic-row move from current main. When combined with
+C30's independently measured 24 vec rows, the same total becomes the intended
+**77 → 51** generic move with **24** `vec-host-bridge` and **26**
+`closure-host-bridge` rows. Routing and body outcomes remain **37 terminal / 30
+emitted / 7 Unsupported / 0 Invariants / 37 legacy bodies / 30 IR bodies**.
+
+The focused C31 suite passes **7/7**. It proves every fixed ID and public label,
+the absence of a second generic callable owner, exact final-slot object
+resolution across a forced late import and dead-slot compaction, zero bridge
+rows for a closure-free module, tracked/untracked byte equality, direct closure
+identity/call behavior, method receiver identity, conditional rest
+classification, and the five-entry census. The adjacent #2083 and closure
+dispatch/runtime matrix passes **36/36 across six files** in addition to C31.
+
+C31 closes exact retained ownership for this bounded closure host-dispatch
+family, not R1. Higher-arity method dispatchers, other support callable
+families, remaining class/type consumers, and module-array or display-name
+scans still need structural owners before R1 can close.
+
 ### R1a validation evidence
 
 - Representative inventory denominator: **1 source / 2 classes / 12 allUnits /

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -34,6 +34,8 @@ import {
 const CLOSURE_HOST_BRIDGE_ROLE = "closure-host-bridge";
 const CLOSURE_HOST_BRIDGE_MANIFEST_NAME = "__\0js2_closure_host_bridge";
 const CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE = "$cm";
+const CLOSURE_HOST_BRIDGE_MARKER_NAME = "__\0js2_closure_host_bridge_marker";
+const CLOSURE_HOST_BRIDGE_MARKER_PHYSICAL_BASE = "$ct";
 const CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC = 0x5a200000;
 const publishedClosureHostBridgeBits = new WeakMap<CodegenContext, number>();
 const publishedClosureHostBridgeManifests = new WeakSet<CodegenContext>();
@@ -131,10 +133,7 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
       occupied.add(physicalName);
     }
   }
-  publishedClosureHostBridgeBits.set(
-    ctx,
-    (publishedClosureHostBridgeBits.get(ctx) ?? 0) | (1 << definition.bit),
-  );
+  publishedClosureHostBridgeBits.set(ctx, (publishedClosureHostBridgeBits.get(ctx) ?? 0) | (1 << definition.bit));
   return funcIdx;
 }
 
@@ -146,12 +145,14 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
  * a reserved NUL-containing internal label that ordinary TypeScript exports
  * cannot declare accidentally.
  */
-export function emitClosureHostBridgeManifest(ctx: CodegenContext): void {
+function emitClosureHostBridgeManifest(ctx: CodegenContext): void {
   if (publishedClosureHostBridgeManifests.has(ctx)) return;
   const bits = publishedClosureHostBridgeBits.get(ctx) ?? 0;
   if ((bits & (1 << 15)) === 0) return;
   publishedClosureHostBridgeManifests.add(ctx);
 
+  const tableIdx = ctx.mod.imports.filter((entry) => entry.desc.kind === "table").length + ctx.mod.tables.length;
+  ctx.mod.tables.push({ elementType: "funcref", min: 0, max: 0 });
   const globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
   ctx.mod.globals.push({
     name: CLOSURE_HOST_BRIDGE_MANIFEST_NAME,
@@ -160,29 +161,38 @@ export function emitClosureHostBridgeManifest(ctx: CodegenContext): void {
     init: [{ op: "i32.const", value: CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC | bits }],
   });
 
-  const occupied = new Set(ctx.mod.exports.map((entry) => entry.name));
-  if (!occupied.has(CLOSURE_HOST_BRIDGE_MANIFEST_NAME)) {
-    ctx.mod.exports.push({
-      name: CLOSURE_HOST_BRIDGE_MANIFEST_NAME,
-      desc: { kind: "global", index: globalIdx },
-    });
-    occupied.add(CLOSURE_HOST_BRIDGE_MANIFEST_NAME);
-  }
-  let maxOccupiedSuffix = -1;
-  for (const name of occupied) {
-    if (!name.startsWith(CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE)) continue;
-    const suffix = name.slice(CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE.length);
-    if (/^\$*$/.test(suffix)) maxOccupiedSuffix = Math.max(maxOccupiedSuffix, suffix.length);
-  }
-  for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
-    const physicalName = `${CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE}${"$".repeat(suffixLength)}`;
-    if (occupied.has(physicalName)) continue;
-    ctx.mod.exports.push({
-      name: physicalName,
-      desc: { kind: "global", index: globalIdx },
-    });
-    occupied.add(physicalName);
-  }
+  const publishManifestExport = (
+    logicalName: string,
+    physicalBase: string,
+    desc: { kind: "table" | "global"; index: number },
+  ): void => {
+    const occupied = new Set(ctx.mod.exports.map((entry) => entry.name));
+    if (!occupied.has(logicalName)) {
+      ctx.mod.exports.push({ name: logicalName, desc });
+      occupied.add(logicalName);
+    }
+    let maxOccupiedSuffix = -1;
+    for (const name of occupied) {
+      if (!name.startsWith(physicalBase)) continue;
+      const suffix = name.slice(physicalBase.length);
+      if (/^\$*$/.test(suffix)) maxOccupiedSuffix = Math.max(maxOccupiedSuffix, suffix.length);
+    }
+    for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
+      const physicalName = `${physicalBase}${"$".repeat(suffixLength)}`;
+      if (occupied.has(physicalName)) continue;
+      ctx.mod.exports.push({ name: physicalName, desc });
+      occupied.add(physicalName);
+    }
+  };
+
+  publishManifestExport(CLOSURE_HOST_BRIDGE_MARKER_NAME, CLOSURE_HOST_BRIDGE_MARKER_PHYSICAL_BASE, {
+    kind: "table",
+    index: tableIdx,
+  });
+  publishManifestExport(CLOSURE_HOST_BRIDGE_MANIFEST_NAME, CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE, {
+    kind: "global",
+    index: globalIdx,
+  });
 }
 
 function directClosureHostBridgeOrdinal(arity: number): number | undefined {
@@ -1380,7 +1390,10 @@ export function emitClosureHasRestExport(ctx: CodegenContext): void {
   const restTypes = [...ctx.closureInfoByTypeIdx]
     .filter(([, info]) => info.hasRestParam === true)
     .map(([typeIdx]) => typeIdx);
-  if (restTypes.length === 0) return;
+  if (restTypes.length === 0) {
+    emitClosureHostBridgeManifest(ctx);
+    return;
+  }
 
   const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$closure_has_rest_type");
   const body: Instr[] = [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "local.set", index: 1 }];
@@ -1408,6 +1421,7 @@ export function emitClosureHasRestExport(ctx: CodegenContext): void {
     } as WasmFunction,
     CLOSURE_HOST_BRIDGE_ORDINAL.closureHasRest,
   );
+  emitClosureHostBridgeManifest(ctx);
 }
 
 /**

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -32,6 +32,11 @@ import {
 } from "./program-abi-planning.js";
 
 const CLOSURE_HOST_BRIDGE_ROLE = "closure-host-bridge";
+const CLOSURE_HOST_BRIDGE_MANIFEST_NAME = "__\0js2_closure_host_bridge";
+const CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE = "$cm";
+const CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC = 0x5a200000;
+const publishedClosureHostBridgeBits = new WeakMap<CodegenContext, number>();
+const publishedClosureHostBridgeManifests = new WeakSet<CodegenContext>();
 
 const CLOSURE_HOST_BRIDGE_ORDINAL = Object.freeze({
   directCall0: 0,
@@ -51,11 +56,36 @@ const CLOSURE_HOST_BRIDGE_ORDINAL = Object.freeze({
 } as const);
 
 /**
+ * Reserved collision-only export family for closure helpers.
+ *
+ * Keep the physical family independent from the Program ABI ordinals: method
+ * dispatchers 6..8 remain runtime-visible but are intentionally outside the
+ * bounded C31 structural-ownership slice.
+ */
+function closureHostBridgeDefinition(logicalName: string): { physicalBase: string; bit: number } {
+  const direct = /^__call_fn_([0-4])$/.exec(logicalName);
+  if (direct) {
+    const bit = Number(direct[1]);
+    return { physicalBase: `$c${bit.toString(36)}`, bit };
+  }
+  const method = /^__call_fn_method_([0-8])$/.exec(logicalName);
+  if (method) {
+    const bit = 5 + Number(method[1]);
+    return { physicalBase: `$c${bit.toString(36)}`, bit };
+  }
+  if (logicalName === "__closure_arity") return { physicalBase: "$ce", bit: 14 };
+  if (logicalName === "__is_closure") return { physicalBase: "$cf", bit: 15 };
+  if (logicalName === "__closure_has_rest") return { physicalBase: "$cg", bit: 16 };
+  throw new Error(`unknown closure host bridge ${logicalName}`);
+}
+
+/**
  * Publish one closure host helper from its exact allocator object.
  *
- * The public export label remains byte-compatible. Program ABI tracking only
- * replaces the generic retained-module owner; it does not allocate another
- * function, rewrite the body, or change the host/runtime-visible namespace.
+ * The historical logical label remains the byte-compatible fast path. When a
+ * user already owns that label or the reserved short family, preserve every
+ * user export and fill the physical family through one free terminal alias.
+ * The runtime recovers that terminal alias without replacing the public name.
  */
 function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, derivedOrdinal: number | undefined): number {
   ctx.mod.functions.push(func);
@@ -73,11 +103,86 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
   if (funcIdx === undefined) {
     throw new Error(`closure host bridge ${func.name} lost its exact allocator object`);
   }
-  ctx.mod.exports.push({
-    name: func.name,
-    desc: { kind: "func", index: funcIdx },
-  });
+  const definition = closureHostBridgeDefinition(func.name);
+  const occupied = new Set(ctx.mod.exports.map((entry) => entry.name));
+  const physicalBase = definition.physicalBase;
+  let maxOccupiedSuffix = -1;
+  for (const name of occupied) {
+    if (!name.startsWith(physicalBase)) continue;
+    const suffix = name.slice(physicalBase.length);
+    if (/^\$*$/.test(suffix)) maxOccupiedSuffix = Math.max(maxOccupiedSuffix, suffix.length);
+  }
+  const logicalNameOccupied = occupied.has(func.name);
+  if (!logicalNameOccupied) {
+    ctx.mod.exports.push({
+      name: func.name,
+      desc: { kind: "func", index: funcIdx },
+    });
+    occupied.add(func.name);
+  }
+  if (logicalNameOccupied || maxOccupiedSuffix >= 0) {
+    for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
+      const physicalName = `${physicalBase}${"$".repeat(suffixLength)}`;
+      if (occupied.has(physicalName)) continue;
+      ctx.mod.exports.push({
+        name: physicalName,
+        desc: { kind: "func", index: funcIdx },
+      });
+      occupied.add(physicalName);
+    }
+  }
+  publishedClosureHostBridgeBits.set(
+    ctx,
+    (publishedClosureHostBridgeBits.get(ctx) ?? 0) | (1 << definition.bit),
+  );
   return funcIdx;
+}
+
+/**
+ * Publish one immutable compiler-authored availability manifest.
+ *
+ * The bitset distinguishes compiler helpers from user-controlled names. Its
+ * physical family is always present and collision-safe; the logical name uses
+ * a reserved NUL-containing internal label that ordinary TypeScript exports
+ * cannot declare accidentally.
+ */
+export function emitClosureHostBridgeManifest(ctx: CodegenContext): void {
+  if (publishedClosureHostBridgeManifests.has(ctx)) return;
+  const bits = publishedClosureHostBridgeBits.get(ctx) ?? 0;
+  if ((bits & (1 << 15)) === 0) return;
+  publishedClosureHostBridgeManifests.add(ctx);
+
+  const globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+  ctx.mod.globals.push({
+    name: CLOSURE_HOST_BRIDGE_MANIFEST_NAME,
+    type: { kind: "i32" },
+    mutable: false,
+    init: [{ op: "i32.const", value: CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC | bits }],
+  });
+
+  const occupied = new Set(ctx.mod.exports.map((entry) => entry.name));
+  if (!occupied.has(CLOSURE_HOST_BRIDGE_MANIFEST_NAME)) {
+    ctx.mod.exports.push({
+      name: CLOSURE_HOST_BRIDGE_MANIFEST_NAME,
+      desc: { kind: "global", index: globalIdx },
+    });
+    occupied.add(CLOSURE_HOST_BRIDGE_MANIFEST_NAME);
+  }
+  let maxOccupiedSuffix = -1;
+  for (const name of occupied) {
+    if (!name.startsWith(CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE)) continue;
+    const suffix = name.slice(CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE.length);
+    if (/^\$*$/.test(suffix)) maxOccupiedSuffix = Math.max(maxOccupiedSuffix, suffix.length);
+  }
+  for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
+    const physicalName = `${CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE}${"$".repeat(suffixLength)}`;
+    if (occupied.has(physicalName)) continue;
+    ctx.mod.exports.push({
+      name: physicalName,
+      desc: { kind: "global", index: globalIdx },
+    });
+    occupied.add(physicalName);
+  }
 }
 
 function directClosureHostBridgeOrdinal(arity: number): number | undefined {

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -25,6 +25,68 @@ import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { isSyntheticStructName } from "./emit-helpers.js";
 export { buildTransferredCharAtApplyArm } from "./char-at-transfer.js";
 import { installCompiledClosureToStringArm } from "./coercion-engine.js";
+import {
+  planProgramAbiEntrySourceSupportCallable,
+  PROGRAM_ABI_CALLABLE_ROLE,
+  resolveProgramAbiSupportCallableHandle,
+} from "./program-abi-planning.js";
+
+const CLOSURE_HOST_BRIDGE_ROLE = "closure-host-bridge";
+
+const CLOSURE_HOST_BRIDGE_ORDINAL = Object.freeze({
+  directCall0: 0,
+  directCall1: 1,
+  directCall2: 2,
+  directCall3: 3,
+  directCall4: 4,
+  methodCall0: 5,
+  methodCall1: 6,
+  methodCall2: 7,
+  methodCall3: 8,
+  methodCall4: 9,
+  methodCall5: 10,
+  closureArity: 11,
+  isClosure: 12,
+  closureHasRest: 13,
+} as const);
+
+/**
+ * Publish one closure host helper from its exact allocator object.
+ *
+ * The public export label remains byte-compatible. Program ABI tracking only
+ * replaces the generic retained-module owner; it does not allocate another
+ * function, rewrite the body, or change the host/runtime-visible namespace.
+ */
+function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, derivedOrdinal: number | undefined): number {
+  ctx.mod.functions.push(func);
+  const ref =
+    derivedOrdinal === undefined
+      ? undefined
+      : planProgramAbiEntrySourceSupportCallable(ctx, {
+          role: CLOSURE_HOST_BRIDGE_ROLE,
+          roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.closureHostBridge,
+          derivedOrdinal,
+          displayName: func.name,
+          func,
+        });
+  const funcIdx = resolveProgramAbiSupportCallableHandle(ctx, ref, func);
+  if (funcIdx === undefined) {
+    throw new Error(`closure host bridge ${func.name} lost its exact allocator object`);
+  }
+  ctx.mod.exports.push({
+    name: func.name,
+    desc: { kind: "func", index: funcIdx },
+  });
+  return funcIdx;
+}
+
+function directClosureHostBridgeOrdinal(arity: number): number | undefined {
+  return arity >= 0 && arity <= 4 ? CLOSURE_HOST_BRIDGE_ORDINAL.directCall0 + arity : undefined;
+}
+
+function methodClosureHostBridgeOrdinal(arity: number): number | undefined {
+  return arity >= 0 && arity <= 5 ? CLOSURE_HOST_BRIDGE_ORDINAL.methodCall0 + arity : undefined;
+}
 
 /**
  * Emit __call_fn_0 export (#851): call a zero-arg WasmGC closure from JS.
@@ -250,7 +312,6 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
   const params: ValType[] = [];
   for (let i = 0; i < arity + 1; i++) params.push({ kind: "externref" });
   const exportFuncTypeIdx = addFuncType(ctx, params, [{ kind: "externref" }], `$${exportName}_type`);
-  const funcIdx = ctx.numImportFuncs + mod.functions.length;
   const bwIdx = baseWrapperIdx;
 
   const body: Instr[] = [];
@@ -403,22 +464,21 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
   body.push(...buildFuncrefExtraction(ctx, entries, anyLocal, funcLocal));
   body.push(...funcrefDispatch);
 
-  mod.functions.push({
-    name: exportName,
-    typeIdx: exportFuncTypeIdx,
-    locals: [
-      { name: "__any", type: { kind: "anyref" } },
-      { name: "__struct", type: { kind: "ref_null", typeIdx: bwIdx } },
-      { name: "__funcref", type: { kind: "funcref" } },
-    ],
-    body,
-    exported: true,
-  } as WasmFunction);
-
-  mod.exports.push({
-    name: exportName,
-    desc: { kind: "func", index: funcIdx },
-  });
+  publishClosureHostBridge(
+    ctx,
+    {
+      name: exportName,
+      typeIdx: exportFuncTypeIdx,
+      locals: [
+        { name: "__any", type: { kind: "anyref" } },
+        { name: "__struct", type: { kind: "ref_null", typeIdx: bwIdx } },
+        { name: "__funcref", type: { kind: "funcref" } },
+      ],
+      body,
+      exported: true,
+    } as WasmFunction,
+    directClosureHostBridgeOrdinal(arity),
+  );
 }
 
 /**
@@ -588,7 +648,6 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
   const params: ValType[] = [];
   for (let i = 0; i < totalParams; i++) params.push({ kind: "externref" });
   const exportFuncTypeIdx = addFuncType(ctx, params, [{ kind: "externref" }], `$${exportName}_type`);
-  const funcIdx = ctx.numImportFuncs + mod.functions.length;
   const bwIdx = baseWrapperIdx;
 
   // Convert closure externref → anyref (closure is at local index 1).
@@ -851,27 +910,26 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
   body.push({ op: "global.set", index: currentThisGlobalIdx });
   body.push({ op: "local.get", index: resultSaveLocal });
 
-  mod.functions.push({
-    name: exportName,
-    typeIdx: exportFuncTypeIdx,
-    locals: [
-      { name: "__any", type: { kind: "anyref" } },
-      { name: "__struct", type: { kind: "ref_null", typeIdx: bwIdx } },
-      { name: "__funcref", type: { kind: "funcref" } },
-      { name: "__prev_this", type: { kind: "externref" } },
-      { name: "__result", type: { kind: "externref" } },
-      // (#3673 round 10) declared arity read off the root wrapper for the
-      // arity-bucketed signature dispatch (-1 = not root-readable).
-      { name: "__declared_arity", type: { kind: "i32" } },
-    ],
-    body,
-    exported: true,
-  } as WasmFunction);
-
-  mod.exports.push({
-    name: exportName,
-    desc: { kind: "func", index: funcIdx },
-  });
+  const funcIdx = publishClosureHostBridge(
+    ctx,
+    {
+      name: exportName,
+      typeIdx: exportFuncTypeIdx,
+      locals: [
+        { name: "__any", type: { kind: "anyref" } },
+        { name: "__struct", type: { kind: "ref_null", typeIdx: bwIdx } },
+        { name: "__funcref", type: { kind: "funcref" } },
+        { name: "__prev_this", type: { kind: "externref" } },
+        { name: "__result", type: { kind: "externref" } },
+        // (#3673 round 10) declared arity read off the root wrapper for the
+        // arity-bucketed signature dispatch (-1 = not root-readable).
+        { name: "__declared_arity", type: { kind: "i32" } },
+      ],
+      body,
+      exported: true,
+    } as WasmFunction,
+    methodClosureHostBridgeOrdinal(arity),
+  );
 
   // (#1719 CPR) Register in funcMap so the in-Wasm `__drive_proto_iterator`
   // driver (filled in post-processing) can resolve `__call_fn_method_0` by name
@@ -901,7 +959,6 @@ export function emitIsClosureExport(ctx: CodegenContext): void {
   if (baseTypeIdxs.length === 0) return;
 
   const isClosureTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$is_closure_type");
-  const funcIdx = ctx.numImportFuncs + mod.functions.length;
 
   // body: convert extern→any, then chained ref.test → return 1 on first match.
   const body: Instr[] = [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "local.set", index: 1 }];
@@ -916,18 +973,17 @@ export function emitIsClosureExport(ctx: CodegenContext): void {
   }
   body.push({ op: "i32.const", value: 0 });
 
-  mod.functions.push({
-    name: "__is_closure",
-    typeIdx: isClosureTypeIdx,
-    locals: [{ name: "__any", type: { kind: "anyref" } }],
-    body,
-    exported: true,
-  } as WasmFunction);
-
-  mod.exports.push({
-    name: "__is_closure",
-    desc: { kind: "func", index: funcIdx },
-  });
+  publishClosureHostBridge(
+    ctx,
+    {
+      name: "__is_closure",
+      typeIdx: isClosureTypeIdx,
+      locals: [{ name: "__any", type: { kind: "anyref" } }],
+      body,
+      exported: true,
+    } as WasmFunction,
+    CLOSURE_HOST_BRIDGE_ORDINAL.isClosure,
+  );
 }
 
 /**
@@ -1130,7 +1186,6 @@ export function emitClosureArityExport(ctx: CodegenContext): void {
   if (entries.length === 0) return;
 
   const arityTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$closure_arity_type");
-  const funcIdx = ctx.numImportFuncs + mod.functions.length;
 
   // Locals: 0 = value externref (param), 1 = anyref, 2 = funcref.
   const anyLocal = 1;
@@ -1184,21 +1239,20 @@ export function emitClosureArityExport(ctx: CodegenContext): void {
   }
   body.push({ op: "i32.const", value: -1 });
 
-  mod.functions.push({
-    name: "__closure_arity",
-    typeIdx: arityTypeIdx,
-    locals: [
-      { name: "__any", type: { kind: "anyref" } },
-      { name: "__funcref", type: { kind: "funcref" } },
-    ],
-    body,
-    exported: true,
-  } as WasmFunction);
-
-  mod.exports.push({
-    name: "__closure_arity",
-    desc: { kind: "func", index: funcIdx },
-  });
+  const funcIdx = publishClosureHostBridge(
+    ctx,
+    {
+      name: "__closure_arity",
+      typeIdx: arityTypeIdx,
+      locals: [
+        { name: "__any", type: { kind: "anyref" } },
+        { name: "__funcref", type: { kind: "funcref" } },
+      ],
+      body,
+      exported: true,
+    } as WasmFunction,
+    CLOSURE_HOST_BRIDGE_ORDINAL.closureArity,
+  );
   // Native in-module callers (notably `__apply_closure`) need the same
   // classifier the JS wrapper uses. Register the canonical function index so
   // reserve-then-fill runtimes can call it without introducing another ABI.
@@ -1224,7 +1278,6 @@ export function emitClosureHasRestExport(ctx: CodegenContext): void {
   if (restTypes.length === 0) return;
 
   const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$closure_has_rest_type");
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
   const body: Instr[] = [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "local.set", index: 1 }];
   for (const restType of new Set(restTypes)) {
     body.push(
@@ -1239,17 +1292,17 @@ export function emitClosureHasRestExport(ctx: CodegenContext): void {
   }
   body.push({ op: "i32.const", value: 0 });
 
-  ctx.mod.functions.push({
-    name: "__closure_has_rest",
-    typeIdx,
-    locals: [{ name: "__any", type: { kind: "anyref" } }],
-    body,
-    exported: true,
-  } as WasmFunction);
-  ctx.mod.exports.push({
-    name: "__closure_has_rest",
-    desc: { kind: "func", index: funcIdx },
-  });
+  publishClosureHostBridge(
+    ctx,
+    {
+      name: "__closure_has_rest",
+      typeIdx,
+      locals: [{ name: "__any", type: { kind: "anyref" } }],
+      body,
+      exported: true,
+    } as WasmFunction,
+    CLOSURE_HOST_BRIDGE_ORDINAL.closureHasRest,
+  );
 }
 
 /**

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -36,8 +36,11 @@ const CLOSURE_HOST_BRIDGE_MANIFEST_NAME = "__\0js2_closure_host_bridge";
 const CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE = "$cm";
 const CLOSURE_HOST_BRIDGE_MARKER_NAME = "__\0js2_closure_host_bridge_marker";
 const CLOSURE_HOST_BRIDGE_MARKER_PHYSICAL_BASE = "$ct";
+const CLOSURE_HOST_BRIDGE_BINDINGS_NAME = "__\0js2_closure_host_bridge_bindings";
+const CLOSURE_HOST_BRIDGE_BINDINGS_PHYSICAL_BASE = "$cu";
 const CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC = 0x5a200000;
 const publishedClosureHostBridgeBits = new WeakMap<CodegenContext, number>();
+const publishedClosureHostBridgeFuncs = new WeakMap<CodegenContext, Map<number, WasmFunction>>();
 const publishedClosureHostBridgeManifests = new WeakSet<CodegenContext>();
 
 const CLOSURE_HOST_BRIDGE_ORDINAL = Object.freeze({
@@ -58,7 +61,7 @@ const CLOSURE_HOST_BRIDGE_ORDINAL = Object.freeze({
 } as const);
 
 /**
- * Reserved collision-only export family for closure helpers.
+ * Reserved physical export family for closure helpers.
  *
  * Keep the physical family independent from the Program ABI ordinals: method
  * dispatchers 6..8 remain runtime-visible but are intentionally outside the
@@ -84,10 +87,11 @@ function closureHostBridgeDefinition(logicalName: string): { physicalBase: strin
 /**
  * Publish one closure host helper from its exact allocator object.
  *
- * The historical logical label remains the byte-compatible fast path. When a
- * user already owns that label or the reserved short family, preserve every
- * user export and fill the physical family through one free terminal alias.
- * The runtime recovers that terminal alias without replacing the public name.
+ * The historical logical label remains the public fast path. Every compiler
+ * helper also owns the terminal alias in its reserved short family; when a user
+ * already owns that label or prefix, preserve each user export and append the
+ * exact helper. The runtime authenticates that alias without replacing public
+ * names.
  */
 function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, derivedOrdinal: number | undefined): number {
   ctx.mod.functions.push(func);
@@ -122,28 +126,33 @@ function publishClosureHostBridge(ctx: CodegenContext, func: WasmFunction, deriv
     });
     occupied.add(func.name);
   }
-  if (logicalNameOccupied || maxOccupiedSuffix >= 0) {
-    for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
-      const physicalName = `${physicalBase}${"$".repeat(suffixLength)}`;
-      if (occupied.has(physicalName)) continue;
-      ctx.mod.exports.push({
-        name: physicalName,
-        desc: { kind: "func", index: funcIdx },
-      });
-      occupied.add(physicalName);
-    }
+  for (let suffixLength = 0; suffixLength <= maxOccupiedSuffix + 1; suffixLength++) {
+    const physicalName = `${physicalBase}${"$".repeat(suffixLength)}`;
+    if (occupied.has(physicalName)) continue;
+    ctx.mod.exports.push({
+      name: physicalName,
+      desc: { kind: "func", index: funcIdx },
+    });
+    occupied.add(physicalName);
   }
   publishedClosureHostBridgeBits.set(ctx, (publishedClosureHostBridgeBits.get(ctx) ?? 0) | (1 << definition.bit));
+  let publishedFuncs = publishedClosureHostBridgeFuncs.get(ctx);
+  if (!publishedFuncs) {
+    publishedFuncs = new Map();
+    publishedClosureHostBridgeFuncs.set(ctx, publishedFuncs);
+  }
+  publishedFuncs.set(definition.bit, func);
   return funcIdx;
 }
 
 /**
  * Publish one immutable compiler-authored availability manifest.
  *
- * The bitset distinguishes compiler helpers from user-controlled names. Its
- * physical family is always present and collision-safe; the logical name uses
- * a reserved NUL-containing internal label that ordinary TypeScript exports
- * cannot declare accidentally.
+ * The bitset distinguishes compiler helpers from user-controlled names. An
+ * empty marker table authenticates the metadata, and a fixed funcref table
+ * binds each availability bit to the exact helper object. Every physical family
+ * is collision-safe; the logical names use reserved NUL-containing labels that
+ * ordinary TypeScript exports cannot declare accidentally.
  */
 function emitClosureHostBridgeManifest(ctx: CodegenContext): void {
   if (publishedClosureHostBridgeManifests.has(ctx)) return;
@@ -151,8 +160,20 @@ function emitClosureHostBridgeManifest(ctx: CodegenContext): void {
   if ((bits & (1 << 15)) === 0) return;
   publishedClosureHostBridgeManifests.add(ctx);
 
-  const tableIdx = ctx.mod.imports.filter((entry) => entry.desc.kind === "table").length + ctx.mod.tables.length;
+  const bindingsTableIdx =
+    ctx.mod.imports.filter((entry) => entry.desc.kind === "table").length + ctx.mod.tables.length;
+  ctx.mod.tables.push({ elementType: "funcref", min: 17, max: 17 });
+  const markerTableIdx = bindingsTableIdx + 1;
   ctx.mod.tables.push({ elementType: "funcref", min: 0, max: 0 });
+  for (const [bit, func] of publishedClosureHostBridgeFuncs.get(ctx) ?? []) {
+    const funcOffset = ctx.mod.functions.indexOf(func);
+    if (funcOffset < 0) throw new Error(`closure host bridge manifest lost helper bit ${bit}`);
+    ctx.mod.elements.push({
+      tableIdx: bindingsTableIdx,
+      offset: [{ op: "i32.const", value: bit }],
+      funcIndices: [ctx.numImportFuncs + funcOffset],
+    });
+  }
   const globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
   ctx.mod.globals.push({
     name: CLOSURE_HOST_BRIDGE_MANIFEST_NAME,
@@ -187,7 +208,11 @@ function emitClosureHostBridgeManifest(ctx: CodegenContext): void {
 
   publishManifestExport(CLOSURE_HOST_BRIDGE_MARKER_NAME, CLOSURE_HOST_BRIDGE_MARKER_PHYSICAL_BASE, {
     kind: "table",
-    index: tableIdx,
+    index: markerTableIdx,
+  });
+  publishManifestExport(CLOSURE_HOST_BRIDGE_BINDINGS_NAME, CLOSURE_HOST_BRIDGE_BINDINGS_PHYSICAL_BASE, {
+    kind: "table",
+    index: bindingsTableIdx,
   });
   publishManifestExport(CLOSURE_HOST_BRIDGE_MANIFEST_NAME, CLOSURE_HOST_BRIDGE_MANIFEST_PHYSICAL_BASE, {
     kind: "global",

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -338,7 +338,6 @@ import {
   emitIsClosureExport,
   emitClosureArityExport,
   emitClosureHasRestExport,
-  emitClosureHostBridgeManifest,
   emitIsDataStructExport,
   fillStandaloneTypeofClosureArms,
 } from "./closure-exports.js"; // (#3272) extracted verbatim
@@ -4179,7 +4178,6 @@ export function generateModule(
     // #2742: classify accessor-returned rest closures before the JS runtime
     // exposes them through a dispatcher that cannot materialize their rest vec.
     emitClosureHasRestExport(ctx);
-    emitClosureHostBridgeManifest(ctx);
 
     // #2794: emit __is_data_struct(externref) -> i32 — POSITIVE data-vs-closure
     // discriminator so `_wrapForHost` only bridges genuine closures and never
@@ -6165,7 +6163,6 @@ export function generateMultiModule(
 
     // #2742: accessor-returned rest-closure discriminator (see primary path).
     emitClosureHasRestExport(ctx);
-    emitClosureHostBridgeManifest(ctx);
 
     // #2794: POSITIVE data-vs-closure discriminator (see generateModule path).
     emitIsDataStructExport(ctx);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -338,6 +338,7 @@ import {
   emitIsClosureExport,
   emitClosureArityExport,
   emitClosureHasRestExport,
+  emitClosureHostBridgeManifest,
   emitIsDataStructExport,
   fillStandaloneTypeofClosureArms,
 } from "./closure-exports.js"; // (#3272) extracted verbatim
@@ -4178,6 +4179,7 @@ export function generateModule(
     // #2742: classify accessor-returned rest closures before the JS runtime
     // exposes them through a dispatcher that cannot materialize their rest vec.
     emitClosureHasRestExport(ctx);
+    emitClosureHostBridgeManifest(ctx);
 
     // #2794: emit __is_data_struct(externref) -> i32 — POSITIVE data-vs-closure
     // discriminator so `_wrapForHost` only bridges genuine closures and never
@@ -6163,6 +6165,7 @@ export function generateMultiModule(
 
     // #2742: accessor-returned rest-closure discriminator (see primary path).
     emitClosureHasRestExport(ctx);
+    emitClosureHostBridgeManifest(ctx);
 
     // #2794: POSITIVE data-vs-closure discriminator (see generateModule path).
     emitIsDataStructExport(ctx);

--- a/src/codegen/program-abi-planning.ts
+++ b/src/codegen/program-abi-planning.ts
@@ -1,11 +1,13 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { irGlobalBindingKey } from "../ir/abi-bindings.js";
-import { irCallableBindingKey, irUnitCallableBindingId } from "../ir/callable-bindings.js";
+import { irCallableBindingKey, irSupportFuncRef, irUnitCallableBindingId } from "../ir/callable-bindings.js";
 import { createIrBindingId, type IrBindingId, type IrClassId, type IrSourceId, type IrUnitId } from "../ir/identity.js";
 import type { IrFuncRef, IrGlobalRef } from "../ir/nodes.js";
-import type { FuncTypeDef, GlobalDef, WasmFunction } from "../ir/types.js";
+import { ProgramAbiInvariantError } from "../ir/program-abi.js";
+import type { FuncHandle, FuncTypeDef, GlobalDef, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { definedFuncHandleOf } from "./func-space.js";
 import {
   canonicalProgramAbiCallableTypeContract,
   canonicalProgramAbiValType,
@@ -22,6 +24,7 @@ export const PROGRAM_ABI_CALLABLE_ROLE = Object.freeze({
   retainedModuleFunction: 6,
   typedThisTwin: 7,
   vecHostBridge: 8,
+  closureHostBridge: 9,
 } as const);
 
 export const PROGRAM_ABI_GLOBAL_ROLE = Object.freeze({
@@ -76,6 +79,98 @@ export interface ProgramAbiFunctionValuePlan {
   readonly trampoline: IrFuncRef;
   readonly cacheGlobal: IrGlobalRef;
   readonly target: IrFuncRef;
+}
+
+export interface ProgramAbiEntrySourceSupportCallablePlan {
+  readonly role: string;
+  readonly roleOrdinal: number;
+  readonly derivedOrdinal: number;
+  readonly displayName: string;
+  readonly func: WasmFunction;
+}
+
+function canonicalEntrySourceId(ctx: CodegenContext): IrSourceId {
+  const session = ctx.programAbiSession;
+  if (!session) {
+    throw new ProgramAbiInvariantError(
+      "unknown-order-anchor",
+      "entry-source support callable planning requires an active Program ABI session",
+    );
+  }
+  const entries = session.inventory.sources.filter((source) => source.kind === "entry");
+  if (entries.length !== 1) {
+    throw new ProgramAbiInvariantError(
+      "unknown-order-anchor",
+      `entry-source support callable planning requires exactly one canonical entry source, found ${entries.length}`,
+    );
+  }
+  return entries[0]!.id;
+}
+
+/**
+ * Give one already-allocated compiler support function an exact entry-source
+ * owner before the retained-callable sweep can classify it generically.
+ *
+ * The allocator object, not its diagnostic label or current numeric index,
+ * owns the slot. Callers can therefore resolve the same binding after late
+ * imports or dead-slot compaction through
+ * {@link resolveProgramAbiSupportCallableHandle}.
+ */
+export function planProgramAbiEntrySourceSupportCallable(
+  ctx: CodegenContext,
+  plan: ProgramAbiEntrySourceSupportCallablePlan,
+): IrFuncRef | undefined {
+  const session = ctx.programAbiSession;
+  if (!session) return undefined;
+  const sourceId = canonicalEntrySourceId(ctx);
+  const signature = ctx.mod.types[plan.func.typeIdx];
+  if (!signature || signature.kind !== "func") {
+    throw new ProgramAbiInvariantError(
+      "type-remap-mismatch",
+      `entry-source support callable ${plan.displayName} references non-function or missing type ${plan.func.typeIdx}`,
+    );
+  }
+  const ref = irSupportFuncRef(sourceId, plan.role, plan.displayName, plan.derivedOrdinal);
+  const bindingId = planProgramAbiSupportCallable(ctx, {
+    ref,
+    anchor: { kind: "source", sourceId },
+    role: plan.role,
+    roleOrdinal: plan.roleOrdinal,
+    derivedOrdinal: plan.derivedOrdinal,
+    signature,
+    func: plan.func,
+  });
+  if (bindingId !== ref.binding.bindingId) {
+    throw new ProgramAbiInvariantError(
+      "invalid-binding-reference",
+      `entry-source support callable ${plan.displayName} was not accepted for ${ref.binding.bindingId}`,
+    );
+  }
+  return ref;
+}
+
+/**
+ * Resolve an exact planned support allocator to its current function handle.
+ *
+ * This consults the Program ABI locator while tracking is active and validates
+ * that the locator still owns the supplied function object. The untracked
+ * compilation path falls back to the same allocator-object lookup so enabling
+ * outcome tracking cannot change emitted bytes.
+ */
+export function resolveProgramAbiSupportCallableHandle(
+  ctx: CodegenContext,
+  ref: IrFuncRef | undefined,
+  func: WasmFunction,
+): FuncHandle | undefined {
+  const session = ctx.programAbiSession;
+  if (!session || !ref) return definedFuncHandleOf(ctx, func);
+  if (ref.binding.kind !== "support" || !session.hasLocator(ref.binding.bindingId, func)) {
+    throw new ProgramAbiInvariantError(
+      "missing-required-locator",
+      `support callable ${ref.name} is not owned by its exact Program ABI allocator object`,
+    );
+  }
+  return session.resolveCurrentIndex(ref.binding.bindingId, "function", irCallableBindingKey(ref.binding));
 }
 
 /**

--- a/src/codegen/program-abi-planning.ts
+++ b/src/codegen/program-abi-planning.ts
@@ -131,6 +131,13 @@ export function planProgramAbiEntrySourceSupportCallable(
     );
   }
   const ref = irSupportFuncRef(sourceId, plan.role, plan.displayName, plan.derivedOrdinal);
+  if (ref.binding.kind !== "support") {
+    throw new ProgramAbiInvariantError(
+      "invalid-binding-reference",
+      `entry-source support callable ${plan.displayName} did not produce a support binding`,
+    );
+  }
+  const expectedBindingId = ref.binding.bindingId;
   const bindingId = planProgramAbiSupportCallable(ctx, {
     ref,
     anchor: { kind: "source", sourceId },
@@ -140,10 +147,10 @@ export function planProgramAbiEntrySourceSupportCallable(
     signature,
     func: plan.func,
   });
-  if (bindingId !== ref.binding.bindingId) {
+  if (bindingId !== expectedBindingId) {
     throw new ProgramAbiInvariantError(
       "invalid-binding-reference",
-      `entry-source support callable ${plan.displayName} was not accepted for ${ref.binding.bindingId}`,
+      `entry-source support callable ${plan.displayName} was not accepted for ${expectedBindingId}`,
     );
   }
   return ref;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1002,6 +1002,7 @@ const _CLOSURE_HOST_BRIDGE_EXPORTS = [
 ] as const;
 
 const _CLOSURE_HOST_BRIDGE_MANIFEST = ["__\0js2_closure_host_bridge", "$cm"] as const;
+const _CLOSURE_HOST_BRIDGE_MARKER = ["__\0js2_closure_host_bridge_marker", "$ct"] as const;
 const _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC = 0x5a200000;
 const _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC_MASK = 0xfff00000;
 const _CLOSURE_HOST_BRIDGE_MANIFEST_BITS_MASK = 0x0001ffff;
@@ -1021,6 +1022,11 @@ function _terminalHostBridgeAlias(exports: Record<string, any>, physicalBase: st
 
 /** Read compiler-authored closure-helper availability from its i32 manifest. */
 function _closureHostBridgeManifestBits(exports: Record<string, any>): number | undefined {
+  const [markerLogicalName, markerPhysicalBase] = _CLOSURE_HOST_BRIDGE_MARKER;
+  if (!Object.prototype.hasOwnProperty.call(exports, markerLogicalName)) return undefined;
+  const marker = _terminalHostBridgeAlias(exports, markerPhysicalBase);
+  if (!(marker instanceof WebAssembly.Table)) return undefined;
+
   const [logicalName, physicalBase] = _CLOSURE_HOST_BRIDGE_MANIFEST;
   if (!Object.prototype.hasOwnProperty.call(exports, logicalName)) return undefined;
   const manifest = _terminalHostBridgeAlias(exports, physicalBase);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -981,23 +981,88 @@ const _VEC_HOST_BRIDGE_EXPORTS = [
   ["__vec_pop", "$v5"],
 ] as const;
 
+const _CLOSURE_HOST_BRIDGE_EXPORTS = [
+  ["__call_fn_0", "$c0"],
+  ["__call_fn_1", "$c1"],
+  ["__call_fn_2", "$c2"],
+  ["__call_fn_3", "$c3"],
+  ["__call_fn_4", "$c4"],
+  ["__call_fn_method_0", "$c5"],
+  ["__call_fn_method_1", "$c6"],
+  ["__call_fn_method_2", "$c7"],
+  ["__call_fn_method_3", "$c8"],
+  ["__call_fn_method_4", "$c9"],
+  ["__call_fn_method_5", "$ca"],
+  ["__call_fn_method_6", "$cb"],
+  ["__call_fn_method_7", "$cc"],
+  ["__call_fn_method_8", "$cd"],
+  ["__closure_arity", "$ce"],
+  ["__is_closure", "$cf"],
+  ["__closure_has_rest", "$cg"],
+] as const;
+
+const _CLOSURE_HOST_BRIDGE_MANIFEST = ["__\0js2_closure_host_bridge", "$cm"] as const;
+const _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC = 0x5a200000;
+const _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC_MASK = 0xfff00000;
+const _CLOSURE_HOST_BRIDGE_MANIFEST_BITS_MASK = 0x0001ffff;
+
 /**
- * Resolve a collision-only compiler vec bridge without replacing a user's
- * same-labelled public export. The logical export is already authoritative
- * when no physical family exists.
+ * Resolve the terminal compiler alias in one collision-safe physical family.
  */
-function _vecHostBridgeExportView<T extends Record<string, any>>(exports: T): T {
-  let view: T | undefined;
+function _terminalHostBridgeAlias(exports: Record<string, any>, physicalBase: string): unknown {
+  let physicalName = physicalBase;
+  let helper: unknown;
+  while (Object.prototype.hasOwnProperty.call(exports, physicalName)) {
+    helper = exports[physicalName];
+    physicalName += "$";
+  }
+  return helper;
+}
+
+/** Read compiler-authored closure-helper availability from its i32 manifest. */
+function _closureHostBridgeManifestBits(exports: Record<string, any>): number | undefined {
+  const [logicalName, physicalBase] = _CLOSURE_HOST_BRIDGE_MANIFEST;
+  if (!Object.prototype.hasOwnProperty.call(exports, logicalName)) return undefined;
+  const manifest = _terminalHostBridgeAlias(exports, physicalBase);
+  if (!(manifest instanceof WebAssembly.Global) || typeof manifest.value !== "number") return undefined;
+  const value = manifest.value | 0;
+  if ((value & _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC_MASK) !== _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC) return undefined;
+  return value & _CLOSURE_HOST_BRIDGE_MANIFEST_BITS_MASK;
+}
+
+/**
+ * Compose vec and closure bridge projections from the same raw export object.
+ *
+ * Vec keeps its collision-only logical-name gate. Closure availability comes
+ * only from the compiler-authored manifest; user-controlled helper-like names
+ * never establish ownership. All overrides land in one prototype view so the
+ * two bridge families cannot hide each other's raw own properties.
+ */
+function _hostBridgeExportView<T extends Record<string, any>>(exports: T): T {
+  const overrides = new Map<string, unknown>();
   for (const [logicalName, physicalBase] of _VEC_HOST_BRIDGE_EXPORTS) {
     if (!Object.prototype.hasOwnProperty.call(exports, logicalName)) continue;
-    let physicalName = physicalBase;
-    let helper: unknown;
-    while (Object.prototype.hasOwnProperty.call(exports, physicalName)) {
-      helper = exports[physicalName];
-      physicalName += "$";
-    }
+    const helper = _terminalHostBridgeAlias(exports, physicalBase);
     if (typeof helper !== "function" || exports[logicalName] === helper) continue;
-    view ??= Object.create(exports) as T;
+    overrides.set(logicalName, helper);
+  }
+
+  const closureBits = _closureHostBridgeManifestBits(exports);
+  for (let bit = 0; bit < _CLOSURE_HOST_BRIDGE_EXPORTS.length; bit++) {
+    const [logicalName, physicalBase] = _CLOSURE_HOST_BRIDGE_EXPORTS[bit]!;
+    if (!Object.prototype.hasOwnProperty.call(exports, logicalName)) continue;
+    let helper: unknown;
+    if (closureBits !== undefined && (closureBits & (1 << bit)) !== 0) {
+      helper = _terminalHostBridgeAlias(exports, physicalBase);
+      if (typeof helper !== "function") helper = exports[logicalName];
+    }
+    if (exports[logicalName] === helper) continue;
+    overrides.set(logicalName, helper);
+  }
+
+  if (overrides.size === 0) return exports;
+  const view = Object.create(exports) as T;
+  for (const [logicalName, helper] of overrides) {
     Object.defineProperty(view, logicalName, {
       value: helper,
       enumerable: false,
@@ -1005,7 +1070,7 @@ function _vecHostBridgeExportView<T extends Record<string, any>>(exports: T): T 
       writable: false,
     });
   }
-  return view ?? exports;
+  return view;
 }
 
 // (#3673) Memoized classification for `_isWasmStruct`. The predicate is on the
@@ -15327,7 +15392,7 @@ export function buildImports(
   // Always provide setExports — needed for callbacks, native string marshaling,
   // and struct field getter discovery (__sget_*).
   result.setExports = (exports: Record<string, Function>) => {
-    wasmExports = _vecHostBridgeExportView(exports);
+    wasmExports = _hostBridgeExportView(exports);
     // (#1712) Replay operations parked during the module START function (see
     // pendingExportsDeferred above) now that struct introspection exports
     // are reachable.
@@ -15468,11 +15533,11 @@ export function wrapExports(
     signatures?: Record<string, WrapExportsSignature>;
   },
 ): Record<string, any> {
-  const callFn0 = rawExports.__call_fn_0 as ((closure: any) => any) | undefined;
-  const callFn1 = rawExports.__call_fn_1 as ((closure: any, arg: any) => any) | undefined;
   // #1504: marshal by default; `marshal: false` keeps raw WasmGC handles.
   const marshal: "copy" | false = options?.marshal === false ? false : "copy";
-  const exportsForMarshal = _vecHostBridgeExportView(rawExports as unknown as Record<string, Function>);
+  const exportsForMarshal = _hostBridgeExportView(rawExports as unknown as Record<string, Function>);
+  const callFn0 = exportsForMarshal.__call_fn_0 as ((closure: any) => any) | undefined;
+  const callFn1 = exportsForMarshal.__call_fn_1 as ((closure: any, arg: any) => any) | undefined;
   // (#1700) Vec allocator + byte-writer for Uint8Array args. Either may be
   // undefined, in which case the wrapper falls back
   // to passing the arg through unchanged.
@@ -15521,6 +15586,11 @@ export function wrapExports(
   const hasVecLen = typeof exportsForMarshal.__vec_len === "function";
   const looksMarshalable = (val: any): boolean => {
     if (val == null || typeof val !== "object") return false;
+    // No positively discovered compiler closure family means this module
+    // cannot return a compiled closure. Do not let a user `__is_closure`
+    // label or the historical old-module fallback turn class instances into
+    // callable wrappers.
+    if (typeof isClosureFn !== "function") return true;
     if (typeof isClosureFn === "function") {
       try {
         if (isClosureFn(val) === 1) return false;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1010,6 +1010,10 @@ const _CLOSURE_HOST_BRIDGE_MANIFEST_BITS_MASK = 0x0001ffff;
 const _CLOSURE_HOST_BRIDGE_MANIFEST_RESERVED_MASK = 0x000e0000;
 const _immutableI32GlobalVerdict = new WeakSet<WebAssembly.Global>();
 let _immutableI32GlobalProbeModule: WebAssembly.Module | undefined;
+const _emptyFuncrefTableVerdict = new WeakSet<WebAssembly.Table>();
+const _bindingFuncrefTableVerdict = new WeakSet<WebAssembly.Table>();
+let _emptyFuncrefTableProbeModule: WebAssembly.Module | undefined;
+let _bindingFuncrefTableProbeModule: WebAssembly.Module | undefined;
 
 /**
  * Resolve the terminal compiler alias in one collision-safe physical family.
@@ -1040,6 +1044,30 @@ function _isImmutableI32Global(value: unknown): value is WebAssembly.Global {
   }
 }
 
+/** Prove a Table's exact funcref limits through Wasm import validation. */
+function _isExactFuncrefTable(value: unknown, size: 0 | 17): value is WebAssembly.Table {
+  if (!(value instanceof WebAssembly.Table) || value.length !== size) return false;
+  const verdict = size === 0 ? _emptyFuncrefTableVerdict : _bindingFuncrefTableVerdict;
+  if (verdict.has(value)) return true;
+  try {
+    const bytes =
+      size === 0
+        ? [0, 97, 115, 109, 1, 0, 0, 0, 2, 10, 1, 1, 101, 1, 116, 1, 112, 1, 0, 0]
+        : [0, 97, 115, 109, 1, 0, 0, 0, 2, 10, 1, 1, 101, 1, 116, 1, 112, 1, 17, 17];
+    let probe = size === 0 ? _emptyFuncrefTableProbeModule : _bindingFuncrefTableProbeModule;
+    if (!probe) {
+      probe = new WebAssembly.Module(Uint8Array.from(bytes));
+      if (size === 0) _emptyFuncrefTableProbeModule = probe;
+      else _bindingFuncrefTableProbeModule = probe;
+    }
+    new WebAssembly.Instance(probe, { e: { t: value } });
+    verdict.add(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 interface ClosureHostBridgeMetadata {
   bits: number;
   bindings: WebAssembly.Table;
@@ -1050,7 +1078,7 @@ function _closureHostBridgeMetadata(exports: Record<string, any>): ClosureHostBr
   const [markerLogicalName, markerPhysicalBase] = _CLOSURE_HOST_BRIDGE_MARKER;
   if (!Object.prototype.hasOwnProperty.call(exports, markerLogicalName)) return undefined;
   const marker = _terminalHostBridgeAlias(exports, markerPhysicalBase);
-  if (!(marker instanceof WebAssembly.Table) || marker.length !== 0) return undefined;
+  if (!_isExactFuncrefTable(marker, 0)) return undefined;
 
   const [logicalName, physicalBase] = _CLOSURE_HOST_BRIDGE_MANIFEST;
   if (!Object.prototype.hasOwnProperty.call(exports, logicalName)) return undefined;
@@ -1064,9 +1092,7 @@ function _closureHostBridgeMetadata(exports: Record<string, any>): ClosureHostBr
   const [bindingsLogicalName, bindingsPhysicalBase] = _CLOSURE_HOST_BRIDGE_BINDINGS;
   if (!Object.prototype.hasOwnProperty.call(exports, bindingsLogicalName)) return undefined;
   const bindings = _terminalHostBridgeAlias(exports, bindingsPhysicalBase);
-  if (!(bindings instanceof WebAssembly.Table) || bindings.length !== _CLOSURE_HOST_BRIDGE_EXPORTS.length) {
-    return undefined;
-  }
+  if (!_isExactFuncrefTable(bindings, 17)) return undefined;
   try {
     for (let bit = 0; bit < _CLOSURE_HOST_BRIDGE_EXPORTS.length; bit++) {
       const binding = bindings.get(bit);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1003,9 +1003,13 @@ const _CLOSURE_HOST_BRIDGE_EXPORTS = [
 
 const _CLOSURE_HOST_BRIDGE_MANIFEST = ["__\0js2_closure_host_bridge", "$cm"] as const;
 const _CLOSURE_HOST_BRIDGE_MARKER = ["__\0js2_closure_host_bridge_marker", "$ct"] as const;
+const _CLOSURE_HOST_BRIDGE_BINDINGS = ["__\0js2_closure_host_bridge_bindings", "$cu"] as const;
 const _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC = 0x5a200000;
 const _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC_MASK = 0xfff00000;
 const _CLOSURE_HOST_BRIDGE_MANIFEST_BITS_MASK = 0x0001ffff;
+const _CLOSURE_HOST_BRIDGE_MANIFEST_RESERVED_MASK = 0x000e0000;
+const _immutableI32GlobalVerdict = new WeakSet<WebAssembly.Global>();
+let _immutableI32GlobalProbeModule: WebAssembly.Module | undefined;
 
 /**
  * Resolve the terminal compiler alias in one collision-safe physical family.
@@ -1020,20 +1024,58 @@ function _terminalHostBridgeAlias(exports: Record<string, any>, physicalBase: st
   return helper;
 }
 
-/** Read compiler-authored closure-helper availability from its i32 manifest. */
-function _closureHostBridgeManifestBits(exports: Record<string, any>): number | undefined {
+/** Prove a Global's exact type and mutability through Wasm import validation. */
+function _isImmutableI32Global(value: unknown): value is WebAssembly.Global {
+  if (!(value instanceof WebAssembly.Global)) return false;
+  if (_immutableI32GlobalVerdict.has(value)) return true;
+  try {
+    _immutableI32GlobalProbeModule ??= new WebAssembly.Module(
+      Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 2, 8, 1, 1, 101, 1, 103, 3, 127, 0]),
+    );
+    new WebAssembly.Instance(_immutableI32GlobalProbeModule, { e: { g: value } });
+    _immutableI32GlobalVerdict.add(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface ClosureHostBridgeMetadata {
+  bits: number;
+  bindings: WebAssembly.Table;
+}
+
+/** Read and authenticate compiler-authored closure-helper metadata. */
+function _closureHostBridgeMetadata(exports: Record<string, any>): ClosureHostBridgeMetadata | undefined {
   const [markerLogicalName, markerPhysicalBase] = _CLOSURE_HOST_BRIDGE_MARKER;
   if (!Object.prototype.hasOwnProperty.call(exports, markerLogicalName)) return undefined;
   const marker = _terminalHostBridgeAlias(exports, markerPhysicalBase);
-  if (!(marker instanceof WebAssembly.Table)) return undefined;
+  if (!(marker instanceof WebAssembly.Table) || marker.length !== 0) return undefined;
 
   const [logicalName, physicalBase] = _CLOSURE_HOST_BRIDGE_MANIFEST;
   if (!Object.prototype.hasOwnProperty.call(exports, logicalName)) return undefined;
   const manifest = _terminalHostBridgeAlias(exports, physicalBase);
-  if (!(manifest instanceof WebAssembly.Global) || typeof manifest.value !== "number") return undefined;
+  if (!_isImmutableI32Global(manifest) || typeof manifest.value !== "number") return undefined;
   const value = manifest.value | 0;
   if ((value & _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC_MASK) !== _CLOSURE_HOST_BRIDGE_MANIFEST_MAGIC) return undefined;
-  return value & _CLOSURE_HOST_BRIDGE_MANIFEST_BITS_MASK;
+  if ((value & _CLOSURE_HOST_BRIDGE_MANIFEST_RESERVED_MASK) !== 0) return undefined;
+  const bits = value & _CLOSURE_HOST_BRIDGE_MANIFEST_BITS_MASK;
+
+  const [bindingsLogicalName, bindingsPhysicalBase] = _CLOSURE_HOST_BRIDGE_BINDINGS;
+  if (!Object.prototype.hasOwnProperty.call(exports, bindingsLogicalName)) return undefined;
+  const bindings = _terminalHostBridgeAlias(exports, bindingsPhysicalBase);
+  if (!(bindings instanceof WebAssembly.Table) || bindings.length !== _CLOSURE_HOST_BRIDGE_EXPORTS.length) {
+    return undefined;
+  }
+  try {
+    for (let bit = 0; bit < _CLOSURE_HOST_BRIDGE_EXPORTS.length; bit++) {
+      const binding = bindings.get(bit);
+      if ((bits & (1 << bit)) !== 0 ? typeof binding !== "function" : binding !== null) return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return { bits, bindings };
 }
 
 /**
@@ -1053,14 +1095,14 @@ function _hostBridgeExportView<T extends Record<string, any>>(exports: T): T {
     overrides.set(logicalName, helper);
   }
 
-  const closureBits = _closureHostBridgeManifestBits(exports);
+  const closureMetadata = _closureHostBridgeMetadata(exports);
   for (let bit = 0; bit < _CLOSURE_HOST_BRIDGE_EXPORTS.length; bit++) {
     const [logicalName, physicalBase] = _CLOSURE_HOST_BRIDGE_EXPORTS[bit]!;
     if (!Object.prototype.hasOwnProperty.call(exports, logicalName)) continue;
     let helper: unknown;
-    if (closureBits !== undefined && (closureBits & (1 << bit)) !== 0) {
+    if (closureMetadata !== undefined && (closureMetadata.bits & (1 << bit)) !== 0) {
       helper = _terminalHostBridgeAlias(exports, physicalBase);
-      if (typeof helper !== "function") helper = exports[logicalName];
+      if (typeof helper !== "function" || helper !== closureMetadata.bindings.get(bit)) helper = undefined;
     }
     if (exports[logicalName] === helper) continue;
     overrides.set(logicalName, helper);

--- a/tests/issue-3520-closure-host-bridge-abi.test.ts
+++ b/tests/issue-3520-closure-host-bridge-abi.test.ts
@@ -490,6 +490,9 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     const externrefForge = clone();
     const availabilityBits = manifestValue & 0x0001ffff;
     for (let bit = 0; bit < CLOSURE_PHYSICAL_BASES.length; bit++) {
+      externrefBindings.set(bit, null);
+    }
+    for (let bit = 0; bit < CLOSURE_PHYSICAL_BASES.length; bit++) {
       if ((availabilityBits & (1 << bit)) === 0) continue;
       const forgedHelper = bit === 15 ? () => 1 : () => undefined;
       externrefBindings.set(bit, forgedHelper);

--- a/tests/issue-3520-closure-host-bridge-abi.test.ts
+++ b/tests/issue-3520-closure-host-bridge-abi.test.ts
@@ -414,6 +414,59 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     expect(instance).not.toBeTypeOf("function");
   });
 
+  it("fails closed for malformed marker, manifest, binding, and physical helper metadata", async () => {
+    const source = `
+      export function __is_closure(_value: any): number { return 1; }
+      export function $cf(): number { return 901; }
+      export function $cm(): number { return 902; }
+      export function $ct(): number { return 903; }
+      export function $cu(): number { return 904; }
+      const identity = function (value: number): number { return value; };
+      class Boxed {
+        value: number = 7;
+        ping(): number { return 1; }
+      }
+      export function getIdentity(): any { return identity; }
+      export function makeBoxed(): Boxed { return new Boxed(); }
+    `;
+    const { exports } = await instantiate(source);
+    expect(exports["$cf$"]).toBeTypeOf("function");
+    expect(exports["$cm$"]).toBeInstanceOf(WebAssembly.Global);
+    expect(exports["$ct$"]).toBeInstanceOf(WebAssembly.Table);
+    expect(exports["$cu$"]).toBeInstanceOf(WebAssembly.Table);
+    expect(wrapExports(exports as WebAssembly.Exports).makeBoxed()).toMatchObject({ value: 7 });
+
+    const clone = (): Record<string, unknown> => Object.assign(Object.create(null), exports);
+    const assertBoxedObject = (tampered: Record<string, unknown>): void => {
+      const value = wrapExports(tampered as WebAssembly.Exports).makeBoxed();
+      expect(value).toMatchObject({ value: 7 });
+      expect(value).not.toBeTypeOf("function");
+    };
+
+    const missingClassifier = Object.assign(
+      Object.create(null),
+      Object.fromEntries(Object.entries(exports).filter(([name]) => name !== "$cf$")),
+    ) as Record<string, unknown>;
+    assertBoxedObject(missingClassifier);
+
+    const nonEmptyMarker = clone();
+    nonEmptyMarker["$ct$"] = new WebAssembly.Table({ element: "anyfunc", initial: 1, maximum: 1 });
+    assertBoxedObject(nonEmptyMarker);
+
+    const manifestValue = (exports["$cm$"] as WebAssembly.Global).value as number;
+    const mutableManifest = clone();
+    mutableManifest["$cm$"] = new WebAssembly.Global({ value: "i32", mutable: true }, manifestValue);
+    assertBoxedObject(mutableManifest);
+
+    const reservedBitManifest = clone();
+    reservedBitManifest["$cm$"] = new WebAssembly.Global({ value: "i32", mutable: false }, manifestValue | (1 << 17));
+    assertBoxedObject(reservedBitManifest);
+
+    const f64Manifest = clone();
+    f64Manifest["$cm$"] = new WebAssembly.Global({ value: "f64", mutable: false }, manifestValue);
+    assertBoxedObject(f64Manifest);
+  });
+
   it("owns closure_has_rest at ordinal 13 only when that helper is emitted", async () => {
     const source = `
       const rest = function (...values: any[]): number { return values.length; };

--- a/tests/issue-3520-closure-host-bridge-abi.test.ts
+++ b/tests/issue-3520-closure-host-bridge-abi.test.ts
@@ -350,9 +350,49 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     expect(addTwo(40)).toBe(42);
   });
 
-  it("does not discover closure helpers from closure-free user logical or physical-prefix exports", async () => {
+  it("composes vec and closure collision projections for setExports and wrapExports", async () => {
+    const source = `
+      export function __vec_len(_value: any): number { return 801; }
+      export function $v0(_value: any): number { return 802; }
+      export function __vec_get(_value: any, _index: number): number { return 803; }
+      export function $v1(_value: any, _index: number): number { return 804; }
+      export function __call_fn_1(_closure: any, _value: any): number { return 805; }
+      export function $c1(): number { return 806; }
+      export function __is_closure(_value: any): number { return 1; }
+      export function $cf(): number { return 807; }
+      export function $cm(): number { return 808; }
+      export function $ct(): number { return 809; }
+      const addTwo = function (value: number): number { return value + 2; };
+      export function getAddTwo(): any { return addTwo; }
+      export function getArray(): number[] { return [3, 4]; }
+      export function runPromise(): Promise<number> {
+        return Promise.resolve(40).then(addTwo);
+      }
+    `;
+    const { exports } = await instantiate(source);
+
+    expect((exports.__vec_len as (value: unknown) => number)(null)).toBe(801);
+    expect((exports.$v0 as (value: unknown) => number)(null)).toBe(802);
+    expect((exports.__call_fn_1 as (fn: unknown, value: unknown) => number)(null, null)).toBe(805);
+    expect((exports.$c1 as () => number)()).toBe(806);
+    expect((exports.__is_closure as (value: unknown) => number)(null)).toBe(1);
+    expect((exports.$cf as () => number)()).toBe(807);
+    expect((exports.$cm as () => number)()).toBe(808);
+    expect((exports.$ct as () => number)()).toBe(809);
+    expect(exports["$cm$"]).toBeInstanceOf(WebAssembly.Global);
+    expect(exports["$ct$"]).toBeInstanceOf(WebAssembly.Table);
+
+    await expect((exports.runPromise as () => Promise<number>)()).resolves.toBe(42);
+
+    const wrapped = wrapExports(exports as WebAssembly.Exports);
+    expect(wrapped.getAddTwo()(40)).toBe(42);
+    expect(wrapped.getArray()).toEqual([3, 4]);
+  });
+
+  it("does not discover closure helpers from a forged closure-free name family", async () => {
     const source = `
       export function __is_closure(_value: any): number { return 1; }
+      export function __call_fn_0(_value: any): number { return 709; }
       export function $cf(): number { return 704; }
       class Empty { ping(): number { return 1; } }
       export function makeEmpty(): Empty { return new Empty(); }
@@ -362,8 +402,11 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
 
     const { exports } = await instantiate(source);
     expect((exports.__is_closure as (value: unknown) => number)(null)).toBe(1);
+    expect((exports.__call_fn_0 as (value: unknown) => number)(null)).toBe(709);
     expect((exports.$cf as () => number)()).toBe(704);
     expect(exports["$cf$"]).toBeUndefined();
+    expect(exports["__\0js2_closure_host_bridge"]).toBeUndefined();
+    expect(exports["__\0js2_closure_host_bridge_marker"]).toBeUndefined();
 
     const wrapped = wrapExports(exports as WebAssembly.Exports);
     const instance = wrapped.makeEmpty();

--- a/tests/issue-3520-closure-host-bridge-abi.test.ts
+++ b/tests/issue-3520-closure-host-bridge-abi.test.ts
@@ -1,0 +1,338 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { SINGLE_HOST_ENTRIES } from "../scripts/check-ir-only.js";
+import { analyzeSource } from "../src/checker/index.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { generateModule } from "../src/codegen/index.js";
+import {
+  planProgramAbiEntrySourceSupportCallable,
+  PROGRAM_ABI_CALLABLE_ROLE,
+  resolveProgramAbiSupportCallableHandle,
+} from "../src/codegen/program-abi-planning.js";
+import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
+import { buildIrUnitInventory, createIrBindingId } from "../src/ir/identity.js";
+import { createEmptyModule, type FuncTypeDef, type Import, type WasmFunction } from "../src/ir/types.js";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+
+// Register the expression/statement delegates used by generateModule.
+import "../src/codegen/expressions.js";
+
+const CLOSURE_HOST_BRIDGE_ROLE = "closure-host-bridge";
+
+const REQUIRED_BRIDGES = Object.freeze([
+  { name: "__call_fn_0", ordinal: 0 },
+  { name: "__call_fn_1", ordinal: 1 },
+  { name: "__call_fn_2", ordinal: 2 },
+  { name: "__call_fn_3", ordinal: 3 },
+  { name: "__call_fn_4", ordinal: 4 },
+  { name: "__call_fn_method_0", ordinal: 5 },
+  { name: "__call_fn_method_1", ordinal: 6 },
+  { name: "__call_fn_method_2", ordinal: 7 },
+  { name: "__call_fn_method_3", ordinal: 8 },
+  { name: "__call_fn_method_4", ordinal: 9 },
+  { name: "__call_fn_method_5", ordinal: 10 },
+  { name: "__closure_arity", ordinal: 11 },
+  { name: "__is_closure", ordinal: 12 },
+] as const);
+
+const ZERO_ARITY_SOURCE = `
+  declare function hostTick(value: number): number;
+  const zero = function (): number { return 17; };
+  export function getZero(): any { return zero; }
+  export function invoke(): number { return hostTick(zero()); }
+`;
+
+function trackedModule(source = ZERO_ARITY_SOURCE) {
+  const ast = analyzeSource(source, "issue-3520-closure-host-bridge.ts");
+  return generateModule(ast, { experimentalIR: true, trackIrOutcomes: true });
+}
+
+function entrySourceRecord(source = ZERO_ARITY_SOURCE) {
+  const ast = analyzeSource(source, "issue-3520-closure-host-bridge.ts");
+  return buildIrUnitInventory([ast.sourceFile], {
+    entrySource: ast.sourceFile,
+    checker: ast.checker,
+  }).sources.find((candidate) => candidate.kind === "entry")!;
+}
+
+function hardErrors(result: ReturnType<typeof generateModule>) {
+  return result.errors.filter((error) => error.severity !== "warning");
+}
+
+async function instantiate(source: string): Promise<{
+  readonly exports: Record<string, unknown>;
+  readonly result: Awaited<ReturnType<typeof compile>>;
+}> {
+  const result = await compile(source, {
+    fileName: "issue-3520-closure-host-runtime.ts",
+    experimentalIR: true,
+    trackIrOutcomes: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool) as Record<string, unknown> & {
+    env?: Record<string, unknown>;
+    setExports?: (value: WebAssembly.Exports) => void;
+  };
+  imports.env = imports.env ?? {};
+  imports.env.hostTick = (value: number) => value;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports);
+  return { exports: instance.exports as Record<string, unknown>, result };
+}
+
+describe("#3520 C31 closure host bridge Program ABI ownership", () => {
+  it("plans fixed entry-source IDs and publishes each exact final helper slot", () => {
+    const result = trackedModule();
+    expect(
+      hardErrors(result),
+      hardErrors(result)
+        .map((error) => error.message)
+        .join("\n"),
+    ).toEqual([]);
+    expect(result.programAbi).toBeDefined();
+
+    const entrySource = entrySourceRecord();
+    const imports = result.module.imports.filter((entry) => entry.desc.kind === "func");
+    expect(imports.length).toBeGreaterThan(0);
+    const exportsByName = new Map(result.module.exports.map((entry) => [entry.name, entry]));
+    const abiEntries = result.programAbi!.abi.entries();
+    const closureEntries = abiEntries.filter(
+      (entry) =>
+        entry.intent.kind === "callable" &&
+        entry.intent.origin === "support" &&
+        entry.intent.sourceId === entrySource!.id &&
+        REQUIRED_BRIDGES.some((bridge) => bridge.name === entry.displayName),
+    );
+
+    expect(closureEntries).toHaveLength(REQUIRED_BRIDGES.length);
+    for (const bridge of REQUIRED_BRIDGES) {
+      const expectedId = createIrBindingId({
+        ownerId: entrySource!.id,
+        domain: "support",
+        role: CLOSURE_HOST_BRIDGE_ROLE,
+        ordinal: bridge.ordinal,
+      });
+      const entry = closureEntries.find((candidate) => candidate.id === expectedId);
+      expect(entry).toMatchObject({
+        id: expectedId,
+        displayName: bridge.name,
+        intent: {
+          kind: "callable",
+          origin: "support",
+          sourceId: entrySource!.id,
+        },
+      });
+      const finalSlot = result.programAbi!.abi.resolveFinalIndex(expectedId);
+      expect(finalSlot).toEqual({ space: "function", index: exportsByName.get(bridge.name)?.desc.index });
+      if (!finalSlot || finalSlot.space !== "function") throw new Error(`missing ${bridge.name} final slot`);
+      const exactFinalObject = result.module.functions[finalSlot.index - imports.length];
+      expect(exactFinalObject).toBeDefined();
+      expect(exactFinalObject?.name).toBe(bridge.name);
+    }
+
+    const allHelperEntries = abiEntries.filter(
+      (entry) =>
+        entry.intent.kind === "callable" && REQUIRED_BRIDGES.some((bridge) => bridge.name === entry.displayName),
+    );
+    expect(allHelperEntries.map((entry) => entry.id).sort()).toEqual(closureEntries.map((entry) => entry.id).sort());
+  });
+
+  it("re-resolves one exact allocator after a late import and dead-slot compaction", () => {
+    const sourceFile = ts.createSourceFile(
+      "/repo/entry.ts",
+      "export function entry(): number { return 1; }",
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
+    const entrySource = inventory.sources.find((source) => source.kind === "entry")!;
+    const module = createEmptyModule();
+    const signature: FuncTypeDef = { kind: "func", params: [{ kind: "externref" }], results: [{ kind: "i32" }] };
+    module.types.push(signature);
+    const helper: WasmFunction = {
+      name: "__is_closure",
+      typeIdx: 0,
+      locals: [],
+      body: [{ op: "i32.const", value: 0 }],
+      exported: true,
+    };
+    const dead: WasmFunction = { name: "dead", typeIdx: 0, locals: [], body: [{ op: "i32.const", value: 0 }] };
+    module.functions.push(helper, dead);
+    const session = new ProgramAbiSession(inventory, module);
+    const ctx = createCodegenContext(module, {} as ts.TypeChecker, undefined, session);
+    const ref = planProgramAbiEntrySourceSupportCallable(ctx, {
+      role: CLOSURE_HOST_BRIDGE_ROLE,
+      roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.closureHostBridge,
+      derivedOrdinal: 12,
+      displayName: helper.name,
+      func: helper,
+    });
+    expect(ref?.binding).toEqual({
+      kind: "support",
+      bindingId: createIrBindingId({
+        ownerId: entrySource.id,
+        domain: "support",
+        role: CLOSURE_HOST_BRIDGE_ROLE,
+        ordinal: 12,
+      }),
+    });
+    expect(session.getDraft(ref!.binding.bindingId)?.structuralOrder).toMatchObject({
+      roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.closureHostBridge,
+      derivedOrdinal: 12,
+    });
+    expect(resolveProgramAbiSupportCallableHandle(ctx, ref, helper)).toBe(0);
+
+    const lateImport: Import = { module: "env", name: "late", desc: { kind: "func", typeIdx: 0 } };
+    module.imports.push(lateImport);
+    module.functions.splice(module.functions.indexOf(dead), 1);
+    expect(resolveProgramAbiSupportCallableHandle(ctx, ref, helper)).toBe(1);
+
+    const publication = session.publish(module);
+    expect(publication.abi.resolveFinalIndex(ref!.binding.bindingId)).toEqual({ space: "function", index: 1 });
+    expect(module.functions[0]).toBe(helper);
+  });
+
+  it("emits no closure bridge rows or exports for a closure-free module", () => {
+    const result = trackedModule(`export function add(a: number, b: number): number { return a + b; }`);
+    expect(
+      hardErrors(result),
+      hardErrors(result)
+        .map((error) => error.message)
+        .join("\n"),
+    ).toEqual([]);
+    expect(
+      result
+        .programAbi!.abi.entries()
+        .filter((entry) => REQUIRED_BRIDGES.some((bridge) => bridge.name === entry.displayName)),
+    ).toEqual([]);
+    const exportNames = result.module.exports.map((entry) => entry.name);
+    for (const bridge of REQUIRED_BRIDGES) expect(exportNames).not.toContain(bridge.name);
+  });
+
+  it("keeps tracked and untracked closure modules byte-identical", async () => {
+    const baseOptions = {
+      fileName: "issue-3520-closure-host-byte-parity.ts",
+      experimentalIR: true,
+    } as const;
+    const untracked = await compile(ZERO_ARITY_SOURCE, baseOptions);
+    const tracked = await compile(ZERO_ARITY_SOURCE, { ...baseOptions, trackIrOutcomes: true });
+    expect(untracked.success, untracked.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(tracked.success, tracked.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(tracked.binary).toEqual(untracked.binary);
+  });
+
+  it("moves exactly 26 five-entry census rows without changing functions or routing", () => {
+    let definedFunctions = 0;
+    let genericRows = 0;
+    let closureRows = 0;
+    let vecRows = 0;
+    let terminalUnits = 0;
+    let emitted = 0;
+    let unsupported = 0;
+    let invariants = 0;
+    let legacyBodies = 0;
+    let irBodies = 0;
+
+    for (const entry of SINGLE_HOST_ENTRIES) {
+      const source = readFileSync(resolve(entry), "utf8");
+      const ast = analyzeSource(source, entry);
+      const result = generateModule(ast, {
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      const errors = hardErrors(result);
+      expect(errors, `${entry}\n${errors.map((error) => error.message).join("\n")}`).toEqual([]);
+      definedFunctions += result.module.functions.length;
+      const entries = result.programAbi!.abi.entries();
+      genericRows += entries.filter((candidate) => candidate.id.includes("retained-module-function")).length;
+      closureRows += entries.filter((candidate) => candidate.id.includes(":closure-host-bridge:")).length;
+      vecRows += entries.filter((candidate) => candidate.id.includes(":vec-host-bridge:")).length;
+      for (const outcome of result.irOutcomes ?? []) {
+        terminalUnits++;
+        if (outcome.kind === "emitted") emitted++;
+        if (outcome.kind === "unsupported") unsupported++;
+        if (outcome.kind === "invariant") invariants++;
+        if (outcome.legacyBodyEmitted) legacyBodies++;
+        if (outcome.irBodyEmitted) irBodies++;
+      }
+    }
+
+    expect({ definedFunctions, closureRows }).toEqual({ definedFunctions: 166, closureRows: 26 });
+    // C30 is an independent structural-ownership slice. Before it lands the
+    // vec rows remain generic; after it lands they move one-for-one.
+    expect([0, 24]).toContain(vecRows);
+    expect(genericRows).toBe(75 - vecRows);
+    expect({ terminalUnits, emitted, unsupported, invariants, legacyBodies, irBodies }).toEqual({
+      terminalUnits: 37,
+      emitted: 30,
+      unsupported: 7,
+      invariants: 0,
+      legacyBodies: 37,
+      irBodies: 30,
+    });
+  });
+
+  it("preserves public labels, closure identity, direct calls, and method receivers", async () => {
+    const { exports } = await instantiate(`
+      declare function hostTick(value: number): number;
+      const direct = function (value: number): number { return value + 2; };
+      const receiver = function (): any { return this; };
+      export function getDirect(): any { return direct; }
+      export function getReceiver(): any { return receiver; }
+      export function test(): number { return hostTick(direct(1)); }
+    `);
+    for (const bridge of REQUIRED_BRIDGES) expect(exports[bridge.name]).toBeTypeOf("function");
+
+    const direct = (exports.getDirect as () => unknown)();
+    expect((exports.__is_closure as (value: unknown) => number)(direct)).toBe(1);
+    expect((exports.__closure_arity as (value: unknown) => number)(direct)).toBe(1);
+    expect((exports.__call_fn_1 as (fn: unknown, value: unknown) => unknown)(direct, 40)).toBe(42);
+
+    const receiver = (exports.getReceiver as () => unknown)();
+    const hostReceiver = { marker: 7 };
+    expect((exports.__call_fn_method_0 as (self: unknown, fn: unknown) => unknown)(hostReceiver, receiver)).toBe(
+      hostReceiver,
+    );
+  });
+
+  it("owns closure_has_rest at ordinal 13 only when that helper is emitted", async () => {
+    const source = `
+      const rest = function (...values: any[]): number { return values.length; };
+      export function getRest(): any { return rest; }
+      export function test(): number { return rest(1, 2, 3); }
+    `;
+    const result = trackedModule(source);
+    expect(
+      hardErrors(result),
+      hardErrors(result)
+        .map((error) => error.message)
+        .join("\n"),
+    ).toEqual([]);
+    const entrySource = entrySourceRecord(source);
+    const expectedId = createIrBindingId({
+      ownerId: entrySource.id,
+      domain: "support",
+      role: CLOSURE_HOST_BRIDGE_ROLE,
+      ordinal: 13,
+    });
+    expect(result.programAbi!.abi.get(expectedId)).toMatchObject({
+      displayName: "__closure_has_rest",
+    });
+
+    const { exports } = await instantiate(source);
+    const rest = (exports.getRest as () => unknown)();
+    expect((exports.__closure_has_rest as (value: unknown) => number)(rest)).toBe(1);
+
+    const noRest = trackedModule();
+    expect(noRest.programAbi!.abi.get(expectedId)).toBeUndefined();
+    expect(noRest.module.exports.map((candidate) => candidate.name)).not.toContain("__closure_has_rest");
+  });
+});

--- a/tests/issue-3520-closure-host-bridge-abi.test.ts
+++ b/tests/issue-3520-closure-host-bridge-abi.test.ts
@@ -42,6 +42,26 @@ const REQUIRED_BRIDGES = Object.freeze([
   { name: "__is_closure", ordinal: 12 },
 ] as const);
 
+const CLOSURE_PHYSICAL_BASES = [
+  "$c0",
+  "$c1",
+  "$c2",
+  "$c3",
+  "$c4",
+  "$c5",
+  "$c6",
+  "$c7",
+  "$c8",
+  "$c9",
+  "$ca",
+  "$cb",
+  "$cc",
+  "$cd",
+  "$ce",
+  "$cf",
+  "$cg",
+] as const;
+
 const ZERO_ARITY_SOURCE = `
   declare function hostTick(value: number): number;
   const zero = function (): number { return 17; };
@@ -465,6 +485,25 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     const f64Manifest = clone();
     f64Manifest["$cm$"] = new WebAssembly.Global({ value: "f64", mutable: false }, manifestValue);
     assertBoxedObject(f64Manifest);
+
+    const externrefBindings = new WebAssembly.Table({ element: "externref", initial: 17, maximum: 17 });
+    const externrefForge = clone();
+    const availabilityBits = manifestValue & 0x0001ffff;
+    for (let bit = 0; bit < CLOSURE_PHYSICAL_BASES.length; bit++) {
+      if ((availabilityBits & (1 << bit)) === 0) continue;
+      const forgedHelper = bit === 15 ? () => 1 : () => undefined;
+      externrefBindings.set(bit, forgedHelper);
+      let physicalName = CLOSURE_PHYSICAL_BASES[bit]!;
+      let terminalName: string | undefined;
+      while (Object.prototype.hasOwnProperty.call(externrefForge, physicalName)) {
+        terminalName = physicalName;
+        physicalName += "$";
+      }
+      expect(terminalName).toBeDefined();
+      externrefForge[terminalName!] = forgedHelper;
+    }
+    externrefForge["$cu$"] = externrefBindings;
+    assertBoxedObject(externrefForge);
   });
 
   it("owns closure_has_rest at ordinal 13 only when that helper is emitted", async () => {

--- a/tests/issue-3520-closure-host-bridge-abi.test.ts
+++ b/tests/issue-3520-closure-host-bridge-abi.test.ts
@@ -18,7 +18,7 @@ import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
 import { buildIrUnitInventory, createIrBindingId } from "../src/ir/identity.js";
 import { createEmptyModule, type FuncTypeDef, type Import, type WasmFunction } from "../src/ir/types.js";
 import { compile } from "../src/index.js";
-import { buildImports } from "../src/runtime.js";
+import { buildImports, wrapExports } from "../src/runtime.js";
 import { ts } from "../src/ts-api.js";
 
 // Register the expression/statement delegates used by generateModule.
@@ -47,6 +47,14 @@ const ZERO_ARITY_SOURCE = `
   const zero = function (): number { return 17; };
   export function getZero(): any { return zero; }
   export function invoke(): number { return hostTick(zero()); }
+`;
+
+const COLLIDING_CLOSURE_SOURCE = `
+  export function __call_fn_1(_closure: any, _value: any): number { return 701; }
+  export function $c1(): number { return 702; }
+  export function $cf(): number { return 703; }
+  const addTwo = function (value: number): number { return value + 2; };
+  export function getAddTwo(): any { return addTwo; }
 `;
 
 function trackedModule(source = ZERO_ARITY_SOURCE) {
@@ -301,6 +309,66 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     expect((exports.__call_fn_method_0 as (self: unknown, fn: unknown) => unknown)(hostReceiver, receiver)).toBe(
       hostReceiver,
     );
+  });
+
+  it("preserves user logical and physical names while runtime dispatch finds the exact closure helper", async () => {
+    const tracked = trackedModule(COLLIDING_CLOSURE_SOURCE);
+    expect(
+      hardErrors(tracked),
+      hardErrors(tracked)
+        .map((error) => error.message)
+        .join("\n"),
+    ).toEqual([]);
+    const exportsByName = new Map(tracked.module.exports.map((entry) => [entry.name, entry]));
+    expect(exportsByName.get("__call_fn_1")?.desc.index).not.toBe(exportsByName.get("$c1$")?.desc.index);
+    expect(exportsByName.get("$c1")?.desc.index).not.toBe(exportsByName.get("$c1$")?.desc.index);
+    expect(exportsByName.get("$cf")?.desc.index).not.toBe(exportsByName.get("$cf$")?.desc.index);
+
+    const entrySource = entrySourceRecord(COLLIDING_CLOSURE_SOURCE);
+    const directOneId = createIrBindingId({
+      ownerId: entrySource.id,
+      domain: "support",
+      role: CLOSURE_HOST_BRIDGE_ROLE,
+      ordinal: 1,
+    });
+    expect(tracked.programAbi!.abi.resolveFinalIndex(directOneId)).toEqual({
+      space: "function",
+      index: exportsByName.get("$c1$")?.desc.index,
+    });
+
+    const { exports } = await instantiate(COLLIDING_CLOSURE_SOURCE);
+    expect((exports.__call_fn_1 as (_closure: unknown, _value: unknown) => number)(null, null)).toBe(701);
+    expect((exports.$c1 as () => number)()).toBe(702);
+    expect((exports.$cf as () => number)()).toBe(703);
+    const closure = (exports.getAddTwo as () => unknown)();
+    expect((exports["$c1$"] as (fn: unknown, value: unknown) => unknown)(closure, 40)).toBe(42);
+    expect((exports["$cf$"] as (value: unknown) => number)(closure)).toBe(1);
+
+    const wrapped = wrapExports(exports as WebAssembly.Exports);
+    const addTwo = wrapped.getAddTwo();
+    expect(addTwo).toBeTypeOf("function");
+    expect(addTwo(40)).toBe(42);
+  });
+
+  it("does not discover closure helpers from closure-free user logical or physical-prefix exports", async () => {
+    const source = `
+      export function __is_closure(_value: any): number { return 1; }
+      export function $cf(): number { return 704; }
+      class Empty { ping(): number { return 1; } }
+      export function makeEmpty(): Empty { return new Empty(); }
+    `;
+    const tracked = trackedModule(source);
+    expect(tracked.programAbi!.abi.entries().filter((entry) => entry.id.includes(":closure-host-bridge:"))).toEqual([]);
+
+    const { exports } = await instantiate(source);
+    expect((exports.__is_closure as (value: unknown) => number)(null)).toBe(1);
+    expect((exports.$cf as () => number)()).toBe(704);
+    expect(exports["$cf$"]).toBeUndefined();
+
+    const wrapped = wrapExports(exports as WebAssembly.Exports);
+    const instance = wrapped.makeEmpty();
+    expect(instance).toEqual({});
+    expect(instance).not.toBeTypeOf("function");
   });
 
   it("owns closure_has_rest at ordinal 13 only when that helper is emitted", async () => {

--- a/tests/issue-3520-vec-support-callable-abi.test.ts
+++ b/tests/issue-3520-vec-support-callable-abi.test.ts
@@ -321,7 +321,7 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
     expect(Object.keys(rawExports).filter(isVecHostBridgePhysicalExport)).toEqual(["$v0"]);
 
     const wrapped = wrapExports(rawExports);
-    expect(typeof wrapped.mkInstance()).toBe("function");
+    expect(wrapped.mkInstance()).toEqual({});
   });
 
   it("aborts compilation when structural vec ABI observation fails", () => {
@@ -424,6 +424,7 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
     let definedFunctions = 0;
     let genericRows = 0;
     let vecRows = 0;
+    let closureRows = 0;
     for (const entry of SINGLE_HOST_ENTRIES) {
       const source = readFileSync(resolve(entry), "utf8");
       const ast = analyzeSource(source, entry);
@@ -437,11 +438,13 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
       const entries = result.programAbi!.abi.entries();
       genericRows += entries.filter((candidate) => candidate.id.includes("retained-module-function")).length;
       vecRows += entries.filter((candidate) => candidate.id.includes(VEC_HOST_BRIDGE_ROLE)).length;
+      closureRows += entries.filter((candidate) => candidate.id.includes(":closure-host-bridge:")).length;
     }
-    expect({ definedFunctions, genericRows, vecRows }).toEqual({
+    expect({ definedFunctions, genericRows, vecRows, closureRows }).toEqual({
       definedFunctions: 166,
-      genericRows: 77,
+      genericRows: 51,
       vecRows: 24,
+      closureRows: 26,
     });
   });
 });


### PR DESCRIPTION
## Summary

- Move all closure host-call helpers from generic retained-function ownership into stable `closure-host-bridge` Program ABI roles.
- Compose closure and vec helper projection from the same raw Wasm export object.
- Preserve user logical and physical export names with collision-only compiler aliases.
- Authenticate closure helper availability with exact immutable metadata and exact `funcref` tables, failing closed for missing, malformed, or forged metadata.

## Migration result

- Five-entry census after C30 + C31:
  - generic rows: 77 to 51
  - vec rows: 24
  - closure rows: 26
  - defined functions: unchanged at 166
- IR routing remains 37 terminal / 30 emitted / 7 unsupported / 0 invariant / 37 legacy / 30 IR.
- Closure-free modules gain no bridge exports or size. Closure-using modules intentionally gain authenticated physical aliases and metadata.

This is structural Program ABI migration. It does not claim terminal IR adoption or legacy-body retirement.

## Safety

- User `__call_fn_*`, `__is_closure`, `$c*`, marker, manifest, and table-like names remain user-owned.
- Runtime accepts only compiler-shaped empty and 17-slot `funcref` tables plus an immutable i32 availability manifest with reserved bits clear.
- Every available helper must resolve to the terminal physical function and the identical binding-table entry; there is no fallback to user logical exports.
- Vec and closure overlays are built together, so neither projection hides the other.

## Validation

- Focused C30 + C31: 20/20 after rebase.
- Full closure/ABI matrix: 95/95 across 13 files.
- Nonincremental typecheck.
- IR fallback, LOC/function, dead-export, oracle, verdict, and readiness gates.
- Pre-push typecheck, lint, formatting, oracle/coercion ratchets, numeric-local parity, and issue integrity.
- Independent adversarial review, including non-vacuous malformed-table and forged-`externref` probes.

Tracks the C31 section in `plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md`.
