### PR TITLE
feat(ir): add sealed prepared-program core

### DIFF
--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -208,18 +208,25 @@ The first R2 landing is intentionally structural. `src/ir/program.ts` and
 without wiring it into `src/codegen/index.ts`:
 
 - the denominator is exactly the R1 inventory's top-level free-function
-  terminals, with every unit present once in exactly one local-call component;
-- every component freezes to one terminal `Prepared`, `Unsupported`, or
-  `Invariant` ownership kind before an emitter can start;
-- `Prepared` records own their final signature, post-pass typed IR, target
-  legality proof, inline-small/monomorphization evidence, symbolic support
-  intents, allocation reservations, and source/pass provenance;
-- a one-shot isolated emission transaction enforces `Prepared -> IR`,
-  `Unsupported -> direct`, and `Invariant -> neither`, and publishes only after
-  every eligible unit reconciles to exactly one staged body;
-- missing/duplicate units, mixed component outcomes, late support discovery,
-  unsealed ABI plans, wrong emitter direction, duplicate emission, and partial
-  publication are fatal invariants.
+  terminals, with every unit represented once;
+- asserted IR/direct/invariant routes, signatures, exports, legality,
+  inline-small/monomorphization results, symbolic support, allocation, and
+  provenance are retained only as explicitly **unvalidated candidates**;
+- caller-supplied component groupings are likewise non-authoritative hints.
+  This slice does not infer the call graph, use those groupings to claim atomic
+  ownership, or reject a mixed grouping as though it were a proven component;
+- a capability-only, one-shot isolated transaction exercises candidate-route
+  accounting and publishes only an explicitly unvalidated candidate snapshot;
+- every input is defensively copied, functions/accessors and other executable
+  or mutable non-data objects are rejected recursively, and any staging,
+  freezing, direction, duplication, or partial-publication error atomically
+  aborts the transaction without retry.
+
+The later production-routing slice must derive call/ABI components and
+Prepared evidence from the actual post-pass IR, symbolic references,
+`ProgramAbiMap`, backend legality results, allocation registry, and provenance
+registry. Only that reconciliation may promote a candidate to terminal
+`Prepared`, `Unsupported`, or `Invariant` ownership and feed a real emitter.
 
 This slice does **not** change production routing and its expected
 legacy-body reduction is therefore exactly **0**. It does not claim the issue's

--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -4,7 +4,7 @@ title: "IR-only R2: prepare-before-emit free-function ownership"
 status: blocked
 sprint: Backlog
 created: 2026-07-21
-updated: 2026-07-21
+updated: 2026-07-30
 priority: critical
 horizon: xl
 complexity: XL
@@ -200,6 +200,38 @@ denominator, and no successful unit may have `direct + IR != 1`.
   transitional `irFirstSkipped` / `irCompiledFuncs` telemetry from exact
   counters.
 - Retain class/module overlay code untouched for #3522/#3523.
+
+## Prepared-program-core structural slice (2026-07-30)
+
+The first R2 landing is intentionally structural. `src/ir/program.ts` and
+`src/ir/prepare.ts` define and validate the immutable prepared-program boundary
+without wiring it into `src/codegen/index.ts`:
+
+- the denominator is exactly the R1 inventory's top-level free-function
+  terminals, with every unit present once in exactly one local-call component;
+- every component freezes to one terminal `Prepared`, `Unsupported`, or
+  `Invariant` ownership kind before an emitter can start;
+- `Prepared` records own their final signature, post-pass typed IR, target
+  legality proof, inline-small/monomorphization evidence, symbolic support
+  intents, allocation reservations, and source/pass provenance;
+- a one-shot isolated emission transaction enforces `Prepared -> IR`,
+  `Unsupported -> direct`, and `Invariant -> neither`, and publishes only after
+  every eligible unit reconciles to exactly one staged body;
+- missing/duplicate units, mixed component outcomes, late support discovery,
+  unsealed ABI plans, wrong emitter direction, duplicate emission, and partial
+  publication are fatal invariants.
+
+This slice does **not** change production routing and its expected
+legacy-body reduction is therefore exactly **0**. It does not claim the issue's
+compile-once cutover acceptance criteria; the later routing slices must consume
+this boundary.
+
+Future routing work must preserve optimization parity rather than treating the
+loss of the legacy discovery pass as acceptable churn. In particular, complete
+program preparation must retain inline-small eligibility, monomorphized clone
+identity/signatures, and allocation provenance, and
+`check:ir-optimization-retirement` remains fail-closed until its committed
+parity evidence is retirement-ready.
 
 ## File ownership and locks
 

--- a/src/ir/prepare.ts
+++ b/src/ir/prepare.ts
@@ -1,80 +1,95 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
-import type { IrBindingId, IrUnitId, IrTerminalUnitRecord } from "./identity.js";
+import type { IrBindingId, IrTerminalUnitRecord, IrUnitId } from "./identity.js";
 import {
-  createValidatedPreparedIrProgram,
+  createPreparedIrCandidateProgram,
   freezePreparedIrValue,
   preparedIrReadonlyMap,
   PreparedIrProgramInvariantError,
-  type PreparedIrAllocationRecord,
-  type PreparedIrBackendLegalityProof,
-  type PreparedIrComponent,
-  type PreparedIrInvariantUnit,
-  type PreparedIrOptimizationEvidence,
-  type PreparedIrPreparedUnit,
+  type PreparedIrAllocationCandidate,
+  type PreparedIrAssertedBackendLegality,
+  type PreparedIrAssertedOptimizationEvidence,
+  type PreparedIrDirectCandidate,
+  type PreparedIrInvariantCandidate,
+  type PreparedIrIrCandidate,
   type PreparedIrProgram,
-  type PreparedIrProvenanceRecord,
-  type PreparedIrSupportIntent,
-  type PreparedIrUnitOutcome,
-  type PreparedIrUnsupportedUnit,
+  type PreparedIrProvenanceCandidate,
+  type PreparedIrSupportIntentCandidate,
+  type PreparedIrUnitCandidate,
 } from "./program.js";
 import type { ProgramAbiCallableSignature } from "./program-abi.js";
 import { ProgramAbiMap } from "./program-abi.js";
 
-export interface PreparedIrPreparedInput {
+export interface PreparedIrIrCandidateInput {
   readonly unitId: IrUnitId;
-  readonly finalSignature: ProgramAbiCallableSignature;
-  readonly exportIntents?: readonly IrBindingId[];
-  readonly backendLegality: PreparedIrBackendLegalityProof;
-  readonly optimization: PreparedIrOptimizationEvidence;
-  readonly ir: unknown;
+  readonly assertedSignature: ProgramAbiCallableSignature;
+  readonly assertedExportIntents?: readonly IrBindingId[];
+  readonly assertedBackendLegality: PreparedIrAssertedBackendLegality;
+  readonly assertedOptimization: PreparedIrAssertedOptimizationEvidence;
+  readonly irCandidate: unknown;
 }
 
-export interface PreparedIrFailureInput {
+export interface PreparedIrFailureCandidateInput {
   readonly unitId: IrUnitId;
   readonly code: string;
   readonly stage: string;
   readonly detail: string;
 }
 
-export interface PreparedIrComponentInput {
+export interface PreparedIrComponentCandidateInput {
   readonly id: string;
   readonly unitIds: readonly IrUnitId[];
 }
 
 type BuilderState = "open" | "sealing" | "sealed" | "failed";
 
-function freezeSignature(signature: ProgramAbiCallableSignature): ProgramAbiCallableSignature {
+function location(unit: IrTerminalUnitRecord) {
+  return Object.freeze({
+    sourceId: unit.sourceId,
+    line: unit.line,
+    column: unit.column,
+    declarationStart: unit.declarationStart,
+    declarationEnd: unit.declarationEnd,
+  });
+}
+
+function ownSignature(signature: ProgramAbiCallableSignature): ProgramAbiCallableSignature {
   return Object.freeze({
     params: Object.freeze([...signature.params]),
     results: Object.freeze([...signature.results]),
   });
 }
 
-function freezePrepared(input: PreparedIrPreparedInput, unit: IrTerminalUnitRecord): PreparedIrPreparedUnit {
+function ownIrCandidate(input: PreparedIrIrCandidateInput, unit: IrTerminalUnitRecord): PreparedIrIrCandidate {
   return Object.freeze({
-    kind: "prepared" as const,
+    kind: "ir-candidate" as const,
+    route: "ir" as const,
+    evidenceStatus: "unvalidated-candidate" as const,
     unitId: input.unitId,
-    location: Object.freeze({
-      sourceId: unit.sourceId,
-      line: unit.line,
-      column: unit.column,
-      declarationStart: unit.declarationStart,
-      declarationEnd: unit.declarationEnd,
-    }),
-    finalSignature: freezeSignature(input.finalSignature),
-    exportIntents: Object.freeze([...(input.exportIntents ?? [])]),
-    backendLegality: Object.freeze({ ...input.backendLegality }),
-    optimization: Object.freeze({ ...input.optimization }),
-    ir: freezePreparedIrValue(input.ir),
+    location: location(unit),
+    assertedSignature: ownSignature(input.assertedSignature),
+    assertedExportIntents: Object.freeze([...(input.assertedExportIntents ?? [])]),
+    assertedBackendLegality: Object.freeze({ ...input.assertedBackendLegality }),
+    assertedOptimization: Object.freeze({ ...input.assertedOptimization }),
+    irCandidate: freezePreparedIrValue(input.irCandidate),
   });
 }
 
-function freezeFailure(
-  kind: "unsupported" | "invariant",
-  input: PreparedIrFailureInput,
-): PreparedIrUnsupportedUnit | PreparedIrInvariantUnit {
-  return Object.freeze({ kind, ...input });
+function ownFailureCandidate(
+  kind: "direct-candidate" | "invariant-candidate",
+  input: PreparedIrFailureCandidateInput,
+  unit: IrTerminalUnitRecord,
+): PreparedIrDirectCandidate | PreparedIrInvariantCandidate {
+  return Object.freeze({
+    kind,
+    route: kind === "direct-candidate" ? ("direct" as const) : ("neither" as const),
+    evidenceStatus: "unvalidated-candidate" as const,
+    unitId: input.unitId,
+    location: location(unit),
+    code: input.code,
+    stage: input.stage,
+    detail: input.detail,
+  }) as PreparedIrDirectCandidate | PreparedIrInvariantCandidate;
 }
 
 function duplicateIds(ids: readonly IrUnitId[]): IrUnitId[] {
@@ -88,17 +103,18 @@ function duplicateIds(ids: readonly IrUnitId[]): IrUnitId[] {
 }
 
 /**
- * Mutable preparation transaction. seal() validates the complete denominator
- * and publishes one immutable PreparedIrProgram snapshot or fails closed.
+ * Structural candidate collector only. seal() proves denominator/lifecycle
+ * integrity, not production Prepared status. Production wiring must derive and
+ * reconcile IR edges, signatures, support, allocation, and provenance.
  */
 export class PreparedIrProgramBuilder {
   readonly #abi: ProgramAbiMap;
   readonly #freeUnits: ReadonlyMap<IrUnitId, IrTerminalUnitRecord>;
-  readonly #outcomes: PreparedIrUnitOutcome[] = [];
-  readonly #components: PreparedIrComponentInput[] = [];
-  readonly #supportIntents: PreparedIrSupportIntent[] = [];
-  readonly #allocations: PreparedIrAllocationRecord[] = [];
-  readonly #provenance: PreparedIrProvenanceRecord[] = [];
+  readonly #candidates: PreparedIrUnitCandidate[] = [];
+  readonly #componentCandidates: PreparedIrComponentCandidateInput[] = [];
+  readonly #supportIntentCandidates: Omit<PreparedIrSupportIntentCandidate, "evidenceStatus">[] = [];
+  readonly #allocationCandidates: Omit<PreparedIrAllocationCandidate, "evidenceStatus">[] = [];
+  readonly #provenanceCandidates: Omit<PreparedIrProvenanceCandidate, "evidenceStatus">[] = [];
   #state: BuilderState = "open";
   #program?: PreparedIrProgram;
 
@@ -117,63 +133,60 @@ export class PreparedIrProgramBuilder {
     );
   }
 
-  recordPrepared(input: PreparedIrPreparedInput): void {
-    this.#assertOpen();
-    const unit = this.#requireFreeUnit(input.unitId);
-    if (
-      input.backendLegality.verified !== true ||
-      input.optimization.allocationProvenance !== "verified" ||
-      !Array.isArray(input.finalSignature.params) ||
-      !Array.isArray(input.finalSignature.results)
-    ) {
-      throw new PreparedIrProgramInvariantError(
-        "invalid-prepared-evidence",
-        `Prepared unit ${input.unitId} lacks final legality/optimization/signature evidence`,
-      );
-    }
-    this.#outcomes.push(freezePrepared(input, unit));
+  recordIrCandidate(input: PreparedIrIrCandidateInput): void {
+    this.#mutate(() => {
+      const unit = this.#requireFreeUnit(input.unitId);
+      if (
+        input.assertedBackendLegality.verified !== true ||
+        input.assertedOptimization.allocationProvenance !== "verified" ||
+        !Array.isArray(input.assertedSignature.params) ||
+        !Array.isArray(input.assertedSignature.results)
+      ) {
+        throw new PreparedIrProgramInvariantError(
+          "invalid-prepared-data",
+          `IR candidate ${input.unitId} lacks structurally valid asserted evidence`,
+        );
+      }
+      this.#candidates.push(ownIrCandidate(input, unit));
+    });
   }
 
-  recordUnsupported(input: PreparedIrFailureInput): void {
-    this.#assertOpen();
-    this.#requireFreeUnit(input.unitId);
-    this.#outcomes.push(freezeFailure("unsupported", input));
+  recordDirectCandidate(input: PreparedIrFailureCandidateInput): void {
+    this.#mutate(() => {
+      const unit = this.#requireFreeUnit(input.unitId);
+      this.#candidates.push(ownFailureCandidate("direct-candidate", input, unit) as PreparedIrDirectCandidate);
+    });
   }
 
-  recordInvariant(input: PreparedIrFailureInput): void {
-    this.#assertOpen();
-    this.#requireFreeUnit(input.unitId);
-    this.#outcomes.push(freezeFailure("invariant", input));
+  recordInvariantCandidate(input: PreparedIrFailureCandidateInput): void {
+    this.#mutate(() => {
+      const unit = this.#requireFreeUnit(input.unitId);
+      this.#candidates.push(ownFailureCandidate("invariant-candidate", input, unit) as PreparedIrInvariantCandidate);
+    });
   }
 
-  addComponent(input: PreparedIrComponentInput): void {
-    this.#assertOpen();
-    this.#components.push(
-      Object.freeze({
-        id: input.id,
-        unitIds: Object.freeze([...input.unitIds]),
-      }),
-    );
+  addComponentCandidate(input: PreparedIrComponentCandidateInput): void {
+    this.#mutate(() => {
+      this.#componentCandidates.push(Object.freeze({ id: input.id, unitIds: Object.freeze([...input.unitIds]) }));
+    });
   }
 
-  addSupportIntent(input: PreparedIrSupportIntent): void {
+  addSupportIntentCandidate(input: Omit<PreparedIrSupportIntentCandidate, "evidenceStatus">): void {
     if (this.#state !== "open") {
       throw new PreparedIrProgramInvariantError(
         "late-support-intent",
-        `support intent ${input.key} was requested after preparation sealed`,
+        `support intent candidate ${input.key} was requested after preparation sealed`,
       );
     }
-    this.#supportIntents.push(Object.freeze({ ...input }));
+    this.#mutate(() => this.#supportIntentCandidates.push(Object.freeze({ ...input })));
   }
 
-  addAllocation(input: PreparedIrAllocationRecord): void {
-    this.#assertOpen();
-    this.#allocations.push(Object.freeze({ ...input }));
+  addAllocationCandidate(input: Omit<PreparedIrAllocationCandidate, "evidenceStatus">): void {
+    this.#mutate(() => this.#allocationCandidates.push(Object.freeze({ ...input })));
   }
 
-  addProvenance(input: PreparedIrProvenanceRecord): void {
-    this.#assertOpen();
-    this.#provenance.push(Object.freeze({ ...input }));
+  addProvenanceCandidate(input: Omit<PreparedIrProvenanceCandidate, "evidenceStatus">): void {
+    this.#mutate(() => this.#provenanceCandidates.push(Object.freeze({ ...input })));
   }
 
   seal(): PreparedIrProgram {
@@ -181,30 +194,17 @@ export class PreparedIrProgramBuilder {
     this.#assertOpen();
     this.#state = "sealing";
     try {
-      const outcomeMap = this.#validateOutcomes();
-      const components = this.#validateComponents(outcomeMap);
-      this.#validateSupportIntents();
-      this.#validatePreparedOwnership(outcomeMap);
-
-      const prepared = [...outcomeMap].filter(
-        (entry): entry is [IrUnitId, PreparedIrPreparedUnit] => entry[1].kind === "prepared",
-      );
-      const direct = [...outcomeMap].filter(
-        (entry): entry is [IrUnitId, PreparedIrUnsupportedUnit] => entry[1].kind === "unsupported",
-      );
-      const invariant = [...outcomeMap].filter(
-        (entry): entry is [IrUnitId, PreparedIrInvariantUnit] => entry[1].kind === "invariant",
-      );
-      this.#program = createValidatedPreparedIrProgram({
+      const units = this.#validateUnitCandidates();
+      this.#validateComponentCandidates();
+      this.#validateSupportCandidates();
+      this.#validateIrOwnedCandidates(units);
+      this.#program = createPreparedIrCandidateProgram({
         abiEntries: this.#abi.entries(),
-        units: preparedIrReadonlyMap(outcomeMap),
-        preparedUnits: preparedIrReadonlyMap(prepared),
-        directUnits: preparedIrReadonlyMap(direct),
-        invariantUnits: preparedIrReadonlyMap(invariant),
-        components,
-        supportIntents: Object.freeze([...this.#supportIntents]),
-        allocations: Object.freeze([...this.#allocations]),
-        provenance: Object.freeze([...this.#provenance]),
+        units,
+        componentCandidates: this.#componentCandidates,
+        supportIntentCandidates: this.#supportIntentCandidates,
+        allocationCandidates: this.#allocationCandidates,
+        provenanceCandidates: this.#provenanceCandidates,
       });
       this.#state = "sealed";
       return this.#program;
@@ -214,120 +214,102 @@ export class PreparedIrProgramBuilder {
     }
   }
 
-  #validateOutcomes(): Map<IrUnitId, PreparedIrUnitOutcome> {
-    const duplicateOutcomes = duplicateIds(this.#outcomes.map((outcome) => outcome.unitId));
-    if (duplicateOutcomes.length > 0) {
+  #validateUnitCandidates(): ReadonlyMap<IrUnitId, PreparedIrUnitCandidate> {
+    const duplicateCandidates = duplicateIds(this.#candidates.map((candidate) => candidate.unitId));
+    if (duplicateCandidates.length > 0) {
       throw new PreparedIrProgramInvariantError(
         "duplicate-unit",
-        `free-function outcomes duplicated: ${duplicateOutcomes.join(", ")}`,
+        `free-function candidates duplicated: ${duplicateCandidates.join(", ")}`,
       );
     }
-    const outcomes = new Map(this.#outcomes.map((outcome) => [outcome.unitId, outcome] as const));
-    const unknown = [...outcomes.keys()].filter((unitId) => !this.#freeUnits.has(unitId));
-    if (unknown.length > 0) {
-      throw new PreparedIrProgramInvariantError("unknown-unit", `outcomes include non-R2 units: ${unknown.join(", ")}`);
-    }
-    const missing = [...this.#freeUnits.keys()].filter((unitId) => !outcomes.has(unitId));
+    const candidates = new Map(this.#candidates.map((candidate) => [candidate.unitId, candidate] as const));
+    const missing = [...this.#freeUnits.keys()].filter((unitId) => !candidates.has(unitId));
     if (missing.length > 0) {
       throw new PreparedIrProgramInvariantError(
         "missing-unit",
-        `free-function outcomes missing: ${missing.join(", ")}`,
+        `free-function candidates missing: ${missing.join(", ")}`,
       );
     }
-    return outcomes;
+    return candidates;
   }
 
-  #validateComponents(outcomes: ReadonlyMap<IrUnitId, PreparedIrUnitOutcome>): readonly PreparedIrComponent[] {
-    const componentIds = this.#components.map((component) => component.id);
-    if (new Set(componentIds).size !== componentIds.length) {
-      throw new PreparedIrProgramInvariantError("duplicate-component", "component IDs must be unique");
-    }
-    const allMembers = this.#components.flatMap((component) => [...component.unitIds]);
-    const duplicateMembers = duplicateIds(allMembers);
-    if (duplicateMembers.length > 0) {
+  #validateComponentCandidates(): void {
+    const ids = this.#componentCandidates.map((component) => component.id);
+    if (new Set(ids).size !== ids.length) {
       throw new PreparedIrProgramInvariantError(
-        "duplicate-component-unit",
-        `free functions belong to multiple components: ${duplicateMembers.join(", ")}`,
+        "duplicate-component-candidate",
+        "component candidate IDs must be unique",
       );
     }
-    const unknownMembers = allMembers.filter((unitId) => !this.#freeUnits.has(unitId));
-    if (unknownMembers.length > 0) {
-      throw new PreparedIrProgramInvariantError(
-        "unknown-unit",
-        `components include non-R2 units: ${unknownMembers.join(", ")}`,
-      );
+    for (const component of this.#componentCandidates) {
+      if (component.unitIds.length === 0) {
+        throw new PreparedIrProgramInvariantError(
+          "empty-component-candidate",
+          `component candidate ${component.id} is empty`,
+        );
+      }
+      const unknown = component.unitIds.filter((unitId) => !this.#freeUnits.has(unitId));
+      if (unknown.length > 0) {
+        throw new PreparedIrProgramInvariantError(
+          "unknown-unit",
+          `component candidate ${component.id} includes non-R2 units: ${unknown.join(", ")}`,
+        );
+      }
     }
-    const missingMembers = [...this.#freeUnits.keys()].filter((unitId) => !allMembers.includes(unitId));
-    if (missingMembers.length > 0) {
-      throw new PreparedIrProgramInvariantError(
-        "missing-component-unit",
-        `free functions lack component ownership: ${missingMembers.join(", ")}`,
-      );
-    }
-    return Object.freeze(
-      this.#components.map((component) => {
-        if (component.unitIds.length === 0) {
-          throw new PreparedIrProgramInvariantError("empty-component", `component ${component.id} is empty`);
-        }
-        const kinds = new Set(component.unitIds.map((unitId) => outcomes.get(unitId)!.kind));
-        if (kinds.size !== 1) {
-          throw new PreparedIrProgramInvariantError(
-            "mixed-component-outcome",
-            `component ${component.id} mixes terminal outcomes: ${[...kinds].join(", ")}`,
-          );
-        }
-        return Object.freeze({
-          id: component.id,
-          unitIds: Object.freeze([...component.unitIds]),
-          outcome: [...kinds][0]!,
-        });
-      }),
-    );
   }
 
-  #validateSupportIntents(): void {
-    const keys = this.#supportIntents.map((intent) => intent.key);
+  #validateSupportCandidates(): void {
+    const keys = this.#supportIntentCandidates.map((candidate) => candidate.key);
     if (new Set(keys).size !== keys.length) {
-      throw new PreparedIrProgramInvariantError("duplicate-support-intent", "support intent keys must be unique");
+      throw new PreparedIrProgramInvariantError(
+        "duplicate-support-intent-candidate",
+        "support intent candidate keys must be unique",
+      );
     }
-    for (const intent of this.#supportIntents) {
-      if (intent.ownerUnitId && !this.#freeUnits.has(intent.ownerUnitId)) {
+    for (const candidate of this.#supportIntentCandidates) {
+      if (candidate.ownerUnitId && !this.#freeUnits.has(candidate.ownerUnitId)) {
         throw new PreparedIrProgramInvariantError(
           "unknown-support-owner",
-          `support intent ${intent.key} has unknown owner ${intent.ownerUnitId}`,
+          `support intent candidate ${candidate.key} has unknown owner ${candidate.ownerUnitId}`,
         );
       }
-      if (intent.bindingId && !this.#abi.get(intent.bindingId)) {
+      if (candidate.bindingId && !this.#abi.get(candidate.bindingId)) {
         throw new PreparedIrProgramInvariantError(
           "unknown-support-binding",
-          `support intent ${intent.key} references unplanned binding ${intent.bindingId}`,
+          `support intent candidate ${candidate.key} references unplanned binding ${candidate.bindingId}`,
         );
       }
     }
   }
 
-  #validatePreparedOwnership(outcomes: ReadonlyMap<IrUnitId, PreparedIrUnitOutcome>): void {
-    const allocationKeys = this.#allocations.map((record) => record.key);
+  #validateIrOwnedCandidates(units: ReadonlyMap<IrUnitId, PreparedIrUnitCandidate>): void {
+    const allocationKeys = this.#allocationCandidates.map((candidate) => candidate.key);
     if (new Set(allocationKeys).size !== allocationKeys.length) {
-      throw new PreparedIrProgramInvariantError("duplicate-allocation", "allocation keys must be unique");
+      throw new PreparedIrProgramInvariantError(
+        "duplicate-allocation-candidate",
+        "allocation candidate keys must be unique",
+      );
     }
-    for (const record of this.#allocations) {
-      if (outcomes.get(record.ownerUnitId)?.kind !== "prepared") {
+    for (const candidate of this.#allocationCandidates) {
+      if (units.get(candidate.ownerUnitId)?.kind !== "ir-candidate") {
         throw new PreparedIrProgramInvariantError(
-          "allocation-not-prepared-owned",
-          `allocation ${record.key} is owned by non-Prepared unit ${record.ownerUnitId}`,
+          "allocation-not-ir-candidate-owned",
+          `allocation candidate ${candidate.key} is owned by non-IR candidate ${candidate.ownerUnitId}`,
         );
       }
     }
-    const artifactIds = this.#provenance.map((record) => record.artifactUnitId);
-    if (new Set(artifactIds).size !== artifactIds.length) {
-      throw new PreparedIrProgramInvariantError("duplicate-provenance", "artifact provenance must be unique");
+    const artifacts = this.#provenanceCandidates.map((candidate) => candidate.artifactUnitId);
+    if (new Set(artifacts).size !== artifacts.length) {
+      throw new PreparedIrProgramInvariantError(
+        "duplicate-provenance-candidate",
+        "provenance candidate artifacts must be unique",
+      );
     }
-    for (const record of this.#provenance) {
-      if (outcomes.get(record.ownerUnitId)?.kind !== "prepared") {
+    for (const candidate of this.#provenanceCandidates) {
+      if (units.get(candidate.ownerUnitId)?.kind !== "ir-candidate") {
         throw new PreparedIrProgramInvariantError(
-          "provenance-not-prepared-owned",
-          `artifact ${record.artifactUnitId} is owned by non-Prepared unit ${record.ownerUnitId}`,
+          "provenance-not-ir-candidate-owned",
+          `provenance candidate ${candidate.artifactUnitId} is owned by non-IR candidate ${candidate.ownerUnitId}`,
         );
       }
     }
@@ -342,6 +324,16 @@ export class PreparedIrProgramBuilder {
       );
     }
     return unit;
+  }
+
+  #mutate(operation: () => void): void {
+    this.#assertOpen();
+    try {
+      operation();
+    } catch (error) {
+      this.#state = "failed";
+      throw error;
+    }
   }
 
   #assertOpen(): void {

--- a/src/ir/prepare.ts
+++ b/src/ir/prepare.ts
@@ -135,39 +135,47 @@ export class PreparedIrProgramBuilder {
 
   recordIrCandidate(input: PreparedIrIrCandidateInput): void {
     this.#mutate(() => {
-      const unit = this.#requireFreeUnit(input.unitId);
+      const ownedInput = freezePreparedIrValue(input) as PreparedIrIrCandidateInput;
+      const unit = this.#requireFreeUnit(ownedInput.unitId);
       if (
-        input.assertedBackendLegality.verified !== true ||
-        input.assertedOptimization.allocationProvenance !== "verified" ||
-        !Array.isArray(input.assertedSignature.params) ||
-        !Array.isArray(input.assertedSignature.results)
+        ownedInput.assertedBackendLegality.verified !== true ||
+        ownedInput.assertedOptimization.allocationProvenance !== "verified" ||
+        !Array.isArray(ownedInput.assertedSignature.params) ||
+        !Array.isArray(ownedInput.assertedSignature.results)
       ) {
         throw new PreparedIrProgramInvariantError(
           "invalid-prepared-data",
-          `IR candidate ${input.unitId} lacks structurally valid asserted evidence`,
+          `IR candidate ${ownedInput.unitId} lacks structurally valid asserted evidence`,
         );
       }
-      this.#candidates.push(ownIrCandidate(input, unit));
+      this.#candidates.push(ownIrCandidate(ownedInput, unit));
     });
   }
 
   recordDirectCandidate(input: PreparedIrFailureCandidateInput): void {
     this.#mutate(() => {
-      const unit = this.#requireFreeUnit(input.unitId);
-      this.#candidates.push(ownFailureCandidate("direct-candidate", input, unit) as PreparedIrDirectCandidate);
+      const ownedInput = freezePreparedIrValue(input) as PreparedIrFailureCandidateInput;
+      const unit = this.#requireFreeUnit(ownedInput.unitId);
+      this.#candidates.push(ownFailureCandidate("direct-candidate", ownedInput, unit) as PreparedIrDirectCandidate);
     });
   }
 
   recordInvariantCandidate(input: PreparedIrFailureCandidateInput): void {
     this.#mutate(() => {
-      const unit = this.#requireFreeUnit(input.unitId);
-      this.#candidates.push(ownFailureCandidate("invariant-candidate", input, unit) as PreparedIrInvariantCandidate);
+      const ownedInput = freezePreparedIrValue(input) as PreparedIrFailureCandidateInput;
+      const unit = this.#requireFreeUnit(ownedInput.unitId);
+      this.#candidates.push(
+        ownFailureCandidate("invariant-candidate", ownedInput, unit) as PreparedIrInvariantCandidate,
+      );
     });
   }
 
   addComponentCandidate(input: PreparedIrComponentCandidateInput): void {
     this.#mutate(() => {
-      this.#componentCandidates.push(Object.freeze({ id: input.id, unitIds: Object.freeze([...input.unitIds]) }));
+      const ownedInput = freezePreparedIrValue(input) as PreparedIrComponentCandidateInput;
+      this.#componentCandidates.push(
+        Object.freeze({ id: ownedInput.id, unitIds: Object.freeze([...ownedInput.unitIds]) }),
+      );
     });
   }
 
@@ -175,18 +183,27 @@ export class PreparedIrProgramBuilder {
     if (this.#state !== "open") {
       throw new PreparedIrProgramInvariantError(
         "late-support-intent",
-        `support intent candidate ${input.key} was requested after preparation sealed`,
+        "support intent candidate was requested after preparation sealed",
       );
     }
-    this.#mutate(() => this.#supportIntentCandidates.push(Object.freeze({ ...input })));
+    this.#mutate(() => {
+      const ownedInput = freezePreparedIrValue(input) as Omit<PreparedIrSupportIntentCandidate, "evidenceStatus">;
+      this.#supportIntentCandidates.push(ownedInput);
+    });
   }
 
   addAllocationCandidate(input: Omit<PreparedIrAllocationCandidate, "evidenceStatus">): void {
-    this.#mutate(() => this.#allocationCandidates.push(Object.freeze({ ...input })));
+    this.#mutate(() => {
+      const ownedInput = freezePreparedIrValue(input) as Omit<PreparedIrAllocationCandidate, "evidenceStatus">;
+      this.#allocationCandidates.push(ownedInput);
+    });
   }
 
   addProvenanceCandidate(input: Omit<PreparedIrProvenanceCandidate, "evidenceStatus">): void {
-    this.#mutate(() => this.#provenanceCandidates.push(Object.freeze({ ...input })));
+    this.#mutate(() => {
+      const ownedInput = freezePreparedIrValue(input) as Omit<PreparedIrProvenanceCandidate, "evidenceStatus">;
+      this.#provenanceCandidates.push(ownedInput);
+    });
   }
 
   seal(): PreparedIrProgram {

--- a/src/ir/prepare.ts
+++ b/src/ir/prepare.ts
@@ -1,0 +1,355 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrBindingId, IrUnitId, IrTerminalUnitRecord } from "./identity.js";
+import {
+  createValidatedPreparedIrProgram,
+  freezePreparedIrValue,
+  preparedIrReadonlyMap,
+  PreparedIrProgramInvariantError,
+  type PreparedIrAllocationRecord,
+  type PreparedIrBackendLegalityProof,
+  type PreparedIrComponent,
+  type PreparedIrInvariantUnit,
+  type PreparedIrOptimizationEvidence,
+  type PreparedIrPreparedUnit,
+  type PreparedIrProgram,
+  type PreparedIrProvenanceRecord,
+  type PreparedIrSupportIntent,
+  type PreparedIrUnitOutcome,
+  type PreparedIrUnsupportedUnit,
+} from "./program.js";
+import type { ProgramAbiCallableSignature } from "./program-abi.js";
+import { ProgramAbiMap } from "./program-abi.js";
+
+export interface PreparedIrPreparedInput {
+  readonly unitId: IrUnitId;
+  readonly finalSignature: ProgramAbiCallableSignature;
+  readonly exportIntents?: readonly IrBindingId[];
+  readonly backendLegality: PreparedIrBackendLegalityProof;
+  readonly optimization: PreparedIrOptimizationEvidence;
+  readonly ir: unknown;
+}
+
+export interface PreparedIrFailureInput {
+  readonly unitId: IrUnitId;
+  readonly code: string;
+  readonly stage: string;
+  readonly detail: string;
+}
+
+export interface PreparedIrComponentInput {
+  readonly id: string;
+  readonly unitIds: readonly IrUnitId[];
+}
+
+type BuilderState = "open" | "sealing" | "sealed" | "failed";
+
+function freezeSignature(signature: ProgramAbiCallableSignature): ProgramAbiCallableSignature {
+  return Object.freeze({
+    params: Object.freeze([...signature.params]),
+    results: Object.freeze([...signature.results]),
+  });
+}
+
+function freezePrepared(input: PreparedIrPreparedInput, unit: IrTerminalUnitRecord): PreparedIrPreparedUnit {
+  return Object.freeze({
+    kind: "prepared" as const,
+    unitId: input.unitId,
+    location: Object.freeze({
+      sourceId: unit.sourceId,
+      line: unit.line,
+      column: unit.column,
+      declarationStart: unit.declarationStart,
+      declarationEnd: unit.declarationEnd,
+    }),
+    finalSignature: freezeSignature(input.finalSignature),
+    exportIntents: Object.freeze([...(input.exportIntents ?? [])]),
+    backendLegality: Object.freeze({ ...input.backendLegality }),
+    optimization: Object.freeze({ ...input.optimization }),
+    ir: freezePreparedIrValue(input.ir),
+  });
+}
+
+function freezeFailure(
+  kind: "unsupported" | "invariant",
+  input: PreparedIrFailureInput,
+): PreparedIrUnsupportedUnit | PreparedIrInvariantUnit {
+  return Object.freeze({ kind, ...input });
+}
+
+function duplicateIds(ids: readonly IrUnitId[]): IrUnitId[] {
+  const seen = new Set<IrUnitId>();
+  const duplicates = new Set<IrUnitId>();
+  for (const id of ids) {
+    if (seen.has(id)) duplicates.add(id);
+    seen.add(id);
+  }
+  return [...duplicates];
+}
+
+/**
+ * Mutable preparation transaction. seal() validates the complete denominator
+ * and publishes one immutable PreparedIrProgram snapshot or fails closed.
+ */
+export class PreparedIrProgramBuilder {
+  readonly #abi: ProgramAbiMap;
+  readonly #freeUnits: ReadonlyMap<IrUnitId, IrTerminalUnitRecord>;
+  readonly #outcomes: PreparedIrUnitOutcome[] = [];
+  readonly #components: PreparedIrComponentInput[] = [];
+  readonly #supportIntents: PreparedIrSupportIntent[] = [];
+  readonly #allocations: PreparedIrAllocationRecord[] = [];
+  readonly #provenance: PreparedIrProvenanceRecord[] = [];
+  #state: BuilderState = "open";
+  #program?: PreparedIrProgram;
+
+  constructor(abi: ProgramAbiMap) {
+    if (!abi.planningSealed) {
+      throw new PreparedIrProgramInvariantError(
+        "abi-not-sealed",
+        "PreparedIrProgram requires a sealed ProgramAbiMap plan",
+      );
+    }
+    this.#abi = abi;
+    this.#freeUnits = preparedIrReadonlyMap(
+      abi.inventory.terminalUnits
+        .filter((unit) => unit.kind === "top-level-function")
+        .map((unit) => [unit.id, unit] as const),
+    );
+  }
+
+  recordPrepared(input: PreparedIrPreparedInput): void {
+    this.#assertOpen();
+    const unit = this.#requireFreeUnit(input.unitId);
+    if (
+      input.backendLegality.verified !== true ||
+      input.optimization.allocationProvenance !== "verified" ||
+      !Array.isArray(input.finalSignature.params) ||
+      !Array.isArray(input.finalSignature.results)
+    ) {
+      throw new PreparedIrProgramInvariantError(
+        "invalid-prepared-evidence",
+        `Prepared unit ${input.unitId} lacks final legality/optimization/signature evidence`,
+      );
+    }
+    this.#outcomes.push(freezePrepared(input, unit));
+  }
+
+  recordUnsupported(input: PreparedIrFailureInput): void {
+    this.#assertOpen();
+    this.#requireFreeUnit(input.unitId);
+    this.#outcomes.push(freezeFailure("unsupported", input));
+  }
+
+  recordInvariant(input: PreparedIrFailureInput): void {
+    this.#assertOpen();
+    this.#requireFreeUnit(input.unitId);
+    this.#outcomes.push(freezeFailure("invariant", input));
+  }
+
+  addComponent(input: PreparedIrComponentInput): void {
+    this.#assertOpen();
+    this.#components.push(
+      Object.freeze({
+        id: input.id,
+        unitIds: Object.freeze([...input.unitIds]),
+      }),
+    );
+  }
+
+  addSupportIntent(input: PreparedIrSupportIntent): void {
+    if (this.#state !== "open") {
+      throw new PreparedIrProgramInvariantError(
+        "late-support-intent",
+        `support intent ${input.key} was requested after preparation sealed`,
+      );
+    }
+    this.#supportIntents.push(Object.freeze({ ...input }));
+  }
+
+  addAllocation(input: PreparedIrAllocationRecord): void {
+    this.#assertOpen();
+    this.#allocations.push(Object.freeze({ ...input }));
+  }
+
+  addProvenance(input: PreparedIrProvenanceRecord): void {
+    this.#assertOpen();
+    this.#provenance.push(Object.freeze({ ...input }));
+  }
+
+  seal(): PreparedIrProgram {
+    if (this.#state === "sealed") return this.#program!;
+    this.#assertOpen();
+    this.#state = "sealing";
+    try {
+      const outcomeMap = this.#validateOutcomes();
+      const components = this.#validateComponents(outcomeMap);
+      this.#validateSupportIntents();
+      this.#validatePreparedOwnership(outcomeMap);
+
+      const prepared = [...outcomeMap].filter(
+        (entry): entry is [IrUnitId, PreparedIrPreparedUnit] => entry[1].kind === "prepared",
+      );
+      const direct = [...outcomeMap].filter(
+        (entry): entry is [IrUnitId, PreparedIrUnsupportedUnit] => entry[1].kind === "unsupported",
+      );
+      const invariant = [...outcomeMap].filter(
+        (entry): entry is [IrUnitId, PreparedIrInvariantUnit] => entry[1].kind === "invariant",
+      );
+      this.#program = createValidatedPreparedIrProgram({
+        abiEntries: this.#abi.entries(),
+        units: preparedIrReadonlyMap(outcomeMap),
+        preparedUnits: preparedIrReadonlyMap(prepared),
+        directUnits: preparedIrReadonlyMap(direct),
+        invariantUnits: preparedIrReadonlyMap(invariant),
+        components,
+        supportIntents: Object.freeze([...this.#supportIntents]),
+        allocations: Object.freeze([...this.#allocations]),
+        provenance: Object.freeze([...this.#provenance]),
+      });
+      this.#state = "sealed";
+      return this.#program;
+    } catch (error) {
+      this.#state = "failed";
+      throw error;
+    }
+  }
+
+  #validateOutcomes(): Map<IrUnitId, PreparedIrUnitOutcome> {
+    const duplicateOutcomes = duplicateIds(this.#outcomes.map((outcome) => outcome.unitId));
+    if (duplicateOutcomes.length > 0) {
+      throw new PreparedIrProgramInvariantError(
+        "duplicate-unit",
+        `free-function outcomes duplicated: ${duplicateOutcomes.join(", ")}`,
+      );
+    }
+    const outcomes = new Map(this.#outcomes.map((outcome) => [outcome.unitId, outcome] as const));
+    const unknown = [...outcomes.keys()].filter((unitId) => !this.#freeUnits.has(unitId));
+    if (unknown.length > 0) {
+      throw new PreparedIrProgramInvariantError("unknown-unit", `outcomes include non-R2 units: ${unknown.join(", ")}`);
+    }
+    const missing = [...this.#freeUnits.keys()].filter((unitId) => !outcomes.has(unitId));
+    if (missing.length > 0) {
+      throw new PreparedIrProgramInvariantError(
+        "missing-unit",
+        `free-function outcomes missing: ${missing.join(", ")}`,
+      );
+    }
+    return outcomes;
+  }
+
+  #validateComponents(outcomes: ReadonlyMap<IrUnitId, PreparedIrUnitOutcome>): readonly PreparedIrComponent[] {
+    const componentIds = this.#components.map((component) => component.id);
+    if (new Set(componentIds).size !== componentIds.length) {
+      throw new PreparedIrProgramInvariantError("duplicate-component", "component IDs must be unique");
+    }
+    const allMembers = this.#components.flatMap((component) => [...component.unitIds]);
+    const duplicateMembers = duplicateIds(allMembers);
+    if (duplicateMembers.length > 0) {
+      throw new PreparedIrProgramInvariantError(
+        "duplicate-component-unit",
+        `free functions belong to multiple components: ${duplicateMembers.join(", ")}`,
+      );
+    }
+    const unknownMembers = allMembers.filter((unitId) => !this.#freeUnits.has(unitId));
+    if (unknownMembers.length > 0) {
+      throw new PreparedIrProgramInvariantError(
+        "unknown-unit",
+        `components include non-R2 units: ${unknownMembers.join(", ")}`,
+      );
+    }
+    const missingMembers = [...this.#freeUnits.keys()].filter((unitId) => !allMembers.includes(unitId));
+    if (missingMembers.length > 0) {
+      throw new PreparedIrProgramInvariantError(
+        "missing-component-unit",
+        `free functions lack component ownership: ${missingMembers.join(", ")}`,
+      );
+    }
+    return Object.freeze(
+      this.#components.map((component) => {
+        if (component.unitIds.length === 0) {
+          throw new PreparedIrProgramInvariantError("empty-component", `component ${component.id} is empty`);
+        }
+        const kinds = new Set(component.unitIds.map((unitId) => outcomes.get(unitId)!.kind));
+        if (kinds.size !== 1) {
+          throw new PreparedIrProgramInvariantError(
+            "mixed-component-outcome",
+            `component ${component.id} mixes terminal outcomes: ${[...kinds].join(", ")}`,
+          );
+        }
+        return Object.freeze({
+          id: component.id,
+          unitIds: Object.freeze([...component.unitIds]),
+          outcome: [...kinds][0]!,
+        });
+      }),
+    );
+  }
+
+  #validateSupportIntents(): void {
+    const keys = this.#supportIntents.map((intent) => intent.key);
+    if (new Set(keys).size !== keys.length) {
+      throw new PreparedIrProgramInvariantError("duplicate-support-intent", "support intent keys must be unique");
+    }
+    for (const intent of this.#supportIntents) {
+      if (intent.ownerUnitId && !this.#freeUnits.has(intent.ownerUnitId)) {
+        throw new PreparedIrProgramInvariantError(
+          "unknown-support-owner",
+          `support intent ${intent.key} has unknown owner ${intent.ownerUnitId}`,
+        );
+      }
+      if (intent.bindingId && !this.#abi.get(intent.bindingId)) {
+        throw new PreparedIrProgramInvariantError(
+          "unknown-support-binding",
+          `support intent ${intent.key} references unplanned binding ${intent.bindingId}`,
+        );
+      }
+    }
+  }
+
+  #validatePreparedOwnership(outcomes: ReadonlyMap<IrUnitId, PreparedIrUnitOutcome>): void {
+    const allocationKeys = this.#allocations.map((record) => record.key);
+    if (new Set(allocationKeys).size !== allocationKeys.length) {
+      throw new PreparedIrProgramInvariantError("duplicate-allocation", "allocation keys must be unique");
+    }
+    for (const record of this.#allocations) {
+      if (outcomes.get(record.ownerUnitId)?.kind !== "prepared") {
+        throw new PreparedIrProgramInvariantError(
+          "allocation-not-prepared-owned",
+          `allocation ${record.key} is owned by non-Prepared unit ${record.ownerUnitId}`,
+        );
+      }
+    }
+    const artifactIds = this.#provenance.map((record) => record.artifactUnitId);
+    if (new Set(artifactIds).size !== artifactIds.length) {
+      throw new PreparedIrProgramInvariantError("duplicate-provenance", "artifact provenance must be unique");
+    }
+    for (const record of this.#provenance) {
+      if (outcomes.get(record.ownerUnitId)?.kind !== "prepared") {
+        throw new PreparedIrProgramInvariantError(
+          "provenance-not-prepared-owned",
+          `artifact ${record.artifactUnitId} is owned by non-Prepared unit ${record.ownerUnitId}`,
+        );
+      }
+    }
+  }
+
+  #requireFreeUnit(unitId: IrUnitId): IrTerminalUnitRecord {
+    const unit = this.#freeUnits.get(unitId);
+    if (!unit) {
+      throw new PreparedIrProgramInvariantError(
+        "unknown-unit",
+        `${unitId} is not an inventoried top-level free function`,
+      );
+    }
+    return unit;
+  }
+
+  #assertOpen(): void {
+    if (this.#state === "failed") {
+      throw new PreparedIrProgramInvariantError("program-seal-failed", "preparation transaction already failed");
+    }
+    if (this.#state !== "open") {
+      throw new PreparedIrProgramInvariantError("program-sealed", `preparation transaction is ${this.#state}`);
+    }
+  }
+}

--- a/src/ir/program.ts
+++ b/src/ir/program.ts
@@ -273,6 +273,11 @@ class FrozenSet<T> implements ReadonlySet<T> {
   }
 }
 
+Object.freeze(FrozenMap.prototype);
+Object.freeze(FrozenMap);
+Object.freeze(FrozenSet.prototype);
+Object.freeze(FrozenSet);
+
 export function preparedIrReadonlyMap<K, V>(entries: Iterable<readonly [K, V]>): ReadonlyMap<K, V> {
   return new FrozenMap(entries);
 }
@@ -284,6 +289,7 @@ function invalidPreparedData(detail: string): never {
 function immutableCopy(value: unknown, ancestors = new Set<object>()): unknown {
   if (typeof value === "function") invalidPreparedData("prepared data cannot contain executable functions");
   if (value === null || typeof value !== "object") return value;
+  if (value instanceof FrozenMap || value instanceof FrozenSet) return value;
   if (ancestors.has(value)) invalidPreparedData("prepared data must be acyclic");
   const nextAncestors = new Set(ancestors).add(value);
   if (Array.isArray(value)) return Object.freeze(value.map((item) => immutableCopy(item, nextAncestors)));
@@ -494,6 +500,10 @@ function expectedCandidateRoute(candidate: PreparedIrUnitCandidate): PreparedIrC
       return "direct";
     case "invariant-candidate":
       return "neither";
+    default:
+      return invalidPreparedData(
+        `candidate has unknown kind ${String((candidate as unknown as { kind?: unknown }).kind)}`,
+      );
   }
 }
 
@@ -502,7 +512,8 @@ function expectedCandidateRoute(candidate: PreparedIrUnitCandidate): PreparedIrC
  * the output remains explicitly pending production reconciliation.
  */
 export function createPreparedIrCandidateProgram(input: PreparedIrCandidateProgramInput): PreparedIrProgram {
-  const entries = Object.freeze(input.abiEntries.map((entry) => ownCandidate(entry)));
+  const ownedInput = ownCandidate(input);
+  const entries = Object.freeze(ownedInput.abiEntries.map((entry) => ownCandidate(entry)));
   const entryMap = new Map(entries.map((entry) => [entry.id, entry]));
   const abi: PreparedIrAbiSnapshot = Object.freeze({
     planningSealed: true as const,
@@ -510,7 +521,7 @@ export function createPreparedIrCandidateProgram(input: PreparedIrCandidateProgr
     get: (id: IrBindingId) => entryMap.get(id),
   });
   const units = preparedIrReadonlyMap(
-    [...input.units].map(([unitId, candidate]) => {
+    [...ownedInput.units].map(([unitId, candidate]) => {
       const ownedCandidate = ownCandidate(candidate);
       if (
         ownedCandidate.unitId !== unitId ||
@@ -537,7 +548,7 @@ export function createPreparedIrCandidateProgram(input: PreparedIrCandidateProgr
     ),
   );
   const componentCandidates = Object.freeze(
-    input.componentCandidates.map((component) => {
+    ownedInput.componentCandidates.map((component) => {
       const unitIds = Object.freeze([...component.unitIds]);
       const unknownUnitIds = unitIds.filter((unitId) => !units.has(unitId));
       if (unknownUnitIds.length > 0) {
@@ -555,18 +566,39 @@ export function createPreparedIrCandidateProgram(input: PreparedIrCandidateProgr
     }),
   );
   const supportIntentCandidates = Object.freeze(
-    input.supportIntentCandidates.map((candidate) =>
-      ownCandidate({ ...candidate, evidenceStatus: "unvalidated-candidate" as const }),
+    ownedInput.supportIntentCandidates.map((candidate) =>
+      ownCandidate({
+        key: candidate.key,
+        kind: candidate.kind,
+        ownerUnitId: candidate.ownerUnitId,
+        bindingId: candidate.bindingId,
+        detail: candidate.detail,
+        evidenceStatus: "unvalidated-candidate" as const,
+      }),
     ),
   );
   const allocationCandidates = Object.freeze(
-    input.allocationCandidates.map((candidate) =>
-      ownCandidate({ ...candidate, evidenceStatus: "unvalidated-candidate" as const }),
+    ownedInput.allocationCandidates.map((candidate) =>
+      ownCandidate({
+        key: candidate.key,
+        kind: candidate.kind,
+        ownerUnitId: candidate.ownerUnitId,
+        bindingId: candidate.bindingId,
+        ordinal: candidate.ordinal,
+        evidenceStatus: "unvalidated-candidate" as const,
+      }),
     ),
   );
   const provenanceCandidates = Object.freeze(
-    input.provenanceCandidates.map((candidate) =>
-      ownCandidate({ ...candidate, evidenceStatus: "unvalidated-candidate" as const }),
+    ownedInput.provenanceCandidates.map((candidate) =>
+      ownCandidate({
+        artifactUnitId: candidate.artifactUnitId,
+        ownerUnitId: candidate.ownerUnitId,
+        role: candidate.role,
+        parentUnitId: candidate.parentUnitId,
+        ordinal: candidate.ordinal,
+        evidenceStatus: "unvalidated-candidate" as const,
+      }),
     ),
   );
   let emissionStarted = false;

--- a/src/ir/program.ts
+++ b/src/ir/program.ts
@@ -4,8 +4,8 @@ import type { IrBackendKind } from "./backend/legality.js";
 import type { IrBindingId, IrSourceId, IrUnitId } from "./identity.js";
 import type { ProgramAbiCallableSignature, ProgramAbiPlanEntry } from "./program-abi.js";
 
-export type PreparedIrOutcomeKind = "prepared" | "unsupported" | "invariant";
-export type PreparedIrEmitter = "direct" | "ir";
+export type PreparedIrCandidateRoute = "ir" | "direct" | "neither";
+export type PreparedIrEmitter = Exclude<PreparedIrCandidateRoute, "neither">;
 
 export type PreparedIrProgramInvariantCode =
   | "abi-not-sealed"
@@ -14,21 +14,19 @@ export type PreparedIrProgramInvariantCode =
   | "duplicate-unit"
   | "missing-unit"
   | "unknown-unit"
-  | "duplicate-component"
-  | "empty-component"
-  | "duplicate-component-unit"
-  | "missing-component-unit"
-  | "mixed-component-outcome"
-  | "duplicate-support-intent"
+  | "duplicate-component-candidate"
+  | "empty-component-candidate"
+  | "duplicate-support-intent-candidate"
   | "late-support-intent"
   | "unknown-support-owner"
   | "unknown-support-binding"
-  | "duplicate-allocation"
-  | "allocation-not-prepared-owned"
-  | "duplicate-provenance"
-  | "provenance-not-prepared-owned"
-  | "invalid-prepared-evidence"
-  | "program-has-invariant"
+  | "duplicate-allocation-candidate"
+  | "allocation-not-ir-candidate-owned"
+  | "duplicate-provenance-candidate"
+  | "provenance-not-ir-candidate-owned"
+  | "invalid-prepared-data"
+  | "program-has-invariant-candidate"
+  | "invalid-transaction-capability"
   | "emission-already-started"
   | "transaction-closed"
   | "wrong-emitter"
@@ -55,52 +53,62 @@ export interface PreparedIrSourceLocation {
   readonly declarationEnd: number;
 }
 
-export interface PreparedIrOptimizationEvidence {
+export interface PreparedIrAssertedOptimizationEvidence {
   readonly inlineSmall: "applied" | "not-applicable";
   readonly monomorphization: "applied" | "not-applicable";
   readonly allocationProvenance: "verified";
 }
 
-export interface PreparedIrBackendLegalityProof {
+export interface PreparedIrAssertedBackendLegality {
   readonly backend: IrBackendKind;
   readonly target: "gc" | "linear" | "standalone" | "wasi";
   readonly verified: true;
 }
 
-export interface PreparedIrPreparedUnit {
-  readonly kind: "prepared";
+interface PreparedIrCandidateBase {
   readonly unitId: IrUnitId;
   readonly location: PreparedIrSourceLocation;
-  readonly finalSignature: ProgramAbiCallableSignature;
-  readonly exportIntents: readonly IrBindingId[];
-  readonly backendLegality: PreparedIrBackendLegalityProof;
-  readonly optimization: PreparedIrOptimizationEvidence;
-  /** Frozen post-pass typed IR. The structural slice deliberately does not emit it. */
-  readonly ir: unknown;
+  /** This structural slice does not make the record production-authoritative. */
+  readonly evidenceStatus: "unvalidated-candidate";
 }
 
-export interface PreparedIrUnsupportedUnit {
-  readonly kind: "unsupported";
-  readonly unitId: IrUnitId;
+export interface PreparedIrIrCandidate extends PreparedIrCandidateBase {
+  readonly kind: "ir-candidate";
+  readonly route: "ir";
+  readonly assertedSignature: ProgramAbiCallableSignature;
+  readonly assertedExportIntents: readonly IrBindingId[];
+  readonly assertedBackendLegality: PreparedIrAssertedBackendLegality;
+  readonly assertedOptimization: PreparedIrAssertedOptimizationEvidence;
+  readonly irCandidate: unknown;
+}
+
+export interface PreparedIrDirectCandidate extends PreparedIrCandidateBase {
+  readonly kind: "direct-candidate";
+  readonly route: "direct";
   readonly code: string;
   readonly stage: string;
   readonly detail: string;
 }
 
-export interface PreparedIrInvariantUnit {
-  readonly kind: "invariant";
-  readonly unitId: IrUnitId;
+export interface PreparedIrInvariantCandidate extends PreparedIrCandidateBase {
+  readonly kind: "invariant-candidate";
+  readonly route: "neither";
   readonly code: string;
   readonly stage: string;
   readonly detail: string;
 }
 
-export type PreparedIrUnitOutcome = PreparedIrPreparedUnit | PreparedIrUnsupportedUnit | PreparedIrInvariantUnit;
+export type PreparedIrUnitCandidate = PreparedIrIrCandidate | PreparedIrDirectCandidate | PreparedIrInvariantCandidate;
 
-export interface PreparedIrComponent {
+/**
+ * Caller-supplied grouping hint only. Production wiring must rebuild and
+ * reconcile components from authoritative IR call/ABI edges.
+ */
+export interface PreparedIrComponentCandidate {
   readonly id: string;
   readonly unitIds: readonly IrUnitId[];
-  readonly outcome: PreparedIrOutcomeKind;
+  readonly candidateRoutes: readonly PreparedIrCandidateRoute[];
+  readonly evidenceStatus: "unvalidated-component-candidate";
 }
 
 export type PreparedIrSupportIntentKind =
@@ -115,35 +123,38 @@ export type PreparedIrSupportIntentKind =
   | "export"
   | "monomorphized-clone";
 
-/** A symbolic request resolved during preparation, before either body emitter runs. */
-export interface PreparedIrSupportIntent {
+/** Unvalidated symbolic discovery retained for later production reconciliation. */
+export interface PreparedIrSupportIntentCandidate {
   readonly key: string;
   readonly kind: PreparedIrSupportIntentKind;
   readonly ownerUnitId?: IrUnitId;
   readonly bindingId?: IrBindingId;
   readonly detail?: string;
+  readonly evidenceStatus: "unvalidated-candidate";
 }
 
 export type PreparedIrAllocationKind = "function" | "global" | "type" | "literal" | "helper";
 
-/** Allocation reservation owned only by a Prepared unit; no concrete Wasm index is allocated here. */
-export interface PreparedIrAllocationRecord {
+/** Unvalidated allocation request; this slice neither reserves nor allocates a concrete index. */
+export interface PreparedIrAllocationCandidate {
   readonly key: string;
   readonly kind: PreparedIrAllocationKind;
   readonly ownerUnitId: IrUnitId;
   readonly bindingId?: IrBindingId;
   readonly ordinal: number;
+  readonly evidenceStatus: "unvalidated-candidate";
 }
 
 export type PreparedIrProvenanceRole = "source" | "lifted-closure" | "monomorphization-clone";
 
-/** Exact source/pass provenance for a Prepared-owned source or derived IR artifact. */
-export interface PreparedIrProvenanceRecord {
+/** Unvalidated source/pass provenance assertion retained for later reconciliation. */
+export interface PreparedIrProvenanceCandidate {
   readonly artifactUnitId: IrUnitId;
   readonly ownerUnitId: IrUnitId;
   readonly role: PreparedIrProvenanceRole;
   readonly parentUnitId?: IrUnitId;
   readonly ordinal: number;
+  readonly evidenceStatus: "unvalidated-candidate";
 }
 
 export interface PreparedIrAbiSnapshot {
@@ -154,7 +165,7 @@ export interface PreparedIrAbiSnapshot {
 
 export interface PreparedIrEmissionLedgerEntry {
   readonly unitId: IrUnitId;
-  readonly outcome: PreparedIrOutcomeKind;
+  readonly candidateRoute: PreparedIrCandidateRoute;
   readonly prepareAttempts: 1;
   readonly directBodyEmissions: number;
   readonly irBodyEmissions: number;
@@ -168,22 +179,25 @@ export interface PreparedIrStagedBody {
   readonly body: unknown;
 }
 
-export interface PreparedIrPublication {
+/** Structural candidate publication only; never a production ownership proof. */
+export interface PreparedIrCandidatePublication {
+  readonly evidenceStatus: "unvalidated-candidate-publication";
   readonly bodies: ReadonlyMap<IrUnitId, PreparedIrStagedBody>;
   readonly ledger: ReadonlyMap<IrUnitId, PreparedIrEmissionLedgerEntry>;
 }
 
 export interface PreparedIrProgram {
   readonly abi: PreparedIrAbiSnapshot;
-  /** Exact R2 denominator: all and only inventoried top-level free functions. */
-  readonly units: ReadonlyMap<IrUnitId, PreparedIrUnitOutcome>;
-  readonly preparedUnits: ReadonlyMap<IrUnitId, PreparedIrPreparedUnit>;
-  readonly directUnits: ReadonlyMap<IrUnitId, PreparedIrUnsupportedUnit>;
-  readonly invariantUnits: ReadonlyMap<IrUnitId, PreparedIrInvariantUnit>;
-  readonly components: readonly PreparedIrComponent[];
-  readonly supportIntents: readonly PreparedIrSupportIntent[];
-  readonly allocations: readonly PreparedIrAllocationRecord[];
-  readonly provenance: readonly PreparedIrProvenanceRecord[];
+  /** Exact authoritative R2 denominator; every value remains an unvalidated candidate. */
+  readonly units: ReadonlyMap<IrUnitId, PreparedIrUnitCandidate>;
+  readonly irCandidates: ReadonlyMap<IrUnitId, PreparedIrIrCandidate>;
+  readonly directCandidates: ReadonlyMap<IrUnitId, PreparedIrDirectCandidate>;
+  readonly invariantCandidates: ReadonlyMap<IrUnitId, PreparedIrInvariantCandidate>;
+  readonly componentCandidates: readonly PreparedIrComponentCandidate[];
+  readonly supportIntentCandidates: readonly PreparedIrSupportIntentCandidate[];
+  readonly allocationCandidates: readonly PreparedIrAllocationCandidate[];
+  readonly provenanceCandidates: readonly PreparedIrProvenanceCandidate[];
+  readonly reconciliation: "pending-production-wiring";
   readonly sealed: true;
   beginEmission(): PreparedIrEmissionTransaction;
 }
@@ -225,15 +239,52 @@ class FrozenMap<K, V> implements ReadonlyMap<K, V> {
   }
 }
 
+class FrozenSet<T> implements ReadonlySet<T> {
+  readonly #set: Set<T>;
+
+  constructor(values: Iterable<T>) {
+    this.#set = new Set(values);
+    Object.freeze(this);
+  }
+
+  get size(): number {
+    return this.#set.size;
+  }
+  has(value: T): boolean {
+    return this.#set.has(value);
+  }
+  forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: unknown): void {
+    for (const value of this.#set) callbackfn.call(thisArg, value, value, this);
+  }
+  entries(): SetIterator<[T, T]> {
+    return this.#set.entries();
+  }
+  keys(): SetIterator<T> {
+    return this.#set.keys();
+  }
+  values(): SetIterator<T> {
+    return this.#set.values();
+  }
+  [Symbol.iterator](): SetIterator<T> {
+    return this.#set[Symbol.iterator]();
+  }
+  get [Symbol.toStringTag](): string {
+    return "FrozenSet";
+  }
+}
+
 export function preparedIrReadonlyMap<K, V>(entries: Iterable<readonly [K, V]>): ReadonlyMap<K, V> {
   return new FrozenMap(entries);
 }
 
+function invalidPreparedData(detail: string): never {
+  throw new PreparedIrProgramInvariantError("invalid-prepared-data", detail);
+}
+
 function immutableCopy(value: unknown, ancestors = new Set<object>()): unknown {
+  if (typeof value === "function") invalidPreparedData("prepared data cannot contain executable functions");
   if (value === null || typeof value !== "object") return value;
-  if (ancestors.has(value)) {
-    throw new PreparedIrProgramInvariantError("invalid-prepared-evidence", "prepared evidence must be acyclic");
-  }
+  if (ancestors.has(value)) invalidPreparedData("prepared data must be acyclic");
   const nextAncestors = new Set(ancestors).add(value);
   if (Array.isArray(value)) return Object.freeze(value.map((item) => immutableCopy(item, nextAncestors)));
   if (value instanceof Map) {
@@ -242,18 +293,24 @@ function immutableCopy(value: unknown, ancestors = new Set<object>()): unknown {
     );
   }
   if (value instanceof Set) {
-    return Object.freeze([...value].map((item) => immutableCopy(item, nextAncestors)));
+    return new FrozenSet([...value].map((item) => immutableCopy(item, nextAncestors)));
   }
   const prototype = Object.getPrototypeOf(value);
   if (prototype !== Object.prototype && prototype !== null) {
-    throw new PreparedIrProgramInvariantError(
-      "invalid-prepared-evidence",
-      `prepared evidence contains unsupported mutable ${prototype?.constructor?.name ?? "object"}`,
-    );
+    invalidPreparedData(`prepared data contains unsupported mutable ${prototype?.constructor?.name ?? "object"}`);
   }
-  const copy: Record<PropertyKey, unknown> = {};
+  const copy = Object.create(null) as Record<PropertyKey, unknown>;
   for (const key of Reflect.ownKeys(value)) {
-    copy[key] = immutableCopy((value as Record<PropertyKey, unknown>)[key], nextAncestors);
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !("value" in descriptor)) {
+      invalidPreparedData(`prepared data property ${String(key)} must be a non-executable data property`);
+    }
+    Object.defineProperty(copy, key, {
+      value: immutableCopy(descriptor.value, nextAncestors),
+      enumerable: descriptor.enumerable,
+      configurable: false,
+      writable: false,
+    });
   }
   return Object.freeze(copy);
 }
@@ -264,31 +321,44 @@ export function freezePreparedIrValue(value: unknown): unknown {
 
 interface MutableLedgerEntry {
   readonly unitId: IrUnitId;
-  readonly outcome: PreparedIrOutcomeKind;
+  readonly candidateRoute: PreparedIrCandidateRoute;
   directBodyEmissions: number;
   irBodyEmissions: number;
 }
+
+const EMISSION_TRANSACTION_CAPABILITY = Symbol("PreparedIrProgram.beginEmission");
 
 export class PreparedIrEmissionTransaction {
   readonly #program: PreparedIrProgram;
   readonly #staged = new Map<IrUnitId, PreparedIrStagedBody>();
   readonly #ledger = new Map<IrUnitId, MutableLedgerEntry>();
   #state: "open" | "published" | "aborted" = "open";
-  #publication?: PreparedIrPublication;
+  #publication?: PreparedIrCandidatePublication;
 
-  constructor(program: PreparedIrProgram) {
+  private constructor(program: PreparedIrProgram, capability: symbol) {
+    if (capability !== EMISSION_TRANSACTION_CAPABILITY) {
+      throw new PreparedIrProgramInvariantError(
+        "invalid-transaction-capability",
+        "emission transactions can only be created by PreparedIrProgram.beginEmission()",
+      );
+    }
     this.#program = program;
-    for (const [unitId, outcome] of program.units) {
+    for (const [unitId, candidate] of program.units) {
       this.#ledger.set(unitId, {
         unitId,
-        outcome: outcome.kind,
+        candidateRoute: candidate.route,
         directBodyEmissions: 0,
         irBodyEmissions: 0,
       });
     }
   }
 
-  get publication(): PreparedIrPublication | undefined {
+  /** @internal Runtime capability remains module-private. */
+  static open(program: PreparedIrProgram, capability: symbol): PreparedIrEmissionTransaction {
+    return new PreparedIrEmissionTransaction(program, capability);
+  }
+
+  get publication(): PreparedIrCandidatePublication | undefined {
     return this.#publication;
   }
 
@@ -306,61 +376,70 @@ export class PreparedIrEmissionTransaction {
 
   failEmission(unitId: IrUnitId, emitter: PreparedIrEmitter, detail: string): never {
     this.#assertOpen();
-    this.#assertDirection(unitId, emitter);
-    this.#state = "aborted";
-    throw new PreparedIrProgramInvariantError("emission-failed", `${emitter} emission for ${unitId} failed: ${detail}`);
+    try {
+      this.#assertDirection(unitId, emitter);
+      throw new PreparedIrProgramInvariantError(
+        "emission-failed",
+        `${emitter} emission for ${unitId} failed: ${detail}`,
+      );
+    } catch (error) {
+      return this.#abort(error);
+    }
   }
 
-  publish(): PreparedIrPublication {
+  publish(): PreparedIrCandidatePublication {
     this.#assertOpen();
-    const missing = [...this.#program.units].filter(([unitId, outcome]) => {
-      if (outcome.kind === "invariant") return false;
-      return !this.#staged.has(unitId);
-    });
-    if (missing.length > 0) {
-      this.#state = "aborted";
-      throw new PreparedIrProgramInvariantError(
-        "partial-publication",
-        `cannot publish ${this.#staged.size}/${this.#program.preparedUnits.size + this.#program.directUnits.size} bodies; missing ${missing
-          .map(([unitId]) => unitId)
-          .join(", ")}`,
+    try {
+      const missing = [...this.#program.units].filter(
+        ([unitId, candidate]) => candidate.route !== "neither" && !this.#staged.has(unitId),
       );
+      if (missing.length > 0) {
+        throw new PreparedIrProgramInvariantError(
+          "partial-publication",
+          `cannot publish ${this.#staged.size}/${this.#program.irCandidates.size + this.#program.directCandidates.size} candidate bodies; missing ${missing
+            .map(([unitId]) => unitId)
+            .join(", ")}`,
+        );
+      }
+      const publication = Object.freeze({
+        evidenceStatus: "unvalidated-candidate-publication" as const,
+        bodies: preparedIrReadonlyMap(this.#staged),
+        ledger: this.#ledgerSnapshot(),
+      });
+      this.#publication = publication;
+      this.#state = "published";
+      return publication;
+    } catch (error) {
+      return this.#abort(error);
     }
-    const publication = Object.freeze({
-      bodies: preparedIrReadonlyMap(this.#staged),
-      ledger: this.#ledgerSnapshot(),
-    });
-    this.#publication = publication;
-    this.#state = "published";
-    return publication;
   }
 
   #stage(unitId: IrUnitId, emitter: PreparedIrEmitter, body: unknown): void {
     this.#assertOpen();
-    this.#assertDirection(unitId, emitter);
-    if (this.#staged.has(unitId)) {
-      this.#state = "aborted";
-      throw new PreparedIrProgramInvariantError("duplicate-emission", `${unitId} was emitted more than once`);
+    try {
+      this.#assertDirection(unitId, emitter);
+      if (this.#staged.has(unitId)) {
+        throw new PreparedIrProgramInvariantError("duplicate-emission", `${unitId} was emitted more than once`);
+      }
+      const staged = Object.freeze({ unitId, emitter, body: freezePreparedIrValue(body) });
+      const ledger = this.#ledger.get(unitId)!;
+      if (emitter === "ir") ledger.irBodyEmissions = 1;
+      else ledger.directBodyEmissions = 1;
+      this.#staged.set(unitId, staged);
+    } catch (error) {
+      this.#abort(error);
     }
-    const frozenBody = freezePreparedIrValue(body);
-    const ledger = this.#ledger.get(unitId)!;
-    if (emitter === "ir") ledger.irBodyEmissions = 1;
-    else ledger.directBodyEmissions = 1;
-    this.#staged.set(unitId, Object.freeze({ unitId, emitter, body: frozenBody }));
   }
 
   #assertDirection(unitId: IrUnitId, emitter: PreparedIrEmitter): void {
-    const outcome = this.#program.units.get(unitId);
-    if (!outcome) {
-      this.#state = "aborted";
+    const candidate = this.#program.units.get(unitId);
+    if (!candidate) {
       throw new PreparedIrProgramInvariantError("unknown-emission-unit", `${unitId} is outside the prepared program`);
     }
-    const expected = outcome.kind === "prepared" ? "ir" : outcome.kind === "unsupported" ? "direct" : "neither";
-    if (emitter !== expected) {
-      this.#state = "aborted";
+    if (emitter !== candidate.route) {
       throw new PreparedIrProgramInvariantError(
         "wrong-emitter",
-        `${unitId} is ${outcome.kind}; expected ${expected} emission, received ${emitter}`,
+        `${unitId} has ${candidate.kind}; expected ${candidate.route} emission, received ${emitter}`,
       );
     }
   }
@@ -371,66 +450,150 @@ export class PreparedIrEmissionTransaction {
     }
   }
 
+  #abort(error: unknown): never {
+    this.#state = "aborted";
+    throw error;
+  }
+
   #ledgerSnapshot(): ReadonlyMap<IrUnitId, PreparedIrEmissionLedgerEntry> {
     return preparedIrReadonlyMap(
-      [...this.#ledger].map(([unitId, entry]) => {
-        const frozen = Object.freeze({
+      [...this.#ledger].map(([unitId, entry]) => [
+        unitId,
+        Object.freeze({
           ...entry,
           prepareAttempts: 1 as const,
           legacyBodyEmitted: entry.directBodyEmissions === 1,
           irBodyEmitted: entry.irBodyEmissions === 1,
-        });
-        return [unitId, frozen] as const;
-      }),
+        }),
+      ]),
     );
   }
 }
 
-export interface ValidatedPreparedIrProgram {
+Object.freeze(PreparedIrEmissionTransaction.prototype);
+Object.freeze(PreparedIrEmissionTransaction);
+
+export interface PreparedIrCandidateProgramInput {
   readonly abiEntries: readonly ProgramAbiPlanEntry[];
-  readonly units: ReadonlyMap<IrUnitId, PreparedIrUnitOutcome>;
-  readonly preparedUnits: ReadonlyMap<IrUnitId, PreparedIrPreparedUnit>;
-  readonly directUnits: ReadonlyMap<IrUnitId, PreparedIrUnsupportedUnit>;
-  readonly invariantUnits: ReadonlyMap<IrUnitId, PreparedIrInvariantUnit>;
-  readonly components: readonly PreparedIrComponent[];
-  readonly supportIntents: readonly PreparedIrSupportIntent[];
-  readonly allocations: readonly PreparedIrAllocationRecord[];
-  readonly provenance: readonly PreparedIrProvenanceRecord[];
+  readonly units: ReadonlyMap<IrUnitId, PreparedIrUnitCandidate>;
+  readonly componentCandidates: readonly { readonly id: string; readonly unitIds: readonly IrUnitId[] }[];
+  readonly supportIntentCandidates: readonly Omit<PreparedIrSupportIntentCandidate, "evidenceStatus">[];
+  readonly allocationCandidates: readonly Omit<PreparedIrAllocationCandidate, "evidenceStatus">[];
+  readonly provenanceCandidates: readonly Omit<PreparedIrProvenanceCandidate, "evidenceStatus">[];
 }
 
-/** @internal The validating builder in prepare.ts is the only supported caller. */
-export function createValidatedPreparedIrProgram(input: ValidatedPreparedIrProgram): PreparedIrProgram {
-  const entries = Object.freeze([...input.abiEntries]);
+function ownCandidate<T>(value: T): T {
+  return freezePreparedIrValue(value) as T;
+}
+
+function expectedCandidateRoute(candidate: PreparedIrUnitCandidate): PreparedIrCandidateRoute {
+  switch (candidate.kind) {
+    case "ir-candidate":
+      return "ir";
+    case "direct-candidate":
+      return "direct";
+    case "invariant-candidate":
+      return "neither";
+  }
+}
+
+/**
+ * @internal Defensively owns every input. prepare.ts is the supported caller;
+ * the output remains explicitly pending production reconciliation.
+ */
+export function createPreparedIrCandidateProgram(input: PreparedIrCandidateProgramInput): PreparedIrProgram {
+  const entries = Object.freeze(input.abiEntries.map((entry) => ownCandidate(entry)));
   const entryMap = new Map(entries.map((entry) => [entry.id, entry]));
   const abi: PreparedIrAbiSnapshot = Object.freeze({
     planningSealed: true as const,
     entries,
     get: (id: IrBindingId) => entryMap.get(id),
   });
+  const units = preparedIrReadonlyMap(
+    [...input.units].map(([unitId, candidate]) => {
+      const ownedCandidate = ownCandidate(candidate);
+      if (
+        ownedCandidate.unitId !== unitId ||
+        ownedCandidate.route !== expectedCandidateRoute(ownedCandidate) ||
+        ownedCandidate.evidenceStatus !== "unvalidated-candidate"
+      ) {
+        throw new PreparedIrProgramInvariantError(
+          "invalid-prepared-data",
+          `candidate ${unitId} has inconsistent identity, kind, route, or evidence status`,
+        );
+      }
+      return [unitId, ownedCandidate] as const;
+    }),
+  );
+  const irCandidates = preparedIrReadonlyMap(
+    [...units].filter((entry): entry is [IrUnitId, PreparedIrIrCandidate] => entry[1].kind === "ir-candidate"),
+  );
+  const directCandidates = preparedIrReadonlyMap(
+    [...units].filter((entry): entry is [IrUnitId, PreparedIrDirectCandidate] => entry[1].kind === "direct-candidate"),
+  );
+  const invariantCandidates = preparedIrReadonlyMap(
+    [...units].filter(
+      (entry): entry is [IrUnitId, PreparedIrInvariantCandidate] => entry[1].kind === "invariant-candidate",
+    ),
+  );
+  const componentCandidates = Object.freeze(
+    input.componentCandidates.map((component) => {
+      const unitIds = Object.freeze([...component.unitIds]);
+      const unknownUnitIds = unitIds.filter((unitId) => !units.has(unitId));
+      if (unknownUnitIds.length > 0) {
+        throw new PreparedIrProgramInvariantError(
+          "unknown-unit",
+          `component candidate ${component.id} includes unknown units: ${unknownUnitIds.join(", ")}`,
+        );
+      }
+      return Object.freeze({
+        id: component.id,
+        unitIds,
+        candidateRoutes: Object.freeze([...new Set(unitIds.map((unitId) => units.get(unitId)!.route))]),
+        evidenceStatus: "unvalidated-component-candidate" as const,
+      }) as PreparedIrComponentCandidate;
+    }),
+  );
+  const supportIntentCandidates = Object.freeze(
+    input.supportIntentCandidates.map((candidate) =>
+      ownCandidate({ ...candidate, evidenceStatus: "unvalidated-candidate" as const }),
+    ),
+  );
+  const allocationCandidates = Object.freeze(
+    input.allocationCandidates.map((candidate) =>
+      ownCandidate({ ...candidate, evidenceStatus: "unvalidated-candidate" as const }),
+    ),
+  );
+  const provenanceCandidates = Object.freeze(
+    input.provenanceCandidates.map((candidate) =>
+      ownCandidate({ ...candidate, evidenceStatus: "unvalidated-candidate" as const }),
+    ),
+  );
   let emissionStarted = false;
   const program: PreparedIrProgram = Object.freeze({
     abi,
-    units: input.units,
-    preparedUnits: input.preparedUnits,
-    directUnits: input.directUnits,
-    invariantUnits: input.invariantUnits,
-    components: Object.freeze([...input.components]),
-    supportIntents: Object.freeze([...input.supportIntents]),
-    allocations: Object.freeze([...input.allocations]),
-    provenance: Object.freeze([...input.provenance]),
+    units,
+    irCandidates,
+    directCandidates,
+    invariantCandidates,
+    componentCandidates,
+    supportIntentCandidates,
+    allocationCandidates,
+    provenanceCandidates,
+    reconciliation: "pending-production-wiring" as const,
     sealed: true as const,
     beginEmission(): PreparedIrEmissionTransaction {
-      if (program.invariantUnits.size > 0) {
+      if (program.invariantCandidates.size > 0) {
         throw new PreparedIrProgramInvariantError(
-          "program-has-invariant",
-          `prepared program contains ${program.invariantUnits.size} invariant outcome(s)`,
+          "program-has-invariant-candidate",
+          `prepared program contains ${program.invariantCandidates.size} invariant candidate(s)`,
         );
       }
       if (emissionStarted) {
         throw new PreparedIrProgramInvariantError("emission-already-started", "prepared program emission is one-shot");
       }
       emissionStarted = true;
-      return new PreparedIrEmissionTransaction(program);
+      return PreparedIrEmissionTransaction.open(program, EMISSION_TRANSACTION_CAPABILITY);
     },
   });
   return program;

--- a/src/ir/program.ts
+++ b/src/ir/program.ts
@@ -1,0 +1,437 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrBackendKind } from "./backend/legality.js";
+import type { IrBindingId, IrSourceId, IrUnitId } from "./identity.js";
+import type { ProgramAbiCallableSignature, ProgramAbiPlanEntry } from "./program-abi.js";
+
+export type PreparedIrOutcomeKind = "prepared" | "unsupported" | "invariant";
+export type PreparedIrEmitter = "direct" | "ir";
+
+export type PreparedIrProgramInvariantCode =
+  | "abi-not-sealed"
+  | "program-sealed"
+  | "program-seal-failed"
+  | "duplicate-unit"
+  | "missing-unit"
+  | "unknown-unit"
+  | "duplicate-component"
+  | "empty-component"
+  | "duplicate-component-unit"
+  | "missing-component-unit"
+  | "mixed-component-outcome"
+  | "duplicate-support-intent"
+  | "late-support-intent"
+  | "unknown-support-owner"
+  | "unknown-support-binding"
+  | "duplicate-allocation"
+  | "allocation-not-prepared-owned"
+  | "duplicate-provenance"
+  | "provenance-not-prepared-owned"
+  | "invalid-prepared-evidence"
+  | "program-has-invariant"
+  | "emission-already-started"
+  | "transaction-closed"
+  | "wrong-emitter"
+  | "duplicate-emission"
+  | "unknown-emission-unit"
+  | "partial-publication"
+  | "emission-failed";
+
+export class PreparedIrProgramInvariantError extends Error {
+  constructor(
+    readonly code: PreparedIrProgramInvariantCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "PreparedIrProgramInvariantError";
+  }
+}
+
+export interface PreparedIrSourceLocation {
+  readonly sourceId: IrSourceId;
+  readonly line: number;
+  readonly column: number;
+  readonly declarationStart: number;
+  readonly declarationEnd: number;
+}
+
+export interface PreparedIrOptimizationEvidence {
+  readonly inlineSmall: "applied" | "not-applicable";
+  readonly monomorphization: "applied" | "not-applicable";
+  readonly allocationProvenance: "verified";
+}
+
+export interface PreparedIrBackendLegalityProof {
+  readonly backend: IrBackendKind;
+  readonly target: "gc" | "linear" | "standalone" | "wasi";
+  readonly verified: true;
+}
+
+export interface PreparedIrPreparedUnit {
+  readonly kind: "prepared";
+  readonly unitId: IrUnitId;
+  readonly location: PreparedIrSourceLocation;
+  readonly finalSignature: ProgramAbiCallableSignature;
+  readonly exportIntents: readonly IrBindingId[];
+  readonly backendLegality: PreparedIrBackendLegalityProof;
+  readonly optimization: PreparedIrOptimizationEvidence;
+  /** Frozen post-pass typed IR. The structural slice deliberately does not emit it. */
+  readonly ir: unknown;
+}
+
+export interface PreparedIrUnsupportedUnit {
+  readonly kind: "unsupported";
+  readonly unitId: IrUnitId;
+  readonly code: string;
+  readonly stage: string;
+  readonly detail: string;
+}
+
+export interface PreparedIrInvariantUnit {
+  readonly kind: "invariant";
+  readonly unitId: IrUnitId;
+  readonly code: string;
+  readonly stage: string;
+  readonly detail: string;
+}
+
+export type PreparedIrUnitOutcome = PreparedIrPreparedUnit | PreparedIrUnsupportedUnit | PreparedIrInvariantUnit;
+
+export interface PreparedIrComponent {
+  readonly id: string;
+  readonly unitIds: readonly IrUnitId[];
+  readonly outcome: PreparedIrOutcomeKind;
+}
+
+export type PreparedIrSupportIntentKind =
+  | "import"
+  | "global"
+  | "type"
+  | "literal"
+  | "helper"
+  | "lifted-closure"
+  | "host-callback"
+  | "runtime-entry"
+  | "export"
+  | "monomorphized-clone";
+
+/** A symbolic request resolved during preparation, before either body emitter runs. */
+export interface PreparedIrSupportIntent {
+  readonly key: string;
+  readonly kind: PreparedIrSupportIntentKind;
+  readonly ownerUnitId?: IrUnitId;
+  readonly bindingId?: IrBindingId;
+  readonly detail?: string;
+}
+
+export type PreparedIrAllocationKind = "function" | "global" | "type" | "literal" | "helper";
+
+/** Allocation reservation owned only by a Prepared unit; no concrete Wasm index is allocated here. */
+export interface PreparedIrAllocationRecord {
+  readonly key: string;
+  readonly kind: PreparedIrAllocationKind;
+  readonly ownerUnitId: IrUnitId;
+  readonly bindingId?: IrBindingId;
+  readonly ordinal: number;
+}
+
+export type PreparedIrProvenanceRole = "source" | "lifted-closure" | "monomorphization-clone";
+
+/** Exact source/pass provenance for a Prepared-owned source or derived IR artifact. */
+export interface PreparedIrProvenanceRecord {
+  readonly artifactUnitId: IrUnitId;
+  readonly ownerUnitId: IrUnitId;
+  readonly role: PreparedIrProvenanceRole;
+  readonly parentUnitId?: IrUnitId;
+  readonly ordinal: number;
+}
+
+export interface PreparedIrAbiSnapshot {
+  readonly planningSealed: true;
+  readonly entries: readonly ProgramAbiPlanEntry[];
+  get(id: IrBindingId): ProgramAbiPlanEntry | undefined;
+}
+
+export interface PreparedIrEmissionLedgerEntry {
+  readonly unitId: IrUnitId;
+  readonly outcome: PreparedIrOutcomeKind;
+  readonly prepareAttempts: 1;
+  readonly directBodyEmissions: number;
+  readonly irBodyEmissions: number;
+  readonly legacyBodyEmitted: boolean;
+  readonly irBodyEmitted: boolean;
+}
+
+export interface PreparedIrStagedBody {
+  readonly unitId: IrUnitId;
+  readonly emitter: PreparedIrEmitter;
+  readonly body: unknown;
+}
+
+export interface PreparedIrPublication {
+  readonly bodies: ReadonlyMap<IrUnitId, PreparedIrStagedBody>;
+  readonly ledger: ReadonlyMap<IrUnitId, PreparedIrEmissionLedgerEntry>;
+}
+
+export interface PreparedIrProgram {
+  readonly abi: PreparedIrAbiSnapshot;
+  /** Exact R2 denominator: all and only inventoried top-level free functions. */
+  readonly units: ReadonlyMap<IrUnitId, PreparedIrUnitOutcome>;
+  readonly preparedUnits: ReadonlyMap<IrUnitId, PreparedIrPreparedUnit>;
+  readonly directUnits: ReadonlyMap<IrUnitId, PreparedIrUnsupportedUnit>;
+  readonly invariantUnits: ReadonlyMap<IrUnitId, PreparedIrInvariantUnit>;
+  readonly components: readonly PreparedIrComponent[];
+  readonly supportIntents: readonly PreparedIrSupportIntent[];
+  readonly allocations: readonly PreparedIrAllocationRecord[];
+  readonly provenance: readonly PreparedIrProvenanceRecord[];
+  readonly sealed: true;
+  beginEmission(): PreparedIrEmissionTransaction;
+}
+
+class FrozenMap<K, V> implements ReadonlyMap<K, V> {
+  readonly #map: Map<K, V>;
+
+  constructor(entries: Iterable<readonly [K, V]>) {
+    this.#map = new Map(entries);
+    Object.freeze(this);
+  }
+
+  get size(): number {
+    return this.#map.size;
+  }
+  has(key: K): boolean {
+    return this.#map.has(key);
+  }
+  get(key: K): V | undefined {
+    return this.#map.get(key);
+  }
+  forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: unknown): void {
+    for (const [key, value] of this.#map) callbackfn.call(thisArg, value, key, this);
+  }
+  entries(): MapIterator<[K, V]> {
+    return this.#map.entries();
+  }
+  keys(): MapIterator<K> {
+    return this.#map.keys();
+  }
+  values(): MapIterator<V> {
+    return this.#map.values();
+  }
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.#map[Symbol.iterator]();
+  }
+  get [Symbol.toStringTag](): string {
+    return "FrozenMap";
+  }
+}
+
+export function preparedIrReadonlyMap<K, V>(entries: Iterable<readonly [K, V]>): ReadonlyMap<K, V> {
+  return new FrozenMap(entries);
+}
+
+function immutableCopy(value: unknown, ancestors = new Set<object>()): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (ancestors.has(value)) {
+    throw new PreparedIrProgramInvariantError("invalid-prepared-evidence", "prepared evidence must be acyclic");
+  }
+  const nextAncestors = new Set(ancestors).add(value);
+  if (Array.isArray(value)) return Object.freeze(value.map((item) => immutableCopy(item, nextAncestors)));
+  if (value instanceof Map) {
+    return preparedIrReadonlyMap(
+      [...value].map(([key, item]) => [immutableCopy(key, nextAncestors), immutableCopy(item, nextAncestors)] as const),
+    );
+  }
+  if (value instanceof Set) {
+    return Object.freeze([...value].map((item) => immutableCopy(item, nextAncestors)));
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new PreparedIrProgramInvariantError(
+      "invalid-prepared-evidence",
+      `prepared evidence contains unsupported mutable ${prototype?.constructor?.name ?? "object"}`,
+    );
+  }
+  const copy: Record<PropertyKey, unknown> = {};
+  for (const key of Reflect.ownKeys(value)) {
+    copy[key] = immutableCopy((value as Record<PropertyKey, unknown>)[key], nextAncestors);
+  }
+  return Object.freeze(copy);
+}
+
+export function freezePreparedIrValue(value: unknown): unknown {
+  return immutableCopy(value);
+}
+
+interface MutableLedgerEntry {
+  readonly unitId: IrUnitId;
+  readonly outcome: PreparedIrOutcomeKind;
+  directBodyEmissions: number;
+  irBodyEmissions: number;
+}
+
+export class PreparedIrEmissionTransaction {
+  readonly #program: PreparedIrProgram;
+  readonly #staged = new Map<IrUnitId, PreparedIrStagedBody>();
+  readonly #ledger = new Map<IrUnitId, MutableLedgerEntry>();
+  #state: "open" | "published" | "aborted" = "open";
+  #publication?: PreparedIrPublication;
+
+  constructor(program: PreparedIrProgram) {
+    this.#program = program;
+    for (const [unitId, outcome] of program.units) {
+      this.#ledger.set(unitId, {
+        unitId,
+        outcome: outcome.kind,
+        directBodyEmissions: 0,
+        irBodyEmissions: 0,
+      });
+    }
+  }
+
+  get publication(): PreparedIrPublication | undefined {
+    return this.#publication;
+  }
+
+  get ledger(): ReadonlyMap<IrUnitId, PreparedIrEmissionLedgerEntry> {
+    return this.#ledgerSnapshot();
+  }
+
+  emitIr(unitId: IrUnitId, body: unknown): void {
+    this.#stage(unitId, "ir", body);
+  }
+
+  emitDirect(unitId: IrUnitId, body: unknown): void {
+    this.#stage(unitId, "direct", body);
+  }
+
+  failEmission(unitId: IrUnitId, emitter: PreparedIrEmitter, detail: string): never {
+    this.#assertOpen();
+    this.#assertDirection(unitId, emitter);
+    this.#state = "aborted";
+    throw new PreparedIrProgramInvariantError("emission-failed", `${emitter} emission for ${unitId} failed: ${detail}`);
+  }
+
+  publish(): PreparedIrPublication {
+    this.#assertOpen();
+    const missing = [...this.#program.units].filter(([unitId, outcome]) => {
+      if (outcome.kind === "invariant") return false;
+      return !this.#staged.has(unitId);
+    });
+    if (missing.length > 0) {
+      this.#state = "aborted";
+      throw new PreparedIrProgramInvariantError(
+        "partial-publication",
+        `cannot publish ${this.#staged.size}/${this.#program.preparedUnits.size + this.#program.directUnits.size} bodies; missing ${missing
+          .map(([unitId]) => unitId)
+          .join(", ")}`,
+      );
+    }
+    const publication = Object.freeze({
+      bodies: preparedIrReadonlyMap(this.#staged),
+      ledger: this.#ledgerSnapshot(),
+    });
+    this.#publication = publication;
+    this.#state = "published";
+    return publication;
+  }
+
+  #stage(unitId: IrUnitId, emitter: PreparedIrEmitter, body: unknown): void {
+    this.#assertOpen();
+    this.#assertDirection(unitId, emitter);
+    if (this.#staged.has(unitId)) {
+      this.#state = "aborted";
+      throw new PreparedIrProgramInvariantError("duplicate-emission", `${unitId} was emitted more than once`);
+    }
+    const frozenBody = freezePreparedIrValue(body);
+    const ledger = this.#ledger.get(unitId)!;
+    if (emitter === "ir") ledger.irBodyEmissions = 1;
+    else ledger.directBodyEmissions = 1;
+    this.#staged.set(unitId, Object.freeze({ unitId, emitter, body: frozenBody }));
+  }
+
+  #assertDirection(unitId: IrUnitId, emitter: PreparedIrEmitter): void {
+    const outcome = this.#program.units.get(unitId);
+    if (!outcome) {
+      this.#state = "aborted";
+      throw new PreparedIrProgramInvariantError("unknown-emission-unit", `${unitId} is outside the prepared program`);
+    }
+    const expected = outcome.kind === "prepared" ? "ir" : outcome.kind === "unsupported" ? "direct" : "neither";
+    if (emitter !== expected) {
+      this.#state = "aborted";
+      throw new PreparedIrProgramInvariantError(
+        "wrong-emitter",
+        `${unitId} is ${outcome.kind}; expected ${expected} emission, received ${emitter}`,
+      );
+    }
+  }
+
+  #assertOpen(): void {
+    if (this.#state !== "open") {
+      throw new PreparedIrProgramInvariantError("transaction-closed", `emission transaction is ${this.#state}`);
+    }
+  }
+
+  #ledgerSnapshot(): ReadonlyMap<IrUnitId, PreparedIrEmissionLedgerEntry> {
+    return preparedIrReadonlyMap(
+      [...this.#ledger].map(([unitId, entry]) => {
+        const frozen = Object.freeze({
+          ...entry,
+          prepareAttempts: 1 as const,
+          legacyBodyEmitted: entry.directBodyEmissions === 1,
+          irBodyEmitted: entry.irBodyEmissions === 1,
+        });
+        return [unitId, frozen] as const;
+      }),
+    );
+  }
+}
+
+export interface ValidatedPreparedIrProgram {
+  readonly abiEntries: readonly ProgramAbiPlanEntry[];
+  readonly units: ReadonlyMap<IrUnitId, PreparedIrUnitOutcome>;
+  readonly preparedUnits: ReadonlyMap<IrUnitId, PreparedIrPreparedUnit>;
+  readonly directUnits: ReadonlyMap<IrUnitId, PreparedIrUnsupportedUnit>;
+  readonly invariantUnits: ReadonlyMap<IrUnitId, PreparedIrInvariantUnit>;
+  readonly components: readonly PreparedIrComponent[];
+  readonly supportIntents: readonly PreparedIrSupportIntent[];
+  readonly allocations: readonly PreparedIrAllocationRecord[];
+  readonly provenance: readonly PreparedIrProvenanceRecord[];
+}
+
+/** @internal The validating builder in prepare.ts is the only supported caller. */
+export function createValidatedPreparedIrProgram(input: ValidatedPreparedIrProgram): PreparedIrProgram {
+  const entries = Object.freeze([...input.abiEntries]);
+  const entryMap = new Map(entries.map((entry) => [entry.id, entry]));
+  const abi: PreparedIrAbiSnapshot = Object.freeze({
+    planningSealed: true as const,
+    entries,
+    get: (id: IrBindingId) => entryMap.get(id),
+  });
+  let emissionStarted = false;
+  const program: PreparedIrProgram = Object.freeze({
+    abi,
+    units: input.units,
+    preparedUnits: input.preparedUnits,
+    directUnits: input.directUnits,
+    invariantUnits: input.invariantUnits,
+    components: Object.freeze([...input.components]),
+    supportIntents: Object.freeze([...input.supportIntents]),
+    allocations: Object.freeze([...input.allocations]),
+    provenance: Object.freeze([...input.provenance]),
+    sealed: true as const,
+    beginEmission(): PreparedIrEmissionTransaction {
+      if (program.invariantUnits.size > 0) {
+        throw new PreparedIrProgramInvariantError(
+          "program-has-invariant",
+          `prepared program contains ${program.invariantUnits.size} invariant outcome(s)`,
+        );
+      }
+      if (emissionStarted) {
+        throw new PreparedIrProgramInvariantError("emission-already-started", "prepared program emission is one-shot");
+      }
+      emissionStarted = true;
+      return new PreparedIrEmissionTransaction(program);
+    },
+  });
+  return program;
+}

--- a/src/ir/program.ts
+++ b/src/ir/program.ts
@@ -289,9 +289,16 @@ function invalidPreparedData(detail: string): never {
 function immutableCopy(value: unknown, ancestors = new Set<object>()): unknown {
   if (typeof value === "function") invalidPreparedData("prepared data cannot contain executable functions");
   if (value === null || typeof value !== "object") return value;
-  if (value instanceof FrozenMap || value instanceof FrozenSet) return value;
   if (ancestors.has(value)) invalidPreparedData("prepared data must be acyclic");
   const nextAncestors = new Set(ancestors).add(value);
+  if (value instanceof FrozenMap) {
+    return preparedIrReadonlyMap(
+      [...value].map(([key, item]) => [immutableCopy(key, nextAncestors), immutableCopy(item, nextAncestors)] as const),
+    );
+  }
+  if (value instanceof FrozenSet) {
+    return new FrozenSet([...value].map((item) => immutableCopy(item, nextAncestors)));
+  }
   if (Array.isArray(value)) return Object.freeze(value.map((item) => immutableCopy(item, nextAncestors)));
   if (value instanceof Map) {
     return preparedIrReadonlyMap(

--- a/tests/issue-3521-prepared-ir-program.test.ts
+++ b/tests/issue-3521-prepared-ir-program.test.ts
@@ -16,6 +16,7 @@ import {
 import { PreparedIrProgramBuilder, type PreparedIrIrCandidateInput } from "../src/ir/prepare.js";
 import {
   createPreparedIrCandidateProgram,
+  preparedIrReadonlyMap,
   PreparedIrEmissionTransaction,
   PreparedIrProgramInvariantError,
   type PreparedIrProgram,
@@ -744,6 +745,55 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
     expect(factoryProgram.allocationCandidates[0]?.key).toBe("mutable:allocation");
     expect(factoryProgram.provenanceCandidates[0]?.ordinal).toBe(1);
     expect(factoryProgram.abi.entries).toEqual(program.abi.entries);
+  });
+
+  it("recursively owns exported readonly-map wrappers and rejects cycles through them", () => {
+    const { program, alphaId } = validPreparedCore();
+    const alpha = program.irCandidates.get(alphaId)!;
+    const nested = { slot: 1 };
+    const wrapped = preparedIrReadonlyMap([["alpha", nested] as const]);
+    const units = new Map(program.units);
+    units.set(alphaId, {
+      ...alpha,
+      irCandidate: { wrapped },
+    });
+    const ownedProgram = createPreparedIrCandidateProgram({
+      abiEntries: program.abi.entries,
+      units,
+      componentCandidates: program.componentCandidates,
+      supportIntentCandidates: program.supportIntentCandidates,
+      allocationCandidates: program.allocationCandidates,
+      provenanceCandidates: program.provenanceCandidates,
+    });
+    nested.slot = 99;
+    const ownedWrapped = (
+      ownedProgram.irCandidates.get(alphaId)?.irCandidate as {
+        wrapped: ReadonlyMap<string, { slot: number }>;
+      }
+    ).wrapped;
+    expect(ownedWrapped.get("alpha")?.slot).toBe(1);
+    expect(ownedWrapped).not.toBe(wrapped);
+
+    const cycleTarget: { wrapped?: ReadonlyMap<string, unknown> } = {};
+    const cyclicWrapper = preparedIrReadonlyMap([["cycle", cycleTarget] as const]);
+    cycleTarget.wrapped = cyclicWrapper;
+    const cyclicUnits = new Map(program.units);
+    cyclicUnits.set(alphaId, {
+      ...alpha,
+      irCandidate: { wrapped: cyclicWrapper },
+    });
+    expectPreparedInvariant(
+      () =>
+        createPreparedIrCandidateProgram({
+          abiEntries: program.abi.entries,
+          units: cyclicUnits,
+          componentCandidates: program.componentCandidates,
+          supportIntentCandidates: program.supportIntentCandidates,
+          allocationCandidates: program.allocationCandidates,
+          provenanceCandidates: program.provenanceCandidates,
+        }),
+      "invalid-prepared-data",
+    );
   });
 
   it("fails closed on inconsistent direct-factory unit identity and unknown grouping units", () => {

--- a/tests/issue-3521-prepared-ir-program.test.ts
+++ b/tests/issue-3521-prepared-ir-program.test.ts
@@ -11,8 +11,17 @@ import {
   createDerivedIrUnitId,
   createIrBindingId,
   type IrBindingId,
+  type IrUnitId,
 } from "../src/ir/identity.js";
+import { PreparedIrProgramBuilder, type PreparedIrPreparedInput } from "../src/ir/prepare.js";
+import {
+  PreparedIrProgramInvariantError,
+  type PreparedIrProgram,
+  type PreparedIrProgramInvariantCode,
+  type PreparedIrSupportIntent,
+} from "../src/ir/program.js";
 import { ProgramAbiInvariantError, type ProgramAbiInvariantCode } from "../src/ir/program-abi.js";
+import { ProgramAbiMap } from "../src/ir/program-abi.js";
 import {
   createEmptyModule,
   type FuncTypeDef,
@@ -375,5 +384,290 @@ describe("#3521 Program ABI plan sealing", () => {
     expect("resolveFinalIndex" in sealed).toBe(false);
     expectInvariant(() => session.bindAndPublish(module), "session-publish-once");
     expectInvariant(() => session.publish(module), "session-publish-once");
+  });
+});
+
+function expectPreparedInvariant(action: () => unknown, code: PreparedIrProgramInvariantCode): void {
+  let caught: unknown;
+  try {
+    action();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(PreparedIrProgramInvariantError);
+  expect((caught as PreparedIrProgramInvariantError).code).toBe(code);
+}
+
+function preparedCoreFixture() {
+  const sourceFile = ts.createSourceFile(
+    "/repo/prepared-core.ts",
+    [
+      "export function alpha(value: number): number { return value + 1; }",
+      "function beta(value: number): number { return alpha(value) * 2; }",
+      "function legacy(value: unknown): unknown { return value; }",
+    ].join("\n"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
+  const units = new Map(
+    inventory.terminalUnits
+      .filter((unit) => unit.kind === "top-level-function")
+      .map((unit) => [unit.displayName, unit] as const),
+  );
+  const alpha = units.get("alpha");
+  const beta = units.get("beta");
+  const legacy = units.get("legacy");
+  if (!alpha || !beta || !legacy) throw new Error("missing prepared-core function inventory");
+  const abi = new ProgramAbiMap(inventory);
+  abi.sealPlan();
+  return { abi, alpha, beta, legacy };
+}
+
+function preparedInput(unitId: IrUnitId, marker: string): PreparedIrPreparedInput {
+  return {
+    unitId,
+    finalSignature: { params: ["f64"], results: ["f64"] },
+    backendLegality: { backend: "wasmgc", target: "gc", verified: true },
+    optimization: {
+      inlineSmall: marker === "beta" ? "applied" : "not-applicable",
+      monomorphization: marker === "alpha" ? "applied" : "not-applicable",
+      allocationProvenance: "verified",
+    },
+    ir: { marker, blocks: [{ id: 0, instructions: [] }] },
+  };
+}
+
+function validPreparedCore(): {
+  readonly program: PreparedIrProgram;
+  readonly alphaId: IrUnitId;
+  readonly betaId: IrUnitId;
+  readonly legacyId: IrUnitId;
+} {
+  const { abi, alpha, beta, legacy } = preparedCoreFixture();
+  const builder = new PreparedIrProgramBuilder(abi);
+  builder.recordPrepared(preparedInput(alpha.id, "alpha"));
+  builder.recordPrepared(preparedInput(beta.id, "beta"));
+  builder.recordUnsupported({
+    unitId: legacy.id,
+    code: "unsupported-syntax",
+    stage: "select",
+    detail: "temporary direct policy",
+  });
+  builder.addComponent({ id: "prepared-call-graph", unitIds: [alpha.id, beta.id] });
+  builder.addComponent({ id: "legacy-singleton", unitIds: [legacy.id] });
+  return { program: builder.seal(), alphaId: alpha.id, betaId: beta.id, legacyId: legacy.id };
+}
+
+describe("#3521 PreparedIrProgram structural ownership", () => {
+  it("freezes the exact inventory, component ownership, support plan, optimization evidence, and emission ledger", () => {
+    const { abi, alpha, beta, legacy } = preparedCoreFixture();
+    const builder = new PreparedIrProgramBuilder(abi);
+    builder.recordPrepared(preparedInput(alpha.id, "alpha"));
+    builder.recordPrepared(preparedInput(beta.id, "beta"));
+    builder.recordUnsupported({
+      unitId: legacy.id,
+      code: "unsupported-syntax",
+      stage: "select",
+      detail: "temporary hybrid route",
+    });
+    builder.addComponent({ id: "numeric", unitIds: [alpha.id, beta.id] });
+    builder.addComponent({ id: "direct", unitIds: [legacy.id] });
+
+    const supportIntents: readonly PreparedIrSupportIntent[] = [
+      { key: "callback:host", kind: "host-callback", ownerUnitId: alpha.id },
+      { key: "date:snapshot", kind: "runtime-entry", ownerUnitId: alpha.id, detail: "Date snapshot" },
+      { key: "promise:delay", kind: "runtime-entry", ownerUnitId: beta.id, detail: "Promise delay" },
+      { key: "literal:hello", kind: "literal", ownerUnitId: alpha.id },
+      { key: "closure:lifted:0", kind: "lifted-closure", ownerUnitId: alpha.id },
+      { key: "clone:mono:0", kind: "monomorphized-clone", ownerUnitId: alpha.id },
+    ];
+    for (const intent of supportIntents) builder.addSupportIntent(intent);
+    builder.addAllocation({ key: "literal:hello", kind: "literal", ownerUnitId: alpha.id, ordinal: 0 });
+    builder.addAllocation({ key: "helper:promise", kind: "helper", ownerUnitId: beta.id, ordinal: 0 });
+    const liftedId = createDerivedIrUnitId({ parentId: alpha.id, role: "lifted-closure", ordinal: 0 });
+    const cloneId = createDerivedIrUnitId({ parentId: alpha.id, role: "monomorphization-clone", ordinal: 0 });
+    builder.addProvenance({
+      artifactUnitId: liftedId,
+      ownerUnitId: alpha.id,
+      parentUnitId: alpha.id,
+      role: "lifted-closure",
+      ordinal: 0,
+    });
+    builder.addProvenance({
+      artifactUnitId: cloneId,
+      ownerUnitId: alpha.id,
+      parentUnitId: alpha.id,
+      role: "monomorphization-clone",
+      ordinal: 0,
+    });
+
+    const program = builder.seal();
+    expect(Object.isFrozen(program)).toBe(true);
+    expect(program.units.size).toBe(3);
+    expect(program.preparedUnits.size).toBe(2);
+    expect(program.directUnits.size).toBe(1);
+    expect(program.invariantUnits.size).toBe(0);
+    expect(program.components.map((component) => [component.id, component.outcome])).toEqual([
+      ["numeric", "prepared"],
+      ["direct", "unsupported"],
+    ]);
+    expect(program.supportIntents.map((intent) => intent.key)).toEqual(supportIntents.map((intent) => intent.key));
+    expect(Object.isFrozen(program.supportIntents)).toBe(true);
+    expect((program.units as Map<IrUnitId, unknown>).set).toBeUndefined();
+    expect(program.preparedUnits.get(beta.id)?.optimization.inlineSmall).toBe("applied");
+    expect(program.preparedUnits.get(alpha.id)?.optimization.monomorphization).toBe("applied");
+    expect(program.provenance.map((record) => record.artifactUnitId)).toEqual([liftedId, cloneId]);
+
+    const emission = program.beginEmission();
+    emission.emitIr(alpha.id, { op: "ir.alpha" });
+    emission.emitIr(beta.id, { op: "ir.beta" });
+    emission.emitDirect(legacy.id, { op: "direct.legacy" });
+    const publication = emission.publish();
+    expect(publication.bodies.size).toBe(3);
+    expect(publication.ledger.get(alpha.id)).toEqual({
+      unitId: alpha.id,
+      outcome: "prepared",
+      prepareAttempts: 1,
+      directBodyEmissions: 0,
+      irBodyEmissions: 1,
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(publication.ledger.get(legacy.id)).toEqual({
+      unitId: legacy.id,
+      outcome: "unsupported",
+      prepareAttempts: 1,
+      directBodyEmissions: 1,
+      irBodyEmissions: 0,
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expectPreparedInvariant(() => program.beginEmission(), "emission-already-started");
+    expectPreparedInvariant(() => emission.emitIr(alpha.id, {}), "transaction-closed");
+  });
+
+  it("fails sealing for missing or duplicate outcomes and missing or duplicate component membership", () => {
+    const missingFixture = preparedCoreFixture();
+    const missing = new PreparedIrProgramBuilder(missingFixture.abi);
+    missing.recordPrepared(preparedInput(missingFixture.alpha.id, "alpha"));
+    missing.recordPrepared(preparedInput(missingFixture.beta.id, "beta"));
+    missing.addComponent({
+      id: "all",
+      unitIds: [missingFixture.alpha.id, missingFixture.beta.id, missingFixture.legacy.id],
+    });
+    expectPreparedInvariant(() => missing.seal(), "missing-unit");
+    expectPreparedInvariant(
+      () => missing.recordInvariant({ unitId: missingFixture.legacy.id, code: "x", stage: "build", detail: "x" }),
+      "program-seal-failed",
+    );
+
+    const duplicateFixture = preparedCoreFixture();
+    const duplicate = new PreparedIrProgramBuilder(duplicateFixture.abi);
+    duplicate.recordPrepared(preparedInput(duplicateFixture.alpha.id, "alpha"));
+    duplicate.recordPrepared(preparedInput(duplicateFixture.alpha.id, "alpha-again"));
+    duplicate.recordPrepared(preparedInput(duplicateFixture.beta.id, "beta"));
+    duplicate.recordUnsupported({ unitId: duplicateFixture.legacy.id, code: "x", stage: "select", detail: "x" });
+    duplicate.addComponent({ id: "a", unitIds: [duplicateFixture.alpha.id] });
+    duplicate.addComponent({ id: "b", unitIds: [duplicateFixture.beta.id, duplicateFixture.legacy.id] });
+    expectPreparedInvariant(() => duplicate.seal(), "duplicate-unit");
+
+    const membershipFixture = preparedCoreFixture();
+    const membership = new PreparedIrProgramBuilder(membershipFixture.abi);
+    membership.recordPrepared(preparedInput(membershipFixture.alpha.id, "alpha"));
+    membership.recordPrepared(preparedInput(membershipFixture.beta.id, "beta"));
+    membership.recordUnsupported({ unitId: membershipFixture.legacy.id, code: "x", stage: "select", detail: "x" });
+    membership.addComponent({ id: "a", unitIds: [membershipFixture.alpha.id, membershipFixture.beta.id] });
+    membership.addComponent({ id: "b", unitIds: [membershipFixture.beta.id, membershipFixture.legacy.id] });
+    expectPreparedInvariant(() => membership.seal(), "duplicate-component-unit");
+  });
+
+  it("rejects mixed terminal outcomes inside one local-call component before emission", () => {
+    const { abi, alpha, beta, legacy } = preparedCoreFixture();
+    const builder = new PreparedIrProgramBuilder(abi);
+    builder.recordPrepared(preparedInput(alpha.id, "alpha"));
+    builder.recordUnsupported({ unitId: beta.id, code: "unsafe-abi-edge", stage: "resolve", detail: "unsafe edge" });
+    builder.recordUnsupported({ unitId: legacy.id, code: "unsupported-syntax", stage: "select", detail: "legacy" });
+    builder.addComponent({ id: "unsafe-local-edge", unitIds: [alpha.id, beta.id] });
+    builder.addComponent({ id: "legacy", unitIds: [legacy.id] });
+    expectPreparedInvariant(() => builder.seal(), "mixed-component-outcome");
+  });
+
+  it("rejects unsealed ABI input and support requests after the atomic seal", () => {
+    const fixture = preparedCoreFixture();
+    const unsealed = new ProgramAbiMap(fixture.abi.inventory);
+    expectPreparedInvariant(() => new PreparedIrProgramBuilder(unsealed), "abi-not-sealed");
+
+    const { program, alphaId } = validPreparedCore();
+    expect(program.sealed).toBe(true);
+    const sealedBuilder = new PreparedIrProgramBuilder(fixture.abi);
+    sealedBuilder.recordPrepared(preparedInput(fixture.alpha.id, "alpha"));
+    sealedBuilder.recordPrepared(preparedInput(fixture.beta.id, "beta"));
+    sealedBuilder.recordUnsupported({
+      unitId: fixture.legacy.id,
+      code: "unsupported-syntax",
+      stage: "select",
+      detail: "legacy",
+    });
+    sealedBuilder.addComponent({ id: "prepared", unitIds: [fixture.alpha.id, fixture.beta.id] });
+    sealedBuilder.addComponent({ id: "direct", unitIds: [fixture.legacy.id] });
+    sealedBuilder.seal();
+    expectPreparedInvariant(
+      () => sealedBuilder.addSupportIntent({ key: "late:helper", kind: "helper", ownerUnitId: alphaId }),
+      "late-support-intent",
+    );
+  });
+
+  it("fails closed on wrong-direction, duplicate, and partial emission without publishing a body", () => {
+    const wrong = validPreparedCore();
+    const wrongTx = wrong.program.beginEmission();
+    expectPreparedInvariant(() => wrongTx.emitDirect(wrong.alphaId, { op: "wrong" }), "wrong-emitter");
+    expect(wrongTx.publication).toBeUndefined();
+    expect(wrongTx.ledger.get(wrong.alphaId)?.directBodyEmissions).toBe(0);
+    expectPreparedInvariant(() => wrongTx.emitIr(wrong.alphaId, { op: "late" }), "transaction-closed");
+
+    const duplicate = validPreparedCore();
+    const duplicateTx = duplicate.program.beginEmission();
+    duplicateTx.emitIr(duplicate.alphaId, { op: "first" });
+    expectPreparedInvariant(() => duplicateTx.emitIr(duplicate.alphaId, { op: "second" }), "duplicate-emission");
+    expect(duplicateTx.publication).toBeUndefined();
+    expect(duplicateTx.ledger.get(duplicate.alphaId)?.irBodyEmissions).toBe(1);
+
+    const failed = validPreparedCore();
+    const failedTx = failed.program.beginEmission();
+    expectPreparedInvariant(
+      () => failedTx.failEmission(failed.alphaId, "ir", "injected backend invariant"),
+      "emission-failed",
+    );
+    expect(failedTx.publication).toBeUndefined();
+    expect(failedTx.ledger.get(failed.alphaId)?.directBodyEmissions).toBe(0);
+    expect(failedTx.ledger.get(failed.alphaId)?.irBodyEmissions).toBe(0);
+
+    const partial = validPreparedCore();
+    const partialTx = partial.program.beginEmission();
+    partialTx.emitIr(partial.alphaId, { op: "only-one" });
+    expectPreparedInvariant(() => partialTx.publish(), "partial-publication");
+    expect(partialTx.publication).toBeUndefined();
+    expectPreparedInvariant(() => partialTx.emitIr(partial.betaId, { op: "too-late" }), "transaction-closed");
+  });
+
+  it("keeps terminal Invariant units on the neither-emitter route", () => {
+    const { abi, alpha, beta, legacy } = preparedCoreFixture();
+    const builder = new PreparedIrProgramBuilder(abi);
+    builder.recordInvariant({
+      unitId: alpha.id,
+      code: "selection-preparation-mismatch",
+      stage: "verify",
+      detail: "injected invariant",
+    });
+    builder.recordPrepared(preparedInput(beta.id, "beta"));
+    builder.recordUnsupported({ unitId: legacy.id, code: "unsupported-syntax", stage: "select", detail: "legacy" });
+    builder.addComponent({ id: "invariant", unitIds: [alpha.id] });
+    builder.addComponent({ id: "prepared", unitIds: [beta.id] });
+    builder.addComponent({ id: "direct", unitIds: [legacy.id] });
+    const program = builder.seal();
+    expect(program.invariantUnits.size).toBe(1);
+    expectPreparedInvariant(() => program.beginEmission(), "program-has-invariant");
   });
 });

--- a/tests/issue-3521-prepared-ir-program.test.ts
+++ b/tests/issue-3521-prepared-ir-program.test.ts
@@ -13,12 +13,13 @@ import {
   type IrBindingId,
   type IrUnitId,
 } from "../src/ir/identity.js";
-import { PreparedIrProgramBuilder, type PreparedIrPreparedInput } from "../src/ir/prepare.js";
+import { PreparedIrProgramBuilder, type PreparedIrIrCandidateInput } from "../src/ir/prepare.js";
 import {
+  createPreparedIrCandidateProgram,
+  PreparedIrEmissionTransaction,
   PreparedIrProgramInvariantError,
   type PreparedIrProgram,
   type PreparedIrProgramInvariantCode,
-  type PreparedIrSupportIntent,
 } from "../src/ir/program.js";
 import { ProgramAbiInvariantError, type ProgramAbiInvariantCode } from "../src/ir/program-abi.js";
 import { ProgramAbiMap } from "../src/ir/program-abi.js";
@@ -425,17 +426,17 @@ function preparedCoreFixture() {
   return { abi, alpha, beta, legacy };
 }
 
-function preparedInput(unitId: IrUnitId, marker: string): PreparedIrPreparedInput {
+function preparedInput(unitId: IrUnitId, marker: string): PreparedIrIrCandidateInput {
   return {
     unitId,
-    finalSignature: { params: ["f64"], results: ["f64"] },
-    backendLegality: { backend: "wasmgc", target: "gc", verified: true },
-    optimization: {
+    assertedSignature: { params: ["f64"], results: ["f64"] },
+    assertedBackendLegality: { backend: "wasmgc", target: "gc", verified: true },
+    assertedOptimization: {
       inlineSmall: marker === "beta" ? "applied" : "not-applicable",
       monomorphization: marker === "alpha" ? "applied" : "not-applicable",
       allocationProvenance: "verified",
     },
-    ir: { marker, blocks: [{ id: 0, instructions: [] }] },
+    irCandidate: { marker, blocks: [{ id: 0, instructions: [] }] },
   };
 }
 
@@ -447,55 +448,55 @@ function validPreparedCore(): {
 } {
   const { abi, alpha, beta, legacy } = preparedCoreFixture();
   const builder = new PreparedIrProgramBuilder(abi);
-  builder.recordPrepared(preparedInput(alpha.id, "alpha"));
-  builder.recordPrepared(preparedInput(beta.id, "beta"));
-  builder.recordUnsupported({
+  builder.recordIrCandidate(preparedInput(alpha.id, "alpha"));
+  builder.recordIrCandidate(preparedInput(beta.id, "beta"));
+  builder.recordDirectCandidate({
     unitId: legacy.id,
     code: "unsupported-syntax",
     stage: "select",
     detail: "temporary direct policy",
   });
-  builder.addComponent({ id: "prepared-call-graph", unitIds: [alpha.id, beta.id] });
-  builder.addComponent({ id: "legacy-singleton", unitIds: [legacy.id] });
+  builder.addComponentCandidate({ id: "prepared-call-graph", unitIds: [alpha.id, beta.id] });
+  builder.addComponentCandidate({ id: "legacy-singleton", unitIds: [legacy.id] });
   return { program: builder.seal(), alphaId: alpha.id, betaId: beta.id, legacyId: legacy.id };
 }
 
 describe("#3521 PreparedIrProgram structural ownership", () => {
-  it("freezes the exact inventory, component ownership, support plan, optimization evidence, and emission ledger", () => {
+  it("owns the exact inventory while labeling all unwired evidence and components as candidates", () => {
     const { abi, alpha, beta, legacy } = preparedCoreFixture();
     const builder = new PreparedIrProgramBuilder(abi);
-    builder.recordPrepared(preparedInput(alpha.id, "alpha"));
-    builder.recordPrepared(preparedInput(beta.id, "beta"));
-    builder.recordUnsupported({
+    builder.recordIrCandidate(preparedInput(alpha.id, "alpha"));
+    builder.recordIrCandidate(preparedInput(beta.id, "beta"));
+    builder.recordDirectCandidate({
       unitId: legacy.id,
       code: "unsupported-syntax",
       stage: "select",
       detail: "temporary hybrid route",
     });
-    builder.addComponent({ id: "numeric", unitIds: [alpha.id, beta.id] });
-    builder.addComponent({ id: "direct", unitIds: [legacy.id] });
+    builder.addComponentCandidate({ id: "numeric", unitIds: [alpha.id, beta.id] });
+    builder.addComponentCandidate({ id: "direct", unitIds: [legacy.id] });
 
-    const supportIntents: readonly PreparedIrSupportIntent[] = [
+    const supportIntents = [
       { key: "callback:host", kind: "host-callback", ownerUnitId: alpha.id },
       { key: "date:snapshot", kind: "runtime-entry", ownerUnitId: alpha.id, detail: "Date snapshot" },
       { key: "promise:delay", kind: "runtime-entry", ownerUnitId: beta.id, detail: "Promise delay" },
       { key: "literal:hello", kind: "literal", ownerUnitId: alpha.id },
       { key: "closure:lifted:0", kind: "lifted-closure", ownerUnitId: alpha.id },
       { key: "clone:mono:0", kind: "monomorphized-clone", ownerUnitId: alpha.id },
-    ];
-    for (const intent of supportIntents) builder.addSupportIntent(intent);
-    builder.addAllocation({ key: "literal:hello", kind: "literal", ownerUnitId: alpha.id, ordinal: 0 });
-    builder.addAllocation({ key: "helper:promise", kind: "helper", ownerUnitId: beta.id, ordinal: 0 });
+    ] as const;
+    for (const intent of supportIntents) builder.addSupportIntentCandidate(intent);
+    builder.addAllocationCandidate({ key: "literal:hello", kind: "literal", ownerUnitId: alpha.id, ordinal: 0 });
+    builder.addAllocationCandidate({ key: "helper:promise", kind: "helper", ownerUnitId: beta.id, ordinal: 0 });
     const liftedId = createDerivedIrUnitId({ parentId: alpha.id, role: "lifted-closure", ordinal: 0 });
     const cloneId = createDerivedIrUnitId({ parentId: alpha.id, role: "monomorphization-clone", ordinal: 0 });
-    builder.addProvenance({
+    builder.addProvenanceCandidate({
       artifactUnitId: liftedId,
       ownerUnitId: alpha.id,
       parentUnitId: alpha.id,
       role: "lifted-closure",
       ordinal: 0,
     });
-    builder.addProvenance({
+    builder.addProvenanceCandidate({
       artifactUnitId: cloneId,
       ownerUnitId: alpha.id,
       parentUnitId: alpha.id,
@@ -506,29 +507,42 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
     const program = builder.seal();
     expect(Object.isFrozen(program)).toBe(true);
     expect(program.units.size).toBe(3);
-    expect(program.preparedUnits.size).toBe(2);
-    expect(program.directUnits.size).toBe(1);
-    expect(program.invariantUnits.size).toBe(0);
-    expect(program.components.map((component) => [component.id, component.outcome])).toEqual([
-      ["numeric", "prepared"],
-      ["direct", "unsupported"],
+    expect(program.irCandidates.size).toBe(2);
+    expect(program.directCandidates.size).toBe(1);
+    expect(program.invariantCandidates.size).toBe(0);
+    expect(program.reconciliation).toBe("pending-production-wiring");
+    expect(
+      program.componentCandidates.map((component) => [
+        component.id,
+        component.candidateRoutes,
+        component.evidenceStatus,
+      ]),
+    ).toEqual([
+      ["numeric", ["ir"], "unvalidated-component-candidate"],
+      ["direct", ["direct"], "unvalidated-component-candidate"],
     ]);
-    expect(program.supportIntents.map((intent) => intent.key)).toEqual(supportIntents.map((intent) => intent.key));
-    expect(Object.isFrozen(program.supportIntents)).toBe(true);
+    expect(program.supportIntentCandidates.map((intent) => intent.key)).toEqual(
+      supportIntents.map((intent) => intent.key),
+    );
+    expect(program.supportIntentCandidates.every((intent) => intent.evidenceStatus === "unvalidated-candidate")).toBe(
+      true,
+    );
+    expect(Object.isFrozen(program.supportIntentCandidates)).toBe(true);
     expect((program.units as Map<IrUnitId, unknown>).set).toBeUndefined();
-    expect(program.preparedUnits.get(beta.id)?.optimization.inlineSmall).toBe("applied");
-    expect(program.preparedUnits.get(alpha.id)?.optimization.monomorphization).toBe("applied");
-    expect(program.provenance.map((record) => record.artifactUnitId)).toEqual([liftedId, cloneId]);
+    expect(program.irCandidates.get(beta.id)?.assertedOptimization.inlineSmall).toBe("applied");
+    expect(program.irCandidates.get(alpha.id)?.assertedOptimization.monomorphization).toBe("applied");
+    expect(program.provenanceCandidates.map((record) => record.artifactUnitId)).toEqual([liftedId, cloneId]);
 
     const emission = program.beginEmission();
     emission.emitIr(alpha.id, { op: "ir.alpha" });
     emission.emitIr(beta.id, { op: "ir.beta" });
     emission.emitDirect(legacy.id, { op: "direct.legacy" });
     const publication = emission.publish();
+    expect(publication.evidenceStatus).toBe("unvalidated-candidate-publication");
     expect(publication.bodies.size).toBe(3);
     expect(publication.ledger.get(alpha.id)).toEqual({
       unitId: alpha.id,
-      outcome: "prepared",
+      candidateRoute: "ir",
       prepareAttempts: 1,
       directBodyEmissions: 0,
       irBodyEmissions: 1,
@@ -537,7 +551,7 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
     });
     expect(publication.ledger.get(legacy.id)).toEqual({
       unitId: legacy.id,
-      outcome: "unsupported",
+      candidateRoute: "direct",
       prepareAttempts: 1,
       directBodyEmissions: 1,
       irBodyEmissions: 0,
@@ -548,50 +562,63 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
     expectPreparedInvariant(() => emission.emitIr(alpha.id, {}), "transaction-closed");
   });
 
-  it("fails sealing for missing or duplicate outcomes and missing or duplicate component membership", () => {
+  it("fails sealing for missing or duplicate unit candidates and duplicate component-candidate IDs", () => {
     const missingFixture = preparedCoreFixture();
     const missing = new PreparedIrProgramBuilder(missingFixture.abi);
-    missing.recordPrepared(preparedInput(missingFixture.alpha.id, "alpha"));
-    missing.recordPrepared(preparedInput(missingFixture.beta.id, "beta"));
-    missing.addComponent({
+    missing.recordIrCandidate(preparedInput(missingFixture.alpha.id, "alpha"));
+    missing.recordIrCandidate(preparedInput(missingFixture.beta.id, "beta"));
+    missing.addComponentCandidate({
       id: "all",
       unitIds: [missingFixture.alpha.id, missingFixture.beta.id, missingFixture.legacy.id],
     });
     expectPreparedInvariant(() => missing.seal(), "missing-unit");
     expectPreparedInvariant(
-      () => missing.recordInvariant({ unitId: missingFixture.legacy.id, code: "x", stage: "build", detail: "x" }),
+      () =>
+        missing.recordInvariantCandidate({ unitId: missingFixture.legacy.id, code: "x", stage: "build", detail: "x" }),
       "program-seal-failed",
     );
 
     const duplicateFixture = preparedCoreFixture();
     const duplicate = new PreparedIrProgramBuilder(duplicateFixture.abi);
-    duplicate.recordPrepared(preparedInput(duplicateFixture.alpha.id, "alpha"));
-    duplicate.recordPrepared(preparedInput(duplicateFixture.alpha.id, "alpha-again"));
-    duplicate.recordPrepared(preparedInput(duplicateFixture.beta.id, "beta"));
-    duplicate.recordUnsupported({ unitId: duplicateFixture.legacy.id, code: "x", stage: "select", detail: "x" });
-    duplicate.addComponent({ id: "a", unitIds: [duplicateFixture.alpha.id] });
-    duplicate.addComponent({ id: "b", unitIds: [duplicateFixture.beta.id, duplicateFixture.legacy.id] });
+    duplicate.recordIrCandidate(preparedInput(duplicateFixture.alpha.id, "alpha"));
+    duplicate.recordIrCandidate(preparedInput(duplicateFixture.alpha.id, "alpha-again"));
+    duplicate.recordIrCandidate(preparedInput(duplicateFixture.beta.id, "beta"));
+    duplicate.recordDirectCandidate({ unitId: duplicateFixture.legacy.id, code: "x", stage: "select", detail: "x" });
+    duplicate.addComponentCandidate({ id: "a", unitIds: [duplicateFixture.alpha.id] });
+    duplicate.addComponentCandidate({ id: "b", unitIds: [duplicateFixture.beta.id, duplicateFixture.legacy.id] });
     expectPreparedInvariant(() => duplicate.seal(), "duplicate-unit");
 
-    const membershipFixture = preparedCoreFixture();
-    const membership = new PreparedIrProgramBuilder(membershipFixture.abi);
-    membership.recordPrepared(preparedInput(membershipFixture.alpha.id, "alpha"));
-    membership.recordPrepared(preparedInput(membershipFixture.beta.id, "beta"));
-    membership.recordUnsupported({ unitId: membershipFixture.legacy.id, code: "x", stage: "select", detail: "x" });
-    membership.addComponent({ id: "a", unitIds: [membershipFixture.alpha.id, membershipFixture.beta.id] });
-    membership.addComponent({ id: "b", unitIds: [membershipFixture.beta.id, membershipFixture.legacy.id] });
-    expectPreparedInvariant(() => membership.seal(), "duplicate-component-unit");
+    const componentsFixture = preparedCoreFixture();
+    const components = new PreparedIrProgramBuilder(componentsFixture.abi);
+    components.recordIrCandidate(preparedInput(componentsFixture.alpha.id, "alpha"));
+    components.recordIrCandidate(preparedInput(componentsFixture.beta.id, "beta"));
+    components.recordDirectCandidate({ unitId: componentsFixture.legacy.id, code: "x", stage: "select", detail: "x" });
+    components.addComponentCandidate({ id: "same", unitIds: [componentsFixture.alpha.id] });
+    components.addComponentCandidate({ id: "same", unitIds: [componentsFixture.beta.id] });
+    expectPreparedInvariant(() => components.seal(), "duplicate-component-candidate");
   });
 
-  it("rejects mixed terminal outcomes inside one local-call component before emission", () => {
+  it("keeps mixed caller groupings explicitly unvalidated instead of treating them as atomic components", () => {
     const { abi, alpha, beta, legacy } = preparedCoreFixture();
     const builder = new PreparedIrProgramBuilder(abi);
-    builder.recordPrepared(preparedInput(alpha.id, "alpha"));
-    builder.recordUnsupported({ unitId: beta.id, code: "unsafe-abi-edge", stage: "resolve", detail: "unsafe edge" });
-    builder.recordUnsupported({ unitId: legacy.id, code: "unsupported-syntax", stage: "select", detail: "legacy" });
-    builder.addComponent({ id: "unsafe-local-edge", unitIds: [alpha.id, beta.id] });
-    builder.addComponent({ id: "legacy", unitIds: [legacy.id] });
-    expectPreparedInvariant(() => builder.seal(), "mixed-component-outcome");
+    builder.recordIrCandidate(preparedInput(alpha.id, "alpha"));
+    builder.recordDirectCandidate({
+      unitId: beta.id,
+      code: "unsafe-abi-edge",
+      stage: "resolve",
+      detail: "unsafe edge",
+    });
+    builder.recordDirectCandidate({ unitId: legacy.id, code: "unsupported-syntax", stage: "select", detail: "legacy" });
+    builder.addComponentCandidate({ id: "unsafe-local-edge", unitIds: [alpha.id, beta.id] });
+    builder.addComponentCandidate({ id: "legacy", unitIds: [legacy.id] });
+    const program = builder.seal();
+    expect(program.componentCandidates[0]).toEqual({
+      id: "unsafe-local-edge",
+      unitIds: [alpha.id, beta.id],
+      candidateRoutes: ["ir", "direct"],
+      evidenceStatus: "unvalidated-component-candidate",
+    });
+    expect(program.reconciliation).toBe("pending-production-wiring");
   });
 
   it("rejects unsealed ABI input and support requests after the atomic seal", () => {
@@ -602,21 +629,180 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
     const { program, alphaId } = validPreparedCore();
     expect(program.sealed).toBe(true);
     const sealedBuilder = new PreparedIrProgramBuilder(fixture.abi);
-    sealedBuilder.recordPrepared(preparedInput(fixture.alpha.id, "alpha"));
-    sealedBuilder.recordPrepared(preparedInput(fixture.beta.id, "beta"));
-    sealedBuilder.recordUnsupported({
+    sealedBuilder.recordIrCandidate(preparedInput(fixture.alpha.id, "alpha"));
+    sealedBuilder.recordIrCandidate(preparedInput(fixture.beta.id, "beta"));
+    sealedBuilder.recordDirectCandidate({
       unitId: fixture.legacy.id,
       code: "unsupported-syntax",
       stage: "select",
       detail: "legacy",
     });
-    sealedBuilder.addComponent({ id: "prepared", unitIds: [fixture.alpha.id, fixture.beta.id] });
-    sealedBuilder.addComponent({ id: "direct", unitIds: [fixture.legacy.id] });
+    sealedBuilder.addComponentCandidate({ id: "prepared", unitIds: [fixture.alpha.id, fixture.beta.id] });
+    sealedBuilder.addComponentCandidate({ id: "direct", unitIds: [fixture.legacy.id] });
     sealedBuilder.seal();
     expectPreparedInvariant(
-      () => sealedBuilder.addSupportIntent({ key: "late:helper", kind: "helper", ownerUnitId: alphaId }),
+      () => sealedBuilder.addSupportIntentCandidate({ key: "late:helper", kind: "helper", ownerUnitId: alphaId }),
       "late-support-intent",
     );
+  });
+
+  it("makes emission-transaction construction capability-only", () => {
+    const { program } = validPreparedCore();
+    expect(Object.isFrozen(PreparedIrEmissionTransaction)).toBe(true);
+    expect(Object.isFrozen(PreparedIrEmissionTransaction.prototype)).toBe(true);
+    expectPreparedInvariant(
+      () =>
+        Reflect.construct(PreparedIrEmissionTransaction as unknown as Function, [program, Symbol("forged-capability")]),
+      "invalid-transaction-capability",
+    );
+    expect(program.beginEmission()).toBeInstanceOf(PreparedIrEmissionTransaction);
+  });
+
+  it("defensively owns builder and factory maps, arrays, and nested candidate data", () => {
+    const { abi, alpha, beta, legacy } = preparedCoreFixture();
+    const params = ["f64"];
+    const blocks = [{ id: 0, instructions: [] as string[] }];
+    const builder = new PreparedIrProgramBuilder(abi);
+    builder.recordIrCandidate({
+      ...preparedInput(alpha.id, "alpha"),
+      assertedSignature: { params, results: ["f64"] },
+      irCandidate: { blocks },
+    });
+    params[0] = "externref";
+    blocks[0]!.id = 99;
+    blocks[0]!.instructions.push("mutated");
+    builder.recordIrCandidate(preparedInput(beta.id, "beta"));
+    builder.recordDirectCandidate({ unitId: legacy.id, code: "x", stage: "select", detail: "x" });
+    const program = builder.seal();
+    expect(program.irCandidates.get(alpha.id)?.assertedSignature.params).toEqual(["f64"]);
+    expect(program.irCandidates.get(alpha.id)?.irCandidate).toEqual({ blocks: [{ id: 0, instructions: [] }] });
+
+    const originalAlpha = program.irCandidates.get(alpha.id)!;
+    const factoryParams = ["f64"];
+    const factoryBlocks = [{ id: 0 }];
+    const mutableUnits = new Map(program.units);
+    mutableUnits.set(alpha.id, {
+      ...originalAlpha,
+      assertedSignature: { params: factoryParams, results: ["f64"] },
+      irCandidate: { blocks: factoryBlocks },
+    });
+    const mutableComponentIds = [alpha.id, beta.id];
+    const mutableComponents = [{ id: "mutable", unitIds: mutableComponentIds }];
+    const mutableSupport = [{ key: "mutable:support", kind: "helper" as const, ownerUnitId: alpha.id }];
+    const mutableAllocation = [
+      { key: "mutable:allocation", kind: "helper" as const, ownerUnitId: alpha.id, ordinal: 0 },
+    ];
+    const mutableProvenance = [
+      {
+        artifactUnitId: createDerivedIrUnitId({
+          parentId: alpha.id,
+          role: "monomorphization-clone",
+          ordinal: 1,
+        }),
+        ownerUnitId: alpha.id,
+        parentUnitId: alpha.id,
+        role: "monomorphization-clone" as const,
+        ordinal: 1,
+      },
+    ];
+    const mutableEntries = [...program.abi.entries];
+    const factoryProgram = createPreparedIrCandidateProgram({
+      abiEntries: mutableEntries,
+      units: mutableUnits,
+      componentCandidates: mutableComponents,
+      supportIntentCandidates: mutableSupport,
+      allocationCandidates: mutableAllocation,
+      provenanceCandidates: mutableProvenance,
+    });
+    mutableUnits.clear();
+    factoryParams[0] = "externref";
+    factoryBlocks[0]!.id = 77;
+    mutableComponentIds.push(legacy.id);
+    mutableComponents[0]!.id = "changed";
+    mutableSupport[0]!.key = "changed";
+    mutableAllocation[0]!.key = "changed";
+    mutableProvenance[0]!.ordinal = 99;
+    mutableEntries.length = 0;
+    expect(factoryProgram.units.size).toBe(3);
+    expect(factoryProgram.irCandidates.get(alpha.id)?.assertedSignature.params).toEqual(["f64"]);
+    expect(factoryProgram.irCandidates.get(alpha.id)?.irCandidate).toEqual({ blocks: [{ id: 0 }] });
+    expect(factoryProgram.componentCandidates[0]?.id).toBe("mutable");
+    expect(factoryProgram.componentCandidates[0]?.unitIds).toEqual([alpha.id, beta.id]);
+    expect(factoryProgram.supportIntentCandidates[0]?.key).toBe("mutable:support");
+    expect(factoryProgram.allocationCandidates[0]?.key).toBe("mutable:allocation");
+    expect(factoryProgram.provenanceCandidates[0]?.ordinal).toBe(1);
+    expect(factoryProgram.abi.entries).toEqual(program.abi.entries);
+  });
+
+  it("fails closed on inconsistent direct-factory unit identity and unknown grouping units", () => {
+    const { program, alphaId } = validPreparedCore();
+    const alpha = program.irCandidates.get(alphaId)!;
+    expectPreparedInvariant(
+      () =>
+        createPreparedIrCandidateProgram({
+          abiEntries: program.abi.entries,
+          units: new Map([[alphaId, { ...alpha, unitId: "forged-unit" as IrUnitId }]]),
+          componentCandidates: [],
+          supportIntentCandidates: [],
+          allocationCandidates: [],
+          provenanceCandidates: [],
+        }),
+      "invalid-prepared-data",
+    );
+    expectPreparedInvariant(
+      () =>
+        createPreparedIrCandidateProgram({
+          abiEntries: program.abi.entries,
+          units: new Map([[alphaId, alpha]]),
+          componentCandidates: [{ id: "unknown", unitIds: ["unknown-unit" as IrUnitId] }],
+          supportIntentCandidates: [],
+          allocationCandidates: [],
+          provenanceCandidates: [],
+        }),
+      "unknown-unit",
+    );
+  });
+
+  it("rejects nested functions as non-data and aborts the preparation collector without retry", () => {
+    const { abi, alpha, beta } = preparedCoreFixture();
+    const builder = new PreparedIrProgramBuilder(abi);
+    expectPreparedInvariant(
+      () =>
+        builder.recordIrCandidate({
+          ...preparedInput(alpha.id, "alpha"),
+          irCandidate: { nested: { execute: () => 1 } },
+        }),
+      "invalid-prepared-data",
+    );
+    expectPreparedInvariant(() => builder.recordIrCandidate(preparedInput(beta.id, "beta")), "program-seal-failed");
+  });
+
+  it("aborts atomically on staging exceptions and nested functions, with no retry or publication", () => {
+    const throwing = validPreparedCore();
+    const throwingTx = throwing.program.beginEmission();
+    const stagingError = new Error("injected-ownKeys-failure");
+    const hostileBody = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw stagingError;
+        },
+      },
+    );
+    expect(() => throwingTx.emitIr(throwing.alphaId, hostileBody)).toThrow(stagingError);
+    expect(throwingTx.publication).toBeUndefined();
+    expect(throwingTx.ledger.get(throwing.alphaId)?.irBodyEmissions).toBe(0);
+    expectPreparedInvariant(() => throwingTx.emitIr(throwing.alphaId, {}), "transaction-closed");
+    expectPreparedInvariant(() => throwingTx.publish(), "transaction-closed");
+
+    const executable = validPreparedCore();
+    const executableTx = executable.program.beginEmission();
+    expectPreparedInvariant(
+      () => executableTx.emitIr(executable.alphaId, { nested: { execute: () => 1 } }),
+      "invalid-prepared-data",
+    );
+    expect(executableTx.publication).toBeUndefined();
+    expectPreparedInvariant(() => executableTx.emitIr(executable.alphaId, {}), "transaction-closed");
   });
 
   it("fails closed on wrong-direction, duplicate, and partial emission without publishing a body", () => {
@@ -652,22 +838,22 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
     expectPreparedInvariant(() => partialTx.emitIr(partial.betaId, { op: "too-late" }), "transaction-closed");
   });
 
-  it("keeps terminal Invariant units on the neither-emitter route", () => {
+  it("keeps invariant candidates on the neither-emitter route", () => {
     const { abi, alpha, beta, legacy } = preparedCoreFixture();
     const builder = new PreparedIrProgramBuilder(abi);
-    builder.recordInvariant({
+    builder.recordInvariantCandidate({
       unitId: alpha.id,
       code: "selection-preparation-mismatch",
       stage: "verify",
       detail: "injected invariant",
     });
-    builder.recordPrepared(preparedInput(beta.id, "beta"));
-    builder.recordUnsupported({ unitId: legacy.id, code: "unsupported-syntax", stage: "select", detail: "legacy" });
-    builder.addComponent({ id: "invariant", unitIds: [alpha.id] });
-    builder.addComponent({ id: "prepared", unitIds: [beta.id] });
-    builder.addComponent({ id: "direct", unitIds: [legacy.id] });
+    builder.recordIrCandidate(preparedInput(beta.id, "beta"));
+    builder.recordDirectCandidate({ unitId: legacy.id, code: "unsupported-syntax", stage: "select", detail: "legacy" });
+    builder.addComponentCandidate({ id: "invariant", unitIds: [alpha.id] });
+    builder.addComponentCandidate({ id: "prepared", unitIds: [beta.id] });
+    builder.addComponentCandidate({ id: "direct", unitIds: [legacy.id] });
     const program = builder.seal();
-    expect(program.invariantUnits.size).toBe(1);
-    expectPreparedInvariant(() => program.beginEmission(), "program-has-invariant");
+    expect(program.invariantCandidates.size).toBe(1);
+    expectPreparedInvariant(() => program.beginEmission(), "program-has-invariant-candidate");
   });
 });

--- a/tests/issue-3521-prepared-ir-program.test.ts
+++ b/tests/issue-3521-prepared-ir-program.test.ts
@@ -662,20 +662,32 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
     const { abi, alpha, beta, legacy } = preparedCoreFixture();
     const params = ["f64"];
     const blocks = [{ id: 0, instructions: [] as string[] }];
+    const lookup = new Map([["alpha", { slot: 1 }]]);
+    const labels = new Set(["prepared"]);
     const builder = new PreparedIrProgramBuilder(abi);
     builder.recordIrCandidate({
       ...preparedInput(alpha.id, "alpha"),
       assertedSignature: { params, results: ["f64"] },
-      irCandidate: { blocks },
+      irCandidate: { blocks, lookup, labels },
     });
     params[0] = "externref";
     blocks[0]!.id = 99;
     blocks[0]!.instructions.push("mutated");
+    lookup.get("alpha")!.slot = 99;
+    lookup.set("late", { slot: 2 });
+    labels.add("late");
     builder.recordIrCandidate(preparedInput(beta.id, "beta"));
     builder.recordDirectCandidate({ unitId: legacy.id, code: "x", stage: "select", detail: "x" });
     const program = builder.seal();
     expect(program.irCandidates.get(alpha.id)?.assertedSignature.params).toEqual(["f64"]);
-    expect(program.irCandidates.get(alpha.id)?.irCandidate).toEqual({ blocks: [{ id: 0, instructions: [] }] });
+    const ownedBuilderCandidate = program.irCandidates.get(alpha.id)?.irCandidate as {
+      blocks: readonly { id: number; instructions: readonly string[] }[];
+      lookup: ReadonlyMap<string, { slot: number }>;
+      labels: ReadonlySet<string>;
+    };
+    expect(ownedBuilderCandidate.blocks).toEqual([{ id: 0, instructions: [] }]);
+    expect([...ownedBuilderCandidate.lookup]).toEqual([["alpha", { slot: 1 }]]);
+    expect([...ownedBuilderCandidate.labels]).toEqual(["prepared"]);
 
     const originalAlpha = program.irCandidates.get(alpha.id)!;
     const factoryParams = ["f64"];
@@ -741,6 +753,27 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
       () =>
         createPreparedIrCandidateProgram({
           abiEntries: program.abi.entries,
+          units: new Map([
+            [
+              alphaId,
+              {
+                ...alpha,
+                kind: "unknown-kind",
+                route: undefined,
+              } as never,
+            ],
+          ]),
+          componentCandidates: [],
+          supportIntentCandidates: [],
+          allocationCandidates: [],
+          provenanceCandidates: [],
+        }),
+      "invalid-prepared-data",
+    );
+    expectPreparedInvariant(
+      () =>
+        createPreparedIrCandidateProgram({
+          abiEntries: program.abi.entries,
           units: new Map([[alphaId, { ...alpha, unitId: "forged-unit" as IrUnitId }]]),
           componentCandidates: [],
           supportIntentCandidates: [],
@@ -775,6 +808,51 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
       "invalid-prepared-data",
     );
     expectPreparedInvariant(() => builder.recordIrCandidate(preparedInput(beta.id, "beta")), "program-seal-failed");
+  });
+
+  it("rejects accessors before executing them in builder and direct-factory inputs", () => {
+    const { abi, alpha } = preparedCoreFixture();
+    const builder = new PreparedIrProgramBuilder(abi);
+    let unitGetterCalls = 0;
+    const accessorCandidate = { ...preparedInput(alpha.id, "alpha") };
+    Object.defineProperty(accessorCandidate, "unitId", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        unitGetterCalls++;
+        return alpha.id;
+      },
+    });
+    expectPreparedInvariant(
+      () => builder.recordIrCandidate(accessorCandidate as PreparedIrIrCandidateInput),
+      "invalid-prepared-data",
+    );
+    expect(unitGetterCalls).toBe(0);
+
+    const { program } = validPreparedCore();
+    let supportGetterCalls = 0;
+    const accessorSupport = { kind: "helper" as const };
+    Object.defineProperty(accessorSupport, "key", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        supportGetterCalls++;
+        return "forged:getter";
+      },
+    });
+    expectPreparedInvariant(
+      () =>
+        createPreparedIrCandidateProgram({
+          abiEntries: program.abi.entries,
+          units: program.units,
+          componentCandidates: [],
+          supportIntentCandidates: [accessorSupport as never],
+          allocationCandidates: [],
+          provenanceCandidates: [],
+        }),
+      "invalid-prepared-data",
+    );
+    expect(supportGetterCalls).toBe(0);
   });
 
   it("aborts atomically on staging exceptions and nested functions, with no retry or publication", () => {


### PR DESCRIPTION
## Summary

- add the immutable `PreparedIrProgram` and preparation collector boundary for R2
- require one candidate route per inventoried top-level free-function unit
- keep component, support, allocation, provenance, and optimization assertions explicitly unvalidated until production reconciliation
- make emission capability-only, transactional, one-shot, and fail closed without direct-codegen retry
- recursively own all caller data, including exported readonly Map/Set wrappers; reject functions, accessors, unsupported mutable objects, and cycles

This is the structural first R2 landing. It intentionally does not change production routing or claim compile-once cutover yet, so the measured legacy-body reduction is `0`. Follow-up R2 slices will reconcile real post-pass IR evidence and wire this boundary into the production emitter while preserving the optimization-retirement ledger.

## Validation

- `pnpm vitest run tests/issue-3521-prepared-ir-program.test.ts --maxWorkers=1` — 18/18
- adversarial ownership/capability/lifecycle review — 6/6
- `pnpm run typecheck`
- `pnpm run check:ir-optimization-retirement`
- `pnpm run check:issue-ids`
- pre-push typecheck, lint, formatting, oracle/coercion/numeric-local parity, fallback and issue-integrity gates

Tracked in `plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md`.
