### PR TITLE
refactor(ir): own Date civil support structurally

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -175,6 +175,7 @@ files:
   - tests/issue-1899-funcidx-authority.test.ts
 loc-budget-allow:
   - src/codegen/closure-exports.ts
+  - src/codegen/expressions/builtins.ts
   - src/codegen/declarations.ts
   - src/codegen/statements/nested-declarations.ts
   - src/codegen/context/types.ts
@@ -2725,6 +2726,39 @@ C31 closes exact retained ownership for this bounded closure host-dispatch
 family, not R1. Higher-arity method dispatchers, other support callable
 families, remaining class/type consumers, and module-array or display-name
 scans still need structural owners before R1 can close.
+
+### 2026-07-30 date civil support callable ownership continuation
+
+The C32 continuation on `codex/3520-c32-date-civil-support` gives
+`__date_civil_from_days` one canonical entry-source `date-civil-support`
+binding at derived ordinal 0 and callable role ordinal 10. The exact allocator
+object remains behind its stable function handle; tracked and untracked
+binaries are byte-identical, and late-import/DCE locator resolution moves
+0 → 1 → 0 without rebuilding the helper. A same-named source function cannot
+occupy the Date role or redirect Date lowering: C32 always mints the exact
+helper independently and installs the `funcMap` compatibility alias only when
+the logical name is free.
+
+Across `SINGLE_HOST_ENTRIES`, C31+C32 contain **166** defined functions,
+**74** generic rows, **26** closure rows, and **1** Date row. Composed with
+C30, the census is **50 generic + 24 vec + 26 closure + 1 Date**, the intended
+one-for-one **51 → 50** generic move for C32. Routing remains **37 terminal /
+30 emitted / 7 Unsupported / 0 Invariants / 37 legacy bodies / 30 IR bodies**,
+so terminal adoption gain is zero.
+
+The focused C32 suite passes **7/7**, including matching `bigint → bigint` and
+mismatched `number → number` source-name collisions in both tracked and
+untracked standalone lanes. Both the Date calendar result and user function
+result are preserved, both binaries validate, and each tracked binary matches
+its untracked counterpart. The suite also preserves leap-day output
+`20240229`, exact structural/final-slot ownership, and census parity. The
+adjacent negative-year suite passes **42/42** and the calendar-residual suite
+passes **28/28**. The sole `date-native` `Date.now()` harness failure reproduces
+on the exact C31 parent because `env.__date_now` is not supplied.
+
+C32 closes exact retained ownership for this one civil-date support helper, not
+R1. Other Date helpers and remaining support callable families still need
+structural owners.
 
 ### R1a validation evidence
 

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -4,15 +4,20 @@
  */
 import { ts } from "../../ts-api.js";
 import { isBooleanType, isNumberType, isStringType } from "../../checker/type-mapper.js";
-import type { Instr, ValType } from "../../ir/types.js";
+import type { Instr, ValType, WasmFunction } from "../../ir/types.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { resolveArrayInfo } from "../array-methods.js";
-import { mintDefinedFunc, pushDefinedFunc } from "../func-space.js"; // (#1916 S3b) stable-regime minting
+import { definedFuncAt, definedFuncHandleOf, mintDefinedFunc, pushDefinedFunc } from "../func-space.js"; // (#1916 S3b) stable-regime minting
 import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { ensureLateImport, flushLateImportShifts } from "../expressions/late-imports.js";
 import { addFuncType, ensureWasiWriteAnyStringHelper } from "../index.js";
 import { emitStandaloneStdoutAppendValue, ensureNativeStringExternBridge } from "../native-strings.js";
+import {
+  planProgramAbiEntrySourceSupportCallable,
+  PROGRAM_ABI_CALLABLE_ROLE,
+  resolveProgramAbiSupportCallableHandle,
+} from "../program-abi-planning.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, VOID_RESULT } from "../shared.js";
 import { compileStringLiteral } from "../string-ops.js";
@@ -147,6 +152,37 @@ function compileConsoleCall(
 // using Howard Hinnant's civil_from_days algorithm, implemented purely in
 // i64 arithmetic — no host imports needed.
 
+const DATE_CIVIL_SUPPORT_ROLE = "date-civil-support";
+const DATE_CIVIL_SUPPORT_ORDINAL = 0;
+const dateCivilHelperByContext = new WeakMap<CodegenContext, WasmFunction>();
+
+/**
+ * Give the civil-date helper one structural owner and resolve its exact
+ * allocator object back to the current function handle.
+ *
+ * The helper's stable handle is byte-compatible with untracked compilation.
+ * Program ABI tracking only prevents the final retained-callable sweep from
+ * assigning a second generic owner.
+ */
+function ownDateCivilHelper(ctx: CodegenContext, func: WasmFunction): number {
+  const ref = planProgramAbiEntrySourceSupportCallable(ctx, {
+    role: DATE_CIVIL_SUPPORT_ROLE,
+    roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.dateCivilSupport,
+    derivedOrdinal: DATE_CIVIL_SUPPORT_ORDINAL,
+    displayName: func.name,
+    func,
+  });
+  const funcIdx = resolveProgramAbiSupportCallableHandle(ctx, ref, func);
+  if (funcIdx === undefined) {
+    throw new Error(`${func.name} lost its exact allocator object`);
+  }
+  const stableHandle = definedFuncHandleOf(ctx, func);
+  if (stableHandle === undefined) {
+    throw new Error(`${func.name} is not present in the defined function registry`);
+  }
+  return stableHandle;
+}
+
 /** Ensure the $__Date struct type exists, return its type index. */
 export function ensureDateStruct(ctx: CodegenContext): number {
   const existing = ctx.structMap.get("__Date");
@@ -237,7 +273,15 @@ function emitPackedMmdd(out: Instr[], tmpLocal: number, yearTmp: number): void {
  */
 export function ensureDateCivilHelper(ctx: CodegenContext): number {
   const existing = ctx.funcMap.get("__date_civil_from_days");
-  if (existing !== undefined) return existing;
+  if (existing !== undefined) {
+    const owned = dateCivilHelperByContext.get(ctx);
+    if (!owned) return existing;
+    const func = definedFuncAt(ctx, existing);
+    if (func !== owned) {
+      throw new Error("__date_civil_from_days no longer resolves to its exact allocator object");
+    }
+    return ownDateCivilHelper(ctx, func);
+  }
 
   // func (param $z i64) (result i64)
   // locals: $z(0), $era(1), $doe(2), $yoe(3), $doy(4), $mp(5), $y(6), $m(7), $d(8)
@@ -396,7 +440,7 @@ export function ensureDateCivilHelper(ctx: CodegenContext): number {
     { op: "i64.add" },
   );
 
-  pushDefinedFunc(ctx, funcIdx, {
+  const func: WasmFunction = {
     name: "__date_civil_from_days",
     typeIdx: funcTypeIdx,
     locals: [
@@ -412,9 +456,11 @@ export function ensureDateCivilHelper(ctx: CodegenContext): number {
     ],
     body,
     exported: false,
-  });
+  };
+  pushDefinedFunc(ctx, funcIdx, func);
+  dateCivilHelperByContext.set(ctx, func);
 
-  return funcIdx;
+  return ownDateCivilHelper(ctx, func);
 }
 
 /**

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -7,7 +7,7 @@ import { isBooleanType, isNumberType, isStringType } from "../../checker/type-ma
 import type { Instr, ValType, WasmFunction } from "../../ir/types.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { resolveArrayInfo } from "../array-methods.js";
-import { definedFuncAt, definedFuncHandleOf, mintDefinedFunc, pushDefinedFunc } from "../func-space.js"; // (#1916 S3b) stable-regime minting
+import { definedFuncHandleOf, mintDefinedFunc, pushDefinedFunc } from "../func-space.js"; // (#1916 S3b) stable-regime minting
 import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { ensureLateImport, flushLateImportShifts } from "../expressions/late-imports.js";
@@ -272,22 +272,22 @@ function emitPackedMmdd(out: Instr[], tmpLocal: number, yearTmp: number): void {
  * Uses Hinnant's algorithm: http://howardhinnant.github.io/date_algorithms.html#civil_from_days
  */
 export function ensureDateCivilHelper(ctx: CodegenContext): number {
-  const existing = ctx.funcMap.get("__date_civil_from_days");
-  if (existing !== undefined) {
-    const owned = dateCivilHelperByContext.get(ctx);
-    if (!owned) return existing;
-    const func = definedFuncAt(ctx, existing);
-    if (func !== owned) {
-      throw new Error("__date_civil_from_days no longer resolves to its exact allocator object");
+  const owned = dateCivilHelperByContext.get(ctx);
+  if (owned) {
+    if (definedFuncHandleOf(ctx, owned) === undefined) {
+      throw new Error("__date_civil_from_days lost its exact allocator object");
     }
-    return ownDateCivilHelper(ctx, func);
+    return ownDateCivilHelper(ctx, owned);
   }
+  const installCompatibilityAlias = !ctx.funcMap.has("__date_civil_from_days");
 
   // func (param $z i64) (result i64)
   // locals: $z(0), $era(1), $doe(2), $yoe(3), $doy(4), $mp(5), $y(6), $m(7), $d(8)
   const funcTypeIdx = addFuncType(ctx, [{ kind: "i64" }], [{ kind: "i64" }]);
   const funcIdx = mintDefinedFunc(ctx);
-  ctx.funcMap.set("__date_civil_from_days", funcIdx);
+  if (installCompatibilityAlias) {
+    ctx.funcMap.set("__date_civil_from_days", funcIdx);
+  }
 
   const body: Instr[] = [];
 

--- a/src/codegen/program-abi-planning.ts
+++ b/src/codegen/program-abi-planning.ts
@@ -25,6 +25,7 @@ export const PROGRAM_ABI_CALLABLE_ROLE = Object.freeze({
   typedThisTwin: 7,
   vecHostBridge: 8,
   closureHostBridge: 9,
+  dateCivilSupport: 10,
 } as const);
 
 export const PROGRAM_ABI_GLOBAL_ROLE = Object.freeze({

--- a/tests/issue-3520-closure-host-bridge-abi.test.ts
+++ b/tests/issue-3520-closure-host-bridge-abi.test.ts
@@ -262,6 +262,7 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     let genericRows = 0;
     let closureRows = 0;
     let vecRows = 0;
+    let dateRows = 0;
     let terminalUnits = 0;
     let emitted = 0;
     let unsupported = 0;
@@ -283,6 +284,7 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
       genericRows += entries.filter((candidate) => candidate.id.includes("retained-module-function")).length;
       closureRows += entries.filter((candidate) => candidate.id.includes(":closure-host-bridge:")).length;
       vecRows += entries.filter((candidate) => candidate.id.includes(":vec-host-bridge:")).length;
+      dateRows += entries.filter((candidate) => candidate.id.includes(":date-civil-support:")).length;
       for (const outcome of result.irOutcomes ?? []) {
         terminalUnits++;
         if (outcome.kind === "emitted") emitted++;
@@ -294,10 +296,11 @@ describe("#3520 C31 closure host bridge Program ABI ownership", () => {
     }
 
     expect({ definedFunctions, closureRows }).toEqual({ definedFunctions: 166, closureRows: 26 });
-    // C30 is an independent structural-ownership slice. Before it lands the
-    // vec rows remain generic; after it lands they move one-for-one.
+    // C30 and C32 are independent structural-ownership slices. As each lands,
+    // its rows move one-for-one out of the generic retained-function bucket.
     expect([0, 24]).toContain(vecRows);
-    expect(genericRows).toBe(75 - vecRows);
+    expect([0, 1]).toContain(dateRows);
+    expect(genericRows).toBe(75 - vecRows - dateRows);
     expect({ terminalUnits, emitted, unsupported, invariants, legacyBodies, irBodies }).toEqual({
       terminalUnits: 37,
       emitted: 30,

--- a/tests/issue-3520-date-civil-support-abi.test.ts
+++ b/tests/issue-3520-date-civil-support-abi.test.ts
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { SINGLE_HOST_ENTRIES } from "../scripts/check-ir-only.js";
+import { analyzeSource } from "../src/checker/index.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { eliminateDeadLayoutAndPlanProgramAbi } from "../src/codegen/program-abi-finalization.js";
+import {
+  PROGRAM_ABI_CALLABLE_ROLE,
+  resolveProgramAbiSupportCallableHandle,
+} from "../src/codegen/program-abi-planning.js";
+import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
+import { eliminateDeadImports } from "../src/codegen/dead-elimination.js";
+import { ensureDateCivilHelper } from "../src/codegen/expressions/builtins.js";
+import { ensureLateImport, flushLateImportShifts } from "../src/codegen/expressions/late-imports.js";
+import { definedFuncAt } from "../src/codegen/func-space.js";
+import { generateModule } from "../src/codegen/index.js";
+import { irSupportFuncRef } from "../src/ir/callable-bindings.js";
+import { buildIrUnitInventory, createIrBindingId } from "../src/ir/identity.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import { compile } from "../src/index.js";
+import { ts } from "../src/ts-api.js";
+
+// Register the expression/statement delegates used by generateModule.
+import "../src/codegen/expressions.js";
+
+const DATE_CIVIL_SUPPORT_ROLE = "date-civil-support";
+const DATE_CIVIL_SUPPORT_ORDINAL = 0;
+const DATE_CIVIL_HELPER = "__date_civil_from_days";
+
+const CALENDAR_SOURCE = `
+  export function stamp(): number {
+    const value = new Date(Date.UTC(2024, 1, 29));
+    return value.getUTCFullYear() * 10000 + (value.getUTCMonth() + 1) * 100 + value.getUTCDate();
+  }
+`;
+
+function hardErrors(result: ReturnType<typeof generateModule>) {
+  return result.errors.filter((error) => error.severity !== "warning");
+}
+
+function entrySourceRecord(source = CALENDAR_SOURCE) {
+  const ast = analyzeSource(source, "issue-3520-date-civil-support.ts");
+  return buildIrUnitInventory([ast.sourceFile], {
+    entrySource: ast.sourceFile,
+    checker: ast.checker,
+  }).sources.find((candidate) => candidate.kind === "entry")!;
+}
+
+describe("#3520 C32 date civil support Program ABI ownership", () => {
+  it("publishes one exact entry-source owner with no duplicate generic owner", () => {
+    const ast = analyzeSource(CALENDAR_SOURCE, "issue-3520-date-civil-support.ts");
+    const result = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      standalone: true,
+    });
+    expect(
+      hardErrors(result),
+      hardErrors(result)
+        .map((error) => error.message)
+        .join("\n"),
+    ).toEqual([]);
+    expect(result.programAbi).toBeDefined();
+
+    const entrySource = entrySourceRecord();
+    const expectedId = createIrBindingId({
+      ownerId: entrySource.id,
+      domain: "support",
+      role: DATE_CIVIL_SUPPORT_ROLE,
+      ordinal: DATE_CIVIL_SUPPORT_ORDINAL,
+    });
+    const matchingEntries = result.programAbi!.abi.entries().filter((entry) => entry.displayName === DATE_CIVIL_HELPER);
+    expect(matchingEntries).toHaveLength(1);
+    expect(matchingEntries[0]).toMatchObject({
+      id: expectedId,
+      intent: {
+        kind: "callable",
+        origin: "support",
+        sourceId: entrySource.id,
+      },
+    });
+
+    const slot = result.programAbi!.abi.resolveFinalIndex(expectedId);
+    expect(slot?.space).toBe("function");
+    if (!slot || slot.space !== "function") throw new Error("missing date civil support slot");
+    const importCount = result.module.imports.filter((entry) => entry.desc.kind === "func").length;
+    expect(result.module.functions[slot.index - importCount]?.name).toBe(DATE_CIVIL_HELPER);
+  });
+
+  it("re-resolves the exact stable allocator after a late import and DCE compaction", () => {
+    const sourceFile = ts.createSourceFile(
+      "/repo/entry.ts",
+      "export function entry(): number { return 1; }",
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
+    const entrySource = inventory.sources.find((source) => source.kind === "entry")!;
+    const module = createEmptyModule();
+    const session = new ProgramAbiSession(inventory, module);
+    const ctx = createCodegenContext(module, {} as ts.TypeChecker, undefined, session);
+
+    const stableHandle = ensureDateCivilHelper(ctx);
+    const helper = definedFuncAt(ctx, stableHandle);
+    expect(helper?.name).toBe(DATE_CIVIL_HELPER);
+    const expectedId = createIrBindingId({
+      ownerId: entrySource.id,
+      domain: "support",
+      role: DATE_CIVIL_SUPPORT_ROLE,
+      ordinal: DATE_CIVIL_SUPPORT_ORDINAL,
+    });
+    expect(session.hasLocator(expectedId, helper)).toBe(true);
+    expect(session.locatorBindingId(helper!)).toBe(expectedId);
+    expect(session.getDraft(expectedId)?.structuralOrder).toMatchObject({
+      roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.dateCivilSupport,
+      derivedOrdinal: DATE_CIVIL_SUPPORT_ORDINAL,
+    });
+    const ref = irSupportFuncRef(
+      entrySource.id,
+      DATE_CIVIL_SUPPORT_ROLE,
+      DATE_CIVIL_HELPER,
+      DATE_CIVIL_SUPPORT_ORDINAL,
+    );
+    expect(resolveProgramAbiSupportCallableHandle(ctx, ref, helper!)).toBe(0);
+
+    ensureLateImport(ctx, "unused_late_date_import", [], []);
+    flushLateImportShifts(ctx, null);
+    expect(ctx.numImportFuncs).toBe(1);
+    expect(ensureDateCivilHelper(ctx)).toBe(stableHandle);
+    expect(resolveProgramAbiSupportCallableHandle(ctx, ref, helper!)).toBe(1);
+
+    eliminateDeadImports(module, ctx);
+    expect(module.imports).toEqual([]);
+    expect(ensureDateCivilHelper(ctx)).toBe(stableHandle);
+    expect(resolveProgramAbiSupportCallableHandle(ctx, ref, helper!)).toBe(0);
+    eliminateDeadLayoutAndPlanProgramAbi(ctx);
+    ctx.indexSpaceFrozen = true;
+    const publication = session.publish(module);
+    expect(publication.abi.resolveFinalIndex(expectedId)).toEqual({ space: "function", index: 0 });
+    expect(module.functions[0]).toBe(helper);
+  });
+
+  it("does not claim a same-named pre-existing allocator as Date support", () => {
+    const sourceFile = ts.createSourceFile(
+      "/repo/entry.ts",
+      "export function entry(): number { return 1; }",
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
+    const entrySource = inventory.sources.find((source) => source.kind === "entry")!;
+    const module = createEmptyModule();
+    module.types.push({ kind: "func", params: [{ kind: "i64" }], results: [{ kind: "i64" }] });
+    const occupied = {
+      name: DATE_CIVIL_HELPER,
+      typeIdx: 0,
+      locals: [],
+      body: [{ op: "local.get" as const, index: 0 }],
+      exported: false,
+    };
+    module.functions.push(occupied);
+    const session = new ProgramAbiSession(inventory, module);
+    const ctx = createCodegenContext(module, {} as ts.TypeChecker, undefined, session);
+    ctx.funcMap.set(DATE_CIVIL_HELPER, 0);
+
+    expect(ensureDateCivilHelper(ctx)).toBe(0);
+    const dateId = createIrBindingId({
+      ownerId: entrySource.id,
+      domain: "support",
+      role: DATE_CIVIL_SUPPORT_ROLE,
+      ordinal: DATE_CIVIL_SUPPORT_ORDINAL,
+    });
+    expect(session.getDraft(dateId)).toBeUndefined();
+    eliminateDeadLayoutAndPlanProgramAbi(ctx);
+    ctx.indexSpaceFrozen = true;
+    const entries = session.publish(module).abi.entries();
+    expect(entries.some((entry) => entry.id === dateId)).toBe(false);
+    expect(entries.filter((entry) => entry.displayName === DATE_CIVIL_HELPER)).toHaveLength(1);
+    expect(session.locatorBindingId(occupied)).toContain("retained-module-function");
+  });
+
+  it("keeps tracked and untracked Date modules byte-identical", async () => {
+    const options = {
+      fileName: "issue-3520-date-civil-byte-parity.ts",
+      experimentalIR: true,
+      target: "standalone",
+    } as const;
+    const untracked = await compile(CALENDAR_SOURCE, options);
+    const tracked = await compile(CALENDAR_SOURCE, { ...options, trackIrOutcomes: true });
+    expect(untracked.success, untracked.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(tracked.success, tracked.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(tracked.binary).toEqual(untracked.binary);
+  });
+
+  it("preserves leap-day calendar behavior", async () => {
+    const result = await compile(CALENDAR_SOURCE, {
+      fileName: "issue-3520-date-civil-runtime.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      target: "standalone",
+    });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.imports).toEqual([]);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.stamp as () => number)()).toBe(20240229);
+  });
+
+  it("moves one five-entry census row without changing functions or terminal routing", () => {
+    let definedFunctions = 0;
+    let genericRows = 0;
+    let dateRows = 0;
+    let vecRows = 0;
+    let terminalUnits = 0;
+    let emitted = 0;
+    let unsupported = 0;
+    let invariants = 0;
+    let legacyBodies = 0;
+    let irBodies = 0;
+
+    for (const entry of SINGLE_HOST_ENTRIES) {
+      const source = readFileSync(resolve(entry), "utf8");
+      const ast = analyzeSource(source, entry);
+      const result = generateModule(ast, {
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+      const errors = hardErrors(result);
+      expect(errors, `${entry}\n${errors.map((error) => error.message).join("\n")}`).toEqual([]);
+      definedFunctions += result.module.functions.length;
+      const entries = result.programAbi!.abi.entries();
+      genericRows += entries.filter((candidate) => candidate.id.includes("retained-module-function")).length;
+      dateRows += entries.filter((candidate) => candidate.id.includes(`:${DATE_CIVIL_SUPPORT_ROLE}:`)).length;
+      vecRows += entries.filter((candidate) => candidate.id.includes(":vec-host-bridge:")).length;
+      for (const outcome of result.irOutcomes ?? []) {
+        terminalUnits++;
+        if (outcome.kind === "emitted") emitted++;
+        if (outcome.kind === "unsupported") unsupported++;
+        if (outcome.kind === "invariant") invariants++;
+        if (outcome.legacyBodyEmitted) legacyBodies++;
+        if (outcome.irBodyEmitted) irBodies++;
+      }
+    }
+
+    expect({ definedFunctions, dateRows }).toEqual({ definedFunctions: 166, dateRows: 1 });
+    // C30 is an independent ownership slice. Composed with its 24 vec rows,
+    // C31+C32 retain 50 generic rows; without C30 this stack retains 74.
+    expect([0, 24]).toContain(vecRows);
+    expect(genericRows).toBe(74 - vecRows);
+    expect({ terminalUnits, emitted, unsupported, invariants, legacyBodies, irBodies }).toEqual({
+      terminalUnits: 37,
+      emitted: 30,
+      unsupported: 7,
+      invariants: 0,
+      legacyBodies: 37,
+      irBodies: 30,
+    });
+  });
+});

--- a/tests/issue-3520-date-civil-support-abi.test.ts
+++ b/tests/issue-3520-date-civil-support-abi.test.ts
@@ -51,6 +51,35 @@ function entrySourceRecord(source = CALENDAR_SOURCE) {
   }).sources.find((candidate) => candidate.kind === "entry")!;
 }
 
+function collisionSource(kind: "bigint" | "number"): string {
+  const literal = kind === "bigint" ? "5n" : "5";
+  const delta = kind === "bigint" ? "17n" : "17";
+  return `
+    function ${DATE_CIVIL_HELPER}(days: ${kind}): ${kind} {
+      return days + ${delta};
+    }
+    export function userProbe(): ${kind} {
+      return ${DATE_CIVIL_HELPER}(${literal});
+    }
+    export function dateProbe(): number {
+      const value = new Date(0);
+      return value.getUTCFullYear() * 10000 + (value.getUTCMonth() + 1) * 100 + value.getUTCDate();
+    }
+  `;
+}
+
+async function compileCollision(
+  kind: "bigint" | "number",
+  trackIrOutcomes: boolean,
+): Promise<Awaited<ReturnType<typeof compile>>> {
+  return compile(collisionSource(kind), {
+    fileName: `issue-3520-date-civil-${kind}-collision.ts`,
+    experimentalIR: true,
+    trackIrOutcomes,
+    target: "standalone",
+  });
+}
+
 describe("#3520 C32 date civil support Program ABI ownership", () => {
   it("publishes one exact entry-source owner with no duplicate generic owner", () => {
     const ast = analyzeSource(CALENDAR_SOURCE, "issue-3520-date-civil-support.ts");
@@ -146,45 +175,47 @@ describe("#3520 C32 date civil support Program ABI ownership", () => {
     expect(module.functions[0]).toBe(helper);
   });
 
-  it("does not claim a same-named pre-existing allocator as Date support", () => {
-    const sourceFile = ts.createSourceFile(
-      "/repo/entry.ts",
-      "export function entry(): number { return 1; }",
-      ts.ScriptTarget.Latest,
-      true,
-      ts.ScriptKind.TS,
-    );
-    const inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
-    const entrySource = inventory.sources.find((source) => source.kind === "entry")!;
-    const module = createEmptyModule();
-    module.types.push({ kind: "func", params: [{ kind: "i64" }], results: [{ kind: "i64" }] });
-    const occupied = {
-      name: DATE_CIVIL_HELPER,
-      typeIdx: 0,
-      locals: [],
-      body: [{ op: "local.get" as const, index: 0 }],
-      exported: false,
-    };
-    module.functions.push(occupied);
-    const session = new ProgramAbiSession(inventory, module);
-    const ctx = createCodegenContext(module, {} as ts.TypeChecker, undefined, session);
-    ctx.funcMap.set(DATE_CIVIL_HELPER, 0);
+  it.each(["bigint", "number"] as const)(
+    "preserves Date and same-named user %s functions in tracked and untracked lanes",
+    async (kind) => {
+      const untracked = await compileCollision(kind, false);
+      const tracked = await compileCollision(kind, true);
+      for (const result of [untracked, tracked]) {
+        expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(result.imports).toEqual([]);
+        expect(WebAssembly.validate(result.binary)).toBe(true);
+        const { instance } = await WebAssembly.instantiate(result.binary, {});
+        const exports = instance.exports as {
+          userProbe: () => bigint | number;
+          dateProbe: () => number;
+        };
+        expect(exports.userProbe()).toBe(kind === "bigint" ? 22n : 22);
+        expect(exports.dateProbe()).toBe(19700101);
+      }
+      expect(tracked.binary).toEqual(untracked.binary);
 
-    expect(ensureDateCivilHelper(ctx)).toBe(0);
-    const dateId = createIrBindingId({
-      ownerId: entrySource.id,
-      domain: "support",
-      role: DATE_CIVIL_SUPPORT_ROLE,
-      ordinal: DATE_CIVIL_SUPPORT_ORDINAL,
-    });
-    expect(session.getDraft(dateId)).toBeUndefined();
-    eliminateDeadLayoutAndPlanProgramAbi(ctx);
-    ctx.indexSpaceFrozen = true;
-    const entries = session.publish(module).abi.entries();
-    expect(entries.some((entry) => entry.id === dateId)).toBe(false);
-    expect(entries.filter((entry) => entry.displayName === DATE_CIVIL_HELPER)).toHaveLength(1);
-    expect(session.locatorBindingId(occupied)).toContain("retained-module-function");
-  });
+      const ast = analyzeSource(collisionSource(kind), `issue-3520-date-civil-${kind}-collision.ts`);
+      const generated = generateModule(ast, {
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        standalone: true,
+      });
+      expect(
+        hardErrors(generated),
+        hardErrors(generated)
+          .map((error) => error.message)
+          .join("\n"),
+      ).toEqual([]);
+      const entries = generated.programAbi!.abi.entries();
+      const dateEntries = entries.filter((entry) => entry.id.includes(`:${DATE_CIVIL_SUPPORT_ROLE}:`));
+      expect(dateEntries).toHaveLength(1);
+      expect(dateEntries[0]).toMatchObject({
+        displayName: DATE_CIVIL_HELPER,
+        intent: { kind: "callable", origin: "support" },
+      });
+      expect(entries.filter((entry) => entry.displayName === DATE_CIVIL_HELPER)).toHaveLength(2);
+    },
+  );
 
   it("keeps tracked and untracked Date modules byte-identical", async () => {
     const options = {

--- a/tests/issue-3520-vec-support-callable-abi.test.ts
+++ b/tests/issue-3520-vec-support-callable-abi.test.ts
@@ -399,7 +399,7 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
     }
   });
 
-  it("keeps tracked output and IR routing stable while the five-entry census moves only the 24 vec rows", async () => {
+  it("keeps tracked output and IR routing stable across the composed five-entry census", async () => {
     const untracked = await compile(ARRAY_SOURCE, {
       fileName: "vec-tracking-parity.ts",
       experimentalIR: true,
@@ -425,6 +425,7 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
     let genericRows = 0;
     let vecRows = 0;
     let closureRows = 0;
+    let dateRows = 0;
     for (const entry of SINGLE_HOST_ENTRIES) {
       const source = readFileSync(resolve(entry), "utf8");
       const ast = analyzeSource(source, entry);
@@ -439,12 +440,14 @@ describe("#3520 vec host-bridge Program ABI ownership", () => {
       genericRows += entries.filter((candidate) => candidate.id.includes("retained-module-function")).length;
       vecRows += entries.filter((candidate) => candidate.id.includes(VEC_HOST_BRIDGE_ROLE)).length;
       closureRows += entries.filter((candidate) => candidate.id.includes(":closure-host-bridge:")).length;
+      dateRows += entries.filter((candidate) => candidate.id.includes(":date-civil-support:")).length;
     }
-    expect({ definedFunctions, genericRows, vecRows, closureRows }).toEqual({
+    expect({ definedFunctions, genericRows, vecRows, closureRows, dateRows }).toEqual({
       definedFunctions: 166,
-      genericRows: 51,
+      genericRows: 51 - dateRows,
       vecRows: 24,
       closureRows: 26,
+      dateRows: 1,
     });
   });
 });


### PR DESCRIPTION
## Summary

- assign `__date_civil_from_days` one canonical entry-source `date-civil-support` Program ABI role
- preserve the exact helper object and final slot across late imports and DCE remapping
- isolate compiler-owned Date lowering from matching or mismatched same-named user functions
- retain tracked/untracked byte parity and leap-day behavior
- make the landed vec/closure census assertions composable with the one Date row

This moves one retained helper row out of the generic bucket: the composed five-entry census is now `50 generic + 24 vec + 26 closure + 1 Date`. Terminal routing is unchanged at `37 total / 30 IR-emitted / 7 Unsupported / 0 Invariants`; this structural ownership slice therefore adds no terminal adoption by itself.

## Validation

- C30 + C31 + C32 + calendar residual suites — 55/55
- focused C32 suite — 7/7
- tracked/untracked byte parity and matching/mismatched source-name collision probes
- `pnpm run typecheck`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- oracle, coercion, numeric-local parity, formatting, lint, and issue-integrity pre-push gates

Tracked in `plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md`.
