### PR TITLE
refactor(ir): seal prepared component ABI scopes

### DIFF
--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -308,7 +308,9 @@ rather than treating a terminal row as the whole component:
 - scoped type evidence pins the full transitive graph reachable from type and
   class cells plus callable/global reference contracts. An exact index
   permutation must preserve each reachable payload definition, including
-  fields, mutability, and supertype relationships, under the same remap;
+  fields, mutability, and supertype relationships, under the same remap.
+  `StructTypeDef.superTypeIdx === -1` remains the open-root sentinel rather
+  than being traversed or rewritten as a concrete type index;
 - semantic-preserving type reorders refresh alias contracts through their
   canonical callable/global owner. Aliases intentionally carrying no sidecar
   of their own therefore remain valid without weakening the exact graph

--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -240,6 +240,45 @@ identity/signatures, and allocation provenance, and
 `check:ir-optimization-retirement` remains fail-closed until its committed
 parity evidence is retirement-ready.
 
+## Scoped prepared-component ABI prerequisite (2026-07-30)
+
+The next file-disjoint prerequisite adds a scoped seal to
+`ProgramAbiSession`; it does not activate production routing. A one-shot
+component transaction starts from exact terminal `IrUnitId`s, automatically
+closes over source and pass-derived callables plus existing aliases/exports,
+and accepts only explicitly discovered external/support binding IDs.
+
+Successful scope sealing proves, before unrelated direct-body planning:
+
+- source/derived callable and support identities are complete;
+- callable/global structured type contracts match their planned signatures;
+- required slots have an observed structural reservation and an exact
+  allocator locator already present in the module;
+- later derived units, aliases, exports, unit-owned support, type-contract
+  additions, or locator replacement cannot extend or mutate the sealed
+  component.
+
+The whole `ProgramAbiSession` intentionally remains in planning state, so
+unrelated direct bindings and support can still be registered. Whole-program
+seal and final publication rebuild each scoped ABI, compare every materialized
+contract while ignoring only whole-program dense-order renumbering, and fail
+closed on missing/drifted identities, contracts, reservations, or locators.
+Explicit type-layout remaps advance the scoped structured contracts through the
+same validated remap rather than hiding an unreported mutation.
+
+Focused evidence in
+`tests/issue-3521-scoped-prepared-abi-seal.test.ts` covers a non-empty source
+callable plus monomorphized clone, alias, export, and support closure; continued
+unrelated planning; missing locator/reservation rejection; prepared-owned late
+support/derived rejection; signature drift at publication; exact final
+reconciliation; and transaction abort/retry without partial scope publication.
+
+This prerequisite changes neither `compileDeclarations` nor
+`compileIrPathFunctions`. Production adoption and legacy-body reduction remain
+exactly **0**, and all inline-small, monomorphization, allocation-provenance,
+and retirement-parity obligations remain assigned to the later prepare/emit
+wiring slice.
+
 ## File ownership and locks
 
 Lock `src/codegen/index.ts`, `src/codegen/declarations.ts`,

--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -292,6 +292,34 @@ Adversarial review further pins the boundary:
 - malformed/custom binding IDs, alias cycles, duplicate dependency discovery,
   and removal of a pinned allocator object all reject before publication.
 
+The follow-up ownership hardening uses the complete structural inventory
+rather than treating a terminal row as the whole component:
+
+- every inventoried nested function, function expression, arrow, object
+  method/accessor, and class-member/support unit whose terminal ownership
+  resolves to a prepared root is part of that root's sealed unit denominator;
+  any existing callable is closed into the scope, while later callable or
+  support planning for those units fails closed;
+- every binding in the final alias/export/support closure retains the terminal
+  owner resolved from its canonical encoded owner. Class owners resolve
+  transitively through `IrClassRecord.lexicalOwnerId`, so a binding beneath a
+  different terminal cannot be auto-claimed through an alias/export edge or
+  explicitly requested as support;
+- scoped type evidence pins the full transitive graph reachable from type and
+  class cells plus callable/global reference contracts. An exact index
+  permutation must preserve each reachable payload definition, including
+  fields, mutability, and supertype relationships, under the same remap;
+- semantic-preserving type reorders refresh alias contracts through their
+  canonical callable/global owner. Aliases intentionally carrying no sidecar
+  of their own therefore remain valid without weakening the exact graph
+  comparison.
+
+Focused coverage includes all inventoried nested callable kinds in the R2
+component, late nested planning rejection, cross-component nested-unit and
+nested-class dependency rejection, disjoint nested-class scopes,
+foreign-owned alias/export closure rejection, referenced payload-shape swap
+rejection, and non-vacuous callable/global inherited-alias reorder success.
+
 This prerequisite changes neither `compileDeclarations` nor
 `compileIrPathFunctions`. Production adoption and legacy-body reduction remain
 exactly **0**, and all inline-small, monomorphization, allocation-provenance,

--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -273,6 +273,25 @@ unrelated planning; missing locator/reservation rejection; prepared-owned late
 support/derived rejection; signature drift at publication; exact final
 reconciliation; and transaction abort/retry without partial scope publication.
 
+Adversarial review further pins the boundary:
+
+- every registered lifted/monomorphized executable beneath a prepared terminal
+  must already own exactly one source-callable reservation, structured
+  contract, structural reference, and locator;
+- explicitly requested bindings are limited to canonical external/support
+  dependencies, cannot import another terminal's source callable/global, and
+  cannot overlap a previously sealed component;
+- type/class cells retain an immutable canonical layout contract. Direct cell
+  remaps and in-place layout mutation fail, while the complete validated
+  `applyTypeLayoutRemap` event advances the pinned layout and callable/global
+  structured contracts together only when each replacement is canonically
+  equal to the prior layout under that exact index remap;
+- imported callable/global locators are re-read for exact host module/name,
+  callable signature, global storage type, and mutability during
+  reconciliation, so mutating the same import object cannot bypass the seal;
+- malformed/custom binding IDs, alias cycles, duplicate dependency discovery,
+  and removal of a pinned allocator object all reject before publication.
+
 This prerequisite changes neither `compileDeclarations` nor
 `compileIrPathFunctions`. Production adoption and legacy-body reduction remain
 exactly **0**, and all inline-small, monomorphization, allocation-provenance,

--- a/src/codegen/program-abi-session.ts
+++ b/src/codegen/program-abi-session.ts
@@ -614,7 +614,7 @@ function remapProgramAbiTypeDef(
           ...field,
           type: remapProgramAbiValType(field.type, targetsByOldIndex, bindingId),
         })),
-        ...(type.superTypeIdx === undefined
+        ...(type.superTypeIdx === undefined || type.superTypeIdx < 0
           ? {}
           : { superTypeIdx: remapProgramAbiTypeIndex(type.superTypeIdx, targetsByOldIndex, bindingId) }),
       };
@@ -649,7 +649,7 @@ function collectProgramAbiTypeReferences(type: TypeDef, references: Set<number>)
       return;
     case "struct":
       type.fields.forEach((field) => addValue(field.type));
-      if (type.superTypeIdx !== undefined) references.add(type.superTypeIdx);
+      if (type.superTypeIdx !== undefined && type.superTypeIdx >= 0) references.add(type.superTypeIdx);
       return;
     case "array":
       addValue(type.element);

--- a/src/codegen/program-abi-session.ts
+++ b/src/codegen/program-abi-session.ts
@@ -464,6 +464,12 @@ export class PreparedProgramAbiScopeTransaction {
 
   includeBinding(id: IrBindingId): void {
     this.#assertOpen("include an ABI binding");
+    if (this.#bindingIds.has(id)) {
+      throw new ProgramAbiInvariantError(
+        "duplicate-session-draft",
+        `prepared ABI scope ${this.scopeId} included binding ${id} more than once`,
+      );
+    }
     this.#bindingIds.add(id);
   }
 
@@ -500,6 +506,7 @@ type SessionState = "planning" | "sealing" | "sealed" | "binding" | "published" 
 interface PreparedProgramAbiLocatorSnapshot {
   readonly kind: ProgramAbiSlotLocator["kind"];
   readonly object: object;
+  readonly hostLinkage?: string;
 }
 
 interface PreparedProgramAbiScopeRecord {
@@ -514,6 +521,7 @@ interface PreparedProgramAbiScopeRecord {
   readonly structuralReferences: ReadonlyMap<IrBindingId, string>;
   readonly callableTypeContracts: Map<IrBindingId, ProgramAbiCallableTypeContract>;
   readonly globalTypeContracts: Map<IrBindingId, ProgramAbiGlobalTypeContract>;
+  readonly typeLayouts: Map<IrBindingId, string>;
   readonly view: SealedPreparedProgramAbiScope;
 }
 
@@ -561,6 +569,70 @@ function remapProgramAbiValType(
     );
   }
   return Object.freeze({ ...type, typeIdx: target }) as ValType;
+}
+
+function remapProgramAbiTypeIndex(
+  typeIdx: number,
+  targetsByOldIndex: readonly (number | null)[],
+  bindingId: IrBindingId,
+): number {
+  if (!Number.isSafeInteger(typeIdx) || typeIdx < 0 || typeIdx >= targetsByOldIndex.length) {
+    throw new ProgramAbiInvariantError(
+      "type-remap-mismatch",
+      `ABI binding ${bindingId} references type index ${typeIdx} outside the old type layout`,
+    );
+  }
+  const target = targetsByOldIndex[typeIdx];
+  if (target === null || target === undefined) {
+    throw new ProgramAbiInvariantError(
+      "type-remap-mismatch",
+      `ABI binding ${bindingId} references eliminated type index ${typeIdx}`,
+    );
+  }
+  return target;
+}
+
+function remapProgramAbiTypeDef(
+  type: TypeDef,
+  targetsByOldIndex: readonly (number | null)[],
+  bindingId: IrBindingId,
+): TypeDef {
+  switch (type.kind) {
+    case "func":
+      return {
+        ...type,
+        params: type.params.map((value) => remapProgramAbiValType(value, targetsByOldIndex, bindingId)),
+        results: type.results.map((value) => remapProgramAbiValType(value, targetsByOldIndex, bindingId)),
+      };
+    case "struct":
+      return {
+        ...type,
+        fields: type.fields.map((field) => ({
+          ...field,
+          type: remapProgramAbiValType(field.type, targetsByOldIndex, bindingId),
+        })),
+        ...(type.superTypeIdx === undefined
+          ? {}
+          : { superTypeIdx: remapProgramAbiTypeIndex(type.superTypeIdx, targetsByOldIndex, bindingId) }),
+      };
+    case "array":
+      return {
+        ...type,
+        element: remapProgramAbiValType(type.element, targetsByOldIndex, bindingId),
+      };
+    case "rec":
+      return {
+        ...type,
+        types: type.types.map((nested) => remapProgramAbiTypeDef(nested, targetsByOldIndex, bindingId)),
+      };
+    case "sub":
+      return {
+        ...type,
+        superType:
+          type.superType === null ? null : remapProgramAbiTypeIndex(type.superType, targetsByOldIndex, bindingId),
+        type: remapProgramAbiTypeDef(type.type, targetsByOldIndex, bindingId) as typeof type.type,
+      };
+  }
 }
 
 function locatorObject(locator: ProgramAbiSlotLocator): object {
@@ -732,7 +804,9 @@ function createSealedProgramAbiPlanView(
  */
 export class ProgramAbiSession {
   private readonly sourceOrderById = new Map<IrSourceId, number>();
+  private readonly inventorySourceIds = new Set<IrSourceId>();
   private readonly inventoryUnitIds = new Set<IrUnitId>();
+  private readonly inventoryClassIds = new Set<IrClassId>();
   private readonly preparedFreeFunctionUnitIds = new Set<IrUnitId>();
   private readonly drafts = new Map<IrBindingId, ProgramAbiDraft>();
   private readonly draftOrderOwners = new Map<string, IrBindingId>();
@@ -748,6 +822,7 @@ export class ProgramAbiSession {
   private readonly preparedScopeByUnitId = new Map<IrUnitId, string>();
   private readonly preparedScopeByBindingId = new Map<IrBindingId, string>();
   private readonly openPreparedScopeIds = new Set<string>();
+  private applyingPreparedTypeLayoutRemap = false;
   private state: SessionState = "planning";
   private sealedDrafts: readonly ProgramAbiDraft[] | undefined;
   private sealedPlanView: SealedProgramAbiPlan | undefined;
@@ -758,8 +833,12 @@ export class ProgramAbiSession {
     readonly inventory: IrUnitInventory,
     readonly module: WasmModule,
   ) {
-    for (const source of inventory.sources) this.sourceOrderById.set(source.id, source.order);
+    for (const source of inventory.sources) {
+      this.sourceOrderById.set(source.id, source.order);
+      this.inventorySourceIds.add(source.id);
+    }
     for (const unit of inventory.allUnits) this.inventoryUnitIds.add(unit.id);
+    for (const classRecord of inventory.classes) this.inventoryClassIds.add(classRecord.id);
     for (const unit of inventory.terminalUnits) {
       if (unit.kind === "top-level-function") this.preparedFreeFunctionUnitIds.add(unit.id);
     }
@@ -1119,6 +1198,13 @@ export class ProgramAbiSession {
           "allocator type object does not belong to this ABI session",
         );
       }
+      const preparedScopeId = this.preparedScopeForTypeCell(cell);
+      if (preparedScopeId !== undefined && !this.applyingPreparedTypeLayoutRemap) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `prepared type cell belongs to sealed scope ${preparedScopeId} and may change only through an exact layout remap`,
+        );
+      }
       if (cell.current !== previous) {
         throw new ProgramAbiInvariantError(
           "type-remap-mismatch",
@@ -1164,6 +1250,7 @@ export class ProgramAbiSession {
         "type layout remap does not describe the session module's exact current type population",
       );
     }
+    this.assertPreparedTypeLayoutsCurrent();
 
     const targetOwners = new Map<number, number>();
     for (let oldIndex = 0; oldIndex < targetsByOldIndex.length; oldIndex++) {
@@ -1198,6 +1285,7 @@ export class ProgramAbiSession {
         );
       }
     }
+    this.assertPreparedTypeLayoutRemap(previousTypes, nextTypes, targetsByOldIndex);
 
     const remappedCallableContracts = new Map<IrBindingId, ProgramAbiCallableTypeContract>();
     for (const [id, contract] of this.callableTypeContracts) {
@@ -1235,7 +1323,12 @@ export class ProgramAbiSession {
       }
       objectRemaps.set(previous, replacement);
     }
-    this.remapTypeObjects([...objectRemaps].filter(([previous, replacement]) => previous !== replacement));
+    this.applyingPreparedTypeLayoutRemap = true;
+    try {
+      this.remapTypeObjects([...objectRemaps].filter(([previous, replacement]) => previous !== replacement));
+    } finally {
+      this.applyingPreparedTypeLayoutRemap = false;
+    }
 
     this.callableTypeContracts.clear();
     for (const [id, contract] of remappedCallableContracts) this.callableTypeContracts.set(id, contract);
@@ -1253,6 +1346,12 @@ export class ProgramAbiSession {
             id,
             Object.freeze({ type: cloneProgramAbiValType(contract.type), mutable: contract.mutable }),
           );
+        }
+      }
+      for (const id of scope.typeLayouts.keys()) {
+        const locator = this.locators.get(id);
+        if (locator?.kind === "type-cell" && locator.cell.current !== null) {
+          scope.typeLayouts.set(id, canonicalProgramAbiTypeDef(locator.cell.current));
         }
       }
     }
@@ -1505,27 +1604,63 @@ export class ProgramAbiSession {
       }
     }
     for (const id of requestedBindingIds) {
-      if (!this.drafts.has(id)) {
+      const draft = this.drafts.get(id);
+      if (!draft) {
         throw new ProgramAbiInvariantError(
           "unknown-binding",
           `prepared ABI scope ${scopeId} requests unplanned binding ${id}`,
         );
       }
+      this.assertPreparedDependencyRequest(scopeId, new Set(terminalUnitIds), draft);
     }
 
     const derivedUnits = this.collectPreparedDerivedUnits(new Set(terminalUnitIds));
     const unitIds = new Set<IrUnitId>(terminalUnitIds);
     for (const record of derivedUnits) unitIds.add(record.id);
     const bindingIds = this.collectPreparedBindingClosure(unitIds, requestedBindingIds);
-    for (const terminalUnitId of terminalUnitIds) {
-      const hasCallable = [...bindingIds].some((id) => {
+    for (const unitId of unitIds) {
+      const callableReservations = [...bindingIds].filter((id) => {
         const draft = this.drafts.get(id)!;
-        return draft.intent.kind === "callable" && draft.intent.unitId === terminalUnitId;
+        return (
+          draft.intent.kind === "callable" &&
+          draft.intent.origin === "source" &&
+          draft.intent.unitId === unitId &&
+          draft.slotPolicy === "required" &&
+          draft.slotSpace === "function"
+        );
       });
-      if (!hasCallable) {
+      if (callableReservations.length !== 1) {
         throw new ProgramAbiInvariantError(
-          "missing-source-unit",
-          `prepared ABI scope ${scopeId} has no callable reservation for terminal ${terminalUnitId}`,
+          callableReservations.length === 0 ? "missing-source-unit" : "duplicate-session-draft",
+          `prepared ABI scope ${scopeId} requires exactly one callable reservation for executable unit ${unitId}; found ${callableReservations.length}`,
+        );
+      }
+    }
+    for (const id of bindingIds) {
+      const draft = this.drafts.get(id)!;
+      this.assertCanonicalPreparedBindingId(draft);
+      if (
+        draft.intent.kind === "callable" &&
+        draft.intent.origin === "source" &&
+        draft.intent.unitId !== undefined &&
+        !unitIds.has(draft.intent.unitId)
+      ) {
+        throw new ProgramAbiInvariantError(
+          "invalid-callable-provenance",
+          `prepared ABI scope ${scopeId} reaches source callable ${id} owned by another component`,
+        );
+      }
+      if (draft.intent.kind === "global" && draft.intent.origin === "source") {
+        throw new ProgramAbiInvariantError(
+          "invalid-callable-provenance",
+          `prepared ABI scope ${scopeId} reaches source global ${id} through a requested dependency`,
+        );
+      }
+      const previousScope = this.preparedScopeByBindingId.get(id);
+      if (previousScope !== undefined) {
+        throw new ProgramAbiInvariantError(
+          "duplicate-session-draft",
+          `prepared ABI binding ${id} overlaps sealed scope ${previousScope}`,
         );
       }
     }
@@ -1538,6 +1673,7 @@ export class ProgramAbiSession {
     const structuralReferences = new Map<IrBindingId, string>();
     const callableTypeContracts = new Map<IrBindingId, ProgramAbiCallableTypeContract>();
     const globalTypeContracts = new Map<IrBindingId, ProgramAbiGlobalTypeContract>();
+    const typeLayouts = new Map<IrBindingId, string>();
 
     for (const draft of drafts) {
       if (draft.intent.kind === "callable") {
@@ -1578,7 +1714,24 @@ export class ProgramAbiSession {
         );
       }
       this.resolveLocator(this.module, draft.id, locator);
-      locatorSnapshots.set(draft.id, Object.freeze({ kind: locator.kind, object: locatorObject(locator) }));
+      if (locator.kind === "type-cell") {
+        if (locator.cell.current === null) {
+          throw new ProgramAbiInvariantError(
+            "eliminated-required-locator",
+            `prepared type/class binding ${draft.id} has an eliminated allocator cell at scope seal`,
+          );
+        }
+        typeLayouts.set(draft.id, canonicalProgramAbiTypeDef(locator.cell.current));
+      }
+      const hostLinkage = this.preparedHostLinkage(locator);
+      locatorSnapshots.set(
+        draft.id,
+        Object.freeze({
+          kind: locator.kind,
+          object: locatorObject(locator),
+          ...(hostLinkage === undefined ? {} : { hostLinkage }),
+        }),
+      );
       structuralReferences.set(draft.id, structuralReference);
     }
 
@@ -1627,6 +1780,7 @@ export class ProgramAbiSession {
       structuralReferences: readonlyMap(structuralReferences),
       callableTypeContracts,
       globalTypeContracts,
+      typeLayouts,
       view,
     };
     recordHolder.value = record;
@@ -1635,11 +1789,7 @@ export class ProgramAbiSession {
     // every identity, contract, reservation, and locator is known-good.
     this.preparedScopes.set(scopeId, record);
     for (const unitId of unitIds) this.preparedScopeByUnitId.set(unitId, scopeId);
-    for (const bindingId of exactBindingIds) {
-      if (!this.preparedScopeByBindingId.has(bindingId)) {
-        this.preparedScopeByBindingId.set(bindingId, scopeId);
-      }
-    }
+    for (const bindingId of exactBindingIds) this.preparedScopeByBindingId.set(bindingId, scopeId);
     return view;
   }
 
@@ -1705,6 +1855,216 @@ export class ProgramAbiSession {
       }
     }
     return included;
+  }
+
+  private assertPreparedDependencyRequest(
+    scopeId: string,
+    terminalUnitIds: ReadonlySet<IrUnitId>,
+    draft: ProgramAbiDraft,
+  ): void {
+    const ownerId = this.assertCanonicalPreparedBindingId(draft);
+    if (
+      draft.intent.kind === "export" ||
+      (draft.intent.kind === "callable" && draft.intent.origin === "source") ||
+      (draft.intent.kind === "global" && draft.intent.origin === "source")
+    ) {
+      throw new ProgramAbiInvariantError(
+        "invalid-callable-provenance",
+        `prepared ABI scope ${scopeId} may request only external/support dependencies, not ${draft.intent.kind} binding ${draft.id}`,
+      );
+    }
+    if (draft.intent.kind === "callable" && draft.intent.unitId) {
+      const terminalOwnerId = this.terminalOwnerForKnownUnit(draft.intent.unitId);
+      if (terminalOwnerId !== null && !terminalUnitIds.has(terminalOwnerId)) {
+        throw new ProgramAbiInvariantError(
+          "invalid-callable-provenance",
+          `prepared ABI scope ${scopeId} requested callable ${draft.id} from terminal ${terminalOwnerId}`,
+        );
+      }
+    }
+    const ownerTerminalId = this.terminalOwnerForKnownUnit(ownerId as IrUnitId);
+    if (ownerTerminalId !== null && !terminalUnitIds.has(ownerTerminalId)) {
+      throw new ProgramAbiInvariantError(
+        "invalid-callable-provenance",
+        `prepared ABI scope ${scopeId} requested dependency ${draft.id} owned by terminal ${ownerTerminalId}`,
+      );
+    }
+  }
+
+  private assertCanonicalPreparedBindingId(draft: ProgramAbiDraft): IrSourceId | IrUnitId | IrClassId {
+    const parts = String(draft.id).split(":");
+    if (parts.length !== 6 || parts[0] !== "ir-binding" || parts[1] !== "v1") {
+      throw new ProgramAbiInvariantError(
+        "invalid-binding-reference",
+        `prepared ABI draft ${draft.id} does not use the canonical binding identity format`,
+      );
+    }
+    const domain = parts[2]!;
+    const encodedOwner = parts[3]!;
+    const encodedRole = parts[4]!;
+    const ordinal = parts[5]!;
+    let ownerId: string;
+    let role: string;
+    try {
+      ownerId = decodeURIComponent(encodedOwner);
+      role = decodeURIComponent(encodedRole);
+    } catch {
+      throw new ProgramAbiInvariantError(
+        "invalid-binding-reference",
+        `prepared ABI draft ${draft.id} contains invalid encoded identity components`,
+      );
+    }
+    const expectedDomain =
+      draft.intent.kind === "callable"
+        ? draft.intent.origin === "support"
+          ? "support"
+          : "callable"
+        : draft.intent.kind;
+    const ordinalValue = Number(ordinal);
+    if (
+      domain !== expectedDomain ||
+      role.length === 0 ||
+      encodeURIComponent(ownerId) !== encodedOwner ||
+      encodeURIComponent(role) !== encodedRole ||
+      !/^\d{16}$/.test(ordinal) ||
+      !Number.isSafeInteger(ordinalValue) ||
+      ordinalValue < 0 ||
+      ordinalValue.toString(10).padStart(16, "0") !== ordinal
+    ) {
+      throw new ProgramAbiInvariantError(
+        "invalid-binding-reference",
+        `prepared ABI draft ${draft.id} is not canonical for its ${draft.intent.kind} intent`,
+      );
+    }
+    const knownOwner =
+      this.inventorySourceIds.has(ownerId as IrSourceId) ||
+      this.inventoryUnitIds.has(ownerId as IrUnitId) ||
+      this.derivedUnits.has(ownerId as IrUnitId) ||
+      this.inventoryClassIds.has(ownerId as IrClassId);
+    if (!knownOwner) {
+      throw new ProgramAbiInvariantError(
+        "invalid-binding-reference",
+        `prepared ABI draft ${draft.id} has unknown structural owner ${ownerId}`,
+      );
+    }
+    const provenanceOwner =
+      draft.intent.kind === "callable"
+        ? (draft.intent.unitId ?? draft.intent.classId ?? draft.intent.sourceId)
+        : draft.intent.kind === "class"
+          ? draft.intent.classId
+          : undefined;
+    if (provenanceOwner !== undefined && provenanceOwner !== ownerId) {
+      throw new ProgramAbiInvariantError(
+        "invalid-binding-reference",
+        `prepared ABI draft ${draft.id} owner disagrees with its callable/class provenance`,
+      );
+    }
+    return ownerId as IrSourceId | IrUnitId | IrClassId;
+  }
+
+  private terminalOwnerForKnownUnit(id: IrUnitId): IrUnitId | null {
+    const inventoryUnit = this.inventory.allUnits.find((unit) => unit.id === id);
+    if (inventoryUnit) return inventoryUnit.terminalOwnerId;
+    return this.derivedUnits.get(id)?.terminalOwnerId ?? null;
+  }
+
+  private preparedHostLinkage(locator: ProgramAbiSlotLocator): string | undefined {
+    if (locator.kind === "import-function") {
+      if (locator.value.desc.kind !== "func") {
+        throw new ProgramAbiInvariantError(
+          "slot-locator-space-mismatch",
+          "prepared imported callable locator no longer has a function descriptor",
+        );
+      }
+      return JSON.stringify({
+        kind: "func",
+        module: locator.value.module,
+        name: locator.value.name,
+      });
+    }
+    if (locator.kind === "import-global") {
+      if (locator.value.desc.kind !== "global") {
+        throw new ProgramAbiInvariantError(
+          "slot-locator-space-mismatch",
+          "prepared imported global locator no longer has a global descriptor",
+        );
+      }
+      return JSON.stringify({
+        kind: "global",
+        module: locator.value.module,
+        name: locator.value.name,
+      });
+    }
+    return undefined;
+  }
+
+  private preparedScopeForTypeCell(cell: ProgramAbiTypeCell): string | undefined {
+    for (const scope of this.preparedScopes.values()) {
+      for (const locator of scope.locators.values()) {
+        if (locator.kind === "type-cell" && locator.object === cell) return scope.scopeId;
+      }
+    }
+    return undefined;
+  }
+
+  private assertPreparedTypeLayoutsCurrent(): void {
+    for (const scope of this.preparedScopes.values()) {
+      for (const [id, expectedLayout] of scope.typeLayouts) {
+        const locator = this.locators.get(id);
+        if (
+          locator?.kind !== "type-cell" ||
+          locator.cell.current === null ||
+          canonicalProgramAbiTypeDef(locator.cell.current) !== expectedLayout
+        ) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `prepared type/class layout ${id} drifted before exact layout remapping`,
+          );
+        }
+      }
+    }
+  }
+
+  private assertPreparedTypeLayoutRemap(
+    previousTypes: readonly TypeDef[],
+    nextTypes: readonly TypeDef[],
+    targetsByOldIndex: readonly (number | null)[],
+  ): void {
+    for (const scope of this.preparedScopes.values()) {
+      for (const [id] of scope.typeLayouts) {
+        const locator = this.locators.get(id);
+        if (locator?.kind !== "type-cell" || locator.cell.current === null) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `prepared type/class layout ${id} has no live cell for exact remapping`,
+          );
+        }
+        const oldIndex = previousTypes.indexOf(locator.cell.current);
+        if (oldIndex < 0 || previousTypes.lastIndexOf(locator.cell.current) !== oldIndex) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `prepared type/class layout ${id} is not uniquely present in the old layout`,
+          );
+        }
+        const target = targetsByOldIndex[oldIndex];
+        if (target === null || target === undefined || !nextTypes[target]) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `prepared type/class layout ${id} was eliminated by an exact layout remap`,
+          );
+        }
+        const expectedLayout = canonicalProgramAbiTypeDef(
+          remapProgramAbiTypeDef(locator.cell.current, targetsByOldIndex, id),
+        );
+        const actualLayout = canonicalProgramAbiTypeDef(nextTypes[target]);
+        if (actualLayout !== expectedLayout) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `prepared type/class layout ${id} changed shape during an exact layout remap`,
+          );
+        }
+      }
+    }
   }
 
   private preparedScopeAffectedByDraft(draft: ProgramAbiDraft): string | undefined {
@@ -1783,6 +2143,40 @@ export class ProgramAbiSession {
             "locator-remap-mismatch",
             `allocator locator for ${id} drifted after prepared scope ${record.scopeId} sealed`,
           );
+        }
+        if (this.preparedHostLinkage(locator) !== expectedLocator.hostLinkage) {
+          throw new ProgramAbiInvariantError(
+            "binding-reference-mismatch",
+            `host linkage for ${id} drifted after prepared scope ${record.scopeId} sealed`,
+          );
+        }
+        const expectedLayout = record.typeLayouts.get(id);
+        if (
+          expectedLayout !== undefined &&
+          (locator.kind !== "type-cell" ||
+            locator.cell.current === null ||
+            canonicalProgramAbiTypeDef(locator.cell.current) !== expectedLayout)
+        ) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `type/class layout for ${id} drifted after prepared scope ${record.scopeId} sealed`,
+          );
+        }
+        const locatorCallable = record.callableTypeContracts.get(id);
+        if (locatorCallable) {
+          if (locator.kind === "defined-function") {
+            this.assertFunctionTypeContract(id, locator.value, locatorCallable, module);
+          } else if (locator.kind === "import-function" && locator.value.desc.kind === "func") {
+            this.assertFunctionTypeIndexContract(id, locator.value.desc.typeIdx, locatorCallable, module);
+          }
+        }
+        const locatorGlobal = record.globalTypeContracts.get(id);
+        if (locatorGlobal) {
+          if (locator.kind === "defined-global") {
+            this.assertGlobalTypeContract(id, locator.value.type, locator.value.mutable, locatorGlobal);
+          } else if (locator.kind === "import-global" && locator.value.desc.kind === "global") {
+            this.assertGlobalTypeContract(id, locator.value.desc.type, locator.value.desc.mutable, locatorGlobal);
+          }
         }
         this.resolveLocator(module, id, locator);
       }

--- a/src/codegen/program-abi-session.ts
+++ b/src/codegen/program-abi-session.ts
@@ -513,15 +513,18 @@ interface PreparedProgramAbiScopeRecord {
   readonly scopeId: string;
   readonly terminalUnitIds: readonly IrUnitId[];
   readonly unitIds: ReadonlySet<IrUnitId>;
+  readonly classIds: ReadonlySet<IrClassId>;
   readonly derivedUnits: readonly ProgramAbiDerivedUnitRecord[];
   readonly requestedBindingIds: ReadonlySet<IrBindingId>;
   readonly bindingIds: ReadonlySet<IrBindingId>;
+  readonly bindingTerminalOwnerIds: ReadonlyMap<IrBindingId, IrUnitId | null>;
   readonly drafts: ReadonlyMap<IrBindingId, ProgramAbiDraft>;
   readonly locators: ReadonlyMap<IrBindingId, PreparedProgramAbiLocatorSnapshot>;
   readonly structuralReferences: ReadonlyMap<IrBindingId, string>;
   readonly callableTypeContracts: Map<IrBindingId, ProgramAbiCallableTypeContract>;
   readonly globalTypeContracts: Map<IrBindingId, ProgramAbiGlobalTypeContract>;
   readonly typeLayouts: Map<IrBindingId, string>;
+  readonly reachableTypeLayouts: Map<number, string>;
   readonly view: SealedPreparedProgramAbiScope;
 }
 
@@ -635,6 +638,32 @@ function remapProgramAbiTypeDef(
   }
 }
 
+function collectProgramAbiTypeReferences(type: TypeDef, references: Set<number>): void {
+  const addValue = (value: ValType): void => {
+    if (value.kind === "ref" || value.kind === "ref_null") references.add(value.typeIdx);
+  };
+  switch (type.kind) {
+    case "func":
+      type.params.forEach(addValue);
+      type.results.forEach(addValue);
+      return;
+    case "struct":
+      type.fields.forEach((field) => addValue(field.type));
+      if (type.superTypeIdx !== undefined) references.add(type.superTypeIdx);
+      return;
+    case "array":
+      addValue(type.element);
+      return;
+    case "rec":
+      type.types.forEach((nested) => collectProgramAbiTypeReferences(nested, references));
+      return;
+    case "sub":
+      if (type.superType !== null) references.add(type.superType);
+      collectProgramAbiTypeReferences(type.type, references);
+      return;
+  }
+}
+
 function locatorObject(locator: ProgramAbiSlotLocator): object {
   return locator.kind === "type-cell" ? locator.cell : locator.value;
 }
@@ -735,14 +764,14 @@ function planEntriesEqualIgnoringDenseOrder(a: ProgramAbiPlanEntry, b: ProgramAb
   );
 }
 
-function bindingOwnerIsUnit(id: IrBindingId, unitId: IrUnitId): boolean {
+function bindingOwnerIs(id: IrBindingId, ownerId: IrUnitId | IrClassId): boolean {
   const prefix = "ir-binding:v1:";
   if (!id.startsWith(prefix)) return false;
   const domainEnd = id.indexOf(":", prefix.length);
   if (domainEnd < 0) return false;
   const ownerEnd = id.indexOf(":", domainEnd + 1);
   if (ownerEnd < 0) return false;
-  return id.slice(domainEnd + 1, ownerEnd) === encodeURIComponent(unitId);
+  return id.slice(domainEnd + 1, ownerEnd) === encodeURIComponent(ownerId);
 }
 
 function readonlySet<T>(values: Iterable<T>): ReadonlySet<T> {
@@ -820,6 +849,7 @@ export class ProgramAbiSession {
   private readonly globalTypeContracts = new Map<IrBindingId, ProgramAbiGlobalTypeContract>();
   private readonly preparedScopes = new Map<string, PreparedProgramAbiScopeRecord>();
   private readonly preparedScopeByUnitId = new Map<IrUnitId, string>();
+  private readonly preparedScopeByClassId = new Map<IrClassId, string>();
   private readonly preparedScopeByBindingId = new Map<IrBindingId, string>();
   private readonly openPreparedScopeIds = new Set<string>();
   private applyingPreparedTypeLayoutRemap = false;
@@ -1336,11 +1366,13 @@ export class ProgramAbiSession {
     for (const [id, contract] of remappedGlobalContracts) this.globalTypeContracts.set(id, contract);
     for (const scope of this.preparedScopes.values()) {
       for (const id of scope.callableTypeContracts.keys()) {
-        const contract = this.callableTypeContracts.get(id);
+        const draft = this.drafts.get(id);
+        const contract = draft === undefined ? undefined : this.callableTypeContractFor(draft);
         if (contract) scope.callableTypeContracts.set(id, cloneProgramAbiCallableTypeContract(contract));
       }
       for (const id of scope.globalTypeContracts.keys()) {
-        const contract = this.globalTypeContracts.get(id);
+        const draft = this.drafts.get(id);
+        const contract = draft === undefined ? undefined : this.globalTypeContractFor(draft);
         if (contract) {
           scope.globalTypeContracts.set(
             id,
@@ -1353,6 +1385,21 @@ export class ProgramAbiSession {
         if (locator?.kind === "type-cell" && locator.cell.current !== null) {
           scope.typeLayouts.set(id, canonicalProgramAbiTypeDef(locator.cell.current));
         }
+      }
+      const remappedReachableLayouts = new Map<number, string>();
+      for (const oldIndex of scope.reachableTypeLayouts.keys()) {
+        const target = targetsByOldIndex[oldIndex];
+        if (target === null || target === undefined || !nextTypes[target]) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `prepared type graph for scope ${scope.scopeId} was eliminated after validation`,
+          );
+        }
+        remappedReachableLayouts.set(target, canonicalProgramAbiTypeDef(nextTypes[target]!));
+      }
+      scope.reachableTypeLayouts.clear();
+      for (const [index, layoutValue] of remappedReachableLayouts) {
+        scope.reachableTypeLayouts.set(index, layoutValue);
       }
     }
   }
@@ -1614,9 +1661,28 @@ export class ProgramAbiSession {
       this.assertPreparedDependencyRequest(scopeId, new Set(terminalUnitIds), draft);
     }
 
-    const derivedUnits = this.collectPreparedDerivedUnits(new Set(terminalUnitIds));
-    const unitIds = new Set<IrUnitId>(terminalUnitIds);
-    for (const record of derivedUnits) unitIds.add(record.id);
+    const terminalUnitIdSet = new Set(terminalUnitIds);
+    const unitIds = this.collectPreparedUnitIds(terminalUnitIdSet);
+    const classIds = this.collectPreparedClassIds(terminalUnitIdSet);
+    for (const unitId of unitIds) {
+      const previous = this.preparedScopeByUnitId.get(unitId);
+      if (previous !== undefined) {
+        throw new ProgramAbiInvariantError(
+          "duplicate-session-draft",
+          `prepared ABI unit ${unitId} overlaps sealed scope ${previous}`,
+        );
+      }
+    }
+    for (const classId of classIds) {
+      const previous = this.preparedScopeByClassId.get(classId);
+      if (previous !== undefined) {
+        throw new ProgramAbiInvariantError(
+          "duplicate-session-draft",
+          `prepared ABI class ${classId} overlaps sealed scope ${previous}`,
+        );
+      }
+    }
+    const derivedUnits = this.collectPreparedDerivedUnits(unitIds);
     const bindingIds = this.collectPreparedBindingClosure(unitIds, requestedBindingIds);
     for (const unitId of unitIds) {
       const callableReservations = [...bindingIds].filter((id) => {
@@ -1629,16 +1695,29 @@ export class ProgramAbiSession {
           draft.slotSpace === "function"
         );
       });
-      if (callableReservations.length !== 1) {
+      const inventoryUnit = this.inventory.allUnits.find((unit) => unit.id === unitId);
+      const requiresCallable = inventoryUnit?.terminal === true || this.derivedUnits.has(unitId);
+      if (callableReservations.length > 1 || (requiresCallable && callableReservations.length !== 1)) {
         throw new ProgramAbiInvariantError(
           callableReservations.length === 0 ? "missing-source-unit" : "duplicate-session-draft",
-          `prepared ABI scope ${scopeId} requires exactly one callable reservation for executable unit ${unitId}; found ${callableReservations.length}`,
+          `prepared ABI scope ${scopeId} ${
+            requiresCallable ? "requires exactly one" : "allows at most one existing"
+          } callable reservation for executable unit ${unitId}; found ${callableReservations.length}`,
         );
       }
     }
+    const bindingTerminalOwnerIds = new Map<IrBindingId, IrUnitId | null>();
     for (const id of bindingIds) {
       const draft = this.drafts.get(id)!;
-      this.assertCanonicalPreparedBindingId(draft);
+      const ownerId = this.assertCanonicalPreparedBindingId(draft);
+      const ownerTerminalId = this.terminalOwnerForStructuralOwner(ownerId);
+      bindingTerminalOwnerIds.set(id, ownerTerminalId);
+      if (ownerTerminalId !== null && !terminalUnitIdSet.has(ownerTerminalId)) {
+        throw new ProgramAbiInvariantError(
+          "invalid-callable-provenance",
+          `prepared ABI scope ${scopeId} reaches binding ${id} structurally owned by terminal ${ownerTerminalId}`,
+        );
+      }
       if (
         draft.intent.kind === "callable" &&
         draft.intent.origin === "source" &&
@@ -1734,6 +1813,12 @@ export class ProgramAbiSession {
       );
       structuralReferences.set(draft.id, structuralReference);
     }
+    const reachableTypeLayouts = this.collectPreparedReachableTypeLayouts(
+      this.module,
+      typeLayouts.keys(),
+      callableTypeContracts,
+      globalTypeContracts,
+    );
 
     const exactTerminalUnitIds = Object.freeze([...terminalUnitIds]);
     const exactDerivedUnits = Object.freeze(derivedUnits.map((record) => Object.freeze({ ...record })));
@@ -1772,15 +1857,18 @@ export class ProgramAbiSession {
       scopeId,
       terminalUnitIds: exactTerminalUnitIds,
       unitIds: readonlySet(unitIds),
+      classIds: readonlySet(classIds),
       derivedUnits: exactDerivedUnits,
       requestedBindingIds: readonlySet(requestedBindingIds),
       bindingIds: readonlySet(exactBindingIds),
+      bindingTerminalOwnerIds: readonlyMap(bindingTerminalOwnerIds),
       drafts: readonlyMap(drafts.map((draft) => [draft.id, cloneDraft(draft)] as const)),
       locators: readonlyMap(locatorSnapshots),
       structuralReferences: readonlyMap(structuralReferences),
       callableTypeContracts,
       globalTypeContracts,
       typeLayouts,
+      reachableTypeLayouts,
       view,
     };
     recordHolder.value = record;
@@ -1789,13 +1877,18 @@ export class ProgramAbiSession {
     // every identity, contract, reservation, and locator is known-good.
     this.preparedScopes.set(scopeId, record);
     for (const unitId of unitIds) this.preparedScopeByUnitId.set(unitId, scopeId);
+    for (const classId of classIds) this.preparedScopeByClassId.set(classId, scopeId);
     for (const bindingId of exactBindingIds) this.preparedScopeByBindingId.set(bindingId, scopeId);
     return view;
   }
 
-  private collectPreparedDerivedUnits(terminalUnitIds: ReadonlySet<IrUnitId>): readonly ProgramAbiDerivedUnitRecord[] {
-    const included = new Set<IrUnitId>(terminalUnitIds);
-    const records: ProgramAbiDerivedUnitRecord[] = [];
+  private collectPreparedUnitIds(terminalUnitIds: ReadonlySet<IrUnitId>): Set<IrUnitId> {
+    const included = new Set<IrUnitId>();
+    for (const unit of this.inventory.allUnits) {
+      const terminalOwnerId = this.terminalOwnerForKnownUnit(unit.id);
+      if (terminalOwnerId !== null && terminalUnitIds.has(terminalOwnerId)) included.add(unit.id);
+    }
+    for (const terminalUnitId of terminalUnitIds) included.add(terminalUnitId);
     for (let changed = true; changed; ) {
       changed = false;
       for (const record of this.derivedUnits.values()) {
@@ -1807,10 +1900,24 @@ export class ProgramAbiSession {
           continue;
         }
         included.add(record.id);
-        records.push(record);
         changed = true;
       }
     }
+    return included;
+  }
+
+  private collectPreparedClassIds(terminalUnitIds: ReadonlySet<IrUnitId>): Set<IrClassId> {
+    const included = new Set<IrClassId>();
+    for (const classRecord of this.inventory.classes) {
+      const terminalOwnerId = this.terminalOwnerForKnownClass(classRecord.id);
+      if (terminalOwnerId !== null && terminalUnitIds.has(terminalOwnerId)) included.add(classRecord.id);
+    }
+    return included;
+  }
+
+  private collectPreparedDerivedUnits(unitIds: ReadonlySet<IrUnitId>): readonly ProgramAbiDerivedUnitRecord[] {
+    const records: ProgramAbiDerivedUnitRecord[] = [];
+    for (const record of this.derivedUnits.values()) if (unitIds.has(record.id)) records.push(record);
     return Object.freeze(
       records.sort((left, right) => {
         const leftDraft = [...this.drafts.values()].find(
@@ -1882,7 +1989,7 @@ export class ProgramAbiSession {
         );
       }
     }
-    const ownerTerminalId = this.terminalOwnerForKnownUnit(ownerId as IrUnitId);
+    const ownerTerminalId = this.terminalOwnerForStructuralOwner(ownerId);
     if (ownerTerminalId !== null && !terminalUnitIds.has(ownerTerminalId)) {
       throw new ProgramAbiInvariantError(
         "invalid-callable-provenance",
@@ -1962,10 +2069,39 @@ export class ProgramAbiSession {
     return ownerId as IrSourceId | IrUnitId | IrClassId;
   }
 
-  private terminalOwnerForKnownUnit(id: IrUnitId): IrUnitId | null {
+  private terminalOwnerForKnownUnit(id: IrUnitId, visited = new Set<IrUnitId>()): IrUnitId | null {
+    if (visited.has(id)) {
+      throw new ProgramAbiInvariantError("invalid-callable-provenance", `unit ownership cycle includes ${id}`);
+    }
+    visited.add(id);
     const inventoryUnit = this.inventory.allUnits.find((unit) => unit.id === id);
-    if (inventoryUnit) return inventoryUnit.terminalOwnerId;
-    return this.derivedUnits.get(id)?.terminalOwnerId ?? null;
+    const directOwner = inventoryUnit?.terminalOwnerId ?? this.derivedUnits.get(id)?.terminalOwnerId ?? null;
+    if (directOwner === null || directOwner === id) return directOwner;
+    const ownerRecord =
+      this.inventory.allUnits.find((unit) => unit.id === directOwner) ?? this.derivedUnits.get(directOwner);
+    if (!ownerRecord) return directOwner;
+    return this.terminalOwnerForKnownUnit(directOwner, visited);
+  }
+
+  private terminalOwnerForKnownClass(id: IrClassId, visited = new Set<IrClassId>()): IrUnitId | null {
+    if (visited.has(id)) {
+      throw new ProgramAbiInvariantError("invalid-callable-provenance", `class ownership cycle includes ${id}`);
+    }
+    visited.add(id);
+    const record = this.inventory.classes.find((candidate) => candidate.id === id);
+    if (!record || record.lexicalOwnerId === null) return null;
+    if (this.inventoryClassIds.has(record.lexicalOwnerId as IrClassId)) {
+      return this.terminalOwnerForKnownClass(record.lexicalOwnerId as IrClassId, visited);
+    }
+    return this.terminalOwnerForKnownUnit(record.lexicalOwnerId as IrUnitId);
+  }
+
+  private terminalOwnerForStructuralOwner(ownerId: IrSourceId | IrUnitId | IrClassId): IrUnitId | null {
+    if (this.inventorySourceIds.has(ownerId as IrSourceId)) return null;
+    if (this.inventoryClassIds.has(ownerId as IrClassId)) {
+      return this.terminalOwnerForKnownClass(ownerId as IrClassId);
+    }
+    return this.terminalOwnerForKnownUnit(ownerId as IrUnitId);
   }
 
   private preparedHostLinkage(locator: ProgramAbiSlotLocator): string | undefined {
@@ -2022,7 +2158,75 @@ export class ProgramAbiSession {
           );
         }
       }
+      const currentReachableLayouts = this.collectPreparedReachableTypeLayouts(
+        this.module,
+        scope.typeLayouts.keys(),
+        scope.callableTypeContracts,
+        scope.globalTypeContracts,
+      );
+      if (
+        currentReachableLayouts.size !== scope.reachableTypeLayouts.size ||
+        [...scope.reachableTypeLayouts].some(([index, layout]) => currentReachableLayouts.get(index) !== layout)
+      ) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `prepared type graph for scope ${scope.scopeId} drifted before exact layout remapping`,
+        );
+      }
     }
+  }
+
+  private collectPreparedReachableTypeLayouts(
+    module: WasmModule,
+    typeBindingIds: Iterable<IrBindingId>,
+    callableContracts: ReadonlyMap<IrBindingId, ProgramAbiCallableTypeContract>,
+    globalContracts: ReadonlyMap<IrBindingId, ProgramAbiGlobalTypeContract>,
+  ): Map<number, string> {
+    const roots = new Set<number>();
+    const addValue = (value: ValType): void => {
+      if (value.kind === "ref" || value.kind === "ref_null") roots.add(value.typeIdx);
+    };
+    for (const id of typeBindingIds) {
+      const locator = this.locators.get(id);
+      if (locator?.kind !== "type-cell" || locator.cell.current === null) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `prepared type/class layout ${id} has no live cell while pinning its type graph`,
+        );
+      }
+      const index = module.types.indexOf(locator.cell.current);
+      if (index < 0 || module.types.lastIndexOf(locator.cell.current) !== index) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `prepared type/class layout ${id} is not uniquely present while pinning its type graph`,
+        );
+      }
+      roots.add(index);
+    }
+    for (const contract of callableContracts.values()) {
+      contract.params.forEach(addValue);
+      contract.results.forEach(addValue);
+    }
+    for (const contract of globalContracts.values()) addValue(contract.type);
+
+    const layouts = new Map<number, string>();
+    const pending = [...roots];
+    while (pending.length > 0) {
+      const index = pending.pop()!;
+      if (layouts.has(index)) continue;
+      if (!Number.isSafeInteger(index) || index < 0 || index >= module.types.length) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `prepared type graph references index ${index} outside the module type layout`,
+        );
+      }
+      const type = module.types[index]!;
+      layouts.set(index, canonicalProgramAbiTypeDef(type));
+      const references = new Set<number>();
+      collectProgramAbiTypeReferences(type, references);
+      for (const reference of references) if (!layouts.has(reference)) pending.push(reference);
+    }
+    return layouts;
   }
 
   private assertPreparedTypeLayoutRemap(
@@ -2031,36 +2235,29 @@ export class ProgramAbiSession {
     targetsByOldIndex: readonly (number | null)[],
   ): void {
     for (const scope of this.preparedScopes.values()) {
-      for (const [id] of scope.typeLayouts) {
-        const locator = this.locators.get(id);
-        if (locator?.kind !== "type-cell" || locator.cell.current === null) {
+      for (const [oldIndex, pinnedLayout] of scope.reachableTypeLayouts) {
+        const oldType = previousTypes[oldIndex];
+        if (!oldType || canonicalProgramAbiTypeDef(oldType) !== pinnedLayout) {
           throw new ProgramAbiInvariantError(
             "type-remap-mismatch",
-            `prepared type/class layout ${id} has no live cell for exact remapping`,
-          );
-        }
-        const oldIndex = previousTypes.indexOf(locator.cell.current);
-        if (oldIndex < 0 || previousTypes.lastIndexOf(locator.cell.current) !== oldIndex) {
-          throw new ProgramAbiInvariantError(
-            "type-remap-mismatch",
-            `prepared type/class layout ${id} is not uniquely present in the old layout`,
+            `prepared type graph for scope ${scope.scopeId} changed at old index ${oldIndex}`,
           );
         }
         const target = targetsByOldIndex[oldIndex];
         if (target === null || target === undefined || !nextTypes[target]) {
           throw new ProgramAbiInvariantError(
             "type-remap-mismatch",
-            `prepared type/class layout ${id} was eliminated by an exact layout remap`,
+            `prepared type graph for scope ${scope.scopeId} eliminated old index ${oldIndex}`,
           );
         }
         const expectedLayout = canonicalProgramAbiTypeDef(
-          remapProgramAbiTypeDef(locator.cell.current, targetsByOldIndex, id),
+          remapProgramAbiTypeDef(oldType, targetsByOldIndex, scope.bindingIds.values().next().value!),
         );
         const actualLayout = canonicalProgramAbiTypeDef(nextTypes[target]);
         if (actualLayout !== expectedLayout) {
           throw new ProgramAbiInvariantError(
             "type-remap-mismatch",
-            `prepared type/class layout ${id} changed shape during an exact layout remap`,
+            `prepared type graph for scope ${scope.scopeId} changed reachable shape during an exact layout remap`,
           );
         }
       }
@@ -2074,6 +2271,14 @@ export class ProgramAbiSession {
       const unitOwner = this.preparedScopeByUnitId.get(draft.intent.unitId);
       if (unitOwner !== undefined) return unitOwner;
     }
+    if (draft.intent.kind === "callable" && draft.intent.classId) {
+      const classOwner = this.preparedScopeByClassId.get(draft.intent.classId);
+      if (classOwner !== undefined) return classOwner;
+    }
+    if (draft.intent.kind === "class") {
+      const classOwner = this.preparedScopeByClassId.get(draft.intent.classId);
+      if (classOwner !== undefined) return classOwner;
+    }
     if (draft.slotPolicy === "alias") {
       const aliasOwner = this.preparedScopeByBindingId.get(draft.aliasOf);
       if (aliasOwner !== undefined) return aliasOwner;
@@ -2083,7 +2288,10 @@ export class ProgramAbiSession {
       if (exportOwner !== undefined) return exportOwner;
     }
     for (const [unitId, scopeId] of this.preparedScopeByUnitId) {
-      if (bindingOwnerIsUnit(draft.id, unitId)) return scopeId;
+      if (bindingOwnerIs(draft.id, unitId)) return scopeId;
+    }
+    for (const [classId, scopeId] of this.preparedScopeByClassId) {
+      if (bindingOwnerIs(draft.id, classId)) return scopeId;
     }
     return undefined;
   }
@@ -2097,7 +2305,22 @@ export class ProgramAbiSession {
   }
 
   private assertPreparedScopeCurrent(record: PreparedProgramAbiScopeRecord, module: WasmModule): void {
-    const derivedUnits = this.collectPreparedDerivedUnits(new Set(record.terminalUnitIds));
+    const terminalUnitIds = new Set(record.terminalUnitIds);
+    const unitIds = this.collectPreparedUnitIds(terminalUnitIds);
+    if (unitIds.size !== record.unitIds.size || [...record.unitIds].some((id) => !unitIds.has(id))) {
+      throw new ProgramAbiInvariantError(
+        "session-draft-mismatch",
+        `source-unit ownership closure drifted after prepared ABI scope ${record.scopeId} sealed`,
+      );
+    }
+    const classIds = this.collectPreparedClassIds(terminalUnitIds);
+    if (classIds.size !== record.classIds.size || [...record.classIds].some((id) => !classIds.has(id))) {
+      throw new ProgramAbiInvariantError(
+        "session-draft-mismatch",
+        `class ownership closure drifted after prepared ABI scope ${record.scopeId} sealed`,
+      );
+    }
+    const derivedUnits = this.collectPreparedDerivedUnits(unitIds);
     if (
       derivedUnits.length !== record.derivedUnits.length ||
       derivedUnits.some((current, index) => {
@@ -2133,6 +2356,13 @@ export class ProgramAbiSession {
         throw new ProgramAbiInvariantError(
           "session-draft-mismatch",
           `ABI draft ${id} drifted after prepared scope ${record.scopeId} sealed`,
+        );
+      }
+      const currentOwnerId = this.assertCanonicalPreparedBindingId(currentDraft);
+      if (this.terminalOwnerForStructuralOwner(currentOwnerId) !== record.bindingTerminalOwnerIds.get(id)) {
+        throw new ProgramAbiInvariantError(
+          "invalid-callable-provenance",
+          `ABI draft ${id} structural owner drifted after prepared scope ${record.scopeId} sealed`,
         );
       }
       const expectedLocator = record.locators.get(id);
@@ -2217,6 +2447,21 @@ export class ProgramAbiSession {
           );
         }
       }
+    }
+    const currentReachableLayouts = this.collectPreparedReachableTypeLayouts(
+      module,
+      record.typeLayouts.keys(),
+      record.callableTypeContracts,
+      record.globalTypeContracts,
+    );
+    if (
+      currentReachableLayouts.size !== record.reachableTypeLayouts.size ||
+      [...record.reachableTypeLayouts].some(([index, layout]) => currentReachableLayouts.get(index) !== layout)
+    ) {
+      throw new ProgramAbiInvariantError(
+        "type-remap-mismatch",
+        `reachable type graph drifted after prepared ABI scope ${record.scopeId} sealed`,
+      );
     }
   }
 

--- a/src/codegen/program-abi-session.ts
+++ b/src/codegen/program-abi-session.ts
@@ -421,7 +421,101 @@ export interface SealedProgramAbiPlan {
   canonicalId(id: IrBindingId): IrBindingId;
 }
 
+/**
+ * Read-only ABI evidence for one prepared free-function component.
+ *
+ * Unlike {@link SealedProgramAbiPlan}, this seal leaves the containing session
+ * open for unrelated direct-body producers. Its identities and reservations
+ * are reconciled again at whole-program seal and publication.
+ */
+export interface SealedPreparedProgramAbiScope {
+  readonly planningSealed: true;
+  readonly scopeId: string;
+  readonly terminalUnitIds: readonly IrUnitId[];
+  readonly derivedUnits: readonly ProgramAbiDerivedUnitRecord[];
+  readonly bindingIds: readonly IrBindingId[];
+  entries(): readonly ProgramAbiPlanEntry[];
+  get(id: IrBindingId): ProgramAbiPlanEntry | undefined;
+  canonicalId(id: IrBindingId): IrBindingId;
+}
+
+type PreparedScopeTransactionState = "open" | "sealed" | "aborted";
+
+/**
+ * One-shot discovery transaction for the ABI dependencies of one prepared
+ * component. Failed sealing and explicit abort publish no partial scope.
+ */
+export class PreparedProgramAbiScopeTransaction {
+  readonly #bindingIds = new Set<IrBindingId>();
+  readonly #sealScope: (bindingIds: ReadonlySet<IrBindingId>) => SealedPreparedProgramAbiScope;
+  readonly #abortScope: () => void;
+  #state: PreparedScopeTransactionState = "open";
+
+  constructor(
+    readonly scopeId: string,
+    readonly terminalUnitIds: readonly IrUnitId[],
+    sealScope: (bindingIds: ReadonlySet<IrBindingId>) => SealedPreparedProgramAbiScope,
+    abortScope: () => void,
+  ) {
+    Object.freeze(this.terminalUnitIds);
+    this.#sealScope = sealScope;
+    this.#abortScope = abortScope;
+  }
+
+  includeBinding(id: IrBindingId): void {
+    this.#assertOpen("include an ABI binding");
+    this.#bindingIds.add(id);
+  }
+
+  seal(): SealedPreparedProgramAbiScope {
+    this.#assertOpen("seal the prepared ABI scope");
+    try {
+      const sealed = this.#sealScope(this.#bindingIds);
+      this.#state = "sealed";
+      return sealed;
+    } catch (error) {
+      this.#state = "aborted";
+      throw error;
+    }
+  }
+
+  abort(): void {
+    this.#assertOpen("abort the prepared ABI scope");
+    this.#state = "aborted";
+    this.#abortScope();
+  }
+
+  #assertOpen(action: string): void {
+    if (this.#state !== "open") {
+      throw new ProgramAbiInvariantError(
+        "session-closed",
+        `cannot ${action} after prepared ABI scope ${this.scopeId} ${this.#state}`,
+      );
+    }
+  }
+}
+
 type SessionState = "planning" | "sealing" | "sealed" | "binding" | "published" | "failed";
+
+interface PreparedProgramAbiLocatorSnapshot {
+  readonly kind: ProgramAbiSlotLocator["kind"];
+  readonly object: object;
+}
+
+interface PreparedProgramAbiScopeRecord {
+  readonly scopeId: string;
+  readonly terminalUnitIds: readonly IrUnitId[];
+  readonly unitIds: ReadonlySet<IrUnitId>;
+  readonly derivedUnits: readonly ProgramAbiDerivedUnitRecord[];
+  readonly requestedBindingIds: ReadonlySet<IrBindingId>;
+  readonly bindingIds: ReadonlySet<IrBindingId>;
+  readonly drafts: ReadonlyMap<IrBindingId, ProgramAbiDraft>;
+  readonly locators: ReadonlyMap<IrBindingId, PreparedProgramAbiLocatorSnapshot>;
+  readonly structuralReferences: ReadonlyMap<IrBindingId, string>;
+  readonly callableTypeContracts: Map<IrBindingId, ProgramAbiCallableTypeContract>;
+  readonly globalTypeContracts: Map<IrBindingId, ProgramAbiGlobalTypeContract>;
+  readonly view: SealedPreparedProgramAbiScope;
+}
 
 function validOrdinal(value: number): boolean {
   return Number.isSafeInteger(value) && value >= 0;
@@ -549,6 +643,44 @@ function draftsEqual(a: ProgramAbiDraft, b: ProgramAbiDraft): boolean {
   );
 }
 
+function planEntriesEqualIgnoringDenseOrder(a: ProgramAbiPlanEntry, b: ProgramAbiPlanEntry): boolean {
+  const ar = a as ProgramAbiPlanEntry & {
+    readonly aliasOf?: IrBindingId;
+    readonly slotSpace?: ProgramAbiSlotSpace;
+  };
+  const br = b as ProgramAbiPlanEntry & {
+    readonly aliasOf?: IrBindingId;
+    readonly slotSpace?: ProgramAbiSlotSpace;
+  };
+  return (
+    a.id === b.id &&
+    a.displayName === b.displayName &&
+    a.structuralReferenceKey === b.structuralReferenceKey &&
+    a.slotPolicy === b.slotPolicy &&
+    ar.slotSpace === br.slotSpace &&
+    ar.aliasOf === br.aliasOf &&
+    intentsEqual(a.intent, b.intent)
+  );
+}
+
+function bindingOwnerIsUnit(id: IrBindingId, unitId: IrUnitId): boolean {
+  const prefix = "ir-binding:v1:";
+  if (!id.startsWith(prefix)) return false;
+  const domainEnd = id.indexOf(":", prefix.length);
+  if (domainEnd < 0) return false;
+  const ownerEnd = id.indexOf(":", domainEnd + 1);
+  if (ownerEnd < 0) return false;
+  return id.slice(domainEnd + 1, ownerEnd) === encodeURIComponent(unitId);
+}
+
+function readonlySet<T>(values: Iterable<T>): ReadonlySet<T> {
+  return new Set(values);
+}
+
+function readonlyMap<K, V>(values: Iterable<readonly [K, V]>): ReadonlyMap<K, V> {
+  return new Map(values);
+}
+
 function structuralOrderKey(sourceOrder: number, order: ProgramAbiDraftOrder): string {
   return [sourceOrder, order.declarationOrdinal, order.domainOrdinal, order.roleOrdinal, order.derivedOrdinal].join(
     ":",
@@ -601,6 +733,7 @@ function createSealedProgramAbiPlanView(
 export class ProgramAbiSession {
   private readonly sourceOrderById = new Map<IrSourceId, number>();
   private readonly inventoryUnitIds = new Set<IrUnitId>();
+  private readonly preparedFreeFunctionUnitIds = new Set<IrUnitId>();
   private readonly drafts = new Map<IrBindingId, ProgramAbiDraft>();
   private readonly draftOrderOwners = new Map<string, IrBindingId>();
   private readonly derivedUnits = new Map<IrUnitId, ProgramAbiDerivedUnitRecord>();
@@ -611,6 +744,10 @@ export class ProgramAbiSession {
   private readonly typeCellsByObject = new Map<TypeDef, MutableProgramAbiTypeCell>();
   private readonly callableTypeContracts = new Map<IrBindingId, ProgramAbiCallableTypeContract>();
   private readonly globalTypeContracts = new Map<IrBindingId, ProgramAbiGlobalTypeContract>();
+  private readonly preparedScopes = new Map<string, PreparedProgramAbiScopeRecord>();
+  private readonly preparedScopeByUnitId = new Map<IrUnitId, string>();
+  private readonly preparedScopeByBindingId = new Map<IrBindingId, string>();
+  private readonly openPreparedScopeIds = new Set<string>();
   private state: SessionState = "planning";
   private sealedDrafts: readonly ProgramAbiDraft[] | undefined;
   private sealedPlanView: SealedProgramAbiPlan | undefined;
@@ -623,6 +760,9 @@ export class ProgramAbiSession {
   ) {
     for (const source of inventory.sources) this.sourceOrderById.set(source.id, source.order);
     for (const unit of inventory.allUnits) this.inventoryUnitIds.add(unit.id);
+    for (const unit of inventory.terminalUnits) {
+      if (unit.kind === "top-level-function") this.preparedFreeFunctionUnitIds.add(unit.id);
+    }
     this.structuralOrder = new ProgramAbiStructuralOrder(inventory);
   }
 
@@ -638,6 +778,68 @@ export class ProgramAbiSession {
 
   get publication(): PublishedProgramAbi | undefined {
     return this.publishedValue;
+  }
+
+  /**
+   * Start exact dependency discovery for one prepared free-function component.
+   *
+   * Source and derived callables are inferred from terminal ownership. The
+   * caller adds only already-discovered external/support dependencies; alias
+   * and export closure is derived by the session when the transaction seals.
+   */
+  beginPreparedComponentScope(
+    scopeId: string,
+    terminalUnitIds: readonly IrUnitId[],
+  ): PreparedProgramAbiScopeTransaction {
+    this.assertPlanning(`begin prepared ABI scope ${scopeId}`);
+    if (scopeId.length === 0 || this.preparedScopes.has(scopeId) || this.openPreparedScopeIds.has(scopeId)) {
+      throw new ProgramAbiInvariantError(
+        "duplicate-session-draft",
+        `prepared ABI scope ID ${scopeId || "<empty>"} is invalid or already owned`,
+      );
+    }
+    const exactTerminalUnitIds = Object.freeze([...terminalUnitIds]);
+    if (exactTerminalUnitIds.length === 0 || new Set(exactTerminalUnitIds).size !== exactTerminalUnitIds.length) {
+      throw new ProgramAbiInvariantError(
+        "invalid-derived-unit",
+        `prepared ABI scope ${scopeId} requires a non-empty unique terminal denominator`,
+      );
+    }
+    for (const unitId of exactTerminalUnitIds) {
+      if (!this.preparedFreeFunctionUnitIds.has(unitId)) {
+        throw new ProgramAbiInvariantError(
+          "unknown-inventory-unit",
+          `prepared ABI scope ${scopeId} references non-R2 or unknown terminal ${unitId}`,
+        );
+      }
+      const owner = this.preparedScopeByUnitId.get(unitId);
+      if (owner !== undefined) {
+        throw new ProgramAbiInvariantError(
+          "duplicate-session-draft",
+          `prepared ABI terminal ${unitId} is already sealed by scope ${owner}`,
+        );
+      }
+    }
+
+    this.openPreparedScopeIds.add(scopeId);
+    let closed = false;
+    const close = (): void => {
+      if (closed) return;
+      closed = true;
+      this.openPreparedScopeIds.delete(scopeId);
+    };
+    return new PreparedProgramAbiScopeTransaction(
+      scopeId,
+      exactTerminalUnitIds,
+      (bindingIds) => {
+        try {
+          return this.sealPreparedComponentScope(scopeId, exactTerminalUnitIds, bindingIds);
+        } finally {
+          close();
+        }
+      },
+      close,
+    );
   }
 
   hasPlan(id: IrBindingId): boolean {
@@ -692,6 +894,13 @@ export class ProgramAbiSession {
 
   plan(draft: ProgramAbiDraft): void {
     this.assertPlanning(`plan ${draft.id}`);
+    const preparedScopeId = this.preparedScopeAffectedByDraft(draft);
+    if (preparedScopeId !== undefined) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        `ABI draft ${draft.id} would mutate sealed prepared scope ${preparedScopeId}`,
+      );
+    }
     if (this.drafts.has(draft.id)) {
       throw new ProgramAbiInvariantError("duplicate-session-draft", `ABI draft ${draft.id} was planned more than once`);
     }
@@ -737,6 +946,15 @@ export class ProgramAbiSession {
 
   registerDerivedUnit(record: ProgramAbiDerivedUnitRecord): void {
     this.assertPlanning(`register derived unit ${record.id}`);
+    const preparedScopeId =
+      this.preparedScopeByUnitId.get(record.parentId) ??
+      (record.terminalOwnerId === null ? undefined : this.preparedScopeByUnitId.get(record.terminalOwnerId));
+    if (preparedScopeId !== undefined) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        `derived unit ${record.id} would mutate sealed prepared scope ${preparedScopeId}`,
+      );
+    }
     if (this.derivedUnits.has(record.id)) {
       throw new ProgramAbiInvariantError(
         "duplicate-derived-unit",
@@ -789,6 +1007,13 @@ export class ProgramAbiSession {
       }
       return;
     }
+    const preparedScopeId = this.preparedScopeByBindingId.get(id);
+    if (preparedScopeId !== undefined) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        `callable type contract for ${id} was requested after prepared scope ${preparedScopeId} sealed`,
+      );
+    }
     this.callableTypeContracts.set(id, contract);
   }
 
@@ -819,6 +1044,13 @@ export class ProgramAbiSession {
         );
       }
       return;
+    }
+    const preparedScopeId = this.preparedScopeByBindingId.get(id);
+    if (preparedScopeId !== undefined) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        `global type contract for ${id} was requested after prepared scope ${preparedScopeId} sealed`,
+      );
     }
     this.globalTypeContracts.set(id, Object.freeze({ type: cloneProgramAbiValType(type), mutable }));
   }
@@ -1009,6 +1241,21 @@ export class ProgramAbiSession {
     for (const [id, contract] of remappedCallableContracts) this.callableTypeContracts.set(id, contract);
     this.globalTypeContracts.clear();
     for (const [id, contract] of remappedGlobalContracts) this.globalTypeContracts.set(id, contract);
+    for (const scope of this.preparedScopes.values()) {
+      for (const id of scope.callableTypeContracts.keys()) {
+        const contract = this.callableTypeContracts.get(id);
+        if (contract) scope.callableTypeContracts.set(id, cloneProgramAbiCallableTypeContract(contract));
+      }
+      for (const id of scope.globalTypeContracts.keys()) {
+        const contract = this.globalTypeContracts.get(id);
+        if (contract) {
+          scope.globalTypeContracts.set(
+            id,
+            Object.freeze({ type: cloneProgramAbiValType(contract.type), mutable: contract.mutable }),
+          );
+        }
+      }
+    }
   }
 
   attachLocator(id: IrBindingId, locator: ProgramAbiSlotLocator): void {
@@ -1125,10 +1372,17 @@ export class ProgramAbiSession {
         `ProgramAbiSession planning cannot be sealed from state ${this.state}`,
       );
     }
+    if (this.openPreparedScopeIds.size > 0) {
+      throw new ProgramAbiInvariantError(
+        "planning-not-sealed",
+        `ProgramAbiSession has open prepared ABI scopes: ${[...this.openPreparedScopeIds].join(", ")}`,
+      );
+    }
     this.state = "sealing";
     try {
       const drafts = [...this.drafts.values()].sort((a, b) => compareDrafts(this.sourceOrderById, a, b));
       const abi = this.buildSealedAbi(drafts, module);
+      this.reconcilePreparedScopes(abi, module);
       for (const entry of abi.entries()) {
         if (entry.slotPolicy === "required" && !this.locators.has(entry.id)) {
           throw new ProgramAbiInvariantError(
@@ -1165,6 +1419,7 @@ export class ProgramAbiSession {
     this.state = "binding";
     try {
       const abi = this.buildSealedAbi(this.sealedDrafts!, module);
+      this.reconcilePreparedScopes(abi, module);
       const pendingBindings: Array<{
         readonly id: IrBindingId;
         readonly finalIndex: ProgramAbiFinalIndex;
@@ -1228,8 +1483,370 @@ export class ProgramAbiSession {
     return this.bindAndPublish(module);
   }
 
-  private buildSealedAbi(drafts: readonly ProgramAbiDraft[], module: WasmModule): ProgramAbiMap {
-    const abi = new ProgramAbiMap(this.inventory, [...this.derivedUnits.values()]);
+  private sealPreparedComponentScope(
+    scopeId: string,
+    terminalUnitIds: readonly IrUnitId[],
+    requestedBindingIds: ReadonlySet<IrBindingId>,
+  ): SealedPreparedProgramAbiScope {
+    this.assertPlanning(`seal prepared ABI scope ${scopeId}`);
+    if (!this.openPreparedScopeIds.has(scopeId) || this.preparedScopes.has(scopeId)) {
+      throw new ProgramAbiInvariantError(
+        "session-closed",
+        `prepared ABI scope ${scopeId} is not an open session transaction`,
+      );
+    }
+    for (const terminalUnitId of terminalUnitIds) {
+      const previous = this.preparedScopeByUnitId.get(terminalUnitId);
+      if (previous !== undefined) {
+        throw new ProgramAbiInvariantError(
+          "duplicate-session-draft",
+          `prepared ABI terminal ${terminalUnitId} is already sealed by scope ${previous}`,
+        );
+      }
+    }
+    for (const id of requestedBindingIds) {
+      if (!this.drafts.has(id)) {
+        throw new ProgramAbiInvariantError(
+          "unknown-binding",
+          `prepared ABI scope ${scopeId} requests unplanned binding ${id}`,
+        );
+      }
+    }
+
+    const derivedUnits = this.collectPreparedDerivedUnits(new Set(terminalUnitIds));
+    const unitIds = new Set<IrUnitId>(terminalUnitIds);
+    for (const record of derivedUnits) unitIds.add(record.id);
+    const bindingIds = this.collectPreparedBindingClosure(unitIds, requestedBindingIds);
+    for (const terminalUnitId of terminalUnitIds) {
+      const hasCallable = [...bindingIds].some((id) => {
+        const draft = this.drafts.get(id)!;
+        return draft.intent.kind === "callable" && draft.intent.unitId === terminalUnitId;
+      });
+      if (!hasCallable) {
+        throw new ProgramAbiInvariantError(
+          "missing-source-unit",
+          `prepared ABI scope ${scopeId} has no callable reservation for terminal ${terminalUnitId}`,
+        );
+      }
+    }
+
+    const drafts = [...bindingIds]
+      .map((id) => this.drafts.get(id)!)
+      .sort((left, right) => compareDrafts(this.sourceOrderById, left, right));
+    const scopedAbi = this.buildSealedAbi(drafts, this.module, derivedUnits);
+    const locatorSnapshots = new Map<IrBindingId, PreparedProgramAbiLocatorSnapshot>();
+    const structuralReferences = new Map<IrBindingId, string>();
+    const callableTypeContracts = new Map<IrBindingId, ProgramAbiCallableTypeContract>();
+    const globalTypeContracts = new Map<IrBindingId, ProgramAbiGlobalTypeContract>();
+
+    for (const draft of drafts) {
+      if (draft.intent.kind === "callable") {
+        const contract = this.callableTypeContractFor(draft);
+        if (!contract) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `prepared callable ${draft.id} has no structured type contract at scope seal`,
+          );
+        }
+        callableTypeContracts.set(draft.id, cloneProgramAbiCallableTypeContract(contract));
+      } else if (draft.intent.kind === "global") {
+        const contract = this.globalTypeContractFor(draft);
+        if (!contract) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `prepared global ${draft.id} has no structured storage contract at scope seal`,
+          );
+        }
+        globalTypeContracts.set(
+          draft.id,
+          Object.freeze({ type: cloneProgramAbiValType(contract.type), mutable: contract.mutable }),
+        );
+      }
+      if (draft.slotPolicy !== "required") continue;
+      const locator = this.locators.get(draft.id);
+      if (!locator) {
+        throw new ProgramAbiInvariantError(
+          "missing-required-locator",
+          `prepared ABI binding ${draft.id} has no allocator locator at scope seal`,
+        );
+      }
+      const structuralReference = draft.structuralReferenceKey;
+      if (structuralReference === undefined || this.structuralReferenceKeys.get(draft.id) !== structuralReference) {
+        throw new ProgramAbiInvariantError(
+          "missing-binding-reference",
+          `prepared ABI binding ${draft.id} has no observed structural reservation`,
+        );
+      }
+      this.resolveLocator(this.module, draft.id, locator);
+      locatorSnapshots.set(draft.id, Object.freeze({ kind: locator.kind, object: locatorObject(locator) }));
+      structuralReferences.set(draft.id, structuralReference);
+    }
+
+    const exactTerminalUnitIds = Object.freeze([...terminalUnitIds]);
+    const exactDerivedUnits = Object.freeze(derivedUnits.map((record) => Object.freeze({ ...record })));
+    const exactBindingIds = Object.freeze(drafts.map((draft) => draft.id));
+    const canonicalIds = new Map(exactBindingIds.map((id) => [id, scopedAbi.canonicalId(id)] as const));
+    const recordHolder: { value?: PreparedProgramAbiScopeRecord } = {};
+    const currentRecord = (): PreparedProgramAbiScopeRecord => {
+      if (!recordHolder.value) {
+        throw new ProgramAbiInvariantError(
+          "session-closed",
+          `prepared ABI scope ${scopeId} was observed before atomic publication`,
+        );
+      }
+      return recordHolder.value;
+    };
+    const view: SealedPreparedProgramAbiScope = Object.freeze({
+      planningSealed: true as const,
+      scopeId,
+      terminalUnitIds: exactTerminalUnitIds,
+      derivedUnits: exactDerivedUnits,
+      bindingIds: exactBindingIds,
+      entries: () => this.buildPreparedScopeAbi(currentRecord(), this.module).entries(),
+      get: (id: IrBindingId) => this.buildPreparedScopeAbi(currentRecord(), this.module).get(id),
+      canonicalId: (id: IrBindingId) => {
+        const canonicalId = canonicalIds.get(id);
+        if (canonicalId === undefined) {
+          throw new ProgramAbiInvariantError(
+            "unknown-binding",
+            `binding ${id} is outside prepared ABI scope ${scopeId}`,
+          );
+        }
+        return canonicalId;
+      },
+    });
+    const record: PreparedProgramAbiScopeRecord = {
+      scopeId,
+      terminalUnitIds: exactTerminalUnitIds,
+      unitIds: readonlySet(unitIds),
+      derivedUnits: exactDerivedUnits,
+      requestedBindingIds: readonlySet(requestedBindingIds),
+      bindingIds: readonlySet(exactBindingIds),
+      drafts: readonlyMap(drafts.map((draft) => [draft.id, cloneDraft(draft)] as const)),
+      locators: readonlyMap(locatorSnapshots),
+      structuralReferences: readonlyMap(structuralReferences),
+      callableTypeContracts,
+      globalTypeContracts,
+      view,
+    };
+    recordHolder.value = record;
+
+    // All validation above is side-effect free. Publish the scope only after
+    // every identity, contract, reservation, and locator is known-good.
+    this.preparedScopes.set(scopeId, record);
+    for (const unitId of unitIds) this.preparedScopeByUnitId.set(unitId, scopeId);
+    for (const bindingId of exactBindingIds) {
+      if (!this.preparedScopeByBindingId.has(bindingId)) {
+        this.preparedScopeByBindingId.set(bindingId, scopeId);
+      }
+    }
+    return view;
+  }
+
+  private collectPreparedDerivedUnits(terminalUnitIds: ReadonlySet<IrUnitId>): readonly ProgramAbiDerivedUnitRecord[] {
+    const included = new Set<IrUnitId>(terminalUnitIds);
+    const records: ProgramAbiDerivedUnitRecord[] = [];
+    for (let changed = true; changed; ) {
+      changed = false;
+      for (const record of this.derivedUnits.values()) {
+        if (
+          included.has(record.id) ||
+          (!included.has(record.parentId) &&
+            (record.terminalOwnerId === null || !terminalUnitIds.has(record.terminalOwnerId)))
+        ) {
+          continue;
+        }
+        included.add(record.id);
+        records.push(record);
+        changed = true;
+      }
+    }
+    return Object.freeze(
+      records.sort((left, right) => {
+        const leftDraft = [...this.drafts.values()].find(
+          (draft) => draft.intent.kind === "callable" && draft.intent.unitId === left.id,
+        );
+        const rightDraft = [...this.drafts.values()].find(
+          (draft) => draft.intent.kind === "callable" && draft.intent.unitId === right.id,
+        );
+        if (leftDraft && rightDraft) return compareDrafts(this.sourceOrderById, leftDraft, rightDraft);
+        return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+      }),
+    );
+  }
+
+  private collectPreparedBindingClosure(
+    unitIds: ReadonlySet<IrUnitId>,
+    requestedBindingIds: ReadonlySet<IrBindingId>,
+  ): Set<IrBindingId> {
+    const included = new Set<IrBindingId>(requestedBindingIds);
+    for (const draft of this.drafts.values()) {
+      if (draft.intent.kind === "callable" && draft.intent.unitId && unitIds.has(draft.intent.unitId)) {
+        included.add(draft.id);
+      }
+    }
+    for (let changed = true; changed; ) {
+      changed = false;
+      for (const id of [...included]) {
+        const draft = this.drafts.get(id);
+        if (!draft) continue;
+        const target = draft.slotPolicy === "alias" ? draft.aliasOf : undefined;
+        if (target !== undefined && !included.has(target)) {
+          included.add(target);
+          changed = true;
+        }
+      }
+      for (const draft of this.drafts.values()) {
+        const pointsIntoScope = draft.slotPolicy === "alias" && included.has(draft.aliasOf);
+        if (pointsIntoScope && !included.has(draft.id)) {
+          included.add(draft.id);
+          changed = true;
+        }
+      }
+    }
+    return included;
+  }
+
+  private preparedScopeAffectedByDraft(draft: ProgramAbiDraft): string | undefined {
+    const exactOwner = this.preparedScopeByBindingId.get(draft.id);
+    if (exactOwner !== undefined) return exactOwner;
+    if (draft.intent.kind === "callable" && draft.intent.unitId) {
+      const unitOwner = this.preparedScopeByUnitId.get(draft.intent.unitId);
+      if (unitOwner !== undefined) return unitOwner;
+    }
+    if (draft.slotPolicy === "alias") {
+      const aliasOwner = this.preparedScopeByBindingId.get(draft.aliasOf);
+      if (aliasOwner !== undefined) return aliasOwner;
+    }
+    if (draft.intent.kind === "export") {
+      const exportOwner = this.preparedScopeByBindingId.get(draft.intent.targetId);
+      if (exportOwner !== undefined) return exportOwner;
+    }
+    for (const [unitId, scopeId] of this.preparedScopeByUnitId) {
+      if (bindingOwnerIsUnit(draft.id, unitId)) return scopeId;
+    }
+    return undefined;
+  }
+
+  private buildPreparedScopeAbi(record: PreparedProgramAbiScopeRecord, module: WasmModule): ProgramAbiMap {
+    this.assertPreparedScopeCurrent(record, module);
+    const drafts = [...record.bindingIds]
+      .map((id) => this.drafts.get(id)!)
+      .sort((left, right) => compareDrafts(this.sourceOrderById, left, right));
+    return this.buildSealedAbi(drafts, module, record.derivedUnits);
+  }
+
+  private assertPreparedScopeCurrent(record: PreparedProgramAbiScopeRecord, module: WasmModule): void {
+    const derivedUnits = this.collectPreparedDerivedUnits(new Set(record.terminalUnitIds));
+    if (
+      derivedUnits.length !== record.derivedUnits.length ||
+      derivedUnits.some((current, index) => {
+        const expected = record.derivedUnits[index]!;
+        return (
+          current.id !== expected.id ||
+          current.parentId !== expected.parentId ||
+          current.terminalOwnerId !== expected.terminalOwnerId ||
+          current.sourceId !== expected.sourceId ||
+          current.role !== expected.role ||
+          current.ordinal !== expected.ordinal
+        );
+      })
+    ) {
+      throw new ProgramAbiInvariantError(
+        "session-draft-mismatch",
+        `derived-unit closure drifted after prepared ABI scope ${record.scopeId} sealed`,
+      );
+    }
+    const currentBindingIds = this.collectPreparedBindingClosure(record.unitIds, record.requestedBindingIds);
+    if (
+      currentBindingIds.size !== record.bindingIds.size ||
+      [...record.bindingIds].some((id) => !currentBindingIds.has(id))
+    ) {
+      throw new ProgramAbiInvariantError(
+        "session-draft-mismatch",
+        `binding closure drifted after prepared ABI scope ${record.scopeId} sealed`,
+      );
+    }
+    for (const [id, expectedDraft] of record.drafts) {
+      const currentDraft = this.drafts.get(id);
+      if (!currentDraft || !draftsEqual(expectedDraft, currentDraft)) {
+        throw new ProgramAbiInvariantError(
+          "session-draft-mismatch",
+          `ABI draft ${id} drifted after prepared scope ${record.scopeId} sealed`,
+        );
+      }
+      const expectedLocator = record.locators.get(id);
+      if (expectedLocator) {
+        const locator = this.locators.get(id);
+        if (!locator || locator.kind !== expectedLocator.kind || locatorObject(locator) !== expectedLocator.object) {
+          throw new ProgramAbiInvariantError(
+            "locator-remap-mismatch",
+            `allocator locator for ${id} drifted after prepared scope ${record.scopeId} sealed`,
+          );
+        }
+        this.resolveLocator(module, id, locator);
+      }
+      const expectedReference = record.structuralReferences.get(id);
+      if (expectedReference !== undefined && this.structuralReferenceKeys.get(id) !== expectedReference) {
+        throw new ProgramAbiInvariantError(
+          "binding-reference-mismatch",
+          `structural reservation for ${id} drifted after prepared scope ${record.scopeId} sealed`,
+        );
+      }
+      const expectedCallable = record.callableTypeContracts.get(id);
+      if (expectedCallable) {
+        const currentCallable = this.callableTypeContractFor(currentDraft);
+        if (
+          !currentCallable ||
+          !programAbiCallableSignaturesEqual(
+            canonicalProgramAbiCallableTypeContract(expectedCallable),
+            canonicalProgramAbiCallableTypeContract(currentCallable),
+          )
+        ) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `callable type contract for ${id} drifted after prepared scope ${record.scopeId} sealed`,
+          );
+        }
+      }
+      const expectedGlobal = record.globalTypeContracts.get(id);
+      if (expectedGlobal) {
+        const currentGlobal = this.globalTypeContractFor(currentDraft);
+        if (
+          !currentGlobal ||
+          currentGlobal.mutable !== expectedGlobal.mutable ||
+          canonicalProgramAbiValType(currentGlobal.type) !== canonicalProgramAbiValType(expectedGlobal.type)
+        ) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `global type contract for ${id} drifted after prepared scope ${record.scopeId} sealed`,
+          );
+        }
+      }
+    }
+  }
+
+  private reconcilePreparedScopes(wholeProgramAbi: ProgramAbiMap, module: WasmModule): void {
+    for (const record of this.preparedScopes.values()) {
+      const scopedAbi = this.buildPreparedScopeAbi(record, module);
+      for (const scopedEntry of scopedAbi.entries()) {
+        const wholeProgramEntry = wholeProgramAbi.get(scopedEntry.id);
+        if (!wholeProgramEntry || !planEntriesEqualIgnoringDenseOrder(scopedEntry, wholeProgramEntry)) {
+          throw new ProgramAbiInvariantError(
+            "session-draft-mismatch",
+            `whole-program ABI does not reconcile prepared binding ${scopedEntry.id} from scope ${record.scopeId}`,
+          );
+        }
+      }
+    }
+  }
+
+  private buildSealedAbi(
+    drafts: readonly ProgramAbiDraft[],
+    module: WasmModule,
+    derivedUnits: readonly ProgramAbiDerivedUnitRecord[] = [...this.derivedUnits.values()],
+  ): ProgramAbiMap {
+    const abi = new ProgramAbiMap(this.inventory, derivedUnits);
     const denseOrderBySource = new Map<IrSourceId, number>();
     for (const queuedDraft of drafts) {
       const draft = this.materializeTypeContract(queuedDraft, module);
@@ -1449,6 +2066,13 @@ export class ProgramAbiSession {
     replacement: T,
   ): void {
     this.assertLayoutMutable(`replace slot locator for ${id}`);
+    const preparedScopeId = this.preparedScopeByBindingId.get(id);
+    if (preparedScopeId !== undefined) {
+      throw new ProgramAbiInvariantError(
+        "locator-remap-mismatch",
+        `ABI binding ${id} belongs to sealed prepared scope ${preparedScopeId} and cannot replace its reserved locator`,
+      );
+    }
     const draft = this.drafts.get(id);
     if (!draft) {
       throw new ProgramAbiInvariantError("unknown-locator-binding", `slot locator targets unplanned ABI draft ${id}`);

--- a/tests/issue-3521-scoped-prepared-abi-seal.test.ts
+++ b/tests/issue-3521-scoped-prepared-abi-seal.test.ts
@@ -1176,6 +1176,98 @@ describe("#3521 scoped prepared-component ABI seal", () => {
     expect(f.session.publish(f.module).abi.resolveFinalIndex(classId)).toEqual({ space: "type", index: 3 });
   });
 
+  it("preserves an open-root struct sentinel through a scoped callable/class type reorder", () => {
+    const f = fixture();
+    const previousTypes: TypeDef[] = [
+      {
+        kind: "struct",
+        name: "$OpenRoot",
+        superTypeIdx: -1,
+        fields: [{ name: "rootValue", type: { kind: "i32" }, mutable: false }],
+      },
+      {
+        kind: "struct",
+        name: "$PreparedClass",
+        superTypeIdx: 0,
+        fields: [{ name: "root", type: { kind: "ref", typeIdx: 0 }, mutable: true }],
+      },
+      {
+        kind: "func",
+        name: "$consumeOpenRoot",
+        params: [{ kind: "ref", typeIdx: 0 }],
+        results: [],
+      },
+    ];
+    f.module.types = previousTypes;
+    const callableContract: ProgramAbiCallableTypeContract = Object.freeze({
+      params: Object.freeze([{ kind: "ref" as const, typeIdx: 0 }]),
+      results: Object.freeze([]),
+    });
+    const callableId = createIrBindingId({ ownerId: f.firstUnitId, domain: "callable", role: "body" });
+    const callableKey = `unit|${f.firstUnitId}|body`;
+    const func: WasmFunction = {
+      name: "first",
+      typeIdx: 2,
+      locals: [],
+      body: [],
+      exported: false,
+    };
+    f.module.functions.push(func);
+    f.session.plan({
+      ...callableDraft(f.session, callableId, f.firstUnitId, "first", callableKey),
+      intent: {
+        kind: "callable",
+        origin: "source",
+        signature: canonicalProgramAbiCallableTypeContract(callableContract),
+        unitId: f.firstUnitId,
+      },
+    });
+    f.session.registerCallableTypeContract(callableId, callableContract);
+    f.session.registerStructuralReference(callableId, callableKey);
+    f.session.attachLocator(callableId, { kind: "defined-function", value: func });
+
+    const classId = createIrBindingId({ ownerId: f.classId, domain: "class", role: "open-root-class" });
+    const classKey = `class|${classId}`;
+    f.session.plan(classDraft(f, classId, classKey));
+    f.session.registerStructuralReference(classId, classKey);
+    const classCell = f.session.createTypeCell(previousTypes[1]!);
+    f.session.attachLocator(classId, { kind: "type-cell", cell: classCell });
+    sealFirst(f, [classId]);
+
+    const nextTypes: TypeDef[] = [
+      {
+        kind: "func",
+        name: "$consumeOpenRoot$reordered",
+        params: [{ kind: "ref", typeIdx: 2 }],
+        results: [],
+      },
+      {
+        kind: "struct",
+        name: "$PreparedClass$reordered",
+        superTypeIdx: 2,
+        fields: [{ name: "root", type: { kind: "ref", typeIdx: 2 }, mutable: true }],
+      },
+      {
+        kind: "struct",
+        name: "$OpenRoot$reordered",
+        superTypeIdx: -1,
+        fields: [{ name: "rootValue", type: { kind: "i32" }, mutable: false }],
+      },
+    ];
+    f.session.applyTypeLayoutRemap({
+      previousTypes,
+      nextTypes,
+      targetsByOldIndex: [2, 1, 0],
+    });
+    f.module.types = nextTypes;
+    func.typeIdx = 0;
+
+    const publication = f.session.publish(f.module);
+    expect(nextTypes[2]).toMatchObject({ kind: "struct", superTypeIdx: -1 });
+    expect(publication.abi.resolveFinalIndex(classId)).toEqual({ space: "type", index: 1 });
+    expect(publication.abi.resolveFinalIndex(callableId)).toEqual({ space: "function", index: 0 });
+  });
+
   it("rejects alias cycles, duplicate discovery, custom IDs, and post-seal locator removal", () => {
     const cycle = fixture();
     planCallable(cycle, cycle.firstUnitId, "body", "first");

--- a/tests/issue-3521-scoped-prepared-abi-seal.test.ts
+++ b/tests/issue-3521-scoped-prepared-abi-seal.test.ts
@@ -12,6 +12,7 @@ import {
   createDerivedIrUnitId,
   createIrBindingId,
   type IrBindingId,
+  type IrClassId,
   type IrSourceId,
   type IrUnitId,
 } from "../src/ir/identity.js";
@@ -20,7 +21,14 @@ import {
   type ProgramAbiDerivedUnitRecord,
   type ProgramAbiInvariantCode,
 } from "../src/ir/program-abi.js";
-import { createEmptyModule, type WasmFunction, type WasmModule } from "../src/ir/types.js";
+import {
+  createEmptyModule,
+  type GlobalDef,
+  type Import,
+  type TypeDef,
+  type WasmFunction,
+  type WasmModule,
+} from "../src/ir/types.js";
 import { ts } from "../src/ts-api.js";
 
 const VOID_SIGNATURE = Object.freeze({
@@ -32,6 +40,7 @@ interface Fixture {
   readonly sourceId: IrSourceId;
   readonly firstUnitId: IrUnitId;
   readonly secondUnitId: IrUnitId;
+  readonly classId: IrClassId;
   readonly module: WasmModule;
   readonly session: ProgramAbiSession;
 }
@@ -45,7 +54,7 @@ interface PlannedCallable {
 function fixture(): Fixture {
   const sourceFile = ts.createSourceFile(
     "/repo/scoped-prepared-abi.ts",
-    "export function first(): void {} function second(): void {}",
+    "export function first(): void {} function second(): void {} class Box {}",
     ts.ScriptTarget.Latest,
     true,
     ts.ScriptKind.TS,
@@ -57,13 +66,15 @@ function fixture(): Fixture {
   const second = inventory.terminalUnits.find(
     (unit) => unit.kind === "top-level-function" && unit.displayName === "second",
   );
-  if (!first || !second) throw new Error("invalid scoped ABI fixture");
+  const classRecord = inventory.classes.find((candidate) => candidate.displayName === "Box");
+  if (!first || !second || !classRecord) throw new Error("invalid scoped ABI fixture");
   const module = createEmptyModule();
   module.types.push({ kind: "func", name: "$void", params: [], results: [] });
   return {
     sourceId: inventory.sources[0]!.id,
     firstUnitId: first.id,
     secondUnitId: second.id,
+    classId: classRecord.id,
     module,
     session: new ProgramAbiSession(inventory, module),
   };
@@ -126,12 +137,12 @@ function supportDraft(session: ProgramAbiSession, id: IrBindingId, unitId: IrUni
   };
 }
 
-function aliasDraft(f: Fixture, id: IrBindingId, targetId: IrBindingId): ProgramAbiDraft {
+function aliasDraft(f: Fixture, id: IrBindingId, targetId: IrBindingId, roleOrdinal = 0): ProgramAbiDraft {
   return {
     id,
     structuralOrder: f.session.structuralOrder.forSource(f.sourceId, {
       domain: "callable",
-      roleOrdinal: 0,
+      roleOrdinal,
     }),
     displayName: "first-alias",
     slotPolicy: "alias",
@@ -162,6 +173,75 @@ function exportDraft(f: Fixture, id: IrBindingId, targetId: IrBindingId): Progra
   };
 }
 
+function importedCallableDraft(f: Fixture, id: IrBindingId, referenceKey: string, roleOrdinal = 1): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: f.session.structuralOrder.forSource(f.sourceId, {
+      domain: "callable",
+      roleOrdinal,
+    }),
+    displayName: "hostCall",
+    structuralReferenceKey: referenceKey,
+    slotPolicy: "required",
+    slotSpace: "function",
+    intent: {
+      kind: "callable",
+      origin: "import",
+      signature: VOID_SIGNATURE,
+    },
+  };
+}
+
+function importedGlobalDraft(f: Fixture, id: IrBindingId, referenceKey: string): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: f.session.structuralOrder.forSource(f.sourceId, {
+      domain: "global",
+      roleOrdinal: 0,
+    }),
+    displayName: "hostGlobal",
+    structuralReferenceKey: referenceKey,
+    slotPolicy: "required",
+    slotSpace: "global",
+    intent: {
+      kind: "global",
+      origin: "import",
+      valueType: JSON.stringify({ kind: "i32" }),
+      mutable: true,
+    },
+  };
+}
+
+function typeDraft(f: Fixture, id: IrBindingId, referenceKey: string): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: f.session.structuralOrder.forSource(f.sourceId, {
+      domain: "type",
+      roleOrdinal: 0,
+    }),
+    displayName: "$PreparedType",
+    structuralReferenceKey: referenceKey,
+    slotPolicy: "required",
+    slotSpace: "type",
+    intent: { kind: "type", shapeKey: "pending" },
+  };
+}
+
+function classDraft(f: Fixture, id: IrBindingId, referenceKey: string): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: f.session.structuralOrder.forClass(f.classId, {
+      domain: "class",
+      roleOrdinal: 0,
+    }),
+    displayName: "$PreparedClass",
+    structuralReferenceKey: referenceKey,
+    slotPolicy: "required",
+    slotSpace: "type",
+    intent: { kind: "class", classId: f.classId, layoutKey: "pending" },
+  };
+}
+
 function expectInvariant(action: () => unknown, code: ProgramAbiInvariantCode): ProgramAbiInvariantError {
   let caught: unknown;
   try {
@@ -178,6 +258,60 @@ function sealFirst(f: Fixture, dependencies: readonly IrBindingId[] = []): Seale
   const transaction = f.session.beginPreparedComponentScope("first-component", [f.firstUnitId]);
   for (const id of dependencies) transaction.includeBinding(id);
   return transaction.seal();
+}
+
+function planPreparedLayouts(f: Fixture) {
+  const typeValue: TypeDef = {
+    kind: "struct",
+    name: "$PreparedType",
+    fields: [{ name: "value", type: { kind: "i32" }, mutable: false }],
+  };
+  const classValue: TypeDef = {
+    kind: "struct",
+    name: "$PreparedClass",
+    fields: [{ name: "field", type: { kind: "i32" }, mutable: true }],
+  };
+  f.module.types.push(typeValue, classValue);
+  const typeId = createIrBindingId({ ownerId: f.sourceId, domain: "type", role: "prepared-type" });
+  const classId = createIrBindingId({ ownerId: f.classId, domain: "class", role: "prepared-class" });
+  const typeKey = `type|${typeId}`;
+  const classKey = `class|${classId}`;
+  f.session.plan(typeDraft(f, typeId, typeKey));
+  f.session.plan(classDraft(f, classId, classKey));
+  f.session.registerStructuralReference(typeId, typeKey);
+  f.session.registerStructuralReference(classId, classKey);
+  const typeCell = f.session.createTypeCell(typeValue);
+  const classCell = f.session.createTypeCell(classValue);
+  f.session.attachLocator(typeId, { kind: "type-cell", cell: typeCell });
+  f.session.attachLocator(classId, { kind: "type-cell", cell: classCell });
+  return { typeId, classId, typeValue, classValue, typeCell, classCell };
+}
+
+function planImportedDependencies(f: Fixture) {
+  const callableId = createIrBindingId({ ownerId: f.sourceId, domain: "callable", role: "host-call" });
+  const globalId = createIrBindingId({ ownerId: f.sourceId, domain: "global", role: "host-global" });
+  const callableKey = "import|3:env|9:host_call";
+  const globalKey = "import-global|3:env|11:host_global";
+  const callable: Import = {
+    module: "env",
+    name: "host_call",
+    desc: { kind: "func", typeIdx: 0 },
+  };
+  const global: Import = {
+    module: "env",
+    name: "host_global",
+    desc: { kind: "global", type: { kind: "i32" }, mutable: true },
+  };
+  f.module.imports.push(callable, global);
+  f.session.plan(importedCallableDraft(f, callableId, callableKey));
+  f.session.plan(importedGlobalDraft(f, globalId, globalKey));
+  f.session.registerCallableTypeContract(callableId, VOID_SIGNATURE);
+  f.session.registerGlobalTypeContract(globalId, { kind: "i32" }, true);
+  f.session.registerStructuralReference(callableId, callableKey);
+  f.session.registerStructuralReference(globalId, globalKey);
+  f.session.attachLocator(callableId, { kind: "import-function", value: callable });
+  f.session.attachLocator(globalId, { kind: "import-global", value: global });
+  return { callableId, globalId, callable, global };
 }
 
 describe("#3521 scoped prepared-component ABI seal", () => {
@@ -228,6 +362,95 @@ describe("#3521 scoped prepared-component ABI seal", () => {
     expect(publication.abi.resolveFinalIndex(clone.id)).toEqual({ space: "function", index: 1 });
     expect(publication.abi.resolveFinalIndex(second.id)).toEqual({ space: "function", index: 2 });
     expect(scoped.entries().map((entry) => entry.id)).toEqual(scoped.bindingIds);
+  });
+
+  it("rejects a registered executable derived unit without its exact callable reservation", () => {
+    const f = fixture();
+    planCallable(f, f.firstUnitId, "body", "first");
+    const liftedUnitId = createDerivedIrUnitId({
+      parentId: f.firstUnitId,
+      role: "lifted-closure",
+      ordinal: 0,
+    });
+    f.session.registerDerivedUnit({
+      id: liftedUnitId,
+      parentId: f.firstUnitId,
+      terminalOwnerId: f.firstUnitId,
+      sourceId: f.sourceId,
+      role: "lifted-closure",
+      ordinal: 0,
+    });
+
+    const incomplete = f.session.beginPreparedComponentScope("incomplete-derived", [f.firstUnitId]);
+    expectInvariant(() => incomplete.seal(), "missing-source-unit");
+
+    const lifted = planCallable(f, liftedUnitId, "body", "first$lifted0");
+    const corrected = f.session.beginPreparedComponentScope("complete-derived", [f.firstUnitId]).seal();
+    expect(corrected.bindingIds).toContain(lifted.id);
+    expect(f.session.publish(f.module).abi.resolveFinalIndex(lifted.id)).toEqual({
+      space: "function",
+      index: 1,
+    });
+  });
+
+  it("allows disjoint scopes but rejects source-callable requests and shared binding ownership", () => {
+    const disjoint = fixture();
+    planCallable(disjoint, disjoint.firstUnitId, "body", "first");
+    planCallable(disjoint, disjoint.secondUnitId, "body", "second");
+    const firstSupport = createIrBindingId({
+      ownerId: disjoint.firstUnitId,
+      domain: "support",
+      role: "first-only",
+    });
+    const secondSupport = createIrBindingId({
+      ownerId: disjoint.secondUnitId,
+      domain: "support",
+      role: "second-only",
+    });
+    disjoint.session.plan(supportDraft(disjoint.session, firstSupport, disjoint.firstUnitId));
+    disjoint.session.plan(supportDraft(disjoint.session, secondSupport, disjoint.secondUnitId));
+    const firstScope = disjoint.session.beginPreparedComponentScope("first", [disjoint.firstUnitId]);
+    firstScope.includeBinding(firstSupport);
+    firstScope.seal();
+    const secondScope = disjoint.session.beginPreparedComponentScope("second", [disjoint.secondUnitId]);
+    secondScope.includeBinding(secondSupport);
+    secondScope.seal();
+    expect(disjoint.session.publish(disjoint.module).abi.entries()).toHaveLength(4);
+
+    const sourceRequest = fixture();
+    planCallable(sourceRequest, sourceRequest.firstUnitId, "body", "first");
+    const other = planCallable(sourceRequest, sourceRequest.secondUnitId, "body", "second");
+    const rejectedSource = sourceRequest.session.beginPreparedComponentScope("source-request", [
+      sourceRequest.firstUnitId,
+    ]);
+    rejectedSource.includeBinding(other.id);
+    expectInvariant(() => rejectedSource.seal(), "invalid-callable-provenance");
+
+    const overlap = fixture();
+    planCallable(overlap, overlap.firstUnitId, "body", "first");
+    planCallable(overlap, overlap.secondUnitId, "body", "second");
+    const importedId = createIrBindingId({
+      ownerId: overlap.sourceId,
+      domain: "callable",
+      role: "shared-import",
+    });
+    const importKey = "import|3:env|6:shared";
+    const imported: Import = {
+      module: "env",
+      name: "shared",
+      desc: { kind: "func", typeIdx: 0 },
+    };
+    overlap.module.imports.push(imported);
+    overlap.session.plan(importedCallableDraft(overlap, importedId, importKey));
+    overlap.session.registerCallableTypeContract(importedId, VOID_SIGNATURE);
+    overlap.session.registerStructuralReference(importedId, importKey);
+    overlap.session.attachLocator(importedId, { kind: "import-function", value: imported });
+    const owner = overlap.session.beginPreparedComponentScope("import-owner", [overlap.firstUnitId]);
+    owner.includeBinding(importedId);
+    owner.seal();
+    const conflicting = overlap.session.beginPreparedComponentScope("import-overlap", [overlap.secondUnitId]);
+    conflicting.includeBinding(importedId);
+    expectInvariant(() => conflicting.seal(), "duplicate-session-draft");
   });
 
   it("rejects missing reservations and locators atomically, then permits a corrected scope", () => {
@@ -338,6 +561,45 @@ describe("#3521 scoped prepared-component ABI seal", () => {
     });
   });
 
+  it("pins imported host module/name, callable signature, and global mutability from exact locators", () => {
+    const linkage = fixture();
+    planCallable(linkage, linkage.firstUnitId, "body", "first");
+    const linked = planImportedDependencies(linkage);
+    sealFirst(linkage, [linked.callableId, linked.globalId]);
+    linked.callable.module = "forged";
+    expectInvariant(() => linkage.session.publish(linkage.module), "binding-reference-mismatch");
+
+    const signature = fixture();
+    planCallable(signature, signature.firstUnitId, "body", "first");
+    const typed = planImportedDependencies(signature);
+    sealFirst(signature, [typed.callableId, typed.globalId]);
+    signature.module.types.push({
+      kind: "func",
+      name: "$forged",
+      params: [{ kind: "i32" }],
+      results: [],
+    });
+    if (typed.callable.desc.kind !== "func") throw new Error("invalid callable import fixture");
+    typed.callable.desc.typeIdx = 1;
+    expectInvariant(() => signature.session.publish(signature.module), "type-remap-mismatch");
+
+    const mutability = fixture();
+    planCallable(mutability, mutability.firstUnitId, "body", "first");
+    const global = planImportedDependencies(mutability);
+    sealFirst(mutability, [global.callableId, global.globalId]);
+    if (global.global.desc.kind !== "global") throw new Error("invalid global import fixture");
+    global.global.name = "forged_global";
+    expectInvariant(() => mutability.session.publish(mutability.module), "binding-reference-mismatch");
+
+    const storage = fixture();
+    planCallable(storage, storage.firstUnitId, "body", "first");
+    const stored = planImportedDependencies(storage);
+    sealFirst(storage, [stored.callableId, stored.globalId]);
+    if (stored.global.desc.kind !== "global") throw new Error("invalid global import fixture");
+    stored.global.desc.mutable = false;
+    expectInvariant(() => storage.session.publish(storage.module), "type-remap-mismatch");
+  });
+
   it("fails closed when the reserved callable contract drifts before final reconciliation", () => {
     const f = fixture();
     const first = planCallable(f, f.firstUnitId, "body", "first");
@@ -410,6 +672,139 @@ describe("#3521 scoped prepared-component ABI seal", () => {
       space: "function",
       index: 0,
     });
+  });
+
+  it("pins type/class layouts structurally and advances them only through exact DCE layout remaps", () => {
+    const drift = fixture();
+    planCallable(drift, drift.firstUnitId, "body", "first");
+    const driftLayouts = planPreparedLayouts(drift);
+    sealFirst(drift, [driftLayouts.typeId, driftLayouts.classId]);
+    expectInvariant(
+      () =>
+        drift.session.remapTypeCell(driftLayouts.typeCell, {
+          kind: "struct",
+          name: "$Forged",
+          fields: [],
+        }),
+      "type-remap-mismatch",
+    );
+    if (driftLayouts.classValue.kind !== "struct") throw new Error("invalid class layout fixture");
+    driftLayouts.classValue.fields.push({
+      name: "late",
+      type: { kind: "i32" },
+      mutable: false,
+    });
+    expectInvariant(() => drift.session.publish(drift.module), "type-remap-mismatch");
+
+    const forgedRemap = fixture();
+    planCallable(forgedRemap, forgedRemap.firstUnitId, "body", "first");
+    const forgedLayouts = planPreparedLayouts(forgedRemap);
+    sealFirst(forgedRemap, [forgedLayouts.typeId, forgedLayouts.classId]);
+    const forgedPrevious = forgedRemap.module.types;
+    const forgedNext: TypeDef[] = [
+      forgedPrevious[0]!,
+      { kind: "struct", name: "$ForgedClass", fields: [] },
+      forgedPrevious[1]!,
+    ];
+    expectInvariant(
+      () =>
+        forgedRemap.session.applyTypeLayoutRemap({
+          previousTypes: forgedPrevious,
+          nextTypes: forgedNext,
+          targetsByOldIndex: [0, 2, 1],
+        }),
+      "type-remap-mismatch",
+    );
+    expect(forgedRemap.session.publish(forgedRemap.module).abi.resolveFinalIndex(forgedLayouts.classId)).toEqual({
+      space: "type",
+      index: 2,
+    });
+
+    const remapped = fixture();
+    planCallable(remapped, remapped.firstUnitId, "body", "first");
+    const exactLayouts = planPreparedLayouts(remapped);
+    sealFirst(remapped, [exactLayouts.typeId, exactLayouts.classId]);
+    const previousTypes = remapped.module.types;
+    if (exactLayouts.typeValue.kind !== "struct" || exactLayouts.classValue.kind !== "struct") {
+      throw new Error("invalid exact layout fixture");
+    }
+    const nextClass: TypeDef = {
+      ...exactLayouts.classValue,
+      name: "$PreparedClass$remapped",
+      fields: exactLayouts.classValue.fields.map((field) => ({ ...field, type: { ...field.type } })),
+    };
+    const nextType: TypeDef = {
+      ...exactLayouts.typeValue,
+      name: "$PreparedType$remapped",
+      fields: exactLayouts.typeValue.fields.map((field) => ({ ...field, type: { ...field.type } })),
+    };
+    const nextTypes = [previousTypes[0]!, nextClass, nextType];
+    remapped.session.applyTypeLayoutRemap({
+      previousTypes,
+      nextTypes,
+      targetsByOldIndex: [0, 2, 1],
+    });
+    remapped.module.types = nextTypes;
+    const publication = remapped.session.publish(remapped.module);
+    expect(publication.abi.resolveFinalIndex(exactLayouts.typeId)).toEqual({
+      space: "type",
+      index: 2,
+    });
+    expect(publication.abi.resolveFinalIndex(exactLayouts.classId)).toEqual({
+      space: "type",
+      index: 1,
+    });
+  });
+
+  it("rejects alias cycles, duplicate discovery, custom IDs, and post-seal locator removal", () => {
+    const cycle = fixture();
+    planCallable(cycle, cycle.firstUnitId, "body", "first");
+    const aliasA = createIrBindingId({ ownerId: cycle.sourceId, domain: "callable", role: "cycle-a" });
+    const aliasB = createIrBindingId({ ownerId: cycle.sourceId, domain: "callable", role: "cycle-b" });
+    cycle.session.plan(aliasDraft(cycle, aliasA, aliasB, 0));
+    cycle.session.plan(aliasDraft(cycle, aliasB, aliasA, 1));
+    const cyclic = cycle.session.beginPreparedComponentScope("alias-cycle", [cycle.firstUnitId]);
+    cyclic.includeBinding(aliasA);
+    expectInvariant(() => cyclic.seal(), "alias-cycle");
+
+    const duplicate = fixture();
+    planCallable(duplicate, duplicate.firstUnitId, "body", "first");
+    const supportId = createIrBindingId({
+      ownerId: duplicate.firstUnitId,
+      domain: "support",
+      role: "duplicate",
+    });
+    duplicate.session.plan(supportDraft(duplicate.session, supportId, duplicate.firstUnitId));
+    const duplicateDiscovery = duplicate.session.beginPreparedComponentScope("duplicate", [duplicate.firstUnitId]);
+    duplicateDiscovery.includeBinding(supportId);
+    expectInvariant(() => duplicateDiscovery.includeBinding(supportId), "duplicate-session-draft");
+    duplicateDiscovery.abort();
+
+    const custom = fixture();
+    const customId = "custom-callable-id" as IrBindingId;
+    const customKey = `unit|${custom.firstUnitId}|body`;
+    const customFunc: WasmFunction = {
+      name: "first",
+      typeIdx: 0,
+      locals: [],
+      body: [],
+      exported: false,
+    };
+    custom.module.functions.push(customFunc);
+    custom.session.plan(callableDraft(custom.session, customId, custom.firstUnitId, "first", customKey));
+    custom.session.registerCallableTypeContract(customId, VOID_SIGNATURE);
+    custom.session.registerStructuralReference(customId, customKey);
+    custom.session.attachLocator(customId, { kind: "defined-function", value: customFunc });
+    expectInvariant(
+      () => custom.session.beginPreparedComponentScope("custom-id", [custom.firstUnitId]).seal(),
+      "invalid-binding-reference",
+    );
+
+    const removed = fixture();
+    planCallable(removed, removed.firstUnitId, "body", "first");
+    sealFirst(removed);
+    removed.module.functions.splice(0, 1);
+    expectInvariant(() => removed.session.publish(removed.module), "eliminated-required-locator");
   });
 
   it("aborts discovery without publishing a partial scope or closing unrelated planning", () => {

--- a/tests/issue-3521-scoped-prepared-abi-seal.test.ts
+++ b/tests/issue-3521-scoped-prepared-abi-seal.test.ts
@@ -1,0 +1,446 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import {
+  ProgramAbiSession,
+  type ProgramAbiDraft,
+  type SealedPreparedProgramAbiScope,
+} from "../src/codegen/program-abi-session.js";
+import { canonicalProgramAbiCallableTypeContract } from "../src/codegen/program-abi-signatures.js";
+import {
+  buildIrUnitInventory,
+  createDerivedIrUnitId,
+  createIrBindingId,
+  type IrBindingId,
+  type IrSourceId,
+  type IrUnitId,
+} from "../src/ir/identity.js";
+import {
+  ProgramAbiInvariantError,
+  type ProgramAbiDerivedUnitRecord,
+  type ProgramAbiInvariantCode,
+} from "../src/ir/program-abi.js";
+import { createEmptyModule, type WasmFunction, type WasmModule } from "../src/ir/types.js";
+import { ts } from "../src/ts-api.js";
+
+const VOID_SIGNATURE = Object.freeze({
+  params: Object.freeze([]),
+  results: Object.freeze([]),
+});
+
+interface Fixture {
+  readonly sourceId: IrSourceId;
+  readonly firstUnitId: IrUnitId;
+  readonly secondUnitId: IrUnitId;
+  readonly module: WasmModule;
+  readonly session: ProgramAbiSession;
+}
+
+interface PlannedCallable {
+  readonly id: IrBindingId;
+  readonly func: WasmFunction;
+  readonly referenceKey: string;
+}
+
+function fixture(): Fixture {
+  const sourceFile = ts.createSourceFile(
+    "/repo/scoped-prepared-abi.ts",
+    "export function first(): void {} function second(): void {}",
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile });
+  const first = inventory.terminalUnits.find(
+    (unit) => unit.kind === "top-level-function" && unit.displayName === "first",
+  );
+  const second = inventory.terminalUnits.find(
+    (unit) => unit.kind === "top-level-function" && unit.displayName === "second",
+  );
+  if (!first || !second) throw new Error("invalid scoped ABI fixture");
+  const module = createEmptyModule();
+  module.types.push({ kind: "func", name: "$void", params: [], results: [] });
+  return {
+    sourceId: inventory.sources[0]!.id,
+    firstUnitId: first.id,
+    secondUnitId: second.id,
+    module,
+    session: new ProgramAbiSession(inventory, module),
+  };
+}
+
+function callableDraft(
+  session: ProgramAbiSession,
+  id: IrBindingId,
+  unitId: IrUnitId,
+  displayName: string,
+  referenceKey: string,
+): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: session.structuralOrder.forUnit(unitId, {
+      domain: "callable",
+      roleOrdinal: 0,
+    }),
+    displayName,
+    structuralReferenceKey: referenceKey,
+    slotPolicy: "required",
+    slotSpace: "function",
+    intent: {
+      kind: "callable",
+      origin: "source",
+      signature: VOID_SIGNATURE,
+      unitId,
+    },
+  };
+}
+
+function planCallable(f: Fixture, unitId: IrUnitId, role: string, displayName: string): PlannedCallable {
+  const id = createIrBindingId({ ownerId: unitId, domain: "callable", role });
+  const referenceKey = `unit|${unitId}|${role}`;
+  const func: WasmFunction = {
+    name: displayName,
+    typeIdx: 0,
+    locals: [],
+    body: [],
+    exported: false,
+  };
+  f.module.functions.push(func);
+  f.session.plan(callableDraft(f.session, id, unitId, displayName, referenceKey));
+  f.session.registerCallableTypeContract(id, VOID_SIGNATURE);
+  f.session.registerStructuralReference(id, referenceKey);
+  f.session.attachLocator(id, { kind: "defined-function", value: func });
+  return { id, func, referenceKey };
+}
+
+function supportDraft(session: ProgramAbiSession, id: IrBindingId, unitId: IrUnitId, roleOrdinal = 0): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: session.structuralOrder.forUnit(unitId, {
+      domain: "support",
+      roleOrdinal,
+    }),
+    displayName: "prepared-support",
+    slotPolicy: "none",
+    intent: { kind: "support", role: "prepared-support" },
+  };
+}
+
+function aliasDraft(f: Fixture, id: IrBindingId, targetId: IrBindingId): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: f.session.structuralOrder.forSource(f.sourceId, {
+      domain: "callable",
+      roleOrdinal: 0,
+    }),
+    displayName: "first-alias",
+    slotPolicy: "alias",
+    aliasOf: targetId,
+    intent: {
+      kind: "callable",
+      origin: "import",
+      signature: VOID_SIGNATURE,
+    },
+  };
+}
+
+function exportDraft(f: Fixture, id: IrBindingId, targetId: IrBindingId): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: f.session.structuralOrder.forSource(f.sourceId, {
+      domain: "export",
+      roleOrdinal: 0,
+    }),
+    displayName: "first",
+    slotPolicy: "alias",
+    aliasOf: targetId,
+    intent: {
+      kind: "export",
+      externalName: "first",
+      targetId,
+    },
+  };
+}
+
+function expectInvariant(action: () => unknown, code: ProgramAbiInvariantCode): ProgramAbiInvariantError {
+  let caught: unknown;
+  try {
+    action();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(ProgramAbiInvariantError);
+  expect((caught as ProgramAbiInvariantError).code).toBe(code);
+  return caught as ProgramAbiInvariantError;
+}
+
+function sealFirst(f: Fixture, dependencies: readonly IrBindingId[] = []): SealedPreparedProgramAbiScope {
+  const transaction = f.session.beginPreparedComponentScope("first-component", [f.firstUnitId]);
+  for (const id of dependencies) transaction.includeBinding(id);
+  return transaction.seal();
+}
+
+describe("#3521 scoped prepared-component ABI seal", () => {
+  it("pins callable, derived, alias, export, and support closure while unrelated direct planning remains legal", () => {
+    const f = fixture();
+    const first = planCallable(f, f.firstUnitId, "body", "first");
+    const derivedUnitId = createDerivedIrUnitId({
+      parentId: f.firstUnitId,
+      role: "monomorphized-clone",
+      ordinal: 0,
+    });
+    const derivedRecord: ProgramAbiDerivedUnitRecord = {
+      id: derivedUnitId,
+      parentId: f.firstUnitId,
+      terminalOwnerId: f.firstUnitId,
+      sourceId: f.sourceId,
+      role: "monomorphized-clone",
+      ordinal: 0,
+    };
+    f.session.registerDerivedUnit(derivedRecord);
+    const clone = planCallable(f, derivedUnitId, "body", "first$mono0");
+    const aliasId = createIrBindingId({ ownerId: f.sourceId, domain: "callable", role: "first-alias" });
+    const exportId = createIrBindingId({ ownerId: f.sourceId, domain: "export", role: "first" });
+    const supportId = createIrBindingId({ ownerId: f.firstUnitId, domain: "support", role: "string-table" });
+    f.session.plan(aliasDraft(f, aliasId, first.id));
+    f.session.plan(exportDraft(f, exportId, first.id));
+    f.session.plan(supportDraft(f.session, supportId, f.firstUnitId));
+
+    const scoped = sealFirst(f, [supportId]);
+    expect(scoped.planningSealed).toBe(true);
+    expect(scoped.terminalUnitIds).toEqual([f.firstUnitId]);
+    expect(scoped.derivedUnits).toEqual([derivedRecord]);
+    expect(new Set(scoped.bindingIds)).toEqual(new Set([first.id, clone.id, aliasId, exportId, supportId]));
+    expect(scoped.canonicalId(aliasId)).toBe(first.id);
+    expect(scoped.canonicalId(exportId)).toBe(first.id);
+    expect(scoped.entries().map((entry) => entry.id)).toEqual(scoped.bindingIds);
+
+    const second = planCallable(f, f.secondUnitId, "body", "second");
+    const unrelatedSupportId = createIrBindingId({
+      ownerId: f.secondUnitId,
+      domain: "support",
+      role: "direct-only",
+    });
+    f.session.plan(supportDraft(f.session, unrelatedSupportId, f.secondUnitId));
+
+    const publication = f.session.publish(f.module);
+    expect(publication.abi.resolveFinalIndex(first.id)).toEqual({ space: "function", index: 0 });
+    expect(publication.abi.resolveFinalIndex(clone.id)).toEqual({ space: "function", index: 1 });
+    expect(publication.abi.resolveFinalIndex(second.id)).toEqual({ space: "function", index: 2 });
+    expect(scoped.entries().map((entry) => entry.id)).toEqual(scoped.bindingIds);
+  });
+
+  it("rejects missing reservations and locators atomically, then permits a corrected scope", () => {
+    const missingLocator = fixture();
+    const locatorId = createIrBindingId({
+      ownerId: missingLocator.firstUnitId,
+      domain: "callable",
+      role: "body",
+    });
+    const locatorKey = `unit|${missingLocator.firstUnitId}|body`;
+    missingLocator.session.plan(
+      callableDraft(missingLocator.session, locatorId, missingLocator.firstUnitId, "first", locatorKey),
+    );
+    missingLocator.session.registerCallableTypeContract(locatorId, VOID_SIGNATURE);
+    missingLocator.session.registerStructuralReference(locatorId, locatorKey);
+    const failedLocator = missingLocator.session.beginPreparedComponentScope("missing-locator", [
+      missingLocator.firstUnitId,
+    ]);
+    expectInvariant(() => failedLocator.seal(), "missing-required-locator");
+    expectInvariant(() => failedLocator.includeBinding(locatorId), "session-closed");
+
+    const locator: WasmFunction = {
+      name: "first",
+      typeIdx: 0,
+      locals: [],
+      body: [],
+      exported: false,
+    };
+    missingLocator.module.functions.push(locator);
+    missingLocator.session.attachLocator(locatorId, { kind: "defined-function", value: locator });
+    const corrected = missingLocator.session.beginPreparedComponentScope("corrected", [missingLocator.firstUnitId]);
+    expect(corrected.seal().bindingIds).toEqual([locatorId]);
+
+    const missingReference = fixture();
+    const unreservedId = createIrBindingId({
+      ownerId: missingReference.firstUnitId,
+      domain: "callable",
+      role: "body",
+    });
+    const unreservedKey = `unit|${missingReference.firstUnitId}|body`;
+    const unreservedFunc: WasmFunction = {
+      name: "first",
+      typeIdx: 0,
+      locals: [],
+      body: [],
+      exported: false,
+    };
+    missingReference.module.functions.push(unreservedFunc);
+    missingReference.session.plan(
+      callableDraft(missingReference.session, unreservedId, missingReference.firstUnitId, "first", unreservedKey),
+    );
+    missingReference.session.registerCallableTypeContract(unreservedId, VOID_SIGNATURE);
+    missingReference.session.attachLocator(unreservedId, {
+      kind: "defined-function",
+      value: unreservedFunc,
+    });
+    const failedReference = missingReference.session.beginPreparedComponentScope("missing-reference", [
+      missingReference.firstUnitId,
+    ]);
+    expectInvariant(() => failedReference.seal(), "missing-binding-reference");
+  });
+
+  it("rejects prepared-owned late support, derived units, and locator replacement but accepts unrelated support", () => {
+    const f = fixture();
+    const first = planCallable(f, f.firstUnitId, "body", "first");
+    sealFirst(f);
+
+    const lateSupportId = createIrBindingId({
+      ownerId: f.firstUnitId,
+      domain: "support",
+      role: "late-helper",
+    });
+    expectInvariant(() => f.session.plan(supportDraft(f.session, lateSupportId, f.firstUnitId)), "planning-sealed");
+    expectInvariant(
+      () =>
+        f.session.registerDerivedUnit({
+          id: createDerivedIrUnitId({
+            parentId: f.firstUnitId,
+            role: "lifted-closure",
+            ordinal: 0,
+          }),
+          parentId: f.firstUnitId,
+          terminalOwnerId: f.firstUnitId,
+          sourceId: f.sourceId,
+          role: "lifted-closure",
+          ordinal: 0,
+        }),
+      "planning-sealed",
+    );
+    expectInvariant(
+      () =>
+        f.session.replaceDefinedFunctionLocator(first.id, first.func, {
+          ...first.func,
+          name: "replacement",
+        }),
+      "locator-remap-mismatch",
+    );
+
+    const unrelatedSupportId = createIrBindingId({
+      ownerId: f.secondUnitId,
+      domain: "support",
+      role: "late-direct-helper",
+    });
+    f.session.plan(supportDraft(f.session, unrelatedSupportId, f.secondUnitId));
+    expect(f.session.publish(f.module).abi.resolveFinalIndex(first.id)).toEqual({
+      space: "function",
+      index: 0,
+    });
+  });
+
+  it("fails closed when the reserved callable contract drifts before final reconciliation", () => {
+    const f = fixture();
+    const first = planCallable(f, f.firstUnitId, "body", "first");
+    sealFirst(f);
+    f.module.types.push({ kind: "func", name: "$i32", params: [{ kind: "i32" }], results: [] });
+    first.func.typeIdx = 1;
+
+    expectInvariant(() => f.session.publish(f.module), "type-remap-mismatch");
+    expectInvariant(() => f.session.publish(f.module), "session-publish-once");
+  });
+
+  it("advances pinned structured contracts only through an explicit type-layout remap", () => {
+    const f = fixture();
+    const previousTypes = [
+      { kind: "struct" as const, name: "$Payload", fields: [] },
+      {
+        kind: "func" as const,
+        name: "$consume",
+        params: [{ kind: "ref" as const, typeIdx: 0 }],
+        results: [],
+      },
+    ];
+    f.module.types = previousTypes;
+    const contract = Object.freeze({
+      params: Object.freeze([{ kind: "ref" as const, typeIdx: 0 }]),
+      results: Object.freeze([]),
+    });
+    const id = createIrBindingId({ ownerId: f.firstUnitId, domain: "callable", role: "body" });
+    const referenceKey = `unit|${f.firstUnitId}|body`;
+    const func: WasmFunction = {
+      name: "first",
+      typeIdx: 1,
+      locals: [],
+      body: [],
+      exported: false,
+    };
+    f.module.functions.push(func);
+    f.session.plan({
+      ...callableDraft(f.session, id, f.firstUnitId, "first", referenceKey),
+      intent: {
+        kind: "callable",
+        origin: "source",
+        signature: canonicalProgramAbiCallableTypeContract(contract),
+        unitId: f.firstUnitId,
+      },
+    });
+    f.session.registerCallableTypeContract(id, contract);
+    f.session.registerStructuralReference(id, referenceKey);
+    f.session.attachLocator(id, { kind: "defined-function", value: func });
+    sealFirst(f);
+
+    const nextTypes = [
+      {
+        kind: "func" as const,
+        name: "$consume",
+        params: [{ kind: "ref" as const, typeIdx: 1 }],
+        results: [],
+      },
+      { kind: "struct" as const, name: "$Payload", fields: [] },
+    ];
+    f.session.applyTypeLayoutRemap({
+      previousTypes,
+      nextTypes,
+      targetsByOldIndex: [1, 0],
+    });
+    f.module.types = nextTypes;
+    func.typeIdx = 0;
+
+    expect(f.session.publish(f.module).abi.resolveFinalIndex(id)).toEqual({
+      space: "function",
+      index: 0,
+    });
+  });
+
+  it("aborts discovery without publishing a partial scope or closing unrelated planning", () => {
+    const f = fixture();
+    planCallable(f, f.firstUnitId, "body", "first");
+    const unknownSupportId = createIrBindingId({
+      ownerId: f.firstUnitId,
+      domain: "support",
+      role: "not-yet-planned",
+    });
+    const failed = f.session.beginPreparedComponentScope("failed-discovery", [f.firstUnitId]);
+    failed.includeBinding(unknownSupportId);
+    expectInvariant(() => failed.seal(), "unknown-binding");
+    expectInvariant(() => failed.abort(), "session-closed");
+
+    f.session.plan(supportDraft(f.session, unknownSupportId, f.firstUnitId));
+    const retry = f.session.beginPreparedComponentScope("retry", [f.firstUnitId]);
+    retry.includeBinding(unknownSupportId);
+    expect(retry.seal().bindingIds).toContain(unknownSupportId);
+    expect(f.session.publish(f.module).abi.get(unknownSupportId)?.intent).toEqual({
+      kind: "support",
+      role: "prepared-support",
+    });
+  });
+
+  it("requires open scope transactions to abort or seal before whole-program sealing", () => {
+    const f = fixture();
+    planCallable(f, f.firstUnitId, "body", "first");
+    const transaction = f.session.beginPreparedComponentScope("open", [f.firstUnitId]);
+    expectInvariant(() => f.session.sealPlan(f.module), "planning-not-sealed");
+    transaction.abort();
+    expect(f.session.publish(f.module).abi.entries()).toHaveLength(1);
+  });
+});

--- a/tests/issue-3521-scoped-prepared-abi-seal.test.ts
+++ b/tests/issue-3521-scoped-prepared-abi-seal.test.ts
@@ -6,7 +6,11 @@ import {
   type ProgramAbiDraft,
   type SealedPreparedProgramAbiScope,
 } from "../src/codegen/program-abi-session.js";
-import { canonicalProgramAbiCallableTypeContract } from "../src/codegen/program-abi-signatures.js";
+import {
+  canonicalProgramAbiCallableTypeContract,
+  canonicalProgramAbiValType,
+  type ProgramAbiCallableTypeContract,
+} from "../src/codegen/program-abi-signatures.js";
 import {
   buildIrUnitInventory,
   createDerivedIrUnitId,
@@ -15,6 +19,7 @@ import {
   type IrClassId,
   type IrSourceId,
   type IrUnitId,
+  type IrUnitInventory,
 } from "../src/ir/identity.js";
 import {
   ProgramAbiInvariantError,
@@ -37,10 +42,13 @@ const VOID_SIGNATURE = Object.freeze({
 });
 
 interface Fixture {
+  readonly inventory: IrUnitInventory;
   readonly sourceId: IrSourceId;
   readonly firstUnitId: IrUnitId;
   readonly secondUnitId: IrUnitId;
   readonly classId: IrClassId;
+  readonly firstNestedClassId: IrClassId;
+  readonly secondNestedClassId: IrClassId;
   readonly module: WasmModule;
   readonly session: ProgramAbiSession;
 }
@@ -54,7 +62,20 @@ interface PlannedCallable {
 function fixture(): Fixture {
   const sourceFile = ts.createSourceFile(
     "/repo/scoped-prepared-abi.ts",
-    "export function first(): void {} function second(): void {} class Box {}",
+    `
+      export function first(): void {
+        function firstNested(): void {}
+        const firstExpression = function (): void {};
+        const firstArrow = (): void => {};
+        const firstObject = { run(): void {} };
+        class FirstNestedClass { run(): void {} }
+      }
+      function second(): void {
+        function secondNested(): void {}
+        class SecondNestedClass { run(): void {} }
+      }
+      class Box {}
+    `,
     ts.ScriptTarget.Latest,
     true,
     ts.ScriptKind.TS,
@@ -67,14 +88,21 @@ function fixture(): Fixture {
     (unit) => unit.kind === "top-level-function" && unit.displayName === "second",
   );
   const classRecord = inventory.classes.find((candidate) => candidate.displayName === "Box");
-  if (!first || !second || !classRecord) throw new Error("invalid scoped ABI fixture");
+  const firstNestedClass = inventory.classes.find((candidate) => candidate.displayName === "FirstNestedClass");
+  const secondNestedClass = inventory.classes.find((candidate) => candidate.displayName === "SecondNestedClass");
+  if (!first || !second || !classRecord || !firstNestedClass || !secondNestedClass) {
+    throw new Error("invalid scoped ABI fixture");
+  }
   const module = createEmptyModule();
   module.types.push({ kind: "func", name: "$void", params: [], results: [] });
   return {
+    inventory,
     sourceId: inventory.sources[0]!.id,
     firstUnitId: first.id,
     secondUnitId: second.id,
     classId: classRecord.id,
+    firstNestedClassId: firstNestedClass.id,
+    secondNestedClassId: secondNestedClass.id,
     module,
     session: new ProgramAbiSession(inventory, module),
   };
@@ -151,6 +179,62 @@ function aliasDraft(f: Fixture, id: IrBindingId, targetId: IrBindingId, roleOrdi
       kind: "callable",
       origin: "import",
       signature: VOID_SIGNATURE,
+    },
+  };
+}
+
+function ownedAliasDraft(
+  f: Fixture,
+  id: IrBindingId,
+  targetId: IrBindingId,
+  ownerUnitId: IrUnitId,
+  signature: ProgramAbiCallableTypeContract = VOID_SIGNATURE,
+): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: f.session.structuralOrder.forUnit(ownerUnitId, {
+      domain: "callable",
+      roleOrdinal: 9,
+    }),
+    displayName: "owned-alias",
+    slotPolicy: "alias",
+    aliasOf: targetId,
+    intent: {
+      kind: "callable",
+      origin: "import",
+      signature: canonicalProgramAbiCallableTypeContract(signature),
+    },
+  };
+}
+
+function classSupportDraft(f: Fixture, id: IrBindingId, classId: IrClassId, roleOrdinal = 0): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: f.session.structuralOrder.forClass(classId, {
+      domain: "support",
+      roleOrdinal,
+    }),
+    displayName: "class-support",
+    slotPolicy: "none",
+    intent: { kind: "support", role: "class-support" },
+  };
+}
+
+function globalAliasDraft(f: Fixture, id: IrBindingId, targetId: IrBindingId, valueType: string): ProgramAbiDraft {
+  return {
+    id,
+    structuralOrder: f.session.structuralOrder.forSource(f.sourceId, {
+      domain: "global",
+      roleOrdinal: 8,
+    }),
+    displayName: "global-alias",
+    slotPolicy: "alias",
+    aliasOf: targetId,
+    intent: {
+      kind: "global",
+      origin: "import",
+      valueType,
+      mutable: true,
     },
   };
 }
@@ -391,6 +475,137 @@ describe("#3521 scoped prepared-component ABI seal", () => {
       space: "function",
       index: 1,
     });
+  });
+
+  it("owns inventoried nested functions, expressions, arrows, and object methods through their terminal root", () => {
+    const f = fixture();
+    planCallable(f, f.firstUnitId, "body", "first");
+    planCallable(f, f.secondUnitId, "body", "second");
+    const nestedUnits = f.inventory.allUnits.filter(
+      (unit) =>
+        unit.terminalOwnerId === f.firstUnitId &&
+        (unit.kind === "nested-function" ||
+          unit.kind === "function-expression" ||
+          unit.kind === "arrow-function" ||
+          unit.kind === "object-method"),
+    );
+    expect(nestedUnits.map((unit) => unit.kind).sort()).toEqual([
+      "arrow-function",
+      "function-expression",
+      "nested-function",
+      "object-method",
+    ]);
+    const nestedCallables = nestedUnits.map((unit) => planCallable(f, unit.id, "body", unit.displayName));
+
+    const scoped = sealFirst(f);
+    expect(new Set(scoped.bindingIds)).toEqual(
+      new Set([
+        createIrBindingId({ ownerId: f.firstUnitId, domain: "callable", role: "body" }),
+        ...nestedCallables.map((entry) => entry.id),
+      ]),
+    );
+
+    const lateSupportId = createIrBindingId({
+      ownerId: nestedUnits[0]!.id,
+      domain: "support",
+      role: "late-nested-support",
+    });
+    expectInvariant(
+      () => f.session.plan(supportDraft(f.session, lateSupportId, nestedUnits[0]!.id, 7)),
+      "planning-sealed",
+    );
+    const lateCallableId = createIrBindingId({
+      ownerId: nestedUnits[1]!.id,
+      domain: "callable",
+      role: "late-nested-callable",
+    });
+    expectInvariant(
+      () => f.session.plan(callableDraft(f.session, lateCallableId, nestedUnits[1]!.id, "lateNested", "late|nested")),
+      "planning-sealed",
+    );
+
+    const crossRequest = fixture();
+    planCallable(crossRequest, crossRequest.firstUnitId, "body", "first");
+    planCallable(crossRequest, crossRequest.secondUnitId, "body", "second");
+    const firstNested = crossRequest.inventory.allUnits.find(
+      (unit) => unit.kind === "nested-function" && unit.terminalOwnerId === crossRequest.firstUnitId,
+    )!;
+    const nestedSupportId = createIrBindingId({
+      ownerId: firstNested.id,
+      domain: "support",
+      role: "nested-only",
+    });
+    crossRequest.session.plan(supportDraft(crossRequest.session, nestedSupportId, firstNested.id, 6));
+    const wrongComponent = crossRequest.session.beginPreparedComponentScope("second-cross-request", [
+      crossRequest.secondUnitId,
+    ]);
+    wrongComponent.includeBinding(nestedSupportId);
+    expectInvariant(() => wrongComponent.seal(), "invalid-callable-provenance");
+  });
+
+  it("retains structural binding and nested-class ownership across closure and disjoint scopes", () => {
+    const closure = fixture();
+    const first = planCallable(closure, closure.firstUnitId, "body", "first");
+    planCallable(closure, closure.secondUnitId, "body", "second");
+    const foreignAliasId = createIrBindingId({
+      ownerId: closure.secondUnitId,
+      domain: "callable",
+      role: "foreign-alias",
+    });
+    closure.session.plan(ownedAliasDraft(closure, foreignAliasId, first.id, closure.secondUnitId));
+    expectInvariant(() => sealFirst(closure), "invalid-callable-provenance");
+
+    const exportClosure = fixture();
+    const exportFirst = planCallable(exportClosure, exportClosure.firstUnitId, "body", "first");
+    planCallable(exportClosure, exportClosure.secondUnitId, "body", "second");
+    const foreignExportId = createIrBindingId({
+      ownerId: exportClosure.secondUnitId,
+      domain: "export",
+      role: "foreign-export",
+    });
+    exportClosure.session.plan({
+      ...exportDraft(exportClosure, foreignExportId, exportFirst.id),
+      displayName: "foreign-export",
+    });
+    expectInvariant(() => sealFirst(exportClosure), "invalid-callable-provenance");
+
+    const classRequest = fixture();
+    planCallable(classRequest, classRequest.firstUnitId, "body", "first");
+    planCallable(classRequest, classRequest.secondUnitId, "body", "second");
+    const secondClassSupportId = createIrBindingId({
+      ownerId: classRequest.secondNestedClassId,
+      domain: "support",
+      role: "second-class-support",
+    });
+    classRequest.session.plan(classSupportDraft(classRequest, secondClassSupportId, classRequest.secondNestedClassId));
+    const wrongClassOwner = classRequest.session.beginPreparedComponentScope("first-class-request", [
+      classRequest.firstUnitId,
+    ]);
+    wrongClassOwner.includeBinding(secondClassSupportId);
+    expectInvariant(() => wrongClassOwner.seal(), "invalid-callable-provenance");
+
+    const disjoint = fixture();
+    planCallable(disjoint, disjoint.firstUnitId, "body", "first");
+    planCallable(disjoint, disjoint.secondUnitId, "body", "second");
+    const firstClassSupportId = createIrBindingId({
+      ownerId: disjoint.firstNestedClassId,
+      domain: "support",
+      role: "first-class-support",
+    });
+    const secondDisjointClassSupportId = createIrBindingId({
+      ownerId: disjoint.secondNestedClassId,
+      domain: "support",
+      role: "second-class-support",
+    });
+    disjoint.session.plan(classSupportDraft(disjoint, firstClassSupportId, disjoint.firstNestedClassId));
+    disjoint.session.plan(classSupportDraft(disjoint, secondDisjointClassSupportId, disjoint.secondNestedClassId));
+    const firstScope = disjoint.session.beginPreparedComponentScope("first-class", [disjoint.firstUnitId]);
+    firstScope.includeBinding(firstClassSupportId);
+    firstScope.seal();
+    const secondScope = disjoint.session.beginPreparedComponentScope("second-class", [disjoint.secondUnitId]);
+    secondScope.includeBinding(secondDisjointClassSupportId);
+    secondScope.seal();
+    expect(disjoint.session.publish(disjoint.module).abi.entries()).toHaveLength(4);
   });
 
   it("allows disjoint scopes but rejects source-callable requests and shared binding ownership", () => {
@@ -674,6 +889,107 @@ describe("#3521 scoped prepared-component ABI seal", () => {
     });
   });
 
+  it("refreshes callable and global aliases that inherit canonical contracts during a valid reorder", () => {
+    const f = fixture();
+    const previousTypes: TypeDef[] = [
+      {
+        kind: "struct",
+        name: "$Payload",
+        fields: [{ name: "value", type: { kind: "i32" }, mutable: false }],
+      },
+      {
+        kind: "func",
+        name: "$consume",
+        params: [{ kind: "ref", typeIdx: 0 }],
+        results: [],
+      },
+    ];
+    f.module.types = previousTypes;
+    const callableContract: ProgramAbiCallableTypeContract = Object.freeze({
+      params: Object.freeze([{ kind: "ref" as const, typeIdx: 0 }]),
+      results: Object.freeze([]),
+    });
+    const callableId = createIrBindingId({ ownerId: f.firstUnitId, domain: "callable", role: "body" });
+    const callableKey = `unit|${f.firstUnitId}|body`;
+    const func: WasmFunction = {
+      name: "first",
+      typeIdx: 1,
+      locals: [],
+      body: [],
+      exported: false,
+    };
+    f.module.functions.push(func);
+    f.session.plan({
+      ...callableDraft(f.session, callableId, f.firstUnitId, "first", callableKey),
+      intent: {
+        kind: "callable",
+        origin: "source",
+        signature: canonicalProgramAbiCallableTypeContract(callableContract),
+        unitId: f.firstUnitId,
+      },
+    });
+    f.session.registerCallableTypeContract(callableId, callableContract);
+    f.session.registerStructuralReference(callableId, callableKey);
+    f.session.attachLocator(callableId, { kind: "defined-function", value: func });
+
+    const callableAliasId = createIrBindingId({
+      ownerId: f.firstUnitId,
+      domain: "callable",
+      role: "inherited-callable-contract",
+    });
+    f.session.plan(ownedAliasDraft(f, callableAliasId, callableId, f.firstUnitId, callableContract));
+
+    const globalType = { kind: "ref" as const, typeIdx: 0 };
+    const globalValueType = canonicalProgramAbiValType(globalType);
+    const globalId = createIrBindingId({ ownerId: f.sourceId, domain: "global", role: "canonical-global" });
+    const globalKey = "import-global|3:env|13:payload_global";
+    const global: Import = {
+      module: "env",
+      name: "payload_global",
+      desc: { kind: "global", type: globalType, mutable: true },
+    };
+    f.module.imports.push(global);
+    f.session.plan({
+      ...importedGlobalDraft(f, globalId, globalKey),
+      intent: { kind: "global", origin: "import", valueType: globalValueType, mutable: true },
+    });
+    f.session.registerGlobalTypeContract(globalId, globalType, true);
+    f.session.registerStructuralReference(globalId, globalKey);
+    f.session.attachLocator(globalId, { kind: "import-global", value: global });
+    const globalAliasId = createIrBindingId({
+      ownerId: f.sourceId,
+      domain: "global",
+      role: "inherited-global-contract",
+    });
+    f.session.plan(globalAliasDraft(f, globalAliasId, globalId, globalValueType));
+
+    const scoped = sealFirst(f, [globalId]);
+    expect(scoped.bindingIds).toEqual(expect.arrayContaining([callableId, callableAliasId, globalId, globalAliasId]));
+
+    const nextTypes: TypeDef[] = [
+      {
+        kind: "func",
+        name: "$consume$reordered",
+        params: [{ kind: "ref", typeIdx: 1 }],
+        results: [],
+      },
+      {
+        kind: "struct",
+        name: "$Payload$reordered",
+        fields: [{ name: "value", type: { kind: "i32" }, mutable: false }],
+      },
+    ];
+    f.session.applyTypeLayoutRemap({ previousTypes, nextTypes, targetsByOldIndex: [1, 0] });
+    f.module.types = nextTypes;
+    func.typeIdx = 0;
+    if (global.desc.kind !== "global") throw new Error("invalid global alias fixture");
+    global.desc.type = { kind: "ref", typeIdx: 1 };
+
+    const publication = f.session.publish(f.module);
+    expect(publication.abi.canonicalId(callableAliasId)).toBe(callableId);
+    expect(publication.abi.canonicalId(globalAliasId)).toBe(globalId);
+  });
+
   it("pins type/class layouts structurally and advances them only through exact DCE layout remaps", () => {
     const drift = fixture();
     planCallable(drift, drift.firstUnitId, "body", "first");
@@ -754,6 +1070,110 @@ describe("#3521 scoped prepared-component ABI seal", () => {
       space: "type",
       index: 1,
     });
+  });
+
+  it("rejects payload-shape swaps reachable from class fields and callable parameters", () => {
+    const f = fixture();
+    const previousTypes: TypeDef[] = [
+      {
+        kind: "struct",
+        name: "$Base",
+        fields: [{ name: "base", type: { kind: "i32" }, mutable: false }],
+      },
+      {
+        kind: "struct",
+        name: "$ClassPayload",
+        superTypeIdx: 0,
+        fields: [{ name: "classValue", type: { kind: "i32" }, mutable: false }],
+      },
+      {
+        kind: "struct",
+        name: "$CallablePayload",
+        fields: [{ name: "callValue", type: { kind: "f64" }, mutable: true }],
+      },
+      {
+        kind: "struct",
+        name: "$PreparedClass",
+        fields: [{ name: "payload", type: { kind: "ref", typeIdx: 1 }, mutable: true }],
+      },
+      {
+        kind: "func",
+        name: "$consume",
+        params: [{ kind: "ref", typeIdx: 2 }],
+        results: [],
+      },
+    ];
+    f.module.types = previousTypes;
+    const callableContract: ProgramAbiCallableTypeContract = Object.freeze({
+      params: Object.freeze([{ kind: "ref" as const, typeIdx: 2 }]),
+      results: Object.freeze([]),
+    });
+    const callableId = createIrBindingId({ ownerId: f.firstUnitId, domain: "callable", role: "body" });
+    const callableKey = `unit|${f.firstUnitId}|body`;
+    const func: WasmFunction = {
+      name: "first",
+      typeIdx: 4,
+      locals: [],
+      body: [],
+      exported: false,
+    };
+    f.module.functions.push(func);
+    f.session.plan({
+      ...callableDraft(f.session, callableId, f.firstUnitId, "first", callableKey),
+      intent: {
+        kind: "callable",
+        origin: "source",
+        signature: canonicalProgramAbiCallableTypeContract(callableContract),
+        unitId: f.firstUnitId,
+      },
+    });
+    f.session.registerCallableTypeContract(callableId, callableContract);
+    f.session.registerStructuralReference(callableId, callableKey);
+    f.session.attachLocator(callableId, { kind: "defined-function", value: func });
+
+    const classId = createIrBindingId({ ownerId: f.classId, domain: "class", role: "prepared-class" });
+    const classKey = `class|${classId}`;
+    f.session.plan(classDraft(f, classId, classKey));
+    f.session.registerStructuralReference(classId, classKey);
+    const classCell = f.session.createTypeCell(previousTypes[3]!);
+    f.session.attachLocator(classId, { kind: "type-cell", cell: classCell });
+    sealFirst(f, [classId]);
+
+    const maliciousPermutation: TypeDef[] = [
+      previousTypes[0]!,
+      {
+        kind: "struct",
+        name: "$ClassPayload$wrong-target",
+        superTypeIdx: 0,
+        fields: [{ name: "classValue", type: { kind: "i32" }, mutable: false }],
+      },
+      {
+        kind: "struct",
+        name: "$CallablePayload$wrong-target",
+        fields: [{ name: "callValue", type: { kind: "f64" }, mutable: true }],
+      },
+      {
+        kind: "struct",
+        name: "$PreparedClass$permuted",
+        fields: [{ name: "payload", type: { kind: "ref", typeIdx: 2 }, mutable: true }],
+      },
+      {
+        kind: "func",
+        name: "$consume$permuted",
+        params: [{ kind: "ref", typeIdx: 1 }],
+        results: [],
+      },
+    ];
+    expectInvariant(
+      () =>
+        f.session.applyTypeLayoutRemap({
+          previousTypes,
+          nextTypes: maliciousPermutation,
+          targetsByOldIndex: [0, 2, 1, 3, 4],
+        }),
+      "type-remap-mismatch",
+    );
+    expect(f.session.publish(f.module).abi.resolveFinalIndex(classId)).toEqual({ space: "type", index: 3 });
   });
 
   it("rejects alias cycles, duplicate discovery, custom IDs, and post-seal locator removal", () => {


### PR DESCRIPTION
## Summary

- add a one-shot, component-scoped ABI seal to `ProgramAbiSession`
- close each prepared component over its complete inventoried nested-unit, class, callable, alias, export, support, locator, and reservation ownership
- pin callable/global contracts and the complete reachable type graph across exact layout remaps
- reject cross-component borrowing, overlapping scopes, late prepared-owned planning, imported-linkage drift, payload-layout swaps, and partial publication
- preserve valid open-root `superTypeIdx: -1` sentinels and inherited alias contracts across semantic-preserving reorders

This is a file-disjoint R2 prerequisite. It does not change production routing, `compileDeclarations`, or `compileIrPathFunctions`; legacy-body reduction remains exactly 0. The next R2 slice will consume this boundary when it prepares whole free-function components before either body emitter runs.

## Validation

- independent adversarial review: approved after three fix/review rounds
- focused Prepared ABI suites: 35/35
- adjacent Program ABI superset: 93/93
- TypeScript typecheck: passed
- LOC and function budget gates: passed
- formatting: passed
- IR optimization retirement ledger: 11 rows, 2 IR-owned, 0 retirement-ready

Tracked in `plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md`.
