### PR TITLE
feat(ir): add strict dynamic member stores

### DIFF
--- a/plan/issues/3795-ir-dynamic-member-set.md
+++ b/plan/issues/3795-ir-dynamic-member-set.md
@@ -1,0 +1,161 @@
+---
+id: 3795
+title: "IR dynamic local widening and member set"
+status: done
+sprint: current
+created: 2026-07-30
+updated: 2026-07-30
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: ir
+es_edition: multi
+language_feature: dynamic-values
+goal: ir-full-coverage
+parent: 3522
+depends_on: [3794]
+related: [2949, 3053, 3789, 3808]
+assignee: ttraenkler/codex
+claimed_by: codex-symphony
+claimed_at: 2026-07-30
+branch: codex/3795-ir-dynamic-member-set
+completed: 2026-07-30
+files:
+  - src/codegen/dyn-read.ts
+  - src/ir/backend/handles.ts
+  - src/ir/builder.ts
+  - src/ir/dynamic-local-widening.ts
+  - src/ir/effects.ts
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/lower.ts
+  - src/ir/nodes.ts
+  - src/ir/passes/inline-small.ts
+  - src/ir/passes/monomorphize.ts
+  - src/ir/select.ts
+  - src/ir/verify.ts
+  - tests/issue-3795-ir-dynamic-member-set.test.ts
+loc-budget-allow:
+  - src/codegen/dyn-read.ts
+  - src/ir/backend/handles.ts
+  - src/ir/builder.ts
+  - src/ir/dynamic-local-widening.ts
+  - src/ir/effects.ts
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/lower.ts
+  - src/ir/nodes.ts
+  - src/ir/passes/inline-small.ts
+  - src/ir/passes/monomorphize.ts
+  - src/ir/select.ts
+  - src/ir/verify.ts
+func-budget-allow:
+  - src/codegen/dyn-read.ts::ensureDynMemberSet
+  - src/ir/builder.ts::emitDynMemberSet
+  - src/ir/dynamic-local-widening.ts::collectDynamicStringLocalWidening
+  - src/ir/effects.ts::isSideEffecting
+  - src/ir/from-ast.ts::lowerFunctionAstToIr
+  - src/ir/from-ast.ts::lowerElementStore
+  - src/ir/from-ast.ts::lowerVarDecl
+  - src/ir/integration.ts::makeDynamicLowering
+  - src/ir/integration.ts::preregisterDynamicSupport
+  - src/ir/lower.ts::emitBlockBody
+  - src/ir/lower.ts::emitInstrTree
+  - src/ir/lower.ts::lowerIrFunctionBody
+  - src/ir/passes/inline-small.ts::renameInstrOperands
+  - src/ir/select.ts::dynamicUsesAreMoveOnly
+  - src/ir/select.ts::isPhase1StatementListInScope
+  - src/ir/select.ts::whyNotIrClaimable
+  - src/ir/verify.ts::verifyInstruction
+---
+
+# #3795 — add canonical dynamic member mutation to Acorn IR
+
+## Problem
+
+After #3794, Acorn's exact runtime-dynamic standalone build emits 31 of 43
+reachable functions through IR. `isPrivateNameConflicted` remains direct even
+though its reads, comparisons, truthiness, and dynamic string concatenation are
+already representable.
+
+Two related representation gaps remain:
+
+1. `next` starts as the concrete string `"true"` and later receives a dynamic
+   concatenation. The existing dynamic slot machinery can carry the later value
+   but whole-local selection does not widen and box the initializer.
+2. `privateNameMap[name] = value` is a statement-position write to the
+   canonical dynamic carrier. IR has `dyn.member_get` but no write dual.
+
+The current `param-type-not-resolvable` outcome is the dynamic-use preclaim
+gate masking those unsupported uses, not an unresolved parameter declaration.
+
+## Scope
+
+- Prove the exact mutable-local family where a boxable concrete string
+  initializer is later assigned a dynamic string concatenation, widen that
+  local to the canonical dynamic slot, and box the initializer exactly once.
+- Add statement-position `dyn.member_set(recv, key, value)` over canonical
+  dynamic carriers.
+- Preserve JavaScript evaluation order and single evaluation of receiver, key,
+  and value.
+- Use strict assignment semantics in Acorn's module body, including setter
+  failure behavior.
+- Preserve host and WasmGC carrier parity and `Object.create(null)` data-key
+  behavior, including `__proto__`.
+- Keep assignment-as-value, optional writes, arbitrary dynamic mutation, and
+  wider mixed-representation or explicitly-typed locals rejected before claim.
+- Preserve `RequireObjectCoercible` for dynamic Get and Set: null, undefined,
+  and their tag-0/tag-1 carrier forms throw before the object runtime observes
+  the access.
+- Preserve #3808's closed token-table, open `Parser.options`, and numeric-local
+  representation decisions without editing their owner paths.
+
+## Acceptance criteria
+
+- [x] Focused truth-table tests cover instance/static private get/set pairs,
+      duplicate declarations, and the transition to the `"true"` conflict
+      marker.
+- [x] Focused write tests prove receiver/key/value single evaluation and
+      left-to-right order, strict setter failure, and `Object.create(null)`
+      `__proto__` behavior.
+- [x] Negative tests keep assignment-as-value, optional/wider writes, and
+      explicitly-typed/unsupported local widening on direct codegen with zero
+      withdrawals in both overlay and IR-first modes.
+- [x] Both host and standalone/GC carrier strategies execute the admitted
+      shape with identical observable results.
+- [x] The exact Acorn driver emits 32 of 43 reachable functions through IR;
+      `isPrivateNameConflicted` is the sole new name and all prior 31 remain.
+- [x] Runtime remains checksum 422 with zero module imports, zero function
+      imports, and zero post-claim withdrawals.
+- [x] Focused and adjacent tests, typecheck, formatting, IR fallback ratchet,
+      function/LOC budgets, and issue checks pass.
+
+## Evidence
+
+- The unchanged runtime-dynamic Acorn driver emits 32 of 43 reachable
+  functions through IR. `isPrivateNameConflicted` is the sole new emitted
+  name, and all prior 31 names remain.
+- The exact runtime run returns checksum 422 with zero module imports, zero
+  function imports, and no post-claim withdrawal.
+- The shared whole-local proof widens only direct-body mutable string-literal
+  locals whose complete write set consists of statement-position dynamic
+  string concatenations. Assignment-as-value, compound/update, nested, and
+  mixed wider or explicitly-typed writes remain pre-claim refusals in overlay
+  and `JS2WASM_IR_FIRST=1`.
+- `dyn.member_set` is a void, call-like heap mutation. Its DCE liveness,
+  verifier, inliner, monomorphizer, and Wasm lowering all consume receiver,
+  key, and value in source order.
+- The strict helper stores raw tag-5 string and tag-6 object payloads while
+  preserving the canonical conversion for other dynamic partitions. Its shared
+  receiver peel rejects null/undefined/tag-0/tag-1 before both Get and Set, and
+  standalone strict Set routes through the native `Reflect.set` verdict before
+  throwing a catchable TypeError. A zero-argument in-Wasm driver executes the
+  compiled Acorn function across instance/static transitions, duplicate and
+  mixed conflicts, the `"true"` marker, frozen-set failure, and an own
+  `__proto__` key on `Object.create(null)`, returning the checked `0xffff`
+  checksum without host-object marshalling.
+- Focused proof:
+  `tests/issue-3795-ir-dynamic-member-set.test.ts` (10/10). Adjacent #3789 and
+  #3794 suites pass. Typecheck and the exact Acorn driver pass.

--- a/src/codegen/dyn-read.ts
+++ b/src/codegen/dyn-read.ts
@@ -1048,7 +1048,6 @@ function emitDynMemberSetPrivateNameSelfTest(ctx: CodegenContext): void {
   const freezeIdx = ctx.funcMap.get("__object_freeze");
   const hasOwnIdx = ctx.funcMap.get("__object_hasOwn") ?? ctx.funcMap.get("__hasOwnProperty");
   const boxBooleanIdx = ctx.funcMap.get("__box_boolean");
-  const strictEqIdx = ctx.funcMap.get(ctx.standalone || ctx.wasi ? "__extern_strict_eq" : "__host_eq");
   const requiredStrings = [
     "name",
     "key",
@@ -1075,7 +1074,6 @@ function emitDynMemberSetPrivateNameSelfTest(ctx: CodegenContext): void {
     freezeIdx === undefined ||
     hasOwnIdx === undefined ||
     boxBooleanIdx === undefined ||
-    strictEqIdx === undefined ||
     requiredStrings.some((value) => !ctx.stringGlobalMap.has(value))
   ) {
     return;
@@ -1166,7 +1164,19 @@ function emitDynMemberSetPrivateNameSelfTest(ctx: CodegenContext): void {
   const expectTrue = (mapLocal: number, kind: string, isStatic: boolean, name = "x"): Instr[] =>
     addBit(conflict(mapLocal, kind, isStatic, name));
   const expectStored = (mapLocal: number, name: string, value: string): Instr[] =>
-    addBit([{ op: "local.get", index: mapLocal }, ...key(name), call(getIdx), ...key(value), call(strictEqIdx)]);
+    addBit([
+      ...newNullProto(),
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 2 },
+      ...key(value),
+      ...bool(true),
+      call(setIdx),
+      { op: "local.get", index: 2 },
+      { op: "local.get", index: mapLocal },
+      ...key(name),
+      call(getIdx),
+      call(hasOwnIdx),
+    ]);
 
   addDriverExport(
     ctx,
@@ -1175,6 +1185,7 @@ function emitDynMemberSetPrivateNameSelfTest(ctx: CodegenContext): void {
     [
       { name: "map", type: externref },
       { name: "checksum", type: i32 },
+      { name: "expectedValues", type: externref },
     ],
     [
       { op: "i32.const", value: 0 },

--- a/src/codegen/dyn-read.ts
+++ b/src/codegen/dyn-read.ts
@@ -42,6 +42,7 @@ import { addFuncType } from "./registry/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import {
   undefinedSingletonActive, // (#2106 S1)
+  undefinedExternInstrs,
   ensureAnyFromExternHelper, // (#3053 U0) settled honest classifier (CS1b)
   ensureAnyToExternHelper, // (#3053 U0) key marshalling
 } from "./any-helpers.js";
@@ -52,6 +53,7 @@ import { addStringConstantGlobal } from "./registry/imports.js";
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { allocLocal } from "./context/locals.js";
 import { collectClosureBaseWrapperTypeIdxs as closureBaseWrapperTypeIdxs } from "./closure-classifier.js"; // (#2175 V2-S1) shared list
+import { buildThrowJsErrorInstrs } from "./js-errors.js";
 
 // `$AnyValue` tag constants (mirror any-helpers.ts box helpers).
 const TAG_NULL = 0;
@@ -523,6 +525,29 @@ export function ensureDynMemberGet(ctx: CodegenContext): void {
   const externref: ValType = { kind: "externref" };
   const i32: ValType = { kind: "i32" };
 
+  // `dyn.member_get` and `dyn.member_set` are the carrier-level equivalents of
+  // JS property access. Preserve RequireObjectCoercible before either helper
+  // reaches the object runtime: null and undefined throw, while all other
+  // primitive/object partitions continue through ordinary property semantics.
+  //
+  // Build the constructor in-module on every target. This keeps the guard
+  // import-neutral (important for standalone closure) and, because
+  // preregisterDynamicSupport calls us before Phase 3, all added types/functions
+  // are reserved before any IR body captures indices.
+  const objectCoercibleThrow = (): Instr[] =>
+    buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot convert undefined or null to object", {
+      forceInModuleCtor: true,
+    });
+  // The externref carrier needs the sentinel-aware undefined predicate. The
+  // object runtime owns the standalone native; host mode may need the import
+  // registered here. Settle that import before resolving any helper indices.
+  let externIsUndefinedIdx = ctx.funcMap.get("__extern_is_undefined");
+  if (!ctx.fast && externIsUndefinedIdx === undefined) {
+    ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [i32]);
+    flushLateImportShifts(ctx, null);
+    externIsUndefinedIdx = ctx.funcMap.get("__extern_is_undefined");
+  }
+
   const externGetIdx = ctx.funcMap.get("__extern_get");
   if (externGetIdx === undefined) {
     ctx.dynMemberGetHelpersEmitted = false;
@@ -595,21 +620,33 @@ export function ensureDynMemberGet(ctx: CodegenContext): void {
     //   difference from `__any_to_extern` (which WRAPS tag-6). tag 6 → the RAW
     //   `$Object` ref (field 3) so `__extern_get`'s `ref.test $Object` hits;
     //   tag 5 → the string externref (field 4); tag 2/3 → __box_number;
-    //   tag 4 → __box_boolean; tag 0/1/null → ref.null.extern (a null/undefined
-    //   receiver → __extern_get miss → the singleton, no null-deref).
+    //   tag 4 → __box_boolean. A null carrier or tag 0/1 is rejected here,
+    //   before conversion, so Get/Set both preserve RequireObjectCoercible.
     const peelBody: Instr[] = [
       { op: "local.get", index: 0 },
       { op: "ref.is_null" },
       {
         op: "if",
-        blockType: { kind: "empty" },
-        then: [{ op: "ref.null.extern" }, { op: "return" }],
+        blockType: { kind: "val", type: i32 },
+        then: [{ op: "i32.const", value: 1 }],
+        else: [
+          { op: "local.get", index: 0 },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: anyIdx, fieldIdx: AV_TAG },
+          { op: "local.tee", index: 1 },
+          { op: "i32.const", value: TAG_NULL },
+          { op: "i32.eq" },
+          { op: "local.get", index: 1 },
+          { op: "i32.const", value: TAG_UNDEFINED },
+          { op: "i32.eq" },
+          { op: "i32.or" },
+        ],
       },
-      // tag = v.tag
-      { op: "local.get", index: 0 },
-      { op: "ref.as_non_null" },
-      { op: "struct.get", typeIdx: anyIdx, fieldIdx: AV_TAG },
-      { op: "local.set", index: 1 },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: objectCoercibleThrow(),
+      },
       // tag 6 → extern.convert_any(v.refval)  — the RAW $Object
       { op: "local.get", index: 1 },
       { op: "i32.const", value: TAG_REF },
@@ -685,7 +722,7 @@ export function ensureDynMemberGet(ctx: CodegenContext): void {
           { op: "return" },
         ],
       },
-      // tag 0 (null) / 1 (undefined) receiver → null externref → __extern_get miss
+      // Residual carrier partition: keep the historical null extern fallback.
       { op: "ref.null.extern" },
     ];
     const peelIdx = addHelper("__carrier_recv_to_extern", [anyRefNull], [externref], peelBody, [
@@ -727,13 +764,41 @@ export function ensureDynMemberGet(ctx: CodegenContext): void {
     return;
   }
 
-  // ── host (gc) carrier = externref ───────────────────────────────────────
-  // The host `__extern_get` import already returns the spec `Get` externref; the
-  // carrier IS externref, so no box/peel. `externGetIdx` is a live import index;
-  // a later dead-elim import shift remaps this baked call (stable-handle body,
-  // scanned by `eliminateDeadImports`).
+  // ── host carrier = externref ────────────────────────────────────────────
+  // Use the same receiver-peel seam as the fast carrier. Here it is an identity
+  // after the null/undefined guard, with the sentinel-aware host predicate
+  // covering JS `undefined` (a non-null externref).
+  if (externIsUndefinedIdx === undefined) {
+    ctx.dynMemberGetHelpersEmitted = false;
+    ctx.usesDynMemberGet = false;
+    return;
+  }
+  const peelHostIdx = addHelper(
+    "__carrier_recv_to_extern",
+    [externref],
+    [externref],
+    [
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: externIsUndefinedIdx },
+      { op: "i32.or" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: objectCoercibleThrow(),
+      },
+      { op: "local.get", index: 0 },
+    ],
+  );
+  if (peelHostIdx === undefined) {
+    ctx.dynMemberGetHelpersEmitted = false;
+    ctx.usesDynMemberGet = false;
+    return;
+  }
   const dmgHostBody: Instr[] = [
     { op: "local.get", index: 0 },
+    { op: "call", funcIdx: peelHostIdx },
     { op: "local.get", index: 1 },
     { op: "call", funcIdx: externGetIdx },
   ];
@@ -744,6 +809,155 @@ export function ensureDynMemberGet(ctx: CodegenContext): void {
     return;
   }
   if (forceSelfTest) emitDynMemberGetSelfTestHost(ctx, dmgHostIdx);
+}
+
+/**
+ * #3795 — register the strict write dual
+ * `__dyn_member_set(recv,key,value) -> ()`.
+ *
+ * The helper consumes the same carrier chosen by `resolveDynamic()`. Fast/GC
+ * mode reuses `__carrier_recv_to_extern` for the receiver, the canonical
+ * `__any_to_extern` key conversion, and an identity-preserving value peel
+ * which unwraps tag-5 strings and tag-6 objects while leaving
+ * null/undefined/scalars to the established conversion helper. Host mode is a
+ * thin externref wrapper.
+ */
+export function ensureDynMemberSet(ctx: CodegenContext): void {
+  if (ctx.funcMap.has("__dyn_member_set")) return;
+
+  const externref: ValType = { kind: "externref" };
+  const nativeStrictSet = ctx.standalone || ctx.wasi;
+  const externSetIdx = ctx.funcMap.get(nativeStrictSet ? "__reflect_set" : "__extern_set_strict");
+  if (externSetIdx === undefined) return;
+  const strictSetFailure = (): Instr[] =>
+    buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot assign to read only property", {
+      forceInModuleCtor: true,
+    });
+  const finishStrictSet = (): Instr[] =>
+    nativeStrictSet
+      ? [
+          { op: "call", funcIdx: externSetIdx },
+          { op: "i32.eqz" },
+          { op: "if", blockType: { kind: "empty" }, then: strictSetFailure() },
+        ]
+      : [{ op: "call", funcIdx: externSetIdx }];
+
+  const addHelper = (name: string, params: ValType[], results: ValType[], body: Instr[]): number | undefined => {
+    const existing = ctx.funcMap.get(name);
+    if (existing !== undefined) return existing;
+    const typeIdx = addFuncType(ctx, params, results, name);
+    const funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals: [], body, exported: false } as never);
+    ctx.funcMap.set(name, funcIdx);
+    return funcIdx;
+  };
+
+  if (ctx.fast) {
+    // The read substrate owns the receiver peel. A dynamic write necessarily
+    // uses the same object runtime, so registering the read helper here is a
+    // small, safe dependency and keeps a single receiver-carrier policy.
+    ctx.usesDynMemberGet = true;
+    ensureDynMemberGet(ctx);
+    const anyIdx = ctx.anyValueTypeIdx;
+    const peelIdx = ctx.funcMap.get("__carrier_recv_to_extern");
+    const anyToExternIdx = ensureAnyToExternHelper(ctx);
+    if (anyIdx < 0 || peelIdx === undefined || anyToExternIdx === undefined) return;
+    const anyRefNull: ValType = { kind: "ref_null", typeIdx: anyIdx };
+
+    // Preserve ordinary JS storage when a dynamic string/object is assigned.
+    // `__any_to_extern` intentionally keeps tags 5/6 wrapped for generic any
+    // round trips; [[Set]] needs their raw payloads so the property contains
+    // the string/object value rather than the internal carrier. Other
+    // partitions retain the canonical null/undefined/number/boolean
+    // conversion.
+    const valueToExternBody: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "ref.null.extern" }, { op: "return" }],
+      },
+      { op: "local.get", index: 0 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: anyIdx, fieldIdx: AV_TAG },
+      { op: "i32.const", value: TAG_STRING },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 0 },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: anyIdx, fieldIdx: AV_EXT },
+          { op: "return" },
+        ],
+      },
+      { op: "local.get", index: 0 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: anyIdx, fieldIdx: AV_TAG },
+      { op: "i32.const", value: TAG_REF },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 0 },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: anyIdx, fieldIdx: AV_REF },
+          { op: "extern.convert_any" },
+          { op: "return" },
+        ],
+      },
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: anyToExternIdx },
+    ];
+    const valueToExternIdx = addHelper("__carrier_value_to_extern", [anyRefNull], [externref], valueToExternBody);
+    if (valueToExternIdx === undefined) return;
+    const dmsIdx = addHelper(
+      "__dyn_member_set",
+      [anyRefNull, anyRefNull, anyRefNull],
+      [],
+      [
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: peelIdx },
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: anyToExternIdx },
+        { op: "local.get", index: 2 },
+        { op: "call", funcIdx: valueToExternIdx },
+        ...finishStrictSet(),
+      ],
+    );
+    if (dmsIdx !== undefined && process.env.JS2WASM_FORCE_DYN_MEMBER_SET === "1") {
+      emitDynMemberSetNullishSelfTest(ctx);
+      emitDynMemberSetPrivateNameSelfTest(ctx);
+    }
+    return;
+  }
+
+  // Host writes share the same sentinel-aware RequireObjectCoercible seam as
+  // reads. A set-only module still registers the read substrate so the receiver
+  // policy cannot diverge between the two operations.
+  ctx.usesDynMemberGet = true;
+  ensureDynMemberGet(ctx);
+  const peelHostIdx = ctx.funcMap.get("__carrier_recv_to_extern");
+  if (peelHostIdx === undefined) return;
+  const dmsIdx = addHelper(
+    "__dyn_member_set",
+    [externref, externref, externref],
+    [],
+    [
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: peelHostIdx },
+      { op: "local.get", index: 1 },
+      { op: "local.get", index: 2 },
+      ...finishStrictSet(),
+    ],
+  );
+  if (dmsIdx !== undefined && process.env.JS2WASM_FORCE_DYN_MEMBER_SET === "1") {
+    emitDynMemberSetNullishSelfTest(ctx);
+    emitDynMemberSetPrivateNameSelfTest(ctx);
+  }
 }
 
 /**
@@ -763,6 +977,254 @@ function addDriverExport(
   pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals, body, exported: true } as never);
   ctx.funcMap.set(name, funcIdx);
   ctx.mod.exports.push({ name, desc: { kind: "func", index: funcIdx } });
+}
+
+/** FORCE-only, zero-argument RequireObjectCoercible probes for Get and Set. */
+function emitDynMemberSetNullishSelfTest(ctx: CodegenContext): void {
+  const getIdx = ctx.funcMap.get("__dyn_member_get");
+  const setIdx = ctx.funcMap.get("__dyn_member_set");
+  if (
+    getIdx === undefined ||
+    setIdx === undefined ||
+    !ctx.stringGlobalMap.has("x") ||
+    !ctx.stringGlobalMap.has("true")
+  ) {
+    return;
+  }
+  const key = (value: string): Instr[] => stringConstantExternrefInstrs(ctx, value);
+  const call = (funcIdx: number): Instr => ({ op: "call", funcIdx });
+
+  if (ctx.fast) {
+    const boxNullIdx = ctx.funcMap.get("__any_box_null");
+    const boxUndefinedIdx = ctx.funcMap.get("__any_box_undefined");
+    const honestIdx = ctx.funcMap.get("__any_from_extern_honest");
+    if (boxNullIdx === undefined || boxUndefinedIdx === undefined || honestIdx === undefined) return;
+    const carrier = (boxIdx: number): Instr[] => [call(boxIdx)];
+    const keyCarrier = (value: string): Instr[] => [...key(value), call(honestIdx)];
+    const getBody = (boxIdx: number): Instr[] => [...carrier(boxIdx), ...keyCarrier("x"), call(getIdx), { op: "drop" }];
+    const setBody = (boxIdx: number): Instr[] => [
+      ...carrier(boxIdx),
+      ...keyCarrier("x"),
+      ...keyCarrier("true"),
+      call(setIdx),
+    ];
+    addDriverExport(ctx, "__dms_null_get", [], [], getBody(boxNullIdx));
+    addDriverExport(ctx, "__dms_undefined_get", [], [], getBody(boxUndefinedIdx));
+    addDriverExport(ctx, "__dms_null_set", [], [], setBody(boxNullIdx));
+    addDriverExport(ctx, "__dms_undefined_set", [], [], setBody(boxUndefinedIdx));
+    return;
+  }
+
+  const nullCarrier = (): Instr[] => [{ op: "ref.null.extern" }];
+  const undefinedCarrier = (): Instr[] => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
+  const getBody = (recv: Instr[]): Instr[] => [...recv, ...key("x"), call(getIdx), { op: "drop" }];
+  const setBody = (recv: Instr[]): Instr[] => [...recv, ...key("x"), ...key("true"), call(setIdx)];
+  addDriverExport(ctx, "__dms_null_get", [], [], getBody(nullCarrier()));
+  addDriverExport(ctx, "__dms_undefined_get", [], [], getBody(undefinedCarrier()));
+  addDriverExport(ctx, "__dms_null_set", [], [], setBody(nullCarrier()));
+  addDriverExport(ctx, "__dms_undefined_set", [], [], setBody(undefinedCarrier()));
+}
+
+/**
+ * #3795 — FORCE-only zero-argument proof for Acorn's exact
+ * `isPrivateNameConflicted` body. The driver builds every receiver and element
+ * with the module's own object runtime, calls the compiled source function, and
+ * returns a 16-bit checksum. No JS object crosses the export boundary.
+ *
+ * This is deliberately keyed by source-function name and therefore lives only
+ * behind `JS2WASM_FORCE_DYN_MEMBER_SET=1`; production modules never emit it.
+ */
+function emitDynMemberSetPrivateNameSelfTest(ctx: CodegenContext): void {
+  // The exact standalone/gc Acorn lane uses the externref dynamic carrier.
+  // Fast-carrier helper coverage remains owned by the generic #3053 drivers.
+  if (ctx.fast) return;
+
+  const conflictIdx = ctx.funcMap.get("isPrivateNameConflicted");
+  const createIdx = ctx.funcMap.get("__object_create");
+  const newObjIdx = ctx.funcMap.get("__new_plain_object");
+  const setIdx = ctx.funcMap.get("__extern_set_strict");
+  const getIdx = ctx.funcMap.get("__extern_get");
+  const freezeIdx = ctx.funcMap.get("__object_freeze");
+  const hasOwnIdx = ctx.funcMap.get("__object_hasOwn") ?? ctx.funcMap.get("__hasOwnProperty");
+  const boxBooleanIdx = ctx.funcMap.get("__box_boolean");
+  const strictEqIdx = ctx.funcMap.get(ctx.standalone || ctx.wasi ? "__extern_strict_eq" : "__host_eq");
+  const requiredStrings = [
+    "name",
+    "key",
+    "type",
+    "kind",
+    "static",
+    "get",
+    "set",
+    "field",
+    "MethodDefinition",
+    "PropertyDefinition",
+    "x",
+    "__proto__",
+    "iget",
+    "sset",
+    "true",
+  ];
+  if (
+    conflictIdx === undefined ||
+    createIdx === undefined ||
+    newObjIdx === undefined ||
+    setIdx === undefined ||
+    getIdx === undefined ||
+    freezeIdx === undefined ||
+    hasOwnIdx === undefined ||
+    boxBooleanIdx === undefined ||
+    strictEqIdx === undefined ||
+    requiredStrings.some((value) => !ctx.stringGlobalMap.has(value))
+  ) {
+    return;
+  }
+
+  const externref: ValType = { kind: "externref" };
+  const i32: ValType = { kind: "i32" };
+  const key = (value: string): Instr[] => stringConstantExternrefInstrs(ctx, value);
+  const call = (funcIdx: number): Instr => ({ op: "call", funcIdx });
+  const addHelper = (
+    name: string,
+    params: ValType[],
+    results: ValType[],
+    locals: { name: string; type: ValType }[],
+    body: Instr[],
+  ): number => {
+    const existing = ctx.funcMap.get(name);
+    if (existing !== undefined) return existing;
+    const typeIdx = addFuncType(ctx, params, results, name);
+    const funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals, body, exported: false } as never);
+    ctx.funcMap.set(name, funcIdx);
+    return funcIdx;
+  };
+
+  // (kind, type, static, name) -> element
+  const elementIdx = addHelper(
+    "__dms_test_element",
+    [externref, externref, externref, externref],
+    [externref],
+    [
+      { name: "keyObj", type: externref },
+      { name: "element", type: externref },
+    ],
+    [
+      call(newObjIdx),
+      { op: "local.set", index: 4 },
+      { op: "local.get", index: 4 },
+      ...key("name"),
+      { op: "local.get", index: 3 },
+      call(setIdx),
+      call(newObjIdx),
+      { op: "local.set", index: 5 },
+      { op: "local.get", index: 5 },
+      ...key("key"),
+      { op: "local.get", index: 4 },
+      call(setIdx),
+      { op: "local.get", index: 5 },
+      ...key("type"),
+      { op: "local.get", index: 1 },
+      call(setIdx),
+      { op: "local.get", index: 5 },
+      ...key("kind"),
+      { op: "local.get", index: 0 },
+      call(setIdx),
+      { op: "local.get", index: 5 },
+      ...key("static"),
+      { op: "local.get", index: 2 },
+      call(setIdx),
+      { op: "local.get", index: 5 },
+    ],
+  );
+
+  const newNullProto = (): Instr[] => [{ op: "ref.null.extern" }, call(createIdx)];
+  const bool = (value: boolean): Instr[] => [{ op: "i32.const", value: value ? 1 : 0 }, call(boxBooleanIdx)];
+  const element = (kind: string, isStatic: boolean, name = "x"): Instr[] => [
+    ...key(kind),
+    ...key(kind === "field" ? "PropertyDefinition" : "MethodDefinition"),
+    ...bool(isStatic),
+    ...key(name),
+    call(elementIdx),
+  ];
+  const conflict = (mapLocal: number, kind: string, isStatic: boolean, name = "x"): Instr[] => [
+    { op: "local.get", index: mapLocal },
+    ...element(kind, isStatic, name),
+    call(conflictIdx),
+  ];
+  const addBit = (condition: Instr[]): Instr[] => [
+    { op: "local.get", index: 1 },
+    { op: "i32.const", value: 2 },
+    { op: "i32.mul" },
+    ...condition,
+    { op: "i32.add" },
+    { op: "local.set", index: 1 },
+  ];
+  const expectFalse = (mapLocal: number, kind: string, isStatic: boolean, name = "x"): Instr[] =>
+    addBit([...conflict(mapLocal, kind, isStatic, name), { op: "i32.eqz" }]);
+  const expectTrue = (mapLocal: number, kind: string, isStatic: boolean, name = "x"): Instr[] =>
+    addBit(conflict(mapLocal, kind, isStatic, name));
+  const expectStored = (mapLocal: number, name: string, value: string): Instr[] =>
+    addBit([{ op: "local.get", index: mapLocal }, ...key(name), call(getIdx), ...key(value), call(strictEqIdx)]);
+
+  addDriverExport(
+    ctx,
+    "__dms_private_name_checksum",
+    [i32],
+    [
+      { name: "map", type: externref },
+      { name: "checksum", type: i32 },
+    ],
+    [
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 1 },
+
+      // Instance getter/setter transition and duplicate after the "true" marker.
+      ...newNullProto(),
+      { op: "local.set", index: 0 },
+      ...expectFalse(0, "get", false),
+      ...expectStored(0, "x", "iget"),
+      ...expectFalse(0, "set", false),
+      ...expectStored(0, "x", "true"),
+      ...expectTrue(0, "get", false),
+
+      // Static setter/getter transition.
+      ...newNullProto(),
+      { op: "local.set", index: 0 },
+      ...expectFalse(0, "set", true),
+      ...expectStored(0, "x", "sset"),
+      ...expectFalse(0, "get", true),
+      ...expectStored(0, "x", "true"),
+
+      // Mixed instance/static does not form an accessor pair.
+      ...newNullProto(),
+      { op: "local.set", index: 0 },
+      ...expectFalse(0, "get", false),
+      ...expectTrue(0, "set", true),
+
+      // Duplicate field declarations conflict.
+      ...newNullProto(),
+      { op: "local.set", index: 0 },
+      ...expectFalse(0, "field", false),
+      ...expectTrue(0, "field", false),
+
+      // Object.create(null): "__proto__" is an own data key, not prototype magic.
+      ...newNullProto(),
+      { op: "local.set", index: 0 },
+      ...expectFalse(0, "field", false, "__proto__"),
+      ...addBit([{ op: "local.get", index: 0 }, ...key("__proto__"), call(hasOwnIdx)]),
+      ...expectStored(0, "__proto__", "true"),
+      { op: "local.get", index: 1 },
+    ],
+  );
+
+  addDriverExport(
+    ctx,
+    "__dms_private_name_strict_failure",
+    [],
+    [{ name: "map", type: externref }],
+    [...newNullProto(), call(freezeIdx), { op: "local.set", index: 0 }, ...conflict(0, "field", false), { op: "drop" }],
+  );
 }
 
 /**

--- a/src/codegen/dyn-read.ts
+++ b/src/codegen/dyn-read.ts
@@ -54,6 +54,7 @@ import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { allocLocal } from "./context/locals.js";
 import { collectClosureBaseWrapperTypeIdxs as closureBaseWrapperTypeIdxs } from "./closure-classifier.js"; // (#2175 V2-S1) shared list
 import { buildThrowJsErrorInstrs } from "./js-errors.js";
+import { boxToAny } from "./value-tags.js";
 
 // `$AnyValue` tag constants (mirror any-helpers.ts box helpers).
 const TAG_NULL = 0;
@@ -995,23 +996,23 @@ function emitDynMemberSetNullishSelfTest(ctx: CodegenContext): void {
   const call = (funcIdx: number): Instr => ({ op: "call", funcIdx });
 
   if (ctx.fast) {
-    const boxNullIdx = ctx.funcMap.get("__any_box_null");
-    const boxUndefinedIdx = ctx.funcMap.get("__any_box_undefined");
     const honestIdx = ctx.funcMap.get("__any_from_extern_honest");
-    if (boxNullIdx === undefined || boxUndefinedIdx === undefined || honestIdx === undefined) return;
-    const carrier = (boxIdx: number): Instr[] => [call(boxIdx)];
+    if (honestIdx === undefined || !undefinedSingletonActive(ctx)) return;
+    const carrier = (jsType: "null" | "undefined"): Instr[] | undefined => {
+      const body: Instr[] = [{ op: "ref.null.extern" }];
+      const emitted = boxToAny(ctx, { body } as FunctionContext, { kind: "externref" }, jsType);
+      return emitted ? body : undefined;
+    };
+    const nullCarrier = carrier("null");
+    const undefinedCarrier = carrier("undefined");
+    if (nullCarrier === undefined || undefinedCarrier === undefined) return;
     const keyCarrier = (value: string): Instr[] => [...key(value), call(honestIdx)];
-    const getBody = (boxIdx: number): Instr[] => [...carrier(boxIdx), ...keyCarrier("x"), call(getIdx), { op: "drop" }];
-    const setBody = (boxIdx: number): Instr[] => [
-      ...carrier(boxIdx),
-      ...keyCarrier("x"),
-      ...keyCarrier("true"),
-      call(setIdx),
-    ];
-    addDriverExport(ctx, "__dms_null_get", [], [], getBody(boxNullIdx));
-    addDriverExport(ctx, "__dms_undefined_get", [], [], getBody(boxUndefinedIdx));
-    addDriverExport(ctx, "__dms_null_set", [], [], setBody(boxNullIdx));
-    addDriverExport(ctx, "__dms_undefined_set", [], [], setBody(boxUndefinedIdx));
+    const getBody = (recv: Instr[]): Instr[] => [...recv, ...keyCarrier("x"), call(getIdx), { op: "drop" }];
+    const setBody = (recv: Instr[]): Instr[] => [...recv, ...keyCarrier("x"), ...keyCarrier("true"), call(setIdx)];
+    addDriverExport(ctx, "__dms_null_get", [], [], getBody(nullCarrier));
+    addDriverExport(ctx, "__dms_undefined_get", [], [], getBody(undefinedCarrier));
+    addDriverExport(ctx, "__dms_null_set", [], [], setBody(nullCarrier));
+    addDriverExport(ctx, "__dms_undefined_set", [], [], setBody(undefinedCarrier));
     return;
   }
 

--- a/src/ir/backend/handles.ts
+++ b/src/ir/backend/handles.ts
@@ -424,6 +424,14 @@ export interface IrDynamicLowering {
    * `ctx.usesDynMemberGet` latch.
    */
   emitElementGet(): readonly Instr[];
+  /**
+   * Three carriers on the stack (`recv`, `key`, then `value`) → void: strict
+   * statement-position dynamic member assignment (#3795). Both backends call
+   * the canonical `__dyn_member_set` helper, which preserves receiver/key/value
+   * evaluation order and delegates to the existing strict object-runtime
+   * setter. Assignment-as-value is intentionally not represented.
+   */
+  emitMemberSet(): readonly Instr[];
 }
 
 /**

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -600,6 +600,26 @@ export class IrFunctionBuilder {
     return result;
   }
 
+  /**
+   * Emit the void, strict statement-position write dual of
+   * {@link emitDynMemberGet}. Receiver, key, and value must already use the
+   * canonical dynamic carrier; conversion is explicit at the AST producer.
+   */
+  emitDynMemberSet(recv: IrValueId, key: IrValueId, value: IrValueId): void {
+    for (const [label, v] of [
+      ["recv", recv],
+      ["key", key],
+      ["value", value],
+    ] as const) {
+      if (this.typeOf(v).kind !== "dynamic") {
+        throw new Error(
+          `IrFunctionBuilder: emitDynMemberSet ${label} operand ${v} is not dynamic — the dynamic member write accepts only boxed-any carriers (#3795) (func ${this.id.name})`,
+        );
+      }
+    }
+    this.pushInstr({ kind: "dyn.member_set", recv, key, value, result: null, resultType: null });
+  }
+
   // --- object ops (#1169b) ------------------------------------------------
 
   /**

--- a/src/ir/dynamic-local-widening.ts
+++ b/src/ir/dynamic-local-widening.ts
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+
+/**
+ * #3795 — prove the narrow mutable-local shape needed by Acorn's
+ * `isPrivateNameConflicted`:
+ *
+ *   var next = "true";
+ *   …
+ *   next = (dynamicMember ? "s" : "i") + dynamicMember;
+ *
+ * The result is shared by selection and AST→IR lowering so widening cannot
+ * claim and then demote. Candidates must be direct function-body mutable
+ * declarations with a string-literal initializer; every write must be a plain
+ * statement-position `=` whose RHS is a dynamic string concat. Compound,
+ * update, assignment-as-value, nested-function, and wider mixed writes reject.
+ */
+export function collectDynamicStringLocalWidening(
+  fn: ts.FunctionLikeDeclaration,
+  initialDynamicNames: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (!fn.body || !ts.isBlock(fn.body) || initialDynamicNames.size === 0) return new Set();
+
+  const candidates = new Map<string, ts.VariableDeclaration>();
+  for (const statement of fn.body.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    if ((statement.declarationList.flags & ts.NodeFlags.Const) !== 0) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        ts.isIdentifier(declaration.name) &&
+        declaration.type === undefined &&
+        declaration.initializer !== undefined &&
+        ts.isStringLiteralLike(declaration.initializer)
+      ) {
+        candidates.set(declaration.name.text, declaration);
+      }
+    }
+  }
+  if (candidates.size === 0) return new Set();
+
+  const writes = new Map<string, ts.Expression[]>();
+  const invalid = new Set<string>();
+  const assignmentOperators = new Set<ts.SyntaxKind>([
+    ts.SyntaxKind.EqualsToken,
+    ts.SyntaxKind.PlusEqualsToken,
+    ts.SyntaxKind.MinusEqualsToken,
+    ts.SyntaxKind.AsteriskEqualsToken,
+    ts.SyntaxKind.SlashEqualsToken,
+    ts.SyntaxKind.PercentEqualsToken,
+    ts.SyntaxKind.AsteriskAsteriskEqualsToken,
+    ts.SyntaxKind.LessThanLessThanEqualsToken,
+    ts.SyntaxKind.GreaterThanGreaterThanEqualsToken,
+    ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
+    ts.SyntaxKind.AmpersandEqualsToken,
+    ts.SyntaxKind.BarEqualsToken,
+    ts.SyntaxKind.CaretEqualsToken,
+    ts.SyntaxKind.QuestionQuestionEqualsToken,
+    ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+    ts.SyntaxKind.BarBarEqualsToken,
+  ]);
+
+  const visit = (node: ts.Node, parent?: ts.Node): void => {
+    if (node !== fn.body && ts.isFunctionLike(node)) return;
+    if (
+      ts.isBinaryExpression(node) &&
+      assignmentOperators.has(node.operatorToken.kind) &&
+      ts.isIdentifier(node.left) &&
+      candidates.has(node.left.text)
+    ) {
+      if (
+        node.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
+        !parent ||
+        !ts.isExpressionStatement(parent) ||
+        parent.expression !== node
+      ) {
+        invalid.add(node.left.text);
+      } else {
+        const list = writes.get(node.left.text);
+        if (list) list.push(node.right);
+        else writes.set(node.left.text, [node.right]);
+      }
+    } else if (
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      ts.isIdentifier(node.operand) &&
+      candidates.has(node.operand.text) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)
+    ) {
+      invalid.add(node.operand.text);
+    }
+    ts.forEachChild(node, (child) => visit(child, node));
+  };
+  visit(fn.body);
+
+  const unwrap = (expression: ts.Expression): ts.Expression => {
+    let current = expression;
+    while (ts.isParenthesizedExpression(current)) current = current.expression;
+    return current;
+  };
+
+  const dynamicRooted = (expression: ts.Expression): boolean => {
+    const candidate = unwrap(expression);
+    if (ts.isIdentifier(candidate)) return initialDynamicNames.has(candidate.text);
+    if (ts.isPropertyAccessExpression(candidate) || ts.isElementAccessExpression(candidate)) {
+      return dynamicRooted(candidate.expression);
+    }
+    return false;
+  };
+
+  const concreteStringPiece = (expression: ts.Expression): boolean => {
+    const candidate = unwrap(expression);
+    if (ts.isStringLiteralLike(candidate)) return true;
+    return (
+      ts.isConditionalExpression(candidate) &&
+      dynamicRooted(candidate.condition) &&
+      concreteStringPiece(candidate.whenTrue) &&
+      concreteStringPiece(candidate.whenFalse)
+    );
+  };
+
+  const dynamicStringPiece = (expression: ts.Expression): boolean => {
+    const candidate = unwrap(expression);
+    if (dynamicRooted(candidate)) return true;
+    if (!ts.isBinaryExpression(candidate) || candidate.operatorToken.kind !== ts.SyntaxKind.PlusToken) return false;
+    const leftDynamic = dynamicStringPiece(candidate.left);
+    const rightDynamic = dynamicStringPiece(candidate.right);
+    return (
+      (leftDynamic && (rightDynamic || concreteStringPiece(candidate.right))) ||
+      (rightDynamic && concreteStringPiece(candidate.left))
+    );
+  };
+
+  const widened = new Set<string>();
+  for (const name of candidates.keys()) {
+    const assignments = writes.get(name) ?? [];
+    if (
+      !invalid.has(name) &&
+      assignments.length > 0 &&
+      assignments.every((rhs) => {
+        const candidate = unwrap(rhs);
+        return (
+          ts.isBinaryExpression(candidate) &&
+          candidate.operatorToken.kind === ts.SyntaxKind.PlusToken &&
+          dynamicStringPiece(candidate)
+        );
+      })
+    ) {
+      widened.add(name);
+    }
+  }
+  return widened;
+}

--- a/src/ir/effects.ts
+++ b/src/ir/effects.ts
@@ -171,6 +171,9 @@ export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new M
     // (`__extern_get` runs accessors), so a dynamic member read is call-like:
     // it may read AND write arbitrary heap state. Conservative like extern.prop.
     case "dyn.member_get":
+    // #3795 — strict dynamic [[Set]] may invoke accessors/proxy-like runtime
+    // hooks and always mutates observable heap state.
+    case "dyn.member_set":
     case "iter.new":
     case "iter.next":
     case "iter.done":
@@ -477,6 +480,10 @@ export function isSideEffecting(i: IrInstr): boolean {
     // slot.read is pure (load a Wasm local) but always-keep to avoid
     // breaking the for-of body's load/use pattern.
     i.kind === "slot.write" ||
+    // #3795: strict dynamic [[Set]] is void-result but its three carrier
+    // operands must seed DCE liveness. The generic null-result keep rule
+    // preserves only the instruction itself, not the definitions it uses.
+    i.kind === "dyn.member_set" ||
     i.kind === "forof.vec" ||
     // Slice 6 part 3 (#1182): host-iterator protocol ops mutate iterator
     // state (advance pointer, dispose). DCE must not eliminate them

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -79,6 +79,7 @@ import {
   sameIrCallableBinding,
 } from "./callable-bindings.js";
 import { collectOuterWrites } from "./closure-captures.js";
+import { collectDynamicStringLocalWidening } from "./dynamic-local-widening.js";
 import {
   requireMatchingModuleBindingOwner,
   requireMatchingLoweringPlanOwner,
@@ -818,6 +819,10 @@ export function lowerFunctionAstToIr(
     options.allocRegistry,
   );
   const mutatedLets = collectMutatedLetNames(fn);
+  const dynamicStringLocals = collectDynamicStringLocalWidening(
+    fn,
+    new Set(params.filter((param) => param.type.kind === "dynamic").map((param) => param.name)),
+  );
 
   // Single scope map for both params and let/const locals. Phase 1 forbids
   // shadowing (enforced by the selector) so there is no nesting to track.
@@ -979,6 +984,7 @@ export function lowerFunctionAstToIr(
     liftedUnitProvenance,
     liftedCounter,
     mutatedLets,
+    dynamicStringLocals,
     i32PureNames,
     i32Slots,
     ownedStringAppendSymbols,
@@ -1722,6 +1728,13 @@ interface LowerCtx {
    * `lowerFunctionAstToIr` via `collectMutatedLetNames`.
    */
   readonly mutatedLets: ReadonlySet<string>;
+  /**
+   * #3795 — direct-body mutable string-literal locals whose every later
+   * write is a statement-position dynamic string concat. Selection and
+   * lowering share the immutable proof so the local can use the canonical
+   * dynamic carrier without widening arbitrary mutable strings.
+   */
+  readonly dynamicStringLocals: ReadonlySet<string>;
   /**
    * (#3758) Names proven, by the SAME analyses legacy's own #1120/#1236
    * i32-local promotion uses (`collectI32CoercedLocals`, `detectI32LoopVar`),
@@ -2736,20 +2749,36 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
     // the slot) would double-evaluate any side effect in `let s = f() | 0`.
     // Every other hint source wins: an explicit annotation, an empty-array
     // inference and a module binding each pin the representation.
+    const widenDynamic = cx.dynamicStringLocals.has(name);
     const promoteI32Slot =
       annotated === undefined &&
       inferredEmptyArrayHint === undefined &&
       moduleBinding === undefined &&
+      !widenDynamic &&
       !isConst &&
       cx.mutatedLets.has(name) &&
       cx.i32Slots?.has(d) === true &&
       d.initializer !== undefined &&
       isCanonI32Lowerable(d.initializer, promotedI32Probe(cx));
     const hint: IrType =
-      annotated ?? inferredEmptyArrayHint ?? moduleBinding?.type ?? (promoteI32Slot ? IR_I32 : irVal({ kind: "f64" }));
-    const value = promoteI32Slot
+      annotated ??
+      inferredEmptyArrayHint ??
+      moduleBinding?.type ??
+      (widenDynamic ? irDynamic() : promoteI32Slot ? IR_I32 : irVal({ kind: "f64" }));
+    let value = promoteI32Slot
       ? lowerAsI32(d.initializer as ts.Expression, cx, "canon")
       : lowerExpr(d.initializer, cx, hint);
+    if (widenDynamic && cx.builder.typeOf(value).kind !== "dynamic") {
+      const boxed = boxConcreteToDynamic(value, cx.builder.typeOf(value), d.initializer, cx);
+      if (boxed === null) {
+        throw new IrUnsupportedError(
+          "operand-coercion-unsupported",
+          "build",
+          `ir/from-ast: proven dynamic local '${name}' initializer has no dynamic string carrier (${cx.funcName})`,
+        );
+      }
+      value = boxed;
+    }
     const inferred = cx.builder.typeOf(value);
     const stringEncoding = inferred.kind === "string" ? inferStringEncoding(d.initializer, cx) : undefined;
     if (annotated) {
@@ -2876,7 +2905,7 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
             kind: "slot",
             slotIndex,
             type: irVal(dynamicValType),
-            asType: inferred,
+            asType: widenDynamic ? irDynamic() : inferred,
           });
           continue;
         }
@@ -4194,6 +4223,39 @@ function lowerElementStore(lhs: ts.ElementAccessExpression, rhs: ts.Expression, 
   }
   const recv = lowerExpr(lhs.expression, cx, irVal({ kind: "f64" }));
   const recvType = cx.builder.typeOf(recv);
+  if (recvType.kind === "dynamic") {
+    const key = lowerExpr(lhs.argumentExpression, cx, irDynamic());
+    if (cx.builder.typeOf(key).kind !== "dynamic") {
+      throw new IrUnsupportedError(
+        "element-store-unsupported",
+        "build",
+        `ir/from-ast: dynamic member-store key is not dynamic (${cx.funcName})`,
+      );
+    }
+    let value = lowerExpr(rhs, cx, irDynamic());
+    const valueType = cx.builder.typeOf(value);
+    if (valueType.kind !== "dynamic") {
+      const candidate = peelParensExpr(rhs);
+      if (!ts.isStringLiteralLike(candidate) || candidate.text !== "true") {
+        throw new IrUnsupportedError(
+          "element-store-unsupported",
+          "build",
+          `ir/from-ast: concrete dynamic member-store value is outside the #3795 conflict marker (${cx.funcName})`,
+        );
+      }
+      const boxed = boxConcreteToDynamic(value, valueType, rhs, cx);
+      if (boxed === null) {
+        throw new IrUnsupportedError(
+          "operand-coercion-unsupported",
+          "build",
+          `ir/from-ast: dynamic member-store conflict marker has no dynamic carrier (${cx.funcName})`,
+        );
+      }
+      value = boxed;
+    }
+    cx.builder.emitDynMemberSet(recv, key, value);
+    return;
+  }
   const recvVal = asVal(recvType);
   // (#2956 L2) Linear vec receivers are scalar i32 arena pointers, not GC
   // refs — admit them via the same resolver probe the read paths use
@@ -9956,6 +10018,7 @@ function liftNestedFunction(
     // mutated-let scope (collected per-body when slice 6 extends to
     // closures). Empty here keeps the slice-3 nested-fn behavior intact.
     mutatedLets: collectMutatedLetNames(fn),
+    dynamicStringLocals: new Set(),
     // (#3758) nested functions get their own independent i32-pure-names set,
     // same reasoning as mutatedLets above.
     i32PureNames: computeI32PureNames(fn),
@@ -10055,6 +10118,7 @@ function liftClosureBody(
       ts.isBlock(expr.body) && (ts.isFunctionExpression(expr) || ts.isArrowFunction(expr))
         ? collectMutatedLetNamesFromBlock(expr.body)
         : new Set<string>(),
+    dynamicStringLocals: new Set(),
     // (#3758) same independent-per-closure reasoning as mutatedLets above;
     // computeI32PureNames itself no-ops on a non-block (concise) body.
     i32PureNames: computeI32PureNames(expr),

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -32,7 +32,7 @@ import {
   ensureExternLooseEqHelper,
   ensureExternStrictEqHelper,
 } from "../codegen/any-helpers.js"; // (#2949) boxed-any carrier for IrType.dynamic
-import { ensureDynMemberGet } from "../codegen/dyn-read.js"; // (#3053 U1) unified dynamic-reader carrier primitive __dyn_member_get
+import { ensureDynMemberGet, ensureDynMemberSet } from "../codegen/dyn-read.js"; // (#3053 U1) / (#3795)
 import {
   ensureIrDynamicRuntime,
   IR_DYN_ADD_FN,
@@ -4521,7 +4521,7 @@ function isDynamicOp(instr: IrInstr): boolean {
   // built on the canonical any-helper family (`__any_from_extern_honest` /
   // `__any_to_extern` / `__box_*`), so it requires the dynamic backing too.
   // The helper itself is registered separately below (`ensureDynMemberGet`).
-  if (instr.kind === "dyn.member_get") return true;
+  if (instr.kind === "dyn.member_get" || instr.kind === "dyn.member_set") return true;
   return false;
 }
 
@@ -4535,6 +4535,10 @@ function isDynamicOp(instr: IrInstr): boolean {
  */
 function usesDynMemberGet(instr: IrInstr): boolean {
   return instr.kind === "dyn.member_get";
+}
+
+function usesDynMemberSet(instr: IrInstr): boolean {
+  return instr.kind === "dyn.member_set";
 }
 
 /**
@@ -4598,6 +4602,7 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
   let usesEq = false;
   let usesToNumber = false;
   let usesMemberGet = false;
+  let usesMemberSet = false;
   // (#3143) A from-ast lowering can emit a DIRECT named call to a member of the
   // `addUnionImports` family (`__box_number` / `__unbox_number` / `__box_boolean`
   // / …) rather than a `box`/`unbox` IR instruction — e.g. `coerceToExpectedExtern`
@@ -4625,6 +4630,7 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
           if (usesDynEq(i)) usesEq = true;
           if (i.kind === "dyn.to_number") usesToNumber = true;
           if (usesDynMemberGet(i)) usesMemberGet = true;
+          if (usesDynMemberSet(i)) usesMemberSet = true;
           if (i.kind === "call" && i.target.binding.kind === "import" && i.target.binding.module === "env") {
             if (UNION_IMPORT_FUNC_NAMES.has(i.target.binding.field)) usesNamedUnionImport = true;
             else if (i.target.binding.field === "__extern_is_undefined") usesExternIsUndefined = true;
@@ -4739,6 +4745,9 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
   if (usesMemberGet) {
     ctx.usesDynMemberGet = true;
     ensureDynMemberGet(ctx);
+  }
+  if (usesMemberSet) {
+    ensureDynMemberSet(ctx);
   }
 }
 
@@ -4914,6 +4923,9 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
         ctx.usesDynMemberGet = true;
         return [callHelper("__dyn_member_get")];
       },
+      emitMemberSet(): readonly Instr[] {
+        return [callHelper("__dyn_member_set")];
+      },
     };
   }
 
@@ -5070,6 +5082,9 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
     emitElementGet(): readonly Instr[] {
       ctx.usesDynMemberGet = true;
       return [callImport("__dyn_member_get")];
+    },
+    emitMemberSet(): readonly Instr[] {
+      return [callImport("__dyn_member_set")];
     },
   };
 }

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1705,6 +1705,30 @@ export function lowerIrFunctionBody<S, Slot>(
         for (const op of dyn.emitMemberGet()) emitter.pushRaw(out, op);
         return;
       }
+      case "dyn.member_set": {
+        const recvT = typeOf(instr.recv);
+        const keyT = typeOf(instr.key);
+        const valueT = typeOf(instr.value);
+        if (recvT.kind !== "dynamic" || keyT.kind !== "dynamic" || valueT.kind !== "dynamic") {
+          throw new Error(
+            `ir/lower: dyn.member_set operands must be dynamic, got ${recvT.kind}/${keyT.kind}/${valueT.kind} (${func.name})`,
+          );
+        }
+        const dyn = resolver.resolveDynamicLowering?.();
+        if (!dyn) {
+          throw new Error(
+            `ir/lower: resolver cannot lower dyn.member_set (resolveDynamicLowering missing/null) (${func.name})`,
+          );
+        }
+        // JS assignment evaluation order: receiver, key, RHS. The SSA
+        // scheduler anchors this side-effecting instruction; operands are
+        // emitted in the same order immediately before the strict helper call.
+        emitValue(instr.recv, out);
+        emitValue(instr.key, out);
+        emitValue(instr.value, out);
+        for (const op of dyn.emitMemberSet()) emitter.pushRaw(out, op);
+        return;
+      }
       case "string.const": {
         emitter.emitStringConst(instr.value, instr.alloc, out);
         return;
@@ -3401,6 +3425,8 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.lhs, instr.rhs];
     case "dyn.member_get":
       return [instr.recv, instr.key];
+    case "dyn.member_set":
+      return [instr.recv, instr.key, instr.value];
     case "string.const":
       return [];
     case "string.concat":

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1726,6 +1726,7 @@ export function lowerIrFunctionBody<S, Slot>(
         emitValue(instr.recv, out);
         emitValue(instr.key, out);
         emitValue(instr.value, out);
+        // pushraw-ok(#3795): backend-provided dynamic store sequence is rejected by non-Wasm backend legality
         for (const op of dyn.emitMemberSet()) emitter.pushRaw(out, op);
         return;
       }

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -1086,6 +1086,24 @@ export interface IrInstrDynMemberGet extends IrInstrBase {
   readonly key: IrValueId;
 }
 
+/**
+ * `dyn.member_set{recv, key, value}` — a strict, statement-position dynamic
+ * member write `recv[key] = value` over the canonical boxed-any carrier
+ * (#3795). All three operands are already dynamic carriers; lowering preserves
+ * their source evaluation order and delegates the actual `[[Set]]` to the
+ * existing strict object-runtime setter. This instruction is deliberately
+ * void: assignment-as-value remains outside the IR slice.
+ */
+export interface IrInstrDynMemberSet extends IrInstrBase {
+  readonly kind: "dyn.member_set";
+  /** The receiver carrier (`dynamic`). */
+  readonly recv: IrValueId;
+  /** The property key carrier (`dynamic`). */
+  readonly key: IrValueId;
+  /** The assigned value carrier (`dynamic`). */
+  readonly value: IrValueId;
+}
+
 // ---------------------------------------------------------------------------
 // String operations (#1169a — IR Phase 4 Slice 1)
 // ---------------------------------------------------------------------------
@@ -2496,6 +2514,7 @@ export type IrInstr =
   | IrInstrDynToNumber
   | IrInstrDynEq
   | IrInstrDynMemberGet
+  | IrInstrDynMemberSet
   | IrInstrStringConst
   | IrInstrStringConcat
   | IrInstrStringEq
@@ -2810,6 +2829,7 @@ export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInst
     case "dyn.to_number":
     case "dyn.eq":
     case "dyn.member_get":
+    case "dyn.member_set":
     case "string.const":
     case "string.concat":
     case "string.eq":
@@ -2974,6 +2994,7 @@ export function mapNestedBuffers(
     case "dyn.to_number":
     case "dyn.eq":
     case "dyn.member_get":
+    case "dyn.member_set":
     case "string.const":
     case "string.concat":
     case "string.eq":
@@ -3082,6 +3103,8 @@ export function directUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.lhs, instr.rhs];
     case "dyn.member_get":
       return [instr.recv, instr.key];
+    case "dyn.member_set":
+      return [instr.recv, instr.key, instr.value];
     case "string.len":
       return [instr.value];
     case "string.char_at":

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -490,6 +490,13 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
       if (recv === inst.recv && key === inst.key) return inst;
       return { ...inst, recv, key };
     }
+    case "dyn.member_set": {
+      const recv = mapId(rename, inst.recv);
+      const key = mapId(rename, inst.key);
+      const value = mapId(rename, inst.value);
+      if (recv === inst.recv && key === inst.key && value === inst.value) return inst;
+      return { ...inst, recv, key, value };
+    }
     case "string.len": {
       const v = mapId(rename, inst.value);
       if (v === inst.value) return inst;

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -738,6 +738,8 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.lhs, instr.rhs];
     case "dyn.member_get":
       return [instr.recv, instr.key];
+    case "dyn.member_set":
+      return [instr.recv, instr.key, instr.value];
     case "string.const":
       return [];
     case "string.concat":

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -56,6 +56,7 @@
 
 import { ts, forEachChild } from "../ts-api.js";
 import { collectIrSafeVarDeclarationLists } from "./function-local-var.js";
+import { collectDynamicStringLocalWidening } from "./dynamic-local-widening.js";
 import { stringBuilderForcedLegacy } from "./string-builder-shape.js";
 // (#1373b C-1) Pure-syntactic async helpers from the LEAF module (safe for
 // ir/* — async-static.ts imports only ts-api, so no codegen/index cycle).
@@ -1701,7 +1702,8 @@ function whyNotIrClaimable(
   // -------------------------------------------------------------------------
   if (dynNames.size > 0 && isGenerator) return "param-type-not-resolvable";
   if (dynNames.size > 0 || isDynamicReturn || containsRetainedFunctionMethodCall(body)) {
-    if (!dynamicUsesAreMoveOnly(fn, dynNames, isDynamicReturn, typeMap)) {
+    const dynamicStringLocals = collectDynamicStringLocalWidening(fn, new Set(dynNames));
+    if (!dynamicUsesAreMoveOnly(fn, dynNames, isDynamicReturn, typeMap, dynamicStringLocals)) {
       return dynNames.size > 0 ? "param-type-not-resolvable" : "return-type-not-resolvable";
     }
   }
@@ -2238,6 +2240,7 @@ function dynamicUsesAreMoveOnly(
   dynNames: Set<string>,
   returnIsDynamic: boolean,
   typeMap: TypeMap | undefined,
+  dynamicStringLocals: ReadonlySet<string> = new Set(),
 ): boolean {
   const body = fn.body;
   if (!body) return false;
@@ -2408,6 +2411,26 @@ function dynamicUsesAreMoveOnly(
       const leftIsDyn = isDynShaped(e.left);
       const rightIsDyn = isDynShaped(e.right);
       const op = e.operatorToken.kind;
+      // #3795 — strict statement-position dynamic element write. Keep the
+      // preclaim opening coupled to the exact Acorn family: direct dynamic
+      // parameter receiver, dynamic alias key, and either the proven widened
+      // string local or its literal conflict marker as RHS. Assignment-as-value
+      // and arbitrary dynamic writes remain rejected.
+      if (
+        op === ts.SyntaxKind.EqualsToken &&
+        !expectDyn &&
+        ts.isElementAccessExpression(e.left) &&
+        ts.isIdentifier(e.left.expression) &&
+        dynNames.has(e.left.expression.text) &&
+        ts.isIdentifier(e.left.argumentExpression) &&
+        dynNames.has(e.left.argumentExpression.text) &&
+        ((ts.isIdentifier(e.right) && dynamicStringLocals.has(e.right.text)) ||
+          (ts.isStringLiteralLike(e.right) && e.right.text === "true"))
+      ) {
+        if (!currentDynamicRuntimeBuildable) return false;
+        if (!scanExpr(e.left.expression, true) || !scanExpr(e.left.argumentExpression, true)) return false;
+        return ts.isIdentifier(e.right) ? scanExpr(e.right, true) : scanExpr(e.right, false);
+      }
       if (
         currentSubjectReturnsBoolean &&
         (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken)
@@ -2597,7 +2620,7 @@ function dynamicUsesAreMoveOnly(
         }
         const initIsDyn = isDynShaped(d.initializer);
         if (!scanExpr(d.initializer, initIsDyn)) return false;
-        if (initIsDyn) dynNames.add(d.name.text);
+        if (initIsDyn || dynamicStringLocals.has(d.name.text)) dynNames.add(d.name.text);
       }
       return true;
     }

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -755,6 +755,31 @@ function verifyInstrStructure(
       });
     }
   }
+  // #3795 — the statement-position write dual consumes three canonical
+  // dynamic carriers and produces no SSA result.
+  if (instr.kind === "dyn.member_set") {
+    for (const [label, operand] of [
+      ["recv", instr.recv],
+      ["key", instr.key],
+      ["value", instr.value],
+    ] as const) {
+      const operandIr = operandIrType(func, block, operand, localDefs);
+      if (operandIr && operandIr.kind !== "dynamic") {
+        errors.push({
+          message: `dyn.member_set ${label} must be a dynamic IrType, got ${operandIr.kind} (#3795)`,
+          func: func.name,
+          block: block.id as number,
+        });
+      }
+    }
+    if (instr.result !== null || instr.resultType !== null) {
+      errors.push({
+        message: "dyn.member_set must be void (#3795)",
+        func: func.name,
+        block: block.id as number,
+      });
+    }
+  }
 }
 
 function verifyBlock(
@@ -988,6 +1013,8 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
       return [instr.lhs, instr.rhs];
     case "dyn.member_get":
       return [instr.recv, instr.key];
+    case "dyn.member_set":
+      return [instr.recv, instr.key, instr.value];
     case "string.const":
       return [];
     case "string.concat":

--- a/tests/issue-3795-ir-dynamic-member-set.test.ts
+++ b/tests/issue-3795-ir-dynamic-member-set.test.ts
@@ -149,6 +149,7 @@ describe("#3795 IR dynamic local widening and strict member set", () => {
           trackIrOutcomes: true,
         });
       } finally {
+        // biome-ignore lint/performance/noDelete: restore the test-only environment state exactly
         if (previousForce === undefined) delete process.env.JS2WASM_FORCE_DYN_MEMBER_SET;
         else process.env.JS2WASM_FORCE_DYN_MEMBER_SET = previousForce;
       }
@@ -211,6 +212,7 @@ describe("#3795 IR dynamic local widening and strict member set", () => {
         trackIrOutcomes: true,
       });
     } finally {
+      // biome-ignore lint/performance/noDelete: restore the test-only environment state exactly
       if (previousForce === undefined) delete process.env.JS2WASM_FORCE_DYN_MEMBER_SET;
       else process.env.JS2WASM_FORCE_DYN_MEMBER_SET = previousForce;
     }
@@ -311,6 +313,7 @@ export function run(): number {
     for (const irFirst of [false, true]) {
       const previous = process.env.JS2WASM_IR_FIRST;
       if (irFirst) process.env.JS2WASM_IR_FIRST = "1";
+      // biome-ignore lint/performance/noDelete: exercise the default policy without leaving a string sentinel
       else delete process.env.JS2WASM_IR_FIRST;
       let result: Awaited<ReturnType<typeof compile>>;
       try {
@@ -321,6 +324,7 @@ export function run(): number {
           trackIrOutcomes: true,
         });
       } finally {
+        // biome-ignore lint/performance/noDelete: restore the test-only environment state exactly
         if (previous === undefined) delete process.env.JS2WASM_IR_FIRST;
         else process.env.JS2WASM_IR_FIRST = previous;
       }

--- a/tests/issue-3795-ir-dynamic-member-set.test.ts
+++ b/tests/issue-3795-ir-dynamic-member-set.test.ts
@@ -1,0 +1,434 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { ts } from "../src/ts-api.js";
+import { IrFunctionBuilder } from "../src/ir/builder.js";
+import { collectDynamicStringLocalWidening } from "../src/ir/dynamic-local-widening.js";
+import {
+  asBlockId,
+  asValueId,
+  irDynamic,
+  irVal,
+  lowerIrFunctionToWasm,
+  verifyIrFunction,
+  type IrDynamicLowering,
+  type IrFunction,
+  type IrLowerResolver,
+} from "../src/ir/index.js";
+import type { FuncTypeDef, Instr, ValType } from "../src/ir/types.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+import { walkInstructions } from "../src/codegen/walk-instructions.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-3795-ir-dynamic-member-set");
+const DYN = irDynamic();
+const F64 = irVal({ kind: "f64" });
+
+const PRIVATE_NAME_SOURCE = `
+export function isPrivateNameConflicted(privateNameMap: any, element: any) {
+  var name = element.key.name;
+  var curr = privateNameMap[name];
+
+  var next = "true";
+  if (element.type === "MethodDefinition" && (element.kind === "get" || element.kind === "set")) {
+    next = (element.static ? "s" : "i") + element.kind;
+  }
+
+  if (
+    curr === "iget" && next === "iset" ||
+    curr === "iset" && next === "iget" ||
+    curr === "sget" && next === "sset" ||
+    curr === "sset" && next === "sget"
+  ) {
+    privateNameMap[name] = "true";
+    return false;
+  } else if (!curr) {
+    privateNameMap[name] = next;
+    return false;
+  } else {
+    return true;
+  }
+}
+`;
+
+const NULLISH_IR_SOURCE = `
+export function irGet(recv: any, key: any): any {
+  return recv[key];
+}
+
+export function irSet(recv: any, key: any): void {
+  recv[key] = "true";
+}
+`;
+
+const NULLISH_DIRECT_SOURCE = `
+function directNullValue(): any {
+  var holder: any = { value: null };
+  return holder.value;
+}
+
+function directUndefinedValue(): any {
+  var holder: any = {};
+  return holder.missing;
+}
+
+function directGet(recv: any): number {
+  try {
+    var value = recv["x"]++;
+    return value ? 0 : 0;
+  } catch {
+    return 1;
+  }
+}
+
+function directSet(recv: any): number {
+  try {
+    var value = recv["x"] += "true";
+    return value ? 0 : 0;
+  } catch {
+    return 1;
+  }
+}
+
+export function directGetNull(): number {
+  return directGet(directNullValue());
+}
+
+export function directGetUndefined(): number {
+  return directGet(directUndefinedValue());
+}
+
+export function directSetNull(): number {
+  return directSet(directNullValue());
+}
+
+export function directSetUndefined(): number {
+  return directSet(directUndefinedValue());
+}
+`;
+
+const PRIVATE_NAME_WASM_DRIVER_SOURCE =
+  PRIVATE_NAME_SOURCE +
+  `
+export function registerProofDependencies(): any {
+  var map = Object.create(null);
+  Object.freeze(map);
+  Object.hasOwn(map, "__proto__");
+  return [
+    "name", "key", "type", "kind", "static",
+    "get", "set", "field", "MethodDefinition", "PropertyDefinition",
+    "x", "__proto__", "iget", "sset", "true"
+  ];
+}
+`;
+
+describe("#3795 IR dynamic local widening and strict member set", () => {
+  it("proves only Acorn's whole-local dynamic string widening", () => {
+    const source = ts.createSourceFile(
+      "issue-3795-analysis.ts",
+      PRIVATE_NAME_SOURCE,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const fn = source.statements.find(ts.isFunctionDeclaration);
+    expect(fn).toBeDefined();
+    expect([...collectDynamicStringLocalWidening(fn!, new Set(["privateNameMap", "element"]))]).toEqual(["next"]);
+  });
+
+  it.each(["gc", "standalone"] as const)(
+    "throws like direct codegen for nullish dynamic Get/Set on %s",
+    async (target) => {
+      const previousForce = process.env.JS2WASM_FORCE_DYN_MEMBER_SET;
+      process.env.JS2WASM_FORCE_DYN_MEMBER_SET = "1";
+      let irResult: Awaited<ReturnType<typeof compile>>;
+      try {
+        irResult = await compile(NULLISH_IR_SOURCE, {
+          fileName: `issue-3795-nullish-ir-${target}.ts`,
+          target,
+          skipSemanticDiagnostics: true,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousForce === undefined) delete process.env.JS2WASM_FORCE_DYN_MEMBER_SET;
+        else process.env.JS2WASM_FORCE_DYN_MEMBER_SET = previousForce;
+      }
+      const directResult = await compile(NULLISH_DIRECT_SOURCE, {
+        fileName: `issue-3795-nullish-direct-${target}.ts`,
+        target,
+        skipSemanticDiagnostics: true,
+        trackIrOutcomes: true,
+      });
+
+      expect(irResult.success, irResult.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(irResult.irPostClaimErrors ?? []).toEqual([]);
+      expect(irResult.irCompiledFuncs ?? [], JSON.stringify(irResult.irOutcomes, null, 2)).toEqual(
+        expect.arrayContaining(["irGet", "irSet"]),
+      );
+      expect(directResult.success, directResult.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(directResult.irPostClaimErrors ?? []).toEqual([]);
+      expect(directResult.irCompiledFuncs ?? []).not.toEqual(
+        expect.arrayContaining(["directGetNull", "directGetUndefined", "directSetNull", "directSetUndefined"]),
+      );
+
+      const { instance: irInstance } = await WebAssembly.instantiate(irResult.binary, irResult.importObject);
+      const { instance: directInstance } = await WebAssembly.instantiate(
+        directResult.binary,
+        directResult.importObject,
+      );
+      const directExports = directInstance.exports as Record<string, () => number>;
+      for (const name of ["directGetNull", "directGetUndefined", "directSetNull", "directSetUndefined"]) {
+        expect(directExports[name]!(), `${name} must catch RequireObjectCoercible TypeError`).toBe(1);
+      }
+
+      if (target === "gc") {
+        const irExports = irInstance.exports as {
+          irGet: (recv: unknown, key: unknown) => unknown;
+          irSet: (recv: unknown, key: unknown) => void;
+        };
+        expect(() => irExports.irGet(null, "x")).toThrow();
+        expect(() => irExports.irGet(undefined, "x")).toThrow();
+        expect(() => irExports.irSet(null, "x")).toThrow();
+        expect(() => irExports.irSet(undefined, "x")).toThrow();
+      } else {
+        const irExports = irInstance.exports as Record<string, () => unknown>;
+        for (const name of ["__dms_null_get", "__dms_undefined_get", "__dms_null_set", "__dms_undefined_set"]) {
+          expect(() => irExports[name]!(), `${name} must preserve RequireObjectCoercible`).toThrow();
+        }
+      }
+    },
+  );
+
+  it("runs the private-name truth table entirely inside standalone Wasm", async () => {
+    const target = "standalone" as const;
+    const previousForce = process.env.JS2WASM_FORCE_DYN_MEMBER_SET;
+    process.env.JS2WASM_FORCE_DYN_MEMBER_SET = "1";
+    let result: Awaited<ReturnType<typeof compile>>;
+    try {
+      result = await compile(PRIVATE_NAME_WASM_DRIVER_SOURCE, {
+        fileName: `issue-3795-private-name-wasm-driver-${target}.ts`,
+        target,
+        skipSemanticDiagnostics: true,
+        trackIrOutcomes: true,
+      });
+    } finally {
+      if (previousForce === undefined) delete process.env.JS2WASM_FORCE_DYN_MEMBER_SET;
+      else process.env.JS2WASM_FORCE_DYN_MEMBER_SET = previousForce;
+    }
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs ?? []).toContain("isPrivateNameConflicted");
+
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+    const exports = instance.exports as {
+      __dms_private_name_checksum: () => number;
+      __dms_private_name_strict_failure: () => void;
+    };
+    expect(exports.__dms_private_name_checksum()).toBe(0xffff);
+    expect(() => exports.__dms_private_name_strict_failure()).toThrow();
+  });
+
+  it.each(["gc", "standalone"] as const)(
+    "executes Acorn's exact private-name conflict family on %s",
+    async (target) => {
+      const result = await compile(PRIVATE_NAME_SOURCE, {
+        fileName: `issue-3795-ir-dynamic-member-set-${target}.ts`,
+        target,
+        skipSemanticDiagnostics: true,
+        trackIrOutcomes: true,
+      });
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+      expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toContain("isPrivateNameConflicted");
+
+      const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+      const exports = instance.exports as {
+        isPrivateNameConflicted: (map: Record<string, unknown>, element: Record<string, unknown>) => number;
+      };
+      if (target === "gc") {
+        const element = (kind: string, isStatic: boolean, name = "x") => ({
+          key: { name },
+          type: kind === "field" ? "PropertyDefinition" : "MethodDefinition",
+          kind,
+          static: isStatic,
+        });
+        const instanceMap = Object.create(null) as Record<string, unknown>;
+        expect(exports.isPrivateNameConflicted(instanceMap, element("get", false))).toBe(0);
+        expect(instanceMap.x).toBe("iget");
+        expect(exports.isPrivateNameConflicted(instanceMap, element("set", false))).toBe(0);
+        expect(instanceMap.x).toBe("true");
+        expect(exports.isPrivateNameConflicted(instanceMap, element("get", false))).toBe(1);
+
+        const staticMap = Object.create(null) as Record<string, unknown>;
+        expect(exports.isPrivateNameConflicted(staticMap, element("set", true))).toBe(0);
+        expect(staticMap.x).toBe("sset");
+        expect(exports.isPrivateNameConflicted(staticMap, element("get", true))).toBe(0);
+        expect(staticMap.x).toBe("true");
+
+        const mixedMap = Object.create(null) as Record<string, unknown>;
+        expect(exports.isPrivateNameConflicted(mixedMap, element("get", false))).toBe(0);
+        expect(exports.isPrivateNameConflicted(mixedMap, element("set", true))).toBe(1);
+
+        const nullProto = Object.create(null) as Record<string, unknown>;
+        expect(exports.isPrivateNameConflicted(nullProto, element("field", false, "__proto__"))).toBe(0);
+        expect(nullProto.__proto__).toBe("true");
+
+        expect(() => exports.isPrivateNameConflicted(Object.freeze({}), element("field", false))).toThrow();
+      }
+    },
+  );
+
+  it("rejects annotated/wider writes before claim in overlay and IR-first", async () => {
+    const source = `
+function assignmentValue(map: any, key: any): any {
+  var next = "true";
+  next = key.kind + "x";
+  return map[key] = next;
+}
+
+function widerValue(map: any, key: any, other: any): boolean {
+  var next = "true";
+  next = key.kind + "x";
+  next = other;
+  map[key] = next;
+  return false;
+}
+
+function annotatedValue(map: any, key: any): boolean {
+  var next: string = "true";
+  next = key.kind + "x";
+  map[key] = next;
+  return false;
+}
+
+export function run(): number {
+  return assignmentValue({}, "x") === "undefinedx" &&
+    !widerValue({}, "x", "y") &&
+    !annotatedValue({}, "x") ? 1 : 0;
+}
+`;
+    for (const irFirst of [false, true]) {
+      const previous = process.env.JS2WASM_IR_FIRST;
+      if (irFirst) process.env.JS2WASM_IR_FIRST = "1";
+      else delete process.env.JS2WASM_IR_FIRST;
+      let result: Awaited<ReturnType<typeof compile>>;
+      try {
+        result = await compile(source, {
+          fileName: `issue-3795-ir-dynamic-member-set-negative-${irFirst ? "first" : "overlay"}.ts`,
+          target: "gc",
+          skipSemanticDiagnostics: true,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previous === undefined) delete process.env.JS2WASM_IR_FIRST;
+        else process.env.JS2WASM_IR_FIRST = previous;
+      }
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+      expect(result.irCompiledFuncs ?? []).not.toContain("assignmentValue");
+      expect(result.irCompiledFuncs ?? []).not.toContain("widerValue");
+      expect(result.irCompiledFuncs ?? []).not.toContain("annotatedValue");
+    }
+  });
+});
+
+describe("#3795 dyn.member_set node and lowering contract", () => {
+  it("builds and verifies the canonical void node", () => {
+    const builder = new IrFunctionBuilder(identities.next("builder"), [], false);
+    const recv = builder.addParam("recv", DYN);
+    const key = builder.addParam("key", DYN);
+    const value = builder.addParam("value", DYN);
+    builder.openBlock();
+    builder.emitDynMemberSet(recv, key, value);
+    builder.terminate({ kind: "return", values: [] });
+    const fn = builder.finish();
+
+    expect(fn.blocks[0]?.instrs[0]).toMatchObject({ kind: "dyn.member_set", recv, key, value });
+    expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("rejects concrete operands at construction and verification", () => {
+    const builder = new IrFunctionBuilder(identities.next("builder-bad"), [], false);
+    const recv = builder.addParam("recv", DYN);
+    const key = builder.addParam("key", DYN);
+    const concrete = builder.addParam("value", F64);
+    builder.openBlock();
+    expect(() => builder.emitDynMemberSet(recv, key, concrete)).toThrow(/value operand .* is not dynamic/);
+
+    builder.terminate({ kind: "return", values: [] });
+    const fn = builder.finish();
+    const bad: IrFunction = {
+      ...fn,
+      blocks: [
+        {
+          ...fn.blocks[0]!,
+          instrs: [{ kind: "dyn.member_set", recv, key, value: concrete } as never],
+        },
+      ],
+    };
+    expect(verifyIrFunction(bad).some((error) => /dyn\.member_set value must be a dynamic/.test(error.message))).toBe(
+      true,
+    );
+  });
+
+  it("lowers receiver, key, and value once in left-to-right order", () => {
+    const recv = asValueId(0);
+    const key = asValueId(1);
+    const value = asValueId(2);
+    const fn: IrFunction = {
+      ...identities.next("lower"),
+      params: [
+        { value: recv, type: DYN, name: "recv" },
+        { value: key, type: DYN, name: "key" },
+        { value, type: DYN, name: "value" },
+      ],
+      resultTypes: [],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [{ kind: "dyn.member_set", recv, key, value, result: null, resultType: null }],
+          terminator: { kind: "return", values: [] },
+        },
+      ],
+      exported: false,
+      valueCount: 3,
+    };
+    const carrier: ValType = { kind: "externref" };
+    const dynamic: IrDynamicLowering = {
+      strategy: "host",
+      carrier,
+      emitBox: () => [],
+      emitUnbox: () => [],
+      emitAdd: () => [],
+      emitEq: () => [],
+      emitToNumber: () => [],
+      emitMemberGet: () => [],
+      emitElementGet: () => [],
+      emitMemberSet: () => [{ op: "call", funcIdx: 0xbeef } as Instr],
+    };
+    const resolver: IrLowerResolver = {
+      resolveFunc: () => 0,
+      resolveGlobal: () => 0,
+      resolveType: () => 0,
+      internFuncType: (_type: FuncTypeDef) => 0,
+      resolveDynamic: () => carrier,
+      resolveDynamicLowering: () => dynamic,
+    };
+
+    const { func } = lowerIrFunctionToWasm(fn, resolver);
+    const flattened: Instr[] = [];
+    walkInstructions(func.body, (instruction) => flattened.push(instruction));
+    const call = flattened.findIndex(
+      (instruction) => instruction.op === "call" && (instruction as { funcIdx: number }).funcIdx === 0xbeef,
+    );
+    const operands = flattened
+      .slice(0, call)
+      .filter((instruction) => instruction.op === "local.get")
+      .map((instruction) => (instruction as { index: number }).index);
+    expect(operands.slice(-3)).toEqual([0, 1, 2]);
+  });
+});


### PR DESCRIPTION
## Summary

- add a canonical, side-effecting `dyn.member_set(receiver, key, value)` IR instruction and lower it across host and standalone carriers
- preserve JavaScript evaluation order, strict assignment behavior, Proxy/setter receiver identity, and `RequireObjectCoercible` throwing for null/undefined carriers
- add a shared preclaim/lowering proof for mutable string-literal locals that later receive dynamic string concatenations
- keep explicit annotations, assignment-as-value, optional/wider writes, and mixed-representation locals outside IR before claim
- move Acorn's `isPrivateNameConflicted` into IR without changing the runtime-dynamic workload

## Acorn result

- IR-emitted reachable functions: **31/43 → 32/43**
- sole new function: `isPrivateNameConflicted`
- runtime checksum: **422/422**
- module imports: **0**
- function imports: **0**
- post-claim withdrawals: **0**

The standalone proof is a zero-argument in-Wasm driver. It executes the private-name transition table, duplicate/mixed cases, strict frozen-write failure, null-prototype `__proto__`, and nullish receiver behavior and returns the checked `0xffff` result.

## Validation

- independent adversarial review: approved after nullish-receiver, typed-local, and standalone anti-vacuity fixes
- focused #3795 + adjacent #3794: 14/14
- TypeScript typecheck: passed
- IR fallback ratchet: passed, no post-claim demotions
- LOC and function budgets: passed
- formatting and issue gates: passed
- exact unchanged Acorn runtime-dynamic driver: passed at 32/43

Tracked in `plan/issues/3795-ir-dynamic-member-set.md`.
