### PR TITLE
fix(pages): resolve benchmark timing source

### DIFF
--- a/scripts/generate-size-benchmarks.ts
+++ b/scripts/generate-size-benchmarks.ts
@@ -21,7 +21,7 @@ import * as path from "node:path";
 import * as zlib from "node:zlib";
 import * as ts from "typescript";
 import { compile, compileMulti, optimizeBinaryAsync } from "./compiler-bundle.mjs";
-import { calibrateBenchmarkBatchSize, timeBenchmarkBatch } from "../benchmarks/timing.js";
+import { calibrateBenchmarkBatchSize, timeBenchmarkBatch } from "../benchmarks/timing.ts";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const HELPERS_PATH = path.resolve(ROOT, "website", "playground", "examples", "benchmarks", "helpers.ts");

--- a/tests/benchmark-harness.test.ts
+++ b/tests/benchmark-harness.test.ts
@@ -1,8 +1,15 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import { BENCHMARK_MAX_BATCH_SIZE, BENCHMARK_SAMPLE_TARGET_MS, nextBenchmarkBatchSize } from "../benchmarks/timing.js";
+
+const ROOT = resolve(import.meta.dirname, "..");
 
 describe("internal benchmark batching", () => {
   it("scales sub-millisecond calls to a scheduler-sized sample", () => {
@@ -15,4 +22,29 @@ describe("internal benchmark batching", () => {
     expect(nextBenchmarkBatchSize(0.000001, 1)).toBe(BENCHMARK_MAX_BATCH_SIZE);
     expect(nextBenchmarkBatchSize(1, BENCHMARK_MAX_BATCH_SIZE)).toBe(BENCHMARK_MAX_BATCH_SIZE);
   });
+
+  it.skipIf(Number(process.versions.node.split(".")[0]) < 22)(
+    "keeps the Pages generator timing import resolvable by native type stripping",
+    () => {
+      const generatorPath = resolve(ROOT, "scripts", "generate-size-benchmarks.ts");
+      const generatorSource = readFileSync(generatorPath, "utf8");
+      const timingImport = generatorSource.match(/from "(\.\.\/benchmarks\/timing\.[^"]+)"/)?.[1];
+
+      expect(timingImport).toBe("../benchmarks/timing.ts");
+
+      const timingUrl = new URL(timingImport!, pathToFileURL(generatorPath));
+      expect(() =>
+        execFileSync(
+          process.execPath,
+          [
+            "--experimental-strip-types",
+            "--input-type=module",
+            "--eval",
+            `const timing = await import(${JSON.stringify(timingUrl.href)}); if (typeof timing.calibrateBenchmarkBatchSize !== "function") process.exit(1);`,
+          ],
+          { stdio: "pipe" },
+        ),
+      ).not.toThrow();
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- import the benchmark timing helper with its explicit TypeScript extension under Node native type stripping
- add a regression that imports the exact Pages generator dependency with the native strip-types flag

## Root cause
The post-#3833 benchmark promotion succeeded, but Pages run 30539936314 requested the JavaScript timing path while the source file is TypeScript. The Pages Node 25.9 invocation rejected that unresolved module.

## Verification
- focused benchmark harness tests
- typecheck
- Prettier and Biome
- exact native Node size-benchmark generator command
- git diff check

Follow-up to #3833 and failed Pages run 30539936314.