### PR TITLE
fix(codegen): preserve this for stable named .call targets

### DIFF
--- a/plan/issues/3796-named-this-call.md
+++ b/plan/issues/3796-named-this-call.md
@@ -1,0 +1,107 @@
+---
+id: 3796
+title: "Receiver-correct stable named FunctionDeclaration.call"
+status: in-progress
+sprint: current
+created: 2026-07-30
+updated: 2026-07-30
+priority: high
+horizon: s
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen, ir
+es_edition: multi
+language_feature: functions
+goal: ir-full-coverage
+parent: 3522
+depends_on: [3794]
+related: [1636, 1702, 2069, 2152, 3673, 3795]
+assignee: codex/finish-node-at-receiver-call
+branch: codex/3796-named-this-call
+files:
+  - src/codegen/named-this-call.ts
+  - src/codegen/expressions/calls.ts
+  - tests/issue-3796-named-this-call.test.ts
+loc-budget-allow:
+  - src/codegen/named-this-call.ts
+  - src/codegen/expressions/calls.ts
+func-budget-allow:
+  - src/codegen/named-this-call.ts::resolveNamedThisCallTarget
+  - src/codegen/named-this-call.ts::ensureNamedThisCallTrampoline
+  - src/codegen/expressions/calls.ts::compileCallExpression
+---
+
+# #3796 — preserve `thisArg` for an exact named `.call`
+
+## Problem
+
+The direct path for `stableFunction.call(thisArg, ...args)` resolves a named
+`FunctionDeclaration` to its exact Wasm target, but evaluates and discards
+`thisArg`. A declaration whose own body reads `this` therefore observes the
+unbound fallback instead of the receiver supplied by `.call`.
+
+Acorn reaches this gap in both `finishNode` and `finishNodeAt`:
+
+```js
+function finishNodeAt(node, type, pos, loc) {
+  node.type = type;
+  node.end = pos;
+  if (this.options.locations) node.loc.end = loc;
+  if (this.options.ranges) node.range[1] = pos;
+  return node;
+}
+
+pp.finishNodeAt = function (node, type, pos, loc) {
+  return finishNodeAt.call(this, node, type, pos, loc);
+};
+```
+
+The IR selector cannot claim that stable call until the exact direct fallback
+has receiver-correct semantics.
+
+## Scope
+
+- Admit only an exact checker-resolved, body-bearing, non-generator,
+  non-async `FunctionDeclaration` whose own body reads `this`.
+- Handle `.call` only. Keep `.apply`, closures, aliases, explicit TypeScript
+  `this` parameters, rest parameters, and unstable declarations on their
+  existing paths.
+- Admit Acorn's bare-`this` receiver and other receiver expressions whose
+  checker type excludes null, undefined, and void.
+- Reserve one exact-target trampoline with ABI
+  `(externref thisArg, ...targetParams) -> targetResults`.
+- Save/install/restore `__current_this`, including restoration in
+  `catch_all` before `rethrow 0`.
+- Preserve receiver-before-arguments evaluation order, exact target ABI,
+  `arguments.length` plumbing, result values, nesting, and re-entrancy.
+- Keep a runtime-null receiver on the prior unbound exact call.
+- Add no host import and preserve all unrelated direct-call optimizations.
+
+## Acceptance criteria
+
+- [x] Receiver identity and four-argument order execute correctly.
+- [x] Nested and re-entrant calls restore the outer receiver.
+- [x] A throwing target restores the outer receiver before rethrow.
+- [x] Acorn's locations/ranges `finishNodeAt` shape executes by value.
+- [x] Nullish, `.apply`, alias, closure, and this-free negative shapes do not
+      reserve the trampoline.
+- [x] IR-first enabled/disabled runs are behaviorally identical.
+- [x] Focused and adjacent tests, typecheck, formatting, LOC/function budgets,
+      IR fallback ratchet, and equivalence gate pass.
+
+## Completion evidence
+
+- Focused #3796 suite: 6/6 passing. It executes the four-argument
+  receiver-first order, `arguments.length`, nested/re-entrant restoration,
+  exceptional restoration, the locations+ranges Acorn shape, negative
+  admission, and IR-first `0`/`1` parity.
+- Every focused standalone module has zero Wasm imports.
+- Adjacent `.call`/ambient-`this` suites: 60 passing. The sole adjacent failure,
+  #2069's string-constants import-object setup, reproduces unchanged on the
+  detached `origin/main` control.
+- Typecheck, Biome lint, Prettier, issue integrity, LOC/function budgets,
+  stack-balance, dead-export, coercion-site, IR fallback, and optimization
+  retirement gates pass.
+- Equivalence gate: 1,611 passing, 32 baseline failures, four baseline failures
+  now passing, and zero new regressions.

--- a/plan/issues/3796-named-this-call.md
+++ b/plan/issues/3796-named-this-call.md
@@ -63,10 +63,16 @@ has receiver-correct semantics.
 ## Scope
 
 - Admit only an exact checker-resolved, body-bearing, non-generator,
-  non-async `FunctionDeclaration` whose own body reads `this`.
+  non-async, unique top-level `FunctionDeclaration` whose own body reads
+  `this`, and require the Program ABI source-callable registry to prove that
+  exact declaration owns the resolved `FuncHandle`.
 - Handle `.call` only. Keep `.apply`, closures, aliases, explicit TypeScript
-  `this` parameters, rest parameters, and unstable declarations on their
-  existing paths.
+  `this` parameters, rest parameters, reassigned live function bindings,
+  nested/same-name shadows, and unstable declarations on their existing paths.
+- Require exact source arity and no spread. Under- and over-application remain
+  on the legacy path. Repair that legacy over-application path so it compiles
+  only formal operands and preserves extras through the established
+  `arguments`/extras ABI (or evaluates and drops them when unobserved).
 - Admit Acorn's bare-`this` receiver and other receiver expressions whose
   checker type excludes null, undefined, and void.
 - Reserve one exact-target trampoline with ABI
@@ -84,8 +90,8 @@ has receiver-correct semantics.
 - [x] Nested and re-entrant calls restore the outer receiver.
 - [x] A throwing target restores the outer receiver before rethrow.
 - [x] Acorn's locations/ranges `finishNodeAt` shape executes by value.
-- [x] Nullish, `.apply`, alias, closure, and this-free negative shapes do not
-      reserve the trampoline.
+- [x] Nullish, `.apply`, alias, closure, this-free, reassigned, nested-shadow,
+      and over-arity negative shapes do not reserve the trampoline.
 - [x] IR-first enabled/disabled runs are behaviorally identical.
 - [x] Focused and adjacent tests, typecheck, formatting, LOC/function budgets,
       IR fallback ratchet, and equivalence gate pass.
@@ -95,9 +101,10 @@ has receiver-correct semantics.
 - Focused #3796 suite: 6/6 passing. It executes the four-argument
   receiver-first order, `arguments.length`, nested/re-entrant restoration,
   exceptional restoration, the locations+ranges Acorn shape, negative
-  admission, and IR-first `0`/`1` parity.
+  admission (including anti-vacuity runtime checks for reassigned,
+  same-name-shadowed, and over-arity targets), and IR-first `0`/`1` parity.
 - Every focused standalone module has zero Wasm imports.
-- Adjacent `.call`/ambient-`this` suites: 60 passing. The sole adjacent failure,
+- Adjacent `.call`/ambient-`this` suites: 59 passing. The sole adjacent failure,
   #2069's string-constants import-object setup, reproduces unchanged on the
   detached `origin/main` control.
 - Typecheck, Biome lint, Prettier, issue integrity, LOC/function budgets,

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -321,6 +321,7 @@ import {
   sourceParamCountFromExpanded,
   wasmParamIndexForSourceParam,
 } from "../linear-uint8-signatures.js";
+import { resolveNamedThisCallTarget } from "../named-this-call.js";
 
 // Registry extracted to its own leaf module (#1793; LOC ratchet #3102) —
 // re-exported here so existing importers keep resolving via calls.js.
@@ -6568,6 +6569,17 @@ function compileCallExpression(
           closureInfo = resolveClosureInfoFromLocal(ctx, fctx, funcName);
         }
 
+        // (#3796) A stable named FunctionDeclaration whose own body reads
+        // `this` needs the `.call` receiver installed in `__current_this`.
+        // Resolve/reserve this before emitting operands so helper publication
+        // cannot happen while values are conceptually live on the Wasm stack.
+        // `.apply`, closures, imports, explicit-this declarations, nullable
+        // receivers, and unstable symbols keep their existing lowerings.
+        const namedThisCall =
+          isCall && !closureInfo && funcIdx !== undefined && expr.arguments.length > 0
+            ? resolveNamedThisCallTarget(ctx, fctx, innerExpr, funcIdx, expr.arguments[0]!)
+            : undefined;
+
         // (#2193 PR-B) `m.call(thisArg, …args)` where `m` is a `$NativeProto`
         // member closure (e.g. `Array.prototype.slice`). Its FIRST user param is
         // the receiver (`this`), NOT an ordinary arg — so unlike a plain
@@ -6606,10 +6618,17 @@ function compileCallExpression(
         }
 
         if (closureInfo || funcIdx !== undefined) {
-          // Evaluate and drop thisArg (first argument) if present
+          // Evaluate thisArg first. The receiver-correct named trampoline owns
+          // it as leading externref param; every other existing path keeps the
+          // legacy evaluate-and-drop behavior.
           if (expr.arguments.length > 0) {
-            const thisType = compileExpression(ctx, fctx, expr.arguments[0]!);
-            if (thisType) {
+            const thisType = compileExpression(
+              ctx,
+              fctx,
+              expr.arguments[0]!,
+              namedThisCall ? { kind: "externref" } : undefined,
+            );
+            if (thisType && !namedThisCall) {
               fctx.body.push({ op: "drop" });
             }
           }
@@ -6698,7 +6717,7 @@ function compileCallExpression(
               getFuncParamTypes(ctx, funcIdx!)?.length ?? remainingArgs.length,
             );
             const finalFuncIdx = ctx.funcMap.get(funcName) ?? funcIdx!;
-            fctx.body.push({ op: "call", funcIdx: finalFuncIdx });
+            fctx.body.push({ op: "call", funcIdx: namedThisCall?.trampolineFuncIdx ?? finalFuncIdx });
 
             // Use actual Wasm return type — TS checker reports `any` for .call()/.apply()
             // which resolves to externref, but the actual function may return f64/i32/ref.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6577,7 +6577,7 @@ function compileCallExpression(
         // receivers, and unstable symbols keep their existing lowerings.
         const namedThisCall =
           isCall && !closureInfo && funcIdx !== undefined && expr.arguments.length > 0
-            ? resolveNamedThisCallTarget(ctx, fctx, innerExpr, funcIdx, expr.arguments[0]!)
+            ? resolveNamedThisCallTarget(ctx, fctx, innerExpr, funcIdx, expr.arguments[0]!, expr.arguments.slice(1))
             : undefined;
 
         // (#2193 PR-B) `m.call(thisArg, …args)` where `m` is a `$NativeProto`
@@ -6681,8 +6681,24 @@ function compileCallExpression(
             } else {
               // Regular function call
               const paramTypes = getFuncParamTypes(ctx, funcIdx!);
-              for (let i = 0; i < remainingArgs.length; i++) {
+              const paramCount = paramTypes?.length ?? remainingArgs.length;
+              const formalArgCount = Math.min(remainingArgs.length, paramCount);
+              for (let i = 0; i < formalArgCount; i++) {
                 compileExpression(ctx, fctx, remainingArgs[i]!, paramTypes?.[i]);
+              }
+              // `.call` over-application must not leave extra operands under
+              // the exact Wasm call. Preserve side effects, and when the target
+              // reads `arguments`, marshal the overflow through the same
+              // extras-argv ABI as a direct identifier call.
+              if (remainingArgs.length > paramCount) {
+                if (ctx.funcUsesArguments.has(funcName)) {
+                  emitSetExtrasArgv(ctx, fctx, remainingArgs as ts.Expression[], paramCount);
+                } else {
+                  for (let i = paramCount; i < remainingArgs.length; i++) {
+                    const extraType = compileExpression(ctx, fctx, remainingArgs[i]!);
+                    if (extraType !== null) fctx.body.push({ op: "drop" });
+                  }
+                }
               }
 
               // Supply defaults for missing optional params

--- a/src/codegen/named-this-call.ts
+++ b/src/codegen/named-this-call.ts
@@ -80,7 +80,27 @@ function resolveDeclaration(ctx: CodegenContext, callee: ts.Identifier): ts.Func
       decl.asteriskToken === undefined &&
       !decl.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword),
   );
-  return bodies.length === 1 ? bodies[0] : undefined;
+  const declaration = bodies.length === 1 ? bodies[0] : undefined;
+  // This slice only has an exact allocator identity for unique source-file
+  // declarations. Nested declarations can shadow a top-level function with
+  // the same funcMap key; name equality is not declaration identity.
+  if (!declaration || declaration.parent !== declaration.getSourceFile()) return undefined;
+  return declaration;
+}
+
+function declarationOwnsHandle(
+  ctx: CodegenContext,
+  declaration: ts.FunctionDeclaration,
+  targetFuncIdx: FuncHandle,
+): boolean {
+  const registry = ctx.programAbiSourceCallables;
+  const identity = registry?.identityContext;
+  const unitId = identity?.unitIdByDeclaration.get(declaration);
+  return (
+    unitId !== undefined &&
+    identity?.declarationByUnitId.get(unitId) === declaration &&
+    registry?.handleForUnit(unitId) === targetFuncIdx
+  );
 }
 
 function callTarget(targetFuncIdx: FuncHandle, paramCount: number): Instr[] {
@@ -184,11 +204,16 @@ export function resolveNamedThisCallTarget(
   callee: ts.Identifier,
   targetFuncIdx: FuncHandle,
   receiver: ts.Expression,
+  userArguments: readonly ts.Expression[],
 ): NamedThisCallTarget | undefined {
   const declaration = resolveDeclaration(ctx, callee);
   if (
     !declaration?.body ||
+    ctx.liveFuncBindingGlobals?.has(callee.text) === true ||
+    !declarationOwnsHandle(ctx, declaration, targetFuncIdx) ||
     declaration.parameters.some((parameter) => parameter.dotDotDotToken !== undefined) ||
+    userArguments.length !== declaration.parameters.length ||
+    userArguments.some((argument) => ts.isSpreadElement(argument)) ||
     (declaration.parameters[0] &&
       ts.isIdentifier(declaration.parameters[0].name) &&
       declaration.parameters[0].name.text === "this") ||

--- a/src/codegen/named-this-call.ts
+++ b/src/codegen/named-this-call.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Receiver-correct direct `.call` for stable named function declarations.
+ *
+ * A named FunctionDeclaration is emitted as a plain Wasm function. Its own
+ * `this` reads the ambient `__current_this` slot, but the legacy
+ * `fn.call(thisArg, ...args)` path evaluated and discarded `thisArg` before
+ * calling that exact function. This module reserves one exact-target
+ * trampoline whose ABI is `(externref thisArg, ...targetParams) ->
+ * targetResults`.
+ *
+ * The live-receiver arm saves/installs/restores `__current_this`. Restoration
+ * is exception-safe: catch_all restores the prior receiver and rethrows the
+ * original exception. A null receiver uses the pre-existing unbound exact call
+ * instead, so this narrow fast path does not redefine the legacy nullish case.
+ */
+import { ts } from "../ts-api.js";
+import type { FuncHandle, Instr, ValType, WasmFunction } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { bodyReferencesOwnThis } from "./helpers/body-references-own-this.js";
+import { addFuncType } from "./registry/types.js";
+import { ensureCurrentThisGlobal } from "./statements/nested-declarations.js";
+
+interface NamedThisCallTarget {
+  readonly trampolineFuncIdx: FuncHandle;
+}
+
+interface CachedTrampoline {
+  readonly funcIdx: FuncHandle;
+  readonly func: WasmFunction;
+}
+
+const trampolineCache = new WeakMap<CodegenContext, WeakMap<WasmFunction, CachedTrampoline>>();
+
+function unwrap(expr: ts.Expression): ts.Expression {
+  let current = expr;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function checkerProvesNonNullish(type: ts.Type): boolean {
+  if (type.isUnion()) return type.types.length > 0 && type.types.every(checkerProvesNonNullish);
+  const refused =
+    ts.TypeFlags.Any |
+    ts.TypeFlags.Unknown |
+    ts.TypeFlags.Never |
+    ts.TypeFlags.Null |
+    ts.TypeFlags.Undefined |
+    ts.TypeFlags.Void;
+  return (type.flags & refused) === 0;
+}
+
+function receiverIsAdmitted(ctx: CodegenContext, fctx: FunctionContext, receiver: ts.Expression): boolean {
+  const inner = unwrap(receiver);
+  // Acorn's exact wrappers use `finishNodeAt.call(this, ...)`. A body whose
+  // own `this` is live reads the receiver installed by the enclosing method
+  // dispatch. The trampoline still runtime-splits a null value to the legacy
+  // unbound call, so a detached/nullish reach does not enter the fast arm.
+  if (inner.kind === ts.SyntaxKind.ThisKeyword) return fctx.readsCurrentThis === true;
+  return checkerProvesNonNullish(ctx.checker.getTypeAtLocation(inner));
+}
+
+function resolveDeclaration(ctx: CodegenContext, callee: ts.Identifier): ts.FunctionDeclaration | undefined {
+  const symbol = ctx.checker.getSymbolAtLocation(callee);
+  if (!symbol || (symbol.flags & ts.SymbolFlags.Alias) !== 0) return undefined;
+  const bodies = (symbol.declarations ?? []).filter(
+    (decl): decl is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(decl) &&
+      decl.body !== undefined &&
+      decl.name?.text === callee.text &&
+      decl.asteriskToken === undefined &&
+      !decl.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword),
+  );
+  return bodies.length === 1 ? bodies[0] : undefined;
+}
+
+function callTarget(targetFuncIdx: FuncHandle, paramCount: number): Instr[] {
+  const body: Instr[] = [];
+  for (let i = 0; i < paramCount; i++) body.push({ op: "local.get", index: i + 1 });
+  body.push({ op: "call", funcIdx: targetFuncIdx });
+  return body;
+}
+
+function safeName(name: string): string {
+  return name.replace(/[^A-Za-z0-9_$]/g, "_");
+}
+
+function ensureNamedThisCallTrampoline(
+  ctx: CodegenContext,
+  targetName: string,
+  targetFuncIdx: FuncHandle,
+  targetFunc: WasmFunction,
+  params: readonly ValType[],
+  results: readonly ValType[],
+): FuncHandle {
+  let byTarget = trampolineCache.get(ctx);
+  if (!byTarget) {
+    byTarget = new WeakMap();
+    trampolineCache.set(ctx, byTarget);
+  }
+  const cached = byTarget.get(targetFunc);
+  // Speculative compilation can roll module state back while the CodegenContext
+  // remains alive. Accept a cache hit only while it still owns the exact
+  // published function object at that stable handle.
+  if (cached && definedFuncAt(ctx, cached.funcIdx) === cached.func) return cached.funcIdx;
+
+  if (definedFuncAt(ctx, targetFuncIdx) !== targetFunc) {
+    throw new Error(`named-this trampoline target changed before reserving ${targetName}`);
+  }
+  const targetOrdinal = ctx.mod.functions.indexOf(targetFunc);
+  const helperName = `__named_this_call_${safeName(targetName)}_${targetOrdinal}`;
+  const currentThisGlobalIdx = ensureCurrentThisGlobal(ctx);
+  const trampolineParams: ValType[] = [{ kind: "externref" }, ...params];
+  const typeIdx = addFuncType(ctx, trampolineParams, [...results], `$${helperName}_type`);
+  const trampolineFuncIdx = mintDefinedFunc(ctx);
+  const prevThisLocal = trampolineParams.length;
+  const resultType = results[0];
+  const resultLocal = resultType === undefined ? -1 : prevThisLocal + 1;
+  const exactCall = callTarget(targetFuncIdx, params.length);
+
+  const liveCall: Instr[] = [
+    { op: "global.get", index: currentThisGlobalIdx },
+    { op: "local.set", index: prevThisLocal },
+    { op: "local.get", index: 0 },
+    { op: "global.set", index: currentThisGlobalIdx },
+    {
+      op: "try",
+      blockType: resultType === undefined ? { kind: "empty" } : { kind: "val", type: resultType },
+      body: exactCall,
+      catches: [],
+      catchAll: [
+        { op: "local.get", index: prevThisLocal },
+        { op: "global.set", index: currentThisGlobalIdx },
+        { op: "rethrow", depth: 0 },
+      ],
+    },
+    ...(resultLocal < 0 ? [] : ([{ op: "local.set", index: resultLocal }] satisfies Instr[])),
+    { op: "local.get", index: prevThisLocal },
+    { op: "global.set", index: currentThisGlobalIdx },
+    ...(resultLocal < 0 ? [] : ([{ op: "local.get", index: resultLocal }] satisfies Instr[])),
+  ];
+
+  const body: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: resultType === undefined ? { kind: "empty" } : { kind: "val", type: resultType },
+      then: callTarget(targetFuncIdx, params.length),
+      else: liveCall,
+    },
+  ];
+  const trampolineFunc: WasmFunction = {
+    name: helperName,
+    typeIdx,
+    locals: [
+      { name: "__previous_this", type: { kind: "externref" } },
+      ...(resultType === undefined ? [] : [{ name: "__result", type: resultType }]),
+    ],
+    body,
+    exported: false,
+  };
+  pushDefinedFunc(ctx, trampolineFuncIdx, trampolineFunc);
+  byTarget.set(targetFunc, { funcIdx: trampolineFuncIdx, func: trampolineFunc });
+  return trampolineFuncIdx;
+}
+
+/**
+ * Resolve and reserve the narrow named `.call` target, or return undefined so
+ * the existing generic lowering remains authoritative.
+ */
+export function resolveNamedThisCallTarget(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  callee: ts.Identifier,
+  targetFuncIdx: FuncHandle,
+  receiver: ts.Expression,
+): NamedThisCallTarget | undefined {
+  const declaration = resolveDeclaration(ctx, callee);
+  if (
+    !declaration?.body ||
+    declaration.parameters.some((parameter) => parameter.dotDotDotToken !== undefined) ||
+    (declaration.parameters[0] &&
+      ts.isIdentifier(declaration.parameters[0].name) &&
+      declaration.parameters[0].name.text === "this") ||
+    !bodyReferencesOwnThis(declaration.body) ||
+    !receiverIsAdmitted(ctx, fctx, receiver)
+  ) {
+    return undefined;
+  }
+
+  const targetFunc = definedFuncAt(ctx, targetFuncIdx);
+  if (!targetFunc || targetFunc.name !== callee.text) return undefined;
+  const signature = ctx.mod.types[targetFunc.typeIdx];
+  if (
+    signature?.kind !== "func" ||
+    signature.params.length !== declaration.parameters.length ||
+    signature.results.length > 1
+  ) {
+    return undefined;
+  }
+  const trampolineFuncIdx = ensureNamedThisCallTrampoline(
+    ctx,
+    callee.text,
+    targetFuncIdx,
+    targetFunc,
+    signature.params,
+    signature.results,
+  );
+  return { trampolineFuncIdx };
+}

--- a/src/codegen/named-this-call.ts
+++ b/src/codegen/named-this-call.ts
@@ -15,6 +15,7 @@
  * instead, so this narrow fast path does not redefine the legacy nullish case.
  */
 import { ts } from "../ts-api.js";
+import type { TypeFact } from "../checker/oracle.js";
 import type { FuncHandle, Instr, ValType, WasmFunction } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
@@ -47,16 +48,23 @@ function unwrap(expr: ts.Expression): ts.Expression {
   return current;
 }
 
-function checkerProvesNonNullish(type: ts.Type): boolean {
-  if (type.isUnion()) return type.types.length > 0 && type.types.every(checkerProvesNonNullish);
-  const refused =
-    ts.TypeFlags.Any |
-    ts.TypeFlags.Unknown |
-    ts.TypeFlags.Never |
-    ts.TypeFlags.Null |
-    ts.TypeFlags.Undefined |
-    ts.TypeFlags.Void;
-  return (type.flags & refused) === 0;
+function oracleProvesNonNullish(fact: TypeFact): boolean {
+  if (fact.kind === "union") {
+    return (
+      !fact.nullable &&
+      !fact.undefinable &&
+      fact.parts.length > 0 &&
+      fact.parts.every((part) => oracleProvesNonNullish(part))
+    );
+  }
+  return (
+    fact.kind !== "any" &&
+    fact.kind !== "unknown" &&
+    fact.kind !== "unresolvable" &&
+    fact.kind !== "null" &&
+    fact.kind !== "undefined" &&
+    fact.kind !== "void"
+  );
 }
 
 function receiverIsAdmitted(ctx: CodegenContext, fctx: FunctionContext, receiver: ts.Expression): boolean {
@@ -66,25 +74,28 @@ function receiverIsAdmitted(ctx: CodegenContext, fctx: FunctionContext, receiver
   // dispatch. The trampoline still runtime-splits a null value to the legacy
   // unbound call, so a detached/nullish reach does not enter the fast arm.
   if (inner.kind === ts.SyntaxKind.ThisKeyword) return fctx.readsCurrentThis === true;
-  return checkerProvesNonNullish(ctx.checker.getTypeAtLocation(inner));
+  return oracleProvesNonNullish(ctx.oracle.typeFactOf(inner));
 }
 
 function resolveDeclaration(ctx: CodegenContext, callee: ts.Identifier): ts.FunctionDeclaration | undefined {
-  const symbol = ctx.checker.getSymbolAtLocation(callee);
-  if (!symbol || (symbol.flags & ts.SymbolFlags.Alias) !== 0) return undefined;
-  const bodies = (symbol.declarations ?? []).filter(
-    (decl): decl is ts.FunctionDeclaration =>
-      ts.isFunctionDeclaration(decl) &&
-      decl.body !== undefined &&
-      decl.name?.text === callee.text &&
-      decl.asteriskToken === undefined &&
-      !decl.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword),
-  );
-  const declaration = bodies.length === 1 ? bodies[0] : undefined;
+  const declaration = ctx.oracle.valueDeclarationOf(callee);
   // This slice only has an exact allocator identity for unique source-file
-  // declarations. Nested declarations can shadow a top-level function with
-  // the same funcMap key; name equality is not declaration identity.
-  if (!declaration || declaration.parent !== declaration.getSourceFile()) return undefined;
+  // declarations. Requiring the declaration in the callee's source file also
+  // refuses imported aliases without exposing checker Symbols outside Oracle.
+  // Nested declarations can shadow a top-level function with the same funcMap
+  // key; name equality is not declaration identity.
+  if (
+    !declaration ||
+    !ts.isFunctionDeclaration(declaration) ||
+    declaration.body === undefined ||
+    declaration.name?.text !== callee.text ||
+    declaration.asteriskToken !== undefined ||
+    declaration.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) === true ||
+    declaration.parent !== declaration.getSourceFile() ||
+    declaration.getSourceFile() !== callee.getSourceFile()
+  ) {
+    return undefined;
+  }
   return declaration;
 }
 

--- a/tests/issue-3796-named-this-call.test.ts
+++ b/tests/issue-3796-named-this-call.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function compileStandalone(source: string, fileName: string) {
+  const result = await compile(source, {
+    fileName,
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const module = await WebAssembly.compile(result.binary);
+  expect(WebAssembly.Module.imports(module)).toEqual([]);
+  return { result, instance: await WebAssembly.instantiate(module, {}) };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("#3796 receiver-correct stable named FunctionDeclaration.call", () => {
+  it("preserves receiver identity, exact target arity, and operand evaluation order", async () => {
+    const { instance } = await compileStandalone(
+      `
+      var order = 0;
+      function receiver() {
+        order = order * 10 + 1;
+        return { value: 7 };
+      }
+      function argument(value) {
+        order = order * 10 + value;
+        return value;
+      }
+      function target(a, b, c, d) {
+        return this.value * 1000000 + arguments.length * 100000 +
+          a * 10000 + b * 1000 + c * 100 + d * 10 + order;
+      }
+      export function run() {
+        return target.call(receiver(), argument(2), argument(3), argument(4), argument(5));
+      }
+      `,
+      "issue-3796-order-and-arity.mjs",
+    );
+
+    // receiver → arg2 → arg3 → arg4 → arg5; target sees all four user args.
+    expect((instance.exports.run as () => number)()).toBe(7_435_795);
+  });
+
+  it("restores the outer receiver after nested and re-entrant named calls", async () => {
+    const { instance } = await compileStandalone(
+      `
+      function recurse(depth) {
+        var own = this.value;
+        if (depth === 0) return own;
+        var inner = recurse.call({ value: own + 1 }, depth - 1);
+        return inner + this.value;
+      }
+      export function run() {
+        return recurse.call({ value: 10 }, 2);
+      }
+      `,
+      "issue-3796-reentrant.mjs",
+    );
+
+    expect((instance.exports.run as () => number)()).toBe(33);
+  });
+
+  it("restores the outer receiver when the exact target throws", async () => {
+    const { result, instance } = await compileStandalone(
+      `
+      function throwFromReceiver() {
+        if (this.fail) throw 7;
+        return 0;
+      }
+      function outer() {
+        try {
+          throwFromReceiver.call({ fail: true });
+        } catch (error) {
+          return this.value;
+        }
+        return -1;
+      }
+      export function run() {
+        return outer.call({ value: 42 });
+      }
+      `,
+      "issue-3796-throw-restore.mjs",
+    );
+
+    expect((instance.exports.run as () => number)()).toBe(42);
+    expect(result.wat).toContain("$__named_this_call_throwFromReceiver_");
+    expect(result.wat).toContain("catch_all");
+    expect(result.wat).toContain("rethrow 0");
+  });
+
+  it("executes Acorn's finishNodeAt locations/ranges wrapper shape", async () => {
+    const { result, instance } = await compileStandalone(
+      `
+      function finishNodeAt(node, type, pos, loc) {
+        node.type = type;
+        node.end = pos;
+        if (this.options.locations) node.loc.end = loc;
+        if (this.options.ranges) node.range[1] = pos;
+        return node;
+      }
+      function wrapper(node, type, pos, loc) {
+        return finishNodeAt.call(this, node, type, pos, loc);
+      }
+      export function run() {
+        var parser = { options: { locations: true, ranges: true } };
+        var node = { type: 0, end: 0, loc: { end: 0 }, range: [1, 0] };
+        var out = wrapper.call(parser, node, 9, 17, 23);
+        return out.type * 1000000 + out.end * 10000 + out.loc.end * 100 + out.range[1];
+      }
+      `,
+      "issue-3796-acorn-finish-node-at.mjs",
+    );
+
+    expect((instance.exports.run as () => number)()).toBe(9_172_317);
+    expect(result.wat).toContain("$__named_this_call_finishNodeAt_");
+    expect(result.wat).toContain("$__named_this_call_wrapper_");
+  });
+
+  it("keeps nullish, apply, aliases, closures, and this-free targets off the trampoline", async () => {
+    const source = `
+      function readsThis(value) { return this.value + value; }
+      function ignoresThis(value) { return value; }
+      var alias = readsThis;
+      var closure = function closure(value) { return this.value + value; };
+      export function nullReceiver() { return readsThis.call(null, 1); }
+      export function applyReceiver() { return readsThis.apply({ value: 2 }, [1]); }
+      export function aliasReceiver() { return alias.call({ value: 3 }, 1); }
+      export function closureReceiver() { return closure.call({ value: 4 }, 1); }
+      export function ignoredReceiver() { return ignoresThis.call({ value: 5 }, 1); }
+    `;
+    const { result } = await compileStandalone(source, "issue-3796-negatives.mjs");
+
+    expect(result.wat).not.toContain("$__named_this_call_readsThis_");
+    expect(result.wat).not.toContain("$__named_this_call_ignoresThis_");
+    expect(result.wat).not.toContain("$__named_this_call_closure_");
+  });
+
+  it("has the same runtime behavior with IR-first enabled and disabled", async () => {
+    const source = `
+      function target(a, b) {
+        return this.base + a * 10 + b;
+      }
+      export function run() {
+        return target.call({ base: 100 }, 2, 3);
+      }
+    `;
+    const observed: number[] = [];
+    for (const irFirst of ["0", "1"]) {
+      vi.stubEnv("JS2WASM_IR_FIRST", irFirst);
+      const { instance } = await compileStandalone(source, `issue-3796-ir-${irFirst}.mjs`);
+      observed.push((instance.exports.run as () => number)());
+      vi.unstubAllEnvs();
+    }
+    expect(observed).toEqual([123, 123]);
+  });
+});

--- a/tests/issue-3796-named-this-call.test.ts
+++ b/tests/issue-3796-named-this-call.test.ts
@@ -122,23 +122,70 @@ describe("#3796 receiver-correct stable named FunctionDeclaration.call", () => {
     expect(result.wat).toContain("$__named_this_call_wrapper_");
   });
 
-  it("keeps nullish, apply, aliases, closures, and this-free targets off the trampoline", async () => {
+  it("keeps unstable identity, over-arity, and unsupported call shapes off the trampoline", async () => {
     const source = `
       function readsThis(value) { return this.value + value; }
       function ignoresThis(value) { return value; }
       var alias = readsThis;
       var closure = function closure(value) { return this.value + value; };
+      function mutableTarget(value) {
+        if (value < 0) return this.value;
+        return value + 1;
+      }
+      function shadowedTarget(value) {
+        return this.value + 1000;
+      }
+      var extraOrder = 0;
+      function extraArgument() {
+        extraOrder = 5;
+        return 7;
+      }
+      function overArityTarget(value) {
+        if (value < 0) return this.value;
+        return arguments.length * 1000 + arguments[1] * 10 + value + extraOrder;
+      }
       export function nullReceiver() { return readsThis.call(null, 1); }
       export function applyReceiver() { return readsThis.apply({ value: 2 }, [1]); }
       export function aliasReceiver() { return alias.call({ value: 3 }, 1); }
       export function closureReceiver() { return closure.call({ value: 4 }, 1); }
       export function ignoredReceiver() { return ignoresThis.call({ value: 5 }, 1); }
+      export function reassignedBeforeWrite() {
+        var result = mutableTarget.call({ value: 99 }, 41);
+        mutableTarget = function replacement(value) { return value + 100; };
+        return result;
+      }
+      export function nestedDeclaration() {
+        function nestedTarget(value) {
+          if (value < 0) return this.value;
+          return value + 1;
+        }
+        return nestedTarget.call({ value: 99 }, 41);
+      }
+      export function sameNameShadow() {
+        function shadowedTarget(value) {
+          if (value < 0) return this.value;
+          return value + 1;
+        }
+        shadowedTarget.call({ value: 99 }, 41);
+        return 42;
+      }
+      export function overArity() {
+        return overArityTarget.call({ value: 99 }, 41, extraArgument());
+      }
     `;
-    const { result } = await compileStandalone(source, "issue-3796-negatives.mjs");
+    const { result, instance } = await compileStandalone(source, "issue-3796-negatives.mjs");
 
     expect(result.wat).not.toContain("$__named_this_call_readsThis_");
     expect(result.wat).not.toContain("$__named_this_call_ignoresThis_");
     expect(result.wat).not.toContain("$__named_this_call_closure_");
+    expect(result.wat).not.toContain("$__named_this_call_mutableTarget_");
+    expect(result.wat).not.toContain("$__named_this_call_nestedTarget_");
+    expect(result.wat).not.toContain("$__named_this_call_shadowedTarget_");
+    expect(result.wat).not.toContain("$__named_this_call_overArityTarget_");
+    expect((instance.exports.reassignedBeforeWrite as () => number)()).toBe(42);
+    expect((instance.exports.nestedDeclaration as () => number)()).toBe(42);
+    expect((instance.exports.sameNameShadow as () => number)()).toBe(42);
+    expect((instance.exports.overArity as () => number)()).toBe(2116);
   });
 
   it("has the same runtime behavior with IR-first enabled and disabled", async () => {


### PR DESCRIPTION
## Summary

- route stable top-level function declarations that read `this` through an exact per-target receiver trampoline
- restore `__current_this` on normal and exceptional exits, including nested/reentrant calls
- reject mutable, aliased, ambiguous, nullable, async, generator, closure, and explicit-this targets unless exact Program ABI ownership is proven
- preserve over-application side effects and `arguments` overflow without corrupting the Wasm operand stack
- record the bounded prerequisite and remaining IR integration work in `plan/issues/3796-named-this-call.md`

## Validation

- `pnpm exec vitest run tests/issue-3796-named-this-call.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism` (6/6)
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:func-budget`
- `pnpm run format:check`
- `pnpm run lint`

This is the direct-codegen correctness prerequisite for the separately reviewed `finishNodeAt.call(this, ...)` IR selector slice.