### PR TITLE
feat(ir): preclaim stable this-bound function calls

### DIFF
--- a/plan/issues/3797-ir-stable-this-call-selector.md
+++ b/plan/issues/3797-ir-stable-this-call-selector.md
@@ -62,7 +62,9 @@ AST-to-IR builder cannot yet bind.
 - Keep the selector effect behind
   `stableFunctionCallIntegrationBuildable`, which defaults false until the
   receiver bridge and ambient-`this` AST-to-IR lowering consume this proof.
-- Restrict the proof to the non-fast externref lane.
+- Restrict the proof to the non-fast externref lane and an exact parenthesized
+  bare-`this` receiver. Typed identifiers, type parameters, assertions, and
+  checker-derived nullability remain outside this first executable slice.
 - Treat only a module-private declaration in an external module as a complete
   source-local population. Exported/export-listed targets and global scripts
   remain unproven without a future Program-wide reference inventory.
@@ -81,9 +83,9 @@ AST-to-IR builder cannot yet bind.
 - [x] Alias, bare call, reassignment, spread, optional, arity mismatch, bare
       `.call` property, and nullable receiver references invalidate the whole
       plan.
-- [x] Assertion-derived receiver types, optional-chain segments anywhere in
-      the target/call shape, exported targets, and global-script targets do not
-      produce a plan.
+- [x] Assertion-derived, nullable, unresolved type-parameter, and non-`this`
+      receiver types; optional-chain segments anywhere in the target/call
+      shape; exported targets; and global-script targets do not produce a plan.
 - [x] Bare, written, or optional ambient `this` uses do not receive the
       selector capability.
 - [x] With the explicit test-only integration capability enabled, the exact
@@ -92,6 +94,8 @@ AST-to-IR builder cannot yet bind.
 - [x] With the capability absent/default-false, both structural selection and
       a production standalone compile keep `finishNodeAt` on direct codegen
       with no post-claim withdrawal.
+- [x] Production GC and standalone anti-vacuity compiles emit a known-positive
+      IR control while keeping `finishNodeAt` absent.
 - [x] Assignment-as-value, compound, optional, nullable, and call-produced
       store receivers remain preclaim rejections.
 - [ ] Receiver-aware direct `.call` and AST-to-IR `__current_this` integration
@@ -111,7 +115,7 @@ issue can be marked done.
 ## Evidence
 
 - Focused selector and identity proof:
-  `tests/issue-3797-ir-stable-this-call-selector.test.ts` (31/31), including
+  `tests/issue-3797-ir-stable-this-call-selector.test.ts` (33/33), including
   production compile anti-vacuity assertions for GC and standalone.
 - Exact unchanged runtime-dynamic Acorn driver: 32/43 reachable functions
   emitted, `finishNodeAt` remains a selector refusal, checksum 422, zero module

--- a/plan/issues/3797-ir-stable-this-call-selector.md
+++ b/plan/issues/3797-ir-stable-this-call-selector.md
@@ -1,0 +1,105 @@
+---
+id: 3797
+title: "IR stable this-call selector preclaim"
+status: in-progress
+sprint: current
+created: 2026-07-30
+updated: 2026-07-30
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: ir
+es_edition: multi
+language_feature: function-calls
+goal: ir-full-coverage
+parent: 3522
+depends_on: [3795]
+related: [2069, 2949, 3053, 3796]
+assignee: ttraenkler/codex-finish-node-at-selector
+claimed_by: codex-symphony
+claimed_at: 2026-07-30
+branch: codex/3797-finish-node-at-selector
+files:
+  - src/ir/module-bindings.ts
+  - src/ir/select.ts
+  - tests/issue-3797-ir-stable-this-call-selector.test.ts
+loc-budget-allow:
+  - src/ir/module-bindings.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/ir/module-bindings.ts::makeStableFunctionCallPlan
+  - src/ir/module-bindings.ts::targetThisUsesOnlyDynamicMemberRoots
+  - src/ir/select.ts::dynamicUsesAreMoveOnly
+  - src/ir/select.ts::isPhase1BodyStatement
+  - src/ir/select.ts::isPhase1StatementListInScope
+  - src/ir/select.ts::scanExpr
+  - src/ir/select.ts::whyNotIrClaimable
+---
+
+# #3797 — preclaim Acorn `finishNodeAt` for receiver-aware IR lowering
+
+## Problem
+
+Acorn's runtime-dynamic standalone build emits 32 of 43 reachable functions
+through IR after #3795. `finishNodeAt` remains direct because its body observes
+ambient `this`, mutates dynamic named and indexed members, and is referenced
+through `finishNodeAt.call(thisArg, node, type, pos, loc)`.
+
+The ordinary direct-call proof is insufficient. A first-class alias,
+reassignment, optional call, spread, or arity mismatch could bypass the
+receiver bridge, while a selector-only widening could claim a body that the
+AST-to-IR builder cannot yet bind.
+
+## Scope
+
+- Add checker-backed proof for an exact top-level four-parameter
+  `FunctionDeclaration` whose complete source reference population consists
+  only of fixed five-argument `.call(thisArg, a, b, c, d)` sites.
+- Carry exact declaration, checker signature, call expression, receiver, user
+  arguments, complete call-site population, and structural unit identity.
+- Restrict the proof to the non-fast externref lane.
+- Expose ambient `this` only when every use starts an admitted, non-optional
+  dynamic member read.
+- Preclaim statement-position dynamic named and element stores rooted in an
+  exact dynamic parameter or admitted ambient `this`.
+- Keep assignment-as-value, compound/update, optional, nullable, computed-key,
+  spread, alias, bare-call, and unsupported receiver shapes rejected before
+  claim.
+
+## Acceptance criteria
+
+- [x] Exact two-site Acorn-shaped `.call` references produce one stable plan
+      with arity four and exact AST identity.
+- [x] Alias, bare call, reassignment, spread, optional, arity mismatch, bare
+      `.call` property, and nullable receiver references invalidate the whole
+      plan.
+- [x] Bare, written, or optional ambient `this` uses do not receive the
+      selector capability.
+- [x] The exact `node.type`, `node.end`, `node.loc.end`, and `node.range[1]`
+      statement stores pass selector preclaim on the non-fast lane.
+- [x] Assignment-as-value, compound, optional, nullable, and call-produced
+      store receivers remain preclaim rejections.
+- [ ] Receiver-aware direct `.call` and AST-to-IR `__current_this` integration
+      land before the Acorn census counts `finishNodeAt` as the 33rd IR
+      function.
+- [x] Focused tests, typecheck, formatting, IR fallback ratchet, function/LOC
+      budgets, and issue checks pass.
+
+## Integration boundary
+
+This slice owns selection evidence only. It does not bind `__current_this`,
+lower the `.call` site, change direct codegen, or report 33/43. Those executable
+pieces must consume the exact plan and preserve receiver restoration on normal
+and exceptional exits before this issue can be marked done.
+
+## Evidence
+
+- Focused selector and identity proof:
+  `tests/issue-3797-ir-stable-this-call-selector.test.ts` (20/20).
+- Adjacent #3794, #3795, and direct-member-equality suites pass.
+- Three failures in the wider #2949/#3053 selector sample reproduce unchanged
+  at the exact `b1304d81e2722e0d4ee975518e2478f2c7c5ef9f` stack base.
+- Typecheck, Prettier, IR fallback, issue-integrity, optimization-retirement,
+  LOC, and function-budget gates pass.

--- a/plan/issues/3797-ir-stable-this-call-selector.md
+++ b/plan/issues/3797-ir-stable-this-call-selector.md
@@ -59,7 +59,13 @@ AST-to-IR builder cannot yet bind.
   only of fixed five-argument `.call(thisArg, a, b, c, d)` sites.
 - Carry exact declaration, checker signature, call expression, receiver, user
   arguments, complete call-site population, and structural unit identity.
+- Keep the selector effect behind
+  `stableFunctionCallIntegrationBuildable`, which defaults false until the
+  receiver bridge and ambient-`this` AST-to-IR lowering consume this proof.
 - Restrict the proof to the non-fast externref lane.
+- Treat only a module-private declaration in an external module as a complete
+  source-local population. Exported/export-listed targets and global scripts
+  remain unproven without a future Program-wide reference inventory.
 - Expose ambient `this` only when every use starts an admitted, non-optional
   dynamic member read.
 - Preclaim statement-position dynamic named and element stores rooted in an
@@ -75,10 +81,17 @@ AST-to-IR builder cannot yet bind.
 - [x] Alias, bare call, reassignment, spread, optional, arity mismatch, bare
       `.call` property, and nullable receiver references invalidate the whole
       plan.
+- [x] Assertion-derived receiver types, optional-chain segments anywhere in
+      the target/call shape, exported targets, and global-script targets do not
+      produce a plan.
 - [x] Bare, written, or optional ambient `this` uses do not receive the
       selector capability.
-- [x] The exact `node.type`, `node.end`, `node.loc.end`, and `node.range[1]`
-      statement stores pass selector preclaim on the non-fast lane.
+- [x] With the explicit test-only integration capability enabled, the exact
+      `node.type`, `node.end`, `node.loc.end`, and `node.range[1]` statement
+      stores pass selector preclaim on the non-fast lane.
+- [x] With the capability absent/default-false, both structural selection and
+      a production standalone compile keep `finishNodeAt` on direct codegen
+      with no post-claim withdrawal.
 - [x] Assignment-as-value, compound, optional, nullable, and call-produced
       store receivers remain preclaim rejections.
 - [ ] Receiver-aware direct `.call` and AST-to-IR `__current_this` integration
@@ -92,12 +105,17 @@ AST-to-IR builder cannot yet bind.
 This slice owns selection evidence only. It does not bind `__current_this`,
 lower the `.call` site, change direct codegen, or report 33/43. Those executable
 pieces must consume the exact plan and preserve receiver restoration on normal
-and exceptional exits before this issue can be marked done.
+and exceptional exits before the integration capability can be enabled or this
+issue can be marked done.
 
 ## Evidence
 
 - Focused selector and identity proof:
-  `tests/issue-3797-ir-stable-this-call-selector.test.ts` (20/20).
+  `tests/issue-3797-ir-stable-this-call-selector.test.ts` (31/31), including
+  production compile anti-vacuity assertions for GC and standalone.
+- Exact unchanged runtime-dynamic Acorn driver: 32/43 reachable functions
+  emitted, `finishNodeAt` remains a selector refusal, checksum 422, zero module
+  and function imports, and zero post-claim withdrawals.
 - Adjacent #3794, #3795, and direct-member-equality suites pass.
 - Three failures in the wider #2949/#3053 selector sample reproduce unchanged
   at the exact `b1304d81e2722e0d4ee975518e2478f2c7c5ef9f` stack base.

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -1447,38 +1447,12 @@ function exactTopLevelFunctionDeclaration(
   return checker.getSymbolAtLocation(declaration.name!) === symbol ? declaration : undefined;
 }
 
-function stableCallReceiverIsAdmissible(receiver: ts.Expression, checker: ts.TypeChecker): boolean {
-  // Match the receiver-aware direct bridge: assertions are not nullability
-  // evidence. In particular, `maybe!` and `null as T` must not manufacture a
-  // live receiver for the ambient-`this` ABI.
-  let asserted = false;
-  const inspectAssertion = (node: ts.Node): void => {
-    if (asserted) return;
-    if (
-      ts.isAsExpression(node) ||
-      ts.isTypeAssertionExpression(node) ||
-      ts.isSatisfiesExpression(node) ||
-      ts.isNonNullExpression(node)
-    ) {
-      asserted = true;
-      return;
-    }
-    node.forEachChild(inspectAssertion);
-  };
-  inspectAssertion(receiver);
-  if (asserted) return false;
-  const candidate = unwrapParens(receiver);
-  if (candidate.kind === ts.SyntaxKind.ThisKeyword) return true;
-  const type = checker.getTypeAtLocation(candidate);
-  const unsupported =
-    ts.TypeFlags.Any |
-    ts.TypeFlags.Unknown |
-    ts.TypeFlags.Never |
-    ts.TypeFlags.Null |
-    ts.TypeFlags.Undefined |
-    ts.TypeFlags.Void;
-  if ((type.flags & unsupported) !== 0) return false;
-  return !type.isUnionOrIntersection() || type.types.every((member) => (member.flags & unsupported) === 0);
+function stableCallReceiverIsAdmissible(receiver: ts.Expression): boolean {
+  // The executable #3796 bridge currently proves only Acorn's exact live
+  // receiver carrier. Do not use checker nullability here: allowJs/strict:false
+  // and unresolved type parameters can erase the evidence needed to
+  // distinguish a live receiver from the unbound/null sentinel.
+  return unwrapParens(receiver).kind === ts.SyntaxKind.ThisKeyword;
 }
 
 function containsOptionalChainSegment(node: ts.Node): boolean {
@@ -1518,7 +1492,6 @@ function sourceModuleExportsSymbol(sourceFile: ts.SourceFile, symbol: ts.Symbol,
 function stableCallSiteForReference(
   reference: ts.Identifier,
   declaration: ts.FunctionDeclaration,
-  checker: ts.TypeChecker,
 ): IrStableFunctionCallSite | undefined {
   const access = reference.parent;
   if (
@@ -1542,7 +1515,7 @@ function stableCallSiteForReference(
     return undefined;
   }
   const receiver = call.arguments[0]!;
-  if (!stableCallReceiverIsAdmissible(receiver, checker)) return undefined;
+  if (!stableCallReceiverIsAdmissible(receiver)) return undefined;
   return { call, receiver, arguments: call.arguments.slice(1) };
 }
 
@@ -1671,7 +1644,7 @@ function makeStableFunctionCallPlan(
         candidate !== declaration.name &&
         checker.getSymbolAtLocation(candidate) === symbol
       ) {
-        const callSite = stableCallSiteForReference(candidate, declaration, checker);
+        const callSite = stableCallSiteForReference(candidate, declaration);
         if (!callSite) {
           stable = false;
           return;

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -630,6 +630,34 @@ export interface IrRetainedFunctionMethodPlan {
   readonly receiverDeclarationOrdinal?: number;
 }
 
+/** One exact `.call(thisArg, ...args)` reference to a stable source function. */
+export interface IrStableFunctionCallSite {
+  readonly call: ts.CallExpression;
+  readonly receiver: ts.Expression;
+  readonly arguments: readonly ts.Expression[];
+}
+
+/**
+ * Checker-backed proof that a top-level FunctionDeclaration is referenced
+ * only through fixed-arity `.call(thisArg, ...args)` sites.
+ *
+ * The selector consumes this proof to expose the declaration's ambient
+ * `this` as the non-fast dynamic carrier. Lowering still owns the executable
+ * receiver bridge; this record carries only exact source identity and the
+ * complete, stable call-site population.
+ */
+export interface IrStableFunctionCallPlan {
+  readonly declaration: ts.FunctionDeclaration;
+  readonly signature: ts.Signature;
+  readonly targetName: string;
+  /** Source parameter count, excluding the leading `.call` receiver. */
+  readonly arity: number;
+  readonly callSites: readonly IrStableFunctionCallSite[];
+  /** Structural fields are present on the identity-aware production resolver. */
+  readonly targetUnitId?: IrUnitId;
+  readonly sourceId?: IrSourceId;
+}
+
 interface IrModuleBindingResolverSurface<TIdentity, TInspection> {
   (node: ts.Identifier, writeValue?: ts.Expression): TIdentity | undefined;
   /**
@@ -663,6 +691,14 @@ interface IrModuleBindingResolverSurface<TIdentity, TInspection> {
   readonly staticNumericArrayPlan: (node: ts.Expression) => IrStaticNumericArrayPlan | undefined;
   /** Exact retained function-object method call whose receiver must stay live. */
   readonly retainedFunctionMethodPlan: (call: ts.CallExpression) => IrRetainedFunctionMethodPlan | undefined;
+  /**
+   * Exact top-level function whose complete reference population is
+   * fixed-arity `.call(thisArg, ...args)`. Accepts either the declaration or
+   * one of its certified call expressions.
+   */
+  readonly stableFunctionCallPlan: (
+    node: ts.FunctionDeclaration | ts.CallExpression,
+  ) => IrStableFunctionCallPlan | undefined;
 }
 
 export interface IrLegacyModuleBindingResolver extends IrModuleBindingResolverSurface<
@@ -1389,6 +1425,212 @@ function makeRetainedFunctionMethodPlan(
   };
 }
 
+function exactTopLevelFunctionDeclaration(
+  node: ts.Identifier,
+  checker: ts.TypeChecker,
+): ts.FunctionDeclaration | undefined {
+  const symbol = checker.getSymbolAtLocation(node);
+  if (!symbol) return undefined;
+  const sourceFile = node.getSourceFile();
+  const declarations = new Set(
+    [symbol.valueDeclaration, ...(symbol.declarations ?? [])].filter(
+      (candidate): candidate is ts.FunctionDeclaration =>
+        candidate !== undefined &&
+        ts.isFunctionDeclaration(candidate) &&
+        candidate.getSourceFile() === sourceFile &&
+        candidate.parent === sourceFile &&
+        candidate.name !== undefined,
+    ),
+  );
+  if (declarations.size !== 1) return undefined;
+  const declaration = [...declarations][0]!;
+  return checker.getSymbolAtLocation(declaration.name!) === symbol ? declaration : undefined;
+}
+
+function stableCallReceiverIsAdmissible(receiver: ts.Expression, checker: ts.TypeChecker): boolean {
+  const candidate = unwrapParens(receiver);
+  if (candidate.kind === ts.SyntaxKind.ThisKeyword) return true;
+  const type = checker.getTypeAtLocation(candidate);
+  const unsupported =
+    ts.TypeFlags.Any |
+    ts.TypeFlags.Unknown |
+    ts.TypeFlags.Never |
+    ts.TypeFlags.Null |
+    ts.TypeFlags.Undefined |
+    ts.TypeFlags.Void;
+  if ((type.flags & unsupported) !== 0) return false;
+  return !type.isUnionOrIntersection() || type.types.every((member) => (member.flags & unsupported) === 0);
+}
+
+function stableCallSiteForReference(
+  reference: ts.Identifier,
+  declaration: ts.FunctionDeclaration,
+  checker: ts.TypeChecker,
+): IrStableFunctionCallSite | undefined {
+  const access = reference.parent;
+  if (
+    !ts.isPropertyAccessExpression(access) ||
+    access.expression !== reference ||
+    access.questionDotToken !== undefined ||
+    access.name.text !== "call"
+  ) {
+    return undefined;
+  }
+  const call = access.parent;
+  if (
+    !ts.isCallExpression(call) ||
+    call.expression !== access ||
+    call.questionDotToken !== undefined ||
+    call.typeArguments?.length ||
+    call.arguments.length !== declaration.parameters.length + 1 ||
+    call.arguments.some(ts.isSpreadElement)
+  ) {
+    return undefined;
+  }
+  const receiver = call.arguments[0]!;
+  if (!stableCallReceiverIsAdmissible(receiver, checker)) return undefined;
+  return { call, receiver, arguments: call.arguments.slice(1) };
+}
+
+function targetThisUsesOnlyDynamicMemberRoots(declaration: ts.FunctionDeclaration): boolean {
+  const body = declaration.body;
+  if (!body) return false;
+  let sawThis = false;
+  let supported = true;
+  const visit = (node: ts.Node): void => {
+    if (!supported) return;
+    if (
+      node !== body &&
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node) ||
+        ts.isConstructorDeclaration(node))
+    ) {
+      return;
+    }
+    if (node.kind === ts.SyntaxKind.ThisKeyword) {
+      sawThis = true;
+      const parent = node.parent;
+      const memberRootIsRead = (access: ts.Expression): boolean => {
+        const use = access.parent;
+        if (ts.isBinaryExpression(use) && use.left === access && isAssignmentOperator(use.operatorToken.kind)) {
+          return false;
+        }
+        if (
+          (ts.isPrefixUnaryExpression(use) || ts.isPostfixUnaryExpression(use)) &&
+          use.operand === access &&
+          (use.operator === ts.SyntaxKind.PlusPlusToken || use.operator === ts.SyntaxKind.MinusMinusToken)
+        ) {
+          return false;
+        }
+        return !(ts.isDeleteExpression(use) && use.expression === access);
+      };
+      if (
+        ts.isPropertyAccessExpression(parent) &&
+        parent.expression === node &&
+        parent.questionDotToken === undefined &&
+        memberRootIsRead(parent)
+      ) {
+        return;
+      }
+      if (
+        ts.isElementAccessExpression(parent) &&
+        parent.expression === node &&
+        parent.questionDotToken === undefined &&
+        memberRootIsRead(parent) &&
+        (ts.isStringLiteralLike(unwrapParens(parent.argumentExpression)) ||
+          ts.isNumericLiteral(unwrapParens(parent.argumentExpression)))
+      ) {
+        return;
+      }
+      supported = false;
+      return;
+    }
+    node.forEachChild(visit);
+  };
+  body.forEachChild(visit);
+  return sawThis && supported;
+}
+
+function makeStableFunctionCallPlan(
+  checker: ts.TypeChecker,
+  node: ts.FunctionDeclaration | ts.CallExpression,
+  cache: Map<ts.FunctionDeclaration, IrStableFunctionCallPlan | null>,
+): IrStableFunctionCallPlan | undefined {
+  const targetIdentifier = ts.isFunctionDeclaration(node)
+    ? node.name
+    : ts.isPropertyAccessExpression(node.expression) && ts.isIdentifier(node.expression.expression)
+      ? node.expression.expression
+      : undefined;
+  if (!targetIdentifier) return undefined;
+  const declaration = exactTopLevelFunctionDeclaration(targetIdentifier, checker);
+  if (
+    !declaration ||
+    !declaration.body ||
+    declaration.asteriskToken ||
+    declaration.typeParameters?.length ||
+    declaration.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) ||
+    declaration.parameters.length !== 4 ||
+    declaration.parameters.some(
+      (parameter) =>
+        !ts.isIdentifier(parameter.name) ||
+        parameter.name.text === "this" ||
+        parameter.dotDotDotToken !== undefined ||
+        parameter.questionToken !== undefined ||
+        parameter.initializer !== undefined,
+    ) ||
+    !targetThisUsesOnlyDynamicMemberRoots(declaration)
+  ) {
+    return undefined;
+  }
+  const signature = checker.getSignatureFromDeclaration(declaration);
+  if (!signature || signature.getParameters().length !== declaration.parameters.length) return undefined;
+
+  let plan = cache.get(declaration);
+  if (plan === null) return undefined;
+  if (plan === undefined) {
+    const symbol = checker.getSymbolAtLocation(declaration.name!);
+    if (!symbol) {
+      cache.set(declaration, null);
+      return undefined;
+    }
+    const callSites: IrStableFunctionCallSite[] = [];
+    let stable = true;
+    const visit = (candidate: ts.Node): void => {
+      if (!stable) return;
+      if (
+        ts.isIdentifier(candidate) &&
+        candidate !== declaration.name &&
+        checker.getSymbolAtLocation(candidate) === symbol
+      ) {
+        const callSite = stableCallSiteForReference(candidate, declaration, checker);
+        if (!callSite) {
+          stable = false;
+          return;
+        }
+        callSites.push(callSite);
+      }
+      candidate.forEachChild(visit);
+    };
+    declaration.getSourceFile().forEachChild(visit);
+    plan =
+      stable && callSites.length > 0
+        ? {
+            declaration,
+            signature,
+            targetName: declaration.name!.text,
+            arity: declaration.parameters.length,
+            callSites,
+          }
+        : null;
+    cache.set(declaration, plan);
+  }
+  if (!plan) return undefined;
+  return ts.isCallExpression(node) && !plan.callSites.some((site) => site.call === node) ? undefined : plan;
+}
+
 function staticStringFromExpression(
   checker: ts.TypeChecker,
   expression: ts.Expression,
@@ -1480,6 +1722,7 @@ export function makeIrLegacyModuleBindingResolver(
   options: IrModuleBindingResolverOptions,
 ): IrLegacyModuleBindingResolver {
   const isAmbientBinding = makeIrAmbientBindingPredicate(checker);
+  const stableFunctionCallPlans = new Map<ts.FunctionDeclaration, IrStableFunctionCallPlan | null>();
   const inspectDirectBinding = (node: ts.Identifier, writeValue?: ts.Expression): IrLegacyModuleBindingInspection => {
     const declaration = directTopLevelDeclaration(node, checker);
     if (!declaration) return { kind: "not-direct" };
@@ -1651,6 +1894,14 @@ export function makeIrLegacyModuleBindingResolver(
         return undefined;
       }
     },
+    stableFunctionCallPlan(node: ts.FunctionDeclaration | ts.CallExpression): IrStableFunctionCallPlan | undefined {
+      if (options.numberStorage !== "f64") return undefined;
+      try {
+        return makeStableFunctionCallPlan(checker, node, stableFunctionCallPlans);
+      } catch {
+        return undefined;
+      }
+    },
   });
 }
 
@@ -1801,6 +2052,21 @@ export function makeIrModuleBindingResolver(
         receiverDeclarationOrdinal: receiverLocation.declarationOrdinal,
       };
     },
+    stableFunctionCallPlan(node: ts.FunctionDeclaration | ts.CallExpression): IrStableFunctionCallPlan | undefined {
+      ownerAt(node);
+      const plan = legacy.stableFunctionCallPlan(node);
+      if (!plan) return undefined;
+      for (const site of plan.callSites) ownerAt(site.call);
+      const targetUnitId = identityContext.unitIdByDeclaration.get(plan.declaration);
+      if (targetUnitId === undefined || identityContext.declarationByUnitId.get(targetUnitId) !== plan.declaration) {
+        return planningInvariant(
+          "missing-unit-declaration",
+          `stable .call target ${plan.targetName} has no exact function-declaration identity`,
+        );
+      }
+      const sourceId = requireIrPlanningSourceId(identityContext, plan.declaration.getSourceFile());
+      return { ...plan, targetUnitId, sourceId };
+    },
   });
 }
 
@@ -1851,5 +2117,16 @@ export function projectIrModuleBindingResolverToLegacy(
     staticRegExpTestPlan: (node: ts.Expression) => resolver.staticRegExpTestPlan(node),
     staticNumericArrayPlan: (node: ts.Expression) => resolver.staticNumericArrayPlan(node),
     retainedFunctionMethodPlan: (call: ts.CallExpression) => resolver.retainedFunctionMethodPlan(call),
+    stableFunctionCallPlan: (node: ts.FunctionDeclaration | ts.CallExpression) => {
+      const plan = resolver.stableFunctionCallPlan(node);
+      if (!plan) return undefined;
+      return {
+        declaration: plan.declaration,
+        signature: plan.signature,
+        targetName: plan.targetName,
+        arity: plan.arity,
+        callSites: plan.callSites,
+      };
+    },
   });
 }

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -1448,6 +1448,25 @@ function exactTopLevelFunctionDeclaration(
 }
 
 function stableCallReceiverIsAdmissible(receiver: ts.Expression, checker: ts.TypeChecker): boolean {
+  // Match the receiver-aware direct bridge: assertions are not nullability
+  // evidence. In particular, `maybe!` and `null as T` must not manufacture a
+  // live receiver for the ambient-`this` ABI.
+  let asserted = false;
+  const inspectAssertion = (node: ts.Node): void => {
+    if (asserted) return;
+    if (
+      ts.isAsExpression(node) ||
+      ts.isTypeAssertionExpression(node) ||
+      ts.isSatisfiesExpression(node) ||
+      ts.isNonNullExpression(node)
+    ) {
+      asserted = true;
+      return;
+    }
+    node.forEachChild(inspectAssertion);
+  };
+  inspectAssertion(receiver);
+  if (asserted) return false;
   const candidate = unwrapParens(receiver);
   if (candidate.kind === ts.SyntaxKind.ThisKeyword) return true;
   const type = checker.getTypeAtLocation(candidate);
@@ -1460,6 +1479,40 @@ function stableCallReceiverIsAdmissible(receiver: ts.Expression, checker: ts.Typ
     ts.TypeFlags.Void;
   if ((type.flags & unsupported) !== 0) return false;
   return !type.isUnionOrIntersection() || type.types.every((member) => (member.flags & unsupported) === 0);
+}
+
+function containsOptionalChainSegment(node: ts.Node): boolean {
+  let found = false;
+  const visit = (candidate: ts.Node): void => {
+    if (found) return;
+    if (
+      (ts.isPropertyAccessExpression(candidate) ||
+        ts.isElementAccessExpression(candidate) ||
+        ts.isCallExpression(candidate)) &&
+      candidate.questionDotToken !== undefined
+    ) {
+      found = true;
+      return;
+    }
+    candidate.forEachChild(visit);
+  };
+  visit(node);
+  return found;
+}
+
+function sourceModuleExportsSymbol(sourceFile: ts.SourceFile, symbol: ts.Symbol, checker: ts.TypeChecker): boolean {
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) return true;
+  try {
+    return checker.getExportsOfModule(moduleSymbol).some((exported) => {
+      const target = (exported.flags & ts.SymbolFlags.Alias) !== 0 ? checker.getAliasedSymbol(exported) : exported;
+      return target === symbol;
+    });
+  } catch {
+    // Export identity is part of the closed-world proof. A checker failure
+    // cannot safely be interpreted as "module-private".
+    return true;
+  }
 }
 
 function stableCallSiteForReference(
@@ -1483,7 +1536,8 @@ function stableCallSiteForReference(
     call.questionDotToken !== undefined ||
     call.typeArguments?.length ||
     call.arguments.length !== declaration.parameters.length + 1 ||
-    call.arguments.some(ts.isSpreadElement)
+    call.arguments.some(ts.isSpreadElement) ||
+    containsOptionalChainSegment(call)
   ) {
     return undefined;
   }
@@ -1494,7 +1548,7 @@ function stableCallSiteForReference(
 
 function targetThisUsesOnlyDynamicMemberRoots(declaration: ts.FunctionDeclaration): boolean {
   const body = declaration.body;
-  if (!body) return false;
+  if (!body || containsOptionalChainSegment(body)) return false;
   let sawThis = false;
   let supported = true;
   const visit = (node: ts.Node): void => {
@@ -1566,8 +1620,20 @@ function makeStableFunctionCallPlan(
       : undefined;
   if (!targetIdentifier) return undefined;
   const declaration = exactTopLevelFunctionDeclaration(targetIdentifier, checker);
+  const sourceFile = declaration?.getSourceFile();
+  const declarationSymbol = declaration?.name ? checker.getSymbolAtLocation(declaration.name) : undefined;
   if (
     !declaration ||
+    !sourceFile ||
+    !declarationSymbol ||
+    // A source-local scan is whole-program proof only for a module-private
+    // declaration. Global scripts and exported declarations can acquire
+    // references from other files that are absent from this traversal.
+    !ts.isExternalModule(sourceFile) ||
+    declaration.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword || modifier.kind === ts.SyntaxKind.DefaultKeyword,
+    ) ||
+    sourceModuleExportsSymbol(sourceFile, declarationSymbol, checker) ||
     !declaration.body ||
     declaration.asteriskToken ||
     declaration.typeParameters?.length ||

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -396,6 +396,13 @@ export interface IrSelectionOptions {
    * write-side representation before the selector claims the function.
    */
   readonly resolveModuleBinding?: IrModuleBindingResolver | IrLegacyModuleBindingResolver;
+  /**
+   * (#3797) True only after receiver-aware named `.call` lowering and ambient
+   * `__current_this` AST-to-IR binding consume the exact
+   * `stableFunctionCallPlan`. Default false: the resolver may expose proof for
+   * diagnostics/tests, but proof alone must not change production selection.
+   */
+  readonly stableFunctionCallIntegrationBuildable?: boolean;
   /** (#2856) True iff the compile targets a JS host (NOT standalone / wasi /
    *  strictNoHostImports). Gates the host-extern capability. */
   readonly jsHostExterns?: boolean;
@@ -1430,7 +1437,9 @@ function whyNotIrClaimable(
   currentNestedFunctionNames = fn.body ? collectDirectNestedFunctionNames(fn.body) : new Set<string>();
   currentLexicalValueBindingNames = new Set<string>();
   currentStableFunctionCallSubject =
-    !isMethod && ts.isFunctionDeclaration(fn)
+    currentSelectionOptions?.stableFunctionCallIntegrationBuildable === true &&
+    !isMethod &&
+    ts.isFunctionDeclaration(fn)
       ? (currentModuleBindingResolver?.stableFunctionCallPlan(fn) ?? null)
       : null;
   // (#2856 Step-1) Clear any stale reject detail from a prior subject; the body

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -78,6 +78,7 @@ import type {
   IrLocalClassExpressionResolver,
   IrModuleBindingResolver,
   IrPrimitiveExpressionFamily,
+  IrStableFunctionCallPlan,
 } from "./module-bindings.js";
 import type { LatticeType, TypeMap } from "./propagate.js";
 import type { RecursiveTypeEvidence } from "./type-evidence.js";
@@ -1209,6 +1210,8 @@ let currentDirectOnlyDynMemberEqualityFunctionsReady = false;
 let currentDynMemberEqualitySubject: ts.FunctionDeclaration | null = null;
 let currentDynEqualityBoxableParamNames = new Set<string>();
 let currentMutableParamSlotNames = new Set<string>();
+let currentStableFunctionCallSubject: IrStableFunctionCallPlan | null = null;
+let currentStableDynamicRootNames = new Set<string>();
 // Grounded parameter families from the propagation map. The checker sees an
 // unannotated allowJs parameter as `any`, but the IR ABI may already have
 // proved it f64 from every call edge. Coercion-sensitive builtin selectors
@@ -1314,6 +1317,8 @@ function prepareDynamicEqualitySubject(fn: IrClaimableSubject, isMethod: boolean
   currentDynMemberEqualitySubject = !isMethod && ts.isFunctionDeclaration(fn) ? fn : null;
   currentDynEqualityBoxableParamNames = new Set<string>();
   currentMutableParamSlotNames = new Set<string>();
+  currentStableFunctionCallSubject = null;
+  currentStableDynamicRootNames = new Set<string>();
   currentNumericParamNames = new Set<string>();
   currentSubjectFunctionName = !isMethod && ts.isFunctionDeclaration(fn) && fn.name !== undefined ? fn.name.text : null;
   currentSubjectReturnsBoolean =
@@ -1424,6 +1429,10 @@ function whyNotIrClaimable(
   currentCallableReturnClasses = new Map<string, string>();
   currentNestedFunctionNames = fn.body ? collectDirectNestedFunctionNames(fn.body) : new Set<string>();
   currentLexicalValueBindingNames = new Set<string>();
+  currentStableFunctionCallSubject =
+    !isMethod && ts.isFunctionDeclaration(fn)
+      ? (currentModuleBindingResolver?.stableFunctionCallPlan(fn) ?? null)
+      : null;
   // (#2856 Step-1) Clear any stale reject detail from a prior subject; the body
   // walk below repopulates it via `shapeNo` when SHAPE_DIAG_ON.
   if (SHAPE_DIAG_ON) shapeRejectDetail = null;
@@ -1544,7 +1553,7 @@ function whyNotIrClaimable(
   // Method bodies and constructor bodies see `this` as an implicit local;
   // mark it so a `return this;` / `this.field` reference passes the
   // identifier-in-scope check at Phase-1 expression position.
-  if (isMethod) scope.add("this");
+  if (isMethod || currentStableFunctionCallSubject !== null) scope.add("this");
   for (let i = 0; i < fn.parameters.length; i++) {
     const p = fn.parameters[i]!;
     // #1372 — binding-pattern params: `function f({ x, y }: Point): …` /
@@ -1601,6 +1610,9 @@ function whyNotIrClaimable(
     if (directMutationNames.has(p.name.text)) currentMutableParamSlotNames.add(p.name.text);
     // #2949 slice 2 — collect dynamic-typed param names for the move-only scan.
     recordDynamicParamKind(p.name.text, paramResolved, dynNames);
+    if (currentStableFunctionCallSubject !== null && paramResolved === "dynamic") {
+      currentStableDynamicRootNames.add(p.name.text);
+    }
 
     const paramType = effectiveIrParamTypeNode(p);
     clearProjectionBinding(p.name.text);
@@ -1701,7 +1713,12 @@ function whyNotIrClaimable(
   // yield machinery has no dynamic arm yet.
   // -------------------------------------------------------------------------
   if (dynNames.size > 0 && isGenerator) return "param-type-not-resolvable";
-  if (dynNames.size > 0 || isDynamicReturn || containsRetainedFunctionMethodCall(body)) {
+  if (
+    dynNames.size > 0 ||
+    isDynamicReturn ||
+    currentStableFunctionCallSubject !== null ||
+    containsRetainedFunctionMethodCall(body)
+  ) {
     const dynamicStringLocals = collectDynamicStringLocalWidening(fn, new Set(dynNames));
     if (!dynamicUsesAreMoveOnly(fn, dynNames, isDynamicReturn, typeMap, dynamicStringLocals)) {
       return dynNames.size > 0 ? "param-type-not-resolvable" : "return-type-not-resolvable";
@@ -2116,6 +2133,10 @@ function subtreeTouchesDynamic(root: ts.Node, dynNames: ReadonlySet<string>): bo
   let found = false;
   const visit = (n: ts.Node): void => {
     if (found) return;
+    if (n.kind === ts.SyntaxKind.ThisKeyword && currentStableFunctionCallSubject !== null) {
+      found = true;
+      return;
+    }
     if (ts.isIdentifier(n) && dynNames.has(n.text)) {
       found = true;
       return;
@@ -2262,6 +2283,7 @@ function dynamicUsesAreMoveOnly(
    */
   const isDynShaped = (e: ts.Expression): boolean => {
     e = unwrap(e);
+    if (e.kind === ts.SyntaxKind.ThisKeyword) return currentStableFunctionCallSubject !== null;
     if (ts.isIdentifier(e)) return dynNames.has(e.text);
     if (ts.isCallExpression(e) && ts.isIdentifier(e.expression) && !dynNames.has(e.expression.text)) {
       return calleeReturnIsDynamic(e.expression.text, typeMap);
@@ -2342,6 +2364,9 @@ function dynamicUsesAreMoveOnly(
    */
   const scanExpr = (expr: ts.Expression, expectDyn: boolean): boolean => {
     const e = unwrap(expr);
+    if (e.kind === ts.SyntaxKind.ThisKeyword) {
+      return currentStableFunctionCallSubject !== null && expectDyn;
+    }
     if (ts.isIdentifier(e)) {
       return dynNames.has(e.text) === expectDyn;
     }
@@ -2411,6 +2436,38 @@ function dynamicUsesAreMoveOnly(
       const leftIsDyn = isDynShaped(e.left);
       const rightIsDyn = isDynShaped(e.right);
       const op = e.operatorToken.kind;
+      // #3797 — statement-position stores used by Acorn's stable
+      // `finishNodeAt.call(thisArg, node, type, pos, loc)` target. The
+      // checker-backed stable-call plan is the authority for exposing ambient
+      // `this`; the dynamic scan remains the authority for receiver/key/value
+      // representations. Keep value-producing assignments, optional stores,
+      // compound/update forms, and non-dynamic receivers outside the claim.
+      if (
+        op === ts.SyntaxKind.EqualsToken &&
+        !expectDyn &&
+        currentStableFunctionCallSubject !== null &&
+        ts.isExpressionStatement(e.parent) &&
+        e.parent.expression === e &&
+        (ts.isPropertyAccessExpression(e.left) || ts.isElementAccessExpression(e.left)) &&
+        e.left.questionDotToken === undefined &&
+        stableDynamicStoreReceiverHasAdmittedRoot(e.left.expression) &&
+        isDynShaped(e.left.expression)
+      ) {
+        if (!currentDynamicRuntimeBuildable || !scanExpr(e.left.expression, true)) return false;
+        if (ts.isElementAccessExpression(e.left)) {
+          const key = unwrap(e.left.argumentExpression);
+          if (ts.isStringLiteralLike(key) || ts.isNumericLiteral(key)) {
+            // Literal keys are boxed by the dynamic member-set producer.
+          } else if (ts.isIdentifier(key) && dynNames.has(key.text)) {
+            if (!scanExpr(key, true)) return false;
+          } else {
+            return false;
+          }
+        }
+        if (rightIsDyn) return scanExpr(e.right, true);
+        const concrete = unwrap(e.right);
+        return concreteDynamicAssignmentOperandIsBuildable(concrete) && scanExpr(concrete, false);
+      }
       // #3795 — strict statement-position dynamic element write. Keep the
       // preclaim opening coupled to the exact Acorn family: direct dynamic
       // parameter receiver, dynamic alias key, and either the proven widened
@@ -2731,6 +2788,28 @@ function thenArmTerminates(stmt: ts.Statement): boolean {
   return false;
 }
 
+function stableDynamicStoreReceiverHasAdmittedRoot(receiver: ts.Expression): boolean {
+  let candidate = unwrapPhase1Parens(receiver);
+  while (ts.isPropertyAccessExpression(candidate) || ts.isElementAccessExpression(candidate)) {
+    if (candidate.questionDotToken !== undefined) return false;
+    if (ts.isElementAccessExpression(candidate)) {
+      const key = unwrapPhase1Parens(candidate.argumentExpression);
+      if (
+        !ts.isStringLiteralLike(key) &&
+        !ts.isNumericLiteral(key) &&
+        !(ts.isIdentifier(key) && currentStableDynamicRootNames.has(key.text))
+      ) {
+        return false;
+      }
+    }
+    candidate = unwrapPhase1Parens(candidate.expression);
+  }
+  return (
+    (candidate.kind === ts.SyntaxKind.ThisKeyword && currentStableFunctionCallSubject !== null) ||
+    (ts.isIdentifier(candidate) && currentStableDynamicRootNames.has(candidate.text))
+  );
+}
+
 function isPhase1StatementList(
   stmts: ReadonlyArray<ts.Statement>,
   scope: Set<string>,
@@ -2852,6 +2931,9 @@ function isPhase1StatementListInScope(
         s.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         ts.isPropertyAccessExpression(s.expression.left)
       ) {
+        if (s.expression.left.questionDotToken !== undefined) {
+          return shapeNo("nontail-assign-optional", s.expression.left);
+        }
         // LHS: <expr>.<id> — receiver expr must be Phase-1, prop must be an
         // Identifier or (#3000) a PrivateIdentifier (`this.#x = v`).
         if (!ts.isIdentifier(s.expression.left.name) && !ts.isPrivateIdentifier(s.expression.left.name))
@@ -2877,7 +2959,13 @@ function isPhase1StatementListInScope(
         ts.isElementAccessExpression(s.expression.left)
       ) {
         const lhs = s.expression.left;
-        if (!ts.isIdentifier(lhs.expression) || !scope.has(lhs.expression.text)) {
+        if (lhs.questionDotToken !== undefined) {
+          return shapeNo("nontail-elemstore-optional", lhs);
+        }
+        if (
+          (!ts.isIdentifier(lhs.expression) || !scope.has(lhs.expression.text)) &&
+          !stableDynamicStoreReceiverHasAdmittedRoot(lhs.expression)
+        ) {
           return shapeNo("nontail-elemstore-recv", lhs.expression);
         }
         if (!isPhase1Expr(lhs.argumentExpression, scope, localClasses))
@@ -3794,6 +3882,9 @@ function isPhase1BodyStatement(
           return true;
         }
         if (ts.isPropertyAccessExpression(stmt.expression.left)) {
+          if (stmt.expression.left.questionDotToken !== undefined) {
+            return shapeNo("body-assign-optional", stmt.expression.left);
+          }
           // #3000 — allow `this.#x = v` (PrivateIdentifier) in method / ctor
           // bodies, in addition to plain-Identifier field writes.
           if (!ts.isIdentifier(stmt.expression.left.name) && !ts.isPrivateIdentifier(stmt.expression.left.name))
@@ -3812,7 +3903,13 @@ function isPhase1BodyStatement(
         // receivers demote cleanly).
         if (ts.isElementAccessExpression(stmt.expression.left)) {
           const lhs = stmt.expression.left;
-          if (!ts.isIdentifier(lhs.expression) || !scope.has(lhs.expression.text)) {
+          if (lhs.questionDotToken !== undefined) {
+            return shapeNo("body-elemstore-optional", lhs);
+          }
+          if (
+            (!ts.isIdentifier(lhs.expression) || !scope.has(lhs.expression.text)) &&
+            !stableDynamicStoreReceiverHasAdmittedRoot(lhs.expression)
+          ) {
             return shapeNo("body-elemstore-recv", lhs.expression);
           }
           if (!isPhase1Expr(lhs.argumentExpression, scope, localClasses)) return false;
@@ -7186,6 +7283,8 @@ export function assessModuleInit(
   currentFnIsAsync = false; // (#1373b C-1) module-init is never an async body
   currentSubjectIsModuleInit = true;
   currentDynMemberEqualitySubject = null;
+  currentStableFunctionCallSubject = null;
+  currentStableDynamicRootNames = new Set<string>();
   currentIrSafeVarDeclarationLists = new Set();
   currentModuleMapGetAliases = new Set<ts.VariableDeclaration>();
   currentModuleScalarAliasFamilies = new Map<ts.VariableDeclaration, "f64" | "boolean">();

--- a/tests/issue-3797-ir-stable-this-call-selector.test.ts
+++ b/tests/issue-3797-ir-stable-this-call-selector.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { compile } from "../src/index.js";
 import {
   makeIrModuleBindingResolver,
   type IrLegacyModuleBindingResolver,
@@ -93,7 +94,10 @@ function stablePlan(source: string, numberStorage: "f64" | "i32" = "f64"): IrSta
   return graph.resolver.stableFunctionCallPlan(declaration(graph.sourceFile));
 }
 
-function selectionFor(source: string): { readonly funcs: ReadonlySet<string>; readonly reason?: string } {
+function selectionFor(
+  source: string,
+  stableFunctionCallIntegrationBuildable = false,
+): { readonly funcs: ReadonlySet<string>; readonly reason?: string } {
   const graph = fixture(source);
   const selection = planIrCompilation(
     graph.sourceFile,
@@ -102,6 +106,7 @@ function selectionFor(source: string): { readonly funcs: ReadonlySet<string>; re
       trackFallbacks: true,
       dynamicRuntimeBuildable: true,
       dynMemberReadBuildable: true,
+      stableFunctionCallIntegrationBuildable,
       resolveModuleBinding: graph.resolver,
     },
     buildTypeMap(graph.sourceFile, graph.checker),
@@ -151,6 +156,30 @@ describe("#3797 stable .call target proof", () => {
     }
   });
 
+  it("rejects an exported target because source-local scanning is not whole-program proof", () => {
+    expect(
+      stablePlan(FINISH_NODE_AT.replace("function finishNodeAt(", "export function finishNodeAt(")),
+    ).toBeUndefined();
+  });
+
+  it("rejects a target exported through an export list", () => {
+    expect(stablePlan(`${FINISH_NODE_AT}\nexport { finishNodeAt };`)).toBeUndefined();
+  });
+
+  it("rejects a global-script target whose reference population can extend across files", () => {
+    expect(
+      stablePlan(`
+        function finishNodeAt(node: any, type: any, pos: number, loc: any): any {
+          if (this.options.locations) node.loc.end = loc;
+          return node;
+        }
+        function wrapper(node: any, type: any, pos: number, loc: any): any {
+          return finishNodeAt.call(this, node, type, pos, loc);
+        }
+      `),
+    ).toBeUndefined();
+  });
+
   it.each([
     ["alias", `const alias = finishNodeAt;`],
     ["bare call", `finishNodeAt(node, type, pos, loc);`],
@@ -160,6 +189,19 @@ describe("#3797 stable .call target proof", () => {
     ["arity mismatch", `finishNodeAt.call(this, node, type, pos);`],
     ["bare call property", `const invoke = finishNodeAt.call;`],
     ["nullable receiver", `finishNodeAt.call(null, node, type, pos, loc);`],
+    ["asserted-null receiver", `finishNodeAt.call(null as unknown as {}, node, type, pos, loc);`],
+    [
+      "nested asserted-null receiver",
+      `const receiver: { parser: {} } | null = null; finishNodeAt.call((receiver as { parser: {} }).parser, node, type, pos, loc);`,
+    ],
+    [
+      "non-null-asserted receiver",
+      `const receiver: { options: {} } | null = null; finishNodeAt.call(receiver!, node, type, pos, loc);`,
+    ],
+    [
+      "optional-chain receiver segment",
+      `const receiver: { parser?: {} } = {}; finishNodeAt.call(receiver?.parser, node, type, pos, loc);`,
+    ],
   ])("rejects %s references from the complete source population", (_label, reference) => {
     expect(
       stablePlan(`
@@ -179,6 +221,7 @@ describe("#3797 stable .call target proof", () => {
     ["bare this value", `const receiver = this;`],
     ["ambient-this write", `this.options = node;`],
     ["optional ambient-this read", `if (this?.options) node.type = type;`],
+    ["nested optional ambient-this read", `if (this.options?.locations) node.type = type;`],
   ])("rejects %s outside admitted dynamic member-read roots", (_label, bodyUse) => {
     expect(
       stablePlan(`
@@ -195,8 +238,14 @@ describe("#3797 stable .call target proof", () => {
 });
 
 describe("#3797 finishNodeAt selector preclaim", () => {
-  it("admits the exact named and nested element stores without counting an integrated 33rd function", () => {
+  it("keeps the proof inert when the executable integration capability is absent", () => {
     const selected = selectionFor(FINISH_NODE_AT);
+    expect(selected.funcs.has("finishNodeAt")).toBe(false);
+    expect(selected.reason).toBeDefined();
+  });
+
+  it("admits the exact named and nested element stores without counting an integrated 33rd function", () => {
+    const selected = selectionFor(FINISH_NODE_AT, true);
     expect(selected.funcs.has("finishNodeAt"), selected.reason).toBe(true);
   });
 
@@ -207,7 +256,8 @@ describe("#3797 finishNodeAt selector preclaim", () => {
     ["nullable receiver", `node.type = type; return node;`, `node: any | null`],
     ["unsupported receiver", `makeNode().type = type; return node;`],
   ])("rejects %s before claim", (_label, statement, firstParameter = "node: any") => {
-    const selected = selectionFor(`
+    const selected = selectionFor(
+      `
       function makeNode(): any { return {}; }
       function finishNodeAt(${firstParameter}, type: any, pos: number, loc: any): any {
         if (this.options.locations) node.loc.end = loc;
@@ -216,8 +266,25 @@ describe("#3797 finishNodeAt selector preclaim", () => {
       export function wrapper(node: any, type: any, pos: number, loc: any): any {
         return finishNodeAt.call(this, node, type, pos, loc);
       }
-    `);
+    `,
+      true,
+    );
     expect(selected.funcs.has("finishNodeAt")).toBe(false);
     expect(selected.reason).toBeDefined();
   });
+
+  it.each(["gc", "standalone"] as const)(
+    "does not prematurely claim the target in a production %s compile",
+    async (target) => {
+      const result = await compile(FINISH_NODE_AT, {
+        fileName: `issue-3797-production-gate-${target}.ts`,
+        target,
+        skipSemanticDiagnostics: true,
+        trackIrOutcomes: true,
+      });
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+      expect(result.irCompiledFuncs ?? []).not.toContain("finishNodeAt");
+    },
+  );
 });

--- a/tests/issue-3797-ir-stable-this-call-selector.test.ts
+++ b/tests/issue-3797-ir-stable-this-call-selector.test.ts
@@ -46,13 +46,13 @@ interface Fixture {
   readonly resolver: IrLegacyModuleBindingResolver;
 }
 
-function fixture(source: string, numberStorage: "f64" | "i32" = "f64"): Fixture {
+function fixture(source: string, numberStorage: "f64" | "i32" = "f64", strict = false): Fixture {
   const fileName = "/repo/issue-3797.ts";
   const options: ts.CompilerOptions = {
     allowJs: true,
     module: ts.ModuleKind.ESNext,
     noLib: true,
-    strict: false,
+    strict,
     target: ts.ScriptTarget.ES2022,
   };
   const host: ts.CompilerHost = {
@@ -89,8 +89,12 @@ function declaration(sourceFile: ts.SourceFile, name = "finishNodeAt"): ts.Funct
   return node;
 }
 
-function stablePlan(source: string, numberStorage: "f64" | "i32" = "f64"): IrStableFunctionCallPlan | undefined {
-  const graph = fixture(source, numberStorage);
+function stablePlan(
+  source: string,
+  numberStorage: "f64" | "i32" = "f64",
+  strict = false,
+): IrStableFunctionCallPlan | undefined {
+  const graph = fixture(source, numberStorage, strict);
   return graph.resolver.stableFunctionCallPlan(declaration(graph.sourceFile));
 }
 
@@ -175,6 +179,44 @@ describe("#3797 stable .call target proof", () => {
         }
         function wrapper(node: any, type: any, pos: number, loc: any): any {
           return finishNodeAt.call(this, node, type, pos, loc);
+        }
+      `),
+    ).toBeUndefined();
+  });
+
+  it("rejects a strict nullable receiver instead of trusting narrowed checker output", () => {
+    expect(
+      stablePlan(
+        `
+        function finishNodeAt(node: any, type: any, pos: number, loc: any): any {
+          if (this.options.locations) node.loc.end = loc;
+          return node;
+        }
+        export function wrapper(
+          receiver: { options: { locations: boolean } } | null,
+          node: any,
+          type: any,
+          pos: number,
+          loc: any,
+        ): any {
+          return finishNodeAt.call(receiver, node, type, pos, loc);
+        }
+      `,
+        "f64",
+        true,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("rejects an unconstrained type-parameter receiver", () => {
+    expect(
+      stablePlan(`
+        function finishNodeAt(node: any, type: any, pos: number, loc: any): any {
+          if (this.options.locations) node.loc.end = loc;
+          return node;
+        }
+        export function wrapper<T>(receiver: T, node: any, type: any, pos: number, loc: any): any {
+          return finishNodeAt.call(receiver, node, type, pos, loc);
         }
       `),
     ).toBeUndefined();
@@ -276,14 +318,21 @@ describe("#3797 finishNodeAt selector preclaim", () => {
   it.each(["gc", "standalone"] as const)(
     "does not prematurely claim the target in a production %s compile",
     async (target) => {
-      const result = await compile(FINISH_NODE_AT, {
-        fileName: `issue-3797-production-gate-${target}.ts`,
-        target,
-        skipSemanticDiagnostics: true,
-        trackIrOutcomes: true,
-      });
+      const result = await compile(
+        `${FINISH_NODE_AT}
+        export function knownIrPositive(value: number): number {
+          return value + 1;
+        }`,
+        {
+          fileName: `issue-3797-production-gate-${target}.ts`,
+          target,
+          skipSemanticDiagnostics: true,
+          trackIrOutcomes: true,
+        },
+      );
       expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
       expect(result.irPostClaimErrors ?? []).toEqual([]);
+      expect(result.irCompiledFuncs ?? []).toContain("knownIrPositive");
       expect(result.irCompiledFuncs ?? []).not.toContain("finishNodeAt");
     },
   );

--- a/tests/issue-3797-ir-stable-this-call-selector.test.ts
+++ b/tests/issue-3797-ir-stable-this-call-selector.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  makeIrModuleBindingResolver,
+  type IrLegacyModuleBindingResolver,
+  type IrStableFunctionCallPlan,
+} from "../src/ir/module-bindings.js";
+import { buildIrUnitInventory } from "../src/ir/identity.js";
+import { buildIrPlanningIdentityContext } from "../src/ir/planning-identity.js";
+import { buildTypeMap } from "../src/ir/propagate.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { ts } from "../src/ts-api.js";
+
+const MODULE_OPTIONS = {
+  numberStorage: "f64",
+  allowHostExterns: false,
+  allowBuiltinMapExtern: false,
+} as const;
+
+const FINISH_NODE_AT = `
+function finishNodeAt(node: any, type: any, pos: number, loc: any): any {
+  node.type = type;
+  node.end = pos;
+  if (this.options.locations) {
+    node.loc.end = loc;
+  }
+  if (this.options.ranges) {
+    node.range[1] = pos;
+  }
+  return node;
+}
+
+export function finishNode(node: any, type: any, pos: number, loc: any): any {
+  return finishNodeAt.call(this, node, type, pos, loc);
+}
+
+export function finishNodeAtWrapper(node: any, type: any, pos: number, loc: any): any {
+  return finishNodeAt.call(this, node, type, pos, loc);
+}
+`;
+
+interface Fixture {
+  readonly sourceFile: ts.SourceFile;
+  readonly checker: ts.TypeChecker;
+  readonly resolver: IrLegacyModuleBindingResolver;
+}
+
+function fixture(source: string, numberStorage: "f64" | "i32" = "f64"): Fixture {
+  const fileName = "/repo/issue-3797.ts";
+  const options: ts.CompilerOptions = {
+    allowJs: true,
+    module: ts.ModuleKind.ESNext,
+    noLib: true,
+    strict: false,
+    target: ts.ScriptTarget.ES2022,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (name) => name === fileName,
+    readFile: (name) => (name === fileName ? source : undefined),
+    getSourceFile: (name, languageVersion) =>
+      name === fileName ? ts.createSourceFile(name, source, languageVersion, true, ts.ScriptKind.TS) : undefined,
+    getDefaultLibFileName: () => "/repo/lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/repo",
+    getDirectories: () => [],
+    directoryExists: (name) => name === "/repo",
+    realpath: (name) => name,
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+  };
+  const program = ts.createProgram([fileName], options, host);
+  const sourceFile = program.getSourceFile(fileName)!;
+  const checker = program.getTypeChecker();
+  return {
+    sourceFile,
+    checker,
+    resolver: makeIrModuleBindingResolver(checker, { ...MODULE_OPTIONS, numberStorage }),
+  };
+}
+
+function declaration(sourceFile: ts.SourceFile, name = "finishNodeAt"): ts.FunctionDeclaration {
+  const node = sourceFile.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name?.text === name,
+  );
+  if (!node) throw new Error(`missing ${name}`);
+  return node;
+}
+
+function stablePlan(source: string, numberStorage: "f64" | "i32" = "f64"): IrStableFunctionCallPlan | undefined {
+  const graph = fixture(source, numberStorage);
+  return graph.resolver.stableFunctionCallPlan(declaration(graph.sourceFile));
+}
+
+function selectionFor(source: string): { readonly funcs: ReadonlySet<string>; readonly reason?: string } {
+  const graph = fixture(source);
+  const selection = planIrCompilation(
+    graph.sourceFile,
+    {
+      experimentalIR: true,
+      trackFallbacks: true,
+      dynamicRuntimeBuildable: true,
+      dynMemberReadBuildable: true,
+      resolveModuleBinding: graph.resolver,
+    },
+    buildTypeMap(graph.sourceFile, graph.checker),
+  );
+  return {
+    funcs: selection.funcs,
+    reason: selection.fallbacks?.find((fallback) => fallback.name === "finishNodeAt")?.reason,
+  };
+}
+
+describe("#3797 stable .call target proof", () => {
+  it("certifies the exact four-parameter target and its complete two-site population", () => {
+    const graph = fixture(FINISH_NODE_AT);
+    const target = declaration(graph.sourceFile);
+    const plan = graph.resolver.stableFunctionCallPlan(target);
+    expect(plan).toBeDefined();
+    expect(plan).toMatchObject({ declaration: target, targetName: "finishNodeAt", arity: 4 });
+    expect(plan!.signature.getParameters()).toHaveLength(4);
+    expect(plan!.callSites).toHaveLength(2);
+    for (const site of plan!.callSites) {
+      expect(site.call.arguments).toHaveLength(5);
+      expect(site.receiver.kind).toBe(ts.SyntaxKind.ThisKeyword);
+      expect(site.arguments).toHaveLength(4);
+      expect(graph.resolver.stableFunctionCallPlan(site.call)?.declaration).toBe(target);
+    }
+  });
+
+  it("is non-fast only", () => {
+    expect(stablePlan(FINISH_NODE_AT, "f64")).toBeDefined();
+    expect(stablePlan(FINISH_NODE_AT, "i32")).toBeUndefined();
+  });
+
+  it("attaches the exact Program inventory identities in production mode", () => {
+    const graph = fixture(FINISH_NODE_AT);
+    const target = declaration(graph.sourceFile);
+    const inventory = buildIrUnitInventory([graph.sourceFile], {
+      checker: graph.checker,
+      entrySource: graph.sourceFile,
+    });
+    const context = buildIrPlanningIdentityContext(inventory);
+    const resolver = makeIrModuleBindingResolver(graph.checker, MODULE_OPTIONS, context);
+    const plan = resolver.stableFunctionCallPlan(target);
+    expect(plan?.targetUnitId).toBe(context.unitIdByDeclaration.get(target));
+    expect(plan?.sourceId).toBe(context.sourceIdBySourceFile.get(graph.sourceFile));
+    for (const site of plan?.callSites ?? []) {
+      expect(resolver.stableFunctionCallPlan(site.call)?.targetUnitId).toBe(plan!.targetUnitId);
+    }
+  });
+
+  it.each([
+    ["alias", `const alias = finishNodeAt;`],
+    ["bare call", `finishNodeAt(node, type, pos, loc);`],
+    ["reassignment", `finishNodeAt = function (node, type, pos, loc) { return node; };`],
+    ["spread", `finishNodeAt.call(this, ...[node, type, pos, loc]);`],
+    ["optional", `finishNodeAt.call?.(this, node, type, pos, loc);`],
+    ["arity mismatch", `finishNodeAt.call(this, node, type, pos);`],
+    ["bare call property", `const invoke = finishNodeAt.call;`],
+    ["nullable receiver", `finishNodeAt.call(null, node, type, pos, loc);`],
+  ])("rejects %s references from the complete source population", (_label, reference) => {
+    expect(
+      stablePlan(`
+        function finishNodeAt(node: any, type: any, pos: number, loc: any): any {
+          if (this.options.locations) node.loc.end = loc;
+          return node;
+        }
+        export function wrapper(node: any, type: any, pos: number, loc: any): any {
+          ${reference}
+          return node;
+        }
+      `),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ["bare this value", `const receiver = this;`],
+    ["ambient-this write", `this.options = node;`],
+    ["optional ambient-this read", `if (this?.options) node.type = type;`],
+  ])("rejects %s outside admitted dynamic member-read roots", (_label, bodyUse) => {
+    expect(
+      stablePlan(`
+        function finishNodeAt(node: any, type: any, pos: number, loc: any): any {
+          ${bodyUse}
+          return node;
+        }
+        export function wrapper(node: any, type: any, pos: number, loc: any): any {
+          return finishNodeAt.call(this, node, type, pos, loc);
+        }
+      `),
+    ).toBeUndefined();
+  });
+});
+
+describe("#3797 finishNodeAt selector preclaim", () => {
+  it("admits the exact named and nested element stores without counting an integrated 33rd function", () => {
+    const selected = selectionFor(FINISH_NODE_AT);
+    expect(selected.funcs.has("finishNodeAt"), selected.reason).toBe(true);
+  });
+
+  it.each([
+    ["assignment as value", `return (node.type = type);`],
+    ["compound write", `node.end += pos; return node;`],
+    ["optional write", `node?.type = type; return node;`],
+    ["nullable receiver", `node.type = type; return node;`, `node: any | null`],
+    ["unsupported receiver", `makeNode().type = type; return node;`],
+  ])("rejects %s before claim", (_label, statement, firstParameter = "node: any") => {
+    const selected = selectionFor(`
+      function makeNode(): any { return {}; }
+      function finishNodeAt(${firstParameter}, type: any, pos: number, loc: any): any {
+        if (this.options.locations) node.loc.end = loc;
+        ${statement}
+      }
+      export function wrapper(node: any, type: any, pos: number, loc: any): any {
+        return finishNodeAt.call(this, node, type, pos, loc);
+      }
+    `);
+    expect(selected.funcs.has("finishNodeAt")).toBe(false);
+    expect(selected.reason).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- prove the exact source-local `finishNodeAt.call(this, ...)` reference shape with checker and structural identity evidence
- admit only parenthesized bare-`this` receivers and exact fixed arity; reject aliases, exports, reassignment, optional/spread calls, assertions, nullable/generic receivers, and ambiguous targets
- preclaim the statement-position dynamic named/indexed stores used by Acorn
- keep the production capability disabled until receiver-aware IR lowering consumes the proof
- track the integration boundary and remaining activation work in `plan/issues/3797-ir-stable-this-call-selector.md`

## Validation

- `pnpm exec vitest run tests/issue-3797-ir-stable-this-call-selector.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism` (33/33)
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:func-budget`
- `pnpm run format:check`
- `pnpm run lint`
- independent soundness re-review: accepted

The exact Acorn driver remains unchanged at 32/43 IR-emitted reachable functions, checksum 422, zero imports, and zero withdrawals; this selector-only slice does not claim `finishNodeAt` until the receiver bridge is connected.