### PR TITLE
perf: restore WASI warm array and string fast paths

### DIFF
--- a/plan/issues/3798-wasi-warm-array-string.md
+++ b/plan/issues/3798-wasi-warm-array-string.md
@@ -1,0 +1,65 @@
+---
+id: 3798
+title: "Restore WASI warm array and string benchmark fast paths"
+status: done
+completed: 2026-07-30
+sprint: current
+created: 2026-07-30
+updated: 2026-07-30
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: ir, codegen, benchmarks
+goal: performance
+assignee: ttraenkler/codex-wasi-warm-array-string
+branch: codex/wasi-warm-array-string
+loc-budget-allow:
+  - src/codegen/expressions/operator-assignment.ts
+  - src/codegen/index.ts
+  - src/codegen/property-access-dispatch.ts
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/codegen/index.ts::planIrOverlay
+  - src/ir/integration.ts::makeResolver
+  - src/ir/select.ts::whyNotIrClaimable
+---
+
+# #3798 — Restore WASI warm array and string benchmark fast paths
+
+## Problem
+
+The landing-page Wasmtime warm lane measured `array-sum` at roughly 21.6 ms
+against V8's 5.3 ms and `string-hash` at roughly 0.59 ms against V8's 0.34 ms.
+
+The real timing wrapper kept `array-sum.run` on the legacy body through
+call-graph closure even though its numeric ABI was exact. That body boxed every
+addition and repeated the full JavaScript ToInt32 conversion in the hot loop.
+The native string-builder path also flattened a provably flat const-literal
+receiver for every `charAt` append and materialized a string view merely to
+read the builder length in the hash-loop condition.
+
+## Resolution
+
+- Certify the exact numeric ABI used by the fused array fill-and-reduce shape.
+- Fuse the non-escaping temporary array into its i32 reduction, with sized
+  allocation and direct stores retained for observable dense fills.
+- Preserve nested bitwise values in native i32 form.
+- Bypass flattening for `charAt` on const string-literal bindings.
+- Read detected string-builder lengths directly from their synthetic i32 local.
+- Cover selection, WAT shape, edge-case behavior, and the exact landing corpus
+  shapes.
+
+## Evidence
+
+Same-machine Wasmtime/V8 A/B, using
+`scripts/generate-wasmtime-hot-runtime.mjs`:
+
+| Benchmark | Main Wasmtime warm | Fixed Wasmtime warm | V8 warm |
+| --- | ---: | ---: | ---: |
+| Array fill + sum | 21.63 ms | 0.51 ms | 5.03 ms |
+| String build + hash | 0.58 ms | 0.16 ms | 0.34 ms |
+

--- a/plan/issues/3798-wasi-warm-array-string.md
+++ b/plan/issues/3798-wasi-warm-array-string.md
@@ -47,6 +47,9 @@ read the builder length in the hash-loop condition.
 - Certify the exact numeric ABI used by the fused array fill-and-reduce shape.
 - Fuse the non-escaping temporary array into its i32 reduction, with sized
   allocation and direct stores retained for observable dense fills.
+- Keep counted `.push` loops on the legacy pre-sized path until IR owns the same
+  capacity proof, and record that deferred selector outcome in the IR-only
+  readiness baseline.
 - Preserve nested bitwise values in native i32 form.
 - Bypass flattening for `charAt` on const string-literal bindings.
 - Read detected string-builder lengths directly from their synthetic i32 local.
@@ -58,8 +61,7 @@ read the builder length in the hash-loop condition.
 Same-machine Wasmtime/V8 A/B, using
 `scripts/generate-wasmtime-hot-runtime.mjs`:
 
-| Benchmark | Main Wasmtime warm | Fixed Wasmtime warm | V8 warm |
-| --- | ---: | ---: | ---: |
-| Array fill + sum | 21.63 ms | 0.51 ms | 5.03 ms |
-| String build + hash | 0.58 ms | 0.16 ms | 0.34 ms |
-
+| Benchmark           | Main Wasmtime warm | Fixed Wasmtime warm | V8 warm |
+| ------------------- | -----------------: | ------------------: | ------: |
+| Array fill + sum    |           21.63 ms |             0.51 ms | 5.03 ms |
+| String build + hash |            0.58 ms |             0.16 ms | 0.34 ms |

--- a/plan/issues/3799-wasi-warm-array-string.md
+++ b/plan/issues/3799-wasi-warm-array-string.md
@@ -1,5 +1,5 @@
 ---
-id: 3798
+id: 3799
 title: "Restore WASI warm array and string benchmark fast paths"
 status: done
 completed: 2026-07-30
@@ -28,7 +28,7 @@ func-budget-allow:
   - src/ir/select.ts::whyNotIrClaimable
 ---
 
-# #3798 — Restore WASI warm array and string benchmark fast paths
+# #3799 — Restore WASI warm array and string benchmark fast paths
 
 ## Problem
 

--- a/plan/log/ir-adoption.md
+++ b/plan/log/ir-adoption.md
@@ -160,7 +160,7 @@ and Algorithms' top-level generic Map initializer are both IR-owned.
 | `class-method`                           | unintended | #1370/#3000 B-C-E — corpus bucket **0** (#3000-E); NOT yet strict (still covers computed/generator/abstract names, static super, subclass-of-builtin) |
 | `destructuring-param-complex`            | unintended | Complex destructuring params lowered (subset of param-shape)                                                                                          |
 | `string-builder-candidate`               | deferred   | Kill-switch only (`JS2WASM_IR_STRING_BUILDER=0`): builder loops are IR-claimed by default via the owned-append fast path (#3740/#3744)                |
-| `array-presize-legacy`                   | deferred   | Counted `.push` loops stay on the direct front-end until typed IR owns an equivalent allocation-site capacity proof (#3798)                           |
+| `array-presize-legacy`                   | deferred   | Counted `.push` loops stay on the direct front-end until typed IR owns an equivalent allocation-site capacity proof (#3799)                           |
 | `async-function`                         | deferred   | Async bodies — CPS lowering tracked separately (#1373/#1796)                                                                                          |
 | `async-generator`                        | deferred   | Out of scope long-term                                                                                                                                |
 | `deferred-feature`                       | deferred   | `eval` / `Proxy` / `with` — wont-fix                                                                                                                  |

--- a/plan/log/ir-adoption.md
+++ b/plan/log/ir-adoption.md
@@ -160,6 +160,7 @@ and Algorithms' top-level generic Map initializer are both IR-owned.
 | `class-method`                           | unintended | #1370/#3000 B-C-E — corpus bucket **0** (#3000-E); NOT yet strict (still covers computed/generator/abstract names, static super, subclass-of-builtin) |
 | `destructuring-param-complex`            | unintended | Complex destructuring params lowered (subset of param-shape)                                                                                          |
 | `string-builder-candidate`               | deferred   | Kill-switch only (`JS2WASM_IR_STRING_BUILDER=0`): builder loops are IR-claimed by default via the owned-append fast path (#3740/#3744)                |
+| `array-presize-legacy`                   | deferred   | Counted `.push` loops stay on the direct front-end until typed IR owns an equivalent allocation-site capacity proof (#3798)                           |
 | `async-function`                         | deferred   | Async bodies — CPS lowering tracked separately (#1373/#1796)                                                                                          |
 | `async-generator`                        | deferred   | Out of scope long-term                                                                                                                                |
 | `deferred-feature`                       | deferred   | `eval` / `Proxy` / `with` — wont-fix                                                                                                                  |

--- a/scripts/check-ir-fallbacks.ts
+++ b/scripts/check-ir-fallbacks.ts
@@ -130,6 +130,7 @@ const DEFERRED: ReadonlySet<IrFallbackReason> = new Set([
   "type-parameters",
   "non-export-modifier",
   "unnamed",
+  "array-presize-legacy",
 ]);
 
 // #1923 — post-claim demotion kinds (IrIntegrationError.kind). These are

--- a/scripts/gen-ir-adoption.mjs
+++ b/scripts/gen-ir-adoption.mjs
@@ -300,7 +300,7 @@ const BUCKETS = {
   ],
   "array-presize-legacy": [
     "deferred",
-    "Counted `.push` loops stay on the direct front-end until typed IR owns an equivalent allocation-site capacity proof (#3798)",
+    "Counted `.push` loops stay on the direct front-end until typed IR owns an equivalent allocation-site capacity proof (#3799)",
   ],
   "async-function": ["deferred", "Async bodies — CPS lowering tracked separately (#1373/#1796)"],
   "async-generator": ["deferred", "Out of scope long-term"],

--- a/scripts/gen-ir-adoption.mjs
+++ b/scripts/gen-ir-adoption.mjs
@@ -298,6 +298,10 @@ const BUCKETS = {
     "deferred",
     "Kill-switch only (`JS2WASM_IR_STRING_BUILDER=0`): builder loops are IR-claimed by default via the owned-append fast path (#3740/#3744)",
   ],
+  "array-presize-legacy": [
+    "deferred",
+    "Counted `.push` loops stay on the direct front-end until typed IR owns an equivalent allocation-site capacity proof (#3798)",
+  ],
   "async-function": ["deferred", "Async bodies — CPS lowering tracked separately (#1373/#1796)"],
   "async-generator": ["deferred", "Out of scope long-term"],
   "deferred-feature": ["deferred", "`eval` / `Proxy` / `with` — wont-fix"],

--- a/scripts/ir-only-baseline.json
+++ b/scripts/ir-only-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generated": "2026-07-21",
+  "generated": "2026-07-30",
   "lanes": {
     "single-host": {
       "entryFloor": 5,
@@ -10,10 +10,10 @@
       "unsupportedCeiling": 7,
       "unsupportedByCode": {
         "select/async-function": 2,
+        "select/array-presize-legacy": 1,
         "select/call-graph-closure": 1,
         "select/body-shape-rejected": 1,
-        "build/static-class-member": 2,
-        "build/void-call-expression": 1
+        "build/static-class-member": 2
       },
       "invariantCeiling": 0
     }

--- a/src/codegen/expressions/operator-assignment.ts
+++ b/src/codegen/expressions/operator-assignment.ts
@@ -1202,10 +1202,28 @@ function tryCompileSingleCharBuilderAppend(
       if (flattenIdx !== undefined) {
         const strTypeIdx = ctx.nativeStrTypeIdx;
         const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
-        // flat = __str_flatten(receiver) → ref $NativeString, stash in a temp.
+        // A const initialized directly from a string literal is already a
+        // flat $NativeString for its entire lifetime. Avoid calling the
+        // generic flatten helper for every append in a hot loop (the landing
+        // string-hash shape reads the same alphabet twice per iteration).
+        const receiverDeclaration = ts.isIdentifier(receiver) ? ctx.oracle.variableDeclarationOf(receiver) : undefined;
+        const receiverIsConstLiteral =
+          receiverDeclaration !== undefined &&
+          ts.isVariableDeclaration(receiverDeclaration) &&
+          receiverDeclaration.initializer !== undefined &&
+          (ts.isStringLiteral(receiverDeclaration.initializer) ||
+            ts.isNoSubstitutionTemplateLiteral(receiverDeclaration.initializer)) &&
+          ts.isVariableDeclarationList(receiverDeclaration.parent) &&
+          (ts.getCombinedNodeFlags(receiverDeclaration.parent) & ts.NodeFlags.Const) !== 0;
+
+        // flat = receiver (proven flat) or __str_flatten(receiver), then stash.
         const recvVal = compileExpression(ctx, fctx, receiver);
         if (recvVal !== null) {
-          fctx.body.push({ op: "call", funcIdx: flattenIdx });
+          if (receiverIsConstLiteral) {
+            fctx.body.push({ op: "ref.cast", typeIdx: strTypeIdx });
+          } else {
+            fctx.body.push({ op: "call", funcIdx: flattenIdx });
+          }
           const flatTmp = allocLocal(fctx, `__sb_charAt_flat_${fctx.locals.length}`, {
             kind: "ref_null",
             typeIdx: strTypeIdx,

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -8,6 +8,7 @@ import { isLinearU8RepresentableNew } from "./linear-uint8-signatures.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
 import { fillHostFnctorMethodDrivers, maxReservedHostFnctorMethodArity } from "./host-fnctor-method-driver.js";
 import { emitVecDefineWritebackExports } from "./vec-define-writeback.js"; // (#3116)
+import { detectArrayReduceFusion } from "./array-reduce-fusion.js";
 import type { MultiTypedAST, TypedAST } from "../checker/index.js";
 import type { TypeFact } from "../checker/oracle.js";
 import {
@@ -2078,8 +2079,14 @@ function planIrOverlay(
     let allProjectionsAreBoolean = true;
     let hasNonFastScalarProjection = false;
     let allProjectionsAreNonFastStable = true;
+    let allPositionsAreExplicitNumbers = true;
     for (const parameter of declaration.parameters) {
-      if (effectiveIrParamTypeNode(parameter)) continue;
+      const explicitType = effectiveIrParamTypeNode(parameter);
+      if (explicitType) {
+        if (explicitType.kind !== ts.SyntaxKind.NumberKeyword) allPositionsAreExplicitNumbers = false;
+        continue;
+      }
+      allPositionsAreExplicitNumbers = false;
       const projection = resolveImplicitParamType(parameter);
       if (!projection) {
         if (ctx.fast) return false;
@@ -2099,7 +2106,13 @@ function planIrOverlay(
         allProjectionsAreNonFastStable = false;
       }
     }
+    const returnType = effectiveIrReturnTypeNode(declaration);
+    const hasExactScalarNumberAbi =
+      allPositionsAreExplicitNumbers &&
+      returnType?.kind === ts.SyntaxKind.NumberKeyword &&
+      detectArrayReduceFusion(ctx, declaration.body).length > 0;
     return (
+      hasExactScalarNumberAbi ||
       hasIndexedCarrier ||
       (hasBooleanProjection && allProjectionsAreBoolean) ||
       (!ctx.fast && hasNonFastScalarProjection && allProjectionsAreNonFastStable)

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -3015,6 +3015,17 @@ export function tryStringLengthIteratorAndExternClassReads(
   // is a native-string ref (e.g. a for-of var from a string-yielding generator):
   // the static type lost the string info, but at the VALUE level it IS a string.
   if ((isStringType(objType) || receiverIsNativeStringValType(ctx, fctx, expr.expression)) && propName === "length") {
+    // A detected string-builder binding is represented by synthetic
+    // (buffer,length,capacity,materialized) locals. Its logical length is
+    // already available directly; materializing a temporary NativeString on
+    // every loop condition obscures this scalar from Wasmtime/Cranelift.
+    if (ts.isIdentifier(expr.expression)) {
+      const builder = fctx.stringBuilders?.get(expr.expression.text);
+      if (builder !== undefined) {
+        fctx.body.push({ op: "local.get", index: builder.lenLocalIdx });
+        return { kind: "i32" };
+      }
+    }
     const recvType = compileExpression(ctx, fctx, expr.expression);
     if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
       // The receiver must be a `$AnyString` ref before reading its `len`

--- a/src/codegen/vec-elem-set.ts
+++ b/src/codegen/vec-elem-set.ts
@@ -29,6 +29,54 @@ import { ensureExnTag } from "./registry/imports.js";
 
 /** Reserved name prefix; the suffix is the vec STRUCT typeIdx. */
 export const VEC_ELEM_SET_PREFIX = "__vec_elem_set_";
+export const VEC_NEW_SIZED_PREFIX = "__vec_new_sized_";
+
+/**
+ * Ensure a one-shot sized-vector allocator for a canonical dense-fill loop.
+ *
+ * Signature: `(f64 upperBound) -> (ref null $vec_<t>)`.
+ * The loop `for (let i = 0; i < upperBound; i++)` executes
+ * `max(ceil(upperBound), 0)` iterations for finite practical bounds, so that
+ * value is both the required capacity and the post-loop JavaScript length.
+ */
+export function ensureVecNewSized(ctx: CodegenContext, vecTypeIdx: number): number | null {
+  const name = `${VEC_NEW_SIZED_PREFIX}${vecTypeIdx}`;
+  const existing = ctx.funcMap.get(name);
+  if (existing !== undefined) return existing;
+
+  const vecDef = ctx.mod.types[vecTypeIdx];
+  if (!vecDef || vecDef.kind !== "struct" || vecDef.fields.length !== 2) return null;
+  if (vecDef.fields[0]?.name !== "length" || vecDef.fields[1]?.name !== "data") return null;
+  const dataField = vecDef.fields[1]!.type;
+  if (dataField.kind !== "ref" && dataField.kind !== "ref_null") return null;
+  const arrTypeIdx = dataField.typeIdx;
+  const arrDef = ctx.mod.types[arrTypeIdx];
+  if (!arrDef || arrDef.kind !== "array") return null;
+
+  const resultType: ValType = { kind: "ref_null", typeIdx: vecTypeIdx };
+  const sigIdx = addFuncType(ctx, [{ kind: "f64" }], [resultType], `$${name}_type`);
+  const funcIdx = mintDefinedFunc(ctx);
+  const fn: WasmFunction = {
+    name,
+    typeIdx: sigIdx,
+    locals: [{ name: "$length", type: { kind: "i32" } }],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "f64.ceil" },
+      { op: "f64.const", value: 0 },
+      { op: "f64.max" },
+      { op: "i32.trunc_sat_f64_s" },
+      { op: "local.tee", index: 1 },
+      { op: "local.get", index: 1 },
+      { op: "array.new_default", typeIdx: arrTypeIdx },
+      { op: "struct.new", typeIdx: vecTypeIdx },
+    ],
+    exported: false,
+  };
+  pushDefinedFunc(ctx, funcIdx, fn);
+  ctx.funcMap.set(name, funcIdx);
+  return funcIdx;
+}
 
 /**
  * Ensure the element-store helper for the vec struct at `vecTypeIdx` exists

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -3806,7 +3806,7 @@ function denseFillPlanForLiteral(expr: ts.ArrayLiteralExpression): DenseFillPlan
   const statements = block.statements;
   const statementIndex = statements.indexOf(declarationStatement);
   const loop = statements[statementIndex + 1];
-  if (!ts.isForStatement(loop)) return null;
+  if (statementIndex < 0 || !loop || !ts.isForStatement(loop)) return null;
 
   const initializer = loop.initializer;
   if (!initializer || !ts.isVariableDeclarationList(initializer) || initializer.declarations.length !== 1) return null;
@@ -3865,7 +3865,14 @@ function denseFillPlanForLoop(loop: ts.ForStatement): DenseFillPlan | null {
   if (!ts.isBlock(parent) && !ts.isSourceFile(parent)) return null;
   const loopIndex = parent.statements.indexOf(loop);
   const previous = parent.statements[loopIndex - 1];
-  if (!ts.isVariableStatement(previous) || previous.declarationList.declarations.length !== 1) return null;
+  if (
+    loopIndex < 1 ||
+    !previous ||
+    !ts.isVariableStatement(previous) ||
+    previous.declarationList.declarations.length !== 1
+  ) {
+    return null;
+  }
   const initializer = previous.declarationList.declarations[0].initializer;
   return initializer && ts.isArrayLiteralExpression(initializer) ? denseFillPlanForLiteral(initializer) : null;
 }

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -175,6 +175,8 @@ import {
 } from "./nodes.js";
 import type { ValType } from "./types.js";
 
+const VEC_NEW_SIZED_PREFIX = "__vec_new_sized_";
+
 function unsupportedVoidCallExpression(detail: string): never {
   throw new IrUnsupportedError("void-call-expression", "build", detail);
 }
@@ -1105,9 +1107,198 @@ function thenArmTerminates(stmt: ts.Statement): boolean {
   return false;
 }
 
+interface DenseArrayReductionPlan {
+  readonly accumulatorDeclaration: ts.VariableStatement;
+  readonly fillLoop: ts.ForStatement;
+  readonly fillValue: ts.Expression;
+  readonly accumulatorName: string;
+  readonly returnStatement: ts.ReturnStatement;
+}
+
+function referencesIdentifier(expr: ts.Expression, name: string): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isIdentifier(node) && node.text === name) {
+      found = true;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  visit(expr);
+  return found;
+}
+
+/**
+ * Eliminate a local dense array that is filled and then consumed exactly once
+ * by an i32 sum reduction. The array never escapes and both loops are pure, so
+ * accumulating the generated value in the fill loop preserves iteration order
+ * while avoiding a large, immediately-dead WasmGC allocation.
+ */
+function denseArrayReductionPlan(stmts: readonly ts.Statement[]): DenseArrayReductionPlan | null {
+  if (stmts.length !== 5) return null;
+  const [arrayStatement, fillStatement, accumulatorStatement, reductionStatement, returnStatement] = stmts;
+  if (
+    !arrayStatement ||
+    !fillStatement ||
+    !accumulatorStatement ||
+    !reductionStatement ||
+    !returnStatement ||
+    !ts.isVariableStatement(arrayStatement) ||
+    !ts.isForStatement(fillStatement) ||
+    !ts.isVariableStatement(accumulatorStatement) ||
+    !ts.isForStatement(reductionStatement) ||
+    !ts.isReturnStatement(returnStatement)
+  ) {
+    return null;
+  }
+
+  const arrayDeclaration = arrayStatement.declarationList.declarations[0];
+  if (
+    arrayStatement.declarationList.declarations.length !== 1 ||
+    !arrayDeclaration ||
+    !arrayDeclaration.initializer ||
+    !ts.isArrayLiteralExpression(arrayDeclaration.initializer)
+  ) {
+    return null;
+  }
+  const fillPlan = denseFillPlanForLiteral(arrayDeclaration.initializer);
+  if (!fillPlan || fillPlan.loop !== fillStatement) return null;
+  const fillBody = ts.isBlock(fillStatement.statement)
+    ? fillStatement.statement.statements[0]
+    : fillStatement.statement;
+  if (!fillBody || !ts.isExpressionStatement(fillBody) || !ts.isBinaryExpression(fillBody.expression)) return null;
+  const fillValue = fillBody.expression.right;
+  if (!isNestedBitwiseResult(fillValue)) return null;
+
+  const accumulatorDeclaration = accumulatorStatement.declarationList.declarations[0];
+  if (
+    accumulatorStatement.declarationList.declarations.length !== 1 ||
+    !accumulatorDeclaration ||
+    !ts.isIdentifier(accumulatorDeclaration.name) ||
+    !accumulatorDeclaration.initializer ||
+    !ts.isNumericLiteral(accumulatorDeclaration.initializer) ||
+    Number(accumulatorDeclaration.initializer.text) !== 0
+  ) {
+    return null;
+  }
+  const accumulatorName = accumulatorDeclaration.name.text;
+  if (referencesIdentifier(fillValue, accumulatorName)) return null;
+
+  const reductionInit = reductionStatement.initializer;
+  if (
+    !reductionInit ||
+    !ts.isVariableDeclarationList(reductionInit) ||
+    reductionInit.declarations.length !== 1 ||
+    !reductionInit.declarations[0]?.initializer ||
+    !ts.isIdentifier(reductionInit.declarations[0].name) ||
+    !ts.isNumericLiteral(reductionInit.declarations[0].initializer) ||
+    Number(reductionInit.declarations[0].initializer.text) !== 0
+  ) {
+    return null;
+  }
+  const reductionIndex = reductionInit.declarations[0].name.text;
+  const reductionCondition = reductionStatement.condition;
+  const reductionIncrement = reductionStatement.incrementor;
+  if (
+    !reductionCondition ||
+    !ts.isBinaryExpression(reductionCondition) ||
+    reductionCondition.operatorToken.kind !== ts.SyntaxKind.LessThanToken ||
+    !ts.isIdentifier(reductionCondition.left) ||
+    reductionCondition.left.text !== reductionIndex ||
+    !ts.isPropertyAccessExpression(reductionCondition.right) ||
+    !ts.isIdentifier(reductionCondition.right.expression) ||
+    reductionCondition.right.expression.text !== fillPlan.arrayName ||
+    reductionCondition.right.name.text !== "length" ||
+    !reductionIncrement ||
+    (!ts.isPrefixUnaryExpression(reductionIncrement) && !ts.isPostfixUnaryExpression(reductionIncrement)) ||
+    reductionIncrement.operator !== ts.SyntaxKind.PlusPlusToken ||
+    !ts.isIdentifier(reductionIncrement.operand) ||
+    reductionIncrement.operand.text !== reductionIndex
+  ) {
+    return null;
+  }
+
+  const reductionBody = ts.isBlock(reductionStatement.statement)
+    ? reductionStatement.statement.statements[0]
+    : reductionStatement.statement;
+  if (!reductionBody || !ts.isExpressionStatement(reductionBody) || !ts.isBinaryExpression(reductionBody.expression)) {
+    return null;
+  }
+  const assignment = reductionBody.expression;
+  const reduced = peelExpr(assignment.right);
+  if (
+    assignment.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
+    !ts.isIdentifier(assignment.left) ||
+    assignment.left.text !== accumulatorName ||
+    !ts.isBinaryExpression(reduced) ||
+    reduced.operatorToken.kind !== ts.SyntaxKind.BarToken ||
+    i32LiteralValue(reduced.right) !== 0
+  ) {
+    return null;
+  }
+  const addition = peelExpr(reduced.left);
+  if (
+    !ts.isBinaryExpression(addition) ||
+    addition.operatorToken.kind !== ts.SyntaxKind.PlusToken ||
+    !ts.isIdentifier(addition.left) ||
+    addition.left.text !== accumulatorName ||
+    !ts.isElementAccessExpression(addition.right) ||
+    !ts.isIdentifier(addition.right.expression) ||
+    addition.right.expression.text !== fillPlan.arrayName ||
+    !ts.isIdentifier(addition.right.argumentExpression) ||
+    addition.right.argumentExpression.text !== reductionIndex
+  ) {
+    return null;
+  }
+
+  const returned = returnStatement.expression ? peelExpr(returnStatement.expression) : null;
+  const returnIsAccumulator =
+    returned !== null &&
+    (ts.isIdentifier(returned)
+      ? returned.text === accumulatorName
+      : ts.isBinaryExpression(returned) &&
+        returned.operatorToken.kind === ts.SyntaxKind.BarToken &&
+        ts.isIdentifier(returned.left) &&
+        returned.left.text === accumulatorName &&
+        i32LiteralValue(returned.right) === 0);
+  if (!returnIsAccumulator) return null;
+
+  return {
+    accumulatorDeclaration: accumulatorStatement,
+    fillLoop: fillStatement,
+    fillValue,
+    accumulatorName,
+    returnStatement,
+  };
+}
+
 function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void {
   if (stmts.length < 1) {
     throw new Error(`ir/from-ast: empty statement list in ${cx.funcName}`);
+  }
+  const denseReduction = denseArrayReductionPlan(stmts);
+  if (denseReduction) {
+    lowerVarDecl(denseReduction.accumulatorDeclaration, cx);
+    lowerForStatement(denseReduction.fillLoop, cx, (bodyCx) => {
+      const accumulator = bodyCx.scope.get(denseReduction.accumulatorName);
+      if (!accumulator || accumulator.kind !== "slot") {
+        throw new Error(`ir/from-ast: fused dense reduction accumulator must use slot storage (${cx.funcName})`);
+      }
+      const value = lowerAsI32(denseReduction.fillValue, bodyCx, "wrap");
+      const accumulatorRead = bodyCx.builder.emitSlotRead(accumulator.slotIndex);
+      const accumulatorI32 =
+        accumulator.i32Storage === true
+          ? accumulatorRead
+          : bodyCx.builder.emitUnary("i32.trunc_sat_f64_s", accumulatorRead, IR_I32);
+      const sum = bodyCx.builder.emitBinary("i32.add", accumulatorI32, value, IR_I32);
+      bodyCx.builder.emitSlotWrite(
+        accumulator.slotIndex,
+        accumulator.i32Storage === true ? sum : bodyCx.builder.emitUnary("f64.convert_i32_s", sum, IR_F64),
+      );
+    });
+    lowerTail(denseReduction.returnStatement, cx);
+    return;
   }
   for (let i = 0; i < stmts.length - 1; i++) {
     const s = stmts[i]!;
@@ -2354,6 +2545,18 @@ function isFusedI32Lowerable(e: ts.Expression, cx: LowerCtx): boolean {
   return isWrapI32Lowerable(e, promotedI32Probe(cx)) || isI32PureExprIR(e, cx.i32PureNames);
 }
 
+/**
+ * A nested bitwise result is already the exact 32-bit pattern the enclosing
+ * bitwise operator's ToInt32 conversion consumes. This deliberately includes
+ * `>>>`: its JavaScript NUMBER result may be above INT32_MAX, so it is not a
+ * generally signed-i32-valued expression, but converting that uint32 result
+ * back through ToInt32 preserves the same 32 bits.
+ */
+function isNestedBitwiseResult(e: ts.Expression): boolean {
+  const inner = peelExpr(e);
+  return ts.isBinaryExpression(inner) && isIrBitwiseOperatorToken(inner.operatorToken.kind);
+}
+
 /** Invariant R — read a promoted slot and widen to the f64 every consumer expects. */
 function readPromotedI32Slot(slotIndex: number, cx: LowerCtx): IrValueId {
   return cx.builder.emitUnary("f64.convert_i32_s", cx.builder.emitSlotRead(slotIndex), IR_F64);
@@ -2367,7 +2570,7 @@ function readPromotedI32Slot(slotIndex: number, cx: LowerCtx): IrValueId {
  * `lower.ts` applies its usual `emitJsToInt32`.
  */
 function lowerBitwiseOperand(e: ts.Expression, parent: ts.BinaryExpression | null, cx: LowerCtx): IrValueId {
-  if (isFusedI32Lowerable(e, cx)) return lowerAsI32(e, cx, "wrap");
+  if (isFusedI32Lowerable(e, cx) || isNestedBitwiseResult(e)) return lowerAsI32(e, cx, "wrap");
   const v = lowerExpr(e, cx, IR_F64);
   // Taking the fused path means we bypassed `lowerBinary`'s operand-shape
   // gates (string / dynamic / packed). Reproduce its verdict EXACTLY for a
@@ -2421,7 +2624,9 @@ function lowerAsI32(expr: ts.Expression, cx: LowerCtx, mode: "canon" | "wrap"): 
 
   if (ts.isBinaryExpression(inner)) {
     const k = inner.operatorToken.kind;
-    if (isBitwiseToken(k)) return lowerBitwiseAsI32(inner, cx);
+    // In wrap-only contexts a `>>>` result is consumed as its raw 32-bit
+    // pattern, so it can use the same native emitter as signed bitwise ops.
+    if (jsBitwiseBinop(k) !== null) return lowerBitwiseAsI32(inner, cx);
     if (
       mode === "wrap" &&
       (k === ts.SyntaxKind.PlusToken || k === ts.SyntaxKind.MinusToken) &&
@@ -2458,8 +2663,10 @@ function lowerAsI32(expr: ts.Expression, cx: LowerCtx, mode: "canon" | "wrap"): 
 
 /**
  * Lower a bitwise binary expression, narrowing its IR result type to i32.
- * `>>>` is excluded by `isBitwiseToken` (its uint32 VALUE can exceed 2^31-1,
- * so an i32-narrowed result would be a different number).
+ * Callers only request an i32 result where the value is consumed as a 32-bit
+ * pattern. That includes nested `>>>`: its standalone JavaScript value remains
+ * unsigned f64, but an enclosing bitwise operation immediately applies
+ * ToInt32 and consumes exactly these bits.
  */
 function lowerBitwiseAsI32(expr: ts.BinaryExpression, cx: LowerCtx): IrValueId {
   const k = expr.operatorToken.kind;
@@ -3548,6 +3755,121 @@ function arrayLiteralWideningEscapes(expr: ts.ArrayLiteralExpression, cx: LowerC
   return false;
 }
 
+function isPureDenseFillRhs(expr: ts.Expression, arrayName: string): boolean {
+  if (ts.isParenthesizedExpression(expr)) return isPureDenseFillRhs(expr.expression, arrayName);
+  if (
+    ts.isNumericLiteral(expr) ||
+    ts.isStringLiteral(expr) ||
+    expr.kind === ts.SyntaxKind.TrueKeyword ||
+    expr.kind === ts.SyntaxKind.FalseKeyword ||
+    expr.kind === ts.SyntaxKind.NullKeyword
+  ) {
+    return true;
+  }
+  if (ts.isIdentifier(expr)) return expr.text !== arrayName;
+  if (ts.isPrefixUnaryExpression(expr)) {
+    return (
+      (expr.operator === ts.SyntaxKind.PlusToken ||
+        expr.operator === ts.SyntaxKind.MinusToken ||
+        expr.operator === ts.SyntaxKind.TildeToken ||
+        expr.operator === ts.SyntaxKind.ExclamationToken) &&
+      isPureDenseFillRhs(expr.operand, arrayName)
+    );
+  }
+  if (!ts.isBinaryExpression(expr)) return false;
+  const operator = expr.operatorToken.kind;
+  if (operator >= ts.SyntaxKind.FirstAssignment && operator <= ts.SyntaxKind.LastAssignment) return false;
+  if (operator === ts.SyntaxKind.CommaToken) return false;
+  return isPureDenseFillRhs(expr.left, arrayName) && isPureDenseFillRhs(expr.right, arrayName);
+}
+
+interface DenseFillPlan {
+  readonly arrayName: string;
+  readonly indexName: string;
+  readonly bound: ts.Expression;
+  readonly loop: ts.ForStatement;
+}
+
+function denseFillPlanForLiteral(expr: ts.ArrayLiteralExpression): DenseFillPlan | null {
+  const declaration = expr.parent;
+  if (!ts.isVariableDeclaration(declaration) || !ts.isIdentifier(declaration.name)) return null;
+  const declarationList = declaration.parent;
+  const declarationStatement = declarationList.parent;
+  const block = declarationStatement.parent;
+  if (
+    !ts.isVariableDeclarationList(declarationList) ||
+    !ts.isVariableStatement(declarationStatement) ||
+    (!ts.isBlock(block) && !ts.isSourceFile(block))
+  ) {
+    return null;
+  }
+  const statements = block.statements;
+  const statementIndex = statements.indexOf(declarationStatement);
+  const loop = statements[statementIndex + 1];
+  if (!ts.isForStatement(loop)) return null;
+
+  const initializer = loop.initializer;
+  if (!initializer || !ts.isVariableDeclarationList(initializer) || initializer.declarations.length !== 1) return null;
+  const indexDeclaration = initializer.declarations[0];
+  if (
+    !ts.isIdentifier(indexDeclaration.name) ||
+    !indexDeclaration.initializer ||
+    !ts.isNumericLiteral(indexDeclaration.initializer) ||
+    Number(indexDeclaration.initializer.text) !== 0
+  ) {
+    return null;
+  }
+  const indexName = indexDeclaration.name.text;
+  const condition = loop.condition;
+  if (
+    !condition ||
+    !ts.isBinaryExpression(condition) ||
+    condition.operatorToken.kind !== ts.SyntaxKind.LessThanToken ||
+    !ts.isIdentifier(condition.left) ||
+    condition.left.text !== indexName ||
+    (!ts.isIdentifier(condition.right) && !ts.isNumericLiteral(condition.right))
+  ) {
+    return null;
+  }
+  const incrementor = loop.incrementor;
+  if (
+    !incrementor ||
+    (!ts.isPrefixUnaryExpression(incrementor) && !ts.isPostfixUnaryExpression(incrementor)) ||
+    incrementor.operator !== ts.SyntaxKind.PlusPlusToken ||
+    !ts.isIdentifier(incrementor.operand) ||
+    incrementor.operand.text !== indexName
+  ) {
+    return null;
+  }
+  const loopStatements = ts.isBlock(loop.statement) ? loop.statement.statements : [loop.statement];
+  if (loopStatements.length !== 1 || !ts.isExpressionStatement(loopStatements[0])) return null;
+  const assignment = loopStatements[0].expression;
+  const arrayName = declaration.name.text;
+  if (
+    !ts.isBinaryExpression(assignment) ||
+    assignment.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
+    !ts.isElementAccessExpression(assignment.left) ||
+    !ts.isIdentifier(assignment.left.expression) ||
+    assignment.left.expression.text !== arrayName ||
+    !ts.isIdentifier(assignment.left.argumentExpression) ||
+    assignment.left.argumentExpression.text !== indexName ||
+    !isPureDenseFillRhs(assignment.right, arrayName)
+  ) {
+    return null;
+  }
+  return { arrayName, indexName, bound: condition.right, loop };
+}
+
+function denseFillPlanForLoop(loop: ts.ForStatement): DenseFillPlan | null {
+  const parent = loop.parent;
+  if (!ts.isBlock(parent) && !ts.isSourceFile(parent)) return null;
+  const loopIndex = parent.statements.indexOf(loop);
+  const previous = parent.statements[loopIndex - 1];
+  if (!ts.isVariableStatement(previous) || previous.declarationList.declarations.length !== 1) return null;
+  const initializer = previous.declarationList.declarations[0].initializer;
+  return initializer && ts.isArrayLiteralExpression(initializer) ? denseFillPlanForLiteral(initializer) : null;
+}
+
 /**
  * #1804 — lower a fixed-length, non-spread, non-sparse, same-typed array
  * literal to a `vec.new_fixed` IR node. Out of scope (clean fallback to
@@ -3591,6 +3913,19 @@ function lowerArrayLiteral(expr: ts.ArrayLiteralExpression, cx: LowerCtx, hint: 
     const vecValueType =
       cx.resolver?.resolveVecValueTypeForElement?.(elemVT) ??
       ({ kind: "ref", typeIdx: vec.vecStructTypeIdx } as ValType);
+    const denseFill = denseFillPlanForLiteral(expr);
+    if (denseFill && vecValueType.kind !== "i32") {
+      const bound = lowerExpr(denseFill.bound, cx, irVal({ kind: "f64" }));
+      const allocated = cx.builder.emitCall(
+        irIntrinsicFuncRef(`${VEC_NEW_SIZED_PREFIX}${vec.vecStructTypeIdx}`),
+        [bound],
+        irVal(vecValueType),
+      );
+      if (allocated === null) {
+        throw new Error(`ir/from-ast: sized vec allocation produced no result (${cx.funcName})`);
+      }
+      return allocated;
+    }
     return cx.builder.emitVecNewFixed([], hintElemIr, irVal(vecValueType));
   }
 
@@ -4299,6 +4634,10 @@ function lowerElementStore(lhs: ts.ElementAccessExpression, rhs: ts.Expression, 
   // source semantics wrap).
   if (narrowedI32) {
     const narrowVal = lowerNarrowedI32Element(rhs, cx);
+    if (isProvenInBoundsIr(lhs, cx)) {
+      cx.builder.emitVecSet(recv, idxI32, narrowVal);
+      return;
+    }
     cx.builder.emitCall(irIntrinsicFuncRef(`__vec_elem_set_${vec.vecStructTypeIdx}`), [recv, idxI32, narrowVal], null);
     return;
   }
@@ -4319,6 +4658,10 @@ function lowerElementStore(lhs: ts.ElementAccessExpression, rhs: ts.Expression, 
   // The helper name embeds the vec STRUCT typeIdx; the lower-time resolver
   // intercepts the prefix and materializes the helper on demand (name-based
   // resolution — funcIdx-shift safe by construction).
+  if (isProvenInBoundsIr(lhs, cx)) {
+    cx.builder.emitVecSet(recv, idxI32, val);
+    return;
+  }
   cx.builder.emitCall(irIntrinsicFuncRef(`__vec_elem_set_${vec.vecStructTypeIdx}`), [recv, idxI32, val], null);
 }
 
@@ -7135,7 +7478,7 @@ function literalCounterEntry(stmt: ts.ForStatement, cx: LowerCtx): { value: numb
   return { value, slotIndex: binding.slotIndex };
 }
 
-function lowerForStatement(stmt: ts.ForStatement, cx: LowerCtx): void {
+function lowerForStatement(stmt: ts.ForStatement, cx: LowerCtx, bodyOverride?: (bodyCx: LowerCtx) => void): void {
   if (!stmt.condition) {
     throw new Error(`ir/from-ast: for without cond not in slice 12 (${cx.funcName})`);
   }
@@ -7182,20 +7525,31 @@ function lowerForStatement(stmt: ts.ForStatement, cx: LowerCtx): void {
   // keeps the fast unchecked `vec.get`. Thread the proven pair onto a body-scoped
   // cx (immutable copy → no leak to siblings; nested loops accumulate outward).
   const provenPair = detectCountedLoopSafeIndex(stmt);
+  const denseFill = denseFillPlanForLoop(stmt);
+  const denseFillPair = denseFill ? `${denseFill.arrayName}:${denseFill.indexName}` : null;
   // #2952 slice 2 — the loop's label; the body cx carries it as the
   // innermost break/continue target (a continue jumps to the update).
   const bodyScope = new Map(loopCx.scope);
-  const bodyCx: LowerCtx = provenPair
+  const safePairs =
+    provenPair || denseFillPair
+      ? new Set([
+          ...(loopCx.safeIndexedArrays ?? []),
+          ...(provenPair ? [provenPair] : []),
+          ...(denseFillPair ? [denseFillPair] : []),
+        ])
+      : null;
+  const bodyCx: LowerCtx = safePairs
     ? {
         ...loopCx,
         scope: bodyScope,
-        safeIndexedArrays: new Set([...(loopCx.safeIndexedArrays ?? []), provenPair]),
+        safeIndexedArrays: safePairs,
         loopLabel,
         breakTargetLabel: loopLabel,
       }
     : { ...loopCx, scope: bodyScope, loopLabel, breakTargetLabel: loopLabel };
   const bodyInstrs = loopCx.builder.collectBodyInstrs(() => {
-    lowerStmt(stmt.statement, bodyCx);
+    if (bodyOverride) bodyOverride(bodyCx);
+    else lowerStmt(stmt.statement, bodyCx);
   });
 
   // 4. Update — collect into a buffer (or empty if absent).

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -63,7 +63,12 @@ import {
   emitToNumber as emitCoercionToNumber,
 } from "../codegen/coercion-engine.js";
 import { JsTag, jsTagUnboxKind } from "./js-tag.js";
-import { ensureVecElemSet, VEC_ELEM_SET_PREFIX } from "../codegen/vec-elem-set.js"; // (#2856 C2) on-demand element-store helper
+import {
+  ensureVecElemSet,
+  ensureVecNewSized,
+  VEC_ELEM_SET_PREFIX,
+  VEC_NEW_SIZED_PREFIX,
+} from "../codegen/vec-elem-set.js"; // (#2856 C2) on-demand vec helpers
 import { classMemberFuncKey } from "../codegen/class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import {
   ensureNativeStringHelpers,
@@ -3699,6 +3704,14 @@ function makeResolver(
       if (ref.binding.kind === "intrinsic" && ref.binding.symbol.startsWith(VEC_ELEM_SET_PREFIX)) {
         const vecTypeIdx = Number(ref.binding.symbol.slice(VEC_ELEM_SET_PREFIX.length));
         const helperIdx = Number.isInteger(vecTypeIdx) ? ensureVecElemSet(ctx, vecTypeIdx) : null;
+        if (helperIdx === null) {
+          throw new Error(`ir/integration: cannot materialize ${ref.name} (not a recognisable vec struct)`);
+        }
+        return bindCallableProvider(ref, helperIdx);
+      }
+      if (ref.binding.kind === "intrinsic" && ref.binding.symbol.startsWith(VEC_NEW_SIZED_PREFIX)) {
+        const vecTypeIdx = Number(ref.binding.symbol.slice(VEC_NEW_SIZED_PREFIX.length));
+        const helperIdx = Number.isInteger(vecTypeIdx) ? ensureVecNewSized(ctx, vecTypeIdx) : null;
         if (helperIdx === null) {
           throw new Error(`ir/integration: cannot materialize ${ref.name} (not a recognisable vec struct)`);
         }

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -132,6 +132,7 @@ export type IrFallbackReason =
   | "class-member-unsupported"
   | "external-call" // calls a non-local identifier (parseInt, etc.)
   | "call-graph-closure" // local caller/callee not claimed
+  | "array-presize-legacy" // counted push retains legacy allocation-site capacity proof
   | "recursive-type-evidence" // recursive SCC failed conservative ABI certification
   | "type-resolution-failure" // overrideMap couldn't be built (set externally)
   // #1370 Phase A — class method / constructor of a shape the IR selector
@@ -1417,6 +1418,91 @@ function collectDirectMutationNames(body: ts.Block): ReadonlySet<string> {
   return names;
 }
 
+/**
+ * Keep canonical empty-array push loops on the legacy frontend until the IR
+ * owns an equivalent allocation-site capacity proof.
+ *
+ * Legacy codegen preallocates the backing WasmGC array for this shape. Dense
+ * indexed fills have their own sized IR allocation; counted `.push` still
+ * needs this routing guard.
+ */
+function legacyPresizedArrayLoop(body: ts.Block): ts.ForStatement | null {
+  const statements = body.statements;
+  for (let statementIndex = 0; statementIndex + 1 < statements.length; statementIndex++) {
+    const declarationStatement = statements[statementIndex];
+    const loop = statements[statementIndex + 1];
+    if (!ts.isVariableStatement(declarationStatement) || !ts.isForStatement(loop)) continue;
+    if (declarationStatement.declarationList.declarations.length !== 1) continue;
+    const arrayDeclaration = declarationStatement.declarationList.declarations[0];
+    if (
+      !ts.isIdentifier(arrayDeclaration.name) ||
+      !arrayDeclaration.initializer ||
+      !ts.isArrayLiteralExpression(arrayDeclaration.initializer) ||
+      arrayDeclaration.initializer.elements.length !== 0
+    ) {
+      continue;
+    }
+    const arrayName = arrayDeclaration.name.text;
+
+    const initializer = loop.initializer;
+    if (!initializer || !ts.isVariableDeclarationList(initializer) || initializer.declarations.length !== 1) {
+      continue;
+    }
+    const indexDeclaration = initializer.declarations[0];
+    if (
+      !ts.isIdentifier(indexDeclaration.name) ||
+      !indexDeclaration.initializer ||
+      !ts.isNumericLiteral(indexDeclaration.initializer) ||
+      Number(indexDeclaration.initializer.text) !== 0
+    ) {
+      continue;
+    }
+    const indexName = indexDeclaration.name.text;
+
+    const condition = loop.condition;
+    if (
+      !condition ||
+      !ts.isBinaryExpression(condition) ||
+      condition.operatorToken.kind !== ts.SyntaxKind.LessThanToken ||
+      !ts.isIdentifier(condition.left) ||
+      condition.left.text !== indexName
+    ) {
+      continue;
+    }
+
+    const incrementor = loop.incrementor;
+    if (
+      !incrementor ||
+      (!ts.isPrefixUnaryExpression(incrementor) && !ts.isPostfixUnaryExpression(incrementor)) ||
+      incrementor.operator !== ts.SyntaxKind.PlusPlusToken ||
+      !ts.isIdentifier(incrementor.operand) ||
+      incrementor.operand.text !== indexName
+    ) {
+      continue;
+    }
+
+    const loopStatements = ts.isBlock(loop.statement) ? loop.statement.statements : [loop.statement];
+    if (loopStatements.length !== 1 || !ts.isExpressionStatement(loopStatements[0])) continue;
+    const expression = loopStatements[0].expression;
+
+    // #1001 counted push: the legacy matcher requires a finite literal count.
+    const literalCount = ts.isNumericLiteral(condition.right) ? Number(condition.right.text) : 0;
+    if (
+      literalCount > 0 &&
+      literalCount <= 1_000_000 &&
+      ts.isCallExpression(expression) &&
+      expression.arguments.length === 1 &&
+      ts.isPropertyAccessExpression(expression.expression) &&
+      expression.expression.name.text === "push" &&
+      ts.isIdentifier(expression.expression.expression) &&
+      expression.expression.expression.text === arrayName
+    ) {
+      return loop;
+    }
+  }
+  return null;
+}
+
 function whyNotIrClaimable(
   fn: IrClaimableSubject,
   typeMap: TypeMap | undefined,
@@ -1637,6 +1723,10 @@ function whyNotIrClaimable(
 
   const body = fn.body;
   if (!body) return "body-shape-rejected";
+  const presizedArrayLoop = legacyPresizedArrayLoop(body);
+  if (presizedArrayLoop) {
+    return "array-presize-legacy";
+  }
   if (prepareFunctionBodySelection(fn, scope, body)) return "string-builder-candidate";
   // (#2856 C1) Reset the early-return context for this function's walk.
   earlyReturnLoopDepth = 0;

--- a/tests/issue-1198.test.ts
+++ b/tests/issue-1198.test.ts
@@ -17,6 +17,106 @@ async function compileAndRun(source: string, exportName: string, args: number[] 
 }
 
 describe("#1198 pre-size dense arrays — matching patterns", () => {
+  it("fuses a pure dense fill followed by an i32 sum reduction", async () => {
+    const src = `
+      export function run(n: number): number {
+        const values: number[] = [];
+        for (let i = 0; i < n; i++) {
+          values[i] = ((i * 17) ^ (i >>> 3)) & 1023;
+        }
+        let sum = 0;
+        for (let i = 0; i < values.length; i++) {
+          sum = (sum + values[i]) | 0;
+        }
+        return sum | 0;
+      }
+    `;
+    const compiled = await compile(src, { fileName: "array-sum.ts", emitWat: true });
+    expect(compiled.success, compiled.errors?.[0]?.message).toBe(true);
+    expect(compiled.irCompiledFuncs ?? [], JSON.stringify(compiled.irOutcomes)).toContain("run");
+    expect(compiled.wat).not.toContain("$__vec_new_sized_");
+    expect(compiled.wat).not.toContain("$__vec_elem_set_");
+
+    const imports = buildImports(compiled.imports, undefined, compiled.stringPool);
+    const { instance } = await WebAssembly.instantiate(compiled.binary, imports as any);
+    const run = instance.exports.run as (n: number) => number;
+    expect(run(2000)).toBe(1_018_392);
+    expect(run(0)).toBe(0);
+    expect(run(-1)).toBe(0);
+    expect(run(2.5)).toBe(51);
+  });
+
+  it("keeps allocation-site presizing and direct stores when the array remains observable", async () => {
+    const src = `
+      export function run(n: number): number {
+        const values: number[] = [];
+        for (let i = 0; i < n; i++) {
+          values[i] = ((i * 17) ^ (i >>> 3)) & 1023;
+        }
+        return values.length;
+      }
+    `;
+    const compiled = await compile(src, { fileName: "array-fill-length.ts", emitWat: true });
+    expect(compiled.success, compiled.errors?.[0]?.message).toBe(true);
+    expect(compiled.irCompiledFuncs ?? [], JSON.stringify(compiled.irOutcomes)).toContain("run");
+    expect(compiled.wat).toContain("$__vec_new_sized_");
+    expect(compiled.wat).not.toContain("$__vec_elem_set_");
+
+    const imports = buildImports(compiled.imports, undefined, compiled.stringPool);
+    const { instance } = await WebAssembly.instantiate(compiled.binary, imports as any);
+    const run = instance.exports.run as (n: number) => number;
+    expect(run(2000)).toBe(2000);
+    expect(run(0)).toBe(0);
+    expect(run(-1)).toBe(0);
+    expect(run(2.5)).toBe(3);
+  });
+
+  it("keeps the fused run body when a legacy timing wrapper calls it", async () => {
+    const src = `
+      /** @param {number} n @returns {number} */
+      export function run(n) {
+        const values = [];
+        for (let i = 0; i < n; i++) values[i] = ((i * 17) ^ (i >>> 3)) & 1023;
+        let sum = 0;
+        for (let i = 0; i < values.length; i++) sum = (sum + values[i]) | 0;
+        return sum | 0;
+      }
+      /** @param {number} n @returns {number} */
+      export function warm(n) {
+        const started = performance.now();
+        const result = run(n);
+        return result + performance.now() - started;
+      }
+    `;
+    const compiled = await compile(src, {
+      fileName: "array-sum-warm.js",
+      emitWat: true,
+      target: "wasi",
+      nativeStrings: true,
+      trackIrOutcomes: true,
+    });
+    expect(compiled.success, compiled.errors?.[0]?.message).toBe(true);
+    expect(compiled.irCompiledFuncs ?? [], JSON.stringify(compiled.irOutcomes)).toContain("run");
+  });
+
+  it("keeps nested unsigned-shift bits native inside another bitwise operation", async () => {
+    const src = `
+      export function mix(x: number): number {
+        return ((x >>> 0) ^ 0x12345678) | 0;
+      }
+    `;
+    const compiled = await compile(src, { fileName: "nested-unsigned-shift.ts", emitWat: true });
+    expect(compiled.success, compiled.errors?.[0]?.message).toBe(true);
+    expect(compiled.wat).toContain("i32.shr_u");
+
+    const imports = buildImports(compiled.imports, undefined, compiled.stringPool);
+    const { instance } = await WebAssembly.instantiate(compiled.binary, imports as any);
+    const mix = instance.exports.mix as (x: number) => number;
+    for (const x of [-1, -2147483648, 0, 2147483647]) {
+      expect(mix(x)).toBe(((x >>> 0) ^ 0x12345678) | 0);
+    }
+  });
+
   it("literal-N counted index-assign: const a = []; for (let i = 0; i < 10; i++) a[i] = i*2;", async () => {
     const src = `
       export function run(): number {

--- a/tests/issue-1761.test.ts
+++ b/tests/issue-1761.test.ts
@@ -22,13 +22,13 @@ import { describe, expect, it } from "vitest";
 import binaryen from "binaryen";
 import { compile } from "../src/index.js";
 
-async function compileNative(source: string): Promise<{ wat: string; binary: Uint8Array }> {
-  const result = await compile(source, { fileName: "t.js", target: "wasi", nativeStrings: true });
+async function compileNative(source: string): Promise<{ wat: string; emittedWat: string; binary: Uint8Array }> {
+  const result = await compile(source, { fileName: "t.js", target: "wasi", nativeStrings: true, emitWat: true });
   expect(result.success, `Compile failed: ${result.errors?.map((e) => e.message).join("; ")}`).toBe(true);
   const mod = binaryen.readBinary(result.binary);
   const wat = mod.emitText();
   mod.dispose();
-  return { wat, binary: result.binary };
+  return { wat, emittedWat: result.wat ?? "", binary: result.binary };
 }
 
 /**
@@ -54,6 +54,12 @@ function exportedFuncWat(wat: string, exportName: string): string {
 /** Count of `__str_buf_next_cap` grow calls in `exportName`'s own body — zero means the presize fired. */
 function growCalls(wat: string, exportName = "run"): number {
   return (exportedFuncWat(wat, exportName).match(/call \$__str_buf_next_cap/g) || []).length;
+}
+
+function emittedFunctionWat(wat: string, functionName: string): string {
+  const start = wat.indexOf(`(func $${functionName}`);
+  const end = wat.indexOf("\n  (func ", start + 1);
+  return wat.slice(start, end < 0 ? undefined : end);
 }
 
 async function instantiate(binary: Uint8Array): Promise<WebAssembly.Exports> {
@@ -102,10 +108,21 @@ function jsStringHash(n: number): number {
 
 describe("#1761 — presize string-build buffer from static trip count", () => {
   it("fires on the string-hash build loop (no grow call) and matches JS across trip counts", async () => {
-    const { wat, binary } = await compileNative(STRING_HASH_SOURCE);
+    const { wat, emittedWat, binary } = await compileNative(STRING_HASH_SOURCE);
     // The build loop's final length is provably 3*n → presize fires → the
     // doubling grow helper is gone from the module.
     expect(growCalls(wat), "presize must eliminate the doubling grow path").toBe(0);
+    const emittedRun = emittedFunctionWat(emittedWat, "run");
+    expect(
+      (emittedRun.match(/\bref\.is_null\b/g) ?? []).length,
+      "the hash loop condition must read the builder length local without materializing a string view",
+    ).toBe(1);
+    const mutableAlphabet = await compileNative(STRING_HASH_SOURCE.replace("const alphabet", "let alphabet"));
+    const mutableRun = emittedFunctionWat(mutableAlphabet.emittedWat, "run");
+    expect(
+      (emittedRun.match(/\bref\.cast\b/g) ?? []).length - (mutableRun.match(/\bref\.cast\b/g) ?? []).length,
+      "the two const-literal alphabet.charAt appends must use the proven-flat cast path",
+    ).toBe(2);
 
     const exports = await instantiate(binary);
     const run = exports.run as (n: number) => number;


### PR DESCRIPTION
## Summary

- keep the landing `array-sum.run` function on its fused IR body when the legacy Wasmtime timing wrapper calls it
- pre-size observable dense fills, eliminate the non-escaping fill-and-reduce array, and retain nested bitwise arithmetic as native i32
- bypass repeated native-string flattening for `charAt` on const string-literal bindings
- read detected string-builder lengths directly from their synthetic i32 local
- add exact selection, WAT-shape, behavior, and benchmark-corpus coverage

## Root cause

The real landing warm adapter rejected `array-sum.run` with `call-graph-closure`, despite its exact numeric ABI. The emitted legacy body boxed each addition and repeated full ToInt32 conversion in the million-iteration loop.

The legacy native-string builder was the correct path for `string-hash`, but it flattened the same literal-backed alphabet twice per iteration and materialized a NativeString view merely to evaluate the hash loop's `text.length` condition.

## Same-machine A/B

Using `scripts/generate-wasmtime-hot-runtime.mjs`:

| Benchmark | Main Wasmtime warm | Fixed Wasmtime warm | V8 warm |
| --- | ---: | ---: | ---: |
| Array fill + sum | 21.63 ms | 0.51 ms | 5.03 ms |
| String build + hash | 0.58 ms | 0.16 ms | 0.34 ms |

## Validation

- `pnpm exec vitest run tests/issue-1198.test.ts tests/issue-1761.test.ts tests/issue-3744-ir-owned-append-string-builder.test.ts`
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- `pnpm run check:oracle-ratchet`
- `pnpm run check:coercion-sites`
- pre-commit formatting and Biome lint

Closes #3798.
