### PR TITLE
ci(benchmarks): make regressions advisory

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -306,6 +306,9 @@ jobs:
             --source-sha "$BENCHMARK_SOURCE_SHA"
 
       - name: Compare same-run PR base and candidate
+        # Performance data is advisory. Keep the comparison, artifact, and
+        # step-level failure visible without blocking the PR or merge queue.
+        continue-on-error: true
         if: |
           github.event_name == 'pull_request' &&
           steps.base_measurement.outputs.bootstrap != 'true' &&

--- a/scripts/benchmark-lifecycle.mjs
+++ b/scripts/benchmark-lifecycle.mjs
@@ -169,8 +169,19 @@ function resultPath(root, name) {
 }
 
 function commandVersion(command, args, cwd) {
+  const env = { ...process.env };
+  if (command === "git") {
+    // Git exports repository-scoped variables while running hooks. Let each
+    // child discover the repository from its own cwd instead of inheriting the
+    // caller's checkout, especially for synthetic fixture roots.
+    delete env.GIT_DIR;
+    delete env.GIT_WORK_TREE;
+    delete env.GIT_INDEX_FILE;
+    delete env.GIT_COMMON_DIR;
+  }
   const result = spawnSync(command, args, {
     cwd,
+    env,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -1022,9 +1033,9 @@ export function compareSnapshots(baselineRoot, candidateRoot) {
       ...toolchainNotes(baselineManifest, candidateManifest),
     ],
     informational: [
-      "Wasmtime regression decisions gate the primary AOT lane; Javy and StarlingMonkey are post-merge, change-scoped comparison controls.",
-      "Internal and loadtime runtime regressions gate only when each calibrated sample spans at least 1ms.",
-      "End-to-end loadtime is jointly gated against its JS control; compile-only microtimings remain informational.",
+      "Wasmtime regressions are reported for the primary AOT lane; Javy and StarlingMonkey are post-merge, change-scoped comparison controls.",
+      "Internal and loadtime runtime regressions are classified as substantial only when each calibrated sample spans at least 1ms.",
+      "End-to-end loadtime is jointly compared with its JS control; compile-only microtimings remain informational.",
       "The legacy non-displayed wasm-host-wasmtime-module-size summary is unsupported and excluded from snapshots.",
     ],
   };

--- a/tests/benchmark-lifecycle.test.ts
+++ b/tests/benchmark-lifecycle.test.ts
@@ -3,6 +3,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -300,6 +301,20 @@ describe("benchmark artifact lifecycle", () => {
     ).toThrow(/not a Git checkout/);
   });
 
+  it("does not leak a Git hook's repository environment into synthetic fixture roots", () => {
+    const previousGitDir = process.env.GIT_DIR;
+    process.env.GIT_DIR = execFileSync("git", ["rev-parse", "--absolute-git-dir"], {
+      cwd: resolve(import.meta.dirname, ".."),
+      encoding: "utf8",
+    }).trim();
+    try {
+      expect(() => packageFixture(fixtureRoot())).not.toThrow();
+    } finally {
+      if (previousGitDir === undefined) Reflect.deleteProperty(process.env, "GIT_DIR");
+      else process.env.GIT_DIR = previousGitDir;
+    }
+  });
+
   it("requires every displayed module-size lane for each program", () => {
     const incomplete = fixtureRoot();
     mutateJson(resolve(incomplete, "benchmarks/results/wasm-host-wasmtime-module-size-per-test.json"), (document) =>
@@ -519,6 +534,11 @@ describe("benchmark artifact lifecycle", () => {
     expect(workflow).toContain("- name: Detect benchmark timing methodology migration");
     expect(workflow).toContain("steps.timing_methodology.outputs.changed != 'true'");
     expect(workflow).toContain("- name: Record timing methodology migration");
+    const comparison = workflow.slice(
+      workflow.indexOf("- name: Compare same-run PR base and candidate"),
+      workflow.indexOf("- name: Record timing methodology migration"),
+    );
+    expect(comparison).toContain("continue-on-error: true");
     const promotion = workflow.slice(workflow.indexOf("promote-benchmarks:"));
     expect(promotion).toContain("- name: Checkout trusted measured main revision");
     expect(promotion).toContain("ref: ${{ needs.measure-and-gate.outputs.source_sha }}");


### PR DESCRIPTION
## Summary

- keep same-run performance comparisons and uploaded regression reports visible
- make reported timing regressions advisory instead of blocking pull requests or the merge queue
- preserve the comparator’s nonzero CLI exit for direct automation and tests
- prevent Git hook environment variables from leaking the caller’s repository into benchmark fixture checks

## Why

The npm-compat PR changed no compiler or runtime code, but an isolated noisy `array-sum:cold` measurement blocked it while the warm lane was unchanged. Performance data is useful evidence, but it should not be a merge gate.

## Validation

- `pnpm exec vitest run tests/benchmark-lifecycle.test.ts tests/dogfood/npm-compat-catalog.test.ts tests/issue-3781-npm-perf-lanes.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- repository pre-commit and pre-push hooks
- actual `git commit` hook execution, including the new inherited-`GIT_DIR` regression test
