### PR TITLE
release: v0.67.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.66.0"
+    "@loopdive/js2": "0.67.0"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
Cuts **v0.67.0** via `node scripts/release.mjs 0.67.0`, per [`docs/releasing.md`](../blob/main/docs/releasing.md).

**1,562 commits since v0.66.0** — 252 `fix`, 91 `feat`, 66 `perf`, 64 `refactor`. Minor bump: features, no intentional breaking change.

## What the release commit contains

| file | 0.66.0 → 0.67.0 |
|---|---|
| `package.json` (`@loopdive/js2`) | ✅ |
| `packages/js2wasm/package.json` (proxy) | ✅ |
| proxy dep pin `@loopdive/js2` | `0.67.0` |
| `jsr.json` | ✅ |

Both packages and the proxy's dependency pin carry the **same** concrete version, which is what `publish-npm.yml`'s `verify-version` job enforces (the guard added for loopdive/js2#389, where the tag and `package.json` drifted and `0.52.0` shipped for thousands of commits).

## ⚠️ The tag is NOT pushed

`v0.67.0` is an annotated tag on this branch and exists **only locally** — verified 0 refs on both `fork` and `origin`. Pushing it fires `publish-npm.yml` on whatever it points at, so per the documented flow it stays unpushed until this PR merges. After merge:

```bash
git fetch origin && git push origin v0.67.0
```

The merge queue uses merge commits (`mergeMethod = MERGE`), so the tagged commit stays reachable from `main` and the tag remains valid after merge.

## Conformance note for the release notes

test262 host reads **29,856 / 43,099** at this commit, *lower* than the number quoted at v0.66.0. That is **not a regression**: `ORACLE_VERSION` advanced 10 → 12 in this range (`69493a7`, the declared re-baseline for the #3603 host de-inflation), which removed vacuously-passing rows. The oracle bump *is* the verdict-logic change, so pre- and post-bump counts are different quantities and cannot be differenced. Standalone highwater **22,626**.

Worth stating plainly in the published notes so the drop isn't read as a quality regression.

## Highlights

- **npm compatibility**: sixteen package harnesses plus a public npm-compat page.
- **IR migration**: substantial adoption — structural reference lookup, class call dependencies, source-global storage ownership, bounded free-function components, stable this-bound calls.
- **Honest measurement**: the test262 de-inflation landed, replacing vacuous passes with a real floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSXz9G2eZrfNeX3satN5X