### PR TITLE
plan(sprint): prioritize ES5, Acorn perf, ESLint and React for the current window

### DIFF
--- a/plan/issues/2200-annexb-block-level-function-hoisting.md
+++ b/plan/issues/2200-annexb-block-level-function-hoisting.md
@@ -1,9 +1,8 @@
 ---
 id: 2200
 title: "Annex B B.3.3 block-level function declaration hoisting — outer binding created/initialized incorrectly (~186 test262 fails)"
-status: in-progress
-assignee: ttraenkler/dev-1769
-sprint: 64
+status: ready
+sprint: current
 created: 2026-06-19
 updated: 2026-06-19
 phase1: done

--- a/plan/issues/2552-annexb-phase2-rework-tdz-var-hotpath-regression.md
+++ b/plan/issues/2552-annexb-phase2-rework-tdz-var-hotpath-regression.md
@@ -1,11 +1,10 @@
 ---
 id: 2552
 title: "Annex B B.3.3 Phase 2 rework — TDZ-var outer-binding allocation perturbs hot-path codegen (-1180 test262 regression)"
-status: in-progress
-sprint: 64
+status: ready
+sprint: current
 created: 2026-06-19
-assignee: ttraenkler/sendev-funcidx
-priority: medium
+priority: high
 feasibility: hard
 reasoning_effort: max
 task_type: bugfix

--- a/plan/issues/2668-es5-object-defineproperty-descriptor-fidelity-residual.md
+++ b/plan/issues/2668-es5-object-defineproperty-descriptor-fidelity-residual.md
@@ -1,8 +1,7 @@
 ---
 id: 2668
 title: "ES5: Object.defineProperty/defineProperties descriptor fidelity residual (~788 fails — largest ES5 cluster)"
-status: in-progress
-assignee: ttraenkler/sd-2668c
+status: ready
 created: 2026-06-25
 updated: 2026-06-26
 priority: high
@@ -14,7 +13,7 @@ es_edition: 5
 language_feature: property-descriptors
 goal: es5
 related: [1460, 1462, 929]
-sprint: 67
+sprint: current
 ---
 # #2668 — ES5 Object.defineProperty/defineProperties descriptor fidelity residual
 

--- a/plan/issues/2670-es6-array-prototype-iteration-method-semantics-residual.md
+++ b/plan/issues/2670-es6-array-prototype-iteration-method-semantics-residual.md
@@ -1,8 +1,7 @@
 ---
 id: 2670
 title: "ES2015: Array.prototype iteration-method semantics residual (~1017 fails — generic array-like receiver, callback/thisArg, holes, length coercion)"
-status: in-progress
-assignee: sd-2670
+status: ready
 created: 2026-06-25
 updated: 2026-06-25
 priority: high
@@ -14,7 +13,7 @@ es_edition: 5
 language_feature: array-methods
 goal: spec-completeness
 related: [2177, 2151, 473, 2580]
-sprint: 67
+sprint: current
 ---
 # #2670 — ES2015 Array.prototype iteration-method semantics residual
 

--- a/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
+++ b/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
@@ -1,8 +1,7 @@
 ---
 id: 2742
 title: "String.prototype methods: ToString(this) generic-receiver coercion, RequireObjectCoercible, and function `.length` own property"
-status: in-progress
-assignee: ttraenkler/opus-loop-d
+status: ready
 sprint: current
 created: 2026-06-27
 updated: 2026-07-28

--- a/plan/issues/2747-forin-fnctor-prototype-chain-and-defineproperty-array-order.md
+++ b/plan/issues/2747-forin-fnctor-prototype-chain-and-defineproperty-array-order.md
@@ -1,9 +1,8 @@
 ---
 id: 2747
 title: "for-in: constructor-function prototype-chain enumeration (S12.6.4_A6*) + Object.defineProperty array+accessor ordering"
-status: in-progress
-assignee: ttraenkler/issue-2747-reflect-setprototypeof-mirror
-sprint: Backlog
+status: ready
+sprint: current
 goal: es5
 feasibility: hard
 depends_on: []

--- a/plan/issues/3475-logical-and-assign-externref-truthy-branch-not-taken.md
+++ b/plan/issues/3475-logical-and-assign-externref-truthy-branch-not-taken.md
@@ -5,7 +5,7 @@ status: ready
 sprint: current
 created: 2026-07-20
 updated: 2026-07-21
-priority: medium
+priority: high
 horizon: m
 feasibility: hard
 reasoning_effort: high

--- a/plan/issues/3631-eval-completion-value-non-expression-last-statement.md
+++ b/plan/issues/3631-eval-completion-value-non-expression-last-statement.md
@@ -4,7 +4,7 @@ title: "eval returns `undefined` when the last statement is not an ExpressionSta
 status: ready
 sprint: current
 goal: es5
-priority: medium
+priority: high
 horizon: m
 feasibility: medium
 ---

--- a/plan/issues/3653-eslint-tests-portable-nonvacuous-paths.md
+++ b/plan/issues/3653-eslint-tests-portable-nonvacuous-paths.md
@@ -1,4 +1,5 @@
 ---
+horizon: m
 id: 3653
 title: "ESLint integration tests: portable dependency paths and non-vacuous skip semantics"
 status: ready
@@ -11,7 +12,7 @@ task_type: test
 area: test-infrastructure
 language_feature: npm-package-integration
 goal: npm-library-support
-sprint: 76
+sprint: current
 required_by: [1400]
 es_edition: n/a
 related: [1282, 1400, 1573, 2693]

--- a/plan/issues/3654-compileproject-eslint-package-context-resolution.md
+++ b/plan/issues/3654-compileproject-eslint-package-context-resolution.md
@@ -1,4 +1,5 @@
 ---
+horizon: m
 id: 3654
 title: "compileProject ESLint graph: resolve importer-scoped deps and extensionless CJS modules"
 status: ready
@@ -11,7 +12,7 @@ task_type: bugfix
 area: module-resolution
 language_feature: commonjs-module-resolution
 goal: npm-library-support
-sprint: 76
+sprint: current
 required_by: [1400, 2691]
 es_edition: n/a
 related: [81, 1044, 1279, 1400, 1559, 1560, 1575, 1791, 2691, 2700, 3653, 3655]

--- a/plan/issues/3655-compileproject-static-json-require.md
+++ b/plan/issues/3655-compileproject-static-json-require.md
@@ -1,4 +1,5 @@
 ---
+horizon: m
 id: 3655
 title: "compileProject allowJs: support static CommonJS require of JSON modules"
 status: ready
@@ -11,7 +12,7 @@ task_type: feature
 area: resolver, codegen
 language_feature: json-modules
 goal: npm-library-support
-sprint: 76
+sprint: current
 required_by: [1400, 2691]
 es_edition: n/a
 related: [1279, 1400, 1575, 2691, 2693, 3654]

--- a/plan/issues/3656-ir-dynamic-object-destructuring-eslint-flags.md
+++ b/plan/issues/3656-ir-dynamic-object-destructuring-eslint-flags.md
@@ -1,4 +1,5 @@
 ---
+horizon: m
 id: 3656
 title: "IR: dynamic destructured parameter blocks ESLint getInactivityReasonMessage"
 status: ready
@@ -11,7 +12,7 @@ task_type: bugfix
 area: ir, codegen
 language_feature: object-destructuring
 goal: npm-library-support
-sprint: 76
+sprint: current
 required_by: [1400, 2691]
 es_edition: ES2015
 related: [1169c, 1400, 2691, 3518, 3654]

--- a/plan/issues/3657-ir-ambient-boolean-host-call-eslint-seam.md
+++ b/plan/issues/3657-ir-ambient-boolean-host-call-eslint-seam.md
@@ -1,4 +1,5 @@
 ---
+horizon: m
 id: 3657
 title: "IR: ambient boolean host call rejected in ESLint Linter class method"
 status: ready
@@ -11,7 +12,7 @@ task_type: bugfix
 area: ir, host-interop
 language_feature: ambient-functions
 goal: npm-library-support
-sprint: 76
+sprint: current
 es_edition: ES2015
 related: [1371, 2693, 2781, 3325, 3518, 3653]
 ---

--- a/plan/issues/3663-properties-over-restricted-configurable-writable-wrongly-false.md
+++ b/plan/issues/3663-properties-over-restricted-configurable-writable-wrongly-false.md
@@ -5,7 +5,7 @@ status: ready
 sprint: current
 created: 2026-07-26
 updated: 2026-07-26
-priority: medium
+priority: high
 horizon: s
 complexity: S
 feasibility: medium

--- a/plan/issues/3672-eslint-linter-resolved-graph-codegen-timeout.md
+++ b/plan/issues/3672-eslint-linter-resolved-graph-codegen-timeout.md
@@ -1,4 +1,5 @@
 ---
+horizon: m
 id: 3672
 title: "ESLint linter.js: resolved 149-file graph exhausts a 2 GB compiler heap"
 status: ready
@@ -11,7 +12,7 @@ task_type: performance
 area: compiler, codegen, observability
 language_feature: multi-module-compilation
 goal: npm-library-support
-sprint: 76
+sprint: current
 required_by: [1400, 2693]
 es_edition: n/a
 related: [824, 1282, 1400, 1573, 1942, 3654, 3655, 3656, 3657]

--- a/plan/issues/3683-typed-this-monomorphization.md
+++ b/plan/issues/3683-typed-this-monomorphization.md
@@ -10,7 +10,7 @@ reasoning_effort: max
 task_type: perf
 area: codegen
 goal: value-rep
-sprint: Backlog
+sprint: current
 related: [3673, 1946, 1947, 1584]
 loc-budget-allow:
   - src/codegen/fnctor-escape-gate.ts

--- a/plan/issues/3684-cross-engine-axis-decomposition.md
+++ b/plan/issues/3684-cross-engine-axis-decomposition.md
@@ -4,7 +4,7 @@ title: "perf: what actually makes node and Porffor faster — per-axis decomposi
 status: ready
 created: 2026-07-27
 updated: 2026-07-27
-priority: medium
+priority: high
 feasibility: medium
 reasoning_effort: high
 task_type: perf

--- a/plan/issues/3768-standalone-object-create-prototype-validation.md
+++ b/plan/issues/3768-standalone-object-create-prototype-validation.md
@@ -5,7 +5,7 @@ status: ready
 sprint: current
 created: 2026-07-28
 updated: 2026-07-28
-priority: medium
+priority: high
 horizon: s
 complexity: S
 feasibility: high

--- a/plan/issues/3801-react-upstream-unit-tests.md
+++ b/plan/issues/3801-react-upstream-unit-tests.md
@@ -1,0 +1,82 @@
+---
+id: 3801
+title: "Run React's own upstream unit tests against compiled React, and make them pass"
+status: ready
+created: 2026-07-31
+priority: high
+horizon: xl
+feasibility: hard
+task_type: feature
+area: dogfood
+goal: compilable
+sprint: current
+related: [1033, 1576, 3835, 3843, 3840]
+---
+
+# #3801 — dogfood React with React's OWN test suite
+
+## Why
+
+We currently validate compiled React with **vectors we wrote ourselves**
+(#3835 added upstream API vectors; #3843 fixed element APIs; #3840 bound host
+data bridges). Self-authored vectors share the author's blind spots: they assert
+what we already believed worked. React's own unit tests were written by people
+who knew where React is fragile, and they encode behaviour we would never think
+to check.
+
+This is the same argument as the test262 de-inflation (#3603): a suite we
+control can silently drift toward vacuity, and only an **external, adversarial**
+suite tells us where we actually are.
+
+## Scope
+
+Take the unit tests from the upstream repository (`facebook/react`, matching the
+React version already vendored for the dogfood harness — pin the exact tag) and
+run them against **React compiled by js2wasm**, not against stock React.
+
+Out of scope for this issue: making all of them pass. The deliverable is an
+honest, running, **non-vacuous** harness plus a measured baseline. Fixes follow
+as child issues.
+
+## The vacuity trap — read before reporting any number
+
+React's tests use Jest (`expect`, `jest.mock`, `act`, custom matchers, snapshot
+serializers). Every one of those is a place a test can **appear** to pass while
+asserting nothing:
+
+- a test whose `expect` never executes because setup threw and was swallowed
+- a suite that reports 0 tests but exits 0
+- a snapshot that silently writes a NEW snapshot instead of comparing
+- an `act()` wrapper that no-ops so effects never flush
+
+Before any pass count is quoted, prove the harness can **fail**: deliberately
+break an assertion and confirm the run goes red. Report `passed / attempted /
+total-discovered` with all three denominators, never a bare percentage. See
+`reference_verifyproperty_vacuous_both_lanes_two_root_causes` and #3592.
+
+## Steps
+
+1. Pin the upstream tag and vendor (or submodule) the test sources; record the
+   exact commit sha in this issue.
+2. Stand up a runner that resolves `react` / `react-dom` to the **js2wasm-compiled**
+   build. Decide explicitly whether Jest itself runs on node (recommended first
+   step — isolates "does compiled React behave" from "can we compile Jest").
+3. **Prove non-vacuity** (see above) before recording anything.
+4. Record the baseline: discovered / attempted / passed, plus a bucketed failure
+   census by root cause, not by test name.
+5. File child issues per failure cluster above a threshold.
+
+## Acceptance
+
+- Upstream React tests execute against compiled React, from a pinned sha.
+- A deliberately-broken assertion turns the run red (non-vacuity proven, and the
+  proof is committed as a permanent check per #2093).
+- A committed baseline with all three denominators.
+- Failure clusters filed as child issues.
+
+## Notes
+
+- Expect a large initial failure count. That is the point — it is a **measurement**,
+  not a regression. Do not tune the harness to make the number look better.
+- Coordinate with #1033 (compile React to Wasm) and #1576 (React Tier 1 survey);
+  this issue is the acceptance instrument those two lack.

--- a/plan/issues/sprints/current.md
+++ b/plan/issues/sprints/current.md
@@ -7,6 +7,38 @@ updated: 2026-07-21
 
 # Current budget window — FOCUS: complete the IR-only migration
 
+## Stakeholder directive (2026-07-31) — ES5 · Acorn perf · ESLint · React
+
+Supersedes the 2026-07-21 IR-only ordering **for new pulls**. The IR migration
+continues as the substrate it always was; these four are what the window is
+judged on:
+
+1. **ES5 compatibility** — close the descriptor/coercion/enumeration residual.
+   `#3776 #3661 #3662 #3420 #3475 #3663 #3768 #3631` plus the reclaimed
+   `#2200 #2668 #2670 #2742 #2747 #2552`.
+2. **Acorn performance** — compiled Acorn is still ~400–500× native at real-file
+   scale (#3756). `#3756 #3675 #3782 #3780 #3686 #3685 #3684 #3683 #3730`.
+3. **ESLint** — continue PR #3687 (`codex/1400-eslint-e2e`, currently DIRTY +
+   held, and it *records* a known regression: the full graph no longer compiles
+   after the merge). Six criticals were stranded on the closed `sprint: 76` and
+   are pulled forward: `#3653 #3654 #3655 #3656 #3657 #3672`.
+4. **React** — `#3801`, new: run React's OWN upstream unit tests against
+   compiled React. Self-authored vectors share our blind spots.
+
+### Reclaimed stalled work
+
+`#2200 #2552 #2668 #2670 #2742 #2747` sat `in-progress` on closed sprints (64/67
+/Backlog) with no open PR and their agents long gone — stalled claims, not live
+work. Reset to `ready` and pulled into this window so they can actually be
+claimed. See the sprint 77 retro for why stalled claims accumulate.
+
+### Standing rule for this window
+
+Report `passed / attempted / total` with all three denominators. A suite we
+control drifts toward vacuity; prove a harness can go red before quoting any
+number from it (#3592, #2093).
+
+
 > **Stakeholder directive (2026-07-21).** Drive the IR migration through an
 > IR-only default and retire direct codegen. This supersedes the June 30
 > ordering for new pulls. Standalone correctness remains a protected parallel

--- a/scripts/sync-current-tasklist.mjs
+++ b/scripts/sync-current-tasklist.mjs
@@ -72,7 +72,7 @@ const VERB = {
   docs: "docs",
   test: "test",
 };
-const PRIO_TAG = { high: "[P1]", medium: "[P2]", low: "[P3]" };
+const PRIO_TAG = { critical: "[P0]", high: "[P1]", medium: "[P2]", low: "[P3]" };
 
 function log(s) {
   if (!QUIET) console.log(s);


### PR DESCRIPTION
Stakeholder directive 2026-07-31. Supersedes the 2026-07-21 IR-only ordering **for new pulls**; the IR migration continues as the substrate it always was.

## Four lanes

1. **ES5 compatibility** — descriptor/coercion/enumeration residual: `#3776 #3661 #3662 #3420 #3475 #3663 #3768 #3631`
2. **Acorn performance** — compiled Acorn is still ~400–500× native at real-file scale (`#3756`): `#3756 #3675 #3782 #3780 #3686 #3685 #3684 #3683 #3730`
3. **ESLint** — continue PR #3687 (`codex/1400-eslint-e2e`, DIRTY + held, and it *records* a regression it does not fix: the full graph no longer compiles after the merge)
4. **React** — files **#3801**: run React's OWN upstream unit tests against compiled React

## The finding that actually mattered

**Six `critical` ESLint issues (#3653 #3654 #3655 #3656 #3657 #3672) were stranded on the CLOSED `sprint: 76`.** `sync-current-tasklist.mjs` only surfaces `sprint: current`, so these had been structurally invisible to every agent pulling from the queue — not deprioritised, *unreachable*. Pulled into `current`.

## A ranking bug this exposed

`PRIO_TAG` in `sync-current-tasklist.mjs` had only `high`/`medium`/`low`, so **`priority: critical` fell through to the `|| "[P2]"` default — critical sorted BELOW high** in the queue agents pull from. 15 tasks were mis-ranked, including all six ESLint criticals and `#2039`/`#3406`/`#779`. Fixed by adding `critical: "[P0]"`.

## Reclaimed stalled work

`#2200 #2552 #2668 #2670 #2742 #2747` sat `in-progress` on closed sprints 64/67/Backlog with no open PR and their agents long gone — stalled claims, not live work. Reset to `ready` and pulled forward. The sprint 77 retro covers why these accumulate.

## #3801 — React's own tests

We validate compiled React with vectors **we wrote**, which share our blind spots. React's own tests were written by people who knew where React is fragile. The issue carries an explicit vacuity warning: Jest has many ways to pass while asserting nothing (swallowed setup, 0 tests discovered, snapshots written instead of compared, no-op `act()`), so it requires proving the harness can go red before any number is quoted, and reporting `passed / attempted / discovered` — never a bare percentage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSXz9G2eZrfNeX3satN5X
