### PR TITLE
docs(#3876): file the prototype-alias reflection defect

### DIFF
--- a/plan/issues/3876-prototype-alias-destroys-reflection-identity.md
+++ b/plan/issues/3876-prototype-alias-destroys-reflection-identity.md
@@ -1,0 +1,141 @@
+---
+id: 3876
+slug: prototype-alias-destroys-reflection-identity
+title: "Aliasing a built-in prototype through a local binding destroys its reflection identity"
+status: ready
+created: 2026-07-31
+updated: 2026-07-31
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: reflection, object-model
+language_feature: property-reflection
+goal: standalone-mode
+sprint: current
+es_edition: es5
+related: [1781, 3254]
+---
+
+# #3876 — `var P = X.prototype` destroys reflection identity
+
+## Problem
+
+Binding a built-in prototype to a local variable before reflecting on it
+returns a different (wrong) answer than reflecting on it inline. Same object,
+same property; the only difference is whether the receiver went through a local
+binding.
+
+**Affects BOTH lanes** — this is not standalone-only.
+
+## Measured (2026-07-31, `origin/main` `af7d6f87`)
+
+Apparatus: bare `compile(src, {target})` + `buildImports`, **no test262
+frontmatter and no harness assembly**, so no test-harness code is in the
+measurement path. Probe: `.tmp/reconcile4.mts`.
+
+```
+                                                      host   standalone
+INLINE gOPD(RegExp.prototype,'global')                1      1
+VAR    P=RegExp.prototype; gOPD(P,'global')           1      0   <- DIFF
+INLINE gOPD(RegExp.prototype,'exec')                  1      1
+VAR    P=RegExp.prototype; gOPD(P,'exec')             1      0   <- DIFF
+INLINE RegExp.prototype.hasOwnProperty('exec')        1      0
+VAR    P=RegExp.prototype; P.hasOwnProperty('exec')   1      0
+INLINE Array.prototype.hasOwnProperty('push')         1      1
+VAR    P=Array.prototype; P.hasOwnProperty('push')    0      0   <- BOTH LANES
+```
+
+The `Array.prototype` row is the clearest case: `hasOwnProperty('push')` is
+correct (1) inline on both lanes, and wrong (0) on both lanes once the receiver
+is a local binding.
+
+## Why this matters beyond the row count
+
+It is a **measurement hazard as well as a defect**. It silently explains a
+harness-vs-bare disagreement that consumed several exchanges between two agents
+before it was isolated: one probe used `var P = RegExp.prototype` and the other
+used the inline form, and the two apparatuses were blamed before the receiver
+shape was.
+
+## Size — measured, not inferred
+
+`dev-es5-coercion` counted the `(var|let|const) X = <Builtin>[.prototype]`
+idiom across the full 866-row ES5 standalone wrong-answer cut:
+**14 / 866 = 1.6 %**.
+
+- Carry as **~14–25 rows, floor 14**.
+- The detector misses aliases via parameter passing, property reads, and
+  multi-step assignment, so 14 is a floor, not an exact count.
+- An earlier claim by this author that the idiom is "near-universal in
+  Sputnik-era tests" was an unmeasured structural inference and is **withdrawn**
+  — it was counted and it is 1.6 %.
+
+## Interaction with the lookup-registration fix
+
+The nine `RegExp/prototype/{global,ignoreCase,multiline}` × `{A8,A9,A10}` rows
+all open with `var __re = RegExp.prototype;` (e.g. `S15.10.7.2_A8.js`). They
+therefore need **both** the lookup-registration fix **and** this one. A
+"replicate the `Array.prototype` registration" fix alone will **not** move them,
+and would surface as a mystery half-fix after implementation.
+
+By contrast, the ~20 `Object/define*` descriptor rows use
+`Object.defineProperty(Array.prototype, …)` **inline** — all 20 verified, 0
+aliased. They are unaffected by this issue.
+
+## Related but DISTINCT — inline object-literal argument to `gOPD`
+
+Recorded here deliberately rather than folded in, because it is a separate
+observation.
+
+```
+                                              host   standalone
+gOPD   ({a:1},'a') truthy                     0      1     <- WRONG on host
+gOPD   ({a:1},'a') === undefined              1      0     <- WRONG on host
+gOPD   var o={a:1}; gOPD(o,'a') truthy        1      1     <- CORRECT
+gOPD   ({a:1},'zz') === undefined             1      1     <- CORRECT
+hasOwn ({a:1}).hasOwnProperty('a')            1      1     <- CORRECT
+propIsEnum ({a:1}).propertyIsEnumerable('a')  1      1     <- CORRECT
+```
+
+`Object.getOwnPropertyDescriptor` with an **inline object literal** argument
+returns `undefined` on host; binding the literal to a variable first returns a
+real descriptor. This is the **same receiver-expression-shape axis, inverted**:
+for built-in prototypes inline works and the variable fails; for an object
+literal argument to `gOPD` inline fails and the variable works.
+
+Two consequences:
+
+1. It is a real host-lane defect, not a harness limitation.
+2. **Instrument rule**: any probe passing an inline object/array literal
+   directly as an argument is suspect under bare `compile()` — bind it to a
+   variable first. Both of the broken controls that confused this investigation
+   were of exactly this shape.
+
+An earlier framing of this as "the host lane has per-route reflection bugs" was
+wrong about the axis: it is receiver expression shape, not route.
+
+## Acceptance criteria
+
+- `var P = X.prototype; P.hasOwnProperty(k)` agrees with
+  `X.prototype.hasOwnProperty(k)` for every built-in prototype, on both lanes.
+- `var P = X.prototype; Object.getOwnPropertyDescriptor(P, k)` agrees with the
+  inline form.
+- `Object.getOwnPropertyDescriptor({a:1},'a')` returns a real descriptor on
+  host (the related-but-distinct defect above), or that defect is split into its
+  own issue with this one citing it.
+- `tests/issue-3876.test.ts` permanently covers inline-vs-variable receiver
+  parity for `hasOwnProperty` and `getOwnPropertyDescriptor` across at least
+  `Array.prototype` and `RegExp.prototype`, on both lanes.
+- Any pass-count claim is re-measured per row rather than read off the baseline.
+
+## Not in scope
+
+- **Lookup registration** — `hasOwnProperty` returns 0 for RegExp/String/Object
+  prototypes even inline, while `Array.prototype` returns 1. `Array.prototype`
+  is a genuine working reference for that route. Separate issue.
+- **Enumeration** — `getOwnPropertyNames().length` is a constant 6 in standalone
+  for Array/RegExp/String/Object prototypes vs host 40/15/52/12. Broken for
+  `Array.prototype` too, so there is **no** working reference for that route.
+  Separate issue, harder.


### PR DESCRIPTION
Files **#3876**, the third defect found while decomposing the ES5 standalone reflection cluster. Issue file only — no code change.

## The defect

Binding a built-in prototype to a local variable before reflecting on it returns a different answer than reflecting on it inline. Same object, same property; the only difference is the local binding. **Affects both lanes.**

```
                                                      host   standalone
INLINE Array.prototype.hasOwnProperty('push')         1      1
VAR    P=Array.prototype; P.hasOwnProperty('push')    0      0   <- BOTH LANES
INLINE gOPD(RegExp.prototype,'exec')                  1      1
VAR    P=RegExp.prototype; gOPD(P,'exec')             1      0
INLINE gOPD(RegExp.prototype,'global')                1      1
VAR    P=RegExp.prototype; gOPD(P,'global')           1      0
```

Measured with bare `compile(src, {target})` + `buildImports` — **no test262 frontmatter, no harness assembly** — so no harness code is in the measurement path.

## Why it is worth its own issue

It is a **measurement hazard as well as a defect**. It silently explains a harness-vs-bare disagreement that two agents spent several exchanges attributing to their instruments before the receiver shape was isolated. Both harnesses were exonerated.

## Size — measured, not inferred

The `(var|let|const) X = <Builtin>[.prototype]` idiom is **14 / 866 = 1.6 %** of the ES5 standalone wrong-answer cut (counted by `dev-es5-coercion`). Carried as **~14–25 rows, floor 14** — the detector misses parameter-passing, property-read, and multi-step aliases.

An earlier claim by this author that the idiom is "near-universal in Sputnik-era tests" was an unmeasured structural inference and is **explicitly withdrawn in the issue**. It was counted, and it is 1.6 %.

## Load-bearing for routing

The nine `RegExp/prototype/{global,ignoreCase,multiline}` × `{A8,A9,A10}` rows all open with `var __re = RegExp.prototype;`. They need **this fix and the lookup-registration fix**. Replicating the `Array.prototype` registration alone will not move them — it would surface as a mystery half-fix after implementation.

The ~20 `Object/define*` descriptor rows use `Object.defineProperty(Array.prototype, …)` inline (all 20 verified, 0 aliased) and are unaffected.

## Related but distinct, recorded without folding in

`Object.getOwnPropertyDescriptor` with an **inline object-literal** argument returns `undefined` on host; bind the literal to a variable first and it returns a real descriptor. Same receiver-expression-shape axis, inverted.

That yields an instrument rule the issue records: **any probe passing an inline object/array literal directly as an argument is suspect under bare `compile()` — bind it first.** Both broken controls that derailed this investigation were exactly that shape.

## Explicitly out of scope

- **Lookup registration** — `hasOwnProperty` returns 0 for RegExp/String/Object prototypes even inline, while `Array.prototype` returns 1. `Array.prototype` is a genuine working reference for that route.
- **Enumeration** — `getOwnPropertyNames().length` is a constant 6 in standalone for Array/RegExp/String/Object prototypes vs host 40/15/52/12. Broken for `Array.prototype` too, so there is **no** working reference. Separate and harder.

Refs #1781 #3254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
