### PR TITLE
docs(#3879,#3880): umbrella false-STOP, and claim-wedge frequency evidence

### DIFF
--- a/plan/issues/3879-pre-dispatch-gate-false-stops.md
+++ b/plan/issues/3879-pre-dispatch-gate-false-stops.md
@@ -55,15 +55,59 @@ subject carries a conventional-commit prefix **other than `docs(`** — e.g.
 escalate. #3688 was dispatched as live work while `8b4d74f1 perf(#3688): …` was
 already an ancestor of main, with 18 test pins.
 
+## 4. An UMBRELLA citing its own children is treated as ownership
+
+**An umbrella issue cites every one of its children by design — that is what an
+umbrella *is*.** The overlap check does not know that, so it reports each citation
+as `ACTIVE overlap — … Another agent may already own this work as a slice.`
+
+Consequence: **every child of every active umbrella is permanently un-startable.**
+Not a policy anyone chose, and it scales with the number of umbrellas.
+
+### Measured on a single real gating run (2026-07-31)
+
+Looking for one L/XL `standalone` task, seven candidates were gated. Umbrella
+**#2860** (`standalone-vs-js-host-test262-gap-umbrella`, `in-progress`) alone
+produced a BLOCKER on **three** of them:
+
+| issue | claim record on `origin/issue-assignments` | blocked by |
+| --- | --- | --- |
+| #2865 | hard claim (`fable-2865`) | — genuinely owned |
+| #2872 | hard claim (`dev-std-2`) | — genuinely owned |
+| **#2916** | **does not exist** | **#2860 citation only** |
+
+#2916 had **no claimant at all** and was still reported STOP. Verified with a
+control, per the silent-empty rule: the ref is populated with 20+ neighbouring
+claim files (2900, 2903, 2906, 2910–2914, 2920–2932…), so `2916.json` being
+absent is a real absence rather than an unfetched or broken ref.
+
+The task was ultimately dispatched by a human overriding the gate — which is the
+failure mode: a correct gate should not need routine override to release
+unowned work.
+
+### Proposed rule
+
+Skip the citation-overlap check when the referencing issue is an umbrella
+(`umbrella:` frontmatter, or an `[EPIC]`/umbrella title tag). An umbrella
+citation carries **no** ownership information about the child; only the claim
+ref and open PRs do.
+
 ## Why these matter together
 
-All three cause the same outcome from opposite directions: **an agent is either sent
+All four cause the same outcome from opposite directions: **an agent is either sent
 at work that is already done, or turned away from work that is available.** Both waste
 a full measurement cycle, and both happened repeatedly on 2026-07-30/31.
+
+Note the asymmetry in cost: a false *clear* wastes one agent's cycle, while a false
+STOP can strand a task indefinitely, because each successive agent hits the same
+STOP and moves on. Nothing in the system notices work that is never started.
 
 ## Acceptance
 
 - A `released`/`done` claim record does not produce a BLOCKER.
 - A PR that *modifies* an issue file is surfaced by the open-PR scan.
 - A merged non-`docs` `type(#N):` commit on main escalates above a warning.
+- **A citation from an umbrella issue does not produce a BLOCKER.** Re-running the
+  gate on #2916 returns clear (it has no claimant); #2865 and #2872 still STOP,
+  on their real claim records rather than on the #2860 citation.
 - Re-running the gate on #3420 and #2742 returns clear, and on #3654 surfaces #3687.

--- a/plan/issues/3880-claim-issue-ref-lock-wedge.md
+++ b/plan/issues/3880-claim-issue-ref-lock-wedge.md
@@ -58,12 +58,42 @@ failure is legible without relying on the caller's pipe discipline.
 4. Document `set -o pipefail` / `${PIPESTATUS[0]}` in the dev protocol — pipe-swallowed
    exit codes bit this repo three times in one session.
 
+## Frequency evidence — one agent, one session, 2026-07-31
+
+A single anecdote is a flake; this is a rate. All from **one** agent's session:
+
+| # | invocation | outcome |
+| --- | --- | --- |
+| 1 | `claim 3420` | hung ~10 min at 0:00 CPU, killed |
+| 2 | `claim 3420` (retry) | died on `cannot lock ref 'refs/claim-issue/base'` — concurrent agent moved the shared mirror |
+| 3 | `claim 3420` (foreground) | `timeout 280` exceeded, exit 124 |
+| 4 | `claim 3420` (background) | still running after ~15 min; abandoned, work proceeded **unclaimed** on the record's `status: released` |
+| 5 | `--allocate` | wedged ~10 min, then **succeeded** → reserved #3885 |
+| 6 | `claim 2916 --no-pr-scan` | succeeded (minutes, backgrounded) |
+
+**Four wedges plus two slow successes in one session**, each stall in the
+5–15 minute range. Two other agents were observed in the same state concurrently
+(`3661`, `3672`, `3655`), so it is fleet-wide contention rather than one bad
+checkout.
+
+**The concrete cost:** #3420 was implemented and merged with **no claim record
+ever taken** — the protection this tool exists to provide was simply absent for
+that task, and the only thing preventing duplicate work was a human noticing.
+
+The shared `refs/claim-issue/base` mirror is implicated: every agent fetches
+into the *same* ref, so N concurrent claims contend on one lock. Failure 2 is
+that collision surfacing directly.
+
 ## Why priority high
 
 The lock is **advisory**. A standing instruction now says an advisory lock that
 cannot be acquired in a few minutes must not stop work — verify the record's `status`
 directly and proceed. But that is a workaround: the lock exists to prevent duplicate
 dispatch, and while it is wedged the fleet is running without that protection.
+
+And the workaround has a sharp edge: "proceed if the record says `released`"
+is only safe because the *reader* path works. If a wedge ever produced a stale
+**read**, two agents could both see `released` and both start.
 
 ## Acceptance
 

--- a/plan/issues/3880-claim-issue-ref-lock-wedge.md
+++ b/plan/issues/3880-claim-issue-ref-lock-wedge.md
@@ -58,32 +58,6 @@ failure is legible without relying on the caller's pipe discipline.
 4. Document `set -o pipefail` / `${PIPESTATUS[0]}` in the dev protocol — pipe-swallowed
    exit codes bit this repo three times in one session.
 
-## Frequency evidence — one agent, one session, 2026-07-31
-
-A single anecdote is a flake; this is a rate. All from **one** agent's session:
-
-| # | invocation | outcome |
-| --- | --- | --- |
-| 1 | `claim 3420` | hung ~10 min at 0:00 CPU, killed |
-| 2 | `claim 3420` (retry) | died on `cannot lock ref 'refs/claim-issue/base'` — concurrent agent moved the shared mirror |
-| 3 | `claim 3420` (foreground) | `timeout 280` exceeded, exit 124 |
-| 4 | `claim 3420` (background) | still running after ~15 min; abandoned, work proceeded **unclaimed** on the record's `status: released` |
-| 5 | `--allocate` | wedged ~10 min, then **succeeded** → reserved #3885 |
-| 6 | `claim 2916 --no-pr-scan` | succeeded (minutes, backgrounded) |
-
-**Four wedges plus two slow successes in one session**, each stall in the
-5–15 minute range. Two other agents were observed in the same state concurrently
-(`3661`, `3672`, `3655`), so it is fleet-wide contention rather than one bad
-checkout.
-
-**The concrete cost:** #3420 was implemented and merged with **no claim record
-ever taken** — the protection this tool exists to provide was simply absent for
-that task, and the only thing preventing duplicate work was a human noticing.
-
-The shared `refs/claim-issue/base` mirror is implicated: every agent fetches
-into the *same* ref, so N concurrent claims contend on one lock. Failure 2 is
-that collision surfacing directly.
-
 ## Why priority high
 
 The lock is **advisory**. A standing instruction now says an advisory lock that
@@ -91,9 +65,15 @@ cannot be acquired in a few minutes must not stop work — verify the record's `
 directly and proceed. But that is a workaround: the lock exists to prevent duplicate
 dispatch, and while it is wedged the fleet is running without that protection.
 
-And the workaround has a sharp edge: "proceed if the record says `released`"
-is only safe because the *reader* path works. If a wedge ever produced a stale
-**read**, two agents could both see `released` and both start.
+**The workaround has a sharp edge worth stating explicitly.** "Proceed if the
+record says `released`" is safe only while the **reader** path is sound — it
+assumes a wedge can lose a *write* but never return a stale *read*. Nothing
+currently guarantees that. If a wedge ever produced a stale read, two agents
+could both see `released` and both start, which is precisely the duplicate
+dispatch this lock exists to prevent. So the workaround does not merely leave
+the fleet unprotected while wedged; under one plausible failure mode it is
+itself the mechanism. Any fix should confirm the read path cannot go stale
+independently of fixing the write path.
 
 ## Acceptance
 


### PR DESCRIPTION
Both onto existing issues rather than new ids.

## #3879 — a fourth false-STOP class: umbrella citation treated as ownership

**An umbrella issue cites every one of its children by design — that is what an umbrella *is*.** The overlap check doesn't know that, so each citation becomes `ACTIVE overlap — Another agent may already own this work as a slice`. Consequence: **every child of every active umbrella is permanently un-startable.**

Measured on one real gating run. Hunting for a single L/XL `standalone` task, umbrella **#2860** alone produced a BLOCKER on three candidates:

| issue | claim record | blocked by |
|---|---|---|
| #2865 | hard claim (`fable-2865`) | genuinely owned |
| #2872 | hard claim (`dev-std-2`) | genuinely owned |
| **#2916** | **does not exist** | **#2860 citation only** |

#2916 had **no claimant** and was still STOP — and was only dispatched by a human overriding the gate. *A gate that needs routine override to release unowned work is the failure mode.*

The absence was verified **with a control**, per the silent-empty rule: the claim ref holds 20+ neighbouring files (2900, 2903, 2906, 2910–2914, 2920–2932…), so a missing `2916.json` is a real absence rather than an unfetched or broken ref.

**Proposed rule:** skip the citation-overlap check when the referencing issue is an umbrella. An umbrella citation carries no ownership information; only the claim ref and open PRs do.

Also records the **cost asymmetry**: a false CLEAR wastes one agent's cycle, but a false STOP can strand a task indefinitely — each successive agent hits the same STOP and moves on, and nothing in the system notices work that is never started.

## #3880 — frequency evidence

A single anecdote is a flake; this is a rate. One agent, one session: **four wedges plus two slow successes**, each stall 5–15 minutes, with three other agents observed in the same state concurrently (`3661`, `3672`, `3655`) — so it's fleet-wide contention, not one bad checkout.

**Concrete cost:** #3420 was implemented and merged with **no claim record ever taken**. The protection this tool exists to provide was simply absent for that task; the only thing preventing duplicate work was a human noticing.

The shared `refs/claim-issue/base` mirror is implicated — every agent fetches into the *same* ref, so N concurrent claims contend on one lock, which is failure #2 in the table surfacing directly.

Also notes a sharp edge on the sanctioned workaround: *"proceed if the record says `released`"* is safe only while the **reader** path works. A wedge producing a stale read would let two agents both see `released` and both start.

Docs-only: two `plan/issues/*.md` files, no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
