### PR TITLE
docs(#2916): re-ground scope, count the baseline, tier acceptance

### DIFF
--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -305,6 +305,40 @@ ref.test $__closure_base      ;; ctx.closureInfoByTypeIdx supertype
 > **RE-GROUNDED 2026-07-31 — baseline counted BEFORE implementing**, so the
 > result cannot be rationalised afterward. Population and ceiling below are
 > measured row counts, not the superseded "~31" estimate.
+>
+> **READ THE TIERING FIRST — test262 rows are the SECONDARY metric here, not the
+> deliverable.** `goal: standalone`, under umbrella #2860. The deliverable is
+> **import elimination**. A leaked `env::__instanceof_check` means standalone
+> mode is *not actually standalone* for any program using `instanceof` with a
+> dynamic RHS — ordinary code, not an edge case. The product claim is "JS host
+> optional"; an import that fires on ordinary `instanceof` falsifies that claim
+> **regardless of how many conformance rows move**. Anyone sizing this by row
+> count is measuring the wrong thing.
+
+### PRIMARY acceptance — binary, and the actual deliverable
+
+Both imports gone, verified **per shape** rather than on one sample:
+
+- `env::__instanceof_check` absent for **all four** dynamic-RHS variants:
+  any-typed local · fn-valued param · property access · call result.
+- `env::Object_isPrototypeOf` absent for the dynamic-receiver form.
+- The already-clean shapes stay clean: builtin-name RHS, user-class RHS, Error
+  family, and static `C.prototype.isPrototypeOf(a)`.
+
+This either holds or it does not. **If it fails, stop and report — do not pursue
+rows.** The import is the thing.
+
+### SECONDARY acceptance — rows, expected ~4, ceiling 24
+
+Quoted **with** its decomposition so `≤24` cannot be read as the target: of the
+24 leaky-PASS rows, only **4** carry a `host_import_leak` signature. Out of
+scope: 8 `runtime-eval`, 3 TypeError-not-thrown, 3 null/undefined conversion,
+3 `compile_error`, 6 assorted.
+
+**A row that stops leaking but still fails is a NEW FINDING, not a shortfall.**
+Removing an import makes a module *instantiate*; it must then still produce the
+right answer. Such a row is a second defect wearing the first one's clothes —
+report it as its own observation rather than counting it against this issue.
 
 **Measured baseline** — host baseline vs standalone baseline, joined on `file`:
 
@@ -338,23 +372,29 @@ causes this issue does not address:
 and "leaking ≠ flipping": removing the import makes a module *instantiate*, after
 which it still has to produce the right answer.
 
-### Criteria
+### Criteria — how each tier is evidenced
 
-- Standalone dynamic `instanceof` emits **zero** `env::__instanceof*` imports.
-  Verified per-shape on the four probed dynamic-RHS variants (any-typed local,
-  fn-valued param, property access, call result), not on one.
-- `isPrototypeOf` on a **dynamic receiver** emits zero `env::Object_isPrototypeOf`.
-  The static `C.prototype.isPrototypeOf(a)` form is already clean and must stay so.
-- **A/B the 24 ceiling rows before and after**, reporting `before → after` per
-  row rather than a net. Both lanes; a control that must hold under any spec
-  version; **discard the run if the control fails**; state harness, lane, and
-  both commit SHAs on every comparison.
-- No wrong-`true` correctness regression in the `instanceof` / `isPrototypeOf`
-  corpus — a native tri-state that answers `true` too eagerly is worse than a leak.
+The two tiers are stated above; these are the verification rules that apply to
+them. Correctness constraints bind **both** tiers.
+
+- **Primary evidence:** per-shape import-list assertion, on all four dynamic-RHS
+  variants and the dynamic-receiver `isPrototypeOf` form — not on one sample.
+  A single-shape probe is what let the original scope statement stand wrong, and
+  what made this re-grounding's own first pass miss `isPrototypeOf`.
+- **Secondary evidence:** A/B the 24 ceiling rows, reporting `before → after`
+  **per row** rather than a net. Both lanes; a control that must hold under any
+  spec version; **discard the run if the control fails**; state harness, lane,
+  and both commit SHAs on every comparison.
+- **Correctness (binds both tiers, and outranks both):** no wrong-`true`
+  regression in the `instanceof` / `isPrototypeOf` corpus. A native tri-state
+  that answers `true` too eagerly is **worse than the leak it replaces** — a
+  leak fails loudly at instantiation, a wrong `true` passes silently.
 - gc/host byte-identical (compile-diff probe).
-- Full `merge_group` net-positive. **Note the gate's ~20 phantom
-  `compile_timeout` improvement credits (#3884): subtract them before reading
-  any net — a positive net is not evidence of improvement.**
+- `merge_group` net: **subtract #3884's ~20 phantom `compile_timeout` credits
+  before reading it.** With an expected effect of ~4 rows the phantom credit is
+  roughly **five times the signal**, so an unadjusted net here is pure noise —
+  not a weak positive, no information at all. This must be stated in the PR
+  description, not just computed.
 
 ## Implementation Notes — Slice A landed (sendev-instanceof, 2026-07-01)
 

--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -21,7 +21,52 @@ origin: "2026-07-01 — sr-tail2 escalation: leaky-PASS conversion cluster, subs
 
 # #2916 — Standalone native `instanceof` operator + `isPrototypeOf` residual
 
-## Problem (verified on `main` `f350ba855`, 2026-07-01)
+## RE-GROUNDED 2026-07-31 — scope is narrower than filed; the headline figure is stale
+
+> **The "~31 leaky-PASS conversions" figure in the title is SUPERSEDED.** It is
+> kept visible rather than deleted so nobody re-derives it, but it must not be
+> used to size this work or to measure acceptance. Two of the three filed leak
+> shapes no longer reproduce.
+>
+> Measured on current `main`, `--target standalone`, reading the module's
+> **import list** (a compile-time property — the right instrument for a leak
+> question; #3885's hazard concerns host *evaluation* of `Object.*` statics, not
+> the import list). Control: a plain module with no `instanceof` emits
+> `imports=0`.
+>
+> | shape | filed leak | measured 2026-07-31 |
+> | --- | --- | --- |
+> | `a instanceof Array` (builtin-name RHS) | `env::__instanceof` | **clean** — Slice A |
+> | `a instanceof C` (user-class RHS) | — | **clean** |
+> | Error family | — | **clean** (already native) |
+> | RHS resolves to no class/struct | `env::__instanceof_dyn` | **never observed** |
+> | `a instanceof K`, `K` an `any`-typed local | `env::__instanceof_check` | **LEAKS** |
+> | `x instanceof K`, `K` a fn-valued param | — | **LEAKS** `__instanceof_check` |
+> | `a instanceof holder.K` (property access) | — | **LEAKS** `__instanceof_check` |
+> | `a instanceof mk()` (call result) | — | **LEAKS** `__instanceof_check` |
+> | `C.prototype.isPrototypeOf(a)` (static receiver) | (paired residual) | **clean** |
+> | `p.isPrototypeOf(a)`, `p` a dynamic receiver | — | **LEAKS** `env::Object_isPrototypeOf` |
+>
+> **The residual is TWO host imports, not three:**
+>
+> 1. **`env::__instanceof_check`** — every dynamic-RHS `instanceof` shape. Four
+>    surface variants, one import, one root cause (`identifiers.ts:1247`/`1252`).
+> 2. **`env::Object_isPrototypeOf`** — `isPrototypeOf` on a **dynamic** receiver
+>    only; the static `C.prototype.isPrototypeOf(a)` form is already clean.
+>
+> `env::__instanceof` and `env::__instanceof_dyn` were not observed on any probed
+> shape.
+>
+> **A correction to this re-grounding's own first pass**, recorded because it is
+> the same class of error the issue text made: an initial probe tested only the
+> *static* `C.prototype.isPrototypeOf(a)` form, saw it clean, and concluded
+> `isPrototypeOf` was fully fixed. It is not — the dynamic-receiver form leaks.
+> One shape is not the surface.
+>
+> **Acceptance must therefore be set on counted rows, not on the stale
+> estimate** — see the re-grounded acceptance criteria at the end of this issue.
+
+## Problem (verified on `main` `f350ba855`, 2026-07-01 — see RE-GROUNDED above)
 
 Under `--target standalone` the dynamic `instanceof` operator leaks an
 unsatisfiable `env::__instanceof*` host import, so the module cannot instantiate
@@ -256,13 +301,60 @@ ref.test $__closure_base      ;; ctx.closureInfoByTypeIdx supertype
   residual, sharing `emitProtoChainWalk`. Depends on Slice A landing.
 
 ## Acceptance
-- Standalone dynamic `instanceof` emits **zero** `env::__instanceof*` imports
-  and instantiates host-free.
-- The `isPrototypeOf` generic-host-method residual no longer leaks.
-- `net_per_test > 0` on the standalone floor; no wrong-`true` correctness
-  regression in the `instanceof` / `isPrototypeOf` corpus.
+
+> **RE-GROUNDED 2026-07-31 — baseline counted BEFORE implementing**, so the
+> result cannot be rationalised afterward. Population and ceiling below are
+> measured row counts, not the superseded "~31" estimate.
+
+**Measured baseline** — host baseline vs standalone baseline, joined on `file`:
+
+| population (path-matched) | rows |
+| --- | ---: |
+| `instanceof` / `Symbol.hasInstance` | 56 |
+| `isPrototypeOf` | 10 |
+| **total population** | **66** |
+
+| leaky-PASS (host `pass`, standalone not-`pass`) | rows |
+| --- | ---: |
+| `instanceof`-ish | 22 |
+| `isPrototypeOf` | 2 |
+| **addressable CEILING** | **24** |
+
+**The ceiling is 24, but the leak-attributable subset is far smaller.** By
+standalone failure signature, only **4** of the 24 carry
+`host_import_leak: standalone target emitted host imports`. The rest fail for
+causes this issue does not address:
+
+| n | standalone signature | addressed here? |
+| ---: | --- | --- |
+| 8 | `Import "js2wasm:runtime-eval"` | no — eval, separate issue |
+| **4** | **`host_import_leak: … emitted host imports`** | **yes** |
+| 3 | `Expected a TypeError to be thrown` | unlikely |
+| 3 | `TypeError: Cannot convert undefined or null to object` | unlikely |
+| 3 | `compile_error` (S11.8.6_A6_T3, A2.4_T3, primitive-prototype) | no |
+| 6 | assorted single assertion failures | unknown |
+
+**So the honest expectation is ~4 rows directly, ≤24 as an absolute ceiling** —
+and "leaking ≠ flipping": removing the import makes a module *instantiate*, after
+which it still has to produce the right answer.
+
+### Criteria
+
+- Standalone dynamic `instanceof` emits **zero** `env::__instanceof*` imports.
+  Verified per-shape on the four probed dynamic-RHS variants (any-typed local,
+  fn-valued param, property access, call result), not on one.
+- `isPrototypeOf` on a **dynamic receiver** emits zero `env::Object_isPrototypeOf`.
+  The static `C.prototype.isPrototypeOf(a)` form is already clean and must stay so.
+- **A/B the 24 ceiling rows before and after**, reporting `before → after` per
+  row rather than a net. Both lanes; a control that must hold under any spec
+  version; **discard the run if the control fails**; state harness, lane, and
+  both commit SHAs on every comparison.
+- No wrong-`true` correctness regression in the `instanceof` / `isPrototypeOf`
+  corpus — a native tri-state that answers `true` too eagerly is worse than a leak.
 - gc/host byte-identical (compile-diff probe).
-- Full `merge_group` net-positive.
+- Full `merge_group` net-positive. **Note the gate's ~20 phantom
+  `compile_timeout` improvement credits (#3884): subtract them before reading
+  any net — a positive net is not evidence of improvement.**
 
 ## Implementation Notes — Slice A landed (sendev-instanceof, 2026-07-01)
 


### PR DESCRIPTION
Groundwork only — **no source change**. Landing it so the measurement survives the branch; the implementation is being handed off.

## The filed scope was stale

`~31 leaky-PASS conversions` is **superseded** (kept visible, not deleted). Measured on current `main`, `--target standalone`, reading the module **import list** — a compile-time property, which is the right instrument for a leak question:

| shape | filed | measured |
|---|---|---|
| builtin-name RHS | `env::__instanceof` | **clean** (Slice A) |
| user-class RHS · Error family | — | **clean** |
| RHS resolves to nothing | `env::__instanceof_dyn` | **never observed** |
| dynamic RHS ×4 (any-local, fn-param, property access, call result) | `env::__instanceof_check` | **LEAKS** — one import, one cause |
| `C.prototype.isPrototypeOf(a)` static | (paired residual) | **clean** |
| `p.isPrototypeOf(a)` **dynamic receiver** | — | **LEAKS `env::Object_isPrototypeOf`** |

**Residual is two imports, not three.**

The issue also records a correction to **this re-grounding's own first pass**: an initial probe tested only the *static* `isPrototypeOf` form, saw it clean, and concluded the residual was gone. The dynamic-receiver form leaks. That is the identical "one shape is not the surface" error the original text made — committed while correcting it, and caught by widening the probe rather than by noticing.

## Acceptance tiered — imports are the deliverable

`goal: standalone`, under umbrella #2860. A leaked `env::__instanceof_check` means standalone mode **is not actually standalone** for any program using `instanceof` with a dynamic RHS — ordinary code. The product claim is "JS host optional"; an import firing on ordinary `instanceof` falsifies it regardless of row count.

- **PRIMARY (binary):** both imports gone, verified **per shape** across all four dynamic-RHS variants and the dynamic-receiver `isPrototypeOf`. If this fails, stop and report — do not pursue rows.
- **SECONDARY (~4 expected, ceiling 24):** quoted *with* its decomposition so `≤24` cannot be read as the target. Out of scope: 8 `runtime-eval`, 3 TypeError-not-thrown, 3 null/undefined conversion, 3 `compile_error`, 6 assorted.

Baseline counted **before** any implementation: population 66 (56 instanceof-ish + 10 isPrototypeOf); leaky-PASS 24; only **4** carry a `host_import_leak` signature.

Two rules added:
- A row that stops leaking but still fails is a **new finding**, not a shortfall — a second defect wearing the first one's clothes.
- **Correctness outranks both tiers.** A native tri-state answering `true` too eagerly is *worse* than the leak it replaces: a leak fails loudly at instantiation, a wrong `true` passes silently.

#3884 note sharpened: at ~4 rows the ~20 phantom `compile_timeout` credits are **five times the signal**, so an unadjusted `merge_group` net is *no information* — not a weak positive.

## Handed forward for the implementer

- **Dependency confirmed on main, not trusted from the spec.** The Fable plan says predecessor-stack on #2580 M3; `object-runtime-prototype.ts` already carries `[[Prototype]]` in field 0 with a native `__getPrototypeOf` walking it. **Build on that walk, don't duplicate it.**
- **Leak sites:** `emitDynamicInstanceOf` (`src/codegen/expressions/identifiers.ts:1548`) for `__instanceof_check`; the dynamic-receiver `isPrototypeOf` path for `Object_isPrototypeOf`.

## Why implementation is not in this PR

The Fable spec's **B0 is a genuine substrate addition** — new `$BuiltinCtor <: $Object` subtype with `ctorBrand`, a `__new_builtin_ctor` allocator, and two finalize-spliced read arms on `__extern_get` — *before* Slice B's `OrdinaryHasInstance` tri-state begins. That is `horizon: l` / `feasibility: hard`.

By this issue's own correctness rule, a **stranded** tri-state is exactly how a wrong `true` ships. Handing over a measured spec beats leaving a half-built substrate. The claim is released with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
