### PR TITLE
docs(#2916,#3880): mark 2916's claim stale; file the release-wedge evidence

### DIFF
--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -21,6 +21,30 @@ origin: "2026-07-01 — sr-tail2 escalation: leaky-PASS conversion cluster, subs
 
 # #2916 — Standalone native `instanceof` operator + `isPrototypeOf` residual
 
+> ## ⚠ Claim status: the `issue-assignments` record for #2916 is STALE — this issue is UNCLAIMED and AVAILABLE
+>
+> `origin/issue-assignments:2916.json` reads
+> `assignee: ttraenkler/dev-es5-coercion`, `status: in-progress`. **That is
+> wrong.** The work was handed off deliberately; the release simply could not be
+> executed.
+>
+> Release failed **three times** on 2026-07-31:
+> 1. Node crash mid-run (the caller nearly read `tail`'s exit status as success)
+> 2. exit 1 — `cannot lock ref 'refs/claim-issue/base': is at 9619a610… but expected c5faa81c…`
+> 3. wedged >560 s after force-updating the mirror ref by hand, then killed
+>
+> This is **#3880** (`claim-issue.mjs` ref-lock wedge). The record was **not**
+> hand-edited: rewriting a shared ref that other lanes read trades a bookkeeping
+> problem for a corruption risk. This note is the durable correction — the issue
+> file is where a gating human or agent looks; the claim ref is advisory and was
+> known-unreliable that day.
+>
+> **Take this issue freely.** Groundwork (measured scope, counted baseline,
+> tiered acceptance, confirmed #2580 M3 dependency, both leak sites) landed in
+> **PR #3881**. Nothing is in flight and nothing is half-implemented — the
+> deliberate stopping point was *before* the Slice B/C substrate, because a
+> stranded `OrdinaryHasInstance` tri-state is how a wrong `true` ships.
+
 ## Problem (verified on `main` `f350ba855`, 2026-07-01)
 
 Under `--target standalone` the dynamic `instanceof` operator leaks an

--- a/plan/issues/3880-claim-issue-ref-lock-wedge.md
+++ b/plan/issues/3880-claim-issue-ref-lock-wedge.md
@@ -29,6 +29,52 @@ related: [2531, 3879]
 - **#3420's claim ref is permanently out of sync** — the work merged (PR #3864) while
   the record still shows a different agent's stale entry.
 
+## Fifth occurrence — first on `--release`, and the strongest single argument for priority
+
+2026-07-31, one agent handing #2916 back to the queue. **Three release attempts,
+zero effect** — `2916.json` still read `status: in-progress` afterwards.
+
+| # | attempt | outcome |
+| --- | --- | --- |
+| 1 | `--release 2916` | **Node crash** mid-run. The caller nearly recorded success: the shell reported `EXIT=0`, which was `tail`'s status from a pipe, not the script's. |
+| 2 | `--release 2916` | **exit 1**, cause captured verbatim: `error: cannot lock ref 'refs/claim-issue/base': is at 9619a610… but expected c5faa81c…` |
+| 3 | `--release 2916` after manually force-updating the mirror (`+issue-assignments:refs/claim-issue/base`) | **wedged >560 s**, killed |
+
+Three firsts in this one episode:
+
+1. **First failure observed on `--release`.** Prior evidence covered `claim` and
+   `--allocate`; this extends the fault to a **third entry point**, so it is the
+   shared-ref layer rather than any one code path.
+2. **First verbatim capture of the lock error**, naming
+   `refs/claim-issue/base` — the shared mirror every agent fetches into — as the
+   contended resource.
+3. **First case where a manual mirror force-update did not rescue the retry.**
+   That workaround had previously worked; here the retry wedged anyway.
+
+### Why this is the argument for prioritising, not just more evidence
+
+**This issue's own acceptance criterion says "a failed release/allocate can never
+be mistaken for success by its caller." Occurrence 1 is exactly that failure,
+and it was caught only because the caller read the record back instead of
+trusting the exit code.** Had it not been, #2916 would now sit falsely claimed by
+a departed agent.
+
+So the tool built to prevent stranding **nearly caused a stranding, then wedged
+while trying to undo it.** The eventual mitigation was to bypass the tool
+entirely: a `Claim status: STALE` note written into the issue file, because
+hand-editing a shared ref that other lanes read trades a bookkeeping problem for
+a corruption risk. **When the claim ref cannot be corrected, the durable record
+has to carry the truth instead** — which means the claim ref is currently not
+authoritative for anything.
+
+**Note on occurrence 1's near-miss** (this is a caller-side hazard worth fixing
+in the docs as well as the tool): `cmd | tail -2; echo $?` reports the *pipe's*
+last stage, so a crashed script reads as success. Use `cmd > file 2>&1; echo $?`,
+`${PIPESTATUS[0]}`, or run bare — and verify the **effect** (read the record
+back), not the exit code. Two agents hit this same trap within an hour on
+2026-07-31, one of whom had it written in their own memory at the time; vigilance
+did not prevent it, so the rule needs to be mechanical.
+
 ## Root cause
 
 The failure is `cannot lock ref 'refs/remotes/origin/issue-assignments': is at X but


### PR DESCRIPTION
Docs-only. Two `plan/issues/*.md` files, no source change.

## #2916 — its claim record is stale, and the issue is available

`origin/issue-assignments:2916.json` reads `assignee: ttraenkler/dev-es5-coercion`, `status: in-progress`. **That is wrong.** The work was handed off deliberately; the release could not be executed.

Three attempts on 2026-07-31:
1. **Node crash** mid-run — the caller nearly recorded success, because the shell's `EXIT=0` was `tail`'s status from a pipe rather than the script's
2. **exit 1** — `cannot lock ref 'refs/claim-issue/base': is at 9619a610… but expected c5faa81c…`
3. **wedged >560 s** after manually force-updating the mirror ref, then killed

**The record was deliberately NOT hand-edited.** Rewriting a shared ref that other lanes read trades a bookkeeping problem for a corruption risk. Instead the *issue file* — where a gating human or agent actually looks — now carries a `Claim status: STALE` banner stating the issue is unclaimed and available, with a pointer to PR #3881 for the groundwork.

Nothing is in flight and nothing is half-implemented: the stopping point was chosen *before* the Slice B/C substrate, because a stranded `OrdinaryHasInstance` tri-state is how a wrong `true` ships.

## #3880 — fifth occurrence, and the argument for priority

Three firsts in this one episode:

- **First failure observed on `--release`.** Prior evidence covered `claim` and `--allocate`; this makes it a **third entry point**, so the fault is the shared-ref layer rather than any one code path.
- **First verbatim capture of the lock error**, naming `refs/claim-issue/base` — the shared mirror every agent fetches into — as the contended resource.
- **First case where a manual mirror force-update did not rescue the retry.** That workaround had worked before; here the retry wedged anyway.

**The priority argument is stronger than the count.** This issue's own acceptance criterion says *"a failed release/allocate can never be mistaken for success by its caller."* Occurrence 1 was exactly that, and was caught only because the caller read the record back instead of trusting the exit code. Had it not been, #2916 would now sit falsely claimed by a departed agent.

So: **the tool built to prevent stranding nearly caused one, then wedged trying to undo it** — and the mitigation was to bypass it entirely. While the claim ref cannot be corrected, it is not authoritative for anything.

## Caller-side hazard, recorded alongside

`cmd | tail -2; echo $?` reports the **pipe's** last stage, so a crashed script reads as success. Use `cmd > file 2>&1; echo $?`, `${PIPESTATUS[0]}`, or run bare — and verify the **effect** (read the record back), not the code.

Two agents hit this same trap within an hour on 2026-07-31, one of whom had it written in their own memory at the time. Vigilance demonstrably did not prevent it, so the rule is stated mechanically rather than as advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
