### PR TITLE
docs(#3647,#3646): host-lane-only diagnosis, severity correction, handoff context

### DIFF
--- a/plan/agent-context/dev-es5-coercion.md
+++ b/plan/agent-context/dev-es5-coercion.md
@@ -1,0 +1,89 @@
+# dev-es5-coercion — session context (2026-07-30/31)
+
+Lane: ES5 coercion / enumeration / frozen-semantics, then standalone descriptor
+and reflection work. Written so a successor does not re-derive any of it.
+
+## Landed
+
+**#3872 / PR #3871 — the only behaviour change of the session.**
+Non-writable data-property writes now fail correctly across **all four**
+assignment lowering sites, both lanes. Standalone probe 10/13 → 13/13
+(standalone was the objective lane).
+
+Root cause, after three wrong hypotheses: `applyDescriptorFlags` leaves the
+WRITABLE bit **clear** when a descriptor merely *omits* `writable`. Correct for a
+fresh define, **wrong for a redefine** ("omitted" means keep-existing).
+`definedPropertyFlags` had always been approximate that way and its historical
+consumers tolerated it; the consult made it load-bearing for correctness. Fix:
+only an **explicit** `writable: false` fires the consult, recorded from all three
+`Object.defineProperty` lowering arms.
+
+Also landed: #3420 (frozen bit consulted on element writes), and a chain of
+docs/measurement PRs (#3876 retraction, #3880/#3879 gate + wedge evidence, #3881
+#2916 groundwork, #3883 stale-claim + wedge evidence).
+
+## Open, with diagnosis complete
+
+- **#3647** — host-lane only; standalone already correct. Dispatch at
+  `runtime.ts:12628` / `:12759` → `_wasmStructPropertyIsEnumerable` (`:5258`).
+  **Next step is one fact:** what `C.prototype` actually *is* in the host lane
+  (wasm struct / plain object / wrapper) and which dispatch path the call takes.
+  That decides where the fix belongs.
+- **#2916** — scope re-grounded (residual is **two** imports, not three),
+  baseline counted, acceptance tiered (imports primary, rows secondary ~4/≤24).
+  Claim record stale; issue file says so.
+- **#3646** — severity corrected: `gOPD(C.prototype,"m")` **traps**, it does not
+  return `null`. Minimal repro needs no computed-name field.
+
+## Things that cost hours — read these before measuring anything
+
+**Six instrument traps, every one locally indistinguishable from success.**
+
+1. **Bare `compile()` cannot measure host-lane `Object.*` statics** (#3885). Its
+   control returns `0` for `Object.keys({a:1,b:2}).length`. Use `runTest262File`,
+   both lanes, **with a control that must hold under any spec version — discard
+   the run if the control fails.** This produced a *phantom defect report*
+   (retracted in #3876), the expensive direction.
+2. **`git checkout <tree> -- <paths>` STAGES the revert.** After an A/B the index
+   holds the reverted copies; the next `git add` silently undoes committed work.
+3. **`git fetch origin main` can leave `refs/remotes/origin/main` stale.** Use
+   `+refs/heads/main:refs/remotes/origin/main` and verify against
+   `gh api repos/loopdive/js2/commits/main --jq .sha`. Cost me a published
+   (retracted) "baseline defect" claim.
+4. **A budget gate reporting `granted by <an issue your PR does not modify>.md`
+   is a CI failure in waiting** — the grant resolves locally, not in CI.
+5. **Never pipe a command whose exit status you need.** `cmd | tail; echo $?`
+   reports the *pipe's* status, so a crashed script reads as success. Use
+   `cmd > file 2>&1; echo $?` and **verify the effect, not the code**.
+6. **A probe that scores identically on the broken and fixed versions
+   discriminated nothing.** The diagnostic is "did it *distinguish* the two
+   versions", not "did it pass". Write the probe against **the branch you
+   actually edited**, not the bug you reasoned your way to.
+
+**Standing rule that emerged:** every A/B must state its **lane**, its
+**harness**, and **which two commits were diffed**. Host-vs-standalone,
+local-vs-CI, and wrong-version-pair each produced a confident wrong conclusion
+within one session, and from the inside they are indistinguishable.
+
+## Measurement facts worth keeping
+
+- The lane discriminator for baselines is **a separate file**, not a field:
+  `test262-standalone-current.jsonl` alongside `test262-current.jsonl`.
+- ES5 = test262's own **`es5id:`** frontmatter marker
+  (`grep -rl "^es5id:" test262/test/{built-ins,language}` → ~8,088).
+  **Not** `scope_official`, which is the whole corpus across every edition —
+  using it inflated an "ES5" denominator to 42,014 and made ES6 generator
+  imports look like the top ES5 lever.
+- **Subtract ~20 before reading any merge_group net** (#3884): the regression
+  numerator filters `compile_timeout`, the improvement numerator does not. A
+  genuinely net-zero change passed showing +18.
+- **PR-level `check for test262 regressions` green is a designed no-op.** Only
+  the `merge_group` re-validation is evidence.
+
+## Working relationships
+
+`shepherd-ci-fix` owns enqueueing (one-shot, `expectedHeadOid` pinned) and
+extracts per-path failure lists from merged-report artifacts — that extraction is
+what turned a statistical argument into a diagnosis on #3872.
+`dev-eslint-graph` holds the reflection cluster (#3875/#3876).
+`dev-es5-descriptors` holds descriptor record/read fidelity (#2668).

--- a/plan/issues/3646-gopd-null-for-class-method-with-computed-fields.md
+++ b/plan/issues/3646-gopd-null-for-class-method-with-computed-fields.md
@@ -18,6 +18,37 @@ origin: "cohort tracker for failures exposed by #3603 S1 host de-inflation (PR #
 
 # #3646 — `getOwnPropertyDescriptor` returns `null` for a class method when the class has computed-name fields
 
+> ## ⚠ SEVERITY CORRECTION 2026-07-31 — it does not return `null`, it TRAPS
+>
+> Found while diagnosing #3647; routed here because nobody holds #3646 and the
+> issue file is the only durable route.
+>
+> `Object.getOwnPropertyDescriptor(C.prototype, "m")` on a plain
+> `class { m() {} }` does not return `null` — it raises:
+>
+> ```
+> RuntimeError: illegal cast in __module_init()
+> ```
+>
+> **Two independent probes crashed on that exact line**, both in the **host**
+> lane, via `runTest262File` with controls that must hold under any spec version
+> (`({a:1}).propertyIsEnumerable("a") === true`, `…("zz") === false`) — both
+> controls passed, which is what licenses reading the result (#3885).
+>
+> Notably the repro needed **no computed-name field**: the minimal
+> `var C = class { m() { return 42; } }; Object.getOwnPropertyDescriptor(C.prototype,"m")`
+> was enough. If that holds, the "when the class has computed-name fields"
+> qualifier in the title is narrower than the real trigger and should be
+> re-measured before it is used to scope a fix.
+>
+> **Why this matters for scoping:** a wrong value is recoverable by a caller;
+> an uncatchable trap in `__module_init` takes the whole module down at
+> instantiation. Anything sized against "returns null" understates it.
+>
+> Adjacent, deliberately NOT folded in: the standalone lane returns `false` from
+> `hasOwnProperty` for the same existing class method — that is **#3875**
+> (*gOPD correct, hasOwnProperty broken*), a different defect on the same probe.
+
 > **Cohort tracker.** This is one of the two failure cohorts EXPOSED (not caused)
 > by #3603 S1's host-lane de-inflation. Per the #3468 F1 landing recipe, every
 > exposed cohort is routed to a tracker — that is what makes a de-inflation

--- a/plan/issues/3647-propertyisenumerable-contradicts-gopd-enumerable.md
+++ b/plan/issues/3647-propertyisenumerable-contradicts-gopd-enumerable.md
@@ -18,6 +18,28 @@ origin: "cohort tracker for failures exposed by #3603 S1 host de-inflation (PR #
 
 # #3647 — `propertyIsEnumerable` contradicts `getOwnPropertyDescriptor().enumerable`
 
+> ## ⚠ Claim status: the `issue-assignments` record is STALE — this issue is UNCLAIMED and AVAILABLE
+>
+> The record reads `assignee: ttraenkler/dev-es5-coercion`, `status: in-progress`.
+> The work was handed off deliberately; the release tooling could not execute it
+> (**#3880** — five failures on 2026-07-31 across `claim`, `--allocate` and
+> `--release`). The record was **not** hand-edited: rewriting a shared ref other
+> lanes read trades a bookkeeping problem for a corruption risk.
+>
+> **Take this issue freely.** Diagnosis is complete and nothing is half-implemented
+> — see the re-measurement below and the "next step is one fact" note.
+>
+> ## ⚠ THE DEFECT IS HOST-LANE ONLY — standalone already answers `false` correctly
+>
+> Read this before writing a fix. A change that "corrects" `propertyIsEnumerable`
+> globally would **regress the lane that is already right**. Verified both lanes,
+> controls passing:
+>
+> ```
+> host:        pIE=true   <- the defect
+> standalone:  pIE=false  <- already correct, do not touch
+> ```
+
 > **Cohort tracker.** One of the two failure cohorts EXPOSED (not caused) by
 > #3603 S1's host-lane de-inflation. Per the #3468 F1 landing recipe, every
 > exposed cohort is routed to a tracker — that is what makes a de-inflation

--- a/plan/issues/3647-propertyisenumerable-contradicts-gopd-enumerable.md
+++ b/plan/issues/3647-propertyisenumerable-contradicts-gopd-enumerable.md
@@ -35,6 +35,63 @@ Class methods are non-enumerable per ES2015+ (§14.6, MethodDefinition →
 importantly it is **self-inconsistent**: our own `getOwnPropertyDescriptor`
 disagrees with our own `propertyIsEnumerable`.
 
+## Re-measured 2026-07-31 — reproduces; host-lane only; two adjacent findings
+
+**Harness:** `runTest262File`, test262-shaped probe, **both lanes**, with controls
+that must hold under any spec version. Controls passed in both lanes
+(`({a:1}).propertyIsEnumerable("a") === true`, `…("zz") === false`), which is
+what licenses reading the rows below (#3885).
+
+```
+host:        ctl_own=true  ctl_bogus=false | pIE=true  | hasOwn=true  | keys_has_m=false
+standalone:  ctl_own=true  ctl_bogus=false | pIE=false | hasOwn=false | keys_has_m=false
+```
+
+**1. The defect is HOST-LANE ONLY.** Host reports `propertyIsEnumerable → true`
+while `Object.keys` on the same object+key correctly omits `m` — the filed
+self-inconsistency, confirmed. **Standalone already answers `false` correctly.**
+Any fix must not "fix" the lane that is already right.
+
+**2. Standalone has a DIFFERENT defect on the same probe:** `hasOwnProperty`
+returns **false** for `C.prototype.m`, which does exist. That is #3875's
+finding (*gOPD is correct, hasOwnProperty is broken*), not this issue —
+recorded so nobody folds the two together.
+
+**3. NEW — `getOwnPropertyDescriptor(C.prototype,"m")` TRAPS on host.** Not the
+`null` that #3646 documents: it raises `RuntimeError: illegal cast in
+__module_init()`. Two independent probes crashed on that exact line. This is
+strictly worse than a wrong value and probably belongs on #3646 as a severity
+correction.
+
+### Dispatch paths located (both gate on `_isWasmStruct`)
+
+- `Object_propertyIsEnumerable` — `src/runtime.ts:12628`
+- `__propertyIsEnumerable` — `src/runtime.ts:12759`
+
+Both delegate to `_wasmStructPropertyIsEnumerable` (`src/runtime.ts:5258`) when
+the receiver is a wasm struct, else fall through to the host's own
+`Object.prototype.propertyIsEnumerable`.
+
+### A latent bug found there, which is NOT this defect
+
+`_wasmStructPropertyIsEnumerable` short-circuits `if (sc && prop in sc) return 1`
+— *present in the sidecar ⇒ enumerable*, unconditionally, without consulting the
+descriptor. Correct for assignment-created properties (§10.1.6.1 gives those
+`enumerable:true`) and wrong for anything whose descriptor disagrees.
+
+**Reordering it to read the descriptor first did NOT change the probe**, so the
+receiver here is evidently *not* taking that branch — `C.prototype` is likely not
+a wasm struct in host mode, so the native JS fallback answers. The reordering was
+reverted rather than shipped: an unvalidated change that fixes nothing measurable
+should not land. It is recorded here because it is a real latent inconsistency
+worth fixing on its own evidence.
+
+**Next step for the implementer:** determine what `C.prototype` actually is in
+the host lane (wasm struct vs plain JS object vs wrapper) and which of the two
+dispatch paths the call takes. That single fact decides whether the fix belongs
+in `_wasmStructPropertyIsEnumerable`, in the fallback, or upstream in how class
+methods are installed on the prototype.
+
 ## Measured (stock `upstream/main`, host lane, no test262 harness involved)
 
 ```js


### PR DESCRIPTION
Docs-only — no source change. Diagnosis for a handoff; `dev-enumerable` is implementing #3647.

## #3647 — reproduced, and it is HOST-LANE ONLY

Measured through `runTest262File`, both lanes, with controls that must hold under any spec version (`({a:1}).propertyIsEnumerable("a") === true`, `…("zz") === false`) — **both passed**, which is what licenses reading the rows (#3885):

```
host:        ctl_own=true  ctl_bogus=false | pIE=true  | hasOwn=true  | keys_has_m=false
standalone:  ctl_own=true  ctl_bogus=false | pIE=false | hasOwn=false | keys_has_m=false
```

**Host says `propertyIsEnumerable → true` while `Object.keys` correctly omits the same key on the same object** — the filed self-inconsistency, confirmed. **Standalone already answers `false`.**

That's the finding most likely to be missed: a fix that "corrects" `propertyIsEnumerable` globally would **regress the lane that is already right**. It's now a banner at the top of the issue.

## A hypothesis eliminated, so the next agent doesn't spend the cycle

`_wasmStructPropertyIsEnumerable` (`runtime.ts:5258`) short-circuits `if (sc && prop in sc) return 1` — *present in sidecar ⇒ enumerable*, unconditionally, without consulting the descriptor. Correct for assignment-created properties (§10.1.6.1), wrong for anything whose descriptor disagrees.

**I reordered it to read the descriptor first. The probe did not move. So I reverted it rather than shipping it.** An unvalidated edit that fixes nothing measurable shouldn't land, however sound the reasoning. It's documented as a real latent bug to fix on its own evidence — but it is **not** the cause here.

**The next step is one fact:** what `C.prototype` actually *is* in the host lane (wasm struct / plain JS object / wrapper), and which dispatch path the call takes — `Object_propertyIsEnumerable` (`runtime.ts:12628`) or `__propertyIsEnumerable` (`:12759`), both gating on `_isWasmStruct`. That decides where the fix belongs.

## #3646 — severity correction

`Object.getOwnPropertyDescriptor(C.prototype,"m")` **does not return `null`** — it raises `RuntimeError: illegal cast in __module_init()`. Two independent probes crashed on that exact line.

A wrong value is recoverable by a caller; an uncatchable trap in `__module_init` takes the module down at instantiation. Anything sized against "returns null" understates it.

The minimal repro needed **no computed-name field** — plain `class { m() {} }` sufficed — so the title's qualifier is narrower than the real trigger and should be re-measured before it scopes a fix. Routed into the issue file because nobody holds #3646.

## Also in this PR

- **`#3647` stale-claim banner.** The `issue-assignments` record still names me; the release tooling failed (#3880). The record was **not** hand-edited — rewriting a shared ref other lanes read trades a bookkeeping problem for a corruption risk.
- **`plan/agent-context/dev-es5-coercion.md`** per CLAUDE.md: what landed, what's open with diagnosis complete, the six instrument traps that cost hours this session (each locally indistinguishable from success), and the measurement facts a successor would otherwise re-derive — the separate standalone baseline *file*, `es5id:` as the ES5 marker rather than `scope_official`, the ~20 phantom credits to subtract from any `merge_group` net (#3884), and PR-level test262 green being a designed no-op.

Adjacent and deliberately **not** folded in: standalone `hasOwnProperty` returning `false` for the same existing class method is **#3875**, a different defect on the same probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
