### PR TITLE
perf(#3780): cut standalone acorn parse allocation 24.8%

### DIFF
--- a/plan/agent-context/acorn-allocation-volume.md
+++ b/plan/agent-context/acorn-allocation-volume.md
@@ -110,14 +110,16 @@ allocation *can* happen, not how often. Recorded only as census candidates:
 ## 4. Tooling — what works, what does not
 
 **Allocation volume, deterministic and contention-proof.** Sum inter-GC heap
-growth out of `--trace-gc`: `allocated += before_i − after_{i−1}`. Scripts left
-in `.tmp/acornperf/` (`drive.mjs`, `gc-sum.mjs`, `ab.mjs`, `analyze-prof.mjs`).
+growth out of `--trace-gc`: `allocated += before_i − after_{i−1}` over the
+`X (Y) -> Z (W) MB` fields, divided by the parse count. The scripts I used were
+throwaway (`.tmp/acornperf/`, gitignored and gone with the container) and are a
+few lines each — regex the trace, sum the deltas.
 This metric does not move with box load and was what made the two lowerings
 attributable at all — it caught an 8.0 MB effect whose predicted value was
 7.93 MB.
 
-**Paired A/B.** `ab.mjs` instantiates every variant binary in ONE process and
-runs them in rotating order, so contention drift hits all variants alike.
+**Paired A/B.** Instantiate every variant binary in ONE process and run them in
+rotating order, so contention drift hits all variants alike.
 Wall-clock medians on this box swing ±20% between processes; interleaved
 p25/median deltas are stable.
 

--- a/plan/agent-context/acorn-allocation-volume.md
+++ b/plan/agent-context/acorn-allocation-volume.md
@@ -1,0 +1,165 @@
+# Context handoff — acorn standalone parse, allocation-volume lane (#3780 round 4)
+
+Session 2026-07-31, branch `claude/acorn-performance-optimization-hagjht`.
+Everything below is first-party measurement on **one** box unless labelled
+otherwise. Numbers I did not take myself are attributed.
+
+---
+
+## 0. TL;DR
+
+1. **Allocation volume is a first-class axis and nobody had measured it.**
+   The standalone module allocates **58.0 MB per 226 KB parse** — ~257 bytes
+   per source byte — and the AST it returns accounts for only ~10 MB.
+2. Two generic lowerings landed and took it to **43.6 MB (−24.8%)**, worth
+   **≈7%** wall clock. Both ship paired controls.
+3. **34 MB per parse is still unexplained transient garbage** (~810 bytes per
+   token). That is the largest single unexplained cost in the lane.
+4. **Build the per-type allocation census before optimizing further.** The two
+   obvious off-the-shelf tools do not work — see §4. Guessing from static
+   `struct.new` site counts is exactly the extrapolation trap §3 of
+   `dev-acorn-throughput.md` warns about.
+
+---
+
+## 1. Read the box caveat before quoting anything
+
+Rounds 1–3 of #3780 were taken on Node 24.4.1 / arm64 macOS. This round is a
+**4-core / 16 GB Linux container on Node 22.22.2**, and the profile is a
+different shape: a debug-named 30-parse profile puts **36.7%** of the parse in
+`(garbage collector)`, against the **4.3%** and **1.5%** the two round-3-era
+profiles recorded. I do not know whether that is the V8 version, the heap
+sizing, or the container.
+
+So: **cross-machine wall-clock is not compared here, and no local number is
+diffed against a committed CI baseline.** Everything argued below is either a
+same-process paired A/B or a deterministic allocation counter.
+
+Local scale for orientation only (not a regression claim): standalone wasm
+~104–126 ms/parse against a same-process node control of ~12 ms, i.e. node
+roughly an order of magnitude ahead.
+
+---
+
+## 2. What landed
+
+Commit `perf(#3780): cut standalone acorn parse allocation 24.8%`.
+
+| build | allocated / parse | vs baseline |
+| --- | ---: | ---: |
+| baseline (both controls off) | 58.0 MB | — |
+| packed presence only | 50.0 MB | −13.8% |
+| interned booleans only | 52.0 MB | −10.3% |
+| **both** | **43.6 MB** | **−24.8%** |
+
+- **Packed presence flags** (`src/codegen/fnctor-presence-bits.ts`). #2847's
+  `$has_<name>` own-presence slot was one `i32` per conditionally-assigned
+  property. Acorn's `Node` has 63 → 252 bytes of a 536-byte node. Now bits in
+  `$presence_<w>` words: **130 fields / 536 B → 69 fields / 292 B**.
+  Control: `JS2WASM_PACKED_PRESENCE_BITS=0` strides the bit assignment by a
+  full word, so each flag lands alone in its own slot and the old footprint
+  comes back through the *identical* read/write lowering — the A/B isolates
+  layout from instruction mix.
+- **Interned boolean carriers** (`src/codegen/interned-boolean-boxes.ts`). Two
+  module-level carriers instead of an allocation. `wasm-opt` inlines
+  `__box_boolean` everywhere, so this is **742 static `struct.new` sites → 2**.
+  Control: `JS2WASM_INTERNED_BOOL_BOXES=0`.
+
+Additive to within 0.4 MB (58.0 − 8.0 − 6.0 = 44.0, measured 43.6) — the
+cross-check that they are independent effects. Wall clock, four builds in ONE
+process, rotating order, 45 rounds: **−5.4% min / −6.3% p25 / −7.4% median**.
+Independent `--trace-gc` accounting agrees: GC **30.1 → 22.5 ms** per parse.
+
+Correctness: checksum 422 with zero imports; official Acorn suite unchanged at
+**3,507/3,518**; `tests/equivalence/` shows **32 failures in 12 files both
+before and after** (verified by re-running those 12 files against `HEAD~1`'s
+`src/`) — all pre-existing.
+
+---
+
+## 3. The 34 MB question — what is and is not known
+
+Per-parse budget, from native-acorn object counts × our measured struct sizes:
+
+| | count / parse | our size | total |
+| --- | ---: | ---: | ---: |
+| AST `Node` structs | 32,487 | 292 B (was 536 B) | 9.5 MB |
+| AST arrays | 4,275 (8,285 elements) | ~56 B empty | ~0.24 MB |
+| token string values | 41,889 tokens / 126 KB of chars | 2 B/char + header | <1 MB |
+| **accounted** | | | **~10 MB** |
+| **measured total** | | | **43.6 MB** |
+
+So **~34 MB per parse — ~810 bytes per token — is transient**. It is *not* the
+result, and it is the dominant remaining cost in a lane where GC is 24–37% of
+the time.
+
+**Do not read the static site counts below as volume.** They say where
+allocation *can* happen, not how often. Recorded only as census candidates:
+
+- `$__vec_<T>` array carriers: **1,137** `struct.new` sites, backing arrays
+  default to capacity 8 (~56 B for an empty `[]`).
+- native string carrier: **1,926** sites. The second-hottest function in the
+  whole parse (`__closure_352__typed_this`, 1.97% self) allocates one.
+- `$AnyValue`: only 25 sites.
+- boxed `f64`: 1 site (inside `__box_number`) — and its i31 fast path already
+  makes every integral value in ±2^30 allocation-free, so acorn's positions and
+  char codes are already free.
+
+---
+
+## 4. Tooling — what works, what does not
+
+**Allocation volume, deterministic and contention-proof.** Sum inter-GC heap
+growth out of `--trace-gc`: `allocated += before_i − after_{i−1}`. Scripts left
+in `.tmp/acornperf/` (`drive.mjs`, `gc-sum.mjs`, `ab.mjs`, `analyze-prof.mjs`).
+This metric does not move with box load and was what made the two lowerings
+attributable at all — it caught an 8.0 MB effect whose predicted value was
+7.93 MB.
+
+**Paired A/B.** `ab.mjs` instantiates every variant binary in ONE process and
+runs them in rotating order, so contention drift hits all variants alike.
+Wall-clock medians on this box swing ±20% between processes; interleaved
+p25/median deltas are stable.
+
+**Binary reuse.** `--inspect-binary <out.wasm>` then
+`--reuse-standalone-binary <out.wasm>` — the standalone acorn compile is ~80 s
+here (not the ~7 min the previous handoff saw), and reuse makes re-measurement
+seconds. `--preserve-debug-names` is mandatory for a readable profile.
+
+**Two things that do NOT work — do not spend a round rediscovering them:**
+
+- **V8's sampling heap profiler does not see WasmGC `struct.new`.**
+  `HeapProfiler.startSampling` over a 58 MB parse sampled **0.2 MB**, all of it
+  attributed to a single `js-to-wasm` frame.
+- **`--trace-gc-object-stats` is not available** on this Node build (accepted
+  silently, prints nothing).
+
+**So the census needs emitter support.** The cheap shape: an env-gated finalize
+pass that inserts a stack-neutral `global.get / i32.const 1 / i32.add /
+global.set` after every `struct.new*` / `array.new*`, one exported mutable
+global per type. Exported globals survive `wasm-opt`'s type renumbering, which
+a typeIdx-keyed reader would not.
+
+---
+
+## 5. Recommended next steps, in order
+
+1. **Build the per-type allocation census** (§4). Everything else in this lane
+   is guesswork without it, and 34 MB is too large a number to guess at.
+2. Only then pick the next lowering. Candidates the census would rank:
+   transient vec/backing-array allocation, string carriers in the tokenizer,
+   argument vectors on generic dispatch.
+3. **Not a parity lever, but worth knowing:** even zeroing *all* remaining
+   allocation and *all* GC would leave this lane several-fold short of node on
+   this box. Allocation is the largest single named cost, not the whole gap.
+
+## 6. Unrelated pre-existing bug found along the way
+
+`"prop" in fnctorInstance` answers **false** in the standalone lane where the
+JS-host lane answers **true** (fixture in
+`tests/issue-3780-allocation-lowerings.test.ts`; 10,660 vs 830,660 on the same
+program, with the value read-back half identical). It reproduces byte-for-byte
+with the presence packing disabled, so it is not round 4's. This is the same
+reflection hole `dev-acorn-throughput.md` §7 records for
+`for…in` / `Object.keys` over fnctor instances, now with a concrete `in`
+repro — which is what a bug report for it would need.

--- a/plan/issues/3780-acorn-wasm-faster-than-node.md
+++ b/plan/issues/3780-acorn-wasm-faster-than-node.md
@@ -4,7 +4,7 @@ title: "Compile Acorn parse hot path to Wasm faster than native Node"
 status: in-progress
 sprint: current
 created: 2026-07-29
-updated: 2026-07-29
+updated: 2026-07-31
 priority: high
 horizon: l
 feasibility: hard
@@ -27,7 +27,17 @@ files:
   - src/codegen/context/types.ts
   - src/codegen/declarations/param-return-inference.ts
   - src/codegen/expressions.ts
+  - src/codegen/expressions/assignment.ts
   - src/codegen/fnctor-escape-gate.ts
+  - src/codegen/fnctor-identity-fields.ts
+  - src/codegen/fnctor-presence-bits.ts
+  - src/codegen/interned-boolean-boxes.ts
+  - src/codegen/member-get-dispatch.ts
+  - src/codegen/member-set-dispatch.ts
+  - src/codegen/object-runtime.ts
+  - src/codegen/program-abi-signatures.ts
+  - src/codegen/registry/imports.ts
+  - src/codegen/struct-field-exports.ts
   - src/codegen/index.ts
   - src/codegen/native-regex.ts
   - src/codegen/declarations/declared-nested-write.ts
@@ -409,6 +419,97 @@ top-level benchmark/parser driver remains direct (`benchmarkUsesIr: false`),
 while 15 reachable character/RegExp helpers are now IR-emitted. These
 representation wins apply to the direct parser path and remain parity
 requirements as the rest of that call graph migrates to IR.
+
+### Runtime-dynamic optimization round 4 — allocation volume
+
+**Different box, so read the deltas and not the absolute times.** Rounds 1-3
+were taken on Node 24.4.1 / arm64 macOS. This round is a 4-core / 16 GB Linux
+container on **Node 22.22.2**, where the profile is not the same shape: a
+debug-named 30-parse profile attributes **36.7%** of the standalone parse to
+`(garbage collector)`, against the 4.3% and 1.5% the two round-3-era profiles
+recorded. Cross-machine wall-clock is not comparable and no comparison against
+a committed baseline is made here. What IS comparable — and is what this round
+is argued on — are **same-process paired A/B measurements** and the
+**deterministic allocation counters**, both taken on one box within minutes of
+each other.
+
+The lever this exposes is allocation *volume*, which nothing in rounds 1-3
+measured. Summing inter-GC heap growth from `--trace-gc` over 12 parses:
+the standalone module allocates **58.0 MB per parse of the 226 KB source**,
+about 257 bytes for every source byte. Only ~10 MB of that is the AST it
+returns (32,487 `Node` structs plus 4,275 arrays and 126 KB of token strings,
+counted from native acorn) — the rest is transient.
+
+Two package-independent lowerings cut it. Both are behaviour-preserving
+representation changes, neither is specific to acorn, and each ships with a
+paired control so the attribution is measured rather than argued:
+
+1. **Packed own-property presence flags** (`JS2WASM_PACKED_PRESENCE_BITS=0`).
+   #2847 gives every conditionally-assigned fnctor property a hidden
+   `$has_<name>` slot so an untouched default stays distinguishable from an
+   explicit `null`/`0`. One whole `i32` per tracked property is correct but is
+   paid on every instance: acorn's `Node` carries 63 tracked properties, so the
+   flags alone were 252 bytes of a 536-byte AST node. They now live in
+   `$presence_<w>` bit words — `Node` goes from **130 fields / 536 B to 69
+   fields / 292 B**. The control strides the bit assignment by a full word so
+   each flag lands alone in its own slot, which reproduces the old footprint
+   through the identical read/write lowering; the A/B therefore isolates the
+   layout, not the instruction mix.
+2. **Interned boolean carriers** (`JS2WASM_INTERNED_BOOL_BOXES=0`). A JS
+   boolean is a primitive with no observable identity, the carrier's `value`
+   field is already immutable, and every consumer discriminates it by
+   `ref.test`/`struct.get` rather than by reference — so the program needs
+   exactly two carriers, built in the global init. `__box_boolean` collapses to
+   a `global.get`. It is inlined by `wasm-opt` into **742 static `struct.new`
+   sites**, the hottest being the boolean arms of `__extern_get`'s
+   closed-struct field ladder, so this fires per boolean-typed property read.
+
+Allocation per parse, one binary per process, 12 parses each (deterministic —
+this metric does not move with box load):
+
+| build | allocated / parse | vs baseline |
+| --- | ---: | ---: |
+| baseline (both controls off) | 58.0 MB | — |
+| packed presence only | 50.0 MB | −13.8% |
+| interned booleans only | 52.0 MB | −10.3% |
+| **both** | **43.6 MB** | **−24.8%** |
+
+The two are additive to within 0.4 MB (58.0 − 8.0 − 6.0 = 44.0 measured 43.6),
+which is the cross-check that they are independent effects and not one effect
+counted twice. The 6.0 MB boolean figure implies roughly 375,000 boolean boxes
+per parse at 16 B each.
+
+Wall clock, all four builds instantiated in **one process** and run in rotating
+order for 45 rounds so contention drift hits every variant alike:
+
+| build | min | p25 | median |
+| --- | ---: | ---: | ---: |
+| baseline | 109.8 ms | 119.1 ms | 125.6 ms |
+| packed presence only | 106.5 ms | 114.7 ms | 122.9 ms |
+| interned booleans only | 111.2 ms | 116.4 ms | 124.2 ms |
+| **both** | **103.9 ms** | **111.6 ms** | **116.3 ms** |
+
+Combined: **−5.4% min / −6.3% p25 / −7.4% median**. The single-lowering rows
+are inside the run-to-run noise of each other and are quoted only as directions;
+the combined row is the one that is separated from baseline in every statistic,
+and it agrees with the independent `--trace-gc` accounting (GC 30.1 → 22.5 ms
+per parse on a separate paired run, i.e. ≈7.6 ms of a ≈120 ms parse).
+
+Cost: the stripped binary grows **1,670,971 → 1,673,257 bytes (+0.14%)** — the
+struct loses 61 fields but each presence test gains a mask-and-compare. The
+`__npmCompatStandaloneBenchmark` export still returns checksum **422** with
+**zero imports**, and the pinned official Acorn suite is unchanged at
+**3,507/3,518 (99.69%)**.
+
+**This does not close the gap and is not claimed to.** On this box the same
+paired protocol leaves Node roughly an order of magnitude ahead; the honest
+reading is that ~24.8% less allocation buys ~7%, and that **34 MB of the
+remaining 43.6 MB per parse is still transient garbage that the returned AST
+does not account for** — about 810 bytes per token. Locating it needs a
+per-type allocation census, which this round did not build: V8's sampling heap
+profiler does not attribute WasmGC `struct.new` (measured: 0.2 MB of a 58 MB
+parse sampled), and `--trace-gc-object-stats` is unavailable on this Node. That
+census is the recommended next step, ahead of another micro-lowering.
 
 ## Compile-time static outcome
 

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -35,6 +35,7 @@ import { emitTaDynViewElementSet, emitTaViewElementSet } from "../dataview-nativ
 import { buildDestructureNullThrow, patternIteratorStepCount } from "../destructuring-params.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { resolveReceiverStruct } from "../fnctor-escape-gate.js"; // (#2681/#2686 A3) pinned-struct write dispatch
+import { presenceSetInstrs, presenceSlotOf } from "../fnctor-presence-bits.js"; // (#3780) packed own-presence flags
 import { tryEmitTypedThisFieldSet } from "../typed-this.js"; // (#3683 S2) typed-`this` field write
 import { reserveMemberSetDispatch } from "../member-set-dispatch.js"; // (#2681/#2686 A3) pre-check set dispatcher
 import { reserveMemberGetDispatch } from "../member-get-dispatch.js"; // (#2681/#2686) symmetric struct read for compound
@@ -3938,9 +3939,7 @@ function compilePropertyAssignment(
 
   const fieldIdx = fields.findIndex((f) => f.name === fieldName);
   if (fieldIdx === -1) return null;
-  const presenceFieldIdx = fields[fieldIdx]!.presenceTracked
-    ? fields.findIndex((field) => field.name === `$has_${fieldName}`)
-    : -1;
+  const presenceSlot = presenceSlotOf(fields, fieldName);
 
   const structSelfType: ValType = { kind: "ref_null", typeIdx: structTypeIdx };
   const structObjResult = compileExpression(ctx, fctx, target.expression, structSelfType);
@@ -3974,16 +3973,10 @@ function compilePropertyAssignment(
         { op: "local.get", index: tmpRecv },
         { op: "local.get", index: tmpVal },
         { op: "struct.set", typeIdx: structTypeIdx, fieldIdx },
-        ...(presenceFieldIdx >= 0
-          ? ([
-              { op: "local.get", index: tmpRecv },
-              { op: "i32.const", value: 1 },
-              { op: "struct.set", typeIdx: structTypeIdx, fieldIdx: presenceFieldIdx },
-            ] as Instr[])
-          : []),
+        ...(presenceSlot ? presenceSetInstrs(structTypeIdx, presenceSlot, tmpRecv) : []),
       ],
     });
-  } else if (presenceFieldIdx >= 0) {
+  } else if (presenceSlot) {
     // Preserve the receiver as well as the RHS so the hidden presence slot can
     // be marked after the real field write.
     fctx.body.push({ op: "local.set", index: tmpVal });
@@ -3992,9 +3985,7 @@ function compilePropertyAssignment(
     fctx.body.push({ op: "local.get", index: tmpRecv });
     fctx.body.push({ op: "local.get", index: tmpVal });
     fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx });
-    fctx.body.push({ op: "local.get", index: tmpRecv });
-    fctx.body.push({ op: "i32.const", value: 1 });
-    fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx: presenceFieldIdx });
+    for (const instr of presenceSetInstrs(structTypeIdx, presenceSlot, tmpRecv)) fctx.body.push(instr);
   } else {
     fctx.body.push({ op: "local.tee", index: tmpVal });
     fctx.body.push({ op: "struct.set", typeIdx: structTypeIdx, fieldIdx });

--- a/src/codegen/fnctor-identity-fields.ts
+++ b/src/codegen/fnctor-identity-fields.ts
@@ -2,6 +2,7 @@
 
 import type { FieldDef } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { presenceWordName } from "./fnctor-presence-bits.js";
 
 export const FNCTOR_CONSTRUCTOR_FIELD = "$constructor";
 
@@ -15,9 +16,24 @@ export function appendFnctorInternalFields(
   fields: FieldDef[],
   onlyConditional: ReadonlyMap<string, boolean>,
 ): void {
-  for (const field of fields.filter((candidate) => onlyConditional.get(candidate.name) === true)) {
+  // (#3780) Presence flags are PACKED — one bit per tracked field, not one
+  // `i32` slot. See `fnctor-presence-bits.ts` for why: on acorn's `Node` the
+  // unpacked form was 252 bytes of every AST node.
+  //
+  // `JS2WASM_PACKED_PRESENCE_BITS=0` is the paired control: it strides the bit
+  // assignment by a full word, so every tracked field lands alone in its own
+  // `$presence_<n>` slot and the struct regains the pre-#3780 footprint. Read
+  // and write lowering is byte-for-byte the same in both modes, which is the
+  // point — the A/B then isolates the LAYOUT from the instruction mix.
+  const stride = process.env.JS2WASM_PACKED_PRESENCE_BITS === "0" ? 32 : 1;
+  const tracked = fields.filter((candidate) => onlyConditional.get(candidate.name) === true);
+  tracked.forEach((field, index) => {
     field.presenceTracked = true;
-    fields.push({ name: `$has_${field.name}`, type: { kind: "i32" }, mutable: true });
+    field.presenceBit = index * stride;
+  });
+  const wordCount = tracked.length === 0 ? 0 : (((tracked.length - 1) * stride) >>> 5) + 1;
+  for (let word = 0; word < wordCount; word++) {
+    fields.push({ name: presenceWordName(word * 32), type: { kind: "i32" }, mutable: true });
   }
   if (ctx.standalone) {
     fields.push({ name: FNCTOR_CONSTRUCTOR_FIELD, type: { kind: "externref" }, mutable: false });

--- a/src/codegen/fnctor-presence-bits.ts
+++ b/src/codegen/fnctor-presence-bits.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { FieldDef, Instr } from "../ir/types.js";
+
+/**
+ * (#3780) Packed own-property presence flags for conditionally-assigned fnctor
+ * fields.
+ *
+ * #2847 gave every conditionally-assigned property a hidden `$has_<name>` slot
+ * so an untouched default is distinguishable from an explicit `null`/`0`. One
+ * whole `i32` per tracked property is correct but expensive in the only place
+ * that matters — object size. Acorn's `Node` has 63 tracked properties, so the
+ * flags alone were 252 bytes of a ~536-byte AST node, and the standalone
+ * self-parse allocates ~32.5k of them.
+ *
+ * The flags now live in `$presence_<w>` words appended after the source fields:
+ * tracked field `i` occupies bit `i & 31` of word `i >>> 5`. 63 flags collapse
+ * from 63 slots to 2.
+ *
+ * Presence is a per-instance bit, never a value, so nothing outside this module
+ * needs the physical layout — call sites ask for a {@link PresenceSlot} and emit
+ * through {@link presenceTestInstrs} / {@link presenceSetInstrs}.
+ */
+export interface PresenceSlot {
+  /** Physical field index of the `$presence_<w>` word holding the bit. */
+  readonly wordFieldIdx: number;
+  /** Single-bit mask selecting this field inside that word. */
+  readonly mask: number;
+}
+
+/** Name of the packed presence word holding bit `bit`. */
+export function presenceWordName(bit: number): string {
+  return `$presence_${bit >>> 5}`;
+}
+
+/**
+ * Resolve `fieldName`'s presence slot, or `undefined` when the field is not
+ * presence-tracked (always-present fields need no check at all).
+ */
+export function presenceSlotOf(
+  fields: readonly (FieldDef | undefined)[] | undefined,
+  fieldName: string,
+): PresenceSlot | undefined {
+  if (!fields) return undefined;
+  const field = fields.find((candidate) => candidate?.name === fieldName);
+  if (!field?.presenceTracked || field.presenceBit === undefined) return undefined;
+  const wordFieldIdx = fields.findIndex((candidate) => candidate?.name === presenceWordName(field.presenceBit!));
+  if (wordFieldIdx < 0) return undefined;
+  // `1 << 31` is negative in JS; wasm `i32.const` is signed LEB128, so the
+  // negative literal encodes the same 32-bit pattern the mask needs.
+  return { wordFieldIdx, mask: (1 << (field.presenceBit & 31)) | 0 };
+}
+
+/**
+ * Consume a struct reference on the stack, push `1` when the field is present
+ * and `0` otherwise.
+ *
+ * Normalized rather than left as the raw masked word because several consumers
+ * hand the result straight to a `return` whose value reaches the host as a
+ * boolean (`__shas_<name>`), where a mask like `4096` would read as a bare
+ * number. Inside a branch the extra `i32.ne` folds away.
+ */
+export function presenceTestInstrs(structTypeIdx: number, slot: PresenceSlot): Instr[] {
+  return [
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: slot.wordFieldIdx },
+    { op: "i32.const", value: slot.mask },
+    { op: "i32.and" },
+    { op: "i32.const", value: 0 },
+    { op: "i32.ne" },
+  ];
+}
+
+/**
+ * Mark the field present. `pushReceiver` must emit the receiver as a
+ * `(ref $struct)` and is used TWICE: setting one bit is a read-modify-write of
+ * a shared word, so unlike the old one-slot-per-field `struct.set` the
+ * reference cannot simply be consumed off the stack. Callers pass a repeatable
+ * producer (a `local.get`, or a `local.get` + `ref.cast`), never a
+ * side-effecting expression.
+ */
+export function presenceSetInstrs(
+  structTypeIdx: number,
+  slot: PresenceSlot,
+  pushReceiver: readonly Instr[] | number,
+): Instr[] {
+  const recv: readonly Instr[] =
+    typeof pushReceiver === "number" ? [{ op: "local.get", index: pushReceiver }] : pushReceiver;
+  return [
+    ...recv,
+    ...recv,
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: slot.wordFieldIdx },
+    { op: "i32.const", value: slot.mask },
+    { op: "i32.or" },
+    { op: "struct.set", typeIdx: structTypeIdx, fieldIdx: slot.wordFieldIdx },
+  ];
+}

--- a/src/codegen/interned-boolean-boxes.ts
+++ b/src/codegen/interned-boolean-boxes.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+
+/**
+ * (#3780) `__box_boolean`'s body, with the two carriers INTERNED rather than
+ * allocated.
+ *
+ * A JS boolean is a primitive: `true` has no observable identity, the carrier's
+ * `value` field is immutable, and every consumer discriminates it with
+ * `ref.test`/`struct.get` rather than by reference. So the whole program needs
+ * exactly two carriers, built once in the global init, and boxing collapses to
+ * a `global.get`.
+ *
+ * This matters because `__box_boolean` is INLINED by `wasm-opt` into every
+ * boolean-producing site — on the standalone acorn self-parse that is 742
+ * static `struct.new` sites, the hottest of them the boolean arms of
+ * `__extern_get`'s closed-struct field ladder. Each fired a fresh 16-byte GC
+ * object on a path that runs millions of times per parse; interning removed
+ * ~6 MB of the 58 MB allocated per parse.
+ *
+ * `mutable: false` globals with a `struct.new` initializer mirror the
+ * `__undefined` singleton in `any-helpers.ts`, which already relies on
+ * `struct.new` being a valid constant expression under the GC proposal.
+ *
+ * `JS2WASM_INTERNED_BOOL_BOXES=0` restores the allocating body — the paired
+ * control the measurement above was taken against.
+ */
+export function boxBooleanBody(ctx: CodegenContext, boxBoolStructIdx: number): Instr[] {
+  const allocating: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "struct.new", typeIdx: boxBoolStructIdx },
+    { op: "extern.convert_any" },
+  ];
+  if (process.env.JS2WASM_INTERNED_BOOL_BOXES === "0") return allocating;
+
+  const carrier = (value: number): number => {
+    const globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: value === 1 ? "__box_boolean_true" : "__box_boolean_false",
+      type: { kind: "ref", typeIdx: boxBoolStructIdx },
+      mutable: false,
+      init: [
+        { op: "i32.const", value },
+        { op: "struct.new", typeIdx: boxBoolStructIdx },
+      ],
+    });
+    return globalIdx;
+  };
+  const trueIdx = carrier(1);
+  const falseIdx = carrier(0);
+  return [
+    { op: "local.get", index: 0 },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [{ op: "global.get", index: trueIdx }, { op: "extern.convert_any" }],
+      else: [{ op: "global.get", index: falseIdx }, { op: "extern.convert_any" }],
+    },
+  ];
+}

--- a/src/codegen/member-get-dispatch.ts
+++ b/src/codegen/member-get-dispatch.ts
@@ -59,6 +59,7 @@ import {
 import { coercionInstrs } from "./type-coercion.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 import { undefinedExternInstrs } from "./any-helpers.js";
+import { presenceTestInstrs } from "./fnctor-presence-bits.js"; // (#3780) packed own-presence flags
 
 /** Mangle a property name into the reserved member-get dispatcher name. */
 function dispatcherName(propName: string): string {
@@ -596,11 +597,11 @@ export function fillMemberGetDispatch(ctx: CodegenContext): void {
         ...box,
       ];
       const readInstrs: Instr[] =
-        cand.presenceFieldIdx !== undefined && cand.presenceFieldIdx >= 0
+        cand.presenceSlot !== undefined
           ? [
               { op: "local.get", index: 1 },
               { op: "ref.cast", typeIdx: cand.structTypeIdx },
-              { op: "struct.get", typeIdx: cand.structTypeIdx, fieldIdx: cand.presenceFieldIdx },
+              ...presenceTestInstrs(cand.structTypeIdx, cand.presenceSlot),
               {
                 op: "if",
                 blockType: { kind: "val", type: { kind: "externref" } },
@@ -795,11 +796,11 @@ export function fillTypedMemberGetF64Dispatch(ctx: CodegenContext): void {
       ];
       const armBody: Instr[] = !numericSlot
         ? fallback
-        : cand.presenceFieldIdx !== undefined && cand.presenceFieldIdx >= 0
+        : cand.presenceSlot !== undefined
           ? [
               { op: "local.get", index: 1 },
               { op: "ref.cast", typeIdx: cand.structTypeIdx },
-              { op: "struct.get", typeIdx: cand.structTypeIdx, fieldIdx: cand.presenceFieldIdx },
+              ...presenceTestInstrs(cand.structTypeIdx, cand.presenceSlot),
               {
                 op: "if",
                 blockType: { kind: "val", type: { kind: "f64" } as ValType },

--- a/src/codegen/member-set-dispatch.ts
+++ b/src/codegen/member-set-dispatch.ts
@@ -44,6 +44,7 @@ import { addFuncType } from "./registry/types.js";
 import { addUnionImportsViaRegistry, ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { buildVecFromExternMaterializer, coercionInstrs, getVecInfo } from "./type-coercion.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
+import { presenceSetInstrs } from "./fnctor-presence-bits.js"; // (#3780) packed own-presence flags
 
 /**
  * Mangle a property name + fallback strictness into the reserved dispatcher name.
@@ -186,12 +187,12 @@ export function fillMemberSetDispatch(ctx: CodegenContext): void {
         ...coerce,
         { op: "struct.set", typeIdx: cand.structTypeIdx, fieldIdx: cand.fieldIdx },
       ];
-      if (cand.presenceFieldIdx !== undefined && cand.presenceFieldIdx >= 0) {
+      if (cand.presenceSlot !== undefined) {
         setFieldInstrs.push(
-          { op: "local.get", index: 2 },
-          { op: "ref.cast", typeIdx: cand.structTypeIdx },
-          { op: "i32.const", value: 1 },
-          { op: "struct.set", typeIdx: cand.structTypeIdx, fieldIdx: cand.presenceFieldIdx },
+          ...presenceSetInstrs(cand.structTypeIdx, cand.presenceSlot, [
+            { op: "local.get", index: 2 },
+            { op: "ref.cast", typeIdx: cand.structTypeIdx },
+          ]),
         );
       }
       return [

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -102,6 +102,8 @@ import { emitSelfHostedFunc } from "./stdlib-selfhost.js"; // (#3160) self-hoste
 import { SELF_HOSTED_OBJECT_RUNTIME } from "../stdlib/object-runtime.js"; // (#3160) TS-source builtins
 import { buildObjectDescriptorHelpers } from "./object-runtime-descriptors.js";
 import { exposedClosedStructFieldName, isOpenDescriptorShape } from "./property-descriptor-shape.js";
+import type { PresenceSlot } from "./fnctor-presence-bits.js"; // (#3780) packed own-presence flags
+import { presenceSlotOf, presenceTestInstrs } from "./fnctor-presence-bits.js";
 import { buildObjectEnumerationHelpers } from "./object-runtime-enumeration.js"; // (#3274 wave-B) enumeration/array-like/object-static helper builders
 import { buildObjectPrototypeHelpers } from "./object-runtime-prototype.js"; // (#3274 wave-B) prototype-chain helper builders
 import * as fnctorArray from "./fnctor-array-prototype.js";
@@ -6291,7 +6293,7 @@ export function fillClosedStructHasOwnArms(ctx: CodegenContext): void {
 
   type Entry = {
     typeIdx: number;
-    presenceFieldIdx?: number;
+    presenceSlot?: PresenceSlot;
     shapeFieldIdx?: number;
     shapeId?: number;
   };
@@ -6304,10 +6306,8 @@ export function fillClosedStructHasOwnArms(ctx: CodegenContext): void {
     const shapeId = ctx.shapeIdByStructName.get(structName);
     for (const field of fields) {
       if (!field?.name || field.name.startsWith("$") || field.name.startsWith("__")) continue;
-      const presenceFieldIdx = field.presenceTracked
-        ? fields.findIndex((candidate) => candidate?.name === `$has_${field.name}`)
-        : -1;
-      if (presenceFieldIdx >= 0) {
+      const presenceSlot = presenceSlotOf(fields, field.name);
+      if (presenceSlot) {
         const typeDef = ctx.mod.types[typeIdx];
         const physicalFields =
           typeDef?.kind === "struct"
@@ -6315,9 +6315,9 @@ export function fillClosedStructHasOwnArms(ctx: CodegenContext): void {
             : typeDef?.kind === "sub" && typeDef.type.kind === "struct"
               ? typeDef.type.fields
               : [];
-        if (presenceFieldIdx >= physicalFields.length) {
+        if (presenceSlot.wordFieldIdx >= physicalFields.length) {
           throw new Error(
-            `closed-struct-has-own presence mismatch: ${structName}.${field.name} index ${presenceFieldIdx}, physical ${physicalFields.length}`,
+            `closed-struct-has-own presence mismatch: ${structName}.${field.name} word ${presenceSlot.wordFieldIdx}, physical ${physicalFields.length}`,
           );
         }
       }
@@ -6328,7 +6328,7 @@ export function fillClosedStructHasOwnArms(ctx: CodegenContext): void {
       }
       entries.push({
         typeIdx,
-        ...(presenceFieldIdx >= 0 ? { presenceFieldIdx } : {}),
+        ...(presenceSlot ? { presenceSlot } : {}),
         ...(shapeFieldIdx >= 0 && shapeId !== undefined ? { shapeFieldIdx, shapeId } : {}),
       });
     }
@@ -6344,13 +6344,13 @@ export function fillClosedStructHasOwnArms(ctx: CodegenContext): void {
       const receiverArms: Instr[] = [];
       for (const entry of entries) {
         const returnPresence: Instr[] =
-          entry.presenceFieldIdx === undefined
+          entry.presenceSlot === undefined
             ? [{ op: "i32.const", value: 1 }, { op: "return" }]
             : [
                 { op: "local.get", index: 0 },
                 { op: "any.convert_extern" },
                 { op: "ref.cast", typeIdx: entry.typeIdx },
-                { op: "struct.get", typeIdx: entry.typeIdx, fieldIdx: entry.presenceFieldIdx },
+                ...presenceTestInstrs(entry.typeIdx, entry.presenceSlot),
                 { op: "return" },
               ];
         const exactThen: Instr[] =
@@ -6458,7 +6458,7 @@ export function fillClosedStructOwnPropertyNamesArms(ctx: CodegenContext): void 
   const objVecPushIdx = ctx.funcMap.get("__objvec_push");
   if (!fn || objVecPushIdx === undefined) return;
 
-  type OwnField = { name: string; presenceFieldIdx?: number };
+  type OwnField = { name: string; presenceSlot?: PresenceSlot };
   type ShapeEntry = {
     typeIdx: number;
     fields: OwnField[];
@@ -6475,12 +6475,10 @@ export function fillClosedStructOwnPropertyNamesArms(ctx: CodegenContext): void 
     const byName = new Map<string, OwnField>();
     for (const field of fields) {
       if (!field?.name || field.name.startsWith("$") || field.name.startsWith("__")) continue;
-      const presenceFieldIdx = field.presenceTracked
-        ? fields.findIndex((candidate) => candidate?.name === `$has_${field.name}`)
-        : -1;
+      const presenceSlot = presenceSlotOf(fields, field.name);
       byName.set(field.name, {
         name: field.name,
-        ...(presenceFieldIdx >= 0 ? { presenceFieldIdx } : {}),
+        ...(presenceSlot ? { presenceSlot } : {}),
       });
     }
     if (byName.size === 0) continue;
@@ -6506,14 +6504,14 @@ export function fillClosedStructOwnPropertyNamesArms(ctx: CodegenContext): void 
         { op: "extern.convert_any" },
         { op: "call", funcIdx: objVecPushIdx },
       ];
-      if (field.presenceFieldIdx === undefined) {
+      if (field.presenceSlot === undefined) {
         pushFields.push(...pushName);
       } else {
         pushFields.push(
           { op: "local.get", index: 0 },
           { op: "any.convert_extern" },
           { op: "ref.cast", typeIdx: entry.typeIdx },
-          { op: "struct.get", typeIdx: entry.typeIdx, fieldIdx: field.presenceFieldIdx },
+          ...presenceTestInstrs(entry.typeIdx, field.presenceSlot),
           { op: "if", blockType: { kind: "empty" }, then: pushName },
         );
       }
@@ -6580,7 +6578,7 @@ export function fillClosedStructExternGetArms(ctx: CodegenContext): void {
     fieldIdx: number;
     fieldType: ValType;
     jsBoolean: boolean;
-    presenceFieldIdx?: number;
+    presenceSlot?: PresenceSlot;
     shapeFieldIdx?: number;
     shapeId?: number;
   };
@@ -6606,9 +6604,7 @@ export function fillClosedStructExternGetArms(ctx: CodegenContext): void {
         (field.type.kind === "i32" &&
           (field.jsBoolean || field.type.boolean ? boxBooleanIdx !== undefined : boxNumberIdx !== undefined));
       if (!boxable) continue;
-      const presenceFieldIdx = field.presenceTracked
-        ? fields.findIndex((candidate) => candidate?.name === `$has_${field.name}`)
-        : -1;
+      const presenceSlot = presenceSlotOf(fields, field.name);
       let entries = byField.get(exposedFieldName);
       if (!entries) {
         entries = [];
@@ -6619,7 +6615,7 @@ export function fillClosedStructExternGetArms(ctx: CodegenContext): void {
         fieldIdx,
         fieldType: field.type,
         jsBoolean: field.jsBoolean === true || (field.type.kind === "i32" && field.type.boolean === true),
-        ...(presenceFieldIdx >= 0 ? { presenceFieldIdx } : {}),
+        ...(presenceSlot ? { presenceSlot } : {}),
         ...(shapeFieldIdx >= 0 && shapeId !== undefined ? { shapeFieldIdx, shapeId } : {}),
       });
     }
@@ -6648,12 +6644,12 @@ export function fillClosedStructExternGetArms(ctx: CodegenContext): void {
     const receiverArms: Instr[] = [];
     for (const entry of entries) {
       const then: Instr[] = [];
-      if (entry.presenceFieldIdx !== undefined) {
+      if (entry.presenceSlot !== undefined) {
         then.push(
           { op: "local.get", index: 0 },
           { op: "any.convert_extern" },
           { op: "ref.cast", typeIdx: entry.typeIdx },
-          { op: "struct.get", typeIdx: entry.typeIdx, fieldIdx: entry.presenceFieldIdx },
+          ...presenceTestInstrs(entry.typeIdx, entry.presenceSlot),
           { op: "i32.eqz" },
           {
             op: "if",

--- a/src/codegen/program-abi-signatures.ts
+++ b/src/codegen/program-abi-signatures.ts
@@ -50,6 +50,10 @@ function canonicalProgramAbiField(field: FieldDef): object {
     mutable: field.mutable,
     ...(field.jsBoolean === true ? { jsBoolean: true as const } : {}),
     ...(field.presenceTracked === true ? { presenceTracked: true as const } : {}),
+    // (#3780) The presence BIT is part of the physical layout — two modules
+    // that agree on which fields are tracked but disagree on bit assignment do
+    // not share an ABI.
+    ...(field.presenceBit === undefined ? {} : { presenceBit: field.presenceBit }),
   };
 }
 

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -19,6 +19,8 @@ import type { FieldDef, Instr, ValType } from "../ir/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { emitBoundsCheckedArrayGet } from "./array-methods.js";
 import { emitHoleToUndefined } from "./array-holes.js"; // (#2001 S1)
+import type { PresenceSlot } from "./fnctor-presence-bits.js"; // (#3780) packed own-presence flags
+import { presenceSlotOf, presenceTestInstrs } from "./fnctor-presence-bits.js";
 import { classMemberFuncKey, resolveMethodOwnerClass } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys; (#2963) method-owner chain
 import { popBody, pushBody } from "./context/bodies.js";
 import { resolveWidenedVarKey, integrityVarKey } from "./widened-var-key.js";
@@ -1200,14 +1202,14 @@ export function findAlternateStructsForField(
   fieldIdx: number;
   fieldType: ValType;
   mutable: boolean;
-  presenceFieldIdx?: number;
+  presenceSlot?: PresenceSlot;
 }[] {
   const result: {
     structTypeIdx: number;
     fieldIdx: number;
     fieldType: ValType;
     mutable: boolean;
-    presenceFieldIdx?: number;
+    presenceSlot?: PresenceSlot;
   }[] = [];
   for (const [typeName, fields] of ctx.structFields) {
     const sIdx = ctx.structMap.get(typeName);
@@ -1219,9 +1221,7 @@ export function findAlternateStructsForField(
         fieldIdx: fIdx,
         fieldType: fields[fIdx]!.type,
         mutable: fields[fIdx]!.mutable,
-        ...(fields[fIdx]!.presenceTracked
-          ? { presenceFieldIdx: fields.findIndex((field) => field.name === `$has_${propName}`) }
-          : {}),
+        ...(presenceSlotOf(fields, propName) ? { presenceSlot: presenceSlotOf(fields, propName)! } : {}),
       });
     }
   }
@@ -1241,15 +1241,11 @@ export function emitNullGuardedStructGet(
   // For result type in the if block, normalize ref to ref_null so the null branch is valid
   const resultType: ValType =
     fieldType.kind === "ref" ? { kind: "ref_null", typeIdx: (fieldType as any).typeIdx } : fieldType;
-  let primaryPresenceFieldIdx: number | undefined;
+  let primaryPresenceSlot: PresenceSlot | undefined;
   if (propName) {
     for (const [structName, fields] of ctx.structFields) {
       if (ctx.structMap.get(structName) !== typeIdx) continue;
-      const field = fields[fieldIdx];
-      if (field?.presenceTracked) {
-        const idx = fields.findIndex((candidate) => candidate.name === `$has_${propName}`);
-        if (idx >= 0) primaryPresenceFieldIdx = idx;
-      }
+      if (fields[fieldIdx]?.presenceTracked) primaryPresenceSlot = presenceSlotOf(fields, propName);
       break;
     }
   }
@@ -1281,10 +1277,10 @@ export function emitNullGuardedStructGet(
         blockType: { kind: "val" as const, type: resultType },
         then: typeErrorThrowInstrs(ctx),
         else:
-          primaryPresenceFieldIdx !== undefined
+          primaryPresenceSlot !== undefined
             ? [
                 { op: "local.get", index: tmp },
-                { op: "struct.get", typeIdx, fieldIdx: primaryPresenceFieldIdx },
+                ...presenceTestInstrs(typeIdx, primaryPresenceSlot),
                 {
                   op: "if",
                   blockType: { kind: "val", type: resultType },
@@ -1329,11 +1325,11 @@ export function emitNullGuardedStructGet(
             op: "if",
             blockType: { kind: "empty" },
             then: [
-              ...(alt.presenceFieldIdx !== undefined && alt.presenceFieldIdx >= 0
+              ...(alt.presenceSlot !== undefined
                 ? ([
                     { op: "local.get", index: srcLocal },
                     { op: "ref.cast", typeIdx: alt.structTypeIdx },
-                    { op: "struct.get", typeIdx: alt.structTypeIdx, fieldIdx: alt.presenceFieldIdx },
+                    ...presenceTestInstrs(alt.structTypeIdx, alt.presenceSlot),
                     {
                       op: "if",
                       blockType: { kind: "val", type: resultType },
@@ -1408,11 +1404,11 @@ export function emitNullGuardedStructGet(
                     op: "if",
                     blockType: { kind: "empty" },
                     then: [
-                      ...(primaryPresenceFieldIdx !== undefined
+                      ...(primaryPresenceSlot !== undefined
                         ? ([
                             { op: "local.get", index: backupLocal },
                             { op: "ref.cast", typeIdx },
-                            { op: "struct.get", typeIdx, fieldIdx: primaryPresenceFieldIdx },
+                            ...presenceTestInstrs(typeIdx, primaryPresenceSlot),
                             {
                               op: "if",
                               blockType: { kind: "val", type: resultType },
@@ -1448,11 +1444,11 @@ export function emitNullGuardedStructGet(
       op: "if",
       blockType: { kind: "empty" },
       then: [
-        ...(primaryPresenceFieldIdx !== undefined
+        ...(primaryPresenceSlot !== undefined
           ? ([
               { op: "local.get", index: tmpAny },
               { op: "ref.cast", typeIdx },
-              { op: "struct.get", typeIdx, fieldIdx: primaryPresenceFieldIdx },
+              ...presenceTestInstrs(typeIdx, primaryPresenceSlot),
               {
                 op: "if",
                 blockType: { kind: "val", type: resultType },
@@ -1685,14 +1681,11 @@ export function emitExternrefToStructGet(
   // For result type, normalize ref to ref_null so the null branch is valid
   const resultType: ValType =
     fieldType.kind === "ref" ? { kind: "ref_null", typeIdx: (fieldType as any).typeIdx } : fieldType;
-  let primaryPresenceFieldIdx: number | undefined;
+  let primaryPresenceSlot: PresenceSlot | undefined;
   if (propName) {
     for (const [structName, fields] of ctx.structFields) {
       if (ctx.structMap.get(structName) !== structTypeIdx) continue;
-      if (fields[fieldIdx]?.presenceTracked) {
-        const idx = fields.findIndex((candidate) => candidate.name === `$has_${propName}`);
-        if (idx >= 0) primaryPresenceFieldIdx = idx;
-      }
+      if (fields[fieldIdx]?.presenceTracked) primaryPresenceSlot = presenceSlotOf(fields, propName);
       break;
     }
   }
@@ -1813,11 +1806,11 @@ export function emitExternrefToStructGet(
           op: "if",
           blockType: { kind: "empty" },
           then: [
-            ...(alt.presenceFieldIdx !== undefined && alt.presenceFieldIdx >= 0
+            ...(alt.presenceSlot !== undefined
               ? ([
                   { op: "local.get", index: tmpAny },
                   { op: "ref.cast", typeIdx: alt.structTypeIdx },
-                  { op: "struct.get", typeIdx: alt.structTypeIdx, fieldIdx: alt.presenceFieldIdx },
+                  ...presenceTestInstrs(alt.structTypeIdx, alt.presenceSlot),
                   {
                     op: "if",
                     blockType: { kind: "val", type: resultType },
@@ -1863,11 +1856,11 @@ export function emitExternrefToStructGet(
     op: "if",
     blockType: { kind: "empty" },
     then: [
-      ...(primaryPresenceFieldIdx !== undefined
+      ...(primaryPresenceSlot !== undefined
         ? ([
             { op: "local.get", index: tmpAny },
             { op: "ref.cast", typeIdx: structTypeIdx },
-            { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: primaryPresenceFieldIdx },
+            ...presenceTestInstrs(structTypeIdx, primaryPresenceSlot),
             {
               op: "if",
               blockType: { kind: "val", type: resultType },

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -26,6 +26,7 @@ import { STANDALONE_REGEXP_REFLECTION_PROPS } from "../regexp-standalone.js";
 import { reconcileNativeStrFinalizeShift } from "../expressions/late-imports.js";
 import { emitWasiErrorConstructor } from "./error-types.js";
 import { emitNativeParseNumber } from "../parse-number-native.js";
+import { boxBooleanBody } from "../interned-boolean-boxes.js"; // (#3780) interned true/false carriers
 import { isTupleType, isStandaloneRegExpMatchArrayValue } from "../index.js";
 import { planProgramAbiStringConstantImport } from "../program-abi-import-planning.js";
 
@@ -1223,12 +1224,8 @@ export function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
     [{ name: "$any_temp", type: { kind: "anyref" } as ValType }],
   );
 
-  // 5. __box_boolean(i32) -> externref
-  registerNative("__box_boolean", i32ToExternref, [
-    { op: "local.get", index: 0 },
-    { op: "struct.new", typeIdx: boxBoolStructIdx },
-    { op: "extern.convert_any" },
-  ]);
+  // 5. __box_boolean(i32) -> externref — interned carriers (#3780).
+  registerNative("__box_boolean", i32ToExternref, boxBooleanBody(ctx, boxBoolStructIdx));
 
   // #1644 Slice E1 — __box_bigint(i64) -> externref. In no-JS-host mode a
   // bigint-branded i64 needs a WasmGC carrier so it cannot fall through to the

--- a/src/codegen/struct-field-exports.ts
+++ b/src/codegen/struct-field-exports.ts
@@ -14,6 +14,8 @@ import type { CodegenContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
 import { addStringConstantGlobal, addUnionImports } from "./registry/imports.js";
 import { isSyntheticStructName } from "./emit-helpers.js";
+import type { PresenceSlot } from "./fnctor-presence-bits.js"; // (#3780) packed own-presence flags
+import { presenceSlotOf, presenceTestInstrs } from "./fnctor-presence-bits.js";
 import { UNDEF_F64_BITS } from "./value-tags.js";
 import { DATA_STRUCT_HOST_BRIDGE_ORDINAL, publishDataStructHostBridge } from "./data-struct-host-bridge.js";
 
@@ -60,20 +62,17 @@ export function emitStructFieldPresenceGetters(ctx: CodegenContext): void {
 
   const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$shas_type");
   for (const fieldName of trackedNames) {
-    const entries: { structTypeIdx: number; presenceFieldIdx?: number }[] = [];
+    const entries: { structTypeIdx: number; presenceSlot?: PresenceSlot }[] = [];
     for (const [structName, fields] of ctx.structFields) {
       if (isSyntheticStructName(structName)) continue;
       const structTypeIdx = ctx.structMap.get(structName);
       if (structTypeIdx === undefined) continue;
       const fieldIdx = fields.findIndex((field) => field?.name === fieldName);
       if (fieldIdx < 0) continue;
-      const field = fields[fieldIdx]!;
-      const presenceFieldIdx = field.presenceTracked
-        ? fields.findIndex((candidate) => candidate?.name === `$has_${fieldName}`)
-        : -1;
+      const presenceSlot = presenceSlotOf(fields, fieldName);
       entries.push({
         structTypeIdx,
-        ...(presenceFieldIdx >= 0 ? { presenceFieldIdx } : {}),
+        ...(presenceSlot ? { presenceSlot } : {}),
       });
     }
     if (entries.length === 0) continue;
@@ -82,11 +81,11 @@ export function emitStructFieldPresenceGetters(ctx: CodegenContext): void {
     for (let i = entries.length - 1; i >= 0; i--) {
       const entry = entries[i]!;
       const then: Instr[] =
-        entry.presenceFieldIdx !== undefined
+        entry.presenceSlot !== undefined
           ? [
               { op: "local.get", index: 1 },
               { op: "ref.cast", typeIdx: entry.structTypeIdx },
-              { op: "struct.get", typeIdx: entry.structTypeIdx, fieldIdx: entry.presenceFieldIdx },
+              ...presenceTestInstrs(entry.structTypeIdx, entry.presenceSlot),
             ]
           : [{ op: "i32.const", value: 1 }];
       dispatch = [

--- a/src/ir/types.ts
+++ b/src/ir/types.ts
@@ -188,6 +188,15 @@ export interface FieldDef {
    * default slot is distinguishable from an explicit null/zero assignment.
    */
   presenceTracked?: true;
+  /**
+   * (#3780) Bit index of this field's presence flag inside the struct's packed
+   * presence words. Only set together with {@link presenceTracked}. The word
+   * holding it is the field named `$presence_<bit >>> 5>`; the mask is
+   * `1 << (bit & 31)`. Packing matters for allocation volume: acorn's `Node`
+   * carries 63 conditionally-assigned properties, which as one `i32` slot each
+   * cost 252 bytes of every AST node — roughly half the object.
+   */
+  presenceBit?: number;
 }
 
 export type ValType =

--- a/tests/issue-3780-allocation-lowerings.test.ts
+++ b/tests/issue-3780-allocation-lowerings.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3780 round 4) Two allocation-volume lowerings for the standalone lane.
+ *
+ * The standalone acorn self-parse allocates ~58 MB per 226 KB source, of which
+ * only ~10 MB is the AST it returns. Two representation changes take ~24.8% off
+ * that, and both are pure size/identity questions with no semantic content:
+ *
+ *  1. **Packed presence flags.** #2847's hidden `$has_<name>` own-presence slot
+ *     is correct but was one whole `i32` per conditionally-assigned property.
+ *     Acorn's `Node` has 63 of them — 252 bytes of a 536-byte AST node. They
+ *     are now bits in `$presence_<w>` words (130 fields → 69).
+ *  2. **Interned boolean carriers.** A JS boolean has no observable identity
+ *     and its carrier field is immutable, so two module-level carriers suffice.
+ *     `__box_boolean` is inlined into every boolean-producing site, so this is
+ *     the difference between a GC object and a `global.get` on a path that runs
+ *     millions of times per parse.
+ *
+ * Each ships with a paired control (`JS2WASM_PACKED_PRESENCE_BITS=0`,
+ * `JS2WASM_INTERNED_BOOL_BOXES=0`) so the measurement is attributable. The
+ * tests below assert the two things that could actually break: that the packed
+ * layout still answers own-presence correctly ACROSS A WORD BOUNDARY (the case
+ * a single-word implementation would silently pass), and that interning is
+ * invisible to boolean semantics.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(source: string, env?: Record<string, string>): Promise<unknown> {
+  const saved: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env ?? {})) {
+    saved[key] = process.env[key];
+    process.env[key] = value;
+  }
+  let result;
+  try {
+    result = await compile(source, { fileName: "t.mjs", skipSemanticDiagnostics: true, target: "standalone" });
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+  if (!result.success) throw new Error(`compile failed: ${result.errors.map((e) => e.message).join("; ")}`);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  (instance.exports as Record<string, () => void>).__module_init?.();
+  return (instance.exports as Record<string, () => unknown>).main!();
+}
+
+async function runHost(source: string): Promise<unknown> {
+  const result = await compile(source, { fileName: "t.mjs", skipSemanticDiagnostics: true });
+  if (!result.success) throw new Error(`compile failed: ${result.errors.map((e) => e.message).join("; ")}`);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, () => unknown>).main!();
+}
+
+/**
+ * 40 conditionally-assigned properties on one constructor — deliberately more
+ * than 32, so `p00`..`p31` and `p32`..`p39` land in DIFFERENT presence words.
+ * A packing bug that ignores the word index, or masks with the wrong bit, shows
+ * up here and nowhere in a small fixture.
+ */
+const CROSS_WORD_PRESENCE = `
+function Bag(seed) { this.seed = seed; }
+export function main() {
+  var total = 0;
+  for (var seed = 0; seed < 41; seed++) {
+    var bag = new Bag(seed);
+${Array.from({ length: 40 }, (_, i) => `    if (seed > ${i}) bag.p${String(i).padStart(2, "0")} = ${i};`).join("\n")}
+    var present = 0;
+${Array.from({ length: 40 }, (_, i) => `    if ("p${String(i).padStart(2, "0")}" in bag) present = present + 1;`).join("\n")}
+    // Every earlier property must still read back its own value, so a shared
+    // word cannot be silently clobbering a sibling's storage either.
+    var sum = 0;
+${Array.from({ length: 40 }, (_, i) => `    if (bag.p${String(i).padStart(2, "0")} !== undefined) sum = sum + bag.p${String(i).padStart(2, "0")};`).join("\n")}
+    total = total + present * 1000 + sum;
+  }
+  return total;
+}
+`;
+
+// seed s assigns p_i for every i < s, so `present` = min(s, 40) and
+// `sum` = sum of 0..min(s,40)-1.
+const EXPECTED_CROSS_WORD = (() => {
+  let total = 0;
+  for (let seed = 0; seed < 41; seed++) {
+    const present = Math.min(seed, 40);
+    let sum = 0;
+    for (let i = 0; i < present; i++) sum += i;
+    total += present * 1000 + sum;
+  }
+  return total;
+})();
+
+const BOOLEAN_IDENTITY = `
+export function main() {
+  var o = { a: true, b: false, c: true };
+  var score = 0;
+  if (o.a === true) score = score + 1;
+  if (o.b === false) score = score + 2;
+  if (o.a === o.c) score = score + 4;         // two boxes, same value
+  if (o.a === o.b) score = score + 8;         // must stay false
+  if (!o.b) score = score + 16;
+  if (o.a) score = score + 32;
+  if (typeof o.a === "boolean") score = score + 64;
+  if (o.a == 1) score = score + 128;          // loose: boolean -> number
+  if (o.b == 0) score = score + 256;
+  score = score + (o.a + 1) * 512;            // ToNumber(true) === 1
+  var flipped = !o.a;
+  if (flipped === false) score = score + 4096;
+  return score;
+}
+`;
+
+// 1 + 2 + 4 + 16 + 32 + 64 + 128 + 256 + 1024 + 4096
+const EXPECTED_BOOLEAN = 1 + 2 + 4 + 16 + 32 + 64 + 128 + 256 + 2 * 512 + 4096;
+
+describe("#3780 — packed own-presence flags", () => {
+  it("answers `in` and reads back values across a presence-word boundary", async () => {
+    expect(await runHost(CROSS_WORD_PRESENCE)).toBe(EXPECTED_CROSS_WORD);
+  });
+
+  /**
+   * The standalone lane is pinned against its own paired control rather than
+   * against `EXPECTED_CROSS_WORD`, because it does NOT currently agree with the
+   * host lane on this fixture: `"pNN" in bag` answers `false` for a fnctor
+   * instance there, so the `present` term drops out (10,660 vs 830,660 — the
+   * value read-back half is identical). That is the standalone reflection hole
+   * already recorded in `plan/agent-context/dev-acorn-throughput.md` §7
+   * (`for…in`/`Object.keys`/presence over fnctor instances), it reproduces
+   * byte-for-byte with packing DISABLED, and it is not this change's to fix.
+   *
+   * Pinning to the control is the assertion that actually matters here anyway:
+   * packing is a pure layout change, so whatever the lane answers, both
+   * layouts must answer the same — including across the 32-bit word boundary,
+   * which a single-word implementation would silently pass.
+   */
+  it("is layout-only: packed and unpacked standalone builds agree", async () => {
+    const packed = await runStandalone(CROSS_WORD_PRESENCE);
+    const unpacked = await runStandalone(CROSS_WORD_PRESENCE, { JS2WASM_PACKED_PRESENCE_BITS: "0" });
+    expect(packed).toBe(unpacked);
+    // The value read-back half does match the host lane; only presence differs.
+    expect(packed).toBe(EXPECTED_CROSS_WORD - 820 * 1000);
+  });
+});
+
+describe("#3780 — interned boolean carriers", () => {
+  it("keeps boolean equality, coercion and truthiness intact", async () => {
+    expect(await runStandalone(BOOLEAN_IDENTITY)).toBe(EXPECTED_BOOLEAN);
+  });
+
+  it("is identity-only: the allocating control produces the identical result", async () => {
+    expect(await runStandalone(BOOLEAN_IDENTITY, { JS2WASM_INTERNED_BOOL_BOXES: "0" })).toBe(EXPECTED_BOOLEAN);
+  });
+});


### PR DESCRIPTION
## Description

This PR implements two allocation-volume lowerings for the standalone acorn parser, reducing per-parse allocation from **58.0 MB to 43.6 MB (−24.8%)** on a 226 KB source. Both are behaviour-preserving representation changes with paired controls for measurement attribution.

### Changes

1. **Packed own-property presence flags** (`JS2WASM_PACKED_PRESENCE_BITS=0` control)
   - #2847 introduced hidden `$has_<name>` slots for conditionally-assigned fnctor properties to distinguish untouched defaults from explicit `null`/`0`
   - One whole `i32` per tracked property was correct but expensive: acorn's `Node` has 63 tracked properties = 252 bytes of a 536-byte AST node
   - Presence flags now live in `$presence_<w>` bit words: **130 fields / 536 B → 69 fields / 292 B**
   - New module: `src/codegen/fnctor-presence-bits.ts` provides `PresenceSlot`, `presenceTestInstrs()`, `presenceSetInstrs()` abstractions
   - Allocation: **58.0 MB → 50.0 MB (−13.8%)**

2. **Interned boolean carriers** (`JS2WASM_INTERNED_BOOL_BOXES=0` control)
   - JS booleans are primitives with no observable identity; the carrier's `value` field is immutable
   - Program needs exactly two carriers (true/false), built once in global init
   - `__box_boolean` inlined by `wasm-opt` into 742 static `struct.new` sites; collapses to `global.get`
   - New module: `src/codegen/interned-boolean-boxes.ts` provides `boxBooleanBody()` with interning logic
   - Allocation: **58.0 MB → 52.0 MB (−10.3%)**

Combined effect: **−24.8%** allocation, **−7.4% median wall clock** (45 rounds, one process, rotating order to isolate from contention drift).

### Measurement & Correctness

- **Allocation metric**: deterministic inter-GC heap growth from `--trace-gc`, not affected by box load
- **Wall clock**: paired A/B in single process with rotating order (±20% cross-process variance eliminated)
- **Correctness**: checksum 422 with zero imports; official Acorn suite **3,507/3,518 (99.69%)** unchanged; 32 pre-existing failures in equivalence tests verified unchanged
- **Binary size**: +0.14% (1,670,971 → 1,673,257 bytes) — struct loses 61 fields but each presence test gains mask-and-compare

### Known Limitations

- **34 MB of the remaining 43.6 MB per parse is still transient garbage** (~810 bytes per token) not accounted for in the returned AST
- V8's sampling heap profiler does not attribute WasmGC `struct.new` (measured 0.2 MB of 58 MB)
- `--trace-gc-object-stats` unavailable on this Node build
- **Per-type allocation census needed** before further optimization (recommended next step)
- Pre-existing bug found: `"prop" in fnctorInstance` answers false in standalone lane (fixture in test file)

### Test Plan

Added `tests/issue-3780-allocation-lowerings.test.ts`:
- Cross-word presence boundary test (40 conditionally-assigned properties, 32+ landing in different presence words)
- Boolean identity/coercion/truthiness test
- Paired control assertions (packed vs unpacked, interned vs allocating)

Existing tests pass; no regressions in equivalence or Acorn suite.

## CLA

- [x] I have read and agree to the CLA

https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL