### PR TITLE
fix(#3636): union the REST fallback — and the open-PR scan is exonerated, not guilty

### DIFF
--- a/plan/issues/3636-claim-issue-allocator-hands-out-taken-ids.md
+++ b/plan/issues/3636-claim-issue-allocator-hands-out-taken-ids.md
@@ -15,22 +15,29 @@ related: [2531, 1616]
 
 ## Five collisions in one sprint
 
-| # | shape | detail |
-|---|---|---|
-| 1 | cross-lane | `--allocate` gave 3585; another lane landed `3585-*` on main mid-flight → renumbered to 3592 |
-| 2 | **self**-collision | one agent filing two issues in quick succession got **3589 twice** → parked PR #3581 on the #1616 integrity gate |
-| 3 | main-vs-PR | PR #3614 introduces `3620-*` while main already has a different `3620-*` |
-| 4 | cross-lane, **full scan enabled** | `--allocate` **with** the PR scan returned **3619**, already used by open PR #3614; **3620 and 3621 likewise taken** (#3614/#3615) → renumbered to 3622 |
-| 5 | main-vs-PR | PR #3627 adds `3630-*` after PR #3626 merged a different `3630-*` |
+| #   | shape                             | detail                                                                                                                                                  |
+| --- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | cross-lane                        | `--allocate` gave 3585; another lane landed `3585-*` on main mid-flight → renumbered to 3592                                                            |
+| 2   | **self**-collision                | one agent filing two issues in quick succession got **3589 twice** → parked PR #3581 on the #1616 integrity gate                                        |
+| 3   | main-vs-PR                        | PR #3614 introduces `3620-*` while main already has a different `3620-*`                                                                                |
+| 4   | cross-lane, **full scan enabled** | `--allocate` **with** the PR scan returned **3619**, already used by open PR #3614; **3620 and 3621 likewise taken** (#3614/#3615) → renumbered to 3622 |
+| 5   | main-vs-PR                        | PR #3627 adds `3630-*` after PR #3626 merged a different `3630-*`                                                                                       |
 
 ## The regression
 
 The earlier working theory was that `--no-pr-scan` was the proximate cause — one agent's
-*both* collisions came from it, while every full-scan allocation held. **Case 4 refutes
+_both_ collisions came from it, while every full-scan allocation held. **Case 4 refutes
 that**: the full scan returned an id already used by an open PR, and the next two were
 taken as well.
 
 So the open-PR half of the scan is **not reliably seeing in-flight ids**. That is the bug.
+
+> **SUPERSEDED — see "Case 6" below.** The one case measured end to end
+> (2026-07-31, #3889) shows a **complete scan behaving correctly**: the id was free when it
+> was reserved, and a second agent wrote a file against it 32 minutes later. Cases 1-5 were
+> attributed to the scan by inference, not measurement, and case 6 shows that inference can
+> be wrong. Treat "the scan is the bug" as an open question, not a finding, and re-verify a
+> case before building on it.
 
 ## Why each one is expensive
 
@@ -42,10 +49,76 @@ gets parked later, costing a full CI round-trip plus a manual diagnosis each tim
 **Note the two distinct gates** — don't pattern-match on one; case 2 hit #1616, case 3 hits
 `against-main`.
 
+## Case 6 (2026-07-31, #3889) — measured, and it exonerates the scan
+
+Investigated from #3880. Two agents wrote `3889-*` files; the CI open-PR gate caught it, the
+allocator did not. Reconstructed timeline, from the reservation ref and the GitHub API:
+
+| time (UTC) | event                                                                            |
+| ---------- | -------------------------------------------------------------------------------- |
+| 09:15:17   | reservation `3889.json` written, **`pr_scan: "ok"`** — a COMPLETE scan           |
+| 09:21:53   | reservation `3890.json`, `pr_scan: "ok"`                                         |
+| 09:31:56   | reservation `3891.json`, **`pr_scan: "off"`**                                    |
+| 09:47:26   | PR **#3884** created (`issue-3889-autoenqueue-trigger-gap`), **3 changed files** |
+| 09:50:51   | PR **#3887** created — "…**file #3889** for the frozen editions artifact"        |
+
+**The allocator was right.** At 09:15 neither PR existed, so nothing had taken 3889 and
+reserving it was correct. The collision was created 32 minutes LATER by a second agent
+writing a `3889-*` file for a different issue. (It was subsequently renumbered — the
+editions issue is `3892-editions-artifact-frozen-missing-test262-submodule.md` on main.)
+
+**So the defect is NOT in the scan. It is that `--allocate` reserves an id and then nothing
+ever checks that the file you create uses the id you reserved.** The reservation and the
+file creation are completely decoupled: an agent can reserve 3890, write `3889-*`, and no
+local tool objects.
+
+**Be precise about what verify-after-allocate buys: cycle time, not coverage.** The CI
+`Issue-ID open-PR collision gate` (#3598) _does_ catch this, and demonstrably did on
+2026-07-31 — an agent hit it and renumbered cleanly in about two minutes. So the guard rail
+below closes no open hole; it moves the same detection from _after a CI round-trip_ to
+_before the file is written_. That is worth having at the queue tax measured this sprint,
+but an issue that implies new coverage will later be read against the CI gate and look
+wrong.
+
+This also **rules out the most attractive competing hypothesis**, which is worth recording
+so nobody re-derives it:
+
+> `tests/issue-2943.test.ts > falls back to REST pagination for >100-file PRs` is **RED on
+> `origin/main`** (verified against main's own copy of the script, so it predates #3880). In
+> `scripts/lib/open-pr-issue-files.mjs` the >100-file REST fallback does
+> `byPr.set(n, hits)` / `byPr.delete(n)` — it **replaces** the GraphQL first-page hits
+> rather than unioning them, so first-page ids are dropped when the fallback engages.
+>
+> That looks like an exact fit for "the full scan returned a taken id" — **but it cannot
+> explain case 6: PR #3884 has 3 changed files, so the >100-file path never engaged.** In
+> production REST `--paginate` returns a superset anyway, which is why replace has not bitten
+> yet. It remains a real latent defect (any partial REST result silently discards known ids,
+> and an empty one `delete`s the PR entirely) and it should be a union, not a replace. But it
+> is a separate, still-unwitnessed bug.
+
+### The asymmetry principle (state once, apply everywhere)
+
+**Fail toward over-inclusion.** For every predicate in this tooling the two errors have
+wildly different costs:
+
+| direction                                                             | cost                                                                               |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| over-include (reserve an id that was free, hold a lock that was free) | wasted number, blocked work — annoying, recoverable                                |
+| under-include (hand out a taken id, report a held lock as free)       | **two agents on one id / one issue** — the collision the tooling exists to prevent |
+
+So the id universe must only ever **grow** (union, never replace), and heldness must treat an
+unrecognised status as **held** (a terminal-state blacklist, not an `in-progress` whitelist —
+see #3880). Same principle, two call sites; keeping it stated once is easier than maintaining
+two local rules that can drift apart.
+
+Note the diagnosis was only possible because #3880 added `pr_scan` forensics to the record.
+It was NOT possible to attribute _who_ reserved what: every record of that era carries
+`assignee: ""`. #3880 adds `requested_by`, which would have named both agents here.
+
 ## Investigate
 
-1. Does the open-PR scan paginate? At the current PR volume an unpaginated first page would
-   silently miss in-flight ids — that shape would explain case 4 exactly.
+1. ~~Does the open-PR scan paginate?~~ Yes, both levels (PRs and files), and case 6 shows a
+   complete scan behaving correctly. Ruled out for case 6; see above.
 2. Is there a caching or a stale-fetch step between the scan and the reservation?
 3. Does the reservation on the orphan `issue-assignments` ref propagate fast enough for a
    second `--allocate` seconds later? Case 2 (self-collision) suggests not.
@@ -55,12 +128,44 @@ gets parked later, costing a full CI round-trip plus a manual diagnosis each tim
 - **Verify-after-allocate**: re-check the returned id against `main` ∪ open PRs ∪ the
   assignments ref immediately before writing files, and fail loudly on a hit.
 - **Renumbering is itself a trap**: a `git mv` that leaves the in-file `id:` unstaged
-  produced a *re-collision* this sprint. The only signal was gh's
+  produced a _re-collision_ this sprint. The only signal was gh's
   `Warning: 1 uncommitted change` on `pr create`. After any renumber, **grep the whole
   change-set for the old id and require zero hits** — filename, `id:` frontmatter, heading,
   cross-refs, test names, PR title, and rationale comments in code.
 - **Verify the incumbent with `git ls-tree origin/main`, not by assumption.** The lead
   asserted which of two same-id files was already on main and had it exactly inverted.
+
+## Status — partially addressed, deliberately NOT closed
+
+Landed here:
+
+- **The diagnosis**, measured rather than inferred (case 6 above). It **exonerates the
+  open-PR scan**, which was this issue's stated root cause ("the open-PR half of the scan is
+  not reliably seeing in-flight ids. That is the bug"). It is not.
+- **The REST-fallback union fix** — `scripts/lib/open-pr-issue-files.mjs` no longer replaces
+  the GraphQL first page. This turns `tests/issue-2943.test.ts > falls back to REST
+pagination for >100-file PRs` from **red on main** back to green, and
+  `tests/issue-3636.test.ts` pins the two newly-corrected behaviours (kill-switch verified:
+  reverting to `set` makes all three red).
+
+**Still open, and it is now the headline:** an id is reserved by `--allocate` and then
+nothing local checks that the file you create uses that id. See the framing note above —
+this buys **cycle time, not coverage**, since the CI `Issue-ID open-PR collision gate`
+already catches it. Sketch:
+
+```bash
+node scripts/claim-issue.mjs --verify-id <id> [--by <agent>]
+#  exit 0  the id is free, or reserved BY YOU
+#  exit 3  reserved by someone else / already on main / in an open PR
+```
+
+Call it immediately before writing `plan/issues/<id>-<slug>.md`, and after any renumber.
+
+**Also re-check the earlier cases against the corrected diagnosis.** Cases 1-5 were all
+attributed to a faulty scan. Case 6 shows that attribution can be wrong, and cases 2 (the
+self-collision — "3589 twice", which smells like the same reserve-then-write-something-else
+shape) and 5 look worth re-reading before any further scan work is done. Do not build a scan
+fix on an unverified premise a second time.
 
 ## NOT the same issue
 

--- a/scripts/lib/open-pr-issue-files.mjs
+++ b/scripts/lib/open-pr-issue-files.mjs
@@ -125,11 +125,24 @@ export function openPrIssueFiles({ repo = process.env.CLAIM_PR_REPO || "loopdive
           "--jq",
           '.[] | select(.status != "removed") | .filename',
         ]);
-        const hits = [];
+        // (#3636) UNION with the GraphQL first page — never REPLACE it. This
+        // used to `set` outright, so the first page's ids were DISCARDED the
+        // moment the fallback engaged. In practice `--paginate` returns a
+        // superset and has hidden the bug, but any PARTIAL REST result silently
+        // narrows the id universe, and both failure modes are invisible: a
+        // narrower universe just looks like a free id.
+        //
+        // The asymmetry is the whole argument. Over-including an id wastes a
+        // number; under-including one hands out an id another open PR already
+        // uses, and that is only caught in the `merge_group`. So the id universe
+        // must only ever GROW. (Same principle as the claim-heldness predicate
+        // in #3880 — fail toward over-inclusion, never toward under-inclusion.)
+        const hits = new Set(byPr.get(n) || []);
         for (const p of raw.split("\n")) {
-          if (ISSUE_ID_RE.test(p.trim())) hits.push(p.trim());
+          const t = p.trim();
+          if (ISSUE_ID_RE.test(t)) hits.add(t);
         }
-        if (hits.length) byPr.set(n, hits);
+        if (hits.size) byPr.set(n, [...hits]);
         else byPr.delete(n);
       }
       return { byPr, complete: true };

--- a/tests/issue-3636.test.ts
+++ b/tests/issue-3636.test.ts
@@ -1,0 +1,83 @@
+// #3636 — the >100-file REST fallback must UNION with the GraphQL first page,
+// never replace it.
+//
+// `openPrIssueFiles` collects issue-file paths from a batched GraphQL query
+// (100 files per PR), then re-reads any PR whose file list was truncated via
+// REST `--paginate`. That second pass used to `byPr.set(n, hits)` outright, so
+// everything the first page had already told us about that PR was discarded.
+//
+// In production `--paginate` returns a superset, which is why this has not been
+// witnessed. It is still wrong, and wrong in the dangerous direction: the id
+// universe feeds `--allocate`, and an id missing from the universe does not look
+// like an error — it looks like a FREE id, and the collision only surfaces in
+// the merge_group.
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "child_process";
+import { mkdtempSync, writeFileSync, chmodSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+const SCRIPT = resolve(__dirname, "..", "scripts", "claim-issue.mjs");
+
+function scanWithFakeGh(fakeGhBody: string): { ids: number[]; complete: boolean } {
+  const dir = mkdtempSync(join(tmpdir(), "fake-gh-3636-"));
+  const gh = join(dir, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash\n${fakeGhBody}\n`);
+  chmodSync(gh, 0o755);
+  const out = execFileSync(process.execPath, [SCRIPT, "--debug-pr-scan"], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return JSON.parse(out);
+}
+
+/** GraphQL reports PR 7 as truncated, with one issue file on the first page. */
+const GRAPHQL_TRUNCATED = `
+if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
+  cat <<'EOF'
+{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"number":7,"files":{"pageInfo":{"hasNextPage":true},"nodes":[{"path":"plan/issues/9998-first-page.md","changeType":"ADDED"}]}}
+]}}}}
+EOF
+  exit 0
+fi`;
+
+describe("#3636 open-PR scan — the id universe must only ever grow", () => {
+  it("keeps first-page ids when the REST fallback does not repeat them", () => {
+    // The REST page lists a DIFFERENT issue file. Replacing would drop 9998 —
+    // and 9998 would then look free to --allocate.
+    const { ids, complete } = scanWithFakeGh(`${GRAPHQL_TRUNCATED}
+if [ "$1" = "api" ] && [[ "$2" == repos/*/pulls/7/files ]]; then
+  printf 'src/a.ts\\nplan/issues/9997-tail-page.md\\n'
+  exit 0
+fi
+exit 1`);
+    expect(complete).toBe(true);
+    expect(ids).toEqual([9997, 9998]);
+  });
+
+  it("keeps first-page ids when the REST fallback returns no issue files at all", () => {
+    // A REST result carrying only non-issue files must not erase the PR. Under
+    // the old `else byPr.delete(n)` this returned [] — a silently empty id
+    // universe, which is indistinguishable from "nothing is in flight".
+    const { ids, complete } = scanWithFakeGh(`${GRAPHQL_TRUNCATED}
+if [ "$1" = "api" ] && [[ "$2" == repos/*/pulls/7/files ]]; then
+  printf 'src/a.ts\\nsrc/b.ts\\n'
+  exit 0
+fi
+exit 1`);
+    expect(complete).toBe(true);
+    expect(ids).toEqual([9998]);
+  });
+
+  it("does not duplicate an id the REST page repeats", () => {
+    const { ids } = scanWithFakeGh(`${GRAPHQL_TRUNCATED}
+if [ "$1" = "api" ] && [[ "$2" == repos/*/pulls/7/files ]]; then
+  printf 'plan/issues/9998-first-page.md\\nplan/issues/9997-tail-page.md\\n'
+  exit 0
+fi
+exit 1`);
+    expect(ids).toEqual([9997, 9998]);
+  });
+});


### PR DESCRIPTION
Addresses #3636 in part. **The diagnosis is the more valuable half, and it refutes the issue's stated root cause.**

## Measured: the scan is exonerated

#3636 says *"the open-PR half of the scan is not reliably seeing in-flight ids. That is the bug."* For the one case measurable end to end — #3889, the collision from 2026-07-31 — **it is not.**

| time (UTC) | event |
|---|---|
| 09:15:17 | reservation `3889.json` written, **`pr_scan: "ok"`** — a complete scan |
| 09:47:26 | PR **#3884** created (added the `3889-*` file), **3 changed files** |
| 09:50:51 | PR **#3887** created — "…**file #3889** for the frozen editions artifact" |

**Nothing had taken 3889 when it was reserved.** The allocator was right; a *second* agent wrote a different file against that id 32 minutes later. And #3884 has **3 changed files**, so the >100-file REST path — the most attractive competing hypothesis — never engaged.

So the real gap is that `--allocate` reserves an id and **nothing local checks that the file you create uses it**. Framed honestly in the issue as **cycle time, not coverage**: the CI `Issue-ID open-PR collision gate` already catches this and demonstrably did the same day, with a clean renumber in ~2 minutes. The guard rail moves detection earlier; it closes no open hole.

Cases 1–5 were attributed to the scan by **inference, not measurement**. Case 6 shows that inference can be wrong, so the issue now flags them for re-verification rather than as a foundation. The superseded conclusion is marked in place rather than deleted.

## Fixed: the latent defect (turns a RED test on main green)

`scripts/lib/open-pr-issue-files.mjs`'s >100-file REST fallback did `byPr.set(n, hits)` / `byPr.delete(n)` — **replacing** the GraphQL first page rather than unioning it, so first-page ids were discarded the moment it engaged. `--paginate` returns a superset in production, which is why this has never been witnessed, but a **partial** REST result silently narrows the id universe and an **empty** one erases the PR entirely.

Both failures are invisible in the worst way: a narrower id universe does not look like an error, **it looks like a free id**. So the universe must only ever **grow** — the same fail-toward-over-inclusion asymmetry as #3880's heldness predicate (over-include = a wasted number; under-include = two agents on one id, caught only in the `merge_group`).

## Tests

- `tests/issue-2943.test.ts > falls back to REST pagination for >100-file PRs` was **RED on `origin/main`** — verified by running it against main's own copy of the script, so it predates this work. Now green.
- `tests/issue-3636.test.ts` pins the two newly-corrected behaviours (first-page ids survive a non-overlapping REST page; and survive a REST page with no issue files at all).
- **Kill-switch verified**: reverting the union to a replace makes all three red.

## Scope

**The issue is deliberately left `status: ready`.** The verify-after-allocate guard rail is *not* implemented here and this PR should not be read as closing #3636. A `--verify-id` sketch and the re-verification note are recorded in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSXz9G2eZrfNeX3satN5X
