### PR TITLE
ci(test262): gate each shard lane on paths that can actually move it

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -207,6 +207,22 @@ jobs:
     # filter already gates the whole workflow, and on workflow_dispatch we
     # always want shards — so this job emits `true` for every non-merge_group
     # event and the shard `if:` keeps its existing arms for those.
+    #
+    # PER-LANE GATING: `run_shards` answers "does test262 run at all?"; the
+    # finer `run_host` / `run_standalone` answer "which LANE runs?". The two
+    # lanes have separate baselines, separate gates and separate shard-weight
+    # maps, so a change that provably cannot move one lane's results should not
+    # schedule that lane's 66 (js-host) or 36 (standalone) shard jobs. Only
+    # `scripts/test262-paths-match.sh` decides this, and it narrows a path to
+    # one lane ONLY when the runner demonstrably does not read it on the other
+    # (today: the two shard-weight maps — all of `src/**` stays both-lane).
+    # `run_shards == run_host || run_standalone`, so every existing consumer of
+    # `run_shards` keeps its exact previous meaning.
+    #
+    # This is merge_group-only in effect: every other event emits true/true/true.
+    # In particular `push`/`workflow_dispatch` ALWAYS run both lanes, because
+    # `promote-baseline` publishes both lanes' baselines from that run and a
+    # single-lane run would promote a half-empty baseline.
     name: detect test262-relevant changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -217,6 +233,12 @@ jobs:
       (github.event_name == 'push' && github.actor != 'github-actions[bot]')
     outputs:
       run_shards: ${{ steps.detect.outputs.run_shards }}
+      # Per-lane verdicts (see the PER-LANE GATING note above). Consumers MUST
+      # treat an empty/missing value as 'run' (`!= 'false'`), never as 'skip' —
+      # this job is skipped entirely for bot pushes, and a missing output must
+      # not be read as permission to drop a lane.
+      run_host: ${{ steps.detect.outputs.run_host }}
+      run_standalone: ${{ steps.detect.outputs.run_standalone }}
       # #1954 — opt-in PR scope directive (empty for all other events and for
       # PRs without a directive). Consumed by the shard matrix (as
       # TEST262_PATH_FILTER) and by every diff-based gate (as --path-filter)
@@ -274,16 +296,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      # #3431 — compute the merge_group-consolidated shard matrix. Pure
-      # node/JS, no dependencies to install; reuses the merge_group-only
-      # checkout above. Runs unconditionally on merge_group (even when
-      # run_shards will end up 'false') since it's cheap and keeps the
-      # output always well-formed; the `test262-shard-mg` job's own `if:`
-      # is what actually gates on run_shards.
-      - name: Compute merge_group shard matrix (#3431)
-        id: mg_matrix
-        if: github.event_name == 'merge_group'
-        run: node scripts/gen-test262-mg-matrix.mjs --github-output >> "$GITHUB_OUTPUT"
+      # NOTE: `detect` runs BEFORE the matrix step — the matrix is now built
+      # only for the lanes `detect` says can move (see below).
       - name: Detect test262-relevant changes
         id: detect
         env:
@@ -292,20 +306,33 @@ jobs:
           MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -uo pipefail
+          # Emit all three verdicts at once. EVERY fail-safe path calls
+          # `emit_all true` so an uncertain detection can never drop a lane —
+          # the only way a lane is skipped is a POSITIVE per-lane 'false' from
+          # scripts/test262-paths-match.sh on a real, non-empty diff.
+          emit_all() {
+            {
+              echo "run_shards=$1"
+              echo "run_host=$1"
+              echo "run_standalone=$1"
+            } >> "$GITHUB_OUTPUT"
+          }
+
           # Non-merge_group events keep the old behaviour: the workflow-level
           # `paths:` filter (PR/push) or unconditional intent (dispatch) already
           # decided we should run, so emit true and let the shard `if:` arms
-          # handle gating per event_name.
+          # handle gating per event_name. Both lanes always run there —
+          # promote-baseline publishes BOTH baselines from a push/dispatch run.
           if [ "$EVENT_NAME" != "merge_group" ]; then
-            echo "Non-merge_group event ($EVENT_NAME): run_shards=true (native paths filter / dispatch governs)."
-            echo "run_shards=true" >> "$GITHUB_OUTPUT"
+            echo "Non-merge_group event ($EVENT_NAME): run_shards=true, both lanes (native paths filter / dispatch governs)."
+            emit_all true
             exit 0
           fi
 
           # --- merge_group: diff base..head ourselves ---
           if [ -z "${MG_BASE_SHA:-}" ] || [ -z "${MG_HEAD_SHA:-}" ]; then
             echo "::warning::merge_group base/head sha missing (base='${MG_BASE_SHA:-}' head='${MG_HEAD_SHA:-}') — FAIL-SAFE run_shards=true."
-            echo "run_shards=true" >> "$GITHUB_OUTPUT"
+            emit_all true
             exit 0
           fi
 
@@ -338,7 +365,7 @@ jobs:
 
           if [ "$rc" -ne 0 ]; then
             echo "::warning::git diff $MG_BASE_SHA..$MG_HEAD_SHA failed (rc=$rc): $(cat /tmp/diff_err) — FAIL-SAFE run_shards=true."
-            echo "run_shards=true" >> "$GITHUB_OUTPUT"
+            emit_all true
             exit 0
           fi
 
@@ -349,13 +376,70 @@ jobs:
           # conservative and run.
           if [ -z "$DIFF" ]; then
             echo "::warning::Empty diff for merge_group $MG_BASE_SHA..$MG_HEAD_SHA — FAIL-SAFE run_shards=true."
-            echo "run_shards=true" >> "$GITHUB_OUTPUT"
+            emit_all true
             exit 0
           fi
 
-          RESULT=$(printf '%s\n' "$DIFF" | bash scripts/test262-paths-match.sh)
-          echo "test262-paths-match → run_shards=$RESULT"
-          echo "run_shards=$RESULT" >> "$GITHUB_OUTPUT"
+          # Per-lane classification. `run_shards` stays the OR of the two lanes,
+          # so it keeps its exact previous value and meaning for every existing
+          # consumer. A non-zero exit from the matcher (bad argument, unreadable
+          # script) leaves RESULT empty → fail-safe to running everything.
+          HOST=$(printf '%s\n' "$DIFF" | bash scripts/test262-paths-match.sh --target host) || HOST=""
+          STANDALONE=$(printf '%s\n' "$DIFF" | bash scripts/test262-paths-match.sh --target standalone) || STANDALONE=""
+          if [ "$HOST" != "true" ] && [ "$HOST" != "false" ]; then
+            echo "::warning::unexpected host verdict '$HOST' from test262-paths-match.sh — FAIL-SAFE run_shards=true."
+            emit_all true
+            exit 0
+          fi
+          if [ "$STANDALONE" != "true" ] && [ "$STANDALONE" != "false" ]; then
+            echo "::warning::unexpected standalone verdict '$STANDALONE' from test262-paths-match.sh — FAIL-SAFE run_shards=true."
+            emit_all true
+            exit 0
+          fi
+
+          RESULT=false
+          if [ "$HOST" = "true" ] || [ "$STANDALONE" = "true" ]; then RESULT=true; fi
+          echo "test262-paths-match → run_shards=$RESULT (host=$HOST, standalone=$STANDALONE)"
+          if [ "$RESULT" = "true" ] && { [ "$HOST" = "false" ] || [ "$STANDALONE" = "false" ]; }; then
+            SKIPPED=host
+            [ "$STANDALONE" = "false" ] && SKIPPED=standalone
+            echo "::notice::Single-lane test262 run: the queued change cannot move the ${SKIPPED} lane, so its shards are not scheduled. The other lane runs its FULL shard count, so its partition and baseline comparison are unchanged."
+          fi
+          {
+            echo "run_shards=$RESULT"
+            echo "run_host=$HOST"
+            echo "run_standalone=$STANDALONE"
+          } >> "$GITHUB_OUTPUT"
+
+      # #3431 — compute the merge_group-consolidated shard matrix. Pure
+      # node/JS, no dependencies to install; reuses the merge_group-only
+      # checkout above. Runs unconditionally on merge_group (even when
+      # run_shards will end up 'false') since it's cheap and keeps the
+      # output always well-formed; the `test262-shard-mg` job's own `if:`
+      # is what actually gates on run_shards.
+      #
+      # `--lanes` drops a lane the `detect` step ruled out. Each surviving lane
+      # keeps its FULL chunk count (66 js-host / 36 standalone) so its corpus
+      # partition is byte-identical to a two-lane run — see
+      # scripts/gen-test262-mg-matrix.mjs. A missing/unknown verdict yields
+      # both lanes (the generator fail-safes an empty selection back to the
+      # full matrix), matching this job's conservative bias.
+      - name: Compute merge_group shard matrix (#3431)
+        id: mg_matrix
+        if: github.event_name == 'merge_group'
+        env:
+          RUN_HOST: ${{ steps.detect.outputs.run_host }}
+          RUN_STANDALONE: ${{ steps.detect.outputs.run_standalone }}
+        run: |
+          set -euo pipefail
+          # if/then, NOT `[ … ] && LANES=…`: under `set -e` a false test as a
+          # bare compound command exits the step, which would abort exactly the
+          # single-lane case this step exists to build.
+          LANES=""
+          if [ "$RUN_HOST" != "false" ]; then LANES="host"; fi
+          if [ "$RUN_STANDALONE" != "false" ]; then LANES="${LANES:+$LANES,}standalone"; fi
+          echo "Building merge_group matrix for lanes: ${LANES:-<none — fail-safe to both>}"
+          node scripts/gen-test262-mg-matrix.mjs --lanes "$LANES" --github-output >> "$GITHUB_OUTPUT"
 
   # =====================================================================
   # merge_group gating truth table (the other event_names are governed by
@@ -364,12 +448,23 @@ jobs:
   #   queued change          changes.run_shards   test262-shard-mg   merge-report
   #   ---------------------  ------------------   ----------------   -------------------
   #   src/** (or any         true                 RUNS (#3431         runs, real result
-  #     &test262-paths)                             102-job matrix)
+  #     shared &test262-path)                       102-job matrix)
   #   website/plan/doc-only  false                SKIPPED             runs, trivial PASS
   #   base_sha empty /       true (fail-safe)     RUNS (#3431         runs, real result
   #     diff fails / empty                          102-job matrix)
+  #   ONLY tests/test262-     true                RUNS, standalone    runs, standalone-only
+  #     slow-tests-           (run_host=false)      lane only           result; js-host
+  #     standalone.json                             (36 jobs)           steps skipped
+  #   ONLY tests/test262-     true                RUNS, js-host       runs, js-host-only
+  #     slow-tests.json       (run_standalone=       lane only          result; standalone
+  #                            false)                (66 jobs)          steps skipped
   #
-  # In ALL three rows the required check "merge shard reports" is produced.
+  # The two single-lane rows are the per-lane gating described on the `changes`
+  # job. They do NOT publish the #1956 `test262-group-<sha>` artifact (it would
+  # be a half-empty baseline), so the follow-on push:main probe MISSES and runs
+  # the full two-lane matrix before promoting. See the publish step's comment.
+  #
+  # In ALL rows the required check "merge shard reports" is produced.
   # It is green only when shards succeeded or the merge_group no-shards skip is
   # intentional. If shards fail or are skipped unexpectedly, the aggregate job
   # itself fails so no required-context stub can hide the red shard.
@@ -824,6 +919,16 @@ jobs:
     #   - any pull_request                       -> trivial PASS
     #   - any other failed/skipped shard result   -> FAIL the required check
     # Steps that touch shard artifacts are guarded by `SHARDS_RAN`.
+    #
+    # PER-LANE: `SHARDS_RAN` answers "did ANY shard run?" and still guards the
+    # shared setup steps and the required-check decision above. Each LANE's own
+    # merge/report/guard steps are guarded by `HOST_RAN` / `STANDALONE_RAN`
+    # instead, because a merge_group may legitimately schedule only one lane
+    # (see the `changes` job). A skipped lane has no shard artifacts, so its
+    # steps must skip — `test -s <merged>.jsonl` on an absent lane would fail
+    # this required check for a change that provably could not affect it.
+    # Both flags are 'true' whenever a lane genuinely ran, so a full two-lane
+    # run behaves exactly as before.
     if: |
       always() &&
       (github.event_name != 'push' || github.actor != 'github-actions[bot]')
@@ -851,6 +956,14 @@ jobs:
       # skipped and promote-baseline sources the JSONLs from that artifact, so
       # there are no shards to merge here and this required check green-skips).
       SHARD_SKIP_OK: ${{ ((github.event_name == 'merge_group' && needs.changes.outputs.run_shards == 'false') || github.event_name == 'pull_request' || (github.event_name == 'push' && needs.mg-artifact-probe.outputs.hit == 'true')) && 'true' || 'false' }}
+      # Per-lane variants of SHARDS_RAN. A merge_group whose queued change
+      # cannot move one lane schedules no shards for it, so that lane has no
+      # artifacts to merge and no report to gate — its steps must skip rather
+      # than fail on a missing JSONL. `!= 'false'` (not `== 'true'`) so a
+      # missing/empty output from `changes` still means "this lane ran",
+      # matching the conservative bias everywhere else in this workflow.
+      HOST_RAN: ${{ (needs.test262-shard.result == 'success' || needs.test262-shard-mg.result == 'success') && needs.changes.outputs.run_host != 'false' && 'true' || 'false' }}
+      STANDALONE_RAN: ${{ (needs.test262-shard.result == 'success' || needs.test262-shard-mg.result == 'success') && needs.changes.outputs.run_standalone != 'false' && 'true' || 'false' }}
 
     steps:
       - name: Fail if required test262 shards did not succeed
@@ -911,21 +1024,21 @@ jobs:
           merge-multiple: false
 
       - name: Merge JS-host test262 JSONL results
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         run: |
           mkdir -p merged-reports
           find shard-artifacts/test262-js-host-shard-* -name 'test262-results-*.jsonl' -print0 | sort -z | xargs -0 cat > merged-reports/test262-results-merged.jsonl
           test -s merged-reports/test262-results-merged.jsonl
 
       - name: Merge standalone test262 JSONL results
-        if: env.SHARDS_RAN == 'true'
+        if: env.STANDALONE_RAN == 'true'
         run: |
           mkdir -p merged-reports
           find shard-artifacts/test262-standalone-shard-* -name 'test262-standalone-results-*.jsonl' -print0 | sort -z | xargs -0 cat > merged-reports/test262-standalone-results-merged.jsonl
           test -s merged-reports/test262-standalone-results-merged.jsonl
 
       - name: Build merged JS-host test262 report
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         run: |
           node scripts/build-test262-report.mjs \
             --input merged-reports/test262-results-merged.jsonl \
@@ -935,7 +1048,7 @@ jobs:
             ${{ github.event_name != 'workflow_dispatch' && '--include-proposals' || (inputs.include_proposals && '--include-proposals' || '') }}
 
       - name: Build merged standalone test262 report
-        if: env.SHARDS_RAN == 'true'
+        if: env.STANDALONE_RAN == 'true'
         run: |
           node scripts/build-test262-report.mjs \
             --input merged-reports/test262-standalone-results-merged.jsonl \
@@ -955,7 +1068,7 @@ jobs:
       # which only ever ratchets UP. It lives inside the required
       # "merge shard reports" check so a breach blocks the merge queue.
       - name: Standalone pass-count high-water floor (#2097)
-        if: env.SHARDS_RAN == 'true'
+        if: env.STANDALONE_RAN == 'true'
         run: |
           node scripts/check-standalone-highwater.mjs \
             --report merged-reports/test262-standalone-report-merged.json
@@ -987,7 +1100,7 @@ jobs:
       #             regression-gate job's business and do not fail this
       #             required check; a catastrophic-size failure does.
       - name: Catastrophic regression guard (#1668)
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         env:
           CATASTROPHIC_REGRESSION_THRESHOLD: "200"
           # #1954 — on a scoped PR run the merged JSONL only covers the scope;
@@ -1086,7 +1199,7 @@ jobs:
       # this step from vetoing a deliberate re-baseline the script approved
       # (pre-#3303 it re-derived net from the raw count and disagreed).
       - name: Standalone regression guard (#1897)
-        if: env.SHARDS_RAN == 'true'
+        if: env.STANDALONE_RAN == 'true'
         env:
           STANDALONE_REGRESSION_TOLERANCE: "15"
           # #1954 — see the catastrophic guard above.
@@ -1187,7 +1300,7 @@ jobs:
       # The aggregate +20% arm (AGG_COMPILE_TIME_PCT_THRESHOLD) is UNCHANGED and
       # remains the standalone systemic-slowdown backstop.
       - name: Compile-time regression guard (#1942, #3447)
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         env:
           # CT_SOFT: contention-flake floor. A CT above this is only actionable
           #   when the aggregate arm agrees (see the combined trigger). Scaled
@@ -1335,8 +1448,18 @@ jobs:
       # drift, no ALLGREEN masking once the queue batches >1). 3-day
       # retention comfortably covers queue lifetimes; an expired/missing
       # artifact just falls back to the runs-cache / latest-main baseline.
+      #
+      # BOTH LANES REQUIRED. This artifact has a second consumer: the #3448
+      # push:main `mg-artifact-probe`, which on a HIT lets `promote-baseline`
+      # publish BOTH lanes' baselines straight from it and skip the full
+      # matrix. A single-lane group would therefore promote a baseline with an
+      # empty side. Publishing only when both lanes ran makes the follow-on
+      # probe MISS instead, which is an already-documented, already-exercised
+      # fallback ("direct push, expired artifact, or doc-only group") that runs
+      # the full two-lane matrix before promoting. Predecessor diffing degrades
+      # the same way — it falls back to the runs-cache / latest-main baseline.
       - name: Publish group results for predecessor diffing (#1956)
-        if: env.SHARDS_RAN == 'true' && github.event_name == 'merge_group'
+        if: env.HOST_RAN == 'true' && env.STANDALONE_RAN == 'true' && github.event_name == 'merge_group'
         uses: actions/upload-artifact@v6
         with:
           retention-days: 3
@@ -1354,6 +1477,14 @@ jobs:
     # published even when shards were intentionally skipped. If shards failed or
     # were unexpectedly skipped, `merge shard reports` is already red; this job
     # no-ops instead of looking for artifacts that do not exist.
+    #
+    # This job is entirely JS-HOST-LANE: it merges the js-host shard JSONLs and
+    # diffs them against the js-host baseline (the standalone lane's equivalent
+    # gates — the #1897 regression guard and the #2097 high-water floor — live
+    # in `merge-report`). It is therefore gated on `HOST_RAN`, not `SHARDS_RAN`:
+    # a merge_group that scheduled only the standalone lane has no js-host
+    # JSONLs to diff, so this job green-no-ops exactly as it does for a
+    # pull_request.
     if: |
       always() &&
       (github.event_name != 'push' || github.actor != 'github-actions[bot]')
@@ -1373,18 +1504,24 @@ jobs:
       contents: read
       actions: read
     env:
-      SHARDS_RAN: ${{ (needs.test262-shard.result == 'success' || needs.test262-shard-mg.result == 'success') && 'true' || 'false' }}
+      # Host-lane variant of SHARDS_RAN: any shard job succeeded AND the
+      # queued change can move the js-host lane. `!= 'false'` so a missing
+      # output from `changes` means 'ran' (conservative), never 'skipped'.
+      HOST_RAN: ${{ (needs.test262-shard.result == 'success' || needs.test262-shard-mg.result == 'success') && needs.changes.outputs.run_host != 'false' && 'true' || 'false' }}
 
     steps:
       - name: No-op pass (no merged test262 report to diff)
-        if: env.SHARDS_RAN != 'true'
+        if: env.HOST_RAN != 'true'
         run: |
-          echo "test262 shards did not produce shard artifacts in this context."
+          echo "No js-host test262 shard artifacts to diff in this context."
           echo "test262-shard result: ${{ needs.test262-shard.result }}, test262-shard-mg result: ${{ needs.test262-shard-mg.result }}"
+          echo "changes.run_host: '${{ needs.changes.outputs.run_host }}' (an explicit 'false' means the"
+          echo "  queued change provably cannot move the js-host lane, so its shards were never scheduled;"
+          echo "  the standalone lane's own gates still ran in 'merge shard reports')."
           echo "If shards failed unexpectedly, the required 'merge shard reports' check is the blocking signal."
 
       - name: Checkout
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         uses: actions/checkout@v5
         with:
           # #1081 — need full history so we can resolve the PR's merge-base
@@ -1395,16 +1532,16 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node and pnpm (cached)
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         uses: ./.github/actions/setup-node-pnpm
 
       - name: Install dependencies
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Fetch fresh baseline from baselines repo
         id: fetch_baseline
-        if: env.SHARDS_RAN == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+        if: env.HOST_RAN == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         run: |
           # Clone the baselines repo to get the current baseline JSONL.
           # This avoids LFS bandwidth on the main repo (all jsonl files are
@@ -1455,7 +1592,7 @@ jobs:
 
       - name: Load cached baseline for merge-base (#1081, base_sha #3467)
         id: merge_base_cache
-        if: env.SHARDS_RAN == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+        if: env.HOST_RAN == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         env:
           # #3467 — on merge_group the REAL parent commit the queue built this
           # group on. Test262-running landed commits write runs/<sha> through
@@ -1565,7 +1702,7 @@ jobs:
       # step never fails the build.
       - name: Resolve predecessor-group baseline (#1956)
         id: pred_group
-        if: env.SHARDS_RAN == 'true' && github.event_name == 'merge_group'
+        if: env.HOST_RAN == 'true' && github.event_name == 'merge_group'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -1623,7 +1760,7 @@ jobs:
         # too — the baselines-repo JSONL is frequently several merges behind main
         # HEAD there (serialization lag), and the footer is what tells a reader
         # the listed "regressions" are drift, not real PR-caused failures.
-        if: env.SHARDS_RAN == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push') && steps.fetch_baseline.outputs.baseline_ts != '0'
+        if: env.HOST_RAN == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push') && steps.fetch_baseline.outputs.baseline_ts != '0'
         run: |
           # #2562 — measure staleness by the count of TEST262-RELEVANT (src)
           # commits between the baseline's recorded main-sha and main HEAD, NOT
@@ -1719,7 +1856,7 @@ jobs:
       # merge-report's merged artifact — that artifact only exists after
       # merge-report finishes, which would serialize this job behind it.
       - name: Download shard artifacts
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         uses: actions/download-artifact@v7
         with:
           path: shard-artifacts
@@ -1727,7 +1864,7 @@ jobs:
           merge-multiple: false
 
       - name: Merge JS-host test262 JSONL results
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         run: |
           mkdir -p merged-reports
           find shard-artifacts/test262-js-host-shard-* -name 'test262-results-*.jsonl' -print0 | sort -z | xargs -0 cat > merged-reports/test262-results-merged.jsonl
@@ -1757,7 +1894,7 @@ jobs:
         # net gate (net < 0), the per-bucket >50 concentration check, and the
         # #3189 uncatchable-trap growth ratchet. `compile_timeout` / ct_flake is
         # already excluded from the wasm-change regression numerator.
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         env:
           # #1954 — scoped PR runs: restrict the baseline to the scope or
           # every out-of-scope baseline pass reads as a pass→absent regression.
@@ -1830,7 +1967,7 @@ jobs:
 
       - name: Upload regressions report
         uses: actions/upload-artifact@v6
-        if: always() && env.SHARDS_RAN == 'true'
+        if: always() && env.HOST_RAN == 'true'
         with:
           retention-days: 1
           name: test262-regressions-report
@@ -1845,7 +1982,7 @@ jobs:
       # regression gate above already fails on the underlying pass→compile_error
       # flips; this surfaces the hard-error bucket explicitly with a pointer.
       - name: Hard-error stability gate (#1853)
-        if: env.SHARDS_RAN == 'true'
+        if: env.HOST_RAN == 'true'
         run: |
           node scripts/check-test262-hard-errors.mjs \
             --jsonl merged-reports/test262-results-merged.jsonl
@@ -1862,7 +1999,7 @@ jobs:
       # shard reports" check; this fine gate stays active for `pull_request` /
       # `merge_group`, where pre-merge gating is the point.
       - name: Fail on regressions
-        if: env.SHARDS_RAN == 'true' && steps.regression_diff.outputs.regressions == 'true' && github.event_name != 'push' && !(github.event_name == 'workflow_dispatch' && inputs.force_baseline_refresh == true && inputs.confirm_force == 'YES')
+        if: env.HOST_RAN == 'true' && steps.regression_diff.outputs.regressions == 'true' && github.event_name != 'push' && !(github.event_name == 'workflow_dispatch' && inputs.force_baseline_refresh == true && inputs.confirm_force == 'YES')
         run: |
           echo "test262 regressions detected relative to benchmarks/results/test262-current.jsonl"
           cat merged-reports/test262-regressions.txt

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -179,6 +179,31 @@ Two test262 workflows currently run on PRs:
   authoritative validation on the merge_group ref regardless (#1657), so
   nothing lands without the real gate's verdict on the merged-with-main tree.
 
+- **Per-lane gating inside a merge_group run.** The two test262 lanes —
+  js-host (`gc`, 66 shards) and standalone (36 shards) — have separate
+  baselines, separate regression gates and separate shard-weight maps, so
+  `scripts/test262-paths-match.sh` also answers the question per lane
+  (`--target host|standalone`). The `changes` job publishes `run_host` /
+  `run_standalone` alongside `run_shards` (which stays exactly their OR, so
+  every existing consumer is unaffected), and a lane the queued diff provably
+  cannot move is dropped from the merge_group shard matrix entirely.
+  Constraints that make this safe, all pinned by
+  `tests/test262-per-lane-gating.test.ts`:
+  - A path is narrowed to one lane **only** when the runner demonstrably does
+    not read it on the other. Today that is exactly the two shard-weight maps
+    (`tests/test262-slow-tests.json` / `-standalone.json`). **All of `src/**`
+    stays both-lane** — `target: "standalone"` is a flag through the same
+    compiler, not a separate source tree, so there is no sound src-level split.
+  - Every uncertain path (missing `base_sha`, failed or empty diff, unexpected
+    matcher output, any non-`merge_group` event) emits **both** lanes, and
+    consumers read the outputs as `!= 'false'` so a missing output means "run".
+  - The surviving lane keeps its **full** shard count, so its corpus partition
+    is byte-identical to a two-lane run and stays comparable to the baseline.
+  - `push` / `workflow_dispatch` always run both lanes: `promote-baseline`
+    publishes both baselines from those runs. A single-lane merge_group also
+    does **not** publish the `test262-group-<sha>` artifact, so the #3448
+    push:main probe MISSES and the full two-lane matrix runs before promoting.
+
 For one-off sharded runs outside the normal PR/merge_group path,
 `workflow_dispatch` is the supported entry point.
 

--- a/scripts/check-baseline-floor-staleness.mjs
+++ b/scripts/check-baseline-floor-staleness.mjs
@@ -122,8 +122,11 @@ function gitOk(args) {
 }
 
 // Count commits in `ref` not reachable from `floorSha` whose changed file set
-// touches a test262-relevant path. Returns { total, relevant, exact } or null
-// when the floor SHA is unreachable from the checkout.
+// touches a test262-relevant path FOR `target` ("any" | "host" | "standalone").
+// Returns { total, relevant, exact } or null when the floor SHA is unreachable
+// from the checkout. Passing the lane matters: a standalone shard-weight
+// refresh is drift for the standalone floor only, and counting it against the
+// host floor overstates that lane's lag.
 //
 // A single `git log --name-only` pass streams every commit + its changed files
 // (one subprocess, not one-per-commit). We early-exit the moment `relevant`
@@ -131,7 +134,7 @@ function gitOk(args) {
 // walk thousands of commits when the floor is far behind. `exact` is false in
 // that early-exit case (the reported counts are a lower bound ≥ the threshold,
 // which is all the breach decision needs).
-export function countRelevantDrift(floorSha, ref, maxBehind) {
+export function countRelevantDrift(floorSha, ref, maxBehind, target = "any") {
   // Floor SHA must be a commit we can name; if not, staleness is undetermined.
   if (!gitOk(["cat-file", "-e", `${floorSha}^{commit}`])) {
     return null;
@@ -152,7 +155,7 @@ export function countRelevantDrift(floorSha, ref, maxBehind) {
   const flush = () => {
     if (!sawCommit) return;
     total++;
-    if (pathsTouchTest262(curFiles.join("\n"))) relevant++;
+    if (pathsTouchTest262(curFiles.join("\n"), target)) relevant++;
     curFiles = [];
   };
   for (const rawLine of out.split("\n")) {
@@ -173,35 +176,57 @@ export function countRelevantDrift(floorSha, ref, maxBehind) {
 }
 
 // Mirror of scripts/test262-paths-match.sh — kept in lockstep with the
-// &test262-paths allowlist in test262-sharded.yml. A changed-file blob (one
-// path per line) touches test262 conformance iff any line matches.
-export function pathsTouchTest262(changedBlob) {
-  const EXACT = new Set([
-    ".github/actions/setup-node-pnpm/action.yml",
-    ".github/workflows/test262-sharded.yml",
-    "package.json",
-    "pnpm-lock.yaml",
-    "tsconfig.json",
-    "scripts/tsconfig.json",
-    "vitest.config.ts",
-    "scripts/build-test262-report.mjs",
-    "scripts/compiler-fork-worker.mjs",
-    "scripts/compiler-pool.ts",
-    "scripts/diff-test262.ts",
-    "scripts/generate-editions.ts",
-    "scripts/test262-worker.mjs",
-    "tests/test262-runner.ts",
-    "tests/test262-scope-classification.test.ts",
-    "tests/test262-shared.ts",
-    "scripts/test262-paths-match.sh",
-  ]);
+// &test262-paths allowlist in test262-sharded.yml (pinned by the
+// "stays in lockstep with scripts/test262-paths-match.sh" case in
+// tests/issue-2178-baseline-floor-staleness.test.ts, which runs a shared path
+// set through BOTH implementations for every target).
+const EXACT_TEST262_PATHS = new Set([
+  ".github/actions/setup-node-pnpm/action.yml",
+  ".github/workflows/test262-sharded.yml",
+  "package.json",
+  "pnpm-lock.yaml",
+  "tsconfig.json",
+  "scripts/tsconfig.json",
+  "vitest.config.ts",
+  "scripts/build-test262-report.mjs",
+  "scripts/compiler-fork-worker.mjs",
+  "scripts/compiler-pool.ts",
+  "scripts/diff-test262.ts",
+  "scripts/generate-editions.ts",
+  "scripts/test262-worker.mjs",
+  "tests/test262-runner.ts",
+  "tests/test262-scope-classification.test.ts",
+  "tests/test262-shared.ts",
+  "scripts/test262-paths-match.sh",
+]);
+
+// Which lane(s) a changed path can move: "both" | "host" | "standalone" | "".
+// Mirrors classify_test262_path in scripts/test262-paths-match.sh — see that
+// file for why the default is "both" and why only the shard-weight maps are
+// lane-exclusive.
+export function classifyTest262Path(p) {
+  if (!p) return "";
+  if (p === "tests/test262-slow-tests-standalone.json") return "standalone";
+  if (p === "tests/test262-slow-tests.json") return "host";
+  if (EXACT_TEST262_PATHS.has(p)) return "both";
+  if (p.startsWith("src/")) return "both";
+  if (/^tests\/test262-chunk.*\.test\.ts$/.test(p)) return "both";
+  if (/^tests\/test262-slow-tests.*\.json$/.test(p)) return "both";
+  return "";
+}
+
+/**
+ * A changed-file blob (one path per line) touches test262 conformance iff any
+ * line matches. `target` narrows the question to a single lane:
+ *   "any" (default) — either lane, i.e. the historical behaviour
+ *   "host"          — the JS-host (gc) lane
+ *   "standalone"    — the standalone lane
+ */
+export function pathsTouchTest262(changedBlob, target = "any") {
   for (const line of changedBlob.split("\n")) {
-    const p = line.trim();
-    if (!p) continue;
-    if (EXACT.has(p)) return true;
-    if (p.startsWith("src/")) return true;
-    if (/^tests\/test262-chunk.*\.test\.ts$/.test(p)) return true;
-    if (/^tests\/test262-slow-tests.*\.json$/.test(p)) return true;
+    const scope = classifyTest262Path(line.trim());
+    if (!scope) continue;
+    if (target === "any" || scope === "both" || scope === target) return true;
   }
   return false;
 }
@@ -228,7 +253,9 @@ async function main() {
       );
       continue;
     }
-    const drift = countRelevantDrift(floor.sha, args.ref, args.maxBehind);
+    // Count drift for THIS lane only: a change that provably cannot move this
+    // lane's results is not lag for this lane's floor (see classifyTest262Path).
+    const drift = countRelevantDrift(floor.sha, args.ref, args.maxBehind, lane);
     if (drift === null) {
       results.push({
         lane,

--- a/scripts/gen-test262-mg-matrix.mjs
+++ b/scripts/gen-test262-mg-matrix.mjs
@@ -101,15 +101,64 @@ export function buildTargetEntries(targetName, test262Target, resultPrefix, chun
   return entries;
 }
 
-export function buildMergeGroupMatrix() {
+/**
+ * Build the merge_group matrix, optionally restricted to the lanes whose
+ * results the queued change can actually move.
+ *
+ * The `changes` job classifies the queued diff with
+ * `scripts/test262-paths-match.sh --target host|standalone` and passes the
+ * verdict in; a lane that provably cannot move (e.g. js-host for a change that
+ * only refreshes tests/test262-slow-tests-standalone.json) is dropped from the
+ * matrix entirely rather than scheduled and thrown away.
+ *
+ * SHARD COUNTS ARE NOT REBALANCED when a lane is dropped. Each lane keeps its
+ * own chunk_total so its partition (assignBalancedChunk, a pure function of
+ * (chunkIndex, totalChunks)) stays IDENTICAL to a full run — a single-lane run
+ * must be directly comparable to the baseline that a two-lane run produced.
+ * Spending the freed runners on more shards for the surviving lane would
+ * re-partition it, which is a change we have no measurement for; the win here
+ * is the ~66 or ~36 jobs not run at all.
+ *
+ * @param {{ host?: boolean, standalone?: boolean }} [lanes]
+ */
+export function buildMergeGroupMatrix(lanes = {}) {
+  const { host = true, standalone = true } = lanes;
+  // Neither lane selected should be unreachable (the caller gates the whole
+  // job on run_shards), but an EMPTY matrix is a workflow-level error in
+  // GitHub Actions, not a skipped job — so fail safe to the full matrix and
+  // let the job's own `if:` decide whether to run at all.
+  if (!host && !standalone) return buildMergeGroupMatrix({ host: true, standalone: true });
   return [
-    ...buildTargetEntries("js-host", "gc", "test262", JS_HOST_CHUNKS),
-    ...buildTargetEntries("standalone", "standalone", "test262-standalone", STANDALONE_CHUNKS),
+    ...(host ? buildTargetEntries("js-host", "gc", "test262", JS_HOST_CHUNKS) : []),
+    ...(standalone ? buildTargetEntries("standalone", "standalone", "test262-standalone", STANDALONE_CHUNKS) : []),
   ];
 }
 
+/**
+ * Parse `--lanes host,standalone` (default: both). Unknown lane names are a
+ * hard error rather than a silent drop — silently emitting a narrower matrix
+ * than the caller asked for would skip conformance coverage.
+ */
+export function parseLanes(argv) {
+  const flag = argv.find((a) => a === "--lanes" || a.startsWith("--lanes="));
+  if (!flag) return { host: true, standalone: true };
+  const raw = flag.startsWith("--lanes=") ? flag.slice("--lanes=".length) : argv[argv.indexOf(flag) + 1];
+  const names = String(raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  for (const n of names) {
+    if (n !== "host" && n !== "standalone") {
+      throw new Error(`gen-test262-mg-matrix: unknown lane '${n}' (expected host or standalone)`);
+    }
+  }
+  // An empty/absent value means "no lane selected"; buildMergeGroupMatrix
+  // fail-safes that back to the full matrix.
+  return { host: names.includes("host"), standalone: names.includes("standalone") };
+}
+
 function main() {
-  const matrix = { include: buildMergeGroupMatrix() };
+  const matrix = { include: buildMergeGroupMatrix(parseLanes(process.argv)) };
   const json = JSON.stringify(matrix);
   if (process.argv.includes("--github-output")) {
     // Single-line JSON — safe for a GITHUB_OUTPUT `key=value` assignment.

--- a/scripts/test262-paths-match.sh
+++ b/scripts/test262-paths-match.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # test262-paths-match.sh — decide whether a set of changed paths touches any
-# test262-relevant path.
+# test262-relevant path, optionally for ONE test262 target lane.
 #
 # Reads NUL- or newline-separated changed paths on stdin (one per line).
 # Prints "true" to stdout if ANY changed path matches the test262-relevant
 # path set, "false" otherwise. Always exits 0 (the caller reads stdout).
+#
+#   test262-paths-match.sh                       # any lane (default, unchanged)
+#   test262-paths-match.sh --target host         # the JS-host (gc) lane only
+#   test262-paths-match.sh --target standalone   # the standalone lane only
 #
 # This is the single source of truth for "does this change affect test262
 # conformance?". It MUST stay in sync with the `&test262-paths` allowlist in
@@ -14,6 +18,23 @@
 # Used by the `changes` job in test262-sharded.yml to gate the merge_group
 # shard matrix: GitHub's merge_group event has no native `paths:` filter, so
 # we diff base_sha..head_sha ourselves and pipe the file list through here.
+# The `--target` mode additionally lets that job drop ONE lane from the matrix
+# when the queued change provably cannot move that lane's results — e.g. a
+# refresh of tests/test262-slow-tests-standalone.json re-shards standalone and
+# leaves js-host byte-identical, so the 66 js-host shards are pure waste.
+#
+# ── Per-target classification ────────────────────────────────────────
+# Every relevant path is classified `both`, `host`, or `standalone`. The
+# DEFAULT IS `both`: a path is only ever narrowed to one lane when the runner
+# provably does not read it on the other lane. This is deliberate — the
+# fail-safe direction is running a lane we did not need (costs CI time), never
+# skipping a lane we did need (lets a real regression through).
+#
+# In particular ALL of `src/**` is `both`. The standalone regime is a flag
+# threaded through the SAME compiler (`compile(src, { target: "standalone" })`
+# — see src/index.ts CompileOptions.target), not a separate source tree, so
+# there is no sound src-level split. Only the per-target SHARD-WEIGHT MAPS are
+# lane-exclusive today; see `classify_test262_path` below for the full table.
 #
 # Fail-safe: this script only decides false vs true on the path patterns. The
 # CALLER is responsible for the conservative default (emit "true" when the
@@ -23,38 +44,100 @@
 
 set -euo pipefail
 
-# Glob patterns (bash extglob / `case`) mirroring &test262-paths. `**` is
-# emulated by matching the prefix; `case` globbing is non-recursive so we
-# match `src/*` as "anything under src/" via the `src/*` pattern (a path like
-# `src/a/b.ts` matches `src/*` in bash `case` because `*` spans slashes).
-matches_test262_path() {
+target="any"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --target)
+      target="${2:-}"
+      shift 2
+      ;;
+    --target=*)
+      target="${1#--target=}"
+      shift
+      ;;
+    *)
+      echo "usage: $0 [--target host|standalone|any]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$target" in
+  any | host | standalone) ;;
+  *)
+    echo "$0: unknown --target '$target' (expected host, standalone, or any)" >&2
+    exit 2
+    ;;
+esac
+
+# Classify one changed path. Echoes the LANE SCOPE it affects:
+#   both       — relevant to the js-host AND standalone lanes
+#   host       — relevant to the js-host (gc) lane only
+#   standalone — relevant to the standalone lane only
+#   (empty)    — not test262-relevant at all
+#
+# Glob patterns (bash `case`) mirror &test262-paths. `**` is emulated by
+# matching the prefix; `case` globbing is non-recursive so we match `src/*` as
+# "anything under src/" (a path like `src/a/b.ts` matches `src/*` in bash
+# `case` because `*` spans slashes).
+classify_test262_path() {
   local p="$1"
   case "$p" in
-    .github/actions/setup-node-pnpm/action.yml) return 0 ;;
-    .github/workflows/test262-sharded.yml) return 0 ;;
-    package.json) return 0 ;;
-    pnpm-lock.yaml) return 0 ;;
-    tsconfig.json) return 0 ;;
-    scripts/tsconfig.json) return 0 ;;
-    vitest.config.ts) return 0 ;;
-    src/*) return 0 ;;
-    scripts/build-test262-report.mjs) return 0 ;;
-    scripts/compiler-fork-worker.mjs) return 0 ;;
-    scripts/compiler-pool.ts) return 0 ;;
-    scripts/diff-test262.ts) return 0 ;;
-    scripts/generate-editions.ts) return 0 ;;
-    scripts/test262-worker.mjs) return 0 ;;
-    tests/test262-chunk*.test.ts) return 0 ;;
-    tests/test262-runner.ts) return 0 ;;
-    tests/test262-scope-classification.test.ts) return 0 ;;
-    tests/test262-shared.ts) return 0 ;;
-    # Weight maps change shard assignment — full validation on refresh (#1953).
-    tests/test262-slow-tests*.json) return 0 ;;
-    # The path matcher itself affects gating logic — treat as relevant so a
-    # change to the matcher always re-runs the full suite (fail-safe).
-    scripts/test262-paths-match.sh) return 0 ;;
-    *) return 1 ;;
+    # ── Lane-EXCLUSIVE paths ─────────────────────────────────────────
+    # The shard-weight maps feed assignBalancedChunk (tests/test262-shared.ts
+    # slowTestPathCandidates): the standalone lane reads
+    # test262-slow-tests-standalone.json and the js-host lane reads
+    # test262-slow-tests.json. A refresh of one cannot change the other lane's
+    # shard assignment, let alone its results, so #1953's "validate a weight
+    # refresh with the full matrix" is satisfied by running only that lane.
+    #
+    # Ordering note: the standalone pattern MUST precede the host one — the
+    # host map is also the standalone lane's FALLBACK candidate, but only when
+    # the standalone map is absent/unparseable, which is itself a change to the
+    # standalone map and therefore already in the diff.
+    tests/test262-slow-tests-standalone.json) echo standalone ;;
+    tests/test262-slow-tests.json) echo host ;;
+
+    # ── Shared paths (`both`) ────────────────────────────────────────
+    .github/actions/setup-node-pnpm/action.yml) echo both ;;
+    .github/workflows/test262-sharded.yml) echo both ;;
+    package.json) echo both ;;
+    pnpm-lock.yaml) echo both ;;
+    tsconfig.json) echo both ;;
+    scripts/tsconfig.json) echo both ;;
+    vitest.config.ts) echo both ;;
+    # The whole compiler. `target: "standalone"` is a flag through this same
+    # code, so every src change is assumed to affect BOTH lanes. Do not split.
+    src/*) echo both ;;
+    scripts/build-test262-report.mjs) echo both ;;
+    scripts/compiler-fork-worker.mjs) echo both ;;
+    scripts/compiler-pool.ts) echo both ;;
+    scripts/diff-test262.ts) echo both ;;
+    scripts/generate-editions.ts) echo both ;;
+    scripts/test262-worker.mjs) echo both ;;
+    tests/test262-chunk*.test.ts) echo both ;;
+    tests/test262-runner.ts) echo both ;;
+    tests/test262-scope-classification.test.ts) echo both ;;
+    tests/test262-shared.ts) echo both ;;
+    # Any FUTURE weight-map variant we have not classified above stays `both`
+    # (#1953) rather than silently falling through to "irrelevant".
+    tests/test262-slow-tests*.json) echo both ;;
+    # The path matcher itself affects gating logic — treat as relevant to both
+    # lanes so a change to the matcher always re-runs the full suite
+    # (fail-safe: a matcher edit must be validated by what it might skip).
+    scripts/test262-paths-match.sh) echo both ;;
+    *) echo "" ;;
   esac
+}
+
+# Does `scope` count as relevant for the requested `target`?
+scope_matches_target() {
+  local scope="$1"
+  [ -z "$scope" ] && return 1
+  [ "$target" = "any" ] && return 0
+  [ "$scope" = "both" ] && return 0
+  [ "$scope" = "$target" ] && return 0
+  return 1
 }
 
 result="false"
@@ -62,7 +145,7 @@ while IFS= read -r line || [ -n "$line" ]; do
   # Tolerate trailing CR and skip blank lines.
   line="${line%$'\r'}"
   [ -z "$line" ] && continue
-  if matches_test262_path "$line"; then
+  if scope_matches_target "$(classify_test262_path "$line")"; then
     result="true"
     break
   fi

--- a/tests/issue-1897.test.ts
+++ b/tests/issue-1897.test.ts
@@ -42,7 +42,13 @@ describe("#1897 standalone test262 merge gate", () => {
   it("diffs the merged standalone JSONL against the standalone baseline with no extra shard run", () => {
     const guard = standaloneGuardBlock();
 
-    expect(guard).toContain("if: env.SHARDS_RAN == 'true'");
+    // Gated on the STANDALONE lane specifically, not on "any shard ran": a
+    // merge_group whose queued change cannot move standalone schedules no
+    // standalone shards, and this guard would then fail the required check on
+    // a missing merged JSONL. STANDALONE_RAN is only 'true' when standalone
+    // shards actually ran, so the guard still fires on every run that has a
+    // standalone report to gate.
+    expect(guard).toContain("if: env.STANDALONE_RAN == 'true'");
     expect(guard).toContain('STANDALONE_REGRESSION_TOLERANCE: "15"');
     expect(guard).toContain("/tmp/cat-baselines/test262-standalone-current.jsonl");
     expect(guard).toContain("merged-reports/test262-standalone-results-merged.jsonl");
@@ -70,7 +76,11 @@ describe("#1897 standalone test262 merge gate", () => {
 
     expect(policy).toContain("Standalone regression guard (#1897)");
     expect(policy).toContain("no branch-protection change is needed");
-    expect(branchProtection).toContain("NO new entry here and NO branch-protection re-apply");
+    // Pre-existing prose drift: the script's #1897 note now reads "needed NO
+    // separate entry here and NO ruleset re-apply". Assert the CLAIM (no extra
+    // required-check entry, no re-apply) rather than one exact sentence, so a
+    // reworded comment doesn't fail a test about branch-protection semantics.
+    expect(branchProtection).toMatch(/NO (new|separate) entry here and NO (branch-protection|ruleset) re-apply/);
     expect(branchProtection).toContain('"merge shard reports"');
     expect(branchProtection).not.toContain('"standalone regression guard"');
   });

--- a/tests/issue-2178-baseline-floor-staleness.test.ts
+++ b/tests/issue-2178-baseline-floor-staleness.test.ts
@@ -55,23 +55,97 @@ describe("#2178 — pathsTouchTest262 mirrors the test262-paths allowlist", () =
   });
 
   it("stays in lockstep with scripts/test262-paths-match.sh", () => {
-    // The JS mirror and the shell source of truth must agree. Spot-check a
-    // representative path set through BOTH and assert identical verdicts.
+    // The JS mirror and the shell source of truth must agree — for EVERY
+    // target, since the per-lane merge_group gating in test262-sharded.yml
+    // reads the shell script while the floor-staleness check reads the mirror.
+    // Spot-check a representative path set through BOTH and assert identical
+    // verdicts.
     const cases = [
       ".github/actions/setup-node-pnpm/action.yml",
       "src/a/b.ts",
       "tests/test262-chunk1.test.ts",
       "tests/test262-runner.ts",
       "scripts/diff-test262.ts",
+      "tests/test262-slow-tests.json",
+      "tests/test262-slow-tests-standalone.json",
+      "tests/test262-slow-tests-future-lane.json",
       "README.md",
       "docs/x.md",
       "plan/y.md",
       "benchmarks/results/test262-current.json",
     ];
     const sh = resolve(ROOT, "scripts/test262-paths-match.sh");
-    for (const p of cases) {
-      const shellVerdict = execFileSync("bash", [sh], { input: p, encoding: "utf8" }).trim() === "true";
-      expect(pathsTouchTest262(p)).toBe(shellVerdict);
+    for (const target of ["any", "host", "standalone"] as const) {
+      const args = target === "any" ? [sh] : [sh, "--target", target];
+      for (const p of cases) {
+        const shellVerdict = execFileSync("bash", args, { input: p, encoding: "utf8" }).trim() === "true";
+        expect(pathsTouchTest262(p, target), `${p} @ ${target}`).toBe(shellVerdict);
+      }
+    }
+  });
+});
+
+describe("per-lane test262 path gating (merge_group single-lane runs)", () => {
+  // The merge_group `changes` job drops a whole shard lane (66 js-host or 36
+  // standalone jobs) when the queued diff provably cannot move it. That is only
+  // sound while the lane-exclusive set stays exactly the shard-weight maps —
+  // everything else, `src/**` above all, must stay both-lane.
+  it("narrows ONLY the per-lane shard-weight maps", () => {
+    expect(pathsTouchTest262("tests/test262-slow-tests-standalone.json", "standalone")).toBe(true);
+    expect(pathsTouchTest262("tests/test262-slow-tests-standalone.json", "host")).toBe(false);
+    expect(pathsTouchTest262("tests/test262-slow-tests.json", "host")).toBe(true);
+    expect(pathsTouchTest262("tests/test262-slow-tests.json", "standalone")).toBe(false);
+    // Both still count as test262-relevant for the coarse "run at all?" question.
+    expect(pathsTouchTest262("tests/test262-slow-tests-standalone.json")).toBe(true);
+    expect(pathsTouchTest262("tests/test262-slow-tests.json")).toBe(true);
+  });
+
+  it("keeps the entire compiler both-lane — `target: standalone` is a flag, not a source tree", () => {
+    for (const p of [
+      "src/compiler.ts",
+      "src/codegen/expressions.ts",
+      "src/codegen-linear/index.ts",
+      "src/runtime.ts",
+      "src/runtime/wasi-polyfill.ts",
+    ]) {
+      expect(pathsTouchTest262(p, "host"), p).toBe(true);
+      expect(pathsTouchTest262(p, "standalone"), p).toBe(true);
+    }
+  });
+
+  it("keeps shared runner/config paths both-lane", () => {
+    for (const p of [
+      "package.json",
+      "pnpm-lock.yaml",
+      "vitest.config.ts",
+      "tests/test262-runner.ts",
+      "tests/test262-shared.ts",
+      "tests/test262-chunk1.test.ts",
+      "scripts/test262-worker.mjs",
+      ".github/workflows/test262-sharded.yml",
+      // The matcher itself: a change to the gating logic must re-validate
+      // everything it could newly skip.
+      "scripts/test262-paths-match.sh",
+      // An unclassified future weight-map variant falls back to both lanes
+      // rather than silently becoming irrelevant.
+      "tests/test262-slow-tests-future-lane.json",
+    ]) {
+      expect(pathsTouchTest262(p, "host"), p).toBe(true);
+      expect(pathsTouchTest262(p, "standalone"), p).toBe(true);
+    }
+  });
+
+  it("never lets a mixed diff drop a lane that one of its paths touches", () => {
+    const blob = "tests/test262-slow-tests-standalone.json\nsrc/compiler.ts";
+    expect(pathsTouchTest262(blob, "host")).toBe(true);
+    expect(pathsTouchTest262(blob, "standalone")).toBe(true);
+  });
+
+  it("irrelevant paths stay irrelevant for every lane", () => {
+    for (const p of ["README.md", "docs/x.md", "plan/y.md", "benchmarks/results/test262-current.json"]) {
+      expect(pathsTouchTest262(p, "any"), p).toBe(false);
+      expect(pathsTouchTest262(p, "host"), p).toBe(false);
+      expect(pathsTouchTest262(p, "standalone"), p).toBe(false);
     }
   });
 });

--- a/tests/issue-3431-mg-matrix.test.ts
+++ b/tests/issue-3431-mg-matrix.test.ts
@@ -19,6 +19,7 @@ import {
   MERGE_GROUP_RUNNER_CAPACITY,
   STANDALONE_CHUNKS,
   buildMergeGroupMatrix,
+  parseLanes,
 } from "../scripts/gen-test262-mg-matrix.mjs";
 
 describe("#3431 gen-test262-mg-matrix", () => {
@@ -79,6 +80,66 @@ describe("#3431 gen-test262-mg-matrix", () => {
     // the constants stay mutually consistent rather than pinning a number
     // forever: whoever re-derives the ratio updates both sides together.
     expect(JS_HOST_CHUNKS / STANDALONE_CHUNKS).toBeCloseTo(1.835, 2);
+  });
+});
+
+describe("per-lane merge_group matrix (single-lane runs)", () => {
+  // The `changes` job drops a lane whose results the queued diff provably
+  // cannot move (see scripts/test262-paths-match.sh --target). These pin the
+  // two properties that make that safe.
+  it("emits only the requested lane", () => {
+    const hostOnly = buildMergeGroupMatrix({ host: true, standalone: false });
+    expect(hostOnly).toHaveLength(JS_HOST_CHUNKS);
+    expect(hostOnly.every((e) => e.target_name === "js-host")).toBe(true);
+
+    const standaloneOnly = buildMergeGroupMatrix({ host: false, standalone: true });
+    expect(standaloneOnly).toHaveLength(STANDALONE_CHUNKS);
+    expect(standaloneOnly.every((e) => e.target_name === "standalone")).toBe(true);
+  });
+
+  it("keeps the surviving lane's partition IDENTICAL to a full two-lane run", () => {
+    // Load-bearing: a single-lane run's results are diffed against a baseline
+    // produced by two-lane runs. assignBalancedChunk is a pure function of
+    // (chunk_index, chunk_total), so the freed runners must NOT be spent
+    // re-partitioning the surviving lane into more shards.
+    const full = buildMergeGroupMatrix();
+    for (const lanes of [
+      { host: true, standalone: false },
+      { host: false, standalone: true },
+    ]) {
+      for (const entry of buildMergeGroupMatrix(lanes)) {
+        const twin = full.find((e) => e.target_name === entry.target_name && e.chunk_index === entry.chunk_index);
+        expect(twin).toEqual(entry);
+      }
+    }
+  });
+
+  it("defaults to both lanes, and fail-safes an empty selection back to both", () => {
+    const both = buildMergeGroupMatrix();
+    expect(buildMergeGroupMatrix({})).toEqual(both);
+    // An empty matrix is a workflow-level error in GitHub Actions, not a
+    // skipped job — and skipping coverage is the wrong direction anyway.
+    expect(buildMergeGroupMatrix({ host: false, standalone: false })).toEqual(both);
+  });
+
+  it("parseLanes maps the CLI flag to lane selections, both-lanes by default", () => {
+    expect(parseLanes(["node", "gen.mjs"])).toEqual({ host: true, standalone: true });
+    expect(parseLanes(["node", "gen.mjs", "--lanes", "host,standalone"])).toEqual({
+      host: true,
+      standalone: true,
+    });
+    expect(parseLanes(["node", "gen.mjs", "--lanes=host"])).toEqual({ host: true, standalone: false });
+    expect(parseLanes(["node", "gen.mjs", "--lanes", "standalone"])).toEqual({
+      host: false,
+      standalone: true,
+    });
+    // Empty value = "no lane selected" -> buildMergeGroupMatrix fail-safes it.
+    expect(parseLanes(["node", "gen.mjs", "--lanes", ""])).toEqual({ host: false, standalone: false });
+  });
+
+  it("parseLanes rejects an unknown lane instead of silently narrowing coverage", () => {
+    expect(() => parseLanes(["node", "gen.mjs", "--lanes", "hsot"])).toThrow(/unknown lane/);
+    expect(() => parseLanes(["node", "gen.mjs", "--lanes", "host,gc"])).toThrow(/unknown lane/);
   });
 });
 

--- a/tests/test262-per-lane-gating.test.ts
+++ b/tests/test262-per-lane-gating.test.ts
@@ -1,0 +1,297 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Per-lane test262 gating in .github/workflows/test262-sharded.yml.
+ *
+ * The `changes` job classifies a queued merge_group diff per LANE
+ * (`scripts/test262-paths-match.sh --target host|standalone`) and drops the
+ * shard matrix for any lane the change provably cannot move — 66 js-host jobs
+ * or 36 standalone jobs that would otherwise run and be thrown away.
+ *
+ * Skipping conformance coverage is exactly the kind of change that is silently
+ * wrong, so this file pins the invariants that make it safe:
+ *   1. Every fail-safe path in `detect` emits ALL lanes (uncertainty ⇒ run).
+ *   2. Consumers read the lane outputs as `!= 'false'`, so a missing output
+ *      means "ran", never "skipped".
+ *   3. Each lane's report/guard steps are gated on THAT lane, so a skipped
+ *      lane cannot fail the required check on a missing JSONL.
+ *   4. The #1956 group artifact — which #3448 lets `promote-baseline` publish
+ *      a baseline straight from — is only published when BOTH lanes ran.
+ *   5. push / workflow_dispatch always run both lanes (they promote baselines).
+ */
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const WORKFLOW_PATH = resolve(ROOT, ".github/workflows/test262-sharded.yml");
+const workflowText = readFileSync(WORKFLOW_PATH, "utf8");
+const MATCHER = resolve(ROOT, "scripts/test262-paths-match.sh");
+
+// Text slicing rather than a YAML parse: `yaml` is not a direct dependency and
+// the rest of the workflow tests in this repo read the file as text too.
+
+/** Text of one top-level job, from its `  <name>:` key to the next one. */
+function job(name: string): string {
+  const start = workflowText.indexOf(`\n  ${name}:\n`);
+  expect(start, `job ${name} missing`).toBeGreaterThan(-1);
+  const rest = workflowText.slice(start + 1);
+  const next = rest.slice(1).search(/\n {2}[a-z][a-z0-9_-]*:\n/);
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+/** Text of one step within a job, from its `- name:` to the next step. */
+function step(jobName: string, stepName: string): string {
+  const jobText = job(jobName);
+  const start = jobText.indexOf(`      - name: ${stepName}\n`);
+  expect(start, `step "${stepName}" not found in job ${jobName}`).toBeGreaterThan(-1);
+  const rest = jobText.slice(start);
+  const next = rest.slice(1).indexOf("\n      - name: ");
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+/** The single-line `if:` condition of a step. */
+function stepIf(jobName: string, stepName: string): string {
+  const m = step(jobName, stepName).match(/\n {8}if: (.*)/);
+  expect(m, `step "${stepName}" in ${jobName} has no single-line if:`).toBeTruthy();
+  return (m as RegExpMatchArray)[1].trim();
+}
+
+/** A `KEY: value` entry from a job-level or step-level env block. */
+function envEntry(text: string, key: string): string {
+  const m = text.match(new RegExp(`\\n\\s*${key}: (.*)`));
+  expect(m, `env ${key} not found`).toBeTruthy();
+  return (m as RegExpMatchArray)[1].trim();
+}
+
+/** Run the real `detect` step body against a synthetic merge_group diff. */
+function runDetect(diff: string | null, { eventName = "merge_group" } = {}) {
+  const detectBody = step("changes", "Detect test262-relevant changes");
+  const runIdx = detectBody.indexOf("\n        run: |\n");
+  expect(runIdx, "detect step body missing").toBeGreaterThan(-1);
+  const script = detectBody
+    .slice(runIdx + "\n        run: |\n".length)
+    .split("\n")
+    .map((l) => (l.startsWith("          ") ? l.slice(10) : l))
+    .join("\n");
+
+  const dir = mkdtempSync(join(tmpdir(), "detect-"));
+  const scriptPath = join(dir, "detect.sh");
+  const outPath = join(dir, "github_output");
+  const binDir = join(dir, "bin");
+  mkdirSync(binDir);
+  writeFileSync(scriptPath, script);
+  writeFileSync(outPath, "");
+  // Stub `git` so the step sees exactly the diff under test. `diff === null`
+  // simulates a failing `git diff` (the fail-safe path).
+  writeFileSync(
+    join(binDir, "git"),
+    `#!/bin/bash\ncase "$1" in\n  diff) [ "$SYNTH_FAIL" = "1" ] && exit 128; printf '%s\\n' "$SYNTH_DIFF"; exit 0;;\n  *) exit 0;;\nesac\n`,
+    { mode: 0o755 },
+  );
+
+  try {
+    execFileSync("bash", [scriptPath], {
+      encoding: "utf8",
+      stdio: "ignore",
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        GITHUB_OUTPUT: outPath,
+        EVENT_NAME: eventName,
+        MG_BASE_SHA: "base",
+        MG_HEAD_SHA: "head",
+        SYNTH_DIFF: diff ?? "",
+        SYNTH_FAIL: diff === null ? "1" : "0",
+      },
+    });
+
+    const verdict: Record<string, string> = {};
+    for (const line of readFileSync(outPath, "utf8").split("\n")) {
+      const eq = line.indexOf("=");
+      if (eq > 0) verdict[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+    }
+    return verdict;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("test262 per-lane gating — the `detect` step", () => {
+  it("runs both lanes for a compiler change", () => {
+    expect(runDetect("src/codegen/expressions.ts")).toEqual({
+      run_shards: "true",
+      run_host: "true",
+      run_standalone: "true",
+    });
+  });
+
+  it("drops the js-host lane for a standalone-only shard-weight refresh", () => {
+    expect(runDetect("tests/test262-slow-tests-standalone.json")).toEqual({
+      run_shards: "true",
+      run_host: "false",
+      run_standalone: "true",
+    });
+  });
+
+  it("drops the standalone lane for a js-host-only shard-weight refresh", () => {
+    expect(runDetect("tests/test262-slow-tests.json")).toEqual({
+      run_shards: "true",
+      run_host: "true",
+      run_standalone: "false",
+    });
+  });
+
+  it("keeps a lane the moment ANY changed path touches it", () => {
+    expect(runDetect("tests/test262-slow-tests-standalone.json\nsrc/compiler.ts")).toEqual({
+      run_shards: "true",
+      run_host: "true",
+      run_standalone: "true",
+    });
+    expect(runDetect("tests/test262-slow-tests-standalone.json\ntests/test262-slow-tests.json")).toEqual({
+      run_shards: "true",
+      run_host: "true",
+      run_standalone: "true",
+    });
+  });
+
+  it("run_shards stays the OR of the two lanes (unchanged meaning for existing consumers)", () => {
+    for (const diff of [
+      "src/compiler.ts",
+      "tests/test262-slow-tests.json",
+      "tests/test262-slow-tests-standalone.json",
+      "README.md",
+      "docs/x.md\nplan/y.md",
+    ]) {
+      const v = runDetect(diff);
+      const anyLane = v.run_host === "true" || v.run_standalone === "true";
+      expect(v.run_shards, diff).toBe(String(anyLane));
+      // And it must still agree with the untargeted matcher, which other
+      // callers (test262-pr-stub.yml, the stale-baseline guard) rely on.
+      const coarse = execFileSync("bash", [MATCHER], { input: diff, encoding: "utf8" }).trim();
+      expect(v.run_shards, diff).toBe(coarse);
+    }
+  });
+
+  it("skips everything for a docs-only queue entry", () => {
+    expect(runDetect("README.md\ndocs/x.md")).toEqual({
+      run_shards: "false",
+      run_host: "false",
+      run_standalone: "false",
+    });
+  });
+
+  it("FAIL-SAFE: every uncertain path emits all lanes", () => {
+    const both = { run_shards: "true", run_host: "true", run_standalone: "true" };
+    expect(runDetect(null), "git diff failed").toEqual(both);
+    expect(runDetect(""), "empty diff").toEqual(both);
+    // Non-merge_group events never narrow: push/workflow_dispatch promote
+    // BOTH baselines, so a single-lane run there would publish a half-empty one.
+    for (const eventName of ["push", "workflow_dispatch", "pull_request"]) {
+      expect(runDetect("tests/test262-slow-tests-standalone.json", { eventName }), eventName).toEqual(both);
+    }
+  });
+});
+
+describe("test262 per-lane gating — workflow wiring", () => {
+  it("`changes` exposes the per-lane outputs", () => {
+    const changes = job("changes");
+    expect(envEntry(changes, "run_host")).toContain("steps.detect.outputs.run_host");
+    expect(envEntry(changes, "run_standalone")).toContain("steps.detect.outputs.run_standalone");
+  });
+
+  it("the merge_group matrix is built from the lane verdict", () => {
+    const s = step("changes", "Compute merge_group shard matrix (#3431)");
+    expect(envEntry(s, "RUN_HOST")).toContain("steps.detect.outputs.run_host");
+    expect(envEntry(s, "RUN_STANDALONE")).toContain("steps.detect.outputs.run_standalone");
+    expect(s).toContain("--lanes");
+    // A missing verdict must select the lane, not drop it.
+    expect(s).toContain('if [ "$RUN_HOST" != "false" ]');
+    expect(s).toContain('if [ "$RUN_STANDALONE" != "false" ]');
+  });
+
+  it("every lane flag treats a missing output as 'ran' (`!= 'false'`, never `== 'true'`)", () => {
+    for (const [jobName, flag] of [
+      ["merge-report", "HOST_RAN"],
+      ["merge-report", "STANDALONE_RAN"],
+      ["regression-gate", "HOST_RAN"],
+    ] as const) {
+      const expr = envEntry(job(jobName), flag);
+      const lane = flag === "HOST_RAN" ? "run_host" : "run_standalone";
+      expect(expr, `${jobName}.${flag}`).toContain(`needs.changes.outputs.${lane} != 'false'`);
+      // Still requires a shard job to have actually succeeded.
+      expect(expr, `${jobName}.${flag}`).toContain("needs.test262-shard.result == 'success'");
+      expect(expr, `${jobName}.${flag}`).toContain("needs.test262-shard-mg.result == 'success'");
+    }
+  });
+
+  it("each lane's steps are gated on that lane", () => {
+    const host = "env.HOST_RAN == 'true'";
+    const standalone = "env.STANDALONE_RAN == 'true'";
+    const expected: Array<[string, string]> = [
+      ["Merge JS-host test262 JSONL results", host],
+      ["Build merged JS-host test262 report", host],
+      ["Catastrophic regression guard (#1668)", host],
+      ["Compile-time regression guard (#1942, #3447)", host],
+      ["Merge standalone test262 JSONL results", standalone],
+      ["Build merged standalone test262 report", standalone],
+      ["Standalone pass-count high-water floor (#2097)", standalone],
+      ["Standalone regression guard (#1897)", standalone],
+    ];
+    for (const [name, guard] of expected) {
+      expect(stepIf("merge-report", name), name).toBe(guard);
+    }
+  });
+
+  it("regression-gate is host-lane and no-ops when js-host did not run", () => {
+    // The whole job consumes js-host JSONLs only; the standalone lane's gates
+    // live in merge-report. It must not look for artifacts that do not exist.
+    // No `SHARDS_RAN` env KEY (the prose mentions it) — the job must not have
+    // a lane-agnostic flag left to accidentally gate on.
+    expect(job("regression-gate")).not.toMatch(/\n {6}SHARDS_RAN:/);
+    expect(job("regression-gate")).not.toContain("env.SHARDS_RAN");
+    expect(stepIf("regression-gate", "No-op pass (no merged test262 report to diff)")).toBe("env.HOST_RAN != 'true'");
+    for (const name of [
+      "Download shard artifacts",
+      "Merge JS-host test262 JSONL results",
+      "Compare against current main baseline",
+      "Hard-error stability gate (#1853)",
+    ]) {
+      expect(stepIf("regression-gate", name), name).toContain("env.HOST_RAN == 'true'");
+    }
+  });
+
+  it("the #1956 group artifact is published ONLY when both lanes ran", () => {
+    // #3448 lets a push:main promote a baseline straight from this artifact.
+    // A single-lane group would promote a baseline with an empty side; not
+    // publishing makes the probe MISS and run the full two-lane matrix.
+    const cond = stepIf("merge-report", "Publish group results for predecessor diffing (#1956)");
+    expect(cond).toContain("env.HOST_RAN == 'true'");
+    expect(cond).toContain("env.STANDALONE_RAN == 'true'");
+    expect(cond).toContain("github.event_name == 'merge_group'");
+  });
+
+  it("the required-check decision still keys off SHARDS_RAN, not a single lane", () => {
+    // "merge shard reports" must stay green/red on the same conditions as
+    // before — per-lane gating narrows WHICH steps run, not whether the
+    // required context is produced (the cascade-skip trap).
+    expect(stepIf("merge-report", "Fail if required test262 shards did not succeed")).toBe(
+      "env.SHARDS_RAN != 'true' && env.SHARD_SKIP_OK != 'true'",
+    );
+    expect(stepIf("merge-report", "No-op pass (shards intentionally skipped)")).toBe(
+      "env.SHARDS_RAN != 'true' && env.SHARD_SKIP_OK == 'true'",
+    );
+  });
+
+  it("the static push/workflow_dispatch matrix still carries BOTH targets", () => {
+    // promote-baseline publishes both lanes' baselines from these runs.
+    const shardJob = job("test262-shard");
+    expect(shardJob).toContain("- name: js-host");
+    expect(shardJob).toContain("- name: standalone");
+    expect(shardJob).toContain("test262_target: gc");
+    expect(shardJob).toContain("test262_target: standalone");
+  });
+});


### PR DESCRIPTION
## Description

The merge_group `changes` job already answered *"does test262 run at all?"* It now also answers it **per lane**, so a queued change that provably cannot move one lane's results no longer schedules that lane's shard jobs — 66 js-host or 36 standalone runners (#3431) that were previously spent and thrown away.

`scripts/test262-paths-match.sh` gains `--target host|standalone` and stays the single source of truth for the per-lane question too. Default (no `--target`) behaviour is byte-identical, so `test262-pr-stub.yml` and the stale-baseline guard are unaffected.

### What is lane-exclusive — and what deliberately is not

A path is narrowed to one lane **only** where the runner demonstrably does not read it on the other. Today that is exactly the two shard-weight maps: `slowTestPathCandidates` in `tests/test262-shared.ts` reads `test262-slow-tests-standalone.json` for standalone and `test262-slow-tests.json` for js-host.

**All of `src/**` stays both-lane.** `target: "standalone"` is a flag threaded through the *same* compiler (`CompileOptions.target`), not a separate source tree, so there is no sound src-level split. Splitting it is where a false negative — silently skipping a lane that a change did move — would come from, so the classifier defaults to `both` and narrowing is opt-in per path.

### Safety properties

All pinned by `tests/test262-per-lane-gating.test.ts`, which executes the **real** `detect` step body extracted from the workflow against synthetic diffs:

- `run_shards` stays exactly `run_host || run_standalone`, so every existing consumer keeps its previous value and meaning.
- Every uncertain path — missing `base_sha`, failed or empty diff, unexpected matcher output, any non-`merge_group` event — emits **both** lanes, and consumers read the outputs as `!= 'false'` so a missing output means "run", never "skip".
- The surviving lane keeps its **full** chunk count, so its corpus partition is byte-identical to a two-lane run and stays comparable to the baseline it is diffed against. The freed runners are *not* spent re-partitioning it.
- `push` / `workflow_dispatch` always run both lanes — `promote-baseline` publishes both baselines from those runs.
- A single-lane merge_group does **not** publish the #1956 `test262-group-<sha>` artifact, so the #3448 push:main probe MISSES and the full two-lane matrix runs before promoting, rather than promoting a baseline with an empty side.
- `merge-report` keeps `SHARDS_RAN` for the required-check decision (no cascade-skip trap); only the per-lane report/guard steps move to `HOST_RAN` / `STANDALONE_RAN`. `regression-gate` is entirely js-host-lane and green-no-ops when that lane did not run.

### Also

- `scripts/check-baseline-floor-staleness.mjs` already iterates host/standalone floors but counted drift with a shared predicate; the lane is now threaded through, so a standalone weight refresh no longer reads as host-floor lag. Its JS mirror stays in lockstep with the shell matcher, now verified for every target.
- `docs/ci-policy.md` documents the per-lane rules and their constraints.
- **Drive-by:** `tests/issue-1897.test.ts` pinned an exact sentence in `enable-branch-protection.sh` that has since been reworded. It was already failing on `main`; relaxed to assert the claim rather than the phrasing, because touching that file made the pre-commit `changed-root-tests` hook run it.

### Verification

- `pnpm run typecheck`, `pnpm run lint`, prettier — clean.
- All 14 workflow-reading test files run: 190 tests, the only failures are the 2 pre-existing `issue-3426` ones (they look up a step name `Compile-time regression guard (#1942)` that is actually `(#1942, #3447)` on `main` — untouched by this PR, confirmed by re-running on a clean tree).
- The `detect` step, the matcher and the matrix generator were each exercised directly against every branch, including all four fail-safe paths.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfzFEfYTDRMpuqVwKhVncF)_