### PR TITLE
docs(#3926,#3927): own every named cause of the standalone acorn gap, and rank them

### DIFF
--- a/plan/issues/3684-cross-engine-axis-decomposition.md
+++ b/plan/issues/3684-cross-engine-axis-decomposition.md
@@ -378,6 +378,28 @@ move under memory pressure, and a 1,188-sample profile gives roughly
 ±1pp resolution on a 2% bucket. The **ranking** is what this section
 asserts; treat individual sub-1% figures as indicative.
 
+## Cross-box caveat on this issue's ranking (#3780 round 4, 2026-07-31)
+
+Every share quoted in this issue comes from a profile of the standalone acorn
+self-parse. A fourth profile, taken on a **4-core Linux container / Node
+22.22.2** (rounds 1-3 of #3780 and both cross-validated profiles above were
+Node 24 / arm64 macOS), disagrees on one bucket by an order of magnitude:
+
+| bucket | Node 24 / macOS profiles | Node 22 / Linux container |
+| --- | ---: | ---: |
+| GC | 1.5% and 4.3% | **24-37%** |
+
+The Linux figure is corroborated by an independent, profiler-free measurement
+(summing inter-GC heap growth from `--trace-gc`: 22.5 ms of a ~120 ms parse
+after #3780 round 4's lowerings, 30.1 ms before). I do not know whether the
+cause is the V8 version, heap sizing, or the container.
+
+**Why it matters here:** the non-GC buckets are shares of a denominator that
+moves with it. If GC is really ~2% on the reference hardware, this issue's
+share is correspondingly *larger* there than the Linux profile suggests, and
+allocation-side work (#3921/#3927) is correspondingly smaller. Re-measure on
+the target hardware before using any of these shares to sequence work.
+
 ## Deliverables
 
 **D1 — the harness itself (done in this issue's PR).**

--- a/plan/issues/3685-generic-receiver-monomorphization.md
+++ b/plan/issues/3685-generic-receiver-monomorphization.md
@@ -592,3 +592,25 @@ back to a dispatch that answers `undefined`. Fix and pins in
 `tests/issue-3719-new-assigned-to-binding.test.ts`; write-up in
 `plan/issues/3719-new-assigned-to-binding-loses-fnctor-approval.md`.
 All five original matrix cases plus the untyped-only control now return 1000.
+
+## Cross-box caveat on this issue's ranking (#3780 round 4, 2026-07-31)
+
+Every share quoted in this issue comes from a profile of the standalone acorn
+self-parse. A fourth profile, taken on a **4-core Linux container / Node
+22.22.2** (rounds 1-3 of #3780 and both cross-validated profiles above were
+Node 24 / arm64 macOS), disagrees on one bucket by an order of magnitude:
+
+| bucket | Node 24 / macOS profiles | Node 22 / Linux container |
+| --- | ---: | ---: |
+| GC | 1.5% and 4.3% | **24-37%** |
+
+The Linux figure is corroborated by an independent, profiler-free measurement
+(summing inter-GC heap growth from `--trace-gc`: 22.5 ms of a ~120 ms parse
+after #3780 round 4's lowerings, 30.1 ms before). I do not know whether the
+cause is the V8 version, heap sizing, or the container.
+
+**Why it matters here:** the non-GC buckets are shares of a denominator that
+moves with it. If GC is really ~2% on the reference hardware, this issue's
+share is correspondingly *larger* there than the Linux profile suggests, and
+allocation-side work (#3921/#3927) is correspondingly smaller. Re-measure on
+the target hardware before using any of these shares to sequence work.

--- a/plan/issues/3686-null-check-and-cast-scaffolding.md
+++ b/plan/issues/3686-null-check-and-cast-scaffolding.md
@@ -239,6 +239,28 @@ typed-and-reachable. **Fold the seen-set into this issue's PR**, where the same
 change supplies the repro that proves the guard works — filing it separately
 would trip the #2093 gate (no failing repro).
 
+## Cross-box caveat on this issue's ranking (#3780 round 4, 2026-07-31)
+
+Every share quoted in this issue comes from a profile of the standalone acorn
+self-parse. A fourth profile, taken on a **4-core Linux container / Node
+22.22.2** (rounds 1-3 of #3780 and both cross-validated profiles above were
+Node 24 / arm64 macOS), disagrees on one bucket by an order of magnitude:
+
+| bucket | Node 24 / macOS profiles | Node 22 / Linux container |
+| --- | ---: | ---: |
+| GC | 1.5% and 4.3% | **24-37%** |
+
+The Linux figure is corroborated by an independent, profiler-free measurement
+(summing inter-GC heap growth from `--trace-gc`: 22.5 ms of a ~120 ms parse
+after #3780 round 4's lowerings, 30.1 ms before). I do not know whether the
+cause is the V8 version, heap sizing, or the container.
+
+**Why it matters here:** the non-GC buckets are shares of a denominator that
+moves with it. If GC is really ~2% on the reference hardware, this issue's
+share is correspondingly *larger* there than the Linux profile suggests, and
+allocation-side work (#3921/#3927) is correspondingly smaller. Re-measure on
+the target hardware before using any of these shares to sequence work.
+
 ## Direction
 
 1. **Hoist the check to the binding, not the access.** A local proven

--- a/plan/issues/3921-wasmgc-allocation-census.md
+++ b/plan/issues/3921-wasmgc-allocation-census.md
@@ -13,7 +13,7 @@ task_type: tooling
 area: codegen, tooling
 language_feature: compiler-internals
 goal: performance
-related: [3780, 3756, 3684, 3686]
+related: [3780, 3756, 3684, 3685, 3686, 3920, 3926, 3927]
 origin: "#3780 round 4 — allocation volume turned out to be the dominant standalone cost, and 34 MB of the 43.6 MB per acorn parse cannot be attributed with any existing tool"
 ---
 
@@ -88,6 +88,31 @@ Notes for whoever builds it:
   the allocation or merge counters for two types that got merged — comparing
   the census total against the independent `--trace-gc` sum (which needs no
   instrumentation) is the cross-check.
+
+## Why this is the head of the queue
+
+The standalone gap is ~9-10x and no identified lever is known to close it
+alone. The ranked causes, and who owns them, are:
+
+| # | cause | owner |
+| ---: | --- | --- |
+| 1 | allocation volume — 34 MB/parse unattributed | **this issue** |
+| 2 | null-check/cast scaffolding inside compiled bodies | #3686 |
+| 3 | untwinned generic bodies (twin admission 150/2,363 = 6.3%) | #3685 |
+| 4 | `__extern_get` generic property lookup | #3926 |
+| 5 | union-of-all-shapes fnctor structs (`Node` = 292 B for 3-6 live props) | #3927 |
+
+This one is first not because it is the biggest — #3686/#3685 may well be —
+but because it is the only one whose size is currently **unknown**, and it is
+cheap to resolve relative to what it unblocks. Items 1 and 5 are both
+allocation-side; sequencing 5 before this would risk spending an XL window on
+a retained 9.5 MB while a transient 34 MB goes unexamined.
+
+**Caveat that applies to the whole table:** these shares come from a Linux /
+Node 22 profile whose GC bucket (24-37%) disagrees by an order of magnitude
+with the two Node 24 / macOS profiles (1.5%, 4.3%). See the cross-box caveat
+now recorded in #3684/#3685/#3686. If GC is genuinely ~2% on the reference
+hardware, items 2-4 outrank items 1 and 5 there.
 
 ## Scope
 

--- a/plan/issues/3926-extern-get-generic-property-lookup-cost.md
+++ b/plan/issues/3926-extern-get-generic-property-lookup-cost.md
@@ -1,0 +1,85 @@
+---
+id: 3926
+title: "perf: `__extern_get` generic property lookup is the largest non-parser function in the standalone parse and is unowned"
+status: ready
+sprint: current
+created: 2026-07-31
+updated: 2026-07-31
+priority: high
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: codegen, runtime
+language_feature: objects
+goal: performance
+related: [3673, 3669, 3671, 3685, 3686, 3780, 3921]
+origin: "#3780 round 4 — re-ranking the standalone acorn profile found __extern_get unowned: #3673 (which carried it as a slice) is done, and #3669/#3671 are about slot MONOMORPHISM, not lookup cost"
+---
+
+# #3926 — `__extern_get` generic property lookup cost has no live owner
+
+## Why this issue exists
+
+Across four independent profiles of the standalone acorn self-parse,
+`__extern_get` is consistently **the largest single non-parser function**:
+
+| profile | `__extern_get` self time | whose |
+| --- | ---: | --- |
+| `dev-acorn-throughput`, 30 parses of 226 KB | 8.03% (bucket 10.10%) | theirs |
+| #3686's, 20,000 parses of 1.5 KB | 9.69% (bucket 12.6%) | theirs |
+| #3780 round 4, 30 parses, this box | 4.46% (bucket 5.15%) | mine |
+
+The spread across boxes is real and unexplained (see the caveat in #3921), but
+no profile puts it below 4%, and two put it near 10%.
+
+**It is nevertheless unowned.** The issue that carried it as a slice, #3673, is
+`status: done`. #3669 is also `done`; #3671 is `ready` but scoped to *slot
+monomorphism* — whether a slot seeded with a number/boolean corrupts on a later
+write — which is a **correctness/representation** question, not the cost of the
+lookup itself. Nothing currently tracks "the generic property read is
+expensive".
+
+## What is already known
+
+- The helper is emitted, not imported, in standalone — this is **internal**
+  cost, not bridge tax. (Do not conflate with #3780's JS-host lane, where
+  `__extern_get` is one of 17.67 M host crossings per parse.)
+- Its structure is a front-guard cascade → per-key prototype-lookup cache
+  (#3673 round 9b) → closed-struct field ladder → `__obj_find` own-property
+  walk → prototype-chain walk → accessor branch. The ladder is what the cache
+  exists to skip.
+- **#3780 round 4 already removed one cost from inside it**: the boolean arms
+  of the closed-struct ladder allocated a fresh 16-byte carrier per read
+  (742 static `struct.new` sites → 2 after interning). That was allocation, not
+  lookup, and the lookup work is untouched.
+- #3780 round 3 routed acorn's `this.options.<x>` reads *directly* to
+  `__extern_get`, deliberately skipping a useless closed-struct candidate
+  ladder at the call site (`JS2WASM_TYPED_OPEN_CARRIER_READS`, 4.59% faster).
+  So some call sites now reach this helper **sooner** by design — which raises,
+  not lowers, the value of making the helper itself cheap.
+
+## Scope
+
+- [ ] Profile *inside* `__extern_get` — which arm actually retires the time on
+      the acorn parse: front guards, cache probe, ladder, `__obj_find`, or the
+      proto walk. The whole-function 4–10% figure does not say.
+- [ ] Establish the hit rate of the #3673 round-9b per-key prototype cache on
+      this workload. A cache that mostly misses is pure added latency.
+- [ ] Only then choose a lowering. Do NOT start from the assumption that the
+      ladder is the problem — that is what the cache was already built to fix.
+
+## Non-goals
+
+- Slot monomorphism (#3671) — different question, different failure mode.
+- The JS-host lane's import count (#3673's old framing) — that lane's cost is
+  the crossing, not this helper's body.
+
+## Acceptance criteria
+
+- [ ] An intra-function attribution for `__extern_get` on the standalone acorn
+      parse, naming which arm costs what.
+- [ ] Cache hit rate reported for the same workload.
+- [ ] Any lowering that lands is measured with a paired control on the
+      standalone acorn parse, and reports binary-size cost alongside the win.
+- [ ] No standalone test262 regression.

--- a/plan/issues/3927-fnctor-shape-splitting.md
+++ b/plan/issues/3927-fnctor-shape-splitting.md
@@ -1,0 +1,101 @@
+---
+id: 3927
+title: "perf: a widened fnctor struct is the union of every shape its constructor ever takes — acorn's `Node` is 292 B for a 3-6 property object"
+status: ready
+sprint: current
+created: 2026-07-31
+updated: 2026-07-31
+priority: medium
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+task_type: performance
+area: codegen
+language_feature: objects, classes
+goal: performance
+related: [3780, 3921, 3686, 3685, 743, 684]
+origin: "#3780 round 4 — after packing the presence flags, `Node` is still 292 B, and the residue is the union-of-all-shapes widening itself"
+---
+
+# #3927 — per-shape splitting of widened fnctor structs
+
+## Problem
+
+A constructor whose instances take different property sets is lowered to ONE
+closed struct carrying the **union** of every property any instance ever gets.
+Acorn's `Node` is the clean example: every AST node kind — `Identifier`,
+`CallExpression`, `TryStatement`, … — is the same `new Node(...)`, so the struct
+carries the union of the whole ESTree surface.
+
+Measured on the standalone acorn module (#3780 round 4):
+
+| | fields | bytes/instance |
+| --- | ---: | ---: |
+| before round 4 | 130 (63 externref + 63 presence `i32` + 2 f64 + 2 ref) | 536 B |
+| after round 4 (presence packed) | 69 | **292 B** |
+| live properties on a typical AST node | 3–6 | — |
+
+Round 4 removed the presence-flag half. The remaining 292 B is **62 `externref`
+slots, of which a given node uses a handful.** At 32,487 nodes per 226 KB parse
+that is 9.5 MB of the 43.6 MB allocated — and unlike the transient garbage in
+#3921, this part is *retained* for the life of the AST, so it is paid twice:
+once by the scavenger copying it, once by promotion.
+
+## Why this is filed as hard, and what it is NOT
+
+This is asking for the thing V8 does with hidden classes, done statically. The
+honest framing:
+
+- **A per-`type`-string split is not sound in general.** Acorn happens to set
+  `node.type` before the shape settles, but nothing in the language says a
+  constructor's instances partition by a string field, and the compiler cannot
+  assume it.
+- The tractable version is a **whole-program shape-set analysis**: collect the
+  set of property sets an instance of `F` can reach, and if that set is small
+  and statically separable, emit a struct per member with a common prefix
+  (subtyping already supports the prefix rule — `$__vec_base` uses it). Where
+  the analysis fails, keep today's union struct.
+- Related prior art in-tree: #743 (whole-program type-flow analysis), #684
+  (`any`-typed variable inference). This is the object-shape analogue and
+  should reuse their fixpoint rather than grow a third one.
+
+## Sequencing — do NOT start this first
+
+Two things should land before this is worth attempting:
+
+1. **#3921 (allocation census).** 34 MB of the 43.6 MB per parse is currently
+   unattributed. If the census shows the transient 34 MB dwarfs the retained
+   9.5 MB — which it does on the only measurement we have — then a cheaper
+   transient-allocation fix outranks this. Do not spend an XL window on the
+   9.5 MB before knowing what the 34 MB is.
+2. **#3686 / #3685.** Splitting shapes makes more field accesses statically
+   typed, which is the input those two want. Doing this first would mean
+   re-deriving their admission logic against a moving representation.
+
+There is also a **latent cycle guard** to fold in, recorded in
+`plan/agent-context/dev-acorn-throughput.md` §6 and in #3686: `objectIrTypeFromTsType`
+↔ `tsTypeToFieldIr` (`src/codegen/index.ts`) carry no seen-set, and today's code
+survives only because a self-referential shape (`class Node { left: Node }`)
+bails to the legacy path before it can recurse. Splitting makes those shapes
+typed-and-reachable, which is exactly when the guard becomes live.
+
+## Scope
+
+- [ ] Whole-program shape-set analysis: per constructor, the set of reachable
+      property sets, with an explicit "unknown / too many" verdict.
+- [ ] Emit per-shape structs sharing a common prefix where the set is small and
+      separable; keep the union struct otherwise.
+- [ ] Fold in the `objectIrTypeFromTsType` ↔ `tsTypeToFieldIr` seen-set, with
+      the repro that proves it — the same PR that makes the shape reachable is
+      the one that can supply it.
+
+## Acceptance criteria
+
+- [ ] Acorn's `Node` allocation drops measurably in the `--trace-gc` per-parse
+      accounting, reported alongside the census total from #3921.
+- [ ] A constructor whose shapes are NOT separable still compiles, via the
+      union struct, with no behaviour change.
+- [ ] `for…in` / `Object.keys` / `in` answer identically before and after for
+      every split shape — see #3920, which shows this surface is already
+      lane-divergent and must not be made worse.
+- [ ] No standalone test262 regression.


### PR DESCRIPTION
Follow-up to #3899 and #3905 (both merged). Docs only — no compiler source, so nothing here can regress.

The ~9–10x standalone acorn gap decomposes into five causes. Two had no live owner; three carried shares that a fourth profile contradicts. This makes "work the gap" a queue rather than a re-derivation each time.

| # | cause | owner |
| ---: | --- | --- |
| 1 | allocation volume — 34 MB/parse unattributed | #3921 |
| 2 | null-check/cast scaffolding in compiled bodies | #3686 |
| 3 | untwinned generic bodies (twin admission 150/2,363 = 6.3%) | #3685 |
| 4 | `__extern_get` generic property lookup | **#3926 (new)** |
| 5 | union-of-all-shapes fnctor structs | **#3927 (new)** |

## New issues (ids via `claim-issue.mjs --allocate`)

**#3926 — `__extern_get` generic property lookup.** Four independent profiles put it at 4.5–9.7% self time, the largest non-parser function in every one, and it is **unowned**: #3673 (which carried it as a slice) is `done`, #3669 is `done`, and #3671 is scoped to slot *monomorphism* — a correctness question, not lookup cost. Notes that #3899 already removed an *allocation* from inside it (the boolean-arm carriers) without touching the lookup, and that #3780 round 3 deliberately routes *more* call sites into it, which raises the value of making the body cheap. Scope explicitly refuses to assume the field ladder is the problem — the round-9b per-key cache was already built for that — so the first tasks are intra-function attribution and the cache hit rate.

**#3927 — union-of-all-shapes fnctor structs.** After #3899 packed the presence flags, acorn's `Node` is still 292 B carrying 62 `externref` slots for an object with 3–6 live properties, because every ESTree node kind is the same `new Node(...)`. Filed hard/XL and sequenced explicitly *behind* #3921 and #3686/#3685: the 9.5 MB it targets is retained, but the 34 MB #3921 would attribute is transient and larger, and splitting shapes moves the representation those two derive admission against. Also folds in the latent `objectIrTypeFromTsType` ↔ `tsTypeToFieldIr` seen-set, which goes live exactly when splitting makes self-referential shapes reachable.

## Updates

#3684, #3685 and #3686 each gain a **cross-box caveat**. Their shares come from Node 24 / arm64 macOS profiles; a Node 22 Linux container profile puts GC at **24–37%** against their **1.5%** and **4.3%**, corroborated profiler-free by `--trace-gc` (22.5 ms of a ~120 ms parse). Because the non-GC buckets are shares of a denominator that moves with it, this changes the whole ranking rather than one row — and it cuts **against** the allocation work, which is why it is recorded on the issues it favours rather than only where it is convenient.

#3921 gains the ranked table above and the argument for why it goes first: not because it is biggest — #3686/#3685 may well be — but because it is the only one whose size is currently unknown.

## Note on the branch

#3905 entered the merge queue between two pushes, so this commit was stranded locally until it merged. Branch restarted from the new `main` and the single commit carried forward. Opened non-draft per the instruction on #3905.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_