### PR TITLE
fix(benchmarks): let the artifact validator accept failed-strategy rows (unblocks #3916)

### DIFF
--- a/scripts/benchmark-lifecycle.mjs
+++ b/scripts/benchmark-lifecycle.mjs
@@ -376,14 +376,42 @@ function validateWasmtimeModuleSizeRows(rows) {
   }
 }
 
-function validateInternalSuite(rows) {
+export function validateInternalSuite(rows) {
   const strategies = new Map();
   validateUniqueRows(
     rows,
     "benchmarks/results/latest.json",
     (row) => (typeof row.name === "string" && typeof row.strategy === "string" ? `${row.name}:${row.strategy}` : null),
     (row, label) => {
-      finitePositive(row.medianMs, `${label}.medianMs`);
+      // (#3904 prerequisite) A benchmark strategy that ERRORED is recorded as a
+      // placeholder row — all-zero timings plus `status: "failed"` and an
+      // `error` message — instead of being dropped from the results entirely.
+      // Such a row is legal but carries no timings, so it is exempt from the
+      // positive-median check while still being required to explain itself.
+      //
+      //   absent row  = strategy not applicable (deliberately skipped)
+      //   failed row  = strategy is BROKEN
+      //
+      // Only the `js` reference must always produce a real measurement; a
+      // failed JS row means the comparison itself is meaningless.
+      //
+      // This validator change MUST land on `main` BEFORE the harness starts
+      // emitting such rows. `benchmark-refresh.yml` deliberately validates the
+      // candidate snapshot with the BASELINE's copy of this script on
+      // `pull_request` (see the `lifecycle=` selection in that workflow), so a
+      // PR cannot weaken its own gate. The consequence is that an artifact
+      // FORMAT change cannot go green in the same PR that teaches the validator
+      // about it — hence this split.
+      if (row.status === "failed") {
+        if (row.strategy === "js") {
+          throw new Error(`${label} records a failed JS reference row; the JS baseline must always measure`);
+        }
+        if (typeof row.error !== "string" || row.error.length === 0) {
+          throw new Error(`${label}.error must be a non-empty message on a failed row`);
+        }
+      } else {
+        finitePositive(row.medianMs, `${label}.medianMs`);
+      }
       if (!strategies.has(row.name)) strategies.set(row.name, new Set());
       strategies.get(row.name).add(row.strategy);
     },

--- a/tests/benchmark-lifecycle.test.ts
+++ b/tests/benchmark-lifecycle.test.ts
@@ -18,6 +18,7 @@ import {
   compareSnapshots,
   packageSnapshot,
   runCli,
+  validateInternalSuite,
   validateSnapshot,
 } from "../scripts/benchmark-lifecycle.mjs";
 
@@ -543,5 +544,56 @@ describe("benchmark artifact lifecycle", () => {
     expect(promotion).toContain("- name: Checkout trusted measured main revision");
     expect(promotion).toContain("ref: ${{ needs.measure-and-gate.outputs.source_sha }}");
     expect(promotion).not.toContain("ref: main");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3904 prerequisite — failed-strategy rows are legal in latest.json
+// ---------------------------------------------------------------------------
+//
+// `benchmark-refresh.yml` validates a PR's candidate snapshot with the
+// BASELINE's copy of `benchmark-lifecycle.mjs`, so a PR cannot weaken its own
+// gate. That means an artifact FORMAT change cannot go green in the same PR
+// that teaches the validator about it — the validator has to land on `main`
+// first. These tests pin the tolerant behaviour so the harness change can
+// follow safely.
+
+describe("validateInternalSuite — failed strategy rows (#3904 prerequisite)", () => {
+  const ok = [
+    { name: "string/split", strategy: "js", medianMs: 0.25 },
+    { name: "string/split", strategy: "gc-native", medianMs: 0.87 },
+  ];
+
+  it("accepts a well-formed suite with no failed rows", () => {
+    expect(() => validateInternalSuite(ok)).not.toThrow();
+  });
+
+  it("accepts a failed row carrying zero timings and an error message", () => {
+    const rows = [
+      ...ok,
+      {
+        name: "string/split",
+        strategy: "linear-memory",
+        medianMs: 0,
+        status: "failed",
+        error: "memory access out of bounds",
+      },
+    ];
+    expect(() => validateInternalSuite(rows)).not.toThrow();
+  });
+
+  it("still rejects a zero median on a row that does NOT declare failure", () => {
+    const rows = [...ok, { name: "string/split", strategy: "linear-memory", medianMs: 0 }];
+    expect(() => validateInternalSuite(rows)).toThrow(/medianMs must be a positive number/);
+  });
+
+  it("requires a failed row to explain itself", () => {
+    const rows = [...ok, { name: "string/split", strategy: "linear-memory", medianMs: 0, status: "failed" }];
+    expect(() => validateInternalSuite(rows)).toThrow(/error must be a non-empty message/);
+  });
+
+  it("refuses a failed JS reference row — the baseline must always measure", () => {
+    const rows = [{ name: "string/split", strategy: "js", medianMs: 0, status: "failed", error: "boom" }];
+    expect(() => validateInternalSuite(rows)).toThrow(/JS baseline must always measure/);
   });
 });


### PR DESCRIPTION
## Description

Prerequisite split out of PR #3916 (issue #3904), which is currently **blocked** on this.

### Why this has to be a separate PR

`benchmark-refresh.yml` deliberately validates a PR's **candidate** snapshot using the **baseline's** copy of `benchmark-lifecycle.mjs` on `pull_request` — see the `lifecycle=` selection at `:295-298`. That is sound: a PR cannot weaken its own gate.

The consequence is a bootstrap problem. An artifact **format** change can never go green in the same PR that teaches the validator about it. #3904 makes the harness record a failed benchmark strategy as a placeholder row (all-zero timings + `status: "failed"` + `error`) instead of dropping it, and main's validator rejects exactly that:

```
benchmarks/results/latest.json[3].medianMs must be a positive number
Exit code 2 = usage or invalid artifact error
```

### Diagnosis

Reproduced locally rather than inferred. Regenerating the strings suite on #3904's branch emits **10** such rows, every one correctly carrying `status: "failed"` and a real error string:

```
BAD  3  string/concat-short  linear-memory  medianMs=0  status=failed  error=memory access out of bounds
BAD  7  string/concat-long   linear-memory  medianMs=0  status=failed  error=Compilation failed (fast=true, target=linear)
...
```

Then, on the same file: **#3904's own validator passes; main's does not.** So the artifact is well-formed and the old validator simply predates the format. Ruled out along the way — the exemption *is* present and correct on #3904's branch, the committed `latest.json` is clean, and packaging does not strip fields.

### What this does

Exempts `status: "failed"` rows from the positive-median check while still requiring them to explain themselves, and exports the function so it is directly testable.

```
absent row = strategy not applicable (deliberately skipped)
failed row = strategy is BROKEN
```

A failed `js` row is still **rejected outright** — if the reference lane did not measure, the comparison is meaningless.

### Safe to land ahead of #3904

This only makes the validator *tolerant* of a shape that nothing currently emits. On `main` today no row carries `status`, so every row still takes the existing `finitePositive` path and behaviour is unchanged.

### Why it matters beyond unblocking one PR

The swallowing this enables us to stop is not cosmetic. Because failed lanes were dropped rather than recorded, a **26-benchmark gap in the linear backend was structurally invisible** — nobody could distinguish "not applicable" from "crashed". #3908's inventory, once the recording existed, found 4 deliberate skips and **22 real failures** (16 unimplemented builtins, 5 memory traps, 1 validation bug).

### Verification

`tests/benchmark-lifecycle.test.ts` — **25/25 green**, including 5 new tests pinning all four branches: accepts a failed row, still rejects a zero median on a row without `status`, requires a non-empty `error`, and refuses a failed `js` row.

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01D29cj9ve5n7eQqnz4tUXk6)_