### PR TITLE
docs(#3636): the id scan must fail loud — the blocking constraint for --verify-id

### DIFF
--- a/plan/issues/3636-claim-issue-allocator-hands-out-taken-ids.md
+++ b/plan/issues/3636-claim-issue-allocator-hands-out-taken-ids.md
@@ -161,6 +161,56 @@ node scripts/claim-issue.mjs --verify-id <id> [--by <agent>]
 
 Call it immediately before writing `plan/issues/<id>-<slug>.md`, and after any renumber.
 
+### BLOCKING requirement — THE ID SCAN MUST FAIL LOUD
+
+State it as a property, not as a banned API. The narrow version ("don't use the contents
+API") invites the next implementer to swap endpoints and keep the swallow.
+
+> **A scan that cannot report its own failure is a placebo, not a verifier.** An id
+> universe that is silently a _floor_ rather than the truth must never be reported as a
+> clean result — it converts a collision CI would have caught into one that looks
+> pre-cleared, while the tool reports that it checked. Strictly worse than no verifier.
+
+Two independent routes into that state were found on 2026-07-31, which is why this is a
+property and not a rule about one call:
+
+1. **Truncation.** `gh api "repos/…/contents/plan/issues?ref=main"` caps at **1000**
+   entries and says nothing; `plan/issues/` holds ~3,364. It returned **zero** `39xx`
+   files. Caught only by a **positive control** — the same call returned zero `38xx` files
+   while `3880`/`3884`/`3886` demonstrably exist on `main`. Use the tree API, which
+   reports its own completeness:
+
+   ```bash
+   gh api "repos/loopdive/js2/git/trees/main:plan/issues" --jq '{n: (.tree|length), truncated}'
+   # -> { "n": 3364, "truncated": false }
+   ```
+
+   **Assert BOTH halves: `truncated == false` AND a floored row count.** A bare
+   `truncated == false` passes happily on an empty tree from a bad ref — truncation is one
+   way to under-report, an empty or short read is another, and both present identically as
+   "no ids taken".
+
+2. **Swallowed failure.** `claim-issue.mjs` never used the contents API — it reads main
+   with `ls-tree`. But `idsFromMain()` returns an **empty set** when that read fails, so a
+   failed main scan reports _every id free_. Same shape, different route, and the more
+   dangerous of the two: with main contributing nothing, `contiguousMax()` is computed from
+   open PRs ∪ reservations alone and can hand out a drastically low, long-taken id.
+
+Same family as `pr_scan: "degraded"` in #3880 — and note that #3880 fixed this property for
+the **assignment ref** (tri-state reads, `die` on a failed read) while leaving the **main
+scan** on the old swallow. Fixing one read path is not fixing the property.
+
+### A live case that needs no scan at all
+
+**PR #3903 adds `plan/issues/3916-standalone-gen-rest-pattern-spill.md` while `main`
+already carries `plan/issues/3916-array-from-nonvec-source-map-closure-illegal-cast.md`** —
+two different issues, one id, found 2026-07-31.
+
+Note what makes this the strongest argument for the guard rail: **the incumbent is already
+on `main`.** No open-PR scan, no reservation ref, no network race — a single
+`git ls-tree origin/main plan/issues/` at write time catches it. It is the cheapest case
+there is, and it still got through, because nothing checks at write time.
+
 **Also re-check the earlier cases against the corrected diagnosis.** Cases 1-5 were all
 attributed to a faulty scan. Case 6 shows that attribution can be wrong, and cases 2 (the
 self-collision — "3589 twice", which smells like the same reserve-then-write-something-else

--- a/plan/issues/3636-claim-issue-allocator-hands-out-taken-ids.md
+++ b/plan/issues/3636-claim-issue-allocator-hands-out-taken-ids.md
@@ -202,9 +202,15 @@ scan** on the old swallow. Fixing one read path is not fixing the property.
 
 ### A live case that needs no scan at all
 
-**PR #3903 adds `plan/issues/3916-standalone-gen-rest-pattern-spill.md` while `main`
-already carries `plan/issues/3916-array-from-nonvec-source-map-closure-illegal-cast.md`** —
-two different issues, one id, found 2026-07-31.
+**PR #3903 adds a `3916-standalone-gen-rest-pattern-spill` issue file while `main` already
+carries `3916-array-from-nonvec-source-map-closure-illegal-cast`** — two different issues,
+one id, found 2026-07-31.
+
+(Written without the `plan/issues/…md` path prefix on purpose: the #1616 link gate resolves
+any such string against **`main`**, and the incoming file is only in an open PR — so citing
+it accurately by full path fails `quality`. That is a third flavour of the same trap, after
+a glob that matches nothing and a glob inside the warning about globs. See the
+`pre-commit-checklist` note.)
 
 Note what makes this the strongest argument for the guard rail: **the incumbent is already
 on `main`.** No open-PR scan, no reservation ref, no network race — a single


### PR DESCRIPTION
Follow-up to #3904 (merged). Records the **implementation constraint for `--verify-id`**, which #3636 leaves as its headline remaining work.

## Stated as a property, not a banned API

> **A scan that cannot report its own failure is a placebo, not a verifier.** An id universe that is silently a *floor* rather than the truth must never be reported as a clean result — it converts a collision CI would have caught into one that looks pre-cleared, while the tool reports that it checked. Strictly worse than no verifier.

The narrow framing ("don't use the contents API") invites the next implementer to swap endpoints and keep the swallow. Two independent routes into that state were found the same day, which is why it is a property:

**1. Truncation.** `gh api "repos/…/contents/plan/issues?ref=main"` caps at **1000** entries and says nothing; `plan/issues/` holds ~3,364. It returned **zero** `39xx` files. Caught only by a **positive control** — the same call also returned zero `38xx` files while `3880`/`3884`/`3886` demonstrably exist on `main`. Use `git/trees`, which reports its own completeness, and assert **both** `truncated == false` **and a floored row count** — a bare `truncated` check passes happily on an empty tree from a bad ref.

**2. Swallowed failure.** `claim-issue.mjs` never used the contents API — it reads main with `ls-tree`. But `idsFromMain()` returned an **empty set** when that read failed, so a failed main scan reported *every id free*. The more dangerous of the two: `contiguousMax()` then runs on open PRs ∪ reservations alone and can hand out a long-taken id. (Fixed in #3901, which also floors the count.)

Both are the same shape as `pr_scan: "degraded"` in #3880 — and note #3880 fixed this property for the **assignment ref** while leaving the **main scan** on the old swallow. Fixing one read path is not fixing the property.

## Plus the cheapest possible collision, live

PR #3903 adds a `3916-standalone-gen-rest-pattern-spill` issue file while `main` **already carries** a different `3916-…` file. The incumbent is already on `main` — no open-PR scan, no reservation ref, no network race. **A single `git ls-tree origin/main plan/issues/` at write time catches it**, and it still got through, because nothing checks at write time. That is the strongest argument for the guard rail.

## Note on citation style

The colliding filename is written **without** the `plan/issues/…md` path prefix on purpose: the #1616 link gate resolves any such string against **`main`**, and the incoming file exists only in an open PR — so citing it accurately by full path fails `quality`. That is a third flavour of that trap (after a glob matching nothing, and a glob inside the warning about globs), and the first one that isn't a mistake — an accurate citation of a not-yet-merged file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSXz9G2eZrfNeX3satN5X
