### PR TITLE
fix(#3880): restore the two commits #3901 merged without

### DIFF
--- a/plan/issues/3880-claim-issue-ref-lock-wedge.md
+++ b/plan/issues/3880-claim-issue-ref-lock-wedge.md
@@ -69,9 +69,9 @@ all reported as failures.**
 
 > **CORRECTION, measured later the same day.** This section originally said
 > "zero effect — `2916.json` still read `status: in-progress` afterwards". That
-> is **false**. The record has read `status: "released"`, `released_at:
-2026-07-31T08:55:03Z` ever since: **one of the three "failed" attempts had in
-> fact written it.** What made it _look_ unreleased was the dispatch gate, which
+> is **false**. The record has read `status: "released"` with a `released_at` of
+> 08:55:03Z ever since: **one of the three "failed" attempts had in fact written
+> it.** What made it _look_ unreleased was the dispatch gate, which
 > tested `assignee` alone and so reported a `released` record as CLAIMED (see the
 > `isHeld` section). The original sentence is left visible rather than deleted
 > because the mistake is the point: an agent inferred "no effect" from three
@@ -543,6 +543,35 @@ clobber the invoking repo's real index, and an inherited `GIT_DIR` would have
 aimed cache-repo commands at the wrong repository. All git calls in both the
 script and the tests now run under a sanitised environment, with `GIT_INDEX_FILE`
 re-added only where it is intended.
+
+## The same failure, arriving through version control — and the session's thesis
+
+Late in this issue's own fix work, the `idsFromMain` fix (see "Fix" item 11) went
+missing from the branch. Not to a conflict — to a **lineage split**. The branch's
+remote head was advanced by `auto-refresh-prs`; another agent, believing the
+author absent after ~50 minutes of a quiet head, built on that refreshed head,
+while my commit sat on the pre-refresh base. Neither lineage contained the other.
+No conflict, no error, a clean-looking tree, and a PR that would have merged
+without the fix.
+
+> **My push failing is the only reason I noticed. Had it succeeded, I'd have
+> reported the fix landed and it would simply not have been there.**
+
+That is the same shape as every other failure catalogued here, arriving through
+git rather than through a tool's output: a **correct-looking report about work
+that isn't there**. The remedies are the same two that the rest of this issue
+argues for — verify by reading the record at the tip (`git show <pushed-sha>:file`),
+not the exit code; and treat "no error" as no evidence.
+
+Two secondary lessons from the same incident:
+
+- **A quiet branch is not an absent author.** The takeover condition was "wait
+  ten minutes, re-check the head, take it if unchanged" — but the head was
+  unchanged precisely _because_ the author's pushes were timing out on the very
+  latency #3880 is about. The failure mode fed the misdiagnosis.
+- **Under contention, preserve before you argue.** Pushing the orphaned commit to
+  a separate `rescue-*` branch made it recoverable by anyone with zero clobber
+  risk, and cost nothing, before any question of ownership was settled.
 
 ## Explicitly NOT fixed here
 

--- a/scripts/claim-issue.mjs
+++ b/scripts/claim-issue.mjs
@@ -656,13 +656,43 @@ function contiguousMax(idSet) {
   return max;
 }
 
+// (#3880/#3636) A FAILED main scan must never read as an EMPTY one.
+//
+// This returned an empty Set when `ls-tree` failed, which is the most dangerous
+// silent-empty in the whole allocator: with main contributing nothing,
+// contiguousMax() is computed from open PRs ∪ reservations alone and hands out a
+// drastically low, long-taken id — and nothing in the output says the scan
+// failed. It is the same defect as the tri-state read fix above, on the other
+// read path; fixing one and not the other is not fixing the property.
+//
+// Note the asymmetry that makes `die` correct rather than cautious: an
+// unreadable main cannot be distinguished from a main with no issues, and
+// guessing "no issues" is precisely the guess that collides.
 function idsFromMain() {
   const out = new Set();
   const ls = git(["ls-tree", "-r", "--name-only", MAIN_REF, "plan/issues/"]);
-  if (!ls.ok) return out;
+  if (!ls.ok) {
+    die(
+      6,
+      `cannot READ ${MAIN_REF} to scan existing issue ids: ${why(ls)}\n` +
+        `Refusing to allocate: an unreadable main is NOT an empty one, and treating it as empty hands out an id ` +
+        `that has been taken for thousands of commits. Fetch ${MAIN_REMOTE} and re-run.`,
+    );
+  }
   for (const f of ls.out.split("\n")) {
     const m = f.match(ISSUE_ID_RE);
     if (m) out.add(Number(m[1]));
+  }
+  // A successful read that finds NOTHING is also suspect — plan/issues/ has
+  // thousands of files. Floor it rather than trusting `truncated`-style
+  // metadata alone: an empty result from a valid-but-wrong ref looks identical
+  // to a healthy read of an empty tree.
+  if (out.size === 0) {
+    die(
+      6,
+      `scanned ${MAIN_REF} for issue ids and found NONE — plan/issues/ is never empty.\n` +
+        "Refusing to allocate against an id universe that is almost certainly a bad ref rather than the truth.",
+    );
   }
   return out;
 }

--- a/tests/issue-3880.test.ts
+++ b/tests/issue-3880.test.ts
@@ -292,6 +292,18 @@ describe("#3880 claim-issue.mjs — an unscanned id is never handed out as clean
     rmSync(fx.root, { recursive: true, force: true });
   });
 
+  it("refuses to allocate when the MAIN id scan fails, rather than treating it as empty", () => {
+    // The most dangerous silent-empty in the allocator: with main contributing
+    // nothing, max+1 is computed from open PRs ∪ reservations alone and hands
+    // out a long-taken id. A failed read is not an empty one.
+    const r = run(fx, ["--allocate", "--no-pr-scan", "--allow-unscanned"], { CLAIM_REMOTE: "no-such-remote" });
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/cannot READ .* to scan existing issue ids|found NONE/);
+    expect(lastLine(r.stderr)).toMatch(/^claim-issue: FAILED —/);
+    expect(r.stdout.trim()).toBe("");
+    expect(listRecords(fx)).toEqual([]); // nothing burned
+  });
+
   it("refuses --no-pr-scan before reserving, so no id is burned", () => {
     const r = run(fx, ["--allocate", "--no-pr-scan"]);
     expect(r.code).toBe(2);


### PR DESCRIPTION
Restores two commits from #3901 that **merged without them**.

## What happened

#3901 merged at 17:28:51Z as `882481274ddc`. Its parents:

```
parents: [ f2746c57…(main), 40081c79… ]
```

`40081c79` is the branch head from **before** my last two commits. The merge queue merged the SHA it had enqueued, and my later pushes were silently left out — while the PR reported `MERGED` with `headRefOid: b4bb5a24…`, i.e. the branch tip, which is a *different fact* from the merged content.

Verified with a positive control so this isn't a bad query:

| ref | floor guard `out.size === 0` |
|---|---|
| PR head `b4bb5a24…` | **1** (present — proves the query works) |
| merge commit `882481274ddc…` | **0** |
| `main` | **0** |

Everything else from #3901 **is** on `main` (the rewrite, the 22 tests, `claim-record.mjs`, the dispatch-gate fix) — those were in `40081c79`'s ancestry. Only these two commits were lost.

## What this restores

**`836e29a2` — `idsFromMain()` must not read a failed scan as an empty one.**

It returned an **empty `Set`** when its `ls-tree` failed, so a failed main scan reported **every id free**. With main contributing nothing, `contiguousMax()` runs on open PRs ∪ reservations alone and hands out a drastically low, long-taken id — silently. That is the same defect #3901 fixes for the assignment ref (tri-state reads, `die` on a failed read), left standing on the *other* read path. Fixing one read path is not fixing the property.

Now dies (exit 6) on a failed read **and** floors the result: a successful read finding zero ids is refused too, since `plan/issues/` is never empty and an empty result from a valid-but-wrong ref is indistinguishable from a healthy one.

> **Note for anyone grepping to check whether this is already fixed:** the old `gitTry(["ls-tree", …])` call *is* gone from `main` — #3901 rewrote `git()` to return a **result object** (`run()`-based). But the **swallow remains**, as `if (!ls.ok) return out;`. A grep for the old call name returns nothing and reads as "fixed". Read the function body.

**To be precise about what is and isn't wrong here**, since it changes how the fix should be reviewed: `git()` genuinely returns `{ok, out, err, …}` on `main`, so `ls.ok` is a real field and the code is type-correct. (Worth confirming rather than assuming — if `git()` still returned a *string*, `ls.ok` would be `undefined`, `!undefined` would be `true`, and `idsFromMain` would return empty **unconditionally**: every id free on every call. It does not.) **The defect is purely the failure policy — the failure branch returns empty instead of dying.**

That also means this is not a novel pattern. The same file already does exactly this, ten lines up:

```js
function cgitOrDie(args, what, opts = {}) {
  const r = cgit(args, opts);
  if (!r.ok) die(6, `${what} failed: ${why(r)}`);
  return r.out;
}
```

`idsFromMain` simply never adopted it.

**`dd141e38` — the lineage-loss write-up**, including the verbatim line. Currently nowhere, and it is the durable half.

## Tests

22 tests in `tests/issue-3880.test.ts`, including `refuses to allocate when the MAIN id scan fails, rather than treating it as empty`.

**Kill-switch verified, and the first attempt was misleading:** removing *one* guard left the test green because the other caught the same case. Both had to be removed to see red. A kill-switch that leaves a redundant guard standing proves nothing — it is insidious precisely because the test then passes for a plausible reason.

## Verification plan

I will confirm this from `main`'s merged content after it lands, not from the merge status — that check is the only reason this PR exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSXz9G2eZrfNeX3satN5X

