### PR TITLE
docs(#3921): Heap2Local cannot touch the $AnyValue boxes — measured, zero sites

### DIFF
--- a/plan/issues/3921-wasmgc-allocation-census.md
+++ b/plan/issues/3921-wasmgc-allocation-census.md
@@ -178,6 +178,38 @@ correctness step for this issue, and until it is closed the byte column must
 not be quoted as measurement. The *counts* are exact — each is a counter
 incremented at the allocation site.
 
+## Follow-up measured 2026-07-31 — scalar replacement is NOT available
+
+The cheapest possible fix for the 310,485 `$AnyValue` boxes would have been the
+optimizer: most boxes are created, crossed and unboxed inside one expression,
+which is exactly what Binaryen's `Heap2Local` promotes to locals. Tested before
+proposing any codegen work, on the shipped 1,673,257 B standalone acorn binary:
+
+| config | ArrayNew | StructNew |
+| --- | ---: | ---: |
+| shipped `-O3` | 731 | 3,759 |
+| `+ --heap2local` | 731 | 3,759 |
+| `+ --closed-world --heap2local` | 731 | 3,759 |
+| `+ --closed-world --gufa --heap2local` | 731 | 3,759 |
+
+**Zero allocation sites promoted, under every configuration.** `Heap2Local`
+works by replacing a `struct.new` whose result provably does not escape; an
+unchanged site count means nothing was provable. So either `-O3` already
+extracted everything available, or — more likely given `$AnyValue`'s shape — the
+boxes genuinely do escape into generic calls that the optimizer cannot see
+through.
+
+**Consequence: the `$AnyValue` fix must be "do not create the box" in codegen,
+not "let the optimizer remove it".** That moves it out of tooling and into the
+same representation family as #3685/#3927. It also means the remaining cheap
+options are interning (constants only) and finding the producer that mints them
+— it is worth reading the top producer's WAT to check whether its consumers
+ever read more than one field of the 5-field union before assuming they need it.
+
+Caveat: a static site count is not a dynamic allocation count. What this
+measurement establishes is that no site was promoted, which is the precondition
+for any dynamic win — not the size of a win that did not happen.
+
 ## Scope
 
 - [x] Emitter-side census pass, env-gated and off by default (PR #3920).


### PR DESCRIPTION
Follow-up to #3928 (merged). Docs only — a negative result, filed so the next window doesn't re-test optimizer flags.

The census put `$AnyValue` boxing at **48% of allocations** (310,485 per parse). The cheapest conceivable fix was the optimizer rather than codegen: most boxes are created, crossed and unboxed inside one expression, which is exactly what Binaryen's `Heap2Local` promotes to locals. Tested that **before** proposing any codegen work.

On the shipped 1,673,257 B standalone acorn binary:

| config | ArrayNew | StructNew |
| --- | ---: | ---: |
| shipped `-O3` | 731 | 3,759 |
| `+ --heap2local` | 731 | 3,759 |
| `+ --closed-world --heap2local` | 731 | 3,759 |
| `+ --closed-world --gufa --heap2local` | 731 | 3,759 |

**Zero sites promoted, under every configuration.**

## Consequence

The `$AnyValue` fix must be **"do not create the box" in codegen**, not "let the optimizer remove it". That moves it out of tooling and into the same representation family as #3685/#3927, and leaves two cheap options: interning (constants only), and reading the top producer's WAT to check whether its consumers ever read more than one field of the 5-field union before assuming they need it.

## Limit on this result

A static site count is not a dynamic allocation count. What this establishes is that **no site was promoted** — the precondition for any dynamic win — not the size of a win that did not happen.

This joins the two dead ends already recorded on #3921 (V8's sampling heap profiler not seeing `struct.new`; `--trace-gc-object-stats` unavailable). Optimizer-flag experiments on this module have now been tried three times by two agents; the pattern is that acorn's dynamic shapes defeat whole-program proof, which is the same conclusion #3686 reached for cast removal.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_