### PR TITLE
fix(npm-compat): sync canonical report with public mirror

### DIFF
--- a/benchmarks/results/npm-compat.json
+++ b/benchmarks/results/npm-compat.json
@@ -1831,44 +1831,6 @@
       "perf": null,
       "knownBugs": [],
       "weeklyDownloads": 6829692
-    },
-    {
-      "name": "crypto",
-      "version": "1.0.1",
-      "issue": null,
-      "entryFile": "index.js",
-      "shape": "cjs-project",
-      "compile": {
-        "success": false,
-        "durationMs": 0,
-        "timedOut": false,
-        "timeoutMs": 30000,
-        "errorCount": 1,
-        "binaryBytes": 0,
-        "categories": {
-          "compiler-diagnostic": {
-            "count": 1,
-            "sample": "published tarball does not contain its declared entry package/index.js"
-          }
-        },
-        "errors": [
-          {
-            "message": "published tarball does not contain its declared entry package/index.js"
-          }
-        ]
-      },
-      "validation": {
-        "validates": false,
-        "firstError": "compile probe failed: published tarball does not contain its declared entry package/index.js"
-      },
-      "tests": {
-        "kind": "upstream-suite",
-        "status": "not-integrated",
-        "reason": "not shipped in npm tarball; adapter pending"
-      },
-      "perf": null,
-      "knownBugs": [],
-      "weeklyDownloads": 1479290
     }
   ]
 }

--- a/tests/dogfood/npm-compat-catalog.test.ts
+++ b/tests/dogfood/npm-compat-catalog.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error — .mjs dogfood helpers have no declaration files
@@ -24,6 +24,11 @@ const EXPECTED_NAMES = [
   "tailwindcss",
 ];
 
+function reportPackageNames(path: URL): string[] {
+  const report = JSON.parse(readFileSync(path, "utf8")) as { packages: Array<{ name: string }> };
+  return report.packages.map((entry) => entry.name);
+}
+
 describe("npm compatibility package catalog", () => {
   it("pins and verifies every requested published package", () => {
     expect(NPM_COMPAT_CATALOG.map((entry: { name: string }) => entry.name)).toEqual(EXPECTED_NAMES);
@@ -34,6 +39,15 @@ describe("npm compatibility package catalog", () => {
       expect(setup.pin.shasum).toMatch(/^[0-9a-f]{40}$/);
       expect(existsSync(setup.entryModulePath)).toBe(entry.expectedEntryMissing !== true);
     }
+  });
+
+  it("keeps the canonical report and public mirror in sync", () => {
+    const canonical = reportPackageNames(new URL("../../benchmarks/results/npm-compat.json", import.meta.url));
+    const publicMirror = reportPackageNames(
+      new URL("../../website/public/benchmarks/results/npm-compat.json", import.meta.url),
+    );
+
+    expect(canonical).toEqual(publicMirror);
   });
 
   const selectedPackage = process.env.DOGFOOD_NPM_CATALOG;


### PR DESCRIPTION
## Summary

Pages prefers `benchmarks/results/npm-compat.json` over the public mirror. The previous removal updated only the mirror, so every Pages build restored the stale crypto card from the canonical report.

Remove crypto from the canonical artifact and add a focused regression test requiring the canonical report and public mirror to contain the same package list.

## Validation

- `pnpm exec vitest run tests/dogfood/npm-compat-catalog.test.ts`
- `pnpm exec prettier --check benchmarks/results/npm-compat.json tests/dogfood/npm-compat-catalog.test.ts`
- JSON parity and crypto-absence check