### PR TITLE
fix(#3948): object-literal methods never registered optional-param metadata — $__argc stayed at the -1 sentinel, so every parameter default was skipped

### DIFF
--- a/plan/issues/3948-objlit-method-optional-param-metadata.md
+++ b/plan/issues/3948-objlit-method-optional-param-metadata.md
@@ -1,0 +1,241 @@
+---
+id: 3948
+title: "Standalone: object-literal methods never register optional-param metadata, so `__argc` stays at the -1 sentinel and every parameter default is skipped — the #2581 generator bail was a workaround for it (98 leak rows)"
+status: done
+completed: 2026-08-01
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: high
+horizon: m
+complexity: M
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: generators, default-parameters, object-literals
+es_edition: multi
+goal: standalone-mode
+umbrella: 3178
+assignee: ttraenkler/dev-objlit-gen-dflt
+related: [3178, 2581, 3893, 3896, 3945, 3949, 2938, 1557]
+loc-budget-allow:
+  # (#3102) Both grants are for THIS change-set. `literals.ts` gains the
+  # optional-param registration block the class path has always had; the rest of
+  # the growth in both files is the recorded correction of #2581's stated
+  # justification, which is deliberately kept at the decision point — a wrong
+  # justification left standing at the gate is how the bail survived review once
+  # already. The full argument lives in this issue; the gate keeps the summary.
+  - src/codegen/literals.ts
+  - src/codegen/generators-native.ts
+func-budget-allow:
+  # (#3400) The registration has to sit inside the object-literal member loop,
+  # next to the `funcUsesArguments` registration it mirrors and after
+  # `methodParams` is built (it reads `methodParams[i + 1]` for the param's
+  # ValType). Hoisting it out would mean re-deriving that array at a second site
+  # — the exact divergence #2938 was caused by. +30 lines, ~20 of them the
+  # comment recording why the map was empty.
+  - src/codegen/literals.ts::compileObjectLiteralForStruct
+origin: "2026-08-01: #3893's SCOPE table left 102 `object/*` whole-param-default rows with no owner. Instrumenting the gate showed the object-literal bail is not a generator defect at all — object-literal methods are the one method form that never registers `funcOptionalParams`."
+---
+
+# #3948 — object-literal methods never register optional-param metadata
+
+## Root cause — instrumented, not inferred
+
+`maybeSetArgcForKnownCall` (`src/codegen/statements/nested-declarations.ts:2174`)
+opens with
+
+```ts
+if (!ctx.funcUsesArguments.has(funcName) && !ctx.funcOptionalParams.has(funcName)) return;
+```
+
+Class bodies populate that map at collection time
+(`class-bodies.ts:1152` → `registerClassOptionalParams`), free functions do it in
+`declarations.ts:553`. **Object-literal methods never did** — `literals.ts` only
+ever registered `funcUsesArguments`. A probe printing the map at the decision
+point:
+
+| receiver                      | trace at the `o.m()` / `new C().m()` call site                                       |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| `const o = { *m(a = 5) {…} }` | `[argc] maybeSet name=__anon_0_m paramCount=1 usesArgs=false optional=false keys=[]` |
+| `class C { *m(a = 5) {…} }`   | `[argc] maybeSet name=C_m paramCount=1 usesArgs=false optional=true keys=[C_m]`      |
+
+So the object-literal call site returned early, never emitted its
+`global.set $__argc`, and the global kept its `-1` **"unknown host/module-init
+caller"** init value. The callee's prologue
+(`cacheParamDefaultArgc` + `emitParamDefaultArgMissingCheck`) evaluates
+`argc != -1 && argc <= argIndex`, which is **false** for `-1` — read as "no
+argument is missing" — so the default was never applied and the body used the
+raw incoming slot (`0` for f64).
+
+That is the whole defect. The generator bail was a workaround for it.
+
+## The controlled experiment
+
+Same tree, same commit (`d3854438366f` = `origin/main`), one token between arms,
+`target: "standalone"`, host-import names from `result.imports`:
+
+| arm                                   | source                        | result                                                                                                                          |
+| ------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| CONTROL — objlit gen, no params       | `{ *m() { yield 1 } }`        | host-free                                                                                                                       |
+| CONTROL2 — objlit gen, pattern        | `{ *m({x}) { yield x } }`     | host-free                                                                                                                       |
+| CONTROL3 — objlit gen, elem dflt      | `{ *m({x = 5}) { yield x } }` | host-free                                                                                                                       |
+| **SUBJECT — whole-param default**     | `{ *m({x} = {…}) {…} }`       | **leaks `__gen_create_buffer, __gen_push_f64, __create_generator, __gen_next, __gen_result_value_f64, __get_caught_exception`** |
+| **SUBJECT2 — identifier default**     | `{ *m(a = 1) {…} }`           | **same six imports**                                                                                                            |
+| CONTRAST — the identical CLASS method | `class { *m({x} = {…}) {…} }` | host-free                                                                                                                       |
+
+The class/object-literal asymmetry on a one-token-identical body is what ruled
+out both the #2571 name-kind exclusion and #3893's fn-expression fix, and pointed
+at a per-emit-site registration difference rather than anything in the generator
+machinery.
+
+## #2581's stated justification was wrong twice over — recorded, not deleted
+
+The lifted bail (`generators-native.ts`, `isNativeGeneratorCandidate`) read:
+
+> Object-literal methods are invoked through the closure trampoline
+> (`emitObjectMethodAsClosure`), which forwards args but does NOT set the
+> `__argc_default` global the param-default check reads … The eager-buffer host
+> path applies defaults correctly for the object-literal case, so route there.
+
+Both halves are false:
+
+1. **Not the trampoline.** A plain `o.m()` is a _direct_ call
+   (`call-receiver-method.ts:1544`) and **does** reach
+   `maybeSetArgcForKnownCall`. The trampoline is only for method _extraction_
+   (`const f = o.m`). What the direct call found was the empty map above.
+2. **The host path does not apply the default either.** Measured on the **default
+   (JS-host) target**, instantiated with `result.importObject`:
+   `{ *m(a = 5) }.m().next().value` → **0**, `imports=7`. So the bail bought no
+   correctness — only a `__gen_*` leak in standalone.
+
+## The wider defect this exposed → #3949
+
+Because the missing registration is not generator-specific, the same `-1`
+sentinel breaks **ordinary object-literal methods in the default target**:
+
+| source                                        |  JS | js2wasm host lane (pre-fix) | js2wasm standalone (pre-fix) |
+| --------------------------------------------- | --: | --------------------------: | ---------------------------: |
+| `{ m(a = 5) { return a } }.m()`               |   5 |                       **0** |                        **0** |
+| `{ m(a, b = 5) { return a+b } }.m(1)`         |   6 |                       **1** |                        **1** |
+| `{ m(a?) { return a===undefined?42:a } }.m()` |  42 |                       **0** |                        **0** |
+
+Filed as **#3949** so a host-lane default-parameter bug is not buried in a
+standalone-generator issue. This PR fixes rows 1 and 2 in both lanes as a
+consequence of the same one-place change; row 3 (`?`) is a value-representation
+gap and stays open there.
+
+## The fix — two guards, each independently load-bearing
+
+**(A) `src/codegen/literals.ts`** — register `ctx.funcOptionalParams` for
+object-literal methods, mirroring `registerClassOptionalParams` (constant vs
+expression default classification included). `methodParams` leads with the
+receiver `this`, so source parameter `i` takes its ValType from
+`methodParams[i + 1]` — the same `paramTypeOffset = 1` the class path uses for
+instance methods.
+
+**(B) `src/codegen/generators-native.ts`** — lift the object-literal
+`param.initializer` bail in `isNativeGeneratorCandidate`. `param.questionToken`
+**still bails**, measured rather than inherited: even with (A) in place,
+`{ *m(a?: number) { yield a === undefined ? 42 : a } }.m()` yields 0, because
+`a?: number` lowers to a bare `f64` with no `undefined` inhabitant, so the
+missing-arg branch has nothing to bind. Admitting it would trade a leak for a
+wrong value. The corrected reasoning is written into the gate itself, not just
+deleted.
+
+## Acceptance
+
+- [x] Object-literal generator methods with a parameter default emit **zero**
+      `env::` imports in the standalone lane (bare compile, `result.imports`).
+- [x] **Value** assertions, not just the import set — including a **read after a
+      suspension** (`yield a; yield a + 1` → 6), proving the defaulted binding
+      round-trips the generator state rather than only loading correctly.
+- [x] The default stays a **call-time** observable (§27.5 EvaluateGeneratorBody +
+      §10.2.11): after `o.m()` and before any `next()`, the initializer has run
+      exactly once and the body not at all.
+- [x] Sibling object literals sharing a method name keep **distinct** defaults
+      (the #2938/#1557 dedup class): `{*m(v=1)}` → 1, `{*m(v=2)}` → 2.
+- [x] Non-generator object-literal defaults correct in **both** lanes.
+- [x] Kill-switch **each guard independently** (see below).
+- [x] Host lane not silently perturbed — `prove-emit-identity` IDENTICAL.
+
+## Kill-switch — both halves, separately
+
+A test never seen failing is not a test, and a guard never seen to matter alone
+is not load-bearing.
+
+| reverted            | `tests/issue-3948.test.ts`                                                                                    | what it proves                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **(B) alone**       | **12 of 19 fail**, all with `WebAssembly.instantiate(): Import #0 "env": module is not an object or function` | the bail is what causes the leak                                                    |
+| **(A) alone**       | **10 of 19 fail** — and the two **import-set assertions still PASS**                                          | the modules are host-free, instantiate with `{}`, and silently return the inert `0` |
+| both restored (fix) | **19 of 19 pass**                                                                                             | —                                                                                   |
+
+**The (A)-alone row is the point.** A fix validated on the import set alone would
+have been green while returning the wrong number — exactly the failure mode
+#3178's "Validation (applies to every slice)" section warns about. Only the value
+assertions catch it. (Note the whole-param _pattern_ arms still pass under (A)-alone:
+those defaults are applied by the destructuring lane, not by argc — so (A) and (B)
+are load-bearing for genuinely different subsets, not redundant.)
+
+## Measured effect — construct-sampled, and read the denominators
+
+Population, re-measured on the **2026-08-01 00:51** standalone baseline
+(48,088 records, oracle_version 12): object-literal, non-async, whole/param-default
+generator rows carrying a host-import leak = **98**. (#3893's SCOPE table said 102
+against the 2026-07-31 promote; 98 is today's count on the same predicate.)
+
+- **All 98 are `compile_error` today.** They have never run. The prize is
+  **host-free instantiation, not a pass delta — do not quote 98 as a pass count.**
+- Shape split: 81 whole-param binding-pattern defaults · 9 identifier param
+  defaults · 6 pattern-with-init · 2 misc.
+
+Construct-sampled flip (`.tmp/cohort.mts`): each of the 98 real test262 files'
+**actual** `*method(<params>)` signature was extracted from the source and
+re-compiled as a minimal object-literal generator in the standalone lane; the
+measured quantity is the import set of a bare compile.
+
+| run                 | probes compiled | host-free | still leaking |
+| ------------------- | --------------: | --------: | ------------: |
+| **pre-fix control** |              97 |     **0** |            97 |
+| **post-fix**        |              97 |    **89** |         **8** |
+
+(1 of 98 had no extractable signature.) The pre-fix control run is what makes the
+post-fix number meaningful — an instrument that cannot return the other answer
+proves nothing.
+
+The **8 residual** are one family: `gen-meth-dflt-{ary,obj}-ptrn-*-init-fn-name-{arrow,fn,gen,class}.js`,
+where the _element_ default is a function/arrow/class/generator **expression**
+(`{ arrow = () => {} } = {}`). Those bail in the plan builder
+(`generators-native.ts`, the `el.initializer && isFunctionExpression | isArrowFunction | isClassExpression`
+check), a different mechanism — not attributed here, not claimed here.
+
+## Scoped-out residuals (probed, so they are stated rather than discovered later)
+
+- **`?`-optional params** keep the host path — value-rep gap, see (B) above and
+  #3949.
+- **Method extraction** `const f = o.m; f()` still does not set `__argc`: the
+  trampoline path has no call-site arity to record. Post-fix it is host-free but
+  throws a `WebAssembly.Exception` from the null-`this` guard; pre-fix it leaked.
+  Neither lane was correct before or after, so this is unchanged, not regressed.
+- **Sibling literals in the HOST lane** still cross-talk (`{*m(v=1)}` reads 2) —
+  the pre-existing #1557/#2938 struct-dedup class, wrong before (0) and wrong
+  after (2). The standalone lane is correct post-fix.
+
+## Test Results
+
+- `tests/issue-3948.test.ts` — 19/19 pass; both kill-switches verified red.
+- `tests/issue-2581-objlit-method-generators.test.ts` — the assertion that
+  encoded the old (wrong) bail is **corrected in place** with the measurement
+  that falsifies it, and a new assertion pins the surviving `?` bail. 13/13 pass.
+- Adjacent suites green: `issue-2571-native-method-generators`, `issue-3893`,
+  `generators`, `generator-method-destructuring` — 44/44 with #3948's file.
+- `node scripts/equivalence-gate.mjs` — exit 0, **no new regressions**
+  (32 failing / 1,611 passing against 36 baseline known-failures; the 4
+  now-passing baseline entries are unrelated pre-existing drift and were **not**
+  ratcheted here).
+- `npx tsx scripts/prove-emit-identity.mjs check` — **IDENTICAL, all 60
+  (file,target) emits.** Modules without an object-literal method carrying a
+  default emit byte-identical bytes in every lane.
+- `default-params` / `class-methods` / `arguments-object` / `anon-struct` /
+  `issue-1672` show 28 failures — **identical, test-for-test, on unmodified
+  `origin/main`** (A/B run). Pre-existing, not this PR.

--- a/plan/issues/3949-objlit-method-param-defaults-host-lane.md
+++ b/plan/issues/3949-objlit-method-param-defaults-host-lane.md
@@ -1,0 +1,99 @@
+---
+id: 3949
+title: "Host lane: object-literal method parameter defaults are silently ignored — `{ m(a = 5) }.m()` evaluates to 0 in the DEFAULT target, no generator involved"
+status: in-progress
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: high
+horizon: s
+complexity: S
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: default-parameters, object-literals, optional-parameters
+es_edition: es6
+goal: spec-completeness
+related: [3948, 2581, 1451, 1053]
+origin: "2026-08-01, found while root-causing #3948: the object-literal optional-param registration gap is not generator-specific and not standalone-specific. Filed separately so a host-lane default-parameter bug is not buried inside a standalone-generator issue, where nobody would look for it."
+---
+
+# #3949 — object-literal method parameter defaults ignored in the host lane
+
+## Problem
+
+An object-literal method with a parameter default silently ignores it. This is
+ordinary JavaScript, in the **default** (JS-host) target, with no generator, no
+destructuring and no standalone mode involved.
+
+Measured on `origin/main` @ `d3854438366f`, instantiated with
+`result.importObject`:
+
+| source                                              |  JS | host lane | standalone |
+| --------------------------------------------------- | --: | --------: | ---------: |
+| `{ m(a = 5) { return a } }.m()`                     |   5 |     **0** |      **0** |
+| `{ m(a, b = 5) { return a + b } }.m(1)`             |   6 |     **1** |      **1** |
+| `{ m(a?) { return a === undefined ? 42 : a } }.m()` |  42 |     **0** |      **0** |
+| `{ m(a = 5) { return a } }.m(7)`                    |   7 |         7 |          7 |
+
+The supplied-argument case is correct, so the wrongness is confined to the
+missing-argument branch — the default itself never fires.
+
+The **class** equivalent (`class C { m(a = 5) {…} }; new C().m()`) and the free
+function (`function f(a = 5) {…}; f()`) both return 5. Object literals are the
+outlier.
+
+## Root cause
+
+Shared with #3948, which carries the full instrumented trace.
+`maybeSetArgcForKnownCall` is gated on
+`ctx.funcUsesArguments.has(n) || ctx.funcOptionalParams.has(n)`. Class bodies and
+free functions populate `funcOptionalParams`; **object-literal methods never
+did**. So the `o.m()` call site emitted no `global.set $__argc`, the global kept
+its `-1` "unknown host/module-init caller" init value, and the callee's
+`emitParamDefaultArgMissingCheck` (`argc != -1 && argc <= argIndex`) read that as
+"no argument is missing".
+
+Instrumented at the decision point:
+
+```
+[argc] maybeSet name=__anon_0_m paramCount=1 usesArgs=false optional=false keys=[]
+[argc] maybeSet name=C_m        paramCount=1 usesArgs=false optional=true  keys=[C_m]
+```
+
+## Status — rows 1 and 2 fixed by #3948; row 3 (`?`) remains
+
+**#3948 lands the registration in `literals.ts`**, and because the gap is one
+place, that fixes the _default-initializer_ rows in **both** lanes as a side
+effect. `tests/issue-3948.test.ts` carries the host-lane assertions
+(`applies the default when the argument is omitted — host lane`, `applies a later
+param's default — host lane`).
+
+**What is still open here** is the `?`-optional row. With the registration in
+place, `{ m(a?: number) { return a === undefined ? 42 : a } }.m()` still returns
+0: `a?: number` lowers to a bare `f64`, which has no `undefined` inhabitant, so
+the missing-argument branch has nothing to bind. That is a
+value-representation gap, not a call-site-metadata one, and it is why #3948
+deliberately keeps `param.questionToken` bailing in the native-generator
+admission gate — admitting it there would trade a host-import leak for a wrong
+value.
+
+## Remaining acceptance
+
+- [ ] `{ m(a?: number) { return a === undefined ? 42 : a } }.m()` → 42 in both
+      lanes (needs an `undefined`-carrying representation for the optional param,
+      or an argc-driven branch that selects an `undefined` sentinel the body's
+      `=== undefined` comparison recognises).
+- [ ] Once that lands, revisit the `questionToken` bail in
+      `isNativeGeneratorCandidate` (`generators-native.ts`) — it is pinned by a
+      test in `tests/issue-2581-objlit-method-generators.test.ts` so lifting it
+      is a visible decision, not a silent drift.
+- [ ] Also still open, and orthogonal: **method extraction** (`const f = o.m`
+      then `f()`) sets no argc at all — the trampoline path has no call-site
+      arity to record. Wrong before and after #3948 in both lanes.
+
+## Notes
+
+- Do **not** confuse this with #1451 (done), which covered method parameter
+  _destructuring_ with non-trivial defaults. This is the plain identifier /
+  optional parameter, and its mechanism is the call-site `__argc` metadata.

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -2065,17 +2065,42 @@ export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: GeneratorD
       return false;
     }
   }
-  // (#2581) An OBJECT-LITERAL generator method with a DEFAULT or OPTIONAL param
-  // must bail to the host path. Object-literal methods are invoked through the
-  // closure trampoline (`emitObjectMethodAsClosure`), which forwards args but
-  // does NOT set the `__argc_default` global the param-default check reads — so
-  // the native factory would read the un-defaulted sentinel and yield the wrong
-  // value (`{ *m(d=5){yield d} }.m()` → 0 instead of 5). Class methods are called
-  // directly (argc set), so they keep defaults native. The eager-buffer host path
-  // applies defaults correctly for the object-literal case, so route there.
+  // (#2581 → #3948) The OBJECT-LITERAL generator method DEFAULT/OPTIONAL bail is
+  // LIFTED. #2581's diagnosis was right about the symptom and wrong about both
+  // the mechanism and the remedy, so the correction is recorded here rather than
+  // just deleted (see issue #3948 for the instrumented trace):
+  //
+  //   * The mechanism was NOT the `emitObjectMethodAsClosure` trampoline. A plain
+  //     `o.m()` is a direct call and does reach `maybeSetArgcForKnownCall`
+  //     (call-receiver-method.ts). What it found there was an EMPTY
+  //     `ctx.funcOptionalParams` — object-literal methods were the one method
+  //     form that never registered optional-param metadata (class bodies do it in
+  //     `registerClassOptionalParams`, free functions in declarations.ts). The
+  //     gate `!funcUsesArguments.has(n) && !funcOptionalParams.has(n)` therefore
+  //     returned early and `$__argc` kept its `-1` "unknown caller" sentinel.
+  //   * The remedy was NOT sound either: routing to the eager-buffer HOST path
+  //     does not apply the default correctly — measured on the host lane,
+  //     `{ *m(a = 5) }.m().next().value` is 0 there too. The bail bought no
+  //     correctness, only a `__gen_*` host-import leak in standalone (98 rows).
+  //
+  // #3948 fixes the real gap in literals.ts (register the optional params), which
+  // makes the argc-driven default fire for object-literal methods in BOTH lanes;
+  // this gate then has nothing left to protect against. Kill-switched both ways:
+  // restoring this bail turns the leak red again, and reverting the literals.ts
+  // registration alone leaves a host-free module that silently yields the inert 0.
+  //
+  // `questionToken` STILL bails, and that half was measured rather than inherited:
+  // with the argc registration in place, `{ *m(a?: number) { yield a === undefined
+  // ? 42 : a } }.m()` still yields 0, not 42 — an `a?: number` param lowers to a
+  // bare `f64` with no `undefined` inhabitant, so there is nothing for the missing
+  // -arg branch to bind. That is a value-representation gap (#3949's family), not
+  // an admission-gate one, and the same 0 comes out of a NON-generator
+  // `{ m(a?: number) }`. Admitting it here would trade a leak for a wrong value,
+  // so it keeps the host path until the rep gap is closed. #3893 made the same
+  // call for function expressions.
   if (ts.isMethodDeclaration(decl) && ts.isObjectLiteralExpression(decl.parent)) {
     for (const param of decl.parameters) {
-      if (param.initializer || param.questionToken) return false;
+      if (param.questionToken) return false;
     }
   }
   // (#2938) A generator METHOD whose emitted name is not unique within its

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -37,7 +37,7 @@ import { emitStandaloneIterableMaterialize } from "./iterator-native.js"; // (#3
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
-import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { CodegenContext, FunctionContext, OptionalParamInfo } from "./context/types.js";
 import { isForeignEvalNode } from "./expressions/eval-source.js";
 import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { resolveStructName } from "./expressions/misc.js";
@@ -53,6 +53,7 @@ import {
   destructureParamArray,
   destructureParamObject,
   ensureStructForType,
+  extractConstantDefault,
   getOrRegisterTupleType,
   getTupleElementTypes,
   isTupleType,
@@ -2918,6 +2919,36 @@ export function compileObjectLiteralForStruct(
       // beyond the formal param count.
       if (prop.body && bodyUsesArguments(prop.body)) {
         ctx.funcUsesArguments.add(fullName);
+      }
+
+      // (#3948) Register optional/defaulted params for this object-literal
+      // method. Class bodies have always done this (class-bodies.ts
+      // `registerClassOptionalParams`), free functions too (declarations.ts);
+      // object literals were the one method form that never did — and
+      // `maybeSetArgcForKnownCall` is gated on exactly this map, so every
+      // `o.m()` call site silently skipped its `global.set $__argc`. The
+      // callee's param-default prologue then read the `-1` "unknown caller"
+      // sentinel, concluded no argument was missing, and used the raw
+      // (zero/null) incoming slot: `{ m(a = 5) }.m()` evaluated to 0 in BOTH
+      // lanes. `methodParams` leads with the receiver `this`, so the ValType
+      // for source parameter `i` is at `methodParams[i + 1]` — the same
+      // `paramTypeOffset = 1` the class path uses for instance methods.
+      const objMethodOptionalParams: OptionalParamInfo[] = [];
+      for (let pi = 0; pi < prop.parameters.length; pi++) {
+        const param = prop.parameters[pi]!;
+        if (!param.questionToken && !param.initializer) continue;
+        const paramValType = methodParams[pi + 1];
+        if (!paramValType) continue;
+        const info: OptionalParamInfo = { index: pi, type: paramValType };
+        if (param.initializer) {
+          const cd = extractConstantDefault(param.initializer, paramValType, ctx);
+          if (cd) info.constantDefault = cd;
+          else info.hasExpressionDefault = true;
+        }
+        objMethodOptionalParams.push(info);
+      }
+      if (objMethodOptionalParams.length > 0) {
+        ctx.funcOptionalParams.set(fullName, objMethodOptionalParams);
       }
 
       const methodTypeIdx = addFuncType(ctx, methodParams, methodResults, `${fullName}_type`);

--- a/tests/issue-2581-objlit-method-generators.test.ts
+++ b/tests/issue-2581-objlit-method-generators.test.ts
@@ -142,20 +142,38 @@ export function test(): number {
     expect(await runNative(src)).toBe(56);
   });
 
-  it("default/optional-param object-literal generator method BAILS to host (closure-trampoline argc gap)", async () => {
-    // (#2581 eject fix) Object-literal methods are invoked through the closure
-    // trampoline, which does not set the `__argc_default` global the param-default
-    // check reads — so the native factory would yield the wrong value
-    // (`{ *m(d=5){yield d} }.m()` → 0 instead of 5). These bail to the host path
-    // (valid module, host imports) where defaults apply correctly. A class method
-    // generator with a default stays native (called directly, argc set).
+  it("DEFAULT-param object-literal generator method lowers NATIVELY (#3948 — was: bail to host)", async () => {
+    // (#3948) Pre-fix this asserted the eager-host bail, on a diagnosis that was
+    // wrong twice over. The mechanism was NOT the closure trampoline — a plain
+    // `o.m()` is a direct call and does reach `maybeSetArgcForKnownCall`; what it
+    // found there was an empty `ctx.funcOptionalParams`, because object-literal
+    // methods were the one method form that never registered optional-param
+    // metadata. And the remedy was not sound either: routing to the eager-buffer
+    // HOST path does not apply the default correctly — measured on the host lane,
+    // this same source yields 0 there too. So the bail bought no correctness, only
+    // a `__gen_*` leak. #3948 registers the metadata in literals.ts, which makes
+    // the argc-driven default fire in both lanes, and lifts the bail.
     const src = `export function test(): number {
   const o = { *m(d: number = 5) { yield d; } };
   return (o.m().next().value as number);
 }`;
+    expect(await runNative(src)).toBe(5);
+  });
+
+  it("OPTIONAL(`?`)-param object-literal generator method still bails to host (value-rep gap)", async () => {
+    // (#3948) The `questionToken` half of the old bail SURVIVES, and was measured
+    // rather than inherited: with the argc registration in place, `a?: number`
+    // still lowers to a bare f64 with no `undefined` inhabitant, so the missing-arg
+    // branch has nothing to bind and the body reads 0, not 42. Admitting it would
+    // trade a leak for a wrong value. The same 0 comes out of a NON-generator
+    // `{ m(a?: number) }`, so this is a value-representation gap, not a gate one.
+    const src = `export function test(): number {
+  const o = { *m(d?: number) { yield d === undefined ? 42 : d; } };
+  return (o.m().next().value as number);
+}`;
     const { binary, genImports } = await compileNoHost(src);
-    expect(genImports.length, "default-param objlit generator must bail to host").toBeGreaterThan(0);
-    expect(WebAssembly.validate(binary), "default-param bail module must be valid Wasm").toBe(true);
+    expect(genImports.length, "optional-param objlit generator must still bail to host").toBeGreaterThan(0);
+    expect(WebAssembly.validate(binary), "optional-param bail module must be valid Wasm").toBe(true);
   });
 
   it("explicit-arg (no default) object-literal generator method stays native", async () => {

--- a/tests/issue-3948.test.ts
+++ b/tests/issue-3948.test.ts
@@ -1,0 +1,261 @@
+/**
+ * #3948 — object-literal methods never registered optional-parameter metadata,
+ * so `maybeSetArgcForKnownCall` no-op'd at every `o.m()` call site and the
+ * callee's param-default prologue read the `-1` "unknown caller" sentinel.
+ *
+ * Two independent guards, kill-switched separately (2026-08-01):
+ *
+ *   (A) `literals.ts` — register `ctx.funcOptionalParams` for object-literal
+ *       methods. Revert it alone and the generator modules below still emit
+ *       ZERO host imports and still instantiate with `{}` — they just return
+ *       the inert `0` instead of the default. Import-set-only acceptance would
+ *       green that; only the value assertions catch it.
+ *
+ *   (B) `generators-native.ts` — lift the #2581 object-literal
+ *       default-param bail in `isNativeGeneratorCandidate`. Revert it alone and
+ *       every standalone generator case below fails at instantiation with
+ *       `Import #0 "env": module is not an object or function`.
+ *
+ * The host-lane assertions are the wider defect (#3949): `{ m(a = 5) }.m()`
+ * evaluated to 0 in the DEFAULT target too, with no generator involved — which
+ * also falsifies #2581's stated justification for the bail ("the eager-buffer
+ * host path applies defaults correctly, so route there").
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+const HOST_GEN_IMPORTS =
+  /__create_generator|__gen_create_buffer|__gen_next|__gen_push|__gen_result|__gen_return|__get_caught_exception/;
+
+type Compiled = {
+  success: boolean;
+  binary: Uint8Array;
+  errors?: unknown;
+  imports?: { module: string; name: string }[];
+  importObject?: WebAssembly.Imports;
+};
+
+async function compileLane(src: string, lane: "standalone" | "host"): Promise<Compiled> {
+  // NOTE: `{ standalone: true }` is rejected by buildCodegenOptions (#86) and used
+  // to silently run the gc-host lane, which makes a "standalone" test vacuous.
+  const opts = lane === "standalone" ? { fileName: "t.ts", target: "standalone" as const } : { fileName: "t.ts" };
+  const r = (await compile(src, opts)) as unknown as Compiled;
+  expect(r.success, `compile failed: ${JSON.stringify(r.errors).slice(0, 300)}`).toBe(true);
+  return r;
+}
+
+/** Standalone run. Instantiating with NO import object is itself the leak assertion. */
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compileLane(src, "standalone");
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+async function runHost(src: string): Promise<unknown> {
+  const r = await compileLane(src, "host");
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+async function standaloneImportNames(src: string): Promise<string> {
+  const r = await compileLane(src, "standalone");
+  return (r.imports ?? []).map((i) => `${i.module}::${i.name}`).join(",");
+}
+
+// ---------------------------------------------------------------------------
+// (B) the leak — object-literal generator methods with a parameter default
+// ---------------------------------------------------------------------------
+
+describe("#3948 standalone: object-literal generator methods with a param default", () => {
+  it("emits no host generator imports for an identifier default", async () => {
+    const names = await standaloneImportNames(
+      `const o = { *m(a: number = 5) { yield a; } };
+       export function test(): number { return o.m().next().value as number; }`,
+    );
+    expect(names).not.toMatch(HOST_GEN_IMPORTS);
+    expect(names).toBe("");
+  });
+
+  it("emits no host generator imports for a whole-param binding-pattern default", async () => {
+    const names = await standaloneImportNames(
+      `const o = { *m({ x }: { x: number } = { x: 23 }) { yield x; } };
+       export function test(): number { return o.m().next().value as number; }`,
+    );
+    expect(names).not.toMatch(HOST_GEN_IMPORTS);
+  });
+
+  // --- value assertions: a host-free module that reads an inert default is
+  // --- exactly the failure the import-set gate cannot see.
+
+  it("applies an identifier default when the argument is omitted", async () => {
+    expect(
+      await runStandalone(
+        `const o = { *m(a: number = 5) { yield a; } };
+         export function test(): number { return o.m().next().value as number; }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("skips the default when an argument is supplied", async () => {
+    expect(
+      await runStandalone(
+        `const o = { *m(a: number = 5) { yield a; } };
+         export function test(): number { return o.m(7).next().value as number; }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("applies a later param's default when an earlier one is supplied", async () => {
+    expect(
+      await runStandalone(
+        `const o = { *m(a: number, b: number = 5) { yield a + b; } };
+         export function test(): number { return o.m(1).next().value as number; }`,
+      ),
+    ).toBe(6);
+  });
+
+  it("applies a whole-param binding-pattern default", async () => {
+    expect(
+      await runStandalone(
+        `const o = { *m({ x }: { x: number } = { x: 23 }) { yield x; } };
+         export function test(): number { return o.m().next().value as number; }`,
+      ),
+    ).toBe(23);
+  });
+
+  it("prefers a supplied argument over a binding-pattern default", async () => {
+    expect(
+      await runStandalone(
+        `const o = { *m({ x }: { x: number } = { x: 23 }) { yield x; } };
+         export function test(): number { return o.m({ x: 4 }).next().value as number; }`,
+      ),
+    ).toBe(4);
+  });
+
+  it("applies a non-constant expression default", async () => {
+    expect(
+      await runStandalone(
+        `function mk(): number { return 11; }
+         const o = { *m(a: number = mk()) { yield a; } };
+         export function test(): number { return o.m().next().value as number; }`,
+      ),
+    ).toBe(11);
+  });
+
+  it("applies a string default (a ref-typed param, not the argc/f64 path)", async () => {
+    expect(
+      await runStandalone(
+        `const o = { *m(a: string = "hi") { yield a.length; } };
+         export function test(): number { return o.m().next().value as number; }`,
+      ),
+    ).toBe(2);
+  });
+
+  // --- the suspension assertion: proves the generator STATE round-trips the
+  // --- defaulted binding, not just that the initial load happened to be right.
+
+  it("still sees the defaulted binding after a suspension", async () => {
+    expect(
+      await runStandalone(
+        `const o = { *m(a: number = 5) { yield a; yield a + 1; } };
+         export function test(): number {
+           const it = o.m();
+           it.next();
+           return it.next().value as number;
+         }`,
+      ),
+    ).toBe(6);
+  });
+
+  it("evaluates the default at call time, not at generator creation (§27.5)", async () => {
+    // `mk()` must have run exactly once when `o.m()` returns, and the BODY must
+    // not have run at all — the eager-buffer path violated both.
+    expect(
+      await runStandalone(
+        `let calls = 0;
+         let bodyRan = 0;
+         function mk(): number { calls = calls + 1; return 11; }
+         const o = { *m(a: number = mk()) { bodyRan = bodyRan + 1; yield a; } };
+         export function test(): number {
+           const it = o.m();
+           return calls * 10 + bodyRan;
+         }`,
+      ),
+    ).toBe(10);
+  });
+
+  // --- #2938/#1557 class: two sibling literals sharing a method name must each
+  // --- run their OWN default, not the first literal's.
+
+  it("keeps sibling object literals' defaults distinct", async () => {
+    const src = (which: string) =>
+      `const a = { *m(v: number = 1) { yield v; } };
+       const b = { *m(v: number = 2) { yield v; } };
+       export function test(): number { return ${which}.m().next().value as number; }`;
+    expect(await runStandalone(src("a"))).toBe(1);
+    expect(await runStandalone(src("b"))).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (A) the wider defect — NON-generator object-literal methods, both lanes
+// ---------------------------------------------------------------------------
+
+describe("#3948/#3949 object-literal method parameter defaults (non-generator)", () => {
+  const identDefault = `const o = { m(a: number = 5) { return a; } };
+     export function test(): number { return o.m(); }`;
+  const secondDefault = `const o = { m(a: number, b: number = 5) { return a + b; } };
+     export function test(): number { return o.m(1); }`;
+
+  it("applies the default when the argument is omitted — standalone", async () => {
+    expect(await runStandalone(identDefault)).toBe(5);
+  });
+
+  it("applies the default when the argument is omitted — host lane", async () => {
+    expect(await runHost(identDefault)).toBe(5);
+  });
+
+  it("applies a later param's default — standalone", async () => {
+    expect(await runStandalone(secondDefault)).toBe(6);
+  });
+
+  it("applies a later param's default — host lane", async () => {
+    expect(await runHost(secondDefault)).toBe(6);
+  });
+
+  it("still prefers a supplied argument", async () => {
+    expect(
+      await runStandalone(
+        `const o = { m(a: number = 5) { return a; } };
+         export function test(): number { return o.m(7); }`,
+      ),
+    ).toBe(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deliberately-unchanged shapes — documented residuals, asserted so a future
+// change that moves them is visible rather than silent.
+// ---------------------------------------------------------------------------
+
+describe("#3948 documented residuals", () => {
+  it("keeps `?`-optional generator methods on the host path (value-rep gap)", async () => {
+    // With the argc registration in place the admission gate COULD accept this,
+    // but `a?: number` lowers to a bare f64 with no `undefined` inhabitant, so
+    // the missing-arg branch has nothing to bind and the body reads 0, not 42.
+    // Admitting it would trade a leak for a wrong value. Measured, not inherited.
+    const names = await standaloneImportNames(
+      `const o = { *m(a?: number) { yield a === undefined ? 42 : a; } };
+       export function test(): number { return o.m().next().value as number; }`,
+    );
+    expect(names).toMatch(HOST_GEN_IMPORTS);
+  });
+
+  it("leaves object literals without defaults byte-identical in shape (no imports)", async () => {
+    const names = await standaloneImportNames(
+      `const o = { *m(a: number) { yield a; } };
+       export function test(): number { return o.m(3).next().value as number; }`,
+    );
+    expect(names).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #3948. Files #3949.

## The defect is one level below where the brief pointed

The task was "object-literal generator methods with a parameter default leak
`__gen_*` host imports in standalone, while the identical **class** method does
not." That asymmetry is real, and it is what localised this — but the bail it
led to is a **workaround**, not the defect.

`maybeSetArgcForKnownCall` opens with

```ts
if (!ctx.funcUsesArguments.has(funcName) && !ctx.funcOptionalParams.has(funcName)) return;
```

Class bodies populate `funcOptionalParams` (`registerClassOptionalParams`), free
functions do too. **Object-literal methods never did** — `literals.ts` registered
only `funcUsesArguments`. So every `o.m()` call site returned early without
emitting `global.set $__argc`, the global kept its `-1` "unknown caller" init
value, and the callee's `emitParamDefaultArgMissingCheck`
(`argc != -1 && argc <= argIndex`) read that as "no argument is missing". The
default never fired.

Instrumented at the decision point rather than reasoned about:

```
[argc] maybeSet name=__anon_0_m paramCount=1 usesArgs=false optional=false keys=[]
[argc] maybeSet name=C_m        paramCount=1 usesArgs=false optional=true  keys=[C_m]
```

## #2581's stated justification is false on both halves

The lifted bail said the trampoline was to blame and that the host path applied
defaults correctly. Measured:

1. **Not the trampoline.** A plain `o.m()` is a **direct** call
   (`call-receiver-method.ts`) and *does* reach `maybeSetArgcForKnownCall`; the
   trampoline is only for method *extraction* (`const f = o.m`).
2. **The host path doesn't apply the default either** —
   `{ *m(a = 5) }.m().next().value` is **0** on the default target too
   (`imports=7`). The bail bought no correctness, only a leak.

Recorded in place at the gate rather than deleted — a wrong justification left
standing is how this survived review once already.

## Fix — two guards, each independently load-bearing

- **(A) `literals.ts`** — register the optional-param metadata (offset `1` for
  the receiver, matching the class path's `paramTypeOffset`).
- **(B) `generators-native.ts`** — lift the object-literal `param.initializer`
  bail. `questionToken` **still bails**, measured not inherited: with (A) in
  place `{ *m(a?: number) }` still yields 0, because `a?: number` lowers to a
  bare `f64` with no `undefined` inhabitant. Value-rep gap (#3949), not an
  admission-gate one — admitting it would trade a leak for a wrong value.

## The acceptance rule earned its keep here

| reverted      | `tests/issue-3948.test.ts`                                        |
| ------------- | ------------------------------------------------------------------ |
| **(B) alone** | 12/19 fail — all `instantiate(): Import #0 "env"`                  |
| **(A) alone** | 10/19 fail — **and both import-set assertions still PASS**         |
| neither (fix) | 19/19 pass                                                         |

**Under (A)-alone the modules are host-free, instantiate with `{}`, and silently
return the inert `0`.** An import-set-only acceptance would have greened a broken
fix. Only the value assertions — including a read *after a suspension*
(`yield a; yield a + 1` → 6) and a call-time-ordering assertion (§27.5: after
`o.m()` the initializer has run once, the body not at all) — catch it. That is
the clearest justification #3178's "Validation (applies to every slice)" section
has.

(The whole-param *pattern* arms still pass under (A)-alone — those defaults come
from the destructuring lane, not argc. So A and B cover genuinely different
subsets; neither is redundant.)

## Measured effect — construct-sampled, with the control run

Population re-measured on the **2026-08-01 00:51** standalone baseline (48,088
records): object-literal, non-async, param-default generator rows carrying a
host-import leak = **98** (81 whole-param binding-pattern · 9 identifier · 6
pattern-with-init · 2 misc).

Each of the 98 real test262 files' **actual** `*method(<params>)` signature was
extracted from the source — shapes derived from the population, not imagined —
and re-compiled bare in the standalone lane; the measured quantity is the import
set:

| run                 | probes compiled | host-free | still leaking |
| ------------------- | --------------: | --------: | ------------: |
| **pre-fix control** |              97 |     **0** |            97 |
| **post-fix**        |              97 |    **89** |         **8** |

The pre-fix control is what makes the post-fix number mean anything. The 8
residual are one family (`*-init-fn-name-{arrow,fn,gen,class}`, where the element
default is a function/class **expression**) — a different bail, not attributed
and not claimed here.

**All 98 are `compile_error` today.** The prize is host-free instantiation, **not
a pass delta — 98 is not a pass count.** `runTest262File` was deliberately not
used as an instrument: it supplies host imports, so a leaking module scores
`pass` regardless of this fix.

## Also fixes the wider defect → #3949

The gap is not generator-specific and not standalone-specific, so `{ m(a = 5) }.m()`
returned **0** in the **default target** too. Now 5, in both lanes; host-lane
assertions are in the test file. Filed as #3949 so a host-lane default-parameter
bug is not buried in a standalone-generator issue — the `?`-optional row and the
method-extraction path stay open there.

## Verification

- `tests/issue-3948.test.ts` — 19/19, both kill-switches verified red.
- `tests/issue-2581-objlit-method-generators.test.ts` — the assertion encoding
  the old (wrong) bail is **corrected in place** with the measurement that
  falsifies it; a new assertion pins the surviving `?` bail. 15/15.
- `prove-emit-identity check` → **IDENTICAL, all 60 (file,target) emits.** No
  host-lane blast radius; modules without a defaulted object-literal method emit
  byte-identical bytes.
- `equivalence-gate` exit 0, **no new regressions**. Baseline not ratcheted (the
  4 now-passing entries are unrelated pre-existing drift).
- `tsc --noEmit`, `biome lint`, `check:oracle-ratchet`, `check:ir-fallbacks`,
  `check:issue-ids`, prettier — all clean. LOC/func budget growth is granted in
  this PR's own issue file with the reason.
- `default-params` / `class-methods` / `arguments-object` / `anon-struct` /
  `issue-1672` show 28 failures **identical test-for-test on unmodified
  `origin/main`** (A/B) — pre-existing, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
