### PR TITLE
fix(#3611): the #2097 high-water raise was skipped on 30 of 30 merges — restore it

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -2080,15 +2080,47 @@ jobs:
     # promoting a flagged run's pass-set would poison the regression baseline
     # every PR gates against. The merged-report ARTIFACT is the measurement
     # deliverable; the baseline stays owned by unflagged runs.
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.actor != 'github-actions[bot]' && !(github.event_name == 'workflow_dispatch' && inputs.ir_first)
+    # (#3611) `!cancelled() &&` IS LOAD-BEARING — do not "simplify" it away.
+    #
+    # Measured 2026-08-01 across **30 of 30** available push:main runs: this job
+    # was SKIPPED every time, so `check-standalone-highwater.mjs --update` — the
+    # #2097 raise — had not executed on a queue merge in the whole observable
+    # window. With `refresh-baseline.yml` also `disabled_manually`, BOTH paths
+    # that can raise the mark were dead, and the failure is silent in the
+    # PERMISSIVE direction (a floor that is too low never fires), so nothing
+    # ever complained.
+    #
+    # It was NOT the actor guard and NOT `success()` over `needs` — both needs
+    # were `success` on all 30, and the sibling `promote root baseline` job,
+    # gated on `github.actor == 'github-merge-queue[bot]'`, RAN on all 30, which
+    # proves the actor value and hence that every conjunct below is true. The
+    # job was skipped in the SAME SECOND `merge-report` resolved, with 0 steps.
+    #
+    # Mechanism: on the #3448 HIT path the shard matrix is skipped, and
+    # `merge-report` survives that only because it carries its own
+    # `if: always() && …`. GitHub then propagates the skip THROUGH that job into
+    # any dependent lacking a status-check function of its own. `!cancelled()`
+    # is that function — it re-enables the job while (unlike bare `always()`)
+    # still honouring cancellation, and the explicit `needs.*.result` checks
+    # below restore the failure semantics the implicit `success()` provided.
+    if: |
+      !cancelled() &&
+      needs.merge-report.result == 'success' &&
+      needs.mg-artifact-probe.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      github.actor != 'github-actions[bot]' &&
+      !(github.event_name == 'workflow_dispatch' && inputs.ir_first)
     name: promote merged report to main baseline
+    # (#2947) `!(… && inputs.ir_first)` above — an IR-first measurement dispatch
+    # (JS2WASM_IR_FIRST=1 in the shards) must NEVER promote its merged report:
+    # promoting a flagged run's pass-set would poison the regression baseline
+    # every PR gates against. The merged-report ARTIFACT is the measurement
+    # deliverable; the baseline stays owned by unflagged runs.
+    #
     # #3448 — mg-artifact-probe decides where the merged JSONLs come from:
     # MISS → the `test262-merged-report` artifact built by merge-report from a
     # fresh matrix (unchanged); HIT → the merge_group's own
-    # `test262-group-<sha>` artifact, skipping the 114-job rerun. Both jobs
-    # run+succeed on push and workflow_dispatch, so the implicit `success()`
-    # over `needs` holds (merge-report green-skips on the HIT path — still
-    # success).
+    # `test262-group-<sha>` artifact, skipping the 114-job rerun.
     needs: [merge-report, mg-artifact-probe]
     runs-on: ubuntu-latest
     # Gate the MAIN_DEPLOY_KEY secret behind a GitHub Environment so only this

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -150,6 +150,27 @@ Two test262 workflows currently run on PRs:
     back. If GH013 recurs, first confirm the ruleset still lists the
     `DeployKey: always` bypass actor
     (`gh api /repos/loopdive/js2/rulesets/16700772 --jq .bypass_actors`).
+  - ⚠️ **`refresh-baseline.yml` is `state=disabled_manually` and CANNOT be
+    dispatched** (verified 2026-07-25 and again 2026-08-01:
+    `gh api repos/loopdive/js2/actions/workflows/265204741 --jq .state`; a
+    `workflow_dispatch` returns **HTTP 422 "Cannot trigger a
+    'workflow_dispatch' on a disabled workflow"** — it fails before doing
+    anything). It is the only non-active workflow in the repo. Any runbook
+    step that says "dispatch `refresh-baseline.yml` in EMERGENCY mode" —
+    historically the documented lever for a queue wedged on #1897 — **will
+    not execute today**. Treat that lever as unavailable until #3611 settles
+    its disposition, and do NOT re-enable it mid-incident: that restarts an
+    8-hourly cron and runs an unconditional, guard-ignoring promote, which is
+    the most dangerous available version of that action.
+    **Note `gh workflow list` simply OMITS disabled workflows**, so absence
+    there is not evidence of non-existence — query the API by id or path.
+  - **Before relying on ANY documented lever, check it is enabled**, not just
+    that it exists:
+    `gh api repos/loopdive/js2/actions/workflows --jq '.workflows[]|"\(.state) \(.path)"' | grep -v '^active'`.
+    Disabling a workflow silently invalidates every runbook line naming it and
+    nothing links the two, so an untested recovery path is indistinguishable
+    from a working one until the moment it is needed. When disabling a
+    workflow, grep the docs for its name **in the same change**.
   - The `check for test262 regressions` job is also required. It compares
     the merged PR report against the baseline and catches full pass→fail
     regressions even when the inline hard guards inside `merge shard reports`

--- a/plan/issues/3611-promote-skip-highwater-never-raises-on-queue-merges.md
+++ b/plan/issues/3611-promote-skip-highwater-never-raises-on-queue-merges.md
@@ -1,17 +1,18 @@
 ---
 id: 3611
 title: "promote-baseline skips on the per-SHA-reuse path, so the #2097 standalone high-water never re-raises on queue merges — the floor drifts permissively, silently"
-status: ready
+status: done
+completed: 2026-08-01
 sprint: current
 created: 2026-07-25
-updated: 2026-07-25
+updated: 2026-08-01
 priority: high
 horizon: m
 feasibility: medium
 task_type: ci
 area: ci, merge-queue, test262
 goal: release-pipeline
-related: [2097, 3467, 3468, 3448, 3592, 2562, 1078, 3601]
+related: [2097, 3467, 3468, 3448, 3592, 2562, 1078, 3601, 3953]
 origin: "PR-queue shepherd verification of the #3601 (#3592 RC2) landing, 2026-07-25. Surfaced only because a deliberate ~5,000-test move was being watched."
 ---
 
@@ -140,6 +141,22 @@ without this issue the same drift resumes on the next queue merge.)
 
 ## Acceptance criteria
 
+> **Disposition, 2026-08-01.** The mechanism is fixed here (2, 6). The criteria that
+> **cannot be settled by a code diff** — the observable post-merge verification (1, 3)
+> and the loudness work (4) — are carried by **#3953** rather than left as unticked
+> boxes inside a `done` issue, because an unowned box is exactly how this defect
+> survived a week unnoticed. **AC5 is deliberately NOT done** — see the position below.
+>
+> | #   | criterion                                | status                                                            |
+> | --- | ---------------------------------------- | ----------------------------------------------------------------- |
+> | 1   | raise runs on a HIT-path landing         | **→ #3953** (needs a real merge + run id)                         |
+> | 2   | gating corrected                         | **done** — and the criterion itself was misdirected; see below    |
+> | 3   | mark left raised, verified on a merge    | **→ #3953**                                                       |
+> | 4   | the silent failure becomes loud          | **→ #3953** (not attempted here)                                  |
+> | 5   | `refresh-baseline.yml` disposition       | **open by design** — rationale unrecorded; escalated, not guessed |
+> | 6   | runbook stops naming a lever that 422s   | **done** — `docs/ci-policy.md`                                    |
+> | 7   | README derives from promoted measurement | untouched by this change                                          |
+
 1. A merge-queue landing that takes the per-SHA-reuse (HIT) path **runs** the
    high-water raise; the mark advances without manual intervention.
 2. The `needs`/`if` gating is corrected so the promote job's own documented
@@ -161,6 +178,18 @@ without this issue the same drift resumes on the next queue merge.)
    name a lever that would fail.
 7. The README / landing-page standalone number derives from the promoted
    measurement, never from an in-PR estimate.
+
+## The finding, stated first (2026-08-01)
+
+> **The standalone high-water mark has not risen at all in the observable window,
+> because BOTH paths that can raise it are dead** — `promote-baseline` skipped on
+> **30 of 30** available push:main runs, and `refresh-baseline.yml` has been
+> `disabled_manually` for over a week.
+
+That is the finding. The `always()`-skip propagation below is only the _mechanism_,
+and the title understates it: this is not "the mark drifts", it is "the mark cannot
+move." And because a floor that is too **low** never fires, the whole thing is
+invisible from the inside.
 
 ## Verification 2026-08-01 — still true, and it is 30/30, not intermittent
 
@@ -235,6 +264,35 @@ is the **absence of a status-check function** on `promote-baseline`, and the fix
 in-file precedent: `merge-report`, the job directly above it in the same chain, already
 does exactly this and is exactly why it survives.
 
+### What shipped, and how acceptance must be judged
+
+`promote-baseline`'s `if:` gains `!cancelled()` — the status-check function whose
+absence let the skip propagate — **plus explicit `needs.merge-report.result ==
+'success'` / `needs.mg-artifact-probe.result == 'success'` terms.** That second half
+is not decoration: `!cancelled()` alone re-enables the job unconditionally, so it
+would also promote a baseline **after `merge-report` FAILED** — a worse bug than the
+stale mark it fixes. The explicit terms restore exactly what the implicit `success()`
+was providing. `!cancelled()` rather than bare `always()` so a cancelled run still
+cancels.
+
+`tests/issue-3611-promote-baseline-runs-on-hit-path.test.ts` pins both halves, and
+each was **positive-controlled by injecting the corresponding defect**: dropping the
+`needs.*.result` terms fails only _"still refuses to promote when either dependency
+did not succeed"_; removing `!cancelled()` fails only _"does not use bare
+`always()`"_. 1 of 7 each, different tests — specific, not merely sensitive. (Writing
+that second test also caught a real slicing bug in the test itself: the job's own
+prose _explains_ `merge-report`'s `always()`, so a naive substring slice matched the
+comment rather than the condition. A substring assertion over YAML is only as good as
+its slice.)
+
+> **⚠️ Acceptance here must be OBSERVABLE, not structural.** The test above is a
+> **guard against regression**, not evidence the bug is fixed. It asserts the shape
+> of the `if:`, and a structural assertion would keep passing while some _other_
+> propagation path kept the job skipped. **Criterion 1/3 is satisfied only by a real
+> queue merge whose run shows `promote merged report to main baseline` with
+> conclusion `success`, cited by run id** — the same audit that produced the 30/30,
+> re-run after this lands (`.tmp/promote-audit.sh`). Do not tick it off the tests.
+
 ### Why nothing caught it
 
 The failure is silent **in the permissive direction** — a floor that is too low never
@@ -242,6 +300,49 @@ fires. Combined with the two jobs having confusingly similar names
 (`promote root baseline …` vs `promote merged report to main baseline`), a reader
 skimming the run sees a green `promote …` job and moves on. **One of them succeeded on
 all 30 runs; the other one is the one that carries the raise.**
+
+### AC5 — position: do NOT re-enable `refresh-baseline.yml` here, and the reason is UNRECORDED
+
+Searched `plan/`, `docs/` and `.claude/memory/` for why it was switched off. **Nothing
+states a rationale.** Recording that as _unknown_ rather than guessing, because the
+honest answer to "why is this off?" is load-bearing: a workflow someone deliberately
+disabled may have been disabled for a reason that still holds, and silently
+re-enabling a **main-pusher** is precisely the class #3915 just had to gate.
+
+Three reasons this issue should not flip it:
+
+1. **Repairing the PRIMARY beats re-enabling a BACKSTOP.** `promote-baseline` is the
+   mechanism; `refresh-baseline` is the safety net. Fixing the net while the
+   mechanism is broken hides the mechanism's failure again.
+2. **Re-enabling is a repo-config change with standing effect** — it restarts an
+   8-hourly cron — and it is not something a code PR can even express. It cannot be
+   reviewed as part of this diff.
+3. **Its rationale is unrecorded**, so re-enabling would be inferring permission.
+   ([[reference_untested_recovery_paths_rot_silently]] reaches the same conclusion
+   independently: _escalate, don't infer permission_.)
+
+**Proposal:** treat re-enablement as its own change with its own justification, after
+criterion 1/3 confirms the primary path works on a real merge. If nobody can state
+why it was disabled, that fact should be recorded in the re-enablement request rather
+than quietly resolved. #3915 already added the merge-queue gate to its main push, so
+whenever it _is_ re-enabled it cannot silently reintroduce the rebuild tax.
+
+### AC6 — the runbook is corrected here
+
+`docs/ci-policy.md` now states, at the point where it lists `refresh-baseline.yml`
+among the deploy-key promoters, that the workflow is `disabled_manually` and that a
+dispatch returns **HTTP 422 before doing anything** — so the historical "dispatch it
+in EMERGENCY mode" lever will not execute. Verified today, and the verification
+command is inline so a reader can re-check rather than trust the date.
+
+Two generalisations added alongside it, because the specific line will rot the same
+way the last one did:
+
+- **Check a lever is `state=active`, not merely that it exists**, before relying on
+  it — with the one-liner that lists every non-active workflow.
+- **`gh workflow list` OMITS disabled workflows**, so absence there is not evidence of
+  non-existence. That is exactly the false-empty shape that makes this class hard to
+  see.
 
 ## Notes
 

--- a/plan/issues/3611-promote-skip-highwater-never-raises-on-queue-merges.md
+++ b/plan/issues/3611-promote-skip-highwater-never-raises-on-queue-merges.md
@@ -162,6 +162,87 @@ without this issue the same drift resumes on the next queue merge.)
 7. The README / landing-page standalone number derives from the promoted
    measurement, never from an in-PR estimate.
 
+## Verification 2026-08-01 — still true, and it is 30/30, not intermittent
+
+Re-verified before touching anything. Two of the three claims hold exactly; the third
+(the stated root cause) is **disproved**, and the correct one is different.
+
+### 1. The skip is universal, not occasional — 30 of 30
+
+Audited every `push:main` `Test262 Sharded` run available (30 runs, 2026-07-30 18:17Z →
+2026-07-31 23:47Z, `.tmp/promote-audit.sh`):
+
+| jobs                                         | outcome across all 30 runs |
+| -------------------------------------------- | -------------------------- |
+| `probe merge_group baseline artifact`        | `success` ×30              |
+| `merge shard reports`                        | `success` ×30              |
+| **`promote merged report to main baseline`** | **`skipped` ×30**          |
+
+Actor was `github-merge-queue[bot]` on all 30. So this is not a rate — **the
+high-water raise has not executed on a queue merge in the entire observable window.**
+
+### 2. `refresh-baseline.yml` is STILL `disabled_manually` — the backstop is still gone
+
+`gh api repos/loopdive/js2/actions/workflows/265204741` → `state=disabled_manually`, and
+it is **the only non-active workflow in the repo**. Corroborated independently from the
+record rather than the API: `git log origin/main --grep="scheduled baseline refresh"` is
+**empty** since at least 2026-07-20.
+
+Both rows of this issue's original table are therefore unchanged, seven days on.
+
+### 3. The stated root cause is WRONG — the `if:` is provably TRUE
+
+This issue attributes the skip to the job's `success()`-over-`needs` assumption failing.
+Both direct `needs` are `success` on all 30 runs, so that is not it. Nor is the actor
+guard, and there is a **positive control in the same run** that settles it:
+
+```yaml
+# promote-baseline (SKIPS)
+if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    && github.actor != 'github-actions[bot]' && !(… && inputs.ir_first)
+
+# promote root baseline + cache per-SHA (RUNS, success ×30)
+if: github.event_name == 'push' && github.actor == 'github-merge-queue[bot]'
+```
+
+The second job **runs**, which proves `github.actor == 'github-merge-queue[bot]'` in this
+context — so `github.actor != 'github-actions[bot]'` is TRUE, `event_name == 'push'` is
+TRUE, and the `inputs.ir_first` clause is TRUE on a push. **Every conjunct of
+`promote-baseline`'s `if:` holds, and it skips anyway.** Reading the two `if:`s side by
+side is what settles this; reasoning about either one alone does not.
+
+The timing says where the skip comes from:
+
+```
+23:47:53Z  run created
+23:47:57Z  test262-shard            skipped   (HIT path — matrix green-skipped)
+23:47:58Z  mg-artifact-probe        success
+23:48:04Z  merge shard reports      success   ← ran only because of its own always()
+23:48:04Z  promote merged report    SKIPPED   ← same second, 0 steps, started==completed
+```
+
+`promote-baseline` is skipped in the **same second** `merge-report` resolves, having run
+zero steps. `merge-report` itself only ran because it carries
+`if: always() && …` (line ~932) over a `needs` set whose shards were **skipped**.
+So the skip **propagates through** the `always()` job to any dependent that does not
+itself use a status-check function — the implicit `success()` on `promote-baseline` is
+satisfied and it is skipped regardless.
+
+**Correcting the record matters here**, because acceptance criterion 2 as written
+("correct the `needs`/`if` gating so the documented `success()`-over-`needs` assumption
+holds") points at an assumption that is not the defect. The gating that needs to change
+is the **absence of a status-check function** on `promote-baseline`, and the fix has an
+in-file precedent: `merge-report`, the job directly above it in the same chain, already
+does exactly this and is exactly why it survives.
+
+### Why nothing caught it
+
+The failure is silent **in the permissive direction** — a floor that is too low never
+fires. Combined with the two jobs having confusingly similar names
+(`promote root baseline …` vs `promote merged report to main baseline`), a reader
+skimming the run sees a green `promote …` job and moves on. **One of them succeeded on
+all 30 runs; the other one is the one that carries the raise.**
+
 ## Notes
 
 - Do **not** reach for `refresh-baseline.yml` EMERGENCY mode for this class of

--- a/plan/issues/3953-highwater-raise-verify-on-merge-and-make-the-silence-loud.md
+++ b/plan/issues/3953-highwater-raise-verify-on-merge-and-make-the-silence-loud.md
@@ -1,0 +1,87 @@
+---
+id: 3953
+title: "verify the #2097 high-water raise actually executes on a real merge, and make its silence loud — a floor that is too low must stop being cost-free"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: high
+horizon: m
+feasibility: medium
+task_type: ci
+area: ci, merge-queue, test262
+goal: release-pipeline
+depends_on: [3611]
+related: [2097, 3448, 3467, 1078, 2562]
+---
+
+# The two halves of #3611 that a code PR cannot close
+
+#3611 fixed the **mechanism**: `promote-baseline` lacked a status-check function, so
+GitHub propagated the #3448 HIT-path skip through `merge-report`'s `always()` and into
+it, and the #2097 standalone high-water raise was skipped on **30 of 30** available
+push:main runs. That change is structural and reviewable.
+
+Two of its acceptance criteria are **not** structural, and are carried here rather than
+ticked off the tests.
+
+## 1. Observable verification — the part that must not be inferred
+
+**A structural test asserting the shape of the `if:` is a regression guard, not
+evidence the bug is fixed.** It would keep passing while some _other_ propagation path
+kept the job skipped. The only thing that settles it is a real merge:
+
+- [ ] After #3611 lands, a **merge-queue landing** produces a `Test262 Sharded`
+      `push:main` run whose `promote merged report to main baseline` job has conclusion
+      **`success`** — cited **by run id** in this issue.
+- [ ] Re-run the same audit that produced the 30/30 (`.tmp/promote-audit.sh` in the
+      #3611 branch, or the equivalent: enumerate `push:main` runs of workflow
+      `265204744` and print that job's conclusion). Expect `success` on runs after the
+      fix; the pre-fix runs stay `skipped` and are the control.
+- [ ] Confirm the **effect**, not just the job status: `scripts/check-standalone-highwater.mjs`
+      target actually advanced (mark `pass`/`sha` changed on main), because a job can
+      succeed while its update step no-ops.
+
+**Do not close this on the tests passing.** That is the whole point of splitting it out.
+
+## 2. Make the silence loud (#3611 AC4)
+
+The reason this survived a week is not that the skip was subtle — it is that
+**nothing anywhere reports a skipped raise.** A high-water mark that is too **low**
+never fires its gate, so the permissive direction is completely silent. Combined with
+two jobs whose names both start `promote …` (one green on all 30 runs, and it is _not_
+the one carrying the raise), a reader skimming a run summary sees green and moves on.
+
+- [ ] If the raise is skipped on a `push:main` run, something says so — an annotation
+      on the run, or an alert like the existing
+      `baseline-floor-staleness-alert.yml` / `trap-tolerance-staleness-alert.yml`.
+- [ ] If the committed mark is more than N landings / hours older than the newest
+      promoted standalone report, that is reported. There is precedent to copy:
+      `baseline-floor-staleness-alert.yml` already does this shape for a sibling
+      artifact.
+- [ ] The detector must have a **third state**. "Could not determine the mark's age"
+      must not render as "fresh" — that is the same false-empty that made the original
+      bug invisible, and it is a documented recurring failure in this repo.
+
+**Cheapest useful version:** a step in `promote-baseline` that fails (or annotates)
+when the raise did not run, plus a scheduled staleness check on the mark. The bar is
+_"a floor that is too low stops being cost-free"_, not full observability.
+
+## 3. Also open, tracked in #3611, NOT here
+
+**AC5 — `refresh-baseline.yml` disposition.** It is `disabled_manually` and **the
+reason is unrecorded** (searched `plan/`, `docs/`, `.claude/memory/`; nothing states
+one). Re-enabling is a repo-config change with standing effect that restarts an
+8-hourly cron, cannot be expressed in a code diff, and would be inferring permission.
+It should be its own change with its own justification — and it should come **after**
+criterion 1 above confirms the primary path works, because repairing the primary beats
+re-enabling a backstop.
+
+AC6 (the runbook naming a lever that returns HTTP 422) is **done** in #3611.
+
+## Why this is a separate issue rather than a checkbox left open
+
+A criterion that can only be verified after merge, on someone else's PR landing, is
+invisible if it stays as an unticked box inside a `done` issue — that is how the
+original defect stayed unnoticed for a week. Giving it an id gives it an owner and a
+queue position.

--- a/tests/issue-3611-promote-baseline-runs-on-hit-path.test.ts
+++ b/tests/issue-3611-promote-baseline-runs-on-hit-path.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3611 — the #2097 standalone high-water raise never ran on a queue merge.
+ *
+ * `promote-baseline` runs `check-standalone-highwater.mjs --update`. Measured
+ * 2026-08-01 it was SKIPPED on **30 of 30** available push:main runs, so the
+ * mark could only fall behind — and because a floor that is too LOW never
+ * fires, nothing ever complained. With `refresh-baseline.yml` also disabled,
+ * both paths that can raise the mark were dead.
+ *
+ * It was not the actor guard and not `success()` over `needs` (both needs were
+ * `success` on all 30). On the #3448 HIT path the shard matrix is skipped;
+ * `merge-report` survives only via its own `if: always() && …`, and GitHub
+ * propagates that skip THROUGH it into any dependent lacking a status-check
+ * function of its own.
+ *
+ * The fix adds `!cancelled()`. **That alone would be a worse bug than the one
+ * it fixes** — it would also let the job promote a baseline after
+ * `merge-report` FAILED. The explicit `needs.*.result == 'success'` terms
+ * restore what the implicit `success()` was providing, and the tests below pin
+ * both halves. Losing either one silently is the whole hazard.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname ?? ".", "..");
+const WF = readFileSync(resolve(ROOT, ".github/workflows/test262-sharded.yml"), "utf8");
+
+/** Slice a job block out by key, up to the next sibling job key. */
+function job(name: string): string {
+  const start = WF.indexOf(`\n  ${name}:\n`);
+  expect(start, `job not found: ${name}`).toBeGreaterThanOrEqual(0);
+  const next = WF.slice(start + 1).search(/\n {2}[a-z0-9-]+:\n/);
+  return next === -1 ? WF.slice(start) : WF.slice(start, start + 1 + next);
+}
+
+const promote = job("promote-baseline");
+
+describe("#3611 promote-baseline must survive the #3448 HIT path", () => {
+  it("is the job that carries the #2097 high-water raise", () => {
+    // Positive control on the slice: if the raise ever moves out of this job,
+    // every other assertion here is testing the wrong block.
+    expect(promote).toContain("promote merged report to main baseline");
+    expect(promote).toContain("check-standalone-highwater.mjs");
+  });
+
+  it("carries a status-check function, without which the skip propagates", () => {
+    // `merge-report` runs under always() over skipped shards; a dependent with
+    // only an implicit success() is skipped along with them. This is the
+    // single character-level property that made the raise dead for 30/30 runs.
+    expect(promote).toMatch(/if:[\s\S]*?!cancelled\(\)/);
+  });
+
+  it("still refuses to promote when either dependency did not succeed", () => {
+    // THE SAFETY HALF. `!cancelled()` re-enables the job unconditionally, so
+    // the failure semantics the implicit success() provided must be restored
+    // explicitly — otherwise a FAILED merge-report would promote its baseline,
+    // which is far worse than a stale high-water mark.
+    expect(promote).toContain("needs.merge-report.result == 'success'");
+    expect(promote).toContain("needs.mg-artifact-probe.result == 'success'");
+  });
+
+  it("keeps the guards that predate this change", () => {
+    // #2947 — an IR-first dispatch must never promote its pass-set.
+    expect(promote).toContain("!(github.event_name == 'workflow_dispatch' && inputs.ir_first)");
+    // The bot-actor guard, and the event restriction.
+    expect(promote).toContain("github.actor != 'github-actions[bot]'");
+    expect(promote).toContain("github.event_name == 'push'");
+    expect(promote).toContain("needs: [merge-report, mg-artifact-probe]");
+  });
+
+  it("does not use bare always(), which would also run on cancellation", () => {
+    // Comments must be stripped first: this job's own prose EXPLAINS the
+    // `always()` on merge-report, so a naive slice matches the explanation
+    // rather than the condition. (Caught by this test failing on exactly
+    // that — a substring assertion over YAML is only as good as its slice.)
+    const code = promote
+      .split("\n")
+      .filter((l) => !/^\s*#/.test(l))
+      .join("\n");
+    const ifBlock = code.slice(code.indexOf("if:"), code.indexOf("name:"));
+    expect(ifBlock).toContain("!cancelled()");
+    expect(ifBlock).not.toMatch(/\balways\(\)/);
+  });
+});
+
+describe("#3611 the sibling job that proved the actor value", () => {
+  /**
+   * This job is the positive control that disproved the issue's stated root
+   * cause: it is gated on the actor being `github-merge-queue[bot]` and it RAN
+   * on all 30 runs, which pins `github.actor` and therefore proves every
+   * conjunct of promote-baseline's old `if:` was true while it skipped anyway.
+   *
+   * Pinned here because that control only works while this gate keeps naming
+   * the actor explicitly — if it is ever relaxed, the disproof in the issue
+   * stops being reproducible from the workflow alone.
+   */
+  it("still names github-merge-queue[bot] explicitly", () => {
+    expect(WF).toContain("github.event_name == 'push' && github.actor == 'github-merge-queue[bot]'");
+  });
+
+  it("is a different job from the one carrying the raise", () => {
+    // The two names differ by a few words and mislead a reader skimming a run
+    // summary: one `promote …` job was green on all 30 runs, and it is not the
+    // one that raises the mark.
+    expect(WF).toContain("promote root baseline + cache per-SHA for queue merge");
+    expect(promote).not.toContain("promote root baseline + cache per-SHA");
+  });
+});


### PR DESCRIPTION
Closes #3611. Follow-up: #3953.

## The finding, first

> **The standalone high-water mark has not risen at all in the observable window, because BOTH paths that can raise it are dead** — `promote-baseline` skipped on **30 of 30** available `push:main` runs, and `refresh-baseline.yml` has been `disabled_manually` for over a week.

That is the finding; the `always()`-skip propagation is only the mechanism. The issue's title understates it: this is not "the mark drifts", it is **"the mark cannot move"** — and because a floor that is too **low** never fires its gate, it is completely silent from the inside.

`promote-baseline` is the job that runs `check-standalone-highwater.mjs --update`.

| jobs, across all 30 `push:main` runs (2026-07-30 18:17Z → 2026-07-31 23:47Z) | outcome |
| --- | --- |
| `probe merge_group baseline artifact` | `success` ×30 |
| `merge shard reports` | `success` ×30 |
| **`promote merged report to main baseline`** | **`skipped` ×30** |

Actor was `github-merge-queue[bot]` throughout. Not a rate — a constant.

## The issue's stated root cause is wrong, and that changes the fix

#3611 attributes the skip to the `success()`-over-`needs` assumption failing. **Both direct `needs` are `success` on all 30**, so that is not it, and neither is the actor guard. There is a **positive control in the same run** that settles it:

```yaml
# promote-baseline — SKIPS
if: (push || workflow_dispatch) && github.actor != 'github-actions[bot]' && !(… && inputs.ir_first)

# promote root baseline + cache per-SHA — RUNS, success ×30
if: github.event_name == 'push' && github.actor == 'github-merge-queue[bot]'
```

The second job **runs**, which pins `github.actor` and therefore proves *every conjunct* of the first job's `if:` was true — while it skipped anyway, **in the same second `merge-report` resolved**, with `0 steps` and `started_at == completed_at`.

**Mechanism:** on the #3448 HIT path the shard matrix is skipped. `merge-report` survives that only because it carries its own `if: always() && …`. GitHub then propagates the skip **through** that job into any dependent lacking a status-check function of its own.

So acceptance criterion 2 as written ("correct the gating so the documented `success()`-over-`needs` assumption holds") points at a non-defect. The record is corrected in the issue.

## The fix is two halves, and both are load-bearing

```yaml
if: |
  !cancelled() &&
  needs.merge-report.result == 'success' &&
  needs.mg-artifact-probe.result == 'success' &&
  (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
  github.actor != 'github-actions[bot]' &&
  !(github.event_name == 'workflow_dispatch' && inputs.ir_first)
```

- `!cancelled()` is the status-check function whose absence let the skip propagate. `!cancelled()` rather than bare `always()` so a cancelled run still cancels.
- **`!cancelled()` alone would be a worse bug than the one it fixes** — it re-enables the job unconditionally, so a **FAILED** `merge-report` would promote its baseline. The explicit `needs.*.result == 'success'` terms restore exactly what the implicit `success()` was providing.

Both pre-existing guards survive: #2947's `ir_first` exclusion and the bot-actor guard.

## Testing — specific, not merely sensitive

7 assertions in `tests/issue-3611-promote-baseline-runs-on-hit-path.test.ts`, pinning both halves plus the sibling positive control (so the disproof above stays reproducible from the workflow alone).

Each half was **positive-controlled by injecting the matching defect**:

| injected defect | tests failed |
| --- | --- |
| dropped the `needs.*.result` terms | **1 of 7** — only *"still refuses to promote when either dependency did not succeed"* |
| removed `!cancelled()` (reverts to the 30/30 bug) | **1 of 7** — only *"does not use bare `always()`"* |

Different tests, one each, the other six green. That is specificity, not just sensitivity.

Writing the second test also caught a real bug **in the test**: this job's own prose *explains* `merge-report`'s `always()`, so a naive substring slice matched the comment rather than the condition, and the test failed on its own explanation. A substring assertion over YAML is only as good as its slice — comments are now stripped first.

## Acceptance is OBSERVABLE, and is NOT claimed here

**The test is a regression guard, not evidence the bug is fixed.** It asserts the shape of the `if:`; it would keep passing while some *other* propagation path kept the job skipped. So criteria 1 and 3 are **not ticked**, and **#3953** carries them:

- a real merge-queue landing whose run shows `promote merged report to main baseline` = `success`, **cited by run id**;
- re-running the same audit that produced the 30/30, with the pre-fix runs as the control;
- confirming the **effect** — that the mark actually advanced — because a job can succeed while its update step no-ops.

#3953 also carries **AC4** (make the silence loud), which this PR does not attempt.

## AC5 — deliberately NOT done, and the reason matters

`refresh-baseline.yml` is `disabled_manually`, and **the rationale is unrecorded** — I searched `plan/`, `docs/` and `.claude/memory/`; nothing states one. Recording that as *unknown* rather than guessing:

1. **Repairing the primary beats re-enabling a backstop** — fixing the net while the mechanism is broken re-hides the mechanism's failure.
2. Re-enabling is a **repo-config change with standing effect** (it restarts an 8-hourly cron) and cannot be expressed in a code diff at all.
3. With no recorded rationale, flipping it would be **inferring permission** — and it is a main-pusher, exactly the class #3915 just had to gate. (#3915 already added the merge-queue gate to its push, so whenever it *is* re-enabled it cannot silently reintroduce the rebuild tax.)

## AC6 — done

`docs/ci-policy.md` no longer presents that workflow as an available emergency lever: it records that a dispatch returns **HTTP 422 before doing anything**, with the verification command inline so a reader can re-check rather than trust a date. Two generalisations added alongside, because the specific line will rot the way the last one did: **check a lever is `state=active`**, not merely that it exists; and **`gh workflow list` OMITS disabled workflows**, so absence there is not evidence of non-existence.

## Why nobody caught it

Silent in the permissive direction, and the two jobs have near-identical names — one `promote …` job is green on all 30 runs, and **it is not the one carrying the raise**. Anyone glancing at a run summary sees a green promote job and moves on: a true observation about the wrong object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
