### PR TITLE
docs(#3954): name the IR's ambient ECMAScript assumptions + Binaryen pass-overlap experiment

### DIFF
--- a/plan/issues/3954-ir-language-neutral-value-model.md
+++ b/plan/issues/3954-ir-language-neutral-value-model.md
@@ -1,6 +1,6 @@
 ---
 id: 3954
-title: "Prepare the IR for a second source language: factor the JS value model behind a tag-domain seam"
+title: "Name the IR's ambient ECMAScript assumptions: factor the JS value model behind a tag-domain seam"
 status: ready
 sprint: current
 created: 2026-08-01
@@ -15,14 +15,41 @@ language_feature: compiler-internals
 goal: backend-agnostic-ir
 ---
 
-# Prepare the IR for a second source language (Python first)
+# Name the IR's ambient ECMAScript assumptions
 
 ## Problem
 
-The IR is already language-neutral *downward* and JS-specific *upward*, but
-nothing in the tree records or enforces that line — so the JS-specific half is
-free to keep leaking into the neutral half, and the cost of a second producer
-rises silently with every commit.
+**The IR's ECMAScript assumptions are ambient rather than named.** `IrType` does
+not have "a dynamic value type" — it has *ECMAScript's* dynamic value type,
+spelled as a closed enum, and nothing in the tree marks it as such. The type
+lattice, the propagation rules, the truthiness and numeric-coercion predicates
+all encode ECMA-262 semantics as if they were facts about compilation in
+general.
+
+That is a maintainability defect in the JavaScript compiler, independently of
+whether a second front-end ever exists:
+
+- **You cannot tell a spec decision from an engineering decision by reading the
+  code.** When `dynTruthy` treats a value a particular way, is that ECMA-262
+  §7.1.2 or a lowering convenience? Today the only way to know is to already
+  know. Every future change to dynamic-value handling re-litigates that
+  question from scratch.
+- **There is no boundary to violate, so nothing can be reviewed against one.**
+  New JS-specific behaviour lands anywhere in the IR without friction, because
+  no rule says where it belongs. The neutral half and the ECMAScript half are
+  interleaved by accident of authorship.
+- **The two halves have different change rates and different owners.** The
+  neutral half (control flow, calls, closures, layout) is stable compiler
+  infrastructure; the ECMAScript half tracks spec conformance and moves with
+  test262. Interleaving them means conformance churn touches infrastructure and
+  vice versa.
+
+Naming the boundary is the deliverable. A second source language becomes
+*possible* as a side effect, but that is a secondary benefit and this issue
+should not be scheduled or descoped on it — see "Second front-end: honest
+scoping" below.
+
+### The boundary is already half-built
 
 **Downward, the boundary is real and deliberate.** `docs/ir/ir-contract.md`
 (frozen #3030-T1) consistently says **"producer"**, never "the TypeScript
@@ -78,12 +105,48 @@ expensive later:
 - Phase 1 alone is a **behaviour-neutral** change: JS stays the only tag domain,
   the emitted bytes must not move. That makes it safely interleavable with
   in-flight IR work in a way a later big-bang factoring would not be.
+- The ratchet is the durable part. Once the gate exists, the boundary stops
+  eroding whether or not anyone ever writes a second front-end — which is
+  precisely why the justification does not rest on one.
+
+### Second front-end: honest scoping
+
+The original framing of this issue led with "prepare for Python." That
+overstates the payoff and is not why it should be scheduled. For the record, so
+nobody picks this up expecting a bigger prize than there is:
+
+- **Python's structural fit is good.** PEP 484 type hints are to Python what
+  TypeScript is to JavaScript, which is exactly the precondition that makes
+  js2wasm's AOT bet tractable; mypyc already demonstrates the speedup is real.
+  The WasmGC precedents (Kotlin, Dart, Java, OCaml, Scheme) are all typed or
+  already-GC'd languages, and "typed Python" has that shape.
+- **But the addressable niche is narrow.** Essentially every existing
+  Python→Wasm effort (Pyodide, CPython wasm32, componentize-py, RustPython,
+  MicroPython, and py2wasm via Nuitka) ships an interpreter. They do that
+  because the C-extension ecosystem — numpy, scipy, pandas, torch — is written
+  against the CPython C API and a flat `PyObject*` heap. A WasmGC AOT compiler
+  **cannot** run those, not "cannot yet": the object representation is
+  incompatible by construction. For most people asking for Python-in-Wasm, the
+  answer they need is numpy.
+- **What is genuinely unoccupied** is typed Python → standalone WasmGC module,
+  no interpreter, no CPython: edge functions, plugin sandboxes, embedded
+  scripting. Real, but small, and entered behind Codon (LLVM/native-first) and
+  mypyc (needs CPython).
+- **Where the design does clearly beat the interpreter ports:** module size and
+  startup (no runtime to ship), and host-GC integration — WasmGC objects are
+  collected by the host, whereas a linear-memory Python heap is invisible to the
+  host collector, so cycles spanning the boundary leak. That is a structural tax
+  the interpreter ports cannot retrofit away.
+
+**A C++ front-end is not on this axis at all** and is a hard non-goal — see
+Non-goals.
 
 ## Non-goals
 
-- **Not** a Python front-end. This issue does not add `from-python.ts`, a Python
-  parser, or any Python runtime. It makes a second producer *possible*; building
-  one is separate work gated on this landing.
+- **Not** a Python front-end, and **not justified by one**. This issue adds no
+  `from-python.ts`, no Python parser, no Python runtime. It makes a second
+  producer *possible* as a side effect; do not schedule, descope, or cancel this
+  issue based on whether a Python front-end is wanted.
 - **Not** a C++ front-end, now or later. C++ needs value semantics,
   copy/move/destructors, RAII scope-exit lifetimes, raw pointers and pointer
   arithmetic, precise struct layout/ABI, unsigned integer types, and template
@@ -160,6 +223,9 @@ lookup on `dynMemberGet`; MRO / multiple inheritance vs single-inheritance
 - [ ] test262 host and standalone pass counts are unchanged (identical).
 - [ ] A test constructs a non-JS tag domain and lowers IR through the bytecode
       backend with it.
+- [ ] Every ECMA-262-derived predicate moved behind the seam cites its spec
+      clause, so a reader can tell a conformance decision from a lowering
+      convenience — this is the issue's primary deliverable, not a nicety.
 - [ ] `docs/architecture/codegen-axes.md` gains a short "producer axis" note
       naming the seam and stating the C++ non-goal, so the boundary is
       documented where the other axes are.

--- a/plan/issues/3954-ir-language-neutral-value-model.md
+++ b/plan/issues/3954-ir-language-neutral-value-model.md
@@ -1,0 +1,178 @@
+---
+id: 3954
+title: "Prepare the IR for a second source language: factor the JS value model behind a tag-domain seam"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: refactor
+area: compiler
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+---
+
+# Prepare the IR for a second source language (Python first)
+
+## Problem
+
+The IR is already language-neutral *downward* and JS-specific *upward*, but
+nothing in the tree records or enforces that line — so the JS-specific half is
+free to keep leaking into the neutral half, and the cost of a second producer
+rises silently with every commit.
+
+**Downward, the boundary is real and deliberate.** `docs/ir/ir-contract.md`
+(frozen #3030-T1) consistently says **"producer"**, never "the TypeScript
+front-end"; `docs/architecture/target-architecture.md` draws an explicit
+"IR INTERCHANGE BOUNDARY — serializable, versioned (#3030)"; and the five-part
+backend contract (`src/ir/backend/`, frozen #3029-S1) already has three
+in-tree realizations plus `backend/porffor/`. A non-TypeScript producer is
+contemplated by the architecture and partly paid for.
+
+**Upward, the JS value model is hardcoded into the IR's own type system.**
+Measured on `main` at 2026-08-01:
+
+| Signal | Value |
+| --- | --- |
+| `IrInstr` kinds in `src/ir/nodes.ts` (union arms) | **78** |
+| …that are language-neutral (control flow, calls, objects, closures, vecs, slots, refcells, try/throw) | **~40** |
+| …that encode ECMAScript semantics (`dyn*`, `tagTest`, `string.*`, `iter.*`/`gen.*`/`forOf.*`, `await`/`async*`, `extern.*`, `regexp`, `class.super*`) | **~35** |
+| `ts.` references in `src/ir/lower.ts` | **23** (in 4,013 lines — effectively decoupled) |
+| `ts.` references in `src/ir/from-ast.ts` / `select.ts` | **785** / **1,055** |
+
+The load-bearing defect is one type. `JsTag` (`src/ir/js-tag.ts:42`) is a
+**closed enum** — `NumberI32 | NumberF64 | Boolean | String | Object |
+Function | Null | Undefined` — and it is baked directly into the IR's type
+lattice as `IrType = … | { kind: "dynamic"; tag?: JsTag }`
+(`src/ir/nodes.ts:358`). Every dynamic instruction (`tagTest`, `dynTruthy`,
+`dynToNumber`, `dynEq`, `dynMemberGet`, `dynMemberSet`) and the propagation /
+evidence machinery (`propagate.ts`, `type-evidence.ts`, `analysis/lattice.ts`)
+dispatch on that fixed set.
+
+So the IR does not have "a dynamic value type" — it has *ECMAScript's* dynamic
+value type, spelled as an enum no other language can extend. Python's
+`int`/`float`/`str`/`bytes`/`tuple`/`list`/`dict`/`set`/`None`/instance
+partition cannot be expressed at all.
+
+**There is a working counterexample in-tree, which is why this is a refactor
+and not a research project.** Strings are *already* parameterized:
+`IrStringEncoding = "ascii" | "utf8-guaranteed" | "wtf16"`
+(`src/ir/string-runtime.ts:7`). The string half of the value model took the
+shape this issue proposes for the tag half, and nothing broke.
+
+### Why now, and why `high`
+
+The cost is **strictly monotonic in time** and this issue is cheap today and
+expensive later:
+
+- Routing tag reads through a seam is mechanical *now* (one enum, a bounded set
+  of dispatch sites). After another ~40 IR instruction kinds land under
+  `ir-full-coverage`, it is a tree-wide rewrite.
+- It does **not** compete with `ir-full-coverage` for the same files. The
+  adoption work is concentrated in `from-ast.ts`/`select.ts` (the TS-coupled
+  producer); this issue touches `js-tag.ts`, `nodes.ts`, `propagate.ts`,
+  `type-evidence.ts`, `analysis/lattice.ts` — the consumer side.
+- Phase 1 alone is a **behaviour-neutral** change: JS stays the only tag domain,
+  the emitted bytes must not move. That makes it safely interleavable with
+  in-flight IR work in a way a later big-bang factoring would not be.
+
+## Non-goals
+
+- **Not** a Python front-end. This issue does not add `from-python.ts`, a Python
+  parser, or any Python runtime. It makes a second producer *possible*; building
+  one is separate work gated on this landing.
+- **Not** a C++ front-end, now or later. C++ needs value semantics,
+  copy/move/destructors, RAII scope-exit lifetimes, raw pointers and pointer
+  arithmetic, precise struct layout/ABI, unsigned integer types, and template
+  monomorphization. `IrType`'s `object`/`class`/`boxed` kinds all assume
+  GC-managed reference identity and cannot express "destroyed at scope end".
+  A C++ front-end should target LLVM. Explicitly out of scope — do not design
+  for it.
+- **Not** a change to the backend axis. WasmGC vs linear stays exactly as
+  `docs/architecture/codegen-axes.md` describes.
+- **Not** a behaviour change in phase 1. Output must be byte-identical.
+
+## Proposal
+
+Four phases, each independently mergeable. Phases 1–2 are the whole point;
+phases 3–4 are only worth starting once a real second producer is funded.
+
+### Phase 1 — the tag-domain seam (M, behaviour-neutral) ← the actual ask
+
+Replace direct `JsTag` enum reads with an indirection, while JS remains the
+only implementation:
+
+- Introduce a `TagDomain` interface in a dependency-free leaf beside
+  `js-tag.ts`: the set of tags, each tag's Wasm-carrier kind (generalizing
+  `jsTagUnboxKind`), the subtyping/join lattice, and the truthiness / numeric
+  coercion predicates that `dynTruthy` / `dynToNumber` currently hardcode.
+- Make `IrType`'s dynamic leaf carry an opaque tag id resolved against a
+  module-level `TagDomain`, not a bare `JsTag` member.
+- Provide `JS_TAG_DOMAIN` as the sole implementation and wire it at the single
+  place the producer is chosen.
+- Ratchet it: a CI gate (same shape as `check:ir-fallbacks` /
+  `check:oracle-ratchet` — committed baseline, growth fails,
+  `--update-on-decrease` banks improvements) counting direct `JsTag` value
+  imports outside the domain leaf, so the seam cannot silently re-erode.
+
+Acceptance: emitted binaries byte-identical across the change; test262 host and
+standalone pass counts **identical**, not "within tolerance".
+
+### Phase 2 — dialect split of `nodes.ts` (M, mechanical)
+
+Split the 3,271-line `nodes.ts` into a neutral core and a `js` dialect
+(MLIR-style), enforced as a dependency-lint rule rather than a convention.
+This makes "is this instruction neutral?" answerable per instruction by path
+instead of by argument, and it is the artifact that keeps phase 1's win from
+decaying. No behaviour change — declaration moves and re-exports only.
+
+### Phase 3 — prove neutrality without a new front-end (M)
+
+Do **not** validate the seam by writing a Python producer. Validate it with the
+existing `backend/bytecode-vm.ts` plus a synthetic non-JS tag domain
+constructed in tests: build IR carrying a tag domain JS could not produce
+(e.g. arbitrary-precision int, codepoint strings) and assert it lowers and
+verifies. This is the cheap falsification test — if it can't be written, the
+seam is nominal.
+
+### Phase 4 — Python producer, out-of-tree, via the #3030 serialized contract
+
+Only if phases 1–3 land and a Python front-end is actually wanted. It consumes
+the serialized IR as an out-of-tree producer — no changes to `from-ast.ts`.
+Known gaps to solve **there**, not here: arbitrary-precision `int` (nothing in
+`IrType` expresses it); `__getattribute__` + descriptor protocol vs JS property
+lookup on `dynMemberGet`; MRO / multiple inheritance vs single-inheritance
+`IrClassShape`; codepoint vs UTF-16 string indexing (partly covered by
+`IrStringEncoding`).
+
+## Acceptance criteria
+
+- [ ] A `TagDomain` seam exists; `IrType`'s dynamic leaf no longer names
+      `JsTag` directly.
+- [ ] `JS_TAG_DOMAIN` is the only implementation and is wired at one place.
+- [ ] A ratcheted CI gate bounds direct `JsTag` value imports outside the domain
+      leaf, with a committed baseline and an `--update-on-decrease` mode.
+- [ ] Emitted binaries are byte-identical across phase 1 on the
+      `website/playground/examples` corpus.
+- [ ] test262 host and standalone pass counts are unchanged (identical).
+- [ ] A test constructs a non-JS tag domain and lowers IR through the bytecode
+      backend with it.
+- [ ] `docs/architecture/codegen-axes.md` gains a short "producer axis" note
+      naming the seam and stating the C++ non-goal, so the boundary is
+      documented where the other axes are.
+
+## References
+
+- `src/ir/js-tag.ts:42` — the closed `JsTag` enum.
+- `src/ir/nodes.ts:358` — `IrType`'s `{ kind: "dynamic"; tag?: JsTag }` leaf.
+- `src/ir/string-runtime.ts:7` — `IrStringEncoding`, the in-tree precedent for a
+  parameterized value-model dimension.
+- `docs/ir/ir-contract.md` (#3030-T1) — the frozen, producer-neutral IR contract.
+- `docs/architecture/target-architecture.md` — the IR interchange boundary.
+- `src/ir/backend/README.md` (#3029-S1) — the five-part backend contract; the
+  already-neutral half of the pipeline.
+- `docs/architecture/codegen-axes.md` — the two existing orthogonal axes this
+  adds a third to.

--- a/plan/log/binaryen-pass-overlap-experiment.md
+++ b/plan/log/binaryen-pass-overlap-experiment.md
@@ -1,0 +1,176 @@
+# Do our low-level passes still earn their keep once `wasm-opt -O3` runs?
+
+**Date:** 2026-08-01 · **Status:** measured, no code change proposed yet
+
+## Question
+
+`src/optimize.ts` already runs Binaryen's `wasm-opt` over the encoded binary.
+Four of our own passes do work that is squarely inside `wasm-opt -O3`'s
+wheelhouse:
+
+| Pass | File |
+| --- | --- |
+| constant folding | `src/ir/passes/constant-fold.ts` |
+| dead-code elimination | `src/ir/passes/dead-code.ts` |
+| CFG simplification | `src/ir/passes/simplify-cfg.ts` |
+| peephole | `src/codegen/peephole.ts` (284 lines) |
+
+If Binaryen subsumes them, they are maintenance cost with no output benefit.
+This experiment measures each pass's **marginal contribution to the shipped
+artifact** — i.e. the `-O3` output, not the pre-optimizer binary.
+
+## Method
+
+Per-pass kill switches were added at the two call sites
+(`runHygienePasses` in `src/ir/integration.ts`; `peepholeOptimize` in
+`src/codegen/index.ts`) and driven by env vars. Six arms: baseline, each pass
+off individually, and all four off. **The kill switches are experiment
+scaffolding and are NOT part of any commit.**
+
+Three corpora:
+
+- **A — breadth.** All 17 `.ts` files under `website/playground/examples/`
+  (the `check:ir-fallbacks` corpus) plus `benchmarks/suites/`. Size + compile
+  time, median of 5 compiles.
+- **B — behaviour.** The 28 programs in `tests/cross-backend/corpus.ts`, which
+  carry declared call/argument tuples. Each arm instantiates the **`-O3`**
+  binary and records every call's return value, so arms are diffed on
+  observable behaviour, not just byte counts. 24 of 28 instantiate in this
+  harness (4 need `wasm:js-string` / `string_constants` host wiring the harness
+  does not provide); the same 4 are excluded in every arm.
+- **C — scale.** acorn 8.16.0 (231 KB of source → 621 KB raw Wasm), the largest
+  real module the repo compiles, and the one the `benchmark:acorn` dogfood lane
+  already uses.
+
+## Results
+
+### Corpus A — 17 files
+
+| arm | raw bytes | Δraw | **-O3 bytes** | **Δ-O3** | Δ-O3 % | compile ms |
+| --- | --- | --- | --- | --- | --- | --- |
+| baseline | 144,755 | 0 | 98,605 | 0 | 0.000% | 7,513 |
+| no-constfold | 145,134 | +379 | 98,605 | **0** | 0.000% | 7,985 |
+| no-dce | 144,755 | **0** | 98,605 | **0** | 0.000% | 8,055 |
+| no-simplifycfg | 144,755 | **0** | 98,605 | **0** | 0.000% | 7,821 |
+| no-peephole | 147,313 | +2,558 | 98,613 | **+8** | 0.008% | 8,033 |
+| all four off | 147,712 | +2,957 | 98,613 | **+8** | 0.008% | 7,922 |
+
+### Corpus B — 28 executable programs
+
+| arm | raw bytes | Δraw | **-O3 bytes** | **Δ-O3** | observable result diffs |
+| --- | --- | --- | --- | --- | --- |
+| baseline | 26,645 | 0 | 14,080 | 0 | — |
+| no-constfold | 27,850 | +1,205 | 14,080 | **0** | **0** |
+| no-dce | 26,645 | **0** | 14,080 | **0** | **0** |
+| no-simplifycfg | 26,645 | **0** | 14,080 | **0** | **0** |
+| no-peephole | 27,186 | +541 | 14,080 | **0** | **0** |
+| all four off | 28,430 | +1,785 | 14,080 | **0** | **0** |
+
+### Corpus C — acorn 8.16.0
+
+> Run in progress at time of writing — arms complete so far. The `-O3`
+> artifact has not moved by a single byte on any arm measured.
+
+| arm | raw bytes | Δraw | **-O3 bytes** | **Δ-O3** | compile ms (median of 3) |
+| --- | --- | --- | --- | --- | --- |
+| baseline | 620,951 | 0 | 343,881 | 0 | 21,438 |
+| no-constfold | 620,953 | +2 | 343,881 | **0** | 21,065 |
+| no-dce | 620,951 | **0** | 343,881 | **0** | 21,401 |
+| no-simplifycfg | _pending_ | | | | |
+| no-peephole | _pending_ | | | | |
+| all four off | _pending_ | | | | |
+
+### Did each pass do anything at all, pre-`wasm-opt`?
+
+Instrumented `runHygienePasses` to count how many `IrFunction`s each pass
+actually **changed** (reference inequality), so "no size delta" can be told
+apart from "never ran".
+
+| corpus | IR fns through hygiene | constant-fold changed | dead-code changed | simplify-cfg changed |
+| --- | --- | --- | --- | --- |
+| examples + bench suites | 57 | 9 | 13 | **0** |
+| acorn 8.16.0 | **25** | 1 | 2 | **0** |
+
+**This is the most important number in the experiment, and it cuts against a
+deletion.** Only **25** IR functions pass through hygiene for the whole of
+acorn — 621 KB of raw Wasm. The rest of the module is still compiled by the
+legacy direct AST→Wasm front-end, which these passes never see. So the
+measurement above is "what the passes are worth **at today's IR coverage**",
+not "what they are worth". As `ir-full-coverage` (#2855/#3518) advances, these
+passes will see a much larger share of the program and the answer can change.
+
+Two secondary readings:
+
+- `simplify-cfg` changed **0 functions on both corpora**. It is not
+  "redundant with Binaryen" — on this evidence it never fires at all. That is a
+  different (and more actionable) finding than redundancy.
+- `dead-code` **did** change 13 functions on corpus A and 2 on acorn, yet the
+  raw binary was byte-identical in both. Its edits are absorbed downstream
+  before encoding, independently of `wasm-opt`.
+
+## Reading
+
+1. **`wasm-opt -O3` absorbs essentially all of it.** Turning off all four passes
+   grows the pre-optimizer binary by 2.0% (corpus A) / 6.7% (corpus B) and moves
+   the shipped `-O3` artifact by **8 bytes out of 98,605** (corpus A) and **0
+   bytes** (corpus B). On acorn, no arm measured so far moves the `-O3`
+   artifact at all.
+2. **…but the passes barely run.** Only 25 IR functions in all of acorn reach
+   the hygiene pipeline. A pass cannot demonstrate value on code it never
+   sees, so this is weak evidence for redundancy and strong evidence that the
+   experiment must be repeated after IR adoption advances.
+3. **No behaviour changed.** 24 executable programs × every declared call,
+   zero diffs in any arm.
+4. **Compile time is not a reason to keep or drop them.** The spread across arms
+   (7,513–8,055 ms) is smaller than run-to-run variance and is not ordered by
+   how much work was disabled — the slowest arm (`no-dce`) disables a pass that
+   provably does nothing.
+
+## What this does NOT establish
+
+- **Runtime performance was not measured** — only size and observable results.
+  A pass could in principle produce faster code at the same size; nothing here
+  rules that out.
+- **These passes may be load-bearing for something other than output.** IR
+  verification, later-pass preconditions, or compile-time blowup on pathological
+  input are all plausible; none were tested.
+- **`--optimize` is opt-in.** `optimizeBinaryAsync` no-ops when neither the
+  `binaryen` package nor a system `wasm-opt` is present, and the CLI only runs
+  it under `--optimize`/`-O`. Every number above assumes the optimizer runs;
+  in an unoptimized build these passes are worth 2–7% of binary size.
+
+## Recommendation
+
+**Do not delete these passes on this evidence.** The original hypothesis
+("Binaryen subsumes them, so they are pure maintenance cost") is not what the
+data shows. What the data shows is that the passes are *nearly unexercised*,
+which is a coverage finding, not a redundancy finding — and deleting code
+because it is currently unreachable is how you discover why it existed.
+
+Scoped follow-ups, in priority order:
+
+1. **`simplify-cfg` fired zero times on both corpora.** Find out whether it is
+   dead code, gated off, or simply never applicable to the shapes IR currently
+   claims. This is the one cheap, decisive question here.
+2. **Re-run this experiment after `ir-full-coverage` advances.** The 25-of-acorn
+   figure is the gate: when the IR front-end claims most of a module, the
+   measurement becomes meaningful. Until then it cannot settle the question.
+3. **Add a runtime arm.** Only size and observable results were measured; a pass
+   could produce faster code at identical size.
+4. **Check for downstream preconditions** (verifier, later IR passes, backend
+   legality) before any deletion is contemplated.
+5. **Settle the unoptimized-build policy.** `--optimize` is opt-in; without it
+   these passes are worth 2–7% of binary size outright.
+
+The passes that are **not** candidates for deletion, and were not tested here:
+`monomorphize.ts`, `tagged-unions.ts`, `alloc-discipline.ts`, and everything in
+`src/ir/analysis/` (`escape`, `ownership`, `stack-alloc`, `string-evidence`,
+`encoding`). Those depend on JS-level facts that are destroyed by lowering, so
+Binaryen structurally cannot do them.
+
+## Reproducing
+
+Harnesses live in `.tmp/ab/` (gitignored, not committed):
+`ab-passes.mts` (corpus A), `ab-exec.mts` (corpus B), `ab-acorn.mts` (corpus C),
+`ab-stats.mts` (effectiveness counts), `compare.mjs` (diff the arms).
+They require the kill-switch patches described under Method.

--- a/plan/log/binaryen-pass-overlap-experiment.md
+++ b/plan/log/binaryen-pass-overlap-experiment.md
@@ -1,6 +1,6 @@
 # Do our low-level passes still earn their keep once `wasm-opt -O3` runs?
 
-**Date:** 2026-08-01 · **Status:** measured, no code change proposed yet
+**Date:** 2026-08-01 · **Status:** complete — measured, no code change proposed
 
 ## Question
 
@@ -68,17 +68,19 @@ Three corpora:
 
 ### Corpus C — acorn 8.16.0
 
-> Run in progress at time of writing — arms complete so far. The `-O3`
-> artifact has not moved by a single byte on any arm measured.
+| arm | raw bytes | Δraw | **-O3 bytes** | **Δ-O3** | Δ-O3 % | compile ms (median of 3) |
+| --- | --- | --- | --- | --- | --- | --- |
+| baseline | 620,951 | 0 | 343,881 | 0 | 0.000% | 21,438 |
+| no-constfold | 620,953 | +2 | 343,881 | **0** | 0.000% | 21,065 |
+| no-dce | 620,951 | **0** | 343,881 | **0** | 0.000% | 21,401 |
+| no-simplifycfg | 620,951 | **0** | 343,881 | **0** | 0.000% | 22,416 |
+| no-peephole | 637,635 | +16,684 | 343,935 | **+54** | 0.016% | 19,925 |
+| all four off | 637,637 | +16,686 | 343,935 | **+54** | 0.016% | 20,054 |
 
-| arm | raw bytes | Δraw | **-O3 bytes** | **Δ-O3** | compile ms (median of 3) |
-| --- | --- | --- | --- | --- | --- |
-| baseline | 620,951 | 0 | 343,881 | 0 | 21,438 |
-| no-constfold | 620,953 | +2 | 343,881 | **0** | 21,065 |
-| no-dce | 620,951 | **0** | 343,881 | **0** | 21,401 |
-| no-simplifycfg | _pending_ | | | | |
-| no-peephole | _pending_ | | | | |
-| all four off | _pending_ | | | | |
+On the largest real module in the repo, the entire contribution of all four
+passes to the shipped artifact is **54 bytes out of 343,881** — and every one
+of those 54 bytes comes from `peephole`. The three IR passes together move the
+`-O3` output by **zero bytes** and the pre-optimizer binary by **2 bytes**.
 
 ### Did each pass do anything at all, pre-`wasm-opt`?
 
@@ -120,7 +122,11 @@ Two secondary readings:
    sees, so this is weak evidence for redundancy and strong evidence that the
    experiment must be repeated after IR adoption advances.
 3. **No behaviour changed.** 24 executable programs × every declared call,
-   zero diffs in any arm.
+   zero diffs in any arm. Independently confirmed by the equivalence gate:
+   with all four passes disabled, `SHARD=1/8 node scripts/equivalence-gate.mjs`
+   reported `5 failing, 178 passing, 36 known-failures in baseline` and
+   `✓ No new equivalence regressions` — every failure already in the committed
+   baseline, none introduced by disabling the passes.
 4. **Compile time is not a reason to keep or drop them.** The spread across arms
    (7,513–8,055 ms) is smaller than run-to-run variance and is not ordered by
    how much work was disabled — the slowest arm (`no-dce`) disables a pass that
@@ -140,6 +146,16 @@ Two secondary readings:
   in an unoptimized build these passes are worth 2–7% of binary size.
 
 ## Recommendation
+
+**Split the verdict by pass — they are not one decision.**
+
+- `peephole` is the only one of the four with a measurable output effect, and
+  it is tiny but real and consistent: +8 bytes on corpus A, +54 on acorn, 0 on
+  corpus B. It also does the most pre-optimizer work of the four (+2.7% raw on
+  acorn). It is not a deletion candidate on this evidence.
+- The three IR passes (`constant-fold`, `dead-code`, `simplify-cfg`) contribute
+  **zero bytes** to the shipped artifact on every corpus measured. But see the
+  coverage caveat below before reading that as redundancy.
 
 **Do not delete these passes on this evidence.** The original hypothesis
 ("Binaryen subsumes them, so they are pure maintenance cost") is not what the
@@ -170,7 +186,21 @@ Binaryen structurally cannot do them.
 
 ## Reproducing
 
-Harnesses live in `.tmp/ab/` (gitignored, not committed):
-`ab-passes.mts` (corpus A), `ab-exec.mts` (corpus B), `ab-acorn.mts` (corpus C),
-`ab-stats.mts` (effectiveness counts), `compare.mjs` (diff the arms).
-They require the kill-switch patches described under Method.
+The harnesses were scratch files under `.tmp/` and did not survive the session
+(the equivalence gate clears that directory). They are not recoverable, so
+reproduction means rebuilding them from this description — which is why the
+method is spelled out concretely above rather than by reference:
+
+1. Add env-gated early-outs at `runHygienePasses` (`src/ir/integration.ts`) for
+   the three IR passes and at both `peepholeOptimize(mod)` call sites
+   (`src/codegen/index.ts`). Six arms: baseline, each pass off, all four off.
+2. For each corpus, `compile()` each source, then `optimizeBinaryAsync(binary,
+   { level: 3 })`, and record `binary.byteLength` before and after.
+   acorn needs `{ fileName: "acorn.mjs", skipSemanticDiagnostics: true }` and
+   `setupAcorn()` from `tests/dogfood/setup-acorn.mjs`.
+3. For corpus B, instantiate the **-O3** binary and invoke each program's
+   declared `calls` from `tests/cross-backend/corpus.ts`, diffing return values
+   across arms.
+4. For the effectiveness counts, instrument `runHygienePasses` to count
+   reference-inequality per pass per `IrFunction`.
+5. For correctness, run `scripts/equivalence-gate.mjs` with all four disabled.


### PR DESCRIPTION
## Description

Docs and planning only — no compiler behaviour change, no `src/` diff.

### 1. New issue #3954 — name the IR's ambient ECMAScript assumptions

`IrType` does not have "a dynamic value type", it has *ECMAScript's* dynamic value type: `JsTag` (`src/ir/js-tag.ts:42`) is a closed enum baked directly into the type lattice at `src/ir/nodes.ts:358`, and every dynamic instruction plus `propagate.ts` / `type-evidence.ts` / `analysis/lattice.ts` dispatches on it. Nothing in the tree marks that as an ECMA-262 commitment rather than a general fact about compilation.

The issue is justified on the **JavaScript compiler's own maintainability**, not on a future second front-end:

- you cannot tell a spec decision from a lowering convenience by reading the code;
- there is no boundary for review to enforce, so JS-specific behaviour lands anywhere in the IR without friction;
- the neutral half (stable infrastructure) and the ECMAScript half (conformance churn, moves with test262) are interleaved despite having different change rates.

Phase 1 is behaviour-neutral (JS stays the only tag domain, emitted bytes must not move) and ends in a ratchet gate of the same shape as `check:ir-fallbacks` / `check:oracle-ratchet`, so the boundary stops eroding. The in-tree precedent is `IrStringEncoding` (`src/ir/string-runtime.ts:7`) — the string half of the value model already took this shape.

A second source language becomes possible as a side effect. That is scoped honestly in the issue rather than used as the justification: the Python fit is structurally good (PEP 484 hints are to Python what TypeScript is to JS), but the niche is narrow, because every existing Python→Wasm effort ships an interpreter to keep the C-extension ecosystem, which a WasmGC AOT compiler cannot run by construction. A C++ front-end is an explicit hard non-goal — `IrType`'s `object`/`class`/`boxed` kinds assume GC-managed reference identity and cannot express RAII scope-exit lifetimes.

Issue id reserved atomically via `claim-issue.mjs` on `origin/issue-assignments`.

### 2. Experiment log — do our low-level passes still earn their keep under `wasm-opt -O3`?

Measured whether `constant-fold` / `dead-code` / `simplify-cfg` / `peephole` still contribute now that `src/optimize.ts` runs `wasm-opt` downstream. Six arms (baseline, each pass off, all four off) via temporary kill switches, across three corpora. **The kill switches were scaffolding and are not in this diff.**

Contribution of all four passes to the shipped `-O3` artifact:

| corpus | -O3 baseline | all four off | delta |
| --- | --- | --- | --- |
| 17 playground/benchmark files | 98,605 B | 98,613 B | +8 B (0.008%) |
| 28 executable cross-backend programs | 14,080 B | 14,080 B | 0 B |
| acorn 8.16.0 (621 KB raw Wasm) | 343,881 B | 343,935 B | +54 B (0.016%) |

Pre-optimizer the same change costs +2.0% / +6.7% / +2.7%, so `wasm-opt` is absorbing nearly all of it. Correctness held: zero observable diffs across 24 executable programs × every declared call, and `scripts/equivalence-gate.mjs` with all four disabled reported `5 failing, 178 passing, 36 known-failures in baseline` → `No new equivalence regressions`.

**The log recommends against deletion**, because the headline number does not mean what it looks like. Instrumenting the pipeline showed only **25 IR functions in all of acorn** reach `runHygienePasses` — the rest of the module still compiles through the legacy AST→Wasm front end. A pass cannot demonstrate value on code it never sees, so this is a coverage finding, not a redundancy finding, and the experiment has to be repeated as `ir-full-coverage` advances. The verdict also splits per pass: `peephole` accounts for all 54 of acorn's bytes and is not a candidate; the three IR passes contribute nothing measurable. The one directly actionable result is that **`simplify-cfg` changed zero functions on every corpus** — worth one cheap investigation into whether it is dead, gated off, or simply never applicable to the shapes IR currently claims.

Not established, and stated as such in the log: runtime performance was not measured (size and observable results only), downstream preconditions were not checked, and `--optimize` is opt-in — in an unoptimized build these passes are worth 2–7% of binary size outright.

### Note on the docs-PR consolidation rule

`CLAUDE.md` asks docs-only changes to go onto one open docs PR rather than opening a second. There are open docs PRs (#3877, #3919, #3927), but this session is pinned to the branch `claude/ir-generalization-python-cpp-w1ik1v` and instructed not to push to another branch, so pushing these commits onto another lane's branch was not available. Flagging it so the queue owner can fold or close as they prefer.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8WZU98KY8TzEsktMcbZEm)_