### PR TITLE
fix(#3909, #3910): two stale-premise codegen bugs behind one "needs three features" surface

### DIFF
--- a/plan/issues/3909-trimstart-validation-multifeature-module.md
+++ b/plan/issues/3909-trimstart-validation-multifeature-module.md
@@ -1,9 +1,10 @@
 ---
 id: 3909
 title: "__str_trimStart fails Wasm validation when JSON.stringify + regex + case conversion appear in one module"
-status: ready
+status: done
 created: 2026-07-31
-updated: 2026-07-31
+updated: 2026-08-01
+completed: 2026-08-01
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -15,11 +16,15 @@ sprint: Backlog
 horizon: m
 es_edition: multi
 related: [3900, 3910]
+loc-budget-allow:
+  - src/ir/integration.ts
+func-budget-allow:
+  - src/ir/integration.ts::compileIrPathFunctions
 ---
 
 # #3909 — `__str_trimStart` mis-validates in a multi-feature module
 
-## Status: open — pre-existing, surfaced during #3900
+## Status: fixed
 
 ## Problem
 
@@ -61,3 +66,211 @@ Found by `issue-3900-case-convert` while probing case conversion. It verified
 the failure **reproduces identically on the parent commit**, so it is
 pre-existing and not caused by that work. Reported rather than fixed, correctly
 — it was out of that issue's scope.
+
+## Resolution
+
+### Repro and exact error
+
+Reproduced by enumerating all 455 three-feature fast-mode combinations from a
+15-feature list. Exactly 13 fail in `__str_trimStart`, and every one of them is
+`JSON.stringify` + a regex + one more feature:
+
+```ts
+export function run(): number {
+  const s = "  Hello World Test String  ";
+  const j = JSON.stringify({ a: 1, b: "x" });
+  const lc = s.toLowerCase();
+  const mm = s.match(/l/);
+  return j.length + lc.length + (mm === null ? 0 : 1);
+}
+```
+
+```
+Compiling function #27:"__str_trimStart" failed:
+  i32.trunc_sat_f64_s[0] expected type f64, found call of type i32
+```
+
+**The validator's wording is not stable across main** — it was
+`call[0] expected type (ref null 6), found i32.trunc_sat_f64_s of type i32`
+before #3907 (which removed fast mode's blanket i32 narrowing and so changed
+the surrounding types). Re-verified on current `main`: same function, same
+mechanism, different message. Do not key on the message text.
+
+Decoding the emitted call targets is what actually identifies it. On current
+`main` the module has 8 imports and 63 defined functions, and
+`__str_trimStart`'s body reads:
+
+```
+call  9 -> __str_flatten     (correct)
+call 24 -> __sh_str_isWs     (WRONG — should be 25, __str_ws_start)
+call 14 -> __str_compare     (WRONG — should be 15, __str_substring)
+```
+
+The tail is `s.substring(i, len)`; it lands on `__str_compare`, which takes
+**two** parameters, not three. The validator matches the 3-operand stack
+against a 2-param signature and reports the mismatch at whichever operand
+happens to line up. Off by exactly one, on **both** helper calls in the body.
+
+### This is a DIFFERENT root cause from #3910
+
+They share a surface (fast mode, validation failure, "needs several features")
+and nothing else. #3910 is a mis-ordered coercion insertion in
+`stack-balance.ts`. #3909 is a stale function index.
+
+This was settled by A/B on current `main`, reverting each fix independently:
+
+| build | regex repros | `__str_trimStart` |
+| --- | --- | --- |
+| both fixes | valid | valid |
+| only #3910 fix | valid | **still broken** |
+| only #3909 fix | **still broken** | valid |
+| neither | broken | broken |
+
+Each fix is necessary; neither is sufficient. Two root causes, not one.
+
+### Root cause: a stable handle downgraded to a live index, then lost by the shift guard
+
+`resolveNativeStrHelper` (`src/codegen/stdlib-selfhost.ts`) resolved a helper
+by scanning `ctx.mod.functions` and returning `ctx.numImportFuncs + i` — a
+**LIVE-regime** index — *before* consulting `ctx.nativeStrHelpers`. Since
+#1916 S3 that map holds **STABLE-regime handles** (`mintDefinedFunc`,
+`>= STABLE_FUNC_BASE`): layout-independent ids no shifter touches, which
+`resolveLayout` maps to a concrete index once, at emit, off the final layout.
+The name scan was preferred because of a comment that predates S3 ("the helpers
+map bakes registration-time indices that late-import passes do not re-shift").
+That premise is now inverted: the stable handle is the one that cannot go
+stale, and the scan is the fragile option.
+
+Why the live index then dies — and why it takes three features. Shifters decide
+what to move with `inLiveShiftRange(idx, importsBefore)`, i.e.
+`idx >= importsBefore`. A baked live index is a defined-function reference, but
+on the wire it is only a number. Once enough imports accumulate that
+`importsBefore` climbs **above** that number, the guard reads the stale
+reference as "an import index below the insertion point" and stops shifting it.
+It is then permanently short by the batches that crossed it.
+
+Measured on the repro (instrumented `addImport`, instrumentation since removed):
+
+```
+bake:                        __str_substring -> 61   (numImportFuncs = 54)
+addImport env.string_match   numImports=55  lastCall=61  trueSub=62  delta=-1
+… 18 more union/typeof imports …
+addImport env.__typeof       numImports=73  lastCall=61  trueSub=80  delta=-19
+addImport env.JSON_stringify numImports=74  lastCall=79  trueSub=81  delta=-2
+```
+
+The divergence opens at the **first** import after the bake and is never fully
+repaired; the deferred reconcile re-applies +18 where +19 was owed. After DCE
+renumbering that residual lands as the observed off-by-one.
+
+The feature-count threshold is now explicit: you need enough imports for the
+running count to cross the baked index. One feature never gets there. A regex
+contributes `RegExp_new` + `string_match`, `JSON.stringify` contributes
+`JSON_stringify` plus the `__str_from_mem` / `__str_to_mem` /
+`__str_extern_len` bridge, and the union/`typeof` block rides along — together
+they clear it. "Only fails with three features" was a **threshold effect**, not
+a feature interaction.
+
+This is precisely the unsoundness `src/emit/resolve-layout.ts` documents:
+*"identity must ride IN the instruction (a handle), because a numeric index is
+ambiguous across shifts — any idx-keyed repair map is unsound."*
+
+### Fix — one shared resolver, applied systemically
+
+New `nativeStrHelperHandle(ctx, name)` in `src/codegen/func-space.ts` (the
+handle authority module): **stable handle first**, then the historical
+positional scan, then whatever the map holds. Helpers still on stable minting
+skip the fragile step entirely; anything not yet migrated behaves exactly as
+before, so the change is strictly safer at every site.
+
+Seven call sites carrying the same outdated comment now route through it:
+
+| file | site |
+| --- | --- |
+| `src/codegen/stdlib-selfhost.ts` | `resolveNativeStrHelper` (the #3909 site) |
+| `src/codegen/statements/loops.ts` | `for…of` over a string — `__str_flatten` / `__str_substring` (#1186) |
+| `src/codegen/string-builder.ts` | `lookupModuleFuncByName` — `__str_flatten` / `__str_buf_next_cap` (#1210) |
+| `src/ir/integration.ts` | `computeStringBackend` — `__str_concat` / `__str_equals` / `__str_concat_owned` |
+| `src/ir/integration.ts` | `IR_STRING_COMPARE_FN` → `__str_compare` |
+| `src/ir/integration.ts` | `makeResolver`'s generic native-helper fallback (#1183) |
+| `src/ir/integration.ts` | `emitStringCharAt` → `__str_charAt` |
+
+Only the first was demonstrably failing; the other six were the same latent
+hazard one import-count threshold away.
+
+**The stale comments were also corrected, and that is part of the fix, not
+cosmetics.** The bug's proximate cause was a comment that outlived its facts:
+several sites asserted "`ctx.nativeStrHelpers` is stale post-shift, so resolve
+by name against `ctx.mod.functions`", which stopped being true at #1916 S3 and
+inverted into a hazard. Two such comments survived the call-site migration
+(`src/ir/integration.ts` Phase-3 entry, and the `StringBackendIndices` doc) and
+have been rewritten to state the current invariant. Leaving them would have
+re-seeded this exact bug for the next reader. That rewrite is the growth the
+`loc-budget-allow` / `func-budget-allow` keys above cover.
+
+### Sweep for other stale-index consumers
+
+1. **`nativeStrHelpers` is now provably clean.** Instrumenting
+   `nativeStrHelperHandle` across 5 string/regex-heavy modules × host and fast
+   modes, **every** resolution reported `STABLE` — 0 `LIVE`, 0 `MISS`. The
+   positional-scan fallback is never taken in practice, so the fix is total
+   for this family rather than partial. Every `nativeStrHelpers.set` site was
+   confirmed to source its value from `mintDefinedFunc`.
+2. **The remaining positional scan-by-name in the WasmGC path is safe.**
+   `findFuncByName` in `stackBalance` (`src/codegen/stack-balance.ts`) resolves
+   `__box_number` / `__unbox_number` by scan, but `stackBalance` is a post-hoc
+   pass over the **final** module: it derives `numImports` and consumes the
+   index within the same pass, with nothing appending after. No
+   append-after-capture window exists.
+3. **`ensureLateImport` sites are not this hazard** — e.g. the
+   `__extern_toString` path in `array-methods.ts` uses the sanctioned
+   late-import mechanism, which drives the shifters rather than baking behind
+   their backs.
+4. **Not swept: `src/codegen-linear/`.** `runtime.ts:4088` and `c-abi.ts:49`
+   carry the same positional scan-by-name shape, but the linear backend is a
+   separate pipeline that does not use the WasmGC late-import shifters. Both
+   look like same-pass compute-and-consume, but this was **not verified** — see
+   "Not verified" below.
+
+### Verification
+
+- All 13 `__str_trimStart` failures gone; zero Wasm validation failures remain
+  in the 455-combo corpus.
+- Both stale calls in the body are repaired (`24 → 25`, `14 → 15`).
+- Benchmark suites (`strings`/`arrays`/`mixed`, host + fast) byte-identical
+  before/after; playground + examples corpus identical.
+- Tests in `tests/issue-3909-3910-index-and-argcoerce.test.ts` assert the
+  module validates AND that `__str_trimStart`'s tail call resolves to
+  `__str_substring` and specifically not to `__str_compare`. 5 of the 6 fail on
+  the unfixed compiler; the 6th is a deliberate non-regression guard.
+- Scoped suites green on current `main`: 431 tests across the self-host,
+  native-string, standalone-string, regex, `for…of`-string, string-builder,
+  JSON-stringify and IR-string surfaces.
+- Gates green: `typecheck`, `lint`, `format:check`, `check:oracle-ratchet`,
+  `check:stack-balance`, `check:coercion-sites`, `check:test-vacuity-shapes`.
+
+### Not verified
+
+- `src/codegen-linear/runtime.ts:4088` and `src/codegen-linear/c-abi.ts:49`
+  were identified as carrying the same scan shape but **not** exercised or
+  proven safe. They are in a separate backend that this change does not touch.
+- The `check:godfiles` gate fails on `src/codegen/index.ts#generateMultiModule`
+  and `#planIrOverlay`. That file is **not** touched by this change (empty
+  diff) — the failure is pre-existing on `main`, not attributable here.
+- `tests/imported-string-constants.test.ts` has 4 failures. Confirmed
+  **pre-existing** by A/B against a fully-reverted tree on the same commit;
+  identical failures with and without this change.
+
+### Relationship to #3902's gating-mismatch family
+
+Not that family. The scope note asked whether `import-collector.ts` gates a
+helper one way and its consumer another (#3902). It does not here — this is an
+index-identity defect, orthogonal to helper gating. No gating audit is
+warranted on this evidence.
+
+### Residual (separate issue)
+
+The repro modules now validate but still fail at runtime, because fast-mode
+regex passes native-string GC structs straight to the JS `RegExp` constructor
+without the `__str_flatten` + `__str_to_extern` bridge — see the residual
+section of #3910. Pre-existing, representation-level, out of scope here.

--- a/plan/issues/3910-regex-plus-string-constants-global-get.md
+++ b/plan/issues/3910-regex-plus-string-constants-global-get.md
@@ -1,9 +1,10 @@
 ---
 id: 3910
 title: "A module combining a regex literal with string constants mis-resolves a global.get in `run`"
-status: ready
+status: done
 created: 2026-07-31
-updated: 2026-07-31
+updated: 2026-08-01
+completed: 2026-08-01
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -15,11 +16,15 @@ sprint: Backlog
 horizon: m
 es_edition: multi
 related: [3900, 3909]
+loc-budget-allow:
+  - src/codegen/stack-balance.ts
+func-budget-allow:
+  - src/codegen/stack-balance.ts::fixCallArgTypesInBody
 ---
 
 # #3910 — regex literal + string constants mis-resolves `global.get` in `run`
 
-## Status: open — pre-existing, surfaced during #3900
+## Status: fixed
 
 ## Problem
 
@@ -62,3 +67,140 @@ Filed separately from #3909 (the `__str_trimStart` multi-feature validation
 failure) because the two have different symptoms and different index spaces,
 but they surfaced together and may share a root cause. Whoever picks up one
 should read the other.
+
+## Resolution
+
+### It is NOT an index shift, and NOT a global-index problem at all
+
+The reported symptom — "the wrong global index is read" — is a misreading of
+the validator message. Both string globals involved are `(ref null $AnyString)`
+and both `global.get`s target the correct global. What is wrong is the
+**coercion**: one of the two arguments reaches the host import unconverted.
+
+The premise in the Scope section ("which pass allocates globals, whether
+anything appends after capture") therefore has no answer, because no global
+index ever goes stale here. Acceptance criterion 3 — "other consumers of global
+indices that could go stale" — is likewise vacuous for this bug; the
+equivalent sweep that *was* warranted is the **function**-index one, and it
+lives in #3909.
+
+Nor is a string constant required. The minimal repro has **no user string
+literal at all**:
+
+```ts
+export function run(s: string): number {
+  const re = /o/;
+  return re.test(s) ? 1 : 0;
+}
+```
+
+compiled with `fast: true` (native strings) fails with
+
+```
+call[1] expected type externref, found global.get of type (ref null 7)
+```
+
+A regex literal *always* materialises two native-string globals of its own —
+the pattern and the (possibly empty) flags — and feeds them to
+`RegExp_new(externref, externref)`. That is the whole trigger. "Regex + string
+constants" was a coincidence of the reporter's repro; "three features" was a
+coincidence of #3909's repro, which is a genuinely different bug.
+
+### Root cause: `insertions` are applied in ascending position order
+
+`fixCallArgTypesInBody` (`src/codegen/stack-balance.ts`) walks **backward**
+from a call to find arguments whose produced type does not match the callee's
+parameter type, queueing `{ afterPos, instrs }` for each. Because the walk runs
+backward, the queue comes out in **descending** `afterPos` order. It was then
+drained back-to-front:
+
+```ts
+// Apply insertions in reverse order (so positions don't shift)
+for (let k = insertions.length - 1; k >= 0; k--) { … body.splice(afterPos + 1, …) }
+```
+
+which iterates it in **ascending** order — exactly the order that shifts every
+position not yet applied. The comment's premise ("reverse order ⇒ positions
+don't shift") only holds if the queue is ascending, and it never is.
+
+Traced on the repro (`JS2_DEBUG` instrumentation, since removed):
+
+```
+insertions=[{afterPos:1,[extern.convert_any]},{afterPos:0,[extern.convert_any]}]
+after=[global.get $pattern, extern.convert_any, extern.convert_any,
+       global.get $flags, call $RegExp_new, …]
+```
+
+Both coercions landed on the **pattern**; the **flags** got none. The later
+`fixupExternConvertAny` repair pass then removed the second (correctly — it saw
+an already-`externref` operand), which is why the emitted WAT showed a single,
+innocent-looking `extern.convert_any` and hid the real shape.
+
+So the defect is: **any call with two or more mismatched arguments mis-places
+every coercion after the first.** One-mismatch calls — the overwhelming
+majority — were unaffected, which is why this survived.
+
+### Fix
+
+`src/codegen/stack-balance.ts` — sort `insertions` descending by `afterPos` and
+apply highest-first. The backward walk already produces that order; sorting
+makes the invariant explicit so a future change to the walk cannot silently
+resurrect the bug. The comment is rewritten to state why ascending is the wrong
+order, since the original comment's incorrect premise is what preserved the bug
+(the `loc-budget-allow` / `func-budget-allow` keys above cover that growth).
+
+### Relationship to #3909 — separate root causes, confirmed by A/B
+
+Verified on current `main` by reverting each fix independently:
+
+| build | regex repros | `__str_trimStart` |
+| --- | --- | --- |
+| both fixes | valid | valid |
+| only #3910 fix | valid | **still broken** |
+| only #3909 fix | **still broken** | valid |
+| neither | broken | broken |
+
+Each fix is necessary and neither is sufficient. They are **not** one shared
+root cause, despite the shared surface (fast mode, validation failure,
+"needs several features"). The generalisable lesson is the one the two share as
+a *class*: both were caused by a **comment whose premise had silently become
+false**, and in both cases the code was faithfully implementing the stale
+comment.
+
+### Blast radius
+
+A sweep over 455 three-feature fast-mode modules, the four benchmark suites and
+the playground/examples corpus found ~60 call sites with 2+ queued coercions
+(`csv-parse`, `replaceAll` with 3, several DOM examples). Benchmark results are
+byte-identical before/after; every Wasm **validation** failure in the 455-combo
+corpus disappears.
+
+### Residual, out of scope: fast-mode regex never reaches the host correctly
+
+With the module now valid, fast-mode regex fails one layer down at runtime:
+`RegExp_new` receives the two native-string GC structs as opaque externrefs and
+V8 reports `Invalid flags supplied to RegExp constructor '[object Object]'`.
+`compileRegExpLiteral` does not route its arguments through the
+`__str_flatten` + `__str_to_extern` bridge the way `console.log` does
+(`src/codegen/expressions/builtins.ts:86-97`), and `RegExp_test` has the same
+gap for its subject string. That is a **representation** defect (runtime, not
+validation) in the #3912 family, pre-existing and independent — before this fix
+the module did not even validate. Worth its own issue.
+
+The regression test therefore asserts the validation property
+(`WebAssembly.validate`) plus the emitted argument shape, not a `run()` result.
+
+### Tests
+
+`tests/issue-3909-3910-index-and-argcoerce.test.ts` — the bare regex literal,
+the reported regex + string-constant form, and a structural assertion that each
+`global.get` feeding `RegExp_new` carries its own `extern.convert_any`. All
+three fail on the unfixed compiler.
+
+### Not verified
+
+- The `~60 call sites with 2+ queued coercions` figure and the
+  byte-identical-benchmark claim are carried over from the pre-interruption
+  investigation and were **not** re-measured against current `main` (which has
+  since taken #3899–#3908). The validation results in the table above *were*
+  re-verified on current `main`.

--- a/src/codegen/func-space.ts
+++ b/src/codegen/func-space.ts
@@ -78,6 +78,61 @@ export function definedFuncHandleOf(ctx: CodegenContext, func: WasmFunction): Fu
 }
 
 /**
+ * (#3909) Resolve a native-string runtime helper to a function handle,
+ * STABLE-regime handle first.
+ *
+ * ## Why this exists
+ *
+ * Half a dozen call sites used to resolve these helpers with a positional scan
+ * (`for i in mod.functions … return ctx.numImportFuncs + i`), each carrying a
+ * comment saying `ctx.nativeStrHelpers` "captures funcIdx at registration time
+ * and is not re-shifted by late-import passes". That was true before #1916 S3.
+ * It is now inverted: every `nativeStrHelpers` entry is minted by
+ * `mintDefinedFunc`, i.e. a STABLE handle (`>= STABLE_FUNC_BASE`) that no
+ * shifter touches and that `resolveLayout` maps to a concrete index exactly
+ * once, at emit, off the FINAL layout. The positional scan produces the
+ * opposite: a LIVE index that is correct only until the next import lands, and
+ * from then on depends on every shifter chasing it correctly.
+ *
+ * ## The failure that chase produces (#3909, and the reason this is unsound
+ * rather than merely fragile)
+ *
+ * Shifters decide what to move with `inLiveShiftRange(idx, importsBefore)`,
+ * i.e. `idx >= importsBefore`. A baked live index is a defined-function
+ * reference, but it is just a number: once enough imports accumulate that
+ * `importsBefore` climbs ABOVE that number, the guard reads the stale
+ * reference as "an import index below the insertion point" and stops shifting
+ * it. The reference is then permanently short by exactly the batches that
+ * crossed it.
+ *
+ * Measured on the #3909 repro: `__str_trimStart`'s call to `__str_substring`
+ * was baked as 61 with 54 imports; the 19 union/`typeof` imports that follow
+ * push `importsBefore` past 61, one batch stops applying, and the call ends up
+ * one slot low — landing on `__str_compare`, which takes 2 args instead of 3.
+ * Wasm validation then rejects the helper with
+ * "call[0] expected type (ref null 6), found i32.trunc_sat_f64_s of type i32".
+ * This is exactly the ambiguity `src/emit/resolve-layout.ts` documents: "a
+ * numeric index is ambiguous across shifts — any idx-keyed repair map is
+ * unsound". It also explains the "only breaks with three features" signature —
+ * you need enough imports for the count to cross the baked index.
+ *
+ * ## Contract
+ *
+ * Stable handle → return it (correct by construction, immune to every shift).
+ * Otherwise → fall back to the historical positional scan, then to whatever the
+ * map holds. So for any helper not yet on stable minting, behaviour is byte-for
+ * byte what it was; for helpers that are, the fragile step is skipped entirely.
+ */
+export function nativeStrHelperHandle(ctx: CodegenContext, helperName: string): FuncHandle | undefined {
+  const stable = ctx.nativeStrHelpers.get(helperName);
+  if (stable !== undefined && stable >= STABLE_FUNC_BASE) return stable;
+  for (let i = 0; i < ctx.mod.functions.length; i++) {
+    if (ctx.mod.functions[i]!.name === helperName) return ctx.numImportFuncs + i;
+  }
+  return stable;
+}
+
+/**
  * Replace the defined-function record for an absolute function handle
  * (patch-in-place, e.g. the IR integration swapping a legacy-compiled body
  * for the IR-lowered one). The write-side twin of `definedFuncAt` — after the

--- a/src/codegen/stack-balance.ts
+++ b/src/codegen/stack-balance.ts
@@ -1878,10 +1878,15 @@ function fixCallArgTypesInBody(
       pos--;
     }
 
-    // Apply insertions in reverse order (so positions don't shift)
+    // (#3910) Apply HIGHEST position first — any other order shifts the
+    // not-yet-applied ones. The old loop drained back-to-front under "reverse
+    // order (so positions don't shift)", which assumed an ASCENDING build order;
+    // the producer scan above walks BACKWARD, so back-to-front WAS ascending and
+    // every call with 2+ mismatched args stacked its 2nd coercion on the 1st arg.
+    // Trace: plan/issues/3910-regex-plus-string-constants-global-get.md.
     if (insertions.length > 0) {
-      for (let k = insertions.length - 1; k >= 0; k--) {
-        const { afterPos, instrs } = insertions[k]!;
+      insertions.sort((a, b) => b.afterPos - a.afterPos);
+      for (const { afterPos, instrs } of insertions) {
         body.splice(afterPos + 1, 0, ...instrs);
         recordFixup("call-arg-coerce", `coerced a call argument (${instrs.length} instr(s))`); // #1918
         ci += instrs.length;

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -75,7 +75,7 @@ import {
 import { collectPatternBindingNames } from "./tdz.js";
 import { tryCompileCountedStringAppend } from "./counted-string-append.js";
 import { emitHoleToUndefined } from "../array-holes.js"; // (#2001 S1)
-import { definedFuncAt } from "../func-space.js"; // (#1916 S2) positional-read chokepoint
+import { definedFuncAt, nativeStrHelperHandle } from "../func-space.js"; // (#1916 S2) positional-read chokepoint
 
 /**
  * Compile a loop body, saving/restoring block-scoped shadows (#817) so that
@@ -1245,15 +1245,12 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
   //
   // The IR path (#1183) sidesteps this by walking
   // `ctx.mod.functions[i].name` at lowering time. Mirroring that here
-  // for the legacy path:
-  let flattenIdx: number | undefined;
-  let substringIdx: number | undefined;
-  for (let i = 0; i < ctx.mod.functions.length; i++) {
-    const name = ctx.mod.functions[i]!.name;
-    if (name === "__str_flatten") flattenIdx = ctx.numImportFuncs + i;
-    else if (name === "__str_substring") substringIdx = ctx.numImportFuncs + i;
-    if (flattenIdx !== undefined && substringIdx !== undefined) break;
-  }
+  // for the legacy path.
+  //
+  // (#3909) That scan is now the SECOND choice — `nativeStrHelpers` holds
+  // unshiftable stable handles since #1916 S3. See `nativeStrHelperHandle`.
+  const flattenIdx = nativeStrHelperHandle(ctx, "__str_flatten");
+  const substringIdx = nativeStrHelperHandle(ctx, "__str_substring");
   if (flattenIdx === undefined || substringIdx === undefined) {
     reportError(ctx, stmt, "for-of on string: __str_flatten/__str_substring helpers not available");
     return;

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -78,7 +78,7 @@ import { lowerIrFunctionToWasm, type IrLowerResolver } from "../ir/lower.js";
 import type { StdlibMathBuiltin } from "../stdlib/math.js";
 import type { CodegenContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
-import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { mintDefinedFunc, nativeStrHelperHandle, pushDefinedFunc } from "./func-space.js";
 
 const F64: IrType = irVal({ kind: "f64" });
 
@@ -478,21 +478,44 @@ export function emitSelfHostedFunc(ctx: CodegenContext, def: SelfHostedFuncDef):
 }
 
 /**
- * (#3256 Tier-1) Resolve a native-string runtime helper's CURRENT absolute
- * funcIdx by name against `ctx.mod.functions` (post-shift — the
- * `nativeStrHelpers` map bakes registration-time indices that late-import
- * passes do not re-shift; mirrors `computeStringBackend` / `makeResolver`'s
- * rationale in src/ir/integration.ts). Falls back to the helpers map for
- * names that aren't defined functions. Returns null when unknown.
+ * (#3256 Tier-1) Resolve a native-string runtime helper's funcIdx.
+ *
+ * (#3909) Ordering matters, and it is the opposite of what the original
+ * comment assumed. `ctx.nativeStrHelpers` entries are minted by
+ * `mintDefinedFunc`, so since #1916 S3 they are **STABLE-regime handles**
+ * (`>= STABLE_FUNC_BASE`): layout-independent ids that no shifter touches and
+ * that `resolveLayout` maps to a concrete index once, at emit. A stable handle
+ * is therefore the *authoritative* identity and can never go stale.
+ *
+ * The `ctx.numImportFuncs + i` name scan below yields a **LIVE-regime**
+ * absolute index instead — a number that is only correct until the next import
+ * lands, after which it depends on every shifter (`shiftLateImportIndices`,
+ * `reconcileNativeStrFinalizeShift`, dead-elim's renumber) covering it. Running
+ * that scan *first* silently downgraded an already-correct stable handle to a
+ * fragile live index.
+ *
+ * That downgrade is #3909: in a module with enough import churn (JSON.stringify
+ * + a regex + one more string feature is the minimal trigger — the regex adds
+ * `RegExp_new`/`string_match`, JSON adds `JSON_stringify` and the
+ * `__str_from_mem`/`__str_to_mem`/`__str_extern_len` bridge), the baked live
+ * index for `__str_substring` ended up exactly one below the real slot. The
+ * self-hosted `__str_trimStart` body then called `__str_compare` — arity 2, not
+ * 3 — and the module failed validation with
+ * "call[0] expected type (ref null 6), found i32.trunc_sat_f64_s of type i32".
+ * Single-feature modules never reached the desync, which is why it looked like
+ * a three-feature interaction.
+ *
+ * So: funcMap first (unchanged), then any STABLE handle, and only then the
+ * live-regime name scan — which remains as the fallback for helpers registered
+ * before stable minting (a live entry in `nativeStrHelpers` really can be
+ * stale, which is the case the scan was written for). That ordering lives in
+ * the shared `nativeStrHelperHandle` (src/codegen/func-space.ts), which every
+ * helper-by-name resolver now goes through.
  */
 function resolveNativeStrHelper(ctx: CodegenContext, helperName: string): number | null {
   const idx = ctx.funcMap.get(helperName);
   if (idx !== undefined) return idx;
-  for (let i = 0; i < ctx.mod.functions.length; i++) {
-    if (ctx.mod.functions[i]!.name === helperName) return ctx.numImportFuncs + i;
-  }
-  const helperIdx = ctx.nativeStrHelpers.get(helperName);
-  return helperIdx === undefined ? null : helperIdx;
+  return nativeStrHelperHandle(ctx, helperName) ?? null;
 }
 
 /** Shared lowering + registration glue for both driver paths. */

--- a/src/codegen/string-builder.ts
+++ b/src/codegen/string-builder.ts
@@ -34,6 +34,7 @@ import { allocLocal } from "./context/locals.js";
 import { snapshotSpeculative, rollbackSpeculative } from "./context/speculative.js";
 import { compileExpression } from "./shared.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { nativeStrHelperHandle } from "./func-space.js";
 
 /**
  * #1761 — presize info for a string-builder whose final length is provably a
@@ -1151,17 +1152,21 @@ export function getBuilderInfo(fctx: FunctionContext, name: string): StringBuild
 }
 
 /**
- * Resolve a module-defined function's current absolute Wasm function index by
- * walking `ctx.mod.functions`. Returns -1 if the function is not present.
+ * Resolve a native-string helper to a function handle. Returns -1 when the
+ * helper is not registered.
  *
- * This bypasses `ctx.nativeStrHelpers` and `ctx.funcMap`, both of which can
- * hold stale indices if a `addImport` call bumped `numImportFuncs` without
- * shifting previously-registered module-function entries. Used at emit time
- * by the #1210 string-builder to ensure the call instruction targets the
- * actual current location of the helper.
+ * Historically this deliberately bypassed `ctx.nativeStrHelpers` and
+ * `ctx.funcMap` (both could hold stale indices when `addImport` bumped
+ * `numImportFuncs` without shifting previously-registered entries) in favour of
+ * a positional `numImportFuncs + i` scan.
+ *
+ * (#3909) That preference is now backwards: `nativeStrHelpers` holds
+ * STABLE-regime handles that no shifter touches, while the positional scan
+ * yields a LIVE index whose correctness depends on every later shifter — and
+ * the shift guard stops tracking it once the import count climbs past it.
+ * `nativeStrHelperHandle` prefers the stable handle and keeps the scan as the
+ * fallback for helpers not yet on stable minting.
  */
 function lookupModuleFuncByName(ctx: CodegenContext, name: string): number {
-  const idx = ctx.mod.functions.findIndex((f) => f.name === name);
-  if (idx < 0) return -1;
-  return ctx.numImportFuncs + idx;
+  return nativeStrHelperHandle(ctx, name) ?? -1;
 }

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -218,7 +218,12 @@ import { AllocSiteRegistry, ALLOC_NAMESPACES } from "./alloc-registry.js";
 import { analyzeEncoding } from "./analysis/encoding.js";
 import { assertAllocProvenance } from "./verify-alloc.js";
 import type { FieldDef, FuncTypeDef, GlobalDef, Import, Instr, StructTypeDef, ValType } from "./types.js";
-import { definedFuncAt, definedFuncHandleOf, replaceDefinedFuncAt } from "../codegen/func-space.js"; // (#1916 S2) positional read/write chokepoints
+import {
+  definedFuncAt,
+  definedFuncHandleOf,
+  nativeStrHelperHandle,
+  replaceDefinedFuncAt,
+} from "../codegen/func-space.js"; // (#1916 S2) positional read/write chokepoints
 import {
   classifyIrFailure,
   IrInvariantError,
@@ -2007,10 +2012,19 @@ export function compileIrPathFunctions(
   // helpers (`__str_concat`, `__str_equals`) and the wasm:js-string imports
   // (`concat`, `equals`, `length`) AT THIS POINT — after all late imports
   // (e.g. `addPrimitiveTypeImports` triggered by legacy compileDeclarations)
-  // have shifted the index space. `ctx.nativeStrHelpers` is a stale map
-  // post-shift (the shift pass updates `funcMap` and call ops in bodies but
-  // not the helpers map), so we resolve names against `ctx.mod.functions`
-  // directly to pick up the current absolute index.
+  // have shifted the index space.
+  //
+  // (#3909) The old rationale here — "`ctx.nativeStrHelpers` is a stale map
+  // post-shift, so resolve names against `ctx.mod.functions` directly" — is
+  // INVERTED as of #1916 S3 and was the direct cause of #3909. Every
+  // `nativeStrHelpers` entry is now minted by `mintDefinedFunc`, i.e. a
+  // STABLE-regime handle that no shifter touches; the `numImportFuncs + i`
+  // name scan yields a LIVE index that every later shifter must chase, and the
+  // shift guard (`idx >= importsBefore`) silently STOPS chasing it once the
+  // import count climbs past it. The map is the reliable authority, the scan is
+  // the fragile one. Resolution goes through `nativeStrHelperHandle`
+  // (src/codegen/func-space.ts), which prefers the stable handle and keeps the
+  // scan only as a fallback for helpers not yet on stable minting.
   const unitCallableSlots = new Map<IrUnitId, IrUnitCallableSlot>();
   const bindUnitCallableSlot = (ref: IrFuncRef, funcIdx: number, physicalName: string): void => {
     if (ref.binding.kind !== "unit") {
@@ -2872,11 +2886,20 @@ function runHygienePasses(fn: IrFunction, registry?: AllocSiteRegistry): IrFunct
 }
 
 /**
- * String-backend funcIdx resolution captured at Phase-3 entry. Both maps
- * (`ctx.nativeStrHelpers`, `ctx.jsStringImports`) can be stale after late
- * import shifts triggered during legacy compileDeclarations; we resolve by
- * name against the current state of `ctx.funcMap` / `ctx.mod.functions` to
- * pick up the absolute index in the post-shift index space.
+ * String-backend funcIdx resolution captured at Phase-3 entry.
+ *
+ * `ctx.jsStringImports` (host lane) can go stale after the late import shifts
+ * triggered during legacy compileDeclarations, so host ops are resolved by name
+ * against the current `ctx.funcMap`.
+ *
+ * (#3909) `ctx.nativeStrHelpers` is the opposite case and used to be described
+ * here as equally stale — it is not. Its entries are STABLE-regime handles
+ * (`mintDefinedFunc`, #1916 S3) that no shifter touches and that
+ * `resolveLayout` maps to a concrete index once, at emit, off the FINAL layout.
+ * Preferring a positional `numImportFuncs + i` scan over that handle downgrades
+ * a shift-immune id to a live index the shift guard abandons once the import
+ * count passes it — the #3909 `__str_trimStart` miscompile. Native helpers
+ * therefore resolve via `nativeStrHelperHandle` (src/codegen/func-space.ts).
  */
 interface StringBackendIndices {
   /** Native-string helper funcIdx by name — null when missing. */
@@ -2889,15 +2912,16 @@ function computeStringBackend(ctx: CodegenContext): StringBackendIndices {
   const nativeHelpers = new Map<string, number>();
   const hostImports = new Map<string, number>();
 
-  // Native helpers are stored as defined functions in `ctx.mod.functions`
-  // with a stable `name` field; convert their local index to absolute via
-  // `numImportFuncs`.
+  // Native helpers are defined functions; resolve each to a handle.
+  // (#3909) `nativeStrHelperHandle` prefers the STABLE-regime handle over the
+  // positional `numImportFuncs + i` scan this used to do inline — a live index
+  // baked here has to be chased by every later shifter, and the shift guard
+  // (`idx >= importsBefore`) silently stops chasing it once the import count
+  // climbs past it. See the helper's doc comment for the measured failure.
   if (ctx.nativeStrings) {
-    for (let i = 0; i < ctx.mod.functions.length; i++) {
-      const f = ctx.mod.functions[i]!;
-      if (f.name === "__str_concat" || f.name === "__str_equals" || f.name === "__str_concat_owned") {
-        nativeHelpers.set(f.name, ctx.numImportFuncs + i);
-      }
+    for (const name of ["__str_concat", "__str_equals", "__str_concat_owned"]) {
+      const h = nativeStrHelperHandle(ctx, name);
+      if (h !== undefined) nativeHelpers.set(name, h);
     }
   } else {
     // wasm:js-string imports live in `ctx.funcMap` keyed by op name (see
@@ -3758,18 +3782,13 @@ function makeResolver(
       if (ref.binding.kind === "intrinsic" && ref.binding.symbol === IR_STRING_COMPARE_FN) {
         if (ctx.nativeStrings) {
           ensureNativeStringHelpers(ctx);
-          const helperIdx = ctx.nativeStrHelpers.get("__str_compare");
-          if (helperIdx === undefined) {
+          if (!ctx.nativeStrHelpers.has("__str_compare")) {
             throw new Error(`ir/integration: cannot materialize ${ref.name} (native __str_compare unavailable)`);
           }
-          // Re-resolve by name against the post-shift function table (the
-          // helper map's captured index can predate later import inserts).
-          for (let i = 0; i < ctx.mod.functions.length; i++) {
-            if (ctx.mod.functions[i]!.name === "__str_compare") {
-              return bindCallableProvider(ref, ctx.numImportFuncs + i);
-            }
-          }
-          return bindCallableProvider(ref, helperIdx);
+          // (#3909) Stable handle first, post-shift name scan only as fallback
+          // — a baked live index stops being shifted once the import count
+          // climbs past it (see `nativeStrHelperHandle`).
+          return bindCallableProvider(ref, nativeStrHelperHandle(ctx, "__str_compare")!);
         }
         const hostIdx = ctx.funcMap.get("string_compare");
         if (hostIdx === undefined) {
@@ -3787,20 +3806,12 @@ function makeResolver(
       if (idx !== undefined) return bindCallableProvider(ref, idx);
       // Slice 6 part 4 (#1183): native-string helpers (`__str_charAt`,
       // `__str_concat`, `__str_equals`, `__str_flatten`, etc.) are
-      // registered in `ctx.nativeStrHelpers`, not `ctx.funcMap`. The
-      // helper map captures funcIdx at registration time and does NOT
-      // get re-shifted by late-import passes, so we re-resolve by name
-      // against the post-shift `ctx.mod.functions` (parallel to
-      // `computeStringBackend`'s rationale for the host string ops).
-      for (let i = 0; i < ctx.mod.functions.length; i++) {
-        if (ctx.mod.functions[i]!.name === adapterName) {
-          return bindCallableProvider(ref, ctx.numImportFuncs + i);
-        }
-      }
-      // Last fallback: the (potentially stale) helpers map. Used when
-      // a name doesn't appear in `ctx.mod.functions` because it's a
-      // host import rather than a defined helper.
-      const helperIdx = ctx.nativeStrHelpers.get(adapterName);
+      // registered in `ctx.nativeStrHelpers`, not `ctx.funcMap`.
+      // (#3909) Resolution order is stable handle → post-shift name scan →
+      // whatever the map holds; the old order put the name scan first, which
+      // downgraded an unshiftable stable handle to a live index that the
+      // shifters stop tracking once the import count passes it.
+      const helperIdx = nativeStrHelperHandle(ctx, adapterName);
       if (helperIdx !== undefined) return bindCallableProvider(ref, helperIdx);
       throw new IrInvariantError("unknown-function-ref", "lower", `ir/integration: unknown function ref "${ref.name}"`);
     },
@@ -4012,12 +4023,10 @@ function makeResolver(
     },
     emitStringCharAt(): readonly Instr[] {
       if (ctx.nativeStrings) {
-        for (let i = 0; i < ctx.mod.functions.length; i++) {
-          if (ctx.mod.functions[i]!.name === "__str_charAt") {
-            return [{ op: "call", funcIdx: ctx.numImportFuncs + i }];
-          }
-        }
-        throw new Error("ir/integration: __str_charAt helper not registered");
+        // (#3909) stable handle first — see `nativeStrHelperHandle`.
+        const h = nativeStrHelperHandle(ctx, "__str_charAt");
+        if (h === undefined) throw new Error("ir/integration: __str_charAt helper not registered");
+        return [{ op: "call", funcIdx: h }];
       }
       const idx = ctx.funcMap.get("string_charAt");
       if (idx === undefined) throw new Error("ir/integration: string_charAt import not registered");

--- a/tests/issue-3909-3910-index-and-argcoerce.test.ts
+++ b/tests/issue-3909-3910-index-and-argcoerce.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3909 / #3910 — two *different* root causes that both surfaced as "this only
+// breaks when three features appear in one module". Both are validation-time
+// failures in `fast` (native-strings) mode.
+//
+// #3910 — call-argument coercions were applied in the wrong order.
+//   `fixCallArgTypesInBody` (src/codegen/stack-balance.ts) collects the
+//   coercions it needs by walking BACKWARD from the call, so the collected
+//   list is in DESCENDING position order. It then applied them "in reverse
+//   order (so positions don't shift)", i.e. ASCENDING — the one order that DOES
+//   shift every not-yet-applied position. For a call with 2+ mismatched args
+//   the 2nd coercion therefore landed on the 1st argument. A fast-mode regex
+//   literal is the minimal trigger:
+//       global.get $pattern ; global.get $flags ; call $RegExp_new
+//   with both native-string args needing `extern.convert_any` became
+//       global.get $pattern ; extern.convert_any ; extern.convert_any ;
+//       global.get $flags   ; call $RegExp_new
+//   and the later `fixupExternConvertAny` repair pass dropped the duplicate,
+//   leaving the FLAGS argument uncoerced:
+//     "call[1] expected type externref, found global.get of type (ref null N)".
+//
+// #3909 — a native-string helper's call target was baked as a LIVE function
+//   index instead of the STABLE handle it already had. `resolveNativeStrHelper`
+//   preferred a positional `numImportFuncs + i` scan over the stable handle in
+//   `ctx.nativeStrHelpers`. A live index has to be chased by every later
+//   shifter, and the shift guard is `idx >= importsBefore` — so once enough
+//   imports accumulate that `importsBefore` climbs ABOVE the baked number, the
+//   stale defined-function reference is misread as an import index and stops
+//   being shifted. Measured: `__str_trimStart`'s call to `__str_substring` was
+//   baked as 61 with 54 imports; the ~19 union/`typeof` imports that follow
+//   push the count past 61, one batch stops applying, and the call lands one
+//   slot low on `__str_compare` — arity 2, not 3:
+//     "call[0] expected type (ref null 6), found i32.trunc_sat_f64_s of type i32".
+//   That crossing threshold is exactly why it took three features to trigger.
+
+async function compileFast(source: string): Promise<{ binary: Uint8Array; wat: string }> {
+  const result = await compile(source, { fast: true, emitWat: true, optimize: 0, fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  return { binary: result.binary, wat: result.wat ?? "" };
+}
+
+/** The body of one `(func $name …)` in the emitted WAT. */
+function funcBody(wat: string, name: string): string {
+  const start = wat.indexOf(`(func $${name} `);
+  expect(start, `no $${name} in the emitted module`).toBeGreaterThanOrEqual(0);
+  const next = wat.indexOf("\n  (func $", start + 1);
+  return wat.slice(start, next < 0 ? undefined : next);
+}
+
+describe("#3910 — every mismatched call argument gets its own coercion", () => {
+  // The reported repro: a regex literal alongside string constants.
+  it("a regex literal in fast mode produces a VALID module", async () => {
+    const { binary } = await compileFast(`
+export function run(): number {
+  const s = "hello world";
+  const re = /o/;
+  return s.length + (re.test(s) ? 1 : 0);
+}`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+  });
+
+  // A regex literal ALWAYS needs two coercions (pattern + flags), even with no
+  // user string constant anywhere — the pattern and the "" flags are both
+  // native-string globals feeding an `(externref, externref)` host import. This
+  // is the smallest form of the bug.
+  it("a bare regex literal — no user string constant — is also valid", async () => {
+    const { binary } = await compileFast(`
+export function run(s: string): number {
+  const re = /o/;
+  return re.test(s) ? 1 : 0;
+}`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+  });
+
+  it("both RegExp_new arguments are coerced, not just the first", async () => {
+    const { wat } = await compileFast(`
+export function run(s: string): number {
+  const re = /o/;
+  return re.test(s) ? 1 : 0;
+}`);
+    const run = funcBody(wat, "run");
+    // Pre-fix the two coercions stacked on the FIRST argument and the repair
+    // pass removed one, so `run` held a single `extern.convert_any` for the
+    // pattern and the flags `global.get` reached `call` raw. Assert the shape
+    // directly: each of the two `global.get`s feeding RegExp_new is followed by
+    // its own conversion.
+    const ops = run
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const globalGets: number[] = [];
+    ops.forEach((op, i) => {
+      if (op.startsWith("global.get")) globalGets.push(i);
+    });
+    expect(globalGets.length, "expected the pattern + flags string globals").toBeGreaterThanOrEqual(2);
+    for (const i of globalGets) {
+      expect(ops[i + 1], `global.get at ${i} (${ops[i]}) must be followed by its own coercion`).toBe(
+        "extern.convert_any",
+      );
+    }
+  });
+});
+
+describe("#3909 — self-hosted string helpers keep their stable call targets", () => {
+  // The exact reported shape: JSON.stringify + a regex + a case conversion.
+  it("JSON.stringify + regex + case conversion produces a VALID module", async () => {
+    const { binary } = await compileFast(`
+export function run(): number {
+  const s = "  Hello World Test String  ";
+  const j = JSON.stringify({ a: 1, b: "x" });
+  const lc = s.toLowerCase();
+  const mm = s.match(/l/);
+  return j.length + lc.length + (mm === null ? 0 : 1);
+}`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+  });
+
+  it("__str_trimStart's substring call targets __str_substring, not its neighbour", async () => {
+    const { wat } = await compileFast(`
+export function run(): number {
+  const s = "  Hello World Test String  ";
+  const j = JSON.stringify({ a: 1, b: "x" });
+  const lc = s.toLowerCase();
+  const mm = s.match(/l/);
+  return j.length + lc.length + s.trimStart().length + (mm === null ? 0 : 1);
+}`);
+
+    // Function index space: imports first (in declaration order), then defined
+    // functions in `(func $name …)` order.
+    const importNames = [...wat.matchAll(/^ {2}\(import "[^"]*" "([^"]*)"/gm)].map((m) => m[1]!);
+    const funcNames = [...wat.matchAll(/^ {2}\(func \$([^\s(]+)/gm)].map((m) => m[1]!);
+    const indexOfFunc = (name: string): number => {
+      const pos = funcNames.indexOf(name);
+      expect(pos, `no $${name} in the emitted module`).toBeGreaterThanOrEqual(0);
+      return importNames.length + pos;
+    };
+
+    const body = funcBody(wat, "__str_trimStart");
+    const calls = [...body.matchAll(/\bcall (\d+)/g)].map((m) => Number(m[1]));
+    expect(calls.length, "expected __str_trimStart to call its helpers").toBeGreaterThan(0);
+
+    // The tail call is `s.substring(i, len)`. Pre-fix it pointed one slot low,
+    // at `__str_compare` — a 2-arg function fed 3 operands.
+    expect(calls.at(-1)).toBe(indexOfFunc("__str_substring"));
+    expect(calls.at(-1)).not.toBe(indexOfFunc("__str_compare"));
+    // The leading `__str_flatten` call was already correct; assert it stays so,
+    // since the fix changes how BOTH are resolved.
+    expect(calls[0]).toBe(indexOfFunc("__str_flatten"));
+  });
+
+  it("string features that use the self-hosted helpers still work in fast mode", async () => {
+    // trim / startsWith / padStart all route through the self-hosted family
+    // whose call targets this fix re-resolves.
+    const { binary } = await compileFast(`
+export function run(): number {
+  const s = "  Hello  ";
+  return s.trim().length + s.trimStart().length + s.trimEnd().length +
+    (s.trim().startsWith("He") ? 1 : 0) + "x".padStart(4, "-").length;
+}`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Closes #3909 and #3910.

Both presented as "only fails when three features coexist". They are **two independent bugs**, proved by A/B rather than assumed — and **#3910's filed premise was wrong**.

### #3909 — a stable handle downgraded to a live one

`resolveNativeStrHelper` (`src/codegen/stdlib-selfhost.ts`) preferred a positional `numImportFuncs + i` scan over `ctx.nativeStrHelpers`, justified by a comment predating #1916 S3. **That premise is inverted today**: the map holds STABLE-regime handles from `mintDefinedFunc` that no shifter touches, while the scan yields a LIVE index every later shifter must chase. Shifters gate on `inLiveShiftRange(idx, importsBefore)`, so once the import count climbs *above* a baked index, the guard misreads a defined-function reference as an import below the insertion point and abandons it.

Verified by decoding call targets rather than trusting the validator message — which matters, because the message **changed** under #3907 (now `i32.trunc_sat_f64_s[0] expected type f64, found call of type i32`). The durable evidence: `__str_trimStart` emitted `call 14` → `__str_compare` (arity 2) where it meant `call 15` → `__str_substring` (arity 3). Both helper calls in that body were stale.

### #3910 — mis-ordered coercion insertion, not a global-index bug

The issue title says a `global.get` mis-resolves. **No global index goes stale.** `fixCallArgTypesInBody` walks *backward* (queue descending by position) but drained back-to-front under the comment *"reverse order (so positions don't shift)"* — which is **ascending**, the one order that shifts every unapplied position. Any call with 2+ mismatched args stacked its second coercion onto the first arg; a later repair pass deleted the duplicate, leaving arg 2 uncoerced and concealing the real shape.

A **bare regex literal** is the minimal trigger — pattern and flags globals both feed `RegExp_new(externref, externref)`. No string constant, no third feature.

### They do not share a root cause — proved, not asserted

A/B on current main, reverting each fix independently:

| build | regex repro | `__str_trimStart` |
|---|---|---|
| both fixes | valid | valid |
| only #3910 | valid | **broken** |
| only #3909 | **broken** | valid |
| neither | broken | broken |

Each necessary, neither sufficient.

### The generalisable finding

Both were caused by **a comment whose premise had silently become false, with the code faithfully implementing the stale comment**. Rewriting those comments is therefore part of the fix — two more still asserted the inverted premise in `src/ir/integration.ts` and would have re-seeded the bug.

Also worth recording: the "needs three features" signature was a **threshold effect** (enough imports to cross a baked index), not a feature interaction. The index-shift lead was right for #3909 and wrong for #3910.

### Sweep

- **`nativeStrHelpers` is provably clean.** Instrumented every `nativeStrHelperHandle` resolution across 5 string/regex-heavy modules × host and fast modes: all `STABLE`, **0 LIVE, 0 MISS**. The positional fallback is never taken in practice, so this family is fully closed. Seven call sites now route through the shared resolver — one was failing, six were latent.
- `findFuncByName` in `stackBalance` is **safe**: post-hoc over the final module, compute-and-consume in one pass, no append-after-capture window.
- `ensureLateImport` sites are the sanctioned mechanism, not this hazard.

## Verification

**431 scoped tests green** (self-host, native-string, standalone-string, regex, `for…of`-string, string-builder, JSON-stringify, IR-string). **5 of the 6 new regression tests fail on the unfixed compiler**; the 6th is a deliberate non-regression guard. Independently re-run by the coordinator: 6/6.

Gates green: typecheck, lint, format, oracle-ratchet, stack-balance, coercion-sites, test-vacuity, `check:issues`, done-status-integrity. LOC/func budget growth is comments-only and covered by `loc-budget-allow`/`func-budget-allow` in the issue files — the sanctioned mechanism; baselines untouched.

## Caveats

1. **`src/codegen-linear/runtime.ts:4088` and `c-abi.ts:49`** carry the same scan shape. Separate backend, no WasmGC shifters, and they *look* like same-pass compute-and-consume — but they were **not exercised**. Recorded in the issue rather than assumed safe.
2. **Two pre-existing failures**, both confirmed not caused here by A/B against a fully-reverted tree on the same commit: `tests/imported-string-constants.test.ts` (4 failures, identical either way) and `check:godfiles` on `src/codegen/index.ts` — a file this diff does not touch.
3. The prior investigation's "~60 call sites with 2+ coercions" and "benchmarks byte-identical" figures are carried forward **unre-measured** against current main, and flagged as such in #3910.

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01D29cj9ve5n7eQqnz4tUXk6)_