### PR TITLE
feat(codegen): host-free `instanceof` for a user function constructor (#3962)

### DIFF
--- a/plan/issues/3962-native-instanceof-user-function-constructor.md
+++ b/plan/issues/3962-native-instanceof-user-function-constructor.md
@@ -1,0 +1,152 @@
+---
+id: 3962
+title: "feat(codegen): host-free `x instanceof <user function constructor>` — retire the `env::__instanceof_check` sole-import leak"
+status: done
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen
+goal: standalone-gap
+assignee: ttraenkler/s78-sendev
+created: 2026-08-01
+completed: 2026-08-01
+related: [2961, 2916, 1473, 1536c, 2660, 1472]
+# +5 lines on identifiers.ts: ONE import and a four-line dispatch. All of the
+# new logic (both membership arms, the safety argument, the spec citations)
+# lives in the NEW subsystem module `src/codegen/native-user-instanceof.ts`;
+# what remains in the god-file is the call that decides which path to take,
+# which by definition has to sit at the dispatch site.
+loc-budget-allow:
+  - src/codegen/expressions/identifiers.ts
+---
+
+# #3962 — native `instanceof` for a plain user function constructor
+
+## Problem
+
+`x instanceof F`, where `F` is a plain function declared in the module, took
+the fully-dynamic path (`emitDynamicInstanceOf`, `src/codegen/expressions/identifiers.ts`)
+and emitted the `env::__instanceof_check` host import. Under `--target
+standalone` that import is unsatisfiable, so the module cannot instantiate and
+the #2961 leak guard refuses the test outright.
+
+Note that **#2961 is the guard, not the bug** — it was working correctly. There
+was no implementation issue for the underlying gap until this one.
+
+## Population — a bound, not a floor
+
+Standalone baseline `20260801-010858`, ≤ES5 scope (`es5id:` frontmatter),
+denominator **8,115**:
+
+- **99** rows cite `__instanceof_check`; **87** name it as their **SOLE** host
+  import.
+- In the ≤ES5 scope: **36 rows, all 36 sole leaks.**
+
+Because every ≤ES5 row is a *sole* leak, 36 is a **complete bound** on what a
+native implementation can flip in that scope — not an underestimate. (The
+opposite was hypothesised, on the reasoning that `instanceof` is an assertion
+primitive used all over test262 and so should flip tests far outside its own
+directory. The sole-leak qualifier is what settles it: a row whose refusal
+names other imports too will still be refused after this change.)
+
+**RHS shape breakdown of the 36** (a file may use several):
+
+| RHS | files |
+| --- | ---: |
+| `Test262Error` | **26** |
+| `TypeError` | 15 (already native — #1473) |
+| `Object` | 4 |
+| `FACTORY` (a `Function(...)` result) | 4 |
+| `OBJECT` | 3 |
+| `MyFunct` / `Function` / `FAKEFACTORY` / `this` / comma-expressions | tail |
+
+So the dominant shape is `e instanceof Test262Error` — the harness's own
+top-level plain-function constructor — and the work is "handle a plain function
+constructor whose prototype chain is statically reachable", not "implement
+general reflective `instanceof`".
+
+## Implementation
+
+`src/codegen/native-user-instanceof.ts` (new). §7.3.20 OrdinaryHasInstance has
+two host-free representations, so membership is the OR of two tests:
+
+1. **Bespoke struct** — a fnctor whose body assigns `this.x = …` lowers to a
+   dedicated `$__fnctor_<F>` WasmGC struct, so membership is an exact
+   `ref.test` on that type index. Plain functions have no subtyping, so the
+   test is precise.
+2. **`$Object` with a real `[[Prototype]]`** — the #2660 S3a reconstruct lowers
+   an approved `new F()` to `__object_create(F.prototype)`, seeding
+   `$Object.$proto` from the **same** per-fnctor prototype global this module
+   reads. Membership is then literally the spec's chain walk, which the native
+   `__isPrototypeOf(proto, value)` helper (#1472 Phase C) already performs.
+
+No new runtime code: both helpers already exist and are DEFINED (not imported)
+in standalone. Type indices are rec-group / dead-elim stable and module globals
+are append-only, so neither arm carries a funcidx-shift hazard. A primitive LHS
+answers `0` without touching either arm (§7.3.20 step 3), and `ref.test` on a
+null / non-matching `anyref` is `0`, so no arm can trap.
+
+Scoped to **plain function constructors**: classes are declined (`ctx.classSet`)
+because class instances carry richer identity — brands, builtin parents — that
+these two arms do not model.
+
+### Why a native answer here cannot regress a passing test
+
+The same safety argument #2916 makes for `nativeBuiltinInstanceOfTypeIdxs`: the
+branch runs **only** under `noJsHost`, where the operand shape it replaces
+*always* leaked `__instanceof_check`. A leaking module cannot instantiate, so
+every test reaching this path already fails. A native answer can only CONVERT a
+failing test. The JS-host lane never enters the function and is byte-identical.
+
+## Measurement
+
+Paired per-file A/B in one process (kill switch `JS2WASM_NO_3962` read at
+lowering time, **removed before commit**, probes re-verified after stripping),
+rows appended per file. Denominator **36** — the complete ≤ES5 sole-leak
+population.
+
+| result | files | of 36 |
+| --- | ---: | ---: |
+| import count drops to **0** | **26** | 72 % |
+| …of which pass on merits | **18** | 50 % |
+| …of which fail for unrelated reasons | 8 | 22 % |
+| still leaking (declined shapes) | 10 | 28 % |
+
+**Verdict agreement: 36/36.** Every file returns the identical verdict with the
+host `__instanceof_check` satisfied (base arm) and with the native lowering and
+no imports at all (new arm). The native answer never disagrees with the JS host
+on this population — the strongest correctness evidence available short of CI.
+
+**Expected CI delta: +18 of 36.** This is a *derivation*, not a direct local
+measurement, and the distinction matters. `runTest262File` — the local
+instrument — does **not** apply the #2961 refusal; only the CI worker does
+(`scripts/test262-worker.mjs`: `if (target === "standalone" &&
+compileMetadata.imports?.length > 0) → compile_error`). So locally the host
+import is satisfied and the tests already run on their merits, which is why the
+local pass/fail A/B is **+0 / −0** and why that zero is *not* the flip count.
+The derivation is: CI refuses all 36 today; after this change 26 emit no
+imports, so the refusal cannot fire for them, and their real verdict — which
+the local run does measure — is 18 pass / 8 fail.
+
+**The 10 that still leak are correctly declined, not missed:**
+
+- `S15.3.5.3_A3_T1/T2`, `S15.3.5.3_A2_T2/T5/T6` — `FACTORY = Function("…")`, a
+  **dynamic `Function` constructor**, so there is no module-level function
+  declaration to test against. Needs runtime-eval; out of scope.
+- `S11.8.6_A6_T1` — RHS is `this`; `S11.8.6_A2.4_T1/T3` — RHS is a comma
+  expression `(object = {}, Object)`; `S11.8.6_A2.1_T1` / `A6_T4` — RHS is
+  `Object`. Non-identifier or builtin RHS; the fully-dynamic path keeps them.
+
+All ten are inside `language/expressions/instanceof` itself.
+
+## Acceptance criteria
+
+- [x] `x instanceof <top-level plain function>` emits no host import in standalone
+- [x] A fnctor instance IS an instance of its ctor; a cross-ctor test is false
+- [x] A native engine error is NOT an instance of a user fnctor
+- [x] Verdict agreement with the JS host over the whole gated population
+- [x] Population enumerated with denominators; the sole-leak bound stated
+- [x] Declined shapes enumerated with reasons rather than left unexplained

--- a/plan/issues/3966-implicit-global-increment-write-does-not-persist.md
+++ b/plan/issues/3966-implicit-global-increment-write-does-not-persist.md
@@ -1,0 +1,65 @@
+---
+id: 3966
+title: "fix(codegen): `position++` on an implicit global does not persist — the increment/compound write path does not consult `sloppyImplicitGlobals`"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bug
+area: codegen
+goal: core-semantics
+created: 2026-08-01
+related: [3956, 2726]
+---
+
+# #3966 — increment / compound-assignment write on an implicit global is lost
+
+## Problem
+
+After #3956 the **read** of an implicit global resolves correctly, but an
+increment or compound-assignment **write** to one does not persist:
+
+```js
+// test/language/types/object/S8.6.2_A5_T2.js (verbatim shape)
+this.position = 0;
+var seat = {};
+seat['move'] = function () { position++ };
+seat.move();
+if (position !== 1) { /* fails: position === 0 */ }
+```
+
+Measured standalone, 2026-08-01: `position` reads back as `0`, so the read
+found the global-object property (pre-#3956 it would have been a
+`ReferenceError` or the auto-local `0`) but `position++` inside the closure
+wrote somewhere else.
+
+Same shape in `test/language/types/object/S8.6.2_A5_T4.js`
+(`this["beep"] = function(){__count++}`).
+
+## Suspected cause
+
+`src/codegen/expressions/assignment.ts`'s **simple-assignment** arm has an
+unresolvable-identifier branch (§6.2.5.6 PutValue) that emits
+`__extern_set(<globalThis>, name, v)` and registers the name in
+`ctx.sloppyImplicitGlobals`. The **increment / compound-assignment** path
+(`src/codegen/expressions/operator-assignment.ts`) has its own identifier
+resolution and does not appear to route through the same carrier — it has a
+`${name} is not defined` throw site of its own around line 1800, which suggests
+it knows about unresolvable identifiers but resolves them differently.
+
+So the read (`emitImplicitGlobalRead`, `src/codegen/global-environment.ts:57`)
+and the increment's write disagree about where the value lives — the mirror
+image of the #3956 defect, which was a dropped write against a correct read.
+
+## Scope
+
+Found while measuring #3956; deliberately kept out of that PR so its
++37 / −0 stayed attributable. Independently reproducible with the snippet above
+and narrower than #3956.
+
+## Acceptance criteria
+
+- [ ] `this.p = 0; (function(){ p++ })(); p === 1` holds in both lanes
+- [ ] `p = 0; p += 2; p === 2` holds for an implicit global in both lanes
+- [ ] A/B measured over the affected population with denominators, both directions

--- a/plan/issues/3967-global-object-element-write-vs-same-named-var.md
+++ b/plan/issues/3967-global-object-element-write-vs-same-named-var.md
@@ -1,0 +1,70 @@
+---
+id: 3967
+title: "fix(codegen): `this['x'] = v` does not reach a same-named script `var x` — the global object and the var binding are still two stores"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bug
+area: codegen
+goal: core-semantics
+created: 2026-08-01
+related: [3956, 2726]
+---
+
+# #3967 — a global-object element write does not update the same-named `var`
+
+## Problem
+
+A script `var x` IS a property of the global object (§9.1.1.4.15
+CreateGlobalVarBinding), so writing `this['x'] = v` must be observable through
+the bare `x` read, and vice versa. It is not:
+
+```js
+// test/language/statements/variable/S12.2_A11.js (shape)
+var __declared__var;
+this['__declared__var'] = "baloon";
+if (__declared__var !== "baloon") { /* fails: __declared__var === undefined */ }
+```
+
+Measured standalone, 2026-08-01 (after #3956): `__declared__var` reads back
+`undefined`. The write lands on the native globalThis `$Object`; the read
+resolves to the Wasm module global that backs the `var`. Two stores, one name.
+
+## Why #3956 does not cover this
+
+#3956 fixed the case where the name has **no** other binding: the write now
+reaches `__module_init` and the read routes through `emitImplicitGlobalRead`
+against the same global object. Here the name **does** have a binding — a
+module global — which correctly wins at the read site
+(`src/codegen/expressions/identifiers.ts`, module-globals branch precedes the
+implicit-global branch). That precedence is right; what is missing is that the
+two stores are not aliased.
+
+`ctx.globalObjectVarBindings` (populated by `recordScriptVarBindingNames`)
+already records exactly the set of names in this situation, and
+`isNonConfigurableGlobalObjectDelete` already consults it for `delete`, so the
+information needed to alias them is present.
+
+## Options
+
+1. Mirror on write: a `globalThis`/`this`-rooted write whose key is in
+   `globalObjectVarBindings` also writes the module global (and the reverse for
+   a `var` write). Cheap, but two stores can still drift via a dynamic key.
+2. Single store: back a script `var` with the global-object property itself
+   when the module contains any global-object write at all. Slower for the
+   common case; correct by construction.
+
+Option 1 is the smaller first slice; sizing needs the population count.
+
+## Scope
+
+Found while measuring #3956; kept out of that PR so its +37 / −0 stayed
+attributable.
+
+## Acceptance criteria
+
+- [ ] `var x; this['x'] = 1; x === 1` holds in both lanes
+- [ ] `var x = 1; this.x === 1` holds in both lanes
+- [ ] A/B measured over the affected population with denominators, both directions

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -17,6 +17,7 @@ import {
 import type { Instr, ValType } from "../../ir/types.js";
 import { emitCachedFuncClosureAccess, emitFuncRefAsClosure } from "../closures.js";
 import { emitNativeGlobalThisObject } from "../array-object-proto.js";
+import { tryEmitNativeUserCtorInstanceOf } from "../native-user-instanceof.js";
 import { emitLazyClassObjectGet } from "./extern.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import {
@@ -1842,6 +1843,11 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
     identifierHasSourceDeclaration(ctx, expr.right) &&
     userErrorParent === undefined
   ) {
+    // (#3962) Host-free answer for a plain user function constructor — the
+    // `e instanceof Test262Error` shape, 26 of the 36 ≤ES5 sole leaks of
+    // `env::__instanceof_check`. Declines to null and leaves this path unchanged.
+    const nativeCtor = noJsHost(ctx) ? tryEmitNativeUserCtorInstanceOf(ctx, fctx, expr, ctorName) : null;
+    if (nativeCtor) return nativeCtor;
     return emitDynamicInstanceOf(ctx, fctx, expr);
   }
 

--- a/src/codegen/native-user-instanceof.ts
+++ b/src/codegen/native-user-instanceof.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3962) Host-free `value instanceof <user function constructor>`.
+ *
+ * ## The leak this closes
+ *
+ * `x instanceof F`, where `F` is a plain function declared in the module, took
+ * the fully-dynamic path (`emitDynamicInstanceOf`) and emitted the
+ * `env::__instanceof_check` host import. In `--target standalone` that import
+ * is unsatisfiable, so the module does not even instantiate and the #2961 leak
+ * guard refuses the test.
+ *
+ * Measured on the standalone baseline of 2026-08-01: **36 files in the ≤ES5
+ * scope name `__instanceof_check` as their SOLE host import** — so 36 is a
+ * complete bound on that scope, not a floor — and **26 of the 36 are
+ * `e instanceof Test262Error`**, i.e. the harness's own top-level plain-function
+ * constructor. `TypeError` and the rest of the Error family already answer
+ * natively (#1473/#1536c), and the builtins answer via #2916, so this one shape
+ * is what remains.
+ *
+ * ## Why a native answer here cannot regress a passing test
+ *
+ * Same safety argument as #2916's `nativeBuiltinInstanceOfTypeIdxs`: this
+ * branch runs ONLY under `noJsHost`, where the operand shape it replaces
+ * *always* leaks `__instanceof_check`. A leaking module cannot instantiate, so
+ * every test reaching this code path already fails. A native answer can only
+ * CONVERT a failing test; it can never turn a passing one into a failure. The
+ * JS-host lane never enters this function and stays byte-identical.
+ *
+ * ## The lowering — §7.3.20 OrdinaryHasInstance, two representations
+ *
+ * `new F()` has two host-free lowerings, so membership is the OR of the two
+ * corresponding tests:
+ *
+ *  1. **Bespoke struct.** A fnctor whose body assigns `this.x = …` lowers to a
+ *     dedicated `$__fnctor_<F>` WasmGC struct (new-super.ts). Membership is an
+ *     exact `ref.test` against that type index — plain functions have no
+ *     subtyping, so the test is precise.
+ *
+ *  2. **`$Object` with a real `[[Prototype]]`.** The #2660 S3a reconstruct
+ *     lowers an approved `new F()` to `__object_create(F.prototype)`, seeding
+ *     `$Object.$proto` from the SAME per-fnctor prototype global this module
+ *     reads. Membership is then literally the spec's chain walk, which the
+ *     native `__isPrototypeOf(proto, value)` helper (#1472 Phase C) already
+ *     performs over `$Object.$proto`.
+ *
+ * Type indices are rec-group / dead-elim stable and module globals are
+ * append-only, so neither arm carries a funcidx-shift hazard.
+ *
+ * A primitive left operand answers `0` without touching either arm — §7.3.20
+ * step 3 ("If Type(O) is not Object, return false") — and `ref.test` on a null
+ * or non-matching `anyref` is `0`, so no arm can trap.
+ */
+import { emitFnctorProtoGet } from "./expressions/fnctor-prototype.js";
+import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
+import { compileExpression } from "./expressions.js";
+import { allocLocal } from "./context/locals.js";
+import { coerceType } from "./type-coercion.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { ValType } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+
+/**
+ * Emit a host-free `expr.left instanceof <ctorName>` when `ctorName` is a
+ * top-level plain function constructor of this module. Leaves an i32 (0/1) on
+ * the stack and returns its ValType, or `null` to decline — in which case the
+ * caller falls through to its existing (host-import) path unchanged.
+ */
+export function tryEmitNativeUserCtorInstanceOf(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+  ctorName: string,
+): ValType | null {
+  // Plain FUNCTION constructors only. Classes keep their existing dispatch:
+  // class instances carry richer identity (brands, builtin parents) that the
+  // two arms below do not model, and widening this to classes is separate,
+  // separately-measured work.
+  if (!ctx.topLevelFunctionNames.has(ctorName)) return null;
+  if (ctx.classSet.has(ctorName)) return null;
+
+  const structTypeIdx = ctx.structMap.get(`__fnctor_${ctorName}`);
+  const hasStructArm = typeof structTypeIdx === "number" && structTypeIdx >= 0;
+
+  // Reserve the proto-walk import BEFORE any operand is compiled, so a late
+  // funcIdx shift reaches the already-emitted instructions through currentFunc.
+  const isProtoOfIdx = ensureLateImport(
+    ctx,
+    "__isPrototypeOf",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "i32" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (isProtoOfIdx === undefined && !hasStructArm) return null;
+
+  // §13.10.1 evaluates the LHS before any check, so compile it either way.
+  const leftType = compileExpression(ctx, fctx, expr.left);
+  if (leftType && (leftType.kind === "i32" || leftType.kind === "f64" || leftType.kind === "i64")) {
+    // A number / boolean primitive is never an Object — §7.3.20 step 3.
+    fctx.body.push({ op: "drop" });
+    fctx.body.push({ op: "i32.const", value: 0 });
+    return { kind: "i32" };
+  }
+  if (!leftType) {
+    fctx.body.push({ op: "ref.null.extern" });
+  } else if (leftType.kind !== "externref") {
+    coerceType(ctx, fctx, leftType, { kind: "externref" });
+  }
+  const valueLocal = allocLocal(fctx, `__uio_val_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: valueLocal });
+
+  let pushedAnArm = false;
+
+  if (hasStructArm) {
+    fctx.body.push({ op: "local.get", index: valueLocal });
+    fctx.body.push({ op: "any.convert_extern" });
+    fctx.body.push({ op: "ref.test", typeIdx: structTypeIdx });
+    pushedAnArm = true;
+  }
+
+  // Chain walk: `__isPrototypeOf(F.prototype, value)`. `emitFnctorProtoGet`
+  // lazily materializes the per-fnctor prototype `$Object` — the same global the
+  // #2660 S3a `new F()` reconstruct seeds `$proto` from, so object identity
+  // holds. It declines (emitting nothing) when the object runtime is
+  // unavailable, in which case we keep whatever the struct arm produced.
+  if (isProtoOfIdx !== undefined) {
+    const bodyLenBefore = fctx.body.length;
+    if (emitFnctorProtoGet(ctx, fctx, ctorName)) {
+      fctx.body.push({ op: "local.get", index: valueLocal });
+      // Re-read the index: the proto-get may have registered helpers.
+      fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__isPrototypeOf") ?? isProtoOfIdx });
+      if (pushedAnArm) fctx.body.push({ op: "i32.or" });
+      pushedAnArm = true;
+    } else {
+      fctx.body.length = bodyLenBefore;
+    }
+  }
+
+  if (!pushedAnArm) {
+    // Neither representation is modeled in this module — `new F()` never
+    // happened here, so nothing can be an instance. A definite `0` is the
+    // correct host-free answer and still beats an unsatisfiable import.
+    fctx.body.push({ op: "i32.const", value: 0 });
+  }
+  return { kind: "i32" };
+}

--- a/src/codegen/native-user-instanceof.ts
+++ b/src/codegen/native-user-instanceof.ts
@@ -121,19 +121,20 @@ export function tryEmitNativeUserCtorInstanceOf(
   // Chain walk: `__isPrototypeOf(F.prototype, value)`. `emitFnctorProtoGet`
   // lazily materializes the per-fnctor prototype `$Object` — the same global the
   // #2660 S3a `new F()` reconstruct seeds `$proto` from, so object identity
-  // holds. It declines (emitting nothing) when the object runtime is
-  // unavailable, in which case we keep whatever the struct arm produced.
-  if (isProtoOfIdx !== undefined) {
-    const bodyLenBefore = fctx.body.length;
-    if (emitFnctorProtoGet(ctx, fctx, ctorName)) {
-      fctx.body.push({ op: "local.get", index: valueLocal });
-      // Re-read the index: the proto-get may have registered helpers.
-      fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__isPrototypeOf") ?? isProtoOfIdx });
-      if (pushedAnArm) fctx.body.push({ op: "i32.or" });
-      pushedAnArm = true;
-    } else {
-      fctx.body.length = bodyLenBefore;
-    }
+  // holds.
+  //
+  // This is NOT a speculative compile and needs no rollback (#1919): the helper's
+  // only failure point is its opening `ensureLateImport("__new_plain_object")`,
+  // which precedes every `body.push` it makes — so a `false` return has emitted
+  // nothing, exactly as its contract states. Truncating `body.length` here would
+  // be a *partial* rollback anyway (it would not undo locals, late imports or
+  // errors), which is the bug pattern the #1919 gate exists to catch.
+  if (isProtoOfIdx !== undefined && emitFnctorProtoGet(ctx, fctx, ctorName)) {
+    fctx.body.push({ op: "local.get", index: valueLocal });
+    // Re-read the index: the proto-get may have registered helpers.
+    fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__isPrototypeOf") ?? isProtoOfIdx });
+    if (pushedAnArm) fctx.body.push({ op: "i32.or" });
+    pushedAnArm = true;
   }
 
   if (!pushedAnArm) {

--- a/tests/issue-3962-native-user-instanceof.test.ts
+++ b/tests/issue-3962-native-user-instanceof.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3962 — `x instanceof <plain user function constructor>` must be answered
+ * host-free in `--target standalone`.
+ *
+ * It previously took the fully-dynamic path and emitted `env::__instanceof_check`,
+ * which a host-free binary cannot satisfy: the module does not instantiate and
+ * the #2961 leak guard refuses the test. In the ≤ES5 standalone scope, **36
+ * files name `__instanceof_check` as their SOLE host import**, and **26 of them
+ * are `e instanceof Test262Error`** — the harness's own top-level plain-function
+ * constructor.
+ *
+ * Two assertions per case, and both matter:
+ *   1. the ANSWER is right, and
+ *   2. the binary carries NO imports — a right answer that still leaks is still
+ *      refused by #2961, so the import count is part of the contract.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface Outcome {
+  result: number;
+  imports: string[];
+}
+
+/** Compile a standalone SCRIPT, run `__module_init`, read `result`. */
+async function run(body: string): Promise<Outcome> {
+  const source = `var result = -1;\n${body}\nexport function test(): number { return result as number; }\n`;
+  const compiled = await compile(source, {
+    allowJs: true,
+    fileName: "native-user-instanceof.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    deferTopLevelInit: true,
+    inferModuleStrictArguments: false,
+  });
+  expect(compiled.success, compiled.errors.map((e) => e.message).join("; ")).toBe(true);
+  const imports = (compiled.imports ?? []).map((i: unknown) =>
+    typeof i === "string" ? i : `${(i as { module: string }).module}::${(i as { name: string }).name}`,
+  );
+  const { instance } = await WebAssembly.instantiate(compiled.binary, {});
+  (instance.exports as Record<string, unknown> & { __module_init?: () => void }).__module_init?.();
+  const result = (instance.exports as Record<string, () => number>).test();
+  return { result, imports };
+}
+
+describe("#3962 — host-free instanceof for a user function constructor", () => {
+  it("a fnctor instance IS an instance of its constructor, host-free", async () => {
+    const o = await run(`function F(){ this.x = 1; }\nvar f = new F();\nresult = (f instanceof F) ? 1 : 0;`);
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("an instance of another fnctor is NOT an instance", async () => {
+    const o = await run(
+      `function F(){ this.x=1; }\nfunction G(){ this.y=2; }\nvar f = new F();\nresult = (f instanceof G) ? 1 : 0;`,
+    );
+    expect(o.result).toBe(0);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("a native engine error is NOT an instance of a user fnctor (the Test262Error shape)", async () => {
+    // `catch (e) { if (e instanceof Test262Error) throw e; }` is the guard 26 of
+    // the 36 gated files use; the engine-thrown error must answer false.
+    const o = await run(
+      `function T(m){ this.message = m; }\nvar r = 0;\ntry { null.foo; } catch (e) { r = (e instanceof T) ? 1 : 0; }\nresult = r;`,
+    );
+    expect(o.result).toBe(0);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("an empty-bodied fnctor's instance IS an instance (the $Object/$proto arm)", async () => {
+    const o = await run(`function T(m){ this.message = m; }\nvar t = new T('x');\nresult = (t instanceof T) ? 1 : 0;`);
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("a primitive left operand answers false without a host import (§7.3.20 step 3)", async () => {
+    const o = await run(`function F(){ this.x = 1; }\nresult = ((1 as any) instanceof F) ? 1 : 0;`);
+    expect(o.result).toBe(0);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("null answers false without a host import", async () => {
+    const o = await run(`function F(){ this.x = 1; }\nvar n: any = null;\nresult = (n instanceof F) ? 1 : 0;`);
+    expect(o.result).toBe(0);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("the JS-host lane is untouched — it keeps the host predicate", async () => {
+    const source = `function F(){ this.x = 1; }\nvar f = new F();\nvar result = (f instanceof F) ? 1 : 0;\nexport function test(): number { return result; }\n`;
+    const compiled = await compile(source, {
+      allowJs: true,
+      fileName: "native-user-instanceof-host.ts",
+      skipSemanticDiagnostics: true,
+      deferTopLevelInit: true,
+      inferModuleStrictArguments: false,
+    });
+    expect(compiled.success).toBe(true);
+    const names = (compiled.imports ?? []).map((i: unknown) =>
+      typeof i === "string" ? i : `${(i as { name: string }).name}`,
+    );
+    // The native branch is `noJsHost`-gated, so the host lane must be unchanged.
+    expect(names.some((n) => n.includes("__instanceof"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #3962. Also files #3966 and #3967 (the two residuals found while measuring #3956, kept separate so its +37/−0 stayed attributable).

## The gap

`x instanceof F`, where `F` is a plain function declared in the module, took the fully-dynamic path and emitted the `env::__instanceof_check` host import. Under `--target standalone` that import is unsatisfiable: the module does not instantiate and the #2961 leak guard refuses the test.

**#2961 is the guard, not the bug** — it was working correctly. There was no implementation issue for the underlying gap until this one.

## Population — a bound, not a floor

Standalone baseline `20260801-010858`, ≤ES5 scope (`es5id:` frontmatter), denominator **8,115**: **99** rows cite `__instanceof_check`, **87** name it as their **SOLE** host import. In the ≤ES5 scope: **36 rows, all 36 sole leaks.**

Because every ≤ES5 row is a *sole* leak, **36 is a complete bound** on what a native implementation can flip there — a row whose refusal also names other imports stays refused either way. (The opposite was the working hypothesis, on the reasoning that `instanceof` is an assertion primitive used all over test262 and so ought to flip tests far outside its own directory. The sole-leak qualifier is what settles it.)

RHS shapes of the 36: `Test262Error` **26** · `TypeError` 15 (already native, #1473) · `Object` 4 · `FACTORY` 4 · `OBJECT` 3 · tail. So the work is "handle a plain function constructor whose prototype chain is statically reachable", not "implement general reflective `instanceof`".

## Implementation

`src/codegen/native-user-instanceof.ts` (new). §7.3.20 OrdinaryHasInstance has two host-free representations, so membership is the OR of two tests:

1. **Bespoke struct** — a fnctor whose body assigns `this.x = …` lowers to a dedicated `$__fnctor_<F>` WasmGC struct, so membership is an exact `ref.test`. Plain functions have no subtyping, so the test is precise.
2. **`$Object` with a real `[[Prototype]]`** — the #2660 S3a reconstruct lowers an approved `new F()` to `__object_create(F.prototype)`, seeding `$Object.$proto` from the **same** per-fnctor prototype global this module reads. Membership is then literally the spec's chain walk, which the native `__isPrototypeOf` helper (#1472 Phase C) already performs.

**No new runtime code**: both helpers already exist and are DEFINED (not imported) in standalone. Type indices are rec-group / dead-elim stable and module globals are append-only, so neither arm carries a funcidx-shift hazard. A primitive LHS answers `0` without touching either arm (§7.3.20 step 3), and `ref.test` on a null / non-matching `anyref` is `0`, so no arm can trap.

Scoped to **plain function constructors**; classes are declined, since class instances carry brands / builtin parents these arms do not model.

### Why this cannot regress a passing test

#2916's argument verbatim: the branch runs **only** under `noJsHost`, where this operand shape *always* leaked `__instanceof_check`. A leaking module cannot instantiate, so every test reaching this path already fails. A native answer can only CONVERT a failing test. The JS-host lane never enters the function and is byte-identical — asserted by a test, not assumed.

## Measurement

Paired per-file A/B in one process (kill switch read at lowering time, **removed** before commit, probes re-verified after stripping), rows appended per file. Denominator **36** — the complete ≤ES5 sole-leak population.

| result | files | of 36 |
| --- | ---: | ---: |
| host import count drops to **0** | **26** | 72 % |
| …of which pass on merits | **18** | 50 % |
| …fail for unrelated reasons | 8 | 22 % |
| still leaking (declined shapes) | 10 | 28 % |

**Verdict agreement: 36/36.** Every file returns the identical verdict with the host `__instanceof_check` satisfied (base arm) and with the native lowering and no imports at all (new arm). The native answer never disagrees with the JS host on this population — for a primitive this widely used, that is stronger evidence than any flip count.

### The local pass/fail A/B is +0 / −0, and that zero is NOT the flip count

`runTest262File` — the local instrument — **does not apply the #2961 refusal**. Only the CI worker does:

```js
// scripts/test262-worker.mjs
if (target === "standalone" && compileMetadata.imports?.length > 0) {
  sendResult({ id, status: "compile_error",
    error: `standalone target emitted host imports: ${...} (#2961)` });
```

So locally the host import is *satisfied* and these tests already run on their merits — removing the import cannot change a local verdict. The instrument cannot observe the effect under test.

**Expected CI delta: +18 of 36.** This is a **derivation**, not a direct measurement: CI refuses all 36 today; after this change 26 emit no imports, so the refusal cannot fire for them, and their real verdict — which the local run *does* measure — is 18 pass / 8 fail. Per the known `runTest262File` caveat, its pass/fail **status** is the trustworthy half, which is the half this uses.

### The 10 that still leak are declined, not missed

- `S15.3.5.3_A3_T1/T2`, `S15.3.5.3_A2_T2/T5/T6` — `FACTORY = Function("…")`, a **dynamic** `Function` constructor, so there is no module-level declaration to test against. Needs runtime-eval (#2928 territory).
- `S11.8.6_A6_T1` (`this` RHS), `S11.8.6_A2.4_T1/T3` (comma expression `(object = {}, Object)`), `S11.8.6_A2.1_T1` / `A6_T4` (`Object` RHS) — non-identifier or builtin RHS; the fully-dynamic path keeps them.

All ten are inside `language/expressions/instanceof` itself — nothing leaked into the wider corpus.

## Tests

`tests/issue-3962-native-user-instanceof.test.ts` — 7 cases, green. Each asserts **both** the answer and that the binary carries **zero imports**, because a right answer that still leaks is still refused by #2961: the import count is part of the contract. Includes a **host-lane control** asserting the JS lane still emits the host predicate, proving the `noJsHost` gate rather than assuming it.

Local gates: LOC and function budgets green (`identifiers.ts` +6 for the dispatch alone, granted with justification in the issue frontmatter — all the logic is in the new subsystem module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
