### PR TITLE
docs(#3968): file the §2 CODEOWNER-review finding — a documented control the ruleset does not enforce

### DIFF
--- a/plan/issues/3968-codeowner-review-requirement-not-enforced.md
+++ b/plan/issues/3968-codeowner-review-requirement-not-enforced.md
@@ -1,0 +1,116 @@
+---
+id: 3968
+title: "`docs/ci-policy.md` §2 documents a CODEOWNER-review requirement that the ruleset does not enforce — decide whether to enforce it or document its absence"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: high
+horizon: s
+feasibility: easy
+task_type: ci
+area: ci, merge-queue, policy
+goal: ci-hardening
+related: [3934, 1525]
+origin: "Found while fixing #3934's required-check-list drift: the same ruleset query that proved `linear-tests` is not required also shows there is no `pull_request` rule at all."
+---
+
+# #3968 — §2's review requirement is a control the project believes it has and does not
+
+## The evidence
+
+The ruleset governing `main` contains exactly two rules:
+
+```bash
+gh api repos/loopdive/js2/rules/branches/main --jq '[.[].type]'
+# ["required_status_checks","merge_queue"]
+```
+
+There is **no `pull_request` rule**, which is the rule type that carries
+`required_approving_review_count`, `require_code_owner_review`,
+`dismiss_stale_reviews_on_push` and `require_last_push_approval`. Classic branch
+protection is not filling the gap either — that endpoint answers `404`:
+
+```bash
+gh api repos/loopdive/js2/branches/main/protection
+# {"message":"Branch not protected", "status":"404"}
+```
+
+Verified 2026-08-01. Re-run both rather than trusting this date.
+
+## What the docs claim
+
+`docs/ci-policy.md` §2 "Reviewer policy" states, as policy that is applied:
+
+- "**At least one approving review from a CODEOWNER** is required before a PR
+  can merge."
+- "**Stale reviews are dismissed** when new commits are pushed to the PR branch."
+- "**The PR author cannot approve their own PR**, including admins."
+- "**Code-owner review is required for every protected path** — the CODEOWNERS
+  entry is treated as authoritative, not advisory."
+
+None of those four is enforced. `CODEOWNERS` still routes review *requests*, so
+the mechanism looks alive from inside a PR — reviewers get requested, the
+Reviewers box populates — but nothing blocks a merge on it. §2 also builds a
+`[skip-review]` label exception class on top of a requirement that does not
+exist, so the exception is currently indistinguishable from the rule.
+
+## Why this is worth its own issue rather than a docs patch
+
+This is a different kind of finding from the `linear-tests` drift fixed in
+#3934. That one was a **typo in a list** — the doc named a seventh required
+check that was never in the ruleset, and correcting the prose fully resolved it.
+
+This one is a **control the project believes it has**. Correcting §2 to say
+"reviews are not enforced" *documents* the hole; it does not close it. And the
+opposite move — adding a `pull_request` rule so the docs become true — changes
+what is enforced on `main` for every contributor and every agent. That is an
+enforcement-policy decision for the user, the same class as
+`scripts/enable-branch-protection.sh` (which still lists `linear-tests` and
+targets the dead classic API, and was deliberately left unedited in #3934 for
+exactly this reason).
+
+So this issue deliberately does **not** pick one. It records the measurement and
+presents the decision.
+
+## The decision
+
+**Option A — enforce it.** Add a `pull_request` rule to the ruleset with
+`require_code_owner_review: true`, `required_approving_review_count: 1`,
+`dismiss_stale_reviews_on_push: true`. Makes §2 true as written.
+
+- Note the interaction that has to be thought through first: **every agent PR in
+  this project is self-merged.** With reviews enforced and self-approval
+  disallowed, no dev agent could land its own work without a second party. That
+  is either the point or a full stop, depending on intent, and it is not a
+  decision to make by side effect.
+
+**Option B — document the absence.** Rewrite §2 to state that review is
+advisory: `CODEOWNERS` routes review requests, the merge gate is the six
+required checks plus the merge queue. Keep the `[skip-review]` section only as
+convention. Cheapest, honest, changes no behaviour.
+
+**Either way**, §2 should carry the verification command inline the way §1 and
+§7 now do after #3934, so the next reader re-checks instead of trusting prose.
+
+## Acceptance
+
+1. `docs/ci-policy.md` §2 matches the live ruleset — whichever direction the
+   decision goes.
+2. §2 carries the `gh api repos/loopdive/js2/rules/branches/main` query inline.
+3. If Option A: the ruleset actually contains a `pull_request` rule afterwards,
+   verified by re-running the query, and the self-merge interaction above is
+   explicitly addressed in the same change.
+4. If Option B: the `[skip-review]` exception class is either removed or
+   restated as convention, since an exception to an unenforced rule is noise.
+
+## Notes
+
+- Related unresolved discrepancy from the same sweep (#3934):
+  `scripts/enable-branch-protection.sh` still lists `linear-tests` as required
+  and PATCHes the classic protection API, which `main` does not use. Documented
+  in §8; not fixed, for the same "that is an enforcement change" reason.
+- The ruleset does enforce **strict** required status checks
+  (`strict_required_status_checks_policy: true`), which is why PRs report
+  `BEHIND` until they are up to date with `main`. That part of the docs is
+  accurate.

--- a/plan/issues/3970-stub-relevance-filter-diverges-from-native-paths-filter.md
+++ b/plan/issues/3970-stub-relevance-filter-diverges-from-native-paths-filter.md
@@ -1,0 +1,131 @@
+---
+id: 3970
+title: "INVARIANT: the stub's relevance filter and GitHub's native `paths:` filter must agree — measured, they don't on stale branches"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: medium
+horizon: s
+feasibility: easy
+task_type: ci
+area: ci, merge-queue
+goal: ci-hardening
+related: [3934, 3968]
+origin: "Measured on probe PR #3952 while constructing the masking experiment for #3934: a path-excluded PR took the stub's SILENT arm because the branch was stale."
+---
+
+# #3970 — the two mirrors disagree on stale branches
+
+This is filed as an **invariant with a measurement**, not a fix proposal. Nothing
+is broken today. The reason it is worth an id is that the only thing making the
+divergence harmless is incidental, and it will stop being harmless the moment
+anyone changes what the stub publishes.
+
+## The invariant
+
+`.github/workflows/test262-pr-stub.yml`'s `detect` job and
+`test262-sharded.yml`'s native `paths: &test262-paths` filter are supposed to be
+**mirrors**: exactly one of the two workflows owns the three test262 required
+contexts on any given PR. The stub's header says so explicitly, and
+`scripts/test262-paths-match.sh` exists to be the single source of truth both
+sides read.
+
+**They must agree on every PR.** They currently do not.
+
+## The measurement
+
+Probe PR #3952, first control round (sha `618961b3`). The PR's own diff touched
+**one file**, `plan/issues/3934-probe-control-duplicate.md` — not a test262-relevant
+path by any reading. Expected: stub takes the GREEN arm and publishes the three
+contexts.
+
+Observed (run 30691153399, `.github/workflows/test262-pr-stub.yml`):
+
+```
+success  test262 PR stub — detect relevance
+skipped  cheap gate (main-ancestor + lint)
+skipped  merge shard reports
+skipped  check for test262 regressions
+```
+
+`detect` **succeeded** and decided `stub_required=false` — the SILENT arm, i.e.
+"a test262 path changed, the real workflow owns these". The real workflow did not
+run: GitHub's native filter correctly saw a path-excluded PR.
+
+## The mechanism
+
+The branch was `BEHIND`. `detect` computes the changed-file set as a **two-dot**
+diff:
+
+```
+git diff --name-only $BASE_SHA $HEAD_SHA     # base TIP .. head
+```
+
+`BASE_SHA` is `pull_request.base.sha`, the base branch **tip at event time** — not
+the merge base. On a stale branch that diff therefore contains every file `main`
+itself changed since the branch point, which on this repo always includes
+`src/**`. The matcher sees `src/...`, says `true`, and the stub goes silent.
+
+GitHub's native `paths:` filter for `pull_request` events evaluates the **PR's
+own** changed files (merge-base..head), so it is unaffected by main moving. Hence
+the disagreement, and it appears precisely when a branch falls behind — which on
+this repo is most branches, most of the time, since the ruleset enforces
+`strict_required_status_checks_policy: true` and `main` moves every few minutes.
+
+**#3934 did not introduce this and deliberately did not change it.** Its
+acceptance criterion #3 was "the narrowed fetch must produce the SAME verdict",
+and the merge-ref parents it now diffs (`HEAD^1`..`HEAD^2`) are the same two
+commits as `BASE_SHA`..`HEAD_SHA`. The semantics were preserved on purpose. This
+issue is about the semantics themselves.
+
+## Why it is harmless today, and why that is not reassuring
+
+When the stub goes silent on a PR the real workflow also skips, **nothing
+publishes SUCCESS for the three names** — they land as `skipped`, and a `skipped`
+required check satisfies branch protection (measured in #3934). So the PR merges
+and the merge queue runs the authoritative validation on the merged state.
+
+The safety therefore rests entirely on the incidental fact that **the divergent
+arm publishes `skipped` rather than SUCCESS**. It is not protected by the mirror
+being correct — the mirror is wrong, and something downstream happens to absorb
+it.
+
+Two consequences a reader would not reconstruct from the code:
+
+1. **The stub's green arm is quietly rarer than the design assumes.** The whole
+   workflow exists to publish those three contexts green on path-excluded PRs.
+   On any stale path-excluded PR it doesn't — it silently declines and the
+   `skipped` conclusions carry the PR instead. The mechanism the workflow was
+   built for is firing less than anyone thinks.
+2. **It becomes a live correctness bug on first contact with any change** that
+   makes the stub's green arm authoritative, or that alters what the silent arm
+   publishes, or that promotes `detect`'s verdict into a gate. At that point the
+   divergence stops being absorbed — and by then this measurement is gone and the
+   next person rediscovers it from a symptom.
+
+## What "fixed" would mean
+
+Not prescribing an approach, but the shape is: `detect`'s changed-file set must
+be the PR's own diff (merge-base..head), the same set GitHub's filter uses.
+
+Whatever is chosen must keep #3934's structural properties — the job must stay
+un-killable (bounded, `continue-on-error` steps; `if: always()` verdict; job
+budget unreachable) and must not restore a full-ref fetch. Note the known trap if
+the changed-file list is taken from `gh api pulls/N/files`: that endpoint is
+paginated and **capped at 3000 files**, and a truncated list drops paths, which
+would flip a src PR onto the green arm and report SUCCESS for a name the real
+workflow owns — the exact masking that PR #496 introduced and commit `c9688f33b`
+backed out. Any such implementation must floor the count against
+`.changed_files` and degrade when they disagree.
+
+## Acceptance
+
+1. A test262-**irrelevant** PR whose branch is stale (`BEHIND`) takes the stub's
+   GREEN arm — the three contexts publish `success`, not `skipped`.
+2. A test262-**relevant** PR still takes the silent arm regardless of staleness,
+   so the two producers never both report SUCCESS for a name.
+3. The mirroring ratchet in `tests/issue-3934.test.ts` still passes, extended
+   with a stale-branch case.
+4. `detect`'s structural properties from #3934 are unchanged: no `fetch-depth: 0`,
+   step budgets sum below the job budget, verdict step `if: always()`.


### PR DESCRIPTION
Files #3968. **Issue file only — no policy change, deliberately.**

## The measurement

```bash
gh api repos/loopdive/js2/rules/branches/main --jq '[.[].type]'
# ["required_status_checks","merge_queue"]

gh api repos/loopdive/js2/branches/main/protection
# {"message":"Branch not protected", "status":"404"}
```

There is **no `pull_request` rule** — that is the rule type carrying `require_code_owner_review`, `required_approving_review_count`, `dismiss_stale_reviews_on_push` and `require_last_push_approval`. Classic protection is not filling the gap. Verified 2026-08-01; the query is in the issue so the next reader re-checks rather than trusting the date.

`docs/ci-policy.md` §2 states four review guarantees as applied policy. **None of the four is enforced.** `CODEOWNERS` still routes review *requests*, so from inside a PR the mechanism looks alive — reviewers get requested — but nothing blocks a merge on it. §2 also builds a `[skip-review]` exception class on top of a requirement that does not exist.

## Why filed and not fixed

Found by the same ruleset query that proved `linear-tests` was not required (#3949, merged). But it is a different kind of finding, which is why it is not folded into that PR:

- `linear-tests` was **a typo in a list** — correcting the prose fully resolved it.
- This is **a control the project believes it has**. Correcting §2 to say "reviews are not enforced" *documents* the hole; it does not close it. Adding a `pull_request` rule so the docs become true changes what is enforced on `main` for every contributor — and, since every agent PR here is self-merged, enforcing review with self-approval disallowed would mean no dev agent can land its own work. That is either the intent or a full stop, and it should not be decided by side effect.

So the issue records the measurement and presents Option A (enforce) vs Option B (document the absence) **without picking one**. Same disposition as `scripts/enable-branch-protection.sh` in #3949: documented, not edited, because changing it alters enforcement rather than documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSXz9G2eZrfNeX3satN5X
