### PR TITLE
fix(#3934): stub-guard must fire by construction — retract the `!cancelled()` reasoning

### DIFF
--- a/.github/workflows/test262-pr-stub.yml
+++ b/.github/workflows/test262-pr-stub.yml
@@ -86,6 +86,8 @@ env:
 # Read-only: this workflow diffs a shallow checkout and reports job status.
 permissions:
   contents: read
+  # stub-guard reads the PR's current head SHA to detect a superseded run.
+  pull-requests: read
 
 concurrency:
   group: test262-pr-stub-${{ github.event.pull_request.number }}
@@ -326,22 +328,67 @@ jobs:
   stub-guard:
     name: test262 PR stub — verdict published
     needs: [detect, cheap-gate, merge-report, regression-gate]
-    # `!cancelled()`, deliberately NOT `always()`:
-    #   - a job-level TIMEOUT on `detect` cancels that JOB, not the RUN, so
-    #     `cancelled()` is false and this guard RUNS — the case we must report;
-    #   - a CONCURRENCY cancel cancels the RUN, so `cancelled()` is true and
-    #     this guard does NOT run — correct: a newer push superseded this SHA
-    #     and there is nothing to report.
-    # Evidence the two are distinguishable, from run 30645425429 (the 5m01s
-    # timeout on PR #3919): after `detect` was killed the three downstream jobs
-    # still had their `if:` EVALUATED — they concluded `skipped`, timestamped
-    # after detect's death. A run in the cancelling state would have cancelled
-    # them outright instead.
-    if: ${{ !cancelled() }}
+    # `always()`, and the superseded-SHA check is INSIDE the job. This was
+    # `!cancelled()` and the reasoning behind that was wrong — retracted here
+    # rather than left to be inherited.
+    #
+    # The retracted claim: "a job-level timeout cancels the JOB, not the RUN, so
+    # `cancelled()` is false and the guard fires", cited to run 30645425429
+    # where the three downstream jobs concluded `skipped` after `detect` was
+    # killed. **That citation proves nothing.** Those jobs carry
+    # `if: needs.detect.outputs.stub_required == 'true'` with no status
+    # function, so the IMPLICIT `success()` applies: a non-success `needs` skips
+    # them without the expression ever being evaluated. The outcome is identical
+    # whether or not the run was cancelling, so it cannot discriminate.
+    # Worse, that run's own RUN-level conclusion is `cancelled`
+    # (`gh api repos/loopdive/js2/actions/runs/30645425429 --jq .conclusion`),
+    # which is at least consistent with `cancelled()` being TRUE on a job
+    # timeout — in which case `!cancelled()` would SKIP this guard in exactly
+    # the case it exists for, and the whole non-silence guarantee would be
+    # empty. Nobody has measured which it is.
+    #
+    # So do not depend on the answer. `always()` fires unconditionally — the
+    # guarantee then holds BY CONSTRUCTION rather than by an unverified reading
+    # of `cancelled()` semantics. The cost of `always()` is that this job also
+    # runs when the RUN was cancelled by the concurrency group (a newer push
+    # superseded this SHA), which is noise; the first step below suppresses
+    # exactly that case by asking whether the SHA we were built for is still the
+    # PR head. That test is direct evidence about the thing we actually care
+    # about, instead of an inference from a status function.
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Under `always()` this job also runs on a concurrency cancel. That is the
+      # only case worth suppressing, and it is directly observable: a newer push
+      # means the PR's head has moved off the SHA this run was built for.
+      #
+      # FAIL-LOUD on doubt. If the lookup itself fails we do NOT suppress — an
+      # unreadable head SHA must not be treated as "superseded, nothing to see".
+      # The cost of that asymmetry is a spurious red on an abandoned SHA; the
+      # cost of the other one is the silence this whole job exists to end.
+      - name: Skip if this SHA has been superseded
+        id: superseded
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_SHA: ${{ github.event.pull_request.head.sha }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          current=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null) || current=""
+          echo "event head : $EVENT_SHA"
+          echo "current head: ${current:-<lookup failed>}"
+          if [ -n "$current" ] && [ -n "$EVENT_SHA" ] && [ "$current" != "$EVENT_SHA" ]; then
+            echo "-> superseded by a newer push; nothing to report for this SHA."
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "superseded=false" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+
       - name: Assert detect published a verdict
+        if: steps.superseded.outputs.superseded != 'true'
         env:
           DETECT_RESULT: ${{ needs.detect.result }}
           DETECT_DEGRADED: ${{ needs.detect.outputs.degraded }}

--- a/tests/issue-3934.test.ts
+++ b/tests/issue-3934.test.ts
@@ -210,11 +210,25 @@ describe("#3934 — the stub's job budget cannot silently strand a PR", () => {
   it("stub-guard makes a dead detect LOUD, and stays quiet on a concurrency cancel", () => {
     const guard = JOBS.get("stub-guard")!;
 
-    // `always()` would also fire when the whole RUN is cancelled (a newer push
-    // superseded this SHA) — noise on a SHA nobody is waiting for. A job-level
-    // timeout cancels the JOB, not the run, so `!cancelled()` still fires there.
-    expect(jobAttr(guard, "if")).toBe("${{ !cancelled() }}");
-    expect(jobAttr(guard, "if")).not.toContain("always()");
+    // MUST be `always()`, not `!cancelled()`. Whether `cancelled()` is true when
+    // a job dies to its own `timeout-minutes` is UNMEASURED — and run
+    // 30645425429's RUN-level conclusion is `cancelled`, which is at least
+    // consistent with it being true. If it is, `!cancelled()` would skip this
+    // guard in exactly the case it exists for, and the non-silence guarantee
+    // would be empty. `always()` makes the guarantee hold by construction.
+    expect(jobAttr(guard, "if")).toBe("${{ always() }}");
+    expect(jobAttr(guard, "if")).not.toContain("cancelled()");
+
+    // The cost of always() — also running on a concurrency cancel — must be
+    // paid by a DIRECT check (has the PR head moved off this SHA?), not by a
+    // status function whose semantics nobody has measured.
+    const steps = stepBlocks(guard);
+    const supersededStep = steps.find((s) => /id:\s*superseded\b/.test(s));
+    expect(supersededStep, "guard must self-suppress on a superseded SHA").toBeDefined();
+    expect(supersededStep!).toContain("head.sha");
+    // And it must fail loud when it cannot tell: a failed lookup must NOT be
+    // treated as "superseded, nothing to see here".
+    expect(supersededStep!).toMatch(/-n "\$current"/);
 
     const needs = jobAttr(guard, "needs")!;
     for (const dep of ["detect", "cheap-gate", "merge-report", "regression-gate"]) {


### PR DESCRIPTION
Self-correction on #3949 (merged). **The guard I added there may never fire in the case it exists for, and my justification for its gating condition was invalid.** Retracting rather than leaving it to be inherited.

## What was wrong

`stub-guard` was gated on `!cancelled()`, justified in the workflow comment and in the issue file as:

> a job-level TIMEOUT cancels the JOB, not the RUN, so `cancelled()` is false and this guard RUNS

cited to run 30645425429, where the three downstream jobs concluded `skipped` after `detect` was killed.

**That citation proves nothing.** Those three jobs carry `if: needs.detect.outputs.stub_required == 'true'` — no status function — so the **implicit `success()`** applies: a non-success `needs` job skips them *without the expression ever being evaluated*. That outcome is identical whether or not the run was in a cancelling state. It cannot discriminate the two hypotheses, and I read it as if it could.

**The risk is live, not theoretical.** That same run's RUN-level conclusion is `cancelled`:

```sh
gh api repos/loopdive/js2/actions/runs/30645425429 --jq .conclusion   # "cancelled"
```

which is at least consistent with `cancelled()` being TRUE on a job timeout. If it is, `!cancelled()` **skips the guard in exactly the case it was built for**, and #3934's whole "if it dies anyway it is LOUD" guarantee is empty. #3949's green run exercised only the happy path — the `exit 1` branch has never executed.

## The fix

Do not depend on an unmeasured semantics.

- **`always()`** fires unconditionally, so the guarantee holds **by construction** rather than by a reading of `cancelled()` that nobody has pinned down.
- Its one cost — also running when the run is cancelled by the concurrency group — is paid by a **direct check**: has the PR's head moved off the SHA this run was built for? That is evidence about the thing actually being asked, instead of an inference from a status function.
- That check **fails loud on doubt**: if the head lookup fails, the job does *not* suppress. An unreadable head SHA must never read as "superseded, nothing to see here". The cost of that asymmetry is a spurious red on an abandoned SHA; the cost of the other direction is the silence this job exists to end.
- Adds `pull-requests: read` for the lookup (read-only, fine for fork PRs).

## Verification

`tests/issue-3934.test.ts` updated to assert `always()`, the presence of the superseded step, and its fail-loud shape. **Mutation-verified**: reverting the workflow to `!cancelled()` fails exactly one test; restoring it passes 41/41.

The underlying question — *is `cancelled()` true when a job dies to its own `timeout-minutes`?* — remains **UNMEASURED**, and is now recorded as such in the workflow comment. This change makes the answer not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSXz9G2eZrfNeX3satN5X
