### PR TITLE
docs: correct a stale acorn claim in the pass-overlap log

### DIFF
--- a/plan/log/binaryen-pass-overlap-experiment.md
+++ b/plan/log/binaryen-pass-overlap-experiment.md
@@ -114,9 +114,10 @@ Two secondary readings:
 
 1. **`wasm-opt -O3` absorbs essentially all of it.** Turning off all four passes
    grows the pre-optimizer binary by 2.0% (corpus A) / 6.7% (corpus B) and moves
-   the shipped `-O3` artifact by **8 bytes out of 98,605** (corpus A) and **0
-   bytes** (corpus B). On acorn, no arm measured so far moves the `-O3`
-   artifact at all.
+   the shipped `-O3` artifact by **8 bytes out of 98,605** (corpus A), **0
+   bytes** (corpus B) and **54 bytes out of 343,881** (corpus C, acorn) — all
+   54 of which come from `peephole`; the three IR passes move acorn's `-O3`
+   output by zero bytes.
 2. **…but the passes barely run.** Only 25 IR functions in all of acorn reach
    the hygiene pipeline. A pass cannot demonstrate value on code it never
    sees, so this is weak evidence for redundancy and strong evidence that the


### PR DESCRIPTION
## Description

Docs-only follow-up to #3941 (merged). One sentence, one file.

`plan/log/binaryen-pass-overlap-experiment.md` shipped with a self-contradiction. The Reading section said:

> On acorn, no arm measured so far moves the `-O3` artifact at all.

That was written while the acorn run was still in flight and was never updated when it finished. The corpus C table sixty lines above it records **+54 bytes** for both `no-peephole` and `all four off`, and the Recommendation section attributes exactly those 54 bytes to `peephole` — so the document asserted both "zero" and "+54" about the same measurement.

Corrected to state all three corpora in one place and to attribute the acorn delta correctly:

> …moves the shipped `-O3` artifact by **8 bytes out of 98,605** (corpus A), **0 bytes** (corpus B) and **54 bytes out of 343,881** (corpus C, acorn) — all 54 of which come from `peephole`; the three IR passes move acorn's `-O3` output by zero bytes.

No measurement changed; this only makes the prose agree with the tables and the recommendation that were already correct.

Branch was restarted from `origin/main` after #3941 merged, per the merged-PR rule, so this PR carries one commit.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8WZU98KY8TzEsktMcbZEm)_