### PR TITLE
docs(#3571,#3976): P3 uncurryThis seam refuted by measurement — 1.7%, not 1,810; retarget to class-element own-properties

### DIFF
--- a/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
+++ b/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
@@ -1,9 +1,10 @@
 ---
 id: 3571
 title: "standalone: Function.prototype.call/apply/bind on builtin methods (uncurryThis/propertyHelper blocker)"
-status: ready
+status: in-progress
 created: 2026-07-24
-updated: 2026-07-24
+updated: 2026-07-26
+assignee: ttraenkler/opus-loop-c
 priority: high
 feasibility: hard
 model: fable
@@ -106,3 +107,69 @@ and is Fable-gated (cf. #2773 value-rep, #2984, #2744).
   (2026-07-24). Contained slices in that lane (WeakMap/WeakSet iterable ctor,
   Symbol.matchAll whitelist, Set host-leak wiring) are being harvested
   separately.
+
+---
+
+## S1 baseline re-measurement (opus-loop-c, 2026-07-26) — and a CORRECTION
+
+This issue **is #3603's slice S1**, which #3603 states must land FIRST: it
+un-vacuums the host lane's `verifyProperty` on its own, it is the prerequisite
+for S2 not producing traps, and it is *the only slice that can prove itself
+today* (the detector in `plan/probes/3603/ab.mts` is already calibrated for the
+host lane). Claimed on that basis, not as a parallel effort.
+
+Baseline re-run of the calibrated harness `plan/probes/3603/uncurry.mts` on
+`upstream/main` (it does NOT touch the shared `test262/harness` symlink — only
+`ab.mts` does — so it is safe to run alongside other lanes):
+
+| case                              | host     | standalone      |
+| --------------------------------- | -------- | --------------- |
+| `uncurried-push-works`            | **fail** | **fail** (trap) |
+| `uncurried-join-works`            | pass     | **fail** (trap) |
+| `uncurried-hasown-objlit`         | pass     | **fail**        |
+| `uncurried-hasown-desc-shape`     | pass     | **fail**        |
+| `failure-accumulation-end-to-end` | **fail** | **fail** (trap) |
+| `runtime-hasown-via-any-param`    | pass     | **fail**        |
+| `runtime-keys-via-any-param`      | pass     | **fail**        |
+| `runtime-forin-via-any-param`     | pass     | **fail**        |
+| `push-then-join-discriminator`    | **fail** | **fail** (trap) |
+| `push-then-index0-discriminator`  | **fail** | **fail** (trap) |
+| `native-push-control` (CONTROL)   | **pass** | **pass**        |
+
+Host **4/10 fail**, standalone **10/10 fail** (5 as uncatchable traps). The
+positive control passes on both lanes, so the harness is live and these are
+real failures, not probe artifacts.
+
+### CORRECTION to this issue's stated root cause
+
+The problem statement above says the bound builtin method "loses its explicit
+receiver". **That is refuted on the host lane by this table.** If the receiver
+were dropped, `__hasOwnProperty(o, "a")` would fail — it **passes** on host. So
+does `__join`. On host, *only* the `__push` family fails:
+
+- `uncurried-push-works`, `failure-accumulation-end-to-end`,
+  `push-then-join-discriminator`, `push-then-index0-discriminator` — all four
+  are the same defect, and all four **mutate** the receiver.
+- `__join` and `__hasOwnProperty` only **read** it, and both work.
+
+So the host-lane defect is **receiver mutation not being observed by the
+caller** — a value-vs-reference/identity problem — **not** receiver dropping.
+That is a different fix from the one this issue's text implies, and it must be
+confirmed before implementing. The receiver-dropping description may still hold
+for the **standalone** lane, where even the read-only cases fail; the two lanes
+must be diagnosed separately rather than assumed to share a cause.
+
+**Do not implement against the original hypothesis without re-deriving it from
+this table.** The 109-test cluster figure above was measured on the standalone
+Map/Set/Symbol lane and is not evidence for the host mechanism.
+
+### Ordering / cross-lane note
+
+- #3603 (S2+) is claimed by another lane and depends on S1 landing first.
+  Coordinate before changing anything `propertyHelper.js` runs through: S1
+  changes what the harness *can do* while #3603 changes what it *asserts*, and
+  a moving harness would make both sets of numbers unpublishable.
+- **#3642** (instance member value-read of a builtin method is `null` on BOTH
+  lanes) is a separate, newly-filed cross-lane defect in the same substrate.
+  It is plausibly upstream of the standalone half of this issue — check it
+  before designing the standalone fix.

--- a/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
+++ b/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
@@ -1,11 +1,11 @@
 ---
 id: 3571
-title: "standalone: Function.prototype.call/apply/bind on builtin methods (uncurryThis/propertyHelper blocker)"
-status: in-progress
+title: "standalone: builtin objects not reified as values (was: Function.prototype.call/apply/bind uncurryThis — MECHANISM REFUTED, see 2026-08-01 section)"
+status: ready
 created: 2026-07-24
-updated: 2026-07-26
-assignee: ttraenkler/opus-loop-c
-priority: high
+updated: 2026-08-01
+assignee: ttraenkler/sendev-p3-uncurry
+priority: medium
 feasibility: hard
 model: fable
 task_type: conformance
@@ -13,9 +13,14 @@ area: codegen
 language_feature: function-dispatch
 goal: standalone
 sprint: current
-horizon: l
+horizon: m
 parent: 2860
-related: [2773, 2984, 2744, 2175]
+related: [2773, 2984, 2744, 2175, 3976, 3642, 3603]
+# (2026-08-01) Priority high -> medium and horizon l -> m: the uncurryThis seam
+# is measured at 1.7% of the 1,810-file routing population it was scheduled on
+# (0% on a stratified sample of this issue's OWN signature). The corrected
+# standalone scope is "builtin objects are not reified as inspectable values",
+# bounded at 217 files. The dominant cause in that population is #3976.
 ---
 
 # standalone: `Function.prototype.call`/`apply`/`bind` on builtin methods (uncurryThis / propertyHelper blocker)
@@ -265,3 +270,113 @@ signature was a property of **where** the failure surfaced — a frame
 #3638's 43-row bucket that was ten different builtins, visible in about two
 minutes of reading the file list, and it turned a "43-row defect" into a 16-row
 one plus nine unrelated causes.
+
+---
+
+# MECHANISM CORRECTED — the standalone arm is NOT a receiver drop (sendev-p3-uncurry, 2026-08-01)
+
+> **The "P3 uncurryThis / propertyHelper seam" was scheduled as an XL target on
+> the figure "1,810 standalone-only failures route through `propertyHelper.js`".
+> Measured causally, the uncurryThis idiom is worth 1.7 % of that. The headline
+> diagnosis below — that `Function.prototype.call.bind` drops the explicit
+> receiver — is REFUTED for the standalone arm by 32/40 on a stratified sample of
+> this issue's OWN documented signature.**
+>
+> Everything here is measured with controls. **Do not re-derive it by reading.**
+
+## Instrument calibration (do this before trusting any number here)
+
+Standalone official rows **43,106 / 25,460 pass (59.1 %)** — exact match to
+baseline run `20260801-010858`. The propertyHelper population reproduces to the
+row: **1,494 pass / 1,810 fail-and-host-pass**.
+
+(My static include-scan finds **5,206** files vs the earlier 4,898. The gap is
+**743 files with no official standalone row**, reported rather than dropped. The
+two load-bearing numbers match exactly.)
+
+## Attribution instrument — a harness-level kill switch
+
+The four uncurried captures on `propertyHelper.js:29-32` are replaced in a
+**private per-worktree harness copy** (symlink restored on every exit path).
+`assembleOriginalHarness` caches sources in a module-private `Map`, so an
+in-process switch is impossible ⇒ **one arm per process**. Cross-process
+comparability was therefore an assumption, so it was **measured**: **arm A run
+twice gave 36/36 identical rows.**
+
+| arm    | what it does                                      | verdict                                                                                                                                                      |
+| ------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **B1** | drop only the `call.bind` layer, keep `.call`     | **INSTRUMENT INVALID** — broke all 6 positive controls                                                                                                       |
+| **B2** | remove ALL reflective dispatch from the captures  | valid — controls 6/6 in both arms                                                                                                                            |
+
+**B1 is reported despite being discarded**, because it teaches something:
+`Array.prototype.push.call(...)` is a **deliberate codegen refusal**
+(`src/codegen/array-prototype-borrow.ts:1144`, #1888 Slice 3/4). The stock
+uncurried spelling **evades that refusal syntactically**; rewriting it to the
+literal `.call` form makes it visible and the compile fails.
+
+B2's controls are load-bearing rather than decorative: `verifyProperty` asserts
+`__hasOwnProperty(obj,name)` is **true**, so a green control proves the
+*replacement itself* works and is not vacuously passing.
+
+## Result
+
+| sample                                                              | n       | fail→pass       | pass→fail | controls     |
+| ------------------------------------------------------------------- | ------- | --------------- | --------- | ------------ |
+| random, seeded, from the 1,810                                      | **120** | **2 (1.7 %)**   | 0         | 6/6 both arms |
+| stratified — the 217 files carrying THIS issue's documented signature | **40**  | **0 (0 %)**     | 0         | 6/6 both arms |
+
+95 % CI on 2/120 ≈ 0.2–5.9 % ⇒ projected **~30 files of 1,810 (CI ~4–107)**.
+95 % upper bound on the stratified 0/40 ≈ 8.8 %.
+
+## WHY it is zero — the mislabel, located
+
+A probe arm labels **where** the throw originates. This is decidable from the
+harness's own structure: `verifyProperty` reaches line 48
+`__getOwnPropertyDescriptor(obj, name)` **before** line 64's uncurried
+`__hasOwnProperty(obj, name)` — and line 27 captures gOPD **directly**
+(`var __getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor`), i.e. **not
+via uncurryThis at all**.
+
+On the 40 files carrying this issue's own signature (controls 6/6 valid):
+
+| n         | origin                                                     |
+| --------- | ---------------------------------------------------------- |
+| **32/40** | `obj` is **ALREADY nullish when `verifyProperty` is entered** |
+| 4         | threw at harness line 62                                    |
+| 3         | threw earlier still, before the probe                      |
+| 1         | threw at harness line 61                                    |
+
+**80 % never reach the uncurried captures.** The receiver is not *dropped* by
+`Function.prototype.call.bind` — it is *missing before the call is made*, because
+the builtin under test (`Number`, `Date`, `TypedArray.prototype.keys`, …) is
+**not reified as a value** in the standalone lane.
+
+⇒ **This is a missing VALUE, not a receiver DROP.** That relabel is the point:
+the wrong mechanism is why this issue's 109-test cluster figure never converted,
+and leaving it in place guarantees the next lane repeats the work.
+
+## Corrected scope for this issue
+
+- **The standalone arm is "builtin objects are not reified as inspectable
+  values"** — bounded at **217 files** (12 % of the 1,810), of which ~80 % show
+  the nullish-receiver origin above. Size it by sampling, not by the 217.
+- The **`__bindfn` invalid-Wasm cluster** (25 files here, 28 corpus-wide) is a
+  **compile-time** sub-mode and stays separate — see `compileFunctionBind`'s
+  standalone arm, `src/codegen/expressions/calls.ts:2249-2300`. A synthetic
+  `Function.prototype.call.bind(...)` does **not** reproduce it.
+- The **host arm remains DONE via #3635**, with the denominator caveat recorded
+  above (the `uncurry.mts` harness does not cover length-preserving mutation).
+  Nothing measured here contradicts the S1 analysis in `66ab19f84`; it is
+  carried forward in this branch rather than left to rot.
+- **The dominant cause in this population is NOT this issue** — it is
+  **#3976** (class elements not installed as own properties): 826 of the 1,810,
+  ~28× this issue's measured lever.
+
+## Method note — what actually generalises
+
+**A routing bound is not a causal bound.** "1,810 files *include* the harness
+that reports the failure" proves the files pass *through* the shape; it says
+nothing about whether the shape is *why* they fail. The distance between the two
+here was **1,810 vs ~30 — a factor of ~60**. The cheap instrument that settles it
+is a **kill switch on the suspected mechanism plus positive controls that
+exercise the replacement**, and it cost ~40 minutes against an XL estimate.

--- a/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
+++ b/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
@@ -173,3 +173,81 @@ Map/Set/Symbol lane and is not evidence for the host mechanism.
   lanes) is a separate, newly-filed cross-lane defect in the same substrate.
   It is plausibly upstream of the standalone half of this issue — check it
   before designing the standalone fix.
+
+---
+
+## RESULT — the HOST arm of this issue is DONE, closed by #3635
+
+Same calibrated harness (`plan/probes/3603/uncurry.mts`), **unchanged**, re-run
+against `upstream/main` **merged with `issue-3603-s1-uncurry-this`** (PR #3635,
+`src/runtime/vec-mirror-writeback.ts` + 14 wiring lines, zero codegen bytes):
+
+| case                              | host BEFORE | host AFTER | standalone (both) |
+| --------------------------------- | ----------- | ---------- | ----------------- |
+| `uncurried-push-works`            | fail        | **pass**   | fail (trap)       |
+| `uncurried-join-works`            | pass        | pass       | fail (trap)       |
+| `uncurried-hasown-objlit`         | pass        | pass       | fail              |
+| `uncurried-hasown-desc-shape`     | pass        | pass       | fail              |
+| `failure-accumulation-end-to-end` | fail        | **pass**   | fail (trap)       |
+| `runtime-hasown-via-any-param`    | pass        | pass       | fail              |
+| `runtime-keys-via-any-param`      | pass        | pass       | fail              |
+| `runtime-forin-via-any-param`     | pass        | pass       | fail              |
+| `push-then-join-discriminator`    | fail        | **pass**   | fail (trap)       |
+| `push-then-index0-discriminator`  | fail        | **pass**   | fail (trap)       |
+| `native-push-control` (CONTROL)   | pass        | pass       | pass              |
+
+**Host 4/10 → 0/10. Control still green on both lanes. Standalone unchanged at
+10/10 fail, 5 of them uncatchable traps.**
+
+So #3635 covers the host arm **including the uncurried spelling** — the
+falsifiable alternative (that it fixed only the direct `.call` spelling and left
+`__push` broken) is refuted. This is a **second, independent harness** agreeing
+with #3635's own tests, reached from the opposite direction:
+
+- I derived the mechanism from a **behavioural split** — the 4 failing host
+  cases all MUTATE the receiver (`__push`), the 2 passing ones
+  (`__hasOwnProperty`, `__join`) only READ it, and native `a.push(x)` passes.
+- #3635 derived it from **mirror identity** — the vec argument arrives as the
+  `__make_iterable` mirror, a real JS array that `convertToJS` refreshes FROM
+  the vec on every crossing (#3368), so the host appends to an array the Wasm
+  side never consults.
+
+Those are the same defect. Read-only crossings never needed the write-back,
+which is exactly why they were never broken. Convergence from two harnesses is
+much stronger evidence than either alone.
+
+### What remains: the STANDALONE arm only
+
+**Do not re-implement the host arm.** The remaining work is standalone, where
+all 10 rows still fail and the mechanism may genuinely differ (5 rows trap
+rather than returning a wrong value).
+
+### Success metric — corrected, and this matters
+
+The original plan assumed uncurryThis vacuity was what gates `verifyProperty` on
+standalone. **It is not** — that is the HOST mechanism. #3603's detector
+separates `NO_CHECKS` (no descriptor check ran) from `SWALLOWED` (a check ran,
+the report was lost), and on standalone **every legible message said
+`NO_CHECKS`; none said `SWALLOWED`**. The four descriptor guards are already
+false before `__push` is ever reached, because they are `__hasOwnProperty(desc, …)`
+queries against a plain object literal — #3603's root cause A.
+
+⇒ **Fixing this issue's standalone arm will NOT un-vacuum `verifyProperty` on
+standalone.** Measure **trap / dispatch-failure reduction** instead. If you
+measure verifyProperty flips you will get ≈0 and wrongly conclude a correct fix
+did nothing. It also means this issue and #3603 S2 cannot double-attribute rows
+— different gates entirely.
+
+The 109-test cluster figure earlier in this issue was measured on the standalone
+Map/Set/Symbol lane and is **not** evidence for the host mechanism.
+
+### Method note worth keeping
+
+A cluster sharing a failure signature is a **population to be enumerated, never
+a forecast to be multiplied**. In every instance seen on 2026-07-25/26 the
+signature was a property of **where** the failure surfaced — a frame
+(`__module_init`, an `assert.throws` callback) or a message string — never of
+**what** was wrong. Ask what VARIES inside the cluster before counting it; for
+#3638's 43-row bucket that was ten different builtins, visible in about two
+minutes of reading the file list, and it turned a "43-row defect" into a 16-row
+one plus nine unrelated causes.

--- a/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
+++ b/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
@@ -216,6 +216,20 @@ Those are the same defect. Read-only crossings never needed the write-back,
 which is exactly why they were never broken. Convergence from two harnesses is
 much stronger evidence than either alone.
 
+### SCOPE LIMIT on "host arm done" — read this before citing 0/10
+
+`uncurry.mts` exercises `push` (length-CHANGING), `join` and `hasOwnProperty`
+(read-only). It does **not** exercise **length-PRESERVING** mutations —
+`sort` / `reverse` / `fill` / `copyWithin`, or a bare `arr[i] = x` — through the
+uncurried/reflective spellings. #3635's author states those remain **silent
+no-ops by design** in that slice.
+
+So the honest claim is **"host 0/10 for the spellings this harness covers"**,
+NOT "every host reflective-mutation spelling now works". A follow-up harness
+covering length-preserving mutation is needed before the host arm can be called
+closed outright. Recorded because 0/10 is exactly the kind of round number that
+gets quoted without its denominator.
+
 ### What remains: the STANDALONE arm only
 
 **Do not re-implement the host arm.** The remaining work is standalone, where

--- a/plan/issues/3642-instance-member-value-read-of-builtin-method-is-null-both-lanes.md
+++ b/plan/issues/3642-instance-member-value-read-of-builtin-method-is-null-both-lanes.md
@@ -1,0 +1,92 @@
+---
+id: 3642
+title: "An instance member value-read of a builtin prototype method reads as null — on BOTH lanes (`var a=[1]; a.fill` → null)"
+status: ready
+sprint: current
+created: 2026-07-26
+priority: high
+horizon: m
+feasibility: hard
+task_type: bug
+area: codegen
+language_feature: function-dispatch
+goal: core-semantics
+related: [3638, 3571, 3603, 2984, 2773]
+origin: "measured while fixing #3638 (opus-loop-c, 2026-07-25)"
+---
+
+# Instance member value-read of a builtin method is `null` — both lanes
+
+> **This is a CROSS-LANE compiler correctness gap, not a standalone-lane gap.**
+> It is filed separately from #3571 and #3638 precisely so it is not read as a
+> footnote on a standalone trap bucket. Both numbers below were measured, on
+> both lanes, in the same process shape.
+
+## Measured (2026-07-25, `upstream/main`)
+
+Same source, same harness, only the compile target differs:
+
+| expression                          | standalone | host  |
+| ----------------------------------- | ---------- | ----- |
+| `var a=[1]; var f=a.fill; f ? 1 : 0`   | **0**      | **0** |
+| `… (f === null \|\| f === undefined)`  | **1**      | **1** |
+| `var f=Array.prototype.fill; f ? 1:0`  | 1          | 1     |
+| `var a=[1]; a.fill === Array.prototype.fill` | 0    | 0     |
+| `var a=[1,2]; a.fill(9); a[0]` (direct call) | 9    | 9     |
+
+So: the **direct call** `a.fill(9)` works, and the `.prototype` **value read**
+works — but the **instance value read** `a.fill` is null on both lanes, and
+`a.fill !== Array.prototype.fill` where §23.1.3 requires identity (an instance
+has no own `fill`; the read must reach `Array.prototype.fill` through the
+prototype chain and yield the same function object).
+
+## Why it matters beyond one method
+
+Any idiom shaped `<instance>.<method>.call(…)` / `.apply(…)` / `.bind(…)` is
+built on this. That includes the reflective-call family (#3571, #3603 S1) and
+ordinary user code (`var m = arr.map; m.call(arr, f)`).
+
+It also caused a **trap** until #3638: the reflective `.call` lowering cast that
+null receiver unconditionally, producing an uncatchable `illegal cast`. #3638
+compensated **at the call site** by resolving the instance spelling to the same
+singleton the `.prototype` spelling reads. **That is a compensation, not a fix
+— this issue is the fix.** With it closed, #3638's `isInstanceMemberProtoRead`
+special case can be reconsidered, and its pinned KNOWN GAP
+(`var f = [].fill; f.call(o, 1)` still traps) closes for free, because the
+identifier would then hold a real function value.
+
+## Where it is
+
+`tryCompileStandaloneBuiltinProtoMemberRead`
+(`src/codegen/builtin-value-read.ts`) requires the base to be literally
+`<Ident>.prototype`:
+
+```ts
+if (!ts.isPropertyAccessExpression(inner)) return undefined;
+if (inner.name.text !== "prototype") return undefined;
+```
+
+There is no instance-receiver counterpart, so the read falls through to the
+dynamic member path (`__extern_get(vec, "fill")`), which has no entry for a
+prototype method on a vec receiver and yields null. The host lane reaches the
+same null by its own route (it is NOT the same code path — that needs
+confirming before a shared fix is designed).
+
+## Acceptance criteria
+
+- `var a=[1]; a.fill` is a callable function value on both lanes.
+- `a.fill === Array.prototype.fill` (§23.1.3 identity — the singleton, not a
+  fresh wrapper per read; `pushBuiltinFnSingletonValueInstrs` is the existing
+  mechanism, cf. #2175 V2-S2).
+- `var f = arr.map; f.call(arr, fn)` works.
+- The #3638 KNOWN-GAP test flips (it is written to fail loudly when this lands).
+
+## Method notes for whoever takes this
+
+- **Assert identity, not truthiness.** "It returns something callable" is the
+  weaker claim and would be satisfied by a fresh `struct.new` per read, which
+  breaks `===` and was already rejected once (#2175 V2-S2).
+- **Do NOT verify with a `typeof x === "function"` string compare on
+  standalone** — dynamic-string `===` false-positives there (measured; see the
+  #2984 handoff). Use a numeric discriminant.
+- The host lane must be measured separately, not assumed to share the cause.

--- a/plan/issues/3642-instance-member-value-read-of-builtin-method-is-null-both-lanes.md
+++ b/plan/issues/3642-instance-member-value-read-of-builtin-method-is-null-both-lanes.md
@@ -1,6 +1,6 @@
 ---
 id: 3642
-title: "An instance member value-read of a builtin prototype method reads as null — on BOTH lanes (`var a=[1]; a.fill` → null)"
+title: "Standalone: an instance member value-read of a builtin prototype method reads as null (`var a=[1]; a.fill`) — host half CONTESTED, see Reconciliation"
 status: ready
 sprint: current
 created: 2026-07-26
@@ -15,14 +15,24 @@ related: [3638, 3571, 3603, 2984, 2773]
 origin: "measured while fixing #3638 (opus-loop-c, 2026-07-25)"
 ---
 
-# Instance member value-read of a builtin method is `null` — both lanes
+# Instance member value-read of a builtin method is `null`
 
-> **This is a CROSS-LANE compiler correctness gap, not a standalone-lane gap.**
-> It is filed separately from #3571 and #3638 precisely so it is not read as a
-> footnote on a standalone trap bucket. Both numbers below were measured, on
-> both lanes, in the same process shape.
+> **SCOPE CORRECTION (2026-07-26).** This issue was filed claiming the defect on
+> **BOTH** lanes. **The standalone half is confirmed. The host half is contested
+> and should NOT be relied on** — opus-loop-a measured the opposite with its own
+> positive controls, and on inspection **my host harness failed its own first
+> positive control**. See "Reconciliation" below. The title and this banner were
+> corrected rather than left standing: a cross-lane claim that turns out to be
+> single-lane is exactly the overstatement that gets a real defect dismissed.
+>
+> The **standalone** defect is real, reproduced in four independent compile
+> modes, and is what this issue tracks.
 
 ## Measured (2026-07-25, `upstream/main`)
+
+> **The `host` column below is the CONTESTED one** — it comes from the harness
+> whose own first positive control failed on host. Read the standalone column as
+> the finding; read the host column only alongside "Reconciliation".
 
 Same source, same harness, only the compile target differs:
 
@@ -34,8 +44,9 @@ Same source, same harness, only the compile target differs:
 | `var a=[1]; a.fill === Array.prototype.fill` | 0    | 0     |
 | `var a=[1,2]; a.fill(9); a[0]` (direct call) | 9    | 9     |
 
-So: the **direct call** `a.fill(9)` works, and the `.prototype` **value read**
-works — but the **instance value read** `a.fill` is null on both lanes, and
+So, **on standalone**: the **direct call** `a.fill(9)` works, and the
+`.prototype` **value read** works — but the **instance value read** `a.fill` is
+null, and
 `a.fill !== Array.prototype.fill` where §23.1.3 requires identity (an instance
 has no own `fill`; the read must reach `Array.prototype.fill` through the
 prototype chain and yield the same function object).
@@ -68,13 +79,14 @@ if (inner.name.text !== "prototype") return undefined;
 
 There is no instance-receiver counterpart, so the read falls through to the
 dynamic member path (`__extern_get(vec, "fill")`), which has no entry for a
-prototype method on a vec receiver and yields null. The host lane reaches the
-same null by its own route (it is NOT the same code path — that needs
-confirming before a shared fix is designed).
+prototype method on a vec receiver and yields null. **This locates the
+STANDALONE defect only.** Whether the host lane has any counterpart is exactly
+what is contested — do not design a shared fix off this paragraph.
 
 ## Acceptance criteria
 
-- `var a=[1]; a.fill` is a callable function value on both lanes.
+- `var a=[1]; a.fill` is a callable function value on **standalone** (add a
+  host arm only if the host claim survives the shared repro).
 - `a.fill === Array.prototype.fill` (§23.1.3 identity — the singleton, not a
   fresh wrapper per read; `pushBuiltinFnSingletonValueInstrs` is the existing
   mechanism, cf. #2175 V2-S2).
@@ -90,3 +102,64 @@ confirming before a shared fix is designed).
   standalone** — dynamic-string `===` false-positives there (measured; see the
   #2984 handoff). Use a numeric discriminant.
 - The host lane must be measured separately, not assumed to share the cause.
+
+---
+
+## Reconciliation — the host half is contested, and my harness is the suspect
+
+Two agents measured the same fact with positive controls and disagreed, so one
+harness is lying. Recording the state honestly rather than defending the
+original claim.
+
+### What I re-measured (4-mode matrix, stock `upstream/main`)
+
+Built specifically to test the hypothesis that the disagreement was a
+JS-mode-vs-TS-mode artifact. **That hypothesis is dead** — all four modes agree:
+
+| probe                                   | host TS | host JS | sa TS | sa JS |
+| --------------------------------------- | ------- | ------- | ----- | ----- |
+| `a.fill === null \|\| === undefined`    | 1       | 1       | 1     | 1     |
+| `a.fill ? 1 : 0` (truthiness, not `===`) | 0       | 0       | 0     | 0     |
+| `a.fill.call(a,9)` on `[1,1]`           | THROW `Cannot read properties of null (reading 'call')` | same | illegal cast | illegal cast |
+| `Array.prototype.fill.call(a,9)`        | **18**  | **18**  | **18** | **18** |
+
+### Why I do not trust my own host rows
+
+**My first positive control FAILED on host.** `export function test(){return 7;}`
+threw `WebAssembly.instantiate(): Import #0 "string…"` on the host lane while
+passing on standalone. Two later controls passed on host (`a[0]+a[1]` → 9,
+direct `a.fill(9)` → 18) and I routed around the failure. That was wrong: a
+failing control says the **host instantiation path used here**
+(`compile()` + `WebAssembly.instantiate(binary, r.importObject)` + `__setExports`)
+does **not** supply a complete host import object. Host-lane probes need the real
+import object via `runTest262File`.
+
+**The distinction that matters, and that this issue exists to record:** a
+positive control proves the detector **FIRES**. It does not prove the **CHANNEL
+carries the value faithfully**. Those are different guarantees. "Reads as null on
+host" is precisely the artifact a thin host import object manufactures. Two
+sibling traps found the same day on these exact channels: the standalone
+string-return channel reads back `undefined` in a naive harness, and
+`typeof X === "function"` evaluates false on host even when `typeof X` renders as
+`"function"`.
+
+### Contested in the other direction too
+
+opus-loop-a reports `Array.prototype.fill.call(a, 9)` **throws on standalone**.
+I measure **18** there, in all four modes, and separately `27` for the
+three-element version in an earlier run. So that row may be its artifact the way
+the host rows may be mine. Both halves need the same reconciliation: run one
+agreed repro verbatim, in one process, with controls on both sides.
+
+### Status of each claim
+
+| claim                                                     | status                          |
+| --------------------------------------------------------- | ------------------------------- |
+| standalone: `a.fill` reads null                            | **CONFIRMED** (4 modes)         |
+| standalone: instance `.call` traps `illegal cast`          | **CONFIRMED** (and fixed at the call site by #3638) |
+| host: `a.fill` reads null                                  | **CONTESTED — do not rely on**  |
+| standalone: `Array.prototype.fill.call(a,9)` works         | measured 18 here; loop-a reports a throw — **CONTESTED** |
+
+Until reconciled, treat this issue as **standalone-scoped**. The acceptance
+criteria below still stand for standalone; re-add a host arm only if the host
+claim survives a shared repro.

--- a/plan/issues/3642-instance-member-value-read-of-builtin-method-is-null-both-lanes.md
+++ b/plan/issues/3642-instance-member-value-read-of-builtin-method-is-null-both-lanes.md
@@ -1,6 +1,6 @@
 ---
 id: 3642
-title: "Standalone: an instance member value-read of a builtin prototype method reads as null (`var a=[1]; a.fill`) — host half CONTESTED, see Reconciliation"
+title: "Instance member value-read of a builtin prototype method reads as null — UNCONDITIONAL on standalone, SHAPE-DEPENDENT on host (`var a: any[]` and cast-at-use)"
 status: ready
 sprint: current
 created: 2026-07-26
@@ -17,16 +17,20 @@ origin: "measured while fixing #3638 (opus-loop-c, 2026-07-25)"
 
 # Instance member value-read of a builtin method is `null`
 
-> **SCOPE CORRECTION (2026-07-26).** This issue was filed claiming the defect on
-> **BOTH** lanes. **The standalone half is confirmed. The host half is contested
-> and should NOT be relied on** — opus-loop-a measured the opposite with its own
-> positive controls, and on inspection **my host harness failed its own first
-> positive control**. See "Reconciliation" below. The title and this banner were
-> corrected rather than left standing: a cross-lane claim that turns out to be
-> single-lane is exactly the overstatement that gets a real defect dismissed.
+> **RESOLVED 2026-07-26 — two harnesses now agree exactly.** This issue was
+> filed as an unqualified "BOTH lanes" claim; opus-loop-a measured the host half
+> the other way; both of us ran positive controls. The variable turned out to be
+> neither lane nor compile mode but the **declaration shape of the receiver**.
+> Settled by running loop-a's repro verbatim under a corrected host import
+> object — every row matches its numbers.
 >
-> The **standalone** defect is real, reproduced in four independent compile
-> modes, and is what this issue tracks.
+> - **Standalone: UNCONDITIONAL.** `a.fill` reads null in every shape tried.
+> - **Host: REAL but SHAPE-DEPENDENT.** `var a: any[]` (and an `as any`
+>   cast at the use site) read null; `const a: any` and untyped shapes are fine.
+>
+> So the original "BOTH lanes" headline was an **overstatement, not an error** —
+> and my host harness *was* broken, yet the finding survived the fix. Both facts
+> are recorded below because each is a separate lesson.
 
 ## Measured (2026-07-25, `upstream/main`)
 
@@ -155,11 +159,65 @@ agreed repro verbatim, in one process, with controls on both sides.
 
 | claim                                                     | status                          |
 | --------------------------------------------------------- | ------------------------------- |
-| standalone: `a.fill` reads null                            | **CONFIRMED** (4 modes)         |
-| standalone: instance `.call` traps `illegal cast`          | **CONFIRMED** (and fixed at the call site by #3638) |
-| host: `a.fill` reads null                                  | **CONTESTED — do not rely on**  |
+| standalone: `a.fill` reads null                            | **CONFIRMED, unconditional**    |
+| standalone: instance `.call` traps `illegal cast`          | **CONFIRMED** (fixed at the call site by #3638) |
+| host: `a.fill` reads null                                  | **CONFIRMED for `var a: any[]` / cast-at-use; NOT for `const a: any` or untyped** |
 | standalone: `Array.prototype.fill.call(a,9)` works         | measured 18 here; loop-a reports a throw — **CONTESTED** |
 
 Until reconciled, treat this issue as **standalone-scoped**. The acceptance
 criteria below still stand for standalone; re-add a host arm only if the host
 claim survives a shared repro.
+
+---
+
+## RESOLUTION — shared repro, both harnesses agree
+
+opus-loop-a's repro, run **verbatim** by opus-loop-c with a corrected host path
+(`buildImports(r.imports, undefined, r.stringPool)` + `setExports`), numeric
+channel only. Every row matches loop-a's independently-observed numbers.
+
+| # | source                                                    | host                              | standalone                        |
+| - | --------------------------------------------------------- | --------------------------------- | --------------------------------- |
+| A | `const a: any = [1,1]; a.fill == null`                    | **0**                             | **1**                             |
+| B | `var a: any[] = [1,1]; a.fill == null`                    | **1**                             | **1**                             |
+| C | `const a: any = [1,1]; a.fill.call(a,9)`                  | **18** (works)                    | **2** (silent no-op)              |
+| D | `var a: any[] = [1,1]; a.fill.call(a,9)`                  | **THREW** `Cannot read properties of null (reading 'call')` | **THREW** `illegal cast` |
+| E | `const a: any; (Array.prototype.fill as any).call(a,9)`   | **18**                            | **THREW** non-stringifiable `WebAssembly.Exception` |
+| F | `var a = [1,1]; Array.prototype.fill.call(a,9)` (untyped) | **18**                            | **18**                            |
+| G | `var a = [1,1]; a.fill.call(a,9)` (untyped)               | **THREW** (same V8 message)       | **THREW** `illegal cast`          |
+| — | `CTRL return 7`                                            | **7**                             | **7**                             |
+
+### The three things this settles
+
+1. **The variable is the declaration shape, not the lane and not the compile
+   mode.** A 4-mode matrix (host/standalone × TS/JS) had already agreed with
+   itself, which killed the mode hypothesis; the shape axis is what neither of
+   us had varied.
+2. **My earlier "contested" row is explained, and both of us were right.** Row E
+   (`as any` cast at the use site) throws on standalone; row F (untyped, my
+   original spelling) returns 18. Same method, same lane, different lowering —
+   so `Array.prototype.fill.call` is *also* shape-dependent. Neither number was
+   an artifact.
+3. **`CTRL return 7` now passes on host** (it failed in my earlier harness).
+   That confirms the harness bug I diagnosed — and note the punchline: with a
+   correct import object the host null **still reproduces** for shapes B, D, G.
+   The conclusion survived the broken harness.
+
+### Two lessons, and they are different lessons
+
+- **A positive control proves the detector FIRES; it does not prove the CHANNEL
+  carries the value faithfully.** My control failed on host and I routed around
+  it. Never do that: a failing control is a finding.
+- **A control passing does not license an unqualified claim.** My host rows were
+  reproducible and still the headline was wrong, because I varied lane and mode
+  but never varied **shape**. Before writing "on BOTH lanes", ask which axes were
+  actually varied — an unvaried axis is an assumption, not a measurement.
+
+### Consequence for the fix
+
+The acceptance criteria must hold **across shapes**, not just for the spelling a
+test happens to use. Any fix should be verified against all of A–G on both
+lanes; `const a: any` passing tells you nothing about `var a: any[]`.
+
+Probe kept at `.tmp/shared-repro.mts`; loop-a's originals at
+`.tmp/3603/shape-matrix.mts` and `.tmp/3603/proto-call-row.mts` in its worktree.

--- a/plan/issues/3976-standalone-class-elements-not-installed-as-own-properties.md
+++ b/plan/issues/3976-standalone-class-elements-not-installed-as-own-properties.md
@@ -1,0 +1,149 @@
+---
+id: 3976
+title: "standalone: class elements are not installed as own properties on the prototype/constructor — invisible to getOwnPropertyDescriptor/hasOwnProperty"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+assignee: ttraenkler/sendev-p3-uncurry
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: conformance
+area: codegen
+es_edition: ES6
+language_feature: class-elements
+goal: standalone
+horizon: l
+parent: 2860
+related: [3571, 3603, 2742, 3642]
+origin: "measured while REFUTING #3571's P3 uncurryThis seam (sendev-p3-uncurry, 2026-08-01)"
+---
+
+# standalone: class elements are not installed as own properties
+
+Under `--target standalone`, a class method/accessor is **callable** but is not
+an **own property** of the object it belongs to. `C.prototype` and `C` exist and
+are inspectable, but
+
+```js
+Object.getOwnPropertyDescriptor(C.prototype, "m")   // -> undefined  (should be a descriptor)
+Object.prototype.hasOwnProperty.call(C.prototype, "m")  // -> false  (should be true)
+```
+
+Per §15.7.14 (ClassElementEvaluation → `MethodDefinitionEvaluation` →
+`DefinePropertyOrThrow`) every non-private class element is installed with
+`{writable: true, enumerable: false, configurable: true}`. We install something
+that dispatches on call but is not reachable through the ordinary
+own-property/descriptor surface.
+
+## Why this issue exists — it is the residual of a REFUTED framing
+
+This was found while measuring **#3571's "P3 uncurryThis/propertyHelper seam"**,
+which was scheduled as an XL target on the figure *"1,810 standalone-only
+failures route through `harness/propertyHelper.js`"*. That figure is a **routing**
+bound. Measured causally, the uncurryThis idiom is worth **1.7 %** of it; this
+issue is worth roughly **28×** more. Full refutation in #3571. **Do not re-derive
+either result by reading — both were measured with controls.**
+
+## Measured population (full census, not a sample)
+
+Source: `.test262-cache/test262-standalone-current.jsonl` and
+`test262-current.jsonl`, same baseline run `20260801-010858`.
+**Instrument calibrated first**: standalone official rows **43,106 / 25,460 pass
+(59.1 %)** — exact match to the published baseline.
+
+Of the **1,810** files that include `propertyHelper.js`, fail standalone and
+pass on host:
+
+| n         | bucket                                                  |
+| --------- | ------------------------------------------------------- |
+| **1,136** | `Test262Error: obj should have an own property X` (63 %) |
+| 217       | receiver nullish / non-reified builtin (12 %)           |
+| 114       | standalone host-import leak                             |
+| 25        | invalid Wasm (`__bindfn_*` — see #3571, separate)       |
+
+Of those 1,136, **826 (73 %) are `language/{statements,expressions}/class`**.
+Class areas are **998 of the whole 1,810 (55 %)**.
+
+`verifyProperty` receiver across the class cluster:
+
+| n   | receiver      | meaning                            |
+| --- | ------------- | ---------------------------------- |
+| 690 | `C.prototype` | instance methods / accessors       |
+| 276 | `c`           | instance fields on an instance     |
+| 204 | `C`           | static methods / static fields     |
+| 192 | `rest`        | object-rest destructuring (adjacent) |
+
+## Root cause, measured — not inferred
+
+Instrument: `runTest262File(abs, cat, 60000, "standalone")` (**status only** is
+trustworthy; its error category and source location are artifacts — see
+`reference_runtest262file_not_ci_path_status_only`). A **probe arm** patches the
+real `test262/harness/propertyHelper.js` to distinguish *where* the failure
+originates. This matters because propertyHelper reaches line 48
+`__getOwnPropertyDescriptor(obj, name)` **before** line 64's uncurried
+`__hasOwnProperty(obj, name)`, and line 27 captures gOPD **directly**, not via
+uncurryThis.
+
+Stratified sample, 40 of the 826, seeded; **6 embedded positive controls green
+(6/6)**, so the reading is load-bearing:
+
+| n         | origin                                                     |
+| --------- | ---------------------------------------------------------- |
+| **40/40** | `obj` EXISTS, property genuinely ABSENT (gOPD → `undefined`) |
+| 0         | `obj` already nullish at entry                              |
+
+**Unanimous.** The receiver is fine; the property is not installed.
+
+## Ceiling — and read the caveat before quoting it
+
+A second arm makes `verifyProperty` an immediate `return true`, i.e. simulates
+*"class elements are installed perfectly with the expected descriptor"*.
+
+- **40/40 of the class sample pass** ⇒ the own-property gap is the **sole**
+  blocker in every sampled file (95 % lower bound ≈ 91 %).
+- **Discriminator control**: the same arm on the 40-file receiver-nullish sample
+  gives **32/40**, not 40/40 — so this arm is **not** trivially green and the
+  40/40 above is informative.
+
+⚠️ **This arm is VACUOUS BY CONSTRUCTION and is an UPPER BOUND only.** It also
+skips *descriptor correctness* (`writable`/`enumerable`/`configurable`), so an
+implementation that installs the property with the **wrong** attributes will
+score below this ceiling. Never quote 40/40 as a flip prediction.
+
+## Acceptance criteria
+
+- `Object.getOwnPropertyDescriptor(C.prototype, "m")` returns a descriptor with
+  `{writable: true, enumerable: false, configurable: true}` for a non-private
+  instance method; likewise on `C` for a static method.
+- `Object.prototype.hasOwnProperty.call(C.prototype, "m")` is `true`;
+  `Object.keys(C.prototype)` does **not** include `m` (non-enumerable).
+- Private elements (`#m`) remain **absent** from the own-property surface —
+  several tests in this cluster assert exactly that
+  (`!hasOwnProperty.call(C.prototype, "m")` for the private name).
+- **Report measured fail→pass / pass→fail on a standalone run with the sample
+  above**, plus the ceiling shortfall (how far below 40/40 the real fix lands and
+  why). Do not report the ceiling as the result.
+- Sizing discipline: **826 is the population GATED, not a forecast.** Measure the
+  attributable ratio on a seeded sample with controls before committing to a size
+  — that is exactly the step that refuted #3571.
+
+## Reproduction
+
+```js
+class C { m() { return 42; } static s() { return 1; } }
+// standalone: both are `undefined`; host: both are descriptors
+Object.getOwnPropertyDescriptor(C.prototype, "m");
+Object.getOwnPropertyDescriptor(C, "s");
+```
+
+## Notes
+
+- The **192 `rest`** files (object-rest destructuring skipping non-enumerable
+  properties) are in the same census bucket but are a **different** mechanism —
+  they need enumerability to be observable, which this issue supplies, but they
+  should be verified separately rather than counted as this issue's yield.
+- The 217 receiver-nullish files are a **separate** root cause (builtin objects
+  such as `Number`/`Date` not reified as values). Tracked in #3571; do not
+  double-attribute.

--- a/plan/issues/3976-standalone-class-elements-not-installed-as-own-properties.md
+++ b/plan/issues/3976-standalone-class-elements-not-installed-as-own-properties.md
@@ -147,3 +147,79 @@ Object.getOwnPropertyDescriptor(C, "s");
 - The 217 receiver-nullish files are a **separate** root cause (builtin objects
   such as `Number`/`Date` not reified as values). Tracked in #3571; do not
   double-attribute.
+
+## Fix shape — measured, with the two dead ends that cost the most
+
+Probes: `plan/probes/3976/synt.mts` (syntactic vs dynamic) and `synt2.mts`
+(value reachability). Both carry controls that pass on **both** lanes, so the
+readings are load-bearing.
+
+### It is NOT a syntactic-reach problem — which is good news
+
+The natural fear (and the exact trap that stopped #3571's P1 shape-matrix wins
+from converting) is that a fix in the compile-time path can't see through
+`propertyHelper`'s function boundary, where `obj`/`name` are **parameters**. Not
+the case here — **even the fully syntactic form already fails**:
+
+| probe                                                | host | standalone |
+| ---------------------------------------------------- | ---- | ---------- |
+| `gOPD(C.prototype, "m")` — literal receiver + key    | pass | **fail**   |
+| `gOPD(o, n)` — via parameters                        | pass | **fail**   |
+| `gOPD(C, "s")` — static, literal                     | pass | **fail**   |
+| `hasOwnProperty.call(o, n)` — via parameters         | pass | **fail**   |
+
+Both spellings fail, so one representation-level fix serves both. There is no
+syntactic/dynamic split to design around.
+
+### Where the host/standalone asymmetry actually lives
+
+`C.prototype` is a **`$ClassName` WasmGC struct** with all fields defaulted,
+converted to externref and cached in a lazy global `__proto_<Class>`
+(`src/codegen/expressions/extern.ts::emitLazyProtoGet`, registered in
+`src/codegen/class-bodies.ts` ~922). The method names ARE collected —
+`ctx.classMethodNames` / `ctx.classStaticMethodNames` (`class-bodies.ts`
+~1375-1420) — but they are handed to the **host** as a CSV via the
+`__register_prototype` **host import**, which populates `_methodNames` /
+`_staticMethodNames` in `src/runtime.ts` (~5060). That is what makes the host
+lane's descriptor surface correct.
+
+**Standalone has no counterpart.** The native `__getOwnPropertyDescriptor` /
+`__hasOwnProperty` / `__propertyIsEnumerable` understand only `$Object` hash-map
+receivers (`src/codegen/object-runtime.ts` ~8342), and a class prototype is not
+one — so every own-property query answers "absent". The compile-time data needed
+is **already computed**; only the standalone consumer is missing.
+
+### The method IS reachable as a value — the gap is the own-property surface
+
+| probe                                     | host     | standalone |
+| ----------------------------------------- | -------- | ---------- |
+| `typeof C.prototype.m === "function"`     | pass     | **pass**   |
+| `typeof c.m` / `typeof C.s`               | pass     | **pass**   |
+| `c.m === C.prototype.m` (§15.7 identity)  | pass     | **pass**   |
+| `new C().m()` / `C.s()`                   | pass     | **pass**   |
+
+So the function object exists, is shared, and dispatches. Only its presence in
+the descriptor/own-property surface is missing. That bounds the change: it does
+**not** require materializing new function objects.
+
+### Adjacent defect found while probing — do NOT fold it in
+
+`o[n]` where both are parameters (`function read(o,n){return o[n];}`) fails on
+**BOTH** lanes for a class method, while the direct `C.prototype.m` read passes
+on both. That is #3642's family, not this issue, and it is a **cross-lane**
+defect. It matters here only because it **invalidated an instrument** (arm S,
+see `plan/probes/3976/NOTES.txt`), not because it blocks this fix.
+
+### Consequence for slicing — read before sizing
+
+`verifyProperty` does not stop at presence. After
+`assert(__hasOwnProperty(obj,name))` it **mutates**: it writes an unlikely value
+to probe `writable`, and deletes to probe `configurable`. So a
+presence-and-descriptor-only fix will **not** flip a file that reaches those
+probes. The 40/40 ceiling (arm U) skips all of it and is an upper bound only.
+
+**Attempting to measure the realised yield of a presence-only fix produced two
+INVALID instruments** (a silent no-op, then a confounded one) — both recorded in
+`plan/probes/3976/NOTES.txt`. **The realised yield of slice 1 is therefore NOT
+yet measured.** Measure it against a real implementation before quoting a size;
+do not inherit the 826 or the 40/40.

--- a/plan/issues/3976-standalone-class-elements-not-installed-as-own-properties.md
+++ b/plan/issues/3976-standalone-class-elements-not-installed-as-own-properties.md
@@ -223,3 +223,52 @@ INVALID instruments** (a silent no-op, then a confounded one) — both recorded 
 `plan/probes/3976/NOTES.txt`. **The realised yield of slice 1 is therefore NOT
 yet measured.** Measure it against a real implementation before quoting a size;
 do not inherit the 826 or the 40/40.
+
+## Implementation plan (slice 1) — three in-tree precedents, not a new mechanism
+
+The shape this needs already exists three times over in the standalone lane:
+**reserve a native at emit time, fill it at finalize time once all metadata is
+registered, then prepend an early arm into the reflective natives.** See
+`fillBuiltinFnMeta` (#2896), `fillExternGetErrorProps` (#3130) and
+`fillObjVecReflectionHelpers` in `src/codegen/index.ts` (~4215-4245).
+
+`__hasOwnProperty` (`src/codegen/object-runtime.ts` ~3035) **already opens with
+exactly this kind of arm** — the `bfnGetMetaIdx` builtin-fn-metadata check that
+returns 1 early before the `$Object` cast. A class-proto arm goes in that same
+slot, ahead of the `ref.test $Object` bail-out that currently answers 0.
+
+Steps:
+
+1. **New native `__class_meta_find(obj, key) -> i32`** (standalone only),
+   reserved at emit time and filled by a new `fillClassProtoMeta(ctx)` after all
+   classes are registered. Body, per class with methods:
+   - identity-compare `obj` against the `__proto_<Class>` global ⇒ consult
+     `ctx.classMethodNames`;
+   - identity-compare against the `__class_<Class>` global ⇒ consult
+     `ctx.classStaticMethodNames`.
+
+   The identity compare is what keeps **instances** correct: `c` and
+   `C.prototype` are both `$ClassName` structs with the same `__tag`, but
+   `hasOwnProperty(c, "m")` must be **false** — only the prototype singleton
+   carries the method. Do **not** key this on `__tag`.
+
+2. **Prepend arms** into `__hasOwnProperty`/`__object_hasOwn` (return 1),
+   `__propertyIsEnumerable` (return **0** — class methods are non-enumerable),
+   and `__getOwnPropertyDescriptor` (synthesize
+   `{value, writable: true, enumerable: false, configurable: true}`; `value`
+   comes from the existing member read, which already works — see the value
+   table above).
+
+3. **Own-key enumeration** (`__getOwnPropertyNames`) should list the same names
+   so `Object.getOwnPropertyNames(C.prototype)` matches host. `Object.keys` must
+   NOT list them (non-enumerable).
+
+**Out of slice 1, deliberately**: `writable`/`configurable` are *behavioural* —
+`verifyProperty` probes them by writing and deleting. Making the synthesized
+descriptor claim `writable: true` without making the write actually take effect
+would trade a missing property for a **wrong** one, which is worse. Either
+implement the mutation path in the same slice or have `verifyProperty`'s probes
+fail honestly; do not fake the flags.
+
+**Private elements** (`#m`) must stay absent from all of the above — several
+tests in this cluster assert exactly that.

--- a/plan/probes/3976/NOTES.txt
+++ b/plan/probes/3976/NOTES.txt
@@ -1,0 +1,97 @@
+#3976 / #3571 — propertyHelper population: census + attribution harness
+=======================================================================
+
+These are the exact scripts behind every number in
+plan/issues/3976-standalone-class-elements-not-installed-as-own-properties.md
+and the 2026-08-01 section of
+plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md.
+
+They live under plan/ deliberately: `format:check` and `lint` are scoped to
+src/ tests/ scripts/, so nothing here is linted, formatted or executed by CI.
+Run by hand from a worktree root.
+
+Run order
+---------
+  node   plan/probes/3976/census.mjs               # CALIBRATE + build the population
+  node   plan/probes/3976/decompose.mjs            # full-census decomposition (no sampling)
+  node   plan/probes/3976/sample.mjs 120 20260801 .tmp/p3-big.json
+  npx tsx plan/probes/3976/arm.mts A  .tmp/p3-big.json .tmp/big-A.json
+  npx tsx plan/probes/3976/arm.mts B2 .tmp/p3-big.json .tmp/big-B2.json
+  node   plan/probes/3976/diff.mjs .tmp/p3-big-meta.json A=.tmp/big-A.json B2=.tmp/big-B2.json
+  npx tsx plan/probes/3976/synt.mts                # syntactic-vs-dynamic gOPD, both lanes
+  npx tsx plan/probes/3976/synt2.mts               # is the method reachable as a VALUE?
+
+census.mjs REFUSES to be trusted unless it reproduces the published standalone
+baseline exactly (43,106 official rows / 25,460 pass @ run 20260801-010858).
+If MATCH=false, fix the scan before reading anything downstream.
+
+The arms
+--------
+  A   stock harness (baseline)
+  A2  stock harness AGAIN — drift control, must equal A row-for-row
+  B1  uncurryThis -> literal `.call(...)`      [INSTRUMENT INVALID, see below]
+  B2  uncurryThis -> primitive, no reflection  [valid]
+  P   probe: WHERE does the throw originate (entry-nullish vs property-absent)
+  U   CEILING: verifyProperty -> `return true`. VACUOUS BY CONSTRUCTION.
+  S   simulate the #3976 fix, real probes still run [CONFOUNDED, see below]
+
+ONE ARM PER PROCESS — this is not optional
+------------------------------------------
+`assembleOriginalHarness` (tests/test262-original-harness.ts) caches harness
+sources in a module-private Map, so flipping the file mid-process has no effect
+after the first read. Each arm therefore runs in its own process over the same
+file list in the same order. That makes cross-process comparability an
+ASSUMPTION, so MEASURE it: run arm A twice and diff. On 2026-08-01 that gave
+36/36 identical rows.
+
+Safety
+------
+arm.mts REPLACES this worktree's test262/harness symlink with a private real
+copy and restores it on every exit path (including process.on("exit")). It
+REFUSES to start if the symlink is already missing — that means a previous run
+died without restoring. Restore by hand with:
+
+  rm -rf test262/harness && ln -s /workspace/test262/harness test262/harness
+
+WORKTREE-SAFE IS NOT SELF-SAFE. While an arm is in flight this worktree's
+propertyHelper.js is the PATCHED one. Do not run any other compile or probe in
+the same worktree during a run — it will silently measure the patched harness.
+Serialize, or use a second worktree.
+
+Three instrument failures worth keeping
+---------------------------------------
+1. ARM B1 BROKE ITS OWN CONTROLS (6/6 -> 0/6). Rewriting the uncurried captures
+   to the literal `.call` spelling makes `Array.prototype.push.call(...)`
+   syntactically visible, and that is a DELIBERATE codegen refusal
+   (src/codegen/array-prototype-borrow.ts:1144, #1888 Slice 3/4). The stock
+   uncurried spelling EVADES the refusal. The arm was discarded as an
+   attribution instrument but the finding was kept.
+
+2. ARM S v1 WAS A SILENT NO-OP. It rebound `__hasOwnProperty = __simPresent`.
+   A function-valued `var` reassignment does not take effect in compiled
+   standalone code, so all 40 rows still failed at the own-property gate and
+   the arm read as "the fix is worth 0". Caught ONLY because the failure
+   SIGNATURE was inspected rather than the pass count. Substitute CALL SITES,
+   never rebind.
+
+3. ARM S v2 WAS CONFOUNDED. Routing the query through a helper function changed
+   the call SHAPE, and the dynamic form answers differently from the direct one
+   (see synt2.mts: `o[n]` behind a function boundary fails on BOTH lanes). Its
+   controls went 6/6 -> 2/6, so it was discarded. Do not read its 0/40.
+
+The general rule these three share: a zero from an unproven arm is
+indistinguishable from a real zero. Every arm here carries positive controls
+that exercise the thing being replaced, and a control regression INVALIDATES
+the arm rather than being noted and ignored.
+
+Reading discipline
+------------------
+* `runTest262File` status is trustworthy; its error_category and source
+  location are ARTIFACTS (reference_runtest262file_not_ci_path_status_only).
+  Classify on the message text, not the `at L#` suffix.
+* Arm U is an UPPER BOUND and must never be quoted as a flip prediction — it
+  skips descriptor correctness (writable/enumerable/configurable) entirely.
+  Its discriminator check is that it gives 32/40 on the receiver-nullish
+  sample, not 40/40, so it is not trivially green.
+* A ROUTING bound is not a CAUSAL bound. "1,810 files include the harness that
+  reports the failure" was off by ~60x from the measured attributable share.

--- a/plan/probes/3976/arm.mts
+++ b/plan/probes/3976/arm.mts
@@ -1,0 +1,202 @@
+/**
+ * P3 attribution sweep — ONE ARM PER PROCESS.
+ *
+ * `assembleOriginalHarness` caches harness sources in a module-private Map, so
+ * an in-process kill switch is impossible; instead each arm runs in its own
+ * process over the IDENTICAL file list in the IDENTICAL order, and arm "A2"
+ * repeats arm A verbatim so ordering/load drift can be EXCLUDED empirically
+ * rather than assumed away.
+ *
+ * Arms:
+ *   A   stock harness (baseline)
+ *   B1  uncurryThis -> literal `.call(...)` spelling      (isolates call.bind)
+ *   B2  uncurryThis -> primitive spelling, NO reflection  (upper bound)
+ *   A2  stock harness again (drift control; must equal A row-for-row)
+ *
+ * usage: npx tsx .tmp/arm.mts <A|B1|B2|A2> <listfile> <outfile>
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { runTest262File } from "../tests/test262-runner.js";
+
+const [arm, listFile, outFile] = process.argv.slice(2);
+if (!arm || !listFile || !outFile) {
+  console.error("usage: arm.mts <A|B1|B2|A2> <listfile> <outfile>");
+  process.exit(2);
+}
+
+const WT = process.cwd();
+const HARNESS = path.join(WT, "test262", "harness");
+const PH = path.join(HARNESS, "propertyHelper.js");
+
+// ── the kill switch ────────────────────────────────────────────────────────
+// Replaces exactly the four uncurried captures on lines 29-32. Every call site
+// in propertyHelper.js passes exactly 2 arguments, so no rest/spread is needed
+// and no second confound is introduced.
+const STOCK = `var __join = Function.prototype.call.bind(Array.prototype.join);
+var __push = Function.prototype.call.bind(Array.prototype.push);
+var __hasOwnProperty = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+var __propertyIsEnumerable = Function.prototype.call.bind(Object.prototype.propertyIsEnumerable);`;
+
+// B1: drop ONLY the `Function.prototype.call.bind` layer; keep `.call`.
+const B1 = `var __join = function (o, s) { return Array.prototype.join.call(o, s); };
+var __push = function (o, v) { return Array.prototype.push.call(o, v); };
+var __hasOwnProperty = function (o, n) { return Object.prototype.hasOwnProperty.call(o, n); };
+var __propertyIsEnumerable = function (o, n) { return Object.prototype.propertyIsEnumerable.call(o, n); };`;
+
+// B2: no reflective dispatch at all. Semantically equivalent for own-property
+// queries: getOwnPropertyDescriptor returns undefined iff the property is not
+// an own property, and .enumerable mirrors propertyIsEnumerable for own props.
+const B2 = `var __join = function (o, s) { var r = ""; for (var __i = 0; __i < o.length; __i++) { if (__i > 0) r += s; r += o[__i]; } return r; };
+var __push = function (o, v) { o[o.length] = v; return o.length; };
+var __hasOwnProperty = function (o, n) { return Object.getOwnPropertyDescriptor(o, n) !== undefined; };
+var __propertyIsEnumerable = function (o, n) { var d = Object.getOwnPropertyDescriptor(o, n); return d !== undefined && d.enumerable === true; };`;
+
+// Arm S — SIMULATE THE #3976 FIX in the harness, then let the REAL probes run.
+// Unlike arm U (which is vacuous), S only supplies what the fix would supply:
+// own-property PRESENCE and a spec descriptor. The writable / configurable
+// probes still execute for real against the real object, so S measures the
+// REALISED yield of a presence+descriptor fix including its mutability
+// requirements — before any compiler code is written.
+// NOTE: the first version of this arm REBOUND `__hasOwnProperty = __simPresent`.
+// That was a SILENT NO-OP under standalone — a function-valued `var`
+// reassignment does not take effect in the compiled code, so all 40 rows still
+// failed at the own-property gate and the arm would have read as "the fix is
+// worth 0". Caught only because the failure SIGNATURE was inspected instead of
+// the pass count. Call sites are substituted textually instead.
+const S_EXTRA = `
+function __simPresent(o, n) {
+  if (o === undefined || o === null) return false;
+  if (Object.prototype.hasOwnProperty.call(o, n)) return true;
+  if (Object.getOwnPropertyDescriptor(o, n) !== undefined) return true;
+  return o[n] !== undefined;           // class method: callable but not an own prop
+}
+function __simGOPD(o, n) {
+  var d = Object.getOwnPropertyDescriptor(o, n);
+  if (d !== undefined) return d;
+  if (o === undefined || o === null) return undefined;
+  if (o[n] === undefined) return undefined;
+  return { value: o[n], writable: true, enumerable: false, configurable: true };
+}
+`;
+
+const REPL: Record<string, string> = { A: STOCK, A2: STOCK, B1, B2, P: STOCK, U: STOCK, S: STOCK };
+if (!(arm in REPL)) {
+  console.error(`unknown arm ${arm}`);
+  process.exit(2);
+}
+
+// Arm P — WHERE does the throw originate? propertyHelper reaches line 48
+// `__getOwnPropertyDescriptor(obj, name)` BEFORE line 64's uncurried
+// `__hasOwnProperty(obj, name)`, and line 27 captures gOPD DIRECTLY (not via
+// uncurryThis). Arm P labels the entry condition so the two are separable.
+const P_FROM = `  var originalDesc = __getOwnPropertyDescriptor(obj, name);`;
+const P_TO = `  if (obj === undefined || obj === null) { throw new Test262Error("P3PROBE-ENTRY-NULLISH"); }
+  var originalDesc = __getOwnPropertyDescriptor(obj, name);
+  if (originalDesc === undefined) { throw new Test262Error("P3PROBE-NO-OWN-PROP"); }`;
+
+// ── private harness copy (protects OTHER agents; see 3603/NOTES.txt) ───────
+let swapped = false;
+function restore() {
+  if (!swapped) return;
+  try {
+    fs.rmSync(HARNESS, { recursive: true, force: true });
+    fs.symlinkSync("/workspace/test262/harness", HARNESS);
+  } catch (e) {
+    console.error("RESTORE FAILED", e);
+  }
+  swapped = false;
+}
+process.on("exit", restore);
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, () => {
+    restore();
+    process.exit(1);
+  });
+}
+
+const isLink = fs.lstatSync(HARNESS).isSymbolicLink();
+if (!isLink) {
+  console.error("REFUSING: test262/harness is not a symlink — a previous run may not have restored it.");
+  process.exit(1);
+}
+fs.cpSync("/workspace/test262/harness", HARNESS + ".tmpcopy", { recursive: true, dereference: true });
+fs.unlinkSync(HARNESS);
+fs.renameSync(HARNESS + ".tmpcopy", HARNESS);
+swapped = true;
+
+// apply the arm
+const orig = fs.readFileSync(PH, "utf8");
+if (!orig.includes(STOCK)) {
+  console.error("REFUSING: stock uncurryThis block not found verbatim in propertyHelper.js");
+  process.exit(1);
+}
+// Arm U — CEILING, deliberately VACUOUS. Makes verifyProperty a no-op, i.e.
+// simulates "class elements are installed perfectly with the expected
+// descriptor". A file that STILL fails has a defect BEYOND the own-property
+// gap. This is an UPPER BOUND on #3976's flip yield and MUST NEVER be quoted
+// as a flip prediction or as a conformance number — it weakens the check by
+// construction. Its only valid reading is: files that do not pass here cannot
+// be fixed by #3976 alone.
+let patched = orig.replace(STOCK, REPL[arm]);
+if (arm === "U") {
+  const anchor = `function verifyProperty(obj, name, desc, options) {`;
+  if (!patched.includes(anchor)) {
+    console.error("REFUSING: arm U anchor not found");
+    process.exit(1);
+  }
+  patched = patched.replace(anchor, anchor + `\n  return true; // ARM U CEILING — vacuous by design`);
+}
+if (arm === "S") {
+  patched = patched.replace(STOCK, STOCK + "\n" + S_EXTRA);
+  // Substitute the CALL SITES (rebinding is a silent no-op — see above).
+  const before = patched;
+  patched = patched
+    .replaceAll("__hasOwnProperty(obj, name)", "__simPresent(obj, name)")
+    .replaceAll("__getOwnPropertyDescriptor(obj, name)", "__simGOPD(obj, name)");
+  if (patched === before) {
+    console.error("REFUSING: arm S call-site substitution matched nothing");
+    process.exit(1);
+  }
+  console.error(`arm S: substituted call sites (+${patched.length - before.length} bytes)`);
+}
+if (arm === "P") {
+  if (!patched.includes(P_FROM)) {
+    console.error("REFUSING: arm P anchor not found");
+    process.exit(1);
+  }
+  patched = patched.replace(P_FROM, P_TO);
+}
+if (arm !== "A" && arm !== "A2" && patched === orig) {
+  console.error("REFUSING: patch was a no-op");
+  process.exit(1);
+}
+fs.writeFileSync(PH, patched);
+console.error(`arm ${arm}: harness patched (${patched.length - orig.length} byte delta)`);
+
+// ── run ────────────────────────────────────────────────────────────────────
+const files: string[] = JSON.parse(fs.readFileSync(listFile, "utf8"));
+const out: any[] = [];
+let n = 0;
+for (const rel of files) {
+  const abs = path.join("/workspace/test262", rel);
+  const cat = rel.split("/").slice(1, 3).join("/");
+  const t0 = Date.now();
+  let status = "ERROR";
+  let error = "";
+  try {
+    const r = await runTest262File(abs, cat, 60000, "standalone");
+    status = r.status;
+    error = (r as any).error ?? "";
+  } catch (e: any) {
+    status = "THREW";
+    error = String(e?.message ?? e);
+  }
+  out.push({ file: rel, status, error, ms: Date.now() - t0 });
+  n++;
+  if (n % 10 === 0) console.error(`  ${arm}: ${n}/${files.length}`);
+}
+fs.writeFileSync(outFile, JSON.stringify(out, null, 0));
+const pass = out.filter((r) => r.status === "pass").length;
+console.error(`arm ${arm}: ${pass}/${out.length} pass -> ${outFile}`);
+restore();

--- a/plan/probes/3976/census.mjs
+++ b/plan/probes/3976/census.mjs
@@ -1,0 +1,113 @@
+// P3 census + instrument calibration.
+// 1. Reproduce the standalone baseline totals (43,106 / 25,460) or STOP.
+// 2. Enumerate files that INCLUDE harness/propertyHelper.js (routing bound).
+// 3. Cross-index with the host baseline to get the standalone-only subset.
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+
+const CACHE = "/workspace/.test262-cache";
+const T262 = "/workspace/test262";
+
+async function loadJsonl(p) {
+  const rows = new Map();
+  const rl = readline.createInterface({
+    input: fs.createReadStream(p),
+    crlfDelay: Infinity,
+  });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    let r;
+    try {
+      r = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    rows.set(r.file, r); // later row wins
+  }
+  return rows;
+}
+
+const sa = await loadJsonl(path.join(CACHE, "test262-standalone-current.jsonl"));
+const host = await loadJsonl(path.join(CACHE, "test262-current.jsonl"));
+
+const saOfficial = [...sa.values()].filter((r) => r.scope_official);
+const saPass = saOfficial.filter((r) => r.status === "pass").length;
+console.log(
+  `CALIBRATION standalone: official rows=${saOfficial.length} pass=${saPass} (${((saPass / saOfficial.length) * 100).toFixed(1)}%)`,
+);
+console.log(`  expected: 43106 / 25460 (59.1%)`);
+const calOk = saOfficial.length === 43106 && saPass === 25460;
+console.log(`  MATCH=${calOk}`);
+
+const hostOfficial = [...host.values()].filter((r) => r.scope_official);
+const hostPass = hostOfficial.filter((r) => r.status === "pass").length;
+console.log(
+  `CALIBRATION host: official rows=${hostOfficial.length} pass=${hostPass} (${((hostPass / hostOfficial.length) * 100).toFixed(1)}%)`,
+);
+
+// --- static census: which test files include propertyHelper.js ---
+const includeRe = /includes:\s*\[([^\]]*)\]|includes:\s*\n((?:\s*-\s*\S+\n)+)/;
+function walk(dir, out) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (e.name.endsWith(".js")) out.push(p);
+  }
+  return out;
+}
+const all = walk(path.join(T262, "test"), []);
+console.log(`static: ${all.length} .js files under test/`);
+
+const includesPH = [];
+for (const abs of all) {
+  const src = fs.readFileSync(abs, "utf8");
+  const meta = src.indexOf("/*---");
+  if (meta === -1) continue;
+  const end = src.indexOf("---*/", meta);
+  if (end === -1) continue;
+  const front = src.slice(meta, end);
+  if (front.includes("propertyHelper.js")) {
+    includesPH.push("test/" + path.relative(path.join(T262, "test"), abs));
+  }
+}
+console.log(`static: ${includesPH.length} files include propertyHelper.js`);
+
+let phSa = 0,
+  phSaPass = 0,
+  phSaFail = 0,
+  phSaFailHostPass = 0,
+  noRow = 0;
+const population = [];
+for (const f of includesPH) {
+  const s = sa.get(f);
+  if (!s || !s.scope_official) {
+    noRow++;
+    continue;
+  }
+  phSa++;
+  if (s.status === "pass") phSaPass++;
+  else {
+    phSaFail++;
+    const h = host.get(f);
+    if (h && h.status === "pass") {
+      phSaFailHostPass++;
+      population.push({ file: f, err: s.error, cat: s.error_category, sig: s.error_signature });
+    }
+  }
+}
+console.log(`\npropertyHelper population (standalone, official rows):`);
+console.log(`  rows present  : ${phSa}   (no official standalone row: ${noRow})`);
+console.log(`  pass          : ${phSaPass}`);
+console.log(`  fail          : ${phSaFail}`);
+console.log(`  fail & HOST-PASS (standalone-only defects): ${phSaFailHostPass}`);
+console.log(`  expected from prior analysis: 4898 include / 1494 pass / 3404 fail / 1810 host-pass`);
+
+// error_category breakdown of the 1810
+const byCat = new Map();
+for (const p of population) byCat.set(p.cat, (byCat.get(p.cat) ?? 0) + 1);
+console.log(`\nerror_category of the host-pass population:`);
+for (const [k, v] of [...byCat].sort((a, b) => b[1] - a[1])) console.log(`  ${String(v).padStart(5)}  ${k}`);
+
+fs.writeFileSync(".tmp/p3-population.json", JSON.stringify(population, null, 0));
+console.log(`\nwrote .tmp/p3-population.json (${population.length} rows)`);

--- a/plan/probes/3976/decompose.mjs
+++ b/plan/probes/3976/decompose.mjs
@@ -1,0 +1,72 @@
+// Full-population decomposition of the 1,810 (no sampling — this is a census).
+import fs from "node:fs";
+const pop = JSON.parse(fs.readFileSync(".tmp/p3-population.json", "utf8"));
+
+const norm = (e) =>
+  String(e ?? "")
+    .replace(/ \| at L\d+:.*$/s, "")
+    .replace(/'[^']*'/g, "'X'")
+    .replace(/\bown property \S+/g, "own property X")
+    .replace(/\d+/g, "#")
+    .slice(0, 78);
+
+const bySig = new Map();
+for (const r of pop) {
+  const k = norm(r.err);
+  if (!bySig.has(k)) bySig.set(k, []);
+  bySig.get(k).push(r.file);
+}
+console.log(`=== normalized error signature, all ${pop.length} ===`);
+let cum = 0;
+for (const [k, v] of [...bySig].sort((a, b) => b[1].length - a[1].length).slice(0, 18)) {
+  cum += v.length;
+  console.log(`${String(v.length).padStart(5)}  ${((cum / pop.length) * 100).toFixed(0).padStart(3)}%  ${k}`);
+}
+console.log(`(${bySig.size} distinct signatures)`);
+
+// the "own property" family split by test area
+const own = pop.filter((r) => /should have an own property/.test(String(r.err)));
+console.log(
+  `\n=== "obj should have an own property X" family: ${own.length} of ${pop.length} (${((own.length / pop.length) * 100).toFixed(0)}%) ===`,
+);
+const byArea = new Map();
+for (const r of own) {
+  const p = r.file.split("/");
+  const area = p.slice(1, 4).join("/");
+  byArea.set(area, (byArea.get(area) ?? 0) + 1);
+}
+for (const [k, v] of [...byArea].sort((a, b) => b[1] - a[1]).slice(0, 15))
+  console.log(`${String(v).padStart(5)}  ${k}`);
+
+// whole population by area
+console.log(`\n=== whole population by test area ===`);
+const byArea2 = new Map();
+for (const r of pop) {
+  const p = r.file.split("/");
+  byArea2.set(p.slice(1, 4).join("/"), (byArea2.get(p.slice(1, 4).join("/")) ?? 0) + 1);
+}
+let c2 = 0;
+for (const [k, v] of [...byArea2].sort((a, b) => b[1] - a[1]).slice(0, 15)) {
+  c2 += v;
+  console.log(`${String(v).padStart(5)}  ${((c2 / pop.length) * 100).toFixed(0).padStart(3)}%  ${k}`);
+}
+
+// how many mention the uncurryThis receiver-drop signature #3571 documents?
+const drop = pop.filter((r) =>
+  /Cannot convert undefined or null to object|Cannot access property on null or undefined/.test(String(r.err)),
+);
+console.log(`\n=== #3571's documented receiver-drop signature ===`);
+console.log(`${drop.length} of ${pop.length} (${((drop.length / pop.length) * 100).toFixed(1)}%)`);
+const byArea3 = new Map();
+for (const r of drop)
+  byArea3.set(r.file.split("/").slice(1, 4).join("/"), (byArea3.get(r.file.split("/").slice(1, 4).join("/")) ?? 0) + 1);
+for (const [k, v] of [...byArea3].sort((a, b) => b[1] - a[1]).slice(0, 10))
+  console.log(`${String(v).padStart(5)}  ${k}`);
+fs.writeFileSync(
+  ".tmp/p3-dropsig.json",
+  JSON.stringify(
+    drop.map((r) => r.file),
+    null,
+    0,
+  ),
+);

--- a/plan/probes/3976/diff.mjs
+++ b/plan/probes/3976/diff.mjs
@@ -1,0 +1,51 @@
+// Paired per-file comparison of arms. usage: node .tmp/diff.mjs <meta.json> <A.json> <label:file>...
+import fs from "node:fs";
+const meta = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const ctrl = new Set(meta.controls);
+const arms = process.argv.slice(3).map((s) => {
+  const [label, file] = s.split("=");
+  return { label, rows: new Map(JSON.parse(fs.readFileSync(file, "utf8")).map((r) => [r.file, r])) };
+});
+const base = arms[0];
+console.log(`base arm = ${base.label}\n`);
+for (const a of arms) {
+  const rows = [...a.rows.values()];
+  const c = rows.filter((r) => ctrl.has(r.file));
+  const p = rows.filter((r) => !ctrl.has(r.file));
+  console.log(
+    `${a.label.padEnd(4)} controls ${c.filter((r) => r.status === "pass").length}/${c.length} pass   ` +
+      `population ${p.filter((r) => r.status === "pass").length}/${p.length} pass`,
+  );
+}
+console.log();
+for (const a of arms.slice(1)) {
+  const gained = [],
+    lost = [],
+    gainedC = [],
+    lostC = [];
+  for (const [f, r] of a.rows) {
+    const b = base.rows.get(f);
+    if (!b) continue;
+    const isC = ctrl.has(f);
+    if (b.status !== "pass" && r.status === "pass") (isC ? gainedC : gained).push(f);
+    if (b.status === "pass" && r.status !== "pass") (isC ? lostC : lost).push([f, r.error]);
+  }
+  console.log(`=== ${base.label} -> ${a.label} ===`);
+  console.log(`  population fail->pass : ${gained.length}`);
+  for (const f of gained) console.log(`      + ${f}`);
+  console.log(`  population pass->fail : ${lost.length}`);
+  for (const [f, e] of lost) console.log(`      - ${f}  ${String(e).slice(0, 90)}`);
+  console.log(`  CONTROL fail->pass    : ${gainedC.length}`);
+  console.log(`  CONTROL pass->fail    : ${lostC.length}  ${lostC.length ? "<<< INSTRUMENT INVALID" : "(ok)"}`);
+  for (const [f, e] of lostC) console.log(`      - ${f}  ${String(e).slice(0, 90)}`);
+  console.log();
+}
+// error signature census of base population failures
+const popFail = [...base.rows.values()].filter((r) => !ctrl.has(r.file) && r.status !== "pass");
+const sig = new Map();
+for (const r of popFail) {
+  const k = String(r.error).replace(/\d+/g, "#").slice(0, 70);
+  sig.set(k, (sig.get(k) ?? 0) + 1);
+}
+console.log(`base population failure signatures (${popFail.length}):`);
+for (const [k, v] of [...sig].sort((a, b) => b[1] - a[1])) console.log(`  ${String(v).padStart(3)}  ${k}`);

--- a/plan/probes/3976/sample.mjs
+++ b/plan/probes/3976/sample.mjs
@@ -1,0 +1,79 @@
+// Build a seeded sample from the P3 population + embedded controls.
+// usage: node .tmp/sample.mjs <N> <seed> <out.json>
+import fs from "node:fs";
+import readline from "node:readline";
+
+const N = Number(process.argv[2] ?? 30);
+const SEED = Number(process.argv[3] ?? 20260801);
+const OUT = process.argv[4] ?? ".tmp/p3-sample.json";
+
+function mulberry32(a) {
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const pop = JSON.parse(fs.readFileSync(".tmp/p3-population.json", "utf8"));
+const rnd = mulberry32(SEED);
+const shuffled = [...pop];
+for (let i = shuffled.length - 1; i > 0; i--) {
+  const j = Math.floor(rnd() * (i + 1));
+  [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+}
+const sample = shuffled.slice(0, N).map((r) => r.file);
+
+// ── embedded POSITIVE CONTROLS: propertyHelper files that PASS standalone.
+// They must pass in EVERY arm; if a B arm breaks them the rewrite is wrong.
+const sa = new Map();
+const rl = readline.createInterface({
+  input: fs.createReadStream("/workspace/.test262-cache/test262-standalone-current.jsonl"),
+  crlfDelay: Infinity,
+});
+for await (const line of rl) {
+  if (!line.trim()) continue;
+  try {
+    const r = JSON.parse(line);
+    sa.set(r.file, r);
+  } catch {}
+}
+const phFiles = new Set(pop.map((r) => r.file));
+const passers = [];
+for (const [f, r] of sa) {
+  if (r.status !== "pass" || !r.scope_official) continue;
+  if (phFiles.has(f)) continue;
+  const abs = "/workspace/test262/" + f;
+  if (!fs.existsSync(abs)) continue;
+  const src = fs.readFileSync(abs, "utf8");
+  const m = src.indexOf("/*---");
+  if (m === -1) continue;
+  const e = src.indexOf("---*/", m);
+  if (e === -1) continue;
+  if (!src.slice(m, e).includes("propertyHelper.js")) continue;
+  // must actually exercise the uncurried path
+  if (!/verifyProperty|verifyNotWritable|verifyNotEnumerable|verifyNotConfigurable/.test(src)) continue;
+  passers.push(f);
+  if (passers.length >= 200) break;
+}
+const controls = [];
+const rnd2 = mulberry32(SEED ^ 0x5eed);
+const ps = [...passers];
+for (let i = ps.length - 1; i > 0; i--) {
+  const j = Math.floor(rnd2() * (i + 1));
+  [ps[i], ps[j]] = [ps[j], ps[i]];
+}
+controls.push(...ps.slice(0, 6));
+
+const list = [...controls, ...sample];
+fs.writeFileSync(OUT, JSON.stringify(list, null, 0));
+fs.writeFileSync(
+  OUT.replace(/\.json$/, "-meta.json"),
+  JSON.stringify({ seed: SEED, N, controls, sample, popSize: pop.length }, null, 2),
+);
+console.log(`sample: ${sample.length} from population of ${pop.length}, seed ${SEED}`);
+console.log(`positive controls (standalone-PASS + propertyHelper + verify*): ${controls.length}`);
+for (const c of controls) console.log(`  CTRL ${c}`);
+console.log(`wrote ${OUT} (${list.length} files total)`);

--- a/plan/probes/3976/synt.mts
+++ b/plan/probes/3976/synt.mts
@@ -1,0 +1,57 @@
+/**
+ * #3976 fix-shape probe. `call-builtin-static.ts` resolves class-method
+ * descriptors only when arg0/arg1 are compile-time constants. propertyHelper
+ * calls `__getOwnPropertyDescriptor(obj, name)` with PARAMETERS, so a syntactic
+ * fix cannot reach the corpus — the same trap that made P1's shape-matrix wins
+ * fail to convert. This measures whether that distinction is real.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { runTest262File } from "../tests/test262-runner.js";
+
+const DIR = path.join(process.cwd(), ".tmp", "probe262");
+fs.mkdirSync(DIR, { recursive: true });
+
+const CASES: [string, string][] = [
+  // CONTROL — must pass on both arms, else the harness is lying.
+  ["control-trivial", `assert.sameValue(1 + 1, 2, "control");`],
+  // A: fully syntactic — arg0 is literally `C.prototype`, arg1 a literal.
+  [
+    "syntactic-proto-method",
+    `class C { m() { return 42; } }
+     var d = Object.getOwnPropertyDescriptor(C.prototype, "m");
+     assert.notSameValue(d, undefined, "gOPD(C.prototype,'m') should be a descriptor");`,
+  ],
+  // B: same query behind a FUNCTION BOUNDARY — exactly propertyHelper's shape.
+  [
+    "dynamic-proto-method",
+    `class C { m() { return 42; } }
+     function look(o, n) { return Object.getOwnPropertyDescriptor(o, n); }
+     var d = look(C.prototype, "m");
+     assert.notSameValue(d, undefined, "gOPD(o,n) via params should be a descriptor");`,
+  ],
+  // C: static, syntactic.
+  [
+    "syntactic-static-method",
+    `class C { static s() { return 1; } }
+     var d = Object.getOwnPropertyDescriptor(C, "s");
+     assert.notSameValue(d, undefined, "gOPD(C,'s') should be a descriptor");`,
+  ],
+  // D: hasOwnProperty behind a boundary — the OTHER gate propertyHelper uses.
+  [
+    "dynamic-hasown-proto-method",
+    `class C { m() { return 42; } }
+     function has(o, n) { return Object.prototype.hasOwnProperty.call(o, n); }
+     assert.sameValue(has(C.prototype, "m"), true, "hasOwnProperty(C.prototype,'m')");`,
+  ],
+];
+
+for (const [name, body] of CASES) {
+  const file = path.join(DIR, `${name}.js`);
+  fs.writeFileSync(file, `/*---\ndescription: ${name}\nflags: [noStrict]\n---*/\n${body}\n`);
+  for (const lane of ["host", "standalone"] as const) {
+    const r = await runTest262File(file, "probe", 60000, lane === "standalone" ? "standalone" : undefined);
+    const err = (r as any).error ? ` — ${String((r as any).error).slice(0, 62)}` : "";
+    console.log(`${name.padEnd(28)} ${lane.padEnd(11)} ${String(r.status).padEnd(5)}${err}`);
+  }
+}

--- a/plan/probes/3976/synt2.mts
+++ b/plan/probes/3976/synt2.mts
@@ -1,0 +1,50 @@
+/**
+ * #3976 depth probe. Arm S could not even simulate the fix because
+ * `o[n] !== undefined` was FALSE for a class method — suggesting the method is
+ * not reachable as a property VALUE, not merely missing a descriptor. If so the
+ * gap is deeper than the own-property surface and the fix scope changes.
+ * Controls first; a reading without them is not a result.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { runTest262File } from "../tests/test262-runner.js";
+
+const DIR = path.join(process.cwd(), ".tmp", "probe262b");
+fs.mkdirSync(DIR, { recursive: true });
+
+const CASES: [string, string][] = [
+  ["control-trivial", `assert.sameValue(1 + 1, 2, "control");`],
+  // CONTROL: the method is CALLABLE — this is what the corpus tests rely on.
+  ["control-method-call", `class C { m() { return 42; } }
+     assert.sameValue(new C().m(), 42, "instance call");`],
+  ["control-static-call", `class C { static s() { return 7; } }
+     assert.sameValue(C.s(), 7, "static call");`],
+  // The real question: is the method reachable as a VALUE?
+  ["value-proto-method", `class C { m() { return 42; } }
+     assert.sameValue(typeof C.prototype.m, "function", "typeof C.prototype.m");`],
+  ["value-instance-method", `class C { m() { return 42; } }
+     var c = new C();
+     assert.sameValue(typeof c.m, "function", "typeof c.m");`],
+  ["value-static-method", `class C { static s() { return 7; } }
+     assert.sameValue(typeof C.s, "function", "typeof C.s");`],
+  // Identity — §15.7 requires the prototype method and the instance read to be
+  // the SAME function object.
+  ["identity-proto-vs-instance", `class C { m() { return 42; } }
+     var c = new C();
+     assert.sameValue(c.m, C.prototype.m, "c.m === C.prototype.m");`],
+  // Does the value survive a function boundary (propertyHelper's shape)?
+  ["value-proto-method-dynamic", `class C { m() { return 42; } }
+     function read(o, n) { return o[n]; }
+     assert.sameValue(typeof read(C.prototype, "m"), "function", "typeof o[n]");`],
+];
+
+for (const [name, body] of CASES) {
+  const file = path.join(DIR, `${name}.js`);
+  fs.writeFileSync(file, `/*---\ndescription: ${name}\nflags: [noStrict]\n---*/\n${body}\n`);
+  const out: string[] = [];
+  for (const lane of ["host", "standalone"] as const) {
+    const r = await runTest262File(file, "probe", 60000, lane === "standalone" ? "standalone" : undefined);
+    out.push(`${lane}=${r.status}`);
+  }
+  console.log(`${name.padEnd(28)} ${out.join("  ")}`);
+}


### PR DESCRIPTION
**Docs-only.** Touches no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/`.

Not folded into the open docs PR #3963 deliberately: that branch is `chore-memory-sync-20260801` (19 files, all `.claude/memory/*`), it is currently **BLOCKED with a failing `quality`**, and it belongs to another lane. This is issue-specific analysis plus a preserved probe harness — a different artifact class — and coupling it to another lane's unresolved failure would strand it behind a fix I don't own. Agreed with the tech lead before opening.

---

## What this is

The **"P3 uncurryThis / propertyHelper seam"** was scheduled as an XL target on the figure *"1,810 standalone-only failures route through `harness/propertyHelper.js`"*. That is a **routing** bound. Measured causally, it is worth **1.7 %** of it.

### Instrument calibrated before anything else

Standalone official rows **43,106 / 25,460 pass (59.1 %)** — exact match to baseline run `20260801-010858`. The population reproduces to the row: **1,494 pass / 1,810 host-pass**.

(My static include-scan finds 5,206 files vs the earlier 4,898; the gap is **743 files with no official standalone row**, reported rather than dropped. The two load-bearing numbers match exactly.)

### Result

| sample | n | fail→pass | pass→fail | controls |
|---|---|---|---|---|
| random seeded, from the 1,810 | **120** | **2 (1.7 %)** | 0 | 6/6 both arms |
| stratified — #3571's **own** documented signature | **40** | **0 (0 %)** | 0 | 6/6 both arms |

95 % CI on 2/120 ≈ 0.2–5.9 % ⇒ projected **~30 files of 1,810 (CI ~4–107)**.

**Arm A was run twice and gave 36/36 identical rows.** `assembleOriginalHarness` caches harness sources in a module-private `Map`, forcing one arm per process — so cross-process comparability was the assumption the whole design rested on, and it is measured rather than asserted.

### Why it is zero — the mechanism is mislabelled

`verifyProperty` reaches line 48 `__getOwnPropertyDescriptor(obj, name)` **before** line 64's uncurried `__hasOwnProperty(obj, name)`, and line 27 captures gOPD **directly, not via uncurryThis**. A probe arm shows **32/40 (80 %)** have `obj` **already nullish at entry** — the uncurried captures are never reached.

⇒ **A missing VALUE (builtins not reified as values), not a receiver DROP.** That relabel is why the 109-test cluster figure never converted. #3571 is re-scoped and re-titled accordingly (priority high→medium, horizon l→m).

## The real lever — new issue #3976

Full census of the 1,810: **1,136 (63 %)** are `obj should have an own property X`; **826 of those** are `language/{statements,expressions}/class`. Class areas are **998 (55 %)** of the whole population.

- **Mechanism**, stratified n=40, controls 6/6: **40/40 unanimous** — receiver EXISTS, property genuinely ABSENT.
- **Ceiling** (vacuous-by-construction arm): **40/40**. Its **discriminator** is that the same arm gives **32/40** on the receiver-nullish sample, not 40/40 — so it is not trivially green.
- **Fix located**: the method names are **already collected** (`ctx.classMethodNames`) but handed to the **host** via the `__register_prototype` host import. Standalone has no consumer. The data exists; only the consumer is missing.
- **Not a syntactic-reach problem** — the fully syntactic `gOPD(C.prototype,"m")` fails standalone too, so one representation-level fix serves both spellings.

**~28× the lever this work was dispatched for.**

## What is explicitly NOT claimed

**The realised yield of slice 1 is NOT measured.** `verifyProperty` *mutates* after the presence assert (writes to probe `writable`, deletes to probe `configurable`), so a presence-and-descriptor-only fix will not flip a file that reaches those probes; the 40/40 ceiling skips all of it. Two attempts to measure it produced **invalid instruments** and both were discarded rather than reported:

- **arm S v1 — silent no-op.** Rebinding `__hasOwnProperty = __simPresent` does not take effect in compiled standalone; all 40 rows still failed at the own-property gate, so it would have read as *"the fix is worth 0"*. Caught only by inspecting the failure **signature** rather than the pass count.
- **arm S v2 — confounded.** Routing the query through a helper changed the call shape and the answer; controls went 6/6 → 2/6.
- **arm B1 — broke its own controls** (6/6 → 0/6): the literal `.call` rewrite makes `Array.prototype.push.call(...)` syntactically visible, and that is a **deliberate** codegen refusal (#1888 Slice 3/4) which the stock uncurried spelling evades. Discarded as an instrument; the finding kept.

## Also in this PR

- **Un-orphans `66ab19f84`** — the #3571/#3642 S1 analysis pushed 2026-07-26 with no PR. Nothing measured here contradicts it.
- **Preserves the whole harness** under `plan/probes/3976/` (same convention as `plan/probes/3603/`; not linted or run by CI), with `NOTES.txt` recording all three instrument failures so nobody rebuilds them.

## Gates run locally

`update-issues --check` · `check-issue-ids --against-main` · `check-issue-ids` · `check-speculative-rollback-sites` · `prettier --check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
