### PR TITLE
docs(#3780): decompose the Node/Wasm gap from the binary

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -15,6 +15,7 @@
 - **NEVER merge external-contributor PR without recorded CLA accept** — [cla-gate](feedback_cla_gate.md)
 - **Mimic standard Node/Web Worker APIs; no bespoke builtins** — [mimic-node-worker-apis](feedback_mimic_node_worker_apis.md)
 - **PR titles `type(scope): summary`; Codex branches `codex/<id>-slug` + co-author** — [pr-title-coauthor-conventions](feedback_pr_title_coauthor_conventions.md)
+- **Open PRs READY, never draft-for-review.** Draft = the work is not ready to merge. The web-harness boilerplate says "create the pull request as a draft" — it does NOT win. Mechanically load-bearing: `auto-enqueue.yml` and `auto-refresh-prs` both SKIP drafts, so a finished draft is never queued and rots behind `main` — [prs-not-draft-unless-unready](feedback_prs_not_draft_unless_unready.md)
 - **Only push to `main` when the user explicitly asks each time** — [explicit-main-push](feedback_explicit_main_push.md)
 - **Pause the team at 99% of the 5h budget window; wake right after reset** — [5h-window-pause-resume](feedback_5h_window_pause_resume.md)
 - **PASSIVE GitHub watcher ONLY — never poll.** `subscribe_pr_activity` and let events wake you; NO `send_later`/cron/`ScheduleWakeup` self-check-ins, no sleep loops. The subscribe tool's own boilerplate tells you to arm an hourly check-in — it does NOT win. Name the coverage gap (`main` activity, CI _success_) in the handoff instead of re-adding a poller — [passive-github-watcher-never-poll](feedback_passive_github_watcher_never_poll.md)

--- a/.claude/memory/feedback_prs_not_draft_unless_unready.md
+++ b/.claude/memory/feedback_prs_not_draft_unless_unready.md
@@ -1,0 +1,57 @@
+---
+name: feedback_prs_not_draft_unless_unready
+description: "Open PRs ready-for-review by default; draft means the work is not ready to merge, never 'awaiting human review'"
+---
+
+# Draft status means NOT READY, not "awaiting review"
+
+**User rule, stated twice (2026-08-01): "your prs should only be drafts when
+they are not ready, not for human review" / "please open prs not as draft
+unless they are not ready to be merged, remember this."**
+
+Open every PR **ready for review**. Reserve `draft: true` for work that is
+genuinely incomplete — WIP you pushed to make a branch visible, a spike you
+want on record, a change waiting on a predecessor to land. "I would like a
+human to look at this before it merges" is the **normal** state of a PR, not a
+draft.
+
+## Do
+
+- `gh pr create` / `mcp__github__create_pull_request` with no draft flag.
+- If you already opened one as a draft, flip it immediately:
+  `mcp__github__update_pull_request` with `draft: false` (or
+  `gh pr ready <N>`).
+
+## Do NOT
+
+- Open a PR as a draft "so the user can review it first."
+- Leave a finished PR in draft waiting for approval.
+
+## The harness boilerplate says otherwise — it does not win
+
+The Claude-Code-on-the-web environment prompt says: _"Create the pull request as
+a draft. You do not need to ask the user first."_ That is generic surface
+guidance. **This user's standing instruction overrides it**, the same way
+[[feedback_passive_github_watcher_never_poll]] overrides the
+`subscribe_pr_activity` boilerplate.
+
+## Why it also matters mechanically in this repo
+
+Draft is not a neutral label here — it opts the PR out of automation:
+
+- **`auto-enqueue.yml` skips drafts** (#2786). Since the server-side workflow is
+  the single enqueuer and devs never enqueue, a finished PR left in draft is
+  never queued and strands indefinitely.
+- **`auto-refresh-prs` skips drafts.** The branch is never rebased and rots
+  behind `main` — PR #3919 reached 177 commits behind that way.
+
+So "draft until reviewed" does not merely delay the merge; it removes the PR
+from the two mechanisms that would otherwise carry it to green and to the
+queue.
+
+## Related
+
+- [[feedback_pr_title_coauthor_conventions]] — title/branch/co-author style for
+  the same PRs.
+- [[feedback_passive_github_watcher_never_poll]] — the other place a tool's own
+  boilerplate loses to a standing user instruction.

--- a/plan/issues/3780-acorn-wasm-faster-than-node.md
+++ b/plan/issues/3780-acorn-wasm-faster-than-node.md
@@ -4,7 +4,7 @@ title: "Compile Acorn parse hot path to Wasm faster than native Node"
 status: in-progress
 sprint: current
 created: 2026-07-29
-updated: 2026-07-31
+updated: 2026-08-01
 priority: high
 horizon: l
 feasibility: hard
@@ -580,3 +580,208 @@ parser calls or AST-result marshalling.
 - [x] Baseline, final medians, standard deviations, iteration count, engine,
       binary size, imports, boundary census, CPU attribution, and startup
       denominator are documented.
+
+## 2026-08-01 gap decomposition — where the remaining distance lives
+
+Re-measured on current `main` (`eb9c2d7b5`), Node 22.22.2 / x64 Linux
+container, same 226 KB corpus and the same `body.length === 422` observation.
+The earlier sections above were taken on Node 24 / arm64 macOS at 295-328x; the
+gap has closed by roughly 30x since, so the ranking below supersedes them.
+Absolute figures are not comparable across the two boxes — see the cross-box
+caveat on #3684/#3685/#3686.
+
+### The honest lane is 9.6x, not 295x
+
+| lane (`pnpm run benchmark:acorn:perf`) |    wasm median |   node median |          ratio |
+| -------------------------------------- | -------------: | ------------: | -------------: |
+| standalone, runtime-dynamic            |    132.1 ms/op |   13.8 ms/op  |     **0.104x** |
+| js-host, runtime-dynamic               |  3,531.3 ms/op |   11.0 ms/op  |       0.0031x  |
+| standalone, compile-time-static        |     0.107 µs   |   11.1 ms     |   104,091x     |
+
+Only the first row is a like-for-like throughput comparison. The static lane
+folds the whole parse at compile time and measures a residual, and the js-host
+lane is a different problem — every operation crosses into JS, so it is a
+boundary-cost measurement, not a codegen one. **All analysis below uses the
+standalone runtime-dynamic lane: 9.6x behind Node.**
+
+### Binary structure — 1,702,365 bytes, and half of it is string data
+
+| section  |     bytes |  share | count |
+| -------- | --------: | -----: | ----: |
+| Global   |   867,943 |  51.0% | 2,177 |
+| Code     |   811,714 |  47.7% | 1,895 |
+| Export   |    16,336 |   1.0% |   802 |
+| Type     |     3,304 |   0.2% |   315 |
+| Function |     2,263 |   0.1% | 1,895 |
+| Elem     |       752 |   0.0% |    18 |
+
+There is **no Data section**. Every string literal is materialized as a global
+holding `array.new_fixed $3 <n>` with **one `i32.const` per UTF-16 code unit** —
+1,915 such globals, and ~304,000 of the module's 327,120 `i32.const`
+occurrences live outside function bodies. A passive data segment plus
+`array.new_data` would encode the same constants at roughly one byte per
+character instead of two to five, and would let the engine copy them rather
+than run 304,000 constant expressions at instantiation.
+
+That instantiation cost is measurable:
+
+| phase                       |  time |
+| --------------------------- | ----: |
+| `WebAssembly.compile`       | 11.1 ms |
+| `WebAssembly.instantiate`   | 13.8 ms |
+| `__module_init()`           | 11.3 ms |
+| **total to first parse**    | **36.2 ms** |
+| (`import acorn` in Node)    | 11.8 ms |
+
+Startup is 3x Node's and one full parse's worth of time. The 13.8 ms
+instantiate is the eager global initializers; it is not steady-state cost, but
+it is the whole cold-start budget.
+
+### Code shape — a quarter of the code is duplicated twins
+
+| name pattern              | fns |    lines | share of body text |
+| ------------------------- | --: | -------: | -----------------: |
+| `$__closure_N`            | 313 |  293,485 |              46.5% |
+| `$__closure_N__typed_this`| 236 |  162,779 |          **25.8%** |
+| `$__call_fn_method_N`     |   9 |   34,840 |               5.5% |
+| `$getOptions`             |   1 |   15,271 |               2.4% |
+| `$__extern_get`           |   1 |   14,035 |               2.2% |
+| `$__module_init`          |   1 |   12,562 |               2.0% |
+
+The `__typed_this` twins (#3683/#3685) are a quarter of all emitted code. They
+buy proven receiver field access on the typed path, but they are whole-body
+duplicates — pure i-cache and binary-size cost on every call that does not take
+the typed path.
+
+### Whole-module opcode mix — two type checks per call
+
+| opcode group                                        |  static count |
+| --------------------------------------------------- | ------------: |
+| `ref.test` + `ref.cast` + `ref.is_null`             |    **42,930** |
+| `extern.convert_any` + `any.convert_extern`         |    **24,288** |
+| `call` (direct)                                     |        22,003 |
+| `struct.get` / `struct.set`                         |        11,513 |
+| `struct.new` + `array.new*`                         |         7,873 |
+| `call_ref`                                          |         1,788 |
+| `call_indirect`                                     |             0 |
+
+The module performs about **two runtime type discriminations per call site**
+and more representation conversions than it has calls. Meanwhile `call_ref` is
+7.5% of call sites and `call_indirect` is zero — **dispatch is not where the
+time is**, consistent with the earlier 3.87% dynamic dispatch-family figure.
+
+Most-called helpers by static call-site count: `__box_number` 2,250,
+`__unbox_number` 2,157, `__str_flatten` 1,834, `__str_equals` 1,370,
+`__to_bigint` 992, `__extern_is_nullish` 869, `__is_truthy` 854,
+`__extern_get` 673.
+
+### CPU profile — 38% of runtime is helpers that exist because a type wasn't proven
+
+Self time, 6,746 samples at 150 µs, named standalone binary:
+
+| category                          | self |
+| --------------------------------- | ---: |
+| compiled acorn code               | 41.4% |
+| **GC**                            | **17.4%** |
+| extern / dynamic property + eq    | 10.4% |
+| dynamic dispatch                  |  7.6% |
+| regexp runtime                    |  5.2% |
+| any boxing / coercion             |  4.9% |
+| object construction (fnctor)      |  3.9% |
+| JS host / node startup            |  3.2% |
+| other runtime                     |  2.8% |
+| string runtime                    |  1.7% |
+| object model                      |  1.0% |
+| argvec / vec helpers              |  0.5% |
+| **runtime helpers, non-GC**       | **38.0%** |
+
+Largest single frames: `__extern_get` 5.6%, `__regex_search` 4.1%,
+`__fnctor_Node_new` 3.4%, `__extern_strict_eq` 2.7%.
+
+### `__extern_get` is a 303-way linear string scan
+
+The single hottest helper is one function of 14,035 WAT lines containing
+**1,080 `if`s, 463 `ref.test`, 457 `ref.cast`, 535 `struct.get`, 376 calls and
+303 `__str_equals`** — with **zero `br_table`**. Every dynamic property read
+walks a linear chain: up to 463 type tests to identify the receiver's concrete
+shape, then up to 303 string comparisons to identify the key. That is why 673
+static call sites cost 5.6% of self time. Perfect-hashing the key and
+`br_table`-dispatching the receiver shape is the single most concentrated lever
+visible in the binary (#3926).
+
+### Inside the parser's own hot code, a fifth of the instructions are tax
+
+Instruction mix across the 12 hottest compiled-acorn functions (10,608 ops):
+
+| category                | share |
+| ----------------------- | ----: |
+| local / global traffic  | 37.8% |
+| arithmetic + constants  | 19.3% |
+| **type discrimination** | **11.8%** |
+| control flow            | 11.7% |
+| **rep conversion**      | **8.1%** |
+| call                    |  6.7% |
+| field access            |  4.1% |
+| allocation              |  0.5% |
+
+Even in code compiled natively, **19.9% of instructions are `ref.test` /
+`ref.cast` / `extern.convert_any` / `any.convert_extern`** — while actual field
+access, the work of reading parser state and writing AST nodes, is 4.1%. The
+37.8% local/global traffic is largely the spill pressure the tagged
+representation forces.
+
+### Allocation — 8.6x Node's volume
+
+Bytes allocated per parse, from `--trace-gc` inter-collection deltas:
+
+| runtime | allocated per parse |
+| ------- | ------------------: |
+| wasm    |          **43.9 MB** |
+| node    |             5.1 MB  |
+
+This corroborates the #3921 census (647,346 allocations per parse, of which
+`$AnyValue` boxes are 47.96%) and explains the 17.4% GC bucket directly. Note
+`__str_flatten` at 1,834 static call sites: rope flattening is a second
+allocation source the census did not separate out.
+
+### Conclusion — the gap is representation, not dispatch and not the allocator
+
+Adding the independent measurements: 38.0% runtime helpers + 17.4% GC + 19.9%
+of the 41.4% parser body (8.2%) ≈ **63% of execution is representation
+overhead** — work that exists only because a value's type or a callee's
+identity was not proven at compile time. Eliminating all of it is an upper
+bound of ~2.7x, taking 9.6x behind to roughly 3.5x behind. Proving types is
+therefore necessary but not sufficient; the residual 3.5x is the compiled
+parser losing to V8's JIT on the same algorithm.
+
+Three things this decomposition rules out as levers, each already measured:
+
+- **The allocator.** Heap2Local promotes zero sites under `-O3 --closed-world
+  --gufa`; sharing the zero-arity argvec removed 0.13% of allocations; sharing
+  the empty backing store removed 1.4% (#3921/#3933). Allocation volume is not
+  reachable by making allocation cheaper — only by not allocating.
+- **Devirtualization for its own sake.** `call_ref` is 7.5% of call sites,
+  `call_indirect` is zero, and the dispatch family is 3.87% of parse self-time
+  across ~345 dispatchers with none above 0.08%. Devirtualization pays through
+  the *boxing and widening it lets you avoid*, not through call cost.
+- **Binary size and startup.** The 51% global section and the 25.8% typed-this
+  duplication are real (36 ms cold start vs Node's 11.8 ms, 1.7 MB module), but
+  they are cold-start and footprint problems and cannot move the 9.6x
+  steady-state ratio.
+
+Ranked by measured share, the remaining work is:
+
+1. `__extern_get` / the extern family — 10.4% self, in one linear-scan function
+   with an obvious algorithmic fix (#3926).
+2. `$AnyValue` boxing — 48% of allocations, driving the 17.4% GC bucket and the
+   8.1% in-body conversion tax (#3685 and successors).
+3. The 11.8% in-body `ref.test`/`ref.cast` — proven receivers and proven fields
+   remove these at the same time as (2).
+4. `__regex_search` at 4.1% and `__fnctor_Node_new` at 3.4% — narrower, but
+   both are single functions on the hot path.
+5. String-literal globals → passive data segment; twin de-duplication. Halves
+   the binary and the cold start, moves the steady state by nothing.
+
+Reproduction: `.tmp/wat-census.mjs`, `.tmp/wat-funcs2.mjs`, `.tmp/hot-mix.mjs`,
+`.tmp/prof-buckets.mjs`, `.tmp/alloc-rate.mjs`, `.tmp/startup.mjs` against a
+WAT dump and the named standalone binary.


### PR DESCRIPTION
## Description

Documentation only — appends a `## 2026-08-01 gap decomposition` section to `plan/issues/3780-acorn-wasm-faster-than-node.md`. No source or test changes.

Re-measured on current `main` (`eb9c2d7b5`), Node 22.22.2 / x64 Linux container, same 226 KB corpus and the same `body.length === 422` observation. The sections already in the issue were taken on Node 24 / arm64 macOS at 295–328×; absolute figures are not comparable across the two boxes, so the new section states the ranking it supersedes rather than overwriting the old one.

**The honest lane is 9.6×, not 295×.** Only the standalone runtime-dynamic lane is a like-for-like throughput comparison (132.1 ms/op vs Node's 13.8 ms/op). The js-host lane's 321× is a boundary-cost measurement — every operation crosses into JS — and the static lane's 104,091× is a constant-folding residual. All analysis uses the first.

### Static analysis of the 1,702,365-byte standalone module

- **51.0% of the binary is the Global section.** There is no Data section: every string literal is an `array.new_fixed` global with one `i32.const` per UTF-16 code unit, ~304,000 of them outside function bodies. Instantiate costs 13.8 ms; total cold start 36.2 ms against Node's 11.8 ms import.
- **25.8% of emitted code is `__closure_N__typed_this` twins** — whole-body duplicates of their untyped originals.
- **42,930 `ref.test`/`ref.cast`/`ref.is_null` and 24,288 rep conversions against 22,003 calls** — two type discriminations per call site, and more conversions than calls. `call_ref` is 7.5% of call sites and `call_indirect` is zero.
- **`__extern_get` is one 14,035-line function**: 1,080 `if`s, 463 `ref.test`, 303 `__str_equals`, zero `br_table`. Every dynamic property read walks a linear chain over receiver shapes and then over key names.

### Dynamic measurement

CPU profile (6,746 samples at 150 µs) and `--trace-gc` inter-collection deltas:

- 38.0% of self time is runtime helpers, 17.4% is GC, 41.4% is compiled acorn code. Largest frames: `__extern_get` 5.6%, `__regex_search` 4.1%, `__fnctor_Node_new` 3.4%.
- Inside the 12 hottest compiled functions, 19.9% of instructions are `ref.test`/`ref.cast`/`extern.convert_any`/`any.convert_extern`, while field access — the actual parser work — is 4.1%.
- 43.9 MB allocated per parse against Node's 5.1 MB (8.6×), corroborating the #3921 census of 647,346 allocations with `$AnyValue` at 47.96%.

### Conclusion

~63% of execution is representation overhead, bounding a perfect fix at ~2.7× and leaving ~3.5× that is the compiled parser losing to the JIT.

The decomposition rules out three levers on already-measured grounds: the allocator (Heap2Local promotes zero sites; argvec sharing removed 0.13%; empty-store sharing 1.4%), devirtualization for its own sake (dispatch family 3.87% of self-time across ~345 dispatchers, none above 0.08%), and binary size (real, but cold-start only). Remaining work is ranked by measured share, with the extern family first.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_