### PR TITLE
docs: file #3986 and #3987 — the two gaps #3963 left open

### DIFF
--- a/plan/issues/3963-setup-node-25-manifest-flake.md
+++ b/plan/issues/3963-setup-node-25-manifest-flake.md
@@ -15,7 +15,7 @@ goal: n/a
 sprint: current
 horizon: s
 es_edition: n/a
-related: [2547, 3597]
+related: [2547, 3597, 3986, 3987]
 ---
 
 # #3963 — Node 25 is absent from the setup-node manifest; every pin was on the fallback path
@@ -176,12 +176,20 @@ workflows". That is wrong. Only **two** files reference it (`ci.yml`,
 `test262-sharded.yml`); the "12" was a count of matching *grep lines*, not
 files.
 
-### Still open — the test262 shard keeps the flake
+### Still open — the test262 shard keeps the flake (now #3987)
 
 The workflow that parked #3914 is **not** fixed by this change. It stays on the
 absent-25 pin and therefore on the fallback download, so the same park can recur
 there. Closing it needs the baseline regeneration above. This is a deliberate
 deferral, recorded so the gap is not mistaken for closed.
+
+Tracked as **#3987**, which carries the sequencing (move the pin and regenerate
+`test262-current.jsonl` atomically) and the open question of *why* results move
+with the Node major.
+
+The `classifyTestScope` fail-open that this investigation wrongly blamed is
+filed separately as **#3986** — ruled out as the cause here, but a real latent
+defect worth closing on its own.
 
 ### Why 24 is safe here
 

--- a/plan/issues/3986-classify-test-scope-fail-open-relpath.md
+++ b/plan/issues/3986-classify-test-scope-fail-open-relpath.md
@@ -1,0 +1,139 @@
+---
+id: 3986
+title: "test262 runner: classifyTestScope fails OPEN — a missing filePath silently disables all three path-based skip rules, unskipping ~1170 proposal/annexB tests"
+status: ready
+created: 2026-08-01
+updated: 2026-08-01
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: bug
+area: testing
+language_feature: n/a
+goal: n/a
+sprint: current
+horizon: s
+es_edition: n/a
+related: [3963, 1390]
+---
+
+# #3986 — `classifyTestScope` fails open when `filePath` is absent
+
+## Status: open — not currently firing; filed as a latent fail-open
+
+## Problem
+
+`tests/test262-runner.ts:222` decides a test's scope — and therefore whether it
+is skipped — almost entirely from the file path:
+
+```ts
+export function classifyTestScope(source: string, meta: Test262Meta, filePath?: string): Test262ScopeInfo {
+  const relPath = getTest262RelativePath(filePath) ?? "";   // ← fail-open
+  const strict = classifyStrictMode(meta, relPath);
+
+  if (relPath.startsWith("test/staging/") || relPath.startsWith("staging/")) → proposal
+  if (relPath.startsWith("test/annexB/")  || relPath.startsWith("annexB/"))  → annex_b
+  if (relPath.includes("built-ins/Temporal/"))                               → proposal
+  // …then meta.features
+}
+```
+
+`filePath` is **optional**, and when it is absent `relPath` becomes `""`. Every
+one of those three checks then returns false, so:
+
+- staging proposals are no longer classified as proposals,
+- annexB tests are no longer classified as `annex_b`,
+- Temporal tests are no longer classified as proposals,
+
+and all of them fall through to be **compiled and run** rather than skipped.
+`classifyStrictMode(meta, "")` is likewise deprived of its path input.
+
+The failure is silent and inverted: losing the path makes the runner do *more*
+work and report *worse* results, with no error anywhere.
+
+## Blast radius, measured
+
+This is not hypothetical arithmetic — a `merge_group` run during #3963 produced
+exactly the shape this fail-open would produce, from a different cause:
+
+```
+pass           31086 → 31035    -51
+compile_error    652 →  1829  +1177
+skip            1278 →   108  -1170
+```
+
+`skip` −1170 and `compile_error` +1177 as mirror images, with the transition
+list wall-to-wall `Temporal/…: skip → compile_error` and `annexB/…` entries.
+So the *observable signature* of this fail-open is a ~1170-test swing that
+reads as a catastrophic conformance regression and **auto-parks the PR**
+(#2547), costing a human-grade diagnosis cycle.
+
+## It is NOT currently firing — and that is the point
+
+Both production call sites pass a `filePath` they have already dereferenced:
+
+- `tests/test262-shared.ts:617-619` — `readFileSync(filePath)` then
+  `classifyTestScope(source, meta, filePath)`
+- `tests/test262-vitest.test.ts:504-506` — same order
+
+so `filePath` cannot be undefined without `readFileSync` having thrown first.
+The #3963 investigation initially blamed this fail-open and was **wrong**; the
+real cause there was the Node major moving under the baseline.
+
+That near-miss is the argument for fixing it. The hypothesis was credible
+precisely because the code permits it, and ruling it out took reading both call
+sites. A gate that *could* fail open costs diagnosis time even on runs where it
+doesn't.
+
+## Two distinct defects
+
+1. **`?? ""` converts "unknown" into "definitely not a proposal".** Absent
+   information is being treated as a negative answer rather than as an error.
+2. **`getTest262RelativePath` is also lossy without being absent.** It is
+   `filePath.replace(/.*test262\//, "")` — if the checkout directory is not
+   named `test262/`, the replace is a no-op and returns the **full absolute
+   path**. Then `startsWith("test/staging/")` and `startsWith("test/annexB/")`
+   both fail while `includes("built-ins/Temporal/")` still matches, so the
+   classifier degrades *partially* — arguably worse than failing outright,
+   because the result looks plausible.
+
+## Suggested fix
+
+Make `filePath` required and fail loud, rather than defaulting:
+
+```ts
+export function classifyTestScope(source: string, meta: Test262Meta, filePath: string): Test262ScopeInfo {
+  const relPath = getTest262RelativePath(filePath);
+  if (relPath === undefined || relPath === filePath) {
+    throw new Error(`classifyTestScope: cannot derive a test262-relative path from ${filePath}`);
+  }
+  …
+}
+```
+
+`relPath === filePath` catches defect 2 — the replace matched nothing. Both call
+sites already have a valid path, so making the parameter required is a
+type-level change with no runtime cost at either. `tests/test262-scope-classification.test.ts`
+already passes absolute `/tmp/test262/...` paths, so it exercises the happy path.
+
+If a throw is judged too aggressive for a runner that processes ~47k files,
+the fallback should at minimum **count and report** the degradation, so a
+mass-unskip shows up as a runner diagnostic rather than as a conformance cliff.
+
+## Acceptance criteria
+
+1. A missing or non-`test262/` `filePath` no longer yields a silently
+   permissive classification.
+2. Whichever behaviour is chosen (throw or counted degradation), it is
+   observable in the run output — the current failure produces no signal at all.
+3. A test pins the degraded case: classification with a path that does not
+   contain `test262/` must not report `standard`/non-proposal for a Temporal or
+   annexB file.
+4. The existing scope-classification tests still pass.
+
+## Provenance
+
+Found while diagnosing the #3963 auto-park. Filed separately because it is a
+real latent defect that was *not* the cause of that park — recording it as
+"the thing I wrongly blamed, which is nonetheless broken" rather than folding
+it into an unrelated fix.

--- a/plan/issues/3987-test262-baseline-node-version-bound.md
+++ b/plan/issues/3987-test262-baseline-node-version-bound.md
@@ -1,0 +1,140 @@
+---
+id: 3987
+title: "test262 shards are stranded on the absent Node 25 manifest pin — moving them to 24 needs the baseline regenerated first, because conformance results are Node-version-bound"
+status: ready
+created: 2026-08-01
+updated: 2026-08-01
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: infrastructure
+area: ci
+language_feature: n/a
+goal: n/a
+sprint: current
+horizon: m
+es_edition: n/a
+related: [3963, 2547, 3597, 3467]
+---
+
+# #3987 — the test262 lane cannot leave Node 25 until its baseline is regenerated
+
+## Status: open — the remaining half of #3963
+
+## Problem
+
+#3963 established that **Node 25 is not in `actions/node-versions` at all**
+(majors present: 26, 24, 22, 20, 18, 16, 14, 13, 12, 10, 8, 6 — zero `25.x`
+entries). Every `node-version: 25` job therefore misses the manifest
+deterministically and falls through to a direct `nodejs.org` download on every
+run. That download is an unconditional third-party network dependency, and when
+it fails inside a `merge_group` test262 shard the PR is **auto-parked** with a
+`hold` label (#2547) — costing a human-grade diagnosis cycle and stranding the
+PR, because the auto-enqueue backstop skips held PRs. Observed on #3914.
+
+#3963 fixed **7 of 18** workflows. `test262-sharded.yml` — the workflow that
+actually parked #3914 — was **deliberately left on 25**, and so was the
+`setup-node-pnpm` composite default it depends on.
+
+## Why it was left behind
+
+Because moving it broke the conformance verdict. #3963's first revision moved
+every pin; the `merge_group` re-validation reported:
+
+```
+pass           31086 → 31035    -51
+compile_error    652 →  1829  +1177
+skip            1278 →   108  -1170
+```
+
+`skip` −1170 and `compile_error` +1177 are mirror images — ~1170
+previously-skipped tests were suddenly compiled, the transition list
+wall-to-wall `Temporal/…: skip → compile_error`. Alongside it, `compile_timeout`
+127 → 171 and aggregate compile time +0.9%.
+
+That is a **test-selection and timing change, not a codegen regression**, and
+the PR carried no compiler source at all.
+
+**What established attribution** was PR #3964: an unrelated PR that passed the
+*same* `check for test262 regressions` gate in `merge_group` in the same window,
+**on Node 25**, because it merged just before the pin change. Same gate, same
+window — one clean, one showing a 1170-test flip. Baseline drift would have hit
+both.
+
+Conclusion: **test262 conformance results are Node-version-bound.** Comparing a
+Node-24 run against a Node-25 baseline is not a valid comparison, so the pin and
+the baseline have to move together.
+
+## What is not yet known
+
+The exact mechanism was never pinned down, and should be before the change
+lands — the plan below differs depending on the answer:
+
+- **Compile-cache invalidation.** The runner keeps a disk cache
+  (`.test262-cache`). If cache identity is affected by the Node/V8 version,
+  a major bump forces mass recompilation, which fits the `compile_timeout`
+  127 → 171 growth and the +0.9% aggregate compile time.
+- **Host-engine capability.** Some statuses may depend on what the executing
+  V8 provides (Node 25's V8 differs from 24's), which would make certain
+  results genuinely engine-dependent rather than merely cache-dependent.
+- **Something in the harness** that reads the host engine's own globals.
+
+The `skip → compile_error` direction specifically is not yet explained by
+either, since `classifyTestScope` is path-based and has no Node dependence
+(see #3986, which was investigated and **ruled out** as the cause here).
+
+## Scope
+
+1. Determine *why* the results move with the Node major. Until that is known,
+   any regeneration risks baking in whatever the real effect is.
+2. Decide the target: 24 (manifest-present, LTS line, already used by 9
+   workflows) or 26 (also in the manifest). Note `engines` is `>=20` and local
+   development runs v22, so neither is constrained by the repo's own floor.
+3. Sequence the switch so the pin and the baseline move atomically:
+   - move `test262-sharded.yml` + the `setup-node-pnpm` composite default,
+   - regenerate `test262-current.jsonl` in `loopdive/js2wasm-baselines` under
+     the new major via `promote-baseline` / `refresh-baseline.yml` (which must
+     move in the same step — it is currently pinned to 25 for exactly this
+     reason),
+   - expect one noisy diff for every in-flight PR until it settles, and say so
+     in advance rather than letting agents diagnose it as a regression.
+4. The other baseline-adjacent workflows left on 25 by #3963 move with it:
+   `test262-canary`, `test262-differential`, `test262-cache-prune`,
+   `baseline-floor-staleness-alert`, `baseline-summary-sync`, `deploy-pages`,
+   `issue-tests`.
+
+## Explicitly out of scope
+
+The **benchmark** baselines (`benchmark-refresh.yml`,
+`landing-four-lane-backend.yml`) are the same class of problem in a different
+domain — the JS lane measures V8, so moving the Node major silently moves
+published numbers. #3963 left both on `25.7.0` for that reason. They are worth
+their own decision and should not be swept along with the conformance move.
+
+## Acceptance criteria
+
+1. The mechanism behind the Node-version sensitivity is identified and recorded
+   — not merely worked around.
+2. `test262-sharded.yml` and the `setup-node-pnpm` composite no longer request
+   an absent major, so the shard stops depending on a per-run `nodejs.org`
+   download.
+3. The committed baseline is regenerated under the same major the shards run,
+   and a PR opened afterwards shows a clean regression diff.
+4. #3963's acceptance criterion 2 — currently marked **not met** — can be
+   closed honestly.
+
+## Worth doing regardless — the park is expensive either way
+
+Independent of the version question: `auto-park` could **decline to park** when
+the failing step is a known setup/infrastructure step rather than a verdict
+step. It already identifies the failing step by name (#3597), which is the hard
+part, and its own comment footnote tells the reader to check for exactly this.
+That would remove the manual diagnosis cycle for this whole class. Carried
+forward from #3963, where it was also left open — the parking behaviour is
+conservative on purpose and narrowing it deserves its own judgement.
+
+## Provenance
+
+The unfinished half of #3963, split out so the deferral is tracked rather than
+buried in a merged issue's prose. #3963 shipped 7 workflows and recorded its own
+criterion 2 as not met specifically so this could be picked up deliberately.


### PR DESCRIPTION
## Description

Docs-only — three issue files, no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` changes.

#3963 shipped 7 of 18 workflows and recorded its own acceptance criterion 2 as **not met**. These are the two things that deferral was hiding, split out so they're tracked rather than buried in a merged issue's prose. No open docs-only PR existed to group onto (the four open PRs are all code fixes), so this opens a new one.

### #3986 — `classifyTestScope` fails **open**

```ts
const relPath = getTest262RelativePath(filePath) ?? "";   // ← absent path ⇒ "" 
if (relPath.startsWith("test/staging/")) → proposal
if (relPath.startsWith("test/annexB/"))  → annex_b
if (relPath.includes("built-ins/Temporal/")) → proposal
```

An absent `filePath` becomes `""`, which turns "unknown" into "definitely not a proposal" and disables all three path-based skip rules at once — the observable signature being a ~1170-test mass unskip that reads as a conformance cliff and auto-parks the PR.

**Not currently firing** — both call sites `readFileSync(filePath)` first, so it cannot be undefined. It's filed *because* the #3963 investigation wrongly blamed it: the hypothesis was credible only because the code permits it, and ruling it out cost a diagnosis cycle.

A second, subtler defect is recorded alongside: the helper is `filePath.replace(/.*test262\//, "")`, so a checkout **not** named `test262/` returns the full absolute path and the classifier degrades *partially* — `startsWith` fails while `includes` still matches. That's worse than failing outright, because the result looks plausible.

### #3987 — the test262 lane is stranded on the absent-25 pin

The workflow that actually parked #3914 can't move off Node 25 until `test262-current.jsonl` is regenerated under the same major, because conformance results are Node-version-bound:

```
pass           31086 → 31035    -51
compile_error    652 →  1829  +1177
skip            1278 →   108  -1170
```

What established attribution was **#3964** — an unrelated PR that passed the same `check for test262 regressions` gate in `merge_group` in the same window, on Node 25, because it merged just before the pin change. Baseline drift would have hit both.

The issue deliberately records that the **mechanism is still unknown**. Compile-cache invalidation and host-engine capability are both plausible; neither is confirmed, and #3986 was investigated and **ruled out** as the cause. Regenerating the baseline before knowing why would bake in whatever the real effect is, so that's written as a precondition rather than a nice-to-have.

### Linking

Both are referenced from #3963 (`related:` plus inline pointers) so the merged issue leads to them instead of dead-ending at "still open".

## ID allocation

`claim-issue.mjs --allocate` exited **6** (nothing written) — this container has no `gh`, so its open-PR scan degrades and it correctly refuses to reserve unverified ids.

Rather than reach for the override, I ran that scan through the GitHub API instead: next free id off `main` is **#3986**, and the only open PRs use #3983 / #3984 / #3985 — all below it. So `--allow-unscanned` was used against a manually-completed scan, not in place of one. Earlier in this session the lazy version of that shortcut (bare `--no-pr-scan`) caused two id collisions and cost two CI cycles.

## Verification

`update-issues.mjs --check`, `check-issue-spec-coverage`, and `check-issue-ids --against-main` all exit 0 — read as verdict lines rather than through a pipe.

## CLA

Internal PR — the `cla-check` gate skips org-member PRs automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D29cj9ve5n7eQqnz4tUXk6

---
_Generated by [Claude Code](https://claude.ai/code/session_01D29cj9ve5n7eQqnz4tUXk6)_