### PR TITLE
fix(codegen): module TDZ flag paired with the wrong declaration aborts multi-package builds

### DIFF
--- a/src/codegen/module-global-registration.ts
+++ b/src/codegen/module-global-registration.ts
@@ -84,7 +84,12 @@ export function registerModuleTdzGlobal(ctx: CodegenContext, sourceFile: ts.Sour
         (candidate) => ts.isIdentifier(candidate.name) && candidate.name.text === name,
       );
       if (declaration) {
-        ctx.programAbiGlobals?.observeModuleTdz(declaration, name, existingGlobal);
+        // (#1282) Only pair the TDZ flag with the declaration that owns the
+        // VALUE global — see `hasModuleValue`. In a multi-package graph the same
+        // bare name can be declared in two modules.
+        if (ctx.programAbiGlobals?.hasModuleValue(declaration) !== false) {
+          ctx.programAbiGlobals?.observeModuleTdz(declaration, name, existingGlobal);
+        }
         return;
       }
     }
@@ -106,7 +111,10 @@ export function registerModuleTdzGlobal(ctx: CodegenContext, sourceFile: ts.Sour
       (candidate) => ts.isIdentifier(candidate.name) && candidate.name.text === name,
     );
     if (declaration) {
-      ctx.programAbiGlobals?.observeModuleTdz(declaration, name, flagGlobal);
+      // (#1282) Same pairing rule as above.
+      if (ctx.programAbiGlobals?.hasModuleValue(declaration) !== false) {
+        ctx.programAbiGlobals?.observeModuleTdz(declaration, name, flagGlobal);
+      }
       return;
     }
   }

--- a/src/codegen/program-abi-global-planning.ts
+++ b/src/codegen/program-abi-global-planning.ts
@@ -54,6 +54,23 @@ export class ProgramAbiGlobalRegistry {
     this.observeModuleBinding(declaration, displayName, value, "tdz");
   }
 
+  /**
+   * True when this exact declaration already owns a value global.
+   *
+   * (#1282) A TDZ flag may only be attached to the declaration that owns the
+   * VALUE global. `ctx.moduleGlobals` / `ctx.tdzLetConstNames` are keyed by BARE
+   * NAME across every module, while the declaration is resolved per source
+   * file, so in a multi-package graph two different modules can each declare
+   * `minimatch` — the value global belongs to whichever was seen first, and the
+   * TDZ would otherwise be observed against the other one. Callers use this to
+   * skip that mismatched pairing instead of tripping the ordering invariant.
+   * Deliberately a cheap map probe: the caller runs it per TDZ name per module,
+   * so it must not do the `mod.globals.includes` scan `moduleBinding` performs.
+   */
+  hasModuleValue(declaration: ts.VariableDeclaration): boolean {
+    return this.moduleBindings.has(declaration);
+  }
+
   /** Resolve one exact module declaration without consulting compatibility names. */
   moduleBinding(declaration: ts.VariableDeclaration): ProgramAbiModuleBindingObservation | undefined {
     const observation = this.moduleBindings.get(declaration);


### PR DESCRIPTION
## Description

Follow-up to #3976 (merged). Removes the **next** hard error stopping the ESLint graph — the one #3976's frontier rung was left pinned at.

### The defect

```
Codegen error: module TDZ global minimatch was observed before its value global
```

`prepareModuleTdzGlobals` iterates `ctx.tdzLetConstNames` — a **context-wide** set spanning every module — but resolves each name to a declaration inside the **current** source file:

```ts
for (const name of ctx.tdzLetConstNames) {
  registerModuleTdzGlobal(ctx, sourceFile, name);   // <- name is graph-wide, sourceFile is not
}
```

`ctx.moduleGlobals` is likewise keyed by **bare name** across the whole graph. So in a multi-package graph where two modules each declare the same bare name, the **value** global belongs to whichever module compiled first, while the **TDZ** flag gets observed against the *other* module's same-named declaration — which owns no value global. That trips the ordering invariant and aborts the entire build.

`minimatch` is exactly that: declared in more than one package in ESLint's graph.

### The fix

A cheap `hasModuleValue(declaration)` probe on the program-ABI global registry, guarding both `observeModuleTdz` call sites — attach a TDZ flag only to the declaration that actually owns the value global.

Deliberately a plain `Map.has` rather than reusing the existing `moduleBinding`, which performs an `O(globals)` `mod.globals.includes` scan; this runs once per TDZ name **per module**, so the cheap probe matters.

**This does not change which globals are allocated.** The TDZ global is still created and registered in `ctx.tdzGlobals` exactly as before — only the structural ABI *observation* is skipped for a declaration that cannot own it. No emitted code changes for any program that previously compiled, which is why the equivalence set is byte-identical.

### Scope

The underlying bare-name collapse across packages is the architectural problem **#3798** describes. This is the narrow correctness guard that stops it aborting a build — **not** that redesign. Two modules sharing a name still share one global; making those distinct is #3798's job.

### Effect on the ESLint graph

The package entry no longer aborts at 297 s. It proceeds into real body codegen and has been running >26 min at 2.4 GB without erroring — consistent with the throughput finding recorded in #3976 (`compileDeclarations` at 10–20 s/file × 149 files). Compilation is now **throughput-bound rather than blocked**, which is a different and more tractable problem.

## Verification

- **`tests/equivalence/` full run, branch vs main: 32 failed / 1611 passed / 3 todo on BOTH, and the 32 failing test names diff byte-identical.** Zero regressions.
- `tests/equivalence/tdz-reference-error.test.ts` fails 6/9 **with and without** this change — A/B confirmed pre-existing and part of that same 32-failure baseline. Worth stating plainly: a TDZ-adjacent fix showing red TDZ tests is exactly the coincidence that deserves an A/B rather than an assumption.
- `tests/issue-1282-…` 3/3 · `tests/issue-3672.test.ts` 4 passed / 1 skipped.
- `typecheck`, `biome lint`, `check:oracle-ratchet`, LOC/function budgets all pass.
- Merged current `main` (21 commits) before pushing.

## Notes for reviewers

- **No new test rung is added here.** The natural one is Tier 1a in `tests/stress/eslint-tier1.test.ts`, which #3976 just pinned at this exact diagnostic — but with the blocker gone the entry no longer aborts at all and instead runs past every budget that suite can carry. Advancing that rung honestly requires a completed compile, which the throughput problem currently prevents; inventing a synthetic two-module repro that reproduces the bare-name collision is possible but I could not confirm it exercises the same path without a measured compile to check against, so I have not guessed one in.
- **Next for `Linter.verify()`**: compiler throughput in `compileDeclarations`. That is now the practical obstacle — a measurable perf problem, not another semantic blocker.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: the CLA is an attestation by the human contributor, not something an agent should tick on their behalf. Per the template, internal/org-member PRs skip this check automatically. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_019xjoFY3RfHwTKb5GyvkY2g)_