### PR TITLE
docs(issues): migrate 8 accidentally-opened GitHub issues into plan/issues

### DIFF
--- a/plan/issues/3993-resolve-inherited-class-member-callables-from-package-graphs.md
+++ b/plan/issues/3993-resolve-inherited-class-member-callables-from-package-graphs.md
@@ -1,0 +1,48 @@
+---
+id: 3993
+title: "codegen: resolve inherited class member callables from package graphs"
+status: ready
+sprint: Backlog
+created: 2026-07-30
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: dogfood
+related: []
+---
+
+# codegen: resolve inherited class member callables from package graphs
+
+## Problem
+
+Packages:
+- Hono 4.12.16 dist/index.js: RegExpRouterWithMatcherExport_add
+- Webpack 5.109.2 lib/index.js: SortableSet_get_size
+- Tailwindcss 4.3.3 dist/lib.mjs: U_get_size
+
+Representative failure:
+```
+inherited class callable SortableSet_get_size has no exact defined function for handle 2438
+```
+
+Resolve inherited class member callables through canonical base-member lookup while preserving override semantics.
+
+Reproduce: pnpm run dogfood:hono, pnpm run dogfood:webpack, pnpm run dogfood:tailwindcss.
+
+## Provenance
+
+Migrated on 2026-08-01 from a GitHub issue on `loopdive/js2` (opened 2026-07-30)
+that was created by an agent in error — this project tracks work as markdown
+under `plan/issues/`, not as GitHub issues. The GitHub issue has been closed and
+points here. **No content was dropped:** the Problem section above is the
+original issue body verbatim.
+
+Metadata below the title is newly assigned and is a **starting estimate, not a
+measurement** — `priority`, `horizon` and `feasibility` were not stated in the
+original and have not been validated against the corpus. Re-derive before
+scheduling.

--- a/plan/issues/3994-bound-recursive-package-graph-traversal-for-typescript.md
+++ b/plan/issues/3994-bound-recursive-package-graph-traversal-for-typescript.md
@@ -1,0 +1,40 @@
+---
+id: 3994
+title: "compiler: bound recursive package graph traversal for TypeScript"
+status: ready
+sprint: Backlog
+created: 2026-07-30
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: dogfood
+related: []
+---
+
+# compiler: bound recursive package graph traversal for TypeScript
+
+## Problem
+
+TypeScript 5.9.3 lib/typescript.js fails with: Codegen error: Maximum call stack size exceeded.
+
+Use bounded or iterative work scheduling for recursive package graph traversal, or provide a structured diagnostic that identifies the recursion front.
+
+Reproduce: pnpm run dogfood:typescript.
+
+## Provenance
+
+Migrated on 2026-08-01 from a GitHub issue on `loopdive/js2` (opened 2026-07-30)
+that was created by an agent in error — this project tracks work as markdown
+under `plan/issues/`, not as GitHub issues. The GitHub issue has been closed and
+points here. **No content was dropped:** the Problem section above is the
+original issue body verbatim.
+
+Metadata below the title is newly assigned and is a **starting estimate, not a
+measurement** — `priority`, `horizon` and `feasibility` were not stated in the
+original and have not been validated against the corpus. Re-derive before
+scheduling.

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -1,0 +1,40 @@
+---
+id: 3995
+title: "npm-compat: pin and adapt original upstream test suites for catalog packages"
+status: ready
+sprint: Backlog
+created: 2026-07-30
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ci
+language_feature: n/a
+goal: dogfood
+related: []
+---
+
+# npm-compat: pin and adapt original upstream test suites for catalog packages
+
+## Problem
+
+The catalog package tarballs do not ship their original unit suites. The npm-compat page correctly reports upstream suite not shipped; adapter pending, but this needs a tracked path to genuine validation.
+
+Pin matching source revisions and provide adapters for: hono, lodash, axios, react-dom, webpack, uuid, typescript, redux, jest, styled-components, moment, stylelint, three, lit, tailwindcss, and cookie. Keep upstream-suite validation distinct from compile checks, synthetic differential vectors, and benchmark harnesses.
+
+Start with React DOM, Jest, and Lit, which already compile and validate their entry artifacts.
+
+## Provenance
+
+Migrated on 2026-08-01 from a GitHub issue on `loopdive/js2` (opened 2026-07-30)
+that was created by an agent in error — this project tracks work as markdown
+under `plan/issues/`, not as GitHub issues. The GitHub issue has been closed and
+points here. **No content was dropped:** the Problem section above is the
+original issue body verbatim.
+
+Metadata below the title is newly assigned and is a **starting estimate, not a
+measurement** — `priority`, `horizon` and `feasibility` were not stated in the
+original and have not been validated against the corpus. Re-derive before
+scheduling.

--- a/plan/issues/3996-keep-local-indexes-stable-across-package-entry-emission.md
+++ b/plan/issues/3996-keep-local-indexes-stable-across-package-entry-emission.md
@@ -1,0 +1,45 @@
+---
+id: 3996
+title: "codegen: keep local indexes stable across package-entry emission"
+status: ready
+sprint: Backlog
+created: 2026-07-30
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: dogfood
+related: []
+---
+
+# codegen: keep local indexes stable across package-entry emission
+
+## Problem
+
+Packages:
+- lodash 4.18.1 lodash.js: __cb_6
+- redux 5.0.1 redux.mjs: observable
+- moment 2.30.1 moment.mjs: normalizeObjectUnits
+
+Failure: Binary emit error: RangeError: Codegen error: local index out of range — 19 (valid: [0, 15))
+
+Derive local indexes from the final function layout after deferred imports, types, and import insertion.
+
+Reproduce: pnpm run dogfood:lodash, pnpm run dogfood:redux, pnpm run dogfood:moment.
+
+## Provenance
+
+Migrated on 2026-08-01 from a GitHub issue on `loopdive/js2` (opened 2026-07-30)
+that was created by an agent in error — this project tracks work as markdown
+under `plan/issues/`, not as GitHub issues. The GitHub issue has been closed and
+points here. **No content was dropped:** the Problem section above is the
+original issue body verbatim.
+
+Metadata below the title is newly assigned and is a **starting estimate, not a
+measurement** — `priority`, `horizon` and `feasibility` were not stated in the
+original and have not been validated against the corpus. Re-derive before
+scheduling.

--- a/plan/issues/3997-scale-bounded-package-compilation-beyond-axios-and-three-js.md
+++ b/plan/issues/3997-scale-bounded-package-compilation-beyond-axios-and-three-js.md
@@ -1,0 +1,42 @@
+---
+id: 3997
+title: "compiler: scale bounded package compilation beyond Axios and Three.js"
+status: ready
+sprint: Backlog
+created: 2026-07-30
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: dogfood
+related: []
+---
+
+# compiler: scale bounded package compilation beyond Axios and Three.js
+
+## Problem
+
+Compilation does not complete within the harness limit for:
+- axios 1.16.1 index.js: over 120 seconds
+- three 0.185.1 build/three.module.js: over 180 seconds
+
+Add progress attribution and bounded compilation behavior so these can be optimized with a concrete front rather than an opaque timeout.
+
+Reproduce: pnpm run dogfood:axios, pnpm run dogfood:three.
+
+## Provenance
+
+Migrated on 2026-08-01 from a GitHub issue on `loopdive/js2` (opened 2026-07-30)
+that was created by an agent in error — this project tracks work as markdown
+under `plan/issues/`, not as GitHub issues. The GitHub issue has been closed and
+points here. **No content was dropped:** the Problem section above is the
+original issue body verbatim.
+
+Metadata below the title is newly assigned and is a **starting estimate, not a
+measurement** — `priority`, `horizon` and `feasibility` were not stated in the
+original and have not been validated against the corpus. Re-derive before
+scheduling.

--- a/plan/issues/3998-give-uuid-v1tov6-a-stable-source-callable-inventory-owner.md
+++ b/plan/issues/3998-give-uuid-v1tov6-a-stable-source-callable-inventory-owner.md
@@ -1,0 +1,40 @@
+---
+id: 3998
+title: "codegen: give UUID v1ToV6 a stable source-callable inventory owner"
+status: ready
+sprint: Backlog
+created: 2026-07-30
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: dogfood
+related: []
+---
+
+# codegen: give UUID v1ToV6 a stable source-callable inventory owner
+
+## Problem
+
+UUID 14.0.1 dist/index.js fails because source callable v1ToV6 has no consistent exact top-level/compiler support inventory owner.
+
+Establish a stable canonical owner for source callables that originate in package entry graphs.
+
+Reproduce: pnpm run dogfood:uuid.
+
+## Provenance
+
+Migrated on 2026-08-01 from a GitHub issue on `loopdive/js2` (opened 2026-07-30)
+that was created by an agent in error — this project tracks work as markdown
+under `plan/issues/`, not as GitHub issues. The GitHub issue has been closed and
+points here. **No content was dropped:** the Problem section above is the
+original issue body verbatim.
+
+Metadata below the title is newly assigned and is a **starting estimate, not a
+measurement** — `priority`, `horizon` and `feasibility` were not stated in the
+original and have not been validated against the corpus. Re-derive before
+scheduling.

--- a/plan/issues/3999-preserve-local-reference-types-in-styled-components.md
+++ b/plan/issues/3999-preserve-local-reference-types-in-styled-components.md
@@ -1,0 +1,40 @@
+---
+id: 3999
+title: "wasm emission: preserve local reference types in styled-components"
+status: ready
+sprint: Backlog
+created: 2026-07-30
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: dogfood
+related: []
+---
+
+# wasm emission: preserve local reference types in styled-components
+
+## Problem
+
+styled-components 6.4.4 dist/styled-components.esm.js emits invalid Wasm: WebAssembly.Module(): Compiling function #212: nt failed: local.tee[0] expected type (ref null 205), found local.get of type i32.
+
+Preserve local type consistency across reference and scalar lowering.
+
+Reproduce: pnpm run dogfood:styled-components.
+
+## Provenance
+
+Migrated on 2026-08-01 from a GitHub issue on `loopdive/js2` (opened 2026-07-30)
+that was created by an agent in error — this project tracks work as markdown
+under `plan/issues/`, not as GitHub issues. The GitHub issue has been closed and
+points here. **No content was dropped:** the Problem section above is the
+original issue body verbatim.
+
+Metadata below the title is newly assigned and is a **starting estimate, not a
+measurement** — `priority`, `horizon` and `feasibility` were not stated in the
+original and have not been validated against the corpus. Re-derive before
+scheduling.

--- a/plan/issues/4000-add-a-capability-explicit-node-fs-lane-for-stylelint.md
+++ b/plan/issues/4000-add-a-capability-explicit-node-fs-lane-for-stylelint.md
@@ -1,0 +1,40 @@
+---
+id: 4000
+title: "npm-compat: add a capability-explicit Node fs lane for Stylelint"
+status: ready
+sprint: Backlog
+created: 2026-07-30
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ci
+language_feature: n/a
+goal: dogfood
+related: []
+---
+
+# npm-compat: add a capability-explicit Node fs lane for Stylelint
+
+## Problem
+
+Stylelint 17.14.1 lib/index.mjs is currently refused because Node fs capability is intentionally disabled.
+
+Add a labeled opt-in Node fs compatibility lane and report it separately on npm-compat. Do not silently grant filesystem access in the default sandboxed lane.
+
+Reproduce: pnpm run dogfood:stylelint.
+
+## Provenance
+
+Migrated on 2026-08-01 from a GitHub issue on `loopdive/js2` (opened 2026-07-30)
+that was created by an agent in error — this project tracks work as markdown
+under `plan/issues/`, not as GitHub issues. The GitHub issue has been closed and
+points here. **No content was dropped:** the Problem section above is the
+original issue body verbatim.
+
+Metadata below the title is newly assigned and is a **starting estimate, not a
+measurement** — `priority`, `horizon` and `feasibility` were not stated in the
+original and have not been validated against the corpus. Re-derive before
+scheduling.


### PR DESCRIPTION
An agent filed eight dogfood findings as **GitHub issues** on `loopdive/js2` (#3851–#3858, 2026-07-30). This project tracks work as markdown under `plan/issues/`, not as GitHub issues — so these existed **nowhere in the repo**.

Verified before migrating: no id match, and no content match on any distinctive keyword (`styled-components`, `Stylelint`, `v1ToV6`, `catalog package`, `recursive package graph`, …) across all 3,440 issue files on main. Closing them without this would have deleted the only record.

| GitHub | plan/issues | subject |
|---|---|---|
| #3851 | #3993 | resolve inherited class member callables from package graphs |
| #3852 | #3994 | bound recursive package graph traversal for TypeScript |
| #3853 | #3995 | pin and adapt original upstream test suites for catalog packages |
| #3854 | #3996 | keep local indexes stable across package-entry emission |
| #3855 | #3997 | scale bounded package compilation beyond Axios and Three.js |
| #3856 | #3998 | give UUID v1ToV6 a stable source-callable inventory owner |
| #3857 | #3999 | preserve local reference types in styled-components |
| #3858 | #4000 | add a capability-explicit Node fs lane for Stylelint |

Ids allocated atomically via `claim-issue.mjs` with `CLAIM_ASSIGN_REMOTE=upstream` (the default `origin` is the **fork**, whose `main` diverges — the root cause of the existing id collisions).

**Every original body is preserved verbatim** under `## Problem`; nothing was summarised away. The assigned `priority`/`horizon`/`feasibility` are **starting estimates, not measurements** — the originals stated none, and each file says so explicitly so the metadata is never later mistaken for evidence. All eight are `sprint: Backlog` so they do not flood the current TaskList.

The GitHub issues are being closed with a pointer to these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)