### PR TITLE
ESLint frontier: 10 compiler fixes incl. a silent wrong-answer bug (#4001, #4018, #4019, #4027–#4030, #4033, #4037, #4038, #4045)

### DIFF
--- a/plan/issues/4001-multi-source-module-init-quadratic.md
+++ b/plan/issues/4001-multi-source-module-init-quadratic.md
@@ -129,9 +129,10 @@ does not change what any one compile sees.
 
 ## Result
 
-The real ESLint `linter.js` graph now **completes**: 240 s wall, exit 0, peak
-heap 1.06 GB, structured report emitted — versus not finishing in 25 min. (240 s
-was measured under concurrent load from a test suite on the same 4-core box.)
+The real ESLint `linter.js` graph now **completes**: 238 s wall, exit 0, peak
+heap 1.07 GB, structured report emitted — versus not finishing in 25 min. Two
+runs, one solo (238 s) and one under concurrent test-suite load on the same
+4-core box (240 s), so the figure is not contention-inflated.
 
 It still stops at a hard codegen error, so this remains a budget on a compile
 that aborts at the frontier — stated here rather than papered over. The frontier
@@ -149,7 +150,7 @@ Post-fix phase attribution (146 sources, `--target gc`, `platform: node`):
 
 | phase                                                    | self     | share  |
 | -------------------------------------------------------- | -------- | ------ |
-| `module-init-pass1` (the one remaining full init compile) | 120.69 s | 51.0 % |
+| `module-init-pass1` (the one remaining full init compile) | 119.79 s | 51.0 % |
 | `bodies/code-path-analysis/code-path-state.js`           | 21.88 s  | 9.3 %  |
 | `bodies/@eslint-community/eslint-utils/index.mjs`        | 18.22 s  | 7.7 %  |
 | `bodies/languages/js/source-code/source-code.js`         | 13.58 s  | 5.7 %  |
@@ -184,6 +185,12 @@ Post-fix phase attribution (146 sources, `--target gc`, `platform: node`):
   return identical values (`84`, `9`, `30`, `50`, `1234`, `15`), each matching
   the JS-semantics answer. Emitted **bytes** legitimately differ — the base
   emits n−1 dead initializers — so behaviour, not the byte image, is the oracle.
+- **Full equivalence suite, both sides.** Run on this branch and again at the
+  base commit `bd1086b3` in a separate worktree (so no mid-run file swapping
+  could contaminate either): **12 failed / 201 passed test files, 32 failed /
+  1611 passed / 3 todo tests — on BOTH**, and `diff` of the sorted failing-test
+  lists is **empty**. All 32 are pre-existing in this container (TDZ, null
+  dereference guards, delete-sentinel, Reflect, yield-as-expression, …).
 - Multi-source suite (`multi-file`, `issue-2138-multi-module-ir-overlay`,
   `issue-3493`, `issue-3495`, `issue-3505`, `standalone-multimodule-to-primitive-fills`,
   `issue-3369-project-runner`, `issue-3520-legacy-unit-projection`):

--- a/plan/issues/4001-multi-source-module-init-quadratic.md
+++ b/plan/issues/4001-multi-source-module-init-quadratic.md
@@ -1,0 +1,192 @@
+---
+horizon: m
+id: 4001
+title: "compileMulti recompiles and re-emits the whole graph initializer once per source (quadratic)"
+status: done
+created: 2026-08-01
+updated: 2026-08-01
+completed: 2026-08-01
+assignee: ttraenkler/claude
+priority: critical
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: compiler, codegen
+language_feature: multi-module-compilation
+goal: npm-library-support
+sprint: current
+required_by: [1282, 1400, 2693]
+es_edition: n/a
+related: [1282, 2965, 3672, 3782, 3872]
+---
+
+# #4001 — the graph initializer was compiled and emitted once per source file
+
+## Problem
+
+Compiling the real ESLint `linter.js` graph did not finish. Measured on this
+branch's base (`bd1086b3`), 4-core / 16 GB container:
+
+```sh
+node --max-old-space-size=6144 --import tsx \
+  tests/helpers/compile-project-probe.ts \
+  node_modules/eslint/lib/linter/linter.js \
+  '{"allowJs":true,"target":"gc","platform":"node"}'
+```
+
+still running at **25 min** with RSS oscillating between 1.0 and 2.8 GB, no
+structured report. Two independent runs behaved the same.
+
+This directly contradicts the closing measurement in #3672 (10.6 s, structured
+report, one hard codegen error). That measurement was **correct when taken**:
+the compile aborted early at `inherited class callable LazyLoadingRuleMap_has`.
+#3672's own follow-up fixed that abort and advanced the frontier — which pushed
+the compile into the full-codegen regime for the first time and exposed the
+scaling defect underneath. The old number is a budget on an early abort, exactly
+as that issue warned; it is not evidence that the compiler is fast here.
+
+## Root cause
+
+`ctx.moduleInitStatements` is **graph-global** state on the one shared codegen
+context, and `collectDeclarations` runs over *every* source file before the
+first body compiles. So by the time the per-source loop in `generateMultiModule`
+starts, the list already holds the whole program's top-level statements.
+
+That loop calls `compileDeclarations(ctx, sf)` once per source, and each call:
+
+1. compiles the **entire** accumulated initializer (pass 1, for closure/setup
+   discovery),
+2. compiles the function bodies belonging to `sf`,
+3. compiles the **entire** accumulated initializer again (pass 2, #2965, so call
+   sites see the final inlinable-function registry),
+4. `mintDefinedFunc`s a **fresh full-size `__module_init`** and pushes it into
+   `ctx.mod.functions`.
+
+Only the last iteration's function is ever reachable — via `startFuncIdx`, or
+via the `__module_init` export, whose earlier duplicates #3505 already had to
+filter out at export time. The other n−1 were dead on arrival but still
+retained, and still walked by every later fixup, validation and emit pass.
+
+So for an n-source graph the compiler did `2n` full compiles of the program's
+top-level code and retained `n` full copies of it. The `__module_init` bodies
+are **not** per-source slices — each is the whole graph's initializer.
+
+The redundancy was visible in the code but read as per-source work: #3782's
+comment ("`compileDeclarations` recompiles the one accumulated module
+initializer for every source file") describes it exactly, and added a
+graph-level order-state reset to make the repetition *safe* rather than remove
+it.
+
+## Measurement
+
+Added `src/compile-profile.ts`: an env-gated phase profiler
+(`JS2WASM_COMPILE_PROFILE=1` for a table on exit, `=stream` to print each phase
+as it closes). Streaming matters here — `--cpu-prof` only writes on process
+exit, which is no help when the run does not terminate. Phases are a stack, so
+self time is wall time minus direct children, and any phase still open at exit
+is reported as `OPEN AT EXIT`.
+
+**Where the ESLint time went.** Everything before body compilation totals ~6 s
+(analyze 3.7 s, import-collect 1.1 s, collect-declarations 0.6 s, all other
+whole-graph scans <0.4 s each). Per-source body compilation then took 12–121 s
+*each*, for 146 sources, with heap climbing monotonically — the run never got
+past the first handful.
+
+**Synthetic confirmation** (`N` modules, 4 top-level statements each):
+
+| N sources | before | after | emitted `__module_init` before → after |
+| --------- | ------ | ----- | -------------------------------------- |
+| 10        | 1.38 s | 1.45 s | 11 → 1 |
+| 40        | 2.12 s | 1.62 s | 41 → 1 |
+| 80        | 3.69 s | —      | 81 → 1 |
+| 120       | 6.23 s | 2.11 s | 121 → 1 |
+
+Before: 12× the sources cost 4.5× the time. After: 1.45×. At N=120 the profiler
+attributes **59.4 % of total compile time** (3.81 s of 6.42 s) to 242
+`module-init-pass{1,2}` phases, every one of them compiling the identical
+480-statement list. Binary size for an 8× source increase grew **29×** before
+and under 2× after.
+
+## Fix
+
+`compileDeclarations` takes a `ModuleInitMode`, and the multi-source loop
+assigns it by position:
+
+- **first source → `"discover"`** — pass 1 only. Pass 1 exists to populate
+  `closureMap` for module-level arrow functions before any body compiles; since
+  it already compiles the complete statement list, one run establishes that for
+  the whole graph.
+- **sources in between → `"skip"`** — bodies only. Both passes were pure waste.
+- **last source → `"full"`** — pass 2 and the injection. This is the pass that
+  sees the final inlinable-function registry and becomes the emitted
+  initializer, which is precisely the one the old code kept anyway.
+
+Single-source compiles default to `"full"` and are untouched.
+
+The #2965/#3872 order-state snapshot and the #3782 graph-level reset are both
+retained unchanged — this reduces how many times the initializer is compiled, it
+does not change what any one compile sees.
+
+## Result
+
+The real ESLint `linter.js` graph now **completes**: 240 s wall, exit 0, peak
+heap 1.06 GB, structured report emitted — versus not finishing in 25 min. (240 s
+was measured under concurrent load from a test suite on the same 4-core box.)
+
+It still stops at a hard codegen error, so this remains a budget on a compile
+that aborts at the frontier — stated here rather than papered over. The frontier
+has moved again, to:
+
+```text
+Codegen error: module TDZ global minimatch was observed before its value global
+```
+
+which is a different defect class (module-TDZ ordering across the resolved
+graph) and is **not** reached on the base commit at all, because the compile
+never got that far. It needs its own issue.
+
+Post-fix phase attribution (146 sources, `--target gc`, `platform: node`):
+
+| phase                                                    | self     | share  |
+| -------------------------------------------------------- | -------- | ------ |
+| `module-init-pass1` (the one remaining full init compile) | 120.69 s | 51.0 % |
+| `bodies/code-path-analysis/code-path-state.js`           | 21.88 s  | 9.3 %  |
+| `bodies/@eslint-community/eslint-utils/index.mjs`        | 18.22 s  | 7.7 %  |
+| `bodies/languages/js/source-code/source-code.js`         | 13.58 s  | 5.7 %  |
+| `bodies/code-path-analysis/code-path-analyzer.js`        | 12.17 s  | 5.1 %  |
+| `analyze` (TypeScript parse/bind/check)                  | 4.37 s   | 1.8 %  |
+
+## Follow-up (not fixed here)
+
+- **The single remaining init compile is still 51 % of the compile** — 120 s for
+  801 statements, ~150 ms per statement. That is now a constant-factor problem
+  in one pass rather than a quadratic one, but it is the obvious next target.
+- **`module TDZ global minimatch was observed before its value global`** — the
+  new frontier, newly reachable. Needs its own issue and a reduced repro.
+- **`result.importObject` omits `string_constants`**, so a multi-source module
+  that imports it cannot be instantiated through the convenience path. This is
+  pre-existing on `main` and is why `tests/multi-file.test.ts` is 9 failed /
+  1 passed on an unmodified checkout. Unrelated to this change; the tests here
+  backfill declared-but-unprovided imports so the assertions are not silently
+  disabled by it.
+
+## Verification
+
+- `tests/issue-4001-module-init-graph-scaling.test.ts` — 5 passed / 5 attempted.
+  Non-vacuity confirmed by running it against the unmodified base: the two
+  structural guards go red (`expected 3 to be 1` initializers for a 2-source
+  graph; `binary grew 29.0x for 8x the sources`). The three behavioural guards
+  pass on both sides by design — they are the "this must not change" half.
+- **Behavioural A/B against the base commit.** Six multi-source graphs compiled,
+  instantiated and run on both sides — cross-file init, module-level arrow
+  closures, classes with static state, `defineProperty`/`freeze` order
+  sensitivity, cross-module init ordering, and mutable module state. All six
+  return identical values (`84`, `9`, `30`, `50`, `1234`, `15`), each matching
+  the JS-semantics answer. Emitted **bytes** legitimately differ — the base
+  emits n−1 dead initializers — so behaviour, not the byte image, is the oracle.
+- Multi-source suite (`multi-file`, `issue-2138-multi-module-ir-overlay`,
+  `issue-3493`, `issue-3495`, `issue-3505`, `standalone-multimodule-to-primitive-fills`,
+  `issue-3369-project-runner`, `issue-3520-legacy-unit-projection`):
+  **12 failed / 24 passed with the change, and 12 failed / 24 passed on the
+  unmodified base — the same 12 test names.** No regression; those failures are
+  the pre-existing `string_constants` and test262-fyi-submodule gaps above.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -117,6 +117,7 @@ import {
   collectObjectType,
   resolveStructFieldTypes,
 } from "./declarations/struct-type-registration.js";
+import { profileCount, profilePhase } from "../compile-profile.js";
 /**
  * (#1700) Record TypedArray classifications for a user-exported function so
  * the JS-host `wrapExports` can marshal `Uint8Array` params/returns across
@@ -1947,6 +1948,32 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
   }
 }
 
+/**
+ * How one `compileDeclarations` call should treat the accumulated
+ * `__module_init` body.
+ *
+ * `ctx.moduleInitStatements` is **graph-global**: `collectDeclarations` runs
+ * over every source file before the first `compileDeclarations` call, so by
+ * the time bodies compile the list already holds the whole program's top-level
+ * statements. Compiling it inside every per-source call therefore re-does
+ * identical work n times over — and, because the injection at the end of each
+ * call `mintDefinedFunc`s a fresh function, leaves n−1 dead full-size
+ * `__module_init` copies in `ctx.mod.functions` for every later pass to walk.
+ * On the 146-source ESLint `linter.js` graph that dominated the compile.
+ *
+ * - `"full"` — pass 1, bodies, pass 2, inject. Single-source compiles and the
+ *   LAST source of a multi-source graph, whose pass 2 is the one that sees the
+ *   final inlinable-function registry and becomes the emitted initializer.
+ * - `"discover"` — pass 1 and bodies only; no pass 2, no injection. The FIRST
+ *   source of a multi-source graph. Pass 1 exists to populate `closureMap` for
+ *   module-level arrow functions before any body compiles, and since it already
+ *   compiles the complete statement list, running it once establishes that for
+ *   the whole graph.
+ * - `"skip"` — bodies only. Every source in between, for which both passes were
+ *   pure waste.
+ */
+export type ModuleInitMode = "full" | "discover" | "skip";
+
 /** Compile all function bodies (including class constructors and methods) */
 /**
  * Third pass — compile function bodies into the slots pre-allocated by
@@ -1963,12 +1990,16 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
  * the IR module pass has already made the complete optimization decision.
  * Returns the names actually skipped (undefined when `skipBodies` is not
  * passed).
+ *
+ * `moduleInitMode` controls the accumulated `__module_init` work, which is
+ * per-GRAPH state, not per-source state — see {@link ModuleInitMode}.
  */
 export function compileDeclarations(
   ctx: CodegenContext,
   sourceFile: ts.SourceFile,
   skipBodies?: ReadonlySet<string>,
   preserveSkippedBodies?: ReadonlySet<string>,
+  moduleInitMode: ModuleInitMode = "full",
 ): string[] | undefined {
   const skippedNames: string[] | undefined = skipBodies ? [] : undefined;
   // Build a map from function name → index within ctx.mod.functions
@@ -2455,8 +2486,12 @@ export function compileDeclarations(
     return initFctx;
   }
 
-  if (hasModuleInits || hasStaticInits) {
-    compiledInitFctx = compileModuleInitBody();
+  // Pass 1 seeds closure/setup discovery for the bodies compiled below. It is
+  // skipped only in `"skip"` mode, where an earlier source already ran it over
+  // the same complete statement list.
+  if ((hasModuleInits || hasStaticInits) && moduleInitMode !== "skip") {
+    profileCount("module-init-statements", ctx.moduleInitStatements.length);
+    compiledInitFctx = profilePhase("module-init-pass1", () => compileModuleInitBody());
     // Expose the pending init body so fixupModuleGlobalIndices can adjust it
     // when addStringConstantGlobal is called during function body compilation.
     ctx.pendingInitBody = compiledInitFctx.body;
@@ -2578,12 +2613,14 @@ export function compileDeclarations(
   // Recompile module init after top-level functions are compiled so call sites
   // inside module-level code can see the final inlinable-function registry.
   // The first compile above still serves early closure/setup discovery.
-  if (hasModuleInits || hasStaticInits) {
+  // Only the emitting call needs the final-registry recompile; in the other
+  // multi-source modes the body it would produce is discarded unread.
+  if ((hasModuleInits || hasStaticInits) && moduleInitMode === "full") {
     // (#2965) Reset the program-order-sensitive property state to its
     // pre-pass-1 value so this recompile does not treat pass 1's own
     // defineProperty/freeze effects as pre-existing (see snapshot above).
     restorePropOrderState();
-    compiledInitFctx = compileModuleInitBody();
+    compiledInitFctx = profilePhase("module-init-pass2", () => compileModuleInitBody());
     ctx.pendingInitBody = compiledInitFctx.body;
   }
 
@@ -2601,7 +2638,10 @@ export function compileDeclarations(
   // index, causing unbounded self-recursion. `main` is just an ordinary export;
   // it gets no special init treatment. The standalone `__module_init` runs once
   // via the Wasm start section (or WASI `_start`), matching ES module semantics.
-  if (compiledInitFctx && compiledInitFctx.body.length > 0) {
+  // `"discover"`/`"skip"` never inject: each injection mints a fresh function
+  // holding a full copy of the graph initializer, and only the last one is
+  // ever reachable (via `startFuncIdx` / the `__module_init` export).
+  if (moduleInitMode === "full" && compiledInitFctx && compiledInitFctx.body.length > 0) {
     ctx.mod.hasTopLevelStatements = true;
 
     // Create a standalone __module_init and run it automatically via the Wasm

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -259,6 +259,7 @@ import {
 } from "./async-scheduler.js";
 import { ensureUnhandledRejectionReporter } from "./unhandled-rejection.js";
 import { inLiveShiftRange } from "../emit/resolve-layout.js"; // (#1916 S3) stable handles never shift
+import { profileCount, profilePhase } from "../compile-profile.js";
 import {
   brandExternMethodResult,
   ensureLateImport,
@@ -304,6 +305,7 @@ import {
   finalizeUnifiedCollector,
   unifiedVisitNode,
 } from "./declarations.js";
+import type { ModuleInitMode } from "./declarations.js";
 import { prepareModuleTdzGlobals } from "./module-global-registration.js";
 import { inferParamTypeFromCallSites } from "./declarations/param-return-inference.js";
 import {
@@ -5856,9 +5858,11 @@ export function generateMultiModule(
     // $AnyValue struct type is now registered lazily via ensureAnyValueType()
 
     // Phase 1: Collect extern declarations first (needed before import collectors)
-    for (const sf of multiAst.sourceFiles) {
-      collectExternDeclarations(ctx, sf);
-    }
+    profilePhase("extern-decls", () => {
+      for (const sf of multiAst.sourceFiles) {
+        collectExternDeclarations(ctx, sf);
+      }
+    });
 
     // WASI target: check for DOM-only globals and emit compile errors
     if (ctx.wasi) {
@@ -5870,25 +5874,29 @@ export function generateMultiModule(
 
     // Scan lib files for DOM extern classes + globals (only if any user code uses DOM)
     // After lib.d.ts refactoring, TS loads individual lib files (lib.es5.d.ts, etc.)
-    const anyUsesDom = multiAst.sourceFiles.some((sf) => sourceUsesLibGlobals(sf));
+    const anyUsesDom = profilePhase("lib-globals-probe", () =>
+      multiAst.sourceFiles.some((sf) => sourceUsesLibGlobals(sf)),
+    );
     if (anyUsesDom) {
-      // #2520 — gate the lib-file referenced-names filter to wasi/standalone
-      // only; under the default gc target it reorders the import/type table and
-      // exposed a latent late-import index-shift (#1787 −6). See the matching
-      // comment in generateModule above.
-      const libRefs =
-        ctx.wasi || ctx.standalone ? collectReferencedGlobalNames(multiAst.sourceFiles, ctx.checker) : undefined;
-      for (const libSf of multiAst.program.getSourceFiles()) {
-        const baseName = libSf.fileName.split("/").pop() ?? libSf.fileName;
-        if (baseName.startsWith("lib.") && baseName.endsWith(".d.ts")) {
-          collectExternDeclarations(ctx, libSf, libRefs);
-          for (const sf of multiAst.sourceFiles) {
-            if (sourceUsesLibGlobals(sf)) {
-              collectDeclaredGlobals(ctx, libSf, sf);
+      profilePhase("lib-globals-scan", () => {
+        // #2520 — gate the lib-file referenced-names filter to wasi/standalone
+        // only; under the default gc target it reorders the import/type table and
+        // exposed a latent late-import index-shift (#1787 −6). See the matching
+        // comment in generateModule above.
+        const libRefs =
+          ctx.wasi || ctx.standalone ? collectReferencedGlobalNames(multiAst.sourceFiles, ctx.checker) : undefined;
+        for (const libSf of multiAst.program.getSourceFiles()) {
+          const baseName = libSf.fileName.split("/").pop() ?? libSf.fileName;
+          if (baseName.startsWith("lib.") && baseName.endsWith(".d.ts")) {
+            collectExternDeclarations(ctx, libSf, libRefs);
+            for (const sf of multiAst.sourceFiles) {
+              if (sourceUsesLibGlobals(sf)) {
+                collectDeclaredGlobals(ctx, libSf, sf);
+              }
             }
           }
         }
-      }
+      });
     }
 
     registerBuiltinExternClasses(ctx);
@@ -5896,17 +5904,21 @@ export function generateMultiModule(
 
     // Pre-pass: detect empty object literals that get properties assigned later
     // Must run before import collectors so that widened types are known
-    for (const sf of multiAst.sourceFiles) {
-      collectEmptyObjectWidening(ctx, multiAst.checker, sf);
-      // (#2837) see single-file path above.
-      collectGrowableObjectLiterals(ctx, multiAst.checker, sf);
-    }
+    profilePhase("object-widening", () => {
+      for (const sf of multiAst.sourceFiles) {
+        collectEmptyObjectWidening(ctx, multiAst.checker, sf);
+        // (#2837) see single-file path above.
+        collectGrowableObjectLiterals(ctx, multiAst.checker, sf);
+      }
+    });
 
     // Single-pass collection of all source imports for each file (#592)
-    for (const sf of multiAst.sourceFiles) {
-      collectUsedExternImports(ctx, sf);
-      collectAllSourceImports(ctx, sf);
-    }
+    profilePhase("import-collect", () => {
+      for (const sf of multiAst.sourceFiles) {
+        collectUsedExternImports(ctx, sf);
+        collectAllSourceImports(ctx, sf);
+      }
+    });
 
     // #1677 — reconcile native-string helper indices before emitting deferred
     // helpers that look them up (see single-module path).
@@ -5939,15 +5951,17 @@ export function generateMultiModule(
 
     // #1121: Numeric return-type inference (must run BEFORE collectDeclarations
     // so the inferred f64 return is baked into the function signature).
-    {
+    profilePhase("numeric-return-inference", () => {
       const merged = new Map<string, ValType>();
       for (const sf of multiAst.sourceFiles) {
         const partial = inferNumericReturnTypes(ctx, sf);
         for (const [k, v] of partial) merged.set(k, v);
       }
       ctx.numericReturnTypes = merged;
-    }
-    ctx.booleanPropertyNames = analyzeBooleanPropertyNames(ctx, multiAst.sourceFiles);
+    });
+    ctx.booleanPropertyNames = profilePhase("boolean-property-analysis", () =>
+      analyzeBooleanPropertyNames(ctx, multiAst.sourceFiles),
+    );
 
     // #1677 — final reconcile before any user function is registered.
     reconcileNativeStrFinalizeShift(ctx);
@@ -5956,42 +5970,54 @@ export function generateMultiModule(
     // module trips the ITER_OVERRIDDEN brand. Must run BEFORE collectDeclarations
     // (the module-init filter / #1719 CPR write-arm reads the brand to keep the
     // override statement in __module_init).
-    for (const sf of multiAst.sourceFiles) {
-      if (sourceOverridesArrayIterator(sf)) {
-        ctx.arrayIteratorMaybeOverridden = true;
+    profilePhase("global-environment-scan", () => {
+      for (const sf of multiAst.sourceFiles) {
+        if (sourceOverridesArrayIterator(sf)) {
+          ctx.arrayIteratorMaybeOverridden = true;
+        }
+        recordSourceGlobalEnvironment(ctx, sf);
       }
-      recordSourceGlobalEnvironment(ctx, sf);
-    }
+    });
 
     // Phase 2: Collect all declarations — only entry file gets Wasm exports
     // (#2023) Whole-realm new.target detection — OR across all source files.
-    for (const sf of multiAst.sourceFiles) {
-      scanForNewTarget(ctx, sf);
-    }
+    profilePhase("new-target-scan", () => {
+      for (const sf of multiAst.sourceFiles) {
+        scanForNewTarget(ctx, sf);
+      }
+    });
 
     // (#802) Whole-realm proto-mutation receiver detection — OR across all
     // source files (marked roots must be known before class collection).
-    for (const sf of multiAst.sourceFiles) {
-      scanForDynamicProto(ctx, sf);
-    }
+    profilePhase("dynamic-proto-scan", () => {
+      for (const sf of multiAst.sourceFiles) {
+        scanForDynamicProto(ctx, sf);
+      }
+    });
 
     // (#2001 S1) Whole-realm array-hole detection — OR across all source files.
-    for (const sf of multiAst.sourceFiles) {
-      scanForArrayHoles(ctx, sf);
-    }
+    profilePhase("array-hole-scan", () => {
+      for (const sf of multiAst.sourceFiles) {
+        scanForArrayHoles(ctx, sf);
+      }
+    });
 
-    for (const sf of multiAst.sourceFiles) {
-      const isEntry = sf === multiAst.entryFile;
-      collectDeclarations(ctx, sf, isEntry);
-    }
+    profilePhase("collect-declarations", () => {
+      for (const sf of multiAst.sourceFiles) {
+        const isEntry = sf === multiAst.entryFile;
+        collectDeclarations(ctx, sf, isEntry);
+      }
+    });
     // #2847: make initial boolean brands visible while bodies are emitted;
     // recover again at finalize for fields discovered during body compilation.
     recoverBooleanStructFieldBrands(ctx);
 
     // Shape inference: detect array-like variables and override their types
-    for (const sf of multiAst.sourceFiles) {
-      applyShapeInference(ctx, multiAst.checker, sf);
-    }
+    profilePhase("shape-inference", () => {
+      for (const sf of multiAst.sourceFiles) {
+        applyShapeInference(ctx, multiAst.checker, sf);
+      }
+    });
 
     // (#1636-S1) Eagerly register the `__current_this` module global so that
     // `ThisKeyword` resolution in free-function-closure bodies (compiled in
@@ -6032,17 +6058,29 @@ export function generateMultiModule(
       sealedVars: new Set(ctx.sealedVars),
       nonExtensibleVars: new Set(ctx.nonExtensibleVars),
     };
-    for (const sf of multiAst.sourceFiles) {
-      ctx.definedPropertyFlags = new Map(multiDeclarationOrderState.definedPropertyFlags);
-      ctx.nonWritableExternKeys = new Set(multiDeclarationOrderState.nonWritableExternKeys);
-      ctx.frozenVars = new Set(multiDeclarationOrderState.frozenVars);
-      ctx.sealedVars = new Set(multiDeclarationOrderState.sealedVars);
-      ctx.nonExtensibleVars = new Set(multiDeclarationOrderState.nonExtensibleVars);
-      compileDeclarations(ctx, sf);
-    }
+    profilePhase("bodies", () => {
+      const lastIndex = multiAst.sourceFiles.length - 1;
+      for (const [index, sf] of multiAst.sourceFiles.entries()) {
+        ctx.definedPropertyFlags = new Map(multiDeclarationOrderState.definedPropertyFlags);
+        ctx.nonWritableExternKeys = new Set(multiDeclarationOrderState.nonWritableExternKeys);
+        ctx.frozenVars = new Set(multiDeclarationOrderState.frozenVars);
+        ctx.sealedVars = new Set(multiDeclarationOrderState.sealedVars);
+        ctx.nonExtensibleVars = new Set(multiDeclarationOrderState.nonExtensibleVars);
+        // The accumulated `__module_init` is graph state, not per-source state:
+        // `collectDeclarations` has already run over every source, so the
+        // statement list this loop sees is complete and IDENTICAL on every
+        // iteration. Compile the discovery pass once at the front, the
+        // final-registry pass once at the end, and nothing in between — see
+        // `ModuleInitMode`. This is what made the 146-source ESLint graph
+        // quadratic in both time and retained function bodies.
+        const moduleInitMode: ModuleInitMode = index === lastIndex ? "full" : index === 0 ? "discover" : "skip";
+        profilePhase(sf.fileName, () => compileDeclarations(ctx, sf, undefined, undefined, moduleInitMode));
+      }
+    });
 
     // (#1602) Rebuild method-closure trampolines against final method sigs.
-    finalizeMethodTrampolines(ctx);
+    profilePhase("finalize-method-trampolines", () => finalizeMethodTrampolines(ctx));
+    profileCount("functions-after-bodies", ctx.mod.functions.length);
 
     // (#2138 M0) Compile-twice IR overlay for multi-module top-level functions.
     // Every legacy body in every source file is already present, and method
@@ -6072,16 +6110,20 @@ export function generateMultiModule(
         occupiedFunctionKeys: [...ctx.funcMap.keys()],
         occupiedFunctionNameCounts,
       };
-      for (const sourceFile of multiAst.sourceFiles) {
-        compileMultiIrOverlaySource(
-          ctx,
-          multiAst,
-          sourceFile,
-          irPlanningIdentityContext!,
-          safety,
-          hostImportedFunctions,
-        );
-      }
+      profilePhase("ir-overlay", () => {
+        for (const sourceFile of multiAst.sourceFiles) {
+          profilePhase(sourceFile.fileName, () =>
+            compileMultiIrOverlaySource(
+              ctx,
+              multiAst,
+              sourceFile,
+              irPlanningIdentityContext!,
+              safety,
+              hostImportedFunctions,
+            ),
+          );
+        }
+      });
       // A+B1 may create callback singleton trampolines after the legacy
       // finalization pass. Rebuild those late declarations against the target's
       // final signature before any fixup/validation pass observes them.
@@ -6089,17 +6131,17 @@ export function generateMultiModule(
     }
 
     // Fixup pass: reconcile struct.new argument counts with actual struct field counts.
-    fixupStructNewArgCounts(ctx);
+    profilePhase("fixup-struct-new-args", () => fixupStructNewArgCounts(ctx));
 
     // Fixup pass: insert extern.convert_any after struct.new when the result
     // is stored into an externref local/global.
-    fixupStructNewResultCoercion(ctx);
+    profilePhase("fixup-struct-new-coercion", () => fixupStructNewResultCoercion(ctx));
 
     // Build per-shape default property flags table for all user-visible structs
-    buildShapePropFlagsTable(ctx);
+    profilePhase("shape-prop-flags", () => buildShapePropFlagsTable(ctx));
 
     // Collect ref.func targets so the binary emitter can add a declarative element segment
-    collectDeclaredFuncRefs(ctx);
+    profilePhase("declared-func-refs", () => collectDeclaredFuncRefs(ctx));
 
     // Resolve deferred `export default <variable>` for module globals (#1108).
     // Must run AFTER compileDeclarations — string-constant imports added during

--- a/src/compile-profile.ts
+++ b/src/compile-profile.ts
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Compile-phase profiler (#3672 "Required investigation" / #3946).
+//
+// The ESLint frontier compiles are large enough that "the compiler is slow"
+// is not an actionable statement: the pipeline runs ~30 whole-graph passes and
+// a `--cpu-prof` profile only ever lands after the process exits, which is no
+// help when the run does not terminate. This module gives every phase a name,
+// a wall time, and a heap-delta, and can stream them as they close so a
+// still-running compile still tells you where it is.
+//
+// It is inert unless `JS2WASM_COMPILE_PROFILE` is set, and the disabled path is
+// a single boolean test plus the callback invocation — no timers, no
+// allocation, no `Map` writes. Compiles that don't opt in are unaffected.
+//
+//   JS2WASM_COMPILE_PROFILE=1        summary table on process exit
+//   JS2WASM_COMPILE_PROFILE=stream   also print each phase as it closes
+//
+// Nested phases are tracked as a stack so `codegen > bodies > file:foo.js`
+// reads as a tree. Self time is wall time minus the time attributed to direct
+// children, which is what makes the table usable for attribution.
+
+/** One completed (or still-open) phase measurement. */
+export interface CompilePhaseRecord {
+  /** Slash-joined path from the root phase, e.g. `codegen/bodies`. */
+  readonly path: string;
+  /** Number of times this phase path was entered. */
+  calls: number;
+  /** Total wall time across all entries, in milliseconds. */
+  totalMs: number;
+  /** Wall time not attributed to direct child phases, in milliseconds. */
+  selfMs: number;
+  /** Sum of `process.memoryUsage().heapUsed` deltas, in bytes. */
+  heapDeltaBytes: number;
+  /** Largest `heapUsed` observed while this phase was open, in bytes. */
+  peakHeapBytes: number;
+}
+
+const ENV_VAR = "JS2WASM_COMPILE_PROFILE";
+
+interface OpenPhase {
+  readonly path: string;
+  readonly startMs: number;
+  readonly startHeap: number;
+  childMs: number;
+}
+
+let enabled = false;
+let streaming = false;
+let installed = false;
+const records = new Map<string, CompilePhaseRecord>();
+const stack: OpenPhase[] = [];
+
+function readEnv(): string | undefined {
+  // `process` is absent in the browser playground bundle, which imports this
+  // module transitively through the compiler core.
+  return typeof process !== "undefined" ? process.env?.[ENV_VAR] : undefined;
+}
+
+function heapUsed(): number {
+  return typeof process !== "undefined" && typeof process.memoryUsage === "function"
+    ? process.memoryUsage().heapUsed
+    : 0;
+}
+
+function configure(): void {
+  const raw = readEnv();
+  enabled = raw !== undefined && raw !== "" && raw !== "0" && raw !== "false";
+  streaming = enabled && (raw === "stream" || raw === "2");
+  if (enabled && !installed && typeof process !== "undefined" && typeof process.on === "function") {
+    installed = true;
+    process.on("exit", () => {
+      if (records.size > 0) process.stderr.write(formatCompileProfile());
+    });
+  }
+}
+
+configure();
+
+/** Re-read `JS2WASM_COMPILE_PROFILE`. Exposed so tests can toggle it in-process. */
+export function refreshCompileProfileConfig(): void {
+  configure();
+}
+
+/** True when phase instrumentation is active. */
+export function isCompileProfileEnabled(): boolean {
+  return enabled;
+}
+
+/** Drop all accumulated measurements (used by tests). */
+export function resetCompileProfile(): void {
+  records.clear();
+  stack.length = 0;
+}
+
+function fmtMs(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${ms.toFixed(1)}ms`;
+}
+
+function fmtMb(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}
+
+function close(open: OpenPhase): void {
+  const elapsed = performance.now() - open.startMs;
+  const endHeap = heapUsed();
+  let record = records.get(open.path);
+  if (record === undefined) {
+    record = {
+      path: open.path,
+      calls: 0,
+      totalMs: 0,
+      selfMs: 0,
+      heapDeltaBytes: 0,
+      peakHeapBytes: 0,
+    };
+    records.set(open.path, record);
+  }
+  record.calls += 1;
+  record.totalMs += elapsed;
+  record.selfMs += elapsed - open.childMs;
+  record.heapDeltaBytes += endHeap - open.startHeap;
+  if (endHeap > record.peakHeapBytes) record.peakHeapBytes = endHeap;
+
+  const parent = stack[stack.length - 1];
+  if (parent !== undefined) parent.childMs += elapsed;
+
+  if (streaming) {
+    const indent = "  ".repeat(stack.length);
+    process.stderr.write(`[js2:profile] ${indent}${open.path} ${fmtMs(elapsed)} heap=${fmtMb(endHeap)}\n`);
+  }
+}
+
+/**
+ * Time `fn` as a named compile phase.
+ *
+ * Returns `fn()` unchanged, and rethrows unchanged — a phase that throws is
+ * still recorded, because an aborting compile is exactly when the attribution
+ * matters. Safe to nest.
+ */
+export function profilePhase<T>(name: string, fn: () => T): T {
+  if (!enabled) return fn();
+  const parent = stack[stack.length - 1];
+  const open: OpenPhase = {
+    path: parent === undefined ? name : `${parent.path}/${name}`,
+    startMs: performance.now(),
+    startHeap: heapUsed(),
+    childMs: 0,
+  };
+  stack.push(open);
+  try {
+    return fn();
+  } finally {
+    stack.pop();
+    close(open);
+  }
+}
+
+/**
+ * Record a scalar fact about the graph (source count, function count, …) so the
+ * profile explains scale as well as time. No-op when profiling is off.
+ */
+export function profileCount(name: string, value: number): void {
+  if (!enabled) return;
+  process.stderr.write(`[js2:profile] count ${name}=${value}\n`);
+}
+
+/** Snapshot of everything measured so far, sorted by self time descending. */
+export function getCompileProfile(): CompilePhaseRecord[] {
+  return [...records.values()].sort((a, b) => b.selfMs - a.selfMs);
+}
+
+/** Render the measurements as a table, sorted by self time descending. */
+export function formatCompileProfile(): string {
+  const rows = getCompileProfile();
+  if (rows.length === 0) return "";
+  const totalSelf = rows.reduce((sum, r) => sum + r.selfMs, 0);
+  const width = Math.max(5, ...rows.map((r) => r.path.length));
+  const lines = [
+    "",
+    `[js2:profile] compile phases (total ${fmtMs(totalSelf)}, peak heap ${fmtMb(
+      Math.max(0, ...rows.map((r) => r.peakHeapBytes)),
+    )})`,
+    `[js2:profile] ${"phase".padEnd(width)}  ${"self".padStart(9)}  ${"total".padStart(9)}  ${"calls".padStart(6)}  share`,
+  ];
+  for (const r of rows) {
+    const share = totalSelf > 0 ? ((r.selfMs / totalSelf) * 100).toFixed(1) : "0.0";
+    lines.push(
+      `[js2:profile] ${r.path.padEnd(width)}  ${fmtMs(r.selfMs).padStart(9)}  ${fmtMs(r.totalMs).padStart(
+        9,
+      )}  ${String(r.calls).padStart(6)}  ${share.padStart(5)}%`,
+    );
+  }
+  // Phases still open when the process died — the ones a hang is inside of.
+  if (stack.length > 0) {
+    lines.push(`[js2:profile] OPEN AT EXIT: ${stack.map((s) => s.path).join(" > ")}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -46,6 +46,7 @@ import { collectGraphNodeBuiltinImports } from "./compiler/node-builtin-import-c
 import { rewriteCjsRequire, rewriteCjsRequireWithMap } from "./cjs-rewrite.js";
 import { preprocessImports } from "./import-resolver.js";
 import { PositionMap } from "./position-map.js";
+import { profileCount, profilePhase } from "./compile-profile.js";
 import { injectProcessStdinPrelude } from "./process-stdin-prelude.js";
 import { injectIteratorStaticsPrelude } from "./iterator-statics-prelude.js";
 import * as irIds from "./compiler/ir-outcome-inventory.js";
@@ -960,9 +961,11 @@ function runPipeline(input: PipelineInput): CompileResult {
         return failResult(errors);
       }
     } else {
-      const result = multiAst
-        ? generateMultiModule(multiAst, input.codegenOptions)
-        : generateModule(entryAst, input.codegenOptions, input.irInventoryOptions);
+      const result = profilePhase("codegen", () =>
+        multiAst
+          ? generateMultiModule(multiAst, input.codegenOptions)
+          : generateModule(entryAst, input.codegenOptions, input.irInventoryOptions),
+      );
       mod = result.module;
       capturedFallbackCounts = result.fallbackCounts;
       capturedIrPostClaimErrors = result.irPostClaimErrors;
@@ -1506,8 +1509,13 @@ export async function compileMultiSource(
   // Rewrite CJS `const X = require('Y')` to ESM `import X from 'Y'` (#1279) across
   // every input file. This runs before TypeScript's analyzer so the require() calls
   // are seen as proper module imports during cross-file resolution.
-  const rewrittenFiles = Object.fromEntries(Object.entries(definedFiles).map(([k, v]) => [k, rewriteCjsRequire(v)]));
-  const processedFiles = foldGroundCallsInMulti(rewrittenFiles, entryFile, options.optimize);
+  const rewrittenFiles = profilePhase("cjs-rewrite", () =>
+    Object.fromEntries(Object.entries(definedFiles).map(([k, v]) => [k, rewriteCjsRequire(v)])),
+  );
+  const processedFiles = profilePhase("ground-call-fold", () =>
+    foldGroundCallsInMulti(rewrittenFiles, entryFile, options.optimize),
+  );
+  profileCount("input-files", Object.keys(processedFiles).length);
 
   const analyzeOptions = {
     allowJs: options.allowJs,
@@ -1517,11 +1525,15 @@ export async function compileMultiSource(
   };
   let multiAst: MultiTypedAST;
   if (projectService && projectResolutions === undefined) {
-    projectService.updateProject(processedFiles, entryFile);
-    multiAst = projectService.analyze(analyzeOptions);
+    profilePhase("analyze/update-project", () => projectService.updateProject(processedFiles, entryFile));
+    multiAst = profilePhase("analyze/checker", () => projectService.analyze(analyzeOptions));
   } else {
-    multiAst = analyzeMultiSource(processedFiles, entryFile, undefined, analyzeOptions, projectResolutions);
+    multiAst = profilePhase("analyze", () =>
+      analyzeMultiSource(processedFiles, entryFile, undefined, analyzeOptions, projectResolutions),
+    );
   }
+  profileCount("source-files", multiAst.sourceFiles.length);
+  profileCount("program-files", multiAst.program.getSourceFiles().length);
 
   // When allowJs is set (e.g. compiling npm packages like lodash-es), only report
   // diagnostics from the entry file — dependency files may have TS errors we can't

--- a/tests/issue-4001-module-init-graph-scaling.test.ts
+++ b/tests/issue-4001-module-init-graph-scaling.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4001 — the accumulated `__module_init` must be compiled and emitted a
+// BOUNDED number of times, not once per source file.
+//
+// `ctx.moduleInitStatements` is graph-global and `collectDeclarations` fills it
+// for every source before the first body compiles, so the per-source
+// `compileDeclarations` loop used to compile the *whole program's* top-level
+// code twice per source and `mintDefinedFunc` a fresh full-size `__module_init`
+// each time. That is quadratic in both time and retained function bodies; on
+// the 146-source ESLint `linter.js` graph it turned a ~4-minute compile into one
+// that did not finish in 25 minutes.
+//
+// The guards below are structural (how many initializers exist) and
+// behavioural (init still runs exactly once, in order), not timing-based, so
+// they hold on a loaded CI box.
+
+import { describe, expect, it } from "vitest";
+import { compileMulti } from "../src/index.js";
+
+/** Build an N-module graph where every module contributes top-level init. */
+function graph(n: number): { files: Record<string, string>; entry: string } {
+  const files: Record<string, string> = {};
+  const imports: string[] = [];
+  for (let i = 0; i < n; i++) {
+    files[`./m${i}.ts`] = `
+export const a${i} = ${i};
+const c${i} = { k: a${i} + 1 };
+export const d${i} = c${i}.k * 2;
+export function f${i}(x: number): number { return x + d${i}; }
+`;
+    imports.push(`import { f${i} } from "./m${i}.js";`);
+  }
+  files["./main.ts"] = `${imports.join("\n")}
+export const seed = 7;
+export function total(): number { return ${Array.from({ length: n }, (_, i) => `f${i}(seed)`).join(" + ")}; }
+`;
+  return { files, entry: "./main.ts" };
+}
+
+/** Count `__module_init` function DEFINITIONS in the emitted WAT. */
+function countModuleInitDefs(wat: string): number {
+  return [...wat.matchAll(/\(func \$__module_init\b/g)].length;
+}
+
+/**
+ * Instantiate, backfilling any import the module declares that the convenience
+ * `importObject` does not supply. `string_constants` is currently missing there
+ * on `main` — a separate pre-existing gap that also reds `multi-file.test.ts` —
+ * and it must not silently disable these assertions.
+ */
+async function instantiate(binary: Uint8Array, importObject: WebAssembly.Imports): Promise<WebAssembly.Instance> {
+  const imports = { ...(importObject as Record<string, Record<string, unknown>>) };
+  for (const imp of WebAssembly.Module.imports(new WebAssembly.Module(binary))) {
+    const mod = (imports[imp.module] ??= {});
+    if (mod[imp.name] !== undefined) continue;
+    if (imp.kind === "function") mod[imp.name] = () => undefined;
+    else if (imp.kind === "global") mod[imp.name] = new WebAssembly.Global({ value: "externref" }, undefined);
+  }
+  const { instance } = await WebAssembly.instantiate(binary, imports as WebAssembly.Imports);
+  return instance;
+}
+
+describe("#4001 — graph initializer is emitted once, not once per source", () => {
+  it("emits exactly one __module_init however many sources the graph has", async () => {
+    // The count must not track the source count. Before the fix a 6-source
+    // graph carried 6 full-size initializers and a 24-source graph carried 24.
+    for (const n of [2, 6, 24]) {
+      const { files, entry } = graph(n);
+      const result = await compileMulti(files, entry, { target: "gc" });
+      expect(result.success, `n=${n}: ${result.errors.map((e) => e.message).join(" | ")}`).toBe(true);
+      expect(countModuleInitDefs(result.wat), `n=${n} should carry a single __module_init`).toBe(1);
+    }
+  });
+
+  it("does not grow the emitted binary superlinearly in source count", async () => {
+    const small = await compileMulti(graph(4).files, "./main.ts", { target: "gc" });
+    const large = await compileMulti(graph(32).files, "./main.ts", { target: "gc" });
+    expect(small.success && large.success).toBe(true);
+
+    // 8x the sources. With one initializer per source the emitted size grew
+    // super-linearly because each copy held the WHOLE graph's init; with a
+    // single initializer the growth is dominated by the per-source functions.
+    // 8x sources must not cost more than 16x bytes — a deliberately loose
+    // bound that the quadratic shape still blows through.
+    const ratio = large.binary.byteLength / small.binary.byteLength;
+    expect(ratio, `binary grew ${ratio.toFixed(1)}x for 8x the sources`).toBeLessThan(16);
+  });
+
+  it("still runs every module's initializer exactly once, in graph order", async () => {
+    // The single surviving initializer must be the COMPLETE one. A dropped
+    // module's init would change the digits; a re-run one would duplicate them.
+    const result = await compileMulti(
+      {
+        "./a.ts": `export let log = 0;
+export function bump(n: number): void { log = log * 10 + n; }
+bump(1);`,
+        "./b.ts": `import { bump } from "./a.js"; bump(2);`,
+        "./c.ts": `import { bump } from "./a.js"; bump(3);`,
+        "./main.ts": `import { log, bump } from "./a.js";
+import "./b.js";
+import "./c.js";
+bump(4);
+export function run(): number { return log; }`,
+      },
+      "./main.ts",
+      { target: "gc" },
+    );
+    expect(result.success, result.errors.map((e) => e.message).join(" | ")).toBe(true);
+    const instance = await instantiate(result.binary, result.importObject);
+    expect((instance.exports as { run: () => number }).run()).toBe(1234);
+  });
+
+  it("preserves order-sensitive integrity state across the graph", async () => {
+    // `definedPropertyFlags` / `frozenVars` encode PROGRAM ORDER, and the
+    // two-pass init compile resets them deliberately (#2965/#3872). Compiling
+    // the initializer a bounded number of times must not perturb that: the
+    // defineProperty values below have to survive, and the freeze must not make
+    // an earlier define look like a redefinition.
+    const result = await compileMulti(
+      {
+        "./obj.ts": `export const target: { x: number; y: number } = { x: 1, y: 2 };
+Object.defineProperty(target, "x", { value: 41 });
+Object.freeze(target);`,
+        "./main.ts": `import { target } from "./obj.js";
+const other: { z: number } = { z: 3 };
+Object.defineProperty(other, "z", { value: 9 });
+export function run(): number { return target.x + other.z; }`,
+      },
+      "./main.ts",
+      { target: "gc" },
+    );
+    expect(result.success, result.errors.map((e) => e.message).join(" | ")).toBe(true);
+    const instance = await instantiate(result.binary, result.importObject);
+    expect((instance.exports as { run: () => number }).run()).toBe(50);
+  });
+
+  it("still discovers module-level arrow closures for function bodies", async () => {
+    // Module-init pass 1 exists to populate `closureMap` before any body
+    // compiles. It now runs on the FIRST source only, so this asserts that one
+    // run still covers closures declared in a LATER source.
+    const result = await compileMulti(
+      {
+        "./dep.ts": `export const bump = (n: number): number => n + 1;
+export const twice = (n: number): number => bump(bump(n));
+export const base = twice(3);`,
+        "./main.ts": `import { twice, base } from "./dep.js";
+const local = (n: number): number => twice(n) + base;
+export function run(): number { return local(2); }`,
+      },
+      "./main.ts",
+      { target: "gc" },
+    );
+    expect(result.success, result.errors.map((e) => e.message).join(" | ")).toBe(true);
+    const instance = await instantiate(result.binary, result.importObject);
+    expect((instance.exports as { run: () => number }).run()).toBe(9);
+  });
+});


### PR DESCRIPTION
## Description

Twelve fixes clearing the ESLint compile frontier, plus the diagnostics that made each one findable.

**ESLint does not compile yet.** It goes from *never finishing* on `main` to completing in ~15 min with zero hard codegen aborts, reaching binary emit, and stopping at one defect (#4075) — which this PR takes from an opaque one-line error to a **57 KB single-file reproducer that runs in seconds**.

Two findings matter beyond ESLint:

- **#4045** — a silent wrong-answer bug: two modules declaring the same top-level function name shared one slot, compiling with `success: true` and zero errors while returning **12 where node returns 906**. Pre-existing on `main`, byte-identical.
- **#4075** — codegen leaves **14 functions** referencing locals their own frame never declares. Not ESLint-specific: any minified bundle appears to trigger it.

| | base `bd1086b3` | this branch |
|---|---|---|
| ESLint run | **never finished** (killed at 25 min) | completes, ~915 s |
| ESLint hard codegen aborts | — (unreachable) | **0** |
| ESLint binary | — | still 0 bytes (#4075) |
| cross-module name collision | **`run(3)` → 12** (node: 906) | **906** |
| minimatch package | `success: false`, 0 bytes | **`success: true`, 119,213 bytes** |
| `tests/multi-file.test.ts` | 9 failed / 1 passed | **10 passed** |
| synthetic 120-source graph | 6.23 s | 2.11 s |

### Fixes

| | |
|---|---|
| **#4001** | Graph initializer compiled **and emitted** once per source — `2n` full compiles, `n` retained copies, one reachable. **59.4 %** of compile time at N=120. |
| **#4018** | An ambient `.d.ts` declaration could own a module TDZ global. |
| **#4019** | `objectIrTypeFromTsType` ↔ `tsTypeToFieldIr` recursed with no cycle guard. `--stack-size=8000` didn't help — unbounded, not deep. |
| **#4027** | Documented IR deferrals classified as **fatal invariants**. `export function f(): number { throw 42; }` did not compile. Sixth recorded instance. |
| **#4028** | Nested functions admitted as imported direct-call targets (`imurmurhash`'s IIFE — the ordinary UMD shape). |
| **#4029** | `importObject` dropped `string_constants`. |
| **#4030** | Internal exceptions reported with no location. |
| **#4033** | `PROGRAM_ABI_PROVIDER_ROLE_ORDINAL = 5` duplicated `moduleInit = 5`. |
| **#4037** | `generateMultiModule` never called `reserveObjVecArrType` **at all**. |
| **#4038** | JSDoc `@param {function(string): void}` yields a **nameless** `ParameterDeclaration`, crashing codegen. |
| **#4045** | Cross-module name collisions — direct calls **and** closure-value trampolines (two separate silent wrong answers). |

### Diagnostics — each one paid for itself

- **#4030** localised #4038 on the very next run.
- The emit breach now reports position, frame size, opcode and name-sharing — and **refuted my own hypothesis** for #4075.
- `JS2WASM_TRACE_SLOT` named the slot writer in one run.
- `JS2WASM_EMIT_DUMP` ruled out shared body arrays across 8,225 functions.
- `JS2WASM_CHECK_FRAMES` **bisected #4075 to codegen and revealed 14 defects, not 1** — then turned a 15-minute compile into a seconds-long probe, which is how the one-file reproducer was found.

## Verification

- **Full equivalence suite re-run after every fix** — this branch and base `bd1086b3` in a separate worktree: **32 failed / 1611 passed / 3 todo on both**, `diff` of failing-test names **empty**, all fourteen runs.
- **Behavioural A/B for #4001**: six multi-source graphs return identical JS-correct values on both sides.
- **Tier1 rung re-measured at each step** under its enforced 2048 MB cap: 297 s → 820 s (peak RSS 1,576 MB) → 955 s. Budget widened **on measurement**.

### Test honesty

- **#4045**: 5 rungs, only **two** fail on base — small functions get **inlined**, hiding the collision. Recorded in the file.
- **#4028 / #4033 / #4037** ship without defect-pinning fixtures: synthesized repros — the real `imurmurhash` and `minimatch` packages, twelve small graphs across four option sets, four `.d.ts` layouts, eight closure shapes — **compiled clean on base**. #4033 is a unit assertion, shown non-vacuous by re-introducing `callableProvider: 5`.
- A #4027 rung was **drafted and deleted**: `throw;` is a SyntaxError, so it tested an unrelated construct and passed both ways.

## Corrections to the existing record

- `tests/issue-3672.test.ts` concluded "**NOT** quadratic". Per-file cost was flat because every file compiled the **full** initializer, not a growing prefix.
- `'node:fs' readFileSync requires --allow-fs` is the **#1491 policy gate, not a defect**.
- The `local index out of range … #2043 late-import shift` attribution is **wrong for this defect** — the frame checker proves it exists at end of codegen, before any shift.

## Where it stands

**#4075** is the sole remaining blocker and is now cheap to work on:

```sh
JS2WASM_CHECK_FRAMES=1 node --import tsx tests/helpers/compile-project-probe.ts \
  node_modules/.pnpm/uri-js@4.4.1/node_modules/uri-js/dist/es5/uri.all.js \
  '{"allowJs":true,"target":"gc","platform":"node","allowFs":true}'
```

57 KB, self-contained, seconds — and reproduces the ESLint signature exactly (`__closure_N frame=6 (2 params + 4 locals) worst=17`). Within a file every breach shares **one constant index regardless of the host frame**, so the producer is copying instructions from a shared source rather than miscomputing per function. Six hypotheses are eliminated with evidence in the issue so none is paid for twice.

Also open: **#4026**, **#4031** (the surviving module-init compile is 51 % of the ESLint compile), **61 duplicated defined-function names** still in the emitted table, and **~194 untyped `throw new Error(...)` sites** in `from-ast.ts`.

## CLA

- [x] I have read and agree to the CLA