### PR TITLE
fix(#3988): the npm-compat refresh never published anything — break the livelock

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -15,9 +15,15 @@ name: Refresh npm-compat
 on:
   push:
     branches: [main]
-  # Backstop: a main busy enough to keep cancelling in-progress runs (see the
-  # concurrency block) could otherwise starve the refresh indefinitely. This
-  # guarantees an upper bound on staleness regardless of merge rate.
+  # Backstop for a quiet main (no pushes ⇒ no push-triggered refresh) and for a
+  # run lost to a deferred merge-queue gate.
+  #
+  # It is NOT a backstop against starvation by a busy main, which is what the
+  # original comment here claimed. A cron run lands in the same concurrency
+  # group as every push run, so under `cancel-in-progress: true` it was
+  # cancelled just like the rest — the "guaranteed upper bound on staleness" was
+  # never guaranteed by anything. That is now handled where it belongs, by not
+  # cancelling in-progress runs at all.
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
@@ -27,11 +33,21 @@ permissions:
 
 concurrency:
   group: npm-compat-refresh-${{ github.ref }}
-  # Only the newest main matters: a cancelled run is always superseded by one
-  # that will publish a strictly fresher artifact. Unlike benchmark-refresh
-  # (7-12 min) this job is tens of minutes, so letting pushes queue would pile
-  # up runs whose output is obsolete before they finish.
-  cancel-in-progress: true
+  # MUST be false. This job takes ~24 min; main merges more often than that. With
+  # `cancel-in-progress: true` every run was killed mid-flight by the next push —
+  # 6 of the first 7 runs were `cancelled` and the artifact never moved off its
+  # first snapshot. The original reasoning ("a cancelled run is always superseded
+  # by one publishing a strictly fresher artifact") only holds when the job is
+  # SHORTER than the merge interval; here the superseding run is cancelled too,
+  # forever. The 6h cron was supposed to backstop that and cannot: it lands in
+  # this same concurrency group and is cancelled by the next push like anything
+  # else.
+  #
+  # `false` is not "let runs pile up": GitHub keeps at most ONE pending run per
+  # group and cancels older pending ones, so this is bounded at one running plus
+  # one queued — finish the current measurement, coalesce everything that arrived
+  # while it ran.
+  cancel-in-progress: false
 
 jobs:
   refresh:
@@ -150,36 +166,74 @@ jobs:
           git remote add deploykey "git@github.com:${GITHUB_REPOSITORY}.git"
           git fetch deploykey main
 
-          # A run measuring an older main must not overwrite a newer one's
-          # artifact. The scheduled trigger makes this reachable in normal
-          # operation, not just as a race.
-          remote_sha="$(git rev-parse deploykey/main)"
-          if [ "$remote_sha" != "$SOURCE_SHA" ]; then
-            echo "Main advanced from ${SOURCE_SHA} to ${remote_sha}; a newer run owns promotion."
+          # Do NOT gate on "did main advance". It always advances — the job runs
+          # ~24 min and main merges faster than that — so the sha-equality guard
+          # this replaces deferred EVERY completed run to "a newer run", while
+          # `cancel-in-progress` was killing those newer runs. The two composed
+          # into a livelock: the artifact sat on its first snapshot for 9 hours
+          # while both mechanisms each pointed at the other.
+          #
+          # The invariant that actually matters is FRESHNESS: never overwrite a
+          # newer artifact with an older measurement. Compare `generatedAt`, not
+          # commit shas. A measurement taken a few commits behind head is still
+          # vastly better than one taken hours behind — that is the entire point
+          # of the job.
+          # Read the remote copy via `git show`, NOT `git checkout -- <path>`:
+          # the working tree currently holds the freshly generated artifact and
+          # a checkout would overwrite the very thing we are about to publish.
+          git show deploykey/main:benchmarks/results/npm-compat.json > /tmp/remote-npm-compat.json 2>/dev/null || true
+          REMOTE_STAMP="$(node -e 'try{const r=JSON.parse(require("fs").readFileSync("/tmp/remote-npm-compat.json","utf8"));process.stdout.write(String(r.generatedAt??""))}catch{process.stdout.write("")}')"
+          OURS_STAMP="$(node -e 'try{const r=JSON.parse(require("fs").readFileSync("benchmarks/results/npm-compat.json","utf8"));process.stdout.write(String(r.generatedAt??""))}catch{process.stdout.write("")}')"
+          if [ -n "$REMOTE_STAMP" ] && [ -n "$OURS_STAMP" ] && [[ "$REMOTE_STAMP" > "$OURS_STAMP" ]]; then
+            echo "main already carries a fresher artifact (${REMOTE_STAMP} > ${OURS_STAMP}); nothing to publish."
             exit 0
           fi
 
-          git add -f -- \
-            benchmarks/results/npm-compat.json \
-            benchmarks/results/npm-compat-perf.json \
-            benchmarks/results/npm-compat-history.json \
-            website/public/benchmarks/results/npm-compat.json \
-            website/public/benchmarks/results/npm-compat-perf.json \
+          ARTIFACTS=(
+            benchmarks/results/npm-compat.json
+            benchmarks/results/npm-compat-perf.json
+            benchmarks/results/npm-compat-history.json
+            website/public/benchmarks/results/npm-compat.json
+            website/public/benchmarks/results/npm-compat-perf.json
             website/public/benchmarks/results/npm-compat-history.json
+          )
 
-          if git diff --cached --quiet; then
-            echo "npm-compat artifacts are already current."
-            exit 0
-          fi
+          # Stash the generated artifacts OUTSIDE the work tree, then replay them
+          # onto whatever main is now. The commit cannot be built on SOURCE_SHA:
+          # main has advanced during the ~24 min measurement, so a push from that
+          # base is a guaranteed non-fast-forward. This is the step that actually
+          # makes a long-running measurement publishable.
+          STAGE="$(mktemp -d)"
+          for f in "${ARTIFACTS[@]}"; do
+            mkdir -p "${STAGE}/$(dirname "$f")"
+            cp "$f" "${STAGE}/$f"
+          done
 
-          git commit -m "chore(ci): refresh npm-compat artifacts [skip ci]"
-          if ! git push deploykey HEAD:main; then
+          for attempt in 1 2 3 4 5; do
             git fetch deploykey main
-            advanced_sha="$(git rev-parse deploykey/main)"
-            if [ "$advanced_sha" != "$SOURCE_SHA" ]; then
-              echo "Main advanced during promotion; the newer run will publish its own snapshot."
+            # `-f`: the work tree still holds the regenerated artifacts, which
+            # differ from main's committed copies, so a plain checkout would
+            # refuse with "local changes would be overwritten". Discarding them
+            # is safe — STAGE holds the only copy that matters.
+            git checkout -q -f -B npm-compat-publish deploykey/main
+            for f in "${ARTIFACTS[@]}"; do
+              mkdir -p "$(dirname "$f")"
+              cp "${STAGE}/$f" "$f"
+            done
+            git add -f -- "${ARTIFACTS[@]}"
+
+            if git diff --cached --quiet; then
+              echo "npm-compat artifacts are already current on main."
               exit 0
             fi
-            echo "::error::push to main failed while main was unchanged."
-            exit 1
-          fi
+
+            git commit -q -m "chore(ci): refresh npm-compat artifacts [skip ci]"
+            if git push deploykey HEAD:main; then
+              echo "Published npm-compat artifacts measured at ${SOURCE_SHA}."
+              exit 0
+            fi
+            echo "push rejected (main advanced mid-promotion); replaying onto the new head — attempt ${attempt}/5."
+          done
+
+          echo "::error::could not publish npm-compat artifacts after 5 replay attempts."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,7 @@ Be concise. Lead with the answer, then only the context needed to act on it.
 | `benchmarks/results/playground-benchmark-sidebar.json`    | main repo (committed, ~1KB) | landing-page sidebar wasm/js perf chart; `benchmark-refresh.yml` regression diff baseline                                  | `benchmark-refresh.yml` auto-commit step on every push to main (#1216) | (none)                                                                                                                                                    |
 | `benchmarks/results/npm-compat.json` (+ `-perf`, `-history`, and the `website/public/` twins) | main repo (committed) | the whole `npm-compat.html` dashboard — every package card's compile/validate, tests and perf | `npm-compat-refresh.yml` auto-commit on every push to main, 6h cron backstop (#3988) | pre-promote check in that workflow: refuses to publish <20 packages or entries missing `name`/`compile` |
 
+
 **`npm-compat.json` is refreshed by CI on every merge to main
 (`npm-compat-refresh.yml`, #3988) — do NOT hand-commit it.** Until 2026-08-01
 nothing regenerated it, so changing `scripts/generate-npm-compat-report.mjs` and
@@ -196,6 +197,21 @@ and no signal; that shipped stale twice in one day (#3958 rendered `39/null`;
 #3977 kept showing `lit` as `not-integrated` after its suite landed). The
 workflow now regenerates and auto-commits with `[skip ci]`, gated on the merge
 queue (#3915) and on a pre-promote sanity check.
+
+**The refresh job is ~24 min — LONGER than the interval between merges to main.
+That is load-bearing for anything you change about it (#3988).** Its first cut
+carried `cancel-in-progress: true` plus a "main advanced, a newer run owns
+promotion" guard, and the two composed into a livelock: every run was cancelled
+mid-flight by the next push, the single run that survived deferred to a "newer
+run" that had itself been cancelled, and the artifact did not move for 9 hours
+while CI stayed green. The 6h cron did not save it — a scheduled run shares the
+same concurrency group and is cancelled like any other. If you touch a long
+auto-commit-to-main workflow, the two rules that fall out of this are: **never
+`cancel-in-progress` a job longer than its own trigger interval**, and **gate
+promotion on artifact FRESHNESS (`generatedAt`), never on commit-sha equality
+with the revision you measured** — main always advances underneath you, so a
+sha check defers 100% of runs. Replay the artifact onto current main and retry
+instead.
 
 Two consequences worth knowing:
 

--- a/plan/issues/3988-npm-compat-artifact-has-no-refresh-job.md
+++ b/plan/issues/3988-npm-compat-artifact-has-no-refresh-job.md
@@ -105,16 +105,62 @@ incidents and dropping the parts that do not apply:
 | decision | why |
 | --- | --- |
 | **push to main + 6h cron + dispatch; NOT on PRs** | The artifact is data, not a correctness gate — a PR run has nothing to decide, and a full generation is expensive. The cron is a backstop so a busy main cannot starve the refresh (see concurrency). |
-| **`cancel-in-progress: true`** | Only the newest main matters; a cancelled run is always superseded by one publishing a strictly fresher artifact. benchmark-refresh lets pushes queue because it is 7-12 min — this job is tens of minutes, so queuing would pile up runs already obsolete when they finish. |
+| ~~**`cancel-in-progress: true`**~~ **WRONG — reverted, see "The livelock" below** | ~~Only the newest main matters; a cancelled run is always superseded by one publishing a strictly fresher artifact.~~ The superseding run gets cancelled too, forever, whenever the job is longer than the merge interval. |
 | **Single job, not measure/promote split** | That split exists because benchmark-refresh also runs on PRs, where untrusted code must never reach write credentials. This never runs on a PR, so everything it executes is main's own trusted code. |
 | **Reuses `scripts/main-push-queue-gate.mjs`** | #3915: ANY push to main — including `[skip ci]` — rebuilds every queued merge group and discards the validation running under it. Not optional. |
 | **`github-actions[bot]` actor guard** | Its own `[skip ci]` commit is a push to main. `[skip ci]` suppresses workflows on that commit; the actor check is what makes the loop *impossible* rather than merely unlikely. |
 | **Sanity-check before promoting** | A generator that exits 0 having written a truncated file would blank the dashboard, and the page has no fallback source. Refuses to publish fewer than 20 packages or entries missing `name`/`compile`. |
-| **Main-advanced check before push** | The cron trigger makes "this run measured an older main" reachable in normal operation, not just as a race. |
+| ~~**Main-advanced check before push**~~ **WRONG — reverted, see "The livelock" below** | ~~The cron trigger makes "this run measured an older main" reachable in normal operation, not just as a race.~~ Main advances on EVERY run of a 24-min job, so this deferred 100% of completed runs. |
 
 Option 2 (a PR staleness gate) is **not** implemented and is no longer needed
 for the original failure mode — with CI regenerating on merge, a PR that changes
 the generator without touching the artifact is now correct rather than stale.
+
+## The livelock: the refresh workflow never published anything (2026-08-01)
+
+The workflow shipped and then **did not refresh the artifact once** in the
+following 9 hours. Both causes were my own design decisions in the table above,
+and they composed into a livelock where each one pointed at the other as the
+recovery path.
+
+Measured: the job takes **~24 min** (18:30:40 → 18:54:45). Main merges more
+often than that.
+
+1. **`cancel-in-progress: true` killed every run mid-flight.** 6 of the first 7
+   runs ended `cancelled`. The stated reasoning — "a cancelled run is always
+   superseded by one publishing a strictly fresher artifact" — only holds when
+   the job is SHORTER than the merge interval. Here the superseding run is
+   cancelled by the next push too, indefinitely.
+2. **The one run that survived deferred itself.** Run 30712669325 completed all
+   24 minutes, regenerated, passed the sanity check and the queue gate — then
+   hit the main-advanced guard: `Main advanced from bc7481e4 to 8eb5b837; a
+   newer run owns promotion.` and exited 0. That "newer run" was cancelled by
+   (1). Net effect: `generatedAt` stayed pinned at `2026-08-01T11:06:18Z`, the
+   hand-committed catch-up value, while `cookie`'s fixed lane (#3981, merged in
+   #3987) never appeared on the page.
+
+The **cron was not a backstop against this**, contrary to what this issue
+claimed. A scheduled run lands in the same concurrency group as a push run and
+was cancelled exactly like the others.
+
+### Fixes
+
+| change | why |
+| --- | --- |
+| `cancel-in-progress: false` | Let the measurement finish. GitHub keeps at most ONE pending run per group and cancels older pending ones, so this is bounded at one running + one queued — it is "coalesce", not "pile up". |
+| Replace the sha-equality guard with a **freshness** comparison | The invariant that matters is "never overwrite a NEWER artifact with an older measurement", which is a `generatedAt` comparison. Whether main advanced is irrelevant — it always does. |
+| Replay the artifacts onto current main before pushing (5 attempts) | A commit built on `SOURCE_SHA` can never fast-forward onto an advanced main. Stash the generated files outside the tree, `checkout -B` onto fresh `deploykey/main`, copy back, commit, push; retry on a mid-flight race. |
+| Push failure after 5 replays is now a **hard error** | The old code exited 0 on a failed push whenever main had moved — i.e. silently, every time. A refresh that cannot publish must be loud. |
+
+### Lesson
+
+The generalisable one: **a "newer run will handle it" deferral is only safe if
+something guarantees a newer run actually completes.** Two independent
+mechanisms that each defer to the other produce a system that is green,
+silent, and permanently stuck. Both of this workflow's guards were written to
+avoid publishing a slightly-stale artifact and together they published nothing
+at all — the far worse outcome, and exactly the failure mode (#3958, #3977) the
+workflow exists to prevent.
 
 ### Cost, stated plainly
 


### PR DESCRIPTION
**The cookie fix (#3981) is on main but not on the compat page, because the refresh workflow I shipped this morning has never published anything.** `benchmarks/results/npm-compat.json` is still stamped `2026-08-01T11:06:18Z` — the hand-committed catch-up value from 9 hours ago.

Both causes were my own decisions in #3988's design table, and they composed into a livelock where each pointed at the other as the recovery path.

## The measurement that makes it a livelock

The job takes **~24 min** (18:30:40 → 18:54:45). Main merges more often than that.

1. **`cancel-in-progress: true` killed every run mid-flight** — 6 of the first 7 ended `cancelled`. My stated reasoning ("a cancelled run is always superseded by one publishing a strictly fresher artifact") only holds when the job is *shorter* than the merge interval. Here the superseding run is cancelled by the next push too, indefinitely.

2. **The one run that survived all 24 minutes deferred itself.** Run [30712669325](https://github.com/loopdive/js2/actions/runs/30712669325) regenerated, passed the sanity check and the queue gate, then hit the main-advanced guard:
   ```
   Main advanced from bc7481e4 to 8eb5b837; a newer run owns promotion.
   ```
   That "newer run" was cancelled by (1).

The **6h cron was not a backstop against this**, contrary to what #3988 claimed — a scheduled run lands in the same concurrency group and is cancelled like any other.

## Fixes

| change | why |
|---|---|
| `cancel-in-progress: false` | Let the measurement finish. GitHub keeps at most **one** pending run per group and cancels older pending ones, so this is bounded at one running + one queued — "coalesce", not "pile up". |
| Gate promotion on artifact **freshness** (`generatedAt`), not sha equality | The real invariant is "never overwrite a newer artifact with an older measurement". Whether main advanced is irrelevant: it always does, so the sha check deferred **100%** of completed runs. |
| Replay the artifacts onto current main before pushing (5 attempts) | A commit built on the measured SHA can never fast-forward onto an advanced main. The generated files are stashed outside the work tree, then copied onto a fresh `deploykey/main` checkout. `checkout -f` because the work tree still holds the regenerated copies. |
| A push still failing after 5 replays is now a **hard error** | The old code exited 0 whenever main had moved — i.e. silently, every time. A refresh that cannot publish must be loud. |

## The generalisable lesson

Recorded in both #3988 and `CLAUDE.md`: **a "a newer run will handle it" deferral is only safe if something guarantees a newer run completes.** Two independent mechanisms that each defer to the other produce a system that is green, silent, and permanently stuck. Both guards were written to avoid publishing a *slightly*-stale artifact, and together they published nothing at all — the exact failure mode (#3958, #3977) the workflow exists to prevent.

The two concrete rules for any long auto-commit-to-main job: never `cancel-in-progress` a job longer than its own trigger interval, and never gate promotion on sha-equality with the revision you measured.

## Verification and its limit

YAML parses; the promote script passes `bash -n`. **The behaviour itself cannot be verified before merge** — the workflow only runs on push to `main`, so its first real exercise is this PR's own merge, same as when it was introduced. What to watch afterwards: the run should end in `Published npm-compat artifacts measured at <sha>`, and `generatedAt` should move off `11:06:18Z`. If it does not, the next thing to check is the merge-queue gate step deferring (`decision=defer`), which is a separate and legitimate deferral with its own 12h staleness floor.

No `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdciSGoMA9bs8AWhQ1tyPh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdciSGoMA9bs8AWhQ1tyPh)_