### PR TITLE
docs: re-land the goal restatement + close #3991 (both lost to enqueue-time snapshot)

### DIFF
--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -175,6 +175,41 @@ and a goal being "ready" doesn't mean it should be worked on immediately.
 | **backend-agnostic-ir**  | Active (s57)                                  | IR lowers to 2+ backends via a trait                                                                  | compiler-architecture                                                               | #1713 (trait seam, hard, arch-spec), #1714 (linear proof), #1715 (bytecode proof), #2953 (pushRaw gap, P1), #2954 (LinearEmitter core ops), #2956 (linear consumes IR, XL); feeds #1584                                                            |
 | **ir-full-coverage**     | **Active — NORTH STAR** (elevated 2026-07-02) | ALL AST kinds through the IR front-end; backends fork below the IR; direct AST→Wasm front-end retired | backend-agnostic-ir (trait seam)                                                    | Current retirement: #3518 epic; #3519 truth; #3520–#3523 identity/compile-once; #3525 whole program; #3526 runtime contract; #3527 async plans; #3528 shared linear; #3090 deletion. Historical inputs: #2855/#2856–#2859, #2949–#2952, #2955.     |
 
+
+### ⚠ ES5 + untagged standalone — goal RESTATED 2026-08-01 (project-lead ruling)
+
+**The goal is ~95.4 % EX-DYNAMIC-CODE, not 100 %.** Target **8,150 of 8,545**
+reachable (6,176 passing + 1,974 non-dynamic failures). Scope = test262 files
+carrying `es5id:` **or** none of `es5id`/`es6id`/`esid`.
+
+**317 files are DECLINE-BY-DEPENDENCY and are OUT OF SCOPE — not failures to fix:**
+
+| blocker | files | needs |
+| --- | ---: | --- |
+| eval / `Function` | ~144 | real eval (#2928) — the Acorn interpreter provider; minutes to compile, unaffordable per shard. A **packaging** problem (#2527) as much as a semantics one. |
+| `with` — object environment records with first-class Reference identity | ~162 | a **front-end substrate**, same weight class as the 795-file descriptor MOP |
+
+Near-disjoint; 13 files need both. **Funding eval does NOT deliver `with`** — an
+earlier version of the census said otherwise and was corrected.
+
+- **Do not dispatch agents at these 317.**
+- **Do not measure progress against 8,545 or report "100 %".** A run at 95.4 % is
+  **success**, not a 4.6 % shortfall.
+- **95.4 % is an UPPER BOUND, not a forecast** — 202 files remain unpriced.
+
+**Why the exclusion is sound (non-circularity control):** the same detector run
+over the 6,176 goal-scope *passes* finds **248 files that use `eval`/`with`/
+`Function` and pass anyway**. The 317 were identified by **engine refusal**, not
+by mentioning the feature.
+
+`with` is additionally **168 of 175 host-lane**, so it is shared front-end
+scope-analysis work, not a standalone-gap item.
+
+**Revisit** if #2527 packaging makes real eval affordable per shard.
+
+Evidence: `plan/log/analysis-2026-08-01-es5-untagged-tail-census.md` (baselines
+`d8c30f3b7df0`, js2 main `bc54c09da`).
+
 ## How to use this
 
 1. **Pick work from active/activatable goals** -- these have their dependencies met

--- a/plan/issues/3991-dynamic-descriptor-static-expansion.md
+++ b/plan/issues/3991-dynamic-descriptor-static-expansion.md
@@ -2,7 +2,8 @@
 id: 3991
 title: "Object.defineProperties/create static expansion silently defines `undefined` for a non-literal descriptor"
 sprint: current
-status: in-progress
+status: done
+completed: 2026-08-01
 priority: high
 horizon: m
 feasibility: hard


### PR DESCRIPTION
Two fixes, one cause: **the merge queue snapshots a PR's head at ENQUEUE time.** Anything pushed afterwards is not rejected — it is **silently absent** from the merged SHA, while `gh pr view` still shows it as the head of a **MERGED** PR, which reads as landed.

1. **The ES5+untagged goal restatement never reached main.** ~95.4% ex-dynamic-code (project-lead ruling 2026-08-01) was pushed to #3990 *after* it was queued at `07f950ccc`. Verified: `git merge-base --is-ancestor 378ce04b5 upstream/main` → **NO**, and `grep -c 'goal RESTATED'` on main → **0**.
2. **#3991 sat at `status: in-progress` on a MERGED issue** for the same reason — the queue took #3982 at `c4d2748cb`, before the flip was pushed. Now `done` + `completed`.

**The rule this implies is sharper than "don't push to a queued PR": anything that must land has to be in the FIRST push, before enqueue.** This PR follows it — both fixes are in the first commit.

Also recorded in the commit message, because it nearly caused real damage: an urgent escalation today claimed a PR was reverting a just-merged fix, based on `git diff <main> <head>`. That **two-dot** diff reports *"main has files this branch does not YET have"* as deletions. The branch deleted nothing — it predated the fix. The honest checks are `git merge-base --is-ancestor` and a **three-dot** diff against the branch's own merge base. Both the reporting agent and the lead ran the flawed check before acting; nothing was damaged, but a dequeue was attempted on that evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)