### PR TITLE
docs(issues): rescue 8 issue files stranded in /workspace; renumber 6 collided ids

### DIFF
--- a/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
+++ b/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
@@ -391,3 +391,51 @@ issue is still warranted.
 - host_free_pass ≥ 24,500 (from 20,885) — i.e. the family's ~90% banked.
 - `registerGeneratorHostImports` (the index.ts:11798 registration) is dead in
   standalone compiles of the test262 corpus (S7 assert).
+
+## 2026-08-01 harvest note — acceptance is NOT measurable from the published baseline
+
+`/harvest-errors` against `loopdive/js2wasm-baselines` run `20260801-090441`
+(gitHash `c601e89b`) turned up a **blocker for closing this umbrella**: the
+acceptance criteria above are all phrased in terms of **leaky passes**
+(`host_free_pass`, "appear in <100 official-scope leaky passes"), but the
+published `test262-standalone-current.jsonl` **cannot express that measurement**:
+
+| Lane | records | carry `imports` | **passing** records carrying `imports` |
+| --- | --- | --- | --- |
+| default (JS-host) | 47,834 | 41,276 | 26,553 |
+| **standalone** | 48,088 | 2,679 | **0** |
+
+No passing standalone record carries an `imports` field, so leaky-pass counts
+per import name are unobtainable from the artifact. Whoever closes this
+umbrella needs the standalone promotion to emit `imports` on **passing**
+records first (or a purpose-built S7 assert per the third bullet), otherwise
+the first two acceptance bullets can be neither verified nor refuted.
+
+### What the published artifact *can* show (different population — do not compare)
+
+The #2961 leak guard names the leaking imports when it **refuses**. Across
+**2,125 official failing** standalone records:
+
+| Import | Records |
+| --- | --- |
+| `env::__gen_next` | 753 |
+| `env::__gen_result_value` | 672 |
+| `env::__gen_create_buffer` | 637 |
+| `env::__get_caught_exception` | 637 |
+| `env::__gen_result_done` | 630 |
+| `env::Promise_then2` | 378 |
+| `env::__create_generator` | 371 |
+| `env::__js_array_new` | 348 |
+| `env::__js_array_push` | 320 |
+| `env::SharedArrayBuffer_new` | 313 |
+| `env::__create_async_generator` | 266 |
+| `env::__gen_return` | 257 |
+| `env::__gen_yield_star` | 205 |
+
+**These are refusals among FAILING tests, not leaky passes.** They are a
+different population from the 1,739 / 2,408 / 2,262 / 4,106 baselines above and
+must not be read as progress against them. `__make_callback` does not appear in
+the top 25 refusal names. Non-generator families also show up in the same guard
+output and belong elsewhere: `__js_array_*` / `__array_concat_any` → #3531,
+`SharedArrayBuffer_new` → #674 / #1354.
+

--- a/plan/issues/3975-standalone-262-detacharraybuffer-unsupported.md
+++ b/plan/issues/3975-standalone-262-detacharraybuffer-unsupported.md
@@ -1,0 +1,100 @@
+---
+id: 3975
+title: "standalone: `$262.detachArrayBuffer` unsupported — 206 tests refuse, 80 of them already pass in the host lane"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: testing
+language_feature: typed-arrays
+goal: standalone-mode
+related: [1523, 1350, 1645, 1781]
+origin: "2026-08-01 /harvest-errors of loopdive/js2wasm-baselines test262-standalone-current.jsonl (run 20260801-090441, gitHash c601e89b)"
+---
+
+# #3975 — standalone lane has no `$262.detachArrayBuffer`
+
+## TL;DR
+
+**206 official failing tests** in the **standalone** lane fail with:
+
+```
+Error: $262.detachArrayBuffer is unsupported by this host
+```
+
+The default (JS-host) lane hits this **zero** times — #1523 provided the `$262`
+host-object API (`createRealm` / `detachArrayBuffer` / `agent`) for the host
+lane only. The standalone lane never got an equivalent, so every test that
+needs to detach a buffer to observe post-detach behaviour refuses.
+
+This is a **lane gap, not a semantics gap**, and it has an unusually clean
+payoff: **80 of the 206 files already pass in the host lane**, so they are
+blocked purely by the missing harness capability.
+
+## Evidence
+
+Source: `test262-standalone-current.jsonl` from `loopdive/js2wasm-baselines`,
+run `20260801-090441` (gitHash `c601e89b`); standalone official
+25,630 / 43,106 pass (59.5 %).
+
+| Category | Count |
+| --- | --- |
+| `built-ins/TypedArray` | 78 |
+| `built-ins/DataView` | 77 |
+| `built-ins/TypedArrayConstructors` | 42 |
+| `built-ins/ArrayBuffer` | 6 |
+| `built-ins/Uint8Array` | 3 |
+| **total** | **206** |
+
+Cross-lane check on the same 206 files:
+
+| Default-lane status | Count |
+| --- | --- |
+| `pass` | **80** |
+| `fail` | 126 |
+
+So ~80 tests are directly recoverable by implementing the capability; the other
+126 fail in the host lane too and are gated on real detached-buffer semantics
+(#1350 `blocked` / #1645 `ready`) rather than on `$262`.
+
+Samples:
+
+```
+test/built-ins/TypedArray/prototype/join/BigInt/detached-buffer.js
+test/built-ins/TypedArray/prototype/toString/BigInt/detached-buffer.js
+test/built-ins/TypedArrayConstructors/internals/GetOwnProperty/detached-buffer-key-is-symbol.js
+test/built-ins/DataView/prototype/getUint32/detached-buffer-after-toindex-byteoffset.js
+test/built-ins/ArrayBuffer/prototype/byteLength/detached-buffer.js
+```
+
+## Scope
+
+Implement `detachArrayBuffer` for the standalone `$262` harness object. In
+standalone there is no JS host to delegate to, so detaching has to be done
+against the WasmGC-native `ArrayBuffer` representation directly — set the
+buffer's backing store to the detached state and make every downstream
+`ArrayBuffer`/`TypedArray`/`DataView` accessor observe it.
+
+**The 126 host-lane-failing files are explicitly out of scope.** Landing this
+should move ~80 tests; do not chase the rest here — route them to #1645.
+
+Worth confirming while in this code: whether `$262.createRealm` and
+`$262.agent` are also missing in standalone. They did not surface in this
+harvest (the tests that need them likely refuse earlier for another reason), so
+they are **not** assumed missing — check rather than infer, and file separately
+if they are.
+
+## Acceptance criteria
+
+- [ ] `$262.detachArrayBuffer(buf)` works in `--target standalone`.
+- [ ] The 206-record `detachArrayBuffer is unsupported by this host` bucket
+      drops to ~0 in a fresh standalone harvest.
+- [ ] Standalone official pass count rises by roughly +80 (the cross-lane
+      recoverable set); report the actual delta.
+- [ ] No host-lane regression — this must not disturb the #1523 host path.
+- [ ] `createRealm` / `agent` standalone availability is checked and recorded.

--- a/plan/issues/4020-test262-js-sources-rejected-with-typescript-diagnostics.md
+++ b/plan/issues/4020-test262-js-sources-rejected-with-typescript-diagnostics.md
@@ -1,0 +1,99 @@
+---
+id: 4020
+title: "test262 .js sources rejected with TS8010/8017 'can only be used in TypeScript files' at L1:1 — 153 tests (112 Atomics, 29 module-code, 12 import)"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: compiler
+language_feature: compiler-internals
+goal: test-infrastructure
+related: [3721, 3427, 1061, 1710]
+origin: "2026-08-01 /harvest-errors of loopdive/js2wasm-baselines test262-current.jsonl (run 20260801-090441, gitHash c601e89b)"
+---
+
+# #3973 — test262 `.js` files rejected as if they were TypeScript
+
+## TL;DR
+
+**153 official failing tests** in the default lane are rejected at **L1:1**
+with a burst of TypeScript-only syntax diagnostics:
+
+```
+L1:1 Signature declarations can only be used in TypeScript files.;
+L1:1 Type annotations can only be used in TypeScript files.;
+L1:1 Type annotations can only be used in TypeScript files.; ...
+```
+
+These are plain ECMAScript `.js` test files. Real `tsc` reports zero errors on
+them. The compiler is putting a `.js` source down a TypeScript parse path, and
+every TS-only construct in whatever text sits at line 1 is reported as a syntax
+error, so the file never compiles.
+
+All positions are **L1:1**, which points at the *assembled harness prelude*
+rather than the test body — the same shape as #3427 (harness-assembly
+`Duplicate identifier 'isPrimitive'`, since fixed).
+
+## Evidence
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260801-090441` (gitHash `c601e89b`).
+
+| Category | Count | Example |
+| --- | --- | --- |
+| `built-ins/Atomics` | 112 | `test/built-ins/Atomics/notify/notify-zero.js` |
+| `language/module-code` | 29 | `test/language/module-code/eval-export-dflt-cls-name-meth.js` |
+| `language/import` | 12 | `test/language/import/import-attributes/json-extensibility-object.js` |
+| **total** | **153** | |
+
+The standalone lane shows the identical 112-record Atomics bucket plus a
+27-record `The 'declare' modifier can only be used in TypeScript files.`
+variant in `language/module-code`, so this is **lane-independent** — it is a
+front-end/harness problem, not a codegen one.
+
+The Atomics concentration is the strongest clue: those tests pull in the
+`agent`/`atomics` harness helpers (`$262.agent.*`). If one of those harness
+files carries TS-flavoured declarations (or is being concatenated ahead of the
+test with the wrong `scriptKind`/`allowJs`), every Atomics test inherits the
+failure regardless of its own content.
+
+## Relationship to #3721
+
+#3721 tracks the **same diagnostic signature** (TS8010/8017 false positives on
+a `.js` file where real `tsc` is clean) but for a different corpus — the
+`diff@9.0.0` npm-package dogfood bundle. This issue is the **test262** instance.
+
+They may share one root cause in the front end's `scriptKind`/`allowJs`
+handling (cf. #1061, "analyzeMultiSource / compileMultiSource drops allowJs and
+forces .js → .ts", already `done`). **Check #3721 first** — if a single fix
+covers both, land it once and close this as a duplicate rather than writing a
+second fix. Filed separately because the corpora, reproduction paths, and
+owners differ, and because 153 conformance tests should not be tracked inside a
+package-dogfood issue.
+
+## Repro sketch
+
+```bash
+# minimal: compile an Atomics test through the same harness-assembly path
+node scripts/... --file test/built-ins/Atomics/notify/notify-zero.js   # (exact runner entry TBD)
+```
+
+The first diagnostic's position (L1:1) and the assembled prelude text are the
+two things to capture — dump the concatenated source the compiler actually
+sees, rather than the test file on disk. That dump is the whole diagnosis.
+
+## Acceptance criteria
+
+- [ ] The assembled source for an Atomics test parses as JavaScript; no
+      TS-only diagnostics are emitted for a `.js` test262 input.
+- [ ] The 153-record `can only be used in TypeScript files` bucket drops to ~0
+      in a fresh host-lane harvest, and the 112 + 27 standalone records with it.
+- [ ] Whatever those tests then do (pass, or fail for a real Atomics reason) is
+      recorded — a genuine `SharedArrayBuffer`/Atomics gap is #674/#1354, not
+      this issue.
+- [ ] Net official pass count does not regress.

--- a/plan/issues/4021-annexb-eval-code-assert-is-not-defined.md
+++ b/plan/issues/4021-annexb-eval-code-assert-is-not-defined.md
@@ -1,0 +1,102 @@
+---
+id: 4021
+title: "annexB eval-code: `assert is not defined` inside eval'd code — 120 tests, harness bindings not visible to the eval scope"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: runtime
+language_feature: eval
+goal: runtime-eval
+related: [3083, 2928, 1387]
+origin: "2026-08-01 /harvest-errors of loopdive/js2wasm-baselines test262-current.jsonl (run 20260801-090441, gitHash c601e89b)"
+---
+
+# #3974 — `assert is not defined` inside annexB eval'd code
+
+## TL;DR
+
+**120 official failing tests**, all in `annexB/language`, fail with:
+
+```
+assert is not defined
+```
+
+Every one of them exercises **Annex B web-compat function hoisting**
+(`B.3.3.*`) through `eval` — `func-block-decl-eval-func-*`,
+`global-if-decl-else-decl-b-eval-global-*`, and friends. The test body calls
+`assert(...)` or `assert.throws(...)` from *inside* the eval'd string, and the
+harness `assert` binding is not reachable from that scope.
+
+So these are not Annex B semantics failures. They fail before they can test
+anything — the harness itself is invisible inside `eval`.
+
+## Evidence
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260801-090441` (gitHash `c601e89b`). All 120 records are in category
+`annexB/language`; no other category contributes.
+
+Samples:
+
+```
+test/annexB/language/eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js
+test/annexB/language/eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-try.js
+test/annexB/language/eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js
+test/annexB/language/eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js
+test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-func-skip-early-err-switch.js
+test/annexB/language/eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err.js
+```
+
+A closely-related 96-record bucket sits right next to it in the same harvest —
+`An initialized binding is not created prior to evaluation / Expected a
+ReferenceError to be thrown but no exception was thrown at all`, over
+`annexB/language/function-code` and `annexB/language/global-code`. Those are
+the **non-eval** siblings of the same Annex B hoisting family and are probably
+a genuine semantics gap. Worth checking whether they move when this lands, but
+they are **not** in scope here.
+
+## Why this is not #3083
+
+#3083 is `wont-fix` and covers a **different** 13-file cluster
+(`matchAll`/`RegExpStringIterator`) whose root cause is a specific unshimmed
+harness helper (`assert.compareIterator` / `matchValidator`). Its verdict —
+"shimming it would be a #2939 vacuity trap" — is about *that* helper, and does
+not generalise to `assert` itself being unresolvable inside `eval`.
+
+Do read #3083 before designing a fix, though: its vacuity argument is the right
+lens. A fix that makes `assert` resolve but does not actually execute the Annex
+B hoisting semantics under test would be exactly the trap #3083 warns about.
+**The bar is that the tests genuinely exercise B.3.3, not merely stop erroring.**
+
+## Root-cause hypothesis
+
+Direct `eval` should run in the caller's variable environment, so `assert`
+(a harness global) ought to resolve by scope chain. Two candidates:
+
+1. the harness binds `assert` in a way that is not on the global object (e.g. a
+   module-local or compiler-synthesised binding), so eval'd code compiled as a
+   separate unit cannot see it; or
+2. the eval implementation does not thread the caller's scope, so *any*
+   outer binding is invisible and `assert` is simply the first one hit.
+
+Hypothesis 2 predicts that non-harness outer bindings also fail inside eval —
+cheap to test and worth doing first, because it would make this a general
+`eval` scoping bug (goal `runtime-eval`, cf. #2928) rather than a harness gap.
+
+## Acceptance criteria
+
+- [ ] `assert` resolves inside directly-eval'd code in the host lane.
+- [ ] The 120-record `assert is not defined` bucket drops to ~0 in a fresh
+      host-lane harvest.
+- [ ] The tests are verified to actually exercise Annex B hoisting (not merely
+      stop throwing) — spot-check at least 3 against expected B.3.3 behaviour,
+      per the #3083 vacuity lesson.
+- [ ] Whichever hypothesis holds is recorded here; if it is (2), file the
+      general eval-scoping defect as its own issue.
+- [ ] Net official pass count does not regress.

--- a/plan/issues/4022-es5-standalone-90pct-census-and-execution-plan.md
+++ b/plan/issues/4022-es5-standalone-90pct-census-and-execution-plan.md
@@ -1,0 +1,146 @@
+---
+id: 4022
+title: "UMBRELLA: es5 standalone → 90% — census on fresh data (66.3%, not the published 59%), reachability ceiling 92.4%, and the prioritised lever list"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+task_type: umbrella
+area: codegen, conformance
+language_feature: n/a
+goal: es5
+related: [3892, 3626, 3628, 1906, 2992, 3251, 2928, 1387, 671, 3983]
+origin: "2026-08-01, goal directive: 90% test262 standalone pass rate for es5-tagged tests. Census recomputed from baselines-repo run 20260801-090441 because the committed editions artifact is frozen (#3892)."
+---
+
+# #3977 — es5 standalone to 90%: census, ceiling, and lever list
+
+## The number is 66.3%, not 59%
+
+The published artifact
+(`website/public/benchmarks/results/test262-standalone-editions.json`) reports
+ES5 standalone at **5,273 / 8,931 = 59 %**, and `plan/goals/es5.md` quotes the
+same figure. **Both are stale by a week** — this is #3892 (the editions artifact
+is frozen since 2026-07-25 because `baseline-summary-sync` has no test262
+submodule and `generate-editions` dies silently).
+
+Recomputed on 2026-08-01 by running the authoritative classifier against the
+fresh baseline (`loopdive/js2wasm-baselines` run `20260801-090441`, gitHash
+`c601e89b`):
+
+```bash
+node scripts/claim-issue.mjs --help >/dev/null   # (unrelated)
+git submodule update --init --depth 1 test262
+npx tsx scripts/generate-editions.ts \
+  --results .test262-cache/test262-standalone-current.jsonl \
+  --target standalone --output /tmp/editions-standalone-fresh.json
+```
+
+| | pass | fail | ce | total | pct |
+| --- | --- | --- | --- | --- | --- |
+| published (2026-07-25) | 5,273 | 3,400 | 258 | 8,931 | 59 % |
+| **fresh (2026-08-01)** | **5,924** | 2,797 | 210 | 8,931 | **66.3 %** |
+
+Fixing #3892 is a **precondition for steering this goal** — nobody should drive
+a conformance push against a frozen gauge.
+
+## Reachability: 90 % is attainable, but with almost no slack
+
+`eval` and `with` are out of reach for standalone today (`eval` → #2928, a
+bytecode-interpreter programme; `with` → #1387 / #671). Partitioning the 3,007
+ES5 standalone failures by whether the **test source** actually depends on them:
+
+| Bucket | Tests |
+| --- | --- |
+| fail, eval-dependent | 501 |
+| fail, with-dependent | 164 |
+| fail, both | 11 |
+| **fail, neither (reachable)** | **2,331** |
+
+(272 eval-using and 45 with-using ES5 tests already pass, so the dependency is
+not automatically fatal.)
+
+```
+90 % target      8,038 passes      (of 8,931)
+today            5,924
+gap              2,114 tests
+reachable pool   2,331 tests
+CEILING w/o eval+with = 8,255 / 8,931 = 92.4 %
+```
+
+**So 90 % is reachable — with 217 tests of headroom.** That is the load-bearing
+fact for planning: it requires closing **2,114 of 2,331 = 91 % of every
+reachable ES5 standalone failure**. There is no version of this that is a few
+targeted fixes. Any single lever below is worth ≤ 15 % of the gap.
+
+If `eval` (#2928) lands, the ceiling rises to ~98 % and the pressure comes off
+entirely. **Landing #2928 is plausibly cheaper than closing the last 500 of the
+long tail** — that trade should be evaluated explicitly before committing to the
+grind.
+
+## Lever list (reachable failures only, by directory)
+
+| Lever | Tests | Share | Notes |
+| --- | --- | --- | --- |
+| **Property descriptors** — `Object/defineProperty` 331, `defineProperties` 264, `create` 142, `getOwnPropertyDescriptor` 35, `prototype` 22, `isExtensible` 16, `preventExtensions` 15, `Array/length` 18, `types/object` 14 | **857** | **37 %** | the one dominant theme |
+| `built-ins/String/prototype` | 194 | 8 % | |
+| `built-ins/Function/prototype` | 117 | 5 % | overlaps #3983 |
+| annexB hoisting (`global-code` 111, `function-code` 96) | 207 | 9 % | B.3.3 semantics |
+| `language/statements/function` | 58 | 2 % | |
+| `built-ins/Array/prototype` | 53 | 2 % | |
+| `built-ins/RegExp/prototype` | 46 | 2 % | + 44 `__module_init` null-derefs |
+| everything else | ~799 | 34 % | genuine long tail |
+
+Top single error signatures in the reachable set are all small — the largest is
+132 (`Expected a TypeError to be thrown but no exception was thrown at all`, 6 %),
+and the top 30 signatures together are only ~34 % cumulative. **This is a long
+tail, not a few big rocks.**
+
+### Property descriptors is the only lever worth a dedicated programme
+
+37 % of the reachable gap sits behind one substrate. The current standalone
+`Object.defineProperties` deliberately **fails loud** ("unsupported descriptor
+shape in standalone mode (#1906)") whenever the receiver or the properties bag
+is not a native `$Object` — see the comment at
+`src/codegen/object-runtime-descriptors.ts:1281`, which is explicit that this is
+a chosen refusal pending the exotic-receiver own-key MOP substrate
+(**#2992 slice 2/5, #3251**). That refusal is correct — removing the gate turns
+a loud failure into a silent no-op — so the path forward is the MOP substrate,
+not deleting the guard.
+
+**#2992 / #3251 are therefore the critical path for this goal.**
+
+## Recommended sequencing
+
+1. **#3892** — unfreeze the editions artifact. Without it the goal has no gauge.
+2. **#2992 / #3251** — exotic-receiver own-key MOP; unlocks the 857-test
+   property-descriptor family (37 % of the gap).
+3. **#3983** — `this` receiver identity; 200-test family, lane-independent, so
+   it pays into the ES5 *host* target too.
+4. Decide explicitly: **#2928 (`eval`)** to lift the ceiling to ~98 %, versus
+   grinding the last ~500 of the long tail against a 92.4 % ceiling.
+5. Long tail: String.prototype, annexB B.3.3 hoisting, RegExp `__module_init`
+   null-derefs.
+
+## Honest status
+
+At 66.3 % today, with a 92.4 % ceiling and a 91 %-of-reachable closure
+requirement, **this is a multi-PR, multi-agent programme, not a single task.**
+It should be tracked as an umbrella with the levers above as children. Anyone
+picking it up should re-run the census first (the artifact is frozen, and these
+numbers age).
+
+### Reproducing the census
+
+The scripts used are in the session scratchpad, not committed; they are ~40
+lines each and re-derivable: classify every standalone JSONL record with
+`parseFrontmatter` + `classifyEdition` from `scripts/generate-editions.ts`, keep
+`classifyEdition() === 5`, apply the host-free pass rule
+(`status === "pass" && !host_import_leak_class`, #2914), then bucket the
+failures by `error_signature` and by directory. The eval/with partition greps
+the **test source** for `eval(` / `with (` plus the `eval-code/` and `with/` path
+segments.

--- a/plan/issues/4023-annexb-b33-hoisting-skipped-on-early-error.md
+++ b/plan/issues/4023-annexb-b33-hoisting-skipped-on-early-error.md
@@ -1,0 +1,181 @@
+---
+id: 4023
+title: "annexB B.3.3: web-compat function hoisting not skipped on Early Error — 96 ES5 standalone + host failures in annexB/language/{global,function}-code"
+status: done
+sprint: current
+created: 2026-08-01
+completed: 2026-08-01
+updated: 2026-08-01
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: function-declarations
+goal: es5
+related: [3977, 3974, 2200, 2552, 3419]
+origin: "2026-08-01 es5 goal, cluster #3 of #3977 (annexB hoisting, 207 reachable ES5 standalone failures)"
+---
+
+# #3980 — Annex B B.3.3 hoisting is not skipped when it would be an Early Error
+
+## The semantics gap
+
+A sloppy-mode `function F` nested in a block, an `if` clause, or a `switch`
+case/default normally gets a **var-scoped** binding in the enclosing function or
+global scope (B.3.3.1 / B.3.3.2). The spec creates it **only when replacing the
+`FunctionDeclaration` with `var F` would not produce an Early Error**. When an
+intervening **lexical** `F` exists — a `let`/`const`/`class` in an enclosing
+block or case clause, a lexical `for` / `for-in` / `for-of` head, or a
+_destructuring_ `catch` parameter (B.3.5) — the extension is skipped and **no
+binding for `F` is created at all**: reading `F` throws ReferenceError and
+`typeof F` is `"undefined"`.
+
+js2wasm's `localMap` is **flat per function**, so the _lexical_ `F` declared in
+an inner block / loop head / catch pattern allocated a function-level slot that
+any nested closure captured from anywhere in the function. All 96 generated
+`*-skip-early-err-*` tests assert exactly against that with
+`assert.throws(ReferenceError, function () { f; })` — a read from a **nested
+closure**, which is precisely where the pre-existing per-`FunctionContext`
+guard (`fctx.annexBCancelled`, #2200 Phase 1) could not see. That guard also
+recognised only a `function` whose _direct parent is a `Block`_ (missing the
+`if`-clause and `switch` case/default positions) and only a lexical shadow at
+the top of an enclosing `Block`/case clause (missing loop heads and catch
+patterns).
+
+Separately, the same guard **over**-fired: it treated a same-named **parameter**
+as a cancellation and walked up into the function's own body block, so
+`*-skip-param.js` and `*-skip-early-err.js` — where the enclosing scope already
+binds the name and Annex B merely declines to create an _additional_ binding —
+threw `ReferenceError: f is not defined` instead of reading the existing value.
+
+## Minimal repro
+
+```ts
+// standalone or host, both identical
+var __r = 0;
+function readF() {
+  try {
+    f;
+    return 0;
+  } catch (e) {
+    return 1;
+  }
+}
+__r += readF() * 1; // want 1 (ReferenceError)
+__r += (typeof f === "undefined" ? 1 : 0) * 2; // want 2
+{
+  let f = 123;
+  {
+    function f() {}
+  }
+}
+__r += readF() * 4; // want 4 (ReferenceError)
+__r += (typeof f === "undefined" ? 1 : 0) * 8; // want 8
+// want __r === 15;  before this fix: 10 — `readF` resolved `f` to the number 123
+```
+
+All eight declaration positions × six cancelling binders reproduce; see
+`tests/issue-3980.test.ts`.
+
+## Lane
+
+**Lane-independent.** The same 96 tests fail identically in the host lane
+(`test262-current.jsonl`) and the standalone lane
+(`test262-standalone-current.jsonl`), and the fix pays into both.
+
+## Fix
+
+New `src/codegen/annexb-cancel.ts` — the position-based, whole-`SourceFile`
+counterpart to the per-`FunctionContext` map:
+
+- `collectAnnexBCancelSites(sf)` collects every name whose web-compat var
+  binding is cancelled, recording `{scopeStart, scopeEnd, blockStart, blockEnd}`.
+  It recognises all three Annex B declaration positions (`Block`, `CaseClause` /
+  `DefaultClause`, `if` then/else clause) and all cancelling binders (block /
+  case-clause `let`/`const`/`class`, lexical loop heads, destructuring `catch`
+  parameters — a _simple_ `catch (f)` deliberately does **not** cancel, per
+  B.3.5). Memoized per `SourceFile`.
+- It suppresses a site when the enclosing scope already binds the name
+  (parameter, `var`, scope-top-level `let`/`const`/`class`/`function`) or when a
+  **sibling** Annex B declaration of the same name in the same scope _is_
+  eligible (`staging/sm/.../block-scoped-functions-annex-b-notapplicable.js`).
+- `annexBReadIsUnbound(sites, id)` answers for a read **anywhere** in the module,
+  including inside nested closures, skipping reads bound by an intervening scope.
+- `compileIdentifierCore` consults it right after the existing
+  `fctx.annexBCancelled` check. The ReferenceError emission moves to
+  `emitAnnexBUnboundReferenceError` in the leaf module `src/codegen/js-errors.ts`
+  (alongside `emitThrowReferenceError`), so both detectors share one emitter and
+  neither god-file grows.
+- `annexBHoistCancels` — the narrow per-`FunctionContext` detector — moves out of
+  `nested-declarations.ts` into `annexb-cancel.ts` next to its superset, gains a
+  `scopeBindsName` bail-out, and loses its wrong param-exclusion branch (which
+  used to _cancel_ on a same-named parameter, turning `*-skip-param` reads into
+  ReferenceErrors). `nested-declarations.ts` shrinks by 63 lines.
+
+**Blast radius, measured:** `collectAnnexBCancelSites` returns a non-empty list
+for **96 of 53,259** test262 files — exactly the 96 target tests, nothing else.
+Every other module short-circuits on the empty list and is byte-identical.
+
+## Measured before/after
+
+Corpus: `annexB/language/{global-code,function-code}` (312 files), run through
+`tests/test262-runner.ts` `runTest262File`.
+
+| lane       | before    | after         | delta   | regressions |
+| ---------- | --------- | ------------- | ------- | ----------- |
+| standalone | 104 / 312 | **199 / 312** | **+95** | 0           |
+| host       | 107 / 312 | **201 / 312** | **+94** | 0           |
+
+(Host "before" is the committed baseline `test262-current.jsonl`, run
+`20260801-090441`; the +94/+95 difference is the two `*-skip-param` /
+`*-skip-early-err` tests whose standalone baseline differs.)
+
+All 96 `*-skip-early-err-*` tests now pass, plus `block-decl-func-skip-param.js`
+and `block-decl-func-skip-early-err.js`.
+
+Wider regression sweep — 977 files across
+`language/statements/{function,switch,try,if}` + `language/block-scope`,
+standalone: **FIXED 2, BROKE 0.** (The sweep initially reported 8 "BROKE"
+`$DONOTEVALUATE` negative-parse tests; re-running those same 8 files against
+**unmodified `HEAD`** reproduces all 8 identically, so they are in-process-runner
+vs sharded-CI-baseline drift, not a regression from this change.)
+
+Suites: `tests/issue-3980.test.ts` (16 new), plus
+`issue-2200-annexb-block-fn-hoist`, `issue-2552-annexb-phase2`, `issue-3419`,
+`issue-2923-eval-const-broaden` and 17 scope/function/closure equivalence suites
+all green. (`tests/equivalence/arguments-nested-and-loops.test.ts:181` fails —
+verified pre-existing on unmodified `HEAD`.)
+
+Gates: `tsc --noEmit`, `biome lint`, `prettier --check`, `check:loc-budget`,
+`check:func-budget`, `check:oracle-ratchet`, `check:pushraw` all clean.
+
+## Left blocked (not in scope here)
+
+The remaining 113 standalone failures in the same two directories:
+
+- **24** — `js2wasm:runtime-eval` unsupported (eval-gated, #2928 / #3974).
+- **15** `Initialized binding created prior to evaluation` + **8**
+  `SameValue(«function …», «undefined»)` — the _positive_ B.3.3 lifecycle: the
+  outer var binding must exist as `undefined` before the block is evaluated and
+  take the function value only at the declaration's evaluation point. #2200
+  Phase 2 (`annexBOuterBindings`) implements this only for the narrow #2552
+  window; widening it is a separate slice.
+- **13** `outer declaration`/`inner declaration` + **13** `first
+declaration`/`second declaration` — B.3.3 interaction with an existing
+  same-named `var`/`function` (`existing-fn-update`, `function-redeclaration-*`).
+- **5** `*-skip-dft-param` — a same-named **default**-valued parameter reads as
+  `NaN`; a default-parameter issue rather than an Annex B one.
+- **3** `illegal cast` / **1** null-deref in `*-block-scoping`, **1**
+  `Cannot redeclare block-scoped variable 'a'` (TS front-end rejection).
+
+## Acceptance criteria
+
+- [x] All 96 `annexB/language/{global,function}-code/*-skip-early-err-*` tests pass.
+- [x] `*-skip-param` / `*-skip-early-err` (scope already binds the name) do not
+      regress into ReferenceError — both now pass.
+- [x] No regression in the 312-file annexB corpus, either lane.
+- [x] Blast radius verified to be exactly the target cluster across all of test262.
+- [x] `tests/issue-3980.test.ts` covers all eight declaration positions, the six
+      cancelling binders, and the non-cancelling counterparts.

--- a/plan/issues/4024-async-rejection-reason-wasm-exception-opaque.md
+++ b/plan/issues/4024-async-rejection-reason-wasm-exception-opaque.md
@@ -1,0 +1,115 @@
+---
+id: 4024
+title: "Async test failures surface the rejection reason as `[object WebAssembly.Exception]` — 1,380 host-lane fails carry no diagnosable error"
+status: ready
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+priority: high
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: runtime
+language_feature: async-generators
+goal: error-model
+related: [1295, 1294, 2962, 2906, 3178]
+origin: "2026-08-01 /harvest-errors of loopdive/js2wasm-baselines test262-current.jsonl (run 20260801-090441, gitHash c601e89b)"
+---
+
+# #3982 — async rejection reasons stringify to `[object WebAssembly.Exception]`
+
+## TL;DR
+
+**1,380 official failing tests** in the default (JS-host) lane report exactly
+one error string:
+
+```
+Test262:AsyncTestFailure:Test262Error: [object WebAssembly.Exception]
+```
+
+This is the **single largest uncategorized bucket in the host lane** — bigger
+than the next five `other` sub-buckets combined. Every record is `status:
+fail` (none are `compile_error`), so these tests compile and run; they fail
+with a rejection reason that has **lost its identity** on the way out.
+
+The practical damage is diagnostic, not just cosmetic: 1,380 failures share a
+single opaque signature, so they cannot be bucketed, triaged, or attributed to
+a root cause by any downstream tooling. They are a blind spot in every harvest.
+
+## Evidence
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260801-090441` (gitHash `c601e89b`), 43,098 official / 30,511 pass.
+
+Distribution over the 1,380 records:
+
+| Slice | Count |
+| --- | --- |
+| async-generator shapes (`async-gen*`, `async-generator`) | 847 |
+| class elements (`class/elements/**`) | 384 |
+| `for-await-of` | 268 |
+| `built-ins/Promise` | 87 |
+| `Array.fromAsync` | 24 |
+
+By category: `language/statements` 634, `language/expressions` 591,
+`built-ins/Promise` 87, `built-ins/AsyncFromSyncIteratorPrototype` 28,
+`built-ins/Array` 24, `built-ins/AsyncGeneratorPrototype` 10.
+
+Samples:
+
+```
+test/built-ins/Array/fromAsync/non-iterable-sync-mapped-callback-err.js
+test/language/statements/class/elements/after-same-line-static-async-gen-rs-private-setter-alt.js
+test/language/statements/class/elements/same-line-async-gen-private-method-getter-usage.js
+test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elision.js
+test/language/statements/class/elements/async-gen-private-method-static/yield-star-getiter-async-not-callable-object-throw.js
+```
+
+## Root-cause hypothesis (needs confirmation)
+
+`[object WebAssembly.Exception]` is the default `Object.prototype.toString`
+rendering of a raw `WebAssembly.Exception` instance. So somewhere on the async
+rejection path a thrown Wasm exception is passed to a **string coercion**
+instead of being unwrapped into its payload (the JS `Error` / `Test262Error`
+carried in the exception's tag fields).
+
+The synchronous path already handles this: #1295 re-throws
+`WebAssembly.Exception` out of `compiler.ts` internal catch blocks, and #1294
+reclassifies them in the test262 worker. The **async** path (promise rejection
+reason → `Test262:AsyncTestFailure:` reporting in `doneprintHandle.js`) appears
+to have no equivalent unwrap, so the reason reaches the harness still boxed.
+
+Two candidate sites, both worth checking before designing a fix:
+
+1. the rejection carrier — where a thrown value crosses the async drive layer
+   into a promise reject (`Promise_reject` / the CPS resume machinery of #2906),
+2. the harness reporting shim that formats `AsyncTestFailure`.
+
+If the payload is intact and only the *formatting* is lossy, this is a small
+fix with a very large legibility payoff. If the payload is genuinely dropped at
+the reject boundary, it is a real async-model bug and the tests are failing for
+a second, hidden reason.
+
+**Do not assume the tests would pass once the message is fixed.** The
+deliverable here is *diagnosability first*: unwrap the reason so the 1,380
+records split into real buckets. Some will then show genuine conformance bugs.
+Re-harvest after landing to get the real distribution — that follow-up split is
+expected to spawn child issues.
+
+## Acceptance criteria
+
+- [ ] An async test whose rejection reason is a Wasm-carried `Test262Error`
+      reports the underlying message, not `[object WebAssembly.Exception]`.
+- [ ] The `other:Test262:AsyncTestFailure:Test262Error: [object
+      WebAssembly.Exception]` bucket drops to ~0 in a fresh host-lane harvest.
+- [ ] Net official pass count does not regress.
+- [ ] A follow-up harvest records the new sub-bucket distribution so the
+      residual real failures can be filed as children of this issue.
+
+## Notes
+
+Scope is the **default (JS-host) lane**. The standalone lane has its own
+native-error-identity work (#2962, `done`) and a separate 20-record
+`other:[object WebAssembly.Exception]` bucket that is likely the same class —
+check whether one fix covers both before splitting.

--- a/plan/issues/4025-apply-drops-receiver-no-this-binding.md
+++ b/plan/issues/4025-apply-drops-receiver-no-this-binding.md
@@ -1,0 +1,157 @@
+---
+id: 4025
+title: "`.apply(thisArg)` DROPS the receiver — no `this`-binding thunk is emitted, so `f.apply(o) === o` is false (`.call()` emits one and is correct)"
+status: in-progress
+sprint: current
+created: 2026-08-01
+updated: 2026-08-01
+assignee: "ttraenkler/claude-harvest"
+priority: high
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: this-binding
+goal: core-semantics
+related: [3507, 3220, 3396, 2015]
+loc-budget-allow:
+  - src/codegen/expressions/calls.ts
+func-budget-allow:
+  - src/codegen/expressions/calls.ts::compileCallExpression
+origin: "2026-08-01, working the es5-standalone-90% goal: the 200-test language/function-code/10.4.3 family fails in BOTH lanes (116 standalone / 114 host); minimised to a 6-line identity control set."
+---
+
+# #3983 — `this` is not identity-equal to its receiver (method call, `.apply()`)
+
+## TL;DR
+
+`this` inside a method — and inside a function invoked via `Function.prototype.apply` —
+is **not `===` to the object that was passed as the receiver**. Plain object
+identity is fine everywhere else, and `.call()` is fine, which makes this a
+narrow carrier bug rather than a broken `===`.
+
+This is **core `this` semantics**, not an edge case: `o.m() === o` is false.
+
+## Minimal repro (measured on `b09a07b`, host lane, via `tests/equivalence/helpers.ts`)
+
+| # | Source (`main` returns the comparison) | JS | Wasm |
+| --- | --- | --- | --- |
+| 1 | `var o = {}; o === o` | true | **1 ✅** |
+| 2 | `function id(x){return x} id(o) === o` | true | **1 ✅** |
+| 3 | `var o = { m: function(){ return this } }; o.m() === o` | true | **0 ❌** |
+| 4 | `function f(){ return this } f.apply(o) === o` | true | **0 ❌** |
+| 5 | `function f(){ return this } f.call(o) === o` | true | **1 ✅** |
+| 6 | `function f(){ "use strict"; return this } f.apply(o) === o` | true | **0 ❌** |
+
+Controls 1 and 2 are the important ones: object identity survives a plain
+function carrier, so `===` and the object representation are both sound. Only
+the **receiver** carrier loses identity.
+
+The `.call()` vs `.apply()` asymmetry (5 vs 4, same function, same receiver,
+same strictness) is the sharpest lead — the two lowering paths must differ in
+how they materialise the receiver, and `.call()` is the one that is right.
+
+Reproduce with `tests/probe-*.test.ts` (gitignored) using
+`compileToWasm` from `tests/equivalence/helpers.ts`.
+
+## Impact
+
+`language/function-code/10.4.3-*` is a **200-test** family; it fails
+**116/200 in standalone and 114/200 in the host lane** — near-identical, which
+confirms this is lane-independent front-end/codegen behaviour, not a standalone
+gap. 41 of those carry the bare `'this' had incorrect value!` signature; the
+rest fail through `assert.sameValue`.
+
+The tests that **pass** today are exactly the ones asserting `this === undefined`
+(`f.apply()`, `f.call(undefined)`) — i.e. the cases that never have to preserve
+an object identity. That split is itself strong evidence for the diagnosis.
+
+True blast radius is almost certainly wider than 10.4.3: any code doing
+`this`-identity comparison, receiver caching, or `this`-keyed lookup is exposed,
+and a silent wrong answer here is far worse than a refusal. Worth measuring
+before/after rather than assuming 200.
+
+## Root cause — CONFIRMED by WAT diff (not an identity/boxing bug)
+
+The first framing of this issue guessed "identity loss through a carrier"
+(the #3507 / #3220 family). **That is wrong — do not go looking for a boxing
+round-trip.** Emitting the WAT for the two forms shows the receiver is not
+mis-boxed, it is **never installed at all**.
+
+`f.call(o)` — correct. Codegen emits a dedicated receiver-binding thunk:
+
+```wat
+(func $__named_this_call_f_0 (param externref) (result externref)
+  (local $__previous_this externref)
+  local.get 0
+  ref.is_null
+  (if (result externref)
+    (then call 3)                  ;; null receiver → plain call
+    (else
+      global.get 4                 ;; save current `this`
+      local.set 1
+      local.get 0
+      global.set 4                 ;; install receiver as `this`
+      (try (result externref)
+        (do call 3)
+        (catch_all                 ;; restore on unwind
+          local.get 1
+          global.set 4
+          rethrow 0)))))
+```
+
+`f.apply(o)` — broken. `$main` is simply:
+
+```wat
+(func $main (result i32)
+  call 3          ;; <-- calls f DIRECTLY; `this` global never set
+  global.get 3    ;; o
+  call 2          ;; ===
+  return)
+```
+
+So `.apply()` invokes the target with whatever the `this` global already holds
+(null/undefined), and `thisArg` is silently discarded. Everything downstream
+follows from that one omission.
+
+Probing for the binding (`/__named_this|global\.set 4/` in the emitted WAT):
+
+| Shape | receiver binding emitted? | runtime result |
+| --- | --- | --- |
+| `f.call(o)` | **yes** | correct |
+| `f.apply(o)` | no | wrong |
+| `f.apply(o, [1])` | no | wrong |
+| `f.apply(o, [])` | no | wrong |
+| `var o = {m: function(){return this}}; o.m()` | no | wrong |
+
+The `.apply()` arity makes no difference — with args, with an empty array, or
+with none, the binding is absent. So the fix is not about argv spreading.
+
+### Fix direction
+
+`src/codegen/expressions/calls.ts:6380` handles `call`/`apply` through a shared
+arm (`const isCall = propAccess.name.text === "call"`), and several downstream
+special cases are explicitly `isCall`-only — e.g. the comment at the #3390 arm
+notes "`.apply` is not intercepted (rare; the corpus uses `.call`)". The
+receiver-binding thunk appears to sit behind one of those `isCall` guards.
+Locate the emitter for `__named_this_call_*` and make the `.apply()` path reach
+it, threading `thisArg` identically.
+
+**The object-literal method row is listed separately on purpose** — it may be a
+distinct mechanism (class/struct methods generally pass `this` as a parameter
+rather than through the global, and plenty of `this`-in-method tests pass
+today). It reproduces as wrong at runtime, but do not assume one fix covers
+both; confirm the method-call path independently.
+
+## Acceptance criteria
+
+- [ ] All six repro rows above return the JS answer.
+- [ ] `o.m() === o` and `f.apply(o) === o` hold for plain objects, class
+      instances, and object literals with typed and untyped receivers.
+- [ ] The `language/function-code/10.4.3-*` family improves materially in
+      **both** lanes; report measured before/after per lane (do not assume 200).
+- [ ] A regression test lands under `tests/` covering the method-call and
+      `.apply()` identity cases (the `.call()` case as a guard against
+      regressing the currently-correct path).
+- [ ] Net official pass count does not regress in either lane.


### PR DESCRIPTION
Eight files sat **staged-but-uncommitted** in the shared `/workspace` checkout (~1,341 lines). Six carried ids that `main` has since given to entirely different issues, so they could never be committed as-is.

| was | now | content |
|---|---|---|
| 3973 | **4020** | test262 JS sources rejected with TypeScript diagnostics |
| 3974 | **4021** | AnnexB eval-code: `assert is not defined` |
| **3977** | **4022** | **ES5 standalone 90% census + execution plan** |
| 3980 | **4023** | AnnexB B.3.3 hoisting skipped on early error |
| 3982 | **4024** | async rejection reason opaque as a Wasm exception |
| 3983 | **4025** | `apply` drops receiver, no `this` binding |

`#3975` (new, no collision) and the `#3178` modification carry over unchanged. **Content is byte-identical to what was staged apart from the `id:` frontmatter** — nothing summarised, nothing dropped.

**Root cause:** `claim-issue.mjs` defaults `CLAIM_ASSIGN_REMOTE=origin`, and `origin` in this checkout is the **fork**, whose `main` diverges from upstream. Ids were reserved against a stale view while upstream had already handed them out. All six replacements were allocated with `CLAIM_ASSIGN_REMOTE=upstream`. The gate-base hazard itself is filed as **#4002** and is still live for anyone allocating from this checkout.

**Why this mattered beyond bookkeeping:** a dirty tree makes `sync-workspace-main.sh` refuse, so `/workspace` sat **123 commits behind** `main` — and the **test262 submodule under it stayed pinned at the March revision**. That is the same staleness that hid **401 corpus files** from every local analysis, turning goal-scope denominators into a floor rather than a number. One uncommitted mess, five months of silent drift. The submodule checkout has since been synced to `b363f29d`, and the denominator is now confirmed at exactly **8,545**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)