### PR TITLE
fix(#4039): resolve the gate diff base from upstream when origin is a fork

### DIFF
--- a/plan/issues/4039-gate-base-resolves-from-fork-not-upstream.md
+++ b/plan/issues/4039-gate-base-resolves-from-fork-not-upstream.md
@@ -1,0 +1,128 @@
+---
+id: 4039
+title: "Gates resolve their diff base from `origin/main` — which is the FORK's stale main, so they blame files the branch never touched"
+status: done
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+completed: 2026-08-02
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: infrastructure
+area: ci
+language_feature: n/a
+goal: dogfood
+related: [4002]
+---
+
+# Gates resolve their diff base from the fork's stale main
+
+Implements the fix for the defect filed as **#4002** (that issue records the
+diagnosis and the four field confirmations; this one carries the change).
+
+## Problem
+
+In an agent checkout `origin` is the **fork** (`ttraenkler/js2`), not upstream
+(`loopdive/js2`). The fork's `main` lags — **139 commits** when this was
+written. Several gates compute "what did this branch change?" by diffing against
+`origin/main`, so **every commit upstream landed since the fork last synced
+looks like part of your change-set**.
+
+Confirmed **four times across three independent agents** in one session:
+
+- `check:oracle-ratchet` reported `getTypeAtLocation +2, ctxChecker +3` in
+  `array-length-define.ts` and `unresolvable-assign.ts` — **two other agents'
+  files**, in a branch that never opened either.
+- `check:issue-ids:against-main` reported **6 phantom id collisions**.
+- `changed-root-tests` selected **14 root test files instead of 1**. Each is a
+  cold vitest process (~90–140 s of transform+collect before any assertion), so
+  a ~20 s gate cost **~40 minutes** — and it failed a commit three times on
+  another agent's test file with **31/31 tests passing**, the exit 1 coming from
+  a reporter RPC timeout under load.
+
+**The dangerous outcome is not the noise.** It is that an agent reads "gate
+blames file X", opens X — which it has never touched — and "fixes" someone
+else's code to silence a phantom. The gate then goes green, so nothing catches
+it.
+
+**It is invisible to CI.** In Actions `origin` *is* upstream, so all of these
+pass there. No CI check can ever detect this class; it only fires locally.
+
+## Fix
+
+One resolver, `resolveMainRef()` in `scripts/lib/change-scope.mjs`, used by all
+three sites:
+
+| site | gates it covers |
+| --- | --- |
+| `scripts/lib/change-scope.mjs` (`resolveChangeBase`) | loc-budget, oracle-ratchet, func-budget, pushraw, coercion-sites, trap-growth, done-status |
+| `scripts/check-issue-ids.mjs` (2 call sites) | `--against-main`, `--against-open-prs` |
+| `scripts/hooks/changed-root-tests.sh` | the pre-commit changed-root-test gate |
+
+Detection compares **normalised remote URLs** rather than merely preferring an
+`upstream` remote — plenty of checkouts have no `upstream`, and some have one
+pointing at the same repo as `origin`. Normalisation folds scp-style
+(`git@host:owner/repo`), `ssh://`, a trailing `.git` and trailing slashes.
+
+Env overrides (`LOC_GATE_BASE`, `GATE_BASE`, `CHANGED_ROOT_TESTS_BASE`) still
+win, so existing CI invocations and emergency overrides are untouched.
+
+Every gate now **prints the base it used** (`base: merge-base(upstream-remote(origin-is-a-fork))`),
+so a wrong base becomes visible instead of silent.
+
+## ⚠ CI cannot regression-test this
+
+In Actions `origin` **is** upstream, so the buggy and fixed resolvers agree
+there **by construction**. A test that runs only in CI would be vacuous. The
+verification below therefore builds a throwaway fork-shaped repo.
+
+### The first lab was vacuous — worth recording
+
+Branching the test repo from the **fork's** main produced *identical* output
+from both arms: `merge-base` is naturally robust in that shape. The bug only
+appears when the branch is cut from **upstream/main**, which is the actual
+workflow (agents are told to branch from `upstream/main`). Rebuilt that way it
+reproduces exactly:
+
+```
+origin/main..upstream/main = 3 commits of divergence
+
+BUGGY (origin/main base) — files this branch is blamed for:
+    mine.ts  u1.ts  u2.ts  u3.ts     <- three it never touched
+FIXED (upstream/main base):
+    mine.ts
+```
+
+### Resolver verified in three states
+
+| state | resolves to | |
+| --- | --- | --- |
+| `upstream` remote present, differs from `origin`, ref fetched | `upstream/main` | ✓ |
+| no `upstream` remote | `origin/main` | ✓ fallback |
+| `upstream` remote exists but its ref is not fetched | `origin/main` | ✓ safe fallback |
+
+The third was hit by accident and is the important one: removing a remote
+deletes its `refs/remotes/*`, and the `rev-parse --verify` guard makes the
+resolver degrade rather than error.
+
+### Against the real repo, with NO env override
+
+Both of these previously false-failed here:
+
+```
+[oracle-ratchet] OK — no net checker-usage growth across 0 changed src/codegen file(s)
+                 (getTypeAtLocation +0, ctx.checker +0;
+                  base: merge-base(upstream-remote(origin-is-a-fork)))
+LOC budget gate: OK — no unallowed growth in 0 changed src file(s)
+                 (base: merge-base(upstream-remote(origin-is-a-fork)), net +0 LOC)
+```
+
+## Note on the env-var names
+
+`LOC_GATE_BASE` reads as "the LOC gate's base" but silently controls the oracle
+ratchet and the function budget too. An agent staring at an oracle-ratchet
+failure has no reason to reach for a variable named after a different gate —
+one reason this kept recurring even for agents who knew #4002 existed. The
+names are kept for compatibility; the fix removes the need to know them.

--- a/scripts/check-issue-ids.mjs
+++ b/scripts/check-issue-ids.mjs
@@ -42,6 +42,7 @@ import { execSync } from "child_process";
 import { readFileSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 import { openPrIssueFiles, findOpenPrCollisions } from "./lib/open-pr-issue-files.mjs";
+import { resolveMainRef } from "./lib/change-scope.mjs";
 
 const args = process.argv.slice(2);
 const mode = args.includes("--against-main")
@@ -183,7 +184,7 @@ function introducedIssueFiles(base) {
 }
 
 function checkAgainstMain() {
-  const base = process.env.GATE_BASE || "origin/main";
+  const base = process.env.GATE_BASE || resolveMainRef(process.cwd()).ref;
   const r = introducedIssueFiles(base);
   if (r === null) {
     // Base ref unavailable (shallow clone without it). Skip cleanly rather than
@@ -240,7 +241,7 @@ function checkAgainstMain() {
 // the PR raced. FAIL-OPEN when the scan can't run (network gate must not be
 // able to freeze all of CI); the merge_group dup gate stays the hard backstop.
 function checkAgainstOpenPrs() {
-  const base = process.env.GATE_BASE || "origin/main";
+  const base = process.env.GATE_BASE || resolveMainRef(process.cwd()).ref;
   const r = introducedIssueFiles(base);
   if (r === null) {
     console.log(

--- a/scripts/hooks/changed-root-tests.sh
+++ b/scripts/hooks/changed-root-tests.sh
@@ -13,7 +13,24 @@ if [ -z "$repo_root" ]; then
 fi
 cd "$repo_root" || exit 1
 
-base_ref="${CHANGED_ROOT_TESTS_BASE:-origin/main}"
+# #4002: "main" is upstream/main when `origin` is a FORK, else origin/main.
+# In CI `origin` IS upstream, so this resolves to origin/main and behaviour is
+# unchanged. In a fork checkout, diffing against the fork's stale main makes
+# every commit upstream landed since the last sync look like this branch's own:
+# measured 14 root test files selected instead of 1, each a cold vitest process,
+# turning a ~20s gate into ~40min.
+resolve_main_ref() {
+  _origin="$(git remote get-url origin 2>/dev/null || true)"
+  _upstream="$(git remote get-url upstream 2>/dev/null || true)"
+  _norm() { printf '%s' "$1" | tr 'A-Z' 'a-z' | sed -e 's#^git@\([^:]*\):#https://\1/#' -e 's#^ssh://#https://#' -e 's#\.git$##' -e 's#/*$##'; }
+  if [ -n "$_upstream" ] && [ "$(_norm "$_upstream")" != "$(_norm "$_origin")" ] &&
+    git rev-parse --verify --quiet upstream/main >/dev/null 2>&1; then
+    printf 'upstream/main'
+  else
+    printf 'origin/main'
+  fi
+}
+base_ref="${CHANGED_ROOT_TESTS_BASE:-$(resolve_main_ref)}"
 base="$(git merge-base "$base_ref" HEAD 2>/dev/null || true)"
 if [ -z "$base" ]; then
   echo "changed-root-tests: cannot resolve a merge base with $base_ref." >&2

--- a/scripts/lib/change-scope.mjs
+++ b/scripts/lib/change-scope.mjs
@@ -57,6 +57,47 @@ function gitTry(repoRoot, argv) {
   }
 }
 
+/** Canonical form of a remote URL, for comparing two remotes for identity. */
+function normalizeRemoteUrl(url) {
+  if (!url) return undefined;
+  return url
+    .trim()
+    .toLowerCase()
+    .replace(/^git@([^:]+):/, "https://$1/") // scp-style -> https
+    .replace(/^ssh:\/\//, "https://")
+    .replace(/\.git$/, "")
+    .replace(/\/+$/, "");
+}
+
+/**
+ * The ref that means "main" for gate purposes (#4002).
+ *
+ * In CI `origin` IS the upstream repo, so this returns `origin/main` and every
+ * gate behaves exactly as before — the fix is a no-op there BY CONSTRUCTION,
+ * which is also why CI cannot regression-test it (see tests/issue-4026).
+ *
+ * In a fork-based checkout `origin` is the FORK, whose `main` lags upstream by
+ * however long since it was last synced (139 commits when this was written).
+ * Diffing against it makes every commit upstream landed in the meantime look
+ * like part of YOUR change-set, so gates blame files the branch never touched:
+ * the oracle ratchet reported `getTypeAtLocation +2` for another agent's file,
+ * and the changed-root-test hook selected 14 unrelated test files instead of 1.
+ * The dangerous outcome is not the noise — it is an agent "fixing" someone
+ * else's code to silence a phantom.
+ *
+ * Detection compares remote URLs rather than merely preferring an `upstream`
+ * remote, because plenty of checkouts have no `upstream` at all and some have
+ * one pointing at the same repo as `origin`.
+ */
+export function resolveMainRef(repoRoot) {
+  const origin = normalizeRemoteUrl(gitTry(repoRoot, ["remote", "get-url", "origin"]));
+  const upstream = normalizeRemoteUrl(gitTry(repoRoot, ["remote", "get-url", "upstream"]));
+  if (upstream && upstream !== origin && gitTry(repoRoot, ["rev-parse", "--verify", "--quiet", "upstream/main"])) {
+    return { ref: "upstream/main", how: "upstream-remote(origin-is-a-fork)" };
+  }
+  return { ref: "origin/main", how: "origin" };
+}
+
 /**
  * Resolve the change-set's diff base. Returns `{ base, how }` where `base`
  * is a committish (or undefined when not in a usable git worktree) and `how`
@@ -83,11 +124,13 @@ export function resolveChangeBase(repoRoot) {
       if (p1) return { base: p1, how: `ci-merge-parent(${ev})` };
     }
   }
-  if (!gitTry(repoRoot, ["rev-parse", "--verify", "--quiet", "origin/main"]))
-    return { base: undefined, how: "no-origin-main" };
-  const mb = gitTry(repoRoot, ["merge-base", "origin/main", "HEAD"]);
-  if (mb) return { base: mb, how: "merge-base" };
-  return { base: "origin/main", how: "origin-main-tree" };
+  // #4002: "main" is `upstream/main` when `origin` is a fork, else `origin/main`.
+  const { ref: mainRef, how: refHow } = resolveMainRef(repoRoot);
+  if (!gitTry(repoRoot, ["rev-parse", "--verify", "--quiet", mainRef]))
+    return { base: undefined, how: `no-${mainRef}` };
+  const mb = gitTry(repoRoot, ["merge-base", mainRef, "HEAD"]);
+  if (mb) return { base: mb, how: `merge-base(${refHow})` };
+  return { base: mainRef, how: `main-tree(${refHow})` };
 }
 
 /**


### PR DESCRIPTION
Implements the fix for **#4002**.

In an agent checkout `origin` is the **fork**, whose `main` lags upstream (**139 commits** when this was written). Gates that diff against `origin/main` therefore treat every commit upstream landed since the fork last synced as part of *your* change-set, and **blame files the branch never touched**.

Confirmed **four times across three agents** in one session:
- `check:oracle-ratchet` blamed `getTypeAtLocation +2, ctxChecker +3` in `array-length-define.ts` and `unresolvable-assign.ts` — **two other agents' files**
- `check:issue-ids:against-main` reported **6 phantom id collisions**
- `changed-root-tests` selected **14 root test files instead of 1** — each a cold vitest process, turning a ~20 s gate into **~40 min**, and failing a commit three times on another agent's test with **31/31 tests passing** (reporter RPC timeout under load)

**The danger is not the noise.** An agent reads "gate blames file X", opens a file it never touched, and "fixes" someone else's code to silence a phantom. The gate then goes green, so nothing catches it.

## Fix

One resolver — `resolveMainRef()` in `scripts/lib/change-scope.mjs` — used by all three sites:

| site | covers |
|---|---|
| `change-scope.mjs` (`resolveChangeBase`) | loc-budget, oracle-ratchet, func-budget, pushraw, coercion-sites, trap-growth, done-status |
| `check-issue-ids.mjs` (×2) | `--against-main`, `--against-open-prs` |
| `hooks/changed-root-tests.sh` | pre-commit test selection |

Detection compares **normalised remote URLs** (scp-style, `ssh://`, trailing `.git`/slashes) rather than merely preferring an `upstream` remote — many checkouts have none, and some have one pointing at the same repo as `origin`. **Env overrides still win**, so existing CI invocations and emergency overrides are untouched. Every gate now **prints the base it used**, so a wrong base is visible rather than silent.

## ⚠ CI cannot regression-test this

In Actions `origin` **is** upstream, so buggy and fixed resolvers agree there **by construction**. A CI-only test would be vacuous. Verification builds a throwaway fork-shaped repo.

**The first lab was vacuous, and that is worth recording.** Branching it from the *fork's* main made both arms agree — `merge-base` is naturally robust in that shape. The bug only appears when the branch is cut from **upstream/main**, which is the documented workflow. Rebuilt that way:

```
origin/main..upstream/main = 3 commits of divergence
BUGGY (origin/main base):   mine.ts  u1.ts  u2.ts  u3.ts   <- 3 never touched
FIXED (upstream/main base): mine.ts
```

**Resolver verified in three states:** upstream present → `upstream/main`; no upstream remote → `origin/main`; upstream remote whose ref is **not fetched** → `origin/main`. The third was hit by accident and is the important one — removing a remote deletes its refs, and the `rev-parse --verify` guard makes it degrade rather than error.

**Against the real repo with no env override**, both gates that previously false-failed now pass and report `0 changed src file(s)`.

Pre-ran the fail-fast downstream gates before pushing: loc-budget, oracle-ratchet, func-budget, speculative-rollback, issue-integrity, biome, prettier, `sh -n` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)