### PR TITLE
docs(issues): file the standalone↔host lane gap on ES5+untagged (#4040 + 3 children)

### DIFF
--- a/plan/issues/4040-standalone-host-lane-gap-es5-untagged.md
+++ b/plan/issues/4040-standalone-host-lane-gap-es5-untagged.md
@@ -1,0 +1,74 @@
+---
+id: 4040
+title: "UMBRELLA: close the standalone↔host lane gap on ES5+untagged — 902 files pass in host and fail in standalone (6.31 pp)"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: high
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: standalone-mode
+related: [1781, 4040]
+---
+
+# UMBRELLA: close the standalone↔host lane gap on ES5+untagged — 902 files pass in host and fail in standalone (6.31 pp)
+
+## The measurement
+
+Goal scope = test262 files carrying `es5id:` **or** none of `es5id`/`es6id`/`esid`.
+Both lanes, same corpus (`b363f29d`), baselines repo, 2026-08-02, **0 unopenable**:
+
+| | files | pass | |
+| --- | ---: | ---: | ---: |
+| host (gc) | 8,544 | 6,837 | **80.02 %** |
+| standalone | 8,544 | 6,298 | **73.71 %** |
+| | | | **gap 6.31 pp** |
+
+⚠ **The net 539 hides the real shape. The three-way split is what matters:**
+
+| | files | meaning |
+| --- | ---: | --- |
+| host-pass ∧ standalone-**fail** | **902** | ← THE GAP. Standalone-specific work. |
+| both-fail | 1,344 | shared front-end/semantics — **NOT lane-gap work** |
+| standalone-pass ∧ host-**fail** | **363** | standalone is *ahead* here |
+
+**The lanes are not nested.** Anyone who reasons about "the gap" as 539, or who
+assumes standalone ⊂ host, will mis-scope: the actionable population is **902**,
+and 363 files would *regress* if standalone were naively made to match host.
+
+## Sub-clusters, and who owns them
+
+Measured from the standalone-side error on the 902:
+
+| cluster | gap files | owner |
+| --- | ---: | --- |
+| descriptor — defineProperty 120 · create 82 · defineProperties 76 | 278 | in flight |
+| `invalid Wasm binary` 35 · null-deref `__module_init` 31 | 66 | in flight |
+| missing `TypeError` | 38 | in flight |
+| **prototype / `constructor` identity** | **~35** | **#4041** |
+| **dynamic RegExp pattern + `RegExp.prototype`** | **~35** | **#4042** |
+| **`__get_builtin` dynamic-shape refusal** | **11** | **#4043** |
+| dynamic-code (`eval`/`Function`) | ~63 | **OUT OF SCOPE** — see the goal restatement |
+| SharedArrayBuffer | 28 | excluded by stakeholder |
+
+Top areas in the 902: `String/prototype` 120 · `Object/defineProperty` 120 ·
+`Object/create` 82 · `Object/defineProperties` 76 · `Function/prototype` 42 ·
+`RegExp/prototype` 35.
+
+## Sizing discipline for anyone picking up a child issue
+
+- **File counts are NOT flip ceilings.** Measured conversions this sprint: 33 %,
+  63 %, 81 %. Report population / reachable / flips separately.
+- **A shared error string is a SIGNATURE, not a mechanism** — a 117-file "family"
+  decomposed into six unrelated defects; an `invalid Wasm binary` bucket into six.
+  Read test bodies before sizing.
+- **Re-fetch the baseline `--force`** before any measurement; the cache goes stale
+  within hours and reproduces its own checks exactly while answering yesterday's
+  question.
+- **Some files pass for the WRONG reason.** Enumerate the complete at-risk set and
+  do not sample — one instance this sprint was 1 file in 634.

--- a/plan/issues/4041-standalone-constructor-identity.md
+++ b/plan/issues/4041-standalone-constructor-identity.md
@@ -1,0 +1,55 @@
+---
+id: 4041
+title: "Prototype / `constructor` identity differs in standalone — obj.constructor is not the expected function, plus an env::Object_set_constructor host-import leak"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: standalone-mode
+related: [1781, 4040]
+---
+
+# Prototype / `constructor` identity differs in standalone — obj.constructor is not the expected function, plus an env::Object_set_constructor host-import leak
+
+## Problem
+
+**~35 goal-scope files that PASS in the host lane and FAIL in standalone** (part
+of the #4040 902-file gap). Two related signatures:
+
+```
+ 14  Test262Error: The value of obj.constructor is expected to equal the value of …
+ 11  Test262Error: The value of n_obj.constructor is expected to equal the value of …
+ 10  standalone target emitted host imports: env::Object_set_constructor, env::…
+```
+
+The third is the tell: standalone **refuses** a host import that the gc lane
+satisfies, so `constructor` is never wired up — and the first two are what that
+looks like from the test's side. Areas: `Object/prototype` 15,
+`Number/prototype` 15, plus `Object/getOwnPropertyDescriptor` 12.
+
+## Why it is a good candidate
+
+It is a **host-import leak with a named import** (`env::Object_set_constructor`),
+which is the most tractable shape in the standalone gap: the refusal names the
+exact capability, and the fix is a Wasm-native implementation of one well-defined
+operation rather than a semantics investigation.
+
+## ⚠ Before sizing
+
+- **Verify the two `constructor` signatures are ONE mechanism**, not two. `n_obj`
+  vs `obj` suggests different fixtures, but the assertion is identical — check the
+  bodies, not the message.
+- **`runTest262File` does NOT apply the #2961 host-import refusal**, so any lever
+  whose mechanism is "stop emitting a host import" reads as **+0 locally** — the
+  import is simply satisfied there. Measure by (a) censusing the import count
+  going 1 → 0, and (b) deriving the CI delta from the worker's rule, labelled as a
+  derivation. Do not call it measured.
+- Check whether the fix also flips files in the 1,344 both-fail set; if it does,
+  say so separately — that is host-lane value, not gap closure.

--- a/plan/issues/4042-standalone-dynamic-regexp-pattern.md
+++ b/plan/issues/4042-standalone-dynamic-regexp-pattern.md
@@ -1,0 +1,53 @@
+---
+id: 4042
+title: "Standalone refuses a dynamic RegExp pattern — 'Unsupported dynamic regular expression pattern' plus the RegExp.prototype residual"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: standalone-mode
+related: [1781, 4040]
+---
+
+# Standalone refuses a dynamic RegExp pattern — 'Unsupported dynamic regular expression pattern' plus the RegExp.prototype residual
+
+## Problem
+
+**~35 goal-scope host-pass ∧ standalone-fail files** (part of #4040). Signature:
+
+```
+ 10  TypeError: Unsupported dynamic regular expression pattern
+ 35  (area) built-ins/RegExp/prototype
+```
+
+The standalone RegExp backend handles statically-known patterns but refuses one
+built at run time.
+
+## ⚠ This is NOT the search-value refusal — that one is fixed
+
+**#4016 landed (PR #3996, merged `68d74d66d`, +35 goal-scope flips)** and covered
+`String.prototype.{search,match,split,…}` falling through to the spec's `ToString`
+path. Its proof that a runtime-built pattern *can* work is directly relevant here:
+a standalone probe of `new RegExp("A"+"B").exec("ssABB")` returns `["AB"]` at
+index 2 — **the backend has supported runtime-string patterns since #2161**.
+
+So "dynamic pattern" refusals may be over-broad in the same way #4016's gate was:
+the compiler treating *"not a statically-known backend RegExp"* as *"needs a JS
+host"*. **Check whether the refusal is still load-bearing before implementing
+anything** — it may be removable, as #4016's partly was.
+
+Related landed/known: #1474 (RegExp standalone, `done` but still cited 43× in
+goal scope — see the regression note in #4040), #1539, #682 dual RegExp backend.
+
+## ⚠ Sizing
+
+Two cuts already measured on the adjacent cluster, **stated separately and never
+summed**: the search-value refusal was ~98 all-official / 51 goal-scope by two
+independent methods. Expect the same divergence here; report both.

--- a/plan/issues/4043-standalone-get-builtin-dynamic-shape.md
+++ b/plan/issues/4043-standalone-get-builtin-dynamic-shape.md
@@ -1,0 +1,47 @@
+---
+id: 4043
+title: "'__get_builtin' (dynamic-shape object/property operation) refused in standalone — 11 gap files, 121 all-official"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: standalone-mode
+related: [1781, 4040]
+---
+
+# '__get_builtin' (dynamic-shape object/property operation) refused in standalone — 11 gap files, 121 all-official
+
+## Problem
+
+```
+L#:# Codegen error: '__get_builtin' (dynamic-shape object/property operation) is …
+```
+
+**11 goal-scope host-pass ∧ standalone-fail files** (part of #4040);
+**121 all-official** — so most of its mass is outside the ES5+untagged goal, and
+the goal-scope payoff is small. Filed for completeness and because the mechanism
+is narrow and named.
+
+## Why it may be cheaper than its count suggests
+
+It is a **single named codegen refusal**, i.e. Tier-1 conclusive: membership needs
+no body-reading, and the compiler itself states the missing capability. The same
+shape (`__get_builtin`, dynamic-shape property access) is adjacent to the
+receiver-representation work in **#4010** (two disjoint identity-keyed side tables,
+`vec-props.ts` #3537 and `vec-overlay.ts` #3251) — **check whether #4010 subsumes
+it before starting**, because a dynamic-shape property operation is exactly what
+that substrate is supposed to answer.
+
+## ⚠ Do not size off the all-official 121
+
+The goal is ES5+untagged. This sprint, ranking by all-official count nearly
+mis-dispatched a dev onto `#680` generators — **320 all-official, 1 in goal
+scope**. Measure in goal scope first; if the goal-scope share stays ~11, this is a
+low-priority tail item, not a lever.


### PR DESCRIPTION
Measured 2026-08-02, **both lanes on the same corpus** (`b363f29d`), 0 unopenable:

| | files | pass | |
|---|---:|---:|---:|
| host (gc) | 8,544 | 6,837 | **80.02%** |
| standalone | 8,544 | 6,298 | **73.71%** |
| | | | **gap 6.31 pp** |

## ⚠ The net 539 hides the shape

| | files | |
|---|---:|---|
| host-pass ∧ standalone-**fail** | **902** | ← the actual gap population |
| both-fail | 1,344 | shared defects, **not** lane-gap work |
| standalone-pass ∧ host-**fail** | **363** | standalone is *ahead* here |

**The lanes are not nested.** Scoping off 539, or assuming standalone ⊂ host, mis-sizes the work *and* misses that 363 files would **regress** if standalone were naively made to match host.

## Ownership of the 902

~380 already in flight (descriptor 278, crashes 66, missing-throw 38); ~63 dynamic-code, **out of scope** per the goal restatement; 28 SharedArrayBuffer, excluded. The three unowned clusters get children:

- **#4041** prototype/`constructor` identity (~35) — includes a **named** `env::Object_set_constructor` host-import leak, the most tractable shape in the gap
- **#4042** dynamic RegExp pattern (~35) — ⚠ **#4016 just proved runtime-built patterns work** (`new RegExp("A"+"B").exec(...)` → `["AB"]`), so check whether the refusal is still load-bearing *before* implementing
- **#4043** `__get_builtin` dynamic-shape (11 goal / 121 all-official) — low goal payoff; check whether **#4010** subsumes it first

## Sizing discipline carried into each child

File counts are **not** flip ceilings (measured conversions this sprint: 33% / 63% / 81%) · a shared error string is a **signature, not a mechanism** · re-fetch the baseline `--force` before measuring · enumerate the complete at-risk set rather than sampling, because some files pass for the **wrong reason** (one instance was 1 in 634).

#4043 also records why all-official ranking is unsafe here: **#680 is 320 all-official and 1 in goal scope**, and nearly took a dev this sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)