### PR TITLE
docs(issues): correct #4059's refuted attribution; file #4075 and #4078

### DIFF
--- a/plan/issues/4045-claim-issue-reservation-ledger-split-brain.md
+++ b/plan/issues/4045-claim-issue-reservation-ledger-split-brain.md
@@ -61,6 +61,7 @@ Three fresh collisions in one session, all from this mechanism:
 | 4047 | this lane + `H-descriptor` | ceded to H-descriptor |
 | 4046 | this lane + PR #4002 | this lane renumbered to 4073 |
 | 4076 | this lane + `H-errmodel` | ceded to H-errmodel; took 4078 |
+| 4072 | `H-crashes` + PR #4002 | H-crashes renumbered to 4077 |
 
 Two things this pinned down that the original report did not:
 
@@ -81,6 +82,46 @@ command, same id, opposite answers — and both exit 0. The identical thing
 happened with #4010, where one lane got exit 3 (claimed) and another got exit 0
 (unassigned), stranding the issue on a claim that did not exist from where the
 next dispatcher was standing.
+
+### ⚠ It manufactures plausible WRONG diagnoses — do not file what it suggests
+
+The #4072 collision is worth recording in full, because the split-brain did not
+merely hide a claim — it **produced a confident, wrong root cause** that was
+about to be filed as its own defect.
+
+The agent that hit it reported: *"#4002 reached 4072 by renumbering away from an
+earlier collision and **never recorded it on the assignments ref** —
+`claim-issue.mjs --check 4072` still answers UNASSIGNED. The renumber path is
+what re-opens the hole #2531/#3880 exist to close."*
+
+That is a coherent, specific, actionable-sounding defect in the **renumber
+path**. It is also false. Checked against both books at the same moment:
+
+```
+origin (fork) : #4072 is UNASSIGNED                                   (exit 0)
+upstream      : #4072 is CLAIMED by ttraenkler/claude since 03:25:45Z (exit 3)
+```
+
+The renumber **did** record the reservation — on the upstream ledger. The
+`--check` read the fork ledger, because `CLAIM_ASSIGN_REMOTE` defaults to
+`origin` and `origin` is the fork. There is nothing wrong with the renumber path.
+
+**So the failure mode of this bug is not just "collisions". It is "an agent
+reads one book, gets a self-consistent story, and files a defect against
+innocent code."** That is the same shape as the gate-base defect in #4002/#4039,
+where agents "fixed" other agents' files to silence phantom blame. Cost here was
+caught only because a second lane checked both refs.
+
+### What is genuinely broken, separately from the ledger
+
+`--allocate` reported **`pr_scan=ok`** while handing out an id that an open PR
+had already held for **40 minutes**. The open-PR scan is a **point-in-time
+check, not a lock**, and it is the second of the two mechanisms that were
+supposed to make allocation safe. Both failed together here.
+
+**Working practice until this lands** (adopted from the lane that hit #4072):
+after `--allocate`, independently re-scan every open PR's added issue files
+rather than trusting `pr_scan=ok`.
 
 **Until this is fixed, state the ref alongside any claim assertion**, and treat
 "the ledger says X" as unusable evidence on its own. Today the **CI open-PR

--- a/plan/issues/4045-claim-issue-reservation-ledger-split-brain.md
+++ b/plan/issues/4045-claim-issue-reservation-ledger-split-brain.md
@@ -22,7 +22,8 @@ goal: dogfood
 
 Root cause of the 2026-07-28 id-collision chain, found by the #3715 lane and VERIFIED independently.
 
-**The bug**, `scripts/claim-issue.mjs:74`:
+**The bug**, `scripts/claim-issue.mjs:149` (the report said `:74`; the constant has
+since moved — corrected 2026-08-02):
 ```js
 const REMOTE = process.env.CLAIM_ASSIGN_REMOTE || "origin";
 ```
@@ -45,5 +46,47 @@ But in agent worktrees `origin` IS the fork (`ttraenkler/js2`), while **CI's col
 **Proposed fix:** default `CLAIM_ASSIGN_REMOTE` to the same remote the gate's tie-break reads (i.e. resolve `upstream` when present, exactly like the main-ref logic already does), and/or write reservations to BOTH ledgers so fork-origin and upstream-origin lanes converge. Add a positive control proving a reservation made in a fork-origin worktree is visible to an upstream-reading gate — without that control the fix is unverifiable and would look identical to the current broken state.
 
 **Workaround meanwhile:** `CLAIM_ASSIGN_REMOTE=upstream node scripts/claim-issue.mjs --allocate`, mirroring to the fork ledger.
+
+---
+
+## Update 2026-08-02 — still live, three more collisions in a single session
+
+Re-measured while filing this issue. Ledger tips: fork `e698bf07b`, upstream
+`a949bee25` — **still two disjoint books**, ~5 days after the original report.
+
+Three fresh collisions in one session, all from this mechanism:
+
+| id | claimants | outcome |
+| --- | --- | --- |
+| 4047 | this lane + `H-descriptor` | ceded to H-descriptor |
+| 4046 | this lane + PR #4002 | this lane renumbered to 4073 |
+| 4076 | this lane + `H-errmodel` | ceded to H-errmodel; took 4078 |
+
+Two things this pinned down that the original report did not:
+
+**1. The workaround only works if EVERY lane uses it.** `H-errmodel` had been
+passing `CLAIM_ASSIGN_REMOTE=upstream` on *every* call — allocate, claim,
+release **and** check — which is the only reason its own reads and writes stayed
+coherent. Lanes that use the default (`origin`) still write to the fork book, so
+a partially-adopted workaround produces exactly the same collisions while
+*looking* like it is working for whoever adopted it. It is a per-lane habit, not
+a repo-level guarantee.
+
+**2. A `--check` result is meaningless without naming the ref it came from.**
+Measured directly: `claim-issue.mjs 4076 --check` reported
+**`#4076 is UNASSIGNED` (exit 0)** from a fork-reading worktree at the same
+moment the upstream book held
+`#4076 CLAIMED by ttraenkler/H-errmodel since 2026-08-02T04:26:14Z`. Same
+command, same id, opposite answers — and both exit 0. The identical thing
+happened with #4010, where one lane got exit 3 (claimed) and another got exit 0
+(unassigned), stranding the issue on a claim that did not exist from where the
+next dispatcher was standing.
+
+**Until this is fixed, state the ref alongside any claim assertion**, and treat
+"the ledger says X" as unusable evidence on its own. Today the **CI open-PR
+collision gate (#3598) is the only thing that actually arbitrates** — it reads
+open-PR *file contents* rather than the ledger, which is why it caught all three
+collisions above. Note that even it is a point-in-time check, not a lock: it
+cannot see a PR opened after its scan (that is how 4046 slipped through).
 
 Same root cause family as the `origin`-is-the-fork verification trap: CLAUDE.md documents `origin` as upstream, which is false in this checkout, and tooling written against that assumption silently reads or writes the wrong book.

--- a/plan/issues/4059-standalone-bindfn-invalid-wasm-cluster.md
+++ b/plan/issues/4059-standalone-bindfn-invalid-wasm-cluster.md
@@ -1,7 +1,7 @@
 ---
 id: 4059
-title: "`__bindfn` invalid-Wasm cluster — 28 corpus-wide / 25 host-pass, one validation message, root-caused to `compileFunctionBind`'s standalone arm"
-status: ready
+title: "`__bindfn` invalid-Wasm cluster — ATTRIBUTION REFUTED: not `Function.prototype.bind`; real cause is an operand-stack miscount in `fixupExternConvertAny` (fixed by #4072)"
+status: wont-fix
 sprint: current
 created: 2026-08-02
 updated: 2026-08-02
@@ -13,8 +13,54 @@ task_type: bug
 area: standalone
 language_feature: n/a
 goal: standalone-mode
+related: [4072]
 ---
-# `__bindfn` invalid-Wasm cluster — 28 corpus-wide / 25 host-pass, one validation message, root-caused to `compileFunctionBind`'s standalone arm
+# `__bindfn` invalid-Wasm cluster — attribution refuted, superseded by #4072
+
+## ⚠ CORRECTION 2026-08-02 — do NOT work this issue as originally written
+
+**The root cause below is WRONG, and acting on it would send you to modify code
+that is not at fault.** Refuted the same day it was filed, by the `H-crashes`
+agent, with a reduced repro.
+
+**What the original said:** the cluster is root-caused to the standalone arm of
+`compileFunctionBind`, `src/codegen/expressions/calls.ts:2277-2300`, because the
+failing WAT is full of `$__bindfn_tgt_*` locals.
+
+**Why that is wrong:** those locals are the first ~200 characters of
+`__module_init`'s **locals list**, and they come from `propertyHelper.js`'s own
+prologue (`Function.prototype.call.bind(Array.prototype.join)`), which runs
+~150 KB of bytecode *before* the failing instruction. **`bind` is incidental to
+the crash.** The reduced repro is **8 lines with no `bind` in it at all**.
+
+This also explains the observation already recorded further down this page — that
+a synthetic `call.bind` probe validates fine. That was the refutation sitting in
+plain sight: the probe did not reproduce the defect because `bind` was never the
+mechanism.
+
+**The real cause** — `fixupExternConvertAny` in `src/codegen/fixups.ts`. It
+rewrites `ref.null.extern` → `ref.null $T` for GC-ref params, and located "which
+argument produced this instruction" by walking **backward assuming one
+instruction == one argument**, with a hand-maintained list of exceptions
+(`local.tee`, `struct.new`, `array.new_fixed`, `call`). **`extern.convert_any`
+was missing from that list** — and it is emitted on essentially every boxed
+argument — so it burned a param index and the `null` at argument 2 received
+argument 1's `(ref null $AnyString)` type.
+
+Same shape as #3989: two halves that must agree about a slot type, living apart.
+Fixed by modelling the operand stack properly (exact pops/pushes plus a forward
+producer-index pass) rather than adding a fifth entry to the exception list.
+
+**Resolution: superseded by #4072 (PR #4007).** Measured there: population 53
+goal-scope `invalid Wasm binary`, mechanism 28, reachable 28, **flips 24**,
+kill-switch control 28/28 fail with the fix reverted, and 0 attributable
+regressions in a 500-file seeded sample.
+
+**Anyone holding a bind-lowering task for these files should drop it.**
+
+---
+
+## Original report (retained for the record — attribution refuted above)
 
 > Filed 2026-08-02 from a TaskList entry that had been carrying the full
 > analysis but no issue file. The body below is the original measurement

--- a/plan/issues/4063-check-godfiles-red-on-main-gates-nothing.md
+++ b/plan/issues/4063-check-godfiles-red-on-main-gates-nothing.md
@@ -31,6 +31,16 @@ VERIFIED NON-GATING: `profile-godfiles` appears nowhere under `.github/`. Both
 `check:godfiles` and `profile:godfiles` exist in package.json but no workflow invokes
 either. It therefore blocks nothing today.
 
+CORROBORATED 2026-08-02, independently and from the opposite direction: the
+`H-crashes` lane observed `quality` **passing** on PR #4007 while `check:godfiles`
+was red on the same tree, and separately confirmed the redness is not
+branch-local by kill-switch (reverting its own change entirely, the gate reports
+the identical two regressions). Re-verified here: `grep -rl godfiles .github/`
+returns nothing. So the "it gates nothing" half of this issue is now confirmed
+by three independent routes — source grep, a passing `quality` on a red tree,
+and a kill-switch — while the "it is red on pristine main" half is confirmed by
+two.
+
 THE ACTUAL DECISION (do not just re-baseline it): a check that is permanently red and
 wired to nothing is worse than no check — it trains agents to ignore a red signal, and
 it cannot catch the god-file growth it was built to catch. Pick one:

--- a/plan/issues/4075-standalone-refuse-loud-channel-is-lossy.md
+++ b/plan/issues/4075-standalone-refuse-loud-channel-is-lossy.md
@@ -1,0 +1,88 @@
+---
+id: 4075
+title: "The standalone refuse-loud channel is LOSSY — a non-`sticky` reportError is discarded by rollbackSpeculative and silently becomes a wrong answer"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: standalone-mode
+related: [3725, 4044]
+---
+
+# The standalone refuse-loud channel is lossy
+
+Found 2026-08-02 by the `H-errmodel` agent while implementing #4044 (PR #4005).
+Traced, not inferred. Reported to the lead rather than folded into that PR,
+because the blast radius is the whole refusal channel, not one call site.
+
+## Mechanism
+
+A codegen site calls `reportError` in order to **refuse** rather than answer
+wrong. If that call omits `sticky` (#3725), `compileExpressionBody`'s
+null-result unwind (`rollbackSpeculative`) **discards the diagnostic** and
+substitutes `pushDefaultValue`.
+
+Measured trace:
+
+```
+errors.len 1 → rollback DROPPING 1 diag → generateModule returns errors.len 0
+             → success:true, imports:[]
+```
+
+The emitted body was:
+
+```wat
+global.get $undefined
+extern.convert_any
+drop
+```
+
+— a placeholder standing in for a refusal **that had already been erased**.
+
+## Why this is worse than one bad lowering
+
+The entire point of the standalone refuse-loud channel is *"refuse rather than
+answer wrong."* Every site that omits `sticky` **silently inverts that
+contract**. And the inversion is invisible to every gate we have:
+
+- no host-import leak is recorded (`imports:[]`)
+- no compile error is reported (`success:true`)
+- the test does not crash — it returns a plausible wrong value
+
+An erased refusal leaves **no evidence anywhere**. This is the same failure
+family as a gate whose output is never read: the observable outcome is identical
+to "everything is fine."
+
+It also means any conformance measurement taken over an affected shape has been
+measuring a *placeholder*, not a refusal — so the failure was never attributable
+to the feature that actually did not work.
+
+## Work
+
+1. Sweep every `reportError` on the standalone codegen path; determine which are
+   non-`sticky` and reachable from a speculative-rollback context.
+2. For each, decide: make it `sticky`, or prove the rollback is legitimate for
+   that site.
+3. Add a gate so a **new** non-sticky refusal cannot be introduced silently.
+
+## ⚠ Required control — a zero result here is not trustworthy without it
+
+The sweep **must** carry a **positive control** that proves the detector fires
+on a known-lossy site (the one in this report, from #4044). Without it, "no
+lossy sites found" is indistinguishable from "the detector does not work" —
+which is precisely the trap this codebase keeps falling into, and precisely the
+trap this defect *is*.
+
+Report the count of sites audited (the denominator), not just the count found.
+
+## Not yet done
+
+`H-errmodel` explicitly did **not** audit the other refusal sites. Nothing here
+has been sized. Do not quote a population until the sweep runs.

--- a/plan/issues/4078-single-process-sweep-poisons-later-results.md
+++ b/plan/issues/4078-single-process-sweep-poisons-later-results.md
@@ -1,0 +1,75 @@
+---
+id: 4078
+title: "A long SINGLE-PROCESS test262 sweep poisons its own later results — 19 apparent regressions, 4 real; state leaks across files in the shared process"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: infrastructure
+area: testing
+language_feature: n/a
+goal: dogfood
+related: [4052]
+---
+
+# A long single-process test262 sweep over-counts failures
+
+Measured 2026-08-02 by the `H-crashes` agent while running the regression
+control for PR #4007 (#4072).
+
+## The observation
+
+A seeded 500-file regression sample over baseline-`pass` goal-scope files:
+
+| stage | result |
+| --- | --- |
+| sweep (one process, serial) | 481 pass / 11 fail / 8 error |
+| the 19 non-passes, **re-run solo** | **15 passed** |
+| the 4 survivors, with the fix reverted | fail identically ⇒ pre-existing |
+
+**0 attributable regressions, against an apparent 19.** ~79 % of the apparent
+regressions were artifacts of the sweep itself.
+
+## ⚠ This is NOT the known contention flake
+
+The sweep was **fully serial, single-process** — no 4-way parallelism. Anyone
+who has internalised *"parallel runs are flaky, serial runs are trustworthy"*
+will walk straight into this.
+
+The mechanism is **state accumulating across files in the shared process**.
+Fingerprint: 8 of the 15 false failures shared one compiler-internal signature,
+
+```
+Invalid value used as weak map key
+```
+
+which appears **only deep into a long run**.
+
+Adjacent to #4052 (`src/runtime.ts` internals are destructible by test262's own
+harness — `verifyProperty` deletes realm intrinsics). Confirm whether that is
+the same root cause or a second one; **do not assume**.
+
+## Why it matters beyond one PR
+
+Every agent that sizes a bucket, or declares a regression, from one long sweep
+is working from an inflated number — inflated in the direction that looks like
+*their own change* broke things. It cuts both ways: a long sweep can equally
+**mask** a real failure behind an earlier file's corruption.
+
+## Work
+
+1. Root-cause the cross-file state leak (start at the `weak map key` signature).
+2. Either isolate per-file state, or make the runner recycle the process on a
+   bounded file count.
+3. Until fixed, the runner should **warn** when a single-process sweep exceeds
+   the threshold where poisoning was observed.
+
+## Interim rule (already in force)
+
+Re-run **every** apparent non-pass **solo** before believing it, then prove
+attribution by reverting the change and confirming the survivors fail
+identically. That single step turned 19 into 4.

--- a/plan/issues/4080-malformed-wasm-gate-exists-corpus-does-not-cover-it.md
+++ b/plan/issues/4080-malformed-wasm-gate-exists-corpus-does-not-cover-it.md
@@ -1,0 +1,110 @@
+---
+id: 4080
+title: "The `malformed_wasm` invariant already catches the compiler-emits-invalid-Wasm class — the gap is diff-test CORPUS COVERAGE, not a missing gate"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: infrastructure
+area: testing
+language_feature: n/a
+goal: dogfood
+related: [2143, 3989, 4077, 4079]
+---
+
+# The gate already exists; the corpus does not reach it
+
+Reframed 2026-08-02 by the `H-crashes` agent, after it **disproved its own first
+instrument** rather than reporting its number. Recorded here because the
+reframing is the deliverable and the negative result is load-bearing.
+
+## The pattern that prompted it — three independent instances, one shape
+
+| issue | the two halves that disagreed |
+| --- | --- |
+| #3989 | slot type known in one place, not the other |
+| #4077 | `fixupExternConvertAny`'s backward walk vs a hand-list of exceptions missing `extern.convert_any` |
+| #4079 | eight hand-rolled inc/dec arms each handling `externref` + `ref`/`ref_null` and each forgetting `i32` |
+| #4081 | a third `__call_fn_method_N` dispatch arm inlining the return sequence with no i32 boxing, while two sibling arms box correctly |
+
+The first framing was *"a hand-maintained type/op case list that one consumer
+keeps in sync and another does not."* The fourth instance **sharpened it**, and
+the sharper version is the one to design against:
+
+> **A duplicated emission sequence, where one copy carries the type handling and
+> another does not.**
+
+#4079 and #4081 are both that. And #4081 adds the detail that makes it
+undetectable by construction: the invariant is written down as a **comment** in
+one copy (`"Stack at this point: [result : externref]"`) and **silently assumed**
+in the other — so nothing can keep the two copies honest.
+
+#4079 is the sharpest cautionary case: a correct implementation
+(`compileStaticPropIncDec`, #2019) was **already in the same file**, merely
+unwired, while eight copies each independently missed `i32`. Generalising it to
+`compileGlobalIncDec` was **net −25 LOC** — the duplication was pure cost.
+
+## ⚠ The source-shape lint was REFUTED — do not rebuild it
+
+The obvious response is a lint for the shape. It was built and it **failed its
+own positive control**:
+
+> A screen for sites testing `kind === "externref"` that also test
+> `ref`/`ref_null` but never `i32` within ±40 lines reported **507 externref
+> sites, 159 matching**. Run against the **pre-fix** `unary-updates.ts` and the
+> **post-fix** version:
+>
+> | source | screen total | hits in `unary-updates.ts` |
+> | --- | ---: | ---: |
+> | pre-fix (known bug present) | 159 | 6 |
+> | post-fix (bug gone) | 159 | 6 |
+>
+> **Identical.** The screen cannot distinguish broken from fixed.
+
+**So 159 is not a population estimate of anything and must never be quoted as
+one.** The reason is instructive: the 6 hits are the `externref`/`ref` arms,
+which still exist after the fix and are *correct*; the defect lived in the
+**fallback after them**, which the fix replaced with a helper call the window
+cannot see. A source-shape lint is the wrong instrument for this class.
+
+## The gate already exists
+
+`scripts/diff-test-gate.ts` / `scripts/diff-test.ts` already carry a
+**`malformed_wasm`** verdict (#2143):
+
+> *"compiler reported success but `WebAssembly.validate` rejected the binary"* —
+> and `malformed_wasm` **fails the gate loudly**.
+
+Verified present in both files. That invariant catches **all three** instances
+**by construction**, because all three emitted invalid Wasm while the compiler
+reported success. No new gate is needed.
+
+**The gap is corpus coverage.** The triggering shapes are simply not in the
+diff-test corpus:
+
+- a `null` argument positioned before a closure argument (#4077)
+- `++`/`--` on a boolean-initialised (i32-slot) global (#4079)
+- a string `+=` into an externref slot (#3989)
+
+## Work — sizing FIRST, shape second
+
+1. **Measure what the `malformed_wasm` corpus actually covers.** This has
+   **NOT** been done. No population figure exists for this issue and none should
+   be invented; the one number produced so far was disproved above.
+2. Only then propose how to extend it — driven by the measured gap, not by the
+   three anecdotes.
+3. Any detector added here **must ship a positive control** proving it fires on
+   a known instance (e.g. pre-fix `unary-updates.ts`). The refuted screen above
+   is exactly why: it looked plausible, produced a confident number, and could
+   not tell broken from fixed.
+
+## Why this is worth doing rather than fixing case lists one at a time
+
+Three instances in one cluster in one session, each found only because a
+conformance test happened to exercise the shape. The invariant that would have
+caught all three at authoring time already runs — it just never sees these
+inputs.

--- a/plan/issues/4081-call-fn-method-early-return-arm-skips-i32-boxing.md
+++ b/plan/issues/4081-call-fn-method-early-return-arm-skips-i32-boxing.md
@@ -1,0 +1,93 @@
+---
+id: 4081
+title: "`__call_fn_method_N` has a THIRD dispatch arm that inlines save-result/restore-`__current_this`/return without the i32 boxing the other two arms do — 12 files"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: standalone
+language_feature: n/a
+goal: standalone-mode
+related: [4077, 4079, 4080]
+---
+
+# A third `__call_fn_method_N` dispatch arm skips return-type boxing
+
+Located 2026-08-02 by the `H-crashes` agent, which **deliberately stopped short
+of implementing** because it had not finished identifying the emitting site.
+Handed over with a repro, the exact failing instruction sequence, one hypothesis
+already eliminated, and the two files to search.
+
+## Population
+
+**12 files** in the `invalid Wasm binary` cluster (population 53). 11 of the 12
+are `built-ins/RegExp/prototype/test/S15.10.6.3_*`.
+
+## Repro — 9 lines, standalone target
+
+```js
+__instance = new Object();
+__instance.test = RegExp.prototype.test;
+__instance.test("…");
+```
+
+Fails as:
+
+```
+__call_fn_method_0 failed: local.set[0] expected type externref, found call_ref of type i32
+```
+
+## The failing sequence, from the emitted WAT
+
+```wat
+… struct.get 114 0 ; ref.cast (ref 113) ; call_ref 113   ;; returns i32
+local.set 6                                              ;; local 6 is externref  <-- crash
+local.get 5 ; global.set 10 ; local.get 6 ; return       ;; __current_this restore
+```
+
+## ⚠ Hypothesis already ELIMINATED — do not re-run this one
+
+The obvious hypothesis, given the two sibling fixes (#4077, #4079), is that
+`entry.returnType` (a recorded signature) disagrees with `entry.funcTypeIdx`
+(the type `call_ref` actually uses). It is **plausible** — the code three lines
+above reads the ground-truth `funcTypeDef` for the self param while taking the
+return type from the parallel record.
+
+It was **instrumented rather than argued**, and disproved:
+
+```
+[RETTYPE] funcTypeIdx=113 recorded={"kind":"i32"} actual={"kind":"i32"}
+```
+
+**They agree. That is not the mechanism.** Both `call_ref` sites already read
+(`closure-exports.ts:554-584` and `:907-937`) box i32 correctly via
+`boxI32ClosureResult`.
+
+## The actual shape
+
+There is a **third** dispatch arm: an early-return path that inlines the
+"save result / restore `__current_this` / reload / return" sequence — the same
+shape as `closure-exports.ts:1039-1042`, whose comment asserts *"Stack at this
+point: [result : externref]"* — and **this copy does no return-type boxing at
+all**.
+
+The emitter that writes it has **not** been identified. It is not either of the
+two arms above. Next place to look: **`closed-method-dispatch.ts:547`**, which
+also calls `__call_fn_method_<arity>`.
+
+## Why this matters beyond 12 files
+
+Fourth instance of the pattern in one cluster (#3989, #4077, #4079, this), and
+it sharpens the statement of it. It is **not merely "a hand-maintained case
+list"** — in #4079 and here it is **a duplicated emission sequence where one
+copy carries the type handling and another does not**. Worse, the invariant is
+written down as a *comment* in one copy (`"[result : externref]"`) and silently
+assumed in the other, so the two copies cannot be kept honest by anything.
+
+See #4080: the `malformed_wasm` invariant already catches this class by
+construction; the gap is diff-test corpus coverage.


### PR DESCRIPTION
Follow-up to #4003. Three issue files, no code.

## 1. #4059 — I filed a wrong root cause this morning, corrected here

#4059 (landed in #4003) said the `__bindfn` invalid-Wasm cluster was "root-caused to `compileFunctionBind`'s standalone arm". **That is wrong**, and acting on it would send a dev to modify code that is not at fault.

Refuted the same day by the H-crashes agent with an **8-line repro containing no `bind` at all**. The `$__bindfn_tgt_*` locals are the first ~200 chars of `__module_init`'s *locals list*, contributed by `propertyHelper.js`'s own prologue — ~150KB of bytecode before the failing instruction. `bind` is incidental.

Real cause: `fixupExternConvertAny` located "which argument produced this instruction" by walking backward assuming one instruction == one argument, with a hand-maintained exception list. `extern.convert_any` was missing from it and is emitted on essentially every boxed argument, so it burned a param index. Fixed in #4072 / PR #4007 (+24 flips, kill-switch 28/28 fail on revert).

Set **`wont-fix` (superseded)**, deliberately not `done`: #4007 has not merged, and this issue's stated work should never be performed regardless of that outcome.

**The refutation was already in the issue text.** It recorded that a synthetic `call.bind` probe "VALIDATES FINE" and told the reader to budget for a harder repro — when the correct reading was that `bind` is not the mechanism. A recorded disconfirming observation that gets explained away is the expensive kind.

## 2. #4075 — the standalone refuse-loud channel is LOSSY

A `reportError` that omits `sticky` is discarded by `rollbackSpeculative` and replaced with `pushDefaultValue`:

```
errors.len 1 → rollback DROPPING 1 diag → generateModule returns errors.len 0
             → success:true, imports:[]
```

So a site that means *"refuse rather than answer wrong"* **silently answers wrong**. No host-import leak, no compile error, no failing check — the refusal is erased, leaving no evidence anywhere. Found by H-errmodel while implementing #4044.

The issue carries a **required positive control**: without one, "no lossy sites found" is indistinguishable from "the detector does not work" — which is the same failure this defect *is*.

## 3. #4078 — a long single-process test262 sweep poisons its own results

19 apparent regressions; **4 real** once each was re-run solo. Critically the sweep was **fully serial** — this is *not* the known contention flake, so "serial is trustworthy" is false. State accumulates across files in the shared process; 8 of the 15 false failures shared one signature (`Invalid value used as weak map key`) that only appears deep into a run. Found by H-crashes.

## Note on ids

#4078, not #4076 — H-errmodel had reserved 4076 concurrently. **Third id collision this session**, all the same root cause, now filed as #4045: the reservation ledger is split-brain across the fork and upstream refs, so `--allocate` reports `pr_scan=ok` for an id another lane already holds. I ceded each time rather than contest it. The CI open-PR gate is what actually arbitrates, and it worked every time.

## Verification

`check:issue-ids`, `check:issue-ids:against-main`, `check:issues` (the filename/frontmatter integrity gate), `check:done-status-integrity`, and `prettier --check` all pass locally. Frontmatter verified by reading the **committed blob**, not the working tree — that distinction is what caught the `id:` mismatch in #4003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcwPzXzbjibq9EcXMDBJAj