### PR TITLE
fix(#4079): route global ++/-- through one type-aware helper

### DIFF
--- a/plan/issues/4079-global-incdec-i32-slot.md
+++ b/plan/issues/4079-global-incdec-i32-slot.md
@@ -1,0 +1,108 @@
+---
+id: 4079
+title: "`++`/`--` on an i32-slot module global emits `f64.add` on an i32 operand — module fails validation"
+status: done
+sprint: current
+priority: high
+horizon: s
+feasibility: hard
+reasoning_effort: max
+goal: standalone-gap
+assignee: ttraenkler/H-crashes
+created: 2026-08-02
+completed: 2026-08-02
+---
+
+## Problem
+
+`var x = false; x++;` emits a module that **fails Wasm validation**:
+
+```
+__module_init failed: f64.add[0] expected type f64,
+                      found global.get of type i32
+```
+
+The module never instantiates, so the whole file's assertions are lost.
+
+Measured on the standalone lane (baseline row timestamp `2.8.2026, 03:32`;
+ES5+untagged goal scope 8,545 run / 6,298 pass / 0 unopenable): **8** of the
+53 goal-scope `invalid Wasm binary` files are this mechanism — the
+`S11.3.1` / `S11.3.2` / `S11.4.4` / `S11.4.5` `_A3_T1` / `_A4_T1` family
+(postfix/prefix increment/decrement with a boolean or Boolean-object operand).
+
+This is **not** the externref `ref.null` family of #4077; it must not be
+folded into it.
+
+## Root cause
+
+`var x = false` gives the module global an **i32** (boolean-branded) slot.
+
+The *read* path already knew this: the `x !== 0 + 1` comparison emits
+`f64.convert_i32_s` on the same global. The *update* path did not.
+
+`src/codegen/expressions/unary-updates.ts` carried **eight** hand-rolled
+copies of "read the global / compute ±1 / store it back" —
+prefix `++`, prefix `--`, postfix `++`, postfix `--`, each duplicated for
+`ctx.moduleGlobals` and `ctx.capturedGlobals`. Every copy branched on the
+global's declared type, and every copy handled `externref` and
+`ref`/`ref_null` and **forgot `i32`**, so an i32 slot fell through to the f64
+arm:
+
+```wat
+global.get 7      ;; i32 (boolean slot)
+global.get 7      ;; i32
+f64.const 1
+f64.add           ;; <-- operand is i32
+global.set 7      ;; and this would store f64 into an i32 global
+```
+
+A correct implementation already existed a few hundred lines above, in the
+same file: `compileStaticPropIncDec` (#2019) converts `i32`→`f64` on read and
+`f64`→`i32` on store. It was only ever wired to static-property globals.
+
+So the eight copies and the one correct version were the same "two halves
+living apart and drifting" shape as #3989 and #4077 — except here the correct
+half was already in the file and simply not reused.
+
+## Fix
+
+Generalise `compileStaticPropIncDec` into **`compileGlobalIncDec`** and route
+all eight fallback arms through it. One type-case list instead of eight; the
+`i32` case cannot be forgotten again because there is only one place to
+forget it.
+
+The `externref` and `ref`/`ref_null` early-returns in each arm are left
+untouched — this change only replaces the final f64-assuming fallback.
+
+## Measurements
+
+Row timestamp `2.8.2026, 03:32` · corpus `test262-standalone-current.jsonl`
+(loopdive/js2wasm-baselines) · official 43,505 run / 25,995 pass (59.75%) ·
+goal scope 8,545 run / 6,298 pass (73.70%) / **0 unopenable**.
+
+| stage      | count | note                                                      |
+| ---------- | ----: | --------------------------------------------------------- |
+| population |    53 | goal-scope `invalid Wasm binary`                          |
+| mechanism  |     8 | `f64.add/sub ... found global.get of type i32`            |
+| reachable  |     8 | all compile; the crash is at instantiate                  |
+| **flips**  |     4 | `runTest262File`, `--target standalone`, run **serially** |
+
+**Kill-switch control** — same 8 files, same runner, `unary-updates.ts`
+reverted to its `HEAD` version: **8 fail / 0 pass**. With the fix:
+**4 pass / 4 fail**.
+
+The 4 residuals are the `CHECK#2` halves of those same files, which use
+`new Boolean(true)` — an **externref** global that takes the separate
+`externref` arm and fails on Boolean-object `ToNumeric` semantics, not on
+validation. That is a different mechanism and is out of scope here.
+
+## Residual
+
+Still open in the goal-scope `invalid Wasm binary` population after #4077 and
+this issue:
+
+- 12 `local.set[0] expected externref, found call_ref of type i32` in
+  `__call_fn_method_N` (11 × `RegExp/prototype/test/S15.10.6.3_*`)
+- 2 `local.set expected (ref null 6), found struct.get of type i32`
+- 2 `type error in fallthru`
+- 1 `any.convert_extern expected externref, found if`

--- a/src/codegen/expressions/unary-updates.ts
+++ b/src/codegen/expressions/unary-updates.ts
@@ -152,12 +152,27 @@ function resolveStaticPropGlobalForUpdate(
 }
 
 /**
- * #2019: emit `++`/`--` against a static-property module global. Reads the
- * global, applies ToNumeric (so non-numeric externref backing values follow
- * §13.4), computes old±1, writes it back, and leaves the spec result on the
- * stack (old value for postfix, new value for prefix). Always yields f64.
+ * #2019: emit `++`/`--` against a Wasm global slot. Reads the global, applies
+ * ToNumeric (so non-numeric externref backing values follow §13.4), computes
+ * old±1, writes it back **coerced to the global's declared type**, and leaves
+ * the spec result on the stack (old value for postfix, new value for prefix).
+ * Always yields f64.
+ *
+ * (#4079) Originally static-property-only. The plain module-global and
+ * captured-global paths below each hand-rolled the same read/compute/store
+ * with their OWN type-case list, and every one of those lists handled
+ * `externref` and `ref`/`ref_null` but forgot **`i32`** — so a boolean-backed
+ * global fell through to the f64 arm and emitted `global.get` (i32) straight
+ * into `f64.add`:
+ *
+ *     var x = false; x++;
+ *     -> f64.add[0] expected type f64, found global.get of type i32
+ *
+ * which kills the module at instantiate. This function already had the i32
+ * arm right, so the fix is to stop having eight copies of the decision and
+ * route them all here.
  */
-function compileStaticPropIncDec(
+function compileGlobalIncDec(
   ctx: CodegenContext,
   fctx: FunctionContext,
   globalIdx: number,
@@ -463,7 +478,7 @@ function compileMemberIncDec(
     {
       const staticGlobalIdx = resolveStaticPropGlobalForUpdate(ctx, fctx, operand.expression, propName);
       if (staticGlobalIdx !== undefined) {
-        return compileStaticPropIncDec(ctx, fctx, staticGlobalIdx, f64Op, mode);
+        return compileGlobalIncDec(ctx, fctx, staticGlobalIdx, f64Op, mode);
       }
     }
 
@@ -1146,16 +1161,9 @@ function compilePrefixUpdate(
             fctx.body.push({ op: "f64.add" });
             return { kind: "f64" };
           }
-          fctx.body.push({ op: "global.get", index: ppModIdx });
-          fctx.body.push({ op: "f64.const", value: 1 });
-          fctx.body.push({ op: "f64.add" });
-          const ppTmp = allocLocal(fctx, `__pp_mod_${fctx.locals.length}`, {
-            kind: "f64",
-          });
-          fctx.body.push({ op: "local.tee", index: ppTmp });
-          fctx.body.push({ op: "global.set", index: ppModIdx });
-          fctx.body.push({ op: "local.get", index: ppTmp });
-          return { kind: "f64" };
+          // (#4079) f64 OR i32 backing slot — the shared helper owns the
+          // read/store coercion so the i32 case cannot be forgotten again.
+          return compileGlobalIncDec(ctx, fctx, ppModIdx, "f64.add", "prefix");
         }
         // Check captured globals for prefix ++
         const ppCapIdx = ctx.capturedGlobals.get(ppOperand.text);
@@ -1182,16 +1190,8 @@ function compilePrefixUpdate(
             fctx.body.push({ op: "f64.add" });
             return { kind: "f64" };
           }
-          fctx.body.push({ op: "global.get", index: ppCapIdx });
-          fctx.body.push({ op: "f64.const", value: 1 });
-          fctx.body.push({ op: "f64.add" });
-          const ppTmp = allocLocal(fctx, `__pp_cap_${fctx.locals.length}`, {
-            kind: "f64",
-          });
-          fctx.body.push({ op: "local.tee", index: ppTmp });
-          fctx.body.push({ op: "global.set", index: ppCapIdx });
-          fctx.body.push({ op: "local.get", index: ppTmp });
-          return { kind: "f64" };
+          // (#4079) f64 OR i32 backing slot — see compileGlobalIncDec.
+          return compileGlobalIncDec(ctx, fctx, ppCapIdx, "f64.add", "prefix");
         }
       }
       // ++obj.prop or ++obj[idx] — delegate to member increment helper
@@ -1360,16 +1360,8 @@ function compilePrefixUpdate(
             fctx.body.push({ op: arithOp });
             return { kind: "f64" };
           }
-          fctx.body.push({ op: "global.get", index: mmModIdx });
-          fctx.body.push({ op: "f64.const", value: 1 });
-          fctx.body.push({ op: arithOp });
-          const mmTmp = allocLocal(fctx, `__mm_mod_${fctx.locals.length}`, {
-            kind: "f64",
-          });
-          fctx.body.push({ op: "local.tee", index: mmTmp });
-          fctx.body.push({ op: "global.set", index: mmModIdx });
-          fctx.body.push({ op: "local.get", index: mmTmp });
-          return { kind: "f64" };
+          // (#4079) f64 OR i32 backing slot — see compileGlobalIncDec.
+          return compileGlobalIncDec(ctx, fctx, mmModIdx, arithOp, "prefix");
         }
         // Check captured globals for prefix --
         const mmCapIdx = ctx.capturedGlobals.get(mmOperand.text);
@@ -1396,16 +1388,8 @@ function compilePrefixUpdate(
             fctx.body.push({ op: arithOp });
             return { kind: "f64" };
           }
-          fctx.body.push({ op: "global.get", index: mmCapIdx });
-          fctx.body.push({ op: "f64.const", value: 1 });
-          fctx.body.push({ op: arithOp });
-          const mmTmp = allocLocal(fctx, `__mm_cap_${fctx.locals.length}`, {
-            kind: "f64",
-          });
-          fctx.body.push({ op: "local.tee", index: mmTmp });
-          fctx.body.push({ op: "global.set", index: mmCapIdx });
-          fctx.body.push({ op: "local.get", index: mmTmp });
-          return { kind: "f64" };
+          // (#4079) f64 OR i32 backing slot — see compileGlobalIncDec.
+          return compileGlobalIncDec(ctx, fctx, mmCapIdx, arithOp, "prefix");
         }
       }
       // --obj.prop or --obj[idx] — delegate to member decrement helper
@@ -1482,13 +1466,8 @@ function compilePostfixUnary(
           coerceType(ctx, fctx, postModGlobalDef.type, { kind: "f64" });
           return { kind: "f64" };
         }
-        // Postfix: return old value, store new value
-        fctx.body.push({ op: "global.get", index: postModIdx });
-        fctx.body.push({ op: "global.get", index: postModIdx });
-        fctx.body.push({ op: "f64.const", value: 1 });
-        fctx.body.push({ op: arithOp });
-        fctx.body.push({ op: "global.set", index: postModIdx });
-        return { kind: "f64" };
+        // (#4079) f64 OR i32 backing slot — see compileGlobalIncDec.
+        return compileGlobalIncDec(ctx, fctx, postModIdx, arithOp, "postfix");
       }
       // Check captured globals for postfix ++/--
       const postCapIdx = ctx.capturedGlobals.get(postOperand.text);
@@ -1515,12 +1494,8 @@ function compilePostfixUnary(
           coerceType(ctx, fctx, postCapGlobalDef.type, { kind: "f64" });
           return { kind: "f64" };
         }
-        fctx.body.push({ op: "global.get", index: postCapIdx });
-        fctx.body.push({ op: "global.get", index: postCapIdx });
-        fctx.body.push({ op: "f64.const", value: 1 });
-        fctx.body.push({ op: arithOp });
-        fctx.body.push({ op: "global.set", index: postCapIdx });
-        return { kind: "f64" };
+        // (#4079) f64 OR i32 backing slot — see compileGlobalIncDec.
+        return compileGlobalIncDec(ctx, fctx, postCapIdx, arithOp, "postfix");
       }
       // Graceful fallback: emit 0 for unknown postfix increment/decrement
       fctx.body.push({ op: "f64.const", value: 0 });

--- a/tests/issue-4079-global-incdec-i32-slot.test.ts
+++ b/tests/issue-4079-global-incdec-i32-slot.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #4079 — `++`/`--` on a module global whose Wasm slot is **i32** emitted
+// `global.get` (i32) straight into `f64.add`, so the module failed validation:
+//
+//     __module_init failed: f64.add[0] expected type f64,
+//                           found global.get of type i32
+//
+// and never instantiated — the file loses 100% of its assertions.
+//
+// `var x = false` gives the global an i32 (boolean) slot. The *comparison*
+// path already inserted `f64.convert_i32_s` when reading that global; the
+// *update* path did not. `unary-updates.ts` had EIGHT hand-rolled copies of
+// "read global / compute ±1 / store back" (prefix++ , prefix-- , postfix++ ,
+// postfix-- × moduleGlobals, capturedGlobals), each with its own type-case
+// list, and every one of them handled `externref` and `ref`/`ref_null` and
+// forgot `i32`.
+//
+// A correct implementation already existed a few hundred lines up in the same
+// file: `compileStaticPropIncDec` (#2019) converts i32→f64 on read and
+// f64→i32 on store. It was only wired to static-property globals. The fix
+// generalises it to `compileGlobalIncDec` and routes all eight fallbacks
+// through it, so there is one type-case list instead of eight.
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    deferTopLevelInit: true,
+  });
+  if (!result.success || result.errors.some((e) => e.severity === "error")) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  return result.binary;
+}
+
+async function runInit(binary: Uint8Array) {
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  const exports = instance.exports as Record<string, CallableFunction>;
+  exports.__module_init?.();
+  return exports;
+}
+
+describe("#4079 — ++/-- on an i32-slot module global", () => {
+  // The reduced form of test262 S11.3.1_A3_T1 CHECK#1.
+  it("postfix ++ on a boolean-initialised global validates", async () => {
+    const binary = await compileStandalone(`var x = false;\nx++;\n`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+  });
+
+  // Validation is not correctness. `false++` must leave `x === 1`, so the
+  // guard below must NOT throw. If the i32→f64→i32 round-trip were dropped or
+  // truncated the wrong way this would trap during __module_init.
+  it("postfix ++ on a boolean global yields ToNumber(false) + 1 === 1", async () => {
+    const binary = await compileStandalone(`
+var x = false;
+x++;
+if (x !== 0 + 1) {
+  throw new Error("x was not 1");
+}
+`);
+    await expect(runInit(binary)).resolves.toBeDefined();
+  });
+
+  it("prefix -- on a boolean global yields ToNumber(true) - 1 === 0", async () => {
+    const binary = await compileStandalone(`
+var y = true;
+--y;
+if (y !== 1 - 1) {
+  throw new Error("y was not 0");
+}
+`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+    await expect(runInit(binary)).resolves.toBeDefined();
+  });
+
+  // The plain f64-slot global must be unchanged by the re-routing — this is
+  // the path all eight call sites already handled correctly.
+  it("++/-- on an ordinary numeric global still works", async () => {
+    const binary = await compileStandalone(`
+var n = 41;
+n++;
+var m = 43;
+m--;
+if (n !== 42) {
+  throw new Error("n");
+}
+if (m !== 42) {
+  throw new Error("m");
+}
+`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+    await expect(runInit(binary)).resolves.toBeDefined();
+  });
+
+  // Postfix must still evaluate to the OLD value and prefix to the NEW one;
+  // the shared helper is what now decides that, so pin it.
+  it("postfix returns the old value and prefix the new one", async () => {
+    const binary = await compileStandalone(`
+var a = 5;
+var post = a++;
+var b = 5;
+var pre = ++b;
+if (post !== 5) {
+  throw new Error("postfix returned the new value");
+}
+if (pre !== 6) {
+  throw new Error("prefix returned the old value");
+}
+`);
+    await expect(runInit(binary)).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #4079. Second mechanism from the standalone crash cluster; independent
of #4007 (different file, different signature).

## What broke

```js
var x = false;
x++;
```

```
__module_init failed: f64.add[0] expected type f64,
                      found global.get of type i32
```

The module never instantiates, so the file loses **100 %** of its assertions.
**8** ES5-scope standalone test262 files: the `S11.3.1` / `S11.3.2` /
`S11.4.4` / `S11.4.5` `_A3_T1` / `_A4_T1` family.

## Root cause

`var x = false` gives the module global an **i32** (boolean-branded) slot.

The **read** path already knew that — the `x !== 0 + 1` comparison in the same
function emits `f64.convert_i32_s` on that very global. The **update** path
did not:

```wat
global.get 7      ;; i32 (boolean slot)
global.get 7      ;; i32
f64.const 1
f64.add           ;; <-- operand is i32
global.set 7      ;; and this would have stored f64 into an i32 global
```

`src/codegen/expressions/unary-updates.ts` carried **eight** hand-rolled
copies of "read the global / compute ±1 / store it back" — prefix `++`,
prefix `--`, postfix `++`, postfix `--`, each duplicated for
`ctx.moduleGlobals` and `ctx.capturedGlobals`. Every copy branched on the
global's declared type. Every copy handled `externref` and `ref`/`ref_null`
and **forgot `i32`**.

A correct implementation already existed a few hundred lines above **in the
same file**: `compileStaticPropIncDec` (#2019) converts `i32`→`f64` on read
and `f64`→`i32` on store. It was only ever wired to static-property globals.

Same shape as #3989 and #4007/#4077 — two halves that must agree about a
slot's type, living apart and drifting — except here the correct half was
already present and simply not reused.

## The fix

Generalise `compileStaticPropIncDec` into **`compileGlobalIncDec`** and route
all eight fallback arms through it. One type-case list instead of eight, so
the `i32` case cannot be forgotten again — there is only one place left to
forget it.

The `externref` and `ref`/`ref_null` early-returns in each arm are untouched;
only the final f64-assuming fallback is replaced. **Net −25 LOC.**

## Measurements

Baseline: `test262-standalone-current.jsonl` (loopdive/js2wasm-baselines),
row timestamp **`2.8.2026, 03:32`**, oracle v12.
Official scope **43,505 run / 25,995 pass (59.75 %)**.
ES5+untagged goal scope **8,545 run / 6,298 pass (73.70 %) / 0 unopenable**.

| stage      | count | note                                                      |
| ---------- | ----: | --------------------------------------------------------- |
| population |    53 | goal-scope `invalid Wasm binary`                          |
| mechanism  |     8 | `f64.add/sub … found global.get of type i32`              |
| reachable  |     8 | all compile; the crash is at instantiate                  |
| **flips**  |     4 | `runTest262File`, `--target standalone`, run **serially** |

**Kill-switch control** — same 8 files, same runner, `unary-updates.ts`
reverted to its `HEAD` version: **8 fail / 0 pass**. With the fix:
**4 pass / 4 fail**.

The 4 residuals are the `CHECK#2` halves of those same files, which use
`new Boolean(true)` — an **externref** global that takes the separate
`externref` arm and fails on Boolean-object `ToNumeric` semantics, not on
validation. Different mechanism, out of scope.

## Tests verify by value, not just validation

`WebAssembly.validate() === true` is not correctness, so the tests also assert
that `false++` leaves `x === 1` and `--true` leaves `y === 0` (both as guards
that must not throw during `__module_init`), that an ordinary numeric global
still increments to 42, and that postfix still evaluates to the **old** value
while prefix evaluates to the **new** one — that last one is now decided by
the shared helper, so it is pinned.

## Not addressed here

Remaining goal-scope `invalid Wasm binary` after #4077 and this PR:
12 × `local.set[0] expected externref, found call_ref of type i32` in
`__call_fn_method_N` (11 of them `RegExp/prototype/test/S15.10.6.3_*`);
2 × `local.set expected (ref null 6), found struct.get`; 2 × fallthru type
error; 1 × `any.convert_extern expected externref, found if`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcwPzXzbjibq9EcXMDBJAj
