### PR TITLE
fix(#4082): give the closure-result boxing one owner

### DIFF
--- a/plan/issues/4081-call-fn-method-early-return-arm-skips-i32-boxing.md
+++ b/plan/issues/4081-call-fn-method-early-return-arm-skips-i32-boxing.md
@@ -1,10 +1,12 @@
 ---
 id: 4081
 title: "`__call_fn_method_N` has a THIRD dispatch arm that inlines save-result/restore-`__current_this`/return without the i32 boxing the other two arms do — 12 files"
-status: ready
+status: done
 sprint: current
 created: 2026-08-02
 updated: 2026-08-02
+completed: 2026-08-02
+assignee: ttraenkler/H-crashes
 priority: high
 horizon: m
 feasibility: medium
@@ -17,6 +19,22 @@ related: [4077, 4079, 4080]
 ---
 
 # A third `__call_fn_method_N` dispatch arm skips return-type boxing
+
+> **DONE — implemented as #4082 (PR #4011). Do NOT dispatch this issue.**
+>
+> `H-crashes` handed this over mid-investigation and then finished it in the
+> same session, so the finding and the fix ended up in two issue files. This
+> one is the finding; **#4082** is the fix and carries the measurements
+> (population 53 → mechanism 12 → reachable 12 → **9 flips**; kill-switch
+> 12/12 fail; regression control 500 → 496 with 0 attributable).
+>
+> The emitting site named as "not yet identified" below **was** identified:
+> `src/codegen/closures/transferred-native-proto.ts` — the #3992
+> transferred-native-proto arm, **not** `closed-method-dispatch.ts`. See the
+> correction at the end of this file.
+>
+> #4082 also records a residual it deliberately did not fix: **#4083**, where
+> the same borrowed call now answers `null` instead of crashing.
 
 Located 2026-08-02 by the `H-crashes` agent, which **deliberately stopped short
 of implementing** because it had not finished identifying the emitting site.
@@ -79,6 +97,24 @@ all**.
 The emitter that writes it has **not** been identified. It is not either of the
 two arms above. Next place to look: **`closed-method-dispatch.ts:547`**, which
 also calls `__call_fn_method_<arity>`.
+
+### CORRECTION (resolved in #4082) — the lead above was wrong
+
+`closed-method-dispatch.ts` was the wrong place to look; it emits no `call_ref`
+at all. The arm is `buildTransferredNativeProtoCallInstrs` in
+**`src/codegen/closures/transferred-native-proto.ts`** — the #3992
+transferred-native-proto arm, reached from `closure-exports.ts` via
+`buildTransferredNativeProtoCallInstrs(...)`, not from a `closed-method`
+path. Recording the miss because a confidently-named "next place to look" is
+the kind of hint that costs the next reader an hour.
+
+Its doc block is also the sharpest evidence for #4080: the invariant it
+violates is written *in that same doc block* — *"each arm pushes exactly one
+externref (the `call_ref` result)"* — so the copy missing the type handling is
+the copy asserting its own correctness in prose.
+
+Fixed by giving the whole ABI one owner for the decision, a new subsystem
+module `src/codegen/closures/result-boxing.ts`, imported by all three arms.
 
 ## Why this matters beyond 12 files
 

--- a/plan/issues/4082-closure-result-boxing.md
+++ b/plan/issues/4082-closure-result-boxing.md
@@ -1,0 +1,162 @@
+---
+id: 4082
+title: "borrowed native-proto methods returning i32 skip result boxing — `local.set` gets a raw i32 and the module fails validation"
+status: done
+sprint: current
+priority: high
+horizon: s
+feasibility: hard
+reasoning_effort: max
+goal: standalone-gap
+assignee: ttraenkler/H-crashes
+created: 2026-08-02
+completed: 2026-08-02
+---
+
+## Problem
+
+Borrowing a native-prototype method onto another object and calling it —
+`obj.test = RegExp.prototype.test; obj.test("…")` — emits a module that
+**fails Wasm validation**:
+
+```
+__call_fn_method_0 failed:
+  local.set[0] expected type externref, found call_ref of type i32
+```
+
+The module never instantiates, so the whole file's assertions are lost.
+
+Measured on the standalone lane (baseline row timestamp `2.8.2026, 03:32`;
+ES5+untagged goal scope 8,545 run / 6,298 pass / 0 unopenable): **12** of the
+53 goal-scope `invalid Wasm binary` files — 11 × `RegExp/prototype/test/
+S15.10.6.3_*` plus `Object/getOwnPropertyDescriptor/15.2.3.3-4-166.js`.
+
+Third distinct mechanism inside that one signature, after #4077 (`ref.null`
+arg mis-pairing, 28 files) and #4079 (i32-slot global `++`, 8 files).
+
+## Root cause
+
+`__call_fn_method_N` returns **externref**. Every dispatch arm therefore has to
+lower its `call_ref` result to externref, and until now each arm carried its
+own copy of that decision.
+
+The #3992 transferred-native-proto arm
+(`src/codegen/closures/transferred-native-proto.ts`) copied the generic arm's
+`call_ref` but **not** its boxing:
+
+```wat
+call_ref $sig          ;; RegExp.prototype.test -> i32
+local.set $resultSave  ;; $resultSave is externref   <-- invalid
+local.get $prevThis
+global.set $__current_this
+local.get $resultSave
+return
+```
+
+The missing half was **asserted in a comment instead of in code**. That
+function's own doc block read:
+
+> Stack balance: each arm pushes exactly one externref (the `call_ref` result)
+> and immediately sinks it into `resultSaveLocal`
+
+which is true only for reference-returning closures. `RegExp.prototype.test`
+returns i32 (boolean), so the claim was simply false for it, and nothing
+checked. An invariant that exists only as prose is not an invariant.
+
+Both generic arms in `closure-exports.ts` (lines ~554 and ~907 pre-change) did
+box correctly, via two byte-identical 30-line if-chains. So the shape is the
+same one #3989, #4077 and #4079 all had: **a decision that must hold in
+several places, duplicated rather than shared, where the newest copy is the
+one missing a case.**
+
+### What this refutes
+
+The obvious hypothesis — given the previous two fixes — was that
+`entry.returnType` (a recorded signature) disagreed with `entry.funcTypeIdx`
+(the type `call_ref` actually uses), especially since the collector reads the
+ground-truth `funcTypeDef` for the *self* param three lines above. That was
+instrumented rather than assumed:
+
+```
+[RETTYPE] funcTypeIdx=113 recorded={"kind":"i32"} actual={"kind":"i32"}
+```
+
+**They agree.** The recorded type was correct and simply never consulted by
+that arm. Not a stale-metadata bug.
+
+## Fix
+
+`buildClosureResultBoxing(ctx, returnType, boxNumberIdx)` in
+`closure-exports.ts` now owns the call_ref-result → externref decision for the
+whole ABI. Both generic arms are re-pointed at it (behaviour-identical: the
+old fall-through-emitting-nothing case becomes an empty instruction list, and
+the null-returnType case still emits `ref.null.extern`), and the
+transferred-native-proto arm receives it as a `boxResult` callback — passed in
+rather than imported, because `closure-exports.ts` already imports that
+module.
+
+`TransferredNativeReceiverEntry` gains `returnType`, taken from the same
+`closureInfoByTypeIdx` record the generic arms use and measured above to match
+the emitted func type.
+
+## Measurements
+
+Row timestamp `2.8.2026, 03:32` · corpus `test262-standalone-current.jsonl`
+(loopdive/js2wasm-baselines) · official 43,505 run / 25,995 pass (59.75%) ·
+goal scope 8,545 run / 6,298 pass (73.70%) / **0 unopenable**.
+
+| stage      | count | note                                                      |
+| ---------- | ----: | --------------------------------------------------------- |
+| population |    53 | goal-scope `invalid Wasm binary`                          |
+| mechanism  |    12 | `local.set[0] expected externref, found call_ref of i32`  |
+| reachable  |    12 | all compile; the crash is at instantiate                  |
+| **flips**  |     9 | `runTest262File`, `--target standalone`, run **serially** |
+
+**Kill-switch control** — same 12 files, same runner, both touched files
+reverted to their `HEAD` versions: **12 fail / 0 pass**. With the fix:
+**9 pass / 3 fail**.
+
+**Regression control** — deterministic seeded sample of 500 goal-scope files
+the baseline records as `pass`, run with the fix: **496 pass / 4 fail**. The 4
+were re-run with both touched files reverted and **failed identically**
+(3 strict-mode negative tests plus one `js2wasm:runtime-eval` host-import case
+that `runTest262File` does not gate the way the CI path does).
+**Attributable regressions: 0 / 500.**
+
+## KNOWN RESIDUAL — this fix removes the crash, not every wrong answer
+
+Measured and stated deliberately, because it is the uncomfortable half.
+
+For the shape `var re = /a/; re.borrowed = RegExp.prototype.test;
+re.borrowed("banana")`:
+
+| | result |
+| --- | --- |
+| base (`HEAD`) | `CompileError` — module never instantiates |
+| with this fix | validates and runs, but the call answers **`null`** |
+
+So the change converts a loud crash into a **silently wrong value** for that
+shape. The cause is NOT the new boxing — a trace shows the arm selecting
+`f64.convert_i32_s ; call $__box_number`, which cannot produce `null`. The
+arm's exact-identity guard simply does not match this receiver at runtime, so
+the outer dispatch falls through to its `ref.null.extern`. That is a **#3992
+coverage gap** which the crash previously masked; this fix makes it
+observable rather than causing it. The file's own #3992 doc block already
+records `null` as the symptom of that gap.
+
+Shipping anyway is justified by measurement, not by preference: 9 of the 12
+files flip to **pass with their real assertions checked** (they assert a
+`TypeError` on a non-RegExp receiver, and the probe confirms a genuine
+`TypeError` is thrown), and there are 0 attributable regressions in 500. The
+`null` case was already broken — as a crash — so nothing regressed. The
+follow-up is to widen the #3992 arm's receiver matching; it is NOT tracked
+here and NOT asserted as correct in the tests, because pinning the wrong value
+would freeze the bug.
+
+## Residual
+
+Goal-scope `invalid Wasm binary` after #4077 (28), #4079 (8) and this (12):
+
+- 2 `local.set expected (ref null 6), found struct.get of type i32`
+- 2 `type error in fallthru`
+- 1 `any.convert_extern expected externref, found if`

--- a/plan/issues/4082-closure-result-boxing.md
+++ b/plan/issues/4082-closure-result-boxing.md
@@ -34,6 +34,12 @@ S15.10.6.3_*` plus `Object/getOwnPropertyDescriptor/15.2.3.3-4-166.js`.
 Third distinct mechanism inside that one signature, after #4077 (`ref.null`
 arg mis-pairing, 28 files) and #4079 (i32-slot global `++`, 8 files).
 
+**Closes #4081 as well.** That issue is the same mechanism, filed from this
+agent's own mid-investigation handoff before it finished the work; #4081 is the
+finding, this is the fix. #4081 is set `done` here so it cannot be dispatched
+to a second agent. Its "next place to look: `closed-method-dispatch.ts`" lead
+was wrong and is corrected there.
+
 ## Root cause
 
 `__call_fn_method_N` returns **externref**. Every dispatch arm therefore has to
@@ -68,6 +74,12 @@ box correctly, via two byte-identical 30-line if-chains. So the shape is the
 same one #3989, #4077 and #4079 all had: **a decision that must hold in
 several places, duplicated rather than shared, where the newest copy is the
 one missing a case.**
+
+This is the **fourth** instance of #4080 in one cluster, and the sharpest: the
+invariant was not merely absent from the newest copy, it was written there as
+a **comment** (*"each arm pushes exactly one externref"*) in the copy that did
+not implement it. Prose cannot be checked; the other three instances at least
+failed silently rather than asserting their own correctness.
 
 ### What this refutes
 
@@ -125,7 +137,9 @@ that `runTest262File` does not gate the way the CI path does).
 
 ## KNOWN RESIDUAL — this fix removes the crash, not every wrong answer
 
-Measured and stated deliberately, because it is the uncomfortable half.
+**Tracked as #4083.** Measured and stated deliberately, because it is the
+uncomfortable half — a loud→quiet trade is acceptable when it is *recorded*,
+and unacceptable when it is absorbed.
 
 For the shape `var re = /a/; re.borrowed = RegExp.prototype.test;
 re.borrowed("banana")`:
@@ -149,9 +163,12 @@ files flip to **pass with their real assertions checked** (they assert a
 `TypeError` on a non-RegExp receiver, and the probe confirms a genuine
 `TypeError` is thrown), and there are 0 attributable regressions in 500. The
 `null` case was already broken — as a crash — so nothing regressed. The
-follow-up is to widen the #3992 arm's receiver matching; it is NOT tracked
-here and NOT asserted as correct in the tests, because pinning the wrong value
-would freeze the bug.
+follow-up — widening the #3992 arm's receiver matching — is tracked as
+**#4083**, and is NOT asserted as correct in the tests here, because pinning
+the wrong value would freeze the bug. The fourth test in
+`tests/issue-4082-closure-result-boxing.test.ts` records only that the module
+is well-formed, and is the place #4083 should upgrade to a real value
+assertion.
 
 ## Residual
 

--- a/plan/issues/4083-borrowed-proto-method-answers-null.md
+++ b/plan/issues/4083-borrowed-proto-method-answers-null.md
@@ -1,0 +1,106 @@
+---
+id: 4083
+title: "borrowed native-proto method answers `null` when the #3992 exact-identity receiver guard misses — a loud crash traded for a quiet wrong value"
+status: ready
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+goal: standalone-gap
+created: 2026-08-02
+---
+
+## Problem
+
+A native-prototype method borrowed onto a receiver that the #3992
+transferred-native-proto dispatch arm's **exact-identity guard does not match**
+returns **`null`** instead of its real value.
+
+Exact repro (standalone target):
+
+```js
+var re = /a/;
+re.borrowed = RegExp.prototype.test;
+re.borrowed("banana"); // → null, should be true
+```
+
+Measured with a probe export that distinguishes `true` / `1` / `false` / `0` /
+`undefined` / `null` by identity: the call answers **`null`** for both a
+matching and a non-matching input (`re.borrowed("zzz")` is also not `false`).
+
+A **direct** call on the same object is correct — `re.test("banana") === true`
+and `re.test("zzz") === false` — so the boxers exist and work. Only the
+borrowed path is wrong.
+
+## This was a CRASH before #4082, and is a silent wrong value after it
+
+| | `var re = /a/; re.borrowed = RegExp.prototype.test; re.borrowed("banana")` |
+| --- | --- |
+| before #4082 | `CompileError: local.set[0] expected type externref, found call_ref of type i32` — module never instantiates |
+| after #4082 | module validates and runs, answers **`null`** |
+
+So #4082 traded a **loud** failure for a **quiet** one on this shape. That is a
+real diagnosability regression and this issue exists so it is *recorded rather
+than absorbed*.
+
+It is **not** an outcome regression: the shape was already broken (as a crash),
+and no test moves from pass to fail. #4082 was shipped on that basis, together
+with 9 verified test262 flips whose real assertions were checked.
+
+## Root cause — NOT the #4082 boxing
+
+Ruled out by tracing rather than by argument. The #4082 boxing selects:
+
+```wat
+f64.convert_i32_s
+call $__box_number
+```
+
+which cannot produce `null`. The `null` comes from the **outer dispatch**: the
+#3992 arm's exact-identity guard (a `ref.test` on the per-(brand, member) META
+subtype, followed by a field-3 `bfnid` equality re-check) does not match this
+receiver at runtime, so control falls through every arm to the trailing
+`ref.null.extern`.
+
+`src/codegen/closures/transferred-native-proto.ts`'s own #3992 doc block
+already names this symptom:
+
+> had its arguments shifted one slot left (`thisValue` received `arg0`) and
+> answered a silently **WRONG** value (measured: `null`), rather than throwing.
+
+#3992 fixed that for the shapes its guard matches. This issue is the remaining
+coverage gap: the guard is too narrow, and the crash was previously masking it.
+
+## Why no test pins the current value
+
+#4082 deliberately did **not** assert `null` anywhere. A test asserting the
+wrong value would freeze the bug and manufacture exactly the vacuous pass this
+issue is about; its fourth test records only that the module is *well-formed*,
+with no correctness claim. That test is the natural place to add the real
+assertion once the guard is widened.
+
+## Acceptance criteria
+
+- `var re = /a/; re.borrowed = RegExp.prototype.test; re.borrowed("banana")`
+  answers `true`, and `re.borrowed("zzz")` answers `false` — asserted **by
+  value and by identity** (`=== true` / `=== false`, not truthiness, so a
+  number `1` does not pass).
+- The residual-shape test in `tests/issue-4082-closure-result-boxing.test.ts`
+  is upgraded from "validates" to the real value assertion.
+- No new `ref.null.extern` fallthrough is reachable for a receiver that
+  structurally carries the borrowed method.
+
+## Notes for whoever takes it
+
+- The guard lives in `collectTransferredNativeProtoReceivers` /
+  `buildTransferredNativeProtoCallInstrs`
+  (`src/codegen/closures/transferred-native-proto.ts`).
+- The collector requires BOTH `nativeProtoReceiverClosureStructTypes` and
+  `builtinFnMetaByTypeIdx` membership; the arm then re-checks field 3 against
+  the literal `typeIdx`. One of those three conditions is what a regex-literal
+  receiver fails — establish which **by measurement** before changing any of
+  them, since narrowing exists deliberately (the shared base wrapper must not
+  capture every structurally equal closure).
+- Related: #4080 (duplicated emission sequences where one copy carries the
+  type handling and another does not) — #4082 was the fourth instance.

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -21,6 +21,7 @@ import {
 } from "./closures/transferred-native-proto.js";
 import { ensureArgcGlobal, ensureCurrentThisGlobal, ensureExtrasArgvGlobal } from "./statements/nested-declarations.js";
 import { ensureAnyToExternHelper, isAnyValue } from "./any-helpers.js";
+import { buildClosureResultBoxing } from "./closures/result-boxing.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { isSyntheticStructName } from "./emit-helpers.js";
 export { buildTransferredCharAtApplyArm } from "./char-at-transfer.js";
@@ -332,22 +333,6 @@ function externToClosureParamRef(paramType: ValType): Instr[] {
   return ops;
 }
 
-/** Preserve the structural boolean brand when an i32 crosses the externref ABI. */
-function boxI32ClosureResult(
-  ctx: CodegenContext,
-  returnType: { kind: "i32"; boolean?: true },
-  boxNumberIdx: number | undefined,
-): Instr[] {
-  const boxBooleanIdx = ctx.funcMap.get("__box_boolean");
-  if (returnType.boolean === true && boxBooleanIdx !== undefined) {
-    return [{ op: "call", funcIdx: boxBooleanIdx }];
-  }
-  if (boxNumberIdx !== undefined) {
-    return [{ op: "f64.convert_i32_s" }, { op: "call", funcIdx: boxNumberIdx }];
-  }
-  return [{ op: "drop" }, { op: "ref.null.extern" }];
-}
-
 /**
  * Emit __call_fn_<arity> export (#1382): call an N-arg WasmGC closure from
  * JS. Takes (externref closure, externref arg0, ..., externref arg<arity-1>)
@@ -550,38 +535,9 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
       { op: "call_ref", typeIdx: entry.funcTypeIdx },
     ];
 
-    // Coerce result to externref.
-    if (entry.returnType) {
-      if ((ctx.standalone || ctx.wasi) && isAnyValue(entry.returnType, ctx)) {
-        const anyToExternIdx = ensureAnyToExternHelper(ctx);
-        if (anyToExternIdx !== undefined) {
-          callBody.push({ op: "call", funcIdx: anyToExternIdx });
-        } else {
-          callBody.push({ op: "extern.convert_any" });
-        }
-      } else if (entry.returnType.kind === "ref" || entry.returnType.kind === "ref_null") {
-        callBody.push({ op: "extern.convert_any" });
-      } else if (entry.returnType.kind === "f64") {
-        if (boxNumberIdx !== undefined) {
-          callBody.push({ op: "call", funcIdx: boxNumberIdx });
-        } else {
-          callBody.push({ op: "drop" });
-          callBody.push({ op: "ref.null.extern" });
-        }
-      } else if (entry.returnType.kind === "i32") {
-        callBody.push(...boxI32ClosureResult(ctx, entry.returnType, boxNumberIdx));
-      } else if (entry.returnType.kind === "i64") {
-        if (boxNumberIdx !== undefined) {
-          callBody.push({ op: "f64.convert_i64_s" });
-          callBody.push({ op: "call", funcIdx: boxNumberIdx });
-        } else {
-          callBody.push({ op: "drop" });
-          callBody.push({ op: "ref.null.extern" });
-        }
-      }
-    } else {
-      callBody.push({ op: "ref.null.extern" });
-    }
+    // (#4082) Coerce result to externref — one shared decision, see
+    // buildClosureResultBoxing.
+    callBody.push(...buildClosureResultBoxing(ctx, entry.returnType, boxNumberIdx));
 
     funcrefDispatch = [
       { op: "local.get", index: funcLocal },
@@ -804,8 +760,16 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
   body.push({ op: "local.get", index: 0 });
   body.push({ op: "global.set", index: currentThisGlobalIdx });
 
-  const npArgs = { anyLocal, resultSaveLocal, prevThisLocal, currentThisGlobalIdx };
-  body.push(...buildTransferredNativeProtoCallInstrs(nativeProtoReceiverEntries, arity, npArgs));
+  const npArgs = {
+    anyLocal,
+    resultSaveLocal,
+    prevThisLocal,
+    currentThisGlobalIdx,
+    // (#4082) The arm must lower its callee's real result to externref, exactly
+    // as the generic dispatch arms below do.
+    boxNumberIdx,
+  };
+  body.push(...buildTransferredNativeProtoCallInstrs(ctx, nativeProtoReceiverEntries, arity, npArgs));
 
   let funcrefDispatch: Instr[] = [{ op: "ref.null.extern" }];
   // (#3673 round 10) per-entry callBody capture for the arity-bucketed
@@ -904,37 +868,8 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
       { op: "call_ref", typeIdx: entry.funcTypeIdx },
     ];
 
-    if (entry.returnType) {
-      if ((ctx.standalone || ctx.wasi) && isAnyValue(entry.returnType, ctx)) {
-        const anyToExternIdx = ensureAnyToExternHelper(ctx);
-        if (anyToExternIdx !== undefined) {
-          callBody.push({ op: "call", funcIdx: anyToExternIdx });
-        } else {
-          callBody.push({ op: "extern.convert_any" });
-        }
-      } else if (entry.returnType.kind === "ref" || entry.returnType.kind === "ref_null") {
-        callBody.push({ op: "extern.convert_any" });
-      } else if (entry.returnType.kind === "f64") {
-        if (boxNumberIdx !== undefined) {
-          callBody.push({ op: "call", funcIdx: boxNumberIdx });
-        } else {
-          callBody.push({ op: "drop" });
-          callBody.push({ op: "ref.null.extern" });
-        }
-      } else if (entry.returnType.kind === "i32") {
-        callBody.push(...boxI32ClosureResult(ctx, entry.returnType, boxNumberIdx));
-      } else if (entry.returnType.kind === "i64") {
-        if (boxNumberIdx !== undefined) {
-          callBody.push({ op: "f64.convert_i64_s" });
-          callBody.push({ op: "call", funcIdx: boxNumberIdx });
-        } else {
-          callBody.push({ op: "drop" });
-          callBody.push({ op: "ref.null.extern" });
-        }
-      }
-    } else {
-      callBody.push({ op: "ref.null.extern" });
-    }
+    // (#4082) One shared decision — see buildClosureResultBoxing.
+    callBody.push(...buildClosureResultBoxing(ctx, entry.returnType, boxNumberIdx));
 
     funcrefDispatch = [
       { op: "local.get", index: funcLocal },

--- a/src/codegen/closures/result-boxing.ts
+++ b/src/codegen/closures/result-boxing.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4082) The one place that lowers a closure `call_ref` result to the
+ * externref the `__call_fn_*` / `__call_fn_method_*` ABI returns.
+ *
+ * Every dispatch arm in that ABI has to do exactly this, and each arm used to
+ * carry its own copy of the decision — two byte-identical 30-line if-chains in
+ * `closure-exports.ts`, and, in the #3992 transferred-native-proto arm, no copy
+ * at all. That arm copied the `call_ref` and asserted the missing half in a
+ * comment instead: *"each arm pushes exactly one externref (the `call_ref`
+ * result)"*. False for any closure returning a non-reference —
+ * `RegExp.prototype.test` returns **i32**, so the arm pushed an i32 into an
+ * externref local and the module stopped validating:
+ *
+ *     __call_fn_method_0 failed:
+ *       local.set[0] expected type externref, found call_ref of type i32
+ *
+ * An invariant that exists only as prose is not an invariant. This module owns
+ * the decision so a new arm gets it by construction rather than by remembering,
+ * and it lives under `closures/` rather than in the `closure-exports` driver so
+ * both callers can import it directly (no callback plumbing, no import cycle).
+ */
+
+import type { Instr, ValType } from "../../ir/types.js";
+import type { CodegenContext } from "../context/types.js";
+import { ensureAnyToExternHelper, isAnyValue } from "../any-helpers.js";
+
+/** Preserve the structural boolean brand when an i32 crosses the externref ABI. */
+function boxI32ClosureResult(
+  ctx: CodegenContext,
+  returnType: { kind: "i32"; boolean?: true },
+  boxNumberIdx: number | undefined,
+): Instr[] {
+  const boxBooleanIdx = ctx.funcMap.get("__box_boolean");
+  if (returnType.boolean === true && boxBooleanIdx !== undefined) {
+    return [{ op: "call", funcIdx: boxBooleanIdx }];
+  }
+  if (boxNumberIdx !== undefined) {
+    return [{ op: "f64.convert_i32_s" }, { op: "call", funcIdx: boxNumberIdx }];
+  }
+  return [{ op: "drop" }, { op: "ref.null.extern" }];
+}
+
+export function buildClosureResultBoxing(
+  ctx: CodegenContext,
+  returnType: ValType | null,
+  boxNumberIdx: number | undefined,
+): Instr[] {
+  // A void closure contributes no value — the ABI still owes one externref.
+  if (!returnType) return [{ op: "ref.null.extern" }];
+  if ((ctx.standalone || ctx.wasi) && isAnyValue(returnType, ctx)) {
+    const anyToExternIdx = ensureAnyToExternHelper(ctx);
+    return anyToExternIdx !== undefined ? [{ op: "call", funcIdx: anyToExternIdx }] : [{ op: "extern.convert_any" }];
+  }
+  if (returnType.kind === "ref" || returnType.kind === "ref_null") {
+    return [{ op: "extern.convert_any" }];
+  }
+  if (returnType.kind === "f64") {
+    return boxNumberIdx !== undefined
+      ? [{ op: "call", funcIdx: boxNumberIdx }]
+      : [{ op: "drop" }, { op: "ref.null.extern" }];
+  }
+  if (returnType.kind === "i32") {
+    return boxI32ClosureResult(ctx, returnType, boxNumberIdx);
+  }
+  if (returnType.kind === "i64") {
+    return boxNumberIdx !== undefined
+      ? [{ op: "f64.convert_i64_s" }, { op: "call", funcIdx: boxNumberIdx }]
+      : [{ op: "drop" }, { op: "ref.null.extern" }];
+  }
+  // Already externref (or an ABI-compatible kind): nothing to do. Matches the
+  // previous behaviour, which fell through every branch and emitted nothing.
+  return [];
+}

--- a/src/codegen/closures/transferred-native-proto.ts
+++ b/src/codegen/closures/transferred-native-proto.ts
@@ -1,13 +1,21 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
-import type { Instr } from "../../ir/types.js";
+import type { Instr, ValType } from "../../ir/types.js";
 import type { CodegenContext } from "../context/types.js";
+import { buildClosureResultBoxing } from "./result-boxing.js";
 
 export interface TransferredNativeReceiverEntry {
   typeIdx: number;
   funcTypeIdx: number;
   /** Declared USER parameter count (closure params minus the `thisValue` slot). */
   declaredUserArity: number;
+  /**
+   * (#4082) The closure's declared result type, so this arm can lower it to the
+   * externref the `__call_fn_method_N` ABI returns. Without it the arm assumed
+   * `call_ref` already yields an externref — see the note on
+   * {@link buildTransferredNativeProtoCallInstrs}.
+   */
+  returnType: ValType | null;
 }
 
 /**
@@ -59,7 +67,12 @@ export function collectTransferredNativeProtoReceivers(
     // The shared base wrapper is also in the set but has no such field, and
     // dispatching on it would capture every structurally equal closure.
     if (!ctx.builtinFnMetaByTypeIdx?.has(typeIdx)) continue;
-    entries.push({ typeIdx, funcTypeIdx: info.funcTypeIdx, declaredUserArity: info.paramTypes.length - 1 });
+    entries.push({
+      typeIdx,
+      funcTypeIdx: info.funcTypeIdx,
+      declaredUserArity: info.paramTypes.length - 1,
+      returnType: info.returnType,
+    });
   }
   return entries;
 }
@@ -92,16 +105,33 @@ export function resolveClosureBaseWrapperTypeIdx(
  * `0` = thisVal, `1` = closure, `2 … arity+1` = the user args. `arity` is the
  * USER arity — one less than the closure's declared param count.
  *
- * Stack balance: each arm pushes exactly one externref (the `call_ref` result)
- * and immediately sinks it into `resultSaveLocal`, so the arm is stack-neutral
- * up to its own `return`; the enclosing `if` is `blockType: empty`.
+ * Stack balance: each arm pushes exactly one externref and immediately sinks it
+ * into `resultSaveLocal`, so the arm is stack-neutral up to its own `return`;
+ * the enclosing `if` is `blockType: empty`.
+ *
+ * (#4082) That externref is produced by `buildClosureResultBoxing`, NOT by
+ * `call_ref` directly.
+ * This comment used to claim the `call_ref` result *was* the externref, and the
+ * arm emitted no coercion — true only for reference-returning closures. A
+ * closure returning i32 (`RegExp.prototype.test`) pushed an i32 into the
+ * externref `resultSaveLocal` and the module failed validation:
+ * `local.set[0] expected type externref, found call_ref of type i32`. The
+ * caller supplies the same boxing every other dispatch arm in this ABI uses, so
+ * there is one decision rather than a per-arm copy.
  */
 export function buildTransferredNativeProtoCallInstrs(
+  ctx: CodegenContext,
   entries: TransferredNativeReceiverEntry[],
   arity: number,
-  slots: { anyLocal: number; resultSaveLocal: number; prevThisLocal: number; currentThisGlobalIdx: number },
+  slots: {
+    anyLocal: number;
+    resultSaveLocal: number;
+    prevThisLocal: number;
+    currentThisGlobalIdx: number;
+    boxNumberIdx: number | undefined;
+  },
 ): Instr[] {
-  const { anyLocal, resultSaveLocal, prevThisLocal, currentThisGlobalIdx } = slots;
+  const { anyLocal, resultSaveLocal, prevThisLocal, currentThisGlobalIdx, boxNumberIdx } = slots;
   const body: Instr[] = [];
   for (const entry of entries) {
     // Supplied args come from locals 2 … arity+1; any trailing slot the closure
@@ -139,6 +169,9 @@ export function buildTransferredNativeProtoCallInstrs(
               { op: "struct.get", typeIdx: entry.typeIdx, fieldIdx: 0 },
               { op: "ref.cast", typeIdx: entry.funcTypeIdx },
               { op: "call_ref", typeIdx: entry.funcTypeIdx },
+              // (#4082) Lower the callee's ACTUAL result to the ABI's externref
+              // before it reaches the externref `resultSaveLocal`.
+              ...buildClosureResultBoxing(ctx, entry.returnType, boxNumberIdx),
               { op: "local.set", index: resultSaveLocal },
               { op: "local.get", index: prevThisLocal },
               { op: "global.set", index: currentThisGlobalIdx },

--- a/tests/issue-4082-closure-result-boxing.test.ts
+++ b/tests/issue-4082-closure-result-boxing.test.ts
@@ -89,14 +89,17 @@ try { box.grab(1); } catch (e) { }
     await expect(WebAssembly.instantiate(binary, {})).resolves.toBeDefined();
   });
 
-  // KNOWN RESIDUAL, deliberately NOT asserted as correct: when the borrowed
-  // method runs on a receiver its arm's exact-identity guard does not match,
-  // the outer dispatch falls through to `ref.null.extern` and the call answers
-  // `null` instead of the boolean. That is the #3992 coverage gap this fix
-  // makes *observable* (base crashed before reaching it), not a regression —
-  // measured on `var re = /a/; re.borrowed = RegExp.prototype.test`. Asserting
-  // the wrong value here would pin the bug, so this test only records that the
-  // module is at least well-formed.
+  // KNOWN RESIDUAL — tracked as #4083, deliberately NOT asserted as correct.
+  //
+  // When the borrowed method runs on a receiver its arm's exact-identity guard
+  // does not match, the outer dispatch falls through to `ref.null.extern` and
+  // the call answers `null` instead of the boolean. That is the #3992 coverage
+  // gap this fix makes *observable* (base crashed before reaching it), not a
+  // regression — measured on `var re = /a/; re.borrowed = RegExp.prototype.test`.
+  //
+  // Asserting the wrong value here would pin the bug and manufacture exactly
+  // the vacuous pass the residual is about, so this test records only that the
+  // module is well-formed. #4083 upgrades it to `=== true` / `=== false`.
   it("a borrowed method on a regex literal receiver at least validates", async () => {
     const binary = await compileStandalone(`
 var re = /a/;

--- a/tests/issue-4082-closure-result-boxing.test.ts
+++ b/tests/issue-4082-closure-result-boxing.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #4082 — the #3992 transferred-native-proto dispatch arm in
+// `__call_fn_method_N` copied the generic arm's `call_ref` but NOT its result
+// boxing, so a borrowed native-prototype method returning a non-reference blew
+// up Wasm validation:
+//
+//     __call_fn_method_0 failed:
+//       local.set[0] expected type externref, found call_ref of type i32
+//
+// `RegExp.prototype.test` returns i32 (boolean). The arm sank the raw i32 into
+// the externref `resultSaveLocal`, the module never instantiated, and the file
+// lost 100% of its assertions.
+//
+// The missing half was asserted in a COMMENT rather than in code — the
+// function's own doc said "each arm pushes exactly one externref (the
+// `call_ref` result)", which is true only for reference-returning closures. An
+// invariant that exists only as prose is not an invariant.
+//
+// Fix: `buildClosureResultBoxing` in `closure-exports.ts` owns the
+// call_ref-result → externref decision for every arm of this ABI; the
+// transferred-native-proto arm receives it as `boxResult`.
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    deferTopLevelInit: true,
+  });
+  if (!result.success || result.errors.some((e) => e.severity === "error")) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  return result.binary;
+}
+
+async function probe(binary: Uint8Array, name: string): Promise<unknown> {
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  const exports = instance.exports as Record<string, CallableFunction>;
+  exports.__module_init?.();
+  return exports[name]!();
+}
+
+describe("#4082 — borrowed native-proto methods box their call_ref result", () => {
+  // The reduced form of test262 S15.10.6.3_A2_T1. Before the fix
+  // `WebAssembly.validate` was false and the module never instantiated.
+  it("a borrowed i32-returning proto method produces a VALID module", async () => {
+    const binary = await compileStandalone(`
+var inst = new Object();
+inst.test = RegExp.prototype.test;
+try { inst.test("message"); } catch (e) { }
+`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+    await expect(WebAssembly.instantiate(binary, {})).resolves.toBeDefined();
+  });
+
+  // Validation is not correctness. This is what the 9 flipped test262 files
+  // actually assert: calling a borrowed `RegExp.prototype.test` on a receiver
+  // that is not a RegExp must throw a *TypeError*. Verified by value — the
+  // probe returns 2 only when a genuine TypeError was caught.
+  it("throws a real TypeError on a non-RegExp receiver (value check)", async () => {
+    const binary = await compileStandalone(`
+var inst = new Object();
+inst.test = RegExp.prototype.test;
+var caught = 0;
+try {
+  inst.test("message");
+  caught = 1;            // returned instead of throwing
+} catch (e) {
+  caught = e instanceof TypeError ? 2 : 3;
+}
+export function probeCaught(): number { return caught; }
+`);
+    expect(await probe(binary, "probeCaught")).toBe(2);
+  });
+
+  // Reference-returning borrowed methods took the previously-correct path.
+  // Pin them so re-pointing the two generic arms at the shared helper cannot
+  // regress the case that already worked.
+  it("a borrowed reference-returning proto method still validates", async () => {
+    const binary = await compileStandalone(`
+var box = new String("hello");
+box.grab = String.prototype.charAt;
+try { box.grab(1); } catch (e) { }
+`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+    await expect(WebAssembly.instantiate(binary, {})).resolves.toBeDefined();
+  });
+
+  // KNOWN RESIDUAL, deliberately NOT asserted as correct: when the borrowed
+  // method runs on a receiver its arm's exact-identity guard does not match,
+  // the outer dispatch falls through to `ref.null.extern` and the call answers
+  // `null` instead of the boolean. That is the #3992 coverage gap this fix
+  // makes *observable* (base crashed before reaching it), not a regression —
+  // measured on `var re = /a/; re.borrowed = RegExp.prototype.test`. Asserting
+  // the wrong value here would pin the bug, so this test only records that the
+  // module is at least well-formed.
+  it("a borrowed method on a regex literal receiver at least validates", async () => {
+    const binary = await compileStandalone(`
+var re = /a/;
+re.borrowed = RegExp.prototype.test;
+var hit = re.borrowed("banana");
+`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #4082 **and #4081** — those are the same mechanism. I handed the
finding over mid-investigation, the lead filed it as #4081, and I then finished
the work in the same session, so the finding and the fix ended up in two issue
files. #4081 is set `done` in this PR so it cannot be dispatched to a second
agent, and its "next place to look: `closed-method-dispatch.ts`" lead is
corrected in place (that file emits no `call_ref` at all).

Third mechanism from the standalone crash cluster, after #4007 (#4077, 28
files) and #4010 (#4079, 8 files). Independent of both.

## What broke

```js
var inst = new Object();
inst.test = RegExp.prototype.test;
inst.test("message");
```

```
__call_fn_method_0 failed:
  local.set[0] expected type externref, found call_ref of type i32
```

The module never instantiates, so the file loses **100 %** of its assertions.
**12** ES5-scope standalone test262 files: 11 × `RegExp/prototype/test/
S15.10.6.3_*` plus `Object/getOwnPropertyDescriptor/15.2.3.3-4-166.js`.

## Root cause

`__call_fn_method_N` returns **externref**, so every dispatch arm has to lower
its `call_ref` result to externref. Each arm carried its own copy of that
decision: two byte-identical 30-line if-chains in `closure-exports.ts`, and —
in the #3992 transferred-native-proto arm — **no copy at all**.

That arm copied the `call_ref` and asserted the missing half in a **comment**:

> Stack balance: each arm pushes exactly one externref (the `call_ref` result)
> and immediately sinks it into `resultSaveLocal`

True only for reference-returning closures. `RegExp.prototype.test` returns
i32 (boolean), so the arm sank a raw i32 into the externref `resultSaveLocal`.
An invariant that exists only as prose is not an invariant.

### What this REFUTES

Given #4077 and #4079, the obvious hypothesis was stale metadata: the recorded
`entry.returnType` disagreeing with `entry.funcTypeIdx` (the type `call_ref`
actually uses) — especially since the collector reads the ground-truth
`funcTypeDef` for the *self* param three lines above. Traced rather than
assumed:

```
[RETTYPE] funcTypeIdx=113 recorded={"kind":"i32"} actual={"kind":"i32"}
```

**They agree.** The recorded type was correct and simply never consulted.

## The fix

Fourth instance of **#4080** in one cluster, and the sharpest: the invariant
was not merely absent from the newest copy, it was written there as a
**comment** in the copy that did not implement it.

New module **`src/codegen/closures/result-boxing.ts`** owns the
call_ref-result → externref decision. Both generic arms and the
transferred-native-proto arm import it directly.

It lives under `closures/` rather than in the `closure-exports` driver for
three reasons: no import cycle, no callback plumbing, and — because
`closure-exports.ts` is a god-file — it satisfies `check:loc-budget` by
**moving code to the subsystem module rather than taking an allowance**
(the gate's own suggested remedy). Net: `closure-exports.ts` −97 lines.

## Measurements

Baseline `test262-standalone-current.jsonl`, row timestamp **`2.8.2026, 03:32`**.
Official **43,505 run / 25,995 pass (59.75 %)**; ES5+untagged goal scope
**8,545 run / 6,298 pass (73.70 %) / 0 unopenable**.

| stage      | count | note                                                      |
| ---------- | ----: | --------------------------------------------------------- |
| population |    53 | goal-scope `invalid Wasm binary`                          |
| mechanism  |    12 | `local.set[0] expected externref, found call_ref of i32`  |
| reachable  |    12 | all compile; the crash is at instantiate                  |
| **flips**  |     9 | `runTest262File`, `--target standalone`, run **serially** |

**Kill-switch** — same 12, both touched files reverted to `HEAD`:
**12 fail / 0 pass**. With the fix: **9 pass / 3 fail**.

**Regression control** — 500 seeded baseline-`pass` goal-scope files:
**496 pass / 4 fail**; those 4 fail **identically** with the fix reverted
(3 strict-mode negative tests + one `js2wasm:runtime-eval` host-import case
`runTest262File` does not gate). **0 attributable regressions.**

## KNOWN RESIDUAL — filed as #4083 in this PR

This fix removes the crash. It does **not** make every borrowed method answer
correctly, and for one shape it trades a loud failure for a quiet one. That
trade is acceptable **because it is recorded**, and would not be if it were
absorbed — so #4083 is added by this PR rather than left in a PR body:

```js
var re = /a/;
re.borrowed = RegExp.prototype.test;
re.borrowed("banana");
```

| | result |
| --- | --- |
| base (`HEAD`) | `CompileError` — module never instantiates |
| with this PR | validates and runs, answers **`null`** |

So for that shape a crash becomes a **silently wrong value**. It is not caused
by the new boxing — a trace shows the arm selecting
`f64.convert_i32_s ; call $__box_number`, which cannot produce `null`. The
arm's exact-identity guard does not match this receiver at runtime, so the
outer dispatch falls through to its own `ref.null.extern`. That is a **#3992
coverage gap** the crash previously masked; the file's own #3992 doc block
already records `null` as that gap's symptom.

Shipping is justified by measurement, not preference: the 9 flips pass with
their **real assertions** checked — they assert a `TypeError` on a non-RegExp
receiver, and a probe confirms a genuine `TypeError` is thrown (`caught === 2`)
— and the `null` case was already broken, as a crash. Nothing regressed.

The tests deliberately do **not** assert the wrong value; pinning it would
freeze the bug and manufacture exactly the vacuous pass the residual is about.
**#4083** carries the repro, the base-vs-post-fix table, the ruled-out cause,
and acceptance criteria that require `=== true` / `=== false` **by identity**
— so a boxed number cannot satisfy it either. Its fix is to widen the #3992
arm's receiver matching, and to upgrade this PR's fourth test from
"validates" to the real value assertion.

## Tests

Four, all value-checked where a value claim is made: the reduced test262 shape
validates; the borrowed call throws a **real `TypeError`** (probe returns 2
only for a genuine TypeError); a reference-returning borrowed method still
validates (guards the two re-pointed generic arms); and the residual shape is
recorded as *well-formed only*, with no correctness claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcwPzXzbjibq9EcXMDBJAj
