### PR TITLE
docs(#4083): re-land the null residual + #4081 close dropped by the merge queue

### DIFF
--- a/plan/issues/4081-call-fn-method-early-return-arm-skips-i32-boxing.md
+++ b/plan/issues/4081-call-fn-method-early-return-arm-skips-i32-boxing.md
@@ -1,10 +1,12 @@
 ---
 id: 4081
 title: "`__call_fn_method_N` has a THIRD dispatch arm that inlines save-result/restore-`__current_this`/return without the i32 boxing the other two arms do — 12 files"
-status: ready
+status: done
 sprint: current
 created: 2026-08-02
 updated: 2026-08-02
+completed: 2026-08-02
+assignee: ttraenkler/H-crashes
 priority: high
 horizon: m
 feasibility: medium
@@ -17,6 +19,22 @@ related: [4077, 4079, 4080]
 ---
 
 # A third `__call_fn_method_N` dispatch arm skips return-type boxing
+
+> **DONE — implemented as #4082 (PR #4011). Do NOT dispatch this issue.**
+>
+> `H-crashes` handed this over mid-investigation and then finished it in the
+> same session, so the finding and the fix ended up in two issue files. This
+> one is the finding; **#4082** is the fix and carries the measurements
+> (population 53 → mechanism 12 → reachable 12 → **9 flips**; kill-switch
+> 12/12 fail; regression control 500 → 496 with 0 attributable).
+>
+> The emitting site named as "not yet identified" below **was** identified:
+> `src/codegen/closures/transferred-native-proto.ts` — the #3992
+> transferred-native-proto arm, **not** `closed-method-dispatch.ts`. See the
+> correction at the end of this file.
+>
+> #4082 also records a residual it deliberately did not fix: **#4083**, where
+> the same borrowed call now answers `null` instead of crashing.
 
 Located 2026-08-02 by the `H-crashes` agent, which **deliberately stopped short
 of implementing** because it had not finished identifying the emitting site.
@@ -79,6 +97,24 @@ all**.
 The emitter that writes it has **not** been identified. It is not either of the
 two arms above. Next place to look: **`closed-method-dispatch.ts:547`**, which
 also calls `__call_fn_method_<arity>`.
+
+### CORRECTION (resolved in #4082) — the lead above was wrong
+
+`closed-method-dispatch.ts` was the wrong place to look; it emits no `call_ref`
+at all. The arm is `buildTransferredNativeProtoCallInstrs` in
+**`src/codegen/closures/transferred-native-proto.ts`** — the #3992
+transferred-native-proto arm, reached from `closure-exports.ts` via
+`buildTransferredNativeProtoCallInstrs(...)`, not from a `closed-method`
+path. Recording the miss because a confidently-named "next place to look" is
+the kind of hint that costs the next reader an hour.
+
+Its doc block is also the sharpest evidence for #4080: the invariant it
+violates is written *in that same doc block* — *"each arm pushes exactly one
+externref (the `call_ref` result)"* — so the copy missing the type handling is
+the copy asserting its own correctness in prose.
+
+Fixed by giving the whole ABI one owner for the decision, a new subsystem
+module `src/codegen/closures/result-boxing.ts`, imported by all three arms.
 
 ## Why this matters beyond 12 files
 

--- a/plan/issues/4081-call-fn-method-early-return-arm-skips-i32-boxing.md
+++ b/plan/issues/4081-call-fn-method-early-return-arm-skips-i32-boxing.md
@@ -35,6 +35,12 @@ related: [4077, 4079, 4080]
 >
 > #4082 also records a residual it deliberately did not fix: **#4083**, where
 > the same borrowed call now answers `null` instead of crashing.
+>
+> **Permanent repro** (#2093): `tests/issue-4082-closure-result-boxing.test.ts`
+> — its first two cases are exactly the shape below, and the second asserts by
+> value that a genuine `TypeError` is thrown. Conformance repros:
+> `test262/test/built-ins/RegExp/prototype/test/S15.10.6.3_A2_T1.js` and
+> `test262/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-166.js`.
 
 Located 2026-08-02 by the `H-crashes` agent, which **deliberately stopped short
 of implementing** because it had not finished identifying the emitting site.

--- a/plan/issues/4082-closure-result-boxing.md
+++ b/plan/issues/4082-closure-result-boxing.md
@@ -34,6 +34,12 @@ S15.10.6.3_*` plus `Object/getOwnPropertyDescriptor/15.2.3.3-4-166.js`.
 Third distinct mechanism inside that one signature, after #4077 (`ref.null`
 arg mis-pairing, 28 files) and #4079 (i32-slot global `++`, 8 files).
 
+**Closes #4081 as well.** That issue is the same mechanism, filed from this
+agent's own mid-investigation handoff before it finished the work; #4081 is the
+finding, this is the fix. #4081 is set `done` here so it cannot be dispatched
+to a second agent. Its "next place to look: `closed-method-dispatch.ts`" lead
+was wrong and is corrected there.
+
 ## Root cause
 
 `__call_fn_method_N` returns **externref**. Every dispatch arm therefore has to
@@ -68,6 +74,12 @@ box correctly, via two byte-identical 30-line if-chains. So the shape is the
 same one #3989, #4077 and #4079 all had: **a decision that must hold in
 several places, duplicated rather than shared, where the newest copy is the
 one missing a case.**
+
+This is the **fourth** instance of #4080 in one cluster, and the sharpest: the
+invariant was not merely absent from the newest copy, it was written there as
+a **comment** (*"each arm pushes exactly one externref"*) in the copy that did
+not implement it. Prose cannot be checked; the other three instances at least
+failed silently rather than asserting their own correctness.
 
 ### What this refutes
 
@@ -125,7 +137,9 @@ that `runTest262File` does not gate the way the CI path does).
 
 ## KNOWN RESIDUAL — this fix removes the crash, not every wrong answer
 
-Measured and stated deliberately, because it is the uncomfortable half.
+**Tracked as #4083.** Measured and stated deliberately, because it is the
+uncomfortable half — a loud→quiet trade is acceptable when it is *recorded*,
+and unacceptable when it is absorbed.
 
 For the shape `var re = /a/; re.borrowed = RegExp.prototype.test;
 re.borrowed("banana")`:
@@ -149,9 +163,12 @@ files flip to **pass with their real assertions checked** (they assert a
 `TypeError` on a non-RegExp receiver, and the probe confirms a genuine
 `TypeError` is thrown), and there are 0 attributable regressions in 500. The
 `null` case was already broken — as a crash — so nothing regressed. The
-follow-up is to widen the #3992 arm's receiver matching; it is NOT tracked
-here and NOT asserted as correct in the tests, because pinning the wrong value
-would freeze the bug.
+follow-up — widening the #3992 arm's receiver matching — is tracked as
+**#4083**, and is NOT asserted as correct in the tests here, because pinning
+the wrong value would freeze the bug. The fourth test in
+`tests/issue-4082-closure-result-boxing.test.ts` records only that the module
+is well-formed, and is the place #4083 should upgrade to a real value
+assertion.
 
 ## Residual
 

--- a/plan/issues/4083-borrowed-proto-method-answers-null.md
+++ b/plan/issues/4083-borrowed-proto-method-answers-null.md
@@ -1,0 +1,106 @@
+---
+id: 4083
+title: "borrowed native-proto method answers `null` when the #3992 exact-identity receiver guard misses — a loud crash traded for a quiet wrong value"
+status: ready
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+goal: standalone-gap
+created: 2026-08-02
+---
+
+## Problem
+
+A native-prototype method borrowed onto a receiver that the #3992
+transferred-native-proto dispatch arm's **exact-identity guard does not match**
+returns **`null`** instead of its real value.
+
+Exact repro (standalone target):
+
+```js
+var re = /a/;
+re.borrowed = RegExp.prototype.test;
+re.borrowed("banana"); // → null, should be true
+```
+
+Measured with a probe export that distinguishes `true` / `1` / `false` / `0` /
+`undefined` / `null` by identity: the call answers **`null`** for both a
+matching and a non-matching input (`re.borrowed("zzz")` is also not `false`).
+
+A **direct** call on the same object is correct — `re.test("banana") === true`
+and `re.test("zzz") === false` — so the boxers exist and work. Only the
+borrowed path is wrong.
+
+## This was a CRASH before #4082, and is a silent wrong value after it
+
+| | `var re = /a/; re.borrowed = RegExp.prototype.test; re.borrowed("banana")` |
+| --- | --- |
+| before #4082 | `CompileError: local.set[0] expected type externref, found call_ref of type i32` — module never instantiates |
+| after #4082 | module validates and runs, answers **`null`** |
+
+So #4082 traded a **loud** failure for a **quiet** one on this shape. That is a
+real diagnosability regression and this issue exists so it is *recorded rather
+than absorbed*.
+
+It is **not** an outcome regression: the shape was already broken (as a crash),
+and no test moves from pass to fail. #4082 was shipped on that basis, together
+with 9 verified test262 flips whose real assertions were checked.
+
+## Root cause — NOT the #4082 boxing
+
+Ruled out by tracing rather than by argument. The #4082 boxing selects:
+
+```wat
+f64.convert_i32_s
+call $__box_number
+```
+
+which cannot produce `null`. The `null` comes from the **outer dispatch**: the
+#3992 arm's exact-identity guard (a `ref.test` on the per-(brand, member) META
+subtype, followed by a field-3 `bfnid` equality re-check) does not match this
+receiver at runtime, so control falls through every arm to the trailing
+`ref.null.extern`.
+
+`src/codegen/closures/transferred-native-proto.ts`'s own #3992 doc block
+already names this symptom:
+
+> had its arguments shifted one slot left (`thisValue` received `arg0`) and
+> answered a silently **WRONG** value (measured: `null`), rather than throwing.
+
+#3992 fixed that for the shapes its guard matches. This issue is the remaining
+coverage gap: the guard is too narrow, and the crash was previously masking it.
+
+## Why no test pins the current value
+
+#4082 deliberately did **not** assert `null` anywhere. A test asserting the
+wrong value would freeze the bug and manufacture exactly the vacuous pass this
+issue is about; its fourth test records only that the module is *well-formed*,
+with no correctness claim. That test is the natural place to add the real
+assertion once the guard is widened.
+
+## Acceptance criteria
+
+- `var re = /a/; re.borrowed = RegExp.prototype.test; re.borrowed("banana")`
+  answers `true`, and `re.borrowed("zzz")` answers `false` — asserted **by
+  value and by identity** (`=== true` / `=== false`, not truthiness, so a
+  number `1` does not pass).
+- The residual-shape test in `tests/issue-4082-closure-result-boxing.test.ts`
+  is upgraded from "validates" to the real value assertion.
+- No new `ref.null.extern` fallthrough is reachable for a receiver that
+  structurally carries the borrowed method.
+
+## Notes for whoever takes it
+
+- The guard lives in `collectTransferredNativeProtoReceivers` /
+  `buildTransferredNativeProtoCallInstrs`
+  (`src/codegen/closures/transferred-native-proto.ts`).
+- The collector requires BOTH `nativeProtoReceiverClosureStructTypes` and
+  `builtinFnMetaByTypeIdx` membership; the arm then re-checks field 3 against
+  the literal `typeIdx`. One of those three conditions is what a regex-literal
+  receiver fails — establish which **by measurement** before changing any of
+  them, since narrowing exists deliberately (the shared base wrapper must not
+  capture every structurally equal closure).
+- Related: #4080 (duplicated emission sequences where one copy carries the
+  type handling and another does not) — #4082 was the fourth instance.

--- a/plan/issues/4084-native-join-assumes-string-elements.md
+++ b/plan/issues/4084-native-join-assumes-string-elements.md
@@ -35,10 +35,16 @@ var x = new Array(object);
 var s = x.toString();
 ```
 
-Goal-scope population: **2** files —
-`built-ins/Array/prototype/toString/S15.4.4.2_A1_T4.js` and
-`built-ins/Array/prototype/toLocaleString/S15.4.4.3_A3_T1.js` (baseline row
-`2.8.2026, 03:32`).
+Goal-scope population: **2** files (baseline row `2.8.2026, 03:32`) — these are
+also the permanent conformance repros (#2093):
+
+- `test262/test/built-ins/Array/prototype/toString/S15.4.4.2_A1_T4.js`
+- `test262/test/built-ins/Array/prototype/toLocaleString/S15.4.4.3_A3_T1.js`
+
+Whoever lands the fix should add a `tests/issue-4084.test.ts` carrying the
+7-line repro above, asserting `WebAssembly.validate(...) === true` **and** that
+the spec `TypeError` is thrown — validation alone would not catch a wrong
+value.
 
 ## Root cause
 

--- a/plan/issues/4084-native-join-assumes-string-elements.md
+++ b/plan/issues/4084-native-join-assumes-string-elements.md
@@ -1,0 +1,134 @@
+---
+id: 4084
+title: "native-string `join` lane assumes any non-numeric element is a string ref — an object element emits an INVALID module"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+goal: standalone-gap
+created: 2026-08-02
+---
+
+## Problem
+
+`Array.prototype.toString` / `join` on an array whose elements are a
+**non-string GC ref** emits a module that **fails Wasm validation**:
+
+```
+type error in fallthru[0] (expected (ref null 6), got (ref 43))
+```
+
+`(ref null 6)` is `$AnyString`; `(ref 43)` is the element's object struct. The
+module never instantiates, so the whole file's assertions are lost.
+
+Repro — 7 lines, standalone target:
+
+```js
+var object = {
+  toString() {
+    return {};
+  },
+};
+var x = new Array(object);
+var s = x.toString();
+```
+
+Goal-scope population: **2** files —
+`built-ins/Array/prototype/toString/S15.4.4.2_A1_T4.js` and
+`built-ins/Array/prototype/toLocaleString/S15.4.4.3_A3_T1.js` (baseline row
+`2.8.2026, 03:32`).
+
+## Root cause
+
+`compileArrayJoinNative` (`src/codegen/array-methods.ts`) builds `elemToStr`
+as a four-way decision:
+
+| arm | handling |
+| --- | --- |
+| `elemIsBoolean` | `"true"` / `"false"` literal |
+| `isNumeric` | `number_toString` |
+| `externref` | `__extern_toString` |
+| **else** | **assume a string ref → `ref.as_non_null`** |
+
+That last arm is an **assumption, not a check** — its own comment says
+*"String element: a (ref null $NativeString) — non-null cast up to
+$AnyString."* For an object element it produces `(ref $Obj)` where the concat
+fold's block type is `(ref $AnyString)`.
+
+Fifth instance of #4080 in this cluster (after #3989, #4077, #4079, #4082),
+and the same sub-shape as #4082: the invariant is written as a comment in the
+arm that does not enforce it.
+
+## Fix (implemented and measured, then deliberately NOT shipped — see below)
+
+The **generic** join lane a few lines below already stringifies `ref` /
+`ref_null` elements correctly (`needsExternJoinStr` → `__extern_join_str`), so
+the fix is to state the native lane's precondition instead of assuming it and
+let a non-string ref fall through:
+
+```ts
+// gate at the native-lane branch in compileArrayJoin
+function nativeJoinHandlesElement(ctx, elemType): boolean {
+  if (elemType.kind !== "ref" && elemType.kind !== "ref_null") return true;
+  const typeIdx = elemType.typeIdx;
+  return (
+    typeIdx === ctx.anyStrTypeIdx ||
+    typeIdx === ctx.nativeStrTypeIdx ||
+    typeIdx === ctx.consStrTypeIdx ||
+    typeIdx === ctx.hashedStrTypeIdx
+  );
+}
+```
+
+Do **not** make `compileArrayJoinNative` `return null` instead — its callers
+treat `null` as a reported compile error, not as a fallback, so bailing there
+converts the crash into a compile error rather than into working code. The
+gate has to sit at the lane choice.
+
+## Measurements — the fix is safe but buys ZERO flips
+
+| check | result |
+| --- | --- |
+| repro | base: module invalid · with fix: **valid**, and the spec `TypeError` is thrown correctly |
+| the 2 goal-scope files | **0 flips** — both still fail |
+| regression control, 500 baseline-`pass` goal-scope files | **496 pass / 4 fail**; those 4 fail identically on base ⇒ **0 attributable regressions** |
+| host-import leak (see caveat) | **none** — `imports=NONE` for `string[] join`, `string[] toString`, `number[] join`, `any[] join`, `object[] join` |
+
+What the 2 files do after the fix is still instructive — the whole-module
+crash becomes two *specific* failures:
+
+- `S15.4.4.2_A1_T4` → `RuntimeError: array element access out of bounds in
+  __str_to_number()` (a deeper, separate bug)
+- `S15.4.4.3_A3_T1` → a real assertion: `n === 2. Actual: 0` (a genuine
+  `toLocaleString` semantics gap)
+
+So this is a **quiet→loud** change — the opposite direction from #4083 — but
+it is not a conformance win on its own.
+
+**Measurement caveat that matters for whoever picks this up:**
+`runTest262File` does **not** apply the #2961 host-import refusal, so a
+regression that pushed joins from the native lane onto a host-import lane
+would be **invisible** in that 500-file control. That is why the import-leak
+row above was measured separately, by compiling five array shapes in
+standalone and listing `WebAssembly.Module.imports`. Re-do that check, not
+just the runner control, if you change which lane handles joins.
+
+## Why it was not shipped
+
+The change is +4 LOC in `src/codegen/array-methods.ts`, a god-file already at
+its `check:loc-budget` ceiling (8388). Landing it needs either a
+`loc-budget-allow:` or shrinking unrelated lines. For a change with **0
+measured flips** neither is a good trade, and gaming the gate to fit is worse.
+
+Land it **for free** when someone is next editing `array-methods.ts` anyway,
+or as part of a god-file split. The predicate's natural home is
+`src/codegen/array-element-typing.ts` (which costs the one import line).
+
+## Acceptance criteria
+
+- The repro above compiles to a **valid** module.
+- `["x","y"].join(",")` and `["x","y"].toString()` still compile with
+  `imports=NONE` in standalone — i.e. string arrays keep the native lane.
+- No `loc-budget-allow:` is taken for `src/codegen/array-methods.ts`.

--- a/tests/issue-4082-closure-result-boxing.test.ts
+++ b/tests/issue-4082-closure-result-boxing.test.ts
@@ -89,14 +89,17 @@ try { box.grab(1); } catch (e) { }
     await expect(WebAssembly.instantiate(binary, {})).resolves.toBeDefined();
   });
 
-  // KNOWN RESIDUAL, deliberately NOT asserted as correct: when the borrowed
-  // method runs on a receiver its arm's exact-identity guard does not match,
-  // the outer dispatch falls through to `ref.null.extern` and the call answers
-  // `null` instead of the boolean. That is the #3992 coverage gap this fix
-  // makes *observable* (base crashed before reaching it), not a regression —
-  // measured on `var re = /a/; re.borrowed = RegExp.prototype.test`. Asserting
-  // the wrong value here would pin the bug, so this test only records that the
-  // module is at least well-formed.
+  // KNOWN RESIDUAL — tracked as #4083, deliberately NOT asserted as correct.
+  //
+  // When the borrowed method runs on a receiver its arm's exact-identity guard
+  // does not match, the outer dispatch falls through to `ref.null.extern` and
+  // the call answers `null` instead of the boolean. That is the #3992 coverage
+  // gap this fix makes *observable* (base crashed before reaching it), not a
+  // regression — measured on `var re = /a/; re.borrowed = RegExp.prototype.test`.
+  //
+  // Asserting the wrong value here would pin the bug and manufacture exactly
+  // the vacuous pass the residual is about, so this test records only that the
+  // module is well-formed. #4083 upgrades it to `=== true` / `=== false`.
   it("a borrowed method on a regex literal receiver at least validates", async () => {
     const binary = await compileStandalone(`
 var re = /a/;


### PR DESCRIPTION
Re-lands content that PR #4011 pushed but **did not merge**, and files #4084.

See "Also in this PR" at the end for #4084 — a fifth #4080 instance I measured
and then deliberately did NOT ship.

## What happened

The merge queue merged **`4e49df476` only** — the first commit on that branch.
The follow-up commit `126b226cf`, which carried the coordinator-mandated #4083
residual issue, the #4081 close, the #4082 cross-references and the test's
#4083 pointer, was pushed to the branch afterwards and never made it in.

Verified on `main`, not inferred:

```
git rev-parse c078883af^2      → 4e49df476     (the merged branch-side parent)
plan/issues/4083-*.md          → absent
plan/issues/4081-*.md status:  → ready
```

The PR reported `mergeStateStatus: BEHIND` immediately before that push, which
is why the push looked safe. It was not: the PR had already been captured by
the queue at the earlier SHA.

## Why this is urgent, not tidy-up

**#4081 describes the mechanism #4082 already fixed**, and it was sitting on
`main` as `status: ready`, unassigned, with no open PR — i.e. **dispatchable**.
Any agent picking it up would have re-implemented merged work. That is the
duplicate-dispatch hazard, arriving this time through a *partially merged PR*
rather than through two lanes racing.

## What this re-lands (unchanged from `126b226cf`)

- **`plan/issues/4083-…`** — the residual #4082 exposed. For
  `var re = /a/; re.borrowed = RegExp.prototype.test; re.borrowed("banana")`,
  base **crashes** and post-fix the module validates and answers **`null`**: a
  loud→quiet trade, acceptable only because it is recorded. The cause is the
  #3992 exact-identity receiver guard missing at runtime, **not** the new
  boxing (traced: the arm selects `f64.convert_i32_s ; call $__box_number`,
  which cannot yield null). Acceptance criteria require `=== true` /
  `=== false` **by identity**, so a boxed number `1` cannot satisfy them
  either.
- **#4081 → `status: done`** with a do-NOT-dispatch banner pointing at #4082,
  and its "next place to look: `closed-method-dispatch.ts`" lead **corrected in
  place** — that file emits no `call_ref` at all; the arm is in
  `src/codegen/closures/transferred-native-proto.ts`. I wrote that wrong lead
  myself in the handoff, so the correction belongs next to it.
- **#4082** cites #4083 and records itself as the fourth instance of #4080.
- The fourth test in `tests/issue-4082-closure-result-boxing.test.ts` names
  #4083 as the issue that upgrades it from "validates" to a real value
  assertion. It still deliberately does **not** assert the wrong value.

No source change. The only non-`plan/` file is a comment block in an existing
test.

## Process note

`mergeStateStatus == BEHIND` is **not** a reliable "not queued" signal. The
safe assumption is that a PR whose CI has gone green may already be enqueued,
so anything that MUST land has to be in the branch **before** CI turns green —
not pushed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcwPzXzbjibq9EcXMDBJAj

## Also in this PR — #4084, filed rather than shipped

The native-string `join` lane's `elemToStr` assumes "not boolean, not numeric,
not externref ⇒ it must be a string ref" and emits a bare `ref.as_non_null`.
For `new Array(objectLiteral)` that pushes `(ref $Obj)` where the concat fold
expects `(ref $AnyString)` → **invalid module**. Fifth instance of #4080; same
sub-shape as #4082 (the invariant is stated in a comment in the arm that does
not enforce it).

I implemented and measured the fix rather than only describing it:

| check | result |
| --- | --- |
| 7-line repro | base invalid → fixed **valid**, spec `TypeError` thrown correctly |
| the 2 goal-scope files | **0 flips** — the crash becomes two *specific* failures |
| 500 baseline-`pass` control | 496/4, the 4 fail identically on base ⇒ **0 attributable regressions** |
| host-import leak | **none**, verified separately (see below) |

**Not shipped.** It is +4 LOC in `array-methods.ts`, a god-file at its
`check:loc-budget` ceiling. For a **0-flip** change, taking a
`loc-budget-allow:` or shrinking unrelated lines to fit is a bad trade, and
gaming the gate is worse. #4084 records the fix, the measurements and the
traps so it lands for free next time that file is edited.

One caveat worth repeating outside the issue: **`runTest262File` does not apply
the #2961 host-import refusal**, so a regression pushing joins from the native
lane onto a host-import lane is **invisible** in a runner control. That is why
the import-leak row was measured by listing `WebAssembly.Module.imports`
directly for five array shapes, not by the 500-file run.
