### PR TITLE
docs(#4087): #4039's gate-base fix was incomplete — 5 more sites, incl. the pre-dispatch gate

### DIFF
--- a/plan/issues/4080-malformed-wasm-gate-exists-corpus-does-not-cover-it.md
+++ b/plan/issues/4080-malformed-wasm-gate-exists-corpus-does-not-cover-it.md
@@ -90,6 +90,42 @@ diff-test corpus:
 - `++`/`--` on a boolean-initialised (i32-slot) global (#4079)
 - a string `+=` into an externref slot (#3989)
 
+## ⚠ CORRECTION 2026-08-02 — the thesis above covers only HALF the family
+
+**Refuted in part by the `L-enum` lane, and the refutation is accepted.** The
+"`malformed_wasm` already catches it, the gap is only corpus coverage" claim
+holds for the instances that emit **invalid Wasm** — and **not at all** for the
+ones that emit **valid Wasm with a wrong value**.
+
+The family splits in two, and the two halves need **different instruments**:
+
+| half | instances | what would catch it |
+| --- | --- | --- |
+| **invalid Wasm**, compiler reports success | #3989, #4077, #4079, #4081 | `malformed_wasm` (#2143) — **exists**; gap is corpus coverage |
+| **valid Wasm, WRONG VALUE** | `__object_keys` (#4071), `__hasOwnProperty` (#4055), the RegExp anchoring bug in #4065 | **nothing today** — needs a value-level gc-vs-standalone differential oracle |
+
+`Object.keys([10,20,30])` returning `[]`, `hasOwnProperty` answering false for a
+property that was just written, and `^(?:a.c|zz)$` failing to match while `a.c`
+matches — all produce **perfectly valid modules**. `WebAssembly.validate` is
+`true`. A validity invariant is structurally incapable of seeing them.
+
+**So this issue's scope is now two pieces of work, not one:**
+
+1. **(as originally filed)** measure and extend the `malformed_wasm` diff-test
+   corpus, for the invalid-Wasm half.
+2. **(new, and probably the larger)** a **value-level differential oracle**:
+   run the same program through the **gc** lane and the **standalone** lane and
+   compare *results*, not validity. Every silent-wrong-answer instance above is
+   a gc/standalone divergence and would fall out of such an oracle immediately.
+
+Precedent that this is tractable: the #4065 lane already ran a **37-case
+differential against Node** (29 agree / 8 loud refusals / **0 wrong / 0 miss**)
+by hand. The proposal is to make that a standing instrument rather than a
+per-lane improvisation.
+
+**Do not size either piece from the anecdotes.** Neither corpus has been
+measured, and the one screen attempted for this family was refuted (above).
+
 ## Work — sizing FIRST, shape second
 
 1. **Measure what the `malformed_wasm` corpus actually covers.** This has

--- a/plan/issues/4087-gate-base-fix-4039-was-incomplete.md
+++ b/plan/issues/4087-gate-base-fix-4039-was-incomplete.md
@@ -1,0 +1,99 @@
+---
+id: 4087
+title: "#4039's gate-base fix was INCOMPLETE — at least 5 more scripts still hardcode `origin/main`, including `pre-dispatch-gate.mjs`, which therefore reads merged-ness from the FORK's stale main"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: infrastructure
+area: ci
+language_feature: n/a
+goal: dogfood
+related: [4002, 4039, 4045, 4080]
+---
+
+# #4039 fixed three sites and never swept for the rest
+
+Filed by the lead 2026-08-02, against **its own earlier fix**. Surfaced by the
+`H-crashes` lane hitting the symptom, then confirmed by an exhaustive sweep of
+`upstream/main`.
+
+## Background
+
+#4002/#4039 established that in an agent checkout `origin` is the **fork**
+(`ttraenkler/js2`), whose `main` lags upstream — **189 commits** as measured
+today. Any gate that diffs against `origin/main` therefore treats every commit
+upstream landed since the last fork sync as part of the branch's change-set.
+
+#4039 introduced `resolveMainRef()` in `scripts/lib/change-scope.mjs` and wired
+**three** sites: `change-scope.mjs`, `check-issue-ids.mjs`, and
+`scripts/hooks/changed-root-tests.sh`. **It never audited for other scripts
+doing their own base resolution.** That is the identical failure mode as #4080's
+family — *a correct treatment exists and consumers were never wired to it* —
+committed by the fix that was supposed to end it.
+
+## Verified on `upstream/main`
+
+Only two files reference `resolveMainRef` (`check-issue-ids.mjs`,
+`lib/change-scope.mjs`; plus the shell twin in `changed-root-tests.sh`). These
+resolve a base **independently**:
+
+| script | line | default |
+| --- | --- | --- |
+| `scripts/check-issue-spec-coverage.mjs` | 44 | `ISSUE_COVERAGE_BASE \|\| "origin/main"` |
+| `scripts/check-verdict-oracle-bump.mjs` | 164 | `VERDICT_ORACLE_BASE \|\| "origin/main"` |
+| `scripts/check-merged-issue-integrity.mjs` | — | `base-ref` default `origin/main` |
+| `scripts/check-baseline-floor-staleness.mjs` | 52 | `MAIN_REF ?? "origin/main"` |
+| `scripts/pre-dispatch-gate.mjs` | 65, 70 | `git ls-tree … origin/main` / `git show origin/main:…` |
+
+## ⚠ The `pre-dispatch-gate.mjs` case is the dangerous one
+
+That gate decides **"is this issue already done — do NOT re-implement"** by
+reading the issue file from `origin/main`:
+
+```js
+const issueOnMain = sh("git", ["ls-tree", "-r", "--name-only", "origin/main", …]);
+const body        = sh("git", ["show", `origin/main:${issueOnMain[0]}`]);
+if (status === "done" || status === "wont-fix") blockers.push(…);
+```
+
+In a fork checkout `origin/main` is stale, so an issue that **is** `done` on real
+main but whose file has not reached the fork's main **reads as not-done, and the
+gate raises no blocker**. It therefore *permits* the duplicate dispatch it exists
+to prevent — a silent false-negative in the primary defence against cross-lane
+duplicate work.
+
+This is the same shape as #4045 (a ledger answering from the wrong book) and
+#4002 (gates blaming files the branch never touched): **an instrument answering
+honestly about a different question.**
+
+## The symptom that surfaced it
+
+`check-issue-spec-coverage` **exits 0 locally and fails in CI**. Only
+`ISSUE_COVERAGE_BASE=upstream/main` reproduces the CI verdict. An agent trusting
+the green local run pushes and burns a cycle — measured today on PR #4015.
+
+## Work
+
+1. Route every script in the table through `resolveMainRef()`. Keep the existing
+   env overrides winning, exactly as #4039 did.
+2. **Then sweep for the general case rather than fixing this list** — the defect
+   here was a fix applied to known sites instead of to a searched population.
+   `grep -rn 'origin/main' scripts/ .husky/` and classify each hit as
+   *diff base* (must resolve) vs *prose/comment* (leave).
+3. Make every one of them **print the base it used**, as #4039's three do
+   (`base: merge-base(upstream-remote(origin-is-a-fork))`). A wrong base must be
+   visible, not silent.
+
+## ⚠ CI cannot regression-test this — same as #4039
+
+In Actions `origin` **is** upstream, so buggy and fixed resolvers agree there by
+construction. A CI-only test is vacuous. #4039's issue documents the
+throwaway fork-shaped-repo lab that does reproduce it; reuse that, and note its
+recorded trap: **branching the test repo from the FORK's main makes both arms
+agree** — the divergence only appears when the branch is cut from `upstream/main`,
+which is the real workflow.


### PR DESCRIPTION
One issue file, no code. **This is a defect in my own earlier fix.**

## What #4039 did, and didn't

#4002/#4039 established that `origin` is the **fork** in an agent checkout, and its `main` lags upstream — **189 commits**, measured today. #4039 introduced `resolveMainRef()` and wired **three** sites. It never swept for others.

Verified on `upstream/main` — only `check-issue-ids.mjs` and `lib/change-scope.mjs` reference the resolver. These still hardcode `origin/main` as a diff base:

| script | line | default |
| --- | --- | --- |
| `check-issue-spec-coverage.mjs` | 44 | `ISSUE_COVERAGE_BASE \|\| "origin/main"` |
| `check-verdict-oracle-bump.mjs` | 164 | `VERDICT_ORACLE_BASE \|\| "origin/main"` |
| `check-merged-issue-integrity.mjs` | — | base-ref default `origin/main` |
| `check-baseline-floor-staleness.mjs` | 52 | `MAIN_REF ?? "origin/main"` |
| `pre-dispatch-gate.mjs` | 65, 70 | `ls-tree` / `show` against `origin/main` |

## ⚠ The pre-dispatch gate is the dangerous one

It decides **"is this issue already done — do NOT re-implement"** by reading the issue file from `origin/main`. In a fork checkout that tree is stale, so an issue that **is** `done` on real main but whose file hasn't reached the fork's main **reads as not-done and the gate raises no blocker.**

It therefore *permits* the duplicate dispatch it exists to prevent — a silent false-negative in the primary defence against cross-lane duplicate work. Same shape as #4045 (a ledger answering from the wrong book) and #4002 itself: **an instrument answering honestly about a different question.**

## How it surfaced

A lane hit the symptom: `check-issue-spec-coverage` **exits 0 locally and fails in CI**; only `ISSUE_COVERAGE_BASE=upstream/main` reproduces the CI verdict. An agent trusting the green local run pushes and burns a cycle — measured on PR #4015.

## What the issue asks for

Not "fix these five". The defect *was* fixing known sites instead of a searched population, so:

1. Route the table through `resolveMainRef()`, env overrides still winning.
2. **Then** `grep -rn 'origin/main' scripts/ .husky/` and classify every hit as *diff base* (must resolve) vs *prose* (leave).
3. Make each site **print the base it used**, as #4039's three do — a wrong base must be visible, not silent.

It also carries #4039's recorded lab trap: **branching the test repo from the FORK's main makes both arms agree**, so the divergence only appears when the branch is cut from `upstream/main`. CI cannot regression-test this at all — in Actions `origin` *is* upstream, so both resolvers agree by construction.

## Verification

Gates run **the way CI runs them**, not the way they run by default: `ISSUE_COVERAGE_BASE=upstream/main check:issue-spec-coverage`, `check:issues`, `check:issue-ids:against-main`, `prettier` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcwPzXzbjibq9EcXMDBJAj