### PR TITLE
fix(#4085): standalone JSON.stringify serialises real arrays instead of `null`

### DIFF
--- a/plan/issues/4085-standalone-json-stringify-null-for-arrays.md
+++ b/plan/issues/4085-standalone-json-stringify-null-for-arrays.md
@@ -1,10 +1,12 @@
 ---
 id: 4085
 title: "JSON.stringify emits the literal `null` for every non-empty array, class instance and object-holding-an-array in standalone — silently corrupt output"
-status: ready
+status: done
 sprint: current
 created: 2026-08-02
 updated: 2026-08-02
+completed: 2026-08-02
+assignee: ttraenkler/L-enum
 priority: high
 horizon: m
 feasibility: medium
@@ -14,6 +16,18 @@ area: standalone
 language_feature: json
 goal: standalone-mode
 related: [4071, 4080, 2166]
+# The arm must live in the emitter that builds `__json_stringify_value`, beside
+# the `$Object` / `$ObjVec` / `$AnyString` arms it is one more case of, and it
+# re-points the shared `L_ANY` local so the existing `$ObjVec` arm runs. Hoisting
+# it to another module would separate a switch case from its switch. The
+# alternative — duplicating the ~120-instruction array arm — is the duplication
+# habit that produced this whole defect family.
+loc-budget-allow:
+  - src/codegen/json-codec-native.ts
+# Same rationale: the normalisation is one more case in this function's own
+# receiver-type ladder and re-points its `L_ANY` local.
+func-budget-allow:
+  - src/codegen/json-codec-native.ts::emitJsonStringifyValue
 ---
 
 # `JSON.stringify` returns `"null"` for ordinary arrays in standalone
@@ -88,3 +102,71 @@ oracle (gc lane vs standalone lane on the same input), not a validity check.
    baseline, denominator stated. Report flips, not file counts.
 5. Empty array / literal plain object (the two shapes that work today) must not
    regress.
+
+---
+
+## Test Results (2026-08-02, `ttraenkler/L-enum`)
+
+### Fix
+
+Normalise a `$__vec_base` receiver into a `$ObjVec` (elements read via
+`__extern_get_idx`, already vec-aware since #2190), then fall into the
+**existing, untouched** `$ObjVec` array arm. This reuses ~120 instructions of
+element / replacer / indent / toJSON logic instead of duplicating it into a
+second copy that would have to be kept in sync — the duplication habit is what
+produced this family of defects in the first place.
+
+Inserted AFTER the `$Object` test and BEFORE the `$ObjVec` test; a `__vec_<k>`
+struct is not a `$Object`, so the earlier arm cannot claim it.
+
+### Per-shape before/after (in-Wasm comparison against the spec-correct literal)
+
+| input | expected | gc | standalone BEFORE | standalone AFTER |
+| --- | --- | --- | --- | --- |
+| `[10,20,30]` | `[10,20,30]` | ok | **`null`** | **ok** |
+| `[[1],[2]]` | `[[1],[2]]` | ok | wrong | **ok** |
+| `["a","b"]` | `["a","b"]` | ok | wrong | **ok** |
+| `{a:[1,2]}` | `{"a":[1,2]}` | ok | wrong | **ok** |
+| `[true,false,null]` | `[true,false,null]` | ok | wrong | **ok** |
+| `[]` | `[]` | ok | ok | ok (no regression) |
+| `{a:1,b:2}` | `{"a":1,"b":2}` | ok | ok | ok (no regression) |
+| `new C()` (class inst.) | `{"a":1,"b":2}` | ok | wrong | **still wrong** |
+| `o={}; o.p=1; o.q=2` | `{"p":1,"q":2}` | ok | wrong | **still wrong** |
+
+### test262 flips: **NET ZERO** — stated plainly, not buried
+
+| stage | count |
+| --- | --- |
+| 1 population (corpus mentions `JSON.stringify`) | 155 |
+| 2a present in standalone baseline | 84 (unopenable / absent: 71) |
+| 2b not passing today | 62 |
+| 3 swept before + after (force-refreshed baseline) | **84** |
+| 4 **flips** | **+0 / −0 = net 0** |
+
+Before-state of the 84 swept: 22 `pass`, 32 `fail`, 20 `compile_error`, 10 `skip`.
+
+**This is a real result, not a broken instrument.** Positive control: the *same*
+sweep harness and code path measured +3/−2 on the `Object.keys` population for
+#4071, so it demonstrably detects flips. The 52 non-passing files here fail for
+reasons this fix does not touch — 20 of them do not even compile.
+
+So: a genuine silent-corruption fix for ordinary user code that moves the
+conformance number by **zero**. Shipped on correctness grounds, with the number
+reported as-is rather than dressed up. Also worth noting the inverse of the usual
+worry — **zero regressions**, including both shapes that already worked.
+
+### Deliberately NOT shipped
+
+**The closed-struct half** (class instances, assignment-built objects). Same
+carrier class whose closed-struct arms leak BUILTIN internals — see #4086, where
+extending exactly that mechanism made `Object.keys(/ab/)` report 7 internal
+RegExp fields. A JSON closed-struct arm would serialise those same internals into
+user-visible output. It needs #4086's user-declared-vs-builtin struct predicate
+first.
+
+### Known deviation
+
+Inside the array arm, `holder` passed to a function `replacer` is the normalised
+`$ObjVec` rather than the original array object. Observable only via `this` in a
+replacer over an array; the entire value previously serialised as `null`, so this
+is strictly an improvement.

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -51,7 +51,7 @@ import {
 } from "./native-strings.js";
 import { ensureObjectRuntime, OBJ_FLAG_RAWJSON } from "./object-runtime.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
-import { addFuncType } from "./registry/types.js";
+import { addFuncType, getOrRegisterVecBaseType } from "./registry/types.js";
 import { emitJsonQuoteString } from "./json-runtime.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
@@ -160,6 +160,19 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
   const objVecTypeIdx = objTypes.objVecTypeIdx;
   const objVecArrTypeIdx = objTypes.objVecArrTypeIdx;
 
+  // (#4085) A real standalone JS array is a `__vec_<elemKind>` struct subtyping
+  // `$__vec_base` (#2186). `$ObjVec` is the enumeration-RESULT vector — a
+  // DIFFERENT type — so the value dispatch below matched NO arm for an ordinary
+  // array and fell through to "unsupported ref", rendering the JSON literal
+  // `null` for `JSON.stringify([10,20,30])`. These four let the ladder normalise
+  // a vec receiver into a `$ObjVec` and then reuse the existing array arm
+  // verbatim, rather than duplicating ~120 instructions of element / replacer /
+  // indent logic that would then have to be kept in sync.
+  const vecBaseIdx = getOrRegisterVecBaseType(ctx);
+  const objVecNewIdx = ctx.funcMap.get("__objvec_new");
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push");
+  const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx");
+
   const i32: ValType = { kind: "i32" };
   const f64: ValType = { kind: "f64" };
   const anyref: ValType = { kind: "anyref" };
@@ -239,6 +252,13 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
   const L_TJM = 23; // externref — the toJSON method looked up on the value
   const L_CHILDV = 24; // anyref — child value after replacer transform (recursion arg)
   const L_CKEY = 25; // externref — current child key (object/array arms)
+  // (#4085) `$__vec_base` → `$ObjVec` normalisation scratch. Dedicated locals
+  // rather than reusing L_CAP/L_I: normalisation runs BEFORE the array arm,
+  // which re-initialises those, but keeping them separate makes the two loops
+  // independently readable and immune to a future reordering of the ladder.
+  const L_VB = 26; // externref — the normalised $ObjVec built from a vec receiver
+  const L_VBLEN = 27; // i32 — vec length
+  const L_VBI = 28; // i32 — normalisation loop index
 
   const litStr = (s: string): Instr[] => nativeStringLiteralInstrs(ctx, s);
 
@@ -876,6 +896,73 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
       blockType: { kind: "empty" },
       then: objectArm,
     },
+    // (#4085) $__vec_base (a REAL JS array) → normalise to $ObjVec, then fall
+    // into the $ObjVec arm below. Elements are read through `__extern_get_idx`,
+    // which is already `$__vec_base`-aware (#2190) and handles every element
+    // kind (f64 / i32 / externref / …), so this needs no per-elemKind cases.
+    //
+    // Ordering: this sits AFTER the `$Object` test and BEFORE the `$ObjVec`
+    // test. A `__vec_<k>` struct is not a `$Object`, so the earlier arm cannot
+    // claim it; re-pointing L_ANY here is what lets the untouched `$ObjVec` arm
+    // do the actual serialisation.
+    //
+    // Known deviation: inside the arm, `holder` for a function `replacer` is the
+    // normalised $ObjVec rather than the original array object. Only observable
+    // via `this` in a replacer over an array; today the entire value serialises
+    // as `null`, so this is strictly an improvement. Noted in #4085.
+    ...(objVecNewIdx !== undefined && objVecPushIdx !== undefined && externGetIdxIdx !== undefined
+      ? ([
+          { op: "local.get", index: L_ANY },
+          { op: "ref.test", typeIdx: vecBaseIdx },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "call", funcIdx: objVecNewIdx },
+              { op: "local.set", index: L_VB },
+              { op: "local.get", index: L_ANY },
+              { op: "ref.cast", typeIdx: vecBaseIdx },
+              { op: "struct.get", typeIdx: vecBaseIdx, fieldIdx: 0 }, // len
+              { op: "local.set", index: L_VBLEN },
+              { op: "i32.const", value: 0 },
+              { op: "local.set", index: L_VBI },
+              {
+                op: "block",
+                blockType: { kind: "empty" },
+                body: [
+                  {
+                    op: "loop",
+                    blockType: { kind: "empty" },
+                    body: [
+                      { op: "local.get", index: L_VBI },
+                      { op: "local.get", index: L_VBLEN },
+                      { op: "i32.ge_s" },
+                      { op: "br_if", depth: 1 },
+                      // __objvec_push(out, __extern_get_idx(vec, f64(i)))
+                      { op: "local.get", index: L_VB },
+                      { op: "local.get", index: L_ANY },
+                      { op: "extern.convert_any" },
+                      { op: "local.get", index: L_VBI },
+                      { op: "f64.convert_i32_s" },
+                      { op: "call", funcIdx: externGetIdxIdx },
+                      { op: "call", funcIdx: objVecPushIdx },
+                      { op: "local.get", index: L_VBI },
+                      { op: "i32.const", value: 1 },
+                      { op: "i32.add" },
+                      { op: "local.set", index: L_VBI },
+                      { op: "br", depth: 0 },
+                    ],
+                  },
+                ],
+              },
+              // Re-point the tested value at the $ObjVec so the arm below runs.
+              { op: "local.get", index: L_VB },
+              { op: "any.convert_extern" },
+              { op: "local.set", index: L_ANY },
+            ],
+          },
+        ] satisfies Instr[])
+      : []),
     // $ObjVec?
     { op: "local.get", index: L_ANY },
     { op: "ref.test", typeIdx: objVecTypeIdx },
@@ -993,6 +1080,9 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
       { count: 1, type: { kind: "externref" } }, // L_TJM   (#2166 PR-D2)
       { count: 1, type: anyref }, // L_CHILDV (#2166 PR-D3)
       { count: 1, type: { kind: "externref" } }, // L_CKEY (#2166 PR-D3)
+      { count: 1, type: { kind: "externref" } }, // L_VB (#4085)
+      { count: 1, type: i32 }, // L_VBLEN (#4085)
+      { count: 1, type: i32 }, // L_VBI (#4085)
     ],
     // (#2166 PR-D2) Deep-clone so every `call`/operand occurrence is an
     // INDEPENDENT object. The body spreads shared helper `Instr[]` arrays

--- a/tests/issue-4085.test.ts
+++ b/tests/issue-4085.test.ts
@@ -1,0 +1,89 @@
+/**
+ * #4085 — `JSON.stringify` emitted the literal `null` for ordinary arrays in
+ * standalone.
+ *
+ * `json-codec-native.ts`'s value dispatch ref-tests `$Object`, `$ObjVec`,
+ * `$AnyString`, the boxed primitives and `$AnyValue`. A real standalone JS array
+ * is a `__vec_<elemKind>` struct subtyping `$__vec_base` (#2186), and `$ObjVec`
+ * is the enumeration-RESULT vector — a DIFFERENT type. So an ordinary array
+ * matched no arm, fell through to "unsupported ref ⇒ undefined serialisation",
+ * and the root arm rendered the JSON literal `null`:
+ *
+ *   JSON.stringify([10, 20, 30])   // was "null", spec says "[10,20,30]"
+ *
+ * That is silently CORRUPT OUTPUT for ordinary user code — no compile error, no
+ * host-import leak, nothing downstream can detect it. Only an EMPTY array and a
+ * LITERAL plain object serialised correctly, i.e. exactly the two shapes a smoke
+ * test is most likely to try.
+ *
+ * Fix: normalise a `$__vec_base` receiver into a `$ObjVec` (elements read via
+ * `__extern_get_idx`, already vec-aware since #2190) and reuse the EXISTING
+ * array arm, instead of duplicating its element/replacer/indent logic.
+ *
+ * Results are compared IN-WASM against the spec-correct literal so no native
+ * string crosses the boundary.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile standalone, assert ZERO env imports, instantiate import-free, run test(). */
+async function runHostFree(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "t.ts", target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("; ")).toBe(true);
+  if (!r.success) return undefined;
+  const envImports = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+  expect(envImports, `unexpected env imports: ${envImports.join(",")}`).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const exports = instance.exports as Record<string, unknown> & { test?: () => unknown; _start?: () => void };
+  exports._start?.();
+  return exports.test?.();
+}
+
+/** 1 iff `JSON.stringify(<carrier>)` equals `want` exactly, compared in-Wasm. */
+async function stringifiesTo(carrier: string, want: string): Promise<unknown> {
+  return runHostFree(
+    `export function test(): number {
+       ${carrier}
+       const s: any = JSON.stringify(v);
+       return s === ${JSON.stringify(want)} ? 1 : 0;
+     }`,
+  );
+}
+
+describe("#4085 standalone JSON.stringify over vec carriers", () => {
+  it("serialises a number array", async () => {
+    expect(await stringifiesTo(`const v: any = [10,20,30];`, `[10,20,30]`)).toBe(1);
+  });
+
+  it("serialises a string array (elements quoted)", async () => {
+    expect(await stringifiesTo(`const v: any = ["a","b"];`, `["a","b"]`)).toBe(1);
+  });
+
+  it("serialises nested arrays (recursion re-enters the vec arm)", async () => {
+    expect(await stringifiesTo(`const v: any = [[1],[2]];`, `[[1],[2]]`)).toBe(1);
+  });
+
+  it("serialises an array held by an object (recursion from the object arm)", async () => {
+    expect(await stringifiesTo(`const v: any = {a:[1,2]};`, `{"a":[1,2]}`)).toBe(1);
+  });
+
+  it("serialises a boolean/null mix", async () => {
+    expect(await stringifiesTo(`const v: any = [true,false,null];`, `[true,false,null]`)).toBe(1);
+  });
+
+  it("empty array still serialises (no regression)", async () => {
+    // One of only two shapes that worked before the fix — guard it explicitly.
+    expect(await stringifiesTo(`const v: any = [];`, `[]`)).toBe(1);
+  });
+
+  it("literal plain object still serialises (no regression)", async () => {
+    // The other pre-fix working shape.
+    expect(await stringifiesTo(`const v: any = {a:1,b:2};`, `{"a":1,"b":2}`)).toBe(1);
+  });
+
+  it("a nested empty array is not confused with the null render", async () => {
+    // `[[]]` vs the old failure mode `null` / `[null]` — distinguishes "fixed"
+    // from "still rendering the undefined-serialisation sentinel".
+    expect(await stringifiesTo(`const v: any = [[]];`, `[[]]`)).toBe(1);
+  });
+});


### PR DESCRIPTION
## In standalone, `JSON.stringify` silently returns the literal `null` for most real values

```js
JSON.stringify([10, 20, 30]); // "null"   — spec: "[10,20,30]"
JSON.stringify(["a", "b"]);   // "null"
JSON.stringify([[1], [2]]);   // "null"
JSON.stringify({ a: [1, 2] }); // wrong   — the nested array poisons the object
```

**Only an empty array and a literal plain object survive** — precisely the two shapes a smoke test is most likely to try, which is why this went unnoticed.

This is **corrupt output for ordinary user code**, not a spec-corner failure and not a refusal: no compile error, no host-import leak, nothing downstream can detect it. Serialised output is the kind of thing that gets stored or transmitted, so a wrong answer here propagates.

Fixes #4085.

## Root cause — the same "one consumer never wired up" pattern

`json-codec-native.ts`'s value dispatch ref-tests `$Object`, `$ObjVec`, `$AnyString`, the boxed primitives and `$AnyValue` — and **never `$__vec_base`**. A real standalone array is a `__vec_<elemKind>` struct subtyping `$__vec_base` (#2186); `$ObjVec` is the enumeration-**result** vector, a different type. So an ordinary array matched no arm, fell through to "unsupported ref ⇒ undefined serialisation", and the root arm renders that as `null`.

The array-serialisation logic **already existed and was correct** — written against `$ObjVec`. The user-array carrier was simply never routed to it. Same shape as #4071, #3989, #4077, #4079, #4081.

## Fix

Normalise a `$__vec_base` receiver into a `$ObjVec` (elements via `__extern_get_idx`, vec-aware since #2190), then fall into the **existing array arm, untouched**. This reuses ~120 instructions of element / replacer / indent / toJSON logic instead of forking a second copy that would have to be kept in sync — every instance in this defect family is a second copy that drifted from the first.

## Measurement — net 0 test262 flips, stated undressed

| stage | count |
| --- | --- |
| 1 population (corpus mentions `JSON.stringify`) | 155 |
| 2a in force-refreshed standalone baseline | 84 (unopenable 71) |
| 2b not passing today | 62 |
| 3 swept before + after | **84** |
| 4 **flips** | **+0 / −0 = net 0** |

Before-state of the 84: 22 `pass`, 32 `fail`, 20 `compile_error`, 10 `skip`.

**Net 0 is a real result, not a broken instrument.** Positive control: the *same* sweep harness and code path measured +3/−2 on #4071's population, so it demonstrably detects flips. The 52 non-passing files here fail for reasons this does not touch — 20 do not even compile. Attribution by kill-switch removal (file-copy revert, never `git stash`).

The conformance number is a **proxy** for correctness, not the objective: zero flips means test262 does not happen to exercise these shapes, not that the fix has no value. **Zero regressions**, including both shapes that already worked.

Per-shape before/after, compared in-Wasm against the spec-correct literal with the `gc` lane as control: number / string / nested arrays, boolean-null mixes and objects-holding-arrays all go wrong → correct; `[]` and `{a:1,b:2}` unchanged.

## What I deliberately did NOT ship

**The closed-struct half** — class instances and assignment-built objects still serialise wrong. Same carrier class whose closed-struct arms leak **builtin internals**: in #4071, extending exactly that mechanism made `Object.keys(/ab/)` report 7 internal RegExp fields. A JSON version would embed those internals in output a user might store or transmit. It needs #4086's user-declared-vs-builtin struct predicate first (filed, claimed).

## Known deviation

Inside the array arm, `holder` passed to a function `replacer` is the normalised `$ObjVec` rather than the original array. Observable only via `this` in a replacer over an array; the whole value previously serialised as `null`, so this is strictly an improvement. Documented in the issue and in-code.

## Test plan

`tests/issue-4085.test.ts` — 8 host-free standalone tests (assert zero `env` imports, instantiate import-free), compared in-Wasm so no native string crosses the boundary. Includes both pre-existing working shapes as explicit non-regression guards, and `[[]]` to distinguish "fixed" from "still rendering the undefined sentinel".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
