### PR TITLE
fix(#4089): RegExp constructor arguments go through ToString

### DIFF
--- a/plan/issues/4089-regexp-ctor-args-need-tostring.md
+++ b/plan/issues/4089-regexp-ctor-args-need-tostring.md
@@ -1,0 +1,168 @@
+---
+id: 4089
+title: "dynamic `new RegExp(pattern, flags)` casts its arguments instead of calling ToString — an object argument null-derefs and kills the module"
+status: done
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+goal: standalone-gap
+assignee: ttraenkler/H-crashes
+created: 2026-08-02
+completed: 2026-08-02
+# RETIRE THIS ALLOWANCE IN #4067 (godfile-split: regexp-standalone engine vs
+# bridge). It is paid for by 13 measured flips, and it is NOT permanent: the
+# split moves `emitArgAsNativeString` out of the god-file and lets the second
+# ToString site (`emitRegexSearchCall`) be deduped against it, at which point
+# this line should be deleted rather than re-baselined.
+loc-budget-allow:
+  - src/codegen/regexp-standalone.ts
+---
+
+## Problem
+
+In standalone mode, a `new RegExp(...)` whose **flags** (or pattern) argument
+is an object traps during top-level evaluation:
+
+```js
+new RegExp("abc{1}", { toString() { return ""; } });
+// → RuntimeError: dereferencing a null pointer in __module_init()
+```
+
+`__module_init` dies, so the file loses **100 %** of its assertions.
+
+Bisected — the object argument is the whole trigger:
+
+| repro | result |
+| --- | --- |
+| `new RegExp("abc{1}", "")` | OK (control) |
+| `new RegExp("abc{1}", {toString(){return ""}})` | **null-pointer deref** |
+
+## Root cause
+
+`compileStandaloneRegExpNew` (`src/codegen/regexp-standalone.ts`) compiled each
+dynamic argument **with a native-string expectation and then `coerceType`d it**:
+
+```ts
+const emitted = compileExpression(ctx, fctx, flagsArg!, strType);
+if (emitted.kind !== "ref" || emitted.typeIdx !== ctx.anyStrTypeIdx) {
+  coerceType(ctx, fctx, emitted, strType, "string", compileStringLiteral);
+}
+```
+
+For a string that is the same thing. For an **object** it is not a conversion
+at all — §22.2.3.1 steps 5/7 require **ToString**, which must call the object's
+own `toString()`. The emitted cast dereferenced a null instead.
+
+The correct conversion already existed **in the same file**:
+`emitRegexSearchCall` routes every `.test`/`.exec` subject through the runtime
+`__extern_toString` (#3724). Two call sites needed the identical conversion and
+only one had it — the recurring #4080 shape — so this extracts
+`emitArgAsNativeString` as the single owner and the constructor now uses it.
+
+### #4080 is now PREDICTIVE, not just retrospective
+
+This is the sixth instance in one cluster (#3989, #4077, #4079, #4082, #4084,
+this), and the distinction worth recording is that #4080 stopped being a
+post-hoc label and started **finding** things:
+
+| # | shape | how it was found |
+| --- | --- | --- |
+| #3989 | store half of a slot-type pair not updated with the load | reported |
+| #4077 | arg↔param pairing re-derived instead of read | root-caused |
+| #4079 | 8 copies of read/±1/store, all missing `i32` | root-caused |
+| #4082 | third dispatch arm copied the `call_ref`, not the boxing | root-caused |
+| #4084 | `elemToStr`'s last arm assumes "must be a string ref" | **predicted** |
+| #4089 | second ToString site missing the conversion the first has | **predicted** |
+
+For the last two the pattern came first: "look for a decision that must hold in
+several places, where the newest copy is the one missing a case, and where the
+invariant is stated in a **comment** rather than enforced." Both were then
+confirmed by measurement. Six retrospective examples argue that #4080 is real;
+two predictions argue it is *useful*, which is the stronger case for funding a
+standing gate.
+
+## Verified before relying on it
+
+Reusing `__extern_toString` would be worthless if it did not honour a
+user-defined `toString`, so that was measured first, not assumed:
+
+```js
+String({ toString() { return "ZZ"; } })   // → "ZZ"   (probe returns 1)
+"" + { toString() { return "ZZ"; } }      // → "ZZ"   (probe returns 1)
+```
+
+It does. So this is a spec-correct conversion, **not** a crash-traded-for-a-
+wrong-value (the #4083 hazard).
+
+## Measurements
+
+Baseline `test262-standalone-current.jsonl`, row timestamp `2.8.2026, 03:32` ·
+official 43,505 run / 25,995 pass (59.75 %) · ES5+untagged goal scope 8,545 run
+/ 6,298 pass (73.70 %) / 0 unopenable.
+
+| stage      | count | note                                                       |
+| ---------- | ----: | ---------------------------------------------------------- |
+| population |    84 | goal-scope `illegal cast` / `null deref` in `__module_init` |
+| mechanism  |    21 | the `built-ins/RegExp` sub-group                           |
+| reachable  |    21 | all compile; the trap is at top-level evaluation           |
+| **flips**  |    13 | `runTest262File`, `--target standalone`, run **serially**  |
+
+**Kill-switch control** — same 21 files, same runner, `regexp-standalone.ts`
+reverted to its `HEAD` version: **21 fail / 0 pass**. With the fix:
+**13 pass / 8 fail**.
+
+The 8 residuals hit the dynamic-engine pattern subset
+(`Unsupported dynamic regular expression pattern`, a catchable TypeError) —
+e.g. `abc{1}` needs `{n}` quantifier support in
+`__regex_compile_dynamic_simple`. That is the regexp-engine lever, a different
+issue, and explicitly out of scope here.
+
+## Why this bucket is smaller than it looks (context for #4080 / triage)
+
+While scoping this I classified where each of the 84 crash-bucket files
+actually crashes:
+
+| | count |
+| --- | ---: |
+| crash while building `throw new Test262Error(...)` — **downstream of an already-failed assertion** | 50 |
+| crash at an `assert.*` line (ambiguous) | 30 |
+| no source line in the error | 4 |
+
+For those **50**, the test had already decided it failed. Fixing the crash
+converts an opaque trap into a proper `Test262Error` — real diagnosability, and
+**zero** conformance gain. So "84 crash files" is **not** 84 potential flips.
+This RegExp sub-group was worth doing precisely because it was disambiguated by
+probe and shown to crash in *construction*, upstream of every assertion.
+
+## LOC-budget allowance — deliberate, and narrower than it looks
+
+`src/codegen/regexp-standalone.ts` is a god-file at its ceiling and this adds
+~40 lines, so the change-set takes a `loc-budget-allow:` above.
+
+The alternatives were tried first and rejected on their merits:
+
+- **Move the helper to a subsystem module.** `src/codegen/regex/` holds
+  engine-only code (bytecode/compile/parse) and this is a *codegen bridge*
+  (it needs `compileExpression` + `coerceType`); `shared.ts` is a
+  delegate-registry that exists to break import cycles, not a home for emission
+  logic. Either would have imported codegen-context deps into the wrong layer
+  to satisfy a line count.
+- **Dedupe by refactoring `emitRegexSearchCall`'s inline copy** to call the new
+  helper. That would pay for the growth, but the search-call site has a subtle
+  path the helper does not reproduce: when `compileExpression` returns `null` it
+  does **not** bail — it still calls `__extern_toString`. Silently changing that
+  under a 13-flip fix is the wrong risk to bundle.
+
+This is **not** the #4084 precedent. There the same gate blocked a **0-flip**
+change and taking an allowance would have been a bad trade, so it was filed
+unshipped instead. Here the trade is 13 measured flips against ~40 lines in a
+file already slated for splitting under **#4067** — which is the natural place
+to retire this allowance and dedupe the two ToString sites together.
+
+## Test
+
+`tests/issue-4089-regexp-ctor-tostring.test.ts` — the object-flags repro
+validates, instantiates and **runs** `__module_init` without trapping, and the
+string-flags control still works. Asserted by value, not just by validation.

--- a/plan/issues/4089-regexp-ctor-args-need-tostring.md
+++ b/plan/issues/4089-regexp-ctor-args-need-tostring.md
@@ -119,6 +119,31 @@ e.g. `abc{1}` needs `{n}` quantifier support in
 `__regex_compile_dynamic_simple`. That is the regexp-engine lever, a different
 issue, and explicitly out of scope here.
 
+## The coercion-site gate caught a second hand-rolled site — and it was right
+
+The first cut of this fix failed `quality` on the **coercion-site drift gate**
+(#2108/#3131/#3279): `regexp-standalone.ts: 2 → 4 (__extern_toString 2→4)`.
+My helper had its own `ensureLateImport` + `funcMap` lookup, duplicating the
+one already in `emitRegexSearchCall`.
+
+That gate offers a `coercion-sites-allow:` escape, and taking it would have
+meant **two allowances in one PR** — exactly the trade this issue argues
+against. It was also diagnosing the real defect: two hand-rolled ToString
+lookups is precisely how these two paths drifted apart in the first place,
+with only one of them actually applying ToString.
+
+Fixed properly instead: `ensureRuntimeToStringIdx` is now the single resolver
+and **both** paths call it. No allowance taken; the gate passes with no net
+vocabulary growth.
+
+Note this is the dedupe I explicitly declined earlier in this issue — but only
+the *lookup*, not the surrounding control flow. `emitRegexSearchCall` keeps its
+own compile/coerce sequence, including the subtle path where a `null` from
+`compileExpression` does **not** bail. Verified by running the existing
+standalone regex suites: **238 tests pass**
+(`issue-1539-standalone-regex`, `-replace`, `issue-2161-regex-const-ctor`,
+`issue-1474-standalone-regex-refuse`).
+
 ## Why this bucket is smaller than it looks (context for #4080 / triage)
 
 While scoping this I classified where each of the 84 crash-bucket files

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -807,6 +807,53 @@ export function ensureStandaloneRegExpStruct(ctx: CodegenContext): number {
 }
 
 /**
+ * (#4089) Compile `expr` and leave a native `$AnyString` on the stack, applying
+ * the SPEC's ToString — i.e. an object argument gets its own `toString()`
+ * called, per §7.1.17.
+ *
+ * This is the conversion `emitRegexSearchCall` has always done for a `.test`/
+ * `.exec` SUBJECT (#3724). The dynamic `new RegExp(pattern, flags)` path did
+ * something different: it compiled the argument with a native-string
+ * expectation and then `coerceType`d it. For a string that is the same thing;
+ * for an OBJECT it is not a conversion at all, and the emitted cast dereferenced
+ * a null at runtime:
+ *
+ *     new RegExp("abc{1}", { toString() { return ""; } })
+ *       → RuntimeError: dereferencing a null pointer in __module_init()
+ *
+ * which kills the module during top-level evaluation, so the whole file's
+ * assertions are lost. Two call sites needed the identical conversion and only
+ * one had it — the recurring shape of #4080 — so this is the single owner and
+ * both sites now call it.
+ *
+ * Returns false when the argument fails to compile (caller bails).
+ */
+function emitArgAsNativeString(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  argExpr: ts.Expression,
+  strType: ValType,
+): boolean {
+  const emitted = compileExpression(ctx, fctx, argExpr, { kind: "externref" });
+  if (emitted === null) return false;
+  if (emitted.kind !== "externref") {
+    coerceType(ctx, fctx, emitted, { kind: "externref" }, "string", compileStringLiteral);
+  }
+  const toStringIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  if (toStringIdx === undefined) {
+    // No runtime ToString available — fall back to the previous direct coercion
+    // rather than emitting nothing.
+    coerceType(ctx, fctx, { kind: "externref" }, strType, "string", compileStringLiteral);
+    return true;
+  }
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__extern_toString") ?? toStringIdx });
+  fctx.body.push({ op: "any.convert_extern" });
+  fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx });
+  return true;
+}
+
+/**
  * Emit the runtime constructor used for genuinely dynamic standalone patterns.
  *
  * The first runtime slice deliberately compiles the shape Acorn executes for
@@ -1727,11 +1774,8 @@ export function compileStandaloneRegExpConstructor(
     const strType = nativeStringType(ctx);
     const patternLocal = allocLocal(fctx, `__re_dyn_pattern_${fctx.locals.length}`, strType);
     if (pattern === null) {
-      const emitted = compileExpression(ctx, fctx, patternArg!, strType);
-      if (emitted === null) return null;
-      if (emitted.kind !== "ref" || emitted.typeIdx !== ctx.anyStrTypeIdx) {
-        coerceType(ctx, fctx, emitted, strType, "string", compileStringLiteral);
-      }
+      // (#4089) §22.2.3.1 step 5/7: ToString, not a cast.
+      if (!emitArgAsNativeString(ctx, fctx, patternArg!, strType)) return null;
     } else {
       for (const instr of nativeStringLiteralInstrs(ctx, pattern ?? "")) fctx.body.push(instr);
     }
@@ -1739,11 +1783,7 @@ export function compileStandaloneRegExpConstructor(
 
     const flagsLocal = allocLocal(fctx, `__re_dyn_flags_${fctx.locals.length}`, strType);
     if (flags === null) {
-      const emitted = compileExpression(ctx, fctx, flagsArg!, strType);
-      if (emitted === null) return null;
-      if (emitted.kind !== "ref" || emitted.typeIdx !== ctx.anyStrTypeIdx) {
-        coerceType(ctx, fctx, emitted, strType, "string", compileStringLiteral);
-      }
+      if (!emitArgAsNativeString(ctx, fctx, flagsArg!, strType)) return null;
     } else {
       for (const instr of nativeStringLiteralInstrs(ctx, flags ?? "")) fctx.body.push(instr);
     }

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -807,6 +807,24 @@ export function ensureStandaloneRegExpStruct(ctx: CodegenContext): number {
 }
 
 /**
+ * (#4089) Resolve the runtime ToString the standalone regex lane uses, as ONE
+ * coercion site.
+ *
+ * Both the `.test`/`.exec` subject path and the dynamic-constructor argument
+ * path need this exact conversion. Each having its own `ensureLateImport` +
+ * `funcMap` lookup is a hand-rolled ToString site per the coercion-site drift
+ * gate (#2108/#3131/#3279) — and the gate is right: that is precisely how the
+ * two paths drifted apart in the first place, with only one of them actually
+ * applying ToString. One resolver, two callers.
+ */
+function ensureRuntimeToStringIdx(ctx: CodegenContext, fctx: FunctionContext | null): number | undefined {
+  const idx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  if (idx === undefined) return undefined;
+  return ctx.funcMap.get("__extern_toString") ?? idx;
+}
+
+/**
  * (#4089) Compile `expr` and leave a native `$AnyString` on the stack, applying
  * the SPEC's ToString — i.e. an object argument gets its own `toString()`
  * called, per §7.1.17.
@@ -839,15 +857,14 @@ function emitArgAsNativeString(
   if (emitted.kind !== "externref") {
     coerceType(ctx, fctx, emitted, { kind: "externref" }, "string", compileStringLiteral);
   }
-  const toStringIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
-  flushLateImportShifts(ctx, fctx);
+  const toStringIdx = ensureRuntimeToStringIdx(ctx, fctx);
   if (toStringIdx === undefined) {
     // No runtime ToString available — fall back to the previous direct coercion
     // rather than emitting nothing.
     coerceType(ctx, fctx, { kind: "externref" }, strType, "string", compileStringLiteral);
     return true;
   }
-  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__extern_toString") ?? toStringIdx });
+  fctx.body.push({ op: "call", funcIdx: toStringIdx });
   fctx.body.push({ op: "any.convert_extern" });
   fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx });
   return true;
@@ -1979,11 +1996,10 @@ export function emitRegexSearchCall(
     if (inputType !== null && inputType.kind !== "externref") {
       coerceType(ctx, fctx, inputType, { kind: "externref" }, "string", compileStringLiteral);
     }
-    const toStringIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
-    flushLateImportShifts(ctx, fctx);
+    // (#4089) Same single resolver the constructor path uses.
+    const toStringIdx = ensureRuntimeToStringIdx(ctx, fctx);
     if (toStringIdx !== undefined) {
-      const finalToStringIdx = ctx.funcMap.get("__extern_toString") ?? toStringIdx;
-      fctx.body.push({ op: "call", funcIdx: finalToStringIdx });
+      fctx.body.push({ op: "call", funcIdx: toStringIdx });
       fctx.body.push({ op: "any.convert_extern" });
       fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx });
       inputType = nativeStringType(ctx);

--- a/tests/issue-4089-regexp-ctor-tostring.test.ts
+++ b/tests/issue-4089-regexp-ctor-tostring.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #4089 — dynamic `new RegExp(pattern, flags)` cast its arguments instead of
+// calling ToString, so an OBJECT argument null-dereferenced during top-level
+// evaluation and killed the module:
+//
+//     new RegExp("abc{1}", { toString() { return ""; } })
+//       → RuntimeError: dereferencing a null pointer in __module_init()
+//
+// §22.2.3.1 steps 5/7 require ToString, which must call the object's own
+// `toString()`. The correct conversion already existed in the same file —
+// `emitRegexSearchCall` routes every `.test`/`.exec` subject through the
+// runtime `__extern_toString` (#3724) — so two sites needed the identical
+// conversion and only one had it (the #4080 shape). `emitArgAsNativeString` is
+// now the single owner.
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    deferTopLevelInit: true,
+  });
+  if (!result.success || result.errors.some((e) => e.severity === "error")) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  return result.binary;
+}
+
+async function runInit(binary: Uint8Array) {
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  const exports = instance.exports as Record<string, CallableFunction>;
+  exports.__module_init?.();
+  return exports;
+}
+
+describe("#4089 — RegExp constructor arguments go through ToString", () => {
+  // Before the fix `__module_init` trapped with a null-pointer dereference.
+  // Note the module ALWAYS validated — the failure was at run time, so
+  // `WebAssembly.validate` alone would not have caught this.
+  it("an object flags argument no longer traps during module init", async () => {
+    const binary = await compileStandalone(`
+var flagsObj = { toString: function () { return ""; } };
+var re = new RegExp("a", flagsObj);
+`);
+    expect(WebAssembly.validate(binary)).toBe(true);
+    await expect(runInit(binary)).resolves.toBeDefined();
+  });
+
+  // Verify by VALUE that the object's own toString() was honoured: "g" must
+  // produce a global regex. If ToString were skipped (or answered
+  // "[object Object]") this would throw on invalid flags instead.
+  it("the object's own toString() supplies the flags (value check)", async () => {
+    const binary = await compileStandalone(`
+var flagsObj = { toString: function () { return "g"; } };
+var got = 0;
+try {
+  var re = new RegExp("a", flagsObj);
+  got = re.global === true ? 1 : 2;
+} catch (e) {
+  got = 3;
+}
+export function probe(): number { return got; }
+`);
+    const exports = await runInit(binary);
+    expect(exports.probe!()).toBe(1);
+  });
+
+  // An object PATTERN argument takes the same path (§22.2.3.1 step 5).
+  it("an object pattern argument goes through ToString too", async () => {
+    const binary = await compileStandalone(`
+var patObj = { toString: function () { return "a"; } };
+var got = 0;
+try {
+  var re = new RegExp(patObj, "");
+  got = re.source === "a" ? 1 : 2;
+} catch (e) {
+  got = 3;
+}
+export function probe(): number { return got; }
+`);
+    const exports = await runInit(binary);
+    expect(exports.probe!()).toBe(1);
+  });
+
+  // The plain string path must be unchanged — this is what every ordinary
+  // `new RegExp(s, "g")` uses.
+  it("string pattern and flags still work", async () => {
+    const binary = await compileStandalone(`
+var re = new RegExp("a", "g");
+var ok = re.global === true && re.ignoreCase === false ? 1 : 2;
+export function probe(): number { return ok; }
+`);
+    const exports = await runInit(binary);
+    expect(exports.probe!()).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #4089. Fourth mechanism from the standalone crash cluster, after #4077
(28 files), #4079 (8) and #4082 (12) — and the first from the
`illegal cast` / `null deref` bucket rather than `invalid Wasm binary`.

## What broke

```js
new RegExp("abc{1}", { toString() { return ""; } });
// → RuntimeError: dereferencing a null pointer in __module_init()
```

`__module_init` dies during top-level evaluation, so the file loses **100 %**
of its assertions. Bisected — the object argument is the whole trigger:

| repro | result |
| --- | --- |
| `new RegExp("abc{1}", "")` | OK ← control |
| `new RegExp("abc{1}", {toString(){return ""}})` | **null-pointer deref** |

**Note the module always validated.** This one is a run-time trap, so
`WebAssembly.validate` — the instrument that caught the previous three
mechanisms — would have said "fine".

## Root cause

`compileStandaloneRegExpNew` compiled each dynamic argument with a
native-string expectation and then `coerceType`d it:

```ts
const emitted = compileExpression(ctx, fctx, flagsArg!, strType);
if (emitted.kind !== "ref" || emitted.typeIdx !== ctx.anyStrTypeIdx) {
  coerceType(ctx, fctx, emitted, strType, "string", compileStringLiteral);
}
```

For a string that is the same thing. For an **object** it is not a conversion
at all — §22.2.3.1 steps 5/7 require **ToString**, which must call the object's
own `toString()`.

The correct conversion already existed **in the same file**:
`emitRegexSearchCall` routes every `.test`/`.exec` subject through the runtime
`__extern_toString` (#3724). Two call sites needed the identical conversion and
only one had it — the sixth instance of **#4080** in this cluster. This
extracts `emitArgAsNativeString` as the single owner; the constructor's pattern
and flags now both use it.

**#4080 is now predictive, not just retrospective.** The first four instances
were root-caused and then labelled; #4084 and this one were **predicted from
the pattern first** — "look for a decision that must hold in several places,
where the newest copy is the one missing a case, and where the invariant is
stated in a *comment* rather than enforced" — and then confirmed by
measurement. Six retrospective examples argue the pattern is real; two
predictions argue it is useful.

## Verified before relying on it

Reusing `__extern_toString` would be worthless — worse, it would be another
#4083 crash-traded-for-a-wrong-value — if it did not honour a user-defined
`toString`. Measured first, not assumed:

```js
String({ toString() { return "ZZ"; } })  // → "ZZ"
"" + { toString() { return "ZZ"; } }     // → "ZZ"
```

## Measurements

Baseline `test262-standalone-current.jsonl`, row timestamp **`2.8.2026, 03:32`**.
Official **43,505 run / 25,995 pass (59.75 %)**; ES5+untagged goal scope
**8,545 run / 6,298 pass (73.70 %) / 0 unopenable**.

| stage      | count | note                                                        |
| ---------- | ----: | ----------------------------------------------------------- |
| population |    84 | goal-scope `illegal cast` / `null deref` in `__module_init` |
| mechanism  |    21 | the `built-ins/RegExp` sub-group                            |
| reachable  |    21 | all compile; the trap is at top-level evaluation            |
| **flips**  |    13 | `runTest262File`, `--target standalone`, run **serially**   |

**Kill-switch** — same 21, `regexp-standalone.ts` reverted to `HEAD`:
**21 fail / 0 pass**. With the fix: **13 pass / 8 fail**.

The 8 residuals hit the dynamic-engine pattern subset (`Unsupported dynamic
regular expression pattern` — `abc{1}` needs `{n}` quantifier support in
`__regex_compile_dynamic_simple`). Different lever, explicitly out of scope.

## Why this bucket is smaller than it looks

While scoping this I classified where each of the 84 crash-bucket files
actually crashes:

| | count |
| --- | ---: |
| crash while building `throw new Test262Error(...)` — **downstream of an already-failed assertion** | 50 |
| crash at an `assert.*` line (ambiguous) | 30 |
| no source line | 4 |

For those **50** the test had already decided it failed; fixing the crash buys
diagnosability and **zero** conformance. So "84 crash files" is **not** 84
potential flips. This sub-group was worth doing precisely because it was
disambiguated by probe and shown to crash in *construction*, upstream of every
assertion.

## The `loc-budget-allow:` is deliberate — and I refused one an hour ago

`regexp-standalone.ts` is a god-file at its ceiling; this adds ~40 lines, so
the change-set takes an allowance.

That is the opposite of what I did in **#4084**, where the same gate blocked a
**0-flip** change and I filed it unshipped rather than take one. The rule I
derived there was *"don't take an allowance for a 0-flip change"* — not "never
take one". Here it is **13 measured flips** against ~40 lines in a file already
slated for splitting under **#4067**, which is the natural place to retire the
allowance. The retirement condition is written **into the `loc-budget-allow:`
block itself**, not only into the issue body — an allowance whose retirement
condition lives in another document becomes permanent by default.

Both alternatives were tried first and rejected on merits:

- **Move the helper to a subsystem module** (the #4082 remedy):
  `src/codegen/regex/` is engine-only (bytecode/compile/parse) and this is a
  *codegen bridge* needing `compileExpression`/`coerceType`; `shared.ts` is a
  delegate registry that exists to break import cycles. Either would drag
  codegen-context deps into the wrong layer to satisfy a line count.
- **Dedupe `emitRegexSearchCall`'s inline copy** to pay for the growth. That is
  the right cleanup, but that site has a subtle path the helper does not
  reproduce: when `compileExpression` returns `null` it does **not** bail — it
  still calls `__extern_toString`. Changing that silently underneath a 13-flip
  fix is the wrong risk to bundle; it belongs in #4067 with its own control.

## Tests

Four, value-checked where a value claim is made: the object-flags repro
instantiates **and runs** `__module_init` without trapping; the object's own
`toString()` is proven to supply the flags (`{toString(){return "g"}}` →
`re.global === true`, which would throw on invalid flags if ToString were
skipped or answered `"[object Object]"`); an object **pattern** argument
likewise (`re.source === "a"`); and the ordinary string path is pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcwPzXzbjibq9EcXMDBJAj
