### PR TITLE
docs(#4098,#4099): the two defects measured while landing #3976 slice 1

### DIFF
--- a/plan/issues/4098-standalone-instance-fields-not-own-properties-of-the-instance.md
+++ b/plan/issues/4098-standalone-instance-fields-not-own-properties-of-the-instance.md
@@ -1,0 +1,104 @@
+---
+id: 4098
+title: "standalone: class instance fields are not own properties of the instance — the unanimous blocker of #3976's residual"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: conformance
+area: codegen
+es_edition: ES6
+language_feature: class-elements
+goal: standalone
+horizon: l
+parent: 2860
+related: [3976, 2860, 3571]
+origin: "measured as the sole residual bucket of #3976 slice 1 (senior-dev-3976-class-elements, 2026-08-02)"
+---
+
+# standalone: class instance fields are not own properties of the instance
+
+#3976 slice 1 made `C.prototype` a real `$Object` and flipped **479 of the 539**
+`C.prototype`-receiver files. **All 60 residuals are ONE bucket, unanimous:**
+
+```
+Test262Error: foo descriptor value should be foobar; foo descriptor should be enumerable; …
+```
+
+i.e. a class *instance field*
+
+```js
+class C { foo = "foobar"; m() { return 42; } }
+verifyProperty(new C(), "foo", { value: "foobar", enumerable: true, writable: true, configurable: true });
+```
+
+is not an own property of the **instance**. Per §15.7.14 / DefineField, a public
+instance field is installed on the instance with
+`{writable: true, enumerable: TRUE, configurable: true}` — note `enumerable:
+true`, the opposite of a method, so this needs `Object.keys` / for-in to *include*
+it.
+
+## Population — measured, with denominators
+
+- **60** = the entire residual of #3976's full 539-file `C.prototype` run
+  (`479/539` pass after slice 1; 60 fail, 100 % in this bucket).
+- **276** = the census's `receiver = c` bucket in #3976 (instance fields on an
+  instance), from the 1,136-file `should have an own property` family.
+
+These overlap: a file can verify both a prototype method and an instance field.
+**Do not add 60 + 276.** Re-derive the union before sizing — the #3976 census
+harness (`plan/probes/3976/census.mjs`) plus `.tmp/classify.mjs`-style static
+classification is the instrument, and `census.mjs` refuses to be trusted unless
+it reproduces the published standalone baseline.
+
+## Why this is NOT a repeat of #3976's shape
+
+#3976's receiver was a **singleton** (`__proto_<C>`, one per class, lazily
+materialized in a module global), which is what made "build it as an `$Object`
+once" viable. An **instance** is not a singleton: it is a `$ClassName` WasmGC
+struct allocated per `new C()`, with the fields as real typed struct fields. You
+cannot replace instances with `$Object` without giving up the typed-field
+representation that the whole class lowering depends on.
+
+So the mechanism must be different. Two candidate shapes, neither yet measured:
+
+1. **Closed-struct reflective arms.** `fillClosedStructHasOwnArms`
+   (`object-runtime.ts` ~6247), `fillClosedStructFieldArms` (~6558) and
+   `fillClosedStructOwnPropertyNamesArms` (~6432) ALREADY answer
+   `hasOwnProperty` / dynamic get / `getOwnPropertyNames` for class structs by
+   `ref.test $ClassName` + `struct.get`. What is missing is
+   `getOwnPropertyDescriptor` (with `enumerable: true` for fields), the
+   `Object.keys`/for-in enumerable half, and — the hard part, exactly as in
+   #3976 — **write-through and delete**, which `verifyProperty` probes by
+   mutating. A struct field can be written; `delete` cannot remove it.
+2. **A per-instance overlay bag**, like the closure carrier bag
+   (`carrier-bag-hasown.ts`, `__closure_bag_lookup`), recording deletions as
+   tombstones and shadowing writes.
+
+**Read #3976's measurement before scoping this**: 100 % of that population
+asserted `writable` AND `configurable`, so a presence-and-descriptor-only fix
+flipped zero. Verify the same ratio here **before** committing to a slice — it is
+the step that decides whether the delete path is optional.
+
+## Acceptance criteria
+
+- `Object.getOwnPropertyDescriptor(new C(), "foo")` returns
+  `{value, writable: true, enumerable: true, configurable: true}` for a public
+  instance field.
+- `Object.keys(new C())` and `for…in` **include** `foo` (fields are enumerable —
+  unlike methods).
+- Private fields (`#f`) stay absent from the own-property surface, including the
+  `__priv_` mangled spelling.
+- Report measured fail→pass **and** pass→fail with denominators, plus a
+  regression control drawn from the standalone-passing class population, with any
+  apparent regression re-run **solo** before it is believed.
+
+## Blocker to check first
+
+`for…in` / `Object.keys` correctness here is entangled with **#4099**:
+`__object_keys` and `__object_keys_forin` currently ignore `FLAG_ENUMERABLE`
+entirely. Since fields are the enumerable case, this issue may need #4099 landed
+first to be verifiable at all.

--- a/plan/issues/4099-object-keys-and-forin-ignore-flag-enumerable.md
+++ b/plan/issues/4099-object-keys-and-forin-ignore-flag-enumerable.md
@@ -1,0 +1,91 @@
+---
+id: 4099
+title: "standalone: __object_keys and __object_keys_forin ignore FLAG_ENUMERABLE — every non-enumerable own property is enumerated"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: medium
+feasibility: medium
+task_type: conformance
+area: codegen
+es_edition: ES5
+language_feature: object-enumeration
+goal: standalone
+horizon: m
+parent: 2860
+related: [3976, 4098]
+origin: "found while making standalone class prototypes real objects (#3976, senior-dev-3976-class-elements, 2026-08-02)"
+---
+
+# `__object_keys` / `__object_keys_forin` ignore `FLAG_ENUMERABLE`
+
+Both helpers walk `__obj_ordered(o)` and push **every** live entry's key. Neither
+tests `FLAG_ENUMERABLE` (bit 1 of `$PropEntry.$flags`, field index 2). Verified
+in `src/codegen/object-runtime-enumeration.ts`: the constant `FLAG_ENUMERABLE` is
+referenced **exactly once** in that whole file (~line 990, inside an unrelated
+spread/assign helper) and in **neither** enumeration helper —
+`__object_keys` (body ~106-172) and `__object_keys_forin` (body ~219+) both push
+unconditionally after only a null/tombstone check.
+
+```js
+var o = {};
+Object.defineProperty(o, "x", { value: 1, enumerable: false });
+Object.keys(o);            // should be []          — standalone leaks ["x"]
+for (var k in o) { … }     // should not yield "x"  — standalone yields it
+```
+
+## Why it has stayed invisible
+
+`verifyProperty` **masks it**. `isEnumerable(obj, name)` (propertyHelper.js:149)
+ANDs the for-in scan with `__propertyIsEnumerable(obj, name)`, and
+`__propertyIsEnumerable` **does** honour the flag. So a leaked for-in key still
+yields the correct final answer, and the whole `propertyHelper` corpus is blind
+to this defect. Only a test that inspects `Object.keys` / `for…in` directly can
+see it.
+
+## Why it matters now
+
+#3976 made standalone class prototypes real `$Object`s with their methods
+installed **non-enumerable**. That is spec-correct, but it means
+`for (k in C.prototype)` now yields the method names where it previously yielded
+nothing (the old defaulted-struct prototype had no `$Object` entries at all). So
+#3976 did not create this defect, but it **widened its reach** to every class
+prototype. #4098 (instance fields, which ARE enumerable) needs this correct in
+the other direction to be verifiable at all.
+
+## Fix
+
+Add the enumerable test to both helpers' entry filter. The exact instruction
+sequence already exists in the same file (~line 980-995) and can be copied:
+
+```
+local.get <e> ; ref.as_non_null ; struct.get $PropEntry 2
+i32.const FLAG_ENUMERABLE ; i32.and ; i32.eqz ; i32.eqz   ;; normalise to 0/1
+```
+
+`__getOwnPropertyNames` must **not** get this filter — it lists non-enumerable
+own keys by design.
+
+## Sizing discipline — measure before believing
+
+This is a **general** change to the enumeration path of every `$Object`, and
+this repo has a precedent (#4017/#4055) where wiring an own-property answer at
+the general point cost **684 host-free regressions**. So:
+
+- The expected direction is *fewer* keys. Any object whose properties were
+  created with flags that omit the enumerable bit will now vanish from
+  `Object.keys` — check the `FLAG_INTERNAL` (`0x10`) slot users and the
+  `__obj_insert` call sites that pass explicit flags, since those are exactly
+  where a non-`FLAG_DEFAULT` (`0x07`) entry comes from.
+- Ordinary `o.x = v` uses `FLAG_DEFAULT`, which includes enumerable, so the
+  common path is unaffected — **confirm that by measurement, not by reading**.
+- Run a regression control over the standalone-passing population and re-run
+  every apparent regression **solo** before believing it.
+
+## Acceptance criteria
+
+- `Object.keys` and `for…in` exclude non-enumerable own properties;
+  `Object.getOwnPropertyNames` still includes them.
+- Measured fail→pass and pass→fail with denominators, plus the regression control
+  above.


### PR DESCRIPTION
Two issue files, no code. Both were **measured** while landing #3976 slice 1 (PR #4033), not inferred by reading.

### #4098 — instance fields are not own properties of the instance

The **unanimous** residual of #3976's full 539-file run: after slice 1 flipped 479, **all 60** remaining failures are one bucket — a public instance field expected at `{value, enumerable: true, writable: true, configurable: true}` on the *instance*.

Deliberately flagged as **not** a repeat of #3976's shape: a prototype is a singleton in a module global (which is what made "build it as an `$Object` once" viable); an instance is a per-`new` `$ClassName` struct with typed fields. The substitution does not transfer, so the issue names two candidate mechanisms and asks for the write/delete ratio to be measured **before** slicing — the step that showed #3976's original slice-1 plan was worth zero.

Sizing note in the file: the 60 residuals and the census's 276 `receiver = c` bucket **overlap**; do not add them.

### #4099 — `__object_keys` / `__object_keys_forin` ignore `FLAG_ENUMERABLE`

General pre-existing defect: neither helper tests the enumerable bit. The constant appears **exactly once** in `object-runtime-enumeration.ts`, in an unrelated helper.

It has stayed invisible because `verifyProperty` **masks** it — `isEnumerable` ANDs the for-in scan with `propertyIsEnumerable`, which does honour the flag — so the entire `propertyHelper` corpus is blind to it. #3976 did not create it but widened its reach to class prototypes (methods are non-enumerable), and #4098 needs it correct in the *other* direction (fields are enumerable) to be verifiable at all.

The file carries the sizing discipline rather than a forecast, and names the 684-regression precedent (#4017/#4055) for wiring an own-property answer at the general point.

Ids reserved via `claim-issue.mjs --allocate` (#4098 and #4099, both verified on `origin/issue-assignments`, `pr_scan=ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)