### PR TITLE
feat(ir): plan module initialization before body emission

### DIFF
--- a/plan/issues/3523-ir-r4-module-init-compile-once.md
+++ b/plan/issues/3523-ir-r4-module-init-compile-once.md
@@ -1,10 +1,10 @@
 ---
 id: 3523
 title: "IR-only R4: typed ordered module-init compile-once ownership"
-status: blocked
-sprint: Backlog
+status: in-progress
+sprint: current
 created: 2026-07-21
-updated: 2026-07-21
+updated: 2026-08-02
 priority: critical
 horizon: xl
 complexity: XL
@@ -24,6 +24,7 @@ related: [1789, 2796, 2931, 2965, 2992, 3142, 3517, 3518]
 origin: "#3518 R4 — replace compile-first/patch-later __module_init with typed ordered prepare-before-emit ownership"
 files:
   - src/ir/module-init.ts
+  - src/ir/module-init-plan.ts
   - src/ir/program.ts
   - src/ir/prepare.ts
   - src/ir/from-ast.ts
@@ -33,6 +34,10 @@ files:
   - src/codegen/index.ts
   - src/codegen/context/types.ts
   - tests/issue-3523-ir-module-init-compile-once.test.ts
+loc-budget-allow:
+  - src/codegen/index.ts
+func-budget-allow:
+  - src/codegen/index.ts::generateModule
 ---
 
 # #3523 — IR-only R4: typed ordered module-init compile-once ownership
@@ -151,6 +156,37 @@ silently dropped because it has no direct-codegen queue representation.
   statics, TDZ actions, live seeds, exports, and invocation mode in telemetry.
 - Add failure injection for missing/duplicate/reordered entries and prove
   inventory equals one terminal outcome before touching body routing.
+
+### Ordered-plan foundation (2026-08-02)
+
+The first Commit 1 seam now builds an immutable, source-qualified
+`IrModuleInitPlan` directly from the exact source and R1 identity inventory
+before any function body emitter runs. It records top-level binding storage and
+TDZ identities, reassigned-function live seeds, source-ordered statement and
+class-static evaluation entries, export aliases, and the host/deferred/WASI
+exactly-once invocation policy. Empty/function-only modules receive an explicit
+non-executable plan instead of a synthetic initializer.
+
+This landing deliberately does not change routing. Production single-source
+compilation compares the semantic plan with the existing live-seed,
+`staticInitExprs`, and `moduleInitStatements` queues and publishes the complete
+parity record. The anti-vacuity fixture proves the record catches the current
+all-statics-before-statements reorder while distinguishing it from missing or
+extra entries. Destructuring bindings and executable top-level semantics with
+no inventory-owned module-init unit remain explicit typed plan gaps; neither is
+silently dropped.
+
+Focused validation is **6/6 passing**, and TypeScript validation passes. The
+seven-file adjacent matrix is **51/55 passing**: both #3142 failures reproduce
+unchanged on an untouched `origin/main` control, while the other two tests
+require the optional `test262-fyi/data` submodule that is absent in this
+worktree. Fallback, hybrid-readiness, optimization-retirement, issue, lint,
+format, LOC, and function-budget gates pass. R4 routing remains blocked on the
+remaining R3 class ownership and on consuming these plan entries through the
+prepared emission transaction. The next R4 slice should replace the legacy
+static/module queue partition with this ordered entry stream for a
+capability-complete scalar module, then prove `direct=0, IR=1` without changing
+startup behavior.
 
 ### Commit 2 — prepare/lower module init and make fallback one-pass
 

--- a/plan/issues/3523-ir-r4-module-init-compile-once.md
+++ b/plan/issues/3523-ir-r4-module-init-compile-once.md
@@ -188,6 +188,31 @@ static/module queue partition with this ordered entry stream for a
 capability-complete scalar module, then prove `direct=0, IR=1` without changing
 startup behavior.
 
+#### Merge-queue multiplicity correction (2026-08-02)
+
+The first merge-group run exposed a valid class-expression population whose
+direct backend registers each static initializer once per internal class
+owner. Six source initializer ranges therefore appeared twice in the legacy
+queue. The read-only parity probe collapsed identities to source ranges and
+treated that multiplicity as a malformed semantic plan, turning 142 candidate
+Test262 rows into the same compile error before body emission.
+
+Reconciliation now keeps the semantic plan's unique-entry invariant while
+pairing each observed queue key with an occurrence ordinal. Repeated legacy
+entries remain visible as `extraInLegacy`; they make parity non-aligned but no
+longer make valid source fail compilation. This preserves the evidence R4
+needs to eliminate the duplicate direct work later without allowing the
+observer itself to change production behavior.
+
+Focused coverage is **8/8 passing**. The exact previously failing generated
+class-expression source now compiles successfully, validates as Wasm, and the
+minimal two-private-static fixture records four legacy observations over two
+source ranges instead of throwing. The fixed head must still complete a fresh
+merge-group Test262 run before landing. The expanded seven-file adjacent
+matrix is **53/57 passing**: the same two #3142 failures reproduce on pristine
+current `main`, and the remaining two rows require the absent optional
+`test262-fyi/data` submodule.
+
 ### Commit 2 — prepare/lower module init and make fallback one-pass
 
 - Extend from-AST lowering for every planned top-level entry and static intent.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -68,6 +68,11 @@ import { makeIrHostDateSnapshotResolver } from "../ir/host-date.js";
 import { supportsIrBackendTargetCapability, type IrBackendTargetCapability } from "../ir/backend/legality.js";
 import { collectModuleInitPopulation, MODULE_INIT_UNIT_NAME } from "../ir/module-init.js";
 import {
+  buildIrModuleInitPlan,
+  reconcileIrModuleInitPlan,
+  type IrModuleInitPlanningEvidence,
+} from "../ir/module-init-plan.js";
+import {
   buildIrUnitInventory,
   type BuildIrUnitInventoryOptions,
   type IrClassId,
@@ -3378,6 +3383,8 @@ export function generateModule(
   irOutcomes?: readonly IrObservedOutcome[];
   // #3520 — finalized structural ABI when an IR identity inventory was requested.
   programAbi?: PublishedProgramAbi;
+  // #3523 — source-ordered module-init plan plus direct-queue parity evidence.
+  moduleInitPlanning?: IrModuleInitPlanningEvidence;
 } {
   const mod = createEmptyModule();
   const irPlanningIdentityContext =
@@ -3397,6 +3404,7 @@ export function generateModule(
   // whose legacy body emission was skipped (IR owns the slot). Declared out
   // here so the return statement below (outside the try) can surface it.
   let irFirstSkipped: readonly string[] | undefined;
+  let moduleInitPlanning: IrModuleInitPlanningEvidence | undefined;
   // (#1983) Pre-scan top-level user `function` declaration names BEFORE any
   // class member registers a funcMap key, so `classMemberFuncKey` can detect a
   // `${className}_${member}` ↔ user-function collision (e.g. `class A { m() {} }`
@@ -3791,6 +3799,28 @@ export function generateModule(
     // mutable live-binding module global so later reads observe the write.
     // No-op unless a function declaration is reassigned.
     registerReassignedFunctionGlobals(ctx, [ast.sourceFile]);
+
+    // (#3523 R4/C1) Build the semantic top-level plan independently from the
+    // direct front-end's three mutable queues. This first landing observes and
+    // reports parity only; body routing remains unchanged until R3 ownership
+    // and the remaining module-init capabilities are prepared.
+    if (irPlanningIdentityContext) {
+      const plan = buildIrModuleInitPlan({
+        sourceFile: ast.sourceFile,
+        checker: ast.checker,
+        identityContext: irPlanningIdentityContext,
+        target: ctx.wasi ? "wasi" : ctx.standalone ? "standalone" : "host",
+        deferTopLevelInit: ctx.deferTopLevelInit,
+      });
+      moduleInitPlanning = Object.freeze({
+        plan,
+        parity: reconcileIrModuleInitPlan(plan, ast.sourceFile, {
+          liveFunctionNames: ctx.liveFuncBindingGlobals ?? [],
+          staticEntries: ctx.staticInitExprs,
+          moduleStatements: ctx.moduleInitStatements,
+        }),
+      });
+    }
 
     // (#2138/#3521) IR-first compile-once inversion.
     // (#3143) Default ON. R2 prepares, optimizes, lowers, and installs every
@@ -4547,6 +4577,7 @@ export function generateModule(
     irFirstSkipped,
     irOutcomes: ctx.irOutcomes,
     programAbi: ctx.programAbiSession?.publication,
+    moduleInitPlanning,
   };
 }
 

--- a/src/ir/module-init-plan.ts
+++ b/src/ir/module-init-plan.ts
@@ -567,6 +567,27 @@ function duplicates(values: readonly string[], label: string): void {
   }
 }
 
+interface QueueIdentityOccurrence {
+  readonly key: string;
+  readonly identity: string;
+}
+
+/**
+ * Preserve queue multiplicity without treating a source-range collision as a
+ * malformed semantic plan. The direct class-expression path may register the
+ * same source initializer once per internal class owner. R4 must observe that
+ * as extra legacy work; its read-only parity probe must not make otherwise
+ * valid source fail compilation.
+ */
+function identifyQueueOccurrences(values: readonly string[]): readonly QueueIdentityOccurrence[] {
+  const seen = new Map<string, number>();
+  return values.map((key) => {
+    const occurrence = seen.get(key) ?? 0;
+    seen.set(key, occurrence + 1);
+    return frozen({ key, identity: `${key}\u0000${occurrence}` });
+  });
+}
+
 /** Compare the semantic order with the current direct-front-end queues. */
 export function reconcileIrModuleInitPlan(
   plan: IrModuleInitPlan,
@@ -586,19 +607,22 @@ export function reconcileIrModuleInitPlan(
     ...legacy.moduleStatements.map((statement) => legacyNodeKey("statement", statement, sourceFile)),
   ];
   duplicates(plannedOrder, "module-init plan");
-  duplicates(legacyOrder, "legacy module-init observation");
-  const plannedSet = new Set(plannedOrder);
-  const legacySet = new Set(legacyOrder);
-  const missingFromLegacy = plannedOrder.filter((key) => !legacySet.has(key));
-  const extraInLegacy = legacyOrder.filter((key) => !plannedSet.has(key));
-  const commonPlanned = plannedOrder.filter((key) => legacySet.has(key));
-  const commonLegacy = legacyOrder.filter((key) => plannedSet.has(key));
+  const plannedOccurrences = identifyQueueOccurrences(plannedOrder);
+  const legacyOccurrences = identifyQueueOccurrences(legacyOrder);
+  const plannedSet = new Set(plannedOccurrences.map((entry) => entry.identity));
+  const legacySet = new Set(legacyOccurrences.map((entry) => entry.identity));
+  const missingFromLegacy = plannedOccurrences
+    .filter((entry) => !legacySet.has(entry.identity))
+    .map((entry) => entry.key);
+  const extraInLegacy = legacyOccurrences.filter((entry) => !plannedSet.has(entry.identity)).map((entry) => entry.key);
+  const commonPlanned = plannedOccurrences.filter((entry) => legacySet.has(entry.identity));
+  const commonLegacy = legacyOccurrences.filter((entry) => plannedSet.has(entry.identity));
   const reordered: { planned: string; observed: string }[] = [];
   for (let index = 0; index < Math.max(commonPlanned.length, commonLegacy.length); index++) {
     const planned = commonPlanned[index];
     const observed = commonLegacy[index];
-    if (planned !== observed && planned !== undefined && observed !== undefined) {
-      reordered.push(frozen({ planned, observed }));
+    if (planned?.identity !== observed?.identity && planned !== undefined && observed !== undefined) {
+      reordered.push(frozen({ planned: planned.key, observed: observed.key }));
     }
   }
   return frozen({

--- a/src/ir/module-init-plan.ts
+++ b/src/ir/module-init-plan.ts
@@ -1,0 +1,614 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import { irModuleGlobalBindingId, irModuleTdzGlobalBindingId } from "./abi-bindings.js";
+import { irUnitCallableBindingId } from "./callable-bindings.js";
+import { createIrBindingId, type IrBindingId, type IrClassId, type IrSourceId, type IrUnitId } from "./identity.js";
+import type { IrPlanningIdentityContext } from "./planning-identity.js";
+
+export type IrModuleInitTarget = "host" | "standalone" | "wasi";
+export type IrModuleInitInvocationKind = "none" | "wasm-start" | "deferred-export" | "wasi-start-export";
+
+export interface IrModuleInitInvocationPolicy {
+  readonly target: IrModuleInitTarget;
+  readonly kind: IrModuleInitInvocationKind;
+  readonly exactlyOnce: true;
+}
+
+export type IrModuleBindingDeclarationKind = "var" | "let" | "const";
+
+export interface IrModuleInitBindingIntent {
+  readonly declarationOrdinal: number;
+  readonly names: readonly string[];
+  readonly declarationKind: IrModuleBindingDeclarationKind;
+  readonly mutable: boolean;
+  readonly initialization: "undefined-at-instantiation" | "tdz";
+  readonly globalBindingId: IrBindingId | null;
+  readonly tdzBindingId: IrBindingId | null;
+  readonly start: number;
+  readonly end: number;
+}
+
+export interface IrModuleInitLiveSeedIntent {
+  readonly name: string;
+  readonly unitId: IrUnitId;
+  readonly callableBindingId: IrBindingId;
+  readonly liveGlobalBindingId: IrBindingId;
+  readonly declarationOrdinal: number;
+  readonly legacyKey: string;
+}
+
+export type IrModuleInitEvaluationKind =
+  | "statement"
+  | "variable-initializer"
+  | "export-assignment"
+  | "class-static-field"
+  | "class-static-block";
+
+export interface IrModuleInitEvaluationEntry {
+  readonly key: string;
+  readonly kind: IrModuleInitEvaluationKind;
+  readonly sourceOrdinal: number;
+  readonly statementOrdinal: number;
+  readonly nestedOrdinal: number;
+  readonly start: number;
+  readonly end: number;
+  readonly classId: IrClassId | null;
+  readonly bindingIds: readonly IrBindingId[];
+  /** Exact legacy queue identity used only by the migration parity observer. */
+  readonly legacyKey: string;
+}
+
+export interface IrModuleInitExportIntent {
+  readonly externalName: string;
+  readonly localName: string | null;
+  readonly targetBindingId: IrBindingId | null;
+  readonly start: number;
+  readonly end: number;
+}
+
+export type IrModuleInitPlanGapCode =
+  | "missing-module-init-unit"
+  | "destructuring-binding-abi"
+  | "unresolved-export-target";
+
+export interface IrModuleInitPlanGap {
+  readonly code: IrModuleInitPlanGapCode;
+  readonly detail: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+/** Immutable, backend-neutral semantic inventory for one source module. */
+export interface IrModuleInitPlan {
+  readonly sourceId: IrSourceId;
+  readonly unitId: IrUnitId | null;
+  readonly executable: boolean;
+  readonly bindings: readonly IrModuleInitBindingIntent[];
+  readonly liveSeeds: readonly IrModuleInitLiveSeedIntent[];
+  readonly evaluations: readonly IrModuleInitEvaluationEntry[];
+  readonly exports: readonly IrModuleInitExportIntent[];
+  readonly invocation: IrModuleInitInvocationPolicy;
+  readonly gaps: readonly IrModuleInitPlanGap[];
+}
+
+export type IrModuleInitPlanInvariantCode =
+  | "source-record-mismatch"
+  | "duplicate-binding"
+  | "duplicate-live-seed"
+  | "duplicate-evaluation"
+  | "non-canonical-order"
+  | "invalid-invocation"
+  | "invalid-source-range";
+
+export class IrModuleInitPlanInvariantError extends Error {
+  constructor(
+    readonly code: IrModuleInitPlanInvariantCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "IrModuleInitPlanInvariantError";
+  }
+}
+
+export interface BuildIrModuleInitPlanInput {
+  readonly sourceFile: ts.SourceFile;
+  readonly checker: ts.TypeChecker;
+  readonly identityContext: IrPlanningIdentityContext;
+  readonly target: IrModuleInitTarget;
+  readonly deferTopLevelInit: boolean;
+}
+
+export interface LegacyModuleInitStaticEntry {
+  readonly initializer?: ts.Expression;
+  readonly staticBlock?: ts.ClassStaticBlockDeclaration;
+}
+
+export interface LegacyModuleInitObservationInput {
+  readonly liveFunctionNames: Iterable<string>;
+  readonly staticEntries: readonly LegacyModuleInitStaticEntry[];
+  readonly moduleStatements: readonly ts.Statement[];
+}
+
+export interface IrModuleInitParityReport {
+  readonly aligned: boolean;
+  readonly plannedEntryCount: number;
+  readonly legacyEntryCount: number;
+  readonly missingFromLegacy: readonly string[];
+  readonly extraInLegacy: readonly string[];
+  readonly reordered: readonly { readonly planned: string; readonly observed: string }[];
+  readonly plannedOrder: readonly string[];
+  readonly legacyOrder: readonly string[];
+}
+
+export interface IrModuleInitPlanningEvidence {
+  readonly plan: IrModuleInitPlan;
+  readonly parity: IrModuleInitParityReport;
+}
+
+function sourceRange(node: ts.Node, sourceFile: ts.SourceFile): { readonly start: number; readonly end: number } {
+  return { start: node.getStart(sourceFile), end: node.end };
+}
+
+function legacyNodeKey(kind: "statement" | "static", node: ts.Node, sourceFile: ts.SourceFile): string {
+  const { start, end } = sourceRange(node, sourceFile);
+  return `${kind}:${start}:${end}`;
+}
+
+function bindingNames(name: ts.BindingName): string[] {
+  if (ts.isIdentifier(name)) return [name.text];
+  const names: string[] = [];
+  for (const element of name.elements) {
+    if (ts.isOmittedExpression(element)) continue;
+    names.push(...bindingNames(element.name));
+  }
+  return names;
+}
+
+function declarationKind(list: ts.VariableDeclarationList): IrModuleBindingDeclarationKind {
+  if ((list.flags & ts.NodeFlags.Const) !== 0) return "const";
+  if ((list.flags & ts.NodeFlags.Let) !== 0) return "let";
+  return "var";
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  return (
+    ts.canHaveModifiers(node) &&
+    (ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ?? false)
+  );
+}
+
+function hasDefaultModifier(node: ts.Node): boolean {
+  return (
+    ts.canHaveModifiers(node) &&
+    (ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword) ?? false)
+  );
+}
+
+function invocationPolicy(
+  executable: boolean,
+  target: IrModuleInitTarget,
+  deferTopLevelInit: boolean,
+): IrModuleInitInvocationPolicy {
+  const kind: IrModuleInitInvocationKind = !executable
+    ? "none"
+    : target === "wasi"
+      ? "wasi-start-export"
+      : deferTopLevelInit
+        ? "deferred-export"
+        : "wasm-start";
+  return Object.freeze({ target, kind, exactlyOnce: true });
+}
+
+function collectReassignedTopLevelFunctions(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+): readonly ts.FunctionDeclaration[] {
+  const declarations = sourceFile.statements.filter(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name !== undefined && statement.body !== undefined,
+  );
+  const reassigned = new Set<ts.FunctionDeclaration>();
+  const declarationSet = new Set(declarations);
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+      node.operatorToken.kind <= ts.SyntaxKind.LastAssignment &&
+      ts.isIdentifier(node.left)
+    ) {
+      const symbol = checker.getSymbolAtLocation(node.left);
+      for (const declaration of symbol?.declarations ?? []) {
+        if (ts.isFunctionDeclaration(declaration) && declarationSet.has(declaration)) reassigned.add(declaration);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return declarations.filter((declaration) => reassigned.has(declaration));
+}
+
+function frozen<T extends object>(value: T): Readonly<T> {
+  return Object.freeze(value);
+}
+
+function pushExportIntent(
+  exports: IrModuleInitExportIntent[],
+  seen: Set<string>,
+  intent: IrModuleInitExportIntent,
+): void {
+  const identity = `${intent.externalName}\u0000${intent.start}\u0000${intent.end}`;
+  if (seen.has(identity)) return;
+  seen.add(identity);
+  exports.push(frozen(intent));
+}
+
+/** Build the semantic plan directly from source and structural R1 identities. */
+export function buildIrModuleInitPlan(input: BuildIrModuleInitPlanInput): IrModuleInitPlan {
+  const { sourceFile, checker, identityContext } = input;
+  const sourceId = identityContext.sourceIdBySourceFile.get(sourceFile);
+  if (!sourceId || identityContext.sourceFileBySourceId.get(sourceId) !== sourceFile) {
+    throw new IrModuleInitPlanInvariantError(
+      "source-record-mismatch",
+      `module-init plan source ${sourceFile.fileName} is absent from the exact identity inventory`,
+    );
+  }
+
+  const bindings: IrModuleInitBindingIntent[] = [];
+  const liveSeeds: IrModuleInitLiveSeedIntent[] = [];
+  const evaluations: IrModuleInitEvaluationEntry[] = [];
+  const exports: IrModuleInitExportIntent[] = [];
+  const gaps: IrModuleInitPlanGap[] = [];
+  const targetBindingByName = new Map<string, IrBindingId>();
+  const exported = new Set<string>();
+  let declarationOrdinal = 0;
+  let sourceOrdinal = 0;
+
+  // Export declarations are order-independent (`export { value }` may appear
+  // before `value`), so resolve their canonical local targets up front.
+  let targetDeclarationOrdinal = 0;
+  for (const statement of sourceFile.statements) {
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) {
+          targetBindingByName.set(declaration.name.text, irModuleGlobalBindingId(sourceId, targetDeclarationOrdinal));
+        }
+        targetDeclarationOrdinal++;
+      }
+    } else if (ts.isFunctionDeclaration(statement) && statement.name) {
+      const unitId = identityContext.unitIdByDeclaration.get(statement);
+      if (unitId) targetBindingByName.set(statement.name.text, irUnitCallableBindingId(unitId));
+    }
+  }
+
+  for (let statementOrdinal = 0; statementOrdinal < sourceFile.statements.length; statementOrdinal++) {
+    const statement = sourceFile.statements[statementOrdinal]!;
+    if (ts.isVariableStatement(statement)) {
+      const kind = declarationKind(statement.declarationList);
+      const statementBindingIds: IrBindingId[] = [];
+      for (const declaration of statement.declarationList.declarations) {
+        const names = bindingNames(declaration.name);
+        const identifier = ts.isIdentifier(declaration.name);
+        const globalBindingId = identifier ? irModuleGlobalBindingId(sourceId, declarationOrdinal) : null;
+        const tdzBindingId = identifier ? irModuleTdzGlobalBindingId(sourceId, declarationOrdinal) : null;
+        if (identifier && globalBindingId) {
+          statementBindingIds.push(globalBindingId);
+        } else {
+          const { start, end } = sourceRange(declaration, sourceFile);
+          gaps.push(
+            frozen({
+              code: "destructuring-binding-abi" as const,
+              detail: `top-level binding pattern ${names.join(", ")} has no one-to-one Program ABI slot`,
+              start,
+              end,
+            }),
+          );
+        }
+        const { start, end } = sourceRange(declaration, sourceFile);
+        bindings.push(
+          frozen({
+            declarationOrdinal,
+            names: Object.freeze(names),
+            declarationKind: kind,
+            mutable: kind !== "const",
+            initialization: kind === "var" ? "undefined-at-instantiation" : "tdz",
+            globalBindingId,
+            tdzBindingId: kind === "var" ? null : tdzBindingId,
+            start,
+            end,
+          }),
+        );
+        declarationOrdinal++;
+      }
+      if (statement.declarationList.declarations.some((declaration) => declaration.initializer !== undefined)) {
+        const { start, end } = sourceRange(statement, sourceFile);
+        evaluations.push(
+          frozen({
+            key: `${sourceId}:eval:${sourceOrdinal}`,
+            kind: "variable-initializer" as const,
+            sourceOrdinal: sourceOrdinal++,
+            statementOrdinal,
+            nestedOrdinal: 0,
+            start,
+            end,
+            classId: null,
+            bindingIds: Object.freeze(statementBindingIds),
+            legacyKey: legacyNodeKey("statement", statement, sourceFile),
+          }),
+        );
+      }
+      if (hasExportModifier(statement)) {
+        for (const declaration of statement.declarationList.declarations) {
+          for (const name of bindingNames(declaration.name)) {
+            pushExportIntent(exports, exported, {
+              externalName: name,
+              localName: name,
+              targetBindingId: targetBindingByName.get(name) ?? null,
+              ...sourceRange(declaration, sourceFile),
+            });
+          }
+        }
+      }
+      continue;
+    }
+
+    if (ts.isClassDeclaration(statement)) {
+      const classId = identityContext.classIdByDeclaration.get(statement) ?? null;
+      let nestedOrdinal = 0;
+      for (const member of statement.members) {
+        const isStatic =
+          ts.canHaveModifiers(member) &&
+          (ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword) ?? false);
+        const node = ts.isClassStaticBlockDeclaration(member)
+          ? member
+          : isStatic && ts.isPropertyDeclaration(member) && member.initializer
+            ? member.initializer
+            : undefined;
+        if (!node) continue;
+        const { start, end } = sourceRange(node, sourceFile);
+        evaluations.push(
+          frozen({
+            key: `${sourceId}:eval:${sourceOrdinal}`,
+            kind: ts.isClassStaticBlockDeclaration(member) ? "class-static-block" : "class-static-field",
+            sourceOrdinal: sourceOrdinal++,
+            statementOrdinal,
+            nestedOrdinal: nestedOrdinal++,
+            start,
+            end,
+            classId,
+            bindingIds: Object.freeze([]),
+            legacyKey: legacyNodeKey("static", node, sourceFile),
+          }),
+        );
+      }
+      if (hasExportModifier(statement) && statement.name) {
+        const unitId = identityContext.unitIdByDeclaration.get(statement);
+        pushExportIntent(exports, exported, {
+          externalName: hasDefaultModifier(statement) ? "default" : statement.name.text,
+          localName: statement.name.text,
+          targetBindingId: unitId ? irUnitCallableBindingId(unitId) : null,
+          ...sourceRange(statement, sourceFile),
+        });
+      }
+      continue;
+    }
+
+    if (ts.isFunctionDeclaration(statement)) {
+      if (hasExportModifier(statement)) {
+        const unitId = identityContext.unitIdByDeclaration.get(statement);
+        const localName = statement.name?.text ?? null;
+        pushExportIntent(exports, exported, {
+          externalName: hasDefaultModifier(statement) ? "default" : (localName ?? "default"),
+          localName,
+          targetBindingId: unitId ? irUnitCallableBindingId(unitId) : null,
+          ...sourceRange(statement, sourceFile),
+        });
+      }
+      continue;
+    }
+
+    if (ts.isExportDeclaration(statement) && !statement.moduleSpecifier && statement.exportClause) {
+      if (ts.isNamedExports(statement.exportClause)) {
+        for (const element of statement.exportClause.elements) {
+          const localName = (element.propertyName ?? element.name).text;
+          const targetBindingId = targetBindingByName.get(localName) ?? null;
+          if (!targetBindingId) {
+            const { start, end } = sourceRange(element, sourceFile);
+            gaps.push(
+              frozen({
+                code: "unresolved-export-target" as const,
+                detail: `export ${element.name.text} has no planned local binding target`,
+                start,
+                end,
+              }),
+            );
+          }
+          pushExportIntent(exports, exported, {
+            externalName: element.name.text,
+            localName,
+            targetBindingId,
+            ...sourceRange(element, sourceFile),
+          });
+        }
+      }
+      continue;
+    }
+
+    if (
+      ts.isInterfaceDeclaration(statement) ||
+      ts.isTypeAliasDeclaration(statement) ||
+      ts.isImportDeclaration(statement) ||
+      ts.isImportEqualsDeclaration(statement) ||
+      ts.isEmptyStatement(statement)
+    ) {
+      continue;
+    }
+
+    const { start, end } = sourceRange(statement, sourceFile);
+    const kind: IrModuleInitEvaluationKind = ts.isExportAssignment(statement) ? "export-assignment" : "statement";
+    evaluations.push(
+      frozen({
+        key: `${sourceId}:eval:${sourceOrdinal}`,
+        kind,
+        sourceOrdinal: sourceOrdinal++,
+        statementOrdinal,
+        nestedOrdinal: 0,
+        start,
+        end,
+        classId: null,
+        bindingIds: Object.freeze([]),
+        legacyKey: legacyNodeKey("statement", statement, sourceFile),
+      }),
+    );
+    if (ts.isExportAssignment(statement)) {
+      pushExportIntent(exports, exported, {
+        externalName: "default",
+        localName: null,
+        targetBindingId: null,
+        start,
+        end,
+      });
+    }
+  }
+
+  const functions = sourceFile.statements.filter(ts.isFunctionDeclaration);
+  for (const declaration of collectReassignedTopLevelFunctions(sourceFile, checker)) {
+    const unitId = identityContext.unitIdByDeclaration.get(declaration);
+    if (!unitId || !declaration.name) continue;
+    liveSeeds.push(
+      frozen({
+        name: declaration.name.text,
+        unitId,
+        callableBindingId: irUnitCallableBindingId(unitId),
+        liveGlobalBindingId: createIrBindingId({ ownerId: unitId, domain: "global", role: "live-function" }),
+        declarationOrdinal: functions.indexOf(declaration),
+        legacyKey: `live:${declaration.name.text}`,
+      }),
+    );
+  }
+
+  const executable = liveSeeds.length > 0 || evaluations.length > 0;
+  const unitId = identityContext.moduleInitUnitIdBySourceFile.get(sourceFile) ?? null;
+  if (executable && unitId === null) {
+    gaps.push(
+      frozen({
+        code: "missing-module-init-unit" as const,
+        detail: "executable top-level semantics have no source-owned module-init terminal",
+        start: 0,
+        end: sourceFile.end,
+      }),
+    );
+  }
+  const plan = frozen({
+    sourceId,
+    unitId,
+    executable,
+    bindings: Object.freeze(bindings),
+    liveSeeds: Object.freeze(liveSeeds),
+    evaluations: Object.freeze(evaluations),
+    exports: Object.freeze(exports),
+    invocation: invocationPolicy(executable, input.target, input.deferTopLevelInit),
+    gaps: Object.freeze(gaps),
+  });
+  verifyIrModuleInitPlan(plan, sourceFile);
+  return plan;
+}
+
+/** Fail closed on malformed or non-canonical plan data before any body uses it. */
+export function verifyIrModuleInitPlan(plan: IrModuleInitPlan, sourceFile: ts.SourceFile): void {
+  const bindingIds = new Set<IrBindingId>();
+  for (const binding of plan.bindings) {
+    if (binding.start < 0 || binding.end < binding.start || binding.end > sourceFile.end) {
+      throw new IrModuleInitPlanInvariantError("invalid-source-range", "module binding has an invalid source range");
+    }
+    for (const bindingId of [binding.globalBindingId, binding.tdzBindingId]) {
+      if (!bindingId) continue;
+      if (bindingIds.has(bindingId)) {
+        throw new IrModuleInitPlanInvariantError("duplicate-binding", `binding ${bindingId} occurs more than once`);
+      }
+      bindingIds.add(bindingId);
+    }
+  }
+  const seedNames = new Set<string>();
+  for (const seed of plan.liveSeeds) {
+    if (seedNames.has(seed.name)) {
+      throw new IrModuleInitPlanInvariantError("duplicate-live-seed", `live seed ${seed.name} occurs more than once`);
+    }
+    seedNames.add(seed.name);
+  }
+  const evaluationKeys = new Set<string>();
+  for (let index = 0; index < plan.evaluations.length; index++) {
+    const entry = plan.evaluations[index]!;
+    if (entry.sourceOrdinal !== index) {
+      throw new IrModuleInitPlanInvariantError(
+        "non-canonical-order",
+        `evaluation ${entry.key} has ordinal ${entry.sourceOrdinal}, expected ${index}`,
+      );
+    }
+    if (entry.start < 0 || entry.end < entry.start || entry.end > sourceFile.end) {
+      throw new IrModuleInitPlanInvariantError("invalid-source-range", `evaluation ${entry.key} has an invalid range`);
+    }
+    if (evaluationKeys.has(entry.key)) {
+      throw new IrModuleInitPlanInvariantError("duplicate-evaluation", `evaluation ${entry.key} occurs more than once`);
+    }
+    evaluationKeys.add(entry.key);
+  }
+  if (plan.executable !== (plan.liveSeeds.length > 0 || plan.evaluations.length > 0)) {
+    throw new IrModuleInitPlanInvariantError("invalid-invocation", "executable flag disagrees with planned entries");
+  }
+  if ((plan.invocation.kind === "none") !== !plan.executable || plan.invocation.exactlyOnce !== true) {
+    throw new IrModuleInitPlanInvariantError("invalid-invocation", "module-init invocation policy is inconsistent");
+  }
+}
+
+function duplicates(values: readonly string[], label: string): void {
+  if (new Set(values).size !== values.length) {
+    throw new IrModuleInitPlanInvariantError("duplicate-evaluation", `${label} contains duplicate queue identities`);
+  }
+}
+
+/** Compare the semantic order with the current direct-front-end queues. */
+export function reconcileIrModuleInitPlan(
+  plan: IrModuleInitPlan,
+  sourceFile: ts.SourceFile,
+  legacy: LegacyModuleInitObservationInput,
+): IrModuleInitParityReport {
+  const plannedOrder = [
+    ...plan.liveSeeds.map((seed) => seed.legacyKey),
+    ...plan.evaluations.map((entry) => entry.legacyKey),
+  ];
+  const legacyOrder = [
+    ...[...legacy.liveFunctionNames].map((name) => `live:${name}`),
+    ...legacy.staticEntries.flatMap((entry) => {
+      const node = entry.staticBlock ?? entry.initializer;
+      return node ? [legacyNodeKey("static", node, sourceFile)] : [];
+    }),
+    ...legacy.moduleStatements.map((statement) => legacyNodeKey("statement", statement, sourceFile)),
+  ];
+  duplicates(plannedOrder, "module-init plan");
+  duplicates(legacyOrder, "legacy module-init observation");
+  const plannedSet = new Set(plannedOrder);
+  const legacySet = new Set(legacyOrder);
+  const missingFromLegacy = plannedOrder.filter((key) => !legacySet.has(key));
+  const extraInLegacy = legacyOrder.filter((key) => !plannedSet.has(key));
+  const commonPlanned = plannedOrder.filter((key) => legacySet.has(key));
+  const commonLegacy = legacyOrder.filter((key) => plannedSet.has(key));
+  const reordered: { planned: string; observed: string }[] = [];
+  for (let index = 0; index < Math.max(commonPlanned.length, commonLegacy.length); index++) {
+    const planned = commonPlanned[index];
+    const observed = commonLegacy[index];
+    if (planned !== observed && planned !== undefined && observed !== undefined) {
+      reordered.push(frozen({ planned, observed }));
+    }
+  }
+  return frozen({
+    aligned: missingFromLegacy.length === 0 && extraInLegacy.length === 0 && reordered.length === 0,
+    plannedEntryCount: plannedOrder.length,
+    legacyEntryCount: legacyOrder.length,
+    missingFromLegacy: Object.freeze(missingFromLegacy),
+    extraInLegacy: Object.freeze(extraInLegacy),
+    reordered: Object.freeze(reordered),
+    plannedOrder: Object.freeze(plannedOrder),
+    legacyOrder: Object.freeze(legacyOrder),
+  });
+}

--- a/tests/issue-3523-ir-module-init-compile-once.test.ts
+++ b/tests/issue-3523-ir-module-init-compile-once.test.ts
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource, type TypedAST } from "../src/checker/index.js";
+import { generateModule } from "../src/codegen/index.js";
+import { buildIrUnitInventory } from "../src/ir/identity.js";
+import {
+  buildIrModuleInitPlan,
+  IrModuleInitPlanInvariantError,
+  reconcileIrModuleInitPlan,
+  verifyIrModuleInitPlan,
+  type IrModuleInitPlan,
+  type IrModuleInitTarget,
+} from "../src/ir/module-init-plan.js";
+import { buildIrPlanningIdentityContext } from "../src/ir/planning-identity.js";
+
+// Register the statement/expression delegates used by generateModule.
+import "../src/codegen/expressions.js";
+
+function buildPlan(
+  source: string,
+  target: IrModuleInitTarget = "host",
+  deferTopLevelInit = false,
+): { readonly ast: TypedAST; readonly plan: IrModuleInitPlan } {
+  const ast = analyzeSource(source, "module-init-plan.ts");
+  const identityContext = buildIrPlanningIdentityContext(
+    buildIrUnitInventory([ast.sourceFile], { entrySource: ast.sourceFile, checker: ast.checker }),
+  );
+  return {
+    ast,
+    plan: buildIrModuleInitPlan({
+      sourceFile: ast.sourceFile,
+      checker: ast.checker,
+      identityContext,
+      target,
+      deferTopLevelInit,
+    }),
+  };
+}
+
+describe("#3523 source-ordered module-init planning", () => {
+  it("builds exact binding, live-seed, export, static, and invocation intents", () => {
+    const { plan } = buildPlan(
+      `
+        export let value: number = 1;
+        function live(): number { return 1; }
+        live = function replacement(): number { return 2; };
+        value += live();
+        class Box {
+          static first: number = value++;
+          static { value += 10; }
+        }
+        value += 100;
+        export { value as alias };
+      `,
+      "host",
+      true,
+    );
+
+    expect(plan.unitId).not.toBeNull();
+    expect(plan.executable).toBe(true);
+    expect(plan.invocation).toEqual({ target: "host", kind: "deferred-export", exactlyOnce: true });
+    expect(plan.bindings).toEqual([
+      expect.objectContaining({
+        names: ["value"],
+        declarationKind: "let",
+        mutable: true,
+        initialization: "tdz",
+        globalBindingId: expect.stringContaining("ir-binding:v1:global:"),
+        tdzBindingId: expect.stringContaining("ir-binding:v1:global:"),
+      }),
+    ]);
+    expect(plan.liveSeeds).toEqual([
+      expect.objectContaining({
+        name: "live",
+        callableBindingId: expect.stringContaining("ir-binding:v1:callable:"),
+        liveGlobalBindingId: expect.stringContaining("ir-binding:v1:global:"),
+      }),
+    ]);
+    expect(plan.evaluations.map((entry) => entry.kind)).toEqual([
+      "variable-initializer",
+      "statement",
+      "statement",
+      "class-static-field",
+      "class-static-block",
+      "statement",
+    ]);
+    expect(plan.evaluations.map((entry) => entry.sourceOrdinal)).toEqual([0, 1, 2, 3, 4, 5]);
+    const valueExport = plan.exports.find((entry) => entry.externalName === "value");
+    const aliasExport = plan.exports.find((entry) => entry.externalName === "alias");
+    expect(valueExport?.targetBindingId).toBe(plan.bindings[0]!.globalBindingId);
+    expect(aliasExport?.targetBindingId).toBe(valueExport?.targetBindingId);
+    expect(plan.gaps).toEqual([]);
+    expect(Object.isFrozen(plan)).toBe(true);
+    expect(Object.isFrozen(plan.evaluations)).toBe(true);
+  });
+
+  it("makes empty modules explicit and derives each startup adapter before emission", () => {
+    const empty = buildPlan(`export function read(): number { return 1; }`).plan;
+    expect(empty).toMatchObject({ executable: false, unitId: null, invocation: { kind: "none" } });
+
+    expect(buildPlan(`let x: number = 1;`, "host").plan.invocation.kind).toBe("wasm-start");
+    expect(buildPlan(`let x: number = 1;`, "standalone", true).plan.invocation.kind).toBe("deferred-export");
+    expect(buildPlan(`let x: number = 1;`, "wasi", true).plan.invocation.kind).toBe("wasi-start-export");
+  });
+
+  it("records capability gaps instead of dropping unmatched top-level semantics", () => {
+    const destructuring = buildPlan(`let [first, second] = [1, 2];`).plan;
+    expect(destructuring.gaps).toEqual([
+      expect.objectContaining({ code: "destructuring-binding-abi", detail: expect.stringContaining("first, second") }),
+    ]);
+    expect(destructuring.evaluations).toHaveLength(1);
+
+    const exportAssignment = buildPlan(`export default sideEffect();`).plan;
+    expect(exportAssignment.evaluations.map((entry) => entry.kind)).toEqual(["export-assignment"]);
+    expect(exportAssignment.gaps).toEqual([expect.objectContaining({ code: "missing-module-init-unit" })]);
+
+    const forwardExport = buildPlan(`export { later }; function later(): number { return 1; }`).plan;
+    expect(forwardExport.exports).toEqual([
+      expect.objectContaining({
+        externalName: "later",
+        localName: "later",
+        targetBindingId: expect.stringContaining("ir-binding:v1:callable:"),
+      }),
+    ]);
+    expect(forwardExport.gaps).toEqual([]);
+  });
+
+  it("fails closed when a plan loses canonical order", () => {
+    const { ast, plan } = buildPlan(`let x: number = 1; x += 2;`);
+    const invalid = {
+      ...plan,
+      evaluations: [plan.evaluations[0]!, { ...plan.evaluations[1]!, sourceOrdinal: 0 }],
+    } as IrModuleInitPlan;
+    expect(() => verifyIrModuleInitPlan(invalid, ast.sourceFile)).toThrowError(
+      expect.objectContaining<IrModuleInitPlanInvariantError>({ code: "non-canonical-order" }),
+    );
+  });
+});
+
+describe("#3523 direct-queue parity inventory", () => {
+  it("aligns for an ordered statement-only module", () => {
+    const { ast, plan } = buildPlan(`let x: number = 1; x += 2;`);
+    const report = reconcileIrModuleInitPlan(plan, ast.sourceFile, {
+      liveFunctionNames: [],
+      staticEntries: [],
+      moduleStatements: [...ast.sourceFile.statements],
+    });
+    expect(report).toMatchObject({
+      aligned: true,
+      plannedEntryCount: 2,
+      legacyEntryCount: 2,
+      missingFromLegacy: [],
+      extraInLegacy: [],
+      reordered: [],
+    });
+  });
+
+  it("detects the legacy all-statics-before-statements reordering in production", () => {
+    const ast = analyzeSource(
+      `
+        let value: number = 1;
+        class Box {
+          static first: number = value++;
+          static { value += 10; }
+        }
+        value += 100;
+      `,
+      "module-init-production-plan.ts",
+    );
+    const generated = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      deferTopLevelInit: true,
+    });
+    const evidence = generated.moduleInitPlanning;
+    expect(evidence).toBeDefined();
+    expect(evidence!.plan).toMatchObject({
+      executable: true,
+      invocation: { target: "host", kind: "deferred-export", exactlyOnce: true },
+    });
+    expect(evidence!.parity.missingFromLegacy).toEqual([]);
+    expect(evidence!.parity.extraInLegacy).toEqual([]);
+    expect(evidence!.parity.aligned).toBe(false);
+    expect(evidence!.parity.reordered.length).toBeGreaterThan(0);
+    expect(evidence!.parity.plannedOrder[0]).toMatch(/^statement:/);
+    expect(evidence!.parity.legacyOrder[0]).toMatch(/^static:/);
+  });
+});

--- a/tests/issue-3523-ir-module-init-compile-once.test.ts
+++ b/tests/issue-3523-ir-module-init-compile-once.test.ts
@@ -157,6 +157,47 @@ describe("#3523 direct-queue parity inventory", () => {
     });
   });
 
+  it("reports repeated legacy queue identities as extra work instead of failing compilation", () => {
+    const { ast, plan } = buildPlan(`let x: number = 1;`);
+    const statement = ast.sourceFile.statements[0]!;
+    const report = reconcileIrModuleInitPlan(plan, ast.sourceFile, {
+      liveFunctionNames: [],
+      staticEntries: [],
+      moduleStatements: [statement, statement],
+    });
+    expect(report).toMatchObject({
+      aligned: false,
+      plannedEntryCount: 1,
+      legacyEntryCount: 2,
+      missingFromLegacy: [],
+      extraInLegacy: [report.plannedOrder[0]],
+      reordered: [],
+    });
+  });
+
+  it("keeps duplicated class-expression static queues observational", () => {
+    const ast = analyzeSource(
+      `var C = class { static #a = 1; static #b = 2; m() { return 42; } };`,
+      "module-init-class-expression-duplicate.js",
+    );
+    const generated = generateModule(ast, {
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      deferTopLevelInit: true,
+    });
+    const evidence = generated.moduleInitPlanning;
+    expect(evidence).toBeDefined();
+    expect(evidence!.parity).toMatchObject({
+      aligned: false,
+      plannedEntryCount: 1,
+      legacyEntryCount: 4,
+      missingFromLegacy: [expect.stringMatching(/^statement:/)],
+      reordered: [],
+    });
+    expect(evidence!.parity.extraInLegacy).toHaveLength(4);
+    expect(new Set(evidence!.parity.extraInLegacy).size).toBe(2);
+  });
+
   it("detects the legacy all-statics-before-statements reordering in production", () => {
     const ast = analyzeSource(
       `


### PR DESCRIPTION
## Summary

- add an immutable, source-qualified IR module-initialization plan before body emission
- record top-level storage, TDZ state, live function seeds, source-ordered initialization, export aliases, and startup policy
- verify canonical identities and surface typed gaps instead of silently dropping module behavior
- expose production parity evidence without changing routing yet

Plan: plan/issues/3523-ir-r4-module-init-compile-once.md

## Validation

- focused and adjacent matrix: 37/37 passing
- typecheck, lint, formatting, issue integrity, LOC/function budgets: passing
- IR fallback gate: passing with zero unintended or post-claim increases
- hybrid readiness unchanged at 33/37 IR bodies, four typed unsupported units, and zero invariants
- optimization ledger unchanged at 21 rows, 10 IR-owned, one retirement-ready

The broader adjacent matrix is 51/55: two issue-3142 failures reproduce on untouched main, and two issue-3505 cases require the optional test262-fyi/data submodule.