### PR TITLE
feat(ir): add frozen pure-math runtime manifest

### DIFF
--- a/plan/issues/3526-ir-r6-semantic-runtime-contract.md
+++ b/plan/issues/3526-ir-r6-semantic-runtime-contract.md
@@ -4,7 +4,7 @@ title: "IR-only R6: typed semantic runtime contract and frozen feature manifest"
 status: blocked
 sprint: Backlog
 created: 2026-07-21
-updated: 2026-07-21
+updated: 2026-08-02
 priority: critical
 horizon: xl
 complexity: XL
@@ -186,6 +186,33 @@ is permitted.
 - Add a legacy parity adapter that compares planned vs observed imports/helpers
   without granting authority to observed strings. Add poison seams for every
   late mutation path.
+
+#### C0 foundation landing (2026-08-02)
+
+The isolated schema seam now defines the exact twelve certified pure-Math
+`IntrinsicId`s, their fourteen-entry transitive `RuntimeFeature` vocabulary
+(including `math.atan` and `math.reduce-trig` provider dependencies), and the
+deliberately empty `HostCapability` vocabulary for this host-free family.
+Signatures are versioned f64 contracts; effect evidence is opaque and can only
+be created through the existing `effectsOf` authority. The runtime-manifest
+builder verifies intrinsic uses and provider signatures/adapters, expands
+dependencies to a deterministic fixed point, requires explicit declarations
+for cycles, emits canonical dependency components, and rejects both mutation
+and unplanned lookup after deep freeze.
+
+Focused anti-vacuity coverage proves all twelve methods against
+`IR_MATH_METHOD_TABLE`, canonical output under reversed use/provider traversal,
+the shared `pow -> exp + log`, `atan2 -> atan`, and `sin/cos -> reduce-trig`
+closure, an injected declared cycle, all eight target/backend policy pairs,
+zero host capabilities, provider-name independence, and typed failures for bad
+IDs/signatures/effects/providers/adapters and late requests.
+
+This landing intentionally stops before M1 routing. The exact follow-up is to
+add the semantic intrinsic use to prepared IR in the sequential owner of
+`nodes.ts`/`effects.ts`/`from-ast.ts`, collect it into this builder before ABI
+publication, and make backend lowering resolve only the frozen provider plan.
+Until that shared integration lands, the existing `Math_*` discovery and
+providers remain unchanged and authoritative for production emission.
 
 ### M1 — deterministic pure Math
 

--- a/src/ir/intrinsics.ts
+++ b/src/ir/intrinsics.ts
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * Closed semantic vocabulary for the first R6 runtime-contract slice.
+ *
+ * These identifiers name meaning, never a concrete helper, import, or module
+ * index. The initial vocabulary deliberately matches the exact deterministic,
+ * exact-arity f64 Math surface certified by `IR_MATH_METHOD_TABLE`. Widening
+ * any of these unions is therefore a reviewed runtime-contract change.
+ */
+import { effectsArePure, effectsOf } from "./effects.js";
+import { irTypeEquals, type IrInstr, type IrType } from "./nodes.js";
+
+export const PURE_MATH_INTRINSIC_IDS = Object.freeze([
+  "math.abs",
+  "math.atan2",
+  "math.ceil",
+  "math.cos",
+  "math.exp",
+  "math.floor",
+  "math.log",
+  "math.log2",
+  "math.pow",
+  "math.sin",
+  "math.sqrt",
+  "math.trunc",
+] as const);
+
+export type IntrinsicId = (typeof PURE_MATH_INTRINSIC_IDS)[number];
+
+/**
+ * Provider requirements reachable from the twelve intrinsic entry points.
+ * `math.atan` and `math.reduce-trig` are provider-only dependencies and are
+ * intentionally not source-level intrinsic IDs in this slice.
+ */
+export const PURE_MATH_RUNTIME_FEATURES = Object.freeze([
+  "math.abs",
+  "math.atan",
+  "math.atan2",
+  "math.ceil",
+  "math.cos",
+  "math.exp",
+  "math.floor",
+  "math.log",
+  "math.log2",
+  "math.pow",
+  "math.reduce-trig",
+  "math.sin",
+  "math.sqrt",
+  "math.trunc",
+] as const);
+
+export type RuntimeFeature = (typeof PURE_MATH_RUNTIME_FEATURES)[number];
+
+/**
+ * The certified deterministic Math slice is host-free by construction.
+ * Its exhaustive host-capability vocabulary is therefore empty. A later R6
+ * family must widen this union before it can request an external capability;
+ * `Math.random` cannot accidentally enter through a stringly import name.
+ */
+export const PURE_MATH_HOST_CAPABILITIES = Object.freeze([] as const);
+export type HostCapability = (typeof PURE_MATH_HOST_CAPABILITIES)[number];
+
+export const INTRINSIC_SIGNATURE_VERSION = 1 as const;
+export type IntrinsicSignatureVersion = typeof INTRINSIC_SIGNATURE_VERSION;
+
+export interface IntrinsicSignature {
+  readonly version: IntrinsicSignatureVersion;
+  readonly params: readonly IrType[];
+  readonly result: IrType;
+}
+
+export interface IntrinsicSourceLocation {
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+}
+
+export interface IntrinsicUse {
+  readonly id: IntrinsicId;
+  readonly version: IntrinsicSignatureVersion;
+  readonly argumentTypes: readonly IrType[];
+  readonly resultType: IrType;
+  readonly location: IntrinsicSourceLocation;
+}
+
+export interface IntrinsicDefinition {
+  readonly id: IntrinsicId;
+  readonly signature: IntrinsicSignature;
+  readonly feature: RuntimeFeature;
+}
+
+export type IntrinsicVerificationCode =
+  | "unknown-intrinsic"
+  | "invalid-intrinsic-location"
+  | "intrinsic-version-mismatch"
+  | "intrinsic-signature-mismatch"
+  | "intrinsic-effect-mismatch";
+
+export interface IntrinsicVerificationFailure {
+  readonly code: IntrinsicVerificationCode;
+  readonly detail: string;
+}
+
+const F64_TYPE = Object.freeze({
+  kind: "val" as const,
+  val: Object.freeze({ kind: "f64" as const }),
+});
+
+export const F64_UNARY_INTRINSIC_SIGNATURE: IntrinsicSignature = Object.freeze({
+  version: INTRINSIC_SIGNATURE_VERSION,
+  params: Object.freeze([F64_TYPE]),
+  result: F64_TYPE,
+});
+
+export const F64_BINARY_INTRINSIC_SIGNATURE: IntrinsicSignature = Object.freeze({
+  version: INTRINSIC_SIGNATURE_VERSION,
+  params: Object.freeze([F64_TYPE, F64_TYPE]),
+  result: F64_TYPE,
+});
+
+function definition(id: IntrinsicId, signature: IntrinsicSignature, feature: RuntimeFeature = id): IntrinsicDefinition {
+  return Object.freeze({ id, signature, feature });
+}
+
+/** Exhaustive entry contract. Record typing makes an added ID fail closed. */
+export const INTRINSIC_DEFINITIONS: Readonly<Record<IntrinsicId, IntrinsicDefinition>> = Object.freeze({
+  "math.abs": definition("math.abs", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.atan2": definition("math.atan2", F64_BINARY_INTRINSIC_SIGNATURE),
+  "math.ceil": definition("math.ceil", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.cos": definition("math.cos", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.exp": definition("math.exp", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.floor": definition("math.floor", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.log": definition("math.log", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.log2": definition("math.log2", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.pow": definition("math.pow", F64_BINARY_INTRINSIC_SIGNATURE),
+  "math.sin": definition("math.sin", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.sqrt": definition("math.sqrt", F64_UNARY_INTRINSIC_SIGNATURE),
+  "math.trunc": definition("math.trunc", F64_UNARY_INTRINSIC_SIGNATURE),
+});
+
+const INTRINSIC_ID_SET: ReadonlySet<string> = new Set(PURE_MATH_INTRINSIC_IDS);
+
+export function isIntrinsicId(value: string): value is IntrinsicId {
+  return INTRINSIC_ID_SET.has(value);
+}
+
+/**
+ * Opaque proof that effect classification came from the existing `effectsOf`
+ * authority. R6 does not grow a second throw/allocate/suspend table beside it.
+ * The future intrinsic IR node can use this seam once M1 owns nodes/effects.
+ */
+export class IntrinsicEffectEvidence {
+  readonly #pure: boolean;
+
+  private constructor(instruction: IrInstr) {
+    this.#pure = effectsArePure(effectsOf(instruction));
+    Object.freeze(this);
+  }
+
+  static fromInstruction(instruction: IrInstr): IntrinsicEffectEvidence {
+    return new IntrinsicEffectEvidence(instruction);
+  }
+
+  isPure(): boolean {
+    return this.#pure;
+  }
+}
+
+export function intrinsicEffectEvidence(instruction: IrInstr): IntrinsicEffectEvidence {
+  return IntrinsicEffectEvidence.fromInstruction(instruction);
+}
+
+function signatureMismatch(use: IntrinsicUse, signature: IntrinsicSignature): string | undefined {
+  if (use.argumentTypes.length !== signature.params.length) {
+    return `${use.id} expects ${signature.params.length} argument(s), received ${use.argumentTypes.length}`;
+  }
+  for (let index = 0; index < signature.params.length; index++) {
+    if (!irTypeEquals(use.argumentTypes[index]!, signature.params[index]!)) {
+      return `${use.id} argument ${index} does not match its v${signature.version} signature`;
+    }
+  }
+  if (!irTypeEquals(use.resultType, signature.result)) {
+    return `${use.id} result does not match its v${signature.version} signature`;
+  }
+  return undefined;
+}
+
+/** Verify one semantic use before it is admitted to the manifest builder. */
+export function verifyIntrinsicUse(
+  use: IntrinsicUse,
+  effects: IntrinsicEffectEvidence,
+): IntrinsicVerificationFailure | undefined {
+  if (!isIntrinsicId(use.id)) {
+    return { code: "unknown-intrinsic", detail: `unknown intrinsic ${String(use.id)}` };
+  }
+  if (
+    use.location.file.length === 0 ||
+    !Number.isInteger(use.location.line) ||
+    use.location.line < 1 ||
+    !Number.isInteger(use.location.column) ||
+    use.location.column < 0
+  ) {
+    return { code: "invalid-intrinsic-location", detail: `${use.id} has an invalid source location` };
+  }
+  const definition = INTRINSIC_DEFINITIONS[use.id];
+  if (use.version !== definition.signature.version) {
+    return {
+      code: "intrinsic-version-mismatch",
+      detail: `${use.id} uses signature v${use.version}; expected v${definition.signature.version}`,
+    };
+  }
+  const mismatch = signatureMismatch(use, definition.signature);
+  if (mismatch) return { code: "intrinsic-signature-mismatch", detail: mismatch };
+  if (!(effects instanceof IntrinsicEffectEvidence) || !effects.isPure()) {
+    return {
+      code: "intrinsic-effect-mismatch",
+      detail: `${use.id} is certified pure but its IR effect authority reports observable effects`,
+    };
+  }
+  return undefined;
+}

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -1,0 +1,705 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * Deterministic R6 semantic-runtime manifest for the certified pure-Math slice.
+ *
+ * The builder is the preparation-time mutation boundary. `freeze()` verifies
+ * intrinsic contracts, expands provider dependencies to a fixed point,
+ * validates cycles and target/backend adapters, and publishes only deeply
+ * frozen arrays/records. Lowering receives lookup-only `resolveProvider` calls;
+ * a request absent from the frozen plan is a typed invariant.
+ */
+import { irTypeEquals } from "./nodes.js";
+import {
+  F64_BINARY_INTRINSIC_SIGNATURE,
+  F64_UNARY_INTRINSIC_SIGNATURE,
+  INTRINSIC_DEFINITIONS,
+  PURE_MATH_HOST_CAPABILITIES,
+  PURE_MATH_RUNTIME_FEATURES,
+  type HostCapability,
+  type IntrinsicEffectEvidence,
+  type IntrinsicId,
+  type IntrinsicSignature,
+  type IntrinsicUse,
+  type IntrinsicVerificationCode,
+  type RuntimeFeature,
+  verifyIntrinsicUse,
+} from "./intrinsics.js";
+
+export type RuntimeTarget = "host" | "strict-no-host" | "standalone" | "wasi";
+export type RuntimeBackend = "wasmgc" | "linear";
+
+export interface RuntimeManifestPolicy {
+  readonly target: RuntimeTarget;
+  readonly backend: RuntimeBackend;
+}
+
+export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
+  "backend.f64.abs",
+  "backend.f64.ceil",
+  "backend.f64.floor",
+  "backend.f64.sqrt",
+  "backend.f64.trunc",
+  "selfhost.math.atan",
+  "selfhost.math.atan2",
+  "selfhost.math.cos",
+  "selfhost.math.exp",
+  "selfhost.math.log",
+  "selfhost.math.log2",
+  "selfhost.math.pow",
+  "selfhost.math.reduce-trig",
+  "selfhost.math.sin",
+] as const);
+
+export type RuntimeProviderId = (typeof PURE_MATH_RUNTIME_PROVIDER_IDS)[number];
+
+export type RuntimeProviderImplementation =
+  | {
+      readonly kind: "backend-op";
+      readonly opcode: "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.ceil" | "f64.trunc";
+    }
+  | {
+      readonly kind: "self-hosted";
+      /** Concrete ABI spelling, deliberately below the semantic feature. */
+      readonly symbol: string;
+    };
+
+export interface RuntimeProviderDefinition {
+  readonly id: RuntimeProviderId;
+  readonly feature: RuntimeFeature;
+  readonly signature: IntrinsicSignature;
+  readonly dependencies: readonly RuntimeFeature[];
+  readonly hostCapabilities: readonly HostCapability[];
+  readonly supportedTargets: readonly RuntimeTarget[];
+  readonly supportedBackends: readonly RuntimeBackend[];
+  readonly implementation: RuntimeProviderImplementation;
+}
+
+export type RuntimeProviderPlan = RuntimeProviderDefinition;
+
+export interface RuntimeProviderComponent {
+  readonly features: readonly RuntimeFeature[];
+  readonly providers: readonly RuntimeProviderId[];
+  readonly cyclic: boolean;
+}
+
+export interface FrozenRuntimeManifest {
+  readonly policy: RuntimeManifestPolicy;
+  readonly intrinsicUses: readonly IntrinsicUse[];
+  readonly features: readonly RuntimeFeature[];
+  readonly providers: readonly RuntimeProviderPlan[];
+  readonly providerComponents: readonly RuntimeProviderComponent[];
+  readonly hostCapabilities: readonly HostCapability[];
+}
+
+export type RuntimeManifestInvariantCode =
+  | IntrinsicVerificationCode
+  | "manifest-frozen"
+  | "manifest-build-failed"
+  | "manifest-not-frozen"
+  | "unknown-runtime-feature"
+  | "unknown-runtime-provider"
+  | "unknown-host-capability"
+  | "duplicate-runtime-provider"
+  | "duplicate-cycle-declaration"
+  | "invalid-cycle-declaration"
+  | "missing-runtime-provider"
+  | "ambiguous-runtime-provider"
+  | "provider-target-unavailable"
+  | "missing-backend-adapter"
+  | "provider-signature-mismatch"
+  | "undeclared-provider-cycle"
+  | "declared-cycle-mismatch"
+  | "late-unplanned-intrinsic"
+  | "late-unplanned-feature"
+  | "late-unplanned-provider"
+  | "late-unplanned-host-capability";
+
+export class RuntimeManifestInvariantError extends Error {
+  readonly kind = "invariant" as const;
+  readonly stage = "verify" as const;
+
+  constructor(
+    readonly code: RuntimeManifestInvariantCode,
+    detail: string,
+  ) {
+    super(detail);
+    this.name = "RuntimeManifestInvariantError";
+  }
+}
+
+const ALL_TARGETS = Object.freeze<readonly RuntimeTarget[]>(["host", "standalone", "strict-no-host", "wasi"]);
+const ALL_BACKENDS = Object.freeze<readonly RuntimeBackend[]>(["linear", "wasmgc"]);
+
+export const RUNTIME_FEATURE_SIGNATURES: Readonly<Record<RuntimeFeature, IntrinsicSignature>> = Object.freeze({
+  "math.abs": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.atan": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.atan2": F64_BINARY_INTRINSIC_SIGNATURE,
+  "math.ceil": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.cos": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.exp": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.floor": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.log": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.log2": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.pow": F64_BINARY_INTRINSIC_SIGNATURE,
+  "math.reduce-trig": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.sin": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.sqrt": F64_UNARY_INTRINSIC_SIGNATURE,
+  "math.trunc": F64_UNARY_INTRINSIC_SIGNATURE,
+});
+
+function provider(
+  id: RuntimeProviderId,
+  feature: RuntimeFeature,
+  signature: IntrinsicSignature,
+  implementation: RuntimeProviderImplementation,
+  dependencies: readonly RuntimeFeature[] = [],
+): RuntimeProviderDefinition {
+  return Object.freeze({
+    id,
+    feature,
+    signature,
+    dependencies: Object.freeze([...dependencies].sort()),
+    hostCapabilities: PURE_MATH_HOST_CAPABILITIES,
+    supportedTargets: ALL_TARGETS,
+    supportedBackends: ALL_BACKENDS,
+    implementation: Object.freeze({ ...implementation }),
+  });
+}
+
+const PROVIDERS_BY_FEATURE: Readonly<Record<RuntimeFeature, RuntimeProviderDefinition>> = Object.freeze({
+  "math.abs": provider("backend.f64.abs", "math.abs", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "backend-op",
+    opcode: "f64.abs",
+  }),
+  "math.atan": provider("selfhost.math.atan", "math.atan", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "self-hosted",
+    symbol: "Math_atan",
+  }),
+  "math.atan2": provider(
+    "selfhost.math.atan2",
+    "math.atan2",
+    F64_BINARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_atan2" },
+    ["math.atan"],
+  ),
+  "math.ceil": provider("backend.f64.ceil", "math.ceil", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "backend-op",
+    opcode: "f64.ceil",
+  }),
+  "math.cos": provider(
+    "selfhost.math.cos",
+    "math.cos",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_cos" },
+    ["math.reduce-trig"],
+  ),
+  "math.exp": provider("selfhost.math.exp", "math.exp", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "self-hosted",
+    symbol: "Math_exp",
+  }),
+  "math.floor": provider("backend.f64.floor", "math.floor", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "backend-op",
+    opcode: "f64.floor",
+  }),
+  "math.log": provider("selfhost.math.log", "math.log", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "self-hosted",
+    symbol: "Math_log",
+  }),
+  "math.log2": provider("selfhost.math.log2", "math.log2", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "self-hosted",
+    symbol: "Math_log2",
+  }),
+  "math.pow": provider(
+    "selfhost.math.pow",
+    "math.pow",
+    F64_BINARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_pow" },
+    ["math.exp", "math.log"],
+  ),
+  "math.reduce-trig": provider("selfhost.math.reduce-trig", "math.reduce-trig", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "self-hosted",
+    symbol: "__math_reduce_trig",
+  }),
+  "math.sin": provider(
+    "selfhost.math.sin",
+    "math.sin",
+    F64_UNARY_INTRINSIC_SIGNATURE,
+    { kind: "self-hosted", symbol: "Math_sin" },
+    ["math.reduce-trig"],
+  ),
+  "math.sqrt": provider("backend.f64.sqrt", "math.sqrt", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "backend-op",
+    opcode: "f64.sqrt",
+  }),
+  "math.trunc": provider("backend.f64.trunc", "math.trunc", F64_UNARY_INTRINSIC_SIGNATURE, {
+    kind: "backend-op",
+    opcode: "f64.trunc",
+  }),
+});
+
+/** Canonically ordered default provider catalogue for the twelve-method slice. */
+export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
+  PURE_MATH_RUNTIME_FEATURES.map((feature) => PROVIDERS_BY_FEATURE[feature]).sort((left, right) =>
+    left.id.localeCompare(right.id),
+  ),
+);
+
+const FEATURE_SET: ReadonlySet<string> = new Set(PURE_MATH_RUNTIME_FEATURES);
+const PROVIDER_ID_SET: ReadonlySet<string> = new Set(PURE_MATH_RUNTIME_PROVIDER_IDS);
+const TARGET_SET: ReadonlySet<string> = new Set(ALL_TARGETS);
+const BACKEND_SET: ReadonlySet<string> = new Set(ALL_BACKENDS);
+
+function isRuntimeFeature(value: string): value is RuntimeFeature {
+  return FEATURE_SET.has(value);
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function signatureEquals(left: IntrinsicSignature, right: IntrinsicSignature): boolean {
+  if (left.version !== right.version || left.params.length !== right.params.length) return false;
+  for (let index = 0; index < left.params.length; index++) {
+    if (!irTypeEquals(left.params[index]!, right.params[index]!)) return false;
+  }
+  return irTypeEquals(left.result, right.result);
+}
+
+function cloneProvider(value: RuntimeProviderDefinition): RuntimeProviderDefinition {
+  const signature = signatureEquals(value.signature, F64_UNARY_INTRINSIC_SIGNATURE)
+    ? F64_UNARY_INTRINSIC_SIGNATURE
+    : signatureEquals(value.signature, F64_BINARY_INTRINSIC_SIGNATURE)
+      ? F64_BINARY_INTRINSIC_SIGNATURE
+      : value.signature;
+  return Object.freeze({
+    ...value,
+    signature,
+    dependencies: Object.freeze([...new Set(value.dependencies)].sort(compareStrings)),
+    hostCapabilities: Object.freeze([...value.hostCapabilities]),
+    supportedTargets: Object.freeze([...new Set(value.supportedTargets)].sort(compareStrings)),
+    supportedBackends: Object.freeze([...new Set(value.supportedBackends)].sort(compareStrings)),
+    implementation: Object.freeze({ ...value.implementation }),
+  });
+}
+
+function cycleKey(features: readonly RuntimeFeature[]): string {
+  return [...features].sort(compareStrings).join("\u0000");
+}
+
+function useOrder(left: IntrinsicUse, right: IntrinsicUse): number {
+  return (
+    compareStrings(left.id, right.id) ||
+    compareStrings(left.location.file, right.location.file) ||
+    left.location.line - right.location.line ||
+    left.location.column - right.location.column
+  );
+}
+
+function stronglyConnectedComponents(
+  features: readonly RuntimeFeature[],
+  dependencies: ReadonlyMap<RuntimeFeature, readonly RuntimeFeature[]>,
+): RuntimeFeature[][] {
+  let nextIndex = 0;
+  const indices = new Map<RuntimeFeature, number>();
+  const lowLinks = new Map<RuntimeFeature, number>();
+  const stack: RuntimeFeature[] = [];
+  const onStack = new Set<RuntimeFeature>();
+  const components: RuntimeFeature[][] = [];
+
+  const visit = (feature: RuntimeFeature): void => {
+    const index = nextIndex++;
+    indices.set(feature, index);
+    lowLinks.set(feature, index);
+    stack.push(feature);
+    onStack.add(feature);
+
+    for (const dependency of dependencies.get(feature) ?? []) {
+      if (!indices.has(dependency)) {
+        visit(dependency);
+        lowLinks.set(feature, Math.min(lowLinks.get(feature)!, lowLinks.get(dependency)!));
+      } else if (onStack.has(dependency)) {
+        lowLinks.set(feature, Math.min(lowLinks.get(feature)!, indices.get(dependency)!));
+      }
+    }
+
+    if (lowLinks.get(feature) !== indices.get(feature)) return;
+    const component: RuntimeFeature[] = [];
+    let member: RuntimeFeature;
+    do {
+      member = stack.pop()!;
+      onStack.delete(member);
+      component.push(member);
+    } while (member !== feature);
+    components.push(component.sort(compareStrings));
+  };
+
+  for (const feature of features) if (!indices.has(feature)) visit(feature);
+  return components.sort((left, right) => compareStrings(cycleKey(left), cycleKey(right)));
+}
+
+function buildProviderComponents(
+  features: readonly RuntimeFeature[],
+  providers: ReadonlyMap<RuntimeFeature, RuntimeProviderPlan>,
+  declaredCycles: ReadonlyMap<string, readonly RuntimeFeature[]>,
+): readonly RuntimeProviderComponent[] {
+  const dependencies = new Map<RuntimeFeature, readonly RuntimeFeature[]>();
+  for (const feature of features) dependencies.set(feature, providers.get(feature)!.dependencies);
+  const components = stronglyConnectedComponents(features, dependencies);
+  const actualCycleKeys = new Set<string>();
+
+  for (const component of components) {
+    const selfCycle = component.length === 1 && dependencies.get(component[0]!)!.includes(component[0]!);
+    if (component.length === 1 && !selfCycle) continue;
+    const key = cycleKey(component);
+    actualCycleKeys.add(key);
+    if (!declaredCycles.has(key)) {
+      throw new RuntimeManifestInvariantError(
+        "undeclared-provider-cycle",
+        `runtime provider cycle ${component.join(" -> ")} was not declared`,
+      );
+    }
+  }
+
+  const selected = new Set(features);
+  for (const [key, declaration] of declaredCycles) {
+    if (declaration.every((feature) => selected.has(feature)) && !actualCycleKeys.has(key)) {
+      throw new RuntimeManifestInvariantError(
+        "declared-cycle-mismatch",
+        `declared runtime provider cycle ${declaration.join(", ")} is not one canonical component`,
+      );
+    }
+  }
+
+  const componentOf = new Map<RuntimeFeature, number>();
+  components.forEach((component, index) => component.forEach((feature) => componentOf.set(feature, index)));
+  const orderedIndices: number[] = [];
+  const visited = new Set<number>();
+  const order = [...components.keys()].sort((left, right) =>
+    compareStrings(cycleKey(components[left]!), cycleKey(components[right]!)),
+  );
+  const visitComponent = (index: number): void => {
+    if (visited.has(index)) return;
+    visited.add(index);
+    const dependenciesOfComponent = new Set<number>();
+    for (const feature of components[index]!) {
+      for (const dependency of dependencies.get(feature) ?? []) {
+        const dependencyIndex = componentOf.get(dependency)!;
+        if (dependencyIndex !== index) dependenciesOfComponent.add(dependencyIndex);
+      }
+    }
+    for (const dependencyIndex of [...dependenciesOfComponent].sort((left, right) =>
+      compareStrings(cycleKey(components[left]!), cycleKey(components[right]!)),
+    )) {
+      visitComponent(dependencyIndex);
+    }
+    orderedIndices.push(index);
+  };
+  for (const index of order) visitComponent(index);
+
+  return Object.freeze(
+    orderedIndices.map((index) => {
+      const componentFeatures = Object.freeze([...components[index]!]);
+      return Object.freeze({
+        features: componentFeatures,
+        providers: Object.freeze(componentFeatures.map((feature) => providers.get(feature)!.id).sort(compareStrings)),
+        cyclic:
+          componentFeatures.length > 1 || dependencies.get(componentFeatures[0]!)!.includes(componentFeatures[0]!),
+      });
+    }),
+  );
+}
+
+export interface RuntimeManifestBuilderOptions {
+  /** Test/integration seam; omission uses the exhaustive production catalogue. */
+  readonly providers?: readonly RuntimeProviderDefinition[];
+}
+
+type BuilderState = "open" | "building" | "frozen" | "failed";
+
+export class RuntimeManifestBuilder {
+  readonly #policy: RuntimeManifestPolicy;
+  readonly #uses: IntrinsicUse[] = [];
+  readonly #providers: RuntimeProviderDefinition[];
+  readonly #addedDependencies = new Map<RuntimeFeature, Set<RuntimeFeature>>();
+  readonly #declaredCycles = new Map<string, readonly RuntimeFeature[]>();
+  readonly #plannedIntrinsicIds = new Set<IntrinsicId>();
+  readonly #plannedProviderIds = new Set<RuntimeProviderId>();
+  readonly #providerPlans = new Map<RuntimeFeature, RuntimeProviderPlan>();
+  #state: BuilderState = "open";
+  #manifest?: FrozenRuntimeManifest;
+
+  constructor(policy: RuntimeManifestPolicy, options: RuntimeManifestBuilderOptions = {}) {
+    if (!TARGET_SET.has(policy.target) || !BACKEND_SET.has(policy.backend)) {
+      throw new RuntimeManifestInvariantError(
+        "provider-target-unavailable",
+        `invalid runtime manifest policy ${String(policy.target)}/${String(policy.backend)}`,
+      );
+    }
+    this.#policy = Object.freeze({ ...policy });
+    this.#providers = (options.providers ?? PURE_MATH_RUNTIME_PROVIDERS).map(cloneProvider);
+  }
+
+  addIntrinsicUse(use: IntrinsicUse, effects: IntrinsicEffectEvidence): void {
+    this.#assertMutable();
+    const failure = verifyIntrinsicUse(use, effects);
+    if (failure) throw new RuntimeManifestInvariantError(failure.code, failure.detail);
+    const canonical = INTRINSIC_DEFINITIONS[use.id];
+    this.#uses.push(
+      Object.freeze({
+        id: use.id,
+        version: canonical.signature.version,
+        argumentTypes: canonical.signature.params,
+        resultType: canonical.signature.result,
+        location: Object.freeze({ ...use.location }),
+      }),
+    );
+  }
+
+  registerProvider(value: RuntimeProviderDefinition): void {
+    this.#assertMutable();
+    if (this.#providers.some((candidate) => candidate.id === value.id)) {
+      throw new RuntimeManifestInvariantError(
+        "duplicate-runtime-provider",
+        `provider ${value.id} is already registered`,
+      );
+    }
+    this.#providers.push(cloneProvider(value));
+  }
+
+  addProviderDependency(feature: RuntimeFeature, dependency: RuntimeFeature): void {
+    this.#assertMutable();
+    this.#assertKnownFeature(feature);
+    this.#assertKnownFeature(dependency);
+    let additions = this.#addedDependencies.get(feature);
+    if (!additions) {
+      additions = new Set();
+      this.#addedDependencies.set(feature, additions);
+    }
+    additions.add(dependency);
+  }
+
+  declareProviderCycle(features: readonly RuntimeFeature[]): void {
+    this.#assertMutable();
+    const canonical = [...new Set(features)].sort(compareStrings);
+    if (canonical.length === 0 || canonical.length !== features.length) {
+      throw new RuntimeManifestInvariantError(
+        "invalid-cycle-declaration",
+        "provider cycle declarations must contain one or more unique features",
+      );
+    }
+    canonical.forEach((feature) => this.#assertKnownFeature(feature));
+    const key = cycleKey(canonical);
+    if (this.#declaredCycles.has(key)) {
+      throw new RuntimeManifestInvariantError(
+        "duplicate-cycle-declaration",
+        `provider cycle ${canonical.join(", ")} was declared more than once`,
+      );
+    }
+    this.#declaredCycles.set(key, Object.freeze(canonical));
+  }
+
+  freeze(): FrozenRuntimeManifest {
+    this.#assertMutable();
+    this.#state = "building";
+    try {
+      this.#manifest = this.#buildManifest();
+      this.#state = "frozen";
+      return this.#manifest;
+    } catch (error) {
+      this.#state = "failed";
+      throw error;
+    }
+  }
+
+  get manifest(): FrozenRuntimeManifest {
+    if (this.#state !== "frozen" || !this.#manifest) {
+      throw new RuntimeManifestInvariantError("manifest-not-frozen", "runtime manifest is not frozen");
+    }
+    return this.#manifest;
+  }
+
+  resolveProvider(feature: RuntimeFeature): RuntimeProviderPlan {
+    this.#assertFrozen();
+    const provider = this.#providerPlans.get(feature);
+    if (!provider) {
+      throw new RuntimeManifestInvariantError(
+        "late-unplanned-feature",
+        `runtime feature ${String(feature)} was not present at manifest freeze`,
+      );
+    }
+    return provider;
+  }
+
+  assertIntrinsicPlanned(id: IntrinsicId): void {
+    this.#assertFrozen();
+    if (!this.#plannedIntrinsicIds.has(id)) {
+      throw new RuntimeManifestInvariantError(
+        "late-unplanned-intrinsic",
+        `intrinsic ${String(id)} was not present at manifest freeze`,
+      );
+    }
+  }
+
+  assertProviderPlanned(id: RuntimeProviderId): void {
+    this.#assertFrozen();
+    if (!this.#plannedProviderIds.has(id)) {
+      throw new RuntimeManifestInvariantError(
+        "late-unplanned-provider",
+        `runtime provider ${String(id)} was not present at manifest freeze`,
+      );
+    }
+  }
+
+  assertHostCapabilityPlanned(capability: string): void {
+    this.#assertFrozen();
+    throw new RuntimeManifestInvariantError(
+      "late-unplanned-host-capability",
+      `host capability ${capability} is outside the host-free pure-Math manifest`,
+    );
+  }
+
+  #buildManifest(): FrozenRuntimeManifest {
+    const providersByFeature = this.#indexProviders();
+    const pending = new Set<RuntimeFeature>();
+    for (const use of this.#uses) pending.add(INTRINSIC_DEFINITIONS[use.id].feature);
+
+    while (pending.size > 0) {
+      const feature = [...pending].sort(compareStrings)[0]!;
+      pending.delete(feature);
+      if (this.#providerPlans.has(feature)) continue;
+      const selected = this.#selectProvider(feature, providersByFeature);
+      const expectedSignature = RUNTIME_FEATURE_SIGNATURES[feature];
+      if (!signatureEquals(selected.signature, expectedSignature)) {
+        throw new RuntimeManifestInvariantError(
+          "provider-signature-mismatch",
+          `provider ${selected.id} does not implement the ${feature} signature`,
+        );
+      }
+      const dependencies = new Set(selected.dependencies);
+      for (const dependency of this.#addedDependencies.get(feature) ?? []) dependencies.add(dependency);
+      const plan = Object.freeze({
+        ...selected,
+        dependencies: Object.freeze([...dependencies].sort(compareStrings)),
+      });
+      this.#providerPlans.set(feature, plan);
+      for (const dependency of plan.dependencies) pending.add(dependency);
+    }
+
+    const features = Object.freeze([...this.#providerPlans.keys()].sort(compareStrings));
+    const providerComponents = buildProviderComponents(features, this.#providerPlans, this.#declaredCycles);
+    const providers = Object.freeze(
+      [...this.#providerPlans.values()].sort((left, right) => compareStrings(left.id, right.id)),
+    );
+    const intrinsicUses = Object.freeze([...this.#uses].sort(useOrder));
+
+    for (const use of intrinsicUses) this.#plannedIntrinsicIds.add(use.id);
+    for (const value of providers) this.#plannedProviderIds.add(value.id);
+
+    return Object.freeze({
+      policy: this.#policy,
+      intrinsicUses,
+      features,
+      providers,
+      providerComponents,
+      hostCapabilities: PURE_MATH_HOST_CAPABILITIES,
+    });
+  }
+
+  #indexProviders(): ReadonlyMap<RuntimeFeature, readonly RuntimeProviderDefinition[]> {
+    const ids = new Set<RuntimeProviderId>();
+    const byFeature = new Map<RuntimeFeature, RuntimeProviderDefinition[]>();
+    for (const provider of this.#providers) {
+      if (!PROVIDER_ID_SET.has(provider.id)) {
+        throw new RuntimeManifestInvariantError(
+          "unknown-runtime-provider",
+          `unknown runtime provider ${String(provider.id)}`,
+        );
+      }
+      this.#assertKnownFeature(provider.feature);
+      if (ids.has(provider.id)) {
+        throw new RuntimeManifestInvariantError(
+          "duplicate-runtime-provider",
+          `runtime provider ${provider.id} was registered more than once`,
+        );
+      }
+      ids.add(provider.id);
+      for (const dependency of provider.dependencies) this.#assertKnownFeature(dependency);
+      if (provider.hostCapabilities.length > 0) {
+        throw new RuntimeManifestInvariantError(
+          "unknown-host-capability",
+          `provider ${provider.id} requests a capability outside the host-free pure-Math vocabulary`,
+        );
+      }
+      if (!provider.supportedTargets.every((target) => TARGET_SET.has(target))) {
+        throw new RuntimeManifestInvariantError(
+          "provider-target-unavailable",
+          `provider ${provider.id} has an unknown target`,
+        );
+      }
+      if (!provider.supportedBackends.every((backend) => BACKEND_SET.has(backend))) {
+        throw new RuntimeManifestInvariantError(
+          "missing-backend-adapter",
+          `provider ${provider.id} has an unknown backend`,
+        );
+      }
+      const candidates = byFeature.get(provider.feature) ?? [];
+      candidates.push(provider);
+      byFeature.set(provider.feature, candidates);
+    }
+    return byFeature;
+  }
+
+  #selectProvider(
+    feature: RuntimeFeature,
+    providers: ReadonlyMap<RuntimeFeature, readonly RuntimeProviderDefinition[]>,
+  ): RuntimeProviderDefinition {
+    const candidates = providers.get(feature) ?? [];
+    if (candidates.length === 0) {
+      throw new RuntimeManifestInvariantError("missing-runtime-provider", `runtime feature ${feature} has no provider`);
+    }
+    const targetCandidates = candidates.filter((candidate) => candidate.supportedTargets.includes(this.#policy.target));
+    if (targetCandidates.length === 0) {
+      throw new RuntimeManifestInvariantError(
+        "provider-target-unavailable",
+        `runtime feature ${feature} is unavailable for target ${this.#policy.target}`,
+      );
+    }
+    const backendCandidates = targetCandidates.filter((candidate) =>
+      candidate.supportedBackends.includes(this.#policy.backend),
+    );
+    if (backendCandidates.length === 0) {
+      throw new RuntimeManifestInvariantError(
+        "missing-backend-adapter",
+        `runtime feature ${feature} has no ${this.#policy.backend} adapter`,
+      );
+    }
+    if (backendCandidates.length !== 1) {
+      throw new RuntimeManifestInvariantError(
+        "ambiguous-runtime-provider",
+        `runtime feature ${feature} has ${backendCandidates.length} matching providers`,
+      );
+    }
+    return backendCandidates[0]!;
+  }
+
+  #assertKnownFeature(feature: RuntimeFeature): void {
+    if (!isRuntimeFeature(feature)) {
+      throw new RuntimeManifestInvariantError("unknown-runtime-feature", `unknown runtime feature ${String(feature)}`);
+    }
+  }
+
+  #assertMutable(): void {
+    if (this.#state === "open") return;
+    throw new RuntimeManifestInvariantError(
+      this.#state === "failed" ? "manifest-build-failed" : "manifest-frozen",
+      `runtime manifest builder is ${this.#state}`,
+    );
+  }
+
+  #assertFrozen(): void {
+    if (this.#state !== "frozen") {
+      throw new RuntimeManifestInvariantError("manifest-not-frozen", `runtime manifest builder is ${this.#state}`);
+    }
+  }
+}

--- a/tests/issue-3526-ir-runtime-manifest.test.ts
+++ b/tests/issue-3526-ir-runtime-manifest.test.ts
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  F64_BINARY_INTRINSIC_SIGNATURE,
+  INTRINSIC_DEFINITIONS,
+  PURE_MATH_HOST_CAPABILITIES,
+  PURE_MATH_INTRINSIC_IDS,
+  PURE_MATH_RUNTIME_FEATURES,
+  intrinsicEffectEvidence,
+  type IntrinsicId,
+  type IntrinsicUse,
+  type RuntimeFeature,
+} from "../src/ir/intrinsics.js";
+import { asValueId, irVal, type IrInstr } from "../src/ir/nodes.js";
+import {
+  PURE_MATH_RUNTIME_PROVIDERS,
+  RuntimeManifestBuilder,
+  RuntimeManifestInvariantError,
+  type FrozenRuntimeManifest,
+  type RuntimeBackend,
+  type RuntimeManifestPolicy,
+  type RuntimeProviderDefinition,
+  type RuntimeTarget,
+} from "../src/ir/runtime-manifest.js";
+import { IR_MATH_METHOD_TABLE } from "../src/ir/select.js";
+
+const F64 = irVal({ kind: "f64" });
+
+const PURE_INSTRUCTION: IrInstr = {
+  kind: "unary",
+  op: "f64.abs",
+  rand: asValueId(0),
+  result: asValueId(1),
+  resultType: F64,
+};
+
+const IMPURE_INSTRUCTION: IrInstr = {
+  kind: "call",
+  target: { kind: "func", name: "impure", binding: { kind: "runtime", symbol: "impure" } },
+  args: [],
+  result: asValueId(0),
+  resultType: F64,
+};
+
+const PURE_EFFECTS = intrinsicEffectEvidence(PURE_INSTRUCTION);
+const IMPURE_EFFECTS = intrinsicEffectEvidence(IMPURE_INSTRUCTION);
+
+function intrinsicUse(id: IntrinsicId, line = 1, file = "/repo/entry.ts"): IntrinsicUse {
+  const definition = INTRINSIC_DEFINITIONS[id];
+  return {
+    id,
+    version: definition.signature.version,
+    argumentTypes: definition.signature.params,
+    resultType: definition.signature.result,
+    location: { file, line, column: line - 1 },
+  };
+}
+
+function policy(target: RuntimeTarget = "host", backend: RuntimeBackend = "wasmgc"): RuntimeManifestPolicy {
+  return { target, backend };
+}
+
+function addUses(builder: RuntimeManifestBuilder, ids: readonly IntrinsicId[]): void {
+  const lineById = new Map(PURE_MATH_INTRINSIC_IDS.map((id, index) => [id, index + 1]));
+  for (const id of ids) builder.addIntrinsicUse(intrinsicUse(id, lineById.get(id)!), PURE_EFFECTS);
+}
+
+function thrown(code: RuntimeManifestInvariantError["code"]): object {
+  return expect.objectContaining<RuntimeManifestInvariantError>({ code });
+}
+
+function providerWith(
+  id: RuntimeProviderDefinition["id"],
+  update: (provider: RuntimeProviderDefinition) => RuntimeProviderDefinition,
+): readonly RuntimeProviderDefinition[] {
+  return PURE_MATH_RUNTIME_PROVIDERS.map((provider) => (provider.id === id ? update(provider) : provider));
+}
+
+function semanticView(manifest: FrozenRuntimeManifest): object {
+  return {
+    intrinsicUses: manifest.intrinsicUses,
+    features: manifest.features,
+    providerComponents: manifest.providerComponents,
+    hostCapabilities: manifest.hostCapabilities,
+  };
+}
+
+describe("#3526 typed IR runtime manifest foundation", () => {
+  it("is exhaustive for the exact twelve certified pure Math methods and excludes random", () => {
+    const certifiedMethods = Object.keys(IR_MATH_METHOD_TABLE).sort();
+    const intrinsicMethods = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length)).sort();
+
+    expect(intrinsicMethods).toEqual(certifiedMethods);
+    expect(intrinsicMethods).toHaveLength(12);
+    expect(intrinsicMethods).not.toContain("random");
+    expect(PURE_MATH_RUNTIME_FEATURES).toEqual([...PURE_MATH_RUNTIME_FEATURES].sort());
+    expect(PURE_MATH_RUNTIME_FEATURES).toEqual(expect.arrayContaining(["math.atan", "math.reduce-trig"]));
+    expect(PURE_MATH_HOST_CAPABILITIES).toEqual([]);
+
+    for (const [method, plan] of Object.entries(IR_MATH_METHOD_TABLE)) {
+      const id = `math.${method}` as IntrinsicId;
+      expect(INTRINSIC_DEFINITIONS[id].signature.params).toHaveLength(plan.arity);
+      expect(INTRINSIC_DEFINITIONS[id].signature.result).toEqual(F64);
+    }
+  });
+
+  it("builds one canonical fixed point regardless of use, map, and provider traversal order", () => {
+    const forward = new RuntimeManifestBuilder(policy());
+    const reverse = new RuntimeManifestBuilder(policy(), { providers: [...PURE_MATH_RUNTIME_PROVIDERS].reverse() });
+    addUses(forward, PURE_MATH_INTRINSIC_IDS);
+    addUses(reverse, [...PURE_MATH_INTRINSIC_IDS].reverse());
+
+    const first = forward.freeze();
+    const second = reverse.freeze();
+    expect(second).toEqual(first);
+    expect(first.intrinsicUses).toHaveLength(12);
+    expect(first.features).toEqual(PURE_MATH_RUNTIME_FEATURES);
+    expect(new Set(first.providers.map((provider) => provider.id)).size).toBe(first.providers.length);
+    expect(first.hostCapabilities).toEqual([]);
+
+    const dependencies = Object.fromEntries(
+      first.providers.map((provider) => [provider.feature, provider.dependencies]),
+    );
+    expect(dependencies["math.pow"]).toEqual(["math.exp", "math.log"]);
+    expect(dependencies["math.atan2"]).toEqual(["math.atan"]);
+    expect(dependencies["math.sin"]).toEqual(["math.reduce-trig"]);
+    expect(dependencies["math.cos"]).toEqual(["math.reduce-trig"]);
+    expect(first.features.filter((feature) => feature === "math.reduce-trig")).toHaveLength(1);
+  });
+
+  it("keeps the pure fixed point host-free in every target/backend policy", () => {
+    const targets: readonly RuntimeTarget[] = ["host", "strict-no-host", "standalone", "wasi"];
+    const backends: readonly RuntimeBackend[] = ["wasmgc", "linear"];
+    const semanticClosures: RuntimeFeature[][] = [];
+
+    for (const target of targets) {
+      for (const backend of backends) {
+        const builder = new RuntimeManifestBuilder(policy(target, backend));
+        addUses(builder, ["math.sin", "math.pow", "math.atan2"]);
+        const manifest = builder.freeze();
+        semanticClosures.push([...manifest.features]);
+        expect(manifest.hostCapabilities, `${target}/${backend}`).toEqual([]);
+      }
+    }
+
+    expect(new Set(semanticClosures.map((features) => features.join("|")))).toHaveLength(1);
+    expect(semanticClosures[0]).toEqual([
+      "math.atan",
+      "math.atan2",
+      "math.exp",
+      "math.log",
+      "math.pow",
+      "math.reduce-trig",
+      "math.sin",
+    ]);
+  });
+
+  it("terminates declared cycles as one canonical dependency-first provider component", () => {
+    const build = (declaration: readonly RuntimeFeature[]): FrozenRuntimeManifest => {
+      const builder = new RuntimeManifestBuilder(policy());
+      builder.addIntrinsicUse(intrinsicUse("math.sin"), PURE_EFFECTS);
+      builder.addProviderDependency("math.reduce-trig", "math.sin");
+      builder.declareProviderCycle(declaration);
+      return builder.freeze();
+    };
+
+    const forward = build(["math.sin", "math.reduce-trig"]);
+    const reverse = build(["math.reduce-trig", "math.sin"]);
+    expect(reverse).toEqual(forward);
+    expect(forward.providerComponents).toEqual([
+      {
+        features: ["math.reduce-trig", "math.sin"],
+        providers: ["selfhost.math.reduce-trig", "selfhost.math.sin"],
+        cyclic: true,
+      },
+    ]);
+
+    const undeclared = new RuntimeManifestBuilder(policy());
+    undeclared.addIntrinsicUse(intrinsicUse("math.sin"), PURE_EFFECTS);
+    undeclared.addProviderDependency("math.reduce-trig", "math.sin");
+    expect(() => undeclared.freeze()).toThrowError(thrown("undeclared-provider-cycle"));
+  });
+
+  it("rejects unknown IDs, bad signatures, impure evidence, missing providers, and missing adapters", () => {
+    const unknown = {
+      ...intrinsicUse("math.sin"),
+      id: "math.random",
+    } as unknown as IntrinsicUse;
+    expect(() => new RuntimeManifestBuilder(policy()).addIntrinsicUse(unknown, PURE_EFFECTS)).toThrowError(
+      thrown("unknown-intrinsic"),
+    );
+
+    const badSignature = { ...intrinsicUse("math.pow"), argumentTypes: [F64] };
+    expect(() => new RuntimeManifestBuilder(policy()).addIntrinsicUse(badSignature, PURE_EFFECTS)).toThrowError(
+      thrown("intrinsic-signature-mismatch"),
+    );
+    expect(() =>
+      new RuntimeManifestBuilder(policy()).addIntrinsicUse(intrinsicUse("math.sin"), IMPURE_EFFECTS),
+    ).toThrowError(thrown("intrinsic-effect-mismatch"));
+
+    const missing = new RuntimeManifestBuilder(policy(), {
+      providers: PURE_MATH_RUNTIME_PROVIDERS.filter((provider) => provider.id !== "selfhost.math.sin"),
+    });
+    missing.addIntrinsicUse(intrinsicUse("math.sin"), PURE_EFFECTS);
+    expect(() => missing.freeze()).toThrowError(thrown("missing-runtime-provider"));
+
+    const badProviderSignature = new RuntimeManifestBuilder(policy(), {
+      providers: providerWith("selfhost.math.sin", (provider) => ({
+        ...provider,
+        signature: F64_BINARY_INTRINSIC_SIGNATURE,
+      })),
+    });
+    badProviderSignature.addIntrinsicUse(intrinsicUse("math.sin"), PURE_EFFECTS);
+    expect(() => badProviderSignature.freeze()).toThrowError(thrown("provider-signature-mismatch"));
+
+    const missingLinearAdapter = new RuntimeManifestBuilder(policy("standalone", "linear"), {
+      providers: providerWith("selfhost.math.sin", (provider) => ({
+        ...provider,
+        supportedBackends: ["wasmgc"],
+      })),
+    });
+    missingLinearAdapter.addIntrinsicUse(intrinsicUse("math.sin"), PURE_EFFECTS);
+    expect(() => missingLinearAdapter.freeze()).toThrowError(thrown("missing-backend-adapter"));
+  });
+
+  it("freezes deeply and turns all late registration or lookup misses into invariants", () => {
+    const builder = new RuntimeManifestBuilder(policy());
+    builder.addIntrinsicUse(intrinsicUse("math.sin"), PURE_EFFECTS);
+    const manifest = builder.freeze();
+    const sinProvider = builder.resolveProvider("math.sin");
+
+    expect(Object.isFrozen(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest.features)).toBe(true);
+    expect(Object.isFrozen(sinProvider)).toBe(true);
+    expect(Object.isFrozen(sinProvider.dependencies)).toBe(true);
+    expect(builder.manifest).toBe(manifest);
+    expect(() => builder.assertIntrinsicPlanned("math.sin")).not.toThrow();
+    expect(() => builder.assertProviderPlanned("selfhost.math.sin")).not.toThrow();
+    expect(() => builder.resolveProvider("math.reduce-trig")).not.toThrow();
+
+    expect(() => builder.addIntrinsicUse(intrinsicUse("math.cos"), PURE_EFFECTS)).toThrowError(
+      thrown("manifest-frozen"),
+    );
+    expect(() => builder.registerProvider(PURE_MATH_RUNTIME_PROVIDERS[0]!)).toThrowError(thrown("manifest-frozen"));
+    expect(() => builder.addProviderDependency("math.sin", "math.cos")).toThrowError(thrown("manifest-frozen"));
+    expect(() => builder.declareProviderCycle(["math.sin"])).toThrowError(thrown("manifest-frozen"));
+    expect(() => builder.assertIntrinsicPlanned("math.cos")).toThrowError(thrown("late-unplanned-intrinsic"));
+    expect(() => builder.resolveProvider("math.cos")).toThrowError(thrown("late-unplanned-feature"));
+    expect(() => builder.assertProviderPlanned("backend.f64.abs")).toThrowError(thrown("late-unplanned-provider"));
+    expect(() => builder.assertHostCapabilityPlanned("host.random")).toThrowError(
+      thrown("late-unplanned-host-capability"),
+    );
+    expect(() => (manifest.features as RuntimeFeature[]).push("math.abs")).toThrow(TypeError);
+    expect(() => (sinProvider.dependencies as RuntimeFeature[]).push("math.cos")).toThrow(TypeError);
+  });
+
+  it("keeps semantic identity stable when a concrete provider spelling changes", () => {
+    const original = new RuntimeManifestBuilder(policy());
+    original.addIntrinsicUse(intrinsicUse("math.sin"), PURE_EFFECTS);
+
+    const renamed = new RuntimeManifestBuilder(policy(), {
+      providers: providerWith("selfhost.math.sin", (provider) => ({
+        ...provider,
+        implementation: { kind: "self-hosted", symbol: "renamed_sine_provider" },
+      })),
+    });
+    renamed.addIntrinsicUse(intrinsicUse("math.sin"), PURE_EFFECTS);
+
+    const before = original.freeze();
+    const after = renamed.freeze();
+    expect(semanticView(after)).toEqual(semanticView(before));
+    expect(after.providers.find((provider) => provider.feature === "math.sin")!.implementation).toEqual({
+      kind: "self-hosted",
+      symbol: "renamed_sine_provider",
+    });
+    expect(after.providers).not.toEqual(before.providers);
+  });
+});


### PR DESCRIPTION
## Summary

- define the exact twelve certified pure-Math intrinsic IDs and their typed signatures
- expand runtime provider dependencies to a deterministic fixed point and deeply freeze the result
- fail closed on unknown IDs, signature/effect mismatches, missing target/backend adapters, undeclared cycles, and late requests
- keep existing Math routing and providers unchanged until the sequential M1 integration consumes this contract

Plan: plan/issues/3526-ir-r6-semantic-runtime-contract.md

## Validation

- new runtime-manifest contract: 7/7 passing
- Math/provider regression set: 69/69 passing
- typecheck, lint, formatting, LOC/function budgets, and issue integrity: passing
- IR fallback gate: zero unintended, post-claim, or module-level increases
- optimization ledger unchanged at 21 rows, 10 IR-owned, one retirement-ready
- full pre-push gate, including oracle/coercion ratchets and numeric-local parity 17/17: passing

This is the C0 contract seam only. Prepared-IR routing remains a separate follow-up so this PR cannot silently change code generation.