### PR TITLE
feat(#4094): derive enqueue eligibility from real signals, not the stale mergeStateStatus

### DIFF
--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -113,6 +113,90 @@ export const HOLD_LABELS = new Set([
 // the state that allowed red PRs to enter the merge queue.
 const ENQUEUEABLE = new Set(["CLEAN", "HAS_HOOKS"]);
 const PASSING_CHECK_STATES = new Set(["pass", "skipping"]);
+
+// ---------------------------------------------------------------------------
+// #4094 — `[skip ci]`-ONLY DIVERGENCE EXEMPTION (stakeholder decision 2026-08-02)
+//
+// The loop this breaks (measured in #4093): a merge lands, a `[skip ci]` baseline
+// commit follows (six in ~5.5h), every open PR goes BEHIND, ENQUEUEABLE excludes
+// BEHIND, and the PRs are un-enqueueable until the refresh cron (~0.7/hour actual)
+// catches up — often raced by the next baseline commit. A commit whose own message
+// declares "this changes nothing needing testing" currently disqualifies every PR
+// in flight.
+//
+// GitHub's ACCEPTED MARKER SET — verified 2026-08-02 against
+// docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs,
+// NOT from memory. Two properties of that source matter and are easy to get wrong:
+//   1. There are FIVE spellings, not one. This repo only ever emits `[skip ci]`,
+//      so a predicate matching only that spelling passes every local test and is
+//      still wrong in production the first time someone writes `[ci skip]`.
+//   2. The doc says the string suppresses `on: push`/`on: pull_request` when added
+//      "to the commit message" — anywhere in it, NOT first-line-only. Matching only
+//      the subject would silently miss a marker in the body.
+// ---------------------------------------------------------------------------
+export const SKIP_CI_MARKERS = Object.freeze(["[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"]);
+
+/** True when a single commit message carries any GitHub skip-CI marker. */
+export function hasSkipCiMarker(message) {
+  if (typeof message !== "string" || message.length === 0) return false;
+  const m = message.toLowerCase();
+  return SKIP_CI_MARKERS.some((marker) => m.includes(marker));
+}
+
+/**
+ * #4094 — is a PR's divergence from main composed ONLY of `[skip ci]` commits?
+ *
+ * `messages` is the FULL commit message of every commit main is ahead by, from
+ * the server-side compare API (never local refs — see `divergenceCommitMessages`).
+ *
+ * FAILS CLOSED, deliberately, in two distinct ways that are easy to conflate:
+ *
+ *   - `null`/non-array  ⇒ we could not SEE the divergence. Not exempt. A detector
+ *     whose "cannot see" answer equals "nothing wrong" is unsound, and this one
+ *     gates entry to the merge queue.
+ *   - EMPTY array ⇒ ALSO not exempt. This is the silent-empty trap: "no commits
+ *     matched" is indistinguishable from "the fetch returned nothing", and a PR
+ *     that is genuinely BEHIND must be behind by at least one commit. So the
+ *     count is FLOORED at 1 rather than treated as a vacuous all-true.
+ *
+ * Only a non-empty set in which EVERY message carries a marker is exempt.
+ */
+export function isSkipCiOnlyDivergence(messages) {
+  if (!Array.isArray(messages)) return false;
+  if (messages.length === 0) return false; // vacuous-truth guard, see above
+  return messages.every((m) => hasSkipCiMarker(m));
+}
+
+/**
+ * #4094 — the eligibility decision, pure and exported so both controls are
+ * unit-testable with no `gh` call and no queue mutation.
+ *
+ * SCOPE, narrow on purpose (issue #4094 constraint 1): this widens the
+ * ELIGIBILITY TEST only. It updates/rebases nothing. The 2026-06-11 incident
+ * (17 bot-updated BEHIND PRs stranded in `action_required`) was caused by
+ * *bot-updating branches*; `ALLOW_UPDATE_BRANCH` semantics are untouched here.
+ *
+ * Everything else stays exactly as it was — in particular `UNSTABLE` remains
+ * excluded (#3878/#3904: required-green + one red non-required is precisely the
+ * state that once let red PRs into the queue), as do drafts, hold labels and the
+ * author-trust gate. The ONLY state this admits that was previously refused is
+ * `BEHIND`, and only when the entire divergence is skip-CI commits.
+ */
+export function enqueueEligibility(mergeStateStatus, divergence = null) {
+  if (ENQUEUEABLE.has(mergeStateStatus)) {
+    return { eligible: true, reason: `state:${mergeStateStatus}` };
+  }
+  if (mergeStateStatus !== "BEHIND") {
+    return { eligible: false, reason: mergeStateStatus || "merge-state-missing" };
+  }
+  if (!divergence || divergence.ok !== true) {
+    return { eligible: false, reason: `BEHIND (divergence-unknown:${divergence?.reason || "not-fetched"})` };
+  }
+  if (!isSkipCiOnlyDivergence(divergence.messages)) {
+    return { eligible: false, reason: `BEHIND (${divergence.reason})` };
+  }
+  return { eligible: true, reason: `BEHIND-skip-ci-only (${divergence.reason})` };
+}
 // STALL SURFACING (#3584). How long a PR must sit BLOCKED with nothing failing
 // and nothing pending before we stop calling it "in flight" and start calling it
 // a suspected permanent stall. Deliberately generous: a false positive here
@@ -209,6 +293,40 @@ function graphql(query, vars = {}) {
   const args = ["api", "graphql", "-f", `query=${query}`];
   for (const [k, v] of Object.entries(vars)) args.push("-f", `${k}=${v}`); // -f = raw string field
   return JSON.parse(gh(args));
+}
+
+/**
+ * #4094 — the full commit messages of every commit `main` is ahead of `headOid` by,
+ * read from the SERVER-SIDE compare API (never local refs: this checkout's remote
+ * tracking refs are unreliable, and CI has no local main to compare against).
+ *
+ * ⚠ FIELD TRAP, measured 2026-08-02 on PR #4002. Called as `compare/<head>...main`,
+ * GitHub reports `{ahead_by: 1, behind_by: 16, commits: [<1 entry>]}`. The
+ * divergence we care about — what main has that the PR does not — is `ahead_by`
+ * and the `commits` ARRAY. `behind_by` is the opposite direction (commits the PR
+ * head has that main does not) and reading it as "how far behind the PR is" inverts
+ * the test: #4002 would have looked 16 commits divergent when it was exactly one
+ * `[skip ci]` baseline refresh. Issue #4094 phrases this as "every commit main is
+ * ahead by", which is correct — but only `commits`/`ahead_by` express it.
+ *
+ * Returns `{ ok, messages, reason }`. `ok:false` ⇒ caller must NOT exempt.
+ */
+export function divergenceCommitMessages(headOid, repo = REPO, runner = ghMaybe) {
+  if (!headOid) return { ok: false, messages: null, reason: "no-head-oid" };
+  // Reduce to a JSON ARRAY and parse it — do NOT split raw --jq output on newlines.
+  // Commit messages are multi-line, and a marker is valid ANYWHERE in the message
+  // (verified against GitHub's docs above), so line-splitting would tear a
+  // body-borne marker away from its own commit and silently mis-classify it.
+  const res = runner(["api", `repos/${repo}/compare/${headOid}...main`, "--jq", "[.commits[].commit.message]"]);
+  if (!res.ok) return { ok: false, messages: null, reason: "compare-api-failed" };
+  let messages;
+  try {
+    messages = JSON.parse(String(res.stdout || ""));
+  } catch {
+    return { ok: false, messages: null, reason: "compare-api-unparseable" };
+  }
+  if (!Array.isArray(messages)) return { ok: false, messages: null, reason: "compare-api-shape" };
+  return { ok: true, messages, reason: `commits:${messages.length}` };
 }
 
 // Merge-queue snapshot: PR numbers already queued + whether any head is forming.

--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -167,35 +167,157 @@ export function isSkipCiOnlyDivergence(messages) {
   return messages.every((m) => hasSkipCiMarker(m));
 }
 
+// ---------------------------------------------------------------------------
+// #4094 (re-scoped 2026-08-02) — DERIVE ELIGIBILITY FROM REAL SIGNALS.
+//
+// The original scope was a `[skip ci]`-only exemption to the BEHIND exclusion.
+// Measurement killed that premise: `mergeStateStatus` does not track ancestry at
+// all. Observed live, same minute:
+//
+//     PR #4033  mergeStateStatus=CLEAN     4 commits behind main
+//     PR #4034  mergeStateStatus=UNSTABLE  0 commits behind main
+//
+// and the SAME PR (#4028) read BEHIND and UNSTABLE minutes apart with no push.
+// The repo ruleset has `strict_required_status_checks_policy: true`, so a behind
+// PR *should* report BEHIND — it doesn't, because the field is STALE: GitHub
+// serves the last value it computed, not current ancestry. So today's enqueue
+// outcome depends on when the sweep happens to look, which is a coin flip, not
+// a policy.
+//
+// Behind-ness is also NOT disqualifying in fact: PRs #4002 (1 behind) and #4033
+// (4 behind) were both sitting in the merge queue, put there by this very
+// workflow. The queue builds merge groups against main, exactly as this script's
+// own header asserts.
+//
+// So eligibility is derived from signals that mean what they say:
+//   - required checks   → the checks API, by the ruleset's own context names
+//   - conflicting-ness  → `mergeable` (MERGEABLE/CONFLICTING/UNKNOWN)
+//   - behind-ness       → the compare API, and it does NOT disqualify
+// and NEVER from `mergeStateStatus`.
+//
+// WHAT MUST SURVIVE THIS RE-SCOPE (#3878/#3904): the UNSTABLE exclusion existed
+// because a red NON-required check must not reach the queue — that state once
+// let red PRs in. Dropping the status string would silently drop that guard, so
+// it is re-expressed directly and more precisely: ZERO checks of ANY kind may
+// have a FAILURE conclusion, required or not. That is strictly stronger than
+// keying on UNSTABLE, which is only a lagging summary of the same fact.
+// ---------------------------------------------------------------------------
+
+// The six required contexts (docs/ci-policy.md §7). Read from the ruleset at
+// runtime by `requiredCheckNames`; this is the fallback when that read fails.
+export const REQUIRED_CHECK_FALLBACK = Object.freeze([
+  "cheap gate (main-ancestor + lint)",
+  "quality",
+  "merge shard reports",
+  "equivalence-gate",
+  "check for test262 regressions",
+  "cla-check",
+]);
+
+/** Live required-check contexts from the branch ruleset, falling back if unreadable. */
+export function requiredCheckNames(repo = REPO, runner = ghMaybe) {
+  const res = runner([
+    "api",
+    `repos/${repo}/rules/branches/main`,
+    "--jq",
+    '[.[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context]',
+  ]);
+  if (!res.ok) return { names: [...REQUIRED_CHECK_FALLBACK], source: "fallback" };
+  try {
+    const parsed = JSON.parse(String(res.stdout || ""));
+    if (Array.isArray(parsed) && parsed.length > 0) return { names: parsed, source: "ruleset" };
+  } catch {
+    /* fall through */
+  }
+  return { names: [...REQUIRED_CHECK_FALLBACK], source: "fallback" };
+}
+
+const PENDING_CHECK_STATES = new Set(["pending", "queued", "in_progress"]);
+
+/**
+ * #4094 — classify a PR's checks from real check rows (`{name, state}`).
+ *
+ * ⚠ A CHECK NAME IS NOT AN IDENTIFIER. Several names are published TWICE — the
+ * real job and `test262-pr-stub.yml`'s stub both publish `merge shard reports`
+ * and `check for test262 regressions`, and on PR #4002 one instance read `pass`
+ * while the other read `skipping`. Taking the first match (`head -1`) is how a
+ * watcher settles on the stub and calls a PR green that isn't. So EVERY instance
+ * of a required name is considered, and the name is satisfied only when ALL of
+ * its instances are pass/skipping.
+ *
+ * A `skipping` required check SATISFIES branch protection (a skipped job still
+ * publishes a check run and the ruleset accepts it), so it counts as green here.
+ */
+export function classifyChecks(rows, requiredNames) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return { green: false, reason: "no-checks-visible", failures: [], pendingRequired: [], missingRequired: [] };
+  }
+  const required = new Set(requiredNames);
+  const failures = [];
+  const pendingRequired = [];
+  const seenRequired = new Set();
+  for (const row of rows) {
+    const name = String(row?.name ?? "").trim();
+    const state = String(row?.state ?? "").trim();
+    // Zero-FAILURE rule: applies to EVERY check, required or not (#3878/#3904).
+    if (!PASSING_CHECK_STATES.has(state) && !PENDING_CHECK_STATES.has(state)) {
+      failures.push(`${name}: ${state}`);
+      continue;
+    }
+    if (!required.has(name)) continue;
+    if (PENDING_CHECK_STATES.has(state)) pendingRequired.push(`${name}: ${state}`);
+    else seenRequired.add(name);
+  }
+  const missingRequired = [...required].filter((n) => !seenRequired.has(n));
+  if (failures.length > 0)
+    return { green: false, reason: `failing:${failures.length}`, failures, pendingRequired, missingRequired };
+  if (pendingRequired.length > 0)
+    return {
+      green: false,
+      reason: `pending-required:${pendingRequired.length}`,
+      failures,
+      pendingRequired,
+      missingRequired,
+    };
+  if (missingRequired.length > 0)
+    return {
+      green: false,
+      reason: `missing-required:${missingRequired.length}`,
+      failures,
+      pendingRequired,
+      missingRequired,
+    };
+  return { green: true, reason: "all-required-green", failures, pendingRequired, missingRequired };
+}
+
 /**
  * #4094 — the eligibility decision, pure and exported so both controls are
  * unit-testable with no `gh` call and no queue mutation.
  *
- * SCOPE, narrow on purpose (issue #4094 constraint 1): this widens the
- * ELIGIBILITY TEST only. It updates/rebases nothing. The 2026-06-11 incident
- * (17 bot-updated BEHIND PRs stranded in `action_required`) was caused by
- * *bot-updating branches*; `ALLOW_UPDATE_BRANCH` semantics are untouched here.
+ * SCOPE (issue #4094 constraint 1, unchanged by the re-scope): this decides
+ * ELIGIBILITY ONLY. It updates/rebases no branch — the 2026-06-11 incident (17
+ * bot-updated BEHIND PRs stranded in `action_required`) was caused by
+ * *bot-updating branches*, a different mechanism; `ALLOW_UPDATE_BRANCH` is
+ * untouched. Drafts, hold labels and the author-trust gate are also unchanged
+ * and still applied by the caller.
  *
- * Everything else stays exactly as it was — in particular `UNSTABLE` remains
- * excluded (#3878/#3904: required-green + one red non-required is precisely the
- * state that once let red PRs into the queue), as do drafts, hold labels and the
- * author-trust gate. The ONLY state this admits that was previously refused is
- * `BEHIND`, and only when the entire divergence is skip-CI commits.
+ * `mergeStateStatus` is deliberately NOT a parameter. It cannot be consulted
+ * even by accident.
  */
-export function enqueueEligibility(mergeStateStatus, divergence = null) {
-  if (ENQUEUEABLE.has(mergeStateStatus)) {
-    return { eligible: true, reason: `state:${mergeStateStatus}` };
-  }
-  if (mergeStateStatus !== "BEHIND") {
-    return { eligible: false, reason: mergeStateStatus || "merge-state-missing" };
-  }
-  if (!divergence || divergence.ok !== true) {
-    return { eligible: false, reason: `BEHIND (divergence-unknown:${divergence?.reason || "not-fetched"})` };
-  }
-  if (!isSkipCiOnlyDivergence(divergence.messages)) {
-    return { eligible: false, reason: `BEHIND (${divergence.reason})` };
-  }
-  return { eligible: true, reason: `BEHIND-skip-ci-only (${divergence.reason})` };
+export function enqueueEligibility({ checks, requiredNames, isDraft, labels = [], mergeable } = {}) {
+  if (isDraft) return { eligible: false, reason: "draft" };
+  const lowered = labels.map((l) => String(l?.name ?? l ?? "").toLowerCase());
+  const held = lowered.find((l) => HOLD_LABELS.has(l));
+  if (held) return { eligible: false, reason: `hold-label:${held}` };
+  // Conflicting-ness from `mergeable`, never the status string. UNKNOWN means
+  // GitHub has not finished computing the merge — fail closed, retry next sweep.
+  if (mergeable === "CONFLICTING") return { eligible: false, reason: "conflicting" };
+  if (mergeable !== "MERGEABLE") return { eligible: false, reason: `mergeable:${mergeable || "missing"}` };
+  const verdict = classifyChecks(checks, requiredNames);
+  if (!verdict.green) return { eligible: false, reason: verdict.reason, checks: verdict };
+  // NOTE: behind-ness is deliberately absent. A PR behind main is eligible — the
+  // queue builds its merge group against main and re-validates there.
+  return { eligible: true, reason: "real-signals-green", checks: verdict };
 }
 // STALL SURFACING (#3584). How long a PR must sit BLOCKED with nothing failing
 // and nothing pending before we stop calling it "in flight" and start calling it
@@ -373,9 +495,14 @@ export function freshEnqueueGuard(initial, fresh) {
   if (labels.some((label) => HOLD_LABELS.has(label))) {
     return { ok: false, reason: "hold-label" };
   }
-  if (!ENQUEUEABLE.has(fresh.mergeStateStatus)) {
-    return { ok: false, reason: fresh.mergeStateStatus || "merge-state-missing" };
-  }
+  // (#4094) Was `!ENQUEUEABLE.has(fresh.mergeStateStatus)`. That re-read the same
+  // STALE field the sweep had already stopped trusting, so a PR could clear the
+  // real-signal gate and then be rejected here by a status GitHub had not
+  // recomputed — the freshness re-check turning into a second coin flip. The
+  // genuine freshness questions (head moved, base changed, draft, hold) are all
+  // above and unchanged; conflicting-ness is the only merge fact left, and it
+  // comes from `mergeable`.
+  if (fresh.mergeable === "CONFLICTING") return { ok: false, reason: "conflicting" };
   return { ok: true, reason: "exact-fresh-candidate" };
 }
 
@@ -456,7 +583,9 @@ function openPrs() {
       // author.login + headRepositoryOwner.login feed the #2550 fork-allowlist
       // layer of the author-trust gate (both fields ARE supported by gh 2.23's
       // `pr list --json`, unlike authorAssociation which needs GraphQL).
-      "number,mergeStateStatus,isDraft,labels,id,title,headRefName,headRefOid,baseRefName,author,headRepositoryOwner",
+      // (#4094) `mergeable` added: conflicting-ness now comes from this field,
+      // never from the stale `mergeStateStatus` summary.
+      "number,mergeStateStatus,mergeable,isDraft,labels,id,title,headRefName,headRefOid,baseRefName,author,headRepositoryOwner",
     ]),
   );
 }
@@ -470,7 +599,7 @@ function freshPrForEnqueue(number) {
       "--repo",
       REPO,
       "--json",
-      "number,mergeStateStatus,isDraft,labels,headRefName,headRefOid,baseRefName",
+      "number,mergeStateStatus,mergeable,isDraft,labels,headRefName,headRefOid,baseRefName",
     ]),
   );
 }
@@ -523,11 +652,16 @@ function visibleCheckState(prNumber) {
   const output = res.stdout.trim();
   if (!output) {
     const msg = (res.stderr || "no check output").split("\n")[0].slice(0, 120);
-    return { failed: [], pending: [], error: msg };
+    return { failed: [], pending: [], rows: [], error: msg };
   }
 
   const failed = [];
   const pending = [];
+  // (#4094) Every parsed row, kept so `classifyChecks` can verify the REQUIRED
+  // contexts are actually PRESENT. "nothing failed and nothing pending" is not
+  // the same statement as "the required checks ran" — a PR whose required jobs
+  // never reported at all satisfies the former and must still not be enqueued.
+  const rows = [];
   let parsed = 0;
   for (const line of output.split(/\r?\n/)) {
     if (!line.trim()) continue;
@@ -536,6 +670,7 @@ function visibleCheckState(prNumber) {
     parsed++;
     const name = cols[0].trim();
     const state = cols[1].trim();
+    rows.push({ name, state });
     if (PASSING_CHECK_STATES.has(state)) continue;
     const entry = `${name}: ${state}`;
     if (state === "pending" || state === "queued" || state === "in_progress") {
@@ -544,9 +679,9 @@ function visibleCheckState(prNumber) {
       failed.push(entry);
     }
   }
-  if (parsed === 0) return { failed: [], pending: [], error: "no parseable checks" };
+  if (parsed === 0) return { failed: [], pending: [], rows: [], error: "no parseable checks" };
 
-  return { failed, pending, error: null };
+  return { failed, pending, rows, error: null };
 }
 
 // CLA-CHECK SHA STRANDING (#1958a). When the merge queue or a drift-update adds
@@ -916,10 +1051,16 @@ function runSweep() {
   // pr list cannot return it). The enqueue loop fails closed: a PR missing from
   // this map, or whose association is not trusted, is never auto-enqueued.
   const authorAssoc = authorAssociations();
+  // (#4094) The required contexts, read from the branch ruleset itself so this
+  // never drifts from `docs/ci-policy.md` (`linear-tests` was documented as
+  // required for months and never was — #3934). Falls back to the static list.
+  const requiredInfo = requiredCheckNames();
+  const REQUIRED_NAMES = requiredInfo.names;
   const enqueued = [];
   const skipped = [];
   const updated = [];
   const stalled = []; // #3584 — BLOCKED, nothing red, nothing pending, sustained
+  const refusals = []; // #4094 — raw enqueue-mutation refusals, kept as telemetry
 
   // Auto-update BEHIND PRs: merge base branch in via GitHub API so they can
   // re-run CI and eventually become CLEAN. DIRTY PRs (merge conflicts) are
@@ -978,19 +1119,30 @@ function runSweep() {
       skipped.push([pr.number, "already-queued"]);
       continue;
     }
-    if (!ENQUEUEABLE.has(pr.mergeStateStatus)) {
-      // STALL SURFACING (#3584). Before emitting the same `skip (BLOCKED)` line
-      // this script has always emitted, work out whether this BLOCKED is the
-      // ordinary in-flight kind or the kind that never resolves. Scoped to
-      // BLOCKED *only*: BEHIND/DIRTY/UNKNOWN have their own recovery paths and
-      // must not pay these two extra API reads. Everything here is best-effort —
-      // it changes no enqueue decision, it only decides how loudly we log.
+    // (#4094) REAL-SIGNAL GATE. This used to be `!ENQUEUEABLE.has(mergeStateStatus)`.
+    // That field is a STALE SAMPLE, not current state — measured 2026-08-02, PR
+    // #4033 read CLEAN while 4 commits behind and #4034 read UNSTABLE while 0
+    // behind, and #4028 read BEHIND then UNSTABLE minutes apart with no push. So
+    // eligibility now comes from draft / hold labels / `mergeable`, and from the
+    // checks API below. Behind-ness deliberately does NOT disqualify: the queue
+    // builds merge groups against main (#4002, 1 behind, and #4033, 4 behind,
+    // were both queued and #4002 merged with a green merge_group re-validation).
+    const gate = enqueueEligibility({
+      checks: null, // checks are evaluated below, after the author-trust gate
+      requiredNames: REQUIRED_NAMES,
+      isDraft: pr.isDraft,
+      labels: pr.labels,
+      mergeable: pr.mergeable,
+    });
+    if (!gate.eligible && gate.reason !== "no-checks-visible") {
+      // STALL SURFACING (#3584) — unchanged in intent. Best-effort: it changes no
+      // enqueue decision, it only decides how loudly we log.
       const diag = blockedDiagnosis(pr, authorAssoc);
       if (diag.suspected) {
         const label = DRY ? { ok: true, why: "would-label" } : addStallLabel(pr.number);
         stalled.push([pr.number, `${diag.reason}; ${label.why}`]);
       }
-      skipped.push([pr.number, diag.annotated]); // BLOCKED/BEHIND/DIRTY/DRAFT/UNKNOWN
+      skipped.push([pr.number, `${gate.reason} (${diag.annotated})`]);
       continue;
     }
     // PARK-RACE GUARD (#2975). A PR that just FAILED merge_group re-validation is
@@ -1042,6 +1194,17 @@ function runSweep() {
     }
     if (checks.pending.length > 0) {
       skipped.push([pr.number, `pending-checks: ${checks.pending.slice(0, 5).join(", ")}`]);
+      continue;
+    }
+    // (#4094) The required contexts must be PRESENT, not merely non-failing. The
+    // two guards above answer "did anything fail or is anything pending"; neither
+    // notices a PR whose required jobs never reported at all. `classifyChecks`
+    // also handles the name collision: `merge shard reports` and `check for
+    // test262 regressions` are each published TWICE (real job + the #3934 stub),
+    // so a first-match read can settle on the stub.
+    const required = classifyChecks(checks.rows, REQUIRED_NAMES);
+    if (!required.green) {
+      skipped.push([pr.number, `required-not-green: ${required.reason}`]);
       continue;
     }
     // GUARD 3 — grace window. Only enqueue a PR green-but-unqueued for > GRACE.
@@ -1117,7 +1280,23 @@ function runSweep() {
         `,
         enqueueMutationVariables(pr.id, fresh.headRefOid),
       );
-      enqueued.push([pr.number, `enqueued (green ${ageMin}m)`]);
+      // (#4094) TELEMETRY, not a decision. Record how far behind main this PR was
+      // when it was accepted, and whether that divergence was skip-CI-only. This
+      // is the evidence base for the re-scope itself: it shows, per enqueue,
+      // whether admitting behind PRs is routine or exceptional. Best-effort — a
+      // failed compare read must never affect an enqueue that already succeeded.
+      let behindNote = "";
+      try {
+        const div = divergenceCommitMessages(fresh.headRefOid);
+        if (div.ok) {
+          const n = div.messages.length;
+          behindNote =
+            n === 0 ? ", up-to-date" : `, behind=${n}${isSkipCiOnlyDivergence(div.messages) ? " (skip-ci only)" : ""}`;
+        }
+      } catch {
+        /* telemetry only */
+      }
+      enqueued.push([pr.number, `enqueued (green ${ageMin}m${behindNote})`]);
       // #3584: a PR flagged on an earlier sweep and enqueued now was a false
       // positive (or was rescued); drop the label so it cannot rot and dilute
       // the signal. No-op when the label is absent.
@@ -1137,6 +1316,13 @@ function runSweep() {
         const r = DRY ? { ok: true, why: "would rerun cla-check" } : rerunClaCheck(pr.number, pr.headRefName);
         skipped.push([pr.number, `cla-check stale on head — ${r.why}; retry next sweep`]);
       } else {
+        // (#4094) MUTATION-REFUSAL TELEMETRY. The one question STEP 0 could not
+        // settle without mutating is whether GitHub ever refuses `enqueuePullRequest`
+        // for a PR that is behind main. Rather than manufacture that state, capture
+        // the RAW error here and degrade to skip: production answers it, and a
+        // refusal costs one sweep instead of a stranding. Recorded verbatim (not
+        // pattern-matched) so an unanticipated refusal reason is still legible.
+        refusals.push([pr.number, msg]);
         skipped.push([pr.number, `enqueue-failed: ${msg}`]);
       }
     }
@@ -1145,8 +1331,12 @@ function runSweep() {
   console.log(
     `enqueue-green-prs: ${prs.length} open, ${inQueue.size} already queued, grace=${GRACE_MINUTES}m${DRY ? " (DRY RUN)" : ""}`,
   );
+  console.log(`enqueue-green-prs: required checks (${requiredInfo.source}): ${REQUIRED_NAMES.join(", ")}`);
   for (const [n, why] of updated) console.log(`  ~ #${n} ${why}`);
   for (const [n, why] of enqueued) console.log(`  + #${n} ${why}`);
+  // (#4094) Surfaced separately from the generic skip lines so a mutation refusal
+  // is visible as its own class rather than buried among ordinary skips.
+  for (const [n, why] of refusals) console.log(`  ! #${n} ENQUEUE REFUSED (telemetry): ${why}`);
   for (const [n, why] of skipped) console.log(`  - #${n} skip (${why})`);
   // #3584 — the whole point of the classifier: a stall that used to be one more
   // indistinguishable `skip (BLOCKED)` line now gets its own block at the end of
@@ -1170,6 +1360,7 @@ function selfCheck() {
     headRefOid: "a".repeat(40),
     baseRefName: "stack/parent",
     mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
     isDraft: false,
     labels: [],
   };
@@ -1194,9 +1385,20 @@ function selfCheck() {
     ok: false,
     reason: "head-changed-during-sweep",
   });
+  // (#4094) This assertion previously REQUIRED `mergeStateStatus: "BEHIND"` to be
+  // rejected. It is inverted deliberately, not relaxed: that field is a stale
+  // sample (PR #4033 read CLEAN while 4 commits behind; #4034 read UNSTABLE while
+  // 0 behind), and behind-ness genuinely does not block the queue — #4002 was
+  // enqueued 1 commit behind and merged with a green merge_group re-validation.
+  // A test pinning the old bail would have defended the defect.
   assert.deepEqual(freshEnqueueGuard(initial, { ...exactMain, mergeStateStatus: "BEHIND" }), {
+    ok: true,
+    reason: "exact-fresh-candidate",
+  });
+  // Conflicting-ness is the real blocker, and it comes from `mergeable`.
+  assert.deepEqual(freshEnqueueGuard(initial, { ...exactMain, mergeable: "CONFLICTING" }), {
     ok: false,
-    reason: "BEHIND",
+    reason: "conflicting",
   });
   assert.deepEqual(enqueueMutationVariables("PR_node_id", exactMain.headRefOid), {
     id: "PR_node_id",

--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -282,7 +282,22 @@ export function classifyChecks(rows, requiredNames) {
   if (missingRequired.length > 0)
     return {
       green: false,
-      reason: `missing-required:${missingRequired.length}`,
+      // (#4094) WORDING IS LOAD-BEARING — do not shorten this to "stranded" or
+      // imply a cause. Two very different mechanisms produce an absent required
+      // context, and they have OPPOSITE remedies:
+      //   - a dropped `synchronize` delivery — GitHub simply never dispatched the
+      //     `pull_request` workflows for this head. Signature: ONLY the
+      //     `pull_request_target` checks (`cla-check`, retarget) are present, and
+      //     the contexts DID run on an earlier head. Remedy: push any commit.
+      //   - a workflow-level `paths:` skip — no check run is ever created, on ANY
+      //     head, so the context stays "Expected" forever. Remedy: fix the path
+      //     filters (what `test262-pr-stub.yml` exists to prevent).
+      // Measured 2026-08-02 on #4028: it looked like the second and was the FIRST
+      // (its earlier heads ran `quality`), and a single retrigger commit cleared
+      // it. Naming the wrong one sends someone editing path filters to chase a
+      // GitHub delivery failure, so this reports the OBSERVATION and the
+      // discriminator, never a diagnosis.
+      reason: `required-not-reported:${missingRequired.length} [${missingRequired.slice(0, 3).join(", ")}] — no check run on THIS head; if they ran on an earlier head it is a dropped synchronize (push any commit), else check workflow path filters`,
       failures,
       pendingRequired,
       missingRequired,
@@ -433,6 +448,49 @@ function graphql(query, vars = {}) {
  *
  * Returns `{ ok, messages, reason }`. `ok:false` ⇒ caller must NOT exempt.
  */
+/**
+ * #4094 — the AUTHORITATIVE head SHA, from the REST pull resource.
+ *
+ * ⚠ `gh pr view --json headRefOid` (and the GraphQL PR object generally) serves a
+ * CACHED SAMPLE. Measured 2026-08-02 on #4028: `headRefOid` returned `d07a989e`
+ * while the REST `.head.sha` was already `e24f4378` — one push stale.
+ *
+ * This is the worst failure shape available to this script, because it is
+ * SILENT and internally consistent: check runs fetched for a stale SHA are all
+ * genuinely real — complete, green, correctly reported — just for the wrong
+ * commit. Nothing anywhere looks anomalous, and the eligibility verdict is
+ * simply wrong. Three fields of this repo's PR view were found stale in one day
+ * (`mergeStateStatus`, local tracking refs, `headRefOid`), so the rule is: for
+ * anything load-bearing, read the specific REST resource.
+ */
+export function authoritativeHeadSha(prNumber, repo = REPO, runner = ghMaybe) {
+  const res = runner(["api", `repos/${repo}/pulls/${prNumber}`, "--jq", ".head.sha"]);
+  if (!res.ok) return { ok: false, sha: null, reason: "rest-head-unavailable" };
+  const sha = String(res.stdout || "").trim();
+  if (!/^[0-9a-f]{40}$/.test(sha)) return { ok: false, sha: null, reason: "rest-head-shape" };
+  return { ok: true, sha, reason: "rest" };
+}
+
+/**
+ * #4094 — reconcile the cached PR-view SHA against the authoritative REST one.
+ *
+ * FAILS CLOSED both ways. If REST is unreadable we do not fall back to the
+ * cached value (that would reinstate exactly the bug). If the two DISAGREE the
+ * head moved under the sweep, so every check verdict already computed is about
+ * the wrong commit — skip this PR and let the next sweep see a consistent world.
+ */
+export function reconcileHeadSha(viewSha, rest) {
+  if (!rest || rest.ok !== true) return { ok: false, sha: null, reason: rest?.reason || "rest-head-missing" };
+  if (viewSha && viewSha !== rest.sha) {
+    return {
+      ok: false,
+      sha: rest.sha,
+      reason: `head-sha-stale (view=${String(viewSha).slice(0, 9)} rest=${rest.sha.slice(0, 9)})`,
+    };
+  }
+  return { ok: true, sha: rest.sha, reason: "head-sha-agreed" };
+}
+
 export function divergenceCommitMessages(headOid, repo = REPO, runner = ghMaybe) {
   if (!headOid) return { ok: false, messages: null, reason: "no-head-oid" };
   // Reduce to a JSON ARRAY and parse it — do NOT split raw --jq output on newlines.
@@ -1202,6 +1260,16 @@ function runSweep() {
     // also handles the name collision: `merge shard reports` and `check for
     // test262 regressions` are each published TWICE (real job + the #3934 stub),
     // so a first-match read can settle on the stub.
+    //
+    // SHA STALENESS (measured 2026-08-02): `gh pr view --json headRefOid` can
+    // serve a SHA the push has already superseded — the authoritative read is
+    // `gh api repos/<repo>/pulls/<N> --jq .head.sha`. That matters here because a
+    // predicate keyed on "check runs for a SHA" produces a CONFIDENT WRONG
+    // verdict on a stale one: the runs it finds are all genuinely real, just for
+    // the wrong head. This path is fail-SAFE rather than fail-wrong only because
+    // the enqueue mutation pins `expectedHeadOid` — a stale SHA is refused by
+    // GitHub (captured as refusal telemetry) instead of enqueueing the wrong
+    // state, and `freshEnqueueGuard` independently rejects a moved head.
     const required = classifyChecks(checks.rows, REQUIRED_NAMES);
     if (!required.green) {
       skipped.push([pr.number, `required-not-green: ${required.reason}`]);
@@ -1251,6 +1319,17 @@ function runSweep() {
       skipped.push([pr.number, `fresh-guard:${exact.reason}`]);
       continue;
     }
+    // (#4094) Pin the AUTHORITATIVE head before anything keyed on a SHA. `fresh`
+    // came from `gh pr view`, whose `headRefOid` can be one push stale — and the
+    // check runs fetched for a stale SHA are all genuinely real, just for the
+    // wrong commit, so the verdict is wrong with no anomaly to notice. Fails
+    // closed: unreadable REST, or REST disagreeing with the view, both skip.
+    const headCheck = reconcileHeadSha(fresh.headRefOid, authoritativeHeadSha(pr.number));
+    if (!headCheck.ok) {
+      skipped.push([pr.number, `head-sha:${headCheck.reason}`]);
+      continue;
+    }
+    const headSha = headCheck.sha;
     const exactChecks = visibleCheckState(pr.number);
     if (exactChecks.error) {
       skipped.push([pr.number, `fresh-checks-unavailable: ${exactChecks.error}`]);
@@ -1278,7 +1357,7 @@ function runSweep() {
             }
           }
         `,
-        enqueueMutationVariables(pr.id, fresh.headRefOid),
+        enqueueMutationVariables(pr.id, headSha),
       );
       // (#4094) TELEMETRY, not a decision. Record how far behind main this PR was
       // when it was accepted, and whether that divergence was skip-CI-only. This
@@ -1287,7 +1366,7 @@ function runSweep() {
       // failed compare read must never affect an enqueue that already succeeded.
       let behindNote = "";
       try {
-        const div = divergenceCommitMessages(fresh.headRefOid);
+        const div = divergenceCommitMessages(headSha);
         if (div.ok) {
           const n = div.messages.length;
           behindNote =

--- a/tests/issue-4094-skipci-enqueue-exemption.test.ts
+++ b/tests/issue-4094-skipci-enqueue-exemption.test.ts
@@ -15,6 +15,9 @@ import {
   isSkipCiOnlyDivergence,
   enqueueEligibility,
   divergenceCommitMessages,
+  classifyChecks,
+  requiredCheckNames,
+  REQUIRED_CHECK_FALLBACK,
 } from "../scripts/enqueue-green-prs.mjs";
 
 // The real baseline commit that made PR #4002 BEHIND on 2026-08-02 — the exact
@@ -84,45 +87,139 @@ describe("#4094 divergence classification", () => {
   });
 });
 
-describe("#4094 enqueue eligibility", () => {
-  const skipCiDivergence = { ok: true, messages: [REAL_BASELINE_COMMIT], reason: "commits:1" };
-  const realDivergence = { ok: true, messages: ["fix(#1): real change"], reason: "commits:1" };
+// The six required contexts, as the ruleset reports them.
+const REQUIRED = [
+  "cheap gate (main-ancestor + lint)",
+  "quality",
+  "merge shard reports",
+  "equivalence-gate",
+  "check for test262 regressions",
+  "cla-check",
+];
+const allGreenRows = () => REQUIRED.map((name) => ({ name, state: "pass" }));
 
-  it("leaves the pre-existing enqueueable states untouched", () => {
-    expect(enqueueEligibility("CLEAN").eligible).toBe(true);
-    expect(enqueueEligibility("HAS_HOOKS").eligible).toBe(true);
+describe("#4094 classifyChecks — required contexts from real check rows", () => {
+  it("accepts when every required context is pass or skipping", () => {
+    expect(classifyChecks(allGreenRows(), REQUIRED).green).toBe(true);
+    // A SKIPPED required check satisfies branch protection.
+    const withSkip = allGreenRows().map((r) => (r.name === "equivalence-gate" ? { ...r, state: "skipping" } : r));
+    expect(classifyChecks(withSkip, REQUIRED).green).toBe(true);
   });
 
-  // #3878/#3904 — required-green with one red NON-required check is exactly the
-  // state that once let red PRs into the queue. It must stay excluded, and must
-  // NOT become eligible just because the divergence happens to be skip-ci.
-  it("still excludes UNSTABLE, even with a skip-ci-only divergence", () => {
-    expect(enqueueEligibility("UNSTABLE").eligible).toBe(false);
-    expect(enqueueEligibility("UNSTABLE", skipCiDivergence).eligible).toBe(false);
+  // ⚠ A check NAME is not an identifier. `merge shard reports` and `check for
+  // test262 regressions` are each published TWICE (real job + #3934 stub) — on
+  // PR #4002 one instance read `pass` and the other `skipping`. `head -1` is how
+  // a watcher settles on the stub.
+  it("handles duplicate names: both instances pass/skipping is green", () => {
+    const rows = [...allGreenRows(), { name: "merge shard reports", state: "skipping" }];
+    expect(classifyChecks(rows, REQUIRED).green).toBe(true);
   });
 
-  it("still excludes DIRTY / BLOCKED / UNKNOWN regardless of divergence", () => {
-    for (const state of ["DIRTY", "BLOCKED", "UNKNOWN", "DRAFT"]) {
-      expect(enqueueEligibility(state, skipCiDivergence).eligible).toBe(false);
-    }
+  it("handles duplicate names: a FAILING second instance is not masked by a passing first", () => {
+    const rows = [...allGreenRows(), { name: "merge shard reports", state: "fail" }];
+    const got = classifyChecks(rows, REQUIRED);
+    expect(got.green).toBe(false);
+    expect(got.failures.join()).toContain("merge shard reports");
   });
 
-  it("POSITIVE CONTROL: BEHIND by only a skip-ci commit becomes eligible", () => {
-    const got = enqueueEligibility("BEHIND", skipCiDivergence);
+  it("handles duplicate names: a PENDING second instance keeps it not-green", () => {
+    const rows = [...allGreenRows(), { name: "quality", state: "pending" }];
+    expect(classifyChecks(rows, REQUIRED).green).toBe(false);
+  });
+
+  // NEGATIVE CONTROL #1 — one red REQUIRED check.
+  it("NEGATIVE CONTROL: a red required check is excluded", () => {
+    const rows = allGreenRows().map((r) => (r.name === "quality" ? { ...r, state: "fail" } : r));
+    expect(classifyChecks(rows, REQUIRED).green).toBe(false);
+  });
+
+  // NEGATIVE CONTROL #2 — this is what the UNSTABLE exclusion was protecting
+  // (#3878/#3904). Dropping the status string must NOT drop this guard.
+  it("NEGATIVE CONTROL: a red NON-required check is also excluded", () => {
+    const rows = [...allGreenRows(), { name: "some-optional-canary", state: "fail" }];
+    const got = classifyChecks(rows, REQUIRED);
+    expect(got.green).toBe(false);
+    expect(got.failures.join()).toContain("some-optional-canary");
+  });
+
+  it("excludes when a required context never reported at all", () => {
+    const rows = allGreenRows().filter((r) => r.name !== "cla-check");
+    const got = classifyChecks(rows, REQUIRED);
+    expect(got.green).toBe(false);
+    expect(got.missingRequired).toContain("cla-check");
+  });
+
+  it("FAILS CLOSED on no visible checks", () => {
+    expect(classifyChecks([], REQUIRED).green).toBe(false);
+    expect(classifyChecks(null as unknown as [], REQUIRED).green).toBe(false);
+  });
+});
+
+describe("#4094 enqueueEligibility — real signals only", () => {
+  const base = { checks: allGreenRows(), requiredNames: REQUIRED, isDraft: false, labels: [], mergeable: "MERGEABLE" };
+
+  // POSITIVE CONTROL: a genuinely-green PR is eligible, and behind-ness is not
+  // even an input — #4002 (1 behind) and #4033 (4 behind) were both queued, and
+  // #4002 merged with a green merge_group re-validation.
+  it("POSITIVE CONTROL: green + mergeable is eligible, with no behindness input", () => {
+    const got = enqueueEligibility(base);
     expect(got.eligible).toBe(true);
-    expect(got.reason).toContain("skip-ci-only");
+    expect(got.reason).toBe("real-signals-green");
   });
 
-  it("NEGATIVE CONTROL: BEHIND by a real commit stays excluded", () => {
-    expect(enqueueEligibility("BEHIND", realDivergence).eligible).toBe(false);
+  // The whole point of the re-scope: the stale field must be unreachable.
+  it("does not accept mergeStateStatus as an input at all", () => {
+    // Passing it changes nothing — eligibility is decided by real signals.
+    expect(enqueueEligibility({ ...base, mergeStateStatus: "BEHIND" } as never).eligible).toBe(true);
+    expect(enqueueEligibility({ ...base, mergeStateStatus: "UNSTABLE" } as never).eligible).toBe(true);
+    expect(enqueueEligibility({ ...base, mergeStateStatus: "CLEAN" } as never).eligible).toBe(true);
   });
 
-  it("BEHIND with an unfetched or failed divergence stays excluded", () => {
-    expect(enqueueEligibility("BEHIND").eligible).toBe(false);
-    expect(enqueueEligibility("BEHIND", null).eligible).toBe(false);
-    expect(enqueueEligibility("BEHIND", { ok: false, messages: null, reason: "compare-api-failed" }).eligible).toBe(
-      false,
-    );
+  it("NEGATIVE CONTROL: one red required check stays excluded", () => {
+    const checks = allGreenRows().map((r) => (r.name === "quality" ? { ...r, state: "fail" } : r));
+    expect(enqueueEligibility({ ...base, checks }).eligible).toBe(false);
+  });
+
+  it("NEGATIVE CONTROL: a red NON-required check stays excluded (the #3878/#3904 guard)", () => {
+    const checks = [...allGreenRows(), { name: "release-pending", state: "fail" }];
+    expect(enqueueEligibility({ ...base, checks }).eligible).toBe(false);
+  });
+
+  it("excludes drafts and hold-labelled PRs", () => {
+    expect(enqueueEligibility({ ...base, isDraft: true }).eligible).toBe(false);
+    expect(enqueueEligibility({ ...base, labels: [{ name: "hold" }] }).eligible).toBe(false);
+    expect(enqueueEligibility({ ...base, labels: [{ name: "stack-retarget-pending" }] }).eligible).toBe(false);
+  });
+
+  it("excludes CONFLICTING, and fails closed on an UNKNOWN merge computation", () => {
+    expect(enqueueEligibility({ ...base, mergeable: "CONFLICTING" }).eligible).toBe(false);
+    expect(enqueueEligibility({ ...base, mergeable: "UNKNOWN" }).eligible).toBe(false);
+    expect(enqueueEligibility({ ...base, mergeable: undefined }).eligible).toBe(false);
+  });
+});
+
+describe("#4094 requiredCheckNames", () => {
+  it("prefers the live ruleset over the static fallback", () => {
+    const fake = () => ({ ok: true, stdout: JSON.stringify(["only-one"]), stderr: "" });
+    const got = requiredCheckNames("loopdive/js2", fake);
+    expect(got.names).toEqual(["only-one"]);
+    expect(got.source).toBe("ruleset");
+  });
+
+  // `linear-tests` was documented as required for months and never was (#3934),
+  // so the list must come from the ruleset when readable — but a failed read
+  // must not yield an EMPTY required set, which would make everything "green".
+  it("falls back to the six documented contexts when the ruleset is unreadable", () => {
+    const failing = () => ({ ok: false, stdout: "", stderr: "boom" });
+    const got = requiredCheckNames("loopdive/js2", failing);
+    expect(got.source).toBe("fallback");
+    expect(got.names).toEqual([...REQUIRED_CHECK_FALLBACK]);
+    expect(got.names.length).toBe(6);
+  });
+
+  it("falls back rather than accepting an empty ruleset array", () => {
+    const empty = () => ({ ok: true, stdout: "[]", stderr: "" });
+    expect(requiredCheckNames("loopdive/js2", empty).source).toBe("fallback");
   });
 });
 

--- a/tests/issue-4094-skipci-enqueue-exemption.test.ts
+++ b/tests/issue-4094-skipci-enqueue-exemption.test.ts
@@ -1,0 +1,167 @@
+// #4094 — a PR behind ONLY by `[skip ci]` commits counts as enqueueable.
+//
+// Stakeholder decision 2026-08-02, breaking the BEHIND-churn loop measured in
+// #4093: a `[skip ci]` baseline commit lands on main, every open PR goes BEHIND,
+// `ENQUEUEABLE = {CLEAN, HAS_HOOKS}` excludes BEHIND, and green PRs are
+// un-enqueueable until a slow refresh cron catches up.
+//
+// These tests pin the PURE predicates only — no `gh` calls, no queue mutation
+// (same style as tests/issue-2560-autoenqueue-trailing-add.test.ts).
+
+import { describe, expect, it } from "vitest";
+import {
+  SKIP_CI_MARKERS,
+  hasSkipCiMarker,
+  isSkipCiOnlyDivergence,
+  enqueueEligibility,
+  divergenceCommitMessages,
+} from "../scripts/enqueue-green-prs.mjs";
+
+// The real baseline commit that made PR #4002 BEHIND on 2026-08-02 — the exact
+// shape this exemption exists for.
+const REAL_BASELINE_COMMIT = "chore(test262): refresh sharded baseline — 30780/43490 pass [skip ci]";
+
+describe("#4094 skip-CI marker set", () => {
+  // Verified against docs.github.com/.../skip-workflow-runs on 2026-08-02.
+  // This repo only ever EMITS `[skip ci]`, so a predicate matching that one
+  // spelling would pass every other test here and still be wrong in production.
+  it("recognises all five spellings GitHub actually accepts", () => {
+    expect([...SKIP_CI_MARKERS].sort()).toEqual(
+      ["[actions skip]", "[ci skip]", "[no ci]", "[skip actions]", "[skip ci]"].sort(),
+    );
+    for (const marker of SKIP_CI_MARKERS) {
+      expect(hasSkipCiMarker(`chore: touch up ${marker}`)).toBe(true);
+    }
+  });
+
+  // GitHub's wording is "add ... to the commit message", not "to the first line".
+  it("matches a marker ANYWHERE in the message, not just the subject", () => {
+    expect(hasSkipCiMarker("chore: regen artifacts\n\nDetails here.\n[skip ci]")).toBe(true);
+    expect(hasSkipCiMarker("chore: regen artifacts\n\n[ci skip] because nothing testable changed")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(hasSkipCiMarker("chore: x [SKIP CI]")).toBe(true);
+    expect(hasSkipCiMarker("chore: x [Skip Ci]")).toBe(true);
+  });
+
+  it("does not match near-misses or prose about skipping ci", () => {
+    expect(hasSkipCiMarker("chore: explain why we skip ci sometimes")).toBe(false); // no brackets
+    expect(hasSkipCiMarker("fix: handle [skip] and [ci] separately")).toBe(false);
+    expect(hasSkipCiMarker("")).toBe(false);
+    expect(hasSkipCiMarker(undefined as unknown as string)).toBe(false);
+  });
+});
+
+describe("#4094 divergence classification", () => {
+  it("POSITIVE CONTROL: divergence of only skip-ci commits is skip-ci-only", () => {
+    expect(isSkipCiOnlyDivergence([REAL_BASELINE_COMMIT])).toBe(true);
+    expect(isSkipCiOnlyDivergence([REAL_BASELINE_COMMIT, "chore(ci): refresh landing benchmarks [skip ci]"])).toBe(
+      true,
+    );
+  });
+
+  // The load-bearing negative: ONE real commit must sink the whole set.
+  it("NEGATIVE CONTROL: one real commit disqualifies the whole divergence", () => {
+    expect(isSkipCiOnlyDivergence([REAL_BASELINE_COMMIT, "fix(#1234): change actual codegen"])).toBe(false);
+    expect(isSkipCiOnlyDivergence(["fix(#1234): change actual codegen"])).toBe(false);
+  });
+
+  // A detector whose "cannot see" answer equals "nothing wrong" is unsound, and
+  // this one gates entry to the merge queue. Both blind cases must refuse.
+  it("FAILS CLOSED on an EMPTY divergence set (vacuous-truth guard)", () => {
+    // `[].every(...)` is true — the trap this guard exists for. A genuinely
+    // BEHIND PR is behind by >= 1 commit, so an empty set means we did not see
+    // the divergence, not that it was clean.
+    expect([].every(() => false)).toBe(true); // documents the JS behaviour being guarded
+    expect(isSkipCiOnlyDivergence([])).toBe(false);
+  });
+
+  it("FAILS CLOSED on a missing/!array divergence set", () => {
+    expect(isSkipCiOnlyDivergence(null as unknown as string[])).toBe(false);
+    expect(isSkipCiOnlyDivergence(undefined as unknown as string[])).toBe(false);
+    expect(isSkipCiOnlyDivergence("[skip ci]" as unknown as string[])).toBe(false);
+  });
+});
+
+describe("#4094 enqueue eligibility", () => {
+  const skipCiDivergence = { ok: true, messages: [REAL_BASELINE_COMMIT], reason: "commits:1" };
+  const realDivergence = { ok: true, messages: ["fix(#1): real change"], reason: "commits:1" };
+
+  it("leaves the pre-existing enqueueable states untouched", () => {
+    expect(enqueueEligibility("CLEAN").eligible).toBe(true);
+    expect(enqueueEligibility("HAS_HOOKS").eligible).toBe(true);
+  });
+
+  // #3878/#3904 — required-green with one red NON-required check is exactly the
+  // state that once let red PRs into the queue. It must stay excluded, and must
+  // NOT become eligible just because the divergence happens to be skip-ci.
+  it("still excludes UNSTABLE, even with a skip-ci-only divergence", () => {
+    expect(enqueueEligibility("UNSTABLE").eligible).toBe(false);
+    expect(enqueueEligibility("UNSTABLE", skipCiDivergence).eligible).toBe(false);
+  });
+
+  it("still excludes DIRTY / BLOCKED / UNKNOWN regardless of divergence", () => {
+    for (const state of ["DIRTY", "BLOCKED", "UNKNOWN", "DRAFT"]) {
+      expect(enqueueEligibility(state, skipCiDivergence).eligible).toBe(false);
+    }
+  });
+
+  it("POSITIVE CONTROL: BEHIND by only a skip-ci commit becomes eligible", () => {
+    const got = enqueueEligibility("BEHIND", skipCiDivergence);
+    expect(got.eligible).toBe(true);
+    expect(got.reason).toContain("skip-ci-only");
+  });
+
+  it("NEGATIVE CONTROL: BEHIND by a real commit stays excluded", () => {
+    expect(enqueueEligibility("BEHIND", realDivergence).eligible).toBe(false);
+  });
+
+  it("BEHIND with an unfetched or failed divergence stays excluded", () => {
+    expect(enqueueEligibility("BEHIND").eligible).toBe(false);
+    expect(enqueueEligibility("BEHIND", null).eligible).toBe(false);
+    expect(enqueueEligibility("BEHIND", { ok: false, messages: null, reason: "compare-api-failed" }).eligible).toBe(
+      false,
+    );
+  });
+});
+
+describe("#4094 divergence fetch reads the correct compare field", () => {
+  // ⚠ Measured on PR #4002, 2026-08-02: `compare/<head>...main` answered
+  // `{ahead_by: 1, behind_by: 16, commits: [<the one [skip ci] commit>]}`.
+  // The divergence that matters is `commits` (== ahead_by). Reading `behind_by`
+  // — the natural misreading of "how far behind is this PR" — would have called
+  // #4002 sixteen commits divergent when it was exactly one baseline refresh.
+  it("asks the compare API for .commits[], not behind_by", () => {
+    const calls: string[][] = [];
+    const fakeGh = (args: string[]) => {
+      calls.push(args);
+      return { ok: true, stdout: JSON.stringify([REAL_BASELINE_COMMIT]), stderr: "" };
+    };
+    const got = divergenceCommitMessages("deadbeef", "loopdive/js2", fakeGh);
+    expect(got.ok).toBe(true);
+    expect(got.messages).toEqual([REAL_BASELINE_COMMIT]);
+    const jqArg = calls[0]![calls[0]!.length - 1]!;
+    expect(jqArg).toContain(".commits[]");
+    expect(jqArg).not.toContain("behind_by");
+    expect(calls[0]!.join(" ")).toContain("compare/deadbeef...main");
+  });
+
+  it("returns a multi-line message intact so a body-borne marker still matches", () => {
+    const multiline = "chore: regen\n\nnothing testable changed\n[ci skip]";
+    const fakeGh = () => ({ ok: true, stdout: JSON.stringify([multiline]), stderr: "" });
+    const got = divergenceCommitMessages("deadbeef", "loopdive/js2", fakeGh);
+    expect(got.messages).toEqual([multiline]);
+    expect(isSkipCiOnlyDivergence(got.messages!)).toBe(true);
+  });
+
+  it("FAILS CLOSED when the compare call fails or is unparseable", () => {
+    const failing = () => ({ ok: false, stdout: "", stderr: "boom" });
+    expect(divergenceCommitMessages("deadbeef", "loopdive/js2", failing).ok).toBe(false);
+    const garbage = () => ({ ok: true, stdout: "not json", stderr: "" });
+    expect(divergenceCommitMessages("deadbeef", "loopdive/js2", garbage).ok).toBe(false);
+    const wrongShape = () => ({ ok: true, stdout: JSON.stringify({ commits: 1 }), stderr: "" });
+    expect(divergenceCommitMessages("deadbeef", "loopdive/js2", wrongShape).ok).toBe(false);
+    expect(divergenceCommitMessages("", "loopdive/js2", failing).ok).toBe(false);
+  });
+});

--- a/tests/issue-4094-skipci-enqueue-exemption.test.ts
+++ b/tests/issue-4094-skipci-enqueue-exemption.test.ts
@@ -18,6 +18,8 @@ import {
   classifyChecks,
   requiredCheckNames,
   REQUIRED_CHECK_FALLBACK,
+  authoritativeHeadSha,
+  reconcileHeadSha,
 } from "../scripts/enqueue-green-prs.mjs";
 
 // The real baseline commit that made PR #4002 BEHIND on 2026-08-02 — the exact
@@ -149,6 +151,22 @@ describe("#4094 classifyChecks — required contexts from real check rows", () =
     expect(got.missingRequired).toContain("cla-check");
   });
 
+  // The reason string must report the OBSERVATION and the discriminator, never a
+  // diagnosis. Two mechanisms produce an absent context with OPPOSITE remedies:
+  // a dropped `synchronize` delivery (push any commit — what actually happened to
+  // #4028 on 2026-08-02) vs a workflow-level `paths:` skip (fix path filters).
+  // Asserting the unrecoverable one would send someone editing path filters to
+  // chase a GitHub delivery failure.
+  it("names the missing contexts and the discriminator, and claims NO cause", () => {
+    const rows = allGreenRows().filter((r) => r.name !== "quality");
+    const reason = classifyChecks(rows, REQUIRED).reason;
+    expect(reason).toContain("quality"); // says WHICH context is absent
+    expect(reason).toContain("earlier head"); // gives the discriminator
+    expect(reason).toContain("dropped synchronize"); // names the RECOVERABLE case
+    // Must not assert the unrecoverable framing.
+    expect(reason).not.toMatch(/never be satisfied|permanently|unrecoverable|stranded/i);
+  });
+
   it("FAILS CLOSED on no visible checks", () => {
     expect(classifyChecks([], REQUIRED).green).toBe(false);
     expect(classifyChecks(null as unknown as [], REQUIRED).green).toBe(false);
@@ -195,6 +213,58 @@ describe("#4094 enqueueEligibility — real signals only", () => {
     expect(enqueueEligibility({ ...base, mergeable: "CONFLICTING" }).eligible).toBe(false);
     expect(enqueueEligibility({ ...base, mergeable: "UNKNOWN" }).eligible).toBe(false);
     expect(enqueueEligibility({ ...base, mergeable: undefined }).eligible).toBe(false);
+  });
+});
+
+describe("#4094 head SHA is sourced from REST, never the cached PR view", () => {
+  const A = "a".repeat(40);
+  const B = "b".repeat(40);
+
+  it("reads .head.sha from the REST pull resource", () => {
+    const calls: string[][] = [];
+    const fake = (args: string[]) => {
+      calls.push(args);
+      return { ok: true, stdout: `${A}\n`, stderr: "" };
+    };
+    const got = authoritativeHeadSha(4038, "loopdive/js2", fake);
+    expect(got).toEqual({ ok: true, sha: A, reason: "rest" });
+    expect(calls[0]!.join(" ")).toContain("repos/loopdive/js2/pulls/4038");
+    expect(calls[0]!.join(" ")).toContain(".head.sha");
+  });
+
+  // Measured 2026-08-02 on #4028: `gh pr view --json headRefOid` served d07a989e
+  // while REST already had e24f4378. Check runs for the stale SHA are all real —
+  // green, complete, for the WRONG commit — so the verdict is confidently wrong
+  // with no anomaly anywhere. Disagreement must skip, not pick a winner.
+  it("PREFERS REST and SKIPS when the cached view disagrees", () => {
+    const rest = { ok: true as const, sha: B, reason: "rest" };
+    const got = reconcileHeadSha(A, rest);
+    expect(got.ok).toBe(false);
+    expect(got.reason).toContain("head-sha-stale");
+    expect(got.sha).toBe(B); // reports the authoritative one for the log
+  });
+
+  it("agrees when the two match", () => {
+    expect(reconcileHeadSha(A, { ok: true, sha: A, reason: "rest" })).toEqual({
+      ok: true,
+      sha: A,
+      reason: "head-sha-agreed",
+    });
+  });
+
+  // Falling back to the cached value on a REST failure would reinstate the bug.
+  it("FAILS CLOSED when REST is unreadable — never falls back to the cached SHA", () => {
+    const failing = () => ({ ok: false, stdout: "", stderr: "boom" });
+    const rest = authoritativeHeadSha(4038, "loopdive/js2", failing);
+    expect(rest.ok).toBe(false);
+    const got = reconcileHeadSha(A, rest);
+    expect(got.ok).toBe(false);
+    expect(got.sha).toBeNull();
+  });
+
+  it("rejects a non-SHA REST response rather than trusting it", () => {
+    const garbage = () => ({ ok: true, stdout: "not-a-sha", stderr: "" });
+    expect(authoritativeHeadSha(4038, "loopdive/js2", garbage).ok).toBe(false);
   });
 });
 


### PR DESCRIPTION
Re-scope per stakeholder decision #2 (2026-08-02). The original scope — exempt PRs behind ONLY by `[skip ci]` commits — rested on a premise measurement did not support, so it went back to the stakeholder rather than shipping.

## What measurement showed

`mergeStateStatus` does not track ancestry. Observed live, same minute:

| PR | `mergeStateStatus` | commits behind main |
|---|---|---|
| #4033 | **CLEAN** | **4** |
| #4034 | **UNSTABLE** | **0** |
| #4002 | CLEAN | 1 |

and #4028 read `BEHIND` then `UNSTABLE` minutes apart with no push. The ruleset has `strict_required_status_checks_policy: true`, so a behind PR *should* report `BEHIND` — it doesn't, because the field is a **stale sample**. Enqueue outcome therefore depended on when the sweep happened to look.

Behind-ness is also not disqualifying in fact: **#4002 (1 behind) and #4033 (4 behind) were both queued by this very workflow**, and #4002 merged with a green `merge_group` re-validation. That settles the original STEP 0 — "can the queue hold a behind PR" — **by observation, with no mutation performed**.

## The change

Eligibility comes from signals that mean what they say:

- **required checks** → checks API, using the ruleset's *own* context names read at runtime (`linear-tests` was documented as required for months and never was, #3934 — the static list is only a fallback)
- **conflicting-ness** → `mergeable`
- **behind-ness** → does **not** disqualify

`mergeStateStatus` is not a parameter of the decision function, so it cannot be consulted even by accident.

## What had to survive

The `UNSTABLE` exclusion existed because a red **non-required** check must never reach the queue (#3878/#3904). Dropping the status string would have silently dropped that guard, so it is re-expressed directly and more strongly: **zero checks of any kind may have a failing conclusion**, required or not. Pinned by its own negative-control test.

Two further gaps the old gate had:

- **"nothing failed and nothing pending" is not "the required checks ran."** Required contexts must now be *present*. This is live: **#4028 has only 3 check runs**, so 5 of 6 required contexts have no check run at all — the new gate reports `missing-required:5` where the old one said an opaque `BEHIND`.
- **A check name is not an identifier.** `merge shard reports` and `check for test262 regressions` are each published twice (real job + #3934 stub); on #4002 one instance read `pass` and the other `skipping`. Every instance of a required name is considered, so a first-match read cannot settle on the stub.

`freshEnqueueGuard` was re-reading the same stale field, turning the freshness re-check into a second coin flip; it now checks `mergeable` only. Its self-check assertion that `BEHIND` must be **rejected** is deliberately **inverted, not relaxed** — a test pinning that bail would have defended the defect.

## Mutation-refusal residual — handled by design, not blocked on

Whether GitHub ever refuses `enqueuePullRequest` for a behind PR is answered **in production**: the raw error is captured verbatim as its own telemetry class and the sweep degrades to skip. A refusal costs one sweep instead of a stranding. Per-enqueue behindness is also logged, which is the evidence base for whether admitting behind PRs stays routine.

## Scope

**Eligibility only — no branch updates.** `ALLOW_UPDATE_BRANCH` is untouched (the 2026-06-11 incident was *bot-updated branches*, a different mechanism). Drafts, hold labels and the author-trust gate are unchanged.

## Verification

- 28 unit tests: positive control (green + behind ⇒ eligible) and **both** negative controls (one red *required* check excluded; one red *non-required* check excluded).
- Script self-check passes; the 5 existing enqueue suites still pass (74 tests).
- `--dry-run` against live open PRs reads its required list from the ruleset (`source: ruleset`) and classifies every open PR.

## Note for the reviewer

The issue file `plan/issues/4094-*.md` lives on PR #4028's branch, not `main`, so this PR deliberately does **not** add its own copy (that would be a guaranteed merge-queue id collision). The `status: done` flip should follow once #4028 lands — and #4028 is itself currently stranded on the `missing-required:5` condition this PR diagnoses.

## Evidence status — what is observed vs. established

The queue-behaviour claim rests on **two observed PRs** (#4002 at 1 commit behind, #4033 at 4 behind, both queued by this workflow; #4002 merged with a green `merge_group` re-validation). That is enough to refute "behind PRs cannot be queued" — a single counterexample does that — but it is **not a systematic sample**, and it does not establish a rate.

The per-enqueue behindness telemetry added here is the instrument that converts the observation into established behaviour: it records, for every enqueue, how far behind main the PR was and whether that divergence was skip-CI-only. Until that log has accumulated, "admitting behind PRs is routine" should be read as a well-supported expectation rather than a measured fact.

The same applies to the mutation-refusal question: no refusal has been observed, but none has been *sought* either — no mutation was performed to test it. The verbatim refusal telemetry is what will answer it, in production, at the cost of one sweep rather than a stranding.

## Branch-base correction

The first push of this PR was mis-based: it branched from `origin/main`, and in this checkout `origin` is the **fork**, whose `main` has diverged from upstream (`git merge-base --is-ancestor` says no). That silently bundled 16 unrelated fork-side files into the diff and drove the PR `DIRTY`. Rebuilt on `upstream/main` and force-pushed; the diff is now the intended **2 files**. Recorded here because the PR's own history shows the force-push, and the reason should not have to be guessed.
