### PR TITLE
feat(ir): define fail-closed async suspension plan

### DIFF
--- a/plan/issues/1373b-ir-async-cps-lowering.md
+++ b/plan/issues/1373b-ir-async-cps-lowering.md
@@ -4,7 +4,7 @@ title: "IR async Phase C: CPS lowering for await + async-return + async-throw"
 status: in-progress
 assignee: ttraenkler/fable-4
 created: 2026-05-09
-updated: 2026-07-18
+updated: 2026-08-02
 priority: top
 feasibility: hard
 model: fable
@@ -24,11 +24,45 @@ loc-budget-allow:
   - src/ir/select.ts
   - src/ir/from-ast.ts
   - src/ir/builder.ts
+  - src/ir/async-plan.ts
+  - src/ir/index.ts
   - src/ir/integration.ts
   - src/codegen/index.ts
   - src/codegen/context/types.ts
+  - tests/ir/issue-1373b-async-plan.test.ts
 ---
 # #1373b — IR async Phase C: CPS lowering
+
+## Update — AST-free plan/Promise ABI foundation (2026-08-02)
+
+The strict R0 production ledger was re-measured on `origin/main` at
+`b310b3b3c5e`: 5/5 playground entries produced 37 terminal units, 33 IR
+bodies, 35 legacy bodies, and exactly four typed async blockers in
+`website/playground/examples/js/async.ts`:
+
+- `fetchAllParallel` — `select/body-shape-rejected`;
+- `fetchAllSequential` — `select/call-graph-closure`;
+- `fetchUser` and `main` — `select/async-function`.
+
+These are three distinct production populations, so widening or relabeling a
+selector cannot safely close them. This bounded foundation adds
+`src/ir/async-plan.ts`: one immutable, target-neutral `IrAsyncPlan` contract
+with canonical Promise-only ABI, semantic Promise/scheduler intents, explicit
+suspend/resume/rejection-handler edges, typed frame spills, deterministic
+serialization/content hashing, and a fail-closed graph/liveness/purity
+verifier. It rejects AST/checker/codegen callbacks, raw Wasm, target/backend
+selection, concrete Wasm indices, raw-value-or-Promise ABI, bad edges, and
+under/over-reported suspension liveness.
+
+This slice intentionally changes no selector, async activation, planner,
+frame, scheduler, import manifest, or production route. Anti-vacuity tests pin
+the exact four typed outcomes and execute the existing two-suspension frame
+engine, while hand-built plan tests cover two suspends, a branch/back-edge,
+handler routing, exact liveness, target-independent hashes, and malformed-plan
+negative controls. The next critical-path slice is to produce this plan from a
+Prepared async free-function unit and adapt the existing frame engine to
+consume it; it must not build a second suspension engine or revive C-1's
+consumer-sensitive raw-`T` ABI.
 
 ## Implementation Plan (AUTHORITATIVE — re-grounded 2026-07-18, fable-4, fable-final sprint)
 

--- a/src/ir/async-plan.ts
+++ b/src/ir/async-plan.ts
@@ -1,0 +1,795 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Backend-neutral async suspension plan.
+ *
+ * This is the preparation boundary needed by #1042/#1373b: source analysis
+ * produces one immutable state graph and every async backend consumes that
+ * graph. The contract deliberately contains only structural IR identities,
+ * IR values/types/instructions, and semantic Promise/scheduler intents. It has
+ * no TypeScript AST, checker, codegen context, callbacks, target selection, or
+ * concrete Wasm indices.
+ *
+ * This slice defines and verifies the contract only. Production routing stays
+ * unchanged until a later slice teaches the existing async frame engine to
+ * consume an IrAsyncPlan.
+ */
+
+import type { IrUnitId } from "./identity.js";
+import { collectUses, forEachInstrDeep, irTypeEquals, type IrInstr, type IrType, type IrValueId } from "./nodes.js";
+
+export type IrAsyncStateId = number & { readonly __brand: "IrAsyncStateId" };
+export type IrAsyncHandlerId = number & { readonly __brand: "IrAsyncHandlerId" };
+
+export function asAsyncStateId(value: number): IrAsyncStateId {
+  return value as IrAsyncStateId;
+}
+
+export function asAsyncHandlerId(value: number): IrAsyncHandlerId {
+  return value as IrAsyncHandlerId;
+}
+
+/** One ABI for every prepared async function: callers always receive a Promise. */
+export interface IrCanonicalPromiseAbi {
+  readonly kind: "canonical-promise";
+  readonly version: 1;
+  readonly fulfillmentType: IrType | null;
+  readonly rejectionType: "dynamic";
+  readonly consumerContract: "promise-only";
+  readonly settlementTiming: "always-async";
+}
+
+export function canonicalPromiseAbi(fulfillmentType: IrType | null): IrCanonicalPromiseAbi {
+  return Object.freeze({
+    kind: "canonical-promise",
+    version: 1,
+    fulfillmentType,
+    rejectionType: "dynamic",
+    consumerContract: "promise-only",
+    settlementTiming: "always-async",
+  });
+}
+
+/** Semantic requirements. A backend selects providers only after preparation. */
+export type IrAsyncRuntimeIntent =
+  | "promise.capability.create"
+  | "promise.resolve"
+  | "promise.react"
+  | "promise.settle.fulfill"
+  | "promise.settle.reject"
+  | "scheduler.enqueue"
+  | "scheduler.drain";
+
+export interface IrAsyncPlanValue {
+  readonly value: IrValueId;
+  readonly type: IrType;
+}
+
+export type IrAsyncSpillStorage = "ssa" | "slot" | "ref-cell" | "receiver";
+
+/**
+ * One typed frame entry. The value identity is semantic; a backend chooses the
+ * concrete field/local representation after the whole program ABI is sealed.
+ */
+export interface IrAsyncSpill {
+  readonly value: IrValueId;
+  readonly type: IrType;
+  readonly storage: IrAsyncSpillStorage;
+}
+
+export interface IrAsyncResumeValue {
+  /** Successor-defined result of the preceding fulfillment/rejection edge. */
+  readonly value: IrValueId;
+  readonly type: IrType;
+  readonly source: "fulfilled" | "rejected";
+}
+
+export interface IrAsyncState {
+  readonly id: IrAsyncStateId;
+  /** At most one scheduler-delivered value is bound when this state begins. */
+  readonly resume?: IrAsyncResumeValue;
+  readonly body: readonly IrInstr[];
+  readonly terminator: IrAsyncTerminator;
+}
+
+export interface IrAsyncHandler {
+  readonly id: IrAsyncHandlerId;
+  readonly kind: "catch";
+  readonly entry: IrAsyncStateId;
+  readonly parent: IrAsyncHandlerId | null;
+}
+
+export interface IrAsyncSuspendTerminator {
+  readonly kind: "suspend";
+  readonly awaited: IrValueId;
+  readonly resume: {
+    readonly state: IrAsyncStateId;
+    /** Must be the target state's fulfilled resume value. */
+    readonly value: IrValueId;
+  };
+  readonly rejected: { readonly kind: "handler"; readonly handler: IrAsyncHandlerId } | { readonly kind: "reject" };
+  /** Exact values that must survive while the activation is suspended. */
+  readonly live: readonly IrValueId[];
+}
+
+export interface IrAsyncGotoTerminator {
+  readonly kind: "goto";
+  readonly target: IrAsyncStateId;
+}
+
+export interface IrAsyncBranchTerminator {
+  readonly kind: "branch";
+  readonly condition: IrValueId;
+  readonly ifTrue: IrAsyncStateId;
+  readonly ifFalse: IrAsyncStateId;
+}
+
+export interface IrAsyncResolveTerminator {
+  readonly kind: "resolve";
+  /** Absent for Promise<void>. */
+  readonly value?: IrValueId;
+}
+
+export interface IrAsyncRejectTerminator {
+  readonly kind: "reject";
+  readonly reason: IrValueId;
+}
+
+export interface IrAsyncCompleteTerminator {
+  readonly kind: "complete";
+}
+
+export type IrAsyncTerminator =
+  | IrAsyncSuspendTerminator
+  | IrAsyncGotoTerminator
+  | IrAsyncBranchTerminator
+  | IrAsyncResolveTerminator
+  | IrAsyncRejectTerminator
+  | IrAsyncCompleteTerminator;
+
+export interface IrAsyncPlan {
+  readonly schemaVersion: 1;
+  readonly ownerUnitId: IrUnitId;
+  readonly kind: "async-function";
+  readonly abi: IrCanonicalPromiseAbi;
+  readonly entry: IrAsyncStateId;
+  readonly params: readonly IrAsyncPlanValue[];
+  /** Exhaustive value/type table, including params, resumes, and body defs. */
+  readonly values: readonly IrAsyncPlanValue[];
+  readonly spills: readonly IrAsyncSpill[];
+  readonly states: readonly IrAsyncState[];
+  readonly handlers: readonly IrAsyncHandler[];
+  readonly runtimeIntents: readonly IrAsyncRuntimeIntent[];
+}
+
+export type IrAsyncPlanInvariantCode =
+  | "forbidden-data"
+  | "invalid-owner"
+  | "invalid-abi"
+  | "duplicate-value"
+  | "unknown-value"
+  | "value-type-mismatch"
+  | "missing-value-definition"
+  | "duplicate-value-definition"
+  | "duplicate-spill"
+  | "missing-spill"
+  | "unused-spill"
+  | "duplicate-state"
+  | "unknown-state"
+  | "unreachable-state"
+  | "invalid-resume"
+  | "unlowered-async-control"
+  | "duplicate-handler"
+  | "unknown-handler"
+  | "handler-cycle"
+  | "invalid-handler"
+  | "duplicate-runtime-intent"
+  | "missing-runtime-intent"
+  | "liveness-mismatch";
+
+export interface IrAsyncPlanVerifyError {
+  readonly code: IrAsyncPlanInvariantCode;
+  readonly message: string;
+  readonly path?: string;
+  readonly state?: IrAsyncStateId;
+}
+
+export class IrAsyncPlanInvariantError extends Error {
+  constructor(readonly errors: readonly IrAsyncPlanVerifyError[]) {
+    super(errors.map((error) => `${error.code}: ${error.message}`).join("\n"));
+    this.name = "IrAsyncPlanInvariantError";
+  }
+}
+
+interface StateLiveness {
+  readonly defs: ReadonlySet<IrValueId>;
+  readonly usesBeforeDef: ReadonlySet<IrValueId>;
+}
+
+interface StateEdge {
+  readonly target: IrAsyncStateId;
+  /** Value materialized by this edge and therefore not spilled by its source. */
+  readonly boundValue?: IrValueId;
+}
+
+const runtimeIntentOrder: readonly IrAsyncRuntimeIntent[] = [
+  "promise.capability.create",
+  "promise.resolve",
+  "promise.react",
+  "promise.settle.fulfill",
+  "promise.settle.reject",
+  "scheduler.enqueue",
+  "scheduler.drain",
+];
+
+const runtimeIntentRank = new Map(runtimeIntentOrder.map((intent, index) => [intent, index] as const));
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function compareNumber(a: number, b: number): number {
+  return a - b;
+}
+
+function sameValueSet(left: ReadonlySet<IrValueId>, right: ReadonlySet<IrValueId>): boolean {
+  if (left.size !== right.size) return false;
+  for (const value of left) if (!right.has(value)) return false;
+  return true;
+}
+
+function describeValues(values: ReadonlySet<IrValueId>): string {
+  return `[${[...values].map(Number).sort(compareNumber).join(", ")}]`;
+}
+
+function terminatorUses(terminator: IrAsyncTerminator): readonly IrValueId[] {
+  switch (terminator.kind) {
+    case "suspend":
+      return [terminator.awaited];
+    case "branch":
+      return [terminator.condition];
+    case "resolve":
+      return terminator.value === undefined ? [] : [terminator.value];
+    case "reject":
+      return [terminator.reason];
+    case "goto":
+    case "complete":
+      return [];
+  }
+}
+
+function stateEdges(
+  state: IrAsyncState,
+  handlers: ReadonlyMap<IrAsyncHandlerId, IrAsyncHandler>,
+): readonly StateEdge[] {
+  const terminator = state.terminator;
+  switch (terminator.kind) {
+    case "goto":
+      return [{ target: terminator.target }];
+    case "branch":
+      return [{ target: terminator.ifTrue }, { target: terminator.ifFalse }];
+    case "suspend": {
+      const edges: StateEdge[] = [{ target: terminator.resume.state, boundValue: terminator.resume.value }];
+      if (terminator.rejected.kind === "handler") {
+        const handler = handlers.get(terminator.rejected.handler);
+        if (handler) edges.push({ target: handler.entry });
+      }
+      return edges;
+    }
+    case "resolve":
+    case "reject":
+    case "complete":
+      return [];
+  }
+}
+
+function stateLiveness(state: IrAsyncState, isEntry: boolean, params: readonly IrAsyncPlanValue[]): StateLiveness {
+  const defs = new Set<IrValueId>();
+  if (isEntry) for (const param of params) defs.add(param.value);
+  if (state.resume) defs.add(state.resume.value);
+  for (const instr of state.body) {
+    forEachInstrDeep(instr, (nested) => {
+      if (nested.result !== null) defs.add(nested.result);
+    });
+  }
+  const usesBeforeDef = new Set<IrValueId>();
+  for (const instr of state.body) {
+    for (const value of collectUses(instr, { deep: true })) {
+      if (!defs.has(value)) usesBeforeDef.add(value);
+    }
+  }
+  for (const value of terminatorUses(state.terminator)) {
+    if (!defs.has(value)) usesBeforeDef.add(value);
+  }
+  return { defs, usesBeforeDef };
+}
+
+function addPurityError(errors: IrAsyncPlanVerifyError[], path: string, message: string): void {
+  errors.push({ code: "forbidden-data", path, message });
+}
+
+function verifyPureData(value: unknown, errors: IrAsyncPlanVerifyError[]): void {
+  const active = new Set<object>();
+  const visit = (candidate: unknown, path: string): void => {
+    if (candidate === null || typeof candidate === "string" || typeof candidate === "boolean") return;
+    if (typeof candidate === "number") {
+      if (!Number.isFinite(candidate)) addPurityError(errors, path, "non-finite numbers are not canonical plan data");
+      return;
+    }
+    if (typeof candidate === "bigint") return;
+    if (candidate === undefined || typeof candidate === "function" || typeof candidate === "symbol") {
+      addPurityError(errors, path, `contains non-data value ${typeof candidate}`);
+      return;
+    }
+    if (typeof candidate !== "object") {
+      addPurityError(errors, path, `contains unsupported ${typeof candidate}`);
+      return;
+    }
+    if (active.has(candidate)) {
+      addPurityError(errors, path, "contains a cycle");
+      return;
+    }
+    active.add(candidate);
+    if (Array.isArray(candidate)) {
+      for (let index = 0; index < candidate.length; index++) visit(candidate[index], `${path}[${index}]`);
+      active.delete(candidate);
+      return;
+    }
+    const prototype = Object.getPrototypeOf(candidate);
+    if (prototype !== Object.prototype && prototype !== null) {
+      addPurityError(errors, path, `contains mutable/non-IR ${prototype?.constructor?.name ?? "object"}`);
+      active.delete(candidate);
+      return;
+    }
+    const record = candidate as Record<string, unknown>;
+    if (record.kind === "raw.wasm") addPurityError(errors, path, "contains raw Wasm instructions");
+    if (typeof record.kind === "number" && typeof record.pos === "number" && typeof record.end === "number") {
+      addPurityError(errors, path, "contains a TypeScript AST node");
+    }
+    for (const key of Object.keys(record)) {
+      const childPath = `${path}.${key}`;
+      if (
+        key === "emit" ||
+        key === "postDeliverEmit" ||
+        key === "ctx" ||
+        key === "fctx" ||
+        key === "checker" ||
+        key === "declaration" ||
+        key === "sourceNode" ||
+        key === "backend" ||
+        key === "wasmType" ||
+        key === "valType" ||
+        /(?:func|type|global|local|field)(?:Idx|Index)$/i.test(key)
+      ) {
+        addPurityError(errors, childPath, `property ${key} crosses the async-plan boundary`);
+      }
+      if (
+        key === "target" &&
+        typeof record[key] === "string" &&
+        ["gc", "standalone", "wasi", "linear"].includes(record[key])
+      ) {
+        addPurityError(errors, childPath, "target selection belongs to backend lowering");
+      }
+      visit(record[key], childPath);
+    }
+    active.delete(candidate);
+  };
+  visit(value, "$plan");
+}
+
+function addError(
+  errors: IrAsyncPlanVerifyError[],
+  code: IrAsyncPlanInvariantCode,
+  message: string,
+  state?: IrAsyncStateId,
+): void {
+  errors.push({ code, message, ...(state === undefined ? {} : { state }) });
+}
+
+function verifyCanonicalPromiseAbi(plan: IrAsyncPlan, errors: IrAsyncPlanVerifyError[]): void {
+  const abi = plan.abi;
+  if (
+    abi.kind !== "canonical-promise" ||
+    abi.version !== 1 ||
+    abi.rejectionType !== "dynamic" ||
+    abi.consumerContract !== "promise-only" ||
+    abi.settlementTiming !== "always-async"
+  ) {
+    addError(
+      errors,
+      "invalid-abi",
+      "async functions must expose canonical Promise ABI v1 with always-async settlement",
+    );
+  }
+}
+
+function requiredRuntimeIntents(plan: IrAsyncPlan): ReadonlySet<IrAsyncRuntimeIntent> {
+  const required = new Set<IrAsyncRuntimeIntent>(["promise.capability.create"]);
+  for (const state of plan.states) {
+    switch (state.terminator.kind) {
+      case "suspend":
+        required.add("promise.resolve");
+        required.add("promise.react");
+        required.add("scheduler.enqueue");
+        required.add("scheduler.drain");
+        if (state.terminator.rejected.kind === "reject") required.add("promise.settle.reject");
+        break;
+      case "resolve":
+        required.add("promise.settle.fulfill");
+        break;
+      case "reject":
+        required.add("promise.settle.reject");
+        break;
+      case "goto":
+      case "branch":
+      case "complete":
+        break;
+    }
+  }
+  return required;
+}
+
+/**
+ * Verify the complete plan graph. Unknown/malformed data is always an
+ * invariant; there is no fallback policy at this boundary.
+ */
+export function verifyIrAsyncPlan(plan: IrAsyncPlan): readonly IrAsyncPlanVerifyError[] {
+  const errors: IrAsyncPlanVerifyError[] = [];
+  verifyPureData(plan, errors);
+  if (plan.schemaVersion !== 1 || plan.kind !== "async-function") {
+    addError(errors, "invalid-abi", "unsupported async-plan schema or callable kind");
+  }
+  if (typeof plan.ownerUnitId !== "string" || !plan.ownerUnitId.startsWith("ir-unit:v1:")) {
+    addError(errors, "invalid-owner", "ownerUnitId must be a structural IrUnitId");
+  }
+  verifyCanonicalPromiseAbi(plan, errors);
+
+  const values = new Map<IrValueId, IrType>();
+  for (const entry of plan.values) {
+    if (values.has(entry.value)) addError(errors, "duplicate-value", `value ${entry.value} is declared more than once`);
+    else values.set(entry.value, entry.type);
+  }
+  const definitions = new Map<IrValueId, string>();
+  const define = (value: IrValueId, owner: string): void => {
+    const previous = definitions.get(value);
+    if (previous) {
+      addError(errors, "duplicate-value-definition", `value ${value} is defined by ${previous} and ${owner}`);
+    } else {
+      definitions.set(value, owner);
+    }
+  };
+  const checkValue = (value: IrValueId, owner: string, state?: IrAsyncStateId): IrType | undefined => {
+    const type = values.get(value);
+    if (!type) addError(errors, "unknown-value", `${owner} references undeclared value ${value}`, state);
+    return type;
+  };
+  for (const param of plan.params) {
+    const type = checkValue(param.value, "parameter");
+    if (type && !irTypeEquals(type, param.type)) {
+      addError(errors, "value-type-mismatch", `parameter ${param.value} type does not match the value table`);
+    }
+    define(param.value, "parameter");
+  }
+
+  const handlers = new Map<IrAsyncHandlerId, IrAsyncHandler>();
+  for (const handler of plan.handlers) {
+    if (!isNonNegativeSafeInteger(handler.id)) {
+      addError(errors, "unknown-handler", `handler id ${handler.id} is invalid`);
+    }
+    if (handlers.has(handler.id))
+      addError(errors, "duplicate-handler", `handler ${handler.id} is declared more than once`);
+    else handlers.set(handler.id, handler);
+  }
+  const states = new Map<IrAsyncStateId, IrAsyncState>();
+  for (const state of plan.states) {
+    if (!isNonNegativeSafeInteger(state.id)) addError(errors, "unknown-state", `state id ${state.id} is invalid`);
+    if (states.has(state.id)) addError(errors, "duplicate-state", `state ${state.id} is declared more than once`);
+    else states.set(state.id, state);
+  }
+  if (!states.has(plan.entry)) addError(errors, "unknown-state", `entry state ${plan.entry} is not declared`);
+  if (states.get(plan.entry)?.resume) {
+    addError(errors, "invalid-resume", `entry state ${plan.entry} cannot bind a resume value`, plan.entry);
+  }
+
+  for (const state of plan.states) {
+    if (state.resume) {
+      const type = checkValue(state.resume.value, `state ${state.id} resume`, state.id);
+      if (type && !irTypeEquals(type, state.resume.type)) {
+        addError(
+          errors,
+          "value-type-mismatch",
+          `state ${state.id} resume type does not match value ${state.resume.value}`,
+          state.id,
+        );
+      }
+      define(state.resume.value, `state ${state.id} resume`);
+    }
+    for (const instr of state.body) {
+      for (const use of collectUses(instr, { deep: true })) checkValue(use, `state ${state.id} body`, state.id);
+      forEachInstrDeep(instr, (nested) => {
+        if (nested.kind === "await" || nested.kind === "async.return" || nested.kind === "async.throw") {
+          addError(
+            errors,
+            "unlowered-async-control",
+            `state ${state.id} contains ${nested.kind}; async control must be represented by a plan terminator`,
+            state.id,
+          );
+        }
+        if (nested.result === null) return;
+        const type = checkValue(nested.result, `state ${state.id} result`, state.id);
+        if (type && nested.resultType && !irTypeEquals(type, nested.resultType)) {
+          addError(
+            errors,
+            "value-type-mismatch",
+            `state ${state.id} result ${nested.result} type does not match the value table`,
+            state.id,
+          );
+        }
+        define(nested.result, `state ${state.id} body`);
+      });
+    }
+    for (const use of terminatorUses(state.terminator)) checkValue(use, `state ${state.id} terminator`, state.id);
+    const terminator = state.terminator;
+    if (terminator.kind === "suspend") {
+      checkValue(terminator.resume.value, `state ${state.id} resume edge`, state.id);
+      const target = states.get(terminator.resume.state);
+      if (!target) {
+        addError(
+          errors,
+          "unknown-state",
+          `state ${state.id} resumes at unknown state ${terminator.resume.state}`,
+          state.id,
+        );
+      } else if (target.resume?.value !== terminator.resume.value || target.resume.source !== "fulfilled") {
+        addError(
+          errors,
+          "invalid-resume",
+          `state ${state.id} resume edge does not match state ${target.id}'s resume binding`,
+          state.id,
+        );
+      }
+    }
+    if (terminator.kind === "suspend" && terminator.rejected.kind === "handler") {
+      if (!handlers.has(terminator.rejected.handler)) {
+        addError(
+          errors,
+          "unknown-handler",
+          `state ${state.id} rejects to unknown handler ${terminator.rejected.handler}`,
+          state.id,
+        );
+      }
+    }
+    if (terminator.kind === "resolve") {
+      const fulfillmentType = plan.abi.fulfillmentType;
+      if (terminator.value === undefined ? fulfillmentType !== null : fulfillmentType === null) {
+        addError(
+          errors,
+          "value-type-mismatch",
+          `state ${state.id} resolve arity does not match its Promise ABI`,
+          state.id,
+        );
+      } else if (terminator.value !== undefined && fulfillmentType !== null) {
+        const valueType = values.get(terminator.value);
+        if (valueType && !irTypeEquals(valueType, fulfillmentType)) {
+          addError(
+            errors,
+            "value-type-mismatch",
+            `state ${state.id} resolve type does not match its Promise ABI`,
+            state.id,
+          );
+        }
+      }
+    }
+    for (const edge of stateEdges(state, handlers)) {
+      if (!states.has(edge.target)) {
+        addError(errors, "unknown-state", `state ${state.id} targets unknown state ${edge.target}`, state.id);
+      }
+    }
+  }
+
+  for (const value of values.keys()) {
+    if (!definitions.has(value)) {
+      addError(
+        errors,
+        "missing-value-definition",
+        `value ${value} has no parameter, resume, or instruction definition`,
+      );
+    }
+  }
+
+  for (const handler of plan.handlers) {
+    const state = states.get(handler.entry);
+    if (!state) {
+      addError(errors, "unknown-state", `handler ${handler.id} targets unknown state ${handler.entry}`);
+    } else if (state.resume?.source !== "rejected") {
+      addError(errors, "invalid-handler", `catch handler ${handler.id} must enter a rejected-value state`);
+    }
+    if (handler.parent !== null && !handlers.has(handler.parent)) {
+      addError(errors, "unknown-handler", `handler ${handler.id} has unknown parent ${handler.parent}`);
+    }
+    const visited = new Set<IrAsyncHandlerId>();
+    let cursor: IrAsyncHandler | undefined = handler;
+    while (cursor && cursor.parent !== null) {
+      if (visited.has(cursor.id)) {
+        addError(errors, "handler-cycle", `handler ${handler.id} participates in a parent cycle`);
+        break;
+      }
+      visited.add(cursor.id);
+      cursor = handlers.get(cursor.parent);
+    }
+  }
+
+  const spillByValue = new Map<IrValueId, IrAsyncSpill>();
+  for (const spill of plan.spills) {
+    if (spillByValue.has(spill.value))
+      addError(errors, "duplicate-spill", `value ${spill.value} has duplicate spill entries`);
+    else spillByValue.set(spill.value, spill);
+    const type = checkValue(spill.value, "spill");
+    if (type && !irTypeEquals(type, spill.type)) {
+      addError(errors, "value-type-mismatch", `spill ${spill.value} type does not match the value table`);
+    }
+  }
+
+  const livenessByState = new Map<IrAsyncStateId, StateLiveness>();
+  for (const state of plan.states) {
+    livenessByState.set(state.id, stateLiveness(state, state.id === plan.entry, plan.params));
+  }
+  const liveIn = new Map<IrAsyncStateId, Set<IrValueId>>();
+  for (const state of plan.states) liveIn.set(state.id, new Set(livenessByState.get(state.id)!.usesBeforeDef));
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let index = plan.states.length - 1; index >= 0; index--) {
+      const state = plan.states[index]!;
+      const local = livenessByState.get(state.id)!;
+      const liveOut = new Set<IrValueId>();
+      for (const edge of stateEdges(state, handlers)) {
+        for (const value of liveIn.get(edge.target) ?? []) {
+          if (value !== edge.boundValue) liveOut.add(value);
+        }
+      }
+      const next = new Set(local.usesBeforeDef);
+      for (const value of liveOut) if (!local.defs.has(value)) next.add(value);
+      const current = liveIn.get(state.id)!;
+      if (!sameValueSet(next, current)) {
+        liveIn.set(state.id, next);
+        changed = true;
+      }
+    }
+  }
+
+  const requiredSpills = new Set<IrValueId>();
+  for (const state of plan.states) {
+    const terminator = state.terminator;
+    if (terminator.kind !== "suspend") continue;
+    const expected = new Set<IrValueId>();
+    for (const edge of stateEdges(state, handlers)) {
+      for (const value of liveIn.get(edge.target) ?? []) {
+        if (value !== edge.boundValue) expected.add(value);
+      }
+    }
+    const declared = new Set(terminator.live);
+    if (declared.size !== terminator.live.length) {
+      addError(errors, "liveness-mismatch", `state ${state.id} declares duplicate live values`, state.id);
+    }
+    for (const value of declared) checkValue(value, `state ${state.id} liveness`, state.id);
+    if (!sameValueSet(expected, declared)) {
+      addError(
+        errors,
+        "liveness-mismatch",
+        `state ${state.id} live set ${describeValues(declared)} must equal ${describeValues(expected)}`,
+        state.id,
+      );
+    }
+    for (const value of expected) requiredSpills.add(value);
+  }
+  for (const value of requiredSpills) {
+    if (!spillByValue.has(value)) addError(errors, "missing-spill", `live value ${value} has no frame spill`);
+  }
+  for (const value of spillByValue.keys()) {
+    if (!requiredSpills.has(value))
+      addError(errors, "unused-spill", `spill value ${value} is never live across suspension`);
+  }
+
+  if (states.has(plan.entry)) {
+    const reachable = new Set<IrAsyncStateId>();
+    const work = [plan.entry];
+    while (work.length > 0) {
+      const stateId = work.pop()!;
+      if (reachable.has(stateId)) continue;
+      reachable.add(stateId);
+      const state = states.get(stateId);
+      if (!state) continue;
+      for (const edge of stateEdges(state, handlers)) work.push(edge.target);
+    }
+    for (const state of plan.states) {
+      if (!reachable.has(state.id)) addError(errors, "unreachable-state", `state ${state.id} is unreachable`, state.id);
+    }
+  }
+
+  const intents = new Set<IrAsyncRuntimeIntent>();
+  for (const intent of plan.runtimeIntents) {
+    if (intents.has(intent)) addError(errors, "duplicate-runtime-intent", `runtime intent ${intent} is duplicated`);
+    intents.add(intent);
+  }
+  for (const intent of requiredRuntimeIntents(plan)) {
+    if (!intents.has(intent)) addError(errors, "missing-runtime-intent", `runtime intent ${intent} is required`);
+  }
+  return Object.freeze(errors);
+}
+
+export function assertIrAsyncPlan(plan: IrAsyncPlan): void {
+  const errors = verifyIrAsyncPlan(plan);
+  if (errors.length > 0) throw new IrAsyncPlanInvariantError(errors);
+}
+
+function clonePlanData(value: unknown, ancestors = new Set<object>()): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (ancestors.has(value))
+    throw new IrAsyncPlanInvariantError([{ code: "forbidden-data", message: "plan contains a cycle" }]);
+  const next = new Set(ancestors).add(value);
+  if (Array.isArray(value)) return Object.freeze(value.map((item) => clonePlanData(item, next)));
+  const copy: Record<string, unknown> = Object.create(null);
+  for (const key of Object.keys(value).sort()) copy[key] = clonePlanData((value as Record<string, unknown>)[key], next);
+  return Object.freeze(copy);
+}
+
+function canonicalPlanInput(plan: IrAsyncPlan): IrAsyncPlan {
+  const states = [...plan.states]
+    .sort((left, right) => compareNumber(left.id, right.id))
+    .map((state) => ({
+      ...state,
+      ...(state.terminator.kind === "suspend"
+        ? { terminator: { ...state.terminator, live: [...state.terminator.live].sort(compareNumber) } }
+        : {}),
+    }));
+  return {
+    ...plan,
+    params: [...plan.params],
+    values: [...plan.values].sort((left, right) => compareNumber(left.value, right.value)),
+    spills: [...plan.spills].sort((left, right) => compareNumber(left.value, right.value)),
+    states,
+    handlers: [...plan.handlers].sort((left, right) => compareNumber(left.id, right.id)),
+    runtimeIntents: [...plan.runtimeIntents].sort(
+      (left, right) => (runtimeIntentRank.get(left) ?? Number.MAX_SAFE_INTEGER) - (runtimeIntentRank.get(right) ?? 0),
+    ),
+  };
+}
+
+/** Validate, canonicalize, copy, and deeply freeze one prepared plan. */
+export function createIrAsyncPlan(plan: IrAsyncPlan): IrAsyncPlan {
+  const canonical = canonicalPlanInput(plan);
+  assertIrAsyncPlan(canonical);
+  return clonePlanData(canonical) as IrAsyncPlan;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string" || typeof value === "boolean") return JSON.stringify(value);
+  if (typeof value === "bigint") return `{"$bigint":${JSON.stringify(value.toString(10))}}`;
+  if (typeof value === "number") {
+    if (Object.is(value, -0)) return `{"$number":"-0"}`;
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
+}
+
+/** Target-independent serialization used by readiness and differential gates. */
+export function serializeIrAsyncPlan(plan: IrAsyncPlan): string {
+  return canonicalJson(createIrAsyncPlan(plan));
+}
+
+/** Stable content fingerprint (FNV-1a-64; identity aid, not a security hash). */
+export function hashIrAsyncPlan(plan: IrAsyncPlan): string {
+  const bytes = new TextEncoder().encode(serializeIrAsyncPlan(plan));
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of bytes) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return `ir-async-plan:v1:${hash.toString(16).padStart(16, "0")}`;
+}

--- a/src/ir/index.ts
+++ b/src/ir/index.ts
@@ -4,6 +4,7 @@ export * from "./outcomes.js";
 export * from "./identity.js";
 export * from "./planning-identity.js";
 export * from "./program-abi.js";
+export * from "./async-plan.js";
 export * from "./nodes.js";
 export * from "./callable-bindings.js";
 export * from "./abi-bindings.js";

--- a/tests/ir/issue-1373b-async-plan.test.ts
+++ b/tests/ir/issue-1373b-async-plan.test.ts
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** #1042/#1373b — AST-free IrAsyncPlan and canonical Promise ABI. */
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../../src/index.js";
+import {
+  asAsyncHandlerId,
+  asAsyncStateId,
+  canonicalPromiseAbi,
+  createIrAsyncPlan,
+  hashIrAsyncPlan,
+  serializeIrAsyncPlan,
+  verifyIrAsyncPlan,
+  type IrAsyncPlan,
+} from "../../src/ir/async-plan.js";
+import { createIrBindingId, createIrSourceId, createIrUnitId } from "../../src/ir/identity.js";
+import { asValueId, irVal, type IrType } from "../../src/ir/nodes.js";
+import { evaluateIrOutcomePolicy } from "../../src/ir/outcomes.js";
+import { compileToWasm } from "../equivalence/helpers.js";
+
+const EXTERN: IrType = irVal({ kind: "externref" });
+const F64: IrType = irVal({ kind: "f64" });
+const I32: IrType = irVal({ kind: "i32" });
+
+function ownerUnitId() {
+  const sourceId = createIrSourceId({ kind: "entry", order: 0, sourceKey: "tests/async-plan.ts" });
+  return createIrUnitId({ sourceId, lexicalOwnerId: null, kind: "function-declaration", ordinal: 0 });
+}
+
+/**
+ * Two suspensions, a conditional loop back-edge, and a rejection handler.
+ * Values 1/2 are genuinely live across both suspension points.
+ */
+function makePlan(): IrAsyncPlan {
+  const owner = ownerUnitId();
+  const nextBinding = createIrBindingId({ ownerId: owner, domain: "support", role: "next-promise" });
+  const promise = asValueId(0);
+  const condition = asValueId(1);
+  const accumulator = asValueId(2);
+  const resumed = asValueId(3);
+  const sum = asValueId(4);
+  const nextPromise = asValueId(5);
+  const rejection = asValueId(6);
+  const entry = asAsyncStateId(0);
+  const loop = asAsyncStateId(1);
+  const suspendAgain = asAsyncStateId(2);
+  const done = asAsyncStateId(3);
+  const caught = asAsyncStateId(4);
+  const handler = asAsyncHandlerId(0);
+  return {
+    schemaVersion: 1,
+    ownerUnitId: owner,
+    kind: "async-function",
+    abi: canonicalPromiseAbi(F64),
+    entry,
+    params: [
+      { value: promise, type: EXTERN },
+      { value: condition, type: I32 },
+      { value: accumulator, type: F64 },
+    ],
+    values: [
+      { value: promise, type: EXTERN },
+      { value: condition, type: I32 },
+      { value: accumulator, type: F64 },
+      { value: resumed, type: F64 },
+      { value: sum, type: F64 },
+      { value: nextPromise, type: EXTERN },
+      { value: rejection, type: EXTERN },
+    ],
+    spills: [
+      { value: condition, type: I32, storage: "slot" },
+      { value: accumulator, type: F64, storage: "ref-cell" },
+    ],
+    states: [
+      {
+        id: entry,
+        body: [],
+        terminator: {
+          kind: "suspend",
+          awaited: promise,
+          resume: { state: loop, value: resumed },
+          rejected: { kind: "handler", handler },
+          live: [accumulator, condition],
+        },
+      },
+      {
+        id: loop,
+        resume: { value: resumed, type: F64, source: "fulfilled" },
+        body: [
+          {
+            kind: "binary",
+            op: "f64.add",
+            lhs: accumulator,
+            rhs: resumed,
+            result: sum,
+            resultType: F64,
+          },
+        ],
+        terminator: { kind: "branch", condition, ifTrue: suspendAgain, ifFalse: done },
+      },
+      {
+        id: suspendAgain,
+        body: [
+          {
+            kind: "call",
+            target: { kind: "func", name: "nextPromise", binding: { kind: "support", bindingId: nextBinding } },
+            args: [sum],
+            result: nextPromise,
+            resultType: EXTERN,
+          },
+        ],
+        terminator: {
+          kind: "suspend",
+          awaited: nextPromise,
+          resume: { state: loop, value: resumed },
+          rejected: { kind: "handler", handler },
+          live: [condition, accumulator],
+        },
+      },
+      { id: done, body: [], terminator: { kind: "resolve", value: sum } },
+      {
+        id: caught,
+        resume: { value: rejection, type: EXTERN, source: "rejected" },
+        body: [],
+        terminator: { kind: "reject", reason: rejection },
+      },
+    ],
+    handlers: [{ id: handler, kind: "catch", entry: caught, parent: null }],
+    runtimeIntents: [
+      "promise.capability.create",
+      "promise.resolve",
+      "promise.react",
+      "promise.settle.fulfill",
+      "promise.settle.reject",
+      "scheduler.enqueue",
+      "scheduler.drain",
+    ],
+  };
+}
+
+function errorCodes(plan: IrAsyncPlan): string[] {
+  return verifyIrAsyncPlan(plan).map((error) => error.code);
+}
+
+describe("#1373b IrAsyncPlan contract", () => {
+  it("verifies, canonicalizes, freezes, and hashes a two-suspend loop/handler plan", () => {
+    const plan = createIrAsyncPlan(makePlan());
+    expect(verifyIrAsyncPlan(plan)).toEqual([]);
+    expect(Object.isFrozen(plan)).toBe(true);
+    expect(Object.isFrozen(plan.states)).toBe(true);
+    expect(plan.states.map((state) => state.id)).toEqual([0, 1, 2, 3, 4]);
+    expect(plan.states[0]?.terminator).toMatchObject({ kind: "suspend", live: [1, 2] });
+    expect(hashIrAsyncPlan(plan)).toMatch(/^ir-async-plan:v1:[0-9a-f]{16}$/);
+  });
+
+  it("canonicalizes plan order independently of any backend target", () => {
+    const prepared = (["host", "standalone", "wasi"] as const).map((_target) => {
+      // Target choice is intentionally unavailable to the plan producer.
+      const plan = makePlan();
+      plan.states.reverse();
+      plan.runtimeIntents.reverse();
+      return { serialized: serializeIrAsyncPlan(plan), hash: hashIrAsyncPlan(plan) };
+    });
+    expect(new Set(prepared.map((item) => item.serialized)).size).toBe(1);
+    expect(new Set(prepared.map((item) => item.hash)).size).toBe(1);
+  });
+
+  it("fails closed on an unknown state and handler", () => {
+    const plan = makePlan();
+    const first = plan.states[0]!;
+    (first as { terminator: unknown }).terminator = {
+      ...first.terminator,
+      resume: { state: asAsyncStateId(99), value: asValueId(3) },
+      rejected: { kind: "handler", handler: asAsyncHandlerId(99) },
+    };
+    expect(errorCodes(plan)).toEqual(expect.arrayContaining(["unknown-state", "unknown-handler"]));
+  });
+
+  it("fails closed when cross-suspend liveness is missing or over-reported", () => {
+    const missing = makePlan();
+    const first = missing.states[0]!;
+    (first as { terminator: unknown }).terminator = { ...first.terminator, live: [asValueId(1)] };
+    expect(errorCodes(missing)).toContain("liveness-mismatch");
+
+    const extra = makePlan();
+    const again = extra.states[2]!;
+    (again as { terminator: unknown }).terminator = {
+      ...again.terminator,
+      live: [asValueId(0), asValueId(1), asValueId(2)],
+    };
+    expect(errorCodes(extra)).toContain("liveness-mismatch");
+  });
+
+  it("rejects callbacks, AST objects, raw Wasm, and concrete backend indices", () => {
+    const plan = makePlan() as IrAsyncPlan & Record<string, unknown>;
+    plan.emit = () => [];
+    plan.sourceNode = { kind: 263, pos: 0, end: 1 };
+    plan.backend = "wasmgc";
+    plan.wasmType = { typeIdx: 4 };
+    plan.states[0]!.body.push({ kind: "raw.wasm", result: null, resultType: null, ops: [], stackDelta: 0 });
+    const errors = verifyIrAsyncPlan(plan).filter((error) => error.code === "forbidden-data");
+    expect(errors.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("rejects the legacy raw-value/thenable ABI and missing scheduler intents", () => {
+    const plan = makePlan();
+    (plan as { abi: unknown }).abi = {
+      ...plan.abi,
+      consumerContract: "raw-or-promise",
+      settlementTiming: "sometimes-sync",
+    };
+    (plan as { runtimeIntents: readonly string[] }).runtimeIntents = ["promise.capability.create"];
+    expect(errorCodes(plan)).toEqual(expect.arrayContaining(["invalid-abi", "missing-runtime-intent"]));
+  });
+
+  it("rejects undeclared definitions and async control left inside state bodies", () => {
+    const missingDefinition = makePlan();
+    missingDefinition.values.push({ value: asValueId(7), type: F64 });
+    expect(errorCodes(missingDefinition)).toContain("missing-value-definition");
+
+    const hiddenAwait = makePlan();
+    hiddenAwait.states[0]!.body.push({
+      kind: "await",
+      operand: asValueId(0),
+      result: null,
+      resultType: null,
+    });
+    expect(errorCodes(hiddenAwait)).toContain("unlowered-async-control");
+  });
+});
+
+describe("#1042/#1373b async migration anti-vacuity", () => {
+  it("keeps the four playground blockers typed and strict while routing is unchanged", async () => {
+    const source = readFileSync(new URL("../../website/playground/examples/js/async.ts", import.meta.url), "utf8");
+    const result = await compile(source, {
+      fileName: "website/playground/examples/js/async.ts",
+      trackIrOutcomes: true,
+    });
+    expect(result.success).toBe(true);
+    const blockers = (result.irOutcomes ?? []).filter((outcome) => outcome.kind !== "emitted");
+    expect(blockers).toHaveLength(4);
+    expect(blockers.map((outcome) => [outcome.displayName, outcome.kind, outcome.stage, outcome.code]).sort()).toEqual([
+      ["fetchAllParallel", "unsupported", "select", "body-shape-rejected"],
+      ["fetchAllSequential", "unsupported", "select", "call-graph-closure"],
+      ["fetchUser", "unsupported", "select", "async-function"],
+      ["main", "unsupported", "select", "async-function"],
+    ]);
+    expect(blockers.every((outcome) => outcome.legacyBodyEmitted && !outcome.irBodyEmitted)).toBe(true);
+    expect(evaluateIrOutcomePolicy(blockers, "ir-only").ready).toBe(false);
+  });
+
+  it("preserves the existing frame engine's real two-suspension execution", async () => {
+    const exports = await compileToWasm(`
+      async function f(): Promise<number> {
+        const a = await Promise.resolve(20).then((x: number) => x + 1);
+        const b = await Promise.resolve(20).then((x: number) => x + 1);
+        return a + b;
+      }
+      export async function main(): Promise<number> { return await f(); }
+    `);
+    await expect(Promise.resolve(exports.main())).resolves.toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary

- define an immutable, AST-free `IrAsyncPlan` for async functions, with state/resume/handler edges, typed spills, and semantic Promise/scheduler intents
- enforce the canonical Promise-only ABI plus graph, definition, liveness, purity, and unlowered-control invariants
- add deterministic serialization/fingerprinting and hand-built positive/negative plan coverage
- pin the exact four playground outcomes and execute the existing two-suspension frame engine without changing selectors or production routing

## Scope

This is the bounded contract foundation for #1042/#1373b. It does not activate an async IR route or claim blocker retirement. On `origin/main` at `b310b3b3c5e`, the strict ledger intentionally remains 37 terminal units / 33 IR-emitted / 4 unsupported / 35 legacy bodies:

- `fetchAllParallel`: `select/body-shape-rejected`
- `fetchAllSequential`: `select/call-graph-closure`
- `fetchUser`: `select/async-function`
- `main`: `select/async-function`

The next slice can produce this contract from a Prepared free async function and adapt the existing frame engine to consume it.

Refs #1042
Refs #1373

## Validation

- `pnpm run typecheck`
- `pnpm exec vitest run tests/ir/issue-1373b-async-plan.test.ts` — 9/9
- focused async/equivalence suites — 202/204; the two failures reproduce unchanged on the matching pristine `origin/main` control (`#2895` standalone drain validation and `#2967` illegal-cast wrapper order)
- `pnpm run check:ir-fallbacks` — async-function 4 → 4; no gated increase
- `pnpm run check:ir-only -- --policy=hybrid` — READY, 37/33/4
- `pnpm run check:ir-only` — expected NOT READY on exactly the four blockers above
- formatting, lint, LOC/function budget, dead exports, issue-spec coverage, stack balance, vacuity shapes, optimization retirement, adoption, coercion, Test262 hard-error, and oracle-ratchet gates
- `check:linear-ir` remains red with the same 8 → 6 and demotion-growth diagnostics reproduced on the pristine control; no baseline update was made
