### PR TITLE
feat(ir): compile flat scalar instance methods once

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -178,6 +178,15 @@ Focused `gc` and `standalone` coverage proves:
 - an injected verifier failure records one Invariant with `direct=0, IR=0`,
   proving there is no post-claim legacy retry.
 
+The authoritative single-host readiness corpus is unchanged before versus
+after this bounded slice: **37 terminal units, 33 IR bodies, 35 legacy bodies,
+4 Unsupported, and zero Invariants** on both `origin/main` and this branch.
+None of its five entries contains an eligible scalar-layout instance method;
+the physical ownership improvement is therefore measured by the focused
+per-unit counters above rather than an artificial corpus change. Hybrid remains
+READY, while strict IR-only remains NOT READY with the same four typed async /
+closure blockers and 35 retained legacy bodies.
+
 Reference-bearing class layouts, constructors, accessors, fields,
 derived/inherited classes, class expressions, nested class units, object
 methods, and closures remain for later R3 slices.

--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -30,6 +30,7 @@ files:
   - src/ir/select.ts
   - src/ir/from-ast.ts
   - src/ir/integration.ts
+  - src/ir/prepared-component-dependencies.ts
   - src/codegen/class-bodies.ts
   - src/codegen/closures.ts
   - src/codegen/declarations.ts
@@ -37,6 +38,7 @@ files:
   - src/codegen/ir-overlay-outcomes.ts
   - src/codegen/program-abi-class-callable-planning.ts
   - src/codegen/program-abi-session.ts
+  - src/codegen/program-abi-type-planning.ts
   - src/codegen/context/types.ts
   - src/codegen/index.ts
   - tests/issue-3522-ir-class-compile-once.test.ts
@@ -117,8 +119,8 @@ physical class slot back for unit-ID correlation. The shared audit proves every
 skipped class slot has one patched terminal result. Unsealed static probes are
 removed from the early report, compile direct, and run through the established
 late overlay; they do not produce duplicate terminal evidence. Instance
-methods, constructors, accessors, fields, and closures remain on that
-transitional route.
+methods, constructors, accessors, fields, and closures remained on that
+transitional route at this slice.
 
 Focused runtime coverage proves:
 
@@ -126,8 +128,9 @@ Focused runtime coverage proves:
   emit no legacy body, validate as Wasm, and return the expected value;
 - same-named static overrides on separate structural class owners retain
   distinct slots and runtime behavior; and
-- an adjacent instance method still emits its direct body, preventing a
-  source-wide or flat-name skip from satisfying the test.
+- an adjacent Unsupported instance method in a separate class still emits its
+  direct body, preventing a source-wide or flat-name skip from satisfying the
+  test.
 
 The authoritative single-host lane moves from **31 to 33 IR-emitted units**,
 from **6 to 4 Unsupported units**, and from **37 to 35 legacy bodies**, with
@@ -136,10 +139,48 @@ async-body shape, and one call-graph closure. Hybrid is READY; strict IR-only
 is still NOT READY because 35 units retain legacy bodies.
 
 This is the first bounded R3 production slice, not issue completion. The
-no-receiver static ABI is preserved, but constructors, instance methods,
-accessors, field work, inheritance support, class expressions, nested units,
+no-receiver static ABI is preserved, but constructors, accessors, field work,
+inheritance support, class expressions, nested units,
 object methods, and closures still need component-atomic prepare/emit ownership
 and optimization-parity evidence before their direct handlers can retire.
+
+## Flat instance-method production slice (2026-08-02)
+
+Ordinary instance methods on exact top-level class declarations without an
+`extends` clause now join the pre-direct class-method preparation pass when the
+method contains no nested executable syntax and the already-collected class
+layout is index-stable and scalar. Scalar here is a structural contract: the
+layout has no parent edge and every field is `i32`, `i64`, `f32`, `f64`,
+`v128`, `i8`, or `i16`. Reference-bearing layouts stay on the established late
+route because their physical type indices may move during compaction. The
+eligible layout is published into Program ABI before IR integration, and the
+exact `class-layout` binding is included in the prepared component scope before
+it seals. This keeps the receiver ABI and class callable handle immutable
+before any class body emitter can run.
+
+Methods that depend on the same canonical class-layout binding are unioned into
+one atomic prepared component. `compileClassBodies` skips only the exact sealed
+ordinary-method slots, preserves the installed IR bodies, and reports their
+physical handles for terminal reconciliation. Constructors and accessors remain
+direct, as do Unsupported instance methods; the direct emitter and its existing
+optimizations are unchanged for those paths. A verifier Invariant is terminal
+and cannot retry the direct body emitter.
+
+Focused `gc` and `standalone` coverage proves:
+
+- two instance methods on the same flat class each record `direct=0, IR=1` and
+  share one prepared component ID, so omitting class-layout ownership or
+  component union cannot satisfy the test;
+- a default-parameter method on a separate string-field class records
+  `direct=1, IR=0`; a direct structural-policy test rejects its `ref_null`
+  layout, while the combined program validates as Wasm and returns the expected
+  runtime value; and
+- an injected verifier failure records one Invariant with `direct=0, IR=0`,
+  proving there is no post-claim legacy retry.
+
+Reference-bearing class layouts, constructors, accessors, fields,
+derived/inherited classes, class expressions, nested class units, object
+methods, and closures remain for later R3 slices.
 
 ## Exhaustive source-unit census
 
@@ -329,7 +370,7 @@ Run adjacent coverage from `tests/issue-1983-funcmap-collision.test.ts`,
 ## Required completion evidence
 
 ```bash
-pnpm exec vitest run tests/issue-3522-ir-class-compile-once.test.ts tests/issue-1983-funcmap-collision.test.ts tests/issue-3000-1b.test.ts tests/issue-3000-e.test.ts tests/issue-3144-ir-class-claims.test.ts tests/class-expressions.test.ts tests/nested-class-declarations.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+pnpm exec vitest run tests/issue-3522-ir-class-compile-once.test.ts tests/issue-3522-ir-static-class-method.test.ts tests/issue-1983-funcmap-collision.test.ts tests/issue-3000-1b.test.ts tests/issue-3000-e.test.ts tests/issue-3144-ir-class-claims.test.ts tests/class-expressions.test.ts tests/nested-class-declarations.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
 pnpm run check:ir-only -- --policy=hybrid
 pnpm run check:ir-only -- --policy=ir-only --json
 pnpm run check:ir-fallbacks -- --verbose

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -2215,12 +2215,12 @@ function compileClassBodiesInner(
       if (methodLocalIdx === undefined) continue;
 
       const func = ctx.mod.functions[methodLocalIdx]!;
-      // (#3522) Static methods whose complete ABI component was sealed and
+      // (#3522) Ordinary methods whose complete ABI component was sealed and
       // installed before direct emission own this exact slot. A prepared body
       // stays intact; an invariant-owned failure receives only a non-shipping
-      // placeholder. Instance methods deliberately remain on the established
-      // direct-then-overlay route in this slice.
-      if (isStatic && routing?.skipBodies.has(fullName)) {
+      // placeholder. Constructors and accessors deliberately remain on the
+      // established direct-then-overlay route in this slice.
+      if (routing?.skipBodies.has(fullName)) {
         if (!routing.preserveSkippedBodies?.has(fullName)) {
           func.body = [{ op: "unreachable" }];
         }

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1957,8 +1957,9 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
  * placeholder for a later IR overlay. R2 passes the exact same names through
  * `preserveSkippedBodies` after their IR bodies have already been prepared and
  * installed, so declaration compilation leaves those bodies untouched.
- * `classBodyRouting` applies the same exact transaction to top-level static
- * methods only; nested declarations and class expressions remain direct-owned.
+ * `classBodyRouting` applies the same exact transaction to top-level ordinary
+ * class methods; constructors, accessors, nested declarations, and class
+ * expressions remain direct-owned.
  *
  * The funcIdx/typeIdx slot itself is untouched in both modes. Skipped
  * functions are deliberately NOT registered as direct-front-end inlinables:

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -146,12 +146,12 @@ import {
 } from "./ir-overlay-safety.js";
 import {
   completePreparedIrIntegration,
+  prepareIrClassMethodBodies,
   prepareIrFreeFunctionBodies,
-  prepareIrStaticClassMethodBodies,
   selectR2PreparedFreeFunctions,
-  selectPreparedStaticClassMethodNames,
+  selectPreparedClassMethodNames,
+  type PreparedIrClassMethodBodies,
   type PreparedIrFreeFunctionBodies,
-  type PreparedIrStaticClassMethodBodies,
 } from "./ir-prepared-free-functions.js";
 import type { FallbackCounts } from "./fallback-telemetry.js";
 import { buildLeakedHostImportError, scanForLeakedHostImports } from "./host-import-allowlist.js";
@@ -3179,21 +3179,21 @@ function callUsesRuntimeEvalBoundary(node: ts.CallExpression | ts.NewExpression)
   );
 }
 
-interface IrFirstFunctionRouting {
+interface IrFirstBodyRouting {
   readonly requestedSkipProjection?: ReturnType<typeof buildIrRequestedFunctionSkipProjection>;
   readonly preparedFreeFunctions?: PreparedIrFreeFunctionBodies;
-  readonly preparedStaticClassMethods?: PreparedIrStaticClassMethodBodies;
+  readonly preparedClassMethods?: PreparedIrClassMethodBodies;
   readonly preparedReport?: IrIntegrationReport;
   readonly preparedSelection?: Pick<IrSelection, "funcs" | "classMembers" | "moduleInit">;
   readonly skipBodies?: ReadonlySet<string>;
   readonly preserveBodies?: ReadonlySet<string>;
 }
 
-function planIrFirstFunctionRouting(
+function planIrFirstBodyRouting(
   ctx: CodegenContext,
   sourceFile: ts.SourceFile,
   plan: IrOverlayPlan,
-): IrFirstFunctionRouting {
+): IrFirstBodyRouting {
   const preliminarySelection = plan.safeSelection;
   const hasLateFeaturePreparation =
     plan.importedCalls.size > 0 ||
@@ -3211,16 +3211,16 @@ function planIrFirstFunctionRouting(
         overridesByUnitId: plan.overrideMapByUnitId,
       })
     : new Set<string>();
-  const preliminaryStaticNames = !hasLateFeaturePreparation
-    ? selectPreparedStaticClassMethodNames({ selection: preliminarySelection, identityPlan: plan.identityPlan })
+  const preliminaryClassMethodNames = !hasLateFeaturePreparation
+    ? selectPreparedClassMethodNames(ctx, preliminarySelection, plan.identityPlan)
     : new Set<string>();
   // A class or module owner does not make an unrelated free-function component
-  // direct-owned. Static methods themselves may now enter the same sealed
-  // preparation transaction; instance members and module init remain direct.
+  // direct-owned. Ordinary instance/static methods may enter the same sealed
+  // preparation transaction; constructors, accessors, and module init remain direct.
   // selectR2PreparedFreeFunctions closes candidates over exact local call
   // edges, so any callable edge that crosses into one of those owners removes
   // the complete affected free-function component before preparation.
-  const useR2PreparedRouting = preliminaryR2Names.size > 0 || preliminaryStaticNames.size > 0;
+  const useR2PreparedRouting = preliminaryR2Names.size > 0 || preliminaryClassMethodNames.size > 0;
 
   if (useR2PreparedRouting) {
     // TDZ globals are part of the frozen Program ABI and may be read while
@@ -3235,15 +3235,12 @@ function planIrFirstFunctionRouting(
         "R2 final-context preparation changed a preflight-certified free-function component",
       );
     }
-    const finalStaticNames = selectPreparedStaticClassMethodNames({
-      selection: preparedSelection,
-      identityPlan: plan.identityPlan,
-    });
-    if ([...preliminaryStaticNames].some((legacyName) => !finalStaticNames.has(legacyName))) {
+    const finalClassMethodNames = selectPreparedClassMethodNames(ctx, preparedSelection, plan.identityPlan);
+    if ([...preliminaryClassMethodNames].some((legacyName) => !finalClassMethodNames.has(legacyName))) {
       throw new IrInvariantError(
         "selection-preparation-mismatch",
         "resolve",
-        "R2 final-context preparation changed a preflight-certified static-method component",
+        "R3 final-context preparation changed a preflight-certified class-method component",
       );
     }
     const freeFunctionSelection = {
@@ -3260,22 +3257,22 @@ function planIrFirstFunctionRouting(
       classShapes: plan.classShapes,
       loweringPlans: irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, freeFunctionSelection),
     });
-    const preparedStaticClassMethods = prepareIrStaticClassMethodBodies({
+    const preparedClassMethods = prepareIrClassMethodBodies({
       ctx,
       sourceFile,
-      selection: { classMembers: preliminaryStaticNames },
+      selection: { classMembers: preliminaryClassMethodNames },
       identityPlan: plan.identityPlan,
       overrideMap: plan.overrideMap,
       classShapes: plan.classShapes,
       projectLoweringPlans: (selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
     });
-    const preparedReport = preparedStaticClassMethods
-      ? mergeIrIntegrationReports(preparedFreeFunctions.report, preparedStaticClassMethods.report)
+    const preparedReport = preparedClassMethods
+      ? mergeIrIntegrationReports(preparedFreeFunctions.report, preparedClassMethods.report)
       : preparedFreeFunctions.report;
     return {
       requestedSkipProjection: preparedFreeFunctions.requestedSkipProjection,
       preparedFreeFunctions,
-      ...(preparedStaticClassMethods ? { preparedStaticClassMethods } : {}),
+      ...(preparedClassMethods ? { preparedClassMethods } : {}),
       preparedReport,
       preparedSelection,
       skipBodies: preparedFreeFunctions.skipBodies,
@@ -3801,9 +3798,11 @@ export function generateModule(
     // `unreachable` placeholder are no longer ownership mechanisms for this
     // population.
     //
-    // Class/member and module-init ownership remains the post-direct overlay
-    // until #3522/#3523. Their report is joined with the free-function report
-    // before telemetry/auditing, so every terminal row is reconciled once.
+    // Dependency-complete top-level ordinary methods now join this prepared
+    // route. Constructors, accessors, inherited methods, nested classes, and
+    // module init retain the post-direct overlay until their R3/R4 owners land.
+    // Both reports are joined before telemetry/auditing, so every terminal row
+    // is reconciled once.
     // Selector-REJECTED functions are never claimed and still compile through
     // the direct path unchanged.
     // Escape hatch (one release, #3143): `JS2WASM_IR_FIRST=0` restores the
@@ -3818,7 +3817,7 @@ export function generateModule(
     let irPlan: IrOverlayPlan | null = null;
     let requestedSkipProjection: ReturnType<typeof buildIrRequestedFunctionSkipProjection> | undefined;
     let preparedFreeFunctions: PreparedIrFreeFunctionBodies | undefined;
-    let preparedStaticClassMethods: PreparedIrStaticClassMethodBodies | undefined;
+    let preparedClassMethods: PreparedIrClassMethodBodies | undefined;
     let preparedReport: IrIntegrationReport | undefined;
     let preparedSelection: Pick<IrSelection, "funcs" | "classMembers" | "moduleInit"> | undefined;
     let irSkippedFunctionUnitIds: ReadonlySet<IrUnitId> = new Set();
@@ -3827,10 +3826,10 @@ export function generateModule(
     let irPreserveBodies: ReadonlySet<string> | undefined;
     if (irFirst) {
       irPlan = planIrOverlay(ctx, ast, irPlanningIdentityContext!);
-      const routing = planIrFirstFunctionRouting(ctx, ast.sourceFile, irPlan);
+      const routing = planIrFirstBodyRouting(ctx, ast.sourceFile, irPlan);
       requestedSkipProjection = routing.requestedSkipProjection;
       preparedFreeFunctions = routing.preparedFreeFunctions;
-      preparedStaticClassMethods = routing.preparedStaticClassMethods;
+      preparedClassMethods = routing.preparedClassMethods;
       preparedReport = routing.preparedReport;
       preparedSelection = routing.preparedSelection;
       irSkipBodies = routing.skipBodies;
@@ -3844,10 +3843,10 @@ export function generateModule(
       ast.sourceFile,
       irSkipBodies,
       irPreserveBodies,
-      preparedStaticClassMethods
+      preparedClassMethods
         ? {
-            skipBodies: preparedStaticClassMethods.skipBodies,
-            preserveSkippedBodies: preparedStaticClassMethods.preserveBodies,
+            skipBodies: preparedClassMethods.skipBodies,
+            preserveSkippedBodies: preparedClassMethods.preserveBodies,
             skippedNames: actuallySkippedClassMembers,
           }
         : undefined,
@@ -3864,9 +3863,9 @@ export function generateModule(
       const correlated = correlateIrSkippedFunctionNames(skipProjection, actuallySkipped ?? []);
       irFirstSkipped = correlated.legacyNames;
       irSkippedFunctionUnitIds = correlated.unitIds;
-      if (preparedStaticClassMethods) {
+      if (preparedClassMethods) {
         const correlatedClassMembers = correlateIrSkippedBodyNames(
-          preparedStaticClassMethods.requestedSkipProjection,
+          preparedClassMethods.requestedSkipProjection,
           actuallySkippedClassMembers,
           "class member",
         );
@@ -3911,9 +3910,7 @@ export function generateModule(
         classShapes,
         ...(preparedReport ? { preparedReport } : {}),
         ...(preparedFreeFunctions ? { preparedLegacyNames: preparedFreeFunctions.completedBodies } : {}),
-        ...(preparedStaticClassMethods
-          ? { preparedClassMemberLegacyNames: preparedStaticClassMethods.completedBodies }
-          : {}),
+        ...(preparedClassMethods ? { preparedClassMemberLegacyNames: preparedClassMethods.completedBodies } : {}),
         projectLoweringPlans: (selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
       });
       consumeIrOverlayReport(

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import type { IrIntegrationLoweringPlans } from "../ir/ast-lowering-plans.js";
-import type { IrUnitId } from "../ir/identity.js";
+import type { IrClassId, IrUnitId } from "../ir/identity.js";
 import { compileIrPathFunctions, type IrIntegrationReport, type IrTypeOverrideMap } from "../ir/integration.js";
 import { asVal, type IrClassShape, type IrType } from "../ir/nodes.js";
 import { IrInvariantError } from "../ir/outcomes.js";
@@ -30,7 +30,7 @@ export interface PreparedIrFreeFunctionBodies {
   readonly preserveBodies: ReadonlySet<string>;
 }
 
-export interface PreparedIrStaticClassMethodBodies {
+export interface PreparedIrClassMethodBodies {
   readonly report: IrIntegrationReport;
   readonly requestedSkipProjection: IrLegacyUnitProjection;
   readonly completedBodies: ReadonlySet<string>;
@@ -38,27 +38,44 @@ export interface PreparedIrStaticClassMethodBodies {
   readonly preserveBodies: ReadonlySet<string>;
 }
 
-/** Project selected static methods through exact structural class ownership. */
-export function selectPreparedStaticClassMethodNames(input: {
-  readonly selection: Pick<IrSelection, "classMembers">;
-  readonly identityPlan: irOverlayIdentity.IrOverlayIdentityPlan;
-}): ReadonlySet<string> {
-  const selectedNames = new Set(input.selection.classMembers ?? []);
-  const staticNames = new Set<string>();
-  for (const claim of input.identityPlan.identitySelection.classMembers?.values() ?? []) {
-    const terminal = input.identityPlan.identityContext.terminalByUnitId.get(claim.unitId);
-    const declaration = input.identityPlan.identityContext.declarationByUnitId.get(claim.unitId);
+/** Project selected ordinary methods through exact structural class ownership. */
+export function selectPreparedClassMethodNames(
+  ctx: CodegenContext,
+  selection: Pick<IrSelection, "classMembers">,
+  identityPlan: irOverlayIdentity.IrOverlayIdentityPlan,
+): ReadonlySet<string> {
+  const selectedNames = new Set(selection.classMembers ?? []);
+  const methodNames = new Set<string>();
+  for (const claim of identityPlan.identitySelection.classMembers?.values() ?? []) {
+    const terminal = identityPlan.identityContext.terminalByUnitId.get(claim.unitId);
+    const declaration = identityPlan.identityContext.declarationByUnitId.get(claim.unitId);
+    const owner = declaration?.parent;
+    const instanceClassId =
+      owner !== undefined && ts.isClassDeclaration(owner)
+        ? identityPlan.identityContext.classIdByDeclaration.get(owner)
+        : undefined;
+    // Derived layouts receive a late leaf-finality decision and constructors /
+    // inherited support still cross the direct boundary. Keep this first
+    // instance-method owner on exact top-level classes without `extends`.
+    const instanceOwnerIsFlat =
+      owner !== undefined &&
+      ts.isClassDeclaration(owner) &&
+      ts.isSourceFile(owner.parent) &&
+      !(owner.heritageClauses?.some((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword) ?? false) &&
+      instanceClassId !== undefined &&
+      ctx.programAbiTypes?.canPrepareScalarClassLayout(instanceClassId) === true;
     if (
       selectedNames.has(claim.legacyMatchName) &&
-      terminal?.staticClassMember === true &&
+      (terminal?.kind === "class-static-method" ||
+        (terminal?.kind === "class-instance-method" && instanceOwnerIsFlat)) &&
       declaration !== undefined &&
       ts.isMethodDeclaration(declaration) &&
       !containsNestedExecutableSyntax(declaration)
     ) {
-      staticNames.add(claim.legacyMatchName);
+      methodNames.add(claim.legacyMatchName);
     }
   }
-  return staticNames;
+  return methodNames;
 }
 
 function deferUnsealedPreparedComponents(
@@ -450,8 +467,8 @@ export function prepareIrFreeFunctionBodies(input: {
   };
 }
 
-/** Prepare selected top-level static class methods before direct class bodies. */
-export function prepareIrStaticClassMethodBodies(input: {
+/** Prepare selected top-level ordinary class methods before direct class bodies. */
+export function prepareIrClassMethodBodies(input: {
   readonly ctx: CodegenContext;
   readonly sourceFile: ts.SourceFile;
   readonly selection: Pick<IrSelection, "classMembers">;
@@ -459,17 +476,44 @@ export function prepareIrStaticClassMethodBodies(input: {
   readonly overrideMap: IrTypeOverrideMap;
   readonly classShapes: ReadonlyMap<string, IrClassShape>;
   readonly projectLoweringPlans: (selection: IrSelection) => IrIntegrationLoweringPlans;
-}): PreparedIrStaticClassMethodBodies | undefined {
-  const staticNames = selectPreparedStaticClassMethodNames(input);
+}): PreparedIrClassMethodBodies | undefined {
+  const methodNames = selectPreparedClassMethodNames(input.ctx, input.selection, input.identityPlan);
   const claimsByUnitId = new Map<IrUnitId, IrExactBodyClaim>();
   for (const claim of input.identityPlan.identitySelection.classMembers?.values() ?? []) {
-    if (!staticNames.has(claim.legacyMatchName)) continue;
+    if (!methodNames.has(claim.legacyMatchName)) continue;
     claimsByUnitId.set(claim.unitId, { unitId: claim.unitId, legacyName: claim.legacyMatchName });
   }
   if (claimsByUnitId.size === 0) return undefined;
+  const classLayouts = new Set<IrClassId>();
+  for (const unitId of claimsByUnitId.keys()) {
+    const terminal = input.identityPlan.identityContext.terminalByUnitId.get(unitId);
+    if (terminal?.kind !== "class-instance-method") continue;
+    const declaration = input.identityPlan.identityContext.declarationByUnitId.get(unitId);
+    const owner = declaration?.parent;
+    const classId =
+      owner !== undefined && ts.isClassDeclaration(owner)
+        ? input.identityPlan.identityContext.classIdByDeclaration.get(owner)
+        : undefined;
+    if (!classId) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `prepared instance method ${unitId} has no exact class-layout owner`,
+      );
+    }
+    classLayouts.add(classId);
+  }
+  if (classLayouts.size > 0 && !input.ctx.programAbiTypes) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "prepared instance methods require one exact class-layout ABI registry",
+    );
+  }
+  for (const classId of classLayouts) input.ctx.programAbiTypes!.prepareScalarClassLayout(classId);
   const selection: IrSelection = {
     funcs: new Set<string>(),
-    classMembers: staticNames,
+    classMembers: methodNames,
     moduleInit: undefined,
   };
   const initialReport = compileIrPathFunctions(
@@ -490,7 +534,7 @@ export function prepareIrStaticClassMethodBodies(input: {
   return {
     report,
     requestedSkipProjection,
-    completedBodies: new Set([...staticNames].filter((legacyName) => !deferredBodies.has(legacyName))),
+    completedBodies: new Set([...methodNames].filter((legacyName) => !deferredBodies.has(legacyName))),
     skipBodies: new Set(requestedSkipProjection.entries.map(({ legacyName }) => legacyName)),
     preserveBodies: new Set(preparedProjection.entries.map(({ legacyName }) => legacyName)),
   };

--- a/src/codegen/program-abi-type-planning.ts
+++ b/src/codegen/program-abi-type-planning.ts
@@ -26,6 +26,14 @@ interface ProgramAbiClassLayoutObservation {
   readonly cell: ProgramAbiTypeCell;
 }
 
+/** True when a class layout has no type-index-bearing field or parent edge. */
+export function isEarlyStableScalarClassLayout(type: StructTypeDef): boolean {
+  return (
+    type.superTypeIdx === undefined &&
+    type.fields.every((field) => ["i32", "i64", "f32", "f64", "v128", "i8", "i16"].includes(field.type.kind))
+  );
+}
+
 function canonicalEntrySource(session: ProgramAbiSession): IrSourceId {
   const entrySources = session.inventory.sources.filter((source) => source.kind === "entry");
   if (entrySources.length !== 1) {
@@ -123,6 +131,39 @@ export class ProgramAbiTypeRegistry {
     if (!type || type.kind !== "struct") return undefined;
     const typeIdx = this.ctx.mod.types.indexOf(type);
     return typeIdx < 0 ? undefined : Object.freeze({ typeIdx, type });
+  }
+
+  /** Whether one collected class layout is stable before type-index compaction. */
+  canPrepareScalarClassLayout(classId: IrClassId): boolean {
+    const layout = this.layoutForClass(classId);
+    return layout !== undefined && isEarlyStableScalarClassLayout(layout.type);
+  }
+
+  /** Publish one index-stable scalar class layout for an early prepared component. */
+  prepareScalarClassLayout(classId: IrClassId): void {
+    if (this.planned) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        `cannot prepare class layout ${classId} after retained type planning`,
+      );
+    }
+    const classRecord = this.session.inventory.classes.find((record) => record.id === classId);
+    const observations = this.classes.get(classId) ?? [];
+    const canonical = observations.filter((observation) => observation.cell.current !== null).at(-1);
+    const current = canonical?.cell.current;
+    if (
+      !classRecord ||
+      !canonical ||
+      !current ||
+      current.kind !== "struct" ||
+      !isEarlyStableScalarClassLayout(current)
+    ) {
+      throw new ProgramAbiInvariantError(
+        "type-remap-mismatch",
+        `prepared class ${classId} has no retained index-stable scalar layout`,
+      );
+    }
+    this.planClass(classId, canonical.displayName, current, canonical.cell);
   }
 
   /** Return the backend-neutral Program-ABI identity used by final string IR. */

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -502,12 +502,7 @@ function sealDependencyCompletePreparedComponents(input: {
       const scope = session.beginPreparedComponentScope(component.id, component.terminalUnitIds);
       const requestedBindingIds = new Set(
         component.abiDependencies
-          .filter(
-            (dependency) =>
-              dependency.kind === "external-callable" ||
-              dependency.kind === "external-global" ||
-              dependency.kind === "support",
-          )
+          .filter(({ kind }) => ["external-callable", "external-global", "class-layout", "support"].includes(kind))
           .map((dependency) => dependency.bindingId),
       );
       for (const bindingId of requestedBindingIds) scope.includeBinding(bindingId);

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -1012,7 +1012,8 @@ function freezeComponent(
  *
  * Exact unit references close the terminal component as an undirected
  * ownership graph. Every directly encoded global/support/class-layout
- * identity is reconciled against Program ABI evidence. Source globals remain
+ * identity is reconciled against Program ABI evidence. Terminals sharing one
+ * canonical class layout form one atomic component. Source globals remain
  * blocked until their terminal storage owner is explicit. Class call sites
  * close over exact callable targets when present; compatibility nodes without
  * one remain blocked rather than guessing from a member name.
@@ -1056,11 +1057,20 @@ export function derivePreparedComponentDependencies(
   }
 
   const union = new ComponentUnion(input.terminalUnitIds);
+  const classLayoutOwner = new Map<IrBindingId, IrUnitId>();
   for (const item of evidence) {
     for (const dependency of item.unitDependencies.values()) {
       union.connect(item.terminalOwnerUnitId, dependency.terminalOwnerUnitId);
     }
     for (const dependency of item.abiDependencies.values()) {
+      if (dependency.kind === "class-layout") {
+        const previousOwner = classLayoutOwner.get(dependency.canonicalBindingId);
+        if (previousOwner === undefined) {
+          classLayoutOwner.set(dependency.canonicalBindingId, item.terminalOwnerUnitId);
+        } else {
+          union.connect(item.terminalOwnerUnitId, previousOwner);
+        }
+      }
       if (
         dependency.kind === "source-global" &&
         dependency.terminalOwnerUnitId !== null &&

--- a/tests/issue-3522-ir-class-compile-once.test.ts
+++ b/tests/issue-3522-ir-class-compile-once.test.ts
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+
+import { isEarlyStableScalarClassLayout } from "../src/codegen/program-abi-type-planning.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+function classMemberOutcome(result: CompileResult, name: string): IrObservedOutcome {
+  const observed = (result.irOutcomes ?? []).filter(
+    (candidate) => candidate.unitKind === "class-member" && candidate.displayName === name,
+  );
+  expect(observed, `terminal outcome count for ${name}`).toHaveLength(1);
+  return observed[0]!;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, Function>;
+  imports.setExports?.(exports);
+  return exports;
+}
+
+describe("#3522 instance class-method compile-once ownership", () => {
+  it("admits only type-index-stable scalar class layouts before direct emission", () => {
+    expect(
+      isEarlyStableScalarClassLayout({
+        kind: "struct",
+        name: "ScalarBox",
+        fields: [
+          { name: "__tag", type: { kind: "i32" }, mutable: false },
+          { name: "value", type: { kind: "f64" }, mutable: true },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      isEarlyStableScalarClassLayout({
+        kind: "struct",
+        name: "StringBox",
+        fields: [
+          { name: "__tag", type: { kind: "i32" }, mutable: false },
+          { name: "value", type: { kind: "ref_null", typeIdx: 7 }, mutable: true },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it.each(["gc", "standalone"] as const)(
+    "prepares a two-method %s class component once while an Unsupported sibling stays direct",
+    async (target) => {
+      const result = await compile(
+        `
+        class Calculator {
+          value: number;
+          constructor(value: number) { this.value = value; }
+          add(delta: number): number { return this.value + delta; }
+          scale(factor: number): number { return this.value * factor; }
+        }
+        class LegacyCalculator {
+          label: string;
+          constructor(label: string) { this.label = label; }
+          withDefault(value: number = 9): number { return this.label.length + value; }
+        }
+        export function run(value: number): number {
+          const calculator = new Calculator(value);
+          return calculator.add(2) * 100 + calculator.scale(3) * 10 + new LegacyCalculator("legacy").withDefault();
+        }
+        `,
+        {
+          fileName: `ir-instance-method-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          target,
+        },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(result.binary)).toBe(true);
+      const add = classMemberOutcome(result, "Calculator_add");
+      const scale = classMemberOutcome(result, "Calculator_scale");
+      for (const observed of [add, scale]) {
+        expect(observed).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+          preparedComponentId: expect.stringMatching(/^prepared-component:/),
+        });
+      }
+      expect(scale.preparedComponentId).toBe(add.preparedComponentId);
+      expect(classMemberOutcome(result, "LegacyCalculator_withDefault")).toMatchObject({
+        kind: "unsupported",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+      expect((await instantiate(result)).run!(5)).toBe(865);
+    },
+  );
+
+  it("fails an instance-method invariant without retrying the direct body emitter", async () => {
+    const previous = process.env.JS2WASM_TEST_INJECT_IR_VERIFY_FAILURE;
+    process.env.JS2WASM_TEST_INJECT_IR_VERIFY_FAILURE = "Box_read";
+    let result: CompileResult;
+    try {
+      result = await compile(
+        `
+        class Box {
+          value: number;
+          constructor(value: number) { this.value = value; }
+          read(): number { return this.value; }
+        }
+        export function run(): number { return new Box(7).read(); }
+        `,
+        {
+          fileName: "ir-instance-method-invariant.ts",
+          experimentalIR: true,
+          trackIrOutcomes: true,
+        },
+      );
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_INJECT_IR_VERIFY_FAILURE");
+      else process.env.JS2WASM_TEST_INJECT_IR_VERIFY_FAILURE = previous;
+    }
+
+    expect(result.success).toBe(false);
+    expect(classMemberOutcome(result, "Box_read")).toMatchObject({
+      kind: "invariant",
+      code: "verifier-failure",
+      stage: "verify",
+      legacyBodyEmitted: false,
+      irBodyEmitted: false,
+    });
+  });
+});

--- a/tests/issue-3522-ir-static-class-method.test.ts
+++ b/tests/issue-3522-ir-static-class-method.test.ts
@@ -26,9 +26,11 @@ describe("#3522 static class-method IR integration", () => {
       `
       class MathBox {
         static double(value: number): number { return value * 2; }
-        offset(): number { return 2; }
       }
-      export function run(value: number): number { return MathBox.double(value) + new MathBox().offset(); }
+      class OffsetBox {
+        offset(value: number = 2): number { return value; }
+      }
+      export function run(value: number): number { return MathBox.double(value) + new OffsetBox().offset(); }
       `,
       {
         fileName: `ir-static-method-${target}.ts`,
@@ -46,12 +48,12 @@ describe("#3522 static class-method IR integration", () => {
       irBodyEmitted: true,
       preparedComponentId: expect.any(String),
     });
-    expect(classMemberOutcome(result, "MathBox_offset")).toMatchObject({
-      kind: "emitted",
+    expect(classMemberOutcome(result, "OffsetBox_offset")).toMatchObject({
+      kind: "unsupported",
       legacyBodyEmitted: true,
-      irBodyEmitted: true,
+      irBodyEmitted: false,
     });
-    expect(classMemberOutcome(result, "MathBox_offset")).not.toHaveProperty("preparedComponentId");
+    expect(classMemberOutcome(result, "OffsetBox_offset")).not.toHaveProperty("preparedComponentId");
     expect(result.irPostClaimErrors ?? []).toEqual([]);
     expect((await instantiate(result)).run!(20)).toBe(42);
   });


### PR DESCRIPTION
## Summary

- Prepare eligible ordinary instance methods on exact top-level, non-derived classes before direct class-body emission.
- Publish the exact scalar class layout into Program ABI, freeze its `class-layout` dependency in the prepared scope, and union methods sharing that canonical layout into one atomic component.
- Keep reference-bearing/native-string layouts, constructors, accessors, inherited/nested classes, and unsupported shapes on their established routes. The direct emitter and its optimizations remain unchanged for those paths.
- Treat verifier failure as terminal: no direct retry after an IR invariant.

Part of #3522; this does not close the broader classes/closures issue.

## Bounded ownership rule

Early preparation admits a class layout only when it has no parent edge and every physical field is one of `i32`, `i64`, `f32`, `f64`, `v128`, `i8`, or `i16`. A reference-bearing layout is structurally excluded before preparation rather than caught, retried, or silently withdrawn after emission.

The focused evidence is anti-vacuous:

| Unit | Outcome | Direct bodies | IR bodies | Component |
| --- | --- | ---: | ---: | --- |
| `Calculator_add` | Prepared/emitted | 0 | 1 | shared class component |
| `Calculator_scale` | Prepared/emitted | 0 | 1 | same component as `add` |
| `LegacyCalculator_withDefault` (string-field layout) | Unsupported | 1 | 0 | none |
| `Box_read` with injected verifier failure | Invariant | 0 | 0 | no retry |

Both `gc` and `standalone` binaries validate and return the expected runtime value. A direct structural-policy test also rejects a `ref_null` field layout.

## Production-file scope

- `src/codegen/ir-prepared-free-functions.ts`: select and prepare only the bounded instance-method population alongside static methods.
- `src/codegen/program-abi-type-planning.ts`: classify index-stable scalar layouts and publish an eligible layout before integration.
- `src/ir/integration.ts`: include the exact `class-layout` binding when sealing a prepared scope.
- `src/ir/prepared-component-dependencies.ts`: union terminals that share one canonical class-layout dependency.
- `src/codegen/class-bodies.ts`: bypass direct emission only for exact routed ordinary-method slots while preserving installed IR bodies.
- `src/codegen/index.ts`: carry the prepared class-method route through the existing pre-direct transaction and final reconciliation.
- `src/codegen/declarations.ts`: keep the physical ownership contract comment accurate for ordinary methods; executable behavior is unchanged there.

## Readiness census

The fixed five-entry single-host corpus contains no eligible scalar-layout instance method, so its aggregate census honestly remains unchanged:

| Metric | `origin/main` | This branch | Delta |
| --- | ---: | ---: | ---: |
| Terminal units | 37 | 37 | 0 |
| IR bodies | 33 | 33 | 0 |
| Legacy bodies | 35 | 35 | 0 |
| Unsupported | 4 | 4 | 0 |
| Invariants | 0 | 0 | 0 |

Hybrid remains READY. Strict IR-only remains NOT READY with the existing four typed async/closure blockers and 35 legacy bodies.

## Validation

- `pnpm run typecheck`
- focused class/claim/native-string/inheritance/collision/nested suite: 32/32 passed
- shared Program ABI/component dependency suite: 43/43 passed
- `pnpm run check:ir-fallbacks -- --verbose`
- `pnpm run check:ir-only -- --policy=hybrid`
- `pnpm run check:ir-only -- --policy=ir-only --json` (expected NOT READY; zero invariants)
- `pnpm run check:ir-optimization-retirement`
- `node scripts/equivalence-gate.mjs` (1,619 passed; no new regressions)
- cross-backend differential suite: 29/29 passed
- `pnpm run lint`
- `pnpm run format:check`
- repository pre-push hook: typecheck, lint, formatting, oracle/coercion ratchets, numeric-local parity, and issue integrity passed

Baseline note: the required `tests/class-expressions.test.ts` file has three `string_constants` import-instantiation failures on both this branch and a detached current `origin/main`; the other seven required files pass 32/32 here.
