### PR TITLE
feat(ir): route certified Math calls through semantic intrinsics

### DIFF
--- a/plan/issues/3526-ir-r6-semantic-runtime-contract.md
+++ b/plan/issues/3526-ir-r6-semantic-runtime-contract.md
@@ -26,12 +26,16 @@ files:
   - src/ir/intrinsics.ts
   - src/ir/runtime-manifest.ts
   - src/ir/nodes.ts
+  - src/ir/intrinsic-support.ts
+  - src/ir/math-runtime-providers.ts
   - src/ir/types.ts
   - src/ir/effects.ts
   - src/ir/select.ts
   - src/ir/from-ast.ts
   - src/ir/integration.ts
   - src/ir/lower.ts
+  - src/ir/backend/legality.ts
+  - src/ir/backend/linear-integration.ts
   - src/ir/backend/emitter.ts
   - src/codegen/context/types.ts
   - src/codegen/index.ts
@@ -47,6 +51,24 @@ files:
   - src/runtime.ts
   - src/index.ts
   - tests/issue-3526-ir-runtime-manifest.test.ts
+  - tests/issue-3526-ir-math-intrinsic-integration.test.ts
+  - tests/issue-3526-ir-linear-math-intrinsics.test.ts
+loc-budget-allow:
+  - src/ir/integration.ts
+  - src/ir/builder.ts
+  - src/ir/nodes.ts
+  - src/ir/lower.ts
+  - src/ir/verify.ts
+  - src/ir/select.ts
+  - src/ir/from-ast.ts
+func-budget-allow:
+  - src/ir/integration.ts::compileIrPathFunctions
+  - src/ir/lower.ts::lowerIrFunctionBody
+  - src/ir/lower.ts::emitInstrTree
+  - src/ir/backend/linear-integration.ts::compileLinearIrFunctions
+  - src/ir/from-ast.ts::lowerMethodCall
+  - src/ir/integration.ts::makeResolver
+  - src/ir/passes/inline-small.ts::renameInstrOperands
 ---
 
 # #3526 — IR-only R6: typed semantic runtime contract and frozen feature manifest
@@ -71,10 +93,10 @@ Runtime, builtin, scheduler, coercion, collection, regex, and host adapter
 implementations remain single-sourced providers; their behavior is not deleted
 with the old front-end.
 
-## Current evidence
+## Baseline evidence and current seam
 
-There is no `IntrinsicId`, `RuntimeFeature`, or `HostCapability` type today.
-Instead, semantics and concrete imports are discovered during emission:
+Before C0, there was no `IntrinsicId`, `RuntimeFeature`, or `HostCapability`
+type. Semantics and concrete imports were discovered during emission:
 
 - `src/index.ts:39-92` exposes a broad string-shaped `ImportIntent` union for
   math, console, extern classes, strings, builtins, callbacks, await, boxing,
@@ -110,13 +132,14 @@ Instead, semantics and concrete imports are discovered during emission:
   and registers providers against the live codegen context, including helper
   materialization, type interning, slot allocation, and `funcMap` mutation.
 
-The first safe semantic slice already has a bounded vocabulary:
+The first safe semantic slice has a bounded vocabulary:
 
 - `src/ir/select.ts:176-189` defines exactly twelve certified, exact-arity,
   proven-f64 `IR_MATH_METHOD_TABLE` specializations: five direct deterministic
   operations and seven symbolic self-host helpers.
-- `src/ir/from-ast.ts:4548-4566` lowers those calls to either direct IR or a
-  stringly `Math_<method>` helper and assumes legacy scanning registered it.
+- `src/ir/from-ast.ts` now lowers those calls to versioned semantic intrinsic
+  nodes with no provider attached. Final IR preparation selects the provider
+  from the frozen runtime manifest.
 - `src/codegen/math-helpers.ts:71-87` emits deterministic inline/self-host Math
   providers. They are runtime substrate to retain. `Math.random` at `:89-153`
   adds host/WASI randomness and is deliberately not part of the first pure
@@ -228,6 +251,48 @@ providers remain unchanged and authoritative for production emission.
   after zero-direct and late-mutation tests pass. Retain selector/from-AST
   recognition, provider bodies, and legacy direct Math dispatch needed by
   non-Prepared unit kinds/coercive shapes until their migration or R9/R10.
+
+#### M1 production landing (2026-08-02)
+
+The exact twelve certified Math calls now enter IR as a closed, versioned
+`intrinsic` instruction. AST/type lowering records only the semantic ID,
+arguments, result signature, and source location. It no longer selects a Wasm
+opcode or names a `Math_*` helper. The builder and verifier reject arity, type,
+version, result, or callable-binding drift.
+
+After all current middle-end passes, `prepareIrRuntimeManifest` collects the
+final reachable intrinsic uses, expands and freezes their provider graph, and
+attaches lookup-only provider choices before callable discovery and prepared
+component sealing. Unprepared nodes are explicit dependency failures and
+lowering invariants. Provider attachment is recursive and idempotent, including
+nested instruction buffers and pass-created functions.
+
+Provider behavior and existing optimizations are preserved:
+
+- WasmGC still emits native `f64.abs`, `f64.sqrt`, `f64.floor`, `f64.ceil`, and
+  `f64.trunc` instructions without boxing or calls.
+- `sin`, `cos`, `exp`, `log`, `log2`, `pow`, and `atan2` still use the same
+  self-hosted `Math_*` provider bodies and the same dependency helpers.
+- Provider materialization is driven by the frozen manifest rather than the
+  legacy pending-Math AST scan. Self-hosted provider IR uses the same manifest
+  preparation recursively, so its own `Math.abs`/`floor`/`trunc` operations do
+  not depend on ambient registry mutation.
+- Linear IR admits exactly the five native backend operations at its legality
+  boundary. The seven callable-backed operations remain fail-closed until the
+  linear backend has an explicit self-host provider ABI.
+
+Focused integration coverage proves all twelve source methods become semantic
+nodes without magic helper calls, provider-free lowering fails before emission,
+the frozen manifest attaches the exact five native and seven callable choices,
+all twelve production bodies emit through IR with
+`legacyBodyEmitted:false`, no Math host imports appear, native opcodes remain in
+WAT, the established self-host helper names remain reachable, and runtime
+results match the direct backend. Shadowed, coercive, wrong-arity, and
+`Math.random` shapes remain outside M1.
+
+M1 changes semantic authority but does not widen the selector, so the strict
+fixed-corpus census is unchanged. The legacy direct Math route remains only for
+non-Prepared shapes until their owning family slices and final R9/R10 deletion.
 
 ### Later measured family slices
 

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -67,6 +67,8 @@ import { collectIrDirectCallLoweringPlans, type IrDirectCallTarget } from "../ir
 import { irIntrinsicFuncRef, irRuntimeFuncRef } from "../ir/callable-bindings.js";
 import { irVal, type IrFunction, type IrType } from "../ir/nodes.js";
 import { IR_VEC_ELEM_SET_PREFIX, parseIrVectorRuntimeElement } from "../ir/vector-runtime.js";
+import { prepareIrRuntimeManifest } from "../ir/intrinsic-support.js";
+import { isIntrinsicId } from "../ir/intrinsics.js";
 import { createDerivedIrUnitId, createIrSourceId, type IrSyntheticUnitRole, type IrUnitId } from "../ir/identity.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { ensureNativeCharCodeAtHelper, NATIVE_CHARCODEAT_FN } from "./char-code-at-helpers.js";
@@ -478,7 +480,15 @@ export function emitSelfHostedFunc(ctx: CodegenContext, def: SelfHostedFuncDef):
   // ValTypes need resolveString()); everything else stays resolver-less.
   const fromAst = def.dialect === "native-strings" ? makeNativeStringsBuildResolver(ctx) : undefined;
   const ir = buildSelfHostedIr(def, createSelfHostedIrUnitId(def.name), fromAst);
-  const funcIdx = lowerAndRegister(ctx, def.name, ir);
+  const prepared = prepareIrRuntimeManifest({
+    functions: [ir],
+    sourceFile: `<stdlib:${def.name}>`,
+    policy: {
+      target: ctx.wasi ? "wasi" : ctx.standalone ? "standalone" : ctx.strictNoHostImports ? "strict-no-host" : "host",
+      backend: "wasmgc",
+    },
+  });
+  const funcIdx = lowerAndRegister(ctx, def.name, prepared?.functions[0] ?? ir);
   return funcIdx;
 }
 
@@ -579,6 +589,11 @@ function lowerAndRegister(ctx: CodegenContext, name: string, ir: IrFunction): nu
           );
         }
         return helperIdx;
+      }
+      if (ref.binding.kind === "intrinsic" && isIntrinsicId(ref.binding.symbol)) {
+        const providerIdx = ctx.funcMap.get(ref.name);
+        if (providerIdx !== undefined) return providerIdx;
+        throw new Error(`stdlib-selfhost: ${name} cannot resolve prepared intrinsic provider ${ref.name}`);
       }
       const adapterName =
         ref.binding.kind === "runtime" || ref.binding.kind === "intrinsic"

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -150,6 +150,17 @@ function linearInstrError(instr: IrInstr): string | null {
           // null/ref/string/undefined consts are representation-divergent.
           return `linear backend does not support const '${instr.value.kind}'`;
       }
+    case "intrinsic":
+      switch (instr.id) {
+        case "math.abs":
+        case "math.ceil":
+        case "math.floor":
+        case "math.sqrt":
+        case "math.trunc":
+          return null;
+        default:
+          return `linear backend does not support semantic intrinsic '${instr.id}' without a native backend operation`;
+      }
     case "binary":
     case "unary":
     case "select":

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -112,6 +112,7 @@ import { planIrCompilationByIdentity, projectIrSelectionToLegacy } from "../sele
 import { buildIrRecursiveTypeEvidence } from "../type-evidence.js";
 import type { FuncTypeDef, Instr, ValType, WasmFunction } from "../types.js";
 import { verifyIrFunction } from "../verify.js";
+import { prepareIrRuntimeManifest } from "../intrinsic-support.js";
 import type { TypeConverter } from "./contract.js";
 import { verifyIrBackendLegality } from "./legality.js";
 import { LinearEmitter } from "./linear-emitter.js";
@@ -450,6 +451,16 @@ export function getLastLinearIrReport(): LinearIrResult | undefined {
   return lastReport;
 }
 
+function prepareLinearIntrinsicFunctions(functions: readonly IrFunction[], sourceFile: string): readonly IrFunction[] {
+  return (
+    prepareIrRuntimeManifest({
+      functions,
+      sourceFile,
+      policy: { target: "host", backend: "linear" },
+    })?.functions ?? functions
+  );
+}
+
 /**
  * Build + lower every selector-claimed top-level FunctionDeclaration for the
  * LINEAR backend. Precompute mutates only append-only/deduped func types and
@@ -724,7 +735,9 @@ export function compileLinearIrFunctions(
     const fn = built.get(ownerUnitId);
     return fn ? [fn] : [];
   });
-  irModule = { functions: plannedFunctions };
+  const preparedFunctions = prepareLinearIntrinsicFunctions(plannedFunctions, sourceFile.fileName);
+  for (const fn of preparedFunctions) built.set(fn.unitId, fn);
+  irModule = { functions: preparedFunctions };
   memoryPlan = planLinearMemory(irModule, allocRegistry, allocationPolicy);
   bindMemoryPlan(memoryPlan);
 

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -36,12 +36,14 @@ import {
   IrUnop,
   IrValueId,
   IrValueIdAllocator,
+  irTypeEquals,
 } from "./nodes.js";
 import type { AllocSiteRegistry } from "./alloc-registry.js";
 import { irSupportFuncRef } from "./callable-bindings.js";
 import type { Instr, ValType } from "./types.js";
 import { JsTag, jsTagUnboxKind } from "./js-tag.js";
 import type { IrStringConcatMode, IrStringEncoding } from "./string-runtime.js";
+import { INTRINSIC_DEFINITIONS, type IntrinsicId } from "./intrinsics.js";
 
 interface OpenBlock {
   readonly id: IrBlockId;
@@ -203,6 +205,35 @@ export class IrFunctionBuilder {
     // for call-result origin rules (JSON.parse, string methods, …).
     const alloc = resultType?.kind === "string" ? this.allocId("string", resultType) : undefined;
     this.pushInstr({ kind: "call", target, args: [...args], result, resultType, alloc });
+    return result;
+  }
+
+  /** Emit one closed semantic intrinsic before any runtime provider is chosen. */
+  emitIntrinsic(id: IntrinsicId, args: readonly IrValueId[], site?: IrSiteId): IrValueId {
+    const definition = INTRINSIC_DEFINITIONS[id];
+    if (args.length !== definition.signature.params.length) {
+      throw new Error(
+        `IrFunctionBuilder: ${id} expects ${definition.signature.params.length} argument(s), received ${args.length}`,
+      );
+    }
+    for (let index = 0; index < args.length; index++) {
+      const actual = this.typeOf(args[index]!);
+      const expected = definition.signature.params[index]!;
+      if (!irTypeEquals(actual, expected)) {
+        throw new Error(`IrFunctionBuilder: ${id} argument ${index} does not match its semantic signature`);
+      }
+    }
+    const result = this.allocator.fresh();
+    this.valueTypes.set(result, definition.signature.result);
+    this.pushInstr({
+      kind: "intrinsic",
+      id,
+      version: definition.signature.version,
+      args: [...args],
+      result,
+      resultType: definition.signature.result,
+      ...(site ? { site } : {}),
+    });
     return result;
   }
 

--- a/src/ir/effects.ts
+++ b/src/ir/effects.ts
@@ -113,6 +113,7 @@ export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new M
     // string content ops. Re-ordering these is unobservable.
     case "const":
     case "string.const":
+    case "intrinsic":
     case "binary":
     case "unary":
     case "select":

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -5986,9 +5986,9 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
     return null;
   }
 
-  // (#1371/#2856) Exact-arity Math builtin. Direct Wasm unary ops remain
-  // direct; transcendental methods call the self-hosted Math_<method> helper
-  // already registered by the legacy declaration scan.
+  // (#1371/#2856/#3526 M1) Exact-arity Math builtin. Every accepted method
+  // becomes a semantic intrinsic here; runtime/backend provider selection is
+  // deferred until final IR preparation, after all middle-end transforms.
   // the shape BEFORE lowering the receiver, because `Math` is a host
   // global with no IR type binding (lowerExpr on `Math` would throw
   // "unknown identifier"). The selector's `isPhase1Expr` already
@@ -6018,11 +6018,12 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
         }
         return arg;
       });
-      if ("op" in plan) return cx.builder.emitUnary(plan.op, args[0]!, irVal({ kind: "f64" }));
-      const result = cx.builder.emitCall(irRuntimeFuncRef(plan.helper), args, irVal({ kind: "f64" }));
-      if (result === null)
-        throw new Error(`ir/from-ast: Math.${methodName} helper produced no result (${cx.funcName})`);
-      return result;
+      const source = expr.getSourceFile();
+      const position = source.getLineAndCharacterOfPosition(expr.getStart(source));
+      return cx.builder.emitIntrinsic(plan.intrinsic, args, {
+        line: position.line + 1,
+        column: position.character,
+      });
     }
     throw new Error(`ir/from-ast: Math.${methodName} not in IR whitelist (${cx.funcName})`);
   }

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -224,6 +224,10 @@ import {
   type IrSelection,
 } from "./select.js";
 import { verifyIrFunction } from "./verify.js";
+import { prepareIrRuntimeManifest, type PreparedIrRuntimeManifest } from "./intrinsic-support.js";
+import { isIntrinsicId, type IntrinsicId } from "./intrinsics.js";
+import { materializePreparedMathProviders, preparedMathProviderIndex } from "./math-runtime-providers.js";
+import type { RuntimeProviderPlan } from "./runtime-manifest.js";
 import { AllocSiteRegistry, ALLOC_NAMESPACES } from "./alloc-registry.js";
 import { analyzeEncoding } from "./analysis/encoding.js";
 import { assertAllocProvenance } from "./verify-alloc.js";
@@ -365,6 +369,36 @@ interface BuiltFn {
   readonly classMember?: boolean;
   /** True when the artifact patches the exact module-initializer slot. */
   readonly moduleInit?: boolean;
+}
+
+function prepareBuiltFnRuntimeManifest(
+  ctx: CodegenContext,
+  sourceFile: string,
+  entries: readonly BuiltFn[],
+): { readonly entries: readonly BuiltFn[]; readonly runtime?: PreparedIrRuntimeManifest } {
+  const runtime = prepareIrRuntimeManifest({
+    functions: entries.map((entry) => entry.fn),
+    sourceFile,
+    policy: {
+      target: ctx.wasi ? "wasi" : ctx.standalone ? "standalone" : ctx.strictNoHostImports ? "strict-no-host" : "host",
+      backend: "wasmgc",
+    },
+  });
+  if (!runtime) return { entries };
+  const preparedByUnitId = new Map(runtime.functions.map((fn) => [fn.unitId, fn] as const));
+  const preparedEntries = entries.map((entry) => {
+    const fn = preparedByUnitId.get(entry.artifactUnitId);
+    if (!fn) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `runtime-manifest preparation lost artifact ${entry.artifactUnitId} / ${entry.name}`,
+      );
+    }
+    return fn === entry.fn ? entry : { ...entry, fn };
+  });
+  materializePreparedMathProviders(ctx, runtime);
+  return { entries: preparedEntries, runtime };
 }
 
 function planDependencyBlockingCallableProviders(
@@ -1972,8 +2006,18 @@ export function compileIrPathFunctions(
       return false;
     }
   };
+  let preparedRuntimeManifest: PreparedIrRuntimeManifest | undefined;
   if (!runGlobalPreparation(() => (healthyForLower = prepareStrings(ctx, healthyForLower)))) return finishReport();
   if (!runGlobalPreparation(() => (healthyForLower = prepareVectors(ctx, healthyForLower)))) return finishReport();
+  if (
+    !runGlobalPreparation(() => {
+      const prepared = prepareBuiltFnRuntimeManifest(ctx, sourceFile.fileName, healthyForLower);
+      preparedRuntimeManifest = prepared.runtime;
+      healthyForLower = [...prepared.entries];
+    })
+  ) {
+    return finishReport();
+  }
   if (!runGlobalPreparation(() => preregisterHostDateSnapshotSupport(ctx, healthyForLower))) {
     return finishReport();
   }
@@ -2028,7 +2072,11 @@ export function compileIrPathFunctions(
   ) {
     return finishReport();
   }
-  recordOwnerPreparationFailures(failures, failedOwners, preregisterCallableProviders(ctx, healthyForLower));
+  recordOwnerPreparationFailures(
+    failures,
+    failedOwners,
+    preregisterCallableProviders(ctx, healthyForLower, preparedRuntimeManifest?.providers),
+  );
   healthyForLower = retainHealthyOwners(healthyForLower);
   if (healthyForLower.length === 0) return finishReport();
   const importedCallableCatalog = catalogProgramAbiCallableImports(ctx);
@@ -2369,6 +2417,7 @@ export function compileIrPathFunctions(
       deferredClass,
       unitCallableSlots,
       importedCallableCatalog,
+      preparedRuntimeManifest?.providers,
     );
     const resolverInjection = process.env.JS2WASM_TEST_INJECT_IR_RESOLVER_FAILURE;
     if (resolverInjection === "function") resolver.resolveFunc(irIntrinsicFuncRef("__injected_missing_func"));
@@ -3875,7 +3924,11 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
   };
 }
 
-function resolveAndObserveCallableProvider(ctx: CodegenContext, ref: IrFuncRef): number {
+function resolveAndObserveCallableProvider(
+  ctx: CodegenContext,
+  ref: IrFuncRef,
+  runtimeProviders?: ReadonlyMap<IntrinsicId, RuntimeProviderPlan>,
+): number {
   if (ref.binding.kind !== "runtime" && ref.binding.kind !== "intrinsic") {
     throw new TypeError("callable-provider resolution requires a runtime or intrinsic reference");
   }
@@ -3885,7 +3938,24 @@ function resolveAndObserveCallableProvider(ctx: CodegenContext, ref: IrFuncRef):
 
   let index: number | null | undefined;
   const { symbol } = ref.binding;
-  if (ref.binding.kind === "intrinsic" && symbol === FMOD_FN) {
+  if (ref.binding.kind === "intrinsic" && isIntrinsicId(symbol)) {
+    const provider = runtimeProviders?.get(symbol);
+    if (!provider || provider.implementation.kind !== "self-hosted") {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `semantic intrinsic ${symbol} has no frozen callable provider`,
+      );
+    }
+    if (ref.name !== provider.implementation.symbol) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `semantic intrinsic ${symbol} changed provider from ${provider.implementation.symbol} to ${ref.name}`,
+      );
+    }
+    index = preparedMathProviderIndex(ctx, provider.implementation.symbol);
+  } else if (ref.binding.kind === "intrinsic" && symbol === FMOD_FN) {
     index = ensureFmod(ctx);
   } else if (ref.binding.kind === "intrinsic" && symbol.startsWith(IR_VEC_ELEM_SET_PREFIX)) {
     const element = parseIrVectorRuntimeElement(symbol, IR_VEC_ELEM_SET_PREFIX);
@@ -4001,6 +4071,7 @@ function makeResolver(
   classResolver: DeferredClassResolver,
   unitCallableSlots: ReadonlyMap<IrUnitId, IrUnitCallableSlot>,
   importedCallableCatalog: ReadonlyMap<string, Import>,
+  runtimeProviders?: ReadonlyMap<IntrinsicId, RuntimeProviderPlan>,
 ): IrLowerResolver {
   // (#2949 slice 3) One dynamic-lowering handle per resolver (undefined =
   // not yet built; null = mode has no dynamic op lowering).
@@ -4073,7 +4144,7 @@ function makeResolver(
         );
       }
       if (ref.binding.kind === "runtime" || ref.binding.kind === "intrinsic") {
-        return resolveAndObserveCallableProvider(ctx, ref);
+        return resolveAndObserveCallableProvider(ctx, ref, runtimeProviders);
       }
       const adapterName = ref.binding.kind === "import" ? ref.binding.field : ref.name;
       const idx = ctx.funcMap.get(adapterName);
@@ -4397,6 +4468,8 @@ function callableProviderRef(instr: IrInstr): IrFuncRef | undefined {
   switch (instr.kind) {
     case "call":
       return instr.target;
+    case "intrinsic":
+      return instr.provider?.kind === "callable" ? instr.provider.target : undefined;
     case "closure.new":
       return instr.liftedFunc;
     case "class.call":
@@ -4422,6 +4495,7 @@ function callableProviderRef(instr: IrInstr): IrFuncRef | undefined {
 function preregisterCallableProviders(
   ctx: CodegenContext,
   fns: readonly BuiltFnRef[],
+  runtimeProviders?: ReadonlyMap<IntrinsicId, RuntimeProviderPlan>,
 ): ReadonlyMap<IrUnitId, IrOwnerPreparationFailure> {
   const failures = new Map<IrUnitId, IrOwnerPreparationFailure>();
   const owners = new Map<IrUnitId, IrLegacyUnitProjectionEntry>();
@@ -4447,7 +4521,7 @@ function preregisterCallableProviders(
           const ref = callableProviderRef(instr);
           if (!ref || (ref.binding.kind !== "runtime" && ref.binding.kind !== "intrinsic")) return;
           try {
-            resolveAndObserveCallableProvider(ctx, ref);
+            resolveAndObserveCallableProvider(ctx, ref, runtimeProviders);
           } catch (error) {
             if (!failures.has(owner.unitId)) {
               failures.set(owner.unitId, { owner, outcome: classifyIrFailure(error, "resolve") });

--- a/src/ir/intrinsic-support.ts
+++ b/src/ir/intrinsic-support.ts
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { irIntrinsicFuncRef, sameIrCallableBinding } from "./callable-bindings.js";
+import { intrinsicEffectEvidence, INTRINSIC_DEFINITIONS } from "./intrinsics.js";
+import {
+  forEachInstrDeep,
+  irTypeEquals,
+  mapNestedBuffers,
+  type IrFunction,
+  type IrInstr,
+  type IrInstrIntrinsic,
+  type IrIntrinsicProvider,
+  type IrType,
+  type IrValueId,
+} from "./nodes.js";
+import {
+  RuntimeManifestBuilder,
+  type FrozenRuntimeManifest,
+  type RuntimeManifestPolicy,
+  type RuntimeProviderPlan,
+} from "./runtime-manifest.js";
+
+export interface PreparedIrRuntimeManifest {
+  readonly functions: readonly IrFunction[];
+  readonly manifest: FrozenRuntimeManifest;
+  /** Lookup-only handle retained after freeze for verifier/lowering adapters. */
+  readonly providers: ReadonlyMap<IrInstrIntrinsic["id"], RuntimeProviderPlan>;
+}
+
+/** Verify the closed semantic signature and any post-freeze provider binding. */
+export function verifyIrIntrinsicInstruction(
+  instr: IrInstrIntrinsic,
+  typeOf: ReadonlyMap<IrValueId, IrType>,
+): readonly string[] {
+  const errors: string[] = [];
+  const definition = INTRINSIC_DEFINITIONS[instr.id];
+  if (instr.version !== definition.signature.version) {
+    errors.push(`${instr.id} uses signature v${instr.version}; expected v${definition.signature.version}`);
+  }
+  if (instr.args.length !== definition.signature.params.length) {
+    errors.push(`${instr.id} expects ${definition.signature.params.length} argument(s), got ${instr.args.length}`);
+  }
+  for (let index = 0; index < instr.args.length && index < definition.signature.params.length; index++) {
+    const actual = typeOf.get(instr.args[index]!);
+    const expected = definition.signature.params[index]!;
+    if (actual && !irTypeEquals(actual, expected)) {
+      errors.push(`${instr.id} argument ${index} does not match its v${instr.version} signature`);
+    }
+  }
+  if (!instr.resultType || !irTypeEquals(instr.resultType, definition.signature.result)) {
+    errors.push(`${instr.id} result does not match its v${instr.version} signature`);
+  }
+  if (
+    instr.provider?.kind === "callable" &&
+    (instr.provider.target.binding.kind !== "intrinsic" || instr.provider.target.binding.symbol !== instr.id)
+  ) {
+    errors.push(`${instr.id} callable provider must retain the semantic intrinsic binding`);
+  }
+  return errors;
+}
+
+function mapArray<T>(values: readonly T[], map: (value: T) => T): readonly T[] {
+  let changed = false;
+  const mapped = values.map((value) => {
+    const next = map(value);
+    changed ||= next !== value;
+    return next;
+  });
+  return changed ? mapped : values;
+}
+
+function valueTypesOf(fn: IrFunction): ReadonlyMap<IrValueId, IrType> {
+  const result = new Map<IrValueId, IrType>();
+  for (const param of fn.params) result.set(param.value, param.type);
+  for (const block of fn.blocks) {
+    for (let index = 0; index < block.blockArgs.length; index++) {
+      const type = block.blockArgTypes[index];
+      if (type) result.set(block.blockArgs[index]!, type);
+    }
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.result !== null && instr.resultType) result.set(instr.result, instr.resultType);
+      });
+    }
+  }
+  return result;
+}
+
+function providerAttachment(id: IrInstrIntrinsic["id"], provider: RuntimeProviderPlan): IrIntrinsicProvider {
+  if (provider.implementation.kind === "backend-op") {
+    return Object.freeze({ kind: "backend-op", opcode: provider.implementation.opcode });
+  }
+  return Object.freeze({
+    kind: "callable",
+    // Structural identity remains the semantic ID. The compatibility name is
+    // the selected concrete provider spelling used by the existing registry.
+    target: irIntrinsicFuncRef(id, provider.implementation.symbol),
+  });
+}
+
+function sameProvider(left: IrIntrinsicProvider, right: IrIntrinsicProvider): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "backend-op" && right.kind === "backend-op") return left.opcode === right.opcode;
+  return (
+    left.kind === "callable" &&
+    right.kind === "callable" &&
+    sameIrCallableBinding(left.target.binding, right.target.binding) &&
+    left.target.name === right.target.name
+  );
+}
+
+function attachProviders(
+  fn: IrFunction,
+  providers: ReadonlyMap<IrInstrIntrinsic["id"], RuntimeProviderPlan>,
+): IrFunction {
+  const mapBuffer = (buffer: readonly IrInstr[]): readonly IrInstr[] => mapArray(buffer, mapInstr);
+  const mapInstr = (instr: IrInstr): IrInstr => {
+    const nested = mapNestedBuffers(instr, mapBuffer);
+    if (nested.kind !== "intrinsic") return nested;
+    const provider = providers.get(nested.id);
+    if (!provider) throw new Error(`IR intrinsic ${nested.id} is absent from the frozen runtime manifest`);
+    const attachment = providerAttachment(nested.id, provider);
+    if (nested.provider) {
+      if (!sameProvider(nested.provider, attachment)) {
+        throw new Error(`IR intrinsic ${nested.id} already carries a different prepared provider`);
+      }
+      return nested;
+    }
+    return { ...nested, provider: attachment };
+  };
+
+  const blocks = mapArray(fn.blocks, (block) => {
+    const instrs = mapBuffer(block.instrs);
+    return instrs === block.instrs ? block : { ...block, instrs };
+  });
+  return blocks === fn.blocks ? fn : { ...fn, blocks };
+}
+
+/**
+ * Collect semantic intrinsic uses, freeze their complete provider graph, and
+ * attach lookup-only provider choices to final IR. This is deliberately after
+ * inference and middle-end transforms and before Program-ABI component seal.
+ */
+export function prepareIrRuntimeManifest(input: {
+  readonly functions: readonly IrFunction[];
+  readonly sourceFile: string;
+  readonly policy: RuntimeManifestPolicy;
+}): PreparedIrRuntimeManifest | undefined {
+  const uses: Array<{ readonly instr: IrInstrIntrinsic; readonly argumentTypes: readonly IrType[] }> = [];
+  for (const fn of input.functions) {
+    const valueTypes = valueTypesOf(fn);
+    for (const block of fn.blocks) {
+      for (const root of block.instrs) {
+        forEachInstrDeep(root, (instr) => {
+          if (instr.kind !== "intrinsic") return;
+          const argumentTypes = instr.args.map((arg) => {
+            const type = valueTypes.get(arg);
+            if (!type) throw new Error(`IR intrinsic ${instr.id} references an untyped SSA value ${arg}`);
+            return type;
+          });
+          uses.push({ instr, argumentTypes });
+        });
+      }
+    }
+  }
+  if (uses.length === 0) return undefined;
+
+  const builder = new RuntimeManifestBuilder(input.policy);
+  for (const { instr, argumentTypes } of uses) {
+    const definition = INTRINSIC_DEFINITIONS[instr.id];
+    if (!instr.resultType || !irTypeEquals(instr.resultType, definition.signature.result)) {
+      throw new Error(`IR intrinsic ${instr.id} has a result outside its semantic signature`);
+    }
+    builder.addIntrinsicUse(
+      {
+        id: instr.id,
+        version: instr.version,
+        argumentTypes,
+        resultType: instr.resultType,
+        location: {
+          file: input.sourceFile,
+          line: instr.site?.line ?? 1,
+          column: instr.site?.column ?? 0,
+        },
+      },
+      intrinsicEffectEvidence(instr),
+    );
+  }
+  const manifest = builder.freeze();
+  const providers = new Map<IrInstrIntrinsic["id"], RuntimeProviderPlan>();
+  for (const use of manifest.intrinsicUses) {
+    providers.set(use.id, builder.resolveProvider(INTRINSIC_DEFINITIONS[use.id].feature));
+  }
+  return Object.freeze({
+    functions: Object.freeze(input.functions.map((fn) => attachProviders(fn, providers))),
+    manifest,
+    providers,
+  });
+}

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -66,6 +66,7 @@ import {
   type IrFunction,
   type IrGlobalRef,
   type IrInstr,
+  type IrInstrIntrinsic,
   type IrLabelId,
   type IrObjectShape,
   type IrStringLengthProvider,
@@ -346,6 +347,26 @@ export interface IrLoweredBody<S, Slot> {
   readonly locals: readonly IrLoweredValue<Slot>[];
   readonly results: readonly (readonly Slot[])[];
   readonly exported: boolean;
+}
+
+function emitPreparedIntrinsic<S>(
+  instr: IrInstrIntrinsic,
+  out: S,
+  emitter: BackendEmitter<S>,
+  resolver: IrLowerResolver,
+  emitValue: (value: IrValueId, out: S) => void,
+  funcName: string,
+): void {
+  for (const arg of instr.args) emitValue(arg, out);
+  if (!instr.provider) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "lower",
+      `ir/lower: semantic intrinsic ${instr.id} has no frozen provider (${funcName})`,
+    );
+  }
+  if (instr.provider.kind === "backend-op") emitter.emitUnary(instr.provider.opcode, out);
+  else emitter.emitCall(resolver.resolveFunc(instr.provider.target), out);
 }
 
 /**
@@ -1246,6 +1267,10 @@ export function lowerIrFunctionBody<S, Slot>(
         // primitive — byte-identical {op:"call"} on WasmGC, OP.CALL on bytecode.
         for (const a of instr.args) emitValue(a, out);
         emitter.emitCall(resolver.resolveFunc(instr.target), out);
+        return;
+      }
+      case "intrinsic": {
+        emitPreparedIntrinsic(instr, out, emitter, resolver, emitValue, func.name);
         return;
       }
       case "global.get":
@@ -3428,6 +3453,8 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
     case "const":
       return [];
     case "call":
+      return instr.args;
+    case "intrinsic":
       return instr.args;
     case "global.get":
       return [];

--- a/src/ir/math-runtime-providers.ts
+++ b/src/ir/math-runtime-providers.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { CodegenContext } from "../codegen/context/types.js";
+import { definedFuncAt } from "../codegen/func-space.js";
+import { emitInlineMathFunctions } from "../codegen/math-helpers.js";
+import type { PreparedIrRuntimeManifest } from "./intrinsic-support.js";
+import { IrInvariantError } from "./outcomes.js";
+
+/** Resolve an exact already-materialized self-host Math provider definition. */
+export function preparedMathProviderIndex(ctx: CodegenContext, symbol: string): number | undefined {
+  const index = ctx.funcMap.get(symbol);
+  if (index === undefined || index < ctx.numImportFuncs) return undefined;
+  return definedFuncAt(ctx, index)?.name === symbol ? index : undefined;
+}
+
+/** Materialize only the self-host Math providers selected by a frozen manifest. */
+export function materializePreparedMathProviders(ctx: CodegenContext, prepared: PreparedIrRuntimeManifest): void {
+  const selfHosted = prepared.manifest.providers.flatMap((provider) =>
+    provider.implementation.kind === "self-hosted" ? [{ id: provider.id, symbol: provider.implementation.symbol }] : [],
+  );
+  if (selfHosted.some((provider) => preparedMathProviderIndex(ctx, provider.symbol) === undefined)) {
+    const methods = new Set(prepared.manifest.intrinsicUses.map((use) => use.id.slice("math.".length)));
+    emitInlineMathFunctions(ctx, methods);
+  }
+  for (const provider of selfHosted) {
+    if (preparedMathProviderIndex(ctx, provider.symbol) === undefined) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `runtime manifest provider ${provider.id} did not materialize ${provider.symbol}`,
+      );
+    }
+  }
+}

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -21,6 +21,7 @@ import type { IrBindingId, IrClassId, IrFunctionIdentity, IrUnitId } from "./ide
 // nodes.ts stays free of value imports.
 import type { JsTag } from "./js-tag.js";
 import type { IrStringConcatMode, IrStringEncoding } from "./string-runtime.js";
+import type { IntrinsicId, IntrinsicSignatureVersion } from "./intrinsics.js";
 
 // ---------------------------------------------------------------------------
 // Symbolic references
@@ -686,6 +687,31 @@ export interface IrInstrCall extends IrInstrBase {
   readonly kind: "call";
   readonly target: IrFuncRef;
   readonly args: readonly IrValueId[];
+}
+
+/** Backend primitive choices available to the first semantic-intrinsic family. */
+export type IrIntrinsicBackendOp = "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.ceil" | "f64.trunc";
+
+/**
+ * Provider attachment selected after middle-end transforms and manifest
+ * freeze. Source/type lowering emits no provider; preparation attaches either
+ * a backend primitive or one exact symbolic callable.
+ */
+export type IrIntrinsicProvider =
+  | { readonly kind: "backend-op"; readonly opcode: IrIntrinsicBackendOp }
+  | { readonly kind: "callable"; readonly target: IrFuncRef };
+
+/**
+ * Versioned semantic intrinsic. Unlike `call`, this names source meaning, not
+ * a concrete runtime helper. The optional provider is a preparation artifact
+ * and must be present before backend lowering.
+ */
+export interface IrInstrIntrinsic extends IrInstrBase {
+  readonly kind: "intrinsic";
+  readonly id: IntrinsicId;
+  readonly version: IntrinsicSignatureVersion;
+  readonly args: readonly IrValueId[];
+  readonly provider?: IrIntrinsicProvider;
 }
 
 /** Read a global by symbolic reference. */
@@ -2604,6 +2630,7 @@ export interface IrInstrSwitch extends IrInstrBase {
 export type IrInstr =
   | IrInstrConst
   | IrInstrCall
+  | IrInstrIntrinsic
   | IrInstrGlobalGet
   | IrInstrGlobalSet
   | IrInstrBinary
@@ -2922,6 +2949,7 @@ export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInst
     // here — the single point that must know about every buffer.
     case "const":
     case "call":
+    case "intrinsic":
     case "global.get":
     case "global.set":
     case "binary":
@@ -3088,6 +3116,7 @@ export function mapNestedBuffers(
     // set as forEachNestedBuffer; the never-check enforces parity.)
     case "const":
     case "call":
+    case "intrinsic":
     case "global.get":
     case "global.set":
     case "binary":
@@ -3188,6 +3217,8 @@ export function directUses(instr: IrInstr): readonly IrValueId[] {
     case "class.alloc":
       return [];
     case "call":
+      return instr.args;
+    case "intrinsic":
       return instr.args;
     case "global.set":
       return [instr.value];

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -407,7 +407,8 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
     case "global.get":
     case "raw.wasm":
       return inst;
-    case "call": {
+    case "call":
+    case "intrinsic": {
       let changed = false;
       const newArgs: IrValueId[] = [];
       for (const a of inst.args) {

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -706,6 +706,7 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
     case "raw.wasm":
       return [];
     case "call":
+    case "intrinsic":
       return instr.args;
     case "global.set":
       return [instr.value];

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -574,6 +574,10 @@ function implicitSupportRequirement(instr: IrInstr): string | null {
       return `${instr.kind} resolves async runtime support without explicit symbolic refs`;
     case "const":
     case "call":
+    case "intrinsic":
+      return instr.kind === "intrinsic" && !instr.provider
+        ? `${instr.kind} has no provider from the frozen runtime manifest`
+        : null;
     case "global.get":
     case "global.set":
     case "unary":
@@ -866,6 +870,10 @@ function collectFunctionEvidence(
             );
           } else {
             recordExternalCallable(evidence, nested.target, input.abi, ownership);
+          }
+        } else if (nested.kind === "intrinsic") {
+          if (nested.provider?.kind === "callable") {
+            recordExternalCallable(evidence, nested.provider.target, input.abi, ownership);
           }
         } else if (nested.kind === "closure.new") {
           if (nested.liftedFunc.binding.kind === "unit") {

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -9,7 +9,7 @@
  * frozen arrays/records. Lowering receives lookup-only `resolveProvider` calls;
  * a request absent from the frozen plan is a typed invariant.
  */
-import { irTypeEquals } from "./nodes.js";
+import { irTypeEquals, type IrIntrinsicBackendOp } from "./nodes.js";
 import {
   F64_BINARY_INTRINSIC_SIGNATURE,
   F64_UNARY_INTRINSIC_SIGNATURE,
@@ -56,7 +56,7 @@ export type RuntimeProviderId = (typeof PURE_MATH_RUNTIME_PROVIDER_IDS)[number];
 export type RuntimeProviderImplementation =
   | {
       readonly kind: "backend-op";
-      readonly opcode: "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.ceil" | "f64.trunc";
+      readonly opcode: IrIntrinsicBackendOp;
     }
   | {
       readonly kind: "self-hosted";

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -87,6 +87,7 @@ import type {
 } from "./module-bindings.js";
 import type { LatticeType, TypeMap } from "./propagate.js";
 import type { RecursiveTypeEvidence } from "./type-evidence.js";
+import type { IntrinsicId } from "./intrinsics.js";
 
 /**
  * #1169q telemetry — record why a top-level FunctionDeclaration didn't make
@@ -206,30 +207,32 @@ function takeShapeRejectDetail(): string | undefined {
 export type IrMathMethodPlan =
   | {
       readonly arity: 1;
+      readonly intrinsic: IntrinsicId;
       readonly op: "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.ceil" | "f64.trunc";
     }
-  | { readonly arity: 1 | 2; readonly helper: `Math_${string}` };
+  | { readonly arity: 1 | 2; readonly intrinsic: IntrinsicId };
 
 /**
  * Exact-arity Math surface shared by selection, call-graph closure, and the
- * AST→IR builder. Direct Wasm unary operations stay direct; transcendental
- * functions call the already-registered self-hosted `Math_<method>` helper.
- * Keeping arity in this table prevents selector/builder drift and preserves
- * ambient-Math identity checks at each consumer.
+ * AST→IR builder. Every accepted method becomes a versioned semantic
+ * intrinsic. `op` remains only as a selector compatibility signal for the
+ * five methods that never require a callable provider; provider selection is
+ * performed after middle-end transforms. Keeping arity here prevents
+ * selector/builder drift and preserves ambient-Math identity checks.
  */
 export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = {
-  abs: { arity: 1, op: "f64.abs" },
-  sqrt: { arity: 1, op: "f64.sqrt" },
-  floor: { arity: 1, op: "f64.floor" },
-  ceil: { arity: 1, op: "f64.ceil" },
-  trunc: { arity: 1, op: "f64.trunc" },
-  sin: { arity: 1, helper: "Math_sin" },
-  cos: { arity: 1, helper: "Math_cos" },
-  exp: { arity: 1, helper: "Math_exp" },
-  log: { arity: 1, helper: "Math_log" },
-  log2: { arity: 1, helper: "Math_log2" },
-  pow: { arity: 2, helper: "Math_pow" },
-  atan2: { arity: 2, helper: "Math_atan2" },
+  abs: { arity: 1, intrinsic: "math.abs", op: "f64.abs" },
+  sqrt: { arity: 1, intrinsic: "math.sqrt", op: "f64.sqrt" },
+  floor: { arity: 1, intrinsic: "math.floor", op: "f64.floor" },
+  ceil: { arity: 1, intrinsic: "math.ceil", op: "f64.ceil" },
+  trunc: { arity: 1, intrinsic: "math.trunc", op: "f64.trunc" },
+  sin: { arity: 1, intrinsic: "math.sin" },
+  cos: { arity: 1, intrinsic: "math.cos" },
+  exp: { arity: 1, intrinsic: "math.exp" },
+  log: { arity: 1, intrinsic: "math.log" },
+  log2: { arity: 1, intrinsic: "math.log2" },
+  pow: { arity: 2, intrinsic: "math.pow" },
+  atan2: { arity: 2, intrinsic: "math.atan2" },
 };
 
 /** Compatibility view for callers/tests that only need the method names. */

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -27,6 +27,7 @@ import type { ValType } from "./types.js";
 // (payload-kind consistency of unbox/tag.test on `dynamic` values). Imported
 // from the dependency-free leaf, so this adds no codegen module-graph pull.
 import { JsTag, jsTagUnboxKind } from "./js-tag.js";
+import { verifyIrIntrinsicInstruction } from "./intrinsic-support.js";
 
 /**
  * #1850 — successor block ids of a block, derived from its terminator.
@@ -1058,6 +1059,8 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
       return [];
     case "call":
       return instr.args;
+    case "intrinsic":
+      return instr.args;
     case "global.get":
       return [];
     case "global.set":
@@ -1512,6 +1515,12 @@ function verifyInstrTypeRules(func: IrFunction, typeOf: ReadonlyMap<IrValueId, I
 
   const checkInstr = (instr: IrInstr, blockId: number): void => {
     switch (instr.kind) {
+      case "intrinsic": {
+        for (const message of verifyIrIntrinsicInstruction(instr, typeOf)) {
+          errors.push({ message, func: func.name, block: blockId });
+        }
+        break;
+      }
       case "binary": {
         const want = binopOperandKind(instr.op);
         for (const [label, v] of [

--- a/tests/issue-3526-ir-linear-math-intrinsics.test.ts
+++ b/tests/issue-3526-ir-linear-math-intrinsics.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { verifyIrBackendLegality } from "../src/ir/backend/legality.js";
+import { IrFunctionBuilder } from "../src/ir/builder.js";
+import { type IntrinsicId, PURE_MATH_INTRINSIC_IDS } from "../src/ir/intrinsics.js";
+import { irVal, type IrFunction } from "../src/ir/nodes.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-3526-ir-linear-math-intrinsics");
+const F64 = irVal({ kind: "f64" });
+const LINEAR_BACKEND_OP_INTRINSICS = [
+  "math.abs",
+  "math.ceil",
+  "math.floor",
+  "math.sqrt",
+  "math.trunc",
+] as const satisfies readonly IntrinsicId[];
+
+function intrinsicFunction(id: IntrinsicId): IrFunction {
+  const builder = new IrFunctionBuilder(identities.next(id.replace(".", "_")), [F64], true);
+  const left = builder.addParam("left", F64);
+  const right = builder.addParam("right", F64);
+  builder.openBlock();
+  const result = builder.emitIntrinsic(id, id === "math.atan2" || id === "math.pow" ? [left, right] : [left]);
+  builder.terminate({ kind: "return", values: [result] });
+  return builder.finish();
+}
+
+describe("#3526 linear semantic Math intrinsic legality", () => {
+  it("admits exactly the five semantic intrinsics backed by native linear f64 operations", () => {
+    const admitted = PURE_MATH_INTRINSIC_IDS.filter(
+      (id) => verifyIrBackendLegality(intrinsicFunction(id), "linear").length === 0,
+    );
+
+    expect(admitted).toStrictEqual(LINEAR_BACKEND_OP_INTRINSICS);
+  });
+
+  it("rejects every callable-backed Math intrinsic at the linear boundary", () => {
+    const callableBacked = PURE_MATH_INTRINSIC_IDS.filter(
+      (id) => !LINEAR_BACKEND_OP_INTRINSICS.includes(id as (typeof LINEAR_BACKEND_OP_INTRINSICS)[number]),
+    );
+
+    for (const id of callableBacked) {
+      expect(verifyIrBackendLegality(intrinsicFunction(id), "linear")).toContainEqual(
+        expect.objectContaining({
+          instr: "intrinsic",
+          message: expect.stringContaining(`does not support semantic intrinsic '${id}'`),
+        }),
+      );
+    }
+  });
+
+  it("leaves WasmGC backend legality unchanged for the complete certified family", () => {
+    for (const id of PURE_MATH_INTRINSIC_IDS) {
+      expect(verifyIrBackendLegality(intrinsicFunction(id), "wasmgc"), id).toStrictEqual([]);
+    }
+  });
+});

--- a/tests/issue-3526-ir-math-intrinsic-integration.test.ts
+++ b/tests/issue-3526-ir-math-intrinsic-integration.test.ts
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { IrFunctionBuilder } from "../src/ir/builder.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { PURE_MATH_INTRINSIC_IDS, type IntrinsicId } from "../src/ir/intrinsics.js";
+import { forEachInstrDeep, irVal, type IrFunction, type IrInstrIntrinsic } from "../src/ir/nodes.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+import { verifyIrFunction } from "../src/ir/verify.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+import { createTestIrFunctionIdentityFactory } from "./helpers/ir-identities.js";
+
+const identities = createTestIrFunctionIdentityFactory("issue-3526-ir-math-intrinsic-integration");
+const F64 = irVal({ kind: "f64" });
+const BACKEND_INTRINSICS = new Set<IntrinsicId>(["math.abs", "math.sqrt", "math.floor", "math.ceil", "math.trunc"]);
+
+const METHODS = PURE_MATH_INTRINSIC_IDS.map((id) => id.slice("math.".length));
+
+function intrinsicInstructions(fn: IrFunction): IrInstrIntrinsic[] {
+  const instructions: IrInstrIntrinsic[] = [];
+  for (const block of fn.blocks) {
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.kind === "intrinsic") instructions.push(instr);
+      });
+    }
+  }
+  return instructions;
+}
+
+function minimalResolver(): IrLowerResolver {
+  let nextType = 0;
+  return {
+    resolveFunc: () => 0,
+    resolveGlobal: () => {
+      throw new Error("resolveGlobal not used in this test");
+    },
+    resolveType: () => {
+      throw new Error("resolveType not used in this test");
+    },
+    internFuncType: () => nextType++,
+  };
+}
+
+function observedOutcome(result: CompileResult, name: string): IrObservedOutcome {
+  const outcome = result.irOutcomes?.find(
+    (candidate) => candidate.unitKind === "function" && candidate.displayName === name,
+  );
+  if (!outcome) throw new Error(`missing IR outcome for ${name}`);
+  return outcome;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, () => number>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, () => number>;
+  (imports as { setExports?: (value: Record<string, () => number>) => void }).setExports?.(exports);
+  return exports;
+}
+
+describe("#3526 M1 semantic Math intrinsic integration", () => {
+  it("keeps source meaning provider-free until the frozen manifest attaches exact providers", () => {
+    const analysis = analyzeSource(`
+      export function allMath(x: number, y: number): number {
+        return Math.abs(x) + Math.sqrt(x) + Math.floor(x) + Math.ceil(x) + Math.trunc(x)
+          + Math.sin(x) + Math.cos(x) + Math.exp(x) + Math.log(x) + Math.log2(x)
+          + Math.pow(x, y) + Math.atan2(x, y);
+      }
+    `);
+    const declaration = analysis.sourceFile.statements.find(ts.isFunctionDeclaration);
+    if (!declaration) throw new Error("missing allMath declaration");
+    const lowered = lowerFunctionAstToIr(declaration, {
+      ownerUnitId: identities.next("allMath").unitId,
+      exported: true,
+    }).main;
+    const semantic = intrinsicInstructions(lowered);
+
+    expect(semantic.map((instr) => instr.id).sort()).toEqual([...PURE_MATH_INTRINSIC_IDS].sort());
+    expect(semantic.every((instr) => instr.provider === undefined)).toBe(true);
+    expect(lowered.blocks.flatMap((block) => block.instrs).filter((instr) => instr.kind === "call")).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ target: { name: expect.stringMatching(/^Math_/) } })]),
+    );
+    expect(() => lowerIrFunctionToWasm(lowered, minimalResolver())).toThrowError(
+      /semantic intrinsic math\.abs has no frozen provider/,
+    );
+
+    const prepared = prepareIrRuntimeManifest({
+      functions: [lowered],
+      sourceFile: analysis.sourceFile.fileName,
+      policy: { target: "host", backend: "wasmgc" },
+    });
+    if (!prepared) throw new Error("expected a non-empty runtime manifest");
+    const instructions = intrinsicInstructions(prepared.functions[0]!);
+
+    expect(prepared.manifest.intrinsicUses.map((use) => use.id).sort()).toEqual([...PURE_MATH_INTRINSIC_IDS].sort());
+    for (const instr of instructions) {
+      if (BACKEND_INTRINSICS.has(instr.id)) {
+        expect(instr.provider).toMatchObject({ kind: "backend-op" });
+      } else {
+        expect(instr.provider).toMatchObject({
+          kind: "callable",
+          target: { binding: { kind: "intrinsic", symbol: instr.id }, name: `Math_${instr.id.slice(5)}` },
+        });
+      }
+    }
+    expect(verifyIrFunction(prepared.functions[0]!)).toEqual([]);
+    expect(() => lowerIrFunctionToWasm(prepared.functions[0]!, minimalResolver())).not.toThrow();
+  });
+
+  it("emits every certified method as an IR-only body with the established native and self-hosted providers", async () => {
+    const source = `
+      export function abs(): number { return Math.abs(-3.5); }
+      export function sqrt(): number { return Math.sqrt(144); }
+      export function floor(): number { return Math.floor(3.9); }
+      export function ceil(): number { return Math.ceil(3.1); }
+      export function trunc(): number { return Math.trunc(-3.9); }
+      export function sin(): number { return Math.sin(0.75); }
+      export function cos(): number { return Math.cos(0.75); }
+      export function exp(): number { return Math.exp(1.25); }
+      export function log(): number { return Math.log(3.5); }
+      export function log2(): number { return Math.log2(32); }
+      export function pow(): number { return Math.pow(2.5, 3); }
+      export function atan2(): number { return Math.atan2(1, -1); }
+    `;
+    const [ir, direct] = await Promise.all([
+      compile(source, {
+        fileName: "issue-3526-ir-math-intrinsics.ts",
+        emitWat: true,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      }),
+      compile(source, {
+        fileName: "issue-3526-direct-math-control.ts",
+        experimentalIR: false,
+      }),
+    ]);
+
+    expect(ir.success, ir.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(direct.success, direct.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(ir.binary)).toBe(true);
+    expect(ir.irPostClaimErrors ?? []).toEqual([]);
+    expect(ir.imports.filter((descriptor) => descriptor.name.startsWith("Math_"))).toEqual([]);
+    for (const method of METHODS) {
+      expect(observedOutcome(ir, method)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+    }
+
+    for (const opcode of ["f64.abs", "f64.sqrt", "f64.floor", "f64.ceil", "f64.trunc"]) {
+      expect(ir.wat).toContain(opcode);
+    }
+    for (const helper of ["sin", "cos", "exp", "log", "log2", "pow", "atan2"]) {
+      expect(ir.wat).toContain(`$Math_${helper}`);
+    }
+    expect(ir.wat).not.toContain("$__box_number");
+
+    const [irExports, directExports] = await Promise.all([instantiate(ir), instantiate(direct)]);
+    for (const method of METHODS) expect(irExports[method]!()).toBe(directExports[method]!());
+  });
+
+  it("keeps the builder closed over the versioned semantic signatures", () => {
+    const builder = new IrFunctionBuilder(identities.next("wrongArity"), [F64]);
+    builder.openBlock();
+    const x = builder.emitConst({ kind: "f64", value: 1 }, F64);
+    expect(() => builder.emitIntrinsic("math.pow", [x])).toThrowError(/expects 2 argument/);
+    builder.terminate({ kind: "return", values: [x] });
+    builder.finish();
+  });
+});


### PR DESCRIPTION
## Summary

This is the M1 production slice tracked in plan/issues/3526-ir-r6-semantic-runtime-contract.md and is stacked on ready PR #4037.

- Represent all twelve certified exact-f64 Math calls as versioned semantic IR intrinsics.
- Freeze the reachable provider graph after middle-end passes and attach lookup-only choices before prepared component sealing.
- Preserve native f64.abs, sqrt, floor, ceil, and trunc operations without boxing.
- Preserve the existing self-hosted Math_sin, Math_cos, Math_exp, Math_log, Math_log2, Math_pow, and Math_atan2 providers.
- Make linear IR admit only the five native operations and reject callable-backed intrinsics fail-closed.
- Remove the Prepared Math path dependency on frontend magic helper names and the pending-Math AST scan.

## Architecture

AST and type lowering now records source meaning only. Runtime provider selection happens from the frozen manifest after current passes. Unprepared or mismatched intrinsics are typed invariants before body publication. Self-hosted provider IR goes through the same preparation path recursively.

This does not widen selection, so the strict census remains 37 terminal units, 33 IR-emitted, 4 expected Unsupported, 0 invariants, and 35 legacy bodies. Non-Prepared and coercive Math shapes retain their direct route for later family retirement.

## Validation

- 153 Math, equivalence, symbol-coercion, self-host, and import-policy tests passed.
- 15 focused manifest, semantic-intrinsic, linear-legality, and production-routing tests passed.
- All twelve production functions report irBodyEmitted:true and legacyBodyEmitted:false.
- Zero Math host imports; native opcodes and established self-host helper reachability are asserted.
- Typecheck, lint, Prettier, IR fallback/readiness/adoption/optimization gates, LOC/function budgets, issue integrity, and pre-push checks passed.

Two broader issue-2856 assertions fail identically on pristine origin/main b310b3b3 and are unrelated to this slice: invalid annotated string initialization and one stale linear rejection-reason assertion.