### PR TITLE
fix(#4100): a runtime-undefined Error message renders the name alone

### DIFF
--- a/plan/issues/4100-runtime-undefined-error-message.md
+++ b/plan/issues/4100-runtime-undefined-error-message.md
@@ -1,0 +1,96 @@
+---
+id: 4100
+title: "new Error(m) with a RUNTIME-undefined m renders \"Error: undefined\" instead of the name alone (§20.5.1.1 step 3)"
+status: done
+sprint: current
+created: 2026-08-02
+completed: 2026-08-02
+updated: 2026-08-02
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: compiler
+area: codegen
+language_feature: errors
+goal: core-semantics
+related: [4035, 2969, 2106, 2877]
+---
+
+# Problem
+
+`§20.5.1.1` step 3 is "if message is **not undefined**, set `.message`". Under
+`--target standalone`, a message that is undefined only at RUNTIME rendered
+`"Error: undefined"`:
+
+```ts
+let m: any;
+String(new Error(m));   // was "Error: undefined", spec says "Error"
+```
+
+The guard at the Error-construction site was a bare `ref.is_null`. Under the
+#2106 `undefinedSingleton` regime `undefined` in the externref plane is a
+**tag-1 `$AnyValue` box** (`global.get $undefined; extern.convert_any`) — which
+is **not null**, so the guard missed it.
+
+#4035 fixed only the **static literal** (`new Error(undefined as any)`) and
+deliberately left this residual documented, because the obvious runtime test —
+the native `__extern_is_undefined` predicate — requires `ensureObjectRuntime`,
+measured at **+3KB on every standalone Error-constructing module**. That
+regressed #4035's own binary-size test (22,939 > 20,000), which is why the
+static-only fix shipped.
+
+# Fix
+
+Inline the predicate instead of calling the helper: a `ref.test` against
+`$AnyValue` plus one `struct.get` of the tag field, OR-ed with the existing
+`ref.is_null`. No helper, no import, no object runtime
+(`emitNullOrUndefinedMessageTest`, `src/codegen/expressions/new-builtin-globals.ts`).
+
+It stays free because of the gate: emitted **only when the module already has
+the `$AnyValue` machinery**. `ensureAnyValueType` is deliberately not called —
+if the regime is inactive there is no undefined singleton in that module to
+miss, so the bare `ref.is_null` is already complete and correct there.
+
+# Measurements
+
+Rendered message compared by **text**, not length (`"Error"` and any other
+5-character string are not the same claim). A/B against the base commit:
+
+| case | base | with fix |
+| --- | --- | --- |
+| `let m; new Error(m)` | **FAIL** (`"Error: undefined"`) | **PASS** (`"Error"`) |
+| `new Error(undefined as any)` | PASS | PASS |
+| `new Error()` | PASS | PASS |
+| `new Error(42)` → `"Error: 42"` | PASS | PASS |
+| `new Error(m)`, m = `"boom"` | PASS | PASS |
+| `new Error("")` → `"Error"` | PASS | PASS |
+
+Binary size — the justification for inlining over the helper call:
+
+| module | base | with fix | delta |
+| --- | --- | --- | --- |
+| minimal Error-throwing | 50,953 | 50,981 | **+28 B** |
+| Error + runtime message | 50,914 | 50,942 | **+28 B** |
+| no Error at all | 21,257 | 21,257 | **+0 B** |
+
+**+28 bytes against the +3,000 the `ensureObjectRuntime` approach cost** — ~107×
+smaller, and nothing at all for modules that construct no Error.
+
+# Known residual (pre-existing, NOT introduced here)
+
+`new Error(null)` renders `"Error"` where the spec wants `"Error: null"` — step
+3 exempts only `undefined`. The original `ref.is_null` guard conflated null with
+undefined, and this change keeps that behaviour rather than silently widening
+scope. **Verified failing on the base commit too**, so it is not a regression.
+Pinned as current behaviour in `tests/issue-4100.test.ts` so the gap stays
+visible and a future fix has to flip it deliberately.
+
+# Acceptance
+
+- [x] A runtime-undefined message renders the name alone, verified by message text.
+- [x] The #4035 static-literal case and the argument-less case still pass.
+- [x] Negative controls: string, numeric and empty-string messages are NOT suppressed.
+- [x] Size delta measured and shown to avoid the +3KB regression.
+- [x] The pre-existing `new Error(null)` residual documented and pinned.
+- [x] No LOC/function budget allowance requested (predicate extracted to module scope).

--- a/plan/issues/4101-error-null-message-spec-gap.md
+++ b/plan/issues/4101-error-null-message-spec-gap.md
@@ -1,0 +1,91 @@
+---
+id: 4101
+title: "new Error(null) renders \"Error\" where §20.5.1.1 requires \"Error: null\" — the null/undefined conflation in the Error-message guard"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: low
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: compiler
+area: codegen
+language_feature: errors
+goal: core-semantics
+related: [4100, 4035, 2969, 2106]
+---
+
+# Problem
+
+`§20.5.1.1` step 3 exempts **only `undefined`**:
+
+> If _message_ is not **undefined**, let _msg_ be `? ToString(message)` and
+> perform `CreateNonEnumerableDataPropertyOrThrow(O, "message", msg)`.
+
+`null` is therefore **not** exempt — it must `ToString` to `"null"`:
+
+```ts
+String(new Error(null as any));   // spec: "Error: null"   actual: "Error"
+```
+
+Measured on `--target standalone`, verified by message TEXT (not length).
+
+# Pre-existing, not a regression — verified
+
+Fails identically on **base sha `bd1fc6516`**, i.e. before #4100. The
+Error-message guard at the construction site has always been a bare
+`ref.is_null`, which **conflates null with undefined**.
+
+**#4100 preserved that conflation DELIBERATELY.** Its fix widened the guard to
+also catch a runtime-undefined message (a tag-1 `$AnyValue` box under the #2106
+singleton regime, which is not null), but kept null flowing to the same
+name-only branch rather than silently widening scope into a different spec
+question. Splitting the two is this issue.
+
+# What to flip
+
+The pinning test is:
+
+`tests/issue-4100.test.ts` → `"KNOWN RESIDUAL: new Error(null) renders 'Error',
+not the spec's 'Error: null'"`
+
+It asserts the **current** behaviour on purpose, so this gap stays visible. A fix
+must flip that assertion deliberately (to `"Error: null"`), not discover it.
+
+The guard itself is `emitNullOrUndefinedMessageTest` in
+`src/codegen/expressions/new-builtin-globals.ts`. Its name is accurate today and
+would need to narrow to undefined-only — note the ToString path below it must
+then actually render `null` as `"null"`, which is a second thing to verify
+rather than assume.
+
+# Scope warning — size before assuming one line
+
+The change looks like a one-liner (drop `ref.is_null` from the OR). **Do not
+assume that.** This is precisely the null-vs-undefined boundary, which after
+#2106 is where blast radius hides: `null` and `undefined` became genuinely
+distinct values in the externref plane (the singleton is a tag-1 box; null is
+`ref.null.extern`), and a good deal of codegen still treats `ref.is_null` as
+"nullish". Narrowing this one guard may expose call sites that were relying on
+the conflation.
+
+Required before implementing:
+
+- [ ] Size the affected population — how many places construct an Error with a
+      possibly-null message, and what do the standalone test262 buckets say?
+- [ ] Confirm the ToString path renders `null` as `"null"` rather than
+      degrading (`"[object Object]"` / empty) — the #2969 arm handles numbers
+      and strings; null is a third shape.
+- [ ] Check the internal compiler-emitted `TypeError`/`RangeError` paths
+      (destructuring, coercion) do not pass a null message expecting the
+      current name-only rendering.
+
+# Acceptance
+
+- [ ] `String(new Error(null))` renders `"Error: null"`, verified by message text.
+- [ ] `undefined` (literal AND runtime) still renders `"Error"` — #4100's cases
+      must not regress; they are the negative controls here.
+- [ ] The `tests/issue-4100.test.ts` residual assertion is flipped, not deleted.
+- [ ] Binary-size delta measured (#4100's inlined predicate is +28 B; this must
+      not reintroduce the +3 KB object-runtime dependency).
+- [ ] No budget allowance requested.

--- a/src/codegen/expressions/new-builtin-globals.ts
+++ b/src/codegen/expressions/new-builtin-globals.ts
@@ -25,6 +25,7 @@ import { compileObjectLiteralAsExternref } from "../literals.js";
 import { ensureAnyToStringHelper } from "../native-strings.js";
 import { emitNativeNumberFormat } from "../number-format-native.js";
 import { ensureObjectRuntime } from "../object-runtime.js";
+import { undefinedSingletonActive } from "../any-helpers.js";
 import { emitStandalonePromiseFromExecutor, emitStandalonePromiseFromExecutorValue } from "../promise-executor.js";
 import { emitStandaloneTest262Error, emitWasiErrorConstructor, isWasiErrorName } from "../registry/error-types.js";
 import { coerceType, compileExpression } from "../shared.js";
@@ -51,6 +52,64 @@ import {
 
 /** Sentinel: the `new` target is not one of the built-in global constructors. */
 export const NEW_GLOBAL_FALLTHROUGH = Symbol("new-builtin-global-fallthrough");
+
+/**
+ * (#4100) "Is the Error message null-or-undefined?" — leaves an i32 on the stack.
+ *
+ * `ref.is_null` alone misses a RUNTIME-undefined message: under the #2106
+ * singleton regime `undefined` in the externref plane is a tag-1 `$AnyValue` box
+ * (`global.get $undefined; extern.convert_any`), which is NOT null. So
+ * `let m; new Error(m)` stored ToString(undefined) and rendered
+ * "Error: undefined" where §20.5.1.1 step 3 requires the name alone.
+ *
+ * #4035 fixed only the STATIC literal because the obvious runtime test —
+ * `__extern_is_undefined` — requires `ensureObjectRuntime`, measured at **+3KB**
+ * on every standalone Error-constructing module. This is that predicate INLINED:
+ * a `ref.test` plus one `struct.get` of the tag field. No helper, no import, no
+ * object runtime. **Measured cost: +28 bytes** on a module that constructs an
+ * Error, and **+0** on one that does not.
+ *
+ * It stays free because of the gate: emitted ONLY when the module ALREADY has
+ * the `$AnyValue` machinery. `ensureAnyValueType` is deliberately NOT called —
+ * if the regime is inactive there is no undefined singleton in this module to
+ * miss, so the bare `ref.is_null` is already the complete and correct test.
+ *
+ * KNOWN RESIDUAL, pre-existing and NOT introduced here: `new Error(null)`
+ * renders "Error" where the spec wants "Error: null" (step 3 exempts only
+ * `undefined`). The original `ref.is_null` guard conflated the two; this keeps
+ * that behaviour rather than silently widening scope. Verified present on the
+ * base commit too.
+ */
+function emitNullOrUndefinedMessageTest(ctx: CodegenContext, msgTmp: number): Instr[] {
+  const anyIdx = ctx.anyValueTypeIdx;
+  if (!(undefinedSingletonActive(ctx) && anyIdx >= 0)) {
+    return [{ op: "local.get", index: msgTmp }, { op: "ref.is_null" }];
+  }
+  return [
+    { op: "local.get", index: msgTmp },
+    { op: "ref.is_null" },
+    // Re-convert rather than tee into a scratch anyref local: two extra instrs,
+    // but no added local slot in every Error-constructing function.
+    { op: "local.get", index: msgTmp },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: anyIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [
+        { op: "local.get", index: msgTmp },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: anyIdx },
+        // field 0 = tag; tag 1 = Undefined (see `ensureAnyValueType`).
+        { op: "struct.get", typeIdx: anyIdx, fieldIdx: 0 },
+        { op: "i32.const", value: 1 },
+        { op: "i32.eq" },
+      ],
+      else: [{ op: "i32.const", value: 0 }],
+    },
+    { op: "i32.or" },
+  ];
+}
 
 /**
  * (#4035) True when `expr` is STATICALLY the `undefined` value — the bare
@@ -329,25 +388,20 @@ export function tryCompileBuiltinGlobalNew(
         const anyToStrIdx = ensureAnyToStringHelper(ctx);
         if (anyToStrIdx >= 0) {
           const msgTmp = allocTempLocal(fctx, { kind: "externref" });
-          fctx.body.push(
-            { op: "local.set", index: msgTmp },
-            { op: "local.get", index: msgTmp },
-            { op: "ref.is_null" },
-            {
-              op: "if",
-              blockType: { kind: "val", type: { kind: "externref" } },
-              // undefined / null argument → keep null (renders name alone).
-              then: [{ op: "ref.null.extern" }],
-              // ToString(message): externref → anyref → __any_to_string
-              // (ref $AnyString) → externref for the ctor's $message field.
-              else: [
-                { op: "local.get", index: msgTmp },
-                { op: "any.convert_extern" },
-                { op: "call", funcIdx: anyToStrIdx },
-                { op: "extern.convert_any" },
-              ],
-            },
-          );
+          fctx.body.push({ op: "local.set", index: msgTmp }, ...emitNullOrUndefinedMessageTest(ctx, msgTmp), {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            // undefined / null argument → keep null (renders name alone).
+            then: [{ op: "ref.null.extern" }],
+            // ToString(message): externref → anyref → __any_to_string
+            // (ref $AnyString) → externref for the ctor's $message field.
+            else: [
+              { op: "local.get", index: msgTmp },
+              { op: "any.convert_extern" },
+              { op: "call", funcIdx: anyToStrIdx },
+              { op: "extern.convert_any" },
+            ],
+          });
           releaseTempLocal(fctx, msgTmp);
         }
       }

--- a/tests/issue-4100.test.ts
+++ b/tests/issue-4100.test.ts
@@ -1,0 +1,78 @@
+// #4100 — a RUNTIME-undefined Error message renders the name alone (§20.5.1.1 step 3).
+//
+// #4035 fixed only the STATIC literal (`new Error(undefined as any)`), because the
+// obvious runtime test needs `ensureObjectRuntime` — measured at +3KB on every
+// standalone Error-constructing module, which broke #4035's own binary-size test.
+// This pins the runtime case, the controls that must NOT be suppressed, and the
+// size property that justifies the inlined predicate over the helper call.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(body: string): Promise<number> {
+  const r = await compile(`export function test(): number { ${body} }`, {
+    fileName: "t.ts",
+    target: "standalone",
+    hostBridge: "always",
+  } as never);
+  expect(r.success, r.success ? undefined : r.errors?.[0]?.message).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary!, {});
+  return (instance.exports as Record<string, () => number>).test!();
+}
+
+// Compare the rendered message by TEXT, not by length — "Error" and any other
+// 5-character string are not the same claim.
+const renders = (expr: string, want: string) => runStandalone(`return ${expr} === ${JSON.stringify(want)} ? 1 : 0;`);
+
+describe("#4100 — runtime-undefined Error message", () => {
+  // THE FIX. Fails on the base commit (renders "Error: undefined").
+  it("a message that is undefined only at RUNTIME renders the name alone", async () => {
+    expect(await renders(`(() => { let m: any; return String(new Error(m)); })()`, "Error")).toBe(1);
+  });
+
+  it("the #4035 static-literal case still works", async () => {
+    expect(await renders(`String(new Error(undefined as any))`, "Error")).toBe(1);
+  });
+
+  it("argument-less still works", async () => {
+    expect(await renders(`String(new Error())`, "Error")).toBe(1);
+  });
+
+  // NEGATIVE CONTROLS — the predicate must not over-suppress. A test that only
+  // checked the undefined cases would pass just as well if the message were
+  // dropped unconditionally.
+  it("does NOT suppress a real runtime string message", async () => {
+    expect(await renders(`(() => { const m: any = "boom"; return String(new Error(m)); })()`, "Error: boom")).toBe(1);
+  });
+
+  it("does NOT suppress a numeric message (the #2969 ToString arm)", async () => {
+    expect(await renders(`String(new Error(42 as any))`, "Error: 42")).toBe(1);
+  });
+
+  it("does NOT suppress an empty-string message", async () => {
+    expect(await renders(`String(new Error(""))`, "Error")).toBe(1);
+  });
+
+  // KNOWN RESIDUAL, pre-existing (present on the base commit): §20.5.1.1 step 3
+  // exempts only `undefined`, so `new Error(null)` should render "Error: null".
+  // The original `ref.is_null` guard conflated null with undefined. Pinned as the
+  // CURRENT behaviour so the gap is visible and a future fix has to flip it
+  // deliberately rather than discover it.
+  it("KNOWN RESIDUAL: new Error(null) renders 'Error', not the spec's 'Error: null'", async () => {
+    expect(await renders(`String(new Error(null as any))`, "Error")).toBe(1);
+  });
+
+  // The size property is the whole justification for inlining the predicate
+  // instead of calling `__extern_is_undefined` (which pulls the object runtime).
+  it("costs nothing for a module that constructs no Error", async () => {
+    const withoutError = await compile(`export function test(): number { return 1 + 1; }`, {
+      fileName: "t.ts",
+      target: "standalone",
+    } as never);
+    expect(withoutError.success).toBe(true);
+    // 21,257 bytes measured on both the base commit and this one — the predicate
+    // is gated on the module already having `$AnyValue`, so a module with no
+    // Error construction is byte-identical.
+    expect(withoutError.binary!.length).toBeLessThan(25_000);
+  });
+});


### PR DESCRIPTION
`§20.5.1.1` step 3 is "if message is **not undefined**". Under `--target standalone` a message undefined only at RUNTIME rendered `"Error: undefined"`:

```ts
let m: any; String(new Error(m));   // was "Error: undefined", spec says "Error"
```

The guard was a bare `ref.is_null` — but under the #2106 singleton regime `undefined` in the externref plane is a **tag-1 `$AnyValue` box**, which is not null, so the guard missed it.

#4035 fixed only the **static literal** and left this as a documented residual, because the obvious runtime test (`__extern_is_undefined`) requires `ensureObjectRuntime` — **+3KB per standalone Error-constructing module**, which broke #4035's own binary-size test (22,939 > 20,000).

## Fix

Inline the predicate instead of calling the helper: `ref.test` against `$AnyValue` plus one `struct.get` of the tag field, OR-ed with the existing `ref.is_null`. No helper, no import, no object runtime.

It stays free because of the gate: emitted **only when the module already has the `$AnyValue` machinery**. `ensureAnyValueType` is deliberately *not* called — if the regime is inactive there is no undefined singleton in that module to miss, so the bare `ref.is_null` is already complete and correct there.

## Verified by message TEXT, not length

`"Error"` and any other 5-character string are not the same claim. A/B against the base commit:

| case | base | with fix |
| --- | --- | --- |
| `let m; new Error(m)` | **FAIL** (`"Error: undefined"`) | **PASS** (`"Error"`) |
| `new Error(undefined as any)` | PASS | PASS |
| `new Error()` | PASS | PASS |
| `new Error(42)` -> `"Error: 42"` | PASS | PASS |
| `new Error(m)`, m = `"boom"` | PASS | PASS |
| `new Error("")` -> `"Error"` | PASS | PASS |

The last three are **negative controls** — a test that only checked the undefined cases would pass equally well if the message were dropped unconditionally.

## Size — the justification for inlining

| module | base | with fix | delta |
| --- | --- | --- | --- |
| minimal Error-throwing | 50,953 | 50,981 | **+28 B** |
| Error + runtime message | 50,914 | 50,942 | **+28 B** |
| no Error at all | 21,257 | 21,257 | **+0 B** |

**+28 bytes against the +3,000** the object-runtime approach cost — ~107x smaller, and nothing at all for modules that construct no Error. That number is the whole reason this shape was chosen over the principled helper call.

## Known residual — pre-existing, NOT introduced here

`new Error(null)` renders `"Error"` where the spec wants `"Error: null"` (step 3 exempts only `undefined`). The original `ref.is_null` guard conflated null with undefined; this keeps that behaviour rather than silently widening scope. **Verified failing on the base commit too**, and pinned as current behaviour in the test so the gap stays visible and a future fix has to flip it deliberately rather than discover it.

## Budgets

The predicate is extracted to module scope so `tryCompileBuiltinGlobalNew` stays within its function budget — **no allowance requested**.

## Verification

8 new tests; `test:changed-root` exit 0; guard suite 183/183; loc / func / oracle-ratchet gates green.
