### PR TITLE
fix(perf): accelerate linear arrays and host substring

### DIFF
--- a/src/codegen-linear/array-pointer.ts
+++ b/src/codegen-linear/array-pointer.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { ts } from "../ts-api.js";
+import { ts as tsApi } from "../ts-api.js";
+import type { LinearContext, LinearFuncContext } from "./context.js";
+
+/**
+ * Compile an Array receiver to its current linear-memory header.
+ *
+ * Growing arrays leave forwarding headers so aliases remain valid. For a
+ * local identifier, cache the resolved pointer back into the local so later
+ * operations do not walk the full historical growth chain again.
+ */
+export function compileResolvedArrayPointer(
+  ctx: LinearContext,
+  fctx: LinearFuncContext,
+  expression: ts.Expression,
+  compileExpression: (ctx: LinearContext, fctx: LinearFuncContext, expression: ts.Expression) => void,
+): void {
+  compileExpression(ctx, fctx, expression);
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__arr_resolve")! });
+  if (tsApi.isIdentifier(expression)) {
+    const localIdx = fctx.localMap.get(expression.text);
+    if (localIdx !== undefined) fctx.body.push({ op: "local.tee", index: localIdx });
+  }
+}
+
+/** Push a local array's current header and retain it for the next operation. */
+export function emitResolvedArrayLocal(ctx: LinearContext, fctx: LinearFuncContext, localIdx: number): void {
+  fctx.body.push(
+    { op: "local.get", index: localIdx },
+    { op: "call", funcIdx: ctx.funcMap.get("__arr_resolve")! },
+    { op: "local.tee", index: localIdx },
+  );
+}

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -6,6 +6,7 @@ import type { FuncTypeDef, Instr, ValType, WasmModule } from "../ir/types.js";
 import { createEmptyModule } from "../ir/types.js";
 import { linearAllocatorPolicy, type LinearAllocatorPolicyId } from "../ir/analysis/linear-memory-plan.js";
 import * as linearIr from "../ir/backend/linear-integration.js";
+import { compileResolvedArrayPointer, emitResolvedArrayLocal } from "./array-pointer.js";
 import type { CollectionKind, FinallyEntry, LinearContext, LinearFuncContext } from "./context.js";
 import { addLocal } from "./context.js";
 import type { ClassLayout } from "./layout.js";
@@ -3139,8 +3140,8 @@ function compilePropertyAccess(ctx: LinearContext, fctx: LinearFuncContext, expr
   const objKind = getExprCollectionKind(ctx, fctx, expr.expression);
 
   if (propName === "length" && (objKind === "Array" || objKind === "Uint8Array" || objKind === "ArrayOrUint8Array")) {
-    // arr.length or u8.length → call __arr_len / __u8arr_len
-    compileExpression(ctx, fctx, expr.expression);
+    if (objKind === "Array") compileResolvedArrayPointer(ctx, fctx, expr.expression, compileExpression);
+    else compileExpression(ctx, fctx, expr.expression);
     if (objKind === "ArrayOrUint8Array") {
       // Runtime dispatch via tag byte
       const arrLenIdx = ctx.funcMap.get("__arr_len")!;
@@ -3282,7 +3283,7 @@ function compileElementAccess(ctx: LinearContext, fctx: LinearFuncContext, expr:
   if (objKind === "Array") {
     // arr[i] → __arr_get(arr, i) → f64 slot (#1938)
     const getIdx = ctx.funcMap.get("__arr_get")!;
-    compileExpression(ctx, fctx, expr.expression); // arr ptr (i32)
+    compileResolvedArrayPointer(ctx, fctx, expr.expression, compileExpression); // arr ptr (i32)
     compileExprToI32(ctx, fctx, expr.argumentExpression); // index → i32
     fctx.body.push({ op: "call", funcIdx: getIdx });
     // The slot is an f64 bit pattern. For a number/boolean element the slot IS
@@ -3386,7 +3387,7 @@ function compileElementAccessAssignment(
     const valLocal = addScratch({ kind: rightIsNumeric ? "f64" : "i32" });
     compileExpression(ctx, fctx, right); // value — evaluated once
     fctx.body.push({ op: "local.set", index: valLocal });
-    compileExpression(ctx, fctx, left.expression); // arr ptr (i32)
+    compileResolvedArrayPointer(ctx, fctx, left.expression, compileExpression); // arr ptr (i32)
     compileExprToI32(ctx, fctx, left.argumentExpression); // index → i32
     fctx.body.push({ op: "local.get", index: valLocal });
     if (!rightIsNumeric) {
@@ -3577,10 +3578,10 @@ function compileArrayMethodCall(
     const pushIdx = ctx.funcMap.get("__arr_push")!;
     const lenIdx = ctx.funcMap.get("__arr_len")!;
     const arrLocal = addLocal(fctx, `__push_arr_${fctx.locals.length}`, { kind: "i32" });
-    compileExpression(ctx, fctx, propAccess.expression); // arr ptr (i32)
+    compileResolvedArrayPointer(ctx, fctx, propAccess.expression, compileExpression); // arr ptr (i32)
     fctx.body.push({ op: "local.set", index: arrLocal });
     for (const arg of expr.arguments) {
-      fctx.body.push({ op: "local.get", index: arrLocal }); // arr ptr (i32)
+      emitResolvedArrayLocal(ctx, fctx, arrLocal);
       if (inferExprType(ctx, fctx, arg).kind === "f64") {
         compileExprToF64(ctx, fctx, arg); // numeric/boolean → f64 slot
       } else {
@@ -3673,8 +3674,7 @@ function compileArrayHOF(
   const resultType: ValType = method === "find" ? elemType : method === "some" ? { kind: "f64" } : { kind: "i32" };
   const resultLocal = addLocal(fctx, `__hof_result_${fctx.locals.length}`, resultType);
 
-  // Initialize: arrLocal = source array
-  compileExpression(ctx, fctx, propAccess.expression);
+  compileResolvedArrayPointer(ctx, fctx, propAccess.expression, compileExpression);
   fctx.body.push({ op: "local.set", index: arrLocal });
 
   // lenLocal = __arr_len(arrLocal)

--- a/src/codegen/char-code-at-helpers.ts
+++ b/src/codegen/char-code-at-helpers.ts
@@ -45,8 +45,97 @@ import { addFuncType } from "./registry/types.js";
 
 /** Reserved name for the host-mode guarded charCodeAt helper. */
 export const JSSTR_CHARCODEAT_FN = "__jsstr_charCodeAt";
+/** Reserved name for the host-mode spec-compatible substring helper. */
+export const JSSTR_SUBSTRING_FN = "__jsstr_substring";
 /** Reserved name for the native-mode guarded charCodeAt helper. */
 export const NATIVE_CHARCODEAT_FN = "__str_charCodeAt";
+
+/**
+ * Ensure a host-string substring helper backed by the engine's
+ * `wasm:js-string.substring` builtin.
+ *
+ * The builtin is deliberately lower-level than `String.prototype.substring`:
+ * its indices must already be in range and ordered. Keep the JavaScript
+ * semantics in Wasm (clamp both indices to `[0, length]`, then swap when
+ * `start > end`) and reserve the actual slicing operation for the engine
+ * builtin. This avoids an `env.string_substring` Wasm-to-JavaScript host call
+ * in every hot-loop iteration while preserving the observable contract.
+ */
+export function ensureHostSubstringGuarded(ctx: CodegenContext): number | null {
+  const existing = ctx.funcMap.get(JSSTR_SUBSTRING_FN);
+  if (existing !== undefined) return existing;
+
+  const substringIdx = ctx.jsStringImports.get("substring");
+  const lengthIdx = ctx.jsStringImports.get("length");
+  if (substringIdx === undefined || lengthIdx === undefined) return null;
+
+  const sigIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "i32" }, { kind: "i32" }], [{ kind: "externref" }]);
+  const funcIdx = mintDefinedFunc(ctx);
+
+  const S = 0;
+  const START = 1;
+  const END = 2;
+  const LEN = 3;
+  const clampParam = (index: number): Instr[] => [
+    { op: "local.get", index },
+    { op: "i32.const", value: 0 },
+    { op: "i32.lt_s" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index },
+      ],
+    },
+    { op: "local.get", index },
+    { op: "local.get", index: LEN },
+    { op: "i32.gt_s" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: LEN },
+        { op: "local.set", index },
+      ],
+    },
+  ];
+
+  const callSubstring = (start: number, end: number): Instr[] => [
+    { op: "local.get", index: S },
+    { op: "local.get", index: start },
+    { op: "local.get", index: end },
+    { op: "call", funcIdx: substringIdx },
+  ];
+
+  const body: Instr[] = [
+    { op: "local.get", index: S },
+    { op: "call", funcIdx: lengthIdx },
+    { op: "local.set", index: LEN },
+    ...clampParam(START),
+    ...clampParam(END),
+    { op: "local.get", index: START },
+    { op: "local.get", index: END },
+    { op: "i32.gt_s" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: callSubstring(END, START),
+      else: callSubstring(START, END),
+    },
+  ];
+
+  const fn: WasmFunction = {
+    name: JSSTR_SUBSTRING_FN,
+    typeIdx: sigIdx,
+    locals: [{ name: "$len", type: { kind: "i32" } }],
+    body,
+    exported: false,
+  };
+  pushDefinedFunc(ctx, funcIdx, fn);
+  ctx.funcMap.set(JSSTR_SUBSTRING_FN, funcIdx);
+  return funcIdx;
+}
 
 /**
  * Ensure the host-mode helper exists; returns its funcIdx, or `null` when the

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -493,8 +493,8 @@ export interface IrFromAstResolver {
    *     sentinel conventions incl. #1248 slice/substring-end + #2002
    *     NaN-position; `"native-slice-len"` = `slice(start)`'s implicit end =
    *     recv.length, i32-truncated; `"native-substring"` (#3156) = substring's
-   *     omitted start/end pad `i32 0` / `i32 0x7fffffff` — `__str_substring`
-   *     clamps end to len, matching the legacy native arm's sentinel;
+   *     omitted start/end pad `i32 0` / `i32 0x7fffffff` — both the native and
+   *     guarded host helpers clamp end to len;
    *     `"charcode-zero"` (#3156) = charCodeAt's omitted position pads
    *     `i32 0` in BOTH modes, since the guarded helpers take an i32 index).
    *
@@ -6643,9 +6643,9 @@ function lowerStringMethodCall(
       loweredArgs.push(cx.builder.emitConst({ kind: "i32", value: 0 }, irVal({ kind: "i32" })));
       continue;
     }
-    // (#3156) native substring — omitted start pads 0; omitted end pads the
-    // 0x7fffffff "to end" sentinel (`__str_substring` clamps to len; exactly
-    // the legacy native arm's convention, string-ops.ts `substring`).
+    // (#3156) i32 substring helpers — omitted start pads 0; omitted end pads
+    // the 0x7fffffff "to end" sentinel. Both the native helper and the guarded
+    // host builtin helper clamp it to len.
     if (plan.padOmitted === "native-substring") {
       loweredArgs.push(cx.builder.emitConst({ kind: "i32", value: i === 1 ? 0x7fffffff : 0 }, irVal({ kind: "i32" })));
       continue;

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -109,11 +109,12 @@ import {
   getOrCreateFuncRefWrapperTypes,
 } from "../codegen/closures/funcref-wrapper-types.js";
 import { ensureFmod, FMOD_FN } from "../codegen/fmod.js"; // #2945 — on-demand `%` helper materialization
-// (#3156) — on-demand guarded charCodeAt helper materialization
 import {
   ensureHostCharCodeAtGuarded,
+  ensureHostSubstringGuarded,
   ensureNativeCharCodeAtHelper,
   JSSTR_CHARCODEAT_FN,
+  JSSTR_SUBSTRING_FN,
   NATIVE_CHARCODEAT_FN,
 } from "../codegen/char-code-at-helpers.js";
 import {
@@ -3583,10 +3584,7 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
       const sig = STRING_METHOD_TABLE[method];
       if (!sig) return null;
       const omitted = argCount < sig.hostArgs.length;
-      // (#3156) substring — native `__str_substring` clamps both indices to
-      // [0, len], so omissions pad exact sentinels (start 0 / end 0x7fffffff,
-      // the legacy native arm's convention) and every arity lowers; host mode
-      // rides the #1248 length-default pad in from-ast.
+      // Both substring helpers take i32 indices and enforce JS clamp/swap semantics.
       if (method === "substring") {
         return native
           ? {
@@ -3595,9 +3593,9 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
               padOmitted: "native-substring" as const,
             }
           : {
-              funcName: "string_substring",
-              indexArgRep: "f64" as const,
-              padOmitted: "host" as const,
+              funcName: JSSTR_SUBSTRING_FN,
+              indexArgRep: "i32" as const,
+              padOmitted: "native-substring" as const,
             };
       }
       // #1248 — native mode only lowers fully-specified call sites, except
@@ -3901,6 +3899,8 @@ function resolveAndObserveCallableProvider(ctx: CodegenContext, ref: IrFuncRef):
     index = Number.isInteger(vecTypeIdx) ? ensureVecNewSized(ctx, vecTypeIdx) : null;
   } else if (ref.binding.kind === "intrinsic" && symbol === JSSTR_CHARCODEAT_FN) {
     index = ensureHostCharCodeAtGuarded(ctx);
+  } else if (ref.binding.kind === "intrinsic" && symbol === JSSTR_SUBSTRING_FN) {
+    index = ensureHostSubstringGuarded(ctx);
   } else if (ref.binding.kind === "intrinsic" && symbol === NATIVE_CHARCODEAT_FN) {
     index = ensureNativeCharCodeAtHelper(ctx);
   } else if (ref.binding.kind === "intrinsic" && symbol === IR_STRING_COMPARE_FN) {

--- a/tests/issue-3156.test.ts
+++ b/tests/issue-3156.test.ts
@@ -207,6 +207,23 @@ describe("#3156 IR string substring/charCodeAt — host mode", () => {
       expect(r.irPostClaimErrors).toEqual([]);
     });
   }
+
+  it("routes substring through the wasm:js-string builtin instead of an env host call", async () => {
+    const r = await compile(
+      `export function test(s: string): string {
+        return s.substring(1, 3);
+      }`,
+      { emitWat: true, optimize: 0 },
+    );
+
+    expect(r.success).toBe(true);
+    const moduleImports = WebAssembly.Module.imports(new WebAssembly.Module(r.binary));
+    expect(moduleImports).toContainEqual(
+      expect.objectContaining({ module: "wasm:js-string", name: "substring", kind: "function" }),
+    );
+    expect(moduleImports.some((imp) => imp.module === "env" && imp.name === "string_substring")).toBe(false);
+    expect(r.wat).toContain("(func $__jsstr_substring");
+  });
 });
 
 describe("#3156 IR string substring/charCodeAt — standalone (native strings)", () => {

--- a/tests/issue-3908.test.ts
+++ b/tests/issue-3908.test.ts
@@ -31,6 +31,14 @@ async function instantiateLinear(source: string) {
   return instance.exports as Record<string, Function>;
 }
 
+/** The body of one `(func $name …)` in the emitted WAT. */
+function funcBody(wat: string, name: string): string {
+  const start = wat.indexOf(`(func $${name} `);
+  expect(start, `no $${name} in the emitted module`).toBeGreaterThanOrEqual(0);
+  const next = wat.indexOf("\n  (func $", start + 1);
+  return wat.slice(start, next < 0 ? undefined : next);
+}
+
 describe("#3908 linear backend: Array.prototype.find result slot matches the element type", () => {
   it("validates and finds a match in a number[] (the reported repro)", async () => {
     const e = await instantiateLinear(`
@@ -134,5 +142,27 @@ export function run(): number {
     // ...so find's accumulator must be f64 too, never i32.
     expect(wat).toMatch(/\(local \$__hof_result_\d+ f64\)/);
     expect(wat).not.toMatch(/\(local \$__hof_result_\d+ i32\)/);
+  });
+
+  it("caches a resolved array parameter before scanning it", async () => {
+    const result = await compile(
+      `
+export function run(arr: number[]): number {
+  const found = arr.find((x: number): boolean => x === 7);
+  if (found !== undefined) return found;
+  return 0;
+}`,
+      { fast: true, target: "linear", emitWat: true, optimize: 0 },
+    );
+    expect(result.success).toBe(true);
+    const wat = result.wat ?? "";
+    const importedFunctionCount = [...wat.matchAll(/^ {2}\(import .+ \(func /gm)].length;
+    const definedFunctionNames = [...wat.matchAll(/^ {2}\(func \$([^\s(]+)/gm)].map((match) => match[1]);
+    const resolverOffset = definedFunctionNames.indexOf("__arr_resolve");
+    expect(resolverOffset, "no $__arr_resolve in the emitted module").toBeGreaterThanOrEqual(0);
+
+    const resolverIndex = importedFunctionCount + resolverOffset;
+    const run = funcBody(wat, "run");
+    expect(run).toMatch(new RegExp(`local\\.get 0\\s+call ${resolverIndex}\\s+local\\.tee 0`));
   });
 });


### PR DESCRIPTION
## Summary

- cache resolved linear-array forwarding pointers in local receivers, so repeated reads, writes, pushes, and higher-order scans start at the current allocation header
- route IR host-mode `String.prototype.substring` through a guarded `wasm:js-string.substring` helper instead of an `env.string_substring` JavaScript host call
- add structural regression coverage for both compiler paths

## Root cause

Growing linear-memory arrays retain forwarding headers so aliases remain valid, but compiler locals kept the original pointer. Every later accessor therefore re-walked the complete growth history. This made grown-array workloads such as `array/find` and matrix multiply disproportionately slow.

The host string lane lowered `substring` to an `env` import, crossing Wasm→JavaScript on every hot-loop call even though V8 exposes the equivalent `wasm:js-string.substring` builtin. The new Wasm helper preserves JavaScript clamp/swap behavior before invoking the builtin.

## Benchmarks

Local Node 24.4.1 on macOS arm64, three fresh-process interleaved A/B runs. Values are medians of the three harness medians.

| benchmark | base | optimized | improvement |
| --- | ---: | ---: | ---: |
| `array/find` linear | 2.048 ms | 0.438 ms | 4.68× faster |
| `mixed/matrix-multiply` linear | 0.807 ms | 0.301 ms | 2.68× faster |
| `string/substring` host | 0.455 ms | 0.274 ms | 1.66× faster |

Measured at base `bd1fc651` versus candidate `d2fa5cd1`; the patch rebased without conflict to this PR's current `10168616`.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test:changed-root` — 42 passed
- `pnpm run test:guard` — 183 passed, 4 skipped
- `pnpm run check:ir-fallbacks`
- oracle, LOC, function, coercion-site, formatting, and issue-integrity pre-push gates
