### PR TITLE
IR: define async runtime provider schema

### DIFF
--- a/plan/issues/4103-ir-async-runtime-provider-schema.md
+++ b/plan/issues/4103-ir-async-runtime-provider-schema.md
@@ -1,0 +1,87 @@
+---
+id: 4103
+title: "IR async runtime provider and host-capability schema"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: critical
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: ir, runtime
+language_feature: compiler-internals
+goal: ir-full-coverage
+lane: ir-retirement-r6
+parent: 3526
+related: [1042, 1373b, 3527]
+origin: "#3526 async schema slice after the pure-Math runtime manifest landed"
+files:
+  - src/ir/runtime-manifest.ts
+  - src/ir/async-plan.ts
+  - src/ir/async-runtime-providers.ts
+  - tests/issue-4103-ir-async-runtime-providers.test.ts
+  - tests/ir/issue-1373b-async-plan.test.ts
+  - plan/issues/4103-ir-async-runtime-provider-schema.md
+---
+
+# #4103 — IR async runtime provider and host-capability schema
+
+## Problem
+
+`IrAsyncPlan` already records seven semantic Promise and scheduling intents,
+but that vocabulary is duplicated inside the plan verifier and has no runtime
+provider catalogue. The frozen runtime manifest covers only deterministic
+Math, so an async producer cannot request its full runtime closure before
+lowering. The existing host async frame engine separately consumes six imports,
+but their concrete spellings must not leak upward into prepared plans or the
+semantic capability set.
+
+## Scope
+
+- Define one closed seven-entry async `RuntimeFeature` vocabulary shared by
+  `IrAsyncPlan` and the runtime manifest.
+- Model Promise requirements as host-capability providers and scheduler
+  enqueue/drain as host-managed Promise-job-queue providers.
+- Close and deduplicate those providers to six typed semantic host-capability
+  IDs in deterministic order.
+- Keep the exact current host adapter module, field, and signature records in a
+  separate six-entry catalogue for the later `ImportIntent` projection.
+- Reject unknown or late requests, unavailable target policies, and missing
+  backend adapters without adding a fallback.
+- Preserve the existing pure-Math provider catalogue and behavior.
+
+Production async-plan routing, `ImportIntent` materialization, Program ABI
+allocation, and backend integration are explicitly outside this slice.
+
+## Acceptance criteria
+
+- Reversing async requirement and provider traversal produces the same frozen
+  manifest.
+- The seven async requirements close to exactly six semantic capabilities;
+  scheduler providers add no import capability.
+- The separate adapter catalogue exactly matches `HostAsyncImports` names and
+  signatures while neither `IrAsyncPlan` nor `FrozenRuntimeManifest` carries a
+  concrete module or import field.
+- Host/WasmGC succeeds; strict-no-host and missing backend adapters fail with
+  typed manifest invariants.
+- Requests after freeze and unplanned provider/capability lookups fail closed.
+- Focused manifest and async-plan tests, typecheck, formatting, and source
+  budget gates pass.
+
+## Handoff
+
+The next slice connects prepared async plans to `requestFeature`, projects the
+frozen semantic capability IDs through the adapter catalogue, and allocates the
+resulting imports through the final Program ABI before lowering.
+
+## Validation
+
+- The focused runtime-manifest and async-plan suite passes: 23 tests across
+  `#3526`, `#1373b`, and this issue.
+- TypeScript typechecking and Prettier checks pass.
+- Source LOC and function-budget gates pass; the accepted source change is a
+  net 231 lines across the three touched `src` files.
+- The IR fallback ratchet passes with the four async blockers unchanged. This
+  slice defines their runtime closure but does not claim an async body.

--- a/src/ir/async-plan.ts
+++ b/src/ir/async-plan.ts
@@ -14,6 +14,7 @@
  * consume an IrAsyncPlan.
  */
 
+import { ASYNC_RUNTIME_FEATURES, isAsyncRuntimeFeature, type AsyncRuntimeFeature } from "./async-runtime-providers.js";
 import type { IrUnitId } from "./identity.js";
 import { collectUses, forEachInstrDeep, irTypeEquals, type IrInstr, type IrType, type IrValueId } from "./nodes.js";
 
@@ -50,14 +51,7 @@ export function canonicalPromiseAbi(fulfillmentType: IrType | null): IrCanonical
 }
 
 /** Semantic requirements. A backend selects providers only after preparation. */
-export type IrAsyncRuntimeIntent =
-  | "promise.capability.create"
-  | "promise.resolve"
-  | "promise.react"
-  | "promise.settle.fulfill"
-  | "promise.settle.reject"
-  | "scheduler.enqueue"
-  | "scheduler.drain";
+export type IrAsyncRuntimeIntent = AsyncRuntimeFeature;
 
 export interface IrAsyncPlanValue {
   readonly value: IrValueId;
@@ -182,6 +176,7 @@ export type IrAsyncPlanInvariantCode =
   | "unknown-handler"
   | "handler-cycle"
   | "invalid-handler"
+  | "unknown-runtime-intent"
   | "duplicate-runtime-intent"
   | "missing-runtime-intent"
   | "liveness-mismatch";
@@ -211,15 +206,7 @@ interface StateEdge {
   readonly boundValue?: IrValueId;
 }
 
-const runtimeIntentOrder: readonly IrAsyncRuntimeIntent[] = [
-  "promise.capability.create",
-  "promise.resolve",
-  "promise.react",
-  "promise.settle.fulfill",
-  "promise.settle.reject",
-  "scheduler.enqueue",
-  "scheduler.drain",
-];
+const runtimeIntentOrder: readonly IrAsyncRuntimeIntent[] = ASYNC_RUNTIME_FEATURES;
 
 const runtimeIntentRank = new Map(runtimeIntentOrder.map((intent, index) => [intent, index] as const));
 
@@ -708,6 +695,10 @@ export function verifyIrAsyncPlan(plan: IrAsyncPlan): readonly IrAsyncPlanVerify
 
   const intents = new Set<IrAsyncRuntimeIntent>();
   for (const intent of plan.runtimeIntents) {
+    if (!isAsyncRuntimeFeature(intent)) {
+      addError(errors, "unknown-runtime-intent", `runtime intent ${String(intent)} is not semantic async vocabulary`);
+      continue;
+    }
     if (intents.has(intent)) addError(errors, "duplicate-runtime-intent", `runtime intent ${intent} is duplicated`);
     intents.add(intent);
   }
@@ -750,7 +741,9 @@ function canonicalPlanInput(plan: IrAsyncPlan): IrAsyncPlan {
     states,
     handlers: [...plan.handlers].sort((left, right) => compareNumber(left.id, right.id)),
     runtimeIntents: [...plan.runtimeIntents].sort(
-      (left, right) => (runtimeIntentRank.get(left) ?? Number.MAX_SAFE_INTEGER) - (runtimeIntentRank.get(right) ?? 0),
+      (left, right) =>
+        (runtimeIntentRank.get(left) ?? Number.MAX_SAFE_INTEGER) -
+          (runtimeIntentRank.get(right) ?? Number.MAX_SAFE_INTEGER) || String(left).localeCompare(String(right)),
     ),
   };
 }

--- a/src/ir/async-runtime-providers.ts
+++ b/src/ir/async-runtime-providers.ts
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * Closed semantic runtime vocabulary for an IR async suspension plan.
+ *
+ * Plans mention only these requirements. Concrete host import spellings live
+ * below this boundary in the capability catalogue, where manifest closure can
+ * validate and deduplicate them before any backend starts emitting code.
+ */
+import type { RuntimeProviderDefinition, RuntimeProviderImplementation } from "./runtime-manifest.js";
+
+export const ASYNC_RUNTIME_FEATURES = Object.freeze([
+  "promise.capability.create",
+  "promise.react",
+  "promise.resolve",
+  "promise.settle.fulfill",
+  "promise.settle.reject",
+  "scheduler.drain",
+  "scheduler.enqueue",
+] as const);
+
+export type AsyncRuntimeFeature = (typeof ASYNC_RUNTIME_FEATURES)[number];
+
+const ASYNC_RUNTIME_FEATURE_SET: ReadonlySet<string> = new Set(ASYNC_RUNTIME_FEATURES);
+
+export function isAsyncRuntimeFeature(value: string): value is AsyncRuntimeFeature {
+  return ASYNC_RUNTIME_FEATURE_SET.has(value);
+}
+
+export const ASYNC_HOST_CAPABILITY_IDS = Object.freeze([
+  "async.callback.wrap",
+  "async.promise.capability.create",
+  "async.promise.react",
+  "async.promise.resolve",
+  "async.promise.settle.fulfill",
+  "async.promise.settle.reject",
+] as const);
+
+export type AsyncHostCapabilityId = (typeof ASYNC_HOST_CAPABILITY_IDS)[number];
+
+export type AsyncHostAdapterValueType = "externref" | "i32";
+
+/** Concrete adapter data, deliberately separate from the semantic manifest. */
+export interface AsyncHostAdapter {
+  readonly capability: AsyncHostCapabilityId;
+  readonly module: "env";
+  readonly field: string;
+  readonly kind: "func";
+  readonly params: readonly AsyncHostAdapterValueType[];
+  readonly results: readonly AsyncHostAdapterValueType[];
+}
+
+function adapter(
+  capability: AsyncHostCapabilityId,
+  field: string,
+  params: readonly AsyncHostAdapterValueType[],
+  results: readonly AsyncHostAdapterValueType[],
+): AsyncHostAdapter {
+  return Object.freeze({
+    capability,
+    module: "env",
+    field,
+    kind: "func",
+    params: Object.freeze([...params]),
+    results: Object.freeze([...results]),
+  });
+}
+
+/** Exact host adapter surface consumed by the existing async frame engine. */
+export const ASYNC_HOST_ADAPTERS: readonly AsyncHostAdapter[] = Object.freeze([
+  adapter("async.callback.wrap", "__make_callback", ["i32", "externref"], ["externref"]),
+  adapter("async.promise.capability.create", "Promise_new_pending", [], ["externref"]),
+  adapter("async.promise.react", "Promise_then2", ["externref", "externref", "externref"], ["externref"]),
+  adapter("async.promise.resolve", "Promise_resolve", ["externref"], ["externref"]),
+  adapter("async.promise.settle.fulfill", "Promise_settle_resolve", ["externref", "externref"], ["externref"]),
+  adapter("async.promise.settle.reject", "Promise_settle_reject", ["externref", "externref"], ["externref"]),
+]);
+
+function capabilities(...ids: readonly AsyncHostCapabilityId[]): readonly AsyncHostCapabilityId[] {
+  return Object.freeze([...ids].sort());
+}
+
+export const ASYNC_RUNTIME_PROVIDER_IDS = Object.freeze([
+  "host.promise.capability.create",
+  "host.promise.react",
+  "host.promise.resolve",
+  "host.promise.settle.fulfill",
+  "host.promise.settle.reject",
+  "host.scheduler.drain",
+  "host.scheduler.enqueue",
+] as const);
+
+export type AsyncRuntimeProviderId = (typeof ASYNC_RUNTIME_PROVIDER_IDS)[number];
+
+const HOST_TARGET = Object.freeze(["host"] as const);
+const WASMGC_BACKEND = Object.freeze(["wasmgc"] as const);
+const NO_DEPENDENCIES = Object.freeze([] as const);
+const NO_HOST_CAPABILITIES = Object.freeze([] as const);
+const HOST_CAPABILITY_IMPLEMENTATION: RuntimeProviderImplementation = Object.freeze({
+  kind: "host-capability",
+});
+const HOST_MANAGED_IMPLEMENTATION: RuntimeProviderImplementation = Object.freeze({
+  kind: "host-managed",
+  service: "promise-job-queue",
+});
+
+function provider(
+  id: AsyncRuntimeProviderId,
+  feature: AsyncRuntimeFeature,
+  hostCapabilities: readonly AsyncHostCapabilityId[],
+  implementation: RuntimeProviderImplementation,
+): RuntimeProviderDefinition {
+  return Object.freeze({
+    id,
+    feature,
+    dependencies: NO_DEPENDENCIES,
+    hostCapabilities,
+    supportedTargets: HOST_TARGET,
+    supportedBackends: WASMGC_BACKEND,
+    implementation,
+  });
+}
+
+/**
+ * Host-WasmGC catalogue for the first async runtime slice. The two scheduler
+ * requirements use the host Promise job queue and therefore add no import.
+ */
+export const ASYNC_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze([
+  provider(
+    "host.promise.capability.create",
+    "promise.capability.create",
+    capabilities("async.promise.capability.create"),
+    HOST_CAPABILITY_IMPLEMENTATION,
+  ),
+  provider(
+    "host.promise.react",
+    "promise.react",
+    capabilities("async.callback.wrap", "async.promise.react"),
+    HOST_CAPABILITY_IMPLEMENTATION,
+  ),
+  provider(
+    "host.promise.resolve",
+    "promise.resolve",
+    capabilities("async.promise.resolve"),
+    HOST_CAPABILITY_IMPLEMENTATION,
+  ),
+  provider(
+    "host.promise.settle.fulfill",
+    "promise.settle.fulfill",
+    capabilities("async.promise.settle.fulfill"),
+    HOST_CAPABILITY_IMPLEMENTATION,
+  ),
+  provider(
+    "host.promise.settle.reject",
+    "promise.settle.reject",
+    capabilities("async.promise.settle.reject"),
+    HOST_CAPABILITY_IMPLEMENTATION,
+  ),
+  provider("host.scheduler.drain", "scheduler.drain", NO_HOST_CAPABILITIES, HOST_MANAGED_IMPLEMENTATION),
+  provider("host.scheduler.enqueue", "scheduler.enqueue", NO_HOST_CAPABILITIES, HOST_MANAGED_IMPLEMENTATION),
+]);

--- a/src/ir/runtime-manifest.ts
+++ b/src/ir/runtime-manifest.ts
@@ -11,23 +11,33 @@
  */
 import { irTypeEquals, type IrIntrinsicBackendOp } from "./nodes.js";
 import {
+  ASYNC_HOST_CAPABILITY_IDS,
+  ASYNC_RUNTIME_FEATURES,
+  ASYNC_RUNTIME_PROVIDERS,
+  ASYNC_RUNTIME_PROVIDER_IDS,
+  type AsyncHostCapabilityId,
+  type AsyncRuntimeFeature,
+  type AsyncRuntimeProviderId,
+} from "./async-runtime-providers.js";
+import {
   F64_BINARY_INTRINSIC_SIGNATURE,
   F64_UNARY_INTRINSIC_SIGNATURE,
   INTRINSIC_DEFINITIONS,
   PURE_MATH_HOST_CAPABILITIES,
   PURE_MATH_RUNTIME_FEATURES,
-  type HostCapability,
   type IntrinsicEffectEvidence,
   type IntrinsicId,
   type IntrinsicSignature,
   type IntrinsicUse,
   type IntrinsicVerificationCode,
-  type RuntimeFeature,
+  type RuntimeFeature as MathRuntimeFeature,
   verifyIntrinsicUse,
 } from "./intrinsics.js";
 
 export type RuntimeTarget = "host" | "strict-no-host" | "standalone" | "wasi";
 export type RuntimeBackend = "wasmgc" | "linear";
+export type RuntimeFeature = MathRuntimeFeature | AsyncRuntimeFeature;
+export type HostCapabilityId = AsyncHostCapabilityId;
 
 export interface RuntimeManifestPolicy {
   readonly target: RuntimeTarget;
@@ -51,7 +61,8 @@ export const PURE_MATH_RUNTIME_PROVIDER_IDS = Object.freeze([
   "selfhost.math.sin",
 ] as const);
 
-export type RuntimeProviderId = (typeof PURE_MATH_RUNTIME_PROVIDER_IDS)[number];
+export type MathRuntimeProviderId = (typeof PURE_MATH_RUNTIME_PROVIDER_IDS)[number];
+export type RuntimeProviderId = MathRuntimeProviderId | AsyncRuntimeProviderId;
 
 export type RuntimeProviderImplementation =
   | {
@@ -62,20 +73,38 @@ export type RuntimeProviderImplementation =
       readonly kind: "self-hosted";
       /** Concrete ABI spelling, deliberately below the semantic feature. */
       readonly symbol: string;
+    }
+  | {
+      /** The provider closes over one or more declared host capabilities. */
+      readonly kind: "host-capability";
+    }
+  | {
+      /** Scheduling is supplied by the host Promise job queue, with no import. */
+      readonly kind: "host-managed";
+      readonly service: "promise-job-queue";
     };
+
+export type MathRuntimeProviderImplementation = Extract<
+  RuntimeProviderImplementation,
+  { readonly kind: "backend-op" | "self-hosted" }
+>;
 
 export interface RuntimeProviderDefinition {
   readonly id: RuntimeProviderId;
   readonly feature: RuntimeFeature;
-  readonly signature: IntrinsicSignature;
+  /** Present for source intrinsics; semantic runtime requirements need no call ABI. */
+  readonly signature?: IntrinsicSignature;
   readonly dependencies: readonly RuntimeFeature[];
-  readonly hostCapabilities: readonly HostCapability[];
+  readonly hostCapabilities: readonly HostCapabilityId[];
   readonly supportedTargets: readonly RuntimeTarget[];
   readonly supportedBackends: readonly RuntimeBackend[];
   readonly implementation: RuntimeProviderImplementation;
 }
 
-export type RuntimeProviderPlan = RuntimeProviderDefinition;
+/** Math lowering compatibility view; async providers are consumed by later adapters. */
+export type RuntimeProviderPlan = RuntimeProviderDefinition & {
+  readonly implementation: MathRuntimeProviderImplementation;
+};
 
 export interface RuntimeProviderComponent {
   readonly features: readonly RuntimeFeature[];
@@ -87,9 +116,9 @@ export interface FrozenRuntimeManifest {
   readonly policy: RuntimeManifestPolicy;
   readonly intrinsicUses: readonly IntrinsicUse[];
   readonly features: readonly RuntimeFeature[];
-  readonly providers: readonly RuntimeProviderPlan[];
+  readonly providers: readonly RuntimeProviderDefinition[];
   readonly providerComponents: readonly RuntimeProviderComponent[];
-  readonly hostCapabilities: readonly HostCapability[];
+  readonly hostCapabilities: readonly HostCapabilityId[];
 }
 
 export type RuntimeManifestInvariantCode =
@@ -131,7 +160,7 @@ export class RuntimeManifestInvariantError extends Error {
 const ALL_TARGETS = Object.freeze<readonly RuntimeTarget[]>(["host", "standalone", "strict-no-host", "wasi"]);
 const ALL_BACKENDS = Object.freeze<readonly RuntimeBackend[]>(["linear", "wasmgc"]);
 
-export const RUNTIME_FEATURE_SIGNATURES: Readonly<Record<RuntimeFeature, IntrinsicSignature>> = Object.freeze({
+export const RUNTIME_FEATURE_SIGNATURES: Readonly<Partial<Record<RuntimeFeature, IntrinsicSignature>>> = Object.freeze({
   "math.abs": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.atan": F64_UNARY_INTRINSIC_SIGNATURE,
   "math.atan2": F64_BINARY_INTRINSIC_SIGNATURE,
@@ -167,7 +196,7 @@ function provider(
   });
 }
 
-const PROVIDERS_BY_FEATURE: Readonly<Record<RuntimeFeature, RuntimeProviderDefinition>> = Object.freeze({
+const PROVIDERS_BY_FEATURE: Readonly<Record<MathRuntimeFeature, RuntimeProviderDefinition>> = Object.freeze({
   "math.abs": provider("backend.f64.abs", "math.abs", F64_UNARY_INTRINSIC_SIGNATURE, {
     kind: "backend-op",
     opcode: "f64.abs",
@@ -245,8 +274,17 @@ export const PURE_MATH_RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] =
   ),
 );
 
-const FEATURE_SET: ReadonlySet<string> = new Set(PURE_MATH_RUNTIME_FEATURES);
-const PROVIDER_ID_SET: ReadonlySet<string> = new Set(PURE_MATH_RUNTIME_PROVIDER_IDS);
+/** Closed, canonically ordered catalogue used by production manifest builders. */
+export const RUNTIME_PROVIDERS: readonly RuntimeProviderDefinition[] = Object.freeze(
+  [...PURE_MATH_RUNTIME_PROVIDERS, ...ASYNC_RUNTIME_PROVIDERS].sort((left, right) => left.id.localeCompare(right.id)),
+);
+
+const FEATURE_SET: ReadonlySet<string> = new Set([...PURE_MATH_RUNTIME_FEATURES, ...ASYNC_RUNTIME_FEATURES]);
+const PROVIDER_ID_SET: ReadonlySet<string> = new Set([
+  ...PURE_MATH_RUNTIME_PROVIDER_IDS,
+  ...ASYNC_RUNTIME_PROVIDER_IDS,
+]);
+const HOST_CAPABILITY_ID_SET: ReadonlySet<string> = new Set(ASYNC_HOST_CAPABILITY_IDS);
 const TARGET_SET: ReadonlySet<string> = new Set(ALL_TARGETS);
 const BACKEND_SET: ReadonlySet<string> = new Set(ALL_BACKENDS);
 
@@ -267,16 +305,19 @@ function signatureEquals(left: IntrinsicSignature, right: IntrinsicSignature): b
 }
 
 function cloneProvider(value: RuntimeProviderDefinition): RuntimeProviderDefinition {
-  const signature = signatureEquals(value.signature, F64_UNARY_INTRINSIC_SIGNATURE)
-    ? F64_UNARY_INTRINSIC_SIGNATURE
-    : signatureEquals(value.signature, F64_BINARY_INTRINSIC_SIGNATURE)
-      ? F64_BINARY_INTRINSIC_SIGNATURE
-      : value.signature;
+  const signature =
+    value.signature === undefined
+      ? undefined
+      : signatureEquals(value.signature, F64_UNARY_INTRINSIC_SIGNATURE)
+        ? F64_UNARY_INTRINSIC_SIGNATURE
+        : signatureEquals(value.signature, F64_BINARY_INTRINSIC_SIGNATURE)
+          ? F64_BINARY_INTRINSIC_SIGNATURE
+          : value.signature;
   return Object.freeze({
     ...value,
-    signature,
+    ...(signature === undefined ? {} : { signature }),
     dependencies: Object.freeze([...new Set(value.dependencies)].sort(compareStrings)),
-    hostCapabilities: Object.freeze([...value.hostCapabilities]),
+    hostCapabilities: Object.freeze([...new Set(value.hostCapabilities)].sort(compareStrings)),
     supportedTargets: Object.freeze([...new Set(value.supportedTargets)].sort(compareStrings)),
     supportedBackends: Object.freeze([...new Set(value.supportedBackends)].sort(compareStrings)),
     implementation: Object.freeze({ ...value.implementation }),
@@ -340,7 +381,7 @@ function stronglyConnectedComponents(
 
 function buildProviderComponents(
   features: readonly RuntimeFeature[],
-  providers: ReadonlyMap<RuntimeFeature, RuntimeProviderPlan>,
+  providers: ReadonlyMap<RuntimeFeature, RuntimeProviderDefinition>,
   declaredCycles: ReadonlyMap<string, readonly RuntimeFeature[]>,
 ): readonly RuntimeProviderComponent[] {
   const dependencies = new Map<RuntimeFeature, readonly RuntimeFeature[]>();
@@ -420,12 +461,14 @@ type BuilderState = "open" | "building" | "frozen" | "failed";
 export class RuntimeManifestBuilder {
   readonly #policy: RuntimeManifestPolicy;
   readonly #uses: IntrinsicUse[] = [];
+  readonly #requestedFeatures = new Set<RuntimeFeature>();
   readonly #providers: RuntimeProviderDefinition[];
   readonly #addedDependencies = new Map<RuntimeFeature, Set<RuntimeFeature>>();
   readonly #declaredCycles = new Map<string, readonly RuntimeFeature[]>();
   readonly #plannedIntrinsicIds = new Set<IntrinsicId>();
   readonly #plannedProviderIds = new Set<RuntimeProviderId>();
-  readonly #providerPlans = new Map<RuntimeFeature, RuntimeProviderPlan>();
+  readonly #plannedHostCapabilityIds = new Set<HostCapabilityId>();
+  readonly #providerPlans = new Map<RuntimeFeature, RuntimeProviderDefinition>();
   #state: BuilderState = "open";
   #manifest?: FrozenRuntimeManifest;
 
@@ -437,7 +480,7 @@ export class RuntimeManifestBuilder {
       );
     }
     this.#policy = Object.freeze({ ...policy });
-    this.#providers = (options.providers ?? PURE_MATH_RUNTIME_PROVIDERS).map(cloneProvider);
+    this.#providers = (options.providers ?? RUNTIME_PROVIDERS).map(cloneProvider);
   }
 
   addIntrinsicUse(use: IntrinsicUse, effects: IntrinsicEffectEvidence): void {
@@ -454,6 +497,13 @@ export class RuntimeManifestBuilder {
         location: Object.freeze({ ...use.location }),
       }),
     );
+  }
+
+  /** Register a semantic runtime requirement discovered during preparation. */
+  requestFeature(feature: RuntimeFeature): void {
+    this.#assertMutable();
+    this.#assertKnownFeature(feature);
+    this.#requestedFeatures.add(feature);
   }
 
   registerProvider(value: RuntimeProviderDefinition): void {
@@ -519,7 +569,9 @@ export class RuntimeManifestBuilder {
     return this.#manifest;
   }
 
-  resolveProvider(feature: RuntimeFeature): RuntimeProviderPlan {
+  resolveProvider(feature: MathRuntimeFeature): RuntimeProviderPlan;
+  resolveProvider(feature: AsyncRuntimeFeature): RuntimeProviderDefinition;
+  resolveProvider(feature: RuntimeFeature): RuntimeProviderDefinition {
     this.#assertFrozen();
     const provider = this.#providerPlans.get(feature);
     if (!provider) {
@@ -553,15 +605,17 @@ export class RuntimeManifestBuilder {
 
   assertHostCapabilityPlanned(capability: string): void {
     this.#assertFrozen();
-    throw new RuntimeManifestInvariantError(
-      "late-unplanned-host-capability",
-      `host capability ${capability} is outside the host-free pure-Math manifest`,
-    );
+    if (!this.#plannedHostCapabilityIds.has(capability as HostCapabilityId)) {
+      throw new RuntimeManifestInvariantError(
+        "late-unplanned-host-capability",
+        `host capability ${capability} was not present at manifest freeze`,
+      );
+    }
   }
 
   #buildManifest(): FrozenRuntimeManifest {
     const providersByFeature = this.#indexProviders();
-    const pending = new Set<RuntimeFeature>();
+    const pending = new Set<RuntimeFeature>(this.#requestedFeatures);
     for (const use of this.#uses) pending.add(INTRINSIC_DEFINITIONS[use.id].feature);
 
     while (pending.size > 0) {
@@ -570,7 +624,10 @@ export class RuntimeManifestBuilder {
       if (this.#providerPlans.has(feature)) continue;
       const selected = this.#selectProvider(feature, providersByFeature);
       const expectedSignature = RUNTIME_FEATURE_SIGNATURES[feature];
-      if (!signatureEquals(selected.signature, expectedSignature)) {
+      if (
+        expectedSignature !== undefined &&
+        (selected.signature === undefined || !signatureEquals(selected.signature, expectedSignature))
+      ) {
         throw new RuntimeManifestInvariantError(
           "provider-signature-mismatch",
           `provider ${selected.id} does not implement the ${feature} signature`,
@@ -592,9 +649,15 @@ export class RuntimeManifestBuilder {
       [...this.#providerPlans.values()].sort((left, right) => compareStrings(left.id, right.id)),
     );
     const intrinsicUses = Object.freeze([...this.#uses].sort(useOrder));
+    const hostCapabilityIds = new Set<HostCapabilityId>();
+    for (const provider of providers) {
+      for (const capability of provider.hostCapabilities) hostCapabilityIds.add(capability);
+    }
+    const hostCapabilities = Object.freeze([...hostCapabilityIds].sort(compareStrings));
 
     for (const use of intrinsicUses) this.#plannedIntrinsicIds.add(use.id);
     for (const value of providers) this.#plannedProviderIds.add(value.id);
+    for (const capability of hostCapabilities) this.#plannedHostCapabilityIds.add(capability);
 
     return Object.freeze({
       policy: this.#policy,
@@ -602,7 +665,7 @@ export class RuntimeManifestBuilder {
       features,
       providers,
       providerComponents,
-      hostCapabilities: PURE_MATH_HOST_CAPABILITIES,
+      hostCapabilities,
     });
   }
 
@@ -625,10 +688,24 @@ export class RuntimeManifestBuilder {
       }
       ids.add(provider.id);
       for (const dependency of provider.dependencies) this.#assertKnownFeature(dependency);
-      if (provider.hostCapabilities.length > 0) {
+      for (const capability of provider.hostCapabilities) {
+        if (!HOST_CAPABILITY_ID_SET.has(capability)) {
+          throw new RuntimeManifestInvariantError(
+            "unknown-host-capability",
+            `provider ${provider.id} requests unknown host capability ${String(capability)}`,
+          );
+        }
+      }
+      if (provider.implementation.kind === "host-managed" && provider.hostCapabilities.length > 0) {
         throw new RuntimeManifestInvariantError(
           "unknown-host-capability",
-          `provider ${provider.id} requests a capability outside the host-free pure-Math vocabulary`,
+          `host-managed provider ${provider.id} cannot request concrete host capabilities`,
+        );
+      }
+      if (provider.implementation.kind === "host-capability" && provider.hostCapabilities.length === 0) {
+        throw new RuntimeManifestInvariantError(
+          "unknown-host-capability",
+          `host-capability provider ${provider.id} must request at least one host capability`,
         );
       }
       if (!provider.supportedTargets.every((target) => TARGET_SET.has(target))) {

--- a/tests/ir/issue-1373b-async-plan.test.ts
+++ b/tests/ir/issue-1373b-async-plan.test.ts
@@ -18,6 +18,7 @@ import {
 import { createIrBindingId, createIrSourceId, createIrUnitId } from "../../src/ir/identity.js";
 import { asValueId, irVal, type IrType } from "../../src/ir/nodes.js";
 import { evaluateIrOutcomePolicy } from "../../src/ir/outcomes.js";
+import { ASYNC_RUNTIME_FEATURES } from "../../src/ir/async-runtime-providers.js";
 import { compileToWasm } from "../equivalence/helpers.js";
 
 const EXTERN: IrType = irVal({ kind: "externref" });
@@ -165,6 +166,24 @@ describe("#1373b IrAsyncPlan contract", () => {
     });
     expect(new Set(prepared.map((item) => item.serialized)).size).toBe(1);
     expect(new Set(prepared.map((item) => item.hash)).size).toBe(1);
+  });
+
+  it("uses the shared semantic vocabulary and rejects concrete host adapter names", () => {
+    const plan = makePlan();
+    expect(new Set(plan.runtimeIntents)).toEqual(new Set(ASYNC_RUNTIME_FEATURES));
+    for (const adapter of [
+      "Promise_new_pending",
+      "Promise_resolve",
+      "Promise_then2",
+      "__make_callback",
+      "Promise_settle_resolve",
+      "Promise_settle_reject",
+    ]) {
+      expect(serializeIrAsyncPlan(plan)).not.toContain(adapter);
+    }
+
+    (plan as { runtimeIntents: readonly string[] }).runtimeIntents = [...plan.runtimeIntents, "Promise_resolve"];
+    expect(errorCodes(plan)).toContain("unknown-runtime-intent");
   });
 
   it("fails closed on an unknown state and handler", () => {

--- a/tests/issue-4103-ir-async-runtime-providers.test.ts
+++ b/tests/issue-4103-ir-async-runtime-providers.test.ts
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ASYNC_HOST_ADAPTERS,
+  ASYNC_HOST_CAPABILITY_IDS,
+  ASYNC_RUNTIME_FEATURES,
+  ASYNC_RUNTIME_PROVIDERS,
+  ASYNC_RUNTIME_PROVIDER_IDS,
+} from "../src/ir/async-runtime-providers.js";
+import {
+  PURE_MATH_RUNTIME_PROVIDERS,
+  RUNTIME_PROVIDERS,
+  RuntimeManifestBuilder,
+  RuntimeManifestInvariantError,
+  type RuntimeBackend,
+  type RuntimeFeature,
+  type HostCapabilityId,
+  type RuntimeProviderDefinition,
+  type RuntimeTarget,
+} from "../src/ir/runtime-manifest.js";
+
+function builder(target: RuntimeTarget = "host", backend: RuntimeBackend = "wasmgc"): RuntimeManifestBuilder {
+  return new RuntimeManifestBuilder({ target, backend });
+}
+
+function requestAll(value: RuntimeManifestBuilder, features: readonly RuntimeFeature[]): void {
+  for (const feature of features) value.requestFeature(feature);
+}
+
+function thrown(code: RuntimeManifestInvariantError["code"]): object {
+  return expect.objectContaining<RuntimeManifestInvariantError>({ code });
+}
+
+describe("#4103 IR async runtime provider schema", () => {
+  it("closes all seven semantic requirements to the exact six existing host imports", () => {
+    const forward = builder();
+    const reverse = builder();
+    requestAll(forward, ASYNC_RUNTIME_FEATURES);
+    requestAll(reverse, [...ASYNC_RUNTIME_FEATURES].reverse());
+
+    const manifest = forward.freeze();
+    expect(reverse.freeze()).toEqual(manifest);
+    expect(manifest.features).toEqual(ASYNC_RUNTIME_FEATURES);
+    expect(manifest.providers.map((provider) => provider.id)).toEqual(ASYNC_RUNTIME_PROVIDER_IDS);
+    expect(manifest.hostCapabilities).toEqual(ASYNC_HOST_CAPABILITY_IDS);
+    expect(ASYNC_HOST_ADAPTERS.map((adapter) => adapter.field).sort()).toEqual([
+      "Promise_new_pending",
+      "Promise_resolve",
+      "Promise_settle_reject",
+      "Promise_settle_resolve",
+      "Promise_then2",
+      "__make_callback",
+    ]);
+    expect(manifest.hostCapabilities).toHaveLength(6);
+    expect(new Set(manifest.hostCapabilities)).toHaveLength(6);
+    const semanticManifest = JSON.stringify(manifest);
+    for (const adapter of ASYNC_HOST_ADAPTERS) {
+      expect(semanticManifest).not.toContain(adapter.field);
+    }
+  });
+
+  it("preserves the existing host import signatures and models scheduling without another import", () => {
+    expect(ASYNC_HOST_ADAPTERS).toEqual([
+      {
+        capability: "async.callback.wrap",
+        module: "env",
+        field: "__make_callback",
+        kind: "func",
+        params: ["i32", "externref"],
+        results: ["externref"],
+      },
+      {
+        capability: "async.promise.capability.create",
+        module: "env",
+        field: "Promise_new_pending",
+        kind: "func",
+        params: [],
+        results: ["externref"],
+      },
+      {
+        capability: "async.promise.react",
+        module: "env",
+        field: "Promise_then2",
+        kind: "func",
+        params: ["externref", "externref", "externref"],
+        results: ["externref"],
+      },
+      {
+        capability: "async.promise.resolve",
+        module: "env",
+        field: "Promise_resolve",
+        kind: "func",
+        params: ["externref"],
+        results: ["externref"],
+      },
+      {
+        capability: "async.promise.settle.fulfill",
+        module: "env",
+        field: "Promise_settle_resolve",
+        kind: "func",
+        params: ["externref", "externref"],
+        results: ["externref"],
+      },
+      {
+        capability: "async.promise.settle.reject",
+        module: "env",
+        field: "Promise_settle_reject",
+        kind: "func",
+        params: ["externref", "externref"],
+        results: ["externref"],
+      },
+    ]);
+    expect(
+      ASYNC_RUNTIME_PROVIDERS.filter((provider) => provider.feature.startsWith("scheduler.")).map(
+        (provider) => provider.implementation,
+      ),
+    ).toEqual([
+      { kind: "host-managed", service: "promise-job-queue" },
+      { kind: "host-managed", service: "promise-job-queue" },
+    ]);
+    expect(
+      ASYNC_RUNTIME_PROVIDERS.filter((provider) => provider.feature.startsWith("scheduler.")).flatMap(
+        (provider) => provider.hostCapabilities,
+      ),
+    ).toEqual([]);
+  });
+
+  it("deduplicates requests and capability closure while keeping Math provider behavior", () => {
+    const value = builder();
+    value.requestFeature("promise.react");
+    value.requestFeature("promise.react");
+    value.requestFeature("scheduler.enqueue");
+    value.requestFeature("scheduler.drain");
+    value.requestFeature("math.sin");
+    const manifest = value.freeze();
+
+    expect(manifest.features).toEqual([
+      "math.reduce-trig",
+      "math.sin",
+      "promise.react",
+      "scheduler.drain",
+      "scheduler.enqueue",
+    ]);
+    expect(manifest.hostCapabilities).toEqual(["async.callback.wrap", "async.promise.react"]);
+    expect(value.resolveProvider("math.sin").implementation).toEqual({ kind: "self-hosted", symbol: "Math_sin" });
+
+    const mathOnlyCatalogue = new RuntimeManifestBuilder(
+      { target: "host", backend: "wasmgc" },
+      { providers: PURE_MATH_RUNTIME_PROVIDERS },
+    );
+    mathOnlyCatalogue.requestFeature("math.sin");
+    const widenedCatalogue = builder();
+    widenedCatalogue.requestFeature("math.sin");
+    expect(widenedCatalogue.freeze()).toEqual(mathOnlyCatalogue.freeze());
+  });
+
+  it("fails closed for post-freeze requests, missing adapters, no-host policy, and missing providers", () => {
+    const frozen = builder();
+    frozen.requestFeature("promise.resolve");
+    frozen.freeze();
+    expect(() => frozen.requestFeature("promise.react")).toThrowError(thrown("manifest-frozen"));
+    expect(() => frozen.assertProviderPlanned("host.promise.resolve")).not.toThrow();
+    expect(() => frozen.assertProviderPlanned("host.promise.react")).toThrowError(thrown("late-unplanned-provider"));
+    expect(() => frozen.assertHostCapabilityPlanned("async.promise.resolve")).not.toThrow();
+    expect(() => frozen.assertHostCapabilityPlanned("async.promise.react")).toThrowError(
+      thrown("late-unplanned-host-capability"),
+    );
+
+    const noHost = builder("strict-no-host");
+    noHost.requestFeature("promise.resolve");
+    expect(() => noHost.freeze()).toThrowError(thrown("provider-target-unavailable"));
+
+    const missingLinearAdapter = builder("host", "linear");
+    missingLinearAdapter.requestFeature("promise.resolve");
+    expect(() => missingLinearAdapter.freeze()).toThrowError(thrown("missing-backend-adapter"));
+
+    const missingProvider = new RuntimeManifestBuilder(
+      { target: "host", backend: "wasmgc" },
+      { providers: RUNTIME_PROVIDERS.filter((provider) => provider.feature !== "promise.resolve") },
+    );
+    missingProvider.requestFeature("promise.resolve");
+    expect(() => missingProvider.freeze()).toThrowError(thrown("missing-runtime-provider"));
+  });
+
+  it("rejects unknown requirements and capability IDs", () => {
+    expect(() => builder().requestFeature("Promise_resolve" as RuntimeFeature)).toThrowError(
+      thrown("unknown-runtime-feature"),
+    );
+
+    const providers = RUNTIME_PROVIDERS.map((provider): RuntimeProviderDefinition => {
+      if (provider.feature !== "promise.resolve") return provider;
+      return {
+        ...provider,
+        hostCapabilities: ["async.promise.unknown" as HostCapabilityId],
+      };
+    });
+    const altered = new RuntimeManifestBuilder({ target: "host", backend: "wasmgc" }, { providers });
+    altered.requestFeature("promise.resolve");
+    expect(() => altered.freeze()).toThrowError(thrown("unknown-host-capability"));
+  });
+
+  it("publishes deeply frozen provider and capability records", () => {
+    const value = builder();
+    value.requestFeature("promise.react");
+    const manifest = value.freeze();
+    const provider = manifest.providers.find((candidate) => candidate.feature === "promise.react")!;
+
+    expect(Object.isFrozen(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest.providers)).toBe(true);
+    expect(Object.isFrozen(manifest.hostCapabilities)).toBe(true);
+    expect(Object.isFrozen(provider.hostCapabilities)).toBe(true);
+    expect(Object.isFrozen(ASYNC_HOST_ADAPTERS[0]!.params)).toBe(true);
+    expect(() => (provider.hostCapabilities as string[]).push("async.promise.resolve")).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Summary

- share one seven-entry semantic async requirement vocabulary between IrAsyncPlan and the frozen runtime manifest
- close host/WasmGC requirements to six deduplicated semantic host-capability IDs
- keep the exact six concrete env adapter names and signatures in a separate projection catalogue
- preserve the pure-Math manifest contract and fail closed for unavailable policies or late requests

Tracked in `plan/issues/4103-ir-async-runtime-provider-schema.md`.

## Validation

- 23 focused runtime-manifest and async-plan tests
- typecheck, lint, Prettier, LOC/function budgets
- IR fallback, oracle, coercion-site, and numeric-local ratchets
- pre-push issue-integrity checks

## Follow-up

A later slice will attach prepared IrAsyncPlan requirements to this manifest and project the semantic capabilities into Program ABI import intents before lowering.