### PR TITLE
fix(#3953): the #2097 high-water raise runs and is then DISCARDED — carry it, and make the freeze loud

### DIFF
--- a/.github/workflows/baseline-summary-sync.yml
+++ b/.github/workflows/baseline-summary-sync.yml
@@ -89,7 +89,19 @@ jobs:
           node scripts/compare-test262-artifact.mjs --type report \
             --baseline public/benchmarks/results/test262-standalone-report.json \
             --candidate /tmp/js2wasm-baselines/test262-standalone-report.json && STANDALONE_UNCHANGED=1
-          if [ "$HOST_UNCHANGED" = "1" ] && [ "$STANDALONE_UNCHANGED" = "1" ]; then
+          # (#3953) The #2097 high-water mark is a THIRD drift axis, independent
+          # of the two report compares above. A stale mark can coexist with
+          # semantically-identical reports (the mark lags whenever the promote's
+          # main-repo commit is deferred by #1951, which is most of the time
+          # under two-lane merge velocity), and a floor that is too LOW never
+          # fires its gate — so nothing else in this repo would notice. Exit 1 =
+          # STALE, exit 2 = UNKNOWN ("cannot see"); BOTH force a sync, because
+          # "I could not determine the mark's age" must never render as fresh.
+          HIGHWATER_STALE=0
+          node scripts/check-highwater-staleness.mjs \
+            --report /tmp/js2wasm-baselines/test262-standalone-report.json \
+            --annotate || HIGHWATER_STALE=1
+          if [ "$HOST_UNCHANGED" = "1" ] && [ "$STANDALONE_UNCHANGED" = "1" ] && [ "$HIGHWATER_STALE" = "0" ]; then
             echo "Committed summary already matches the baselines repo — nothing to sync."
             echo "sync=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -110,9 +122,22 @@ jobs:
           # stranded (#3379, follow-up to #3375's host-compare fix).
           COMMITTED_TS=$(git log -1 --format=%ct -- public/benchmarks/results/test262-report.json 2>/dev/null || echo 0)
           AGE_H=$(( ($(date +%s) - ${COMMITTED_TS:-0}) / 3600 ))
-          echo "Drift detected (host_unchanged=$HOST_UNCHANGED standalone_unchanged=$STANDALONE_UNCHANGED); queue=${QUEUE_LEN:-?} committed-summary age=${AGE_H}h force=$FORCE"
-          if [ "$FORCE" != "true" ] && [ -n "$QUEUE_LEN" ] && [ "$QUEUE_LEN" -gt 0 ] 2>/dev/null && [ "$AGE_H" -lt 6 ]; then
-            echo "Merge queue busy and summary <6h old — skipping this cycle (#1951)."
+          # (#3953) A stale high-water mark ALSO earns the busy-queue bypass, but
+          # only at the SAME 6h floor the committed summary uses — otherwise this
+          # hourly job would push (and trigger a queue rebuild) every hour the
+          # mark lags. Re-run the detector at 6h rather than reusing the 3h
+          # verdict above: 3h decides "is there anything to sync", 6h decides
+          # "is it worth a queue-rebuild right now". Without this the two guards
+          # DEADLOCK — promote defers because the queue is busy, and this job
+          # skips because the queue is busy and the reports are fresh, so the
+          # mark strands indefinitely. That deadlock is the #3953 defect.
+          HIGHWATER_STALE_6H=0
+          node scripts/check-highwater-staleness.mjs \
+            --report /tmp/js2wasm-baselines/test262-standalone-report.json \
+            --max-age-hours 6 >/dev/null 2>&1 || HIGHWATER_STALE_6H=1
+          echo "Drift detected (host_unchanged=$HOST_UNCHANGED standalone_unchanged=$STANDALONE_UNCHANGED highwater_stale=$HIGHWATER_STALE highwater_stale_6h=$HIGHWATER_STALE_6H); queue=${QUEUE_LEN:-?} committed-summary age=${AGE_H}h force=$FORCE"
+          if [ "$FORCE" != "true" ] && [ -n "$QUEUE_LEN" ] && [ "$QUEUE_LEN" -gt 0 ] 2>/dev/null && [ "$AGE_H" -lt 6 ] && [ "$HIGHWATER_STALE_6H" = "0" ]; then
+            echo "Merge queue busy, summary <6h old, high-water mark fresh — skipping this cycle (#1951)."
             echo "sync=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -165,6 +190,37 @@ jobs:
           # only feeds the --all audit + no-git fallback). Non-fatal.
           node scripts/check-func-budget.mjs --update-on-decrease || \
             echo "WARN: func-budget baseline update failed (non-fatal)"
+          # (#3953) #2097 STANDALONE HIGH-WATER RAISE — this workflow is the
+          # fallback carrier the promote job's #1951 deferral message has always
+          # NAMED ("it will land via ... the hourly baseline-summary-sync") but
+          # could not actually be, because it never staged the file (grep
+          # "highwater" over this workflow returned 0 hits before this change).
+          #
+          # Consequence, measured 2026-08-02: promote's raise EXECUTED
+          # (26546 → 27019, run 30756312728) and was then discarded with the
+          # deferred commit, 37 merge commits in a row. The mark was load-bearing
+          # on the queue happening to be empty at promote time. Effective floor
+          # 26496 vs reality 27021 = 525 passes of silent permissive headroom.
+          #
+          # TWO-WRITER RACE — why last-writer-wins is safe here. After this
+          # change the mark has two writers: promote-baseline (on an empty queue)
+          # and this job (hourly). They can interleave, but the script is a
+          # RAISE-ONLY ratchet: it rewrites the file only when the measured
+          # host-free count strictly EXCEEDS the committed one, so any interleaving
+          # yields max(writes) and neither writer can lower the mark. The only
+          # ordering hazard would be writing a value computed against a DIFFERENT
+          # (older) committed mark than the one on disk at commit time — which is
+          # why the re-anchor loop below re-reads the mark from the freshly
+          # fetched tip and recomputes, rather than replaying this snapshot.
+          #
+          # Provenance is the baselines repo's own `baseline_sha` — the revision
+          # actually MEASURED — not this job's checkout sha, which is unrelated
+          # to the measurement. Non-fatal: a stale mark must never wedge the sync.
+          SA_REPORT=/tmp/js2wasm-baselines/test262-standalone-report.json
+          HW_SHA=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$SA_REPORT','utf8')).baseline_sha||'')}catch{console.log('')}")
+          node scripts/check-standalone-highwater.mjs \
+            --report "$SA_REPORT" --update ${HW_SHA:+--sha "$HW_SHA"} || \
+            echo "WARN: high-water raise failed (non-fatal) — mark may lag"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -189,6 +245,9 @@ jobs:
             # #3131 — LOC-budget baseline, refreshed just above (sole writer).
             git add -f scripts/loc-budget-baseline.json 2>/dev/null || true
             git add -f scripts/func-budget-baseline.json 2>/dev/null || true
+            # (#3953) The #2097 high-water mark, raised just above. THIS LINE is
+            # the fix: without it the raise wrote a file nothing ever committed.
+            git add -f benchmarks/results/test262-standalone-highwater.json 2>/dev/null || true
             git add -f README.md ROADMAP.md CLAUDE.md plan/goals/goal-graph.md \
               2>/dev/null || true
           }
@@ -241,6 +300,21 @@ jobs:
               echo "WARN: func-budget baseline recompute on re-anchored tip failed (non-fatal)"
             git add -f scripts/loc-budget-baseline.json 2>/dev/null || true
             git add -f scripts/func-budget-baseline.json 2>/dev/null || true
+            # (#3953) STALE-CHECKOUT GUARD for the high-water mark — same shape
+            # as the coercion/LOC guards above, and load-bearing for the
+            # two-writer race described in the raise step. The re-apply loop just
+            # copied OUR snapshot of the mark over the re-anchored tip; if
+            # promote-baseline raised the mark HIGHER while we were working, that
+            # copy would silently LOWER it — turning a raise-only ratchet into a
+            # last-writer-wins clobber. So discard our copy, take the mark from
+            # the freshly fetched tip, and re-run the raise against THAT. The
+            # ratchet then compares the new measurement to main's actual current
+            # mark, so the committed value is always max(ours, main's).
+            git checkout deploykey/main -- benchmarks/results/test262-standalone-highwater.json 2>/dev/null || true
+            node scripts/check-standalone-highwater.mjs \
+              --report "$SA_REPORT" --update ${HW_SHA:+--sha "$HW_SHA"} || \
+              echo "WARN: high-water recompute on re-anchored tip failed (non-fatal)"
+            git add -f benchmarks/results/test262-standalone-highwater.json 2>/dev/null || true
             if git diff --cached --quiet; then
               echo "Summary already current on main after re-anchor — nothing to push."
               PUSHED=1

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1096,6 +1096,26 @@ jobs:
           node scripts/check-standalone-highwater.mjs \
             --report merged-reports/test262-standalone-report-merged.json
 
+      # (#3953) MAKE THE SILENCE LOUD. The step above is the only place in CI
+      # that holds BOTH the committed mark and a fresh measurement of reality,
+      # and it already prints the gap — as an ordinary log line, in a job with
+      # thousands of them. That is why a 475-wide gap went unremarked for 37
+      # consecutive merges: the gate reported "passed" the whole time, because
+      # a floor that is too LOW never fires. Nothing anywhere reported a mark
+      # that had stopped moving.
+      #
+      # This step turns that gap into a run-summary ANNOTATION once it outlives
+      # the grace window. It is deliberately NON-FATAL (`|| true`): `merge shard
+      # reports` is a REQUIRED check, and a lagging mark is an infrastructure
+      # fault, never the fault of the PR sitting in the queue. Failing here
+      # would wedge the queue on someone else's defect.
+      - name: Report a STALE high-water mark (#3953)
+        if: env.STANDALONE_RAN == 'true'
+        run: |
+          node scripts/check-highwater-staleness.mjs \
+            --report merged-reports/test262-standalone-report-merged.json \
+            --annotate || true
+
       # #1668 — HARD catastrophic-regression guard. Lives INSIDE the REQUIRED
       # "merge shard reports" check so it blocks the merge queue. The
       # fine-grained `regression-gate` job below also blocks the merge queue
@@ -2596,6 +2616,19 @@ jobs:
           # via the hourly baseline-summary-sync.yml fallback (6h staleness
           # floor). Fail-open: if the queue query errors, keep the old
           # always-push behavior rather than silently freezing the summary.
+          #
+          # (#3953) ⚠️ THIS DEFERRAL ALSO DISCARDS THE #2097 HIGH-WATER RAISE.
+          # The raise runs earlier in this job and WRITES the mark file; the
+          # commit dropped here is its only carrier. Until 2026-08-02 the
+          # fallback named on the next line did not stage that file at all
+          # (`grep highwater baseline-summary-sync.yml` → 0 hits), so on a
+          # continuously-busy queue the mark could only be landed by the
+          # coincidence of an empty queue at promote time — measured: 37
+          # consecutive merges with no raise, a 475-wide gap, 525 passes of
+          # silent permissive headroom. baseline-summary-sync.yml now stages
+          # and re-raises the mark, so the sentence below is true for it too.
+          # If you ever narrow that fallback's file set, this deferral silently
+          # reopens the hole.
           OWNER="${GITHUB_REPOSITORY%/*}"; NAME="${GITHUB_REPOSITORY#*/}"
           QUEUE_LEN=$(gh api graphql \
             -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){mergeQueue{entries(first:1){totalCount}}}}' \

--- a/plan/issues/3611-promote-skip-highwater-never-raises-on-queue-merges.md
+++ b/plan/issues/3611-promote-skip-highwater-never-raises-on-queue-merges.md
@@ -16,6 +16,39 @@ related: [2097, 3467, 3468, 3448, 3592, 2562, 1078, 3601, 3953]
 origin: "PR-queue shepherd verification of the #3601 (#3592 RC2) landing, 2026-07-25. Surfaced only because a deliberate ~5,000-test move was being watched."
 ---
 
+> ## Adjudication 2026-08-02 (from #3953): this issue is CORRECTLY `done`
+>
+> #3953 was dispatched to determine whether this issue was a **false-done**, a
+> **regression**, or an **incomplete fix**, because its exact symptom — a frozen
+> high-water mark — was live again on 2026-08-02. **It is none of the three.**
+>
+> The fix here works. Verified by content, not by title:
+>
+> - `957adc7b8` (PR #3938) is on main and carries both halves of the `if:` —
+>   `!cancelled()` **and** the explicit `needs.*.result == 'success'` terms.
+> - **AC1 is now satisfiable with a run id**, which this issue explicitly refused
+>   to tick off the structural tests: push:main runs **`30756312728`** and
+>   **`30755117423`** show `promote merged report to main baseline` with
+>   conclusion **`success`**. The pre-fix `skipped` ×30 audit is the control.
+> - The raise itself executes — job **`91518979710`**:
+>   `[standalone-highwater] raised host-free mark 26546 → 27019`.
+> - **AC3 partially landed for real**: the mark advanced **11 times** on main
+>   between 2026-08-01T02:57 and 2026-08-02T12:14 (22626 → 26546). Before this
+>   fix it had not moved on a queue merge at all. That is the direct,
+>   observable, on-main effect this issue was asking for.
+>
+> **The live 2026-08-02 symptom has a THIRD, independent cause downstream of
+> this one** — the raise runs and writes the file, then the main-repo commit
+> carrying it is discarded by the #1951 non-empty-queue deferral, whose named
+> fallback (`baseline-summary-sync.yml`) did not stage the high-water file at
+> all (`grep -c highwater` → 0). Fixed in **#3953**; the measurement and the
+> full evidence table live there.
+>
+> This issue's own diagnosis anticipated the shape but not the layer: it warned
+> that _"a job can succeed while its update step no-ops"_. The update step does
+> not no-op — **its commit is thrown away.** Worth recording precisely, because
+> the two have identical symptoms and different fixes.
+
 # #3611 — the standalone high-water mark never re-raises on queue merges
 
 ## Problem

--- a/plan/issues/3953-highwater-raise-verify-on-merge-and-make-the-silence-loud.md
+++ b/plan/issues/3953-highwater-raise-verify-on-merge-and-make-the-silence-loud.md
@@ -1,10 +1,11 @@
 ---
 id: 3953
 title: "verify the #2097 high-water raise actually executes on a real merge, and make its silence loud — a floor that is too low must stop being cost-free"
-status: ready
+status: done
+completed: 2026-08-02
 sprint: current
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-02
 priority: high
 horizon: m
 feasibility: medium
@@ -13,6 +14,119 @@ area: ci, merge-queue, test262
 goal: release-pipeline
 depends_on: [3611]
 related: [2097, 3448, 3467, 1078, 2562]
+---
+
+## Resolution 2026-08-02 — #3611's fix WORKS; a THIRD defect downstream of it kept the mark frozen
+
+**Adjudication first, because it was the assigned precondition: #3611 is
+correctly `done`. Not regressed, not a false-done, not incomplete in the way it
+was suspected of being.** Its fix executes exactly as designed — and saying so
+matters as much as the new finding, because a false "false-done" verdict would
+have sent someone re-fixing a working fix.
+
+Evidence, by CONTENT rather than by title (a merged PR citing an issue is not
+evidence that issue is done — measured 0/26 in this project):
+
+| claim                                         | evidence                                                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| the fix is on main                            | `957adc7b8` (PR #3938) adds `!cancelled()` + explicit `needs.*.result == 'success'` to `promote-baseline`'s `if:` — read the diff, not the subject |
+| **AC1** the job RUNS on a HIT-path landing    | push:main runs `30756312728` and `30755117423` — `promote merged report to main baseline` conclusion **`success`** (pre-fix control: `skipped` ×30) |
+| **the raise ITSELF executes**                 | job `91518979710` log: `[standalone-highwater] raised host-free mark 26546 → 27019 (commit de9f10bea…)`                                     |
+| **AC3** the mark advanced ON MAIN             | **PARTIAL — 11 raises DID land** (22626 → 25765 → … → 26546 across 2026-08-01T02:57 → 08-02T12:14), then froze                              |
+
+That partial row is the whole story. #3611 predicted the residual risk almost
+exactly — _"a job can succeed while its update step no-ops"_ — and the truth is
+one layer further out still: **the update step succeeds, and the commit that
+carries it is thrown away.**
+
+### The actual gap: the #1951 deferral discards the raise, and its named fallback could not carry it
+
+```
+Merge queue has 4 entrie(s) — deferring main-repo baseline summary commit (#1951).
+It will land via the next promote on an empty queue or the hourly baseline-summary-sync.
+```
+
+The high-water file is written by the raise step and then staged into the **same
+atomic main-repo commit** as the baseline summary. When #1951 defers that commit
+— which it does whenever the merge queue is non-empty — the raise goes with it.
+
+And the fallback that sentence names **provably could not carry it**:
+`grep -c highwater .github/workflows/baseline-summary-sync.yml` → **0**. That
+workflow re-derives its file set from the baselines repo, which does not hold the
+high-water mark at all, and never staged the file.
+
+So both landing paths were conditional on the same coincidence:
+
+| path                                              | condition                                    |
+| ------------------------------------------------- | -------------------------------------------- |
+| `promote-baseline` main-repo commit               | merge queue **empty at promote time**        |
+| `baseline-summary-sync.yml` hourly fallback       | **never** — file not in its staging set      |
+
+**The mark was load-bearing on an empty-queue coincidence.** Under two-lane
+velocity the queue is rarely empty, so it froze.
+
+### Measured motivation (2026-08-02T16:33Z)
+
+| quantity                                       | value                                                    |
+| ---------------------------------------------- | -------------------------------------------------------- |
+| committed mark                                 | `26546` (`generated_at` 2026-08-02T12:14:07Z)            |
+| merge_group current (run `30756313038`)        | `27021`                                                  |
+| effective #2097 floor (mark − tolerance 50)    | `26496`                                                  |
+| **silent permissive headroom**                 | **525 passes**                                           |
+| staleness                                      | **4.3 h / 37 merge commits**                             |
+
+Standalone conformance could have dropped **525 passes** before #2097 fired,
+while every run reported green — because a floor that is too LOW never fires.
+
+### What shipped
+
+1. **`baseline-summary-sync.yml` now genuinely IS the fallback the deferral
+   claims.** It raises the mark from the baselines repo's own standalone report
+   (provenance = that report's `baseline_sha`, the revision actually measured,
+   not this job's unrelated checkout sha) and **stages the file**. A stale mark
+   is also a third drift axis in the `decide` step, and earns the busy-queue
+   bypass at the same 6h floor the summary uses — without that term the two
+   guards **deadlock**: promote defers because the queue is busy, and the sync
+   skips because the queue is busy and the reports are fresh.
+2. **`scripts/check-highwater-staleness.mjs`** — the detector, with a real third
+   state (below).
+3. **The merge_group `#2097` step now annotates a stale mark** — that is the one
+   place in CI holding both the committed mark and a fresh measurement, and it
+   already printed the gap as an ordinary log line among thousands. Deliberately
+   **non-fatal**: `merge shard reports` is required, and a lagging mark is an
+   infrastructure fault, never the queued PR's fault.
+
+### Controls
+
+| control                                                    | result                                                     |
+| ---------------------------------------------------------- | ---------------------------------------------------------- |
+| **positive** — replay the real frozen state (26546 vs 27021) | **FIRES**, exit 1, reports floor 26496 / headroom 525      |
+| **negative** — mark tracks reality (excess 14 ≤ tol 50)      | quiet, exit 0                                              |
+| **negative** — same 475 gap but 30 min old                   | quiet (a promote is plausibly in flight)                   |
+| **third state** — mark absent / garbled / current unreadable | **UNKNOWN, exit 2, `::error::`** — never green             |
+| **third state** — mark has no parseable `generated_at`       | **UNKNOWN**, not "brand new" (the subtle one)              |
+| **defect injection** — delete the `git add` staging line      | **1 of 18** tests fail, and it is the right one            |
+
+Freshness is judged on the artifact's own `generated_at`, never on sha-equality
+with the revision that measured it — per the #3988 lesson, a sha check defers
+100% of the time because main always advances underneath a long promote.
+
+**Two-writer race.** The mark now has two writers (promote on an empty queue,
+and the hourly sync). Both are **raise-only ratchets** — the script rewrites only
+when the measured count strictly exceeds the committed one — so any interleaving
+yields `max(writes)` and neither can lower the mark. The one real ordering hazard
+is writing a value computed against an older committed mark than the one on disk
+at commit time, which is why the sync's re-anchor loop discards its snapshot,
+re-reads the mark from the freshly fetched tip, and recomputes.
+
+### Deliberately NOT done
+
+**The mark was not hand-seeded.** Re-seeding would make ~475 passes of headroom
+non-refundable instantly, and that is a stakeholder decision, not a dev one. If
+this fix works the next qualifying sync raises the mark on its own — which is
+both the proof and the production positive control. AC5 (`refresh-baseline.yml`
+disposition) remains open by design in #3611.
+
 ---
 
 # The two halves of #3611 that a code PR cannot close

--- a/scripts/check-highwater-staleness.mjs
+++ b/scripts/check-highwater-staleness.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3953 — make a STALE #2097 standalone high-water mark LOUD.
+//
+// Why this exists (the shape of the bug it detects):
+//   The #2097 mark is a raise-only floor. When it falls behind reality, the
+//   #2097 gate still reports "passed" — it is just protecting a level far below
+//   the current pass count. **A floor that is too LOW never fires.** So the
+//   failure is completely silent in the permissive direction, and the only way
+//   to see it is to look for the mark FAILING TO MOVE, which nothing did.
+//
+//   Measured 2026-08-02, the state this detector is built against:
+//     mark  = 26546  (generated_at 2026-08-02T12:14:07Z)
+//     current (merge_group) = 27021
+//     floor = 26546 − 50 = 26496
+//   → standalone conformance could have dropped **525 passes** before #2097
+//     fired, while every run reported green. 4.3h and 37 merge commits stale.
+//
+// Two defects in series produced that, and only the first was fixed:
+//   1. #3611 — `promote-baseline` was SKIPPED on the HIT path, so the raise
+//      never ran at all. FIXED (verified: the raise now executes, run
+//      30756312728 / job 91518979710, "raised host-free mark 26546 → 27019").
+//   2. #3953 (this) — the raise now runs and writes the file, but the main-repo
+//      commit CARRYING it is dropped by the #1951 non-empty-merge-queue
+//      deferral. The deferral names `baseline-summary-sync.yml` as the fallback
+//      — and that workflow did not stage the high-water file at all (grep
+//      "highwater" → 0 hits), so the mark was load-bearing on the queue
+//      happening to be empty at promote time.
+//
+// THE THIRD STATE IS THE POINT. A detector that cannot see must not render as
+// "fresh" — that is the same false-empty that made the original bug invisible.
+// An unreadable/absent/garbled mark, an unreadable current measurement, or a
+// mark with no parseable `generated_at` all resolve to UNKNOWN and exit LOUD.
+//
+// Usage:
+//   node scripts/check-highwater-staleness.mjs --current <N> [--max-age-hours H]
+//   node scripts/check-highwater-staleness.mjs --report <merged-standalone-report.json>
+//   ... [--mark <path>] [--annotate] [--now <iso>] [--json]
+//
+// Exit codes:
+//   0 — FRESH   (mark tracks reality, or the gap is younger than the grace)
+//   1 — STALE   (current exceeds the mark by > tolerance AND the mark is old)
+//   2 — UNKNOWN (cannot determine — LOUD, never treated as fresh)
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+export const DEFAULT_MARK_PATH = resolve(REPO_ROOT, "benchmarks/results/test262-standalone-highwater.json");
+
+/** Default grace: the mark may lag reality for this long before it is a breach. */
+export const DEFAULT_MAX_AGE_HOURS = 3;
+/** Fallback tolerance when the mark itself does not carry one. */
+export const DEFAULT_TOLERANCE = 50;
+
+export const FRESH = "FRESH";
+export const STALE = "STALE";
+export const UNKNOWN = "UNKNOWN";
+
+/**
+ * Classify the mark against a current measurement. PURE — all I/O is done by
+ * the caller so this is directly testable (and positive-controllable) without
+ * touching the filesystem or the clock.
+ *
+ * @param {object|null|undefined} mark parsed high-water JSON, or null/undefined if unreadable
+ * @param {number|null|undefined} current current host-free standalone pass count
+ * @param {{maxAgeHours?: number, now?: Date}} [opts]
+ * @returns {{state: string, reason: string, mark: number|null, current: number|null,
+ *            floor: number|null, excess: number|null, headroom: number|null,
+ *            ageHours: number|null, tolerance: number|null}}
+ */
+export function classify(mark, current, opts = {}) {
+  const maxAgeHours = opts.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS;
+  const now = opts.now ?? new Date();
+  const base = {
+    state: UNKNOWN,
+    reason: "",
+    mark: null,
+    current: null,
+    floor: null,
+    excess: null,
+    headroom: null,
+    ageHours: null,
+    tolerance: null,
+  };
+
+  // --- Third state, branch 1: the mark cannot be read. -----------------------
+  // Absent, unparseable, or carrying no numeric host-free count. Explicitly NOT
+  // "fresh": we have no idea what floor is in force, which is strictly worse
+  // than knowing it is stale.
+  if (mark === null || mark === undefined || typeof mark !== "object") {
+    return { ...base, reason: "high-water mark file is missing or unreadable" };
+  }
+  const markPass = mark.host_free_pass ?? mark.pass;
+  if (typeof markPass !== "number" || !Number.isFinite(markPass)) {
+    return { ...base, reason: "high-water mark carries no numeric host_free_pass/pass" };
+  }
+
+  // --- Third state, branch 2: the current measurement cannot be read. --------
+  if (typeof current !== "number" || !Number.isFinite(current)) {
+    return { ...base, mark: markPass, reason: "current standalone pass count is missing or unreadable" };
+  }
+
+  const tolerance = typeof mark.tolerance === "number" ? mark.tolerance : DEFAULT_TOLERANCE;
+  const floor = markPass - tolerance;
+  const excess = current - markPass;
+  // The silent permissive gap: how far conformance could fall from where it
+  // actually is before the #2097 gate would fire.
+  const headroom = current - floor;
+  const withNumbers = { ...base, mark: markPass, current, floor, excess, headroom, tolerance };
+
+  // --- Third state, branch 3: the mark cannot be AGED. ----------------------
+  // (#3988 lesson, applied) Freshness is judged on the artifact's OWN
+  // `generated_at`, never on sha-equality with the revision that measured it —
+  // main always advances underneath a long promote, so a sha check would defer
+  // 100% of the time and report "fresh" forever.
+  const generatedAt = mark.generated_at;
+  const ts = generatedAt ? Date.parse(generatedAt) : Number.NaN;
+  if (!Number.isFinite(ts)) {
+    return {
+      ...withNumbers,
+      reason: "high-water mark has no parseable `generated_at` — cannot determine its age",
+    };
+  }
+  const ageHours = (now.getTime() - ts) / 3_600_000;
+  const sized = { ...withNumbers, ageHours };
+
+  // --- Determinate states ---------------------------------------------------
+  // A mark BELOW current by no more than the tolerance is doing its job: the
+  // gate's floor still tracks reality closely. Only a gap wider than the
+  // tolerance represents headroom a regression could hide in.
+  if (excess <= tolerance) {
+    return { ...sized, state: FRESH, reason: `mark tracks current (excess ${excess} ≤ tolerance ${tolerance})` };
+  }
+  // A wide gap that is BRAND NEW is normal: a merge just improved conformance
+  // and the promote has not landed yet. Only a wide gap that PERSISTS is the
+  // defect — that is the "fails to move" signature.
+  if (ageHours < maxAgeHours) {
+    return {
+      ...sized,
+      state: FRESH,
+      reason: `mark is ${excess} behind but only ${ageHours.toFixed(1)}h old (grace ${maxAgeHours}h) — a promote is likely in flight`,
+    };
+  }
+  return {
+    ...sized,
+    state: STALE,
+    reason:
+      `mark ${markPass} is ${excess} behind current ${current} and ${ageHours.toFixed(1)}h old ` +
+      `(grace ${maxAgeHours}h) — the #2097 floor is ${floor}, so standalone conformance could drop ` +
+      `${headroom} passes before the gate fires`,
+  };
+}
+
+/** Read + parse the mark, returning null on ANY failure (→ UNKNOWN upstream). */
+export function loadMark(path) {
+  try {
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Read the current host-free standalone pass count from a merged report. */
+export function currentFromReport(path) {
+  try {
+    const r = JSON.parse(readFileSync(resolve(path), "utf-8"));
+    const v = r?.full_summary?.host_free_pass ?? r?.summary?.host_free_pass;
+    return typeof v === "number" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const args = {
+    current: undefined,
+    report: undefined,
+    mark: DEFAULT_MARK_PATH,
+    maxAgeHours: DEFAULT_MAX_AGE_HOURS,
+    annotate: false,
+    json: false,
+    now: undefined,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--current") args.current = Number(argv[++i]);
+    else if (a === "--report") args.report = argv[++i];
+    else if (a === "--mark") args.mark = argv[++i];
+    else if (a === "--max-age-hours") args.maxAgeHours = Number(argv[++i]);
+    else if (a === "--now") args.now = new Date(argv[++i]);
+    else if (a === "--annotate") args.annotate = true;
+    else if (a === "--json") args.json = true;
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: node scripts/check-highwater-staleness.mjs (--current <N> | --report <r.json>) " +
+          "[--mark <path>] [--max-age-hours H] [--annotate] [--json]\n" +
+          "Exit: 0 FRESH · 1 STALE · 2 UNKNOWN (loud — never green)",
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const mark = loadMark(args.mark);
+  const current = Number.isFinite(args.current) ? args.current : args.report ? currentFromReport(args.report) : null;
+
+  const r = classify(mark, current, { maxAgeHours: args.maxAgeHours, now: args.now });
+
+  if (args.json) {
+    console.log(JSON.stringify(r, null, 2));
+  } else {
+    console.log(
+      `[highwater-staleness] ${r.state}: ${r.reason}` +
+        (r.mark !== null ? ` (mark=${r.mark}, current=${r.current ?? "?"}, floor=${r.floor ?? "?"})` : ""),
+    );
+  }
+
+  if (args.annotate) {
+    // UNKNOWN is annotated as an ERROR, not a warning: "I cannot see" must be
+    // at least as loud as "I see a problem". Rendering it quietly is the exact
+    // false-empty this detector exists to prevent.
+    if (r.state === UNKNOWN) console.log(`::error title=High-water mark: CANNOT DETERMINE::${r.reason}`);
+    else if (r.state === STALE) console.log(`::error title=High-water mark is STALE::${r.reason}`);
+  }
+
+  process.exit(r.state === FRESH ? 0 : r.state === STALE ? 1 : 2);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/issue-3953-highwater-staleness.test.ts
+++ b/tests/issue-3953-highwater-staleness.test.ts
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3953 — the #2097 high-water staleness detector.
+//
+// The load-bearing tests here are the CONTROLS, not the shape assertions:
+//   • POSITIVE control — replay the exact frozen state measured on 2026-08-02
+//     (mark 26546 @ 12:14:07Z vs merge_group current 27021) and show it FIRES.
+//     A detector that has never been shown to fire on a real defect is not
+//     evidence of anything.
+//   • NEGATIVE control — a mark that tracks reality stays QUIET, so the alarm
+//     is specific rather than merely sensitive.
+//   • THIRD-STATE controls — every "cannot see" input resolves to UNKNOWN, not
+//     FRESH. This is the whole point: the original bug was invisible precisely
+//     because absence rendered as OK.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { classify, FRESH, STALE, UNKNOWN, DEFAULT_MAX_AGE_HOURS } from "../scripts/check-highwater-staleness.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const HIGHWATER_FILE = "benchmarks/results/test262-standalone-highwater.json";
+const readWorkflow = (name: string) => readFileSync(resolve(REPO_ROOT, ".github/workflows", name), "utf-8");
+
+// The literal committed mark on main at the time #3953 was diagnosed.
+const FROZEN_MARK = {
+  pass: 26546,
+  host_free_pass: 26546,
+  official_pass: 26247,
+  official_total: 43505,
+  sha: "93b8f068bd9ddf43c6f97c9e082fc043cf1f78f5",
+  generated_at: "2026-08-02T12:14:07Z",
+  tolerance: 50,
+};
+// What merge_group run 30756313038 actually read at 16:29:07Z.
+const OBSERVED_CURRENT = 27021;
+const OBSERVED_NOW = new Date("2026-08-02T16:33:32Z");
+
+describe("#3953 high-water staleness detector", () => {
+  describe("positive control — the real 2026-08-02 frozen state", () => {
+    it("FIRES on the measured mark/current pair", () => {
+      const r = classify(FROZEN_MARK, OBSERVED_CURRENT, { now: OBSERVED_NOW });
+      expect(r.state).toBe(STALE);
+    });
+
+    it("reports the silent permissive headroom as 525 passes", () => {
+      const r = classify(FROZEN_MARK, OBSERVED_CURRENT, { now: OBSERVED_NOW });
+      // floor = 26546 − 50 = 26496; reality = 27021 → 525 passes could vanish
+      // before #2097 fires. This number IS the defect's cost.
+      expect(r.floor).toBe(26496);
+      expect(r.headroom).toBe(525);
+      expect(r.excess).toBe(475);
+    });
+
+    it("ages the mark from its own generated_at (~4.3h)", () => {
+      const r = classify(FROZEN_MARK, OBSERVED_CURRENT, { now: OBSERVED_NOW });
+      expect(r.ageHours).toBeGreaterThan(4);
+      expect(r.ageHours).toBeLessThan(4.5);
+    });
+  });
+
+  describe("negative control — a healthy mark stays quiet", () => {
+    it("is FRESH when the mark tracks current within tolerance", () => {
+      const r = classify({ ...FROZEN_MARK, host_free_pass: 27000 }, OBSERVED_CURRENT, { now: OBSERVED_NOW });
+      // excess = 21 ≤ tolerance 50 → the floor still tracks reality.
+      expect(r.state).toBe(FRESH);
+    });
+
+    it("is FRESH when a wide gap is younger than the grace window", () => {
+      // Same 475-wide gap, but the mark was written 30 minutes ago — a promote
+      // is plausibly in flight, so this must NOT alarm.
+      const justNow = { ...FROZEN_MARK, generated_at: "2026-08-02T16:03:32Z" };
+      const r = classify(justNow, OBSERVED_CURRENT, { now: OBSERVED_NOW });
+      expect(r.state).toBe(FRESH);
+      expect(r.excess).toBe(475);
+    });
+
+    it("still fires once that same gap outlives the grace window", () => {
+      const aged = { ...FROZEN_MARK, generated_at: "2026-08-02T12:00:00Z" };
+      const r = classify(aged, OBSERVED_CURRENT, {
+        now: OBSERVED_NOW,
+        maxAgeHours: DEFAULT_MAX_AGE_HOURS,
+      });
+      expect(r.state).toBe(STALE);
+    });
+  });
+
+  describe("third state — 'cannot see' is LOUD, never FRESH", () => {
+    it("UNKNOWN when the mark file is absent/unreadable", () => {
+      expect(classify(null, OBSERVED_CURRENT).state).toBe(UNKNOWN);
+      expect(classify(undefined, OBSERVED_CURRENT).state).toBe(UNKNOWN);
+    });
+
+    it("UNKNOWN when the mark is garbled (no numeric pass count)", () => {
+      expect(classify({ sha: "abc", generated_at: "2026-08-02T12:14:07Z" }, OBSERVED_CURRENT).state).toBe(UNKNOWN);
+      expect(classify({ host_free_pass: "lots" }, OBSERVED_CURRENT).state).toBe(UNKNOWN);
+      expect(classify({ host_free_pass: Number.NaN }, OBSERVED_CURRENT).state).toBe(UNKNOWN);
+    });
+
+    it("UNKNOWN when the current measurement cannot be read", () => {
+      expect(classify(FROZEN_MARK, null).state).toBe(UNKNOWN);
+      expect(classify(FROZEN_MARK, undefined).state).toBe(UNKNOWN);
+      expect(classify(FROZEN_MARK, Number.NaN).state).toBe(UNKNOWN);
+    });
+
+    it("UNKNOWN when the mark cannot be AGED — not FRESH by default", () => {
+      // This is the subtle one. A mark with no parseable timestamp would, under
+      // a naive `age < grace ⇒ fresh` reading, look BRAND NEW and silence the
+      // alarm forever — the failure mode this whole issue is about.
+      const undateable = { ...FROZEN_MARK, generated_at: undefined };
+      const r = classify(undateable, OBSERVED_CURRENT, { now: OBSERVED_NOW });
+      expect(r.state).toBe(UNKNOWN);
+      expect(r.state).not.toBe(FRESH);
+
+      expect(classify({ ...FROZEN_MARK, generated_at: "not-a-date" }, OBSERVED_CURRENT).state).toBe(UNKNOWN);
+    });
+
+    it("still surfaces the numbers it DID manage to read", () => {
+      // "I don't know" should not throw away partial evidence.
+      const r = classify({ ...FROZEN_MARK, generated_at: "garbage" }, OBSERVED_CURRENT, { now: OBSERVED_NOW });
+      expect(r.state).toBe(UNKNOWN);
+      expect(r.mark).toBe(26546);
+      expect(r.current).toBe(27021);
+      expect(r.headroom).toBe(525);
+    });
+  });
+
+  // These are REGRESSION GUARDS, not evidence the pipeline works — the only
+  // evidence for that is the mark actually advancing on main (see #3953's
+  // observable-acceptance note). They exist because the defect was precisely an
+  // absent line: the promote job's #1951 deferral names baseline-summary-sync as
+  // the fallback carrier, and that workflow never staged the file, so the
+  // deferral silently discarded every raise.
+  describe("the named fallback carrier actually carries the mark", () => {
+    it("baseline-summary-sync stages the high-water file", () => {
+      const wf = readWorkflow("baseline-summary-sync.yml");
+      expect(wf).toContain(`git add -f ${HIGHWATER_FILE}`);
+    });
+
+    it("baseline-summary-sync RAISES the mark before staging it", () => {
+      // Staging alone would commit whatever stale copy the checkout had.
+      const wf = readWorkflow("baseline-summary-sync.yml");
+      expect(wf).toContain("check-standalone-highwater.mjs");
+      expect(wf).toMatch(/--report "\$SA_REPORT" --update/);
+    });
+
+    it("re-anchor loop re-reads the mark from the fetched tip (raise-only race guard)", () => {
+      // Without this the snapshot copy-back can LOWER a mark that
+      // promote-baseline raised higher while this job was running.
+      const wf = readWorkflow("baseline-summary-sync.yml");
+      expect(wf).toContain(`git checkout deploykey/main -- ${HIGHWATER_FILE}`);
+    });
+
+    it("a stale mark forces a sync even when both reports look unchanged", () => {
+      const wf = readWorkflow("baseline-summary-sync.yml");
+      expect(wf).toContain("check-highwater-staleness.mjs");
+      expect(wf).toContain('[ "$HIGHWATER_STALE" = "0" ]');
+      // ...and earns the busy-queue bypass, or promote-defers and sync-skips
+      // deadlock while the queue stays busy.
+      expect(wf).toContain('[ "$HIGHWATER_STALE_6H" = "0" ]');
+    });
+
+    it("the merge_group gate annotates a stale mark", () => {
+      const wf = readWorkflow("test262-sharded.yml");
+      expect(wf).toContain("Report a STALE high-water mark (#3953)");
+      expect(wf).toContain("check-highwater-staleness.mjs");
+    });
+
+    it("that annotation is NON-fatal — it must not wedge the required check", () => {
+      // `merge shard reports` is required; a lagging mark is an infrastructure
+      // fault, never the queued PR's fault.
+      const wf = readWorkflow("test262-sharded.yml");
+      const idx = wf.indexOf("Report a STALE high-water mark (#3953)");
+      expect(idx).toBeGreaterThan(-1);
+      expect(wf.slice(idx, idx + 800)).toContain("--annotate || true");
+    });
+  });
+
+  describe("tolerance is read from the mark, not hardcoded", () => {
+    it("honours a mark-supplied tolerance", () => {
+      const wide = { ...FROZEN_MARK, tolerance: 1000 };
+      const r = classify(wide, OBSERVED_CURRENT, { now: OBSERVED_NOW });
+      // excess 475 ≤ tolerance 1000 → not a staleness breach at that tolerance.
+      expect(r.state).toBe(FRESH);
+      expect(r.tolerance).toBe(1000);
+    });
+  });
+});


### PR DESCRIPTION
Closes #3953. Adjudicates #3611.

## Adjudication first — #3611 is CORRECTLY `done`

This issue was dispatched to determine whether #3611 was a false-done, a regression, or an incomplete fix, because its exact symptom was live again today. **It is none of the three, and saying so matters as much as the new finding** — a false "false-done" verdict would have sent someone re-fixing a working fix.

Verified by **content, not title** (a merged PR citing an issue is not evidence it is done — measured 0/26 here):

| claim | evidence |
|---|---|
| fix is on main | `957adc7b8` (PR #3938) carries both halves of the `if:` |
| **AC1** job runs on the HIT path | push:main runs `30756312728`, `30755117423` → `promote merged report to main baseline` = **`success`** (pre-fix control: `skipped` ×30) |
| the raise itself executes | job `91518979710`: `raised host-free mark 26546 → 27019` |
| **AC3** mark advanced on main | **11 raises landed**, 22626 → 26546 (08-01T02:57 → 08-02T12:14), then froze |

## The actual gap — a third defect, downstream of both

The raise executes and writes the file. The **main-repo commit carrying it** is then discarded by the #1951 non-empty-merge-queue deferral:

```
Merge queue has 4 entrie(s) — deferring main-repo baseline summary commit (#1951).
It will land via the next promote on an empty queue or the hourly baseline-summary-sync.
```

And the fallback that sentence names **provably could not carry it**: `grep -c highwater .github/workflows/baseline-summary-sync.yml` → **0**. It re-derives its file set from the baselines repo, which does not hold the mark at all.

Both landing paths were therefore conditional on the same coincidence — an empty queue at promote time. Under two-lane velocity, rarely.

#3611 anticipated the shape but not the layer: it warned *"a job can succeed while its update step no-ops."* The update step does **not** no-op — **its commit is thrown away.** Identical symptoms, different fix.

### Measured (2026-08-02T16:33Z)

| | |
|---|---|
| committed mark | `26546` @ 12:14:07Z |
| merge_group current (run `30756313038`) | `27021` |
| effective #2097 floor | `26496` |
| **silent permissive headroom** | **525 passes** |
| staleness | **4.3 h / 37 merge commits** |

525 passes could have vanished before #2097 fired, with every run green — a floor that is too LOW never fires.

## What shipped

1. **`baseline-summary-sync.yml` genuinely IS the fallback it was named as** — raises the mark from the baselines repo's own standalone report and **stages** it. Provenance is that report's `baseline_sha` (the revision actually measured), never this job's unrelated checkout sha. A stale mark is a third drift axis in `decide`, and earns the busy-queue bypass at the **same 6h floor** the summary uses — without that term the two guards **deadlock** (promote defers on a busy queue; sync skips on a busy queue with fresh reports).
2. **`scripts/check-highwater-staleness.mjs`** — the detector, with a real third state.
3. **The merge_group #2097 step annotates a stale mark** — the one place in CI holding both the mark and a fresh measurement. Deliberately **non-fatal**: `merge shard reports` is required, and a lagging mark is an infrastructure fault, never the queued PR's fault.

## Controls

| control | result |
|---|---|
| **positive** — replay the real frozen state (26546 vs 27021) | **FIRES**, exit 1, floor 26496 / headroom 525 |
| **negative** — mark tracks reality (excess 14 ≤ tol 50) | quiet |
| **negative** — same 475 gap, only 30 min old | quiet (promote plausibly in flight) |
| **third state** — mark absent / garbled / current unreadable | **UNKNOWN, exit 2, `::error::`** |
| **third state** — no parseable `generated_at` | **UNKNOWN**, not "brand new" (the subtle one) |
| **defect injection** — delete the `git add` staging line | **1 of 18** tests fail, and it is the right one |

Freshness keys on the artifact's own `generated_at`, never sha-equality with the measured revision (#3988 lesson: a sha check defers 100% of the time).

**Two-writer race, stated explicitly.** Two writers now exist (promote on an empty queue, hourly sync). Both are **raise-only ratchets**, so any interleaving yields `max(writes)` and neither can lower the mark. The real hazard is writing a value computed against an older committed mark than the one on disk at commit time — hence the re-anchor loop discards its snapshot, re-reads the mark from the freshly fetched tip, and recomputes. `baseline-summary-sync` is `cancel-in-progress: false` on an hourly cron with a 15-min timeout, so no cancellation interaction.

## Deliberately not done

**The mark is NOT hand-seeded.** Re-seeding makes ~475 passes of headroom non-refundable instantly — a stakeholder decision, not a dev one. If this works the next qualifying sync raises it unaided, which is both the proof and the production positive control.

## Verification

- 18/18 new tests + 7/7 #3611 tests pass (25/25)
- `tsc --noEmit`: 0 errors · prettier clean · biome clean · `update-issues --check` exit 0
- Both workflows parse (prettier YAML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
