### PR TITLE
IR: prepare Promise delay closures before emit

### DIFF
--- a/plan/issues/4102-ir-promise-delay-closure-compile-once.md
+++ b/plan/issues/4102-ir-promise-delay-closure-compile-once.md
@@ -1,0 +1,150 @@
+---
+id: 4102
+title: "IR R3: prepare the exact Promise-delay closure component before direct body emission"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: critical
+horizon: m
+complexity: M
+feasibility: hard
+reasoning_effort: high
+task_type: refactor
+area: ir, codegen, compiler
+language_feature: Promise, closures, setTimeout
+es_edition: ES2015
+goal: ir-full-coverage
+lane: ir-retirement-r3
+parent: 3521
+depends_on: [4041]
+related: [2138, 2856, 3520, 3521]
+origin: "R3 prerequisite: move the checker-certified Promise delay and its two lifted closures onto prepare-before-emit ownership"
+files:
+  - src/codegen/ir-prepared-free-functions.ts
+  - src/codegen/index.ts
+  - src/codegen/program-abi-type-planning.ts
+  - src/ir/integration.ts
+  - src/ir/prepared-closure-support.ts
+  - src/ir/prepared-component-dependencies.ts
+  - src/ir/prepared-component-sealing.ts
+  - tests/issue-3521-prepared-component-dependencies.test.ts
+  - tests/issue-4102-ir-promise-delay-closure-compile-once.test.ts
+  - tests/issue-4102-program-abi-closure-support.test.ts
+---
+
+# #4102 — prepare the exact Promise-delay closure component before direct emission
+
+## Objective
+
+Move only the already checker-certified delay shape onto real prepared-component
+ownership:
+
+```ts
+export function delay(ms: number, value: number): Promise<number> {
+  return new Promise<number>((resolve) => {
+    setTimeout(() => resolve(value), ms);
+  });
+}
+```
+
+The owner, executor closure, and timer closure must be built, dependency-closed,
+and sealed before `compileDeclarations` emits any body. The owner then emits
+exactly once through IR (`legacyBodyEmitted: false`, `irBodyEmitted: true`) and
+has a real `preparedComponentId`. This is a closure-ownership prerequisite for
+R3; it is not async-function selection and does not introduce or consume an
+async plan.
+
+## Existing capability
+
+#2856 already owns the exact semantic certification and lowering:
+
+- global, unshadowed `Promise` and `setTimeout` identities;
+- an exact two-parameter `f64, f64 -> Promise` owner ABI;
+- deterministic derived identities for the executor and timer arrows;
+- exact capture order and lifted signatures;
+- the four runtime imports `Promise_new`, `__timer_set_timeout`,
+  `__box_number`, and `__call_1_f64`;
+- runtime settlement, concurrent-call isolation, malformed-shape rejection,
+  import-collision demotion, and optimized byte determinism.
+
+That lowering currently runs after direct body emission. R2 preparation also
+rejects every function containing nested executable syntax. The missing piece
+is ownership of the already-planned closure support, not another Promise or
+closure recognizer.
+
+## Implementation boundary
+
+1. After final runtime/import preparation, select an R3 candidate only when the
+   exact #2856 construction plan still matches its authoritative top-level
+   function unit, allocated `(f64, f64) -> externref` slot, source AST identity,
+   and non-escaping callable use.
+2. Project the owner through the existing prepared free-function transaction.
+   Preserve the inherited compile-once skip set for unrelated functions.
+3. Immediately before prepared-component sealing, materialize the wrapper,
+   lifted-funcref, and captured-subtype types referenced by the final
+   `closure.new`, `closure.cap`, and `closure.call` population.
+4. Give those physical types canonical Program ABI support bindings and expose
+   the exact refs to dependency discovery. Reuse the same closure registry
+   instance during lowering so no post-seal duplicate subtype is allocated.
+5. Settle all four delay imports before direct emission. Later direct-only
+   imports may shift indices through the established fixups, but may not change
+   ownership or closure layout.
+
+The closure-support step must fail closed. Unsupported closure signatures,
+capture types, stale derived identities, or missing Program ABI bindings leave
+the whole component on the direct route before any owner body is skipped.
+
+## Non-goals
+
+- no generic nested-function or function-expression widening;
+- no async/generator selection and no `IrAsyncPlan` production or consumption;
+- no Promise shape beyond #2856's exact certified delay;
+- no host-free, WASI, fast, native-string, or multi-module widening;
+- no unsealed pre-direct transaction and no success without a
+  `preparedComponentId`;
+- no new runtime helpers or changes to Promise/timer ABI.
+
+## Acceptance criteria
+
+- The exact delay outcome has `legacyBodyEmitted: false`,
+  `irBodyEmitted: true`, and a `prepared-component:*` identity.
+- `irFirstSkipped` contains the exact owner, while `irCompiledFuncs` contains
+  the owner plus both deterministic lifted closure names.
+- Optimized and unoptimized binaries validate and concurrent calls settle to
+  their own values.
+- A direct-only function that adds a later import cannot corrupt the prepared
+  delay's call or closure indices.
+- A near-miss Promise shape remains direct (`legacyBodyEmitted: true`,
+  `irBodyEmitted: false`) and has no prepared-component identity.
+- Runtime-helper collisions retain the existing preclaim demotion behavior.
+- The four delay imports and their signatures are unchanged; no replacement
+  callback helper appears.
+- Focused Promise-delay, prepared-routing, typecheck, IR fallback, and relevant
+  pre-push gates pass with no census withdrawal.
+
+## Current status
+
+Implementation is complete on the #4041 merge base. The exact selector routes
+only the certified Promise delay through preparation. One pre-seal closure
+registry allocates the final wrapper/subtype population, Program ABI planning
+publishes support refs keyed by the exact post-pass function/instruction/type
+objects, and lowering reuses that same registry. Exact derived callable slots
+and the four settled imports are planned before dependency discovery seals the
+component. A private physical name keeps early derived slots separate from
+source functions that reuse the lifted display names.
+
+The positive owner now has a real `prepared-component:*` identity and no
+legacy body; both lifted closures emit through IR. Empty or unrelated closure
+evidence remains blocked, nested signature dependencies are still discovered,
+near misses remain direct, runtime-helper collisions retain preclaim demotion,
+and optimized/unoptimized concurrent delay calls settle correctly.
+
+Validation on this worktree:
+
+- focused #2856/#3521/#4102: 56/56 passing;
+- typecheck, IR fallback, LOC budget, function budget, and diff checks passing;
+- migration census: 33/37 IR bodies, 34 legacy bodies, 4 Unsupported, 0 Invariant.
+
+The full #3521 prepared-routing file retains its existing class-member boundary
+failure on current `origin/main`; #4102 does not change that path.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -143,7 +143,6 @@ import {
 import {
   buildIrExactFunctionClaimIndex,
   buildIrRequestedFunctionSkipProjection,
-  computeIrFirstSkipUnitIds,
   correlateIrSkippedBodyNames,
   correlateIrSkippedFunctionNames,
   mergeIrIntegrationReports,
@@ -151,9 +150,11 @@ import {
 } from "./ir-overlay-safety.js";
 import {
   completePreparedIrIntegration,
+  computePreparedInheritedIrFirstSkipUnitIds,
   prepareIrClassMethodBodies,
   prepareIrFreeFunctionBodies,
   selectR2PreparedFreeFunctions,
+  selectR3PreparedPromiseDelayFunctions,
   selectPreparedClassMethodNames,
   type PreparedIrClassMethodBodies,
   type PreparedIrFreeFunctionBodies,
@@ -3200,6 +3201,20 @@ function planIrFirstBodyRouting(
   plan: IrOverlayPlan,
 ): IrFirstBodyRouting {
   const preliminarySelection = plan.safeSelection;
+  const inheritedSkipInput = {
+    sourceFile,
+    identityContext: plan.identityPlan.identityContext,
+    safeFunctionUnitIds: plan.identityPlan.safeFunctionUnitIds,
+    claimsByUnitId: plan.functionClaimsByUnitId,
+    overridesByUnitId: plan.overrideMapByUnitId,
+    potentiallyBlockedOwnerUnitIds: new Set([
+      ...[...plan.hostVoidCallbacks.values()].map((callback) => callback.ownerUnitId),
+      ...plan.hostDateImportsByOwnerUnitId.keys(),
+      ...[...plan.promiseDelays.constructions.values()].map((delay) => delay.ownerUnitId),
+    ]),
+    generatorsSkippable: !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports),
+    fast: ctx.fast,
+  };
   const hasLateFeaturePreparation =
     plan.importedCalls.size > 0 ||
     plan.hostVoidCallbacks.size > 0 ||
@@ -3225,14 +3240,18 @@ function planIrFirstBodyRouting(
   // selectR2PreparedFreeFunctions closes candidates over exact local call
   // edges, so any callable edge that crosses into one of those owners removes
   // the complete affected free-function component before preparation.
-  const useR2PreparedRouting = preliminaryR2Names.size > 0 || preliminaryClassMethodNames.size > 0;
+  const hasPromiseDelayComponent = plan.promiseDelays.constructions.size > 0;
+  const usePreparedRouting =
+    preliminaryR2Names.size > 0 || preliminaryClassMethodNames.size > 0 || hasPromiseDelayComponent;
+  let finalizedSelection: Pick<IrSelection, "funcs" | "classMembers" | "moduleInit"> | undefined;
 
-  if (useR2PreparedRouting) {
+  if (usePreparedRouting) {
     // TDZ globals are part of the frozen Program ABI and may be read while
-    // the IR program is prepared. The fallback branch deliberately keeps
-    // their legacy declaration-pass order.
+    // the IR program is prepared. The exact Promise-delay route also settles
+    // its late runtime imports here, before any direct body can bake funcIdxs.
     prepareModuleTdzGlobals(ctx, sourceFile);
     const preparedSelection = finalizePreparedIrSelection(ctx, sourceFile, plan);
+    finalizedSelection = preparedSelection;
     if ([...preliminaryR2Names].some((legacyName) => !preparedSelection.funcs.has(legacyName))) {
       throw new IrInvariantError(
         "selection-preparation-mismatch",
@@ -3248,41 +3267,64 @@ function planIrFirstBodyRouting(
         "R3 final-context preparation changed a preflight-certified class-method component",
       );
     }
-    const freeFunctionSelection = {
-      funcs: preliminaryR2Names,
-      classMembers: new Set<string>(),
-      moduleInit: undefined,
-    };
-    const preparedFreeFunctions = prepareIrFreeFunctionBodies({
+    const promiseDelayNames = selectR3PreparedPromiseDelayFunctions({
       ctx,
       sourceFile,
-      selection: freeFunctionSelection,
-      claimsByUnitId: plan.functionClaimsByUnitId,
-      overrideMap: plan.overrideMap,
-      classShapes: plan.classShapes,
-      loweringPlans: irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, freeFunctionSelection),
-    });
-    const preparedClassMethods = prepareIrClassMethodBodies({
-      ctx,
-      sourceFile,
-      selection: { classMembers: preliminaryClassMethodNames },
+      selectedLegacyNames: preparedSelection.funcs,
       identityPlan: plan.identityPlan,
-      overrideMap: plan.overrideMap,
-      classShapes: plan.classShapes,
-      projectLoweringPlans: (selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
+      claimsByUnitId: plan.functionClaimsByUnitId,
+      overridesByUnitId: plan.overrideMapByUnitId,
+      promiseDelays: plan.promiseDelays,
     });
-    const preparedReport = preparedClassMethods
-      ? mergeIrIntegrationReports(preparedFreeFunctions.report, preparedClassMethods.report)
-      : preparedFreeFunctions.report;
-    return {
-      requestedSkipProjection: preparedFreeFunctions.requestedSkipProjection,
-      preparedFreeFunctions,
-      ...(preparedClassMethods ? { preparedClassMethods } : {}),
-      preparedReport,
-      preparedSelection,
-      skipBodies: preparedFreeFunctions.skipBodies,
-      preserveBodies: preparedFreeFunctions.preserveBodies,
-    };
+    const preparedFreeFunctionNames = new Set([...preliminaryR2Names, ...promiseDelayNames]);
+    if (preparedFreeFunctionNames.size === 0 && preliminaryClassMethodNames.size === 0) {
+      // Final-context Promise preparation may reject an occupied/mismatched
+      // runtime ABI. Keep that owner on the established direct route.
+    } else {
+      const freeFunctionSelection = {
+        funcs: preparedFreeFunctionNames,
+        classMembers: new Set<string>(),
+        moduleInit: undefined,
+      };
+      const preparedFreeFunctions = prepareIrFreeFunctionBodies({
+        ctx,
+        sourceFile,
+        selection: freeFunctionSelection,
+        claimsByUnitId: plan.functionClaimsByUnitId,
+        overrideMap: plan.overrideMap,
+        classShapes: plan.classShapes,
+        loweringPlans: irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, freeFunctionSelection),
+      });
+      const preparedClassMethods = prepareIrClassMethodBodies({
+        ctx,
+        sourceFile,
+        selection: { classMembers: preliminaryClassMethodNames },
+        identityPlan: plan.identityPlan,
+        overrideMap: plan.overrideMap,
+        classShapes: plan.classShapes,
+        projectLoweringPlans: (selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
+      });
+      const preparedReport = preparedClassMethods
+        ? mergeIrIntegrationReports(preparedFreeFunctions.report, preparedClassMethods.report)
+        : preparedFreeFunctions.report;
+      const requestedSkipUnitIds = computePreparedInheritedIrFirstSkipUnitIds(inheritedSkipInput);
+      for (const entry of preparedFreeFunctions.requestedSkipProjection.entries) {
+        requestedSkipUnitIds.add(entry.unitId);
+      }
+      const requestedSkipProjection = buildIrRequestedFunctionSkipProjection(
+        requestedSkipUnitIds,
+        plan.functionClaimsByUnitId,
+      );
+      return {
+        requestedSkipProjection,
+        preparedFreeFunctions,
+        ...(preparedClassMethods ? { preparedClassMethods } : {}),
+        preparedReport,
+        preparedSelection,
+        skipBodies: new Set(requestedSkipProjection.entries.map(({ legacyName }) => legacyName)),
+        preserveBodies: preparedFreeFunctions.preserveBodies,
+      };
+    }
   }
 
   // Free-function components outside the bounded R2 population retain the
@@ -3290,59 +3332,7 @@ function planIrFirstBodyRouting(
   // This keeps fast numeric, structured ABI, cross-policy call components,
   // and late support discovery byte-compatible until their state moves into
   // preparation.
-  const generatorsSkippable = !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports);
-  const requestedSkipUnitIds = new Set(
-    computeIrFirstSkipUnitIds({
-      sourceFile,
-      identityContext: plan.identityPlan.identityContext,
-      safeFunctionUnitIds: plan.identityPlan.safeFunctionUnitIds,
-      claimsByUnitId: plan.functionClaimsByUnitId,
-      overridesByUnitId: plan.overrideMapByUnitId,
-      potentiallyBlockedOwnerUnitIds: new Set([
-        ...[...plan.hostVoidCallbacks.values()].map((callback) => callback.ownerUnitId),
-        ...plan.hostDateImportsByOwnerUnitId.keys(),
-        ...[...plan.promiseDelays.constructions.values()].map((delay) => delay.ownerUnitId),
-      ]),
-      generatorsSkippable,
-    }),
-  );
-  // Fast mode can ground source `number` positions to i32 during direct body
-  // discovery even though the early IR override still says f64. Keep only the
-  // annotation-proven boolean subset on the inherited compile-once route until
-  // exact callable-contract comparison moves into R2 preparation.
-  if (ctx.fast) {
-    const fastBlockedUnitIds = new Set<IrUnitId>();
-    for (const unitId of requestedSkipUnitIds) {
-      const declaration = plan.functionClaimsByUnitId.get(unitId)?.declaration;
-      const stableFastSignature =
-        declaration !== undefined &&
-        declaration.parameters.every(
-          (parameter) =>
-            !parameter.questionToken &&
-            !parameter.dotDotDotToken &&
-            !parameter.initializer &&
-            parameter.type?.kind === ts.SyntaxKind.BooleanKeyword,
-        ) &&
-        (declaration.type?.kind === ts.SyntaxKind.BooleanKeyword ||
-          declaration.type?.kind === ts.SyntaxKind.VoidKeyword);
-      if (!stableFastSignature) {
-        requestedSkipUnitIds.delete(unitId);
-        fastBlockedUnitIds.add(unitId);
-      }
-    }
-    const callEdges = collectLocalCallEdgesByIdentity(sourceFile, plan.identityPlan.identityContext);
-    for (let changed = true; changed; ) {
-      changed = false;
-      for (const unitId of requestedSkipUnitIds) {
-        if (![...(callEdges.callees.get(unitId) ?? [])].some((calleeUnitId) => fastBlockedUnitIds.has(calleeUnitId))) {
-          continue;
-        }
-        requestedSkipUnitIds.delete(unitId);
-        fastBlockedUnitIds.add(unitId);
-        changed = true;
-      }
-    }
-  }
+  const requestedSkipUnitIds = computePreparedInheritedIrFirstSkipUnitIds(inheritedSkipInput);
   const requestedSkipProjection = buildIrRequestedFunctionSkipProjection(
     requestedSkipUnitIds,
     plan.functionClaimsByUnitId,
@@ -3350,6 +3340,7 @@ function planIrFirstBodyRouting(
   return {
     requestedSkipProjection,
     skipBodies: new Set(requestedSkipProjection.entries.map(({ legacyName }) => legacyName)),
+    ...(finalizedSelection ? { preparedSelection: finalizedSelection } : {}),
   };
 }
 
@@ -3882,7 +3873,7 @@ export function generateModule(
         : undefined,
     );
     if (irFirst) {
-      const skipProjection = preparedFreeFunctions?.requestedSkipProjection ?? requestedSkipProjection;
+      const skipProjection = requestedSkipProjection;
       if (!skipProjection) {
         throw new IrInvariantError(
           "selection-preparation-mismatch",

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -5,7 +5,12 @@ import type { IrClassId, IrUnitId } from "../ir/identity.js";
 import { compileIrPathFunctions, type IrIntegrationReport, type IrTypeOverrideMap } from "../ir/integration.js";
 import { asVal, type IrClassShape, type IrType } from "../ir/nodes.js";
 import { IrInvariantError } from "../ir/outcomes.js";
-import { buildIrLegacyUnitProjection, type IrLegacyUnitProjection } from "../ir/planning-identity.js";
+import {
+  buildIrLegacyUnitProjection,
+  type IrLegacyUnitProjection,
+  type IrPlanningIdentityContext,
+} from "../ir/planning-identity.js";
+import type { IrPromiseDelayLoweringPlan, IrPromiseDelayLoweringPlans } from "../ir/promise-delay-lowering.js";
 import type { IrSelection } from "../ir/select.js";
 import type { ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
@@ -15,11 +20,76 @@ import { collectLocalCallEdgesByIdentity } from "./ir-first-gate.js";
 import * as irOverlayIdentity from "./ir-overlay-identity.js";
 import {
   buildIrRequestedFunctionSkipProjection,
+  computeIrFirstSkipUnitIds,
   mergeIrIntegrationReports,
   preparedIrBodyRouting,
   type IrExactBodyClaim,
   type IrExactFunctionClaim,
 } from "./ir-overlay-safety.js";
+
+/** Preserve the inherited compile-once allowlist for owners not prepared early. */
+export function computePreparedInheritedIrFirstSkipUnitIds(input: {
+  readonly sourceFile: ts.SourceFile;
+  readonly identityContext: IrPlanningIdentityContext;
+  readonly safeFunctionUnitIds: ReadonlySet<IrUnitId>;
+  readonly claimsByUnitId: ReadonlyMap<IrUnitId, IrExactFunctionClaim>;
+  readonly overridesByUnitId: ReadonlyMap<
+    IrUnitId,
+    { readonly params: readonly IrType[]; readonly returnType: IrType | null }
+  >;
+  readonly potentiallyBlockedOwnerUnitIds: ReadonlySet<IrUnitId>;
+  readonly generatorsSkippable: boolean;
+  readonly fast: boolean;
+}): Set<IrUnitId> {
+  const requestedSkipUnitIds = new Set(
+    computeIrFirstSkipUnitIds({
+      sourceFile: input.sourceFile,
+      identityContext: input.identityContext,
+      safeFunctionUnitIds: input.safeFunctionUnitIds,
+      claimsByUnitId: input.claimsByUnitId,
+      overridesByUnitId: input.overridesByUnitId,
+      potentiallyBlockedOwnerUnitIds: input.potentiallyBlockedOwnerUnitIds,
+      generatorsSkippable: input.generatorsSkippable,
+    }),
+  );
+  // Fast mode can ground source `number` positions to i32 during direct body
+  // discovery even though the early IR override still says f64. Keep only the
+  // annotation-proven boolean subset on the inherited compile-once route until
+  // exact callable-contract comparison moves into preparation.
+  if (!input.fast) return requestedSkipUnitIds;
+
+  const fastBlockedUnitIds = new Set<IrUnitId>();
+  for (const unitId of requestedSkipUnitIds) {
+    const declaration = input.claimsByUnitId.get(unitId)?.declaration;
+    const stableFastSignature =
+      declaration !== undefined &&
+      declaration.parameters.every(
+        (parameter) =>
+          !parameter.questionToken &&
+          !parameter.dotDotDotToken &&
+          !parameter.initializer &&
+          parameter.type?.kind === ts.SyntaxKind.BooleanKeyword,
+      ) &&
+      (declaration.type?.kind === ts.SyntaxKind.BooleanKeyword || declaration.type?.kind === ts.SyntaxKind.VoidKeyword);
+    if (!stableFastSignature) {
+      requestedSkipUnitIds.delete(unitId);
+      fastBlockedUnitIds.add(unitId);
+    }
+  }
+  const callEdges = collectLocalCallEdgesByIdentity(input.sourceFile, input.identityContext);
+  for (let changed = true; changed; ) {
+    changed = false;
+    for (const unitId of requestedSkipUnitIds) {
+      if (![...(callEdges.callees.get(unitId) ?? [])].some((calleeUnitId) => fastBlockedUnitIds.has(calleeUnitId))) {
+        continue;
+      }
+      requestedSkipUnitIds.delete(unitId);
+      fastBlockedUnitIds.add(unitId);
+      changed = true;
+    }
+  }
+  return requestedSkipUnitIds;
+}
 
 export interface PreparedIrFreeFunctionBodies {
   readonly report: IrIntegrationReport;
@@ -320,6 +390,105 @@ function r2SignatureMatchesAllocatedSlot(
     signature.params.every((type, index) => sameValType(type, params[index]!)) &&
     (result === null || sameValType(signature.results[0]!, result))
   );
+}
+
+/**
+ * The certified Promise-delay owner is the first R3 closure component whose
+ * complete derived population is already produced by the IR lowerer. Its
+ * source return type is reference-shaped, so keep this ABI proof separate
+ * from the scalar/string R2 predicate rather than widening R2 implicitly.
+ */
+function r3PromiseDelaySignatureMatchesAllocatedSlot(
+  ctx: CodegenContext,
+  unitId: IrUnitId,
+  override: { readonly params: readonly IrType[]; readonly returnType: IrType | null },
+): boolean {
+  if (
+    override.params.length !== 2 ||
+    override.params.some((type) => asVal(type)?.kind !== "f64") ||
+    override.returnType?.kind !== "extern" ||
+    override.returnType.className !== "Promise"
+  ) {
+    return false;
+  }
+  const func = ctx.programAbiSourceCallables?.functionForUnit(unitId);
+  const signature = func === undefined ? undefined : ctx.mod.types[func.typeIdx];
+  return (
+    signature?.kind === "func" &&
+    signature.params.length === 2 &&
+    signature.params.every((type) => type.kind === "f64") &&
+    signature.results.length === 1 &&
+    signature.results[0]?.kind === "externref"
+  );
+}
+
+/**
+ * Select only exact checker-certified Promise-delay components after their
+ * final runtime/import preparation has retained the owner. The two nested
+ * arrows are not a generic nested-syntax widening: the lowering plan owns
+ * their derived unit IDs, capture order, signatures, and lifted bodies.
+ */
+export function selectR3PreparedPromiseDelayFunctions(input: {
+  readonly ctx: CodegenContext;
+  readonly sourceFile: ts.SourceFile;
+  readonly selectedLegacyNames: ReadonlySet<string>;
+  readonly identityPlan: irOverlayIdentity.IrOverlayIdentityPlan;
+  readonly claimsByUnitId: ReadonlyMap<IrUnitId, IrExactFunctionClaim>;
+  readonly overridesByUnitId: ReadonlyMap<
+    IrUnitId,
+    { readonly params: readonly IrType[]; readonly returnType: IrType | null }
+  >;
+  readonly promiseDelays: IrPromiseDelayLoweringPlans;
+}): ReadonlySet<string> {
+  const planByOwnerUnitId = new Map<IrUnitId, IrPromiseDelayLoweringPlan>();
+  for (const [construction, plan] of input.promiseDelays.constructions) {
+    if (construction !== plan.construction) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `R3 Promise-delay construction map lost exact AST identity for ${plan.ownerUnitId}`,
+      );
+    }
+    const prior = planByOwnerUnitId.get(plan.ownerUnitId);
+    if (prior && prior !== plan) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `R3 Promise-delay owner ${plan.ownerUnitId} has multiple lowering plans`,
+      );
+    }
+    planByOwnerUnitId.set(plan.ownerUnitId, plan);
+  }
+
+  const functionUnitsByName = topLevelFunctionUnitsByName(input.sourceFile, input.identityPlan);
+  const functionValueTargets = collectTopLevelFunctionValueTargets(input.sourceFile, functionUnitsByName);
+  const selected = new Set<string>();
+  for (const legacyName of input.selectedLegacyNames) {
+    const unitId = irOverlayIdentity.requireIrOverlayFunctionUnitId(input.identityPlan, legacyName);
+    const plan = planByOwnerUnitId.get(unitId);
+    if (!plan) continue;
+    const claim = input.claimsByUnitId.get(unitId);
+    const override = input.overridesByUnitId.get(unitId);
+    if (!claim || !override) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `R3 Promise-delay candidate ${unitId} / ${legacyName} has no exact claim/signature`,
+      );
+    }
+    if (
+      plan.ownerName !== legacyName ||
+      plan.construction.getSourceFile() !== input.sourceFile ||
+      claim.declaration !== plan.construction.parent?.parent?.parent ||
+      functionValueTargets.has(unitId) ||
+      containsTopLevelFunctionValueReference(claim.declaration, functionUnitsByName) ||
+      !r3PromiseDelaySignatureMatchesAllocatedSlot(input.ctx, unitId, override)
+    ) {
+      continue;
+    }
+    selected.add(legacyName);
+  }
+  return selected;
 }
 
 /**

--- a/src/codegen/program-abi-type-planning.ts
+++ b/src/codegen/program-abi-type-planning.ts
@@ -2,10 +2,10 @@
 
 import { irClassTypeRef, irSupportTypeRef, irTypeBindingKey } from "../ir/abi-bindings.js";
 import type { IrBindingId, IrClassId, IrSourceId } from "../ir/identity.js";
-import type { IrTypeRef, IrVecLayoutRef } from "../ir/nodes.js";
+import type { IrClosureSignature, IrType, IrTypeRef, IrVecLayoutRef } from "../ir/nodes.js";
 import type { IrPlanningIdentityContext } from "../ir/planning-identity.js";
 import { ProgramAbiInvariantError } from "../ir/program-abi.js";
-import type { StructTypeDef, TypeDef } from "../ir/types.js";
+import type { FuncTypeDef, StructTypeDef, TypeDef } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import type { CodegenContext } from "./context/types.js";
 import { requireIrClassShapeClassId } from "./ir-class-shapes.js";
@@ -17,8 +17,139 @@ const PROGRAM_ABI_TYPE_ROLE = Object.freeze({
   stringCarrier: 1,
   vectorCarrier: 2,
   vectorData: 3,
+  closureWrapperRoot: 4,
+  closureSignatureWrapper: 5,
+  closureLiftedFunc: 6,
+  closureCapturedSubtype: 7,
   classLayout: 0,
 } as const);
+
+export interface ProgramAbiClosureSupportLayoutRequest {
+  readonly signature: IrClosureSignature;
+  readonly captureFieldTypes: readonly IrType[];
+  /** Canonical module-wide wrapper root already allocated by the closure registry. */
+  readonly wrapperRootType: StructTypeDef;
+  /** Signature allocation wrapper; equal to wrapperRootType for the first signature. */
+  readonly allocationWrapperType: StructTypeDef;
+  /** Exact lifted-funcref type whose leading self parameter references the wrapper root. */
+  readonly liftedFuncType: FuncTypeDef;
+  /** Captured allocation subtype; equal to allocationWrapperType when there are no captures. */
+  readonly capturedSubtypeType: StructTypeDef;
+}
+
+export interface ProgramAbiClosureSupportLayout {
+  readonly semanticSignatureKey: string;
+  readonly semanticLayoutKey: string;
+  readonly wrapperRootRef: IrTypeRef;
+  readonly allocationWrapperRef: IrTypeRef;
+  readonly liftedFuncRef: IrTypeRef;
+  readonly capturedSubtypeRef: IrTypeRef;
+}
+
+interface ObservedClosureSupportLayout {
+  readonly request: ProgramAbiClosureSupportLayoutRequest;
+  readonly layout: ProgramAbiClosureSupportLayout;
+}
+
+interface CanonicalClosureSupportRequest {
+  readonly request: ProgramAbiClosureSupportLayoutRequest;
+  readonly signatureKey: string;
+  readonly layoutKey: string;
+}
+
+function canonicalClosureSupportIrType(type: IrType, active: Set<object>): unknown {
+  if (active.has(type)) {
+    throw new ProgramAbiInvariantError(
+      "unknown-order-anchor",
+      "closure support semantic type contains a recursive anonymous IR layout",
+    );
+  }
+  active.add(type);
+  try {
+    switch (type.kind) {
+      case "val":
+        if (type.val.kind === "ref" || type.val.kind === "ref_null") {
+          throw new ProgramAbiInvariantError(
+            "unknown-order-anchor",
+            "closure support semantic types cannot contain module-relative ref type indices",
+          );
+        }
+        return {
+          kind: type.kind,
+          value: canonicalProgramAbiValType(type.val),
+          ...(type.val.kind === "i32" ? { signed: type.signed ?? true } : {}),
+        };
+      case "string":
+        return { kind: type.kind };
+      case "vec":
+        return {
+          kind: type.kind,
+          elementType: canonicalClosureSupportIrType(type.elementType, active),
+          nullable: type.nullable,
+        };
+      case "object":
+        return {
+          kind: type.kind,
+          fields: type.shape.fields.map((field) => ({
+            name: field.name,
+            type: canonicalClosureSupportIrType(field.type, active),
+          })),
+        };
+      case "closure":
+      case "callable":
+        return {
+          kind: type.kind,
+          signature: canonicalClosureSupportSignature(type.signature, active),
+        };
+      case "class":
+        return { kind: type.kind, classId: type.shape.classId };
+      case "extern":
+        return { kind: type.kind, className: type.className };
+      case "union":
+        return {
+          kind: type.kind,
+          members: type.members.map((member) => canonicalClosureSupportIrType(member, active)),
+        };
+      case "boxed":
+        return { kind: type.kind, inner: canonicalClosureSupportIrType(type.inner, active) };
+      case "dynamic":
+        return { kind: type.kind, tag: type.tag ?? null };
+    }
+  } finally {
+    active.delete(type);
+  }
+}
+
+function canonicalClosureSupportSignature(signature: IrClosureSignature, active = new Set<object>()): unknown {
+  if (active.has(signature)) {
+    throw new ProgramAbiInvariantError("unknown-order-anchor", "closure support contains a recursive IR signature");
+  }
+  active.add(signature);
+  try {
+    return {
+      params: signature.params.map((type) => canonicalClosureSupportIrType(type, active)),
+      returnType: signature.returnType === null ? null : canonicalClosureSupportIrType(signature.returnType, active),
+    };
+  } finally {
+    active.delete(signature);
+  }
+}
+
+/** Backend-neutral semantic key for one caller-visible closure signature. */
+export function canonicalProgramAbiClosureSignatureKey(signature: IrClosureSignature): string {
+  return JSON.stringify(canonicalClosureSupportSignature(signature));
+}
+
+/** Backend-neutral semantic key for one signature plus ordered capture layout. */
+export function canonicalProgramAbiClosureLayoutKey(
+  signature: IrClosureSignature,
+  captureFieldTypes: readonly IrType[],
+): string {
+  return JSON.stringify({
+    signature: canonicalClosureSupportSignature(signature),
+    captures: captureFieldTypes.map((type) => canonicalClosureSupportIrType(type, new Set<object>())),
+  });
+}
 
 interface ProgramAbiClassLayoutObservation {
   readonly classId: IrClassId;
@@ -79,6 +210,8 @@ export class ProgramAbiTypeRegistry {
       readonly layout: IrVecLayoutRef;
     }
   >();
+  private readonly closureSupportLayouts = new Map<string, ObservedClosureSupportLayout>();
+  private closureSupportBatchPlanned = false;
   private planned = false;
 
   constructor(
@@ -298,6 +431,164 @@ export class ProgramAbiTypeRegistry {
     return layout;
   }
 
+  /**
+   * Plan the exact physical type population already allocated for a batch of
+   * compiler-owned closures.
+   *
+   * The batch boundary is deliberate: semantic signature/layout keys are
+   * sorted before structural ordinals are assigned, so caller traversal and
+   * closure creation order cannot perturb Program ABI ordering. Repeating the
+   * exact batch is idempotent; adding a new semantic layout later fails rather
+   * than silently changing earlier ordinals.
+   */
+  prepareClosureSupportLayouts(
+    requests: readonly ProgramAbiClosureSupportLayoutRequest[],
+  ): readonly ProgramAbiClosureSupportLayout[] {
+    if (this.planned) {
+      throw new ProgramAbiInvariantError(
+        "planning-sealed",
+        "cannot prepare closure support after retained type planning",
+      );
+    }
+    if (requests.length === 0) return [];
+
+    const canonical = requests.map((request) => {
+      const signatureKey = canonicalProgramAbiClosureSignatureKey(request.signature);
+      const layoutKey = canonicalProgramAbiClosureLayoutKey(request.signature, request.captureFieldTypes);
+      this.validateAllocatedClosureSupport(request, signatureKey);
+      return { request, signatureKey, layoutKey } satisfies CanonicalClosureSupportRequest;
+    });
+
+    if (this.closureSupportBatchPlanned) {
+      return canonical.map(({ request, layoutKey }) => {
+        const observed = this.closureSupportLayouts.get(layoutKey);
+        if (!observed) {
+          throw new ProgramAbiInvariantError(
+            "planning-sealed",
+            `closure support layout ${layoutKey} was requested after the canonical batch was planned`,
+          );
+        }
+        this.assertSameClosurePhysicalLayout(observed.request, request, layoutKey);
+        return observed.layout;
+      });
+    }
+
+    const first = canonical[0]!;
+    for (const candidate of canonical) {
+      if (candidate.request.wrapperRootType !== first.request.wrapperRootType) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          "one closure support batch references more than one physical wrapper root",
+        );
+      }
+    }
+
+    const bySignature = new Map<string, CanonicalClosureSupportRequest>();
+    const byLayout = new Map<string, CanonicalClosureSupportRequest>();
+    let rootAllocationSignatureKey: string | undefined;
+    for (const candidate of canonical) {
+      const priorSignature = bySignature.get(candidate.signatureKey);
+      if (priorSignature) {
+        if (
+          priorSignature.request.allocationWrapperType !== candidate.request.allocationWrapperType ||
+          priorSignature.request.liftedFuncType !== candidate.request.liftedFuncType
+        ) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `closure signature ${candidate.signatureKey} maps to different physical wrapper/funcref types`,
+          );
+        }
+      } else {
+        bySignature.set(candidate.signatureKey, candidate);
+      }
+
+      const priorLayout = byLayout.get(candidate.layoutKey);
+      if (priorLayout) {
+        this.assertSameClosurePhysicalLayout(priorLayout.request, candidate.request, candidate.layoutKey);
+      } else {
+        byLayout.set(candidate.layoutKey, candidate);
+      }
+
+      if (candidate.request.allocationWrapperType === candidate.request.wrapperRootType) {
+        if (rootAllocationSignatureKey !== undefined && rootAllocationSignatureKey !== candidate.signatureKey) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            "the physical closure wrapper root is claimed by more than one semantic signature",
+          );
+        }
+        rootAllocationSignatureKey = candidate.signatureKey;
+      }
+    }
+
+    const signatureOrdinals = new Map([...bySignature.keys()].sort().map((key, index) => [key, index] as const));
+    const layoutOrdinals = new Map([...byLayout.keys()].sort().map((key, index) => [key, index] as const));
+    const rootRef = this.planClosureSupportType({
+      semanticRole: "wrapper-root",
+      adapterName: "__ir_closure_wrapper_root",
+      type: first.request.wrapperRootType,
+      roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureWrapperRoot,
+      derivedOrdinal: 0,
+    });
+
+    const resultByLayout = new Map<string, ProgramAbiClosureSupportLayout>();
+    for (const [signatureKey, candidate] of [...bySignature].sort(([left], [right]) => left.localeCompare(right))) {
+      const signatureOrdinal = signatureOrdinals.get(signatureKey)!;
+      const allocationWrapperRef =
+        candidate.request.allocationWrapperType === candidate.request.wrapperRootType
+          ? rootRef
+          : this.planClosureSupportType({
+              semanticRole: `signature-wrapper:${signatureKey}`,
+              adapterName: `__ir_closure_wrapper_${signatureOrdinal}`,
+              type: candidate.request.allocationWrapperType,
+              roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureSignatureWrapper,
+              derivedOrdinal: signatureOrdinal,
+            });
+      const liftedFuncRef = this.planClosureSupportType({
+        semanticRole: `lifted-func:${signatureKey}`,
+        adapterName: `__ir_closure_lifted_func_${signatureOrdinal}`,
+        type: candidate.request.liftedFuncType,
+        roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureLiftedFunc,
+        derivedOrdinal: signatureOrdinal,
+      });
+
+      for (const [layoutKey, layoutCandidate] of [...byLayout]
+        .filter(([, value]) => value.signatureKey === signatureKey)
+        .sort(([left], [right]) => left.localeCompare(right))) {
+        const layoutOrdinal = layoutOrdinals.get(layoutKey)!;
+        const capturedSubtypeRef =
+          layoutCandidate.request.capturedSubtypeType === layoutCandidate.request.allocationWrapperType
+            ? allocationWrapperRef
+            : this.planClosureSupportType({
+                semanticRole: `captured-subtype:${layoutKey}`,
+                adapterName: `__ir_closure_captured_${layoutOrdinal}`,
+                type: layoutCandidate.request.capturedSubtypeType,
+                roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureCapturedSubtype,
+                derivedOrdinal: layoutOrdinal,
+              });
+        resultByLayout.set(
+          layoutKey,
+          Object.freeze({
+            semanticSignatureKey: signatureKey,
+            semanticLayoutKey: layoutKey,
+            wrapperRootRef: rootRef,
+            allocationWrapperRef,
+            liftedFuncRef,
+            capturedSubtypeRef,
+          }),
+        );
+      }
+    }
+
+    for (const [layoutKey, candidate] of byLayout) {
+      this.closureSupportLayouts.set(
+        layoutKey,
+        Object.freeze({ request: candidate.request, layout: resultByLayout.get(layoutKey)! }),
+      );
+    }
+    this.closureSupportBatchPlanned = true;
+    return canonical.map(({ layoutKey }) => resultByLayout.get(layoutKey)!);
+  }
+
   /** Plan all source classes plus every retained allocator type after DCE. */
   planRetained(): void {
     if (this.planned) return;
@@ -435,5 +726,119 @@ export class ProgramAbiTypeRegistry {
     if (!this.session.hasLocator(bindingId, cell)) {
       this.session.attachLocator(bindingId, { kind: "type-cell", cell });
     }
+  }
+
+  private validateAllocatedClosureSupport(request: ProgramAbiClosureSupportLayoutRequest, signatureKey: string): void {
+    const rootIndex = this.requireUniqueAllocatedType(request.wrapperRootType, "closure wrapper root");
+    const wrapperIndex = this.requireUniqueAllocatedType(request.allocationWrapperType, "closure signature wrapper");
+    this.requireUniqueAllocatedType(request.liftedFuncType, "closure lifted function type");
+    const subtypeIndex = this.requireUniqueAllocatedType(request.capturedSubtypeType, "closure captured subtype");
+
+    const hasCanonicalWrapperFields = (type: StructTypeDef): boolean =>
+      type.fields.length === 2 && type.fields[0]?.type.kind === "funcref" && type.fields[1]?.type.kind === "i32";
+    if (!hasCanonicalWrapperFields(request.wrapperRootType)) {
+      throw new ProgramAbiInvariantError(
+        "type-remap-mismatch",
+        `closure signature ${signatureKey} has a non-canonical physical wrapper root`,
+      );
+    }
+    if (
+      request.allocationWrapperType !== request.wrapperRootType &&
+      (!hasCanonicalWrapperFields(request.allocationWrapperType) ||
+        request.allocationWrapperType.superTypeIdx !== rootIndex)
+    ) {
+      throw new ProgramAbiInvariantError(
+        "type-remap-mismatch",
+        `closure signature ${signatureKey} has a wrapper outside the canonical root hierarchy`,
+      );
+    }
+
+    const self = request.liftedFuncType.params[0];
+    if (
+      request.liftedFuncType.params.length !== request.signature.params.length + 1 ||
+      request.liftedFuncType.results.length !== (request.signature.returnType === null ? 0 : 1) ||
+      (self?.kind !== "ref" && self?.kind !== "ref_null") ||
+      self.typeIdx !== rootIndex
+    ) {
+      throw new ProgramAbiInvariantError(
+        "type-remap-mismatch",
+        `closure signature ${signatureKey} has a mismatched lifted function type`,
+      );
+    }
+
+    if (request.captureFieldTypes.length === 0) {
+      if (request.capturedSubtypeType !== request.allocationWrapperType) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `capture-free closure signature ${signatureKey} allocated a redundant subtype`,
+        );
+      }
+    } else if (
+      request.capturedSubtypeType === request.allocationWrapperType ||
+      request.capturedSubtypeType.superTypeIdx !== wrapperIndex ||
+      request.capturedSubtypeType.fields.length !== request.captureFieldTypes.length + 2 ||
+      request.capturedSubtypeType.fields[0]?.type.kind !== "funcref" ||
+      request.capturedSubtypeType.fields[1]?.type.kind !== "i32"
+    ) {
+      throw new ProgramAbiInvariantError(
+        "type-remap-mismatch",
+        `closure layout ${signatureKey} has a mismatched captured subtype at ${subtypeIndex}`,
+      );
+    }
+  }
+
+  private assertSameClosurePhysicalLayout(
+    previous: ProgramAbiClosureSupportLayoutRequest,
+    next: ProgramAbiClosureSupportLayoutRequest,
+    layoutKey: string,
+  ): void {
+    if (
+      previous.wrapperRootType !== next.wrapperRootType ||
+      previous.allocationWrapperType !== next.allocationWrapperType ||
+      previous.liftedFuncType !== next.liftedFuncType ||
+      previous.capturedSubtypeType !== next.capturedSubtypeType
+    ) {
+      throw new ProgramAbiInvariantError(
+        "type-remap-mismatch",
+        `closure support semantic layout ${layoutKey} maps to different physical type objects`,
+      );
+    }
+  }
+
+  private requireUniqueAllocatedType(type: TypeDef, label: string): number {
+    const index = this.ctx.mod.types.indexOf(type);
+    if (index < 0 || this.ctx.mod.types.indexOf(type, index + 1) >= 0) {
+      throw new ProgramAbiInvariantError(
+        "type-remap-mismatch",
+        `${label} must be one exact existing allocator type object`,
+      );
+    }
+    return index;
+  }
+
+  private planClosureSupportType(input: {
+    readonly semanticRole: string;
+    readonly adapterName: string;
+    readonly type: TypeDef;
+    readonly roleOrdinal: number;
+    readonly derivedOrdinal: number;
+  }): IrTypeRef {
+    const entrySourceId = canonicalEntrySource(this.session);
+    const ref = irSupportTypeRef(
+      entrySourceId,
+      `closure-support:${input.semanticRole}`,
+      input.adapterName,
+      input.derivedOrdinal,
+    );
+    const cell = this.session.typeCellFor(input.type) ?? this.session.createTypeCell(input.type);
+    const previousOwner = this.session.locatorBindingId(cell);
+    if (previousOwner !== undefined && previousOwner !== ref.binding.bindingId) {
+      throw new ProgramAbiInvariantError(
+        "type-remap-mismatch",
+        `closure support type ${input.semanticRole} is already owned by ${previousOwner}`,
+      );
+    }
+    this.planPreparedSupportType(ref, input.type, cell, input.roleOrdinal, input.derivedOrdinal);
+    return ref;
   }
 }

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -258,9 +258,12 @@ import {
   type IrIntegrationTerminalFailureEvent,
 } from "./integration-report.js";
 import {
-  derivePreparedComponentDependencies,
-  type PreparedComponentDependencyReport,
-} from "./prepared-component-dependencies.js";
+  allocatePreparedDerivedCallableSlots,
+  lowerPreparedClosureSupportType,
+  prepareDependencyCompleteClosureSupport,
+  type PreparedDerivedCallableSlot,
+} from "./prepared-closure-support.js";
+import { sealDependencyCompletePreparedComponents } from "./prepared-component-sealing.js";
 import { attachIrStringCarrier } from "./string-carrier.js";
 import { attachIrStringSupport } from "./string-support.js";
 import { attachIrVecLayouts } from "./vec-layout.js";
@@ -372,6 +375,48 @@ interface BuiltFn {
   readonly moduleInit?: boolean;
 }
 
+interface PreparedClosureTransaction {
+  readonly registry: ClosureStructRegistry;
+  readonly freshSlots: readonly PreparedDerivedCallableSlot[];
+  readonly componentIds: ReadonlyMap<IrUnitId, string>;
+  bindLowerResolver(resolver: IrLowerResolver): void;
+}
+
+function prepareClosureTransaction(input: {
+  readonly ctx: CodegenContext;
+  readonly entries: readonly BuiltFn[];
+  readonly originalArtifactUnitIds: ReadonlySet<IrUnitId>;
+  readonly inventory: IrUnitInventory;
+  readonly callableImports: ReadonlyMap<string, Import>;
+  readonly onSealFailure: (terminalUnitId: IrUnitId, error: IrInvariantError) => void;
+}): PreparedClosureTransaction {
+  let resolveValType: (type: IrType) => ValType = lowerPreparedClosureSupportType;
+  const registry = new ClosureStructRegistry(input.ctx, (type) => resolveValType(type));
+  const closureSupport = prepareDependencyCompleteClosureSupport(input.ctx, input.entries, registry);
+  const freshSlots = allocatePreparedDerivedCallableSlots(
+    input.ctx,
+    input.entries,
+    input.originalArtifactUnitIds,
+    registry,
+  );
+  const componentIds = sealDependencyCompletePreparedComponents({
+    ctx: input.ctx,
+    entries: input.entries,
+    inventory: input.inventory,
+    closureSupport,
+    callableImports: input.callableImports,
+    onSealFailure: input.onSealFailure,
+  });
+  return {
+    registry,
+    freshSlots,
+    componentIds,
+    bindLowerResolver: (resolver) => {
+      resolveValType = (type) => lowerIrTypeToValType(type, resolver, "<closure-registry>");
+    },
+  };
+}
+
 function prepareBuiltFnRuntimeManifest(
   ctx: CodegenContext,
   sourceFile: string,
@@ -400,164 +445,6 @@ function prepareBuiltFnRuntimeManifest(
   });
   materializePreparedMathProviders(ctx, runtime);
   return { entries: preparedEntries, runtime };
-}
-
-function planDependencyBlockingCallableProviders(
-  ctx: CodegenContext,
-  report: PreparedComponentDependencyReport,
-): boolean {
-  const registry = ctx.programAbiCallableProviders;
-  if (!registry) return false;
-  const selectedKeys = new Set<string>();
-  const selectedImports = new Set<Import>();
-  for (const component of report.components) {
-    const unresolvedKeys = new Set(
-      component.externalCallables
-        .filter((dependency) => dependency.programAbiBindingId === null)
-        .map((dependency) => dependency.structuralReferenceKey),
-    );
-    const providerImports = registry.importsForPreparedProviders(unresolvedKeys);
-    if (
-      unresolvedKeys.size === 0 ||
-      component.failures.length === 0 ||
-      !component.failures.every(
-        (failure) =>
-          failure.code === "unplanned-abi-binding" &&
-          failure.structuralReferenceKey !== undefined &&
-          unresolvedKeys.has(failure.structuralReferenceKey),
-      ) ||
-      providerImports === undefined
-    ) {
-      continue;
-    }
-    for (const key of unresolvedKeys) selectedKeys.add(key);
-    for (const imported of providerImports) selectedImports.add(imported);
-  }
-  if (selectedKeys.size === 0) return false;
-  if (selectedImports.size > 0) {
-    const importRegistry = ctx.programAbiCallableImports;
-    if (!importRegistry) {
-      throw new IrInvariantError(
-        "selection-preparation-mismatch",
-        "resolve",
-        "prepared callable providers require one canonical callable-import registry",
-      );
-    }
-    importRegistry.planPrepared(selectedImports);
-  }
-  if (!registry.canPlanPrepared(selectedKeys)) {
-    throw new IrInvariantError(
-      "selection-preparation-mismatch",
-      "resolve",
-      "prepared callable provider imports did not acquire canonical Program ABI owners",
-    );
-  }
-  registry.planPrepared(selectedKeys);
-  return true;
-}
-
-function sealDependencyCompletePreparedComponents(input: {
-  readonly ctx: CodegenContext;
-  readonly entries: readonly BuiltFn[];
-  readonly inventory: IrUnitInventory;
-  readonly onSealFailure: (terminalUnitId: IrUnitId, error: IrInvariantError) => void;
-}): ReadonlyMap<IrUnitId, string> {
-  const { ctx, entries, inventory } = input;
-  const session = ctx.programAbiSession;
-  if (!session) {
-    throw new IrInvariantError(
-      "selection-preparation-mismatch",
-      "resolve",
-      "R2 prepared-component sealing requires one production ProgramAbiSession",
-    );
-  }
-  const terminalUnitIds = new Set(entries.map((entry) => entry.terminalOwnerUnitId));
-  const terminalEntries = new Map(
-    entries
-      .filter((entry) => entry.artifactUnitId === entry.terminalOwnerUnitId && !entry.derivedUnit)
-      .map((entry) => [entry.terminalOwnerUnitId, entry] as const),
-  );
-  const terminalCallableBindingIds = new Set<IrBindingId>();
-  for (const terminalUnitId of terminalUnitIds) {
-    const entry = terminalEntries.get(terminalUnitId);
-    const funcIdx = entry?.moduleInit
-      ? ctx.programAbiModuleInitCallables?.handleForUnit(terminalUnitId)
-      : entry?.classMember
-        ? ctx.programAbiClassCallables?.handleForUnit(terminalUnitId)
-        : ctx.programAbiSourceCallables?.handleForUnit(terminalUnitId);
-    const func = funcIdx === undefined ? undefined : definedFuncAt(ctx, funcIdx);
-    const signature = func === undefined ? undefined : ctx.mod.types[func.typeIdx];
-    if (!entry || !func || !signature || signature.kind !== "func") {
-      throw new IrInvariantError(
-        "selection-preparation-mismatch",
-        "resolve",
-        `dependency preparation has no exact allocated callable for terminal ${terminalUnitId}`,
-      );
-    }
-    const bindingId = planProgramAbiUnitCallable(ctx, {
-      ref: irUnitFuncRef(entry.fn),
-      signature,
-      func,
-    });
-    if (bindingId !== irUnitCallableBindingId(terminalUnitId)) {
-      throw new IrInvariantError(
-        "selection-preparation-mismatch",
-        "resolve",
-        `dependency preparation could not plan the exact callable for terminal ${terminalUnitId}`,
-      );
-    }
-    terminalCallableBindingIds.add(bindingId);
-  }
-  ctx.programAbiExports?.planAliasesForTargets(terminalCallableBindingIds);
-
-  const derivedUnits = [
-    ...new Map(
-      entries.flatMap((entry) => (entry.derivedUnit ? ([[entry.derivedUnit.id, entry.derivedUnit]] as const) : [])),
-    ).values(),
-  ];
-  const deriveDependencies = (): PreparedComponentDependencyReport =>
-    derivePreparedComponentDependencies({
-      module: { functions: entries.map((entry) => entry.fn) },
-      terminalUnitIds,
-      inventory,
-      derivedUnits,
-      abi: {
-        get: (id) => session.getDraft(id),
-        bindingIdsForStructuralReference: (key) => session.bindingIdsForStructuralReference(key),
-      },
-    });
-  let dependencyReport = deriveDependencies();
-  if (planDependencyBlockingCallableProviders(ctx, dependencyReport)) dependencyReport = deriveDependencies();
-  const componentIdByTerminalUnitId = new Map<IrUnitId, string>();
-  for (const component of dependencyReport.components) {
-    // String/dynamic/object/layout operations still carry implicit support in
-    // transitional IR. R6 must make those dependencies symbolic first.
-    if (component.status !== "complete") continue;
-    try {
-      const scope = session.beginPreparedComponentScope(component.id, component.terminalUnitIds);
-      const requestedBindingIds = new Set(
-        component.abiDependencies
-          .filter(({ kind }) => ["external-callable", "external-global", "class-layout", "support"].includes(kind))
-          .map((dependency) => dependency.bindingId),
-      );
-      for (const bindingId of requestedBindingIds) scope.includeBinding(bindingId);
-      scope.seal();
-      for (const terminalUnitId of component.terminalUnitIds) {
-        componentIdByTerminalUnitId.set(terminalUnitId, component.id);
-      }
-    } catch (error) {
-      const failure = new IrInvariantError(
-        "selection-preparation-mismatch",
-        "resolve",
-        `dependency-complete R2 component ${component.id} failed ABI sealing: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-        error,
-      );
-      for (const terminalUnitId of component.terminalUnitIds) input.onSealFailure(terminalUnitId, failure);
-    }
-  }
-  return componentIdByTerminalUnitId;
 }
 
 function fillSealedPreparedCallable(
@@ -2076,31 +1963,28 @@ export function compileIrPathFunctions(
   healthyForLower = retainHealthyOwners(healthyForLower);
   if (healthyForLower.length === 0) return finishReport();
   const importedCallableCatalog = catalogProgramAbiCallableImports(ctx);
+  const freshSlots: PreparedDerivedCallableSlot[] = [];
   let preparedComponentIdByTerminalUnitId: ReadonlyMap<IrUnitId, string> = new Map();
+  let preparedClosure: PreparedClosureTransaction | undefined;
   if (options?.sealPreparedComponents) {
     runGlobalPreparation(() => {
-      preparedComponentIdByTerminalUnitId = sealDependencyCompletePreparedComponents({
+      preparedClosure = prepareClosureTransaction({
         ctx,
         entries: healthyForLower,
+        originalArtifactUnitIds,
         inventory: moduleBindingIdentityContext.inventory,
+        callableImports: importedCallableCatalog,
         onSealFailure: (terminalUnitId, error) => {
           const owner = activeOwnerProjection.requireUnit(terminalUnitId);
           markOwnerFailure(owner, terminalUnitId, owner.legacyName, error, "resolve");
         },
       });
+      freshSlots.push(...preparedClosure.freshSlots);
+      preparedComponentIdByTerminalUnitId = preparedClosure.componentIds;
     });
     if ((healthyForLower = retainHealthyOwners(healthyForLower)).length === 0) return finishReport();
   }
-  // -------------------------------------------------------------------------
-  // Register monomorphized clones in `ctx` — append a placeholder
-  // WasmFunction slot and record the assigned funcIdx in `ctx.funcMap`.
-  // The placeholder body is overwritten with the real lowered body in the
-  // Phase-3 loop below.
-  // -------------------------------------------------------------------------
-  // (#3551) Track freshly-allocated slots so an owner failure AFTER
-  // allocation (e.g. the ABI-parity withdrawal cascade in Phase 3) can stub
-  // the orphaned slot instead of leaving an EMPTY body in the module (see
-  // the stub pass after the patch loop below).
+  // Allocate remaining synthetic placeholders and retain every fresh slot for orphan stubbing (#3551).
   const exactArtifactFuncIdx = (unitId: IrUnitId): number | undefined => {
     const func = ctx.irUnitFuncMap.get(unitId);
     return func ? definedFuncHandleOf(ctx, func) : undefined;
@@ -2129,11 +2013,6 @@ export function compileIrPathFunctions(
     const func = funcIdx === undefined ? undefined : definedFuncAt(ctx, funcIdx);
     if (func) ctx.irUnitFuncMap.set(entry.artifactUnitId, func);
   }
-  const freshSlots: Array<{
-    readonly artifactUnitId: IrUnitId;
-    readonly funcIdx: number;
-    readonly terminalOwnerUnitId: IrUnitId;
-  }> = [];
   const claimedIrFunctions = new Set(ctx.irUnitFuncMap.values());
   for (const entry of healthyForLower) {
     // Top-level (non-synthesized) functions already have a funcIdx
@@ -2205,8 +2084,6 @@ export function compileIrPathFunctions(
   // machinery — but we still walk the IR for symmetry and to keep the
   // resolver path uniform.
   // -------------------------------------------------------------------------
-  // Registration completed transactionally above, before synthetic slots.
-
   // -------------------------------------------------------------------------
   // Slice 6 part 3 (#1182) — iterator host imports.
   //
@@ -2375,7 +2252,15 @@ export function compileIrPathFunctions(
           `ir/integration: no slot allocated for exact artifact ${entry.fn.unitId} / ${entry.name}`,
         );
       }
-      bindUnitCallableSlot(irUnitFuncRef(entry.fn), funcIdx, entry.moduleInit ? "__module_init" : entry.name);
+      const allocated = definedFuncAt(ctx, funcIdx);
+      if (!allocated) {
+        throw new IrInvariantError(
+          "missing-function-slot",
+          "resolve",
+          `ir/integration: exact artifact ${entry.fn.unitId} / ${entry.name} has no allocated function object`,
+        );
+      }
+      bindUnitCallableSlot(irUnitFuncRef(entry.fn), funcIdx, allocated.name);
     }
     for (const plan of preparedDirectCalls.values()) bindPlannedUnitTarget(plan.target);
     for (const plan of loweringPlans?.importedCalls.values() ?? []) bindPlannedUnitTarget(plan.target);
@@ -2490,9 +2375,10 @@ export function compileIrPathFunctions(
     }
     const objectRegistry = new ObjectStructRegistry(ctx, (t) => lowerIrTypeToValType(t, resolver, "<obj-registry>"));
     deferredObj.resolve = (shape) => objectRegistry.resolve(shape);
-    const closureRegistry = new ClosureStructRegistry(ctx, (t) =>
-      lowerIrTypeToValType(t, resolver, "<closure-registry>"),
-    );
+    preparedClosure?.bindLowerResolver(resolver);
+    const closureRegistry =
+      preparedClosure?.registry ??
+      new ClosureStructRegistry(ctx, (t) => lowerIrTypeToValType(t, resolver, "<closure-registry>"));
     deferredCl.resolveBase = (sig) => closureRegistry.resolveBase(sig);
     deferredCl.resolveSubtype = (sig, fields) => closureRegistry.resolveSubtype(sig, fields);
     const refCellRegistry = new RefCellRegistry(ctx);

--- a/src/ir/prepared-closure-support.ts
+++ b/src/ir/prepared-closure-support.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { getFuncRefWrapperRootTypeIdx } from "../codegen/closures/funcref-wrapper-types.js";
+import type { CodegenContext } from "../codegen/context/types.js";
+import { definedFuncHandleOf } from "../codegen/func-space.js";
+import type {
+  ProgramAbiClosureSupportLayout,
+  ProgramAbiClosureSupportLayoutRequest,
+} from "../codegen/program-abi-type-planning.js";
+import { addFuncType } from "../codegen/registry/types.js";
+import { irTypeBindingKey } from "./abi-bindings.js";
+import type { IrUnitId } from "./identity.js";
+import type { PreparedComponentClosureSupportEvidence } from "./prepared-component-dependencies.js";
+import { IrInvariantError } from "./outcomes.js";
+import {
+  forEachInstrDeep,
+  type IrClosureSignature,
+  type IrFunction,
+  type IrInstr,
+  type IrType,
+  type IrTypeRef,
+} from "./nodes.js";
+import type { IrClosureLowering } from "./lower.js";
+import type { FuncTypeDef, StructTypeDef, ValType, WasmFunction } from "./types.js";
+
+export interface PreparedClosureRegistry {
+  resolveBase(signature: IrClosureSignature): IrClosureLowering | null;
+  resolveSubtype(signature: IrClosureSignature, captureFieldTypes: readonly IrType[]): IrClosureLowering | null;
+}
+
+export function lowerPreparedClosureSupportType(type: IrType): ValType {
+  if (type.kind === "val" && type.val.kind !== "ref" && type.val.kind !== "ref_null") return type.val;
+  if (type.kind === "extern" || type.kind === "callable") return { kind: "externref" };
+  throw new Error(`closure support type ${type.kind} requires the complete IR resolver`);
+}
+
+export function prepareDerivedCallableTypeIdx(
+  ctx: CodegenContext,
+  registry: PreparedClosureRegistry,
+  fn: IrFunction,
+): number {
+  const lower = (type: IrType): ValType => {
+    if (type.kind !== "closure") return lowerPreparedClosureSupportType(type);
+    if (!registry.resolveBase(type.signature)) {
+      throw new Error("prepared callable signature cannot allocate its closure type");
+    }
+    const rootTypeIdx = getFuncRefWrapperRootTypeIdx(ctx);
+    if (rootTypeIdx === undefined) throw new Error("prepared callable signature has no closure wrapper root");
+    return { kind: "ref", typeIdx: rootTypeIdx };
+  };
+  return addFuncType(
+    ctx,
+    fn.params.map(({ type }) => lower(type)),
+    fn.resultTypes.map(lower),
+    fn.name,
+  );
+}
+
+export interface PreparedDerivedCallableSlot {
+  readonly artifactUnitId: IrUnitId;
+  readonly funcIdx: number;
+  readonly terminalOwnerUnitId: IrUnitId;
+}
+
+export function allocatePreparedDerivedCallableSlots(
+  ctx: CodegenContext,
+  entries: readonly {
+    readonly artifactUnitId: IrUnitId;
+    readonly terminalOwnerUnitId: IrUnitId;
+    readonly name: string;
+    readonly fn: IrFunction;
+    readonly synthesized?: boolean;
+    readonly classMember?: boolean;
+    readonly moduleInit?: boolean;
+  }[],
+  originalArtifactUnitIds: ReadonlySet<IrUnitId>,
+  registry: PreparedClosureRegistry,
+): readonly PreparedDerivedCallableSlot[] {
+  const slots: PreparedDerivedCallableSlot[] = [];
+  for (const entry of entries) {
+    if (originalArtifactUnitIds.has(entry.artifactUnitId) && !entry.synthesized) continue;
+    if (entry.classMember || entry.moduleInit || ctx.irUnitFuncMap.has(entry.artifactUnitId)) continue;
+    // Declaration-body compilation still projects allocator slots by
+    // compatibility name. A source function may reuse a lifted display name,
+    // so an early derived slot must stay outside that legacy name map.
+    const physicalName = ctx.funcMap.has(entry.name) ? `__\0js2_ir_prepared_derived_${slots.length}` : entry.name;
+    const func: WasmFunction = {
+      name: physicalName,
+      typeIdx: prepareDerivedCallableTypeIdx(ctx, registry, entry.fn),
+      locals: [],
+      body: [],
+      exported: entry.fn.exported,
+    };
+    ctx.mod.functions.push(func);
+    const funcIdx = definedFuncHandleOf(ctx, func);
+    if (funcIdx === undefined) {
+      throw new IrInvariantError(
+        "missing-function-slot",
+        "resolve",
+        `prepared derived artifact ${entry.artifactUnitId} / ${entry.name} has no allocator slot`,
+      );
+    }
+    ctx.irUnitFuncMap.set(entry.artifactUnitId, func);
+    slots.push({
+      artifactUnitId: entry.artifactUnitId,
+      funcIdx,
+      terminalOwnerUnitId: entry.terminalOwnerUnitId,
+    });
+  }
+  return slots;
+}
+
+function requireStructType(ctx: CodegenContext, typeIdx: number, label: string): StructTypeDef {
+  const type = ctx.mod.types[typeIdx];
+  if (!type || type.kind !== "struct") {
+    throw new IrInvariantError(
+      "abi-type-index-mismatch",
+      "resolve",
+      `prepared closure ${label} has no exact allocated struct type at ${typeIdx}`,
+    );
+  }
+  return type;
+}
+
+function requireFuncType(ctx: CodegenContext, typeIdx: number): FuncTypeDef {
+  const type = ctx.mod.types[typeIdx];
+  if (!type || type.kind !== "func") {
+    throw new IrInvariantError(
+      "abi-type-index-mismatch",
+      "resolve",
+      `prepared closure lifted callable has no exact allocated function type at ${typeIdx}`,
+    );
+  }
+  return type;
+}
+
+function distinctRefs(layout: ProgramAbiClosureSupportLayout): readonly IrTypeRef[] {
+  return Object.freeze([
+    ...new Map(
+      [layout.wrapperRootRef, layout.allocationWrapperRef, layout.liftedFuncRef, layout.capturedSubtypeRef].map(
+        (ref) => [irTypeBindingKey(ref.binding), ref] as const,
+      ),
+    ).values(),
+  ]);
+}
+
+/** Prepare exact final-IR closure types and publish identity-keyed ABI evidence. */
+export function prepareDependencyCompleteClosureSupport(
+  ctx: CodegenContext,
+  entries: readonly { readonly fn: IrFunction }[],
+  registry: PreparedClosureRegistry,
+): PreparedComponentClosureSupportEvidence {
+  const typeRefs = new Map<IrType, readonly IrTypeRef[]>();
+  const instructionRefs = new Map<IrInstr, readonly IrTypeRef[]>();
+  const functionRefs = new Map<IrFunction, readonly IrTypeRef[]>();
+  const pending: Array<{
+    readonly request: ProgramAbiClosureSupportLayoutRequest;
+    readonly publish: (refs: readonly IrTypeRef[]) => void;
+  }> = [];
+  const schedule = (
+    signature: IrClosureSignature,
+    captureFieldTypes: readonly IrType[],
+    publish: (refs: readonly IrTypeRef[]) => void,
+  ): void => {
+    const base = registry.resolveBase(signature);
+    const subtype = registry.resolveSubtype(signature, captureFieldTypes);
+    if (!base || !subtype) return;
+    const rootTypeIdx = getFuncRefWrapperRootTypeIdx(ctx);
+    if (rootTypeIdx === undefined) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        "prepared closure support allocated no canonical wrapper root",
+      );
+    }
+    pending.push({
+      request: {
+        signature,
+        captureFieldTypes,
+        wrapperRootType: requireStructType(ctx, rootTypeIdx, "wrapper root"),
+        allocationWrapperType: requireStructType(ctx, base.structTypeIdx, "signature wrapper"),
+        liftedFuncType: requireFuncType(ctx, base.funcTypeIdx),
+        capturedSubtypeType: requireStructType(ctx, subtype.structTypeIdx, "captured subtype"),
+      },
+      publish,
+    });
+  };
+
+  for (const { fn } of entries) {
+    const valueTypes = new Map(fn.params.map((param) => [param.value, param.type] as const));
+    const exactTypes = new Set<IrType>([
+      ...fn.params.map((param) => param.type),
+      ...fn.resultTypes,
+      ...fn.blocks.flatMap((block) => block.blockArgTypes),
+    ]);
+    for (const block of fn.blocks) {
+      block.blockArgs.forEach((value, index) => {
+        const type = block.blockArgTypes[index];
+        if (type) valueTypes.set(value, type);
+      });
+      for (const instr of block.instrs) {
+        forEachInstrDeep(instr, (nested) => {
+          if (nested.result !== null && nested.resultType !== null) valueTypes.set(nested.result, nested.resultType);
+          if (nested.resultType) exactTypes.add(nested.resultType);
+        });
+      }
+    }
+    for (const type of exactTypes) {
+      if (type.kind !== "closure" && type.kind !== "callable") continue;
+      schedule(type.signature, [], (refs) => typeRefs.set(type, refs));
+    }
+    if (fn.closureSubtype) {
+      schedule(fn.closureSubtype.signature, fn.closureSubtype.captureFieldTypes, (refs) => functionRefs.set(fn, refs));
+    }
+    for (const block of fn.blocks) {
+      for (const instr of block.instrs) {
+        forEachInstrDeep(instr, (nested) => {
+          if (nested.kind === "closure.new") {
+            schedule(nested.signature, nested.captureFieldTypes, (refs) => instructionRefs.set(nested, refs));
+          } else if (nested.kind === "closure.call") {
+            const calleeType = valueTypes.get(nested.callee);
+            if (calleeType?.kind === "closure" || calleeType?.kind === "callable") {
+              schedule(calleeType.signature, [], (refs) => instructionRefs.set(nested, refs));
+            }
+          }
+        });
+      }
+    }
+  }
+
+  if (pending.length > 0) {
+    const programAbiTypes = ctx.programAbiTypes;
+    if (!programAbiTypes) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        "prepared closure support requires one canonical Program ABI type registry",
+      );
+    }
+    const layouts = programAbiTypes.prepareClosureSupportLayouts(pending.map(({ request }) => request));
+    if (layouts.length !== pending.length) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        "prepared closure support planning returned a non-parallel layout population",
+      );
+    }
+    layouts.forEach((layout, index) => pending[index]!.publish(distinctRefs(layout)));
+  }
+  return Object.freeze({ typeRefs, instructionRefs, functionRefs });
+}

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -109,12 +109,24 @@ export interface PreparedComponentDependencyReport {
   readonly componentByTerminalUnitId: ReadonlyMap<IrUnitId, PreparedComponentDependencyEvidence>;
 }
 
+/**
+ * Exact post-pass closure-support evidence prepared against allocator-owned
+ * type objects before a component is sealed. Object identity is deliberate:
+ * a later IR rewrite cannot inherit closure ownership from an earlier shape.
+ */
+export interface PreparedComponentClosureSupportEvidence {
+  readonly typeRefs: ReadonlyMap<IrType, readonly IrTypeRef[]>;
+  readonly instructionRefs: ReadonlyMap<IrInstr, readonly IrTypeRef[]>;
+  readonly functionRefs: ReadonlyMap<IrFunction, readonly IrTypeRef[]>;
+}
+
 export interface DerivePreparedComponentDependenciesInput {
   readonly module: IrModule;
   /** Exact R2 candidate denominator. Local calls close components within it. */
   readonly terminalUnitIds: ReadonlySet<IrUnitId>;
   readonly inventory: IrUnitInventory;
   readonly derivedUnits?: readonly ProgramAbiDerivedUnitRecord[];
+  readonly closureSupport?: PreparedComponentClosureSupportEvidence;
   readonly abi: PreparedComponentAbiLookup;
 }
 
@@ -493,7 +505,7 @@ function valueTypesOf(fn: IrFunction): Map<IrValueId, IrType> {
   return types;
 }
 
-function implicitSupportRequirement(instr: IrInstr): string | null {
+function implicitSupportRequirement(instr: IrInstr, hasPreparedClosureSupport = false): string | null {
   switch (instr.kind) {
     case "binary":
       return instr.op.startsWith("js.")
@@ -532,7 +544,9 @@ function implicitSupportRequirement(instr: IrInstr): string | null {
     case "closure.new":
     case "closure.cap":
     case "closure.call":
-      return `${instr.kind} resolves closure wrapper/type support beyond its explicit callable ref`;
+      return hasPreparedClosureSupport
+        ? null
+        : `${instr.kind} resolves closure wrapper/type support beyond its explicit callable ref`;
     case "refcell.new":
     case "refcell.get":
     case "refcell.set":
@@ -834,8 +848,22 @@ function collectFunctionEvidence(
   const classes = new Map<IrClassId, IrClassShape>();
   const seenTypes = new Set<IrType>();
   const seenImplicitTypes = new Set<IrType>();
+  const recordPreparedClosureRefs = (refs: readonly IrTypeRef[] | undefined, detail: string): boolean => {
+    if (!refs || refs.length === 0) return false;
+    for (const ref of refs) recordSupportTypeReference(evidence, ref, input.abi, ownership, detail);
+    return true;
+  };
   const collectType = (type: IrType): void => {
     collectIrTypeClasses(type, classes, seenTypes);
+    const preparedRefs = input.closureSupport?.typeRefs.get(type);
+    if (
+      (type.kind === "closure" || type.kind === "callable") &&
+      recordPreparedClosureRefs(preparedRefs, `prepared IR ${type.kind} type must use Program ABI support refs`)
+    ) {
+      for (const param of type.signature.params) collectType(param);
+      if (type.signature.returnType) collectType(type.signature.returnType);
+      return;
+    }
     recordImplicitTypeRequirement(evidence, type, seenImplicitTypes, input.abi, ownership);
   };
   for (const param of fn.params) collectType(param.type);
@@ -843,6 +871,11 @@ function collectFunctionEvidence(
   if (fn.closureSubtype) {
     for (const capture of fn.closureSubtype.captureFieldTypes) collectType(capture);
   }
+  const functionClosureSupport = input.closureSupport?.functionRefs.get(fn);
+  recordPreparedClosureRefs(
+    functionClosureSupport,
+    "prepared IR lifted closure body must use Program ABI support refs",
+  );
 
   for (const block of fn.blocks) {
     for (const type of block.blockArgTypes) collectType(type);
@@ -850,7 +883,16 @@ function collectFunctionEvidence(
       forEachInstrDeep(instr, (nested) => {
         if (nested.resultType) collectType(nested.resultType);
         for (const shape of explicitClassShapes(nested, valueTypes)) collectClassShape(shape, classes, seenTypes);
-        const implicitSupport = implicitSupportRequirement(nested);
+        const instructionClosureSupport = input.closureSupport?.instructionRefs.get(nested);
+        recordPreparedClosureRefs(
+          instructionClosureSupport,
+          `prepared IR ${nested.kind} must use Program ABI support refs`,
+        );
+        const hasPreparedClosureSupport =
+          nested.kind === "closure.cap"
+            ? (functionClosureSupport?.length ?? 0) > 0
+            : (instructionClosureSupport?.length ?? 0) > 0;
+        const implicitSupport = implicitSupportRequirement(nested, hasPreparedClosureSupport);
         if (implicitSupport) {
           addFailure(evidence, {
             code: "implicit-support-reference-unavailable",

--- a/src/ir/prepared-component-sealing.ts
+++ b/src/ir/prepared-component-sealing.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { CodegenContext } from "../codegen/context/types.js";
+import { definedFuncAt } from "../codegen/func-space.js";
+import { planProgramAbiUnitCallable } from "../codegen/program-abi-planning.js";
+import { irUnitCallableBindingId, irUnitFuncRef } from "./callable-bindings.js";
+import type { IrBindingId, IrUnitId, IrUnitInventory } from "./identity.js";
+import type { IrFunction } from "./nodes.js";
+import { IrInvariantError } from "./outcomes.js";
+import {
+  derivePreparedComponentDependencies,
+  type PreparedComponentClosureSupportEvidence,
+  type PreparedComponentDependencyReport,
+} from "./prepared-component-dependencies.js";
+import type { ProgramAbiDerivedUnitRecord } from "./program-abi.js";
+import type { Import } from "./types.js";
+
+export interface PreparedComponentArtifactEntry {
+  readonly artifactUnitId: IrUnitId;
+  readonly terminalOwnerUnitId: IrUnitId;
+  readonly fn: IrFunction;
+  readonly derivedUnit?: ProgramAbiDerivedUnitRecord;
+  readonly classMember?: boolean;
+  readonly moduleInit?: boolean;
+}
+
+function planBlockingCallableProviders(ctx: CodegenContext, report: PreparedComponentDependencyReport): boolean {
+  const registry = ctx.programAbiCallableProviders;
+  if (!registry) return false;
+  const selectedKeys = new Set<string>();
+  const selectedImports = new Set<Import>();
+  for (const component of report.components) {
+    const unresolvedKeys = new Set(
+      component.externalCallables
+        .filter((dependency) => dependency.programAbiBindingId === null)
+        .map((dependency) => dependency.structuralReferenceKey),
+    );
+    const providerImports = registry.importsForPreparedProviders(unresolvedKeys);
+    if (
+      unresolvedKeys.size === 0 ||
+      component.failures.length === 0 ||
+      !component.failures.every(
+        (failure) =>
+          failure.code === "unplanned-abi-binding" &&
+          failure.structuralReferenceKey !== undefined &&
+          unresolvedKeys.has(failure.structuralReferenceKey),
+      ) ||
+      providerImports === undefined
+    ) {
+      continue;
+    }
+    for (const key of unresolvedKeys) selectedKeys.add(key);
+    for (const imported of providerImports) selectedImports.add(imported);
+  }
+  if (selectedKeys.size === 0) return false;
+  if (selectedImports.size > 0) {
+    const importRegistry = ctx.programAbiCallableImports;
+    if (!importRegistry) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        "prepared callable providers require one canonical callable-import registry",
+      );
+    }
+    importRegistry.planPrepared(selectedImports);
+  }
+  if (!registry.canPlanPrepared(selectedKeys)) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "prepared callable provider imports did not acquire canonical Program ABI owners",
+    );
+  }
+  registry.planPrepared(selectedKeys);
+  return true;
+}
+
+function planBlockingCallableImports(
+  ctx: CodegenContext,
+  report: PreparedComponentDependencyReport,
+  catalog: ReadonlyMap<string, Import>,
+): boolean {
+  const selected = new Set<Import>();
+  for (const component of report.components) {
+    const unresolvedImports = new Map(
+      component.externalCallables.flatMap((dependency) => {
+        if (dependency.programAbiBindingId !== null) return [];
+        const imported = catalog.get(dependency.structuralReferenceKey);
+        return imported ? ([[dependency.structuralReferenceKey, imported]] as const) : [];
+      }),
+    );
+    if (
+      unresolvedImports.size === 0 ||
+      component.failures.length === 0 ||
+      !component.failures.every(
+        (failure) =>
+          failure.code === "unplanned-abi-binding" &&
+          failure.structuralReferenceKey !== undefined &&
+          unresolvedImports.has(failure.structuralReferenceKey),
+      )
+    ) {
+      continue;
+    }
+    for (const imported of unresolvedImports.values()) selected.add(imported);
+  }
+  if (selected.size === 0) return false;
+  const registry = ctx.programAbiCallableImports;
+  if (!registry) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "prepared callable dependencies require one canonical callable-import registry",
+    );
+  }
+  registry.planPrepared(selected);
+  return true;
+}
+
+export function sealDependencyCompletePreparedComponents(input: {
+  readonly ctx: CodegenContext;
+  readonly entries: readonly PreparedComponentArtifactEntry[];
+  readonly inventory: IrUnitInventory;
+  readonly closureSupport?: PreparedComponentClosureSupportEvidence;
+  readonly callableImports: ReadonlyMap<string, Import>;
+  readonly onSealFailure: (terminalUnitId: IrUnitId, error: IrInvariantError) => void;
+}): ReadonlyMap<IrUnitId, string> {
+  const { ctx, entries, inventory } = input;
+  const session = ctx.programAbiSession;
+  if (!session) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "prepared-component sealing requires one production ProgramAbiSession",
+    );
+  }
+  const terminalUnitIds = new Set(entries.map((entry) => entry.terminalOwnerUnitId));
+  const terminalCallableBindingIds = new Set<IrBindingId>();
+  for (const entry of entries) {
+    const terminalUnitId = entry.terminalOwnerUnitId;
+    const isTerminal = entry.artifactUnitId === terminalUnitId && !entry.derivedUnit;
+    const func = isTerminal
+      ? (() => {
+          const funcIdx = entry.moduleInit
+            ? ctx.programAbiModuleInitCallables?.handleForUnit(terminalUnitId)
+            : entry.classMember
+              ? ctx.programAbiClassCallables?.handleForUnit(terminalUnitId)
+              : ctx.programAbiSourceCallables?.handleForUnit(terminalUnitId);
+          return funcIdx === undefined ? undefined : definedFuncAt(ctx, funcIdx);
+        })()
+      : ctx.irUnitFuncMap.get(entry.artifactUnitId);
+    const signature = func === undefined ? undefined : ctx.mod.types[func.typeIdx];
+    if (!func || !signature || signature.kind !== "func") {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `dependency preparation has no exact allocated callable for artifact ${entry.artifactUnitId}`,
+      );
+    }
+    const bindingId = planProgramAbiUnitCallable(ctx, { ref: irUnitFuncRef(entry.fn), signature, func });
+    if (bindingId !== irUnitCallableBindingId(entry.artifactUnitId)) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `dependency preparation could not plan the exact callable for artifact ${entry.artifactUnitId}`,
+      );
+    }
+    if (isTerminal) terminalCallableBindingIds.add(bindingId);
+  }
+  ctx.programAbiExports?.planAliasesForTargets(terminalCallableBindingIds);
+
+  const derivedUnits = [
+    ...new Map(
+      entries.flatMap((entry) => (entry.derivedUnit ? ([[entry.derivedUnit.id, entry.derivedUnit]] as const) : [])),
+    ).values(),
+  ];
+  const derive = (): PreparedComponentDependencyReport =>
+    derivePreparedComponentDependencies({
+      module: { functions: entries.map((entry) => entry.fn) },
+      terminalUnitIds,
+      inventory,
+      derivedUnits,
+      ...(input.closureSupport ? { closureSupport: input.closureSupport } : {}),
+      abi: {
+        get: (id) => session.getDraft(id),
+        bindingIdsForStructuralReference: (key) => session.bindingIdsForStructuralReference(key),
+      },
+    });
+  let report = derive();
+  if (planBlockingCallableImports(ctx, report, input.callableImports)) report = derive();
+  if (planBlockingCallableProviders(ctx, report)) report = derive();
+
+  const componentIdByTerminalUnitId = new Map<IrUnitId, string>();
+  for (const component of report.components) {
+    if (component.status !== "complete") continue;
+    try {
+      const scope = session.beginPreparedComponentScope(component.id, component.terminalUnitIds);
+      const requestedBindingIds = new Set(
+        component.abiDependencies
+          .filter(({ kind }) => ["external-callable", "external-global", "class-layout", "support"].includes(kind))
+          .map((dependency) => dependency.bindingId),
+      );
+      for (const bindingId of requestedBindingIds) scope.includeBinding(bindingId);
+      scope.seal();
+      for (const terminalUnitId of component.terminalUnitIds) {
+        componentIdByTerminalUnitId.set(terminalUnitId, component.id);
+      }
+    } catch (error) {
+      const failure = new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        `dependency-complete component ${component.id} failed ABI sealing: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        error,
+      );
+      for (const terminalUnitId of component.terminalUnitIds) input.onSealFailure(terminalUnitId, failure);
+    }
+  }
+  return componentIdByTerminalUnitId;
+}

--- a/tests/issue-2856-async-delay-ir.test.ts
+++ b/tests/issue-2856-async-delay-ir.test.ts
@@ -98,7 +98,7 @@ describe("#2856 exact Promise timer delay IR slice", () => {
     expect(result.irCompiledFuncs ?? []).toEqual(
       expect.arrayContaining(["delay", "delay__closure_0", "delay__closure_0__closure_1"]),
     );
-    expect(result.irFirstSkipped ?? []).not.toContain("delay");
+    expect(result.irFirstSkipped ?? []).toContain("delay");
 
     const names = importNames(result);
     expect(names).toEqual(

--- a/tests/issue-3521-prepared-component-dependencies.test.ts
+++ b/tests/issue-3521-prepared-component-dependencies.test.ts
@@ -32,8 +32,11 @@ import {
   irVal,
   irVec,
   type IrClassShape,
+  type IrClosureSignature,
   type IrFunction,
   type IrInstr,
+  type IrType,
+  type IrTypeRef,
 } from "../src/ir/nodes.js";
 import {
   derivePreparedComponentDependencies,
@@ -155,6 +158,15 @@ function abiLookup(entries: readonly PreparedComponentAbiEntry[]): PreparedCompo
   return {
     get: (id) => byId.get(id),
     entries: () => entries,
+  };
+}
+
+function supportTypeEntry(ref: IrTypeRef): PreparedComponentAbiEntry {
+  return {
+    id: ref.binding.bindingId,
+    structuralReferenceKey: irTypeBindingKey(ref.binding),
+    slotPolicy: "required",
+    intent: { kind: "type", shapeKey: `test:${ref.name}` },
   };
 }
 
@@ -1030,6 +1042,85 @@ describe("#3521 post-pass prepared-component dependency evidence", () => {
         detail: expect.stringContaining("iterator runtime callables"),
       }),
     ]);
+  });
+
+  it.each(["empty", "unrelated"] as const)(
+    "does not accept %s closure evidence for a different final IR object",
+    (evidenceKind) => {
+      const f = fixture();
+      const signature: IrClosureSignature = { params: [], returnType: null };
+      const closureType: IrType = { kind: "closure", signature };
+      const supportRef = irSupportTypeRef(f.first.id, "test-closure-wrapper", "__test_closure_wrapper");
+      const closureNew: IrInstr = {
+        kind: "closure.new",
+        liftedFunc: irUnitFuncRef({ unitId: f.second.id, name: "second" }),
+        signature,
+        captureFieldTypes: [],
+        captures: [],
+        result: asValueId(0),
+        resultType: closureType,
+      };
+      const unrelatedClosureNew: IrInstr = { ...closureNew };
+      const refs = evidenceKind === "empty" ? [] : [supportRef];
+      const report = derivePreparedComponentDependencies({
+        module: { functions: [irFunction(f.first, [closureNew]), irFunction(f.second)] },
+        terminalUnitIds: new Set([f.first.id, f.second.id]),
+        inventory: f.inventory,
+        closureSupport: {
+          typeRefs: new Map([[closureType, refs]]),
+          instructionRefs: new Map([[evidenceKind === "empty" ? closureNew : unrelatedClosureNew, refs]]),
+          functionRefs: new Map(),
+        },
+        abi: abiLookup([
+          sourceCallableEntry(f.first.id),
+          sourceCallableEntry(f.second.id),
+          supportTypeEntry(supportRef),
+        ]),
+      });
+
+      expect(report.components[0]!.status).toBe("blocked");
+      expect(report.components[0]!.failures).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "implicit-support-reference-unavailable",
+            detail: expect.stringContaining("closure.new resolves closure wrapper/type support"),
+          }),
+        ]),
+      );
+    },
+  );
+
+  it("keeps nested closure-signature support dependencies fail-closed", () => {
+    const f = fixture();
+    const signature: IrClosureSignature = { params: [{ kind: "string" }], returnType: null };
+    const closureType: IrType = { kind: "callable", signature };
+    const supportRef = irSupportTypeRef(f.first.id, "test-callable-wrapper", "__test_callable_wrapper");
+    const fn: IrFunction = {
+      ...irFunction(f.first),
+      params: [{ value: asValueId(0), name: "callback", type: closureType }],
+      valueCount: 1,
+    };
+    const report = derivePreparedComponentDependencies({
+      module: { functions: [fn] },
+      terminalUnitIds: new Set([f.first.id]),
+      inventory: f.inventory,
+      closureSupport: {
+        typeRefs: new Map([[closureType, [supportRef]]]),
+        instructionRefs: new Map(),
+        functionRefs: new Map(),
+      },
+      abi: abiLookup([sourceCallableEntry(f.first.id), supportTypeEntry(supportRef)]),
+    });
+
+    expect(report.components[0]!.status).toBe("blocked");
+    expect(report.components[0]!.failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "implicit-support-reference-unavailable",
+          detail: expect.stringContaining("IR string type resolves through backend support"),
+        }),
+      ]),
+    );
   });
 
   it("fails closed for an unresolved exact unit ref and for a foreign terminal owner", () => {

--- a/tests/issue-4102-ir-promise-delay-closure-compile-once.test.ts
+++ b/tests/issue-4102-ir-promise-delay-closure-compile-once.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const EXACT_DELAY = `
+export function delay(ms: number, value: number): Promise<number> {
+  return new Promise<number>((resolve) => {
+    setTimeout(() => resolve(value), ms);
+  });
+}
+`;
+
+function terminalOutcome(result: CompileResult, name: string): IrObservedOutcome {
+  const observed = result.irOutcomes?.find(
+    (candidate) => candidate.unitKind === "function" && candidate.displayName === name,
+  );
+  if (!observed) throw new Error(`missing IR outcome for ${name}`);
+  return observed;
+}
+
+async function compileTracked(source: string, optimize = false): Promise<CompileResult> {
+  return compile(source, {
+    fileName: "issue-4102-ir-promise-delay-closure-compile-once.ts",
+    experimentalIR: true,
+    trackFallbacks: true,
+    trackIrOutcomes: true,
+    skipSemanticDiagnostics: true,
+    optimize,
+  });
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, Function>;
+  imports.setExports?.(exports);
+  return exports;
+}
+
+async function settled<T>(value: T | Promise<T>, ms = 4000): Promise<T> {
+  let watchdog: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve(value),
+      new Promise<never>((_, reject) => {
+        watchdog = setTimeout(() => reject(new Error("delay result never settled")), ms);
+      }),
+    ]);
+  } finally {
+    if (watchdog !== undefined) clearTimeout(watchdog);
+  }
+}
+
+describe("#4102 exact Promise-delay closure prepare-before-emit ownership", () => {
+  it.each([false, true])("prepares the owner and both lifted closures once (optimize=%s)", async (optimize) => {
+    const result = await compileTracked(EXACT_DELAY, optimize);
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irFirstSkipped ?? []).toContain("delay");
+    expect(result.irCompiledFuncs ?? []).toEqual(
+      expect.arrayContaining(["delay", "delay__closure_0", "delay__closure_0__closure_1"]),
+    );
+    expect(terminalOutcome(result, "delay")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(terminalOutcome(result, "delay").preparedComponentId).toMatch(/^prepared-component:/);
+
+    const exports = await instantiate(result);
+    const delay = exports.delay as (ms: number, value: number) => Promise<number>;
+    const slow = delay(15, 4102);
+    const fast = delay(1, 2041);
+    await expect(settled(fast)).resolves.toBe(2041);
+    await expect(settled(slow)).resolves.toBe(4102);
+  });
+
+  it("keeps prepared closure indices valid when a direct-only body adds a later import", async () => {
+    const result = await compileTracked(`
+      ${EXACT_DELAY}
+      export function directOnly(...values: number[]): number { return Date.now() + values.length; }
+    `);
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.irFirstSkipped ?? []).toContain("delay");
+    expect(terminalOutcome(result, "delay").preparedComponentId).toMatch(/^prepared-component:/);
+    expect(terminalOutcome(result, "directOnly")).toMatchObject({
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.imports.map((entry) => `${entry.module}.${entry.name}`)).toContain("env.__date_now");
+
+    const exports = await instantiate(result);
+    await expect(settled((exports.delay as (ms: number, value: number) => Promise<number>)(1, 99))).resolves.toBe(99);
+  });
+
+  it("leaves a near-miss Promise shape on direct ownership", async () => {
+    const result = await compileTracked(`
+      export function delay(ms: number, value: number): Promise<number> {
+        return new Promise<number>((resolve) => setTimeout(() => resolve(value), ms));
+      }
+    `);
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.irFirstSkipped ?? []).not.toContain("delay");
+    expect(result.irCompiledFuncs ?? []).not.toContain("delay");
+    expect(terminalOutcome(result, "delay")).toMatchObject({
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(terminalOutcome(result, "delay")).not.toHaveProperty("preparedComponentId");
+  });
+});

--- a/tests/issue-4102-program-abi-closure-support.test.ts
+++ b/tests/issue-4102-program-abi-closure-support.test.ts
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import {
+  canonicalProgramAbiClosureLayoutKey,
+  canonicalProgramAbiClosureSignatureKey,
+  type ProgramAbiClosureSupportLayoutRequest,
+} from "../src/codegen/program-abi-type-planning.js";
+import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
+import { irTypeBindingKey } from "../src/ir/abi-bindings.js";
+import { buildIrUnitInventory } from "../src/ir/identity.js";
+import { irVal, type IrClosureSignature, type IrType } from "../src/ir/nodes.js";
+import { buildIrPlanningIdentityContext } from "../src/ir/planning-identity.js";
+import { ProgramAbiInvariantError } from "../src/ir/program-abi.js";
+import {
+  createEmptyModule,
+  type FieldDef,
+  type FuncTypeDef,
+  type StructTypeDef,
+  type TypeDef,
+  type ValType,
+} from "../src/ir/types.js";
+
+const F64 = irVal({ kind: "f64" });
+const EXTERNREF = irVal({ kind: "externref" });
+const WRAPPER_FIELDS: readonly FieldDef[] = Object.freeze([
+  Object.freeze({ name: "func", type: { kind: "funcref" }, mutable: false }),
+  Object.freeze({ name: "$arity", type: { kind: "i32" }, mutable: false }),
+]);
+
+function physicalType(type: IrType): ValType {
+  if (type.kind !== "val" || type.val.kind === "ref" || type.val.kind === "ref_null") {
+    throw new Error(`test fixture cannot materialize ${type.kind}`);
+  }
+  return type.val;
+}
+
+function appendLayout(
+  types: TypeDef[],
+  input: {
+    readonly signature: IrClosureSignature;
+    readonly captures: readonly IrType[];
+    readonly root?: StructTypeDef;
+    readonly name: string;
+  },
+): ProgramAbiClosureSupportLayoutRequest {
+  const root = input.root ?? {
+    kind: "struct",
+    name: `${input.name}_root`,
+    fields: WRAPPER_FIELDS,
+    superTypeIdx: -1,
+  };
+  if (!input.root) types.push(root);
+  const rootIndex = types.indexOf(root);
+  if (rootIndex < 0) throw new Error("closure root is not allocated");
+  const wrapper: StructTypeDef = input.root
+    ? {
+        kind: "struct",
+        name: `${input.name}_wrapper`,
+        fields: WRAPPER_FIELDS,
+        superTypeIdx: rootIndex,
+      }
+    : root;
+  if (wrapper !== root) types.push(wrapper);
+  const wrapperIndex = types.indexOf(wrapper);
+  const lifted: FuncTypeDef = {
+    kind: "func",
+    name: `${input.name}_lifted`,
+    params: [{ kind: "ref", typeIdx: rootIndex }, ...input.signature.params.map(physicalType)],
+    results: input.signature.returnType === null ? [] : [physicalType(input.signature.returnType)],
+  };
+  types.push(lifted);
+  const captured: StructTypeDef =
+    input.captures.length === 0
+      ? wrapper
+      : {
+          kind: "struct",
+          name: `${input.name}_captured`,
+          fields: [
+            ...WRAPPER_FIELDS,
+            ...input.captures.map((type, index) => ({
+              name: `cap${index}`,
+              type: physicalType(type),
+              mutable: false,
+            })),
+          ],
+          superTypeIdx: wrapperIndex,
+        };
+  if (captured !== wrapper) types.push(captured);
+  return {
+    signature: input.signature,
+    captureFieldTypes: input.captures,
+    wrapperRootType: root,
+    allocationWrapperType: wrapper,
+    liftedFuncType: lifted,
+    capturedSubtypeType: captured,
+  };
+}
+
+function fixture() {
+  const ast = analyzeSource(
+    "export function owner(ms: number, value: number): number { return ms + value; }",
+    "/repo/issue-4102-program-abi-closure-support.ts",
+  );
+  const inventory = buildIrUnitInventory([ast.sourceFile], { entrySource: ast.sourceFile, checker: ast.checker });
+  const identityContext = buildIrPlanningIdentityContext(inventory);
+  const module = createEmptyModule();
+  const session = new ProgramAbiSession(inventory, module);
+  const ctx = createCodegenContext(module, ast.checker, {}, session, identityContext);
+  if (!ctx.programAbiTypes) throw new Error("missing Program ABI type registry");
+  return { module, session, registry: ctx.programAbiTypes };
+}
+
+function promiseLayouts(f: ReturnType<typeof fixture>) {
+  const executorSignature: IrClosureSignature = { params: [EXTERNREF], returnType: null };
+  const timerSignature: IrClosureSignature = { params: [], returnType: null };
+  const executor = appendLayout(f.module.types, {
+    signature: executorSignature,
+    captures: [F64, F64],
+    name: "executor",
+  });
+  const timer = appendLayout(f.module.types, {
+    signature: timerSignature,
+    captures: [EXTERNREF, F64],
+    root: executor.wrapperRootType,
+    name: "timer",
+  });
+  return { executor, timer };
+}
+
+function expectProgramAbiInvariant(action: () => unknown, code: string): ProgramAbiInvariantError {
+  let caught: unknown;
+  try {
+    action();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(ProgramAbiInvariantError);
+  expect((caught as ProgramAbiInvariantError).code).toBe(code);
+  return caught as ProgramAbiInvariantError;
+}
+
+describe("#4102 Program ABI prepared closure support types", () => {
+  it("plans semantic refs in sorted order and dedupes exact requests without allocating types", () => {
+    const f = fixture();
+    const { executor, timer } = promiseLayouts(f);
+    const typeCount = f.module.types.length;
+
+    const [timerLayout, executorLayout, duplicateExecutor] = f.registry.prepareClosureSupportLayouts([
+      timer,
+      executor,
+      executor,
+    ]);
+    expect(f.module.types).toHaveLength(typeCount);
+    expect(duplicateExecutor).toBe(executorLayout);
+    expect(executorLayout!.wrapperRootRef).toBe(executorLayout!.allocationWrapperRef);
+    expect(timerLayout!.wrapperRootRef).toBe(executorLayout!.wrapperRootRef);
+    expect(timerLayout!.allocationWrapperRef).not.toBe(timerLayout!.wrapperRootRef);
+    expect(
+      new Set([
+        irTypeBindingKey(executorLayout!.wrapperRootRef.binding),
+        irTypeBindingKey(executorLayout!.liftedFuncRef.binding),
+        irTypeBindingKey(executorLayout!.capturedSubtypeRef.binding),
+        irTypeBindingKey(timerLayout!.allocationWrapperRef.binding),
+        irTypeBindingKey(timerLayout!.liftedFuncRef.binding),
+        irTypeBindingKey(timerLayout!.capturedSubtypeRef.binding),
+      ]),
+    ).toHaveLength(6);
+
+    const expectedSignatureOrder = [
+      canonicalProgramAbiClosureSignatureKey(executor.signature),
+      canonicalProgramAbiClosureSignatureKey(timer.signature),
+    ].sort();
+    for (const layout of [executorLayout!, timerLayout!]) {
+      expect(layout.semanticSignatureKey).not.toContain("typeIdx");
+      expect(layout.semanticLayoutKey).not.toContain("typeIdx");
+      expect(f.session.getDraft(layout.liftedFuncRef.binding.bindingId)?.structuralOrder.derivedOrdinal).toBe(
+        expectedSignatureOrder.indexOf(layout.semanticSignatureKey),
+      );
+    }
+    expect(f.registry.prepareClosureSupportLayouts([executor, timer])).toEqual([executorLayout, timerLayout]);
+  });
+
+  it("rejects one semantic layout mapping to different physical type objects before planning", () => {
+    const f = fixture();
+    const { executor } = promiseLayouts(f);
+    const alternateSubtype: StructTypeDef = {
+      ...executor.capturedSubtypeType,
+      fields: [...executor.capturedSubtypeType.fields],
+    };
+    f.module.types.push(alternateSubtype);
+    const alternate = { ...executor, capturedSubtypeType: alternateSubtype };
+
+    expectProgramAbiInvariant(
+      () => f.registry.prepareClosureSupportLayouts([executor, alternate]),
+      "type-remap-mismatch",
+    );
+    expect(f.session.typeCellFor(executor.wrapperRootType)).toBeUndefined();
+    expect(f.session.typeCellFor(executor.capturedSubtypeType)).toBeUndefined();
+  });
+
+  it("publishes semantic closure refs through an exact allocator-object remap", () => {
+    const f = fixture();
+    const { executor } = promiseLayouts(f);
+    const [layout] = f.registry.prepareClosureSupportLayouts([executor]);
+    const subtypeIndex = f.module.types.indexOf(executor.capturedSubtypeType);
+    const replacement: StructTypeDef = {
+      ...executor.capturedSubtypeType,
+      name: "executor_captured_after_remap",
+      fields: [...executor.capturedSubtypeType.fields],
+    };
+    const cell = f.session.typeCellFor(executor.capturedSubtypeType);
+    expect(cell).toBeDefined();
+    f.session.remapTypeObject(executor.capturedSubtypeType, replacement);
+    f.module.types[subtypeIndex] = replacement;
+    expect(cell!.current).toBe(replacement);
+
+    f.registry.planRetained();
+    const publication = f.session.publish(f.module);
+    expect(publication.abi.resolveFinalIndex(layout!.wrapperRootRef.binding.bindingId)).toEqual({
+      space: "type",
+      index: f.module.types.indexOf(executor.wrapperRootType),
+    });
+    expect(publication.abi.resolveFinalIndex(layout!.liftedFuncRef.binding.bindingId)).toEqual({
+      space: "type",
+      index: f.module.types.indexOf(executor.liftedFuncType),
+    });
+    expect(publication.abi.resolveFinalIndex(layout!.capturedSubtypeRef.binding.bindingId)).toEqual({
+      space: "type",
+      index: subtypeIndex,
+    });
+    expect(layout!.semanticLayoutKey).toBe(
+      canonicalProgramAbiClosureLayoutKey(executor.signature, executor.captureFieldTypes),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- move the checker-certified Promise delay owner and both lifted closures onto one sealed prepared-component transaction
- plan exact derived callable slots, closure wrapper/subtype refs, and settled imports through Program ABI before direct body emission
- reuse the same closure registry during lowering and keep incomplete or stale evidence fail-closed
- extract closure preparation and component sealing from the integration driver so LOC and function budgets remain green

Tracked in `plan/issues/4102-ir-promise-delay-closure-compile-once.md`.

## Migration effect

- exact delay owner: `legacyBodyEmitted: false`, `irBodyEmitted: true`, real `prepared-component:*` ID
- bounded readiness corpus: 33/37 IR bodies, 34 legacy bodies (down from 35), 4 typed Unsupported, 0 Invariant
- near misses and unsupported target/backend configurations remain on direct ownership

## Validation

- 56/56 focused #2856/#3521-dependencies/#4102 tests
- typecheck, lint, Prettier, LOC/function budgets
- IR fallback and optimization-retirement gates
- hybrid IR-only readiness: READY
- pre-push oracle, coercion-site, numeric-local, and issue-integrity gates

## Baseline note

The broader #3521 routing file has one class-member call-site-plan failure that reproduces unchanged on current `origin/main`; this PR does not touch that selector path.