### PR TITLE
feat(ir): consume async runtime plans before ABI sealing

### DIFF
--- a/plan/issues/4104-ir-async-plan-runtime-consumer.md
+++ b/plan/issues/4104-ir-async-plan-runtime-consumer.md
@@ -1,0 +1,97 @@
+---
+id: 4104
+title: "IR async plan runtime-manifest and Program ABI consumer"
+status: ready
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: critical
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: ir, runtime, codegen
+language_feature: async
+goal: ir-full-coverage
+lane: ir-retirement-r6
+parent: 3526
+depends_on: [4103]
+related: [1042, 1373b, 3527]
+files:
+  - src/ir/nodes.ts
+  - src/ir/intrinsic-support.ts
+  - src/ir/prepared-component-dependencies.ts
+  - src/codegen/ir-async-runtime-adapters.ts
+  - src/ir/integration.ts
+  - tests/issue-4104-ir-async-plan-runtime-consumer.test.ts
+  - plan/issues/4104-ir-async-plan-runtime-consumer.md
+loc-budget-allow:
+  - src/ir/integration.ts
+  - src/ir/nodes.ts
+  - src/ir/verify.ts
+---
+
+# #4104 — IR async plan runtime-manifest and Program ABI consumer
+
+## Problem
+
+`IrAsyncPlan` records the complete semantic Promise and scheduler requirement
+set, and #4103 maps that set to six host capabilities, but production
+preparation does not consume either contract. The existing async frame engine
+still obtains its concrete imports from an AST prepass. Moving a genuinely
+suspending function such as playground `fetchUser` to Prepared IR before this
+seam exists would either discover imports from source syntax again or mutate
+the function index space during lowering.
+
+## Scope
+
+- Attach a target-neutral `IrAsyncPlan` to its exact `IrFunction` owner.
+- Validate the owner, function kind, plan graph, and canonical Promise ABI
+  while preparing the frozen runtime manifest.
+- Request every plan runtime intent through `RuntimeManifestBuilder` and attach
+  the selected host/WasmGC adapter references only after the manifest freezes.
+- Materialize the exact six existing host adapter signatures before Program
+  ABI component sealing; reuse and validate imports already registered by the
+  transitional AST collector.
+- Make every attached adapter an explicit prepared-component callable
+  dependency so Program ABI allocation, not `funcMap` text lookup, owns its
+  final index.
+- Preserve the semantic boundary: neither `IrAsyncPlan` nor
+  `FrozenRuntimeManifest` contains concrete module/field names or indices.
+
+Producing an async plan from `fetchUser` and adapting the frame emitter to
+consume state bodies are the immediately following slice. This issue does not
+claim an async body or change its observable runtime behavior.
+
+## Acceptance criteria
+
+- A prepared plan with all seven intents closes to the exact six host adapter
+  dependencies in deterministic order.
+- Existing matching imports are reused; missing imports are registered with
+  the catalogue signatures; signature or owner drift fails before lowering.
+- The six imports acquire Program ABI identities through dependency-complete
+  component sealing.
+- Host/WasmGC succeeds; strict-no-host and non-WasmGC policies keep their typed
+  manifest failures.
+- Focused tests, typecheck, formatting, source/function budgets, and the IR
+  fallback ratchet pass with the four async blockers unchanged.
+
+## Validation
+
+- The focused #4104/#4103/#1373b suite passes 20 tests, including canonical
+  semantic closure, post-freeze intrinsic attachment, six exact adapter
+  imports, Program ABI identities, owner drift, signature drift, and target
+  policy failures.
+- The prepared-component, Math-runtime, callable-import ABI, and async-frame
+  regression suites pass 41 tests.
+- Typecheck, formatting, LOC/function budgets, and the IR fallback ratchet
+  pass. The bounded census remains four typed blockers: `fetchUser`/`main`
+  (`async-function`), `fetchAllSequential` (`call-graph-closure`), and
+  `fetchAllParallel` (`body-shape-rejected`).
+
+## Handoff
+
+The next slice produces an `IrAsyncPlan` from the exact linear `fetchUser`
+shape and makes the existing frame emitter consume its prepared state bodies.
+It must retain one frame engine and the canonical Promise-only ABI; it must not
+reintroduce AST-driven import discovery or a second suspension machine.

--- a/src/codegen/ir-async-runtime-adapters.ts
+++ b/src/codegen/ir-async-runtime-adapters.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import {
+  ASYNC_HOST_ADAPTERS,
+  type AsyncHostAdapter,
+  type AsyncHostAdapterValueType,
+  type AsyncHostCapabilityId,
+} from "../ir/async-runtime-providers.js";
+import { sameIrCallableBinding, irImportFuncRef } from "../ir/callable-bindings.js";
+import type { IrFunction } from "../ir/nodes.js";
+import type { FuncTypeDef, Import, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { addImport } from "./registry/imports.js";
+import { addFuncType } from "./registry/types.js";
+
+function lowerAdapterType(type: AsyncHostAdapterValueType): ValType {
+  return type === "i32" ? { kind: "i32" } : { kind: "externref" };
+}
+
+function sameValType(left: ValType, right: ValType): boolean {
+  return left.kind === right.kind;
+}
+
+function expectedSignature(adapter: AsyncHostAdapter): FuncTypeDef {
+  return {
+    kind: "func",
+    params: adapter.params.map(lowerAdapterType),
+    results: adapter.results.map(lowerAdapterType),
+  };
+}
+
+function assertImportSignature(ctx: CodegenContext, imported: Import, adapter: AsyncHostAdapter): void {
+  if (imported.desc.kind !== "func") {
+    throw new Error(`IR async adapter ${adapter.capability} resolved to a non-function import`);
+  }
+  const actual = ctx.mod.types[imported.desc.typeIdx];
+  const expected = expectedSignature(adapter);
+  if (
+    !actual ||
+    actual.kind !== "func" ||
+    actual.params.length !== expected.params.length ||
+    actual.results.length !== expected.results.length ||
+    actual.params.some((type, index) => !sameValType(type, expected.params[index]!)) ||
+    actual.results.some((type, index) => !sameValType(type, expected.results[index]!))
+  ) {
+    throw new Error(
+      `IR async adapter ${adapter.capability} import ${adapter.module}.${adapter.field} has a signature outside the frozen catalogue`,
+    );
+  }
+}
+
+function findExactImport(ctx: CodegenContext, adapter: AsyncHostAdapter): Import | undefined {
+  for (let index = ctx.mod.imports.length - 1; index >= 0; index--) {
+    const imported = ctx.mod.imports[index]!;
+    if (imported.module === adapter.module && imported.name === adapter.field) return imported;
+  }
+  return undefined;
+}
+
+/**
+ * Materialize the concrete host adapter projection selected after semantic
+ * runtime-manifest freeze. This runs before prepared component / Program ABI
+ * sealing. Existing imports from the transitional AST collector are validated
+ * and reused; no body-lowering path may lazily invent another adapter.
+ */
+export function materializePreparedAsyncHostAdapters(ctx: CodegenContext, functions: readonly IrFunction[]): void {
+  const requested = new Map<AsyncHostCapabilityId, AsyncHostAdapter>();
+  const catalogue = new Map(ASYNC_HOST_ADAPTERS.map((adapter) => [adapter.capability, adapter] as const));
+
+  for (const fn of functions) {
+    if (!fn.asyncRuntime) continue;
+    if (!fn.asyncPlan || fn.funcKind !== "async") {
+      throw new Error(`IR async runtime attachment for ${fn.name} has no valid async plan owner`);
+    }
+    for (const attached of fn.asyncRuntime.adapters) {
+      const adapter = catalogue.get(attached.capability);
+      if (!adapter) throw new Error(`IR async runtime attachment uses unknown capability ${attached.capability}`);
+      const expectedTarget = irImportFuncRef(adapter.module, adapter.field, adapter.field);
+      if (!sameIrCallableBinding(attached.target.binding, expectedTarget.binding)) {
+        throw new Error(`IR async adapter ${attached.capability} does not match its frozen import projection`);
+      }
+      requested.set(attached.capability, adapter);
+    }
+  }
+
+  for (const adapter of ASYNC_HOST_ADAPTERS) {
+    if (!requested.has(adapter.capability)) continue;
+    let imported = findExactImport(ctx, adapter);
+    if (!imported) {
+      const signature = expectedSignature(adapter);
+      const typeIdx = addFuncType(ctx, signature.params, signature.results);
+      imported = addImport(ctx, adapter.module, adapter.field, { kind: "func", typeIdx });
+    }
+    if (!imported) {
+      throw new Error(`IR async adapter ${adapter.capability} could not be registered before Program ABI freeze`);
+    }
+    assertImportSignature(ctx, imported, adapter);
+  }
+}

--- a/src/ir/async-plan.ts
+++ b/src/ir/async-plan.ts
@@ -14,9 +14,22 @@
  * consume an IrAsyncPlan.
  */
 
-import { ASYNC_RUNTIME_FEATURES, isAsyncRuntimeFeature, type AsyncRuntimeFeature } from "./async-runtime-providers.js";
+import {
+  ASYNC_RUNTIME_FEATURES,
+  isAsyncRuntimeFeature,
+  type AsyncHostCapabilityId,
+  type AsyncRuntimeFeature,
+} from "./async-runtime-providers.js";
 import type { IrUnitId } from "./identity.js";
-import { collectUses, forEachInstrDeep, irTypeEquals, type IrInstr, type IrType, type IrValueId } from "./nodes.js";
+import {
+  collectUses,
+  forEachInstrDeep,
+  irTypeEquals,
+  type IrFuncRef,
+  type IrInstr,
+  type IrType,
+  type IrValueId,
+} from "./nodes.js";
 
 export type IrAsyncStateId = number & { readonly __brand: "IrAsyncStateId" };
 export type IrAsyncHandlerId = number & { readonly __brand: "IrAsyncHandlerId" };
@@ -153,6 +166,23 @@ export interface IrAsyncPlan {
   readonly states: readonly IrAsyncState[];
   readonly handlers: readonly IrAsyncHandler[];
   readonly runtimeIntents: readonly IrAsyncRuntimeIntent[];
+}
+
+/**
+ * Backend attachment created only after the semantic runtime manifest freezes.
+ * The plan above stays target-neutral; this lookup-only record gives prepared
+ * component sealing exact symbolic dependencies for the selected adapter.
+ */
+export interface PreparedIrAsyncHostAdapter {
+  readonly capability: AsyncHostCapabilityId;
+  readonly target: IrFuncRef;
+}
+
+export interface PreparedIrAsyncRuntime {
+  readonly kind: "host-wasmgc";
+  readonly adapters: readonly PreparedIrAsyncHostAdapter[];
+  /** State bodies with post-freeze intrinsic provider attachments. */
+  readonly states: readonly IrAsyncState[];
 }
 
 export type IrAsyncPlanInvariantCode =

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -228,6 +228,7 @@ import { verifyIrFunction } from "./verify.js";
 import { prepareIrRuntimeManifest, type PreparedIrRuntimeManifest } from "./intrinsic-support.js";
 import { isIntrinsicId, type IntrinsicId } from "./intrinsics.js";
 import { materializePreparedMathProviders, preparedMathProviderIndex } from "./math-runtime-providers.js";
+import { materializePreparedAsyncHostAdapters } from "../codegen/ir-async-runtime-adapters.js";
 import type { RuntimeProviderPlan } from "./runtime-manifest.js";
 import { AllocSiteRegistry, ALLOC_NAMESPACES } from "./alloc-registry.js";
 import { analyzeEncoding } from "./analysis/encoding.js";
@@ -444,6 +445,7 @@ function prepareBuiltFnRuntimeManifest(
     return fn === entry.fn ? entry : { ...entry, fn };
   });
   materializePreparedMathProviders(ctx, runtime);
+  materializePreparedAsyncHostAdapters(ctx, runtime.functions);
   return { entries: preparedEntries, runtime };
 }
 

--- a/src/ir/intrinsic-support.ts
+++ b/src/ir/intrinsic-support.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
-import { irIntrinsicFuncRef, sameIrCallableBinding } from "./callable-bindings.js";
+import { irImportFuncRef, irIntrinsicFuncRef, sameIrCallableBinding } from "./callable-bindings.js";
+import { createIrAsyncPlan, type IrAsyncPlan, type PreparedIrAsyncRuntime } from "./async-plan.js";
+import { ASYNC_HOST_ADAPTERS, type AsyncHostCapabilityId } from "./async-runtime-providers.js";
 import { intrinsicEffectEvidence, INTRINSIC_DEFINITIONS } from "./intrinsics.js";
 import {
   forEachInstrDeep,
@@ -72,6 +74,7 @@ function mapArray<T>(values: readonly T[], map: (value: T) => T): readonly T[] {
 function valueTypesOf(fn: IrFunction): ReadonlyMap<IrValueId, IrType> {
   const result = new Map<IrValueId, IrType>();
   for (const param of fn.params) result.set(param.value, param.type);
+  for (const value of fn.asyncPlan?.values ?? []) result.set(value.value, value.type);
   for (const block of fn.blocks) {
     for (let index = 0; index < block.blockArgs.length; index++) {
       const type = block.blockArgTypes[index];
@@ -109,11 +112,11 @@ function sameProvider(left: IrIntrinsicProvider, right: IrIntrinsicProvider): bo
   );
 }
 
-function attachProviders(
-  fn: IrFunction,
+function attachProvidersToBuffer(
+  buffer: readonly IrInstr[],
   providers: ReadonlyMap<IrInstrIntrinsic["id"], RuntimeProviderPlan>,
-): IrFunction {
-  const mapBuffer = (buffer: readonly IrInstr[]): readonly IrInstr[] => mapArray(buffer, mapInstr);
+): readonly IrInstr[] {
+  const mapBuffer = (nestedBuffer: readonly IrInstr[]): readonly IrInstr[] => mapArray(nestedBuffer, mapInstr);
   const mapInstr = (instr: IrInstr): IrInstr => {
     const nested = mapNestedBuffers(instr, mapBuffer);
     if (nested.kind !== "intrinsic") return nested;
@@ -128,9 +131,15 @@ function attachProviders(
     }
     return { ...nested, provider: attachment };
   };
+  return mapBuffer(buffer);
+}
 
+function attachProviders(
+  fn: IrFunction,
+  providers: ReadonlyMap<IrInstrIntrinsic["id"], RuntimeProviderPlan>,
+): IrFunction {
   const blocks = mapArray(fn.blocks, (block) => {
-    const instrs = mapBuffer(block.instrs);
+    const instrs = attachProvidersToBuffer(block.instrs, providers);
     return instrs === block.instrs ? block : { ...block, instrs };
   });
   return blocks === fn.blocks ? fn : { ...fn, blocks };
@@ -147,10 +156,22 @@ export function prepareIrRuntimeManifest(input: {
   readonly policy: RuntimeManifestPolicy;
 }): PreparedIrRuntimeManifest | undefined {
   const uses: Array<{ readonly instr: IrInstrIntrinsic; readonly argumentTypes: readonly IrType[] }> = [];
+  const asyncPlans = new Map<IrFunction["unitId"], IrAsyncPlan>();
   for (const fn of input.functions) {
+    if (fn.asyncPlan) {
+      if (fn.funcKind !== "async") {
+        throw new Error(`IR async plan owner ${fn.name} is not marked funcKind=async`);
+      }
+      if (fn.asyncPlan.ownerUnitId !== fn.unitId) {
+        throw new Error(`IR async plan owner mismatch for ${fn.name}: ${fn.asyncPlan.ownerUnitId} != ${fn.unitId}`);
+      }
+      asyncPlans.set(fn.unitId, createIrAsyncPlan(fn.asyncPlan));
+    } else if (fn.asyncRuntime) {
+      throw new Error(`IR async runtime attachment for ${fn.name} has no semantic async plan`);
+    }
     const valueTypes = valueTypesOf(fn);
-    for (const block of fn.blocks) {
-      for (const root of block.instrs) {
+    const collectBuffer = (buffer: readonly IrInstr[]): void => {
+      for (const root of buffer) {
         forEachInstrDeep(root, (instr) => {
           if (instr.kind !== "intrinsic") return;
           const argumentTypes = instr.args.map((arg) => {
@@ -161,11 +182,16 @@ export function prepareIrRuntimeManifest(input: {
           uses.push({ instr, argumentTypes });
         });
       }
-    }
+    };
+    for (const block of fn.blocks) collectBuffer(block.instrs);
+    for (const state of fn.asyncPlan?.states ?? []) collectBuffer(state.body);
   }
-  if (uses.length === 0) return undefined;
+  if (uses.length === 0 && asyncPlans.size === 0) return undefined;
 
   const builder = new RuntimeManifestBuilder(input.policy);
+  for (const plan of asyncPlans.values()) {
+    for (const intent of plan.runtimeIntents) builder.requestFeature(intent);
+  }
   for (const { instr, argumentTypes } of uses) {
     const definition = INTRINSIC_DEFINITIONS[instr.id];
     if (!instr.resultType || !irTypeEquals(instr.resultType, definition.signature.result)) {
@@ -191,8 +217,37 @@ export function prepareIrRuntimeManifest(input: {
   for (const use of manifest.intrinsicUses) {
     providers.set(use.id, builder.resolveProvider(INTRINSIC_DEFINITIONS[use.id].feature));
   }
+  const attachAsyncRuntime = (fn: IrFunction): IrFunction => {
+    const plan = asyncPlans.get(fn.unitId);
+    if (!plan) return fn;
+    const capabilities = new Set<AsyncHostCapabilityId>();
+    for (const intent of plan.runtimeIntents) {
+      for (const capability of builder.resolveProvider(intent).hostCapabilities) capabilities.add(capability);
+    }
+    const runtime: PreparedIrAsyncRuntime = Object.freeze({
+      kind: "host-wasmgc",
+      adapters: Object.freeze(
+        ASYNC_HOST_ADAPTERS.filter((adapter) => capabilities.has(adapter.capability)).map((adapter) =>
+          Object.freeze({
+            capability: adapter.capability,
+            target: irImportFuncRef(adapter.module, adapter.field, adapter.field),
+          }),
+        ),
+      ),
+      states: Object.freeze(
+        plan.states.map((state) => {
+          const body = attachProvidersToBuffer(state.body, providers);
+          return body === state.body ? state : Object.freeze({ ...state, body });
+        }),
+      ),
+    });
+    if (fn.asyncRuntime && JSON.stringify(fn.asyncRuntime) !== JSON.stringify(runtime)) {
+      throw new Error(`IR async runtime attachment for ${fn.name} differs from the frozen manifest`);
+    }
+    return { ...fn, asyncPlan: plan, asyncRuntime: runtime };
+  };
   return Object.freeze({
-    functions: Object.freeze(input.functions.map((fn) => attachProviders(fn, providers))),
+    functions: Object.freeze(input.functions.map((fn) => attachAsyncRuntime(attachProviders(fn, providers)))),
     manifest,
     providers,
   });

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -22,6 +22,7 @@ import type { IrBindingId, IrClassId, IrFunctionIdentity, IrUnitId } from "./ide
 import type { JsTag } from "./js-tag.js";
 import type { IrStringConcatMode, IrStringEncoding } from "./string-runtime.js";
 import type { IntrinsicId, IntrinsicSignatureVersion } from "./intrinsics.js";
+import type { IrAsyncPlan, PreparedIrAsyncRuntime } from "./async-plan.js";
 
 // ---------------------------------------------------------------------------
 // Symbolic references
@@ -2853,6 +2854,18 @@ export interface IrFunction extends IrFunctionIdentity {
    *   - `"regular"`: no special treatment (default if absent).
    */
   readonly funcKind?: "regular" | "generator" | "async";
+  /**
+   * Canonical, target-neutral suspension graph for a genuinely asynchronous
+   * function. It is produced before backend selection and contains no AST,
+   * Wasm indices, or concrete host adapter spellings.
+   */
+  readonly asyncPlan?: IrAsyncPlan;
+  /**
+   * Lookup-only backend attachment added after runtime-manifest freeze. This
+   * is deliberately separate from `asyncPlan` so plan hashes stay target
+   * independent while Program ABI sealing can see exact adapter callables.
+   */
+  readonly asyncRuntime?: PreparedIrAsyncRuntime;
   /**
    * Slice 7a (#1169f) — for `funcKind === "generator"` functions only,
    * the slot index (in `slots`) of the `__gen_buffer` Wasm-local. The

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -491,6 +491,7 @@ function collectClassShape(shape: IrClassShape, classes: Map<IrClassId, IrClassS
 function valueTypesOf(fn: IrFunction): Map<IrValueId, IrType> {
   const types = new Map<IrValueId, IrType>();
   for (const param of fn.params) types.set(param.value, param.type);
+  for (const value of fn.asyncPlan?.values ?? []) types.set(value.value, value.type);
   for (const block of fn.blocks) {
     block.blockArgs.forEach((value, index) => {
       const type = block.blockArgTypes[index];
@@ -868,6 +869,11 @@ function collectFunctionEvidence(
   };
   for (const param of fn.params) collectType(param.type);
   for (const result of fn.resultTypes) collectType(result);
+  if (fn.asyncPlan) {
+    if (fn.asyncPlan.abi.fulfillmentType) collectType(fn.asyncPlan.abi.fulfillmentType);
+    for (const value of fn.asyncPlan.values) collectType(value.type);
+    for (const spill of fn.asyncPlan.spills) collectType(spill.type);
+  }
   if (fn.closureSubtype) {
     for (const capture of fn.closureSubtype.captureFieldTypes) collectType(capture);
   }
@@ -877,122 +883,130 @@ function collectFunctionEvidence(
     "prepared IR lifted closure body must use Program ABI support refs",
   );
 
+  const collectInstr = (instr: IrInstr): void => {
+    forEachInstrDeep(instr, (nested) => {
+      if (nested.resultType) collectType(nested.resultType);
+      for (const shape of explicitClassShapes(nested, valueTypes)) collectClassShape(shape, classes, seenTypes);
+      const instructionClosureSupport = input.closureSupport?.instructionRefs.get(nested);
+      recordPreparedClosureRefs(
+        instructionClosureSupport,
+        `prepared IR ${nested.kind} must use Program ABI support refs`,
+      );
+      const hasPreparedClosureSupport =
+        nested.kind === "closure.cap"
+          ? (functionClosureSupport?.length ?? 0) > 0
+          : (instructionClosureSupport?.length ?? 0) > 0;
+      const implicitSupport = implicitSupportRequirement(nested, hasPreparedClosureSupport);
+      if (implicitSupport) {
+        addFailure(evidence, {
+          code: "implicit-support-reference-unavailable",
+          ownerUnitId: terminalOwnerUnitId,
+          detail: implicitSupport,
+        });
+      }
+      if (nested.kind === "call") {
+        if (nested.target.binding.kind === "unit") {
+          recordUnitReference(
+            evidence,
+            nested.target.binding.unitId,
+            functionsByUnitId,
+            input.terminalUnitIds,
+            input.abi,
+            ownership,
+          );
+        } else {
+          recordExternalCallable(evidence, nested.target, input.abi, ownership);
+        }
+      } else if (nested.kind === "intrinsic") {
+        if (nested.provider?.kind === "callable") {
+          recordExternalCallable(evidence, nested.provider.target, input.abi, ownership);
+        }
+      } else if (nested.kind === "closure.new") {
+        if (nested.liftedFunc.binding.kind === "unit") {
+          recordUnitReference(
+            evidence,
+            nested.liftedFunc.binding.unitId,
+            functionsByUnitId,
+            input.terminalUnitIds,
+            input.abi,
+            ownership,
+          );
+        } else {
+          recordExternalCallable(evidence, nested.liftedFunc, input.abi, ownership);
+        }
+      } else if (nested.kind === "global.get" || nested.kind === "global.set") {
+        recordGlobalReference(evidence, nested.target, input.abi, ownership, input.terminalUnitIds);
+      } else if (nested.kind === "string.const") {
+        if (nested.storage) {
+          recordGlobalReference(evidence, nested.storage, input.abi, ownership, input.terminalUnitIds);
+        } else if (nested.materializer) {
+          recordExternalCallable(evidence, nested.materializer, input.abi, ownership);
+        }
+      } else if (nested.kind === "string.len" && nested.provider) {
+        if (nested.provider.kind === "callable") {
+          recordExternalCallable(evidence, nested.provider.target, input.abi, ownership);
+        } else {
+          recordSupportTypeReference(
+            evidence,
+            nested.provider.ownerType,
+            input.abi,
+            ownership,
+            "IR string.len struct field must use a compiler-support Program ABI type ref",
+          );
+        }
+      } else if (
+        (nested.kind === "string.concat" ||
+          nested.kind === "string.eq" ||
+          nested.kind === "string.char_at" ||
+          nested.kind === "string.char_code_at" ||
+          nested.kind === "forof.string") &&
+        nested.provider
+      ) {
+        recordExternalCallable(evidence, nested.provider, input.abi, ownership);
+      }
+      if (
+        nested.kind === "class.call" ||
+        nested.kind === "class.super_init" ||
+        nested.kind === "class.super_call" ||
+        nested.kind === "class.static_call" ||
+        nested.kind === "class.new"
+      ) {
+        const shape = explicitClassShapes(nested, valueTypes)[0];
+        const target = nested.target;
+        if (!target) {
+          addFailure(evidence, {
+            code: "class-member-callable-unavailable",
+            ownerUnitId: terminalOwnerUnitId,
+            ...(shape ? { referencedClassId: shape.classId } : {}),
+            detail:
+              `${nested.kind} carries a class/member descriptor but no exact symbolic callable reference; ` +
+              "dependency ownership cannot be inferred from compatibility names",
+          });
+        } else if (target.binding.kind === "unit") {
+          recordUnitReference(
+            evidence,
+            target.binding.unitId,
+            functionsByUnitId,
+            input.terminalUnitIds,
+            input.abi,
+            ownership,
+          );
+        } else {
+          recordExternalCallable(evidence, target, input.abi, ownership);
+        }
+      }
+    });
+  };
   for (const block of fn.blocks) {
     for (const type of block.blockArgTypes) collectType(type);
-    for (const instr of block.instrs) {
-      forEachInstrDeep(instr, (nested) => {
-        if (nested.resultType) collectType(nested.resultType);
-        for (const shape of explicitClassShapes(nested, valueTypes)) collectClassShape(shape, classes, seenTypes);
-        const instructionClosureSupport = input.closureSupport?.instructionRefs.get(nested);
-        recordPreparedClosureRefs(
-          instructionClosureSupport,
-          `prepared IR ${nested.kind} must use Program ABI support refs`,
-        );
-        const hasPreparedClosureSupport =
-          nested.kind === "closure.cap"
-            ? (functionClosureSupport?.length ?? 0) > 0
-            : (instructionClosureSupport?.length ?? 0) > 0;
-        const implicitSupport = implicitSupportRequirement(nested, hasPreparedClosureSupport);
-        if (implicitSupport) {
-          addFailure(evidence, {
-            code: "implicit-support-reference-unavailable",
-            ownerUnitId: terminalOwnerUnitId,
-            detail: implicitSupport,
-          });
-        }
-        if (nested.kind === "call") {
-          if (nested.target.binding.kind === "unit") {
-            recordUnitReference(
-              evidence,
-              nested.target.binding.unitId,
-              functionsByUnitId,
-              input.terminalUnitIds,
-              input.abi,
-              ownership,
-            );
-          } else {
-            recordExternalCallable(evidence, nested.target, input.abi, ownership);
-          }
-        } else if (nested.kind === "intrinsic") {
-          if (nested.provider?.kind === "callable") {
-            recordExternalCallable(evidence, nested.provider.target, input.abi, ownership);
-          }
-        } else if (nested.kind === "closure.new") {
-          if (nested.liftedFunc.binding.kind === "unit") {
-            recordUnitReference(
-              evidence,
-              nested.liftedFunc.binding.unitId,
-              functionsByUnitId,
-              input.terminalUnitIds,
-              input.abi,
-              ownership,
-            );
-          } else {
-            recordExternalCallable(evidence, nested.liftedFunc, input.abi, ownership);
-          }
-        } else if (nested.kind === "global.get" || nested.kind === "global.set") {
-          recordGlobalReference(evidence, nested.target, input.abi, ownership, input.terminalUnitIds);
-        } else if (nested.kind === "string.const") {
-          if (nested.storage) {
-            recordGlobalReference(evidence, nested.storage, input.abi, ownership, input.terminalUnitIds);
-          } else if (nested.materializer) {
-            recordExternalCallable(evidence, nested.materializer, input.abi, ownership);
-          }
-        } else if (nested.kind === "string.len" && nested.provider) {
-          if (nested.provider.kind === "callable") {
-            recordExternalCallable(evidence, nested.provider.target, input.abi, ownership);
-          } else {
-            recordSupportTypeReference(
-              evidence,
-              nested.provider.ownerType,
-              input.abi,
-              ownership,
-              "IR string.len struct field must use a compiler-support Program ABI type ref",
-            );
-          }
-        } else if (
-          (nested.kind === "string.concat" ||
-            nested.kind === "string.eq" ||
-            nested.kind === "string.char_at" ||
-            nested.kind === "string.char_code_at" ||
-            nested.kind === "forof.string") &&
-          nested.provider
-        ) {
-          recordExternalCallable(evidence, nested.provider, input.abi, ownership);
-        }
-        if (
-          nested.kind === "class.call" ||
-          nested.kind === "class.super_init" ||
-          nested.kind === "class.super_call" ||
-          nested.kind === "class.static_call" ||
-          nested.kind === "class.new"
-        ) {
-          const shape = explicitClassShapes(nested, valueTypes)[0];
-          const target = nested.target;
-          if (!target) {
-            addFailure(evidence, {
-              code: "class-member-callable-unavailable",
-              ownerUnitId: terminalOwnerUnitId,
-              ...(shape ? { referencedClassId: shape.classId } : {}),
-              detail:
-                `${nested.kind} carries a class/member descriptor but no exact symbolic callable reference; ` +
-                "dependency ownership cannot be inferred from compatibility names",
-            });
-          } else if (target.binding.kind === "unit") {
-            recordUnitReference(
-              evidence,
-              target.binding.unitId,
-              functionsByUnitId,
-              input.terminalUnitIds,
-              input.abi,
-              ownership,
-            );
-          } else {
-            recordExternalCallable(evidence, target, input.abi, ownership);
-          }
-        }
-      });
-    }
+    for (const instr of block.instrs) collectInstr(instr);
+  }
+  for (const state of fn.asyncRuntime?.states ?? fn.asyncPlan?.states ?? []) {
+    if (state.resume) collectType(state.resume.type);
+    for (const instr of state.body) collectInstr(instr);
+  }
+  for (const adapter of fn.asyncRuntime?.adapters ?? []) {
+    recordExternalCallable(evidence, adapter.target, input.abi, ownership);
   }
   for (const shape of classes.values()) {
     addClassLayout(evidence, shape, input.terminalUnitIds, input.abi, ownership);

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -28,6 +28,7 @@ import type { ValType } from "./types.js";
 // from the dependency-free leaf, so this adds no codegen module-graph pull.
 import { JsTag, jsTagUnboxKind } from "./js-tag.js";
 import { verifyIrIntrinsicInstruction } from "./intrinsic-support.js";
+import { verifyIrAsyncPlan } from "./async-plan.js";
 
 /**
  * #1850 — successor block ids of a block, derived from its terminator.
@@ -387,6 +388,33 @@ function verifySymbolicReferences(func: IrFunction, errors: IrVerifyError[]): vo
 export function verifyIrFunction(func: IrFunction): IrVerifyError[] {
   const errors: IrVerifyError[] = [];
   const defs = new Set<IrValueId>();
+
+  if (func.asyncPlan) {
+    if (func.funcKind !== "async") {
+      errors.push({ message: "asyncPlan requires funcKind=async", func: func.name });
+    }
+    if (func.asyncPlan.ownerUnitId !== func.unitId) {
+      errors.push({ message: "asyncPlan ownerUnitId does not match its IrFunction", func: func.name });
+    }
+    for (const error of verifyIrAsyncPlan(func.asyncPlan)) {
+      errors.push({ message: `asyncPlan ${error.code}: ${error.message}`, func: func.name });
+    }
+  } else if (func.asyncRuntime) {
+    errors.push({ message: "asyncRuntime requires a semantic asyncPlan", func: func.name });
+  }
+  if (func.asyncRuntime) {
+    const capabilities = new Set<string>();
+    for (const adapter of func.asyncRuntime.adapters) {
+      if (capabilities.has(adapter.capability)) {
+        errors.push({ message: `asyncRuntime duplicates capability ${adapter.capability}`, func: func.name });
+      }
+      capabilities.add(adapter.capability);
+      const problem = callableReferenceProblem(adapter.target);
+      if (problem !== null) {
+        errors.push({ message: `asyncRuntime adapter ${adapter.capability} ${problem}`, func: func.name });
+      }
+    }
+  }
 
   verifySymbolicReferences(func, errors);
 

--- a/tests/issue-4104-ir-async-plan-runtime-consumer.test.ts
+++ b/tests/issue-4104-ir-async-plan-runtime-consumer.test.ts
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { createCodegenContext } from "../src/codegen/context/create-context.js";
+import { materializePreparedAsyncHostAdapters } from "../src/codegen/ir-async-runtime-adapters.js";
+import { planProgramAbiCallableImports } from "../src/codegen/program-abi-import-planning.js";
+import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
+import { asAsyncStateId, canonicalPromiseAbi, createIrAsyncPlan, type IrAsyncPlan } from "../src/ir/async-plan.js";
+import { ASYNC_HOST_ADAPTERS, ASYNC_RUNTIME_FEATURES } from "../src/ir/async-runtime-providers.js";
+import { irCallableBindingKey } from "../src/ir/callable-bindings.js";
+import { buildIrUnitInventory, type IrTerminalUnitRecord } from "../src/ir/identity.js";
+import { prepareIrRuntimeManifest } from "../src/ir/intrinsic-support.js";
+import { asBlockId, asValueId, irVal, type IrFunction } from "../src/ir/nodes.js";
+import { derivePreparedComponentDependencies } from "../src/ir/prepared-component-dependencies.js";
+import { RuntimeManifestInvariantError } from "../src/ir/runtime-manifest.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import { verifyIrFunction } from "../src/ir/verify.js";
+import { ts } from "../src/ts-api.js";
+
+const EXTERN = irVal({ kind: "externref" });
+const F64 = irVal({ kind: "f64" });
+
+function fixture(suffix = ""): {
+  readonly inventory: ReturnType<typeof buildIrUnitInventory>;
+  readonly unit: IrTerminalUnitRecord;
+} {
+  const source = ts.createSourceFile(
+    `/repo/async-plan-consumer${suffix}.ts`,
+    "export async function fetchUser(p: Promise<number>): Promise<number> { return await p; }",
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const inventory = buildIrUnitInventory([source], { entrySource: source });
+  const unit = inventory.terminalUnits.find(
+    (candidate) => candidate.kind === "top-level-function" && candidate.displayName === "fetchUser",
+  );
+  if (!unit) throw new Error("missing fetchUser inventory unit");
+  return { inventory, unit };
+}
+
+function asyncPlan(unit: IrTerminalUnitRecord, withIntrinsic = false): IrAsyncPlan {
+  const promise = asValueId(0);
+  const resumed = asValueId(1);
+  const absolute = asValueId(2);
+  return createIrAsyncPlan({
+    schemaVersion: 1,
+    ownerUnitId: unit.id,
+    kind: "async-function",
+    abi: canonicalPromiseAbi(F64),
+    entry: asAsyncStateId(0),
+    params: [{ value: promise, type: EXTERN }],
+    values: [
+      { value: promise, type: EXTERN },
+      { value: resumed, type: F64 },
+      ...(withIntrinsic ? [{ value: absolute, type: F64 }] : []),
+    ],
+    spills: [],
+    states: [
+      {
+        id: asAsyncStateId(0),
+        body: [],
+        terminator: {
+          kind: "suspend",
+          awaited: promise,
+          resume: { state: asAsyncStateId(1), value: resumed },
+          rejected: { kind: "reject" },
+          live: [],
+        },
+      },
+      {
+        id: asAsyncStateId(1),
+        resume: { value: resumed, type: F64, source: "fulfilled" },
+        body: withIntrinsic
+          ? [
+              {
+                kind: "intrinsic",
+                id: "math.abs",
+                version: 1,
+                args: [resumed],
+                result: absolute,
+                resultType: F64,
+              },
+            ]
+          : [],
+        terminator: { kind: "resolve", value: withIntrinsic ? absolute : resumed },
+      },
+    ],
+    handlers: [],
+    runtimeIntents: ASYNC_RUNTIME_FEATURES,
+  });
+}
+
+function irFunction(unit: IrTerminalUnitRecord, withIntrinsic = false): IrFunction {
+  const promise = asValueId(0);
+  return {
+    unitId: unit.id,
+    name: unit.displayName,
+    params: [{ value: promise, type: EXTERN, name: "p" }],
+    resultTypes: [EXTERN],
+    blocks: [
+      {
+        id: asBlockId(0),
+        blockArgs: [],
+        blockArgTypes: [],
+        instrs: [],
+        terminator: { kind: "return", values: [promise] },
+      },
+    ],
+    exported: true,
+    valueCount: 2,
+    funcKind: "async",
+    asyncPlan: asyncPlan(unit, withIntrinsic),
+  };
+}
+
+function prepare(fn: IrFunction) {
+  const prepared = prepareIrRuntimeManifest({
+    functions: [fn],
+    sourceFile: "/repo/async-plan-consumer.ts",
+    policy: { target: "host", backend: "wasmgc" },
+  });
+  if (!prepared) throw new Error("missing async runtime manifest");
+  return prepared;
+}
+
+describe("#4104 IR async plan runtime consumer", () => {
+  it("closes a semantic plan to exact prepared adapter references without contaminating the plan or manifest", () => {
+    const { unit } = fixture();
+    const prepared = prepare(irFunction(unit));
+    const fn = prepared.functions[0]!;
+
+    expect(prepared.manifest.features).toEqual(ASYNC_RUNTIME_FEATURES);
+    expect(fn.asyncRuntime?.adapters.map((adapter) => adapter.capability)).toEqual(
+      ASYNC_HOST_ADAPTERS.map((adapter) => adapter.capability),
+    );
+    expect(fn.asyncRuntime?.adapters.map((adapter) => adapter.target.binding)).toEqual(
+      ASYNC_HOST_ADAPTERS.map((adapter) => ({ kind: "import", module: adapter.module, field: adapter.field })),
+    );
+    expect(verifyIrFunction(fn)).toEqual([]);
+
+    const semanticData = JSON.stringify({ plan: fn.asyncPlan, manifest: prepared.manifest });
+    for (const adapter of ASYNC_HOST_ADAPTERS) expect(semanticData).not.toContain(adapter.field);
+  });
+
+  it("keeps semantic plan bodies target-neutral while attaching intrinsic providers to prepared states", () => {
+    const { unit } = fixture();
+    const prepared = prepare(irFunction(unit, true));
+    const fn = prepared.functions[0]!;
+    const semantic = fn.asyncPlan!.states[1]!.body[0];
+    const lowered = fn.asyncRuntime!.states[1]!.body[0];
+
+    expect(semantic).toMatchObject({ kind: "intrinsic", id: "math.abs" });
+    expect(semantic).not.toHaveProperty("provider");
+    expect(lowered).toMatchObject({ kind: "intrinsic", id: "math.abs", provider: { kind: "backend-op" } });
+    expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("materializes, reuses, and Program-ABI-plans all six imports before component sealing", () => {
+    const { inventory, unit } = fixture();
+    const module = createEmptyModule();
+    const session = new ProgramAbiSession(inventory, module);
+    const ctx = createCodegenContext(module, {} as ts.TypeChecker, undefined, session);
+    const prepared = prepare(irFunction(unit));
+
+    materializePreparedAsyncHostAdapters(ctx, prepared.functions);
+    const typeCount = module.types.length;
+    materializePreparedAsyncHostAdapters(ctx, prepared.functions);
+
+    expect(module.imports.map((imported) => `${imported.module}.${imported.name}`).sort()).toEqual(
+      ASYNC_HOST_ADAPTERS.map((adapter) => `${adapter.module}.${adapter.field}`).sort(),
+    );
+    expect(module.imports).toHaveLength(6);
+    expect(module.types).toHaveLength(typeCount);
+
+    const planned = planProgramAbiCallableImports(ctx);
+    expect(planned.size).toBe(6);
+    const report = derivePreparedComponentDependencies({
+      module: { functions: prepared.functions },
+      terminalUnitIds: new Set([unit.id]),
+      inventory,
+      abi: {
+        get: (id) => session.getDraft(id),
+        bindingIdsForStructuralReference: (key) => session.bindingIdsForStructuralReference(key),
+      },
+    });
+    expect(report.components[0]?.status).toBe("complete");
+    expect(
+      report.components[0]?.externalCallables.map((dependency) => dependency.structuralReferenceKey).sort(),
+    ).toEqual(
+      prepared.functions[0]!.asyncRuntime!.adapters.map((adapter) =>
+        irCallableBindingKey(adapter.target.binding),
+      ).sort(),
+    );
+    expect(report.components[0]?.externalCallables.every((dependency) => dependency.programAbiBindingId !== null)).toBe(
+      true,
+    );
+  });
+
+  it("fails closed on owner drift and unavailable target policies", () => {
+    const first = fixture();
+    const second = fixture("-other");
+    const wrongOwner = { ...irFunction(first.unit), asyncPlan: asyncPlan(second.unit) };
+    expect(() => prepare(wrongOwner)).toThrow(/owner mismatch/);
+
+    expect(() =>
+      prepareIrRuntimeManifest({
+        functions: [irFunction(first.unit)],
+        sourceFile: "/repo/async-plan-consumer.ts",
+        policy: { target: "strict-no-host", backend: "wasmgc" },
+      }),
+    ).toThrowError(expect.objectContaining<RuntimeManifestInvariantError>({ code: "provider-target-unavailable" }));
+
+    const malformedModule = createEmptyModule();
+    malformedModule.types.push({ kind: "func", params: [{ kind: "f64" }], results: [] });
+    malformedModule.imports.push({
+      module: "env",
+      name: "Promise_resolve",
+      desc: { kind: "func", typeIdx: 0 },
+    });
+    const malformedCtx = createCodegenContext(malformedModule, {} as ts.TypeChecker);
+    expect(() => materializePreparedAsyncHostAdapters(malformedCtx, prepare(irFunction(first.unit)).functions)).toThrow(
+      /signature outside the frozen catalogue/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- consume IrAsyncPlan.runtimeIntents through the frozen runtime-provider manifest
- keep the semantic plan target-neutral while attaching exact host/WasmGC adapters after freeze
- materialize and validate the six existing async imports before prepared-component sealing
- expose plan state bodies and adapter callables to dependency-complete Program ABI ownership

## Migration impact

This is the runtime-consumer prerequisite for moving genuinely suspending functions such as playground fetchUser onto Prepared IR. It removes the need for AST-driven async import discovery on that future route. It intentionally does not claim a body yet, so the bounded fallback census remains the same four typed async blockers.

Tracked in plan/issues/4104-ir-async-plan-runtime-consumer.md.

## Validation

- 20 focused #4104/#4103/#1373b tests
- 41 prepared-component, Math-runtime, callable-import ABI, and async-frame regression tests
- typecheck and formatting
- LOC/function/oracle/coercion budgets
- IR fallback ratchet
- pre-commit and pre-push hooks