### PR TITLE
feat(ir): emit single-await async functions from prepared plans

### DIFF
--- a/plan/agent-context/ir-migration-handover-2026-08-02.md
+++ b/plan/agent-context/ir-migration-handover-2026-08-02.md
@@ -1,0 +1,139 @@
+# IR migration handover — 2026-08-02
+
+Work is wound down after the first production `IrAsyncPlan` source-owner
+slice. All delegated agents have finished, and no follow-up implementation
+slice was started. The completed work is published as ready PR
+[#4050](https://github.com/loopdive/js2/pull/4050), with auto-merge enabled.
+
+The issue Markdown files remain authoritative. Start with:
+
+- `plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md`
+- `plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md`
+- `plan/issues/4106-ir-async-fetch-user-state-machine.md`
+- `plan/issues/3522-*` through `plan/issues/3528-*`
+
+## Exact stop point
+
+- Branch: `codex/4106-ir-async-fetch-user`
+- Isolated worktree: `/private/tmp/ts2wasm-4106-async-fetch-user`
+- PR head before this handover commit: `b0237c394b41024e75b6c0a7e62b23409ca89a7a`
+- Base at publication: `origin/main` `b157531c1e59ef85fa4047371d33a25205e12e8f`
+- PR state at handover: open, ready, auto-merge enabled, required CI running,
+  no observed failures.
+
+Do not amend or push this branch once GitHub places it in the merge queue.
+
+## What this slice completes
+
+The exact host/WasmGC source shape
+
+```ts
+async function f(...): Promise<T> {
+  const value = await expression;
+  return value;
+}
+```
+
+can now be prepared as a canonical two-state `IrAsyncPlan`, with the
+pre-suspension computation moved into a structurally identified IR state
+helper. The prepared plan resolves its six host runtime adapters through the
+frozen runtime manifest and Program ABI, then emits through the existing async
+frame/scheduler engine.
+
+The producer keeps the semantic fulfilled value (`f64` for the playground
+case) separate from the physical Promise-returning callable ABI (`externref`).
+For the exact numeric identity tail, it also preserves the direct path's
+optimization by avoiding an `externref -> f64 -> externref` carrier round trip.
+
+The playground `fetchUser` function and `fetchUser__ir_async_state_0` now emit
+through IR with no post-claim error. `fetchAllSequential`,
+`fetchAllParallel`, and `main` remain typed `async-function` blockers.
+
+## Measured migration state
+
+The production single-host readiness lane is:
+
+- 5/5 entries observed
+- 37 terminal source units
+- 34 IR-emitted terminal units (91.9%)
+- 3 typed Unsupported units
+- 0 Invariant units
+- 34 legacy bodies emitted
+- 34 IR bodies emitted
+
+The high IR-emission percentage is overlay coverage, not retirement coverage.
+Only three terminal units currently avoid legacy body emission. The compiler
+therefore remains a default-on hybrid, and the direct frontend/codegen path is
+not ready for deletion.
+
+## Safest next serial steps
+
+1. Let #4050 merge; fetch the resulting `origin/main` before starting work.
+2. Move the exact proven async owner from the post-direct overlay into
+   compile-once preparation. Allocate its canonical Promise callable ABI
+   before body emission and prove `direct=0, IR=1` at the terminal owner.
+3. Widen the same producer and frame-consumer seam from one suspension to
+   multiple states and explicit spills.
+4. Migrate the three remaining playground async owners through that widened
+   seam. Keep loops, Promise combinators, rejection, and settlement behavior
+   on the shared frame engine.
+5. Continue the broader retirement sequence: R2 dependency families, R3
+   classes/closures, R4 ordered module init, R5 whole-program ownership, R6/R7
+   runtime and suspension families, R8 linear consumption, then the R9 default
+   flip and R10 deletion.
+
+Keep core changes serial. `src/codegen/index.ts`, `src/ir/select.ts`,
+`src/ir/from-ast.ts`, `src/ir/integration.ts`, declaration planning, and class/
+closure allocation are overlapping ownership seams. Safe parallel work is
+limited to disjoint fixtures, provider catalogues, benchmark evidence, and the
+optimization ledger.
+
+## Optimization-retirement guard
+
+Do not retire a direct handler solely because its syntax family emits through
+IR. Preserve every optimization with an explicit IR owner and evidence.
+
+The existing ledger contains the Acorn representation requirements, but the
+following still need stable machine-tracked rows:
+
+- #4106 numeric Promise-carrier round-trip elision;
+- leaf-struct finality used for V8 devirtualization;
+- inline-small eligibility discovery;
+- monomorphized clone identity/signature preservation;
+- allocation-provenance preservation.
+
+Before final deletion, add a fail-closed inventory denominator tying every
+reachable direct handler and fast-path marker to a ledger row. A green ledger
+is insufficient if an optimization was never inventoried.
+
+## Last green validation
+
+```bash
+pnpm exec vitest run \
+  tests/issue-4106-ir-async-fetch-user.test.ts \
+  tests/ir/issue-1373b-async-plan.test.ts
+pnpm run typecheck
+pnpm run check:ir-fallbacks
+pnpm exec tsx scripts/check-ir-only.ts --policy=hybrid
+pnpm run check:loc-budget
+pnpm run check:func-budget
+```
+
+The focused matrix passed 13/13. Typecheck, fallback and post-claim ratchets,
+the 34/37 hybrid readiness gate, formatting, oracle/coercion ratchets, and LOC/
+function budgets passed. The value-level test instantiates the Wasm and proves
+`fetchUser(7)` settles to `70`.
+
+## Resume procedure
+
+1. Read this handover and #4106 completely.
+2. Confirm #4050 is merged and its merge commit is an ancestor of the live
+   `origin/main` ref.
+3. Use a new isolated worktree. The root checkout contains unrelated user and
+   parallel-session state.
+4. Re-run the readiness lane before widening it; do not infer compile-once
+   ownership from `irBodyEmitted` alone.
+5. Allocate a new Markdown issue through `scripts/claim-issue.mjs --allocate`
+   and keep the implementation/result/validation/handoff current there.
+6. Open completed PRs as ready, enable auto-merge, and never rewrite a queued
+   head.

--- a/plan/issues/4106-ir-async-fetch-user-state-machine.md
+++ b/plan/issues/4106-ir-async-fetch-user-state-machine.md
@@ -29,6 +29,7 @@ files:
   - src/ir/ast-lowering-plans.ts
   - src/ir/identity.ts
   - scripts/ir-only-baseline.json
+  - plan/agent-context/ir-migration-handover-2026-08-02.md
   - tests/issue-4106-ir-async-fetch-user.test.ts
   - tests/ir/issue-1373b-async-plan.test.ts
   - plan/issues/4106-ir-async-fetch-user-state-machine.md

--- a/plan/issues/4106-ir-async-fetch-user-state-machine.md
+++ b/plan/issues/4106-ir-async-fetch-user-state-machine.md
@@ -1,0 +1,117 @@
+---
+id: 4106
+title: "IR async fetchUser plan producer and frame consumer"
+status: in-progress
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: critical
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: ir, runtime, codegen
+language_feature: async
+goal: ir-full-coverage
+lane: ir-retirement-r6
+parent: 3526
+depends_on: [4104]
+related: [1042, 1373b, 3527]
+files:
+  - src/ir/async-prepare.ts
+  - src/ir/select.ts
+  - src/ir/integration.ts
+  - src/codegen/async-frame.ts
+  - src/codegen/async-ir-planning.ts
+  - src/codegen/ir-async-frame.ts
+  - src/codegen/ir-overlay-identity.ts
+  - src/codegen/program-abi-planning.ts
+  - src/ir/ast-lowering-plans.ts
+  - src/ir/identity.ts
+  - scripts/ir-only-baseline.json
+  - tests/issue-4106-ir-async-fetch-user.test.ts
+  - tests/ir/issue-1373b-async-plan.test.ts
+  - plan/issues/4106-ir-async-fetch-user-state-machine.md
+loc-budget-allow:
+  - src/ir/integration.ts
+  - src/ir/select.ts
+  - src/codegen/async-frame.ts
+---
+
+# #4106 — IR async fetchUser plan producer and frame consumer
+
+## Problem
+
+#4104 closes an `IrAsyncPlan` to its prepared host runtime and Program ABI
+dependencies, but no source function produces that plan and no backend emits
+its state graph. The playground `fetchUser` function therefore remains an
+`async-function` fallback even though its lowered IR is the bounded one-await
+shape needed for the first production suspension slice.
+
+## Scope
+
+- Admit only the exact host/WasmGC linear shape `const x = await E; return x`
+  when the existing async engine already proves that it genuinely suspends.
+- Split the ordinary IR at its single `await`: move the pre-await computation
+  into one structurally identified derived IR state helper and attach a
+  canonical two-state `IrAsyncPlan` to the source owner.
+- Convert that prepared plan into the existing async frame engine's CFG
+  contract. Reuse its Promise assimilation, callback, rejection, scheduling,
+  and settlement implementation instead of introducing another state machine.
+- Resolve the state helper and six runtime adapters through frozen symbolic
+  references and Program ABI slots; do not rediscover imports from AST syntax.
+- Preserve the current post-direct overlay for this first producer slice. A
+  follow-up moves the proven owner into compile-once preparation after its
+  Promise-returning callable ABI is allocated before body emission.
+
+## Acceptance criteria
+
+- The exact playground `fetchUser` source produces one immutable two-state
+  plan, one derived IR state helper, and a Promise-returning IR-owned wrapper.
+- The frame emitter consumes only the prepared plan/helper for the replacement
+  body while retaining the existing host scheduler and settlement behavior.
+- Playground async execution still resolves the same values, and the terminal
+  census drops from four blockers to three with no new invariant.
+- Near-miss async shapes remain on their prior route.
+- Focused tests, typecheck, formatting, source/function budgets, and the IR
+  fallback ratchet pass.
+
+## Result
+
+- The selector admits only the exact host/WasmGC two-statement source shape;
+  non-identity post-await tails and host-free targets remain on the direct
+  route.
+- IR preparation splits `fetchUser` into a Promise-returning state-0 helper
+  and an immutable two-state async plan. The callable Program ABI projects the
+  source owner to `externref` while its semantic fulfillment remains `f64`.
+- The existing async frame engine consumes the prepared graph and retains its
+  scheduler, Promise assimilation, rejection, and settlement behavior. The
+  numeric tail also avoids the legacy `externref` to `f64` to `externref`
+  carrier round trip.
+- The playground census has five terminal functions: `delay` and `fetchUser`
+  emit through IR, while `fetchAllSequential`, `fetchAllParallel`, and `main`
+  remain typed `async-function` blockers. `fetchUser__ir_async_state_0` is also
+  IR-emitted as a derived helper, with no post-claim errors.
+
+## Validation
+
+- `pnpm exec vitest run tests/issue-4106-ir-async-fetch-user.test.ts tests/ir/issue-1373b-async-plan.test.ts`
+  — 13/13 tests pass, including a value-level `fetchUser(7) === 70` check.
+- `pnpm run typecheck` — passes.
+- `pnpm run check:loc-budget` and `pnpm run check:func-budget` — pass; async
+  planning lives in a dedicated subsystem module instead of growing the
+  codegen driver or its largest functions.
+- Focused Prettier and `git diff --check` — pass.
+- `pnpm run check:ir-fallbacks` — passes with no gated fallback or post-claim
+  increase.
+- `pnpm exec tsx scripts/check-ir-only.ts --policy=hybrid` — READY at 34/37
+  terminal bodies emitted by IR, three typed async blockers, and zero
+  invariants. The supported baseline update consolidates the prior body-shape
+  and call-graph labels into the more accurate `async-function` reason.
+
+## Handoff
+
+After this slice, move this exact owner into the prepared compile-once route by
+allocating its canonical Promise result ABI during declaration planning. Then
+widen the plan producer from the one-await tail form to multiple states and
+spills before claiming `main` and the loop/combinator functions.

--- a/scripts/ir-only-baseline.json
+++ b/scripts/ir-only-baseline.json
@@ -1,18 +1,15 @@
 {
   "schemaVersion": 1,
-  "generated": "2026-07-30",
+  "generated": "2026-08-02",
   "lanes": {
     "single-host": {
       "entryFloor": 5,
       "terminalUnitFloor": 37,
-      "emittedFloor": 30,
-      "irBodyEmittedFloor": 30,
-      "unsupportedCeiling": 6,
+      "emittedFloor": 34,
+      "irBodyEmittedFloor": 34,
+      "unsupportedCeiling": 3,
       "unsupportedByCode": {
-        "select/async-function": 2,
-        "select/call-graph-closure": 1,
-        "select/body-shape-rejected": 1,
-        "build/static-class-member": 2
+        "select/async-function": 3
       },
       "invariantCeiling": 0
     }

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -260,8 +260,11 @@ export function asyncFnNeedsHostDrive(
 export interface AsyncFrameInfo {
   /** Source function name (the `__async_resume_f<name>` / struct name stem). */
   functionName: string;
-  /** The async function/method declaration this frame belongs to. */
-  decl: ts.FunctionLikeDeclaration;
+  /**
+   * The async function/method declaration this frame belongs to. Prepared IR
+   * frames omit it because their CFG and value carriers are already closed.
+   */
+  decl?: ts.FunctionLikeDeclaration;
   /** Per-frame `$AsyncFrame_<name>` state struct typeIdx. */
   stateTypeIdx: number;
   /** Field index of the i32 resume mode (`MODE_FIELD`). FrameLayout. */
@@ -1270,7 +1273,38 @@ function validateAsyncCfg(cfg: AsyncCfgPlan): string | null {
  * — a stale capture would otherwise repoint every baked `call`/`ref.func`. The
  * N-segment body widens that window (more helpers) but the discipline is the same.
  */
-export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameInfo, plan: AsyncCpsPlan): number {
+function planAsyncResumeCfg(
+  ctx: CodegenContext,
+  info: AsyncFrameInfo,
+  plan: AsyncCpsPlan | null,
+  preparedCfg: AsyncCfgPlan | undefined,
+): AsyncCfgPlan | null {
+  if (preparedCfg) return preparedCfg;
+  if (!info.decl) return null;
+  if (info.asyncGen) {
+    // #2570: keep delegate mode on the same carrier split as admission.
+    return planAsyncGenCfg(
+      info.decl,
+      isStandalonePromiseActive(ctx) ? { oracle: ctx.oracle } : null,
+      asyncGenDelegatesForPlan(ctx, info.decl, isStandalonePromiseActive(ctx) ? "carrier" : "awaitFree"),
+    );
+  }
+  if (!plan) return null;
+  // #3587: both settlement backends admit try/catch across await; host still
+  // refuses return-in-try and loops until its suspension rounds are widened.
+  return planAsyncCfg(ctx, info.decl, plan, {
+    allowLoops: !info.host,
+    allowTryCatch: true,
+    allowReturnInTry: !info.host,
+  });
+}
+
+export function ensureAsyncResumeFunction(
+  ctx: CodegenContext,
+  info: AsyncFrameInfo,
+  plan: AsyncCpsPlan | null,
+  preparedCfg?: AsyncCfgPlan,
+): number {
   if (info.resumeFuncIdx !== undefined) return info.resumeFuncIdx;
 
   // (#2906 slice 3/3a) Build the general CFG plan the emitter drives.
@@ -1288,24 +1322,11 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // (`isAsyncGenDriveCandidate`) keyed the body's shape check on, so gate and
   // planner always see the same segment split. Type queries go through
   // `ctx.oracle` (the #1930 boundary), not the raw checker.
-  const cfg = info.asyncGen
-    ? planAsyncGenCfg(
-        info.decl,
-        isStandalonePromiseActive(ctx) ? { oracle: ctx.oracle } : null,
-        // (#2570) Emit-time delegates mode (registry-backed helper resolution)
-        // on the same lane split as the admission gate, so gate and planner
-        // always see the same segment shape.
-        asyncGenDelegatesForPlan(ctx, info.decl, isStandalonePromiseActive(ctx) ? "carrier" : "awaitFree"),
-      )
-    : planAsyncCfg(ctx, info.decl, plan, {
-        allowLoops: !info.host,
-        // (#3587) try/catch-across-await is admitted on BOTH settle backends —
-        // the host gate (`asyncFnNeedsHostDrive`) mirrors this via
-        // `computeTryCatchSpills`, keeping predicate and producer in lockstep.
-        allowTryCatch: true,
-        allowReturnInTry: !info.host,
-      });
+  const cfg = planAsyncResumeCfg(ctx, info, plan, preparedCfg);
   if (cfg === null) {
+    if (!info.decl) {
+      throw new Error("internal: prepared async-frame resume has no closed CFG");
+    }
     reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1/3a)");
     info.resumeFuncIdx = -1;
     return -1;
@@ -1313,6 +1334,7 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
 
   const cfgError = validateAsyncCfg(cfg);
   if (cfgError !== null) {
+    if (!info.decl) throw new Error(`internal: prepared async CFG violates the emitter contract — ${cfgError}`);
     reportError(ctx, info.decl, `internal: async CFG plan violates the emitter contract — ${cfgError} (#2906)`);
     info.resumeFuncIdx = -1;
     return -1;
@@ -2493,9 +2515,23 @@ export function emitAsyncFrameStateMachine(
   info.boxedCaptures = fctx.boxedCaptures;
   info.readsCurrentThis = fctx.readsCurrentThis;
   info.selfCaptureLayout = fctx.selfCaptureLayout;
-  const resumeFuncIdx = ensureAsyncResumeFunction(ctx, info, plan);
+  emitAsyncFrameEntry(ctx, fctx, info, plan);
+}
+
+function emitAsyncFrameEntry(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  info: AsyncFrameInfo,
+  plan: AsyncCpsPlan | null,
+  preparedCfg?: AsyncCfgPlan,
+): void {
+  const host = info.host;
+  const hostImports = info.hostImports;
+  const promiseTypeIdx = info.promiseTypeIdx;
+  const resumeFuncIdx = ensureAsyncResumeFunction(ctx, info, plan, preparedCfg);
   if (resumeFuncIdx < 0) {
-    reportError(ctx, decl, "internal: async-frame resume function unavailable (#2895 slice 1)");
+    if (!info.decl) throw new Error("internal: prepared async-frame resume function unavailable");
+    reportError(ctx, info.decl, "internal: async-frame resume function unavailable (#2895 slice 1)");
     fctx.body.push({ op: "ref.null.extern" });
     return;
   }
@@ -2575,6 +2611,16 @@ export function emitAsyncFrameStateMachine(
   fctx.body.push({ op: "local.get", index: resultPromiseLocal });
   if (!host) fctx.body.push({ op: "extern.convert_any" });
   fctx.body.push({ op: "return" });
+}
+
+/** Emit a prepared, AST-free async CFG through the existing frame engine. */
+export function emitPreparedAsyncFrameStateMachine(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  info: AsyncFrameInfo,
+  cfg: AsyncCfgPlan,
+): void {
+  emitAsyncFrameEntry(ctx, fctx, info, null, cfg);
 }
 
 // ── async-generator PRODUCER core (#2906 slice 3d-i) ─────────────────────────

--- a/src/codegen/async-ir-planning.ts
+++ b/src/codegen/async-ir-planning.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { isSingleAwaitReturnAsyncCandidate } from "../ir/async-prepare.js";
+import type { IrUnitId } from "../ir/identity.js";
+import type { IrSelectionOptions } from "../ir/select.js";
+import { asyncEngineWouldActivate } from "./async-activation.js";
+import { analyzeAsyncBody } from "./async-cps.js";
+import type { CodegenContext } from "./context/types.js";
+import type { IrOverlayIdentityPlan } from "./ir-overlay-identity.js";
+
+type AsyncSelectionOptions = Pick<
+  IrSelectionOptions,
+  "supportsAsyncIr" | "asyncEngineClaims" | "asyncHasRealSuspension" | "canPrepareSuspendingAsync"
+>;
+
+/** Keep selector admission and the production async engine on one proof. */
+export function prepareIrAsyncSelectionOptions(ctx: CodegenContext): AsyncSelectionOptions {
+  return {
+    supportsAsyncIr: ctx.supportsAsyncIr,
+    asyncEngineClaims: (fn) => asyncEngineWouldActivate(ctx, fn),
+    asyncHasRealSuspension: (fn) => {
+      const plan = analyzeAsyncBody(ctx, fn);
+      return plan.awaitPoints.some((awaited) => plan.awaitedStaticallyResolved.get(awaited) !== true);
+    },
+    // #4106: first genuinely-suspending IR producer. Host/WasmGC only — the
+    // prepared runtime-provider catalogue has no standalone/WASI projection.
+    canPrepareSuspendingAsync: (fn) => !ctx.wasi && !ctx.standalone && isSingleAwaitReturnAsyncCandidate(fn),
+  };
+}
+
+/** Reconcile selector claims to the exact owners the post-build producer must split. */
+export function collectPreparedIrAsyncOwners(
+  ctx: CodegenContext,
+  identityPlan: IrOverlayIdentityPlan,
+  selectedFunctions: ReadonlySet<string>,
+): ReadonlySet<IrUnitId> {
+  const owners = new Set<IrUnitId>();
+  if (ctx.wasi || ctx.standalone) return owners;
+  for (const claim of identityPlan.functionClaims) {
+    if (
+      selectedFunctions.has(claim.legacyName) &&
+      isSingleAwaitReturnAsyncCandidate(claim.declaration) &&
+      asyncEngineWouldActivate(ctx, claim.declaration)
+    ) {
+      owners.add(claim.unitId);
+    }
+  }
+  return owners;
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -100,7 +100,7 @@ import {
   makeIrRegExpExpressionPredicate,
   type IrModuleBindingResolver,
 } from "../ir/module-bindings.js"; // (#2856 Capability C)
-import { asyncEngineWouldActivate } from "./async-activation.js"; // (#1373b C-1)
+import { collectPreparedIrAsyncOwners, prepareIrAsyncSelectionOptions } from "./async-ir-planning.js";
 import { unwrapPromiseTypeNode } from "./async-static.js"; // (#1373b C-1)
 import { createCodegenContext } from "./context/create-context.js";
 import { ProgramAbiSession, type PublishedProgramAbi } from "./program-abi-session.js";
@@ -1750,6 +1750,7 @@ interface IrOverlayPlan {
   readonly hostDateImportsByOwnerUnitId: ReadonlyMap<IrUnitId, IrHostDateSnapshotImportPlan>;
   /** Exact Promise-delay plans, keyed separately by each owned AST call. */
   readonly promiseDelays: IrPromiseDelayLoweringPlans;
+  readonly suspendingAsyncUnitIds: ReadonlySet<IrUnitId>;
   readonly importedFunctionResolver?: irOverlayIdentity.IrIdentityImportedFunctionResolver;
 }
 
@@ -2165,8 +2166,7 @@ function planIrOverlay(
       // async engine ($AsyncFrame drive / host-drive) declines it — the
       // legacy sync-pass-through population. Engine-activated functions keep
       // byte-identical routing.
-      supportsAsyncIr: ctx.supportsAsyncIr,
-      asyncEngineClaims: (fn) => asyncEngineWouldActivate(ctx, fn),
+      ...prepareIrAsyncSelectionOptions(ctx),
     },
     identityMaps,
   );
@@ -2201,7 +2201,6 @@ function planIrOverlay(
     identityContext,
   );
   // Build per-function IR type overrides from the propagated TypeMap.
-  //
   // For a claimed function, the selector must have resolved each
   // param + return to a concrete primitive via either an explicit
   // TS annotation OR the TypeMap. We mirror that resolution here to
@@ -2497,6 +2496,7 @@ function planIrOverlay(
     hostVoidCallbacks,
     hostDateImportsByOwnerUnitId,
     promiseDelays,
+    suspendingAsyncUnitIds: collectPreparedIrAsyncOwners(ctx, identityPlan, safeSelection.funcs),
     ...(options.importedFunctions ? { importedFunctionResolver: options.importedFunctions } : {}),
   };
 }

--- a/src/codegen/ir-async-frame.ts
+++ b/src/codegen/ir-async-frame.ts
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { AsyncCfgPlan } from "./async-cps.js";
+import { emitPreparedAsyncFrameStateMachine, type AsyncFrameInfo, type HostAsyncImports } from "./async-frame.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { ERROR_FIELD, MODE_FIELD, PARAM_FIELD_OFFSET, SENT_FIELD, sanitizeTypeName } from "./frame-core.js";
+import type { AsyncHostCapabilityId } from "../ir/async-runtime-providers.js";
+import type { IrFuncRef, IrFunction } from "../ir/nodes.js";
+import type { FieldDef, ValType, WasmFunction } from "../ir/types.js";
+
+export interface PreparedIrAsyncFrameResolver {
+  resolveFunc(ref: IrFuncRef): number;
+}
+
+function preparedHostImports(fn: IrFunction, resolver: PreparedIrAsyncFrameResolver): HostAsyncImports {
+  if (fn.asyncRuntime?.kind !== "host-wasmgc") {
+    throw new Error(`IR async function ${fn.name} has no prepared host/WasmGC runtime`);
+  }
+  const resolved = new Map<AsyncHostCapabilityId, number>();
+  for (const adapter of fn.asyncRuntime.adapters) {
+    if (resolved.has(adapter.capability)) {
+      throw new Error(`IR async function ${fn.name} repeats adapter ${adapter.capability}`);
+    }
+    resolved.set(adapter.capability, resolver.resolveFunc(adapter.target));
+  }
+  const requireCapability = (capability: AsyncHostCapabilityId): number => {
+    const index = resolved.get(capability);
+    if (index === undefined) throw new Error(`IR async function ${fn.name} is missing adapter ${capability}`);
+    return index;
+  };
+  return {
+    makeCbIdx: requireCapability("async.callback.wrap"),
+    newPendingIdx: requireCapability("async.promise.capability.create"),
+    then2Idx: requireCapability("async.promise.react"),
+    promiseResolveIdx: requireCapability("async.promise.resolve"),
+    settleResolveIdx: requireCapability("async.promise.settle.fulfill"),
+    settleRejectIdx: requireCapability("async.promise.settle.reject"),
+  };
+}
+
+function exactSingleAwaitCall(fn: IrFunction) {
+  const plan = fn.asyncPlan;
+  const runtime = fn.asyncRuntime;
+  if (
+    fn.funcKind !== "async" ||
+    !plan ||
+    !runtime ||
+    plan.states.length !== 2 ||
+    runtime.states.length !== 2 ||
+    plan.spills.length !== 0 ||
+    plan.handlers.length !== 0
+  ) {
+    throw new Error(`IR async function ${fn.name} is outside the prepared single-await frame slice`);
+  }
+  const semanticEntry = plan.states[0]!;
+  const entry = runtime.states[0]!;
+  const continuation = plan.states[1]!;
+  if (
+    semanticEntry.id !== plan.entry ||
+    entry.id !== semanticEntry.id ||
+    entry.body.length !== 1 ||
+    entry.body[0]?.kind !== "call" ||
+    semanticEntry.terminator.kind !== "suspend" ||
+    semanticEntry.terminator.awaited !== entry.body[0].result ||
+    semanticEntry.terminator.live.length !== 0 ||
+    semanticEntry.terminator.rejected.kind !== "reject" ||
+    semanticEntry.terminator.resume.state !== continuation.id ||
+    continuation.resume?.source !== "fulfilled" ||
+    continuation.body.length !== 0 ||
+    continuation.terminator.kind !== "resolve" ||
+    continuation.terminator.value !== continuation.resume.value ||
+    entry.body[0].args.length !== fn.params.length ||
+    entry.body[0].args.some((value, index) => value !== fn.params[index]!.value)
+  ) {
+    throw new Error(`IR async function ${fn.name} has a malformed single-await plan`);
+  }
+  return entry.body[0];
+}
+
+function buildFrameInfo(
+  ctx: CodegenContext,
+  fn: IrFunction,
+  params: readonly { readonly name: string; readonly type: ValType }[],
+  hostImports: HostAsyncImports,
+): AsyncFrameInfo {
+  const functionName = `${fn.name}__ir`;
+  const fields: FieldDef[] = [
+    { name: "state", type: { kind: "i32" }, mutable: true },
+    { name: "sent", type: { kind: "externref" }, mutable: true },
+    { name: "mode", type: { kind: "i32" }, mutable: true },
+    { name: "abrupt", type: { kind: "externref" }, mutable: true },
+    { name: "error", type: { kind: "externref" }, mutable: true },
+    ...params.map((param) => ({ name: `param_${param.name}`, type: param.type, mutable: false })),
+    { name: "result_promise", type: { kind: "externref" }, mutable: true },
+  ];
+  const stateName = `$AsyncFrame_${sanitizeTypeName(functionName)}`;
+  const stateTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({ kind: "struct", name: stateName, fields });
+  ctx.structMap.set(stateName, stateTypeIdx);
+  ctx.typeIdxToStructName.set(stateTypeIdx, stateName);
+  ctx.structFields.set(stateName, fields);
+  const resultPromiseFieldIdx = PARAM_FIELD_OFFSET + params.length;
+  return {
+    functionName,
+    stateTypeIdx,
+    modeFieldIdx: MODE_FIELD,
+    sentFieldIdx: SENT_FIELD,
+    errorFieldIdx: ERROR_FIELD,
+    paramNames: params.map((param) => param.name),
+    paramTypes: params.map((param) => param.type),
+    paramFieldOffset: PARAM_FIELD_OFFSET,
+    spillNames: [],
+    spillTypes: [],
+    spillFieldOffset: resultPromiseFieldIdx,
+    resultPromiseFieldIdx,
+    promiseTypeIdx: -1,
+    host: true,
+    hostImports,
+  };
+}
+
+function preparedCfg(fn: IrFunction, helperFuncIdx: number): AsyncCfgPlan {
+  return {
+    handlers: [],
+    states: [
+      {
+        id: 0,
+        resumeFrom: null,
+        lead: [],
+        terminator: {
+          kind: "suspend",
+          resumeState: 1,
+          handler: 0,
+          awaited: {
+            emit: (_ctx, fctx) => {
+              for (const param of fn.params) {
+                const local = fctx.localMap.get(param.name ?? "");
+                if (local === undefined) throw new Error(`IR async frame lost parameter ${param.name ?? "<unnamed>"}`);
+                fctx.body.push({ op: "local.get", index: local });
+              }
+              fctx.body.push({ op: "call", funcIdx: helperFuncIdx });
+              return { kind: "externref" };
+            },
+          },
+        },
+      },
+      {
+        id: 1,
+        resumeFrom: { binding: null, handler: 0 },
+        lead: [],
+        terminator: { kind: "settleSent" },
+      },
+    ],
+  };
+}
+
+/** Lower one prepared two-state async function through the shared frame engine. */
+export function lowerPreparedIrAsyncFunction(
+  ctx: CodegenContext,
+  fn: IrFunction,
+  resolver: PreparedIrAsyncFrameResolver,
+  existing: WasmFunction,
+): WasmFunction {
+  const signature = ctx.mod.types[existing.typeIdx];
+  if (
+    !signature ||
+    signature.kind !== "func" ||
+    signature.params.length !== fn.params.length ||
+    signature.results.length !== 1 ||
+    signature.results[0]?.kind !== "externref"
+  ) {
+    throw new Error(`IR async function ${fn.name} does not match its Promise-returning allocated ABI`);
+  }
+  const helper = exactSingleAwaitCall(fn);
+  const helperFuncIdx = resolver.resolveFunc(helper.target);
+  const params = fn.params.map((param, index) => ({
+    name: param.name ?? `p${index}`,
+    type: signature.params[index]!,
+  }));
+  const fctx: FunctionContext = {
+    name: fn.name,
+    params,
+    locals: [],
+    localMap: new Map(params.map((param, index) => [param.name, index] as const)),
+    returnType: { kind: "externref" },
+    body: [],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  };
+  const info = buildFrameInfo(ctx, fn, params, preparedHostImports(fn, resolver));
+  const previous = ctx.currentFunc;
+  ctx.currentFunc = fctx;
+  try {
+    emitPreparedAsyncFrameStateMachine(ctx, fctx, info, preparedCfg(fn, helperFuncIdx));
+  } finally {
+    ctx.currentFunc = previous;
+  }
+  return {
+    name: existing.name,
+    typeIdx: existing.typeIdx,
+    locals: fctx.locals,
+    body: fctx.body,
+    exported: existing.exported,
+  };
+}

--- a/src/codegen/ir-overlay-identity.ts
+++ b/src/codegen/ir-overlay-identity.ts
@@ -8,6 +8,7 @@ import {
 } from "../ir/ast-lowering-plans.js";
 import { irUnitFuncRef } from "../ir/callable-bindings.js";
 import type { IrUnitId } from "../ir/identity.js";
+import { irVal } from "../ir/nodes.js";
 import {
   makeIrIdentityImportedFunctionResolver,
   projectIrIdentityImportedFunctionResolverToLegacy,
@@ -281,7 +282,7 @@ export function projectIrIntegrationLoweringPlans(
     readonly directCalls?: IrIntegrationLoweringPlans["directCalls"];
   } & Pick<
     IrIntegrationLoweringPlans,
-    "importedCalls" | "topLevelFunctionValues" | "hostVoidCallbacks" | "promiseDelays"
+    "importedCalls" | "topLevelFunctionValues" | "hostVoidCallbacks" | "promiseDelays" | "suspendingAsyncUnitIds"
   >,
   selection: {
     readonly funcs: ReadonlySet<string>;
@@ -293,9 +294,17 @@ export function projectIrIntegrationLoweringPlans(
   const ownerUnitIdByLegacyName = new Map(
     ownerProjection.entries.map(({ legacyName, unitId }) => [legacyName, unitId]),
   );
+  const activeOwnerUnitIds = new Set(ownerProjection.entries.map(({ unitId }) => unitId));
+  const signaturesByUnitId = new Map(plan.overrideMapByUnitId);
+  const callableSignaturesByUnitId = new Map(signaturesByUnitId);
+  for (const unitId of plan.suspendingAsyncUnitIds) {
+    if (!activeOwnerUnitIds.has(unitId)) continue;
+    const signature = callableSignaturesByUnitId.get(unitId);
+    if (signature) callableSignaturesByUnitId.set(unitId, { ...signature, returnType: irVal({ kind: "externref" }) });
+  }
   const directCallTargets = new Map<string, IrDirectCallTarget>();
   for (const { unitId, legacyName } of ownerProjection.entries) {
-    const signature = plan.overrideMapByUnitId.get(unitId);
+    const signature = callableSignaturesByUnitId.get(unitId);
     if (!signature) continue;
     directCallTargets.set(legacyName, {
       target: irUnitFuncRef({ unitId, name: legacyName }),
@@ -315,11 +324,14 @@ export function projectIrIntegrationLoweringPlans(
     ownerProjection,
     ownerUnitIdByLegacyName,
     directCalls,
-    signaturesByUnitId: plan.overrideMapByUnitId,
+    signaturesByUnitId,
     importedCalls: plan.importedCalls,
     topLevelFunctionValues: plan.topLevelFunctionValues,
     hostVoidCallbacks: plan.hostVoidCallbacks,
     promiseDelays: plan.promiseDelays,
+    suspendingAsyncUnitIds: new Set(
+      [...plan.suspendingAsyncUnitIds].filter((unitId) => activeOwnerUnitIds.has(unitId)),
+    ),
   };
 }
 

--- a/src/codegen/program-abi-planning.ts
+++ b/src/codegen/program-abi-planning.ts
@@ -203,7 +203,12 @@ export function planProgramAbiUnitCallable(
   const unitId = plan.ref.binding.unitId;
   if (!session.hasKnownUnit(unitId)) return undefined;
   const derived = session.registeredDerivedUnit(unitId);
-  if (derived && derived.role !== "lifted-closure" && derived.role !== "monomorphization-clone") {
+  if (
+    derived &&
+    derived.role !== "lifted-closure" &&
+    derived.role !== "ir-async-state" &&
+    derived.role !== "monomorphization-clone"
+  ) {
     return undefined;
   }
   const bindingId = irUnitCallableBindingId(unitId);

--- a/src/ir/ast-lowering-plans.ts
+++ b/src/ir/ast-lowering-plans.ts
@@ -128,6 +128,8 @@ export interface IrIntegrationLoweringPlans {
   readonly topLevelFunctionValues: ReadonlyMap<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;
   readonly hostVoidCallbacks: ReadonlyMap<ts.ArrowFunction, IrHostVoidCallbackLoweringPlan>;
   readonly promiseDelays: IrPromiseDelayLoweringPlans;
+  /** Exact engine-activated source owners admitted by the async-plan producer. */
+  readonly suspendingAsyncUnitIds: ReadonlySet<IrUnitId>;
 }
 
 export function requireMatchingLoweringPlanOwner(

--- a/src/ir/async-prepare.ts
+++ b/src/ir/async-prepare.ts
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import { ASYNC_RUNTIME_FEATURES } from "./async-runtime-providers.js";
+import { asAsyncStateId, canonicalPromiseAbi, createIrAsyncPlan } from "./async-plan.js";
+import { irUnitFuncRef } from "./callable-bindings.js";
+import { createDerivedIrUnitId, type IrDerivedUnitProvenance } from "./identity.js";
+import {
+  asBlockId,
+  asValueId,
+  irTypeEquals,
+  irVal,
+  type IrFunction,
+  type IrInstr,
+  type IrType,
+  type IrValueId,
+} from "./nodes.js";
+
+const EXTERNREF = irVal({ kind: "externref" });
+
+/**
+ * First production suspension shape. It is deliberately syntax-small so the
+ * selector and the post-build IR transform can prove the same two-state graph:
+ *
+ *   const value = await expression;
+ *   return value;
+ */
+export function isSingleAwaitReturnAsyncCandidate(fn: ts.FunctionLikeDeclaration): boolean {
+  if (!ts.isFunctionDeclaration(fn) || fn.asteriskToken || !fn.body) return false;
+  if (!fn.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword)) return false;
+  if (fn.body.statements.length !== 2) return false;
+  const declarationStatement = fn.body.statements[0];
+  const returned = fn.body.statements[1];
+  if (
+    !declarationStatement ||
+    !ts.isVariableStatement(declarationStatement) ||
+    declarationStatement.declarationList.declarations.length !== 1 ||
+    !returned ||
+    !ts.isReturnStatement(returned) ||
+    !returned.expression ||
+    !ts.isIdentifier(returned.expression)
+  ) {
+    return false;
+  }
+  const declaration = declarationStatement.declarationList.declarations[0]!;
+  return (
+    ts.isIdentifier(declaration.name) &&
+    declaration.initializer !== undefined &&
+    ts.isAwaitExpression(declaration.initializer) &&
+    returned.expression.text === declaration.name.text
+  );
+}
+
+export interface PreparedSingleAwaitIrFunction {
+  readonly main: IrFunction;
+  readonly stateFunctions: readonly IrFunction[];
+  readonly provenance: readonly IrDerivedUnitProvenance[];
+}
+
+function valueTypesOf(fn: IrFunction): Map<IrValueId, IrType> {
+  const types = new Map(fn.params.map((param) => [param.value, param.type] as const));
+  for (const block of fn.blocks) {
+    for (let index = 0; index < block.blockArgs.length; index++) {
+      types.set(block.blockArgs[index]!, block.blockArgTypes[index]!);
+    }
+    for (const instr of block.instrs) {
+      if (instr.result !== null && instr.resultType !== null) types.set(instr.result, instr.resultType);
+    }
+  }
+  return types;
+}
+
+function maxValueId(params: IrFunction["params"], instrs: readonly IrInstr[], returned: IrValueId): number {
+  let maximum = Number(returned);
+  for (const param of params) maximum = Math.max(maximum, Number(param.value));
+  for (const instr of instrs) {
+    if (instr.result !== null) maximum = Math.max(maximum, Number(instr.result));
+  }
+  return maximum;
+}
+
+/**
+ * Turn the exact one-await IR into a semantic two-state plan plus one derived
+ * ordinary IR helper. The helper owns all pre-await computation; the async
+ * backend only needs to invoke it, suspend on its Promise result, and settle
+ * the source function with the delivered value.
+ */
+export function prepareSingleAwaitIrFunction(fn: IrFunction): PreparedSingleAwaitIrFunction | null {
+  if (fn.funcKind !== "async" || fn.asyncPlan || fn.blocks.length !== 1 || fn.resultTypes.length !== 1) return null;
+  const block = fn.blocks[0]!;
+  if (block.blockArgs.length !== 0 || block.terminator.kind !== "return" || block.terminator.values.length !== 1) {
+    return null;
+  }
+  const awaitIndices = block.instrs.flatMap((instr, index) => (instr.kind === "await" ? [index] : []));
+  if (awaitIndices.length !== 1) return null;
+  const awaitIndex = awaitIndices[0]!;
+  const awaited = block.instrs[awaitIndex]!;
+  if (
+    awaited.kind !== "await" ||
+    awaited.result === null ||
+    awaited.resultType === null ||
+    block.terminator.values[0] === undefined
+  ) {
+    return null;
+  }
+  const valueTypes = valueTypesOf(fn);
+  const operandType = valueTypes.get(awaited.operand);
+  if (
+    !operandType ||
+    (!irTypeEquals(operandType, EXTERNREF) && !(operandType.kind === "extern" && operandType.className === "Promise"))
+  ) {
+    return null;
+  }
+
+  const role = "ir-async-state" as const;
+  const stateUnitId = createDerivedIrUnitId({ parentId: fn.unitId, role, ordinal: 0 });
+  const stateName = `${fn.name}__ir_async_state_0`;
+  const prefix = block.instrs.slice(0, awaitIndex);
+  const entryFunction: IrFunction = {
+    unitId: stateUnitId,
+    name: stateName,
+    params: fn.params.map((param) => ({ ...param })),
+    resultTypes: [operandType],
+    blocks: [
+      {
+        id: asBlockId(0),
+        blockArgs: [],
+        blockArgTypes: [],
+        instrs: prefix,
+        terminator: { kind: "return", values: [awaited.operand] },
+      },
+    ],
+    exported: false,
+    valueCount: maxValueId(fn.params, prefix, awaited.operand) + 1,
+    funcKind: "regular",
+  };
+
+  const suffix = block.instrs.slice(awaitIndex + 1);
+  const returned = block.terminator.values[0]!;
+  const fulfillmentType = fn.resultTypes[0]!;
+  const carrierUnbox = suffix.length === 1 ? suffix[0] : undefined;
+  const elidesNumericCarrierRoundTrip =
+    carrierUnbox?.kind === "call" &&
+    carrierUnbox.target.name === "__unbox_number" &&
+    carrierUnbox.target.binding.kind === "import" &&
+    carrierUnbox.target.binding.module === "env" &&
+    carrierUnbox.target.binding.field === "__unbox_number" &&
+    carrierUnbox.args.length === 1 &&
+    carrierUnbox.args[0] === awaited.result &&
+    carrierUnbox.result === returned &&
+    carrierUnbox.resultType !== null &&
+    irTypeEquals(carrierUnbox.resultType, fulfillmentType);
+  const directIdentity =
+    suffix.length === 0 && returned === awaited.result && irTypeEquals(awaited.resultType, fulfillmentType);
+  const identityContinuation = directIdentity || elidesNumericCarrierRoundTrip;
+  // The frame carrier delivers an externref, but the canonical Promise ABI
+  // already represents its fulfillment as T. Avoid the direct backend's
+  // redundant externref→f64→externref round trip for the exact numeric tail.
+  const resumedType = elidesNumericCarrierRoundTrip ? fulfillmentType : awaited.resultType;
+  const continuationUnitId = identityContinuation
+    ? null
+    : createDerivedIrUnitId({ parentId: fn.unitId, role, ordinal: 1 });
+  const continuationName = `${fn.name}__ir_async_state_1`;
+  const continuationFunction: IrFunction | null = continuationUnitId
+    ? {
+        unitId: continuationUnitId,
+        name: continuationName,
+        params: [{ name: "__resumed", type: resumedType, value: awaited.result }],
+        resultTypes: [fulfillmentType],
+        blocks: [
+          {
+            id: asBlockId(0),
+            blockArgs: [],
+            blockArgTypes: [],
+            instrs: suffix,
+            terminator: { kind: "return", values: [returned] },
+          },
+        ],
+        exported: false,
+        valueCount: maxValueId([{ name: "__resumed", type: resumedType, value: awaited.result }], suffix, returned) + 1,
+        funcKind: "regular",
+      }
+    : null;
+
+  const helperResult = asValueId(fn.valueCount);
+  const resumed = asValueId(fn.valueCount + 1);
+  const resolved = asValueId(fn.valueCount + 2);
+  const asyncPlan = createIrAsyncPlan({
+    schemaVersion: 1,
+    ownerUnitId: fn.unitId,
+    kind: "async-function",
+    abi: canonicalPromiseAbi(fulfillmentType),
+    entry: asAsyncStateId(0),
+    params: fn.params.map((param) => ({ value: param.value, type: param.type })),
+    values: [
+      ...fn.params.map((param) => ({ value: param.value, type: param.type })),
+      { value: helperResult, type: operandType },
+      { value: resumed, type: resumedType },
+      ...(continuationFunction ? [{ value: resolved, type: fulfillmentType }] : []),
+    ],
+    spills: [],
+    states: [
+      {
+        id: asAsyncStateId(0),
+        body: [
+          {
+            kind: "call",
+            target: irUnitFuncRef({ unitId: stateUnitId, name: stateName }),
+            args: fn.params.map((param) => param.value),
+            result: helperResult,
+            resultType: operandType,
+          },
+        ],
+        terminator: {
+          kind: "suspend",
+          awaited: helperResult,
+          resume: { state: asAsyncStateId(1), value: resumed },
+          rejected: { kind: "reject" },
+          live: [],
+        },
+      },
+      {
+        id: asAsyncStateId(1),
+        resume: { value: resumed, type: resumedType, source: "fulfilled" },
+        body: continuationFunction
+          ? [
+              {
+                kind: "call",
+                target: irUnitFuncRef({ unitId: continuationFunction.unitId, name: continuationFunction.name }),
+                args: [resumed],
+                result: resolved,
+                resultType: fulfillmentType,
+              },
+            ]
+          : [],
+        terminator: { kind: "resolve", value: continuationFunction ? resolved : resumed },
+      },
+    ],
+    handlers: [],
+    runtimeIntents: ASYNC_RUNTIME_FEATURES,
+  });
+
+  return {
+    main: {
+      ...fn,
+      asyncPlan,
+    },
+    stateFunctions: continuationFunction ? [entryFunction, continuationFunction] : [entryFunction],
+    provenance: [
+      { id: stateUnitId, parentId: fn.unitId, role, ordinal: 0 },
+      ...(continuationFunction
+        ? [{ id: continuationFunction.unitId, parentId: fn.unitId, role, ordinal: 1 } as const]
+        : []),
+    ],
+  };
+}

--- a/src/ir/identity.ts
+++ b/src/ir/identity.ts
@@ -51,6 +51,7 @@ export interface IrDerivedUnitProvenance {
 export type IrSyntheticUnitRole =
   | `compiler-unit:${CompilerSourceProducer}:${string}`
   | `stdlib-selfhost:${string}`
+  | "ir-async-state"
   | "lifted-closure"
   | "monomorphization-clone";
 /** Compiler-created class roles live in a namespace separate from source classes. */

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -104,6 +104,7 @@ import {
 } from "../codegen/registry/types.js";
 import type { CodegenContext, FunctionContext } from "../codegen/context/types.js";
 import { applyIrTailCalls } from "../codegen/ir-tail-call.js";
+import { lowerPreparedIrAsyncFunction } from "../codegen/ir-async-frame.js";
 import {
   getFuncRefWrapperRootTypeIdx,
   getOrCreateFuncRefWrapperTypes,
@@ -125,6 +126,7 @@ import {
   type LoweredFunctionResult,
   type ModuleBindingGlobal,
 } from "./from-ast.js";
+import { prepareSingleAwaitIrFunction } from "./async-prepare.js";
 import {
   collectIrDirectCallLoweringPlans,
   type IrDirectCallLoweringPlan,
@@ -290,6 +292,43 @@ export {
   type IrIntegrationTerminalFailureEvent,
   type IrIntegrationTerminalEvidence,
 } from "./integration-report.js";
+
+function prepareSuspendingAsyncLowering(
+  lowered: LoweredFunctionResult,
+  ownerUnitId: IrUnitId,
+  name: string,
+  suspendingOwners: ReadonlySet<IrUnitId> | undefined,
+): LoweredFunctionResult {
+  if (!suspendingOwners?.has(ownerUnitId)) return lowered;
+  const prepared = prepareSingleAwaitIrFunction(lowered.main);
+  if (!prepared) {
+    throw new IrUnsupportedError(
+      "body-shape-rejected",
+      "build",
+      `async-plan producer could not split the certified single-await body ${name}`,
+    );
+  }
+  return {
+    main: prepared.main,
+    lifted: [...lowered.lifted, ...prepared.stateFunctions],
+    liftedUnitProvenance: [...lowered.liftedUnitProvenance, ...prepared.provenance],
+  };
+}
+
+function isLiftedExecutableRole(role: ProgramAbiDerivedUnitRecord["role"]): boolean {
+  return role === "lifted-closure" || role === "ir-async-state";
+}
+
+function lowerIrEntryFunction(
+  ctx: CodegenContext,
+  fn: IrFunction,
+  resolver: IrLowerResolver,
+  existing: WasmFunction,
+): WasmFunction {
+  return fn.asyncPlan
+    ? lowerPreparedIrAsyncFunction(ctx, fn, resolver, existing)
+    : lowerIrFunctionToWasm(fn, resolver).func;
+}
 
 /**
  * Find checker-certified ambient Date snapshots in owners that have already
@@ -584,8 +623,7 @@ export function compileIrPathFunctions(
     allowHostExterns: jsHostExterns && !ctx.nativeStrings,
     allowBuiltinMapExtern: jsHostExterns && !ctx.nativeStrings,
   };
-  // Compatibility-only direct callers still receive one exact local planning
-  // context. Structural global refs must never fall back to declaration names.
+  // Direct compatibility callers share this context; structural globals never fall back to declaration names.
   const compatibilityInventory = loweringPlans
     ? undefined
     : buildIrUnitInventory([sourceFile], { entrySource: sourceFile, checker: ctx.checker });
@@ -623,7 +661,7 @@ export function compileIrPathFunctions(
     }
     const records = new Map<IrUnitId, ProgramAbiDerivedUnitRecord>();
     for (const provenance of result.liftedUnitProvenance) {
-      if (provenance.parentId !== parentUnitId || provenance.role !== "lifted-closure") {
+      if (provenance.parentId !== parentUnitId || !isLiftedExecutableRole(provenance.role)) {
         throw new IrInvariantError(
           "selection-preparation-mismatch",
           "build",
@@ -980,7 +1018,7 @@ export function compileIrPathFunctions(
         );
       }
       const o = effectiveOverride(name);
-      const result = lowerFunctionAstToIr(stmt, {
+      const lowered = lowerFunctionAstToIr(stmt, {
         exported: hasExportModifier(stmt),
         ownerUnitId,
         directCalls: directCallsFor(stmt, ownerUnitId),
@@ -1003,6 +1041,7 @@ export function compileIrPathFunctions(
         // #3765: share direct-codegen's grounded numeric-local oracle with IR.
         numericLocalScalarForDecl: (decl) => ctx.usageInference.scalarForDecl(decl),
       });
+      const result = prepareSuspendingAsyncLowering(lowered, ownerUnitId, name, loweringPlans?.suspendingAsyncUnitIds);
       if (result.main.unitId !== ownerUnitId) {
         throw new IrInvariantError(
           "selection-preparation-mismatch",
@@ -2520,7 +2559,7 @@ export function compileIrPathFunctions(
         continue;
       }
 
-      const { func: wasmFunc } = lowerIrFunctionToWasm(entry.fn, resolver);
+      const wasmFunc = lowerIrEntryFunction(ctx, entry.fn, resolver, existing);
       // #1370 Phase B: signature parity guard for class methods.
       //
       // The legacy `class-bodies.ts` pass pre-allocated this method's

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -381,6 +381,20 @@ export interface IrSelectionOptions {
    */
   readonly asyncEngineClaims?: (fn: ts.FunctionLikeDeclaration) => boolean;
   /**
+   * Exact producer proof for an engine-activated async declaration whose
+   * suspension graph can be prepared as `IrAsyncPlan`. The engine remains the
+   * only scheduler/emitter; this callback only permits the IR to own its state
+   * bodies. Absent by default, so bare selector callers cannot claim a real
+   * suspension accidentally.
+   */
+  readonly canPrepareSuspendingAsync?: (fn: ts.FunctionLikeDeclaration) => boolean;
+  /**
+   * True when at least one await cannot be eliminated by the shared async
+   * analysis. An engine decline does not make such a body synchronous; until
+   * an `IrAsyncPlan` producer claims it, it must remain a typed fallback.
+   */
+  readonly asyncHasRealSuspension?: (fn: ts.FunctionLikeDeclaration) => boolean;
+  /**
    * (#2856) Host-extern support — resolves a bare identifier that is NOT a
    * local/param binding to an ambient host global (`document`, `console`, …).
    * Returns the extern class name (`"Document"`, `"Console"`) when the
@@ -573,7 +587,8 @@ export function isAsyncIrReady(options: IrSelectionOptions | undefined, fn: ts.F
   if (!fn.body) return false;
   // ONE-engine invariant: without the engine's verdict, never claim.
   if (options.asyncEngineClaims === undefined) return false;
-  if (options.asyncEngineClaims(fn)) return false;
+  if (options.asyncEngineClaims(fn)) return options.canPrepareSuspendingAsync?.(fn) === true;
+  if (options.asyncHasRealSuspension?.(fn) === true) return false;
   // Body-scope bounds: `for await` and nested async function-likes are out.
   if (bodyHasAsyncOutOfIrScope(fn.body)) return false;
   return true;

--- a/tests/ir/issue-1373b-async-plan.test.ts
+++ b/tests/ir/issue-1373b-async-plan.test.ts
@@ -251,7 +251,7 @@ describe("#1373b IrAsyncPlan contract", () => {
 });
 
 describe("#1042/#1373b async migration anti-vacuity", () => {
-  it("keeps the four playground blockers typed and strict while routing is unchanged", async () => {
+  it("IR-emits fetchUser while keeping the three remaining playground blockers typed", async () => {
     const source = readFileSync(new URL("../../website/playground/examples/js/async.ts", import.meta.url), "utf8");
     const result = await compile(source, {
       fileName: "website/playground/examples/js/async.ts",
@@ -259,14 +259,18 @@ describe("#1042/#1373b async migration anti-vacuity", () => {
     });
     expect(result.success).toBe(true);
     const blockers = (result.irOutcomes ?? []).filter((outcome) => outcome.kind !== "emitted");
-    expect(blockers).toHaveLength(4);
+    expect(blockers).toHaveLength(3);
     expect(blockers.map((outcome) => [outcome.displayName, outcome.kind, outcome.stage, outcome.code]).sort()).toEqual([
-      ["fetchAllParallel", "unsupported", "select", "body-shape-rejected"],
-      ["fetchAllSequential", "unsupported", "select", "call-graph-closure"],
-      ["fetchUser", "unsupported", "select", "async-function"],
+      ["fetchAllParallel", "unsupported", "select", "async-function"],
+      ["fetchAllSequential", "unsupported", "select", "async-function"],
       ["main", "unsupported", "select", "async-function"],
     ]);
     expect(blockers.every((outcome) => outcome.legacyBodyEmitted && !outcome.irBodyEmitted)).toBe(true);
+    expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "fetchUser")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: true,
+      irBodyEmitted: true,
+    });
     expect(evaluateIrOutcomePolicy(blockers, "ir-only").ready).toBe(false);
   });
 

--- a/tests/issue-4106-ir-async-fetch-user.test.ts
+++ b/tests/issue-4106-ir-async-fetch-user.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** #4106 — first genuinely-suspending source function prepared and emitted through IR. */
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { ASYNC_HOST_ADAPTERS } from "../src/ir/async-runtime-providers.js";
+import { isSingleAwaitReturnAsyncCandidate } from "../src/ir/async-prepare.js";
+import { ts } from "../src/ts-api.js";
+
+const EXACT_SOURCE = `
+  function delay(ms: number, value: number): Promise<number> {
+    return new Promise<number>((resolve) => {
+      setTimeout(() => resolve(value), ms);
+    });
+  }
+
+  export async function fetchUser(id: number): Promise<number> {
+    const value = await delay(0, id * 10);
+    return value;
+  }
+`;
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.irPostClaimErrors ?? []).toEqual([]);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+}
+
+function parseFunction(body: string): ts.FunctionDeclaration {
+  const source = ts.createSourceFile("issue-4106-candidate.ts", body, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const declaration = source.statements.find(ts.isFunctionDeclaration);
+  if (!declaration) throw new Error("missing function declaration fixture");
+  return declaration;
+}
+
+async function settled<T>(value: T | Promise<T>, ms = 4000): Promise<T> {
+  return Promise.race([
+    Promise.resolve(value),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error("async result never settled")), ms)),
+  ]);
+}
+
+describe("#4106 IR single-await async producer", () => {
+  it("recognizes only the exact two-statement source shape", () => {
+    expect(
+      isSingleAwaitReturnAsyncCandidate(
+        parseFunction(`async function fetchUser(id: number): Promise<number> {
+          const value = await delay(0, id * 10);
+          return value;
+        }`),
+      ),
+    ).toBe(true);
+
+    for (const source of [
+      `async function fetchUser(id: number): Promise<number> {
+        const value = await delay(0, id * 10);
+        const adjusted = value + 0;
+        return adjusted;
+      }`,
+      `async function fetchUser(id: number): Promise<number> {
+        const value = await delay(0, id * 10);
+        return value + 0;
+      }`,
+      `function fetchUser(id: number): Promise<number> {
+        const value = await delay(0, id * 10);
+        return value;
+      }`,
+    ]) {
+      expect(isSingleAwaitReturnAsyncCandidate(parseFunction(source))).toBe(false);
+    }
+  });
+
+  it("IR-emits the exact host function and resolves its numeric fulfillment", async () => {
+    const result = await compile(EXACT_SOURCE, {
+      fileName: "issue-4106-ir-async-fetch-user.ts",
+      target: "gc",
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+
+    expect(result.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["fetchUser", "fetchUser__ir_async_state_0"]));
+    const outcome = (result.irOutcomes ?? []).find((candidate) => candidate.displayName === "fetchUser");
+    expect(outcome).toMatchObject({ kind: "emitted", legacyBodyEmitted: true, irBodyEmitted: true });
+
+    const adapterNames = new Set(ASYNC_HOST_ADAPTERS.map((adapter) => adapter.field));
+    const actualAdapters = WebAssembly.Module.imports(new WebAssembly.Module(result.binary))
+      .filter((entry) => entry.module === "env" && entry.kind === "function" && adapterNames.has(entry.name))
+      .map((entry) => entry.name)
+      .sort();
+    expect(actualAdapters).toEqual(ASYNC_HOST_ADAPTERS.map((adapter) => adapter.field).sort());
+
+    const imports = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+    imports.setExports?.(instance.exports as Record<string, Function>);
+    const fetchUser = instance.exports.fetchUser as (id: number) => Promise<number>;
+    await expect(settled(fetchUser(7))).resolves.toBe(70);
+  });
+
+  it("leaves a non-identity post-await tail on the direct route", async () => {
+    const result = await compile(
+      EXACT_SOURCE.replace(
+        "return value;",
+        `const adjusted = value + 0;
+        return adjusted;`,
+      ),
+      {
+        fileName: "issue-4106-near-miss.ts",
+        target: "gc",
+        trackIrOutcomes: true,
+      },
+    );
+    expectSuccess(result);
+
+    expect(result.irCompiledFuncs ?? []).not.toContain("fetchUser");
+    expect((result.irOutcomes ?? []).find((candidate) => candidate.displayName === "fetchUser")).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      code: "async-function",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- prepare the exact host single-await async shape as a canonical two-state IR plan
- emit its structurally owned state helper through the existing async frame engine and frozen Program ABI adapters
- preserve the numeric Promise-carrier round-trip elision and keep fulfillment typing separate from the callable Promise ABI
- move the production IR readiness census to 34/37 emitted terminal units with zero invariants

## Validation

- focused async-plan and fetchUser tests: 13/13 pass
- typecheck
- IR fallback ratchet
- IR-only hybrid readiness gate
- LOC and function budgets
- pre-push lint, formatting, oracle, coercion-site, and numeric-local parity gates

Tracked in plan/issues/4106-ir-async-fetch-user-state-machine.md.