### PR TITLE
fix(ir): require final allocation provenance verification

### DIFF
--- a/plan/issues/4113-ir-final-allocation-provenance-gate.md
+++ b/plan/issues/4113-ir-final-allocation-provenance-gate.md
@@ -1,7 +1,7 @@
 ---
 id: 4113
 title: "Require final allocation-provenance verification for every IR artifact"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-02
 updated: 2026-08-02
@@ -89,19 +89,19 @@ and include this gate in its deletion-readiness result.
 
 ## Acceptance criteria
 
-- [ ] `IR_VERIFY_ALLOC` continues to control optional checks at intermediate
+- [x] `IR_VERIFY_ALLOC` continues to control optional checks at intermediate
       pass boundaries.
-- [ ] Final allocation-provenance verification is unconditional and runs once
-      for every final WasmGC IR artifact before analysis/lowering.
-- [ ] Ordinary, synthetic, and monomorphized final functions cannot bypass the
+- [x] Final allocation-provenance verification is unconditional and runs once
+      for every final WasmGC IR artifact before publication/lowering.
+- [x] Ordinary, synthetic, and monomorphized final functions cannot bypass the
       required gate.
-- [ ] A focused injected final-stage defect fails with
+- [x] A focused injected final-stage defect fails with
       `allocation-provenance-failure` while `IR_VERIFY_ALLOC` is unset.
-- [ ] A normal focused compile succeeds with the flag unset.
-- [ ] Focused IR and type/format checks pass.
-- [ ] Compile overhead is measured on a named stable corpus; the result is
+- [x] A normal focused compile succeeds with the flag unset.
+- [x] Focused IR and type/format checks pass.
+- [x] Compile overhead is measured on a named stable corpus; the result is
       recorded without treating timing noise as zero cost.
-- [ ] #3792 v2 follow-up classification is documented without inserting an
+- [x] #3792 v2 follow-up classification is documented without inserting an
       incompatible ledger row.
 
 ## Out of scope
@@ -113,4 +113,31 @@ and include this gate in its deletion-readiness result.
 
 ## Result
 
-Pending implementation and measurement.
+`assertFinalAllocProvenance` now ignores the optional debug flag and shares the
+same verifier/error producer as the intermediate assertion. WasmGC integration
+runs that required assertion after string, vector, and runtime-manifest
+attachments and before prepared-component sealing, slot publication, resolver
+construction, or lowering. It walks the complete healthy artifact collection,
+so ordinary source functions, lifted/async synthetic functions, and
+monomorphized clones share one final boundary.
+
+The focused suites pass **11/11** tests: seven allocation-verifier tests plus
+four integration tests covering a normal compile and injected ordinary,
+synthetic, and monomorphized failures with `IR_VERIFY_ALLOC` unset. Typecheck,
+formatting, the IR fallback gate, LOC budget, and function budget pass. The
+broader #3519 outcome suite passes **38/40**; both failures reproduce unchanged
+on the control commit (a stale static-method expectation and the existing
+overload inventory defect), so neither is attributed to this change.
+
+Compile overhead was measured with the stable repository command
+`pnpm run check:ir-fallbacks`, using three alternating fresh-process runs after
+filesystem warm-up on the same machine:
+
+| Configuration | Commit | Samples (seconds) | Mean | Median |
+| --- | --- | --- | ---: | ---: |
+| Control | `efc05e59f99aa4` | 24.38, 25.79, 20.51 | 23.56 | 24.38 |
+| Required final gate | `5fc43544470746` | 25.53, 20.75, 20.39 | 22.22 | 20.75 |
+
+The ranges overlap (**20.51–25.79 s** control and **20.39–25.53 s** candidate).
+No compile-time regression is detected at this corpus and timing resolution;
+the result does not establish zero cost for the additional final walk.

--- a/plan/issues/4113-ir-final-allocation-provenance-gate.md
+++ b/plan/issues/4113-ir-final-allocation-provenance-gate.md
@@ -1,0 +1,116 @@
+---
+id: 4113
+title: "Require final allocation-provenance verification for every IR artifact"
+status: in-progress
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: critical
+horizon: s
+complexity: S
+feasibility: easy
+reasoning_effort: medium
+task_type: infrastructure
+area: ir, codegen
+language_feature: compiler-internals
+es_edition: n/a
+goal: ir-full-coverage
+parent: 3518
+depends_on: [1586]
+required_by: [3792]
+related: [1586, 3518, 3792]
+files:
+  - src/ir/verify-alloc.ts
+  - src/ir/integration.ts
+  - tests/ir/alloc-provenance.test.ts
+  - tests/issue-4113-ir-final-allocation-provenance.test.ts
+loc-budget-allow:
+  - src/ir/integration.ts
+---
+
+# #4113 — Require final allocation-provenance verification for every IR artifact
+
+## Objective
+
+Make allocation-provenance validation an unconditional final publication gate
+for WasmGC IR artifacts. Keep `IR_VERIFY_ALLOC` as the opt-in switch for extra
+checks at intermediate pass boundaries, but verify each final ordinary,
+synthetic, and monomorphized function after all transforms and before lowering.
+
+## Retirement risk
+
+#1586 introduced allocation identities and a verifier, but its integration
+calls are all disabled unless `IR_VERIFY_ALLOC` is set. A production build can
+therefore publish a transformed IR function with missing, stale, dangling, or
+kind-mismatched allocation provenance. That is unsafe for retiring direct
+codegen because later IR-only optimizations depend on the final artifact's
+allocation identity, including specialization-created allocation sites.
+
+Running the verifier after every pass in every production build would multiply
+the walk cost. This slice instead separates two policies:
+
+- optional intermediate assertions remain controlled by `IR_VERIFY_ALLOC` and
+  retain their pass-local diagnostic value; and
+- one required final assertion runs for every function that will be lowered,
+  after inlining, monomorphization, clone rewriting, and final hygiene.
+
+The final walk must fail closed: an artifact that cannot be verified is not
+published or lowered.
+
+## Scope
+
+1. Give `src/ir/verify-alloc.ts` distinct optional-intermediate and
+   required-final assertion entry points without duplicating verification
+   logic.
+2. Route the WasmGC integration pipeline through one final-artifact verifier
+   immediately before downstream analysis/lowering. Cover the complete final
+   function collection, including synthetic helpers and monomorphized clones.
+3. Add a negative integration control that injects invalid provenance after
+   the last transform and proves compilation fails while `IR_VERIFY_ALLOC` is
+   unset.
+4. Add a positive focused compile control with the flag unset and retain unit
+   coverage for optional intermediate checks.
+5. Measure elapsed compile cost on a stable focused corpus with the final gate
+   enabled and with a local diagnostic kill switch used only for measurement.
+   Record the harness, commits/configurations, repetitions, and result.
+
+The linear backend has a separate integration pipeline and registry. It does
+not yet consume the same prepared artifact (#3518 R8), so this slice does not
+pretend to close its retirement gate. When the shared prepared program lands,
+its final backend boundary must consume the same required verification result.
+
+## Optimization-retirement ledger classification
+
+The current #3792 ledger schema inventories direct-path optimizations with a
+direct owner and three parity evidence classes. This safeguard is an IR-native
+correctness invariant, not a migrated direct optimization, so adding it as a
+row would be inaccurate. #3792 v2 must classify always-on IR-native safeguards
+and include this gate in its deletion-readiness result.
+
+## Acceptance criteria
+
+- [ ] `IR_VERIFY_ALLOC` continues to control optional checks at intermediate
+      pass boundaries.
+- [ ] Final allocation-provenance verification is unconditional and runs once
+      for every final WasmGC IR artifact before analysis/lowering.
+- [ ] Ordinary, synthetic, and monomorphized final functions cannot bypass the
+      required gate.
+- [ ] A focused injected final-stage defect fails with
+      `allocation-provenance-failure` while `IR_VERIFY_ALLOC` is unset.
+- [ ] A normal focused compile succeeds with the flag unset.
+- [ ] Focused IR and type/format checks pass.
+- [ ] Compile overhead is measured on a named stable corpus; the result is
+      recorded without treating timing noise as zero cost.
+- [ ] #3792 v2 follow-up classification is documented without inserting an
+      incompatible ledger row.
+
+## Out of scope
+
+- Changing allocation identity, registry alias/retire semantics, or lowering.
+- Enabling every intermediate assertion in production.
+- Claiming full linear-backend or IR-only retirement readiness.
+- Expanding the current #3792 ledger schema in this slice.
+
+## Result
+
+Pending implementation and measurement.

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -196,6 +196,7 @@ import {
   forEachInstrDeep, // (#2949 slice 3) deep instr walk for preregisterDynamicSupport
   irVal,
   irTypeEquals,
+  mapNestedBuffers,
   type IrClassMemberKind,
   type IrClassShape,
   type IrClosureSignature,
@@ -234,7 +235,7 @@ import { materializePreparedAsyncHostAdapters } from "../codegen/ir-async-runtim
 import type { RuntimeProviderPlan } from "./runtime-manifest.js";
 import { AllocSiteRegistry, ALLOC_NAMESPACES } from "./alloc-registry.js";
 import { analyzeEncoding } from "./analysis/encoding.js";
-import { assertAllocProvenance } from "./verify-alloc.js";
+import { assertAllocProvenance, assertFinalAllocProvenance } from "./verify-alloc.js";
 import type { FieldDef, FuncTypeDef, GlobalDef, Import, Instr, StructTypeDef, ValType, WasmFunction } from "./types.js";
 import {
   definedFuncAt,
@@ -486,6 +487,69 @@ function prepareBuiltFnRuntimeManifest(
   materializePreparedMathProviders(ctx, runtime);
   materializePreparedAsyncHostAdapters(ctx, runtime.functions);
   return { entries: preparedEntries, runtime };
+}
+
+/** Test-only negative control for the required #4113 final gate. */
+function injectFinalAllocProvenanceFailure(
+  fn: IrFunction,
+  compatibilityName: string,
+  artifactKind: "ordinary" | "synthetic" | "monomorphized",
+): IrFunction {
+  const selector = process.env.JS2WASM_TEST_INJECT_IR_FINAL_ALLOC_FAILURE;
+  if (selector === undefined || (selector !== "1" && selector !== compatibilityName && selector !== artifactKind)) {
+    return fn;
+  }
+
+  let removed = false;
+  const rewriteInstr = (instr: IrInstr): IrInstr => {
+    const withNested = mapNestedBuffers(instr, (buffer) => {
+      const rewritten = buffer.map(rewriteInstr);
+      return rewritten.some((candidate, index) => candidate !== buffer[index]) ? rewritten : buffer;
+    });
+    if (removed || withNested.alloc === undefined) return withNested;
+    const { alloc: _removedAlloc, ...withoutAlloc } = withNested;
+    removed = true;
+    return withoutAlloc as IrInstr;
+  };
+  const blocks = fn.blocks.map((block) => {
+    const instrs = block.instrs.map(rewriteInstr);
+    return instrs.some((instr, index) => instr !== block.instrs[index]) ? { ...block, instrs } : block;
+  });
+  if (!removed) {
+    throw new Error(
+      `final allocation-provenance injection for ${compatibilityName} requires one allocation instruction`,
+    );
+  }
+  return { ...fn, blocks };
+}
+
+/**
+ * Require final provenance after all IR attachments and before component
+ * sealing, publication, or lowering. The collection includes source,
+ * synthetic, async-state, and monomorphized artifacts.
+ */
+function verifyFinalAllocArtifacts(
+  entries: readonly BuiltFn[],
+  registry: AllocSiteRegistry,
+  cloneOrigins: ReadonlyMap<IrUnitId, IrUnitId>,
+  onFailure: (entry: BuiltFn, error: unknown) => void,
+): BuiltFn[] {
+  const verified: BuiltFn[] = [];
+  for (const entry of entries) {
+    try {
+      const artifactKind = cloneOrigins.has(entry.artifactUnitId)
+        ? "monomorphized"
+        : entry.synthesized
+          ? "synthetic"
+          : "ordinary";
+      const fn = injectFinalAllocProvenanceFailure(entry.fn, entry.name, artifactKind);
+      assertFinalAllocProvenance(fn, registry);
+      verified.push(fn === entry.fn ? entry : { ...entry, fn });
+    } catch (error) {
+      onFailure(entry, error);
+    }
+  }
+  return verified;
 }
 
 function fillSealedPreparedCallable(
@@ -1885,7 +1949,6 @@ export function compileIrPathFunctions(
 
   // -------------------------------------------------------------------------
   // 2g. Ownership + access-semantics analysis (#1587) — gated, default OFF.
-  //
   // Runs on the final (post-mono/TU) IR shape, writing inferred ownership /
   // access annotations to the registry `ownership` namespace. The analysis is
   // purely an optimization aid: it does NOT mutate the IR and registry
@@ -1895,7 +1958,6 @@ export function compileIrPathFunctions(
   // is likewise gated and annotation-only). Behind `JS2WASM_IR_OWNERSHIP=1`
   // for the rollout period.
   // -------------------------------------------------------------------------
-  //
   // 2h. Escape analysis (#747) — gated, default OFF. When
   // `JS2WASM_IR_ESCAPE=1`, classifies each allocation
   // (local/returned/stored/captured/opaque) on top of the ownership result and
@@ -1917,10 +1979,7 @@ export function compileIrPathFunctions(
   }
   healthyForLower = retainHealthyOwners(healthyForLower);
   if (healthyForLower.length === 0) return finishReport();
-
-  // Every late-registration boundary is part of IR preparation. Unknown
-  // throws are invariants and must fan out to the active source owners rather
-  // than escaping or being silently demoted.
+  // Late registrations are preparation; unknown throws fan out to active owners.
   const runGlobalPreparation = (action: () => void): boolean => {
     try {
       action();
@@ -1942,6 +2001,11 @@ export function compileIrPathFunctions(
   ) {
     return finishReport();
   }
+  healthyForLower = verifyFinalAllocArtifacts(healthyForLower, allocRegistry, monoResult.cloneOrigins, (entry, error) =>
+    markOwnerFailure(terminalOwnerOf(entry), entry.artifactUnitId, entry.name, error, "verify"),
+  );
+  healthyForLower = retainHealthyOwners(healthyForLower);
+  if (healthyForLower.length === 0) return finishReport();
   if (!runGlobalPreparation(() => preregisterHostDateSnapshotSupport(ctx, healthyForLower))) {
     return finishReport();
   }

--- a/src/ir/verify-alloc.ts
+++ b/src/ir/verify-alloc.ts
@@ -15,11 +15,13 @@
 // This is the conservative gate from the issue's Risks section: an
 // allocation-bearing instr without a live id, or a dangling/kind-mismatched
 // id, is flagged so audit gaps and pass-discipline drift surface in CI rather
-// than later. It is gated behind a debug flag so it is free in production.
+// than later. Intermediate pass checks are gated behind a debug flag; the
+// final publication boundary is always checked.
 //
 // Like `verifyIrFunction`, this returns errors rather than throwing, so the
-// caller decides whether to bail. `assertAllocProvenance` is the throwing
-// wrapper used at the integration verify boundaries.
+// caller decides whether to bail. `assertAllocProvenance` is the optional
+// intermediate wrapper; `assertFinalAllocProvenance` is the required final
+// wrapper.
 
 import type { AllocSiteRegistry } from "./alloc-registry.js";
 import type { AllocKind, AllocSiteId, IrFunction, IrInstr } from "./nodes.js";
@@ -127,11 +129,25 @@ function checkId(
 }
 
 /**
- * Throwing wrapper for the integration verify boundaries. No-op unless the
- * debug flag is on, so it costs nothing in production.
+ * Throwing wrapper for intermediate integration verify boundaries. No-op
+ * unless the debug flag is on, so production does not repeat the walk after
+ * every pass.
  */
 export function assertAllocProvenance(func: IrFunction, registry: AllocSiteRegistry): void {
   if (!allocVerifyEnabled()) return;
+  assertVerifiedAllocProvenance(func, registry);
+}
+
+/**
+ * Required final-artifact gate. This deliberately ignores `IR_VERIFY_ALLOC`:
+ * every artifact must pass once after all transforms and before publication or
+ * lowering.
+ */
+export function assertFinalAllocProvenance(func: IrFunction, registry: AllocSiteRegistry): void {
+  assertVerifiedAllocProvenance(func, registry);
+}
+
+function assertVerifiedAllocProvenance(func: IrFunction, registry: AllocSiteRegistry): void {
   const errors = verifyAllocProvenance(func, registry);
   if (errors.length > 0) {
     const lines = errors.map((e) => `  - [${e.func}] ${e.message}`).join("\n");

--- a/tests/ir/alloc-provenance.test.ts
+++ b/tests/ir/alloc-provenance.test.ts
@@ -16,6 +16,7 @@ import {
   AllocSiteRegistry,
   IrFunctionBuilder,
   assertAllocProvenance,
+  assertFinalAllocProvenance,
   asAllocSiteId,
   irVal,
   verifyAllocProvenance,
@@ -111,6 +112,33 @@ describe("#1586 — alloc provenance", () => {
           stage: "verify",
         });
       }
+    } finally {
+      if (original === undefined) Reflect.deleteProperty(process.env, "IR_VERIFY_ALLOC");
+      else process.env.IR_VERIFY_ALLOC = original;
+    }
+  });
+
+  it("keeps intermediate assertions optional while the final assertion is required", () => {
+    const original = process.env.IR_VERIFY_ALLOC;
+    Reflect.deleteProperty(process.env, "IR_VERIFY_ALLOC");
+    try {
+      const reg = new AllocSiteRegistry();
+      const b = new IrFunctionBuilder(identities.next("f"), [{ kind: "string" }], false, reg);
+      b.openBlock();
+      const s = b.emitStringConst("final");
+      b.terminate({ kind: "return", values: [s] });
+      const fn = b.finish();
+      const strInstr = fn.blocks[0]!.instrs.find((instr) => instr.kind === "string.const")!;
+      reg.retire(strInstr.alloc!);
+
+      expect(() => assertAllocProvenance(fn, reg)).not.toThrow();
+      expect(() => assertFinalAllocProvenance(fn, reg)).toThrowError(
+        expect.objectContaining({
+          name: "IrInvariantError",
+          code: "allocation-provenance-failure",
+          stage: "verify",
+        }),
+      );
     } finally {
       if (original === undefined) Reflect.deleteProperty(process.env, "IR_VERIFY_ALLOC");
       else process.env.IR_VERIFY_ALLOC = original;

--- a/tests/issue-4113-ir-final-allocation-provenance.test.ts
+++ b/tests/issue-4113-ir-final-allocation-provenance.test.ts
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { injectedMonomorphParents } = vi.hoisted(() => ({
+  injectedMonomorphParents: new Set<string>(),
+}));
+
+// Production call tuples are normalized before the current monomorphization
+// pass. This narrow wrapper supplies one contract-shaped clone so the final
+// integration collection, rather than only the pass unit tests, can prove the
+// required gate observes monomorphized artifacts.
+vi.mock("../src/ir/passes/monomorphize.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/ir/passes/monomorphize.js")>();
+  const { createDerivedIrUnitId } = await import("../src/ir/identity.js");
+  const { forkAllocInInstr } = await import("../src/ir/passes/alloc-discipline.js");
+  return {
+    ...actual,
+    monomorphize(...args: Parameters<typeof actual.monomorphize>) {
+      const result = actual.monomorphize(...args);
+      const cloneSignatures = new Map(result.cloneSignatures);
+      const cloneOrigins = new Map(result.cloneOrigins);
+      const cloneUnitProvenance = new Map(result.cloneUnitProvenance);
+      const clones: (typeof result.module.functions)[number][] = [];
+      for (const parent of result.module.functions) {
+        if (!injectedMonomorphParents.has(parent.name)) continue;
+        const returnType = parent.resultTypes[0];
+        if (!returnType || parent.resultTypes.length !== 1) {
+          throw new Error(`monomorphized final-gate fixture requires one result from ${parent.name}`);
+        }
+        const unitId = createDerivedIrUnitId({
+          parentId: parent.unitId,
+          role: "monomorphization-clone",
+          ordinal: 0,
+        });
+        const name = `${parent.name}$final_alloc_test`;
+        clones.push({
+          ...parent,
+          unitId,
+          name,
+          exported: false,
+          blocks: parent.blocks.map((block) => ({
+            ...block,
+            instrs: block.instrs.map((instr) => forkAllocInInstr(instr, args[1])),
+          })),
+        });
+        cloneSignatures.set(unitId, {
+          name,
+          params: parent.params.map((param) => param.type),
+          returnType,
+        });
+        cloneOrigins.set(unitId, parent.unitId);
+        cloneUnitProvenance.set(unitId, {
+          id: unitId,
+          parentId: parent.unitId,
+          role: "monomorphization-clone",
+          ordinal: 0,
+        });
+      }
+      return {
+        ...result,
+        module: { functions: [...result.module.functions, ...clones] },
+        cloneSignatures,
+        cloneOrigins,
+        cloneUnitProvenance,
+      };
+    },
+  };
+});
+
+import { compile } from "../src/index.js";
+
+const TRACKED_ENV = ["IR_VERIFY_ALLOC", "JS2WASM_TEST_INJECT_IR_FINAL_ALLOC_FAILURE"] as const;
+const ORIGINAL_ENV = new Map(TRACKED_ENV.map((name) => [name, process.env[name]]));
+
+afterEach(() => {
+  injectedMonomorphParents.clear();
+  for (const name of TRACKED_ENV) {
+    const original = ORIGINAL_ENV.get(name);
+    if (original === undefined) Reflect.deleteProperty(process.env, name);
+    else process.env[name] = original;
+  }
+});
+
+describe("#4113 final allocation-provenance gate", () => {
+  it("accepts a normal final artifact with IR_VERIFY_ALLOC unset", async () => {
+    Reflect.deleteProperty(process.env, "IR_VERIFY_ALLOC");
+    const result = await compile(`export function value(): string { return "final"; }`, {
+      fileName: "issue-4113-pass.ts",
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irOutcomes).toEqual([
+      expect.objectContaining({ displayName: "value", kind: "emitted", irBodyEmitted: true }),
+    ]);
+  });
+
+  it("rejects invalid final provenance with IR_VERIFY_ALLOC unset", async () => {
+    Reflect.deleteProperty(process.env, "IR_VERIFY_ALLOC");
+    process.env.JS2WASM_TEST_INJECT_IR_FINAL_ALLOC_FAILURE = "broken";
+    const result = await compile(
+      `
+export function broken(): string { return "invalid"; }
+export function independent(value: number): number { return value + 1; }
+`,
+      { fileName: "issue-4113-fail.ts", trackIrOutcomes: true },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.irOutcomes?.find((outcome) => outcome.displayName === "broken")).toMatchObject({
+      kind: "invariant",
+      code: "allocation-provenance-failure",
+      stage: "verify",
+      irBodyEmitted: false,
+    });
+    expect(result.irOutcomes?.find((outcome) => outcome.displayName === "independent")).toMatchObject({
+      kind: "emitted",
+      irBodyEmitted: true,
+    });
+  });
+
+  it("does not let a synthetic final artifact bypass the required gate", async () => {
+    Reflect.deleteProperty(process.env, "IR_VERIFY_ALLOC");
+    process.env.JS2WASM_TEST_INJECT_IR_FINAL_ALLOC_FAILURE = "synthetic";
+    const result = await compile(
+      `
+export function outer(prefix: string): string {
+  function append(value: string): string { return prefix + value; }
+  return append("final");
+}
+`,
+      { fileName: "issue-4113-synthetic.ts", trackIrOutcomes: true },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.irOutcomes).toEqual([
+      expect.objectContaining({
+        displayName: "outer",
+        kind: "invariant",
+        code: "allocation-provenance-failure",
+        stage: "verify",
+        irBodyEmitted: false,
+      }),
+    ]);
+  });
+
+  it("does not let a monomorphized final artifact bypass the required gate", async () => {
+    Reflect.deleteProperty(process.env, "IR_VERIFY_ALLOC");
+    injectedMonomorphParents.add("cloneSource");
+    process.env.JS2WASM_TEST_INJECT_IR_FINAL_ALLOC_FAILURE = "monomorphized";
+    const result = await compile(`export function cloneSource(): string { return "clone"; }`, {
+      fileName: "issue-4113-monomorphized.ts",
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.irOutcomes).toEqual([
+      expect.objectContaining({
+        displayName: "cloneSource",
+        kind: "invariant",
+        code: "allocation-provenance-failure",
+        stage: "verify",
+        irBodyEmitted: false,
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- keep IR_VERIFY_ALLOC as the optional intermediate-pass diagnostic switch
- require one final allocation-provenance verification after all IR attachments and before component publication or lowering
- cover ordinary, lifted synthetic, and monomorphized artifacts with fail-closed integration controls
- close the markdown plan issue with measured compile-overhead evidence and a documented IR-native classification requirement for the next optimization-ledger schema

## Validation

- focused allocation and integration suites: 11/11 passed
- pnpm run typecheck
- pnpm run check:ir-fallbacks
- pnpm run check:issues
- prettier, LOC budget, function budget, oracle, coercion, and numeric-local pre-push gates
- broader issue-3519 outcomes: 38/40; both failures reproduce on the control commit and are unrelated existing failures

## Compile overhead

Three alternating fresh-process runs of pnpm run check:ir-fallbacks produced overlapping ranges: control 20.51–25.79 seconds and candidate 20.39–25.53 seconds. No regression was detected at this resolution; this does not claim the final walk has zero cost.