### PR TITLE
feat(ir): compile Promise.all continuations through IR

### DIFF
--- a/plan/issues/4110-ir-fetch-all-parallel-continuation.md
+++ b/plan/issues/4110-ir-fetch-all-parallel-continuation.md
@@ -1,7 +1,7 @@
 ---
 id: 4110
 title: "IR async fetchAllParallel non-identity continuation"
-status: blocked
+status: in-progress
 sprint: current
 created: 2026-08-02
 updated: 2026-08-02

--- a/plan/issues/4110-ir-fetch-all-parallel-continuation.md
+++ b/plan/issues/4110-ir-fetch-all-parallel-continuation.md
@@ -1,0 +1,159 @@
+---
+id: 4110
+title: "IR async fetchAllParallel non-identity continuation"
+status: blocked
+sprint: current
+created: 2026-08-02
+updated: 2026-08-02
+priority: critical
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: ir, runtime, codegen
+language_feature: async, Promise.all
+goal: ir-full-coverage
+lane: ir-retirement-r7
+parent: 3527
+depends_on: [4107]
+related: [1042, 1373b, 2867, 2906, 2918, 3137, 3518, 3587, 3792, 4106, 4109]
+files:
+  - src/ir/async-prepare.ts
+  - src/codegen/async-ir-planning.ts
+  - src/codegen/ir-async-frame.ts
+  - src/codegen/ir-prepared-free-functions.ts
+  - src/ir/prepared-component-dependencies.ts
+  - src/ir/integration.ts
+  - src/codegen/index.ts
+  - scripts/ir-only-baseline.json
+  - tests/ir/issue-1373b-async-plan.test.ts
+  - tests/issue-1042-host-drive.test.ts
+  - tests/issue-4110-ir-fetch-all-parallel.test.ts
+  - plan/issues/4110-ir-fetch-all-parallel-continuation.md
+loc-budget-allow:
+  - src/codegen/ir-async-frame.ts
+  - src/ir/async-prepare.ts
+---
+
+# #4110 — IR async fetchAllParallel non-identity continuation
+
+## Problem
+
+After #4107, the exact playground `fetchUser` owner has a canonical
+Promise-returning source slot and compiles once from its prepared async plan.
+`fetchAllParallel` still receives a typed `Unsupported / select /
+async-function` outcome, emits one direct body, and emits no IR body.
+
+Its one suspension is already structurally simple:
+
+```ts
+const pending: Promise<number>[] = [];
+for (...) pending.push(fetchUser(ids[i]));
+const results = await Promise.all(pending);
+let total = 0;
+for (...) total = total + results[i];
+return total;
+```
+
+`prepareSingleAwaitIrFunction` can split the ordinary IR around the await and
+derive entry and continuation helpers. The prepared frame consumer currently
+rejects the result because it accepts only an empty identity continuation.
+Keeping this owner direct would preserve a backend-specific AST path for a
+shape already representable by the shared IR plan.
+
+## Scope
+
+- Admit only a checker- and IR-certified top-level host/WasmGC function with
+  one real suspension and a continuation whose only live input from before the
+  await is the delivered fulfillment value.
+- Freeze the canonical Promise source-callable ABI before Program ABI
+  publication, using the same structural owner and no function-name allowlist.
+- Retain the existing prefix helper for vector construction, `fetchUser`
+  fan-out, and `Promise.all`; derive one ordinary IR continuation helper for
+  the post-resume reduction.
+- Extend the prepared frame adapter to invoke that symbolic continuation
+  helper after fulfillment, then settle its numeric result through the
+  existing frame engine and six frozen host adapters.
+- Keep `spills: []`: `pending` is dead at suspension, `results` is the resume
+  value, and `total`/the reduction counter are created after resumption.
+- Seal entry, continuation, source callable, runtime adapters, and every
+  required vector/runtime provider as one dependency-complete prepared
+  component before direct body emission.
+- Bank every measured decrease through the #4109 legacy-body ceiling.
+
+## Semantic and optimization parity
+
+- All `fetchUser` calls must occur before the single suspension; the IR path
+  may not serialize the fan-out.
+- Preserve `Promise.all` input ordering, output ordering, assimilation, and
+  fail-fast rejection. Reuse its existing runtime provider rather than adding
+  a new combinator or scheduler.
+- Preserve the canonical Promise-only, always-async caller ABI and propagate
+  rejection through the existing frame rejection path.
+- Preserve the pending/result vector representations, direct indexed reads,
+  numeric accumulator representation, loop-counter narrowing, and any proven
+  bounds-elision shape present on the direct path.
+- Add function-specific WAT assertions for the continuation call, result
+  settlement, and vector hot path. Runtime equality alone is insufficient for
+  optimization retirement.
+- Record any newly exposed direct fast-path decision in the optimization
+  retirement ledger before its direct owner can be deleted.
+
+## Fail-closed boundary
+
+- A continuation that captures any pre-await value other than the fulfillment
+  value remains typed Unsupported until explicit spills exist.
+- Multiple awaits, nested awaits, loops containing awaits, handlers across an
+  await, nested executable syntax, function-value escape, generic/reference
+  ABI drift, standalone, WASI, and linear remain on their established route.
+- A dependency, Program ABI, verifier, or lowering failure after the owner is
+  sealed is terminal. It cannot retry the direct body.
+- Source syntax may certify early ABI eligibility, but the backend consumes
+  only the prepared `IrAsyncPlan`, symbolic function references, and frozen
+  runtime manifest; it may not inspect TypeScript AST nodes.
+
+## Acceptance criteria
+
+- The unchanged playground `fetchAllParallel` has
+  `legacyBodyEmitted: false`, `irBodyEmitted: true`, and a non-empty
+  `preparedComponentId`.
+- Its source callable, entry helper, and continuation helper are all emitted
+  through IR and resolve through Program ABI identities, with no post-claim
+  errors or direct fallback.
+- Runtime coverage proves all requests are started before any one resolves,
+  results retain input order, the sum is correct, and the first rejection
+  rejects the outer Promise without running the reduction.
+- Near-miss capture, multi-await, host-free, ABI-mismatch, and injected-failure
+  controls stay direct or fail terminally as specified.
+- The production readiness lane moves from 34/37 to 35/37 IR-emitted, from
+  three to two typed async blockers, from 33 to 32 legacy bodies, and remains
+  at zero invariants.
+- The committed legacy-body ceiling is exactly the freshly measured 32; an
+  increase fails the hybrid gate.
+- Focused async-plan/runtime tests, typecheck, fallback/readiness/optimization
+  gates, formatting, source/function budgets, and relevant pre-push tests pass.
+
+## Validation plan
+
+- Reuse the pending-input, element-order, and first-rejection controls from
+  `tests/issue-2867-gap4.test.ts`; the new host fixture must exercise the same
+  semantics through the prepared source owner.
+- Keep `tests/issue-2918-promise-then-funcidx-shift.test.ts` green and add a
+  late-import control around the prepared entry/continuation helpers so
+  Promise combinator indices cannot drift after sealing.
+- Keep `tests/issue-3587-async-rejection-delivery.test.ts` green and assert the
+  prepared continuation never runs after the awaited combinator rejects.
+- Use `tests/issue-3137.test.ts` as the existing Promise.all ordering/rejection
+  semantic control; #4110 does not replace or fork the combinator runtime.
+- The focused #4110 file must inspect the exact source owner, entry helper,
+  continuation helper, resume function, and their resolved calls in WAT, then
+  instantiate the module and prove value, timing, ordering, and rejection.
+
+## Integration order
+
+This is the first serial async widening after #4107. `fetchAllSequential`
+follows with structured `for` CFG states and spills; `main` follows last with
+two awaits, explicit liveness, and `Promise<void>` settlement. These slices
+share the async producer, frame consumer, dependency scanner, Program ABI
+routing, and codegen driver, so their production edits must not be developed
+or merged concurrently.

--- a/plan/issues/4110-ir-fetch-all-parallel-continuation.md
+++ b/plan/issues/4110-ir-fetch-all-parallel-continuation.md
@@ -1,10 +1,11 @@
 ---
 id: 4110
 title: "IR async fetchAllParallel non-identity continuation"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-02
-updated: 2026-08-02
+updated: 2026-08-03
+completed: 2026-08-03
 priority: critical
 horizon: m
 feasibility: medium
@@ -132,6 +133,46 @@ shape already representable by the shared IR plan.
   increase fails the hybrid gate.
 - Focused async-plan/runtime tests, typecheck, fallback/readiness/optimization
   gates, formatting, source/function budgets, and relevant pre-push tests pass.
+
+## Result
+
+`fetchAllParallel` now compiles through the prepared IR async component. Its
+source callable, entry helper, and post-resume reduction continuation share a
+frozen Promise ABI and resolve through stable Program ABI identities. The
+entry preserves the three-request fan-out before suspension; the continuation
+materializes the fulfilled host array into the typed vector representation,
+reduces it with direct indexed reads and numeric loop state, and settles the
+outer Promise through the existing frame runtime. Rejection bypasses the
+continuation and reaches the established rejection path.
+
+The production census is now 35 of 37 reachable functions emitted through IR,
+32 legacy bodies, two typed async blockers, and zero invariants. The two
+remaining blockers are `fetchAllSequential` and async `main`.
+
+No new optimization-retirement ledger row was required: this slice introduced
+no new direct-only optimization. Existing vector representation, indexed-read,
+numeric accumulator, loop-counter, and bounds decisions are covered by the
+focused WAT assertions. The next serial slice is `fetchAllSequential`.
+
+## Validation evidence
+
+- The focused #4110 suite passes all 18 tests, covering source/entry/
+  continuation ownership, fan-out and ordering, first rejection, stable
+  symbolic targets, exact vector materialization, continuation WAT shape, and
+  fail-closed controls.
+- The post-rebase async, runtime, allocation, vector, and regression selection
+  passes all 147 tests across 12 files.
+- Typecheck and formatting checks pass.
+- Source LOC and function-size budgets pass with only the issue-scoped
+  allowances for `ir-async-frame.ts` and `async-prepare.ts`.
+- The raw-checker TypeOracle ratchet passes with zero new checker accesses.
+- The normal fallback ratchet and the body-shape diagnostic pass with zero
+  unintended fallback growth, post-claim fallback growth, module growth, or
+  body-shape rejection.
+- Hybrid readiness passes at 35/37 IR-emitted, 32 legacy bodies, two
+  unsupported async owners, and zero invariants.
+- Optimization-retirement validation passes all 22 tracked decisions: 11 are
+  IR-owned, one is retirement-ready, and two remain source-anchored.
 
 ## Validation plan
 

--- a/scripts/ir-only-baseline.json
+++ b/scripts/ir-only-baseline.json
@@ -5,12 +5,12 @@
     "single-host": {
       "entryFloor": 5,
       "terminalUnitFloor": 37,
-      "emittedFloor": 34,
-      "irBodyEmittedFloor": 34,
-      "legacyBodyEmittedCeiling": 33,
-      "unsupportedCeiling": 3,
+      "emittedFloor": 35,
+      "irBodyEmittedFloor": 35,
+      "legacyBodyEmittedCeiling": 32,
+      "unsupportedCeiling": 2,
       "unsupportedByCode": {
-        "select/async-function": 3
+        "select/async-function": 2
       },
       "invariantCeiling": 0
     }

--- a/src/checker/oracle.ts
+++ b/src/checker/oracle.ts
@@ -148,6 +148,8 @@ export interface TypeOracle {
    * boundary without exposing the checker Symbol.
    */
   valueDeclarationOf(id: ts.Node): ts.Declaration | undefined;
+  /** All declarations for an exact binding, without exposing its Symbol. */
+  declarationsOf(node: ts.Node): readonly ts.Declaration[];
   /**
    * Variable declaration for a plain identifier binding. Returning the AST
    * declaration (rather than the checker Symbol) keeps binding-identity
@@ -408,6 +410,14 @@ export class TsCheckerOracle implements TypeOracle {
       return sym?.valueDeclaration ?? sym?.declarations?.[0];
     } catch {
       return undefined;
+    }
+  }
+
+  declarationsOf(node: ts.Node): readonly ts.Declaration[] {
+    try {
+      return [...(this.checker.getSymbolAtLocation(node)?.declarations ?? [])];
+    } catch {
+      return [];
     }
   }
 

--- a/src/codegen/async-ir-planning.ts
+++ b/src/codegen/async-ir-planning.ts
@@ -1,19 +1,256 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { isSingleAwaitReturnAsyncCandidate } from "../ir/async-prepare.js";
+import { irImportFuncRef } from "../ir/callable-bindings.js";
+import type { IrFromAstResolver } from "../ir/from-ast.js";
+import { irVal, irVec } from "../ir/nodes.js";
 import type { ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import type { IrUnitId } from "../ir/identity.js";
 import type { IrSelectionOptions } from "../ir/select.js";
 import { asyncEngineWouldActivate } from "./async-activation.js";
-import { analyzeAsyncBody } from "./async-cps.js";
+import { analyzeAsyncBody, splitBodyAtAwait } from "./async-cps.js";
 import type { CodegenContext } from "./context/types.js";
 import type { IrOverlayIdentityPlan } from "./ir-overlay-identity.js";
 
 type AsyncSelectionOptions = Pick<
   IrSelectionOptions,
-  "supportsAsyncIr" | "asyncEngineClaims" | "asyncHasRealSuspension" | "canPrepareSuspendingAsync"
+  | "supportsAsyncIr"
+  | "asyncEngineClaims"
+  | "asyncHasRealSuspension"
+  | "canPrepareSuspendingAsync"
+  | "preparedAsyncPromiseVectorLocal"
+  | "preparedAsyncThenableCall"
+  | "preparedAsyncPromiseAllCall"
 >;
+
+export interface PreparedIrAsyncSourceShape {
+  readonly kind: "identity" | "promise-all-continuation";
+  readonly awaitedCall: ts.CallExpression;
+}
+
+function collectBindingDeclarations(
+  ctx: CodegenContext,
+  name: ts.BindingName,
+  declarations: Set<ts.Declaration>,
+): void {
+  if (ts.isIdentifier(name)) {
+    const declaration = ctx.oracle.valueDeclarationOf(name);
+    if (declaration) declarations.add(declaration);
+    return;
+  }
+  for (const element of name.elements) {
+    if (!ts.isOmittedExpression(element)) collectBindingDeclarations(ctx, element.name, declarations);
+  }
+}
+
+function isNestedExecutable(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isConstructorDeclaration(node)
+  );
+}
+
+function bodyHasNestedExecutable(body: ts.Block): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (isNestedExecutable(node)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  for (const statement of body.statements) visit(statement);
+  return found;
+}
+
+function declarationsAreAmbient(ctx: CodegenContext, node: ts.Node): boolean {
+  const declarations = ctx.oracle.declarationsOf(node);
+  return declarations.length > 0 && declarations.every((declaration) => declaration.getSourceFile().isDeclarationFile);
+}
+
+function isExactPromiseVectorDeclaration(ctx: CodegenContext, declaration: ts.VariableDeclaration): boolean {
+  const type = declaration.type;
+  return (
+    !!type &&
+    ts.isArrayTypeNode(type) &&
+    ts.isTypeReferenceNode(type.elementType) &&
+    ts.isIdentifier(type.elementType.typeName) &&
+    type.elementType.typeName.text === "Promise" &&
+    type.elementType.typeArguments?.length === 1 &&
+    type.elementType.typeArguments[0]?.kind === ts.SyntaxKind.NumberKeyword &&
+    declarationsAreAmbient(ctx, type.elementType.typeName) &&
+    !!declaration.initializer &&
+    ts.isArrayLiteralExpression(declaration.initializer) &&
+    declaration.initializer.elements.length === 0
+  );
+}
+
+/** Checker proof that the continuation reads no parameter or prefix local. */
+function continuationHasNoPreAwaitCapture(
+  ctx: CodegenContext,
+  fn: ts.FunctionDeclaration,
+  prefix: readonly ts.Statement[],
+  suffix: readonly ts.Statement[],
+): boolean {
+  const preAwaitDeclarations = new Set<ts.Declaration>();
+  for (const parameter of fn.parameters) collectBindingDeclarations(ctx, parameter.name, preAwaitDeclarations);
+  const collectPrefix = (node: ts.Node): void => {
+    if (isNestedExecutable(node)) return;
+    if (ts.isVariableDeclaration(node)) collectBindingDeclarations(ctx, node.name, preAwaitDeclarations);
+    ts.forEachChild(node, collectPrefix);
+  };
+  for (const statement of prefix) collectPrefix(statement);
+
+  let captured = false;
+  const inspectSuffix = (node: ts.Node): void => {
+    if (captured || isNestedExecutable(node)) return;
+    if (node.kind === ts.SyntaxKind.ThisKeyword || (ts.isIdentifier(node) && node.text === "arguments")) {
+      captured = true;
+      return;
+    }
+    if (ts.isIdentifier(node)) {
+      const declaration = ctx.oracle.valueDeclarationOf(node);
+      if (declaration && preAwaitDeclarations.has(declaration)) {
+        captured = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, inspectSuffix);
+  };
+  for (const statement of suffix) inspectSuffix(statement);
+  return !captured;
+}
+
+function isAmbientPromiseAll(ctx: CodegenContext, call: ts.CallExpression): boolean {
+  const target = call.expression;
+  if (
+    !ts.isPropertyAccessExpression(target) ||
+    !ts.isIdentifier(target.expression) ||
+    target.expression.text !== "Promise" ||
+    target.name.text !== "all"
+  ) {
+    return false;
+  }
+  if (call.questionDotToken || call.typeArguments?.length || call.arguments.length !== 1) return false;
+  const pendingDeclaration = ts.isIdentifier(call.arguments[0]!)
+    ? ctx.oracle.variableDeclarationOf(call.arguments[0]!)
+    : undefined;
+  return (
+    declarationsAreAmbient(ctx, target.expression) &&
+    declarationsAreAmbient(ctx, target.name) &&
+    pendingDeclaration !== undefined &&
+    isExactPromiseVectorDeclaration(ctx, pendingDeclaration)
+  );
+}
+
+/**
+ * Source-level proof used before callable ABI publication. The continuation
+ * widening remains one exact Promise.all suspension and rejects every value
+ * that would need a frame spill; final IR preparation re-verifies the split.
+ */
+export function preparedIrAsyncSourceShape(
+  ctx: CodegenContext,
+  fn: ts.FunctionLikeDeclaration,
+): PreparedIrAsyncSourceShape | null {
+  if (!ts.isFunctionDeclaration(fn) || fn.asteriskToken || !fn.body || bodyHasNestedExecutable(fn.body)) return null;
+  if (!fn.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword)) return null;
+  const plan = analyzeAsyncBody(ctx, fn);
+  const split = splitBodyAtAwait(fn, plan);
+  if (!split || !ts.isCallExpression(split.awaitedExpr)) return null;
+  if (isSingleAwaitReturnAsyncCandidate(fn)) {
+    return { kind: "identity", awaitedCall: split.awaitedExpr };
+  }
+  if (
+    split.isReturnAwait ||
+    !split.resumeBinding ||
+    split.suffix.length === 0 ||
+    !isAmbientPromiseAll(ctx, split.awaitedExpr) ||
+    !continuationHasNoPreAwaitCapture(ctx, fn, split.prefix, split.suffix)
+  ) {
+    return null;
+  }
+  return { kind: "promise-all-continuation", awaitedCall: split.awaitedExpr };
+}
+
+export function preparedIrAsyncSourceCanSuspend(ctx: CodegenContext, fn: ts.FunctionDeclaration): boolean {
+  const shape = preparedIrAsyncSourceShape(ctx, fn);
+  return shape !== null && (shape.kind === "promise-all-continuation" || asyncEngineWouldActivate(ctx, fn));
+}
+
+/** Exact awaited Promise.all node owned by the certified continuation shape. */
+export function isPreparedIrPromiseAllCall(ctx: CodegenContext, call: ts.CallExpression): boolean {
+  const owner = enclosingFunctionDeclaration(call);
+  if (!owner) return false;
+  const shape = preparedIrAsyncSourceShape(ctx, owner);
+  return shape?.kind === "promise-all-continuation" && shape.awaitedCall === call;
+}
+
+function preparedAsyncParamAbiIsStable(ctx: CodegenContext, param: ValType): boolean {
+  if (param.kind === "f64") return true;
+  const numericVecTypeIdx = ctx.vecTypeMap.get("f64");
+  return (
+    (param.kind === "ref" || param.kind === "ref_null") &&
+    numericVecTypeIdx !== undefined &&
+    param.typeIdx === numericVecTypeIdx
+  );
+}
+
+function enclosingFunctionDeclaration(node: ts.Node): ts.FunctionDeclaration | null {
+  for (let current: ts.Node | undefined = node.parent; current; current = current.parent) {
+    if (ts.isFunctionDeclaration(current)) return current;
+    if (isNestedExecutable(current)) return null;
+  }
+  return null;
+}
+
+/** Exact pending-vector annotation owned by the certified Promise.all prefix. */
+export function isPreparedIrPromiseVectorLocal(ctx: CodegenContext, declaration: ts.VariableDeclaration): boolean {
+  if (!isExactPromiseVectorDeclaration(ctx, declaration)) return false;
+  const owner = enclosingFunctionDeclaration(declaration);
+  if (!owner) return false;
+  const shape = preparedIrAsyncSourceShape(ctx, owner);
+  return shape?.kind === "promise-all-continuation" && declaration.end <= shape.awaitedCall.pos;
+}
+
+/** Exact Promise-producing call stored in the certified pending vector. */
+function isPreparedAsyncThenableCall(ctx: CodegenContext, call: ts.CallExpression): boolean {
+  if (!ts.isIdentifier(call.expression)) return false;
+  const owner = enclosingFunctionDeclaration(call);
+  if (!owner) return false;
+  const ownerShape = preparedIrAsyncSourceShape(ctx, owner);
+  if (ownerShape?.kind !== "promise-all-continuation" || call.end > ownerShape.awaitedCall.pos) return false;
+
+  const pushCall = call.parent;
+  if (
+    !ts.isCallExpression(pushCall) ||
+    pushCall.arguments.length !== 1 ||
+    pushCall.arguments[0] !== call ||
+    !ts.isPropertyAccessExpression(pushCall.expression) ||
+    pushCall.expression.name.text !== "push" ||
+    !ts.isIdentifier(pushCall.expression.expression)
+  ) {
+    return false;
+  }
+  const pendingDeclaration = ctx.oracle.variableDeclarationOf(pushCall.expression.expression);
+  if (!pendingDeclaration || !isPreparedIrPromiseVectorLocal(ctx, pendingDeclaration)) return false;
+
+  const callee = ctx.oracle.valueDeclarationOf(call.expression);
+  return (
+    callee !== undefined &&
+    ts.isFunctionDeclaration(callee) &&
+    ts.isSourceFile(callee.parent) &&
+    callee.getSourceFile() === owner.getSourceFile() &&
+    preparedIrAsyncSourceShape(ctx, callee)?.kind === "identity" &&
+    preparedIrAsyncSourceCanSuspend(ctx, callee)
+  );
+}
 
 /**
  * Freeze the canonical Promise-returning callable ABI before program-ABI
@@ -34,9 +271,8 @@ export function prepareAsyncCallableAbi(
     !ctx.standalone &&
     !fn.typeParameters?.length &&
     ts.isSourceFile(fn.parent) &&
-    isSingleAwaitReturnAsyncCandidate(fn) &&
-    asyncEngineWouldActivate(ctx, fn) &&
-    params.every((param) => param.kind === "f64") &&
+    preparedIrAsyncSourceCanSuspend(ctx, fn) &&
+    params.every((param) => preparedAsyncParamAbiIsStable(ctx, param)) &&
     fulfillmentResults.length === 1 &&
     fulfillmentResults[0]?.kind === "f64";
   return [params, usesPromiseAbi ? [{ kind: "externref" }] : fulfillmentResults];
@@ -53,7 +289,32 @@ export function prepareIrAsyncSelectionOptions(ctx: CodegenContext): AsyncSelect
     },
     // #4106: first genuinely-suspending IR producer. Host/WasmGC only — the
     // prepared runtime-provider catalogue has no standalone/WASI projection.
-    canPrepareSuspendingAsync: (fn) => !ctx.wasi && !ctx.standalone && isSingleAwaitReturnAsyncCandidate(fn),
+    canPrepareSuspendingAsync: (fn) =>
+      !ctx.wasi && !ctx.standalone && ts.isFunctionDeclaration(fn) && preparedIrAsyncSourceCanSuspend(ctx, fn),
+    preparedAsyncPromiseVectorLocal: (declaration) => isPreparedIrPromiseVectorLocal(ctx, declaration),
+    preparedAsyncThenableCall: (call) => isPreparedAsyncThenableCall(ctx, call),
+    preparedAsyncPromiseAllCall: (call) => isPreparedIrPromiseAllCall(ctx, call),
+  };
+}
+
+/** Backend-bound AST resolver fragment for exact prepared async constructs. */
+export function preparedIrAsyncFromAstResolver(
+  ctx: CodegenContext,
+): Pick<IrFromAstResolver, "preparedAsyncPromiseVectorLocal" | "preparedAsyncPromiseAllPlan"> {
+  return {
+    preparedAsyncPromiseVectorLocal: (declaration) => isPreparedIrPromiseVectorLocal(ctx, declaration),
+    preparedAsyncPromiseAllPlan: (call) => {
+      if (
+        ctx.standalone ||
+        ctx.wasi ||
+        ctx.strictNoHostImports ||
+        !ctx.funcMap.has("Promise_all") ||
+        !isPreparedIrPromiseAllCall(ctx, call)
+      ) {
+        return null;
+      }
+      return { target: irImportFuncRef("env", "Promise_all"), resultType: irVec(irVal({ kind: "f64" }), true) };
+    },
   };
 }
 
@@ -66,11 +327,7 @@ export function collectPreparedIrAsyncOwners(
   const owners = new Set<IrUnitId>();
   if (ctx.wasi || ctx.standalone) return owners;
   for (const claim of identityPlan.functionClaims) {
-    if (
-      selectedFunctions.has(claim.legacyName) &&
-      isSingleAwaitReturnAsyncCandidate(claim.declaration) &&
-      asyncEngineWouldActivate(ctx, claim.declaration)
-    ) {
+    if (selectedFunctions.has(claim.legacyName) && preparedIrAsyncSourceCanSuspend(ctx, claim.declaration)) {
       owners.add(claim.unitId);
     }
   }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -151,11 +151,11 @@ import {
 import {
   completePreparedIrIntegration,
   computePreparedInheritedIrFirstSkipUnitIds,
+  finalizeR3PreparedOwnerPopulation,
   prepareIrClassMethodBodies,
   prepareIrFreeFunctionBodies,
   selectR2PreparedFreeFunctions,
   selectR3PreparedPromiseDelayFunctions,
-  selectR3PreparedSuspendingAsyncFunctions,
   selectPreparedClassMethodNames,
   type PreparedIrClassMethodBodies,
   type PreparedIrFreeFunctionBodies,
@@ -3256,21 +3256,13 @@ function planIrFirstBodyRouting(
     // the IR program is prepared. The exact Promise-delay route also settles
     // its late runtime imports here, before any direct body can bake funcIdxs.
     prepareModuleTdzGlobals(ctx, sourceFile);
-    const preparedSelection = finalizePreparedIrSelection(ctx, sourceFile, plan);
+    let preparedSelection = finalizePreparedIrSelection(ctx, sourceFile, plan);
     finalizedSelection = preparedSelection;
     if ([...preliminaryR2Names].some((legacyName) => !preparedSelection.funcs.has(legacyName))) {
       throw new IrInvariantError(
         "selection-preparation-mismatch",
         "resolve",
         "R2 final-context preparation changed a preflight-certified free-function component",
-      );
-    }
-    const finalClassMethodNames = selectPreparedClassMethodNames(ctx, preparedSelection, plan.identityPlan);
-    if ([...preliminaryClassMethodNames].some((legacyName) => !finalClassMethodNames.has(legacyName))) {
-      throw new IrInvariantError(
-        "selection-preparation-mismatch",
-        "resolve",
-        "R3 final-context preparation changed a preflight-certified class-method component",
       );
     }
     const promiseDelayNames = selectR3PreparedPromiseDelayFunctions({
@@ -3282,19 +3274,21 @@ function planIrFirstBodyRouting(
       overridesByUnitId: plan.overrideMapByUnitId,
       promiseDelays: plan.promiseDelays,
     });
-    const suspendingAsyncNames = selectR3PreparedSuspendingAsyncFunctions({
+    const preparedPopulation = finalizeR3PreparedOwnerPopulation({
       ctx,
       sourceFile,
-      selectedLegacyNames: preparedSelection.funcs,
-      identityPlan: plan.identityPlan,
-      claimsByUnitId: plan.functionClaimsByUnitId,
-      overridesByUnitId: plan.overrideMapByUnitId,
-      suspendingAsyncUnitIds: plan.suspendingAsyncUnitIds,
-      preparedDependencyLegacyNames: new Set([...preliminaryR2Names, ...promiseDelayNames]),
+      plan,
+      selection: preparedSelection,
+      preliminaryClassMethodNames,
+      preliminaryR2Names,
+      promiseDelayNames,
       projectLoweringPlans: (selection) => irOverlayIdentity.projectIrIntegrationLoweringPlans(plan, selection),
     });
-    const preparedFreeFunctionNames = new Set([...preliminaryR2Names, ...promiseDelayNames, ...suspendingAsyncNames]);
-    if (preparedFreeFunctionNames.size === 0 && preliminaryClassMethodNames.size === 0) {
+    preparedSelection = preparedPopulation.selection;
+    finalizedSelection = preparedSelection;
+    const { classMethodNames: finalClassMethodNames, freeFunctionNames: preparedFreeFunctionNames } =
+      preparedPopulation;
+    if (preparedFreeFunctionNames.size === 0 && finalClassMethodNames.size === 0) {
       // Final-context Promise preparation may reject an occupied/mismatched
       // runtime ABI. Keep that owner on the established direct route.
     } else {
@@ -3315,7 +3309,7 @@ function planIrFirstBodyRouting(
       const preparedClassMethods = prepareIrClassMethodBodies({
         ctx,
         sourceFile,
-        selection: { classMembers: preliminaryClassMethodNames },
+        selection: { classMembers: finalClassMethodNames },
         identityPlan: plan.identityPlan,
         overrideMap: plan.overrideMap,
         classShapes: plan.classShapes,

--- a/src/codegen/ir-async-frame.ts
+++ b/src/codegen/ir-async-frame.ts
@@ -5,8 +5,11 @@ import { emitPreparedAsyncFrameStateMachine, type AsyncFrameInfo, type HostAsync
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { ERROR_FIELD, MODE_FIELD, PARAM_FIELD_OFFSET, SENT_FIELD, sanitizeTypeName } from "./frame-core.js";
 import type { AsyncHostCapabilityId } from "../ir/async-runtime-providers.js";
-import type { IrFuncRef, IrFunction } from "../ir/nodes.js";
+import { irTypeBindingKey } from "../ir/abi-bindings.js";
+import { asVal, type IrFuncRef, type IrFunction, type IrInstr, type IrType } from "../ir/nodes.js";
 import type { FieldDef, ValType, WasmFunction } from "../ir/types.js";
+import { coerceType } from "./shared.js";
+import { definedFuncAt } from "./func-space.js";
 
 export interface PreparedIrAsyncFrameResolver {
   resolveFunc(ref: IrFuncRef): number;
@@ -38,7 +41,18 @@ function preparedHostImports(fn: IrFunction, resolver: PreparedIrAsyncFrameResol
   };
 }
 
-function exactSingleAwaitCall(fn: IrFunction) {
+type IrCall = Extract<IrInstr, { readonly kind: "call" }>;
+
+interface ExactSingleAwaitCalls {
+  readonly entry: IrCall;
+  readonly continuation: {
+    readonly call: IrCall;
+    readonly paramType: IrType;
+    readonly resultType: IrType;
+  } | null;
+}
+
+function exactSingleAwaitCalls(fn: IrFunction): ExactSingleAwaitCalls {
   const plan = fn.asyncPlan;
   const runtime = fn.asyncRuntime;
   if (
@@ -66,15 +80,42 @@ function exactSingleAwaitCall(fn: IrFunction) {
     semanticEntry.terminator.rejected.kind !== "reject" ||
     semanticEntry.terminator.resume.state !== continuation.id ||
     continuation.resume?.source !== "fulfilled" ||
-    continuation.body.length !== 0 ||
     continuation.terminator.kind !== "resolve" ||
-    continuation.terminator.value !== continuation.resume.value ||
     entry.body[0].args.length !== fn.params.length ||
     entry.body[0].args.some((value, index) => value !== fn.params[index]!.value)
   ) {
     throw new Error(`IR async function ${fn.name} has a malformed single-await plan`);
   }
-  return entry.body[0];
+  const continuationCall =
+    continuation.body.length === 1 && continuation.body[0]?.kind === "call" ? continuation.body[0] : null;
+  const identityContinuation =
+    continuation.body.length === 0 && continuation.terminator.value === continuation.resume.value;
+  const calledContinuation =
+    continuationCall !== null &&
+    continuationCall.args.length === 1 &&
+    continuationCall.args[0] === continuation.resume.value &&
+    continuationCall.result !== null &&
+    continuationCall.resultType !== null &&
+    continuation.terminator.value === continuationCall.result;
+  if (!identityContinuation && !calledContinuation) {
+    throw new Error(`IR async function ${fn.name} has a malformed single-await continuation`);
+  }
+  let preparedContinuation: ExactSingleAwaitCalls["continuation"] = null;
+  if (continuationCall) {
+    const resultType = continuationCall.resultType;
+    if (resultType === null) {
+      throw new Error(`IR async function ${fn.name} has an untyped prepared continuation call`);
+    }
+    preparedContinuation = {
+      call: continuationCall,
+      paramType: continuation.resume.type,
+      resultType,
+    };
+  }
+  return {
+    entry: entry.body[0],
+    continuation: preparedContinuation,
+  };
 }
 
 function buildFrameInfo(
@@ -119,7 +160,76 @@ function buildFrameInfo(
   };
 }
 
-function preparedCfg(fn: IrFunction, helperFuncIdx: number): AsyncCfgPlan {
+interface PreparedContinuation {
+  readonly funcIdx: number;
+  readonly paramType: ValType;
+  readonly resultType: ValType;
+  readonly fromExternFuncIdx: number | null;
+}
+
+function sameValType(left: ValType, right: ValType): boolean {
+  if (left.kind !== right.kind) return false;
+  if ((left.kind === "ref" || left.kind === "ref_null") && (right.kind === "ref" || right.kind === "ref_null")) {
+    return left.typeIdx === right.typeIdx;
+  }
+  return true;
+}
+
+function preparedAsyncValueType(ctx: CodegenContext, fn: IrFunction, type: IrType): ValType {
+  const scalar = asVal(type);
+  if (scalar && scalar.kind !== "ref" && scalar.kind !== "ref_null") return scalar;
+  if (type.kind === "extern" || type.kind === "callable") return { kind: "externref" };
+  if (type.kind !== "vec") {
+    throw new Error(`IR async function ${fn.name} has unsupported continuation type ${type.kind}`);
+  }
+  const attachment = fn.asyncRuntime?.typeLayouts?.find((entry) => entry.logicalType === type);
+  const session = ctx.programAbiSession;
+  if (!attachment || !session) {
+    throw new Error(`IR async function ${fn.name} has no exact prepared layout for its continuation vector`);
+  }
+  return {
+    kind: type.nullable ? "ref_null" : "ref",
+    typeIdx: session.resolveCurrentIndex(
+      attachment.layout.carrierType.binding.bindingId,
+      "type",
+      irTypeBindingKey(attachment.layout.carrierType.binding),
+    ),
+  };
+}
+
+function preparedAsyncFromExternFuncIdx(
+  ctx: CodegenContext,
+  fn: IrFunction,
+  type: IrType,
+  paramType: ValType,
+  resolver: PreparedIrAsyncFrameResolver,
+): number | null {
+  if (type.kind !== "vec") return null;
+  const attachment = fn.asyncRuntime?.typeLayouts?.find((entry) => entry.logicalType === type);
+  if (!attachment?.fromExtern) throw new Error(`IR async function ${fn.name} has no sealed vector materializer`);
+  const funcIdx = resolver.resolveFunc(attachment.fromExtern);
+  const target = definedFuncAt(ctx, funcIdx);
+  const signature = target ? ctx.mod.types[target.typeIdx] : undefined;
+  if (
+    !target ||
+    !signature ||
+    signature.kind !== "func" ||
+    signature.params.length !== 1 ||
+    signature.params[0]?.kind !== "externref" ||
+    signature.results.length !== 1 ||
+    !sameValType(signature.results[0]!, paramType)
+  ) {
+    throw new Error(`IR async function ${fn.name} has a malformed sealed vector materializer ABI`);
+  }
+  return funcIdx;
+}
+
+function preparedCfg(
+  fn: IrFunction,
+  helperFuncIdx: number,
+  continuation: PreparedContinuation | null,
+  info: AsyncFrameInfo,
+): AsyncCfgPlan {
   return {
     handlers: [],
     states: [
@@ -148,6 +258,25 @@ function preparedCfg(fn: IrFunction, helperFuncIdx: number): AsyncCfgPlan {
         id: 1,
         resumeFrom: { binding: null, handler: 0 },
         lead: [],
+        ...(continuation
+          ? {
+              emit: (ctx: CodegenContext, fctx: FunctionContext): void => {
+                const frameLocal = fctx.localMap.get("__frame");
+                if (frameLocal === undefined) throw new Error(`IR async frame ${fn.name} lost its frame parameter`);
+                fctx.body.push({ op: "local.get", index: frameLocal });
+                fctx.body.push({ op: "local.get", index: frameLocal });
+                fctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD });
+                if (continuation.fromExternFuncIdx === null) {
+                  coerceType(ctx, fctx, { kind: "externref" }, continuation.paramType);
+                } else {
+                  fctx.body.push({ op: "call", funcIdx: continuation.fromExternFuncIdx });
+                }
+                fctx.body.push({ op: "call", funcIdx: continuation.funcIdx });
+                coerceType(ctx, fctx, continuation.resultType, { kind: "externref" });
+                fctx.body.push({ op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD });
+              },
+            }
+          : {}),
         terminator: { kind: "settleSent" },
       },
     ],
@@ -171,8 +300,8 @@ export function lowerPreparedIrAsyncFunction(
   ) {
     throw new Error(`IR async function ${fn.name} does not match its Promise-returning allocated ABI`);
   }
-  const helper = exactSingleAwaitCall(fn);
-  const helperFuncIdx = resolver.resolveFunc(helper.target);
+  const calls = exactSingleAwaitCalls(fn);
+  const helperFuncIdx = resolver.resolveFunc(calls.entry.target);
   const params = fn.params.map((param, index) => ({
     name: param.name ?? `p${index}`,
     type: signature.params[index]!,
@@ -191,10 +320,37 @@ export function lowerPreparedIrAsyncFunction(
     savedBodies: [],
   };
   const info = buildFrameInfo(ctx, fn, params, preparedHostImports(fn, resolver));
+  const continuation = calls.continuation
+    ? (() => {
+        const funcIdx = resolver.resolveFunc(calls.continuation.call.target);
+        const target = definedFuncAt(ctx, funcIdx);
+        const targetType = target ? ctx.mod.types[target.typeIdx] : undefined;
+        if (
+          !target ||
+          !targetType ||
+          targetType.kind !== "func" ||
+          targetType.params.length !== 1 ||
+          targetType.results.length !== 1
+        ) {
+          throw new Error(`IR async function ${fn.name} has a malformed prepared continuation callable ABI`);
+        }
+        const paramType = preparedAsyncValueType(ctx, fn, calls.continuation.paramType);
+        const resultType = preparedAsyncValueType(ctx, fn, calls.continuation.resultType);
+        if (!sameValType(targetType.params[0]!, paramType) || !sameValType(targetType.results[0]!, resultType)) {
+          throw new Error(`IR async function ${fn.name} continuation layout disagrees with its callable ABI`);
+        }
+        return {
+          funcIdx,
+          paramType,
+          resultType,
+          fromExternFuncIdx: preparedAsyncFromExternFuncIdx(ctx, fn, calls.continuation.paramType, paramType, resolver),
+        };
+      })()
+    : null;
   const previous = ctx.currentFunc;
   ctx.currentFunc = fctx;
   try {
-    emitPreparedAsyncFrameStateMachine(ctx, fctx, info, preparedCfg(fn, helperFuncIdx));
+    emitPreparedAsyncFrameStateMachine(ctx, fctx, info, preparedCfg(fn, helperFuncIdx, continuation, info));
   } finally {
     ctx.currentFunc = previous;
   }

--- a/src/codegen/ir-overlay-identity.ts
+++ b/src/codegen/ir-overlay-identity.ts
@@ -316,7 +316,12 @@ export function projectIrIntegrationLoweringPlans(
     const declaration = plan.identityPlan.identityContext.declarationByUnitId.get(unitId);
     if (!declaration) continue;
     for (const [call, directCall] of collectIrDirectCallLoweringPlans(declaration, unitId, directCallTargets)) {
-      if (!directCalls.has(call)) directCalls.set(call, directCall);
+      // The projected callable ABI is authoritative for every exact active
+      // source edge. In particular, a prepared suspending async target keeps
+      // its numeric fulfillment type in `signaturesByUnitId`, while calls to
+      // its source slot observe the Promise-returning externref ABI. A stale
+      // pre-projection plan would otherwise unbox that Promise as a number.
+      directCalls.set(call, directCall);
     }
   }
   return {

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -15,9 +15,12 @@ import type { IrSelection } from "../ir/select.js";
 import type { ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import type { CodegenContext } from "./context/types.js";
+import { preparedIrAsyncSourceCanSuspend, preparedIrAsyncSourceShape } from "./async-ir-planning.js";
 import { getOrRegisterVecType } from "./registry/types.js";
 import { collectLocalCallEdgesByIdentity } from "./ir-first-gate.js";
 import * as irOverlayIdentity from "./ir-overlay-identity.js";
+import { closeIrBlockedComponentByIdentity } from "./ir-overlay-finalize.js";
+import { applyIrFinalContextFunctionUnitIds, type IrOverlayPreparationPlan } from "./ir-overlay-preparation.js";
 import {
   buildIrRequestedFunctionSkipProjection,
   computeIrFirstSkipUnitIds,
@@ -422,14 +425,23 @@ function r3PromiseDelaySignatureMatchesAllocatedSlot(
   );
 }
 
-/** Exact #4106 numeric fulfillment ABI projected onto a Promise callable slot. */
+function r3SuspendingAsyncParamValType(ctx: CodegenContext, type: IrType): ValType | undefined {
+  const scalar = asVal(type);
+  if (scalar?.kind === "f64") return scalar;
+  if (type.kind !== "vec" || asVal(type.elementType)?.kind !== "f64") return undefined;
+  const vecTypeIdx = ctx.vecTypeMap.get("f64");
+  return vecTypeIdx === undefined ? undefined : { kind: type.nullable ? "ref_null" : "ref", typeIdx: vecTypeIdx };
+}
+
+/** Exact numeric fulfillment ABI projected onto a Promise callable slot. */
 function r3SuspendingAsyncSignatureMatchesAllocatedSlot(
   ctx: CodegenContext,
   unitId: IrUnitId,
   override: { readonly params: readonly IrType[]; readonly returnType: IrType | null },
 ): boolean {
+  const params = override.params.map((type) => r3SuspendingAsyncParamValType(ctx, type));
   if (
-    override.params.some((type) => asVal(type)?.kind !== "f64") ||
+    params.some((type) => type === undefined) ||
     override.returnType === null ||
     asVal(override.returnType)?.kind !== "f64"
   ) {
@@ -440,7 +452,7 @@ function r3SuspendingAsyncSignatureMatchesAllocatedSlot(
   return (
     signature?.kind === "func" &&
     signature.params.length === override.params.length &&
-    signature.params.every((type) => type.kind === "f64") &&
+    signature.params.every((type, index) => sameValType(type, params[index]!)) &&
     signature.results.length === 1 &&
     signature.results[0]?.kind === "externref"
   );
@@ -532,61 +544,160 @@ export function selectR3PreparedSuspendingAsyncFunctions(input: {
 }): ReadonlySet<string> {
   const functionUnitsByName = topLevelFunctionUnitsByName(input.sourceFile, input.identityPlan);
   const functionValueTargets = collectTopLevelFunctionValueTargets(input.sourceFile, functionUnitsByName);
-  const dependencySelection: IrSelection = {
-    funcs: new Set(input.preparedDependencyLegacyNames),
-    classMembers: new Set(),
-    moduleInit: undefined,
-  };
-  const preparedDependencyUnitIds = new Set(
-    input.projectLoweringPlans(dependencySelection).ownerProjection.entries.map(({ unitId }) => unitId),
-  );
+  const callEdges = collectLocalCallEdgesByIdentity(input.sourceFile, input.identityPlan.identityContext);
   const selected = new Set<string>();
-  for (const legacyName of input.selectedLegacyNames) {
-    const unitId = irOverlayIdentity.requireIrOverlayFunctionUnitId(input.identityPlan, legacyName);
-    if (!input.suspendingAsyncUnitIds.has(unitId)) continue;
-    const claim = input.claimsByUnitId.get(unitId);
-    const override = input.overridesByUnitId.get(unitId);
-    if (!claim || !override) {
-      throw new IrInvariantError(
-        "selection-preparation-mismatch",
-        "resolve",
-        `R3 suspending async candidate ${unitId} / ${legacyName} has no exact claim/signature`,
+  const prepared = new Set(input.preparedDependencyLegacyNames);
+  for (let changed = true; changed; ) {
+    changed = false;
+    const additions: string[] = [];
+    const dependencySelection: IrSelection = {
+      funcs: new Set(prepared),
+      classMembers: new Set(),
+      moduleInit: undefined,
+    };
+    const preparedDependencyUnitIds = new Set(
+      [...prepared].map((legacyName) =>
+        irOverlayIdentity.requireIrOverlayFunctionUnitId(input.identityPlan, legacyName),
+      ),
+    );
+    for (const legacyName of input.selectedLegacyNames) {
+      if (selected.has(legacyName)) continue;
+      const unitId = irOverlayIdentity.requireIrOverlayFunctionUnitId(input.identityPlan, legacyName);
+      if (!input.suspendingAsyncUnitIds.has(unitId)) continue;
+      const claim = input.claimsByUnitId.get(unitId);
+      const override = input.overridesByUnitId.get(unitId);
+      if (!claim || !override) {
+        throw new IrInvariantError(
+          "selection-preparation-mismatch",
+          "resolve",
+          `R3 suspending async candidate ${unitId} / ${legacyName} has no exact claim/signature`,
+        );
+      }
+      if (
+        containsNestedExecutableSyntax(claim.declaration) ||
+        functionValueTargets.has(unitId) ||
+        containsTopLevelFunctionValueReference(claim.declaration, functionUnitsByName) ||
+        !r3SuspendingAsyncSignatureMatchesAllocatedSlot(input.ctx, unitId, override)
+      ) {
+        continue;
+      }
+      const sourceShape = preparedIrAsyncSourceShape(input.ctx, claim.declaration);
+      if (!sourceShape || !preparedIrAsyncSourceCanSuspend(input.ctx, claim.declaration)) continue;
+      const sourceCallees = callEdges.callees.get(unitId) ?? new Set<IrUnitId>();
+      if ([...sourceCallees].some((calleeUnitId) => !preparedDependencyUnitIds.has(calleeUnitId))) continue;
+      const candidatePlans = input.projectLoweringPlans({
+        ...dependencySelection,
+        funcs: new Set([...dependencySelection.funcs, legacyName]),
+      });
+      const unitCalls = [...candidatePlans.directCalls.values()].filter(
+        (call) => call.ownerUnitId === unitId && call.target.binding.kind === "unit",
       );
+      if (
+        unitCalls.some(
+          (call) => call.target.binding.kind !== "unit" || !preparedDependencyUnitIds.has(call.target.binding.unitId),
+        )
+      ) {
+        continue;
+      }
+      if (sourceShape.kind === "identity") {
+        const awaitedCall = candidatePlans.directCalls.get(sourceShape.awaitedCall);
+        if (
+          awaitedCall?.ownerUnitId !== unitId ||
+          awaitedCall.target.binding.kind !== "unit" ||
+          !preparedDependencyUnitIds.has(awaitedCall.target.binding.unitId)
+        ) {
+          continue;
+        }
+      } else if (unitCalls.length === 0) {
+        continue;
+      }
+      additions.push(legacyName);
     }
-    if (
-      containsNestedExecutableSyntax(claim.declaration) ||
-      functionValueTargets.has(unitId) ||
-      containsTopLevelFunctionValueReference(claim.declaration, functionUnitsByName) ||
-      !r3SuspendingAsyncSignatureMatchesAllocatedSlot(input.ctx, unitId, override)
-    ) {
-      continue;
+    for (const legacyName of additions) {
+      selected.add(legacyName);
+      prepared.add(legacyName);
+      changed = true;
     }
-    const declarationStatement = claim.declaration.body?.statements[0];
-    const declaration =
-      declarationStatement && ts.isVariableStatement(declarationStatement)
-        ? declarationStatement.declarationList.declarations[0]
-        : undefined;
-    const awaited = declaration?.initializer;
-    const awaitedCall =
-      awaited && ts.isAwaitExpression(awaited) && ts.isCallExpression(awaited.expression)
-        ? awaited.expression
-        : undefined;
-    if (!awaitedCall) continue;
-    const candidatePlans = input.projectLoweringPlans({
-      ...dependencySelection,
-      funcs: new Set([...dependencySelection.funcs, legacyName]),
-    });
-    const directCall = candidatePlans.directCalls.get(awaitedCall);
-    if (
-      directCall?.ownerUnitId !== unitId ||
-      directCall.target.binding.kind !== "unit" ||
-      !preparedDependencyUnitIds.has(directCall.target.binding.unitId)
-    ) {
-      continue;
-    }
-    selected.add(legacyName);
   }
   return selected;
+}
+
+/** Reconcile the final async fixed point with whole-source IR ownership. */
+export function finalizeR3PreparedOwnerPopulation(input: {
+  readonly ctx: CodegenContext;
+  readonly sourceFile: ts.SourceFile;
+  readonly plan: IrOverlayPreparationPlan & {
+    readonly suspendingAsyncUnitIds: ReadonlySet<IrUnitId>;
+    readonly functionClaimsByUnitId: ReadonlyMap<IrUnitId, IrExactFunctionClaim>;
+    readonly overrideMapByUnitId: ReadonlyMap<
+      IrUnitId,
+      { readonly params: readonly IrType[]; readonly returnType: IrType | null }
+    >;
+  };
+  readonly selection: IrSelection;
+  readonly preliminaryClassMethodNames: ReadonlySet<string>;
+  readonly preliminaryR2Names: ReadonlySet<string>;
+  readonly promiseDelayNames: ReadonlySet<string>;
+  readonly projectLoweringPlans: (selection: IrSelection) => IrIntegrationLoweringPlans;
+}): {
+  readonly selection: IrSelection;
+  readonly classMethodNames: ReadonlySet<string>;
+  readonly freeFunctionNames: ReadonlySet<string>;
+} {
+  let selection = input.selection;
+  let classMethodNames = selectPreparedClassMethodNames(input.ctx, selection, input.plan.identityPlan);
+  if ([...input.preliminaryClassMethodNames].some((name) => !classMethodNames.has(name))) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "resolve",
+      "R3 final-context preparation changed a preflight-certified class-method component",
+    );
+  }
+
+  let suspendingAsyncNames = selectR3PreparedSuspendingAsyncFunctions({
+    ctx: input.ctx,
+    sourceFile: input.sourceFile,
+    selectedLegacyNames: selection.funcs,
+    identityPlan: input.plan.identityPlan,
+    claimsByUnitId: input.plan.functionClaimsByUnitId,
+    overridesByUnitId: input.plan.overrideMapByUnitId,
+    suspendingAsyncUnitIds: input.plan.suspendingAsyncUnitIds,
+    preparedDependencyLegacyNames: new Set([...input.preliminaryR2Names, ...input.promiseDelayNames]),
+    projectLoweringPlans: input.projectLoweringPlans,
+  });
+  const rejectedUnitIds = new Set(
+    [...input.plan.suspendingAsyncUnitIds].filter((unitId) => {
+      const claim = input.plan.functionClaimsByUnitId.get(unitId);
+      if (!claim) {
+        throw new IrInvariantError(
+          "selection-preparation-mismatch",
+          "resolve",
+          `R3 suspending async candidate ${unitId} has no exact function claim`,
+        );
+      }
+      return !suspendingAsyncNames.has(claim.legacyName);
+    }),
+  );
+  if (rejectedUnitIds.size > 0) {
+    const retainedUnitIds = closeIrBlockedComponentByIdentity(
+      input.sourceFile,
+      input.plan.identityPlan.identityContext,
+      input.plan.identityPlan.safeFunctionUnitIds,
+      rejectedUnitIds,
+    );
+    selection = applyIrFinalContextFunctionUnitIds(input.plan, selection, retainedUnitIds);
+    classMethodNames = selectPreparedClassMethodNames(input.ctx, selection, input.plan.identityPlan);
+    suspendingAsyncNames = new Set([...suspendingAsyncNames].filter((name) => selection.funcs.has(name)));
+  }
+  return {
+    selection,
+    classMethodNames,
+    freeFunctionNames: new Set(
+      [...input.preliminaryR2Names, ...input.promiseDelayNames, ...suspendingAsyncNames].filter((name) =>
+        selection.funcs.has(name),
+      ),
+    ),
+  };
 }
 
 /**

--- a/src/codegen/program-abi-type-planning.ts
+++ b/src/codegen/program-abi-type-planning.ts
@@ -182,6 +182,8 @@ function vectorLogicalOrdinal(logicalKey: string): number {
       return 0;
     case "vec<i32>":
       return 1;
+    case "vec<externref>":
+      return 2;
     default:
       throw new ProgramAbiInvariantError(
         "unknown-order-anchor",

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -92,6 +92,30 @@ const VEC_HOST_BRIDGE_DEFINITIONS: readonly VecHostBridgeDefinition[] = Object.f
   }),
 ]);
 
+export type VecHostBridgeMaterializerElementKind = "f64" | "i32" | "externref";
+
+const VEC_HOST_BRIDGE_MATERIALIZER_ORDINALS: Readonly<Record<VecHostBridgeMaterializerElementKind, number>> = (() => {
+  for (const [index, definition] of VEC_HOST_BRIDGE_DEFINITIONS.entries()) {
+    if (definition.ordinal !== index) {
+      throw new Error(`vec host bridge ${definition.kind} has non-contiguous ordinal ${definition.ordinal}`);
+    }
+  }
+  const firstMaterializerOrdinal = VEC_HOST_BRIDGE_DEFINITIONS.length;
+  if (firstMaterializerOrdinal !== 6) {
+    throw new Error(`vec host bridge materializer ABI must start at ordinal 6, got ${firstMaterializerOrdinal}`);
+  }
+  return Object.freeze({
+    f64: firstMaterializerOrdinal,
+    i32: firstMaterializerOrdinal + 1,
+    externref: firstMaterializerOrdinal + 2,
+  });
+})();
+
+/** Program ABI derived ordinal for the host-to-vec materializer family. */
+export function vecHostBridgeMaterializerOrdinal(kind: VecHostBridgeMaterializerElementKind): number {
+  return VEC_HOST_BRIDGE_MATERIALIZER_ORDINALS[kind];
+}
+
 const vecHostBridgeAllocations = new WeakMap<CodegenContext, ReadonlyMap<VecHostBridgeKind, VecHostBridgeAllocation>>();
 
 function vecHostBridgeDefinition(kind: VecHostBridgeKind): VecHostBridgeDefinition {

--- a/src/ir/array-element-lowering.ts
+++ b/src/ir/array-element-lowering.ts
@@ -26,6 +26,7 @@ interface ArrayElementResolver {
   resolveVecForElement?(elementValType: ValType): IrVecLowering | null;
   resolveVecOutOfBoundsConst?(elementValType: ValType): IrConst | null;
   isVecValueExpression?(expression: ts.Expression): boolean;
+  preparedAsyncPromiseVectorLocal?(declaration: ts.VariableDeclaration): boolean;
 }
 
 /**
@@ -300,6 +301,24 @@ export function emptyLiteralElementValType(initializer: ts.Expression, host: Arr
   if (inference?.kind !== "resolved" || !inference.int32Narrowed) return f64;
   const i32: ValType = { kind: "i32" };
   return host.resolver?.resolveVecForElement?.(i32) ? i32 : f64;
+}
+
+/** Resolve an explicitly annotated empty-array representation. */
+export function annotatedArrayElementValType(
+  declaration: ts.VariableDeclaration,
+  host: ArrayElementLoweringHost,
+): ValType {
+  const type = declaration.type;
+  if (!type || !ts.isArrayTypeNode(type)) {
+    throw new Error(`ir/from-ast: annotated array '${declaration.name.getText()}' lost its array type`);
+  }
+  if (type.elementType.kind === ts.SyntaxKind.NumberKeyword) {
+    return emptyLiteralElementValType(declaration.initializer!, host);
+  }
+  if (host.resolver?.preparedAsyncPromiseVectorLocal?.(declaration) === true) return { kind: "externref" };
+  throw new Error(
+    `ir/from-ast: array annotation on '${declaration.name.getText()}' must be number[] or a certified async vector`,
+  );
 }
 
 /**

--- a/src/ir/async-from-ast.ts
+++ b/src/ir/async-from-ast.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import type { IrFunctionBuilder } from "./builder.js";
+import { irVal, type IrFuncRef, type IrType, type IrValueId } from "./nodes.js";
+import { coerceIrValueToExternref } from "./value-coercion.js";
+
+export interface PreparedAsyncPromiseAllPlan {
+  readonly target: IrFuncRef;
+  readonly resultType: IrType;
+}
+
+/** Prepared-async evidence consumed by AST-to-IR lowering. */
+export interface PreparedAsyncFromAstResolver {
+  readonly preparedAsyncPromiseVectorLocal?: (declaration: ts.VariableDeclaration) => boolean;
+  readonly preparedAsyncPromiseAllPlan?: (call: ts.CallExpression) => PreparedAsyncPromiseAllPlan | null;
+}
+
+/** Resume type for an awaited prepared combinator, if the exact call is owned. */
+export function preparedAsyncAwaitResultType(
+  expression: ts.Expression,
+  resolver: PreparedAsyncFromAstResolver | undefined,
+): IrType | undefined {
+  return ts.isCallExpression(expression) ? resolver?.preparedAsyncPromiseAllPlan?.(expression)?.resultType : undefined;
+}
+
+/** Lower the exact prepared Promise.all provider boundary or decline it. */
+export function tryLowerPreparedAsyncPromiseAll(input: {
+  readonly expression: ts.CallExpression;
+  readonly statementPosition: boolean;
+  readonly resolver: PreparedAsyncFromAstResolver | undefined;
+  readonly builder: IrFunctionBuilder;
+  readonly functionName: string;
+  readonly lowerExpression: (expression: ts.Expression, expected: IrType) => IrValueId;
+}): IrValueId | undefined {
+  const plan = input.resolver?.preparedAsyncPromiseAllPlan?.(input.expression);
+  if (!plan) return undefined;
+  if (
+    input.statementPosition ||
+    input.expression.arguments.length !== 1 ||
+    ts.isSpreadElement(input.expression.arguments[0]!)
+  ) {
+    throw new Error(`ir/from-ast: prepared Promise.all call shape diverged in ${input.functionName}`);
+  }
+
+  const externref = irVal({ kind: "externref" });
+  const thisArg = input.builder.emitConst({ kind: "null", ty: externref }, externref);
+  const iterable = coerceIrValueToExternref(
+    input.builder,
+    input.lowerExpression(input.expression.arguments[0]!, externref),
+  );
+  const directCall = input.builder.emitConst({ kind: "i32", value: 1 }, irVal({ kind: "i32" }));
+  const result = input.builder.emitCall(plan.target, [thisArg, iterable, directCall], externref);
+  if (result === null)
+    throw new Error(`ir/from-ast: prepared Promise.all provider returned void in ${input.functionName}`);
+  return result;
+}

--- a/src/ir/async-plan.ts
+++ b/src/ir/async-plan.ts
@@ -28,6 +28,7 @@ import {
   type IrFuncRef,
   type IrInstr,
   type IrType,
+  type IrVecLayoutRef,
   type IrValueId,
 } from "./nodes.js";
 
@@ -181,6 +182,13 @@ export interface PreparedIrAsyncHostAdapter {
 export interface PreparedIrAsyncRuntime {
   readonly kind: "host-wasmgc";
   readonly adapters: readonly PreparedIrAsyncHostAdapter[];
+  /** Backend-only layouts keyed by the exact logical types in `asyncPlan`. */
+  readonly typeLayouts?: readonly {
+    readonly logicalType: IrType;
+    readonly layout: IrVecLayoutRef;
+    /** Present only for a host-fulfilled resume value that crosses representations. */
+    readonly fromExtern?: IrFuncRef;
+  }[];
   /** State bodies with post-freeze intrinsic provider attachments. */
   readonly states: readonly IrAsyncState[];
 }

--- a/src/ir/async-prepare.ts
+++ b/src/ir/async-prepare.ts
@@ -8,8 +8,10 @@ import { createDerivedIrUnitId, type IrDerivedUnitProvenance } from "./identity.
 import {
   asBlockId,
   asValueId,
+  forEachInstrDeep,
   irTypeEquals,
   irVal,
+  mapNestedBuffers,
   type IrFunction,
   type IrInstr,
   type IrType,
@@ -70,13 +72,41 @@ function valueTypesOf(fn: IrFunction): Map<IrValueId, IrType> {
   return types;
 }
 
-function maxValueId(params: IrFunction["params"], instrs: readonly IrInstr[], returned: IrValueId): number {
-  let maximum = Number(returned);
-  for (const param of params) maximum = Math.max(maximum, Number(param.value));
+function usedSlotIndices(instrs: readonly IrInstr[]): ReadonlySet<number> {
+  const used = new Set<number>();
   for (const instr of instrs) {
-    if (instr.result !== null) maximum = Math.max(maximum, Number(instr.result));
+    forEachInstrDeep(instr, (nested) => {
+      if (nested.kind === "slot.read" || nested.kind === "slot.write") used.add(nested.slotIndex);
+    });
   }
-  return maximum;
+  return used;
+}
+
+function remapUsedSlots(
+  fn: IrFunction,
+  instrs: readonly IrInstr[],
+  used = usedSlotIndices(instrs),
+): { readonly instrs: readonly IrInstr[]; readonly slots?: IrFunction["slots"] } {
+  if (used.size === 0) return { instrs };
+  const oldIndices = [...used].sort((left, right) => left - right);
+  const remap = new Map(oldIndices.map((oldIndex, newIndex) => [oldIndex, newIndex] as const));
+  const slots = oldIndices.map((oldIndex, newIndex) => {
+    const slot = fn.slots?.[oldIndex];
+    if (!slot || slot.index !== oldIndex) {
+      throw new Error(`IR async function ${fn.name} lost slot ${oldIndex} while splitting its suspension`);
+    }
+    return { ...slot, index: newIndex };
+  });
+  const mapInstr = (instr: IrInstr): IrInstr => {
+    const nested = mapNestedBuffers(instr, (buffer) => buffer.map(mapInstr));
+    if (nested.kind !== "slot.read" && nested.kind !== "slot.write") return nested;
+    const slotIndex = remap.get(nested.slotIndex);
+    if (slotIndex === undefined) {
+      throw new Error(`IR async function ${fn.name} could not remap slot ${nested.slotIndex}`);
+    }
+    return { ...nested, slotIndex };
+  };
+  return { instrs: instrs.map(mapInstr), slots };
 }
 
 /**
@@ -115,7 +145,17 @@ export function prepareSingleAwaitIrFunction(fn: IrFunction): PreparedSingleAwai
   const role = "ir-async-state" as const;
   const stateUnitId = createDerivedIrUnitId({ parentId: fn.unitId, role, ordinal: 0 });
   const stateName = `${fn.name}__ir_async_state_0`;
-  const prefix = block.instrs.slice(0, awaitIndex);
+  const prefixInstrs = block.instrs.slice(0, awaitIndex);
+  const suffixInstrs = block.instrs.slice(awaitIndex + 1);
+  const prefixSlots = usedSlotIndices(prefixInstrs);
+  const suffixSlots = usedSlotIndices(suffixInstrs);
+  if ([...prefixSlots].some((slotIndex) => suffixSlots.has(slotIndex))) {
+    // The first prepared frame contract has no spills. Independently reject a
+    // mutable local whose slot would otherwise be cloned into unrelated entry
+    // and continuation helpers and silently lose its pre-await value.
+    return null;
+  }
+  const prefix = remapUsedSlots(fn, prefixInstrs, prefixSlots);
   const entryFunction: IrFunction = {
     unitId: stateUnitId,
     name: stateName,
@@ -126,19 +166,20 @@ export function prepareSingleAwaitIrFunction(fn: IrFunction): PreparedSingleAwai
         id: asBlockId(0),
         blockArgs: [],
         blockArgTypes: [],
-        instrs: prefix,
+        instrs: prefix.instrs,
         terminator: { kind: "return", values: [awaited.operand] },
       },
     ],
     exported: false,
-    valueCount: maxValueId(fn.params, prefix, awaited.operand) + 1,
+    valueCount: fn.valueCount,
+    ...(prefix.slots ? { slots: prefix.slots } : {}),
     funcKind: "regular",
   };
 
-  const suffix = block.instrs.slice(awaitIndex + 1);
+  const suffix = remapUsedSlots(fn, suffixInstrs, suffixSlots);
   const returned = block.terminator.values[0]!;
   const fulfillmentType = fn.resultTypes[0]!;
-  const carrierUnbox = suffix.length === 1 ? suffix[0] : undefined;
+  const carrierUnbox = suffix.instrs.length === 1 ? suffix.instrs[0] : undefined;
   const elidesNumericCarrierRoundTrip =
     carrierUnbox?.kind === "call" &&
     carrierUnbox.target.name === "__unbox_number" &&
@@ -151,7 +192,7 @@ export function prepareSingleAwaitIrFunction(fn: IrFunction): PreparedSingleAwai
     carrierUnbox.resultType !== null &&
     irTypeEquals(carrierUnbox.resultType, fulfillmentType);
   const directIdentity =
-    suffix.length === 0 && returned === awaited.result && irTypeEquals(awaited.resultType, fulfillmentType);
+    suffix.instrs.length === 0 && returned === awaited.result && irTypeEquals(awaited.resultType, fulfillmentType);
   const identityContinuation = directIdentity || elidesNumericCarrierRoundTrip;
   // The frame carrier delivers an externref, but the canonical Promise ABI
   // already represents its fulfillment as T. Avoid the direct backend's
@@ -172,12 +213,13 @@ export function prepareSingleAwaitIrFunction(fn: IrFunction): PreparedSingleAwai
             id: asBlockId(0),
             blockArgs: [],
             blockArgTypes: [],
-            instrs: suffix,
+            instrs: suffix.instrs,
             terminator: { kind: "return", values: [returned] },
           },
         ],
         exported: false,
-        valueCount: maxValueId([{ name: "__resumed", type: resumedType, value: awaited.result }], suffix, returned) + 1,
+        valueCount: fn.valueCount,
+        ...(suffix.slots ? { slots: suffix.slots } : {}),
         funcKind: "regular",
       }
     : null;
@@ -243,6 +285,16 @@ export function prepareSingleAwaitIrFunction(fn: IrFunction): PreparedSingleAwai
   return {
     main: {
       ...fn,
+      blocks: [
+        {
+          id: block.id,
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [],
+          terminator: { kind: "unreachable" },
+        },
+      ],
+      slots: undefined,
       asyncPlan,
     },
     stateFunctions: continuationFunction ? [entryFunction, continuationFunction] : [entryFunction],

--- a/src/ir/async-selection.ts
+++ b/src/ir/async-selection.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+
+/** Async-specific selector evidence supplied by the codegen preparation layer. */
+export interface IrAsyncSelectionOptions {
+  /** Enables the shared CPS/IR async producer for this backend. */
+  readonly supportsAsyncIr?: boolean;
+  /** Authoritative verdict from the single converged async engine. */
+  readonly asyncEngineClaims?: (fn: ts.FunctionLikeDeclaration) => boolean;
+  /** Exact producer proof for a real suspension represented by IrAsyncPlan. */
+  readonly canPrepareSuspendingAsync?: (fn: ts.FunctionLikeDeclaration) => boolean;
+  /** True when shared analysis finds at least one non-static await. */
+  readonly asyncHasRealSuspension?: (fn: ts.FunctionLikeDeclaration) => boolean;
+  /** Exact Promise<number>[] pending-vector representation proof. */
+  readonly preparedAsyncPromiseVectorLocal?: (declaration: ts.VariableDeclaration) => boolean;
+  /** Exact pending-Promise producer call owned by a prepared prefix. */
+  readonly preparedAsyncThenableCall?: (call: ts.CallExpression) => boolean;
+  /** Exact awaited Promise.all call owned by a prepared continuation. */
+  readonly preparedAsyncPromiseAllCall?: (call: ts.CallExpression) => boolean;
+}
+
+/** Central async ownership gate shared by production selection and tests. */
+export function isAsyncIrReady(options: IrAsyncSelectionOptions | undefined, fn: ts.FunctionLikeDeclaration): boolean {
+  if (!options?.supportsAsyncIr || !ts.isFunctionDeclaration(fn) || fn.asteriskToken || !fn.body) return false;
+  if (options.asyncEngineClaims === undefined) return false;
+  if (options.asyncEngineClaims(fn)) return options.canPrepareSuspendingAsync?.(fn) === true;
+  if (options.asyncHasRealSuspension?.(fn) === true) return options.canPrepareSuspendingAsync?.(fn) === true;
+  return !bodyHasAsyncOutOfIrScope(fn.body);
+}
+
+/** Return the certified Promise.all arguments, excluding spread shapes. */
+export function preparedAsyncPromiseAllArguments(
+  expression: ts.Expression,
+  options: IrAsyncSelectionOptions | undefined,
+): readonly ts.Expression[] | null {
+  if (
+    !ts.isCallExpression(expression) ||
+    options?.preparedAsyncPromiseAllCall?.(expression) !== true ||
+    expression.arguments.some(ts.isSpreadElement)
+  ) {
+    return null;
+  }
+  return expression.arguments;
+}
+
+/** Reject unawaited async calls unless the prepared prefix owns the exact site. */
+export function isUnpreparedAsyncCallee(
+  call: ts.CallExpression,
+  scope: ReadonlySet<string>,
+  asyncNames: ReadonlySet<string>,
+  options: IrAsyncSelectionOptions | undefined,
+): boolean {
+  return (
+    ts.isIdentifier(call.expression) &&
+    asyncNames.has(call.expression.text) &&
+    !scope.has(call.expression.text) &&
+    options?.preparedAsyncThenableCall?.(call) !== true
+  );
+}
+
+function bodyHasAsyncOutOfIrScope(body: ts.Node): boolean {
+  let found = false;
+  const walk = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isForOfStatement(node) && node.awaitModifier) {
+      found = true;
+      return;
+    }
+    if (
+      (ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node)) &&
+      node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, walk);
+  };
+  ts.forEachChild(body, walk);
+  return found;
+}

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -1266,11 +1266,10 @@ export class IrFunctionBuilder {
    * operand through — see lower.ts `case "await"`). Only valid inside
    * `funcKind === "async"` functions.
    */
-  emitAwait(operand: IrValueId): IrValueId {
+  emitAwait(operand: IrValueId, resultType: IrType = { kind: "val", val: { kind: "externref" } }): IrValueId {
     if (this.funcKind !== "async") {
       throw new Error(`IrFunctionBuilder: emitAwait requires funcKind=async (${this.id.name})`);
     }
-    const resultType: IrType = { kind: "val", val: { kind: "externref" } };
     const result = this.allocator.fresh();
     this.valueTypes.set(result, resultType);
     this.pushInstr({ kind: "await", operand, result, resultType });

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -109,6 +109,7 @@ import {
   inferEmptyArrayElementTypes,
 } from "./array-element-inference.js";
 import {
+  annotatedArrayElementValType,
   canonicalCountedPushPlanForLiteral,
   emitForwardingAwareLinearVecLen,
   emitSafeNarrowedI32VecGet,
@@ -119,6 +120,11 @@ import {
   planI32ArrayElements,
   tryLowerVecPush,
 } from "./array-element-lowering.js";
+import {
+  preparedAsyncAwaitResultType,
+  tryLowerPreparedAsyncPromiseAll,
+  type PreparedAsyncFromAstResolver,
+} from "./async-from-ast.js";
 import {
   assertNotDeferred,
   binaryOpCapability,
@@ -177,6 +183,7 @@ import {
   type IrValueId,
 } from "./nodes.js";
 import type { ValType } from "./types.js";
+import { coerceIrValueToExternref } from "./value-coercion.js";
 import { irVecElemSetSymbol, irVecNewSizedSymbol } from "./vector-runtime.js";
 
 interface ResolvedIrVecType {
@@ -295,7 +302,7 @@ export interface IrExternClassMeta {
  * `resolveClosure`. Those depend on registries that aren't populated
  * until Phase 3, so from-ast doesn't see them.
  */
-export interface IrFromAstResolver {
+export interface IrFromAstResolver extends PreparedAsyncFromAstResolver {
   /**
    * Resolve the canonical host ToPropertyDescriptor entry point for an
    * ambient `Object.defineProperty(target, key, descriptor)` call.
@@ -1684,7 +1691,7 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
         if (valTy?.kind === "f64" || valTy?.kind === "i32") {
           cx.builder.emitGenSetReturn(value);
         } else {
-          cx.builder.emitGenSetReturn(coerceYieldValueToExternref(value, cx));
+          cx.builder.emitGenSetReturn(coerceIrValueToExternref(cx.builder, value));
         }
       }
       const generatorObj = cx.builder.emitGenEpilogue();
@@ -2961,14 +2968,11 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
     // with a NumberKeyword element), so every claim reaches a hint here. A
     // resolver that can't register the vec throws → clean demote to legacy.
     if (annotated === undefined && d.type && ts.isArrayTypeNode(d.type)) {
-      if (d.type.elementType.kind !== ts.SyntaxKind.NumberKeyword) {
-        throw new Error(`ir/from-ast: array annotation on '${name}' must be number[] in ${cx.funcName}`);
-      }
       // (#3734) An ANNOTATED `const arr: number[] = []` reaches the vec type
       // through this arm, not through the inference arm below — so the i32
       // element narrowing has to be consulted here too, or the exact shape the
       // landing-page `array.ts` benchmark uses would never narrow.
-      const elementValType = emptyLiteralElementValType(d.initializer, cx);
+      const elementValType = annotatedArrayElementValType(d, cx);
       const vec = cx.resolver?.resolveVecForElement?.(elementValType);
       if (!vec) {
         throw new Error(
@@ -3475,7 +3479,7 @@ function lowerExpr(expr: ts.Expression, cx: LowerCtx, hint: IrType): IrValueId {
     const externShaped =
       (opVal !== undefined && opVal !== null && opVal.kind === "externref") || opType?.kind === "extern";
     if (!externShaped) return operand;
-    return cx.builder.emitAwait(operand);
+    return cx.builder.emitAwait(operand, preparedAsyncAwaitResultType(expr.expression, cx.resolver));
   }
   if (ts.isNumericLiteral(expr)) {
     return cx.builder.emitConst({ kind: "f64", value: Number(expr.text) }, irVal({ kind: "f64" }));
@@ -5069,6 +5073,15 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = fa
   if (expr.questionDotToken) {
     throw new Error(`ir/from-ast: optional call (?.()) not in slice 11 (${cx.funcName})`);
   }
+  const preparedPromiseAll = tryLowerPreparedAsyncPromiseAll({
+    expression: expr,
+    statementPosition,
+    resolver: cx.resolver,
+    builder: cx.builder,
+    functionName: cx.funcName,
+    lowerExpression: (expression, expected) => lowerExpr(expression, cx, expected),
+  });
+  if (preparedPromiseAll !== undefined) return preparedPromiseAll;
   // #3000-E: `super(args)` — a derived constructor chaining to its parent's
   // `_init`. Intercepted BEFORE the property-access / identifier dispatch below
   // because `super` is a keyword, not an identifier the receiver-lowering can
@@ -6878,7 +6891,7 @@ function lowerYield(expr: ts.YieldExpression, cx: LowerCtx): void {
     // `__gen_yield_star(externref, externref)` import sees the
     // right Wasm value type.
     const inner = lowerExpr(expr.expression, cx, irVal({ kind: "externref" }));
-    const innerExt = coerceYieldValueToExternref(inner, cx);
+    const innerExt = coerceIrValueToExternref(cx.builder, inner);
     cx.builder.emitGenYieldStar(innerExt);
     return;
   }
@@ -6916,51 +6929,8 @@ function lowerYield(expr: ts.YieldExpression, cx: LowerCtx): void {
   }
   // Reference-shaped yield — coerce to externref so the lowerer's
   // `__gen_push_ref(buf, externref)` arm sees the right Wasm type.
-  const valueExt = coerceYieldValueToExternref(value, cx);
+  const valueExt = coerceIrValueToExternref(cx.builder, value);
   cx.builder.emitGenPush(valueExt);
-}
-
-/**
- * Slice 7b helper: coerce a yielded SSA value to externref for the
- * `__gen_push_ref` / `__gen_yield_star` arms. Skips the coerce when
- * the value's underlying Wasm valtype is ALREADY externref —
- * emitting `extern.convert_any` on an already-externref operand is
- * actually a Wasm validation error (the op expects an `anyref`
- * subtype, and `externref` is NOT a subtype of `anyref`).
- *
- * Cases that skip the coerce:
- *   - `IrType.val` with `val.kind === "externref"` — directly externref.
- *   - `IrType.string` in HOST-strings mode — `resolveString()` returns
- *     externref for the host backend (the wasm:js-string imports take
- *     externref), so the value flowing through is already externref.
- *
- * Cases that DO coerce:
- *   - `IrType.string` in NATIVE-strings mode — value is `(ref $AnyString)`,
- *     a struct ref subtype of anyref, so `extern.convert_any` re-tags it.
- *   - `IrType.val` with `val.kind === "ref"` / `"ref_null"` —
- *     struct/array refs are anyref subtypes; coerce is valid.
- *   - `IrType.object` / `class` / `closure` — all backed by struct refs,
- *     anyref subtypes; coerce is valid.
- *
- * Reuses `coerce.to_externref` (#1182) so the generator path and the
- * iter-host for-of path share one IR primitive — the lowerer emits
- * `extern.convert_any` for both.
- */
-function coerceYieldValueToExternref(value: IrValueId, cx: LowerCtx): IrValueId {
-  const t = cx.builder.typeOf(value);
-  if (t.kind === "val" && t.val.kind === "externref") {
-    return value;
-  }
-  // #2955 — de-polymorph on string mode. A string operand IS externref in
-  // host-strings mode and `(ref $AnyString)` (an anyref subtype needing
-  // `extern.convert_any`) in native-strings mode. That per-mode decision no
-  // longer branches here in the front-end: emit the abstract
-  // `coerce.to_externref` unconditionally and let the lowerer resolve the
-  // mode (host → the convert is elided because the value is already
-  // externref; native → `extern.convert_any`). The lowered bytes stay
-  // byte-identical to the previous `!nativeStrings` guard in both modes,
-  // and the produced IR is now identical across string modes.
-  return cx.builder.emitCoerceToExternref(value);
 }
 
 /**
@@ -6982,7 +6952,7 @@ function coerceYieldValueToExternref(value: IrValueId, cx: LowerCtx): IrValueId 
  *
  *   - Declared result is `externref` and the value is reference-shaped
  *     (class / object / closure / vec ref / ref_null / native-string) →
- *     coerce via `coerceYieldValueToExternref` (`extern.convert_any`). This
+ *     coerce via `coerceIrValueToExternref` (`extern.convert_any`). This
  *     is a zero-cost re-tag valid for any anyref subtype, agnostic to the
  *     exact struct typeIdx (so type compaction cannot break it).
  *   - Declared result is `externref` but the value is a native scalar
@@ -7065,10 +7035,10 @@ function coerceReturnValue(value: IrValueId, cx: LowerCtx, sourceExpression?: ts
     );
   }
   // Reference-shaped (class / object / closure / vec ref / ref_null /
-  // native-string) → extern.convert_any. `coerceYieldValueToExternref` is a
+  // native-string) → extern.convert_any. `coerceIrValueToExternref` is a
   // no-op for host-strings (already externref) and re-tags all anyref
   // subtypes otherwise.
-  return coerceYieldValueToExternref(value, cx);
+  return coerceIrValueToExternref(cx.builder, value);
 }
 
 /**
@@ -10732,7 +10702,7 @@ function lowerThrowStatement(stmt: ts.ThrowStatement, cx: LowerCtx): void {
   // Reference-shaped — coerce to externref. The helper is a no-op
   // when the value is already externref or `IrType.string` in host
   // mode (mirrors the slice-7b yield value coercion).
-  const valueExt = coerceYieldValueToExternref(value, cx);
+  const valueExt = coerceIrValueToExternref(cx.builder, value);
   cx.builder.emitThrow(valueExt);
 }
 

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -86,7 +86,6 @@ import {
   planProgramAbiSupportCallableAlias,
   planProgramAbiSupportCallable,
   planProgramAbiGlobal,
-  planProgramAbiUnitCallable,
   PROGRAM_ABI_CALLABLE_ROLE,
   PROGRAM_ABI_GLOBAL_ROLE,
 } from "../codegen/program-abi-planning.js";
@@ -105,6 +104,7 @@ import {
 import type { CodegenContext, FunctionContext } from "../codegen/context/types.js";
 import { applyIrTailCalls } from "../codegen/ir-tail-call.js";
 import { lowerPreparedIrAsyncFunction } from "../codegen/ir-async-frame.js";
+import { preparedIrAsyncFromAstResolver } from "../codegen/async-ir-planning.js";
 import {
   getFuncRefWrapperRootTypeIdx,
   getOrCreateFuncRefWrapperTypes,
@@ -153,7 +153,6 @@ import {
 import {
   buildIrUnitInventory,
   indexIrTerminalDeclarations,
-  type IrBindingId,
   type IrClassId,
   type IrUnitInventory,
   type IrUnitId,
@@ -166,6 +165,15 @@ import {
   type IrPlanningIdentityContext,
 } from "./planning-identity.js";
 import { validateIrIntegrationPopulation } from "./integration-identity.js";
+import {
+  preparedUnitProgramAbiBinding,
+  resolvePreparedSupportCallable,
+  resolvePreparedUnitCallable,
+  settlePreparedDerivedCallable,
+  type PreparedIrUnitCallableSlot,
+} from "./prepared-callable-resolution.js";
+export { exactPreparedUnitCallableBindingId } from "./prepared-callable-resolution.js";
+import { prepareIrVectorSupport } from "./prepared-vector-support.js";
 import {
   makeIrArrayExpressionPredicate,
   makeIrDeclaredPrimitiveExpressionClassifier,
@@ -270,7 +278,6 @@ import {
 import { sealDependencyCompletePreparedComponents } from "./prepared-component-sealing.js";
 import { attachIrStringCarrier } from "./string-carrier.js";
 import { attachIrStringSupport } from "./string-support.js";
-import { attachIrVecLayouts } from "./vec-layout.js";
 import { IR_VEC_ELEM_SET_PREFIX, IR_VEC_NEW_SIZED_PREFIX, parseIrVectorRuntimeElement } from "./vector-runtime.js";
 import {
   IR_STRING_CHAR_AT_FN,
@@ -327,7 +334,7 @@ function lowerIrEntryFunction(
   existing: WasmFunction,
 ): WasmFunction {
   return fn.asyncPlan
-    ? lowerPreparedIrAsyncFunction(ctx, fn, resolver, existing)
+    ? lowerPreparedIrAsyncFunction(ctx, fn, { resolveFunc: (ref) => resolver.resolveFunc(ref) }, existing)
     : lowerIrFunctionToWasm(fn, resolver).func;
 }
 
@@ -431,7 +438,7 @@ function prepareClosureTransaction(input: {
   readonly callableImports: ReadonlyMap<string, Import>;
   readonly onSealFailure: (terminalUnitId: IrUnitId, error: IrInvariantError) => void;
 }): PreparedClosureTransaction {
-  let resolveValType: (type: IrType) => ValType = lowerPreparedClosureSupportType;
+  let resolveValType: (type: IrType) => ValType = (type) => lowerPreparedClosureSupportType(input.ctx, type);
   const registry = new ClosureStructRegistry(input.ctx, (type) => resolveValType(type));
   const closureSupport = prepareDependencyCompleteClosureSupport(input.ctx, input.entries, registry);
   const freshSlots = allocatePreparedDerivedCallableSlots(
@@ -969,7 +976,7 @@ export function compileIrPathFunctions(
           `direct-call plan at ${sourceFile.fileName}:${call.pos} disagrees with exact integration identity`,
         );
       }
-      preparedDirectCalls.set(call, plan);
+      if (!existing) preparedDirectCalls.set(call, plan);
     }
     return preparedDirectCalls;
   };
@@ -1991,7 +1998,6 @@ export function compileIrPathFunctions(
   };
   let preparedRuntimeManifest: PreparedIrRuntimeManifest | undefined;
   if (!runGlobalPreparation(() => (healthyForLower = prepareStrings(ctx, healthyForLower)))) return finishReport();
-  if (!runGlobalPreparation(() => (healthyForLower = prepareVectors(ctx, healthyForLower)))) return finishReport();
   if (
     !runGlobalPreparation(() => {
       const prepared = prepareBuiltFnRuntimeManifest(ctx, sourceFile.fileName, healthyForLower);
@@ -2001,6 +2007,7 @@ export function compileIrPathFunctions(
   ) {
     return finishReport();
   }
+  if (!runGlobalPreparation(() => (healthyForLower = prepareVectors(ctx, healthyForLower)))) return finishReport();
   healthyForLower = verifyFinalAllocArtifacts(healthyForLower, allocRegistry, monoResult.cloneOrigins, (entry, error) =>
     markOwnerFailure(terminalOwnerOf(entry), entry.artifactUnitId, entry.name, error, "verify"),
   );
@@ -2269,7 +2276,7 @@ export function compileIrPathFunctions(
   // the fragile one. Resolution goes through `nativeStrHelperHandle`
   // (src/codegen/func-space.ts), which prefers the stable handle and keeps the
   // scan only as a fallback for helpers not yet on stable minting.
-  const unitCallableSlots = new Map<IrUnitId, IrUnitCallableSlot>();
+  const unitCallableSlots = new Map<IrUnitId, PreparedIrUnitCallableSlot>();
   const bindUnitCallableSlot = (ref: IrFuncRef, funcIdx: number, physicalName: string): void => {
     if (ref.binding.kind !== "unit") {
       throw new IrInvariantError(
@@ -2307,19 +2314,7 @@ export function compileIrPathFunctions(
       );
     }
     ctx.irUnitFuncMap.set(ref.binding.unitId, defined);
-    let programAbiBindingId: IrBindingId | undefined;
-    const derived = ctx.programAbiSession?.registeredDerivedUnit(ref.binding.unitId);
-    if (ctx.programAbiSession?.hasKnownUnit(ref.binding.unitId) && !derived) {
-      const signature = ctx.mod.types[defined.typeIdx];
-      if (!signature || signature.kind !== "func") {
-        throw new IrInvariantError(
-          "abi-type-index-mismatch",
-          "resolve",
-          `ir/integration: exact unit ${ref.binding.unitId} / ${ref.name} has non-function type ${defined.typeIdx}`,
-        );
-      }
-      programAbiBindingId = planProgramAbiUnitCallable(ctx, { ref, signature, func: defined });
-    }
+    const programAbiBindingId = preparedUnitProgramAbiBinding(ctx, ref, defined);
     unitCallableSlots.set(ref.binding.unitId, {
       funcIdx,
       physicalName,
@@ -2533,48 +2528,6 @@ export function compileIrPathFunctions(
       ctx.programAbiSession!.replaceDefinedFunctionLocator(bindingId, previous, replacement);
     }
     return replacement;
-  };
-  const planSettledDerivedCallable = (
-    entry: BuiltFn,
-    replacement: NonNullable<ReturnType<typeof definedFuncAt>>,
-  ): void => {
-    if (!entry.derivedUnit || !ctx.programAbiSession) return;
-    const slot = unitCallableSlots.get(entry.artifactUnitId);
-    if (!slot || slot.programAbiBindingId) {
-      throw new IrInvariantError(
-        "selection-preparation-mismatch",
-        "patch",
-        `ir/integration: derived unit ${entry.artifactUnitId} has no unique unsettled callable slot`,
-      );
-    }
-    const signature = ctx.mod.types[replacement.typeIdx];
-    if (!signature || signature.kind !== "func") {
-      throw new IrInvariantError(
-        "abi-type-index-mismatch",
-        "patch",
-        `ir/integration: derived unit ${entry.artifactUnitId} has non-function type ${replacement.typeIdx}`,
-      );
-    }
-    if (!ctx.programAbiSession.registeredDerivedUnit(entry.artifactUnitId)) {
-      throw new IrInvariantError(
-        "selection-preparation-mismatch",
-        "patch",
-        `ir/integration: derived unit ${entry.artifactUnitId} was not registered before callable ordering`,
-      );
-    }
-    const bindingId = planProgramAbiUnitCallable(ctx, {
-      ref: irUnitFuncRef(entry.fn),
-      signature,
-      func: replacement,
-    });
-    if (!bindingId) {
-      throw new IrInvariantError(
-        "selection-preparation-mismatch",
-        "patch",
-        `ir/integration: derived unit ${entry.artifactUnitId} was not accepted by Program ABI planning`,
-      );
-    }
-    slot.programAbiBindingId = bindingId;
   };
   const pendingPatches: PendingPatch[] = [];
   // (#3551) Exact artifact identities withdrawn by the typeIdx-parity guard
@@ -2800,7 +2753,7 @@ export function compileIrPathFunctions(
       patch.existing,
       replacement,
     );
-    planSettledDerivedCallable(patch.entry, installed);
+    settlePreparedDerivedCallable(ctx, patch.entry, installed, unitCallableSlots.get(patch.entry.artifactUnitId));
     compiled.push(patch.entry.name);
     compiledArtifactEvidence.push({
       artifactUnitId: patch.entry.artifactUnitId,
@@ -3237,15 +3190,6 @@ interface DeferredClassResolver {
 }
 
 /** Exact binding of one structural source unit to its settled Wasm slot. */
-interface IrUnitCallableSlot {
-  readonly funcIdx: number;
-  readonly physicalName: string;
-  /** Temporary adapter labels admitted for this exact unit and slot only. */
-  readonly compatibilityNames: Set<string>;
-  /** Set once the unit has a settled signature and Program ABI plan. */
-  programAbiBindingId?: IrBindingId;
-}
-
 /**
  * Slice 6 part 4 refactor (#1185): build the from-ast subset of the
  * IR resolver eagerly (before Phase 1 IR build). Only the methods
@@ -3535,6 +3479,7 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
       capability,
     );
   return {
+    ...preparedIrAsyncFromAstResolver(ctx),
     retainedFunctionMethodPlan(call: ts.CallExpression) {
       if (
         !supportsBackendCapability("standalone-native-regexp-test-carrier") ||
@@ -3580,8 +3525,7 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
     },
     // (#2955 slice 5) No raw `nativeStrings()` here anymore — from-ast's
     // interface no longer carries the mode discriminator; every mode
-    // decision flows through the named capability/rep/strategy queries
-    // below.
+    // decision flows through the named capability/rep/strategy queries.
     // (#2955 slice 2) The WHOLE string-prototype-method mode decision table,
     // relocated here from from-ast's `lowerStringMethodCall` so the front-end
     // reads no `nativeStrings` at that site. Byte-inert by construction: the
@@ -4055,7 +3999,7 @@ function makeResolver(
   closureResolver: DeferredClosureResolver,
   refCellResolver: DeferredRefCellResolver,
   classResolver: DeferredClassResolver,
-  unitCallableSlots: ReadonlyMap<IrUnitId, IrUnitCallableSlot>,
+  unitCallableSlots: ReadonlyMap<IrUnitId, PreparedIrUnitCallableSlot>,
   importedCallableCatalog: ReadonlyMap<string, Import>,
   runtimeProviders?: ReadonlyMap<IntrinsicId, RuntimeProviderPlan>,
 ): IrLowerResolver {
@@ -4072,29 +4016,10 @@ function makeResolver(
         );
       }
       if (ref.binding.kind === "unit") {
-        const slot = unitCallableSlots.get(ref.binding.unitId);
-        if (!slot || !slot.compatibilityNames.has(ref.name)) {
-          throw new IrInvariantError(
-            "unknown-function-ref",
-            "lower",
-            `ir/integration: unknown exact function ref ${ref.binding.unitId} / ${JSON.stringify(ref.name)}`,
-          );
-        }
-        if (ctx.programAbiSession && slot.programAbiBindingId) {
-          return ctx.programAbiSession.resolveCurrentIndex(
-            slot.programAbiBindingId,
-            "function",
-            irCallableBindingKey(ref.binding),
-          );
-        }
-        return slot.funcIdx;
+        return resolvePreparedUnitCallable(ctx, ref, unitCallableSlots);
       }
       if (ref.binding.kind === "support" && ctx.programAbiSession?.hasPlan(ref.binding.bindingId)) {
-        return ctx.programAbiSession.resolveCurrentIndex(
-          ref.binding.bindingId,
-          "function",
-          irCallableBindingKey(ref.binding),
-        );
+        return resolvePreparedSupportCallable(ctx, ref);
       }
       if (ref.binding.kind === "import" && ctx.programAbiSession) {
         const structuralReferenceKey = irCallableBindingKey(ref.binding);
@@ -4773,31 +4698,13 @@ function prepareStrings(ctx: CodegenContext, fns: BuiltFn[]): BuiltFn[] {
   return prepared;
 }
 
-/** Attach exact Program-ABI vector layouts after logical IR construction. */
 function prepareVectors(ctx: CodegenContext, fns: BuiltFn[]): BuiltFn[] {
-  const registry = ctx.programAbiTypes;
-  if (!registry) return fns;
-  const layouts = new Map<string, import("./nodes.js").IrVecLayoutRef>();
-  const prepared = fns.map((entry) => {
-    const attachment = attachIrVecLayouts(entry.fn, (type) => {
-      const logicalKey = irTypeKey({ kind: "vec", elementType: type.elementType, nullable: false });
-      const cached = layouts.get(logicalKey);
-      if (cached) return cached;
-      const elementValType = asVal(type.elementType);
-      if (!elementValType || (elementValType.kind !== "f64" && elementValType.kind !== "i32")) {
-        throw new Error(`ir/integration: prepared vec element ${irTypeKey(type.elementType)} is not yet supported`);
-      }
-      const vec = resolveVecForElementImpl(ctx, elementValType);
-      if (!vec) {
-        throw new Error(`ir/integration: no physical vector layout for ${logicalKey}`);
-      }
-      const layout = registry.prepareVectorLayout(logicalKey, vec.vecStructTypeIdx, vec.arrayTypeIdx);
-      layouts.set(logicalKey, layout);
-      return layout;
-    });
-    return attachment.function === entry.fn ? entry : { ...entry, fn: attachment.function };
+  return prepareIrVectorSupport({
+    ctx,
+    entries: fns,
+    resolveVecForElement: (element) => resolveVecForElementImpl(ctx, element),
+    typeKey: irTypeKey,
   });
-  return prepared;
 }
 
 function instrUsesStrings(instr: IrInstr): boolean {

--- a/src/ir/prepared-callable-resolution.ts
+++ b/src/ir/prepared-callable-resolution.ts
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { CodegenContext } from "../codegen/context/types.js";
+import { definedFuncAt, definedFuncHandleOf } from "../codegen/func-space.js";
+import { planProgramAbiUnitCallable } from "../codegen/program-abi-planning.js";
+import { irCallableBindingKey, irUnitCallableBindingId, irUnitFuncRef } from "./callable-bindings.js";
+import type { IrBindingId, IrUnitId } from "./identity.js";
+import type { IrFuncRef, IrFunction } from "./nodes.js";
+import { IrInvariantError } from "./outcomes.js";
+import type { WasmFunction } from "./types.js";
+
+/** Exact binding of one structural source unit to its settled Wasm slot. */
+export interface PreparedIrUnitCallableSlot {
+  readonly funcIdx: number;
+  readonly physicalName: string;
+  readonly compatibilityNames: Set<string>;
+  programAbiBindingId?: IrBindingId;
+}
+
+/** Exact pre-sealed callable owner; a planned binding alone is insufficient. */
+export function exactPreparedUnitCallableBindingId(
+  session: Pick<NonNullable<CodegenContext["programAbiSession"]>, "hasPlan" | "hasLocator">,
+  unitId: IrUnitId,
+  func: WasmFunction,
+): IrBindingId | undefined {
+  const bindingId = irUnitCallableBindingId(unitId);
+  return session.hasPlan(bindingId) && session.hasLocator(bindingId, func) ? bindingId : undefined;
+}
+
+/** Reuse a sealed unit binding or plan its exact settled source callable. */
+export function preparedUnitProgramAbiBinding(
+  ctx: CodegenContext,
+  ref: IrFuncRef,
+  func: WasmFunction,
+): IrBindingId | undefined {
+  if (ref.binding.kind !== "unit" || !ctx.programAbiSession) return undefined;
+  const exact = exactPreparedUnitCallableBindingId(ctx.programAbiSession, ref.binding.unitId, func);
+  if (exact) return exact;
+  if (
+    !ctx.programAbiSession.hasKnownUnit(ref.binding.unitId) ||
+    ctx.programAbiSession.registeredDerivedUnit(ref.binding.unitId)
+  ) {
+    return undefined;
+  }
+  const signature = ctx.mod.types[func.typeIdx];
+  if (!signature || signature.kind !== "func") {
+    throw new IrInvariantError(
+      "abi-type-index-mismatch",
+      "resolve",
+      `prepared unit ${ref.binding.unitId} / ${ref.name} has non-function type ${func.typeIdx}`,
+    );
+  }
+  return planProgramAbiUnitCallable(ctx, { ref, signature, func });
+}
+
+/** Resolve one exact prepared source-unit callable through its allocator object. */
+export function resolvePreparedUnitCallable(
+  ctx: CodegenContext,
+  ref: IrFuncRef,
+  slots: ReadonlyMap<IrUnitId, PreparedIrUnitCallableSlot>,
+): number {
+  if (ref.binding.kind !== "unit") {
+    throw new IrInvariantError("unknown-function-ref", "lower", `non-unit prepared callable ${ref.name}`);
+  }
+  const slot = slots.get(ref.binding.unitId);
+  if (!slot || !slot.compatibilityNames.has(ref.name)) {
+    throw new IrInvariantError(
+      "unknown-function-ref",
+      "lower",
+      `unknown exact function ref ${ref.binding.unitId} / ${JSON.stringify(ref.name)}`,
+    );
+  }
+  if (!ctx.programAbiSession || !slot.programAbiBindingId) return slot.funcIdx;
+  const exact = ctx.irUnitFuncMap.get(ref.binding.unitId);
+  const handle = exact ? definedFuncHandleOf(ctx, exact) : undefined;
+  if (
+    !exact ||
+    handle === undefined ||
+    exact !== definedFuncAt(ctx, slot.funcIdx) ||
+    !ctx.programAbiSession.hasLocator(slot.programAbiBindingId, exact)
+  ) {
+    throw new IrInvariantError(
+      "unknown-function-ref",
+      "lower",
+      `prepared unit ${ref.binding.unitId} lost its exact allocator-owned callable`,
+    );
+  }
+  return handle;
+}
+
+/** Resolve a sealed support callable without trusting a shifted numeric index. */
+export function resolvePreparedSupportCallable(ctx: CodegenContext, ref: IrFuncRef): number {
+  if (ref.binding.kind !== "support") {
+    throw new IrInvariantError("unknown-function-ref", "lower", `non-support prepared callable ${ref.name}`);
+  }
+  const session = ctx.programAbiSession;
+  if (!session?.hasPlan(ref.binding.bindingId)) {
+    throw new IrInvariantError(
+      "unknown-function-ref",
+      "lower",
+      `unplanned support ${irCallableBindingKey(ref.binding)}`,
+    );
+  }
+  const bindingId = ref.binding.bindingId;
+  if (!session.hasLocator(bindingId)) {
+    return session.resolveCurrentIndex(bindingId, "function", irCallableBindingKey(ref.binding));
+  }
+  const matches = ctx.mod.functions.filter((candidate) => session.locatorBindingId(candidate) === bindingId);
+  const exact = matches.length === 1 ? matches[0] : undefined;
+  const handle = exact ? definedFuncHandleOf(ctx, exact) : undefined;
+  if (!exact || handle === undefined || !session.hasLocator(bindingId, exact)) {
+    throw new IrInvariantError(
+      "unknown-function-ref",
+      "lower",
+      `support callable ${bindingId} lost its exact allocator object`,
+    );
+  }
+  return handle;
+}
+
+/** Publish or validate the settled callable for one derived IR artifact. */
+export function settlePreparedDerivedCallable(
+  ctx: CodegenContext,
+  entry: {
+    readonly artifactUnitId: IrUnitId;
+    readonly derivedUnit?: unknown;
+    readonly fn: IrFunction;
+  },
+  replacement: WasmFunction,
+  slot: PreparedIrUnitCallableSlot | undefined,
+): void {
+  if (!entry.derivedUnit || !ctx.programAbiSession) return;
+  if (!slot) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "patch",
+      `derived unit ${entry.artifactUnitId} has no unique unsettled callable slot`,
+    );
+  }
+  if (slot.programAbiBindingId) {
+    const expected = irUnitCallableBindingId(entry.artifactUnitId);
+    if (slot.programAbiBindingId !== expected || !ctx.programAbiSession.hasLocator(expected, replacement)) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "patch",
+        `prepared derived unit ${entry.artifactUnitId} lost its exact settled callable locator`,
+      );
+    }
+    return;
+  }
+  const signature = ctx.mod.types[replacement.typeIdx];
+  if (!signature || signature.kind !== "func") {
+    throw new IrInvariantError(
+      "abi-type-index-mismatch",
+      "patch",
+      `derived unit ${entry.artifactUnitId} has non-function type ${replacement.typeIdx}`,
+    );
+  }
+  if (!ctx.programAbiSession.registeredDerivedUnit(entry.artifactUnitId)) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "patch",
+      `derived unit ${entry.artifactUnitId} was not registered before callable ordering`,
+    );
+  }
+  const bindingId = planProgramAbiUnitCallable(ctx, {
+    ref: irUnitFuncRef(entry.fn),
+    signature,
+    func: replacement,
+  });
+  if (!bindingId) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "patch",
+      `derived unit ${entry.artifactUnitId} was not accepted by Program ABI planning`,
+    );
+  }
+  slot.programAbiBindingId = bindingId;
+}

--- a/src/ir/prepared-closure-support.ts
+++ b/src/ir/prepared-closure-support.ts
@@ -2,7 +2,7 @@
 
 import { getFuncRefWrapperRootTypeIdx } from "../codegen/closures/funcref-wrapper-types.js";
 import type { CodegenContext } from "../codegen/context/types.js";
-import { definedFuncHandleOf } from "../codegen/func-space.js";
+import { mintDefinedFunc, pushDefinedFunc } from "../codegen/func-space.js";
 import type {
   ProgramAbiClosureSupportLayout,
   ProgramAbiClosureSupportLayoutRequest,
@@ -28,9 +28,19 @@ export interface PreparedClosureRegistry {
   resolveSubtype(signature: IrClosureSignature, captureFieldTypes: readonly IrType[]): IrClosureLowering | null;
 }
 
-export function lowerPreparedClosureSupportType(type: IrType): ValType {
+export function lowerPreparedClosureSupportType(ctx: CodegenContext, type: IrType): ValType {
   if (type.kind === "val" && type.val.kind !== "ref" && type.val.kind !== "ref_null") return type.val;
   if (type.kind === "extern" || type.kind === "callable") return { kind: "externref" };
+  if (type.kind === "vec" && type.layout && ctx.programAbiSession) {
+    return {
+      kind: type.nullable ? "ref_null" : "ref",
+      typeIdx: ctx.programAbiSession.resolveCurrentIndex(
+        type.layout.carrierType.binding.bindingId,
+        "type",
+        irTypeBindingKey(type.layout.carrierType.binding),
+      ),
+    };
+  }
   throw new Error(`closure support type ${type.kind} requires the complete IR resolver`);
 }
 
@@ -40,7 +50,7 @@ export function prepareDerivedCallableTypeIdx(
   fn: IrFunction,
 ): number {
   const lower = (type: IrType): ValType => {
-    if (type.kind !== "closure") return lowerPreparedClosureSupportType(type);
+    if (type.kind !== "closure") return lowerPreparedClosureSupportType(ctx, type);
     if (!registry.resolveBase(type.signature)) {
       throw new Error("prepared callable signature cannot allocate its closure type");
     }
@@ -91,15 +101,8 @@ export function allocatePreparedDerivedCallableSlots(
       body: [],
       exported: entry.fn.exported,
     };
-    ctx.mod.functions.push(func);
-    const funcIdx = definedFuncHandleOf(ctx, func);
-    if (funcIdx === undefined) {
-      throw new IrInvariantError(
-        "missing-function-slot",
-        "resolve",
-        `prepared derived artifact ${entry.artifactUnitId} / ${entry.name} has no allocator slot`,
-      );
-    }
+    const funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, func);
     ctx.irUnitFuncMap.set(entry.artifactUnitId, func);
     slots.push({
       artifactUnitId: entry.artifactUnitId,

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -13,6 +13,7 @@ import {
   type IrType,
   type IrTypeRef,
   type IrValueId,
+  type IrVecLayoutRef,
 } from "./nodes.js";
 import type { ProgramAbiDerivedUnitRecord, ProgramAbiIntent, ProgramAbiPlanEntry } from "./program-abi.js";
 
@@ -506,6 +507,88 @@ function valueTypesOf(fn: IrFunction): Map<IrValueId, IrType> {
   return types;
 }
 
+function reachableAsyncPlanVecTypes(fn: IrFunction): ReadonlySet<IrType> {
+  const vectors = new Set<IrType>();
+  const seen = new Set<IrType>();
+  const collectType = (type: IrType): void => {
+    if (seen.has(type)) return;
+    seen.add(type);
+    switch (type.kind) {
+      case "vec":
+        vectors.add(type);
+        collectType(type.elementType);
+        return;
+      case "object":
+        for (const field of type.shape.fields) collectType(field.type);
+        return;
+      case "closure":
+      case "callable":
+        for (const param of type.signature.params) collectType(param);
+        if (type.signature.returnType) collectType(type.signature.returnType);
+        return;
+      case "union":
+        for (const member of type.members) collectType(member);
+        return;
+      case "boxed":
+        collectType(type.inner);
+        return;
+      case "val":
+      case "string":
+      case "class":
+      case "extern":
+      case "dynamic":
+        return;
+    }
+  };
+  const collectInstr = (instr: IrInstr): void => {
+    forEachInstrDeep(instr, (nested) => {
+      if (nested.resultType) collectType(nested.resultType);
+      switch (nested.kind) {
+        case "const":
+          if (nested.value.kind === "null") collectType(nested.value.ty);
+          return;
+        case "box":
+          collectType(nested.toType);
+          return;
+        case "object.new":
+          for (const field of nested.shape.fields) collectType(field.type);
+          return;
+        case "closure.new":
+          for (const param of nested.signature.params) collectType(param);
+          if (nested.signature.returnType) collectType(nested.signature.returnType);
+          for (const capture of nested.captureFieldTypes) collectType(capture);
+          return;
+        case "vec.new_fixed":
+        case "forof.vec":
+          collectType(nested.elementType);
+          return;
+        default:
+          return;
+      }
+    });
+  };
+  const plan = fn.asyncPlan;
+  if (!plan) return vectors;
+  if (plan.abi.fulfillmentType) collectType(plan.abi.fulfillmentType);
+  for (const value of plan.params) collectType(value.type);
+  for (const value of plan.values) collectType(value.type);
+  for (const spill of plan.spills) collectType(spill.type);
+  for (const state of plan.states) {
+    if (state.resume) collectType(state.resume.type);
+    for (const instr of state.body) collectInstr(instr);
+  }
+  return vectors;
+}
+
+function samePreparedVecLayout(left: IrVecLayoutRef, right: IrVecLayoutRef): boolean {
+  return (
+    irTypeBindingKey(left.carrierType.binding) === irTypeBindingKey(right.carrierType.binding) &&
+    irTypeBindingKey(left.dataType.binding) === irTypeBindingKey(right.dataType.binding) &&
+    left.lengthFieldIndex === right.lengthFieldIndex &&
+    left.dataFieldIndex === right.dataFieldIndex
+  );
+}
+
 function implicitSupportRequirement(instr: IrInstr, hasPreparedClosureSupport = false): string | null {
   switch (instr.kind) {
     case "binary":
@@ -849,6 +932,68 @@ function collectFunctionEvidence(
   const classes = new Map<IrClassId, IrClassShape>();
   const seenTypes = new Set<IrType>();
   const seenImplicitTypes = new Set<IrType>();
+  const reachableAsyncVectors = reachableAsyncPlanVecTypes(fn);
+  const fulfilledAsyncVectors = new Set(
+    (fn.asyncPlan?.states ?? []).flatMap((state) =>
+      state.resume?.source === "fulfilled" && state.resume.type.kind === "vec" ? [state.resume.type] : [],
+    ),
+  );
+  const preparedAsyncLayouts = new Map<IrType, IrVecLayoutRef>();
+  for (const entry of fn.asyncRuntime?.typeLayouts ?? []) {
+    if (entry.logicalType.kind !== "vec") {
+      addFailure(evidence, {
+        code: "implicit-support-reference-unavailable",
+        ownerUnitId: terminalOwnerUnitId,
+        detail: `prepared async layout is attached to non-vector IR type ${entry.logicalType.kind}`,
+      });
+      continue;
+    }
+    if (!reachableAsyncVectors.has(entry.logicalType)) {
+      addFailure(evidence, {
+        code: "implicit-support-reference-unavailable",
+        ownerUnitId: terminalOwnerUnitId,
+        detail: "prepared async vec layout is dangling from the exact final async-plan type objects",
+      });
+      continue;
+    }
+    if (preparedAsyncLayouts.has(entry.logicalType)) {
+      addFailure(evidence, {
+        code: "implicit-support-reference-unavailable",
+        ownerUnitId: terminalOwnerUnitId,
+        detail: "prepared async vec type has duplicate backend layout sidecars",
+      });
+      continue;
+    }
+    if (entry.logicalType.layout && !samePreparedVecLayout(entry.logicalType.layout, entry.layout)) {
+      addFailure(evidence, {
+        code: "implicit-support-reference-unavailable",
+        ownerUnitId: terminalOwnerUnitId,
+        detail: "prepared async vec sidecar disagrees with the logical type's existing layout",
+      });
+      continue;
+    }
+    preparedAsyncLayouts.set(entry.logicalType, entry.layout);
+    const needsFromExtern = fulfilledAsyncVectors.has(entry.logicalType);
+    if (needsFromExtern !== (entry.fromExtern !== undefined)) {
+      addFailure(evidence, {
+        code: "implicit-support-reference-unavailable",
+        ownerUnitId: terminalOwnerUnitId,
+        detail: needsFromExtern
+          ? "prepared fulfilled async vec type has no exact extern materializer"
+          : "prepared async vec layout carries a materializer outside an exact fulfilled resume type",
+      });
+    } else if (entry.fromExtern) {
+      recordExternalCallable(evidence, entry.fromExtern, input.abi, ownership);
+    }
+  }
+  for (const type of reachableAsyncVectors) {
+    if (preparedAsyncLayouts.has(type)) continue;
+    addFailure(evidence, {
+      code: "implicit-support-reference-unavailable",
+      ownerUnitId: terminalOwnerUnitId,
+      detail: "prepared async vec type has no exact backend layout sidecar",
+    });
+  }
   const recordPreparedClosureRefs = (refs: readonly IrTypeRef[] | undefined, detail: string): boolean => {
     if (!refs || refs.length === 0) return false;
     for (const ref of refs) recordSupportTypeReference(evidence, ref, input.abi, ownership, detail);
@@ -856,6 +1001,47 @@ function collectFunctionEvidence(
   };
   const collectType = (type: IrType): void => {
     collectIrTypeClasses(type, classes, seenTypes);
+    const preparedAsyncLayout = preparedAsyncLayouts.get(type);
+    if (preparedAsyncLayout) {
+      if (type.kind !== "vec") {
+        addFailure(evidence, {
+          code: "implicit-support-reference-unavailable",
+          ownerUnitId: terminalOwnerUnitId,
+          detail: `prepared async layout is attached to non-vector IR type ${type.kind}`,
+        });
+        return;
+      }
+      if (
+        !Number.isSafeInteger(preparedAsyncLayout.lengthFieldIndex) ||
+        preparedAsyncLayout.lengthFieldIndex < 0 ||
+        !Number.isSafeInteger(preparedAsyncLayout.dataFieldIndex) ||
+        preparedAsyncLayout.dataFieldIndex < 0 ||
+        preparedAsyncLayout.lengthFieldIndex === preparedAsyncLayout.dataFieldIndex
+      ) {
+        addFailure(evidence, {
+          code: "implicit-support-reference-unavailable",
+          ownerUnitId: terminalOwnerUnitId,
+          detail: "prepared async vec type carries an invalid field layout",
+        });
+        return;
+      }
+      recordSupportTypeReference(
+        evidence,
+        preparedAsyncLayout.carrierType,
+        input.abi,
+        ownership,
+        "prepared async vec carrier must use a compiler-support Program ABI type ref",
+      );
+      recordSupportTypeReference(
+        evidence,
+        preparedAsyncLayout.dataType,
+        input.abi,
+        ownership,
+        "prepared async vec backing array must use a compiler-support Program ABI type ref",
+      );
+      collectType(type.elementType);
+      return;
+    }
     const preparedRefs = input.closureSupport?.typeRefs.get(type);
     if (
       (type.kind === "closure" || type.kind === "callable") &&

--- a/src/ir/prepared-component-sealing.ts
+++ b/src/ir/prepared-component-sealing.ts
@@ -81,6 +81,7 @@ function planBlockingCallableImports(
   catalog: ReadonlyMap<string, Import>,
 ): boolean {
   const selected = new Set<Import>();
+  const providers = ctx.programAbiCallableProviders;
   for (const component of report.components) {
     const unresolvedImports = new Map(
       component.externalCallables.flatMap((dependency) => {
@@ -89,19 +90,25 @@ function planBlockingCallableImports(
         return imported ? ([[dependency.structuralReferenceKey, imported]] as const) : [];
       }),
     );
-    if (
-      unresolvedImports.size === 0 ||
-      component.failures.length === 0 ||
-      !component.failures.every(
-        (failure) =>
+    const allFailuresArePlannableCallables =
+      component.failures.length > 0 &&
+      component.failures.every((failure) => {
+        const key = failure.structuralReferenceKey;
+        return (
           failure.code === "unplanned-abi-binding" &&
-          failure.structuralReferenceKey !== undefined &&
-          unresolvedImports.has(failure.structuralReferenceKey),
-      )
-    ) {
+          key !== undefined &&
+          (unresolvedImports.has(key) || providers?.importsForPreparedProviders(new Set([key])) !== undefined)
+        );
+      });
+    if (!allFailuresArePlannableCallables) {
       continue;
     }
     for (const imported of unresolvedImports.values()) selected.add(imported);
+    for (const failure of component.failures) {
+      const key = failure.structuralReferenceKey;
+      if (!key) continue;
+      for (const imported of providers?.importsForPreparedProviders(new Set([key])) ?? []) selected.add(imported);
+    }
   }
   if (selected.size === 0) return false;
   const registry = ctx.programAbiCallableImports;

--- a/src/ir/prepared-vector-support.ts
+++ b/src/ir/prepared-vector-support.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { CodegenContext } from "../codegen/context/types.js";
+import { definedFuncAt } from "../codegen/func-space.js";
+import {
+  planProgramAbiEntrySourceSupportCallable,
+  PROGRAM_ABI_CALLABLE_ROLE,
+} from "../codegen/program-abi-planning.js";
+import { buildVecFromExternMaterializer, vecFromExternFuncIdx } from "../codegen/type-coercion.js";
+import {
+  VEC_HOST_BRIDGE_ROLE,
+  vecHostBridgeMaterializerOrdinal,
+  type VecHostBridgeMaterializerElementKind,
+} from "../codegen/vec-access-exports.js";
+import { irTypeBindingKey } from "./abi-bindings.js";
+import { sameIrCallableBinding } from "./callable-bindings.js";
+import type { IrVecLowering } from "./lower.js";
+import { asVal, type IrFuncRef, type IrFunction, type IrType, type IrVecLayoutRef } from "./nodes.js";
+import type { ValType } from "./types.js";
+import { attachIrVecLayouts } from "./vec-layout.js";
+
+interface PreparedVectorEntry {
+  readonly fn: IrFunction;
+}
+
+type MaterializerElement = ValType & { readonly kind: VecHostBridgeMaterializerElementKind };
+
+/** Attach backend layouts and exact host-to-vec materializers after IR construction. */
+export function prepareIrVectorSupport<T extends PreparedVectorEntry>(input: {
+  readonly ctx: CodegenContext;
+  readonly entries: readonly T[];
+  readonly resolveVecForElement: (element: ValType) => IrVecLowering | null;
+  readonly typeKey: (type: IrType) => string;
+}): T[] {
+  const registry = input.ctx.programAbiTypes;
+  if (!registry) return [...input.entries];
+  const layouts = new Map<string, IrVecLayoutRef>();
+  const physicalVectors = new Map<string, { readonly structTypeIdx: number; readonly element: MaterializerElement }>();
+  const materializers = new Map<string, IrFuncRef>();
+  const fromExternFor = (logicalKey: string): IrFuncRef => {
+    const cached = materializers.get(logicalKey);
+    if (cached) return cached;
+    const physical = physicalVectors.get(logicalKey);
+    if (!physical) throw new Error(`prepared async vector ${logicalKey} lost its physical layout`);
+    const name = buildVecFromExternMaterializer(input.ctx, physical.structTypeIdx);
+    const handle = name ? vecFromExternFuncIdx(input.ctx, physical.structTypeIdx) : undefined;
+    const func = handle === undefined ? undefined : definedFuncAt(input.ctx, handle);
+    const ref = func
+      ? planProgramAbiEntrySourceSupportCallable(input.ctx, {
+          role: VEC_HOST_BRIDGE_ROLE,
+          roleOrdinal: PROGRAM_ABI_CALLABLE_ROLE.vecHostBridge,
+          derivedOrdinal: vecHostBridgeMaterializerOrdinal(physical.element.kind),
+          displayName: name!,
+          func,
+        })
+      : undefined;
+    if (!ref) throw new Error(`no sealed extern materializer for ${logicalKey}`);
+    materializers.set(logicalKey, ref);
+    return ref;
+  };
+
+  return input.entries.map((entry) => {
+    const attachment = attachIrVecLayouts(entry.fn, (type) => {
+      const logicalKey = input.typeKey({ kind: "vec", elementType: type.elementType, nullable: false });
+      const cached = layouts.get(logicalKey);
+      if (cached) return cached;
+      const element = asVal(type.elementType);
+      if (!element || (element.kind !== "f64" && element.kind !== "i32" && element.kind !== "externref")) {
+        throw new Error(`prepared vec element ${input.typeKey(type.elementType)} is not supported`);
+      }
+      const vec = input.resolveVecForElement(element);
+      if (!vec) throw new Error(`no physical vector layout for ${logicalKey}`);
+      const layout = registry.prepareVectorLayout(logicalKey, vec.vecStructTypeIdx, vec.arrayTypeIdx);
+      layouts.set(logicalKey, layout);
+      physicalVectors.set(logicalKey, { structTypeIdx: vec.vecStructTypeIdx, element });
+      return layout;
+    });
+    let fn = attachment.function;
+    if (attachment.asyncPlanLayouts.size > 0) {
+      if (!fn.asyncRuntime) throw new Error(`async vector owner ${fn.name} has no prepared runtime attachment`);
+      const typeLayouts = Object.freeze(
+        [...attachment.asyncPlanLayouts].map(([logicalType, layout]) => {
+          if (logicalType.kind !== "vec") throw new Error(`non-vector async layout key ${logicalType.kind}`);
+          const logicalKey = input.typeKey({ kind: "vec", elementType: logicalType.elementType, nullable: false });
+          const fulfilled =
+            fn.asyncPlan?.states.some(
+              (state) => state.resume?.source === "fulfilled" && state.resume.type === logicalType,
+            ) === true;
+          return Object.freeze({
+            logicalType,
+            layout,
+            ...(fulfilled ? { fromExtern: fromExternFor(logicalKey) } : {}),
+          });
+        }),
+      );
+      if (fn.asyncRuntime.typeLayouts) {
+        const divergent =
+          fn.asyncRuntime.typeLayouts.length !== typeLayouts.length ||
+          fn.asyncRuntime.typeLayouts.some((prior, index) => {
+            const next = typeLayouts[index]!;
+            return (
+              prior.logicalType !== next.logicalType ||
+              irTypeBindingKey(prior.layout.carrierType.binding) !==
+                irTypeBindingKey(next.layout.carrierType.binding) ||
+              irTypeBindingKey(prior.layout.dataType.binding) !== irTypeBindingKey(next.layout.dataType.binding) ||
+              prior.layout.lengthFieldIndex !== next.layout.lengthFieldIndex ||
+              prior.layout.dataFieldIndex !== next.layout.dataFieldIndex ||
+              (prior.fromExtern === undefined) !== (next.fromExtern === undefined) ||
+              (prior.fromExtern !== undefined &&
+                next.fromExtern !== undefined &&
+                !sameIrCallableBinding(prior.fromExtern.binding, next.fromExtern.binding))
+            );
+          });
+        if (divergent) throw new Error(`async vector owner ${fn.name} carries divergent prepared layouts`);
+      } else {
+        fn = { ...fn, asyncRuntime: Object.freeze({ ...fn.asyncRuntime, typeLayouts }) };
+      }
+    }
+    return (fn === entry.fn ? entry : { ...entry, fn }) as T;
+  });
+}

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -55,6 +55,13 @@
 //     `localClasses` set drives that exemption.
 
 import { ts, forEachChild } from "../ts-api.js";
+import {
+  isAsyncIrReady,
+  isUnpreparedAsyncCallee,
+  preparedAsyncPromiseAllArguments,
+  type IrAsyncSelectionOptions,
+} from "./async-selection.js";
+export { isAsyncIrReady } from "./async-selection.js";
 import { collectIrSafeVarDeclarationLists } from "./function-local-var.js";
 import { collectDynamicStringLocalWidening } from "./dynamic-local-widening.js";
 import { stringBuilderForcedLegacy } from "./string-builder-shape.js";
@@ -312,7 +319,7 @@ export interface IrModuleInitAssessment {
   readonly detail?: string;
 }
 
-export interface IrSelectionOptions {
+export interface IrSelectionOptions extends IrAsyncSelectionOptions {
   readonly experimentalIR?: boolean;
   /** When true, the returned selection includes a `fallbacks` array listing
    *  every top-level FunctionDeclaration that the selector did NOT claim
@@ -350,50 +357,6 @@ export interface IrSelectionOptions {
    * pass every ordinary selector shape and closure gate.
    */
   readonly recursiveTypeEvidence?: RecursiveTypeEvidence;
-  /**
-   * (#1373b Slice 1) When true, async functions (no `*`) are eligible to
-   * flow through the IR's CPS lowering (Phase C). When false (default),
-   * the selector buckets them into the `"async-function"` fallback reason
-   * and the legacy direct-codegen path takes over.
-   *
-   * Even when true, individual async functions are still rejected by the
-   * selector if their body uses features the Phase C lowering can't handle
-   * yet (try/catch around await — see `isAsyncIrReady`).
-   *
-   * Threaded from `CodegenContext.supportsAsyncIr` via `integration.ts`.
-   */
-  readonly supportsAsyncIr?: boolean;
-  /**
-   * (#1373b C-1) The ONE-engine consistency predicate: returns `true` when
-   * the converged async engine (the #2906 `$AsyncFrame` drive / host-drive
-   * machine, entry `decideAsyncActivation` in `async-activation.ts`) would
-   * ACTIVATE for this async function declaration. The IR path claims an
-   * async function IFF the engine declines it — the legacy synchronous
-   * pass-through population — so engine-activated functions keep
-   * byte-identical routing and the IR never builds a second suspension
-   * machine (the #2367 graveyard rule).
-   *
-   * Bound by the real-compile call site (`planIrOverlay` in
-   * codegen/index.ts) to `asyncEngineWouldActivate(ctx, fn)`. When ABSENT
-   * (bare `planIrCompilation` callers without a codegen context), the gate
-   * treats every async fn as engine-claimed — the safe default: never
-   * IR-claim without the engine's verdict.
-   */
-  readonly asyncEngineClaims?: (fn: ts.FunctionLikeDeclaration) => boolean;
-  /**
-   * Exact producer proof for an engine-activated async declaration whose
-   * suspension graph can be prepared as `IrAsyncPlan`. The engine remains the
-   * only scheduler/emitter; this callback only permits the IR to own its state
-   * bodies. Absent by default, so bare selector callers cannot claim a real
-   * suspension accidentally.
-   */
-  readonly canPrepareSuspendingAsync?: (fn: ts.FunctionLikeDeclaration) => boolean;
-  /**
-   * True when at least one await cannot be eliminated by the shared async
-   * analysis. An engine decline does not make such a body synchronous; until
-   * an `IrAsyncPlan` producer claims it, it must remain a typed fallback.
-   */
-  readonly asyncHasRealSuspension?: (fn: ts.FunctionLikeDeclaration) => boolean;
   /**
    * (#2856) Host-extern support — resolves a bare identifier that is NOT a
    * local/param binding to an ambient host global (`document`, `console`, …).
@@ -559,66 +522,6 @@ export interface IrSelectionOptions {
    * selection remains unchanged outside the one production proof.
    */
   readonly promiseDelays?: IrPromiseDelayResolver;
-}
-
-/**
- * (#1373b C-1) Centralised gate for whether the IR path can claim a given
- * async function. C-1 opens the gate for the SYNC-PASS-THROUGH population
- * only — async function DECLARATIONS the converged engine declines
- * (`asyncEngineClaims(fn) === false`). Engine-activated functions (genuinely
- * suspending, engine-drivable shapes) stay on the `$AsyncFrame` machine;
- * claiming one here would regress real suspension back to sync semantics.
- *
- * Accepting here only opens the door: the normal Phase-1 body-shape pipeline
- * still runs (with `await` accepted via the `isPhase1Expr` arm), so anything
- * the IR can't build stays legacy (correct-or-legacy).
- *
- * Out of C-1 scope (kept in their fallback buckets):
- *   - async methods / arrows / function expressions (#2957 activation paths);
- *   - async generators (`async-generator` bucket, engine 3d lanes);
- *   - bodies containing `for await` (engine 3b/3dii lanes) or nested async
- *     function-likes (closure-lifted async lowering not wired).
- */
-export function isAsyncIrReady(options: IrSelectionOptions | undefined, fn: ts.FunctionLikeDeclaration): boolean {
-  if (!options?.supportsAsyncIr) return false;
-  // C-1 scope: top-level function declarations only.
-  if (!ts.isFunctionDeclaration(fn)) return false;
-  if (fn.asteriskToken) return false; // async generator — never this gate
-  if (!fn.body) return false;
-  // ONE-engine invariant: without the engine's verdict, never claim.
-  if (options.asyncEngineClaims === undefined) return false;
-  if (options.asyncEngineClaims(fn)) return options.canPrepareSuspendingAsync?.(fn) === true;
-  if (options.asyncHasRealSuspension?.(fn) === true) return false;
-  // Body-scope bounds: `for await` and nested async function-likes are out.
-  if (bodyHasAsyncOutOfIrScope(fn.body)) return false;
-  return true;
-}
-
-/**
- * (#1373b C-1) Walk an async fn body for shapes the C-1 claim excludes:
- * `for await` loops and nested async function-likes (async arrows / function
- * expressions / declarations — their lowering rides the closure-lift path,
- * which has no async arm yet).
- */
-function bodyHasAsyncOutOfIrScope(body: ts.Node): boolean {
-  let found = false;
-  const walk = (node: ts.Node): void => {
-    if (found) return;
-    if (ts.isForOfStatement(node) && node.awaitModifier) {
-      found = true;
-      return;
-    }
-    if (
-      (ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node)) &&
-      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword)
-    ) {
-      found = true;
-      return;
-    }
-    ts.forEachChild(node, walk);
-  };
-  ts.forEachChild(body, walk);
-  return found;
 }
 
 const EMPTY: IrSelection = { funcs: new Set<string>() };
@@ -4324,7 +4227,11 @@ function isPhase1VarDecl(stmt: ts.VariableStatement, scope: Set<string>, localCl
       recordCallableProjection(d.name.text, d.initializer.parameters.length, d.initializer.type);
       continue;
     }
-    if (d.type && !isPhase1TypeNode(d.type)) {
+    if (
+      d.type &&
+      !isPhase1TypeNode(d.type) &&
+      !(currentFnIsAsync && currentSelectionOptions?.preparedAsyncPromiseVectorLocal?.(d) === true)
+    ) {
       // Module-init gets the logical extern brand from its direct legacy
       // global map, so nullable host-class annotations are safe here. A local
       // declaration (including a same-named shadow) resolves undefined and
@@ -6134,15 +6041,16 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
   }
   if (ts.isParenthesizedExpression(expr)) return isPhase1Expr(expr.expression, scope, localClasses);
   // (#1373b C-1) `await <e>` inside a C-1 async body mirrors legacy sync-model lowering:
-  //   - `await Promise.resolve(x)` → the settled expression `x` (#3227
-  //     static substitution) — check THAT shape; the zero-arg form settles
-  //     to `undefined`, which from-ast has no value lowering for → reject.
+  //   - `await Promise.resolve(x)` → static substitution; zero args settle to
+  //     `undefined`, which from-ast cannot lower.
   //   - anything else → the operand itself (identity / one-level unwrap).
   if (ts.isAwaitExpression(expr)) {
     if (!currentFnIsAsync) return shapeNo("expr-await-outside-async", expr);
     const settled = staticPromiseResolveSettledExpr(expr.expression);
     if (settled === "undefined") return shapeNo("expr-await-undefined-settle", expr);
     if (settled !== null) return isPhase1Expr(settled, scope, localClasses);
+    const preparedPromiseAll = preparedAsyncPromiseAllArguments(expr.expression, currentSelectionOptions);
+    if (preparedPromiseAll) return preparedPromiseAll.every((argument) => isPhase1Expr(argument, scope, localClasses));
     // Direct `await f(...)` of a local async fn — the ONE consumer position
     // where an async callee is claimable (both legacy and IR deliver the raw
     // `T`; #1796). Handled inline so the generic call arm can reject every
@@ -6719,9 +6627,8 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
       return true;
     }
     if (!ts.isIdentifier(expr.expression)) return false;
-    // (#1373b C-1) Only the await arm above admits local async callees; every
-    // other use remains a legacy thenable consumer.
-    if (currentAsyncDeclNames.has(expr.expression.text) && !scope.has(expr.expression.text)) {
+    // Only the await arm admits local async callees; other uses stay direct.
+    if (isUnpreparedAsyncCallee(expr, scope, currentAsyncDeclNames, currentSelectionOptions)) {
       return shapeNo("expr-async-callee-not-awaited", expr);
     }
     if (currentSelectionOptions?.ambientClassCalls?.(expr))

--- a/src/ir/value-coercion.ts
+++ b/src/ir/value-coercion.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrFunctionBuilder } from "./builder.js";
+import type { IrValueId } from "./nodes.js";
+
+/** Preserve an existing externref or cross the abstract anyref boundary once. */
+export function coerceIrValueToExternref(builder: IrFunctionBuilder, value: IrValueId): IrValueId {
+  const type = builder.typeOf(value);
+  return type.kind === "val" && type.val.kind === "externref" ? value : builder.emitCoerceToExternref(value);
+}

--- a/src/ir/vec-layout.ts
+++ b/src/ir/vec-layout.ts
@@ -2,6 +2,7 @@
 
 import { irTypeBindingKey } from "./abi-bindings.js";
 import {
+  forEachInstrDeep,
   type IrClosureSignature,
   type IrFunction,
   type IrInstr,
@@ -14,6 +15,8 @@ import {
 export interface IrVecLayoutAttachment {
   readonly function: IrFunction;
   readonly usesVec: boolean;
+  /** Backend-side evidence for logical vector types retained in IrAsyncPlan. */
+  readonly asyncPlanLayouts: ReadonlyMap<IrType, IrVecLayoutRef>;
 }
 
 function mapArray<T>(values: readonly T[], map: (value: T) => T): readonly T[] {
@@ -203,5 +206,83 @@ export function attachIrVecLayouts(
           blocks,
           ...(closureSubtype === undefined ? {} : { closureSubtype }),
         };
-  return Object.freeze({ function: mapped, usesVec });
+
+  // IrAsyncPlan stays canonical and target-neutral. Resolve every type site
+  // against the selected layout only to publish backend-side Program ABI
+  // evidence; never write the layout refs into the semantic plan or its hash.
+  const asyncPlanLayouts = new Map<IrType, IrVecLayoutRef>();
+  const seenAsyncTypes = new Set<IrType>();
+  const collectAsyncType = (type: IrType): void => {
+    if (seenAsyncTypes.has(type)) return;
+    seenAsyncTypes.add(type);
+    if (type.kind === "vec") {
+      const prepared = mapType(type);
+      if (prepared.kind !== "vec" || !prepared.layout) {
+        throw new Error("IR async vec type has no prepared backend layout evidence");
+      }
+      asyncPlanLayouts.set(type, prepared.layout);
+      collectAsyncType(type.elementType);
+      return;
+    }
+    switch (type.kind) {
+      case "object":
+        for (const field of type.shape.fields) collectAsyncType(field.type);
+        return;
+      case "closure":
+      case "callable":
+        for (const param of type.signature.params) collectAsyncType(param);
+        if (type.signature.returnType) collectAsyncType(type.signature.returnType);
+        return;
+      case "union":
+        for (const member of type.members) collectAsyncType(member);
+        return;
+      case "boxed":
+        collectAsyncType(type.inner);
+        return;
+      case "val":
+      case "string":
+      case "class":
+      case "extern":
+      case "dynamic":
+        return;
+    }
+  };
+  const collectAsyncInstr = (instr: IrInstr): void => {
+    forEachInstrDeep(instr, (nested) => {
+      if (nested.resultType) collectAsyncType(nested.resultType);
+      switch (nested.kind) {
+        case "const":
+          if (nested.value.kind === "null") collectAsyncType(nested.value.ty);
+          return;
+        case "box":
+          collectAsyncType(nested.toType);
+          return;
+        case "object.new":
+          for (const field of nested.shape.fields) collectAsyncType(field.type);
+          return;
+        case "closure.new":
+          for (const param of nested.signature.params) collectAsyncType(param);
+          if (nested.signature.returnType) collectAsyncType(nested.signature.returnType);
+          for (const capture of nested.captureFieldTypes) collectAsyncType(capture);
+          return;
+        case "vec.new_fixed":
+        case "forof.vec":
+          collectAsyncType(nested.elementType);
+          return;
+        default:
+          return;
+      }
+    });
+  };
+  if (fn.asyncPlan) {
+    if (fn.asyncPlan.abi.fulfillmentType) collectAsyncType(fn.asyncPlan.abi.fulfillmentType);
+    for (const value of fn.asyncPlan.params) collectAsyncType(value.type);
+    for (const value of fn.asyncPlan.values) collectAsyncType(value.type);
+    for (const spill of fn.asyncPlan.spills) collectAsyncType(spill.type);
+    for (const state of fn.asyncPlan.states) {
+      if (state.resume) collectAsyncType(state.resume.type);
+      for (const instr of state.body) collectAsyncInstr(instr);
+    }
+  }
+  return Object.freeze({ function: mapped, usesVec, asyncPlanLayouts });
 }

--- a/src/ir/vector-runtime.ts
+++ b/src/ir/vector-runtime.ts
@@ -6,12 +6,12 @@ import type { ValType } from "./types.js";
 export const IR_VEC_ELEM_SET_PREFIX = "__ir_vec_elem_set_";
 export const IR_VEC_NEW_SIZED_PREFIX = "__ir_vec_new_sized_";
 
-export type IrVectorRuntimeElementKind = "f64" | "i32";
+export type IrVectorRuntimeElementKind = "f64" | "i32" | "externref";
 
 /** Return the runtime-specializable scalar carried by a logical IR vector. */
 export function irVectorRuntimeElementKind(type: IrType): IrVectorRuntimeElementKind | null {
   const value = asVal(type);
-  return value?.kind === "f64" || value?.kind === "i32" ? value.kind : null;
+  return value?.kind === "f64" || value?.kind === "i32" || value?.kind === "externref" ? value.kind : null;
 }
 
 function requireRuntimeElementKind(type: IrType, operation: string): IrVectorRuntimeElementKind {
@@ -36,5 +36,5 @@ export function parseIrVectorRuntimeElement(
   prefix: typeof IR_VEC_ELEM_SET_PREFIX | typeof IR_VEC_NEW_SIZED_PREFIX,
 ): ValType | null {
   const suffix = symbol.startsWith(prefix) ? symbol.slice(prefix.length) : "";
-  return suffix === "f64" || suffix === "i32" ? { kind: suffix } : null;
+  return suffix === "f64" || suffix === "i32" || suffix === "externref" ? { kind: suffix } : null;
 }

--- a/tests/ir/issue-1373b-async-plan.test.ts
+++ b/tests/ir/issue-1373b-async-plan.test.ts
@@ -251,7 +251,7 @@ describe("#1373b IrAsyncPlan contract", () => {
 });
 
 describe("#1042/#1373b async migration anti-vacuity", () => {
-  it("IR-emits fetchUser while keeping the three remaining playground blockers typed", async () => {
+  it("IR-emits fetchUser and fetchAllParallel while keeping the two remaining playground blockers typed", async () => {
     const source = readFileSync(new URL("../../website/playground/examples/js/async.ts", import.meta.url), "utf8");
     const result = await compile(source, {
       fileName: "website/playground/examples/js/async.ts",
@@ -259,14 +259,19 @@ describe("#1042/#1373b async migration anti-vacuity", () => {
     });
     expect(result.success).toBe(true);
     const blockers = (result.irOutcomes ?? []).filter((outcome) => outcome.kind !== "emitted");
-    expect(blockers).toHaveLength(3);
+    expect(blockers).toHaveLength(2);
     expect(blockers.map((outcome) => [outcome.displayName, outcome.kind, outcome.stage, outcome.code]).sort()).toEqual([
-      ["fetchAllParallel", "unsupported", "select", "async-function"],
       ["fetchAllSequential", "unsupported", "select", "async-function"],
       ["main", "unsupported", "select", "async-function"],
     ]);
     expect(blockers.every((outcome) => outcome.legacyBodyEmitted && !outcome.irBodyEmitted)).toBe(true);
     expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "fetchUser")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "fetchAllParallel")).toMatchObject({
       kind: "emitted",
       legacyBodyEmitted: false,
       irBodyEmitted: true,

--- a/tests/issue-4106-ir-async-fetch-user.test.ts
+++ b/tests/issue-4106-ir-async-fetch-user.test.ts
@@ -229,13 +229,9 @@ describe("#4106 IR single-await async producer", () => {
     );
     expect(abiMismatch.success, abiMismatch.errors.map((error) => error.message).join("\n")).toBe(true);
     expect(WebAssembly.validate(abiMismatch.binary)).toBe(true);
-    expect(abiMismatch.irPostClaimErrors ?? []).toEqual([
-      expect.objectContaining({
-        func: "fetchFlag",
-        kind: "build",
-        message: expect.stringContaining("async-plan producer could not split"),
-      }),
-    ]);
+    // The final async fixed point rejects this ABI before the IR owner is
+    // claimed, so it stays on the direct route without a post-claim failure.
+    expect(abiMismatch.irPostClaimErrors ?? []).toEqual([]);
     expect(abiMismatch.irFirstSkipped ?? []).not.toContain("fetchFlag");
     expect((abiMismatch.irOutcomes ?? []).find((candidate) => candidate.displayName === "fetchFlag")).toMatchObject({
       legacyBodyEmitted: true,

--- a/tests/issue-4110-ir-fetch-all-parallel.test.ts
+++ b/tests/issue-4110-ir-fetch-all-parallel.test.ts
@@ -1,0 +1,683 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** #4110 — prepared Promise.all prefix plus numeric IR continuation. */
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import {
+  asAsyncStateId,
+  canonicalPromiseAbi,
+  createIrAsyncPlan,
+  hashIrAsyncPlan,
+  serializeIrAsyncPlan,
+} from "../src/ir/async-plan.js";
+import { ASYNC_RUNTIME_FEATURES } from "../src/ir/async-runtime-providers.js";
+import { prepareSingleAwaitIrFunction } from "../src/ir/async-prepare.js";
+import {
+  irCallableBindingKey,
+  irSupportFuncRef,
+  irUnitCallableBindingId,
+  irUnitFuncRef,
+} from "../src/ir/callable-bindings.js";
+import { buildIrUnitInventory } from "../src/ir/identity.js";
+import { exactPreparedUnitCallableBindingId } from "../src/ir/integration.js";
+import {
+  asBlockId,
+  asValueId,
+  irVal,
+  irVec,
+  type IrFunction,
+  type IrType,
+  type IrVecLayoutRef,
+} from "../src/ir/nodes.js";
+import {
+  derivePreparedComponentDependencies,
+  type PreparedComponentAbiEntry,
+} from "../src/ir/prepared-component-dependencies.js";
+import { attachIrVecLayouts } from "../src/ir/vec-layout.js";
+import { irSupportTypeRef, irTypeBindingKey } from "../src/ir/abi-bindings.js";
+import type { WasmFunction } from "../src/ir/types.js";
+import { ts } from "../src/ts-api.js";
+
+const EXACT_SOURCE = `
+  function delay(ms: number, value: number): Promise<number> {
+    return new Promise<number>((resolve) => {
+      setTimeout(() => resolve(value), ms);
+    });
+  }
+
+  async function fetchUser(id: number): Promise<number> {
+    const value = await delay(30, id * 10);
+    return value;
+  }
+
+  export async function fetchAllParallel(ids: number[]): Promise<number> {
+    const pending: Promise<number>[] = [];
+    for (let i = 0; i < ids.length; i++) {
+      pending.push(fetchUser(ids[i]));
+    }
+    const results = await Promise.all(pending);
+    let code = 0;
+    for (let i = 0; i < results.length; i++) {
+      code = code + results[i];
+    }
+    return code;
+  }
+`;
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.irPostClaimErrors ?? []).toEqual([]);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+}
+
+async function compileTracked(source = EXACT_SOURCE, fileName = "issue-4110-ir-fetch-all-parallel.ts") {
+  return compile(source, { fileName, target: "gc", emitWat: true, trackIrOutcomes: true });
+}
+
+function extractFunctionBody(wat: string, name: string): string {
+  const marker = `(func $${name}`;
+  const start = wat.indexOf(marker);
+  if (start < 0) throw new Error(`missing WAT function ${name}`);
+  let depth = 0;
+  for (let index = start; index < wat.length; index++) {
+    if (wat[index] === "(") depth++;
+    else if (wat[index] === ")" && --depth === 0) return wat.slice(start, index + 1);
+  }
+  throw new Error(`unterminated WAT function ${name}`);
+}
+
+function watFunctionIndex(wat: string, name: string): number {
+  const functions = [...wat.matchAll(/\(func \$([^\s(]+)/g)].map((match) => match[1]!);
+  const index = functions.indexOf(name);
+  if (index < 0) throw new Error(`missing WAT function index for ${name}`);
+  return index;
+}
+
+function expectExactMaterializedContinuation(wat: string): void {
+  const continuationName = "fetchAllParallel__ir_async_state_1";
+  const continuation = extractFunctionBody(wat, continuationName);
+  const resume = extractFunctionBody(wat, "__async_resume_ffetchAllParallel__ir");
+  const carrierType = continuation.match(/\(param \(ref null (\d+)\)\) \(result f64\)/)?.[1];
+  expect(carrierType, "prepared continuation lost its exact vec carrier ABI").toBeDefined();
+
+  const materializerName = `__vec_from_extern_${carrierType}`;
+  const materializer = extractFunctionBody(wat, materializerName);
+  const materializerIdx = watFunctionIndex(wat, materializerName);
+  const continuationIdx = watFunctionIndex(wat, continuationName);
+  const materializerCalls = [...resume.matchAll(new RegExp(`\\bcall ${materializerIdx}\\b`, "g"))];
+  const continuationCalls = [...resume.matchAll(new RegExp(`\\bcall ${continuationIdx}\\b`, "g"))];
+
+  expect(materializer).toMatch(new RegExp(`\\(param externref\\) \\(result \\(ref null ${carrierType}\\)\\)`));
+  expect(materializer).toMatch(/any\.convert_extern[\s\S]*ref\.test/);
+  expect(materializerCalls).toHaveLength(1);
+  expect(continuationCalls).toHaveLength(1);
+  expect(materializerCalls[0]!.index).toBeLessThan(continuationCalls[0]!.index);
+  expect(resume).not.toMatch(/any\.convert_extern|ref\.test/);
+}
+
+async function settled<T>(value: T | Promise<T>, ms = 4000): Promise<T> {
+  let watchdog: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve(value),
+      new Promise<never>((_, reject) => {
+        watchdog = setTimeout(() => reject(new Error("prepared Promise.all never settled")), ms);
+      }),
+    ]);
+  } finally {
+    if (watchdog !== undefined) clearTimeout(watchdog);
+  }
+}
+
+function numberVec(exports: WebAssembly.Exports, values: readonly number[]): unknown {
+  const allocate = exports.__new_vec_f64 as ((length: number) => unknown) | undefined;
+  const set = exports.__vec_set_byte as ((vec: unknown, index: number, value: number) => void) | undefined;
+  const get = exports.__vec_get as ((vec: unknown, index: number) => unknown) | undefined;
+  if (!allocate || !set || !get) throw new Error("numeric vector host bridge exports are unavailable");
+  const vec = allocate(values.length);
+  values.forEach((value, index) => set(vec, index, value));
+  values.forEach((value, index) => {
+    if (get(vec, index) !== value) throw new Error(`numeric vector bridge lost element ${index}`);
+  });
+  return vec;
+}
+
+describe("#4110 prepared fetchAllParallel", () => {
+  it("emits the exact owner and both helpers once with no direct body", async () => {
+    const result = await compileTracked();
+    expectSuccess(result);
+
+    expect(result.irFirstSkipped ?? []).toEqual(expect.arrayContaining(["delay", "fetchUser", "fetchAllParallel"]));
+    expect(result.irCompiledFuncs ?? []).toEqual(
+      expect.arrayContaining([
+        "fetchAllParallel",
+        "fetchAllParallel__ir_async_state_0",
+        "fetchAllParallel__ir_async_state_1",
+      ]),
+    );
+    expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "fetchAllParallel")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+
+    const source = extractFunctionBody(result.wat, "fetchAllParallel");
+    const entry = extractFunctionBody(result.wat, "fetchAllParallel__ir_async_state_0");
+    const continuation = extractFunctionBody(result.wat, "fetchAllParallel__ir_async_state_1");
+    const resume = extractFunctionBody(result.wat, "__async_resume_ffetchAllParallel__ir");
+    const fetchUserIdx = watFunctionIndex(result.wat, "fetchUser");
+    const promiseAllIdx = watFunctionIndex(result.wat, "Promise_all_import");
+    const functionNames = [...result.wat.matchAll(/\(func \$([^\s(]+)/g)].map((match) => match[1]!);
+    const scalarBridgeIndices = functionNames.flatMap((name, index) =>
+      name === "__unbox_number_import" || name === "__box_number_import" ? [index] : [],
+    );
+
+    expect(entry).toMatch(/array\.new_fixed/);
+    expect(entry.match(/array\.new_fixed/g)).toHaveLength(1);
+    expect(entry).toMatch(new RegExp(`\\bcall ${fetchUserIdx}\\b`));
+    expect(entry).toMatch(new RegExp(`\\bcall ${fetchUserIdx}\\b\\s+local\\.(?:tee|set) \\d+`));
+    expect(scalarBridgeIndices.length).toBeGreaterThan(0);
+    for (const index of scalarBridgeIndices) expect(entry).not.toMatch(new RegExp(`\\bcall ${index}\\b`));
+    expect(entry).toMatch(new RegExp(`\\bcall ${promiseAllIdx}\\b`));
+    expect(continuation).toMatch(/\(param \(ref null \d+\)\) \(result f64\)/);
+    expect(continuation).toMatch(/struct\.get[\s\S]*array\.get[\s\S]*f64\.add/);
+    expect(continuation).toMatch(/\(loop/);
+    expect(continuation.match(/\barray\.get\b/g)).toHaveLength(1);
+    expect(continuation.match(/\bf64\.add\b/g)).toHaveLength(1);
+    expect(continuation.match(/\bi32\.add\b/g)).toHaveLength(1);
+    expect(continuation.match(/\bbr_if\b/g)).toHaveLength(1);
+    expect(continuation).not.toMatch(/\bcall(?:_ref)?\b|any\.convert|extern\.convert|ref\.cast/);
+    expectExactMaterializedContinuation(result.wat);
+    expect(resume).toMatch(/struct\.set/);
+    expect(`${source}\n${continuation}\n${resume}`).not.toMatch(/array\.new_fixed/);
+  });
+
+  it("fans out before settlement and preserves Promise.all input order", async () => {
+    const result = await compileTracked(
+      EXACT_SOURCE.replace("async function fetchUser", "export async function fetchUser"),
+    );
+    expectSuccess(result);
+    const events: string[] = [];
+    const nativeSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((callback: (...args: unknown[]) => void, ms?: number, ...args: unknown[]) => {
+      events.push(`start:${Number(ms)}`);
+      return nativeSetTimeout(() => {
+        events.push(`done:${Number(ms)}`);
+        callback(...args);
+      }, ms);
+    }) as typeof setTimeout;
+    try {
+      const imports = buildImports(result.imports, undefined, result.stringPool);
+      const env = imports.env as Record<string, (...args: unknown[]) => unknown>;
+      const promiseAll = env.Promise_all!;
+      let aggregateValues: unknown;
+      env.Promise_all = (...args) =>
+        Promise.resolve(promiseAll(...args)).then((values) => {
+          aggregateValues = values;
+          return values;
+        });
+      const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+      imports.setExports?.(instance.exports as Record<string, Function>);
+
+      await expect(
+        Promise.all([1, 2, 3].map((id) => (instance.exports.fetchUser as (id: number) => Promise<number>)(id))),
+      ).resolves.toEqual([10, 20, 30]);
+      events.length = 0;
+
+      const ids = numberVec(instance.exports, [1, 2, 3]);
+      const resolved = await settled((instance.exports.fetchAllParallel as (ids: unknown) => Promise<number>)(ids));
+      expect(events.slice(0, 3)).toEqual(["start:30", "start:30", "start:30"]);
+      expect(events.findIndex((event) => event.startsWith("done:"))).toBeGreaterThanOrEqual(3);
+      expect(events.filter((event) => event.startsWith("done:")).slice(0, 3)).toEqual([
+        "done:30",
+        "done:30",
+        "done:30",
+      ]);
+      expect(aggregateValues).toEqual([10, 20, 30]);
+      expect(resolved).toBe(60);
+    } finally {
+      globalThis.setTimeout = nativeSetTimeout;
+    }
+  });
+
+  it("keeps the named materializer and continuation targets stable after a later direct import", async () => {
+    const result = await compileTracked(
+      `
+      ${EXACT_SOURCE}
+      export function lateDirect(value: any = "A"): boolean { return value === "A"; }
+    `,
+      "issue-4110-late-import-targets.ts",
+    );
+    expectSuccess(result);
+    expect(result.imports.map((entry) => entry.name)).toContain("__extern_is_undefined");
+    expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "fetchAllParallel")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "lateDirect")).toMatchObject({
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expectExactMaterializedContinuation(result.wat);
+  });
+
+  it("fails terminally without retrying the exact owner after preparation starts", async () => {
+    const previous = process.env.JS2WASM_TEST_INJECT_IR_PHASE_THROW;
+    process.env.JS2WASM_TEST_INJECT_IR_PHASE_THROW = "inline";
+    try {
+      const result = await compileTracked(EXACT_SOURCE, "issue-4110-preparation-failure.ts");
+      expect(result.success).toBe(false);
+      expect(result.irFirstSkipped ?? []).toContain("fetchAllParallel");
+      expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "fetchAllParallel")).toMatchObject({
+        kind: "invariant",
+        legacyBodyEmitted: false,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual(
+        expect.arrayContaining([expect.objectContaining({ func: "fetchAllParallel" })]),
+      );
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_INJECT_IR_PHASE_THROW");
+      else process.env.JS2WASM_TEST_INJECT_IR_PHASE_THROW = previous;
+    }
+  });
+
+  it("propagates the first aggregate rejection without settling the outer promise from the continuation", async () => {
+    const result = await compileTracked();
+    expectSuccess(result);
+    const imports = buildImports(result.imports, undefined, result.stringPool);
+    const env = imports.env as Record<string, (...args: unknown[]) => unknown>;
+    const newPending = env.Promise_new_pending!;
+    const settleResolve = env.Promise_settle_resolve!;
+    const settleReject = env.Promise_settle_reject!;
+    let outerPromise: unknown;
+    let outerResolves = 0;
+    let outerRejects = 0;
+    env.Promise_new_pending = (...args) => {
+      const promise = newPending(...args);
+      outerPromise ??= promise;
+      return promise;
+    };
+    env.Promise_settle_resolve = (...args) => {
+      if (args[0] === outerPromise) outerResolves++;
+      return settleResolve(...args);
+    };
+    env.Promise_settle_reject = (...args) => {
+      if (args[0] === outerPromise) outerRejects++;
+      return settleReject(...args);
+    };
+    env.Promise_all = () => Promise.reject(4110);
+
+    const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+    imports.setExports?.(instance.exports as Record<string, Function>);
+    const ids = numberVec(instance.exports, [1, 2, 3]);
+    await expect(settled((instance.exports.fetchAllParallel as (ids: unknown) => Promise<number>)(ids))).rejects.toBe(
+      4110,
+    );
+    expect(outerRejects).toBe(1);
+    expect(outerResolves).toBe(0);
+  });
+
+  it("keeps the unchanged non-identity owner direct on the host-free target", async () => {
+    const result = await compile(EXACT_SOURCE, {
+      fileName: "issue-4110-host-free.ts",
+      target: "standalone",
+      emitWat: true,
+      trackIrOutcomes: true,
+    });
+    expectSuccess(result);
+    expect(result.irFirstSkipped ?? []).not.toContain("fetchAllParallel");
+    expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "fetchAllParallel")).toMatchObject({
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+  });
+
+  it.each([
+    [
+      "ordinary array",
+      EXACT_SOURCE.replace("const pending: Promise<number>[] = [];", "const pending: number[] = [];").replace(
+        "pending.push(fetchUser(ids[i]));",
+        "pending.push(ids[i]);",
+      ),
+    ],
+    [
+      "non-numeric promise array",
+      EXACT_SOURCE.replace("const pending: Promise<number>[] = [];", "const pending: Promise<string>[] = [];")
+        .replace("pending.push(fetchUser(ids[i]));", "pending.push(Promise.resolve(ids[i].toString()));")
+        .replace("code = code + results[i];", "code = code + results[i].length;"),
+    ],
+    ["generic owner", EXACT_SOURCE.replace("fetchAllParallel(ids: number[])", "fetchAllParallel<T>(ids: number[])")],
+    [
+      "nested executable",
+      EXACT_SOURCE.replace("let code = 0;", "function zero(): number { return 0; }\n    let code = zero();"),
+    ],
+    [
+      "pre-await capture",
+      EXACT_SOURCE.replace(
+        "const pending: Promise<number>[] = [];",
+        "const offset = 1;\n    const pending: Promise<number>[] = [];",
+      ).replace("return code;", "return code + offset;"),
+    ],
+    [
+      "multiple awaits",
+      EXACT_SOURCE.replace(
+        "const results = await Promise.all(pending);",
+        "const results = await Promise.all(pending);\n    await Promise.resolve(0);",
+      ),
+    ],
+    [
+      "nullable vector ABI",
+      EXACT_SOURCE.replace("fetchAllParallel(ids: number[])", "fetchAllParallel(ids: number[] | null)")
+        .replaceAll("ids.length", "ids!.length")
+        .replaceAll("ids[i]", "ids![i]"),
+    ],
+  ])("keeps the %s near miss off prepared ownership", async (_label, source) => {
+    const result = await compileTracked(source, `issue-4110-${String(_label).replaceAll(" ", "-")}.ts`);
+    expectSuccess(result);
+    expect(result.irFirstSkipped ?? []).not.toContain("fetchAllParallel");
+    expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "fetchAllParallel")).toMatchObject({
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+  });
+
+  it("keeps static-settled identity owners and unresolved cycles off the prepared fixed point", async () => {
+    const source = `
+      async function staticValue(): Promise<number> {
+        const value = await Promise.resolve(1);
+        return value;
+      }
+      async function a(id: number): Promise<number> { const value = await b(id); return value; }
+      async function b(id: number): Promise<number> { const value = await a(id); return value; }
+      export async function cycle(ids: number[]): Promise<number> {
+        const pending: Promise<number>[] = [];
+        for (let i = 0; i < ids.length; i++) pending.push(a(ids[i]));
+        const values = await Promise.all(pending);
+        let total = 0;
+        for (let i = 0; i < values.length; i++) total = total + values[i];
+        return total;
+      }
+      export async function settled(): Promise<number> { const value = await staticValue(); return value; }
+    `;
+    const result = await compileTracked(source, "issue-4110-fixed-point-near-misses.ts");
+    expectSuccess(result);
+    for (const name of ["staticValue", "a", "b", "cycle", "settled"]) {
+      expect(result.irFirstSkipped ?? []).not.toContain(name);
+      expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === name)).toMatchObject({
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+    }
+  });
+});
+
+describe("#4110 target-neutral async vector evidence", () => {
+  function fixture() {
+    const source = ts.createSourceFile(
+      "issue-4110-sidecar.ts",
+      "export async function f(p: Promise<number[]>): Promise<number[]> { return await p; }",
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const inventory = buildIrUnitInventory([source], { entrySource: source });
+    const unit = inventory.terminalUnits.find((candidate) => candidate.displayName === "f")!;
+    const extern = irVal({ kind: "externref" });
+    const fulfilledVec = irVec(irVal({ kind: "f64" }), true);
+    const unrelatedVec = irVec(irVal({ kind: "f64" }), true);
+    const promise = asValueId(0);
+    const carried = asValueId(1);
+    const resumed = asValueId(2);
+    const plan = createIrAsyncPlan({
+      schemaVersion: 1,
+      ownerUnitId: unit.id,
+      kind: "async-function",
+      abi: canonicalPromiseAbi(fulfilledVec),
+      entry: asAsyncStateId(0),
+      params: [
+        { value: promise, type: extern },
+        { value: carried, type: unrelatedVec },
+      ],
+      values: [
+        { value: promise, type: extern },
+        { value: carried, type: unrelatedVec },
+        { value: resumed, type: fulfilledVec },
+      ],
+      spills: [{ value: carried, type: unrelatedVec, storage: "slot" }],
+      states: [
+        {
+          id: asAsyncStateId(0),
+          body: [],
+          terminator: {
+            kind: "suspend",
+            awaited: promise,
+            resume: { state: asAsyncStateId(1), value: resumed },
+            rejected: { kind: "reject" },
+            live: [carried],
+          },
+        },
+        {
+          id: asAsyncStateId(1),
+          resume: { value: resumed, type: fulfilledVec, source: "fulfilled" },
+          body: [],
+          terminator: { kind: "resolve", value: carried },
+        },
+      ],
+      handlers: [],
+      runtimeIntents: ASYNC_RUNTIME_FEATURES,
+    });
+    const fn: IrFunction = {
+      unitId: unit.id,
+      name: "f",
+      params: [{ value: promise, type: extern, name: "p" }],
+      resultTypes: [extern],
+      blocks: [{ id: asBlockId(0), blockArgs: [], blockArgTypes: [], instrs: [], terminator: { kind: "unreachable" } }],
+      exported: true,
+      valueCount: 3,
+      funcKind: "async",
+      asyncPlan: plan,
+      asyncRuntime: { kind: "host-wasmgc", adapters: [], states: plan.states },
+    };
+    const carrier = irSupportTypeRef(unit.sourceId, "vec-carrier", "vec-carrier");
+    const data = irSupportTypeRef(unit.sourceId, "vec-data", "vec-data");
+    const layout: IrVecLayoutRef = { carrierType: carrier, dataType: data, lengthFieldIndex: 0, dataFieldIndex: 1 };
+    const fromExtern = irSupportFuncRef(unit.sourceId, "vec-host-bridge", "__vec_from_extern_test", 6);
+    if (fromExtern.binding.kind !== "support") throw new Error("invalid vec materializer fixture");
+    const voidSignature = Object.freeze({ params: Object.freeze([]), results: Object.freeze([]) });
+    const sourceCallable: PreparedComponentAbiEntry = {
+      id: irUnitCallableBindingId(unit.id),
+      structuralReferenceKey: irCallableBindingKey(irUnitFuncRef(fn).binding),
+      slotPolicy: "required",
+      intent: { kind: "callable", origin: "source", unitId: unit.id, signature: voidSignature },
+    };
+    const materializerEntry: PreparedComponentAbiEntry = {
+      id: fromExtern.binding.bindingId,
+      structuralReferenceKey: irCallableBindingKey(fromExtern.binding),
+      slotPolicy: "required",
+      intent: { kind: "callable", origin: "support", sourceId: unit.sourceId, signature: voidSignature },
+    };
+    const typeEntry = (ref: typeof carrier): PreparedComponentAbiEntry => ({
+      id: ref.binding.bindingId,
+      structuralReferenceKey: irTypeBindingKey(ref.binding),
+      slotPolicy: "required",
+      intent: { kind: "type", shapeKey: ref.name },
+    });
+    const abi = new Map(
+      [sourceCallable, materializerEntry, typeEntry(carrier), typeEntry(data)].map(
+        (entry) => [entry.id, entry] as const,
+      ),
+    );
+    return { inventory, unit, fn, layout, fromExtern, abi };
+  }
+
+  it("keeps serialization/hash target-neutral while covering every exact final plan vector object", () => {
+    const { fn, layout } = fixture();
+    const before = serializeIrAsyncPlan(fn.asyncPlan!);
+    const beforeHash = hashIrAsyncPlan(fn.asyncPlan!);
+    const attachment = attachIrVecLayouts(fn, () => layout);
+    expect(attachment.function).toBe(fn);
+    expect(serializeIrAsyncPlan(fn.asyncPlan!)).toBe(before);
+    expect(hashIrAsyncPlan(fn.asyncPlan!)).toBe(beforeHash);
+    expect(fn.asyncPlan).not.toHaveProperty("typeLayouts");
+
+    const exactVecObjects = [
+      ...(fn.asyncPlan!.abi.fulfillmentType ? [fn.asyncPlan!.abi.fulfillmentType] : []),
+      ...fn.asyncPlan!.params.map((value) => value.type),
+      ...fn.asyncPlan!.values.map((value) => value.type),
+      ...fn.asyncPlan!.spills.map((spill) => spill.type),
+      ...fn.asyncPlan!.states.flatMap((state) => (state.resume ? [state.resume.type] : [])),
+    ].filter((type) => type.kind === "vec");
+    expect(attachment.asyncPlanLayouts.size).toBe(new Set(exactVecObjects).size);
+    expect(attachment.asyncPlanLayouts.size).toBeGreaterThan(1);
+    for (const type of exactVecObjects) expect(attachment.asyncPlanLayouts.get(type)).toBe(layout);
+  });
+
+  it("accepts only valid exact-identity async vec sidecars", () => {
+    const { inventory, unit, fn, layout, fromExtern, abi } = fixture();
+    const fulfilledResumeType = fn.asyncPlan!.states.find((state) => state.resume?.source === "fulfilled")!.resume!
+      .type;
+    const exactEntries = [...attachIrVecLayouts(fn, () => layout).asyncPlanLayouts].map(([logicalType, candidate]) => ({
+      logicalType,
+      layout: candidate,
+      ...(logicalType === fulfilledResumeType ? { fromExtern } : {}),
+    }));
+    const report = (
+      typeLayouts: readonly {
+        readonly logicalType: IrType;
+        readonly layout: IrVecLayoutRef;
+        readonly fromExtern?: ReturnType<typeof irSupportFuncRef>;
+      }[],
+    ) =>
+      derivePreparedComponentDependencies({
+        module: {
+          functions: [
+            {
+              ...fn,
+              asyncRuntime: {
+                ...fn.asyncRuntime!,
+                typeLayouts,
+              },
+            },
+          ],
+        },
+        terminalUnitIds: new Set([unit.id]),
+        inventory,
+        abi: { get: (id) => abi.get(id) },
+      }).components[0]!;
+
+    expect(report(exactEntries).failures).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "implicit-support-reference-unavailable" })]),
+    );
+    const fulfilledEntry = exactEntries.find((entry) => entry.logicalType === fulfilledResumeType)!;
+    const unrelatedEntry = exactEntries.find((entry) => entry.logicalType !== fulfilledResumeType)!;
+    expect(fulfilledEntry.fromExtern).toBe(fromExtern);
+    expect(unrelatedEntry).not.toHaveProperty("fromExtern");
+    expect(
+      report(exactEntries.map((entry) => (entry === unrelatedEntry ? { ...entry, fromExtern } : entry))).failures,
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "implicit-support-reference-unavailable",
+        detail: expect.stringContaining("outside an exact fulfilled resume type"),
+      }),
+    );
+    const wrongFromExtern = irSupportFuncRef(unit.sourceId, "vec-host-bridge", "__vec_from_extern_wrong", 7);
+    expect(
+      report(
+        exactEntries.map((entry) => (entry === fulfilledEntry ? { ...entry, fromExtern: wrongFromExtern } : entry)),
+      ).failures,
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "unplanned-abi-binding",
+        bindingId: wrongFromExtern.binding.kind === "support" ? wrongFromExtern.binding.bindingId : undefined,
+      }),
+    );
+    expect(
+      report([{ ...exactEntries[0]!, layout: { ...layout, dataFieldIndex: 0 } }, ...exactEntries.slice(1)]).failures,
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "implicit-support-reference-unavailable",
+        detail: expect.stringContaining("invalid field layout"),
+      }),
+    );
+    expect(report([...exactEntries, exactEntries[0]!]).failures).toContainEqual(
+      expect.objectContaining({
+        code: "implicit-support-reference-unavailable",
+        detail: expect.stringContaining("duplicate backend layout"),
+      }),
+    );
+    expect(
+      report([...exactEntries, { logicalType: irVal({ kind: "f64" }), layout, fromExtern }]).failures,
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "implicit-support-reference-unavailable",
+        detail: expect.stringContaining("non-vector"),
+      }),
+    );
+    expect(
+      report([...exactEntries, { logicalType: irVec(irVal({ kind: "f64" }), true), layout, fromExtern }]).failures,
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "implicit-support-reference-unavailable",
+        detail: expect.stringContaining("dangling"),
+      }),
+    );
+    expect(report(exactEntries.slice(1)).failures).toContainEqual(
+      expect.objectContaining({
+        code: "implicit-support-reference-unavailable",
+        detail: expect.stringContaining("no exact backend layout sidecar"),
+      }),
+    );
+  });
+
+  it("requires the planned binding to own the exact pre-sealed allocator object", () => {
+    const { unit } = fixture();
+    const owned: WasmFunction = { name: "owned", typeIdx: 0, locals: [], body: [], exported: false };
+    const foreign: WasmFunction = { ...owned, name: "foreign" };
+    const bindingId = irUnitCallableBindingId(unit.id);
+    const session = {
+      hasPlan: (candidate: typeof bindingId) => candidate === bindingId,
+      hasLocator: (candidate: typeof bindingId, func: WasmFunction) => candidate === bindingId && func === owned,
+    };
+    expect(exactPreparedUnitCallableBindingId(session, unit.id, owned)).toBe(bindingId);
+    expect(exactPreparedUnitCallableBindingId(session, unit.id, foreign)).toBeUndefined();
+  });
+
+  it("rejects a mutable slot used on both sides of the suspension", () => {
+    const { unit } = fixture();
+    const extern = irVal({ kind: "externref" });
+    const f64 = irVal({ kind: "f64" });
+    const promise = asValueId(0);
+    const written = asValueId(1);
+    const resumed = asValueId(2);
+    const returned = asValueId(3);
+    const fn: IrFunction = {
+      unitId: unit.id,
+      name: "sharedSlot",
+      params: [{ value: promise, type: extern, name: "p" }],
+      resultTypes: [f64],
+      blocks: [
+        {
+          id: asBlockId(0),
+          blockArgs: [],
+          blockArgTypes: [],
+          instrs: [
+            { kind: "const", value: { kind: "f64", value: 1 }, result: written, resultType: f64 },
+            { kind: "slot.write", slotIndex: 0, value: written, result: null, resultType: null },
+            { kind: "await", operand: promise, result: resumed, resultType: f64 },
+            { kind: "slot.read", slotIndex: 0, result: returned, resultType: f64 },
+          ],
+          terminator: { kind: "return", values: [returned] },
+        },
+      ],
+      exported: false,
+      valueCount: 4,
+      slots: [{ index: 0, name: "shared", type: f64 }],
+      funcKind: "async",
+    };
+    expect(prepareSingleAwaitIrFunction(fn)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- compile the checker-certified `fetchAllParallel` owner as one sealed prepared IR component spanning its source callable, entry helper, and post-resume continuation
- preserve the Promise source ABI separately from numeric fulfillment typing, and materialize the `Promise.all` host array into the typed vector representation before reduction
- resolve callable, vector, materializer, and runtime dependencies through stable Program ABI identities
- bank production readiness at 35/37 IR-emitted functions, 32 legacy bodies, two typed async blockers, and zero invariants

## Behavior and optimization parity

- all three requests start before any one settles, results retain input order, and the reduction returns `60`
- the first rejection bypasses the continuation and rejects the outer Promise
- the continuation retains direct indexed vector reads, numeric accumulation, and the grounded integer loop counter
- no new direct-only optimization was introduced, so no new optimization-retirement ledger row is needed
- unsupported near-misses remain direct or fail terminally after ownership, as specified

Tracked in `plan/issues/4110-ir-fetch-all-parallel-continuation.md`; sprint work is tracked in Markdown rather than GitHub Issues.

## Validation

- focused #4110 suite: 18/18 passed
- async/runtime/allocation/vector regression selection: 147/147 across 12 files
- typecheck and formatting passed
- source LOC and function-size budgets passed
- TypeOracle ratchet passed with zero new raw-checker accesses
- fallback and body-shape gates passed with zero unintended, post-claim, module, or shape-rejection growth
- hybrid readiness passed at 35/37 IR-emitted, 32 legacy bodies, two unsupported async owners, and zero invariants
- optimization-retirement validation passed all 22 tracked decisions: 11 IR-owned, one retirement-ready, and two source-anchored
