### PR TITLE
fix(#4010): S2 — tombstones, so `delete` is real on a non-$Object receiver

### DIFF
--- a/plan/issues/4010-m2-disjoint-receiver-side-tables.md
+++ b/plan/issues/4010-m2-disjoint-receiver-side-tables.md
@@ -1,10 +1,11 @@
 ---
 id: 4010
 title: "M2 — own properties on a non-$Object receiver live in TWO DISJOINT side tables that clobber each other; unify them"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-03
+assignee: ttraenkler/dev-4010-s2
 priority: high
 horizon: l
 feasibility: medium
@@ -345,3 +346,134 @@ never a redirection.
   construction**; `.tmp/delete-control.mts` is the precondition-gated version.
   S2 should promote the corrected control into a committed test rather than
   leave it in `.tmp/`.
+
+---
+
+# S2 — DONE. What landed, what it cost, and what S3 inherits
+
+Slice table:
+
+| slice | status | PR | what it changed |
+| --- | --- | --- | --- |
+| **S1′** clobber fix | done | #4058 | `defineProperty` stopped destroying the bag's value |
+| **S2** tombstones | **done** | this PR | `delete` is real on array + function own-property stores |
+| **S3** visibility | not started | — | `hasOwn`/`in`/gOPD/`keys` widening; **gated**, see below |
+
+## The mechanism, and the half the sketch did not predict
+
+The sketch's option (1) — "tombstone flag on the companion `$PropEntry`" — was
+**not** what the defect needed, and building it that way would have fixed
+nothing. The measured root cause is one level up:
+
+> `__delete_property`'s non-`$Object` arm **returned 1 (success) without
+> deleting anything.** `delete a.q` on an array reported `true` while `a.q`
+> stayed `12`. A loud claim of success covering a silent wrong answer.
+
+The values live in a per-receiver `$Object` **bag** (`vec-props.ts` #3537 for
+arrays, `closure-props.ts` #3468 for functions). Because a bag **is** an
+ordinary `$Object`, all of OrdinaryDelete already exists for it —
+`FLAG_TOMBSTONE`, the §10.1.10 configurability preflight, the count/tombstone
+bookkeeping. **No delete semantics were re-implemented.** The new native
+(`src/codegen/carrier-bag-delete.ts`) only finds the right bag and delegates,
+which is why a non-configurable entry still refuses correctly and why the
+refusal is byte-identical to the `$Object` control.
+
+**The half the sketch flagged as a "risk" turned out to be half the defect, and
+it needed its own fix.** The sketch said a companion-only tombstone *might*
+leave `__extern_get` answering from the bag. It does, always:
+
+```js
+a.q = 12;
+Object.defineProperty(a, "q", { writable: true });   // now in BOTH tables
+delete a.q;                                          // companion tombstoned
+a.q                                                  // => 12   (measured)
+```
+
+`__obj_find` **skips** tombstoned entries, so tombstoning the companion simply
+restores the fall-through to the bag. So the vec arm now **shadows the bag**
+after a successful companion delete. Confirmed by measurement, not by reading
+the sketch.
+
+## Why the result is tri-state, and why that is the whole safety argument
+
+`__carrier_bag_delete` returns **-1 not handled / 0 refused / 1 deleted**.
+Collapsing `-1` into `1` reproduces the original defect exactly — "I could not
+see anything" becoming indistinguishable from "there was nothing". Keeping them
+apart is also what makes the change **strictly additive**: the arm fires only
+for a key the bag *demonstrably holds*, so every receiver/key the old code
+answered for keeps its answer bit-for-bit.
+
+In particular the **#2896 builtin-fn arm still runs FIRST and returns**, so
+`delete fn.name` / `delete fn.length` never reach the new code. That is
+deliberate and load-bearing: `built-ins/**/{name,length}.js` is the ~700-file
+population that cost #4055 v1 **-684** host-free passes, and S2 does not touch
+it. A committed regression guard pins it.
+
+## Acceptance — the delete column, on TWO derivations each
+
+Every cell is precondition-gated (a failed precondition returns a distinct code
+so the case fails loudly instead of measuring nothing), and every compiled
+module is asserted to have **zero imports**.
+
+| cell | derivation | before | after |
+| --- | --- | --- | --- |
+| array named expando | value read | **STILL PRESENT** | genuinely absent |
+| array named expando | **bag's own record** — an attribute-only redefine re-seeds from the bag via S1′, never touching the read lane | bag still held `12` | bag empty |
+| array, key in BOTH tables | value read | **STILL PRESENT** | genuinely absent |
+| array, companion-only key | value read + gOPD | already correct | unchanged |
+| function expando | value read | **STILL PRESENT** | genuinely absent |
+| function expando | **closure bag's own record** — `__desc_has_own` via #4055's function-as-descriptor path, a different consumer entirely | bag still held `42` | bag empty |
+| `$Object` **CONTROL** | value read · hasOwn · non-configurable refusal | 3/3 correct | 3/3 correct |
+
+The delete's own return value is the reason one derivation was never enough:
+before S2 it already answered **`true`** on both arms while the value survived.
+
+Promoted into `tests/issue-4010.test.ts` (26 cases, incl. 3 SCOPE PINs and 2
+regression guards). `.tmp/matrix4010.mts`'s known-misleading delete column is
+superseded by it.
+
+## Byte-neutrality and blast radius
+
+- **gc/host mode: byte-identical** — same sha256 on a mixed probe module
+  exercising array/function/object deletes and for-in. Only standalone and wasi
+  binaries change (+166 / +133 bytes).
+- **No visibility surface moved.** `hasOwnProperty` / `__object_hasOwn` /
+  `__vec_gopd` / `Object.keys` reach is unchanged on both receivers, pinned by
+  the SCOPE PIN cases. S1′'s two pins are untouched; S2 adds three more.
+- `src/codegen/vec-overlay.ts` **shrank** (its `__delete_property` arm moved to
+  `vec-bag-seed.ts`, which now owns both directions of the seam); `object-runtime.ts`
+  shrank by 19 lines. No `loc-budget-allow` grant was needed or taken.
+
+## Found while measuring — NOT fixed here, and not caused here
+
+**`Reflect.deleteProperty` throws for every non-`$Object` receiver**, including
+plain success cases (`Reflect.deleteProperty(arr, "q")` on an ordinary expando).
+Verified **identical on base and after** — pre-existing, independent of S2. The
+`delete` operator is unaffected; only the `Reflect` spelling is. Worth a
+separate issue; deliberately out of S2's scope because fixing it would move a
+surface this slice promised not to move.
+
+## What S3 inherits
+
+1. **Deletability is now real, so visibility widening can pay out.** The -684
+   mechanism was `propertyHelper.js` getting a longer runway and then dying at
+   the `configurable` wall because `delete` did not work. That wall is gone for
+   array/function *named* keys.
+2. **The composition pattern to preserve** is still #4055 v2's: consult the
+   existing helper **first**, the bag **only on `false`** — additive, never a
+   redirection. `carrier-bag-delete.ts` follows it and is the shape to copy;
+   `__carrier_bag_delete`'s tri-state is the same idea for a non-boolean answer.
+3. **The gate is unchanged and non-negotiable**: run the entire
+   `built-ins/**/{name,length}.js` stratum (~700 files) explicitly, before the
+   PR goes near the queue.
+4. **Restore-after-delete is the new thing to check.** `verifyProperty` deletes
+   a property and then restores it with `Object.defineProperty`. On an **array**
+   that round-trips (the companion takes the redefine). On a **function** it does
+   **not**: `Object.defineProperty(fn, "p", …)` still lands nowhere (#4055's
+   finding), so a harness-driven delete of a function expando is now
+   irreversible where it used to be a silent no-op. S2's scoped sweep found no
+   file that hits this, but S3 widens exactly the visibility that gives
+   `propertyHelper` the runway to reach it — measure it explicitly.
+5. Class instances / Date / RegExp / Error remain **out of scope**: they have no
+   bag, so `__carrier_bag_delete` answers `-1` for them and nothing changed.
+   Their expando substrate is still greenfield (matrix rows 4-7).

--- a/src/codegen/carrier-bag-delete.ts
+++ b/src/codegen/carrier-bag-delete.ts
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4010 S2) `__carrier_bag_delete(obj, key)` — OrdinaryDelete over the
+ * own-property side table of a **non-`$Object` receiver**, and the non-`$Object`
+ * arms of `__delete_property` that reach it.
+ *
+ * ## The defect this closes
+ * `__delete_property`'s non-`$Object` arm returned **1 (success) without
+ * deleting anything**. That is the worst shape a gate can have: a loud claim of
+ * success covering a silent wrong answer. Measured on current main, standalone:
+ *
+ * ```js
+ * const a = [1,2,3]; a.q = 12; delete a.q;   // returns TRUE
+ * a.q                                        // => 12   (STILL PRESENT)
+ *
+ * function f(){}  f.p = 12;  delete f.p;     // returns TRUE
+ * f.p                                        // => 12   (STILL PRESENT)
+ * ```
+ *
+ * Both values live in a per-receiver `$Object` **bag** — `vec-props.ts` (#3537)
+ * for arrays, `closure-props.ts` (#3468) for functions — that the delete native
+ * had never heard of. Because the bag IS an ordinary `$Object`, the whole of
+ * OrdinaryDelete (§10.1.10: configurability preflight, `FLAG_TOMBSTONE`,
+ * count/tombstone bookkeeping) is already implemented for it — this native only
+ * has to find the right bag and delegate. No delete semantics are re-implemented
+ * here, which is why a non-configurable bag entry still refuses correctly.
+ *
+ * ## Tri-state, because a detector must be able to say "I don't know"
+ * The result is deliberately **-1 / 0 / 1**, not a boolean:
+ *
+ * | result | meaning                       | caller does            |
+ * | ------ | ----------------------------- | ---------------------- |
+ * | `-1`   | no bag, or the bag does not hold this key — **NOT HANDLED** | fall through, unchanged |
+ * | `0`    | the bag holds it and refused (non-configurable)              | `return 0`              |
+ * | `1`    | deleted                                                      | `return 1`              |
+ *
+ * Collapsing `-1` into `1` would make "I could not see anything" indistinguishable
+ * from "there was nothing", which is exactly the defect above. It is also what
+ * makes the change **strictly additive**: the arm fires only for a key the bag
+ * demonstrably holds, so every receiver/key the old code answered for keeps its
+ * answer bit-for-bit. In particular `delete fn.name` / `delete fn.length` on a
+ * builtin stays with the #2896 `__builtinfn_delete` arm, which runs FIRST and
+ * returns — this native is never consulted for it. That matters: the
+ * `built-ins/**\/{name,length}.js` stratum is the ~700-file population whose
+ * regression cost #4055 v1 **-684** host-free passes, and it is untouched here.
+ *
+ * ## Scope: delete only (#4010's ordering law)
+ * > Own-property VISIBILITY cannot ship before own-property DELETABILITY.
+ *
+ * S1' fixed the value clobber; this is S2. **No visibility surface moves**:
+ * `__hasOwnProperty` / `__object_hasOwn` / `__vec_gopd` / `Object.keys` reach is
+ * byte-identical, pinned by the SCOPE PIN cases in `tests/issue-4010.test.ts`.
+ * Widening those is S3 and is gated on running the `{name,length}.js` stratum
+ * explicitly first.
+ *
+ * ## LOOKUP, never ENSURE
+ * Same rule as `carrier-bag-hasown.ts`: deleting a key a receiver never had must
+ * not allocate a bag for it and hand a later `__integrity_bag` consumer a
+ * carrier that previously had none.
+ *
+ * ## Byte-neutrality
+ * Reserved only when a carrier predicate exists (standalone/wasi — in gc/host
+ * mode the `env::__extern_*` imports own the dynamic-property path), and the
+ * placeholder body is `i32.const -1` ("not handled"), so a skipped fill degrades
+ * to exactly today's behaviour instead of trapping.
+ */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { addFuncType } from "./registry/types.js";
+
+/** The tri-state carrier-bag delete native minted here. */
+export const CARRIER_BAG_DELETE = "__carrier_bag_delete";
+
+/** #3468 closure-own-property side table (`closure-props.ts`). */
+const IS_CLOSURE_PROP_CARRIER = "__is_closure_prop_carrier";
+const CLOSURE_BAG_LOOKUP = "__closure_bag_lookup";
+/** #3537 array-expando side table (`vec-props.ts`). */
+const IS_VEC_PROP_CARRIER = "__is_vec_prop_carrier";
+const VEC_BAG_LOOKUP = "__vec_bag_lookup";
+
+/** Sole local of `__carrier_bag_delete` (params are 0=obj, 1=key). */
+const BAG = 2;
+
+/**
+ * Reserve `__carrier_bag_delete(externref, externref) -> i32` as an
+ * `i32.const -1` placeholder, so `__delete_property`'s arms can bake a
+ * `call <idx>` before `fillCarrierBagDelete` knows `__delete_property`'s own
+ * index. Append-only mint (no funcIdx shifts), idempotent, and a no-op unless a
+ * carrier substrate was reserved. Returns the funcIdx, or `undefined`.
+ */
+export function reserveCarrierBagDelete(ctx: CodegenContext): number | undefined {
+  const existing = ctx.funcMap.get(CARRIER_BAG_DELETE);
+  if (existing !== undefined) return existing;
+  const hasCarrier =
+    ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER) !== undefined || ctx.funcMap.get(IS_VEC_PROP_CARRIER) !== undefined;
+  if (!hasCarrier) return undefined;
+
+  const externref = { kind: "externref" } as const;
+  const typeIdx = addFuncType(ctx, [externref, externref], [{ kind: "i32" }], `$${CARRIER_BAG_DELETE}_type`);
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: CARRIER_BAG_DELETE,
+    typeIdx,
+    locals: [{ name: "bag", type: externref }],
+    // Safe no-op: "not handled" ⇒ every caller keeps its pre-#4010 answer.
+    body: [{ op: "i32.const", value: -1 }],
+    exported: false,
+  });
+  ctx.funcMap.set(CARRIER_BAG_DELETE, funcIdx);
+  return funcIdx;
+}
+
+/**
+ * The non-`$Object` head of `__delete_property`'s body, in emission order:
+ *
+ * 1. the #2896 builtin-fn metadata arm (`delete fn.name` / `delete fn.length`) —
+ *    UNCHANGED, and deliberately first, so the `{name,length}.js` stratum never
+ *    reaches the bag arm;
+ * 2. `if (!(obj is $Object))` → consult the carrier bag; only a definite answer
+ *    (`>= 0`) returns, otherwise the historical `return 1` no-op success.
+ *
+ * `resultLocal` must be an i32 local of the enclosing native.
+ */
+export function buildNonObjectDeleteArms(
+  ctx: CodegenContext,
+  args: { bfnDeleteIdx: number | undefined; objectTypeIdx: number; anyLocal: number; resultLocal: number },
+): Instr[] {
+  const cbdIdx = ctx.funcMap.get(CARRIER_BAG_DELETE);
+  const bagArm: Instr[] =
+    cbdIdx === undefined
+      ? []
+      : [
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: 1 },
+          { op: "call", funcIdx: cbdIdx },
+          { op: "local.tee", index: args.resultLocal },
+          { op: "i32.const", value: 0 },
+          { op: "i32.ge_s" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "local.get", index: args.resultLocal }, { op: "return" }],
+          },
+        ];
+  return [
+    ...(args.bfnDeleteIdx !== undefined
+      ? ([
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: 1 },
+          { op: "call", funcIdx: args.bfnDeleteIdx },
+          { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 1 }, { op: "return" }] },
+        ] satisfies Instr[])
+      : []),
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.tee", index: args.anyLocal },
+    { op: "ref.test", typeIdx: args.objectTypeIdx },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...bagArm, { op: "i32.const", value: 1 }, { op: "return" }],
+    },
+  ];
+}
+
+/**
+ * Fill `__carrier_bag_delete` at FINALIZE, once `__delete_property` /
+ * `__obj_find` and both carrier substrates are in `funcMap`:
+ *
+ * ```
+ * bag = closure-carrier ? __closure_bag_lookup(obj)
+ *     : vec-carrier     ? __vec_bag_lookup(obj)
+ *     : null;                                  // LOOKUP, never ensure
+ * if (bag == null || !(bag is $Object)) return -1;
+ * if (__obj_find(bag, key) == null) return -1; // the bag does not hold it
+ * return __delete_property(bag, key);          // §10.1.10, already correct
+ * ```
+ *
+ * Leaves the `-1` placeholder in place when any dependency is missing.
+ */
+export function fillCarrierBagDelete(ctx: CodegenContext): void {
+  const cbdIdx = ctx.funcMap.get(CARRIER_BAG_DELETE);
+  if (cbdIdx === undefined) return;
+  const fn = definedFuncAt(ctx, cbdIdx);
+  if (!fn) return;
+  const objectTypeIdx = ctx.objectRuntimeTypes?.objectTypeIdx;
+  const objFindIdx = ctx.funcMap.get("__obj_find");
+  const deleteIdx = ctx.funcMap.get("__delete_property");
+  if (objectTypeIdx === undefined || objFindIdx === undefined || deleteIdx === undefined) return;
+
+  /** `if (<carrier predicate>) bag = <lookup>(obj);` guarded on bag still being null. */
+  const lookupArm = (isIdx: number | undefined, lookupIdx: number | undefined): Instr[] =>
+    isIdx === undefined || lookupIdx === undefined
+      ? []
+      : [
+          { op: "local.get", index: BAG },
+          { op: "ref.is_null" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 0 },
+              { op: "call", funcIdx: isIdx },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: 0 },
+                  { op: "call", funcIdx: lookupIdx },
+                  { op: "local.set", index: BAG },
+                ],
+              },
+            ],
+          },
+        ];
+
+  const closureArm = lookupArm(ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER), ctx.funcMap.get(CLOSURE_BAG_LOOKUP));
+  const vecArm = lookupArm(ctx.funcMap.get(IS_VEC_PROP_CARRIER), ctx.funcMap.get(VEC_BAG_LOOKUP));
+  if (closureArm.length === 0 && vecArm.length === 0) return;
+
+  const notHandled: Instr[] = [{ op: "i32.const", value: -1 }, { op: "return" }];
+  fn.body = [
+    ...closureArm,
+    ...vecArm,
+    { op: "local.get", index: BAG },
+    { op: "ref.is_null" },
+    { op: "if", blockType: { kind: "empty" }, then: notHandled.map((i) => ({ ...i })) },
+    // The `ref.test` is not decoration: a bag is a `__new_plain_object` product
+    // today, but a bare `ref.cast` would turn any future substrate change into a
+    // trap inside a helper that must never throw (#3468 S1 discipline).
+    { op: "local.get", index: BAG },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: objectTypeIdx },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: notHandled.map((i) => ({ ...i })) },
+    // Presence in the bag is what makes this arm additive — see the tri-state
+    // table above. `__obj_find` already skips tombstoned entries, so a key
+    // deleted twice reports "not handled" and the caller's `return 1` (delete of
+    // an absent own property succeeds, §10.1.10 step 2) stands.
+    { op: "local.get", index: BAG },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: objectTypeIdx },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: objFindIdx },
+    { op: "ref.is_null" },
+    { op: "if", blockType: { kind: "empty" }, then: notHandled.map((i) => ({ ...i })) },
+    { op: "local.get", index: BAG },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: deleteIdx },
+  ];
+}

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -82,6 +82,7 @@ import { buildApplyClosureArityWidening, buildTransferredCharAtApplyArm } from "
 import { addUnionImportsViaRegistry, flushLateImportShifts } from "./shared.js";
 import { reserveAccessorGetDriver, reserveAccessorSetDriver } from "./accessor-driver.js";
 import { registerDescriptorHasOwn } from "./carrier-bag-hasown.js"; // (#4055) descriptor-scoped HasProperty over the #3468 bag
+import { buildNonObjectDeleteArms, reserveCarrierBagDelete } from "./carrier-bag-delete.js"; // (#4010 S2) OrdinaryDelete over the carrier bags
 import { reserveClosurePropHelpers } from "./closure-props.js"; // (#3468 C-core) closure-own-property side table
 import { OBJECT_INTEGRITY_OBJ_PREDICATES } from "./object-integrity-carrier.js"; // (#4032)
 // (#3537) array ($Vec) expando side table — composes AROUND the #3468 closure
@@ -2702,36 +2703,15 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   // import parity).
   //
   // params: 0=obj(externref) 1=key(externref)
-  // locals: 2=any(anyref) 3=o(ref null $Object) 4=e(ref null $PropEntry)
+  // locals: 2=any(anyref) 3=o(ref null $Object) 4=e($PropEntry?) 5=cbd(i32)
   {
+    // (#4010 S2) The non-$Object head, owned by carrier-bag-delete.ts: the
+    // #2896 builtin-fn metadata arm FIRST (unchanged), then the #3468/#3537
+    // carrier-bag arm, then the historical `return 1` no-op success. See that
+    // module for why the bag consult is tri-state and strictly additive.
+    reserveCarrierBagDelete(ctx);
     const body: Instr[] = [
-      // (#2896) Builtin-fn metadata arm: `delete fn.name` / `delete fn.length`
-      // on a builtin function value marks the instance's deleted bit (the
-      // properties are configurable, §10.2.9) and reports success. Other
-      // receivers/keys fall through (the helper returns 0).
-      ...(bfnDeleteIdx !== undefined
-        ? ([
-            { op: "local.get", index: 0 },
-            { op: "local.get", index: 1 },
-            { op: "call", funcIdx: bfnDeleteIdx },
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [{ op: "i32.const", value: 1 }, { op: "return" }],
-            },
-          ] satisfies Instr[])
-        : []),
-      // any = any.convert_extern(obj) ; if !ref.test $Object → return 1 (no-op success)
-      { op: "local.get", index: 0 },
-      { op: "any.convert_extern" },
-      { op: "local.tee", index: 2 },
-      { op: "ref.test", typeIdx: objectTypeIdx },
-      { op: "i32.eqz" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [{ op: "i32.const", value: 1 }, { op: "return" }],
-      },
+      ...buildNonObjectDeleteArms(ctx, { bfnDeleteIdx, objectTypeIdx, anyLocal: 2, resultLocal: 5 }),
       // o = cast<$Object>(any) ; e = __obj_find(o, key)
       { op: "local.get", index: 2 },
       { op: "ref.cast", typeIdx: objectTypeIdx },
@@ -2816,6 +2796,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         { name: "any", type: { kind: "anyref" } },
         { name: "o", type: objRefNull },
         { name: "e", type: entryRefNull },
+        { name: "cbd", type: { kind: "i32" } }, // (#4010 S2) carrier-bag tri-state
       ],
       body,
     );

--- a/src/codegen/objvec-array-proto.ts
+++ b/src/codegen/objvec-array-proto.ts
@@ -5,10 +5,17 @@ import { ensureArrayNativeProtoGlue } from "./array-object-proto.js";
 import { definedFuncAt } from "./func-space.js";
 import { emitLazyNativeProtoGet } from "./native-proto.js";
 import { fillVecOverlayHelpers } from "./vec-overlay.js";
+import { fillCarrierBagDelete } from "./carrier-bag-delete.js";
 
 /** Finalize the generic vec overlay before installing the exact `$ObjVec` prototype arm. */
 export function fillObjVecReflectionHelpers(ctx: CodegenContext): void {
   fillVecOverlayHelpers(ctx);
+  // (#4010 S2) `__carrier_bag_delete`'s body needs `__delete_property`'s own
+  // funcIdx, so it is reserved early and filled here — the same finalize pass
+  // that owns the rest of the overlay↔bag seam. Order-independent: every caller
+  // baked the reserved index, and both bag lookups are funcMap entries from
+  // RESERVE time, not fill time.
+  fillCarrierBagDelete(ctx);
   fillObjVecArrayPrototypeArm(ctx);
 }
 

--- a/src/codegen/vec-bag-seed.ts
+++ b/src/codegen/vec-bag-seed.ts
@@ -58,9 +58,30 @@
  * Reached only from `fillVecOverlayHelpers`, which returns early unless
  * `ctx.standalone`, so gc/host output is unchanged. Degrades to emitting nothing
  * when `vec-props.ts` reserved no helpers (a module with no expando writes).
+ *
+ * ## (#4010 S2) The DELETE side of the same seam
+ * `buildVecDeletePrologue` below is the vec arm of `__delete_property`, moved
+ * here from `vec-overlay.ts` so both directions of the seam — seeding a value IN
+ * and taking a property OUT — have one owner. Its S2 change is the mirror of the
+ * seed's: the companion is not the whole store, so
+ *
+ *  - when the companion has **no** entry for the key, the #3537 bag is consulted
+ *    before reporting the historical no-op success (this is the `STILL PRESENT`
+ *    cell of #4010's capability matrix, measured on both arms); and
+ *  - when the companion **did** hold the key and the delete succeeded, the bag is
+ *    **shadowed** as well. Without that step a tombstoned companion entry simply
+ *    makes `__obj_find` return null again and `__extern_get`'s named-key prologue
+ *    falls through to the bag, which still holds the value — measured, not
+ *    assumed: `a.q=12; Object.defineProperty(a,"q",{writable:true}); delete a.q`
+ *    left `a.q === 12` with a companion-only tombstone.
+ *
+ * Both steps go through `__carrier_bag_delete` (`carrier-bag-delete.ts`), whose
+ * tri-state result keeps them additive; see that module for why.
  */
-import type { Instr } from "../ir/types.js";
+import type { Instr, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { CARRIER_BAG_DELETE } from "./carrier-bag-delete.js";
+import { nativeStringLiteralInstrs } from "./native-strings.js";
 
 /** #3537 array expando bag reader (`vec-props.ts`). */
 const VEC_PROP_GET = "__vec_prop_get";
@@ -193,4 +214,198 @@ export function buildBagValueSeed(
       ],
     },
   ];
+}
+
+/** Everything `buildVecDeletePrologue` needs from `fillVecOverlayHelpers`. */
+export interface VecDeleteDeps {
+  objectTypeIdx: number;
+  propEntryTypeIdx: number;
+  vecBaseIdx: number;
+  vecGopdIdx: number;
+  toPropertyKeyIdx: number;
+  externIsUndefinedIdx: number;
+  externGetIdx: number;
+  unboxBoolIdx: number;
+  deletePropertyIdx: number;
+  dpValueIdx: number;
+  objFindIdx: number;
+  ensureIdx: number;
+  numericFlagGlobalIdx: number;
+  /** `FLAG_DELETED_INDEX | FLAG_COMPANION_VALUE` — owned by `vec-overlay.ts`. */
+  deletedIndexFlags: number;
+  /** Fresh undefined-sentinel instrs (never a shared array — #DCE double-remap). */
+  missExtern: () => Instr[];
+  /** `idxLocal = __obj_index_of_key(key)` — canonical array index, or -1. */
+  parseIndex: (keyLocal: number, idxLocal: number) => Instr[];
+}
+
+/**
+ * Splice the vec arm into `__delete_property` (append-locals, splice-front —
+ * the #2190/#3183 fill discipline). §13.5.1 / §10.1.10 on a vec receiver:
+ *
+ * ```
+ * key = ToPropertyKey(key);
+ * if (obj is a vec) {
+ *   d = __vec_gopd(obj, key);
+ *   if (d === undefined) {                     // the companion does not know it
+ *     rc = __carrier_bag_delete(obj, key);     // (#4010 S2) ...but the BAG may
+ *     if (rc >= 0) return rc;
+ *     return 1;                                //   absent everywhere ⇒ success
+ *   }
+ *   if (!d.configurable) return 0;
+ *   comp = ensure(obj);
+ *   if (!isArrayIndex(key)) {
+ *     rc = __delete_property(comp, key);
+ *     if (rc) __carrier_bag_delete(obj, key);  // (#4010 S2) shadow the BAG
+ *     return rc;
+ *   }
+ *   <index key: mark the element deleted via the companion — unchanged>
+ * }
+ * ```
+ *
+ * The index arm is byte-identical to the version this replaces: it defines
+ * `undefined` into the companion and marks the entry
+ * `FLAG_DELETED_INDEX | FLAG_COMPANION_VALUE` so the read prologues answer a
+ * hole. Deliberately NOT given the bag steps — an index key's storage is the vec
+ * element, and the bag never owns one (`__vec_prop_set` writes named keys). This
+ * is the same explicit split as the seed's accessor exclusion: decide the case,
+ * do not pattern-match the neighbouring arm.
+ */
+export function buildVecDeletePrologue(ctx: CodegenContext, fn: WasmFunction, d: VecDeleteDeps): void {
+  const base = 2 + fn.locals.length;
+  const anyLocal = base;
+  const keyLocal = base + 1;
+  const descLocal = base + 2;
+  const compLocal = base + 3;
+  const entryLocal = base + 4;
+  const indexLocal = base + 5;
+  const rcLocal = base + 6;
+  fn.locals.push(
+    { name: "__vec_del_any", type: { kind: "anyref" } },
+    { name: "__vec_del_key", type: { kind: "externref" } },
+    { name: "__vec_del_desc", type: { kind: "externref" } },
+    { name: "__vec_del_comp", type: { kind: "ref_null", typeIdx: d.objectTypeIdx } },
+    { name: "__vec_del_entry", type: { kind: "ref_null", typeIdx: d.propEntryTypeIdx } },
+    { name: "__vec_del_index", type: { kind: "i32" } },
+    { name: "__vec_del_rc", type: { kind: "i32" } },
+  );
+
+  const cbdIdx = ctx.funcMap.get(CARRIER_BAG_DELETE);
+  /** `rc = __carrier_bag_delete(obj, key); if (rc >= 0) return rc;` */
+  const bagConsult: Instr[] =
+    cbdIdx === undefined
+      ? []
+      : [
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: keyLocal },
+          { op: "call", funcIdx: cbdIdx },
+          { op: "local.tee", index: rcLocal },
+          { op: "i32.const", value: 0 },
+          { op: "i32.ge_s" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "local.get", index: rcLocal }, { op: "return" }],
+          },
+        ];
+  /** Best-effort bag removal after the companion already agreed to the delete. */
+  const bagShadow: Instr[] =
+    cbdIdx === undefined
+      ? []
+      : [
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: keyLocal },
+          { op: "call", funcIdx: cbdIdx },
+          { op: "drop" },
+        ];
+
+  fn.body.unshift(
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: d.toPropertyKeyIdx },
+    { op: "local.set", index: keyLocal },
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.tee", index: anyLocal },
+    { op: "ref.test", typeIdx: d.vecBaseIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 0 },
+        { op: "local.get", index: keyLocal },
+        { op: "call", funcIdx: d.vecGopdIdx },
+        { op: "local.tee", index: descLocal },
+        { op: "call", funcIdx: d.externIsUndefinedIdx },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [...bagConsult, { op: "i32.const", value: 1 }, { op: "return" }],
+        },
+        { op: "local.get", index: descLocal },
+        ...nativeStringLiteralInstrs(ctx, "configurable"),
+        { op: "extern.convert_any" },
+        { op: "call", funcIdx: d.externGetIdx },
+        { op: "call", funcIdx: d.unboxBoolIdx },
+        { op: "i32.eqz" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+        },
+        { op: "local.get", index: anyLocal },
+        { op: "call", funcIdx: d.ensureIdx },
+        { op: "local.set", index: compLocal },
+        ...d.parseIndex(keyLocal, indexLocal),
+        { op: "local.get", index: indexLocal },
+        { op: "i32.const", value: 0 },
+        { op: "i32.lt_s" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: compLocal },
+            { op: "extern.convert_any" },
+            { op: "local.get", index: keyLocal },
+            { op: "call", funcIdx: d.deletePropertyIdx },
+            { op: "local.tee", index: rcLocal },
+            { op: "if", blockType: { kind: "empty" }, then: bagShadow },
+            { op: "local.get", index: rcLocal },
+            { op: "return" },
+          ],
+        },
+        { op: "i32.const", value: 1 },
+        { op: "global.set", index: d.numericFlagGlobalIdx },
+        { op: "local.get", index: compLocal },
+        { op: "extern.convert_any" },
+        { op: "local.get", index: keyLocal },
+        ...d.missExtern(),
+        { op: "f64.const", value: 0xbc },
+        { op: "call", funcIdx: d.dpValueIdx },
+        { op: "drop" },
+        { op: "local.get", index: compLocal },
+        { op: "ref.as_non_null" },
+        { op: "local.get", index: keyLocal },
+        { op: "call", funcIdx: d.objFindIdx },
+        { op: "local.tee", index: entryLocal },
+        { op: "ref.is_null" },
+        { op: "i32.eqz" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: entryLocal },
+            { op: "ref.as_non_null" },
+            { op: "local.get", index: entryLocal },
+            { op: "ref.as_non_null" },
+            { op: "struct.get", typeIdx: d.propEntryTypeIdx, fieldIdx: 2 },
+            { op: "i32.const", value: d.deletedIndexFlags },
+            { op: "i32.or" },
+            { op: "struct.set", typeIdx: d.propEntryTypeIdx, fieldIdx: 2 },
+          ],
+        },
+        { op: "i32.const", value: 1 },
+        { op: "return" },
+      ],
+    },
+  );
 }

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -81,7 +81,7 @@ import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecBaseType } from "./r
 import { nextModuleGlobalIdx } from "./registry/imports.js";
 import { reserveAccessorGetDriver } from "./accessor-driver.js";
 import { ensureVecElemSet } from "./vec-elem-set.js";
-import { buildBagValueSeed, buildRealElementSeed } from "./vec-bag-seed.js";
+import { buildBagValueSeed, buildRealElementSeed, buildVecDeletePrologue } from "./vec-bag-seed.js";
 import { undefinedExternInstrs } from "./any-helpers.js";
 import { nativeStringLiteralInstrs } from "./native-strings.js";
 
@@ -1520,111 +1520,31 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
     }
   }
 
+  // (#4010 S1′/S2) The vec arm of `__delete_property` lives in vec-bag-seed.ts —
+  // ONE owner for both directions of the overlay↔bag seam (seed a value in,
+  // delete a property out). See that module for the S2 bag consult + shadow.
   {
     const fn = findFn("__delete_property");
     const vecGopdIdx = ctx.funcMap.get(GOPD_NAME);
     if (fn && vecGopdIdx !== undefined) {
-      const base = 2 + fn.locals.length;
-      const anyLocal = base;
-      const keyLocal = base + 1;
-      const descLocal = base + 2;
-      const compLocal = base + 3;
-      const entryLocal = base + 4;
-      const indexLocal = base + 5;
-      fn.locals.push(
-        { name: "__vec_del_any", type: { kind: "anyref" } },
-        { name: "__vec_del_key", type: { kind: "externref" } },
-        { name: "__vec_del_desc", type: { kind: "externref" } },
-        { name: "__vec_del_comp", type: { kind: "ref_null", typeIdx: objectTypeIdx } },
-        { name: "__vec_del_entry", type: { kind: "ref_null", typeIdx: propEntryTypeIdx } },
-        { name: "__vec_del_index", type: { kind: "i32" } },
-      );
-      fn.body.unshift(
-        { op: "local.get", index: 1 },
-        { op: "call", funcIdx: toPropertyKeyIdx },
-        { op: "local.set", index: keyLocal },
-        { op: "local.get", index: 0 },
-        { op: "any.convert_extern" },
-        { op: "local.tee", index: anyLocal },
-        { op: "ref.test", typeIdx: vecBaseIdx },
-        {
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [
-            { op: "local.get", index: 0 },
-            { op: "local.get", index: keyLocal },
-            { op: "call", funcIdx: vecGopdIdx },
-            { op: "local.tee", index: descLocal },
-            { op: "call", funcIdx: externIsUndefinedIdx },
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [{ op: "i32.const", value: 1 }, { op: "return" }],
-            },
-            { op: "local.get", index: descLocal },
-            ...nativeStringLiteralInstrs(ctx, "configurable"),
-            { op: "extern.convert_any" },
-            { op: "call", funcIdx: externGetIdx },
-            { op: "call", funcIdx: unboxBoolIdx },
-            { op: "i32.eqz" },
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [{ op: "i32.const", value: 0 }, { op: "return" }],
-            },
-            { op: "local.get", index: anyLocal },
-            { op: "call", funcIdx: core.ensureIdx },
-            { op: "local.set", index: compLocal },
-            ...parseIndex(keyLocal, indexLocal),
-            { op: "local.get", index: indexLocal },
-            { op: "i32.const", value: 0 },
-            { op: "i32.lt_s" },
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [
-                { op: "local.get", index: compLocal },
-                { op: "extern.convert_any" },
-                { op: "local.get", index: keyLocal },
-                { op: "call", funcIdx: deletePropertyIdx },
-                { op: "return" },
-              ],
-            },
-            { op: "i32.const", value: 1 },
-            { op: "global.set", index: core.numericFlagGlobalIdx },
-            { op: "local.get", index: compLocal },
-            { op: "extern.convert_any" },
-            { op: "local.get", index: keyLocal },
-            ...missExtern(),
-            { op: "f64.const", value: 0xbc },
-            { op: "call", funcIdx: dpValueIdx },
-            { op: "drop" },
-            { op: "local.get", index: compLocal },
-            { op: "ref.as_non_null" },
-            { op: "local.get", index: keyLocal },
-            { op: "call", funcIdx: objFindIdx },
-            { op: "local.tee", index: entryLocal },
-            { op: "ref.is_null" },
-            { op: "i32.eqz" },
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [
-                { op: "local.get", index: entryLocal },
-                { op: "ref.as_non_null" },
-                { op: "local.get", index: entryLocal },
-                { op: "ref.as_non_null" },
-                { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
-                { op: "i32.const", value: FLAG_DELETED_INDEX | FLAG_COMPANION_VALUE },
-                { op: "i32.or" },
-                { op: "struct.set", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
-              ],
-            },
-            { op: "i32.const", value: 1 },
-            { op: "return" },
-          ],
-        },
-      );
+      buildVecDeletePrologue(ctx, fn, {
+        objectTypeIdx,
+        propEntryTypeIdx,
+        vecBaseIdx,
+        vecGopdIdx,
+        toPropertyKeyIdx,
+        externIsUndefinedIdx,
+        externGetIdx,
+        unboxBoolIdx,
+        deletePropertyIdx,
+        dpValueIdx,
+        objFindIdx,
+        ensureIdx: core.ensureIdx,
+        numericFlagGlobalIdx: core.numericFlagGlobalIdx,
+        deletedIndexFlags: FLAG_DELETED_INDEX | FLAG_COMPANION_VALUE,
+        missExtern,
+        parseIndex,
+      });
     }
   }
   fillVecHasOwnHelpers(ctx, vecBaseIdx);

--- a/tests/issue-4010.test.ts
+++ b/tests/issue-4010.test.ts
@@ -132,3 +132,277 @@ describe("#4010 S1′ — defineProperty no longer clobbers an array expando's v
     ).toBe(2);
   });
 });
+
+// ===========================================================================
+// #4010 S2 — TOMBSTONES: `delete` is real on the carrier own-property stores.
+//
+// This block is the promoted, PRECONDITION-GATED delete control. The plain
+// version of this matrix was WRONG in two ways at once and is why the gating
+// exists (see the issue file):
+//
+//  - it measured "deleted" as `hasOwnProperty(o,"q") === false`, which is
+//    `false` on an array/function receiver whether or not the value survived —
+//    so it read "ok" while `o.q === 12` was still true;
+//  - on receivers where the write never landed at all, "not an own property
+//    afterwards" carries zero information — the cell is VACUOUS, not passing.
+//
+// So every case below:
+//  1. RETURNS 0 when its own precondition fails (`expect(...).toBe(1)` then
+//     fails loudly instead of the case quietly measuring nothing), and
+//  2. is asserted through TWO INDEPENDENT DERIVATIONS of "is the key in the
+//     store?" — a value read, and a path that consults the store's own record
+//     without going through the read lane at all (see each case).
+//
+// `run()` above additionally asserts ZERO imports per compiled module, so a
+// case cannot pass by silently falling back to a JS host.
+//
+// Acceptance for this slice is these cells, NOT pass-count: tombstones alone
+// flip few test262 files, because currently-invisible properties fail earlier
+// in `propertyHelper`. Deletability and visibility pay out together, and
+// visibility is S3 (gated on the ~700-file `{name,length}.js` stratum control).
+// ===========================================================================
+describe("#4010 S2 — delete is real on a non-$Object receiver's own-property store", () => {
+  // ---- ARRAY (the #3537 bag) ----------------------------------------------
+  it("array: the value is genuinely gone after delete (derivation 1 — value read)", async () => {
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1,2,3];
+  a.q = 12;
+  if (a.q !== 12) return 0;                  // precondition: the write landed
+  delete a.q;
+  return a.q === undefined ? 1 : (a.q === 12 ? 2 : 3);
+}`),
+    ).toBe(1);
+  });
+
+  it("array: the BAG's own record is empty after delete (derivation 2 — the S1′ seed)", async () => {
+    // An attribute-only `defineProperty` seeds the companion's pre-state FROM
+    // THE BAG (S1′), and that path never touches `__extern_get`. So the value
+    // read here answers "what does the bag still hold?" — 12 if the delete only
+    // stopped the read, undefined if the entry is really gone.
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1,2,3];
+  a.q = 12;
+  if (a.q !== 12) return 0;
+  delete a.q;
+  Object.defineProperty(a, "q", { writable: false });
+  return a.q === undefined ? 1 : (a.q === 12 ? 2 : 3);
+}`),
+    ).toBe(1);
+  });
+
+  it("array: a key held by BOTH tables is gone from both (the companion tombstone must shadow the bag)", async () => {
+    // The mechanism that made this fail: `__delete_property` tombstones the
+    // companion entry, `__obj_find` then skips it, and `__extern_get`'s
+    // named-key prologue falls straight through to the bag — which still had 12.
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1,2,3];
+  a.q = 12;
+  Object.defineProperty(a, "q", { writable: true });
+  if (a.q !== 12) return 0;
+  delete a.q;
+  return a.q === undefined ? 1 : (a.q === 12 ? 2 : 3);
+}`),
+    ).toBe(1);
+  });
+
+  it("array: a companion-only key stays deletable, by value AND by gOPD", async () => {
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1,2,3];
+  Object.defineProperty(a, "q", { value: 5, writable: true, enumerable: true, configurable: true });
+  if (a.q !== 5) return 0;
+  if (Object.getOwnPropertyDescriptor(a, "q") === undefined) return 0;   // gOPD must SEE it first
+  delete a.q;
+  const gone = a.q === undefined && Object.getOwnPropertyDescriptor(a, "q") === undefined;
+  return gone ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  // ---- FUNCTION (the #3468 closure bag) -----------------------------------
+  it("function: the value is genuinely gone after delete (derivation 1 — value read)", async () => {
+    expect(
+      await run(`export function test(): number {
+  function f(){}
+  const g: any = f;
+  g.p = 12;
+  if (g.p !== 12) return 0;
+  delete g.p;
+  return g.p === undefined ? 1 : (g.p === 12 ? 2 : 3);
+}`),
+    ).toBe(1);
+  });
+
+  it("function: the closure BAG's own record is empty after delete (derivation 2 — __desc_has_own)", async () => {
+    // #4055's ToPropertyDescriptor reads a function-shaped descriptor through
+    // `__desc_has_own`, which queries the closure bag directly — a completely
+    // different consumer from the `g.p` read lane. If `value` survived the
+    // delete, `o.p` becomes 42.
+    expect(
+      await run(`export function test(): number {
+  function f(){}
+  const d: any = f;
+  d.value = 42; d.writable = true; d.enumerable = true; d.configurable = true;
+  if (d.value !== 42) return 0;
+  delete d.value;
+  const o: any = {};
+  Object.defineProperty(o, "p", d);
+  return o.p === undefined ? 1 : (o.p === 42 ? 2 : 3);
+}`),
+    ).toBe(1);
+  });
+
+  // ---- the arm must be ADDITIVE, not a redirection -------------------------
+  it("array: a non-configurable companion entry still REFUSES (and the value survives)", async () => {
+    // Strict-mode `delete` of a non-configurable own property throws TypeError
+    // (§13.5.1.2) — identical to the $Object control below. The bag must not be
+    // emptied behind a refusal.
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1,2,3];
+  a.q = 12;
+  Object.defineProperty(a, "q", { configurable: false });
+  if (a.q !== 12) return 0;
+  let threw = 0;
+  try { delete a.q; } catch (e) { threw = 1; }
+  return (threw === 1 && a.q === 12) ? 1 : (threw === 0 ? 2 : 3);
+}`),
+    ).toBe(1);
+  });
+
+  it("CONTROL $Object: the same refusal, so a failure above is the substrate not the harness", async () => {
+    expect(
+      await run(`export function test(): number {
+  const o: any = {};
+  Object.defineProperty(o, "q", { value: 5, configurable: false });
+  if (o.q !== 5) return 0;
+  let threw = 0;
+  try { delete o.q; } catch (e) { threw = 1; }
+  return (threw === 1 && o.q === 5) ? 1 : (threw === 0 ? 2 : 3);
+}`),
+    ).toBe(1);
+  });
+
+  it("array: a plain expando delete does NOT throw and sibling keys survive", async () => {
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1,2,3];
+  a.q = 12; a.r = 34;
+  if (a.q !== 12 || a.r !== 34) return 0;
+  let threw = 0;
+  try { delete a.q; } catch (e) { threw = 1; }
+  return (threw === 0 && a.q === undefined && a.r === 34) ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  it("array: elements, length and index-delete semantics are untouched", async () => {
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1,2,3];
+  a.q = 12;
+  if (a.q !== 12) return 0;
+  delete a.q;
+  delete a[1];
+  return (a.length === 3 && a[0] === 1 && a[1] === undefined && a[2] === 3) ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  it("array: two arrays keep independent stores (identity keying survives delete)", async () => {
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1]; const b: any = [2];
+  a.q = 12; b.q = 34;
+  if (a.q !== 12 || b.q !== 34) return 0;
+  delete a.q;
+  return (a.q === undefined && b.q === 34) ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  it("delete of a key the store never held still reports success (§10.1.10 step 2)", async () => {
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1,2,3];
+  function f(){}
+  const g: any = f;
+  return ((delete a.never) && (delete g.never)) ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  it("re-setting after a delete round-trips on both receivers", async () => {
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1]; a.q = 12; delete a.q; a.q = 7;
+  function f(){}
+  const g: any = f; g.p = 1; delete g.p; g.p = 9;
+  return (a.q === 7 && g.p === 9) ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  // ---- the -684 stratum stays out of scope --------------------------------
+  it("REGRESSION GUARD: `delete fn.name` still routes to the #2896 builtin-fn arm", async () => {
+    // The builtin-fn metadata arm runs BEFORE the carrier-bag arm and returns,
+    // so `built-ins/**/{name,length}.js` — the ~700-file population that cost
+    // #4055 v1 -684 host-free passes — never reaches the new code.
+    expect(
+      await run(`export function test(): number {
+  const f: any = Array.prototype.push;
+  if (typeof f.name !== "string") return 0;
+  delete f.name;
+  return f.name === undefined ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  it("REGRESSION GUARD: #4055's function-as-descriptor path is unchanged", async () => {
+    expect(
+      await run(`export function test(): number {
+  function d(){}
+  const dd: any = d;
+  dd.value = 42; dd.writable = true; dd.enumerable = true; dd.configurable = true;
+  const o: any = {};
+  Object.defineProperty(o, "p", dd);
+  return o.p === 42 ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  // ---- S2 moves NO visibility surface (#4010's ordering law) --------------
+  it("SCOPE PIN: array hasOwnProperty reach is STILL unchanged after S2", async () => {
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1];
+  a.q = 12;
+  return Object.prototype.hasOwnProperty.call(a, "q") ? 1 : 2;
+}`),
+    ).toBe(2);
+  });
+
+  it("SCOPE PIN: function hasOwnProperty reach is STILL unchanged after S2", async () => {
+    expect(
+      await run(`export function test(): number {
+  function f(){}
+  const g: any = f;
+  g.p = 12;
+  return Object.prototype.hasOwnProperty.call(g, "p") ? 1 : 2;
+}`),
+    ).toBe(2);
+  });
+
+  it("SCOPE PIN: array gOPD reach for a bag-only expando is STILL unchanged", async () => {
+    expect(
+      await run(`export function test(): number {
+  const a: any = [1];
+  a.q = 12;
+  return Object.getOwnPropertyDescriptor(a, "q") === undefined ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Read this first: acceptance here is NOT pass-count

Per #4010's slice plan, agreed with the tech lead:

> Accept on the **delete-column cells going STILL-PRESENT → genuinely-absent**,
> verified **both** by value read **and** by the store's own record.

Tombstones alone flip few test262 files, because currently-invisible properties
fail *earlier* in `propertyHelper`. Deletability and visibility only pay out
**together**, and visibility is S3. **A low corpus flip count is the expected
outcome of this slice, not a failure** — see the numbers at the bottom.

## The defect

`__delete_property`'s non-`$Object` arm returned **1 (success) without deleting
anything** — a loud claim of success covering a silent wrong answer. Measured on
current main, standalone:

```js
const a = [1,2,3]; a.q = 12; delete a.q;   // returns TRUE
a.q                                        // => 12   (STILL PRESENT)

function f(){}  f.p = 12;  delete f.p;     // returns TRUE
f.p                                        // => 12   (STILL PRESENT)
```

Both values live in a per-receiver `$Object` **bag** — `vec-props.ts` (#3537)
for arrays, `closure-props.ts` (#3468) for functions — that the delete native
had never heard of.

## The fix

A bag **is** an ordinary `$Object`, so all of OrdinaryDelete already exists for
it (§10.1.10 configurability preflight, `FLAG_TOMBSTONE`, count/tombstone
bookkeeping). The new `__carrier_bag_delete` finds the right bag and delegates.
**No delete semantics are re-implemented** — which is why a non-configurable
entry still refuses correctly, byte-identically to the `$Object` control.

**The half the design sketch did not predict.** The sketch flagged as a *risk*
that a companion-only tombstone *might* leave `__extern_get` answering from the
bag. It does, always — `__obj_find` **skips** tombstoned entries, so tombstoning
the companion simply restores the fall-through:

```js
a.q = 12;
Object.defineProperty(a, "q", { writable: true });   // now in BOTH tables
delete a.q;                                          // companion tombstoned
a.q                                                  // => 12   (measured)
```

So the vec arm now also **shadows the bag** after a successful companion delete.

**Tri-state on purpose**: `-1` not handled / `0` refused / `1` deleted.
Collapsing `-1` into `1` reproduces the original defect exactly — "I could not
see anything" becoming indistinguishable from "there was nothing". It is also
what makes the change **strictly additive**: the arm fires only for a key the
bag *demonstrably holds*, so every receiver/key the old code answered for keeps
its answer bit-for-bit.

## Scope, and why the −684 stratum cannot fire

Per #4010's ordering law (*visibility cannot ship before deletability*), **no
own-property visibility surface moves**: `hasOwnProperty` / `__object_hasOwn` /
`__vec_gopd` / `Object.keys` reach is unchanged, pinned by SCOPE PIN tests
(S1′'s two are untouched; three more added).

The **#2896 builtin-fn arm still runs FIRST and returns**, so `delete fn.name` /
`delete fn.length` never reach the new code — `built-ins/**/{name,length}.js`,
the ~700-file population that cost #4055 v1 **−684** host-free passes, is
untouched. Pinned by a committed regression guard **and** measured (below).

## Acceptance evidence — two independent derivations per cell

Every case is precondition-gated (a failed precondition returns a distinct code,
so it fails loudly instead of measuring nothing) and every compiled module is
asserted to have **zero imports**.

| cell | derivation | before | after |
| --- | --- | --- | --- |
| array named expando | value read | **STILL PRESENT** | genuinely absent |
| array named expando | **bag's own record** — attribute-only redefine re-seeds from the bag via S1′, never touching the read lane | bag still held `12` | bag empty |
| array, key in BOTH tables | value read | **STILL PRESENT** | genuinely absent |
| array, companion-only key | value read + gOPD | already correct | unchanged |
| function expando | value read | **STILL PRESENT** | genuinely absent |
| function expando | **closure bag's own record** — `__desc_has_own` via #4055's function-as-descriptor path, a different consumer entirely | bag still held `42` | bag empty |
| `$Object` **CONTROL** | value read · hasOwn · non-configurable refusal | 3/3 correct | 3/3 correct |

One derivation was never enough here: the delete's own **return value already
answered `true` on both arms while the value survived**.

## Corpus numbers (low, as predicted — with denominators)

- **74 / 74 files identical**, base vs. this branch, over the population most
  likely to be affected: test262 files performing a member `delete` whose
  receiver is statically an array or function (74 of the 797 member-delete files
  in the 43,488-file corpus). Zero regressions, zero gains.
- **`built-ins/**/{name,length}.js` stratum (1,240 files)**: see the comment
  below for the base-vs-branch diff.
- **Equivalence gate: no new regressions** (32 failing / 1,619 passing / 36
  known-failures in baseline; 4 pre-existing baseline failures now pass, all
  unrelated — i32 peephole, `Math.pow`, Symbol — so the shared baseline is
  deliberately **not** ratcheted here).
- **gc/host mode is byte-identical** (same sha256 on a mixed probe module
  exercising array/function/object deletes and for-in). Only standalone (+166 B)
  and wasi (+133 B) change.
- 5 pre-existing failures in adjacent delete tests (#1821, #2130 ×3, #2992)
  reproduce **identically on base** — not caused here.

## Found while measuring, deliberately NOT fixed

**`Reflect.deleteProperty` throws for every non-`$Object` receiver**, including
plain success cases. Verified **identical on base and after** — pre-existing and
independent of S2. The `delete` operator is unaffected. Fixing it would move a
surface this slice promised not to move; it wants its own issue.

## Structure

`src/codegen/vec-overlay.ts` **shrank** — its `__delete_property` arm moved into
`vec-bag-seed.ts`, which now owns both directions of the overlay↔bag seam
(seeding a value in, taking a property out). `object-runtime.ts` shrank by 19
lines. No `loc-budget-allow` grant was needed or taken.

Closes the S2 slice of #4010; unblocks #4098. `status:` stays `in-progress`
because S3 remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)