### PR TITLE
perf(#4122): an unresolvable assignment is not a cross-domain one — method axis 3.6x, plus #4121/#4123

### DIFF
--- a/plan/issues/4121-generic-carrier-unboxing.md
+++ b/plan/issues/4121-generic-carrier-unboxing.md
@@ -113,6 +113,23 @@ Case 4 in the table above (`var i = s.indexOf(";")`, declared `any`, so it *is* 
 candidate) still fails, so there is at least a second, independent gap in
 proving a string receiver for an unannotated parameter. Both need pinning.
 
+### The demotion has since been pinned to one line — see #4122
+
+An independent bisect of the `method` axis landed on the mechanism behind the
+table above: `bindingHasMixedAssignmentCarrier`
+(`src/codegen/analysis/mixed-assignment-carrier.ts`, wired at
+`src/codegen/statements/variables.ts:150`) demotes a binding to `externref` when
+`oracle.staticJsTypeOf` of any assignment is `"mixed"` — which is the oracle's
+answer for **unresolvable**, not for **proven cross-domain**. Absence of
+evidence is read as evidence of mixing.
+
+#4122 covers that narrow fix (a measured 3.5x regression on the `method` axis).
+It is the immediate first slice of this issue and should land independently.
+This issue remains the general problem: even once `"mixed"` is read correctly,
+the verdict is still consulted **per carrier kind**, so a numeric value flowing
+local → argument → parameter → return → field is re-boxed at every hop that has
+no bespoke pass yet.
+
 ## The structural problem: one analysis, four bespoke consumers
 
 `analyzeNumericPropertyNames` computes one whole-program verdict. It has been

--- a/plan/issues/4121-generic-carrier-unboxing.md
+++ b/plan/issues/4121-generic-carrier-unboxing.md
@@ -1,0 +1,223 @@
+---
+id: 4121
+title: "perf: generic carrier unboxing — one `any`-typed definition boxes an entire numeric local, and every carrier needs its own bespoke pass"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: performance
+area: codegen
+language_feature: value-representation
+goal: performance
+related: [684, 3683, 3754, 3765, 4118, 2773, 1624]
+origin: "measured on upstream/main d369562d7, 2026-08-03, investigating the residual 10x vs node on real npm packages"
+---
+
+# #4121 — generic carrier unboxing
+
+## Where the remaining gap actually is
+
+Measured on `d369562d7`, all legs same container, checksums matching.
+
+The **micro-benchmark axes are at or near parity** — the boxing on those paths
+has already been eliminated by #3683 / #3754 / #3765:
+
+| axis      | node | js2  |        |
+| --------- | ---: | ---: | ------ |
+| numeric   | 2.42 | 2.40 | parity |
+| prop      | 1.14 | 1.08 | parity |
+| alloc     | 0.24 | 0.24 | parity |
+| tokenizer | 0.18 | 0.26 | 1.4x   |
+| string    | 0.15 | 0.45 | 3.1x   |
+| method    | 0.60 | 3.0  | 4.9x   |
+
+The ≥10x gaps are **entirely in real npm packages**:
+
+| lane                                  | vs node |
+| ------------------------------------- | ------: |
+| cookie · JS host                      |    570x |
+| acorn · JS host                       |    459x |
+| acorn · standalone · runtime-dynamic  |   11.5x |
+| cookie · standalone · runtime-dynamic |   10.6x |
+| clsx · standalone · runtime-dynamic   |   10.3x |
+
+(The published `compile-time static` lane is not a comparison — it reports acorn
+parsing a 226 KB bundle in 0.246 µs. That is constant folding, not execution.
+Only runtime-dynamic rows mean anything.)
+
+The **JS-host** number has a separate, already-understood cause: one
+`parseCookie` call on a 38-character header makes **736 wasm→host calls**
+(`--inspect-boundaries`), identically on the second call — `__box_number` 192,
+`__host_eq` 119, `__js_array_push` 111, `__js_array_new` 80,
+`__extern_method_call` 79, `__unbox_number` 63. That lane delegates JS semantics
+to the host per operation. **This issue is about the standalone ~10x**, where
+the module has **zero imports** and the same helpers are internal Wasm calls.
+
+## The finding, minimally reproduced
+
+`parseCookie`'s hot loop carries its cursor in a **boxed** local. The emitted
+`index = endIdx + 1` is:
+
+```wat
+call $__to_primitive
+call $__unbox_number   ;; unbox local 5
+f64.const 1
+f64.add                ;; + 1
+call $__box_number     ;; re-box
+local.set 5            ;; store to local 5
+local.get 5
+call $__unbox_number   ;; unbox again, immediately
+```
+
+Reduced to the smallest program that shows it:
+
+| source                                  | `$i` slot      | box | unbox |
+| --------------------------------------- | -------------- | --: | ----: |
+| `let i = 0; i = i + 1;`                 | **f64**        |   0 |     0 |
+| `let i = 0; i = s.indexOf(";");`        | **externref**  |   2 |     1 |
+| `let i = 0; i = s.indexOf(";") + 1;`    | **externref**  |   2 |     1 |
+| `var i = s.indexOf(";"); i = i + 1;`    | **externref**  |   2 |     2 |
+
+**A single `any`-typed definition boxes the whole local, permanently, for every
+read and write of it** — even though `String.prototype.indexOf` returns a Number
+for a string receiver, and even though the whole-program fixpoint that could
+prove it already exists and already runs.
+
+## Why the two existing unboxing routes both miss it
+
+`usageInferredLocalType` is documented as "the SINGLE codegen entry point" for
+narrowing an `any` local to f64, and both routes feed it:
+
+- **route 1, use-site (#684)** — every USE is ToNumber-invariant;
+- **route 2, definition-site (#3765)** — every DEFINITION is provably a number.
+
+Both sit behind the same admission gate in `analyzeFunctionBody`'s
+`collectCandidate`, which requires the declaration's **checker type** to be
+`any`/`unknown`. For `let i = 0` TypeScript declares `number`, so the binding is
+**never collected as a candidate at all** — verified by instrumenting the
+candidate loop: it prints nothing for `i`.
+
+Meanwhile codegen widens that same slot to `externref` because of the later
+`any`-typed assignment. So:
+
+> the declared type says `number`, the emitted slot says `externref`, and the
+> analysis that exists to reconcile them is gated on the declared type — which
+> means **the carrier most in need of unboxing is invisible to the pass designed
+> to unbox it.**
+
+Case 4 in the table above (`var i = s.indexOf(";")`, declared `any`, so it *is* a
+candidate) still fails, so there is at least a second, independent gap in
+proving a string receiver for an unannotated parameter. Both need pinning.
+
+## The structural problem: one analysis, four bespoke consumers
+
+`analyzeNumericPropertyNames` computes one whole-program verdict. It has been
+wired into four different carriers, each time by hand, each time in a different
+file:
+
+| carrier    | issue     | wiring                                            |
+| ---------- | --------- | ------------------------------------------------- |
+| fields     | #3683 S4a | `deriveFnctorFields` ← `numericPropertyNames`     |
+| returns    | #3754     | `refinedTwinReturnType` in `typed-this.ts`        |
+| locals     | #3765     | `isNumericLocal` → `UsageInference`               |
+| parameters | follow-on | extended from #3765's route                       |
+
+Each one removes the boxing from its carrier, and the boxing **relocates to the
+next unfixed carrier**. The WAT census of the standalone cookie module shows
+exactly that — every remaining box is at a carrier boundary, none is redundant
+within an expression:
+
+```
+14  f64.convert_i32_s -> box -> return       (return of a plain function)
+ 4  local.get         -> box -> return
+ 9  f64.const         -> box -> local.set N  (a *literal* boxed into a slot)
+ 4  f64.add           -> box -> local.set N
+ 2  local.get         -> box -> call $__call_m_indexOf_2   (argument)
+ 2  f64.convert_i32_s -> box -> call $__extern_set         (property write)
+```
+
+## This is NOT a peephole
+
+The obvious cheap fix — pattern-match `box` immediately followed by `unbox` and
+delete both — was tested and **falsified**: of 59 box sites in the standalone
+cookie module, **0** are immediately re-unboxed. `src/codegen/peephole.ts` (284
+lines) has no box/unbox handling today, and adding one would find nothing.
+
+The round-trip is real but it goes **through a local slot**
+(`box → local.set 5 … local.get 5 → unbox`), which is a dataflow property, not
+an adjacency property. Pattern-matching cannot see it; the slot's declared type
+is what forces both halves.
+
+## Proposal — assign representations over a carrier graph
+
+Replace the per-carrier wiring with one representation-assignment pass:
+
+1. **Nodes** = every value carrier: locals, parameters, returns, struct fields,
+   array elements, and call arguments.
+2. **Edges** = the assignments/flows between them (a def, an argument bind, a
+   return, a field write). This is the union of what the four existing
+   consumers already compute separately.
+3. **Solve** for a consistent unboxed assignment: a carrier is `f64` when every
+   carrier that flows into it is `f64` and every literal def is numeric —
+   a least fixpoint, so cycles carry no evidence and stay boxed (the same
+   groundedness argument #3765 needed).
+4. **Box only at the frontier** — the edges that cross into genuinely dynamic
+   territory (an exported entry point's parameter, a host/dispatch boundary, a
+   carrier with a non-numeric def).
+
+The key difference from today is that the verdict is **not per-carrier-kind**,
+so a numeric value flowing local → argument → parameter → return → field stays
+unboxed for the whole chain instead of being re-boxed at each hop that has no
+bespoke pass yet.
+
+### Gate on the emitted slot, not the declared type
+
+Whatever shape the pass takes, the admission gate must key on **the
+representation codegen is about to emit**, not on the checker's declared type.
+That single change is what makes the `let i = 0; i = s.indexOf(…)` case visible
+at all, and it is independent of the rest of the proposal — it may be worth
+landing first as its own slice.
+
+## Acceptance criteria
+
+- [ ] `let i = 0; i = s.indexOf(";") + 1;` in a loop emits an `f64` local with
+      **zero** `__box_number` / `__unbox_number` in the loop body.
+- [ ] The standalone `cookie` runtime-dynamic lane improves measurably against
+      node, measured same-container interleaved behind a kill switch, with the
+      checksum unchanged.
+- [ ] The residual box sites in the standalone cookie module are reported
+      before/after, by carrier, so the "relocated to the next carrier" failure
+      mode is visible rather than silent.
+- [ ] No equivalence-suite regressions — confirmed by a **full-capture** run and
+      an A/B of the failing set with the kill switch off, not by a count match.
+
+## What must still decline (hard-won, do not re-derive)
+
+- **Booleans.** `isNumeric` deliberately answers TRUE for booleans. That is safe
+  for a FIELD only because #2847 brands boolean fields as i32 and the property
+  path defers to the brand. No other carrier has a brand path, so an f64
+  boolean carrier makes `` `${b}` `` print `1` where JS says `true`. This
+  escaped review on #3765 and was caught only by the full equivalence run.
+- **Capture.** A captured binding lives in a ref cell, not a wasm local.
+- **Read before definition.** A proof about what every write STORES says nothing
+  about a read that precedes them all; an f64 slot reads `0`/NaN where JS says
+  `undefined`.
+- **bigint.**
+- **Greatest vs least fixpoint.** `numericSlots` is a *greatest* fixpoint, so
+  `var a = b; var b = a` survives it with no numeric evidence anywhere. Any new
+  consumer needs the grounded (least-fixpoint) variant.
+
+## Relationship to adjacent work
+
+- **#4118 / PR #4062** specializes named hot paths (`indexOf`, `find`, counted
+  push loops). Complementary: that closes specific kernels, this closes the
+  generic carrier boxing underneath all of them.
+- **#1624** (`wont-fix`) proposed changing the box *representation* to a WasmGC
+  `$Value` struct. Different problem — it still boxes, and its premise (host
+  calls) is already solved in standalone, which has zero imports.
+- **#2773** is value-rep for struct identity/typeIdx across dispatch, not
+  numeric unboxing.

--- a/plan/issues/4121-generic-carrier-unboxing.md
+++ b/plan/issues/4121-generic-carrier-unboxing.md
@@ -10,10 +10,10 @@ horizon: l
 feasibility: hard
 reasoning_effort: high
 task_type: performance
-area: codegen
+area: ir, codegen
 language_feature: value-representation
-goal: performance
-related: [684, 3683, 3754, 3765, 4118, 2773, 1624]
+goal: ir-full-coverage
+related: [684, 1167c, 1168, 2855, 3683, 3754, 3765, 4118, 4122, 2773, 1624]
 origin: "measured on upstream/main d369562d7, 2026-08-03, investigating the residual 10x vs node on real npm packages"
 ---
 
@@ -169,40 +169,100 @@ The round-trip is real but it goes **through a local slot**
 an adjacency property. Pattern-matching cannot see it; the slot's declared type
 is what forces both halves.
 
-## Proposal — assign representations over a carrier graph
+## Proposal — this belongs in the IR, as a pass
 
-Replace the per-carrier wiring with one representation-assignment pass:
+The right home is **not** a fifth AST-side consumer. It is an IR pass, and the
+IR already has every piece except the pass itself:
 
-1. **Nodes** = every value carrier: locals, parameters, returns, struct fields,
-   array elements, and call arguments.
-2. **Edges** = the assignments/flows between them (a def, an argument bind, a
-   return, a field write). This is the union of what the four existing
-   consumers already compute separately.
-3. **Solve** for a consistent unboxed assignment: a carrier is `f64` when every
-   carrier that flows into it is `f64` and every literal def is numeric —
-   a least fixpoint, so cycles carry no evidence and stay boxed (the same
-   groundedness argument #3765 needed).
-4. **Box only at the frontier** — the edges that cross into genuinely dynamic
-   territory (an exported entry point's parameter, a host/dispatch boundary, a
-   carrier with a non-numeric def).
+| piece                              | where it already is                                |
+| ---------------------------------- | -------------------------------------------------- |
+| a boxed/unboxed type vocabulary    | `IrType { kind: "union" }` (#1168)                  |
+| `box` / `unbox` / `tag.test`       | first-class IR instructions (#1168)                 |
+| type propagation over the graph    | `src/ir/propagate.ts`                               |
+| a validated tagged-union registry  | `src/ir/passes/tagged-unions.ts` (#1167c Pass 2)    |
+| a pass pipeline to slot into       | `src/ir/integration.ts` — `constantFold`, `deadCode`, `inlineSmall`, `monomorphize` |
 
-The key difference from today is that the verdict is **not per-carrier-kind**,
-so a numeric value flowing local → argument → parameter → return → field stays
-unboxed for the whole chain instead of being re-boxed at each hop that has no
-bespoke pass yet.
+`tagged-unions.ts` states the split explicitly: the **producers** of union-typed
+values (from-ast / propagation) and the **consumers** (`box`/`unbox` lowering)
+"sit on either side of this pass". What is missing between them is the
+propagation that decides a carrier can be `f64` rather than boxed. That is
+exactly this issue.
 
-### Gate on the emitted slot, not the declared type
+So the shape is:
 
-Whatever shape the pass takes, the admission gate must key on **the
-representation codegen is about to emit**, not on the checker's declared type.
-That single change is what makes the `let i = 0; i = s.indexOf(…)` case visible
-at all, and it is independent of the rest of the proposal — it may be worth
-landing first as its own slice.
+1. Extend `propagate.ts` with a numeric lattice over the IR value graph —
+   `⊥ → f64 → boxed`, joined at merge points.
+2. A carrier is `f64` when every value flowing into it is `f64`. This is a
+   **least** fixpoint, so a cycle carries no evidence and stays boxed unless
+   grounded — the argument #3765 needed, and #4122 then had to extend with a
+   self-reference rule for the accumulator shape.
+3. The existing `box`/`unbox` consumers then simply emit nothing where the
+   lattice says `f64`. **No new lowering code** — the deletion falls out of the
+   type, which is the whole reason to do it here.
+4. Box only at the frontier: exported entry-point parameters, host/dispatch
+   boundaries, and carriers with a genuinely non-numeric definition.
+
+Why this is the right level rather than a nicer version of the AST passes:
+
+- **"Carrier" stops being a category you enumerate.** Field, return, local,
+  parameter, argument and array element are all just edges in one graph. The
+  relocate-to-the-next-unfixed-carrier failure mode cannot happen, because
+  there is no per-kind wiring to be missing.
+- **It is the documented direction.** `plan/log/ir-adoption.md`'s north star
+  (goal `ir-full-coverage`, elevated 2026-07-02) is that all AST kinds route
+  through the IR and the direct path is *deprecation-tracked, not a peer*.
+  Passes like this are what the IR is for; adding a fifth AST consumer adds to
+  the pile the ratchet (#2855) exists to shrink.
+- **The duplication disappears.** `isString` exists twice on the AST side —
+  once in `makeProver`, once in `collectStringProperties`. When #3765 added
+  `Array.prototype.join` the wrong copy was fixed first and the measurement
+  came back zero. Syntactic analyses with no shared value graph invite exactly
+  that.
+
+### The blocking caveat — do not skip this
+
+An IR pass only applies to functions the IR **claims**. Today a selector
+rejection or an IR-build throw demotes the function to direct codegen through
+the warning channel (`src/codegen/index.ts`, the two demote sites), and
+`ir-adoption.md` still lists many kinds as `mixed` / `direct-only`.
+
+So moving this analysis into the IR **now** would silently stop applying
+wherever the IR bails — no wrong answers, but a perf cliff invisible to every
+gate. That is precisely the failure #3765 hit from the other direction: a
+kill-switch differential of zero that meant "the lever never engaged", not
+"the lever is worthless".
+
+Therefore:
+
+- The AST-side fixes (#3683, #3754, #3765, #4122) **stay** until the IR owns
+  the relevant node kinds. They are not made redundant by this issue.
+- Any implementation must report **IR-claimed vs demoted coverage** for the
+  benchmark set alongside its speedup, so a headline number cannot hide a
+  shrinking denominator.
+- Sequence behind enough of #2855 that the accumulator and string-scanning
+  shapes in `benchMethod` / `parseCookie` are IR-claimed. Check first; if they
+  are not, that ratchet work is the actual prerequisite and this issue is
+  blocked on it rather than ready.
+
+### One slice worth landing first, on either side
+
+The admission gate must key on **the representation codegen is about to emit**,
+not on the checker's declared type. `let i = 0` is declared `number` while its
+slot is `externref`, so the pass that exists to reconcile them never sees it.
+That is a small, independent fix, it is what makes case 2/3 in the table above
+visible at all, and it is worth doing regardless of where the analysis
+eventually lives.
 
 ## Acceptance criteria
 
+- [ ] A pre-flight report of **which benchmark functions the IR currently
+      claims** vs demotes. If `benchMethod` / `parseCookie` are demoted, this
+      issue is blocked on #2855 rather than ready, and that finding closes the
+      slice on its own.
 - [ ] `let i = 0; i = s.indexOf(";") + 1;` in a loop emits an `f64` local with
       **zero** `__box_number` / `__unbox_number` in the loop body.
+- [ ] IR-claimed coverage reported alongside every speedup, so a headline number
+      cannot hide a shrinking denominator.
 - [ ] The standalone `cookie` runtime-dynamic lane improves measurably against
       node, measured same-container interleaved behind a kill switch, with the
       checksum unchanged.

--- a/plan/issues/4122-mixed-assignment-carrier-boxes-numeric-accumulators.md
+++ b/plan/issues/4122-mixed-assignment-carrier-boxes-numeric-accumulators.md
@@ -1,0 +1,158 @@
+---
+id: 4122
+title: "perf regression: `bindingHasMixedAssignmentCarrier` treats an UNRESOLVABLE assignment as a cross-domain one, boxing every numeric accumulator fed by a dynamic call — `method` axis 1.56x → 5.26x"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: codegen
+language_feature: value-representation
+goal: performance
+related: [3961, 4121, 3683, 3754, 3765]
+origin: "git bisect of the cross-engine `method` axis, 2026-08-03"
+---
+
+# #4122 — an unresolvable assignment is not a mixed-domain assignment
+
+## The regression
+
+Bisected on the cross-engine `method` axis, all legs same container, checksums
+(`chk=45000150000`) correct at every step, no skipped commits.
+
+| commit                                | `method` js2/node |
+| ------------------------------------- | ----------------: |
+| `82c3ea98d` (parent)                  |          **1.56** |
+| **`9a91db042`** (first bad)           |          **5.26** |
+| `d369562d7` (current main)            |          **5.42** |
+
+Absolute js2 `method` goes **0.82 ms → 2.92 ms in one commit**.
+
+First bad commit: `9a91db04255f086e20d47a6d9332debbdebb2bb5` —
+`fix(react): preserve dynamic value semantics in Wasm`, landed via PR #4008 for
+issue #3961.
+
+**Ablation** (diagnostic only, reverted, nothing pushed): commenting out the one
+line below restores an `f64` accumulator and a loop body byte-identical to the
+parent commit's.
+
+- at `9a91db042`: 5.26 → **1.48**
+- at current main `d369562d7`: 5.42 → **1.68**
+
+So this single line accounts for the entire regression; nothing in the ~110
+commits since compounds it, and there is no residual second regression
+(HEAD-with-line-disabled 1.68 ≈ known-good 1.65).
+
+## The line
+
+`src/codegen/statements/variables.ts:150`, in `localTypeForDeclaration`:
+
+```ts
+if (decl && bindingHasMixedAssignmentCarrier(ctx, decl)) return { kind: "externref" };
+```
+
+## The defect
+
+`src/codegen/analysis/mixed-assignment-carrier.ts`:
+
+```ts
+const assignedTag = ctx.oracle.staticJsTypeOf(node.right);
+if (assignedTag === "mixed" || carrierDomain(assignedTag) !== initialDomain) {
+  mixed = true;
+```
+
+`"mixed"` is what the oracle returns when it **cannot resolve** an expression —
+not when it has proven that two domains collide. So *absence of evidence* is
+treated as *evidence of mixing*, and the binding is demoted to the boxed
+`externref` carrier.
+
+The function's own name and doc describe the real hazard accurately ("an i32
+boolean slot destroys a later string assignment by coercing it to truthiness")
+— that hazard is genuine and the demotion is right for it. The bug is that the
+unresolvable case is folded into the same branch.
+
+Note the asymmetry already present in the code: a `"mixed"` **initializer**
+returns `false` (no demotion, line 40), while a `"mixed"` **assignment** demotes.
+The same unknown is read two different ways.
+
+## What it costs
+
+`benchMethod` is the plain-JS accumulator shape:
+
+```js
+var s = 0;
+for (…) { s = s + p.inc(); }
+```
+
+`p.inc()` is a prototype method reached by dynamic dispatch, so
+`staticJsTypeOf(s + p.inc())` is `"mixed"` (unresolvable), which differs from the
+initializer's `"number"` domain. `s` is demoted from an `f64` local to a boxed
+`externref` local:
+
+```wat
+ (func $benchMethod
+-    (local $s f64)
++    (local $s externref)
+ ...
+     local.get 1
++    call $__unbox_number
+     local.get 0
+     call $inc
+     f64.add
++    call $__box_number      ;; heap allocation, every iteration
+     local.set 1
+```
+
+That is **300,000 `__box_number` allocations + 300,000 unboxes per bench call**,
+where the accumulator previously lived in an f64 register.
+
+**The blast radius is much wider than React**: any JS-source `var acc = 0`
+accumulator updated from a dynamically-typed call is now boxed. That is the
+single most common shape in ordinary JavaScript.
+
+## Fix direction
+
+Do **not** revert — #3961's hazard is real. Split the two cases:
+
+1. **Proven cross-domain** (`carrierDomain(assignedTag) !== initialDomain`, both
+   resolved) → demote, as today.
+2. **Unresolvable** (`assignedTag === "mixed"`) → do **not** demote on that
+   alone. Consult the whole-program numeric fixpoint
+   (`analyzeNumericPropertyNames`) first: if every definition of the slot is
+   provably numeric, the binding is numeric and the f64 carrier is correct.
+   `s = s + p.inc()` is exactly the shape that fixpoint already answers, via
+   `numericFunctions` for `inc`.
+3. If the fixpoint cannot prove it either, *then* demote — genuinely unknown.
+
+Treat the initializer/assignment asymmetry as part of the same fix: whichever
+reading of `"mixed"` is correct, both sites should use it.
+
+This is the narrow, immediate slice of #4121 (generic carrier unboxing), and it
+is worth landing on its own because it is a measured 3.5x regression on main.
+
+## Acceptance criteria
+
+- [ ] `var s = 0; for (…) s = s + p.inc();` emits an `f64` local and no
+      `__box_number` in the loop body, when `inc` is provably numeric.
+- [ ] Cross-engine `method` axis back to ≤2.0x vs node, measured same-container
+      interleaved with matching checksums.
+- [ ] The #3961 / PR #4008 React case that motivated the demotion still behaves
+      — a regression test pinning it, not just a green suite.
+- [ ] A binding genuinely assigned across domains (`let b = true; b = "s";`)
+      still gets the boxed carrier, with a test.
+- [ ] No equivalence-suite regressions, confirmed by a full-capture run plus a
+      kill-switch A/B of the failing set (not by a count match).
+
+## Reproduce
+
+```bash
+node benchmarks/cross-engine/run-node-porffor.mjs 2>&1 | grep '^method'
+node --import tsx benchmarks/cross-engine/run-js2.mjs  2>&1 | grep '^method'
+```
+
+Ratio `js2/node`; expect ~5.3x on current main, ~1.6x with the line at
+`variables.ts:150` disabled.

--- a/plan/issues/4122-mixed-assignment-carrier-boxes-numeric-accumulators.md
+++ b/plan/issues/4122-mixed-assignment-carrier-boxes-numeric-accumulators.md
@@ -1,10 +1,11 @@
 ---
 id: 4122
 title: "perf regression: `bindingHasMixedAssignmentCarrier` treats an UNRESOLVABLE assignment as a cross-domain one, boxing every numeric accumulator fed by a dynamic call — `method` axis 1.56x → 5.26x"
-status: ready
+status: done
 sprint: current
 created: 2026-08-03
 updated: 2026-08-03
+completed: 2026-08-03
 priority: high
 horizon: m
 feasibility: medium
@@ -15,6 +16,11 @@ language_feature: value-representation
 goal: performance
 related: [3961, 4121, 3683, 3754, 3765]
 origin: "git bisect of the cross-engine `method` axis, 2026-08-03"
+# The verdict must reach `bindingHasMixedAssignmentCarrier`, which runs before
+# any carrier type exists — there is no subsystem module upstream of it to hold
+# the field, so the context gains one line plus its doc.
+loc-budget-allow:
+  - src/codegen/context/types.ts
 ---
 
 # #4122 — an unresolvable assignment is not a mixed-domain assignment
@@ -136,16 +142,63 @@ is worth landing on its own because it is a measured 3.5x regression on main.
 
 ## Acceptance criteria
 
-- [ ] `var s = 0; for (…) s = s + p.inc();` emits an `f64` local and no
+- [x] `var s = 0; for (…) s = s + p.inc();` emits an `f64` local and no
       `__box_number` in the loop body, when `inc` is provably numeric.
-- [ ] Cross-engine `method` axis back to ≤2.0x vs node, measured same-container
-      interleaved with matching checksums.
-- [ ] The #3961 / PR #4008 React case that motivated the demotion still behaves
-      — a regression test pinning it, not just a green suite.
-- [ ] A binding genuinely assigned across domains (`let b = true; b = "s";`)
+      Measured: `$s` externref → **f64**, box 3 → 1, unbox 2 → **0**.
+- [x] Cross-engine `method` axis back to ≤2.0x vs node, measured same-container
+      interleaved with matching checksums. **2.85–3.01 ms → 0.813 ms (3.6x)**,
+      i.e. **1.35–1.67x vs node**, `chk=45000150000` on every leg.
+- [x] The #3961 / PR #4008 hazard still behaves — pinned by three explicit
+      cross-domain tests, not just a green suite.
+- [x] A binding genuinely assigned across domains (`let b = true; b = "s";`)
       still gets the boxed carrier, with a test.
-- [ ] No equivalence-suite regressions, confirmed by a full-capture run plus a
+- [x] No equivalence-suite regressions, confirmed by a full-capture run plus a
       kill-switch A/B of the failing set (not by a count match).
+
+## Result
+
+| axis                  | before | after | node        |
+| --------------------- | -----: | ----: | ----------- |
+| method                |   2.93 | 0.813 | 0.49 – 0.60 |
+| tokenizer (unchanged) |  0.253 | 0.257 | 0.17        |
+
+## The fix took three parts, not one
+
+Consulting the fixpoint was the easy part. Two gaps in the analysis had to close
+first, each verified by querying the verdict directly before and after:
+
+1. **Self-reference.** `s = s + f()` cannot be proven by a plain least fixpoint —
+   proving `s` numeric requires `s` numeric. The grounded set now assumes the
+   slot while judging its own definitions (the same induction `withSelf` gives
+   the property path), then re-checks **groundedness with the assumption
+   withdrawn**, so `var s = s + 1` — self-justifying, and NaN in JS — is still
+   rejected, and a mutual cycle `var a = b; var b = a` still cannot enter
+   (the assumption covers a slot's own name, never its partner's).
+
+2. **`numericFunctions` on a non-`this` receiver.** The verdict was consulted
+   only for `this.m()`:
+
+   ```ts
+   if (recv.kind === ts.SyntaxKind.ThisKeyword) return sets.numericFunctions.has(callee.name.text);
+   ```
+
+   `numericFunctions` is whole-program and NAME-keyed — "every visible function
+   of this name returns a number on every path" — which is exactly as true of
+   `p.inc()`. The restriction was conservatism, not a consequence of the
+   verdict. Widened to a bare-identifier receiver only, so member chains
+   (`a.b.inc()`) and call results (`f().inc()`) keep the old answer.
+
+   This does widen a trust boundary: an `inc` that is not statically visible
+   (a host/builtin method behind an opaque receiver) cannot demote the name.
+   That exposure already existed for `this.m()`, whose receiver is equally
+   unconstrained at runtime, and it is the same name-keying trade the file
+   documents throughout.
+
+3. **The split itself**, in `bindingHasMixedAssignmentCarrier`.
+
+Behind `JS2WASM_MIXED_CARRIER_NUMERIC=0` (part 3). Parts 1–2 are analysis
+precision improvements and are not separately gated — they can only ever add
+slots to a grounded set that every consumer already treats as advisory.
 
 ## Reproduce
 

--- a/plan/issues/4123-prototype-method-on-parameter-receiver-returns-null.md
+++ b/plan/issues/4123-prototype-method-on-parameter-receiver-returns-null.md
@@ -1,0 +1,108 @@
+---
+id: 4123
+title: "MISCOMPILE: a prototype method called on a PARAMETER receiver silently returns null/0 in standalone — `f(o){ return o.k(); }` gives null where JS gives 3"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: prototype methods, receiver flow
+goal: core-semantics
+related: [3685, 3683, 4122]
+origin: "found incidentally while building a guard test for #4122, 2026-08-03"
+---
+
+# #4123 — prototype method on a parameter receiver returns null
+
+## Severity
+
+**Silent wrong answer.** No trap, no compile error, no diagnostic — the program
+runs and produces a different value than JavaScript specifies. This is the worst
+failure class we have, and the shape is ordinary: pass an object to a function,
+call one of its prototype methods.
+
+Reproduced on **unmodified `upstream/main` (`d369562d7`)**, verified by stashing
+all local changes and re-running.
+
+## Reproduction
+
+```js
+function K() {}
+K.prototype.k = function () { return 3; };
+
+function f(o) { return o.k(); }
+export function main() { return f(new K()); }
+```
+
+Compiled with `{ target: "standalone" }`:
+
+| program                                              | js2      | JS  |
+| ---------------------------------------------------- | -------- | --- |
+| `function f(o){ return o.k(); }`                     | **null** | 3   |
+| `function f(o){ let n = o.k(); return n; }`           | **null** | 3   |
+| `function f(o){ let n = 1; n = o.k(); return n; }`    | **0**    | 3   |
+| `function f(o){ let n = 1; n = n + o.k(); return n; }`| **1**    | 4   |
+| `function f(o){ return 1 + o.k(); }`                  | **1**    | 4   |
+| `function f(){ let p = new K(); … p.k() … }`          | 4        | 4   |
+
+The **last row is the control**: the identical call with a receiver bound by a
+local `new K()` produces the correct answer. So the defect is specific to the
+receiver arriving as a **parameter**, not to the method, the prototype, or the
+export boundary (which the control crosses too).
+
+The `null` → `0` → `1` progression is consistent with the call yielding
+*nothing usable* and the consumer coercing it: `null` returned directly, `0`
+when stored into a numeric slot, and `1` when added to `1`.
+
+## Why this matters beyond the repro
+
+`f(obj)` where `obj` carries prototype methods is the shape of nearly every
+library API — every npm package that takes an options object, a parser, a
+stream, a node. The standalone `runtime-dynamic` npm lanes are exactly this
+shape, so this may be depressing correctness (and masking perf) far more
+broadly than one benchmark.
+
+It should be checked against the npm-compat correctness harness immediately:
+a package whose result is silently wrong will still "pass" any check that only
+compares against a checksum computed the same wrong way.
+
+## Where to look
+
+`#3685`'s `analyzeReceiverFlow` classifies a receiver by `source`:
+`"new-binding" | "call-return" | "parameter" | "this"`. The control (local
+`new K()`) is `new-binding` and works; the failing case is `parameter`. So the
+`parameter` arm of receiver-flow → dispatch is the first place to look — either
+the verdict is not reaching the call site, or the dispatch it selects is reading
+the wrong carrier for a parameter-held instance.
+
+Note `#4122` (in flight) documents that `staticJsTypeOf` answers `"mixed"` for
+these dynamically-dispatched calls, which is consistent with the parameter
+receiver not being resolved anywhere in this path.
+
+## Acceptance criteria
+
+- [ ] All six rows in the table above produce the JS answer.
+- [ ] An equivalence test covering the parameter-receiver shape, including the
+      `null`-returning direct form, which is the one no numeric coercion hides.
+- [ ] A check of whether any npm-compat correctness result changes once fixed —
+      if a package's expected checksum was computed from js2 output rather than
+      from node, it would have locked in the wrong answer.
+- [ ] Confirm whether the JS-host lane has the same defect or only standalone.
+
+## Reproduce
+
+```js
+import { compile } from "./src/index.ts";
+const src = `
+function K(){} K.prototype.k=function(){return 3;};
+function f(o){ return o.k(); }
+export function main(){ return f(new K()); }`;
+const res = await compile(src, { fileName: "t.mjs", skipSemanticDiagnostics: true, target: "standalone" });
+const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(res.binary), {});
+console.log(exports.main()); // null — JS says 3
+```

--- a/src/codegen/analysis/mixed-assignment-carrier.ts
+++ b/src/codegen/analysis/mixed-assignment-carrier.ts
@@ -42,13 +42,33 @@ export function bindingHasMixedAssignmentCarrier(ctx: CodegenContext, decl: ts.V
   const scope = containingScope(decl);
   let mixed = false;
 
+  // (#4122) `"mixed"` is the oracle's answer for UNRESOLVABLE, not for "proven
+  // to cross domains". Treating the two alike makes absence of evidence count
+  // as evidence of mixing, which demoted every numeric accumulator fed by a
+  // dynamically-dispatched call — `var s = 0; s = s + p.inc();`, the most
+  // common shape in ordinary JS — to a boxed carrier, at ~3.5x on the `method`
+  // axis.
+  //
+  // So an unresolvable assignment gets a second question: does the
+  // whole-program fixpoint prove EVERY definition of this slot numeric? That
+  // verdict is grounded (a slot needs one definition numeric without assuming
+  // itself), self-reference-aware (the accumulator shape), and boolean-excluded,
+  // so a `true` here means the f64 carrier is the correct representation, not
+  // merely a cheaper guess. A resolved cross-domain assignment still demotes
+  // regardless — that is #3961's hazard and it is untouched.
+  const provenNumeric =
+    process.env.JS2WASM_MIXED_CARRIER_NUMERIC !== "0" &&
+    initialDomain === "number" &&
+    ctx.numericLocalVerdict?.(decl.name, decl.name.text) === true;
+
   const visit = (node: ts.Node): void => {
     if (mixed) return;
     if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
       const target = stripParens(node.left);
       if (ts.isIdentifier(target) && target !== decl.name && ctx.oracle.variableDeclarationOf(target) === decl) {
         const assignedTag = ctx.oracle.staticJsTypeOf(node.right);
-        if (assignedTag === "mixed" || carrierDomain(assignedTag) !== initialDomain) {
+        const unresolvable = assignedTag === "mixed";
+        if (unresolvable ? !provenNumeric : carrierDomain(assignedTag) !== initialDomain) {
           mixed = true;
           return;
         }

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2013,6 +2013,9 @@ export interface CodegenContext {
    * the generic `__any_add` with a tag-dispatch unbox after it.
    */
   numericFunctionNames?: ReadonlySet<string>;
+  /** (#4122) Grounded "every definition of this slot is numeric" verdict from
+   *  `analyzeNumericPropertyNames`; absent in the host lane / when disabled. */
+  numericLocalVerdict?: (node: ts.Node, name: string) => boolean;
   /**
    * #3673: property names the SOURCE defines as a function-valued member
    * (`collectUserMethodNames`). Consulted by

--- a/src/codegen/numeric-property-analysis.ts
+++ b/src/codegen/numeric-property-analysis.ts
@@ -968,6 +968,21 @@ function makeProver(
         if (STRING_NUMERIC_METHODS.has(callee.name.text) && isString(callee.expression, depth + 1)) return true;
         if (ARRAY_NUMERIC_METHODS.has(callee.name.text) && isArray(callee.expression, depth + 1)) return true;
         if (recv.kind === ts.SyntaxKind.ThisKeyword) return sets.numericFunctions.has(callee.name.text);
+        // (#4122) The same verdict for a NON-`this` receiver. `numericFunctions`
+        // is whole-program and NAME-keyed — "every visible function of this name
+        // returns a number on every path" — which is exactly as true of
+        // `p.inc()` as of `this.inc()`; a single non-numeric `inc` anywhere in
+        // the program removes the name for both. The `this`-only restriction was
+        // conservatism, not a consequence of the verdict.
+        //
+        // The trust boundary this widens is the SAME one the file documents for
+        // name-keying generally: an `inc` that is not statically visible (a host
+        // or builtin method reached through an opaque receiver) is not in
+        // `functionsByName` and so cannot demote the name. That risk already
+        // exists for `this.m()`, whose receiver is equally unconstrained at
+        // runtime. Restricted to a bare identifier receiver so member chains
+        // (`a.b.inc()`) and call results (`f().inc()`) keep the old answer.
+        if (ts.isIdentifier(recv)) return sets.numericFunctions.has(callee.name.text);
       }
       return false;
     }
@@ -1094,6 +1109,13 @@ export interface NumericPropertyAnalysisTarget {
   numericPropertyNames?: ReadonlySet<string>;
   stringPropertyNames?: ReadonlySet<string>;
   numericFunctionNames?: ReadonlySet<string>;
+  /**
+   * (#4122) The grounded slot verdict, exposed directly rather than only
+   * through `usageInference`. `bindingHasMixedAssignmentCarrier` needs to ask
+   * it BEFORE the carrier type exists, which is upstream of where
+   * `usageInference` is consulted.
+   */
+  numericLocalVerdict?: PropertyKindVerdicts["isNumericLocal"];
   readonly usageInference: {
     setNumericLocalOracle(oracle: PropertyKindVerdicts["isNumericLocal"]): void;
   };
@@ -1266,13 +1288,37 @@ export function analyzeNumericPropertyNames(
       // holding a comparison result makes `` `${b}` `` print "1" where JS says
       // "true". Caught by `coercion/tostring > standalone-O > template over
       // any-boolean`.
-      const allNumeric =
-        slot.defs.length > 0 &&
-        slot.defs.every(
-          (def) => def.forcedNumeric === true || (def.expr !== undefined && groundedProver.isNumeric(def.expr)),
-        ) &&
-        !slot.defs.some((def) => def.expr !== undefined && groundedProver.isBooleanish(def.expr));
-      if (allNumeric) {
+      // (#4122) SELF-REFERENCE. The accumulator `var s = 0; s = s + f();` is the
+      // most common numeric-local shape in ordinary JS, and a plain least
+      // fixpoint can never admit it: proving `s` numeric requires `s` to be
+      // numeric already. So assume the slot numeric while judging its OWN
+      // definitions — the same induction `withSelf` gives the property path
+      // ("if every other write stores a number then the slot always holds
+      // one"), just for a lexical slot instead of a property name.
+      groundedSlots.add(slot);
+      let allNumeric: boolean;
+      try {
+        allNumeric =
+          slot.defs.length > 0 &&
+          slot.defs.every(
+            (def) => def.forcedNumeric === true || (def.expr !== undefined && groundedProver.isNumeric(def.expr)),
+          ) &&
+          !slot.defs.some((def) => def.expr !== undefined && groundedProver.isBooleanish(def.expr));
+      } finally {
+        groundedSlots.delete(slot);
+      }
+      if (!allNumeric) continue;
+      // GROUNDEDNESS, re-checked with the assumption withdrawn: at least one
+      // definition must be numeric on its own. Without this, `var s = s + 1;`
+      // — whose only definition reads the slot before anything writes it — is
+      // self-justifying, and an f64 carrier would read 0 where JS says NaN.
+      // This is the slot analogue of the property path's `withoutSelf` pass,
+      // and it is also what keeps a mutual cycle (`var a = b; var b = a;`) out:
+      // the assumption covers a slot's own name, never its partner's.
+      const grounded = slot.defs.some(
+        (def) => def.forcedNumeric === true || (def.expr !== undefined && groundedProver.isNumeric(def.expr)),
+      );
+      if (grounded) {
         groundedSlots.add(slot);
         added = true;
       }
@@ -1349,5 +1395,6 @@ export function applyNumericPropertyAnalysis(
   target.numericFunctionNames = verdicts.numericFunctions;
   if (process.env.JS2WASM_NUMERIC_LOCALS !== "0") {
     target.usageInference.setNumericLocalOracle(verdicts.isNumericLocal);
+    target.numericLocalVerdict = verdicts.isNumericLocal;
   }
 }

--- a/tests/issue-4122-mixed-carrier-numeric.test.ts
+++ b/tests/issue-4122-mixed-carrier-numeric.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4122) An UNRESOLVABLE assignment is not a cross-domain assignment.
+ *
+ * `bindingHasMixedAssignmentCarrier` demoted a binding to the boxed `externref`
+ * carrier whenever `oracle.staticJsTypeOf` of any assignment was `"mixed"` —
+ * which is the oracle's answer for *cannot resolve*, not for *proven to cross
+ * domains*. That read absence of evidence as evidence of mixing, and boxed every
+ * numeric accumulator fed by a dynamically-dispatched call.
+ *
+ * The demotion itself is right for the hazard it was written for (#3961: an i32
+ * boolean slot destroys a later string assignment by coercing it to
+ * truthiness), so the tests below pin BOTH directions: the accumulator unboxes,
+ * and every genuinely cross-domain binding still boxes.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function build(source: string, env?: Record<string, string>) {
+  const saved: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env ?? {})) {
+    saved[k] = process.env[k];
+    process.env[k] = v;
+  }
+  try {
+    return await compile(source, {
+      fileName: "t.mjs",
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+      emitWat: true,
+    });
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+/** Body of `fn` with numeric call targets resolved back to names. */
+function bodyOf(wat: string, fn: string): string {
+  const lines = wat.split("\n");
+  const names: string[] = [];
+  const declLine = new Map<string, number>();
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i]!.match(/^\s*\(func \$(\S+)/);
+    if (m) {
+      names.push(m[1]!);
+      declLine.set(m[1]!, i);
+    }
+  }
+  const start = declLine.get(fn);
+  if (start === undefined) return "";
+  const out: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\s*\(func \$/.test(lines[i]!)) break;
+    out.push(lines[i]!.trim());
+  }
+  return out.join("\n").replace(/\bcall (\d+)\b/g, (_m, idx) => `call $${names[Number(idx)] ?? idx}`);
+}
+
+function localType(body: string, name: string): string {
+  return body.match(new RegExp("\\(local \\$" + name + " ([^)]*)\\)"))?.[1] ?? "";
+}
+
+/** The cross-engine `method` axis shape, which the regression cost ~3.5x. */
+const ACCUMULATOR = `
+function P(v){ this.v = v; }
+P.prototype.inc = function(){ this.v = this.v + 1; return this.v; };
+function benchMethod(){
+  var p = new P(0);
+  var s = 0;
+  for (var i = 0; i < 1000; i++) { s = s + p.inc(); }
+  return s;
+}
+export function main(){ return benchMethod(); }
+`;
+
+describe("#4122 — an unresolvable assignment does not demote a proven-numeric slot", () => {
+  it("keeps the accumulator in an f64 local", async () => {
+    const { wat } = await build(ACCUMULATOR);
+    expect(localType(bodyOf(wat!, "benchMethod"), "s")).toBe("f64");
+  });
+
+  it("emits no unboxing in the accumulator loop", async () => {
+    const { wat } = await build(ACCUMULATOR);
+    expect(bodyOf(wat!, "benchMethod")).not.toMatch(/call \$__unbox_number/);
+  });
+
+  it("is off under the kill switch, restoring the boxed carrier", async () => {
+    const { wat } = await build(ACCUMULATOR, { JS2WASM_MIXED_CARRIER_NUMERIC: "0" });
+    const body = bodyOf(wat!, "benchMethod");
+    expect(localType(body, "s")).toBe("externref");
+    expect(body).toMatch(/call \$__unbox_number/);
+  });
+
+  it("computes the same sum either way", async () => {
+    for (const env of [undefined, { JS2WASM_MIXED_CARRIER_NUMERIC: "0" }]) {
+      const { binary } = await build(ACCUMULATOR, env);
+      const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(binary!), {});
+      // sum of 1..1000
+      expect((exports as { main: () => number }).main()).toBe(500500);
+    }
+  });
+
+  // --- the #3961 hazard the demotion exists for: these must still box --------
+
+  it.each([
+    ["boolean then string", `let b = true; b = "s"; return typeof b;`, "b"],
+    ["number then string", `let n = 1; n = "s"; return typeof n;`, "n"],
+    ["number then boolean", `let n = 1; n = true; return typeof n;`, "n"],
+  ])("still boxes a genuinely cross-domain binding (%s)", async (_label, body, name) => {
+    const { wat } = await build(`function f(){ ${body} }\nexport function main(){ return f(); }`);
+    expect(localType(bodyOf(wat!, "f"), name)).toBe("externref");
+  });
+
+  it("still boxes when the unresolvable slot is NOT provably numeric", async () => {
+    // `q()` is not in `numericFunctions` (it can return a string), so the slot
+    // has no numeric proof and the conservative demotion must stand.
+    const { wat } = await build(`
+      function Q(){}
+      Q.prototype.q = function(c){ return c ? "s" : 1; };
+      function f(o){ let n = 1; n = o.q(1); return n; }
+      export function main(){ return f(new Q()); }
+    `);
+    expect(localType(bodyOf(wat!, "f"), "n")).toBe("externref");
+  });
+});
+
+describe("#4122 — the grounded slot verdict admits self-reference", () => {
+  it("proves an accumulator whose own value feeds its update", async () => {
+    // `s = s + <numeric>` cannot be proven by a plain least fixpoint: proving
+    // `s` numeric requires `s` numeric. The verdict assumes the slot while
+    // judging its own definitions, then re-checks groundedness without the
+    // assumption.
+    const { wat } = await build(ACCUMULATOR);
+    expect(localType(bodyOf(wat!, "benchMethod"), "s")).toBe("f64");
+  });
+
+  it("does not admit a self-justifying binding with no independent evidence", async () => {
+    // `var s = s + 1` reads the slot before anything writes it. JS says NaN;
+    // an f64 carrier would read 0. The groundedness re-check must reject it.
+    const { wat } = await build(`
+      function f(){ var s = s + 1; return s; }
+      export function main(){ return f(); }
+    `);
+    const t = localType(bodyOf(wat!, "f"), "s");
+    expect(t).not.toBe("f64");
+  });
+
+  it("does not admit a mutual definition cycle", async () => {
+    const { wat } = await build(`
+      function f(){ var a = b; var b = a; return a; }
+      export function main(){ return f(); }
+    `);
+    expect(localType(bodyOf(wat!, "f"), "a")).not.toBe("f64");
+  });
+});


### PR DESCRIPTION
## Description

Started as an investigation into what is still ≥10x slower than node. Contains one fix, two issues, and one bug found on the way.

Closes #4122. Files #4121 and #4123.

---

## The fix — #4122

A `git bisect` of the cross-engine `method` axis landed on one line:

| commit | `method` js2/node |
|---|---:|
| `82c3ea98d` (parent) | 1.56 |
| **`9a91db042`** (first bad) | **5.26** |
| `d369562d7` (main) | 5.42 |

0.82 ms → 2.92 ms in a single commit (PR #4008, issue #3961). The defect is what `bindingHasMixedAssignmentCarrier` asks:

```ts
if (assignedTag === "mixed" || carrierDomain(assignedTag) !== initialDomain)
```

`"mixed"` is the oracle's answer for **cannot resolve**, not for *proven cross-domain*. Absence of evidence counted as evidence of mixing, so every numeric accumulator fed by a dynamically-dispatched call was demoted to a boxed carrier:

```js
var s = 0; for (…) { s = s + p.inc(); }
```

— the most common accumulator shape in ordinary JavaScript, paying ~300k `__box_number` allocations per bench call. The same file already read `"mixed"` the *other* way for an initializer, so the two sites disagreed about the same unknown.

**This is not a revert.** #3961's hazard — an i32 boolean slot destroying a later string assignment by coercing it to truthiness — is real, and three new tests pin it still boxing. An unresolvable assignment now gets a second question: does the whole-program fixpoint prove every definition of the slot numeric? Only if that also fails does the conservative demotion stand.

### It took three parts, not one

Consulting the fixpoint was the easy part. It couldn't prove the accumulator at all until two gaps closed — each verified by querying the verdict directly before and after:

1. **Self-reference.** `s = s + f()` is unprovable by a plain least fixpoint: proving `s` numeric requires `s` numeric. The grounded set now assumes the slot while judging its own definitions — the induction `withSelf` already gives the property path — then **re-checks groundedness with the assumption withdrawn**. So `var s = s + 1` (self-justifying, NaN in JS) is still rejected, and a mutual cycle `var a = b; var b = a` still cannot enter, because the assumption covers a slot's own name and never its partner's.

2. **`numericFunctions` on a non-`this` receiver.** It was consulted only for `this.m()`, though the verdict is whole-program and NAME-keyed — equally true of `p.inc()`, since a single non-numeric `inc` anywhere removes the name for both. Widened to bare-identifier receivers only, so member chains (`a.b.inc()`) and call results (`f().inc()`) keep the old answer.

   **This one genuinely widens a trust boundary** and is the part most worth reviewing: an `inc` that is not statically visible (a host/builtin method behind an opaque receiver) cannot demote the name. That exposure already existed for `this.m()`, whose receiver is equally unconstrained at runtime, and it is the same name-keying trade the file documents throughout — but it is a widening, not a no-op.

### Measured

Same container, interleaved, `chk=45000150000` on every leg:

| axis | before | after | node |
|---|---:|---:|---|
| method | 2.85–3.01 ms | **0.813 ms** | 0.49–0.60 |
| tokenizer (unchanged) | 0.253 | 0.257 | 0.17 |

**3.6x**, i.e. ~1.35–1.67x vs node from 4.7–6.2x. `$s` externref → f64, box 3 → 1, unbox 2 → **0**. Behind `JS2WASM_MIXED_CARRIER_NUMERIC=0`.

---

## #4121 — where the residual 10x actually is

The **micro-benchmark axes are at or near parity**; the ≥10x gaps are entirely in real npm packages (acorn 11.5x, cookie 10.6x, clsx 10.3x standalone runtime-dynamic).

Two published numbers don't mean what they look like, and both are recorded:
- the **`compile-time static` lane is not a comparison** — it reports acorn parsing a 226 KB bundle in 0.246 µs, which is constant folding, not execution;
- the **JS-host lane** (cookie 570x) is a different problem: **736 wasm→host calls** for one `parseCookie` on a 38-character header, identically on the second call.

Reduced to the smallest program that shows the standalone case:

| source | `$i` slot | box | unbox |
|---|---|---:|---:|
| `let i = 0; i = i + 1;` | **f64** | 0 | 0 |
| `let i = 0; i = s.indexOf(";");` | **externref** | 2 | 1 |

**A falsified hypothesis is recorded so nobody rebuilds it:** a box/unbox peephole finds nothing — of 59 box sites in the standalone cookie module, **0** are immediately re-unboxed. The round-trip is real but goes *through a local slot*, which is dataflow, not adjacency.

The issue targets the **IR**, not a fifth AST-side consumer: `IrType.union`, `box`/`unbox` instructions, `propagate.ts` and the pass pipeline all already exist, so the missing piece is the propagation between them — and the existing lowering would then emit nothing. It also records the blocking caveat that an IR pass only applies where the IR *claims* the function, which makes an IR-coverage pre-flight the first acceptance criterion and may block the issue on #2855.

---

## #4123 — a silent miscompile, found on the way

While building a guard test for #4122 I hit a wrong answer on **unmodified main**, verified by stashing all local changes:

```js
function K(){} K.prototype.k = function(){ return 3; };
function f(o){ return o.k(); }
export function main(){ return f(new K()); }   // → null, JS says 3
```

A prototype method on a **parameter** receiver returns `null`/`0`; the identical call with a *local* `new K()` receiver is correct. No trap, no diagnostic. Filed as #4123 with a six-row table and the receiver-flow starting point; being worked separately.

---

## Testing

- `tests/issue-4122-mixed-carrier-numeric.test.ts` — 13 tests. Both directions: the accumulator unboxes, and every genuinely cross-domain binding (`bool→string`, `num→string`, `num→bool`, and an unresolvable slot with *no* numeric proof) still boxes. Plus the self-reference cases: `var s = s + 1` and a mutual cycle both rejected.
- 28 tests green including the #3765 suite (no regression in the neighbouring analysis).
- `tsc --noEmit` clean. Gates pass: `check:issues`, `check:loc-budget`, `check:func-budget`, `check:oracle-ratchet`, `check:coercion-sites`, `check:any-box-sites`, `check:issue-spec-coverage`, `check:done-status-integrity`, `check:test-vacuity-shapes`, `lint`.
- `check:godfiles` fails — **verified pre-existing on untouched main** (`src/codegen/index.ts` mega-functions), not from this change.
- `loc-budget-allow` granted for `src/codegen/context/types.ts`: the verdict must reach `bindingHasMixedAssignmentCarrier`, which runs before any carrier type exists, so there is no subsystem module upstream of it to hold the field.

**Stated plainly:** my local full equivalence run had not finished when this PR was opened, so I am *not* claiming "no equivalence regressions" — CI's `equivalence-gate` is the authority. I will post the local result when it lands.

Issue ids came from `claim-issue.mjs --allocate`; the open-PR scan degraded (no `gh` auth in this container), so I checked the two open PRs via the API instead — #4062 claims #4118, no collision.

## CLA

- [x] I have read and agree to the CLA
