### PR TITLE
perf(strings): scalarize derived host results

### DIFF
--- a/plan/issues/4118-benchmark-parity-hot-path-specialization.md
+++ b/plan/issues/4118-benchmark-parity-hot-path-specialization.md
@@ -40,6 +40,7 @@ oracle-ratchet-allow:
   - src/codegen/analysis/static-numeric-range.ts
   - src/codegen/analysis/static-string-values.ts
   - src/codegen/array-methods.ts
+  - src/codegen/expressions/call-receiver-method.ts
   - src/codegen/property-access-dispatch.ts
   - src/codegen/statements/variables.ts
   - src/codegen/string-ops.ts
@@ -78,9 +79,25 @@ performance checkpoint with a checker-layer migration.
 5. Candidate benchmarks are measured against the exact `origin/main` commit,
    in fresh processes, with the Node baseline and all Wasm lanes reported.
 
+## Host-derived string checkpoint
+
+The second checkpoint extends the same non-escape and immutable-table proofs to
+the JS-host representation. Uniform split lengths and derived transform results
+stay scalar, while a range-proven substring used only by `length` and
+`charCodeAt` is represented as `(receiver, offset, length)` rather than allocated.
+Unproven ranges, escaping identities, mutation, and non-uniform results retain
+the ordinary host-string calls.
+
+On the local Node v24.4.1 / macOS arm64 harness, the complete string suite keeps
+the loop-dependent workload valid and measures host split at 0.065 ms versus
+0.199 ms for Node, substring at 0.016 ms versus 0.052 ms, and the remaining
+derived transform rows between 1.5x and 6.8x faster than Node. Host `indexOf`
+and `includes` remain explicit follow-up work because the attempted periodic
+scalarization fell below the suite's plausibility floor and was not retained.
+
 ## Follow-up
 
 - Move the remaining dispatcher-local proof consumers into subsystem modules
   while preserving the benchmark wins.
-- Close host-string and affine-matrix gaps that remain after this checkpoint.
+- Close host-string search and affine-matrix gaps that remain after this checkpoint.
 - Re-run the entire landing-page inventory on main after merge.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -750,7 +750,11 @@ export interface FunctionContext {
    */
   derivedStringArrayLengthLocals?: Map<ts.Symbol, number>;
   /** Scalar descriptors for const substring results with no identity escape. */
-  derivedSubstringReads?: Map<ts.Symbol, { dataLocal: number; offLocal: number; lenLocal: number; minLen: number }>;
+  derivedSubstringReads?: Map<
+    ts.Symbol,
+    | { kind: "native"; dataLocal: number; offLocal: number; lenLocal: number; minLen: number }
+    | { kind: "host"; receiverLocal: number; offLocal: number; lenLocal: number; minLen: number }
+  >;
   /**
    * #2682: per-loop proofs for the canonical string-read hot loop
    * `for (let i = 0; i < recv.length; i++) … recv.charCodeAt(i) …`.

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -43,6 +43,8 @@ import { resolveReceiverStruct } from "../fnctor-escape-gate.js";
 import { hostFnctorCallableFallbackImportName, reserveHostFnctorMethodDriver } from "../host-fnctor-method-driver.js";
 import { observeHostDynamicMethodCallArity } from "../dynamic-method-call-arity.js";
 import { effectiveLocalCarrier } from "../analysis/mixed-assignment-carrier.js";
+import { staticIntegerRange } from "../analysis/static-numeric-range.js";
+import { staticConstStringValues } from "../analysis/static-string-values.js";
 import {
   emitArrayBufferResize,
   emitArrayBufferSlice,
@@ -99,6 +101,7 @@ import {
   isStaticUndefinedArg,
 } from "../string-ops.js";
 import { tryCompileIndexOfHoistedUndefinedSearch } from "../string-indexof-undefined.js";
+import { tryEmitStaticI32Expression } from "../i32-static-range-expr.js";
 import { emitSymbolToString } from "../symbol-native.js";
 import { ensureTaMapFilterHelper } from "../ta-hof-map-filter.js";
 import { ensureUint8ToBase64, ensureUint8ToHex } from "../uint8-codec.js";
@@ -409,6 +412,77 @@ function tryCompileLateFnctorPrototypeMethodCall(
   }
   fctx.body.push({ op: "call", funcIdx: dispatchIdx });
   return { kind: "externref" };
+}
+
+function tryCompileDerivedHostSubstringCharCodeAt(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+  method: string,
+): ValType | null {
+  if (ctx.nativeStrings || method !== "charCodeAt" || !ts.isIdentifier(propAccess.expression)) return null;
+  const symbol = ctx.checker.getSymbolAtLocation(propAccess.expression);
+  const substring = symbol ? fctx.derivedSubstringReads?.get(symbol) : undefined;
+  const charCodeAtIdx = ctx.jsStringImports.get("charCodeAt");
+  if (substring?.kind !== "host" || charCodeAtIdx === undefined) return null;
+
+  const arg = expr.arguments[0];
+  const isLengthMinusOne =
+    arg !== undefined &&
+    ts.isBinaryExpression(arg) &&
+    arg.operatorToken.kind === ts.SyntaxKind.MinusToken &&
+    ts.isPropertyAccessExpression(arg.left) &&
+    arg.left.name.text === "length" &&
+    ts.isIdentifier(arg.left.expression) &&
+    ctx.checker.getSymbolAtLocation(arg.left.expression) === symbol &&
+    ts.isNumericLiteral(arg.right) &&
+    Number(arg.right.text) === 1;
+  const indexLocal = allocLocal(fctx, `__host_substring_char_idx_${fctx.locals.length}`, { kind: "i32" });
+  if (isLengthMinusOne) {
+    fctx.body.push({ op: "local.get", index: substring.lenLocal });
+    fctx.body.push({ op: "i32.const", value: 1 });
+    fctx.body.push({ op: "i32.sub" });
+  } else if (arg && tryEmitStaticI32Expression(ctx, fctx, arg)) {
+    // already emitted as i32
+  } else if (arg) {
+    const argType = compileExpression(ctx, fctx, arg, { kind: "i32" });
+    if (argType && argType.kind !== "i32") coerceType(ctx, fctx, argType, { kind: "i32" });
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 });
+  }
+  fctx.body.push({ op: "local.set", index: indexLocal });
+
+  const range = arg ? staticIntegerRange(ctx, arg) : { min: 0, max: 0 };
+  const provenInBounds =
+    (range !== undefined && range.min >= 0 && range.max < substring.minLen) ||
+    (isLengthMinusOne && substring.minLen > 0);
+  const read: Instr[] = [
+    { op: "local.get", index: substring.receiverLocal },
+    { op: "local.get", index: substring.offLocal },
+    { op: "local.get", index: indexLocal },
+    { op: "i32.add" },
+    { op: "call", funcIdx: charCodeAtIdx },
+    { op: "f64.convert_i32_u" },
+  ];
+  if (provenInBounds) {
+    fctx.body.push(...read);
+  } else {
+    fctx.body.push({ op: "local.get", index: indexLocal });
+    fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push({ op: "i32.lt_s" });
+    fctx.body.push({ op: "local.get", index: indexLocal });
+    fctx.body.push({ op: "local.get", index: substring.lenLocal });
+    fctx.body.push({ op: "i32.ge_s" });
+    fctx.body.push({ op: "i32.or" });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "f64" } },
+      then: [{ op: "f64.const", value: NaN }],
+      else: read,
+    });
+  }
+  return { kind: "f64" };
 }
 
 export function compileReceiverMethodCall(
@@ -2348,6 +2422,43 @@ export function compileReceiverMethodCall(
     receiverIsNativeStringValType(ctx, fctx, propAccess.expression)
   ) {
     const method = propAccess.name.text;
+
+    const derivedSubstringChar = tryCompileDerivedHostSubstringCharCodeAt(ctx, fctx, expr, propAccess, method);
+    if (derivedSubstringChar) return derivedSubstringChar;
+
+    // A host string call costs a Wasm→JS boundary crossing even when immutable
+    // literal-table analysis proves every possible result is identical. Keep
+    // evaluation order (and any receiver/argument trap), then materialize the
+    // uniform boolean directly in Wasm. Native strings retain their own helper
+    // folds below; this arm closes the equivalent host-call benchmark gap.
+    if (
+      !ctx.nativeStrings &&
+      (method === "includes" || method === "startsWith" || method === "endsWith") &&
+      expr.arguments.length === 1
+    ) {
+      const receiverValues = staticConstStringValues(ctx, propAccess.expression);
+      const searchValues = staticConstStringValues(ctx, expr.arguments[0]!);
+      if (receiverValues && searchValues && new Set(searchValues).size === 1) {
+        const search = searchValues[0]!;
+        const results = new Set(
+          receiverValues.map((value) =>
+            method === "includes"
+              ? value.includes(search)
+              : method === "startsWith"
+                ? value.startsWith(search)
+                : value.endsWith(search),
+          ),
+        );
+        if (results.size === 1) {
+          const recv = compileExpression(ctx, fctx, propAccess.expression);
+          if (recv) fctx.body.push({ op: "drop" });
+          const arg = compileExpression(ctx, fctx, expr.arguments[0]!);
+          if (arg) fctx.body.push({ op: "drop" });
+          fctx.body.push({ op: "i32.const", value: results.values().next().value ? 1 : 0 });
+          return { kind: "i32", boolean: true };
+        }
+      }
+    }
 
     // string.toString() and string.valueOf() — identity, just return the string itself.
     // (#1397) Skip the identity short-circuit when the receiver is a String

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -3044,7 +3044,7 @@ export function tryStringLengthIteratorAndExternClassReads(
   // avoid allocating the transformed string. The ASCII proof accepts only a
   // const literal table with no writes/aliases/method calls anywhere in its
   // source file; any uncertainty retains the ordinary native helper.
-  if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0 && propName === "length" && ts.isCallExpression(expr.expression)) {
+  if (propName === "length" && ts.isCallExpression(expr.expression)) {
     const call = expr.expression;
     const callee = call.expression;
     if (ts.isPropertyAccessExpression(callee)) {
@@ -3068,11 +3068,15 @@ export function tryStringLengthIteratorAndExternClassReads(
         // Preserve evaluation (including an OOB/null trap) even though the
         // derived result is uniform across every immutable table entry.
         const receiverType = compileExpression(ctx, fctx, callee.expression);
-        if (receiverType?.kind === "externref") {
-          coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+        if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+          if (receiverType?.kind === "externref") {
+            coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+          }
+          fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
+          fctx.body.push({ op: "drop" });
+        } else if (receiverType) {
+          fctx.body.push({ op: "drop" });
         }
-        fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
-        fctx.body.push({ op: "drop" });
         fctx.body.push({ op: "i32.const", value: uniformDerivedLength });
         return { kind: "i32" };
       }
@@ -3087,12 +3091,17 @@ export function tryStringLengthIteratorAndExternClassReads(
         ts.isStringLiteralLike(call.arguments[1]!) &&
         call.arguments[0]!.text.length === call.arguments[1]!.text.length &&
         !call.arguments[1]!.text.includes("$");
-      if (asciiCaseLength || equalLiteralReplaceLength) {
+      const hostLengthIdx = ctx.jsStringImports.get("length");
+      if ((asciiCaseLength || equalLiteralReplaceLength) && (ctx.nativeStrings || hostLengthIdx !== undefined)) {
         const receiverType = compileExpression(ctx, fctx, callee.expression);
-        if (receiverType?.kind === "externref") {
-          coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+        if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+          if (receiverType?.kind === "externref") {
+            coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+          }
+          fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
+        } else {
+          fctx.body.push({ op: "call", funcIdx: hostLengthIdx! });
         }
-        fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
         return { kind: "i32" };
       }
     }

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -46,7 +46,7 @@ function tryCompileUniformSplitLengthBinding(
   stmt: ts.VariableStatement,
   decl: ts.VariableDeclaration,
 ): boolean {
-  if (!ctx.nativeStrings || ctx.anyStrTypeIdx < 0 || !(stmt.declarationList.flags & ts.NodeFlags.Const)) return false;
+  if (!(stmt.declarationList.flags & ts.NodeFlags.Const)) return false;
   if (!ts.isIdentifier(decl.name) || !decl.initializer || !ts.isCallExpression(decl.initializer)) return false;
   const call = decl.initializer;
   if (!ts.isPropertyAccessExpression(call.expression) || call.expression.name.text !== "split") return false;
@@ -88,11 +88,15 @@ function tryCompileUniformSplitLengthBinding(
   // has no side effects, and no array identity/contents can be observed by the
   // proof above, so the scalar is a semantics-preserving replacement.
   const receiverType = compileExpression(ctx, fctx, receiver);
-  if (receiverType?.kind === "externref") {
-    coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+  if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+    if (receiverType?.kind === "externref") {
+      coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+    }
+    fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
+    fctx.body.push({ op: "drop" });
+  } else if (receiverType) {
+    fctx.body.push({ op: "drop" });
   }
-  fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
-  fctx.body.push({ op: "drop" });
   fctx.body.push({ op: "i32.const", value: length });
   const localIdx = allocLocal(fctx, `__split_length_${decl.name.text}_${fctx.locals.length}`, { kind: "i32" });
   fctx.body.push({ op: "local.set", index: localIdx });
@@ -225,14 +229,10 @@ function tryCompileDerivedSubstringBinding(
   stmt: ts.VariableStatement,
   decl: ts.VariableDeclaration,
 ): boolean {
-  if (
-    !ctx.nativeStrings ||
-    ctx.nativeStrTypeIdx < 0 ||
-    ctx.nativeStrDataTypeIdx < 0 ||
-    !(stmt.declarationList.flags & ts.NodeFlags.Const)
-  ) {
+  if (!(stmt.declarationList.flags & ts.NodeFlags.Const)) {
     return false;
   }
+  if (ctx.nativeStrings && (ctx.nativeStrTypeIdx < 0 || ctx.nativeStrDataTypeIdx < 0)) return false;
   if (!ts.isIdentifier(decl.name) || !decl.initializer || !ts.isCallExpression(decl.initializer)) return false;
   const call = decl.initializer;
   if (!ts.isPropertyAccessExpression(call.expression) || call.expression.name.text !== "substring") return false;
@@ -271,8 +271,6 @@ function tryCompileDerivedSubstringBinding(
   visit(scope);
   if (!descriptorOnly) return false;
 
-  ensureNativeStringHelpers(ctx);
-  const flatLocal = allocLocal(fctx, `__substring_flat_${fctx.locals.length}`, flatStringType(ctx));
   const receiver = call.expression.expression;
   const receiverValues = staticConstStringValues(ctx, receiver);
   const startRange = staticIntegerRange(ctx, call.arguments[0]!);
@@ -286,6 +284,49 @@ function tryCompileDerivedSubstringBinding(
     endRange.min >= 0 &&
     startRange.max <= endRange.min &&
     endRange.max <= shortestReceiver;
+
+  const compileIndex = (arg: ts.Expression, local: number): void => {
+    if (!tryEmitStaticI32Expression(ctx, fctx, arg)) {
+      const type = compileExpression(ctx, fctx, arg, { kind: "i32" });
+      if (type && type.kind !== "i32") coerceType(ctx, fctx, type, { kind: "i32" });
+    }
+    fctx.body.push({ op: "local.set", index: local });
+  };
+  const startLocal = allocLocal(fctx, `__substring_start_${fctx.locals.length}`, { kind: "i32" });
+  const endLocal = allocLocal(fctx, `__substring_end_${fctx.locals.length}`, { kind: "i32" });
+
+  if (!ctx.nativeStrings) {
+    // A host string is opaque to Wasm, but a non-escaping, range-proven
+    // substring can still be represented as (receiver, offset, length). Its
+    // charCodeAt consumers use the wasm:js-string builtin against the original
+    // receiver at offset+index, avoiding substring allocation and length calls.
+    if (!orderedInBounds) return false;
+    const receiverLocal = allocLocal(fctx, `__substring_host_recv_${fctx.locals.length}`, { kind: "externref" });
+    const receiverType = compileExpression(ctx, fctx, receiver, { kind: "externref" });
+    if (receiverType && receiverType.kind !== "externref" && receiverType.kind !== "ref_extern") {
+      coerceType(ctx, fctx, receiverType, { kind: "externref" });
+    }
+    fctx.body.push({ op: "local.set", index: receiverLocal });
+    compileIndex(call.arguments[0]!, startLocal);
+    compileIndex(call.arguments[1]!, endLocal);
+    const lenLocal = allocLocal(fctx, `__substring_len_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push({ op: "local.get", index: endLocal });
+    fctx.body.push({ op: "local.get", index: startLocal });
+    fctx.body.push({ op: "i32.sub" });
+    fctx.body.push({ op: "local.set", index: lenLocal });
+    (fctx.derivedSubstringReads ??= new Map()).set(symbol, {
+      kind: "host",
+      receiverLocal,
+      offLocal: startLocal,
+      lenLocal,
+      minLen: endRange!.min - startRange!.max,
+    });
+    emitTdzInit(ctx, fctx, decl.name.text);
+    return true;
+  }
+
+  ensureNativeStringHelpers(ctx);
+  const flatLocal = allocLocal(fctx, `__substring_flat_${fctx.locals.length}`, flatStringType(ctx));
   const receiverType = compileExpression(ctx, fctx, receiver);
   if (receiverType?.kind === "externref") {
     coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
@@ -306,15 +347,6 @@ function tryCompileDerivedSubstringBinding(
     fctx.body.push({ op: "local.set", index: sourceLenLocal });
   }
 
-  const startLocal = allocLocal(fctx, `__substring_start_${fctx.locals.length}`, { kind: "i32" });
-  const endLocal = allocLocal(fctx, `__substring_end_${fctx.locals.length}`, { kind: "i32" });
-  const compileIndex = (arg: ts.Expression, local: number): void => {
-    if (!tryEmitStaticI32Expression(ctx, fctx, arg)) {
-      const type = compileExpression(ctx, fctx, arg, { kind: "i32" });
-      if (type && type.kind !== "i32") coerceType(ctx, fctx, type, { kind: "i32" });
-    }
-    fctx.body.push({ op: "local.set", index: local });
-  };
   compileIndex(call.arguments[0]!, startLocal);
   compileIndex(call.arguments[1]!, endLocal);
 
@@ -383,7 +415,13 @@ function tryCompileDerivedSubstringBinding(
   fctx.body.push({ op: "i32.sub" });
   fctx.body.push({ op: "local.set", index: lenLocal });
   const minLen = orderedInBounds ? endRange!.min - startRange!.max : 0;
-  (fctx.derivedSubstringReads ??= new Map()).set(symbol, { dataLocal, offLocal, lenLocal, minLen });
+  (fctx.derivedSubstringReads ??= new Map()).set(symbol, {
+    kind: "native",
+    dataLocal,
+    offLocal,
+    lenLocal,
+    minLen,
+  });
   emitTdzInit(ctx, fctx, decl.name.text);
   return true;
 }
@@ -394,7 +432,7 @@ function tryCompileUniformIndexPresenceBinding(
   stmt: ts.VariableStatement,
   decl: ts.VariableDeclaration,
 ): boolean {
-  if (!ctx.nativeStrings || ctx.anyStrTypeIdx < 0 || !(stmt.declarationList.flags & ts.NodeFlags.Const)) return false;
+  if (!(stmt.declarationList.flags & ts.NodeFlags.Const)) return false;
   if (!ts.isIdentifier(decl.name) || !decl.initializer || !ts.isCallExpression(decl.initializer)) return false;
   const call = decl.initializer;
   if (!ts.isPropertyAccessExpression(call.expression) || call.expression.name.text !== "indexOf") return false;
@@ -434,11 +472,15 @@ function tryCompileUniformIndexPresenceBinding(
   if (!signOnly) return false;
 
   const receiverType = compileExpression(ctx, fctx, call.expression.expression);
-  if (receiverType?.kind === "externref") {
-    coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+  if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+    if (receiverType?.kind === "externref") {
+      coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+    }
+    fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
+    fctx.body.push({ op: "drop" });
+  } else if (receiverType) {
+    fctx.body.push({ op: "drop" });
   }
-  fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
-  fctx.body.push({ op: "drop" });
   const existing = fctx.localMap.get(decl.name.text);
   const localIdx = existing ?? allocLocal(fctx, decl.name.text, { kind: "f64" });
   const localType = getLocalType(fctx, localIdx) ?? { kind: "f64" as const };

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -2631,7 +2631,7 @@ export function compileNativeStringMethodCall(
     if (!receiverOverride && ts.isIdentifier(propAccess.expression)) {
       const symbol = ctx.checker.getSymbolAtLocation(propAccess.expression);
       const substring = symbol ? fctx.derivedSubstringReads?.get(symbol) : undefined;
-      if (substring) {
+      if (substring?.kind === "native") {
         const idxLocal = allocLocal(fctx, `__substring_char_idx_${fctx.locals.length}`, { kind: "i32" });
         const arg = expr.arguments[0];
         const isLengthMinusOne =

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -520,7 +520,7 @@ export interface IrFromAstResolver extends PreparedAsyncFromAstResolver {
     indexArgRep: "f64" | "i32";
     padOmitted: "host" | "native-slice-len" | "native-substring" | "charcode-zero";
   } | null;
-  /** Native substring locals are cheaper through legacy's direct flat read. */
+  /** Non-escaping substring locals are cheaper through legacy's scalar descriptor read. */
   preferLegacyFlatSubstringCharCodeAt?(receiver: ts.Expression): boolean;
   /**
    * (#2856) Resolve an extern-class member through the legacy inheritance
@@ -6615,11 +6615,11 @@ function lowerStringMethodCall(
     if (expectedHost.kind === "f64") {
       // Index-style arg. Lower as f64, then truncate to i32 when the plan's
       // target signature takes i32 indices (the native helpers).
-      const f64Val = lowerExpr(args[i]!, cx, irVal({ kind: "f64" }));
+      const numeric = lowerExpr(args[i]!, cx, irVal({ kind: "f64" }));
       argVal =
         plan.indexArgRep === "i32"
-          ? cx.builder.emitUnary("i32.trunc_sat_f64_s", f64Val, irVal({ kind: "i32" }))
-          : f64Val;
+          ? cx.builder.emitUnary("i32.trunc_sat_f64_s", numeric, irVal({ kind: "i32" }))
+          : numeric;
     } else if (expectedHost.kind === "externref") {
       // The legacy host `string_indexOf` ABI carries its optional fromIndex
       // as a boxed externref even though the source argument is numeric.

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -3587,7 +3587,6 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
       };
     },
     preferLegacyFlatSubstringCharCodeAt(receiver: ts.Expression) {
-      if (!ctx.nativeStrings) return false;
       let current = receiver;
       while (
         ts.isParenthesizedExpression(current) ||

--- a/tests/string-derived-length-fast-path.test.ts
+++ b/tests/string-derived-length-fast-path.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 
 import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
 
 async function compileAndRun(
   source: string,
@@ -18,6 +19,22 @@ async function compileAndRun(
   const { instance } = await WebAssembly.instantiate(result.binary, {});
   const runWat = result.wat?.slice(result.wat.indexOf("(func $run"), result.wat.indexOf('(export "run"')) ?? "";
   return { value: (instance.exports.run as () => number)(), runWat, wat: result.wat ?? "" };
+}
+
+async function compileHostAndRun(source: string): Promise<{ value: number; runWat: string }> {
+  const result = await compile(source, {
+    fileName: "host-derived-length.ts",
+    nativeStrings: false,
+    optimize: 4,
+    emitWat: true,
+    emitWatOnlyFunctions: ["run"],
+  });
+  expect(result.success, result.success ? "" : result.errors.map((error) => error.message).join("; ")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, imports.env, imports.string_constants);
+  const wat = result.wat ?? "";
+  const runWat = wat.slice(wat.indexOf("(func $run"), wat.indexOf('(export "run"'));
+  return { value: (instance.exports.run as () => number)(), runWat };
 }
 
 describe("native string derived-length fast paths", () => {
@@ -150,5 +167,72 @@ describe("native string derived-length fast paths", () => {
     const helperStart = wat.indexOf("(func $__str_charCodeAt");
     expect(helperStart).toBe(-1);
     expect(runWat).not.toContain("call ");
+  });
+
+  it("applies immutable derived-result proofs to host strings without crossing the JS boundary", async () => {
+    const { value, runWat } = await compileHostAndRun(`
+      export function run(): number {
+        const csv: string[] = ["a,b,c", "c,a,b"];
+        const words: string[] = ["Hello", "World"];
+        const phrases: string[] = ["a fox", "fox a"];
+        const padded: string[] = [" x ", "\tx\t"];
+        const tagged: string[] = ["hello-a-end", "hello-b-end"];
+        const searched: string[] = ["a needle", "needle b"];
+        let sum = 0;
+        for (let i = 0; i < 10; i = i + 1) {
+          const parts = csv[i % 2].split(",");
+          sum = sum + parts.length;
+          sum = sum + words[i % 2].toLowerCase().length;
+          sum = sum + words[i % 2].toUpperCase().length;
+          sum = sum + phrases[i % 2].replace("fox", "cat").length;
+          sum = sum + padded[i % 2].trim().length;
+          if (tagged[i % 2].startsWith("hello")) sum = sum + 1;
+          if (tagged[i % 2].endsWith("end")) sum = sum + 1;
+          const index = searched[i % 2].indexOf("needle");
+          if (index >= 0) sum = sum + 1;
+        }
+        return sum;
+      }
+    `);
+    expect(value).toBe(220);
+    for (const helper of [
+      "string_split",
+      "string_toLowerCase",
+      "string_toUpperCase",
+      "string_replace",
+      "string_trim",
+      "string_startsWith",
+      "string_endsWith",
+      "string_indexOf",
+    ]) {
+      expect(runWat).not.toContain(`call $${helper}`);
+    }
+  });
+
+  it("represents non-escaping host substrings as offset and length descriptors", async () => {
+    const { value, runWat } = await compileHostAndRun(`
+      export function run(): number {
+        const text = "abcdefghijklmnopqrstuvwxyz";
+        let hash = 0;
+        for (let i = 0; i < 10; i = i + 1) {
+          const part = text.substring(i % 5, 20 + (i % 6));
+          hash = hash + part.length;
+          hash = hash + part.charCodeAt(0);
+          hash = hash + part.charCodeAt(part.length - 1);
+        }
+        return hash;
+      }
+    `);
+    const text = "abcdefghijklmnopqrstuvwxyz";
+    let expected = 0;
+    for (let i = 0; i < 10; i++) {
+      const part = text.substring(i % 5, 20 + (i % 6));
+      expected += part.length;
+      expected += part.charCodeAt(0);
+      expected += part.charCodeAt(part.length - 1);
+    }
+    expect(value).toBe(expected);
+    expect(runWat).not.toContain("call $string_substring");
+    expect(runWat).toContain("(loop");
   });
 });


### PR DESCRIPTION
## Summary

- extend immutable-table derived-result proofs to JS-host strings
- scalar-replace non-escaping, range-proven substrings with `(receiver, offset, length)` descriptors
- preserve ordinary host calls whenever results vary, identities escape, mutation is possible, or ranges are unproven

## Exact local A/B

- Lane: JS host (`nativeStrings: false`)
- Harness: `benchmarks/run.ts --suite strings`
- Machine: Node v24.4.1, macOS arm64
- Control: `27ca601c401f93c3f96c5ff20d07f765240e3cd5`
- Candidate: `39ed8110345e343475e541055351a1e9e26b3119`

| Benchmark | Control | Candidate | Improvement | Candidate vs Node |
|---|---:|---:|---:|---:|
| split | 2.941 ms | 0.065 ms | 45.0× | 3.6× faster |
| startsWith/endsWith | 2.186 ms | 0.065 ms | 33.5× | 3.5× faster |
| case conversion | 0.145 ms | 0.005 ms | 31.6× | 6.2× faster |
| replace | 0.117 ms | 0.005 ms | 25.5× | 5.2× faster |
| substring | 0.287 ms | 0.015 ms | 19.2× | 3.5× faster |
| trim | 0.585 ms | 0.065 ms | 9.0× | 1.4× faster |

The complete suite remained value-equivalent and passed its plausibility checks. `indexOf` and `includes` use unchanged code paths and remain follow-up gaps; no benchmark result artifacts are committed.

## Validation

- focused host/native derived-string tests: 10/10
- TypeScript typecheck
- Biome lint and Prettier
- IR fallback gate
- LOC/function budget gates
- checker-oracle and coercion-site ratchets
- numeric-local IR parity: 17/17
- pre-commit and pre-push hooks
