### PR TITLE
fix(#4123): prototype method on a parameter receiver silently returned null

### DIFF
--- a/src/codegen/fnctor-escape-gate.ts
+++ b/src/codegen/fnctor-escape-gate.ts
@@ -388,16 +388,23 @@ function collectFnctorOwnFields(ctorSym: ts.Symbol): Set<string> {
  *
  * Conservative: an unrecognised use that COULD be a typed field read is treated
  * as `"typed"` (keep), never as `"dynamic"`.
+ *
+ * (#4123) `useNode` is the expression standing for the instance at this site.
+ * For a BOUND instance that is the identifier reading the binding; for an
+ * INLINE `new F()` it is the `NewExpression` itself (after unwrapping any
+ * paren/`as`/`!` layers). Both are ordinary expression nodes, and every rule
+ * below only inspects `useNode.parent` plus `useNode` as a checker *location* —
+ * so one ladder serves both and the two call sites cannot drift apart again.
  */
 function classifyUse(
   checker: ts.TypeChecker,
-  idNode: ts.Identifier,
+  useNode: ts.Expression,
   ownFields: ReadonlySet<string>,
 ): "typed" | "dynamic" | "neutral" {
-  const parent = idNode.parent;
+  const parent = useNode.parent;
 
   // `inst.<name>` — property access.
-  if (ts.isPropertyAccessExpression(parent) && parent.expression === idNode) {
+  if (ts.isPropertyAccessExpression(parent) && parent.expression === useNode) {
     const name = parent.name.text;
     // `inst.method.call(...)` / `inst.method.apply(...)` reflective dispatch is
     // dynamic ONLY when `inst` is the receiver ARG, not the method holder; a bare
@@ -411,7 +418,7 @@ function classifyUse(
   }
 
   // `inst[expr]` — element access. Computed/indexed reads are dynamic.
-  if (ts.isElementAccessExpression(parent) && parent.expression === idNode) {
+  if (ts.isElementAccessExpression(parent) && parent.expression === useNode) {
     return "dynamic";
   }
 
@@ -422,7 +429,7 @@ function classifyUse(
   if (
     ts.isBinaryExpression(parent) &&
     parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-    parent.right === idNode &&
+    parent.right === useNode &&
     (ts.isPropertyAccessExpression(parent.left) || ts.isElementAccessExpression(parent.left))
   ) {
     return "dynamic";
@@ -430,7 +437,7 @@ function classifyUse(
 
   // `someMethod.call(inst, …)` / `.apply(inst, …)` — `inst` is the receiver arg
   // of a reflective generic-method call → array-like dynamic use.
-  if (ts.isCallExpression(parent) && parent.arguments.length > 0 && parent.arguments[0] === idNode) {
+  if (ts.isCallExpression(parent) && parent.arguments.length > 0 && parent.arguments[0] === useNode) {
     const callee = parent.expression;
     if (ts.isPropertyAccessExpression(callee) && GENERIC_METHOD_CALL.has(callee.name.text)) {
       return "dynamic";
@@ -443,12 +450,12 @@ function classifyUse(
   // (the callee's own uses would be classified at that param's site in a fuller
   // interprocedural pass — out of scope for S1's conservative single-level view).
   if (ts.isCallExpression(parent)) {
-    const argIdx = parent.arguments.indexOf(idNode);
+    const argIdx = parent.arguments.indexOf(useNode);
     if (argIdx >= 0) {
       const sig = checker.getResolvedSignature(parent);
       const paramSym = sig?.parameters[argIdx];
       if (paramSym) {
-        const pType = checker.getTypeOfSymbolAtLocation(paramSym, idNode);
+        const pType = checker.getTypeOfSymbolAtLocation(paramSym, useNode);
         if (isAnyOrUnknown(pType)) return "dynamic";
       }
       return "neutral";
@@ -1306,37 +1313,27 @@ export function analyzeFnctorEscapeGate(checker: ts.TypeChecker, sourceFile: ts.
       // Inline `new F().X` — classify the single immediate consuming use,
       // unwrapping any `( … )` / `as` / `!` wrappers between the NewExpression
       // and its consumer (`(new Con()).x` has a ParenthesizedExpression parent).
+      //
+      // (#4123) This arm used to re-implement a SUBSET of {@link classifyUse}'s
+      // ladder and, in doing so, dropped its call-ARGUMENT rule: `f(new F())`
+      // passed to an `any`/`unknown` parameter was classified `keep-static`
+      // while the otherwise identical `var o = new F(); f(o)` was classified
+      // `dynamic` ⇒ `reconstruct`. That asymmetry is a silent MISCOMPILE, not a
+      // missed optimization: a `keep-static` instance is lowered to the bespoke
+      // `$__fnctor_<F>` struct, which carries own fields but NO `$proto` link,
+      // so the callee's dynamic `o.k()` (`__extern_method_call` → `__extern_get`
+      // own+prototype walk) finds nothing and yields `undefined` — the call
+      // returns `null`/`0` with no trap. Delegating to `classifyUse` restores
+      // the symmetry; its ladder is a strict superset of the one that was here.
       let inner: ts.Expression = newExpr;
       let parent = inner.parent;
       while (ts.isParenthesizedExpression(parent) || ts.isAsExpression(parent) || ts.isNonNullExpression(parent)) {
         inner = parent;
         parent = parent.parent;
       }
-      if (ts.isPropertyAccessExpression(parent) && parent.expression === inner) {
-        if (ownFields.has(parent.name.text)) sawTyped = true;
-        else sawDynamic = true;
-      } else if (ts.isElementAccessExpression(parent) && parent.expression === inner) {
-        sawDynamic = true;
-      } else if (
-        ts.isBinaryExpression(parent) &&
-        parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-        parent.right === inner &&
-        (ts.isPropertyAccessExpression(parent.left) || ts.isElementAccessExpression(parent.left))
-      ) {
-        // `return table[key] = new F()` is Acorn's keyword-token factory shape.
-        // The constructed value escapes through an open object table, so keep
-        // its carrier dynamic across both the assignment result and later read.
-        sawDynamic = true;
-      } else if (
-        ts.isCallExpression(parent) &&
-        parent.arguments.length > 0 &&
-        parent.arguments[0] === inner &&
-        ts.isPropertyAccessExpression(parent.expression) &&
-        GENERIC_METHOD_CALL.has(parent.expression.name.text)
-      ) {
-        // `some.call(new F(), …)` inline receiver.
-        sawDynamic = true;
-      }
+      const c = classifyUse(checker, inner, ownFields);
+      if (c === "typed") sawTyped = true;
+      else if (c === "dynamic") sawDynamic = true;
       // any other inline use → neither; stays keep-static.
     }
 

--- a/tests/equivalence/issue-4123-param-receiver-proto-method.test.ts
+++ b/tests/equivalence/issue-4123-param-receiver-proto-method.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4123 — a prototype method invoked on a PARAMETER receiver silently returned
+// `null`/`0` in `target: "standalone"`.
+//
+// Mechanism: the #2660 fnctor escape gate classifies each `new F()` site as
+// `reconstruct` (lower to a `$Object` with a `$proto` link) or `keep-*` (lower
+// to the bespoke `$__fnctor_F` struct, which has own fields but NO prototype
+// chain). Its INLINE arm — the one used when the `new F()` is not bound to a
+// variable — re-implemented a strict SUBSET of `classifyUse`'s ladder and
+// dropped the call-ARGUMENT rule. So `f(new K())` was `keep-static` while the
+// otherwise identical `var o = new K(); f(o)` was `dynamic` ⇒ `reconstruct`.
+// The callee's dynamic `o.k()` then walked a prototype chain that did not
+// exist, resolved `k` to `undefined`, and produced `null` — with no trap and no
+// compile error. Every consumer downstream coerced that: `null` bare, `0` into
+// a numeric local, `1` through `1 + o.k()`.
+//
+// The bare `return o.k();` row is the load-bearing one: it is the only shape
+// where no numeric coercion hides the wrong value behind a plausible-looking
+// number.
+//
+// These run STANDALONE on purpose. `assertEquivalent` compiles the JS-host
+// lane, which cannot express `K.prototype.k = fn` dispatch at all yet — even
+// with a locally-bound receiver — so it would fail here for an unrelated,
+// pre-existing reason. The comparison against native JS is kept: each case is
+// evaluated with `evaluateAsJs` and the two answers must agree.
+import { describe, expect, it } from "vitest";
+import { compile } from "../../src/index.js";
+import { evaluateAsJs } from "./helpers.js";
+
+/** Compile `source` standalone, run `main`, and assert it equals native JS. */
+async function assertStandaloneEquivalent(source: string): Promise<void> {
+  const result = await compile(source, {
+    fileName: "issue-4123.js",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  const exports = instance.exports as Record<string, () => unknown>;
+  exports.__module_init?.();
+  const jsExports = evaluateAsJs(source);
+  expect(exports.main!()).toBe(jsExports.main!());
+}
+
+const K = `function K() {} K.prototype.k = function () { return 3; };\n`;
+
+describe("#4123 prototype method on a parameter receiver (standalone)", () => {
+  it("returns the method result directly — `return o.k();`", async () => {
+    await assertStandaloneEquivalent(
+      K + `function f(o) { return o.k(); }\nexport function main() { return f(new K()); }`,
+    );
+  }, 120_000);
+
+  it("binds the method result to a fresh local", async () => {
+    await assertStandaloneEquivalent(
+      K + `function f(o) { var n = o.k(); return n; }\nexport function main() { return f(new K()); }`,
+    );
+  }, 120_000);
+
+  it("assigns the method result over an existing numeric local", async () => {
+    await assertStandaloneEquivalent(
+      K + `function f(o) { var n = 1; n = o.k(); return n; }\nexport function main() { return f(new K()); }`,
+    );
+  }, 120_000);
+
+  it("accumulates the method result into a numeric local", async () => {
+    await assertStandaloneEquivalent(
+      K + `function f(o) { var n = 1; n = n + o.k(); return n; }\nexport function main() { return f(new K()); }`,
+    );
+  }, 120_000);
+
+  it("uses the method result as an operand — `return 1 + o.k();`", async () => {
+    await assertStandaloneEquivalent(
+      K + `function f(o) { return 1 + o.k(); }\nexport function main() { return f(new K()); }`,
+    );
+  }, 120_000);
+
+  it("control: the same call with a locally-`new`-bound receiver", async () => {
+    // Never broken — this is what proved the defect was specific to the
+    // receiver arriving as a parameter rather than to the method, the
+    // prototype, or the export boundary.
+    await assertStandaloneEquivalent(
+      K +
+        `function f() { var p = new K(); var n = 1; n = n + p.k(); return n; }\nexport function main() { return f(); }`,
+    );
+  }, 120_000);
+
+  it("reads an inherited DATA property through a parameter receiver", async () => {
+    // Same gate verdict, no call involved: `keep-static` also lost plain
+    // prototype-chain reads (`o.k` was `undefined` where JS says 7).
+    await assertStandaloneEquivalent(
+      `function K2() {} K2.prototype.k = 7;\n` +
+        `function f(o) { return o.k; }\nexport function main() { return f(new K2()); }`,
+    );
+  }, 120_000);
+
+  it("passes the inline instance in a non-first argument position", async () => {
+    await assertStandaloneEquivalent(
+      K + `function f(a, o) { return a + o.k(); }\nexport function main() { return f(10, new K()); }`,
+    );
+  }, 120_000);
+
+  it("still reaches the method through a second call hop", async () => {
+    await assertStandaloneEquivalent(
+      K +
+        `function g(o) { return o.k(); }\nfunction f(o) { return g(o); }\n` +
+        `export function main() { return f(new K()); }`,
+    );
+  }, 120_000);
+
+  it("negative control: a typed own-field consumer keeps the fnctor struct", async () => {
+    // Clause (B) of the gate is absolute — a site with a typed own-field read
+    // must stay `keep-typed` so the read remains a `struct.get`. This pins that
+    // the #4123 widening did not move such a site onto the reconstructed path.
+    await assertStandaloneEquivalent(
+      `function P() { this.x = 5; }\nfunction f(o) { return o.x; }\n` +
+        `export function main() { var p = new P(); return p.x + f(p); }`,
+    );
+  }, 120_000);
+});


### PR DESCRIPTION
## Description

Closes #4123. Fixes a **silent wrong answer** — no trap, no diagnostic — in a shape every library API uses.

```js
function K(){} K.prototype.k = function(){ return 3; };
function f(o){ return o.k(); }
export function main(){ return f(new K()); }   // → null, JS says 3
```

## Mechanism

Not the receiver-flow analysis (`JS2WASM_DIRECT_CALLS=0` changes nothing — devirtualization is an optimization on top). The defect is one layer down, in the **#2660 fnctor escape gate**, which decides how `new F()` is *represented*.

From the emitted WAT: the failing program lowers `new K()` via `call $__fnctor_K_new` (a bespoke `$__fnctor_K` struct), while the working control lowers via `call $__object_create` (a `$Object` carrying a `$proto` link). `$f` itself is byte-identical in both — `local.get 0; global.get $__strlit_"k"; call $__ir_dyn_method_call_0` → `__extern_method_call` → `__extern_get`'s own+prototype walk. **The bespoke struct has own fields but no prototype chain**, so the walk finds nothing, `k` resolves to `undefined`, and the call yields `null`. `JS2WASM_LOG_FNCTOR_GATE=1` confirms: `f(new K())` → `keep-static=1`, control → `reconstruct=1`.

The root cause is an **asymmetry between two spellings of the same program**. The gate's site-classification has two arms: the *bound* arm calls `classifyUse`, whose ladder includes "passed as a call argument to an `any`/`unknown` parameter → dynamic". The *inline* arm (for a `new F()` not bound to a variable) re-implemented a strict **subset** of that ladder and dropped exactly that rule. So `f(new K())` was `keep-static` while `var o = new K(); f(o)` was `reconstruct`.

## Diff

One source file, net **−3 LOC**:

- `classifyUse`'s parameter widened `ts.Identifier` → `ts.Expression` (every rule already only read `.parent` and used the node as a checker location).
- The inline arm's open-coded ladder replaced by a `classifyUse(...)` call, so the two sites cannot drift apart again.
- Clause (B) untouched: a typed own-field consumer still forces `keep-typed`, so no `struct.get` read migrates to `__extern_get`.

## Result

| program | before | after | JS |
|---|---|---|---|
| `return o.k();` | null | **3** | 3 |
| `let n = o.k(); return n;` | null | **3** | 3 |
| `let n=1; n=o.k(); return n;` | 0 | **3** | 3 |
| `let n=1; n=n+o.k(); return n;` | 1 | **4** | 4 |
| `return 1 + o.k();` | 1 | **4** | 4 |
| control (local `new K()`) | 4 | 4 | 4 |

Independently re-verified against this branch with a probe written before the fix existed.

Also fixed by the same change: inherited **data** reads (`K.prototype.k = 7` read `undefined`, now `7`), non-first argument positions, and multi-hop `f(o) → g(o)`.

## Testing

- `tests/equivalence/issue-4123-param-receiver-proto-method.test.ts` — 10 cases. **8 of 10 fail on untouched main; all 10 pass here.** The 2 passing on both are deliberate controls.
- Full `tests/equivalence/` on both sides, complete output captured (not piped through `tail`/`head`):
  - untouched `upstream/main`: 12 files / 32 tests failed, 1619 passed
  - this branch: 12 files / 32 tests failed, 1629 passed
  - failing sets diffed **by full test name**, `comm` empty both directions — identical sets, not merely identical counts. The +10 passing are the new tests.
- `tsc --noEmit` exit 0. `check:issues`, `check:loc-budget` (−3), `check:oracle-ratchet` (raw-checker calls +0), `check:coercion-sites`, `check:any-box-sites`, `check:func-budget`, `lint` all clean.

## Two findings worth separate attention

**The JS-host lane does not have this defect — it has a broader one that subsumes it.** In host mode, `K.prototype.k = fn` dispatch fails for *every* receiver shape including the local control (`TypeError: value is not callable`), and `K2.prototype.k = 7` reads `undefined`. Class methods and object-literal methods are fine. Verified byte-identical before and after this change, so it is a separate pre-existing "function-constructor prototype chain unsupported in the host lane" gap. It is also why the new test compiles standalone rather than using `assertEquivalent`.

**npm-compat could not have caught this, and its green rows carry no information about it.** The `shasum`/`integrity` fields are npm-registry hashes of the *input tarball*, never of js2 output, and no pin file records an expected output value — so no wrong answer was locked in. But `npm-compat.json` records only `compile.success` / `validation.validates` / perf, and the catalog test asserts `report.diff.runnable === false` — it never runs the package. A silent wrong answer produces a fully green npm-compat row. Reported only; harness untouched.

## Deliberately left undone

Three sibling escape shapes still classify `keep-static` and miscompile identically. All **pre-existing and unchanged** by this fix (verified before and after):

- array-literal element — `let a = [new K()]; f(a[0])` → `null`
- object-literal property value — `let t = { v: new K() }; f(t.v)` → `null`
- return-escape — `function g(){ return new K(); } f(g())` → **traps** (null pointer dereference)

`classifyUse` returns `"neutral"` for `ReturnStatement` ("S1 conservative") and has no rule for aggregate literals. Closing these means extending the analysis to those positions or inverting the gate's conservative default; the latter risks the #1888 `__extern_get` perf floor, so it was left out of a bug fix rather than landing a wide representation change unmeasured against the standalone floor guard.

One further residual with a **different root cause**, also pre-existing: an own function-valued field (`function K(){ this.k = function(){…}; }`) called through a parameter returns `null` even though the property is present (`o.k === undefined` is false, and the direct-receiver call works). That is a defect in the dynamic call bridge (`__extern_method_call` / `__apply_closure`), not the gate — flipping that site to `reconstruct` does not fix it. Worth its own issue.

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_013rC8ahHETYHdMDfkG4xBKE)_