### PR TITLE
rescue(#4122): re-land PR #4064's orphaned final commit — the queue merged a stale snapshot

### DIFF
--- a/plan/issues/4121-generic-carrier-unboxing.md
+++ b/plan/issues/4121-generic-carrier-unboxing.md
@@ -10,10 +10,10 @@ horizon: l
 feasibility: hard
 reasoning_effort: high
 task_type: performance
-area: codegen
+area: ir, codegen
 language_feature: value-representation
-goal: performance
-related: [684, 3683, 3754, 3765, 4118, 2773, 1624]
+goal: ir-full-coverage
+related: [684, 1167c, 1168, 2855, 3683, 3754, 3765, 4118, 4122, 2773, 1624]
 origin: "measured on upstream/main d369562d7, 2026-08-03, investigating the residual 10x vs node on real npm packages"
 ---
 
@@ -169,40 +169,100 @@ The round-trip is real but it goes **through a local slot**
 an adjacency property. Pattern-matching cannot see it; the slot's declared type
 is what forces both halves.
 
-## Proposal — assign representations over a carrier graph
+## Proposal — this belongs in the IR, as a pass
 
-Replace the per-carrier wiring with one representation-assignment pass:
+The right home is **not** a fifth AST-side consumer. It is an IR pass, and the
+IR already has every piece except the pass itself:
 
-1. **Nodes** = every value carrier: locals, parameters, returns, struct fields,
-   array elements, and call arguments.
-2. **Edges** = the assignments/flows between them (a def, an argument bind, a
-   return, a field write). This is the union of what the four existing
-   consumers already compute separately.
-3. **Solve** for a consistent unboxed assignment: a carrier is `f64` when every
-   carrier that flows into it is `f64` and every literal def is numeric —
-   a least fixpoint, so cycles carry no evidence and stay boxed (the same
-   groundedness argument #3765 needed).
-4. **Box only at the frontier** — the edges that cross into genuinely dynamic
-   territory (an exported entry point's parameter, a host/dispatch boundary, a
-   carrier with a non-numeric def).
+| piece                              | where it already is                                |
+| ---------------------------------- | -------------------------------------------------- |
+| a boxed/unboxed type vocabulary    | `IrType { kind: "union" }` (#1168)                  |
+| `box` / `unbox` / `tag.test`       | first-class IR instructions (#1168)                 |
+| type propagation over the graph    | `src/ir/propagate.ts`                               |
+| a validated tagged-union registry  | `src/ir/passes/tagged-unions.ts` (#1167c Pass 2)    |
+| a pass pipeline to slot into       | `src/ir/integration.ts` — `constantFold`, `deadCode`, `inlineSmall`, `monomorphize` |
 
-The key difference from today is that the verdict is **not per-carrier-kind**,
-so a numeric value flowing local → argument → parameter → return → field stays
-unboxed for the whole chain instead of being re-boxed at each hop that has no
-bespoke pass yet.
+`tagged-unions.ts` states the split explicitly: the **producers** of union-typed
+values (from-ast / propagation) and the **consumers** (`box`/`unbox` lowering)
+"sit on either side of this pass". What is missing between them is the
+propagation that decides a carrier can be `f64` rather than boxed. That is
+exactly this issue.
 
-### Gate on the emitted slot, not the declared type
+So the shape is:
 
-Whatever shape the pass takes, the admission gate must key on **the
-representation codegen is about to emit**, not on the checker's declared type.
-That single change is what makes the `let i = 0; i = s.indexOf(…)` case visible
-at all, and it is independent of the rest of the proposal — it may be worth
-landing first as its own slice.
+1. Extend `propagate.ts` with a numeric lattice over the IR value graph —
+   `⊥ → f64 → boxed`, joined at merge points.
+2. A carrier is `f64` when every value flowing into it is `f64`. This is a
+   **least** fixpoint, so a cycle carries no evidence and stays boxed unless
+   grounded — the argument #3765 needed, and #4122 then had to extend with a
+   self-reference rule for the accumulator shape.
+3. The existing `box`/`unbox` consumers then simply emit nothing where the
+   lattice says `f64`. **No new lowering code** — the deletion falls out of the
+   type, which is the whole reason to do it here.
+4. Box only at the frontier: exported entry-point parameters, host/dispatch
+   boundaries, and carriers with a genuinely non-numeric definition.
+
+Why this is the right level rather than a nicer version of the AST passes:
+
+- **"Carrier" stops being a category you enumerate.** Field, return, local,
+  parameter, argument and array element are all just edges in one graph. The
+  relocate-to-the-next-unfixed-carrier failure mode cannot happen, because
+  there is no per-kind wiring to be missing.
+- **It is the documented direction.** `plan/log/ir-adoption.md`'s north star
+  (goal `ir-full-coverage`, elevated 2026-07-02) is that all AST kinds route
+  through the IR and the direct path is *deprecation-tracked, not a peer*.
+  Passes like this are what the IR is for; adding a fifth AST consumer adds to
+  the pile the ratchet (#2855) exists to shrink.
+- **The duplication disappears.** `isString` exists twice on the AST side —
+  once in `makeProver`, once in `collectStringProperties`. When #3765 added
+  `Array.prototype.join` the wrong copy was fixed first and the measurement
+  came back zero. Syntactic analyses with no shared value graph invite exactly
+  that.
+
+### The blocking caveat — do not skip this
+
+An IR pass only applies to functions the IR **claims**. Today a selector
+rejection or an IR-build throw demotes the function to direct codegen through
+the warning channel (`src/codegen/index.ts`, the two demote sites), and
+`ir-adoption.md` still lists many kinds as `mixed` / `direct-only`.
+
+So moving this analysis into the IR **now** would silently stop applying
+wherever the IR bails — no wrong answers, but a perf cliff invisible to every
+gate. That is precisely the failure #3765 hit from the other direction: a
+kill-switch differential of zero that meant "the lever never engaged", not
+"the lever is worthless".
+
+Therefore:
+
+- The AST-side fixes (#3683, #3754, #3765, #4122) **stay** until the IR owns
+  the relevant node kinds. They are not made redundant by this issue.
+- Any implementation must report **IR-claimed vs demoted coverage** for the
+  benchmark set alongside its speedup, so a headline number cannot hide a
+  shrinking denominator.
+- Sequence behind enough of #2855 that the accumulator and string-scanning
+  shapes in `benchMethod` / `parseCookie` are IR-claimed. Check first; if they
+  are not, that ratchet work is the actual prerequisite and this issue is
+  blocked on it rather than ready.
+
+### One slice worth landing first, on either side
+
+The admission gate must key on **the representation codegen is about to emit**,
+not on the checker's declared type. `let i = 0` is declared `number` while its
+slot is `externref`, so the pass that exists to reconcile them never sees it.
+That is a small, independent fix, it is what makes case 2/3 in the table above
+visible at all, and it is worth doing regardless of where the analysis
+eventually lives.
 
 ## Acceptance criteria
 
+- [ ] A pre-flight report of **which benchmark functions the IR currently
+      claims** vs demotes. If `benchMethod` / `parseCookie` are demoted, this
+      issue is blocked on #2855 rather than ready, and that finding closes the
+      slice on its own.
 - [ ] `let i = 0; i = s.indexOf(";") + 1;` in a loop emits an `f64` local with
       **zero** `__box_number` / `__unbox_number` in the loop body.
+- [ ] IR-claimed coverage reported alongside every speedup, so a headline number
+      cannot hide a shrinking denominator.
 - [ ] The standalone `cookie` runtime-dynamic lane improves measurably against
       node, measured same-container interleaved behind a kill switch, with the
       checksum unchanged.

--- a/plan/issues/4122-mixed-assignment-carrier-boxes-numeric-accumulators.md
+++ b/plan/issues/4122-mixed-assignment-carrier-boxes-numeric-accumulators.md
@@ -1,10 +1,11 @@
 ---
 id: 4122
 title: "perf regression: `bindingHasMixedAssignmentCarrier` treats an UNRESOLVABLE assignment as a cross-domain one, boxing every numeric accumulator fed by a dynamic call — `method` axis 1.56x → 5.26x"
-status: ready
+status: done
 sprint: current
 created: 2026-08-03
 updated: 2026-08-03
+completed: 2026-08-03
 priority: high
 horizon: m
 feasibility: medium
@@ -15,6 +16,11 @@ language_feature: value-representation
 goal: performance
 related: [3961, 4121, 3683, 3754, 3765]
 origin: "git bisect of the cross-engine `method` axis, 2026-08-03"
+# The verdict must reach `bindingHasMixedAssignmentCarrier`, which runs before
+# any carrier type exists — there is no subsystem module upstream of it to hold
+# the field, so the context gains one line plus its doc.
+loc-budget-allow:
+  - src/codegen/context/types.ts
 ---
 
 # #4122 — an unresolvable assignment is not a mixed-domain assignment
@@ -136,16 +142,63 @@ is worth landing on its own because it is a measured 3.5x regression on main.
 
 ## Acceptance criteria
 
-- [ ] `var s = 0; for (…) s = s + p.inc();` emits an `f64` local and no
+- [x] `var s = 0; for (…) s = s + p.inc();` emits an `f64` local and no
       `__box_number` in the loop body, when `inc` is provably numeric.
-- [ ] Cross-engine `method` axis back to ≤2.0x vs node, measured same-container
-      interleaved with matching checksums.
-- [ ] The #3961 / PR #4008 React case that motivated the demotion still behaves
-      — a regression test pinning it, not just a green suite.
-- [ ] A binding genuinely assigned across domains (`let b = true; b = "s";`)
+      Measured: `$s` externref → **f64**, box 3 → 1, unbox 2 → **0**.
+- [x] Cross-engine `method` axis back to ≤2.0x vs node, measured same-container
+      interleaved with matching checksums. **2.85–3.01 ms → 0.813 ms (3.6x)**,
+      i.e. **1.35–1.67x vs node**, `chk=45000150000` on every leg.
+- [x] The #3961 / PR #4008 hazard still behaves — pinned by three explicit
+      cross-domain tests, not just a green suite.
+- [x] A binding genuinely assigned across domains (`let b = true; b = "s";`)
       still gets the boxed carrier, with a test.
-- [ ] No equivalence-suite regressions, confirmed by a full-capture run plus a
+- [x] No equivalence-suite regressions, confirmed by a full-capture run plus a
       kill-switch A/B of the failing set (not by a count match).
+
+## Result
+
+| axis                  | before | after | node        |
+| --------------------- | -----: | ----: | ----------- |
+| method                |   2.93 | 0.813 | 0.49 – 0.60 |
+| tokenizer (unchanged) |  0.253 | 0.257 | 0.17        |
+
+## The fix took three parts, not one
+
+Consulting the fixpoint was the easy part. Two gaps in the analysis had to close
+first, each verified by querying the verdict directly before and after:
+
+1. **Self-reference.** `s = s + f()` cannot be proven by a plain least fixpoint —
+   proving `s` numeric requires `s` numeric. The grounded set now assumes the
+   slot while judging its own definitions (the same induction `withSelf` gives
+   the property path), then re-checks **groundedness with the assumption
+   withdrawn**, so `var s = s + 1` — self-justifying, and NaN in JS — is still
+   rejected, and a mutual cycle `var a = b; var b = a` still cannot enter
+   (the assumption covers a slot's own name, never its partner's).
+
+2. **`numericFunctions` on a non-`this` receiver.** The verdict was consulted
+   only for `this.m()`:
+
+   ```ts
+   if (recv.kind === ts.SyntaxKind.ThisKeyword) return sets.numericFunctions.has(callee.name.text);
+   ```
+
+   `numericFunctions` is whole-program and NAME-keyed — "every visible function
+   of this name returns a number on every path" — which is exactly as true of
+   `p.inc()`. The restriction was conservatism, not a consequence of the
+   verdict. Widened to a bare-identifier receiver only, so member chains
+   (`a.b.inc()`) and call results (`f().inc()`) keep the old answer.
+
+   This does widen a trust boundary: an `inc` that is not statically visible
+   (a host/builtin method behind an opaque receiver) cannot demote the name.
+   That exposure already existed for `this.m()`, whose receiver is equally
+   unconstrained at runtime, and it is the same name-keying trade the file
+   documents throughout.
+
+3. **The split itself**, in `bindingHasMixedAssignmentCarrier`.
+
+Behind `JS2WASM_MIXED_CARRIER_NUMERIC=0` (part 3). Parts 1–2 are analysis
+precision improvements and are not separately gated — they can only ever add
+slots to a grounded set that every consumer already treats as advisory.
 
 ## Reproduce
 

--- a/plan/issues/4123-prototype-method-on-parameter-receiver-returns-null.md
+++ b/plan/issues/4123-prototype-method-on-parameter-receiver-returns-null.md
@@ -1,0 +1,108 @@
+---
+id: 4123
+title: "MISCOMPILE: a prototype method called on a PARAMETER receiver silently returns null/0 in standalone — `f(o){ return o.k(); }` gives null where JS gives 3"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: prototype methods, receiver flow
+goal: core-semantics
+related: [3685, 3683, 4122]
+origin: "found incidentally while building a guard test for #4122, 2026-08-03"
+---
+
+# #4123 — prototype method on a parameter receiver returns null
+
+## Severity
+
+**Silent wrong answer.** No trap, no compile error, no diagnostic — the program
+runs and produces a different value than JavaScript specifies. This is the worst
+failure class we have, and the shape is ordinary: pass an object to a function,
+call one of its prototype methods.
+
+Reproduced on **unmodified `upstream/main` (`d369562d7`)**, verified by stashing
+all local changes and re-running.
+
+## Reproduction
+
+```js
+function K() {}
+K.prototype.k = function () { return 3; };
+
+function f(o) { return o.k(); }
+export function main() { return f(new K()); }
+```
+
+Compiled with `{ target: "standalone" }`:
+
+| program                                              | js2      | JS  |
+| ---------------------------------------------------- | -------- | --- |
+| `function f(o){ return o.k(); }`                     | **null** | 3   |
+| `function f(o){ let n = o.k(); return n; }`           | **null** | 3   |
+| `function f(o){ let n = 1; n = o.k(); return n; }`    | **0**    | 3   |
+| `function f(o){ let n = 1; n = n + o.k(); return n; }`| **1**    | 4   |
+| `function f(o){ return 1 + o.k(); }`                  | **1**    | 4   |
+| `function f(){ let p = new K(); … p.k() … }`          | 4        | 4   |
+
+The **last row is the control**: the identical call with a receiver bound by a
+local `new K()` produces the correct answer. So the defect is specific to the
+receiver arriving as a **parameter**, not to the method, the prototype, or the
+export boundary (which the control crosses too).
+
+The `null` → `0` → `1` progression is consistent with the call yielding
+*nothing usable* and the consumer coercing it: `null` returned directly, `0`
+when stored into a numeric slot, and `1` when added to `1`.
+
+## Why this matters beyond the repro
+
+`f(obj)` where `obj` carries prototype methods is the shape of nearly every
+library API — every npm package that takes an options object, a parser, a
+stream, a node. The standalone `runtime-dynamic` npm lanes are exactly this
+shape, so this may be depressing correctness (and masking perf) far more
+broadly than one benchmark.
+
+It should be checked against the npm-compat correctness harness immediately:
+a package whose result is silently wrong will still "pass" any check that only
+compares against a checksum computed the same wrong way.
+
+## Where to look
+
+`#3685`'s `analyzeReceiverFlow` classifies a receiver by `source`:
+`"new-binding" | "call-return" | "parameter" | "this"`. The control (local
+`new K()`) is `new-binding` and works; the failing case is `parameter`. So the
+`parameter` arm of receiver-flow → dispatch is the first place to look — either
+the verdict is not reaching the call site, or the dispatch it selects is reading
+the wrong carrier for a parameter-held instance.
+
+Note `#4122` (in flight) documents that `staticJsTypeOf` answers `"mixed"` for
+these dynamically-dispatched calls, which is consistent with the parameter
+receiver not being resolved anywhere in this path.
+
+## Acceptance criteria
+
+- [ ] All six rows in the table above produce the JS answer.
+- [ ] An equivalence test covering the parameter-receiver shape, including the
+      `null`-returning direct form, which is the one no numeric coercion hides.
+- [ ] A check of whether any npm-compat correctness result changes once fixed —
+      if a package's expected checksum was computed from js2 output rather than
+      from node, it would have locked in the wrong answer.
+- [ ] Confirm whether the JS-host lane has the same defect or only standalone.
+
+## Reproduce
+
+```js
+import { compile } from "./src/index.ts";
+const src = `
+function K(){} K.prototype.k=function(){return 3;};
+function f(o){ return o.k(); }
+export function main(){ return f(new K()); }`;
+const res = await compile(src, { fileName: "t.mjs", skipSemanticDiagnostics: true, target: "standalone" });
+const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(res.binary), {});
+console.log(exports.main()); // null — JS says 3
+```

--- a/src/codegen/analysis/mixed-assignment-carrier.ts
+++ b/src/codegen/analysis/mixed-assignment-carrier.ts
@@ -42,13 +42,33 @@ export function bindingHasMixedAssignmentCarrier(ctx: CodegenContext, decl: ts.V
   const scope = containingScope(decl);
   let mixed = false;
 
+  // (#4122) `"mixed"` is the oracle's answer for UNRESOLVABLE, not for "proven
+  // to cross domains". Treating the two alike makes absence of evidence count
+  // as evidence of mixing, which demoted every numeric accumulator fed by a
+  // dynamically-dispatched call — `var s = 0; s = s + p.inc();`, the most
+  // common shape in ordinary JS — to a boxed carrier, at ~3.5x on the `method`
+  // axis.
+  //
+  // So an unresolvable assignment gets a second question: does the
+  // whole-program fixpoint prove EVERY definition of this slot numeric? That
+  // verdict is grounded (a slot needs one definition numeric without assuming
+  // itself), self-reference-aware (the accumulator shape), and boolean-excluded,
+  // so a `true` here means the f64 carrier is the correct representation, not
+  // merely a cheaper guess. A resolved cross-domain assignment still demotes
+  // regardless — that is #3961's hazard and it is untouched.
+  const provenNumeric =
+    process.env.JS2WASM_MIXED_CARRIER_NUMERIC !== "0" &&
+    initialDomain === "number" &&
+    ctx.numericLocalVerdict?.(decl.name, decl.name.text) === true;
+
   const visit = (node: ts.Node): void => {
     if (mixed) return;
     if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
       const target = stripParens(node.left);
       if (ts.isIdentifier(target) && target !== decl.name && ctx.oracle.variableDeclarationOf(target) === decl) {
         const assignedTag = ctx.oracle.staticJsTypeOf(node.right);
-        if (assignedTag === "mixed" || carrierDomain(assignedTag) !== initialDomain) {
+        const unresolvable = assignedTag === "mixed";
+        if (unresolvable ? !provenNumeric : carrierDomain(assignedTag) !== initialDomain) {
           mixed = true;
           return;
         }

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2039,6 +2039,9 @@ export interface CodegenContext {
    * the generic `__any_add` with a tag-dispatch unbox after it.
    */
   numericFunctionNames?: ReadonlySet<string>;
+  /** (#4122) Grounded "every definition of this slot is numeric" verdict from
+   *  `analyzeNumericPropertyNames`; absent in the host lane / when disabled. */
+  numericLocalVerdict?: (node: ts.Node, name: string) => boolean;
   /**
    * #3673: property names the SOURCE defines as a function-valued member
    * (`collectUserMethodNames`). Consulted by

--- a/src/codegen/numeric-property-analysis.ts
+++ b/src/codegen/numeric-property-analysis.ts
@@ -968,6 +968,21 @@ function makeProver(
         if (STRING_NUMERIC_METHODS.has(callee.name.text) && isString(callee.expression, depth + 1)) return true;
         if (ARRAY_NUMERIC_METHODS.has(callee.name.text) && isArray(callee.expression, depth + 1)) return true;
         if (recv.kind === ts.SyntaxKind.ThisKeyword) return sets.numericFunctions.has(callee.name.text);
+        // (#4122) The same verdict for a NON-`this` receiver. `numericFunctions`
+        // is whole-program and NAME-keyed — "every visible function of this name
+        // returns a number on every path" — which is exactly as true of
+        // `p.inc()` as of `this.inc()`; a single non-numeric `inc` anywhere in
+        // the program removes the name for both. The `this`-only restriction was
+        // conservatism, not a consequence of the verdict.
+        //
+        // The trust boundary this widens is the SAME one the file documents for
+        // name-keying generally: an `inc` that is not statically visible (a host
+        // or builtin method reached through an opaque receiver) is not in
+        // `functionsByName` and so cannot demote the name. That risk already
+        // exists for `this.m()`, whose receiver is equally unconstrained at
+        // runtime. Restricted to a bare identifier receiver so member chains
+        // (`a.b.inc()`) and call results (`f().inc()`) keep the old answer.
+        if (ts.isIdentifier(recv)) return sets.numericFunctions.has(callee.name.text);
       }
       return false;
     }
@@ -1094,6 +1109,13 @@ export interface NumericPropertyAnalysisTarget {
   numericPropertyNames?: ReadonlySet<string>;
   stringPropertyNames?: ReadonlySet<string>;
   numericFunctionNames?: ReadonlySet<string>;
+  /**
+   * (#4122) The grounded slot verdict, exposed directly rather than only
+   * through `usageInference`. `bindingHasMixedAssignmentCarrier` needs to ask
+   * it BEFORE the carrier type exists, which is upstream of where
+   * `usageInference` is consulted.
+   */
+  numericLocalVerdict?: PropertyKindVerdicts["isNumericLocal"];
   readonly usageInference: {
     setNumericLocalOracle(oracle: PropertyKindVerdicts["isNumericLocal"]): void;
   };
@@ -1266,13 +1288,37 @@ export function analyzeNumericPropertyNames(
       // holding a comparison result makes `` `${b}` `` print "1" where JS says
       // "true". Caught by `coercion/tostring > standalone-O > template over
       // any-boolean`.
-      const allNumeric =
-        slot.defs.length > 0 &&
-        slot.defs.every(
-          (def) => def.forcedNumeric === true || (def.expr !== undefined && groundedProver.isNumeric(def.expr)),
-        ) &&
-        !slot.defs.some((def) => def.expr !== undefined && groundedProver.isBooleanish(def.expr));
-      if (allNumeric) {
+      // (#4122) SELF-REFERENCE. The accumulator `var s = 0; s = s + f();` is the
+      // most common numeric-local shape in ordinary JS, and a plain least
+      // fixpoint can never admit it: proving `s` numeric requires `s` to be
+      // numeric already. So assume the slot numeric while judging its OWN
+      // definitions — the same induction `withSelf` gives the property path
+      // ("if every other write stores a number then the slot always holds
+      // one"), just for a lexical slot instead of a property name.
+      groundedSlots.add(slot);
+      let allNumeric: boolean;
+      try {
+        allNumeric =
+          slot.defs.length > 0 &&
+          slot.defs.every(
+            (def) => def.forcedNumeric === true || (def.expr !== undefined && groundedProver.isNumeric(def.expr)),
+          ) &&
+          !slot.defs.some((def) => def.expr !== undefined && groundedProver.isBooleanish(def.expr));
+      } finally {
+        groundedSlots.delete(slot);
+      }
+      if (!allNumeric) continue;
+      // GROUNDEDNESS, re-checked with the assumption withdrawn: at least one
+      // definition must be numeric on its own. Without this, `var s = s + 1;`
+      // — whose only definition reads the slot before anything writes it — is
+      // self-justifying, and an f64 carrier would read 0 where JS says NaN.
+      // This is the slot analogue of the property path's `withoutSelf` pass,
+      // and it is also what keeps a mutual cycle (`var a = b; var b = a;`) out:
+      // the assumption covers a slot's own name, never its partner's.
+      const grounded = slot.defs.some(
+        (def) => def.forcedNumeric === true || (def.expr !== undefined && groundedProver.isNumeric(def.expr)),
+      );
+      if (grounded) {
         groundedSlots.add(slot);
         added = true;
       }
@@ -1349,5 +1395,6 @@ export function applyNumericPropertyAnalysis(
   target.numericFunctionNames = verdicts.numericFunctions;
   if (process.env.JS2WASM_NUMERIC_LOCALS !== "0") {
     target.usageInference.setNumericLocalOracle(verdicts.isNumericLocal);
+    target.numericLocalVerdict = verdicts.isNumericLocal;
   }
 }

--- a/tests/issue-4122-mixed-carrier-numeric.test.ts
+++ b/tests/issue-4122-mixed-carrier-numeric.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4122) An UNRESOLVABLE assignment is not a cross-domain assignment.
+ *
+ * `bindingHasMixedAssignmentCarrier` demoted a binding to the boxed `externref`
+ * carrier whenever `oracle.staticJsTypeOf` of any assignment was `"mixed"` —
+ * which is the oracle's answer for *cannot resolve*, not for *proven to cross
+ * domains*. That read absence of evidence as evidence of mixing, and boxed every
+ * numeric accumulator fed by a dynamically-dispatched call.
+ *
+ * The demotion itself is right for the hazard it was written for (#3961: an i32
+ * boolean slot destroys a later string assignment by coercing it to
+ * truthiness), so the tests below pin BOTH directions: the accumulator unboxes,
+ * and every genuinely cross-domain binding still boxes.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+async function build(source: string, env?: Record<string, string>) {
+  const saved: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env ?? {})) {
+    saved[k] = process.env[k];
+    process.env[k] = v;
+  }
+  try {
+    return await compile(source, {
+      fileName: "t.mjs",
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+      emitWat: true,
+    });
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+/** Body of `fn` with numeric call targets resolved back to names. */
+function bodyOf(wat: string, fn: string): string {
+  const lines = wat.split("\n");
+  const names: string[] = [];
+  const declLine = new Map<string, number>();
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i]!.match(/^\s*\(func \$(\S+)/);
+    if (m) {
+      names.push(m[1]!);
+      declLine.set(m[1]!, i);
+    }
+  }
+  const start = declLine.get(fn);
+  if (start === undefined) return "";
+  const out: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\s*\(func \$/.test(lines[i]!)) break;
+    out.push(lines[i]!.trim());
+  }
+  return out.join("\n").replace(/\bcall (\d+)\b/g, (_m, idx) => `call $${names[Number(idx)] ?? idx}`);
+}
+
+function localType(body: string, name: string): string {
+  return body.match(new RegExp("\\(local \\$" + name + " ([^)]*)\\)"))?.[1] ?? "";
+}
+
+/** The cross-engine `method` axis shape, which the regression cost ~3.5x. */
+const ACCUMULATOR = `
+function P(v){ this.v = v; }
+P.prototype.inc = function(){ this.v = this.v + 1; return this.v; };
+function benchMethod(){
+  var p = new P(0);
+  var s = 0;
+  for (var i = 0; i < 1000; i++) { s = s + p.inc(); }
+  return s;
+}
+export function main(){ return benchMethod(); }
+`;
+
+describe("#4122 — an unresolvable assignment does not demote a proven-numeric slot", () => {
+  it("keeps the accumulator in an f64 local", async () => {
+    const { wat } = await build(ACCUMULATOR);
+    expect(localType(bodyOf(wat!, "benchMethod"), "s")).toBe("f64");
+  });
+
+  it("emits no unboxing in the accumulator loop", async () => {
+    const { wat } = await build(ACCUMULATOR);
+    expect(bodyOf(wat!, "benchMethod")).not.toMatch(/call \$__unbox_number/);
+  });
+
+  it("is off under the kill switch, restoring the boxed carrier", async () => {
+    const { wat } = await build(ACCUMULATOR, { JS2WASM_MIXED_CARRIER_NUMERIC: "0" });
+    const body = bodyOf(wat!, "benchMethod");
+    expect(localType(body, "s")).toBe("externref");
+    expect(body).toMatch(/call \$__unbox_number/);
+  });
+
+  it("computes the same sum either way", async () => {
+    for (const env of [undefined, { JS2WASM_MIXED_CARRIER_NUMERIC: "0" }]) {
+      const { binary } = await build(ACCUMULATOR, env);
+      const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(binary!), {});
+      // sum of 1..1000
+      expect((exports as { main: () => number }).main()).toBe(500500);
+    }
+  });
+
+  // --- the #3961 hazard the demotion exists for: these must still box --------
+
+  it.each([
+    ["boolean then string", `let b = true; b = "s"; return typeof b;`, "b"],
+    ["number then string", `let n = 1; n = "s"; return typeof n;`, "n"],
+    ["number then boolean", `let n = 1; n = true; return typeof n;`, "n"],
+  ])("still boxes a genuinely cross-domain binding (%s)", async (_label, body, name) => {
+    const { wat } = await build(`function f(){ ${body} }\nexport function main(){ return f(); }`);
+    expect(localType(bodyOf(wat!, "f"), name)).toBe("externref");
+  });
+
+  it("still boxes when the unresolvable slot is NOT provably numeric", async () => {
+    // `q()` is not in `numericFunctions` (it can return a string), so the slot
+    // has no numeric proof and the conservative demotion must stand.
+    const { wat } = await build(`
+      function Q(){}
+      Q.prototype.q = function(c){ return c ? "s" : 1; };
+      function f(o){ let n = 1; n = o.q(1); return n; }
+      export function main(){ return f(new Q()); }
+    `);
+    expect(localType(bodyOf(wat!, "f"), "n")).toBe("externref");
+  });
+});
+
+describe("#4122 — the grounded slot verdict admits self-reference", () => {
+  it("proves an accumulator whose own value feeds its update", async () => {
+    // `s = s + <numeric>` cannot be proven by a plain least fixpoint: proving
+    // `s` numeric requires `s` numeric. The verdict assumes the slot while
+    // judging its own definitions, then re-checks groundedness without the
+    // assumption.
+    const { wat } = await build(ACCUMULATOR);
+    expect(localType(bodyOf(wat!, "benchMethod"), "s")).toBe("f64");
+  });
+
+  it("does not admit a self-justifying binding with no independent evidence", async () => {
+    // `var s = s + 1` reads the slot before anything writes it. JS says NaN;
+    // an f64 carrier would read 0. The groundedness re-check must reject it.
+    const { wat } = await build(`
+      function f(){ var s = s + 1; return s; }
+      export function main(){ return f(); }
+    `);
+    const t = localType(bodyOf(wat!, "f"), "s");
+    expect(t).not.toBe("f64");
+  });
+
+  it("does not admit a mutual definition cycle", async () => {
+    const { wat } = await build(`
+      function f(){ var a = b; var b = a; return a; }
+      export function main(){ return f(); }
+    `);
+    expect(localType(bodyOf(wat!, "f"), "a")).not.toBe("f64");
+  });
+});


### PR DESCRIPTION
**Re-applies commit `335c4b50` from PR #4064, which reads MERGED but never landed its final commit.**

What happened (verified by merge-commit parents and content, not `mergedAt`): the queue snapshotted #4064's head at enqueue time (`dfa9e088`), the author pushed `335c4b50` eight minutes later, the queue merged the snapshot — and GitHub marked the PR merged with the newer SHA as `headRefOid`. `compare/335c4b50...main → behind_by: 1`; the git tree on main (`truncated: false`) contained neither of the commit's new files.

**Contents (cherry-picked verbatim, one commit, no edits):**
- `src/codegen/analysis/mixed-assignment-carrier.ts` (+21/−1), `src/codegen/numeric-property-analysis.ts` (+54/−7), `src/codegen/context/types.ts` (+3) — the #4122 perf fix ("an unresolvable assignment is not a cross-domain one")
- `tests/issue-4122-mixed-carrier-numeric.test.ts` (+159, new) — its regression test
- `plan/issues/4123-prototype-method-on-parameter-receiver-returns-null.md` (new issue, existed nowhere on main until now; id verified free on main's tree, upstream ledger, and open PRs)
- updates to `plan/issues/4121-*` / `4122-*`

**Provenance:** original author is the `claude/generic-carrier-unboxing-4121` lane (not reachable; it believes this landed). Orphan pinned as `refs/rescued/pr4064-orphaned-20260803` and preserved on the fork branch. Rescued by cherry-pick onto fresh `upstream/main` — not a file copy, so nothing that landed since is reverted (the diffstat is the guard: 7 files, +498/−48, matching the original commit).

CI is the first validation this commit gets on current main — the original PR-level checks ran on a base 190+ commits old. If it parks, that is the system working, and the pin preserves the work either way.

Related memory/doctrine: `reference_merge_queue_snapshots_head_at_enqueue_time` — second confirmed partial-merge today; anything that must land has to be in the first push, before enqueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcwPzXzbjibq9EcXMDBJAj