### PR TITLE
docs: file #4125–#4128 — the residual defects found around #4123

### DIFF
--- a/plan/issues/4125-escape-gate-sibling-positions-miscompile.md
+++ b/plan/issues/4125-escape-gate-sibling-positions-miscompile.md
@@ -1,0 +1,93 @@
+---
+id: 4125
+title: "MISCOMPILE: three sibling escape positions still classify keep-static — `[new K()]`, `{ v: new K() }` and `return new K()` all lose the prototype chain (one returns null, one traps)"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: prototype chain, object representation
+goal: core-semantics
+related: [4123, 2660, 1888]
+origin: "residuals left undone by #4123's fix, independently reproduced 2026-08-03"
+---
+
+# #4125 — the escape gate's remaining keep-static positions
+
+## Severity
+
+**Silent wrong answers, plus one trap.** Same class as #4123 and the same root
+cause; #4123 fixed the *call-argument* position only.
+
+## The defect
+
+#4123 fixed one arm of the #2660 fnctor escape gate: a `new F()` passed
+**inline as a call argument** to an `any` parameter was classified `keep-static`,
+so it lowered to a bespoke `$__fnctor_K` struct that carries own fields but
+**no prototype chain**. `__extern_get`'s own+prototype walk then finds nothing,
+the method resolves to `undefined`, and the call yields `null`.
+
+Three sibling escape positions still classify `keep-static` and miscompile
+identically. All reproduced on the #4123 fix branch (i.e. these are *not* fixed
+by it):
+
+```js
+function K(){} K.prototype.k = function(){ return 3; };
+function f(o){ return o.k(); }
+```
+
+| escape position          | program                                                | result                              | JS |
+| ------------------------ | ------------------------------------------------------ | ----------------------------------- | -- |
+| array-literal element    | `let a = [new K()]; return f(a[0]);`                   | **null**                            | 3  |
+| object-literal property  | `let t = { v: new K() }; return f(t.v);`               | **null**                            | 3  |
+| return-escape            | `function g(){ return new K(); } return f(g());`       | **traps** — null pointer dereference | 3  |
+
+Controls that pass on the same build: a locally-bound receiver
+(`let o = new K(); o.k()`), and #4123's now-fixed call-argument position.
+
+## Why they were left out of #4123
+
+`classifyUse` explicitly returns `"neutral"` for `ReturnStatement` (marked "S1
+conservative"), and has no rule at all for aggregate literals. Closing these
+means either extending the single-level analysis to those positions, or
+inverting the gate's conservative default.
+
+**The second option is the risky one and should not be taken casually**: the
+gate's conservatism is what keeps reads on `struct.get` rather than
+`__extern_get`, and inverting it risks the #1888 `__extern_get` perf floor.
+#4123 deliberately stayed a bug fix rather than becoming a wide representation
+change unmeasured against the standalone floor guard — that judgement still
+stands, and whoever takes this issue owns the floor measurement.
+
+## Acceptance criteria
+
+- [ ] All three positions produce the JS answer, including the return-escape
+      case that currently traps.
+- [ ] An equivalence test per position, alongside #4123's, including the
+      **direct `return o.k()` form** for each — the one no numeric coercion
+      hides.
+- [ ] The standalone floor / net guards (#1888, #1897, #2097) measured before
+      and after, since the plausible fix widens `reconstruct` classification.
+- [ ] No equivalence-suite regressions, confirmed by comparing failing **sets**
+      from a full-capture run, not counts.
+
+## Reproduce
+
+```js
+import { compile } from "./src/index.ts";
+const K = `function K(){} K.prototype.k = function(){ return 3; };`;
+const src = `${K}
+function f(o){ return o.k(); }
+export function main(){ let a = [new K()]; return f(a[0]); }`;
+const res = await compile(src, { fileName: "t.mjs", skipSemanticDiagnostics: true, target: "standalone" });
+const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(res.binary), {});
+console.log(exports.main()); // null — JS says 3
+```
+
+`JS2WASM_LOG_FNCTOR_GATE=1` prints the gate's verdict (`keep-static` vs
+`reconstruct`) and is the fastest way to confirm a shape belongs to this issue.

--- a/plan/issues/4126-own-function-field-through-parameter-returns-null.md
+++ b/plan/issues/4126-own-function-field-through-parameter-returns-null.md
@@ -1,0 +1,83 @@
+---
+id: 4126
+title: "MISCOMPILE: an OWN function-valued field called through a parameter returns null, even though the property is present — dynamic call bridge, not the escape gate"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: dynamic dispatch, closures
+goal: core-semantics
+related: [4123, 4125]
+origin: "residual found while fixing #4123, independently reproduced 2026-08-03"
+---
+
+# #4126 — own function-valued field through a parameter returns null
+
+## Severity
+
+**Silent wrong answer.** Distinct root cause from #4123 / #4125 — do not fold
+this into them.
+
+## The defect
+
+```js
+function K(){ this.k = function(){ return 3; }; }
+function f(o){ return o.k(); }
+export function main(){ return f(new K()); }   // → null, JS says 3
+```
+
+Reproduced on the **#4123 fix branch**, so it is not the escape-gate
+classification bug: #4123's fix flips this site to `reconstruct` and it *still*
+returns `null`.
+
+What rules the escape gate out as the cause:
+
+- the property is genuinely **present** — `o.k === undefined` is `false`;
+- the **same call with a direct receiver works**:
+  `let o = new K(); o.k()` → `3`;
+- it is an **own** field assigned in the constructor, not a prototype
+  property, so no prototype walk is involved at all.
+
+So the failure is in the dynamic call bridge — `__extern_method_call` /
+`__apply_closure` — mishandling a **closure-valued own field** reached through
+an opaque (parameter) receiver. The property read succeeds and the *call* is
+what produces nothing.
+
+## Why this matters
+
+`function K(){ this.method = function(){…} }` is the pre-class idiom for
+per-instance methods, and it is pervasive in older npm packages — the exact
+corpus the standalone `runtime-dynamic` lanes compile. A silent `null` here is
+indistinguishable from a missing method at the call site.
+
+## Acceptance criteria
+
+- [ ] `f(new K())` returns `3` for the program above.
+- [ ] Equivalence tests covering: own function field via parameter receiver, via
+      a locally-bound receiver (currently passing — keep it passing), and with
+      arguments and a return value that is not a number (so no numeric coercion
+      can mask the result).
+- [ ] Confirm whether the same bridge mishandles an own function field reached
+      through other opaque receivers (array element, object property) once
+      #4125 lands — they may share this second defect underneath.
+- [ ] No equivalence-suite regressions, compared as failing **sets** from a
+      full-capture run.
+
+## Reproduce
+
+```js
+import { compile } from "./src/index.ts";
+const src = `
+function K(){ this.k = function(){ return 3; }; }
+function f(o){ return o.k(); }
+export function main(){ return f(new K()); }`;
+const res = await compile(src, { fileName: "t.mjs", skipSemanticDiagnostics: true, target: "standalone" });
+const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(res.binary), {});
+console.log(exports.main()); // null — JS says 3
+```

--- a/plan/issues/4127-npm-compat-never-runs-packages.md
+++ b/plan/issues/4127-npm-compat-never-runs-packages.md
@@ -1,0 +1,91 @@
+---
+id: 4127
+title: "npm-compat never RUNS the packages it reports on — a silent wrong answer produces a fully green row, so green carries no correctness information"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: tooling
+area: tooling, dogfood
+language_feature: npm packages
+goal: dogfood
+related: [4123, 4125, 4126, 3781]
+origin: "asked while fixing #4123 whether npm-compat had locked in a wrong answer; it had not, for a worse reason"
+---
+
+# #4127 — npm-compat's green rows carry no correctness information
+
+## The finding
+
+While fixing #4123 (a prototype method on a parameter receiver silently
+returning `null`) the obvious worry was that a package's expected output had
+been recorded **from js2 rather than from node**, locking the wrong answer into
+a pin file.
+
+**That did not happen, and structurally cannot.** The `shasum` / `integrity`
+fields in `tests/dogfood/npm-compat-catalog.json` and every `*-pin.json` are
+npm-registry hashes of the **input tarball**, never of js2 output, and no pin
+file records an expected output value. The behaviour-diffing dogfood harnesses
+(cookie, clsx, marked, acorn) compute their oracle at run time by importing the
+same package into native node and comparing.
+
+The real problem is the inverse, and it is worse:
+
+**`npm-compat` never runs the package at all.** `npm-compat.json` records only
+`compile.success`, `validation.validates` and perf, and the catalog test asserts
+
+```ts
+// tests/dogfood/npm-compat-catalog.test.ts:65
+expect(report.diff.runnable).toBe(false);
+```
+
+So a package that compiles to a valid module and produces **completely wrong
+answers** yields a fully green npm-compat row. #4123 was exactly that: a silent
+`null` in the shape every library API uses, invisible to the dashboard that
+exists to report npm compatibility.
+
+## Why this is worth fixing rather than documenting
+
+The dashboard's audience reads "compatible" as "works". Today it means
+"compiles and validates" — a much weaker claim, and one that a reader has no
+way to distinguish from the stronger one. Meanwhile #4123, #4125 and #4126 are
+three silent-wrong-answer defects found in a single session by hand, none of
+which any npm-compat row would have flagged.
+
+Note this is not a criticism of #3781's lane work, which correctly separated
+standalone from JS-host **performance**. The gap is on the correctness axis.
+
+## Direction
+
+1. Give each catalogued package a **consumed, checksummed workload** — the same
+   discipline #3781 established for the perf lanes: same inputs, same observed
+   output, native node as the shared oracle, computed at run time (never
+   recorded from js2).
+2. Report a per-package **correctness** verdict distinct from `compile.success`
+   / `validates`, and surface it on the page so "compiles" is never read as
+   "works".
+3. Flip `report.diff.runnable` from an asserted-`false` invariant to a real
+   capability wherever a workload exists; keep the assertion only for packages
+   that genuinely cannot be driven yet, and count those explicitly.
+4. Do **not** record any expected value into a committed pin — the oracle must
+   stay "run it in node right now", which is what keeps a miscompile from being
+   ratified.
+
+## Acceptance criteria
+
+- [ ] At least the packages that already have behaviour-diffing harnesses
+      (cookie, clsx, marked, acorn) report a correctness verdict in
+      `npm-compat.json`, derived from a native-node oracle computed at run time.
+- [ ] A deliberately miscompiled package (e.g. compiled with the #4123 fix
+      reverted behind its kill switch, or an injected fault) turns that verdict
+      **red** — the gate is demonstrated to detect a wrong answer, not merely
+      added.
+- [ ] The npm-compat page distinguishes "compiles + validates" from "produces
+      correct output"; a package with the former and not the latter cannot read
+      as green.
+- [ ] Packages with no drivable workload are counted and named, not silently
+      folded into the compatible set.

--- a/plan/issues/4128-host-lane-function-constructor-prototype-chain.md
+++ b/plan/issues/4128-host-lane-function-constructor-prototype-chain.md
@@ -1,0 +1,76 @@
+---
+id: 4128
+title: "JS-host lane: function-constructor prototype chain appears unsupported — `K.prototype.k = fn` reportedly fails for EVERY receiver shape, class methods fine"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: prototype chain, JS host lane
+goal: core-semantics
+related: [4123, 4125]
+origin: "reported while fixing #4123; NOT independently reproduced — see the verification note"
+---
+
+# #4128 — function-constructor prototype chain in the JS-host lane
+
+## Verification status — read this first
+
+**This issue is second-hand and is not independently reproduced.** It was
+reported by the author of #4123's fix, who verified the behaviour is
+byte-identical before and after that change (so it is at least pre-existing and
+unrelated to it).
+
+My own attempt to reproduce it failed for a mechanical reason, not a
+substantive one: a JS-host-lane module needs the host import harness (9–10
+imports), and a bare `WebAssembly.instantiate(mod, {})` cannot start it. So I
+could not confirm or refute the claim.
+
+**First step for whoever picks this up is to reproduce it through the real host
+harness** and either confirm the shape below or close this issue. Do not build
+on the description without that.
+
+## Reported behaviour
+
+In the **JS-host lane** (no `target: "standalone"`):
+
+| program                                                    | reported          | JS |
+| ---------------------------------------------------------- | ----------------- | -- |
+| `function K(){} K.prototype.k = fn; let o = new K(); o.k()` | `TypeError: value is not callable` | 3 |
+| `function K2(){} K2.prototype.k = 7; let o = new K2(); o.k` | `undefined`       | 7  |
+| `class C { k(){…} }` (control)                              | works             | ✓  |
+| object-literal method (control)                             | works             | ✓  |
+
+If accurate, this is **broader than #4123**, which it would subsume: #4123 was
+the standalone lane losing the prototype chain only for a *parameter* receiver,
+whereas this reports the host lane failing for **every** receiver shape,
+including a locally-bound one. It affects both method and data properties on
+`F.prototype`.
+
+## Why it matters if confirmed
+
+`function F(){}; F.prototype.m = …` is the pre-class constructor idiom and is
+pervasive in the older npm corpus. Class methods and object-literal methods
+working while the `prototype` assignment form does not would be a large,
+systematic gap in the host lane rather than an edge case.
+
+It is also why #4123's regression test compiles standalone instead of using
+`assertEquivalent` — the host lane would have failed it for this unrelated
+reason.
+
+## Acceptance criteria
+
+- [ ] **Reproduce through the real host import harness** and record the actual
+      failure, or close this issue as not-a-bug with that evidence.
+- [ ] If confirmed: both the method form (`K.prototype.k = fn`) and the data
+      form (`K.prototype.k = 7`) return the JS answer for a locally-bound
+      receiver and for a parameter receiver.
+- [ ] Equivalence coverage in the host lane, so #4123's test can drop its
+      standalone-only workaround and use `assertEquivalent`.
+- [ ] Determine whether this and #4123 share a root cause or are two
+      independent prototype-chain gaps in the two lanes.


### PR DESCRIPTION
## Description

Docs-only. Four issues left over from #4123 (PR #4071). **All reproduced independently before filing**, on the #4123 fix branch, with two controls passing on the same build — except #4128, which is explicitly marked second-hand.

### #4125 — three sibling escape positions still miscompile

Same root cause as #4123, which fixed only the *call-argument* arm of the #2660 escape gate:

```js
function K(){} K.prototype.k = function(){ return 3; };
function f(o){ return o.k(); }
```

| position | program | result | JS |
|---|---|---|---|
| array-literal element | `let a = [new K()]; f(a[0])` | **null** | 3 |
| object-literal property | `let t = { v: new K() }; f(t.v)` | **null** | 3 |
| return-escape | `function g(){ return new K(); } f(g())` | **traps** | 3 |

Left out of #4123 deliberately, and the issue says why: `classifyUse` returns `"neutral"` for `ReturnStatement` and has no aggregate-literal rule, and the plausible fix widens `reconstruct` classification — which risks the #1888 `__extern_get` perf floor. Whoever takes it owns that measurement, and the acceptance criteria say so.

### #4126 — own function-valued field through a parameter, *different* root cause

```js
function K(){ this.k = function(){ return 3; }; }
function f(o){ return o.k(); }   // → null, JS says 3
```

Explicitly **not** the escape gate: the property is present (`o.k === undefined` is `false`), the direct-receiver call works, and #4123's fix flips this site to `reconstruct` without helping. It's the dynamic call bridge (`__extern_method_call` / `__apply_closure`) mishandling a closure-valued own field behind an opaque receiver.

`function K(){ this.m = function(){…} }` is the pre-class per-instance-method idiom, pervasive in the older npm corpus.

### #4127 — npm-compat never runs the packages it reports on

The worry while fixing #4123 was that a wrong answer had been recorded into a pin file. **It had not, and structurally cannot** — `shasum`/`integrity` are npm-registry hashes of the *input tarball*, and the diffing harnesses compute their oracle from native node at run time.

The real problem is the inverse. `npm-compat.json` records only `compile.success` / `validation.validates` / perf, and:

```ts
// tests/dogfood/npm-compat-catalog.test.ts:65
expect(report.diff.runnable).toBe(false);
```

So a package that compiles to a valid module and produces **completely wrong answers** yields a fully green npm-compat row. #4123 was exactly that. Three silent-wrong-answer defects were found by hand this session; no npm-compat row would have flagged any of them.

The issue asks for a demonstrated gate — a deliberately miscompiled package must turn the verdict **red** — rather than just adding a check, and insists the oracle stay "run it in node right now" so a miscompile can never be ratified into a pin.

### #4128 — host-lane prototype chain (**not independently reproduced**)

Reported by #4123's author: in the JS-host lane, `K.prototype.k = fn` fails for *every* receiver shape including a locally-bound one, while class and object-literal methods work. If accurate that subsumes #4123 and is a large systematic gap.

**I could not confirm it.** A host-lane module needs the import harness (9–10 imports) and a bare `WebAssembly.instantiate(mod, {})` cannot start it. The issue leads with that verification note and makes *"reproduce through the real harness, or close it"* the first acceptance criterion, so nobody builds on an unverified description.

## Testing

Docs-only; no source changes. `check:issues`, `check:issue-spec-coverage`, `check:done-status-integrity` pass.

Ids from `claim-issue.mjs --allocate`; the open-PR scan degraded (no `gh` auth in this container), so I checked open PRs via the API instead — no collision.

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_013rC8ahHETYHdMDfkG4xBKE)_