### PR TITLE
docs: #4129 Reflect.deleteProperty + S2 result fold-in + memory deltas

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -78,7 +78,7 @@ Team setup/budget/spawn/comms: **`plan/method/team-setup.md`**. Agent defs: **`.
 - reference_merge_queue_park_triage_four_causes · reference_merge_group_gate_reads_a_moving_baseline · reference_baseline_promote_trap_gate_two_failure_modes · reference_verdict_logic_change_must_bump_oracle_version
 - reference_ci_status_feed_retired_use_required_checks · reference_ci_gate_change_scoped_not_wholetree_absolute
 - [two-checks-share-a-name](reference_two_checks_share_a_name_head1_watcher_settles_on_a_stub.md) — a check NAME is not an identifier; filter `skipping`, never `head -1`
-- [workflow-prs-never-autoenqueue](reference_workflow_touching_prs_never_autoenqueue.md) — **FALSIFIED**; ALWAYS check the queue before enqueuing
+- [workflow-prs-never-autoenqueue](reference_workflow_touching_prs_never_autoenqueue.md) — **RE-CONFIRMED LIVE 2026-08-02** (the earlier FALSIFIED marking is itself falsified): the App is refused on workflow-touching PRs (`refusing to allow a GitHub App to create or update workflow`); remedy = shepherd's one-shot PAT enqueue, or grant the App `workflows` permission (admin act)
 - reference_never_push_to_a_queued_pr_it_ejects_to_the_back · reference_autoenqueue_grace0_races_mergestate_recompute · reference_dropped_synchronize_only_cla_check_repush
 - reference_quality_failfast_masks_downstream_gates · reference_baseline_gates_need_postmerge_autorefresh · reference_ci_quality_format_uses_prettier_not_biome · feedback_trigger_deploy_pages · feedback_cla_check_rerun_after_merge_commit
 - reference_host_restore_triage_verify_first_measure · reference_error_analysis · reference_standalone_harvest_rootcausemap_mislabeled · project_wrapforhost_setexports_harness

--- a/.claude/memory/reference_hold_label_does_not_dequeue_inflight_merge_queue_pr.md
+++ b/.claude/memory/reference_hold_label_does_not_dequeue_inflight_merge_queue_pr.md
@@ -18,3 +18,25 @@ metadata:
 **Saving grace this time:** the `publish-npm.yml` job FAILED (the `@loopdive/js2` + `js2wasm` proxy publish step errored), so nothing reached npm (`npm view @loopdive/js2` → 404). The user's intent held by luck (publish failure), not by the hold. The only durable effect was the committed v0.57.0 version bump on main — reversible via a revert PR. The publish workflow triggers on push-to-main when the version changes, so a bumped-but-unpublished version leaves the publish "armed" for any future successful run.
 
 See [[feedback_explicit_main_push]] (outward-facing actions need explicit per-time consent) and the merge-queue requeue hazard in [[project_merge_queue_requeue_cancels_run]].
+
+## ⚠ STRONGER FORM, observed end-to-end 2026-08-02 (#4036): a held PR that passes its merge_group MERGES, hold and all
+
+PR #4036 merged at 17:10:40Z with `labels: ["hold"]` — the bot's park label from
+15:12:38Z, never removed (exactly one label event in the whole timeline, no
+`unlabeled` ever). The merged PR carries the label to this day.
+
+So the property is sharper than "labeling doesn't dequeue":
+
+> **`hold` is honoured only at queue ENTRY (`auto-enqueue`, `auto-refresh-prs`
+> skip it). Once a PR is inside the queue, the label has NO effect at any
+> point — including at the moment of merge.**
+
+`hold` is an admission filter, not a brake. Anyone treating it as a safety
+stop on an already-queued PR is relying on nothing. In the #4036 case the
+outcome was right because a real fix had landed first — but the same PR was
+ALSO enqueued unfixed at 15:21 and was saved by scheduling (dequeued before
+reaching the head), not by the label.
+
+Corollary defect (to file): the auto-park comment tells authors to "remove the
+`hold` label to re-enqueue", which implies the label gates merging. It gates
+only re-admission. The comment should say so.

--- a/.claude/memory/reference_silent_empty_is_indistinguishable_from_real.md
+++ b/.claude/memory/reference_silent_empty_is_indistinguishable_from_real.md
@@ -117,6 +117,38 @@ someone else's work**:
 - `git stash push -- <file>` printing *"No local changes to save"* because the change was already **committed**, so the run labelled *"fix reverted"* still contained the fix. Two runs agreed; the agreement was meaningless.
 - A regex that never captured the token it was asserting on, so it passed **by absence**.
 
+## `contents` API on a big directory: empty = TRUNCATION, not absence (2× in one day, 2026-08-02/03)
+
+`gh api repos/<o>/<r>/contents/plan/issues --jq '.[].name' | grep '^NNNN'` came
+back EMPTY for files that were ON MAIN — the endpoint caps at 1000 entries and
+`plan/issues/` holds 4000+. Two independent near-misses in one session (one
+almost reported a live id collision that had already been resolved). The
+canonical "does main contain X" check is the git tree API **with an explicit
+truncation check**:
+
+```bash
+gh api "repos/<o>/<r>/git/trees/main?recursive=1" --jq '.truncated'  # must be false
+# then grep the tree for the path; or fetch the exact path via contents/<full/path>
+```
+
+A single exact-path `contents/<dir>/<file>` GET is also safe (404 = absent).
+Never grep a listing that can silently cap.
+
+## An HONEST negative from an unvalidated instrument is still unvalidated (2026-08-03, #4096)
+
+An agent marked "all 463 single-statement `ref.null.extern` push sites across
+60 files", got no marker hit on the repro, and honestly reported "the null
+comes from another spelling — not one of these sites." The next agent pinned
+the emit site by chokepoint instrumentation **on the first try** — and it WAS
+a plain single-statement push, squarely inside the class the sweep claimed to
+cover. **The sweep's negative was an instrument failure**: it had no positive
+control (mark a site KNOWN to be reached; confirm the marker fires through the
+same build/run path). The honesty of the report ("not pinned, here is what was
+ruled out") was real and still valuable — but "ruled out" was itself a result
+from an unproven tool, and it misdirected the follow-up brief. Rule: a
+negative sweep without a fired positive control rules out NOTHING; say "the
+sweep found nothing AND was not validated" — those are different handoffs.
+
 The same agent had built structural positive controls into an instrument hours
 earlier and then failed to apply the principle three feet away. **Knowing the
 rule does not protect you; running the falsifiability test does.**

--- a/.claude/memory/reference_workflow_touching_prs_never_autoenqueue.md
+++ b/.claude/memory/reference_workflow_touching_prs_never_autoenqueue.md
@@ -60,6 +60,29 @@ and note that an admin/PAT `CLEAN` really is a bypass artifact
 token still does not tell you the enqueuer's view. That part of the original
 note survives.
 
+## RE-CONFIRMED LIVE 2026-08-02 (#4046) — the FALSIFIED marking is itself falsified
+
+The App-token `enqueuePullRequest` was refused with the exact string
+`Pull request refusing to allow a GitHub App to create or update workflow
+'.github/workflows/baseline-summary-sync.yml'` — attribution clean, not
+correlational: same mutation, same PR, same instant, refused for the App,
+**accepted for the user PAT** (scope `workflow` present). The old entry
+attributed the effect to fork-head; the refusal string names the App and the
+file, so the mechanism is now unambiguous.
+
+**Scope of the restriction — measured end-to-end, and narrower than feared:**
+
+> **The App block applies to the ENQUEUE mutation only. Once enqueued (by
+> PAT), the merge queue MERGES workflow-touching PRs fine** — #4046 went
+> position 3 → merge_group green → merged 18:06:02Z with no further friction.
+
+So the shepherd's one-shot PAT enqueue is a **complete remedy** for this
+class, not a step that moves the block to merge time. Standing rule until an
+admin grants the App the `workflows` permission: every workflow-touching PR
+needs the shepherd's manual one-shot; `auto-enqueue` will refuse it and —
+because the run still concludes `success` — the refusal is visible only in
+the job log (via #4038's telemetry; before that, nothing printed at all).
+
 Related: [[reference_never_push_to_a_queued_pr_it_ejects_to_the_back]] ·
 [[reference_autoenqueue_grace0_races_mergestate_recompute]] ·
 [[reference_ci_status_feed_retired_use_required_checks]]

--- a/plan/issues/4010-m2-disjoint-receiver-side-tables.md
+++ b/plan/issues/4010-m2-disjoint-receiver-side-tables.md
@@ -477,3 +477,27 @@ surface this slice promised not to move.
 5. Class instances / Date / RegExp / Error remain **out of scope**: they have no
    bag, so `__carrier_bag_delete` answers `-1` for them and nothing changed.
    Their expando substrate is still greenfield (matrix rows 4-7).
+
+# S2 RESULT — landed (PR #4063, merged 73ee7169b, 2026-08-03)
+
+Root cause was NOT the sketch's companion-tombstone: `__obj_find` skips
+tombstoned entries, so tombstoning alone restores the fall-through to the bag
+(measured — the value survived). The real defect was one level up:
+**`__delete_property`'s non-`$Object` arm returned 1 (success) without deleting
+anything.** Fix: `src/codegen/carrier-bag-delete.ts` finds the receiver's bag
+and delegates to the existing `$Object` OrdinaryDelete; the vec arm also
+SHADOWS the bag (do not "simplify" that away). Tri-state result (`-1` not
+handled / `0` refused / `1` deleted) — collapsing `-1` into `1` IS the original
+defect.
+
+**Certifying numbers (merge_group on the merged state, 43,487 files):
+improvements=13, wasm-change regressions=0, net +13.** The
+`built-ins/**/{name,length}.js` −684 stratum untouched (the #2896 builtin-fn
+arm runs first). Full evidence table: PR #4063's comment thread.
+
+S3 inherits (see task): visibility widening now legal; the ~700-file stratum
+control mandatory pre-merge; NEW hazard — `verifyProperty` deletes-then-
+restores and a define on a FUNCTION still lands nowhere, so a harness delete of
+a function expando is irreversible where it was a no-op; S3 widens exactly the
+runway that reaches it. S2's partial local stratum data was measured against a
+superseded tree — not reusable; run the control fresh, both arms.

--- a/plan/issues/4129-reflect-deleteproperty-throws-for-all-non-object-receivers.md
+++ b/plan/issues/4129-reflect-deleteproperty-throws-for-all-non-object-receivers.md
@@ -1,0 +1,57 @@
+---
+id: 4129
+title: "standalone: Reflect.deleteProperty throws for EVERY non-$Object receiver — including plain success cases; the `delete` operator is fine, only the Reflect spelling"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: reflect
+goal: standalone-mode
+related: [4010, 1781]
+---
+
+# Reflect.deleteProperty is broken where `delete` now works
+
+Found by the #4010 S2 owner while measuring tombstones (2026-08-03), deliberately
+not folded into that slice. **Verified identical on the S2 base commit and after
+S2 landed** — pre-existing, independent of the store work.
+
+## Behaviour
+
+```js
+var arr = [1, 2, 3];
+arr.q = 12;
+Reflect.deleteProperty(arr, "q");   // standalone: THROWS
+delete arr.q;                        // standalone: works (post-S2/PR #4063)
+```
+
+`Reflect.deleteProperty` throws for **every non-`$Object` receiver**, including
+plain success cases on ordinary expandos. Only the `Reflect` spelling is
+affected; the `delete` operator's lowering is separate and correct as of S2.
+
+## Likely shape (verify, don't inherit)
+
+The `delete` operator's non-`$Object` arm was just rewired to the carrier-bag
+delete (`src/codegen/carrier-bag-delete.ts`, PR #4063) with a tri-state result.
+`Reflect.deleteProperty` presumably routes through an older/different path that
+never learned about non-`$Object` receivers — the #4080 family shape (a correct
+treatment exists; one consumer never wired to it). The fix is most likely
+routing the Reflect spelling through the same delete native the operator now
+uses — at the Reflect dispatch site, not by widening anything general.
+
+## Acceptance
+
+- [ ] `Reflect.deleteProperty(arr, "q")` on an expando returns `true` and the
+      property is genuinely gone (value read AND store record — two
+      derivations, per the S2 standard; the S2 evidence table shows why one
+      derivation lies).
+- [ ] Returns `false` (not throw) where OrdinaryDelete would refuse.
+- [ ] `delete` operator behaviour byte-identical before/after (it is correct;
+      this fix must not touch its path).
+- [ ] Population sized from the fresh baseline before any flip claims.


### PR DESCRIPTION
Docs-only batch: (1) files **#4129** — `Reflect.deleteProperty` throws for every non-`$Object` receiver in standalone (pre-existing, found during #4010 S2; the `delete` operator is correct, only the Reflect spelling is unwired); (2) folds S2's certifying result (+13/−0 on 43,487, real root cause, S3 inheritance hazards) into the #4010 issue file; (3) lands the accumulated memory deltas (hold-is-admission-only stronger form, App-block re-confirmation, contents-API truncation trap, honest-negative rule). No src/tests/scripts/.github changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcwPzXzbjibq9EcXMDBJAj