### PR TITLE
style(benchmarks): clarify performance trend hierarchy

### DIFF
--- a/website/components/npm-compat-chart.js
+++ b/website/components/npm-compat-chart.js
@@ -239,7 +239,7 @@ class NpmCompatChart extends HTMLElement {
         return `
           <line x1="${pad.left}" y1="${yPos}" x2="${W - pad.right}" y2="${yPos}"
             stroke="${baseline ? "rgba(255,255,255,0.55)" : "rgba(255,255,255,0.08)"}"
-            stroke-width="${baseline ? 1.5 : 1}" ${baseline ? 'stroke-dasharray="5 4"' : ""}/>
+            stroke-width="${baseline ? 0.85 : 0.7}" ${baseline ? 'stroke-dasharray="4 5"' : ""}/>
           <text x="${pad.left - 8}" y="${yPos + 4}" text-anchor="end"
             fill="${baseline ? "rgba(255,255,255,0.72)" : "rgba(255,255,255,0.35)"}"
             font-size="10" font-family="monospace">${this._ratioTick(value)}</text>`;
@@ -251,15 +251,22 @@ class NpmCompatChart extends HTMLElement {
         const path = item.points
           .map((point, index) => `${index === 0 ? "M" : "L"} ${x(point.time)} ${y(point.ratio)}`)
           .join(" ");
+        const primary = item.key === "dynamic";
+        const fillPath = primary
+          ? `${path} L ${x(item.points.at(-1).time)} ${pad.top + plotH} L ${x(item.points[0].time)} ${pad.top + plotH} Z`
+          : "";
         const dots = item.points
           .map(
             (point) => `
-              <circle cx="${x(point.time)}" cy="${y(point.ratio)}" r="3" fill="${item.color}">
+              <circle cx="${x(point.time)}" cy="${y(point.ratio)}" r="${primary ? 1.7 : 1.25}"
+                fill="${item.color}" opacity="${primary ? 0.8 : 0.55}">
                 <title>${this._esc(`${item.label} · ${this._shortDate(point.generatedAt)} · ${this._perfLabel(point.ratio).text}`)}</title>
               </circle>`,
           )
           .join("");
-        return `<path d="${path}" fill="none" stroke="${item.color}" stroke-width="2"/>${dots}`;
+        return `${primary ? `<path d="${fillPath}" fill="url(#primary-speed-fill)"/>` : ""}
+          <path d="${path}" fill="none" stroke="${item.color}" stroke-width="${primary ? 2.5 : 1}"
+            opacity="${primary ? 1 : 0.68}" stroke-linecap="round" stroke-linejoin="round"/>${dots}`;
       })
       .join("");
 
@@ -287,10 +294,12 @@ class NpmCompatChart extends HTMLElement {
         <svg viewBox="0 0 ${W} ${H}" role="img"
           aria-label="${this._esc(`${pkg.name} relative speed versus Node over time`)}">
           <title>${this._esc(`${pkg.name}: relative Wasm speed, with native Node fixed at 1×`)}</title>
-          <rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${Math.max(0, baselineY - pad.top)}"
-            fill="rgba(74,222,128,0.025)"/>
-          <rect x="${pad.left}" y="${baselineY}" width="${plotW}"
-            height="${Math.max(0, pad.top + plotH - baselineY)}" fill="rgba(248,113,113,0.025)"/>
+          <defs>
+            <linearGradient id="primary-speed-fill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#8ba4ff" stop-opacity="0.22"/>
+              <stop offset="100%" stop-color="#8ba4ff" stop-opacity="0"/>
+            </linearGradient>
+          </defs>
           ${grid}
           <text x="${W - pad.right - 4}" y="${baselineY - 6}" text-anchor="end"
             fill="rgba(255,255,255,0.62)" font-size="9" font-family="monospace">Node 1×</text>
@@ -807,9 +816,7 @@ class NpmCompatChart extends HTMLElement {
           display: block;
         }
         .speed-chart {
-          background: rgba(255, 255, 255, 0.035);
-          border: 1px solid rgba(255, 255, 255, 0.07);
-          padding: 4px 7px 8px;
+          padding: 4px 0 8px;
         }
         .speed-chart svg {
           display: block;
@@ -839,7 +846,10 @@ class NpmCompatChart extends HTMLElement {
         .chart-legend-item.unavailable { opacity: 0.48; }
         .legend-swatch {
           width: 14px;
-          border-top: 2px solid var(--series-color);
+          border-top: 1px solid var(--series-color);
+        }
+        .chart-legend-item:last-child .legend-swatch {
+          border-top-width: 3px;
         }
         .chart-scale {
           padding: 5px 8px 0;

--- a/website/public/benchmarks/performance.html
+++ b/website/public/benchmarks/performance.html
@@ -100,10 +100,17 @@
         gap: 0.375rem;
       }
       .legend-dot {
-        width: 10px;
-        height: 10px;
-        border-radius: 2px;
+        width: 18px;
+        height: 0;
+        border-top: 1px solid var(--legend-color);
         flex-shrink: 0;
+      }
+      .legend-dot.legend-js {
+        border-top-style: dashed;
+        opacity: 0.62;
+      }
+      .legend-dot.legend-gc-native {
+        border-top-width: 3px;
       }
       .bench-section {
         max-width: 1200px;
@@ -164,9 +171,8 @@
         gap: 1rem;
       }
       .trend-card {
-        background: var(--surface);
-        border: 1px solid var(--border);
-        padding: 1rem;
+        min-width: 0;
+        padding: 0 0 1rem;
       }
       .trend-card .bench-name {
         margin-bottom: 0.5rem;
@@ -258,10 +264,10 @@
 
       function makeLegend(items) {
         const legend = el("div", { className: "legend" });
-        for (const [label, color] of items) {
+        for (const [label, color, strategy] of items) {
           const dot = el("div", {
-            className: "legend-dot",
-            style: { background: color },
+            className: `legend-dot legend-${strategy}`,
+            style: { "--legend-color": color },
           });
           const item = el("div", { className: "legend-item" }, dot, " " + label);
           legend.appendChild(item);
@@ -372,10 +378,10 @@
         container.appendChild(el("div", { className: "subtitle" }, history.length + " benchmark runs"));
         container.appendChild(
           makeLegend([
-            ["JavaScript", STRAT_COLORS.js],
-            ["Host-call", STRAT_COLORS["host-call"]],
-            ["GC-native", STRAT_COLORS["gc-native"]],
-            ["Linear-memory", STRAT_COLORS["linear-memory"]],
+            ["JavaScript (V8)", STRAT_COLORS.js, "js"],
+            ["Host-call", STRAT_COLORS["host-call"], "host-call"],
+            ["GC-native", STRAT_COLORS["gc-native"], "gc-native"],
+            ["Linear-memory", STRAT_COLORS["linear-memory"], "linear-memory"],
           ]),
         );
 
@@ -427,6 +433,29 @@
             svg.setAttribute("preserveAspectRatio", "none");
             svg.style.height = H + "px";
 
+            const gcPoints = stratData["gc-native"];
+            if (gcPoints?.length >= 2) {
+              const gradientId = `gc-fill-${name.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`;
+              const defs = document.createElementNS(svgNS, "defs");
+              const gradient = document.createElementNS(svgNS, "linearGradient");
+              gradient.setAttribute("id", gradientId);
+              gradient.setAttribute("x1", "0");
+              gradient.setAttribute("y1", "0");
+              gradient.setAttribute("x2", "0");
+              gradient.setAttribute("y2", "1");
+              const topStop = document.createElementNS(svgNS, "stop");
+              topStop.setAttribute("offset", "0%");
+              topStop.setAttribute("stop-color", STRAT_COLORS["gc-native"]);
+              topStop.setAttribute("stop-opacity", "0.24");
+              const bottomStop = document.createElementNS(svgNS, "stop");
+              bottomStop.setAttribute("offset", "100%");
+              bottomStop.setAttribute("stop-color", STRAT_COLORS["gc-native"]);
+              bottomStop.setAttribute("stop-opacity", "0");
+              gradient.append(topStop, bottomStop);
+              defs.appendChild(gradient);
+              svg.appendChild(defs);
+            }
+
             // Find global min/max across all strategies for this benchmark
             let globalMin = Infinity,
               globalMax = 0;
@@ -445,8 +474,30 @@
             const xScale = (idx) => PAD + (idx / (history.length - 1)) * (W - 2 * PAD);
             const yScale = (ms) => PAD + (1 - (ms - globalMin) / (globalMax - globalMin)) * (H - 2 * PAD);
 
-            // Draw lines for each strategy
-            for (const [strat, pts] of Object.entries(stratData)) {
+            // Draw the GC-native area below every line, then draw GC-native last
+            // so it remains the one visually dominant series.
+            if (gcPoints?.length >= 2) {
+              const gradientId = `gc-fill-${name.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`;
+              let fillD = "";
+              for (let i = 0; i < gcPoints.length; i++) {
+                const x = xScale(gcPoints[i].idx);
+                const y = yScale(gcPoints[i].ms);
+                fillD += (i === 0 ? "M" : "L") + x.toFixed(1) + "," + y.toFixed(1);
+              }
+              fillD += `L${xScale(gcPoints.at(-1).idx).toFixed(1)},${H - PAD}`;
+              fillD += `L${xScale(gcPoints[0].idx).toFixed(1)},${H - PAD}Z`;
+              const fill = document.createElementNS(svgNS, "path");
+              fill.setAttribute("d", fillD);
+              fill.setAttribute("fill", `url(#${gradientId})`);
+              svg.appendChild(fill);
+            }
+
+            const strategies = Object.entries(stratData).sort(([left], [right]) => {
+              if (left === "gc-native") return 1;
+              if (right === "gc-native") return -1;
+              return 0;
+            });
+            for (const [strat, pts] of strategies) {
               if (pts.length < 2) continue;
               const color = STRAT_COLORS[strat] || "#888";
 
@@ -461,26 +512,18 @@
               path.setAttribute("d", d);
               path.setAttribute("fill", "none");
               path.setAttribute("stroke", color);
-              path.setAttribute("stroke-width", "2");
+              path.setAttribute("stroke-width", strat === "gc-native" ? "2.75" : strat === "js" ? "0.9" : "1.1");
+              path.setAttribute("opacity", strat === "gc-native" ? "1" : strat === "js" ? "0.62" : "0.7");
+              if (strat === "js") path.setAttribute("stroke-dasharray", "4 5");
               path.setAttribute("stroke-linecap", "round");
               path.setAttribute("stroke-linejoin", "round");
               svg.appendChild(path);
-
-              // Draw dots at each point
-              for (const p of pts) {
-                const circle = document.createElementNS(svgNS, "circle");
-                circle.setAttribute("cx", xScale(p.idx).toFixed(1));
-                circle.setAttribute("cy", yScale(p.ms).toFixed(1));
-                circle.setAttribute("r", "3");
-                circle.setAttribute("fill", color);
-                svg.appendChild(circle);
-              }
             }
 
             card.appendChild(svg);
 
-            // Show delta for the primary strategy (host-call preferred, then gc-native, then js)
-            const primaryStrat = stratData["host-call"] ? "host-call" : stratData["gc-native"] ? "gc-native" : "js";
+            // Match the visual hierarchy: GC-native is the primary trend when available.
+            const primaryStrat = stratData["gc-native"] ? "gc-native" : stratData["host-call"] ? "host-call" : "js";
             const pts = stratData[primaryStrat];
             if (pts && pts.length >= 2) {
               const first = pts[0].ms;


### PR DESCRIPTION
## Summary

- remove the panel background and border from performance trend plots
- render the V8/Node baseline as a thinner dashed line
- keep secondary strategies thin while emphasizing GC-native/dynamic Wasm with a subtle area fill

## Validation

- `pnpm exec prettier --check website/public/benchmarks/performance.html website/components/npm-compat-chart.js`
- `node --check website/components/npm-compat-chart.js`
- `git diff --check`
- visually verified both pages against current benchmark history in the in-app browser with no console errors
