### PR TITLE
fix(#4130): npm-compat refresh reported success and committed nothing — the staleness floor measured the wrong artifact

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -84,6 +84,22 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # (#4130) MUST run BEFORE the regeneration below. The staleness floor in
+      # the queue gate asks "how old is the artifact main is currently serving",
+      # and the only moment that question is answerable is before this job
+      # overwrites the file. Reading it afterwards yields the age of the
+      # measurement this job just took — always ~0 — so the floor could never
+      # fire and a permanently busy queue deferred the promotion forever. The
+      # workflow ran, reported success, and committed nothing for two days.
+      - name: Capture the COMMITTED artifact's age (before regenerating)
+        id: committed
+        shell: bash
+        run: |
+          set -euo pipefail
+          LAST_REFRESH="$(node -e 'try{const r=JSON.parse(require("fs").readFileSync("benchmarks/results/npm-compat.json","utf8"));process.stdout.write(String(r.generatedAt??""))}catch{process.stdout.write("")}')"
+          echo "last_refresh=${LAST_REFRESH}" >> "$GITHUB_OUTPUT"
+          echo "committed artifact generatedAt: ${LAST_REFRESH:-<unreadable>}"
+
       - name: Regenerate the npm-compat artifacts
         # No `--only`: a focused run never writes, because a partial file would
         # drop the other packages. Refreshing anything means regenerating all of
@@ -121,7 +137,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
-          LAST_REFRESH="$(node -e 'try{const r=JSON.parse(require("fs").readFileSync("benchmarks/results/npm-compat.json","utf8"));process.stdout.write(String(r.generatedAt??""))}catch{process.stdout.write("")}')"
+          # (#4130) From the step that ran BEFORE the regeneration — the age of
+          # what main is serving, not of the measurement just taken.
+          LAST_REFRESH="${{ steps.committed.outputs.last_refresh }}"
           # `|| RC=$?`, not a bare call then `RC=$?`: the default step shell is
           # `bash -e {0}`, so a bare non-zero exit aborts the step before the
           # next line runs and the DEFER path would look like a step failure.

--- a/plan/issues/4130-npm-compat-refresh-staleness-floor-never-fires.md
+++ b/plan/issues/4130-npm-compat-refresh-staleness-floor-never-fires.md
@@ -1,0 +1,118 @@
+---
+id: 4130
+title: "npm-compat refresh reports SUCCESS and commits nothing — the staleness floor reads the artifact the job just regenerated, so it is always ~0h old and a busy queue defers forever"
+status: done
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+completed: 2026-08-03
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: tooling, ci
+language_feature: none
+goal: dogfood
+related: [3988, 3915, 3958, 3977, 4127]
+origin: "user asked why acorn's improvements were not visible on npm-compat.html, 2026-08-03"
+---
+
+# #4130 — the npm-compat staleness floor can never fire
+
+## Symptom
+
+`website/public/benchmarks/results/npm-compat*.json` last changed on
+**2026-08-01 11:07** (`3ffd8ed5c`) — and that was a *manual* regeneration commit,
+not the workflow's. Main was at `fb4f9d415` (2026-08-03 05:28) with the
+dashboard still serving 2-day-old measurements.
+
+`npm-compat-refresh.yml` ran repeatedly across that window and **succeeded**:
+
+```
+2026-08-03T04:30:15Z  push  completed  success
+2026-08-03T04:03:31Z  push  completed  success
+2026-08-03T03:41:00Z  push  completed  success
+2026-08-03T03:00:37Z  push  completed  success
+```
+
+Four green runs, zero commits. Nothing was red; the only symptom was a page that
+quietly stopped moving.
+
+## Root cause
+
+The job regenerates the artifact and *then* asks how old the artifact is:
+
+```yaml
+- name: Regenerate the npm-compat artifacts     # writes generatedAt: <now>
+  run: pnpm run generate:npm-compat
+...
+- name: Gate the main push on the merge queue
+  run: |
+    LAST_REFRESH="$(node -e '…readFileSync("benchmarks/results/npm-compat.json")…generatedAt')"
+    node scripts/main-push-queue-gate.mjs --last-refresh "$LAST_REFRESH" --stale-after-hours 12
+```
+
+`LAST_REFRESH` is therefore the timestamp of the measurement **this job just
+took** — always ~0 hours old — so `ageHours` never reaches the 12h floor and
+`decide()` returns `defer` whenever the merge queue is busy. On this repo the
+queue is busy essentially always (pushes every ~10 minutes), so the promotion
+is deferred on every run, forever.
+
+Confirmed by executing the gate's own decision function:
+
+| ageHours | queueLen | decision |
+| -------: | -------: | -------- |
+|        0 |        3 | **defer** (what happens today) |
+|        0 |        0 | proceed |
+|       12 |        3 | proceed |
+|       42 |        3 | proceed (the artifact's real age) |
+
+The gate script is fine — its own usage doc says `--last-refresh` should come
+from "a value carried IN the artifact", meaning the committed one. Only this
+workflow's step ordering is wrong.
+
+## Why it went unnoticed
+
+Every visible signal said healthy. The run was green, the sanity-check passed,
+the defer path is deliberately *not* a failure (correctly — a deferred refresh
+is normal), and the staleness floor existed precisely so an indefinite defer
+could not happen. The floor was the safety net, and the safety net was measuring
+the wrong thing.
+
+This is the third time this dashboard has shipped stale. The workflow's own
+header records the first two (#3958 rendered `39/null`; #3977 kept showing `lit`
+as not-integrated) and says they were "the case for a mechanism rather than for
+remembering". The mechanism was built and then defeated by a two-line ordering
+detail.
+
+## Fix
+
+Capture the committed artifact's `generatedAt` in a step that runs **before**
+the regeneration, and feed the gate from that.
+
+## Acceptance criteria
+
+- [x] The staleness floor is computed from the artifact main is currently
+      serving, not from the freshly generated one.
+- [x] A structural regression test, since this failure has no observable output
+      to assert on: step ORDER (`id: committed` before
+      `pnpm run generate:npm-compat`) and the wiring
+      (`steps.committed.outputs.last_refresh`, and no post-regeneration re-read).
+- [x] The test is demonstrated to FAIL against the unfixed workflow — 2 of 5
+      fail on `main`'s version, 5 of 5 pass with the fix.
+- [x] The gate's decision table is pinned directly, so a future change to
+      `decide()` cannot silently reintroduce a permanent defer.
+
+## Deliberately not done
+
+- **No locally-measured artifact commit.** The obvious "just refresh it" is to
+  run `pnpm run generate:npm-compat` here and commit the result — but these
+  numbers come from a shared, noisy container while every committed measurement
+  so far came from a clean CI runner. Mixing the two would corrupt the trend
+  history with incomparable figures for a one-time gain. The correct refresh is
+  the next workflow run, which this fix unblocks.
+- **The `cancelled` runs are not investigated.** Several runs in the same window
+  show `cancelled` despite `cancel-in-progress: false`; that is consistent with
+  GitHub keeping at most one *pending* run per group (which the workflow's
+  comment already anticipates), but it was not verified here.

--- a/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
+++ b/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4130) The npm-compat refresh workflow's staleness floor must measure the
+ * COMMITTED artifact, not the one the job just regenerated.
+ *
+ * The failure this guards against is invisible by construction: the workflow
+ * ran on every push to main, reported **success**, and committed nothing for
+ * two days. Nothing was red. The only symptom was a dashboard that quietly
+ * stopped moving — precisely the class of bug the workflow's own header says it
+ * exists to prevent ("shipped stale twice in one session").
+ *
+ * So the guard is structural: assert the step ORDER and the wiring, because
+ * when this breaks there is no output to assert on. Raw-text assertions match
+ * `ci-quality-failfast.test.ts`; the repo carries no YAML parser, and step order
+ * is a property of the file's text anyway.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+const workflow = readFileSync(resolve(ROOT, ".github/workflows/npm-compat-refresh.yml"), "utf8");
+
+const at = (needle: string): number => workflow.indexOf(needle);
+
+describe("#4130 — the staleness floor measures the committed artifact", () => {
+  it("captures the committed artifact's age BEFORE regenerating it", () => {
+    const capture = at("id: committed");
+    const regenerate = at("pnpm run generate:npm-compat");
+
+    expect(capture, "a step with `id: committed` must exist").toBeGreaterThanOrEqual(0);
+    expect(regenerate, "the regeneration step must exist").toBeGreaterThanOrEqual(0);
+    // The whole bug in one assertion. Reading `generatedAt` after the
+    // regeneration yields the age of the measurement just taken — always ~0 —
+    // so the floor never fires and a busy queue defers forever.
+    expect(capture).toBeLessThan(regenerate);
+  });
+
+  it("feeds the gate from that captured value, not from a re-read of the file", () => {
+    expect(workflow).toContain("steps.committed.outputs.last_refresh");
+    // A re-read AFTER regeneration is the regression: it would silently restore
+    // the old behaviour while every assertion about the gate's flags still
+    // passed. Pin that the gate step no longer reads the file itself.
+    const gateBlock = workflow.slice(at("id: queue_gate"), at("- name: Promote"));
+    expect(gateBlock).not.toContain('readFileSync("benchmarks/results/npm-compat.json"');
+  });
+
+  it("still passes a staleness floor to the gate", () => {
+    expect(workflow).toMatch(/--stale-after-hours\s+\d+/);
+  });
+
+  it("gates promotion on the queue decision", () => {
+    expect(workflow.slice(at("- name: Promote"))).toContain("steps.queue_gate.outputs.decision");
+  });
+});
+
+describe("#4130 — the gate's own decision function", () => {
+  it("defers a busy queue only while the artifact is fresh, and proceeds once it is stale", async () => {
+    const { decide } = await import("../scripts/main-push-queue-gate.mjs");
+    const busy = { force: false, queueLen: 3, staleAfterHours: 12 };
+
+    // What the workflow produced before the fix: the just-regenerated file is
+    // always ~0h old, so a busy queue deferred every single run.
+    expect(decide({ ...busy, ageHours: 0 }).decision).toBe("defer");
+    // What it produces now — the committed artifact's real age clears the floor.
+    expect(decide({ ...busy, ageHours: 42 }).decision).toBe("proceed");
+    expect(decide({ ...busy, ageHours: 12 }).decision).toBe("proceed");
+    // A quiet queue never needed the floor at all.
+    expect(decide({ ...busy, queueLen: 0, ageHours: 0 }).decision).toBe("proceed");
+  });
+});


### PR DESCRIPTION
## Description

Closes #4130. Found while investigating why acorn's numbers were not moving on `npm-compat.html`.

## Symptom

`benchmarks/results/npm-compat*.json` last changed **2026-08-01 11:07** (`3ffd8ed5c`) — and that was a *manual* regeneration, not the workflow's. Main was at `fb4f9d415` (08-03 05:28) with the dashboard still serving 2-day-old measurements.

`npm-compat-refresh.yml` ran repeatedly across that window and **succeeded**:

```
2026-08-03T04:30:15Z  push  completed  success
2026-08-03T04:03:31Z  push  completed  success
2026-08-03T03:41:00Z  push  completed  success
2026-08-03T03:00:37Z  push  completed  success
```

Four green runs, zero commits.

## Root cause

The job regenerates the artifact and *then* asks how old the artifact is:

```yaml
- name: Regenerate the npm-compat artifacts     # writes generatedAt: <now>
  run: pnpm run generate:npm-compat
...
- name: Gate the main push on the merge queue
  run: |
    LAST_REFRESH="$(node -e '…readFileSync("benchmarks/results/npm-compat.json")…generatedAt')"
    node scripts/main-push-queue-gate.mjs --last-refresh "$LAST_REFRESH" --stale-after-hours 12
```

`LAST_REFRESH` is the timestamp of the measurement **this job just took** — always ~0h old — so `ageHours` never reaches the 12h floor and `decide()` returns `defer` whenever the merge queue is busy. On this repo the queue is busy essentially always (pushes every ~10 min), so promotion deferred on every run, forever.

Confirmed by executing the gate's own decision function:

| ageHours | queueLen | decision |
|---:|---:|---|
| 0 | 3 | **defer** ← what happens today |
| 0 | 0 | proceed |
| 12 | 3 | proceed |
| 42 | 3 | proceed ← the artifact's real age |

`main-push-queue-gate.mjs` is fine — its own usage doc says `--last-refresh` should come from "a value carried IN the artifact", meaning the committed one. Only this workflow's step ordering was wrong.

## Fix

Capture the committed `generatedAt` in a step that runs **before** regeneration, and feed the gate from that. Two lines of wiring; the diff is 19 insertions, most of it the comment explaining why the order is load-bearing.

## Why it went unnoticed

Every visible signal said healthy — green run, sanity-check passed, and the defer path is deliberately *not* a failure (correctly: a deferred refresh is normal). The staleness floor existed precisely so an indefinite defer could not happen. **The floor was the safety net, and the safety net was measuring the wrong thing.**

This is the third time this dashboard has shipped stale. The workflow's own header records the first two (#3958 rendered `39/null`; #3977 kept showing `lit` as not-integrated) and calls them "the case for a mechanism rather than for remembering". The mechanism was built and then defeated by an ordering detail.

## Testing

`tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts` — 5 tests. The guard is **structural**, because when this breaks there is no output to assert on: step order (`id: committed` before `pnpm run generate:npm-compat`), the wiring (`steps.committed.outputs.last_refresh`, and no post-regeneration re-read inside the gate step), and the gate's decision table pinned directly so a future change to `decide()` cannot silently reintroduce a permanent defer.

**Demonstrated to fail against the unfixed workflow**: 2 of 5 fail on `main`'s version, 5 of 5 pass with the fix.

`check:issues`, `check:issue-spec-coverage`, `check:done-status-integrity`, `lint` all pass.

## Deliberately not done

- **No locally-measured artifact commit.** The obvious "just refresh it" would be to run the generator here and commit the result — but these numbers come from a shared, noisy container while every committed measurement so far came from a clean CI runner. Mixing them would corrupt the trend history with incomparable figures for a one-time gain. The correct refresh is the next workflow run, which this unblocks.
- **The `cancelled` runs are not investigated.** Several runs in the same window show `cancelled` despite `cancel-in-progress: false`. That is consistent with GitHub keeping at most one *pending* run per group — which the workflow's comment already anticipates — but I did not verify it.

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_013rC8ahHETYHdMDfkG4xBKE)_