### PR TITLE
fix(#4131): Annex B B.3.3.1 step 3 — update an EXISTING var binding

### DIFF
--- a/plan/issues/4131-annexb-existing-var-update.md
+++ b/plan/issues/4131-annexb-existing-var-update.md
@@ -1,0 +1,159 @@
+---
+id: 4131
+title: "Annex B B.3.3.1 step 3 — a block/if/case-nested function must UPDATE an existing var binding"
+status: done
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+goal: core-semantics
+assignee: ttraenkler/senior-dev
+completed: 2026-08-03
+---
+
+## Problem
+
+Annex B B.3.3.1 has two halves. The compiler implemented one.
+
+- **Create** — a block-nested sloppy `function F` gets a *new* var-scoped binding in
+  the enclosing function/global scope. Implemented: `annexBBlockNestedEligible` +
+  `fctx.annexBOuterBindings` (#2200 Phase 2), with the cancellation cases in
+  `src/codegen/annexb-cancel.ts` (#3980).
+- **Update** — step 3.f, `fenvRec.SetMutableBinding(F, fobj, false)`: when the
+  declaration is *evaluated*, the function object is written into the var-scoped
+  binding **whether or not Annex B created it**. Not implemented at all. The
+  create-half bails outright when the name already has a local:
+
+  ```ts
+  // statements/nested-declarations.ts
+  // Skip if the name already has a function-local (e.g. a var/param) — that
+  // binding wins, no Annex B var.
+  if (!fctx.localMap.has(funcName)) { /* allocate + record */ }
+  ```
+
+  The comment is right about *allocation* and wrong about *assignment*.
+
+Measured on `main` (312-file sweep of `annexB/language/{function,global}-code`):
+all 6 `block-decl-*` / `switch-*-*-existing-var-update` files fail with
+`Expected SameValue («"number"», «"function"»)` — the read sees the `var`'s own
+value, never the function.
+
+## Why the five `if-*` files "passed" — and why that was an accident
+
+`if-decl-*-func-existing-var-update.js` (5 files) passed on `main`, but not
+because step 3 worked. Their wrapper is an IIFE; `compileTailDispatch`'s inline
+path did **not** hoist `var` declarations, so at `after = f` no local named `f`
+existed yet and identifier resolution fell through to the cached function-closure
+singleton (`emitCachedFuncClosureAccess`). Position-insensitive luck.
+
+Any change that makes an inlined IIFE body hoist its vars — as a real
+FunctionDeclarationInstantiation must — flips those five to a **null
+dereference**. That is what the Codex eval-capture stack
+(`codex/2929-annexb-init-update`) does: commit `0d14fa56d` adds
+`hoistVarDeclarations` to both arms of the inlined-IIFE path in
+`src/codegen/expressions/call-tail-dispatch.ts`, motivated by indirect eval
+observing a nested local as a realm-global mutation. That change is correct on
+its own terms; it merely removes the accident.
+
+Emitted code for `after = f` under the hoist, from the WAT:
+
+```wat
+;; main                                    ;; with the var-hoist
+global.get $__fn_closure_f                 local.get 0        ;; the f64 var slot, still 0
+ref.is_null                                call $__box_number
+(if (then ref.func $__fn_tramp_f_cached    global.set $__mod_after
+          i32.const 0 struct.new …
+          global.set $__fn_closure_f))
+global.get $__fn_closure_f
+… → global.set $__mod_after
+```
+
+`after` then holds a boxed `0`, and the call dispatch traps rather than throwing:
+its guard throws TypeError only when the *raw* value is null, so a non-null
+non-callable falls through to `struct.get` on a null cast result. (Read from the
+emitted WAT; not separately minimised — see "Follow-ups".)
+
+## Attribution (kill-switch removal)
+
+`hoistVarDeclarations` in the two inlined-IIFE arms of `call-tail-dispatch.ts` was
+replicated locally on `main` as the kill switch. Lane: JS-host (default target),
+`runTest262File`, status only.
+
+| build | 5 × `function-code/if-*-func-existing-var-update` |
+| --- | --- |
+| `main` (e5c7747c5) | `pass` ×5 |
+| `main` + hoist replica, **no fix** | `null_deref` ×5 — same 5 files, same `dereferencing a null pointer in __module_init() at source L44` as the Codex stack |
+| `main` + hoist replica + this fix | `pass` ×5 |
+| `main` + this fix | `pass` ×5 |
+
+`git bisect` over `main..codex/2929-annexb-init-update` (27 commits) names
+`0d14fa56d` as the first bad commit; the trace
+`allocLocal ← hoistVarDecl ← walkStmtForVars ← hoistVarDeclarations ←
+compileTailDispatch` pins the line.
+
+## Fix
+
+Three sites, sharing one predicate.
+
+1. `src/codegen/annexb-cancel.ts` — `annexBUpdatesExistingVarBinding(fd)` and the
+   memoized `annexBExistingVarUpdateNames(scope)`. Reuses `annexBDeclaringRange`,
+   so the Block / `if`-clause / `switch`-clause position set stays defined once.
+   `annexBBlockNestedEligible` could not host this: it only recognises a direct
+   `Block` parent.
+2. `src/codegen/analysis/mixed-assignment-carrier.ts` — an Annex B declaration is
+   a *hidden* cross-domain assignment: no `F = …` BinaryExpression exists for the
+   existing walk to see, so `var f = 123` keeps an f64 slot and the write-back is
+   unrepresentable. Widen the carrier to externref for those names only.
+3. `src/codegen/statements.ts` — emit the store at the declaration's textual
+   position, **after** whichever path defines the function.
+
+## Measured effect
+
+| population | before | after |
+| --- | --- | --- |
+| `annexB/language/{function,global}-code`, 312 files | 203 pass / 108 fail / 1 CE | **byte-identical** |
+| `tests/issue-4131.test.ts` (4 cases, 2 semantic + 2 negative control) | 2 fail | 4 pass |
+| `tests/issue-3980.test.ts` (annexb-cancel detector) | 18 pass | 18 pass |
+| 5 `if-*` files under the Codex var-hoist | `null_deref` | `pass` |
+
+On `main` alone the change is a **no-op across the whole annexB corpus** — every
+test262 file in that family wraps its case in an IIFE, which `main` inlines
+without hoisting, so the code path is unreachable there. Its measurable effect on
+`main` is the named-wrapper shape in `tests/issue-4131.test.ts` (fail → pass); its
+effect on the Codex stack is the 5-file regression removed. Both are stated rather
+than averaged into one number on purpose.
+
+## Explicitly NOT fixed
+
+- **`block-decl` / `switch-*` positions** (6 files, already failing on `main`).
+  Widening the *carrier* is not enough: the binding's **static type** stays
+  `number`, so the assignment path emits `__unbox_number` → `__box_number` around
+  the closure and `after` receives `NaN`. Verified in the WAT of a named-wrapper
+  `block` case. Fixing these needs the binding's *type* to widen, not just its
+  slot — a TypeMap/oracle change, not a codegen one.
+- **Global scope.** A script-scope `var` is a module global, on a different
+  representation path; an earlier cut that did not exclude `SourceFile` scopes
+  produced `local.tee expected (ref null 25), found global.get of type f64` on the
+  5 `global-code/if-*` files. The predicate now returns `false` for
+  `SourceFile`/`ModuleBlock` scopes.
+- The 16 `eval-code/{direct,indirect}/*-existing-var-update` twins — not measured.
+
+## Approaches that failed (do not repeat)
+
+1. **Return early from the new `statements.ts` branch** (mirroring the
+   `annexBOuterBindings` branch, which ends in `return`). The `if`/`case`
+   declaration positions are not always pre-compiled by the hoist pre-pass, so the
+   early return dropped the function definition outright and the name read as
+   null. Measured: 5 × `TypeError: Cannot access property on null or undefined`.
+2. **Applying the carrier widening at script scope too** — invalid Wasm, above.
+3. **Guarding the collection walk with `isVarScopeBoundary` before testing the
+   node.** A `FunctionDeclaration` *is* a var-scope boundary, so the guard skipped
+   the very declarations being collected and the set came back empty for every
+   case — a silent no-op that looked like "the fix does not work".
+
+## Follow-ups (not filed)
+
+- The callable-dispatch guard throws TypeError only on a *null* raw value; a
+  non-null non-callable externref (e.g. a host-owned boxed number) reaches
+  `struct.get` on a null cast result and **traps**. This is what turned an honest
+  `fail` into a `null_deref`. Observed in emitted WAT; worth its own issue.

--- a/src/codegen/analysis/mixed-assignment-carrier.ts
+++ b/src/codegen/analysis/mixed-assignment-carrier.ts
@@ -11,6 +11,7 @@
 import { ts, forEachChild } from "../../ts-api.js";
 import type { JsTag } from "../../checker/oracle.js";
 import type { ValType } from "../../ir/types.js";
+import { annexBExistingVarUpdateNames } from "../annexb-cancel.js";
 import { getLocalType } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 
@@ -40,6 +41,13 @@ export function bindingHasMixedAssignmentCarrier(ctx: CodegenContext, decl: ts.V
   if (initialTag === "mixed") return false;
   const initialDomain = carrierDomain(initialTag);
   const scope = containingScope(decl);
+  // (#4131) An Annex B B.3.3 block/`if`/`case`-nested `function F` in this same
+  // var scope is a HIDDEN cross-domain assignment to `F`: B.3.3.1 step 3.f writes
+  // the function object into the existing var binding when the declaration is
+  // evaluated. No `F = …` BinaryExpression exists for the walk below to see, so
+  // without this the slot keeps the initializer's narrow representation
+  // (`var f = 123` → f64) and the write-back is unrepresentable.
+  if (initialDomain !== "function" && annexBExistingVarUpdateNames(scope).has(decl.name.text)) return true;
   let mixed = false;
 
   // (#4122) `"mixed"` is the oracle's answer for UNRESOLVABLE, not for "proven

--- a/src/codegen/annexb-cancel.ts
+++ b/src/codegen/annexb-cancel.ts
@@ -272,6 +272,73 @@ export function annexBHoistCancels(fnDecl: ts.FunctionDeclaration): ts.Block | n
   return null;
 }
 
+/**
+ * (#4131) B.3.3.1 step 3 — the half of Annex B that is an *assignment*, not a
+ * declaration.
+ *
+ * `collectAnnexBCancelSites` below answers "does this name read as UNBOUND?".
+ * This answers the complementary question: when the enclosing var scope ALREADY
+ * binds the name, B.3.3.1 step 3.f still requires that *evaluating* the
+ * block-nested `function F` perform `fenvRec.SetMutableBinding(F, fobj, false)`
+ * on that existing binding. The compiler modelled only the "create a new
+ * web-compat binding" half (`annexBBlockNestedEligible` in
+ * `statements/nested-declarations.ts`, which bails outright when the name
+ * already has a local) — so `var f = 123` in the same scope never saw the
+ * function object, and every `annexB/language/*-existing-var-update` test read
+ * the var's own value instead.
+ *
+ * Restricted to FUNCTION var scopes on purpose. A script-scope `var` is a module
+ * GLOBAL, not a local, and its representation is decided by a different path;
+ * widening the local carrier for it produced `local.tee expected (ref null N),
+ * found global.get of type f64` (measured on the 5 `global-code/if-*` files).
+ * Global-scope B.3.3.1 step 3 is real and still unimplemented — see #4131.
+ *
+ * Deliberately shares `annexBDeclaringRange` with the cancellation collector, so
+ * the Block / `if`-clause / `switch`-clause position set is defined exactly once.
+ * The `if` and `switch` positions are why this could not simply be added to
+ * `annexBBlockNestedEligible`, which only recognises a direct `Block` parent.
+ */
+export function annexBUpdatesExistingVarBinding(fd: ts.FunctionDeclaration): boolean {
+  const name = fd.name?.text;
+  if (!name || !fd.body) return false;
+  if (annexBDeclaringRange(fd) === null) return false;
+  const scope = enclosingVarScope(fd);
+  if (!scope || ts.isSourceFile(scope) || ts.isModuleBlock(scope)) return false;
+  // A cancelled extension creates NO binding and updates none either (B.3.3.1
+  // step 1.a.ii skips the whole step-3 replacement).
+  if (hasInterveningLexicalBinder(fd.parent, name, scope)) return false;
+  return scopeBindsName(scope, name);
+}
+
+const SCOPE_UPDATE_CACHE = new WeakMap<ts.Node, Set<string>>();
+
+/**
+ * (#4131) The names in `scope` that some Annex B statement-position `function`
+ * declaration must write back to an ALREADY-EXISTING var binding. Memoized per
+ * var scope; the result is almost always empty, so ordinary code pays one walk
+ * per scope and no allocation beyond the shared empty set.
+ */
+export function annexBExistingVarUpdateNames(scope: ts.Node): ReadonlySet<string> {
+  const cached = SCOPE_UPDATE_CACHE.get(scope);
+  if (cached) return cached;
+  const names = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    // Test the node BEFORE the boundary guard: a `FunctionDeclaration` IS a var
+    // scope boundary, so guarding first would skip the very declarations this
+    // walk is looking for (measured: the set came back empty for every case).
+    if (ts.isFunctionDeclaration(node) && node.name && node.body && annexBUpdatesExistingVarBinding(node)) {
+      names.add(node.name.text);
+    }
+    // Do not descend into a nested var scope — its own Annex B declarations
+    // belong to ITS binding set, not this one.
+    if (node !== scope && isVarScopeBoundary(node)) return;
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(scope, visit);
+  SCOPE_UPDATE_CACHE.set(scope, names);
+  return names;
+}
+
 const CACHE = new WeakMap<ts.SourceFile, AnnexBCancelSite[]>();
 
 /** Shared empty result for callers with no SourceFile — never mutated. */

--- a/src/codegen/statements.ts
+++ b/src/codegen/statements.ts
@@ -15,8 +15,10 @@
  *   - statements/shared.ts         — utilities shared across all sub-modules
  */
 import { ts } from "../ts-api.js";
+import { annexBUpdatesExistingVarBinding } from "./annexb-cancel.js";
 import { emitCachedFuncClosureAccess } from "./closures.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
+import { getLocalType } from "./context/locals.js";
 import { attachSourcePos, getSourcePos } from "./context/source-pos.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { compileExpression, registerCompileStatement } from "./shared.js";
@@ -251,8 +253,40 @@ function compileStatementInner(ctx: CodegenContext, fctx: FunctionContext, stmt:
       // nothing else to emit at this textual position.
       return;
     }
+    // (#4131) B.3.3.1 step 3.f on an ALREADY-EXISTING var binding. The branch
+    // above covers the case where Annex B CREATES the web-compat binding; when
+    // the enclosing var scope already binds the name (`var f = 123` beside a
+    // block/`if`/`case`-nested `function f`), no binding is created but the
+    // existing one must still be UPDATED with the function object when the
+    // declaration is evaluated.
+    //
+    // Unlike the branch above this must NOT return early: the `if`/`case`
+    // declaration positions are not always pre-compiled by the hoist pre-pass, so
+    // swallowing the statement here drops the function definition outright (the
+    // name then reads as null — measured on the 5 `function-code/if-*` files).
+    // The store is therefore emitted AFTER whichever path defines the function.
+    const annexBVarUpdate = funcName !== undefined && annexBUpdatesExistingVarBinding(stmt);
+    const emitAnnexBVarUpdate = (): void => {
+      if (!annexBVarUpdate || funcName === undefined) return;
+      const varLocal = fctx.localMap.get(funcName);
+      const fnIdx = ctx.funcMap.get(funcName);
+      // The externref check is a hard precondition, not an optimisation: the
+      // carrier widening in `analysis/mixed-assignment-carrier.ts` is what makes
+      // the slot able to hold a closure at all. If it did not happen (a shape
+      // that analysis declines), storing here would emit invalid Wasm, so fall
+      // through to today's wrong-but-valid behaviour instead.
+      if (varLocal === undefined || fnIdx === undefined) return;
+      if (getLocalType(fctx, varLocal)?.kind !== "externref") return;
+      const closureType = emitCachedFuncClosureAccess(ctx, fctx, funcName, fnIdx);
+      if (!closureType) return;
+      if (closureType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
+      fctx.body.push({ op: "local.set", index: varLocal });
+    };
     const hasReservedBodylessEntry = funcName ? (ctx.preRegisteredBodyless?.has(funcName) ?? false) : false;
-    if (funcName && ctx.funcMap.has(funcName) && !hasReservedBodylessEntry) return;
+    if (funcName && ctx.funcMap.has(funcName) && !hasReservedBodylessEntry) {
+      emitAnnexBVarUpdate();
+      return;
+    }
     // Re-attempt compilation even if hoisting failed — the failure may have been
     // due to const/let captures not yet in scope during the hoisting pre-pass.
     // Now that we're in statement order, those locals should be available.
@@ -264,6 +298,7 @@ function compileStatementInner(ctx: CodegenContext, fctx: FunctionContext, stmt:
     } else {
       compileNestedFunctionDeclaration(ctx, fctx, stmt);
     }
+    emitAnnexBVarUpdate();
     return;
   }
 

--- a/tests/issue-4131.test.ts
+++ b/tests/issue-4131.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4131) Annex B B.3.3.1 step 3.f — a block/`if`/`case`-nested sloppy-mode
+ * `function F` must WRITE the function object into the var-scoped binding for
+ * `F` when the declaration is evaluated, including when that binding already
+ * exists (`var f = 123` in the same function).
+ *
+ * The compiler only ever modelled the "CREATE a new web-compat binding" half
+ * (`annexBBlockNestedEligible`, #2200 Phase 2), which bails outright when the
+ * name already has a local. The `annexB/language/*-existing-var-update` family
+ * therefore read the var's own value instead of the function.
+ *
+ * The five `annexB/language/function-code/if-decl-*-func-existing-var-update.js`
+ * files nevertheless PASSED, by accident: their wrapper is an IIFE, the IIFE
+ * inline path did NOT hoist `var` declarations, so at `after = f` no local named
+ * `f` existed yet and identifier resolution fell through to the cached
+ * function-closure singleton. Any change that makes the IIFE body hoist its vars
+ * — as a real FunctionDeclarationInstantiation must — flips those five from
+ * `pass` to a **null dereference**: `f` resolves to the uninitialised f64 slot,
+ * `__box_number(0)` lands in `after`, and the call dispatch does `struct.get` on
+ * a null cast result.
+ *
+ * These tests pin the SEMANTICS, not the accident: they use a NAMED wrapper
+ * function (not an IIFE), which does hoist its vars, so they exercise the real
+ * B.3.3.1 step 3 path and fail on a compiler that lacks the write-back.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runJs(source: string): Promise<unknown[]> {
+  const out: unknown[] = [];
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "/issue-4131.js",
+    skipSemanticDiagnostics: true,
+    deferTopLevelInit: true,
+    hostBridge: "always",
+  });
+  expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const imports = buildImports(
+    result.imports ?? [],
+    { console: { log: (v: unknown) => out.push(v), warn: () => {}, error: () => {} } },
+    result.stringPool ?? [],
+  );
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  (instance.exports as Record<string, () => void>).__module_init?.();
+  return out;
+}
+
+describe("#4131 Annex B B.3.3.1 step 3 — update an EXISTING var binding", () => {
+  it("if-clause declaration writes the function object into the existing var", async () => {
+    const out = await runJs(`
+      var after;
+      function wrap() {
+        if (true) function f() { return 'fd'; }
+        after = f;
+        var f = 123;
+      }
+      wrap();
+      console.log(typeof after);
+    `);
+    expect(out).toEqual(["function"]);
+  });
+
+  it("if/else declaration in the else clause behaves the same", async () => {
+    const out = await runJs(`
+      var after;
+      function wrap() {
+        if (false) ; else function f() { return 'fd'; }
+        after = f;
+        var f = 123;
+      }
+      wrap();
+      console.log(typeof after);
+    `);
+    expect(out).toEqual(["function"]);
+  });
+
+  it("a var with NO Annex B declaration keeps its numeric carrier", async () => {
+    // Negative control for the carrier widening in mixed-assignment-carrier.ts:
+    // the widening must fire ONLY for names an Annex B declaration writes back.
+    const out = await runJs(`
+      var after;
+      function wrap() {
+        var f = 123;
+        after = f;
+      }
+      wrap();
+      console.log(typeof after);
+    `);
+    expect(out).toEqual(["number"]);
+  });
+
+  it("a skipped if-clause leaves the existing var binding untouched", async () => {
+    const out = await runJs(`
+      var after;
+      function wrap() {
+        if (false) function f() { return 'fd'; }
+        var f = 7;
+        after = f;
+      }
+      wrap();
+      console.log(typeof after);
+    `);
+    expect(out).toEqual(["number"]);
+  });
+});


### PR DESCRIPTION
## What

Implements the missing half of Annex B B.3.3.1: step 3.f, `fenvRec.SetMutableBinding(F, fobj, false)`. A block/`if`/`case`-nested sloppy `function F` must write the function object into the var-scoped binding for `F` when the declaration is evaluated — **even when that binding already exists**. Only the "create a new web-compat binding" half was implemented; it bails outright when the name already has a local, so `var f = 123` in the same function never saw the function.

## Why now — five `pass` files that were passing by accident

`annexB/language/function-code/if-decl-*-func-existing-var-update.js` (5 files) pass on `main`, but not because step 3 works. Their wrapper is an IIFE; `compileTailDispatch`'s inline path did **not** hoist `var` declarations, so at `after = f` no local named `f` existed yet and identifier resolution fell through to the cached function-closure singleton.

Any change that makes an inlined IIFE body hoist its vars — as a real FunctionDeclarationInstantiation must — flips all five to a **null dereference**. The Codex eval-capture stack (`codex/2929-annexb-init-update`, commit `0d14fa56d`) does exactly that, for a good reason of its own (indirect eval observing a nested local as a realm-global mutation). Its change is correct; it merely removes the accident. This PR removes the accident's cause instead.

## Attribution — kill-switch removal

`hoistVarDeclarations` in the two inlined-IIFE arms was replicated locally on `main` as the kill switch. JS-host lane, `runTest262File`, status only.

| build | 5 × `function-code/if-*-func-existing-var-update` |
| --- | --- |
| `main` | `pass` ×5 |
| `main` + hoist replica, **no fix** | `null_deref` ×5 — same 5 files, same `dereferencing a null pointer in __module_init()` as the Codex stack |
| `main` + hoist replica + this fix | `pass` ×5 |
| `main` + this fix | `pass` ×5 |

`git bisect` over the 27 commits of `main..codex/2929-annexb-init-update` names `0d14fa56d`; the trace `allocLocal ← hoistVarDecl ← walkStmtForVars ← hoistVarDeclarations ← compileTailDispatch` pins the line.

## Measured effect

| population | before | after |
| --- | --- | --- |
| `annexB/language/{function,global}-code`, 312 files | 203 pass / 108 fail / 1 CE | **byte-identical** |
| `tests/issue-4131.test.ts` (2 semantic + 2 negative control) | 2 fail | 4 pass |
| `tests/issue-3980.test.ts` (annexb-cancel detector) | 18 pass | 18 pass |

**On `main` alone this is a no-op across the whole annexB corpus** — every test262 file in that family wraps its case in an IIFE, which `main` inlines without hoisting, so the path is unreachable there. Its measurable effect on `main` is the named-wrapper shape in the new test (fail → pass); its effect on the Codex stack is the 5-file regression removed. Stated separately rather than averaged into one number.

## Changes

Three sites, one shared predicate:

- `src/codegen/annexb-cancel.ts` — `annexBUpdatesExistingVarBinding` / memoized `annexBExistingVarUpdateNames`, reusing `annexBDeclaringRange` so the Block / `if`-clause / `switch`-clause position set stays defined once. `annexBBlockNestedEligible` could not host this: it only recognises a direct `Block` parent.
- `src/codegen/analysis/mixed-assignment-carrier.ts` — an Annex B declaration is a *hidden* cross-domain assignment; no `F = …` node exists for the existing walk to see, so the slot keeps an f64 carrier and the write-back is unrepresentable. Widened for those names only.
- `src/codegen/statements.ts` — emit the store at the declaration's textual position, **after** whichever path defines the function.

## Explicitly NOT fixed (reasons in the issue file)

- **`block-decl` / `switch-*` positions** (6 files already failing on `main`). Widening the *carrier* is not enough: the binding's **static type** stays `number`, so the assignment emits `__unbox_number` → `__box_number` around the closure and the target receives `NaN`. Needs a TypeMap/oracle change.
- **Global scope** — a script-scope `var` is a module global on a different representation path; an earlier cut that did not exclude `SourceFile` scopes produced `local.tee expected (ref null 25), found global.get of type f64`.
- The 16 `eval-code/*-existing-var-update` twins — not measured.

Three approaches that failed, with their measurements, are recorded in `plan/issues/4131-annexb-existing-var-update.md` so they are not repeated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)