### PR TITLE
fix(#4132): npm-compat promotion blocked by husky's pre-commit hook — the second blocker, unmasked by #4130

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -245,7 +245,18 @@ jobs:
               exit 0
             fi
 
-            git commit -q -m "chore(ci): refresh npm-compat artifacts [skip ci]"
+            # (#4132) --no-verify: this job installs dependencies, so husky's
+          # pre-commit hook is live, and it runs `test:changed-root`, which needs
+          # a merge base with `origin/main`. The checkout is `fetch-depth: 1`
+          # with `persist-credentials: false` and the push remote is `deploykey`,
+          # so `origin/main` does not exist and the hook aborts the commit:
+          #   "changed-root-tests: cannot resolve a merge base with origin/main"
+          # The sibling `benchmark-refresh` is immune only structurally — its
+          # promote job is separate and never runs `pnpm install`, so no hook is
+          # installed. This workflow is deliberately a SINGLE job, so it has to
+          # opt out explicitly. Running the changed-root suite over generated
+          # JSON artifacts would be meaningless anyway.
+          git commit -q --no-verify -m "chore(ci): refresh npm-compat artifacts [skip ci]"
             if git push deploykey HEAD:main; then
               echo "Published npm-compat artifacts measured at ${SOURCE_SHA}."
               exit 0

--- a/plan/issues/4132-npm-compat-promote-blocked-by-pre-commit-hook.md
+++ b/plan/issues/4132-npm-compat-promote-blocked-by-pre-commit-hook.md
@@ -1,0 +1,86 @@
+---
+id: 4132
+title: "npm-compat promotion fails: the bot's `git commit` runs husky's pre-commit hook, which cannot resolve a merge base under `fetch-depth: 1` — the artifact still never lands"
+status: done
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+completed: 2026-08-03
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: tooling, ci
+language_feature: none
+goal: dogfood
+related: [4130, 3988, 4127]
+origin: "the #4130 fix landed, the gate stopped deferring, and the promote step failed instead — 2026-08-03"
+---
+
+# #4132 — the promotion commit is blocked by the pre-commit hook
+
+## How this surfaced
+
+#4130 fixed the staleness floor so the queue gate stops deferring on every run.
+It worked: the promote step now **executes**. It then **fails**.
+
+Every `npm-compat-refresh` run after #4130 landed (06:49) has failed — 06:49,
+08:23, 09:56, 11:32 — and the artifact is still the manual 2026-08-01 snapshot.
+
+This is a second, independent bug that #4130 unmasked. It has presumably been
+there since the workflow was written; the promote step had simply never run.
+
+## Root cause
+
+```
+> @loopdive/js2@0.67.0 test:changed-root
+> sh scripts/hooks/changed-root-tests.sh
+
+changed-root-tests: cannot resolve a merge base with origin/main.
+Fetch origin/main or set CHANGED_ROOT_TESTS_BASE to a local base ref.
+ ELIFECYCLE  Command failed with exit code 1.
+```
+
+`.husky/pre-commit` runs `pnpm run test:changed-root`, which needs a merge base
+with `origin/main`. In this job there is none:
+
+- the checkout is `fetch-depth: 1` with `persist-credentials: false`;
+- the push remote is added as `deploykey`, not `origin`.
+
+So the hook aborts the commit and the step exits 1.
+
+## Why the sibling bot is unaffected
+
+`benchmark-refresh.yml` issues the same hook-free `git commit` and works — but
+only **structurally**. Its `promote-benchmarks` job is separate and does
+checkout + `download-artifact` only; it never runs `pnpm install`, so husky's
+hooks are never installed.
+
+`npm-compat-refresh.yml` is deliberately a SINGLE job (its own comment explains
+why: it never runs on PRs, so there is no untrusted-code split to make), which
+means it installs dependencies and then commits in the same job. It therefore
+has to opt out of the hook explicitly.
+
+## Fix
+
+`git commit --no-verify` in the promote step. Running the changed-root test
+suite over generated JSON artifacts would be meaningless even if it could
+resolve a base.
+
+## Acceptance criteria
+
+- [x] The promote step commits without invoking the pre-commit hook.
+- [x] A structural regression test asserting `--no-verify` on the promote
+      commit, and that the `[skip ci]` marker survives (it is what breaks the
+      trigger loop).
+- [x] The test is demonstrated to FAIL against the unfixed workflow.
+
+## Not yet verified
+
+**The end-to-end promotion has NOT been observed.** #4130 was also believed
+fixed until its next run revealed this. The only proof that matters is the
+artifact's commit history moving off `3ffd8ed5c` (2026-08-01), and that cannot
+be confirmed until a run completes after this lands. If a THIRD blocker sits
+behind this one, the same investigation applies: read the failing step, do not
+assume the previous fix was sufficient.

--- a/plan/issues/4132-npm-compat-promote-blocked-by-pre-commit-hook.md
+++ b/plan/issues/4132-npm-compat-promote-blocked-by-pre-commit-hook.md
@@ -68,12 +68,21 @@ has to opt out of the hook explicitly.
 suite over generated JSON artifacts would be meaningless even if it could
 resolve a base.
 
+## Permanent repro
+
+`tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts` — the guard lives
+alongside #4130's rather than in a file of its own, because the two failures are
+the same mechanism observed one step apart (the gate stops deferring, so the
+promote step finally runs, and then fails). Splitting them would let one be
+edited without the other being re-read. The `#4132` describe block asserts
+`--no-verify` on the promote commit and that `[skip ci]` survives.
+
 ## Acceptance criteria
 
 - [x] The promote step commits without invoking the pre-commit hook.
 - [x] A structural regression test asserting `--no-verify` on the promote
       commit, and that the `[skip ci]` marker survives (it is what breaks the
-      trigger loop).
+      trigger loop) — `tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts`.
 - [x] The test is demonstrated to FAIL against the unfixed workflow.
 
 ## Not yet verified

--- a/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
+++ b/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
@@ -56,6 +56,23 @@ describe("#4130 — the staleness floor measures the committed artifact", () => 
   });
 });
 
+describe("#4132 — the promotion commit must not run the pre-commit hook", () => {
+  it("commits with --no-verify", () => {
+    // This job installs dependencies, so husky's hook is live and runs
+    // `test:changed-root`, which needs a merge base with `origin/main`. The
+    // checkout is `fetch-depth: 1` with `persist-credentials: false` and the
+    // push remote is `deploykey`, so there is no `origin/main` and the hook
+    // aborts the commit. It stayed hidden until #4130 stopped the gate
+    // deferring on every run — the step had simply never executed.
+    const promote = workflow.slice(at("- name: Promote"));
+    expect(promote).toMatch(/git commit[^\n]*--no-verify/);
+  });
+
+  it("keeps the [skip ci] marker that breaks the trigger loop", () => {
+    expect(workflow.slice(at("- name: Promote"))).toContain("[skip ci]");
+  });
+});
+
 describe("#4130 — the gate's own decision function", () => {
   it("defers a busy queue only while the artifact is fresh, and proceeds once it is stale", async () => {
     const { decide } = await import("../scripts/main-push-queue-gate.mjs");


### PR DESCRIPTION
## Description

Closes #4132. Follow-on to #4130 (PR #4082, merged).

**#4130 worked, and was not enough.** The gate now stops deferring, so the promote step *executes* — and then fails. Every run since #4130 landed at 06:49 has failed (06:49, 08:23, 09:56, 11:32), and the artifact is still the manual 2026-08-01 snapshot.

```
6  Capture the COMMITTED artifact's age    success
9  Gate the main push on the merge queue   success     ← no longer defers
10 Promote the refreshed artifacts to main FAILURE     ← previously never ran
```

## Root cause

```
> sh scripts/hooks/changed-root-tests.sh
changed-root-tests: cannot resolve a merge base with origin/main.
Fetch origin/main or set CHANGED_ROOT_TESTS_BASE to a local base ref.
 ELIFECYCLE  Command failed with exit code 1.
```

`.husky/pre-commit` runs `pnpm run test:changed-root`, which needs a merge base with `origin/main`. This job has none:

- checkout is `fetch-depth: 1` with `persist-credentials: false`;
- the push remote is added as `deploykey`, not `origin`.

The hook aborts the commit and the step exits 1.

## Why the sibling bot is unaffected

`benchmark-refresh.yml` issues the same hook-free `git commit` and works — but only **structurally**. Its `promote-benchmarks` job is separate and does checkout + `download-artifact` only; it never runs `pnpm install`, so husky's hooks are never installed.

`npm-compat-refresh.yml` is deliberately a *single* job — its own comment explains why (it never runs on PRs, so there is no untrusted-code split to make) — which means it installs dependencies and then commits in the same job. It has to opt out explicitly.

## Fix

`git commit --no-verify` in the promote step. Running the changed-root suite over generated JSON artifacts would be meaningless even if it could resolve a base.

This bug has presumably been there since the workflow was written. It was invisible because the promote step had never executed.

## Testing

Extends the #4130 structural guard: `--no-verify` on the promote commit, and the `[skip ci]` marker preserved (it is what breaks the trigger loop). 7/7 pass with the fix; **the new assertion fails against main's version**.

`check:issues`, `check:issue-spec-coverage`, `check:done-status-integrity`, `lint` pass.

## Not yet verified — stated plainly

**The end-to-end promotion has NOT been observed.** #4130 was also believed fixed until its next run revealed this one. The only proof that counts is the artifact's commit history moving off `3ffd8ed5c` (2026-08-01), and that cannot be confirmed until a run completes after this lands.

If a third blocker sits behind this one, the same method applies: read the failing step, don't assume the previous fix was sufficient.

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_013rC8ahHETYHdMDfkG4xBKE)_