### PR TITLE
fix(codegen/ir): five defects blocking acorn on --target standalone

### DIFF
--- a/plan/issues/4138-standalone-forin-nested-dynamic-object-children.md
+++ b/plan/issues/4138-standalone-forin-nested-dynamic-object-children.md
@@ -1,0 +1,57 @@
+---
+id: 4138
+title: "standalone: for…in over a nested dynamic object misses children — generic AST walk visits 1 of N nodes"
+status: ready
+sprint: Backlog
+priority: high
+goal: standalone-gap
+feasibility: medium
+horizon: m
+created: 2026-08-03
+requested_by: ttraenkler/claude-bench
+related: [4088]
+---
+
+# #4138 — standalone: for…in over nested dynamic objects yields 1 of N children
+
+## Problem
+
+A generic object-graph walk — the canonical "visit every AST node" loop — visits
+only the root on `--target standalone`. 15-line repro, returns **1** where node
+returns **3**:
+
+```js
+export function bench() {
+  var root = { type: "A", kids: [{ type: "B" }, { type: "C" }] };
+  var stack = [root]; var n = 0;
+  while (stack.length > 0) {
+    var node = stack.pop();
+    if (node === null || typeof node !== "object") continue;
+    if (typeof node.type === "string") n = n + 1;
+    for (var k in node) { var v = node[k]; if (v !== null && typeof v === "object") stack.push(v); }
+  }
+  return n;
+}
+```
+
+Either the `for…in` over the dynamic object enumerates no/too-few keys, or the
+computed read `node[k]` answers null for object-valued properties — the repro
+does not yet distinguish. A variant where the walk lives in a function taking
+the object as an untyped parameter does not compile at all.
+
+## Why it matters
+
+This is what blocks a **correct** acorn self-parse checksum on standalone.
+With PR #4088's three fixes, acorn 8.18 compiles and parses its own 233 KB
+source **correctly** (`ast.body.length`/`ast.end` agree exactly with node
+acorn, probe 422232958 both sides) — but the cross-engine benchmark's AST-walk
+checksum computes 1,232,968 vs node's 32,692,356,805 because the walk sees ~1
+node. Every other engine in the test262.fyi benchmark lane passes this
+checksum; js2's standalone lane is marked invalid on the one whole-program
+case. The walk shape (for…in + computed member read over heterogeneous
+objects) is ubiquitous in real traversal code, not benchmark-specific.
+
+## Acceptance
+
+- The repro above returns 3 on `--target standalone` (and gc).
+- acorn self-parse AST checksum matches node acorn on the same source.

--- a/plan/issues/4138-standalone-forin-nested-dynamic-object-children.md
+++ b/plan/issues/4138-standalone-forin-nested-dynamic-object-children.md
@@ -10,6 +10,10 @@ horizon: m
 created: 2026-08-03
 requested_by: ttraenkler/claude-bench
 related: [4088]
+loc-budget-allow:
+  - src/codegen/statements/loops.ts
+func-budget-allow:
+  - src/codegen/statements/loops.ts::compileForInStatement
 ---
 
 # #4138 — standalone: for…in over nested dynamic objects yields 1 of N children
@@ -50,6 +54,26 @@ node. Every other engine in the test262.fyi benchmark lane passes this
 checksum; js2's standalone lane is marked invalid on the one whole-program
 case. The walk shape (for…in + computed member read over heterogeneous
 objects) is ubiquitous in real traversal code, not benchmark-specific.
+
+## Progress
+
+**Narrow slice landed 2026-08-03** (with PR #4088's branch): a receiver typed
+`T | undefined` (the `Array.pop()` shape) hit the standalone static-unroll
+path with a UNION type, whose `getProperties()` is the common set — empty —
+so the loop silently enumerated nothing. The static shape is now read off
+`getNonNullableType()`; `tests/issue-4138-forin-nonnullable-receiver.test.ts`
+covers it. The repro above still returns 1, not 3: with heterogeneous
+pushes the union's common property set is `{type}` alone, so children are
+still never enumerated.
+
+## What remains (the actual body of this issue)
+
+1. A receiver that is POLYMORPHIC at runtime must not static-unroll one
+   shape — it needs runtime key enumeration.
+2. Runtime enumeration (`__object_keys_forin`) only sees `$Object` values;
+   closed WasmGC structs (object literals with stable shapes, fnctor
+   instances) are not enumerable through it. A generic walk needs either a
+   reflection path over closed structs or a rep change.
 
 ## Acceptance
 

--- a/plan/issues/4139-fnctor-twin-capture-args-not-in-frame.md
+++ b/plan/issues/4139-fnctor-twin-capture-args-not-in-frame.md
@@ -10,6 +10,10 @@ horizon: m
 created: 2026-08-03
 requested_by: ttraenkler/claude-bench
 related: [4088, 2043]
+loc-budget-allow:
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/context/types.ts
+  - src/codegen/closures.ts
 ---
 
 # #4139 — `__fnctor_<C>_new` forwards captures its frame does not hold
@@ -70,6 +74,26 @@ So the fallback is not a safe landing zone; only capture threading fixes this.
 An adjacent silent-miscompile exists in the same family: a fnctor ctor calling
 a sibling that reads a captured `hasOwn`-style binding through `.call` returns
 wrong values (probe expected 20, got null) without any validation error.
+
+## Progress
+
+**Capture threading landed 2026-08-03** (standalone): the twin's prologue
+casts the `__constructor_identity` param — which call sites already load with
+the constructor's closure VALUE — to the closure struct recorded per AST node
+(`ctx.closureStructByNode`) and spills every capture field into a frame local
+registered under the capture's own name (cells register in `boxedCaptures`).
+Sibling-call prepends then resolve in-frame via `capture-source-slot.ts`.
+Guarded by `ref.test`; a null/foreign identity keeps the old behaviour.
+acorn UMD's `__fnctor_Parser_new` validation failure is gone; the 39
+fnctor/new/constructor test files show byte-identical failure lists with and
+without the change (25 pre-existing). gc-target twins remain uncovered (no
+identity param there).
+
+acorn UMD now proceeds to the NEXT defect in its chain: `__closure_0` fails
+validation with `local.set[0] expected (ref null 7), found local.tee of type
+(ref null 6)` — a stack-balance arg-coercion temp (`$sn_tmp_*`,
+stack-balance.ts) typed off inference that disagrees with the real value type.
+Separate defect, not this issue.
 
 ## Acceptance
 

--- a/plan/issues/4139-fnctor-twin-capture-args-not-in-frame.md
+++ b/plan/issues/4139-fnctor-twin-capture-args-not-in-frame.md
@@ -1,0 +1,63 @@
+---
+id: 4139
+title: "fnctor constructor twin passes sibling-capture arguments its own frame never received"
+status: ready
+sprint: Backlog
+priority: medium
+goal: core-semantics
+feasibility: hard
+horizon: m
+created: 2026-08-03
+requested_by: ttraenkler/claude-bench
+related: [4088, 2043]
+---
+
+# #4139 — `__fnctor_<C>_new` forwards captures its frame does not hold
+
+## Problem
+
+When a constructor function expression is admitted as a write-once fnctor and
+its body calls **capturing sibling functions**, the devirtualized twin
+(`__fnctor_<C>_new`) emits the sibling call with capture arguments sourced via
+`cap.outerLocalIdx` — slots of the frame that *declared* the captures. The
+fnctor twin's own frame has neither those slots nor same-named locals
+(`fctx.localMap.get(cap.name) === undefined`), so PR #4088's cross-frame
+capture-slot fix cannot rescue it: there is nothing in-frame to redirect to.
+
+Observed on acorn 8.18's **UMD** bundle (`dist/acorn.js` — every top-level
+binding lives in one IIFE, so `getOptions`/`wordsRegexp`/`hasOwn`/`isArray`
+are frame locals of the IIFE):
+
+```
+WebAssembly.compile(): Compiling function #384:"__fnctor_Parser_new" failed:
+call[0] expected type (ref null 125), found local.get of type anyref
+```
+
+Instrumented capture-slot misses during that compile (all with
+`inFrame=undefined`):
+
+```
+fn=__fnctor_Parser_new callee=wordsRegexp cap=regexpCache outer=26 max=13
+fn=__fnctor_Parser_new callee=getOptions  cap=isArray     outer=25 max=6
+fn=__fnctor_Parser_new callee=getOptions  cap=hasOwn      outer=24 max=5
+```
+
+## Repro
+
+Compile acorn 8.18 `dist/acorn.js` (UMD) with a `bench()` export on either
+target — after PR #4088, compile succeeds and validation fails at
+`__fnctor_Parser_new`. The ESM entry (module-level bindings, no IIFE) does not
+reach this: same functions, but the captures resolve as module bindings.
+
+## Direction (not prescribed)
+
+Either thread the transitive sibling captures into the fnctor twin's signature
+(the same leading-capture-params contract lifted declarations use), or refuse
+fnctor admission for constructors whose call graph reaches capturing siblings
+declared in an enclosing function frame — a decline is strictly better than
+emitting an invalid module.
+
+## Acceptance
+
+- acorn 8.18 UMD compiles to a **validating** module, or the fnctor admission
+  declines with the generic path taking over (no `WebAssembly.compile` error).

--- a/plan/issues/4139-fnctor-twin-capture-args-not-in-frame.md
+++ b/plan/issues/4139-fnctor-twin-capture-args-not-in-frame.md
@@ -51,11 +51,25 @@ reach this: same functions, but the captures resolve as module bindings.
 
 ## Direction (not prescribed)
 
-Either thread the transitive sibling captures into the fnctor twin's signature
-(the same leading-capture-params contract lifted declarations use), or refuse
-fnctor admission for constructors whose call graph reaches capturing siblings
-declared in an enclosing function frame — a decline is strictly better than
-emitting an invalid module.
+Thread the transitive sibling captures into the fnctor twin's signature (the
+same leading-capture-params contract lifted declarations use).
+
+**The decline alternative was tried on 2026-08-03 and does NOT work.** A
+post-compile audit (flag any capture-argument prepend that sources a foreign
+frame slot; abort the twin, `unreachable` body, no cache, fall through to the
+generic `new` path) produced strictly worse results on both probes:
+
+- a WORKING minimal fnctor-with-capturing-sibling case regressed 6 → 0: the
+  generic standalone `new` path over a function-expression constructor does
+  not deliver the fnctor semantics the working twin did;
+- acorn UMD then failed in a DIFFERT function (`__closure_0`:
+  `local.set[0] expected (ref null 7), found local.tee of type (ref null 6)`)
+  — the generic path has its own invalid-emission defect on this shape.
+
+So the fallback is not a safe landing zone; only capture threading fixes this.
+An adjacent silent-miscompile exists in the same family: a fnctor ctor calling
+a sibling that reads a captured `hasOwn`-style binding through `.call` returns
+wrong values (probe expected 20, got null) without any validation error.
 
 ## Acceptance
 

--- a/plan/issues/4144-stack-balance-unknown-slot-declared-field-type.md
+++ b/plan/issues/4144-stack-balance-unknown-slot-declared-field-type.md
@@ -1,0 +1,50 @@
+---
+id: 4144
+title: "stack-balance: unknown stack slot typed from the struct field's declared type — supertype value fails validation"
+status: ready
+sprint: Backlog
+priority: medium
+goal: core-semantics
+feasibility: medium
+horizon: m
+created: 2026-08-03
+requested_by: ttraenkler/claude-bench
+related: [4088, 4139]
+---
+
+# #4144 — stack-balance temp typed from declared field type breaks on supertype values
+
+## Problem
+
+`stack-balance.ts`'s struct.new arg-coercion fixup saves the top N stack
+values into temps typed from its inference:
+
+    const actualType = widenPackedToI32(fieldTypes[fi] ?? fields[fi]!.type);
+
+When inference has NO type for a slot (`fieldTypes[fi]` null — e.g. the value
+crossed a control-flow join), the temp falls back to the **field's declared
+type**. If the runtime value is a SUPERTYPE of the field type, the emitted
+`local.set` fails engine validation:
+
+    __closure_0: local.set[0] expected type (ref null 7),   ;; $NativeString
+                 found local.tee of type (ref null 6)       ;; $AnyString
+
+Observed compiling acorn 8.18 UMD on --target standalone (function #1612,
+after the #4088 + #4139 fixes cleared the four defects ahead of it).
+
+## Two layers
+
+1. **The balancer's fallback is unsound**: a temp for an UNKNOWN slot must be
+   typed to hold whatever arrives (or the slot's coercion must be resolved
+   from the true type), never narrowed to the field's declared type.
+2. **The upstream producer is the real defect**: the pre-fixup code was
+   already passing an `$AnyString` where the struct field is declared
+   `$NativeString` — the producer should have flattened (Cons → Native)
+   before construction. The balancer only moves the failure earlier.
+
+## Acceptance
+
+- acorn 8.18 UMD (`dist/acorn.js` + CJS shim) compiles to a validating
+  module on --target standalone.
+- A reduced repro (struct.new with a NativeString field receiving a value
+  the checker only knows as AnyString across a join) compiles and runs.

--- a/plan/issues/4145-acorn-umd-standalone-tracking.md
+++ b/plan/issues/4145-acorn-umd-standalone-tracking.md
@@ -1,0 +1,43 @@
+---
+id: 4145
+title: "tracking: acorn 8.18 UMD compiles and runs on --target standalone"
+status: ready
+sprint: Backlog
+priority: medium
+goal: standalone-gap
+feasibility: hard
+horizon: l
+created: 2026-08-03
+requested_by: ttraenkler/claude-bench
+related: [4088, 4138, 4139, 4144]
+---
+
+# #4145 — tracking: acorn UMD end-to-end on standalone
+
+The UMD bundle (`dist/acorn.js`) wraps every top-level binding in one IIFE,
+turning the whole parser into frame locals + capturing siblings. Compiling it
+with a `bench()` export surfaced five distinct compiler defects, fixed or
+filed in this order (each fix un-masked the next):
+
+1. ✅ Cross-frame capture argument from a dead slot — PR #4088 (`ae6f9cb6`).
+2. ✅ Name-matched shape arm emits an unbridgeable `struct.get` — PR #4088
+   (`433b553f`).
+3. ✅ Selector/build vec-ABI disagreement on numeric-array module vars —
+   PR #4088 (`c7a57f35`).
+4. ✅ Fnctor twin sibling captures — #4139 (standalone; `2ef595b7`).
+   ⛔ gc-target twins remain: no `__constructor_identity` param there.
+5. ⛔ #4144 — stack-balance types an unknown slot's temp from the struct
+   field's DECLARED type (`$NativeString`) while the value is its supertype
+   (`$AnyString`); underneath, the producer passes unflattened strings into
+   a NativeString-typed field. Current blocker: `__closure_0` validation.
+
+Unknown whether more defects hide behind (5) — each fix so far revealed the
+next. The benchmark meanwhile vendors the ESM-script form
+(test262-data `02b19d4`), which works end-to-end after PR #4088; UMD stays
+the harder exercise and this issue is done when it passes too.
+
+## Acceptance
+
+- acorn 8.18 UMD + CJS shim compiles to a validating module on standalone,
+  runs `parse` of its own source, and the parse agrees with node acorn.
+- Same on gc (needs the twin-capture mechanism without the identity param).

--- a/src/codegen/alternate-field-arm.ts
+++ b/src/codegen/alternate-field-arm.ts
@@ -1,0 +1,46 @@
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { coercionInstrs } from "./type-coercion.js";
+import { valTypesMatch } from "./shared.js";
+
+/**
+ * The read of one name-matched alternate shape in an inlined property-access
+ * dispatch chain: `ref.cast` the receiver to that shape, `struct.get` its
+ * field, coerce to the read's result type.
+ *
+ * Returns `null` when the alternate cannot produce `resultType` at all, and
+ * the caller should skip the arm.
+ *
+ * Why skipping is right: `findAlternateStructsForField` enumerates candidates
+ * by field NAME, so it deliberately over-approximates — two unrelated shapes
+ * can share a property name and hold different types under it. `coercionInstrs`
+ * answers `[]` both for "no coercion needed" and for "cannot bridge this pair",
+ * so an unbridgeable arm used to emit a bare `struct.get` feeding a local of
+ * the wrong type: invalid wasm the emitter produces happily and only the engine
+ * rejects —
+ *
+ *   __closure_21: local.set[0] expected type (ref null 6),
+ *                 found struct.get of type i32
+ *
+ * which is acorn's `Parser`, where `reservedWords[...]` (a string read) matched
+ * `defaultOptions` on name and found an i32 field. A shape that cannot yield
+ * the result type is not a candidate for this read, so the chain should fall
+ * through to the generic path instead.
+ */
+export function alternateFieldArmRead(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  alt: { structTypeIdx: number; fieldIdx: number; fieldType: ValType },
+  resultType: ValType,
+  sourceLocal: number,
+): Instr[] | null {
+  const coerce = coercionInstrs(ctx, alt.fieldType, resultType, fctx);
+  if (coerce.length === 0 && !valTypesMatch(alt.fieldType, resultType)) return null;
+
+  return [
+    { op: "local.get", index: sourceLocal },
+    { op: "ref.cast", typeIdx: alt.structTypeIdx },
+    { op: "struct.get", typeIdx: alt.structTypeIdx, fieldIdx: alt.fieldIdx },
+    ...coerce,
+  ];
+}

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -2713,6 +2713,9 @@ export function compileArrowAsClosure(
   });
   let { structTypeIdx, liftedFuncTypeIdx, liftedParams } = mintedTypes;
   const { liftedSelfTypeIdx } = mintedTypes;
+  // (#4139) Record the node -> closure-struct mapping for the fnctor twin
+  // build, which materializes the ctor's sibling captures from this struct.
+  (ctx.closureStructByNode ??= new WeakMap()).set(arrow, { structTypeIdx });
 
   // 5. Build the lifted function body — extracted to compileLiftedClosureBody
   //    (#3683 S2) so the same AST can also be compiled as a typed-`this` twin.

--- a/src/codegen/closures/capture-source-slot.ts
+++ b/src/codegen/closures/capture-source-slot.ts
@@ -1,0 +1,43 @@
+import type { FunctionContext } from "../context/types.js";
+
+/**
+ * Which local a capture-argument prepend should read when it hands a lifted
+ * function its leading capture values.
+ *
+ * `cap.outerLocalIdx` is a slot number in the frame that DECLARED the capture.
+ * Emitted from that same frame it is exactly right, and it is what this
+ * resolver returns. Emitted from a DIFFERENT frame it means nothing — a
+ * cross-frame call (a sibling nested function, or a lifted arrow / function
+ * expression calling one) addresses an unrelated local, or a slot that does
+ * not exist at all.
+ *
+ * Two cases are sound cross-frame, and only these two:
+ *
+ *  1. The name is recorded as THIS lifted function's own leading capture
+ *     parameter (`liftedCaptureNames`) — the value is right here, by
+ *     construction of the lifted signature.
+ *
+ *  2. `cap.outerLocalIdx` is not a slot this frame has AT ALL, and this frame
+ *     binds the capture's own name. The historical fallback cannot be what
+ *     anything depends on in that case: it is `local index out of range` at
+ *     emit, or a read of whatever unrelated local the index lands on.
+ *
+ * Anything else keeps `cap.outerLocalIdx`. That restraint is the point:
+ * #1177's blanket "prefer localMap" lookup regressed 100+ test262 tests
+ * because in-range wrong-slot behaviour turned out to be load-bearing, so an
+ * index that IS in range is left exactly as it was.
+ *
+ * Reaches acorn's UMD bundle, which puts every top-level binding inside one
+ * IIFE: `pp.method = function (...) { ... capturingSibling(...) ... }` is a
+ * lifted function expression addressing the IIFE frame's slot 35 from a frame
+ * with 35 locals.
+ */
+export function captureSourceSlot(fctx: FunctionContext, cap: { name: string; outerLocalIdx: number }): number {
+  const inFrameIdx = fctx.localMap.get(cap.name);
+  if (fctx.liftedCaptureNames?.has(cap.name)) return inFrameIdx ?? cap.outerLocalIdx;
+
+  const existsHere = cap.outerLocalIdx < fctx.params.length + fctx.locals.length;
+  if (!existsHere && inFrameIdx !== undefined) return inFrameIdx;
+
+  return cap.outerLocalIdx;
+}

--- a/src/codegen/closures/funcref-as-closure.ts
+++ b/src/codegen/closures/funcref-as-closure.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ClosureInfo, CodegenContext, FunctionContext } from "../context/types.js";
+import { captureSourceSlot } from "./capture-source-slot.js";
 import type { FieldDef, Instr, ValType } from "../../ir/types.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
 import { popBody, pushBody } from "../context/bodies.js";
@@ -157,9 +158,7 @@ function emitMemoizedNestedFnClosure(
         fctx.body.push({ op: "ref.as_non_null" });
       }
     } else {
-      const capSourceIdx = fctx.liftedCaptureNames?.has(cap.name)
-        ? (fctx.localMap.get(cap.name) ?? cap.outerLocalIdx)
-        : cap.outerLocalIdx;
+      const capSourceIdx = captureSourceSlot(fctx, cap);
       fctx.body.push({ op: "local.get", index: capSourceIdx });
     }
   }

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2273,6 +2273,11 @@ export interface CodegenContext {
    * cannot desync a cached raw index.
    */
   nestedFnClosureArtifacts?: Map<string, { structTypeIdx: number; trampolineName: string }>;
+  /** (#4139) Closure struct type minted for a lifted arrow / function
+   *  expression, keyed by the AST node. The fnctor twin build reads it to
+   *  materialize the ctor's sibling captures from the closure value that
+   *  arrives as the standalone `__constructor_identity` param. */
+  closureStructByNode?: WeakMap<ts.Node, { structTypeIdx: number }>;
   /** Nested function capture info. */
   nestedFuncCaptures: Map<
     string,

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -9,6 +9,7 @@
 // identifier cases, so the caller in calls.ts continues its dispatch chain.
 // Moved verbatim: the emitted Wasm is byte-identical.
 import { ts } from "../../ts-api.js";
+import { captureSourceSlot } from "../closures/capture-source-slot.js";
 import { isBooleanType, isPromiseType, isStringType, isVoidType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { resolveArrayInfo } from "../array-methods.js";
@@ -2013,9 +2014,7 @@ export function compileIdentifierCall(
           // Stage 1's blanket localMap-first lookup remains reverted. The one
           // sound cross-frame case is a name explicitly recorded as THIS
           // lifted function's leading capture parameter.)
-          const capSourceIdx = fctx.liftedCaptureNames?.has(cap.name)
-            ? (fctx.localMap.get(cap.name) ?? cap.outerLocalIdx)
-            : cap.outerLocalIdx;
+          const capSourceIdx = captureSourceSlot(fctx, cap);
           fctx.body.push({ op: "local.get", index: capSourceIdx });
           // Coerce capture value to expected param type if they differ
           const expectedCapType = captureParamTypes?.[capIdx];

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1,4 +1,5 @@
 import type { FieldDef, Instr, ValType } from "../../ir/types.js";
+import { materializeFnctorTwinCaptures } from "../fnctor-twin-captures.js";
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
  * new/super/class expression compilation.
@@ -1553,6 +1554,18 @@ function compileNewFunctionDeclaration(
   if (savedFunc) ctx.parentBodiesStack.push(savedFunc.body);
   if (savedFunc) ctx.funcStack.push(savedFunc);
   ctx.currentFunc = ctorFctx;
+  // (#4139) A function-EXPRESSION constructor compiled as a closure carries
+  // the transitive captures of every sibling it calls as struct fields; the
+  // standalone identity param holds that closure value. Spill the fields into
+  // frame locals named after the captures BEFORE the body compiles, so
+  // sibling-call prepends and direct reads resolve in-frame instead of
+  // addressing the declaring frame's dead slots.
+  if (ctx.standalone) {
+    const closureRecord = ctx.closureStructByNode?.get(funcDecl);
+    if (closureRecord) {
+      materializeFnctorTwinCaptures(ctx, ctorFctx, closureRecord.structTypeIdx, ctorIdentityParamIdx);
+    }
+  }
   for (const stmt of body.statements) {
     compileStatement(ctx, ctorFctx, stmt);
   }

--- a/src/codegen/fnctor-twin-captures.ts
+++ b/src/codegen/fnctor-twin-captures.ts
@@ -1,0 +1,98 @@
+import { CLOSURE_CAPTURE_FIELD_BASE } from "./closures/funcref-wrapper-types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { allocLocal } from "./context/locals.js";
+import { refCellValueType } from "./registry/types.js";
+import type { Instr, StructTypeDef, ValType } from "../ir/types.js";
+
+/**
+ * (#4139) Materialize a fnctor constructor twin's sibling-capture bindings
+ * from the constructor's own closure value.
+ *
+ * The twin compiles the ctor body in a FRESH frame, so a body that calls
+ * capturing sibling functions (acorn's UMD wrapper: `getOptions`,
+ * `wordsRegexp` — captures of the module IIFE's frame) had its capture
+ * arguments prepended from `cap.outerLocalIdx` — slots the twin does not
+ * have. That emitted a read of whatever the twin's same-numbered local held:
+ * an engine validation error when the types disagreed, a silently wrong value
+ * when they did not.
+ *
+ * The values already travel to the twin: on standalone every call site passes
+ * the constructor's closure VALUE as the hidden `__constructor_identity`
+ * param (fnctor-constructor-identity.ts), and the closure struct's capture
+ * fields carry exactly the bindings the body needs — `compileArrowAsClosure`
+ * unions in the transitive captures of every called sibling, which is why the
+ * closure compilation of the same body works. So the twin prologue casts the
+ * identity param to the closure struct and spills each capture field into a
+ * frame local registered under the capture's own name. Sibling-call prepends
+ * then resolve in-frame (`capture-source-slot.ts`), and direct reads of the
+ * captured names inside the ctor body resolve the same way the closure body's
+ * do (cells register in `boxedCaptures`).
+ *
+ * The cast is guarded by `ref.test`: a null or foreign identity value leaves
+ * the locals at their defaults — exactly the pre-existing behaviour, never a
+ * trap.
+ */
+export function materializeFnctorTwinCaptures(
+  ctx: CodegenContext,
+  ctorFctx: FunctionContext,
+  closureStructTypeIdx: number,
+  identityParamIdx: number,
+): void {
+  const def = ctx.mod.types[closureStructTypeIdx];
+  if (!def || def.kind !== "struct") return;
+  const fields = (def as StructTypeDef).fields;
+
+  const spills: { fieldIdx: number; local: number }[] = [];
+  for (let fieldIdx = CLOSURE_CAPTURE_FIELD_BASE; fieldIdx < fields.length; fieldIdx++) {
+    const field = fields[fieldIdx]!;
+    // Layout: [funcref, arity, ...captures, ...__tdz_* flags, __constructible?].
+    if (field.name.startsWith("__tdz_") || field.name === "__constructible") continue;
+    // The ctor body's own bindings win: a user param or hoisted local with the
+    // captured name shadows the outer capture, matching the closure body.
+    if (ctorFctx.localMap.has(field.name)) continue;
+
+    const local = allocLocal(ctorFctx, field.name, field.type);
+    ctorFctx.localMap.set(field.name, local);
+    spills.push({ fieldIdx, local });
+
+    // A ref-cell field is a boxed (mutable / already-boxed) capture: register
+    // it so reads/writes inside the body dereference the cell, sharing writes
+    // with every other holder of the same cell.
+    const fieldType = field.type as ValType;
+    if (fieldType.kind === "ref_null" || fieldType.kind === "ref") {
+      const typeIdx = (fieldType as { typeIdx: number }).typeIdx;
+      if (ctx.typeIdxToStructName.get(typeIdx)?.startsWith("__ref_cell_")) {
+        const valType = refCellValueType(ctx, typeIdx);
+        if (valType) {
+          if (!ctorFctx.boxedCaptures) ctorFctx.boxedCaptures = new Map();
+          ctorFctx.boxedCaptures.set(field.name, { refCellTypeIdx: typeIdx, valType });
+        }
+      }
+    }
+  }
+  if (spills.length === 0) return;
+
+  const castLocal = allocLocal(ctorFctx, "__ctor_closure_cast", {
+    kind: "ref_null",
+    typeIdx: closureStructTypeIdx,
+  });
+  ctorFctx.body.push({ op: "local.get", index: identityParamIdx });
+  ctorFctx.body.push({ op: "any.convert_extern" });
+  ctorFctx.body.push({ op: "ref.test", typeIdx: closureStructTypeIdx });
+  ctorFctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: identityParamIdx },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: closureStructTypeIdx },
+      { op: "local.set", index: castLocal },
+      ...spills.flatMap((spill): Instr[] => [
+        { op: "local.get", index: castLocal },
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: closureStructTypeIdx, fieldIdx: spill.fieldIdx },
+        { op: "local.set", index: spill.local },
+      ]),
+    ],
+  });
+}

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -168,6 +168,7 @@ import {
 import { coercionInstrs, defaultValueInstrs } from "./type-coercion.js";
 import { tryEmitJsonParseElementAccess, tryEmitJsonParsePropertyAccess } from "./json-standalone.js";
 import { reserveMemberSetDispatch } from "./member-set-dispatch.js";
+import { alternateFieldArmRead } from "./alternate-field-arm.js";
 import { classMethodCandidatesForProp, reserveMemberGetDispatch } from "./member-get-dispatch.js";
 import { resolveReceiverStruct } from "./fnctor-escape-gate.js"; // (#2681/#2686 A3) pinned-struct read dispatch
 import { emitGuardedNativeStringElementGet } from "./string-element-read.js"; // (#3973) any-typed native-string element read
@@ -1313,13 +1314,9 @@ export function emitNullGuardedStructGet(
     const buildFallback = (srcLocal: number, altIdx: number): Instr[] => {
       if (altIdx < alternates.length) {
         const alt = alternates[altIdx]!;
-        const altCoerce = coercionInstrs(ctx, alt.fieldType, resultType, fctx);
-        const altRead: Instr[] = [
-          { op: "local.get", index: srcLocal },
-          { op: "ref.cast", typeIdx: alt.structTypeIdx },
-          { op: "struct.get", typeIdx: alt.structTypeIdx, fieldIdx: alt.fieldIdx },
-          ...altCoerce,
-        ];
+        // null = this shape cannot produce `resultType`; skip the arm.
+        const altRead = alternateFieldArmRead(ctx, fctx, alt, resultType, srcLocal);
+        if (!altRead) return buildFallback(srcLocal, altIdx + 1);
         return [
           { op: "local.get", index: srcLocal },
           { op: "ref.test", typeIdx: alt.structTypeIdx },
@@ -1797,13 +1794,9 @@ export function emitExternrefToStructGet(
   const buildFallbackChain = (altIdx: number): Instr[] => {
     if (altIdx < alternates.length) {
       const alt = alternates[altIdx]!;
-      const altCoerce = coercionInstrs(ctx, alt.fieldType, resultType, fctx);
-      const altRead: Instr[] = [
-        { op: "local.get", index: tmpAny },
-        { op: "ref.cast", typeIdx: alt.structTypeIdx },
-        { op: "struct.get", typeIdx: alt.structTypeIdx, fieldIdx: alt.fieldIdx },
-        ...altCoerce,
-      ];
+      // null = this shape cannot produce `resultType`; skip the arm.
+      const altRead = alternateFieldArmRead(ctx, fctx, alt, resultType, tmpAny);
+      if (!altRead) return buildFallbackChain(altIdx + 1);
       return [
         { op: "local.get", index: tmpAny },
         { op: "ref.test", typeIdx: alt.structTypeIdx },

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -3470,7 +3470,15 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
     // Fallback: static unrolling. Used in standalone for a closed-shape receiver
     // (WasmGC struct) — the static key set is exact — and as the historical
     // fallback when no enumeration primitive is available.
-    const exprType = ctx.checker.getTypeAtLocation(stmt.expression);
+    // (#4138) Strip null/undefined before reading the static shape: a receiver
+    // that flowed through `Array.pop()` / an optional access types as
+    // `T | undefined`, and a UNION's getProperties() is the COMMON property
+    // set — empty here — so the loop silently enumerated nothing (the runtime
+    // null case is already handled by the guards the loop emits). This is the
+    // narrow slice of #4138; a receiver that is genuinely POLYMORPHIC at
+    // runtime still unrolls one static shape, and closed structs remain
+    // non-enumerable through the dynamic runtime — both stay open in #4138.
+    const exprType = ctx.checker.getTypeAtLocation(stmt.expression).getNonNullableType();
     const props = exprType.getProperties();
     if (props.length === 0) return;
     for (const prop of props) {

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -23,6 +23,7 @@
 // That's the whole point of the symbolic-ref design — spec #1131 §1.2.
 
 import { ts } from "../ts-api.js";
+import { acceptsStaticNumericArrayParam, staticNumericArrayGlobalMatches } from "./select-vector-slots.js";
 import { makeIrHostDateSnapshotResolver } from "./host-date.js";
 import { supportsIrBackendTargetCapability, type IrBackendTargetCapability } from "./backend/legality.js";
 
@@ -3407,28 +3408,18 @@ function resolveRetainedFunctionMethod(
   return { receiverGlobal, funcName };
 }
 
-function sameExactValType(left: ValType, right: ValType): boolean {
-  if (left.kind !== right.kind) return false;
-  if (left.kind === "ref" || left.kind === "ref_null") {
-    return right.kind === left.kind && left.typeIdx === right.typeIdx;
-  }
-  return true;
-}
-
 function resolveStaticNumericArrayGlobal(
   ctx: CodegenContext,
   plan: IrStaticNumericArrayPlan,
   expected: IrType,
 ): { readonly globalRef: IrGlobalRef; readonly type: IrType } {
-  const expectedVal = asVal(expected);
   if (
     plan.globalBindingId === undefined ||
     plan.storageOwnerUnitId === undefined ||
     plan.sourceId === undefined ||
     plan.declarationOrdinal === undefined ||
     !ts.isIdentifier(plan.declaration.name) ||
-    expectedVal === null ||
-    (expectedVal.kind !== "ref" && expectedVal.kind !== "ref_null")
+    !acceptsStaticNumericArrayParam(expected)
   ) {
     throw new IrInvariantError(
       "selection-preparation-mismatch",
@@ -3453,7 +3444,8 @@ function resolveStaticNumericArrayGlobal(
     const globalIdx = ctx.moduleGlobals.get(name);
     global = globalIdx === undefined ? undefined : ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
   }
-  if (!global || global.name !== globalName || !sameExactValType(global.type, expectedVal)) {
+  const nameOf = (i: number) => ctx.typeIdxToStructName.get(i);
+  if (!global || global.name !== globalName || !staticNumericArrayGlobalMatches(global.type, expected, nameOf)) {
     throw new IrInvariantError(
       "abi-type-index-mismatch",
       "build",
@@ -3508,11 +3500,10 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
       };
     },
     staticNumericArrayRead(expression: ts.Expression, expected: IrType) {
-      const expectedValue = asVal(expected);
       if (
         !supportsBackendCapability("legacy-numeric-array-global") ||
         !moduleBindingResolver ||
-        (expectedValue?.kind !== "ref" && expectedValue?.kind !== "ref_null")
+        !acceptsStaticNumericArrayParam(expected)
       ) {
         return null;
       }

--- a/src/ir/select-vector-slots.ts
+++ b/src/ir/select-vector-slots.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { ts } from "../ts-api.js";
+import { asVal, type IrType } from "./nodes.js";
+import type { ValType } from "./types.js";
 
 type ImplicitNumericVecPredicate = (parameter: ts.ParameterDeclaration) => boolean;
 type MutableSlotResolvedKind = "f64" | "bool" | "string" | "object" | "void" | "closure" | "dynamic";
@@ -39,4 +41,54 @@ export function mutableParameterHasIrSlot(
     resolvedKind === "dynamic" ||
     (resolvedKind === "object" && parameterUsesNumericVecAbi(parameter, implicit))
   );
+}
+
+/**
+ * True for the IR type a direct-call plan gives an unannotated numeric-array
+ * parameter: `vec<f64>`. The annotation-driven overrides path types the same
+ * ABI as a raw `val ref` of the legacy `__vec_f64` struct instead — both
+ * lower to the identical ValType, and the static numeric-array admission
+ * (`directCallParamUsesNumericVecAbi`) accepts both, so the build-side plan
+ * consumers must too. Accepting only the raw-ref shape made the selector
+ * over-claim and surfaced as the hard `identifier "…" is not in scope`
+ * invariant on acorn's `isIdentifierStart(code, astralIdentifierStartCodes)`.
+ */
+export function isNumericVecIrType(t: IrType): boolean {
+  return t.kind === "vec" && t.elementType.kind === "val" && t.elementType.val.kind === "f64";
+}
+
+/**
+ * True when `expected` is an acceptable static-numeric-array param type for
+ * the plan consumers: a raw ref/ref_null val, or the vec<f64> IR shape.
+ */
+export function acceptsStaticNumericArrayParam(expected: IrType): boolean {
+  if (isNumericVecIrType(expected)) return true;
+  const expectedVal = asVal(expected);
+  return expectedVal !== null && (expectedVal.kind === "ref" || expectedVal.kind === "ref_null");
+}
+
+/**
+ * Build-side twin: the module global backing a static numeric array must be
+ * type-compatible with the callee param. For the vec<f64> shape (no typeIdx
+ * to compare exactly) the verification goes through the struct-name registry
+ * — the global must actually be the legacy `__vec_f64` struct; the raw-ref
+ * shape keeps the exact ValType comparison via `sameVal`.
+ */
+export function staticNumericArrayGlobalMatches(
+  globalType: ValType,
+  expected: IrType,
+  structNameOf: (typeIdx: number) => string | undefined,
+): boolean {
+  if (isNumericVecIrType(expected)) {
+    return (
+      (globalType.kind === "ref" || globalType.kind === "ref_null") &&
+      structNameOf((globalType as { typeIdx: number }).typeIdx) === "__vec_f64"
+    );
+  }
+  const expectedVal = asVal(expected);
+  if (expectedVal === null || globalType.kind !== expectedVal.kind) return false;
+  if (globalType.kind === "ref" || globalType.kind === "ref_null") {
+    return (globalType as { typeIdx: number }).typeIdx === (expectedVal as { typeIdx: number }).typeIdx;
+  }
+  return true;
 }

--- a/tests/issue-4138-forin-nonnullable-receiver.test.ts
+++ b/tests/issue-4138-forin-nonnullable-receiver.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4138 (narrow slice) — for-in over a receiver typed `T | undefined`.
+ *
+ * A receiver that flowed through `Array.pop()` types as `T | undefined`, and a
+ * union's `getProperties()` is the COMMON property set — empty — so the
+ * standalone static-unroll path silently enumerated nothing (the walk in the
+ * acorn self-parse benchmark visited only the root). The static shape must be
+ * read off the non-nullable type; the loop's own guards already handle the
+ * runtime null case.
+ *
+ * The rest of #4138 (runtime-polymorphic receivers, closed-struct
+ * enumerability through the dynamic runtime) is deliberately NOT covered here.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const SRC = `
+export function bench() {
+  var root = { type: "A", kid: { type: "B" } };
+  var stack = [root];
+  var node = stack.pop();
+  var n = 0;
+  for (var k in node) { n = n + 1; }
+  return n;
+}
+`;
+
+describe("#4138 — for-in over a popped (T | undefined) receiver", () => {
+  // standalone-only: that is where the static-unroll branch decides the key
+  // set at compile time. The gc lane routes through the `__for_in_*` host
+  // imports and enumerates at runtime, so it was never affected.
+  it("enumerates the non-nullable shape's keys (standalone)", async () => {
+    const result = await compile(SRC, { fileName: "m.mjs", skipSemanticDiagnostics: true, target: "standalone" });
+    expect(result.binary.length).toBeGreaterThan(0);
+    const mod = await WebAssembly.compile(result.binary as BufferSource);
+    const instance = await WebAssembly.instantiate(mod, {});
+    expect((instance.exports.bench as () => number)()).toBe(2);
+  });
+});


### PR DESCRIPTION
## Description

Five independent compiler defects, found by compiling acorn 8.18 as a [test262.fyi cross-engine benchmark case](https://github.com/loopdive/test262-data/tree/claude/dev-microbenchmarks-js2wasm) and fixed in dependency order — each fix un-masked the next. Umbrella tracking: **#4145**.

| commit | defect | fix |
|---|---|---|
| `ae6f9cb6` | cross-frame capture argument sourced from a dead slot (`local index out of range`, `__closure_209`) | second sound cross-frame case in `closures/capture-source-slot.ts`; both prepend sites converge on it |
| `433b553f` | name-matched shape arm emits an unbridgeable `struct.get` (invalid wasm, `__closure_21`) | skip arms whose field type cannot reach the read's result type — `codegen/alternate-field-arm.ts` |
| `c7a57f35` | selector/build vec-ABI disagreement on numeric-array module vars (hard IR invariant, both targets) | accept the `vec<f64>` shape in the plan consumers — `select-vector-slots.ts` |
| `2ef595b7` | fnctor twin sibling captures from the declaring frame's dead slots (`__fnctor_Parser_new`) — **#4139** | twin prologue casts the standalone `__constructor_identity` param (already the ctor's closure value) and spills capture fields into frame locals — `fnctor-twin-captures.ts` |
| `659c0bf9` | stack-balance walker typed `local.tee` as a pass-through; wasm types a tee's result as the **local's declared type** (`__closure_0`, `expected (ref null 7), found (ref null 6)`) — **#4144** | tee arm pops and pushes `localTypes[idx]` |
| `77f080d0` | *(related)* for-in over a `T \| undefined` receiver silently enumerated nothing — **#4138** slice | static shape read off `getNonNullableType()` + regression test |

**Result:** acorn 8.18 UMD now compiles to a *validating* 2.3 MB module on `--target standalone` (previously: emit crash). The ESM-script form compiles, runs, and parses its own source in exact agreement with node acorn. On the cross-engine benchmark, js2's acorn cell went FAIL → 9.36× V8 (282 ms/parse).

### Open follow-ups (filed, not in this PR)

- **#4144** — executing the UMD module throws a module-level exception even for a tiny parse: a runtime semantic defect needing standalone error-payload tooling to diagnose.
- **#4139** — gc-target twins (no `__constructor_identity` param there).
- **#4138** — full heterogeneous for-in walk: runtime enumeration for polymorphic receivers + closed-struct enumerability (S3b/value-rep territory).
- **#4145** — umbrella tracking for acorn UMD end-to-end.

### Validation

- 119 closure/capture/property/member/struct/shape/`ir-*` test files: **byte-identical failure lists** (83 pre-existing) on clean `609c995c` vs the full stack.
- 39 fnctor/constructor files: byte-identical (25 pre-existing) for the twin fix.
- 43-file capture set re-verified after the tee fix: identical 23-failure list.
- `check:loc-budget` / `check:func-budget` / `check:oracle-ratchet` pass (allowances granted in the issue files where drivers grew by comments).
- Full-suite CI is the final gate.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: the CLA is a human attestation. Internal/org-member PRs skip the check automatically. -->