### PR TITLE
docs(#4119): re-measure, settle the #3170 attribution, re-scope the ladder

### DIFF
--- a/plan/issues/3170-standalone-array-search-methods-value-arraylike.md
+++ b/plan/issues/3170-standalone-array-search-methods-value-arraylike.md
@@ -176,3 +176,21 @@ Residual 42 split by bucket:
 - **Bucket 7** (`-9-5`/`-8-5`, harness/vacuity-artifact rows, not a real
   indexOf gap) — flagged to whoever owns the #3086 honest-vacuity oracle;
   not this issue's or #3317's concern.
+
+## Residual still live — re-confirmed 2026-08-03 (from #4119)
+
+Buckets 1 + 2 above are **still open and still correctly attributed here.**
+#4119 (the `array-object-proto.ts` refusal ladder) found 24 rows —
+`indexOf` 11, `lastIndexOf` 12, `includes` 1 — carrying the same
+`… is not yet callable as a value in --target standalone` string, and asked
+whether this issue's fix was partial or a second site had been missed.
+
+Verified from the test files themselves (standalone baseline
+`2026-08-03 19:17`): **neither.** Every one of the 24 is a primitive or exotic
+receiver — `applied to boolean primitive`, `to number primitive`,
+`to string primitive`, `to Function object`, `call-with-boolean.js` — i.e.
+exactly buckets 2 and 1 as written above. They were left deliberately, needing
+`ToObject(primitive)` / host-object dynamic length+index reads, and #4119 has
+**dropped** them from its scope rather than double-fixing.
+
+No action here; recorded so the next reader does not re-derive it.

--- a/plan/issues/4119-standalone-array-prototype-method-refusal-ladder.md
+++ b/plan/issues/4119-standalone-array-prototype-method-refusal-ladder.md
@@ -117,8 +117,112 @@ or it regressed; **verify against #2501's own repro before scoping**.
       `test262-standalone-current.jsonl`; report the delta with denominators.
       Target: both buckets → 0 refusals (the tests may still fail for other
       reasons; count refusals, not passes).
-- [ ] If any sub-bucket turns out to be owned by #3170 or #2501, close it here
-      and record which, rather than double-fixing.
+- [x] If any sub-bucket turns out to be owned by #3170 or #2501, close it here
+      and record which, rather than double-fixing. *(done 2026-08-03 — the 24
+      `indexOf`/`lastIndexOf`/`includes` rows are #3170's own known-blocked
+      residual, dropped from this issue; #2501's fix is a compile-time static
+      fold that cannot reach the reflective-closure shape, so the 76 stay
+      here. See the re-scope section above.)*
+
+## Re-measure + re-scope — 2026-08-03, `ttraenkler/dev-4120-typeof`
+
+Baselines re-fetched with `--force` (`test262-standalone-current.jsonl` @
+`2026-08-03 19:17`, main ≈ `e9f8bfaf3`). Denominator: **43,505 official
+standalone files, 16,240 non-pass**.
+
+| signature | issue said | fresh |
+| --- | ---: | ---: |
+| `… is not yet callable as a value in --target standalone` | 265 | **271** |
+| `… is not yet implemented in --target standalone` (ALL members) | — | **136** |
+| …of which `Object.prototype.toString` | 76 | **76** |
+
+The `not yet implemented` bucket is **136**, not 76 — the issue counted only the
+`Object.prototype.toString` slice of it. The other 60 are different members
+(`String.prototype.split` 12, `Promise.resolve` 9, `Array.from` 7, `Array.of` 6,
+`String.prototype.slice` 5, …) and are NOT in this issue's scope.
+
+Bucket 1 is **entirely** receiver `Array` (271/271).
+
+### The cheapest entry is SETTLED — and it is a third answer
+
+The issue asks whether the 23 (now 24, incl. `includes`) `indexOf`/`lastIndexOf`
+rows mean #3170's fix was **partial** or a **second site was missed**. Measured
+from the test files themselves, not from prose: **neither.**
+
+```
+15.4.4.14-1-3   Array.prototype.indexOf applied to boolean primitive
+15.4.4.14-1-5   Array.prototype.indexOf applied to number primitive
+15.4.4.14-1-7   Array.prototype.indexOf applied to string primitive
+15.4.4.14-1-9   Array.prototype.indexOf applied to Function object
+call-with-boolean.js  (indexOf / lastIndexOf / includes)
+```
+
+Every one is a **primitive or exotic-host receiver**. #3170's own write-up
+already names them as its residual buckets 1 and 2 — "Primitive receivers
+(~11) … Reflective closure body (`emitArrayProtoMemberBody`,
+array-object-proto.ts) still refuses everything but `slice`" and "Exotic
+host-object receivers (~10)" — and its re-scope decision explicitly left both
+as known-blocked, needing `ToObject(primitive)` and host-object dynamic
+length/index reads.
+
+**Decision: these 24 rows are DROPPED from #4119** and stay attributed to
+#3170's known-blocked residual. They are not a cheap entry point; they are the
+most expensive rows in the bucket.
+
+### What the bucket actually is
+
+- **`Array.prototype.map` = 147 of 271 (54 %).** Most of those rows are **not**
+  `Array/prototype/map` tests — they come from the test262 **harness**:
+  `deepEqual.js` calls `.map(…)` on array-likes, so any test that pulls in
+  `assert.deepEqual` hits the refusal. That is why the bucket spans `Promise/`,
+  `TypedArray/`, `language/expressions/await/`, `Object/`. Large lane-wide
+  leverage — but mostly OUTSIDE the ES5 goal scope, so it must not displace the
+  `Object.prototype.toString` arm, which carries the 72 ES5 slice/splice rows.
+  **Hazard when building it:** with the harness as the caller, a `map` that only
+  satisfies `deepEqual`'s usage would green rows without being correct. Build a
+  real §15.4.4.19 body (callback, `thisArg`, holes, array-like receivers) and
+  verify with direct-value probes; the harness passing is the outcome, never the
+  test.
+- **The mechanism is ONE site.** `emitArrayProtoMemberBody`
+  (`array-object-proto.ts`) implements **only `slice`**; every other member
+  falls to `emitThrowTypeError`. There is exactly **one**
+  `compileArray*FromVecLocal` core in the tree
+  (`compileArraySliceFromVecLocal`), so each further member needs its own
+  AST-free core — that, not the ladder wiring, is the cost.
+
+### A second defect sits on top of the refusal (measured)
+
+`typeof` of a reified `Array.prototype` method, through a parameter hop
+(standalone, `e9f8bfaf3`):
+
+| expression | `typeof` |
+| --- | --- |
+| `Array.prototype.slice` (member body IS implemented) | `"undefined"` |
+| `Array.prototype.map` (member body refuses) | `"undefined"` |
+
+`slice` is the control that matters: **implementing the member body does not
+make the reified value a function.** So a #4119 fix must ALSO produce a genuine
+callable carrier, not just a working body — and it must be a **closure-wrapper
+struct** (which the `typeof` natives already `ref.test`), *not* the
+`OBJ_FLAG_CALLABLE`-branded `$Object` added for #4120: that brand is for the
+reified builtin CONSTRUCTOR carriers and does not apply here. This is the
+6-row overlap #4120 recorded as its "mode 1".
+
+### Suggested ordering for whoever builds this
+
+1. `Object.prototype.toString` reflective body (**76**, of which 72 ES5) — the
+   bounded, goal-scoped arm. Note that #2501's fix is a **compile-time static
+   fold** keyed on the receiver's TS type and fires only for the syntactic
+   `Object.prototype.toString.call(v)` form, so it cannot serve a reflective
+   closure whose `this` is a runtime externref. #3201 solved the very same
+   `arr.getClass = Object.prototype.toString; arr.getClass()` idiom but **host
+   lane only** (`if (!ctx.standalone && !ctx.wasi)`), and its own comment calls
+   the native dispatcher's coverage "a follow-up" — this bucket is that
+   follow-up. It needs a RUNTIME `[object X]` classifier (chained `ref.test`
+   over vec / closure-wrapper / `$Object` / boxed-primitive types), the same
+   shape as the `__typeof` native.
+2. `Array.prototype.map` (**147**) — highest leverage, mostly out of ES5 scope.
+3. The 100-odd remaining bucket-1 members, ≤7 rows each.
 
 ## Reproduction
 


### PR DESCRIPTION
Docs-only. Re-measures #4119, settles its open question against #3170, and
re-scopes the ladder for whoever builds it. No code changes.

## Fresh populations

Standalone baseline re-fetched with `--force` (`2026-08-03 19:17`, main ≈
`e9f8bfaf3`). Denominator **43,505 official / 16,240 non-pass**.

| signature | issue said | fresh |
| --- | ---: | ---: |
| `… is not yet callable as a value in --target standalone` | 265 | **271** |
| `… is not yet implemented in --target standalone` (all members) | — | **136** |
| …of which `Object.prototype.toString` | 76 | **76** |

## The open question is settled — with a third answer

#4119 asked whether the 23 (now 24, incl. `includes`) `indexOf`/`lastIndexOf`
rows meant #3170's fix was **partial** or a **second site was missed**.
Verified from the test files, not the prose: **neither.** Every one is
`applied to boolean/number/string primitive` or `to Function object` — i.e.
#3170's own documented residual buckets 1 and 2, left deliberately because they
need `ToObject(primitive)` / host-object dynamic length+index reads.

So they are the **most expensive** rows in the bucket, not the cheapest entry.
Dropped from #4119; a residual note is added to #3170 so the next reader does
not re-derive it.

## Also recorded

- **`Array.prototype.map` is 147 of 271**, and most of those rows are not
  `Array/prototype/map` tests — they come from the test262 **harness**
  (`deepEqual.js` calls `.map` on array-likes), which is why the bucket spans
  `Promise/`, `TypedArray/`, `await/`. Big lane-wide leverage but mostly
  outside ES5 goal scope. Hazard noted in the issue: with the harness as the
  caller, a `map` that satisfies only `deepEqual`'s usage would green rows
  without being correct.
- **One site, one core.** `emitArrayProtoMemberBody` implements only `slice`,
  and `compileArraySliceFromVecLocal` is the only `*FromVecLocal` core in the
  tree — that, not the ladder wiring, is the cost per member.
- **A second defect sits on top of the refusal.** `typeof` of a reified
  `Array.prototype` method through a parameter: `slice` (body IS implemented)
  and `map` (body refuses) **both** answer `"undefined"`. `slice` is the
  control — implementing the body does not make the value a function. The fix
  needs a closure-wrapper carrier, **not** #4120's `OBJ_FLAG_CALLABLE`
  `$Object` brand (that is for reified builtin *constructors*).
- **#2501 cannot reach this shape** — it is a compile-time static fold keyed on
  the receiver's TS type, firing only for syntactic
  `Object.prototype.toString.call(v)`. **#3201** solved the exact
  `arr.getClass = Object.prototype.toString; arr.getClass()` idiom but **host
  lane only**, and its own comment calls the native side "a follow-up". This
  76-row bucket is that follow-up; it needs a runtime `[object X]` classifier.

## Suggested build order

1. `Object.prototype.toString` reflective body — **76**, of which 72 are the
   ES5 `slice`/`splice` rows this dispatch exists for. Bounded and goal-scoped.
2. `Array.prototype.map` — 147, highest leverage, mostly out of ES5 scope.
3. The ~100 remaining bucket-1 members, ≤7 rows each.

Not built here: the budget window is at 16 % remaining with a ~2 % per-agent
share (horizon `S`), and the runtime `[object X]` classifier is not `S`-sized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
