### PR TITLE
fix(#4140): the npm-compat promote PUSH runs husky too — and the retry loop lied about why

### DIFF
--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -245,21 +245,35 @@ jobs:
               exit 0
             fi
 
-            # (#4132) --no-verify: this job installs dependencies, so husky's
-          # pre-commit hook is live, and it runs `test:changed-root`, which needs
-          # a merge base with `origin/main`. The checkout is `fetch-depth: 1`
-          # with `persist-credentials: false` and the push remote is `deploykey`,
-          # so `origin/main` does not exist and the hook aborts the commit:
-          #   "changed-root-tests: cannot resolve a merge base with origin/main"
-          # The sibling `benchmark-refresh` is immune only structurally — its
-          # promote job is separate and never runs `pnpm install`, so no hook is
-          # installed. This workflow is deliberately a SINGLE job, so it has to
-          # opt out explicitly. Running the changed-root suite over generated
-          # JSON artifacts would be meaningless anyway.
-          git commit -q --no-verify -m "chore(ci): refresh npm-compat artifacts [skip ci]"
-            if git push deploykey HEAD:main; then
+            # (#4132/#4140) --no-verify on BOTH the commit and the push. This job
+            # installs dependencies, so husky's hooks are live:
+            #   pre-commit runs `test:changed-root`, which needs a merge base with
+            #     `origin/main`;
+            #   pre-push  runs the oracle ratchet, which fails here too.
+            # The checkout is `fetch-depth: 1` with `persist-credentials: false`
+            # and the push remote is `deploykey`, so `origin/main` does not exist
+            # and neither hook can do its job. The sibling `benchmark-refresh` is
+            # immune only structurally — its promote job is separate and never
+            # runs `pnpm install`, so no hook is installed. This workflow is
+            # deliberately a SINGLE job and has to opt out explicitly. Running
+            # either check over generated JSON artifacts would be meaningless.
+            git commit -q --no-verify -m "chore(ci): refresh npm-compat artifacts [skip ci]"
+
+            # (#4140) Distinguish a genuine mid-promotion race from any other push
+            # failure. Replaying only helps when main moved under us; for
+            # anything else the replay is guaranteed to fail identically, and it
+            # buries the real error under five rounds of a MISLEADING message.
+            # That is exactly how a rejected pre-push hook read as "main advanced
+            # mid-promotion" for a full cycle.
+            push_err="$(mktemp)"
+            if git push --no-verify deploykey HEAD:main 2>"$push_err"; then
               echo "Published npm-compat artifacts measured at ${SOURCE_SHA}."
               exit 0
+            fi
+            cat "$push_err"
+            if ! grep -Eqi 'non-fast-forward|fetch first|behind its remote|stale info' "$push_err"; then
+              echo "::error::npm-compat push failed for a reason that replaying cannot fix (see above)."
+              exit 1
             fi
             echo "push rejected (main advanced mid-promotion); replaying onto the new head — attempt ${attempt}/5."
           done

--- a/plan/issues/4140-npm-compat-promote-push-hook-and-misleading-replay.md
+++ b/plan/issues/4140-npm-compat-promote-push-hook-and-misleading-replay.md
@@ -1,0 +1,100 @@
+---
+id: 4140
+title: "npm-compat promotion STILL fails: the commit was opted out of husky but the PUSH was not, and the retry loop reports every push failure as a mid-promotion race"
+status: done
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+completed: 2026-08-03
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: tooling, ci
+language_feature: none
+goal: dogfood
+related: [4130, 4132, 3988, 4127]
+origin: "the third blocker, found by watching the first refresh run that carried both prior fixes — 2026-08-03"
+---
+
+# #4140 — the promote PUSH runs husky too
+
+## How this surfaced
+
+Third blocker in a chain. #4130 fixed the staleness floor so the gate stops
+deferring; #4132 fixed the pre-COMMIT hook. Run `30843466125` (18:55, the first
+with both) got further than any before it — the promote step ran for **6
+minutes** instead of failing in 11 seconds — and still failed.
+
+The artifact has now been stuck on the manual 2026-08-01 snapshot
+(`3ffd8ed5c`) through three separate causes.
+
+## Root cause A — the push runs the pre-push hook
+
+```
+Fix direct checker growth before pushing, or use --no-verify (CI will catch).
+error: failed to push some refs to 'github.com:loopdive/js2.git'
+```
+
+#4132 added `--no-verify` to `git commit` and **not** to `git push`. Both hooks
+are live in this job because it runs `pnpm install`:
+
+| hook | runs | why it fails here |
+| ---- | ---- | ----------------- |
+| pre-commit | `test:changed-root` | needs a merge base with `origin/main` |
+| pre-push | oracle ratchet | reports huge "direct checker growth" |
+
+The checkout is `fetch-depth: 1` with `persist-credentials: false` and the push
+remote is `deploykey`, so `origin/main` does not exist and neither hook can do
+its job. The hook's own message even suggests the remedy ("or use `--no-verify`
+(CI will catch)") — and CI does catch it: the ratchet is a required check on
+every PR.
+
+This one is mine. #4132's PR said "if a third blocker sits behind this one, the
+same method applies" — and the third blocker was one line below the line I
+changed.
+
+## Root cause B — the retry loop mislabels every failure as a race
+
+```
+push rejected (main advanced mid-promotion); replaying onto the new head — attempt 5/5.
+::error::could not publish npm-compat artifacts after 5 replay attempts.
+```
+
+The loop treats ANY push failure as "main advanced mid-promotion" and replays
+five times. Replaying only helps for a genuine non-fast-forward. For a rejected
+hook the replay fails identically every time, and the honest error
+(`Fix direct checker growth before pushing`) is buried under five rounds of a
+confident, wrong diagnosis.
+
+That is why this took an extra cycle to find: the log's own summary line said
+"race", and it was not a race.
+
+## Fix
+
+1. `git push --no-verify` alongside the existing `git commit --no-verify`.
+2. Capture the push's stderr and replay **only** on race markers
+   (`non-fast-forward` / `fetch first` / `behind its remote` / `stale info`).
+   Anything else fails immediately with the real message surfaced.
+
+Also re-indents #4132's comment block, which I left mis-indented.
+
+## Acceptance criteria
+
+- [x] The promote step pushes without invoking the pre-push hook.
+- [x] A non-race push failure exits immediately with the underlying error
+      instead of five misleading replays.
+- [x] Structural guard extended in
+      `tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts` — asserts
+      `--no-verify` on the push and the race-marker discrimination.
+- [x] Both new assertions demonstrated to FAIL against main's version
+      (2 of 9 fail without the fix; 9 of 9 pass with it).
+
+## Not yet verified
+
+**The artifact has still never moved.** Three fixes in, and the only evidence
+that counts is `npm-compat-perf.json` leaving `3ffd8ed5c`. Do not record this
+chain as working until that commit line changes. If a FOURTH blocker appears,
+read the failing step — the pattern so far is that each fix reveals the next
+one, and twice the log's own summary line pointed the wrong way.

--- a/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
+++ b/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
@@ -71,6 +71,23 @@ describe("#4132 — the promotion commit must not run the pre-commit hook", () =
   it("keeps the [skip ci] marker that breaks the trigger loop", () => {
     expect(workflow.slice(at("- name: Promote"))).toContain("[skip ci]");
   });
+
+  // (#4140) The commit was fixed and the PUSH was not, so the promotion still
+  // failed — on husky's pre-push hook (the oracle ratchet) instead of
+  // pre-commit. Both hooks are live in this job; both must be opted out.
+  it("also pushes with --no-verify", () => {
+    expect(workflow.slice(at("- name: Promote"))).toMatch(/git push[^\n]*--no-verify/);
+  });
+
+  it("does not replay a push failure that replaying cannot fix", () => {
+    // Replaying only helps when main moved under us. For any other failure the
+    // replay fails identically five times and buries the real error under a
+    // MISLEADING "main advanced mid-promotion" message — which is exactly how a
+    // rejected pre-push hook stayed hidden for a full cycle.
+    const promote = workflow.slice(at("- name: Promote"));
+    expect(promote).toMatch(/non-fast-forward\|fetch first/);
+    expect(promote).toContain("replaying cannot fix");
+  });
 });
 
 describe("#4130 — the gate's own decision function", () => {


### PR DESCRIPTION
## Description

Closes #4140. Third blocker in the chain after #4130 (PR #4082) and #4132 (PR #4084), both merged.

**#4132 worked, and was not enough — again.** Run `30843466125` (18:55, the first carrying both prior fixes) got further than any before it: the promote step ran for **6 minutes** instead of failing in 11 seconds. It still failed, and the artifact is still the manual 2026-08-01 snapshot.

```
6  Capture the COMMITTED artifact's age    success
9  Gate the main push on the merge queue   success
10 Promote the refreshed artifacts to main FAILURE   ← got past the commit, died on the push
```

## Root cause A — the push runs the pre-push hook

```
Fix direct checker growth before pushing, or use --no-verify (CI will catch).
error: failed to push some refs to 'github.com:loopdive/js2.git'
```

#4132 added `--no-verify` to `git commit` and **not** to `git push`. Both hooks are live because this job runs `pnpm install`:

| hook | runs | why it fails here |
|---|---|---|
| pre-commit | `test:changed-root` | needs a merge base with `origin/main` |
| pre-push | oracle ratchet | reports large "direct checker growth" |

Checkout is `fetch-depth: 1` with `persist-credentials: false` and the push remote is `deploykey`, so `origin/main` doesn't exist and neither hook can do its job. The hook's own message suggests the remedy — *"or use `--no-verify` (CI will catch)"* — and CI genuinely does catch it: the ratchet is a required check on every PR.

**This one is mine.** #4132's PR body said *"if a third blocker sits behind this one, the same method applies"*. It did, and it was one line below the line I changed.

## Root cause B — the retry loop mislabels every failure as a race

```
push rejected (main advanced mid-promotion); replaying onto the new head — attempt 5/5.
::error::could not publish npm-compat artifacts after 5 replay attempts.
```

The loop treats *any* push failure as a mid-promotion race and replays five times. Replaying only helps for a genuine non-fast-forward; for a rejected hook it fails identically every time and buries the real error under five rounds of a confident, wrong diagnosis.

That's why this cost an extra cycle — **the log's own summary line said "race", and it was not a race.**

## Fix

1. `git push --no-verify` alongside the existing `git commit --no-verify`.
2. Capture the push's stderr and replay **only** on race markers (`non-fast-forward` / `fetch first` / `behind its remote` / `stale info`). Anything else exits immediately with the underlying message surfaced.

Also re-indents #4132's comment block, which I left mis-indented.

## Testing

Guard extended in `tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts` — asserts `--no-verify` on the push and the race-marker discrimination. **9/9 pass with the fix; the 2 new assertions fail against main's version.** YAML re-parsed to confirm the block edit is structurally sound.

`check:issues`, `check:issue-spec-coverage`, `check:done-status-integrity`, `lint` pass.

## Not yet verified

**The artifact has still never moved.** Three fixes in, and the only evidence that counts is `npm-compat-perf.json` leaving `3ffd8ed5c` (2026-08-01). Please don't record this chain as working until that commit line changes.

If a fourth blocker appears, read the failing step. The pattern so far is that each fix reveals the next, and **twice the log's own summary line pointed the wrong way** — first a green run that committed nothing, now a "race" that was a hook rejection.

## CLA

- [x] I have read and agree to the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_013rC8ahHETYHdMDfkG4xBKE)_