### PR TITLE
fix(#4141): heal poison rows under the shards' proposal scope; treat baseline `skip` as can't-testify

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -2336,6 +2336,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Heal poison-classified rows (#2099)
+        # (#4141) HEAL/SHARD SCOPE PARITY — load-bearing, do not drop.
+        # `heal-poison-rows.ts` re-runs each poison row through
+        # `runTest262File`, which applies `shouldSkip` → `classifyTestScope`.
+        # Without this env the healer's process disagrees with the shard
+        # process that produced the row: `built-ins/Temporal/**` classifies as
+        # a *proposal* and the re-run returns `status: "skip"` instead of the
+        # row's true verdict. That laundered ~1,229 real Temporal traps into
+        # baseline `skip` rows (all carrying `poison_healed: true` and
+        # `error: "Proposal excluded from default scope: proposal feature:
+        # Temporal"`), while the candidate JSONL — which is never healed —
+        # kept them as traps. The trap ratchet then charged the whole delta to
+        # whatever PR happened to be in the merge group (`null_deref
+        # 156 → 1360`), parking #4074 and #4088 on a phantom regression.
+        # The expression MIRRORS the `test262-shard` job's env (~L723) exactly
+        # rather than hardcoding "1", so an `include_proposals: false` dispatch
+        # heals under the same scope its shards ran under.
+        env:
+          TEST262_INCLUDE_PROPOSALS: ${{ github.event_name != 'workflow_dispatch' && '1' || (inputs.include_proposals && '1' || '0') }}
         run: |
           npx tsx scripts/heal-poison-rows.ts \
             --in  shard-artifacts/test262-results-merged.jsonl \
@@ -3173,6 +3191,14 @@ jobs:
 
       - name: Heal poison-classified rows (#2099 parity)
         if: steps.group.outputs.found == 'true'
+        # (#4141) Same heal/shard scope parity as `promote-baseline` — see the
+        # long comment there. This job is `push` + merge-queue-bot only, so it
+        # always corresponds to the shards' non-dispatch branch ("1"); it can
+        # never be an `include_proposals: false` dispatch. Without it the
+        # per-SHA cached base (the #3467 regression base every later PR diffs
+        # against) carries the same laundered Temporal `skip` rows.
+        env:
+          TEST262_INCLUDE_PROPOSALS: "1"
         run: |
           # Match promote-baseline: heal contamination-poison rows before the
           # base is persisted, so no phantom "Binary emit error" row is carried

--- a/plan/issues/4141-heal-poison-rows-scope-asymmetry-phantom-trap-growth.md
+++ b/plan/issues/4141-heal-poison-rows-scope-asymmetry-phantom-trap-growth.md
@@ -1,0 +1,155 @@
+---
+id: 4141
+title: "merge_group trap ratchet charges ~1,200 baseline-skip Temporal rows to the candidate as new null_deref traps — the baseline heal step runs without TEST262_INCLUDE_PROPOSALS, so it launders real traps into `skip`"
+status: done
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+completed: 2026-08-03
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: ci, tooling
+language_feature: none
+goal: dogfood
+related: [3189, 3595, 3596, 2099, 3467, 2547, 4142]
+origin: "PRs #4074 and #4088 auto-parked in different lanes with a byte-identical phantom regression, 2026-08-03"
+---
+
+# #4141 — heal/shard scope asymmetry manufactures phantom trap growth
+
+## Symptom
+
+Two unrelated PRs in different lanes (#4074 `claude/eslint-compiler-performance-o12y0w`,
+#4088 `claude/js2-cross-frame-capture-slot`) were auto-parked by
+`auto-park-bot:merge-group-failure` with the **byte-identical** gate delta:
+
+```
+skip       1322 → 115   (−1207)
+null_deref  156 → 1360  (+1204)
+Regressions excluding compile_timeout: 0
+```
+
+with the host fine-gate net **positive** and **zero** `pass → trap` transitions.
+
+Two facts make this not-a-codegen-regression on their face:
+
+- a codegen change cannot **un-skip** 1,200 tests — skipping is a
+  pre-compile scope decision, nothing a compiler diff can reach;
+- the delta is identical across two independent branches, so it is a property
+  of the *comparison*, not of either branch.
+
+## Root cause — the healer runs under a different scope than the shards
+
+1. `scripts/heal-poison-rows.ts` (#2099) re-runs contamination-poison rows
+   through `runTest262File(...)`. For a non-`negative` test that applies
+   `shouldSkip` → `classifyTestScope`, and `built-ins/Temporal/**` classifies
+   as a **proposal** — skipped unless `TEST262_INCLUDE_PROPOSALS === "1"`.
+2. The shard jobs set that env (`test262-shard` ~L723, `mg-test262-shard`
+   ~L896). **The two heal steps did not** (`promote-baseline` ~L2338,
+   `write-run-cache-bot` ~L3174). So a Temporal poison row that the shard had
+   measured as a real trap was re-run in a process where the same file is out
+   of scope, and the healer wrote back `status: "skip"`.
+3. Healing runs on the **baseline** path only. `merge-report` (~L991), which
+   builds the **candidate** JSONL, does not heal — so the candidate keeps those
+   rows as traps.
+4. `scripts/diff-test262.ts` excluded only `compile_timeout` / `compile_error` /
+   absent from the #3595 "baseline can't testify" set. `skip` was not in it, so
+   the whole asymmetry landed as trap growth on whatever PR was in the group.
+
+Measured on the live baseline (`test262-current.jsonl`, 48,368 rows,
+fetched 2026-08-03):
+
+| count | rows |
+| --- | --- |
+| 1,344 | baseline `skip` rows total |
+| 1,229 | of those carry `poison_healed: true` |
+| 1,229 | of those are `built-ins/Temporal/**` with `error: "Proposal excluded from default scope: proposal feature: Temporal"` |
+| 115 | genuine skips — **exactly the `115` the gate reported for the candidate** |
+
+Every single `poison_healed` row in the baseline is one of these; the laundering
+is 100 % of the healed population. A representative row:
+
+```json
+{"file":"test/built-ins/Temporal/PlainDate/prototype/subtract/basic.js","status":"skip",
+ "reached_test":false,"compile_ms":4827,"scope":"proposal","retried":true,"retry_count":1,
+ "poison_healed":true,"error":"Proposal excluded from default scope: proposal feature: Temporal"}
+```
+
+`compile_ms: 4827` on a row claiming to be skipped is the tell: the *shard*
+compiled it for nearly 5 s, then the *healer* overwrote the verdict with a scope
+decision.
+
+## Why #4087 / #4086 / #4084 "passed the same gate"
+
+They are not controls. Their `merge_group` runs had every shard job skipped by
+`detect test262-relevant changes`, so the shards never executed and no candidate
+JSONL was produced to diff. Any PR whose merge_group run actually runs the
+shards hits this.
+
+## Fix
+
+**(1) Root cause** — set `TEST262_INCLUDE_PROPOSALS` on both heal steps so the
+healer's scope matches the shard's. `promote-baseline` mirrors the shard's own
+expression (`github.event_name != 'workflow_dispatch' && '1' || …`) rather than
+hardcoding `"1"`, so an `include_proposals: false` dispatch heals under the
+scope its shards actually ran under. `write-run-cache-bot` is push +
+merge-queue-bot only, so it is always the non-dispatch branch: `"1"`.
+
+**(2) Defense in depth** — add `skip` to the baseline-can't-testify exclusion in
+`evaluateTrapCategoryGrowth`. A skipped test was never compiled and never
+instantiated, so the baseline made no runtime observation of it at all; a
+candidate trap is *unknown*, not *introduced*. This is correct on its own merits
+for every skip reason (scope filter, `HANGING_TESTS`, feature filter) and does
+not depend on the healer bug. It is **narrow**: a baseline that actually ran
+(`pass` or `fail`) and now traps still fails the ratchet, hard.
+
+**(3) Healing the candidate too — deliberately NOT done.** Symmetry could also
+be restored by healing `merge-report`'s candidate JSONL, but that is the wrong
+lever here and would have been a worse fix:
+
+- it does not remove the defect, it *balances* it — both sides would then
+  launder Temporal traps into `skip`, which silently drops ~1,200 real traps
+  out of the measured population on both sides. The gate would go quiet by
+  becoming blinder.
+- with (1) applied, there is nothing left to symmetrise: healed rows record
+  their true `fail`/trap verdict, so a healed baseline and an unhealed
+  candidate agree on scope.
+- it adds a multi-minute serial re-run to the critical path of every
+  `merge_group`, which is the most latency-sensitive job in the queue.
+
+Healing the candidate remains defensible for the *original* #2099 reason
+(a phantom "Binary emit error" in a candidate row), but that is a separate
+question and should not ride along on a ratchet fix.
+
+## Loose end filed separately
+
+The heal steps also omit `TEST262_FULL_RUNTIME_EVAL`, which the **standalone**
+shard lane sets to `1` (with the `runtime-eval-provider` artifact downloaded).
+A standalone poison row healed without it is re-run on the REFUSAL provider
+tier, which `scripts/runtime-eval-provider.mjs` itself labels "NOT
+CI-comparable" — the same class of heal/shard asymmetry as this bug. It is not
+fixed here because setting the env alone is a no-op (the heal jobs have no
+provider cache); it needs the artifact wired into those jobs. Tracked in #4142's
+sibling note — see the PR body.
+
+## Acceptance criteria
+
+- [x] Both heal steps run under the shard lane's proposal scope.
+- [x] A baseline `skip` row cannot contribute trap-category growth.
+- [x] A genuine `pass → trap` or `fail → trap` transition still fails the gate,
+      including when it is hidden inside a large skip-unknown bucket.
+- [x] `TRAP_RATCHET_TOLERANCE` untouched; no `trap-growth-allow` granted.
+- [x] Unit coverage in `tests/issue-4141-trap-growth-baseline-skip.test.ts`,
+      including a scaled reconstruction of the +1204 phantom.
+
+## Diagnostics also fixed
+
+The gate printed `(baseline compile_timeout)` for **every** unknown, hardcoded
+at the reporting site. That has been wrong since #3595 added `compile_error`,
+and it actively misleads triage: it tells the reader the predecessor timed out
+when it in fact never ran. It now prints the row's real baseline status plus a
+per-status summary, and caps the per-file listing at 50 so a bulk producer-side
+asymmetry cannot bury the summary line under a 1,200-line dump.

--- a/plan/issues/4142-auto-park-bot-false-batch-membership.md
+++ b/plan/issues/4142-auto-park-bot-false-batch-membership.md
@@ -1,0 +1,128 @@
+---
+id: 4142
+title: "auto-park bot reports a false batched-merge-group membership list — it enumerates the whole compare range, so a PR branch's merged-in main commits and issue references are parsed as co-member PRs"
+status: ready
+sprint: current
+created: 2026-08-03
+updated: 2026-08-03
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ci, tooling
+language_feature: none
+goal: dogfood
+related: [3914, 2547, 4141, 4074, 4088]
+origin: "observed on #4074's park comment while diagnosing #4141, 2026-08-03"
+---
+
+# #4142 — the auto-park bot invents batch co-members
+
+## Symptom
+
+The `auto-park-bot:merge-group-failure` comment on **#4074** declared:
+
+> **This was a batched merge group** (#4001, #4029, #4033, #4045, #4075, #4133).
+> The failure is attributed to the group as a whole — any member could be the
+> cause, so all of them are parked. Re-enqueue them ONE AT A TIME to attribute
+> the failure before removing `hold` from the rest.
+
+None of that is true:
+
+- **#4001, #4029, #4033, #4045 all merged on 2026-08-02**, a day before this
+  merge group existed. They cannot be members of it.
+- **#4075 and #4133 are issue ids, not PRs at all.**
+- Every queue ref involved was `gh-readonly-queue/main/pr-4074-<base>` with
+  **exactly two parents** (the queue base and this PR's head) — i.e. the group
+  was **solo**, as the serial queue (`min_entries_to_merge: 1`) guarantees.
+
+So the group had one member, #4074, and the bot named six others.
+
+## Root cause
+
+`prNumbersInGroup()` in `scripts/auto-park-merge-group-failure.mjs` enumerates
+membership from the **compare API over the whole range**:
+
+```js
+ghMaybe(["api", `repos/${REPO}/compare/${baseSha}...${headSha}`, "--jq", ".commits[].commit.message"]);
+```
+
+then feeds every subject to `prNumbersFromCommitSubjects()`, which matches
+either `^Merge pull request #(\d+)` or `\(#(\d+)\)\s*$`.
+
+The base sha comes from the queue branch name and is an ancestor of the head, so
+the range returns **every commit the queue entry's merge commit introduced** —
+which is the PR branch's entire unique history, not one commit per group entry.
+Two distinct leaks follow:
+
+1. **Merged-in main commits.** #4074's branch had `origin/main` merged into it
+   (correct per the merge protocol — never rebase). Every main-side squash
+   commit it absorbed carries a `title (#N)` subject and is read as a co-member.
+   That is exactly where #4001/#4029/#4033/#4045 came from: they are commits the
+   branch *contains*, not PRs the group *holds*.
+2. **Issue references are indistinguishable from squash refs.** `(#4133)` at the
+   end of a subject matches the squash pattern whether it refers to a PR or an
+   issue — and in this repo PR numbers and issue ids share ONE sequence, so
+   there is no numeric range test that could separate them. #4075/#4133 are
+   issues.
+
+The `--self-check` fixtures at L361-387 only exercise clean, hand-written
+subjects; nothing in them resembles a real long-lived branch's history, so the
+unit checks pass while the production path is wrong.
+
+## Why it matters
+
+The bot prints an explicit protocol — "re-enqueue them ONE AT A TIME to
+attribute the failure" — and then hands over a list that makes that protocol
+impossible to follow. Concretely, during the #4141 investigation three parks
+were initially read as unattributed because the membership list pointed at PRs
+that had merged the previous day. It also means the bot may add `hold` to
+unrelated open PRs whose numbers happen to appear in a branch's history,
+stranding them (a held PR is skipped by `auto-enqueue` and never recovers on
+its own).
+
+The failure direction is the bad one: it over-parks and misattributes, and the
+misattribution is *confident* — it is printed as a positive claim, not a guess.
+
+## Suggested fix
+
+Enumerate membership from the queue head's **commit graph**, not from a compare
+range. Each queue entry is one merge commit stacked on the base, so the members
+are the merge commits on the **first-parent path** from `head` back to `base`,
+and each contributes only its **own** subject:
+
+```
+git rev-list --first-parent <base>..<head>      # one commit per queue entry
+```
+
+via `repos/{REPO}/commits?sha=<head>` walking `parents[0]` until `<base>`, or the
+compare API filtered to first-parent-path commits. A commit reachable only
+through `parents[1]` (the PR branch's own history) must never contribute a
+number.
+
+Secondary hardening, both cheap:
+
+- Only accept `^Merge pull request #(\d+)` for **queue** commits; the squash
+  pattern should apply only if the repo's merge method is actually squash, and
+  even then only on the first-parent path.
+- **Verify each candidate is an open PR whose head is in this group** before
+  printing it or labelling it. A number that resolves to an issue, or to a PR
+  merged before the group's base, is a parse artifact — drop it silently and
+  say the group is solo.
+- Fail **closed on the naming, open on the parking**: when membership cannot be
+  established confidently, park only the ref-named PR (today's degraded
+  fallback, which is correct) and print "solo / membership unresolved" rather
+  than a speculative list.
+
+## Acceptance criteria
+
+- [ ] A park on a solo queue entry names exactly the ref-named PR, regardless of
+      how much history the PR branch carries.
+- [ ] A `--self-check` fixture reproduces the #4074 shape: a queue merge commit
+      whose second-parent history contains both `Merge pull request #X` and
+      `title (#Y)` subjects, asserting neither X nor Y is reported.
+- [ ] A number that does not resolve to a PR in the group is never printed as a
+      co-member and never receives a `hold` label.
+- [ ] A genuinely batched group (if `min_entries_to_merge` is ever raised) still
+      names every real member.

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -650,8 +650,12 @@ export interface TrapCategoryGrowth {
   /** files that newly entered each trap category (weren't trapping there in baseline). */
   newlyTrapping: Record<TrapCategory, string[]>;
   /**
-   * Candidate traps whose baseline never reached runtime because compilation
-   * timed out. They are unknown baseline outcomes, not observed trap growth.
+   * Candidate traps whose baseline never reached runtime: compilation timed
+   * out (`compile_timeout`), produced invalid Wasm that never instantiated
+   * (`compile_error`, #3595), or the file was never run at all (`skip`,
+   * #4141). All three are unknown baseline outcomes, not observed trap growth.
+   * (The field name predates the latter two; it is kept for compatibility with
+   * the existing gate output and tests.)
    */
   unknownBaselineTimeouts: Record<TrapCategory, string[]>;
   /**
@@ -703,8 +707,8 @@ export interface TrapCategoryGrowthOptions {
  * filter (#1222). This prevents a flaky pass→trap flip on an identical binary
  * from tripping the ratchet.
  *
- * A baseline `compile_timeout` or an absent baseline row is also not an observed
- * runtime outcome. If the candidate compiles that file and exposes a trap, the
+ * A baseline `compile_timeout`, `compile_error`, `skip`, or an absent baseline
+ * row is also not an observed runtime outcome. If the candidate compiles that file and exposes a trap, the
  * ratchet must not claim a new trap: the predecessor run did not establish that
  * the file was trap-free. Such rows stay visible in diagnostics, while the hard
  * ratchet remains unchanged for every baseline row that reached runtime.
@@ -770,7 +774,27 @@ export function evaluateTrapCategoryGrowth(
     // `Iterator/zip/iterables-iteration.js` traps identically with and without
     // the PR that made the file compile, so the trap pre-existed the change that
     // merely let the module reach it.
-    if (base?.status === "compile_timeout" || base?.status === "compile_error") {
+    //
+    // (#4141) `skip` is the THIRD member of the same class, and the most
+    // obviously so: a skipped test was never compiled and never instantiated,
+    // so the baseline run produced no runtime observation of that file at all.
+    // It cannot testify that the file was trap-free, and a candidate trap on
+    // it is therefore *unknown*, not *introduced*. This is correct on its own
+    // merits — it holds for every reason a row can be skipped (scope filter,
+    // HANGING_TESTS, feature filter) and does not depend on any particular
+    // producer bug. It also happens to be defense in depth for the healer
+    // asymmetry fixed alongside this in `test262-sharded.yml`: the baseline
+    // heal step ran without `TEST262_INCLUDE_PROPOSALS`, rewriting ~1,229 real
+    // Temporal traps as `skip`, while the never-healed candidate kept them as
+    // traps — a phantom `null_deref 156 → 1360` charged to two unrelated PRs
+    // (#4074, #4088). With the healer fixed those rows record as `fail` again;
+    // with this exclusion a future scope/skip asymmetry from ANY source cannot
+    // manufacture trap growth either.
+    //
+    // Deliberately NOT loosened beyond that: a baseline that actually RAN
+    // (`pass` or `fail`) and now traps still fails the ratchet, hard. See the
+    // `pass → trap` / `fail → trap` cases in `tests/issue-3189.test.ts`.
+    if (base?.status === "compile_timeout" || base?.status === "compile_error" || base?.status === "skip") {
       unknownBaselineTimeouts[row.error_category].push(file);
       continue;
     }
@@ -2422,15 +2446,42 @@ async function run(
       ` (#3189 ratchet) ===`,
   );
   const trapBaselineUnknowns = TRAP_ERROR_CATEGORIES.flatMap((category) => [
-    ...trapGrowth.unknownBaselineTimeouts[category].map((file) => ({ category, file, baseline: "compile_timeout" })),
+    // (#4141) Report the file's ACTUAL baseline status, not a hardcoded
+    // "compile_timeout". The bucket has covered `compile_error` since #3595 and
+    // `skip` since #4141, so the fixed label was already wrong and actively
+    // misleading: it tells a triager the predecessor timed out when it in fact
+    // never ran at all. The baseline status is the single field that selects
+    // which mechanism is in play, so print the real one.
+    ...trapGrowth.unknownBaselineTimeouts[category].map((file) => ({
+      category,
+      file,
+      baseline: baseline.get(file)?.status ?? "compile_timeout",
+    })),
     ...trapGrowth.unknownBaselineMissingRows[category].map((file) => ({ category, file, baseline: "absent" })),
   ]);
   if (trapBaselineUnknowns.length > 0) {
+    const byStatus = new Map<string, number>();
+    for (const u of trapBaselineUnknowns) byStatus.set(u.baseline, (byStatus.get(u.baseline) ?? 0) + 1);
     console.log(
-      `=== Trap baseline unknowns (absent/compile_timeout → trap; excluded from #3189): ${trapBaselineUnknowns.length} ===`,
+      `=== Trap baseline unknowns (baseline never observed runtime → trap; excluded from #3189): ` +
+        `${trapBaselineUnknowns.length} (` +
+        [...byStatus.entries()]
+          .sort()
+          .map(([s, n]) => `${s} ${n}`)
+          .join(", ") +
+        `) ===`,
     );
-    for (const { category, file, baseline: baselineStatus } of trapBaselineUnknowns) {
+    // Cap the per-file listing. A producer-side asymmetry can push this bucket
+    // into the thousands (#4141 put ~1,200 laundered Temporal rows in it), and
+    // a 1,200-line dump buries the summary line that actually names the cause.
+    const UNKNOWN_LIST_CAP = 50;
+    for (const { category, file, baseline: baselineStatus } of trapBaselineUnknowns.slice(0, UNKNOWN_LIST_CAP)) {
       console.log(`  ${category}: ${file} (baseline ${baselineStatus})`);
+    }
+    if (trapBaselineUnknowns.length > UNKNOWN_LIST_CAP) {
+      console.log(
+        `  … and ${trapBaselineUnknowns.length - UNKNOWN_LIST_CAP} more (listing capped at ${UNKNOWN_LIST_CAP}).`,
+      );
     }
   }
   for (const reason of trapGrowth.failures) {

--- a/tests/issue-4141-trap-growth-baseline-skip.test.ts
+++ b/tests/issue-4141-trap-growth-baseline-skip.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { evaluateTrapCategoryGrowth } from "../scripts/diff-test262.js";
+
+// #4141 — a baseline `skip` row is the same "baseline can't testify" class as
+// `compile_timeout` (#3189) and `compile_error` (#3595): a skipped test was
+// never compiled and never instantiated, so the predecessor run made NO runtime
+// observation of that file. It therefore cannot establish that the file was
+// trap-free, and a candidate trap on it is *unknown*, not *introduced*.
+//
+// The concrete failure that motivated it: the baseline heal step
+// (`heal-poison-rows.ts`, run only on the BASELINE path) executed without
+// `TEST262_INCLUDE_PROPOSALS=1`, so re-running a poison `built-ins/Temporal/**`
+// row classified it as an excluded proposal and rewrote its verdict to `skip`.
+// The candidate JSONL is never healed and kept the same rows as traps. Result:
+// `skip 1322 → 115 (−1207)` alongside `null_deref 156 → 1360 (+1204)`, with
+// ZERO pass→trap transitions, charged to whichever PR was in the merge group —
+// which parked two unrelated PRs (#4074, #4088) in different lanes with a
+// byte-identical delta.
+//
+// The workflow fix removes the producer asymmetry; this exclusion is the
+// defense in depth, and is correct independent of that bug for any skip reason.
+
+type Row = { status: string; error_category?: string; wasm_sha?: string | null };
+const mk = (rows: Record<string, Row>): Map<string, Row> => new Map(Object.entries(rows));
+
+describe("#4141 — baseline `skip` is a can't-testify outcome, not trap growth", () => {
+  it("treats skip → trap as an unknown baseline runtime outcome", () => {
+    const base = mk({
+      "null.js": { status: "skip" },
+      "oob.js": { status: "skip" },
+    });
+    const cur = mk({
+      "null.js": { status: "fail", error_category: "null_deref", wasm_sha: "null" },
+      "oob.js": { status: "fail", error_category: "oob", wasm_sha: "oob" },
+    });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures).toEqual([]);
+    expect(r.newCounts.null_deref).toBe(0);
+    expect(r.newCounts.oob).toBe(0);
+    expect(r.unknownBaselineTimeouts.null_deref).toEqual(["null.js"]);
+    expect(r.unknownBaselineTimeouts.oob).toEqual(["oob.js"]);
+  });
+
+  it("holds for a healer-laundered proposal skip specifically (the #4141 row shape)", () => {
+    // The exact baseline row shape observed in `test262-current.jsonl`:
+    // status "skip", poison_healed, and a proposal-exclusion error, on a file
+    // the candidate reports as a real trap.
+    const base = mk({
+      "test/built-ins/Temporal/PlainDate/prototype/subtract/basic.js": { status: "skip", wasm_sha: null },
+    });
+    const cur = mk({
+      "test/built-ins/Temporal/PlainDate/prototype/subtract/basic.js": {
+        status: "fail",
+        error_category: "null_deref",
+        wasm_sha: "candidate",
+      },
+    });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures).toEqual([]);
+    expect(r.newCounts.null_deref).toBe(0);
+  });
+
+  it("neutralises a bulk phantom (scaled reconstruction of +1204 → 0)", () => {
+    // 1,204 files the baseline skipped and the candidate traps on, plus a real
+    // trap population that merely HOLDS. Before the fix this reported
+    // `null_deref 0 → 1204`; after it, the ratchet sees no growth.
+    const baseRows: Record<string, Row> = {};
+    const curRows: Record<string, Row> = {};
+    for (let i = 0; i < 1204; i++) {
+      const f = `test/built-ins/Temporal/t${i}.js`;
+      baseRows[f] = { status: "skip", wasm_sha: null };
+      curRows[f] = { status: "fail", error_category: "null_deref", wasm_sha: `c${i}` };
+    }
+    // A pre-existing, still-present trap: population holds at 1.
+    baseRows["held.js"] = { status: "fail", error_category: "null_deref", wasm_sha: "h" };
+    curRows["held.js"] = { status: "fail", error_category: "null_deref", wasm_sha: "h2" };
+
+    const r = evaluateTrapCategoryGrowth(mk(baseRows), mk(curRows));
+    expect(r.baseCounts.null_deref).toBe(1);
+    expect(r.newCounts.null_deref).toBe(1);
+    expect(r.failures).toEqual([]);
+    expect(r.unknownBaselineTimeouts.null_deref).toHaveLength(1204);
+  });
+
+  // The other direction. Loosening a ratchet can hide the very trap explosion
+  // the gate exists to catch, so pin that the exclusion is NARROW: only the
+  // baseline-never-ran case is excused.
+  it("still FAILS on a genuine pass → trap transition alongside skip unknowns", () => {
+    const base = mk({
+      "skipped.js": { status: "skip" },
+      "observed.js": { status: "pass", wasm_sha: "before" },
+    });
+    const cur = mk({
+      "skipped.js": { status: "fail", error_category: "null_deref", wasm_sha: "s" },
+      "observed.js": { status: "fail", error_category: "null_deref", wasm_sha: "after" },
+    });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures).toHaveLength(1);
+    expect(r.failures[0]).toContain('null_deref" grew 0 → 1');
+    expect(r.newlyTrapping.null_deref).toEqual(["observed.js"]);
+    expect(r.unknownBaselineTimeouts.null_deref).toEqual(["skipped.js"]);
+  });
+
+  it("still FAILS on a genuine fail → trap transition (skip exclusion does not generalise)", () => {
+    const base = mk({ "observed.js": { status: "fail", error_category: "assertion_fail", wasm_sha: "before" } });
+    const cur = mk({ "observed.js": { status: "fail", error_category: "null_deref", wasm_sha: "after" } });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures).toHaveLength(1);
+    expect(r.failures[0]).toContain('null_deref" grew 0 → 1');
+  });
+
+  it("a bulk skip-unknown bucket does not mask a real trap explosion hiding inside it", () => {
+    // 500 legitimately-unknown skip rows PLUS 5 real pass→trap regressions.
+    // The gate must still fail, and must name only the 5 observed ones.
+    const baseRows: Record<string, Row> = {};
+    const curRows: Record<string, Row> = {};
+    for (let i = 0; i < 500; i++) {
+      baseRows[`skipped${i}.js`] = { status: "skip" };
+      curRows[`skipped${i}.js`] = { status: "fail", error_category: "unreachable", wasm_sha: `s${i}` };
+    }
+    for (let i = 0; i < 5; i++) {
+      baseRows[`real${i}.js`] = { status: "pass", wasm_sha: `b${i}` };
+      curRows[`real${i}.js`] = { status: "fail", error_category: "unreachable", wasm_sha: `a${i}` };
+    }
+    const r = evaluateTrapCategoryGrowth(mk(baseRows), mk(curRows));
+    expect(r.failures).toHaveLength(1);
+    expect(r.failures[0]).toContain('unreachable" grew 0 → 5');
+    expect(r.newlyTrapping.unreachable.sort()).toEqual(["real0.js", "real1.js", "real2.js", "real3.js", "real4.js"]);
+  });
+});


### PR DESCRIPTION
Unblocks the phantom merge-group regression that parked **#4074** and **#4088**. Related gate issues: #3189 (the trap ratchet), #3595 (`compile_error` as can't-testify), #3596, #2099 (the healer). Also files **#4142** (auto-park bot's false batch-membership list).

## The defect

Two unrelated PRs in different lanes were auto-parked with the **byte-identical** delta — `skip 1322 → 115 (−1207)`, `null_deref 156 → 1360 (+1204)`, `Regressions excluding compile_timeout: 0`, host fine-gate net positive, **zero** `pass → trap` transitions. A codegen change cannot un-skip 1,200 tests, and an identical delta on two independent branches is a property of the comparison, not of either branch.

**Root cause.** `scripts/heal-poison-rows.ts` re-runs poison rows through `runTest262File`, which applies `shouldSkip` → `classifyTestScope`; `built-ins/Temporal/**` is a *proposal*, skipped unless `TEST262_INCLUDE_PROPOSALS=1`. The shard jobs set it (~L723, ~L896); the two heal steps did not (`promote-baseline` ~L2338, `write-run-cache-bot` ~L3174). Healing runs on the **baseline** path only — `merge-report` never heals the candidate — so real Temporal traps were laundered into baseline `skip` while the candidate kept them as traps, and `diff-test262.ts` did not have `skip` in its baseline-can't-testify set.

## What each layer does

**1. Root cause — `.github/workflows/test262-sharded.yml`.** `TEST262_INCLUDE_PROPOSALS` on both heal steps. `promote-baseline` **mirrors the shard job's own expression** byte-for-byte rather than hardcoding `"1"`, so an `include_proposals: false` dispatch heals under the scope its shards actually ran under; `write-run-cache-bot` is `push` + merge-queue-bot only, so it is always the non-dispatch branch.

**2. Defense in depth — `scripts/diff-test262.ts`.** `skip` added to the exclusion at the former L773. A skipped test was never compiled and never instantiated, so the baseline made no runtime observation of it — the same class as `compile_timeout`/`compile_error`. Correct on its own merits for every skip reason (scope filter, `HANGING_TESTS`, feature filter), independent of the healer bug.

**3. Healing the candidate too — deliberately NOT done**, reasoning in the issue file: it would *balance* the defect rather than remove it (both sides would then drop ~1,200 real traps from the measured population — the gate goes quiet by going blinder), it is redundant once (1) makes the healer scope-faithful, and it adds a multi-minute serial re-run to the most latency-sensitive job in the queue. Healing the candidate remains defensible for the original #2099 reason, but that is a separate question and shouldn't ride on a ratchet fix.

**Bonus — diagnostics.** The gate hardcoded `(baseline compile_timeout)` for *every* unknown. That has been wrong since #3595 added `compile_error` and it actively misleads triage — it says the predecessor timed out when it in fact never ran. Now prints each row's real baseline status plus a per-status summary, and caps the per-file listing at 50 so a bulk producer-side asymmetry can't bury the summary under a 1,200-line dump.

## Verification

Against the live baseline JSONL (48,368 rows, fetched today): **1,229** of the **1,344** baseline `skip` rows carry `poison_healed: true` **and** `error: "Proposal excluded from default scope: proposal feature: Temporal"` — 100 % of the healed population — leaving exactly the **115** genuine skips the parked gate reported. One row's `compile_ms: 4827` on a "skipped" test is the tell: the shard compiled it for ~5 s, then the healer overwrote the verdict with a scope decision.

Replaying those rows as an un-laundered candidate, A/B on the same data:

| | `null_deref` | verdict |
|---|---|---|
| before | 156 → **1385** (+1229) | GATE FAIL |
| after | 156 → **156** | passes; 1,229 rows in the unknown bucket |
| after + one injected `pass → null_deref` | 156 → **157** | **GATE FAIL**, names the file |

Baseline 156 matches the parked run exactly.

Unit coverage in `tests/issue-4141-trap-growth-baseline-skip.test.ts` (6 tests) — including a scaled reconstruction of the +1204 phantom and, in the other direction, 5 real `pass → trap` regressions hidden inside a 500-row skip-unknown bucket, which must still fail and name only the 5. `tests/issue-3189.test.ts` and the other four trap-ratchet suites still pass (61 tests total). `TRAP_RATCHET_TOLERANCE` untouched; no `trap-growth-allow` granted.

`pnpm run typecheck`, `biome lint`, prettier, `check:issue-ids:staged`, `check:issue-ids:against-main` all green. No local test262.

## Known adjacent gap, filed not fixed

The heal steps also omit `TEST262_FULL_RUNTIME_EVAL`, which the standalone shard lane sets to `1` with the `runtime-eval-provider` artifact downloaded. A standalone poison row healed without it re-runs on the REFUSAL provider tier, which `scripts/runtime-eval-provider.mjs` itself labels "NOT CI-comparable" — the same asymmetry class as this fix. Setting the env alone would be a no-op (those jobs have no provider cache), so it needs the artifact wired in: a real change with its own failure modes that does not belong in a ratchet fix.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgUtJiKt2aRZ4cnHi4STS3)_