### PR TITLE
docs(issues): file #4147 (runTest262File links no runtime-eval provider) and #4148 (host-lane bare-identifier typeof, 31 rows)

### DIFF
--- a/plan/issues/4147-runtest262file-links-no-runtime-eval-provider.md
+++ b/plan/issues/4147-runtest262file-links-no-runtime-eval-provider.md
@@ -1,0 +1,125 @@
+---
+id: 4147
+title: "`runTest262File` links no `js2wasm:runtime-eval` provider — every standalone file including propertyHelper.js dies at instantiate, so local measurement is silently blind"
+status: ready
+sprint: current
+created: 2026-08-04
+updated: 2026-08-04
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: tooling
+language_feature: n/a
+goal: standalone-mode
+related: [2527, 4010, 4061, 4098]
+---
+
+# `runTest262File` links no `js2wasm:runtime-eval` provider — local standalone measurement is silently blind
+
+`runTest262File` (`tests/test262-runner.ts`) does **not** supply the separately
+compiled `js2wasm:runtime-eval` provider that the CI worker links
+(`scripts/test262-worker.mjs` → `instantiateRuntimeEvalNamespace`). Any
+standalone module whose harness assembly carries those imports therefore dies at
+`WebAssembly.instantiate`:
+
+```
+TypeError: WebAssembly.instantiate(): Import #0 "js2wasm:runtime-eval":
+module is not an object or function
+```
+
+**`propertyHelper.js` in the assembly is the trigger** — measured by the S3
+owner: prefix alone = 0 imports, prefix + `propertyHelper` = 2. Since
+`propertyHelper.js` is the standard include for any test asserting property
+attributes, this silently removes a large, systematically-chosen slice of the
+corpus from every local measurement.
+
+## Why this is a blindness bug and not a nuisance
+
+The failure is **indistinguishable from a compiler failure at the call site**.
+`runTest262File` returns `status: "fail"` with an error string, exactly as it
+would for a real miscompile. An agent measuring a fix locally sees rows that
+"fail", attributes them to its own change, and either chases a phantom
+regression or — worse — discounts real ones because "those were already
+failing". The rows are not marked skipped, not marked errored, and carry no
+signal that the instrument, rather than the compiler, is what broke.
+
+This is the [[silent-empty]] shape applied to a measurement lane: *what does the
+instrument do when it cannot see?* Here it answers "the test fails", which is
+the one answer that cannot be distinguished from a real result.
+
+## Two independent measurements, from two lanes that did not coordinate
+
+### 1. S3 / #4010 owner — the trigger and the scale
+
+A pilot of the `{name,length}.js` stratum scored **0 / 11 runnable**. The
+instrument was blind, not the compiler broken. Their workaround: neutralise
+`$262.evalScript`'s `eval` in a **local copy** of
+`scripts/test262-fyi-runtime.js` (a function no `{name,length}.js` test calls).
+With the instrument repaired it agreed with the published CI standalone baseline
+**16/16** pass/not-pass. Recorded in `plan/issues/4010-m2-disjoint-receiver-side-tables.md`
+under "Instrument note — `runTest262File` cannot run this corpus unaided"
+(currently on PR #4091's branch, not yet on `main`).
+
+### 2. #4061 owner — two controls proving it is the instrument, not the change
+
+While sweeping the 182 baseline-passing `built-ins/Object/create` files for
+regressions, **27** failed with the identical import error. Two controls
+established that this was the harness:
+
+- **`built-ins/Object/create/name.js` was among the 27.** It is a pure
+  `Object.create.name === "create"` assertion — it contains no descriptor
+  argument at all, so the descriptor-routing change under test could not
+  possibly reach it.
+- **Four baseline-passing tests from unrelated directories reproduced it
+  exactly**: `Array/prototype/{filter,findLast,flatMap}` and
+  `String/prototype/lastIndexOf` → **0 / 4**, same error, same instantiate
+  failure.
+
+Corrected reading of that sweep: **155 pass, 27 unrunnable, 0 regressed** — a
+number that would have read as "27 regressions" without the controls.
+
+## Cost when undetected
+
+Two independent lanes each burned real effort on it in the same session, and
+neither could have found it from the error text alone — one needed a
+descriptor-free file inside its own failing set, the other needed a
+cross-directory control. A third lane hitting this would start from zero again.
+Every local standalone measurement in the project is currently understating
+runnable coverage by an unknown amount, and the understatement is
+**systematic** (it selects exactly the attribute-asserting tests), not random.
+
+## Acceptance
+
+- [ ] A `propertyHelper.js`-including test — e.g.
+      `built-ins/Object/create/name.js` — is **measurable locally** through
+      `runTest262File` with `target: "standalone"`, and its status **matches the
+      published CI standalone baseline** for the same commit. Matching CI is the
+      criterion; "does not throw at instantiate" is not sufficient, since a
+      wrongly-linked provider could instantiate and then answer differently from
+      CI.
+- [ ] The fix links the **same** provider CI links
+      (`instantiateRuntimeEvalNamespace`, `scripts/test262-worker.mjs`) rather
+      than a second local shim, so the two lanes cannot drift apart. If a shim
+      is unavoidable, state explicitly what it does NOT provide.
+- [ ] A positive control is included: at least one test that legitimately
+      **fails** on the measured commit still reports `fail`, so the fix is not
+      confused with "everything now passes".
+- [ ] **The unlinked case must announce itself.** If the provider genuinely
+      cannot be linked, `runTest262File` must return a distinct status
+      (`skip`/`error` with a named reason), never `fail` — a detector that
+      cannot see must say so rather than return the same answer as a real
+      failure. This criterion is the point of the issue; the convenience fix
+      without it leaves the next unlinked path silently blind again.
+- [ ] Re-run the #4061 182-file `Object/create` sweep as a regression witness:
+      expect 182 runnable, not 155.
+
+## Notes
+
+- Related: **#2527** (core-wasm linking / host shims and runtime) — the
+  runtime-eval provider is part of that packaging story, and a fix here should
+  not fork it.
+- The S3 workaround (patching a local copy of `scripts/test262-fyi-runtime.js`)
+  is a **measurement-lane** hack and explicitly *not* a defect on `main`; do not
+  land it as-is.

--- a/plan/issues/4148-host-lane-bare-identifier-builtin-value-read.md
+++ b/plan/issues/4148-host-lane-bare-identifier-builtin-value-read.md
@@ -1,0 +1,118 @@
+---
+id: 4148
+title: "Host lane: `typeof` a bare builtin identifier through a parameter answers \"object\" — 31 rows, a different mechanism from the standalone carrier brand"
+status: ready
+sprint: current
+created: 2026-08-04
+updated: 2026-08-04
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: n/a
+goal: core-semantics
+related: [4120, 4119, 3571]
+---
+
+# Host lane: `typeof` a bare builtin identifier through a parameter answers `"object"`
+
+Split out of **#4120** on 2026-08-04, at that issue's own request: *"the honest
+scoped host bucket is 31, not 43, and it needs its own issue."* The analysis
+below is #4120's, not re-derived — see its `## Host-arm triage (the 43)` section
+(landed on `main`; PR **#4090** is the standalone counterpart,
+`fix(#4120): typeof of a reified builtin constructor answers "function"`,
+merged 2026-08-03).
+
+## The bucket is 31, not 43 — the split is load-bearing
+
+#4120 measured **43** failing official tests in the default/host lane
+(denominator 43,488 official host files) under the signature
+`typeof <builtin> !== "function"`. Probing the named builtin's existence in the
+JS host itself split them:
+
+- **12 of 43 — out of scope.** The builtin does not exist in the JS host either,
+  so `typeof undefined !== "function"` is the **correct** answer and the row
+  fails for a legitimate missing-builtin reason:
+  `ArrayBuffer.prototype.{sliceToImmutable,transferToImmutable}`,
+  `Iterator.prototype.join`, `Map.prototype.{getOrInsert,getOrInsertComputed}`,
+  `WeakMap.prototype.{getOrInsert,getOrInsertComputed}`, `Math.sumPrecise`,
+  `Promise.{allKeyed,allSettledKeyed}`, `Error.prototype.stack` getter+setter.
+- **31 of 43 — this issue.** A real gap, and a **different mechanism** from the
+  one #4120 fixed.
+
+Quoting 43 for this fix overstates it by ~39 %. #4120's file states the rule
+directly: *"Do not treat the host 43 as one bucket."*
+
+## Mechanism — a bare-identifier value read, not a carrier brand
+
+Measured host-mode `typeof` through a **one-parameter indirection**:
+
+| identifier | host `typeof` |
+| --- | --- |
+| `Set` | `"function"` ✓ |
+| `Array` | `"function"` ✓ |
+| `AggregateError` | `"object"` ✗ |
+| `BigInt` | `"object"` ✗ |
+| `WeakRef` | `"object"` ✗ |
+| `escape` | `"object"` ✗ |
+| `eval` | `"object"` ✗ |
+| `parseInt` | `"object"` ✗ |
+
+`Set`/`Array` are the controls that matter: some bare builtin identifiers **do**
+read back as callable in the host lane, so this is not "the host lane has no
+builtin identity" — it is a per-identifier value-read gap.
+
+**The #4120 fix cannot touch it.** That brand is applied at
+`pushBuiltinCtorOwnPropSeed` and is **`ctx.standalone`-gated**; #4120 states the
+host emit is **byte-identical** before and after, and made no host-side change.
+So this needs its own mechanism, not a widening of the gate — widening it
+blindly would change host emit that is currently correct for `Set`/`Array`.
+
+## Why the indirection is mandatory in any probe
+
+`typeof <Builtin>` written in place is **constant-folded** and never touches the
+value carrier — it will answer `"function"` regardless of whether the underlying
+read is broken. #4120 records this trap explicitly and asserts the in-place
+spelling only as a CONTROL that must keep working. Any probe or test for this
+issue must route the identifier through a parameter hop, or it measures the
+static path and reports success that is not there. See
+[[reference_constant_folded_probe_tests_the_static_path]].
+
+## Relationship to the neighbouring buckets — do not merge them
+
+- **#4120 / PR #4090** — reified builtin **constructor** carriers, standalone
+  lane. Landed. This issue is its host-lane counterpart *in symptom only*; the
+  mechanism differs.
+- **#4119 / #3571** — `typeof Array.prototype.map` answers `"undefined"`
+  because the **member read** does not resolve (69 prototype methods, #4120's
+  "mode 1"). #4119 additionally measured that `Array.prototype.slice` — whose
+  member body **is** implemented — still answers `"undefined"`, so implementing
+  a member body does not by itself produce a callable value. Different defect,
+  different lane, already owned.
+
+## Acceptance
+
+- [ ] Host-lane `typeof` **through a parameter hop** answers `"function"` for
+      `AggregateError`, `BigInt`, `WeakRef`, `escape`, `eval`, `parseInt`.
+- [ ] `Set` and `Array` — the identifiers that already answer correctly —
+      still answer `"function"`. They are the regression control; a fix that
+      makes the six work by changing how all bare builtin identifiers read must
+      prove it did not disturb these.
+- [ ] Every assertion routes through a parameter; the in-place spelling appears
+      only as a control (it is constant-folded — see above).
+- [ ] Report flips against the **31**-row scoped population with its
+      denominator (43,488 official host files), and state explicitly that the
+      12 missing-builtin rows are excluded and why.
+- [ ] Standalone emit is unchanged, or any change is measured on the standalone
+      lane too — #4120's brand is `ctx.standalone`-gated and correct today.
+
+## Reproduction
+
+```bash
+node scripts/fetch-baseline-jsonl.mjs --force
+# filter test262-current.jsonl (HOST lane) on scope_official && status != pass
+#   signature: typeof <builtin> !== "function"   -> 43
+#   minus the 12 not-in-host-either rows listed above -> 31
+```


### PR DESCRIPTION
Two issue files, no code. Both ids reserved via `claim-issue.mjs --allocate` (`pr_scan=ok`, verified on `upstream/issue-assignments`) and confirmed absent from main's git tree (`truncated: false`, so the listing is complete rather than paginated-empty).

## #4147 — `runTest262File` links no `js2wasm:runtime-eval` provider

Local standalone measurement is **silently blind** for any test whose harness assembly includes `propertyHelper.js`. The module dies at `WebAssembly.instantiate`:

```
TypeError: WebAssembly.instantiate(): Import #0 "js2wasm:runtime-eval":
module is not an object or function
```

The reason this is a blindness bug and not a nuisance: `runTest262File` returns `status: "fail"` with an error string — **indistinguishable from a real miscompile at the call site**. The rows are not skipped, not errored, and carry no signal that the instrument rather than the compiler is what broke. An agent measuring a fix locally either chases a phantom regression or discounts real ones because "those were already failing". Because `propertyHelper.js` is the standard include for attribute-asserting tests, the understatement is **systematic**, not random.

Two independent measurements, from lanes that did not coordinate:

- **S3 / #4010 owner** — trigger isolated (`propertyHelper.js` in the assembly: prefix alone = 0 imports, prefix + propertyHelper = 2); a pilot of the `{name,length}.js` stratum scored **0 / 11 runnable**; with the instrument repaired it agreed with the published CI standalone baseline **16/16**.
- **#4061 owner** — 27 of 182 baseline-passing `Object/create` files failed identically. Two controls proved it was the harness: `Object/create/name.js` was among them (a pure `Object.create.name === "create"` assertion with no descriptor argument, so the change under test could not reach it), and four baseline-passing tests from `Array/prototype/{filter,findLast,flatMap}` + `String/prototype/lastIndexOf` reproduced it at **0 / 4**. Corrected reading: **155 pass, 27 unrunnable, 0 regressed** — a number that would otherwise have read as 27 regressions.

The acceptance criterion that carries the issue: **an unlinkable provider must return a distinct `skip`/`error`, never `fail`.** A detector that cannot see must say so. Without that, the convenience fix leaves the next unlinked path silently blind again.

Related: **#2527** (core-wasm linking / host shims) — the provider is part of that packaging story and a fix here should not fork it. The S3 workaround (patching a local copy of `scripts/test262-fyi-runtime.js`) is a measurement-lane hack and explicitly *not* a defect on main; it should not land as-is.

## #4148 — host-lane `typeof` a bare builtin identifier answers `"object"` (31 rows)

Split out of **#4120** at that issue's own request — *"the honest scoped host bucket is 31, not 43, and it needs its own issue."* Analysis is #4120's, not re-derived.

The 12/31 split is load-bearing: 12 of the 43 rows name builtins that **do not exist in the JS host either**, where `typeof undefined !== "function"` is the *correct* answer. Quoting 43 overstates the fix by ~39 %.

Mechanism, measured through a one-parameter indirection: `Set` and `Array` answer `"function"` (correct), while `AggregateError`, `BigInt`, `WeakRef`, `escape`, `eval`, `parseInt` answer `"object"`. So this is a per-identifier value-read gap, not "the host lane has no builtin identity" — and #4120's fix cannot touch it: that brand is `ctx.standalone`-gated at `pushBuiltinCtorOwnPropSeed`, with host emit byte-identical. PR **#4090** is the standalone counterpart.

Any probe **must** route through a parameter hop: `typeof <Builtin>` written in place is constant-folded and never touches the value carrier, so it answers `"function"` regardless of whether the read is broken. `Set`/`Array` are recorded as the regression control.

Distinct from #4119 / #3571, which own the reified-prototype-method read (`typeof Array.prototype.map` → `"undefined"`, and `slice` too even though its member body *is* implemented). Same symptom family, different defect.

---

Docs-only: no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` changes. Checked before opening — no other docs PR was open, so this is the group.
