### PR TITLE
fix(hooks): pre-commit fast lane — prettier/biome unconditional, slow checks skippable

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,16 @@
-npx lint-staged &&
-  pnpm run test:changed-root &&
+npx lint-staged || exit 1
+
+# Fast lane (#4100 post-mortem): the slow chain below takes minutes and exceeds
+# agent tool timeouts, which drove wholesale `git commit --no-verify` — losing
+# the seconds-cheap prettier/biome gate above along with the slow checks.
+# SKIP_SLOW_PRECOMMIT=1 keeps the format gate unconditional and skips only the
+# slow checks (CI runs them all regardless). Never use `--no-verify`; use this.
+if [ -n "$SKIP_SLOW_PRECOMMIT" ]; then
+  echo "pre-commit: fast gate passed (lint-staged: prettier + biome); slow checks skipped (SKIP_SLOW_PRECOMMIT=1) — CI still runs them"
+  exit 0
+fi
+
+pnpm run test:changed-root &&
   pnpm run check:oracle-ratchet &&
   pnpm run check:loc-budget &&
   pnpm run check:func-budget

--- a/plan/method/pre-commit-checklist.md
+++ b/plan/method/pre-commit-checklist.md
@@ -16,6 +16,13 @@
 7. [ ] No test files from other issues being deleted
 8. [ ] No source files being reverted to old versions
 9. [ ] Commit message references your issue number (#N)
+10. [ ] **Never `git commit --no-verify`.** If the full pre-commit chain is too
+        slow for your tool timeout (test:changed-root + ratchets take minutes),
+        commit with `SKIP_SLOW_PRECOMMIT=1 git commit …` instead — that keeps
+        the seconds-cheap prettier/biome gate (lint-staged) and skips only the
+        slow checks, which CI runs anyway. `--no-verify` skips EVERYTHING, and
+        that is how PR #4100 shipped an unformatted file to a failing `quality`
+        lane (2026-08-04 post-mortem).
 
 ## Lint suppressions — this project uses BIOME, not ESLint
 


### PR DESCRIPTION
## Post-mortem fix for PR #4100's format failure

The pre-commit chain (`test:changed-root` + 3 ratchets) takes minutes and exceeds agent tool timeouts, so agents committed `--no-verify` wholesale — losing the seconds-cheap lint-staged (prettier + biome) gate along with the slow checks. That is how PR #4100 shipped an unformatted `carrier-bag-delete.ts` to a failing `quality` lane.

**Change:** `SKIP_SLOW_PRECOMMIT=1` skips only the slow checks (CI runs them all regardless); `lint-staged` now always runs and its failure always blocks the commit. `plan/method/pre-commit-checklist.md` gains item 10: `--no-verify` for commits is no longer sanctioned — use the fast lane.

No behavior change for anyone running the hook without the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCuWfyTva65YvSDcAnfpPi