### PR TITLE
docs: record post-merge state of #4133/#4134 after PR #4074

### DIFF
--- a/plan/issues/4133-cross-module-function-name-collision-wrong-answer.md
+++ b/plan/issues/4133-cross-module-function-name-collision-wrong-answer.md
@@ -4,8 +4,8 @@ id: 4133
 title: "Same-named top-level functions in different modules share one slot and silently compute the wrong answer"
 status: in-progress
 created: 2026-08-02
-updated: 2026-08-02
-assignee: ttraenkler/claude
+updated: 2026-08-04
+assignee: unassigned  # authoring lane stood down after PR #4074 landed the first slice
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -250,3 +250,42 @@ closure/trampoline-focused tests, not just the #4133 rungs.
 - Whether two versions of the *same package* (the eslint-visitor-keys 3.4.3 /
   5.0.1 case) need anything beyond per-unit naming — they are distinct units by
   construction, so probably not, but it has not been verified.
+
+---
+
+# POST-MERGE STATE — PR #4074 landed a slice, 2026-08-04
+
+`status` stays `in-progress`. Both halves of the *naming* defect shipped; the
+residual is the reachability problem tracked jointly with #4134.
+
+## What landed
+
+- **Top-level collision** — `funcMap` is rebound per source, so two modules
+  declaring the same top-level function name no longer share one slot.
+- **Nested collision** — a nested declaration's bare name is scoped to its
+  **enclosing function**, not to the parent block. The scope choice is
+  load-bearing: an earlier revision walked only to the parent block and
+  regressed Annex B §B.3.3 block-hoisted declarations (#165) plus lodash #1303.
+
+Both were **silent wrong answers**, not crashes — they compile and validate
+cleanly and only the computed value detects them. A factory whose nested `equal`
+lost to another module's `equal` returned `0` where node gives `306`.
+
+Regression guards: `tests/issue-4133-cross-module-function-name-collision.test.ts`
+and `tests/issue-4133-nested-name-scope.test.ts`, both verified non-vacuous
+against the unfixed base.
+
+## What remains
+
+The out-of-scope nested binding case, where the correct callee is not reachable
+from the calling frame. Neither available end is safe today:
+
+| out-of-scope nested binding | consequence |
+| --- | --- |
+| suppress it | call falls to `ref.null.extern` → `null_deref` +1200 (measured) |
+| let it through | wrong-frame capture index → module fails to validate |
+
+The shipped code lets it through. A real fix makes the callee *reachable* via
+the #2029 family-A promotion to `capturedGlobals`, which changes mutation
+semantics and needs a spec first. This is the same remainder as #4134's — the
+two should be specced together, not separately.

--- a/plan/issues/4134-eslint-local-index-out-of-range-emit.md
+++ b/plan/issues/4134-eslint-local-index-out-of-range-emit.md
@@ -2,10 +2,10 @@
 horizon: m
 id: 4134
 title: "Codegen leaves out-of-frame local references; reproduces in ONE file (uri.all.js)"
-status: ready
+status: in-progress
 created: 2026-08-02
-updated: 2026-08-02
-assignee: unassigned
+updated: 2026-08-04
+assignee: unassigned  # partial slice landed in PR #4074; remainder needs a spec
 priority: critical
 feasibility: hard
 reasoning_effort: max
@@ -939,3 +939,74 @@ A correct fix has to make the *right* callee reachable, which is the same
 promotion work. Until then the branch takes the "let it through" end, because an
 invalid module is a loud failure and a null-trap explosion is a conformance
 regression that also parks the merge queue.
+
+---
+
+# POST-MERGE STATE — PR #4074 landed a slice, 2026-08-04
+
+`status` stays `in-progress`, **not** `done`: the PR that closed ten sibling
+issues shipped only the first half of this one. Recording the boundary so the
+next lane starts from the remainder rather than re-deriving it.
+
+## What landed
+
+The out-of-frame capture guard. `main` had independently landed the equivalent
+as a shared helper — `captureSourceSlot` (`src/codegen/closures/capture-source-slot.ts`)
+— and the merge took main's version, so the rule now lives in one place:
+
+> prefer the mapped slot when the name is one of this lifted function's own
+> capture params, **or** when `outerLocalIdx` lands outside the frame entirely
+> (where the historical read is provably invalid Wasm, so there is no behaviour
+> to preserve).
+
+Restricting the second disjunct to *out-of-frame* is what makes it safe where
+#1177's blanket `localMap`-first lookup was not: every in-frame call stays
+byte-identical.
+
+Measured effect: `uri.all.js` went from 8 out-of-frame functions and no binary
+to **0 and a valid 131 KB module**. ESLint went from 14 to **2**.
+
+## What remains — and why re-indexing will not close it
+
+Two functions still emit out-of-frame locals:
+
+| function | worst index | frame |
+| --- | ---: | ---: |
+| `__fnctor_MurmurHash3_new` | 24 | 15 |
+| `assertASTDidntChange` | 51 | 4 |
+
+These are **not** more of the same bug. The right callee is not merely
+mis-indexed, it is **unreachable** from the frame doing the call, so no choice
+of index is correct. The mechanism that fixes it already exists: the #2029
+family-A promotion of a capture to `capturedGlobals`. Applying it here changes
+mutation semantics for the promoted binding, so it needs a spec before code —
+see `/architect-spec`.
+
+## Negative results — do not re-run these
+
+- **A third guard site** (`funcref-as-closure.ts`, the closure-**value**
+  materialisation path, as opposed to the call-site prepend) was implemented and
+  **measured ineffective**: `localMap` is empty there, so the guard falls through
+  to the identical index. It was briefly claimed here as "the last blocker" —
+  that was wrong and was retracted on the PR. The merge dropped it in favour of
+  main's shared helper.
+- **A recompile path** (`funcMapOwnerDecl` + `restoreShadowedFuncBindings`) broke
+  lodash `createHybrid` and was backed out entirely.
+- **Suppressing the out-of-scope nested binding** — i.e. emitting
+  `ref.null.extern` rather than a wrong index — trades an invalid module for a
+  `null_deref` explosion (+1200 on Temporal, measured). The shipped code
+  deliberately picks "let it through": an invalid module fails loudly at
+  validation, whereas a null-trap explosion is a silent conformance regression.
+  That trade is the residual this issue still owns.
+
+## Instrumentation left in place (env-gated, inert by default)
+
+`JS2WASM_FRAME_TRAP=<fn>` (`src/codegen/frame-trap.ts`) reports, with a stack,
+the moment an instruction referencing an out-of-frame local is appended to a
+function's body. It installs the accessor on the **FunctionContext**, not on
+`fctx.body` — `body` is reassigned by the `savedBodies` swap, so a proxy on the
+array stops observing after the first swap. That detail is what made it work
+where a naive proxy did not; keep it if you touch the file.
+
+Also available: `JS2WASM_COMPILE_PROFILE`, `JS2WASM_CHECK_FRAMES`,
+`JS2WASM_FRAME_OPS`, `JS2WASM_FRAME_STAGES`, `JS2WASM_TRACE_SLOT`.


### PR DESCRIPTION
## Description

Issue files only — two files, no code, no behaviour change.

PR #4074 closed ten sibling issues but landed only the **first slice** of #4133 and #4134, so neither is `done`. #4134 was still `status: ready`, `assignee: unassigned` — which reads as *untouched*. That is the actionable defect here: `sync-current-tasklist.mjs` would offer it as fresh work, and the next lane would re-derive everything, including three approaches already measured not to work.

Both issues now carry a what-landed / what-remains section.

### #4134

Landed: the out-of-frame capture guard. `main` had independently landed the equivalent as a shared helper (`captureSourceSlot`), and #4074's merge took main's version, so the rule lives in one place. `uri.all.js` went from 8 out-of-frame functions and no binary to 0 and a valid 131 KB module; ESLint from 14 to 2.

Remains — and this is the part worth reading before picking it up: **the two survivors are not more of the same bug.** The callee is *unreachable* from the calling frame, not merely mis-indexed, so no choice of index is correct. The mechanism that fixes it exists (#2029 family-A promotion to `capturedGlobals`) but changes mutation semantics for the promoted binding, so it wants a spec before code.

### #4133

Landed: both halves of the naming defect — per-source `funcMap` rebinding, and nested-declaration names scoped to the enclosing *function*. The scope choice is load-bearing: an earlier revision walked only to the parent block and regressed Annex B §B.3.3 hoisting (#165) plus lodash #1303.

Remains: the same reachability problem as #4134's. The two should be specced **together**, not separately.

### Negative results recorded so they are not re-run

- **Third guard site** (`funcref-as-closure.ts`, closure-*value* materialisation): implemented, then **measured ineffective** — `localMap` is empty there, so it falls through to the identical index. It was briefly claimed on #4074 as "the last blocker"; that was wrong and was retracted there.
- **Recompile path** (`funcMapOwnerDecl` + `restoreShadowedFuncBindings`): broke lodash `createHybrid`, backed out entirely.
- **Suppressing the out-of-scope binding** (emitting `ref.null.extern` instead of a wrong index): +1200 `null_deref`, measured. The shipped code deliberately picks "let it through" — an invalid module fails loudly at validation, whereas a null-trap explosion is a silent conformance regression.

Also clears the stale `assignee` on #4133 (that lane has stood down) and notes the `JS2WASM_FRAME_TRAP` accessor detail — it installs on the `FunctionContext`, not on `fctx.body`, because `body` is reassigned by the `savedBodies` swap and a proxy on the array stops observing after the first swap.

### Why this is a separate PR from #4101

It was written as a second commit on #4101's branch, but that PR had already been auto-enqueued and the branch was frozen (`Branches that are queued for merging cannot be updated`). I did not dequeue #4101 to make room, and did not open a competing docs PR while it was in the queue — this goes up now that #4101 has merged.

Gates run locally: `prettier --check` clean.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWGbrA8MMahzAad4ce4McL)_