### PR TITLE
release: v0.68.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.67.0"
+    "@loopdive/js2": "0.68.0"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
Version bump only — root `@loopdive/js2` and the unscoped proxy `packages/js2wasm` in lockstep, 0.67.0 → 0.68.0, cut via `node scripts/release.mjs minor`.

Minor rather than patch: this window landed user-visible conformance features, not just fixes.

**What's in it since v0.67.0** (measured, standalone lane):
- `typeof` on reified builtin constructors (#4120) — +16, 0 regressions
- #4010 **S3** own-property visibility, and the −684 root cause fixed at source (§10.1.9) — +4/−0 with a 729/729 stratum control
- #4061 §8.10.5 descriptor-argument validation (#4096) — 16/17, 0/182 regressions, plus a silent-wrong-answer fix (`Object.create` was dropping *every* accessor descriptor)
- #4098 **G1 stage 1** (#4100) — real `delete` on class instances via per-instance tombstones
- pre-commit fast lane (#4102) — keeps the prettier/biome gate unconditional

The annotated tag `v0.68.0` exists locally on the release commit and is **deliberately not pushed** — pushing it before merge would fire `publish-npm.yml` on unreviewed code. After this merges: `git push origin v0.68.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCuWfyTva65YvSDcAnfpPi