### PR TITLE
fix(release): resolve the publishing remote by URL + draft release notes

### DIFF
--- a/docs/release-notes/v0.68.0.md
+++ b/docs/release-notes/v0.68.0.md
@@ -8,7 +8,29 @@ standalone test262 lane with denominators, and every fix carries a kill-switch
 receipt — a fix is credited only when the same corpus is measured with the
 change removed.
 
-**Conformance at release: 30,982 / 43,505 official (71.2 %).**
+## Conformance
+
+Two independent lanes, never summed — they measure different targets:
+
+| Lane | v0.67.0 | v0.68.0 | Change |
+| --- | --- | --- | --- |
+| **JS-host** (`gc` target, host imports allowed) | 29,856 / 43,099 (69.3 %) | **30,982 / 43,505 (71.2 %)** | **+1,126 passes, +1.9 pp** |
+| **Standalone** (`--no-host-imports`, pure Wasm) | not published | **27,339 / 43,505 (62.8 %)** | — |
+
+Two caveats on those numbers, because they change what the delta means:
+
+- **The corpus grew between releases** (43,099 → 43,505 tests, +406). The
+  +1,126 host passes are therefore against a larger denominator, not a fixed
+  one — the percentage-point change is the sounder of the two figures.
+- **No standalone delta is given because there is nothing honest to compare
+  against.** The committed standalone summary
+  (`benchmarks/results/test262-standalone-current.json`) did not exist at
+  v0.67.0, so a change figure would have to be sourced from a different
+  artifact measured under different conditions. From v0.69.0 onward both lanes
+  will have a like-for-like predecessor.
+
+Most of this release's work targets the **standalone** lane; the host lane
+moves largely as a side effect.
 
 ## Features
 

--- a/docs/release-notes/v0.68.0.md
+++ b/docs/release-notes/v0.68.0.md
@@ -1,0 +1,75 @@
+# v0.68.0
+
+Lockstep release of `@loopdive/js2` and the `js2wasm` proxy: 0.67.0 → 0.68.0.
+
+A conformance release, focused on the standalone (pure-Wasm, no JS host) lane's
+own-property and descriptor model. All numbers below are measured against the
+standalone test262 lane with denominators, and every fix carries a kill-switch
+receipt — a fix is credited only when the same corpus is measured with the
+change removed.
+
+**Conformance at release: 30,982 / 43,505 official (71.2 %).**
+
+## Features
+
+- **`typeof` on reified builtin constructors** (#4120). A builtin captured into
+  a value (`const C = Array`) reported `"object"`, because the standalone
+  carrier is a plain `$Object` singleton while the `typeof` natives classify by
+  closure-wrapper shape. Now carried on two internal-slot bits, so callable and
+  constructible are distinguished (`isNaN` is callable but not constructible)
+  and `Math`/`JSON`/`Reflect` correctly stay `"object"`.
+  **+16 files, 0 regressions across a 66-file control set.**
+- **`Object.prototype.toString` in standalone** (#4119 arm 1). A runtime
+  §20.1.3.6 classifier replaces a blanket refusal. **The 76 target rows go
+  0/76 → 75/76; the refusal bucket goes 76 → 0**, with 0 regressions across an
+  82-row sweep. Receivers the classifier cannot yet tag correctly — `$Proxy`
+  (which subtypes `$Object`, so a revoked proxy must still throw), primitive
+  wrapper objects, and a few exotics — keep the **loud refusal** rather than
+  falling through to a default `[object Object]`.
+- **Own-property visibility over the unified store** (#4010 S3). `hasOwnProperty`,
+  `in`, `getOwnPropertyDescriptor` and `Object.keys` now see properties held in
+  the carrier bag. **+4 files, 0 regressions**, validated against the complete
+  729-file at-risk stratum (`built-ins/**/{name,length}.js`), not a sample.
+- **Deletability on class instances** (#4098 stage 1). `delete o[k]` is now real
+  on a user-declared class instance, via a per-instance tombstone store. This is
+  substrate: it flips no test262 files on its own (the property-descriptor
+  verifier is all-or-nothing and needs the remaining stages), and shipping it
+  alone is deliberate — the alternative partial reproduces a known 684-file
+  regression.
+
+## Fixes
+
+- **`Object.create` silently dropped every accessor descriptor** (#4061). Its
+  static expansion set the accessor flag but never compiled the getter, so
+  `Object.create({}, {p: {get: () => 9}}).p` evaluated to `0` — a wrong answer
+  with no error, on the *legal* path. Accessor-bearing descriptors now route to
+  the dynamic applier.
+- **Descriptor-argument validation per §8.10.5** (#4061). `Object.create` and
+  `Object.defineProperties` now reject non-object descriptors, non-callable
+  `get`/`set`, and data+accessor conflicts. **16/17 target files, 0 regressions
+  across a 182-file sweep.**
+- **Non-writable builtin properties were silently writable into the closure
+  bag** (#4010). A write to a builtin's non-writable `name`/`length` was
+  deposited invisibly, which made `configurable: true` assertions fail across
+  roughly 700 files whenever own-property queries widened. Fixed at the source
+  (§10.1.9 `OrdinarySet` is a no-op over a non-writable own data property)
+  rather than at the query.
+
+## Other
+
+- **Pre-commit fast lane.** The full pre-commit chain exceeded tooling timeouts,
+  which drove wholesale `--no-verify` and disarmed the cheap format/lint gate
+  along with it. `SKIP_SLOW_PRECOMMIT=1` now skips only the slow checks; the
+  formatter always runs. CI is unchanged.
+- Issues filed with reduced repros and measurement-backed acceptance criteria:
+  #4143, #4146, #4147, #4148, #4151.
+
+## Known gaps
+
+- `Object.prototype.toString` on `Date`/`Error`/`RegExp`/class instances,
+  `$Proxy`, and Symbol/BigInt wrappers still refuses loudly (#4119 arm 2 and
+  successors). A refusal is deliberate here: a wrong tag would be worse.
+- `Array.prototype` methods other than `slice`/`toString` still refuse when used
+  as values (#4119, #3571).
+- Class *instance fields* remain invisible to `getOwnPropertyDescriptor` and
+  `Object.keys` (#4098 stages 2–4); only deletability landed in this release.

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -25,7 +25,7 @@
 //      publish-npm.yml on un-reviewed code. See docs/releasing.md.
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -114,6 +114,99 @@ function setVersion(dir, version) {
   });
 }
 
+// Which remote is the PUBLISHING repo? `origin` is NOT a safe default: in this
+// project's agent worktrees (and any fork-based clone) `origin` is the FORK, so
+// the script's old `git push origin <tag>` instruction tagged the fork — where
+// publish-npm.yml never fires against the real package. The release then looks
+// done while nothing ships. Resolve by URL, and say so when it isn't `origin`.
+export function pickUpstreamRemote(remotesOutput) {
+  const remotes = new Map();
+  for (const line of remotesOutput.split("\n")) {
+    const m = line.match(/^(\S+)\s+(\S+)/);
+    if (m) remotes.set(m[1], m[2]);
+  }
+  for (const [name, url] of remotes) {
+    if (/[/:]loopdive\/js2(\.git)?$/.test(url)) {
+      return {
+        name,
+        note:
+          name === "origin"
+            ? null
+            : `the publishing remote here is '${name}' (${url}), NOT 'origin' ` +
+              `(${remotes.get("origin") ?? "unset"}). Pushing the tag to 'origin' would tag a fork ` +
+              `and publish nothing.`,
+      };
+    }
+  }
+  return {
+    name: "origin",
+    note: "could not identify a remote pointing at loopdive/js2 — VERIFY which remote publishes before pushing the tag.",
+  };
+}
+
+function upstreamRemote() {
+  try {
+    return pickUpstreamRemote(git(["remote", "-v"]));
+  } catch {
+    return { name: "origin", note: "could not read git remotes — verify the publishing remote by hand." };
+  }
+}
+
+// Draft release notes from the commit range, so the notes exist before the
+// release PR is opened rather than being reconstructed afterwards. Merge
+// commits carry the PR titles, which are the useful unit here (the project
+// merges, never rebases). Written to docs/release-notes/<tag>.md and included
+// in the release commit; edit before merging if the generated grouping is off.
+export function groupReleaseLines(subjects) {
+  const groups = { Features: [], Fixes: [], Other: [] };
+  for (const s of subjects) {
+    const title = s.replace(/^Merge pull request #\d+ from \S+\s*/, "").trim();
+    if (!title || /^release: v/.test(title)) continue;
+    if (/^(feat|perf)[(:]/.test(title)) groups.Features.push(title);
+    else if (/^fix[(:]/.test(title)) groups.Fixes.push(title);
+    else groups.Other.push(title);
+  }
+  return groups;
+}
+
+function writeReleaseNotes(target, tag, previousVersion) {
+  const prevTag = `v${previousVersion}`;
+  let subjects = [];
+  try {
+    const hasPrev = git(["tag", "--list", prevTag]).trim();
+    const range = hasPrev ? `${prevTag}..HEAD` : "HEAD";
+    subjects = git(["log", range, "--format=%s"]).split("\n").filter(Boolean);
+  } catch {
+    return null; // notes are a convenience; never fail a release over them
+  }
+
+  const g = groupReleaseLines(subjects);
+  const section = (name, lines) => (lines.length ? `## ${name}\n\n${lines.map((l) => `- ${l}`).join("\n")}\n\n` : "");
+  const body =
+    `# ${tag}\n\n` +
+    `Lockstep release of \`@loopdive/js2\` and the \`js2wasm\` proxy: ` +
+    `${previousVersion} → ${target}.\n\n` +
+    section("Features", g.Features) +
+    section("Fixes", g.Fixes) +
+    section("Other", g.Other) +
+    `<!-- Drafted by scripts/release.mjs from ${prevTag}..HEAD. Edit before merging: ` +
+    `commit subjects are a starting point, not the announcement. Conformance ` +
+    `numbers belong here with their denominators. -->\n`;
+
+  const notesDir = join(repoRoot, "docs", "release-notes");
+  const notesPath = join(notesDir, `${tag}.md`);
+  try {
+    mkdirSync(notesDir, { recursive: true });
+    writeFileSync(notesPath, body);
+    git(["add", notesPath]);
+    git(["commit", "--amend", "--no-edit", "--no-verify"]);
+    git(["tag", "-f", "-a", tag, "-m", tag]); // re-point the tag at the amended commit
+    return `docs/release-notes/${tag}.md`;
+  } catch {
+    return null;
+  }
+}
+
 function main() {
   const arg = process.argv[2];
   if (!arg) {
@@ -189,17 +282,24 @@ function main() {
   const commitSha = git(["rev-parse", "HEAD"]).trim();
   console.log(`Created release commit ${commitSha.slice(0, 9)} and tag ${tag}.\n`);
 
+  const notesPath = writeReleaseNotes(target, tag, currentRoot);
+  if (notesPath) console.log(`Release notes drafted: ${notesPath}\n`);
+
+  const upstream = upstreamRemote();
   console.log("NEXT STEPS:");
   console.log(`  1) Push the BRANCH normally and open a 'release: ${tag}' PR — do NOT push the tag yet.`);
   console.log(`  2) ⚠️  Do NOT 'git push --tags' / '--follow-tags' before merge — publish-npm.yml`);
   console.log(`     fires on ANY v<x.y.z> push and would publish un-reviewed code.`);
-  console.log(`  3) After the PR merges (the merge commit keeps your tagged commit in main's`);
-  console.log(
-    `     history), push the tag to trigger publish:\n` +
-      `       git push origin ${tag}\n` +
-      `     publish-npm.yml's verify-version job confirms the tag, manifests,`,
-  );
+  console.log(`  3) After the PR merges, VERIFY before tagging — a squash/rebase would leave the`);
+  console.log(`     tagged commit off main and the tag would point at an orphan:`);
+  console.log(`       git fetch ${upstream.name} main`);
+  console.log(`       git merge-base --is-ancestor ${tag}^{commit} FETCH_HEAD && echo IN-MAIN`);
+  console.log(`  4) Then push the tag to trigger publish:`);
+  console.log(`       git push --no-verify ${upstream.name} refs/tags/${tag}:refs/tags/${tag}`);
+  console.log(`       git ls-remote --tags ${upstream.name} refs/tags/${tag}   # verify it LANDED`);
+  console.log(`     publish-npm.yml's verify-version job confirms the tag, manifests,`);
   console.log(`     and proxy dependency all match before publishing. See docs/releasing.md.`);
+  if (upstream.note) console.log(`\n  ⚠️  ${upstream.note}`);
 }
 
 if (resolve(process.argv[1] || "") === releaseScriptPath) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -299,6 +299,13 @@ function main() {
   console.log(`       git ls-remote --tags ${upstream.name} refs/tags/${tag}   # verify it LANDED`);
   console.log(`     publish-npm.yml's verify-version job confirms the tag, manifests,`);
   console.log(`     and proxy dependency all match before publishing. See docs/releasing.md.`);
+  if (notesPath) {
+    console.log(`  5) Publish the notes onto the GitHub Release (publish-npm.yml creates the`);
+    console.log(`     release with an EMPTY body, so this is what readers actually see):`);
+    console.log(`       gh release edit ${tag} -R loopdive/js2 --notes-file ${notesPath}`);
+    console.log(`       gh release view ${tag} -R loopdive/js2 --json body   # verify it landed`);
+    console.log(`     ('edit', not 'create' — the release already exists by then.)`);
+  }
   if (upstream.note) console.log(`\n  ⚠️  ${upstream.note}`);
 }
 


### PR DESCRIPTION
## Why

Cutting v0.68.0 exposed a real defect in `scripts/release.mjs`: its NEXT STEPS said

```
git push origin v0.68.0
```

but in this project's agent worktrees — and in any fork-based clone — **`origin` is the FORK**. Following that instruction tags the fork, where `publish-npm.yml` never fires against the real package. The release *looks* complete and nothing ships. It needed a manual correction to push to `upstream` instead.

Two more things the v0.68.0 cut surfaced, both now in the printed steps:

- **The tag push hangs past tool timeouts** on the pre-push hook chain, and the first attempt landed nothing while appearing to have run — so the steps now use `--no-verify` (sanctioned for pushes here) and an `ls-remote` **verification** that the ref actually landed.
- **The tagged commit must be verified in `main`'s history** before pushing the tag. The script's comment assumed the merge preserves it; that is true for merge commits but a squash or rebase would leave the tag pointing at an orphan, and `verify-version` would not catch it.

## What changed

- `pickUpstreamRemote()` — resolves the publishing remote by **URL**, not by name, and prints a warning naming the correct remote when it isn't `origin`. Unknown topology says so explicitly rather than silently defaulting.
- `writeReleaseNotes()` — drafts `docs/release-notes/<tag>.md` from the previous tag's commit range, grouped feat/fix/other, and folds it into the release commit so notes exist *before* the release PR is opened. Failure to draft never fails a release.
- NEXT STEPS rewritten with the ancestry check, the verified tag push, and the `ls-remote` confirmation.

Both new helpers are exported and were unit-checked against a fork topology (picks `upstream`, warns), a plain clone (picks `origin`, silent), and commit-subject grouping.

Also adds **`docs/release-notes/v0.68.0.md`**, written by hand since that release shipped before this change — a conformance release covering the typeof fix, `Object.prototype.toString`, own-property visibility, descriptor-argument validation, and the `Object.create` silent-accessor bug, with denominators and a known-gaps section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCuWfyTva65YvSDcAnfpPi