### PR TITLE
feat(#743): new-expression call sites for parameter inference — measured, worth 2 slots

### DIFF
--- a/plan/issues/743-whole-program-type-flow-analysis.md
+++ b/plan/issues/743-whole-program-type-flow-analysis.md
@@ -27,6 +27,19 @@ files:
   src/codegen/expressions.ts:
     breaking:
       - "use narrowed parameter/return types from whole-program analysis"
+loc-budget-allow:
+  # +6: a three-line comment and one call in `deriveFnctorFields`, which is the
+  # single place a fnctor field slot is chosen and therefore the only place this
+  # narrowing can be applied. All of the decision logic — the flag, the
+  # parameter-resolution checks, the call-site query and the f64-only
+  # restriction — lives in the new `fnctor-ctor-param-types.ts`.
+  - src/codegen/fnctor-escape-gate.ts
+func-budget-allow:
+  # `deriveFnctorFields` 300 -> 301, crossing the threshold by one line for the
+  # call described above. Splitting it is a real refactor (#3399) and doing it
+  # underneath a flag-gated inference change would make both harder to review;
+  # the function is not growing in complexity, only in one delegation.
+  - src/codegen/fnctor-escape-gate.ts::deriveFnctorFields
 ---
 
 # #743 — Whole-program type flow analysis

--- a/src/codegen/declarations/param-return-inference.ts
+++ b/src/codegen/declarations/param-return-inference.ts
@@ -93,7 +93,7 @@ export function inferParamTypeFromCallSites(
   let sawCallSite = false;
   let sawUnderApplied = false;
 
-  const isRecursiveCall = (call: ts.CallExpression): boolean => {
+  const isRecursiveCall = (call: ts.CallExpression | ts.NewExpression): boolean => {
     const target = ctx.oracle.valueDeclarationOf(call.expression);
     for (let owner: ts.Node | undefined = call.parent; owner; owner = owner.parent) {
       if (!ts.isFunctionLike(owner)) continue;
@@ -105,7 +105,28 @@ export function inferParamTypeFromCallSites(
   };
 
   function visit(node: ts.Node) {
-    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === funcName) {
+    // (#743) `new F(…)` is a call site for F's PARAMETERS exactly as `F(…)` is —
+    // same arity rules, same argument-to-parameter mapping, same under-application
+    // semantics. Until now only `isCallExpression` matched, so every
+    // function-style constructor's parameters were invisible to this inference:
+    // acorn's `new Parser(options, input, startPos)` contributed nothing, and its
+    // ctor params stayed `any`, which is what seeds 43 of its 96 fnctor field
+    // slots as `externref` (#4155 census). Widening the node test is the whole
+    // change — the agreement, conflict, under-application (#3548) and recursion
+    // (#3961) soundness rules below are shared verbatim.
+    //
+    // Gated with the field half (`fnctor-ctor-param-types.ts`) on the SAME
+    // variable, and checked inline rather than imported to avoid a module cycle
+    // (that module imports this one). The two must not be separable: narrowing
+    // the parameter while the slot stays `externref` re-boxes on every store and
+    // measured strictly WORSE than doing nothing (+27 bytes on a one-field
+    // fixture). Default off — see that module for the acorn numbers.
+    const ctorSitesEnabled = process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES === "1";
+    if (
+      (ts.isCallExpression(node) || (ctorSitesEnabled && ts.isNewExpression(node))) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === funcName
+    ) {
       // A matching call exists regardless of arg types — the function IS invoked
       // internally, so its params are determined by runtime call args, not the
       // body-usage fallback. Record this before any conflict short-circuit.
@@ -117,9 +138,13 @@ export function inferParamTypeFromCallSites(
       // zero-arg call site's pad could only satisfy with `ref.null` +
       // `ref.as_non_null` — an unconditional runtime trap on the (usually
       // passing) zero-arg path.
-      if (node.arguments.length <= paramIndex) sawUnderApplied = true;
+      // `new F` with no parens has NO argument list at all (`arguments` is
+      // undefined, not empty) — that is an under-applied site for every
+      // parameter, so treat a missing list as length 0 rather than skipping it.
+      const callArgs = node.arguments;
+      if ((callArgs?.length ?? 0) <= paramIndex) sawUnderApplied = true;
       if (!conflict) {
-        const arg = node.arguments[paramIndex];
+        const arg = callArgs?.[paramIndex];
         if (arg) {
           const argType = ctx.checker.getTypeAtLocation(arg);
           // Skip if the argument itself is also `any` — no useful info

--- a/src/codegen/fnctor-ctor-param-types.ts
+++ b/src/codegen/fnctor-ctor-param-types.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#743) Give a fnctor field the type its constructor PARAMETER was narrowed to.
+ *
+ * `deriveFnctorFields` picks a slot from the CHECKER's view of the assigned
+ * value. For `function P(start) { this.pos = start }` the checker says `any`, so
+ * the slot boxes — even when every `new P(…)` site in the module passes a
+ * number. On acorn that single pattern is most of the 43-of-96 `unknown` slots
+ * the #4155 census reports, because its constructors take untyped parameters and
+ * seed nearly every field straight from one.
+ *
+ * `inferParamTypeFromCallSites` already computes the answer, with the soundness
+ * rules that matter: every call site must AGREE, a conflict bails, an
+ * under-applied site widens (#3548), and a value forwarded recursively is
+ * treated as dynamic (#3961). Until this slice it could not see `new F(…)` at
+ * all — it matched only `isCallExpression` — so constructors contributed
+ * nothing. Widening that test is the companion half of this change.
+ *
+ * **Both halves are required, and neither is useful alone.** Narrowing the
+ * parameter without the slot makes the ctor store an f64 into an `externref`
+ * field, which re-boxes on every construction: measured +27 bytes on a
+ * one-field fixture, i.e. strictly worse than doing nothing. Narrowing the slot
+ * without the parameter is the mirror image — an `externref` local unboxed at
+ * every store, with a new failure mode when the value is not numeric. They move
+ * together or not at all.
+ *
+ * Deliberately NARROW:
+ *  - only a bare parameter reference (`this.x = start`), never an expression
+ *    over one — anything else is the existing carrier logic's job;
+ *  - only when the checker itself gave up (`rhsWasm` is `externref`), so a slot
+ *    that already has a machine type is never perturbed;
+ *  - only f64. The other narrowings `inferParamTypeFromCallSites` can return
+ *    (refs, native strings, bool-branded i32) each carry their own null and
+ *    identity questions at a struct field, and none of them is the acorn case;
+ *  - a named function declaration only, since the inference is keyed by name.
+ */
+import { ts } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+import type { ValType } from "../ir/types.js";
+import { inferParamTypeFromCallSites } from "./declarations/param-return-inference.js";
+
+/**
+ * OFF by default — opt in with `JS2WASM_FNCTOR_CTOR_PARAM_TYPES=1`.
+ *
+ * The mechanism works (a one-field fixture goes `externref` → `f64`, and the
+ * #2660/#4155 fnctor suites stay green), but on the corpus it was built for it
+ * does not yet pay: **acorn recovers 2 slots** (`unknown` 43 → 41) **for +90
+ * bytes** (943,140 → 943,230). Direct call-site agreement is not enough there,
+ * because acorn's constructor arguments are themselves untyped values forwarded
+ * from other untyped parameters — `new Parser(options, input, startPos)` inside
+ * a function whose own params are `any` teaches this pass nothing.
+ *
+ * Resolving the other 41 needs #743's actual Phase 2: an iterative fixpoint that
+ * propagates types transitively through the call graph until convergence, rather
+ * than a single-hop agreement check. This slice is the prerequisite for that —
+ * it establishes that `new F(…)` participates at all — not a substitute.
+ *
+ * Kept and shipped rather than deleted because the negative result is the
+ * useful part: the next attempt should start from the fixpoint, and should not
+ * re-derive that single-hop agreement is worth 2 slots.
+ */
+export function fnctorCtorParamTypesEnabled(): boolean {
+  return process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES === "1";
+}
+
+/**
+ * The narrowed slot type for `this.<field> = <param>`, or null to leave the
+ * existing checker-derived choice alone.
+ */
+export function inferFnctorFieldTypeFromCtorParam(
+  ctx: CodegenContext,
+  funcDecl: ts.FunctionDeclaration | ts.FunctionExpression,
+  valueExpr: ts.Expression,
+  rhsWasm: ValType,
+): ValType | null {
+  if (!fnctorCtorParamTypesEnabled()) return null;
+  // Only rescue a slot the checker could not type; never perturb a typed one.
+  if (rhsWasm.kind !== "externref") return null;
+  if (!ts.isIdentifier(valueExpr)) return null;
+  const name = funcDecl.name?.text;
+  if (name === undefined) return null;
+
+  // The identifier must resolve to a PARAMETER OF THIS constructor — not a
+  // same-named outer binding, and not a local that shadows one.
+  const decl = ctx.oracle.valueDeclarationOf(valueExpr);
+  if (decl === undefined || !ts.isParameter(decl)) return null;
+  if (decl.parent !== funcDecl) return null;
+  // A defaulted or rest parameter does not have the plain positional
+  // argument-to-parameter mapping the call-site scan assumes.
+  if (decl.initializer !== undefined || decl.dotDotDotToken !== undefined) return null;
+
+  const paramIndex = funcDecl.parameters.indexOf(decl);
+  if (paramIndex < 0) return null;
+
+  const inferred = inferParamTypeFromCallSites(ctx, name, paramIndex, funcDecl.getSourceFile());
+  // `sawCallSite && type === null` is the polymorphic/conflicting case — the
+  // scan's own signal that narrowing would be unsound. No call sites at all is
+  // equally inconclusive here (an exported ctor invoked from outside).
+  if (!inferred.sawCallSite || inferred.type === null) return null;
+  return inferred.type.kind === "f64" ? { kind: "f64" } : null;
+}

--- a/src/codegen/fnctor-escape-gate.ts
+++ b/src/codegen/fnctor-escape-gate.ts
@@ -47,6 +47,7 @@ import type { FieldDef } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { appendFnctorInternalFields } from "./fnctor-identity-fields.js";
 import { recordFnctorFieldProvenance } from "./fnctor-field-provenance.js";
+import { inferFnctorFieldTypeFromCtorParam } from "./fnctor-ctor-param-types.js";
 import { resolveWasmType } from "./index.js";
 
 /** Classification of a `new F()` fnctor allocation site. */
@@ -1454,13 +1455,18 @@ export function deriveFnctorFields(
     // cast `getOptions(options)` to null at the constructor assignment. The
     // early carrier scan records the RHS return type before fnctor reservation,
     // so let that proven dynamic representation override the nominal LHS.
+    // (#743) `this.x = <ctor param>` — narrow the slot to what the parameter's
+    // call sites agree on. Off by default; rationale + acorn numbers live in
+    // `fnctor-ctor-param-types.ts`.
+    const paramInferred = inferFnctorFieldTypeFromCtorParam(ctx, funcDecl, valueExpr, rhsWasm);
     const fieldType = carrierIsDynamicObjectCall
       ? ({ kind: "externref" } as const)
-      : ctx.objectHashConsumerTypes.has(rhsType) || ctx.objectHashConsumerTypes.has(carrierType)
-        ? carrierWasm
-        : lhsWasm.kind === "externref"
-          ? rhsWasm
-          : lhsWasm;
+      : (paramInferred ??
+        (ctx.objectHashConsumerTypes.has(rhsType) || ctx.objectHashConsumerTypes.has(carrierType)
+          ? carrierWasm
+          : lhsWasm.kind === "externref"
+            ? rhsWasm
+            : lhsWasm));
     fields.push({
       name: fieldName,
       type: fieldType,


### PR DESCRIPTION
## Description

A first slice of #743's forward propagation, shipped **default-off with a negative measurement**, because the negative result is the useful part.

### What was actually missing

Call-site parameter inference already exists (`inferParamTypeFromCallSites`) with real soundness rules — all sites must agree, conflicts bail, under-application widens (#3548), recursive forwarding is dynamic (#3961). It matched only `isCallExpression`, so **`new F(…)` was invisible**: every function-style constructor's parameters got no call-site inference at all. That is exactly acorn's `new Parser(options, input, startPos)`.

### Two halves, neither useful alone

1. **`param-return-inference.ts`** — the node test now also matches `ts.NewExpression`. `new F` with no parens has no argument list at all (`arguments` is `undefined`, not empty), so a missing list counts as under-applied rather than being skipped.
2. **`fnctor-escape-gate.ts`** — `deriveFnctorFields` picks the slot from the *checker* type, so half 1 alone made the ctor store a narrowed f64 into an `externref` field, re-boxing on every construction: **+27 bytes, strictly worse than doing nothing**. The slot now consults the same inference.

Both are gated on one variable so they cannot be separated.

### Measured on acorn — it does not pay yet

| | before | after |
|---|---:|---:|
| census `unknown` | 43 | **41** |
| census `typed` | 49 | 51 |
| binary | 943,140 B | 943,230 B (**+90**) |
| imports / canaries | 0 / 2,3,4,5 | 0 / 2,3,4,5 |

Two slots, for ninety bytes. acorn's constructor *arguments* are themselves untyped values forwarded from other untyped parameters, so single-hop agreement teaches this pass almost nothing. Resolving the other 41 needs #743's actual Phase 2 — an iterative fixpoint propagating transitively through the call graph until convergence, not a one-hop agreement check.

**So this ships `JS2WASM_FNCTOR_CTOR_PARAM_TYPES=1`, default off** (byte-identical when off: 92,555 both ways on the fixture). Kept rather than deleted so the next attempt starts from the fixpoint and does not re-derive that single-hop agreement is worth 2 slots.

### Verification

- Mechanism: fixture slot goes `externref` → `f64`, result unchanged.
- **32 tests** green across the #4155 Phase 0 and #2660 fnctor suites.
- Default-off path byte-identical to base.
- Gates by **exit code**: `loc-budget` (+6, granted), `func-budget` (`deriveFnctorFields` 300→301, granted), `oracle-ratchet` (+0), `dead-exports`, `tsc --noEmit`, prettier.

Both budget grants are in #743's own frontmatter with justification: the call has to live at the single place a slot is chosen, and all decision logic is in the new `fnctor-ctor-param-types.ts`.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_