### PR TITLE
perf(#4156): host-import wrapper — dispatch on arguments.length, not ...args (~4%, and the wasm→JS crossing is the real cost)

### DIFF
--- a/plan/issues/4156-host-import-wrapper-per-call-overhead.md
+++ b/plan/issues/4156-host-import-wrapper-per-call-overhead.md
@@ -1,0 +1,146 @@
+---
+id: 4156
+title: "perf: the host-import wrapper allocated a rest-args array on every call — and the wasm→JS crossing, not the wrapper, is what makes the host-call lane 4–14x slower than js"
+status: done
+created: 2026-08-04
+updated: 2026-08-04
+completed: 2026-08-04
+priority: medium
+feasibility: easy
+reasoning_effort: high
+task_type: performance
+area: runtime
+language_feature: n/a
+goal: performance
+sprint: current
+horizon: s
+es_edition: n/a
+related: [3898, 3922, 3924]
+loc-budget-allow:
+  - src/runtime.ts
+---
+
+# #4156 — host-import wrapper overhead, and where the host-call gap actually lives
+
+## Status: done — small fix landed; the large finding is that the wrapper was never the main cost
+
+## What was changed
+
+Every host import in a compiled module passes through a single wrapper in
+`buildImports` (recursion-depth guard + exception capture for `catch_all`). It
+collected `...args` and called `.apply`, so **every** host call — string method,
+DOM operation, coercion — allocated a fresh array.
+
+Replaced with a switch on `arguments.length` dispatching to a direct `.call`
+for 0–4 arguments, falling back to `.apply(this, arguments)` beyond that.
+
+Interleaved wasm-side A/B, 200 samples × 2 rounds, 1000
+`String.prototype.includes` calls per sample, alternating runtimes by file copy
+(**not** `git stash` — shared-stack hazard):
+
+| wrapper | median ns/op |
+| --- | --- |
+| `...args` + `.apply` | 66.2 / 69.5 |
+| `switch` → `.call` | 64.9 / 65.4 |
+
+**~4%**, both rounds favouring the new shape, and noticeably steadier
+(round-to-round spread 4.6 → 0.5 ns).
+
+## Trap 1 — the obvious measurement is the wrong one
+
+A JS→JS microbenchmark of the two wrapper shapes reports **57.9 → 34.0 ns/op,
+a 41% cut**. That number was nearly shipped as the headline. It does not
+transfer: host imports are called **from wasm**, and V8's wasm→JS entry already
+materialises the argument list, so most of the rest-parameter saving never
+appears. The honest figure is ~4%.
+
+The lesson generalises past this change: when optimising a wrapper, benchmark it
+on the call path it actually sits on, not the one that is convenient to set up.
+
+## Trap 2 — arity specialisation must key off arguments RECEIVED
+
+The tempting version of this fix builds a fixed-arity wrapper from
+`original.length`. That is **unsound here**: `length` is 0 for a variadic or
+defaulted callee, so such a wrapper would declare zero parameters and silently
+drop every argument. Several resolved imports are variadic.
+
+Keying the switch off `arguments.length` forwards exactly what was received,
+whatever the callee's declared arity. Verified against a variadic callee
+(`length === 0`) for 0, 1, 2, 3, 4, 5 and 7 arguments — the callee observed
+exactly what was passed in every case.
+
+## The larger finding — the wrapper was never the main cost
+
+Decomposing `string/includes` in the host-call lane (1000 ops per call):
+
+| component | ns/op |
+| --- | --- |
+| full loop, wasm host-call lane | ~65 |
+| the same `includes` work in raw JS | 17.5 |
+| inline `h.includes(...)`, no call at all | 18.3 |
+| js reference (whole benchmark) | 17.0 |
+| loop + arithmetic only, no host call | 7.1 |
+
+So of ~65 ns/op, only **~17 ns is the actual work** — the remaining **~48 ns is
+the wasm→JS crossing itself**. No wrapper change reaches that.
+
+A second measurement rules out a plausible alternative culprit: removing the
+`(i * 61) % 10011` argument arithmetic (which lowers to an f64 modulo **helper
+call**, since wasm has no f64 remainder instruction) changes the total by only
+**2.5 ns/op** (69.0 → 66.5). The f64 modulo helper is nearly free here and is
+not worth pursuing for this benchmark, despite looking suspicious in the WAT.
+
+**Consequence:** the host-call lane cannot be brought near parity by making the
+boundary cheaper. It has to stop crossing the boundary per operation. That is
+exactly why the gc-native lane — which lowers these operations to native WasmGC
+kernels and never leaves wasm — runs the same benchmarks at ~1.1x:
+
+| benchmark | host-call | gc-native |
+| --- | --- | --- |
+| `string/split` | 13.8x | 1.09x |
+| `string/includes` | 8.1x | 1.08x |
+| `string/trim` | 5.4x | 1.45x |
+| `string/indexOf` | 4.1x | 1.09x |
+
+The same crossing cost explains the DOM benchmarks sitting at ~3.1–3.5x, since
+those are *nothing but* host calls.
+
+## Follow-up worth its own issue
+
+Closing the host-call gap properly means one of:
+
+1. **Native kernels over host strings** — materialise once, scan in wasm. Only
+   pays off when the per-call crossing exceeds the copy, so it needs a
+   length threshold and a way to cache the materialised form across calls.
+2. **Keep strings native in more configurations** — i.e. widen where the
+   gc-native representation is used, which is the direction #3912 was already
+   pushing on the number→string side.
+
+Both are codegen-scale changes and neither is attempted here. Recorded so the
+~4% wrapper fix is not mistaken for having addressed the 4–14x gap.
+
+## Acceptance criteria
+
+1. ✅ The rest-args allocation is gone from the host-import path.
+2. ✅ Forwarding is exact for variadic and defaulted callees, verified across
+   0–7 arguments.
+3. ✅ No new test failures: `tests/equivalence/spec` and
+   `dom-extern-class` show only the 8 pre-existing `coercion/arithmetic-add`
+   failures, which reproduce **identically on the base runtime** (8 failed / 12
+   passed either way). `tests/playground-full.test.ts` fails to collect because
+   `playground/` does not exist in this checkout — environmental.
+4. ✅ The measured effect is reported as ~4%, not as the misleading 41%.
+
+## Note on the LOC budget
+
+`src/runtime.ts` is a god-file sitting exactly at its ceiling (16352), so any
+growth trips `check:loc-budget`. The comment was trimmed to the two traps that
+would otherwise be re-discovered the hard way; the switch itself is irreducibly
+~12 lines. `loc-budget-allow` is granted in this issue's frontmatter for that
+reason.
+
+## Provenance
+
+From a request to optimise the performance-page benchmarks. The measurement
+groundwork — and the discovery that several of those benchmarks were not
+measuring anything real — is #3898 and PR #4118.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15915,7 +15915,18 @@ export function buildImports(
     // Wrap host imports with recursion depth guard + exception capture for catch_all
     {
       const original = fn;
-      fn = function (this: any, ...args: any[]) {
+      // (#4156) Dispatch on `arguments.length` to a direct `.call` rather than
+      // collecting `...args` and using `.apply`: the rest parameter allocates an
+      // array on EVERY host import call, and this wrapper is on the path of all
+      // of them. Wasm-side A/B: ~4% (66.2/69.5 -> 64.9/65.4 ns/op) and steadier.
+      //
+      // Two traps, both recorded in #4156. (1) A JS->JS microbenchmark of these
+      // shapes claims -41%; that is MISLEADING, because V8's wasm->JS entry
+      // already materialises the argument list. (2) The switch must key off
+      // arguments RECEIVED, never `original.length` — that is 0 for a variadic
+      // or defaulted callee, so an arity-specialised wrapper built from it would
+      // silently drop arguments.
+      fn = function (this: any) {
         if (importCounts) importCounts[importIndex]++;
         if (hostCallDepth >= MAX_HOST_RECURSION_DEPTH) {
           const err = new RangeError("Maximum call stack size exceeded");
@@ -15924,7 +15935,21 @@ export function buildImports(
         }
         hostCallDepth++;
         try {
-          return original.apply(this, args);
+          switch (arguments.length) {
+            case 0:
+              return original.call(this);
+            case 1:
+              return original.call(this, arguments[0]);
+            case 2:
+              return original.call(this, arguments[0], arguments[1]);
+            case 3:
+              return original.call(this, arguments[0], arguments[1], arguments[2]);
+            case 4:
+              return original.call(this, arguments[0], arguments[1], arguments[2], arguments[3]);
+            default:
+              // Exact forwarding for the rare >4-argument import; no array literal.
+              return original.apply(this, arguments as unknown as any[]);
+          }
         } catch (e) {
           lastCaughtException = e;
           throw e;


### PR DESCRIPTION
## Description

Every host import in a compiled module passes through one wrapper in `buildImports` (recursion-depth guard + exception capture for `catch_all`). It collected `...args` and called `.apply`, so **every** host call allocated a fresh array — string methods, DOM operations, coercions, all of them.

Now a `switch` on `arguments.length` dispatching to a direct `.call` for 0–4 arguments, falling back to `.apply(this, arguments)` beyond that.

## The number is ~4%, and I nearly published 41%

A JS→JS microbenchmark of the two wrapper shapes reports **57.9 → 34.0 ns/op (−41%)**. I wrote that into the code comment before checking it. It's misleading: host imports are called **from wasm**, and V8's wasm→JS entry already materialises the argument list, so most of the rest-parameter saving never appears.

Interleaved wasm-side A/B — 200 samples × 2 rounds, 1000 `String.prototype.includes` calls per sample, runtimes alternated by file copy (**not** `git stash` — shared-stack hazard):

| wrapper | median ns/op |
|---|---|
| `...args` + `.apply` | 66.2 / 69.5 |
| `switch` → `.call` | 64.9 / 65.4 |

**~4%**, both rounds favouring the new shape, and steadier (round-to-round spread 4.6 → 0.5 ns). Small, free, and on the path of every host import. The in-code comment states the wasm-side figure and explicitly flags the JS-side one as misleading, so the next reader doesn't repeat it.

## Forwarding is exact — the part that had to be right

The tempting version builds a fixed-arity wrapper from `original.length`. That is **unsound**: `length` is 0 for a variadic or defaulted callee, and several resolved imports are variadic, so such a wrapper would declare zero parameters and silently drop every argument.

Keying the switch off `arguments.length` forwards exactly what was received, whatever the callee declares. Verified against a variadic callee (`length === 0`) for 0, 1, 2, 3, 4, 5 and 7 arguments — the callee observed exactly what was passed in every case.

## The wrapper was never the main cost

Decomposing `string/includes` in the host-call lane (1000 ops/call):

| component | ns/op |
|---|---|
| full loop, host-call lane | ~65 |
| same `includes` work in raw JS | 17.5 |
| inline `h.includes(...)`, no call | 18.3 |
| js reference (whole benchmark) | 17.0 |
| loop + arithmetic only, no host call | 7.1 |

Only **~17 ns is the actual work**; **~48 ns is the wasm→JS crossing itself**, which no wrapper change reaches.

A second measurement rules out the other suspect: the `(i * 61) % 10011` argument lowers to an f64 modulo **helper call** (wasm has no f64 remainder instruction) and looks damning in the WAT — but removing it moves the total by only **2.5 ns/op** (69.0 → 66.5).

**Consequence:** the host-call lane cannot approach parity by making the boundary cheaper, only by not crossing it per operation. That is exactly why the gc-native lane, which lowers these to native WasmGC kernels and never leaves wasm, runs the same benchmarks at ~1.1×:

| benchmark | host-call | gc-native |
|---|---|---|
| `string/split` | 13.8× | 1.09× |
| `string/includes` | 8.1× | 1.08× |
| `string/trim` | 5.4× | 1.45× |
| `string/indexOf` | 4.1× | 1.09× |

The same crossing cost explains the four DOM benchmarks at ~3.1–3.5×, since those are *nothing but* host calls.

## Verification

- No new test failures. `tests/equivalence/spec` + `dom-extern-class` show only the 8 `coercion/arithmetic-add` cases, which reproduce **identically on the base runtime** (8 failed / 12 passed either way) — pre-existing.
- `tests/playground-full.test.ts` fails to collect because `playground/` does not exist in this checkout at all — environmental, not caused by this change.
- `check:loc-budget`, `check:func-budget`, `check:oracle-ratchet`, `update-issues --check`, `check-issue-spec-coverage`, `check-issue-ids --against-main` all exit 0.

## LOC budget

`src/runtime.ts` is a god-file sitting **exactly** at its ceiling (16352), so any growth trips `check:loc-budget`. The comment was trimmed to the two traps a future reader would otherwise re-discover the hard way; the switch itself is irreducibly ~12 lines. `loc-budget-allow` is granted in #4156's frontmatter, which is the sanctioned mechanism.

## Not attempted here

Closing the 4–14× gap properly means either running native kernels over materialised host strings (needs a length threshold and cross-call caching, since the copy has to beat the crossing), or widening where the native string representation is used — the direction #3912 was already pushing. Both are codegen-scale bets; recorded in #4156 so this 4% isn't mistaken for having addressed the gap.

## CLA

Internal PR — the `cla-check` gate skips org-member PRs automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D29cj9ve5n7eQqnz4tUXk6

---
_Generated by [Claude Code](https://claude.ai/code/session_01D29cj9ve5n7eQqnz4tUXk6)_