### PR TITLE
fix(#3982): wire the react-dom upstream suite into the npm-compat generator

### DIFF
--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -43,6 +43,7 @@ import { runHarness as runPrettier } from "../tests/dogfood/prettier-harness.mjs
 import { runHarness as runReact } from "../tests/dogfood/react-harness.mjs";
 import { runHarness as runReactUpstreamSuite } from "../tests/dogfood/react-upstream-suite.mjs";
 import { runHarness as runLitUpstreamSuite } from "../tests/dogfood/lit-upstream-suite.mjs";
+import { runHarness as runReactDomUpstreamSuite } from "../tests/dogfood/react-dom-upstream-suite.mjs";
 import { NPM_COMPAT_CATALOG, NPM_COMPAT_CATALOG_NAMES } from "../tests/dogfood/npm-compat-catalog.mjs";
 import { runNpmCompatCatalogHarness } from "../tests/dogfood/npm-compat-catalog-harness.mjs";
 
@@ -1581,11 +1582,53 @@ if (selectedPackages.has("lit")) {
   );
 }
 
+if (selectedPackages.has("react-dom")) {
+  console.log("[npm-compat] react-dom — package entry + react-dom's own upstream unit tests...");
+  const reactDomEntry = NPM_COMPAT_CATALOG.find((entry) => entry.name === "react-dom");
+  const reactDomReport = await runNpmCompatCatalogHarness("react-dom", { quiet: true });
+  const reactDomSuite = await runReactDomUpstreamSuite({ quiet: true });
+  packages.push(
+    await buildPackageEntry({
+      name: "react-dom",
+      version: reactDomEntry.version,
+      issue: 3982,
+      entryFile: reactDomEntry.entryModule.replace(/^package\//, ""),
+      shape: reactDomEntry.shape,
+      report: reactDomReport,
+      // (#3982) The suite landed in PR #4079 but this card kept saying
+      // "not-integrated" — the same failure mode as lit/#3977: a suite that
+      // exists in tests/dogfood/ is invisible to the dashboard until THIS
+      // generator runs it, because the refresh workflow regenerates from this
+      // file alone. Denominator is `scored`, not the admitted count, matching
+      // the react card: a test the harness cannot reproduce natively says
+      // nothing about the compiler.
+      tests: {
+        kind: "upstream-suite",
+        passed: reactDomSuite.results?.passed ?? null,
+        total: reactDomSuite.results?.scored ?? null,
+        passRatePct: reactDomSuite.summary?.passRatePct ?? null,
+        admitted: reactDomSuite.extraction?.admitted ?? null,
+        upstreamTestsSeen: reactDomSuite.extraction?.upstreamTestsSeen ?? null,
+        harnessIncompatible: reactDomSuite.results?.harnessIncompatible ?? null,
+        // Why 0 can be scored while 1,942 are admitted: while #3982 is open the
+        // implementation module itself may be rejected, and the suite's OWN
+        // test file pins that this is REPORTED with the compiler's message,
+        // never a silent zero. Carry that explanation onto the card (the lit
+        // card does the same via implementationInvalidTests, #3977/#3978).
+        implementationInvalidTests: reactDomSuite.summary?.implementationInvalidTests ?? null,
+        implementationError: reactDomSuite.summary?.implementationError ?? null,
+        sourceIssue: 3982,
+      },
+      perf: null,
+    }),
+  );
+}
+
 for (const entry of NPM_COMPAT_CATALOG) {
   if (!selectedPackages.has(entry.name)) continue;
   // Handled above with its own upstream suite rather than as a bare
-  // package-entry card.
   if (entry.name === "lit") continue;
+  if (entry.name === "react-dom") continue;
   console.log(`[npm-compat] ${entry.name} — bounded published package-entry compile/validate...`);
   const report = await runNpmCompatCatalogHarness(entry.name, { quiet: true });
   packages.push(


### PR DESCRIPTION
## Description

The npm-compat page kept showing react-dom as "not-integrated; adapter pending" even after PR #4079 landed its upstream suite. **Deployment is fine** — the refresh workflow regenerates and promotes on schedule (twins byte-identical, artifact fresh). The cause is the exact **#3977 lit failure mode, again**: the dashboard is regenerated solely from `scripts/generate-npm-compat-report.mjs`, and that file was never taught to run the new suite — its only react-dom reference was a download count. A suite the generator does not run is invisible forever, refresh after refresh.

### The fix

Mirrors the lit/react integration precisely:

- import `runHarness` from `tests/dogfood/react-dom-upstream-suite.mjs`
- skip `react-dom` in the generic catalog loop (which is what emitted the eternal "not-integrated" card)
- build the card from real suite results — denominator is `scored`, not the admitted count, matching the react card's convention (a test the harness cannot reproduce natively says nothing about the compiler)

### What the card will now show — and why that's correct

Verified with a focused run (`--only react-dom --no-write`, exit 0):

```
upstreamTestsSeen: 2003   admitted: 1942   scored: 0   passed: 0
```

Zero scored is the suite's **actual current truth** while #3982 is open, and its own test file pins the reporting contract: an implementation the validator rejects must be *reported with the compiler's message, never left as a silent zero* — "frontier reporting, not pass-rate fiction". The card therefore also carries `implementationError` / `implementationInvalidTests` (as lit's card does per #3977/#3978), so the page can say *why* zero scored instead of rendering a bare 0/0.

### Notes

- **Refresh-job duration (#3988):** this lengthens the ~24-min workflow the same way wiring lit and react did. No concurrency/promotion semantics are touched.
- No artifact is committed here — per #3988 the workflow regenerates and auto-commits on the next merge to main; a hand-committed one would just be overwritten.
- Local-only footnote: reproducing this required `pnpm install` (#4079 added `jsdom` to `package.json`; CI installs fresh and was never affected).

## Testing

- Focused run `npx tsx scripts/generate-npm-compat-report.mjs --only react-dom --no-write`: exit 0, card emitted with the fields above; compile/validate section intact (`success: true, validates: true`).
- `node --check` and prettier clean. Docs/scripts-only change — no `src/` paths touched.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_