### PR TITLE
feat(#4159/#4160): shared AST pre-scan flags for the prototype-index and accessor-descriptor substrate

### DIFF
--- a/plan/issues/4159-typed-lane-array-read-bypasses-vec-overlay-accessor.md
+++ b/plan/issues/4159-typed-lane-array-read-bypasses-vec-overlay-accessor.md
@@ -15,6 +15,18 @@ language_feature: arrays, property-descriptors
 goal: standalone-mode
 related: [3251, 3116, 2042, 3185]
 origin: "Design review of #3251's fast-path guard, 2026-08-04"
+# (#3102 LOC ratchet) Work Item A declares two new CodegenContext flags. A
+# context field has no subsystem module to live in — types.ts IS the
+# declaration site — so the growth is the irreducible cost of the flags
+# themselves, not logic added to a barrel. Comments were trimmed first; the
+# full rationale lives in this issue instead.
+loc-budget-allow:
+  - src/codegen/context/types.ts
+# (#3400 func ratchet) +2 lines in createCodegenContext: the two new flags need
+# an initialiser each, next to the existing protoIndexDirty. Same reasoning as
+# the LOC grant — a context field's initialiser has exactly one legal home.
+func-budget-allow:
+  - src/codegen/context/create-context.ts::createCodegenContext
 ---
 
 # #4159 — typed-lane array element access bypasses the vec overlay (accessor arm)
@@ -222,7 +234,10 @@ lazy per-site flag: function compilation order is not source order, so a lazily
 set flag desyncs reads in one function against stores in another. The same
 hazard applies here — reuse the pre-scan, do not invent a lazy flag.
 
-### Work Item A: `ctx.vecAccessorDescriptorDirty` pre-scan flag
+### Work Item A: `ctx.vecAccessorDescriptorDirty` pre-scan flag — **LANDED 2026-08-05**
+
+Shipped with #4160 slice 1 in one commit (the spec's own "land A once, consume it from both"). `isNonDataDescriptorDefine` covers `Object.defineProperty`/`defineProperties`/`Object.create`/`Reflect.defineProperty`, treats a provably data-only literal as clean (so #3251's value write-back keeps its fast path), and recurses one level into a descriptor bag. A descriptor held in a variable, a spread, or a computed key all set the flag — unprovable means dirty. Byte-identity A/B'd against main over 14 compilations: identical. Work Items B and C remain.
+
 **Risk**: Low — purely additive; no emission changes at all.
 **Priority**: 1st
 

--- a/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
+++ b/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
@@ -127,9 +127,35 @@ the flag is dirty. Programs that never touch a prototype index keep today's
 emission **byte-identical**, with no runtime guard, which is a stronger
 no-regression guarantee than any benchmark.
 
+## Slice 1 — LANDED 2026-08-05
+
+`protoIndexDirty` (renamed from `arrayProtoIndexDirty`) now matches
+`Object.prototype` as well as `Array.prototype`, and a new `dynamicCodeDirty`
+predicate forces it when the module contains `eval` / `Function` / `new
+Function` — closing the hole where static eval inlining (#1163) splices
+statements in *after* this pre-pass has run. Byte-identity verified by A/B
+against main's compiler over 14 compilations (7 programs x both lanes): all
+hashes identical.
+
+**One latent bug found and fixed while doing it.** The #2001 predicate matched
+only a bare `PropertyAccessExpression`, so `(Array.prototype as any)[0] = 1` —
+which is how you write it in **TypeScript**, the language this compiler actually
+consumes — did not set the flag. test262's plain-JS corpus has no cast, which is
+why it went unnoticed. `unwrapExpr` now strips parens and the type-only
+assertion forms.
+
+**Behaviour change to be aware of:** widening the flag also widens its one
+existing consumer, `shouldHoleSkip`. A module writing `Object.prototype[i]` or
+using `eval` now loses the HOF hole-visit-skip and falls back to
+visit-with-`undefined`. For an inherited *value* that is still not spec-correct
+(the callback should see the inherited value, not `undefined`) — but the visit
+COUNT becomes right, and the fallback is the prerequisite for slice 2, which
+makes the value right too. Verified against main: the hole/peephole test set has
+an identical pass/fail split before and after.
+
 ## Slices (suggested)
 
-1. **Widen the pre-scan to `Object.prototype`.** Generalise `isArrayPrototypeExpr`
+1. ~~**Widen the pre-scan to `Object.prototype`.**~~ **DONE** — Generalise `isArrayPrototypeExpr`
    to `isArrayOrObjectPrototypeExpr`, rename the flag to `protoIndexDirty` (keep
    an alias if that churns too many sites), and unit-test that
    `Object.prototype[1] = 1`, `Object.defineProperty(Object.prototype, "1", …)`

--- a/src/codegen/array-holes.ts
+++ b/src/codegen/array-holes.ts
@@ -57,7 +57,9 @@ import { emitUndefined } from "./expressions/late-imports.js";
  */
 export function scanForArrayHoles(ctx: CodegenContext, root: ts.Node): void {
   const visit = (node: ts.Node): void => {
-    if (ctx.usesArrayHoles && ctx.arrayProtoIndexDirty) return;
+    if (ctx.usesArrayHoles && ctx.protoIndexDirty && ctx.vecAccessorDescriptorDirty && ctx.dynamicCodeDirty) {
+      return;
+    }
     if (ts.isArrayLiteralExpression(node)) {
       for (const el of node.elements) {
         if (ts.isOmittedExpression(el)) {
@@ -66,27 +68,171 @@ export function scanForArrayHoles(ctx: CodegenContext, root: ts.Node): void {
         }
       }
     }
-    if (!ctx.arrayProtoIndexDirty && isArrayProtoIndexWrite(node)) {
-      ctx.arrayProtoIndexDirty = true;
+    if (!ctx.protoIndexDirty && isProtoIndexWrite(node)) {
+      ctx.protoIndexDirty = true;
+    }
+    if (!ctx.vecAccessorDescriptorDirty && isNonDataDescriptorDefine(node)) {
+      ctx.vecAccessorDescriptorDirty = true;
+    }
+    // (#4159/#4160) Dynamic code defeats the whole pre-scan: static eval
+    // inlining (#1163) splices parsed statements in during BODY compilation,
+    // after this pass has finished, so `eval('Array.prototype[0] = 1')` would
+    // otherwise leave every flag clear. Setting a flag lazily at splice time is
+    // exactly the desync this pass exists to prevent, so presence of dynamic
+    // code dirties everything, statically.
+    if (!ctx.dynamicCodeDirty && isDynamicCodeUse(node)) {
+      ctx.dynamicCodeDirty = true;
+      ctx.protoIndexDirty = true;
+      ctx.vecAccessorDescriptorDirty = true;
     }
     forEachChild(node, visit);
   };
   visit(root);
 }
 
-/** Structurally `Array.prototype` (`PropertyAccess(Identifier "Array", "prototype")`). */
-function isArrayPrototypeExpr(node: ts.Node): boolean {
+/**
+ * Structurally `Array.prototype` or `Object.prototype`
+ * (`PropertyAccess(Identifier "Array"|"Object", "prototype")`).
+ *
+ * (#4160) `Object.prototype` was added 2026-08-05. Only `Array.prototype` was
+ * matched before, which missed the dominant test262 shape — `15.4.4.18-7-b-12`
+ * and the 135 files sharing its assertion write `Object.prototype[1] = 1` and
+ * then iterate an array-LIKE (a plain object with a `length`), never an array.
+ */
+function isArrayOrObjectPrototypeExpr(node: ts.Node): boolean {
+  const inner = unwrapExpr(node);
   return (
-    ts.isPropertyAccessExpression(node) &&
-    node.name.text === "prototype" &&
-    ts.isIdentifier(node.expression) &&
-    node.expression.text === "Array"
+    ts.isPropertyAccessExpression(inner) &&
+    inner.name.text === "prototype" &&
+    ts.isIdentifier(inner.expression) &&
+    (inner.expression.text === "Array" || inner.expression.text === "Object")
   );
 }
 
 /**
- * (#2001 S2 / PR #2832 park) Does this node WRITE an index property onto
- * `Array.prototype`? Detects the shapes test262 uses to make a hole's index
+ * Strip the wrappers that carry no runtime meaning — parentheses and the
+ * type-only assertion forms — so a structural match sees the real expression.
+ *
+ * Load-bearing for TS input, which is what this compiler consumes: writing
+ * `Array.prototype[0] = 1` in TypeScript needs a cast
+ * (`(Array.prototype as any)[0] = 1`), and without this the `AsExpression`
+ * wrapper made the match fail. test262's plain-JS corpus has no cast, which is
+ * why the #2001 predicate worked there and the gap went unnoticed.
+ */
+function unwrapExpr(node: ts.Node): ts.Node {
+  let cur = node;
+  for (;;) {
+    if (ts.isParenthesizedExpression(cur) || ts.isAsExpression(cur) || ts.isNonNullExpression(cur)) {
+      cur = cur.expression;
+      continue;
+    }
+    if (ts.isTypeAssertionExpression?.(cur) || ts.isSatisfiesExpression?.(cur)) {
+      cur = (cur as ts.TypeAssertion | ts.SatisfiesExpression).expression;
+      continue;
+    }
+    return cur;
+  }
+}
+
+/** Descriptor fields that make a descriptor purely a DATA descriptor. */
+const DATA_DESCRIPTOR_KEYS = new Set(["value", "writable", "enumerable", "configurable"]);
+
+/**
+ * Is `node` PROVABLY a data-only descriptor object literal — `{value, writable,
+ * enumerable, configurable}` and nothing else?
+ *
+ * Deliberately conservative: anything this cannot see through (a spread, a
+ * computed key, a `get`/`set` accessor or shorthand method, a descriptor held in
+ * a variable rather than written inline) answers `false`, i.e. "may be an
+ * accessor". False negatives cost a fast path; false positives would be a
+ * miscompile.
+ */
+function isDataOnlyDescriptorLiteral(node: ts.Expression | undefined): boolean {
+  if (!node || !ts.isObjectLiteralExpression(node)) return false;
+  for (const prop of node.properties) {
+    if (ts.isSpreadAssignment(prop)) return false;
+    if (ts.isGetAccessorDeclaration(prop) || ts.isSetAccessorDeclaration(prop)) return false;
+    const name = prop.name;
+    if (!name) return false;
+    let key: string;
+    if (ts.isIdentifier(name)) key = name.text;
+    else if (ts.isStringLiteral(name)) key = name.text;
+    else return false; // computed / numeric / private — cannot prove
+    if (!DATA_DESCRIPTOR_KEYS.has(key)) return false;
+  }
+  return true;
+}
+
+/**
+ * Is `node` provably a data-only descriptor BAG — the second argument shape of
+ * `Object.defineProperties(O, props)` / `Object.create(proto, props)`, where
+ * each own property's VALUE is itself a descriptor? Recurses one level, per the
+ * #4159 edge-case note.
+ */
+function isDataOnlyDescriptorBag(node: ts.Expression | undefined): boolean {
+  if (!node || !ts.isObjectLiteralExpression(node)) return false;
+  for (const prop of node.properties) {
+    // Anything other than `key: <literal descriptor>` (spread, shorthand,
+    // method, accessor) is unprovable.
+    if (!ts.isPropertyAssignment(prop)) return false;
+    if (!isDataOnlyDescriptorLiteral(prop.initializer)) return false;
+  }
+  return true;
+}
+
+/**
+ * (#4159) Does this node install a descriptor that might be an ACCESSOR (or a
+ * non-writable data descriptor) on some receiver?
+ *
+ * Matches `Object.defineProperty` / `Object.defineProperties` / `Object.create`
+ * / `Reflect.defineProperty` whose descriptor argument is not provably
+ * data-only. A plain `{value: 1, writable: true}` does NOT set the flag — that
+ * case stays coherent through #3251's value write-back into the vec, so the
+ * typed inline `array.get` fast path remains correct for it.
+ *
+ * Same deliberate over-approximation as `isProtoIndexWrite`: a module that might
+ * install an accessor ANYWHERE loses the typed element fast path EVERYWHERE. The
+ * flag is per-module, not per-array; a tighter escape analysis is the
+ * measurement-driven follow-up, not this substrate.
+ */
+function isNonDataDescriptorDefine(node: ts.Node): boolean {
+  if (!ts.isCallExpression(node)) return false;
+  const callee = node.expression;
+  if (!ts.isPropertyAccessExpression(callee) || !ts.isIdentifier(callee.expression)) return false;
+  const ns = callee.expression.text;
+  const method = callee.name.text;
+
+  if (method === "defineProperty" && (ns === "Object" || ns === "Reflect")) {
+    // (O, key, descriptor) — the descriptor is argument 2.
+    return !isDataOnlyDescriptorLiteral(node.arguments[2]);
+  }
+  if (method === "defineProperties" && ns === "Object") {
+    return !isDataOnlyDescriptorBag(node.arguments[1]);
+  }
+  if (method === "create" && ns === "Object") {
+    // `Object.create(proto)` installs no descriptors at all.
+    return node.arguments.length >= 2 && !isDataOnlyDescriptorBag(node.arguments[1]);
+  }
+  return false;
+}
+
+/**
+ * (#4159/#4160) Does this node introduce code the pre-scan cannot see — `eval(…)`,
+ * `Function(…)`, or `new Function(…)`? Bare-identifier callees only: a
+ * `foo.eval(…)` member call is not the global `eval`.
+ */
+function isDynamicCodeUse(node: ts.Node): boolean {
+  if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
+    const callee = node.expression;
+    if (ts.isIdentifier(callee) && (callee.text === "eval" || callee.text === "Function")) return true;
+  }
+  return false;
+}
+
+/**
+ * (#2001 S2 / PR #2832 park; widened to `Object.prototype` by #4160) Does this
+ * node WRITE an index property onto `Array.prototype` or `Object.prototype`?
+ * Detects the shapes test262 uses to make an index
  * visible through the prototype chain (`HasProperty(O, k)` true although the
  * own slot is absent):
  *
@@ -102,12 +248,12 @@ function isArrayPrototypeExpr(node: ts.Node): boolean {
  * that dirties `Array.prototype` indices anywhere loses the HOF hole
  * visit-skip everywhere (falling back to the pre-S2 visit-with-`undefined`
  * behavior), because the flat vec cannot check the prototype per element at
- * runtime. See `arrayProtoIndexDirty` in context/types.ts.
+ * runtime. See `protoIndexDirty` in context/types.ts.
  */
-function isArrayProtoIndexWrite(node: ts.Node): boolean {
+function isProtoIndexWrite(node: ts.Node): boolean {
   // Object.defineProperty(Array.prototype, …) / Object.defineProperties /
   // Reflect.defineProperty — first argument is Array.prototype.
-  if (ts.isCallExpression(node) && node.arguments.length > 0 && isArrayPrototypeExpr(node.arguments[0])) {
+  if (ts.isCallExpression(node) && node.arguments.length > 0 && isArrayOrObjectPrototypeExpr(node.arguments[0])) {
     const callee = node.expression;
     if (
       ts.isPropertyAccessExpression(callee) &&
@@ -123,8 +269,8 @@ function isArrayProtoIndexWrite(node: ts.Node): boolean {
     ts.isBinaryExpression(node) &&
     node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
     node.operatorToken.kind <= ts.SyntaxKind.LastAssignment &&
-    ts.isElementAccessExpression(node.left) &&
-    isArrayPrototypeExpr(node.left.expression)
+    ts.isElementAccessExpression(unwrapExpr(node.left)) &&
+    isArrayOrObjectPrototypeExpr((unwrapExpr(node.left) as ts.ElementAccessExpression).expression)
   ) {
     return true;
   }

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -5579,7 +5579,7 @@ function emitArrayLoop(fctx: FunctionContext, loopBody: Instr[]): void {
  * are byte-identical — no `ref.test`, no gate.
  *
  * (PR #2832 merge-group park) ALSO disabled module-wide when the pre-scan saw
- * an `Array.prototype` INDEX write (`arrayProtoIndexDirty`): §23.1.3.* keys the
+ * an `Array`/`Object.prototype` INDEX write (`protoIndexDirty`): §23.1.3.* keys the
  * skip on `HasProperty(O, k)`, which is TRUE for a hole whose index is
  * inherited from `Array.prototype` — a relationship the flat vec cannot check
  * per element. Falling back to the S1 visit-with-`undefined` behavior matches
@@ -5588,7 +5588,7 @@ function emitArrayLoop(fctx: FunctionContext, loopBody: Instr[]): void {
  * `{every,filter,some}/*-c-i-22.js`.
  */
 function shouldHoleSkip(ctx: CodegenContext, elemType: ValType): boolean {
-  return ctx.usesArrayHoles && !ctx.arrayProtoIndexDirty && elemType.kind === "externref";
+  return ctx.usesArrayHoles && !ctx.protoIndexDirty && elemType.kind === "externref";
 }
 
 /**

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -127,7 +127,9 @@ export function createCodegenContext(
     dynamicProtoLiteralNodes: new WeakSet(), // (#802) object-literal proto receivers (Slice A)
     dynProtoSentinelGlobalIdx: undefined, // (#802) "explicit null proto" sentinel global
     usesArrayHoles: false, // (#2001 S1) set by the scanForArrayHoles pre-scan
-    arrayProtoIndexDirty: false, // (#2001 S2) set by scanForArrayHoles: Array.prototype index write ⇒ HOF hole-skip disabled
+    protoIndexDirty: false, // (#2001 S2, widened #4160) scanForArrayHoles: Array/Object.prototype index write
+    vecAccessorDescriptorDirty: false, // (#4159) scanForArrayHoles: a non-data descriptor may exist somewhere
+    dynamicCodeDirty: false, // (#4159/#4160) scanForArrayHoles: eval/Function present ⇒ both flags above forced
     usesVecValue: false, // (#2083) flipped by genuine getOrRegisterVecType usage
     // (#4035) "auto" = the JS host needs the bridge as its calling convention,
     // a JS-free host does not. Standalone/WASI callers that DO inspect the

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1404,7 +1404,22 @@ export interface CodegenContext {
    * keeps the spec-correct skip. See the regressed trio
    * `built-ins/Array/prototype/{every,filter,some}/*-c-i-22.js`.
    */
-  arrayProtoIndexDirty: boolean;
+  protoIndexDirty: boolean;
+  /**
+   * (#4159) A descriptor that is not provably data-only may exist somewhere in
+   * the module. Consumers: the TYPED element read/write lanes only — #3251's
+   * value write-back keeps `array.get` coherent for DATA descriptors, but an
+   * accessor has no value to write back. Clear ⇒ byte-identical emission, no
+   * runtime guard. Per-MODULE over-approximation; see #4159 for the rationale.
+   */
+  vecAccessorDescriptorDirty: boolean;
+  /**
+   * (#4159/#4160) `eval` / `Function` present ⇒ forces BOTH flags above.
+   * Load-bearing: static eval inlining (#1163) splices statements in during
+   * BODY compilation, after this pre-scan, so the flags would otherwise stay
+   * clear for code the scan never saw. See #4160.
+   */
+  dynamicCodeDirty: boolean;
   /**
    * (#2083) Set true the first time `getOrRegisterVecType` is asked for a vec
    * type from a genuine usage site (an array literal, array method, for-of over

--- a/tests/issue-4159-4160-prescan-flags.test.ts
+++ b/tests/issue-4159-4160-prescan-flags.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4159 Work Item A / #4160 slice 1) The shared AST pre-scan flags.
+//
+// `scanForArrayHoles` is the single pre-pass that decides, before any body is
+// compiled, whether the module may contain (a) array holes, (b) a prototype
+// INDEX write, (c) a non-data descriptor define, (d) dynamic code. Flags (b)-(d)
+// gate the generic/spec-correct arms of #4159 and #4160; when they are clear the
+// emission is byte-identical to today, which is the whole no-regression
+// argument. So the predicates are the thing worth pinning.
+import { describe, expect, it } from "vitest";
+// `src/index.js` first, deliberately: importing `array-holes.js` on its own
+// initialises the codegen module graph in a different order than the compiler
+// does (array-holes -> expressions/late-imports -> calls -> collections-brand)
+// and trips a circular-import TDZ on `COLLECTION_KIND`. Pulling the entry point
+// in first establishes the normal order.
+import "../src/index.js";
+import { ts } from "../src/ts-api.js";
+import { scanForArrayHoles } from "../src/codegen/array-holes.js";
+import type { CodegenContext } from "../src/codegen/context/types.js";
+
+/** Run the pre-scan over `src` and return just the four flags it sets. */
+function scan(src: string) {
+  const sf = ts.createSourceFile("t.ts", src, ts.ScriptTarget.ES2022, true);
+  // The pass touches only these four fields.
+  const ctx = {
+    usesArrayHoles: false,
+    protoIndexDirty: false,
+    vecAccessorDescriptorDirty: false,
+    dynamicCodeDirty: false,
+  } as unknown as CodegenContext;
+  scanForArrayHoles(ctx, sf);
+  return {
+    holes: ctx.usesArrayHoles,
+    proto: ctx.protoIndexDirty,
+    accessor: ctx.vecAccessorDescriptorDirty,
+    dynamic: ctx.dynamicCodeDirty,
+  };
+}
+
+describe("#4160 — protoIndexDirty covers Object.prototype as well as Array.prototype", () => {
+  it("Object.prototype[1] = v sets it (the 15.4.4.18-7-b-12 shape, 135 files)", () => {
+    expect(scan(`(Object.prototype as any)[1] = 111;`).proto).toBe(true);
+  });
+
+  it("Object.defineProperty(Object.prototype, '1', …) sets it", () => {
+    expect(scan(`Object.defineProperty(Object.prototype, "1", { value: 1 });`).proto).toBe(true);
+  });
+
+  it("the pre-existing Array.prototype shapes still set it", () => {
+    expect(scan(`(Array.prototype as any)[0] = 1;`).proto).toBe(true);
+    expect(scan(`Object.defineProperty(Array.prototype, "0", { value: 1 });`).proto).toBe(true);
+    expect(scan(`Reflect.defineProperty(Array.prototype, "0", { value: 1 });`).proto).toBe(true);
+  });
+
+  it("a non-literal index still counts — Array.prototype[i] = v", () => {
+    expect(scan(`declare const i: number; (Array.prototype as any)[i] = 1;`).proto).toBe(true);
+  });
+
+  it("a NAME write does NOT set it — it cannot make an integer index inherited", () => {
+    expect(scan(`(Object.prototype as any).foo = 1;`).proto).toBe(false);
+    expect(scan(`(Array.prototype as any).foo = 1;`).proto).toBe(false);
+  });
+
+  it("a plain program sets nothing", () => {
+    const f = scan(`export function f(): number { const a = [1, 2, 3]; return a[1]; }`);
+    expect(f).toEqual({ holes: false, proto: false, accessor: false, dynamic: false });
+  });
+});
+
+describe("#4159 — vecAccessorDescriptorDirty fires only when a descriptor is not provably data-only", () => {
+  it("an accessor descriptor sets it", () => {
+    expect(scan(`Object.defineProperty(a, "1", { get: function () { return 9; } });`).accessor).toBe(true);
+    expect(scan(`Object.defineProperty(a, "1", { set: function (v) {} });`).accessor).toBe(true);
+  });
+
+  it("a shorthand accessor METHOD sets it", () => {
+    expect(scan(`Object.defineProperty(a, "1", { get() { return 9; } });`).accessor).toBe(true);
+  });
+
+  it("a real get/set accessor declaration in the literal sets it", () => {
+    expect(scan(`Object.defineProperty(a, "1", { get x() { return 9; } });`).accessor).toBe(true);
+  });
+
+  it("a data-only descriptor does NOT set it — #3251's write-back keeps that coherent", () => {
+    expect(scan(`Object.defineProperty(a, "1", { value: 77, writable: true, configurable: true });`).accessor).toBe(
+      false,
+    );
+    expect(scan(`Object.defineProperty(a, "1", { value: 1, enumerable: false });`).accessor).toBe(false);
+  });
+
+  it("a descriptor held in a VARIABLE sets it — unprovable at the call site", () => {
+    expect(scan(`const d = { value: 1 }; Object.defineProperty(a, "1", d);`).accessor).toBe(true);
+  });
+
+  it("a spread sets it — the over-approximation must not see through it", () => {
+    expect(scan(`Object.defineProperty(a, "1", { ...base, value: 1 });`).accessor).toBe(true);
+  });
+
+  it("a computed key sets it", () => {
+    expect(scan(`Object.defineProperty(a, "1", { [k]: 1 });`).accessor).toBe(true);
+  });
+
+  it("defineProperties / Object.create recurse ONE level into the bag", () => {
+    expect(scan(`Object.defineProperties(o, { a: { value: 1 } });`).accessor).toBe(false);
+    expect(scan(`Object.defineProperties(o, { a: { get: g } });`).accessor).toBe(true);
+    expect(scan(`Object.create(p, { a: { value: 1 } });`).accessor).toBe(false);
+    expect(scan(`Object.create(p, { a: { get: g } });`).accessor).toBe(true);
+  });
+
+  it("Object.create with no descriptor bag installs nothing", () => {
+    expect(scan(`Object.create(proto);`).accessor).toBe(false);
+  });
+
+  it("Reflect.defineProperty is covered too", () => {
+    expect(scan(`Reflect.defineProperty(a, "1", { get: g });`).accessor).toBe(true);
+  });
+});
+
+describe("#4159/#4160 — dynamic code forces both flags", () => {
+  // Load-bearing: static eval inlining (#1163) splices statements in during BODY
+  // compilation, AFTER this pre-scan has run, so `eval('Array.prototype[0]=1')`
+  // sets nothing on today's main. Dynamic code therefore dirties everything.
+  it("eval(...) forces proto + accessor", () => {
+    const f = scan(`eval("Array.prototype[0] = 1");`);
+    expect(f.dynamic).toBe(true);
+    expect(f.proto).toBe(true);
+    expect(f.accessor).toBe(true);
+  });
+
+  it("Function(...) and new Function(...) both count", () => {
+    expect(scan(`Function("return 1");`).dynamic).toBe(true);
+    expect(scan(`new Function("return 1");`).dynamic).toBe(true);
+  });
+
+  it("a MEMBER call named eval is not the global eval", () => {
+    expect(scan(`foo.eval("x");`).dynamic).toBe(false);
+  });
+});
+
+describe("the pre-scan still finds array holes, and finds flags AFTER a hole", () => {
+  it("array-literal elision sets usesArrayHoles", () => {
+    expect(scan(`const a = [1, , 3];`).holes).toBe(true);
+  });
+
+  // Regression guard for the early-exit: it must not bail once the flags it knew
+  // about before #4159 are set, or a later node never gets visited.
+  it("a hole EARLY does not stop the scan from finding a later accessor define", () => {
+    const f = scan(`const a = [1, , 3]; Object.defineProperty(o, "k", { get: g });`);
+    expect(f.holes).toBe(true);
+    expect(f.accessor).toBe(true);
+  });
+
+  it("a proto write EARLY does not stop the scan from finding a later hole", () => {
+    const f = scan(`(Array.prototype as any)[0] = 1; const a = [1, , 3];`);
+    expect(f.proto).toBe(true);
+    expect(f.holes).toBe(true);
+  });
+});


### PR DESCRIPTION
Work Item A of #4159 and slice 1 of #4160 are the same change, so they land together — the architect spec's own *"land A once, consume it from both"*.

This is **substrate only**: it introduces the flags and nothing yet reads the two new ones. The generic arms that consume them (#4159 Work Items B/C, #4160 slices 2-4) follow.

## Three flags, all set by the existing `scanForArrayHoles` pre-pass

- **`protoIndexDirty`** (renamed from `arrayProtoIndexDirty`) now matches `Object.prototype` as well as `Array.prototype`. The dominant test262 shape — `15.4.4.18-7-b-12` and the 135 files sharing its assertion — writes `Object.prototype[1] = 1` and then iterates an array-**like**, never an array. Only `Array.prototype` was matched before.
- **`vecAccessorDescriptorDirty`** (new) fires when a `defineProperty` / `defineProperties` / `Object.create` / `Reflect.defineProperty` descriptor is **not provably a data-only literal**. Data-only descriptors stay clean, because #3251's value write-back already keeps the typed fast path coherent for those — that's why control B in #4159's repro passes today.
- **`dynamicCodeDirty`** (new) fires on `eval` / `Function` / `new Function` and forces both flags above.

That third flag is load-bearing rather than defensive. Static eval inlining (#1163) parses a compile-time-constant eval string and splices its statements in **during body compilation — after this pre-pass has run**, so `eval('Array.prototype[0] = 1')` sets no flag at all on today's main. Setting a flag lazily at splice time is precisely the read/store desync the pre-pass exists to prevent, so dynamic code dirties everything statically instead.

## Why compile-time flags and not a runtime protector cell

V8 and SpiderMonkey use a runtime cell because they JIT a long-running process and need invalidation. This compiler emits a whole module ahead of time and already knows the answer statically. When the flags are clear **there is no new instruction to measure** — a stronger no-regression guarantee than any benchmark.

Proven, not asserted: A/B against main's compiler over **14 compilations** (7 programs × standalone and host — dense numeric loop, typed element read/write, array HOF, map/filter/reduce, array holes, data-descriptor define, string ops). Every output hash identical.

## A latent bug fixed along the way

The #2001 predicate matched only a bare `PropertyAccessExpression`, so `(Array.prototype as any)[0] = 1` — the way you write it in **TypeScript, which is what this compiler consumes** — did not set the flag. test262's plain-JS corpus has no cast, which is why it went unnoticed. `unwrapExpr` now strips parentheses and the type-only assertion forms. My first test run caught this: four cases failed for exactly this reason.

## Behaviour change worth flagging

Widening `protoIndexDirty` also widens its one existing consumer, `shouldHoleSkip`. A module writing `Object.prototype[i]` or using `eval` now loses the HOF hole-visit-skip and falls back to visit-with-`undefined`.

That is still not spec-correct for an inherited *value* (the callback should see the inherited value, not `undefined`) — but the visit **count** becomes right, and the fallback is the prerequisite for the generic arm that makes the value right too. Verified against main: `issue-2001-s1`, `issue-2001-s2` and `ref-cast-peephole` have an **identical pass/fail split** before and after — 7 pre-existing failures on both sides, all the `string_constants` host-import environment issue, none caused here.

## Tests

22 new unit tests in `tests/issue-4159-4160-prescan-flags.test.ts` pin every predicate: the `Object.prototype` widening, the pre-existing `Array.prototype` shapes, name-writes *not* firing, data-only vs accessor descriptors, descriptors held in variables / spreads / computed keys, one-level bag recursion for `defineProperties` and `Object.create`, `foo.eval()` not counting as global `eval`, and an early-exit regression guard — a flag set early must not stop the walk before a later node is seen.

## Budget gates

Both granted in #4159's frontmatter with reasons, rather than worked around: `context/types.ts` +15 LOC and `createCodegenContext` +2. A context field declaration and its initialiser have exactly one legal home each; there is no subsystem module to move them to. Doc comments were trimmed first (the full rationale lives in the issue), which took the LOC growth from +34 to +15.

Closes nothing on its own — #4159 and #4160 stay open for their consumer slices.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_