### PR TITLE
feat(#4160): prototype-index store + read-chokepoint fallbacks (standalone) — capability slice, +0 test262 by design

### DIFF
--- a/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
+++ b/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
@@ -30,6 +30,15 @@ loc-budget-allow:
   - src/codegen/object-runtime.ts
   - src/codegen/index.ts
   - src/codegen/context/types.ts
+# (#1917/#2108 coercion-sites gate) proto-index-store.ts's `__protoidx_norm_key`
+# DELEGATES to the engine's own helpers by funcMap name (number_toString /
+# __str_to_number / __unbox_number — the same trio __to_property_key composes);
+# it hand-rolls no ToString/ToNumber matrix. The gate counts the references.
+# The CanonicalNumericIndexString round-trip (ToString(StringToNumber(k)) == k,
+# §7.1.4 canonical-integer-index gate) has no single engine entry point today;
+# if one lands, this helper is a one-call rewrite.
+coercion-sites-allow:
+  - src/codegen/proto-index-store.ts
 ---
 
 # #4160 — "clean elements" protector cell for Array.prototype traversal

--- a/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
+++ b/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
@@ -1,7 +1,8 @@
 ---
 id: 4160
 title: "Per-call \"clean elements\" protector cell for Array.prototype traversal — make prototype-chain index inheritance correct without taxing the dense loop (~297 ES5+untagged)"
-status: ready
+status: in-progress
+assignee: ttraenkler/sendev-4160-read
 sprint: current
 created: 2026-08-05
 updated: 2026-08-05
@@ -357,6 +358,35 @@ A/B vs main over 9 flag-clear programs × {standalone, gc} — all 18 sha256
 identical; scoped standalone test262 A/B over
 `built-ins/Array/prototype/{forEach,map,filter,some,every,reduce,reduceRight}`
 (results in the PR description).
+
+### Sizing correction (measured 2026-08-05, scoped A/B) — the ~297 figure conflates TWO mechanisms
+
+The scoped standalone test262 A/B over `built-ins/Array/prototype/{forEach,
+map,filter,some,every,reduce,reduceRight}` (1,605 files, both sides run with
+the same instrument) came back **byte-identical: {pass 879, fail 721,
+compile_error 5} on BOTH main and this branch — zero transitions**. The
+instrument is not blind: swapping main's compiler files in flips this issue's
+own acceptance test from 8/8 to 5-failed, so the A/B can see compiler changes.
+The zero is real.
+
+Root cause (project-lead triage, confirmed): the ~297-file estimate came from
+signature-based clustering, which lumped **own-accessor-descriptor** tests
+together with **prototype-chain-inheritance** tests because they share
+assertion text. The canonical `15.4.4.18-7-b-12` needs an own accessor on
+`obj["0"]` (whose getter deletes `obj[1]`) to run BEFORE the inherited index
+can matter, and e.g. `every/15.4.4.16-7-c-i-9.js` is "own accessor property on
+an Array-like object" — no prototype involved at all. Both pre-scan flags DO
+fire on the real test sources; the blocker is that the own-descriptor path
+(closed-struct/`$Object` accessor descriptors — #2668 / #3251 / #4161 scope)
+fails first, so the prototype-chain mechanism never gets to matter.
+
+**Real dependency order:** own-accessor descriptors on array-like receivers
+land FIRST; only then can the prototype-chain half of this cluster be scored.
+This slice is therefore **capability, not conformance**: the mechanism is
+proven by its acceptance tests (P2/P3 + 9 more in
+`tests/issue-4160-proto-index-store.test.ts`), and its test262 yield is gated
+behind the own-descriptor work. Do NOT re-derive a target count for this issue
+from the old cluster; re-measure after #3251-family lands.
 
 **Known boundaries (recorded in the module header too):**
 - `Object.defineProperties(Object.prototype, {...})` (plural) not armed.

--- a/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
+++ b/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
@@ -40,6 +40,27 @@ loc-budget-allow:
 # if one lands, this helper is a one-call rewrite.
 coercion-sites-allow:
   - src/codegen/proto-index-store.ts
+# (#3400 func ratchet) This slice's whole shape is "emit extra arms under a
+# compile-time flag", so the emitters that host those arms grow. Each entry is
+# the irreducible cost of a chokepoint the spec named, not logic that could
+# live in the new subsystem module (proto-index-store.ts owns everything that
+# CAN be factored out — the store, the key gate, and the consult builders; what
+# remains at each site is the splice itself):
+#   - ensureNativeArrayHof (+103, the largest): the per-iteration HasProperty
+#     gate plus the reduce first-present seed scan are inline loop-body emission
+#     for 7 methods. Splitting a 435-line emitter is a real refactor and belongs
+#     with #3182/#3105, not smuggled into a behavioural slice.
+#   - buildObjectEnumerationHelpers / ensureObjectRuntime / generateModule /
+#     generateMultiModule: reserve + fill wiring for the new helpers.
+#   - fillExternArrayLikeStructArms crosses 300 for the first time (+10) — it is
+#     the closed-struct field-ladder miss point, one of the read chokepoints.
+func-budget-allow:
+  - src/codegen/hof-native.ts::ensureNativeArrayHof
+  - src/codegen/object-runtime-enumeration.ts::buildObjectEnumerationHelpers
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
+  - src/codegen/object-runtime.ts::fillExternArrayLikeStructArms
+  - src/codegen/index.ts::generateModule
+  - src/codegen/index.ts::generateMultiModule
 ---
 
 # #4160 — "clean elements" protector cell for Array.prototype traversal

--- a/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
+++ b/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
@@ -16,6 +16,20 @@ goal: builtin-methods
 related: [3185, 3251, 2670, 2001, 4159]
 depends_on: [4159]
 origin: "plan/log/analysis-2026-08-04-es5-untagged-standalone-clusters.md — design review of the fast-path question"
+# (#3102 LOC ratchet) Slice-1-read growth lives where the seams are, not where
+# the logic is: the store itself is a NEW module (proto-index-store.ts, under
+# budget by construction). What grows the god-files is only integration that
+# has exactly one legal home — object-runtime.ts: the reserve hook + the
+# registration-time terminal-miss consults inside the `__extern_get` /
+# `__extern_has` bodies it owns, plus the fillExternGetIdxVecArms /
+# fillExternArrayLikeStructArms miss-point swaps (those fills live there);
+# index.ts: the two finalize-order call sites for fillProtoIndexStore (the
+# finalize sequence is index.ts's); context/types.ts: four ctx field
+# declarations (reserve latch, fill latch, two companion global indices).
+loc-budget-allow:
+  - src/codegen/object-runtime.ts
+  - src/codegen/index.ts
+  - src/codegen/context/types.ts
 ---
 
 # #4160 — "clean elements" protector cell for Array.prototype traversal
@@ -276,3 +290,73 @@ standalone mechanism transfers.
 **Sequencing.** Shared slice **S0** (the pre-scan flags, jointly with #4159's
 Work Item A) lands once and first. This issue's S1/S2 then run in parallel with
 #4159's S3.
+
+## Implementation notes — S1+S2 read side (sendev-4160-read, 2026-08-05)
+
+Implements #4159 architect-spec §(c) items 1-4 (item 5, LengthOfArrayLike,
+deliberately untouched). New module `src/codegen/proto-index-store.ts`; consult
+hooks in `object-runtime.ts` / `object-runtime-enumeration.ts` / `hof-native.ts`;
+finalize wiring in `index.ts`. Everything gated `ctx.standalone &&
+ctx.protoIndexDirty`.
+
+**WHY the shape differs from a literal reading of the spec — three findings:**
+
+1. **"Final arms in `__extern_get_idx`/`__extern_has_idx`" cannot work as
+   literally specced for `$Object` receivers.** Measured (P3 WAT): the
+   `$Object` arm of `__extern_get_idx` DELEGATES to `__extern_get(v,
+   ToString(i))` and returns its result — a final arm after it never runs. The
+   own-absent miss is only precisely knowable inside `__extern_get`'s
+   proto-walk (an own entry HOLDING undefined must still shadow the chain), so
+   the consult lives at the TERMINAL miss of `__extern_get` / `__extern_has`
+   (registration-time, flag known from the pre-scan), and at the OOB/ladder
+   miss points of the vec + closed-struct arms (finalize, same gate). Same
+   semantics as the spec intended, different insertion points.
+2. **Write arms are substitution-by-RECURSION, not re-implementation** (the
+   #4161 `closureBagSubstitutionArm` idea): the prepended `$NativeProto` brand
+   arm re-targets `__extern_set` / `__defineProperty_value` / `_accessor` at
+   the companion `$Object` and calls ITSELF — accessor-set gate, #2042-S4
+   preflight, flag translation and frozen checks all apply to the companion
+   for free, and the define arms still return the ORIGINAL receiver.
+   `__extern_set_strict` needs no arm (its non-`$Object` head already
+   delegates to `__extern_set`).
+3. **Integer-index-only participation is enforced at the WRITE, not the
+   read.** `__protoidx_norm_key` admits only canonical non-negative-integer
+   keys ("01"/" 1"/""/1.5/2^53 all refused, matching host `_protoIndexHas`'s
+   `Number.isInteger && >= 0` plus CanonicalNumericIndexString for strings),
+   so the companions' key space is integer-only by construction and reads can
+   consult unconditionally. Symbol/object keys fall through untouched — an
+   object key is NOT ToPrimitive'd in the gate, so a user `toString` never
+   runs twice.
+
+**`__hof_*` gate (spec item 4):** per-iteration `__extern_has_idx` gate on
+forEach/map/filter/some/every/reduce/reduceRight (NOT the find* family —
+§23.1.3 visits every index there); map pushes undefined for an absent index to
+keep result alignment (the dense `$ObjVec` carrier cannot hold a hole); reduce
+no-init additionally scans for the FIRST PRESENT element as the seed
+(§23.1.3.24 step 8.b), keeping the documented return-undefined boundary for
+"no present element" instead of the spec TypeError.
+
+**Bonus beyond the letter of the spec:** direct read-back on the proto objects
+themselves (`Object.prototype[1]` after the write) via a `$NativeProto` brand
+arm on `__extern_get_idx`/`__extern_has_idx` — a store you cannot read back
+from its own carrier is a debugging trap.
+
+**Verified:** P3 → 111 (was NaN), P2 → sum 113/visits 3 (was 2/2);
+defineProperty + OOB-array + `in` + non-integer-refusal + dirty-dense-HOF
+probes green (`tests/issue-4160-proto-index-store.test.ts`); byte-identity
+A/B vs main over 9 flag-clear programs × {standalone, gc} — all 18 sha256
+identical; scoped standalone test262 A/B over
+`built-ins/Array/prototype/{forEach,map,filter,some,every,reduce,reduceRight}`
+(results in the PR description).
+
+**Known boundaries (recorded in the module header too):**
+- `Object.defineProperties(Object.prototype, {...})` (plural) not armed.
+- Companion setter invoked with the companion as `this` (write side only; the
+  Get side binds the spec receiver).
+- In-bounds vec holes still answer present (dense carriers; #2001/#3185).
+- `$ObjVec` OOB and unrecognized-receiver misses in `__extern_get_idx` do not
+  consult (enumeration-result arrays; out of the measured cluster).
+- The `__hof_*` route only serves vec/`$ObjVec` receivers today (measured:
+  plain-`$Object`/closed-struct `obj.forEach(...)` member calls miss on main
+  independently of this change — the test262 `.call` shapes go through
+  `compileArrayLikeBorrow`, which is covered).

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1684,6 +1684,22 @@ export interface CodegenContext {
    */
   vecPropBaseTypeIdx?: number;
   /**
+   * (#4160) Set when `ensureObjectRuntime` reserved the prototype-index-store
+   * helpers (`__protoidx_*`, proto-index-store.ts) — the runtime companions
+   * that make `Object.prototype[i]` / `Array.prototype[i]` writes visible
+   * through the prototype chain. Reserved ONLY under
+   * `ctx.standalone && ctx.protoIndexDirty` (pre-scan flag, #4128), so a
+   * flag-clear module carries no trace; bodies + chokepoint arms are filled by
+   * `fillProtoIndexStore` at FINALIZE.
+   */
+  protoIndexStoreReserved?: boolean;
+  /** (#4160) Set once `fillProtoIndexStore` has run (idempotency latch). */
+  protoIndexStoreFilled?: boolean;
+  /** (#4160) Global index of `__protoidx_obj_companion` (`(mut externref)`). */
+  protoIndexObjCompanionGlobalIdx?: number;
+  /** (#4160) Global index of `__protoidx_arr_companion` (`(mut externref)`). */
+  protoIndexArrCompanionGlobalIdx?: number;
+  /**
    * (#1100) Set when the standalone Proxy trap-dispatch runtime reserved its
    * `__proxy_call_{get,set,has}` driver placeholders (in `ensureProxyRuntime`).
    * Those drivers invoke the user trap closures through the `__call_fn_method_N`

--- a/src/codegen/hof-native.ts
+++ b/src/codegen/hof-native.ts
@@ -90,6 +90,7 @@ export function ensureNativeArrayHof(ctx: CodegenContext, methodName: string): n
   const applyClosureIdx = reserveApplyClosure(ctx);
   const externLengthIdx = ctx.funcMap.get("__extern_length");
   const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx");
+  const externHasIdxIdx = ctx.funcMap.get("__extern_has_idx");
   const objVecNewIdx = ctx.funcMap.get("__objvec_new");
   const objVecPushIdx = ctx.funcMap.get("__objvec_push");
   const boxNumIdx = ctx.funcMap.get("__box_number");
@@ -109,6 +110,23 @@ export function ensureNativeArrayHof(ctx: CodegenContext, methodName: string): n
 
   const isReduce = NATIVE_HOF_REDUCE.has(methodName);
   const backward = methodName === "findLast" || methodName === "findLastIndex" || methodName === "reduceRight";
+
+  // (#4160) Per-iteration HasProperty gate. §23.1.3's presence-sensitive
+  // methods (forEach/map/filter/some/every/reduce/reduceRight — NOT the
+  // find* family, which visits every index) run `HasProperty(O, ToString(k))`
+  // before each Get and SKIP absent indices; the chain-inclusive check is what
+  // makes an index inherited from `Object.prototype[i] = v` visitable while a
+  // genuinely absent own index on an array-like is skipped. Emitted ONLY when
+  // the module dirtied a prototype index (`ctx.protoIndexDirty`, a pre-scan
+  // flag fixed before any body compiles) — the flag-clear helper body is
+  // byte-identical by construction. The own-absent-visit-with-undefined
+  // behaviour of flag-CLEAR modules is #3185/#2001 scope, deliberately not
+  // widened here.
+  const PRESENCE_SENSITIVE = new Set(["forEach", "map", "filter", "some", "every", "reduce", "reduceRight"]);
+  const hasGateIdx =
+    ctx.protoIndexDirty && PRESENCE_SENSITIVE.has(methodName) && externHasIdxIdx !== undefined
+      ? externHasIdxIdx
+      : undefined;
 
   // (#2872 slice 5) S1-producer discipline for every "returns `undefined`"
   // result of these helpers (`find`/`findLast` miss, `forEach`'s void result,
@@ -300,6 +318,70 @@ export function ensureNativeArrayHof(ctx: CodegenContext, methodName: string): n
     }
     prologue.push(...(backward ? iInitBackward : iInitForward));
   } else {
+    // (#4160) Flag-dirty no-init seed: §23.1.3.24 step 8.b scans for the FIRST
+    // PRESENT index in iteration order (skipping absent ones through the
+    // HasProperty gate) before consuming it as the accumulator; running off
+    // the end without a present element is the spec's TypeError, kept as the
+    // documented return-undefined boundary (see module header). The scan's
+    // range test also covers the empty receiver, so the explicit `len <= 0`
+    // preflight of the ungated body is subsumed.
+    const reduceSeedScan = (): Instr[] => [
+      ...(backward
+        ? ([
+            { op: "local.get", index: L.len },
+            { op: "f64.const", value: 1 },
+            { op: "f64.sub" },
+            { op: "local.set", index: L.i },
+          ] satisfies Instr[])
+        : ([
+            { op: "f64.const", value: 0 },
+            { op: "local.set", index: L.i },
+          ] satisfies Instr[])),
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // out of range → no present element anywhere → undefined boundary
+              ...((backward
+                ? [{ op: "local.get", index: L.i }, { op: "f64.const", value: 0 }, { op: "f64.lt" }]
+                : [
+                    { op: "local.get", index: L.i },
+                    { op: "local.get", index: L.len },
+                    { op: "f64.ge" },
+                  ]) satisfies Instr[]),
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [...(undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }]), { op: "return" }],
+              },
+              // present? → seed found, exit the scan
+              { op: "local.get", index: 0 },
+              { op: "local.get", index: L.i },
+              { op: "call", funcIdx: hasGateIdx! },
+              { op: "br_if", depth: 1 },
+              { op: "local.get", index: L.i },
+              { op: "f64.const", value: 1 },
+              { op: backward ? "f64.sub" : "f64.add" },
+              { op: "local.set", index: L.i },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      // acc = Get(recv, i) ; advance i past the seed
+      { op: "local.get", index: 0 },
+      { op: "local.get", index: L.i },
+      { op: "call", funcIdx: externGetIdxIdx },
+      { op: "local.set", index: L.acc },
+      { op: "local.get", index: L.i },
+      { op: "f64.const", value: 1 },
+      { op: backward ? "f64.sub" : "f64.add" },
+      { op: "local.set", index: L.i },
+    ];
     // hasInit ? (acc = init; i = first) : (empty → undefined; acc = first elem; i = second)
     prologue.push(
       { op: "local.get", index: 3 },
@@ -311,43 +393,73 @@ export function ensureNativeArrayHof(ctx: CodegenContext, methodName: string): n
           { op: "local.set", index: L.acc },
           ...(backward ? iInitBackward : iInitForward),
         ],
-        else: [
-          // len <= 0 → return undefined (boundary: spec TypeError, see header)
-          { op: "local.get", index: L.len },
-          { op: "f64.const", value: 0 },
-          { op: "f64.le" },
-          {
-            op: "if",
-            blockType: { kind: "empty" },
-            then: [...undefExtern, { op: "return" }],
-          },
-          // acc = first-in-iteration-order element; i = the next one
-          ...((backward
-            ? [
-                { op: "local.get", index: 0 },
-                { op: "local.get", index: L.len },
-                { op: "f64.const", value: 1 },
-                { op: "f64.sub" },
-                { op: "call", funcIdx: externGetIdxIdx },
-                { op: "local.set", index: L.acc },
-                { op: "local.get", index: L.len },
-                { op: "f64.const", value: 2 },
-                { op: "f64.sub" },
-                { op: "local.set", index: L.i },
-              ]
+        else:
+          hasGateIdx !== undefined
+            ? reduceSeedScan()
             : [
-                { op: "local.get", index: 0 },
+                // len <= 0 → return undefined (boundary: spec TypeError, see header)
+                { op: "local.get", index: L.len },
                 { op: "f64.const", value: 0 },
-                { op: "call", funcIdx: externGetIdxIdx },
-                { op: "local.set", index: L.acc },
-                { op: "f64.const", value: 1 },
-                { op: "local.set", index: L.i },
-              ]) satisfies Instr[]),
-        ],
+                { op: "f64.le" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [...undefExtern, { op: "return" }],
+                },
+                // acc = first-in-iteration-order element; i = the next one
+                ...((backward
+                  ? [
+                      { op: "local.get", index: 0 },
+                      { op: "local.get", index: L.len },
+                      { op: "f64.const", value: 1 },
+                      { op: "f64.sub" },
+                      { op: "call", funcIdx: externGetIdxIdx },
+                      { op: "local.set", index: L.acc },
+                      { op: "local.get", index: L.len },
+                      { op: "f64.const", value: 2 },
+                      { op: "f64.sub" },
+                      { op: "local.set", index: L.i },
+                    ]
+                  : [
+                      { op: "local.get", index: 0 },
+                      { op: "f64.const", value: 0 },
+                      { op: "call", funcIdx: externGetIdxIdx },
+                      { op: "local.set", index: L.acc },
+                      { op: "f64.const", value: 1 },
+                      { op: "local.set", index: L.i },
+                    ]) satisfies Instr[]),
+              ],
       },
     );
   }
 
+  // (#4160) Under the gate, each iteration's Get + callback runs only when
+  // `HasProperty(recv, k)` holds; an absent index is SKIPPED (map keeps its
+  // result aligned by pushing the undefined the hole reads back as — the
+  // dense `$ObjVec` carrier cannot represent a result hole). Gate-off (the
+  // flag-clear default) emits the exact pre-existing sequence.
+  const iterCore: Instr[] = [...readVal, ...buildArgs, ...invoke, ...perIter];
+  const iterBody: Instr[] =
+    hasGateIdx === undefined
+      ? iterCore
+      : [
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: L.i },
+          { op: "call", funcIdx: hasGateIdx },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: iterCore,
+            else:
+              methodName === "map"
+                ? [
+                    { op: "local.get", index: L.out },
+                    ...(undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" } satisfies Instr]),
+                    { op: "call", funcIdx: objVecPushIdx },
+                  ]
+                : [],
+          },
+        ];
   const body: Instr[] = [
     ...prologue,
     {
@@ -357,16 +469,7 @@ export function ensureNativeArrayHof(ctx: CodegenContext, methodName: string): n
         {
           op: "loop",
           blockType: { kind: "empty" },
-          body: [
-            ...loopExitTest,
-            { op: "br_if", depth: 1 },
-            ...readVal,
-            ...buildArgs,
-            ...invoke,
-            ...perIter,
-            ...loopStep,
-            { op: "br", depth: 0 },
-          ],
+          body: [...loopExitTest, { op: "br_if", depth: 1 }, ...iterBody, ...loopStep, { op: "br", depth: 0 }],
         },
       ],
     },

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -234,6 +234,7 @@ import {
 import { fillClosurePropHelpers } from "./closure-props.js"; // (#3468 C-core) closure-own-property side table
 import { fillInstanceTombstones } from "./instance-tombstones.js"; // (#4098 G1 s1) per-instance own-property deletability
 import { fillVecPropHelpers } from "./vec-props.js"; // (#3537) array ($Vec) expando side table
+import { fillProtoIndexStore } from "./proto-index-store.js"; // (#4160) prototype-index companions
 import { finalizeFunctionPoisonPillCalls } from "./function-poison-pill.js";
 import { fillDataViewConstructProtoArm, fillTaDynViewMopArms } from "./ta-dyn-mop.js"; // (#3177/#3371) native view prototype arms
 import { fillObjVecReflectionHelpers } from "./objvec-array-proto.js"; // (#3666) RegExp indices Array reflection
@@ -4493,6 +4494,18 @@ export function generateModule(
     // native errors (standalone/wasi only) — byte-identical otherwise.
     fillExternGetErrorProps(ctx);
 
+    // (#4160) Prototype-index store: fill the reserved `__protoidx_*` helper
+    // bodies and splice the `$NativeProto` write/direct-read arms into
+    // `__extern_set` / `__defineProperty_value` / `__defineProperty_accessor`
+    // / `__extern_get_idx` / `__extern_has_idx`. Runs AFTER every fill above
+    // that locates its splice point by the helpers' preamble shape
+    // (`fillExternGetIdxVecArms` / `fillExternArrayLikeStructArms`) — this
+    // fill PREPENDS at body[0], which would break those shape probes if it ran
+    // first. The prepended `$NativeProto` arm is receiver-disjoint from every
+    // vec / TA-view arm, so taking the front slot is semantically inert.
+    // No-op unless `ctx.standalone && ctx.protoIndexDirty` reserved the store.
+    fillProtoIndexStore(ctx);
+
     // (#802 Slices B+C) Mint the struct-proto natives and prepend the
     // marked-root dispatch arms into `__object_setPrototypeOf` /
     // `__getPrototypeOf` / `__extern_get`, so `Object.setPrototypeOf(
@@ -6682,6 +6695,10 @@ export function generateMultiModule(
     fillTaDynViewMopArms(ctx);
     fillDataViewConstructProtoArm(ctx);
     fillReflectIsConstructor(ctx);
+    // (#4160) Prototype-index store — multi-source parity with the
+    // generateModule call above (same after-the-shape-probing-fills ordering;
+    // see the single-source comment). No-op unless reserved.
+    fillProtoIndexStore(ctx);
     // Emit __vec_get / __vec_len exports for runtime iterator fallback.
     emitVecAccessExports(ctx);
 

--- a/src/codegen/object-runtime-enumeration.ts
+++ b/src/codegen/object-runtime-enumeration.ts
@@ -28,6 +28,9 @@ import { getOrRegisterVecBaseType } from "./registry/types.js";
 import { undefinedExternInstrs } from "./any-helpers.js";
 import { buildExternGetIdxBody } from "./object-runtime.js";
 import { bagKeysIf } from "./carrier-bag-visibility.js"; // (#4010 S3) carrier-bag key enumeration
+// (#4160) prototype-index companion consult for the vec OOB Has (resolves to
+// `undefined` unless `ctx.standalone && ctx.protoIndexDirty` reserved it).
+import { protoIndexHasIdxInstrs } from "./proto-index-store.js";
 
 /**
  * Everything the enumeration/array-like/object-static block reads from the
@@ -804,6 +807,14 @@ export function buildObjectEnumerationHelpers(ctx: CodegenContext, s: ObjectEnum
     // fast path is untouched). Standalone-gated; host import owns the path in
     // gc/host mode.
     const vecBaseHasIdx = objArrayLikeArms ? getOrRegisterVecBaseType(ctx) : -1;
+    // (#4160) Under `protoIndexDirty`, an OOB index on a real array is a
+    // prototype lookup (§7.3.12 walks the chain; the chain is
+    // Array.prototype → Object.prototype), so the miss consults the
+    // prototype-index companions instead of answering a constant 0. In-bounds
+    // stays the dense-presence answer, byte-for-byte. `protoHasConsult` is
+    // `undefined` for every flag-clear / host compile → the exact
+    // pre-existing `i32.and; return` tail is emitted.
+    const protoHasConsult = objArrayLikeArms ? protoIndexHasIdxInstrs(ctx, 1, 1) : undefined;
     const vecHasArm: Instr[] = objArrayLikeArms
       ? [
           { op: "local.get", index: 2 },
@@ -823,6 +834,16 @@ export function buildObjectEnumerationHelpers(ctx: CodegenContext, s: ObjectEnum
               { op: "struct.get", typeIdx: vecBaseHasIdx, fieldIdx: 0 },
               { op: "i32.lt_s" },
               { op: "i32.and" },
+              ...(protoHasConsult === undefined
+                ? []
+                : ([
+                    {
+                      op: "if",
+                      blockType: { kind: "val", type: { kind: "i32" } },
+                      then: [{ op: "i32.const", value: 1 }],
+                      else: protoHasConsult,
+                    },
+                  ] satisfies Instr[])),
               { op: "return" },
             ],
           },

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -101,6 +101,15 @@ import {
   reserveVecPropHelpers,
 } from "./vec-props.js";
 import { ensureSymbolCarrier } from "./symbol-native.js";
+// (#4160) prototype-index store — reserve + registration-time consult builders
+// (all resolve to `undefined` unless `ctx.standalone && ctx.protoIndexDirty`).
+import {
+  protoIndexGetIdxMissInstrs,
+  protoIndexGetKeyMissInstrs,
+  protoIndexHasIdxInstrs,
+  protoIndexHasKeyMissInstrs,
+  reserveProtoIndexStore,
+} from "./proto-index-store.js";
 import { reserveArrayToPrimitiveString } from "./array-to-primitive.js";
 import { UNDEF_F64_BITS } from "./value-tags.js";
 // (#2106 S1) function-level-only cycle with any-helpers.ts (which imports
@@ -846,6 +855,12 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     reserveVecPropHelpers(ctx);
     reserveCarrierBagVisibility(ctx); // (#4010 S3) visibility over both bags — see that module
     reserveInstanceTombstones(ctx); // (#4098 G1 s1) per-instance delete over the SAME bag
+    // (#4160) Prototype-index store — self-gated on `ctx.standalone &&
+    // ctx.protoIndexDirty`, so a flag-clear module reserves NOTHING and every
+    // consult site below resolves `funcMap.get("__protoidx_*") === undefined`,
+    // emitting its exact pre-existing instructions (byte-identity by
+    // construction). Same reserve-before-arms-bake discipline as above.
+    reserveProtoIndexStore(ctx);
   }
 
   // ── __extern_is_array(externref v) -> i32 ────────────────────────────────
@@ -1865,8 +1880,14 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
           },
         ],
       },
-      // not found anywhere → miss (undefined under the S1 regime; legacy null)
-      ...getMiss(),
+      // not found anywhere → miss (undefined under the S1 regime; legacy null).
+      // (#4160) Under `protoIndexDirty` the chain-exhausted miss consults the
+      // prototype-index companions first (an implicit-`Object.prototype`
+      // integer index written via `Object.prototype[i] = v`) — the helper
+      // itself answers the undefined miss when the companions have nothing.
+      // Consulted ONLY here, where own + every `$proto` link have missed, so
+      // an own entry (even one holding `undefined`) still shadows (§7.3.2).
+      ...(protoIndexGetKeyMissInstrs(ctx, 0, 1) ?? getMiss()),
     ];
     registerNative(
       "__extern_get",
@@ -3166,8 +3187,11 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
           },
         ],
       },
-      // not found anywhere → 0
-      { op: "i32.const", value: 0 },
+      // not found anywhere → 0.
+      // (#4160) Under `protoIndexDirty`, consult the prototype-index
+      // companions before answering absent — HasProperty (§7.3.12) is
+      // prototype-inclusive and the implicit chain end is Object.prototype.
+      ...(protoIndexHasKeyMissInstrs(ctx, 1) ?? [{ op: "i32.const", value: 0 } satisfies Instr]),
     ];
     registerNative(
       "__extern_has",
@@ -6231,7 +6255,17 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
   // objects per use — a factory, never a shared array, per the finalize
   // double-remap hazard). The singleton instrs carry no funcIdx/typeIdx, so
   // splicing them at FINALIZE cannot desync any index-shift walk.
-  const idxMiss = (): Instr[] => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
+  // (#4160) Under `protoIndexDirty` an OOB vec read is a prototype lookup, not
+  // a plain undefined: `[1,2][5]` resolves through Array.prototype["5"] then
+  // Object.prototype["5"] (the 15.4.4.19-8-b-15 shape — the loop bound is
+  // fixed at entry, so a callback that shrinks the array makes later indices
+  // OOB and the spec resolves them through the chain). The consult helper
+  // answers the same undefined miss when the companions have nothing, and it
+  // is absent (=> today's miss) for every flag-clear / host compile. The
+  // negative-index point is included for uniformity: the companions can never
+  // hold a negative key (norm-key refuses them), so it stays a miss.
+  const idxMiss = (): Instr[] =>
+    protoIndexGetIdxMissInstrs(ctx, 0, 1, 1) ?? undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
   // (#2903 R4) Packed sub-i32 element carriers (`i8`/`i16`) need an UNSIGNED
   // packed load (`array.get_u`) — plain `array.get` is invalid on a packed
   // array — then f64-box the zero-extended i32 (0..255 / 0..65535, always
@@ -7861,6 +7895,15 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
   cands.sort((a, b) => a.typeIdx - b.typeIdx);
 
   const idxMiss = (): Instr[] => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
+  // (#4160) Arm-level miss for a closed-struct receiver — every own integer
+  // field missed, so the spec continues the [[Get]]/[[HasProperty]] on the
+  // prototype chain, whose implicit end is Object.prototype (consultArray=0:
+  // a plain `{0:x, length:n}` object-like never inherits from
+  // Array.prototype). Absent (flag clear / host) → today's undefined miss.
+  // NOT used for an unboxable OWN field (`closedStructIndexValue`'s inner
+  // miss): a present own field shadows the chain even when unreadable.
+  const protoGetMiss = (): Instr[] | undefined => protoIndexGetIdxMissInstrs(ctx, 0, 1, 0);
+  const protoHasSeed = (): Instr[] | undefined => protoIndexHasIdxInstrs(ctx, 1, 0);
   const MAX_SAFE = 9007199254740991; // 2^53 - 1
 
   /** Shared preamble test (identical for all three helpers). */
@@ -8005,8 +8048,16 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
         );
       }
       const protoGlobalIdx = fnctorProtoGlobals.get(cand.typeIdx);
-      const inheritedMiss = fnctorArray.fnctorGetIndexMiss(protoGlobalIdx, getIdxSelfIdx, 1, idxMiss());
-      if (fieldChecks.length === 0 && protoGlobalIdx === undefined) continue;
+      // (#4160) When a live fnctor prototype exists the recursion into
+      // `__extern_get_idx(protoObj, idx)` reaches the consult through THAT
+      // receiver's own arms; otherwise the arm-level miss consults directly.
+      const inheritedMiss = fnctorArray.fnctorGetIndexMiss(
+        protoGlobalIdx,
+        getIdxSelfIdx,
+        1,
+        protoGetMiss() ?? idxMiss(),
+      );
+      if (fieldChecks.length === 0 && protoGlobalIdx === undefined && protoGetMiss() === undefined) continue;
       arms.push(
         { op: "local.get", index: 2 },
         { op: "ref.test", typeIdx: cand.typeIdx },
@@ -8026,8 +8077,14 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
     const hasIdxSelfIdx = ctx.funcMap.get("__extern_has_idx");
     for (const cand of cands) {
       const protoGlobalIdx = fnctorProtoGlobals.get(cand.typeIdx);
-      if (cand.numericFields.length === 0 && protoGlobalIdx === undefined) continue;
-      const hasChain = fnctorArray.fnctorHasIndexSeed(protoGlobalIdx, hasIdxSelfIdx, 1);
+      if (cand.numericFields.length === 0 && protoGlobalIdx === undefined && protoHasSeed() === undefined) continue;
+      // (#4160) No live fnctor prototype → seed the OR-chain with the
+      // prototype-index companion consult instead of a constant 0 (with one,
+      // the recursion into `__extern_has_idx(protoObj, idx)` consults there).
+      const hasChain =
+        protoGlobalIdx === undefined
+          ? (protoHasSeed() ?? fnctorArray.fnctorHasIndexSeed(protoGlobalIdx, hasIdxSelfIdx, 1))
+          : fnctorArray.fnctorHasIndexSeed(protoGlobalIdx, hasIdxSelfIdx, 1);
       for (const nf of cand.numericFields) {
         hasChain.push(
           { op: "local.get", index: 1 },

--- a/src/codegen/proto-index-store.ts
+++ b/src/codegen/proto-index-store.ts
@@ -1,0 +1,827 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4160) Prototype-INDEX store for `--target standalone` — the runtime
+ * substrate that makes an integer-index property written onto
+ * `Object.prototype` / `Array.prototype` VISIBLE through the prototype chain.
+ *
+ * ## The gap this closes (measured — #4159 architect-spec probes P2/P3)
+ *
+ * In standalone, `Object.prototype` / `Array.prototype` evaluate to the
+ * `$NativeProto` glue singleton (native-proto.ts) — NOT a `$Object` — so
+ * `Object.prototype[1] = 111` routed into `__extern_set`'s non-`$Object`
+ * miss arm and landed NOWHERE (P3: the subsequent `({length:3})[1]` read
+ * answered NaN). And the read chokepoints answered OWN-ONLY, so even with a
+ * store the inherited index stayed invisible to the
+ * `Array.prototype.<HOF>.call(obj)` borrow loops (P2: `{0:0,2:2,length:3}`
+ * visited 2 of 3 indices).
+ *
+ * ## The mechanism (mirrors the host lane's ratified `_protoIndexHas` /
+ * `_protoIndexGet`, src/runtime.ts:409/417)
+ *
+ * Two module globals hold lazily-minted `$Object` COMPANIONS — one for
+ * `%Object.prototype%`, one for `%Array.prototype%`. Everything delegates to
+ * the existing `$Object` machinery (`__new_plain_object`, `__obj_find`,
+ * `__extern_set`, `__defineProperty_*`), never re-implements it:
+ *
+ *  - WRITE arms (finalize-spliced, substitution-by-recursion — the #4161
+ *    `closureBagSubstitutionArm` idea): `__extern_set` /
+ *    `__defineProperty_value` / `__defineProperty_accessor` get a prepended
+ *    `$NativeProto`-brand arm. An Object/Array-branded receiver whose key is
+ *    a CANONICAL NON-NEGATIVE INTEGER string re-targets the call at the
+ *    companion (minting it on first write) and RECURSES, so the whole
+ *    existing machinery (accessor-set gate, #2042-S4 preflight, flag
+ *    translation, frozen checks) applies unchanged. Non-integer keys and
+ *    other brands fall through byte-unchanged — integer-index-only
+ *    participation, exactly the host model. `__extern_set_strict` needs no
+ *    arm: its non-`$Object` head delegates to `__extern_set`.
+ *  - READ fallbacks: the chokepoints consult the companions only after every
+ *    own/chain probe missed — `__extern_get` / `__extern_has` at their
+ *    terminal proto-walk miss (covers `$Object` receivers, incl. the
+ *    `__extern_get_idx` / `__extern_has_idx` `$Object` arms that delegate
+ *    there), the `$__vec_base` arms on OOB, and the closed-struct arms
+ *    (`fillExternArrayLikeStructArms`) on field-ladder miss. A `$__vec_base`
+ *    receiver consults the Array companion FIRST, then the Object companion
+ *    (Array.prototype's own chain ends at Object.prototype); everything else
+ *    consults the Object companion only. Presence is value-independent
+ *    (§7.3.12); Get invokes a companion accessor with the ORIGINAL receiver
+ *    bound as `this` (§6.2.5.5) via `__call_accessor_get`.
+ *
+ * ## Gate — `ctx.standalone && ctx.protoIndexDirty`; byte-identity by construction
+ *
+ * `protoIndexDirty` is a PRE-SCAN flag (array-holes.ts, set before any body
+ * compiles — #4128), so the reserve below simply never runs for a clean
+ * module: no globals, no helpers, and every consult site in object-runtime
+ * resolves `funcMap.get(...) === undefined` and emits its exact pre-existing
+ * instructions. Host/gc output is additionally untouched because the reserve
+ * is standalone-gated. This is the flag-clear-means-no-new-instruction
+ * guarantee the #4160 issue names as its no-regression criterion.
+ *
+ * ## Reserve-then-fill (the established funcIdx discipline)
+ *
+ * The six helpers are reserved as typed stubs from `ensureObjectRuntime`
+ * BEFORE the `__extern_*` bodies bake their `call <idx>` (the vec-props /
+ * closure-props pattern); bodies are filled at FINALIZE
+ * (`fillProtoIndexStore`), when `$NativeProto` + the builtin brands + every
+ * dependency funcIdx are known and resolvable from `funcMap`. Spliced arms
+ * append locals only (never renumber) and build fresh Instr objects per use
+ * (the shared-instr double-remap hazard,
+ * `reference_shared_instr_object_dce_double_remap`).
+ *
+ * ## Known boundaries (deliberate, recorded)
+ *
+ *  - `Object.defineProperties(Object.prototype, {...})` (the PLURAL form) is
+ *    not armed — its receiver head keeps the lenient no-op for a
+ *    `$NativeProto`, as before. The singular forms (the test262-dominant
+ *    shapes, incl. everything `isProtoIndexWrite` recognises) are covered.
+ *  - A companion SETTER invoked via the `__extern_set` recursion receives the
+ *    companion (not the proto object) as `this` — the same receiver
+ *    approximation the delegation buys everywhere else on the write side.
+ *    The GET side does bind the spec receiver (see `__protoidx_get_k`).
+ *  - In-bounds vec HOLES still answer present/undefined (dense carriers; a
+ *    `$Hole`-aware Has/Get is #2001/#3185 scope, not widened here).
+ */
+import type { Instr, ValType, WasmFunction } from "../ir/types.js";
+import { undefinedExternInstrs } from "./any-helpers.js";
+import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { getBuiltinBrand } from "./native-proto.js";
+import { addFuncType } from "./registry/types.js";
+
+/** Reserved helper names (all internal, never exported from the module). */
+const PROTOIDX_COMPANION = "__protoidx_companion";
+const PROTOIDX_NORM_KEY = "__protoidx_norm_key";
+const PROTOIDX_HAS_K = "__protoidx_has_k";
+const PROTOIDX_GET_K = "__protoidx_get_k";
+const PROTOIDX_HAS_F = "__protoidx_has_f";
+const PROTOIDX_GET_F = "__protoidx_get_f";
+
+/** `$PropEntry` field indices (object-runtime.ts layout — value/flags/get). */
+const ENTRY_VALUE = 1;
+const ENTRY_FLAGS = 2;
+const ENTRY_GET = 4;
+/** `$PropEntry.$flags` accessor bit (object-runtime.ts `FLAG_ACCESSOR`). */
+const FLAG_ACCESSOR = 0x08;
+/** i31 abstract heap type (signed LEB -20) — small-int boxed numbers (#3673). */
+const I31_HEAP_TYPE = -20;
+/** 2^53 − 1 — the spec's integer-index ceiling (§6.1.7 "integer index"). */
+const MAX_SAFE_INTEGER = 9007199254740991;
+
+/**
+ * Reserve the proto-index-store globals + helper stubs. Called from
+ * `ensureObjectRuntime` right after the closure/vec side-table reserves,
+ * BEFORE the `__extern_*` bodies bake their `call <idx>`. Self-gated on
+ * `ctx.standalone && ctx.protoIndexDirty` (see module header) and idempotent.
+ * Appends types/globals/funcs only — never shifts an existing index.
+ */
+export function reserveProtoIndexStore(ctx: CodegenContext): void {
+  if (!ctx.standalone || !ctx.protoIndexDirty) return;
+  if (ctx.protoIndexStoreReserved) return;
+  ctx.protoIndexStoreReserved = true;
+
+  // --- companion globals: (mut externref) = null, minted on first write ---
+  const objGlobalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+  ctx.mod.globals.push({
+    name: "__protoidx_obj_companion",
+    type: { kind: "externref" },
+    mutable: true,
+    init: [{ op: "ref.null.extern" }],
+  });
+  ctx.protoIndexObjCompanionGlobalIdx = objGlobalIdx;
+  const arrGlobalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+  ctx.mod.globals.push({
+    name: "__protoidx_arr_companion",
+    type: { kind: "externref" },
+    mutable: true,
+    init: [{ op: "ref.null.extern" }],
+  });
+  ctx.protoIndexArrCompanionGlobalIdx = arrGlobalIdx;
+
+  // --- helper stubs (bodies filled by fillProtoIndexStore at finalize).
+  // Stub bodies are FRESH arrays per helper — never a shared Instr list.
+  const reserve = (name: string, params: ValType[], results: ValType[], stub: () => Instr[]): void => {
+    if (ctx.funcMap.get(name) !== undefined) return;
+    const typeIdx = addFuncType(ctx, params, results, `$${name}_type`);
+    const funcIdx = mintDefinedFunc(ctx);
+    const placeholder: WasmFunction = { name, typeIdx, locals: [], body: stub(), exported: false };
+    pushDefinedFunc(ctx, funcIdx, placeholder);
+    ctx.funcMap.set(name, funcIdx);
+  };
+  const ext: ValType = { kind: "externref" };
+  const i32: ValType = { kind: "i32" };
+  const f64: ValType = { kind: "f64" };
+  const nullExt = (): Instr[] => [{ op: "ref.null.extern" }];
+  const zero = (): Instr[] => [{ op: "i32.const", value: 0 }];
+  // (which: 0=Object 1=Array, create: 0/1) -> companion externref (null when
+  // absent and create=0).
+  reserve(PROTOIDX_COMPANION, [i32, i32], [ext], nullExt);
+  // ToPropertyKey-lite normalizer: string / boxed-number key -> its canonical
+  // non-negative-integer string, or null-extern when the key does not
+  // participate (non-integer, non-canonical, symbol/object — the latter two
+  // deliberately untouched so no user ToPrimitive ever runs twice).
+  reserve(PROTOIDX_NORM_KEY, [ext], [ext], nullExt);
+  // (key, consultArray) -> 1 iff a companion carries the key (§7.3.12 —
+  // presence only, value-independent).
+  reserve(PROTOIDX_HAS_K, [ext, i32], [i32], zero);
+  // (origRecv, key, consultArray) -> [[Get]] through the companions: data
+  // value, accessor invoked with origRecv as `this`, or the undefined miss.
+  reserve(PROTOIDX_GET_K, [ext, ext, i32], [ext], nullExt);
+  // f64-index conveniences for the numeric chokepoints (canonicalise via
+  // number_toString — a non-integer index stringifies to "1.5" and misses).
+  reserve(PROTOIDX_HAS_F, [f64, i32], [i32], zero);
+  reserve(PROTOIDX_GET_F, [ext, f64, i32], [ext], nullExt);
+}
+
+/**
+ * Registration-time consult for `__extern_get`'s terminal proto-walk miss:
+ * `[recv, key, 0] -> call __protoidx_get_k` (tail position — the caller's
+ * body ends with an externref). Returns `undefined` when the store is not
+ * reserved (flag clear / host mode) so the caller emits its exact
+ * pre-existing miss.
+ */
+export function protoIndexGetKeyMissInstrs(
+  ctx: CodegenContext,
+  recvLocal: number,
+  keyLocal: number,
+): Instr[] | undefined {
+  const getKIdx = ctx.funcMap.get(PROTOIDX_GET_K);
+  if (getKIdx === undefined) return undefined;
+  return [
+    { op: "local.get", index: recvLocal },
+    { op: "local.get", index: keyLocal },
+    { op: "i32.const", value: 0 },
+    { op: "call", funcIdx: getKIdx },
+  ];
+}
+
+/**
+ * Registration-time consult for `__extern_has`'s terminal proto-walk miss:
+ * `[key, 0] -> call __protoidx_has_k` (tail i32). `undefined` when unreserved.
+ */
+export function protoIndexHasKeyMissInstrs(ctx: CodegenContext, keyLocal: number): Instr[] | undefined {
+  const hasKIdx = ctx.funcMap.get(PROTOIDX_HAS_K);
+  if (hasKIdx === undefined) return undefined;
+  return [
+    { op: "local.get", index: keyLocal },
+    { op: "i32.const", value: 0 },
+    { op: "call", funcIdx: hasKIdx },
+  ];
+}
+
+/**
+ * Numeric-index consult `[idx, consultArray] -> i32` for the `$__vec_base` /
+ * closed-struct Has arms. `undefined` when unreserved.
+ */
+export function protoIndexHasIdxInstrs(
+  ctx: CodegenContext,
+  idxLocal: number,
+  consultArray: 0 | 1,
+): Instr[] | undefined {
+  const hasFIdx = ctx.funcMap.get(PROTOIDX_HAS_F);
+  if (hasFIdx === undefined) return undefined;
+  return [
+    { op: "local.get", index: idxLocal },
+    { op: "i32.const", value: consultArray },
+    { op: "call", funcIdx: hasFIdx },
+  ];
+}
+
+/**
+ * Numeric-index consult `[recv, idx, consultArray] -> externref` for the Get
+ * miss points of the vec / closed-struct arms. `undefined` when unreserved.
+ */
+export function protoIndexGetIdxMissInstrs(
+  ctx: CodegenContext,
+  recvLocal: number,
+  idxLocal: number,
+  consultArray: 0 | 1,
+): Instr[] | undefined {
+  const getFIdx = ctx.funcMap.get(PROTOIDX_GET_F);
+  if (getFIdx === undefined) return undefined;
+  return [
+    { op: "local.get", index: recvLocal },
+    { op: "local.get", index: idxLocal },
+    { op: "i32.const", value: consultArray },
+    { op: "call", funcIdx: getFIdx },
+  ];
+}
+
+/** Everything the finalize fill needs; null when some dependency is absent. */
+interface ProtoIndexFillDeps {
+  objectTypeIdx: number;
+  propEntryTypeIdx: number;
+  companionIdx: number;
+  newPlainObjectIdx: number;
+  objFindIdx: number;
+  unboxNumberIdx: number;
+  strToNumberIdx: number;
+  numberToStringIdx: number;
+  callAccessorGetIdx: number;
+  strFlattenIdx: number;
+  strEqualsIdx: number;
+  objGlobalIdx: number;
+  arrGlobalIdx: number;
+}
+
+function resolveFillDeps(ctx: CodegenContext): ProtoIndexFillDeps | null {
+  const types = ctx.objectRuntimeTypes;
+  if (!types) return null;
+  const companionIdx = ctx.funcMap.get(PROTOIDX_COMPANION);
+  const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object");
+  const objFindIdx = ctx.funcMap.get("__obj_find");
+  const unboxNumberIdx = ctx.funcMap.get("__unbox_number");
+  const strToNumberIdx = ctx.funcMap.get("__str_to_number");
+  const numberToStringIdx = ctx.funcMap.get("number_toString");
+  const callAccessorGetIdx = ctx.funcMap.get("__call_accessor_get");
+  const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals");
+  const objGlobalIdx = ctx.protoIndexObjCompanionGlobalIdx;
+  const arrGlobalIdx = ctx.protoIndexArrCompanionGlobalIdx;
+  if (
+    companionIdx === undefined ||
+    newPlainObjectIdx === undefined ||
+    objFindIdx === undefined ||
+    unboxNumberIdx === undefined ||
+    strToNumberIdx === undefined ||
+    numberToStringIdx === undefined ||
+    callAccessorGetIdx === undefined ||
+    strFlattenIdx === undefined ||
+    strEqualsIdx === undefined ||
+    objGlobalIdx === undefined ||
+    arrGlobalIdx === undefined
+  ) {
+    return null;
+  }
+  return {
+    objectTypeIdx: types.objectTypeIdx,
+    propEntryTypeIdx: types.propEntryTypeIdx,
+    companionIdx,
+    newPlainObjectIdx,
+    objFindIdx,
+    unboxNumberIdx,
+    strToNumberIdx,
+    numberToStringIdx,
+    callAccessorGetIdx,
+    strFlattenIdx,
+    strEqualsIdx,
+    objGlobalIdx,
+    arrGlobalIdx,
+  };
+}
+
+function findFn(ctx: CodegenContext, name: string): WasmFunction | undefined {
+  const idx = ctx.funcMap.get(name);
+  return idx === undefined ? undefined : definedFuncAt(ctx, idx);
+}
+
+/**
+ * FINALIZE — fill the reserved helper bodies and splice the `$NativeProto`
+ * write/read arms, all funcIdx/typeIdx resolved NOW from `funcMap`/ctx (the
+ * `fillExternArrayLikeStructArms` discipline). Idempotent. No-op unless
+ * `reserveProtoIndexStore` ran (flag-set standalone modules only).
+ */
+export function fillProtoIndexStore(ctx: CodegenContext): void {
+  if (!ctx.protoIndexStoreReserved || ctx.protoIndexStoreFilled) return;
+  ctx.protoIndexStoreFilled = true;
+  const deps = resolveFillDeps(ctx);
+  if (!deps) return; // dependencies absent — stubs keep answering "miss" (safe)
+
+  fillCompanionBody(ctx, deps);
+  fillNormKeyBody(ctx, deps);
+  fillHasKBody(ctx, deps);
+  fillGetKBody(ctx, deps);
+  fillHasFBody(ctx, deps);
+  fillGetFBody(ctx, deps);
+  spliceNativeProtoWriteArms(ctx);
+  spliceNativeProtoDirectReadArms(ctx);
+}
+
+/** `__protoidx_companion(which, create) -> externref` — lazily-minted store. */
+function fillCompanionBody(ctx: CodegenContext, deps: ProtoIndexFillDeps): void {
+  const fn = findFn(ctx, PROTOIDX_COMPANION);
+  if (!fn) return;
+  // params: 0=which 1=create
+  const branch = (globalIdx: number): Instr[] => [
+    { op: "global.get", index: globalIdx },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 1 },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "call", funcIdx: deps.newPlainObjectIdx },
+            { op: "global.set", index: globalIdx },
+          ],
+        },
+      ],
+    },
+    { op: "global.get", index: globalIdx },
+    { op: "return" },
+  ];
+  const tail = branch(deps.objGlobalIdx);
+  tail.pop(); // trailing `return` is redundant in tail position
+  fn.body = [
+    { op: "local.get", index: 0 },
+    { op: "if", blockType: { kind: "empty" }, then: branch(deps.arrGlobalIdx) },
+    ...tail,
+  ];
+}
+
+/**
+ * `__protoidx_norm_key(key) -> externref` — the canonical-integer-index gate
+ * (the host `_protoIndexHas/Get`'s `Number.isInteger(idx) && idx >= 0`, plus
+ * the CanonicalNumericIndexString check a string key needs). Returns the
+ * canonical decimal string, or null-extern when the key does not participate.
+ */
+function fillNormKeyBody(ctx: CodegenContext, deps: ProtoIndexFillDeps): void {
+  const fn = findFn(ctx, PROTOIDX_NORM_KEY);
+  if (!fn || ctx.anyStrTypeIdx < 0) return;
+  const anyStr = ctx.anyStrTypeIdx;
+  const boxNumTypeIdx = ctx.nativeBoxNumberTypeIdx;
+  // locals: 1=any(anyref) 2=str(externref) 3=n(f64)
+  fn.locals = [
+    { name: "any", type: { kind: "anyref" } },
+    { name: "str", type: { kind: "externref" } },
+    { name: "n", type: { kind: "f64" } },
+  ];
+  const miss = (): Instr[] => [{ op: "ref.null.extern" }, { op: "return" }];
+  fn.body = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.tee", index: 1 },
+    // string key → keep as-is; boxed-number / i31 key → canonical decimal
+    // string; anything else (symbol / object) → does not participate. Object
+    // keys are deliberately NOT ToPrimitive'd here: the fall-through path
+    // coerces them exactly once, and running a user toString twice would
+    // double its side effects.
+    { op: "ref.test", typeIdx: anyStr },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 0 },
+        { op: "local.set", index: 2 },
+      ],
+      else:
+        boxNumTypeIdx >= 0
+          ? [
+              { op: "local.get", index: 1 },
+              { op: "ref.test", typeIdx: boxNumTypeIdx },
+              { op: "local.get", index: 1 },
+              { op: "ref.test", typeIdx: I31_HEAP_TYPE },
+              { op: "i32.or" },
+              { op: "i32.eqz" },
+              { op: "if", blockType: { kind: "empty" }, then: miss() },
+              { op: "local.get", index: 0 },
+              { op: "call", funcIdx: deps.unboxNumberIdx },
+              { op: "call", funcIdx: deps.numberToStringIdx },
+              { op: "local.set", index: 2 },
+            ]
+          : miss(),
+    },
+    // n = StringToNumber(str) (§7.1.4.1)
+    { op: "local.get", index: 2 },
+    { op: "call", funcIdx: deps.strToNumberIdx },
+    { op: "local.tee", index: 3 },
+    // integer index: trunc(n) == n (NaN fails) && n >= 0 && n <= 2^53−1
+    // (Infinity fails the ceiling).
+    { op: "f64.trunc" },
+    { op: "local.get", index: 3 },
+    { op: "f64.eq" },
+    { op: "local.get", index: 3 },
+    { op: "f64.const", value: 0 },
+    { op: "f64.ge" },
+    { op: "i32.and" },
+    { op: "local.get", index: 3 },
+    { op: "f64.const", value: MAX_SAFE_INTEGER },
+    { op: "f64.le" },
+    { op: "i32.and" },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: miss() },
+    // canonicity: ToString(n) must equal the key string — "01" / " 1" / "1e2"
+    // / "" are NOT integer indices (they stay plain string props, untouched).
+    { op: "local.get", index: 3 },
+    { op: "call", funcIdx: deps.numberToStringIdx },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: anyStr },
+    { op: "call", funcIdx: deps.strFlattenIdx },
+    { op: "local.get", index: 2 },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: anyStr },
+    { op: "call", funcIdx: deps.strFlattenIdx },
+    { op: "call", funcIdx: deps.strEqualsIdx },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: miss() },
+    { op: "local.get", index: 2 },
+  ];
+}
+
+/**
+ * Probe one companion (LOOKUP, never ensure — reads must not allocate): if it
+ * exists and `__obj_find` answers a live entry for the key, run `hit`.
+ * `cLocal` is an externref scratch local of the enclosing helper.
+ */
+function companionProbeArm(
+  deps: ProtoIndexFillDeps,
+  which: 0 | 1,
+  keyLocal: number,
+  cLocal: number,
+  hit: Instr[],
+): Instr[] {
+  return [
+    { op: "i32.const", value: which },
+    { op: "i32.const", value: 0 },
+    { op: "call", funcIdx: deps.companionIdx },
+    { op: "local.set", index: cLocal },
+    { op: "local.get", index: cLocal },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: cLocal },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: deps.objectTypeIdx },
+        { op: "local.get", index: keyLocal },
+        { op: "call", funcIdx: deps.objFindIdx },
+        { op: "ref.is_null" },
+        { op: "i32.eqz" },
+        { op: "if", blockType: { kind: "empty" }, then: hit },
+      ],
+    },
+  ];
+}
+
+/** `__protoidx_has_k(key, consultArray) -> i32` — §7.3.12 presence. */
+function fillHasKBody(ctx: CodegenContext, deps: ProtoIndexFillDeps): void {
+  const fn = findFn(ctx, PROTOIDX_HAS_K);
+  if (!fn) return;
+  // params: 0=key 1=consultArray ; locals: 2=c(externref)
+  fn.locals = [{ name: "c", type: { kind: "externref" } }];
+  const hit = (): Instr[] => [{ op: "i32.const", value: 1 }, { op: "return" }];
+  fn.body = [
+    { op: "local.get", index: 1 },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: companionProbeArm(deps, 1, 0, 2, hit()),
+    },
+    ...companionProbeArm(deps, 0, 0, 2, hit()),
+    { op: "i32.const", value: 0 },
+  ];
+}
+
+/** `__protoidx_get_k(origRecv, key, consultArray) -> externref` — §6.2.5.5 Get. */
+function fillGetKBody(ctx: CodegenContext, deps: ProtoIndexFillDeps): void {
+  const fn = findFn(ctx, PROTOIDX_GET_K);
+  if (!fn) return;
+  const entryRefNull: ValType = { kind: "ref_null", typeIdx: deps.propEntryTypeIdx };
+  // params: 0=origRecv 1=key 2=consultArray
+  // locals: 3=c(externref) 4=e(ref null $PropEntry, default null) 5=getter(externref)
+  fn.locals = [
+    { name: "c", type: { kind: "externref" } },
+    { name: "e", type: entryRefNull },
+    { name: "getter", type: { kind: "externref" } },
+  ];
+  const miss = (): Instr[] => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
+  const probeInto = (which: 0 | 1): Instr[] => [
+    { op: "i32.const", value: which },
+    { op: "i32.const", value: 0 },
+    { op: "call", funcIdx: deps.companionIdx },
+    { op: "local.set", index: 3 },
+    { op: "local.get", index: 3 },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 3 },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: deps.objectTypeIdx },
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: deps.objFindIdx },
+        { op: "local.set", index: 4 },
+      ],
+    },
+  ];
+  fn.body = [
+    // consultArray → probe the Array companion first.
+    { op: "local.get", index: 2 },
+    { op: "if", blockType: { kind: "empty" }, then: probeInto(1) },
+    // Object companion only when nothing was found yet.
+    { op: "local.get", index: 4 },
+    { op: "ref.is_null" },
+    { op: "if", blockType: { kind: "empty" }, then: probeInto(0) },
+    // No entry anywhere → undefined miss.
+    { op: "local.get", index: 4 },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...miss(), { op: "return" }],
+    },
+    // Accessor entry → invoke the getter with the ORIGINAL receiver
+    // (§6.2.5.5 step 8 — Receiver is the object the Get started on).
+    { op: "local.get", index: 4 },
+    { op: "ref.as_non_null" },
+    { op: "struct.get", typeIdx: deps.propEntryTypeIdx, fieldIdx: ENTRY_FLAGS },
+    { op: "i32.const", value: FLAG_ACCESSOR },
+    { op: "i32.and" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 4 },
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: deps.propEntryTypeIdx, fieldIdx: ENTRY_GET },
+        { op: "extern.convert_any" },
+        { op: "local.tee", index: 5 },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [...miss(), { op: "return" }],
+        },
+        { op: "local.get", index: 0 },
+        { op: "local.get", index: 5 },
+        { op: "call", funcIdx: deps.callAccessorGetIdx },
+        { op: "return" },
+      ],
+    },
+    // Data entry → its value.
+    { op: "local.get", index: 4 },
+    { op: "ref.as_non_null" },
+    { op: "struct.get", typeIdx: deps.propEntryTypeIdx, fieldIdx: ENTRY_VALUE },
+    { op: "extern.convert_any" },
+  ];
+}
+
+/** `__protoidx_has_f(idx, consultArray)` = has_k(ToString(idx), consultArray). */
+function fillHasFBody(ctx: CodegenContext, deps: ProtoIndexFillDeps): void {
+  const fn = findFn(ctx, PROTOIDX_HAS_F);
+  const hasKIdx = ctx.funcMap.get(PROTOIDX_HAS_K);
+  if (!fn || hasKIdx === undefined) return;
+  fn.body = [
+    { op: "local.get", index: 0 },
+    { op: "call", funcIdx: deps.numberToStringIdx },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: hasKIdx },
+  ];
+}
+
+/** `__protoidx_get_f(recv, idx, consultArray)` = get_k(recv, ToString(idx), ca). */
+function fillGetFBody(ctx: CodegenContext, deps: ProtoIndexFillDeps): void {
+  const fn = findFn(ctx, PROTOIDX_GET_F);
+  const getKIdx = ctx.funcMap.get(PROTOIDX_GET_K);
+  if (!fn || getKIdx === undefined) return;
+  fn.body = [
+    { op: "local.get", index: 0 },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: deps.numberToStringIdx },
+    { op: "local.get", index: 2 },
+    { op: "call", funcIdx: getKIdx },
+  ];
+}
+
+/**
+ * The `$NativeProto` brand head shared by the write arms: runs `then` when
+ * the receiver (param 0) is the Object/Array prototype glue singleton and the
+ * key (param `keyParam`) normalises to a canonical integer index (left in
+ * `nkLocal`; brand left in `brandLocal`). Falls through untouched otherwise.
+ */
+function nativeProtoWriteArmHead(
+  ctx: CodegenContext,
+  opts: { brandLocal: number; nkLocal: number; keyParam: number; objBrand: number; arrBrand: number; then: Instr[] },
+): Instr[] | undefined {
+  const npTypeIdx = ctx.nativeProtoTypeIdx;
+  const normKeyIdx = ctx.funcMap.get(PROTOIDX_NORM_KEY);
+  if (npTypeIdx === undefined || normKeyIdx === undefined) return undefined;
+  return [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: npTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 0 },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: npTypeIdx },
+        { op: "struct.get", typeIdx: npTypeIdx, fieldIdx: 0 }, // $brand
+        { op: "local.set", index: opts.brandLocal },
+        { op: "local.get", index: opts.brandLocal },
+        { op: "i32.const", value: opts.objBrand },
+        { op: "i32.eq" },
+        { op: "local.get", index: opts.brandLocal },
+        { op: "i32.const", value: opts.arrBrand },
+        { op: "i32.eq" },
+        { op: "i32.or" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: opts.keyParam },
+            { op: "call", funcIdx: normKeyIdx },
+            { op: "local.tee", index: opts.nkLocal },
+            { op: "ref.is_null" },
+            { op: "i32.eqz" },
+            { op: "if", blockType: { kind: "empty" }, then: opts.then },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+/** `[brandLocal == arrBrand (which), create=1] -> call companion` (externref). */
+function companionForBrandInstrs(companionIdx: number, brandLocal: number, arrBrand: number): Instr[] {
+  return [
+    { op: "local.get", index: brandLocal },
+    { op: "i32.const", value: arrBrand },
+    { op: "i32.eq" },
+    { op: "i32.const", value: 1 }, // create — this is the write side
+    { op: "call", funcIdx: companionIdx },
+  ];
+}
+
+/**
+ * FINALIZE — prepend the `$NativeProto` write arms (substitution-by-recursion)
+ * onto `__extern_set` / `__defineProperty_value` / `__defineProperty_accessor`.
+ * The arm re-targets the call at the companion `$Object` and RECURSES (the
+ * companion is a plain `$Object`, so the recursion takes the ordinary path and
+ * terminates), which keeps the accessor-set gate, the #2042-S4 preflight, the
+ * flag translation and the frozen checks all working unchanged; the define
+ * arms still return the ORIGINAL receiver (defineProperty returns O). Locals
+ * are appended, never renumbered.
+ */
+function spliceNativeProtoWriteArms(ctx: CodegenContext): void {
+  const objBrand = getBuiltinBrand(ctx, "Object");
+  const arrBrand = getBuiltinBrand(ctx, "Array");
+  const companionIdx = ctx.funcMap.get(PROTOIDX_COMPANION);
+  if (objBrand === undefined || arrBrand === undefined || companionIdx === undefined) return;
+
+  const spliceInto = (
+    name: string,
+    numParams: number,
+    inner: (brandLocal: number, nkLocal: number, selfIdx: number) => Instr[],
+  ): void => {
+    const selfIdx = ctx.funcMap.get(name);
+    const fn = selfIdx === undefined ? undefined : definedFuncAt(ctx, selfIdx);
+    if (!fn || selfIdx === undefined) return;
+    const brandLocal = numParams + fn.locals.length;
+    const nkLocal = brandLocal + 1;
+    const arm = nativeProtoWriteArmHead(ctx, {
+      brandLocal,
+      nkLocal,
+      keyParam: 1,
+      objBrand,
+      arrBrand,
+      then: inner(brandLocal, nkLocal, selfIdx),
+    });
+    if (!arm) return;
+    fn.locals.push(
+      { name: "__protoidx_brand", type: { kind: "i32" } },
+      { name: "__protoidx_nk", type: { kind: "externref" } },
+    );
+    fn.body.splice(0, 0, ...arm);
+  };
+
+  // __extern_set(obj, key, value) -> void
+  spliceInto("__extern_set", 3, (brandLocal, nkLocal, selfIdx) => [
+    ...companionForBrandInstrs(companionIdx, brandLocal, arrBrand),
+    { op: "local.get", index: nkLocal },
+    { op: "local.get", index: 2 },
+    { op: "call", funcIdx: selfIdx },
+    { op: "return" },
+  ]);
+  // __defineProperty_value(obj, key, value, flagsF64) -> externref (returns O)
+  spliceInto("__defineProperty_value", 4, (brandLocal, nkLocal, selfIdx) => [
+    ...companionForBrandInstrs(companionIdx, brandLocal, arrBrand),
+    { op: "local.get", index: nkLocal },
+    { op: "local.get", index: 2 },
+    { op: "local.get", index: 3 },
+    { op: "call", funcIdx: selfIdx },
+    { op: "drop" },
+    { op: "local.get", index: 0 }, // return the ORIGINAL proto receiver
+    { op: "return" },
+  ]);
+  // __defineProperty_accessor(obj, key, getter, setter, flagsF64) -> externref
+  spliceInto("__defineProperty_accessor", 5, (brandLocal, nkLocal, selfIdx) => [
+    ...companionForBrandInstrs(companionIdx, brandLocal, arrBrand),
+    { op: "local.get", index: nkLocal },
+    { op: "local.get", index: 2 },
+    { op: "local.get", index: 3 },
+    { op: "local.get", index: 4 },
+    { op: "call", funcIdx: selfIdx },
+    { op: "drop" },
+    { op: "local.get", index: 0 },
+    { op: "return" },
+  ]);
+}
+
+/**
+ * FINALIZE — read-your-writes coherence for DIRECT indexed reads on the proto
+ * objects themselves (`Object.prototype[1]` / `Array.prototype[1]` as
+ * receivers): prepend a `$NativeProto` brand arm onto `__extern_get_idx` /
+ * `__extern_has_idx` that consults the companions (the Array brand consults
+ * the Array companion first — its own chain ends at Object.prototype). Other
+ * brands fall through to today's behaviour.
+ */
+function spliceNativeProtoDirectReadArms(ctx: CodegenContext): void {
+  const npTypeIdx = ctx.nativeProtoTypeIdx;
+  const objBrand = getBuiltinBrand(ctx, "Object");
+  const arrBrand = getBuiltinBrand(ctx, "Array");
+  const getFIdx = ctx.funcMap.get(PROTOIDX_GET_F);
+  const hasFIdx = ctx.funcMap.get(PROTOIDX_HAS_F);
+  if (npTypeIdx === undefined || objBrand === undefined || arrBrand === undefined) return;
+  if (getFIdx === undefined || hasFIdx === undefined) return;
+
+  const splice = (name: string, isHas: boolean, consultIdx: number): void => {
+    const fn = findFn(ctx, name);
+    if (!fn) return;
+    // params: 0=v(externref) 1=idx(f64); append a brand scratch local.
+    const brandLocal = 2 + fn.locals.length;
+    fn.locals.push({ name: "__protoidx_brand", type: { kind: "i32" } });
+    // has_f takes (idx, consultArray); get_f takes (recv, idx, consultArray).
+    const consult = (consultArray: 0 | 1): Instr[] => [
+      ...(isHas ? [] : ([{ op: "local.get", index: 0 }] satisfies Instr[])),
+      { op: "local.get", index: 1 },
+      { op: "i32.const", value: consultArray },
+      { op: "call", funcIdx: consultIdx },
+      { op: "return" },
+    ];
+    const arm: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: npTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 0 },
+          { op: "any.convert_extern" },
+          { op: "ref.cast", typeIdx: npTypeIdx },
+          { op: "struct.get", typeIdx: npTypeIdx, fieldIdx: 0 },
+          { op: "local.set", index: brandLocal },
+          { op: "local.get", index: brandLocal },
+          { op: "i32.const", value: objBrand },
+          { op: "i32.eq" },
+          { op: "if", blockType: { kind: "empty" }, then: consult(0) },
+          { op: "local.get", index: brandLocal },
+          { op: "i32.const", value: arrBrand },
+          { op: "i32.eq" },
+          { op: "if", blockType: { kind: "empty" }, then: consult(1) },
+          // other brands: fall through unchanged
+        ],
+      },
+    ];
+    fn.body.splice(0, 0, ...arm);
+  };
+  splice("__extern_get_idx", false, getFIdx);
+  splice("__extern_has_idx", true, hasFIdx);
+}

--- a/tests/issue-4160-proto-index-store.test.ts
+++ b/tests/issue-4160-proto-index-store.test.ts
@@ -108,6 +108,39 @@ describe("#4160 prototype-index store (standalone)", () => {
     expect(r).toBe(35);
   });
 
+  it("__hof_ gate SKIP branch: callback shrink makes later indices absent -> skipped", async () => {
+    // len is fixed at 3; pop() inside the callback shrinks the array, so i=2
+    // is OOB -> HasProperty false (no proto entry in range) -> skipped.
+    // Ungated (main) behaviour visits all 3 with an undefined read.
+    const r = await runStandalone(`
+      function visit(a: any): number {
+        let visits = 0;
+        a.forEach(function (v: any) { visits++; a.pop(); });
+        return visits;
+      }
+      export function main(): number {
+        (Object.prototype as any)[9] = 1; // dirty only
+        return visit([10, 20, 30]);
+      }
+    `);
+    expect(r).toBe(2);
+  });
+
+  it("__hof_ gate PROTO branch: vacated index resolves through Array.prototype", async () => {
+    const r = await runStandalone(`
+      function visit(a: any): number {
+        let sum = 0;
+        a.forEach(function (v: any) { sum += v; a.pop(); });
+        return sum;
+      }
+      export function main(): number {
+        (Array.prototype as any)[2] = 99;
+        return visit([10, 20, 30]);
+      }
+    `);
+    expect(r).toBe(129); // 10 + 20 + 99 (index 2 OOB after pop -> proto)
+  });
+
   it("flag-clear module emits NO proto-index machinery (structural byte-identity witness)", async () => {
     // A dense loop + HOF + dynamic read program that never touches a prototype
     // index: the compiled WAT must contain no __protoidx_ symbol and no

--- a/tests/issue-4160-proto-index-store.test.ts
+++ b/tests/issue-4160-proto-index-store.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4160 — prototype-index store (standalone): integer-index properties written
+ * onto `Object.prototype` / `Array.prototype` must be visible through the
+ * prototype chain, and a flag-clear module must carry NO trace of the
+ * mechanism (the byte-identity guarantee, asserted structurally on the WAT).
+ *
+ * The P2/P3 shapes are the acceptance probes from the #4159 architect spec —
+ * both measured failing on main (P3 → NaN; P2 → sum 2 / visits 2).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, { target: "standalone" });
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  const { instance } = await WebAssembly.instantiate(result.binary!, {});
+  return (instance.exports as { main: () => unknown }).main();
+}
+
+describe("#4160 prototype-index store (standalone)", () => {
+  it("P3: Object.prototype[1] = 111 is readable through a plain array-like", async () => {
+    const r = await runStandalone(`
+      export function main(): number {
+        (Object.prototype as any)[1] = 111;
+        const o: any = { length: 3 };
+        return o[1];
+      }
+    `);
+    expect(r).toBe(111);
+  });
+
+  it("P2: forEach.call visits the inherited index and skips the absent one", async () => {
+    const r = await runStandalone(`
+      export function main(): number {
+        (Object.prototype as any)[1] = 111;
+        const obj: any = { 0: 0, 2: 2, length: 3 };
+        let sum = 0;
+        let visits = 0;
+        Array.prototype.forEach.call(obj, function (v: any) {
+          sum += v;
+          visits++;
+        });
+        return sum * 10 + visits;
+      }
+    `);
+    expect(r).toBe(1133); // sum 113, visits 3
+  });
+
+  it("defineProperty(Object.prototype, index, {value}) lands and reads back", async () => {
+    const r = await runStandalone(`
+      export function main(): number {
+        Object.defineProperty(Object.prototype, "1", { value: 55, configurable: true });
+        const o: any = { length: 3 };
+        return o[1];
+      }
+    `);
+    expect(r).toBe(55);
+  });
+
+  it("OOB read on a real array resolves through the Array.prototype companion", async () => {
+    const r = await runStandalone(`
+      export function main(): number {
+        (Array.prototype as any)[5] = 42;
+        const arr: any = [1, 2];
+        return arr[5];
+      }
+    `);
+    expect(r).toBe(42);
+  });
+
+  it("the in-operator sees the inherited index", async () => {
+    const r = await runStandalone(`
+      export function main(): number {
+        (Object.prototype as any)[1] = 111;
+        const o: any = { length: 3 };
+        return (1 in o ? 10 : 0) + (2 in o ? 1 : 0);
+      }
+    `);
+    expect(r).toBe(10);
+  });
+
+  it("non-integer keys do not participate (canonical-integer gate)", async () => {
+    const r = await runStandalone(`
+      export function main(): number {
+        (Object.prototype as any)["01"] = 5;
+        (Object.prototype as any)[1.5] = 6;
+        const o: any = { length: 3 };
+        const a = o[1];
+        return a === undefined ? -1 : a;
+      }
+    `);
+    expect(r).toBe(-1);
+  });
+
+  it("dirty flag does not change dense-array HOF results (gate correctness)", async () => {
+    const r = await runStandalone(`
+      function red(a: any): number {
+        return a.reduce(function (x: any, y: any) { return x + y; });
+      }
+      export function main(): number {
+        (Object.prototype as any)[9] = 1;
+        return red([5, 10, 20]);
+      }
+    `);
+    expect(r).toBe(35);
+  });
+
+  it("flag-clear module emits NO proto-index machinery (structural byte-identity witness)", async () => {
+    // A dense loop + HOF + dynamic read program that never touches a prototype
+    // index: the compiled WAT must contain no __protoidx_ symbol and no
+    // proto-index companion global. This is the CI-durable form of the
+    // branch-vs-main byte-identity A/B (which cannot run in CI).
+    const result = await compile(
+      `
+      export function main(): number {
+        const a = [1, 2, 3];
+        let s = 0;
+        for (let i = 0; i < a.length; i++) s += a[i];
+        const o: any = { length: 3, 0: 1 };
+        return s + (o[0] as number) + a.map((x) => x + 1).length;
+      }
+      `,
+      { target: "standalone" },
+    );
+    expect(result.success).toBe(true);
+    expect(result.wat).not.toContain("__protoidx_");
+    expect(result.wat).not.toContain("protoidx_obj_companion");
+  });
+});


### PR DESCRIPTION
Implements the READ side of #4160 per the #4159 architect spec §(c) items 1-4 (item 5, LengthOfArrayLike, out of scope). Standalone lane only; every new emission gated on `ctx.standalone && ctx.protoIndexDirty` (the #4128 pre-scan substrate). Branch base: `origin/main` @ `251df3b03`.

**Read this first: this PR moves ZERO test262 tests in its scoped set.** It is a capability slice — the mechanism the spec asked for, proven by its own acceptance tests — whose test262 yield is gated behind the own-accessor-descriptor path (#2668 / #3251 / #4161). Details under "Scoped test262 A/B" below. Do not merge this expecting conformance movement.

## What

- **New module `src/codegen/proto-index-store.ts`** — two lazily-minted `$Object` companions (`%Object.prototype%` / `%Array.prototype%`) in `(mut externref)` globals, six reserve-then-fill `__protoidx_*` helpers (companion access, canonical-integer-index key gate, key/f64 Has+Get consults). Mirrors the host lane's ratified `_protoIndexHas`/`_protoIndexGet` (`src/runtime.ts:409/417`): integer-index-only participation, presence value-independent (§7.3.12), Get invokes accessors with the ORIGINAL receiver (§6.2.5.5).
- **Write arms** (finalize-spliced, substitution-by-recursion — the #4161 `closureBagSubstitutionArm` idea): `__extern_set` / `__defineProperty_value` / `__defineProperty_accessor` get a prepended `$NativeProto`-brand arm that re-targets the call at the companion and recurses, so the accessor-set gate, #2042-S4 preflight, flag translation and frozen checks all apply unchanged. `__extern_set_strict` needs no arm (its non-`$Object` head delegates).
- **Read fallbacks**, consulted only after every own/chain probe missed: `__extern_get`/`__extern_has` terminal proto-walk miss (`$Object` receivers, incl. the `__extern_get_idx`/`__extern_has_idx` `$Object` arms that delegate there), `$__vec_base` OOB (get_idx vec arms + has_idx vec arm), closed-struct field-ladder miss (`fillExternArrayLikeStructArms`), plus direct read-back arms on the proto objects themselves.
- **`__hof_*` HasProperty gate**: per-iteration `__extern_has_idx` on forEach/map/filter/some/every/reduce/reduceRight (not the find* family); map pushes undefined for an absent index to keep result alignment; reduce no-init scans for the first PRESENT element as its seed (§23.1.3.24 8.b).

## One spec correction, one sizing correction

1. **"Final arms in `__extern_get_idx`/`__extern_has_idx`" cannot work as literally specced for `$Object` receivers.** Measured on the P3 WAT: the `$Object` arm of `__extern_get_idx` DELEGATES to `__extern_get(v, ToString(i))` and returns — a final arm after it never executes for that receiver class (which includes P3's `{length:3}`). The consult therefore lives at the TERMINAL miss of `__extern_get`/`__extern_has`, where own-absence is precisely known (an own entry HOLDING `undefined` still shadows the chain), plus the vec/closed-struct miss points. Same intended semantics, corrected insertion points.
2. **The ~297-file target conflated two mechanisms** (project-lead triage on this A/B, recorded in the issue's `### Sizing correction`): the signature clustering lumped own-accessor-descriptor tests with prototype-chain-inheritance tests. The dominant shapes need an OWN accessor on the receiver to work first (`15.4.4.18-7-b-12`'s `obj["0"]` getter; `every/15.4.4.16-7-c-i-9` involves no prototype at all). Both pre-scan flags DO fire on the real test sources — the arms are active; the tests fail upstream of them. Dependency order: own-descriptor path first, then re-measure this cluster.

## Acceptance (measured; committed as `tests/issue-4160-proto-index-store.test.ts`, 10 tests)

- **P3**: `(Object.prototype as any)[1] = 111` then `({length:3} as any)[1]` → **111** (main: NaN).
- **P2**: `Object.prototype[1]=111`; `Array.prototype.forEach.call({0:0,2:2,length:3}, cb)` → **sum 113, visits 3** (main: sum 2, visits 2).
- **Positive control (proves the A/B instrument below is not blind):** with main's compiler files swapped in, this test file runs **5 failed / 3 passed**; with this branch's files restored, **all green**.
- Also green: defineProperty-value on the proto; real-array OOB resolving through the Array companion; `in`-operator; non-integer-key refusal (`"01"`/`1.5` do not participate); dirty-flag dense-HOF parity.
- **Both `__hof_*` gate branches are exercised by committed tests**: a callback `pop()` shrink makes a later index absent → skipped (visits 3→2), and the same shrink with `Array.prototype[2]=99` resolves the vacated index through the companion (sum 129). The reduce first-present seed scan runs in the dirty-reduce test (seed found at index 0); its skip iteration is UNREACHABLE on the current `__hof_*` receiver set (vec/`$ObjVec` are dense in-range) — it exists for correctness-by-construction and no test can exercise it today. Stated plainly rather than implied covered.

## Byte-identity when the flag is clear (A/B vs main @`251df3b03`)

9 flag-clear programs (dense loop, typed r/w, dynamic HOF, map/filter/reduce, holes, strings, dynamic object props, defineProperty, forEach.call borrow) × 2 lanes (**standalone, gc**): **all 18 sha256 hashes identical** between main's compiler and this branch (file-copy swap method, never `git stash`). Host/gc output byte-identical by the same measurement. A CI-durable structural witness (flag-clear WAT contains no `__protoidx_` symbol) is in the committed test file.

## Scoped test262 A/B — standalone lane, +0 by design

Lane establishment (enforced, not asserted): every file ran through `runTest262File(file, category, timeout, "standalone")` — the runner's positional target argument. Under this target a module that emits ANY host import fails via `standaloneHostImportError` (#2961), so a `pass` is a genuinely host-free pass — the same lane the standalone floor / `host_free_pass` metrics measure.

Scope: all **1,605** files under `built-ins/Array/prototype/{forEach,map,filter,some,every,reduce,reduceRight}`.

| side | pass | fail | compile_error |
| --- | ---: | ---: | ---: |
| main @`251df3b03` | 879 | 721 | 5 |
| this branch | 879 | 721 | 5 |

**Individual pass→fail transitions: none. Individual fail→pass transitions: none. The two per-file result sets are byte-identical**, and the 5 compile_error rows exist identically on both sides (no new compile errors). The instrument is proven non-blind by the positive control above. See the sizing-correction section for why the yield sits behind the own-descriptor path.

## Not in this PR (deliberate)

- Typed-lane WRITES (#4159) — blocked on #3251 S2. Not touched.
- LengthOfArrayLike as a real `[[Get]]` (#4160 slice 3).
- `Object.defineProperties(proto, {...})` plural form; for-in enumeration of inherited proto indices; `$ObjVec` OOB consult — recorded boundaries in the module header + issue notes.

#4160 stays open (host half, slice 3, and the re-measure after the own-descriptor path lands). Gate grants (`loc-budget-allow`, `coercion-sites-allow`) are in the issue frontmatter with reasons.

## Independent verification (main session, before opening)

Checked against the pushed tip rather than taken on report:

- `tests/issue-4160-proto-index-store.test.ts` — **10/10 pass** on `8fdd1ae90`, and `tsc --noEmit` clean.
- **Positive control, run both ways**: with main's compiler files swapped into the worktree the acceptance suite fails 5 of 8; with the branch's files restored it is green. So the A/B harness demonstrably sees compiler changes.
- **The scoped `+0` is therefore a real result, not a blind instrument.** The two result JSONs are byte-identical (same md5, 0 rows differ, `{879 pass, 721 fail, 5 CE}` × 1,605 files); the 5 compile errors are present on BOTH sides.
- **Why zero**, confirmed directly: `protoIndexDirty` and `vecAccessorDescriptorDirty` both fire on the real `15.4.4.18-7-b-12` source, so the new arms are active — those tests fail earlier, on the own-accessor descriptor path. That is the sizing correction above, and it is a correction to the *issue's* estimate, not to this implementation.
- Six commits, all signed and all carrying the checklist sign-off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_