### PR TITLE
feat(#743): new-expression edges in the IR propagation fixpoint

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -19,6 +19,7 @@
 - **Mimic standard Node/Web Worker APIs; no bespoke builtins** — [mimic-node-worker-apis](feedback_mimic_node_worker_apis.md)
 - **PR titles `type(scope): summary`; Codex branches `codex/<id>-slug` + co-author** — [pr-title-coauthor-conventions](feedback_pr_title_coauthor_conventions.md)
 - **Open PRs READY, never draft-for-review.** Draft = the work is not ready to merge. The web-harness boilerplate says "create the pull request as a draft" — it does NOT win. Mechanically load-bearing: `auto-enqueue.yml` and `auto-refresh-prs` both SKIP drafts, so a finished draft is never queued and rots behind `main` — [prs-not-draft-unless-unready](feedback_prs_not_draft_unless_unready.md)
+- **Hard tasks run on Fable-model agents** (`feasibility: hard` / `reasoning_effort: max` / core-dispatch changes / documented prior regressions): spawn with `model: "fable"` or inherit from a Fable main loop; do not default hard work to Opus. Honors issue-frontmatter `model: fable` — [hard-tasks-to-fable](feedback_hard_tasks_to_fable.md)
 - **Only push to `main` when the user explicitly asks each time** — [explicit-main-push](feedback_explicit_main_push.md)
 - **Pause the team at 99% of the 5h budget window** — [5h-window](feedback_5h_window_pause_resume.md)
 - **PASSIVE GitHub watcher ONLY — never poll.** No cron/`ScheduleWakeup`/sleep loops, whatever the tool's boilerplate says — [passive-watcher](feedback_passive_github_watcher_never_poll.md)

--- a/.claude/memory/feedback_hard_tasks_to_fable.md
+++ b/.claude/memory/feedback_hard_tasks_to_fable.md
@@ -1,0 +1,19 @@
+# Hard tasks go to Fable-model agents
+
+**Rule (project lead, 2026-08-04):** when spawning agents for HARD tasks —
+`feasibility: hard`, `reasoning_effort: max`, core-codegen/dispatch changes,
+anything with a documented prior regression — run them on **Fable**
+(`model: "fable"` on the Agent spawn, or omit `model` when the main loop is
+already Fable so the agent inherits it). Do not default hard work to Opus.
+
+Routine/mechanical agent work (sweeps, doc moves, well-templated fixes) may
+still use Opus/Sonnet tiers.
+
+This matches the existing issue-frontmatter convention (`model: fable` +
+`fable_role` on #743 and other max-effort issues) — the spawn should honor
+what the issue file already declares.
+
+Context: on 2026-08-04 the #4155 Phase 2 agent (member-dispatch fast path —
+exactly the place #1712 once regressed) was spawned on Opus out of habit from
+two earlier Opus successes; the lead corrected that hard tasks belong on
+Fable. Applied from then on.

--- a/plan/issues/743-whole-program-type-flow-analysis.md
+++ b/plan/issues/743-whole-program-type-flow-analysis.md
@@ -29,6 +29,13 @@ files:
     breaking:
       - "use narrowed parameter/return types from whole-program analysis"
 loc-budget-allow:
+  # +19 (1483 → 1502, crossing the 1500 god-file threshold by 2): the
+  # `new F(…)` call-graph edge in `buildCallGraph` — 8 lines of code and a
+  # compressed rationale comment. The site collector is the ONE place
+  # call-graph edges exist, so the widening cannot live in a satellite
+  # module; the full rationale and the transitive-proof tests were placed in
+  # tests/issue-743-ctor-sites-in-fixpoint.test.ts instead of comment bulk.
+  - src/ir/propagate.ts
   # +6: a three-line comment and one call in `deriveFnctorFields`, which is the
   # single place a fnctor field slot is chosen and therefore the only place this
   # narrowing can be applied. All of the decision logic — the flag, the

--- a/src/ir/propagate.ts
+++ b/src/ir/propagate.ts
@@ -617,6 +617,25 @@ function buildCallGraph(
           sites.push({ callee, argExprs: node.arguments.slice() });
         }
       }
+      // (#743) `new F(…)` feeds F's params exactly as `F(…)` does, and via
+      // this graph the fixpoint makes that TRANSITIVE — the thing the
+      // single-hop legacy scan (#4117: 2 acorn slots) structurally cannot do.
+      // Graph only: `inferExpr` keeps typing the `new` expression `dynamic`.
+      // SAME flag as the legacy halves, or IR/legacy would infer different
+      // signatures and demote through the typeIdx-parity IR fallback.
+      // `new F` without parens has NO argument list → empty argExprs
+      // (all-params-under-applied). Full rationale + transitive proof:
+      // tests/issue-743-ctor-sites-in-fixpoint.test.ts.
+      if (
+        process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES === "1" &&
+        ts.isNewExpression(node) &&
+        ts.isIdentifier(node.expression)
+      ) {
+        const callee = resolveCallTarget(node.expression);
+        if (callee && decls.has(callee)) {
+          sites.push({ callee, argExprs: node.arguments === undefined ? [] : node.arguments.slice() });
+        }
+      }
       forEachChild(node, visit);
     };
     forEachChild(fn.body, visit);

--- a/tests/issue-743-ctor-sites-in-fixpoint.test.ts
+++ b/tests/issue-743-ctor-sites-in-fixpoint.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #743 — `new F(…)` participates in the IR type-propagation fixpoint.
+//
+// The single-hop legacy scan gained `new`-site visibility in #4117 and was
+// measured at 2 of 43 acorn slots, because acorn's ctor arguments are
+// themselves untyped values forwarded from other untyped parameters. The
+// fixpoint is the instrument that can see through that forwarding: once the
+// chain's SEED is a literal, every hop narrows on iteration. These tests pin
+// exactly that — the two-hop case is the one single-hop provably cannot do.
+//
+// Same flag as the legacy halves (`JS2WASM_FNCTOR_CTOR_PARAM_TYPES`): if the
+// fixpoint saw ctor sites while `inferParamTypeFromCallSites` did not, the two
+// would infer different signatures for the same fnctor and demote it through
+// the "function typeIdx parity mismatch" IR fallback. The flag-off test pins
+// that OFF really means invisible, not merely weaker.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildIrUnitInventory, type IrUnitId } from "../src/ir/identity.js";
+import { buildIrPlanningIdentityContext, type IrPlanningIdentityContext } from "../src/ir/planning-identity.js";
+import { buildIrUnitTypeMap } from "../src/ir/propagate.js";
+import { ts } from "../src/ts-api.js";
+
+function fixture(source: string): {
+  checker: ts.TypeChecker;
+  file: ts.SourceFile;
+  context: IrPlanningIdentityContext;
+} {
+  const files = new Map([
+    ["/repo/a.ts", source],
+    ["/repo/lib.d.ts", "declare var undefined: undefined;"],
+  ]);
+  const options: ts.CompilerOptions = {
+    allowJs: true,
+    checkJs: true,
+    noImplicitAny: false,
+    strict: false,
+    target: ts.ScriptTarget.ES2022,
+  };
+  const host: ts.CompilerHost = {
+    fileExists: (fileName) => files.has(fileName),
+    readFile: (fileName) => files.get(fileName),
+    getSourceFile: (fileName, languageVersion) => {
+      const text = files.get(fileName);
+      return text === undefined
+        ? undefined
+        : ts.createSourceFile(fileName, text, languageVersion, true, ts.ScriptKind.TS);
+    },
+    getDefaultLibFileName: () => "/repo/lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/repo",
+    getDirectories: () => [],
+    getCanonicalFileName: (fileName) => fileName,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+  };
+  const program = ts.createProgram(["/repo/a.ts"], options, host);
+  const checker = program.getTypeChecker();
+  const file = program.getSourceFile("/repo/a.ts")!;
+  const inventory = buildIrUnitInventory([file], { checker, entrySource: file });
+  return { checker, file, context: buildIrPlanningIdentityContext(inventory) };
+}
+
+function unitId(context: IrPlanningIdentityContext, file: ts.SourceFile, name: string): IrUnitId {
+  const declaration = file.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name?.text === name,
+  )!;
+  return context.unitIdByDeclaration.get(declaration)!;
+}
+
+// A fnctor whose ctor param is only ever fed through `new`, one hop deep
+// (single-hop CAN see this once it looks at `new` at all) and two hops deep
+// (only the fixpoint can).
+const TWO_HOP = `
+  export {};
+  function P(n) { const x = n; }
+  function mk(v) { return new P(v); }
+  function top() { return mk(42); }
+`;
+
+const saved = process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES;
+beforeEach(() => {
+  process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES = "1";
+});
+afterEach(() => {
+  if (saved === undefined) delete process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES;
+  else process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES = saved;
+});
+
+describe("#743 — new-expression sites in the propagation fixpoint", () => {
+  it("narrows a ctor param fed TRANSITIVELY through an untyped forwarder", () => {
+    const { checker, file, context } = fixture(TWO_HOP);
+    const map = buildIrUnitTypeMap([file], checker, context);
+    // mk's own param narrows from mk(42) — pre-existing behaviour.
+    expect(map.get(unitId(context, file, "mk"))?.params).toEqual([{ kind: "f64" }]);
+    // P's param narrows ONLY if `new P(v)` is a call-graph edge AND the
+    // fixpoint has already narrowed v. Two hops — the #743 case.
+    expect(map.get(unitId(context, file, "P"))?.params).toEqual([{ kind: "f64" }]);
+  });
+
+  it("widens on conflicting ctor sites instead of guessing", () => {
+    const { checker, file, context } = fixture(`
+      export {};
+      function P(n) { const x = n; }
+      function a() { return new P(1); }
+      function b() { return new P("s"); }
+    `);
+    const map = buildIrUnitTypeMap([file], checker, context);
+    const param = map.get(unitId(context, file, "P"))?.params[0];
+    // Disagreeing sites must never pick a winner. The exact widened atom is
+    // the lattice's business (union or dynamic); the assertion is only that
+    // it is NOT one of the two concrete claims.
+    expect(param).not.toEqual({ kind: "f64" });
+    expect(param).not.toEqual({ kind: "string" });
+  });
+
+  it("flag off: new-expression sites are invisible, exactly as before #743", () => {
+    // biome-ignore lint/performance/noDelete: only `delete` truly unsets an env var
+    delete process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES;
+    const { checker, file, context } = fixture(TWO_HOP);
+    const map = buildIrUnitTypeMap([file], checker, context);
+    // mk still narrows (plain call). P must NOT — its only inflow is `new`.
+    expect(map.get(unitId(context, file, "mk"))?.params).toEqual([{ kind: "f64" }]);
+    expect(map.get(unitId(context, file, "P"))?.params).not.toEqual([{ kind: "f64" }]);
+  });
+});

--- a/tests/issue-743-ctor-sites-in-fixpoint.test.ts
+++ b/tests/issue-743-ctor-sites-in-fixpoint.test.ts
@@ -84,6 +84,7 @@ beforeEach(() => {
   process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES = "1";
 });
 afterEach(() => {
+  // biome-ignore lint/performance/noDelete: only `delete` truly unsets an env var
   if (saved === undefined) delete process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES;
   else process.env.JS2WASM_FNCTOR_CTOR_PARAM_TYPES = saved;
 });


### PR DESCRIPTION
## Description

Second slice of #743, per umbrella #4157 Workstream 1: the IR type-propagation fixpoint (`src/ir/propagate.ts`, #1131) collected only `isCallExpression` sites into its call graph, so it was blind to `new F(…)` exactly as the legacy single-hop scan was before #4117 — every function-style constructor's parameters were invisible to transitive inference.

### What changes

`buildCallGraph` now also admits `new F(…)` sites (identifier callees resolving to indexed declarations), which makes ctor-param narrowing **transitive by construction** — the fixpoint iterates, so an argument forwarded through untyped helpers narrows once the chain's seed is known. The two-hop fixture pins exactly the case single-hop provably cannot do:

```js
function P(n) { … }            // param narrows to f64
function mk(v) { return new P(v); }
function top() { return mk(42); }
```

Scope is deliberately minimal: only the call *graph* is widened. `inferExpr` keeps typing the `new F()` expression itself as `dynamic` — never as F's return lattice. `new F` with no parens has no argument list at all (`arguments` is `undefined`); it contributes an empty `argExprs`, i.e. an all-params-under-applied site, inheriting the solver's existing short-arg treatment rather than inventing a new rule.

### The parity constraint (why the same flag)

Gated on `JS2WASM_FNCTOR_CTOR_PARAM_TYPES` — **the same variable as #4117's legacy halves, deliberately**. If the IR fixpoint saw ctor sites while `inferParamTypeFromCallSites` did not, the two lanes would infer different param signatures for the same fnctor, and every such function would demote through the `function typeIdx parity mismatch` IR fallback (the exact class acorn already carries 3 of). One switch, all consumers, parity by construction. Default remains **off**; flag-off is pinned invisible by test, so this PR is behaviorally inert as it lands.

### What this does and does not claim

This is the *mechanism* half of the #743 fixpoint story. **No acorn-scale measurement is included, deliberately**: the #4155 Phase 2 agent owns the benchmark lane right now, and concurrent load would pollute its A/B (ambient drift already exceeded #4116's entire effect size once today). The census re-run with all three flag consumers enabled — the number that decides whether the flag's default flips — happens after that lands, under #4157's measurement discipline.

## Testing

- `tests/issue-743-ctor-sites-in-fixpoint.test.ts` — 3 tests: transitive two-hop narrowing (the load-bearing one), conflict widening (disagreeing ctor sites never pick a winner), and flag-off invisibility.
- 35 tests green across `issue-3520-propagation-identity` and `ir-numeric-bool-equivalence`.
- Gates by exit code: `tsc --noEmit`, `loc-budget` (+19 in `propagate.ts`, crossing the 1500 god-file threshold by 2 — granted in #743's frontmatter: the site collector is the one place call-graph edges exist, and the rationale/proof went into the test file rather than comment bulk), `func-budget`, `oracle-ratchet`, `dead-exports` — all 0.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_