### PR TITLE
fix(#2875): wire borrowed String.prototype.slice in standalone (+4 measured)

### DIFF
--- a/plan/issues/2875-standalone-string-prototype-cluster.md
+++ b/plan/issues/2875-standalone-string-prototype-cluster.md
@@ -391,3 +391,69 @@ out-of-range `=== undefined` return-value comparison (a separate return-path
 undefined-singleton mismatch), the case family (`toUpperCase`/`toLowerCase`,
 un-wired), the RegExp-arg family (~114), and the #2862 ToPrimitive
 object-receiver bucket.
+
+## Slice C (LANDED, lead-es5, 2026-08-06) — borrowed `String.prototype.slice`
+
+`emitStringProtoMemberBody` wired `substring` to a real reflective body but let
+`slice` fall through to `emitProtoMemberBodyRefusal`, so
+`x.slice = String.prototype.slice; x.slice(0, 1)` threw *"String.prototype.slice
+is not yet implemented in --target standalone"*.
+
+The two methods differ only in §22.1.3.22-vs-§22.1.3.24 index resolution
+(`slice` resolves negative indices; `substring` swaps reversed bounds), and that
+difference lives entirely inside the native helper: `__str_slice` and
+`__str_substring` share the signature `(ref $NativeString, i32 start, i32 end)
+-> ref $NativeString` **and** the same `0x7fffffff` absent-end sentinel — the
+two direct paths in `string-ops.ts` already emit the same call sequence with
+only the helper name differing. So `emitStringSubstringMemberBody` is now
+parameterised on `"substring" | "slice"` and swaps the helper; nothing else
+changed.
+
+**Measured** — scoped standalone test262, `built-ins/String/prototype/slice`:
+**29/38 → 33/38, +4**, no regressions in that path. Covered by
+`tests/issue-2875-borrowed-string-slice.test.ts` (7 cases, including the two
+that prove the helper swap actually happened: negative indices resolve from the
+end, and reversed bounds give `""` rather than substring's swap; plus a
+substring-unaffected guard).
+
+Harvested from fork PR #4124's `#3978` slice, re-derived against current main.
+**Most of that PR's String work is already on main** — its census claimed +29
+across the case-conversion family, `indexOf`, `charCodeAt` and `substring`, and
+all of those now pass on main by other routes. `slice` was the only part still
+outstanding. Do not re-harvest #3978 expecting its headline number.
+
+## Next slice — primitive-number and builtin-brand receivers return `null`
+
+Found while measuring slice C; **not fixed**. Probed on main + slice C
+(literal-JS `allowJs` lane, `--target standalone`), each returning a
+discriminator rather than a boolean:
+
+| receiver shape | result |
+| --- | --- |
+| `new Object(true).toUpperCase = String.prototype.toUpperCase` | **correct** |
+| `"AB".toLowerCase()` direct | **correct** |
+| `Number.prototype.toLowerCase = String.prototype.toLowerCase; NaN.toLowerCase()` | `null` |
+| same, `(123).toLowerCase()` | `null` |
+| same, `new Number(123).toLowerCase()` | `null` |
+| `var r = new RegExp("abc"); r.toUpperCase = String.prototype.toUpperCase; r.toUpperCase()` | `null` |
+| controls `String(NaN)`, `"" + NaN` | **correct** |
+
+`null` is `emitProtoMemberBodyRefusal`'s "not wired — fall through" signal, so
+these calls are **not reaching the reflective body at all**. Since a plain
+`new Object(...)` receiver works, the gap is not "borrowed methods" generally —
+it is member-call dispatch when the borrowed method is installed on a **builtin
+prototype** (`Number.prototype`) or a **builtin-branded instance** (a RegExp
+object), and/or when the receiver is a **primitive** number. That points at the
+transferred-closure dispatch arms rather than at ToString.
+
+Worth roughly **12–17 ES5-label standalone files** in the 2026-08-06 baseline:
+the `Number.prototype.<caseMethod>` × `{NaN, Infinity, -Infinity}` matrix (~12),
+the `new RegExp(...)` receiver family (~5), and two `eval("\"bj\"")`-produced
+string cases. Verify by repro before sizing — the L6 census that produced these
+counts is signature-derived.
+
+**Out of scope for this issue** (measured 2026-08-06, `ES5` label, standalone,
+`built-ins/String/prototype` = 109 failures): `split` 11 + `replace`/`match`
+RegExp-gated ~16 belong to the standalone RegExp engine (#4016/#4065 — #4065
+already refuted the "51-file RegExp lever inside String.prototype" framing);
+`concat` (4) is variadic and needs a different closure ABI.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -828,6 +828,13 @@ function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, m
 
   const IN_SCOPE = new Set(["at", "charCodeAt", "codePointAt"]);
   if (member === "substring") return emitStringSubstringMemberBody(ctx, fctx);
+  // (#2875 slice C) `slice` (§22.1.3.22) shares `substring`'s closure ABI —
+  // `this`/start/end, same `0x7fffffff` absent-end sentinel — and `__str_slice`
+  // has the identical helper signature, differing only in resolving negative
+  // indices rather than swapping reversed bounds. Without this it fell through
+  // to `emitProtoMemberBodyRefusal`, so a borrowed `slice` threw
+  // "not yet implemented in --target standalone".
+  if (member === "slice") return emitStringSubstringMemberBody(ctx, fctx, "slice");
   // (#2875 slice 3a) The number-returning search family — `indexOf` /
   // `lastIndexOf` — has a DIFFERENT closure ABI from the index accessors
   // (param 2 is the search STRING, not an integer position; the optional

--- a/src/codegen/string-proto-substring.ts
+++ b/src/codegen/string-proto-substring.ts
@@ -18,14 +18,14 @@ import { ensureObjectRuntime } from "./object-runtime.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { flushLateImportShifts } from "./shared.js";
 
-function emitRefusal(ctx: CodegenContext, fctx: FunctionContext): null {
-  emitThrowTypeError(ctx, fctx, "String.prototype.substring is not yet implemented in --target standalone");
+function emitRefusal(ctx: CodegenContext, fctx: FunctionContext, member: string): null {
+  emitThrowTypeError(ctx, fctx, `String.prototype.${member} is not yet implemented in --target standalone`);
   return null;
 }
 
-function emitRequireObjectCoercible(ctx: CodegenContext, fctx: FunctionContext): void {
+function emitRequireObjectCoercible(ctx: CodegenContext, fctx: FunctionContext, member: string): void {
   const rocThrow: Instr[] = [];
-  emitBrandCheckTypeError(ctx, rocThrow, "String.prototype.substring called on null or undefined");
+  emitBrandCheckTypeError(ctx, rocThrow, `String.prototype.${member} called on null or undefined`);
   fctx.body.push({ op: "local.get", index: 1 }, { op: "ref.is_null" });
   const isUndefIdx = undefinedSingletonActive(ctx) ? ctx.funcMap.get("__extern_is_undefined") : undefined;
   if (isUndefIdx !== undefined) {
@@ -48,12 +48,24 @@ function unboxBoundToI32(ctx: CodegenContext, fctx: FunctionContext, paramIdx: n
 }
 
 /**
- * Native body for a reflective `String.prototype.substring` closure.
+ * Native body for a reflective `String.prototype.{substring,slice}` closure.
  * Closure ABI: `this` = param 1, start = param 2, end = param 3. The body
  * preserves receiver/bound coercion order and delegates clamping plus swapped
  * bounds to the existing native substring core.
+ *
+ * `slice` shares this body: `__str_slice` has the IDENTICAL
+ * `(ref $NativeString, i32 start, i32 end) -> ref $NativeString` shape and the
+ * same `0x7fffffff` "absent end" sentinel as `__str_substring` — it only
+ * resolves negative indices instead of swapping reversed bounds, which is
+ * exactly the §22.1.3.22-vs-§22.1.3.24 difference. Both direct paths in
+ * `string-ops.ts` already emit the same call sequence with only the helper
+ * name differing, so the reflective closure can do the same.
  */
-export function emitStringSubstringMemberBody(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
+export function emitStringSubstringMemberBody(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  member: "substring" | "slice" = "substring",
+): ValType | null {
   ensureNativeStringHelpers(ctx);
   ensureObjectRuntime(ctx);
   if (undefinedSingletonActive(ctx)) flushLateImportShifts(ctx, fctx);
@@ -65,12 +77,12 @@ export function emitStringSubstringMemberBody(ctx: CodegenContext, fctx: Functio
   const anyToStrIdx = ensureAnyToStringHelper(ctx);
   const toPrimitiveIdx = getToPrimitiveProvider(ctx);
   const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
-  const substringIdx = ctx.nativeStrHelpers.get("__str_substring");
+  const substringIdx = ctx.nativeStrHelpers.get(member === "slice" ? "__str_slice" : "__str_substring");
   if (toPrimitiveIdx === undefined || flattenIdx === undefined || substringIdx === undefined) {
-    return emitRefusal(ctx, fctx);
+    return emitRefusal(ctx, fctx, member);
   }
 
-  emitRequireObjectCoercible(ctx, fctx);
+  emitRequireObjectCoercible(ctx, fctx, member);
 
   // The abstract ToString operation rejects Symbols, unlike the printable
   // fallback intentionally provided by __any_to_string.
@@ -94,7 +106,7 @@ export function emitStringSubstringMemberBody(ctx: CodegenContext, fctx: Functio
     { op: "call", funcIdx: anyToStrIdx },
     { op: "call", funcIdx: flattenIdx },
   );
-  const flatLocal = allocLocal(fctx, `__str_pm_substring_${fctx.locals.length}`, flatStringType(ctx));
+  const flatLocal = allocLocal(fctx, `__str_pm_${member}_${fctx.locals.length}`, flatStringType(ctx));
   fctx.body.push({ op: "local.set", index: flatLocal });
 
   const startLocal = unboxBoundToI32(ctx, fctx, 2);

--- a/tests/issue-2875-borrowed-string-slice.test.ts
+++ b/tests/issue-2875-borrowed-string-slice.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2875 slice C — borrowed `String.prototype.slice` on a non-string receiver.
+//
+// `emitStringProtoMemberBody` wired `substring` to a real reflective body but
+// left `slice` to fall through to `emitProtoMemberBodyRefusal`, so
+// `x.slice = String.prototype.slice; x.slice(0, 1)` threw
+// "String.prototype.slice is not yet implemented in --target standalone".
+//
+// The two differ only in §22.1.3.22-vs-§22.1.3.24 index resolution (slice
+// resolves negative indices; substring swaps reversed bounds), and that
+// difference lives entirely inside the native helper: `__str_slice` and
+// `__str_substring` share the signature
+// `(ref $NativeString, i32 start, i32 end) -> ref $NativeString` and the same
+// `0x7fffffff` absent-end sentinel. So `slice` reuses the substring body with
+// the helper swapped.
+//
+// Compile through the SAME lane the test262 standalone runner uses — literal
+// JavaScript with `allowJs`. A `.ts` probe does NOT reproduce this: an
+// annotated receiver takes a different, statically-typed member-call route.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, {
+    target: "standalone",
+    allowJs: true,
+    fileName: "test.js",
+    skipSemanticDiagnostics: true,
+  });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect(r.imports ?? []).toEqual([]); // host-free
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2875 slice C — borrowed String.prototype.slice (standalone)", () => {
+  // The exact shape of test262 built-ins/String/prototype/slice/S15.5.4.13_A1_T1.
+  it("new Object(true).slice(false, true) === 't'", async () => {
+    expect(
+      await runStandalone(
+        `export function test() {
+           var x = new Object(true);
+           x.slice = String.prototype.slice;
+           return x.slice(false, true) === "t" ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("value-erased .call('abcde', 1, 3) === 'bc'", async () => {
+    expect(
+      await runStandalone(
+        `export function test() {
+           var f = String.prototype.slice;
+           return f.call("abcde", 1, 3) === "bc" ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  // The behaviour that makes slice NOT substring: a negative index counts back
+  // from the end instead of clamping to 0. If this passed while the previous
+  // case also passed, the helper swap would be unproven.
+  it("negative indices resolve from the end — .call('abcde', -3, -1) === 'cd'", async () => {
+    expect(
+      await runStandalone(
+        `export function test() {
+           var f = String.prototype.slice;
+           return f.call("abcde", -3, -1) === "cd" ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  // Reversed bounds must yield "" (slice), NOT the swapped substring result.
+  it("reversed bounds give '' rather than substring's swap", async () => {
+    expect(
+      await runStandalone(
+        `export function test() {
+           var f = String.prototype.slice;
+           return f.call("abcde", 3, 1) === "" ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("absent end runs to the end — .call('abcde', 2) === 'cde'", async () => {
+    expect(
+      await runStandalone(
+        `export function test() {
+           var f = String.prototype.slice;
+           return f.call("abcde", 2) === "cde" ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("RequireObjectCoercible: .call(null) throws a catchable TypeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test() {
+           try { String.prototype.slice.call(null, 0, 1); return 0; }
+           catch (e) { return (e instanceof TypeError) ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  // Guard the sibling: routing slice through the shared body must not change
+  // substring's swap behaviour.
+  it("substring is unaffected — .call('abcde', 3, 1) still swaps to 'bc'", async () => {
+    expect(
+      await runStandalone(
+        `export function test() {
+           var f = String.prototype.substring;
+           return f.call("abcde", 3, 1) === "bc" ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

`emitStringProtoMemberBody` wired `substring` to a real reflective body but let `slice` fall through to `emitProtoMemberBodyRefusal`, so a borrowed `slice` threw *"String.prototype.slice is not yet implemented in --target standalone"*:

```js
var x = new Object(true);
x.slice = String.prototype.slice;
x.slice(false, true);   // → TypeError instead of "t"
```

That is test262 `built-ins/String/prototype/slice/S15.5.4.13_A1_T1.js` verbatim.

## Why the fix is this small

`slice` and `substring` differ only in negative-index resolution (§22.1.3.22) vs reversed-bound swapping (§22.1.3.24), and that difference lives entirely inside the native helper. `__str_slice` and `__str_substring` share the signature `(ref $NativeString, i32 start, i32 end) -> ref $NativeString` **and** the same `0x7fffffff` absent-end sentinel — the two direct paths in `string-ops.ts` already emit the same call sequence with only the helper name differing.

So `emitStringSubstringMemberBody` is parameterised on `"substring" | "slice"` and swaps the helper; the refusal and RequireObjectCoercible messages take the member name. No other behaviour changed.

## Measured

Scoped standalone test262, `built-ins/String/prototype/slice`: **29/38 → 33/38, +4**, no regressions in that path. (Baseline read from `test262-standalone-current.jsonl` fetched 2026-08-06; after-number from a local scoped run, `TEST262_TARGET=standalone`.)

`tests/issue-2875-borrowed-string-slice.test.ts` — 7 cases, all green. Two of them exist specifically to prove the helper swap actually happened rather than `slice` quietly aliasing `substring`: negative indices resolve from the end (`slice("abcde", -3, -1) === "cd"`), and reversed bounds give `""` rather than substring's swap. A seventh guards that `substring` itself is unaffected.

Both budget gates pass (`array-object-proto.ts` growth is already granted by #2875's `loc-budget-allow`).

## Provenance, and a stale number worth flagging

Harvested from fork PR #4124's `#3978` slice, re-derived against current `main`.

**Most of that PR's String work is already on main.** Its census claimed +29 across the case-conversion family, `indexOf`, `charCodeAt` and `substring` — I probed all of them on current `main` and they pass today by other routes. `slice` was the only part still outstanding. Anyone reaching for #4124's String slice later should not expect its headline number.

## Recorded but NOT fixed here

While measuring, a distinct gap surfaced and is written up in #2875 with its probe table. A borrowed method installed on a **builtin prototype** (`Number.prototype`) or a **builtin-branded instance** (a RegExp object), or invoked on a **primitive** number, returns `null` — the not-wired fall-through signal — so it never reaches the reflective body at all. A plain `new Object(...)` receiver works, which is what makes this narrower than "borrowed methods are broken" and points at the transferred-closure dispatch arms rather than at ToString.

Worth roughly 12–17 ES5-label standalone files. Left for the next slice deliberately: it is a dispatch change, not a helper swap, and does not belong in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_