### PR TITLE
feat(#4155): Phase 2 — typed fnctor field reads, flag-gated; measured null on acorn

### DIFF
--- a/plan/issues/4155-fnctor-instance-type-discarded-to-externref.md
+++ b/plan/issues/4155-fnctor-instance-type-discarded-to-externref.md
@@ -4,7 +4,7 @@ title: "why acorn's types cannot be inferred: 96.6% of `this.<field>` reads are 
 status: ready
 sprint: current
 created: 2026-08-02
-updated: 2026-08-04
+updated: 2026-08-06
 priority: high
 horizon: xl
 feasibility: hard
@@ -42,6 +42,20 @@ loc-budget-allow:
   # logic (flag, standalone check, gate-approval check, reserved-index lookup)
   # is in the new `fnctor-typed-instances.ts` module.
   - src/codegen/index.ts
+  # Phase 2 wiring (2026-08-06): all decision + emission logic lives in the new
+  # `fnctor-typed-reads.ts` module; the god-files get only the hook calls, and
+  # the hooks can live nowhere else — the admission is on the receiver's
+  # COMPILED ValType, so each call must sit at the exact point where the
+  # dynamic path is about to erase that type to externref:
+  # +11: `finalizeStructAndDynamicMemberGet`'s isExternObj arm (import + one
+  # try-call between the receiver compile and `extern.convert_any`).
+  - src/codegen/property-access-dispatch.ts
+  # +9: `tryEmitPinnedStructMemberGet`, before `reserveMemberGetDispatch`
+  # (import + one try-call).
+  - src/codegen/property-access.ts
+  # +20: `compilePropertyAssignmentExternSet` write twin (import + one guarded
+  # try-call; the guard keeps `forceRuntimeSet`/runtime-eval routes dynamic).
+  - src/codegen/expressions/assignment.ts
 func-budget-allow:
   # +1 line in `resolveWasmType` (354 > 353). Same two-line hook as the LOC
   # grant above: the #1712 `return { kind: "externref" }` becomes
@@ -51,6 +65,11 @@ func-budget-allow:
   # doing it under a flag-gated behavior change would make both harder to
   # review. All decision logic lives in `fnctor-typed-instances.ts`.
   - src/codegen/index.ts::resolveWasmType
+  # +10 (Phase 2): the read hook in the isExternObj arm — see the
+  # `property-access-dispatch.ts` LOC grant above. The arm is inside this one
+  # (already-oversized, #3399) function; splitting it is a separate refactor
+  # that should not ride along with a flag-gated behavior change.
+  - src/codegen/property-access-dispatch.ts::finalizeStructAndDynamicMemberGet
 ---
 
 # #4155 — the type is known and thrown away
@@ -576,6 +595,101 @@ parks, attribution is unambiguous — and the reason
    claim that instance typing works.
 3. **Phase 3/4 as written**, with the census's `discarded` bucket measured on
    real acorn rather than a fixture.
+
+## 2026-08-06 — Phase 2 implemented (typed fnctor field reads), census-first
+
+**Verdict: coverage is real but small (78 sites) and the A/B is a wash →
+`JS2WASM_FNCTOR_TYPED_READS` stays OFF by default.** The lever is
+representation-correct and fully wired/tested; it just does not move the acorn
+benchmark, because the sites it converts are not where the time goes.
+
+### What landed
+
+`src/codegen/fnctor-typed-reads.ts` (written at the 90b26f5ef checkpoint) is
+now wired at three call sites, all admission-after-receiver-compile, all
+flag-gated, all census-instrumented independently of the flag
+(`JS2WASM_FNCTOR_TYPED_READS_DEBUG=1`):
+
+- read: `finalizeStructAndDynamicMemberGet`'s `isExternObj` arm
+  (`property-access-dispatch.ts`), between the receiver compile and the
+  `extern.convert_any` erase;
+- read: `tryEmitPinnedStructMemberGet` (`property-access.ts`), before
+  `reserveMemberGetDispatch`;
+- write: `compilePropertyAssignmentExternSet` (`expressions/assignment.ts`),
+  gated on `!forceRuntimeSet && !wrapRuntimeEvalCallable` so the
+  accessor-descriptor and runtime-eval routes stay dynamic.
+
+Flag-off byte-identity was asserted, not assumed: unoptimized standalone acorn
+sha256 `e820698f…baa8` (1,578,609 B) identical between the wired tree
+(flag off) and the unwired checkpoint.
+
+### Census (standalone acorn 8.16.0, flag-independent)
+
+74 candidate gets + 4 sets. Every one is a SECOND-HOP access through a
+Phase-1-typed slot — the predecessor's hypothesis, confirmed:
+
+| site | count | field slot |
+| --- | --- | --- |
+| get `TokenType.keyword` | 40 | externref |
+| get `TokenType.binop` | 8 | externref |
+| get `SourceLocation.start` | 8 | f64 |
+| get `TokenType.isLoop`/`prefix`/`postfix`/`startsExpr` | 4 each | i32 |
+| get `TokenType.isAssign` | 2 | i32 |
+| set `RegExpValidationState.switchN` | 4 | i32 |
+
+Declines are exclusively `nofield:__fnctor_Parser.*` (ctor-unseeded flags like
+`inAsync`, `canAwait` — correctly refused; #743 territory). The counts are all
+even (each site visited twice by the dual/speculative compile), so ~39 distinct
+emission sites. First-hop receivers (`this.options.*`, 95 sites) remain
+#2937-externref and never reach the hook — the receiver-representation story
+from the checkpoint's WAT sampling stands.
+
+### Why the reads reach the dynamic path at all (fixture recipe)
+
+The checker cannot bind `this` in acorn's `var pp = Parser.prototype;
+pp.m = function () { … this.type.keyword … }` idiom, so the read compiles down
+the DYNAMIC member path — but codegen's typed-this twin still compiles the
+receiver (`this.type`) to `(ref null $__fnctor_TokenType)`. That mismatch
+(static any / compiled struct) is exactly what the fast path consumes.
+`tests/issue-4155-phase2-typed-reads.test.ts` reproduces it in six behaviors:
+fast-path read (WAT drops `__get_member_*`, mutation-checked against flag-off),
+write twin (assignment evaluates to RHS), member call stays dynamic,
+ctor-unseeded property stays dynamic, presence-tracked/conditional field still
+answers undefined, null receiver still throws the catchable TypeError.
+
+### A/B (`benchmark:acorn:standalone-dynamic`, 3 pairs back-to-back, same container)
+
+| run | flag OFF ratio (std) | flag ON ratio (std) |
+| --- | --- | --- |
+| 1 | 0.1142 (±0.026) | 0.1107 (±0.023) |
+| 2 | 0.1141 (±0.024) | 0.1185 (±0.041) |
+| 3 | 0.1251 (±0.027) | 0.1175 (±0.014) |
+| mean | **0.1178** | **0.1156** |
+
+Statistically indistinguishable (mean delta −1.9%, per-run std ±12–35%).
+Dogfood canaries flag-on: unchanged (2, 3, 4, 5), `functionImports: []`,
+errors exactly the 3 pre-existing IR-FALLBACKs. Optimized binary 866,718 →
+867,182 B (+464 B, +0.05%) — the per-site null guards, no dispatcher bodies
+saved because other props still reserve them.
+
+Suites flag-on, all green: the 4 × #2660 fnctor suites + Phase 0 shape
+regression (54), `issue-4123` + 17 object/struct/proto/super/private
+equivalence files (110), plus the 6 new Phase 2 tests.
+
+### Default decision and the successor lever
+
+Per this module's own rule — the default is set by measurement — a wash does
+not justify ON: it buys no measured perf, costs +464 B, and adds
+standalone-test262 exposure that only the `merge_group` can validate. The flag
+stays available as a one-variable enable for future coverage growth.
+
+The reason coverage is small is upstream of this hook: at most member sites the
+receiver has ALREADY been erased to externref (locals, params, `this.options.*`)
+before any read is compiled, so the admission — correctly — never sees a struct
+type. The next lever is retyping those BINDINGS (#2660 S3b territory: locals /
+params / return slots carrying `(ref null $__fnctor_F)` instead of externref),
+which would multiply the sites this already-wired fast path converts. Phase 2's
+hook then becomes the consumer that makes binding retype pay.
 
 ## Scope
 

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -36,6 +36,7 @@ import { buildDestructureNullThrow, patternIteratorStepCount } from "../destruct
 import { resolveComputedKeyExpression } from "../literals.js";
 import { resolveReceiverStruct } from "../fnctor-escape-gate.js"; // (#2681/#2686 A3) pinned-struct write dispatch
 import { presenceSetInstrs, presenceSlotOf } from "../fnctor-presence-bits.js"; // (#3780) packed own-presence flags
+import { tryEmitFnctorTypedFieldSet } from "../fnctor-typed-reads.js"; // (#4155 Phase 2) struct-typed fnctor receiver
 import { tryEmitTypedThisFieldSet } from "../typed-this.js"; // (#3683 S2) typed-`this` field write
 import { reserveMemberSetDispatch } from "../member-set-dispatch.js"; // (#2681/#2686 A3) pre-check set dispatcher
 import { reserveMemberGetDispatch } from "../member-get-dispatch.js"; // (#2681/#2686) symmetric struct read for compound
@@ -3933,6 +3934,25 @@ function compilePropertyAssignmentExternSet(
   // Compile object expression and convert to externref
   const objResult = compileExpression(ctx, fctx, target.expression);
   if (!objResult) return null;
+  // (#4155 Phase 2) Struct-typed receiver + own mutable data slot → one
+  // `struct.set` instead of the externref hop + `__extern_set` ladder. Never
+  // when a runtime accessor descriptor forced this path (`forceRuntimeSet`) or
+  // the runtime-eval callable wrap is needed — those must stay dynamic.
+  // Flag-gated (declines are byte-identical); flag-independent census under
+  // JS2WASM_FNCTOR_TYPED_READS_DEBUG.
+  if (!forceRuntimeSet && !wrapRuntimeEvalCallable) {
+    const fnctorTypedSet = tryEmitFnctorTypedFieldSet(
+      ctx,
+      fctx,
+      target,
+      propName,
+      objResult,
+      value,
+      () => typeErrorThrowInstrs(ctx, target),
+      (valType) => ensureI32Condition(fctx, valType, ctx),
+    );
+    if (fnctorTypedSet !== undefined) return fnctorTypedSet;
+  }
   if (objResult.kind === "externref") {
     // already externref
   } else if (objResult.kind === "ref" || objResult.kind === "ref_null") {

--- a/src/codegen/fnctor-typed-reads.ts
+++ b/src/codegen/fnctor-typed-reads.ts
@@ -1,0 +1,360 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4155 Phase 2) Direct `struct.get` / `struct.set` for a DATA FIELD read or
+ * written through a receiver whose COMPILED ValType is already a
+ * `$__fnctor_<Name>` struct reference.
+ *
+ * ## What this is, and what it is not
+ *
+ * Phase 1 (`fnctor-typed-instances.ts`) made a fnctor instance TYPE resolve to
+ * its reserved struct instead of `externref`. That changed which slot the value
+ * lands in; it did NOT change how the value is READ. Every dynamic member path
+ * still begins by boxing whatever the receiver compiled to:
+ *
+ *     const objExprType = compileExpression(ctx, fctx, expr.expression);
+ *     if (objExprType.kind === "ref" || objExprType.kind === "ref_null")
+ *       fctx.body.push({ op: "extern.convert_any" });     // ← the type is gone
+ *     … null-check … call $__get_member_<name> … unbox …
+ *
+ * — `property-access-dispatch.ts` (read) and
+ * `expressions/assignment.ts` (write). So a receiver the compiler had in a
+ * typed register was re-erased one instruction later and the field was fetched
+ * through a `ref.test` ladder. This module is the missing consumer: given the
+ * receiver ValType the caller ALREADY has in hand, it answers "this is a plain
+ * data slot of that exact struct" and the caller emits one `struct.get`.
+ *
+ * This is the #3753 S1c lesson applied to instance types — *"promoting the slot
+ * alone moved nothing because the READ never consulted it."*
+ *
+ * ## Why no prediction, no speculation, no guard
+ *
+ * The admission decision is made AFTER the receiver is compiled, from the
+ * ValType `compileExpression` returned. So:
+ *
+ *   - there is no static predictor that can be wrong (contrast #3685's
+ *     receiver-flow verdict, which needs a `ref.test` because it is an
+ *     inference);
+ *   - the receiver is evaluated exactly once, by the caller, in the order it
+ *     already was;
+ *   - a decline costs nothing — the caller falls through to the byte-identical
+ *     pre-#4155-Phase-2 boxing sequence.
+ *
+ * The emitted `struct.get` is the arm `fillMemberGetDispatch` would have
+ * selected: the dispatcher tests candidates with `ref.test` and our receiver's
+ * static type IS the candidate, so the same slot is loaded — minus the box, the
+ * call, the ladder and the unbox.
+ *
+ * ## A member CALL is NEVER static off the struct type
+ *
+ * This is the rule that killed the #1712 attempt and it is enforced here twice:
+ * only names that are DECLARED DATA FIELDS of the struct are admitted (methods
+ * live on the per-fnctor prototype `$Object`, #2660 S2, and are never fields),
+ * and a property access that is syntactically the callee of a call expression
+ * is refused outright even if the name does resolve to a field. Method dispatch
+ * keeps its existing dynamic lowering, unchanged, in every case.
+ *
+ * ## Carve-outs (identical to #3683 S2 / #3685 S2 — they are semantic)
+ *
+ *   1. **presence-tracked fields** (#2847): the dispatcher answers `undefined`
+ *      for an unset slot, which a bare `struct.get` cannot express.
+ *   2. **accessor names** on that struct: a getter/setter must keep winning
+ *      over the slot.
+ *   3. **reserved names** (`length`/`constructor`/`__proto__`/`prototype`/
+ *      `name`) and call-signature-typed accesses, which the dynamic paths
+ *      themselves refuse.
+ *   4. **optional chaining / private identifiers** — separate lowerings.
+ *
+ * ## Null discipline
+ *
+ * A `ref_null` receiver reproduces the null behaviour of the site it replaces
+ * (throw a catchable TypeError, never a raw `struct.get` trap — a Wasm trap is
+ * not catchable by Wasm EH, #789). `ref` receivers cannot be null and skip it.
+ *
+ * ## Flag
+ *
+ * `JS2WASM_FNCTOR_TYPED_READS` — see {@link fnctorTypedReadsEnabled} for the
+ * measured default and the evidence behind it.
+ */
+import { ts } from "../ts-api.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { Instr, ValType } from "../ir/types.js";
+import { allocLocal } from "./context/locals.js";
+// `shared.js` holds the late-bound engine delegates precisely so a feature
+// module can reach the expression/coercion engines without a cycle back through
+// property-access.ts / index.ts.
+import { coerceType, compileExpression } from "./shared.js";
+
+/**
+ * Names with dedicated lowerings (array length, proto walk, constructor
+ * identity, function name). Mirrors `RESERVED_PROPS` in `typed-this.ts` and the
+ * identical carve-out in `tryEmitPinnedStructMemberGet`, so this path never
+ * claims an access the dynamic paths would have refused.
+ */
+const RESERVED_PROPS: ReadonlySet<string> = new Set(["length", "constructor", "__proto__", "prototype", "name"]);
+
+/**
+ * OFF by default. `JS2WASM_FNCTOR_TYPED_READS=1` enables the direct
+ * `struct.get`/`struct.set` lowering for a struct-typed fnctor receiver.
+ *
+ * The default is set by measurement, not by preference — see the #4155
+ * "Phase 2" section for the `standaloneDynamic` A/B, the census counts and the
+ * binary sizes that chose it. The switch stays either way: standalone test262
+ * only runs in the `merge_group` re-validation, so a one-variable revert has to
+ * remain available without a code change.
+ */
+export function fnctorTypedReadsEnabled(): boolean {
+  return process.env.JS2WASM_FNCTOR_TYPED_READS === "1";
+}
+
+/**
+ * `JS2WASM_FNCTOR_TYPED_READS_DEBUG=1` — per-compile tallies of what the
+ * admission gates did, printed at process exit.
+ *
+ * Deliberately independent of {@link fnctorTypedReadsEnabled}: the census
+ * counts CANDIDATES, so one compile with the flag off reports exactly how many
+ * sites the flag would convert. That is the measurement this phase exists to
+ * produce, and it must be obtainable without changing the artifact being
+ * measured.
+ */
+export const fnctorTypedReadStats = {
+  gets: 0,
+  sets: 0,
+  declines: new Map<string, number>(),
+  sites: new Map<string, number>(),
+};
+let statsHookInstalled = false;
+function censusEnabled(): boolean {
+  return process.env.JS2WASM_FNCTOR_TYPED_READS_DEBUG === "1";
+}
+function note(bucket: Map<string, number>, key: string): void {
+  if (!censusEnabled()) return;
+  if (!statsHookInstalled) {
+    statsHookInstalled = true;
+    process.on("exit", () => {
+      const top = (m: Map<string, number>, n: number): string =>
+        [...m.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, n)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(" ");
+      process.stderr.write(
+        `[fnctor-typed-reads] gets=${fnctorTypedReadStats.gets} sets=${fnctorTypedReadStats.sets}\n` +
+          `[fnctor-typed-reads] sites: ${top(fnctorTypedReadStats.sites, 40)}\n` +
+          `[fnctor-typed-reads] declines: ${top(fnctorTypedReadStats.declines, 30)}\n`,
+      );
+    });
+  }
+  bucket.set(key, (bucket.get(key) ?? 0) + 1);
+}
+
+/** A plain data slot of the receiver's own `$__fnctor_<Name>` struct. */
+export interface FnctorTypedField {
+  structName: string;
+  structTypeIdx: number;
+  fieldIdx: number;
+  fieldType: ValType;
+  mutable: boolean;
+  /** The receiver ValType was `ref_null` — the caller must null-check. */
+  nullable: boolean;
+}
+
+/**
+ * Resolve `<receiver>.<propName>` against the receiver's COMPILED ValType, or
+ * `undefined` to decline. Every decline leaves the caller's existing lowering
+ * untouched.
+ *
+ * `recvType` must be what `compileExpression` returned for the receiver — this
+ * function deliberately makes no inference of its own.
+ */
+export function resolveFnctorTypedField(
+  ctx: CodegenContext,
+  recvType: ValType | null | undefined,
+  propName: string,
+): FnctorTypedField | undefined {
+  // Standalone only: the win is the host-free native slot lane, and in JS-host
+  // mode a fnctor instance must keep `$Object` identity for the host MOP.
+  if (!ctx.standalone) return undefined;
+  if (recvType == null) return undefined;
+  if (recvType.kind !== "ref" && recvType.kind !== "ref_null") return undefined;
+  const typeIdx = (recvType as { typeIdx?: number }).typeIdx;
+  if (typeIdx === undefined) return undefined;
+  const structName = ctx.typeIdxToStructName.get(typeIdx);
+  if (structName === undefined || !structName.startsWith("__fnctor_")) return undefined;
+  // The name→index map is the emitter's own source of truth; require the round
+  // trip to agree so a stale/aliased index can never select another struct.
+  if (ctx.structMap.get(structName) !== typeIdx) {
+    note(fnctorTypedReadStats.declines, `idx-mismatch:${structName}`);
+    return undefined;
+  }
+  if (RESERVED_PROPS.has(propName)) {
+    note(fnctorTypedReadStats.declines, `reserved:${propName}`);
+    return undefined;
+  }
+  if (ctx.classAccessorSet.has(`${structName}_${propName}`)) {
+    note(fnctorTypedReadStats.declines, `accessor:${structName}.${propName}`);
+    return undefined;
+  }
+  const fields = ctx.structFields.get(structName);
+  if (fields === undefined) {
+    note(fnctorTypedReadStats.declines, `no-field-table:${structName}`);
+    return undefined;
+  }
+  const fieldIdx = fields.findIndex((f) => f.name === propName);
+  if (fieldIdx < 0) {
+    // Not an own slot ⇒ a prototype method, an accessor installed at runtime,
+    // or a genuinely dynamic property. All three are the dynamic path's.
+    note(fnctorTypedReadStats.declines, `nofield:${structName}.${propName}`);
+    return undefined;
+  }
+  const field = fields[fieldIdx]!;
+  if (field.presenceTracked) {
+    note(fnctorTypedReadStats.declines, `presence:${structName}.${propName}`);
+    return undefined;
+  }
+  return {
+    structName,
+    structTypeIdx: typeIdx,
+    fieldIdx,
+    fieldType: field.type,
+    mutable: field.mutable,
+    nullable: recvType.kind === "ref_null",
+  };
+}
+
+/**
+ * Syntactic refusals shared by the read and write entry points. Kept separate
+ * from {@link resolveFnctorTypedField} because they are about the ACCESS NODE,
+ * not the slot.
+ *
+ * The call-callee refusal is the #1712 rule made syntactic: `p.f()` stays on
+ * the dynamic method path even if `f` happens to name a field. The
+ * `signatureOf` refusal is its type-level twin (a field whose value is
+ * callable keeps the closure/funcref lowering rather than being boxed as a
+ * value), asked through `ctx.oracle` rather than the raw checker.
+ */
+function accessNodeRefused(ctx: CodegenContext, expr: ts.PropertyAccessExpression): boolean {
+  if (expr.questionDotToken !== undefined) return true;
+  if (ts.isPrivateIdentifier(expr.name)) return true;
+  const parent = expr.parent;
+  if (parent !== undefined) {
+    if ((ts.isCallExpression(parent) || ts.isNewExpression(parent)) && parent.expression === expr) return true;
+    if (ts.isTaggedTemplateExpression(parent) && parent.tag === expr) return true;
+    if (ts.isDeleteExpression(parent)) return true;
+  }
+  return ctx.oracle.signatureOf(expr) !== undefined;
+}
+
+/**
+ * The catchable-TypeError null guard, emitted for a `ref_null` receiver that is
+ * already on the stack. Reproduces the guard of the sites this path replaces
+ * (`property-access-dispatch.ts`'s `__nullchk_` tee, `emitNullCheckThrow`):
+ * a raw `struct.get` on null would be an UNCATCHABLE Wasm trap (#789).
+ *
+ * Leaves the receiver back on the stack, unchanged.
+ */
+function emitReceiverNullGuard(fctx: FunctionContext, recvType: ValType, throwInstrs: Instr[]): void {
+  const tmp = allocLocal(fctx, `__ftr_recv_${fctx.locals.length}`, recvType);
+  fctx.body.push({ op: "local.tee", index: tmp });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: throwInstrs, else: [] });
+  // No `ref.as_non_null`: `struct.get` accepts a nullable ref (it traps on
+  // null), and the guard above has already thrown the catchable TypeError on
+  // that path, so the trap is unreachable.
+  fctx.body.push({ op: "local.get", index: tmp });
+}
+
+/**
+ * (#4155 Phase 2, read) The receiver is ON THE STACK with ValType `recvType`.
+ * On admission this consumes it and leaves the field value, returning the
+ * FIELD's ValType (an `f64` slot stays an unboxed f64) exactly as #3683 S2 /
+ * #3685 S2 do. Returns `undefined` without emitting anything to decline, in
+ * which case the caller's existing boxing sequence runs unchanged.
+ */
+export function tryEmitFnctorTypedFieldGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.PropertyAccessExpression,
+  propName: string,
+  recvType: ValType | null | undefined,
+  throwInstrs: () => Instr[],
+): ValType | undefined {
+  const f = resolveFnctorTypedField(ctx, recvType, propName);
+  if (f === undefined) return undefined;
+  if (accessNodeRefused(ctx, expr)) {
+    note(fnctorTypedReadStats.declines, `node-refused:${f.structName}.${propName}`);
+    return undefined;
+  }
+  note(fnctorTypedReadStats.sites, `get:${f.structName}.${propName}:${f.fieldType.kind}`);
+  if (!fnctorTypedReadsEnabled()) return undefined;
+  if (f.nullable) emitReceiverNullGuard(fctx, recvType as ValType, throwInstrs());
+  fctx.body.push({ op: "struct.get", typeIdx: f.structTypeIdx, fieldIdx: f.fieldIdx });
+  fnctorTypedReadStats.gets++;
+  return f.fieldType;
+}
+
+/**
+ * (#4155 Phase 2, write) The receiver is ON THE STACK with ValType `recvType`
+ * and the value has NOT been compiled yet. On admission this compiles the value
+ * (reference-before-value, §13.15.2), stores the slot and leaves the RHS value
+ * on the stack, returning the RHS's ValType — an assignment evaluates to `rval`
+ * as written, not to the field-coerced value.
+ *
+ * Declines without emitting for an immutable slot (`struct.set` on one is a
+ * hard validator error, which is exactly why `fillMemberSetDispatch` filters
+ * its candidates the same way).
+ */
+export function tryEmitFnctorTypedFieldSet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.PropertyAccessExpression,
+  propName: string,
+  recvType: ValType | null | undefined,
+  value: ts.Expression,
+  throwInstrs: () => Instr[],
+  /** `ensureI32Condition` — injected because it lives in `codegen/index.ts`. */
+  toBoolean: (valType: ValType | null) => void,
+): ValType | undefined {
+  const f = resolveFnctorTypedField(ctx, recvType, propName);
+  if (f === undefined || !f.mutable) return undefined;
+  if (accessNodeRefused(ctx, target)) {
+    note(fnctorTypedReadStats.declines, `node-refused-set:${f.structName}.${propName}`);
+    return undefined;
+  }
+  note(fnctorTypedReadStats.sites, `set:${f.structName}.${propName}:${f.fieldType.kind}`);
+  if (!fnctorTypedReadsEnabled()) return undefined;
+  if (f.nullable) emitReceiverNullGuard(fctx, recvType as ValType, throwInstrs());
+
+  let valType = compileExpression(ctx, fctx, value);
+  if (valType === null) {
+    fctx.body.push({ op: "ref.null.extern" });
+    valType = { kind: "externref" };
+  }
+  if (ctx.booleanPropertyNames.has(propName)) {
+    // #2847 parity with every other write path: the whole-program property
+    // analysis proved this slot is boolean, so normalize through ToBoolean and
+    // carry the boolean BRAND (a bare `__box_number` would make `o.flag ===
+    // true` answer false).
+    toBoolean(valType);
+    valType = { kind: "i32", boolean: true };
+  }
+  const valTmp = allocLocal(fctx, `__ftr_val_${fctx.locals.length}`, valType);
+  fctx.body.push({ op: "local.set", index: valTmp });
+  fctx.body.push({ op: "local.get", index: valTmp });
+  // Two DIFFERENT nominal struct types cannot be bridged directly — take the
+  // same externref hop the dispatcher's write arm takes (value→externref at the
+  // call site, externref→field inside the arm). Everything else is one
+  // coercion-engine step. Mirrors `tryEmitTypedThisFieldSet`.
+  const bothRefs =
+    (valType.kind === "ref" || valType.kind === "ref_null") &&
+    (f.fieldType.kind === "ref" || f.fieldType.kind === "ref_null");
+  if (bothRefs && (valType as { typeIdx: number }).typeIdx !== (f.fieldType as { typeIdx: number }).typeIdx) {
+    coerceType(ctx, fctx, valType, { kind: "externref" });
+    coerceType(ctx, fctx, { kind: "externref" }, f.fieldType);
+  } else if (valType.kind !== f.fieldType.kind) {
+    coerceType(ctx, fctx, valType, f.fieldType);
+  }
+  fctx.body.push({ op: "struct.set", typeIdx: f.structTypeIdx, fieldIdx: f.fieldIdx });
+  fctx.body.push({ op: "local.get", index: valTmp });
+  fnctorTypedReadStats.sets++;
+  return valType;
+}

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -170,6 +170,7 @@ import {
 } from "./property-access.js";
 import { tryEmitExactStructFieldGet, tryEmitStructuralContractReadFromLocal } from "./property-access-exact-shapes.js";
 import { tryEmitProvenReceiverFieldGet, tryEmitTypedThisFieldGet } from "./typed-this.js"; // (#3683 S2 / #3685 S2) inline field reads
+import { tryEmitFnctorTypedFieldGet } from "./fnctor-typed-reads.js"; // (#4155 Phase 2) struct-typed fnctor receiver
 import { emitRuntimeEvalSharedValueUnwrap, runtimeEvalSharedValueUnwrapInstrs } from "./global-environment.js";
 
 /**
@@ -3705,6 +3706,16 @@ export function finalizeStructAndDynamicMemberGet(
       let unboxIdx = ensureScalarUnbox(ctx, fctx, accessWasm);
       if (getIdx !== undefined) {
         const objExprType = compileExpression(ctx, fctx, expr.expression);
+        // (#4155 Phase 2) The receiver's compiled ValType is already a
+        // `$__fnctor_<Name>` struct ref and `propName` is one of its plain data
+        // slots: read it with one `struct.get` instead of erasing the type one
+        // instruction later and round-tripping through `__extern_get`'s
+        // ref.test ladder. Flag-gated (declines → byte-identical fallthrough);
+        // flag-independent census under JS2WASM_FNCTOR_TYPED_READS_DEBUG.
+        const fnctorTypedGet = tryEmitFnctorTypedFieldGet(ctx, fctx, expr, propName, objExprType, () =>
+          typeErrorThrowInstrs(ctx, expr),
+        );
+        if (fnctorTypedGet !== undefined) return fnctorTypedGet;
         // If the expression produced a ref/ref_null (struct), convert to externref
         // so that __extern_get (which expects externref) can be used.
         if (objExprType && (objExprType.kind === "ref" || objExprType.kind === "ref_null")) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -73,6 +73,7 @@ import {
 import { tryCompileNativeSetSizeGet } from "./set-runtime.js";
 import { tryEmitLinearU8ElementGet, tryEmitLinearU8Length } from "./linear-uint8-codegen.js";
 import { tryEmitFnctorPrototypeRead } from "./expressions/fnctor-prototype.js";
+import { tryEmitFnctorTypedFieldGet } from "./fnctor-typed-reads.js"; // (#4155 Phase 2) struct-typed fnctor receiver
 import { ensureNativeStringHelpers, stringConstantExternrefInstrs } from "./native-strings.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
 import { emitIsUndefF64 } from "./value-tags.js";
@@ -2424,6 +2425,14 @@ export function tryEmitPinnedStructMemberGet(
   // — `local index out of range` in `__module_init`. A stack-resident receiver
   // has no local to orphan.)
   const objResult = compileExpression(ctx, fctx, expr.expression);
+  // (#4155 Phase 2) Struct-typed receiver + own data slot → one `struct.get`
+  // instead of the externref hop + `__get_member_<name>` ladder. Flag-gated
+  // (declines are byte-identical); flag-independent census under
+  // JS2WASM_FNCTOR_TYPED_READS_DEBUG.
+  const fnctorTypedGet = tryEmitFnctorTypedFieldGet(ctx, fctx, expr, propName, objResult, () =>
+    typeErrorThrowInstrs(ctx, expr),
+  );
+  if (fnctorTypedGet !== undefined) return fnctorTypedGet;
   if (objResult && objResult.kind !== "externref") {
     coerceType(ctx, fctx, objResult, { kind: "externref" });
   } else if (!objResult) {

--- a/tests/issue-4155-phase2-typed-reads.test.ts
+++ b/tests/issue-4155-phase2-typed-reads.test.ts
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4155 Phase 2 — direct `struct.get`/`struct.set` for a data field accessed
+// through a receiver whose COMPILED ValType is already a `$__fnctor_<Name>`
+// struct reference (`src/codegen/fnctor-typed-reads.ts`).
+//
+// The coverage (measured on standalone acorn 8.16.0, census 2026-08-06) is
+// SECOND-HOP reads off Phase-1-typed slots: `this.type.keyword` where the
+// `type` slot is `(ref null $__fnctor_TokenType)`. The checker cannot bind
+// `this` in acorn's `pp = Parser.prototype; pp.m = function () {…}` idiom, so
+// the read reaches the DYNAMIC member path — but codegen's typed-this twin
+// compiles the receiver to a struct-typed ValType, which is exactly what the
+// fast path consumes. The fixtures below reproduce that shape: a JS file
+// (checker types `new T()` by ctor-shape inference), a prototype ALIAS (breaks
+// static `this` binding), and a fnctor slot seeded with another fnctor's
+// instance in the constructor.
+//
+// Everything here is behavior-equal by construction: the flag may only change
+// HOW a field is read (one `struct.get` vs the `__get_member_<name>` ladder),
+// never WHAT it answers. The WAT assertions pin the representation change and
+// are mutation-checked against the flag-off compile of the same source.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+const FLAG = "JS2WASM_FNCTOR_TYPED_READS";
+
+async function compileStandaloneJs(src: string, flagOn: boolean): Promise<{ wat: string; binary: Uint8Array }> {
+  const saved = process.env[FLAG];
+  if (flagOn) process.env[FLAG] = "1";
+  // biome-ignore lint/performance/noDelete: only `delete` truly unsets an env var
+  else delete process.env[FLAG];
+  try {
+    const r = await compile(src, {
+      fileName: "t.mjs",
+      allowJs: true,
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+      emitWat: true,
+    });
+    expect(r.success, r.errors.map((e) => String(e.message ?? e)).join("\n")).toBe(true);
+    expect(WebAssembly.validate(r.binary), "invalid wasm").toBe(true);
+    return { wat: r.wat ?? "", binary: r.binary };
+  } finally {
+    if (saved === undefined) {
+      // biome-ignore lint/performance/noDelete: only `delete` truly unsets an env var
+      delete process.env[FLAG];
+    } else {
+      process.env[FLAG] = saved;
+    }
+  }
+}
+
+async function run(binary: Uint8Array): Promise<unknown> {
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+/** Compile the same source flag-on and flag-off; assert identical results. */
+async function runBothWays(src: string): Promise<{ result: unknown; watOn: string; watOff: string }> {
+  const off = await compileStandaloneJs(src, false);
+  const on = await compileStandaloneJs(src, true);
+  const resultOff = await run(off.binary);
+  const resultOn = await run(on.binary);
+  expect(resultOn, "flag-on result must equal flag-off result").toEqual(resultOff);
+  return { result: resultOn, watOn: on.wat, watOff: off.wat };
+}
+
+// The acorn shape: prototype-ALIAS methods (static `this` unresolvable) doing
+// second-hop reads through a ctor-seeded fnctor-instance slot.
+const SECOND_HOP_READ_SRC = `
+function T(k) { this.keyword = k; this.beforeExpr = true; }
+function P() { this.type = new T(41); this.pos = 0; }
+var pp = P.prototype;
+pp.readKeyword = function () { return this.type.keyword; };
+pp.readFlag = function () { return this.type.beforeExpr ? 1 : 0; };
+export function test() {
+  const p = new P();
+  return p.readKeyword() + p.readFlag();
+}
+`;
+
+describe("#4155 Phase 2 — typed fnctor field reads (flag-gated)", () => {
+  it("second-hop read off a typed slot: same result, and the flag-on WAT drops __get_member_", async () => {
+    const { result, watOn, watOff } = await runBothWays(SECOND_HOP_READ_SRC);
+    expect(result).toBe(42);
+    // Mutation check: the dynamic dispatcher IS the flag-off lowering for this
+    // fixture — if this stops matching, the fixture no longer covers the fast
+    // path and the flag-on assertion below is vacuous.
+    expect(watOff).toContain("__get_member_keyword");
+    // The fast path replaced every dynamic read of the fixture: no dispatcher
+    // is referenced (not even defined — nothing reserves it).
+    expect(watOn).not.toContain("__get_member_keyword");
+    expect(watOn).not.toContain("__get_member_beforeExpr");
+  });
+
+  it("write twin: struct.set through the typed receiver, assignment still evaluates to the RHS", async () => {
+    const { result } = await runBothWays(`
+function T(k) { this.keyword = k; this.beforeExpr = true; }
+function P() { this.type = new T(41); this.pos = 0; }
+var pp = P.prototype;
+pp.bump = function () { this.type.keyword = this.type.keyword + 1; return this.type.keyword; };
+pp.assignResult = function () { return (this.type.keyword = 7) + this.type.keyword; };
+export function test() {
+  const p = new P();
+  return p.bump() * 100 + p.assignResult();
+}
+`);
+    // bump: 41+1 = 42; assignResult: (=7 evaluates to 7) + 7 = 14.
+    expect(result).toBe(4214);
+  });
+
+  it("member CALL through the typed receiver stays dynamic and keeps working", async () => {
+    const { result } = await runBothWays(`
+function T(k) { this.keyword = k; }
+T.prototype.twice = function () { return this.keyword * 2; };
+function P() { this.type = new T(21); }
+var pp = P.prototype;
+pp.callTwice = function () { return this.type.twice(); };
+export function test() {
+  const p = new P();
+  return p.callTwice();
+}
+`);
+    expect(result).toBe(42);
+  });
+
+  it("ctor-unseeded property on the typed receiver stays dynamic (write-then-read round trip)", async () => {
+    // `extra` is never seeded in T's ctor, so it is NOT a struct slot — the
+    // access must keep taking the dynamic path (`nofield` decline). What the
+    // dynamic path ANSWERS for an expando on a fnctor instance is its own
+    // (pre-existing) business and is deliberately not pinned here; the
+    // contract is that the flag does not change it (runBothWays asserts
+    // flag-on === flag-off) and that the write does not corrupt the real
+    // struct slot next to it.
+    const { result } = await runBothWays(`
+function T(k) { this.keyword = k; }
+function P() { this.type = new T(40); }
+var pp = P.prototype;
+pp.stash = function () { this.type.extra = 2; return this.type.extra; };
+pp.readKeyword = function () { return this.type.keyword; };
+export function test() {
+  const p = new P();
+  const e = p.stash();
+  const eTag = e === 2 ? 1 : e === undefined ? 2 : e === null ? 3 : 4;
+  return eTag * 1000 + (p.readKeyword() === 40 ? 100 : 0);
+}
+`);
+    // The seeded slot survives the neighboring expando write in both modes.
+    expect(typeof result).toBe("number");
+    expect((result as number) % 1000).toBe(100);
+  });
+
+  it("presence-tracked / conditionally-seeded field keeps answering undefined when unset", async () => {
+    const { result } = await runBothWays(`
+function T(k) { this.keyword = k; if (k > 100) { this.opt = k; } }
+function P(k) { this.type = new T(k); }
+var pp = P.prototype;
+pp.readOpt = function () { return this.type.opt === undefined ? -1 : this.type.opt; };
+export function test() {
+  const unset = new P(41);
+  const set = new P(200);
+  return unset.readOpt() * 1000 + set.readOpt();
+}
+`);
+    expect(result).toBe(-800); // -1 * 1000 + 200
+  });
+
+  it("null receiver throws a CATCHABLE TypeError, not a trap", async () => {
+    // `rawRead` is load-bearing: with a single reader the compiler resolves the
+    // read statically and answers undefined for a null receiver in BOTH flag
+    // states (no dispatcher is ever built). The second reader forces the
+    // dynamic `__get_member_` route, whose null behavior is the catchable
+    // TypeError this test pins — and the flag-on fast path must reproduce it
+    // (`emitReceiverNullGuard`), never a raw `struct.get` trap.
+    const { result, watOff } = await runBothWays(`
+function T(k) { this.keyword = k; }
+function P() { this.type = new T(41); }
+var pp = P.prototype;
+pp.tryRead = function () { try { return this.type.keyword; } catch (e) { return -7; } };
+pp.rawRead = function () { return this.type.keyword; };
+export function test() {
+  const p = new P();
+  p.type = null;
+  return p.tryRead();
+}
+export function test2() {
+  const p = new P();
+  return p.rawRead();
+}
+`);
+    expect(watOff, "fixture must exercise the dynamic dispatcher flag-off").toContain("__get_member_keyword");
+    expect(result).toBe(-7);
+  });
+});


### PR DESCRIPTION
## Description

Implements #4155 Phase 2 per umbrella #4157 Workstream 1: direct `struct.get`/`struct.set` for data-field access on a struct-typed fnctor receiver, behind `JS2WASM_FNCTOR_TYPED_READS` — and ships the **measured null result** that decides its default.

### Census first (the finding that scoped everything)

A flag-independent candidate census ran before any wiring: standalone acorn has **74 candidate gets + 4 sets** — and every one is a **second-hop read off a Phase-1-typed slot** (largest: `TokenType.keyword` ×40). First-hop receivers at the 4,940 dispatcher sites are externref locals, exactly as the predecessor's WAT sampling suggested: Phase 1 typed the *slots*, but bindings holding instances are still `any` → externref, so the receiver ValType this fast path admits on almost never appears at first hops.

### What shipped

- Read hook in the `isExternObj` arm of `property-access-dispatch.ts` (between `compileExpression` and the `extern.convert_any` that discards its ValType), write twin in `compilePropertyAssignmentExternSet`, both admitting on the receiver's **compiled ValType** — never a static predictor (the half-emitted-receiver hazard, #2681 funcIdx trap).
- Member calls are never static off the struct type; presence-tracked fields, accessors, optional chains, `delete`, and callee positions all refuse.
- **Flag-off is byte-identical, sha256-asserted.**

### The A/B, and the default it dictates

Three back-to-back pairs on the `standaloneDynamic` lane: **OFF 0.1178 vs ON 0.1156** — inside ±0.014–0.041 std. A wash. 78 sites against 4,940 dispatcher sites was never going to move wall clock, and the umbrella's measurement rules say a null gets recorded, not stretched. **Default: OFF**, full numbers in the issue's "2026-08-06 — Phase 2 implemented" section.

### What this buys despite the null

The mechanism is correct, tested (170 tests green flag-on), and sitting behind one variable. Its coverage is bounded by receiver *representation*, not by the hook — so the documented successor lever, **binding retype (#2660 S3b)**, multiplies this hook's coverage the moment instance-holding bindings carry their struct type. The read side is now ready for that day; the umbrella's Workstream 1 pivot point is retyping, not more read paths.

## Testing

- 170 tests green with the flag ON across the Phase 0 regression suite, the four #2660 fnctor suites, and targeted equivalence files; new `tests/issue-4155-phase2-typed-reads.test.ts` with the WAT-level no-dispatcher assertion, mutation-checked against flag-off.
- Dogfood canaries unchanged; flag-off binary byte-identical (sha-asserted).
- All 9 gates by exit code: tsc, lint, oracle-ratchet, loc-budget, func-budget, dead-exports, coercion-sites, stack-balance, prettier.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_