### PR TITLE
perf(#4157): post-campaign CPU profile of standalone acorn — reorder Workstream 2

### DIFF
--- a/plan/issues/4157-close-the-acorn-node-performance-gap.md
+++ b/plan/issues/4157-close-the-acorn-node-performance-gap.md
@@ -4,7 +4,7 @@ title: "umbrella: close the acorn-vs-Node performance gap — representation fir
 status: ready
 sprint: current
 created: 2026-08-04
-updated: 2026-08-04
+updated: 2026-08-06
 priority: high
 horizon: xl
 feasibility: hard
@@ -14,6 +14,8 @@ area: codegen
 goal: performance
 assignee: "ttraenkler/claude-fable"
 related: [3780, 4155, 743, 3926, 3927, 4074, 2860]
+loc-budget-allow:
+  - src/codegen/closures.ts
 origin: "2026-08-04 — synthesis of the #3780/#4155 measurement campaign into a scheduled program"
 ---
 
@@ -107,6 +109,160 @@ The gap decomposes into two unequal parts (#3780):
       the realistic Workstream-1+2 target; parity is NOT promised by this
       umbrella and would require wins beyond both workstreams.
 - [ ] The three #4155 Phase 0 `it.fails` tests are promoted to passing.
+
+## 2026-08-06 — post-campaign profile (replaces the hypothesis with a self-time table)
+
+All four receiver-side levers (#4116 slot typing, typed reads, binding retype
+PR #4141, ctor-param seeds PR #4140) measured NULL on wall-clock; the recorded
+hypothesis was "the converted sites' VALUES stay boxed, and the remaining
+dynamic-lookup sites and/or scanner/string work dominate." This section is the
+measured replacement for that hypothesis.
+
+**Setup.** `origin/main` @ `b2a713e57`, Node 22.22.2, 4-core/16 GB container.
+`standalone-dynamic` lane exactly as shipped (`--only acorn --perf-only --lane
+standalone-dynamic`, optimize 4, checksum 422, zero imports, binary
+**1,505,459 B** — down from the #3780-era 1.69 MB with #4116 now default-on).
+Same-process lane medians: **wasm 144,186 µs/op vs node 17,861 µs/op, ratio
+0.124 (8.1x)**. Profile: V8 inspector sampling over **300 parses, 48,429 ms
+wall, 39,586 samples** (~1.2 ms/sample — coarser than #3780's 150 µs, but 6x
+the sample count). All percentages below are of that 48.4 s (~161 ms/parse
+under profiler, +12 % overhead over the unprofiled 144 ms median).
+`__closure_N` frames are mapped to acorn source functions via the new
+`JS2WASM_CLOSURE_NAME_MAP=1` diagnostic (src/codegen/closures.ts).
+
+**Caveat**: `JS2WASM_FNCTOR_TYPED_BINDINGS` (#4141) is NOT on this base — the
+flags-ON run below toggles only the two landed levers (`TYPED_READS`,
+`CTOR_PARAM_TYPES`); the third env var was silently inert.
+
+### Top-25 self-time (baseline, all flags off)
+
+| # | self % | cum % | bucket | frame |
+| --: | --: | --: | --- | --- |
+| 1 | 18.49 | 18.5 | gc-engine | (garbage collector) |
+| 2 | 7.69 | 26.2 | dynamic-lookup | `__extern_get` |
+| 3 | 5.12 | 31.3 | regexp | `__regex_search` |
+| 4 | 3.73 | 35.0 | string-runtime | `__str_flatten` |
+| 5 | 3.72 | 38.7 | dynamic-eq | `__extern_strict_eq` |
+| 6 | 3.10 | 41.8 | dynamic-eq | `__is_truthy` |
+| 7 | 2.30 | 44.1 | cast-convert | `__box_number` |
+| 8 | 1.94 | 46.1 | scanner | `getTokenFromCode` twin |
+| 9 | 1.89 | 48.0 | parser | `parseSubscript` |
+| 10 | 1.66 | 49.6 | scanner | `fullCharCodeAt` twin |
+| 11 | 1.42 | 51.1 | scanner | `skipSpace` twin |
+| 12 | 1.32 | 52.4 | scanner | `pp.next` |
+| 13 | 1.31 | 53.7 | cast-convert | `__unbox_number` |
+| 14 | 1.23 | 54.9 | call-dispatch | `__dc_Parser_nextToken_0_g` |
+| 15 | 1.10 | 56.0 | alloc | `__fnctor_Node_new` |
+| 16 | 1.10 | 57.1 | cast-convert | `__to_primitive` |
+| 17 | 0.99 | 58.1 | parser | `currentVarScope` |
+| 18 | 0.95 | 59.1 | string-runtime | `__str_equals` |
+| 19 | 0.93 | 60.0 | call-dispatch | `__call_fn_method_7` |
+| 20 | 0.91 | 60.9 | call-dispatch | `__extern_method_call` |
+| 21 | 0.89 | 61.8 | parser | `parseMaybeAssign` |
+| 22 | 0.87 | 62.7 | scanner | `readToken` twin |
+| 23 | 0.85 | 63.5 | dynamic-lookup | `__obj_find` |
+| 24 | 0.82 | 64.3 | call-dispatch | `__call_fn_method_0` |
+| 25 | 0.80 | 65.1 | cast-convert | `__any_from_extern` |
+
+### Buckets, and the A/B with the two landed receiver flags ON
+
+| bucket | flags OFF | flags ON | #3780 (2026-08-01) |
+| --- | --: | --: | --: |
+| gc-engine | **18.5 %** | 17.0 % | 17.4 % |
+| dynamic-lookup (`__extern_get` 7.7 + per-key `__get/set_member_*` 6.1 + `__obj_find/hash` 1.5) | **16.1 %** | 15.3 % | ~10.4 % (grouped w/ eq) |
+| parser logic (compiled) | 15.4 % | 16.1 % | } 41.4 % ("compiled acorn", |
+| scanner/tokenizer (compiled) | 13.2 % | 13.7 % | } grouping differs — see note) |
+| call-dispatch (`__dc_*` 4.2, `__call_fn_method_*` 2.6, `__call_m_*` 1.3, `__extern_method_call` 0.9) | **10.0 %** | 10.5 % | 7.6 % |
+| dynamic-eq (`__extern_strict_eq` 3.7, `__is_truthy` 3.1) | **7.1 %** | 6.9 % | 2.7 % visible (`strict_eq` frame) |
+| regexp (`__regex_search` 5.1 + test dispatch) | 6.6 % | 6.7 % | 5.2 % |
+| cast-convert (`__box/__unbox/__to_primitive/__any_*`) | 6.1 % | 6.1 % | 4.9 % |
+| string-runtime (`__str_flatten` **3.7**, `__str_equals` 1.0) | **5.6 %** | 6.1 % | 1.7 % |
+| alloc helpers (`__fnctor_Node_new` 1.1) | 1.3 % | 1.5 % | 3.9 % |
+| lane total (same box, minutes apart) | 144.2 ms/op | 137.8 ms/op | (132.1 ms/op, other box-day) |
+
+Grouping note: #3780's "compiled acorn 41.4 %" almost certainly folded the
+per-key `__get/set_member_*` helpers (6.1 pp here) and `__dc_*` trampolines
+(4.2 pp) into compiled code; per-frame comparisons are the robust ones:
+`__extern_get` **5.6 → 7.7 %**, `__regex_search` 4.1 → 5.1 %,
+`__extern_strict_eq` 2.7 → 3.7 %, `__fnctor_Node_new` **3.4 → 1.1 %** (the
+round-4 allocation work + slot typing really did shrink Node construction).
+
+**The flags-ON A/B confirms values-stay-boxed from the inside.** Lane 137.8 vs
+144.2 ms/op (ratio 0.117 vs 0.124 — inside the campaign's noise band,
+ratioStd ≈ 0.025); binary +570 B. The dispatch bucket does not even shrink
+meaningfully: `__extern_get` 7.7 → 7.8 %, per-key member helpers 6.1 → 5.4 %
+(−0.7 pp, the only visible movement), everything else flat. Typing the
+receiver converts a sliver of per-key member traffic and nothing else on the
+hot path.
+
+### Who pays for the top helpers (nearest-caller attribution)
+
+- `__extern_get` (7.69 %): `__extern_method_call` 1.30, `__fnctor_Node_new`
+  1.06 (the ctor's `options.locations/ranges` reads — `Parser.options` is an
+  open `$Object` by design, #4155), `checkUnreserved` 1.01 (its
+  `this.options.ecmaVersion` reads), `finishNodeAt` 0.68, then the tokenizer
+  (`next`/`readToken`/`readWord`/`finishToken` ≈ 1.6 combined). Spread wide —
+  only an algorithmic fix to the helper itself (#3926) reaches all of them.
+- `__str_flatten` (3.73 %): **`skipSpace` 1.19 + `fullCharCodeAt` 0.54** — the
+  scanner's per-character path re-enters rope flattening on every
+  `charCodeAt` of the (concat-built, hence rope-backed) input string. This is
+  a single, narrow, previously uncatalogued lever.
+- `__extern_strict_eq` (3.72 %): `parseSubscript` 1.38 (its `===` chain on
+  boxed operands), then spread across `parseMaybe*`/`eat`/`isContextual`.
+- `__regex_search` (5.12 %): 4.97 via `__regexp_test_carrier`/`__call_m_test_1`
+  — tokenizer-adjacent `.test` calls, almost nothing else.
+
+### Workstream 2, REORDERED (by measured bucket size)
+
+1. **#3926 `__extern_get` perfect-hash / `br_table`** — still first, and its
+   target GREW: dynamic-lookup is 16.1 % (extern_get self 7.7 % vs the 5.6 %
+   baseline; acceptance criterion "< 3 %" now needs a −4.7 pp move). Pays on
+   every read no representation lever converts, callers spread too wide for
+   site fixes.
+2. **NEW ISSUE NEEDED — dynamic strict-eq / truthiness lowering (7.1 %,
+   nothing targets it)**: `__extern_strict_eq` 3.7 + `__is_truthy` 3.1. No
+   current Workstream 2 issue touches boxed `===`/condition tests; top payer
+   is `parseSubscript`'s token-comparison chain.
+3. **NEW ISSUE NEEDED — `charCodeAt`-on-rope flatten guard (3.7 %, nothing
+   targets it)**: `__str_flatten` re-entered per scanned character from
+   `skipSpace`/`fullCharCodeAt`. The string bucket tripled vs #3780
+   (1.7 → 5.6 %); this one function is two-thirds of it. Likely the cheapest
+   slice on this list (cache the flat array ref / early-exit already-flat).
+4. **Regexp `.test` residue (6.6 %)** — the "scanner/string tuning" line item,
+   now scoped: it is `__regex_search` reached via the test carrier on
+   tokenizer regexes. Rounds 1-2 already took the easy wins; treat as bounded.
+5. **#3927 per-shape fnctor splitting — DEMOTED**: `__fnctor_Node_new` self
+   fell 3.4 → 1.1 % (presence-bit packing + slot typing already banked much of
+   it); remaining payoff routes through the GC bucket only, capped at ~19 % of
+   allocation.
+
+**What Workstream 2 cannot reach (and the profile says out loud):** GC 18.5 %
++ dynamic-eq 7.1 % + cast-convert 6.1 % ≈ **32 % is the boxed-VALUES tax** —
+that is Workstream 1 (#4155 Phase 2 read side, #743 fixpoint) territory, and
+it is exactly why four receiver-side levers measured null: typing the receiver
+without unboxing the values converts neither the read results nor the
+comparisons nor the allocations. The profile does not demote Workstream 1; it
+confirms its target is the single largest cluster.
+
+**Single next slice to dispatch: #3926.** Largest bucket any single PR can
+address (16.1 % dynamic-lookup, one helper function), independent of every
+in-flight representation lever, acceptance criterion already pinned in this
+umbrella, and its payoff is unconditional — every future typing improvement
+still leaves the fallback path on it.
+
+### Reproduction
+
+```bash
+# profile (writes .cpuprofile + binary; stderr carries the closure map):
+JS2WASM_CLOSURE_NAME_MAP=1 npx tsx scripts/generate-npm-compat-report.mjs \
+  --only acorn --no-write --perf-only --lane standalone-dynamic \
+  --preserve-debug-names --profile-runtime wasm \
+  --profile-output .tmp/acorn.cpuprofile --profile-iterations 300 \
+  2> .tmp/closure-map.log
+# analyze:
+node scripts/profile-buckets.mjs .tmp/acorn.cpuprofile .tmp/closure-map.log 25 \
+  --detail --callers=__extern_get
+```
 
 ## Dupe check
 

--- a/scripts/profile-buckets.mjs
+++ b/scripts/profile-buckets.mjs
@@ -1,0 +1,185 @@
+// Bucket a V8 .cpuprofile of a compiled standalone module by self-time (#4157).
+//
+// Usage:
+//   node scripts/profile-buckets.mjs <file.cpuprofile> [closure-map.log] [topN] [--detail] [--callers=NAME]
+//
+// The .cpuprofile comes from the npm-compat report generator's profiling mode,
+// e.g. for the acorn standalone runtime-dynamic lane:
+//
+//   npx tsx scripts/generate-npm-compat-report.mjs --only acorn --no-write \
+//     --perf-only --lane standalone-dynamic --preserve-debug-names \
+//     --profile-runtime wasm --profile-output .tmp/acorn.cpuprofile \
+//     --profile-iterations 300 2> .tmp/closure-map.log
+//
+// The optional closure-map.log is the stderr of a compile run with
+// `JS2WASM_CLOSURE_NAME_MAP=1` (see src/codegen/closures.ts): it maps the
+// opaque emitted `__closure_N` names (and their `__typed_this` twins) back to
+// the source functions they were lifted from, so hot compiled-package frames
+// are readable. Passing the SAME lane invocation's stderr (as above) guarantees
+// the ids match the profiled binary.
+//
+// Buckets:
+//   gc-engine       V8 GC / engine frames
+//   dynamic-lookup  __extern_get + per-key __get_member_*/__set_member_* +
+//                   open-object hash helpers (the #3926 territory)
+//   call-dispatch   generic call dispatchers + direct-call trampolines
+//   dynamic-eq      __extern_strict_eq / __is_truthy / nullish tests
+//   cast-convert    boxing, unboxing, ToPrimitive, any<->extern conversions
+//   regexp          regex engine + .test dispatch
+//   string-runtime  __str_* rope/compare/slice helpers
+//   alloc-helpers   fnctor constructors + vector helpers
+//   scanner         compiled package code matching the tokenizer-name heuristic
+//   compiled        remaining compiled package code
+//   other-runtime   remaining __-prefixed runtime helpers
+//   js-host         JS frames (host driver, node internals)
+import { readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const flags = args.filter((a) => a.startsWith("--"));
+const positional = args.filter((a) => !a.startsWith("--"));
+const [profilePath, mapPath] = positional[1]?.endsWith(".cpuprofile")
+  ? [positional[0], undefined]
+  : [positional[0], positional[1] && Number.isNaN(Number(positional[1])) ? positional[1] : undefined];
+const topN = Number(positional.find((a, i) => i > 0 && !Number.isNaN(Number(a))) ?? 25);
+if (!profilePath) {
+  console.error(
+    "usage: node scripts/profile-buckets.mjs <file.cpuprofile> [closure-map.log] [topN] [--detail] [--callers=NAME]",
+  );
+  process.exit(2);
+}
+const profile = JSON.parse(readFileSync(profilePath, "utf-8"));
+
+const closureMap = new Map();
+if (mapPath) {
+  for (const line of readFileSync(mapPath, "utf-8").split("\n")) {
+    const m = line.match(/\[js2:closure-map\] (__closure_\d+) <- (\S+) @(\d+)/);
+    if (m) closureMap.set(m[1], m[2]);
+  }
+}
+
+function displayName(raw) {
+  const m = raw.match(/^(__closure_\d+)(__typed_this)?$/);
+  if (!m) return raw;
+  const mapped = closureMap.get(m[1]);
+  return mapped ? `${mapped}${m[2] ?? ""} [${m[1]}]` : raw;
+}
+
+// Tokenizer/scanner method names (tuned for acorn's dist bundle; harmless
+// elsewhere — unmatched compiled code just lands in "compiled").
+const SCANNER_RE =
+  /\.(next|getToken\w*|nextToken|read\w+|skip\w+|finishToken|finishOp|fullCharCodeAt|curContext|updateContext|initialContext|inGeneratorContext|overrideContext|codePointToString|currentPos|curPosition)(__typed_this)? \[/;
+
+function classify(raw, name) {
+  if (/^\((garbage collector|program|idle|root)\)/.test(raw)) return "gc-engine";
+  if (
+    /^(__extern_(get|set|in|has|delete|keys)|__get_member|__set_member|__obj_(find|hash)|__method_cache_lookup)/.test(
+      raw,
+    )
+  )
+    return "dynamic-lookup";
+  if (
+    /^(__extern_method_call|__call_fn_method|__call_m_(?!test)|__dc_|__named_this_call|__apply_closure|__builtinfn_get_meta|__call_function)/.test(
+      raw,
+    )
+  )
+    return "call-dispatch";
+  if (/^(__extern_(strict_)?eq|__host_(eq|compare)|__is_truthy|__typeof|__extern_is_nullish)/.test(raw))
+    return "dynamic-eq";
+  if (
+    /^(__box_|__unbox_|__to_primitive|__to_number|__to_int32|__to_uint32|__any_(from|to|unbox)_|__coerce|__number_to)/.test(
+      raw,
+    )
+  )
+    return "cast-convert";
+  if (/^(__regex|__call_m_test|__regexp)/.test(raw)) return "regexp";
+  if (/^(__str_|__string|__char|__code_point)/.test(raw)) return "string-runtime";
+  if (/^(__fnctor_\w+_new|__alloc|__argvec|__vec_|__objvec)/.test(raw)) return "alloc-helpers";
+  if (/^__closure_/.test(raw)) return SCANNER_RE.test(name) ? "scanner" : "compiled";
+  if (/^__/.test(raw)) return "other-runtime";
+  if (raw.startsWith("[js] ") || raw === "(anonymous)") return "js-host";
+  // Named wasm functions from the package source (finishNodeAt, getOptions, ...)
+  return "compiled";
+}
+
+const totalSamples = profile.nodes.reduce((sum, node) => sum + (node.hitCount ?? 0), 0);
+const totalMicros = profile.endTime - profile.startTime;
+
+const byName = new Map();
+for (const node of profile.nodes) {
+  const hits = node.hitCount ?? 0;
+  if (!hits) continue;
+  const cf = node.callFrame;
+  const isWasm = (cf.url ?? "").startsWith("wasm:");
+  let raw = cf.functionName || "(anonymous)";
+  if (!isWasm && !raw.startsWith("(")) raw = `[js] ${raw}`;
+  const entry = byName.get(raw) ?? { raw, hits: 0 };
+  entry.hits += hits;
+  byName.set(raw, entry);
+}
+
+const frames = [...byName.values()].sort((a, b) => b.hits - a.hits);
+const buckets = new Map();
+for (const frame of frames) {
+  frame.name = displayName(frame.raw);
+  frame.bucket = classify(frame.raw, frame.name);
+  buckets.set(frame.bucket, (buckets.get(frame.bucket) ?? 0) + frame.hits);
+}
+
+const pct = (hits) => ((hits / totalSamples) * 100).toFixed(2).padStart(6);
+console.log(`profile: ${profilePath}`);
+console.log(`total: ${(totalMicros / 1000).toFixed(0)} ms wall, ${totalSamples} samples\n`);
+
+console.log(`top ${topN} frames by self time:`);
+console.log("self%   cum%    bucket           name");
+let cum = 0;
+for (const frame of frames.slice(0, topN)) {
+  cum += frame.hits;
+  console.log(`${pct(frame.hits)}  ${pct(cum)}  ${frame.bucket.padEnd(15)}  ${frame.name}`);
+}
+
+console.log("\nbucket totals (self time):");
+for (const [bucket, hits] of [...buckets.entries()].sort((a, b) => b[1] - a[1])) {
+  console.log(`${pct(hits)}%  ${bucket}`);
+}
+
+if (flags.includes("--detail")) {
+  for (const [bucket] of [...buckets.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`\n== ${bucket}`);
+    for (const frame of frames.filter((f) => f.bucket === bucket).slice(0, 25)) {
+      console.log(`${pct(frame.hits)}  ${frame.name}`);
+    }
+  }
+}
+
+// --callers=__extern_get: attribute a frame's self hits to its nearest
+// distinct ancestor, answering "who pays for this helper".
+const callersFlag = flags.find((f) => f.startsWith("--callers="));
+if (callersFlag) {
+  const target = callersFlag.slice("--callers=".length);
+  const byId = new Map(profile.nodes.map((n) => [n.id, n]));
+  const parentOf = new Map();
+  for (const n of profile.nodes) for (const c of n.children ?? []) parentOf.set(c, n.id);
+  const callers = new Map();
+  let targetHits = 0;
+  for (const n of profile.nodes) {
+    if (n.callFrame.functionName !== target) continue;
+    const hits = n.hitCount ?? 0;
+    if (!hits) continue;
+    targetHits += hits;
+    let pid = parentOf.get(n.id);
+    let parentName = "(root)";
+    while (pid) {
+      const pn = byId.get(pid);
+      if (pn.callFrame.functionName !== target) {
+        parentName = pn.callFrame.functionName;
+        break;
+      }
+      pid = parentOf.get(pid);
+    }
+    callers.set(parentName, (callers.get(parentName) ?? 0) + hits);
+  }
+  console.log(`\ncallers of ${target} (self ${pct(targetHits)}%):`);
+  for (const [name, hits] of [...callers.entries()].sort((a, b) => b[1] - a[1]).slice(0, 15)) {
+    console.log(`${pct(hits)}  ${displayName(name)}`);
+  }
+}

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -2692,6 +2692,30 @@ function reportClosureFrameBreach(
   );
 }
 
+/**
+ * (#4157) `JS2WASM_CLOSURE_NAME_MAP=1` prints one line per lifted closure
+ * mapping the opaque emitted name (`__closure_N`, and by suffix its
+ * `__closure_N__typed_this` twin) back to the source function it came from.
+ * CPU profiles of compiled packages surface hot frames only under the emitted
+ * name; without this map "which package function is hot" is guesswork.
+ * Consumed by `scripts/profile-buckets.mjs`.
+ */
+function reportClosureNameMap(arrow: ts.ArrowFunction | ts.FunctionExpression, closureName: string): void {
+  if (typeof process === "undefined" || !process.env?.JS2WASM_CLOSURE_NAME_MAP) return;
+  let label = ts.isFunctionExpression(arrow) && arrow.name ? arrow.name.text : "";
+  if (!label) {
+    const parent = arrow.parent;
+    if (ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      label = parent.left.getText();
+    } else if (ts.isPropertyAssignment(parent) || ts.isVariableDeclaration(parent)) {
+      label = parent.name.getText();
+    }
+  }
+  const sourceFile = arrow.getSourceFile();
+  const { line } = sourceFile.getLineAndCharacterOfPosition(arrow.getStart());
+  console.error(`[js2:closure-map] ${closureName} <- ${label || "(anonymous)"} @${line + 1}`);
+}
+
 /** Compile an arrow function as a first-class closure value (Wasm GC struct + funcref) */
 export function compileArrowAsClosure(
   ctx: CodegenContext,
@@ -2701,6 +2725,7 @@ export function compileArrowAsClosure(
   const closureId = ctx.closureCounter++;
   const closureName = `__closure_${closureId}`;
   const body = arrow.body;
+  reportClosureNameMap(arrow, closureName);
 
   // Check if this is a generator function expression (function*() { ... })
   const isGenerator = ts.isFunctionExpression(arrow) && arrow.asteriskToken !== undefined;


### PR DESCRIPTION
## Description

The measured answer to "where do the ~205 ms actually go now" — the explicitly recorded next step after the 2026-08-06 campaign implemented all four receiver-side representation levers and measured every one null on wall-clock. Full table and reordered plan in the new **"2026-08-06 — post-campaign profile"** section of `plan/issues/4157-close-the-acorn-node-performance-gap.md`; this PR is that section plus the profiling driver.

### Headline buckets (self-time on the runtime-dynamic parse)

| bucket | share | note |
|---|---:|---|
| GC / allocation | **18.5%** | largest single bucket |
| dynamic property lookup | **16.1%** | `__extern_get` self-time **7.7% — UP from #3780's 5.6%** |
| call dispatch | 10.0% | |
| dynamic equality | **7.1%** | **no issue exists for this bucket** |
| `__str_flatten` | **3.7%** | called **per scanned character** from `skipSpace`/`fullCharCodeAt` — **no issue exists** |

### Two confirmations and two discoveries

- **Values-stay-boxed, confirmed from the inside**: with the landed receiver flags ON, the dispatch bucket does not shrink and the total stays inside noise — the campaign's post-mortem holds. (Caveat recorded honestly: #4141's binding-retype flag was not yet on `main` at profile time, so the flags-ON run toggled only the two landed levers.)
- **The original #3780 attribution has drifted**: `__extern_get` grew from 5.6% to 7.7% self-time as other costs moved — re-profiling before re-planning was the right call.
- **Two buckets nobody has an issue for**: dynamic equality (7.1%) and per-character string flattening in the scanner (3.7%) — together larger than the entire receiver-lever campaign's theoretical target.

### Recommended next slice

**#3926** (perfect-hash / `br_table` the `__extern_get` key dispatch): largest addressable single function, now 7.7% self-time and rising, benefits every one of the ~4,500 sites the receiver levers could not convert. Then file and take the two unowned buckets.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_