### PR TITLE
fix(#4172): make the standalone [[Prototype]] chain live for reassigned F.prototype (+95 on the 219-file ES5 lever)

### DIFF
--- a/plan/agent-context/W2-prototype-chain.md
+++ b/plan/agent-context/W2-prototype-chain.md
@@ -1,6 +1,6 @@
 # W2 — prototype-chain lever: PR body + session notes
 
-**Agent**: `ttraenkler/W2-prototype-chain` · **Issue**: #4163 (allocated via
+**Agent**: `ttraenkler/W2-prototype-chain` · **Issue**: #4172 (allocated via
 `claim-issue.mjs --allocate --allow-unscanned`, gh unavailable in container;
 claim verified on `origin/issue-assignments`).
 **Branch**: `issue-4163-standalone-proto-chain-live` (pushed to `origin` =
@@ -10,11 +10,11 @@ upstream `loopdive/js2`). **PR**: to be opened by main agent — body below.
 
 ## PR title
 
-fix(#4163): make the standalone [[Prototype]] chain live for reassigned F.prototype (+95 on the 219-file ES5 lever)
+fix(#4172): make the standalone [[Prototype]] chain live for reassigned F.prototype (+95 on the 219-file ES5 lever)
 
 ## PR body
 
-Closes #4163. Largest single mechanism in the ES5 standalone tail (219 files,
+Closes #4172. Largest single mechanism in the ES5 standalone tail (219 files,
 `description:`-frontmatter census — see #4008's pickup notes, which this PR
 executes).
 

--- a/plan/agent-context/W2-prototype-chain.md
+++ b/plan/agent-context/W2-prototype-chain.md
@@ -1,0 +1,100 @@
+# W2 — prototype-chain lever: PR body + session notes
+
+**Agent**: `ttraenkler/W2-prototype-chain` · **Issue**: #4163 (allocated via
+`claim-issue.mjs --allocate --allow-unscanned`, gh unavailable in container;
+claim verified on `origin/issue-assignments`).
+**Branch**: `issue-4163-standalone-proto-chain-live` (pushed to `origin` =
+upstream `loopdive/js2`). **PR**: to be opened by main agent — body below.
+
+---
+
+## PR title
+
+fix(#4163): make the standalone [[Prototype]] chain live for reassigned F.prototype (+95 on the 219-file ES5 lever)
+
+## PR body
+
+Closes #4163. Largest single mechanism in the ES5 standalone tail (219 files,
+`description:`-frontmatter census — see #4008's pickup notes, which this PR
+executes).
+
+**Measured, CI-aligned shimmed instrument** (runtime-eval provider shim per
+`plan/agent-context/L2-array-exotic-define.md` §2):
+
+| 219-file lever list | pass |
+| --- | ---: |
+| `origin/main` @ 83e7c4db3 (A/B file-swap) | 0 |
+| this branch | **95** |
+
+0 regressions on the list; instrument verified responsive both directions
+(95→0 on revert-swap). Blast-radius: 773-file deterministic sample of
+`built-ins/Object/**` + `language/{expressions/new,arguments-object,
+statements/function}` OUTSIDE the lever list: [before/after — filled in below].
+Subsystem unit tests (2660/802/3468/4055/4161 families): 107/107 pass.
+
+The #2660 substrate (S1 escape gate, S2 per-fnctor prototype `$Object`, S3a
+`__object_create` reconstruction) already existed and classified the canonical
+repro `reconstruct` — three independent gaps kept the chain dead:
+
+1. **S3a G4 only accepted function-LOCAL externref bindings**
+   (`fnctorNewResultConsumedAsExternref`, new-super.ts). Top-level
+   `var child = new F()` — the dominant test262 shape — is a module-global
+   binding; widened to accept a module global whose ALLOCATED slot is
+   externref (same read-the-real-slot discipline as the local arm).
+2. **The prototype object itself compiled as a closed struct.** `var proto =
+   {foo: 1}` has no contextual type → closed struct → `__object_create(proto)`
+   seeds `$proto = null`. Fixed by marking proto-SOURCE literals (one-hop
+   identifier bindings flowing into `F.prototype = X` for gate-approved
+   fnctors, `Object.create(X)`, `setPrototypeOf(_, X)`, `__proto__ = X`) into
+   the existing #802 `ctx.dynamicProtoLiteralNodes` promotion
+   (scanForDynamicProto), and adding the MISSING third slot-typing consult in
+   declarations.ts `moduleInitForcesExternref` (module-global twin of the two
+   index.ts consults — the lockstep discipline requires all three).
+3. **Clause A missed the descriptor idiom.** `Object.defineProperty(obj, "p",
+   attr)` passes `attr` to a CONCRETELY-typed lib.d.ts param, so the
+   any/unknown-param check never fired → keep-static → struct. Added: any
+   argument of a builtin `Object.*`/`Reflect.*` call is a dynamic consumer.
+   Clause B (typed own-field ⇒ keep-typed) and the S3a lowering gate (empty
+   body, no args, externref slot) unchanged, so typed fnctors cannot be moved
+   off their struct.
+
+Plus the **#4008 "do not re-derive" prerequisite re-land**: `__desc_has_own`
+widened from HasOwnProperty to full §7.3.12 HasProperty — final arm delegates
+to `__extern_has` (registration moved after it for funcIdx ordering; bag-miss
+now falls through instead of answering 0). Measured +0 while the chain was
+dead; load-bearing now (probe: inherited `value`/`enumerable` on a
+`new Con()` descriptor argument now flow through
+`Object.defineProperty`).
+
+**Scope guard**: every widening stays behind the S1 (A)∧(B) gate — the #2660
+S2 header records a measured −40 standalone-floor cost for UNSCOPED
+interception; nothing here is unscoped. Host/gc lanes: all changed lowerings
+are `ctx.standalone`-gated; the classification widening only feeds
+standalone-gated consumers.
+
+**Deliberately left out** (follow-ups, same lever):
+- `Object.prototype.x = …` named-key visibility (12 files) — #4160's
+  proto-index store minus its integer-key gate (probe2 still red).
+- Builtin-prototype tests (`String.prototype` S15.5.3.1_A*, `Number.prototype`)
+  — different mechanism (builtin proto objects, not user fnctors).
+- `hasOwnProperty` returns i32 0/1 where sameValue(false) is asserted —
+  preexisting, orthogonal.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+---
+
+## Session notes (for the next agent on this lever)
+
+- Instrument: `.tmp/w2-{child.mts,run.mjs,probe.mts}` in the worktree
+  `/home/user/js2/.claude/worktrees/agent-a0ea534c6e5394997/` — verbatim from
+  L2's handoff (known-good, CI-aligned). Rebuild
+  `scripts/compiler-bundle.mjs` + refusal provider before every measurement.
+- Probes 1/1a/1b/1c/2/3/3b in `.tmp/` cover both shapes + the descriptor
+  idiom. probe2 (`Object.prototype.zzz`) is the remaining red one.
+- The #4008 trap is real: `gpo:true` while `in:false` was observed live
+  (probe2 output) — never trust the identity comparison.
+- Remaining-failure clusters on the lever list after this PR: 15 ×
+  override-of-inherited define (§8.12.9 step 1), 14 × `accessed !== true`
+  (accessor invocation), 8 × missing TypeError arms, 12 × Object.prototype
+  named keys, long tail builtin-proto.

--- a/plan/issues/4163-standalone-proto-chain-live.md
+++ b/plan/issues/4163-standalone-proto-chain-live.md
@@ -1,0 +1,89 @@
+---
+id: 4163
+title: "Standalone: make the [[Prototype]] chain LIVE for `new F()` with reassigned `F.prototype` (ES5 inherited-property family)"
+status: in-progress
+assignee: ttraenkler/W2-prototype-chain
+sprint: current
+created: 2026-08-06
+updated: 2026-08-06
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: prototype chain, constructor functions
+goal: standalone-gap
+related: [2660, 4008, 4055, 4160, 802]
+---
+
+# Standalone: make the [[Prototype]] chain LIVE for `new F()` with reassigned `F.prototype`
+
+## Problem
+
+**The largest single mechanism in the ES5 standalone tail — 219 files**
+(list: `.tmp/levers/W2-prototype-chain.txt`, derived from test262
+`description:` frontmatter, not error-string clustering; see the #4008
+pickup notes). Two shapes, one substrate gap:
+
+1. `new F()` with a REASSIGNED `F.prototype` does not link `[[Prototype]]`:
+
+   ```js
+   var proto = { foo: 1 };
+   var F = function () {};
+   F.prototype = proto;
+   var child = new F();
+   // standalone: "foo" in child === false, Object.getPrototypeOf(child) === proto === false
+   ```
+
+2. `Object.prototype.x = …` is invisible to every instance (12 files —
+   separate slice, #4160's proto-index store minus its integer-key gate).
+
+⚠ **Identity-without-liveness trap** (#4008 notes): `Object.getPrototypeOf({})
+=== Object.prototype` evaluates TRUE in standalone while the chain is dead.
+Probe with `in` or a property read, never the identity.
+
+## Root causes found (measured, 2026-08-06)
+
+The #2660 substrate (S1 escape gate, S2 per-fnctor prototype `$Object`, S3a
+`__object_create` reconstruction) already exists and the S1 gate classified the
+canonical repro `reconstruct` — but THREE independent gaps kept the chain dead:
+
+1. **S3a's G4 gate only accepted function-LOCAL externref bindings.**
+   `fnctorNewResultConsumedAsExternref` (new-super.ts) returned false for a
+   module-global binding — and top-level `var child = new F()` is the dominant
+   test262 shape. Widened to accept a module-global whose ALLOCATED slot is
+   externref.
+
+2. **The prototype OBJECT itself compiled as a closed struct.** `var proto =
+   {foo: 1}` (non-empty literal, no contextual type) takes the closed-struct
+   path, so `__object_create(proto)` seeds `$proto = (proto is $Object ? proto
+   : null)` → null. Fixed by marking proto-SOURCE literals (one-hop
+   identifier bindings flowing into `F.prototype = X` for approved fnctors,
+   `Object.create(X)`, `setPrototypeOf(_, X)`, `__proto__ = X`) into the
+   existing #802 `ctx.dynamicProtoLiteralNodes` promotion (scanForDynamicProto)
+   — literals.ts builds them as `$Object`, slot typing follows in lockstep.
+   Also added the MISSING third slot-typing consult: declarations.ts
+   `moduleInitForcesExternref` (the module-global twin of the two index.ts
+   consults).
+
+3. **Clause A missed the descriptor idiom.** `Object.defineProperty(obj, "p",
+   attr)` passes `attr` to a CONCRETELY-typed lib.d.ts param, so the
+   any/unknown-param dynamic-use check never fired → `keep-static` → struct
+   path. Added: any argument of a builtin `Object.*`/`Reflect.*` call is a
+   dynamic consumer (their standalone lowerings all consume via the externref
+   `$Object` runtime). Clause B (typed own-field ⇒ keep-typed) unchanged.
+
+Plus the **#4008 prerequisite re-land**: `__desc_has_own` widened from
+HasOwnProperty to full §7.3.12 HasProperty (final arm delegates to
+`__extern_has`, registered after it for funcIdx ordering). Measured +0 while
+the chain was dead; load-bearing now that it is live.
+
+## Acceptance
+
+- The four-line repros above resolve `in`/read/gpo correctly (probes 1, 1a-1c,
+  3, 3b in `.tmp/` — all verified 2026-08-06).
+- Measured pass-count gain on the 219-file lever list, 0 regressions on it.
+- Standalone floor / equivalence tests green (the #2660 S2 header records a
+  −40 floor cost for unscoped interception — every widening here stays behind
+  the S1 (A)∧(B) gate).

--- a/plan/issues/4163-standalone-proto-chain-live.md
+++ b/plan/issues/4163-standalone-proto-chain-live.md
@@ -28,6 +28,13 @@ loc-budget-allow:
   # registerDescriptorHasOwn moved after __extern_has (funcIdx ordering) +
   # rationale comment; the logic lives in carrier-bag-hasown.ts (not a god-file)
   - src/codegen/object-runtime.ts
+func-budget-allow:
+  # one predicate line + lockstep-rationale comment; the consult must live in
+  # moduleInitForcesExternref (nested closure of collectDeclarations)
+  - src/codegen/declarations.ts::collectDeclarations
+  # registerDescriptorHasOwn call relocation + rationale comment inside the
+  # ensure flow — the funcIdx-ordering constraint pins it to this position
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
 ---
 
 # Standalone: make the [[Prototype]] chain LIVE for `new F()` with reassigned `F.prototype`
@@ -91,6 +98,22 @@ Plus the **#4008 prerequisite re-land**: `__desc_has_own` widened from
 HasOwnProperty to full §7.3.12 HasProperty (final arm delegates to
 `__extern_has`, registered after it for funcIdx ordering). Measured +0 while
 the chain was dead; load-bearing now that it is live.
+
+## Measured (2026-08-06, CI-aligned shimmed instrument — see L2 handoff §2/§3)
+
+| | pass on the 219-file lever list |
+| --- | ---: |
+| origin/main (`83e7c4db3`), base files swapped in | **0 / 219** |
+| this branch | **95 / 219** |
+
+Delta **+95**, 0 regressions on the list. Instrument responsiveness verified in
+both directions (95 → 0 on revert-swap, 0 → 95 on restore). Remaining 124:
+15 × override-of-inherited define semantics (§8.12.9 step-1 refinements),
+14 × `accessed !== true` (accessor `this`-binding / invocation shapes),
+12-file `Object.prototype.x` named-key slice (probe2 — proto-index store minus
+its integer gate, follow-up), 8 × missing TypeError arms, plus a long tail of
+builtin-prototype (`String.prototype` S15.5.3.1_A*, `Number.prototype`) tests
+that are a DIFFERENT mechanism (builtin proto objects, not user fnctors).
 
 ## Acceptance
 

--- a/plan/issues/4163-standalone-proto-chain-live.md
+++ b/plan/issues/4163-standalone-proto-chain-live.md
@@ -15,6 +15,19 @@ area: codegen
 language_feature: prototype chain, constructor functions
 goal: standalone-gap
 related: [2660, 4008, 4055, 4160, 802]
+loc-budget-allow:
+  # clause-A widening belongs inside classifyUse's ladder — extracting one
+  # rung would split the single classification ladder #4123 unified
+  - src/codegen/fnctor-escape-gate.ts
+  # G4 module-global arm is the same slot-type check as the local arm and
+  # must read the ALLOCATED slot inside fnctorNewResultConsumedAsExternref
+  - src/codegen/expressions/new-super.ts
+  # one predicate line in moduleInitForcesExternref — the module-global twin
+  # of the two index.ts dynamicProtoLiteralNodes consults (lockstep set)
+  - src/codegen/declarations.ts
+  # registerDescriptorHasOwn moved after __extern_has (funcIdx ordering) +
+  # rationale comment; the logic lives in carrier-bag-hasown.ts (not a god-file)
+  - src/codegen/object-runtime.ts
 ---
 
 # Standalone: make the [[Prototype]] chain LIVE for `new F()` with reassigned `F.prototype`

--- a/plan/issues/4172-standalone-proto-chain-live.md
+++ b/plan/issues/4172-standalone-proto-chain-live.md
@@ -1,5 +1,5 @@
 ---
-id: 4163
+id: 4172
 title: "Standalone: make the [[Prototype]] chain LIVE for `new F()` with reassigned `F.prototype` (ES5 inherited-property family)"
 status: in-progress
 assignee: ttraenkler/W2-prototype-chain
@@ -35,6 +35,19 @@ func-budget-allow:
   # registerDescriptorHasOwn call relocation + rationale comment inside the
   # ensure flow — the funcIdx-ordering constraint pins it to this position
   - src/codegen/object-runtime.ts::ensureObjectRuntime
+# (#1930/#3273 oracle ratchet) dynamic-proto.ts: ctxChecker 0 -> 1.
+# NOT a hand-rolled checker query. The new proto-SOURCE detection calls the
+# EXISTING `resolveFnctorSymbol` (src/codegen/fnctor-escape-gate.ts:233), whose
+# signature is `(checker: ts.TypeChecker, calleeExpr)` and which is shared with
+# the #2660 escape gate — so the call site cannot avoid passing `ctx.checker`
+# without changing that shared helper's signature and every existing caller.
+# That refactor belongs with the gate it serves, not smuggled into a
+# behavioural slice; doing it here would widen this PR's blast radius across
+# the one subsystem whose S2 header records a measured -40 standalone-floor
+# cost for unscoped change. The gate is counting the reference, not new
+# vocabulary: total raw-checker QUERIES in the tree are unchanged.
+oracle-ratchet-allow:
+  - src/codegen/dynamic-proto.ts
 ---
 
 # Standalone: make the [[Prototype]] chain LIVE for `new F()` with reassigned `F.prototype`

--- a/src/codegen/carrier-bag-hasown.ts
+++ b/src/codegen/carrier-bag-hasown.ts
@@ -109,9 +109,11 @@ const BAG = 2;
  * if (__hasOwnProperty(obj, key)) return 1;          // never overridden
  * if (__is_closure_prop_carrier(obj)) {
  *   bag = __closure_bag_lookup(obj);                 // LOOKUP, never ensure
- *   if (bag != null && bag is $Object) return __obj_find(bag, key) != null;
+ *   if (bag != null && bag is $Object) {
+ *     if (__obj_find(bag, key) != null) return 1;    // (#4163) fall through on miss
+ *   }
  * }
- * return 0;
+ * return __extern_has(obj, key);                     // (#4163) §7.3.12 chain walk
  * ```
  *
  * The `__hasOwnProperty` call comes FIRST so every answer the existing helper
@@ -119,13 +121,25 @@ const BAG = 2;
  * answers `false` on, never an override. That ordering is what keeps this
  * additive rather than a redirection.
  *
+ * (#4163) The FINAL arm is the full ES §7.3.12 HasProperty — delegate to
+ * `__extern_has`, which walks the `$Object.$proto` chain (and the #4160
+ * prototype-index companions). ToPropertyDescriptor's field-presence step IS
+ * HasProperty, not HasOwnProperty: an INHERITED `enumerable`/`value`/… on a
+ * descriptor-argument object must be honored (the `Con.prototype = proto; new
+ * Con()` descriptor family). Prototype pollution was checked and is a
+ * non-issue: none of the six descriptor field names is reachable via `in` on
+ * any standalone plain object/array/function/RegExp/Date/Error/Arguments/
+ * wrapper receiver by default. This arm measured +0 while the #2660 chain was
+ * dead and is re-landed WITH the chain-liveness fix, where it is load-bearing
+ * (see plan/issues/4008-*.md "do not re-derive" note).
+ *
  * Returns the funcIdx, or `undefined` when a dependency is missing, in which
  * case callers keep using `__hasOwnProperty` directly.
  */
 export function registerDescriptorHasOwn(
   ctx: CodegenContext,
   registerNative: RegisterNative,
-  args: { hasOwnIdx: number; objFindIdx: number; objectTypeIdx: number },
+  args: { hasOwnIdx: number; objFindIdx: number; objectTypeIdx: number; externHasIdx?: number | undefined },
 ): number | undefined {
   const existing = ctx.funcMap.get(DESC_HAS_OWN);
   if (existing !== undefined) return existing;
@@ -179,7 +193,13 @@ export function registerDescriptorHasOwn(
                   { op: "call", funcIdx: args.objFindIdx },
                   { op: "ref.is_null" },
                   { op: "i32.eqz" },
-                  { op: "return" },
+                  // (#4163) HIT → 1; a bag MISS now falls through to the
+                  // §7.3.12 chain arm below instead of answering 0.
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+                  },
                 ],
               },
             ],
@@ -189,7 +209,15 @@ export function registerDescriptorHasOwn(
     );
   }
 
-  body.push({ op: "i32.const", value: 0 });
+  // (#4163) FINAL arm — full §7.3.12 HasProperty via `__extern_has` (own +
+  // carrier bag + `$proto` chain + #4160 companions). Registered after
+  // `__extern_has` precisely so this funcIdx is available; when it is not
+  // (dependency missing), keep the previous own-only 0 answer.
+  if (args.externHasIdx !== undefined) {
+    body.push({ op: "local.get", index: 0 }, { op: "local.get", index: 1 }, { op: "call", funcIdx: args.externHasIdx });
+  } else {
+    body.push({ op: "i32.const", value: 0 });
+  }
 
   return registerNative(
     DESC_HAS_OWN,

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1413,6 +1413,17 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
     // the null-access payload before strict [[Set]] can produce TypeError.
     if (!ctx.sourceIsModule && decl.initializer.kind === ts.SyntaxKind.ThisKeyword) return true;
     if (!ts.isObjectLiteralExpression(decl.initializer)) return false;
+    // (#802 Slice A / #4163) A proto-RECEIVER or proto-SOURCE object literal
+    // (marked by scanForDynamicProto, which runs before declaration collection)
+    // is built as an open `$Object` (externref) by the literals.ts routing —
+    // `$Object` is the only representation with a live `$proto` slot. The
+    // receiving module GLOBAL must be externref to match. This is the module-
+    // global twin of the hoistVarDecl / walkStmtForLetConst consults in
+    // index.ts; without it a top-level `var proto = {…}; F.prototype = proto`
+    // stored the `$Object` into a struct-typed global (or kept the closed
+    // struct), seeding `$proto = null` at `new F()` and killing every
+    // inherited read.
+    if (ctx.standalone && ctx.dynamicProtoLiteralNodes.has(decl.initializer)) return true;
     // (#3369) An untyped empty object literal is constructed by literals.ts as
     // a host `$Object` (`__new_plain_object`). Keep the module global on the
     // same externref representation unless a shape pre-pass deliberately

--- a/src/codegen/dynamic-proto.ts
+++ b/src/codegen/dynamic-proto.ts
@@ -79,6 +79,7 @@ import { nextModuleGlobalIdx } from "./registry/imports.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { undefinedExternInstrs } from "./any-helpers.js";
 import { INITIAL_CAP } from "./object-runtime.js";
+import { resolveFnctorSymbol } from "./fnctor-escape-gate.js"; // (#4163) proto-SOURCE marks
 
 const EXTERNREF: ValType = { kind: "externref" };
 
@@ -150,6 +151,43 @@ export function scanForDynamicProto(ctx: CodegenContext, root: ts.Node): void {
     // closed struct flowing in as `any` keeps today's behavior (spec §5).
   };
 
+  // (#4163) Mark a PROTO-SOURCE expression: an object that will BECOME a
+  // [[Prototype]] (the donor side — the receiver-side marks above are #802's).
+  // In standalone the proto-position natives (`__object_create`'s `$proto`
+  // seed, `__object_setPrototypeOf`, the #2660 S3a reconstruct seed) all
+  // require the proto value to be an open `$Object`; a closed-struct literal
+  // silently seeds `$proto = null` and the whole inherited-read chain is dead
+  // (probe: `var proto = {foo:1}; F.prototype = proto; new F()` — `"foo" in
+  // child` was false while `Object.getPrototypeOf(child) === proto` READ true,
+  // the #4163 identity-without-liveness trap). Marking the literal initializer
+  // into `ctx.dynamicProtoLiteralNodes` reuses the ENTIRE Slice-A promotion:
+  // literals.ts builds it as `$Object`, and variables.ts / index.ts type the
+  // binding slot externref in lockstep. Direct literal proto ARGS (e.g.
+  // `Object.create({...})`) already build as `$Object` via compileProtoArg /
+  // the S2 fnctor-prototype assign interception, so only the one-hop
+  // identifier-binding case needs the mark.
+  const markProtoSource = (srcRaw: ts.Expression): void => {
+    let src = srcRaw;
+    while (
+      ts.isAsExpression(src) ||
+      ts.isParenthesizedExpression(src) ||
+      ts.isNonNullExpression(src) ||
+      ts.isSatisfiesExpression(src) ||
+      ts.isTypeAssertionExpression(src)
+    ) {
+      src = src.expression;
+    }
+    if (!ts.isIdentifier(src)) return;
+    const init = ctx.oracle.variableInitializerOf(src);
+    if (process.env.JS2WASM_LOG_PROTO_SOURCE === "1") {
+      // eslint-disable-next-line no-console
+      console.error(`[#4163 proto-source] id=${src.text} init=${init ? ts.SyntaxKind[init.kind] : "none"}`);
+    }
+    if (init && ts.isObjectLiteralExpression(init)) {
+      ctx.dynamicProtoLiteralNodes.add(init);
+    }
+  };
+
   const visit = (node: ts.Node): void => {
     if (ts.isClassDeclaration(node) && node.name) {
       declaredClasses.add(node.name.text);
@@ -168,6 +206,19 @@ export function scanForDynamicProto(ctx: CodegenContext, root: ts.Node): void {
       node.arguments.length >= 1
     ) {
       markReceiver(node.arguments[0]!);
+      // (#4163) the PROTO argument is a proto-source.
+      if (node.arguments.length >= 2) markProtoSource(node.arguments[1]!);
+    }
+    // (#4163) Object.create(X, …) — X is a proto-source.
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === "Object" &&
+      node.expression.name.text === "create" &&
+      node.arguments.length >= 1
+    ) {
+      markProtoSource(node.arguments[0]!);
     }
     // X.__proto__ = _  (the §B.2.2.1 setter form; assignment.ts routes it to
     // the same helper)
@@ -179,6 +230,30 @@ export function scanForDynamicProto(ctx: CodegenContext, root: ts.Node): void {
       node.left.name.text === "__proto__"
     ) {
       markReceiver(node.left.expression);
+      // (#4163) the assigned value is a proto-source.
+      markProtoSource(node.right);
+    }
+    // (#4163) `F.prototype = X` for an APPROVED user fnctor (#2660 S2/S3a):
+    // the assigned object becomes the live `[[Prototype]]` seed of every
+    // reconstructed `new F()` instance, so a literal-initialized binding X
+    // must build as an open `$Object` — `__object_create` seeds `$proto =
+    // (proto is $Object ? proto : null)`, and a closed struct kills the chain.
+    // Gated on the S1 escape gate's approvedNames (the same scope the S2
+    // prototype interception and the S3a reconstruct use), so a keep-typed /
+    // keep-static fnctor's prototype binding keeps its representation — the
+    // #2660 S2 header records a measured −40 standalone-floor cost for an
+    // UNSCOPED interception here.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(node.left) &&
+      !ts.isPrivateIdentifier(node.left.name) &&
+      node.left.name.text === "prototype"
+    ) {
+      const sym = resolveFnctorSymbol(ctx.checker, node.left.expression);
+      if (sym && ctx.fnctorEscapeGate?.approvedNames.has(sym.name)) {
+        markProtoSource(node.right);
+      }
     }
     forEachChild(node, visit);
   };

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1137,22 +1137,36 @@ function flattenCallArgs(args: readonly ts.Expression[]): ts.Expression[] | null
  *       the REAL slot type — rather than re-deriving it from the TS annotation —
  *       is robust against every type-override in variables.ts and is exactly the
  *       value the result is `local.set` into.
+ *   (a') a MODULE-scope `var x = new F()` whose ALREADY-ALLOCATED module global
+ *       is externref (#4163). `collectDeclarations` registers module globals
+ *       (registerModuleGlobal) before any body compiles, so the slot type is
+ *       final here for the same reason (a)'s is. This is the dominant test262
+ *       shape — top-level `var child = new F()` in a script — which the
+ *       function-local-only check missed entirely, leaving the whole ES5
+ *       inherited-property family on the dead struct path.
  *   (b) an inline member/element receiver `new F().x` / `new F()[i]` (unwrapping
  *       `( )`/`as`/`!`): an externref receiver routes through the dynamic
  *       `__extern_get` + `$proto` walk — the resolution path we want.
- * Anything else (a struct-typed local, a module-global binding, a call argument,
- * a return, an assignment target) → false → status-quo struct lowering. The
- * conservative miss costs a row, never the floor.
+ * Anything else (a struct-typed local or global, a call argument, a return, an
+ * assignment target) → false → status-quo struct lowering. The conservative
+ * miss costs a row, never the floor.
  */
 function fnctorNewResultConsumedAsExternref(
-  _ctx: CodegenContext,
+  ctx: CodegenContext,
   fctx: FunctionContext,
   newExpr: ts.NewExpression,
 ): boolean {
   const declParent = newExpr.parent;
   if (ts.isVariableDeclaration(declParent) && declParent.initializer === newExpr && ts.isIdentifier(declParent.name)) {
     const localIdx = fctx.localMap.get(declParent.name.text);
-    if (localIdx === undefined) return false; // module-global binding → status quo
+    if (localIdx === undefined) {
+      // (a') module-global binding: accept iff the ALLOCATED global slot is
+      // externref (the untyped/`any` representation). A struct-typed or numeric
+      // global keeps status quo — returning externref into it would trap.
+      const globalIdx = ctx.moduleGlobals.get(declParent.name.text);
+      if (globalIdx === undefined) return false;
+      return ctx.mod.globals[localGlobalIdx(ctx, globalIdx)]?.type.kind === "externref";
+    }
     return getLocalType(fctx, localIdx)?.kind === "externref";
   }
   // Inline: unwrap `( )` / `as` / `!` between the new-expression and its consumer.

--- a/src/codegen/fnctor-escape-gate.ts
+++ b/src/codegen/fnctor-escape-gate.ts
@@ -454,6 +454,28 @@ function classifyUse(
   if (ts.isCallExpression(parent)) {
     const argIdx = parent.arguments.indexOf(useNode);
     if (argIdx >= 0) {
+      // (#4163) ANY argument of a builtin `Object.*` / `Reflect.*` namespace
+      // call is a DYNAMIC consumer: the standalone lowering of every such
+      // builtin consumes the value through the externref `$Object` runtime
+      // (descriptor field reads via `__desc_has_own`/`__extern_get`, proto
+      // seeds via `__object_create`, key walks, integrity checks …). The
+      // lib.d.ts parameter types are CONCRETE (`PropertyDescriptor`,
+      // `object`), so the any/unknown check below never fires for them, and
+      // the dominant test262 idiom — `Object.defineProperty(obj, "p", attr)`
+      // with `attr = new Con()` carrying INHERITED descriptor fields — was
+      // classified keep-static, leaving the instance a closed struct the
+      // descriptor reader cannot walk. Clause B (typed own-field consumer ⇒
+      // keep-typed) still applies unchanged, and the S3a lowering gate (empty
+      // body, no args, externref slot) is unaffected, so a typed fnctor
+      // cannot be moved off its struct by this widening.
+      const callee = parent.expression;
+      if (
+        ts.isPropertyAccessExpression(callee) &&
+        ts.isIdentifier(callee.expression) &&
+        (callee.expression.text === "Object" || callee.expression.text === "Reflect")
+      ) {
+        return "dynamic";
+      }
       const sig = checker.getResolvedSignature(parent);
       const paramSym = sig?.parameters[argIdx];
       if (paramSym) {

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -3061,18 +3061,9 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   emitHasOwn("__hasOwnProperty");
   emitHasOwn("__object_hasOwn");
 
-  // (#4055) ToPropertyDescriptor's HasProperty step, and ONLY it, must also see
-  // the #3468 closure own-property bag — a function used as a descriptor keeps
-  // its `value`/`enumerable`/… there, and gating each field on a bag-blind
-  // HasProperty yielded an empty descriptor with all-false defaults. Deliberately
-  // a separate native rather than a widening of `__hasOwnProperty`: #4017 tried
-  // the latter and cost 684 host-free passes via `propertyHelper.js`. See
-  // carrier-bag-hasown.ts.
-  registerDescriptorHasOwn(ctx, registerNative, {
-    hasOwnIdx: ctx.funcMap.get("__hasOwnProperty")!,
-    objFindIdx,
-    objectTypeIdx,
-  });
+  // (#4055/#4163) `registerDescriptorHasOwn` moved to AFTER the `__extern_has`
+  // registration below, so the §7.3.12 chain-walk arm can bake `__extern_has`'s
+  // funcIdx. See carrier-bag-hasown.ts.
 
   // ── __propertyIsEnumerable(externref obj, externref key) -> i32 (#2541) ─────
   //
@@ -3204,6 +3195,26 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       body,
     );
   }
+
+  // (#4055) ToPropertyDescriptor's HasProperty step, and ONLY it, must also see
+  // the #3468 closure own-property bag — a function used as a descriptor keeps
+  // its `value`/`enumerable`/… there, and gating each field on a bag-blind
+  // HasProperty yielded an empty descriptor with all-false defaults. Deliberately
+  // a separate native rather than a widening of `__hasOwnProperty`: #4017 tried
+  // the latter and cost 684 host-free passes via `propertyHelper.js`. See
+  // carrier-bag-hasown.ts.
+  // (#4163) Registered AFTER `__extern_has` so the widening to the full §7.3.12
+  // HasProperty (own + carrier bag + prototype chain) can delegate to it as the
+  // final arm — ToPropertyDescriptor's spec step IS HasProperty, and with the
+  // #2660 S3a chain now live (approved fnctor reconstruction + proto-source
+  // `$Object` promotion) an INHERITED descriptor field must be seen. Measured
+  // +0 while the chain was dead (per the #4008 pickup notes); load-bearing now.
+  registerDescriptorHasOwn(ctx, registerNative, {
+    hasOwnIdx: ctx.funcMap.get("__hasOwnProperty")!,
+    objFindIdx,
+    objectTypeIdx,
+    externHasIdx: ctx.funcMap.get("__extern_has"),
+  });
 
   // ── __to_primitive(externref input, externref hint) -> externref ─────────
   //


### PR DESCRIPTION
Closes #4172. Largest single mechanism in the ES5 standalone tail (219 files, `description:`-frontmatter census — see #4008's pickup notes, which this PR executes).

**Measured, CI-aligned shimmed instrument** (runtime-eval provider shim per `plan/agent-context/L2-array-exotic-define.md` §2, i.e. #4162):

| 219-file lever list | pass |
| --- | ---: |
| `origin/main` @ 83e7c4db3 (A/B file-swap) | 0 |
| this branch | **95** |

0 regressions on the list; instrument verified responsive **both directions** (95→0 on revert-swap). Blast radius — 773-file deterministic sample of `built-ins/Object/**` + `language/{expressions/new,arguments-object,statements/function}` **outside** the lever list: **560 → 562, 0 regressions, +2 incidental fixes**. Subsystem unit tests (2660/802/3468/4055/4161 families): 107/107.

## Root cause

The #2660 substrate (S1 escape gate, S2 per-fnctor prototype `$Object`, S3a `__object_create` reconstruction) already existed and classified the canonical repro `reconstruct`. Three independent gaps kept the chain dead:

1. **S3a G4 only accepted function-LOCAL externref bindings** (`fnctorNewResultConsumedAsExternref`, `new-super.ts`). Top-level `var child = new F()` — the dominant test262 shape — is a module-global binding; widened to accept a module global whose ALLOCATED slot is externref (same read-the-real-slot discipline as the local arm).
2. **The prototype object itself compiled as a closed struct.** `var proto = {foo: 1}` has no contextual type → closed struct → `__object_create(proto)` seeds `$proto = null`. Fixed by marking proto-SOURCE literals (one-hop identifier bindings flowing into `F.prototype = X` for gate-approved fnctors, `Object.create(X)`, `setPrototypeOf(_, X)`, `__proto__ = X`) into the existing #802 `ctx.dynamicProtoLiteralNodes` promotion (`scanForDynamicProto`), and adding the **missing third slot-typing consult** in `declarations.ts` `moduleInitForcesExternref` — the module-global twin of the two `index.ts` consults; the lockstep discipline requires all three.
3. **Clause A missed the descriptor idiom.** `Object.defineProperty(obj, "p", attr)` passes `attr` to a concretely-typed lib.d.ts param, so the any/unknown-param check never fired → keep-static → struct. Added: any argument of a builtin `Object.*`/`Reflect.*` call is a dynamic consumer. Clause B (typed own-field ⇒ keep-typed) and the S3a lowering gate (empty body, no args, externref slot) are unchanged, so typed fnctors cannot be moved off their struct.

Plus the **#4008 "do not re-derive" prerequisite re-land**: `__desc_has_own` widened from HasOwnProperty to full §7.3.12 HasProperty — final arm delegates to `__extern_has` (registration moved after it for funcIdx ordering; bag-miss now falls through instead of answering 0). L1 measured this at **+0 twice** while the chain was dead and correctly declined to ship it as unmeasured generality; it is load-bearing now (probe: inherited `value`/`enumerable` on a `new Con()` descriptor argument now flow through `Object.defineProperty`).

## Scope guard

Every widening stays behind the S1 (A)∧(B) gate — the #2660 S2 header records a measured **−40 standalone-floor** cost for unscoped interception, and nothing here is unscoped. Host/gc lanes: all changed lowerings are `ctx.standalone`-gated, and the classification widening only feeds standalone-gated consumers.

## Caveats for the merge

- The full local equivalence suite OOM'd (the known constrained-env limit). The 3 failures seen before the OOM — `logical-conditional-identity`, `void`-in-numeric-context — **reproduce identically with main's files**, so they are pre-existing. Scoped suites green. CI's `equivalence-gate` is the real check.
- The clause-A widening changes fnctor classification, so the **merge_group standalone floor is the authoritative validator**; the local 773-file sample says clean.

## Deliberately left out (follow-ups, same lever)

- `Object.prototype.x = …` named-key visibility (12 files) — #4160's proto-index store minus its integer-key gate (probe2 still red).
- Builtin-prototype tests (`String.prototype` S15.5.3.1_A*, `Number.prototype`) — a different mechanism (builtin proto objects, not user fnctors).
- `hasOwnProperty` returns i32 0/1 where `sameValue(false)` is asserted — pre-existing, orthogonal.

Remaining-failure clusters on the lever after this PR, for whoever continues: 15 × override-of-inherited define (§8.12.9 step 1), 14 × `accessed !== true` (accessor invocation), 8 × missing TypeError arms, 12 × `Object.prototype` named keys, long tail builtin-proto.

## Note on the issue id

Filed as #4172, not #4163 as the branch name suggests. Open PR #4124 hand-picked 4163–4171 without reserving any of them on `origin/issue-assignments`, so #4163 would have failed `check:issue-ids:against-open-prs` (as #4164 did on #4142). Branch name left alone — it is already pushed and CI-visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_