### PR TITLE
perf(#3926): hash dispatch in __extern_get — +4.1% acorn parse throughput, ships on

### DIFF
--- a/plan/issues/3926-extern-get-generic-property-lookup-cost.md
+++ b/plan/issues/3926-extern-get-generic-property-lookup-cost.md
@@ -1,7 +1,8 @@
 ---
 id: 3926
 title: "perf: `__extern_get` generic property lookup is the largest non-parser function in the standalone parse and is unowned"
-status: in-progress
+status: done
+completed: 2026-08-06
 assignee: ttraenkler/claude-fable
 sprint: current
 created: 2026-07-31
@@ -80,9 +81,72 @@ expensive".
 
 ## Acceptance criteria
 
-- [ ] An intra-function attribution for `__extern_get` on the standalone acorn
-      parse, naming which arm costs what.
-- [ ] Cache hit rate reported for the same workload.
-- [ ] Any lowering that lands is measured with a paired control on the
+- [x] An intra-function attribution for `__extern_get` on the standalone acorn
+      parse, naming which arm costs what. (Partial, by construction + paired
+      profile: the string-key SELECTION — length/c0 guard scan + in-bucket
+      `__str_equals` probes — was ~1.6pp of the 7.9% self-time plus 0.4pp of
+      out-of-line `__str_equals`; the remainder is the per-name receiver
+      `ref.test` arms, tombstone/numeric/front guards, the flatten call
+      (~3.0% out-of-line, unchanged), and the hash-table/proto walk. See
+      Results below.)
+- [ ] Cache hit rate reported for the same workload. (NOT measured — the
+      #4157 post-campaign profile re-scoped this issue to the hash-dispatch
+      lowering directly; the round-9b cache arm is untouched and still runs
+      ahead of the new dispatch.)
+- [x] Any lowering that lands is measured with a paired control on the
       standalone acorn parse, and reports binary-size cost alongside the win.
-- [ ] No standalone test262 regression.
+- [x] No standalone test262 regression. (Gated in the merge_group standalone
+      floor/net guards; local: 60 fnctor tests, 52 object-equivalence tests,
+      acorn dogfood 7/7 fixtures equal, standalone canaries 2/3/4/5 with
+      imports [] and exactly the 3 pre-existing IR-FALLBACKs.)
+
+## Results (2026-08-06, #3926 hash dispatch — branch `claude/issue-3926-extern-get-hash-dispatch`)
+
+**What landed.** `fillClosedStructExternGetArms` (src/codegen/object-runtime.ts)
+no longer selects the field-name probe by the #3673 length-bucket/first-char
+ladder. It now:
+
+1. flattens the key once (unchanged),
+2. reads the compile-time-baked FNV-1a hash from `$HashedString` field 3 —
+   one `struct.get` for every interned member-read key — falling back to one
+   `__obj_hash` call for plain `$NativeString` keys (which memoizes the hash
+   for next time),
+3. masks the hash and dispatches through ONE `br_table` over a power-of-two
+   bucket table at load factor ≤ 0.5 (nested-block tree; empty slots branch
+   straight past every arm),
+4. verifies inside the bucket with `__str_equals` exactly as before —
+   equality remains the arbiter, the hash only prunes; misses fall through to
+   the builtin-meta arm / `__obj_find` walk / proto chain unchanged.
+
+WHY this shape: the receiver-typing campaign left ~4,500 dynamic sites that
+must go through this helper, and the ladder scan (≈15 length compares + c0
+compares per lookup) was pure selection overhead the baked hash already paid
+for at compile time. Perfect hashing was considered and skipped — plain
+mask+verify measured well and keeps collisions correct by construction.
+
+**A/B, `benchmark:acorn:standalone-dynamic`, 3 interleaved pairs (file-copy):**
+
+| pair | base ratio | new ratio |
+| ---- | ---------- | --------- |
+| 1    | 0.11338    | 0.11727   |
+| 2    | 0.11423    | 0.12016   |
+| 3    | 0.11450    | 0.11886   |
+
+Base mean 0.11404 (σ≈0.0006), new mean 0.11876 (σ≈0.0015) → **+4.1%
+throughput**, min-new > max-base (non-overlapping). The profile's ceiling was
+~7.7% if the whole self-time vanished; ~4.1% is the realized share because
+selection was only part of the self-time (see attribution above).
+
+**`__extern_get` self-time** (named wasm profile, 30 parses, same box):
+7.91% → 6.33% (−20% relative); `__str_equals` 0.83% → 0.45%. The #4157
+"< 3%" target needs the remaining receiver-arm/flatten cost, not better key
+selection.
+
+**Binary size**: standalone acorn 868,088 → 870,089 B (**+2,001 B, +0.23%**);
+bench artifact 1,473,605 → 1,475,604 B (+1,999 B) — the br_table + block tree
+costs ~2 bytes/slot.
+
+**Ship decision: ON, no flag.** Standalone-only code path, correctness suites
+fully green, A/B clean and consistent, size cost trivial. Defensive
+degradation to a linear probe ladder exists only for the (unreachable) case
+of a missing `__obj_hash`/`$HashedString`.

--- a/plan/issues/3926-extern-get-generic-property-lookup-cost.md
+++ b/plan/issues/3926-extern-get-generic-property-lookup-cost.md
@@ -1,10 +1,13 @@
 ---
 id: 3926
 title: "perf: `__extern_get` generic property lookup is the largest non-parser function in the standalone parse and is unowned"
-status: ready
+status: in-progress
+assignee: ttraenkler/claude-fable
 sprint: current
 created: 2026-07-31
-updated: 2026-07-31
+updated: 2026-08-06
+loc-budget-allow:
+  - src/codegen/object-runtime.ts
 priority: high
 horizon: l
 feasibility: medium

--- a/plan/issues/4157-close-the-acorn-node-performance-gap.md
+++ b/plan/issues/4157-close-the-acorn-node-performance-gap.md
@@ -77,9 +77,14 @@ The gap decomposes into two unequal parts (#3780):
 
 ### Workstream 2 — JIT-class structural work (the ~3.5x residue)
 
-- [ ] **#3926 — `__extern_get` lookup cost**: perfect-hash / `br_table` the
+- [x] **#3926 — `__extern_get` lookup cost**: perfect-hash / `br_table` the
       key dispatch (today: 1,080 ifs, 463 `ref.test`, 303 `__str_equals`,
       zero `br_table`). Pays off on every read Workstream 1 does NOT convert.
+      → LANDED 2026-08-06: baked-hash + `br_table` bucket dispatch, +4.1%
+      `standaloneDynamic` (3 interleaved pairs, min-new > max-base), self-time
+      7.91% → 6.33%, +2,001 B. The residual self-time is receiver `ref.test`
+      arms + the per-lookup flatten, so the "< 3%" acceptance line below stays
+      open. Details in #3926's Results section.
 - [ ] **#3927 — per-shape fnctor splitting**: `Node` is a 292 B union struct
       for a 3-6 property object; #4074's declared-shape partition (acorn's
       own `.d.ts`, 83 interfaces) is the cheap partition signal. Bounded at

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -63,6 +63,7 @@ import { getFuncRefWrapperRootTypeIdx } from "./closures/funcref-wrapper-types.j
 import {
   ensureAnyToStringHelper,
   ensureNativeStringHelpers,
+  nativeStringLiteralHash,
   nativeStringLiteralInstrs,
   stringConstantExternrefInstrs,
 } from "./native-strings.js";
@@ -6857,89 +6858,119 @@ export function fillClosedStructExternGetArms(ctx: CodegenContext): void {
     return receiverArms;
   };
 
-  // (#3673) The key is flattened ONCE into a scratch local (its length into a
-  // second), and the arms are grouped into LENGTH BUCKETS: one inline length
-  // compare per distinct name length (~15 for acorn), each guarding the
-  // `__str_equals` probes of just that bucket. The old shape — a linear ladder
-  // with per-arm `flatten(key)` + equals call over one arm per distinct field
-  // name in the program (hundreds for acorn) — was the dominant cost of a
-  // standalone dynamic property read.
+  // (#3926) The key is flattened ONCE into a scratch local and dispatched by
+  // HASH, replacing #3673's length/first-char bucket ladder. Interned literal
+  // keys (every `obj.name` member read) carry a compile-time-baked FNV-1a hash
+  // in `$HashedString` field 3 (0 = uncomputed), so the common case pays one
+  // `struct.get`; any other key takes one `__obj_hash` call (which flattens
+  // memoized and writes the hash back for next time). The masked hash then
+  // indexes ONE `br_table` over the statically-known field-name buckets —
+  // O(1) selection instead of a linear scan over ~15 length guards + c0
+  // guards. Equality remains the arbiter: the hash only prunes, and every
+  // bucket still verifies with `__str_equals` (which itself fast-paths
+  // identity and hash-rejects collisions), so same-slot collisions and
+  // foreign keys landing in a live slot fall through exactly like a ladder
+  // miss — into the builtin-meta arm / `__obj_find` walk / proto chain below.
+  const objHashIdx = ctx.funcMap.get("__obj_hash");
   const fkeyLocal = 2 + fn.locals.length;
-  const fkeyLenLocal = fkeyLocal + 1;
-  const fkeyC0Local = fkeyLocal + 2;
+  const fkeyHashLocal = fkeyLocal + 1;
   fn.locals.push(
     { name: "__fkey_ladder", type: { kind: "ref_null", typeIdx: ctx.nativeStrTypeIdx } },
-    { name: "__fkey_len", type: { kind: "i32" } },
-    { name: "__fkey_c0", type: { kind: "i32" } },
+    { name: "__fkey_hash", type: { kind: "i32" } },
   );
-  const byLen = new Map<number, Map<number, Array<[string, Entry[]]>>>();
-  for (const [fieldName, entries] of byField) {
-    let lenGroup = byLen.get(fieldName.length);
-    if (!lenGroup) {
-      lenGroup = new Map();
-      byLen.set(fieldName.length, lenGroup);
-    }
-    const c0 = fieldName.length > 0 ? fieldName.charCodeAt(0) : -1;
-    let c0Group = lenGroup.get(c0);
-    if (!c0Group) {
-      c0Group = [];
-      lenGroup.set(c0, c0Group);
-    }
-    c0Group.push([fieldName, entries]);
-  }
+  const buildNameProbe = (fieldName: string, entries: Entry[]): Instr[] => [
+    { op: "local.get", index: fkeyLocal },
+    { op: "ref.as_non_null" },
+    ...nativeStringLiteralInstrs(ctx, fieldName),
+    { op: "call", funcIdx: equalsIdx },
+    { op: "if", blockType: { kind: "empty" }, then: buildReceiverArms(entries) },
+  ];
   const stringKeyArms: Instr[] = [
     { op: "local.get", index: 1 },
     { op: "any.convert_extern" },
     { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
     { op: "call", funcIdx: flattenIdx },
     { op: "local.tee", index: fkeyLocal },
-    { op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 0 },
-    { op: "local.tee", index: fkeyLenLocal },
-    // c0 = len > 0 ? data[off] : -1 — one array read per lookup, shared by
-    // every first-char sub-bucket guard below.
-    {
-      op: "if",
-      blockType: { kind: "val", type: { kind: "i32" } },
-      then: [
-        { op: "local.get", index: fkeyLocal },
-        { op: "ref.as_non_null" },
-        { op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 2 },
-        { op: "local.get", index: fkeyLocal },
-        { op: "ref.as_non_null" },
-        { op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 1 },
-        { op: "array.get_u", typeIdx: ctx.nativeStrDataTypeIdx },
-      ],
-      else: [{ op: "i32.const", value: -1 }],
-    },
-    { op: "local.set", index: fkeyC0Local },
   ];
-  for (const [len, lenGroup] of byLen) {
-    const lenBucket: Instr[] = [];
-    for (const [c0, c0Group] of lenGroup) {
-      const c0Bucket: Instr[] = [];
-      for (const [fieldName, entries] of c0Group) {
-        const receiverArms = buildReceiverArms(entries);
-        c0Bucket.push(
-          { op: "local.get", index: fkeyLocal },
-          { op: "ref.as_non_null" },
-          ...nativeStringLiteralInstrs(ctx, fieldName),
-          { op: "call", funcIdx: equalsIdx },
-          { op: "if", blockType: { kind: "empty" }, then: receiverArms },
-        );
-      }
-      lenBucket.push(
-        { op: "local.get", index: fkeyC0Local },
-        { op: "i32.const", value: c0 },
-        { op: "i32.eq" },
-        { op: "if", blockType: { kind: "empty" }, then: c0Bucket },
-      );
-    }
+  if (ctx.hashedStrTypeIdx < 0 || objHashIdx === undefined) {
+    // Defensive shape only — both are registered unconditionally whenever
+    // `__extern_get` itself is. Without a runtime hash for arbitrary (plain
+    // `$NativeString`) keys a hash dispatch would FALSE-MISS, so degrade to
+    // the plain linear probe ladder, which is dispatch-order-identical.
+    stringKeyArms.push({ op: "drop" });
+    for (const [fieldName, entries] of byField) stringKeyArms.push(...buildNameProbe(fieldName, entries));
+  } else {
+    // hash = flat is $HashedString ? flat.hash : 0 ; 0 (uncomputed) → one
+    // `__obj_hash` call. Low bits of the stored `(fnv & 0x7fffffff) | signbit`
+    // encoding equal the raw FNV low bits, so masking with tableMask needs no
+    // sign-bit normalization on either path.
     stringKeyArms.push(
-      { op: "local.get", index: fkeyLenLocal },
-      { op: "i32.const", value: len },
-      { op: "i32.eq" },
-      { op: "if", blockType: { kind: "empty" }, then: lenBucket },
+      { op: "ref.test", typeIdx: ctx.hashedStrTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "local.get", index: fkeyLocal },
+          { op: "ref.cast", typeIdx: ctx.hashedStrTypeIdx },
+          { op: "struct.get", typeIdx: ctx.hashedStrTypeIdx, fieldIdx: 3 },
+        ],
+        else: [{ op: "i32.const", value: 0 }],
+      },
+      { op: "local.tee", index: fkeyHashLocal },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "call", funcIdx: objHashIdx },
+          { op: "local.set", index: fkeyHashLocal },
+        ],
+      },
     );
+    // Power-of-two table at load factor ≤ 0.5 so most live slots hold exactly
+    // one name; the br_table cost is size-only (~2 bytes/slot), not time.
+    let tableSize = 4;
+    while (tableSize < byField.size * 2) tableSize *= 2;
+    const tableMask = tableSize - 1;
+    const buckets = new Map<number, Array<[string, Entry[]]>>();
+    for (const [fieldName, entries] of byField) {
+      const slot = nativeStringLiteralHash(fieldName) & tableMask;
+      let bucket = buckets.get(slot);
+      if (!bucket) {
+        bucket = [];
+        buckets.set(slot, bucket);
+      }
+      bucket.push([fieldName, entries]);
+    }
+    const orderedBuckets = [...buckets.entries()].sort((a, b) => a[0] - b[0]);
+    const bucketCount = orderedBuckets.length;
+    // br_table depth map: bucket ordinal j breaks out of the j-th nested
+    // block (landing on that bucket's probes); an empty slot takes depth
+    // `bucketCount` — the wrapper block — skipping every arm (a miss).
+    const targets: number[] = new Array<number>(tableSize).fill(bucketCount);
+    orderedBuckets.forEach(([slot], ordinal) => {
+      targets[slot] = ordinal;
+    });
+    let dispatchTree: Instr[] = [
+      { op: "local.get", index: fkeyHashLocal },
+      { op: "i32.const", value: tableMask },
+      { op: "i32.and" },
+      { op: "br_table", targets, defaultDepth: bucketCount },
+    ];
+    for (let ordinal = 0; ordinal < bucketCount; ordinal++) {
+      const probes: Instr[] = [];
+      for (const [fieldName, entries] of orderedBuckets[ordinal]![1])
+        probes.push(...buildNameProbe(fieldName, entries));
+      dispatchTree = [
+        { op: "block", blockType: { kind: "empty" }, body: dispatchTree },
+        ...probes,
+        // Probes exhausted without a hit: skip the outer buckets' probes. The
+        // last bucket falls through to the wrapper block end naturally.
+        ...(ordinal === bucketCount - 1 ? [] : ([{ op: "br", depth: bucketCount - 1 - ordinal }] satisfies Instr[])),
+      ];
+    }
+    stringKeyArms.push({ op: "block", blockType: { kind: "empty" }, body: dispatchTree });
   }
   const numericKeyArms: Instr[] = [];
   const i31NumericKeyArms: Instr[] = [];


### PR DESCRIPTION
## Description

Implements #3926, the top recommendation of the post-campaign CPU profile (#4157/PR #4143): the generic property-lookup function `__extern_get` now dispatches on a **hash of the key** instead of the length/first-char comparison ladder.

`fillClosedStructExternGetArms` (`src/codegen/object-runtime.ts`): read the compile-time-baked FNV-1a hash from `$HashedString` (one `struct.get` for every interned member-read key; one memoizing `__obj_hash` call for plain `$NativeString` keys) → mask → single `br_table` over power-of-two buckets at load factor ≤ 0.5 → `__str_equals` verifies inside the bucket. Equality remains the arbiter; collisions and foreign keys fall through to the builtin-meta arm / `__obj_find` / prototype walk **bit-identically**.

### Measured — the first non-null of the program

**A/B, 3 interleaved file-copy pairs on `standaloneDynamic`:**

| | ratios | mean | σ |
|---|---|---:|---:|
| base | 0.11338 / 0.11423 / 0.11450 | 0.11404 | 0.0006 |
| new | 0.11727 / 0.12016 / 0.11886 | **0.11876** | 0.0015 |

**+4.1% parse throughput, min-new > max-base** — clean separation, not a noise call.

Self-time (named wasm profile, 30 parses): `__extern_get` **7.91% → 6.33%**, `__str_equals` 0.83% → 0.45%. Realized 4.1% of the 7.7% ceiling because key *selection* was only part of the cost — the residual is receiver `ref.test` arms and the per-lookup flatten (~3%, untouched), so the umbrella's "< 3% self-time" acceptance line stays honestly open (and the flatten part is exactly #4174's territory, in progress).

Binary: +2,001 B (+0.23%).

### Ship decision: ON, no flag

Standalone-only path, suites fully green (fnctor 60/60, object equivalence 52/52, dogfood acorn 7/7 fixtures equal, canaries 2,3,4,5, imports [], exactly the 3 pre-existing IR fallbacks, plus a dedicated rope-key/miss/numeric/proto-walk probe passing on both variants), and a clean, consistent A/B on a measured hot function — this meets the umbrella's bar for a default-on change. All gates exit 0; loc-budget granted in the issue frontmatter. Issue file carries full results and `status: done`; the cache-hit-rate scope item is explicitly recorded as not measured (the profile re-scoped the issue to the lowering directly).

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_