### PR TITLE
docs(#4177): file the IR-first hard-fail on lattice-narrowed `+`

### DIFF
--- a/plan/issues/4177-ir-first-lattice-narrowed-plus-hard-fail.md
+++ b/plan/issues/4177-ir-first-lattice-narrowed-plus-hard-fail.md
@@ -1,0 +1,81 @@
+---
+id: 4177
+title: "IR-first hard-fails on lattice-narrowed `+`: selection claims a function off the fixpoint's f64 param fact, but from-ast `+` provability does not consume lattice facts"
+status: ready
+sprint: current
+created: 2026-08-06
+updated: 2026-08-06
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ir
+goal: backend-agnostic-ir
+related: [743, 4140, 2855, 1131]
+origin: "2026-08-06 — found twice independently during the #743 seeding slice; reproduced on untouched origin/main"
+---
+
+# #4177 — IR-first hard-fails on lattice-narrowed `+`
+
+## Problem
+
+Reproduced on untouched `origin/main`, standalone target, default IR-first:
+
+```ts
+function addOne(n) { return n + 1; }
+export function top(k: number): number { return addOne(k); }
+```
+
+hard-fails with **"'+' operands not provably both-number or both-string"**.
+
+The mechanism is a split-brain between two IR stages:
+
+- **Selection** admits `addOne` to the IR path because the interprocedural
+  fixpoint (`src/ir/propagate.ts`, #1131) proves `n: f64` from the single
+  call site (`k: number`).
+- **from-ast's `+` provability** then re-derives operand types WITHOUT
+  consuming the lattice's parameter facts — it sees an unannotated `n`,
+  cannot prove both-number, and hard-fails — after the legacy body was
+  already skipped, so there is no fallback.
+
+One stage claims the function *because of* a fact the next stage refuses to
+look at. Either from-ast must consume lattice param facts, or selection must
+not claim on facts from-ast will not honor.
+
+## Why it matters beyond the fixture
+
+- The shape (`untyped helper called from a typed caller`) is ubiquitous in
+  mixed TS/JS code and in every corpus the #743 program targets.
+- **It blocks #743 flag-on adoption**: both the call-site narrowing flag and
+  the `.d.ts` entrypoint-seeding flag (#4140) STEER MORE functions into this
+  trap — each new lattice fact widens selection's claims without widening
+  from-ast's provability. Recorded in #4140 as a reason its flag stays OFF.
+- Hard-fail (not fallback) means a compile that used to succeed via the
+  legacy body now fails outright — a regression class, not a perf issue.
+
+## Fix directions (price both; the first is likely right)
+
+1. **Feed lattice param facts into from-ast's provability** — the `TypeMap`
+   is already computed before body lowering; from-ast's `+` proof should
+   accept `param n` when the map's entry for the enclosing function types it
+   f64. Aligns the two stages on one source of truth.
+2. Alternatively, make selection's claim conditional on from-ast-provability
+   (claim only what the weaker prover can re-derive). Cheaper but entrenches
+   the weaker prover and forfeits fixpoint wins.
+
+## Acceptance criteria
+
+- [ ] The fixture above compiles standalone under default IR-first and
+      returns 43 for `top(42)`.
+- [ ] `JS2WASM_FNCTOR_CTOR_PARAM_TYPES=1` and `JS2WASM_DTS_ENTRYPOINT_SEEDS=1`
+      no longer steer additional functions into the trap (spot-check the
+      #4140 test fixtures flag-on).
+- [ ] The "#743 flag stays OFF" blockers list in #4140's notes is updated.
+- [ ] No `check:ir-fallbacks` unintended-bucket growth.
+
+## Also recorded nearby (separate defect, needs its own issue)
+
+`tests/issue-3486-fnctor-constructor-identity.test.ts` ("own fields and
+enumeration are untouched…") fails on untouched `origin/main` (`ownKeys`
+returns `''`) — unrelated mechanism, listed here only so it is not lost.


### PR DESCRIPTION
## Description

Docs-only: promotes a compiler failure — found twice independently during the type-seeding work and reproduced on untouched `main` — from a buried note inside #743's issue file to its own scheduled, trackable issue (#4177, id claimed on the assignments ledger).

The defect, plainly: the new compilation path's *selection* stage admits a function because the whole-program type solver proved its parameter is a number — but the *body-lowering* stage then re-derives types on its own, refuses to consult the solver's facts, can't prove the `+` is numeric, and **hard-fails after the old path's fallback was already skipped**. A two-line program (`function addOne(n) { return n + 1; }` called from a typed caller) fails to compile standalone.

Why it's scheduled `priority: high`: the shape (untyped helper called from typed code) is everywhere in mixed codebases, and this trap is the recorded reason both type-seeding switches must stay off — every new fact the solver learns widens the set of functions steered into the split-brain. Fix directions and acceptance criteria in the issue; the likely fix is making body-lowering consume the solver's parameter facts (one source of truth).

Also carries a pointer to a second, unrelated pre-existing red test on `main` (object-enumeration returning `''`) so it isn't lost, marked as needing its own issue.

## Testing

Docs-only — one file under `plan/issues/`. Id claimed and verified on `origin/issue-assignments` (4175/4176 were taken by other active lanes; the open-PR collision class from earlier today was checked against).

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_