### PR TITLE
docs(#4178): mixed-type ternary — IR bails, legacy fallback miscompiles concat (refutes the #3251 RESIDUAL BLOCKER framing)

### DIFF
--- a/plan/issues/4178-mixed-type-ternary-ir-bail-miscompiles-concat.md
+++ b/plan/issues/4178-mixed-type-ternary-ir-bail-miscompiles-concat.md
@@ -1,0 +1,178 @@
+---
+id: 4178
+title: "Mixed-type ternary: the IR path BAILS on differing arm types, and the legacy fallback then miscompiles string-concat of the result (§13.15.3) — sometimes it fails to compile at all"
+status: ready
+sprint: current
+created: 2026-08-06
+updated: 2026-08-06
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: ir, codegen, coercion
+language_feature: conditional-expression
+goal: core-semantics
+related: [2949, 2855, 3144, 1820, 3251, 1917, 2108]
+origin: "Isolated 2026-08-06 while chasing the '#3251 RESIDUAL BLOCKER' runtime-eval ternary report; that report's framing is REFUTED below."
+---
+
+# #4178 — mixed-type ternary: IR bails, legacy fallback miscompiles concat
+
+## The framing this REFUTES
+
+This was handed over as *"runtime-eval-consumer mode miscompiles mixed-type
+ternaries into an incoherent box"* — four readers disagreeing (`typeof` says
+`"string"`, `Number()` gives NaN, concat gives `"[object Object]"`, `String()`
+correct), flipped on by one line of `Function.prototype.call.bind(...)`, and
+recorded as such in `plan/issues/3251-array-descriptor-overlay-substrate.md`
+under `## RESIDUAL BLOCKER`.
+
+**Measured on `main` @ `f31a1c3e3e`, `--target standalone`, literal-JS
+`allowJs` lane. Almost none of that survives:**
+
+| claim | measured |
+| --- | --- |
+| runtime-eval-consumer only | **false** — reproduces with NO eval boundary at all |
+| `Function.prototype.call.bind(...)` flips the mode | **false** — that line does not set the eval-consumer flag; `evalConsumer=false` both with and without it, so the reported "control" and "trigger" were the same compile |
+| `typeof v` wrong | **false** — returns `"number"`, correct |
+| `Number(v)` NaN | **false** — returns the right number |
+| `String(v)` correct | true |
+| concat `"" + v` wrong | **TRUE — this is the whole bug** |
+
+A bare `var F = Function;` *does* set the eval-consumer flag (the module then
+imports `js2wasm:runtime-eval`), which is probably how eval-mode got implicated:
+the reporter was working inside propertyHelper-including tests, which are all
+eval consumers for an unrelated reason (#4162).
+
+## What actually breaks
+
+Only **string-concatenation of a mixed-type ternary result**:
+
+```js
+var n = 42;
+var v = true ? n : "s";     // arms: f64 vs string
+"" + v                      // WRONG
+String(v)                   // "42"  correct
+Number(v)                   // 42    correct
+typeof v                    // "number" correct
+```
+
+Measured matrix (1 = correct):
+
+| probe | result |
+| --- | --- |
+| `true ? num : "s"` then `"" + v` | **FAIL** |
+| `false ? num : "str"` then `"" + v` | **FAIL** (not branch-dependent) |
+| `v + ""` (operand order reversed) | **FAIL** |
+| `true ? str : "s"` — arms SAME type | pass |
+| `any` number + `""` with no ternary | pass |
+| plain local number + `""` | pass |
+| `String(v)` / `Number(v)` / `typeof v` on the mixed ternary | pass |
+
+So the corruption is specific to the **concat lowering reading a value produced
+by a demoted mixed-type ternary** — not to the ternary's value in general, and
+not to `any`-operand concat in general.
+
+## Root cause
+
+`lowerConditional` (`src/ir/from-ast.ts:8600`, throw at **:8647**):
+
+```ts
+if (!irTypeEquals(ttype, ftype)) {
+  throw new Error(`ir/from-ast: ternary branches have different types (…) in ${cx.funcName}`);
+}
+```
+
+#3144 already relaxed this for non-scalar arms of the *same* IrType. Genuinely
+mismatched arms still throw, which demotes the whole function to the legacy
+AST→Wasm path — and that path miscompiles the concat.
+
+**The demotion is also inconsistent, which is worse than either outcome alone.**
+Same mechanism, two different behaviours depending on surrounding syntax:
+
+- `return ("" + v) === "42" ? 1 : 0;` → compiles, returns the WRONG answer.
+- `var s = "" + v; if (s === "42") …` → **hard compile error**
+  `Codegen error: IR path failed for test: ir/from-ast: ternary branches have
+  different types (f64 vs string) [IR-FALLBACK]`.
+
+A user cannot tell which they will get.
+
+## Proposed fix (aligned with #2855)
+
+Do not bail. When the arms genuinely mismatch, **box both to `dynamic`** and
+give the `if`/`else` a dynamic result type. That is what the spec means by the
+result being an ordinary JS value, and it retires an IR fallback rather than
+widening one — the explicit #2855 direction.
+
+The primitive already exists: `IrFunctionBuilder.emitBox(value, toType)`
+(`src/ir/builder.ts:442`, #2949 S5.0), which erases a concrete value into a
+boxed-any carrier and supports a `JsTag` refinement.
+
+**Read this before starting.** `emitBox`'s own header states the S5.0 methods
+are *"byte-inert by construction … no producer calls them yet (from-ast/select
+unchanged)"*. Implementing this makes you **the first producer**, so the
+lowering path is unexercised in practice — budget for finding gaps there, and
+verify the emitted module rather than trusting that the builder accepts it.
+
+Constraints that fall out of the existing code:
+
+- Each `emitBox` must be emitted **inside its own arm's body buffer**
+  (`collectBodyInstrs`), or #1820's short-circuit guarantee breaks — that
+  regression is documented in the function's header (a `select`-based version
+  once caused non-termination on `n <= 1 ? 1 : n * fact(n-1)`).
+- `emitBox` throws if its operand is already dynamic (verifier R1), so box only
+  the non-dynamic side when one arm is already boxed.
+- Prefer a refined `irDynamic(JsTag.X)` where the arm's partition is statically
+  known — the builder header says lowering maps the refinement onto the
+  canonical boxing helper.
+
+## Measurable acceptance
+
+There is a **committed, ratchetable** test for this — better than any probe:
+
+`tests/equivalence/spec/coercion-arithmetic-add.test.ts` fails **8 of 20** on
+main, and all 8 are in `scripts/equivalence-baseline.json`'s `knownFailures`
+(one per lane × two cases):
+
+```
+coercion/arithmetic-add {host,host-O,standalone,standalone-O} any string + any string concatenates
+coercion/arithmetic-add {host,host-O,standalone,standalone-O} any string + any number concatenates (§13.15.3)
+```
+
+That is **8 of the 36 entries in the entire equivalence known-failures baseline
+— 22%**, one mechanism, failing in all four lanes including host. So this is
+not standalone-only.
+
+- [ ] The probe matrix above returns correct for all rows.
+- [ ] Neither demotion shape occurs: no `IR-FALLBACK` for a mixed-type ternary,
+      and no hard `Codegen error` for the `var s = "" + v` shape.
+- [ ] `pnpm run check:ir-fallbacks` shows the mixed-type-ternary rejection
+      bucket shrink; ratchet it with `--update-on-decrease`.
+- [ ] `scripts/equivalence-baseline.json` drops those 8 entries
+      (`equivalence-gate --update` reports them as "newly fixed").
+- [ ] No standalone-floor regression.
+
+## Size
+
+**Unmeasured — deliberately.** The handover claimed it caps every
+`propertyHelper` `verifyProperty(…, {writable: …})` because `isWritable`
+computes exactly this mixed-type ternary shape; that part is plausible and
+untested. A separate measurement found **739 ES5-label standalone failures live
+in eval-consumer modules**, but that is an upper bound on a *different*
+population and must not be read as this bug's yield — the eval-consumer
+correlation is now known to be incidental (see the refutation table).
+
+Whoever picks this up: measure the lever first, with the #4162 shim, before
+committing to a plan. Five of five levers this session had their framing
+refuted by the agent working them, and this issue is itself the sixth.
+
+## Notes
+
+- **Id provenance:** reserved via `claim-issue.mjs --allocate`. The open-PR scan
+  degraded (`gh` unavailable), so `--allow-unscanned` was used, and the id was
+  taken **above 4172** deliberately: open PR #4124 hand-picks 4163–4171 without
+  reserving any of them, which has already collided with two PRs (#4142, #4145).
+- The `## RESIDUAL BLOCKER` section in
+  `plan/issues/3251-array-descriptor-overlay-substrate.md` should be replaced by
+  a pointer here once this lands — it records the refuted framing.


### PR DESCRIPTION
Docs-only. Files #4178 and records a measured refutation of a handover that was about to send someone down the wrong path.

## What was handed over vs what is true

`plan/issues/3251-array-descriptor-overlay-substrate.md` `## RESIDUAL BLOCKER` describes *"runtime-eval-consumer mode miscompiles mixed-type ternaries into an incoherent box"* — four readers disagreeing, flipped on by one line of `Function.prototype.call.bind(...)`.

Measured on `main` @ `f31a1c3e3e`, `--target standalone`, literal-JS `allowJs` lane:

| claim | measured |
| --- | --- |
| runtime-eval-consumer only | **false** — reproduces with no eval boundary at all |
| `Function.prototype.call.bind(...)` flips the mode | **false** — that line does not set the flag; `evalConsumer=false` either way, so the reported "control" and "trigger" were the same compile |
| `typeof v` wrong | **false** — `"number"`, correct |
| `Number(v)` NaN | **false** — correct |
| concat `"" + v` wrong | **TRUE — this is the whole bug** |

A bare `var F = Function;` *does* set the flag, which is likely how eval-mode got implicated: the reporter was working inside propertyHelper-including tests, which are all eval consumers for an unrelated reason (#4162).

## Root cause

`lowerConditional` (`src/ir/from-ast.ts:8647`) throws when arm `IrType`s genuinely differ, demoting the function to the legacy AST→Wasm path, which miscompiles the concat. #3144 already relaxed this for same-`IrType` non-scalar arms.

The demotion is **inconsistent**, which is worse than either outcome alone — same mechanism, two behaviours depending on surrounding syntax:

- `return ("" + v) === "42" ? 1 : 0;` → compiles, **wrong answer**
- `var s = "" + v; if (s === "42") …` → **hard compile error** (`IR-FALLBACK`)

## Proposed fix, aligned with #2855

Box mismatched arms to `dynamic` via the existing `emitBox` (#2949 S5.0) instead of bailing — retiring a fallback rather than widening one. The issue records the three constraints that fall out of existing code (box inside each arm's body buffer or #1820's short-circuit guarantee breaks; `emitBox` rejects an already-dynamic operand; prefer a refined `JsTag`), plus the warning that `emitBox` has **no producers today**, so the implementer is the first and its lowering is unexercised.

## Why acceptance is unusually solid here

There is a **committed, ratchetable** artifact rather than a probe: `tests/equivalence/spec/coercion-arithmetic-add.test.ts` fails **8 of 20** on main, and those 8 are **22% of the entire equivalence known-failures baseline** (8 of 36) — one mechanism, all four lanes including host. A fix should let `equivalence-gate --update` report them as newly fixed.

## Size deliberately left unmeasured

The handover's "caps every `verifyProperty(…, {writable:…})`" is plausible and untested; the separate "739 ES5 failures in eval-consumer modules" figure is an upper bound on a *different* population and must not be read as this bug's yield, now that the eval correlation is known to be incidental. The issue says so explicitly, and tells whoever picks it up to measure the lever first with the #4162 shim.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_