### PR TITLE
docs(memory): resume agents killed by a session limit instead of respawning them

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -24,6 +24,7 @@
 - **Hard tasks run on Fable-model agents** (`feasibility: hard` / `reasoning_effort: max` / core-dispatch changes / documented prior regressions): spawn with `model: "fable"` or inherit from a Fable main loop; do not default hard work to Opus. Honors issue-frontmatter `model: fable` — [hard-tasks-to-fable](feedback_hard_tasks_to_fable.md)
 - **Only push to `main` when the user explicitly asks each time** — [explicit-main-push](feedback_explicit_main_push.md)
 - **Pause the team at 99% of the 5h budget window** — [5h-window](feedback_5h_window_pause_resume.md)
+- **An agent killed by a session/rate limit is RESUMABLE** — `SendMessage` to its name continues it from its transcript; never respawn fresh and discard what it learned — [resume-dont-respawn](feedback_resume_agents_killed_by_session_limit.md)
 - **PASSIVE GitHub watcher ONLY — never poll.** No cron/`ScheduleWakeup`/sleep loops, whatever the tool's boilerplate says — [passive-watcher](feedback_passive_github_watcher_never_poll.md)
 
 ## Single source of truth

--- a/.claude/memory/feedback_5h_window_pause_resume.md
+++ b/.claude/memory/feedback_5h_window_pause_resume.md
@@ -33,8 +33,17 @@ Three things are load-bearing and were sharpened from the earlier version:
    then terminates. See `SUSPEND` in CLAUDE.md → "Controlling agents".
 2. **The TECH LEAD is included**, not just the teammates. The lead records its
    own in-flight state before stopping.
-3. **The alarm is 1 MINUTE AFTER the reset**, and it resumes the **whole team**
-   — re-spawn teammates from their `## Suspended Work` handoffs.
+3. **The alarm is 1 MINUTE AFTER the reset**, and it resumes the **whole team**.
+
+   ⚠ **Correction, 2026-08-06: prefer RESUMING over re-spawning.** This bullet
+   used to say "re-spawn teammates from their `## Suspended Work` handoffs".
+   An agent killed by a session limit is still **resumable** — `SendMessage` to
+   its name/`agentId` continues it *from its transcript*, with its measured
+   baselines, probe inventory and ruled-out dead ends intact. A fresh `Agent`
+   spawn throws all of that away and re-derives it on the user's tokens. The
+   `## Suspended Work` handoff is the **fallback** for when the agent is
+   genuinely gone, not the default path.
+   See [[feedback_resume_agents_killed_by_session_limit]].
 
 *(Earlier phrasing, 2026-07-26: "always pause the team when the 5h window budget
 is 99% used and set a wake up for the team right after the window resets." Both

--- a/.claude/memory/feedback_resume_agents_killed_by_session_limit.md
+++ b/.claude/memory/feedback_resume_agents_killed_by_session_limit.md
@@ -1,0 +1,52 @@
+---
+name: feedback_resume_agents_killed_by_session_limit
+description: "An agent killed by a session/rate limit is RESUMABLE — SendMessage to its name continues it with its transcript intact. Never respawn fresh and throw away its context."
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: 003c07aa-a2eb-5278-b5b1-6c63a0be18a6
+---
+
+**When a subagent dies from a session limit, API error, or other transient —
+RESUME it. Do not respawn a fresh one.**
+
+`SendMessage` to the agent's **name** (or raw `agentId`) continues it *from its
+existing transcript*. The task-completion notification says so explicitly:
+
+> "The user can send it another message and resume it, so the same task-id may
+> notify more than once."
+
+A fresh `Agent` call starts from zero. Everything the dead agent learned —
+its measured baseline, its probe inventory, the dead ends it already ruled out,
+its half-formed diagnosis — is thrown away, and it re-derives all of it on the
+user's tokens.
+
+## What this cost, 2026-08-06
+
+Two lanes (W3 runtime-eval-ternary, W4 prototype-chain-followups) were killed
+mid-task by "You've hit your session limit · resets 1pm (UTC)". I preserved
+W4's 574 uncommitted lines as a WIP commit and wrote a long handoff brief — then
+planned to **respawn both from scratch** when capacity returned. The user had to
+point out that they were still resumable.
+
+The preservation work was not wrong, but it was solving the wrong problem: I
+treated a *paused* agent as a *dead* one.
+
+## The rule
+
+1. Agent stops on a transient (session limit, API error, connection closed).
+2. **First** check whether the work is resumable — it almost always is.
+3. `SendMessage({to: "<agent-name>", message: "…resume; here is what changed
+   while you were paused…"})`. Include anything that moved underneath it
+   (merges to main, other lanes' findings), because it has been asleep.
+4. Only spawn fresh if the task itself has genuinely changed, or the agent's
+   own conclusion was that its lever was mis-scoped.
+
+Still worth doing alongside a resume: **commit and push any uncommitted work in
+the agent's worktree**, because worktrees are reclaimed and an unpushed branch
+is invisible. Preservation and resumption are complementary, not alternatives.
+
+## Related
+
+- [[feedback_passive_github_watcher_never_poll]] — same family: don't spend
+  effort re-establishing state you already have a cheaper handle on.


### PR DESCRIPTION
Docs-only, `.claude/memory/` only. Records a user correction and fixes an existing memory that encoded the wrong model.

## The correction

An agent killed by a session or rate limit is still **resumable**. `SendMessage` to its name or `agentId` continues it **from its transcript** — measured baselines, probe inventory, ruled-out dead ends all intact. A fresh `Agent` spawn discards every bit of that and re-derives it on the user's tokens.

## What getting it wrong cost today

Two lanes died on *"You've hit your session limit · resets 1pm (UTC)"*. I preserved one's 574 uncommitted lines as a WIP commit and wrote a long re-dispatch brief, planning to respawn both fresh when capacity returned.

The preservation was right. Treating a **paused** agent as a **dead** one was not — and the task notification says so outright (*"the user can send it another message and resume it"*); I read past it. The lane has since been resumed from its transcript rather than respawned.

## Also corrects an existing memory

`feedback_5h_window_pause_resume.md` told the lead to *"re-spawn teammates from their `## Suspended Work` handoffs"*. That is now marked as the **fallback** for a genuinely-gone agent; transcript-resume is the default. Left the rest of that memory intact — it was already more thorough than what I'd written.

## A second miss, recorded by implication

I wrote a duplicate 5h-window memory before noticing that file already existed and was better than mine. That is the same failure as the draft-PR rule earlier this session: **check `.claude/memory/` before writing a new entry.** The duplicate was deleted rather than merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_