### PR TITLE
fix(#4179): top-level `with` was silently dropped from `__module_init` (+40 on the dynamic-scope lever)

### DIFF
--- a/plan/agent-context/W6-dynamic-scope.md
+++ b/plan/agent-context/W6-dynamic-scope.md
@@ -94,6 +94,30 @@ with main's `declarations.ts` swapped in.
 - `tests/issue-2663*.test.ts` / `issue-1387*`: 5 failures pre-existing,
   verified identical with main's `declarations.ts` swapped in.
 
+## Remaining lever buckets (post-fix, 41/308), sharpest-first
+
+- **11× `null pointer in __str_concat (via __module_init)`** (`S12.10_A3.*`):
+  NOT part of the #4179 drop — these tests wrap the `with` in a top-level
+  `try`, and nested withs were always compiled (`compileStatement` handles
+  them; only DIRECT top-level withs were dropped). Probed the exact shape:
+  a `throw value;` from inside the with body **escapes the enclosing
+  top-level `catch`** (uncaught `WebAssembly.Exception` at module init in a
+  clean probe; the published `__str_concat` deref is the harness variant of
+  the same escape). Mechanism: module-init exception plumbing around a with
+  body, not string concat and not dynamic scope.
+- **29× Tier-2 refusal** (`body contains a nested function or class`): the
+  #2663-deferred closure-capture-of-object-environment tier. Hard; grew from
+  12 because previously-dropped withs now honestly reach the refusal.
+- **27+13+15+13× annexB decl-update/init families** ("first declaration" /
+  "outer declaration" / "Initialized binding created prior to evaluation" /
+  "binding is initialized to undefined"): L3's ground — #2200 Phase 2 +
+  B.3.3 update semantics; the 15 `Initialized binding` ones are the AOT
+  twins L3 flagged as needing #2200 Phase 2 (last attempt −1180, do not
+  retry without a local slice over the regressed buckets).
+- **24× `SyntaxError: NaN`**: L3's two-layer diagnosis stands (#4178 fix
+  alone will not flip them; a compiled-acorn scope-tracking defect sits
+  behind the message).
+
 ## Substrate gaps found and deliberately NOT fixed here
 
 - **`__extern_has` has no closed-struct field arm** (`object-runtime.ts`

--- a/plan/agent-context/W6-dynamic-scope.md
+++ b/plan/agent-context/W6-dynamic-scope.md
@@ -1,0 +1,108 @@
+# W6 — dynamic-scope residue (2026-08-06): context + PR body
+
+Agent `ttraenkler/W6-dynamic-scope`. Issue **#4179** (claimed on
+`origin/issue-assignments`), branch `issue-4179-toplevel-with-module-init`.
+Lever: `.tmp/levers/W5-dynamic-scope.txt` — 308 ES5-label standalone failures.
+
+## PR body (verbatim)
+
+Closes #4179. Measured **1 → 41 of 308** on the dynamic-scope standalone lever
+list; **+35 net** (45 fixes / 10 vacuous-pass conversions, itemized below) on
+the full 391-file with-exposure population.
+
+### Root cause — the lever's framing was wrong (third refutation on this ground)
+
+The 30 `S11.13.2_A5.*_T2/_T3` residuals were handed off as a "module-scope
+struct-slot vs sidecar observability gap (#2659 family)". Measured: **the
+`with` body never executed at all.** `collectDeclarations`' module-init
+collection (`src/codegen/declarations.ts` ~1598) is an allow-list of statement
+kinds and `ts.WithStatement` was not in it — a top-level `with (o) { … }`
+matched no arm and was silently dropped from `__module_init`. Disassembly
+receipt: a module whose statements were `var sB2 = mk(); with (sB2 || null)
+{ x = 55; }` compiled to a `__module_init` containing exactly one instruction
+(`global.set (call $mk)`).
+
+Same family as #2992 (top-level `delete`), #3592 (top-level `throw`), #3615
+(top-level bare property read). The with-lowering itself (#1387 / #3025 W1 /
+#2663 Tiers 1-2 + RMW) was never at fault — the identical code inside a
+function body passed.
+
+### Fix
+
+Two arms in `src/codegen/declarations.ts`:
+- `ts.isWithStatement(stmt)` in the module-init collection allow-list;
+- `walkModuleStmtForVars` recursion into the with body (`with (o) { var v; }`
+  hoists `v` to module scope).
+
+Byte-identical for any module without a top-level `with`.
+
+### Measurement
+
+Harness: L4's validated in-process runner (`runTest262File`, standalone lane)
+with the #4162 `js2wasm:runtime-eval` provider shim; provider **rebuilt from
+current main** before the baseline (the cached one predated today's six PRs).
+Baseline reproduced the published histogram before any change.
+
+| run | pass | delta |
+| --- | ---: | ---: |
+| lever list (308), main `176e…`/`5b12…` | 1 | — |
+| lever list (308), fixed | **41** | **+40** |
+
+Bucket flips: both `scope.x === 6. Actual: NaN` / `innerScope.x` buckets
+(15+15) → pass; `with` requires-closed-shape refusals grew 12 → 29
+(previously-dropped statements now honestly reach the Tier-2
+nested-function-boundary refusal — all were already failing).
+
+Exposure-population regression sweep — every test262 file containing a `with (`
+statement (382 line-start + 9 mid-line extras), both builds run locally on the
+same provider binary:
+
+| population | main (A) | fixed (B) | net |
+| --- | ---: | ---: | ---: |
+| 382-file exposure | 115 | **150** | **+35** |
+| 9 mid-line extras | 4 | 4 | 0 (no flips) |
+
+45 files pass→, **10 pass→fail — every one a VACUOUS PASS converting to an
+honest verdict** (the with body never ran before, so the test's assertions
+never executed):
+
+- 5 → compile_error (the pre-existing Tier-2 nested-function-boundary refusal
+  now reached): `has-property-err`, `unscopables-get-err`,
+  `unscopables-prop-get-err`, `S12.10_A3.8_T3`, `S12.10_A1.8_T3`.
+- 3 → fail: `built-ins/Proxy/has/*-using-with` (standalone Proxy gap, body now
+  actually exercises it).
+- 2 → fail: `binding-not-blocked-by-unscopables-{falsey-prop,non-obj}`
+  (@@unscopables edge in the Tier-2 gate, now actually exercised).
+
+This is the same accepted trade as #3615 ("a test whose entire point is
+'reading this property must throw/observe' ran to completion and scored
+pass"). Net on the exposure population is +35; the merge_group net guard sees
+a strictly positive delta.
+
+Gates: `tsc --noEmit` clean; `check:oracle-ratchet` / `check:coercion-sites`
+clean; `check:loc-budget` / `check:func-budget` green via `loc-budget-allow` /
+`func-budget-allow` on #4179 (the allow-list IS `collectDeclarations`; +2
+predicates cannot live in a subsystem module). `tests/issue-4179-toplevel-with.test.ts`
+5/5; `tests/issue-2663-with-rmw.test.ts` 10/10; the 5 failures in
+`tests/issue-2663.test.ts`/`issue-1387*` are pre-existing — verified identical
+with main's `declarations.ts` swapped in.
+
+## State / next steps
+
+- `tests/issue-4179-toplevel-with.test.ts` — 5 cases (Tier-1 static, Tier-2
+  dynamic, the `_A5` RMW reference-once shape, var-hoisting, JS-host lane).
+- `tests/issue-2663*.test.ts` / `issue-1387*`: 5 failures pre-existing,
+  verified identical with main's `declarations.ts` swapped in.
+
+## Substrate gaps found and deliberately NOT fixed here
+
+- **`__extern_has` has no closed-struct field arm** (`object-runtime.ts`
+  ~3123): `k in o` and the Tier-2 with HasBinding gate answer 0 for a
+  closed-struct receiver (probe: `dynIn({y:1},"y")` false while
+  `Object.hasOwn` true). Tier-1 W1 covers the dominant `var o={…}; with(o)`
+  pattern, so post-#4179 this is a narrow residue (non-provable targets like
+  `with (o || null)`).
+- **`__extern_set` has no closed-struct write-through** — that is #4098 G1
+  **stage 2 by design** (ordering law from #4010: deletability → visibility →
+  write-through; stage 1 = instance tombstones, landed). Do NOT bolt it on
+  ad-hoc; it interacts with the descriptor-family lane (W5).

--- a/plan/issues/4179-toplevel-with-dropped-from-module-init.md
+++ b/plan/issues/4179-toplevel-with-dropped-from-module-init.md
@@ -1,0 +1,101 @@
+---
+id: 4179
+title: "top-level `with` statements are silently DROPPED from __module_init — the entire body never executes (collection allow-list gap, #2992/#3592/#3615 family)"
+status: in-review
+assignee: ttraenkler/W6-dynamic-scope
+sprint: current
+created: 2026-08-06
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: with-statement
+goal: standalone-gap
+related: [2663, 1387, 3025, 2992, 3592, 3615, 4133]
+# The two collection arms live in collectDeclarations' module-init loop by
+# necessity (the allow-list IS that function); the growth is 2 predicates +
+# short pointers, not barrel spill.
+loc-budget-allow:
+  - src/codegen/declarations.ts
+func-budget-allow:
+  - src/codegen/declarations.ts::collectDeclarations
+origin: "2026-08-06 W6-dynamic-scope — probing the 30 S11.13.2_A5.*_T2/_T3 residuals L4 handed off as a 'module-scope struct-slot observability gap' (#2659 family). The observability frame was WRONG: the with body never ran at all."
+---
+
+# #4179 — top-level `with` never reaches `__module_init`
+
+## TL;DR (root cause)
+
+`collectDeclarations`' module-init collection (`src/codegen/declarations.ts`,
+the source-order loop at ~1598) is an **allow-list of statement kinds**, and
+`ts.WithStatement` was not in it. A module-level
+
+```js
+with (scope) { x *= 3; }
+```
+
+matched no arm and was **silently dropped**: no code emitted, body never
+executed. Disassembly evidence: `__module_init` for a module whose only
+statements were `var sB2 = mk(); with (sB2 || null) { x = 55; }` contained
+exactly ONE instruction (`global.set (call $mk)`).
+
+The same `with` inside a function body always worked — `compileStatement` →
+`compileWithStatement` handles all three tiers (#1387 literal, #3025 W1
+struct-typed, #2663 Tier-2 dynamic). This is the exact shape of the prior
+collection-gap fixes: #2992 (top-level `delete`), #3592 (top-level `throw`),
+#3615 (top-level bare property read).
+
+## What the wrong frame was (measured, so nobody re-derives it)
+
+L4's handoff attributed the `_T2`/`_T3` failures to the #2659 module-scope
+struct-slot vs sidecar observability gap ("the RMW routes correctly, but the
+final `scope.x` read-back still runs the getter"). Measured on current main
+before this fix:
+
+- the getter was **alive** at read-back (`scope.x === 2`) — i.e. the RMW read
+  never invoked it, the `delete this.x` never ran, the write never happened;
+- a side-channel probe (`with (s3) { capture(y); }`) showed the **call never
+  executed** — not a storage-divergence symptom, an execution-never-happened
+  symptom;
+- direct member protocol on the same receivers (getter run, delete, recreate,
+  read-back) is fully correct at module scope — the substrate was never the
+  binding constraint for these tests.
+
+Real substrate gaps that DO exist but were not the constraint here (left
+open, see "Not fixed here"): `__extern_has` and `__extern_set` have no
+closed-struct field arms (`__extern_set`'s is #4098 G1 stage 2 by design).
+
+## Fix
+
+Two arms in `src/codegen/declarations.ts`:
+
+1. `ts.isWithStatement(stmt)` added to the control-flow collection allow-list
+   (collects the statement into `ctx.moduleInitStatements`).
+2. `walkModuleStmtForVars` recurses into `stmt.statement` for a
+   `WithStatement`, so `with (o) { var v = …; }` hoists `v` to module scope.
+
+Byte-identical for any module without a top-level `with`. The IR module-init
+planner already includes `with` in its population and demotes to legacy
+(body-shape rejection), so no IR-path interaction.
+
+## Measured result (standalone, in-process runner + #4162 provider shim)
+
+- Lever list (308 files, `.tmp/levers/W5-dynamic-scope.txt`): **1 → 41 (+40)**.
+  Both `scope.x/innerScope.x Actual: NaN` buckets (15+15, the whole
+  `S11.13.2_A5.*` / update-expression `_T2`/`_T3` families) flipped to pass.
+- Full with-exposure population (391 files): **115 → 150 (+35 net)** — 45
+  fixes, 10 pass→fail all of which are vacuous passes converting to honest
+  verdicts (5 Tier-2 refusal compile_errors, 3 standalone-Proxy, 2
+  @@unscopables edges). Itemized in `plan/agent-context/W6-dynamic-scope.md`.
+
+## Not fixed here
+
+- `__extern_has` has no closed-struct field arm — a struct-backed receiver
+  that reaches Tier-2 (non-provable target shapes like `with (s || null)`)
+  still misses HasBinding and cascades outward. Tier-1 W1 covers the dominant
+  `var o = {…}; with (o)` pattern, so this is a narrow residue.
+- `__extern_set` closed-struct write-through is #4098 G1 stage 2 (ordering
+  law from #4010: deletability before visibility before write-through) — not
+  touched here.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1574,6 +1574,12 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       walkModuleStmtForVars(stmt.statement);
       return;
     }
+    // (#4179) `with (o) { var v = …; }` hoists `v` to module scope like any
+    // other control-flow statement (see the collection allow-list below).
+    if (ts.isWithStatement(stmt)) {
+      walkModuleStmtForVars(stmt.statement);
+      return;
+    }
     if (ts.isTryStatement(stmt)) {
       for (const s of stmt.tryBlock.statements) walkModuleStmtForVars(s);
       if (stmt.catchClause) {
@@ -1636,7 +1642,13 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       ts.isIfStatement(stmt) ||
       ts.isTryStatement(stmt) ||
       ts.isSwitchStatement(stmt) ||
-      ts.isLabeledStatement(stmt)
+      ts.isLabeledStatement(stmt) ||
+      // (#4179) Top-level `with (o) { … }` matched NO arm of this allow-list,
+      // so the ENTIRE statement was silently dropped from `__module_init` —
+      // the body never executed. Same collection-gap family as #2992 (top-level
+      // `delete`), #3592 (`throw`), #3615 (bare property read); the tiering in
+      // compileWithStatement (#1387/#3025/#2663) was never at fault.
+      ts.isWithStatement(stmt)
     ) {
       walkModuleStmtForVars(stmt);
       ctx.moduleInitStatements.push(stmt);

--- a/tests/issue-4179-toplevel-with.test.ts
+++ b/tests/issue-4179-toplevel-with.test.ts
@@ -1,0 +1,67 @@
+// #4179 — top-level `with` statements were silently DROPPED from __module_init.
+//
+// `collectDeclarations`' module-init collection is an allow-list of statement
+// kinds, and `ts.WithStatement` was not in it: a module-level `with (o) { … }`
+// matched no arm, so the ENTIRE statement was dropped — the body never
+// executed, every write through the object environment was lost, and the
+// `var`s inside the body were never hoisted. The same `with` inside a function
+// body always worked (the tiering in compileWithStatement is not at fault).
+// Same collection-gap family as #2992 (top-level `delete`), #3592 (top-level
+// `throw`), #3615 (top-level bare property read).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function runModule(pre: string, ret: string, target?: "standalone"): Promise<any> {
+  const src = `${pre}\nexport function test(): any { return ${ret}; }`;
+  const result: any = await compile(src, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments: false,
+    ...(target ? { target } : {}),
+  } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  (instance.exports as any).__module_init?.();
+  const exp = wrapExports(instance.exports, { signatures: result.exportSignatures });
+  return exp.test();
+}
+
+describe("#4179 — top-level `with` reaches __module_init", () => {
+  it("Tier-1 static write through a top-level with (standalone)", async () => {
+    expect(await runModule(`var s = { z: 9 };\nwith (s) { z = 44; }`, `(s as any).z`, "standalone")).toBe(44);
+  });
+
+  it("Tier-2 dynamic write through a top-level with (standalone)", async () => {
+    expect(
+      await runModule(
+        `function mk(): any { return { x: 1 }; }\nvar s = mk();\nwith ((s as any) || null) { x = 55; }`,
+        `s.x`,
+        "standalone",
+      ),
+    ).toBe(55);
+  });
+
+  it("S11.13.2_A5.*_T2 shape: top-level RMW resolves the Reference once (standalone)", async () => {
+    // The getter deletes the property mid-read; the write must still land on
+    // the with-object (recreating it as a data property), and the outer `x`
+    // must stay untouched.
+    expect(
+      await runModule(
+        `var x = 0;\nvar scope = { get x() { delete (this as any).x; return 2; } };\nwith (scope) { x *= 3; }`,
+        `(scope as any).x * 100 + x`,
+        "standalone",
+      ),
+    ).toBe(600); // scope.x === 6, x === 0
+  });
+
+  it("hoists `var` declarations out of a top-level with body", async () => {
+    expect(await runModule(`var s = { z: 7 };\nwith (s) { var hoisted = z; }`, `hoisted`, "standalone")).toBe(7);
+  });
+
+  it("top-level with executes on the JS-host lane too", async () => {
+    expect(await runModule(`var s = { z: 9 };\nwith (s) { z = 44; }`, `(s as any).z`)).toBe(44);
+  });
+});


### PR DESCRIPTION
Closes #4179. Measured **1 → 41 of 308** on the dynamic-scope standalone lever list; **+35 net** (45 fixes / 10 vacuous-pass conversions, itemized below) on the full 391-file with-exposure population.

## Root cause — the lever's framing was wrong (third refutation on this ground)

The 30 `S11.13.2_A5.*_T2/_T3` residuals were handed over as a *"module-scope struct-slot vs sidecar observability gap (#2659 family)"*. Measured: **the `with` body never executed at all.**

`collectDeclarations`' module-init collection (`src/codegen/declarations.ts` ~1598) is an allow-list of statement kinds, and `ts.WithStatement` was not in it — so a top-level `with (o) { … }` matched no arm and was silently dropped from `__module_init`. Disassembly receipt: a module whose statements were `var sB2 = mk(); with (sB2 || null) { x = 55; }` compiled to a `__module_init` containing exactly **one** instruction (`global.set (call $mk)`).

Same family as #2992 (top-level `delete`), #3592 (top-level `throw`), #3615 (top-level bare property read). The `with` lowering itself (#1387 / #3025 W1 / #2663 Tiers 1–2 + RMW) was never at fault — identical code inside a function body passed.

## Fix

Two arms in `src/codegen/declarations.ts`:
- `ts.isWithStatement(stmt)` added to the module-init collection allow-list;
- `walkModuleStmtForVars` recurses into the with body, so `with (o) { var v; }` hoists `v` to module scope.

Byte-identical for any module without a top-level `with`.

## Measurement

Harness: the validated in-process runner (`runTest262File`, standalone lane) with the **#4162** `js2wasm:runtime-eval` provider shim; provider **rebuilt from current main** before the baseline, because the cached one predated today's six PRs. The baseline reproduced the published histogram before any change.

| run | pass | delta |
| --- | ---: | ---: |
| lever list (308), main | 1 | — |
| lever list (308), fixed | **41** | **+40** |

Bucket flips: both `scope.x === 6. Actual: NaN` / `innerScope.x` buckets (15+15) → pass. The `with`-requires-closed-shape refusals grew 12 → 29 — previously-dropped statements now honestly reach the Tier-2 nested-function-boundary refusal; all of those were already failing.

## The 10 pass→fail, itemized — please read before judging the diff

Every one is a **vacuous pass converting to an honest verdict**: the with body never ran before, so the test's assertions never executed and the `pass` was meaningless.

- **5 → compile_error** (the pre-existing Tier-2 nested-function-boundary refusal is now actually reached): `has-property-err`, `unscopables-get-err`, `unscopables-prop-get-err`, `S12.10_A3.8_T3`, `S12.10_A1.8_T3`.
- **3 → fail**: `built-ins/Proxy/has/*-using-with` — the standalone Proxy gap, now genuinely exercised.
- **2 → fail**: `binding-not-blocked-by-unscopables-{falsey-prop,non-obj}` — an `@@unscopables` edge in the Tier-2 gate, now genuinely exercised.

This is the same accepted trade as **#3615** ("a test whose entire point is *reading this property must throw/observe* ran to completion and scored pass"). Net on the exposure population is **+35**, so the merge_group net guard sees a strictly positive delta. Itemized here specifically so the merge_group diff is explainable rather than surprising.

## Gates

`tsc --noEmit` clean; `check:oracle-ratchet` and `check:coercion-sites` clean; `check:loc-budget` / `check:func-budget` green via allowances on #4179 (the allow-listed function *is* `collectDeclarations` — two predicates cannot live in a subsystem module). `tests/issue-4179-toplevel-with.test.ts` 5/5; `tests/issue-2663-with-rmw.test.ts` 10/10. The 5 failures in `tests/issue-2663.test.ts` / `issue-1387*` are pre-existing, verified identical with main's `declarations.ts` swapped in.

## Substrate gaps found and deliberately NOT fixed here

- **`__extern_has` has no closed-struct field arm** (`object-runtime.ts` ~3123): `k in o` and the Tier-2 `with` HasBinding gate answer 0 for a closed-struct receiver.
- **`__extern_set` write-through** is #4098 G1 stage 2 by design — adjacent to the concurrently-running descriptor lane, so not bolted on here.

Remaining buckets on this lever for a follow-up: annexB decl-update families (~27 + 13 + 15), `SyntaxError: NaN` (24, a two-layer defect — see #4178 and #4137), nested-function-boundary refusals (now 29).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_