### PR TITLE
perf(#4185): attribute the standalone 607k-allocation stream; kill the dead $ObjVec pairs on dynamic closure .call (−13.6% allocs/parse)

### DIFF
--- a/plan/issues/4185-standalone-alloc-stream-attribution.md
+++ b/plan/issues/4185-standalone-alloc-stream-attribution.md
@@ -1,0 +1,123 @@
+---
+id: 4185
+title: "perf: attribute standalone acorn's 607k-allocation stream; kill the top elidable stream (dead $ObjVec pairs on dynamic closure .call)"
+status: in-progress
+assignee: "ttraenkler/claude-fable-7"
+sprint: current
+created: 2026-08-06
+updated: 2026-08-06
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: performance
+area: codegen
+goal: performance
+related: [4157, 3927, 3921, 4173, 4174, 3685, 743]
+loc-budget-allow:
+  - src/codegen/closed-method-dispatch.ts
+func-budget-allow:
+  - src/codegen/closed-method-dispatch.ts::fillClosedMethodDispatch
+origin: "#4157 umbrella — GC/alloc bucket is 20.66% of parse self-time (largest); #3927's census counted 607,469 allocs/parse with only 32,468 attributed to __fnctor_Node"
+---
+
+# #4185 — attribute the standalone allocation stream, kill the top elidable one
+
+## Problem
+
+The GC bucket is the largest in the standalone acorn parse profile (20.66%
+post-#4174), and the #3927 census counted **607,469 allocations per parse** of
+which `__fnctor_Node` — the retained AST — is only 32,468 (5.3%). The other
+~575k were unattributed. Nobody knew what the compiler was allocating.
+
+## Mandate 1 deliverable — the attributed allocation table
+
+Census machinery extended (`src/codegen/alloc-census.ts`, all env-gated,
+byte-identical off): `JS2WASM_ALLOC_CENSUS_BY_FUNC=1` (per-function×type
+counters), `JS2WASM_ALLOC_CENSUS_FOCUS=<substr,…>` (type filter),
+`JS2WASM_ALLOC_CENSUS_CALLS=<substr,…>` (per-caller→callee call counters),
+plus a stderr shape/size report per counted type.
+
+> Implementation note (WHY, for the next census user): per-caller matching
+> MUST resolve callees through `ctx.funcMap`, not by position in
+> `ctx.mod.functions` + `numImportFuncs`. Bodies carry mint-time HANDLES that
+> the emitter resolves through the layout seam at encode time;
+> `ctx.numImportFuncs` is additionally stale after dead-import elimination
+> (reads 4 on a 0-import standalone module). Positional matching found 0 of
+> 261k measured calls; funcMap matching found all of them.
+
+Measured on main @ 431ea77d5, standalone-dynamic lane, optimize 4 (counts
+identical at optimize 0 — the census installs pre-wasm-opt), checksum 422×3
+intact, **614,820 allocations/parse** (drift from #3927's 607,469 is
+main-advance). Top 10 by count, with per-function and per-caller attribution:
+
+| count/parse | share | type (shape, est. bytes) | attributed to |
+| ---: | ---: | --- | --- |
+| 283,370 | 46.1% | `$AnyValue` (5 fields, ~32 B, transient) | `__any_from_extern` 261,362 — **100.0% called by `__extern_strict_eq`** (the #4173 stream); `__any_from_extern_honest` 20,454 (typed-this closures 18.7k + `__ir_dyn_string_replace` 1.7k); `__any_box_f64` 1,554 |
+| 57,973 | 9.4% | `$AnyString` header (3 fields, ~20 B) | `__str_substring` 30,449 (header-only view — no char copy), `__str_concat` 19,786, `__str_slice` 3,683, rest string runtime |
+| 41,811 | 6.8% | `$ObjVecArr` (externref array, cap 8 → ~40 B) | ALL in `__objvec_new`; callers: `__closure_method_call` 20,849 + `__call_m_call_2` 20,680 |
+| 41,811 | 6.8% | `$ObjVec` header (2 fields, ~16 B) | same — **two dead arg-vec pairs per dynamic closure `.call`** |
+| 33,761 | 5.5% | `__anon_14` (i32 array) | `__regexp_test_carrier` 29,117 (per-`.test` captures scratch), typed-this closure 4,291 |
+| 32,468 | 5.3% | `__fnctor_Node` (69 fields, 292 B, retained) | `__fnctor_Node_new` — the AST; demoted per #3927 §6 |
+| 31,415 | 5.1% | `__vec_externref` header (~16 B) | closure_550 17,091, `__call_fn_method_1` 5,160, `__fnctor_Scope_new` 4,125, `__vec_push` growth 2,970 |
+| 27,668 | 4.5% | `__str_data` (i16 array) | `__str_concat` 19,786 (real char copies), `__str_slice` 3,683, rest |
+| 27,361 | 4.5% | `__arr_externref` (backing arrays) | same producers as the vec headers |
+| 18,722 | 3.0% | `type_187` (2×i32+ref, ~20 B) | `__regex_run` — per-run engine state |
+
+Tail: `$DestructuringErrors` 7,252 (acorn's own per-`parseMaybeAssign`
+allocation — real program behavior), `$BoxedNumber` 3,862, `$ConsString`
+3,726, `$Scope` 1,375+4,125 vecs, object-runtime `$PropEntry`/`$PropMap`
+~1,900.
+
+**Reading of the table:**
+
+- The #1 stream (46%) is `__extern_strict_eq`'s operand boxing — **already
+  killed by in-flight #4173** (`JS2WASM_FAST_STRICT_EQ`, default ON, branch
+  `claude/issue-4173-boxed-strict-eq`). Not duplicated here.
+- The #1 **post-#4173 elidable** stream is the `$ObjVec` pair: 83.6k heap
+  objects (~2.3 MB) per parse, all dispatch plumbing for ~20.7k dynamic
+  `fn.call(this, x)` invocations (acorn's `update.call(this, prevType)` in
+  `updateContext`, per context-sensitive token), unpacked immediately by
+  `__apply_closure` and dead. Two pairs per call: `__call_m_call_2` packs all
+  args, `__closure_method_call`'s %Function.prototype.call% route re-packs
+  args minus thisArg.
+- `$AnyString` substring headers and `__str_data` concat copies are the string
+  VALUES themselves (not plumbing); `__fnctor_Node` is the retained AST
+  (#3927 demotion stands); the regexp streams (48k) are engine-internal
+  scratch — priced below, not taken in this slice.
+
+## Mandate 2/3 — the kill: closure-receiver fast `.call` arm
+
+`src/codegen/closure-call-fast.ts` + a one-call hook in
+`fillClosedMethodDispatch` (`closed-method-dispatch.ts`, +6 lines — hence the
+loc/func-budget allowances: the fill was exactly at both caps, and the
+arm-chain hook cannot live outside the arm-chain builder; the arm body itself
+is in the new file). Outermost arm in `__call_m_call_<K>` (K ≥ 1):
+
+1. receiver `ref.test` funcref-wrapper root (closures are
+   representation-disjoint from every other arm's receiver);
+2. own-prop `call` override guard via `__extern_get` + `__nullish_to_null` —
+   the same §10.2 [[Get]] precedence check `__closure_method_call` route 1
+   performs (an override falls through to the legacy chain and still wins);
+3. under-application gate: declared `$arity ≤ K−1`, because
+   `__call_fn_method_N` carries only closures with formals ≤ N and the
+   missing-arg padding lives in `__apply_closure`'s #3592 widening (silent
+   vacuous-undefined hazard otherwise — the 9th-dogfood-wall class);
+4. then direct `__call_fn_method_(K−1)(thisArg, fn, a…)` with argc
+   preset/reset — byte-for-byte the #3673 round-13 cached-direct-call idiom.
+
+Zero allocations on the fast path (WAT-verified: no `objvec_new`; legacy chain
+intact in the else-arm). Flag `JS2WASM_FAST_CLOSURE_CALL`, `=0` restores the
+legacy-only dispatcher. Vararg `.call(...xs)`, `.apply`, arity-0 `.call()`,
+non-closure receivers: unchanged legacy path.
+
+## Acceptance criteria
+
+- [x] Top-10 attribution table with counts × size × producer × caller (above)
+- [x] Mechanism WAT-verified before measurement
+- [ ] Census A/B: `$ObjVec` allocations collapse on the standalone acorn parse
+- [ ] Profile bucket + wall A/B with order-reversal controls (#3927 §6 rules)
+- [ ] Semantics pinned: this-binding, under/over-application, own-prop
+      override, flag-off parity
+- [ ] Dogfood canaries 2/3/4/5, `functionImports: []`, 3 pre-existing
+      IR-FALLBACKs unchanged

--- a/plan/issues/4185-standalone-alloc-stream-attribution.md
+++ b/plan/issues/4185-standalone-alloc-stream-attribution.md
@@ -1,7 +1,7 @@
 ---
 id: 4185
 title: "perf: attribute standalone acorn's 607k-allocation stream; kill the top elidable stream (dead $ObjVec pairs on dynamic closure .call)"
-status: in-progress
+status: done
 assignee: "ttraenkler/claude-fable-7"
 sprint: current
 created: 2026-08-06
@@ -111,13 +111,100 @@ intact in the else-arm). Flag `JS2WASM_FAST_CLOSURE_CALL`, `=0` restores the
 legacy-only dispatcher. Vararg `.call(...xs)`, `.apply`, arity-0 `.call()`,
 non-closure receivers: unchanged legacy path.
 
+## Results — 2026-08-06
+
+### Census A/B (deterministic; the primary evidence)
+
+Standalone-dynamic acorn, checksum 422×3 intact both sides:
+
+| | flag OFF (legacy) | flag ON | delta |
+| --- | ---: | ---: | ---: |
+| total allocations/parse | 614,820 | **531,424** | **−83,396 (−13.6%)** |
+| `$ObjVec` pairs/parse | 41,811 + 41,811 | 113 + 113 | **−99.7%** |
+| every other stream | — | unchanged (e.g. `$AnyValue` 283,370 both sides) | isolation clean |
+
+Binary 1,479,679 → 1,479,820 B (+141 B).
+
+### Profile bucket A/B (300 parses each, order-reversed pairs)
+
+| bucket | pair 1 ON→OFF | pair 2 OFF→ON (control) |
+| --- | --- | --- |
+| call-dispatch | 8.53 / 11.06 (**−2.5pp**) | 9.34 / 10.82 (**−1.5pp**) |
+| gc-engine | 21.83 / 17.56 (contaminated — see below) | 17.10 / 17.82 (−0.7pp) |
+
+`__extern_method_call`'s 1.89% self-time frame is GONE from both ON profiles
+(the ladder truly dies). Call-dispatch −2.0pp mean, consistent in BOTH orders
+— the trustworthy profile finding. **The pair-1 gc reading (21.83% ON) is a
+§3927-§6-class contamination artifact**: mechanism-inconsistent (removing 83k
+allocs cannot raise GC share 4pp), and the order-reversal control read
+17.10 ON vs 17.82 OFF. Recorded because it would have flipped the verdict if
+the control hadn't been run — the §6 lesson held again, in the other
+direction.
+
+### Wall A/B (back-to-back pairs, both orders; shared box, other lanes active)
+
+| pair | order | ON wasmUs | OFF wasmUs | within-pair |
+| --- | --- | ---: | ---: | ---: |
+| 1 (under profiler) | ON→OFF | 161,386 | 163,019 | −1.0% |
+| 2 (under profiler) | OFF→ON | 155,264 | 168,159 | −7.7% |
+| 3 (plain) | ON→OFF | 164,346 | 176,672 | −7.0% |
+| 4 (plain) | OFF→ON | 167,238 | 171,208 | −2.3% |
+
+4/4 pairs favor ON, both orders represented; pooled mean 162,059 vs 169,765
+(**−4.5%**). Each individual pair is below this box's ~10% resolvability bar
+(§6); the claim rests on 4/4 order-balanced consistency + the deterministic
+census + the both-orders call-dispatch drop, not on any single wall number.
+
+### Flag decision
+
+`JS2WASM_FAST_CLOSURE_CALL` ships **default ON**: allocation kill is
+deterministic and isolated, the dispatch-ladder removal is profile-verified in
+both orders, wall is 4/4 positive, and every guard that could change
+semantics routes back to the byte-equivalent legacy chain (`=0` restores the
+legacy-only dispatcher).
+
+### Semantics findings
+
+- Own-`call` override via **dynamic** member write is honored on both paths
+  (1005 — the §10.2 guard works; pinned).
+- Own-`call` override via **static** assignment (`real.call = …` at top
+  level) is ignored by BOTH paths (answers 6; Node answers 1005) — a
+  **pre-existing gap**, not an arm regression: the static assignment never
+  reaches the closure side bag that `__extern_get` reads. Pinned as parity so
+  a future side-bag fix updates both paths together.
+
+### What was priced and NOT taken (for the next #4157 slice)
+
+Post-#4173+#4185, the remaining allocation streams by count: `$AnyString`
+substring/concat headers 58k (the string VALUES — not plumbing, not elidable),
+`__regexp_test_carrier` captures scratch 29k + `__regex_run` state 18.7k
+(engine-internal; a test-only scratch-captures reuse is plausible but touches
+the regex engine — priced M, not taken here), `__vec_externref` closure arg
+vecs ~25k spread across `__closure_550`/`__call_fn_method_1`/`Scope_new`
+(spread wide, no single chokepoint), `__fnctor_Node` 32.5k retained (#3927
+demotion stands), `$AnyValue` residual ~22k (honest-boxing via typed-this
+reads — #3685/#743 territory).
+
+### Gates (all by exit code, 0 unless noted)
+
+tsc 0 · biome lint 0 · oracle-ratchet 0 · loc-budget 0 (granted:
+closed-method-dispatch.ts +6) · func-budget 0 (granted:
+`fillClosedMethodDispatch` +5 — the fill was exactly at cap; the arm body
+lives in the new file) · dead-exports 0 · coercion-sites 0 · stack-balance 0
+· check:ir-fallbacks 0 · prettier 0. Suites: issue-4185 7/7, #3673
+closure-call/apply + #4096 21/21, #4155 Phase 0+2+provenance 25/25, #2660
+fnctor 54/54. Dogfood canaries 2/3/4/5, `functionImports: []`, exactly the 3
+pre-existing IR-FALLBACKs (typeIdx parity on parse/parseExpressionAt/
+tokenizer).
+
 ## Acceptance criteria
 
 - [x] Top-10 attribution table with counts × size × producer × caller (above)
 - [x] Mechanism WAT-verified before measurement
-- [ ] Census A/B: `$ObjVec` allocations collapse on the standalone acorn parse
-- [ ] Profile bucket + wall A/B with order-reversal controls (#3927 §6 rules)
-- [ ] Semantics pinned: this-binding, under/over-application, own-prop
-      override, flag-off parity
-- [ ] Dogfood canaries 2/3/4/5, `functionImports: []`, 3 pre-existing
+- [x] Census A/B: `$ObjVec` allocations collapse (−99.7%, isolation clean)
+- [x] Profile bucket + wall A/B with order-reversal controls (#3927 §6 rules)
+- [x] Semantics pinned: this-binding, under/over-application, own-prop
+      override (dynamic honored; static = pre-existing gap pinned as parity),
+      flag-off parity
+- [x] Dogfood canaries 2/3/4/5, `functionImports: []`, 3 pre-existing
       IR-FALLBACKs unchanged

--- a/src/codegen/alloc-census.ts
+++ b/src/codegen/alloc-census.ts
@@ -31,15 +31,59 @@
  * measurement build, and the quantity it measures is deterministic, so it does
  * not compete with the timing benchmarks.
  */
-import type { Instr } from "../ir/types.js";
+import type { Instr, TypeDef, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { walkChildren } from "./walk-instructions.js";
 
 /** Export-name prefix for a per-type counter. */
 export const ALLOC_CENSUS_PREFIX = "__alloc_count_";
 
+/** (#4185) Export-name prefix for a per-(caller→callee) call counter. */
+export const CALL_CENSUS_PREFIX = "__call_census_";
+
 export function allocCensusEnabled(): boolean {
   return process.env.JS2WASM_ALLOC_CENSUS === "1";
+}
+
+/**
+ * (#4185) When set alongside `JS2WASM_ALLOC_CENSUS=1`, the per-type counters
+ * become per-(function × type) counters — attributing each allocation to the
+ * defined function whose body contains the `struct.new`/`array.new`. This is
+ * how a census whose top type is allocated inside shared helper functions
+ * (`__any_box_*` for `$AnyValue`) gets its first level of attribution.
+ */
+function allocCensusByFunc(): boolean {
+  return process.env.JS2WASM_ALLOC_CENSUS_BY_FUNC === "1";
+}
+
+/**
+ * (#4185) Comma-separated substrings limiting which allocated types get
+ * counters (matched against the census export name, e.g. `type_75` or
+ * `__fnctor_Node`). Unset = all. BY_FUNC mode without a focus can create
+ * thousands of exported globals; focusing keeps the measurement build sane.
+ */
+function allocCensusFocus(): string[] {
+  const raw = process.env.JS2WASM_ALLOC_CENSUS_FOCUS;
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * (#4185) Comma-separated substrings. Every direct `call`/`return_call` to a
+ * defined function whose name contains one of them gets a per-(caller, callee)
+ * exported counter — the second attribution level: WHO calls the allocating
+ * helpers. Self-gated; usable with or without the per-type census.
+ */
+function callCensusTargets(): string[] {
+  const raw = process.env.JS2WASM_ALLOC_CENSUS_CALLS;
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
 }
 
 /** The allocation opcodes worth counting — every WasmGC heap producer. */
@@ -72,30 +116,191 @@ function censusName(ctx: CodegenContext, typeIdx: number): string {
  * frozen import index space.
  */
 export function installAllocCensus(ctx: CodegenContext): void {
-  if (!allocCensusEnabled()) return;
+  if (allocCensusEnabled()) installTypeCensus(ctx);
+  installCallCensus(ctx);
+}
 
+function installTypeCensus(ctx: CodegenContext): void {
   // Pass 1 — which types are actually allocated anywhere. Allocating a global
   // per declared type would bloat a module whose type table is mostly cold.
   const allocated = new Set<number>();
   for (const fn of ctx.mod.functions) collectAllocatedTypes(fn.body, allocated);
+  const focus = allocCensusFocus();
+  if (focus.length > 0) {
+    for (const typeIdx of [...allocated]) {
+      if (!focus.some((f) => censusName(ctx, typeIdx).includes(f))) allocated.delete(typeIdx);
+    }
+  }
   if (allocated.size === 0) return;
 
-  // Pass 2 — one exported mutable counter per allocated type.
-  const globalIdxByType = new Map<number, number>();
+  // Shape report — the census export names carry only the type NAME; the
+  // reader needs the per-instance size to turn counts into bytes. stderr so a
+  // harness capturing stdout for counts is undisturbed.
   for (const typeIdx of [...allocated].sort((a, b) => a - b)) {
-    const globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
-    ctx.mod.globals.push({
-      name: censusName(ctx, typeIdx),
-      type: { kind: "i32" },
-      mutable: true,
-      init: [{ op: "i32.const", value: 0 }],
-    });
-    ctx.mod.exports.push({ name: censusName(ctx, typeIdx), desc: { kind: "global", index: globalIdx } });
-    globalIdxByType.set(typeIdx, globalIdx);
+    process.stderr.write(`[alloc-census] ${censusName(ctx, typeIdx)}: ${typeShapeSummary(ctx, typeIdx)}\n`);
   }
 
-  // Pass 3 — splice the increments in.
-  for (const fn of ctx.mod.functions) instrumentBody(fn.body, globalIdxByType);
+  if (!allocCensusByFunc()) {
+    // Pass 2 — one exported mutable counter per allocated type.
+    const globalIdxByType = new Map<number, number>();
+    for (const typeIdx of [...allocated].sort((a, b) => a - b)) {
+      const globalIdx = newCounterGlobal(ctx, censusName(ctx, typeIdx));
+      globalIdxByType.set(typeIdx, globalIdx);
+    }
+    // Pass 3 — splice the increments in.
+    for (const fn of ctx.mod.functions) instrumentBody(fn.body, (typeIdx) => globalIdxByType.get(typeIdx));
+    return;
+  }
+
+  // (#4185) BY_FUNC mode: one counter per (containing function × type),
+  // created lazily so cold (function, type) pairs cost nothing.
+  for (let i = 0; i < ctx.mod.functions.length; i++) {
+    const fn = ctx.mod.functions[i]!;
+    const perType = new Map<number, number>();
+    instrumentBody(fn.body, (typeIdx) => {
+      if (!allocated.has(typeIdx)) return undefined;
+      let globalIdx = perType.get(typeIdx);
+      if (globalIdx === undefined) {
+        globalIdx = newCounterGlobal(ctx, `${censusName(ctx, typeIdx)}__in__${sanitize(fn.name)}_${i}`);
+        perType.set(typeIdx, globalIdx);
+      }
+      return globalIdx;
+    });
+  }
+}
+
+/**
+ * (#4185) Call census: exported per-(caller, callee) counters on every direct
+ * `call`/`return_call` to a defined function whose name matches a target.
+ */
+function installCallCensus(ctx: CodegenContext): void {
+  const targets = callCensusTargets();
+  if (targets.length === 0) return;
+
+  // Match callees through `ctx.funcMap` — the SAME lookup call sites used when
+  // they emitted `{op:"call", funcIdx}`. Positional matching against
+  // `ctx.mod.functions` does not work here: bodies carry mint-time HANDLES
+  // (import-space at registration, before dead-import elimination), which the
+  // emitter resolves through the layout seam at encode time; recomputing
+  // "final index" from list position matched zero of 261k measured calls.
+  const matched = new Map<number, string>(); // call-site funcIdx handle → callee name
+  for (const [name, funcIdx] of ctx.funcMap) {
+    if (targets.some((t) => name.includes(t))) matched.set(funcIdx, name);
+  }
+  process.stderr.write(
+    `[call-census] ${matched.size} callee(s) match [${targets.join(",")}]: ${[...matched.values()].join(", ")}\n`,
+  );
+  if (matched.size === 0) return;
+  let staticSites = 0;
+
+  for (let i = 0; i < ctx.mod.functions.length; i++) {
+    const fn = ctx.mod.functions[i]!;
+    const perCallee = new Map<number, number>();
+    for (const arr of everyArray(fn.body)) {
+      let hit = false;
+      for (const instr of arr) {
+        if ((instr.op === "call" || instr.op === "return_call") && matched.has(instr.funcIdx)) {
+          hit = true;
+          break;
+        }
+      }
+      if (!hit) continue;
+      const rewritten: Instr[] = [];
+      for (const instr of arr) {
+        // A `return_call` never returns to the caller, so the increment must
+        // precede it; for plain `call` the pre-increment is equally correct
+        // (the callee cannot observe the counter) and keeps one code path.
+        if ((instr.op === "call" || instr.op === "return_call") && matched.has(instr.funcIdx)) {
+          let globalIdx = perCallee.get(instr.funcIdx);
+          if (globalIdx === undefined) {
+            globalIdx = newCounterGlobal(
+              ctx,
+              `${CALL_CENSUS_PREFIX}${sanitize(fn.name)}_${i}__TO__${sanitize(matched.get(instr.funcIdx)!)}`,
+            );
+            perCallee.set(instr.funcIdx, globalIdx);
+          }
+          rewritten.push(...incrementInstrs(globalIdx));
+          staticSites++;
+        }
+        rewritten.push(instr);
+      }
+      arr.splice(0, arr.length, ...rewritten);
+    }
+  }
+  process.stderr.write(`[call-census] instrumented ${staticSites} static call site(s)\n`);
+}
+
+function sanitize(name: string): string {
+  return name.replace(/[^A-Za-z0-9_]/g, "_");
+}
+
+function newCounterGlobal(ctx: CodegenContext, name: string): number {
+  const globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+  ctx.mod.globals.push({
+    name,
+    type: { kind: "i32" },
+    mutable: true,
+    init: [{ op: "i32.const", value: 0 }],
+  });
+  ctx.mod.exports.push({ name, desc: { kind: "global", index: globalIdx } });
+  return globalIdx;
+}
+
+function incrementInstrs(globalIdx: number): Instr[] {
+  return [
+    { op: "global.get", index: globalIdx },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "global.set", index: globalIdx },
+  ];
+}
+
+/** Estimated V8 pointer-compressed heap bytes for one field/element. */
+function valTypeBytes(t: ValType): number {
+  switch (t.kind) {
+    case "i8":
+      return 1;
+    case "i16":
+      return 2;
+    case "i64":
+    case "f64":
+    case "v128":
+      return t.kind === "v128" ? 16 : 8;
+    default:
+      return 4; // i32/f32 and every compressed reference kind
+  }
+}
+
+/**
+ * Resolve a final type index against `ctx.mod.types`, which stores rec groups
+ * as ONE entry spanning `types.length` consecutive indices (mirrors the WAT
+ * emitter's numbering).
+ */
+function resolveTypeDef(ctx: CodegenContext, typeIdx: number): TypeDef | undefined {
+  let idx = 0;
+  for (const t of ctx.mod.types) {
+    const span = t.kind === "rec" ? t.types.length : 1;
+    if (typeIdx < idx + span) return t.kind === "rec" ? t.types[typeIdx - idx] : t;
+    idx += span;
+  }
+  return undefined;
+}
+
+/** Human-readable field breakdown + estimated per-instance bytes (8 B header). */
+function typeShapeSummary(ctx: CodegenContext, typeIdx: number): string {
+  let def = resolveTypeDef(ctx, typeIdx);
+  if (def !== undefined && def.kind === "sub") def = def.type;
+  if (def === undefined) return "unresolved type";
+  if (def.kind === "array") return `array of ${def.element.kind} (${valTypeBytes(def.element)} B/elem + header)`;
+  if (def.kind !== "struct") return def.kind;
+  const kinds = new Map<string, number>();
+  let bytes = 8; // object header
+  for (const field of def.fields) {
+    kinds.set(field.type.kind, (kinds.get(field.type.kind) ?? 0) + 1);
+    bytes += valTypeBytes(field.type);
+  }
+  const breakdown = [...kinds.entries()].map(([k, n]) => `${n}×${k}`).join(" ");
+  return `struct, ${def.fields.length} fields (${breakdown}), ~${bytes} B/instance`;
 }
 
 /** Every nested instruction array reachable from `instrs`, including itself. */
@@ -119,13 +324,13 @@ function collectAllocatedTypes(instrs: Instr[], out: Set<number>): void {
   }
 }
 
-function instrumentBody(instrs: Instr[], globalIdxByType: ReadonlyMap<number, number>): void {
+function instrumentBody(instrs: Instr[], counterForType: (typeIdx: number) => number | undefined): void {
   // Collect the arrays FIRST, then rewrite: splicing while walking would make
   // the walk revisit the instructions it just inserted.
   for (const arr of everyArray(instrs)) {
     let hit = false;
     for (const instr of arr) {
-      if (ALLOC_OPS.has(instr.op) && globalIdxByType.has((instr as { typeIdx?: number }).typeIdx ?? -1)) {
+      if (ALLOC_OPS.has(instr.op) && typeof (instr as { typeIdx?: number }).typeIdx === "number") {
         hit = true;
         break;
       }
@@ -136,14 +341,9 @@ function instrumentBody(instrs: Instr[], globalIdxByType: ReadonlyMap<number, nu
       rewritten.push(instr);
       const typeIdx = (instr as { typeIdx?: number }).typeIdx;
       if (!ALLOC_OPS.has(instr.op) || typeIdx === undefined) continue;
-      const globalIdx = globalIdxByType.get(typeIdx);
+      const globalIdx = counterForType(typeIdx);
       if (globalIdx === undefined) continue;
-      rewritten.push(
-        { op: "global.get", index: globalIdx },
-        { op: "i32.const", value: 1 },
-        { op: "i32.add" },
-        { op: "global.set", index: globalIdx },
-      );
+      rewritten.push(...incrementInstrs(globalIdx));
     }
     arr.splice(0, arr.length, ...rewritten);
   }

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -53,6 +53,7 @@ import { addUnionImportsViaRegistry } from "./shared.js";
 import { ensureArgcGlobal } from "./statements/nested-declarations.js"; // (#3673 round 13) direct-call argc preset
 import { CLOSURE_ARITY_FIELD_IDX, getFuncRefWrapperRootTypeIdx } from "./closures/funcref-wrapper-types.js"; // (#3673 round 13) under-application gate
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2 read chokepoint / S3b stable-regime minting)
+import { wrapClosureCallFastArm } from "./closure-call-fast.js"; // (#4185) closure-receiver fast `.call` arm
 import { buildFnctorArrayHofTargetTest } from "./fnctor-array-prototype.js";
 import { resolveVecHostBridgeHelper } from "./vec-access-exports.js";
 
@@ -1363,6 +1364,11 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
     if (process.env.JS2WASM_REGEXP_TEST_OUTER_BRAND !== "0" && wrapNativeRegExpTest !== undefined) {
       current = wrapNativeRegExpTest(current);
     }
+
+    // (#4185) Closure-receiver fast `.call` arm, outermost (see
+    // closure-call-fast.ts) — appends its own scratch local BEFORE the
+    // round-13 patch below computes its slot, so both stay distinct.
+    current = wrapClosureCallFastArm(ctx, methodName, arity, anyLocalIdx, current, locals);
 
     // (#3673 round 13) Patch the cached-direct-call arm's scratch-local slot
     // now that the locals array is final.

--- a/src/codegen/closure-call-fast.ts
+++ b/src/codegen/closure-call-fast.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4185) Closure-receiver fast arm for the dynamic `.call` dispatchers.
+ *
+ * The standalone allocation census attributed the largest post-#4173 transient
+ * stream to `__objvec_new`: 41.8k pairs (83.6k heap objects, ~2.3 MB) per
+ * 226 KB acorn parse, split almost exactly in half between
+ * `__call_m_call_2` and `__closure_method_call`. Both halves are the SAME
+ * event: a dynamically-dispatched `fn.call(thisArg, a…)` — acorn's
+ * `update.call(this, prevType)` in `updateContext`, once per
+ * context-sensitive token — walks
+ *
+ *   __call_m_call_K(fn, thisArg, a…)          [$ObjVec #1: pack ALL args]
+ *     → __extern_method_call(fn, "call", vec)
+ *       → __closure_method_call(fn, "call", vec)
+ *         → own-prop "call" miss → %Function.prototype.call% route
+ *           [$ObjVec #2: re-pack args MINUS thisArg]
+ *           → __apply_closure(fn, thisArg, vec2) → __call_fn_method_N ladder
+ *
+ * and both vectors are dead the moment `__apply_closure` unpacks them. The
+ * consumer unwraps immediately; the boxes are pure dispatch plumbing.
+ *
+ * This arm decides the whole chain at the dispatcher, allocation-free: when
+ * the receiver IS a WasmGC closure (funcref-wrapper root `ref.test`), has NO
+ * own `call` property (`__extern_get` — the same §10.2 [[Get]] precedence
+ * check `__closure_method_call` route 1 performs), and is not UNDER-applied
+ * (declared formals ≤ provided args — the exact-arity ladder only carries
+ * closures with `formals <= N`; under-application must keep the legacy path
+ * whose #3592 widening pads the missing args), invoke
+ * `__call_fn_method_(K-1)(thisArg, fn, a…)` directly, argc preset/reset
+ * around it exactly like the #3673 round-13 cached-direct-call arm.
+ *
+ * Everything else — own-prop overrides, under-application, non-closure
+ * receivers, ropes, `.apply`, the vararg dispatcher — falls through to the
+ * legacy chain unchanged.
+ *
+ * Flag: `JS2WASM_FAST_CLOSURE_CALL=0` restores the legacy-only dispatcher.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { ensureArgcGlobal } from "./statements/nested-declarations.js";
+import { CLOSURE_ARITY_FIELD_IDX, getFuncRefWrapperRootTypeIdx } from "./closures/funcref-wrapper-types.js";
+
+export function fastClosureCallEnabled(): boolean {
+  return process.env.JS2WASM_FAST_CLOSURE_CALL !== "0";
+}
+
+/**
+ * Wrap `current` (the already-built dispatcher arm chain for
+ * `__call_m_call_<arity>`) in the closure fast arm. Returns `current`
+ * unchanged — and appends no local — when the arm does not apply (flag off,
+ * wrong method, arity 0, or a required helper is absent).
+ *
+ * When armed, appends ONE externref scratch (`__cc_m` — first the own-prop
+ * probe result, then the call result) to `locals`, whose slot is
+ * `arity + 1 + locals.length` at append time. This is safe against the
+ * round-13 `mcPatchInstrs` deferred-slot pattern in the caller: that patch
+ * computes ITS slot from `locals.length` after this append, so both are
+ * distinct and final. The caller must not reorder `locals` afterwards.
+ *
+ * Only READS funcMap — every dependency (`__extern_get`, the interned "call"
+ * literal, `__call_fn_method_*`) was registered at reserve time or earlier;
+ * missing ones disable the arm rather than minting anything at finalize.
+ */
+export function wrapClosureCallFastArm(
+  ctx: CodegenContext,
+  methodName: string,
+  arity: number,
+  anyLocalIdx: number,
+  current: Instr[],
+  locals: { name: string; type: ValType }[],
+): Instr[] {
+  if (!fastClosureCallEnabled()) return current;
+  if (methodName !== "call" || arity < 1) return current;
+  const rootIdx = getFuncRefWrapperRootTypeIdx(ctx);
+  const externGetIdx = ctx.funcMap.get("__extern_get");
+  const nullishIdx = ctx.funcMap.get("__nullish_to_null");
+  const callFnMethodIdx = ctx.funcMap.get(`__call_fn_method_${arity - 1}`);
+  if (rootIdx === undefined || externGetIdx === undefined || callFnMethodIdx === undefined) return current;
+
+  const scratchLocal = arity + 1 + locals.length;
+  locals.push({ name: "__cc_m", type: { kind: "externref" } });
+  const scratch = (op: "local.get" | "local.set" | "local.tee"): Instr => ({ op, index: scratchLocal });
+  const argcGlobalIdx = ensureArgcGlobal(ctx);
+
+  return [
+    // receiver is a WasmGC closure?
+    { op: "local.get", index: anyLocalIdx },
+    { op: "ref.test", typeIdx: rootIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [
+        // no own `call` property? (§10.2 precedence — an override must win)
+        { op: "local.get", index: 0 },
+        ...stringConstantExternrefInstrs(ctx, methodName),
+        { op: "call", funcIdx: externGetIdx },
+        ...(nullishIdx !== undefined ? ([{ op: "call", funcIdx: nullishIdx }] satisfies Instr[]) : []),
+        scratch("local.tee"),
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i32" } },
+          then: [
+            // not under-applied? (declared formals ≤ the K-1 provided args)
+            { op: "local.get", index: anyLocalIdx },
+            { op: "ref.cast", typeIdx: rootIdx },
+            { op: "struct.get", typeIdx: rootIdx, fieldIdx: CLOSURE_ARITY_FIELD_IDX },
+            { op: "i32.const", value: arity - 1 },
+            { op: "i32.le_s" },
+          ],
+          else: [{ op: "i32.const", value: 0 }],
+        },
+      ],
+      else: [{ op: "i32.const", value: 0 }],
+    },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [
+        { op: "i32.const", value: arity - 1 },
+        { op: "global.set", index: argcGlobalIdx },
+        { op: "local.get", index: 1 }, // thisArg — `.call`'s first argument
+        { op: "local.get", index: 0 }, // the closure itself is the callee
+        ...Array.from({ length: arity - 1 }, (_, a): Instr => ({ op: "local.get", index: 2 + a })),
+        { op: "call", funcIdx: callFnMethodIdx },
+        scratch("local.set"),
+        { op: "i32.const", value: -1 },
+        { op: "global.set", index: argcGlobalIdx },
+        scratch("local.get"),
+      ],
+      else: current,
+    },
+  ];
+}

--- a/tests/issue-4185-fast-closure-call.test.ts
+++ b/tests/issue-4185-fast-closure-call.test.ts
@@ -1,0 +1,132 @@
+/**
+ * #4185 — closure-receiver fast `.call` arm (closure-call-fast.ts).
+ *
+ * The allocation census attributed the largest post-#4173 transient stream to
+ * the dynamic-`.call` dispatch plumbing: two dead $ObjVec pairs per
+ * `fn.call(thisArg, a…)` on a closure receiver (~83.6k heap objects per
+ * standalone acorn parse), unpacked immediately by `__apply_closure`. The
+ * fast arm decides the chain at `__call_m_call_<K>` allocation-free via a
+ * direct `__call_fn_method_(K-1)` invocation.
+ *
+ * These pins are the arm's semantic contract — every guard that routes back
+ * to the legacy chain, and the flag-off parity:
+ *  - this-binding and argument threading (the fast path itself),
+ *  - UNDER-application (declared formals > provided args) must keep the
+ *    legacy path, whose `__apply_closure` #3592 widening pads the missing
+ *    args — a fixed-arity direct call would silently answer undefined,
+ *  - over-application (extra args dropped),
+ *  - an OWN `call` property on the closure must still win (§10.2 [[Get]]
+ *    precedence — route 1 in `__closure_method_call`),
+ *  - `JS2WASM_FAST_CLOSURE_CALL=0` answers identically (legacy chain).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+const FLAG = "JS2WASM_FAST_CLOSURE_CALL";
+const savedFlag = process.env[FLAG];
+afterEach(() => {
+  if (savedFlag === undefined) delete process.env[FLAG];
+  else process.env[FLAG] = savedFlag;
+});
+
+async function runStandalone(source: string): Promise<unknown> {
+  const r = await compile(source, { fileName: "t.ts", skipSemanticDiagnostics: true, target: "standalone" });
+  expect(r.binary?.length ?? 0).toBeGreaterThan(0);
+  const module = await WebAssembly.compile(r.binary as BufferSource);
+  expect(WebAssembly.Module.imports(module).length).toBe(0);
+  const { exports } = await WebAssembly.instantiate(module, {});
+  return (exports as { test?: () => unknown }).test?.();
+}
+
+/** The acorn shape: receiver erased through an object field, `.call(this, x)`. */
+const DYNAMIC_CALL_SRC = `var holder: any = { update: null, base: 0 };
+function readsThis(x) { return this.base + x; }
+holder.base = 30;
+holder.update = readsThis;
+export function test(): number {
+  var u = holder.update;
+  return u.call(holder, 12);
+}`;
+
+describe("#4185 — closure-receiver fast .call arm (standalone)", () => {
+  it("threads thisArg and the argument on the fast path", async () => {
+    expect(await runStandalone(DYNAMIC_CALL_SRC)).toBe(42);
+  });
+
+  it("flag off: identical answer through the legacy chain", async () => {
+    process.env[FLAG] = "0";
+    expect(await runStandalone(DYNAMIC_CALL_SRC)).toBe(42);
+  });
+
+  it("UNDER-application keeps the widening path (missing arg is undefined, not a vacuous undefined call)", async () => {
+    const got = await runStandalone(`var holder: any = { f: null };
+function two(a, b) { return (a === undefined ? 100 : a) + (b === undefined ? 10 : b); }
+holder.f = two;
+export function test(): number {
+  var u = holder.f;
+  return u.call(undefined, 5);
+}`);
+    expect(got).toBe(15);
+  });
+
+  it("over-application drops the extra argument", async () => {
+    const got = await runStandalone(`var holder: any = { f: null };
+function zero() { return 7; }
+holder.f = zero;
+export function test(): number {
+  var u = holder.f;
+  return u.call(undefined, 99);
+}`);
+    expect(got).toBe(7);
+  });
+
+  it("an own `call` property behaves identically to the legacy chain (pre-existing gap, pinned as parity)", async () => {
+    // Node answers 1005 here — the own property shadows
+    // %Function.prototype.call% (§10.2 [[Get]]). The compiler answers 6 on
+    // BOTH paths (measured: the assignment does not reach the closure side
+    // bag that `__extern_get` reads), so this is a PRE-EXISTING gap, not an
+    // arm regression. The arm's override guard is the same `__extern_get`
+    // probe route 1 of `__closure_method_call` performs, so a future side-bag
+    // fix flips both paths together — at which point this pin updates to
+    // 1005 for both.
+    const src = `var holder: any = { f: null };
+function real(x) { return x + 1; }
+real.call = function (a, b) { return 1000 + b; };
+holder.f = real;
+export function test(): number {
+  var u = holder.f;
+  return u.call(undefined, 5);
+}`;
+    const fast = await runStandalone(src);
+    process.env[FLAG] = "0";
+    const legacy = await runStandalone(src);
+    expect(fast).toBe(legacy);
+    expect(fast).toBe(6);
+  });
+
+  it("a DYNAMICALLY-assigned own `call` property still wins (§10.2 precedence guard)", async () => {
+    // Unlike the static-assignment shape above, a dynamic member write on the
+    // erased reference DOES reach the closure side bag, and the arm's
+    // `__extern_get` guard must route it back to the legacy chain.
+    const got = await runStandalone(`var holder: any = { f: null };
+function real(x) { return x + 1; }
+holder.f = real;
+export function test(): number {
+  var u = holder.f;
+  u.call = function (a, b) { return 1000 + b; };
+  return u.call(undefined, 5);
+}`);
+    expect(got).toBe(1005);
+  });
+
+  it("multi-arg fast path (arity 3 dispatcher)", async () => {
+    const got = await runStandalone(`var holder: any = { f: null, tag: 4 };
+function threeArgs(a, b, c) { return this.tag * 1000 + a * 100 + b * 10 + c; }
+holder.f = threeArgs;
+export function test(): number {
+  var u = holder.f;
+  return u.call(holder, 1, 2, 3);
+}`);
+    expect(got).toBe(4123);
+  });
+});


### PR DESCRIPTION
## Description

Implements #4185 under umbrella #4157: the GC/allocation bucket (20.66% of parse self-time, the largest) had 95% of its allocation *count* unattributed. This PR attributes all of it, then kills the top elidable stream.

### Deliverable 1 — the 607k allocations, attributed

Census machinery extended (`BY_FUNC`/`FOCUS`/`CALLS` modes + shape dump, env-gated, byte-identical off); full top-10 table in `plan/issues/4185-standalone-alloc-stream-attribution.md`. Headlines:

- **614,820 allocations per parse** on current main.
- **46% are `$AnyValue` boxes minted by `__any_from_extern` — and 100.0% of its 261,362 calls per parse come from `__extern_strict_eq`**, i.e. exactly the stream the in-flight #4173 equality PR eliminates. Verified as *not yet on main* and **not duplicated here** — when #4173 lands, nearly half the allocation stream goes with it.
- **#2 elidable stream: `$ObjVec` argument-vector pairs — 83.6k objects per parse**, two *dead* pairs allocated per dynamic closure `.call` (acorn's `updateContext` path), whose consumer (`__apply_closure`) unwraps immediately.
- Strings / `Node` / regexp streams priced and deliberately not taken (real values, retained data, or engine-internal — reasoning in the issue).

### Deliverable 2 — the kill

`src/codegen/closure-call-fast.ts`: a fast arm in `__call_m_call_<K>` — closure `ref.test` + §10.2 own-property guard + under-application gate, then a direct `__call_fn_method_(K-1)` call. WAT-verified allocation-free. Flag `JS2WASM_FAST_CLOSURE_CALL`, **default ON per evidence**:

- Census: **allocations −13.6% per parse; the ObjVec stream −99.7%**; isolation clean, checksum intact.
- Profile: **call-dispatch bucket −2.0pp in BOTH order-reversed pairs**; the `__extern_method_call` frame eliminated. (A first GC-share reading was a §6-class contamination artifact — caught by the order-reversal control and documented, per the #3927 measurement rules.)
- Wall: 4/4 pairs positive in both orders, pooled **−4.5%** (individual pairs sub-resolvability per §6 — the bucket deltas are the trustworthy signal).
- Binary +141 B.

### Semantics

Own-`call` override coverage pinned by test: a *dynamically assigned* `real.call = …` override works and is honored by the guard (answers 1005). A *statically assigned* override is a **pre-existing gap on both paths** (answers 6 on the old path too; Node says 1005) — pinned as parity, not a regression.

## Validation

Gates all exit 0 (loc/func budget grants in the issue frontmatter); suites 7/7 + 21/21 + 25/25 + 54/54; canaries 2/3/4/5, imports [], exactly the 3 pre-existing IR fallbacks.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_