### PR TITLE
fix(#4192): install the receiver for .call/.apply on a variable-held function expression

### DIFF
--- a/plan/agent-context/W13-builtin-proto-residue.md
+++ b/plan/agent-context/W13-builtin-proto-residue.md
@@ -1,0 +1,150 @@
+# W13 — `Function.prototype` / `String.prototype` residue
+
+Branch: `issue-4192-this-in-function-expression` (pushed to `origin`).
+Agent: `ttraenkler/W13-builtin-proto-residue`, 2026-08-06. No `gh` in this lane —
+someone else must open the PR.
+
+## PR body
+
+**Title:** `fix(#4192): install the receiver for .call/.apply on a variable-held function expression`
+
+```js
+var fe = function () { this.touched = true; };
+var o = {}; fe.call(o);          // o.touched === undefined   (want true)
+function fd() { this.touched = true; }
+var p = {}; fd.call(p);          // true  ✓ — a DECLARATION already worked
+```
+
+A function **declaration** gets this right (#3796/#4025 `.call`, #3983 `.apply`
+— `named-this-call.ts` reserves an exact-target trampoline that saves, installs
+and restores `__current_this`). A function **expression** did not:
+`resolveDeclaration` there demands `ts.isFunctionDeclaration`, and the call site
+gates the whole named-`this` arm on `!closureInfo` — and `var f = function (){}`
+registers a `closureMap` entry. So the dominant JS function shape fell into the
+legacy arm, which evaluates `thisArg` and **drops** it. Same defect class, both
+lanes: this is a JS-host bug too, not an es5-standalone one.
+
+**The lifted body needed no change.** WAT for the repro shows it already opening
+with `global.get $__current_this; ref.is_null; (if … $__undefined …)`; nothing in
+the module ever *wrote* that global on this path. Only the writer was missing.
+
+New leaf module `src/codegen/closure-receiver-install.ts`:
+`planClosureReceiverInstall` (admission) + `emitClosureReceiverInstall` /
+`finishClosureReceiverCall` (inline save/install/restore, mirroring
+`__call_fn_method_N` and `fillDirectCallTrampolines` — including their
+documented limitation that an exceptional unwind skips the restore). Admission
+is narrow: a `VariableDeclaration` initialised with a `FunctionExpression`
+(arrows excluded — their `this` is lexical), non-generator, non-`async`, no
+explicit `this` parameter, body references its own `this`. A null receiver needs
+no arm: the body's own `ref.is_null` guard already answers `undefined`, so
+`f.call(null)` is unchanged.
+
+**Measured** (base-vs-head, `--target standalone`, ES5, interpreter runtime-eval
+tier): `built-ins/Function/prototype` 94 → **95**; a 148-file corpus (every ES5
+file using `.call(`/`.apply(` *and* a function expression, ∪ the
+`Array.prototype` HOF-`thisArg` family — the other `__current_this` consumer)
+84 → **86**. **FIXED 2, BROKE 0**, no signature changes among the still-failing.
+Two apparent regressions in the first sweep were parallel-run compile timeouts
+and pass when re-run serially. All **8 equivalence shards** green, no new
+regressions. Four ratchets green (`calls.ts` +31 LOC / `compileCallExpression`
++26 allowed in the issue frontmatter — the mechanism itself is in the new leaf
+module; only the call-site wiring can live in the driver). `check:ir-fallbacks`
+green. `tsc --noEmit` clean.
+
+Covered by `tests/issue-4192-fn-expr-this-call-apply.test.ts` — 10 cases, each
+on **both** lanes. Verify-first: **6 are RED on `origin/main`**; the 4 green on
+both are the guards that must not move (null receiver, function declaration,
+arrow, callee that never mentions `this`).
+
+The ES5 delta is small because only 43 ES5 files use this shape at all. The
+value is correctness in the dominant JS function form, in both lanes.
+
+**Coordination:** W12 is concurrently implementing the 168-file 10.4.3
+`this`-binding cluster in `src/codegen/expressions.ts`. Different mechanism,
+adjacent territory. This PR touches neither `expressions.ts` nor the body's
+`this` lowering — it only adds the missing *writer* of `__current_this` at one
+call site. The two compose: W12 decides what a body reads when nothing is
+installed; this decides what gets installed.
+
+Also in the PR: `plan/issues/4192` (live), `4191` + `4193` as **superseded
+stubs** (see below), and a re-measure section appended to `plan/issues/2875`.
+
+## Superseded, deliberately not pursued
+
+- **#4191** → PR **#4163**. Same defect (the in-process test262 runner never
+  linked `js2wasm:runtime-eval`), but #4163 fixes it at a shared seam across all
+  five instantiate sites with a structural guard, and carries a second vacuity
+  fix. The stub keeps two things #4163 does not have: the measurement (**46 of
+  95** ES5 `Function/prototype` standalone failures were that one phantom
+  bucket) and a correction to its trigger analysis — the trigger is the
+  compiler's `sourceUsesRuntimeEvalBoundary` pre-scan firing on **any
+  value-position mention** of `Function`/`eval` (`var g = Function;` is enough),
+  not only the `$262.evalScript` shim.
+- **#4193** → **#4176 / PR #4155**, already implemented and measured **+76**.
+  The stub keeps the independent census reached from the String side: of the 139
+  ES5 files that assign a named property onto a builtin `.prototype`, **112
+  fail**, and **63 of those are in `built-ins/Object/defineProperty`** — inside
+  #4163's #1 lever but *not* behind the descriptor MOP.
+
+## Census (2026-08-06 main, ES5 label, `--target standalone`, provider attached)
+
+### `built-ins/Function/prototype` — 189 files, 94 pass, 95 fail
+
+| n | mechanism | lane |
+| ---: | --- | --- |
+| 42 | source drives `Function(…)` / `eval` — the interpreter's `this`/global handling | #2928 |
+| **34** | **`Function.prototype.bind`** | unowned, see below |
+| 19 | rest (`apply`/`call` `this` → #4192, `__get_builtin` CE, proto identity) | mixed |
+
+`bind` sub-buckets: 13 × `new (bound)()` [[Construct]]; 8 × `<Builtin>.bind(null)`
+then call → `__module_init` null deref; 5 × "expected TypeError, none thrown";
+3 × `this` not applied (#4192's remaining half); 3 × null deref; 1 × `bind is not
+yet implemented in --target standalone`; 1 CE. **This is the largest unowned
+mechanism I found inside the original brief and it still has no issue.**
+
+### `built-ins/String/prototype` — 630 files, 528 pass, 102 fail
+
+67 of 102 are the borrowed-method idiom, and it is **three** defects:
+~23 = #4176/PR #4155 (the builtin-proto write is a no-op), ~19 = genuinely
+#2875's unwired reflective glue (`split` 10, `concat` 3, `search` 2, `replace` 2,
+`match` 2), ~6 = exotic-receiver `__any_to_string` answering `"[object Object]"`.
+Remainder: ~16 RegExp-engine-gated (#4016/#4065 — refuted lever, do not
+re-litigate), plus a long tail.
+
+**`split` is 23 ES5 failures, not the 11 recorded in #2875** — the old number
+came through the unlinked runner.
+
+## Verdict on the original framing
+
+**The 197-file "`Function.prototype` + `String.prototype` residue" is genuinely
+fragmented — nothing inside it is above ~34 files.** After correcting the
+instrumentation: 42 interpreter (#2928), ~34 `bind` (unowned), ~19 String glue
+(#2875), ~20 `this`-binding (#4192), ~23 builtin-proto (#4176), ~16 RegExp
+(#4016/#4065), long tail. Not worth staffing further as a unit.
+
+## Measurement setup (reusable)
+
+```bash
+ln -s <repo>/node_modules node_modules
+# test262 is a submodule dir git keeps recreating EMPTY — symlink the two
+# subdirs INSIDE it, not the dir itself:
+mkdir -p test262
+ln -s <checkout>/test262/test    test262/test
+ln -s <checkout>/test262/harness test262/harness
+
+node --import tsx scripts/build-runtime-eval-provider.mjs   # ~100 s
+TEST262_FULL_RUNTIME_EVAL=1 <sweep>                         # CI-comparable tier
+```
+
+Three traps, each of which cost time here:
+
+1. Without `TEST262_FULL_RUNTIME_EVAL=1` you get the **REFUSAL** tier, which
+   links but throws on any real dynamic-code call.
+2. **Any `src/` edit invalidates the provider cache** (`computeCompilerBundleHash`)
+   and silently drops you back to REFUSAL mid-A/B. That turned a clean
+   `+2 / 0 regressions` into an apparent `-10` on the first run. Rebuild after
+   changing the compiler and confirm the printed tier on **both** sides.
+3. Sweep with **one child process per chunk** — the in-process runner executes
+   test code in the caller's realm, so later tests poison earlier ones. And a
+   parallel sweep produces spurious `compilation timeout` entries: re-run any
+   apparent regression serially before believing it.

--- a/plan/issues/2875-standalone-string-prototype-cluster.md
+++ b/plan/issues/2875-standalone-string-prototype-cluster.md
@@ -457,3 +457,40 @@ counts is signature-derived.
 RegExp-gated ~16 belong to the standalone RegExp engine (#4016/#4065 — #4065
 already refuted the "51-file RegExp lever inside String.prototype" framing);
 `concat` (4) is variadic and needs a different closure ABI.
+
+## Re-measure + decomposition (W13, 2026-08-06)
+
+Full ES5-label sweep of `built-ins/String/prototype` on 2026-08-06 main, with
+the in-process runner patched to attach the `js2wasm:runtime-eval` provider (the
+fix that PR **#4163** lands properly, at a shared seam across all five
+instantiate sites) and `TEST262_FULL_RUNTIME_EVAL=1` (the CI-comparable
+interpreter tier): **630 files, 528 pass, 102 fail.** The `split` count above is
+**23, not 11** — the earlier figure was taken through a runner whose
+`js2wasm:runtime-eval` link error overwrote the real signatures.
+
+**67 of the 102 are ONE idiom**: `x.m = String.prototype.m; x.m(…)` — a borrowed
+`String.prototype` method on a non-String receiver. But that idiom is **three
+different defects**, and the previous "Next slice" note conflated them and
+under-sized the whole thing at 12–17:
+
+| # | sub-mechanism | probe | ES5 files | owner |
+| --- | --- | --- | ---: | --- |
+| **b1** | receiver is a **builtin prototype** (`Number.prototype.m = …`) — the write itself is a silent no-op; nothing to dispatch to | `Number.prototype.foo = f; typeof Number.prototype.foo === "undefined"` | ~23 | **#4176 / PR #4155** (not this issue) |
+| **a** | member has **no reflective glue body** → `emitProtoMemberBodyRefusal` → *"not yet implemented in --target standalone"* | `new Boolean().split = String.prototype.split; …split()` throws | ~19 (`split` 10, `concat` 3, `search` 2, `replace` 2, `match` 2) | **this issue** |
+| **b2** | glue exists but **ToString of an exotic receiver** is wrong — `__any_to_string` answers `"[object Object]"` instead of the brand's `toString` | `fn.slice(0,8)` → `"[object "` (want `"function"`); `regExp.toUpperCase()` → `"[OBJECT OBJECT]"` (want `"/ABC/"`) | ~6 | this issue (or #2862) |
+
+The remaining 35 are: RegExp-engine-gated `replace`/`match` (#4016/#4065, ~16,
+do not re-litigate), `String.hasOwnProperty('prototype')` static reflection (4),
+`delete String.prototype.toString` (3), and a long tail.
+
+**The 12-file `Number.prototype.<caseMethod>` matrix named in the previous
+"Next slice" is b1, i.e. #4176 / PR #4155 — it is NOT fixable inside the String
+glue, and it is already implemented there.** The
+`null` return that section observed is not the glue's refusal signal reaching a
+String receiver; it is the *assignment never having happened*. Confirmed by the
+brand-independent probe: `Object.prototype.qux = fn; ({}).qux()` is `null` too,
+with no String involvement anywhere.
+
+So the honest next slice for **this** issue is (a) — wire `split` and `concat`
+reflective glue bodies, ~13 ES5 files — with (b2) as a small follow-up. That is
+a genuinely ~15-file lever, not a 67-file one.

--- a/plan/issues/4191-test262-runner-runtime-eval-seam.md
+++ b/plan/issues/4191-test262-runner-runtime-eval-seam.md
@@ -1,0 +1,79 @@
+---
+id: 4191
+title: "SUPERSEDED by #4163 — test262 in-process runner did not link js2wasm:runtime-eval (kept for the measurement)"
+status: wont-fix
+created: 2026-08-06
+updated: 2026-08-06
+priority: high
+task_type: bug
+area: conformance, tooling
+goal: es5
+sprint: current
+horizon: s
+superseded_by: 4163
+related: [4163, 2928, 4192, 2875]
+---
+
+# #4191 — superseded by #4163; kept only for the measurement
+
+**Do not implement this.** PR **#4163** fixes the same defect properly: a shared
+`scripts/test262-import-object.mjs` seam across **all five** instantiate sites
+(worker, shared fixture lane, in-process runner, …), normalisation of
+`WebAssembly.instantiate`'s two return shapes, and a **structural** guard that
+asserts no lane calls `WebAssembly.instantiate` on a test binary itself. It also
+carries a second vacuity fix #4191 did not find (`handleNegativeTest` built
+compile options from an unbound `target`, and the `ReferenceError` landed in the
+`try` whose `catch` returns `pass` — so every parse/early/resolution negative
+test was "passing" without compiling anything).
+
+This file is retained because the reservation is spent and the measurement below
+is corroborating evidence for #4163, plus one correction to its trigger
+analysis.
+
+## What was measured (2026-08-06, ES5 label, `--target standalone`)
+
+`tests/test262-runner.ts` did not attach the cached `js2wasm:runtime-eval`
+namespace, so any standalone module importing that carrier died at
+`WebAssembly.instantiate` with
+`Import #0 module="js2wasm:runtime-eval": module is not an object` — **and that
+link error overwrote the test's real failure signature.**
+
+| runner state | top signature in `built-ins/Function/prototype` |
+| --- | --- |
+| before | `dynamic code evaluation … not supported` — **46 of 95 failures**, one bucket |
+| after | that bucket disappears; the real distribution is `bind` 34, apply/call `this` 19, misc |
+
+## Correction to #4163's trigger analysis
+
+#4163 attributes the import to the `$262.evalScript` shim. That may also be
+true, but the simpler and much broader trigger is the compiler's own pre-scan
+`sourceUsesRuntimeEvalBoundary` (`src/codegen/index.ts`), which emits the
+carrier import for **any value-position mention of `Function` or `eval`**.
+Minimal demonstration, no harness involved:
+
+```
+"var g = Function; var z = 1;"  =>  js2wasm:runtime-eval::__runtime_apply_interpreted,
+                                    js2wasm:runtime-eval::__runtime_indirect_eval
+"var f = new Function('return 1');" =>  (none)
+"var y = 1 + 1;"                    =>  (none)
+```
+
+So `for (var p in Function)` and `Function.propertyIsEnumerable('prototype')`
+were affected too — tests that never evaluate dynamic code at all.
+
+## Second half of the trap, for whoever measures locally
+
+The runner's default provider tier is **REFUSAL**; CI standalone runs with
+`TEST262_FULL_RUNTIME_EVAL=1`, i.e. the **INTERPRETER** tier
+(`test262-sharded.yml`). The refusal tier links but throws
+`dynamic code evaluation is not supported` on any real dynamic-code call, so a
+local sweep without that env var still mis-buckets every genuinely
+`Function()`-driven test. `selectCachedRuntimeEvalProvider` prints the tier it
+chose on first use — read that line before trusting a sweep.
+
+**And: any `src/` edit changes `computeCompilerBundleHash`, which invalidates
+the provider cache and silently drops you back to REFUSAL mid-A/B.** That
+turned a clean `+2 / 0 regressions` into an apparent `-10` on the first #4192
+measurement. Rebuild with `node --import tsx
+scripts/build-runtime-eval-provider.mjs` (~100 s) after changing the compiler,
+and confirm the printed tier on both sides of the comparison.

--- a/plan/issues/4192-standalone-this-in-function-expression-not-bound.md
+++ b/plan/issues/4192-standalone-this-in-function-expression-not-bound.md
@@ -1,0 +1,141 @@
+---
+id: 4192
+title: "`this` is dead inside a variable-held function EXPRESSION — .call/.apply/.bind and method invocation all drop the receiver (BOTH lanes)"
+status: in-progress
+created: 2026-08-06
+updated: 2026-08-06
+priority: high
+task_type: bug
+area: codegen
+goal: es5
+feasibility: hard
+reasoning_effort: max
+assignee: ttraenkler/W13-builtin-proto-residue
+sprint: current
+horizon: l
+related: [4025, 3983, 3796, 2152, 1636, 4163]
+# Slice 1 (this PR): +31 LOC in calls.ts — the receiver-install plan + the three
+# `finishClosureReceiverCall` sites. The mechanism itself lives in the new leaf
+# module src/codegen/closure-receiver-install.ts; only the call-site wiring can
+# live in the driver.
+loc-budget-allow:
+  - src/codegen/expressions/calls.ts
+func-budget-allow:
+  - src/codegen/expressions/calls.ts::compileCallExpression
+---
+
+# #4192 — `this` in a variable-held function expression is never bound
+
+## Repro (both `--target standalone` AND the JS-host lane)
+
+```js
+var fe = function () { this.touched = true; };
+var o1 = {}; fe.call(o1);        // o1.touched === undefined   (want true)
+var o3 = {}; fe.apply(o3);       // o3.touched === undefined   (want true)
+var o4 = {}; fe.bind(o4)();      // o4.touched === undefined   (want true)
+var o5 = { m: fe }; o5.m();      // o5.touched === undefined   (want true)
+
+var ge = function () { return this.v; };
+ge.call({ v: 9 });               // NaN                        (want 9)
+
+function fd() { this.touched = true; }   // a DECLARATION works
+var o2 = {}; fd.call(o2); // o2.touched === true  ✓
+```
+
+Verified through `runTest262File(…, "standalone")` **and** the JS-host lane on
+the same file — identical failure text, so this is **not** a standalone gap.
+
+## Root cause (traced, then confirmed against the emitted WAT)
+
+The receiver-install machinery is keyed on **`ts.isFunctionDeclaration`**:
+
+- `resolveDeclaration` (`src/codegen/named-this-call.ts:94`) returns `undefined`
+  for anything that is not a `FunctionDeclaration`, so
+  `resolveNamedThisCallTarget` / `tryReshapeApplyToNamedThisCall` never fire.
+- At the call site (`src/codegen/expressions/calls.ts`) the named-`this` arm is
+  additionally gated on **`!closureInfo`**. `var fe = function (){}` registers a
+  `closureMap` entry, so even the identifier form takes the `closureInfo`
+  branch — the legacy *evaluate-`thisArg`-and-**drop**-it* lowering.
+
+Same defect class #4025/#3983 fixed for declarations ("a silent wrong answer,
+not a refusal"), left standing for the dominant JS shape.
+
+**The lifted body needs no change.** WAT for the repro shows the closure opening
+with `global.get $__current_this; ref.is_null; (if … $__undefined …)` — i.e.
+`bodyReferencesOwnThis` was true, `compileFunctionBody` set `readsCurrentThis`,
+and the body reads the global correctly. Nothing in the module ever *wrote* it:
+`global.set` on `$__current_this` appeared only inside `__call_fn_method_N`,
+which this path does not reach. Only the writer was missing.
+
+## Slice 1 — LANDED: `.call` / `.apply` (this PR)
+
+New leaf module `src/codegen/closure-receiver-install.ts`:
+
+- `planClosureReceiverInstall` — admission. Fires only when the callee
+  identifier resolves to a `VariableDeclaration` whose initializer is a
+  **`FunctionExpression`** (arrows excluded: their `this` is lexical, and
+  installing a dynamic receiver would *change* their meaning), non-generator,
+  non-`async`, no explicit `this` parameter, and whose body
+  `bodyReferencesOwnThis` — the same predicate the body used to decide it would
+  read the global, so the two can never disagree.
+- `emitClosureReceiverInstall` / `finishClosureReceiverCall` — inline
+  save/install/restore around the call, mirroring `__call_fn_method_N`
+  (closure-exports.ts) and `fillDirectCallTrampolines` (typed-this.ts),
+  **including their documented limitation that an exceptional unwind skips the
+  restore**. An inline sequence cannot use the trampoline's `catch_all` without
+  wrapping an arbitrary sub-expression in a `try`; matching the established
+  sequence exactly is worth more than being the one path that differs.
+
+A **null** receiver needs no arm: the body's own `ref.is_null` guard already
+answers `undefined`, so `f.call(null)` keeps the value it has today. That is
+deliberately unlike `named-this-call.ts`, which must branch because its
+trampoline passes the receiver as a parameter.
+
+Reassignment of the variable is deliberately **not** checked. Unlike the
+exact-target trampoline this install bakes no callee: if the variable holds some
+other function at runtime, that function either reads `__current_this` (in which
+case installing the spec receiver is correct) or does not (in which case the
+install is unobservable).
+
+### Measured
+
+Base-vs-head, `--target standalone`, ES5 label, interpreter runtime-eval tier:
+
+| corpus | base | head |
+| --- | ---: | ---: |
+| `built-ins/Function/prototype` (189 ES5 files) | 94 pass | **95** pass |
+| 148-file corpus: every ES5 file using `.call(`/`.apply(` **and** a function expression, ∪ the `Array.prototype` HOF-`thisArg` family (the other `__current_this` consumer) | 84 pass | **86** pass |
+
+**FIXED 2** (`Function/prototype/{apply,call}/S15.3.4.{3,4}_A5_T5.js` — literally
+the repro), **BROKE 0**, zero signature changes among the still-failing. Two
+apparent regressions in the first sweep were parallel-run compile timeouts and
+pass when re-run serially.
+
+Covered by `tests/issue-4192-fn-expr-this-call-apply.test.ts` (10 cases, each
+asserted on **both** lanes). Verify-first: 6 of the 10 are RED on `origin/main`;
+the 4 that are green on both are the guards that must not move (null receiver,
+function declaration, arrow, callee that never mentions `this`).
+
+The ES5 count is small because only 43 ES5 files use this shape at all. The
+value is host-lane correctness in the dominant JS function form, not the
+conformance delta.
+
+## Remaining (NOT this PR)
+
+1. **Method invocation** — `var o = { m: fe }; o.m()` still drops the receiver.
+   Different call path (`call-receiver-method.ts`), same missing install. This
+   is the commonest shape and worth the most.
+2. **`.bind`** — `fe.bind(o)()` still drops it; the `$__bound_fn` carrier
+   (#3140) is a third path. It is also entangled with the 34-file
+   `Function.prototype.bind` bucket (construct-through-`bind`,
+   `<Builtin>.bind(null)`), which wants its own issue.
+
+## Coordination
+
+W12 is concurrently implementing the 168-file 10.4.3 `this`-binding cluster
+(sloppy-mode `this` falling through to `emitUndefined` regardless of strictness)
+in `src/codegen/expressions.ts`. **Different mechanism, adjacent territory.**
+This slice touches neither `expressions.ts` nor the body's `this` lowering — it
+only adds the missing *writer* of `__current_this` at one call site. The two
+compose: W12 decides what a body reads when nothing is installed; this decides
+what gets installed.

--- a/plan/issues/4193-standalone-builtin-prototype-named-expando.md
+++ b/plan/issues/4193-standalone-builtin-prototype-named-expando.md
@@ -1,0 +1,82 @@
+---
+id: 4193
+title: "SUPERSEDED by #4176 / PR #4155 — named properties on builtin prototypes (kept for the independent measurement)"
+status: wont-fix
+created: 2026-08-06
+updated: 2026-08-06
+priority: high
+task_type: bug
+area: codegen
+goal: es5
+sprint: current
+horizon: xl
+superseded_by: 4176
+related: [4176, 4160, 4159, 2875, 4163]
+---
+
+# #4193 — superseded by #4176 / PR #4155
+
+**Do not implement this.** #4176 (PR #4155) already implements the per-brand
+proto-property store — named keys on builtin prototypes living through the
+prototype chain, generalising #4160's integer-key store to all brands — and
+measured **+76** on a 219-file lever. It found the same root cause independently
+(module-init collection dropping top-level `<Builtin>.prototype.<name> = …`
+writes because builtins have no module-global root identifier). It is held only
+to sequence a conflict with #4153.
+
+Retained because the reservation is spent and because the census below is
+independent corroboration reached from a completely different direction — the
+`built-ins/String/prototype` borrowed-method residue.
+
+## The defect (repro, `--target standalone`, pre-#4155)
+
+```js
+Number.prototype.foo = function () { return "FOO"; };
+typeof Number.prototype.foo;             // "undefined"   (want "function")
+(1).foo();                               // null          (want "FOO")
+Number.prototype.bar = 7;
+Number.prototype.hasOwnProperty("bar");  // false         (want true)
+
+Boolean.prototype.baz = function () {…}; true.baz();  // null
+Object.prototype.qux = function () {…};  ({}).qux();  // null
+Array.prototype.quux = function () {…};  [].quux();   // null
+```
+
+An **own** property on an ordinary object works
+(`new Object(42).charAt = String.prototype.charAt` → `"4"`). The gap is specific
+to the builtin **prototype object**: `$NativeProto` (`native-proto.ts`) has six
+fields — `brand`, `isClass`, `ctor`, `parent`, `memberCsv`, `name` — and no
+own-property store, so the write has nowhere to land.
+
+## Independent size measurement (2026-08-06, ES5 label, standalone)
+
+List every ES5 test262 file whose body matches
+`\b(Object|Function|Array|String|Number|Boolean|Date|RegExp|Error|…)\.prototype\.\w+\s*=`
+(139 files) and sweep with the runtime-eval provider attached and
+`TEST262_FULL_RUNTIME_EVAL=1`:
+
+| directory | fail / total |
+| --- | ---: |
+| `built-ins/Object/defineProperty` (+ `defineProperties`) | 63 / 87 |
+| `built-ins/String/prototype/split` | 13 / 13 |
+| `built-ins/String/prototype/{toLowerCase,toUpperCase,toLocale*Case}` | 12 / 12 |
+| `built-ins/String/prototype/{slice,substring,match,replace,concat,indexOf,lastIndexOf}` | 12 / 12 |
+| `built-ins/RegExp/prototype/{exec,test}` | 6 / 6 |
+| `built-ins/Function/prototype/bind` | 3 / 5 |
+| `built-ins/Array/**`, `built-ins/Number/prototype`, misc | 3 / 4 |
+| **total** | **112 / 139** |
+
+Spot-verified causal, not incidental:
+
+- `Object/defineProperty/15.2.3.6-3-34-1.js` — `Array.prototype.enumerable = true;`
+  then an `[]` is used as the attributes bag and must inherit `enumerable`.
+- `Object/defineProperty/15.2.3.6-3-248-1.js` — `Function.prototype.set = fn;`
+  then a function object is the attributes bag and must inherit `set`.
+- `String/prototype/split/call-split-1-0-instance-is-number.js` —
+  `Number.prototype.split = String.prototype.split; new Number(…).split(1,0)`.
+
+The load-bearing part for planning: **63 of those sit in
+`built-ins/Object/defineProperty`**, i.e. inside #4163's #1 lever (857 reachable
+failures) but **not** behind the descriptor MOP (#1906/#2992/#3251). They are
+attributes bags inheriting from a monkey-patched builtin prototype, and #4155
+closes them without any MOP work.

--- a/src/codegen/closure-receiver-install.ts
+++ b/src/codegen/closure-receiver-install.ts
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4192) Receiver install for `.call` / `.apply` on a **variable-held function
+ * expression**.
+ *
+ * ## The defect
+ *
+ * ```js
+ * var fe = function () { this.touched = true; };
+ * var o = {};
+ * fe.call(o);          // o.touched === undefined   (want true)
+ * ```
+ *
+ * A function *declaration* gets this right — `named-this-call.ts` (#3796/#4025,
+ * `.apply` via #3983) reserves an exact-target trampoline that saves, installs
+ * and restores `__current_this` around the call. But `resolveDeclaration` there
+ * demands `ts.isFunctionDeclaration`, and the call site additionally gates the
+ * whole named-`this` arm on `!closureInfo` — and `var fe = function () {}`
+ * registers a `closureMap` entry. So the dominant JS function shape fell into
+ * the legacy arm, which evaluates `thisArg` and **drops** it:
+ *
+ * ```wat
+ * local.get <thisArg> ; drop        ;; ← the receiver, discarded
+ * <closure call>
+ * ```
+ *
+ * That is a silent wrong answer, not a refusal — the same failure this module's
+ * sibling was created to remove for declarations.
+ *
+ * ## Why the fix is only a call-site install
+ *
+ * The lifted closure body is already correct. Measured on the WAT for the
+ * snippet above: `bodyReferencesOwnThis` is true for the function expression, so
+ * `compileFunctionBody` sets `readsCurrentThis` and the body opens with
+ *
+ * ```wat
+ * global.get $__current_this ; ref.is_null
+ * (if (result externref) (then global.get $__undefined …) (else …))
+ * ```
+ *
+ * i.e. it reads the global and falls back to `undefined` when nothing was
+ * installed. Nothing in the module ever wrote that global — `global.set` on it
+ * appeared only inside `__call_fn_method_N`, which this path does not reach.
+ * So the body half needs no change; only the writer was missing.
+ *
+ * ## Shape
+ *
+ * Inline save/install/restore, mirroring `__call_fn_method_N`
+ * (closure-exports.ts) and `fillDirectCallTrampolines` (typed-this.ts) —
+ * **including their one documented limitation, that an exceptional unwind
+ * skips the restore**. An inline sequence cannot use the trampoline's
+ * `catch_all` without wrapping an arbitrary sub-expression in a `try`, and
+ * matching the established sequence exactly is worth more here than being the
+ * one path that differs.
+ *
+ * ```wat
+ * <thisArg>                       ;; already on the stack (externref)
+ * local.set   $__recv
+ * global.get  $__current_this
+ * local.set   $__prev_this
+ * local.get   $__recv
+ * global.set  $__current_this
+ * <closure call>                  ;; result (or nothing) on the stack
+ * [local.set  $__recv_result]
+ * local.get   $__prev_this
+ * global.set  $__current_this
+ * [local.get  $__recv_result]
+ * ```
+ *
+ * A **null** receiver needs no special arm: the body's own `ref.is_null` guard
+ * already answers `undefined`, so `f.call(null)` / `f.call(undefined)` keep the
+ * exact value they have today. That is deliberately different from
+ * `named-this-call.ts`, which must branch because its trampoline hands the
+ * receiver over as a parameter.
+ *
+ * ## Admission
+ *
+ * Narrow on purpose — it fires only where the current lowering provably throws
+ * the receiver away:
+ *
+ *  - the callee identifier resolves to a `VariableDeclaration` whose initializer
+ *    is a **`FunctionExpression`** (an arrow is excluded: its `this` is
+ *    lexical, and installing a dynamic receiver would change its meaning);
+ *  - that function's body references its **own** `this`
+ *    (`bodyReferencesOwnThis` — the same predicate the body used to decide it
+ *    would read the global, so the two can never disagree);
+ *  - it is not a generator, not `async`, and has no explicit `this` parameter.
+ *
+ * Reassignment of the variable is *not* checked, and does not need to be: unlike
+ * the exact-target trampoline, this install bakes no callee. If the variable
+ * holds some other function at runtime, that function either reads
+ * `__current_this` (in which case installing the spec receiver is the correct
+ * answer) or does not (in which case the install is unobservable).
+ */
+import { ts } from "../ts-api.js";
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { allocLocal } from "./context/locals.js";
+import { bodyReferencesOwnThis } from "./helpers/body-references-own-this.js";
+import { ensureCurrentThisGlobal } from "./statements/nested-declarations.js";
+
+/**
+ * Narrow a `compileExpression`-family result (`InnerResult = ValType | null |
+ * VOID_RESULT`) to the `ValType` the restore must preserve, or `undefined` when
+ * the call left nothing on the stack. Typed structurally rather than importing
+ * `shared.ts`, to keep this module free of a codegen import cycle.
+ */
+export function innerResultValType(result: ValType | null | symbol): ValType | undefined {
+  return result === null || typeof result === "symbol" ? undefined : result;
+}
+
+/** Locals + global reserved for one install/restore pair. */
+export interface ClosureReceiverInstall {
+  readonly globalIdx: number;
+  readonly recvLocal: number;
+  readonly prevLocal: number;
+}
+
+/**
+ * Does `callee` name a variable holding a `this`-reading function expression?
+ * Returns the reserved install handle, or `undefined` to leave every existing
+ * lowering (including the evaluate-and-drop one) authoritative.
+ */
+export function planClosureReceiverInstall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  callee: ts.Identifier,
+): ClosureReceiverInstall | undefined {
+  const declaration = ctx.oracle.valueDeclarationOf(callee);
+  if (!declaration || !ts.isVariableDeclaration(declaration)) return undefined;
+  const initializer = declaration.initializer;
+  if (!initializer || !ts.isFunctionExpression(initializer) || initializer.body === undefined) return undefined;
+  if (initializer.asteriskToken !== undefined) return undefined;
+  if (initializer.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) === true) return undefined;
+  const first = initializer.parameters[0];
+  if (first && ts.isIdentifier(first.name) && first.name.text === "this") return undefined;
+  if (!bodyReferencesOwnThis(initializer.body)) return undefined;
+
+  const globalIdx = ensureCurrentThisGlobal(ctx);
+  const seq = fctx.locals.length;
+  return {
+    globalIdx,
+    recvLocal: allocLocal(fctx, `__recv_this_${seq}`, { kind: "externref" }),
+    prevLocal: allocLocal(fctx, `__prev_this_${seq}`, { kind: "externref" }),
+  };
+}
+
+/**
+ * Consume the `thisArg` already on the stack (externref) and install it,
+ * stashing the previous receiver. Replaces the legacy `drop`.
+ */
+export function emitClosureReceiverInstall(fctx: FunctionContext, install: ClosureReceiverInstall): void {
+  fctx.body.push(
+    { op: "local.set", index: install.recvLocal },
+    { op: "global.get", index: install.globalIdx },
+    { op: "local.set", index: install.prevLocal },
+    { op: "local.get", index: install.recvLocal },
+    { op: "global.set", index: install.globalIdx },
+  );
+}
+
+/**
+ * Restore the saved receiver after a closure call and hand `result` straight
+ * back, so a call site reads `return finishClosureReceiverCall(fctx, install,
+ * compileClosureCall(…))`. A `null`/`VOID_RESULT` result left nothing on the
+ * stack; anything else is parked in a typed local across the restore.
+ *
+ * `install === undefined` (the callee was not admitted) is a pass-through, which
+ * is what keeps every unadmitted shape byte-identical.
+ */
+export function finishClosureReceiverCall<T extends ValType | null | symbol>(
+  fctx: FunctionContext,
+  install: ClosureReceiverInstall | undefined,
+  result: T,
+): T {
+  if (!install) return result;
+  const restore: Instr[] = [
+    { op: "local.get", index: install.prevLocal },
+    { op: "global.set", index: install.globalIdx },
+  ];
+  const type = innerResultValType(result);
+  if (type === undefined) {
+    fctx.body.push(...restore);
+    return result;
+  }
+  const resultLocal = allocLocal(fctx, `__recv_this_res_${fctx.locals.length}`, type);
+  fctx.body.push({ op: "local.set", index: resultLocal }, ...restore, { op: "local.get", index: resultLocal });
+  return result;
+}

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -345,6 +345,11 @@ import {
   wasmParamIndexForSourceParam,
 } from "../linear-uint8-signatures.js";
 import { resolveNamedThisCallTarget, tryReshapeApplyToNamedThisCall } from "../named-this-call.js";
+import {
+  emitClosureReceiverInstall,
+  finishClosureReceiverCall,
+  planClosureReceiverInstall,
+} from "../closure-receiver-install.js";
 import { isStrictContext } from "../helpers/is-strict-function.js";
 
 // Registry extracted to its own leaf module (#1793; LOC ratchet #3102) —
@@ -7045,6 +7050,18 @@ function compileCallExpression(
           }
         }
 
+        // (#4192) A CLOSURE callee (`var fe = function () { … this … }`) never
+        // reached the named-`this` trampoline above — that arm is gated on
+        // `!closureInfo` — so its receiver was evaluated and DROPPED. Install
+        // it in `__current_this`, which the lifted body already reads. Load-
+        // bearing invariant: every `closureInfo` sub-path below returns through
+        // a `finishClosureReceiverCall`, so the restore is always reachable.
+        // See closure-receiver-install.ts.
+        const closureReceiver =
+          closureInfo !== undefined && expr.arguments.length > 0
+            ? planClosureReceiverInstall(ctx, fctx, innerExpr)
+            : undefined;
+
         if (closureInfo || funcIdx !== undefined) {
           // Evaluate thisArg first. The receiver-correct named trampoline owns
           // it as leading externref param; every other existing path keeps the
@@ -7054,9 +7071,11 @@ function compileCallExpression(
               ctx,
               fctx,
               expr.arguments[0]!,
-              namedThisCall ? { kind: "externref" } : undefined,
+              namedThisCall || closureReceiver ? { kind: "externref" } : undefined,
             );
-            if (thisType && !namedThisCall) {
+            if (thisType && closureReceiver) {
+              emitClosureReceiverInstall(fctx, closureReceiver);
+            } else if (thisType && !namedThisCall) {
               fctx.body.push({ op: "drop" });
             }
           }
@@ -7074,7 +7093,11 @@ function compileCallExpression(
               );
               // Copy source file info for error reporting
               (syntheticCall as any).parent = expr.parent;
-              return compileClosureCall(ctx, fctx, syntheticCall as ts.CallExpression, funcName, closureInfo);
+              return finishClosureReceiverCall(
+                fctx,
+                closureReceiver,
+                compileClosureCall(ctx, fctx, syntheticCall as ts.CallExpression, funcName, closureInfo),
+              );
             }
 
             // Check for rest parameters on the callee
@@ -7180,7 +7203,11 @@ function compileCallExpression(
                   elements as unknown as readonly ts.Expression[],
                 );
                 (syntheticCall as any).parent = expr.parent;
-                return compileClosureCall(ctx, fctx, syntheticCall as ts.CallExpression, funcName, closureInfo);
+                return finishClosureReceiverCall(
+                  fctx,
+                  closureReceiver,
+                  compileClosureCall(ctx, fctx, syntheticCall as ts.CallExpression, funcName, closureInfo),
+                );
               }
               const applyRestInfo = ctx.funcRestParams.get(funcName);
               if (applyRestInfo) {
@@ -7249,7 +7276,11 @@ function compileCallExpression(
             if (closureInfo) {
               const syntheticCall = ts.factory.createCallExpression(innerExpr, undefined, []);
               (syntheticCall as any).parent = expr.parent;
-              return compileClosureCall(ctx, fctx, syntheticCall as ts.CallExpression, funcName, closureInfo);
+              return finishClosureReceiverCall(
+                fctx,
+                closureReceiver,
+                compileClosureCall(ctx, fctx, syntheticCall as ts.CallExpression, funcName, closureInfo),
+              );
             }
             const applyNoArgsRestInfo = ctx.funcRestParams.get(funcName);
             if (applyNoArgsRestInfo) {

--- a/tests/issue-4192-fn-expr-this-call-apply.test.ts
+++ b/tests/issue-4192-fn-expr-this-call-apply.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #4192 — `f.call(thisArg)` / `f.apply(thisArg)` must install the receiver when
+// `f` is a variable-held FUNCTION EXPRESSION.
+//
+// A function DECLARATION already worked (#3796/#4025 `.call`, #3983 `.apply` —
+// `named-this-call.ts` reserves an exact-target trampoline that saves,
+// installs and restores `__current_this`). A function EXPRESSION did not:
+// `resolveDeclaration` there demands `ts.isFunctionDeclaration`, and the call
+// site gates the whole named-`this` arm on `!closureInfo` — and
+// `var f = function () {}` registers a `closureMap` entry. So the dominant JS
+// shape fell into the legacy arm, which evaluates `thisArg` and DROPS it. A
+// silent wrong answer, and present in BOTH lanes — hence every case below runs
+// host and standalone.
+//
+// Compile through the SAME lane the test262 runner uses — literal JavaScript
+// with `allowJs`; an annotated `.ts` receiver takes a different, statically
+// typed member-call route and does not reproduce it.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * Compile `body` at TOP LEVEL (where `var f = function () {…}` really is a
+ * module-level binding — nesting it inside a probe function changes the
+ * closure shape and does not reproduce the defect), record its verdict in
+ * `__r`, and read that back through an exported `test()`.
+ */
+async function run(body: string, standalone: boolean): Promise<number> {
+  const r = await compile(`var __r = 0;\n${body}\nexport function test() { return __r; }`, {
+    ...(standalone ? { target: "standalone" as const } : {}),
+    allowJs: true,
+    fileName: "test.js",
+    skipSemanticDiagnostics: true,
+  });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  if (standalone) expect(r.imports ?? [], "standalone must stay host-free").toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool) as Record<string, unknown>;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as never);
+  (imports as { setInstance?: (i: WebAssembly.Instance) => void }).setInstance?.(instance);
+  const exports = instance.exports as { __module_init?(): void; test(): number };
+  exports.__module_init?.();
+  return exports.test();
+}
+
+/** Assert the probe answers 1 on the JS-host lane AND on `--target standalone`. */
+async function expectBoth(body: string): Promise<void> {
+  expect(await run(body, false), "JS-host lane").toBe(1);
+  expect(await run(body, true), "standalone lane").toBe(1);
+}
+
+describe("#4192 `this` through .call/.apply on a variable-held function expression", () => {
+  it("writes through `this` (the test262 S15.3.4.4_A5_T5 shape)", async () => {
+    await expectBoth(`
+      var f = function () { this.touched = true; };
+      var obj = {};
+      f.call(obj);
+      __r = obj.touched === true ? 1 : 0;
+    `);
+  });
+
+  it("reads through `this` and returns the value", async () => {
+    await expectBoth(`
+      var g = function () { return this.v; };
+      __r = g.call({ v: 9 }) === 9 ? 1 : 0;
+    `);
+  });
+
+  it("keeps the bound args positional alongside the receiver", async () => {
+    await expectBoth(`
+      var h = function (a, b) { return String(this.v) + ":" + String(a) + String(b); };
+      __r = h.call({ v: 7 }, "x", "y") === "7:xy" ? 1 : 0;
+    `);
+  });
+
+  it("works through .apply with an array literal", async () => {
+    await expectBoth(`
+      var h = function (a) { return String(this.v) + ":" + String(a); };
+      __r = h.apply({ v: 5 }, ["z"]) === "5:z" ? 1 : 0;
+    `);
+  });
+
+  it("works through .apply with no argument array", async () => {
+    await expectBoth(`
+      var f = function () { this.touched = true; };
+      var obj = {};
+      f.apply(obj);
+      __r = obj.touched === true ? 1 : 0;
+    `);
+  });
+
+  it("a NULL receiver still yields `undefined` (the spec row that must not move)", async () => {
+    await expectBoth(`
+      var g = function () { return typeof this; };
+      __r = g.call(null) === "undefined" ? 1 : 0;
+    `);
+  });
+
+  // The install/restore PAIRING, not just the install: the outer receiver must
+  // survive an inner `.call` that installed a different one.
+  it("restores the previous receiver after the call", async () => {
+    await expectBoth(`
+      var inner = function () { return String(this.tag); };
+      var outer = function () { return inner.call({ tag: "IN" }) + "/" + String(this.tag); };
+      __r = outer.call({ tag: "OUT" }) === "IN/OUT" ? 1 : 0;
+    `);
+  });
+
+  it("leaves a function DECLARATION on its existing (already correct) path", async () => {
+    await expectBoth(`
+      function d() { return String(this.v); }
+      __r = d.call({ v: 3 }) === "3" ? 1 : 0;
+    `);
+  });
+
+  // An arrow ignores the `.call` receiver by spec — its `this` is lexical — so
+  // `planClosureReceiverInstall` refuses arrows outright. Installing for them
+  // would be a behaviour change, not a fix.
+  it("does NOT install a dynamic receiver for an arrow", async () => {
+    await expectBoth(`
+      var a = () => 42;
+      __r = a.call({ v: 1 }) === 42 ? 1 : 0;
+    `);
+  });
+
+  it("does not disturb a callee that never mentions `this`", async () => {
+    await expectBoth(`
+      var p = function (x) { return "p" + String(x); };
+      __r = p.call({ v: 1 }, 8) === "p8" ? 1 : 0;
+    `);
+  });
+});


### PR DESCRIPTION
```js
var fe = function () { this.touched = true; };
var o = {}; fe.call(o);          // o.touched === undefined   (want true)
function fd() { this.touched = true; }
var p = {}; fd.call(p);          // true  ✓ — a DECLARATION already worked
```

A function **declaration** gets this right (#3796/#4025 `.call`, #3983 `.apply` — `named-this-call.ts` reserves an exact-target trampoline that saves, installs and restores `__current_this`). A function **expression** did not: `resolveDeclaration` there demands `ts.isFunctionDeclaration`, and the call site gates the whole named-`this` arm on `!closureInfo` — and `var f = function (){}` registers a `closureMap` entry. So the dominant JS function shape fell into the legacy arm, which evaluates `thisArg` and **drops** it. Same defect class in both lanes: this is a JS-host bug too, not an es5-standalone one.

**The lifted body needed no change.** WAT for the repro shows it already opening with `global.get $__current_this; ref.is_null; (if … $__undefined …)`; nothing in the module ever *wrote* that global on this path. Only the writer was missing.

## Change

New leaf module `src/codegen/closure-receiver-install.ts`: `planClosureReceiverInstall` (admission) + `emitClosureReceiverInstall` / `finishClosureReceiverCall` (inline save/install/restore, mirroring `__call_fn_method_N` and `fillDirectCallTrampolines` — including their documented limitation that an exceptional unwind skips the restore).

Admission is narrow: a `VariableDeclaration` initialised with a `FunctionExpression` (arrows excluded — their `this` is lexical), non-generator, non-`async`, no explicit `this` parameter, body references its own `this`. A null receiver needs no arm: the body's own `ref.is_null` guard already answers `undefined`, so `f.call(null)` is unchanged.

## Measured

Base-vs-head, `--target standalone`, ES5, interpreter runtime-eval tier:

| corpus | base | head |
| --- | ---: | ---: |
| `built-ins/Function/prototype` | 94 | **95** |
| 148-file corpus (every ES5 file using `.call(`/`.apply(` **and** a function expression, ∪ the `Array.prototype` HOF-`thisArg` family — the other `__current_this` consumer) | 84 | **86** |

**FIXED 2, BROKE 0**, no signature changes among the still-failing. Two apparent regressions in the first sweep were parallel-run compile timeouts and pass when re-run serially.

All **8 equivalence shards** green. Four ratchets green (`calls.ts` +31 LOC / `compileCallExpression` +26, allowed in the issue frontmatter — the mechanism itself is in the new leaf module; only the call-site wiring can live in the driver). `check:ir-fallbacks` green. `tsc --noEmit` clean.

`tests/issue-4192-fn-expr-this-call-apply.test.ts` — 10 cases, each on **both** lanes. Verify-first: **6 are RED on `origin/main`**; the 4 green on both are the guards that must not move (null receiver, function declaration, arrow, callee that never mentions `this`).

The ES5 delta is small because only 43 ES5 files use this shape at all. The value is correctness in the dominant JS function form, in both lanes.

## Deliberately out of scope

- **Method invocation** — `var o = { m: fe }; o.m()` still drops the receiver. Different path (`call-receiver-method.ts`) and the commonest shape, so probably the most valuable follow-up.
- **`.bind`** — the `$__bound_fn` carrier, entangled with the 34-file `Function.prototype.bind` bucket.

## Also in this PR

`plan/issues/4192` (live), `4191` and `4193` as **superseded stubs** keeping only what the superseding work lacks, and a re-measure section appended to `plan/issues/2875`:

- **#4191 → PR #4163**, plus a correction to #4163's trigger analysis. The trigger is not (only) the `$262.evalScript` shim — it is `sourceUsesRuntimeEvalBoundary` firing on any value-position mention of `Function`/`eval`. Minimal proof, no harness: `"var g = Function; var z = 1;"` emits the carrier import, `"var f = new Function('return 1');"` does not.
- **#4193 → #4176 / PR #4155**, plus the independent 112/139 census and specifically that **63 of them are in `built-ins/Object/defineProperty`** — inside #4163's #1 lever but not behind the descriptor MOP.

## Coordination

W12 concurrently implements the 168-file 10.4.3 `this`-binding cluster in `src/codegen/expressions.ts`. Different mechanism, adjacent territory. This PR touches neither `expressions.ts` nor the body's `this` lowering — it only adds the missing *writer* of `__current_this` at one call site. The two compose: W12 decides what a body reads when nothing is installed; this decides what gets installed.

## Measurement trap worth propagating

Any `src/` edit changes `computeCompilerBundleHash`, invalidating the runtime-eval provider cache and silently dropping a standalone A/B back to the **refusal** tier. That turned a clean `+2 / 0 regressions` into an apparent `−10` on the first run — 10 files "broke" with `dynamic code evaluation is not supported`. Recorded in the #4191 stub.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_