### PR TITLE
docs(#4194): standalone instances have no expando substrate — the cause of compiled-acorn's { f } rejection, + the #4158 eval-code +16

### DIFF
--- a/plan/agent-context/W14-annexb-eval-code.md
+++ b/plan/agent-context/W14-annexb-eval-code.md
@@ -1,0 +1,301 @@
+# W14 — annexB eval-code lever (2026-08-06): context + PR body
+
+Agent `ttraenkler/W14-annexb-eval-code`. Branch
+`issue-4137-acorn-forin-instance-keys` on `origin` (this checkout's `origin`
+**is** upstream `loopdive/js2`; there is no `fork` remote). No PR — `gh` is
+unauthenticated here (401).
+
+**Nothing was fixed. Two things were measured and one issue was filed.** The
+42-file lever refuted its framing: neither arm is an Annex B defect, and neither
+is fixable in this lane without work that belongs to other issues.
+
+---
+
+## PR body (verbatim)
+
+Files **#4194** and records two measurements. No compiler change.
+
+### 1. The lever, measured with a control
+
+Population: the 42 standalone ES5-label failures under
+`annexB/language/eval-code/` (2026-08-06 published baseline). Control: the 427
+files in the same directory that currently pass.
+
+| build | lever pass / 42 | control pass / 427 |
+| --- | ---: | ---: |
+| `origin/main` (431ea77d55) | 1 | 427 |
+| + `origin/issue-4182-annexb-global-blockfn` merged | **17** | **427** |
+
+**+16, zero regressions.** Both control runs are the full 427, not a sample.
+
+The instrument was validated before any claim: the baseline run agrees with the
+published standalone jsonl on **41 of 42** files (the one disagreement is
+`func-if-decl-no-else-eval-func-existing-block-fn-update.js`, a
+`compile_timeout` in CI that passes locally), and the control proves the runner
+can see a pass — a lever-only instrument cannot tell "my fix did nothing" from
+"my runner cannot see a pass".
+
+### 2. `issue-4182-annexb-global-blockfn` is worth +16 in a directory nobody
+attributed to it
+
+All 16 flips are `annexB/language/eval-code/**-existing-block-fn-update`. Every
+one has the same outer shape — `{ function f(){ return 'first declaration'; } }`
+at script top level — whose AOT binding does not exist on `main`, so eval's
+B.3.3 `SetMutableBinding` has nothing to update.
+
+The eval→AOT write-back itself is **not** broken, which is the part worth
+recording because it is the obvious wrong suspect. Probe `p11.js`, one file, four
+outer forms, all four correct on plain `main`:
+
+| outer binding | eval'd code | result |
+| --- | --- | --- |
+| `var v1 = 'first'` | `v1 = "second"` | second |
+| `var v2 = 'first'` | `var v2 = "second"` | second |
+| `var v3 = 'first'` | `{ function v3(){ return "second"; } }` | second |
+| `function v4(){ return 'first' }` | `{ function v4(){ return "second"; } }` | second |
+
+Only the form with **no AOT binding at all** fails. So the family is purely
+#4182-downstream; there is no separate eval-side defect here.
+
+### 3. #4194 — the other 24 files are a compiled-acorn defect, three layers deep
+
+The 24 `*-skip-early-err-try` files all fail as `SyntaxError: NaN`. Root cause,
+A/B'd on the real pinned acorn tarball: **in `--target standalone` a constructed
+instance has no expando substrate.**
+
+| surface, instance with ctor fields + a later `n.name = "f"` | standalone | js-host |
+| --- | ---: | ---: |
+| `for (const p in n)` — keys seen | **0** | all |
+| `Object.keys(n).length` | **0** | 2 |
+| `("type" in n) + ("name" in n)` | **neither** | both |
+| read back `n.name` after writing it | **undefined** | `"f"` |
+
+Acorn's `copyNode` is `for (var prop in node) { newNode[prop] = node[prop] }`
+over a `Node` instance, and it is called on exactly one path — **object-property
+shorthand**. It returns a blank node, so `checkLValPattern` reads
+`type === undefined`, falls through to `checkLValSimple`'s `default:` arm, and
+raises. Compile the tarball twice changing **only** `copyNode`:
+
+| build | `var { a } = {}` | `var { a: b } = {}` | `catch ({ f }) {{ function f(){} }}` | `var o = { f }` |
+| --- | --- | --- | --- | --- |
+| stock | **raise** | ok | **raise** | ok |
+| copyNode patched | ok | ok | ok | ok |
+
+Consequence well beyond these 24: **no standalone `eval`/`Function` parses object
+destructuring shorthand.** `var {a}={}`, `let {f}={}`, `function g({f}){}`,
+`({f}={})`, `for (var {f} of [])`, `catch ({f})` all reject; `{a: b}`, `[a]` and
+object-*expression* `{f}` are fine.
+
+Fixing that alone flips **zero** of the 24. Two more layers, both measured:
+
+- **Layer 2** — with a shorthand-free but semantically identical oracle
+  (`catch ({ f: f })`, which stock compiled acorn *can* parse) the interpreter
+  refuses: `interp/emitter: unsupported in Phase 1: catch destructuring
+  (ObjectPattern)`. #4137 arm 3 / #2928 Phase 2.
+- **Layer 3** — B.3.5 exempts only a `BindingIdentifier`; a *destructuring*
+  CatchParameter must **cancel** the Annex B synthetic var. #4137 built
+  `SIMPLE_CATCH_SCOPE_LABEL` for the exempt half; the cancelling half has never
+  been reached by any input.
+
+Not attempted here on purpose: layer 1 is `#4098` / `#4010` rows 4-7 greenfield
+and the adjacent widening carries a **measured -5** on record (#4071,
+`Object.keys` over closed structs). Landing it unmeasured at the tail of a budget
+window is the shape of failure this project already has receipts for.
+
+### 4. Correction to #4137's arm 3
+
+#4137's handoff attributes `SyntaxError: NaN` to an `any`-typed compound `+` in
+`src/codegen/expressions/operator-assignment.ts` and to a second compiled-acorn
+**scope-tracking** defect, handing on a `pa9.ts`/`pa10.ts` probe pair. The
+message corruption is real but **cosmetic**; the verdict-changing defect is
+`copyNode`, and it is not scope tracking. `err.pos` is `NaN` as well as
+`err.message`, which a `message += string` bug cannot explain — on genuine syntax
+errors (`var 1 = 2;`, `(`, `a b c`) node-acorn gives `Unexpected token (1:N)` with
+`err.pos = N` and compiled acorn gives message `"NaN"`, `err.pos = NaN`. Anyone
+starting from the scope tracker will not find the bug.
+
+**#4137 was NOT edited** — it is still claimed by `ttraenkler/L3-annexb-hoisting`
+on `origin/issue-assignments` and owner pins are absolute. The correction lives
+in #4194 so the next lane finds it.
+
+---
+
+## 5. Requested side-measurement — the shape of annexB `function-code` (50 failures)
+
+Asked for by the lead before dispatching anyone at that bucket. **No fix, shape
+only.** Note it is **50**, not 49 (the census's 49 omits the one `compile_error`).
+
+First, the decisive negative: **`issue-4182-annexb-global-blockfn` flips 0 of the
+50** (measured on the same stacked build that scored +16 in eval-code). It is
+global-scope only; function-code needs its own work.
+
+These are **pure AOT** — no `eval` anywhere. Every test declares a function whose
+body contains a block-level function declaration, and asserts §B.3.3.1
+(FunctionDeclarationInstantiation) behaviour:
+
+```js
+var init, changed;
+(function() {
+  init = f;                       // want undefined — the FDI-created var binding
+  f = 123;
+  changed = f;
+  { function f() {  } }
+}());
+assert.sameValue(init, undefined, 'binding is initialized to `undefined`');
+assert.sameValue(changed, 123,    'binding is mutable');
+```
+
+By test **case** (the suffix after `-func-`; the prefix is only the syntactic
+form — `block-decl` / `if-decl-*` / `switch-*` — and is NOT the mechanism):
+
+| case | fail/total | dominant signature |
+| --- | ---: | --- |
+| `skip-dft-param` | 8/8 | `binding is not initialized to undefined` — got `NaN`, want `123` |
+| `init` | 8/8 | `binding is initialized to undefined` — got a function |
+| `existing-block-fn-update` | 8/8 | `"first declaration"` vs `"second declaration"` |
+| `no-skip-try` | 7/8 | `Initialized binding created prior to evaluation` |
+| `existing-fn-update` | 5/8 | `"outer declaration"` vs `"inner declaration"` |
+| `existing-var-update` | 3/8 | `"number"` vs `"function"` |
+| `existing-fn-no-init` | 3/8 | `"inner declaration"` vs `"outer declaration"` |
+| `block-scoping` | 3/8 | **`illegal cast [in f() ← __module_init]`** |
+| `skip-early-err-{try,for-in,for-of}` | 3/24 | `An uninitialized binding is not created following evaluation` |
+| `function-redeclaration-switch` | 1/1 | **`compile_error: Cannot redeclare block-scoped variable 'a'`** |
+| `skip-arguments` | 1/1 | `""` vs `"[object Arguments]"` |
+
+Three groups, and they are **not** one dispatch:
+
+- **A — the var binding is never created at FDI (34 files):** `init`,
+  `skip-dft-param`, `no-skip-try`, `existing-fn-update`, `existing-var-update`,
+  `existing-fn-no-init`. This is `annexBOuterBindings` in FDI — **#2200 Phase 2**,
+  whose last attempt (#1769) cost **-1180** and was reverted. Do not dispatch this
+  without a local test262 slice over the buckets that regressed.
+- **B — the binding exists but the block-fn assignment does not update it
+  (8 files):** `existing-block-fn-update`. This is the **function-scope twin of
+  what #4182 just solved for global scope** — same case name, same assertion pair,
+  same mechanism one scope down. Plausibly a bounded extension of an
+  already-reviewed design rather than the Phase-2 rewrite. Best value in the
+  bucket, and it is separable from group A.
+- **C — crashes / compile failures, orthogonal to Annex B semantics (5 files):**
+  3× `illegal cast [in f() ← __module_init]` (`block-scoping`), 1 compile_error
+  (`Cannot redeclare block-scoped variable 'a'`), 1 `skip-arguments`. A hard cast
+  trap is a codegen bug that happens to live here; it needs no FDI change and can
+  be taken by anyone.
+
+Population and control lists are `.tmp/lever/fc.txt` (50) and
+`.tmp/lever/fc-control.txt` (109 currently-passing) — regenerate from the
+standalone jsonl with a two-line filter on
+`test/annexB/language/function-code/`.
+
+## Instrument (reproduce before trusting any number above)
+
+Three separate traps, all of which have cost other lanes time today:
+
+1. `tests/test262-runner.ts`'s in-process `runTest262File` does **not** attach
+   the `js2wasm:runtime-eval` provider namespace (#4162, filed, unmerged). Do not
+   use it for this lane; mirror `tests/test262-shared.ts`'s normal path instead —
+   `CompilerPool(n, "unified")` + `assembleOriginalHarness` + strict rerun. That
+   harness is `.tmp/lever/run.mts` (list → json) and `.tmp/lever/probe.mts`
+   (arbitrary file → verdict).
+2. Build order is not optional: esbuild `src/index.ts → scripts/compiler-bundle.mjs`
+   **and** `src/runtime.ts → scripts/runtime-bundle.mjs`, then
+   `node scripts/build-runtime-eval-provider.mjs` (~100 s; its cache key folds in
+   the compiler-bundle hash, so redo it after **every** source change being
+   A/B'd), then run with `TEST262_FULL_RUNTIME_EVAL=1`. Without the flag the
+   REFUSAL tier answers and every eval test reports
+   `dynamic code evaluation is not supported`.
+3. A fresh worktree's `test262` / `node_modules` may be symlinked into **another
+   agent's worktree** (this one was, into `agent-a788d4f5a3ccb09f5`) — that
+   vanishes when they clean up. Repoint them at the shared checkout.
+
+## Preserved probes
+
+`.tmp/` is gitignored and dies with the worktree. Everything load-bearing is
+restated in #4194; these are the two that are hardest to re-derive.
+
+### The standalone-vs-host expando table (`.tmp/probe/forin-lanes.mts`)
+
+Compile ONE source twice — `{ target: "standalone" }` vs the host default — and
+call all four exports. ~10 s total; it is the fastest way to re-confirm #4194.
+
+```ts
+class Node {
+  type: any; start: any;
+  constructor(start: any) { this.type = "Identifier"; this.start = start; }
+}
+export function seesFields(): number {          // standalone 0, host 111
+  const n: any = new Node(7); n.name = "f";
+  let seen = 0;
+  for (const p in n) {
+    if (p === "type") seen += 1;
+    if (p === "start") seen += 10;
+    if (p === "name") seen += 100;
+  }
+  return seen;
+}
+export function keysLen(): number {             // standalone 0, host 2
+  const n: any = new Node(7); n.name = "f";
+  return Object.keys(n).length;
+}
+export function hasType(): number {             // standalone 0, host 11
+  const n: any = new Node(7); n.name = "f";
+  return ("type" in n ? 1 : 0) + ("name" in n ? 10 : 0);
+}
+export function readsBack(): number {           // standalone 101, host 111
+  const n: any = new Node(7); n.name = "f";
+  return (n.type === "Identifier" ? 1 : 0) + (n.name === "f" ? 10 : 0) + (n.start === 7 ? 100 : 0);
+}
+```
+
+Host-lane instantiation needs `compileAndInstantiate` from
+`src/runtime-instantiate.ts` (a bare `WebAssembly.Instance` fails on `env::*`).
+
+### The copyNode A/B (`.tmp/probe/acorn-copynode-ab.mjs`)
+
+Compile `tests/dogfood/setup-acorn.mjs`'s pinned tarball twice (~50 s each),
+replacing exactly this text and nothing else:
+
+```js
+// stock
+pp$2.copyNode = function(node) {
+  var newNode = new Node(this, node.start, this.startLoc);
+  for (var prop in node) { newNode[prop] = node[prop]; }
+  return newNode
+};
+// patched — enough fields for an Identifier key
+pp$2.copyNode = function(node) {
+  var newNode = new Node(this, node.start, this.startLoc);
+  newNode.type = node.type; newNode.start = node.start; newNode.end = node.end;
+  newNode.name = node.name; newNode.loc = node.loc; newNode.range = node.range;
+  return newNode
+};
+```
+
+Append numeric-only probes (nothing may cross the boundary as a string):
+
+```ts
+export function pos_x(): number {
+  try { parse(<src>, { ecmaVersion: 2022, sourceType: "script" }); return -1; }
+  catch (e: any) { const p = e.pos; if (p !== p) return -3; return p === undefined ? -2 : p; }
+}
+```
+
+`-1` = parsed, `-3` = raised with a NaN pos. Stock gives `-3` for
+`var { a } = {}` and `catch ({ f })`; patched gives `-1` for both.
+
+## What I deliberately left undone
+
+- **#4194 itself.** Reasons above: greenfield substrate, a -5 on the adjacent
+  widening, and two further layers behind it so layer 1 alone banks nothing.
+  Whoever takes it should split the **write** half (a dynamic assignment to an
+  instance is currently dropped) from the **enumeration** half, and must NOT
+  widen `for-in` and `Object.keys` with one switch — the -5 lives on the
+  `Object.keys`-over-builtin-structs side.
+- **The `NaN` message/pos channel.** Independent, cosmetic, flips nothing, but it
+  is why the shorthand bug survived this long. Both `err.message` and `err.pos`
+  are numerified, so it is not only the `message += " (" + line + ":" + col + ")"`
+  concat that #4137 identified.
+- **`direct/script-decl-lex-no-collision.js`** — the 42nd file, a singleton
+  (`Expected SameValue(«function () { [native code] }», «1»)`), untouched.
+- **The 12 non-annexB `SyntaxError: NaN` files** (`language/{expressions,
+  statements}/class`). Same acorn root cause; they may need only layer 1, which
+  cannot be tested until layer 1 exists.

--- a/plan/issues/4194-standalone-instance-expando-substrate-breaks-compiled-acorn.md
+++ b/plan/issues/4194-standalone-instance-expando-substrate-breaks-compiled-acorn.md
@@ -1,0 +1,227 @@
+---
+id: 4194
+title: "standalone: a constructed instance has no expando substrate — for-in/Object.keys/`in` see 0 keys and a dynamic write is DROPPED; this is what makes compiled acorn reject `{ f }` destructuring in every eval"
+status: ready
+sprint: current
+created: 2026-08-06
+updated: 2026-08-06
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: runtime
+es_edition: 5
+language_feature: objects
+goal: standalone-mode
+related: [2928, 4010, 4055, 4071, 4098, 4137, 4182]
+origin: "W14 (annexB eval-code lever, 2026-08-06). Reserved with pr_scan=degraded (gh unauthenticated) — re-verify the id before merge."
+---
+
+# #4194 — a constructed instance has no expando substrate in standalone, and compiled acorn is the victim
+
+## TL;DR
+
+In `--target standalone`, an object produced by `new C(...)` (ES `class` **or**
+function constructor) supports **no reflective own-property surface at all**,
+and a dynamically-added property is **silently discarded**. Measured on current
+`main`, same source compiled twice:
+
+| surface, on an instance with ctor fields `type`/`start` + a later `n.name = "f"` | standalone | js-host | correct |
+| --- | ---: | ---: | ---: |
+| `for (const p in n)` — keys seen (bitmask 1/10/100) | **0** | 111 | 111 |
+| `Object.keys(n).length` | **0** | 2 | 3 |
+| `("type" in n) + ("name" in n)` (1/10) | **0** | 11 | 11 |
+| direct reads `n.type` / `n.name` / `n.start` (1/10/100) | **101** | 111 | 111 |
+
+The last row is the sharpest one: `readsBack = 101` means the *write itself*
+was dropped — `n.name = "f"` on an `any` holding a class instance is a no-op in
+standalone, and the read-back is `undefined`. The host lane is essentially
+correct (its `keysLen = 2` vs 3 is a separate, much smaller gap).
+
+`carrier-bag-visibility.ts` already names this as known-greenfield —
+*"Date / RegExp / Error / class instances have no bag, so `__carrier_bag_of`
+answers null … their expando substrate is still greenfield (#4010's matrix rows
+4-7); #4098 is the issue that needs it."* This issue is not the discovery of
+that gap. It is the **consumer** that makes it urgent, plus a decisive A/B that
+localises the payoff.
+
+## Why this is not a niche reflection bug
+
+The standalone `eval` / `new Function` provider is **compiled acorn**. Acorn's
+`copyNode` is:
+
+```js
+pp$2.copyNode = function(node) {
+  var newNode = new Node(this, node.start, this.startLoc);
+  for (var prop in node) { newNode[prop] = node[prop]; }   // <- enumerates NOTHING
+  return newNode
+};
+```
+
+`node` is an untyped parameter, so the receiver is `any` → the for-in takes the
+dynamic path (`__object_keys_forin`) → the runtime value is not a `$Object` and
+has no carrier bag → **zero keys** → `copyNode` returns a blank `Node`.
+
+`copyNode` is called on exactly one hot path: **object-property shorthand**.
+
+```js
+// acorn parsePropertyValue, shorthand arm
+prop.value = isPattern
+  ? this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key))   // pattern
+  : this.copyNode(prop.key);                                              // expression
+```
+
+For an object *expression* nobody inspects the copy, so `var o = { f }` looks
+fine. For an object **pattern**, `checkLValPattern(prop.value)` reads
+`expr.type` — `undefined` on the blank copy — falls through every case to
+`checkLValSimple`'s `default:` arm and **raises**. Hence:
+
+| eval'd source | node-acorn | compiled acorn (standalone) |
+| --- | --- | --- |
+| `var { a: b } = {};` | ok | ok |
+| `var [a] = [];` | ok | ok |
+| `var o = { f };` | ok | ok |
+| **`var { a } = {};`** | ok | **SyntaxError** |
+| **`let { f } = {};` / `function g({ f }){}` / `({ f } = {})` / `for (var { f } of [])` / `catch ({ f })`** | ok | **SyntaxError** |
+
+So: **no standalone `eval`/`Function` can parse object destructuring shorthand.**
+
+### The A/B that proves it — on the real artifact, not a model
+
+Compile the pinned acorn tarball twice, changing **only** `copyNode`'s for-in
+into explicit field copies (`.tmp/probe/acorn-copynode-ab.mjs`):
+
+| build | `var { a } = {}` | `var { a: b } = {}` | `catch ({ f }) {{ function f(){} }}` | `var o = { f }` |
+| --- | --- | --- | --- | --- |
+| A stock | **raise** | ok | **raise** | ok |
+| B copyNode patched | **ok** | ok | **ok** | ok |
+
+One two-line change to a single acorn function, and every shorthand shape
+parses. Nothing else in the parser is implicated.
+
+## Second, INDEPENDENT defect found alongside — every acorn diagnostic renders `NaN`
+
+Recorded here because the two are always seen together and were previously
+conflated (see "Corrections to #4137" below). On genuine syntax errors, where
+compiled acorn is *supposed* to raise:
+
+| eval'd source | node-acorn | compiled acorn |
+| --- | --- | --- |
+| `var 1 = 2;` | `Unexpected token (1:4)`, `err.pos = 4` | message `"NaN"`, `err.pos = NaN` |
+| `(` | `Unexpected token (1:1)`, `err.pos = 1` | message `"NaN"`, `err.pos = NaN` |
+| `a b c` | `Unexpected token (1:2)`, `err.pos = 2` | message `"NaN"`, `err.pos = NaN` |
+
+`err.pos` is `NaN` too, not just the message — so this is **not** only the
+`message += " (" + line + ":" + col + ")"` string-concat lowering. Something in
+`pp.raise(pos, message)`'s argument path numerifies **both** operands. This
+defect changes **no verdicts** on its own (the raise still happens, the test
+still fails) — it destroys the *diagnostic*, which is why the shorthand bug
+above stayed invisible for so long. Fix the substrate first; fix this so the
+next one is findable.
+
+## Payoff, measured honestly
+
+`SyntaxError: NaN` is **36 standalone records** — 24 in
+`annexB/language/eval-code/**-skip-early-err-try`, 12 in
+`language/{expressions,statements}/class`. Every one of them is this shorthand
+raise.
+
+**But fixing this alone flips ZERO of the 24 annexB files.** They need a
+three-layer stack, and layers 2 and 3 are separate work:
+
+1. **this issue** — instance expando substrate, so `copyNode` works and acorn
+   parses `catch ({ f })`.
+2. **interpreter emitter** — measured with a shorthand-free but semantically
+   identical oracle (`catch ({ f: f })`, which stock compiled acorn *can*
+   parse): the interpreter then refuses with
+   `Error: interp/emitter: unsupported in Phase 1: catch destructuring
+   (ObjectPattern)`. That is #4137's arm 3 / #2928 Phase 2 scope.
+3. **B.3.3 condition ii / B.3.5** — a *destructuring* CatchParameter must
+   **cancel** the Annex B synthetic var (only a `BindingIdentifier` is exempt).
+   #4137 built `SIMPLE_CATCH_SCOPE_LABEL` for the exempt half; the cancelling
+   half is untested because nothing has ever reached it.
+
+The 12 class-family files may need only layer 1 — not verified, because layer 1
+does not exist yet to test against.
+
+The wider payoff is not countable from the current baseline at all: every
+standalone `eval` of shorthand-using source fails *today* with an unrelated-
+looking message, and a working instance expando substrate is a prerequisite for
+#4098 and for `Date`/`RegExp`/`Error` expandos (#4010 rows 4-7).
+
+## Implementation notes / hazards
+
+- **`Object.keys` is NOT the same surface as `for-in` here, and the difference
+  is load-bearing.** #4071 measured **-5** for letting closed-struct fields into
+  `Object.keys` and was reverted. Do not widen `Object.keys` and for-in with one
+  switch. The acorn consumer needs **for-in** (and the dynamic *write* to be
+  retained); `Object.keys` on builtin-backed structs is where the -5 lives.
+- The **write** half is the harder half and probably has to come first: there is
+  no point enumerating a key the assignment threw away. `readsBack = 101` says
+  `n.name = "f"` on an instance-typed `any` currently lands nowhere.
+- Follow the composition rule the bag work established: the existing answer runs
+  **first** and is returned when affirmative; the new substrate is consulted only
+  where today's answer is "absent". That is what kept #4055 v2 from re-running
+  into the -684.
+- A **query must never allocate** a bag/substrate (`carrier-bag-hasown.ts`
+  rule) — `for (p in x)` on a fresh instance must not hand a later
+  `__integrity_bag` consumer a carrier it did not have.
+
+## Reproduction
+
+All probes are in the (gitignored) worktree `.tmp/probe/`; each is restated
+inline above so nothing load-bearing dies with the worktree.
+
+- `forin-lanes.mts` — the standalone-vs-host table at the top. Compiles ONE
+  source twice; ~10 s.
+- `acorn-copynode-ab.mjs` — the decisive A/B. Compiles the pinned acorn tarball
+  twice (~50 s each) with only `copyNode` changed.
+- `acorn-raise3.mjs` — the shape matrix (which shorthand forms raise) plus the
+  genuine-syntax-error control that isolates the `NaN` message/pos channel.
+- `.tmp/probe/oracle-shorthand.js` — the layer-2 oracle: the real
+  `skip-early-err-try` body with `catch ({ f })` rewritten to `catch ({ f: f })`.
+  Run through the standalone test262 lane; returns the Phase-1 refusal.
+
+**Instrument** (non-negotiable — a run without it measures a different
+compiler): rebuild `scripts/compiler-bundle.mjs` and `scripts/runtime-bundle.mjs`
+with esbuild, then `node scripts/build-runtime-eval-provider.mjs` (~106 s, its
+cache key folds in the compiler-bundle hash, so redo it after every source
+change being A/B'd), then run with `TEST262_FULL_RUNTIME_EVAL=1`. Without that
+flag the REFUSAL tier answers and every eval test reports
+`dynamic code evaluation is not supported` — a different, equally fake result.
+
+## Corrections to #4137 (its arm 3, `SyntaxError: NaN`)
+
+#4137's work log attributes this family to "Acorn's `pp.raise` message … an
+`any`-typed compound `+` … it is a **codegen** bug in
+`src/codegen/expressions/operator-assignment.ts`", and hands off a
+`pa9.ts`/`pa10.ts` probe pair as *the* diagnostic. That diagnosis is **half
+right and points at the wrong file for the verdict**:
+
+- The message corruption is real, but it is **cosmetic** — #4137 already said
+  fixing it would not flip the 24 tests, and that is right for a reason it did
+  not have: the raise is **spurious**, and it comes from `copyNode`, not from
+  the message path. Also, `err.pos` is `NaN` as well, which a
+  `message += string` bug cannot explain.
+- #4137 says "a second compiled-acorn **scope-tracking** defect sits
+  underneath". It is not scope tracking. It is `copyNode` returning a blank
+  node, so `checkLValPattern` never sees an `Identifier`. Anyone starting from
+  the scope tracker will not find it.
+
+Neither correction reflects badly on that lane's measurement — it explicitly
+flagged the arm as diagnosed-not-fixed and told the next lane to expect a second
+layer. There were three.
+
+## Acceptance criteria
+
+- [ ] `for (const p in instanceOfC)` enumerates the instance's own enumerable
+      keys in standalone, including keys added by a later dynamic assignment.
+- [ ] A dynamic write to an instance-typed `any` (`n.name = "f"`) is retained
+      and reads back.
+- [ ] The A/B above collapses: **stock** compiled acorn parses `var { a } = {}`,
+      `catch ({ f })`, `function g({ f }){}` with no source patch.
+- [ ] `Object.keys` behaviour on builtin-backed receivers is **unchanged** —
+      re-measure against the #4071 -5 bucket explicitly, do not assume.
+- [ ] Measured on the standalone lane with a lever list AND a control list of
+      currently-passing files in the same clauses; report both.


### PR DESCRIPTION
Files **#4194** and records two measurements. No compiler change.

## 1. The lever, measured with a control

Population: the 42 standalone ES5-label failures under `annexB/language/eval-code/` (2026-08-06 published baseline). Control: the 427 files in the same directory that currently pass.

| build | lever pass / 42 | control pass / 427 |
| --- | ---: | ---: |
| `origin/main` (431ea77d55) | 1 | 427 |
| + `origin/issue-4182-annexb-global-blockfn` merged | **17** | **427** |

**+16, zero regressions.** Both control runs are the full 427, not a sample.

The instrument was validated before any claim: the baseline run agrees with the published standalone jsonl on **41 of 42** files (the one disagreement is `func-if-decl-no-else-eval-func-existing-block-fn-update.js`, a `compile_timeout` in CI that passes locally), and the control proves the runner can see a pass — a lever-only instrument cannot tell "my fix did nothing" from "my runner cannot see a pass".

## 2. `issue-4182-annexb-global-blockfn` (PR #4158) is worth +16 in a directory nobody attributed to it

All 16 flips are `annexB/language/eval-code/**-existing-block-fn-update`. Every one has the same outer shape — `{ function f(){ return 'first declaration'; } }` at script top level — whose AOT binding does not exist on `main`, so eval's B.3.3 `SetMutableBinding` has nothing to update.

The eval→AOT write-back itself is **not** broken, which is the part worth recording because it is the obvious wrong suspect. One probe file, four outer forms, all four correct on plain `main`:

| outer binding | eval'd code | result |
| --- | --- | --- |
| `var v1 = 'first'` | `v1 = "second"` | second |
| `var v2 = 'first'` | `var v2 = "second"` | second |
| `var v3 = 'first'` | `{ function v3(){ return "second"; } }` | second |
| `function v4(){ return 'first' }` | `{ function v4(){ return "second"; } }` | second |

Only the form with **no AOT binding at all** fails. So the family is purely #4182-downstream; there is no separate eval-side defect here.

## 3. #4194 — the other 24 files are a compiled-acorn defect, three layers deep

The 24 `*-skip-early-err-try` files all fail as `SyntaxError: NaN`. Root cause, A/B'd on the real pinned acorn tarball: **in `--target standalone` a constructed instance has no expando substrate.**

| surface, instance with ctor fields + a later `n.name = "f"` | standalone | js-host |
| --- | ---: | ---: |
| `for (const p in n)` — keys seen | **0** | all |
| `Object.keys(n).length` | **0** | 2 |
| `("type" in n) + ("name" in n)` | **neither** | both |
| read back `n.name` after writing it | **undefined** | `"f"` |

Acorn's `copyNode` is `for (var prop in node) { newNode[prop] = node[prop] }` over a `Node` instance, and it is called on exactly one path — **object-property shorthand**. It returns a blank node, so `checkLValPattern` reads `type === undefined`, falls through to `checkLValSimple`'s `default:` arm, and raises. Compiling the tarball twice, changing **only** `copyNode`:

| build | `var { a } = {}` | `var { a: b } = {}` | `catch ({ f }) {{ function f(){} }}` | `var o = { f }` |
| --- | --- | --- | --- | --- |
| stock | **raise** | ok | **raise** | ok |
| `copyNode` patched | ok | ok | ok | ok |

Consequence well beyond these 24: **no standalone `eval`/`Function` parses object destructuring shorthand.** `var {a}={}`, `let {f}={}`, `function g({f}){}`, `({f}={})`, `for (var {f} of [])`, `catch ({f})` all reject; `{a: b}`, `[a]` and object-*expression* `{f}` are fine.

Fixing that alone flips **zero** of the 24. Two more layers, both measured:

- **Layer 2** — with a shorthand-free but semantically identical oracle (`catch ({ f: f })`, which stock compiled acorn *can* parse) the interpreter refuses: `interp/emitter: unsupported in Phase 1: catch destructuring (ObjectPattern)`. #4137 arm 3 / #2928 Phase 2.
- **Layer 3** — B.3.5 exempts only a `BindingIdentifier`; a *destructuring* CatchParameter must **cancel** the Annex B synthetic var. #4137 built `SIMPLE_CATCH_SCOPE_LABEL` for the exempt half; the cancelling half has never been reached by any input.

Not attempted here on purpose: layer 1 is #4098 / #4010 rows 4–7 greenfield and the adjacent widening carries a **measured −5** on record (#4071, `Object.keys` over closed structs). Landing it unmeasured at the tail of a budget window is a shape of failure this project already has receipts for.

## 4. Correction to #4137's arm 3

#4137's handoff attributes `SyntaxError: NaN` to an `any`-typed compound `+` in `src/codegen/expressions/operator-assignment.ts` and to a second compiled-acorn **scope-tracking** defect. The message corruption is real but **cosmetic**; the verdict-changing defect is `copyNode`, and it is not scope tracking. `err.pos` is `NaN` as well as `err.message`, which a `message += string` bug cannot explain.

#4137 was **not** edited — it is still claimed by `ttraenkler/L3-annexb-hoisting` and owner pins are absolute. The correction lives in #4194 with a pointer.

## Note on the issue id

#4194 was reserved with `pr_scan=degraded` (`gh` unauthenticated in that lane). Re-verified before opening this PR by enumerating every open PR's added `plan/issues/` files: the highest id any open PR introduces is **4190**, so 4194 is clear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_