### PR TITLE
chore(docs): resync the standalone conformance number — main is out of sync and it is parking every PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The line above is the **JS-host path** (default `gc` target): runs alongside the
 
 <!-- AUTO:conformance-standalone-start -->
 
-**standalone (host-free) test262 conformance**: 27,825 / 43,505 (64.0 %)
+**standalone (host-free) test262 conformance**: 27,999 / 43,505 (64.4 %)
 
 <!-- AUTO:conformance-standalone-end -->
 


### PR DESCRIPTION
**One line in `README.md`. This unblocks the whole queue — please prioritise it.**

`quality` → `sync:conformance:check` is currently failing on **every** open PR, including docs-only ones that touch neither README nor any baseline artifact. Confirmed on four so far tonight:

| PR | where it failed | what it touches |
| --- | --- | --- |
| #4154 | merge_group (auto-parked) | `declarations.ts` telemetry |
| #4176 | PR-level | one memory doc |
| #4177 | PR-level | codegen + test |
| #4165 | merge_group (auto-parked) | one plan doc |

## The drift

`pnpm run sync:conformance` on current `main` (`d40692a3c2`) produces exactly the diff CI is complaining about:

```diff
- **standalone (host-free) test262 conformance**: 27,825 / 43,505 (64.0 %)
+ **standalone (host-free) test262 conformance**: 27,999 / 43,505 (64.4 %)
```

`1 updated, 4 unchanged` — README's standalone line is the only stale one.

## Cause

`d40692a3c2` — *"chore(test262): scheduled baseline summary sync — 31540/43505 pass `[skip ci]`"* (#1951) — advanced the summary artifacts without the derived doc numbers following.

`test262-sharded.yml`'s promote step documents this failure mode against itself, and is emphatic that the update has to be atomic:

> *"Sync the conformance numbers baked into the prose docs to match the freshly-promoted `test262-current.json`. This is the ONLY writer of the number on main, so it must update everything derived from it **ATOMICALLY in the same commit** — otherwise main goes out of sync the instant the baseline bumps, and every in-flight PR that reaches the merge-queue head is dropped by the `quality` gate's `sync:conformance:check` … See #1522 + the 2026-05-29 merge-queue drops of #895/#896."*

Two things let it happen anyway:

1. **That writer is non-fatal**: `node scripts/sync-conformance-numbers.mjs || echo "WARN: sync-conformance-numbers failed (non-fatal) — docs may drift"`. A single silent `WARN` produces exactly this state.
2. **The scheduled-sync path appears not to run it at all** — it is a different job from promote-baseline, and it moved the summary without touching the docs.

So the invariant the promote step carefully maintains is bypassed by a second writer, and the cost is borne by whichever PRs happen to be in the queue.

## This commit

Nothing but `pnpm run sync:conformance` on current main. The number going **up** is real — it reflects the conformance work that landed tonight (+76 from #4155, +58 from #4167, and more behind them).

## Worth a follow-up, not done here

The scheduled baseline-summary job should either run the doc sync in the same commit or not move the summary at all — and the promote step's sync arguably should not be `|| echo WARN`, since its failure is silent and the blast radius is every in-flight PR. I have not changed either; that is a CI-ownership call and this PR is deliberately the minimum that unblocks the queue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_