### PR TITLE
fix(#4199): keep top-level builtin-namespace expando writes in __module_init (+38 ES5 standalone)

### DIFF
--- a/plan/issues/4199-builtin-namespace-toplevel-expando.md
+++ b/plan/issues/4199-builtin-namespace-toplevel-expando.md
@@ -1,0 +1,180 @@
+---
+id: 4199
+title: "Standalone: a TOP-LEVEL expando write onto a builtin namespace singleton (Math.x = …, JSON.x = …) is dropped from __module_init"
+status: done
+assignee: ttraenkler/W17
+completed: 2026-08-07
+sprint: current
+created: 2026-08-07
+updated: 2026-08-07
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: builtins, property descriptors, module init
+goal: standalone-gap
+related: [4176, 4098, 4197, 2907, 2671, 3468, 1907, 1888]
+---
+
+# #4199 — top-level `Math.x = …` / `JSON.x = …` compiles to nothing (standalone)
+
+## Symptom
+
+```js
+Math.configurable = true;
+Object.defineProperty(obj, "property", Math);   // test262 15.2.3.6-3-91
+delete obj.property;                            // does nothing — descriptor was empty
+```
+
+`Math.hasOwnProperty("value")` is `false` after `Math.value = "D"` at top level.
+
+## Root cause: the statement is never emitted, not mis-lowered
+
+`collectDeclarations` (`src/codegen/declarations.ts`) keeps a top-level
+assignment statement only when its assignment ROOT resolves to something it
+recognises — a module global, a top-level function, `globalThis`. `Math` is a
+BUILTIN identifier, so `getAssignmentRootIdentifier` finds no root and the whole
+statement is discarded. It compiles to **nothing**.
+
+The bisect that settles it — the identical write from inside a function body
+already worked, before any change:
+
+| form | result on `main` + #4177 |
+| --- | --- |
+| `Math.value = "D";` at top level, then `defineProperty(obj,"p",Math)` | `obj.p === undefined` |
+| `function s(){ Math.value = "D"; } s();` then the same define | `obj.p === "D"` |
+| `var c = Math; c.value = "D";` then the same define | `obj.p === "D"` |
+
+The write ARM is correct: `Math` as a bare value resolves to the
+identity-stable extensible `$Object` namespace singleton
+(`emitBuiltinNamespaceObject`, #2907) and the ordinary property-write arm stores
+into it via `__extern_set`. **Keeping the statement is the whole fix.**
+
+Sixth recorded instance of the module-init COLLECTION elision family, one level
+shallower than #4176's `<Builtin>.prototype.<name>`: #2671
+(`Test262Error.thrower`), #2992 (top-level `delete`), #3468 F1
+(`assert.sameValue`), #3592 (`throw`), #4176.
+
+## Why it matters — the §8.10.5 descriptor-carrier idiom
+
+ES5 `ToPropertyDescriptor` reads its fields off an arbitrary object, and a large
+test262 family builds that object by hanging fields on a builtin. This is the
+single largest tractable slice of the remaining ES5 descriptor residue.
+
+## Measurements
+
+Base: `origin/main` `d40692a3c2` + fast-forward merge of
+`origin/issue-4197-consumer-mode-fn-decl-getter` (`a37f5c90f3`; PR #4177, open).
+Standalone baseline JSONL re-fetched `--force`, row stamp `7.8.2026 05:05:53`.
+Driver: `runTest262File(..., "standalone")` with the `js2wasm:runtime-eval`
+namespace shimmed in by wrapping `WebAssembly.instantiate` (#4163 unlanded).
+
+**Instrument recovery, two-sided, before touching anything:** on the 558-file
+ES5 descriptor lever the local run reproduced **284 pass / 274 fail**; all 178
+CI-passing files reproduced, **0 lost**, and the 106 newly-passing were exactly
+#4197's claim.
+
+| measurement | before | after |
+| --- | ---: | ---: |
+| 558-file ES5 descriptor lever | 284 pass | **322 pass** (**FIXED 38, BROKE 0**) |
+| blast radius — every corpus file writing a `Math`/`JSON`/`Reflect` expando (63) | 6 pass | 44 pass (FIXED 38, BROKE 0, 0 signature drift) |
+
+## The census this came out of (274 residue by spec algorithm, n/558)
+
+| n/558 | mechanism |
+| ---: | --- |
+| **108** | **M1 ToPropertyDescriptor (§8.10.5) over a non-literal descriptor carrier** |
+| 54 | M2 Array exotic `[[DefineOwnProperty]]` (§15.4.5.1) |
+| 41 | M4 attributes of a *builtin's own* property (27 of them `gOPD`) |
+| 20 | M9 other |
+| 15 | M5 ordinary §8.12.9 on a non-plain `O` |
+| 14 | M6 `[[Prototype]]` shadowing / inherited attributes |
+| 11 | M3 Arguments exotic (§10.6) |
+| 8 | M8 `getOwnPropertyNames` |
+| 3 | M7 `Object.create` argument handling |
+
+Two negative results worth keeping, so the next lane does not re-derive them:
+
+**The descriptor READ side is not the defect — do not rewrite it.** A 14-carrier
+matrix, each `<carrier>.value = "D"; Object.defineProperty(obj,"property",<carrier>)`:
+
+| carrier | verdict |
+| --- | --- |
+| plain object · function · array · `arguments` · the global object | PASS |
+| `new String` · `new Number` · `new Boolean` · `new Date` · `new RegExp` · `new Object` | PASS |
+| **`Math`** · **`JSON`** (statically named namespace) | **FAIL** → this issue |
+| **`new Error()`** (and `new TypeError()` etc.) | **FAIL** → #4098, out of scope |
+
+**`SITE-PROPS-BAG-NOT-AUTHORITATIVE` is 14 files and is a SYMPTOM of M1, not a
+bucket.** #4047 measured that arm at +6 and reverted it; it should not be
+re-litigated a third time as though it were its own lever.
+
+## Implementation
+
+`src/codegen/builtin-write-keeps.ts` (new) holds both builtin-receiver keep
+predicates. `isBuiltinProtoWriteTarget` (#4176) MOVED here unchanged;
+`isBuiltinNamespaceExpandoWriteTarget` (#4199) is new; `collectDeclarations`
+now calls one `shouldKeepBuiltinReceiverWrite(ctx, left)` instead of carrying
+two predicates and two comment blocks. **Both the LOC and function budgets pass
+with no allowance** — declarations.ts and `collectDeclarations` both shrink.
+
+### Scope, and the cases that must STAY dropped
+
+- **Namespaces**: only the three #2907 bare-value carriers whose
+  `SUPPORTED_STATIC_PROPS` list is EMPTY (`Math`, `JSON`, `Reflect`) — pure
+  namespace singletons, so a kept write cannot collide with a claimed
+  identifier-level fast path. `Array`/`Object` excluded (they claim `isArray` /
+  `keys`); the Error-family carriers excluded (constructors; `new` /
+  `instanceof` resolve before identifier resolution, and #4098 owns their
+  instance-side storage).
+- **Property names**: only names NOT on the namespace's own static surface.
+  Correctness in both directions, not timidity:
+  - `Math.PI = 3` — `Math.PI` is `{[[Writable]]: false}` (§21.3.1), so dropping
+    that write is the SPEC-CORRECT outcome; keeping it would be a regression.
+  - `JSON.stringify = fn` — the call site resolves statically through
+    `BUILTIN_STATIC_METHOD_ARITY`, so a bag entry would be a SECOND storage the
+    reader never consults. An honest no-op beats silent divergence; patching
+    builtin statics is separate, measured work (cf. the #2623 P-7b
+    `Promise.resolve` arm, host/GC-only for the same reason).
+- **Computed keys** (`Math[k] = v`) declined — the own-static-surface test is
+  undecidable at compile time and admitting it would let `Math["PI"] = 3`
+  through the back door.
+- **Shadowing** (`var Math = {}`) declined — already owned by the collection's
+  module-global arm.
+- **Standalone only.** Host/GC output is byte-identical (the predicate runs
+  behind `ctx.standalone`).
+
+## Verification
+
+`tests/issue-4199.test.ts`. Four end-to-end cases are RED on the unpatched base
+and green on this branch. The **precondition** case (the same write from inside a
+function body) is green on BOTH — it is what makes this a collection bug rather
+than a storage bug, and a fixture that only exercised the in-body form would
+have passed on unpatched main and proved nothing. Predicate-level scope guards
+cover every declined shape.
+
+`Math.PI` shadowing could not be asserted end-to-end: reading `Math.tag` when a
+user `const Math` shadows the builtin still hits the #1907
+builtin-static-value-read refusal, a SEPARATE pre-existing defect that
+reproduces identically without this change.
+
+## Not fixed here (findings for the next lane)
+
+- **#1907 has surviving refusals.** It is `status: done` (sprint 75), yet
+  `Math.<expando>` as a VALUE READ is still
+  `Codegen error: … built-in static property value read is not supported in
+  --target standalone`. This issue makes the WRITE land; the read-back of an
+  expando through the static path stays refused.
+- **`undefined.writable` returns `undefined` instead of throwing** in
+  standalone. This is why the 24 `gOPD`-on-builtins tests report
+  `desc.writable === undefined` rather than a TypeError — the descriptor really
+  is `undefined` and the member read silently succeeds. Worth its own issue.
+- **`<Ctor>.prototype.constructor` is missing entirely** (17 of the 27 M4 `gOPD`
+  files): `Error.prototype.constructor`, `Object.prototype.constructor`, … all
+  read `undefined`, and `gOPD` of them returns `undefined`.
+- **M2 (Array exotic §15.4.5.1, 54 files) is the next-largest slice**, and
+  **18 of its 54 share one signature** — "Expected a TypeError to be thrown but
+  no exception was thrown at all", almost all of them `'O' is an Array` with the
+  `length` property or an array-index named property.

--- a/src/codegen/builtin-write-keeps.ts
+++ b/src/codegen/builtin-write-keeps.ts
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * TOP-LEVEL property writes whose receiver is a BUILTIN — the module-init
+ * collection KEEP predicates, extracted from declarations.ts.
+ *
+ * ## The shared defect these guard against
+ *
+ * `collectDeclarations` keeps a top-level assignment statement only when its
+ * assignment ROOT resolves to something it recognises (a module global, a
+ * top-level function, `globalThis`, …). When the root is a builtin identifier
+ * there is no such root, so the whole statement is dropped — it compiles to
+ * NOTHING, silently. That elision family already has five recorded instances
+ * (#2671 `Test262Error.thrower`, #2992 top-level `delete`, #3468 F1
+ * `assert.sameValue`, #3592 `throw`, #4176 `<Builtin>.prototype.<name>`); the
+ * two predicates here are its builtin-receiver members:
+ *
+ * | shape | issue |
+ * | --- | --- |
+ * | `<Builtin>.prototype.<name> = …` | #4176 |
+ * | `<Namespace>.<name> = …`         | #4199 |
+ *
+ * (#4199) The second is one level shallower than the first and was extracted
+ * here together with it, so declarations.ts carries one call instead of two
+ * predicates plus two comment blocks.
+ *
+ * ## #4199: what was and was not broken
+ *
+ * The write ARM was never broken. `Math` as a bare value already resolves to
+ * the identity-stable extensible `$Object` namespace singleton
+ * (`emitBuiltinNamespaceObject`, #2907) and the ordinary property-write arm
+ * stores into it via `__extern_set`. Measured:
+ *
+ * ```js
+ * Math.value = "D";                                  // top level  → DROPPED
+ * Object.defineProperty(obj, "p", Math); obj.p       // undefined  (want "D")
+ *
+ * function setup() { Math.value = "D"; } setup();    // in a body  → WORKS
+ * Object.defineProperty(obj, "p", Math); obj.p       // "D"
+ * ```
+ *
+ * So keeping the statement IS the whole fix.
+ *
+ * ## Why it matters: the §8.10.5 descriptor-carrier idiom
+ *
+ * ES5 `ToPropertyDescriptor` reads its fields off an arbitrary object, and a
+ * large test262 family builds that object by hanging fields on a builtin:
+ *
+ * ```js
+ * Math.configurable = true;
+ * Object.defineProperty(obj, "property", Math);      // 15.2.3.6-3-91
+ * ```
+ *
+ * Measured on `main` + #4177 (2026-08-07): of the 274 remaining ES5-standalone
+ * descriptor-family failures, **38 use the `Math.`/`JSON.` expando idiom**
+ * (19 + 19). A 14-carrier matrix showed 11 carriers ALREADY work — plain
+ * objects, functions, arrays, `new String/Number/Boolean/Date/RegExp/Object`,
+ * `arguments`, the global object — so the descriptor READ side is NOT the
+ * defect and must not be rewritten. (`new Error()` instances are the third
+ * failing carrier; that is #4098's instance-field storage, out of scope here.)
+ *
+ * ## #4199 scope — deliberately narrower than "any builtin receiver"
+ *
+ * **Namespaces**: only the three #2907 bare-value carriers whose
+ * `SUPPORTED_STATIC_PROPS` list is EMPTY (`Math`, `JSON`, `Reflect`). Those are
+ * pure namespace singletons — `isSupportedBuiltinStaticProperty` is false for
+ * every member — so keeping a write cannot collide with a claimed
+ * identifier-level fast path. `Array`/`Object` are excluded (they DO claim
+ * static props, `isArray`/`keys`); the Error-family carriers are excluded
+ * because they are CONSTRUCTORS whose `new`/`instanceof` forms resolve before
+ * identifier resolution.
+ *
+ * **Property names**: only names NOT on the namespace's own static surface.
+ * This is correctness in both directions, not timidity:
+ *
+ *  - `Math.PI = 3` — `Math.PI` is `{[[Writable]]: false}` (§21.3.1), so
+ *    dropping that write is the SPEC-CORRECT outcome; keeping it would be a
+ *    regression.
+ *  - `JSON.stringify = fn` — the call site resolves statically through
+ *    `BUILTIN_STATIC_METHOD_ARITY`, so a bag entry would be a SECOND storage
+ *    the reader never consults. Silent divergence is worse than an honest
+ *    no-op; patching builtin statics is separate, measured work (cf. the
+ *    #2623 P-7b `Promise.resolve` arm, host/GC-only for the same reason).
+ *
+ * **Shadowing**: declines when a user binding shadows the name; those are
+ * caught by the collection's own module-global / top-level-function arms.
+ *
+ * **Standalone only** — both predicates run behind a `ctx.standalone` gate, so
+ * host/GC output stays byte-identical.
+ */
+import { ts } from "../ts-api.js";
+import { isBrandedBuiltinName } from "./builtin-brands.js";
+import { BUILTIN_STATIC_METHOD_ARITY } from "./builtin-fn-meta.js";
+
+/**
+ * (#4199) The #2907 bare-value namespace carriers with an EMPTY
+ * supported-static-prop list. Keep in sync with `SUPPORTED_STATIC_PROPS` in
+ * builtin-static-globals.ts — a name added there with a NON-empty list must
+ * not be added here.
+ */
+const EXPANDO_NAMESPACES: ReadonlySet<string> = new Set(["Math", "JSON", "Reflect"]);
+
+/**
+ * (#4199) Own data properties of `Math` that the value-read path
+ * constant-folds (`MATH_CONSTANT_PROPS`, builtin-value-read.ts). All are
+ * non-writable per §21.3.1, so a write to one keeps its dropped lowering.
+ */
+const MATH_CONSTANTS: ReadonlySet<string> = new Set(["PI", "E", "LN2", "LN10", "SQRT2", "SQRT1_2", "LOG2E", "LOG10E"]);
+
+/** Strip parens / `as` / `!` / `<T>` wrappers. */
+function unwrap(expr: ts.Expression): ts.Expression {
+  let e = expr;
+  while (
+    ts.isParenthesizedExpression(e) ||
+    ts.isAsExpression(e) ||
+    ts.isNonNullExpression(e) ||
+    ts.isTypeAssertionExpression(e)
+  ) {
+    e = e.expression;
+  }
+  return e;
+}
+
+/** The collection's view of which names a user binding has taken. */
+export interface BuiltinWriteKeepCtx {
+  readonly standalone?: boolean;
+  readonly protoNamedDirty?: boolean;
+  readonly protoIndexDirty?: boolean;
+  readonly moduleGlobals: { has(name: string): boolean };
+  readonly topLevelFunctionNames: { has(name: string): boolean };
+  readonly classSet: { has(name: string): boolean };
+}
+
+/**
+ * (#4176) Is this assignment LHS a write onto a branded builtin's `.prototype`
+ * — `Function.prototype.value` / `Object.prototype["zzz"]` (member or element
+ * form, unwrapped through parens/casts)? `F.prototype = …` (the whole reassign,
+ * name === "prototype") is NOT matched — that stays owned by the #2660 S2
+ * fnctor arm.
+ */
+export function isBuiltinProtoWriteTarget(left: ts.Expression): boolean {
+  const lhs = unwrap(left);
+  let receiver: ts.Expression | undefined;
+  if (ts.isPropertyAccessExpression(lhs) && !ts.isPrivateIdentifier(lhs.name)) receiver = lhs.expression;
+  else if (ts.isElementAccessExpression(lhs)) receiver = lhs.expression;
+  if (!receiver) return false;
+  const base = unwrap(receiver);
+  return (
+    ts.isPropertyAccessExpression(base) &&
+    base.name.text === "prototype" &&
+    ts.isIdentifier(base.expression) &&
+    isBrandedBuiltinName(base.expression.text)
+  );
+}
+
+/** (#4199) Is `prop` on `ns`'s own static surface (so a write stays dropped)? */
+function isOwnStaticSurface(ns: string, prop: string): boolean {
+  if (BUILTIN_STATIC_METHOD_ARITY[ns]?.[prop] !== undefined) return true;
+  return ns === "Math" && MATH_CONSTANTS.has(prop);
+}
+
+/**
+ * (#4199) Is this assignment LHS a top-level EXPANDO write onto a builtin
+ * namespace singleton (`Math.value = …` / `JSON["configurable"] = …`)? See the
+ * module header for the scope argument; every case that must stay dropped
+ * returns false.
+ *
+ * An element access with a NON-literal key (`Math[k] = v`) is declined: the
+ * own-static-surface test cannot be decided at compile time, and admitting it
+ * would let `Math["PI"] = 3` through by the back door.
+ */
+export function isBuiltinNamespaceExpandoWriteTarget(left: ts.Expression, ctx: BuiltinWriteKeepCtx): boolean {
+  const lhs = unwrap(left);
+  let receiver: ts.Expression;
+  let propName: string;
+  if (ts.isPropertyAccessExpression(lhs) && !ts.isPrivateIdentifier(lhs.name)) {
+    receiver = lhs.expression;
+    propName = lhs.name.text;
+  } else if (ts.isElementAccessExpression(lhs)) {
+    const key = unwrap(lhs.argumentExpression);
+    if (!ts.isStringLiteralLike(key)) return false;
+    receiver = lhs.expression;
+    propName = key.text;
+  } else {
+    return false;
+  }
+  const base = unwrap(receiver);
+  if (!ts.isIdentifier(base)) return false;
+  const ns = base.text;
+  if (!EXPANDO_NAMESPACES.has(ns)) return false;
+  if (ctx.moduleGlobals.has(ns) || ctx.topLevelFunctionNames.has(ns) || ctx.classSet.has(ns)) return false;
+  return !isOwnStaticSurface(ns, propName);
+}
+
+/**
+ * The single entry point `collectDeclarations` calls: should this top-level
+ * assignment statement be KEPT in `__module_init` because its receiver is a
+ * builtin the generic root-identifier check cannot see? Standalone-only.
+ */
+export function shouldKeepBuiltinReceiverWrite(ctx: BuiltinWriteKeepCtx, left: ts.Expression): boolean {
+  if (!ctx.standalone) return false;
+  if ((ctx.protoNamedDirty || ctx.protoIndexDirty) && isBuiltinProtoWriteTarget(left)) return true;
+  return isBuiltinNamespaceExpandoWriteTarget(left, ctx);
+}

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -87,7 +87,7 @@ import {
 } from "./registry/types.js";
 import { isArrayProtoIteratorAssignTarget } from "./expressions/proto-override.js";
 import { isFnctorPrototypeAssignTarget } from "./expressions/fnctor-prototype.js";
-import { isBrandedBuiltinName } from "./builtin-brands.js"; // (#4176) builtin-proto write keep
+import { shouldKeepBuiltinReceiverWrite } from "./builtin-write-keeps.js"; // (#4176/#4199) builtin-receiver write keeps
 import { compileExpression, compileStatement } from "./shared.js";
 import { expandLinearU8ParamTypes } from "./linear-uint8-signatures.js";
 import { definedFuncAt, mintDefinedFunc } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
@@ -156,46 +156,6 @@ const STANDALONE_FN_STATIC_KEEP_EXCLUDED = new Set([
   "caller",
   "arguments",
 ]);
-
-/**
- * (#4176) Is this assignment LHS a write onto a branded builtin's `.prototype`
- * — `Function.prototype.value` / `Object.prototype["zzz"]` (member or element
- * form, unwrapped through parens/casts)? Used by the module-init collection to
- * KEEP such top-level statements when the proto-property store is reserved;
- * the receiver `<Builtin>.prototype` has no module-global root, so the generic
- * root-identifier check would silently drop them. `F.prototype = …` (the whole
- * reassign, name === "prototype") is NOT matched — that stays owned by the
- * #2660 S2 fnctor arm.
- */
-function isBuiltinProtoWriteTarget(left: ts.Expression): boolean {
-  let lhs: ts.Expression = left;
-  while (
-    ts.isParenthesizedExpression(lhs) ||
-    ts.isAsExpression(lhs) ||
-    ts.isNonNullExpression(lhs) ||
-    ts.isTypeAssertionExpression(lhs)
-  ) {
-    lhs = lhs.expression;
-  }
-  let receiver: ts.Expression | undefined;
-  if (ts.isPropertyAccessExpression(lhs) && !ts.isPrivateIdentifier(lhs.name)) receiver = lhs.expression;
-  else if (ts.isElementAccessExpression(lhs)) receiver = lhs.expression;
-  if (!receiver) return false;
-  while (
-    ts.isParenthesizedExpression(receiver) ||
-    ts.isAsExpression(receiver) ||
-    ts.isNonNullExpression(receiver) ||
-    ts.isTypeAssertionExpression(receiver)
-  ) {
-    receiver = receiver.expression;
-  }
-  return (
-    ts.isPropertyAccessExpression(receiver) &&
-    receiver.name.text === "prototype" &&
-    ts.isIdentifier(receiver.expression) &&
-    isBrandedBuiltinName(receiver.expression.text)
-  );
-}
 
 function recordExportSignature(
   ctx: CodegenContext,
@@ -1840,17 +1800,14 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
           ctx.moduleInitStatements.push(stmt);
           continue;
         }
-        // (#4176) `<Builtin>.prototype.<name> = …` / `<Builtin>.prototype[k] = …`
-        // at top level (`Function.prototype.value = "x"`, `Object.prototype.zzz
-        // = 1`, `Array.prototype.enumerable = true` — the §8.10.5
-        // inherited-descriptor-field idiom): the root identifier is a BUILTIN,
-        // not a module global, so the generic check below dropped the whole
-        // statement and the write never reached the proto-property store's
-        // `$NativeProto` write arm — it compiled to NOTHING (measured: the
-        // statement is absent from `__module_init`). Keep it when the
-        // pre-scan reserved the store; byte-identical otherwise (the flags
-        // are set by `scanForArrayHoles`, which runs before this collection).
-        if (ctx.standalone && (ctx.protoNamedDirty || ctx.protoIndexDirty) && isBuiltinProtoWriteTarget(expr.left)) {
+        // (#4176 / #4199) A top-level write whose RECEIVER is a builtin —
+        // `Object.prototype.zzz = 1` or `Math.value = "D"`. The root identifier
+        // is a builtin, so the generic check below dropped the whole statement
+        // and the write compiled to NOTHING. Both write arms are already
+        // correct (the identical statement inside a function body works), so
+        // keeping the statement is the whole fix. Scope + the cases that must
+        // STAY dropped: builtin-write-keeps.ts.
+        if (shouldKeepBuiltinReceiverWrite(ctx, expr.left)) {
           ctx.moduleInitStatements.push(stmt);
           continue;
         }

--- a/tests/issue-4199.test.ts
+++ b/tests/issue-4199.test.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4199 — a TOP-LEVEL expando write onto a builtin NAMESPACE singleton
+ * (`Math.value = "D"`, `JSON.configurable = true`) must reach the singleton.
+ *
+ * Sixth instance of the module-init COLLECTION family, one level shallower
+ * than #4176's `<Builtin>.prototype.<name>`: the assignment root is a builtin
+ * identifier, so `collectDeclarations` found no module-global root and dropped
+ * the whole statement — it compiled to NOTHING.
+ *
+ * ## The precondition these tests assert
+ *
+ * The write ARM was never broken. `Math` as a bare value already resolves to
+ * the identity-stable #2907 namespace singleton and the ordinary property-write
+ * arm stores into it. The `writes from inside a function body ALREADY worked`
+ * case below pins that: it passes both before and after the fix, and it is what
+ * makes the top-level case a *collection* bug rather than a storage bug. A
+ * fixture that only exercised the in-body form would pass on unpatched main and
+ * prove nothing.
+ *
+ * ## Why this matters beyond the shape
+ *
+ * It is the ES5 §8.10.5 `ToPropertyDescriptor` idiom — a descriptor built by
+ * hanging fields on a builtin, then passed as the `Attributes` argument
+ * (test262 `15.2.3.6-3-91`, `-253`, and 36 siblings).
+ */
+import { describe, expect, it } from "vitest";
+import { isBuiltinNamespaceExpandoWriteTarget } from "../src/codegen/builtin-write-keeps.js";
+import { compile } from "../src/index.js";
+import { ts } from "../src/ts-api.js";
+
+const EMPTY: ReadonlySet<string> = new Set<string>();
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, { target: "standalone" });
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  expect(result.imports ?? [], "must stay host-free").toEqual([]);
+  expect(WebAssembly.validate(result.binary!), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary!, {});
+  return (instance.exports as { main: () => unknown }).main();
+}
+
+describe("#4199 top-level expando writes on builtin namespace singletons (standalone)", () => {
+  // PRECONDITION — passes on unpatched main too. Establishes that the write arm
+  // and the singleton's identity stability are NOT the mode under test.
+  it("precondition: the same write from inside a function body already worked", async () => {
+    expect(
+      await runStandalone(`
+        function setup(): void {
+          (Math as any).probe = 5;
+        }
+        export function main(): number {
+          setup();
+          const obj: any = {};
+          Object.defineProperty(obj, "p", Math as any);
+          return (Math as any).probe === undefined ? -1 : 5;
+        }
+      `),
+    ).toBe(5);
+  });
+
+  // The headline shape. Measured returning 0 (the statement was dropped) before.
+  it("Math.<name> = … at top level reaches the namespace singleton", async () => {
+    expect(
+      await runStandalone(`
+        (Math as any).value = 7;
+        export function main(): number {
+          const obj: any = {};
+          Object.defineProperty(obj, "p", Math as any);
+          return obj.p === 7 ? 7 : 0;
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("JSON.<name> = … at top level reaches the namespace singleton", async () => {
+    expect(
+      await runStandalone(`
+        (JSON as any).value = 9;
+        export function main(): number {
+          const obj: any = {};
+          Object.defineProperty(obj, "p", JSON as any);
+          return obj.p === 9 ? 9 : 0;
+        }
+      `),
+    ).toBe(9);
+  });
+
+  // test262 15.2.3.6-3-91 in miniature: a non-value descriptor FIELD, observed
+  // through the resulting property's attributes rather than through its value.
+  it("Math.configurable = true at top level is honoured by ToPropertyDescriptor", async () => {
+    expect(
+      await runStandalone(`
+        (Math as any).configurable = true;
+        export function main(): number {
+          const obj: any = {};
+          Object.defineProperty(obj, "p", Math as any);
+          const before: boolean = obj.hasOwnProperty("p");
+          delete obj.p;
+          const after: boolean = obj.hasOwnProperty("p");
+          return (before ? 1 : 0) + (after ? 0 : 2);
+        }
+      `),
+    ).toBe(3);
+  });
+
+  // Element-access form with a literal key.
+  it('JSON["<name>"] = … at top level is kept', async () => {
+    expect(
+      await runStandalone(`
+        (JSON as any)["writable"] = true;
+        (JSON as any)["value"] = 3;
+        export function main(): number {
+          const obj: any = {};
+          Object.defineProperty(obj, "p", JSON as any);
+          obj.p = 4;
+          return obj.p === 4 ? 3 : 0;
+        }
+      `),
+    ).toBe(3);
+  });
+
+  // SCOPE GUARD — a write to the namespace's OWN static surface must stay
+  // dropped. `Math.PI` is {[[Writable]]: false} (§21.3.1), so dropping it is
+  // the spec-correct outcome, and keeping it would put a bag entry behind a
+  // constant-folded read that never consults the bag.
+  it("Math.PI = … stays dropped (non-writable own property)", async () => {
+    expect(
+      await runStandalone(`
+        (Math as any).PI = 3;
+        export function main(): number {
+          return Math.PI > 3.14 && Math.PI < 3.15 ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+});
+
+/**
+ * The remaining scope guards are asserted on the predicate directly rather than
+ * end-to-end. A shadowed `Math` cannot be checked through compiled output today:
+ * reading `Math.tag` when a user `const Math` shadows the builtin still hits the
+ * #1907 builtin-static-value-read refusal, which is a SEPARATE pre-existing
+ * defect (it reproduces identically without this change). Asserting the keep
+ * predicate keeps this test honest about what #4199 does and does not fix.
+ */
+describe("#4199 keep predicate scope", () => {
+  const shadow = { moduleGlobals: EMPTY, topLevelFunctionNames: EMPTY, classSet: EMPTY };
+
+  function lhsOf(code: string): ts.Expression {
+    const sf = ts.createSourceFile("t.ts", code, ts.ScriptTarget.ESNext, true);
+    const stmt = sf.statements[0] as ts.ExpressionStatement;
+    return (stmt.expression as ts.BinaryExpression).left;
+  }
+
+  it.each([
+    ["Math.value = 1;", true],
+    ["JSON.configurable = true;", true],
+    ["Reflect.writable = true;", true],
+    ['JSON["value"] = 1;', true],
+    ["(Math as any).value = 1;", true],
+  ])("keeps %s", (code, want) => {
+    expect(isBuiltinNamespaceExpandoWriteTarget(lhsOf(code), shadow)).toBe(want);
+  });
+
+  it.each([
+    // own static surface — must stay dropped (see the module header)
+    ["Math.PI = 3;", false],
+    ["Math.abs = f;", false],
+    ["JSON.stringify = f;", false],
+    ['Math["PI"] = 3;', false],
+    // non-namespace receivers stay owned by the #4176 / #2671 / #3468 arms
+    ["Object.prototype.zzz = 1;", false],
+    ["Array.isArray = f;", false],
+    ["TypeError.thrower = f;", false],
+    ["o.value = 1;", false],
+    // a computed key cannot be decided at compile time
+    ["Math[k] = 1;", false],
+    // the bare namespace itself is not an expando write
+    ["Math = 1;", false],
+  ])("declines %s", (code, want) => {
+    expect(isBuiltinNamespaceExpandoWriteTarget(lhsOf(code), shadow)).toBe(want);
+  });
+
+  it("declines when a user binding shadows the namespace", () => {
+    const shadowed = { moduleGlobals: new Set(["Math"]), topLevelFunctionNames: EMPTY, classSet: EMPTY };
+    expect(isBuiltinNamespaceExpandoWriteTarget(lhsOf("Math.value = 1;"), shadowed)).toBe(false);
+    expect(isBuiltinNamespaceExpandoWriteTarget(lhsOf("JSON.value = 1;"), shadowed)).toBe(true);
+  });
+});


### PR DESCRIPTION
`Math.value = "D"` / `JSON.configurable = true` at **module top level** compiled to **nothing** under `--target standalone`.

`collectDeclarations` keeps a top-level assignment only when its assignment ROOT resolves to a module global / top-level function / `globalThis`. `Math` is a builtin identifier, so `getAssignmentRootIdentifier` found no root and the whole statement was discarded.

**The write arm was never broken.** The identical statement inside a function body already worked — it stores into the identity-stable #2907 namespace singleton via `__extern_set`. Keeping the statement is the whole fix:

| form | on unpatched main |
| --- | --- |
| `Math.value = "D";` at top level, then `defineProperty(obj,"p",Math)` | `obj.p === undefined` |
| `function s(){ Math.value = "D"; } s();` then the same define | `obj.p === "D"` |
| `var c = Math; c.value = "D";` then the same define | `obj.p === "D"` |

Sixth instance of the module-init collection-elision family (#2671, #2992, #3468 F1, #3592, #4176), one level shallower than #4176's `<Builtin>.prototype.<name>`.

This is the ES5 §8.10.5 `ToPropertyDescriptor` carrier idiom:

```js
Math.configurable = true;
Object.defineProperty(obj, "property", Math);   // test262 15.2.3.6-3-91
```

## Measured

Driver: `runTest262File(..., "standalone")` with the `js2wasm:runtime-eval` namespace shimmed in (#4163 unlanded). Standalone baseline re-fetched `--force`, row stamp `7.8.2026 05:05:53`.

| population | before | after |
| --- | ---: | ---: |
| 558-file ES5 descriptor lever, base `origin/main` | 178 | **216** — FIXED 38, BROKE 0 |
| same lever, base `main` + #4177 | 284 | **322** — FIXED 38, BROKE 0 |
| blast radius: every corpus file writing a `Math`/`JSON`/`Reflect` expando (63) | 6 | 44 — BROKE 0, **0 signature drift** |
| control: all 2,078 CI-*passing* descriptor-family files | 2078 | **2078** — 0 regressions |

**The instrument recovered already-landed work exactly before any change was made**: on the 558 lever all 178 CI-passing files reproduced with **0 lost**, and the 106 newly-passing on the #4177 base were exactly #4197's claim. The delta is identical on both bases, which is what establishes it as orthogonal to #4197 (zero file overlap).

## Scope — what must STAY dropped, and why

- **Namespaces**: only the three #2907 bare-value carriers with an EMPTY `SUPPORTED_STATIC_PROPS` list — `Math`, `JSON`, `Reflect`. `Array`/`Object` claim static props (`isArray`/`keys`); the Error-family carriers are constructors and their instance-side storage is #4098.
- `Math.PI = 3` stays dropped — `Math.PI` is `{[[Writable]]: false}` (§21.3.1), so dropping it is the **spec-correct** outcome.
- `JSON.stringify = fn` stays dropped — the call site resolves statically through `BUILTIN_STATIC_METHOD_ARITY`, so a bag entry would be a **second storage the reader never consults**. Cf. the #2623 P-7b `Promise.resolve` arm.
- Computed keys (`Math[k] = v`) declined — undecidable at compile time, and admitting them would let `Math["PI"] = 3` in through the back door.
- Shadowing (`var Math = {}`) declined. `ctx.standalone`-gated: host/GC byte-identical.

## Implementation

New `src/codegen/builtin-write-keeps.ts` owns **both** builtin-receiver keep predicates; #4176's `isBuiltinProtoWriteTarget` moved there unchanged, and `declarations.ts` now calls one `shouldKeepBuiltinReceiverWrite()` instead of two predicates plus two comment blocks.

**LOC and function budgets both pass with no allowance** — `declarations.ts` and `collectDeclarations` each *shrink*.

## Verification

`tests/issue-4199.test.ts` — 4 end-to-end cases RED on the unpatched base, green here, plus a **precondition** case (the same write inside a function body) green on **both**. That precondition is what makes this a *collection* bug rather than a storage bug; a fixture exercising only the in-body form would have passed on unpatched main and proved nothing. Predicate-level guards cover every declined shape.

Gates all green locally: `tsc --noEmit`, `oracle-ratchet`, `loc-budget`, `func-budget`, `coercion-sites`, `ir-fallbacks`, `format:check`, `lint`.

## Not fixed here

- **#1907 is `status: done` but its refusal survives**: `Math.<expando>` as a *value read* still hard-fails with `built-in static property value read is not supported in --target standalone (#1907 / #1888 S6-b)`. This PR makes the write land; reading it back through the static path is still refused.
- **`undefined.writable` returns `undefined` instead of throwing** in standalone — why the 24 `gOPD`-on-builtins tests fail one assertion later than they should.
- **`<Ctor>.prototype.constructor` is missing outright** (17 of the 27 M4 `gOPD` files): `Error.prototype.constructor`, `Object.prototype.constructor` all read `undefined`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_