### PR TITLE
docs(memory): the default baseline path is the HOST lane — correct the standalone cross-check

### DIFF
--- a/.claude/memory/reference_standalone_eval_instrument_reports_unmeasured_failures.md
+++ b/.claude/memory/reference_standalone_eval_instrument_reports_unmeasured_failures.md
@@ -57,10 +57,43 @@ Concretely, from the lanes that did it right:
 - lever 1/42 at base + control 427/427 → same shape, full control population,
   not a sample. Then `+16 / 0 regressed` means something.
 
-Cross-check the base run against the published standalone jsonl file-by-file
-and state the disagreement count (one lane: 41 of 42 agree, the one outlier a
-CI `compile_timeout` that passes locally). A base run that does not reproduce
-the baseline is a broken instrument, not a discovery.
+Cross-check the base run against a **same-mode** jsonl file-by-file and state
+the disagreement count (one lane: 41 of 42 agree, the one outlier a CI
+`compile_timeout` that passes locally). A base run that does not reproduce its
+same-mode baseline is a broken instrument, not a discovery.
+
+### ⚠ The DEFAULT baseline path is the HOST lane — do not diff standalone against it
+
+`.test262-cache/test262-current.jsonl`, what a bare
+`scripts/fetch-baseline-jsonl.mjs` hands you, is the **host** lane. Verified
+2026-08-07 over all 48,619 rows: the only import namespace appearing anywhere
+is **`env`** (2,145,612 occurrences, zero `js2wasm:runtime-eval`), and there is
+no `mode`/`target` field to warn you.
+
+**`oracle_lane: "honest"` is NOT a mode marker.** It is the honest-vs-fast
+*oracle* axis (#3462) and it is on 100% of rows. It reads like "the real lane",
+which is exactly why this is easy to get wrong.
+
+A standalone run diffed against it produces a large disagreement count that
+**is the host-vs-standalone gap itself** (one lane measured ~219), not
+instrument error. A lane that follows the cross-check instruction literally
+will either distrust a working instrument or — far worse — tune its runner
+until it agrees with the host lane's answers.
+
+There **is** a standalone baseline; it is just not the default:
+`ensureStandaloneBaselineJsonl({ force: true })` from the same module
+(`STANDALONE_BASELINE_CACHE_PATH`). Use that, or a prior standalone lane's
+jsonl.
+
+### Rebuilding the provider can silently HIT the cache
+
+`node --import tsx scripts/build-runtime-eval-provider.mjs` is **not** by itself
+proof of a rebuild: the cache key is `no-bundle`-static in this configuration,
+so a plain rebuild can no-op while reporting success — leaving you in the very
+refusal tier you were trying to escape. **Delete the cache first, then verify
+the emitted binary actually changed** (measured: 3,970,936 → 3,970,952 on one
+lane, 3,970,952 → 3,971,726 on another). Two lanes independently reported the
+`cache HIT` line after a `src/` edit.
 
 ## The trap has a false-NEGATIVE form too, and it is worse
 


### PR DESCRIPTION
One file. Corrects an instruction in `reference_standalone_eval_instrument_reports_unmeasured_failures.md` that is actively misleading standalone lanes.

## The error

The memory says: *"Cross-check the base run against the published standalone jsonl."* At the default path that artifact does not exist — what a bare `scripts/fetch-baseline-jsonl.mjs` hands you (`.test262-cache/test262-current.jsonl`) is the **host** lane.

Verified over **all 48,619 rows**: the only import namespace appearing anywhere is **`env`** — 2,145,612 occurrences, **zero** `js2wasm:runtime-eval` — and there is no `mode`/`target` field to warn you.

**`oracle_lane: "honest"` is not a mode marker.** It's the honest-vs-fast *oracle* axis (#3462), present on 100% of rows. It reads like "the real lane", which is precisely the trap.

## Why it matters

A standalone run diffed against it shows a large disagreement count that **is the host-vs-standalone gap itself** — one lane measured ~219 — not instrument error. Followed literally, a lane either distrusts a working instrument or, far worse, tunes its runner until it agrees with the host lane's answers. That second failure is silent and would corrupt every measurement downstream of it.

There **is** a standalone baseline; it just isn't the default: `ensureStandaloneBaselineJsonl({ force: true })` from the same module (`STANDALONE_BASELINE_CACHE_PATH`).

## Also recorded

`node --import tsx scripts/build-runtime-eval-provider.mjs` is not by itself proof of a rebuild — the cache key is `no-bundle`-static, so it can no-op while reporting success, leaving you in the refusal tier you were trying to escape. Delete the cache and verify the emitted binary changed. Two lanes hit this independently and measured it: **3,970,936 → 3,970,952** and **3,970,952 → 3,971,726**.

## Provenance

Both were found by lanes working *against instructions I had written*. The import-namespace census is my own verification of their claims rather than a relay.

Note this correction was originally committed on a branch stacked on #4165. By the time #4165 merged, that branch had gone so stale that its diff against `main` was a **10,120-line revert** of the night's work — so it was abandoned and the change re-applied to main's current copy. A branch merely stale against files it never edited still reads as a revert in a tip-to-tip diff; that is the second time that shape nearly caused damage tonight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_