### PR TITLE
chore(gitignore): match .test262-cache as a symlink, not only a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ benchmarks/results/test262-run.log
 .codex/ci-status/
 .codex/symphony/
 .codex/dispatch/
-.test262-cache/
+.test262-cache
 output/
 examples/native-messaging/out/
 scripts/compiler-bundle.mjs


### PR DESCRIPTION
One character. `.gitignore` line 52 was `.test262-cache/` **with a trailing slash**, which matches directories only.

Lanes routinely symlink the shared cache into their worktree to avoid re-downloading ~25 MB each — a sensible thing to do, and a symlink is not a directory. So every such worktree reports an untracked `.test262-cache` and trips the untracked-files check.

Observed in two worktrees tonight; it will recur for every future lane that shares the cache.

Dropping the slash matches both spellings. Nothing else in the ignore file uses a bare name where a directory is specifically meant, so this doesn't widen anything unintended.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_