### PR TITLE
docs(memory): Fable can be out of credits — check before routing a spec

### DIFF
--- a/.claude/memory/feedback_hard_tasks_to_fable.md
+++ b/.claude/memory/feedback_hard_tasks_to_fable.md
@@ -12,6 +12,22 @@ So the split is now by **phase**, not by difficulty:
 | implementation, all tiers | **Opus** |
 | implementation spec for a **really hard** issue | **Fable**, written first |
 
+### ⚠ Fable can be OUT OF CREDITS — check before routing (2026-08-07)
+
+A Fable architect spawn for #4203 died on its first turn:
+`You've reached your Fable 5 limit. Run /usage-credits to continue`. The spawn
+**fails immediately**, so the cost is only a wasted pane — but if you have
+stalled an implementer waiting for the spec, you have stalled it forever.
+
+This is the concrete reason for the "do not stall the implementer" rule below,
+and it argues for keeping it: the Opus lane had already been told its own
+measurement outranks the spec, so it continued unaffected.
+
+When Fable is exhausted, do **not** substitute a parallel Opus architect onto an
+issue an Opus lane is already implementing — a second opinion arriving mid-flight
+into the same files buys little and can contradict the implementer's own
+measurements. Let the implementer run; spec only what nobody has started.
+
 For a `feasibility: hard` / `reasoning_effort: max` issue: spawn a **Fable
 architect** to write the `## Implementation Plan` into the issue file, and an
 **Opus** lane to implement it. They can run **in parallel** — the implementer's


### PR DESCRIPTION
Docs only — one file under `.claude/memory/`, no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/`. Opened as its own PR because no docs-only PR is currently open (#4188 merged a few minutes ago).

## What happened

The model-routing rule recorded on 2026-08-07 is *"continue work with opus instead of fable"* + *"if something is really hard ask fable to spec it first"* — so a `feasibility: hard` / `reasoning_effort: max` issue gets a Fable architect writing the spec in parallel with an Opus implementer.

Spawning that Fable architect for #4203 failed on its first turn:

```
You've reached your Fable 5 limit. Run /usage-credits to continue
```

## Why it is worth recording

The spawn **fails immediately**, so the direct cost is a wasted pane. The real hazard is second-order: if you have stalled the implementer waiting for the spec, you have stalled it *forever*, and the failure gives no signal at the implementer's end.

That is exactly the failure the existing "do not stall the implementer waiting for the spec" rule was written against — so this is evidence for keeping that rule, not a reason to relax it. In this instance W22 had already been told its own measurement outranks the spec, and continued unaffected.

## The other half: what NOT to do on exhaustion

Do not substitute a parallel **Opus** architect onto an issue an Opus lane is already implementing. A second opinion arriving mid-flight into the same files buys little and can contradict the implementer's own measurements — and specs in this repo are routinely right in shape and wrong in specifics (three named wrong root causes on 2026-08-06 alone). Let the implementer run; spec only what nobody has started.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_