### PR TITLE
docs(#4205,#4206): retract the census masking analysis — measured 0 reclassified, not 96

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The line above is the **JS-host path** (default `gc` target): runs alongside the
 
 <!-- AUTO:conformance-standalone-start -->
 
-**standalone (host-free) test262 conformance**: 28,222 / 43,505 (64.9 %)
+**standalone (host-free) test262 conformance**: 28,227 / 43,505 (64.9 %)
 
 <!-- AUTO:conformance-standalone-end -->
 

--- a/plan/issues/4206-with-statement-es5-standalone-residue.md
+++ b/plan/issues/4206-with-statement-es5-standalone-residue.md
@@ -1,6 +1,6 @@
 ---
 id: 4206
-title: "`with` statement: the closed-object-literal-shape gate hard-refuses 39 ES5 standalone files and 11 more mis-resolve — 68 further files are blocked behind #4205, not behind `with`"
+title: "`with` statement: the closed-object-literal-shape gate hard-refuses 39 ES5 standalone files and 11 more mis-resolve — plus 68 previously mis-attributed to #4205 that are measured to be `with`'s own"
 status: ready
 sprint: current
 created: 2026-08-07
@@ -29,18 +29,36 @@ the lever.** Splitting by what actually fails first:
 | --- | --- | --- |
 | Compiler hard-refuses at the gate | **39** | error text is literally `#1387: with statement requires a proven closed object-literal shape before codegen` |
 | Runtime scope-chain misresolution, no `this.x=` contamination | **11** | `Scope chain disturbed`, `with(null) x = 2 must throw TypeError`, `o.foo` wrong |
-| Also carry a script top-level `this.x = …` — **first failure is #4205, not `with`** | **68** | e.g. `S12.10_A1.1_T1.js` dies on line 61 (`p1 === 1. Actual: null`), `with` block is on line 42 |
+| Also carry a script top-level `this.x = …` — ~~first failure is #4205, not `with`~~ **MEASURED: these are `with`'s own** | **68** | see the correction below |
 | total | 118 | |
 
 Only **12 of the 118 pass in the host lane**, so this is a general semantics
 gap, not a standalone-lowering gap.
 
-**Do not quote 118 as this issue's yield.** The honest expectation is 39 + 11 =
-**50**, plus up to 68 more *after* #4205 lands. Per
-`[[reference_error_signature_is_not_a_bucket_boundary]]`, a masked file counts
-toward neither fix until both land — and when #4205 lands first, those 68 will
-surface as *fresh* `with` failures, which reads as a regression to anyone who
-did not write this down.
+### ⚠ CORRECTION (2026-08-07, W25 — supersedes the masking claim above)
+
+The original text said those 68 were blocked behind #4205 and that this issue
+should be discounted to **50** until #4205 landed. **That is measured false.**
+
+#4205 was implemented (PR #4192) and A/B'd over 388 files, per file:
+**ZERO changed error signature.** Not 96, not 68 — zero.
+
+Delta-debugging the canonical `with/S12.10_A1.1_T1.js` against the runner's own
+message as invariant isolates a **pure `with` defect**: remove one `valueOf`
+member from the with-object and the same file fails on `p1='x1'` instead of
+`p1=null` — i.e. the with-scoped assignment wrote **through to the global**.
+That is this issue's mechanism, not a global-`this` binding failure.
+
+**So: size this issue from its own mechanism, undiscounted. There is no #4205
+sequencing dependency, and nothing here counts toward another issue's yield.**
+
+The original inference was that the global-`this` assertion appears on an
+earlier *line* than the `with` block, so it must fail first. That is textual
+ordering, not causation — it reads like a measurement and is not one. Re-derive
+the population with the compiler's own predicates over effective source rather
+than inheriting any count on this page; the census that produced them ran **no
+local compiles**, and its lever #1 was wrong by a factor of 19 for exactly that
+reason.
 
 ## Root cause
 
@@ -97,7 +115,11 @@ Representative: `language/statements/with/S12.10_A1.12_T1.js`,
 - [ ] The 5 `S10.2.2_A1_T*` scope-chain files resolve identifiers through the
       object environment record.
 - [ ] `with(null)` / `with(undefined)` throw TypeError.
-- [ ] A/B reports the 50-file cohort and the 68 #4205-masked files **separately**.
+- [ ] A/B reports the **gate-refusal** cohort (the `#1387` path) and the
+      **runtime wrong-answer** cohort separately — they are plausibly different
+      work with different risk, and one PR may not want to carry both.
+      (The old "report the 68 #4205-masked files separately" criterion is void:
+      measured 0 masked.)
 
 ## Measurement provenance
 

--- a/plan/log/es5-standalone-lever-census-20260807.md
+++ b/plan/log/es5-standalone-lever-census-20260807.md
@@ -1,5 +1,44 @@
 # ES5 standalone lever census — 2026-08-07 (W23)
 
+> ## ⚠ CORRECTION, 2026-08-07 — lever #1 and the whole masking analysis (§4) are WRONG
+>
+> W25 implemented #4205 and measured it. Two load-bearing claims below do not
+> survive contact:
+>
+> **1. Lever #1 is not 133 files. It is 7.** The root cause this census
+> attributed to it **does not reproduce**: `this.p1 = 1; if (!(p1 === 1)) throw`
+> compiles and runs clean in `--target standalone` on unmodified main, 0
+> imports. The `!ctx.standalone` conjunct in `isScriptGlobalThisReceiver` is
+> **gOPD-local** and is not on that path. **"Standalone has no realm global
+> object" has been false since #2996** (`emitNativeGlobalThisObject` — a real,
+> identity-stable `$Object` singleton); #3956 + #3365 + #2996 already compose
+> into a working script-goal global object. Result: **FIXED 7 · BROKE 0**
+> (PR #4192).
+>
+> **2. §4's masking claim is false, and it was the most consequential thing in
+> this document.** Predicted: ~96 `with` files reclassify once #4205 lands.
+> Measured across 388 files, per file: **ZERO changed error signature.**
+> Delta-debugging `with/S12.10_A1.1_T1.js` isolates a **pure `with` defect** —
+> drop one `valueOf` member from the with-object and the same file fails on
+> `p1='x1'` instead of `p1=null`, i.e. the with-scoped assignment wrote through
+> to the global.
+>
+> **Consequences for anyone steering from this document:**
+> - **Estimate #4206 from its own mechanism, UNDISCOUNTED.** The "+68 masked"
+>   adjustment and the "sequence #4205 before #4206" instruction in §4, §7 and
+>   §8 are void. There is no sequencing dependency.
+> - Do not inherit any count in the table without re-deriving it. §0 already
+>   says **no local compile was run**; lever #1 is what that limitation looks
+>   like in practice — a shape predicate matched 133 files, and 126 of them were
+>   failing for other reasons entirely.
+> - The method failure is specific and worth naming: **co-occurrence was read as
+>   causation.** "128 of the 133 also match another mechanism, and the
+>   global-`this` assertion appears on an earlier line" is evidence of textual
+>   ordering, not of one failure blocking another. The line-number argument in
+>   §4 felt like a measurement and was not one.
+>
+> Everything below is left as originally written, for provenance.
+
 Ranked, mechanism-bucketed census of the **ES5-label `--target standalone`**
 failing residue, produced to steer the "90 % ES5 standalone" goal. Bucketing is
 by **mechanism** (established by reading the failing source and locating the
@@ -148,6 +187,11 @@ files against it.
 
 ## 4. Masking — the most consequential structural fact
 
+> **⚠ THIS ENTIRE SECTION IS RETRACTED — see the correction at the top.**
+> Measured per file across 388 files: **0 reclassified**, not 96. `with` is an
+> independent mechanism; there is no #4205 → #4206 sequencing dependency. The
+> reasoning below mistook co-occurrence and line ordering for causation.
+
 **128 of the 133 script-goal-global-object files also match another
 mechanism**, and 96 of them are `with` tests. In every one inspected, the
 global-`this` assertion fires *first*:
@@ -223,8 +267,14 @@ Two forms, both measured:
 
 ## 7. Recommended sequencing
 
-1. **#4205 script-goal global object** (133) — first, because it unmasks 96
-   `with` files and 41 others. Unowned.
+> **⚠ Item 1 is spent and item 5's `+68 after #4205` is void — see the
+> correction at the top.** #4205 measured **7 files**, not 133, and unmasked
+> **nothing**. Revised head of the queue: **#4206 `with`** (sized from its own
+> mechanism, undiscounted), then #2928, #2668, #4208, #4207.
+
+1. ~~**#4205 script-goal global object** (133) — first, because it unmasks 96
+   `with` files and 41 others. Unowned.~~ **DONE, PR #4192 — 7 files, unmasked
+   nothing.**
 2. **#2928 interpreter lane** (164 union) — one substrate, one number, and the
    only lever whose payoff is not entangled with any other. Currently
    `released`, not claimed.
@@ -236,15 +286,15 @@ Two forms, both measured:
 4. **#4208 operator abstract-ops** (55) — high value beyond ES5: it is the
    root of ~16 files currently mis-filed as crashes, and 45 of its 55 fail in
    host too.
-5. **#4207 transferred proto method** (59) and **#4206 `with`** (39 + 11, then
-   +68 after #4205).
+5. **#4207 transferred proto method** (59) and **#4206 `with`** (39 + 11; the
+   "+68 after #4205" adjustment is **void** — measured 0 reclassified).
 
 ## 8. New issues filed by this census
 
 | id | lever | files | why it was not already filed |
 | --- | --- | --- | --- |
-| #4205 | script-goal global object | 133 | #2727 covers only `typeof this === "object"`; the binding-creation half was never sized |
-| #4206 | `with` statement residue | 39 + 11 (+68 masked) | #671 is a 2026-03 backlog stub with no sizing; #1387/#3025 are done |
+| #4205 | script-goal global object | ~~133~~ → **7 measured** | #2727 covers only `typeof this === "object"`; the binding-creation half was never sized. **The 133 was wrong — see the correction at the top.** |
+| #4206 | `with` statement residue | 39 + 11 (~~+68 masked~~ — **void**, 0 measured) | #671 is a 2026-03 backlog stub with no sizing; #1387/#3025 are done |
 | #4207 | transferred builtin proto method | 70 (59 primary) | #3992 fixed the argument slot, #4076 fixed the `.call` form; the transfer form's `this` handling is uncovered |
 | #4208 | operator abstract-ops from static type | 55–59 | #3055/#4183 cover only `===` on boxed values |
 


### PR DESCRIPTION
Docs only — the census log and #4206's issue file. No `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/`.

This corrects the census merged in #4191 **two hours ago**. It was steering the next lane wrong, and the wrong instruction was the most prominent thing in the document.

## What was wrong

W25 implemented #4205 (PR #4192) and measured it. Two load-bearing claims did not survive contact:

**1. Lever #1 is 7 files, not 133.** The root cause the census attributed to it does not reproduce — `this.p1 = 1; if (!(p1 === 1)) throw` compiles and runs clean in `--target standalone` on unmodified main, 0 imports. The `!ctx.standalone` conjunct in `isScriptGlobalThisReceiver` is **gOPD-local** and is not on that path, and **"standalone has no realm global object" has been false since #2996** (`emitNativeGlobalThisObject`).

**2. §4, the masking analysis, is retracted outright.** It predicted ~96 `with` files would reclassify once #4205 landed, and told the next lane to discount #4206 to 50 and sequence it behind #4205. Measured across 388 files, per file: **zero changed error signature.**

Delta-debugging `with/S12.10_A1.1_T1.js` against the runner's own message as invariant isolates a **pure `with` defect** — remove one `valueOf` member from the with-object and the same file fails on `p1='x1'` instead of `p1=null`, i.e. the with-scoped assignment wrote through to the global.

## The method error, because it will recur

**Co-occurrence and line ordering were read as causation.** "128 of the 133 also match another mechanism, and the global-`this` assertion sits on an earlier line than the `with` block" is evidence about *text*, not about which failure blocks which. It was presented as "the most consequential structural fact" and read like a measurement; it was not one.

§0 of the census already disclosed that **no local compile was run**. Lever #1 is what that limitation looks like in practice: a shape predicate matched 133 files and 126 of them were failing for unrelated reasons. The disclosure was honest and still insufficient — a limitation stated in §0 does not travel with a number quoted from §2.

## What changed

- **Census log** — correction banner at the top; §4 marked retracted; §7 item 1 struck and the revised queue head stated; §7 item 5 and §8's table rows de-discounted.
- **#4206 issue file** — title restated, the masking row and the "discount to 50" paragraph replaced with the measured result, and the acceptance criterion rewritten. The old criterion asked for the 68 masked files to be reported separately; the replacement asks for the **gate-refusal** cohort (the `#1387` path) and the **runtime wrong-answer** cohort to be reported separately, since those are plausibly different work with different risk.

Both files now say: **size #4206 from its own mechanism, undiscounted, and re-derive rather than inheriting any count on the page.**

Everything else in the census is left as written, for provenance — including the findings that still stand, notably that ES5 standalone is 5.4 points *ahead* of ES5 host and that ~16 files in the crash cluster are a coercion defect rather than a crash mechanism.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_