### PR TITLE
chore(#3437): rebank the harness compile budget to main's actual 111,568 — the gate has 1.1% headroom and is a trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The line above is the **JS-host path** (default `gc` target): runs alongside the
 
 <!-- AUTO:conformance-standalone-start -->
 
-**standalone (host-free) test262 conformance**: 28,222 / 43,505 (64.9 %)
+**standalone (host-free) test262 conformance**: 28,227 / 43,505 (64.9 %)
 
 <!-- AUTO:conformance-standalone-end -->
 

--- a/scripts/harness-compile-budget.json
+++ b/scripts/harness-compile-budget.json
@@ -1,7 +1,7 @@
 {
-  "forEachChildCalls": 98089,
+  "forEachChildCalls": 111568,
   "marginPct": 15,
   "fixtureCallSites": 120,
-  "updated": "2026-07-23",
+  "updated": "2026-08-07",
   "note": "Deterministic shared-forEachChild traversal count for the #3437 representative harness assembly. Reseed with `npx tsx scripts/check-harness-compile-budget.ts --update` when a slowdown is intentional and justified. See the script header."
 }


### PR DESCRIPTION
One-line change to `scripts/harness-compile-budget.json`: `98089` → `111568`.

## The gate currently cannot do its job

| | |
|---|---|
| banked (2026-07-23) | 98,089 |
| **main measures today** | **111,568** |
| ceiling (+15 %) | 112,803 |
| **headroom** | **1,235 — 1.1 %** |

That is pre-existing drift accumulated across landed work since July, attributable to no single change. Verified on a clean checkout of `origin/main` with no local `src/` changes.

`check:harness-compile-budget` exists to catch a change that **materially** slows harness-shaped compilation — the #3433 regression class. At 1.1 % headroom it does something else: the next lane to add any small per-file scan trips a required check on drift it did not cause, with a failure message pointing at its own diff.

Rebanking to main's measured value restores the full 15 % margin (new ceiling ≈128,303).

## Why this is not a blanket permission to rebank

Worth stating explicitly, because `--update` looks identical whether you are absorbing someone else's drift or laundering your own regression, and the script offers it in the failure message either way.

This was surfaced by the #4205 lane (PR #4192) — which was **refused** an `--update` for its own **+21.7 %** regression (98,089 → 119,352). It fixed the scan instead:

| sources | measured |
|---|---|
| first cut (red) | 119,352 |
| statement-level walk only | 111,865 |
| + `this`/`globalThis` precondition (shipped) | **111,568 — +0, byte-identical to base** |

Its root cause was a walk descending into every expression of top-level code plus a second whole-file traversal for the alias set. Both were removed rather than banked.

So: **rebanking pre-existing landed drift and rebanking your own regression are different acts.** Only the first is happening here. A lane whose own change moves this number should still fix the scan.

## Follow-up worth considering separately

A gate that silently drifts to 98.9 % of its own ceiling has no signal until it fires on the wrong person. Options — not taken here, since this PR should stay a one-liner:

- have the post-merge job auto-rebank *downward-or-flat* drift the way `check:ir-fallbacks --update-on-decrease` banks improvements, so the baseline tracks main automatically;
- or warn in CI once headroom drops below some fraction of the margin, so the rebank is a deliberate scheduled act rather than a discovery made by whoever trips it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_