### PR TITLE
docs(memory): two more ways the test262 harness measures the wrong compiler

### DIFF
--- a/.claude/memory/reference_standalone_eval_instrument_reports_unmeasured_failures.md
+++ b/.claude/memory/reference_standalone_eval_instrument_reports_unmeasured_failures.md
@@ -42,6 +42,29 @@ and no populated `test262/`** (`bash scripts/provision-worktree-deps.sh`). A
 hand-made `ln -s test262` was clobbered mid-session and a census went from
 1,609 attributed to **0** with no error at all.
 
+### Two MORE ways the harness measures the wrong compiler (2026-08-07, W26)
+
+Same family, different layer — neither is about the provider:
+
+4. **The pool worker imports `scripts/compiler-bundle.mjs` and
+   `scripts/runtime-bundle.mjs` — NOT `src/`.** Edit `src/`, re-run through the
+   pool worker, and you measure the **previous compiler**. Both bundles must be
+   rebuilt for **each arm** of an A/B. Fails exactly like the provider-cache
+   trap: a plausible result, no error, nothing saying the arm never saw your
+   change.
+
+5. **`scripts/provision-worktree-deps.sh` silently no-ops on a container with
+   no `/workspace`.** `SOURCE_ROOT` resolves to the agent's own worktree and the
+   script **exits 0 having done nothing**. The pool worker then dies importing
+   the missing `scripts/compiler-bundle.mjs`, every test times out at 90 s, and
+   the run reports **everything FAILED with a 0-byte jsonl**. Workaround:
+   `JS2_WORKTREE_SOURCE=/home/user/js2`. Cost one lane ~1 h.
+
+   This one at least fails loudly — but *implausibly* loudly. A 201/201 wipeout
+   reads as "my change broke the world", so the danger is not believing it; it
+   is spending an hour bisecting your own diff. **A total failure with a 0-byte
+   jsonl is an instrument failure until proven otherwise.**
+
 ## The rule
 
 **Build a two-sided instrument before believing any number**: the failing lever

--- a/.claude/memory/reference_standalone_eval_instrument_reports_unmeasured_failures.md
+++ b/.claude/memory/reference_standalone_eval_instrument_reports_unmeasured_failures.md
@@ -65,6 +65,19 @@ Same family, different layer — neither is about the provider:
    is spending an hour bisecting your own diff. **A total failure with a 0-byte
    jsonl is an instrument failure until proven otherwise.**
 
+   **The REPAIRED run has its own trap, and this one is silent.** A second lane
+   hit the no-op, re-ran with `JS2_WORKTREE_SOURCE`, and the repaired run linked
+   `node_modules` and a per-entry `test262/` symlink farm into **another agent's
+   worktree** rather than the main checkout. Point it at `/home/user/js2` and
+   verify where the links actually landed (`ls -l node_modules test262`).
+
+   A dep tree living inside another lane's worktree is a **delayed** version of
+   the clobber that once took a census from 1,609 attributed to 0: it works
+   perfectly until that lane's worktree is removed after its PR merges, and then
+   your next run fails — or worse, half-fails — for reasons that have nothing to
+   do with your change. Worktree cleanup is routine, so this is a scheduled
+   failure, not a hypothetical one.
+
 ## The rule
 
 **Build a two-sided instrument before believing any number**: the failing lever


### PR DESCRIPTION
Docs only — one memory file. Both traps found by the #4206 lane today; both sit **outside** the provider layer the file already covered, and both fail the same way: the arm silently does not see your change.

## 4. The pool worker imports the BUNDLES, not `src/`

`scripts/compiler-bundle.mjs` and `scripts/runtime-bundle.mjs` — not `src/`. Edit `src/`, re-run through the pool worker, and you measure **the previous compiler**. Both bundles must be rebuilt for **each arm** of an A/B.

Fails exactly like the provider-cache trap: plausible result, no error, nothing indicating the arm never saw the change.

## 5. `provision-worktree-deps.sh` silently no-ops with no `/workspace`

`SOURCE_ROOT` resolves to the agent's own worktree and the script **exits 0 having done nothing**. The pool worker then dies importing the missing `scripts/compiler-bundle.mjs`, every test times out at 90 s, and the run reports **everything FAILED with a 0-byte jsonl**.

Workaround: `JS2_WORKTREE_SOURCE=/home/user/js2`. Cost one lane ~1 hour today.

**This one fails loudly — but implausibly loudly, which is its own trap.** A 201/201 wipeout reads as "my change broke the world", so the cost is not believing the number; it is spending an hour bisecting your own diff. Recorded the heuristic: **a total failure with a 0-byte jsonl is an instrument failure until proven otherwise.**

## Why this file keeps growing

Five mechanisms now, found by five different lanes, each rediscovering theirs from scratch. They share one shape — the measurement completes and reports something that looks like a result while the instrument was not live — which is why they belong in one place rather than in five issue files.

Worth noting what the existing entries bought today: three lanes deleted the provider cache per arm as instructed and one of them independently re-confirmed that the cache key is worthless as a control (identical key `854c120ce015d507` across builds emitting 3,971,954 / 3,995,550 / 4,141,601 bytes). The entries are load-bearing, not folklore.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_