### PR TITLE
docs(memory): a standalone refusal that throws TypeError is a vacuous-pass generator

### DIFF
--- a/.claude/memory/project_hostfree_pass_can_be_vacuous_inject_throw_probe.md
+++ b/.claude/memory/project_hostfree_pass_can_be_vacuous_inject_throw_probe.md
@@ -11,4 +11,38 @@ metadata:
 
 **Why:** the leak was the only thing excluding these vacuous passes from the honest count. Eliminating a leak without making the body execute converts leaky-vacuous → host-free-vacuous, silently inflating `host_free_pass`.
 
+## Second mechanism: a REFUSAL throwing the exception the test wanted (2026-08-07, #4207)
+
+A `--target standalone` **not-yet-implemented refusal** throws a `TypeError`. Any
+test whose success condition is "a TypeError is thrown" therefore **passes
+because the feature is missing**.
+
+Measured probe (W28, #4207 lane):
+
+```js
+s = new String();
+s.valueOf = Number.prototype.valueOf;
+s.valueOf();   // TypeError — but from the refusal body,
+               // "Number.prototype.valueOf is not yet implemented in --target standalone",
+               // NOT from the [[Class]] brand check the test is actually exercising
+```
+
+**This inverts the usual incentive.** Implementing the member correctly turns a
+passing file into a failing one, unless the brand check lands in the same
+change. So a lane doing good work gets charged with a regression caused by a
+*different* missing piece — and because the regression gates run on the merged
+state, it surfaces as a `merge_group` auto-park rather than at PR level, after
+the author has moved on.
+
+**Before implementing any standalone builtin member, enumerate the files whose
+current pass depends on that member's refusal throwing.** That set is a
+deliverable in its own right, independent of the fix, and it is the difference
+between "I caused a regression" and "I converted a known vacuous pass, here is
+the list".
+
+Distinguishing test: a genuine pass survives implementing the feature; a vacuous
+one does not. If a test passes today and its assertion is `assert.throws(TypeError, …)`
+against a member the standalone lane refuses, treat it as vacuous until shown
+otherwise.
+
 **How to apply:** any leak-elimination PR must prove the affected test bodies actually EXECUTE, not just that the import disappears. Standard probe: inject `throw new Error('RAN')` (or a log) as the first statement of the callback/wrapper body — if the test still passes, the body is dead and the "fix" is dishonest. Also output-diff standalone vs js-host on a sample. Root blocker for the #2921 class: dynamic dispatch of `any`-typed closure params requires exact arity+kind match (`src/codegen/expressions/calls-closures.ts` ~L688 exact-arity continue + L693-698 kind check) instead of JS arity semantics; fix routed to senior lane. Related: [[reference_standalone_any_string_value_read_substrate]].


### PR DESCRIPTION
Docs only — one memory file. Adds a second mechanism to the existing vacuous-pass note (which covered the #2921 dead-callback-body class).

## The mechanism

A `--target standalone` **not-yet-implemented refusal throws a `TypeError`**. Any test whose success condition is "a TypeError is thrown" therefore **passes because the feature is missing**.

Measured on the #4207 lane today:

```js
s = new String();
s.valueOf = Number.prototype.valueOf;
s.valueOf();   // TypeError — but from the refusal body,
               // "Number.prototype.valueOf is not yet implemented in --target standalone",
               // NOT from the [[Class]] brand check the test actually exercises
```

The same probe set found the brand check is not simply absent — it works for some receivers and is *inverted* for others (`RegExp.prototype.test` transferred onto a RegExp is correct; onto a Number correctly throws; `Boolean.prototype.toString` onto a Boolean wrongly throws).

## Why it is worse than the mechanism already recorded

It **inverts the incentive**. Implementing the member correctly turns a passing file into a failing one, unless the brand check lands in the same change. So a lane doing good work is charged with a regression caused by a *different* missing piece.

And because the real regression gates run on the merged state, it surfaces as a `merge_group` auto-park rather than at PR level — after the author has moved on, and in front of whoever is shepherding the queue.

## The rule recorded

**Before implementing any standalone builtin member, enumerate the files whose current pass depends on that member's refusal throwing.** That set is a deliverable in its own right, independent of the fix, and it is the difference between "I caused a regression" and "I converted a known vacuous pass, here is the list".

Distinguishing test: a genuine pass survives implementing the feature; a vacuous one does not. A test passing today whose assertion is `assert.throws(TypeError, …)` against a member the standalone lane refuses should be treated as vacuous until shown otherwise.

## Scope of this PR

The **class**, not the count. The #4207 lane is enumerating the at-risk set now; if it turns out large it will get its own issue, and its PR carries the specifics. Recording the class separately because it applies to any lane implementing a standalone builtin, not only to #4207 — the next one could hit it tomorrow without ever reading that PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_