### PR TITLE
docs(#4209): file the refusal-vacuous-pass census, and record that the pre-scan dirty gates cannot bound a blast radius

### DIFF
--- a/.claude/memory/reference_standalone_eval_instrument_reports_unmeasured_failures.md
+++ b/.claude/memory/reference_standalone_eval_instrument_reports_unmeasured_failures.md
@@ -78,6 +78,23 @@ Same family, different layer — neither is about the provider:
    do with your change. Worktree cleanup is routine, so this is a scheduled
    failure, not a hypothetical one.
 
+### ⚠ The pre-scan "dirty" gates cannot bound a blast radius in THIS corpus
+
+A tempting safety claim is "my change is gated on `protoNamedDirty` (or another
+pre-scan dirty flag), so every file that fails the gate is byte-identical."
+True in principle. Worth **0.07 %** of the corpus in practice.
+
+The js2wasm host-globals shim that `assembleOriginalHarness` prepends to
+**every** file contains `return eval(sourceText);`, so `isDynamicCodeUse` sets
+`dynamicCodeDirty` ⇒ `protoNamedDirty`. Measured 2026-08-07 over the effective
+source of all 48,619 baseline rows: **48,587 have the gate SET; 32 are provably
+clear.**
+
+So the gate is not a filter, it is a constant. Size exposure by the **real
+trigger** — the syntactic shape that actually reaches your modified code path —
+and byte-hash the emitted modules to prove the rest untouched. Any reviewer
+seeing "gated on X ⇒ safe" should ask what fraction of the corpus fails gate X.
+
 ## The rule
 
 **Build a two-sided instrument before believing any number**: the failing lever

--- a/plan/issues/4209-refusal-vacuous-pass-census.md
+++ b/plan/issues/4209-refusal-vacuous-pass-census.md
@@ -1,0 +1,121 @@
+---
+id: 4209
+title: "Census: how many currently-PASSING standalone tests pass only because a not-yet-implemented refusal throws TypeError? (decisive experiment: swap the refusal to RangeError)"
+status: ready
+sprint: current
+created: 2026-08-07
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: research
+area: standalone, test262-infra
+es_edition: 5
+goal: es5
+related: [4207, 2875, 2961, 2921, 1897, 2097]
+origin: "2026-08-07 W28 (#4207 transferred-proto-method lane) — found the mechanism, declined to half-measure the count inside its own PR, and handed over the experiment design."
+---
+
+# #4209 — the refusal-vacuous-pass census
+
+## The mechanism
+
+A `--target standalone` **not-yet-implemented refusal throws a `TypeError`**. Any
+test whose success condition is "a TypeError is thrown" therefore **passes
+because the feature is missing**.
+
+Measured on the #4207 lane:
+
+```js
+s = new String();
+s.valueOf = Number.prototype.valueOf;
+s.valueOf();   // TypeError — but from the refusal body,
+               // "Number.prototype.valueOf is not yet implemented in --target standalone",
+               // NOT from the [[Class]] brand check the test actually exercises
+```
+
+## Why this needs a number, not just a warning
+
+The class **inverts the incentive on correctness work**. Implementing the member
+properly converts a passing file into a failing one, unless whatever the test is
+*really* checking lands in the same change. So a lane doing good work is charged
+with a regression caused by a different missing piece.
+
+Worse, the regression gates run on the **merged state**, so it surfaces as a
+`merge_group` auto-park (#2547) — after the author has stood down, in front of
+whoever is shepherding the queue, and attributed to the wrong PR.
+
+Every future standalone-builtin implementation walks into this. Without the set,
+each one rediscovers it as a surprise park.
+
+It also means **the standalone conformance number is inflated by an unknown
+amount**, in a way the honest-metric work (#1897/#2097 floors, #2921's host-free
+rule) does not currently catch: these files are host-free *and* genuinely
+executed. They are simply passing for the wrong reason.
+
+## The decisive experiment (W28's design)
+
+The cheap version — grep for currently-`pass` files asserting a TypeError
+against a refused member — is **an upper bound only**, because a file can assert
+TypeError for a reason the refusal coincidentally satisfies *and* would still
+pass once implemented.
+
+The decisive version is one extra arm:
+
+1. Change the refusal body to throw a **`RangeError`** instead of a `TypeError`.
+   Nothing else.
+2. Re-run the standalone corpus.
+3. **Every currently-passing file that flips is passing because the feature is
+   missing.** No inference required — a test that wanted a real TypeError is
+   unaffected, and one that was only catching the refusal fails.
+
+This is clean, self-contained, and needs no judgement calls about intent.
+
+## Deliverable
+
+- The **enumerated set**, per file, with the refused member each one depends on.
+- Grouped by owning issue (#2875 unimplemented-member, #2961 host-import leak,
+  and whatever else appears) so each implementation lane can find its own
+  at-risk files before it starts.
+- A recommendation on whether the refusal should throw a **distinguishable**
+  error type permanently, so this class becomes self-detecting rather than
+  needing a census each time. Note the tension: a non-`TypeError` refusal is
+  further from spec behaviour for code that legitimately expects a TypeError,
+  so this is a real trade-off and not an obvious win.
+
+## Candidate predicate (starting point, not the answer)
+
+Currently-`pass` files whose effective source (body + `includes:` harness) reads
+`<Builtin>.prototype.<m>` as a **value** and asserts a TypeError.
+
+## Acceptance criteria
+
+- [ ] The RangeError arm is run over the full standalone corpus, not a sample.
+- [ ] The flipped set is enumerated per file and attributed to a refused member.
+- [ ] The result is stated as a **count of inflated passes** in the standalone
+      metric, so the honest number is known even if nothing is fixed.
+- [ ] The at-risk set is written somewhere an implementing lane will hit it —
+      the owning issues, not only this one.
+
+## Instrument notes
+
+- `.claude/memory/project_hostfree_pass_can_be_vacuous_inject_throw_probe.md`
+  records this as the **second** vacuous-pass mechanism; the first is the #2921
+  dead-callback-body class. Read both before designing the run.
+- Standard traps apply: use `ensureStandaloneBaselineJsonl({force:true})` (the
+  default jsonl is the HOST lane), delete the provider `.wasm` per arm, rebuild
+  `scripts/compiler-bundle.mjs` + `scripts/runtime-bundle.mjs` per arm, and use
+  `JS2_WORKTREE_SOURCE=/home/user/js2` because
+  `scripts/provision-worktree-deps.sh` silently no-ops here.
+
+## Do NOT bound this by the pre-scan dirty gates
+
+Measured by W28 over the effective source of all 48,619 baseline rows: the
+js2wasm host-globals shim that `assembleOriginalHarness` prepends to **every**
+file contains `return eval(sourceText);`, so `isDynamicCodeUse` sets
+`dynamicCodeDirty` ⇒ `protoNamedDirty`. **48,587 of 48,619 rows have the gate
+SET; only 32 are provably clear.**
+
+Any "gated on `protoNamedDirty`, therefore byte-identical" safety claim is true
+in principle and worth **0.07 %** of the corpus in practice. Size exposure by the
+real trigger instead.


### PR DESCRIPTION
Docs only — one new issue file and one memory file. Both findings come from the #4207 lane, which deliberately handed them over rather than half-measuring them inside its own PR.

## #4209 — the refusal-vacuous-pass census

A `--target standalone` **not-yet-implemented refusal throws `TypeError`**, so any test asserting "a TypeError is thrown" **passes because the feature is missing**.

Two consequences worth filing for:

- **It inverts the incentive on correctness work.** Implementing the member properly converts a passing file into a failing one, unless whatever the test is *really* checking lands in the same change. And because the regression gates run on the merged state, it surfaces as a `merge_group` auto-park — after the author has stood down, and attributed to the wrong PR. Every future standalone-builtin implementation walks into this and rediscovers it as a surprise park.
- **The standalone conformance number is inflated by an unknown amount**, in a way the honest-metric work does not catch. These files are host-free *and* genuinely executed — the #2921 rule and the #1897/#2097 floors all pass them. They are simply passing for the wrong reason.

### The decisive experiment, which is why this is worth an issue

The cheap version — grep currently-`pass` files asserting TypeError against a refused member — is **an upper bound only**: a file can assert TypeError for a reason the refusal coincidentally satisfies and still pass once implemented.

The decisive version is one extra arm: **change the refusal body to throw `RangeError`** and re-run. Every currently-passing file that flips was passing because the feature is missing. No inference about intent required.

The issue carries the design, the candidate predicate, and the acceptance criteria, including the open question of whether the refusal should permanently throw a distinguishable error type — with the trade-off stated rather than assumed, since a non-`TypeError` refusal is further from spec for code that legitimately expects one.

## The dirty-gate exposure trap

Recorded in the instrument memory, because it invalidates a safety claim that reads as rigorous.

"My change is gated on `protoNamedDirty`, so every file failing the gate is byte-identical" is true in principle and worth **0.07 %** of the corpus in practice. The js2wasm host-globals shim that `assembleOriginalHarness` prepends to **every** file contains `return eval(sourceText);`, so `isDynamicCodeUse` sets `dynamicCodeDirty` ⇒ `protoNamedDirty`.

Measured over the effective source of all 48,619 baseline rows: **48,587 have the gate SET; 32 are provably clear.**

The gate is a constant, not a filter. Size exposure by the real trigger and byte-hash the emitted modules instead — and a reviewer seeing "gated on X ⇒ safe" should ask what fraction of the corpus fails gate X.

## Id reservation

`#4209` was reserved with `pr_scan="degraded"` (`gh` is unusable in this container — REST 401). The open-PR scan was run **out of band from the coordinator loop**: only #4200 is open and it adds no issue file. So the reservation is **verified clean**, not merely unscanned.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_