### PR TITLE
fix(ci): #4211 — sync the conformance docs AFTER the high-water raise, not before

### DIFF
--- a/.github/workflows/baseline-summary-sync.yml
+++ b/.github/workflows/baseline-summary-sync.yml
@@ -172,8 +172,11 @@ jobs:
           node --experimental-strip-types scripts/generate-editions.ts \
             --results /tmp/js2wasm-baselines/test262-current.jsonl || \
             echo "WARN: generate-editions failed (non-fatal) — edition buckets may lag"
-          node scripts/sync-conformance-numbers.mjs || \
-            echo "WARN: sync-conformance-numbers failed (non-fatal) — docs may drift"
+          # NOTE: sync-conformance-numbers is deliberately NOT run here. It
+          # derives the standalone line from the high-water mark, which is not
+          # raised until further down — running it now would sync the docs to
+          # the PRE-raise value and commit that alongside the POST-raise mark.
+          # See the call sited after the raise below.
           # #2108 — coercion-site drift baseline (pure source-grep). The
           # promote-baseline job in test262-sharded.yml is the primary refresher
           # on every push to main; this hourly fallback re-anchors it too so a
@@ -221,6 +224,18 @@ jobs:
           node scripts/check-standalone-highwater.mjs \
             --report "$SA_REPORT" --update ${HW_SHA:+--sha "$HW_SHA"} || \
             echo "WARN: high-water raise failed (non-fatal) — mark may lag"
+
+          # Sync the prose docs LAST, after BOTH inputs are final: the JS-host
+          # number from test262-current.json (copied above) and the standalone
+          # line from the high-water mark (raised immediately above). Running it
+          # before the raise — as this job did until #4211 — committed a NEW mark
+          # next to a README synced from the OLD one, so main shipped internally
+          # inconsistent and every open PR then failed the `quality` gate's
+          # sync:conformance:check until some unrelated PR happened to carry the
+          # repair commit. Observed three times on 2026-08-07 and it parked nine
+          # PRs that morning.
+          node scripts/sync-conformance-numbers.mjs || \
+            echo "WARN: sync-conformance-numbers failed (non-fatal) — docs may drift"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -319,6 +334,16 @@ jobs:
               --report "$SA_REPORT" --update ${HW_SHA:+--sha "$HW_SHA"} || \
               echo "WARN: high-water recompute on re-anchored tip failed (non-fatal)"
             git add -f benchmarks/results/test262-standalone-highwater.json 2>/dev/null || true
+            # (#4211) The re-apply loop restored the README we synced against
+            # our ORIGINAL mark, and the recompute immediately above may have
+            # landed on a different one (main's tip is max(ours, main's)). So
+            # re-sync against the mark that is actually about to be committed,
+            # and re-stage the prose docs. Without this the re-anchor path
+            # commits the same old-mark/new-mark mismatch the fresh path used to.
+            node scripts/sync-conformance-numbers.mjs || \
+              echo "WARN: sync-conformance-numbers on re-anchored tip failed (non-fatal)"
+            git add -f README.md ROADMAP.md CLAUDE.md plan/goals/goal-graph.md \
+              2>/dev/null || true
             if git diff --cached --quiet; then
               echo "Summary already current on main after re-anchor — nothing to push."
               PUSHED=1

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The line above is the **JS-host path** (default `gc` target): runs alongside the
 
 <!-- AUTO:conformance-standalone-start -->
 
-**standalone (host-free) test262 conformance**: 28,257 / 43,505 (65.0 %)
+**standalone (host-free) test262 conformance**: 28,270 / 43,505 (65.0 %)
 
 <!-- AUTO:conformance-standalone-end -->
 

--- a/plan/issues/4211-conformance-sync-ordering.md
+++ b/plan/issues/4211-conformance-sync-ordering.md
@@ -1,0 +1,100 @@
+---
+id: 4211
+title: "baseline-summary-sync commits a NEW standalone high-water mark next to a README synced from the OLD one — main ships internally inconsistent and every open PR fails the quality gate"
+status: done
+completed: 2026-08-07
+assignee: ttraenkler/lead
+sprint: current
+created: 2026-08-07
+priority: high
+horizon: s
+feasibility: easy
+task_type: fix
+area: ci
+goal: dogfood
+related: [1522, 3953, 2097, 4178, 1951]
+origin: "2026-08-07 — third recurrence in one session (28,222→28,227, then 28,257→28,270); nine PRs parked on the same gate that morning."
+---
+
+# #4211 — the conformance-sync ordering bug
+
+## Symptom
+
+Every open PR fails the `quality` gate:
+
+```
+[sync-conformance] DIFFERS  README.md (standalone)
+  committed: **standalone (host-free) test262 conformance**: 28,257 / 43,505 (65.0 %)
+  generated: **standalone (host-free) test262 conformance**: 28,270 / 43,505 (65.0 %)
+```
+
+The mismatch is between **main's own README** and **main's own committed
+artifacts** — nothing to do with the PR being tested. It clears only when some
+unrelated PR happens to carry a `pnpm run sync:conformance` commit, and it comes
+straight back on the next baseline bump.
+
+Observed **three times on 2026-08-07**, and it parked nine PRs that morning
+(patched then as #4178, which repaired the symptom and not the cause).
+
+## Root cause
+
+`sync-conformance-numbers.mjs` derives **two** numbers from **two different
+files**:
+
+| line | source |
+| --- | --- |
+| JS-host conformance | `benchmarks/results/test262-current.json` |
+| **standalone (host-free)** | **`benchmarks/results/test262-standalone-highwater.json`** |
+
+In `.github/workflows/baseline-summary-sync.yml` the order was:
+
+1. copy the fresh `test262-current.json`
+2. **run `sync-conformance-numbers.mjs`** ← reads the *old* high-water mark
+3. **`check-standalone-highwater.mjs --update`** ← raises the mark
+4. `git add` the mark **and** the README, and commit
+
+So the commit contains a **new mark** and a README standalone line synced from
+the **old** one. Not a race and not flaky — a deterministic, guaranteed
+inconsistency emitted every time the mark rises.
+
+The `promote-baseline` job in `test262-sharded.yml` carries a comment insisting
+this sync "must update everything derived from it ATOMICALLY in the same
+commit". That intent was right; this job's ordering silently broke it, because
+the standalone half derives from an artifact that is written *later in the same
+job*.
+
+The **re-anchor / retry path** (the `for attempt in 1 2 3 4 5` loop) had the same
+defect in a subtler form: it re-applies the snapshotted README — already synced
+against the *original* mark — then recomputes the mark against main's freshly
+fetched tip (`max(ours, main's)`), and never re-syncs.
+
+## Fix
+
+- **Fresh path:** move the `sync-conformance-numbers.mjs` call to *after* the
+  high-water raise, so both inputs are final before the docs are written.
+- **Re-anchor path:** re-run the sync after the recompute and re-stage
+  `README.md ROADMAP.md CLAUDE.md plan/goals/goal-graph.md`.
+
+`refresh-baseline.yml` already had the correct order (raise at ~447, sync at
+~780) and is unchanged. `test262-sharded.yml`'s promote job takes the mark from
+an artifact that is already final when it syncs, and is unchanged.
+
+## Why this was worth chasing rather than patching again
+
+The per-PR repair is one line and takes a minute, which is exactly why it kept
+being the chosen response. But the cost is not the minute:
+
+- it blocks **every** open PR simultaneously, so it scales with queue depth;
+- the failure names the *PR's* `quality` job, so each lane diagnoses it from
+  scratch as though it were their own regression;
+- and it recurs on every baseline bump, which is several times a day.
+
+## Verification
+
+`baseline-summary-sync.yml` parses (`yaml.safe_load`), and both `sync` calls now
+follow their corresponding `check-standalone-highwater` call — verified by line
+order: raise 224 → sync 237, raise 333 → sync 343.
+
+The real proof is behavioural and arrives on the next high-water rise: main
+should stay self-consistent and no PR should need a hand-carried sync commit.
+If one does, this fix is incomplete and there is a third writer.

--- a/tests/issue-4211.test.ts
+++ b/tests/issue-4211.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * #4211 — the conformance-sync ordering bug.
+ *
+ * `sync-conformance-numbers.mjs` writes TWO derived numbers into the prose docs:
+ * the JS-host line from `benchmarks/results/test262-current.json`, and the
+ * standalone line from `benchmarks/results/test262-standalone-highwater.json`.
+ *
+ * `baseline-summary-sync.yml` writes the high-water mark itself, in the same
+ * job. So if the sync runs BEFORE the raise, the job commits a new mark next to
+ * a README synced from the old one — main ships internally inconsistent and
+ * every open PR then fails the `quality` gate's `sync:conformance:check` until
+ * some unrelated PR happens to carry the repair commit.
+ *
+ * That is not hypothetical: it fired three times on 2026-08-07 and parked nine
+ * PRs in one morning.
+ *
+ * This is a workflow-ordering invariant, so the guard is a workflow-ordering
+ * assertion. It fails if anyone reorders the calls back.
+ */
+
+const WORKFLOW = resolve(__dirname, "..", ".github", "workflows", "baseline-summary-sync.yml");
+
+/** Line indices (0-based) of every line matching `needle`. */
+function lineIndicesOf(lines: readonly string[], needle: string): number[] {
+  const out: number[] = [];
+  lines.forEach((line, i) => {
+    // Ignore comment-only lines: the fix documents itself in comments that
+    // legitimately mention both script names.
+    if (line.trim().startsWith("#")) return;
+    if (line.includes(needle)) out.push(i);
+  });
+  return out;
+}
+
+describe("#4211 — baseline-summary-sync syncs the docs AFTER raising the high-water mark", () => {
+  const lines = readFileSync(WORKFLOW, "utf8").split("\n");
+  const raises = lineIndicesOf(lines, "check-standalone-highwater.mjs");
+  const syncs = lineIndicesOf(lines, "sync-conformance-numbers.mjs");
+
+  it("PRECONDITION: the workflow still invokes both scripts", () => {
+    // If either disappears the invariant below is vacuous, so assert the
+    // premise rather than letting the real test pass for the wrong reason.
+    expect(raises.length).toBeGreaterThan(0);
+    expect(syncs.length).toBeGreaterThan(0);
+  });
+
+  it("PRECONDITION: both the fresh path and the re-anchor path are present", () => {
+    // The job has two code paths that commit the mark: the initial attempt and
+    // the re-anchor/retry loop. Both must raise, and both must sync.
+    expect(raises.length).toBeGreaterThanOrEqual(2);
+    expect(syncs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("every high-water raise is followed by a doc sync before the next raise", () => {
+    // For each raise, there must be a sync after it and before the following
+    // raise — i.e. the mark that a given path commits was the one the docs were
+    // generated from.
+    for (let i = 0; i < raises.length; i++) {
+      const raise = raises[i]!;
+      const nextRaise = raises[i + 1] ?? Number.POSITIVE_INFINITY;
+      const syncBetween = syncs.some((s) => s > raise && s < nextRaise);
+      expect(
+        syncBetween,
+        `high-water raise at line ${raise + 1} is not followed by a ` +
+          `sync-conformance-numbers call before the next raise. The job would ` +
+          `commit a new mark next to docs generated from the old one (#4211).`,
+      ).toBe(true);
+    }
+  });
+
+  it("no doc sync precedes the first high-water raise", () => {
+    // The original bug in its exact shape: a sync at the top of the job,
+    // reading a mark that is raised further down.
+    const firstRaise = raises[0]!;
+    const strayEarlySync = syncs.find((s) => s < firstRaise);
+    expect(
+      strayEarlySync,
+      `sync-conformance-numbers at line ${(strayEarlySync ?? 0) + 1} runs ` +
+        `BEFORE the first high-water raise at line ${firstRaise + 1} — it would ` +
+        `read the pre-raise mark (#4211).`,
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The recurring `quality` failure that has blocked every open PR three times today, traced to its cause rather than patched again.

## Symptom

```
[sync-conformance] DIFFERS  README.md (standalone)
  committed: **standalone (host-free) test262 conformance**: 28,257 / 43,505 (65.0 %)
  generated: **standalone (host-free) test262 conformance**: 28,270 / 43,505 (65.0 %)
```

The mismatch is between **main's own README** and **main's own committed artifacts** — nothing to do with the PR being tested. It clears only when some unrelated PR happens to carry a `sync:conformance` commit, and returns on the next baseline bump.

Seen three times on 2026-08-07 (28,222→28,227, then 28,257→28,270), and it parked **nine PRs** that morning. #4178 repaired that instance without finding the cause.

## Root cause

`sync-conformance-numbers.mjs` derives **two** numbers from **two different files**:

| line | source |
|---|---|
| JS-host conformance | `benchmarks/results/test262-current.json` |
| **standalone (host-free)** | **`benchmarks/results/test262-standalone-highwater.json`** |

In `baseline-summary-sync.yml` the order was:

1. copy the fresh `test262-current.json`
2. **run `sync-conformance-numbers.mjs`** ← reads the *old* high-water mark
3. **`check-standalone-highwater.mjs --update`** ← raises the mark
4. `git add` the mark **and** the README, and commit

So one commit carries a **new mark** and a README synced from the **old** one. Not a race, not flaky — a deterministic inconsistency emitted **every time the mark rises**.

The `promote-baseline` job in `test262-sharded.yml` carries a comment insisting this sync "must update everything derived from it ATOMICALLY in the same commit". That intent was right; this job silently broke it, because the standalone half derives from an artifact written *later in the same job*.

The **re-anchor / retry path** had the same defect in subtler form: it re-applies the snapshotted README — already synced against the *original* mark — then recomputes the mark against main's freshly fetched tip (`max(ours, main's)`), and never re-syncs.

## Fix

- **Fresh path** — the sync now runs *after* the raise, when both inputs are final.
- **Re-anchor path** — re-run the sync after the recompute, and re-stage `README.md ROADMAP.md CLAUDE.md plan/goals/goal-graph.md`.

`refresh-baseline.yml` already had the correct order (raise ~447, sync ~780) and is **unchanged**. `test262-sharded.yml`'s promote job syncs from an artifact that is already final and is **unchanged**.

## Why chase it instead of patching again

The per-PR repair is one line and takes a minute, which is exactly why it kept being the chosen response. The minute is not the cost:

- it blocks **every** open PR at once, so it scales with queue depth;
- the failure names the **PR's own** `quality` job, so each lane diagnoses it from scratch as though it were their own regression — three lanes did that today;
- it recurs on every baseline bump, several times a day.

## Verification

`baseline-summary-sync.yml` parses (`yaml.safe_load`), and both `sync` calls now follow their corresponding raise — verified by line order: raise 224 → sync 237, raise 333 → sync 343.

**The real proof is behavioural and arrives on the next high-water rise:** main should stay self-consistent and no PR should need a hand-carried sync commit. If one does, this fix is incomplete and there is a third writer — stated in the issue file so the next person isn't misled by a green CI run here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_