### PR TITLE
docs(#4157,#3552): the i31 lever is already spent; byte-ranked allocation census; root-test CI coverage

### DIFF
--- a/plan/issues/3552-guard-suite-required-gate.md
+++ b/plan/issues/3552-guard-suite-required-gate.md
@@ -116,3 +116,73 @@ landing order.
 - An enforcement loop for issue-tests.yml red-on-main (e.g. auto-filing a
   `[CI-FIX]` task) — detection without a consumer is how today's red runs
   went unnoticed.
+
+## 2026-08-07 — root-test CI coverage, stated accurately
+
+Recorded because an earlier claim in the same session got this wrong in the
+"CI is blind to root tests" direction, and the opposite overstatement is just
+as easy. Both halves matter.
+
+**The population and what gates it.** `tests/` root holds **2,702**
+`*.test.ts` files today (measured on main; a previously-circulated ~2,697 is
+close but not the number, and this issue's own §"Why not gate the whole root
+suite" still says ~2,100 — all three are just different dates). `ci.yml` runs
+**8** of them by explicit name — `host-import-allowlist-{budget,gate}`,
+`issue-{1580,3004,3303}`, `c-abi`, `simd`, `simd-wat` — plus the
+`tests/linear-*.test.ts` glob (21 files), so **29 root files run
+unconditionally per PR**. Everything else is reached only by
+`test:changed-root`, which selects `--diff-filter=AM` against the merge base:
+**only root tests the branch itself adds or modifies**. A root test that goes
+red because of a *source* change is therefore in **no** PR-level required
+check. That is exactly the gap this issue's guard suite (14 manifest entries)
+was cut to narrow, and it is still narrow.
+
+**But CI is not blind to them.** `.github/workflows/issue-tests.yml` (#3008)
+shards the whole root suite post-merge on every push to `main`, plus a
+6-hourly cron, gated against a known-failures baseline
+(`issue-tests-baseline.json` in `loopdive/js2wasm-baselines`). Its header
+records the two numbers that force the two-layer design: the full suite is
+**~9 CPU-hours** single-fork, and **~40 % of files sampled were already
+failing** when the baseline was established.
+
+**Two root tests observed red on main today**, both reproduced here on
+`origin/main` single-fork:
+
+| file | failure |
+| --- | --- |
+| `tests/issue-1712-standalone.test.ts` | asserts `report.errors` deep-equals `[]`; gets 3 `[IR-FALLBACK]` entries — `function typeIdx parity mismatch: IR=466, legacy=101` for `parse`, `parseExpressionAt`, `tokenizer` |
+| `tests/issue-3156.test.ts` | 2 of 35 fail: `ir/from-ast: method call .charCodeAt(...) on string not in slice 4 (test)` |
+
+Neither is in the guard-suite manifest, so neither is required-gated —
+consistent with them being baselined known-rot rather than new breakage.
+**That is an inference, not a check: the baseline itself was NOT read.** It
+lives in a separate repo cloned over SSH by the workflow, and this container
+has no `gh` and no access to that remote. Confirming it means reading
+`issue-tests-baseline.json` and looking for both paths.
+
+**Sampling the rot rate — bounded, not pinned.** A 30-file deterministic
+sample (`ls tests/*.test.ts | shuf --random-source=<(yes 42) | head -30`, run
+single-fork) gave **3 failed, 12 passed, and 15 unaccounted for** in vitest's
+summary line, because the run's output was truncated by a `tail` *inside* the
+command — so whether those 15 were skipped or merely unsummarised is
+unrecoverable. That bounds the current failure rate at **10–20 %**, materially
+below the ~40 % at baseline, but it **must not be quoted as a number**. What
+would pin it: re-run the same sample without truncating the output and count
+the summary line. The sample list is reproducible (the `shuf` seed is fixed);
+it was **not** re-run here.
+
+Two things that run bled that are worth carrying:
+
+- The sample surfaced a **vitest-level unhandled error** (`TypeError: errors
+  is not iterable` inside vitest's own `failTask`), which vitest itself warns
+  "might cause false positive tests". It appeared in a plain 30-file sample,
+  so it is not exotic — distrust *pass* results in any run where it shows up.
+- Truncating a command's output *inside* the command loses the rest
+  permanently. Same family as the repo's "never pipe a command whose exit
+  status you need" rule, and it cost a whole sample here.
+
+**The gap this issue's own follow-up list names is still open**, and today is
+its second data point: *"an enforcement loop for issue-tests.yml red-on-main
+(e.g. auto-filing a `[CI-FIX]` task) — detection without a consumer is how
+today's red runs went unnoticed."* Detection exists and works; nothing acts on
+it, so red-on-main still depends on someone happening to look.

--- a/plan/issues/4157-close-the-acorn-node-performance-gap.md
+++ b/plan/issues/4157-close-the-acorn-node-performance-gap.md
@@ -403,3 +403,122 @@ Two results from that run that change what the NEXT slice should target:
    `$AnyValue` boxing streams outweigh what is left after that. That points the
    residual GC bucket squarely back at **Workstream 1** (value representation:
    #4155 / #743), not at further plumbing elision.
+
+## 2026-08-07 — the `i31` lever is already spent, and the byte-ranked table
+
+All numbers below re-measured on `origin/main` today (post-PR #4211),
+standalone-dynamic acorn self-parse, checksum 422:
+
+```
+JS2WASM_ALLOC_CENSUS=1 npx tsx scripts/generate-npm-compat-report.mjs \
+  --only acorn --no-write --perf-only --lane standalone-dynamic \
+  --inspect-binary <out.wasm>
+```
+
+then instantiate, call `__module_init`, snapshot every `__alloc_count_*`
+global, run `__npmCompatStandaloneBenchmark(1, 3780)`, and diff.
+(`tests/issue-3921-alloc-census.test.ts` shows the idiom.) Adding
+`JS2WASM_ALLOC_CENSUS_CALLS=<substr>` (#4185) adds per-(caller→callee) call
+counters for matching callees — that is what §1 below rests on.
+
+### 1. Packing small ints into `i31` is dead twice over
+
+The plausible future lever — "JS numbers in dynamic fields heap-allocate a
+boxed struct, so pack signed-31-bit integers into `i31ref` and skip the
+allocation" — is closed on both ends.
+
+**(a) It already exists.** `src/codegen/registry/imports.ts:1113-1160`
+registers `__box_number` with an `i31` fast path (#3673): a value that
+survives an `i32.trunc_sat_f64_s` round-trip *and* a `shl 1 / shr_s 1`
+round-trip becomes `ref.i31` with no allocation; everything else falls through
+to `struct.new`. The exclusion list is the reusable part, and the comment
+carries the *why*:
+
+> Excluded: `-0` (i31 cannot carry the sign — `1/x` and `Object.is` would lose
+> it), NaN and infinities (fail the trunc round-trip), and values outside
+> `[-2^30, 2^30-1]` (fail the shl/shr round-trip).
+
+**(b) The remaining prize is 0.06 MB/parse.** The boxed-number struct is
+`type_67` — `struct, 1 fields (1×f64), ~16 B/instance` — allocated **3,862
+times per parse, 1.79 % of 215,286 allocations, ≈0.06 MB**, against a parse
+allocating **12.34 MB** of struct bytes. Even eliminating it entirely is
+0.5 % of struct bytes.
+
+**(c) It resolves the `__box_number` puzzle.** The 08-07 profile above puts
+`__box_number` at **1.99 %** self-time while it barely allocates. Measured
+cause, via the call census:
+
+| | per parse |
+| --- | ---: |
+| `__box_number` calls | **556,923** (70 call sites) |
+| …that allocate (`type_67`) | 3,862 |
+| …that take the `i31` path | **553,061 — 99.31 %** |
+
+So it is called **2.6× more often than the parse allocates anything at all**,
+and 99.31 % of those calls never touch the heap. Its 1.99 % is call overhead
+plus the range test — **not** allocation. The lever that would move it is
+inlining/call elimination at the top callers (one closure alone accounts for
+163,778 calls), not anything in the allocator.
+
+### 2. The byte-ranked table — and why count-ranking misleads
+
+PR #4208's lesson generalised: **rank allocation streams by count × instance
+size, not by count.** It removed 18.2 % of allocation *events* for ~0.4 pp of
+runtime because the streams it took were the smallest objects in the census
+(this is already recorded in the preceding section; the table is what was
+missing).
+
+Shapes come from the census build's own stderr dump, joined to the counts **by
+export name** (see §3a):
+
+| type | count/parse | size | bytes/parse | byte share |
+| --- | ---: | ---: | ---: | ---: |
+| `__fnctor_Node_18` — struct, 69 fields (62×externref, 3×ref_null, 2×f64, 2×i32) | 32,468 | 292 B | **9.48 MB** | **76.8 %** |
+| `type_7` — struct, 3 fields (2×i32, 1×ref) | 54,818 | 20 B | 1.10 MB | 8.9 % |
+| `type_75` — struct, 5 fields (2×i32, 1×f64, 1×eqref, 1×externref) | 22,008 | 32 B | 0.70 MB | 5.7 % |
+| `__vec_externref_2` — struct, 2 fields (1×i32, 1×ref) | 31,414 | 16 B | 0.50 MB | 4.1 % |
+| `type_235` — struct, 6 fields (5×f64, 1×externref) | 7,252 | 52 B | 0.38 MB | 3.1 % |
+| `type_67` — boxed number, 1×f64 | 3,862 | 16 B | 0.06 MB | 0.5 % |
+| `type_1` / `type_5` | 27,361 / 26,064 | arrays (4 B and 2 B per element) | payload-dependent | — |
+
+The inversion is the point: by **count** the node struct is 15.1 % and ranks
+*second*; by **bytes** it is three quarters of everything. Array types are
+excluded from the byte total because the census records per-element size, not
+length.
+
+**Caveat — the struct-byte denominator does not currently agree with itself.**
+This run measures **12.34 MB / node at 76.8 %**, over 215,286 allocations
+baselined *after* `__module_init`. #3927 §1 records **12.23 MB / 77.5 %** in
+its table but **12,827,613 B over 270,062 allocations** in the adjacent prose
+— and 9,480,656 / 12,827,613 is 73.9 %, not 77.5 %. The count gap is most
+likely the `__module_init` baseline (this reader excludes module-init
+allocations; a whole-instance snapshot does not). The three figures cannot all
+be right; resolving them belongs to #3927, which owns that measurement. What
+is **not** in doubt and is safe to quote: the node struct is between three
+quarters and 78 % of struct bytes, and this supersedes the older **43.6 MB**
+figure, which came from `--trace-gc` and also counts array payload (both are
+right about different quantities — quote the census when ranking struct-shape
+levers).
+
+Note the counts themselves are **unchanged** from the pre-#4211 measurement,
+so the table is current on today's main.
+
+### 3. Two instrument traps, each of which nearly produced a wrong conclusion
+
+**(a) Type numbering: the census and `wasm-dis` do not share it.** Census
+counters are named in the **compiler's** type numbering
+(`__alloc_count_type_67`); `wasm-dis` shows **post-`wasm-opt`** indices, and
+the optimizer renumbers types. Reading a struct's shape off a disassembly and
+matching it to a census counter by index gives a wrong answer — doing exactly
+that nearly recorded the AST node struct as 7 fields when it has **69**. The
+only correct join key is the census build's own stderr shape dump, keyed by
+export name. `src/codegen/alloc-census.ts:26-27` already states the reason
+("`wasm-opt` renumbers types, so a `typeIdx`-keyed reader would go stale,
+while export names survive"); this is its concrete failure mode.
+
+**(b) Never pipe a command whose exit status — or whose output — you need.**
+Already a repo rule, and it bit twice more today: a gate piped to `tail -3`
+showed only trailing advisory text and hid its `FAILED` line, so a broken PR
+shipped. The output half is the less-documented one: truncating with `tail -N`
+*inside* the command loses the rest **permanently**, which is how a 30-file
+test sample was rendered uninterpretable (see #3552, 2026-08-07).


### PR DESCRIPTION
Docs-only. Records four findings that existed only in a chat session. Two files, 189 lines added, no existing content reflowed. Touches no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` file.

Every number was re-measured on `origin/main` today rather than transcribed; where a figure did not reproduce, the section says so instead of dropping it.

## `plan/issues/4157-close-the-acorn-node-performance-gap.md`

**The `i31` idea is dead twice over.** The plausible future lever — pack small-integer JS numbers into `i31ref` to skip the boxed-struct allocation — is closed on both ends. It is *already implemented* (`src/codegen/registry/imports.ts:1113-1160`, #3673, with the `-0`/NaN/infinity/range exclusions and their reasoning), and the remaining prize is **0.06 MB/parse** against a 12.34 MB struct-byte parse.

A call census (`JS2WASM_ALLOC_CENSUS_CALLS`, #4185) turned the supporting hypothesis into a measurement and made it sharper than expected: `__box_number` is called **556,923 times per parse** — 2.6× the parse's entire allocation count — and **99.31 %** of those calls take the i31 path and never touch the heap. That is why it costs 1.99 % of self-time while barely allocating. The lever that would move it is inlining at the top callers, not anything in the allocator.

**The byte-ranked allocation table.** PR #4208's lesson generalised: rank allocation streams by count × instance size, not by count. By **count** the AST node struct is 15.1 % and ranks second; by **bytes** it is 76.8 %. Shapes are joined to counts by export name, per the census's own contract.

**Two instrument traps**, each of which nearly produced a wrong conclusion: census type numbering cannot be joined to `wasm-dis` indices (`wasm-opt` renumbers types — this nearly recorded the node struct as 7 fields when it has 69), and truncating a command's own output *inside* the command loses the rest permanently.

## `plan/issues/3552-guard-suite-required-gate.md`

Root-test CI coverage, stated accurately in **both** directions, correcting a mistaken claim made earlier the same day. 2,702 root `*.test.ts` files; 29 run unconditionally per PR; `test:changed-root` gates only files the branch itself adds or modifies — so a root test that reddens from a *source* change has no PR-level required check. But CI is not blind to them: `issue-tests.yml` (#3008) shards the whole suite post-merge against a known-failures baseline. Two files observed red today were reproduced here with their exact failure text.

The issue's own open follow-up — an enforcement loop for `issue-tests.yml` red-on-main — is confirmed still open, with today as its second data point.

## Deliberately not asserted

- **The `issue-tests` baseline was not read.** It lives in `loopdive/js2wasm-baselines`, cloned over SSH by the workflow; this container has no `gh` and no access to that remote. The two red files are *inferred* to be baselined known-rot. The section says the check was not performed rather than asserting the conclusion.
- **The 10–20 % rot bound is not pinned** and the section says so, along with what would pin it (re-run the deterministic 30-file sample without truncating its output). It was not re-run here.

## One discrepancy surfaced, deliberately not fixed here

The struct-byte denominator does not currently agree with itself. This run measures **12.34 MB / node at 76.8 %** over 215,286 allocations (baselined after `__module_init`). #3927 section 1 records **12.23 MB / 77.5 %** in its table but **12,827,613 B over 270,062 allocations** in the adjacent prose — and 9,480,656 / 12,827,613 is 73.9 %, not 77.5 %. The count gap is most likely the `__module_init` baseline. The three figures cannot all be right.

This is flagged in #4157 and left to **#3927**, which owns that measurement and is under concurrent edit by two other agents. **This PR does not touch `plan/issues/3927-fnctor-shape-splitting.md`.**

What is not in doubt, and is safe to quote either way: the node struct is between three quarters and 78 % of struct bytes, and this supersedes the older 43.6 MB figure (which came from `--trace-gc` and also counts array payload).

## Verification

Gates run and checked by exit code, never by piping to `tail`:

- `npx prettier --check` on both files → exit 0
- `npm run -s check:issue-ids:against-main` → exit 0
- `npm run -s check:issues` → exit 0

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_016zVUkJ2adCdrLoET5AkoUL)_