### PR TITLE
test(#4047): flip the two DATE refusal pins — the &quot;no substrate&quot; premise expired

### DIFF
--- a/tests/issue-4047.test.ts
+++ b/tests/issue-4047.test.ts
@@ -171,7 +171,12 @@ const CASES: Record<string, [string, number]> = {
     }`,
     0,
   ],
-  "D2 DATE receiver O -> still refuses loudly (no substrate) [2]": [
+  // Flipped from the [2] refusal pin: Date GAINED a substrate when
+  // `builtinInstanceCarrierTypeIdxs` (src/codegen/closure-props.ts) added
+  // `__Date`/`__StandaloneRegExp` to the closure-bag carrier chain. The define
+  // now lands and the read-back is correct, so the old "(no substrate)" premise
+  // has expired — same shape as F3 below.
+  "D2 DATE receiver O -> bag carrier, define lands [0]": [
     `export function test(): number {
       try {
         const d: any = new Date(0);
@@ -181,7 +186,7 @@ const CASES: Record<string, [string, number]> = {
         return d.p === 1 ? 0 : 1;
       } catch (e) { return 2; }
     }`,
-    2,
+    0,
   ],
   "D3 primitive receiver O -> TypeError [2]": [
     `export function test(): number {
@@ -189,14 +194,17 @@ const CASES: Record<string, [string, number]> = {
     }`,
     2,
   ],
-  "E1 DATE Properties -> still refuses loudly (no substrate) [2]": [
+  // Flipped from the [2] refusal pin, same mechanism as D2: a Date used AS the
+  // `Properties` map is now a bag carrier, so its own properties enumerate and
+  // the define lands on the target.
+  "E1 DATE Properties -> bag enumerated, define lands [0]": [
     `export function test(): number {
       const obj: any = {};
       const props: any = new Date(0);
       props.prop = { value: 1, enumerable: true };
       try { Object.defineProperties(obj, props); return obj.hasOwnProperty("prop") ? 0 : 1; } catch (e) { return 2; }
     }`,
-    2,
+    0,
   ],
   "F1 Object.create(proto, undefined) -> skips, returns obj [0]": [
     `export function test(): number {


### PR DESCRIPTION
`tests/issue-4047.test.ts` is **red on main**. Two cases assert that `Object.defineProperties` "still refuses loudly (no substrate)" for a Date receiver (D2) and for a Date used as the `Properties` map (E1):

```
× D2 DATE receiver O -> still refuses loudly (no substrate) [2]
× E1 DATE Properties -> still refuses loudly (no substrate) [2]
    expected 'v=0 imports=0' to be 'v=2 imports=0'
```

**The behaviour is right; the assertion is stale.** Date gained a substrate when `builtinInstanceCarrierTypeIdxs` (`src/codegen/closure-props.ts:312`) added `__Date`/`__StandaloneRegExp` to the closure-bag carrier chain. The define now lands and reads back correctly, so `v=0` is the correct answer and the pin expired.

Flipped `2 → 0` and renamed both cases to describe what they now verify, with the mechanism cited so the next reader doesn't re-derive it. This follows the file's **own** convention — F3 a few lines below already carries "Flipped from the [2] refusal pin" (#4161) for the same reason.

**23/23 green.** Verified red first on a clean checkout of `origin/main@39d151732f` before changing anything, so this repairs a known-red test rather than guessing at one.

## How it was found, and the gap behind it

The #4210 lane hit these while running the descriptor family against its branch, and confirmed on a **base worktree** that both failed identically there — which is what established they weren't its own. Same shape as the #4210 issue text corrected earlier today: a fixture pinning a limitation that a later PR removed.

The reason nobody noticed is real and already tracked: CI does not run the full vitest suite (it OOMs, PR #432), so `equivalence-gate` and friends run narrowly scoped subsets and `test:changed-root` gates only files the branch itself touches. A stale unit test can therefore go red on main and stay green in CI.

That gap is **#3552**, whose open follow-up is an enforcement loop for `issue-tests.yml` red-on-main — and PR #4212 (in flight now) is recording today as a further data point. **Not filing a duplicate**; this PR just clears one of the red files.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwZmzQKe9C1m3f2CDwaBKY)_