### PR TITLE
docs(#3927): correct the per-type-layout baseline, retract the `copyNode` mechanism, and make #3920 a hard blocker

### DIFF
--- a/plan/issues/3927-fnctor-shape-splitting.md
+++ b/plan/issues/3927-fnctor-shape-splitting.md
@@ -503,12 +503,32 @@ standalone acorn is **byte-identical with the flag ON** (937,273 B, canaries
 **Headline: the shapes ARE separable, by a lot, and the plan is empirically
 sound on the motivating corpus.**
 
-| | today (union struct) | #4211 hot/cold, K=24 | per-type layouts (this plan) |
-| --- | ---: | ---: | ---: |
-| `__fnctor_Node` B/instance | 292 (model: 300) | 206.6 | **98.0** |
-| Node stream, MB/parse | 9.74 | 6.71 | **3.18** |
-| vs the union struct | — | −31.1 % | **−67.3 %** |
-| share of ALL struct bytes/parse (12.23 MB) | — | −21.6 % | **−53.6 %** |
+| | union struct | #4211 K=24 (flag-OFF) | slice C K=20 (default-ON) | per-type layouts (this plan) |
+| --- | ---: | ---: | ---: | ---: |
+| `__fnctor_Node` B/instance | 292 | 206.6 | ~181 | **98.0** |
+| Node stream, MB/parse | 9.48 | 6.71 | 5.89 | **3.10** |
+| vs the union struct | — | −31.1 % | −37.9 % | **−67.3 %** |
+
+**⚠ Baseline correction (2026-08-07, after slice C).** The first draft of this
+section quoted "−53.6 % of ALL struct bytes", measured against the UNION-struct
+baseline. That baseline is gone: slice C
+(`claude/issue-3927-ranking-and-generator`) makes the hot/cold split
+**default-ON in the standalone lane at K=20** and measures 12.69 → 9.10 MB of
+struct bytes per parse (−28.3 %). Against that new default the marginal figure
+is smaller, and it is the one that should be quoted:
+
+| comparison | struct bytes/parse | |
+| --- | ---: | ---: |
+| slice C default (the new baseline) | 9.10 MB | — |
+| + per-type layouts | **6.31 MB** | **−30.7 %** |
+| both, vs the pre-split union struct | 6.31 MB | −50.3 % |
+
+Read on the Node stream alone, per-type layouts remove a further **−47.4 %** of
+what slice C leaves. The two techniques **overlap rather than compose** for this
+fnctor: §4 measures a 0 % residual rate for per-type layouts, so where a layout
+is proved the cold tail has nothing left to move (slice C's tail rate is 28.1 %).
+The cold tail stays valuable exactly where the layout analysis returns a
+non-`split` verdict.
 
 ### 1. Why §3's "the shape is not knowable at the `struct.new`" was right but not fatal
 
@@ -666,17 +686,49 @@ arm, 16 need 2, 9 need 3, one needs 4, `body` needs 6 and `expressions` needs
 11 (the one remaining blur). `type`/`end` are base fields ⇒ 1 arm. So the
 arm-count blow-up that kills the naive per-shape version does not materialise.
 
+**The chokepoint that will bite, named in advance — the consumer-side narrowing
+VOTE, not the `ref.test` arms.** Slice C traced the §4 `generator` defect to
+`finalizeStructAndDynamicMemberGet` (the #1269 Phase-3 narrowing in
+`property-access-dispatch.ts`, around the `fieldKinds` set): to decide whether an
+`any`-receiver read can drop its boxing, it asks whether *every candidate struct*
+carries the field with the same scalar kind — and its candidate set is
+`findAlternateStructsForField`, which hides `$…__cold`. Hiding a carrier from
+that **vote** is wrong even though hiding it from the `ref.test` **arms** is
+right; the vote narrowed to `i32` and pushed a correct boxed value through
+`__unbox_number`.
+
+Per-type layouts hit the same seam twice over, and worse:
+
+1. the residual `$resid` carrier must be hidden from the arms (it is a private
+   payload, never a receiver) but MUST be visible to the vote — the identical
+   bug;
+2. the vote's candidate set grows from 1 struct to N layouts, so a field whose
+   inferred scalar kind differs across layouts now makes the vote *unanimous by
+   accident* only when it happens to agree. A layout that simply lacks the field
+   must not be read as "agrees".
+
+Treat "which set answers the narrowing vote" as a distinct question from "which
+set gets a `ref.test` arm" at every consumer, and enumerate both before writing
+any emission code.
+
 ### 7. Honest translation to wall clock, and why it is an extrapolation
 
 #4211 measured the mechanism: **−21.6 % of allocated struct bytes ⇒ −3.92 pp of
 the 15.71 % gc-engine bucket** (−25 % of the bucket itself), every other bucket
 diluting proportionally upward — the signature of a single absolute reduction.
-This plan projects **−53.6 %** of allocated struct bytes, ~2.5× further along
-the same axis. If the bucket stays proportional to allocated bytes, that scales
-to roughly **−9 to −10 pp of wall**.
+Slice C then measured a second point on the same axis — −28.3 % of struct bytes
+for **−4.51 pp** of the gc-engine bucket in an order-reversed ON/OFF/OFF/ON
+block — which is consistent with #4211's slope and strengthens the mechanism.
 
-**That is an extrapolation 2.5× beyond the only measured point, not a
-measurement**, and this box cannot resolve anything under ~10 % by wall A/B
+This plan's **marginal** figure over slice C's new default is −30.7 % of
+allocated struct bytes, i.e. roughly one more step of the size both measured
+points already cover, projecting to about **−4 to −5 pp of wall on top of slice
+C**. (Against the pre-split union baseline the combined figure is −50.3 % of
+struct bytes; the earlier draft of this section quoted the combined number as if
+it were marginal, which overstated what this slice adds.)
+
+**That is still an extrapolation, not a measurement**, and this box cannot
+resolve anything under ~10 % by wall A/B
 (§6 of the 2026-08-06 slice — an uncontrolled block there read +29 % and was
 pure load contamination). Treat −9 % as an upper-ish estimate whose mechanism
 is sound and whose magnitude is unverified. What IS measured here: the bytes
@@ -711,3 +763,13 @@ are untouched`, reproduces on `origin/main` with this branch's
 Standalone acorn with the flag ON: 937,273 B — byte-identical to the flag-OFF
 baseline — canaries 2/3/4/5, `functionImports []`, exactly the 3 pre-existing
 IR-FALLBACKs.
+
+**Interaction with slice C's flag change.** Slice C makes the hot/cold split
+default-ON in standalone and moves the disable token to
+`JS2WASM_FNCTOR_HOT_FIELDS=off` (a bare unset now means ON). Every byte-identity
+assertion in this slice is **relative** — `JS2WASM_FNCTOR_LAYOUTS` set vs unset,
+with the cold-tail state held equal on both sides — so none of them assumes
+"unset ⇒ no split" and none needs the new token. The one figure that is
+*absolute*, the 937,273 B, is a cold-tail-OFF measurement and will move when
+slice C lands; it is quoted only as the two sides of an equality, not as a
+tracked artifact size.

--- a/plan/issues/3927-fnctor-shape-splitting.md
+++ b/plan/issues/3927-fnctor-shape-splitting.md
@@ -668,7 +668,45 @@ closed-struct receiver; three of the four break the moment the receiver is
 one dynamic operation that still reaches a correct answer — that asymmetry, not
 "the presence read is broken", is where a fix should start.
 
-Two notes for whoever takes it:
+**The mechanism under the axis, and why "make the broken three match the working
+ones" is a trap.** Six dynamic helpers back these surfaces; three were given
+closed-struct arms at finalize (`src/codegen/index.ts` :4450-4452) and three were
+not, and the split is 3-for-3: `hasOwnProperty`, `Object.getOwnPropertyNames`
+and computed `obj[k]` have arms; `Object.keys`, `for…in` and `in` do not. So the
+dynamic path is not uniformly broken — half the helpers were taught closed
+structs and half were not.
+
+**But the working half is not a template to copy, because it is the same bug
+already live.** Those arms enumerate `ctx.structFields`, which includes BUILTIN
+carriers whose internal fields carry no `$`/`__` prefix. Sharing them with
+`__object_keys` was implemented, measured and **reverted** (#4071). Verified
+independently here (`.tmp/gopn-leak.mjs`, `--target standalone`, `optimize: 0`,
+no host imports; "host" = the reference answer):
+
+| probe | standalone | host | |
+| --- | ---: | ---: | --- |
+| `Object.getOwnPropertyNames(classInst as any).length` | 3 | 3 | ✓ the 4th working surface |
+| `Object.getOwnPropertyNames(/ab/).length` | **7** | 1 | ✗ leaks 6 internal RegExp fields |
+| `Object.getOwnPropertyNames(/ab/)[0][0]` | `'f'` | `'l'` | ✗ not even `lastIndex` first |
+| `Object.getOwnPropertyNames(new Date(0)).length` | **1** | 0 | ✗ leaks — *not previously reported* |
+| `Object.keys(new Date(0)).length` | 0 | 0 | ✓ — **accidentally**, see below |
+
+The last row is the point. `Object.keys` is correct on a builtin *precisely
+because* it is broken on user classes: having no closed-struct arms, it
+enumerates nothing, and nothing is the right answer for `Date`. Copying the
+working arms onto it would fix the user-class case and simultaneously break the
+builtin case — which is exactly what #4071 measured
+(`Object.keys(new Date(0))` → `["timestamp"]`) and why it was reverted. **The
+fix is "build the user-declared-vs-builtin predicate, then share", not "share
+the arms".** A helper that reads as passing is where that gets missed.
+
+**This is the strongest available corroboration of §6's name-list-source
+constraint, and it upgrades it from a design preference to an observed failure
+mode**: the surfaces that source their names from the receiver's struct field
+list are leaking internals in production today. Per-type layouts would multiply
+that field list per label, so the constraint tightens rather than relaxes.
+
+Two further notes for whoever takes it:
 
 - slice C separately eliminated 24 configurations (structural canonicalization
   of an identically-shaped sibling struct, `optimize` 0/3/unset, class-shape
@@ -750,7 +788,11 @@ Three properties fall out, and each removes a class of #4211's risk:
   that bug decides whether it holds: an enumeration that derives its name list
   from the receiver's **struct field list** becomes layout-DEPENDENT and
   re-inherits #4211's per-carrier-arm problem, whereas one that derives it from
-  the base presence words does not. Say which, in the fix.
+  the base presence words does not. Say which, in the fix. **§4 now shows the
+  struct-field-list route is not merely layout-fragile but already leaking
+  internals in production** (`getOwnPropertyNames(/ab/)` answers 7 where the
+  host answers 1), so the constraint has a measured failure mode behind it and
+  needs a user-declared-vs-builtin predicate either way;
 
   **And the constraint binds wider than this issue.** Independently replicated
   on this branch (§4's settled matrix): a **class** instance reaching the site

--- a/plan/issues/3927-fnctor-shape-splitting.md
+++ b/plan/issues/3927-fnctor-shape-splitting.md
@@ -604,12 +604,37 @@ ObjectPattern / ArrayPattern / RestElement / AssignmentPattern nodes via the
 four in-place `toAssignable` conversions, and none of them has a property
 outside its allocation label's set.
 
+**Why this check is not the vacuous kind.** Slice C nearly shipped an
+enumeration-based differential that passed by comparing `undefined` to
+`undefined`, and warns that on this receiver class *any* enumeration-based
+check passes for free. This one is a different instrument and carries its own
+non-vacuity witnesses: it runs against **native acorn in Node**, not in wasm, so
+`Object.keys` is the language's; the denominator is non-trivial (32,468 nodes,
+matching the census exactly); and the occupancy numerator is non-trivial
+(64,008 populated slots). A degenerate plan would fail loudly rather than
+silently — empty planned sets would make *every* property overflow, i.e. ~100 %
+rather than 0 %.
+
 **What this check does NOT cover, stated plainly: `copyNode` never fires on
-this corpus** (0 of the 25 executing sites). `copyNode` is
+this corpus** (0 of the 25 executing sites). It is
 `for (var prop in node) { newNode[prop] = node[prop] }` — enumeration plus a
-COMPUTED write — and it is precisely the reflective surface that silently
-corrupted #4211's first cut. The emission slice must route it through the
-residual carrier and must validate on a corpus that triggers it.
+COMPUTED write. The emission slice must route it through the residual carrier
+and must validate on a corpus that triggers it.
+
+⚠ **Correction (2026-08-07, after slice C): do not build on the recorded
+`copyNode` story.** An earlier draft of this section, and the 2026-08-07
+hot/cold slice's §3 above, attribute the pre-wiring K=52 divergence to
+`copyNode`. Slice C measured, in-wasm on this same self-parse, that **`for…in`
+over a standalone closed fnctor struct enumerates ZERO own properties** (keys on
+15 of 32,506 walked objects, none of them AST nodes; the reference
+implementation yields keys on all 32,487). It is identical with the split
+disabled, so it is pre-existing and belongs to neither slice. A routine that
+enumerates nothing cannot copy anything — and this slice independently measured
+`copyNode` executing zero times. Two independent lines of evidence against the
+named cause. Wiring the three reflective passes *did* resolve the divergence, so
+something in it mattered; **the mechanism is unknown.** Anything derived from
+"copyNode did it" — including the risk ordering in §6 — is derived from an
+unsupported story and should be re-derived.
 
 ### 5. Retyping needs no special case, and here is the argument
 
@@ -672,10 +697,15 @@ Three properties fall out, and each removes a class of #4211's risk:
 - `ref.test $__fnctor_Node` still matches every layout, so every existing
   consumer of base fields is untouched;
 - **presence bits live in the BASE at fixed indices**, so `hasOwnProperty`,
-  `in`, `Object.keys`, for-in and the delete/tombstone path stay
-  layout-INDEPENDENT — only the value's storage location varies. That is
-  strictly simpler than #4211, where the reflective passes each needed a cold
-  arm;
+  `in`, `Object.keys`, for-in and the delete/tombstone path *can* stay
+  layout-INDEPENDENT — only the value's storage location varies. **Read this as
+  a CONSTRAINT on the enumeration fix, not as a property already held.** Slice C
+  measured `for…in` over a standalone closed fnctor struct yielding zero own
+  properties today (§4's correction), so the claim is untestable as things
+  stand, and whatever repairs that bug decides whether it holds: an enumeration
+  that derives its name list from the receiver's **struct field list** becomes
+  layout-DEPENDENT and re-inherits #4211's per-carrier-arm problem, whereas one
+  that derives it from the base presence words does not. Say which, in the fix;
 - layouts are **siblings, not nested**, so arm order in the dispatchers cannot
   matter. (A prefix-CHAIN design was evaluated and rejected for this reason
   plus worse bytes: −60.9 % vs −67.3 %, because a label needing one
@@ -718,14 +748,22 @@ the 15.71 % gc-engine bucket** (−25 % of the bucket itself), every other bucke
 diluting proportionally upward — the signature of a single absolute reduction.
 Slice C then measured a second point on the same axis — −28.3 % of struct bytes
 for **−4.51 pp** of the gc-engine bucket in an order-reversed ON/OFF/OFF/ON
-block — which is consistent with #4211's slope and strengthens the mechanism.
+block — consistent with #4211's slope. Two caveats it supplied about its own
+number, which matter to anyone leaning on the pair:
+
+- the ON-side scatter is **3.15 pp** against an OFF-side replication of 0.35 pp,
+  so −4.51 pp is a **bracket of roughly −3 to −6 pp**, not a point;
+- its absolute bucket shares are **not** comparable with #4211's table (no
+  closure name map attached, so `scanner` folds into `compiled`). Only the
+  **delta** is cross-session sound.
 
 This plan's **marginal** figure over slice C's new default is −30.7 % of
 allocated struct bytes, i.e. roughly one more step of the size both measured
 points already cover, projecting to about **−4 to −5 pp of wall on top of slice
-C**. (Against the pre-split union baseline the combined figure is −50.3 % of
-struct bytes; the earlier draft of this section quoted the combined number as if
-it were marginal, which overstated what this slice adds.)
+C** — and given the endpoint bracket above, **−3 to −7 pp** is the honest range.
+(Against the pre-split union baseline the combined figure is −50.3 % of struct
+bytes; the earlier draft of this section quoted the combined number as if it
+were marginal, which overstated what this slice adds.)
 
 **That is still an extrapolation, not a measurement**, and this box cannot
 resolve anything under ~10 % by wall A/B
@@ -738,7 +776,15 @@ label) and the 0 % overflow rate.
 ### 8. What is NOT done
 
 1. **The emission.** §6 is a design with the keystone resolved, not code.
-2. **`copyNode` is unexercised** (§4). It is the highest-risk surface.
+2. **The whole enumeration surface is unvalidated, by anyone.** `copyNode` is
+   unexercised on this corpus (§4), and slice C's in-wasm enumeration
+   differential is vacuous today because `for…in` over these structs yields
+   nothing. So the risk §7 of the 2026-08-06 slice named as this design's
+   principal one — a consumer silently reading `undefined` through a reflective
+   path — is currently covered by **no** evidence in either lane. Repairing the
+   pre-existing `for…in` bug is a **prerequisite** for the emission slice, not a
+   parallel nicety: until enumeration works, no differential can distinguish a
+   correct split from a broken one.
 3. **No test262 / no host-lane work.** Flag-OFF is byte-identical and the
    analysis is standalone-oriented; the emission slice owns conformance.
 4. **The 18.8 % slot occupancy is left on the table** (§4). A

--- a/plan/issues/3927-fnctor-shape-splitting.md
+++ b/plan/issues/3927-fnctor-shape-splitting.md
@@ -636,6 +636,39 @@ something in it mattered; **the mechanism is unknown.** Anything derived from
 "copyNode did it" — including the risk ordering in §6 — is derived from an
 unsupported story and should be re-derived.
 
+**Replication of the enumeration matrix, and a partial DISAGREEMENT worth
+settling before anyone builds on it** (this branch = `origin/main` + this
+slice's inert analysis; `.tmp/enum-matrix.mjs`, `--target standalone`,
+`optimize: 0`, 3-field fixtures, no host imports):
+
+| case | slice C | this branch |
+| --- | ---: | ---: |
+| `for…in` over an object literal | 3 ✓ | 3 ✓ |
+| `for…in`, class instance typed AT the loop | 3 ✓ | 3 ✓ |
+| `for…in`, class instance arriving as `any` | 0 ✗ | **0 ✗** |
+| `for…in` over a fnctor instance | 0 ✗ | **0 ✗** |
+| `Object.keys(objectLiteral).length` | 3 ✓ | 3 ✓ |
+| `Object.keys(classInstance).length` | **0 ✗** | **3 ✓ — disagrees** |
+| `classInstance.hasOwnProperty("a")` | 1 ✓ | 1 ✓ |
+| `"a" in classInstance` | **0 ✗** | **1 ✓ — disagrees** |
+
+Six of eight agree, and the two `for…in` failures — the ones this design
+actually depends on — replicate exactly. The two that disagree both **pass**
+here. Consequences:
+
+- The **grouping** conclusion differs. Slice C reads the split as
+  "`hasOwnProperty` works, `in`/`for…in`/`Object.keys` do not". On this branch's
+  evidence the split is "**`for…in` (on a dynamic receiver) is broken, the other
+  three work**". A fixer starting from the wrong grouping starts from the wrong
+  shared predicate, so #3920 should settle this before the fix is scoped.
+- **Cause of the divergence is not yet known.** The obvious hypothesis —
+  slice C's default-ON hot/cold split — was tested and **rejected**:
+  `JS2WASM_FNCTOR_HOT_FIELDS=20` reproduces this branch's column exactly.
+  But that test is weak evidence, because these 3-field fixtures are entirely
+  constructor-assigned, so no field is split-eligible and the flag is inert on
+  them. Fixture shape remains the leading explanation. Settling it needs the two
+  fixture sets compared directly, not two summaries compared.
+
 ### 5. Retyping needs no special case, and here is the argument
 
 `toAssignable` mutates in place through a reference the code cannot replace
@@ -699,13 +732,22 @@ Three properties fall out, and each removes a class of #4211's risk:
 - **presence bits live in the BASE at fixed indices**, so `hasOwnProperty`,
   `in`, `Object.keys`, for-in and the delete/tombstone path *can* stay
   layout-INDEPENDENT — only the value's storage location varies. **Read this as
-  a CONSTRAINT on the enumeration fix, not as a property already held.** Slice C
-  measured `for…in` over a standalone closed fnctor struct yielding zero own
-  properties today (§4's correction), so the claim is untestable as things
-  stand, and whatever repairs that bug decides whether it holds: an enumeration
-  that derives its name list from the receiver's **struct field list** becomes
-  layout-DEPENDENT and re-inherits #4211's per-carrier-arm problem, whereas one
-  that derives it from the base presence words does not. Say which, in the fix;
+  a CONSTRAINT on the enumeration fix (#3920), not as a property already held.**
+  `for…in` over these structs yields zero own properties today (§4's
+  correction), so the claim is untestable as things stand, and whatever repairs
+  that bug decides whether it holds: an enumeration that derives its name list
+  from the receiver's **struct field list** becomes layout-DEPENDENT and
+  re-inherits #4211's per-carrier-arm problem, whereas one that derives it from
+  the base presence words does not. Say which, in the fix.
+
+  **And the constraint binds wider than this issue.** Independently replicated
+  on this branch (`.tmp/enum-matrix.mjs`, `--target standalone`, `optimize: 0`):
+  a **class** instance that reaches the loop as `any` enumerates 0 of 3 keys,
+  exactly like a fnctor instance, while the same class instance typed AT the
+  loop enumerates 3, and an object literal enumerates 3. So the boundary is not
+  "fnctor" — it is **the dynamic path over any closed struct**, and the
+  name-list-source rule above therefore applies to every closed-struct receiver
+  kind, not only the ones per-type layouts touches;
 - layouts are **siblings, not nested**, so arm order in the dispatchers cannot
   matter. (A prefix-CHAIN design was evaluated and rejected for this reason
   plus worse bytes: −60.9 % vs −67.3 %, because a label needing one
@@ -785,6 +827,12 @@ label) and the 0 % overflow rate.
    pre-existing `for…in` bug is a **prerequisite** for the emission slice, not a
    parallel nicety: until enumeration works, no differential can distinguish a
    correct split from a broken one.
+
+   **That bug is already filed as #3920** (`status: ready`, `priority: high`,
+   `sprint: current`, unclaimed as of 2026-08-07) — whose Problem section
+   already names the wider hole. It needs an OWNER, not a new file. Neither this
+   lane nor slice C may allocate ids in this container, which is a second reason
+   not to re-file it.
 3. **No test262 / no host-lane work.** Flag-OFF is byte-identical and the
    analysis is standalone-oriented; the emission slice owns conformance.
 4. **The 18.8 % slot occupancy is left on the table** (§4). A

--- a/plan/issues/3927-fnctor-shape-splitting.md
+++ b/plan/issues/3927-fnctor-shape-splitting.md
@@ -636,38 +636,50 @@ something in it mattered; **the mechanism is unknown.** Anything derived from
 "copyNode did it" — including the risk ordering in §6 — is derived from an
 unsupported story and should be re-derived.
 
-**Replication of the enumeration matrix, and a partial DISAGREEMENT worth
-settling before anyone builds on it** (this branch = `origin/main` + this
-slice's inert analysis; `.tmp/enum-matrix.mjs`, `--target standalone`,
-`optimize: 0`, 3-field fixtures, no host imports):
+**The enumeration matrix, SETTLED — the discriminator is the RECEIVER'S STATIC
+TYPE, not the operation** (`.tmp/enum-settle.mjs`, `--target standalone`,
+`optimize: 0`, no host imports; want = keys 3, in 1, for…in 3, hasOwn 1):
 
-| case | slice C | this branch |
-| --- | ---: | ---: |
-| `for…in` over an object literal | 3 ✓ | 3 ✓ |
-| `for…in`, class instance typed AT the loop | 3 ✓ | 3 ✓ |
-| `for…in`, class instance arriving as `any` | 0 ✗ | **0 ✗** |
-| `for…in` over a fnctor instance | 0 ✗ | **0 ✗** |
-| `Object.keys(objectLiteral).length` | 3 ✓ | 3 ✓ |
-| `Object.keys(classInstance).length` | **0 ✗** | **3 ✓ — disagrees** |
-| `classInstance.hasOwnProperty("a")` | 1 ✓ | 1 ✓ |
-| `"a" in classInstance` | **0 ✗** | **1 ✓ — disagrees** |
+| receiver | `Object.keys` | `in` | `for…in` | `hasOwnProperty` |
+| --- | ---: | ---: | ---: | ---: |
+| `const o = new C()` (statically typed) | 3 ✓ | 1 ✓ | 3 ✓ | 1 ✓ |
+| `const o: any = new C()` | **0 ✗** | **0 ✗** | **0 ✗** | 1 ✓ |
+| laundered through `id(x): any` | **0 ✗** | **0 ✗** | **0 ✗** | 1 ✓ |
 
-Six of eight agree, and the two `for…in` failures — the ones this design
-actually depends on — replicate exactly. The two that disagree both **pass**
-here. Consequences:
+Identical for both class spellings (field initialisers and constructor
+assignment), so the class shape is not a factor.
 
-- The **grouping** conclusion differs. Slice C reads the split as
-  "`hasOwnProperty` works, `in`/`for…in`/`Object.keys` do not". On this branch's
-  evidence the split is "**`for…in` (on a dynamic receiver) is broken, the other
-  three work**". A fixer starting from the wrong grouping starts from the wrong
-  shared predicate, so #3920 should settle this before the fix is scoped.
-- **Cause of the divergence is not yet known.** The obvious hypothesis —
-  slice C's default-ON hot/cold split — was tested and **rejected**:
-  `JS2WASM_FNCTOR_HOT_FIELDS=20` reproduces this branch's column exactly.
-  But that test is weak evidence, because these 3-field fixtures are entirely
-  constructor-assigned, so no field is split-eligible and the flag is inert on
-  them. Fixture shape remains the leading explanation. Settling it needs the two
-  fixture sets compared directly, not two summaries compared.
+This **resolves a disagreement between the two lanes, in slice C's favour, and
+the error was on this side.** An earlier draft of this section reported
+`Object.keys(classInstance)` and `"a" in classInstance` *passing* and treated
+slice C's failing column as unreproduced. The cause was a fixture confound
+here: those two probes used a **statically typed** receiver (`var o = new C()`)
+while the `for…in` probe laundered through `id(x)`. Slice C's fixture used
+`const o: any = new C()` throughout — i.e. it measured the dynamic path
+consistently, and this lane did not. Its grouping conclusion stands:
+
+> `hasOwnProperty` reaches a working predicate on a receiver where `in`,
+> `for…in` and `Object.keys` all answer nothing.
+
+The cross product adds the axis that unifies both columns and is the actionable
+statement for #3920: **every one of the four works on a statically-typed
+closed-struct receiver; three of the four break the moment the receiver is
+`any`.** So the defect lives on the DYNAMIC path, and `hasOwnProperty` is the
+one dynamic operation that still reaches a correct answer — that asymmetry, not
+"the presence read is broken", is where a fix should start.
+
+Two notes for whoever takes it:
+
+- slice C separately eliminated 24 configurations (structural canonicalization
+  of an identically-shaped sibling struct, `optimize` 0/3/unset, class-shape
+  spelling, and — by swapping its three changed files for their `origin/main`
+  blobs — its own branch), so none of those is the cause either;
+- seen in passing and **not** an enumeration bug: laundering a
+  field-initialiser class through `id(x): any` and calling `hasOwnProperty`
+  fails the COMPILE with `IR-FALLBACK … arg 0 of call to id is class<C>,
+  expected dynamic`. Distinct signature, IR admission rather than reflection;
+  the constructor-assignment spelling of the same program compiles and answers
+  correctly.
 
 ### 5. Retyping needs no special case, and here is the argument
 
@@ -741,13 +753,16 @@ Three properties fall out, and each removes a class of #4211's risk:
   the base presence words does not. Say which, in the fix.
 
   **And the constraint binds wider than this issue.** Independently replicated
-  on this branch (`.tmp/enum-matrix.mjs`, `--target standalone`, `optimize: 0`):
-  a **class** instance that reaches the loop as `any` enumerates 0 of 3 keys,
-  exactly like a fnctor instance, while the same class instance typed AT the
-  loop enumerates 3, and an object literal enumerates 3. So the boundary is not
-  "fnctor" — it is **the dynamic path over any closed struct**, and the
-  name-list-source rule above therefore applies to every closed-struct receiver
-  kind, not only the ones per-type layouts touches;
+  on this branch (§4's settled matrix): a **class** instance reaching the site
+  as `any` answers 0 for `Object.keys` / `in` / `for…in`, exactly like a fnctor
+  instance, while the same instance statically typed answers correctly on all
+  four, and an object literal enumerates 3. So the boundary is not "fnctor" — it
+  is **the dynamic path over any closed struct**, and the name-list-source rule
+  above therefore applies to every closed-struct receiver kind, not only the
+  ones per-type layouts touches. That matters here specifically because a
+  per-type layout receiver is *usually* dynamic: the analysis publishes a
+  single-label pin only where one label is provable, and every unpinned
+  receiver takes exactly the path that is broken today;
 - layouts are **siblings, not nested**, so arm order in the dispatchers cannot
   matter. (A prefix-CHAIN design was evaluated and rejected for this reason
   plus worse bytes: −60.9 % vs −67.3 %, because a label needing one


### PR DESCRIPTION
Docs-only follow-up to #4213 (which landed the per-type layout analysis). **Corrects three things this lane previously asserted**, two of them stated as fact.

## 1. The headline was the combined figure, quoted as marginal

#4213 quoted **−53.6 %** of all struct bytes, measured against the union-struct baseline — which **disappears** once #4217 makes the hot/cold split default-ON.

| | struct bytes/parse | |
| --- | ---: | ---: |
| #4217's K=20 default | 9.10 MB | — |
| + per-type layouts | 6.31 MB | **−30.7 %** |
| both, vs the pre-split union | 6.31 MB | −50.3 % |

Wall projection widened to **≈ −3 to −7 pp on top of #4217's** — a bracket, not a point, citing #4217's 3.15 pp ON-side scatter against its 0.35 pp OFF-side replication. Its absolute bucket shares are not cross-session comparable, so only the delta travels.

## 2. RETRACTED: the `copyNode` mechanism

#4213 asserted that acorn's `copyNode` was "precisely the reflective surface that silently corrupted #4211's first cut." Two independent measurements contradict it: `for…in` over a standalone closed struct enumerates **zero** own properties, and `copyNode` executes **zero times** on this corpus. A routine that enumerates nothing cannot copy anything. The three reflective passes #4211 wired *did* fix its divergence, but **the mechanism is unknown**. #4213's §6 risk ordering partly inherits from it and is flagged for re-derivation rather than reuse.

## 3. RETRACTED: this lane's contradiction of the enumeration matrix — the error was here

An earlier revision of this branch reported that `Object.keys` and `in` **pass** on an untyped receiver, contradicting the other lane. **That was a probe defect, not a measurement.** This lane's `Object.keys`/`in` probes used a *statically typed* receiver while only its `for…in` probe laundered through `id(x): any` — two different code paths, reported as one contradiction. The other lane's fixture used `const o: any` throughout and was internally consistent. **Their grouping was correct**; the CONTESTED note is being withdrawn.

Two process notes, recorded because they are what converged it in one round: the other lane put its **fixture inline in the message** rather than describing it, and its **24-configuration elimination** — ruling out structural canonicalization, optimize level, class spelling, and its own branch by swapping in `origin/main` blobs — left "how the probes are written" as the only hypothesis standing, which is where the fault was.

### The cross product neither original column had

| receiver | `Object.keys` | `in` | `for…in` | `hasOwnProperty` |
|---|---:|---:|---:|---:|
| `const o = new C()` (typed) | 3 ✓ | 1 ✓ | 3 ✓ | 1 ✓ |
| `const o: any = new C()` | **0** | **0** | **0** | 1 ✓ |
| laundered via `id(x): any` | **0** | **0** | **0** | 1 ✓ |

**All four operations work on a statically-typed closed-struct receiver; three of four break the moment it is `any`.** That moves the defect from "the presence read is broken" to "**the dynamic path is broken, and `hasOwnProperty` is the one dynamic operation still reaching a correct answer**" — which is the actionable form and is suggested as #3920's headline. This PR does **not** edit #3920: the enumeration lane has claimed it (`ttraenkler/opus-forin`) and is its single author.

## 4. #3920 is a HARD blocker on the emission slice, not a hygiene item

A per-type-layout receiver is **usually dynamic** — the analysis pins a single label only where exactly one is provable, so **every unpinned receiver takes precisely the broken path**. Until the dynamic reflective surface is correct, no differential can distinguish a correct split from a broken one, and a green reflective check must not be read as coverage in either PR.

Root cause is now known and in the source: six dynamic helpers back these surfaces; three received closed-struct arms and three never did, matching the matrix 3-for-3. `object-runtime.ts:6665` records that sharing the arms with `__object_keys` **was implemented, measured and reverted**, because `ctx.structFields` includes builtin carriers — and that leak is **already shipped** through the one surface that does have arms (`Object.getOwnPropertyNames(/ab/g)` answers 7, should be 1).

## 5. This lane's own validation, re-examined rather than assumed

The other lane's vacuity catch prompted a re-check rather than an assumption. It holds — it runs against native acorn in Node, so `Object.keys` is the language's — but "different instrument" is not an argument by itself, so the witnesses are recorded: denominator 32,468 (matches the census), occupancy numerator 64,008, and the structural point that **a degenerate plan would report ~100 % overflow, not 0 %**.

## 6. Adopted from #4217

**The `generator` root cause transfers, and the seam is worse here.** Hiding a carrier from the `ref.test` *arms* is correct; hiding it from the consumer-side narrowing *vote* is a bug. The vote's candidate set grows from one struct to N layouts, where "this layout lacks the field" must **not** count as agreeing.

**The two techniques overlap rather than compose on `Node`**: 0 % residual rate here against #4217's 28.1 % tail rate — where a layout is proved, the cold tail has nothing left to move. Complementary *by verdict*, not a competition.

**Corrected design constraint.** The earlier "derive the enumerable name list from presence bits" does not hold as written — presence words carry *bits, not names*, and only conditionally-assigned fields have one. The defensible version, which the working `getOwnPropertyNames` arm already does: **names from the base struct's field list, liveness per name from the base presence words.** That keeps enumeration layout-independent and survives the per-type split, because the presence words live in the base.

## Recorded separately, deliberately not folded into #3920

Laundering a **field-initialiser** class through `id(x): any` and calling `hasOwnProperty` fails to **compile** (`IR-FALLBACK … arg 0 of call to id is class<C>, expected dynamic`), while the constructor-assignment spelling works. That is an IR admission gap, not a reflection defect — kept apart so it is not merged in by proximity.

## Needs an owner

**#3920 is unclaimed and now blocks #3927's emission slice.**

## CLA

- [x] I have read and agree to the CLA