### PR TITLE
fix(scripts): sync-workspace-main must not detonate the pre-push chain on every hook fire

### DIFF
--- a/scripts/sync-workspace-main.sh
+++ b/scripts/sync-workspace-main.sh
@@ -39,6 +39,14 @@ say() { echo "[sync-workspace-main] $*"; }
 
 [ -d "$WS/.git" ] || { say "no git repo at $WS — skipping"; exit 0; }
 
+# SINGLE-FLIGHT: this script is wired into SessionStart AND Stop hooks, so
+# concurrent invocations are routine (every agent stop fires one). Without a
+# lock they stack: on 2026-08-08 seven overlapping runs each spawned the full
+# pre-push verification chain and drove load to 29 on 8 cores. One sync at a
+# time; a second concurrent run has nothing new to do anyway.
+exec 9>"$WS/.git/sync-workspace-main.lock" 2>/dev/null || exit 0
+if ! flock -n 9; then say "another sync in progress — skipping"; exit 0; fi
+
 # Keep the FORK's main synced with upstream (clean fast-forward ONLY). Agents
 # branch from origin/main and the statusline reads /workspace, so when the fork
 # (origin = ttraenkler/js2) lags upstream (loopdive/js2 — where PRs actually
@@ -53,7 +61,12 @@ if git -C "$WS" remote get-url upstream >/dev/null 2>&1 \
   u=$(git -C "$WS" rev-parse upstream/main 2>/dev/null)
   if [ -n "$o" ] && [ -n "$u" ] && [ "$o" != "$u" ] \
      && git -C "$WS" merge-base --is-ancestor "$o" "$u" 2>/dev/null; then
-    if git -C "$WS" push origin "$u:refs/heads/main" --quiet 2>/dev/null; then
+    # --no-verify: this mirror push carries only upstream-merged, CI-validated
+    # commits — the local pre-push chain (typecheck+lint+tests, ~5 min) adds
+    # nothing and made every Stop-hook invocation cost a full verification run
+    # (the 2026-08-08 load-29 pileup). Sanctioned for pushes by the hook's own
+    # header and CLAUDE.md; CI runs the real gate.
+    if git -C "$WS" push origin "$u:refs/heads/main" --quiet --no-verify 2>/dev/null; then
       say "synced fork origin/main -> upstream/main ($(echo "$u" | cut -c1-9))"
     else
       say "WARNING: upstream->origin/main fast-forward push failed (perms/protection?)"


### PR DESCRIPTION
The sync script is wired into the SessionStart and Stop hooks. Its fork-mirror push (origin/main → upstream/main fast-forward) triggered `.husky/pre-push`, which runs the full typecheck + lint + vitest chain (~5 min). Stop events fire more often than that chain finishes, so invocations stacked: on 2026-08-08, seven concurrent chains (each spawning `tsc --noEmit`) drove the 1-min load to 29 on an 8-core box and starved interactive use.

Two changes, both scoped to this script:

1. **flock single-flight guard** on `.git/sync-workspace-main.lock` — a second concurrent sync has nothing new to do; skip instead of stack.
2. **`--no-verify` on the mirror push only.** It carries exclusively upstream-merged, CI-validated commits; the local verification chain adds nothing there. Sanctioned for pushes by `.husky/pre-push`'s own header and CLAUDE.md (CI runs the real gate). Real work pushes are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAPpV5PjTA98gW2Tjqhrki