### PR TITLE
#4157/#743: acorn cross-runtime profile, second-corpus census, and the first two Parser.pos pin slices

### DIFF
--- a/plan/issues/4157-close-the-acorn-node-performance-gap.md
+++ b/plan/issues/4157-close-the-acorn-node-performance-gap.md
@@ -926,3 +926,19 @@ is observable (`NaN === NaN` must stay false for the same reference).
 
 **Still untouched by anything: dynamic property lookup 13.5 % + call dispatch
 8.1 %.** Nothing in this umbrella currently targets either.
+
+## 2026-08-08 — the second-corpus measurement RAN (pako): acorn's exhaustion does not generalize
+
+The "measure a second dogfood corpus" recommendation is now answered — full
+record in **#743, "2026-08-08 — second-corpus measurement"**. pako 2.1.0
+(226 KB dist, function-ctors, numeric-heavy) censuses at **77.0 % typed vs
+acorn's 58.3 %**, and its 25-slot untyped residue contains **zero** slots of
+acorn's dominant "integer `this`-field-read argument" bucket. Its residue is
+instead 68 % first-write-decides null seeds and 20 % ref-valued args — the two
+levers acorn priced at ~0. Consequences for this umbrella: the receiver-typing
+program is exhausted *for acorn specifically*; the `Parser.pos` field-fact XL
+program serves acorn's number only and must be justified on that basis, not on
+generality. pako becomes a runnable corpus once #4216 (i16 packed-local emit
+bug, sole standalone blocker) lands; luxon/styled-components were measured
+unusable (native-class syntax bypasses the fnctor machinery entirely / non-
+self-contained bundle).

--- a/plan/issues/4157-close-the-acorn-node-performance-gap.md
+++ b/plan/issues/4157-close-the-acorn-node-performance-gap.md
@@ -4,7 +4,7 @@ title: "umbrella: close the acorn-vs-Node performance gap — representation fir
 status: ready
 sprint: current
 created: 2026-08-04
-updated: 2026-08-06
+updated: 2026-08-08
 priority: high
 horizon: xl
 feasibility: hard
@@ -382,6 +382,75 @@ on its own.
 before the next representation lever. Four levers have now priced out for
 reasons specific to acorn's shape; a corpus with declared types would say
 whether the representation program is exhausted generally or only here.
+
+## 2026-08-08 — cross-runtime profile: wasm and Node bucketed side by side
+
+Every prior profile in this file measured only the wasm side. This run profiles
+**both runtimes with the same instrument** (`--profile-runtime wasm` and
+`--profile-runtime node`, 300 iterations each, same runtime-suffixed 226 KB
+corpus) and joins them phase by phase, so "where it loses to Node" is now a
+per-bucket subtraction rather than an inference. Fresh 4-core Xeon 2.10 GHz
+container, Node 22.22.2, main @ `41ad08c3`, binary 1,567,288 B, checksum green.
+
+Per-parse from the profile windows (34,325 ms / 300 wasm; 4,234 ms / 300 node):
+**wasm 114.4 ms vs node 14.1 ms → 8.1×**. Wasm agrees with its unprofiled lane
+median (116.0 ms) to within 1.5 %; the node side is where the ratio moves —
+this session's two lane runs gave node medians of 21.9 ms and 18.8 ms (lane
+ratios 5.3× / 6.4×) against 14.1 ms under the profiler. The node baseline swing
+is the known §6 band; the wasm number is stable across all four measurements.
+
+### The side-by-side (ms per parse, self-time)
+
+| phase | wasm | share | node | share | wasm/node |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| scanner/tokenizer (compiled acorn) | 21.6 | 18.9 % | 7.1 | 50.0 % | **3.1×** |
+| parser logic (compiled acorn) | 20.9 | 18.2 % | 5.9 | 41.9 % | **3.5×** |
+| dynamic-lookup (`__extern_get` 6.9 pp + per-key members) | 18.0 | 15.7 % | — | — | — |
+| gc-engine | 13.6 | 11.9 % | 0.9 | 6.4 % | 15× |
+| call-dispatch (`__dc_*`, `__call_fn_method_*`) | 11.7 | 10.2 % | — | — | — |
+| regexp engine (`__regex_search` 6.7 pp) | 9.2 | 8.1 % | ~0.1 | 0.9 % | (see caveat) |
+| dynamic-eq (`__is_truthy` 3.3 + `__extern_strict_eq` 2.2) | 6.5 | 5.7 % | — | — | — |
+| string-runtime (`__str_flatten` 2.8, `__str_equals` 1.2) | 5.9 | 5.1 % | — | — | — |
+| cast-convert (`__box/__unbox/__to_primitive`) | 5.5 | 4.9 % | — | — | — |
+| alloc-helpers | 1.3 | 1.2 % | — | — | — |
+| **total** | **114.4** | | **14.1** | | **8.1×** |
+
+Node's regexp row counts only acorn's own `regexp_*` validator frames; V8
+attributes native `RegExp.test` ticks to the calling JS frame, so some node
+regexp time hides inside its scanner rows. The 72× row-ratio is therefore an
+overstatement — but the wasm regexp engine at 9.2 ms/parse still exceeds any
+plausible node figure several times over.
+
+### Gap attribution (100.3 ms of gap)
+
+| component | ms | % of gap |
+| --- | ---: | ---: |
+| runtime helpers with **no node counterpart** (lookup + dispatch + eq + string + cast + alloc) | 49.2 | **49 %** |
+| compiled parser slower than JIT'd parser | 14.9 | 15 % |
+| compiled scanner slower than JIT'd scanner | 14.6 | 15 % |
+| extra GC | 12.7 | 13 % |
+| extra regexp | 9.1 | 9 % |
+
+Reading: **Node spends 92.9 % of its parse inside acorn's own code; the wasm
+build spends 37.1 % there.** The other 62.9 % is machinery — helper functions
+(43.0 %), GC (11.9 %), and the wasm regex engine (8.1 %). Removing every
+helper/GC/regexp millisecond would leave 42.5 ms vs 14.1 ms ≈ **3.0×** — the
+measured floor of the "JIT-class residue" this umbrella estimated at ~3.5×.
+Conversely the residue cannot be attacked below ~3× without making the
+compiled scanner/parser code itself faster, which is register allocation /
+inlining / IC-class work, not helper elision.
+
+Scanner/parser rows are self-time only: helper time *caused by* the scanner
+(e.g. `__str_flatten` re-entered from `skipSpace`, both still visible in this
+profile at 2.8 pp) is charged to the helper buckets, so the 3.1×/3.5× rows are
+lower bounds on the phases' end-to-end cost ratio.
+
+Reproduction: §Reproduction above for the wasm side; the node side is the same
+command with `--profile-runtime node --profile-output .tmp/acorn-node.cpuprofile`
+(no closure map needed), bucketed with `profile-buckets.mjs <profile> /dev/null`.
+Phase split for node frames: `read*/next/nextToken/skip*/finish{Token,Op}/
+updateContext/curContext/getTokenFromCode/types$1.*` → scanner; `regexp_*` +
+`readRegexp` → regexp; remainder → parser.
 
 ## Dupe check
 

--- a/plan/issues/4216-pako-standalone-i16-packed-local-emit.md
+++ b/plan/issues/4216-pako-standalone-i16-packed-local-emit.md
@@ -1,0 +1,73 @@
+---
+id: 4216
+title: "standalone pako: packed i16 storage type leaks into a value position at binary emit"
+status: ready
+sprint: Backlog
+created: 2026-08-08
+priority: medium
+horizon: m
+feasibility: medium
+task_type: bug
+area: emit
+goal: standalone-gap
+related: [743, 4157, 679]
+origin: "2026-08-08 — found by the #743 second-corpus census (pako 2.1.0 standalone compile)"
+---
+
+# #4216 — standalone pako: packed `i16` leaks into a value position at binary emit
+
+## Problem
+
+Compiling pako 2.1.0's self-contained dist bundle (`dist/pako.esm.mjs`, 226 KB,
+zlib port) with `target: "standalone"` fails at binary emit with exactly one
+error:
+
+```
+Binary emit error: Error: encodeValType: packed storage type "i16" is not valid
+in a value position (only struct fields / array elements) — a packed type leaked
+into a param/result/local/global
+    at encodeValType (src/emit/binary.ts:855)
+    at encodeFunctionWithSourceMap (src/emit/binary.ts:667-669)   ← locals vector
+    at emitBinaryWithSourceMapUnguarded (src/emit/binary.ts:571)
+```
+
+The frame at `binary.ts:667-669` is the function-locals vector, so some
+function declares a **local** of packed type `i16`. Packed types (`i8`/`i16`)
+are storage-only in WasmGC; a local/param/result/global must widen to `i32`.
+The emit-time guard (which is doing its job) was added precisely to catch this
+class of leak — this is the first real-corpus reproduction.
+
+Codegen itself completes: the fnctor field-provenance census runs to the end
+(122 slots recorded) and this is the **only** error in the compile. pako is
+heavy on `Uint16Array`/`Uint8Array` and the native-strings backend uses i16
+arrays (#679), so the likely source is an array-element read whose result type
+was taken as the storage type instead of the widened `i32` — but the emitting
+function has not been identified yet; that is the first step.
+
+## Repro
+
+```bash
+cd /tmp && npm pack pako@2.1.0 && tar xzf pako-2.1.0.tgz
+# then compile package/dist/pako.esm.mjs with:
+#   compile(source, { fileName: "pako.mjs", skipSemanticDiagnostics: true,
+#                     target: "standalone" })
+```
+
+(Probe used by the census: see #743 "2026-08-08 — second-corpus measurement".)
+
+## Why it matters
+
+pako is the chosen **second dogfood corpus** for the #743/#4157 representation
+program (same size class as acorn's bundle, function-ctor classes, numeric/
+typed-array-heavy — the contrast corpus to acorn's string/object shape). This
+one error is all that blocks it from becoming a compiled, runnable standalone
+corpus with its own perf lane; until then it is census-only.
+
+## Acceptance criteria
+
+- [ ] pako 2.1.0 `dist/pako.esm.mjs` compiles to a valid standalone binary
+      (Wasm validation passes; no packed types in value positions).
+- [ ] A minimal fixture pins the widening (i16-array element read flowing into
+      a local/param/result) as a regression test.
+- [ ] A smoke canary (deflate → inflate round-trip of a short string inside the
+      module) returns the expected checksum.

--- a/plan/issues/743-whole-program-type-flow-analysis.md
+++ b/plan/issues/743-whole-program-type-flow-analysis.md
@@ -4,7 +4,7 @@ title: "Whole-program type flow analysis"
 status: in-progress
 assignee: ttraenkler/opus-impl-4
 created: 2026-03-22
-updated: 2026-08-07
+updated: 2026-08-08
 priority: critical
 horizon: xl
 feasibility: hard
@@ -2270,3 +2270,111 @@ its facts agreed with the in-compile census on every cross-checkable row;
 promotion at the #3753 site rather than through the flag's own consumer, because
 the two produce the same struct shape and the former needs no plumbing — §6
 explains why that choice does not weaken the conclusion.
+
+## 2026-08-08 — second-corpus measurement (pako 2.1.0): the acorn conclusion does NOT generalize
+
+The re-ranked levers above put "a second corpus" ahead of the field-fact XL
+program: three levers priced out on acorn for corpus-shaped reasons, and the
+question was whether the representation program is exhausted generally or only
+there. **Answer: only there.** pako's untyped residue is dominated by exactly
+the two levers acorn made look worthless.
+
+### Setup
+
+Tree: `41ad08c3` (main) + docs commits. Probe: compile the package's
+self-contained dist bundle with `target: "standalone"`,
+`JS2WASM_FNCTOR_FIELD_PROVENANCE=1 JS2WASM_FNCTOR_CTOR_PARAM_TYPES=1`, then
+read `fnctorFieldProvenanceRecords()` + `classifyFieldSlot` in-process (no
+optimize step — slot decisions are made in codegen, before Binaryen). Same-tree
+acorn control: `tests/dogfood/acorn-standalone-compile.mjs` reproduces the
+recorded census EXACTLY — 96 slots, 56 / 1 / 39, canaries 2,3,4,5, imports
+`[]` — so the cross-corpus comparison is same-commit, not cross-session.
+
+### Corpus selection (two candidates rejected, recorded so nobody retries them)
+
+- **styled-components 6.4.4** (the only substantial npm-compat package whose
+  compile lane is green): its esm entry is a 39 KB re-export wrapper, not a
+  self-contained bundle; standalone compile fails (50× TDZ "Cannot access 'n'
+  before initialization") and produces **0 fnctor records**. Unusable.
+- **luxon 3.7.2** (262 KB, 25 classes): **native `class` syntax — the fnctor
+  machinery (function-constructor path) never engages, 0 records.** Also
+  standalone-blocked (`String.prototype.match` unsupported, Intl host-import
+  leaks). Beyond unusable, this is a finding in its own right: **the entire
+  fnctor typing program is invisible to modern class-syntax bundles.** Any
+  future corpus must be an ES5-style function-ctor bundle, or the program
+  needs a class-ctor equivalent first.
+- **pako 2.1.0** `dist/pako.esm.mjs` (226 KB — acorn's size class; zlib port;
+  7 function-ctors; typed-array/numeric-heavy where acorn is string/object-
+  heavy): census runs to completion. **Chosen.** One caveat: binary emit fails
+  with a single error (packed `i16` leaked into a local — filed as **#4216**),
+  so pako is census-only until that lands; codegen and all 122 slot decisions
+  complete before the emit stage.
+
+### The census, side by side
+
+| | acorn 8.16.0 | pako 2.1.0 |
+| --- | ---: | ---: |
+| slots | 96 | 122 |
+| typed | 56 (58.3 %) | **94 (77.0 %)** |
+| discarded | 1 (1.0 %) | 3 (2.5 %) |
+| unknown | 39 (40.6 %) | **25 (20.5 %)** |
+
+pako's typed slots: 77× f64, 10× ref_null, 5× i32, 2× ref. Its discarded
+bucket (`Deflate.strm: ZStream`, `Inflate.strm: ZStream`, `Inflate.header:
+GZheader`) is acorn's #1712 shape-model gap, same cause, same size class.
+Call-site param inference **works where its preconditions hold**: `Config`'s
+four numeric tuning params are all typed f64 from ten all-literal `new Config`
+sites.
+
+### The 25 unknowns, bucketed (each verified in source)
+
+1. **17 (68 %) — null-in-ctor, concretely assigned post-ctor** (`DeflateState`
+   9, `InflateState` 8): `this.window = null` in the ctor; `s.window = new
+   Uint8Array(...)`, `s.head = new Uint16Array(...)`, `s.l_desc = new
+   TreeDesc(...)` in `deflateInit2`/`inflateInit` — monomorphic concrete
+   writes outside the ctor. **The blocker is `deriveFnctorFields`' first-
+   write-decides rule, not inference.** The lever is slot-typing from the JOIN
+   OF ALL WRITES (the mutual-fixpoint slice already built the write scan that
+   would feed it). Acorn has ~6 such slots; here it is two-thirds of the
+   residue.
+2. **5 (20 %) — ref-valued ctor args, concrete at every site**
+   (`StaticTreeDesc.static_tree/extra_bits`, `TreeDesc.dyn_tree/stat_desc`,
+   `Config.func`): module-const arrays, `Uint16Array` this-fields,
+   `StaticTreeDesc` instances, function references. **The blocker is the
+   f64-only consumer ABI** — the ref/string consumer that measured 1 slot /
+   0 bytes on acorn has a real population here.
+3. **1 — conditional-join extension**: `has_stree = static_tree &&
+   static_tree.length` — the lhs is a ref (always truthy), so the `&&` always
+   yields the numeric rhs; typing it needs the shipped ToBoolean-totality join
+   rule extended to ref-typed lhs.
+4. **2 (8 %) — open options objects** (`Deflate.options`, `Inflate.options`
+   via `assign({}, DEFAULTS, options)`): acorn's `Parser.options` analog —
+   genuinely dynamic, honest boxes.
+
+**And 0 slots in acorn's dominant bucket.** The ~14-slot "integer-valued
+`this`-field-read arguments" population that drives acorn's residue — and
+motivates the `Parser.pos` field-fact XL program — simply does not exist here.
+
+### Consequences for the lever ranking
+
+- **The receiver-typing program is NOT exhausted generally — it is exhausted
+  on acorn.** pako's residue is addressable, and by levers already
+  half-built: (1) **all-writes slot join** (17 slots here vs ~6 on acorn;
+  collection side exists in the mutual-fixpoint write scan), then (2) **ref-
+  typed slot consumption** (5 slots here vs the measured 1/0-bytes on acorn).
+- **The `Parser.pos` field-fact XL program is acorn-specific.** Do not
+  greenlight it on generality grounds; if it is built, it is for acorn's
+  perf number alone.
+- Numeric-heavy corpora are already well served (77 % typed) — consistent
+  with #4157's cross-runtime profile showing the remaining tax is in boxed
+  VALUES and comparisons, not receivers.
+- The `.d.ts`-seed lever stays untested on a second corpus: pako ships no
+  bundled declarations (`@types/pako` is external). A typed-declaration
+  corpus remains unmeasured.
+- Wall-clock A/B is not applicable pre-#4216 (no binary); the census is the
+  pre-registered instrument for this question and is deterministic.
+
+Probe artifacts: `.tmp/file-census.mjs` (inline in this section's Setup),
+outputs `.tmp/pako-census.json`, `.tmp/luxon-census.json`,
+`.tmp/sc-census.json`, acorn control `.tmp/acorn-probe.{json,err}` — scratch
+only; this section is the durable record.


### PR DESCRIPTION
## Description

Started as the cross-runtime measurement record; now carries the #743 `Parser.pos` program's first code slices as well. Three parts:

**1. docs — cross-runtime acorn profile (#4157):** wasm and Node profiled with the same instrument (300 iterations, `standalone-dynamic` lane): wasm 114.4 ms vs node 14.1 ms per parse (8.1×). Gap attribution: 49 % runtime helpers with no node counterpart, 15 %+15 % compiled scanner/parser vs the JIT, 13 % extra GC, 9 % wasm regex engine.

**2. docs — second-corpus census (#743) + new issue #4216:** pako 2.1.0 censuses 94/3/25 (77.0 % typed) vs acorn's 56/1/39 (58.3 %), with **zero** slots in acorn's dominant this-field-read bucket — the receiver-typing program is exhausted on acorn specifically, not generally. #4216 filed: a packed-`i16` local at binary emit is pako's sole standalone blocker. luxon (native class syntax bypasses the fnctor machinery) and styled-components (non-self-contained entry) measured unusable.

**3. code — Parser.pos pin-census instrument + two pin slices (#743):**
- `JS2WASM_FNCTOR_FIELD_FACT_TRACE` (new `src/ir/fnctor-field-fact-trace.ts`, env-gated, inert off): records every write reaching a field fact with its evaluated contribution, plus-assign RHS separately so derivative pins are distinguishable from roots. The live census corrected the hand-traced §7 pin table (conditional-join had already retired the ternary pin; the "benign" `+= literal` sites were derivative).
- **Slice A (§4 carve-out)**: writes onto a proven builtin instance (`var err = new SyntaxError(…)`, ctor out-of-file, binding never reassigned by any in-file assignment form) attribute nowhere — retires the `raise` pin on every owner's `pos`.
- **Slice B (`src/ir/fnctor-f64-producers.ts`)**: `- * / % **` with either operand provably not BigInt is a Number (ToNumeric totality, sibling of the i32-producer rule).

`Parser.pos` root pins 5 → 2 families (22 all-bucket `state.pos` writes + `end + 2`). Flag-off standalone binary **byte-identical** (sha `fbea40a8…`, file-copy A/B); flag-on slot census unchanged 56/1/39 as pre-registered; family suites 299/299 green plus the new `tests/issue-743-pos-pin-slices.test.ts` 9/9 (negative tests caught a real shorthand-destructuring symbol bug during development).

## CLA

- [x] I have read and agree to the CLA