### PR TITLE
ci(#3927): layout_emit dispatch input — flag-ON test262 measurement lane

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -78,6 +78,11 @@ on:
         required: false
         default: false
         type: boolean
+      layout_emit:
+        description: "(#3927) Measurement lane for the per-type-layout default-ON decision: export JS2WASM_FNCTOR_LAYOUT_EMIT=1 into the shard env. Same contract as ir_first: NEVER promotes a baseline — the merged report artifact is the measurement output, diffed against the same-SHA committed baseline."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -735,6 +740,11 @@ jobs:
       # workers inherit the job env, and results are never cached across runs,
       # so a flag-on dispatch measures a full fresh compile of every test.
       JS2WASM_IR_FIRST: ${{ github.event_name == 'workflow_dispatch' && inputs.ir_first && '1' || '' }}
+      # (#3927) Same pattern as JS2WASM_IR_FIRST directly above: '1' only on a
+      # workflow_dispatch that opted in via layout_emit; empty string (falsy for
+      # truthyEnv) everywhere else, so all default lanes stay byte-identical.
+      # The flag is additionally standalone-gated inside the compiler itself.
+      JS2WASM_FNCTOR_LAYOUT_EMIT: ${{ github.event_name == 'workflow_dispatch' && inputs.layout_emit && '1' || '' }}
       TEST262_INCLUDE_PROPOSALS: ${{ github.event_name != 'workflow_dispatch' && '1' || (inputs.include_proposals && '1' || '0') }}
       RUN_TIMESTAMP: ${{ github.run_id }}-${{ matrix.target.name }}-chunk${{ matrix.chunk }}
       TEST262_TARGET: ${{ matrix.target.test262_target }}
@@ -908,6 +918,7 @@ jobs:
       # baseline alongside refresh-baseline.yml.
       COMPILER_POOL_SIZE: "4"
       JS2WASM_IR_FIRST: ""
+      JS2WASM_FNCTOR_LAYOUT_EMIT: ""
       TEST262_INCLUDE_PROPOSALS: "1"
       RUN_TIMESTAMP: ${{ github.run_id }}-${{ matrix.target_name }}-mgchunk${{ matrix.chunk_label }}
       TEST262_TARGET: ${{ matrix.test262_target }}
@@ -2239,7 +2250,8 @@ jobs:
       needs.mg-artifact-probe.result == 'success' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       github.actor != 'github-actions[bot]' &&
-      !(github.event_name == 'workflow_dispatch' && inputs.ir_first)
+      !(github.event_name == 'workflow_dispatch' && inputs.ir_first) &&
+      !(github.event_name == 'workflow_dispatch' && inputs.layout_emit)
     name: promote merged report to main baseline
     # (#2947) `!(… && inputs.ir_first)` above — an IR-first measurement dispatch
     # (JS2WASM_IR_FIRST=1 in the shards) must NEVER promote its merged report:

--- a/plan/issues/4235-multifile-compile-fnctor-pipeline-inert.md
+++ b/plan/issues/4235-multifile-compile-fnctor-pipeline-inert.md
@@ -1,0 +1,84 @@
+---
+id: 4235
+title: "generateMultiModule never assigns ctx.fnctorEscapeGate — the entire fnctor pipeline (per-type layouts included) is silently inert on every multi-file compile"
+status: ready
+created: 2026-08-08
+updated: 2026-08-08
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: classes, objects
+goal: performance
+related: [3927, 4157, 4211, 4074]
+origin: "2026-08-08 second-corpus layout census (lead's measurement subagent): the positive control — identical options, compile() vs compileMulti() on a two-site fixture — separated compile path from options after a first pass reported zeros for acorn through compileProject."
+---
+
+# #4235 — multi-file compiles silently skip the whole fnctor pipeline
+
+## Problem
+
+`analyzeFnctorEscapeGate` is called **only** at `src/codegen/index.ts:3536`,
+inside `generateModule` — the single-file path. `generateMultiModule`
+(`src/codegen/index.ts:6206`), which `compileProject`/`compileMulti` dispatch
+to via `src/compiler.ts:975`, never assigns `ctx.fnctorEscapeGate`.
+
+Consequence: on any multi-file compile the entire fnctor pipeline is inert —
+escape-gate analysis, presence bits/hot-cold split (#4211/#4217), and the
+per-type layout analysis + emission (#3927/PR #4230). No error, no fallback
+telemetry: the compile succeeds with the unsplit union representation, which
+is a **silent-empty** — a zero from this path is indistinguishable from "no
+fnctors in the package".
+
+Line numbers verified 2026-08-08 on main @ `5d661603f`; re-verify before
+fixing — this file cites a moving target.
+
+## Why it matters
+
+- Most of the npm-compat corpus compiles through `compileProject`. Every
+  fnctor-pipeline measurement or optimization validated on single-file
+  `compile()` (acorn's lane) has never run on those packages at all.
+- The 2026-08-08 second-corpus census had to fall back to single-file
+  `compile()` for every package; its acorn numbers were validated against CI
+  (binary 621,552 B == npm-compat.json) only via that path.
+- Any future default-ON of `JS2WASM_FNCTOR_LAYOUT_EMIT` (#3927 §6) will look
+  like it shipped to the whole corpus while actually engaging only on
+  single-file compiles.
+
+## Evidence (reproducible)
+
+Two-site fnctor fixture (`TWO_SITE`), identical options:
+
+- `compile()` (single-file): `[alloc-labels]` stderr reports the family,
+  verdicts, and labels.
+- `compileMulti()`: zero fnctor analysis output; `ctx.fnctorEscapeGate`
+  undefined throughout codegen.
+
+The census subagent's first acorn-through-`compileProject` pass reported
+zeros for everything — only the positive control exposed the path
+difference. (Full census table in the lead session log, 2026-08-08; the
+report's .tmp copy was lost to worktree auto-cleanup — the summary survives
+in the session transcript and the conclusions in #3927 §6.4's data note.)
+
+## Acceptance criteria
+
+- [ ] `generateMultiModule` runs the same fnctor pipeline (escape gate →
+      presence/cold analysis → layout analysis when flagged) with
+      whole-program visibility across the module graph, or an explicit,
+      TELEMETERED refusal (a counted fallback reason, not silence) where
+      cross-module analysis is genuinely not yet supported.
+- [ ] A regression test pins the parity: the `TWO_SITE` fixture compiled via
+      `compile()` and `compileMulti()` yields the same fnctor analysis
+      verdicts (or the telemetered refusal on the multi path).
+- [ ] The alloc-labels diagnostic prints which compile path it ran under, so
+      a zero can never again be read without its provenance.
+
+## Notes for the implementer
+
+- Check what else `generateModule` sets up around index.ts:3536 that
+  `generateMultiModule` also lacks — the escape gate may not be the only
+  single-path-only analysis (audit, don't assume).
+- The detector-must-say-I-don't-know rule applies: if multi-file support is
+  deferred, the deferral must be visible in diagnostics and counted in the
+  IR-fallback-style budget, not silent.


### PR DESCRIPTION
Clones the `ir_first` measurement-lane pattern for the per-type-layout default-ON decision (#3927/#4157): a `layout_emit` `workflow_dispatch` input exports `JS2WASM_FNCTOR_LAYOUT_EMIT=1` into the shard env. Empty string on every other event, so all default lanes stay byte-identical; `promote-baseline` is hard-skipped for `layout_emit` runs exactly as for `ir_first` — the merged-report artifact is the measurement output, diffed against the same-SHA committed baseline.

First use: run [31261617785](https://github.com/loopdive/js2/actions/runs/31261617785), the flag-ON conformance measurement gating the default-ON flip.

Note for the shepherd: workflow-touching PR — the auto-enqueue App refuses these; needs the one-shot PAT enqueue once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAPpV5PjTA98gW2Tjqhrki