### PR TITLE
docs(#4236): spike findings — one-heap identity PROVEN, trampoline free, blocked only on the wasi-sdk artifact

### DIFF
--- a/plan/issues/4236-linear-lane-quickjs-boxed-tier-exploration.md
+++ b/plan/issues/4236-linear-lane-quickjs-boxed-tier-exploration.md
@@ -5,6 +5,10 @@ status: backlog
 sprint: Backlog
 created: 2026-08-08
 updated: 2026-08-08
+# 2026-08-08: acceptance box 1 (the link/identity/measurement spike) executed —
+# see "## Spike findings". Status stays `backlog`: the exploration's remaining
+# boxes (frontier A/B, strings, cycle policy, split-brain audit, version pin)
+# are untouched, and the WASI-standalone artifact is still blocked.
 priority: low
 horizon: xl
 feasibility: hard
@@ -107,10 +111,14 @@ reachable by dynamic code; everything else stays native.
 
 ## What the exploration must answer (acceptance criteria)
 
-- [ ] A spike: link libquickjs (quickjs-ng) into a WASI module alongside
+- [x] A spike: link libquickjs (quickjs-ng) into a WASI module alongside
       js2wasm-compiled code sharing one linear memory; round-trip a value and
       an object through `JS_Eval` with identity preserved. Measure binary size
       (expect ~+1.2 MB) and the API-call trampoline cost.
+      → **Done 2026-08-08, see "Spike findings" below.** Identity + round-trip
+      PROVEN over one shared memory (503 KB / 234 KB gz, 1.86 ns trampoline).
+      The *WASI-standalone* half is NOT proven — no wasi-sdk build was
+      obtainable in-sandbox; that is the next slice's blocker.
 - [ ] Decide tainted-allocation vs exotic-wrapper for the object frontier
       (or the hybrid: tainted sites for known-escaping types, wrappers for
       the residue), with a measured A/B on an eval-heavy fixture.
@@ -150,3 +158,307 @@ through the #2928 provider's four-import seam, QuickJS `evalCode`, and Node
 indirect eval. js2wasm AOT number from
 `node --import tsx scripts/generate-npm-compat-report.mjs --only acorn
 --perf-only --lane standalone-dynamic` (wasmUs 84576, nodeUs 11913).
+
+## Spike findings (2026-08-08)
+
+Executes acceptance box 1 (the link + round-trip + measurement spike). Probe
+artifacts lived in `.tmp/spike-4236/` (gitignored — every load-bearing number
+and the key code is restated here so nothing dies with the worktree).
+
+**Rung reached: R4 complete + R5 complete. R1 route (a) FAILED, route (b)
+succeeded.**
+
+### Verdict
+
+**The one-heap identity claim is PROVEN. The standalone-link claim is NOT.**
+
+Two wasm modules over one linear memory, driving QuickJS entirely through its
+exported C-API wrappers, preserve object identity and two-way mutation with a
+**1.86 ns** cross-module call cost. That is the load-bearing half of the design
+and it holds. What the spike did *not* establish is that the pair can be linked
+**without a JS host** — the only QuickJS-wasm build obtainable in this sandbox
+is emscripten-flavoured (imports `env.emscripten_*` alongside
+`wasi_snapshot_preview1`), and the toolchain to build a real WASI one is
+unavailable here. Since the WASI/standalone lane is the *entire* premise of
+this issue, that gap is the go/no-go blocker, not a detail.
+
+**Signal for the next slice: GO on the architecture, BLOCKED on the artifact.**
+The next slice is not codegen — it is "produce a wasi-sdk-built `libquickjs.a`
+in CI and prove the link with no JS in the loop". If that cannot be produced,
+the rest is moot.
+
+### R1 — toolchain
+
+**(a) clang/wasm-ld source build: FAILED. Two independent causes.**
+
+1. *No WASI sysroot on the box.* `clang 18.1.3` and `wasm-ld` are at
+   `/usr/bin`, and `clang --print-targets` does list `wasm32`/`wasm64`. A
+   freestanding link genuinely works:
+   `clang --target=wasm32 -nostdlib -Wl,--no-entry -Wl,--export-all -O2 -o t.wasm t.c`
+   → 446-byte wasm. But the moment libc is involved it falls back to the *host*
+   glibc headers:
+   ```
+   $ clang --target=wasm32-wasi -c t2.c      # t2.c: #include <stdlib.h>
+   /usr/include/stdlib.h:26:10: fatal error: 'bits/libc-header-start.h' file not found
+   ```
+   Nothing under `/opt/wasi-sdk*`, `/usr/share/wasi-sysroot`, or any
+   `*sysroot*/wasi` path exists. QuickJS needs a full libc (stdio, stdlib,
+   string, math, time), so this is fatal, not a flag away.
+2. *QuickJS source is unreachable.* The agent proxy gates GitHub per repository:
+   `curl -L https://github.com/quickjs-ng/quickjs/archive/refs/tags/v0.10.1.tar.gz`
+   returns **403** with body `{"message":"GitHub access to this repository is
+   not enabled for this session. Use add_repo to request access."}` — and no
+   `add_repo` tool was available to this agent. npm (which *is* reachable,
+   it's in `no_proxy`) has neither the source nor a sysroot: `quickjs-ng`,
+   `wasi-sdk`, `@wasmer/wasi-sdk` are all 404; the `quickjs` npm package is an
+   unrelated front-end scaffold.
+
+   → **Neither cause is about the design.** Both are sandbox provisioning. A CI
+   job with `wasi-sdk` + repo access closes this.
+
+**(b) prebuilt `quickjs-emscripten`: SUCCEEDED, and better than hoped.**
+
+Installed out-of-tree (`npm install --no-save --prefix .tmp/spike-4236/qjs-pkg
+quickjs-emscripten`) so `package.json`/lockfile stay untouched. Inspecting the
+shipped `.wasm` with `WebAssembly.Module.imports/exports`:
+
+- **The release-sync module IMPORTS its memory** (`a.a:memory`) — it does *not*
+  export one. This is the single most important toolchain fact for this design:
+  the embedder (or a peer module) owns the memory, so sharing is a *supported*
+  configuration, not a hack. 20 imports total (1 memory + 19 functions).
+- The **debug-sync** build ships **unmangled** exports: the full thin-C-wrapper
+  surface (`QTS_Eval`, `QTS_NewRuntime`, `QTS_NewContext`, `QTS_NewObject`,
+  `QTS_GetProp`, `QTS_SetProp`, `QTS_IsEqual`, `QTS_DupValuePointer`,
+  `QTS_FreeValuePointer`, `QTS_Call`, `QTS_NewFunction`, …) **plus `malloc` and
+  `free`**. Exactly the "thin C wrappers, never struct layouts" ABI this issue
+  mandates — it already exists upstream and needs no new C.
+- The release build's exports are minified (`QTS_Eval` → `b.pa`). The mapping is
+  recoverable mechanically from the shipped glue with one regex
+  (`grep -oE "(QTS_[A-Za-z0-9_]+|_malloc|_free)=[a-z]+\.[A-Za-z0-9_$]+"
+  emscripten-module.mjs`), which is what the probe did. **This minification is a
+  property of the npm distribution, not of QuickJS** — a source build would not
+  minify. Do not design around it.
+
+Notably the QuickJS module was instantiated **with no emscripten JS glue at
+all** — an embedder-created `WebAssembly.Memory` plus 19 `() => 0` stubs. Only
+**3** of the 19 stubs were ever called (two `environ_*`, one other), all
+harmlessly returning 0. The runtime does not need the glue for this workload.
+
+### R2 — shared-memory link: PASS
+
+`module2.wat` (1,080 bytes assembled, via `wabt@1.0.39` already in the repo)
+imports QuickJS's memory *object* and 12 of its C-API exports, and does real
+work over the shared heap:
+
+```wat
+(import "qjs" "memory" (memory 0))
+(import "qjs" "malloc"          (func $malloc (param i32) (result i32)))
+(import "qjs" "QTS_Eval"        (func $eval (param i32 i32 i32 i32 i32 i32) (result i32)))
+(import "qjs" "QTS_GetFloat64"  (func $getf64 (param i32 i32) (result f64)))
+...
+(data $d_code "40+2")                      ;; PASSIVE segment
+(func $lit_code (result i32) (local $p i32)
+  (local.set $p (call $malloc (i32.const 5)))          ;; QuickJS's allocator
+  (memory.init $d_code (local.get $p) (i32.const 0) (i32.const 4))
+  (i32.store8 offset=4 (local.get $p) (i32.const 0)) (local.get $p))
+```
+
+The **passive** data segment + `memory.init` into a `malloc`-returned pointer is
+the load-bearing idiom: module 2 must never pick an absolute address in a heap
+it does not own. An *active* data segment would have written at a link-time
+offset straight through QuickJS's static data.
+
+Result: `r2_roundtrip(ctx)` → **42** — module 2 authored the source bytes,
+called `JS_Eval`, and read the f64 back, with zero JS in the data path.
+
+### R3 — object identity: PASS
+
+`r3_identity(ctx)` returns `x*10 + identity_bit`; measured **411.0**, i.e.
+`x === 41` **and** `IsEqual(o, globalThis.c) === 1`. The sequence, entirely from
+module 2:
+
+1. `QTS_NewObject(ctx)` → `o`; publish as `globalThis.o` via `QTS_SetProp`
+   (handing it `QTS_DupValuePointer(o)` — `SetProp` consumes a reference).
+2. `JS_Eval("globalThis.o.x = 41; globalThis.c = globalThis.o;")`.
+3. `QTS_GetProp(o, "x")` **through module 2's own handle** → 41. The mutation
+   made by eval'd code is visible on the handle module 2 has been holding since
+   step 1 — no copy, no marshalling.
+4. `QTS_IsEqual(o, globalThis.c, /*strict ===*/ 0)` → 1. Same object.
+
+Cross-checked from the JS side of the same heap:
+`typeof globalThis.o + ':' + globalThis.o.x + ':' + (globalThis.o === globalThis.c)`
+→ `object:41:true`.
+
+**This is the claim §"The idea" makes, and it holds.** The 2c objection
+(identity destroyed at the boundary) genuinely does dissolve when there is one
+heap.
+
+### R4 — measurements
+
+All on the 4-core container, Node 22 (V8), `@jitl/quickjs-wasmfile-release-sync`,
+median of 5–7 reps.
+
+**Size** (`node .tmp/spike-4236/r4-sizes.mjs`):
+
+| artifact | raw | gzip |
+| --- | ---: | ---: |
+| QuickJS release-sync | **503,134** | **233,588** |
+| QuickJS release-asyncify | 1,027,523 | 362,445 |
+| QuickJS debug-sync | 1,218,626 | 456,203 |
+| js2wasm `--target linear` (tiny2.ts) | 261 | 230 |
+| js2wasm `--target wasi` (tiny.ts, WasmGC) | 16,588 | 13,229 |
+| `module2.wasm` (spike stub) | 1,080 | 613 |
+
+The issue predicted **~+1.2 MB**; the real release-sync cost is **~503 KB raw /
+234 KB gzip** — 2.4× better. (The 1.2 MB figure matches the *debug* build.) That
+is with all intrinsics on — RegExp, Date, TypedArrays, Proxy, Promise, JSON —
+so a trimmed source build lands lower. Do not take the asyncify variant: it
+doubles the size and this design does not need it.
+
+**Cross-module call cost** — a trivial leaf export (`QTS_BuildIsDebug`, no
+args, no work), 20M iterations, with an identical call-free loop subtracted:
+
+| path | gross ns/iter | net call cost |
+| --- | ---: | ---: |
+| module 2 → QuickJS wasm | 2.2 | **1.86 ns** |
+| JS host → QuickJS wasm | 9.1 | **8.77 ns** |
+| (loop baseline, no call) | 0.31 | — |
+
+**The wasm→wasm trampoline is ~1.9 ns and is 4.7× cheaper than the JS host
+boundary.** For design purposes it is free: it is ~9% of one QuickJS property
+operation.
+
+**Realistic C-API op** — `QTS_GetProp` + `QTS_GetFloat64` +
+`QTS_FreeValuePointer` per iteration on a live object, 2M iterations:
+
+| driver | ns/iteration (3 calls) | ≈ per call |
+| --- | ---: | ---: |
+| module 2 → QuickJS | **62.1** | 20.7 |
+| JS host → QuickJS | 85.9 | 28.6 |
+
+wasm-driven is 1.38× faster on identical work. Note the *work* (atom lookup,
+property lookup, JSValue alloc/free) is ~11× the boundary — so **the tiering is
+not boundary-limited**. Its cost is set purely by how much of the program lands
+in the boxed tier, which is the design's own thesis and the reason the frontier
+analysis (tainted-alloc vs exotic-wrapper) is where the real risk lives.
+
+**The issue's 100k-loop eval workload**, parse + execute per call, 40 evals:
+
+| path | ms/eval | vs V8 |
+| --- | ---: | ---: |
+| Node/V8 indirect eval (this box) | **0.123** | 1× |
+| module 2 → `JS_Eval` (this spike) | **3.30–3.45** | ~27× |
+| JS host → `JS_Eval` (raw, glue-free) | 3.29–3.37 | ~27× |
+| quickjs-emscripten high-level API (recorded above) | 4.7 | 15×* |
+| js2wasm Phase-1 interpreter (#2928, recorded above) | 1857 | ~6000×* |
+
+\* the previously-recorded rows used a V8 baseline of 0.31 ms on a
+differently-loaded box; the ratios are not directly comparable across rows, the
+**absolute ms/eval column is**.
+
+Two results worth keeping:
+
+- **Driving `JS_Eval` from wasm costs nothing measurable** vs driving it from
+  JS (3.30–3.45 vs 3.29–3.37 ms — the two overlap across runs). The boxed tier
+  does not pay for being reached from compiled code.
+- The glue-free path is **4.7 → ~3.3 ms**, so `quickjs-emscripten`'s
+  `Lifetime`/handle bookkeeping is ~30% of the observed cost. A wasm-side
+  caller skips it entirely. The honest headline against the alternative:
+  **~3.3 ms vs the Phase-1 interpreter's 1857 ms is ~560×.**
+
+### R5 — what the real linear lane would need (no codegen written)
+
+Read `src/codegen-linear/{index.ts,runtime.ts,c-abi.ts}` and compiled through
+the real lane. Gaps, most-blocking first:
+
+1. **The linear lane emits ZERO imports — of any kind.** `grep -rE
+   "imports\.push|addImport" src/codegen-linear/` returns **nothing**, and a
+   compiled module confirms it (`--target linear` on a 3-function file →
+   261 bytes, `imports: []`). The C-API call sites this design needs would be
+   the *first* imports the lane has ever emitted. This is the largest single
+   gap.
+   - *Encouraging*: the index arithmetic is already parameterised —
+     `ctx.numImportFuncs` exists in `context.ts` and is used at
+     `index.ts:159/213/258/326/388/5186/5521`; it is merely hard-coded to `0` at
+     both entry points (`index.ts:144` and `index.ts:311`). So imports are
+     index-safe **provided they are added before codegen starts**. Do not
+     replicate the WasmGC lane's late `addUnionImports` index-shifting.
+2. **`c-abi.ts` is export-direction only.** `mapParamsToCabi` /
+   `mapResultToCabi` / `emitCabiWrappers` (c-abi.ts:106/169/217) describe *what
+   a C host can call in us*. There is no way to declare `extern JSValue*
+   JS_GetProperty(...)` and call it. The import direction — an extern-C
+   declaration table plus an opaque `JSValue*` handle type in the type system —
+   is new surface.
+3. **Memory ownership must be inverted or negotiated.**
+   `addRuntime` (`codegen-linear/runtime.ts:84-95`) unconditionally does
+   `mod.memories.push({ min: 1, max: 256 })` and exports it; verified in the
+   emitted wat: `(memory 1 256)`. `--target wasi` likewise self-defines
+   (`codegen/wasi.ts:127`). Neither can import one today.
+   - *Encouraging*: the topology already exists on the **WasmGC** side —
+     `--link node:fs` (#2633, `codegen/wasi.ts:97`) makes the user module
+     **import memory at index 0** from an already-instantiated provider, with
+     the user module declaring and exporting none. That is precisely the shape
+     needed here; it just has no analogue in `codegen-linear/`.
+   - Direction to prefer: QuickJS release-sync **imports** memory, so js2wasm
+     can keep ownership (define + export) and QuickJS imports it. That inverts
+     the gap in our favour — but see (4).
+4. **The bump arena and QuickJS's allocator cannot coexist unmodified.**
+   Measured in the shared memory (`r5-addrmap.mjs`): QuickJS's **first
+   `malloc()` returns 5,333,128 (0x516088)** — ~5.1 MiB of emscripten static
+   data + stack sits below it. js2wasm's linear `__heap_ptr` initialises to a
+   hard-coded **1024** (`tiny2.wat:3`), i.e. **5,332,104 bytes inside QuickJS's
+   region**. On top of that, `__malloc` emits its own `memory.grow`
+   (`tiny2.wat:35`) while emscripten grows via `emscripten_resize_heap`/sbrk
+   with its own `DYNAMICTOP` — two independent growers over one memory is a
+   corruption hazard, not a tuning issue. And `max 256` pages (16 MiB) is a hard
+   cap below what a QuickJS heap wants. The clean answer is the design's own:
+   **the boxed tier allocates from QuickJS's `malloc`**; the arena keeps only
+   the native tier and must be relocated above QuickJS's region (or made
+   dynamic).
+5. **No standalone (non-emscripten) QuickJS artifact exists.** The available
+   build imports `env.emscripten_date_now`, `env.emscripten_resize_heap`,
+   `env._mmap_js`, `env.__syscall_*` etc. alongside
+   `wasi_snapshot_preview1.*`. A WASI-lane deployment cannot satisfy `env.*`.
+   Blocked on R1(a) — needs a wasi-sdk source build.
+6. **Refcount discipline is a codegen obligation, and the spike already hit
+   it.** `QTS_SetProp` consumes a reference; the R3 probe only worked because it
+   passed `QTS_DupValuePointer(o)` and kept its own. Any lowering that emits
+   `SetProp`/`Call` must own this, per the issue's ABI rule.
+7. **Linear-lane coverage is thinner than the design assumes.** `--target
+   linear` on `return "n=" + n` fails wasm **validation**, not codegen:
+   `Compiling function #51:"greet" failed: f64.add[0] expected type f64, found
+   call of type i32` — a stack-type bug in the linear string-concat path. The
+   non-goal "no work while the linear lane's basic coverage is behind" is
+   accurate and this is a live instance of it.
+
+### Not established by this spike (deliberately)
+
+- Standalone/WASI linking with no JS in the loop (blocked, see R1(a)/R5#5).
+  **The JS in the R2/R3 wiring is only the instantiation harness** — it hands
+  the `Memory` object and the export table across — but a real WASI artifact
+  needs a wasi-sdk build to exist at all.
+- Cross-heap cycle leaks (QuickJS's cycle collector cannot see edges through
+  native memory) — untested, still an open acceptance criterion.
+- Tainted-allocation vs exotic-wrapper A/B on an eval-heavy fixture — untested.
+- The acorn/parse workload through the boxed tier — untested.
+- String story (`JSString` adoption vs boundary conversion) — untested.
+
+### Repro
+
+```bash
+cd <worktree>
+pnpm install --prefer-offline
+mkdir -p .tmp/spike-4236/qjs-pkg && cd .tmp/spike-4236/qjs-pkg
+npm install --no-save --prefix . quickjs-emscripten   # out-of-tree, never committed
+cd -
+node .tmp/spike-4236/r1-inspect.mjs                     # R1(b) memory-import + export surface
+node .tmp/spike-4236/r1-inspect.mjs .../quickjs-wasmfile-debug-sync/dist/emscripten-module.wasm
+node .tmp/spike-4236/build-module2.mjs                  # WAT -> module2.wasm via wabt
+node .tmp/spike-4236/r2a-jshost-smoke.mjs               # glue-free instantiation, JS_Eval -> 42
+node .tmp/spike-4236/r2r3-link.mjs                      # R2 -> 42, R3 -> 411
+node .tmp/spike-4236/r4-bench.mjs                       # trampoline + eval timings
+node .tmp/spike-4236/r4-sizes.mjs                       # raw/gzip table
+node .tmp/spike-4236/r5-addrmap.mjs                     # QuickJS heap base vs js2wasm arena
+node --import tsx src/cli.ts .tmp/spike-4236/tiny2.ts --target linear -o .tmp/spike-4236/out-linear
+node .tmp/spike-4236/r5-inspect-js2wasm.mjs .tmp/spike-4236/out-linear/tiny2.wasm
+```


### PR DESCRIPTION
## Description

Appends `## Spike findings (2026-08-08)` to #4236 — acceptance box 1 (the link/identity/measurement spike) executed, R1(b) through R5 complete. Headline results:

- **One-heap identity PROVEN** (R3): an object created via the C API from a second wasm module importing QuickJS's memory, mutated by `JS_Eval`'d code, reads back `x === 41` with `JS_IsEqual === 1` — same object, no copy, no marshalling wall.
- **The trampoline is free**: 1.86 ns per wasm→QuickJS call (vs 8.77 ns from the JS host), ~9% of one QuickJS property operation — the tiering is not boundary-limited.
- **`JS_Eval` through the raw C API: 3.3 ms** for the 100k-loop workload — ~560× faster than the #2928 Phase-1 interpreter (1857 ms) and 30% faster than quickjs-emscripten's high-level API (its `Lifetime` bookkeeping).
- **Size corrected**: QuickJS release-sync is 503 KB raw / 234 KB gzip — the issue's ~1.2 MB estimate matched the debug build (2.4× pessimistic).
- **R1(a) source build failed for sandbox reasons only** (no WASI sysroot; quickjs-ng repo proxy-gated) — recorded precisely; the next slice is "produce a wasi-sdk-built libquickjs in CI," not codegen.
- **R5 gap list for `codegen-linear`** (most-blocking first): zero import support today (though `numImportFuncs` plumbing exists and is index-safe if imports are added before codegen), export-only `c-abi.ts`, unconditional memory ownership (the `--link node:fs` provider topology on the WasmGC side is the precedent to port), allocator coexistence (answer: boxed tier allocates from QuickJS's malloc), refusal-grade thinness in linear string paths (a live wasm-validation bug on string concat is recorded).
- **Verdict: GO on the architecture, BLOCKED on the artifact.** Frontier analysis (tainted-alloc vs exotic wrappers) is where the remaining risk lives; cycles/strings/split-brain boxes stay open.

Docs-only: one issue-file edit. Probe scripts (WAT module, link harness, benchmarks) are restated inline in the findings so nothing dies with the gitignored worktree.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1RTKiL2tywvYQCTrFa1Yk)_