### PR TITLE
docs(#4236, #4237): no-regex/split-module QuickJS measurements + Irregexp bytecode-backend estimate

### DIFF
--- a/plan/issues/4236-linear-lane-quickjs-boxed-tier-exploration.md
+++ b/plan/issues/4236-linear-lane-quickjs-boxed-tier-exploration.md
@@ -1173,3 +1173,46 @@ regex-completeness option without adopting any of the boxed tier.
 9,896 gzip; with one regex literal 96,737 / 40,009 → **≈75.5 KB raw /
 ≈30 KB gzip marginal, duplicated in every regex-using binary**. The shared
 lre-only artifact is ~1.5× bigger once but breaks even at the second module.
+
+## Feature-subset builds + the split regex module (2026-08-08, measured)
+
+Two follow-up questions answered empirically on the slice-1 build env
+(scratchpad `noregex/`, reusing the pinned quickjs-ng v0.16.1 objects):
+
+**QuickJS builds without regex — intrinsics are runtime-modular.**
+`JS_NewContextRaw` + per-intrinsic adders (13: BaseObjects, Date, Eval,
+RegExp(+Compiler), JSON, Proxy, MapSet, TypedArrays, Promise, BigInt,
+WeakRef, DOMException, AToB); skip an adder and `--gc-sections` strips its
+code. Shim variant calling every adder except RegExp: **933,497 raw /
+316,778 gzip vs 1,037,624 / 359,899 full** (−104 KB raw / −43 KB gzip).
+Probe green — eval/JSON/Promise/async/MapSet/BigInt/TypedArray all work;
+`/a/` → `SyntaxError: RegExp are not supported`, `new RegExp` →
+`ReferenceError`. This is the general knob for trimming the boxed-tier
+engine to what the frontier actually needs.
+
+**libregexp links as a SEPARATE wasm module — built and proven.** Core with
+the RegExp builtin ON, engine imported cross-module:
+
+- Seam: 7 functions core→regex (`lre_compile`, `lre_exec`, 5 bytecode
+  accessors) and shared memory + 3 hooks regex→core (`lre_realloc`,
+  `lre_check_stack_overflow`, `lre_check_timeout`). Sizes: core 966,775 raw
+  / 326,254 gzip; regex module 114,284 / 52,636 (libunicode rides along —
+  data symbols cannot cross wasm module boundaries).
+- Functional through the seam: `exec` captures, named groups,
+  `String.replace`/`split` with regex, `/u` flag, negatives.
+- Wrinkle 1: wasm-ld-18 SEGFAULTS on `--wrap` + `--import-undefined`; the
+  working cut is preprocessor renames (`-Dlre_compile=…_local_unused`) on
+  the core's libregexp compile plus a 7-thunk import file.
+- Wrinkle 2: the core's LEXER uses libregexp's `lre_parse_escape` + an ident
+  **data** table — those ~2 KB stay in core; the cut is at the engine entry
+  points, not the file boundary.
+- Wrinkle 3 (the real productization work): the probe parks the regex
+  module's static data at a fixed 14 MB `--global-base` and late-binds the
+  circular imports with harness closures — production needs the same
+  memory-region coordination as the slice-1 allocator-collision finding.
+
+Payoff: ONE shared regex module can serve BOTH lanes — the GC lane binds it
+directly (the lre-only artifact recorded above is the same class of build),
+the linear lane's core imports it, and non-regex users load neither. The
+builtin-routing "delegate RegExp to QuickJS" row therefore does not force
+regex bytes into every deployment.

--- a/plan/issues/4237-compile-time-regex-specialization.md
+++ b/plan/issues/4237-compile-time-regex-specialization.md
@@ -138,3 +138,36 @@ on real corpora is high enough to matter.
 - Any change to the #4236 slice sequence; this issue is independent of the
   QuickJS boxed-tier adoption and merely shares the libregexp artifact
   option with it.
+
+## Path B staged estimate — and the bytecode-backend route (2026-08-08)
+
+Design update that supersedes the "~40-method C++ `RegExpMacroAssemblerWasm`"
+framing above: Irregexp already has TWO codegen backends — the native
+macro-assemblers and `RegExpBytecodeGenerator` (its interpreter bytecode).
+Since we only need Irregexp at BUILD time, use the bytecode backend
+unmodified and write the **bytecode → wasm translator in TypeScript inside
+js2wasm**. The bytecode is pattern-specialized linear code (~50 opcodes);
+the optimization passes (Boyer-Moore lookahead, quick checks) run before
+bytecode emission, so they are preserved. C++ work then reduces to making
+V8's `src/regexp` parser+compiler subset build standalone.
+
+| Stage | Work | Estimate |
+| --- | --- | --- |
+| Spike | vendor V8 `src/regexp` subset + SpiderMonkey-style shim (fake `Isolate`, `Zone`, strings, flags), emscripten → wasm blob the TS compiler calls at build time; compile one pattern, dump bytecode | days-to-a-week; go/no-go = "does the subset link standalone" |
+| MVP | TS bytecode→wasm translator (dispatch-loop lowering — `loop` + `br_table` over a state var — for the irreducible backtrack jumps), wired into both lanes' literal path, fallback-on-unsupported-flag; decline `\p{…}` in v1 (drags in ICU) | ≈ 1 budget window |
+| Coverage | `lastIndex`/`g`/`y`, capture materialization per lane, `match`/`replace`/`split`/`exec` routing, test262 `built-ins/RegExp` + differential fuzz vs native V8 | ≈ 1 window (shared with path A — not B-specific) |
+| Standing | pin a V8 revision; `src/regexp` churns faster than quickjs-ng, occasional real re-sync | ongoing, small |
+
+Total ≈ 2–3 windows to tested integration vs ≈ 1 window for path A; the
+spike front-loads nearly all uncertainty. Calibration: SpiderMonkey's 2020
+import was multi-month, but included runtime execution, GC integration, and
+JIT-tier bridging — all skipped here. Honest ceiling: the bytecode route
+keeps the node-network optimizations but loses native-emission peepholes,
+and the dispatch loop costs branch overhead vs fallthrough — target
+**5–10× on hot literal patterns**, not the full 18×; B's edge over A is
+correctness breadth (V8's parser + case-folding tables), not extra speed.
+
+Fallback-engine note: the split-module proof in #4236 ("Feature-subset
+builds + the split regex module") means the decline path can be the ONE
+shared libregexp module serving both lanes — the specializer never has to
+carry a per-module generic engine.


### PR DESCRIPTION
## Description

Docs-only follow-up to #4244, recording today's measured findings in the two exploration issues.

**#4236 — feature-subset builds + the split regex module.** QuickJS intrinsics are runtime-modular (`JS_NewContextRaw` + 13 adders); a no-RegExp build of the slice-1 artifact measures **933,497 raw / 316,778 gzip** (−104 KB / −43 KB vs full), probe green with RegExp cleanly absent. And libregexp links as a **separate wasm module**: 7-function seam core→regex, shared memory + 3 hooks back, with captures/named-groups/`replace`/`split`/`/u` all working through it (core 966,775 / 326,254; regex module 114,284 / 52,636). Recorded wrinkles: wasm-ld-18 segfaults on `--wrap` (preprocessor renames + a thunk file instead), the core lexer's libregexp *data* symbols stay in core, and the fixed `--global-base` + late-bound circular imports mark the memory-region coordination as the real productization work. Payoff: one shared regex module can serve both lanes.

**#4237 — path B reframed and staged.** Irregexp's existing `RegExpBytecodeGenerator` backend replaces the hypothetical C++ `RegExpMacroAssemblerWasm`: the wasm backend becomes a **TypeScript bytecode→wasm translator** (~50 opcodes, dispatch-loop lowering for backtrack jumps), and the C++ work shrinks to building V8's `src/regexp` subset standalone behind a SpiderMonkey-style shim that runs only at compile time. Staged estimate: spike days-to-a-week, MVP ≈ 1 budget window, coverage ≈ 1 window (shared with path A), small standing V8-pin sync cost — total ≈ 2–3 windows vs ≈ 1 for path A, with a realistic 5–10× target on hot literals.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1RTKiL2tywvYQCTrFa1Yk)_