### PR TITLE
docs(#4254): floor breaches land on the wrong PR after unmeasured queue crossings

### DIFF
--- a/plan/issues/4254-unmeasured-merge-group-runs-defer-floor-breaches.md
+++ b/plan/issues/4254-unmeasured-merge-group-runs-defer-floor-breaches.md
@@ -1,0 +1,67 @@
+---
+id: 4254
+title: "merge_group runs that skip the shard matrix defer floor breaches onto the NEXT measuring PR — attribution lands on the wrong doorstep by design"
+status: ready
+created: 2026-08-09
+updated: 2026-08-09
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: ci
+language_feature: n/a
+goal: dogfood
+related: [2097, 2879, 2547, 4239]
+origin: "2026-08-09 PR #4252 park diagnosis: three consecutive merge_group runs (pr-4251/4253/4254) reported SHARDS_RAN: false — never measured — so main's −17 drift plus the candidate's −103 arrived as one −120 breach on the first PR whose run DID measure"
+---
+
+# #4254 — unmeasured queue crossings make the floor fire on the wrong PR
+
+## Problem
+
+Not every `merge_group` run measures conformance: runs where the shard matrix
+is skipped (docs-only diffs, path-filtered changes) report `SHARDS_RAN: false`
+and publish green without a standalone pass count. The #2097/#2879 high-water
+floor therefore only fires on the next run that DOES measure — which receives
+the accumulated drift of every unmeasured merge since the last measurement,
+attributed to the one candidate on whose doorstep it lands.
+
+Observed 2026-08-09 (PR #4252's park): the mark stood at 28,939; main's last
+MEASURED run (bb5566798, 20:33Z) was already at 28,922 (−17); three
+intervening merges crossed unmeasured; PR #4252's run then breached at 28,819
+and the bot parked it for the full −120, of which −103 was genuinely its own.
+The diagnosis could separate the two only because the compiler diff between
+the last measured main and the candidate's base happened to be EMPTY — with
+any real interleaved code merge, the attribution would have required manual
+archaeology under a bot hold.
+
+Two failure modes this enables:
+
+1. **Wrong-doorstep parks**: a clean PR that merely follows an unmeasured
+   regressing merge gets parked for someone else's drop and must prove its
+   innocence from artifacts.
+2. **Tolerance consumption**: drift accumulated across unmeasured crossings
+   eats the ±50 tolerance silently, so the floor's effective budget for the
+   measuring candidate shrinks by however much slipped through unmeasured.
+
+## What this is NOT
+
+Not a claim that the skips are wrong — docs-only merges skipping a ~40-min
+shard matrix is correct economics. The gap is that the floor's ERROR MESSAGE
+and the park comment attribute the whole delta to the candidate, and nothing
+records "N merges crossed unmeasured since the last mark-relevant
+measurement."
+
+## Acceptance
+
+- [ ] The floor-breach error message reports the last MEASURED main value and
+      its sha alongside the mark (e.g. "mark 28,939 @ 83a1202; last measured
+      main 28,922 @ bb55667; candidate 28,819 ⇒ ≤ −103 attributable to this
+      candidate"), so a parked PR's owner starts with the split instead of
+      deriving it.
+- [ ] The auto-park comment includes the count of unmeasured merge_group
+      crossings since the last measured run.
+- [ ] Optional, decide at implementation time: a scheduled measured run on
+      main (or promote-time re-measure) when K consecutive crossings were
+      unmeasured, so drift cannot accumulate unboundedly between
+      measurements.

--- a/plan/issues/4255-standalone-chained-ctor-method-field-wrong-value.md
+++ b/plan/issues/4255-standalone-chained-ctor-method-field-wrong-value.md
@@ -1,0 +1,62 @@
+---
+id: 4255
+title: "standalone: a field read through a chained ctor→method→field expression returns a wrong value (−1) — pre-existing on main, flag-independent"
+status: ready
+created: 2026-08-09
+updated: 2026-08-09
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: classes, objects
+goal: core-semantics
+related: [743, 4246]
+origin: "Surfaced 2026-08-09 while building PR #4246's E2E for the #743 Parser.pos program; reproduced flag-OFF on unmodified main's emission — pre-existing, not #4246's. Recorded only in the lane's report until this filing."
+---
+
+# #4255 — chained `new P(7).tok().s` answers −1 in standalone
+
+## Problem
+
+A chained expression that constructs a fnctor instance, calls a method on it
+returning a second object, and reads a field off that result —
+
+```js
+function P(n){ this.pos = n }
+P.prototype.tok = function(){ return new Token(this) }
+function Token(p){ this.s = p.start }   // shape per the acorn-derived fixture
+new P(7).tok().s
+```
+
+— returns **−1** in the standalone lane where native JS returns the real
+field value. Reproduced on **unmodified main with every #743-family flag
+off**: this is a pre-existing emission defect, independent of the value-flow
+work that surfaced it.
+
+The exact pinned fixture lives in `tests/issue-743-pos-value-flow.test.ts`
+(PR #4246), whose E2E deliberately pins only flag-on ≡ flag-off (family
+precedent) — i.e. the pin currently ENSHRINES the wrong value equally on both
+sides rather than asserting the spec answer. Start there: promote that pin to
+the native answer as part of the fix.
+
+## Why −1 is suspicious in itself
+
+−1 is a known sentinel in the string/search helpers and in uninitialized
+i32 slots. A chained receiver (the method's fresh return value, never bound
+to a local) plausibly takes a different dispatch/marshal path than a
+named-binding receiver — compare against the same expression split into
+temporaries (`var p = new P(7); var t = p.tok(); t.s`), which the #4246 lane
+implied works (the census movers were measured through named bindings).
+Whether the wrong value comes from a missed field init, a sentinel leaking
+from a helper, or a receiver-representation mismatch on the unnamed
+temporary is the first thing to establish.
+
+## Acceptance
+
+- [ ] Minimal repro pinned with the NATIVE answer (not lane-equality) in a
+      test that fails on today's main.
+- [ ] The chained and temporary-split spellings of the same expression agree
+      with native for f64, i32, string, and ref-typed fields.
+- [ ] The #4246 E2E's lane-equality pin upgraded to the spec answer once
+      fixed.


### PR DESCRIPTION
Files the systemic finding from PR #4252's park diagnosis: merge_group runs that skip the shard matrix (SHARDS_RAN: false) defer floor accounting onto the next measuring PR, which inherits accumulated drift attributed as its own. Acceptance criteria make the breach message self-attributing and count unmeasured crossings in the park comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAPpV5PjTA98gW2Tjqhrki