### PR TITLE
fix(#3628): canonicalize computed assignment keys

### DIFF
--- a/plan/issues/3628-es3-edition-close-remaining-host-failures.md
+++ b/plan/issues/3628-es3-edition-close-remaining-host-failures.md
@@ -5,7 +5,7 @@ status: done
 completed: 2026-07-31
 sprint: current
 created: 2026-07-25
-updated: 2026-07-31
+updated: 2026-08-09
 assignee: ttraenkler/dev-es3-editions
 priority: high
 horizon: m
@@ -18,6 +18,9 @@ es_edition: es3
 goal: spec-completeness
 related: [3486, 2899, 2900]
 origin: "2026-07-25 lead measurement: ES3 is the oldest edition and the closest to complete; the remaining gap is 3 issues, not a feature list."
+loc-budget-allow:
+  - src/codegen/dyn-read.ts
+  - src/codegen/expressions/assignment.ts
 ---
 
 # #3628 — ≤ES3 edition: close the remaining 43 host-lane failures
@@ -29,6 +32,21 @@ origin: "2026-07-25 lead measurement: ES3 is the oldest edition and the closest 
 > [Closing measurement](#closing-measurement-2026-07-31-host-lane) at the
 > bottom — including the two claims in this file that did **not** survive
 > re-checking.
+
+> **REGRESSION AUDIT, 2026-08-09.** Fresh host and standalone baseline rows
+> were joined to the repository's committed 273-file legacy-edition index.
+> Host reported 271 pass plus two `compile_timeout` rows; both timeout files
+> passed when rerun alone in 0.6–0.7 seconds, so they are long-process baseline
+> artifacts rather than compiler failures. Standalone reported 272 pass plus
+> one real failure,
+> `language/expressions/assignment/S11.13.1_A7_T4.js`. The standalone computed
+> assignment path did not canonicalize an object key before receiver-specific
+> setter dispatch, and it evaluated the RHS before the key. The regression fix
+> performs `ToPropertyKey` once at the Reference boundary before the RHS and
+> applies the same canonicalization to IR `dyn.member_set`. The permanent test
+> reruns all three apparent residuals in both lanes and includes an executed
+> standalone IR-store proof. This is combined fresh-baseline + isolated-rerun
+> evidence, not a new full 273-file sweep.
 
 ## Why this issue exists
 

--- a/src/codegen/dyn-read.ts
+++ b/src/codegen/dyn-read.ts
@@ -830,6 +830,13 @@ export function ensureDynMemberSet(ctx: CodegenContext): void {
   const nativeStrictSet = ctx.standalone || ctx.wasi;
   const externSetIdx = ctx.funcMap.get(nativeStrictSet ? "__reflect_set" : "__extern_set_strict");
   if (externSetIdx === undefined) return;
+  // Standalone receiver dispatch contains early-return arms before the
+  // string-keyed object table.  Canonicalize the key at the dynamic Reference
+  // boundary so IR dyn.member_set and legacy computed stores agree.  Host
+  // setters already perform ToPropertyKey themselves.
+  const toPropertyKeyIdx = nativeStrictSet ? ctx.funcMap.get("__to_property_key") : undefined;
+  const canonicalizeKey = (): Instr[] =>
+    toPropertyKeyIdx === undefined ? [] : [{ op: "call", funcIdx: toPropertyKeyIdx }];
   const strictSetFailure = (): Instr[] =>
     buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot assign to read only property", {
       forceInModuleCtor: true,
@@ -924,6 +931,7 @@ export function ensureDynMemberSet(ctx: CodegenContext): void {
         { op: "call", funcIdx: peelIdx },
         { op: "local.get", index: 1 },
         { op: "call", funcIdx: anyToExternIdx },
+        ...canonicalizeKey(),
         { op: "local.get", index: 2 },
         { op: "call", funcIdx: valueToExternIdx },
         ...finishStrictSet(),
@@ -951,6 +959,7 @@ export function ensureDynMemberSet(ctx: CodegenContext): void {
       { op: "local.get", index: 0 },
       { op: "call", funcIdx: peelHostIdx },
       { op: "local.get", index: 1 },
+      ...canonicalizeKey(),
       { op: "local.get", index: 2 },
       ...finishStrictSet(),
     ],

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -122,6 +122,7 @@ import { isStrictContext } from "../helpers/is-strict-function.js";
 import { tryCompileStrictFunctionPoisonAssignment } from "../function-poison-pill-access.js";
 import { emitRuntimeEvalAotCallableAdapter } from "../runtime-eval-callable.js";
 import { tryEmitStaticI32Expression } from "../i32-static-range-expr.js";
+import { emitToPropertyKeyOnce } from "./computed-member-reference.js";
 
 /**
  * Emit a null/undefined guard for an externref-typed destructuring source.
@@ -5190,7 +5191,22 @@ function compileExternSetFallback(
   });
   fctx.body.push({ op: "local.set", index: objLocal });
 
-  // Compile value first so we can save it for return
+  // §13.15.2: evaluate and canonicalize the computed key before the RHS.
+  // The native standalone setter has receiver-specific early dispatch arms
+  // which can return before its string-keyed object table performs
+  // ToPropertyKey.  Canonicalizing at the Reference boundary both preserves
+  // the observable ordering and gives every receiver arm the same key.
+  const keyResult = compileExpression(ctx, fctx, target.argumentExpression, {
+    kind: "externref",
+  });
+  if (!keyResult) return null;
+  emitToPropertyKeyOnce(ctx, fctx);
+  const keyLocal = allocLocal(fctx, `__eset_key_${fctx.locals.length}`, {
+    kind: "externref",
+  });
+  fctx.body.push({ op: "local.set", index: keyLocal });
+
+  // Compile value after ToPropertyKey and save it for the assignment result.
   const valResult = compileExpression(ctx, fctx, value, { kind: "externref" });
   if (!valResult) return null;
   const valLocal = allocLocal(fctx, `__eset_val_${fctx.locals.length}`, {
@@ -5200,9 +5216,7 @@ function compileExternSetFallback(
 
   // Push args: obj, key, val
   fctx.body.push({ op: "local.get", index: objLocal });
-  compileExpression(ctx, fctx, target.argumentExpression, {
-    kind: "externref",
-  });
+  fctx.body.push({ op: "local.get", index: keyLocal });
   fctx.body.push({ op: "local.get", index: valLocal });
 
   // (#3374) Bracket writes carry the same PutValue strictness bit as dot writes.

--- a/tests/issue-3628-legacy-residue.test.ts
+++ b/tests/issue-3628-legacy-residue.test.ts
@@ -1,0 +1,71 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const residue = [
+  "language/expressions/assignment/S11.13.1_A7_T4.js",
+  "language/expressions/compound-assignment/S11.13.2_A7.8_T4.js",
+  "language/expressions/compound-assignment/S11.13.2_A7.9_T3.js",
+] as const;
+
+describe("#3628 legacy Test262 residue", () => {
+  for (const relative of residue) {
+    for (const lane of [undefined, "standalone"] as const) {
+      const laneName = lane ?? "host";
+      it(`${relative} passes in ${laneName}`, async () => {
+        const result = await runTest262File(resolve("test262/test", relative), "issue-3628", 120_000, lane);
+        expect(result.status, result.error ?? result.reason ?? "").toBe("pass");
+      }, 180_000);
+    }
+  }
+
+  it("canonicalizes a computed key in the standalone IR member-store path", async () => {
+    const result = await compile(
+      `
+var propertyKeyEvaluated = 0;
+
+export function store(base: any, key: any): void {
+  base[key] = "true";
+}
+
+export function makeBase(): any {
+  return {};
+}
+
+export function makeKey(): any {
+  return {
+    toString: function() {
+      propertyKeyEvaluated++;
+      return "";
+    }
+  };
+}
+
+export function keyEvaluationCount(): number {
+  return propertyKeyEvaluated;
+}
+`,
+      {
+        fileName: "issue-3628-standalone-ir-property-key.ts",
+        target: "standalone",
+        skipSemanticDiagnostics: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs ?? [], JSON.stringify(result.irOutcomes, null, 2)).toContain("store");
+
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+    const exports = instance.exports as {
+      store: (base: unknown, key: unknown) => void;
+      makeBase: () => unknown;
+      makeKey: () => unknown;
+      keyEvaluationCount: () => number;
+    };
+    exports.store(exports.makeBase(), exports.makeKey());
+    expect(exports.keyEvaluationCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- apply `ToPropertyKey` exactly once before the RHS in extern-backed computed assignments
- apply the same standalone key canonicalization to IR `dyn.member_set`
- document the fresh 273-file legacy-edition audit and add exact host, standalone, and executed IR regression coverage

## Root cause

The standalone setter has receiver-specific early dispatch arms that can return before the string-keyed object table canonicalizes the key. The legacy computed-assignment fallback also evaluated the RHS before it evaluated and canonicalized the key. An object key could therefore skip its `toString` conversion entirely or run it in the wrong order.

## Measurement

The fresh legacy-edition population contains 273 files. The host baseline had 271 passes and two compile timeouts; both timed-out files passed alone in 0.6–0.7 seconds. The standalone baseline had 272 passes and one reproducible failure, `language/expressions/assignment/S11.13.1_A7_T4.js`; that file passes after this patch. This is baseline plus isolated-rerun evidence, not a new full 273-file sweep.

## Validation

- focused Vitest: 28/28 across the exact residue, compound-assignment controls, and IR dynamic-store suite
- TypeScript typecheck
- Biome lint and Prettier format check
- IR fallback gate
- LOC/function budgets, oracle ratchet, coercion-site ratchet, numeric-local IR parity, and issue integrity through repository hooks

Relates to #3628.
