### PR TITLE
perf: close V8 gaps in host calls and native strings

### DIFF
--- a/benchmarks/suites/dom.ts
+++ b/benchmarks/suites/dom.ts
@@ -98,7 +98,7 @@ function setAttributes(): void {
   }
 }
 
-function readAttributes(): void {
+function readAttributes(): number {
   const elements: MockElement[] = [];
   for (let i = 0; i < 1000; i++) {
     const el = mockDoc.createElement("div");
@@ -107,17 +107,16 @@ function readAttributes(): void {
   }
   let count = 0;
   for (const el of elements) {
-    if (el.getAttribute("data-value") !== null) count++;
+    const v = el.getAttribute("data-value");
+    if (v !== null && v.length > 0) count++;
   }
+  return count;
 }
 
 function modifyText(): void {
-  const elements: MockElement[] = [];
-  for (let i = 0; i < 1000; i++) elements.push(mockDoc.createElement("span"));
-  for (let round = 0; round < 10; round++) {
-    for (const el of elements) {
-      el.textContent = "updated content " + round;
-    }
+  for (let i = 0; i < 1000; i++) {
+    const el = mockDoc.createElement("span");
+    el.textContent = "updated content";
   }
 }
 
@@ -193,7 +192,7 @@ declare class Document {
 }
 declare class Element {
   setAttribute(name: string, value: string): void;
-  getAttribute(name: string): string;
+  getAttribute(name: string): string | null;
 }
 declare const document: Document;
 
@@ -203,7 +202,7 @@ export function run(): number {
     const el = document.createElement("div");
     el.setAttribute("data-value", "test");
     const v = el.getAttribute("data-value");
-    if (v.length > 0) count = count + 1;
+    if (v !== null && v.length > 0) count = count + 1;
   }
   return count;
 }`,
@@ -214,7 +213,8 @@ export function run(): number {
   {
     name: "dom/modify-text",
     iterations: 100,
-    // 1000 createElement + 1000 textContent writes.
+    // 1000 createElement + 1000 textContent writes, matching the JS baseline
+    // above.
     opsPerCall: 2000,
     source: `
 declare class Document {

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -2363,10 +2363,10 @@ export function compileStringIntegerArg(
     fctx.body.push({ op: "i32.const", value: 0 });
     return;
   }
-  // #2600 — the index/position is `ToIntegerOrInfinity(arg)` = truncate-toward-
-  // zero of `ToNumber(arg)` (§7.1.5), NOT a direct i32 coercion. In standalone
-  // a fast i32 coercion of a fractional / non-numeric-typed position
-  // (`"1.9"`, `{valueOf(){…}}`, `true`) resolves to a wrong index. Route the
+  // Range-proven integer positions avoid the f64 ToInteger lowering.
+  if (tryEmitStaticI32Expression(ctx, fctx, arg)) return;
+  // #2600 — the index/position is `ToIntegerOrInfinity(arg)` = truncate-toward-zero of `ToNumber(arg)` (§7.1.5), NOT a direct i32 coercion. In standalone
+  // a fast i32 coercion of a fractional / non-numeric-typed position (`"1.9"`, `{valueOf(){…}}`, `true`) resolves to a wrong index. Route the
   // arg through the existing numeric coercion engine to f64 (string →
   // `__str_to_number`, object → ToPrimitive("number") — both already present
   // for `+str` / `Number(x)`), then apply ToIntegerOrInfinity (NaN → 0, then

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -9682,7 +9682,7 @@ assert._isSameValue = isSameValue;
           return Number(v);
         };
         return (obj: any) => {
-          if (obj == null) return 0;
+          if (obj == null || Array.isArray(obj)) return obj == null ? 0 : obj.length;
           // Reading .length on an opaque wasmGC struct throws — resolve through
           // the #1629-safe own-descriptor reader (#983 sidecar + vec live length
           // + shape-gated struct field), then the inherited chain.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -16079,7 +16079,7 @@ export function buildImports(
         fn = function (this: any) {
           guardEnter();
           try {
-            return original.call(this);
+            return original();
           } catch (e) {
             lastCaughtException = e;
             throw e;
@@ -16091,7 +16091,7 @@ export function buildImports(
         fn = function (this: any, a: any) {
           guardEnter();
           try {
-            return original.call(this, a);
+            return original(a);
           } catch (e) {
             lastCaughtException = e;
             throw e;
@@ -16103,7 +16103,7 @@ export function buildImports(
         fn = function (this: any, a: any, b: any) {
           guardEnter();
           try {
-            return original.call(this, a, b);
+            return original(a, b);
           } catch (e) {
             lastCaughtException = e;
             throw e;
@@ -16115,7 +16115,7 @@ export function buildImports(
         fn = function (this: any, a: any, b: any, c: any) {
           guardEnter();
           try {
-            return original.call(this, a, b, c);
+            return original(a, b, c);
           } catch (e) {
             lastCaughtException = e;
             throw e;
@@ -16127,7 +16127,7 @@ export function buildImports(
         fn = function (this: any, a: any, b: any, c: any, d: any) {
           guardEnter();
           try {
-            return original.call(this, a, b, c, d);
+            return original(a, b, c, d);
           } catch (e) {
             lastCaughtException = e;
             throw e;

--- a/tests/host-import-wrapper-arity.test.ts
+++ b/tests/host-import-wrapper-arity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildImports, compile, instantiateWasm } from "../src/index.js";
+
+/**
+ * The import guard uses fixed-arity wrappers for compiler-produced manifests.
+ * Keep a host method whose result depends on its receiver so the wrapper cannot
+ * accidentally replace the explicit `self` argument with the wrapper's JS
+ * `this` value.
+ */
+class StatefulElement {
+  readonly base = 41;
+
+  read(): number {
+    return this.base + 1;
+  }
+}
+
+class StatefulDocument {
+  createElement(_tag: string): StatefulElement {
+    return new StatefulElement();
+  }
+}
+
+describe("fixed-arity host import wrappers", () => {
+  it("preserves extern-class method receiver binding", async () => {
+    const result = await compile(`
+      declare class Document {
+        createElement(tag: string): Element;
+      }
+      declare class Element {
+        read(): number;
+      }
+      declare const document: Document;
+
+      export function test(): number {
+        return document.createElement("div").read();
+      }
+    `);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+
+    const doc = new StatefulDocument();
+    const imports = buildImports(
+      result.imports,
+      { Document: StatefulDocument, Element: StatefulElement, document: doc },
+      result.stringPool,
+    );
+    const { instance } = await instantiateWasm(result.binary, imports.env, imports.string_constants);
+    imports.setInstance?.(instance);
+    expect((instance.exports as { test: () => number }).test()).toBe(42);
+  });
+});

--- a/tests/native-strings.test.ts
+++ b/tests/native-strings.test.ts
@@ -291,6 +291,25 @@ describe("fast mode: native strings", () => {
     expect(await runFast(src)).toBe(3);
   });
 
+  it("preserves search-position coercion outside the proven i32 range", async () => {
+    const src = `export function test(): number {
+      const s = "0123456789";
+      let result = 0;
+      for (let i = 0; i < 4; i++) {
+        result += s.indexOf("0", i - 2);
+      }
+      result += s.indexOf("3", 2.9);
+      result += s.indexOf("9", 2147483648);
+      result += s.includes("3", 2.9) ? 1000 : 0;
+      result += s.includes("0", -1) ? 10000 : 0;
+      result += s.includes("9", 2147483648) ? 100000 : 0;
+      return result;
+    }`;
+    // The loop exercises a proven i32 expression that produces negative
+    // positions; the literals cover fractional and out-of-range ToInteger.
+    expect(await runFast(src)).toBe(11001);
+  });
+
   it("indexOf empty string", async () => {
     const src = `export function test(): number {
       return "hello".indexOf("");


### PR DESCRIPTION
## Summary

- Keep statically proven integer string search positions in i32 arithmetic, avoiding the generic f64 remainder/coercion path for counted-loop positions.
- Remove redundant `Function.prototype.call` binding from fixed-arity compiler-generated host import guards while preserving explicit extern-class receiver arguments.
- Make the DOM host benchmarks equivalent between the JS and Wasm implementations so the comparison measures the same work.

## Measurements

All measurements used the local Node v24.4.1 arm64 benchmark harness with 50 calibrated iterations and 1,000 string operations per call.

- `string/indexOf` gc-native: candidate 7.748 / 7.816 / 7.829 ns/op across three runs; the block-removed base was 11.544 / 17.985 / 12.245 ns/op.
- `string/includes` gc-native: candidate 9.829 / 7.812 / 10.288 ns/op; base 13.780 / 12.160 / 20.618 ns/op.
- `dom/set-attributes` host-call median: 0.106916 ms → 0.078625 ms. A direct-environment control stayed flat at about 0.059 ms, isolating the wrapper dispatch overhead.
- `mixed/csv-parse` host-call median: 3.518 ms → 2.884 ms (~18%) after fast-pathing ordinary host-array lengths; gc-native was already about 0.25× JS on the same fresh run.

The array/map-filter lane is already faster than V8 in the published data. The matrix benchmark remains on a legacy fallback path; its current WAT already uses native numeric arrays, and a sound cache would require broader alias/mutation invalidation machinery, so no speculative change is included here.

## Correctness and verification

- Added receiver-binding coverage for fixed-arity host wrappers.
- Added native-string coercion coverage for negative, fractional, and out-of-range search positions.
- Corrected DOM JS baselines (read null handling and modify-text work) to match the Wasm workload.
- `pnpm exec vitest run tests/host-import-wrapper-arity.test.ts tests/native-strings.test.ts` (93 passed)
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:issues`
- Prettier, diff checks, and commit-time LOC/function/oracle gates

The existing four `dom-containment` failures and three `issue-3201-inherited-length` failures reproduce on the unchanged base and are unrelated to this PR.
