### PR TITLE
test(#4253): un-rot the two root tests that were red on main

### DIFF
--- a/plan/issues/4253-latent-red-root-tests-invisible-until-touched.md
+++ b/plan/issues/4253-latent-red-root-tests-invisible-until-touched.md
@@ -51,13 +51,65 @@ work:
   *"keeps constructor off the instance's enumerable own keys"*
   → `expected +0 to be 1`
 
-These are left unfixed deliberately: each is an unrelated behavioural question
-(has the proven-receiver inline path stopped firing? is `$$constructor` now
-enumerable?), and fixing them inside an unrelated PR would pull them into that
-PR's `#3008` gate and hide the diagnosis. **Each needs its own look — the
-assertion may be stale like the two above, or it may be a real regression.**
-Do not assume stale; the `#3617` one in particular reads like a real
-enumerability change.
+These were left unfixed in the PR that found them: each is an unrelated
+behavioural question, and fixing them inside an unrelated PR would pull them
+into that PR's `#3008` gate and hide the diagnosis.
+
+### TRIAGED 2026-08-09 — both STALE PINS, neither a real defect
+
+Diagnosed on pristine `upstream/main` @ `49cab5c82`. **Both suspicions above
+were wrong, and both for the same structural reason: each test compared a
+single SCALAR — a length, a boolean — that two very different causes could
+produce.** A pin that cannot distinguish "the thing I guard broke" from "the
+thing I guard got better" is not a guard.
+
+**`tests/issue-3617.test.ts` — NOT an enumerability regression.** Probed:
+
+| probe | value | meaning |
+| --- | ---: | --- |
+| `Object.keys(new DummyError("boom")).length` | 1 | node/spec says `["message"]` — correct |
+| `hasOwnProperty("constructor")` | 0 | the invariant the test is NAMED for still holds |
+| `hasOwnProperty("message")` | 1 | |
+| `Object.keys(new Empty()).length` | 0 | no leak on a field-less instance |
+| `value.constructor === DummyError` | 1 | back-pointer intact |
+
+`constructor` never leaked. The pin asserted `length === 0`, which pinned the
+BUG — closed fnctor source fields were not surfaced at all, so `message` was
+missing too. Its own comment admitted this ("pin the zero-key baseline").
+`23fcac402` **fix(#3920): standalone reflection over closed structs enumerated
+nothing** made reflection work, `message` correctly appeared, and the stale pin
+went red *looking like* a leak.
+
+**`tests/issue-3685-presence-tracked-proven-reads.test.ts` — a stale FIXTURE,
+and the machinery is intact.** The census showed all four `n.label` reads
+declining `nofield:Node.label`, and the struct said why — `label` is not a
+field. `$__fnctor_Node` is now `(start, type, $$presence_0, $$constructor,
+$$shape, $$resid)`: `500c4f99b` **feat(standalone): instance expando substrate
+(#4194)** routes a field first written from OUTSIDE the constructor into the
+`$$resid` bag, so the fixture stopped producing the shape it was written for.
+
+"The #3685 S2 slice is dead code" would have been a real finding (the slice was
+built for ~156 acorn sites), so it was checked rather than assumed. Positive
+control — conditionally assigned INSIDE the ctor from an UNTYPED param:
+
+```
+(field $label (mut externref)) (field $$presence_0 (mut i32))
+proven=5 inlined=5    4x  ok:Node.label:externref:presence
+```
+
+That is the exact key the file has always asserted: neither the machinery nor
+the census format moved.
+
+**Neither is test262-visible.** Semantics matched plain JavaScript in every
+configuration probed, for both files — so neither contributes to main's floor
+drift, and neither needs attribution back into the #4252/#4254 story.
+
+Fixed by asserting CONTENT instead of a scalar, each with a kill-switch:
+`#3617` gains an `Empty()` control plus exact-key assertions; `#3685` moves to
+a fixture that produces the externref presence slot, and pins BOTH shapes it
+used to have (`presence-nonextern:...:ref_null`, `nofield:Node.label`) as
+kill-switches, since either one silently turns the main assertion into a test
+of nothing.
 
 ## What to do
 
@@ -81,8 +133,10 @@ Two independent pieces of work; the second is the point of this issue.
 
 ## Acceptance criteria
 
-- [ ] The two files named above are triaged and either fixed or recorded with a
-      reason.
+- [x] The two files named above are triaged and either fixed or recorded with a
+      reason. **Done 2026-08-09** — both stale pins, both fixed, verdicts and
+      probes recorded above. This was the *symptom*; everything below is the
+      issue proper and remains open.
 - [ ] The full root `tests/*.test.ts` population is executed on some cadence
       that does not depend on a PR touching each file.
 - [ ] A file that goes red is *discoverable without editing it* — a list, an

--- a/tests/issue-3617.test.ts
+++ b/tests/issue-3617.test.ts
@@ -76,9 +76,27 @@ describe("#3617 — standalone fnctor instance constructor back-pointer", () => 
       await runStandalone(`
         var value: any = new DummyError("boom");
         if (value.hasOwnProperty("constructor")) return 0;
-        // Closed fnctor source fields are not yet surfaced by Object.keys on
-        // main; pin the zero-key baseline and ensure the hidden link adds none.
-        return Object.keys(value).length === 0 ? 1 : 0;
+        // Object.keys must surface the SOURCE field and NOTHING else.
+        //
+        // This asserted \`length === 0\` until 2026-08-09, which pinned a BUG
+        // rather than the behaviour: closed fnctor source fields were not
+        // surfaced at all, so \`message\` was missing too. #3920 (23fcac402,
+        // "standalone reflection over closed structs enumerated nothing")
+        // fixed that, and the zero-key pin went red — reading, misleadingly,
+        // as though the constructor link had started leaking.
+        //
+        // The length alone could not tell those apart, so assert the CONTENT.
+        // \`indexOf\` and \`join\` over the key array still trap in standalone
+        // (separate pre-existing gaps), hence index + length.
+        var keys = Object.keys(value);
+        if (keys.length !== 1) return 0;
+        if (keys[0] !== "message") return 0;
+        // Kill-switch: a field-less instance must have NO keys. Without this,
+        // the pin above would still pass if the hidden link were emitted as a
+        // second key on instances that happen to have exactly one field.
+        var bare: any = new EmptyA();
+        if (Object.keys(bare).length !== 0) return 0;
+        return 1;
       `),
     ).toBe(1);
   });

--- a/tests/issue-3685-presence-tracked-proven-reads.test.ts
+++ b/tests/issue-3685-presence-tracked-proven-reads.test.ts
@@ -33,26 +33,70 @@ import { afterEach, describe, expect, it } from "vitest";
 import { compile } from "../src/index.ts";
 import { provenReceiverStats, resetProvenReceiverStats } from "../src/codegen/proven-receiver-stats.ts";
 
-// `label` is assigned only under a condition, and from OUTSIDE the constructor,
-// so it is a presence-tracked externref slot of `$__fnctor_Node`. `n` is a
-// never-reassigned binding initialized from `new Node(...)`, which the #3685 S1
-// receiver-flow analysis proves — so the reads below reach
-// `tryEmitProvenReceiverFieldGet` with a verdict in hand.
+// `label` is assigned only under a condition, so it is a presence-tracked slot
+// of `$__fnctor_Node`, and it is written from an UNTYPED PARAMETER, which is
+// what keeps that slot `externref` — the admission this file pins is
+// externref-only by design. `n` is a never-reassigned binding initialized from
+// `new Node(...)`, which the #3685 S1 receiver-flow analysis proves — so the
+// reads below reach `tryEmitProvenReceiverFieldGet` with a verdict in hand.
+//
+// (2026-08-09) The condition used to live OUTSIDE the constructor
+// (`function tag(n, v) { if (v > 0) { n.label = "L" + v; } }`). Two later
+// changes each independently stopped that shape from producing the slot this
+// file is about, and the census assertion below had been red on `main` ever
+// since:
+//
+//   - #4194's instance-expando substrate routes a field first written from
+//     outside the constructor into the `$$resid` EXPANDO BAG, so `label` was
+//     not a struct field at all and every read declined `nofield:Node.label`;
+//   - writing `"L" + v` makes the slot a native string `ref_null`, which the
+//     admission correctly refuses (`presence-nonextern:`).
+//
+// Both of those are pinned below as kill-switches rather than merely described,
+// because either one silently turns this file's main assertion into a test of
+// nothing. The machinery itself was verified intact at the same time: the
+// fixture below produces `ok:Node.label:externref:presence` x4, the exact key
+// this file has always asserted.
 const SOURCE = `
-function Node(pos) {
+function Node(pos, v) {
   this.start = pos;
   this.type = "T";
+  if (pos > 0) { this.label = v; }
 }
-function tag(n, v) {
-  if (v > 0) { n.label = "L" + v; }
-  return n;
-}
+export function readBeforeAssign() { var n = new Node(0, "L5"); return n.label === undefined ? 1 : 0; }
+export function readAfterAssign() { var n = new Node(2, "L5"); return n.label === "L5" ? 1 : 0; }
+export function absentIsNotNull() { var n = new Node(0, "L5"); return n.label === null ? 1 : 0; }
+export function typeofAbsent() { var n = new Node(0, "L5"); return typeof n.label === "undefined" ? 1 : 0; }
+export function plainFieldStillReads() { var n = new Node(9, "L5"); return n.start; }
+`;
+
+/**
+ * The two shapes that must NOT reach the presence admission, each with the
+ * decline reason it must produce. These are the kill-switches for `SOURCE`
+ * above: they are the shapes it used to have, and each one reaching `ok:` would
+ * mean the externref-only rule had been relaxed.
+ */
+const DECLINING_SHAPES = [
+  {
+    what: "native-string presence slot (#3753 promoted the carrier)",
+    reason: "presence-nonextern:Node.label:ref_null",
+    source: `
+function Node(pos, v) { this.start = pos; this.type = "T"; if (pos > 0) { this.label = "L" + v; } }
+export function readBeforeAssign() { var n = new Node(0, 5); return n.label === undefined ? 1 : 0; }
+export function readAfterAssign() { var n = new Node(2, 5); return n.label === "L5" ? 1 : 0; }
+`,
+  },
+  {
+    what: "first written from OUTSIDE the ctor (#4194 expando bag)",
+    reason: "nofield:Node.label",
+    source: `
+function Node(pos) { this.start = pos; this.type = "T"; }
+function tag(n, v) { if (v > 0) { n.label = "L" + v; } return n; }
 export function readBeforeAssign() { var n = new Node(1); return n.label === undefined ? 1 : 0; }
 export function readAfterAssign() { var n = new Node(2); tag(n, 5); return n.label === "L5" ? 1 : 0; }
-export function absentIsNotNull() { var n = new Node(3); return n.label === null ? 1 : 0; }
-export function typeofAbsent() { var n = new Node(4); return typeof n.label === "undefined" ? 1 : 0; }
-export function plainFieldStillReads() { var n = new Node(9); return n.start; }
-`;
+`,
+  },
+] as const;
 
 const EXPORT_NAMES = [
   "readBeforeAssign",
@@ -124,6 +168,39 @@ describe("#3685 step 2 — presence-tracked proven-receiver field reads", () => 
     }
     expect(provenReceiverStats.proven).toBe(provenReceiverStats.inlined + declines);
   });
+
+  it.each(DECLINING_SHAPES)(
+    "kill-switch: $what declines with $reason and still matches plain JS",
+    async ({ reason, source }) => {
+      process.env.JS2WASM_PROVEN_RECEIVER_STATS = "1";
+      resetProvenReceiverStats();
+      const r = await compile(source, {
+        fileName: "t.mjs",
+        skipSemanticDiagnostics: true,
+        target: "standalone",
+        optimize: 0,
+      });
+      expect(r.binary?.length ?? 0).toBeGreaterThan(0);
+
+      // The point of the pin: these shapes reach the proven-receiver analysis
+      // (so the fixture is not simply failing to compile the reads) and are
+      // then REFUSED, for the stated reason.
+      expect(provenReceiverStats.proven).toBeGreaterThan(0);
+      expect([...provenReceiverStats.reasons.keys()]).toContain(reason);
+      expect([...provenReceiverStats.reasons.keys()].some((k) => k.startsWith("ok:Node.label"))).toBe(false);
+
+      // A refusal must cost precision only — never an answer.
+      const module = await WebAssembly.compile(r.binary as BufferSource);
+      expect(WebAssembly.Module.imports(module).length).toBe(0);
+      const wasm = (await WebAssembly.instantiate(module, {})).exports as Record<string, () => unknown>;
+      const js = new Function(
+        `${source.replace(/export /g, "")}\nreturn { readBeforeAssign, readAfterAssign };`,
+      )() as Record<string, () => unknown>;
+      for (const name of ["readBeforeAssign", "readAfterAssign"]) {
+        expect(`${name}=${String(wasm[name]?.())}`).toBe(`${name}=${String(js[name]?.())}`);
+      }
+    },
+  );
 
   it("admits a presence-tracked slot ONLY when it is externref", async () => {
     process.env.JS2WASM_PROVEN_RECEIVER_STATS = "1";


### PR DESCRIPTION
Fixes the two root test files that were red on `main` and invisible, found by the sweep in #4255. **Both are STALE PINS. Neither is a real defect**, so neither is test262-visible and neither feeds the floor-drift story in #4252/#4254.

Both suspicions in #4253's original filing — mine — were wrong, and **both for the same structural reason**: each test compared a single **scalar** (a length, a boolean) that two very different causes could produce. A pin that cannot distinguish *"the thing I guard broke"* from *"the thing I guard got better"* is not a guard. That is the transferable finding here, more than either individual assertion.

Diagnosed against pristine `upstream/main` @ `49cab5c82` — **src *and* test files**, which is the control my first attempt got wrong (restoring main's `src` while keeping my own test file compares main's compiler against my expectations and cannot separate the hypotheses).

## `tests/issue-3617.test.ts` — filed as a possible enumerability regression. It is not.

| probe | value | meaning |
| --- | ---: | --- |
| `Object.keys(new DummyError("boom")).length` | 1 | node/spec: `["message"]` — correct |
| `hasOwnProperty("constructor")` | 0 | the invariant the test is NAMED for still holds |
| `hasOwnProperty("message")` | 1 | |
| `Object.keys(new Empty()).length` | 0 | no leak on a field-less instance |
| `value.constructor === DummyError` | 1 | back-pointer intact |

`constructor` never leaked. The pin asserted `length === 0`, which pinned **the bug** — closed fnctor source fields were not surfaced at all, so `message` was missing too. Its own comment admitted it: *"Closed fnctor source fields are not yet surfaced by Object.keys on main; pin the zero-key baseline"*. Then `23fcac402` **fix(#3920): standalone reflection over closed structs enumerated nothing** made reflection work, the legitimate `message` key appeared, and the stale pin went red *looking like* a leak.

Now asserts **content**: exactly one key, and it is `message`, plus an `Empty()` kill-switch — without which the pin would still pass if the hidden link were emitted as a second key on any single-field instance. (`indexOf` and `join` over the key array still trap in standalone — separate pre-existing gaps — hence index+length rather than the obvious spelling.)

## `tests/issue-3685-presence-tracked-proven-reads.test.ts` — a stale FIXTURE; the machinery is intact

The census showed all four `n.label` reads declining `nofield:Node.label`, and the struct said why — **`label` is not a field**. `$__fnctor_Node` is now `(start, type, $$presence_0, $$constructor, $$shape, $$resid)`: `500c4f99b` **feat(standalone): instance expando substrate (#4194)** routes a field first written from *outside* the constructor into the `$$resid` bag, so the fixture stopped producing the shape it was written to exercise.

**"The #3685 S2 slice is dead code" would have been a real finding** (~156 acorn sites), so it was checked rather than assumed. Positive control — conditionally assigned *inside* the ctor from an *untyped* param:

```
(field $label (mut externref)) (field $$presence_0 (mut i32))
proven=5 inlined=5    4x  ok:Node.label:externref:presence
```

That is the exact key the file has always asserted — neither the machinery nor the census format moved. The fixture is now that shape, and **both shapes it used to have are pinned as kill-switches** rather than described in a comment, because either one silently turns the main assertion into a test of nothing:

| shape | decline reason |
| --- | --- |
| `this.label = "L" + v` (native string slot, #3753) | `presence-nonextern:Node.label:ref_null` |
| assigned outside the ctor (#4194 expando bag) | `nofield:Node.label` |

Each kill-switch also asserts the refusal costs **precision only, never an answer**, by comparing against the same source evaluated as plain JavaScript.

## Verification

- Both files green: **9 tests** (up from 7 — the two kill-switch cases are new).
- `pnpm run test:changed-root` (the #3008 gate) exits **0**.
- Re-run after merging current `main`, which now carries the #4255 derivation-defaults flip: still green.
- Semantics matched plain JavaScript in **every** configuration probed, for both files.

## #4253 stays OPEN

This closes only its **first** acceptance item, and that item was the *symptom*. The issue proper is untouched: nothing runs the root `tests/*.test.ts` population (**2,646** files after the gate's own exclusions) on any cadence, so a file that goes red is undiscoverable until an unrelated PR happens to edit it — which is how all four of these rotted unseen. A change-scoped gate answers *"nothing wrong"* for every file it never looked at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Mjntn1rYJ7sH8kgfFDoqM
