### PR TITLE
feat(dogfood): complete React package test infrastructure

### DIFF
--- a/benchmarks/results/npm-compat.json
+++ b/benchmarks/results/npm-compat.json
@@ -92,31 +92,26 @@
     {
       "name": "typescript",
       "version": "5.9.3",
-      "issue": null,
+      "issue": 3994,
       "entryFile": "lib/typescript.js",
       "shape": "cjs-project",
       "compile": {
         "success": false,
-        "durationMs": 12752,
-        "timedOut": false,
-        "timeoutMs": 180000,
-        "errorCount": 1,
+        "durationMs": 600076,
+        "timedOut": true,
+        "timeoutMs": 600000,
+        "errorCount": 0,
         "binaryBytes": 0,
         "categories": {
-          "compiler-diagnostic": {
+          "compile-budget": {
             "count": 1,
-            "sample": "Codegen error: Maximum call stack size exceeded"
+            "sample": "compileProject exceeded the 600000ms budget"
           }
-        },
-        "errors": [
-          {
-            "message": "Codegen error: Maximum call stack size exceeded"
-          }
-        ]
+        }
       },
       "validation": {
         "validates": false,
-        "firstError": "Codegen error: Maximum call stack size exceeded"
+        "firstError": "compileProject exceeded the 600000ms budget"
       },
       "tests": {
         "kind": "upstream-suite",

--- a/plan/issues/3994-bound-recursive-package-graph-traversal-for-typescript.md
+++ b/plan/issues/3994-bound-recursive-package-graph-traversal-for-typescript.md
@@ -26,6 +26,24 @@ Use bounded or iterative work scheduling for recursive package graph traversal, 
 
 Reproduce: pnpm run dogfood:typescript.
 
+## Current investigation
+
+The first crash is now localized to the generic object-assignment widening
+pre-pass, not module graph resolution. In the pinned TypeScript 5.9.3 entry,
+the checker overflows while asking for the type of the RHS of
+`links.aliasTarget = target || unknownSymbol`. The pre-pass now treats that
+single `RangeError` as an unknown RHS, keeps the conservative object carrier,
+and continues scanning; non-stack checker errors are still propagated. The
+regression is covered by `tests/issue-3994.test.ts`.
+
+That moves the exact package probe past the opaque stack error. The catalog
+budget is now 600 seconds for this unusually large entry, so the compiler can
+continue measuring the post-fix frontier instead of being cut off at the
+generic three-minute limit. The remaining work is to reduce or schedule that
+large-package codegen frontier without
+silently dropping its dependency graph; the timeout remains the honest catalog
+result if the extended budget is still exhausted.
+
 ## Provenance
 
 Migrated on 2026-08-01 from a GitHub issue on `loopdive/js2` (opened 2026-07-30)

--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -5,7 +5,7 @@
  * fields. Extracted verbatim from codegen/declarations.ts (#3268).
  */
 import { collectShapes } from "../../shape-inference.js";
-import { forEachChild, ts } from "../../ts-api.js";
+import { forEachChild, getTypeAtLocationBounded, ts } from "../../ts-api.js";
 import { resolveWasmType } from "../index.js";
 import { localGlobalIdx } from "../registry/imports.js";
 import { getArrTypeIdxFromVec, getOrRegisterVecType, registerStructType } from "../registry/types.js";
@@ -95,7 +95,7 @@ export function collectObjectLiteralAssignedPropertyNames(ctx: CodegenContext, s
       ) {
         rhs = rhs.expression;
       }
-      const rhsType = ctx.checker.getTypeAtLocation(rhs);
+      const rhsType = getTypeAtLocationBounded(ctx.checker, rhs);
       const mayCarryObject =
         ts.isObjectLiteralExpression(rhs) ||
         ts.isArrayLiteralExpression(rhs) ||

--- a/src/ts-api.ts
+++ b/src/ts-api.ts
@@ -199,3 +199,15 @@ export function forEachChild<T>(
   }
   return ts.forEachChild(node, cbNode, cbNodeArray);
 }
+
+const BOUNDED_UNKNOWN_TYPE = { flags: ts.TypeFlags.Unknown } as ts.Type;
+
+/** Query a checker type without letting one recursive shape abort a compile. */
+export function getTypeAtLocationBounded(checker: ts.TypeChecker, node: ts.Node): ts.Type {
+  try {
+    return checker.getTypeAtLocation(node);
+  } catch (error) {
+    if (error instanceof RangeError && /Maximum call stack/i.test(error.message)) return BOUNDED_UNKNOWN_TYPE;
+    throw error;
+  }
+}

--- a/tests/dogfood/README.md
+++ b/tests/dogfood/README.md
@@ -23,6 +23,12 @@ substitute harness-authored smoke vectors or imply that validation is a test
 pass. Matching upstream source suites can be pinned and adapted package by
 package, following the existing Acorn/React precedent.
 
+The extracted catalog fixture is also given the installed package's importer
+context (`node_modules`), including pnpm's private dependency links. This keeps
+the published bytes under test while allowing relative imports such as jsdom's
+`tough-cookie` dependency to resolve from the same locked graph. A pin marker
+invalidates stale ignored extractions when a tarball revision changes.
+
 The original package-specific harnesses, plus the deeper Acorn conformance
 check, are:
 
@@ -223,6 +229,14 @@ Three rules keep the number honest:
 3. **A test the harness cannot reproduce natively is not evidence about the
    compiler.** It is excluded from the score under its own
    `harness-incompatible` bucket instead of being counted as a compiler bug.
+
+Both React harnesses install the same explicit jsdom browser-global set for
+their native oracle. ReactDOM's extractor also removes unsupported ESM helper
+imports before building a `new Function`, recording their bindings as
+unavailable instead of allowing one import to poison every test in a batch.
+Renderer, Jest, and internal-test-utils bindings remain in the explicit
+`harness-incompatible` bucket until equivalent compiled modules are available;
+the harness never turns a native-only adapter into compiler evidence.
 
 Failures stay in the corpus. The vitest wrapper enforces a pass FLOOR, not a
 target, so a regression is caught while the remaining frontier stays visible.

--- a/tests/dogfood/npm-compat-catalog.json
+++ b/tests/dogfood/npm-compat-catalog.json
@@ -83,7 +83,8 @@
     "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
     "entryModule": "package/lib/typescript.js",
     "shape": "cjs-project",
-    "timeoutMs": 180000
+    "issue": 3994,
+    "timeoutMs": 600000
   },
   {
     "name": "redux",

--- a/tests/dogfood/npm-compat-catalog.test.ts
+++ b/tests/dogfood/npm-compat-catalog.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error — .mjs dogfood helpers have no declaration files
@@ -52,25 +53,38 @@ describe("npm compatibility package catalog", () => {
     expect(canonical).toEqual(expect.arrayContaining(EXPECTED_NAMES));
   });
 
+  it("wires jsdom's published dependency graph into its extracted fixture", () => {
+    const setup = setupNpmCompatCatalogPackage("jsdom");
+    expect(setup.dependencyNodeModulesPath).toBeTruthy();
+    expect(existsSync(join(setup.root, "node_modules", "tough-cookie"))).toBe(true);
+    expect(existsSync(join(setup.root, "node_modules", "whatwg-url"))).toBe(true);
+  });
+
   const selectedPackage = process.env.DOGFOOD_NPM_CATALOG;
   const heavy = selectedPackage ? it : it.skip;
-  heavy("records the selected package's bounded compile and validation frontier", { timeout: 240_000 }, async () => {
-    expect(EXPECTED_NAMES).toContain(selectedPackage);
-    const report = await runNpmCompatCatalogHarness(selectedPackage, { quiet: true });
-    expect(report[selectedPackage!]?.version).toBe(
-      NPM_COMPAT_CATALOG.find((entry: { name: string }) => entry.name === selectedPackage)?.version,
-    );
-    expect(typeof report.compile.success).toBe("boolean");
-    expect(typeof report.validation.validates).toBe("boolean");
-    // (#4127) `diff.runnable === false` is a FACT about this harness (it
-    // compiles and validates, it never runs the package), not a property worth
-    // asserting on its own — asserting it was how "we never checked" stayed
-    // indistinguishable from "we checked and it was fine". What must hold is
-    // that the report says so on the record: the correctness axis is present
-    // and explicitly `unverified`, with a reason.
-    expect(report.diff.runnable).toBe(false);
-    expect(report.correctness.status).toBe("unverified");
-    expect(report.correctness.reason).toEqual(expect.any(String));
-    expect(report.correctness.reason.length).toBeGreaterThan(0);
-  });
+  const selectedTimeoutMs =
+    NPM_COMPAT_CATALOG.find((entry: { name: string }) => entry.name === selectedPackage)?.timeoutMs ?? 120_000;
+  heavy(
+    "records the selected package's bounded compile and validation frontier",
+    { timeout: Math.max(240_000, selectedTimeoutMs + 60_000) },
+    async () => {
+      expect(EXPECTED_NAMES).toContain(selectedPackage);
+      const report = await runNpmCompatCatalogHarness(selectedPackage, { quiet: true });
+      expect(report[selectedPackage!]?.version).toBe(
+        NPM_COMPAT_CATALOG.find((entry: { name: string }) => entry.name === selectedPackage)?.version,
+      );
+      expect(typeof report.compile.success).toBe("boolean");
+      expect(typeof report.validation.validates).toBe("boolean");
+      // (#4127) `diff.runnable === false` is a FACT about this harness (it
+      // compiles and validates, it never runs the package), not a property worth
+      // asserting on its own — asserting it was how "we never checked" stayed
+      // indistinguishable from "we checked and it was fine". What must hold is
+      // that the report says so on the record: the correctness axis is present
+      // and explicitly `unverified`, with a reason.
+      expect(report.diff.runnable).toBe(false);
+      expect(report.correctness.status).toBe("unverified");
+      expect(report.correctness.reason).toEqual(expect.any(String));
+      expect(report.correctness.reason.length).toBeGreaterThan(0);
+    },
+  );
 });

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -28,13 +28,13 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { performance } from "node:perf_hooks";
 import { createRequire } from "node:module";
-import { JSDOM } from "jsdom";
 
 import { compile } from "../../src/index.ts";
 import { wrapExports } from "../../src/runtime.ts";
 import { setupReact } from "./setup-react.mjs";
 import { setupReactDomImplementation, setupReactDomUpstreamSuite } from "./setup-react-dom-upstream-suite.mjs";
 import { extractReactUpstreamTests } from "./react-upstream-extract.mjs";
+import { installReactTestEnvironment } from "./react-test-environment.mjs";
 import { REACT_EXPECT_SHIM, LAST_ERROR_EXPORT, buildTestFunction } from "./react-upstream-shim.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -176,42 +176,6 @@ function withReactDomSetup(test) {
   return { ...test, prelude };
 }
 
-function installDomGlobals() {
-  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
-    url: "http://localhost/",
-    pretendToBeVisual: true,
-  });
-  const window = dom.window;
-  const globals = [
-    "window",
-    "self",
-    "document",
-    "navigator",
-    "Node",
-    "Element",
-    "HTMLElement",
-    "HTMLInputElement",
-    "HTMLSelectElement",
-    "HTMLTextAreaElement",
-    "Event",
-    "CustomEvent",
-    "MouseEvent",
-    "KeyboardEvent",
-    "FocusEvent",
-    "InputEvent",
-    "MutationObserver",
-    "getComputedStyle",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  for (const name of globals) {
-    const value = name === "window" || name === "self" ? window : window[name];
-    if (value === undefined) continue;
-    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
-  }
-  return dom;
-}
-
 function buildModuleSource(implementation, tests) {
   return [
     implementation,
@@ -231,12 +195,13 @@ function buildNativeRunners(implementation, tests) {
       .join(", ")} } };`,
   ].join("\n");
   // eslint-disable-next-line no-new-func
-  return new Function(source);
+  return new Function("require", source);
 }
 
 async function runNative(implementation, tests) {
   try {
-    const runners = buildNativeRunners(implementation, tests)();
+    const nativeRequire = createRequire(import.meta.url);
+    const runners = buildNativeRunners(implementation, tests)(nativeRequire);
     const out = [];
     for (const test of tests) {
       let value;
@@ -253,6 +218,17 @@ async function runNative(implementation, tests) {
     const message = thrown instanceof Error ? thrown.message : String(thrown);
     return tests.map((test) => ({ id: test.id, value: undefined, error: `oracle build failed: ${message}` }));
   }
+}
+
+async function runNativeByFile(implementation, tests) {
+  const byFile = new Map();
+  for (const test of tests) {
+    if (!byFile.has(test.file)) byFile.set(test.file, []);
+    byFile.get(test.file).push(test);
+  }
+  const results = [];
+  for (const fileTests of byFile.values()) results.push(...(await runNative(implementation, fileTests)));
+  return results;
 }
 
 // Compiles the implementation ALONE — no test code. If this cannot produce a
@@ -312,7 +288,7 @@ function splitBySize(tests) {
 
 export async function runHarness({ quiet = false } = {}) {
   const log = quiet ? () => {} : (...values) => console.log(...values);
-  installDomGlobals();
+  installReactTestEnvironment();
 
   // --- 1. ACQUIRE ----------------------------------------------------------
   const { root: reactRoot, version: reactVersion } = setupReact();
@@ -401,7 +377,10 @@ export async function runHarness({ quiet = false } = {}) {
     // are scored as failures rather than quietly dropped.
     implementationInvalid = { error: String(baseline.error), compileMs: baseline.compileMs };
     admitted = selectedTests;
-    const nativeResults = new Map((await runNative(implementation, selectedTests)).map((e) => [e.id, e]));
+    // Build one native oracle per upstream file.  A single ESM helper import
+    // in one file must not turn every unrelated test into an oracle-build
+    // failure (the extractor records those helpers as dropped scaffolding).
+    const nativeResults = new Map((await runNativeByFile(implementation, selectedTests)).map((e) => [e.id, e]));
     for (const test of selectedTests) {
       runResults.set(test.id, {
         native: nativeResults.get(test.id) ?? {},

--- a/tests/dogfood/react-test-environment.mjs
+++ b/tests/dogfood/react-test-environment.mjs
@@ -1,0 +1,92 @@
+import { JSDOM } from "jsdom";
+
+// React's upstream tests expect the browser globals that Jest installs through
+// jsdom.  Keep this list explicit: copying every property from `window` would
+// overwrite Node's process/timer globals and make the native oracle differ
+// from the host used by the compiler.
+const DOM_GLOBALS = [
+  "window",
+  "self",
+  "document",
+  "navigator",
+  "location",
+  "history",
+  "Node",
+  "NodeList",
+  "NodeFilter",
+  "Element",
+  "HTMLElement",
+  "HTMLDocument",
+  "HTMLHtmlElement",
+  "HTMLHeadElement",
+  "HTMLBodyElement",
+  "HTMLDivElement",
+  "HTMLInputElement",
+  "HTMLSelectElement",
+  "HTMLTextAreaElement",
+  "HTMLButtonElement",
+  "HTMLFormElement",
+  "HTMLIFrameElement",
+  "HTMLOptionElement",
+  "HTMLTemplateElement",
+  "SVGElement",
+  "SVGSVGElement",
+  "Text",
+  "Comment",
+  "DocumentFragment",
+  "DocumentType",
+  "Event",
+  "CustomEvent",
+  "MouseEvent",
+  "KeyboardEvent",
+  "FocusEvent",
+  "InputEvent",
+  "CompositionEvent",
+  "UIEvent",
+  "WheelEvent",
+  "MutationObserver",
+  "IntersectionObserver",
+  "Range",
+  "Selection",
+  "TreeWalker",
+  "DOMParser",
+  "XMLSerializer",
+  "getComputedStyle",
+  "requestAnimationFrame",
+  "cancelAnimationFrame",
+];
+
+export function installReactTestEnvironment() {
+  const dom = new JSDOM("<!doctype html><html><head></head><body></body></html>", {
+    url: "http://localhost/",
+    pretendToBeVisual: true,
+  });
+  const { window } = dom;
+  const previous = new Map();
+  for (const name of DOM_GLOBALS) {
+    const value = name === "window" || name === "self" ? window : window[name];
+    if (value === undefined) continue;
+    previous.set(name, { present: Object.hasOwn(globalThis, name), value: globalThis[name] });
+    Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  }
+  // React's act() warning gate is part of the upstream test environment.  It
+  // is deliberately a host setup value, not a compiler result.
+  const previousActEnvironment = {
+    present: Object.hasOwn(globalThis, "IS_REACT_ACT_ENVIRONMENT"),
+    value: globalThis.IS_REACT_ACT_ENVIRONMENT,
+  };
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  return {
+    dom,
+    cleanup() {
+      dom.window.close();
+      for (const [name, state] of previous) {
+        if (state.present)
+          Object.defineProperty(globalThis, name, { configurable: true, writable: true, value: state.value });
+        else delete globalThis[name];
+      }
+      if (previousActEnvironment.present) globalThis.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment.value;
+      else delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+    },
+  };
+}

--- a/tests/dogfood/react-upstream-extract.mjs
+++ b/tests/dogfood/react-upstream-extract.mjs
@@ -109,6 +109,14 @@ function isSkipped(node) {
 function filterPreludeStatement(statement, sourceFile, supportedInfrastructure) {
   const text = statement.getText(sourceFile);
   if (/^\s*['"]use strict['"]/.test(text)) return null;
+  // The lifted tests are evaluated by `new Function` (and later embedded in a
+  // Wasm module), neither of which accepts ESM import declarations.  Jest's
+  // module transform normally resolves these imports before the test runs;
+  // this harness does not have those helper modules, so drop the declaration
+  // and retain its local names in `droppedNames`.  Conservative admission then
+  // rejects a test that reaches for one, while admit-all records it as a native
+  // harness failure instead of letting one import poison an entire batch.
+  if (ts.isImportDeclaration(statement) || ts.isImportEqualsDeclaration(statement)) return null;
   // Scaffolding that only exists to wire up the infrastructure this harness
   // deliberately does not have (`let ReactDOMClient;`, the `internal-test-utils`
   // destructure, `jest.resetModules()`). Dropping it here rather than rejecting
@@ -139,6 +147,18 @@ function declaredNames(node, into = new Set()) {
 
   if (ts.isVariableStatement(node)) {
     for (const declaration of node.declarationList.declarations) addBinding(declaration.name);
+  } else if (ts.isImportDeclaration(node)) {
+    const clause = node.importClause;
+    if (!clause) return into;
+    addBinding(clause.name);
+    if (clause.namedBindings) {
+      if (ts.isNamespaceImport(clause.namedBindings)) addBinding(clause.namedBindings.name);
+      else {
+        for (const element of clause.namedBindings.elements) addBinding(element.name);
+      }
+    }
+  } else if (ts.isImportEqualsDeclaration(node)) {
+    addBinding(node.name);
   } else if (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) {
     addBinding(node.name);
   } else if (ts.isExpressionStatement(node)) {

--- a/tests/dogfood/react-upstream-extract.test.ts
+++ b/tests/dogfood/react-upstream-extract.test.ts
@@ -1,0 +1,28 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — .mjs dogfood helper has no declaration file
+import { extractReactUpstreamTests } from "./react-upstream-extract.mjs";
+
+describe("react upstream extractor", () => {
+  it("drops ESM helper imports and records their bindings as unavailable scaffolding", () => {
+    const root = mkdtempSync(join(tmpdir(), "js2-react-extract-"));
+    const file = "fixture.js";
+    try {
+      mkdirSync(join(root, "suite"));
+      writeFileSync(
+        join(root, file),
+        `import {helper as importedHelper} from "external-helper";\n` +
+          `describe("fixture", () => { it("uses helper", () => { importedHelper(); }); });\n`,
+      );
+      const result = extractReactUpstreamTests({ root, testFiles: [file], admitAll: false });
+      expect(result.tests).toHaveLength(0);
+      expect(result.rejectionCounts["needs-dropped-scaffolding"]).toBe(1);
+      expect(result.rejected[0].fullName).toBe("fixture › uses helper");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/dogfood/react-upstream-suite.mjs
+++ b/tests/dogfood/react-upstream-suite.mjs
@@ -40,6 +40,7 @@ import { wrapExports } from "../../src/runtime.ts";
 import { setupReact } from "./setup-react.mjs";
 import { setupReactUpstreamSuite } from "./setup-react-upstream-suite.mjs";
 import { extractReactUpstreamTests } from "./react-upstream-extract.mjs";
+import { installReactTestEnvironment } from "./react-test-environment.mjs";
 import { REACT_EXPECT_SHIM, LAST_ERROR_EXPORT, buildTestFunction } from "./react-upstream-shim.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -70,12 +71,18 @@ function buildNativeRunners(tests) {
       .join(", ")} } };`,
   ].join("\n");
   // eslint-disable-next-line no-new-func
-  return new Function("__REACT__", source);
+  return new Function("__REACT__", "require", source);
 }
 
 async function runNative(tests, nativeReact) {
   try {
-    const runners = buildNativeRunners(tests)(nativeReact);
+    // A few upstream tests intentionally require the published ReactDOM
+    // package (for example Portal coverage).  Supplying Node's real resolver
+    // to the native oracle makes that an honest host dependency; the Wasm side
+    // still reports the same call as unavailable if the compiler cannot lower
+    // it, rather than hiding the gap behind an oracle-build failure.
+    const nativeRequire = createRequire(import.meta.url);
+    const runners = buildNativeRunners(tests)(nativeReact, nativeRequire);
     const out = [];
     for (const test of tests) {
       let value;
@@ -129,6 +136,7 @@ function quarantineFromErrors(moduleSource, tests, errors) {
 
 export async function runHarness({ quiet = false } = {}) {
   const log = quiet ? () => {} : (...values) => console.log(...values);
+  installReactTestEnvironment();
 
   // --- 1. ACQUIRE ----------------------------------------------------------
   const { root: packageRoot, version, pin } = setupReact();

--- a/tests/dogfood/react-upstream-suite.test.ts
+++ b/tests/dogfood/react-upstream-suite.test.ts
@@ -1,10 +1,14 @@
 import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 // @ts-expect-error — .mjs dogfood setup has no declaration file
-import { loadReactUpstreamSuitePin } from "./setup-react-upstream-suite.mjs";
+import { isReactUpstreamSuiteCheckoutValid, loadReactUpstreamSuitePin } from "./setup-react-upstream-suite.mjs";
+// @ts-expect-error — .mjs dogfood environment has no declaration file
+import { installReactTestEnvironment } from "./react-test-environment.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -20,6 +24,29 @@ const ADMITTED_FLOOR = 270;
 const INVALID_BATCH_CEILING = 5;
 
 describe("react upstream suite", () => {
+  it("provides the browser globals used by the native React oracle", () => {
+    const dom = installReactTestEnvironment();
+    try {
+      expect(document.createElement("div").ownerDocument).toBe(document);
+      expect(typeof window.requestAnimationFrame).toBe("function");
+      expect((globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT).toBe(
+        true,
+      );
+    } finally {
+      dom.cleanup();
+    }
+  });
+
+  it("rejects a malformed generated source checkout so setup can repair it", () => {
+    const root = mkdtempSync(join(tmpdir(), "js2-react-suite-"));
+    try {
+      mkdirSync(join(root, ".git"));
+      expect(isReactUpstreamSuiteCheckoutValid(root, "eaf3e95ca92be7a23d3c9cc8ffd6f199a40be401")).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("pins the source revision matching the published React version", () => {
     const pin = loadReactUpstreamSuitePin();
     expect(pin.tag).toBe("v19.2.6");

--- a/tests/dogfood/setup-pinned-package.mjs
+++ b/tests/dogfood/setup-pinned-package.mjs
@@ -1,10 +1,115 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const requireFromHere = createRequire(import.meta.url);
 
 function sha1(buffer) {
   return createHash("sha1").update(buffer).digest("hex");
+}
+
+function pinMarkerMatches(markerPath, pin, name) {
+  try {
+    const marker = JSON.parse(readFileSync(markerPath, "utf-8"));
+    return (
+      marker.name === name &&
+      marker.version === pin.version &&
+      marker.shasum === pin.shasum &&
+      marker.entryModule === pin.entryModule
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Expose the installed package's real dependency directory to an extracted
+ * tarball.  This matters for pnpm: the package itself is hoisted at
+ * `node_modules/<name>`, while its private dependencies live beside it in the
+ * store and are not visible from `tests/dogfood/.npm-compat/<name>/package`.
+ * The compiler intentionally resolves imports from the fixture's filesystem,
+ * so without this link jsdom/ESLint fail for a missing graph before their real
+ * compiler frontier is measured.
+ */
+function resolveInstalledPackageRoot(name) {
+  let installedEntry;
+  try {
+    // Prefer the package entry so this also works for packages whose exports
+    // map intentionally blocks `name/package.json` (lit, hono, three, ...).
+    installedEntry = requireFromHere.resolve(name);
+  } catch {
+    return null;
+  }
+
+  let directory = dirname(realpathSync(installedEntry));
+  while (true) {
+    try {
+      const packageJson = JSON.parse(readFileSync(join(directory, "package.json"), "utf-8"));
+      if (packageJson.name === name) return directory;
+    } catch {
+      // Keep walking toward the repository root; an entry can sit below the
+      // package root in `lib/` or `dist/`.
+    }
+    const parent = dirname(directory);
+    if (parent === directory) return null;
+    directory = parent;
+  }
+}
+
+function wireInstalledDependencies(root, name, pin) {
+  const installedRoot = resolveInstalledPackageRoot(name);
+  if (!installedRoot) {
+    // Some fixture-only packages are not installed as direct dependencies. A
+    // self-contained package remains valid without an importer-context link.
+    return null;
+  }
+  const installedPackage = JSON.parse(readFileSync(join(installedRoot, "package.json"), "utf-8"));
+  if (installedPackage.name !== name || installedPackage.version !== pin.version) {
+    throw new Error(
+      `[dogfood] installed ${name} does not match the pinned package: ` +
+        `${installedPackage.name}@${installedPackage.version} (expected ${name}@${pin.version})`,
+    );
+  }
+  // In a flat npm tree this is `<project>/node_modules`; in pnpm it is the
+  // package's importer directory (`.pnpm/<pkg>/node_modules`) containing the
+  // dependency symlinks.  The package-local `node_modules` directory itself
+  // may be empty in pnpm and is not the dependency graph we need.
+  const installedNodeModules = dirname(installedRoot);
+  if (!existsSync(installedNodeModules)) return null;
+
+  const dependencyRoot = join(root, "node_modules");
+  let dependencyStat = null;
+  try {
+    dependencyStat = lstatSync(dependencyRoot);
+  } catch {
+    // No existing link/directory; create the importer-context link below.
+  }
+  if (dependencyStat) {
+    try {
+      if (dependencyStat.isSymbolicLink() && realpathSync(dependencyRoot) === realpathSync(installedNodeModules)) {
+        return dependencyRoot;
+      }
+    } catch {
+      // Replace a broken stale link below.
+    }
+    // Never remove package contents: only a link created by this helper is
+    // replaceable, and a real directory is left for the package to own.
+    if (!dependencyStat.isSymbolicLink()) return null;
+    rmSync(dependencyRoot, { recursive: true, force: true });
+  }
+  symlinkSync(installedNodeModules, dependencyRoot, "dir");
+  return dependencyRoot;
 }
 
 export function loadPinnedPackagePin(here, pinFile) {
@@ -38,13 +143,31 @@ export function setupPinnedPackage({
   const root = join(here, extractionDirectory);
   const entryModulePath = join(root, pin.entryModule);
   if (force && existsSync(root)) rmSync(root, { recursive: true, force: true });
+  const markerPath = join(root, ".js2-pinned-package.json");
+  if (existsSync(entryModulePath) && !pinMarkerMatches(markerPath, pin, name)) {
+    // The tarball pin can advance while an ignored extraction cache remains.
+    // Do not compile stale bytes just because the old entry path still exists.
+    rmSync(root, { recursive: true, force: true });
+  }
   if (!existsSync(entryModulePath)) {
     mkdirSync(root, { recursive: true });
     execFileSync("tar", ["-xzf", tarballPath, "-C", root], { stdio: "pipe" });
+    writeFileSync(
+      markerPath,
+      `${JSON.stringify({ name, version: pin.version, shasum: pin.shasum, entryModule: pin.entryModule }, null, 2)}\n`,
+    );
   }
   if (!existsSync(entryModulePath) && !allowMissingEntry) {
     throw new Error(`[dogfood] extraction did not produce ${pin.entryModule} under ${root}`);
   }
 
-  return { root, entryModulePath, entryExists: existsSync(entryModulePath), version: pin.version, pin };
+  const dependencyNodeModulesPath = wireInstalledDependencies(root, name, pin);
+  return {
+    root,
+    entryModulePath,
+    entryExists: existsSync(entryModulePath),
+    dependencyNodeModulesPath,
+    version: pin.version,
+    pin,
+  };
 }

--- a/tests/dogfood/setup-react-upstream-suite.mjs
+++ b/tests/dogfood/setup-react-upstream-suite.mjs
@@ -1,12 +1,45 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 export function loadReactUpstreamSuitePin() {
   return JSON.parse(readFileSync(join(HERE, "react-upstream-suite-pin.json"), "utf-8"));
+}
+
+function readReactUpstreamSuiteCheckoutCommit(root) {
+  if (!existsSync(join(root, ".git"))) return null;
+  try {
+    const topLevel = resolve(
+      execFileSync("git", ["-C", root, "rev-parse", "--show-toplevel"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim(),
+    );
+    if (topLevel !== resolve(root)) return null;
+    return execFileSync("git", ["-C", root, "rev-parse", "--verify", "HEAD^{commit}"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check the checkout itself, rather than only checking that `.git` exists.
+ *
+ * A generated suite can be left behind as a directory containing a copied
+ * `.git` entry (or a worktree whose HEAD was removed).  `existsSync(root/.git)`
+ * used to accept that state and the subsequent `git rev-parse` then failed
+ * before the harness could repair it.  Comparing the repository root also
+ * prevents accidentally accepting a parent checkout through Git's upward
+ * search.
+ */
+export function isReactUpstreamSuiteCheckoutValid(root, expectedCommit) {
+  return readReactUpstreamSuiteCheckoutCommit(root) === expectedCommit;
 }
 
 // React's published tarball omits its Jest tests. Acquire only the exact
@@ -17,8 +50,13 @@ export function setupReactUpstreamSuite({ force = false } = {}) {
   const root = join(HERE, ".react-upstream-suite");
 
   if (force && existsSync(root)) rmSync(root, { recursive: true, force: true });
-  if (!existsSync(join(root, ".git"))) {
-    rmSync(root, { recursive: true, force: true });
+  // Recover malformed generated checkouts (for example a stale directory with
+  // no HEAD) by removing only this cache and recloning the pinned source.
+  // A malformed/missing checkout is repaired automatically.  A valid checkout
+  // at the wrong revision is not silently replaced: it remains an integrity
+  // error below, preserving the old fail-closed pin behavior.
+  if (readReactUpstreamSuiteCheckoutCommit(root) === null) {
+    if (existsSync(root)) rmSync(root, { recursive: true, force: true });
     mkdirSync(root, { recursive: true });
     execFileSync("git", ["clone", "--depth", "1", "--branch", pin.tag, pin.repo, root], { stdio: "pipe" });
   }

--- a/tests/issue-3994.test.ts
+++ b/tests/issue-3994.test.ts
@@ -1,0 +1,40 @@
+// #3994 — checked-JS packages can expose a recursive flow/type shape while
+// the object-assignment widening pre-pass asks for the RHS type. A TypeScript
+// checker stack overflow is not a reason to abort the whole package compile;
+// the pre-pass must conservatively retain the property-carrier mark and move
+// on to the rest of the source.
+import { describe, expect, it } from "vitest";
+import { ts } from "../src/ts-api.js";
+import { collectObjectLiteralAssignedPropertyNames } from "../src/codegen/declarations/object-shape-widening.js";
+
+describe("#3994 — bounded object-assignment type queries", () => {
+  it("keeps scanning when the checker overflows on a recursive RHS", () => {
+    const sourceFile = ts.createSourceFile(
+      "issue-3994.js",
+      "const target = {}; target.alias = target || unknownSymbol; target.done = target;",
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.JS,
+    );
+    const checker = {
+      getTypeAtLocation(node: ts.Node): ts.Type {
+        // Model the recursive checker path observed in TypeScript 5.9.3's
+        // `links.aliasTarget = target || unknownSymbol` assignment. The
+        // production pre-pass must only swallow this bounded failure class.
+        if (node.getText() === "target || unknownSymbol") {
+          throw new RangeError("Maximum call stack size exceeded");
+        }
+        return { flags: ts.TypeFlags.Object } as ts.Type;
+      },
+    } as unknown as ts.TypeChecker;
+    const objectLiteralAssignedPropertyNames = new Set<string>();
+    const context = {
+      checker,
+      objectLiteralAssignedPropertyNames,
+      objectLiteralAssignedPropertyTypes: new Map<string, ts.Type[]>(),
+    } as never;
+
+    expect(() => collectObjectLiteralAssignedPropertyNames(context, sourceFile)).not.toThrow();
+    expect(objectLiteralAssignedPropertyNames).toEqual(new Set(["alias", "done"]));
+  });
+});

--- a/website/public/benchmarks/results/npm-compat.json
+++ b/website/public/benchmarks/results/npm-compat.json
@@ -92,31 +92,26 @@
     {
       "name": "typescript",
       "version": "5.9.3",
-      "issue": null,
+      "issue": 3994,
       "entryFile": "lib/typescript.js",
       "shape": "cjs-project",
       "compile": {
         "success": false,
-        "durationMs": 12752,
-        "timedOut": false,
-        "timeoutMs": 180000,
-        "errorCount": 1,
+        "durationMs": 600076,
+        "timedOut": true,
+        "timeoutMs": 600000,
+        "errorCount": 0,
         "binaryBytes": 0,
         "categories": {
-          "compiler-diagnostic": {
+          "compile-budget": {
             "count": 1,
-            "sample": "Codegen error: Maximum call stack size exceeded"
+            "sample": "compileProject exceeded the 600000ms budget"
           }
-        },
-        "errors": [
-          {
-            "message": "Codegen error: Maximum call stack size exceeded"
-          }
-        ]
+        }
       },
       "validation": {
         "validates": false,
-        "firstError": "Codegen error: Maximum call stack size exceeded"
+        "firstError": "compileProject exceeded the 600000ms budget"
       },
       "tests": {
         "kind": "upstream-suite",


### PR DESCRIPTION
## Summary

- add one explicit jsdom browser-global environment for React and ReactDOM native oracles;
- drop unsupported ESM helper imports from lifted ReactDOM tests and record their bindings as unavailable instead of poisoning whole native batches;
- repair malformed pinned React source checkouts and wire extracted npm fixtures to the installed pnpm dependency context, with stale extraction markers;
- bound recursive TypeScript checker queries in the generic object-assignment widening pre-pass and extend the TypeScript catalog budget to 600 seconds.

## Verification

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- focused Vitest suites for React extraction/environment, npm catalog setup, React upstream contracts, and #3994
- pre-commit and pre-push gates (LOC, function, oracle, coercion, numeric-local, issue integrity)
- React upstream: 55/55 scored passes; 209 tests remain explicitly harness-incompatible
- ReactDOM limited run: ESM oracle poisoning removed; published implementation still reports the existing `Do not know how to serialize a BigInt` compiler blocker
- TypeScript 5.9.3: former stack overflow removed; full entry now reaches the bounded codegen budget and remains unverified
