### PR TITLE
fix(website): standalone edition filter, issue links pointing at unrelated PRs, JS-host benchmark sources

### DIFF
--- a/scripts/build-test262-report.mjs
+++ b/scripts/build-test262-report.mjs
@@ -214,7 +214,9 @@ const STANDALONE_ROOT_CAUSE_BUCKETS = [
   {
     // #3086 — honest-vacuity reclassification. A would-be pass whose harness
     // wrapper or nested callback never executed (so no assertion ran) is scored
-    // `fail` + `vacuous: true` by the runner's vacuity gate (#2463/#2940/#3086).
+    // `fail` + `vacuous: true` by the runner's vacuity gate (#2940/#3086,
+    // implemented by PR #2463 — a PR number, so it is deliberately NOT in the
+    // `issues` list below: those render as links to plan/issues/<id>.md).
     // These are a KNOWN, deliberate honest-metric reclassification, not a
     // codegen root cause — so they get their own bucket rather than falling into
     // `unclassified` (which the strict threshold-0 gate would then trip). Placed
@@ -222,7 +224,7 @@ const STANDALONE_ROOT_CAUSE_BUCKETS = [
     // IS the dropped callback, never the feature the dead assertion targeted, so
     // no feature-path bucket should poach it.
     id: "honest-vacuity-reclassification",
-    issues: ["#3086", "#2940", "#2463"],
+    issues: ["#3086", "#2940"],
     label:
       "Honest-vacuity reclassification (harness/nested callback never executed → no assertion ran; scored vacuous fail, excluded from host_free_pass)",
     match: (record, text) => record.vacuous === true || hasAny(text, ["vacuous:", "no assertion ran"]),

--- a/tests/report-standalone-category-edition-scope.test.ts
+++ b/tests/report-standalone-category-edition-scope.test.ts
@@ -1,0 +1,146 @@
+// The report page's STANDALONE view must honour the edition slider in its
+// category table.
+//
+// Observed symptom: selecting ES2026 in the standalone tab still listed
+// `built-ins/Temporal` — 4,603 proposal tests — as a category row. Temporal is
+// not in any published edition.
+//
+// Root cause: a different code path from the host-side Error Patterns leak
+// (see report-error-patterns-edition-scope.test.ts). The standalone view was
+// constructed with `categoryEditions: null`, so `computeAllowedCategories`
+// bailed out and returned null, which `applyFilters` reads as "no edition
+// filter at all" — every standalone category row stayed visible at every
+// slider position. The host view was unaffected because it was passed the map.
+//
+// The map is legitimately shared: an edition is a property of the test file's
+// frontmatter, not of the compile target, and the filter reads only the map's
+// edition KEYS, never its host pass/fail counts.
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname ?? ".", "..");
+const REPORT_HTML = join(ROOT, "website", "public", "benchmarks", "report.html");
+const RESULTS = join(ROOT, "website", "public", "benchmarks", "results");
+const CATEGORY_EDITIONS = join(RESULTS, "test262-category-editions.json");
+const STANDALONE_REPORT = join(RESULTS, "test262-standalone-report.json");
+
+const html = readFileSync(REPORT_HTML, "utf-8");
+
+function extractFunction(source: string, name: string): string {
+  const start = source.indexOf(`function ${name}(`);
+  expect(start, `${name} not found in report.html`).toBeGreaterThanOrEqual(0);
+  let depth = 0;
+  let seen = false;
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === "{") {
+      depth++;
+      seen = true;
+    } else if (source[i] === "}") {
+      depth--;
+      if (seen && depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces while extracting ${name}`);
+}
+
+/**
+ * Build the page's REAL `computeAllowedCategories` as a callable, supplying the
+ * two things it closes over (`computeAllowedEditions` and `view`). Running the
+ * literal source keeps this test honest if the rule is ever edited.
+ */
+function buildAllowedCategories(
+  source: string,
+): (allowedEditions: Set<string> | null, categoryEditions: unknown) => Set<string> | null {
+  const body = `
+    return function (allowedEditions, categoryEditions) {
+      const view = { categoryEditions };
+      const computeAllowedEditions = () => allowedEditions;
+      ${extractFunction(source, "computeAllowedCategories")}
+      return computeAllowedCategories();
+    };
+  `;
+  return new Function(body)() as ReturnType<typeof buildAllowedCategories>;
+}
+
+/**
+ * Evaluate the standalone view's LITERAL `categoryEditions:` expression, so a
+ * data-level assertion exercises the real wiring instead of assuming a map was
+ * passed. With the bug present this returns null and the filter goes inert.
+ */
+function buildStandaloneCategoryEditions(source: string): (categoryEditions: unknown) => unknown {
+  const at = source.indexOf('mode: "standalone"');
+  expect(at, "standalone view not found").toBeGreaterThanOrEqual(0);
+  const expr = /categoryEditions:\s*([^,\n]+),/.exec(source.slice(at, source.indexOf("}", at)));
+  expect(expr, "standalone view has no categoryEditions field").not.toBeNull();
+  return new Function(`return function (categoryEditions) { return (${expr?.[1]}); };`)() as (
+    categoryEditions: unknown,
+  ) => unknown;
+}
+
+describe("report page standalone view — category edition scoping", () => {
+  it("passes the shared category×edition map to the standalone view", () => {
+    const standalone = html.slice(html.indexOf('mode: "standalone"'));
+    const wiring = standalone.slice(0, standalone.indexOf("}"));
+    // `categoryEditions: null` is the bug: it disables the filter entirely
+    // rather than narrowing it.
+    expect(wiring).not.toMatch(/categoryEditions:\s*null/);
+    expect(wiring).toMatch(/categoryEditions:\s*categoryEditions\s*\|\|\s*null/);
+  });
+
+  it("reads only edition keys from the map, never host counts", () => {
+    // This is what makes sharing the host-derived map sound. If the filter ever
+    // starts summing counts, the standalone view would be reporting host
+    // numbers and this sharing would no longer be safe.
+    const src = extractFunction(html, "computeAllowedCategories");
+    expect(src).toContain("Object.keys(byEdition).some");
+  });
+
+  it("returns null (no filter) only when there is no edition selection", () => {
+    const compute = buildAllowedCategories(html);
+    const map = { "built-ins/Array": { ES5: 10 }, "built-ins/Temporal": { Proposals: 4603 } };
+
+    // Slider at overall → no edition filter, everything visible. That is the
+    // legitimate null, and it must survive.
+    expect(compute(null, map)).toBeNull();
+
+    // An edition IS selected and a map is present → a real filter.
+    const allowed = compute(new Set(["ES5", "ES2026"]), map);
+    expect(allowed).toBeInstanceOf(Set);
+    expect(allowed?.has("built-ins/Array")).toBe(true);
+    expect(allowed?.has("built-ins/Temporal")).toBe(false);
+  });
+
+  it("hides every proposal-only category under a published edition", () => {
+    if (!existsSync(CATEGORY_EDITIONS) || !existsSync(STANDALONE_REPORT)) return;
+
+    const compute = buildAllowedCategories(html);
+    const map = JSON.parse(readFileSync(CATEGORY_EDITIONS, "utf-8")) as Record<string, Record<string, unknown>>;
+    const standalone = JSON.parse(readFileSync(STANDALONE_REPORT, "utf-8")) as {
+      categories?: Array<{ name: string }>;
+    };
+    const categories = standalone.categories ?? [];
+    expect(categories.length).toBeGreaterThan(10);
+
+    // Widest published selection the slider can make.
+    const published = new Set<string>();
+    for (const byEdition of Object.values(map)) {
+      for (const ed of Object.keys(byEdition)) {
+        if (/^ES(\d{4}|5|3 \/ Core|[12])$/.test(ed)) published.add(ed);
+      }
+    }
+    // Route the map through the standalone view's own wiring — with the bug
+    // present this yields null and every row below stays visible.
+    const asWired = buildStandaloneCategoryEditions(html)(map);
+    const allowed = compute(published, asWired);
+    expect(allowed, "standalone view produced no category filter").toBeInstanceOf(Set);
+
+    const visible = categories.map((c) => c.name).filter((name) => allowed?.has(name));
+    // The headline symptom.
+    expect(visible).not.toContain("built-ins/Temporal");
+    // …and no other proposal-scope category rides along.
+    expect(visible).not.toContain("built-ins/AbstractModuleSource");
+    // The filter must narrow, not blank the table.
+    expect(visible.length).toBeGreaterThan(categories.length / 2);
+  });
+});

--- a/tests/website-issue-links.test.ts
+++ b/tests/website-issue-links.test.ts
@@ -1,0 +1,93 @@
+// Issue references on the website must link to THIS project's markdown issues,
+// never to github.com/<repo>/issues/<id>.
+//
+// Why this matters more than a normal broken link: the repo has no GitHub
+// issues at all, and — per CLAUDE.md — issue ids share ONE number sequence with
+// pull requests. So github.com/loopdive/js2/issues/661 does not 404. GitHub
+// redirects it to PR #661, an unrelated page that looks entirely legitimate.
+// Measured before this fix:
+//   report.html  #661  "Temporal proposal/polyfill gap"
+//                      -> PR "docs(#1632): escalate Function.bind/toString"
+//   npm-compat   #1031 (lodash)
+//                      -> PR "feat(number): add standalone integer radix toString"
+//   npm-compat   #1710 (acorn)
+//                      -> PR "fix(#6408): standalone object-literal data/method keys"
+// Nothing on the page signals the mismatch, which is why it went unnoticed.
+//
+// The correct target is the dashboard's markdown viewer, which already resolves
+// a bare id (including suffixed ids like 1326c) through plan/issues/index.json.
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname ?? ".", "..");
+const REPORT_HTML = join(ROOT, "website", "public", "benchmarks", "report.html");
+const NPM_CHART = join(ROOT, "website", "components", "npm-compat-chart.js");
+const ISSUE_VIEWER = join(ROOT, "website", "dashboard", "issue.html");
+
+const read = (p: string) => readFileSync(p, "utf-8");
+
+describe("website issue links", () => {
+  it("never points an issue id at the GitHub issues tracker", () => {
+    for (const [name, path] of [
+      ["report.html", REPORT_HTML],
+      ["npm-compat-chart.js", NPM_CHART],
+    ] as const) {
+      const src = read(path);
+      // Any interpolation of an id into an issues URL is the bug, in either
+      // template form.
+      expect(src, `${name} still builds a GitHub issues URL`).not.toMatch(
+        /github\.com\/loopdive\/js2\/issues\/(\$\{|"\s*\+|'\s*\+)/,
+      );
+    }
+  });
+
+  it("routes both report and npm-compat issue refs to the markdown viewer", () => {
+    expect(read(REPORT_HTML)).toContain('assetPath("dashboard/issue.html?id="');
+    const chart = read(NPM_CHART);
+    expect(chart).toContain("dashboard/issue.html?id=");
+    // Both call sites go through the one helper rather than hand-rolling a URL.
+    expect(chart).toContain("_issueUrl(pkg.issue)");
+    expect(chart).toContain("_issueUrl(b.issue)");
+  });
+
+  it("accepts the numeric `id` parameter the new links use", () => {
+    const viewer = read(ISSUE_VIEWER);
+    // Linking to ?id= against a viewer that only reads ?slug= would render the
+    // "Invalid issue URL" error for every link on the site.
+    expect(viewer).toMatch(/params\.get\("slug"\)\s*\|\|\s*params\.get\("id"\)/);
+  });
+
+  it("resolves issue data relative to the deployment base path", () => {
+    const viewer = read(ISSUE_VIEWER);
+    // The site is served from a domain root AND from loopdive.github.io/js2/.
+    // Absolute "/plan/issues/…" 404s under the subpath, which would make every
+    // one of these links land on a broken viewer there.
+    expect(viewer).toContain("const BASE_PATH =");
+    expect(viewer).toMatch(/issueAsset\(`plan\/issues\/\$\{slug\}\.md`\)/);
+    expect(viewer).toContain('issueAsset("plan/issues/index.json")');
+    expect(viewer).not.toMatch(/fetch\(["'`]\/plan\/issues\//);
+  });
+
+  it("links ids that the issue index can actually resolve", () => {
+    const indexPath = join(ROOT, "plan", "issues");
+    if (!existsSync(indexPath)) return;
+
+    // Every id referenced by the standalone root-cause buckets must correspond
+    // to a real plan/issues/<id>-*.md, or the viewer will 404 on it.
+    const reportBuilder = join(ROOT, "scripts", "build-test262-report.mjs");
+    if (!existsSync(reportBuilder)) return;
+    const ids = new Set<string>();
+    for (const m of read(reportBuilder).matchAll(/issues:\s*\[([^\]]*)\]/g)) {
+      for (const raw of m[1].matchAll(/["']#?([0-9]+[a-z]?)["']/g)) ids.add(raw[1]);
+    }
+    expect(ids.size).toBeGreaterThan(10);
+
+    const { readdirSync } = require("node:fs") as typeof import("node:fs");
+    const files = readdirSync(indexPath).filter((f) => f.endsWith(".md"));
+    const known = new Set(files.map((f) => f.split("-")[0]));
+
+    const dangling = [...ids].filter((id) => !known.has(id));
+    expect(dangling, `issue ids referenced by the report with no plan/issues file: ${dangling.join(", ")}`).toEqual([]);
+  });
+});

--- a/website/components/npm-compat-chart.js
+++ b/website/components/npm-compat-chart.js
@@ -66,6 +66,21 @@ class NpmCompatChart extends HTMLElement {
     return `https://www.npmjs.com/package/${name}/v/${version}${code ? "?activeTab=code" : ""}`;
   }
 
+  // An issue reference here is THIS project's markdown issue
+  // (plan/issues/<id>-<slug>.md), not a GitHub issue. The repo has no GitHub
+  // issues, and issue ids share one number sequence with PRs, so
+  // github.com/loopdive/js2/issues/<id> did not 404 — it silently redirected to
+  // an unrelated PULL REQUEST (lodash's #1031 opened "feat(number): add
+  // standalone integer radix toString"). Link the dashboard's markdown viewer,
+  // which resolves a bare id via plan/issues/index.json.
+  //
+  // Relative, not absolute: this page is served both from the domain root and
+  // from a project subpath (loopdive.github.io/js2/), and it always sits one
+  // level above `dashboard/`.
+  _issueUrl(id) {
+    return `dashboard/issue.html?id=${encodeURIComponent(String(id))}`;
+  }
+
   _fmtDate(iso) {
     if (!iso) return "";
     const d = new Date(iso);
@@ -340,7 +355,7 @@ class NpmCompatChart extends HTMLElement {
     const npmPackageUrl = this._npmUrl(pkg);
     const npmCodeUrl = this._npmUrl(pkg, true);
     const issueLink = pkg.issue
-      ? `<a class="issue" href="https://github.com/loopdive/js2/issues/${pkg.issue}" target="_blank" rel="noopener">#${pkg.issue}</a>`
+      ? `<a class="issue" href="${this._issueUrl(pkg.issue)}" target="_blank" rel="noopener">#${pkg.issue}</a>`
       : "";
     const lanes = pkg.perf?.lanes ?? (pkg.perf ? { jsHost: pkg.perf } : {});
     const speedFactor = (lane) => {
@@ -455,7 +470,7 @@ class NpmCompatChart extends HTMLElement {
           pkg.knownBugs
             .map(
               (b) =>
-                `<a href="https://github.com/loopdive/js2/issues/${b.issue}" target="_blank" rel="noopener" title="${this._esc(b.summary)}">#${b.issue}</a>`,
+                `<a href="${this._issueUrl(b.issue)}" target="_blank" rel="noopener" title="${this._esc(b.summary)}">#${b.issue}</a>`,
             )
             .join(" "),
         )

--- a/website/dashboard/issue.html
+++ b/website/dashboard/issue.html
@@ -180,6 +180,16 @@
     </article>
 
     <script>
+      // The site is served from the domain root (js2.loopdive.com) AND from a
+      // project subpath (loopdive.github.io/js2/). Absolute "/plan/issues/…"
+      // fetches only work in the first case — under the subpath they resolve to
+      // loopdive.github.io/plan/… and 404, so this viewer was unreachable there.
+      // Derive the base the same way benchmarks/report.html does.
+      const BASE_PATH = window.location.pathname.replace(/\/dashboard\/.*$/, "");
+      function issueAsset(path) {
+        return BASE_PATH ? `${BASE_PATH}/${path}` : `/${path}`;
+      }
+
       // Fetch an issue's markdown. `slug` may be a full filename stem
       // (681-pure-wasm-…) or a bare issue id (681 / 1525b). Resolution works in
       // both modes:
@@ -190,15 +200,15 @@
       async function fetchIssueMarkdown(slug) {
         // 1) Try the slug directly (full filename, or a bare id the dev plugin
         //    prefix-resolves).
-        let response = await fetch(`/plan/issues/${slug}.md`);
+        let response = await fetch(issueAsset(`plan/issues/${slug}.md`));
         if (response.ok) return await response.text();
 
         // 2) Fall back: treat the slug as a bare id and resolve via index.json.
-        const index = await fetch("/plan/issues/index.json")
+        const index = await fetch(issueAsset("plan/issues/index.json"))
           .then((r) => (r.ok ? r.json() : null))
           .catch(() => null);
         if (index && index[slug]) {
-          response = await fetch(`/plan/issues/${index[slug]}.md`);
+          response = await fetch(issueAsset(`plan/issues/${index[slug]}.md`));
           if (response.ok) return await response.text();
         }
 
@@ -206,13 +216,17 @@
       }
 
       async function loadIssue() {
-        // Extract slug from URL query parameter
+        // Extract the issue reference from the URL. `slug` is the dashboard's
+        // form (full filename stem); `id` is the numeric form used by callers
+        // that only carry an issue id — the report page's root-cause buckets
+        // and the npm-compat cards. Both funnel into the same resolver, which
+        // already handles a bare id via index.json.
         const params = new URLSearchParams(window.location.search);
-        const slug = params.get("slug");
+        const slug = params.get("slug") || params.get("id");
 
         if (!slug) {
           document.getElementById("content").innerHTML =
-            '<div class="error">Invalid issue URL. Missing slug parameter.</div>';
+            '<div class="error">Invalid issue URL. Missing slug or id parameter.</div>';
           return;
         }
 

--- a/website/public/benchmarks/report.html
+++ b/website/public/benchmarks/report.html
@@ -2229,6 +2229,14 @@
           header.appendChild(
             el("span", { style: { fontSize: "0.8125rem", wordBreak: "break-word" } }, b.label || b.id),
           );
+          // These ids are THIS project's markdown issues (plan/issues/<id>-<slug>.md),
+          // not GitHub issues. The repo has no GitHub issues at all, and issue
+          // ids share one number sequence with PRs — so linking to
+          // github.com/loopdive/js2/issues/<id> did not 404, it silently
+          // redirected to an unrelated PULL REQUEST (e.g. the Temporal bucket's
+          // #661 opened "docs(#1632): escalate Function.bind/toString"). Point
+          // at the dashboard's markdown viewer instead, which resolves a bare
+          // id — including suffixed ones like 1326c — via plan/issues/index.json.
           for (const issue of b.issues || []) {
             const num = String(issue).replace(/^#/, "");
             header.appendChild(
@@ -2236,7 +2244,7 @@
                 "a",
                 {
                   className: "rc-issue-link",
-                  href: "https://github.com/loopdive/js2/issues/" + num,
+                  href: assetPath("dashboard/issue.html?id=" + encodeURIComponent(num)),
                   target: "_blank",
                   rel: "noopener",
                 },

--- a/website/public/benchmarks/report.html
+++ b/website/public/benchmarks/report.html
@@ -2566,8 +2566,24 @@
 
         if (conformance) {
           // (#2871 #1) Host (JS) vs Standalone (pure Wasm) views. Both share the
-          // same report schema; standalone ships no per-file JSONL nor a
-          // per-category×edition file, so those degrade gracefully.
+          // same report schema; standalone ships no per-file JSONL, so the
+          // per-test error-pattern list degrades to the root-cause buckets.
+          //
+          // The per-category×edition map is SHARED, not host-only. An edition is
+          // a property of the test file's frontmatter, not of the compile
+          // target, and the category-table filter reads only this map's edition
+          // KEYS (`computeAllowedCategories`), never its host pass/fail counts —
+          // so pointing the standalone view at it cannot leak host numbers.
+          // Passing `null` here used to make `computeAllowedCategories` bail out
+          // and return null, which `applyFilters` reads as "no edition filter":
+          // every standalone category row stayed visible at every slider
+          // position, so selecting ES2026 still listed `built-ins/Temporal`
+          // (4,603 proposal tests). The only standalone categories absent from
+          // the map are `built-ins/Temporal` and `built-ins/AbstractModuleSource`
+          // (both Proposals) plus `built-ins/undefined` and `language/export`
+          // (both Unclassified) — none is a published edition, so hiding them
+          // under a published-edition selection is correct and makes the two
+          // views behave the same way.
           const hostView = {
             mode: "host",
             report: conformance,
@@ -2580,7 +2596,7 @@
                 mode: "standalone",
                 report: standaloneReport,
                 editionsSrc: STANDALONE_EDITIONS_JSON,
-                categoryEditions: null,
+                categoryEditions: categoryEditions || null,
                 fileResultsSrc: null,
               }
             : null;


### PR DESCRIPTION
## Description

Three independent website fixes, each its own commit. They share a branch because the work was sequential.

---

## 1. The standalone tab ignored the edition slider (`9cb52fac`)

Selecting **ES2026** in the **standalone** tab listed `built-ins/Temporal` (4,603 proposal tests) as a category row.

Not a regression of #4237 — that fix covered the host view's Error Patterns list and is intact. This is a different code path it never touched.

### Root cause

The standalone view was constructed with `categoryEditions: null`. `computeAllowedCategories` then hits its bail-out:

```js
if (!categoryEditions || Object.keys(categoryEditions).length === 0) return null;
```

and `applyFilters` reads that `null` as *"no edition filter"*, not *"nothing allowed"*:

```js
const editionMatch = !allowedCats || allowedCats.has(cat.name);
```

So **every** standalone category row stayed visible at **every** slider position — the tab ignored the slider entirely. Temporal was just the most conspicuous row.

### Fix

Pass the same per-category × edition map to the standalone view. Sharing it is sound: an edition is a property of the test file's **frontmatter**, not of the compile target, and the filter reads only the map's edition **keys**, never its host pass/fail counts — pinned by a test.

Verified against deployed artifacts: ES2026 standalone now shows **87 of 94** rows; the 7 hidden are `Temporal` / `AbstractModuleSource` (Proposals), `built-ins/undefined` / `language/export` (Unclassified), and `DisposableStack` / `AsyncDisposableStack` / `SuppressedError` (ES2027).

---

## 2. Issue links opened unrelated pull requests (`78dbdd4a`)

Issue references linked to `github.com/loopdive/js2/issues/<id>`. This project has **no GitHub issues** — they are markdown files at `plan/issues/<id>-<slug>.md` — and issue ids share **one number sequence** with PRs. So the links did not 404; GitHub redirected each to the PR with that number:

| Link | Means | Actually opened |
|---|---|---|
| `#661` "Temporal proposal/polyfill gap" | `661-temporal-api-via-compiled-polyfill.md` | PR *"docs(#1632): escalate Function.bind/toString"* |
| `#1031` (lodash) | `1031-compile-lodash-to-wasm-as.md` | PR *"feat(number): add standalone integer radix toString"* |
| `#1710` (acorn) | `1710-acorn-dogfood-harness.md` | PR *"fix(#6408): standalone object-literal data/method keys"* |

A real, plausible page with nothing to do with what was clicked, and nothing on screen signalling the mismatch.

### Fix

Three call sites — the report page's root-cause buckets (92 refs) and both npm-compat link sites — now target the dashboard's markdown viewer, which already resolved a bare id (including suffixed ids like `1326c`) via `plan/issues/index.json`. Two supporting fixes the links depend on:

- `issue.html` accepted only `?slug=`; it now also takes `?id=`.
- `issue.html` fetched an **absolute** `/plan/issues/…`, which 404s under the project-subpath deployment (`loopdive.github.io/js2/`) — the viewer was **already broken there**. It now derives `BASE_PATH` the way `benchmarks/report.html` does. Verified both hosts resolve `#661`, `#1031`, `#1326c` to a real `.md` (HTTP 200).

Also drops `"#2463"` from the honest-vacuity bucket's issue list: it is a **PR** number (the PR that implemented #2940, already listed), so it pointed at a nonexistent issue file. The new test caught it. `website/index.html`'s link to `axios/axios/issues/10636` is untouched — a genuine external issue.

---

## 3. JS-host benchmarks now show their source, like WASI (`107ea70f`)

The WASI host group gives every benchmark a "Show source" block; the JavaScript host group gave none, so its four bars (`fib`, `loop`, `string`, `array`) were unattributed numbers — a reader could see a speedup but not what was measured.

Adds a **Sources** area to the JS-host group using the same markup and classes as the WASI groups, so it needs no new CSS.

What is shown is the measured **kernel** — the single exported function the harness times (`bench_fib` / `bench_loop` / `bench_string` / `bench_array`, per the entry table in `scripts/generate-playground-benchmark-sidebar.mjs`), plus `fib()`'s recursive helper. Each file also exports a `main()` that draws the playground's DOM card; it is compiled but never timed, so including it would overstate the kernel — the subcopy says so rather than leaving the omission implicit. Descriptions are the ones the benchmark files already give themselves in their `addBenchCard()` calls.

Verified the rendered result with jsdom: the JS-host group now has 4 source blocks to WASI's 4, entities decode back to the original TypeScript, and both charts are still in place.

---

## Tests

All three suites drive the real artifacts rather than a re-implementation, because a re-implemented rule passes happily while the real one regresses — I hit exactly that on the first draft of the first two.

- `report-standalone-category-edition-scope.test.ts` — routes the map through the standalone view's own `categoryEditions:` expression, so it fails on a **wiring** regression, not only a logic one. 2 of 4 fail with the fix reverted.
- `website-issue-links.test.ts` — 4 of 5 fail when the three aspects are reverted. The fifth cross-checks every linked id against real `plan/issues/*.md`; that is what found `#2463`.
- `landing-benchmark-sources.test.ts` — inlined source is only honest if it cannot drift, so it pins that every charted benchmark (read from `playground-benchmark-sidebar.json`) has a block, that each snippet appears **verbatim** in its `.ts` file, that each contains the export the generator names as timed, and that none contains `main()`. Editing a snippet and deleting a block were both confirmed to fail it.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: agreeing to a CLA is the repository owner's affirmation to make. Internal authors are exempt by allowlist. -->