### PR TITLE
feat(website): npm-compat measured-at shows time, not only date

### DIFF
--- a/website/components/npm-compat-chart.js
+++ b/website/components/npm-compat-chart.js
@@ -70,7 +70,10 @@ class NpmCompatChart extends HTMLElement {
     if (!iso) return "";
     const d = new Date(iso);
     if (Number.isNaN(d.valueOf())) return "";
-    return d.toISOString().slice(0, 10);
+    // Date AND time (UTC): the artifact refreshes on every merge to main —
+    // several times a day — so a bare date cannot tell a fresh measurement
+    // from a twelve-hour-old one (stakeholder request, 2026-08-09).
+    return `${d.toISOString().slice(0, 16).replace("T", " ")} UTC`;
   }
 
   // ratio = nodeUs / wasmUs. >1 => wasm faster. <1 => node faster.


### PR DESCRIPTION
Stakeholder request: the npm-compat page's data refreshes on every merge to main, so the measured-at display needs the time — a bare date can't distinguish a fresh measurement from a twelve-hour-old one. Renders `YYYY-MM-DD HH:MM UTC` (single formatter call site; trend-axis ticks stay date-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAPpV5PjTA98gW2Tjqhrki