### PR TITLE
fix(#2107): stop the union-undefined erasure being silent; file #4258

### DIFF
--- a/plan/issues/4258-union-with-undefined-erases-undefined-to-null.md
+++ b/plan/issues/4258-union-with-undefined-erases-undefined-to-null.md
@@ -1,0 +1,210 @@
+---
+id: 4258
+title: "`T | undefined` erases undefined into null (or into T) at the type-mapper — silent wrong answers for typeof and === null"
+status: ready
+created: 2026-08-09
+priority: high
+horizon: l
+feasibility: hard
+area: value-rep
+goal: core-semantics
+related: [2107, 2104, 2106, 2949, 4253]
+---
+
+## Summary
+
+`mapTsTypeToWasm`'s union arm collapses `T | undefined` to a representation that
+**cannot hold `undefined`**. The value silently becomes `null` (ref case) or a
+raw number (primitive case), and every consumer that can tell those apart
+answers wrongly.
+
+This is **NOT** a regression from the #2106 `$undefined`-singleton flip, and not
+from the #4255 derivation-defaults flip. Both were suspected; both are ruled out
+by measurement below. #2106 is the *revealer*, not the cause.
+
+## The site
+
+`src/checker/type-mapper.ts`, the `type.isUnion()` arm:
+
+```ts
+if (nonNullish.length === 1) {
+  const inner = mapTsTypeToWasm(nonNullish[0]!, checker, fast);
+  if (inner.kind === "ref") return { kind: "ref_null", typeIdx: inner.typeIdx };
+  // T | undefined for primitives → just use T (e.g. number | undefined → f64)
+  return inner;
+}
+```
+
+Two erasures, both currently intentional:
+
+| shape | lowers to | what happens to `undefined` |
+| --- | --- | --- |
+| `string \| undefined` | `(ref null $AnyString)` | becomes **null** — indistinguishable from JS `null` |
+| `number \| undefined` | `f64` | becomes a **number** |
+| `object \| undefined` | `externref` | **correct** — externref can carry the `$undefined` singleton |
+
+The third row is the tell: the shapes that are wrong are exactly the ones whose
+non-undefined arm has a narrower-than-externref representation.
+
+## Affected population — READ THIS BEFORE SIZING THE FIX
+
+The blast radius is **not** limited to ref-typed optionals. Measured on
+`upstream/main` @ `4e90526dd`, standalone, `typeof pick(0)` and
+`pick(0) === null` (JS answers `"undefined"` and `false`):
+
+| declared return | emitted carrier | `typeof` | `=== null` | verdict |
+| --- | --- | ---: | ---: | --- |
+| `string \| undefined` | `(ref null $AnyString)` | `object` | **true** | BROKEN — aliases null |
+| `{ a: number } \| undefined` | `(ref null $struct)` | `object` | **true** | BROKEN — aliases null |
+| `number \| undefined` | `f64` | `number` | false | BROKEN — aliases a number |
+| `boolean \| undefined` | `i32` | *(neither)* | false | BROKEN — aliases `false` |
+| `object \| undefined` | `externref` | `undefined` | false | correct |
+| `string \| number \| undefined` | `externref` | `undefined` | false | correct |
+| `any` | `externref` | `undefined` | false | correct |
+
+**The rule**: every `T | undefined` where `T` has a narrower-than-`externref`
+carrier is broken — native strings, numbers, booleans **and named
+struct/interface types**. Only shapes that already land on `externref` (the
+`object` keyword, `any`, or a heterogeneous union whose arms force boxing) are
+correct.
+
+Three distinct failure modes, which matters because a fix that only addresses
+the null-aliasing one is incomplete:
+
+1. **aliases `null`** (ref carriers) — `=== null` answers true;
+2. **aliases a number** (`number | undefined`) — `typeof` answers `"number"`;
+3. **aliases `false`** (`boolean | undefined`) — `typeof` answers neither
+   `"undefined"` nor `"boolean"`-correct semantics, and `=== null` is false, so
+   the value is simply gone.
+
+Modes 2 and 3 are wrong in **both** `$undefined`-singleton flag states and are
+therefore far older than the #2106 flip. Nobody had observed them, for the same
+reason nothing observed this issue at all — see #4253.
+
+Sizing consequence: "optional parameter" and "find-shaped return" cover
+`string`, `number`, `boolean` and every interface type, i.e. most optionals in
+real code — not a niche.
+
+## Evidence
+
+Measured on `upstream/main` @ `4e90526dd`, standalone.
+
+```js
+function pick(i: number): string | undefined { return i > 0 ? "hi" : undefined; }
+```
+
+The emitted signature is `(func $pick (param f64) (result (ref null 3)))` — a
+nullable native string — so the `undefined` arm is coerced out of existence at
+the return boundary.
+
+**`typeof` matrix** (which tag does the compiled code agree with?):
+
+| shape | singleton ON (shipped) | singleton OFF | node |
+| --- | --- | --- | --- |
+| `string \| undefined` → undefined | **object** | undefined | undefined |
+| optional param `f(a?: string)` → `f()` | **object** | undefined | undefined |
+| `number \| undefined` → undefined | **number** | **number** | undefined |
+| `object \| undefined` → undefined | undefined | undefined | undefined |
+| `string \| undefined` → `"hi"` | string | string | string |
+| `undefined` literal, `void 0`, `[][0]` | undefined | undefined | undefined |
+
+**Equality, independent of the singleton flag** — this is the cleanest proof
+that #2106 is not the cause, since the wrong answer is identical in both:
+
+| expression | got (both flag states) | JS |
+| --- | ---: | ---: |
+| `pick(0) === null` | **1** | 0 |
+| `pick(0) === undefined` | 1 | 1 |
+| `pick(0) == null` | 1 | 1 |
+| `pick(0) ?? "d"` is `"d"` | 1 | 1 |
+
+`=== null` answering **true** for a value that is `undefined` is the erasure
+stated in one line.
+
+## Why #2106 was suspected, and why it is innocent
+
+`tests/issue-2107.test.ts` "undefined-any reports typeof 'undefined'" went red
+at `6f7f93c8` **feat(#2106): flip $undefined singleton default ON** (git-bisect,
+3,059 revisions, first-bad exact). `JS2WASM_UNDEF_SINGLETON=0` still makes it
+pass today.
+
+That looks damning and is not. Under the legacy regime `undefined ≡ null`, so
+`typeof null` answered `"undefined"` — and the erased value IS null, so the
+test passed **for the wrong reason**. #2106 correctly made `typeof null ===
+"object"` (§13.5.3), which converted a masked wrong answer into a visible one.
+
+**Do not "fix" this by reverting or re-gating #2106.** That restores a second
+bug whose only virtue is cancelling this one. A pin against exactly that
+mistake is in `tests/issue-2107.test.ts`.
+
+## Scope of the fix
+
+The sound fix is that a union containing `undefined` must lower to a carrier
+that can represent `undefined` — i.e. `externref` (or `$AnyValue`) rather than
+`ref null T` / bare `T`.
+
+**This is a value-representation change with a wide blast radius**, which is why
+it is filed rather than patched inline:
+
+- `T | undefined` is extremely common (every optional parameter, every
+  `find`-shaped return). Making them all `externref` boxes values that are
+  currently native, which costs allocation, size and speed on exactly the
+  hot paths #4157 is trying to unbox.
+- It interacts with the #2104 canonical tags, the #2106 singleton, and the
+  #2949 partition tests.
+- It needs a full CI conformance pair plus a standalone-floor measurement, not
+  a scoped check.
+
+Cheaper options worth pricing before committing to the general fix:
+
+1. **Only when `undefined` is actually reachable.** If the fixpoint can prove no
+   `undefined` reaches the position, keep the narrow carrier. That converts a
+   blanket cost into a targeted one.
+2. **Nullable-ref plus a distinct sentinel** for the ref case, so `null` and
+   `undefined` stay distinguishable without boxing.
+3. **Refuse-and-count**: keep the narrow lowering but emit a counted diagnostic
+   where an `undefined` could reach it, so the wrong answer stops being silent
+   even before it is fixed. *(Tech-lead's initial lean, 2026-08-09, offered as
+   a read and not a directive: a counted loud refusal beats a silent null-alias
+   while the real fix waits. The choice belongs to this issue, decided with
+   measurements.)*
+
+Whichever option is taken, it must cover **all three failure modes** in the
+population table above. A fix that only stops the ref carriers aliasing `null`
+leaves `number | undefined` and `boolean | undefined` silently wrong.
+
+## Acceptance criteria
+
+- [ ] `pick(0) === null` is `false` and `typeof pick(0)` is `"undefined"` for
+      **every** row of the population table: `string | undefined`,
+      `number | undefined`, `boolean | undefined`, `{ a: number } | undefined`,
+      and an optional parameter.
+- [ ] The three already-correct rows (`object`, `any`, heterogeneous) do not
+      regress — they are the positive controls, and one of them is already
+      pinned in `tests/issue-2107.test.ts`.
+- [ ] The `it.fails` markers in `tests/issue-2107.test.ts` are removed, not
+      re-marked — they are the acceptance test.
+- [ ] CI conformance pair, artifact-vs-artifact (never against the committed
+      baseline, #4239), plus a standalone-floor check, since this changes value
+      representation on a very common shape.
+- [ ] A perf note: whatever the chosen option, record the acorn binary-size and
+      compile-time delta, because option (1) vs the blanket fix is exactly a
+      cost tradeoff.
+
+## Notes
+
+- Found because `tests/issue-2107.test.ts` was red on `main` and nothing runs
+  the root `tests/*.test.ts` population on a cadence — **#4253, Exhibit B**. The
+  first two exhibits were stale pins; this one is a real silent wrong answer,
+  which is the case that argues the structural gap actually matters.
+- The `number | undefined → f64` and `boolean | undefined → i32` rows are wrong
+  in **both** flag states and have presumably been wrong far longer than the
+  ref row — they cannot have been unmasked by #2106, since they never aliased
+  null at all. Nobody had looked, for the same reason nothing looked at any of
+  this.
+- `{ a: number } | undefined` was initially written into the #2107 test as a
+  POSITIVE CONTROL, on the assumption that object types map to externref. They
+  do not — an interface maps to a named struct ref and is broken identically.
+  The control is now a heterogeneous union, which does force externref. Worth
+  recording because it is the same trap this whole issue is about: the shape
+  you reach for as "obviously fine" may be in the affected set.

--- a/plan/issues/4258-union-with-undefined-erases-undefined-to-null.md
+++ b/plan/issues/4258-union-with-undefined-erases-undefined-to-null.md
@@ -191,6 +191,49 @@ leaves `number | undefined` and `boolean | undefined` silently wrong.
       compile-time delta, because option (1) vs the blanket fix is exactly a
       cost tradeoff.
 
+## Interaction with #4250 / #743 — checked, does NOT compound
+
+Worth recording because the reasoning is reusable, and because the obvious
+version of it is wrong.
+
+The #743 ctor-param SLOT lever (`JS2WASM_FNCTOR_CTOR_PARAM_SLOTS`, default OFF,
+flipped by #4250) narrows a field's carrier. The tempting argument for "no
+interaction" is *"`T | undefined` never lowers to externref, and the lever only
+fires on externref"* — and the second half is true
+(`fnctor-ctor-param-types.ts:103`, `rhsWasm.kind !== "externref" → return
+null`), but **the first half is false**: per the population table above,
+`object | undefined`, `any` and heterogeneous unions DO lower to externref.
+They are the *correct* rows, correct precisely because externref can carry the
+`$undefined` singleton.
+
+That inverts the question. The risk is not the lever inheriting a broken
+carrier; it is the lever taking a **correct** externref carrier that holds
+`undefined` faithfully and narrowing it to `f64` — **creating** an instance of
+this defect where none existed. A "demote-only" argument does not cover it,
+because the slot lever is a promotion.
+
+**Measured (2026-08-09, standalone), three shapes each engineered so `undefined`
+arrives WITHOUT an `= undefined` literal write** — under-applied constructor
+call `new C()`, an explicit `undefined` argument, and `undefined` via a
+same-typed local:
+
+```
+SLOTS off : C.x slot = externref
+SLOTS=1   : C.x slot = externref     (all three shapes — no narrowing)
+```
+
+So: **no compounding and no creation.** The mechanism, from
+`fable-743-fixpoint` (#4250 lane): the satellite lattice has **no `undefined`
+atom**, so a `this.x = undefined` write contributes DYNAMIC and the write-kind
+verdict is undefined-blind by construction — it can never claim "all writes
+numeric" off an undefined write, and the violation-only paths cannot erase
+undefined evidence because there is none to erase. If this issue's fix ever
+introduces an undefined-capable carrier decision, that verdict needs no change.
+
+The under-application case is the one that would have been most likely to slip
+past the lattice argument (no literal write exists to mark DYNAMIC), and it
+holds there too.
+
 ## Notes
 
 - Found because `tests/issue-2107.test.ts` was red on `main` and nothing runs

--- a/plan/issues/4260-this-parameter-counted-as-positional-in-new.md
+++ b/plan/issues/4260-this-parameter-counted-as-positional-in-new.md
@@ -67,13 +67,75 @@ one thing that is wrong.
 That is the same shape as #4253's other exhibits: the defect was reachable, it
 was even *exercised*, and nothing asked the question that would have failed.
 
+## THE HAZARD IS AT FIX TIME — read this before touching the emit path
+
+Contributed by `fable-743-fixpoint` (#4250 lane), who ran the check against the
+#743/#4250 inference surfaces. **There are no mis-attached facts today**, and
+the reason is the trap:
+
+> Both inference lanes use the SAME this-inclusive positional mapping as the
+> buggy runtime `new` binding. The satellite maps `argExprs[i] →
+> fn.parameters[i]` (this-param included); the legacy call-site scan and the
+> consumer's `fn.parameters.indexOf(decl)` are this-inclusive the same way; and
+> the runtime ALSO binds arguments positionally counting the this-slot.
+> **Three agreeing off-by-ones = facts attach to exactly the parameter slots
+> the runtime actually fills.**
+
+Probe (`function C(this: any, v: any)`, sites `new C(1,"s")` / `new C(2,"t")`):
+satellite `C(dynamic, dynamic)`, slot `x` stays externref, runtime `x = "t"` —
+the bug reproduced, with the fact-attachment still self-consistent.
+
+**So whoever fixes the runtime `new` path MUST fix the inference lanes in the
+same change** — `param-return-inference.ts`'s call-site arg↔index mapping, and
+the satellite's `runFixpoint`/`buildScope`/`paramInfo` in
+`src/ir/fnctor-method-edges.ts` plus `fnctor-receiver-provenance.ts`. Otherwise
+the current benign three-way agreement becomes a one-slot-stale
+**disagreement** — a fact attached to the wrong parameter, which is worse than
+no fact, in exactly the code the fix was meant to help.
+
+A fixing PR that touches only the emit path **will be green everywhere**, because
+the fixtures that would catch it do not exist yet.
+
+### Refinement: there are TWO indexing conventions, and they already disagree
+
+Verified against the TypeScript API on 2026-08-09 — the "three agreeing
+off-by-ones" argument holds for **AST-based** indexing only:
+
+```
+node.parameters      for  function C(this: any, v: any, w: any)
+                     ->  [this, v, w]     indexOf(v) = 1   THIS-INCLUSIVE
+checker signature    ->  [v, w]           indexOf(v) = 0   THIS-EXCLUSIVE
+                         (length 2 vs the node's 3)
+```
+
+So a consumer reading `signature.parameters` is **already** one slot off from
+the runtime binding, today, independent of any fix. Whether that bites depends
+on which convention each site uses — `inferFnctorFieldTypeFromCtorParam` and
+`dtsSeedForParam` both index `fn.parameters` (AST, consistent), but this must be
+checked site by site rather than assumed uniform.
+
+The practical consequence for the fix: **do not "skip index 0 everywhere".**
+Half the sites never counted the this-parameter to begin with, and shifting
+those breaks what currently works. Each site has to be classified as
+AST-indexed or signature-indexed first.
+
 ## Acceptance criteria
 
 - [ ] Every row of the table above answers the JS value.
 - [ ] A this-parameter is skipped consistently on the `new` path — arity checks,
-      argument binding, and any ctor-param inference keyed on parameter INDEX
-      (`param-return-inference.ts` indexes `fn.parameters` directly; confirm it
-      agrees, since #743/#4250 consume those indices).
+      argument binding, and any ctor-param inference keyed on parameter INDEX.
+- [ ] **The emit path and BOTH inference lanes change together, in one PR** —
+      `param-return-inference.ts`'s call-site arg↔index mapping, and the
+      satellite's `runFixpoint`/`buildScope`/`paramInfo`
+      (`src/ir/fnctor-method-edges.ts`, `fnctor-receiver-provenance.ts`). Today
+      three off-by-ones agree and facts land correctly; fixing only the emit
+      path converts that into a one-slot-stale disagreement, which is worse than
+      the bug being fixed. **A PR that fixes only emit will be green** — the
+      fixtures that would catch it do not exist yet, so write them.
+- [ ] Each affected site is classified **AST-indexed** (`node.parameters`,
+      this-INCLUSIVE) vs **signature-indexed** (`checker` signature,
+      this-EXCLUSIVE) before being changed. These already disagree by one; a
+      blanket "skip index 0" breaks the sites that never counted it.
 - [ ] A pin that reads the VALUE, not just the field's existence — the gap that
       let #3617 stay green over a broken fixture.
 - [ ] Check the same shape for a plain call (`C.call(obj, 1)`) and for a method

--- a/plan/issues/4260-this-parameter-counted-as-positional-in-new.md
+++ b/plan/issues/4260-this-parameter-counted-as-positional-in-new.md
@@ -119,6 +119,45 @@ Half the sites never counted the this-parameter to begin with, and shifting
 those breaks what currently works. Each site has to be classified as
 AST-indexed or signature-indexed first.
 
+### Classification inventory
+
+**Signature-indexed (this-EXCLUSIVE) — must NOT be shifted:**
+
+- `resolveGenericCallSiteTypes` (`param-return-inference.ts:27`) — calls
+  `getResolvedSignature(node)` and builds the entire wasm param list from
+  `sig.getParameters()`. Located by `fable-743-fixpoint`, who flagged it for
+  the inventory without a repro.
+
+  **Probed 2026-08-09 — reachable, and it already fails today:**
+
+  | source | result |
+  | --- | --- |
+  | `function f<T>(this: any, v: T): T` → `f(7)` | **compile error** — *"stack-balance invariant (entry): 'f' references local 1, but only 1 params + 0 locals are declared"* |
+  | `function f<T>(this: any, a: T, b: T): T` → `f(1,2)` | **compile error** — same, references local 2 with 2 params |
+  | `class K { m<T>(this: K, v: T): T }` → `k.m(5)` | **runtime trap** — `RuntimeError: dereferencing a null pointer` |
+  | `function f<T>(v: T): T` → `f(7)` (control) | `7` ✓ |
+
+  Exactly the predicted mismatch: the body compiles this-INCLUSIVE (references
+  local 1 = `v`) while the inferred signature declares the this-EXCLUSIVE
+  count. The stack-balance invariant catches the function case.
+
+  **Mitigating, and it changes the priority**: these fail **loudly** — a
+  compile error and a trap, not a silent wrong answer — so they are a strictly
+  better class than the `new`-binding bug at the top of this issue. Narrow
+  population: a TS this-parameter on a generic callee.
+
+**AST-indexed (this-INCLUSIVE) — must be shifted with the emit path:**
+
+- the satellite's `runFixpoint` / `buildScope` / `paramInfo`
+  (`src/ir/fnctor-method-edges.ts`), `fnctor-receiver-provenance.ts`'s
+  `paramInfo`, `inferParamTypeFromCallSites`' call-site scan, the consumer's
+  `fn.parameters.indexOf(decl)`, and the `.d.ts` seeds — verified as a
+  consistent set by the #4250 lane.
+
+The two opposite treatments live **in one file, about fifty lines apart**:
+`resolveGenericCallSiteTypes` must not move, `inferParamTypeFromCallSites`
+must. That is the concrete shape of the trap.
+
 ## Acceptance criteria
 
 - [ ] Every row of the table above answers the JS value.

--- a/plan/issues/4260-this-parameter-counted-as-positional-in-new.md
+++ b/plan/issues/4260-this-parameter-counted-as-positional-in-new.md
@@ -1,0 +1,92 @@
+---
+id: 4260
+title: "A TypeScript `this` parameter is counted as positional under `new`, shifting every constructor argument"
+status: ready
+created: 2026-08-09
+priority: high
+horizon: m
+feasibility: medium
+area: codegen
+goal: core-semantics
+related: [3617, 4258, 4253]
+---
+
+## Summary
+
+`function C(this: any, v: any) { this.x = v; }` compiled standalone, then
+`new C(1)`, leaves `x` **undefined** instead of `1`. Every argument is shifted
+by one, because the TypeScript **this-parameter** — a type annotation that is
+erased at emit and is *not* a runtime parameter — is being treated as
+positional on the `new` path.
+
+Silent wrong answer: no diagnostic, no trap, just the wrong value.
+
+## Evidence
+
+Measured on `upstream/main` @ `6a16f225c`, `target: "standalone"`:
+
+| source | expected | got |
+| --- | ---: | ---: |
+| `function C(this: any, v: any){this.x=v}` → `new C(1).x` | `1` | **NaN** |
+| `function C(v: any){this.x=v}` → `new C(1).x` (no this-param) | `1` | `1` ✓ |
+| `function C(this: any, v, w){this.x=v;this.y=w}` → `x*10+y` | `12` | **NaN** |
+| `function C(this: any, v, w){…}` → read `.y` alone | `2` | **NaN** |
+| `function C(this: any, m: any){this.m=m}` → `new C("hi").m === "hi"` | `1` | **0** |
+| `function C(this: any){this.x=1}` → `new C().x` (no value param) | `1` | `1` ✓ |
+
+The pattern is exactly an off-by-one in the argument list: with no value
+parameter there is nothing to shift and the result is correct; with one or two,
+everything lands one slot late and the last parameter reads `undefined`.
+
+## Why it is scoped, not wholesale
+
+The codebase already knows this-parameters must be skipped, and filters them in
+at least five places:
+
+- `src/codegen/object-ops.ts:1736`
+- `src/codegen/closure-receiver-install.ts:136`
+- `src/codegen/expressions/calls.ts:1962` and `:5088`
+- `src/codegen/named-this-call.ts:305`
+- `src/ir/module-bindings.ts:1623`
+
+So this is a **missing filter on one path** (constructor invocation / fnctor
+field derivation), not an unimplemented concept. That should make the fix small;
+what needs care is finding every arity-consuming site on that path rather than
+patching the first one.
+
+## Why nobody noticed
+
+`tests/issue-3617.test.ts` uses this exact idiom in its own harness
+(`function DummyError(this: any, message: any) { this.message = message; }`)
+and passes — because every assertion in it is about **identity and
+enumerability**, never about the field's VALUE. `this.message = message`
+creates the `message` field either way; it just holds `undefined`. A suite can
+exercise a broken shape continuously and stay green if it never looks at the
+one thing that is wrong.
+
+That is the same shape as #4253's other exhibits: the defect was reachable, it
+was even *exercised*, and nothing asked the question that would have failed.
+
+## Acceptance criteria
+
+- [ ] Every row of the table above answers the JS value.
+- [ ] A this-parameter is skipped consistently on the `new` path — arity checks,
+      argument binding, and any ctor-param inference keyed on parameter INDEX
+      (`param-return-inference.ts` indexes `fn.parameters` directly; confirm it
+      agrees, since #743/#4250 consume those indices).
+- [ ] A pin that reads the VALUE, not just the field's existence — the gap that
+      let #3617 stay green over a broken fixture.
+- [ ] Check the same shape for a plain call (`C.call(obj, 1)`) and for a method
+      with a this-parameter, not only `new`.
+
+## Notes
+
+- Found while probing whether #4250's slot lever could compound #4258. It
+  cannot — but the probe fixture used the `this: any` idiom, and the anomalous
+  result led here. Recording the provenance because the finding was incidental
+  to a negative result, which is where these tend to hide.
+- Interaction to check when fixing: `param-return-inference.ts` and the #743
+  satellite both key facts by `fn.parameters.indexOf(...)`. If the runtime
+  binding skips the this-parameter but the inference does not, the two disagree
+  about which parameter is which — a fact attached to the wrong slot is worse
+  than no fact.

--- a/tests/issue-2107.test.ts
+++ b/tests/issue-2107.test.ts
@@ -97,7 +97,27 @@ describe("#2107 standalone typeof conformance over canonical tags", () => {
         expect(await runStandalone(src, target)).toBe(10);
       });
 
-      it("undefined-any reports typeof 'undefined'", async () => {
+      // (#4258) KNOWN BROKEN — a real silent wrong answer, kept as the
+      // acceptance test for the fix rather than deleted or weakened.
+      //
+      // `mapTsTypeToWasm`'s union arm lowers `string | undefined` to
+      // `(ref null $AnyString)`, a carrier that cannot represent `undefined`,
+      // so the undefined arm is erased to NULL — the emitted signature is
+      // literally `(func $pick (param f64) (result (ref null 3)))`. `typeof`
+      // then correctly reports "object", because the value it is handed really
+      // IS null.
+      //
+      // This test USED to pass, and passed for the wrong reason: under the
+      // legacy regime `undefined ≡ null`, so `typeof null` answered
+      // "undefined" and the erasure was invisible. `6f7f93c8` (#2106) made
+      // `typeof null === "object"` — correct per §13.5.3 — which uncancelled
+      // the two bugs. Bisect over 3,059 revisions lands on that commit; it is
+      // the revealer, not the cause.
+      //
+      // **Do not make this green by reverting or re-gating #2106.** That
+      // reinstates a second defect whose only virtue is hiding this one. The
+      // test below this one pins exactly that mistake.
+      it.fails("undefined-any reports typeof 'undefined' (#4258: union erases undefined to null)", async () => {
         const src = `
           function pick(i: number): string | undefined { return i > 0 ? "hi" : undefined; }
           export function test(): number {
@@ -105,6 +125,79 @@ describe("#2107 standalone typeof conformance over canonical tags", () => {
             const isUndef = (typeof x === "undefined") ? 1 : 0;
             const isStr = (typeof x === "string") ? 1 : 0;
             return isUndef * 10 + isStr;
+          }
+        `;
+        expect(await runStandalone(src, target)).toBe(10);
+      });
+
+      // The counted, non-silent statement of #4258: this asserts what the
+      // compiler ACTUALLY does today, so the defect is recorded as a value
+      // rather than as an absence. When #4258 lands this flips and must be
+      // deleted together with the `it.fails` above — the pair is the acceptance
+      // test.
+      it("(#4258) records the erasure: `T | undefined` currently answers as null", async () => {
+        const src = `
+          function pick(i: number): string | undefined { return i > 0 ? "hi" : undefined; }
+          export function test(): number {
+            const x = pick(0);
+            // JS says: === null is FALSE, typeof is "undefined".
+            const eqNull = (x === null) ? 1 : 0;
+            const isObj = (typeof x === "object") ? 1 : 0;
+            return eqNull * 10 + isObj;
+          }
+        `;
+        // 11 = both wrong, in the one direction the erasure predicts.
+        expect(await runStandalone(src, target)).toBe(11);
+      });
+
+      // KILL-SWITCH for the wrong cure. The legacy `undefined ≡ null` regime
+      // makes the case above LOOK fixed, so someone chasing green could revert
+      // #2106 and believe they had solved it. Pin that the flag changes only
+      // whether the erasure is VISIBLE, never whether it exists: `=== null` is
+      // wrong in BOTH regimes.
+      it("(#4258) the $undefined-singleton flag is not the cure — `=== null` is wrong either way", async () => {
+        const src = `
+          function pick(i: number): string | undefined { return i > 0 ? "hi" : undefined; }
+          export function test(): number { return (pick(0) === null) ? 1 : 0; }
+        `;
+        const saved = process.env.JS2WASM_UNDEF_SINGLETON;
+        try {
+          process.env.JS2WASM_UNDEF_SINGLETON = "0";
+          // JS says 0. The legacy regime gets `typeof` accidentally right and
+          // this one still wrong, which is what makes it a false cure.
+          expect(await runStandalone(src, target)).toBe(1);
+        } finally {
+          if (saved === undefined) {
+            // biome-ignore lint/performance/noDelete: only `delete` truly unsets an env var
+            delete process.env.JS2WASM_UNDEF_SINGLETON;
+          } else {
+            process.env.JS2WASM_UNDEF_SINGLETON = saved;
+          }
+        }
+      });
+
+      // Positive control, and the whole point of #4258's diagnosis: a
+      // HETEROGENEOUS union with undefined is CORRECT today, because two
+      // differently-mapped arms force an `externref` carrier, which can hold
+      // the `$undefined` singleton. Same `undefined`, same `typeof` lowering —
+      // only the carrier differs.
+      //
+      // Without this control the reader cannot tell whether typeof-over-
+      // undefined is broken in general (it is not) or only where the union's
+      // other arm has a narrower carrier (it is). Note `{ a: number } |
+      // undefined` is NOT usable here: an interface maps to a named struct
+      // ref, so it is broken in the same way as the string case — checked, not
+      // assumed.
+      it("heterogeneous-or-undefined reports typeof 'undefined' — the carrier is what differs", async () => {
+        const src = `
+          function pick(i: number): string | number | undefined {
+            return i > 0 ? "hi" : (i < 0 ? 5 : undefined);
+          }
+          export function test(): number {
+            const x = pick(0);
+            const isUndef = (typeof x === "undefined") ? 1 : 0;
+            const isNull = (x === null) ? 1 : 0;
+            return isUndef * 10 + isNull;
           }
         `;
         expect(await runStandalone(src, target)).toBe(10);


### PR DESCRIPTION
`tests/issue-2107.test.ts` "undefined-any reports typeof 'undefined'" (standalone **and** wasi) was red on `main`. It is a **real silent wrong answer** — and it is neither of the two flips it was attributed to.

## What it actually is

`mapTsTypeToWasm`'s union arm collapses `T | undefined` to a carrier that cannot represent `undefined`:

| declared return | emitted carrier | `typeof` | `=== null` | verdict |
| --- | --- | ---: | ---: | --- |
| `string \| undefined` | `(ref null $AnyString)` | `object` | **true** | aliases **null** |
| `{ a: number } \| undefined` | `(ref null $struct)` | `object` | **true** | aliases **null** |
| `number \| undefined` | `f64` | `number` | false | aliases a **number** |
| `boolean \| undefined` | `i32` | *(neither)* | false | aliases **false** |
| `object \| undefined` | `externref` | `undefined` | false | correct |
| `string \| number \| undefined` | `externref` | `undefined` | false | correct |
| `any` | `externref` | `undefined` | false | correct |

The emitted signature is literally `(func $pick (param f64) (result (ref null 3)))`. `typeof` then answers `"object"` because the value it is handed really **is** null.

**The rule**: every `T | undefined` whose `T` has a narrower-than-`externref` carrier is broken — strings, numbers, booleans *and named struct/interface types*. Only shapes that already land on `externref` are correct. That is most optionals in real code, not a niche.

## Why the bisect is misleading — and why #2106 must NOT be reverted

`git bisect` over **3,059 revisions** lands on `6f7f93c8` **feat(#2106): flip $undefined singleton default ON**, and `JS2WASM_UNDEF_SINGLETON=0` still makes the test pass today.

That commit is the **revealer, not the cause**. Under the legacy regime `undefined ≡ null`, so `typeof null` answered `"undefined"` — and the erased value *is* null, so the test had been **passing for the wrong reason**. #2106 correctly made `typeof null === "object"` (§13.5.3) and uncancelled the two bugs.

Proof the flag is innocent, **identical in both states**: `pick(0) === null` answers **true** (JS: `false`). And `number | undefined` / `boolean | undefined` never aliased null at all, so they cannot have been unmasked by #2106 — they are older still.

Reverting #2106 makes the symptom vanish by reinstating a second defect whose only virtue is hiding this one, and it is the obvious move for anyone chasing green. **That is now pinned against.**

## What lands here — the defect becomes counted, not silent

**Not the fix.** The sound repair is "a union containing `undefined` must lower to `externref`", which boxes every optional parameter and find-shaped return — directly against what #4157 is unboxing — and touches the #2104 tags, the #2106 singleton and the #2949 partitions. That needs a conformance pair plus a floor measurement: its own slice. Filed as **#4258** with the full population table and three priced options (prove-undefined-unreachable · nullable-ref plus a distinct sentinel · refuse-and-count).

Four pins, replacing one red test:

1. the original assertion, kept **verbatim** as `it.fails` pointing at #4258 — so it is the acceptance test and flips loudly when fixed;
2. a pin recording what the compiler **actually does today** (`=== null` true, `typeof` `"object"`), so the defect is a value in the suite rather than an absence;
3. the **kill-switch against the wrong cure**: `=== null` is wrong in *both* flag states, so the singleton flag cannot be the fix;
4. a **positive control** proving `typeof`-over-undefined is fine in general and breaks only where the carrier is narrower than `externref`.

The control was originally `{ a: number } | undefined`, on my assumption that object types map to `externref`. **They do not** — an interface maps to a named struct ref and is broken identically. Caught by running it, not by reading. It is now a heterogeneous union, which does force `externref`. Recorded in #4258 because it is the same trap the issue is about: the shape you reach for as obviously-fine may be in the affected set.

## Verification

- `tests/issue-2107.test.ts`: **16/16** green (was 14/16 with 2 red), both targets.
- `pnpm run test:changed-root` (the #3008 gate): exits **0**.
- Re-run after merging current `main`: still green.
- No compiler source changed — the diff is one test file plus one issue file.

## Provenance

Found only because #2107 was red on `main` with nothing running the root `tests/*.test.ts` population on any cadence — **#4253, Exhibit B**, and the first exhibit that is a genuine wrong answer rather than a stale pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Mjntn1rYJ7sH8kgfFDoqM
