### PR TITLE
fix(#4235): run the fnctor pipeline on the multi-file compile path

### DIFF
--- a/plan/issues/4235-multifile-compile-fnctor-pipeline-inert.md
+++ b/plan/issues/4235-multifile-compile-fnctor-pipeline-inert.md
@@ -1,9 +1,18 @@
 ---
 id: 4235
 title: "generateMultiModule never assigns ctx.fnctorEscapeGate — the entire fnctor pipeline (per-type layouts included) is silently inert on every multi-file compile"
-status: ready
+status: done
+completed: 2026-08-09
+assignee: ttraenkler/opus-4235-multifile
 created: 2026-08-08
-updated: 2026-08-08
+updated: 2026-08-09
+loc-budget-allow:
+  - src/codegen/fnctor-escape-gate.ts
+  - src/codegen/index.ts
+func-budget-allow:
+  - src/codegen/index.ts::generateMultiModule
+  - src/codegen/index.ts::generateModule
+  - src/codegen/fnctor-escape-gate.ts::analyzeProtoMethodWriteOnce
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -92,22 +101,125 @@ census.
 
 ## Acceptance criteria
 
-- [ ] `generateMultiModule` runs the same fnctor pipeline (escape gate →
+- [x] `generateMultiModule` runs the same fnctor pipeline (escape gate →
       presence/cold analysis → layout analysis when flagged) with
       whole-program visibility across the module graph, or an explicit,
       TELEMETERED refusal (a counted fallback reason, not silence) where
       cross-module analysis is genuinely not yet supported.
-- [ ] A regression test pins the parity: the `TWO_SITE` fixture compiled via
+- [x] A regression test pins the parity: the `TWO_SITE` fixture compiled via
       `compile()` and `compileMulti()` yields the same fnctor analysis
       verdicts (or the telemetered refusal on the multi path).
-- [ ] The alloc-labels diagnostic prints which compile path it ran under, so
+- [x] The alloc-labels diagnostic prints which compile path it ran under, so
       a zero can never again be read without its provenance.
 
-## Notes for the implementer
+## Resolution (2026-08-09)
 
-- Check what else `generateModule` sets up around index.ts:3536 that
-  `generateMultiModule` also lacks — the escape gate may not be the only
-  single-path-only analysis (audit, don't assume).
-- The detector-must-say-I-don't-know rule applies: if multi-file support is
-  deferred, the deferral must be visible in diagnostics and counted in the
-  IR-fallback-style budget, not silent.
+**The whole-program arm landed, not the refusal arm** — with one narrow,
+counted refusal inside it. Line numbers re-verified against main @ `49cab5c82`
+(the filed `:3536` / `:6206` had drifted to `:3548` / `:6241`).
+
+### What changed
+
+`analyzeFnctorEscapeGate` now takes the graph's source files instead of one
+file, and every sub-pass walks all of them:
+`analyzeProtoMethodWriteOnce`, `buildProtoMethodIndex`,
+`buildReceiverStructMap`, and `analyzeFnctorAllocLabels`/`indexSourceFile`.
+`generateMultiModule` calls it at the same point in the pass that
+`generateModule` does, and gained the matching
+`collectDynamicObjectReturnCarrierTypes` + `reserveFnctorStructTypes`
+reservation (same relative position — after `$ObjVecArr`, before
+`collectDeclarations`).
+
+Widening the walk is monotone toward SAFETY in every pass, which is why the
+whole-program arm was landable rather than the refusal arm:
+
+- Site classification: more visible uses can only ADD `sawTyped`/`sawDynamic`
+  evidence, and clause B (`sawTyped` ⇒ `keep-typed`) is absolute. A use still
+  missed leaves the site `keep-static`, which no lowering consumes.
+- `analyzeProtoMethodWriteOnce` admits a slot precisely BECAUSE it saw no
+  second write — so a one-file view of a graph would admit a slot another
+  module overwrites (a real miscompile). Unioning across files only ever adds
+  writes and poison.
+- `buildProtoMethodIndex`: more bodies for a name make it ambiguous
+  (≥2 ⇒ unresolved), never resolve it to a wrong callee.
+
+### The two genuinely cross-module hazards, and what was done
+
+1. **Import-alias symbol identity.** A use in module B of a binding declared
+   in A keys under the import-alias symbol, so A's binding looked unused.
+   Fixed by resolving through `checker.getAliasedSymbol`. (Left unfixed this
+   was inert rather than wrong — no uses ⇒ `keep-static` — but it forfeited
+   exactly the cross-module escapes this change exists to see.)
+2. **Cross-module fnctor NAME collision — REFUSED and COUNTED.** Everything
+   downstream is keyed by bare name (`__fnctor_<Name>` struct key,
+   `approvedNames`, the write-once ledger). One source made that safe by
+   construction; a graph does not — #4133 measured 55 colliding top-level
+   names across the 146-file ESLint graph. `first-seen wins` would reserve one
+   module's constructor shape and apply it to another module's same-named,
+   differently-shaped fnctor: a wrong field set, not a missed optimization.
+   Such families are dropped and counted under
+   `provenance.refusals["multi-module-name-collision"]`. The refusal is
+   per-family, not a blanket bail — a non-colliding fnctor in the same graph is
+   still analysed (pinned by test).
+
+### Evidence
+
+Positive control, identical source and options, `target: "standalone"`:
+
+| | before | after |
+| --- | --- | --- |
+| `compile()` | `path=single files=1 … reconstruct=2`; `Node: verdict=split labels=2`; 3 layouts emitted | unchanged |
+| `compileMulti()` | **no output at all** | `path=multi files=1 … reconstruct=2`; `Node: verdict=split labels=2`; 3 layouts emitted |
+
+`tests/issue-4235-multifile-fnctor-parity.test.ts` — 8 tests. The 6 analysis
+tests pin verdict parity, provenance, cross-module visibility, the counted
+refusal and whole-graph write-once closure; the 2 end-to-end tests drive the
+real compilers and pin the WIRING. **Negative control run:** with the one
+`ctx.fnctorEscapeGate = …` line removed from `generateMultiModule`, the 6
+analysis tests still pass and exactly the 2 wiring tests fail — so the wiring
+tests genuinely defend this defect rather than restating the analysis.
+
+### Deliberately NOT included
+
+`applyNumericPropertyAnalysis` (#3683 S4a) is also single-path-only and reads
+`fnctorEscapeGate.receiverStruct`, so it is fnctor-adjacent — but it changes
+numeric field REPRESENTATION graph-wide, which is a separate blast radius from
+wiring up the pipeline, and it is not needed for verdict parity (it affects
+derived field types, not verdicts). Recorded in #4256 with the rest of the
+audit.
+
+## Audit — what ELSE is single-path-only (per the implementer note)
+
+Diffed `generateModule`'s prologue against `generateMultiModule`'s. **Thirteen**
+setup steps run only on the single-file path; the escape gate was not the only
+one. Everything below is ABSENT from `generateMultiModule` on main @ `49cab5c82`
+(verified by name search across the whole function body, not just the prologue):
+
+| single-path-only step | sets | scope |
+| --- | --- | --- |
+| `analyzeFnctorEscapeGate` | `ctx.fnctorEscapeGate` | **fixed here** |
+| `collectDynamicObjectReturnCarrierTypes` | `ctx.dynamicObjectReturnFunctions` | **fixed here** |
+| `reserveFnctorStructTypes` | `$__fnctor_<Name>` type slots | **fixed here** |
+| `applyNumericPropertyAnalysis` | `ctx.numericPropertyNames` etc. | #4256 |
+| `collectUserMethodNames` | `ctx.userMethodNames` | #4256 |
+| `scanModuleMemberDeletes` | `ctx.moduleUsesDelete`, `memberDeleteReceiverNames` | #4256 |
+| `sourceUsesRuntimeEvalBoundary` | `ctx.runtimeEvalCallableBoundaryEnabled` | #4256 |
+| top-level `function` pre-scan | `ctx.topLevelFunctionNames` | #4256 |
+| `sourceHasDynamicTaConstruct` | `ctx.moduleUsesDynTaView` | #4256 |
+| `reserveTypedArraySubviewTypes` | `$__subview_<elem>` type slots | #4256 |
+| `analyzeLinearUint8` + `reserveLinearU8AllocType` | `ctx.linearUint8` | #4256 (WASI) |
+| `registerJsxRuntimeImports` | JSX runtime imports | #4256 |
+| `addStringImports` | string helper imports | #4256 |
+
+**Plus a live correctness defect found while validating, PRE-EXISTING and
+independent of this change** (#4256): a fnctor prototype method's
+`this.<field> = …` writes do not take effect through `generateMultiModule`.
+Same source, same options, `target: "standalone"` — `compile()` returns 1 for
+both `a.end === 5` and `a.type === "A"` after `a.finish("A", 5)`;
+`compileMulti()` returns 0 for both, while a plain own-field read
+(`b.extraC === 3`) passes on both. Established by a full-tree A/B (all three
+changed files reverted to `HEAD` via file copies, not `git stash`): the
+baseline fails identically, so this change is exactly neutral on it. Two audit
+items were excluded as the cause by direct experiment — wiring
+`collectUserMethodNames` into the multi path did not flip it, and neither did
+`applyNumericPropertyAnalysis`.

--- a/plan/issues/4256-multifile-path-setup-gaps-and-proto-method-write-defect.md
+++ b/plan/issues/4256-multifile-path-setup-gaps-and-proto-method-write-defect.md
@@ -1,0 +1,110 @@
+---
+id: 4256
+title: "generateMultiModule is missing 10 more single-path-only setup steps, and drops fnctor prototype-method this-writes outright"
+status: ready
+sprint: current
+created: 2026-08-09
+updated: 2026-08-09
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: classes, objects, modules
+goal: core-semantics
+horizon: l
+related: [4235, 4133, 4037, 3683, 3673, 2179]
+origin: "2026-08-09, while fixing #4235: the audit the issue asked for turned up twelve MORE single-path-only setup steps, and validating the fix surfaced a live multi-path miscompile that predates it."
+---
+
+# #4256 — the rest of the multi-file setup gap, and a live prototype-method defect
+
+#4235 fixed ONE of these (the fnctor pipeline). This is what the audit it
+mandated turned up, plus a correctness defect found while validating it.
+
+## Part A — a live miscompile: prototype-method `this.<field> = …` writes are
+## dropped on the multi-file path
+
+**This is the urgent half.** It is a wrong answer, not a missed optimization,
+and it predates #4235.
+
+Same source, same options (`target: "standalone"`), one file, both paths:
+
+```ts
+function Node(pos: any) { this.type = ""; this.start = pos; this.end = 0; }
+Node.prototype.finish = function (t: any, end: any) {
+  this.type = t; this.end = end; return this;
+};
+function makeA(p: any) { const n = new Node(p); n.extraA = 1; return n; }
+function makeB(p: any) { const n = new Node(p); n.extraB = 2; n.extraC = 3; return n; }
+
+export function c2(): number { const a: any = makeA(1); a.finish("A", 5); return (a.end as number) === 5 ? 1 : 0; }
+export function c3(): number { const a: any = makeA(1); a.finish("A", 5); return (a.type as string) === "A" ? 1 : 0; }
+export function c4(): number { const b: any = makeB(2); return (b.extraC as number) === 3 ? 1 : 0; }
+```
+
+| | `c2` (`this.end`) | `c3` (`this.type`) | `c4` (plain own field) |
+| --- | --- | --- | --- |
+| `compile()` | **1** | **1** | 1 |
+| `compileMulti()` | **0** | **0** | 1 |
+
+Both compiles report `success: true` with zero errors — the wrong value is
+returned silently. `c4` passing is the control that says this is specific to
+the prototype-method `this` write, not to fnctor own-field access in general.
+
+Established with a full-tree A/B against `HEAD` (all three files #4235 touched
+reverted via file copies — **not** `git stash`, which is a shared stack across
+worktrees). The baseline fails identically, so #4235 is exactly neutral on it:
+it neither caused nor fixed this.
+
+**Root cause NOT yet identified.** Two candidates were excluded by direct
+experiment — temporarily wiring `collectUserMethodNames` into
+`generateMultiModule` did not flip `c2`/`c3`, and neither did
+`applyNumericPropertyAnalysis`. Start from the remaining Part-B rows, or from
+the `this`-receiver dispatch itself (`FunctionContext.thisStructName` /
+`typed-this.ts`), which #2660's substrate routes differently.
+
+## Part B — ten more single-path-only setup steps
+
+Produced by diffing `generateModule`'s prologue against
+`generateMultiModule`'s and then verifying each name is absent from the whole
+`generateMultiModule` body (main @ `49cab5c82`). #4235 fixed the first three
+rows of the original thirteen; these ten remain:
+
+| step | sets | note |
+| --- | --- | --- |
+| `applyNumericPropertyAnalysis` | `ctx.numericPropertyNames`, `stringPropertyNames`, `numericFunctionNames`, the numeric-local oracle | #3683 S4a. Standalone-only. Reads `fnctorEscapeGate.receiverStruct`, so it is fnctor-adjacent, but it changes numeric field REPRESENTATION graph-wide — deliberately excluded from #4235 as a separate blast radius. Already takes `readonly ts.SourceFile[]`, so wiring it is a one-liner; the risk is in what it changes, not in the plumbing. |
+| `collectUserMethodNames` | `ctx.userMethodNames` | #3673. Without it the guarded native-string method lowering cannot tell a genuine `String.prototype` call from a same-named USER method on an object receiver. |
+| `scanModuleMemberDeletes` | `ctx.moduleUsesDelete`, `ctx.memberDeleteReceiverNames` | #2179/#4187. Without it an `any`-receiver property read keeps the inline `struct.get` fast path and ignores the runtime delete tombstone. |
+| `sourceUsesRuntimeEvalBoundary` / `isRuntimeEvalBoundaryName` | `ctx.runtimeEvalCallableBoundaryEnabled` | standalone/WASI. |
+| top-level `function` declaration pre-scan | `ctx.topLevelFunctionNames` | #1983. Its absence means `classMemberFuncKey` cannot detect a `${className}_${member}` ↔ user-function collision on the multi path. Note this interacts with #4133's bare-name `funcMap` collisions, which multi already has to work around. |
+| `sourceHasDynamicTaConstruct` | `ctx.moduleUsesDynTaView` | #3057. Standalone/WASI. |
+| `reserveTypedArraySubviewTypes` | `$__subview_<elem>` type slots | #2357/#47. Standalone/WASI. Reserved up-front on the single path *specifically* so the subview type index is pass-invariant. |
+| `analyzeLinearUint8` + `reserveLinearU8AllocType` | `ctx.linearUint8` | #1886. WASI only. |
+| `registerJsxRuntimeImports` | JSX runtime imports | multi-file JSX gets no runtime imports. |
+| `addStringImports` | string helper imports | registered as a lazy delegate elsewhere, so verify whether multi genuinely lacks it before wiring. |
+
+## Why this keeps happening
+
+`generateModule` and `generateMultiModule` are two ~800–1300-line prologues
+that must stay in step by hand, and nothing tells you when they diverge. Every
+fix in this family has been found the same way — someone measured the multi
+path and got a zero (#4037's `$ObjVecArr`, #4133's `funcMap`, #4235's fnctor
+pipeline, and now these). **Consider a structural fix as part of this issue:**
+extract the shared prologue into one `setUpModuleAnalyses(ctx, sourceFiles)`
+that both entry points call, so a new analysis is wired into both by
+construction rather than by memory. That is the change that stops the next
+one.
+
+## Acceptance criteria
+
+- [ ] Part A root-caused and fixed: `c2`/`c3` above return 1 through
+      `compileMulti()`, with a regression test that pins the single/multi
+      runtime VALUES (not just compile success — both paths already "succeed").
+- [ ] Each Part-B row is either wired into `generateMultiModule` or given a
+      recorded, reasoned decline in this file. No row is left unstated.
+- [ ] Where a row is wired, its gate matches the single-path gate exactly, so
+      graphs that do not use the feature stay byte-identical.
+- [ ] A check that FAILS when the two prologues diverge again — the structural
+      fix above, or a test that asserts the multi path sets every `ctx` field
+      the single path sets for a fixture exercising all of them.

--- a/src/codegen/fnctor-alloc-labels.ts
+++ b/src/codegen/fnctor-alloc-labels.ts
@@ -265,7 +265,19 @@ interface SourceIndex {
   readonly propWrites: readonly ts.BinaryExpression[];
 }
 
-function indexSourceFile(sourceFile: ts.SourceFile): SourceIndex {
+/**
+ * 1-based line of `n`, resolved against the node's OWN source file. (#4235)
+ * Asking one designated file for the position of a node declared in another
+ * silently answers from the wrong file's line table — under a multi-file graph
+ * that turns every label's `line` into a plausible-looking wrong number, and a
+ * diagnostic that lies is worse than one that is absent.
+ */
+function lineOf(n: ts.Node): number {
+  const sf = n.getSourceFile();
+  return sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
+}
+
+function indexSourceFile(sourceFiles: readonly ts.SourceFile[]): SourceIndex {
   const protoIndex = new Map<string, ts.FunctionLikeDeclaration[]>();
   const allFns: ts.FunctionLikeDeclaration[] = [];
   const decls: ts.VariableDeclaration[] = [];
@@ -298,7 +310,11 @@ function indexSourceFile(sourceFile: ts.SourceFile): SourceIndex {
     if (ts.isCallExpression(n)) calls.push(n);
     forEachChild(n, indexNode);
   };
-  indexNode(sourceFile);
+  // (#4235) Index the WHOLE module graph. A layout derived from a strict subset
+  // of a fnctor's allocation sites would omit fields written at the unseen ones
+  // — the emitted `struct.new` would then have the wrong field set. Partial
+  // visibility is not a weaker plan here, it is a wrong one.
+  for (const sf of sourceFiles) indexNode(sf);
   return { protoIndex, allFns, decls, assigns, calls, propWrites };
 }
 
@@ -310,12 +326,13 @@ function indexSourceFile(sourceFile: ts.SourceFile): SourceIndex {
  */
 export function analyzeFnctorAllocLabels(
   checker: ts.TypeChecker,
-  sourceFile: ts.SourceFile,
+  sourceFiles: readonly ts.SourceFile[],
   /** `__fnctor_<Name>` stems to analyse, keyed by the CONSTRUCTOR declaration. */
   ctorDeclByName: ReadonlyMap<string, ts.FunctionLikeDeclaration>,
+  /** (#4235) Which compile path ran this — printed by the diagnostic. */
+  compilePath: "single" | "multi" = "single",
 ): AllocLabelResult {
-  const lineOf = (n: ts.Node): number => sourceFile.getLineAndCharacterOfPosition(n.getStart(sourceFile)).line + 1;
-  const { protoIndex, allFns, decls, assigns, calls, propWrites } = indexSourceFile(sourceFile);
+  const { protoIndex, allFns, decls, assigns, calls, propWrites } = indexSourceFile(sourceFiles);
 
   /**
    * Callee resolution. Checker symbol first, then the syntactic prototype index
@@ -597,7 +614,9 @@ export function analyzeFnctorAllocLabels(
   }
   for (const c of calls) publish(c);
 
-  if (process.env.JS2WASM_FNCTOR_LAYOUT_DIAG === "1") writeLayoutDiag(plans, rounds);
+  if (process.env.JS2WASM_FNCTOR_LAYOUT_DIAG === "1") {
+    writeLayoutDiag(plans, rounds, compilePath, sourceFiles.length);
+  }
 
   return { plans, labelOfExpr };
 }
@@ -653,8 +672,25 @@ function buildPlan(
  * Human-readable plan dump. The per-label field list is the thing a byte number
  * cannot tell you and the first question when a consumer turns out not to know
  * a layout, so it prints in full rather than summarised.
+ *
+ * (#4235) It now leads with the COMPILE PATH and file count, and emits a header
+ * even when there is nothing to report. Before this, a multi-file compile
+ * printed nothing at all — and "no `[alloc-labels]` lines" was read as "this
+ * package has no fnctors" when the truth was "this path never ran the
+ * analysis". A zero must arrive with its provenance attached or it is not a
+ * measurement.
  */
-function writeLayoutDiag(plans: ReadonlyMap<string, FnctorLayoutPlan>, rounds: number): void {
+function writeLayoutDiag(
+  plans: ReadonlyMap<string, FnctorLayoutPlan>,
+  rounds: number,
+  compilePath: "single" | "multi",
+  sourceFileCount: number,
+): void {
+  const planned = [...plans.values()].filter((p) => p.labels.length > 0).length;
+  process.stderr.write(
+    `[alloc-labels] path=${compilePath} files=${sourceFileCount} ` +
+      `families=${plans.size} with-labels=${planned} rounds=${rounds}\n`,
+  );
   for (const plan of plans.values()) {
     if (plan.labels.length === 0) continue;
     process.stderr.write(

--- a/src/codegen/fnctor-escape-gate.ts
+++ b/src/codegen/fnctor-escape-gate.ts
@@ -141,6 +141,34 @@ export interface FnctorEscapeGateResult {
    * `fnctor-alloc-labels.ts`.
    */
   readonly allocLabels?: AllocLabelResult;
+  /**
+   * (#4235) Provenance of THIS analysis run — which compile path produced it,
+   * over how many source files, and every fnctor family the analysis DECLINED
+   * with the reason it declined for.
+   *
+   * The reason this field exists: until #4235 `generateMultiModule` never
+   * assigned `ctx.fnctorEscapeGate` at all, so every multi-file compile
+   * produced ZERO fnctor analysis and that zero was indistinguishable from
+   * "this package has no fnctors". A detector must be able to say "I don't
+   * know"; this is where it says it. `refusals` is a counted ledger, never
+   * silence — the same discipline the IR-fallback budget applies.
+   */
+  readonly provenance: FnctorGateProvenance;
+}
+
+/** (#4235) Which `generate*Module` entry point ran the fnctor pipeline. */
+export type FnctorCompilePath = "single" | "multi";
+
+/** (#4235) Counted refusal reasons — one entry per DECLINED fnctor family. */
+export interface FnctorGateProvenance {
+  /** `single` = `generateModule`, `multi` = `generateMultiModule`. */
+  readonly compilePath: FnctorCompilePath;
+  /** How many source files the whole-program walk actually covered. */
+  readonly sourceFileCount: number;
+  /** Refusal reason → number of fnctor families declined for that reason. */
+  readonly refusals: ReadonlyMap<string, number>;
+  /** The declined fnctor names, for diagnostics (sorted, deterministic). */
+  readonly refusedNames: readonly string[];
 }
 
 /**
@@ -197,15 +225,23 @@ const EMPTY_WRITE_ONCE: ProtoMethodWriteOnceResult = {
   runtimeDefined: new Map(),
 };
 
-const EMPTY_RESULT: FnctorEscapeGateResult = {
-  sites: new Map(),
-  approved: new Set(),
-  approvedNames: new Set(),
-  receiverStruct: new Map(),
-  newThisOwnerNames: new Set(),
-  ctorDeclByName: new Map(),
-  protoMethodWriteOnce: EMPTY_WRITE_ONCE,
-};
+/**
+ * (#4235) The "no fnctor `new` sites at all" result. Carries its provenance so
+ * even the empty answer names the path that produced it — an empty result from
+ * a 146-file graph and one from a single file are different claims.
+ */
+function emptyResult(compilePath: FnctorCompilePath, sourceFileCount: number): FnctorEscapeGateResult {
+  return {
+    sites: new Map(),
+    approved: new Set(),
+    approvedNames: new Set(),
+    receiverStruct: new Map(),
+    newThisOwnerNames: new Set(),
+    ctorDeclByName: new Map(),
+    protoMethodWriteOnce: EMPTY_WRITE_ONCE,
+    provenance: { compilePath, sourceFileCount, refusals: new Map(), refusedNames: [] },
+  };
+}
 
 /**
  * Resolve a fnctor symbol to the function-like declaration that supplies its
@@ -605,7 +641,7 @@ function isFunctionLike(node: ts.Node): node is ts.FunctionLikeDeclaration {
  * {@link ProtoMethodWriteOnceResult} for the contract). Purely syntactic and
  * whole-source-file; no checker, no codegen, no side effects.
  */
-export function analyzeProtoMethodWriteOnce(sourceFile: ts.SourceFile): ProtoMethodWriteOnceResult {
+export function analyzeProtoMethodWriteOnce(sourceFiles: readonly ts.SourceFile[]): ProtoMethodWriteOnceResult {
   const aliasToOwner = new Map<string, string>(); // "pp$8" → "Parser"
   const collidingAliases = new Set<string>();
   const poisoned = new Set<string>();
@@ -617,7 +653,18 @@ export function analyzeProtoMethodWriteOnce(sourceFile: ts.SourceFile): ProtoMet
 
   // Pass 1 — top-level `var pp = F.prototype;` aliases. A name declared twice
   // for DIFFERENT owners is ambiguous: poison both owners and drop the alias.
-  for (const stmt of sourceFile.statements) {
+  //
+  // (#4235) Every pass below now runs over the WHOLE module graph, not one
+  // file. That is not an optimization — it is the only sound closed world for
+  // this analysis. `methods` admits a slot precisely because it saw no SECOND
+  // write; run over one file of a graph it would admit a slot another module
+  // overwrites. Merging is monotone toward safety in every direction the
+  // analysis has: `poisoned` unions, a second write in `writes` flips `bad`,
+  // `otherNameWrites` unions (and its `null` sentinel is the most conservative
+  // state), `inheritedFrom` unions. So more files can only ever REMOVE
+  // admissions.
+  const topLevelStatements = sourceFiles.flatMap((sf) => [...sf.statements]);
+  for (const stmt of topLevelStatements) {
     if (!ts.isVariableStatement(stmt)) continue;
     for (const d of stmt.declarationList.declarations) {
       if (!ts.isIdentifier(d.name) || !d.initializer) continue;
@@ -701,7 +748,7 @@ export function analyzeProtoMethodWriteOnce(sourceFile: ts.SourceFile): ProtoMet
     if (!ts.isIdentifier(a)) return undefined;
     let init: ts.ObjectLiteralExpression | undefined;
     let declCount = 0;
-    for (const stmt of sourceFile.statements) {
+    for (const stmt of topLevelStatements) {
       if (!ts.isVariableStatement(stmt)) continue;
       for (const d of stmt.declarationList.declarations) {
         if (!ts.isIdentifier(d.name) || d.name.text !== a.text) continue;
@@ -738,7 +785,7 @@ export function analyzeProtoMethodWriteOnce(sourceFile: ts.SourceFile): ProtoMet
       }
       forEachChild(n, scan);
     };
-    scan(sourceFile);
+    for (const sf of sourceFiles) scan(sf);
     return ok ? keys : undefined;
   };
 
@@ -781,10 +828,17 @@ export function analyzeProtoMethodWriteOnce(sourceFile: ts.SourceFile): ProtoMet
     }
   };
 
+  // (#4235) `=== sourceFile` became `isSourceFile(…)`: with the walk covering
+  // the graph, "top level of ITS OWN module" is the property that matters, and
+  // an identity test against one designated file would silently demote every
+  // other module's top-level write to "conditional" (⇒ `bad`). That is the safe
+  // direction, but it would make the multi-file result differ from the
+  // single-file one for no reason — the parity this issue exists to establish.
   const isUnconditionalTopLevel = (assignment: ts.Node): boolean =>
     assignment.parent !== undefined &&
     ts.isExpressionStatement(assignment.parent) &&
-    assignment.parent.parent === sourceFile;
+    assignment.parent.parent !== undefined &&
+    ts.isSourceFile(assignment.parent.parent);
 
   const walk = (n: ts.Node): void => {
     if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
@@ -897,7 +951,7 @@ export function analyzeProtoMethodWriteOnce(sourceFile: ts.SourceFile): ProtoMet
     }
     forEachChild(n, walk);
   };
-  walk(sourceFile);
+  for (const sf of sourceFiles) walk(sf);
 
   const methods = new Map<string, ReadonlyMap<string, ts.FunctionLikeDeclaration>>();
   for (const [owner, perOwner] of writes) {
@@ -924,7 +978,7 @@ export function analyzeProtoMethodWriteOnce(sourceFile: ts.SourceFile): ProtoMet
  */
 type ProtoMethodIndex = ReadonlyMap<string, ts.FunctionLikeDeclaration[]>;
 
-function buildProtoMethodIndex(sourceFile: ts.SourceFile): ProtoMethodIndex {
+function buildProtoMethodIndex(sourceFiles: readonly ts.SourceFile[]): ProtoMethodIndex {
   const idx = new Map<string, ts.FunctionLikeDeclaration[]>();
   const walk = (n: ts.Node): void => {
     if (
@@ -942,7 +996,9 @@ function buildProtoMethodIndex(sourceFile: ts.SourceFile): ProtoMethodIndex {
     }
     forEachChild(n, walk);
   };
-  walk(sourceFile);
+  // (#4235) Graph-wide. More indexed bodies for a name can only make it
+  // AMBIGUOUS (≥2 ⇒ unresolved), never resolve it to a wrong callee.
+  for (const sf of sourceFiles) walk(sf);
   return idx;
 }
 
@@ -1166,12 +1222,12 @@ export function writeOnceThisCallReturnStruct(
  */
 function buildReceiverStructMap(
   checker: ts.TypeChecker,
-  sourceFile: ts.SourceFile,
+  sourceFiles: readonly ts.SourceFile[],
   usesBySymbol: ReadonlyMap<ts.Symbol, ts.Identifier[]>,
 ): Map<ts.Expression, string> {
   const map = new Map<ts.Expression, string>();
   const memo = new Map<ts.FunctionLikeDeclaration, string | undefined>();
-  const protoIndex = buildProtoMethodIndex(sourceFile);
+  const protoIndex = buildProtoMethodIndex(sourceFiles);
   const structBySymbol = new Map<ts.Symbol, string>();
   const declarations: ts.VariableDeclaration[] = [];
   const assignments: ts.BinaryExpression[] = [];
@@ -1193,7 +1249,7 @@ function buildReceiverStructMap(
     if (ts.isPropertyAccessExpression(node)) propertyAccesses.push(node);
     forEachChild(node, indexFlowSites);
   };
-  indexFlowSites(sourceFile);
+  for (const sf of sourceFiles) indexFlowSites(sf);
 
   const inferExprStruct = (expression: ts.Expression): string | undefined => {
     const expr = unwrapExpr(expression);
@@ -1352,14 +1408,44 @@ export function resolveReceiverStruct(
 /**
  * #2660 S1 — classify every `new F()` fnctor site in the program.
  *
- * @param checker     the program type checker
- * @param sourceFile  the (already import-preprocessed) module source
+ * (#4235) **Whole-program over the WHOLE module graph.** This used to take a
+ * single `ts.SourceFile` and was called only from `generateModule`, so on every
+ * multi-file compile (`compileProject` / `compileMulti` — most of the npm-compat
+ * corpus) the entire fnctor pipeline was inert and silent. It now takes the
+ * graph's source files and every sub-pass walks all of them.
+ *
+ * Why extending the walk is the SAFE direction, pass by pass:
+ *
+ * - `sites` classification is monotone toward safety. Seeing MORE uses of a
+ *   binding can only add `sawTyped` / `sawDynamic` evidence, and clause B
+ *   (`sawTyped` ⇒ `keep-typed`) is absolute. A use we still fail to see leaves
+ *   the site at `keep-static`, which no lowering consumes — inert, not wrong.
+ * - `analyzeProtoMethodWriteOnce` admits a method ONLY on the absence of a
+ *   second write. Run over one file of a graph it would admit a slot that
+ *   another module overwrites — a real miscompile. Its closed world must be the
+ *   whole graph, which is exactly what this change gives it. Unioning across
+ *   files only ever ADDS writes/poison, never removes.
+ * - `analyzeFnctorAllocLabels` derives per-type layouts from the allocation
+ *   sites it can see; a layout computed from a strict subset of a fnctor's
+ *   allocations would omit fields set at the unseen sites. Whole-graph or not
+ *   at all.
+ *
+ * The one hazard the loop alone does NOT fix is cross-module symbol identity —
+ * see the alias resolution in step 2 and the name-collision refusal in step 3.
+ *
+ * @param checker      the program type checker (shared across the whole graph)
+ * @param sourceFiles  every (already import-preprocessed) module source in the
+ *                     graph; the single-file path passes a one-element array
+ * @param standalone   see below
+ * @param compilePath  which `generate*Module` called us — recorded in the
+ *                     result's provenance so a zero can never again be read
+ *                     without knowing which path produced it
  * @returns a frozen {@link FnctorEscapeGateResult}; empty when no fnctor `new`
  *          sites exist (so the pass is a no-op for class-only / fnctor-free code).
  */
 export function analyzeFnctorEscapeGate(
   checker: ts.TypeChecker,
-  sourceFile: ts.SourceFile,
+  sourceFiles: readonly ts.SourceFile[],
   /**
    * (#3927 default-ON) Whether this compile targets the standalone lane. The
    * per-type-layout ANALYSIS (a second whole-program fixpoint) is only worth
@@ -1369,10 +1455,17 @@ export function analyzeFnctorEscapeGate(
    * (legacy callers) preserves the flag-only behaviour.
    */
   standalone?: boolean,
+  compilePath: FnctorCompilePath = "single",
 ): FnctorEscapeGateResult {
   const sites = new Map<ts.NewExpression, FnctorGateClass>();
   const approved = new Set<ts.NewExpression>();
   const approvedNames = new Set<string>();
+  const refusals = new Map<string, number>();
+  const refusedNames = new Set<string>();
+  const refuse = (name: string, reason: string): void => {
+    refusedNames.add(name);
+    refusals.set(reason, (refusals.get(reason) ?? 0) + 1);
+  };
 
   // 1. Collect every `new F()` whose callee is a fnctor.
   const newSites: { newExpr: ts.NewExpression; ctorSym: ts.Symbol }[] = [];
@@ -1398,33 +1491,90 @@ export function analyzeFnctorEscapeGate(
     }
     forEachChild(node, collect);
   };
-  collect(sourceFile);
-  if (newSites.length === 0) return EMPTY_RESULT;
+  for (const sf of sourceFiles) collect(sf);
+  if (newSites.length === 0) {
+    // (#4235) Even "there are no fnctor `new` sites" must announce itself under
+    // the diagnostic. Returning in silence here is what made the multi-path
+    // zero unreadable: no output was produced BOTH when a package genuinely had
+    // no fnctors and when the path never ran the analysis at all, and those are
+    // the two hypotheses a reader most needs to tell apart.
+    if (process.env.JS2WASM_FNCTOR_LAYOUT_DIAG === "1") {
+      process.stderr.write(
+        `[alloc-labels] path=${compilePath} files=${sourceFiles.length} ` +
+          `families=0 with-labels=0 rounds=0 (no fnctor new-sites in this graph)\n`,
+      );
+    }
+    return emptyResult(compilePath, sourceFiles.length);
+  }
 
   // #2773 S1 — index fnctor name → declaration (first-seen wins, deterministic by
   // source order) for the up-front struct-type reservation pass.
   const ctorDeclByName = new Map<string, ts.FunctionDeclaration | ts.FunctionExpression>();
+  // (#4235) A fnctor NAME whose `new F()` sites resolve to DECLARATIONS IN MORE
+  // THAN ONE source file is refused outright. Everything downstream of this
+  // analysis is keyed by bare NAME — `ctorDeclByName`, `approvedNames`,
+  // `reserveFnctorStructTypes`'s `__fnctor_<Name>` struct key, the whole
+  // `protoMethodWriteOnce` ledger — and a single-source graph made that safe by
+  // construction. A module graph does not: #4133 measured 55 top-level function
+  // names colliding across the 146-file resolved ESLint graph. `first-seen wins`
+  // would then reserve ONE struct shape derived from ONE module's constructor
+  // body and apply it to another module's same-named, differently-shaped fnctor
+  // — a wrong field set, i.e. a miscompile, not a missed optimization. Refusing
+  // costs only the optimization and is COUNTED, so the decline is visible.
+  const declFilesByName = new Map<string, Set<ts.SourceFile>>();
   for (const { ctorSym } of newSites) {
-    if (ctorDeclByName.has(ctorSym.name)) continue;
+    const decl = fnctorDeclFromSymbol(ctorSym);
+    if (!decl) continue;
+    const seen = declFilesByName.get(ctorSym.name);
+    if (seen) seen.add(decl.getSourceFile());
+    else declFilesByName.set(ctorSym.name, new Set([decl.getSourceFile()]));
+  }
+  for (const { ctorSym } of newSites) {
+    if (ctorDeclByName.has(ctorSym.name) || refusedNames.has(ctorSym.name)) continue;
+    if ((declFilesByName.get(ctorSym.name)?.size ?? 0) > 1) {
+      refuse(ctorSym.name, "multi-module-name-collision");
+      continue;
+    }
     const decl = fnctorDeclFromSymbol(ctorSym);
     if (decl) ctorDeclByName.set(ctorSym.name, decl);
   }
 
   // 2. Build a per-binding-symbol index of identifier uses across the program,
   //    so a `const c = new F()` instance's uses can be found by symbol identity.
+  //
+  // (#4235) Cross-module uses land under the IMPORT ALIAS symbol, not the
+  // declaration's symbol: for `import { p } from "./a"; p.foo = 1;` the checker
+  // answers module B's `p` with the alias symbol created by the import
+  // specifier. Without resolving that, module B's uses key differently from
+  // module A's binding and the analysis sees an instance with no uses at all.
+  // That direction is inert rather than wrong (no uses ⇒ `keep-static` ⇒ nothing
+  // consumes it), but it silently forfeits exactly the cross-module escapes this
+  // whole change exists to see. Resolve to the aliased symbol so both sides
+  // share one key.
   const usesBySymbol = new Map<ts.Symbol, ts.Identifier[]>();
+  const canonicalSymbol = (sym: ts.Symbol): ts.Symbol => {
+    if ((sym.flags & ts.SymbolFlags.Alias) === 0) return sym;
+    try {
+      return checker.getAliasedSymbol(sym);
+    } catch {
+      // A malformed / unresolvable alias keeps its own identity. Worst case the
+      // uses stay split, which is the inert direction described above.
+      return sym;
+    }
+  };
   const indexUses = (node: ts.Node): void => {
     if (ts.isIdentifier(node)) {
       const sym = checker.getSymbolAtLocation(node);
       if (sym) {
-        const arr = usesBySymbol.get(sym);
+        const key = canonicalSymbol(sym);
+        const arr = usesBySymbol.get(key);
         if (arr) arr.push(node);
-        else usesBySymbol.set(sym, [node]);
+        else usesBySymbol.set(key, [node]);
       }
     }
     forEachChild(node, indexUses);
   };
-  indexUses(sourceFile);
+  for (const sf of sourceFiles) indexUses(sf);
 
   // #2773 S2b — fnctor NAMES that own a reconstruct-classified `new this()` site
   // (acorn's Parser). Populated during classification below; the #2773 S1 up-front
@@ -1436,6 +1586,9 @@ export function analyzeFnctorEscapeGate(
 
   // 3. Classify each site.
   for (const { newExpr, ctorSym } of newSites) {
+    // (#4235) A name refused above is not classified at all — leaving it out of
+    // `sites` keeps it off every downstream path.
+    if (refusedNames.has(ctorSym.name)) continue;
     const ownFields = collectFnctorOwnFields(ctorSym);
     let sawDynamic = false;
     let sawTyped = false;
@@ -1444,7 +1597,7 @@ export function analyzeFnctorEscapeGate(
     if (bind) {
       // Classify every use of the binding symbol.
       const bindSym = checker.getSymbolAtLocation(bind);
-      const uses = bindSym ? (usesBySymbol.get(bindSym) ?? []) : [];
+      const uses = bindSym ? (usesBySymbol.get(canonicalSymbol(bindSym)) ?? []) : [];
       for (const use of uses) {
         if (use === bind) continue; // the declaration name itself
         const c = classifyUse(checker, use, ownFields);
@@ -1504,17 +1657,35 @@ export function analyzeFnctorEscapeGate(
   // 4. (#2660 PART-1) Build the receiver-struct flow map for local bindings whose
   //    initializer is a single-return-inferable fnctor-returning call. Reuses the
   //    symbol→uses index from step 2. INERT — stored for the PART-2 dispatch.
-  const receiverStruct = buildReceiverStructMap(checker, sourceFile, usesBySymbol);
+  const receiverStruct = buildReceiverStructMap(checker, sourceFiles, usesBySymbol);
+
+  const provenance: FnctorGateProvenance = {
+    compilePath,
+    sourceFileCount: sourceFiles.length,
+    refusals,
+    refusedNames: [...refusedNames].sort(),
+  };
 
   // 5. Optional inert logging (no effect on output).
   if (process.env.JS2WASM_LOG_FNCTOR_GATE === "1" && (sites.size > 0 || receiverStruct.size > 0)) {
     const counts = { reconstruct: 0, "keep-typed": 0, "keep-static": 0 };
     for (const c of sites.values()) counts[c]++;
+    const declined =
+      refusals.size === 0
+        ? "none"
+        : [...refusals]
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([reason, n]) => `${reason}=${n}`)
+            .join(" ");
     // eslint-disable-next-line no-console
     console.error(
-      `[#2660 fnctor-escape-gate] ${sites.size} new F() site(s): ` +
+      // (#4235) The path + file count lead the line: an analysis result read
+      // without knowing which compile path produced it is what made the
+      // multi-file zero invisible for as long as it was.
+      `[#2660 fnctor-escape-gate] path=${compilePath} files=${sourceFiles.length} ` +
+        `${sites.size} new F() site(s): ` +
         `reconstruct=${counts.reconstruct} keep-typed=${counts["keep-typed"]} keep-static=${counts["keep-static"]}; ` +
-        `receiverStruct flow-map entries=${receiverStruct.size}`,
+        `receiverStruct flow-map entries=${receiverStruct.size}; refused: ${declined}`,
     );
   }
 
@@ -1525,9 +1696,10 @@ export function analyzeFnctorEscapeGate(
     receiverStruct,
     newThisOwnerNames,
     ctorDeclByName,
+    provenance,
     // (#3683 S1) inert write-once verdicts — consumed by the S2 typed-twin
     // emission, no lowering reads them yet.
-    protoMethodWriteOnce: analyzeProtoMethodWriteOnce(sourceFile),
+    protoMethodWriteOnce: analyzeProtoMethodWriteOnce(sourceFiles),
     // (#3927) Per-type layout plan. The fixpoint is a second whole-program
     // pass, so it runs only where it can pay: the analysis-only flag forces it
     // (measurement lane, any target); otherwise the emit flag — default ON
@@ -1536,7 +1708,7 @@ export function analyzeFnctorEscapeGate(
     // (`standalone === false`); a legacy caller that passed no target keeps
     // the flag-only behaviour.
     ...(fnctorLayoutsEnabled() || (fnctorLayoutEmitEnabled() && standalone !== false)
-      ? { allocLabels: analyzeFnctorAllocLabels(checker, sourceFile, ctorDeclByName) }
+      ? { allocLabels: analyzeFnctorAllocLabels(checker, sourceFiles, ctorDeclByName, compilePath) }
       : {}),
   };
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3545,7 +3545,10 @@ export function generateModule(
   // reconstruction lowering but is NOT yet consumed, so emitted Wasm is
   // byte-identical. Side-effect free; safe to run unconditionally (no fnctor
   // `new` sites ⇒ empty result ⇒ no-op).
-  ctx.fnctorEscapeGate = analyzeFnctorEscapeGate(ast.checker, ast.sourceFile, ctx.standalone);
+  // (#4235) The array + explicit `"single"` path tag. `generateMultiModule`
+  // makes the identical call with the whole graph and `"multi"`; keeping the
+  // two call shapes the same is what makes the parity testable.
+  ctx.fnctorEscapeGate = analyzeFnctorEscapeGate(ast.checker, [ast.sourceFile], ctx.standalone, "single");
   // (#3673) Names the source itself defines as function-valued members, so the
   // guarded native-string method lowering can tell a genuine `String.prototype`
   // call apart from a same-named USER method on an object receiver. Cheap
@@ -6278,6 +6281,26 @@ export function generateMultiModule(
   // (#4232) Narrower gate for the ordinary-object arm alone.
   ctx.plainCtorCarrierDemanded =
     ctx.wrapperCtorCarrierDemanded && multiAst.sourceFiles.some((sf) => moduleMentionsObjectIdentifier(sf));
+  // (#4235) Run the fnctor pipeline HERE — the same point in the pass that
+  // `generateModule` runs it, but over the whole module graph.
+  //
+  // Until this landed `generateMultiModule` never assigned `ctx.fnctorEscapeGate`
+  // at all, so on every `compileProject` / `compileMulti` the escape gate, the
+  // presence-bit/hot-cold split (#4211/#4217) and the per-type layout analysis
+  // and emission (#3927) were ALL inert — silently. Not a fallback, not a
+  // warning: the compile succeeded with the unsplit representation, and the
+  // resulting zero was indistinguishable from "this package has no fnctors".
+  // With the layout emission defaulting ON (2026-08-08) that became a lying
+  // default — the flag reported enabled while the machinery never ran, on the
+  // path most of the npm-compat corpus actually compiles through.
+  //
+  // The analysis takes the graph's source files, so its closed-world passes
+  // (write-once admission, allocation-site layout labelling) are closed over the
+  // WHOLE program rather than one file of it; see `analyzeFnctorEscapeGate` for
+  // why each pass is monotone-safe under that widening, and for the two hazards
+  // it handles explicitly (import-alias symbol identity, and cross-module
+  // fnctor NAME collisions, which are refused and COUNTED).
+  ctx.fnctorEscapeGate = analyzeFnctorEscapeGate(multiAst.checker, multiAst.sourceFiles, ctx.standalone, "multi");
   try {
     // WASI target: register linear memory, bump pointer global, and WASI imports
     if (ctx.wasi) {
@@ -6445,6 +6468,18 @@ export function generateMultiModule(
     if (multiAst.sourceFiles.some((sf) => sourceContainsClass(sf))) {
       reserveObjVecArrType(ctx);
     }
+
+    // (#4235) Multi-source parity for the #2773 S1 up-front fnctor struct-type
+    // reservation, in the same relative position the single-source path uses:
+    // after the `$ObjVecArr` reservation, before `collectDeclarations` and
+    // therefore before any body compiles — so `$__fnctor_<Name>`'s type index is
+    // fixed at ONE deterministic point for every pass that reads it. Both calls
+    // are gated on the escape gate having approved something, so a fnctor-free
+    // graph reserves nothing and stays byte-identical.
+    for (const sf of multiAst.sourceFiles) {
+      collectDynamicObjectReturnCarrierTypes(ctx, multiAst.checker, sf);
+    }
+    reserveFnctorStructTypes(ctx);
 
     // (#4133) `ctx.funcMap` is keyed by BARE function name, so two modules that
     // each declare a top-level `function shared()` collide: registration mints a

--- a/tests/issue-2660-fnctor-escape-gate.test.ts
+++ b/tests/issue-2660-fnctor-escape-gate.test.ts
@@ -36,7 +36,7 @@ function checkerFor(source: string): { sf: ts.SourceFile; checker: ts.TypeChecke
 /** Collect the classification of the (single) `new F()` site in `source`. */
 function classifyOnly(source: string): FnctorGateClass | undefined {
   const { sf, checker } = checkerFor(source);
-  const result = analyzeFnctorEscapeGate(checker, sf);
+  const result = analyzeFnctorEscapeGate(checker, [sf]);
   const entries = [...result.sites.values()];
   return entries[0];
 }
@@ -119,7 +119,7 @@ describe("#2660 S1 — fnctor escape/dynamic-use gate (inert analysis)", () => {
       [].forEach.call(c, function () {});
     `;
     const { sf, checker } = checkerFor(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     expect(result.sites.size).toBe(0);
     expect(result.approved.size).toBe(0);
   });
@@ -130,13 +130,13 @@ describe("#2660 S1 — fnctor escape/dynamic-use gate (inert analysis)", () => {
       var a: any = new Arrow();
     `;
     const { sf, checker } = checkerFor(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     expect(result.sites.size).toBe(0);
   });
 
   it("fnctor-free / empty program yields an empty result (no-op)", () => {
     const { sf, checker } = checkerFor(`var x: number = 1 + 2;`);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     expect(result.sites.size).toBe(0);
     expect(result.approved.size).toBe(0);
   });
@@ -151,7 +151,7 @@ describe("#2660 S1 — fnctor escape/dynamic-use gate (inert analysis)", () => {
       var y: any = b.x;
     `;
     const { sf, checker } = checkerFor(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const reconstructCount = [...result.sites.values()].filter((c) => c === "reconstruct").length;
     expect(result.approved.size).toBe(reconstructCount);
     expect(result.approved.size).toBe(1); // only `a`

--- a/tests/issue-2660-part1-receiver-resolve.test.ts
+++ b/tests/issue-2660-part1-receiver-resolve.test.ts
@@ -76,7 +76,7 @@ describe("#2660 PART-1 — receiver-struct flow map (inert analysis)", () => {
       };
     `;
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const recv = findReceiver(sf, "node")!;
     expect(recv).toBeDefined();
     expect(result.receiverStruct.get(recv)).toBe("__fnctor_Node");
@@ -95,7 +95,7 @@ describe("#2660 PART-1 — receiver-struct flow map (inert analysis)", () => {
       };
     `;
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const recv = findReceiver(sf, "scope")!;
     expect(result.receiverStruct.get(recv)).toBe("__fnctor_Scope");
   });
@@ -113,7 +113,7 @@ describe("#2660 PART-1 — receiver-struct flow map (inert analysis)", () => {
       };
     `;
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const recv = findReceiver(sf, "v");
     // recv may be undefined if no `v.` access — but here `v.x` exists.
     expect(recv).toBeDefined();
@@ -131,7 +131,7 @@ describe("#2660 PART-1 — receiver-struct flow map (inert analysis)", () => {
       };
     `;
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const recv = findReceiver(sf, "o")!;
     expect(result.receiverStruct.get(recv)).toBeUndefined();
   });
@@ -147,14 +147,14 @@ describe("#2660 PART-1 — receiver-struct flow map (inert analysis)", () => {
       };
     `;
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const recv = findReceiver(sf, "v")!;
     expect(result.receiverStruct.get(recv)).toBeUndefined();
   });
 
   it("is empty for fnctor-free code", () => {
     const { sf, checker } = checkerForJs(`function f() { return 1; } f();`);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     expect(result.receiverStruct.size).toBe(0);
   });
 });
@@ -174,7 +174,7 @@ describe("#2660 PART-1 — resolveReceiverStruct (3-case resolution)", () => {
 
   it("case 1: `this` receiver → fctx.thisStructName (when registered)", () => {
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const ctx = mockCtx(result, ["__fnctor_Parser", "__fnctor_Node"]);
     const fctx = mockFctx("__fnctor_Parser");
     // Synthesize a `this` expression.
@@ -184,7 +184,7 @@ describe("#2660 PART-1 — resolveReceiverStruct (3-case resolution)", () => {
 
   it("case 1: `this` receiver but thisStructName unset → undefined", () => {
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const ctx = mockCtx(result, ["__fnctor_Parser"]);
     const fctx = mockFctx(undefined);
     expect(resolveReceiverStruct(ctx, fctx, ts.factory.createThis())).toBeUndefined();
@@ -192,7 +192,7 @@ describe("#2660 PART-1 — resolveReceiverStruct (3-case resolution)", () => {
 
   it("case 2: local in the flow map AND struct registered → the struct name", () => {
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const ctx = mockCtx(result, ["__fnctor_Node"]);
     const fctx = mockFctx("__fnctor_Parser");
     const recv = findReceiver(sf, "node")!;
@@ -201,7 +201,7 @@ describe("#2660 PART-1 — resolveReceiverStruct (3-case resolution)", () => {
 
   it("case 2 (conservative): flow-map hit but struct NOT registered → undefined", () => {
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const ctx = mockCtx(result, []); // structMap empty → __fnctor_Node not registered yet
     const fctx = mockFctx("__fnctor_Parser");
     const recv = findReceiver(sf, "node")!;
@@ -210,7 +210,7 @@ describe("#2660 PART-1 — resolveReceiverStruct (3-case resolution)", () => {
 
   it("case 3: an unrelated local receiver → undefined (dynamic path)", () => {
     const { sf, checker } = checkerForJs(src);
-    const result = analyzeFnctorEscapeGate(checker, sf);
+    const result = analyzeFnctorEscapeGate(checker, [sf]);
     const ctx = mockCtx(result, ["__fnctor_Node"]);
     const fctx = mockFctx("__fnctor_Parser");
     // `other` is a number, never in the flow map.

--- a/tests/issue-3683-proto-method-write-once.test.ts
+++ b/tests/issue-3683-proto-method-write-once.test.ts
@@ -17,7 +17,7 @@ import { setupAcorn } from "./dogfood/setup-acorn.mjs";
 
 function analyze(source: string) {
   const sf = ts.createSourceFile("t.ts", source, ts.ScriptTarget.ES2022, true);
-  return analyzeProtoMethodWriteOnce(sf);
+  return analyzeProtoMethodWriteOnce([sf]);
 }
 
 describe("#3683 S1 — prototype-method write-once analysis", () => {
@@ -108,7 +108,7 @@ describe("#3683 S1 — prototype-method write-once analysis", () => {
     const { entryModulePath } = setupAcorn();
     const source = readFileSync(entryModulePath, "utf-8");
     const sf = ts.createSourceFile("acorn.mjs", source, ts.ScriptTarget.ES2022, true);
-    const r = analyzeProtoMethodWriteOnce(sf);
+    const r = analyzeProtoMethodWriteOnce([sf]);
     expect(r.poisoned.has("Parser")).toBe(false);
     const parser = r.methods.get("Parser");
     expect(parser).toBeDefined();
@@ -156,7 +156,7 @@ describe("#3683 S1b — direct-call admission facts", () => {
     const { entryModulePath } = setupAcorn();
     const source = readFileSync(entryModulePath, "utf-8");
     const sf = ts.createSourceFile("acorn.mjs", source, ts.ScriptTarget.ES2022, true);
-    const r = analyzeProtoMethodWriteOnce(sf);
+    const r = analyzeProtoMethodWriteOnce([sf]);
     // acorn writes `keywordTypes[name] = …` with a dynamic key at init, so
     // name-only shadowing proofs are unavailable — S3 must pair the verdicts
     // with receiver-shape runtime guards. Pin the fact so a future refinement

--- a/tests/issue-3927-fnctor-alloc-labels.test.ts
+++ b/tests/issue-3927-fnctor-alloc-labels.test.ts
@@ -53,7 +53,7 @@ function analyze(source: string, ctorNames: readonly string[]) {
     ts.forEachChild(n, walk);
   };
   walk(sf);
-  return analyzeFnctorAllocLabels(program.getTypeChecker(), sf, ctorDeclByName);
+  return analyzeFnctorAllocLabels(program.getTypeChecker(), [sf], ctorDeclByName);
 }
 
 /**

--- a/tests/issue-4235-multifile-fnctor-parity.test.ts
+++ b/tests/issue-4235-multifile-fnctor-parity.test.ts
@@ -1,0 +1,328 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4235) Path parity for the fnctor pipeline.
+ *
+ * `generateMultiModule` never assigned `ctx.fnctorEscapeGate`, so on every
+ * multi-file compile (`compileProject` / `compileMulti` — the path most of the
+ * npm-compat corpus goes through) the escape gate, the presence-bit/hot-cold
+ * split and the per-type layout analysis were ALL inert, with no error and no
+ * fallback telemetry. The failure was a **silent empty**: a zero from that path
+ * was indistinguishable from "this package contains no fnctors", which is
+ * exactly how the 2026-08-08 corpus census came to be run entirely through the
+ * single-file path without anyone noticing the other one was dark.
+ *
+ * These tests pin the property that makes that impossible to regress to:
+ * **the same source analysed through `compile()` and through `compileMulti()`
+ * yields the same fnctor verdicts** — and where the multi path declines, it
+ * declines out loud, into a counted ledger.
+ *
+ * The analysis is exercised directly rather than through the compilers so a
+ * verdict mismatch fails HERE, on the verdict, instead of surfacing later as a
+ * byte-count difference nobody can attribute.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { ts } from "../src/ts-api.js";
+import { analyzeFnctorEscapeGate } from "../src/codegen/fnctor-escape-gate.js";
+import { compile, compileMulti } from "../src/index.js";
+
+/**
+ * The TWO_SITE fixture from the issue: one fnctor, two factories that give its
+ * instances two DIFFERENT shapes. The single-file path proves `split` on this;
+ * anything less from the multi path is the bug.
+ */
+const TWO_SITE = `
+function Node(pos: any) {
+  this.type = "";
+  this.start = pos;
+  this.end = 0;
+}
+Node.prototype.finish = function (t: any, end: any) {
+  this.type = t;
+  this.end = end;
+  return this;
+};
+function makeA(p: any) { const n = new Node(p); n.extraA = 1; return n; }
+function makeB(p: any) { const n = new Node(p); n.extraB = 2; n.extraC = 3; return n; }
+export function test(): number {
+  const a: any = makeA(1);
+  const b: any = makeB(2);
+  a.finish("A", 5);
+  b.finish("B", 6);
+  return (a.end as number) + (b.end as number) === 11 ? 1 : 0;
+}
+`;
+
+/** Build an in-memory program over `files` and return its checker + sources. */
+function programOf(files: Record<string, string>): {
+  checker: ts.TypeChecker;
+  sourceFiles: ts.SourceFile[];
+} {
+  const sources = new Map<string, ts.SourceFile>();
+  for (const [name, text] of Object.entries(files)) {
+    sources.set(name, ts.createSourceFile(name, text, ts.ScriptTarget.ES2020, true));
+  }
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) => sources.get(name),
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => undefined,
+    getCurrentDirectory: () => "",
+    getCanonicalFileName: (f) => f,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: (name) => sources.has(name),
+    readFile: (name) => files[name],
+  };
+  const program = ts.createProgram([...sources.keys()], { allowJs: true, noLib: true }, host);
+  return {
+    checker: program.getTypeChecker(),
+    sourceFiles: [...sources.keys()].map((k) => sources.get(k)!),
+  };
+}
+
+/** The verdict surface the two paths must agree on. */
+function verdicts(files: Record<string, string>, path: "single" | "multi") {
+  const { checker, sourceFiles } = programOf(files);
+  const r = analyzeFnctorEscapeGate(checker, sourceFiles, true, path);
+  const byClass = { reconstruct: 0, "keep-typed": 0, "keep-static": 0 };
+  for (const c of r.sites.values()) byClass[c]++;
+  return {
+    byClass,
+    approvedNames: [...r.approvedNames].sort(),
+    ctorNames: [...r.ctorDeclByName.keys()].sort(),
+    receiverStructEntries: r.receiverStruct.size,
+    writeOncePoisoned: [...r.protoMethodWriteOnce.poisoned].sort(),
+    provenance: r.provenance,
+  };
+}
+
+describe("#4235 — the fnctor pipeline runs on the multi-file compile path", () => {
+  it("gives the SAME verdicts for the TWO_SITE fixture on both paths", () => {
+    const files = { "main.ts": TWO_SITE };
+    const single = verdicts(files, "single");
+    const multi = verdicts(files, "multi");
+
+    // A vacuous pass is the whole hazard here: if the fixture produced no
+    // fnctor sites at all, "single === multi" would hold trivially and this
+    // test would defend nothing. Floor the counts first.
+    expect(single.byClass.reconstruct).toBeGreaterThan(0);
+    expect(single.approvedNames).toContain("Node");
+
+    expect(multi.byClass).toEqual(single.byClass);
+    expect(multi.approvedNames).toEqual(single.approvedNames);
+    expect(multi.ctorNames).toEqual(single.ctorNames);
+    expect(multi.receiverStructEntries).toBe(single.receiverStructEntries);
+    expect(multi.writeOncePoisoned).toEqual(single.writeOncePoisoned);
+  });
+
+  it("labels every result with the compile path that produced it", () => {
+    const files = { "main.ts": TWO_SITE };
+    expect(verdicts(files, "single").provenance.compilePath).toBe("single");
+    expect(verdicts(files, "multi").provenance.compilePath).toBe("multi");
+  });
+
+  it("reports the source-file count, so an empty result is never anonymous", () => {
+    // The regression that motivated this: an empty result from a 146-file graph
+    // and an empty result from one file are DIFFERENT claims, and before #4235
+    // both were rendered as the same silence.
+    const one = verdicts({ "main.ts": TWO_SITE }, "multi");
+    expect(one.provenance.sourceFileCount).toBe(1);
+
+    const { checker, sourceFiles } = programOf({
+      "a.ts": "export function f(): number { return 1; }",
+      "b.ts": "export function g(): number { return 2; }",
+    });
+    // No fnctor `new` sites at all — the empty result STILL carries provenance.
+    const empty = analyzeFnctorEscapeGate(checker, sourceFiles, true, "multi");
+    expect(empty.approvedNames.size).toBe(0);
+    expect(empty.provenance.compilePath).toBe("multi");
+    expect(empty.provenance.sourceFileCount).toBe(2);
+  });
+
+  it("sees a fnctor whose allocation and consumption live in DIFFERENT modules", () => {
+    // The escape a single-module analysis never faced. `p` is allocated in a.ts
+    // and consumed dynamically in b.ts; the whole-program walk plus the
+    // import-alias symbol resolution is what lets the uses in b.ts reach the
+    // binding declared in a.ts.
+    const files = {
+      "a.ts": `
+        export function P(x: any) { this.v = x; }
+        P.prototype.m = function () { return this.v; };
+        export const p: any = new P(1);
+      `,
+      "b.ts": `
+        import { p } from "./a";
+        export function test(): number { p.m(); return 1; }
+      `,
+    };
+    const { checker, sourceFiles } = programOf(files);
+    const graph = analyzeFnctorEscapeGate(checker, sourceFiles, true, "multi");
+    expect(graph.provenance.sourceFileCount).toBe(2);
+    // The `new P(1)` site is found and classified — not silently absent.
+    expect(graph.sites.size).toBeGreaterThan(0);
+    expect(graph.ctorDeclByName.has("P")).toBe(true);
+
+    // Positive control for the cross-module claim: analysing a.ts ALONE cannot
+    // see b.ts's dynamic `p.m()`, so it must classify strictly less
+    // aggressively. If this ever stops differing, the fixture stopped testing
+    // cross-module visibility and the assertion above is vacuous.
+    const aOnly = analyzeFnctorEscapeGate(checker, [sourceFiles[0]!], true, "single");
+    expect(aOnly.approvedNames.has("P")).toBe(false);
+    expect(graph.approvedNames.has("P")).toBe(true);
+  });
+
+  it("REFUSES a fnctor name declared in two modules, and COUNTS the refusal", () => {
+    // Everything downstream is keyed by bare NAME (`__fnctor_<Name>` struct
+    // key, `approvedNames`, the write-once ledger). A single source made that
+    // safe by construction; a module graph does not — #4133 measured 55
+    // colliding top-level names across the 146-file ESLint graph. Reserving one
+    // module's constructor shape and applying it to another module's
+    // same-named, differently-shaped fnctor is a wrong field set, not a missed
+    // optimization. The refusal must be visible, which is what `refusals` is.
+    const files = {
+      "a.ts": `
+        export function Dup(x: any) { this.a = x; }
+        export function useA(): any { const d: any = new Dup(1); d.dyn = 1; return d; }
+      `,
+      "b.ts": `
+        export function Dup(y: any) { this.b = y; this.c = y; }
+        export function useB(): any { const d: any = new Dup(2); d.dyn = 2; return d; }
+      `,
+    };
+    const { checker, sourceFiles } = programOf(files);
+    const r = analyzeFnctorEscapeGate(checker, sourceFiles, true, "multi");
+
+    expect(r.approvedNames.has("Dup")).toBe(false);
+    expect(r.ctorDeclByName.has("Dup")).toBe(false);
+    expect(r.provenance.refusedNames).toContain("Dup");
+    expect(r.provenance.refusals.get("multi-module-name-collision")).toBe(1);
+
+    // And the refusal is SPECIFIC, not a blanket bail: a non-colliding fnctor
+    // in the same graph is still analysed. Without this the test would pass on
+    // an implementation that simply gave up on every multi-module graph.
+    const withOk = {
+      ...files,
+      "c.ts": `
+        export function Solo(z: any) { this.z = z; }
+        export function useC(): any { const s: any = new Solo(3); s.dyn = 3; return s; }
+      `,
+    };
+    const g2 = programOf(withOk);
+    const r2 = analyzeFnctorEscapeGate(g2.checker, g2.sourceFiles, true, "multi");
+    expect(r2.provenance.refusedNames).toContain("Dup");
+    expect(r2.ctorDeclByName.has("Solo")).toBe(true);
+  });
+
+  it("keeps write-once admission closed over the WHOLE graph", () => {
+    // The sharpest cross-module hazard: `analyzeProtoMethodWriteOnce` admits a
+    // method precisely BECAUSE it saw no second write. Run over one file of a
+    // graph it admits a slot that another module overwrites — a typed twin for
+    // a mutable slot, i.e. a real miscompile rather than a missed
+    // optimization. The graph-wide walk is what makes the second write visible.
+    const files = {
+      "a.ts": `
+        export function W(x: any) { this.v = x; }
+        W.prototype.m = function () { return 1; };
+        export const w: any = new W(1);
+      `,
+      "b.ts": `
+        import { w } from "./a";
+        export function test(): number { w.m(); return 1; }
+      `,
+    };
+    const aOnly = programOf(files);
+    const admittedFromAAlone = analyzeFnctorEscapeGate(
+      aOnly.checker,
+      [aOnly.sourceFiles[0]!],
+      true,
+      "single",
+    ).protoMethodWriteOnce.methods.get("W");
+    // Control: with only a.ts in view, `m` IS admitted as write-once.
+    expect(admittedFromAAlone?.has("m")).toBe(true);
+
+    // Now the same a.ts inside a graph whose OTHER module rewrites the slot.
+    const overwritten = {
+      ...files,
+      "b.ts": `
+        import { w } from "./a";
+        import { W } from "./a";
+        W.prototype.m = function () { return 2; };
+        export function test(): number { w.m(); return 1; }
+      `,
+    };
+    const g = programOf(overwritten);
+    const graphVerdict = analyzeFnctorEscapeGate(g.checker, g.sourceFiles, true, "multi").protoMethodWriteOnce;
+    // The second write must retract the admission — either by demoting the
+    // method or by poisoning the owner. Both are correct; silence is not.
+    const stillAdmitted = graphVerdict.methods.get("W")?.has("m") === true && !graphVerdict.poisoned.has("W");
+    expect(stillAdmitted).toBe(false);
+  });
+});
+
+/**
+ * The tests above exercise the ANALYSIS. They would all still pass if someone
+ * deleted the one line in `generateMultiModule` that assigns
+ * `ctx.fnctorEscapeGate` — which is the exact defect #4235 is about. These pin
+ * the WIRING, by driving the real compilers and observing that the pipeline
+ * actually ran, and under which path.
+ */
+describe("#4235 — the wiring, observed end-to-end through the compilers", () => {
+  const ORIGINAL_WRITE = process.stderr.write.bind(process.stderr);
+  const ORIGINAL_LAYOUTS = process.env.JS2WASM_FNCTOR_LAYOUTS;
+  const ORIGINAL_DIAG = process.env.JS2WASM_FNCTOR_LAYOUT_DIAG;
+
+  afterEach(() => {
+    process.stderr.write = ORIGINAL_WRITE;
+    process.env.JS2WASM_FNCTOR_LAYOUTS = ORIGINAL_LAYOUTS;
+    process.env.JS2WASM_FNCTOR_LAYOUT_DIAG = ORIGINAL_DIAG;
+  });
+
+  /** Run `fn` with the layout diagnostic on, returning everything it wrote. */
+  async function captureDiag(fn: () => Promise<unknown>): Promise<string> {
+    process.env.JS2WASM_FNCTOR_LAYOUTS = "1";
+    process.env.JS2WASM_FNCTOR_LAYOUT_DIAG = "1";
+    let buf = "";
+    process.stderr.write = ((chunk: unknown) => {
+      buf += String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await fn();
+    } finally {
+      process.stderr.write = ORIGINAL_WRITE;
+    }
+    return buf;
+  }
+
+  it("runs the layout analysis on BOTH paths and stamps each with its path", async () => {
+    const single = await captureDiag(() => compile(TWO_SITE, { fileName: "main.ts", target: "standalone" } as never));
+    const multi = await captureDiag(() =>
+      compileMulti({ "main.ts": TWO_SITE }, "main.ts", { target: "standalone" } as never),
+    );
+
+    // Positive control FIRST: the single path must actually produce the plan we
+    // are about to demand from the multi path. If the fixture ever stops
+    // proving `split`, every assertion below becomes vacuous and this line is
+    // what says so.
+    expect(single).toMatch(/\[alloc-labels\] path=single files=1/);
+    expect(single).toMatch(/\[alloc-labels\] Node: verdict=split/);
+
+    // The bug: before #4235 this produced NOTHING at all.
+    expect(multi).toMatch(/\[alloc-labels\] path=multi files=1/);
+    expect(multi).toMatch(/\[alloc-labels\] Node: verdict=split/);
+
+    // Parity on the verdict line itself (labels/layouts/union/width all match).
+    const verdictLine = (s: string) => /\[alloc-labels\] Node: (.*)/.exec(s)?.[1];
+    expect(verdictLine(multi)).toBe(verdictLine(single));
+  });
+
+  it("stamps the path even when the graph has nothing to report", async () => {
+    // A zero must never again be readable without its provenance — the header
+    // prints whether or not any family carries labels.
+    const out = await captureDiag(() =>
+      compileMulti({ "m.ts": "export function f(): number { return 1; }" }, "m.ts", {
+        target: "standalone",
+      } as never),
+    );
+    expect(out).toMatch(/\[alloc-labels\] path=multi files=1 families=\d+ with-labels=\d+/);
+  });
+});


### PR DESCRIPTION
Fixes #4235.

## The bug

`generateMultiModule` never assigned `ctx.fnctorEscapeGate`, so on **every**
multi-file compile — `compileProject` / `compileMulti`, the path most of the
npm-compat corpus goes through — the escape gate, the presence-bit/hot-cold
split (#4211/#4217) and the per-type layout analysis and emission (#3927) were
all inert. No error, no fallback telemetry: the compile succeeded with the
unsplit representation, and the resulting zero was indistinguishable from
"this package has no fnctors". With the layout emission defaulting ON since
2026-08-08 that became a *lying default* — the flag reported enabled while the
machinery never ran.

Positive control, identical source and options, `target: "standalone"`:

| | before | after |
| --- | --- | --- |
| `compile()` | `path=single files=1 … reconstruct=2`; `Node: verdict=split labels=2`; 3 layouts emitted | unchanged |
| `compileMulti()` | **no output at all** | `path=multi files=1 … reconstruct=2`; `Node: verdict=split labels=2`; 3 layouts emitted |

## Which arm landed

**The whole-program arm, not the telemetered-refusal arm** — with one narrow,
counted refusal inside it.

`analyzeFnctorEscapeGate` now takes the graph's source files instead of one
file, and every sub-pass walks all of them (`analyzeProtoMethodWriteOnce`,
`buildProtoMethodIndex`, `buildReceiverStructMap`,
`analyzeFnctorAllocLabels`/`indexSourceFile`). `generateMultiModule` calls it
at the same point in the pass `generateModule` does, and gained the matching
`collectDynamicObjectReturnCarrierTypes` + `reserveFnctorStructTypes`
reservation in the same relative position.

Widening the walk is monotone toward **safety** in every pass, which is what
made this arm landable rather than the refusal arm:

- Site classification: more visible uses can only ADD `sawTyped`/`sawDynamic`
  evidence, and clause B (`sawTyped` ⇒ `keep-typed`) is absolute. A use still
  missed leaves the site `keep-static`, which no lowering consumes.
- `analyzeProtoMethodWriteOnce` admits a slot precisely BECAUSE it saw no
  second write — so a one-file view of a graph would admit a slot another
  module overwrites (a real miscompile). Unioning across files only ever adds
  writes and poison.
- `buildProtoMethodIndex`: more bodies for a name make it ambiguous
  (≥2 ⇒ unresolved), never resolve it to a wrong callee.

## The two genuinely cross-module hazards

1. **Import-alias symbol identity.** A use in module B of a binding declared
   in A keyed under the import-alias symbol, so A's binding looked unused.
   Resolved through `checker.getAliasedSymbol`. (Unfixed this was inert rather
   than wrong, but it forfeited exactly the cross-module escapes this change
   exists to see.)
2. **Cross-module fnctor NAME collision — REFUSED and COUNTED.** Everything
   downstream is keyed by bare name (`__fnctor_<Name>` struct key,
   `approvedNames`, the write-once ledger). One source made that safe by
   construction; a graph does not — #4133 measured 55 colliding top-level
   names across the 146-file ESLint graph. Applying one module's constructor
   shape to another module's same-named, differently-shaped fnctor is a wrong
   field set, not a missed optimization. Such families are dropped and counted
   under `provenance.refusals["multi-module-name-collision"]` — per-family, not
   a blanket bail (a non-colliding fnctor in the same graph is still analysed,
   pinned by test).

## Provenance — so a zero is never anonymous again

Every result carries `provenance` (compile path, source-file count, refusal
ledger), and the `[alloc-labels]` diagnostic leads with `path=` — **including**
for a graph with no fnctor sites at all, which previously printed nothing and
so could not be told apart from a path that never ran.

## Tests

`tests/issue-4235-multifile-fnctor-parity.test.ts` — 8 tests. Six pin the
analysis (verdict parity on the TWO_SITE fixture, provenance, cross-module
visibility, the counted refusal, whole-graph write-once closure); two drive the
real compilers and pin the **wiring**.

**Negative control run:** with the single `ctx.fnctorEscapeGate = …` line
removed from `generateMultiModule`, the six analysis tests still pass and
exactly the two wiring tests fail — so the wiring tests genuinely defend this
defect rather than restating the analysis. Each parity assertion is also
floored by a positive control first, so a fixture that stopped proving `split`
would fail loudly instead of passing vacuously.

Existing suites updated for the array signature and re-run green: `#2660`
gate/receiver-resolve, `#3683` write-once, `#3927` alloc-labels, plus `#2660`
S2/S3, `#3927` layout-emit/cold-tail/pad-probe, `#4211`, and `multi-file` —
48 + 60 tests.

## Audit (the issue's implementer note asked for this)

Diffing `generateModule`'s prologue against `generateMultiModule`'s found
**thirteen** single-path-only setup steps. This PR fixes three (the fnctor
pipeline). The other ten — plus a **live, pre-existing multi-path miscompile**
found while validating: fnctor prototype-method `this.<field> = …` writes are
dropped, so `a.finish("A",5); a.end === 5` returns 1 through `compile()` and 0
through `compileMulti()`, both reporting success — are filed as **#4256**,
which also proposes the structural fix (one shared `setUpModuleAnalyses` both
entry points call) so the next divergence cannot happen silently.

A full-tree A/B (all three changed files reverted to `HEAD` via file copies)
establishes this change is **exactly neutral** on that defect. Two audit items
were excluded as its cause by direct experiment.

## Known-red on main, not caused here

The two `tests/issue-3683-numeric-fields.test.ts` failures — verified by A/B
against a clean tree, and matching the pair recorded in #4253 (packed presence
word vs `$$has_<f>`; reflection bitmask `11` vs a stale hard-coded `3`).

## Budget gates

`check:loc-budget` and `check:func-budget` both green, with grants recorded in
this PR's own issue file. No new over-budget function (`analyzeFnctorAllocLabels`
was kept under 300 by lifting `lineOf` to module scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Mjntn1rYJ7sH8kgfFDoqM
