### PR TITLE
feat(linear): cache literals and lower string searches

### DIFF
--- a/src/codegen-linear/context.ts
+++ b/src/codegen-linear/context.ts
@@ -6,6 +6,7 @@ import type { ClassLayout } from "./layout.js";
 export interface LinearStringLiteralData {
   readonly offset: number;
   readonly bytes: readonly number[];
+  readonly cacheGlobalIdx: number;
 }
 
 /** Module-level context for linear-memory codegen */

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -14,6 +14,7 @@ import { computeClassLayout } from "./layout.js";
 import * as linearCoercion from "./coercion-engine.js";
 import * as numberFormat from "./number-format.js";
 import { addLinearStackArenaRuntime } from "./runtime-stack-arena.js";
+import { compileLinearStringMethodCall } from "./string-methods.js";
 import {
   addArrayRuntime,
   addFmodRuntime,
@@ -28,8 +29,8 @@ import {
   addUint8ArrayRuntime,
   finalizeLinearHeapLayout,
   FMOD_FN,
-  linearStringLiteralInstrs,
 } from "./runtime.js";
+import { linearStringLiteralInstrs } from "./string-literals.js";
 
 /** Type tag for class instances in linear memory */
 const CLASS_TYPE_TAG = 5;
@@ -3470,57 +3471,14 @@ function compileMethodCall(ctx: LinearContext, fctx: LinearFuncContext, expr: ts
     compileMapMethodCall(ctx, fctx, expr, propAccess, methodName);
   } else if (objKind === "Set") {
     compileSetMethodCall(ctx, fctx, expr, propAccess, methodName);
-  } else if (methodName === "split" && isStringExpr(ctx, fctx, propAccess.expression)) {
-    // string.split(sep) → __str_split(str, sep) → i32 (array pointer)
-    const splitIdx = ctx.funcMap.get("__str_split")!;
-    compileExpression(ctx, fctx, propAccess.expression); // str
-    if (expr.arguments.length > 0) {
-      compileExpression(ctx, fctx, expr.arguments[0]); // sep
-    } else {
-      compileStringLiteral(ctx, fctx, "");
-    }
-    fctx.body.push({ op: "call", funcIdx: splitIdx });
-    return;
-  } else if (methodName === "slice" && isStringExpr(ctx, fctx, propAccess.expression)) {
-    // string.slice(start, end) → __str_slice(str, start, end)
-    const sliceIdx = ctx.funcMap.get("__str_slice")!;
-    compileExpression(ctx, fctx, propAccess.expression); // str
-    compileExprToI32(ctx, fctx, expr.arguments[0]); // start → i32
-    if (expr.arguments.length > 1) {
-      compileExprToI32(ctx, fctx, expr.arguments[1]); // end → i32
-    } else {
-      // end = str.length
-      compileExpression(ctx, fctx, propAccess.expression);
-      const strLenIdx = ctx.funcMap.get("__str_len")!;
-      fctx.body.push({ op: "call", funcIdx: strLenIdx });
-    }
-    fctx.body.push({ op: "call", funcIdx: sliceIdx });
-    return;
-  } else if (methodName === "indexOf" && isStringExpr(ctx, fctx, propAccess.expression)) {
-    // string.indexOf(search) → __str_index_of(str, search, 0) → i32, convert to f64
-    const indexOfIdx = ctx.funcMap.get("__str_index_of")!;
-    compileExpression(ctx, fctx, propAccess.expression); // str
-    compileExpression(ctx, fctx, expr.arguments[0]); // search
-    if (expr.arguments.length > 1) {
-      compileExprToI32(ctx, fctx, expr.arguments[1]); // fromIdx
-    } else {
-      fctx.body.push({ op: "i32.const", value: 0 });
-    }
-    fctx.body.push({ op: "call", funcIdx: indexOfIdx });
-    fctx.body.push({ op: "f64.convert_i32_s" });
-    return;
-  } else if (methodName === "startsWith" && isStringExpr(ctx, fctx, propAccess.expression)) {
-    // string.startsWith(prefix) → __str_starts_with(str, prefix)
-    const startsWithIdx = ctx.funcMap.get("__str_starts_with")!;
-    compileExpression(ctx, fctx, propAccess.expression); // str
-    if (expr.arguments.length > 0) {
-      compileExpression(ctx, fctx, expr.arguments[0]); // prefix
-    } else {
-      compileStringLiteral(ctx, fctx, "");
-    }
-    fctx.body.push({ op: "call", funcIdx: startsWithIdx });
-    // Convert i32 result to f64
-    fctx.body.push({ op: "f64.convert_i32_s" });
+  } else if (
+    compileLinearStringMethodCall(ctx, fctx, expr, propAccess, methodName, {
+      compileExpression,
+      compileExprToI32,
+      compileStringLiteral,
+      isStringExpr,
+    })
+  ) {
     return;
   } else if (methodName === "toString") {
     // Exact no-radix Number::toString uses the host-free Ryū runtime.

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -5,8 +5,8 @@ import {
   LINEAR_STRING_PAYLOAD_PREFIX_BYTES,
   LINEAR_STRING_PAYLOAD_SIZE_OFFSET,
 } from "../ir/analysis/linear-memory-plan.js";
-import type { LinearContext } from "./context.js";
 import { hashProbeAdvanceInstrs, hashProbeInitInstrs } from "./emit-idioms.js";
+import { isLinearStringLiteralCacheGlobal } from "./string-literals.js";
 
 /** Heap starts at byte offset 1024 (leave low addresses for null/sentinel) */
 const HEAP_START = 1024;
@@ -258,6 +258,16 @@ export function finalizeLinearHeapLayout(mod: WasmModule): void {
   }
   const oldHeapStart = init.value;
   const newHeapStart = Math.max(oldHeapStart, align8(dataEnd));
+
+  // Arena reset invalidates every lazily interned literal pointer. Clear the
+  // caches with the heap rewind so the next use rematerializes valid records.
+  const arenaReset = mod.functions.find((func) => func.name === "__arena_reset");
+  if (arenaReset !== undefined) {
+    for (let index = 0; index < mod.globals.length; index++) {
+      if (!isLinearStringLiteralCacheGlobal(mod.globals[index]!.name)) continue;
+      arenaReset.body.push({ op: "i32.const", value: 0 }, { op: "global.set", index });
+    }
+  }
 
   // Data segments are initialised before any code runs, so the *declared*
   // minimum has to cover them (memory.grow in __malloc is too late).
@@ -2806,30 +2816,6 @@ export function addLinearIrStringRuntime(mod: WasmModule): void {
     },
     5,
   );
-}
-
-/** Materialize a literal through canonical UTF-8 data and `__str_from_data`. */
-export function linearStringLiteralInstrs(
-  ctx: LinearContext,
-  value: string,
-  strFromDataIdx = ctx.funcMap.get("__str_from_data"),
-  plannedBytes?: readonly number[],
-): readonly Instr[] {
-  const encoded = plannedBytes === undefined ? [...new TextEncoder().encode(value)] : [...plannedBytes];
-  let literal = ctx.stringLiterals.get(value);
-  if (literal === undefined) {
-    literal = { offset: ctx.dataSegmentOffset, bytes: encoded };
-    ctx.stringLiterals.set(value, literal);
-    ctx.dataSegmentOffset += literal.bytes.length;
-  } else if (literal.bytes.length !== encoded.length || literal.bytes.some((byte, index) => byte !== encoded[index])) {
-    throw new Error(`linear string runtime: conflicting data bytes for ${JSON.stringify(value)}`);
-  }
-  if (strFromDataIdx === undefined) throw new Error("linear string runtime: __str_from_data helper missing");
-  return [
-    { op: "i32.const", value: literal.offset },
-    { op: "i32.const", value: literal.bytes.length },
-    { op: "call", funcIdx: strFromDataIdx },
-  ];
 }
 
 /**

--- a/src/codegen-linear/string-literals.ts
+++ b/src/codegen-linear/string-literals.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import type { Instr } from "../ir/types.js";
+import type { LinearContext } from "./context.js";
+
+const LITERAL_CACHE_GLOBAL_PREFIX = "__str_literal_cache_";
+
+export function isLinearStringLiteralCacheGlobal(name: string): boolean {
+  return name.startsWith(LITERAL_CACHE_GLOBAL_PREFIX);
+}
+
+/** Materialize each immutable literal once per instance, then reuse its arena pointer. */
+export function linearStringLiteralInstrs(
+  ctx: LinearContext,
+  value: string,
+  strFromDataIdx = ctx.funcMap.get("__str_from_data"),
+  plannedBytes?: readonly number[],
+): readonly Instr[] {
+  const encoded = plannedBytes === undefined ? [...new TextEncoder().encode(value)] : [...plannedBytes];
+  let literal = ctx.stringLiterals.get(value);
+  if (literal === undefined) {
+    const cacheGlobalIdx = ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: `${LITERAL_CACHE_GLOBAL_PREFIX}${ctx.stringLiterals.size}`,
+      type: { kind: "i32" },
+      mutable: true,
+      init: [{ op: "i32.const", value: 0 }],
+    });
+    literal = { offset: ctx.dataSegmentOffset, bytes: encoded, cacheGlobalIdx };
+    ctx.stringLiterals.set(value, literal);
+    ctx.dataSegmentOffset += literal.bytes.length;
+  } else if (literal.bytes.length !== encoded.length || literal.bytes.some((byte, index) => byte !== encoded[index])) {
+    throw new Error(`linear string runtime: conflicting data bytes for ${JSON.stringify(value)}`);
+  }
+  if (strFromDataIdx === undefined) throw new Error("linear string runtime: __str_from_data helper missing");
+
+  const materialize: Instr[] = [
+    { op: "i32.const", value: literal.offset },
+    { op: "i32.const", value: literal.bytes.length },
+    { op: "call", funcIdx: strFromDataIdx },
+    { op: "global.set", index: literal.cacheGlobalIdx },
+    { op: "global.get", index: literal.cacheGlobalIdx },
+  ];
+  return [
+    { op: "global.get", index: literal.cacheGlobalIdx },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: materialize,
+      else: [{ op: "global.get", index: literal.cacheGlobalIdx }],
+    },
+  ];
+}

--- a/src/codegen-linear/string-methods.ts
+++ b/src/codegen-linear/string-methods.ts
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { ts } from "../ts-api.js";
+import type { LinearContext, LinearFuncContext } from "./context.js";
+import { addLocal } from "./context.js";
+
+type CompileExpression = (ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Expression) => void;
+type CompileStringLiteral = (ctx: LinearContext, fctx: LinearFuncContext, value: string) => void;
+
+export interface LinearStringMethodCompiler {
+  readonly compileExpression: CompileExpression;
+  readonly compileExprToI32: CompileExpression;
+  readonly compileStringLiteral: CompileStringLiteral;
+  readonly isStringExpr: (ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Expression) => boolean;
+}
+
+const MAX_FOLDED_REPEAT_BYTES = 1024 * 1024;
+
+function nodeLoc(node: ts.Node): { line: number; column: number } {
+  try {
+    const sf = node.getSourceFile();
+    const { line, character } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+    return { line: line + 1, column: character + 1 };
+  } catch {
+    return { line: 0, column: 0 };
+  }
+}
+
+function emitUnsupported(ctx: LinearContext, fctx: LinearFuncContext, expr: ts.CallExpression, message: string): void {
+  ctx.errors.push({ message, ...nodeLoc(expr) });
+  fctx.body.push({ op: "f64.const", value: 0 });
+}
+
+function literalText(expr: ts.Expression): string | undefined {
+  return ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr) ? expr.text : undefined;
+}
+
+function foldLiteralRepeat(receiver: ts.Expression, args: ts.NodeArray<ts.Expression>): string | undefined {
+  const value = literalText(receiver);
+  const countArg = args[0];
+  if (value === undefined || args.length !== 1 || countArg === undefined || !ts.isNumericLiteral(countArg)) {
+    return undefined;
+  }
+  const count = Number(countArg.text);
+  if (!Number.isSafeInteger(count) || count < 0) return undefined;
+  const byteLength = new TextEncoder().encode(value).length;
+  if (byteLength !== 0 && count > Math.floor(MAX_FOLDED_REPEAT_BYTES / byteLength)) return undefined;
+  return value.repeat(count);
+}
+
+function isProvablyAsciiString(ctx: LinearContext, expr: ts.Expression, seen: Set<ts.Symbol> = new Set()): boolean {
+  if (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) || ts.isNonNullExpression(expr)) {
+    return isProvablyAsciiString(ctx, expr.expression, seen);
+  }
+  const text = literalText(expr);
+  if (text !== undefined) return [...text].every((char) => char.codePointAt(0)! < 0x80);
+  if (
+    ts.isCallExpression(expr) &&
+    ts.isPropertyAccessExpression(expr.expression) &&
+    expr.expression.name.text === "repeat"
+  ) {
+    return (
+      foldLiteralRepeat(expr.expression.expression, expr.arguments) !== undefined &&
+      isProvablyAsciiString(ctx, expr.expression.expression, seen)
+    );
+  }
+  if (!ts.isIdentifier(expr)) return false;
+  const symbol = ctx.checker.getSymbolAtLocation(expr);
+  if (symbol === undefined || seen.has(symbol)) return false;
+  const declaration = symbol.valueDeclaration;
+  if (
+    declaration === undefined ||
+    !ts.isVariableDeclaration(declaration) ||
+    declaration.initializer === undefined ||
+    !ts.isVariableDeclarationList(declaration.parent) ||
+    (declaration.parent.flags & ts.NodeFlags.Const) === 0
+  ) {
+    return false;
+  }
+  seen.add(symbol);
+  return isProvablyAsciiString(ctx, declaration.initializer, seen);
+}
+
+function compileEndsWith(
+  ctx: LinearContext,
+  fctx: LinearFuncContext,
+  receiver: ts.Expression,
+  suffix: ts.Expression,
+  compileExpression: CompileExpression,
+): void {
+  const strLocal = addLocal(fctx, `__ends_str_${fctx.locals.length}`, { kind: "i32" });
+  const suffixLocal = addLocal(fctx, `__ends_suffix_${fctx.locals.length}`, { kind: "i32" });
+  const strLenIdx = ctx.funcMap.get("__str_len")!;
+  const indexOfIdx = ctx.funcMap.get("__str_index_of")!;
+
+  compileExpression(ctx, fctx, receiver);
+  fctx.body.push({ op: "local.set", index: strLocal });
+  compileExpression(ctx, fctx, suffix);
+  fctx.body.push({ op: "local.set", index: suffixLocal });
+  fctx.body.push(
+    { op: "local.get", index: strLocal },
+    { op: "call", funcIdx: strLenIdx },
+    { op: "local.get", index: suffixLocal },
+    { op: "call", funcIdx: strLenIdx },
+    { op: "i32.ge_u" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [
+        { op: "local.get", index: strLocal },
+        { op: "local.get", index: suffixLocal },
+        { op: "local.get", index: strLocal },
+        { op: "call", funcIdx: strLenIdx },
+        { op: "local.get", index: suffixLocal },
+        { op: "call", funcIdx: strLenIdx },
+        { op: "i32.sub" },
+        { op: "call", funcIdx: indexOfIdx },
+        { op: "local.get", index: strLocal },
+        { op: "call", funcIdx: strLenIdx },
+        { op: "local.get", index: suffixLocal },
+        { op: "call", funcIdx: strLenIdx },
+        { op: "i32.sub" },
+        { op: "i32.eq" },
+      ],
+      else: [{ op: "i32.const", value: 0 }],
+    },
+    { op: "f64.convert_i32_s" },
+  );
+}
+
+/** Compile a direct-backend String.prototype method, returning whether it handled the call. */
+export function compileLinearStringMethodCall(
+  ctx: LinearContext,
+  fctx: LinearFuncContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+  methodName: string,
+  compiler: LinearStringMethodCompiler,
+): boolean {
+  const { compileExpression, compileExprToI32, compileStringLiteral, isStringExpr } = compiler;
+  if (!isStringExpr(ctx, fctx, propAccess.expression)) return false;
+
+  if (methodName === "repeat") {
+    const repeated = foldLiteralRepeat(propAccess.expression, expr.arguments);
+    if (repeated === undefined) {
+      ctx.errors.push({
+        message: `Unsupported String.repeat() in linear backend: expected a literal receiver and a non-negative integer literal producing at most ${MAX_FOLDED_REPEAT_BYTES} UTF-8 bytes`,
+        ...nodeLoc(expr),
+      });
+      fctx.body.push({ op: "i32.const", value: 0 });
+    } else {
+      compileStringLiteral(ctx, fctx, repeated);
+    }
+    return true;
+  }
+
+  if (methodName === "split") {
+    const splitIdx = ctx.funcMap.get("__str_split")!;
+    compileExpression(ctx, fctx, propAccess.expression);
+    if (expr.arguments.length > 0) compileExpression(ctx, fctx, expr.arguments[0]!);
+    else compileStringLiteral(ctx, fctx, "");
+    fctx.body.push({ op: "call", funcIdx: splitIdx });
+    return true;
+  }
+
+  if (methodName === "slice") {
+    const sliceIdx = ctx.funcMap.get("__str_slice")!;
+    compileExpression(ctx, fctx, propAccess.expression);
+    if (expr.arguments.length > 0) compileExprToI32(ctx, fctx, expr.arguments[0]!);
+    else fctx.body.push({ op: "i32.const", value: 0 });
+    if (expr.arguments.length > 1) compileExprToI32(ctx, fctx, expr.arguments[1]!);
+    else {
+      compileExpression(ctx, fctx, propAccess.expression);
+      fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__str_len")! });
+    }
+    fctx.body.push({ op: "call", funcIdx: sliceIdx });
+    return true;
+  }
+
+  if (methodName === "indexOf") {
+    const search = expr.arguments[0];
+    if (search === undefined || !isStringExpr(ctx, fctx, search)) {
+      emitUnsupported(
+        ctx,
+        fctx,
+        expr,
+        "Unsupported String.indexOf() in linear backend: expected a string search value",
+      );
+      return true;
+    }
+    compileExpression(ctx, fctx, propAccess.expression);
+    compileExpression(ctx, fctx, search);
+    if (expr.arguments.length > 1) compileExprToI32(ctx, fctx, expr.arguments[1]!);
+    else fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__str_index_of")! }, { op: "f64.convert_i32_s" });
+    return true;
+  }
+
+  if (methodName === "includes") {
+    const search = expr.arguments[0];
+    if (search === undefined || !isStringExpr(ctx, fctx, search) || expr.arguments.length > 2) {
+      emitUnsupported(
+        ctx,
+        fctx,
+        expr,
+        "Unsupported String.includes() in linear backend: expected a string search value",
+      );
+      return true;
+    }
+    if (expr.arguments.length === 2 && !isProvablyAsciiString(ctx, propAccess.expression)) {
+      emitUnsupported(
+        ctx,
+        fctx,
+        expr,
+        "Unsupported String.includes() position in linear backend: receiver needs a compile-time ASCII proof",
+      );
+      return true;
+    }
+    compileExpression(ctx, fctx, propAccess.expression);
+    compileExpression(ctx, fctx, search);
+    if (expr.arguments.length === 2) compileExprToI32(ctx, fctx, expr.arguments[1]!);
+    else fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push(
+      { op: "call", funcIdx: ctx.funcMap.get("__str_index_of")! },
+      { op: "i32.const", value: -1 },
+      { op: "i32.ne" },
+      { op: "f64.convert_i32_s" },
+    );
+    return true;
+  }
+
+  if (methodName === "startsWith") {
+    compileExpression(ctx, fctx, propAccess.expression);
+    if (expr.arguments.length > 0) compileExpression(ctx, fctx, expr.arguments[0]!);
+    else compileStringLiteral(ctx, fctx, "undefined");
+    fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__str_starts_with")! }, { op: "f64.convert_i32_s" });
+    return true;
+  }
+
+  if (methodName === "endsWith") {
+    const suffix = expr.arguments[0];
+    if (suffix === undefined || !isStringExpr(ctx, fctx, suffix) || expr.arguments.length !== 1) {
+      emitUnsupported(
+        ctx,
+        fctx,
+        expr,
+        "Unsupported String.endsWith() in linear backend: expected one string suffix and the default end position",
+      );
+      return true;
+    }
+    compileEndsWith(ctx, fctx, propAccess.expression, suffix, compileExpression);
+    return true;
+  }
+
+  return false;
+}

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -46,8 +46,8 @@ import {
   LINEAR_IR_STRING_CHAR_CODE_AT_FN,
   LINEAR_IR_STRING_APPEND_ASCII_FN,
   LINEAR_IR_VEC_INIT_F64_FN,
-  linearStringLiteralInstrs,
 } from "../../codegen-linear/runtime.js";
+import { linearStringLiteralInstrs } from "../../codegen-linear/string-literals.js";
 import { IR_STRING_COMPARE_FN, lowerFunctionAstToIr, type IrFromAstResolver, typeNodeToIr } from "../from-ast.js";
 import { collectIrDirectCallLoweringPlans, type IrDirectCallTarget } from "../ast-lowering-plans.js";
 import { irUnitFuncRef } from "../callable-bindings.js";

--- a/tests/linear-string-search-cache.test.ts
+++ b/tests/linear-string-search-cache.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileLinear(source: string, allocator?: "arena-reset") {
+  const result = await compile(source, { target: "linear", allocator });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return { result, exports: instance.exports as Record<string, CallableFunction> };
+}
+
+describe("linear string search and literal caching", () => {
+  it("materializes each immutable literal once and invalidates caches on arena reset", async () => {
+    const { result, exports } = await compileLinear(
+      `
+        export function first(): number { return "cached".length; }
+        export function second(): number { return "different literal".length; }
+      `,
+      "arena-reset",
+    );
+    const used = exports.__arena_used as () => number;
+    const reset = exports.__arena_reset as () => void;
+
+    expect(result.wat).toContain("__str_literal_cache_");
+    expect(used()).toBe(0);
+    expect(exports.first()).toBe(6);
+    const afterFirstUse = used();
+    expect(afterFirstUse).toBeGreaterThan(0);
+    expect(exports.first()).toBe(6);
+    expect(used()).toBe(afterFirstUse);
+
+    reset();
+    expect(used()).toBe(0);
+    expect(exports.second()).toBe(17); // Reuses the first arena address.
+    expect(exports.first()).toBe(6); // Must rematerialize, not read the overwritten record.
+  });
+
+  it("folds bounded literal repeat and searches from an ASCII position", async () => {
+    const { exports } = await compileLinear(`
+      export function run(): number {
+        const text = "abc".repeat(4);
+        let score = text.indexOf("bc", 4) * 100;
+        if (text.includes("bc", 4)) score = score + 10;
+        if (text.includes("zz")) score = score + 1;
+        return score;
+      }
+    `);
+    expect(exports.run()).toBe(410);
+  });
+
+  it("handles allocation-free includes and endsWith over UTF-8 strings", async () => {
+    const { exports } = await compileLinear(`
+      export function run(): number {
+        const text = "naïve🚀";
+        let score = 0;
+        if (text.includes("ïve")) score = score + 100;
+        if (text.endsWith("🚀")) score = score + 10;
+        if (text.endsWith("na")) score = score + 1;
+        return score;
+      }
+    `);
+    expect(exports.run()).toBe(110);
+  });
+
+  it("rejects a UTF-16 position when the receiver is not proven ASCII", async () => {
+    for (const source of [
+      `export function run(text: string): boolean { return text.includes("x", 1); }`,
+      `export function run(): boolean { const text = "é".repeat(2); return text.includes("é", 1); }`,
+    ]) {
+      const result = await compile(source, { target: "linear" });
+      expect(result.success).toBe(false);
+      expect(result.errors.map((error) => error.message).join("\n")).toContain(
+        "receiver needs a compile-time ASCII proof",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- cache each distinct linear-memory string literal in a mutable per-instance global, avoiding repeated arena allocation and UTF-8 copies in hot loops
- clear literal caches from `__arena_reset`, so reset and pointer reuse remain safe
- fold bounded literal `.repeat()` calls and lower direct `.includes()` / one-argument `.endsWith()` through the existing string-search runtime
- require compile-time ASCII proof for `.includes(search, position)`, where byte offsets and UTF-16 code-unit offsets are equivalent
- share literal emission between the direct and IR-backed linear paths and split the string lowering out of the large codegen modules

ASCII case mapping is intentionally excluded; that work is tracked separately in #4272.

## Why this checkpoint

On exact base `dda0d1dc72f4a701b98c09f74f1edd2573985d26`, a fresh JS/GC-native/linear inventory had 21 failed linear rows. The string `indexOf`, `includes`, `startsWith-endsWith`, and mixed text-search rows all failed during linear setup because literal `.repeat()`, `.includes()`, or `.endsWith()` could not lower.

Before changing code, I compared the exact GC-native `array/indexOf` benchmark in V8 TurboFan with the shipped Wasm in Wasmtime/Cranelift. V8 reaches the compact `ArrayIndexOfSmi` loop, while the Wasm loop repeatedly performs GC-ref, metadata, physical-length, bounds, DRC-payload, and numeric-representation work. That remaining GC-native lag needs a representation-level change, so this PR takes the independent high-impact linear checkpoint.

## Performance and correctness

Environment: Node v24.4.1, Darwin arm64.

Focused official `runBenchmark` harness, same host and configuration:

| Benchmark | Base `dda0d1d` linear-memory | Candidate `7604f2f` linear-memory | Exact result |
|---|---:|---:|---:|
| string/indexOf | setup failure | 7.188 ns/op | 4,914,000 |
| string/includes | setup failure | 7.271 ns/op | 998 |
| string/startsWith-endsWith | setup failure | 7.823 ns/op | 10,000 |
| mixed/text-search | setup failure | 13.217 ns/op | 235,000 |

The JS lane was run alongside linear-memory as the semantic oracle for each row.

Positive control, `mixed/fibonacci`, under the same official harness:

- base `dda0d1d`: 4.08545 ns/op
- candidate `7604f2f`: 4.08330 ns/op (-0.05%)
- exact result on both lanes: `320399944`

A focused literal-cache A/B used the same official harness with 10,000 `startsWith` operations per call:

| Lane | Base `dda0d1d` | Candidate `7604f2f` |
|---|---:|---:|
| JS positive control | 8.03958 ns/op | 8.13373 ns/op |
| linear-memory | 21.67915 ns/op | 9.98750 ns/op |

That is a 2.17x linear-memory speedup with matching result `5000`; the JS controls stayed within 1.2%.

## Validation

- `pnpm run typecheck`
- focused Vitest: 3 files, 22 tests passed
- targeted linker/closure control: 1 passed, 1 skipped
- `pnpm run check:ir-fallbacks`
- `pnpm run check:stack-balance`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- pre-commit formatting/lint and full pre-push hook suite

`pnpm run check:linear-ir` reports the same pre-existing baseline mismatch on the exact base and candidate worktrees: the committed baseline expects 8 compiled cases while the current corpus produces 6, with identical `illegal:instr-vec.set_length` and `select:string-builder-candidate` deltas. This PR does not alter that baseline.
