### PR TITLE
perf(codegen): cache ambient host globals per instance

### DIFF
--- a/src/codegen/declared-global-cache.ts
+++ b/src/codegen/declared-global-cache.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Cache ambient host-global resolver calls in module globals (#4150).
+ *
+ * `collectDeclaredGlobals` imports an ambient value such as `document` as
+ * `env.global_document: () -> externref`. The runtime resolves that value when
+ * it builds the import object and the resulting closure is constant for the
+ * lifetime of the instance. Calling the closure again therefore adds a host
+ * boundary without observing new state; DOM loops paid that boundary once per
+ * ambient-identifier read.
+ *
+ * Keep the public import ABI and lazily snapshot its result on first use. A
+ * separate ready bit is required because both `null` and `undefined` are valid
+ * externref results. The bit is written only after the import returns, so an
+ * exception leaves the cache uninitialized and a later read retries exactly
+ * as an uncached read would.
+ *
+ * This pass runs after all import globals have settled and before dead import
+ * elimination. Rewriting the final Wasm instruction tree makes the behavior
+ * identical for legacy- and IR-owned functions.
+ */
+
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { nextModuleGlobalIdx } from "./registry/imports.js";
+import { walkChildren } from "./walk-instructions.js";
+
+interface CacheSlot {
+  readonly valueGlobalIdx: number;
+  readonly readyGlobalIdx: number;
+}
+
+/** Every distinct instruction array in the module, including nested arms. */
+function instructionArrays(bodies: readonly Instr[][]): Instr[][] {
+  const arrays: Instr[][] = [];
+  const seen = new WeakSet<Instr[]>();
+  const pending = [...bodies];
+  while (pending.length > 0) {
+    const array = pending.pop()!;
+    if (seen.has(array)) continue;
+    seen.add(array);
+    arrays.push(array);
+    for (const instr of array) walkChildren(instr, (child) => pending.push(child));
+  }
+  return arrays;
+}
+
+/** Map live `declaredGlobals` entries to their exact env function imports. */
+function declaredGlobalImports(ctx: CodegenContext): Map<number, string> {
+  const importsByFuncIdx = new Map<number, (typeof ctx.mod.imports)[number]>();
+  let funcIdx = 0;
+  for (const entry of ctx.mod.imports) {
+    if (entry.desc.kind !== "func") continue;
+    importsByFuncIdx.set(funcIdx++, entry);
+  }
+
+  const globals = new Map<number, string>();
+  for (const [name, info] of ctx.declaredGlobals) {
+    const entry = importsByFuncIdx.get(info.funcIdx);
+    if (entry?.module === "env" && entry.name === `global_${name}`) {
+      globals.set(info.funcIdx, name);
+    }
+  }
+  return globals;
+}
+
+/**
+ * Replace each `call global_<name>` with a lazy module-global read.
+ *
+ * The original call remains in the cache-miss arm, which keeps the import live
+ * through DCE and lets the ordinary function-index remapper update it.
+ */
+export function cacheDeclaredGlobalReads(ctx: CodegenContext): void {
+  const targets = declaredGlobalImports(ctx);
+  if (targets.size === 0) return;
+
+  const slots = new Map<number, CacheSlot>();
+  const slotFor = (funcIdx: number, name: string): CacheSlot => {
+    const existing = slots.get(funcIdx);
+    if (existing) return existing;
+    const valueGlobalIdx = nextModuleGlobalIdx(ctx);
+    ctx.mod.globals.push({
+      name: `__declared_global_${name}`,
+      type: { kind: "externref" },
+      mutable: true,
+      init: [{ op: "ref.null.extern" }],
+    });
+    const readyGlobalIdx = nextModuleGlobalIdx(ctx);
+    ctx.mod.globals.push({
+      name: `__declared_global_${name}_ready`,
+      type: { kind: "i32" },
+      mutable: true,
+      init: [{ op: "i32.const", value: 0 }],
+    });
+    const slot = { valueGlobalIdx, readyGlobalIdx };
+    slots.set(funcIdx, slot);
+    return slot;
+  };
+
+  // Collect the complete original tree before rewriting so newly-created miss
+  // arms cannot be revisited when instruction arrays are shared across bodies.
+  const arrays = instructionArrays(ctx.mod.functions.map((fn) => fn.body));
+  for (const array of arrays) {
+    const rewritten: Instr[] = [];
+    for (const instr of array) {
+      if (instr.op !== "call" && instr.op !== "return_call") {
+        rewritten.push(instr);
+        continue;
+      }
+      const name = targets.get(instr.funcIdx);
+      if (name === undefined) {
+        rewritten.push(instr);
+        continue;
+      }
+      const { valueGlobalIdx, readyGlobalIdx } = slotFor(instr.funcIdx, name);
+      const wasTailCall = instr.op === "return_call";
+      const resolverCall: Instr = { ...instr, op: "call" };
+      rewritten.push(
+        { op: "global.get", index: readyGlobalIdx },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          then: [{ op: "global.get", index: valueGlobalIdx }],
+          else: [
+            resolverCall,
+            { op: "global.set", index: valueGlobalIdx },
+            { op: "i32.const", value: 1 },
+            { op: "global.set", index: readyGlobalIdx },
+            { op: "global.get", index: valueGlobalIdx },
+          ],
+        },
+      );
+      if (wasTailCall) rewritten.push({ op: "return" });
+    }
+    array.splice(0, array.length, ...rewritten);
+  }
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -14,7 +14,7 @@ import { fillNativeConstructDrivers, maxReservedNativeConstructArity } from "./n
 import { fillConstructBoundDriver } from "./construct-bound.js"; // (#4196)
 import { emitVecDefineWritebackExports } from "./vec-define-writeback.js"; // (#3116)
 import { detectArrayReduceFusion } from "./array-reduce-fusion.js";
-import { hoistConstantBoxedNumbers } from "./const-box-hoist.js"; // (#4157)
+import { finalizeModuleValueCaches } from "./module-value-caches.js"; // (#4150/#4157)
 import type { MultiTypedAST, TypedAST } from "../checker/index.js";
 import type { TypeFact, TypeOracle } from "../checker/oracle.js";
 import {
@@ -4675,9 +4675,9 @@ export function generateModule(
     // index freeze. No-op unless a gc/host delete-aware read recorded the flag.
     finalizeInModuleInitFlag(ctx);
 
-    // (#4157) Constant number boxes → module globals. Placement contract (why
-    // exactly here) is in const-box-hoist.ts's own doc comment.
-    hoistConstantBoxedNumbers(ctx);
+    // (#4150/#4157) Finalize ambient-global and constant-box caches after every
+    // import global settles. Each pass documents its exact placement contract.
+    finalizeModuleValueCaches(ctx);
 
     // (#2853) Nominal shape branding: structurally-colliding `__anon_*` /
     // `__fnctor_*` shape types get a trailing brand-ref field so the engine's
@@ -6926,8 +6926,8 @@ export function generateMultiModule(
     // index freeze. No-op unless a gc/host delete-aware read recorded the flag.
     finalizeInModuleInitFlag(ctx);
 
-    // (#4157) Same pass + placement as the single-module pipeline.
-    hoistConstantBoxedNumbers(ctx);
+    // (#4150/#4157) Same module-value caches as the single-module pipeline.
+    finalizeModuleValueCaches(ctx);
 
     // (#2853) Nominal shape branding — same pass + placement as the
     // single-module pipeline (see generateModule): after all instruction

--- a/src/codegen/module-value-caches.ts
+++ b/src/codegen/module-value-caches.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Finalize module-level caches after import-global indices have settled. */
+
+import type { CodegenContext } from "./context/types.js";
+import { hoistConstantBoxedNumbers } from "./const-box-hoist.js";
+import { cacheDeclaredGlobalReads } from "./declared-global-cache.js";
+
+export function finalizeModuleValueCaches(ctx: CodegenContext): void {
+  cacheDeclaredGlobalReads(ctx);
+  hoistConstantBoxedNumbers(ctx);
+}

--- a/tests/issue-4150-declared-global-cache.test.ts
+++ b/tests/issue-4150-declared-global-cache.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4150 P4 — ambient globals such as `document` are resolved by a zero-arg
+// host import. The runtime binds that import to one value for the lifetime of
+// the instance, so repeated reads must reuse a module-global cache instead of
+// crossing the Wasm/JS boundary on every loop iteration.
+
+import { describe, expect, it } from "vitest";
+import { buildImports, compile, compileMulti, instantiateWasm } from "../src/index.js";
+
+const SOURCE = `
+declare class Document {
+  createElement(tag: string): Element;
+}
+declare class Element {
+  setAttribute(name: string, value: string): void;
+}
+declare const document: Document;
+
+export function create(count: number): number {
+  for (let i = 0; i < count; i++) {
+    const el = document.createElement("div");
+    el.setAttribute("id", "test");
+  }
+  return count;
+}
+
+export function identity(): Document {
+  return document;
+}
+`;
+
+class MockElement {
+  setAttribute(_name: string, _value: string): void {}
+}
+
+class MockDocument {
+  createElement(_tag: string): MockElement {
+    return new MockElement();
+  }
+}
+
+async function instanceWithResolver(
+  experimentalIR: boolean,
+  value: MockDocument | null,
+  resolve: (value: MockDocument | null) => MockDocument | null,
+  multi = false,
+) {
+  const result = multi
+    ? await compileMulti({ "t.ts": SOURCE }, "t.ts", { experimentalIR, emitWat: true, optimize: 0 })
+    : await compile(SOURCE, { fileName: "t.ts", experimentalIR, emitWat: true, optimize: 0 });
+  expect(result.success, result.success ? undefined : result.errors[0]?.message).toBe(true);
+  const imports = buildImports(
+    result.imports,
+    { document: value, Document: MockDocument, Element: MockElement },
+    result.stringPool,
+  );
+  let resolutions = 0;
+  imports.env.global_document = () => {
+    resolutions++;
+    return resolve(value);
+  };
+  const { instance } = await instantiateWasm(result.binary, imports.env, imports.string_constants);
+  imports.setInstance?.(instance);
+  return {
+    exports: instance.exports as unknown as {
+      create(count: number): number;
+      identity(): MockDocument | null;
+    },
+    result,
+    resolutions: () => resolutions,
+  };
+}
+
+describe("#4150 — declared-global module cache", () => {
+  it.each([false, true])("resolves document once across loops and exports (IR=%s)", async (experimentalIR) => {
+    const document = new MockDocument();
+    const probe = await instanceWithResolver(experimentalIR, document, (value) => value);
+
+    expect(probe.exports.create(8)).toBe(8);
+    expect(probe.exports.identity()).toBe(document);
+    expect(probe.exports.create(3)).toBe(3);
+    expect(probe.resolutions()).toBe(1);
+    expect(probe.result.wat).toContain("$__declared_global_document");
+    expect(probe.result.wat).toContain("$__declared_global_document_ready");
+  });
+
+  it("caches null using the ready bit instead of treating it as a miss", async () => {
+    const probe = await instanceWithResolver(true, null, (value) => value);
+
+    expect(probe.exports.identity()).toBeNull();
+    expect(probe.exports.identity()).toBeNull();
+    expect(probe.resolutions()).toBe(1);
+  });
+
+  it("applies the same module-wide cache to compileMulti", async () => {
+    const document = new MockDocument();
+    const probe = await instanceWithResolver(true, document, (value) => value, true);
+
+    expect(probe.exports.create(5)).toBe(5);
+    expect(probe.exports.identity()).toBe(document);
+    expect(probe.resolutions()).toBe(1);
+  });
+
+  it("retries after a resolver exception and caches only a successful result", async () => {
+    const document = new MockDocument();
+    let fail = true;
+    const probe = await instanceWithResolver(true, document, (value) => {
+      if (fail) {
+        fail = false;
+        throw new Error("resolver probe");
+      }
+      return value;
+    });
+
+    expect(() => probe.exports.identity()).toThrow("resolver probe");
+    expect(probe.resolutions()).toBe(1);
+    expect(probe.exports.identity()).toBe(document);
+    expect(probe.exports.identity()).toBe(document);
+    expect(probe.resolutions()).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- cache each live `declared_global` resolver result in a lazy, per-instance Wasm module global
- apply the same finalization pass after legacy or IR lowering, for single- and multi-source compiles
- preserve the existing import ABI, valid `null`/`undefined` results, and retry behavior after resolver exceptions

Relates to #4150 P4. This is independent of the primitive-string and zero-formal argument work in #4272.

## Root cause

Ambient identifiers such as `document` lower to `env.global_document: () -> externref`. `buildImports` resolves that value once and closes over it, but generated Wasm called the zero-argument closure on every identifier read.

The exact `dom/set-attributes` WAT performs seven imports per loop iteration: `global_document`, `Document_createElement`, and five `Element_setAttribute` calls. Wasmtime's CLIF consequently contains seven indirect-call sites, while TurboFan inlines the mock `Document`/`Element` layers used by the JS control. The new cache leaves the resolver call only in a first-use miss arm; subsequent reads are Wasm global loads.

The cache uses a separate i32 ready bit because both `null` and `undefined` are valid externref values. It sets that bit only after a successful resolver return, so an exception leaves the cache uninitialized and a later read retries.

## Benchmark

Harness:

```text
pnpm exec tsx --experimental-wasm-stringref --experimental-wasm-custom-descriptors \
  benchmarks/run.ts --suite dom --strategy js,host-call
```

- lane: `host-call` with the same-run `js` control
- host: Node v24.4.1, macOS/darwin arm64
- base: `dda0d1dc72f4a701b98c09f74f1edd2573985d26`
- candidate: `9b2c03fad7e8ec5f530ddd8dd0542197521fbcb2`
- sampling: eight alternating fresh-process A/B pairs; values below are medians of the eight process medians
- denominator: nanoseconds per benchmark operation (`ns/op`)

| Benchmark | Base host-call | Candidate host-call | Reduction |
| --- | ---: | ---: | ---: |
| `dom/create-elements` | 38.90 ns/op | 32.10 ns/op | 17.5% |
| `dom/set-attributes` | 26.40 ns/op | 22.61 ns/op | 14.3% |
| `dom/read-attributes` | 35.63 ns/op | 26.87 ns/op | 24.6% |
| `dom/modify-text` | 48.92 ns/op | 41.67 ns/op | 14.8% |

Same-run JS control medians were 21.36 -> 16.20, 15.81 -> 13.96, 12.04 -> 13.04, and 13.59 -> 12.99 ns/op respectively. The alternating order balances the changing runner conditions rather than deriving a single-run ratio from the bimodal V8 DOM control.

Positive controls:

- all 16 benchmark processes completed the harness's JS/Wasm `checkSameResult` check
- `dom/read-attributes` still returns the expected 1000
- focused instrumentation observes exactly one `global_document` resolution across loops and exports for each module instance

The optimized `dom/set-attributes` probe grows from 497 to 524 bytes (+27 bytes) for the cache globals and miss arm.

## Validation

- 21 focused DOM / host-global tests
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:ir-optimization-retirement`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- Prettier, Biome, `git diff --check`, oracle/coercion ratchets, and pre-push hooks

The focused proof covers legacy and IR lowering, `call` and `return_call`, single and multi-source compilation, cached `null`, and retry after a resolver exception.
