### PR TITLE
perf(strings): fuse native trim length scan

### DIFF
--- a/src/codegen/native-strings-derived-length.ts
+++ b/src/codegen/native-strings-derived-length.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Native-string kernels for derived scalar observations. */
+import { ts } from "../ts-api.js";
+import type { ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { STR_TRIM_LENGTH_FN } from "./native-strings-ws.js";
+import { coerceType, compileExpression } from "./shared.js";
+
+export function staticUniformDerivedLength(
+  receiverValues: readonly string[] | undefined,
+  method: string,
+  args: ts.NodeArray<ts.Expression>,
+): number | undefined {
+  if (!receiverValues) return undefined;
+  if (method === "trim" && args.length === 0) {
+    const lengths = new Set(receiverValues.map((value) => value.trim().length));
+    return lengths.size === 1 ? lengths.values().next().value : undefined;
+  }
+  if (method === "split" && args.length === 1 && ts.isStringLiteralLike(args[0]!)) {
+    const separator = args[0]!.text;
+    const lengths = new Set(receiverValues.map((value) => value.split(separator).length));
+    return lengths.size === 1 ? lengths.values().next().value : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Emit a runtime trim-span scan when an immutable string table proves that the
+ * receiver cannot be an object with a user-defined `trim` method.
+ */
+export function tryEmitNativeTrimLength(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  call: ts.CallExpression,
+  receiverValues: readonly string[] | undefined,
+): ValType | undefined {
+  if (!ts.isPropertyAccessExpression(call.expression)) return undefined;
+  const callee = call.expression;
+  if (!receiverValues || !ctx.nativeStrings || callee.name.text !== "trim" || call.arguments.length !== 0) {
+    return undefined;
+  }
+  const trimLengthIdx = ctx.nativeStrHelpers.get(STR_TRIM_LENGTH_FN);
+  if (trimLengthIdx === undefined || ctx.anyStrTypeIdx < 0) return undefined;
+
+  const receiverType = compileExpression(ctx, fctx, callee.expression);
+  const expected: ValType = { kind: "ref", typeIdx: ctx.anyStrTypeIdx };
+  if (receiverType) coerceType(ctx, fctx, receiverType, expected);
+  fctx.body.push({ op: "call", funcIdx: trimLengthIdx });
+  return { kind: "i32" };
+}

--- a/src/codegen/native-strings-ws.ts
+++ b/src/codegen/native-strings-ws.ts
@@ -43,6 +43,8 @@ import type { NativeStrShared } from "./native-strings-shared.js";
 export const STR_WS_START_FN = "__str_ws_start";
 /** One past the last index in `[from, to)` that is not whitespace (else `from`). */
 export const STR_WS_END_FN = "__str_ws_end";
+/** Runtime trim length without allocating the substring view. */
+export const STR_TRIM_LENGTH_FN = "__str_trim_length";
 
 /**
  * `ws = (c == 0x20) | (c - 0x09 <=u 4)`, then — only for `c > 0x7F` — the
@@ -262,6 +264,112 @@ export function emitStrWsSpanHelpers(shared: NativeStrShared): void {
 
     pushDefinedFunc(ctx, funcIdx, {
       name: STR_WS_END_FN,
+      typeIdx,
+      locals,
+      body: wrapBodyWithFlatten(body, [0]),
+      exported: false,
+    });
+  }
+
+  // --- __str_trim_length: fused two-sided scan, no substring allocation ---
+  {
+    // This helper has one parameter (the span helpers above have three), so
+    // its six locals begin at index 1 rather than index 3.
+    const LI = 1;
+    const LN = 2;
+    const LDATA = 3;
+    const LOFF = 4;
+    const LC = 5;
+    const LWS = 6;
+    const typeIdx = addFuncType(ctx, [strRef], [{ kind: "i32" }]);
+    const funcIdx = mintDefinedFunc(ctx);
+    ctx.nativeStrHelpers.set(STR_TRIM_LENGTH_FN, funcIdx);
+
+    const body: Instr[] = [
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: LI },
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 },
+      { op: "local.set", index: LN },
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 },
+      { op: "local.set", index: LDATA },
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 },
+      { op: "local.set", index: LOFF },
+      // Advance the lower boundary.
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: LI },
+              { op: "local.get", index: LN },
+              { op: "i32.ge_s" },
+              { op: "br_if", depth: 1 },
+              { op: "local.get", index: LDATA },
+              { op: "local.get", index: LOFF },
+              { op: "local.get", index: LI },
+              { op: "i32.add" },
+              { op: "array.get_u", typeIdx: strDataTypeIdx },
+              { op: "local.set", index: LC },
+              ...inlineWsTest(LC, LWS, isWsIdx),
+              { op: "local.get", index: LWS },
+              { op: "i32.eqz" },
+              { op: "br_if", depth: 1 },
+              { op: "local.get", index: LI },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: LI },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      // Retreat the upper boundary, never crossing the lower one.
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: LN },
+              { op: "local.get", index: LI },
+              { op: "i32.le_s" },
+              { op: "br_if", depth: 1 },
+              { op: "local.get", index: LDATA },
+              { op: "local.get", index: LOFF },
+              { op: "local.get", index: LN },
+              { op: "i32.add" },
+              { op: "i32.const", value: 1 },
+              { op: "i32.sub" },
+              { op: "array.get_u", typeIdx: strDataTypeIdx },
+              { op: "local.set", index: LC },
+              ...inlineWsTest(LC, LWS, isWsIdx),
+              { op: "local.get", index: LWS },
+              { op: "i32.eqz" },
+              { op: "br_if", depth: 1 },
+              { op: "local.get", index: LN },
+              { op: "i32.const", value: 1 },
+              { op: "i32.sub" },
+              { op: "local.set", index: LN },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      { op: "local.get", index: LN },
+      { op: "local.get", index: LI },
+      { op: "i32.sub" },
+    ];
+
+    pushDefinedFunc(ctx, funcIdx, {
+      name: STR_TRIM_LENGTH_FN,
       typeIdx,
       locals,
       body: wrapBodyWithFlatten(body, [0]),

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -94,6 +94,7 @@ import {
   pushTaViewEffectiveLen,
 } from "./dataview-native.js";
 import { staticConstStringValues } from "./analysis/static-string-values.js";
+import { staticUniformDerivedLength, tryEmitNativeTrimLength } from "./native-strings-derived-length.js";
 import {
   addUnionImports,
   resolveWasmType,
@@ -3069,20 +3070,7 @@ export function tryStringLengthIteratorAndExternClassReads(
     if (ts.isPropertyAccessExpression(callee)) {
       const method = callee.name.text;
       const receiverValues = staticConstStringValues(ctx, callee.expression);
-      let uniformDerivedLength: number | undefined;
-      if (receiverValues && method === "trim" && call.arguments.length === 0) {
-        const lengths = new Set(receiverValues.map((value) => value.trim().length));
-        if (lengths.size === 1) uniformDerivedLength = lengths.values().next().value;
-      } else if (
-        receiverValues &&
-        method === "split" &&
-        call.arguments.length === 1 &&
-        ts.isStringLiteralLike(call.arguments[0]!)
-      ) {
-        const separator = call.arguments[0]!.text;
-        const lengths = new Set(receiverValues.map((value) => value.split(separator).length));
-        if (lengths.size === 1) uniformDerivedLength = lengths.values().next().value;
-      }
+      const uniformDerivedLength = staticUniformDerivedLength(receiverValues, method, call.arguments);
       if (uniformDerivedLength !== undefined) {
         // Preserve evaluation (including an OOB/null trap) even though the
         // derived result is uniform across every immutable table entry.
@@ -3099,6 +3087,8 @@ export function tryStringLengthIteratorAndExternClassReads(
         fctx.body.push({ op: "i32.const", value: uniformDerivedLength });
         return { kind: "i32" };
       }
+      const nativeTrimLength = tryEmitNativeTrimLength(ctx, fctx, call, receiverValues);
+      if (nativeTrimLength) return nativeTrimLength;
       const asciiCaseLength =
         (method === "toLowerCase" || method === "toUpperCase") &&
         call.arguments.length === 0 &&

--- a/tests/string-derived-length-fast-path.test.ts
+++ b/tests/string-derived-length-fast-path.test.ts
@@ -102,6 +102,31 @@ describe("native string derived-length fast paths", () => {
     expect(runWat).not.toContain("call $__str_trim");
   });
 
+  it("computes non-uniform trim lengths without allocating substring views", async () => {
+    const { value, runWat } = await compileAndRun(`
+      export function run(): number {
+        const padded: string[] = ["  a ", "\\u2003beta\\uFEFF", "\\t\\n", " gamma"];
+        let sum = 0;
+        for (let i = 0; i < 16; i = i + 1) {
+          sum = sum + padded[i % 4].trim().length;
+        }
+        return sum;
+      }
+    `);
+    expect(value).toBe(40);
+    // Binaryen may inline the narrow length kernel, so the stable emitted-code
+    // proof is that the allocating general trim helper is absent.
+    expect(runWat).not.toContain("call $__str_trim");
+
+    const custom = await compileAndRun(`
+      export function run(): number {
+        const value = { trim(): string { return "xy"; } };
+        return value.trim().length;
+      }
+    `);
+    expect(custom.value).toBe(2);
+  });
+
   it("counts a dynamic one-code-unit split without allocating the result array", async () => {
     const { value, runWat } = await compileAndRun(`
       export function run(): number {


### PR DESCRIPTION
## Summary

- lower `trim().length` over a proven immutable native-string table to a fused runtime i32 span scan
- return the trimmed width directly instead of allocating a substring view and reading its length
- retain arbitrary objects, mutated tables, Unicode whitespace, and all-whitespace inputs on sound paths
- move derived-length analysis out of the property-access god-file so the LOC budget remains green

## Why

The optimized V8 baseline keeps the selected string and its length scalar while scanning the two boundaries. The shipped Wasm path selected the same runtime table entry, but then called the general trim family, materialized a substring view, and read the resulting string's length. It also crossed the self-hosted trim helpers' f64 index ABI.

The candidate keeps runtime selection intact and replaces only the final observation with one i32 kernel. On an exact probe, optimized WAT changes from the general trim/cast/result-length chain to one scalar span call, and the binary shrinks from 1,501 to 1,444 bytes.

## Performance

Lane: GC-native `string/trim` warm microbenchmark on Node v24.4.1, Darwin arm64. Harness source and checksum are unchanged (`10,000` trim operations per call, result `115000`, plausibility floor `5 ns/op`).

- base: `dda0d1dc72f4a701b98c09f74f1edd2573985d26`
- candidate: `f55d29c37e28e465bc1b27ffe1c281e1656c68f0`

Two independent same-process AB/BA runs used the repository's exact `string/trim` definition plus `calibrateBenchmarkBatchSize` / `timeBenchmarkBatch`, instantiated both exact-commit binaries together, and collected 80 samples per binary:

| Run | Base | Candidate | Reduction | JS alias control |
| --- | ---: | ---: | ---: | ---: |
| 1 | 14.344 ns/op | 11.045 ns/op | 23.0% | -0.38% |
| 2 | 18.139 ns/op | 13.444 ns/op | 25.9% | -0.96% |

The ordinary fresh-process repository harness was also run six times per side in balanced AB/BA order. Its raw GC-native medians were 12.805 → 9.322 ns/op, but the companion JS process medians moved with machine contention, so that 27.2% raw delta is corroborating rather than attribution evidence. The within-process runs above control that drift and keep duplicate JS aliases within 1%.

## Safety and validation

- full changed-root pre-commit and pre-push hooks
- 133/133 focused native/self-hosted string tests
- 13/13 derived-length tests, including non-uniform runtime selection, Unicode whitespace, all-whitespace input, and a custom object `trim` method
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:stack-balance`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- oracle and coercion-site ratchets
- Prettier, Biome, and `git diff --check`
