### PR TITLE
perf(strings): avoid integer format scratch allocation

### DIFF
--- a/src/codegen/number-format-native.ts
+++ b/src/codegen/number-format-native.ts
@@ -484,32 +484,21 @@ function emitToString(
   const L_NEG = 4;
   const L_ABS = 5;
 
-  const finalizeReturn = (): Instr[] => [
-    { op: "local.get", index: L_BUF },
-    { op: "local.get", index: L_POS },
-    { op: "call", funcIdx: finalizeIdx },
-    { op: "return" },
-  ];
+  // Integer formatting is the overwhelmingly common ToString path in loops
+  // (array indices, counters, template substitutions).  The shared non-finite
+  // prologue allocates a 256-code-unit Ryū scratch buffer, but safe integers
+  // immediately delegate to the radix-10 formatter and never read that buffer.
+  // Test the integer regime first so those calls avoid the dead allocation.
+  // Keep an emission kill switch for exact A/B attribution and emergency
+  // rollback; disabled output retains the former post-prologue guard.
+  const integerBeforeScratch = process.env.JS2WASM_NUMBER_TO_STRING_INTEGER_FASTPATH !== "0";
 
-  const body: Instr[] = [
-    ...emitNonFinitePrologue(ctx, finalizeIdx, strDataTypeIdx, L_VALUE, L_BUF, L_POS, L_TMP, L_NEG, L_ABS),
-
-    // NOTE (#1537): the §6.1.6.1.20 exponential-notation regime is NOT special-
-    // cased here. The shortest-roundtrip Ryū formatter below (`__num_ryu_to_buf`)
-    // implements the full §6.1.6.1.13 framing and already chooses fixed vs
-    // `d.dddde±N` by the decimal-point position `n` (exponential when n > 21 or
-    // n <= -6), producing V8-exact output for `1e21`→"1e+21", `1e-7`→"1e-7",
-    // `5e-324`, and Number.MAX_VALUE alike. The earlier #1836 magnitude-threshold
-    // gate routed those through a fixed 15-significant-digit `emitExponential`,
-    // which truncated the shortest representation (e.g. MAX_VALUE →
-    // "1.79769313486232e+308"); Ryū supersedes it.
-
-    // Safe integers can reuse the radix-10 formatter exactly.
-    { op: "local.get", index: L_ABS },
-    { op: "local.get", index: L_ABS },
+  const safeIntegerReturn = (integerValue: Instr[], magnitude: Instr[]): Instr[] => [
+    ...integerValue,
+    ...integerValue,
     { op: "f64.floor" },
     { op: "f64.eq" },
-    { op: "local.get", index: L_ABS },
+    ...magnitude,
     { op: "f64.const", value: MAX_SAFE_INTEGER },
     { op: "f64.le" },
     { op: "i32.and" },
@@ -523,6 +512,39 @@ function emitToString(
         { op: "return" },
       ],
     },
+  ];
+
+  const preScratchIntegerReturn = (): Instr[] =>
+    safeIntegerReturn([{ op: "local.get", index: L_VALUE }], [{ op: "local.get", index: L_VALUE }, { op: "f64.abs" }]);
+
+  const postScratchIntegerReturn = (): Instr[] =>
+    safeIntegerReturn([{ op: "local.get", index: L_ABS }], [{ op: "local.get", index: L_ABS }]);
+
+  const finalizeReturn = (): Instr[] => [
+    { op: "local.get", index: L_BUF },
+    { op: "local.get", index: L_POS },
+    { op: "call", funcIdx: finalizeIdx },
+    { op: "return" },
+  ];
+
+  const body: Instr[] = [
+    ...(integerBeforeScratch ? preScratchIntegerReturn() : []),
+    ...emitNonFinitePrologue(ctx, finalizeIdx, strDataTypeIdx, L_VALUE, L_BUF, L_POS, L_TMP, L_NEG, L_ABS),
+
+    // NOTE (#1537): the §6.1.6.1.20 exponential-notation regime is NOT special-
+    // cased here. The shortest-roundtrip Ryū formatter below (`__num_ryu_to_buf`)
+    // implements the full §6.1.6.1.13 framing and already chooses fixed vs
+    // `d.dddde±N` by the decimal-point position `n` (exponential when n > 21 or
+    // n <= -6), producing V8-exact output for `1e21`→"1e+21", `1e-7`→"1e-7",
+    // `5e-324`, and Number.MAX_VALUE alike. The earlier #1836 magnitude-threshold
+    // gate routed those through a fixed 15-significant-digit `emitExponential`,
+    // which truncated the shortest representation (e.g. MAX_VALUE →
+    // "1.79769313486232e+308"); Ryū supersedes it.
+
+    // Safe integers can reuse the radix-10 formatter exactly. With the fast
+    // path enabled this branch already returned before scratch allocation; the
+    // disabled form is deliberately the former byte-for-byte position/shape.
+    ...(integerBeforeScratch ? [] : postScratchIntegerReturn()),
 
     // Fractional / unsafe-magnitude branch: shortest-roundtrip Ryū (#1537).
     // `__num_ryu_to_buf(abs, neg, buf, pos)` writes the §6.1.6.1.13-formatted

--- a/tests/native-number-string-integer-fastpath.test.ts
+++ b/tests/native-number-string-integer-fastpath.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Native Number::toString integer fast path.
+ *
+ * Safe integers delegate to the radix-10 formatter. They must do so before the
+ * generic Ryū path allocates its 256-code-unit scratch buffer; the scratch is
+ * otherwise dead for the dominant counter/index formatting regime.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const ENV_NAME = "JS2WASM_NUMBER_TO_STRING_INTEGER_FASTPATH";
+const originalEnv = process.env[ENV_NAME];
+
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env[ENV_NAME];
+  else process.env[ENV_NAME] = originalEnv;
+});
+
+async function numberToStringWat(disabled: boolean): Promise<string> {
+  if (disabled) process.env[ENV_NAME] = "0";
+  else delete process.env[ENV_NAME];
+  const result = await compile(
+    `export function run(value: number): number {
+       return value.toString().length;
+     }`,
+    {
+      fileName: disabled ? "number-string-control.ts" : "number-string-fast.ts",
+      target: "standalone",
+      optimize: 4,
+      emitWat: true,
+      emitWatOnlyFunctions: ["number_toString"],
+    },
+  );
+  expect(result.success, result.success ? "" : String(result.errors?.[0]?.message)).toBe(true);
+  return result.wat ?? "";
+}
+
+describe("native Number::toString integer fast path", () => {
+  it("returns safe integers before allocating the Ryū scratch buffer", async () => {
+    const wat = await numberToStringWat(false);
+    const integerCheck = wat.indexOf("f64.floor");
+    const scratchAllocation = wat.indexOf("array.new_default");
+    expect(integerCheck).toBeGreaterThanOrEqual(0);
+    expect(scratchAllocation).toBeGreaterThan(integerCheck);
+  });
+
+  it("keeps a kill switch that restores the allocation-before-check control", async () => {
+    const wat = await numberToStringWat(true);
+    const integerCheck = wat.indexOf("f64.floor");
+    const scratchAllocation = wat.indexOf("array.new_default");
+    expect(scratchAllocation).toBeGreaterThanOrEqual(0);
+    expect(integerCheck).toBeGreaterThan(scratchAllocation);
+  });
+});


### PR DESCRIPTION
## Summary

- check the safe-integer `Number::toString` regime before allocating the generic Ryū scratch buffer
- delegate integer counters and indices directly to the existing radix-10 formatter
- keep `JS2WASM_NUMBER_TO_STRING_INTEGER_FASTPATH=0` as an exact emission kill switch
- add WAT-level coverage for both the optimized and control instruction order

## Why

`number_toString` allocated a 256-code-unit scratch array before testing whether its input was a safe integer. Safe integers immediately returned through `number_toString_radix`, so that allocation was always dead for the common counter/index formatting path. This is visible in the landed clsx runtime-dynamic profile, where number formatting accounts for about 23% of Wasm self-time.

The new guard is semantics-preserving for `NaN`, infinities, fractions, unsafe integers, and `-0`: values outside the safe-integer regime still enter the unchanged non-finite/Ryū path.

## Performance

Base: `a7f429e8d8d97aa07ec28448fe5097dc8a8a70b8`  
Candidate: `3d54ffc66abd46e103c39bf466c5d57c1d060f4a`

Focused standalone `optimize: 4` A/B probe: 100,000 runtime-supplied safe integers are converted with `.toString().length`; 21 measured samples after 10 warmups, checksum `497496`. The control is the candidate compiled with the kill switch, whose 16,003-byte binary is byte-identical to origin/main (`sha256 0fe60ac75ae0e4255c637275faf3e1412772d4222cfcfd6808d4f46eb7e72c56`).

| Order | Control median | Candidate median | Reduction | Unchanged arithmetic control |
| --- | ---: | ---: | ---: | ---: |
| control → candidate | 9.780 ms | 7.787 ms | 20.4% | candidate 5.0% faster |
| candidate → control | 6.030 ms | 3.854 ms | 36.1% | candidate 29.1% slower |

The positive-control movement shows the machine was noisy, but it cannot explain the win: in reverse order the candidate's unchanged control was materially slower while integer formatting was still 36% faster. Two earlier sequential AB/BA pairs showed 1.43× and 1.62× focused speedups. The real pinned clsx standalone runtime-dynamic workload also moved from 46.129 ms to 41.377 ms in an interleaved same-process run (~10.3%); that is corroborating evidence only because its duplicate Node controls were noisy.

Binary size for the focused probe changes from 16,003 to 16,004 bytes.

## Validation

- `pnpm exec vitest run tests/native-number-string-integer-fastpath.test.ts --maxWorkers=1`
- `pnpm exec vitest run tests/issue-1537.test.ts --maxWorkers=1` (33 tests, including the 30k-value V8 differential sweep)
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:stack-balance`
- LOC and function budget gates
- oracle and coercion-site ratchets
- pre-commit and pre-push hooks

The full test suite was not run locally.
