### PR TITLE
perf(array): accelerate hot indexOf scans

### DIFF
--- a/src/codegen/analysis/static-numeric-range.ts
+++ b/src/codegen/analysis/static-numeric-range.ts
@@ -1,6 +1,11 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 import { ts } from "../../ts-api.js";
-import type { CodegenContext } from "../context/types.js";
+import type { TypeOracle } from "../../checker/oracle.js";
+import { loopBodyMutatesIndexOrArray } from "../statements/loop-analysis.js";
+
+export interface StaticIntegerRangeContext {
+  readonly oracle: Pick<TypeOracle, "variableDeclarationOf">;
+}
 
 export interface StaticIntegerRange {
   readonly min: number;
@@ -8,14 +13,17 @@ export interface StaticIntegerRange {
 }
 
 /** Conservative integer range proof for literals and canonical counted loops. */
-export function staticIntegerRange(ctx: CodegenContext, expression: ts.Expression): StaticIntegerRange | undefined {
+export function staticIntegerRange(
+  ctx: StaticIntegerRangeContext,
+  expression: ts.Expression,
+): StaticIntegerRange | undefined {
   return staticIntegerRangeInner(ctx, expression, new Set());
 }
 
 function staticIntegerRangeInner(
-  ctx: CodegenContext,
+  ctx: StaticIntegerRangeContext,
   expression: ts.Expression,
-  visiting: Set<ts.Symbol>,
+  visiting: Set<ts.VariableDeclaration>,
 ): StaticIntegerRange | undefined {
   let current = expression;
   while (
@@ -35,16 +43,16 @@ function staticIntegerRangeInner(
     return inner ? { min: -inner.max, max: -inner.min } : undefined;
   }
   if (ts.isIdentifier(current)) {
-    const symbol = ctx.checker.getSymbolAtLocation(current);
-    if (!symbol || visiting.has(symbol)) return undefined;
-    visiting.add(symbol);
+    const declaration = ctx.oracle.variableDeclarationOf(current);
+    if (!declaration || visiting.has(declaration)) return undefined;
+    visiting.add(declaration);
     try {
       return (
-        countedLoopIdentifierRange(ctx, current, symbol, visiting) ??
-        constIdentifierRange(ctx, current, symbol, visiting)
+        countedLoopIdentifierRange(ctx, current, declaration, visiting) ??
+        constIdentifierRange(ctx, current, declaration, visiting)
       );
     } finally {
-      visiting.delete(symbol);
+      visiting.delete(declaration);
     }
   }
   if (!ts.isBinaryExpression(current)) return undefined;
@@ -82,13 +90,12 @@ function staticIntegerRangeInner(
 }
 
 function constIdentifierRange(
-  ctx: CodegenContext,
+  ctx: StaticIntegerRangeContext,
   identifier: ts.Identifier,
-  symbol: ts.Symbol,
-  visiting: Set<ts.Symbol>,
+  declaration: ts.VariableDeclaration,
+  visiting: Set<ts.VariableDeclaration>,
 ): StaticIntegerRange | undefined {
-  const declaration = symbol?.valueDeclaration;
-  if (!symbol || !declaration || !ts.isVariableDeclaration(declaration) || !declaration.initializer) return undefined;
+  if (!declaration.initializer) return undefined;
   if (!ts.isVariableDeclarationList(declaration.parent) || !(declaration.parent.flags & ts.NodeFlags.Const)) {
     return undefined;
   }
@@ -102,42 +109,50 @@ function constIdentifierRange(
 }
 
 function countedLoopIdentifierRange(
-  ctx: CodegenContext,
+  ctx: StaticIntegerRangeContext,
   identifier: ts.Identifier,
-  symbol: ts.Symbol,
-  visiting: Set<ts.Symbol>,
+  declaration: ts.VariableDeclaration,
+  visiting: Set<ts.VariableDeclaration>,
 ): StaticIntegerRange | undefined {
-  const declaration = symbol.valueDeclaration;
-  if (!declaration || !ts.isVariableDeclaration(declaration) || !declaration.initializer) return undefined;
+  if (!declaration.initializer) return undefined;
   const list = declaration.parent;
   const loop = ts.isVariableDeclarationList(list) && ts.isForStatement(list.parent) ? list.parent : undefined;
   if (!loop || loop.initializer !== list || !loop.condition || !loop.incrementor) return undefined;
   const start = staticIntegerRangeInner(ctx, declaration.initializer, visiting);
   if (!start || start.min !== start.max) return undefined;
   if (!ts.isBinaryExpression(loop.condition) || !ts.isIdentifier(loop.condition.left)) return undefined;
-  if (ctx.checker.getSymbolAtLocation(loop.condition.left) !== symbol) return undefined;
+  if (ctx.oracle.variableDeclarationOf(loop.condition.left) !== declaration) return undefined;
   const bound = staticIntegerRangeInner(ctx, loop.condition.right, visiting);
   if (!bound || bound.min !== bound.max) return undefined;
   let max: number;
   if (loop.condition.operatorToken.kind === ts.SyntaxKind.LessThanToken) max = bound.max - 1;
   else if (loop.condition.operatorToken.kind === ts.SyntaxKind.LessThanEqualsToken) max = bound.max;
   else return undefined;
-  if (!isIncreasingLoopIncrement(ctx, loop.incrementor, symbol)) return undefined;
+  if (!isIncreasingLoopIncrement(ctx, loop.incrementor, declaration)) return undefined;
+  // The loop header alone is not a range proof if the body can reassign the
+  // counter before a use. Passing an impossible array-binding name asks the
+  // shared mutation scan to check only the index (and conservatively rejects
+  // nested closures that could capture it).
+  if (loopBodyMutatesIndexOrArray(loop.statement, identifier.text, "")) return undefined;
   return start.min <= max ? { min: start.min, max } : undefined;
 }
 
-function isIncreasingLoopIncrement(ctx: CodegenContext, expression: ts.Expression, symbol: ts.Symbol): boolean {
+function isIncreasingLoopIncrement(
+  ctx: StaticIntegerRangeContext,
+  expression: ts.Expression,
+  declaration: ts.VariableDeclaration,
+): boolean {
   if (ts.isPostfixUnaryExpression(expression) || ts.isPrefixUnaryExpression(expression)) {
     return (
       expression.operator === ts.SyntaxKind.PlusPlusToken &&
       ts.isIdentifier(expression.operand) &&
-      ctx.checker.getSymbolAtLocation(expression.operand) === symbol
+      ctx.oracle.variableDeclarationOf(expression.operand) === declaration
     );
   }
   if (!ts.isBinaryExpression(expression) || !ts.isIdentifier(expression.left)) return false;
-  if (ctx.checker.getSymbolAtLocation(expression.left) !== symbol) return false;
+  if (ctx.oracle.variableDeclarationOf(expression.left) !== declaration) return false;
   if (expression.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken) {
-    const step = staticIntegerRangeInner(ctx, expression.right, new Set([symbol]));
+    const step = staticIntegerRangeInner(ctx, expression.right, new Set([declaration]));
     return step !== undefined && step.min === step.max && step.min > 0;
   }
   if (expression.operatorToken.kind !== ts.SyntaxKind.EqualsToken || !ts.isBinaryExpression(expression.right)) {
@@ -145,7 +160,7 @@ function isIncreasingLoopIncrement(ctx: CodegenContext, expression: ts.Expressio
   }
   const rhs = expression.right;
   if (rhs.operatorToken.kind !== ts.SyntaxKind.PlusToken || !ts.isIdentifier(rhs.left)) return false;
-  if (ctx.checker.getSymbolAtLocation(rhs.left) !== symbol) return false;
-  const step = staticIntegerRangeInner(ctx, rhs.right, new Set([symbol]));
+  if (ctx.oracle.variableDeclarationOf(rhs.left) !== declaration) return false;
+  const step = staticIntegerRangeInner(ctx, rhs.right, new Set([declaration]));
   return step !== undefined && step.min === step.max && step.min > 0;
 }

--- a/src/codegen/array-element-typing.ts
+++ b/src/codegen/array-element-typing.ts
@@ -22,6 +22,54 @@
  * that consume the value in a non-i32 context (#1126's existing pattern).
  */
 import { ts, forEachChild } from "../ts-api.js";
+import type { TypeOracle } from "../checker/oracle.js";
+import { staticIntegerRange } from "./analysis/static-numeric-range.js";
+
+/**
+ * A deliberately narrow range-backed extension to the structural Q-CANON
+ * matcher. Requiring every arithmetic subtree to stay non-negative and within
+ * signed i32 both makes its f64 result exact and rules out observable `-0`.
+ * This admits bounded counted-loop arithmetic such as
+ * `(i * 7919) % 10000` without reopening the overflow/saturation bug fixed by
+ * #2789.
+ */
+function isNonNegativeStaticI32Expression(expr: ts.Expression, oracle: TypeOracle, depth = 0): boolean {
+  if (depth > 32) return false;
+  let current = expr;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+  const range = staticIntegerRange({ oracle }, current);
+  if (
+    range === undefined ||
+    range.min < 0 ||
+    range.max > 0x7fffffff ||
+    Object.is(range.min, -0) ||
+    Object.is(range.max, -0)
+  ) {
+    return false;
+  }
+  if (ts.isNumericLiteral(current) || ts.isIdentifier(current)) return true;
+  if (!ts.isBinaryExpression(current)) return false;
+  const operator = current.operatorToken.kind;
+  if (
+    operator !== ts.SyntaxKind.PlusToken &&
+    operator !== ts.SyntaxKind.MinusToken &&
+    operator !== ts.SyntaxKind.AsteriskToken &&
+    operator !== ts.SyntaxKind.PercentToken
+  ) {
+    return false;
+  }
+  return (
+    isNonNegativeStaticI32Expression(current.left, oracle, depth + 1) &&
+    isNonNegativeStaticI32Expression(current.right, oracle, depth + 1)
+  );
+}
 
 /**
  * Return true if `expr` provably produces a **canonical** signed-32-bit integer
@@ -73,19 +121,22 @@ import { ts, forEachChild } from "../ts-api.js";
 export function isI32SafeExprForArray(
   expr: ts.Expression | undefined,
   i32Locals: ReadonlySet<string>,
+  oracle?: TypeOracle,
   depth = 0,
 ): boolean {
   if (!expr) return false;
   if (depth > 32) return false;
 
+  if (oracle && isNonNegativeStaticI32Expression(expr, oracle)) return true;
+
   if (ts.isParenthesizedExpression(expr)) {
-    return isI32SafeExprForArray(expr.expression, i32Locals, depth + 1);
+    return isI32SafeExprForArray(expr.expression, i32Locals, oracle, depth + 1);
   }
   if (ts.isAsExpression(expr) || ts.isNonNullExpression(expr)) {
-    return isI32SafeExprForArray(expr.expression, i32Locals, depth + 1);
+    return isI32SafeExprForArray(expr.expression, i32Locals, oracle, depth + 1);
   }
   if (ts.isTypeAssertionExpression(expr)) {
-    return isI32SafeExprForArray(expr.expression, i32Locals, depth + 1);
+    return isI32SafeExprForArray(expr.expression, i32Locals, oracle, depth + 1);
   }
 
   if (ts.isNumericLiteral(expr)) {
@@ -102,7 +153,7 @@ export function isI32SafeExprForArray(
     // `~x` always yields a canonical int32; unary `+x` is the identity on an
     // i32-safe operand. Both preserve the canonical-i32 invariant.
     if (op === ts.SyntaxKind.PlusToken || op === ts.SyntaxKind.TildeToken) {
-      return isI32SafeExprForArray(expr.operand, i32Locals, depth + 1);
+      return isI32SafeExprForArray(expr.operand, i32Locals, oracle, depth + 1);
     }
     // #2789: unary `-` can produce negative zero. i32 cannot represent `-0`
     // (it collapses to `+0`), so storing `-0` and then observing the sign of
@@ -114,7 +165,7 @@ export function isI32SafeExprForArray(
     // could hold 0) and `-(expr)` demote to the f64 array.
     if (op === ts.SyntaxKind.MinusToken) {
       if (!ts.isNumericLiteral(expr.operand)) return false;
-      if (!isI32SafeExprForArray(expr.operand, i32Locals, depth + 1)) return false;
+      if (!isI32SafeExprForArray(expr.operand, i32Locals, oracle, depth + 1)) return false;
       return Number(expr.operand.text.replace(/_/g, "")) !== 0;
     }
     return false;
@@ -263,6 +314,7 @@ function collectForCounterNames(decl: ts.FunctionLikeDeclaration): Set<string> {
 export function collectI32SpecializedArrays(
   decl: ts.FunctionLikeDeclaration,
   i32CoercedLocals: ReadonlySet<string>,
+  oracle?: TypeOracle,
 ): Set<string> {
   const result = new Set<string>();
   if (!decl.body || !ts.isBlock(decl.body)) return result;
@@ -356,7 +408,7 @@ export function collectI32SpecializedArrays(
       candidates.has(node.left.expression.text) &&
       !insideNested
     ) {
-      if (!isI32SafeExprForArray(node.right, i32Locals)) {
+      if (!isI32SafeExprForArray(node.right, i32Locals, oracle)) {
         disqualified.add(node.left.expression.text);
       }
     }
@@ -405,13 +457,24 @@ export function collectI32SpecializedArrays(
       const method = node.expression.name.text;
       if (method === "push") {
         for (const arg of node.arguments) {
-          if (ts.isSpreadElement(arg) || !isI32SafeExprForArray(arg, i32Locals)) {
+          if (ts.isSpreadElement(arg) || !isI32SafeExprForArray(arg, i32Locals, oracle)) {
             disqualified.add(arrName);
             break;
           }
         }
+      } else if (
+        method === "indexOf" &&
+        node.arguments.length >= 1 &&
+        node.arguments.length <= 2 &&
+        !ts.isSpreadElement(node.arguments[0]!) &&
+        isI32SafeExprForArray(node.arguments[0]!, i32Locals, oracle)
+      ) {
+        // Read-only and representation-transparent when the strict-equality
+        // search value is itself an exact signed int32. A fractional, `-0`, or
+        // out-of-range search value keeps the f64 backing so compiling the
+        // argument for an i32 element cannot change the match result.
       } else {
-        // .map / .filter / .reduce / .slice / .splice / .indexOf / .includes / etc.
+        // .map / .filter / .reduce / .slice / .splice / .includes / etc.
         // would require f64 element semantics or callback type inference. Skip
         // them all conservatively; future work can lift specific cases.
         disqualified.add(arrName);

--- a/src/codegen/array-indexof-scan.ts
+++ b/src/codegen/array-indexof-scan.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { ts } from "../ts-api.js";
+import type { Instr, ValType } from "../ir/types.js";
+import type { FunctionContext } from "./context/types.js";
+
+const HOT_COUNTED_PUSH_TRIP_COUNT = 1024;
+const HOT_NUMERIC_INDEX_OF_UNROLL = 32;
+
+interface CountedPushProof {
+  readonly tripCount: number;
+  readonly call: ts.CallExpression;
+  readonly arrayName: string;
+}
+
+interface IndexOfScan {
+  readonly fast: boolean;
+  readonly arrTypeIdx: number;
+  readonly dataLocal: number;
+  readonly indexLocal: number;
+  readonly effectiveLengthLocal: number;
+  readonly valueLocal: number;
+  readonly resultLocal: number;
+  readonly getOp: "array.get" | "array.get_s" | "array.get_u";
+  readonly equality: readonly Instr[];
+  readonly holeMap: readonly Instr[];
+  readonly unroll: number;
+}
+
+// This is code-selection metadata, not a semantic proof. Keeping it outside
+// FunctionContext avoids making every emitter subsystem depend on this one
+// benchmark-oriented heuristic, while WeakMap keeps its lifetime compile-local.
+const countedPushTripCounts = new WeakMap<FunctionContext, Map<string, number>>();
+
+export function registerCountedPushArray(fctx: FunctionContext, proof: CountedPushProof, vecTypeIdx: number): void {
+  (fctx.presizedArrayPushCalls ??= new Map()).set(proof.call, vecTypeIdx);
+  const counts = countedPushTripCounts.get(fctx) ?? new Map<string, number>();
+  counts.set(proof.arrayName, proof.tripCount);
+  countedPushTripCounts.set(fctx, counts);
+}
+
+/** Pick a wide scan only when its code growth is amortized by a proven hot fill. */
+export function countedPushIndexOfUnroll(
+  fctx: FunctionContext,
+  receiverName: string | undefined,
+  elemType: ValType,
+): number {
+  const numericElements = elemType.kind === "f64" || elemType.kind === "i32";
+  const tripCount = receiverName === undefined ? undefined : countedPushTripCounts.get(fctx)?.get(receiverName);
+  return numericElements && (tripCount ?? 0) >= HOT_COUNTED_PUSH_TRIP_COUNT ? HOT_NUMERIC_INDEX_OF_UNROLL : 1;
+}
+
+/** Emit a scalar scan or a wide main loop with a scalar tail. */
+export function emitArrayIndexOfScan(fctx: FunctionContext, scan: IndexOfScan): void {
+  const indexInstrs = (offset: number): Instr[] => {
+    const instrs: Instr[] = [{ op: "local.get", index: scan.indexLocal }];
+    if (offset > 0) instrs.push({ op: "i32.const", value: offset }, { op: "i32.add" });
+    return instrs;
+  };
+  const compareAtOffset = (offset: number, breakDepth: number): Instr[] => [
+    { op: "local.get", index: scan.dataLocal },
+    ...indexInstrs(offset),
+    { op: scan.getOp, typeIdx: scan.arrTypeIdx },
+    ...scan.holeMap,
+    { op: "local.get", index: scan.valueLocal },
+    ...scan.equality,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...indexInstrs(offset),
+        ...(scan.fast ? [] : ([{ op: "f64.convert_i32_s" }] as Instr[])),
+        { op: "local.set", index: scan.resultLocal },
+        { op: "br", depth: breakDepth },
+      ],
+    },
+  ];
+  const increment = (amount: number): Instr[] => [
+    { op: "local.get", index: scan.indexLocal },
+    { op: "i32.const", value: amount },
+    { op: "i32.add" },
+    { op: "local.set", index: scan.indexLocal },
+    { op: "br", depth: 0 },
+  ];
+  const scalarLoop: Instr[] = [
+    { op: "local.get", index: scan.indexLocal },
+    { op: "local.get", index: scan.effectiveLengthLocal },
+    { op: "i32.ge_s" },
+    { op: "br_if", depth: 1 },
+    ...compareAtOffset(0, 2),
+    ...increment(1),
+  ];
+  if (scan.unroll <= 1) {
+    fctx.body.push({
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [{ op: "loop", blockType: { kind: "empty" }, body: scalarLoop }],
+    });
+    return;
+  }
+
+  const wideLoop: Instr[] = [
+    { op: "local.get", index: scan.effectiveLengthLocal },
+    { op: "local.get", index: scan.indexLocal },
+    { op: "i32.sub" },
+    { op: "i32.const", value: scan.unroll },
+    { op: "i32.lt_s" },
+    { op: "br_if", depth: 1 },
+  ];
+  for (let offset = 0; offset < scan.unroll; offset++) {
+    wideLoop.push(...compareAtOffset(offset, 3));
+  }
+  wideLoop.push(...increment(scan.unroll));
+
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [{ op: "loop", blockType: { kind: "empty" }, body: wideLoop }],
+      },
+      { op: "loop", blockType: { kind: "empty" }, body: scalarLoop },
+    ],
+  });
+}

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -67,6 +67,7 @@ import { emitStableMergeSort } from "./merge-sort.js"; // (#3902) shared stable 
 import { coerceType, coercionInstrs, defaultValueInstrs, emitGuardedRefCast } from "./type-coercion.js";
 import { staticIntegerRange } from "./analysis/static-numeric-range.js";
 import { tryEmitStaticI32Expression } from "./i32-static-range-expr.js";
+import { countedPushIndexOfUnroll, emitArrayIndexOfScan } from "./array-indexof-scan.js";
 
 // (#3264) Array.prototype-borrow subsystem extracted to array-prototype-borrow.ts;
 // re-export the two public entries so existing importers keep resolving.
@@ -2742,54 +2743,25 @@ function compileArrayIndexOf(
     holeMap = holeToUndefinedInstrs(ctx, fctx);
   }
 
-  const loopBody: Instr[] = [
-    { op: "local.get", index: iTmp },
-    { op: "local.get", index: effLenTmp },
-    { op: "i32.ge_s" },
-    { op: "br_if", depth: 1 },
-
-    { op: "local.get", index: dataTmp },
-    { op: "local.get", index: iTmp },
-    { op: getOp, typeIdx: arrTypeIdx },
-    ...holeMap,
-    { op: "local.get", index: valTmp },
-    ...eqInstrs,
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: ctx.fast
-        ? [
-            { op: "local.get", index: iTmp },
-            { op: "local.set", index: resTmp },
-            { op: "br", depth: 2 }, // break out of block
-          ]
-        : [
-            { op: "local.get", index: iTmp },
-            { op: "f64.convert_i32_s" },
-            { op: "local.set", index: resTmp },
-            { op: "br", depth: 2 }, // break out of block
-          ],
-    },
-
-    { op: "local.get", index: iTmp },
-    { op: "i32.const", value: 1 },
-    { op: "i32.add" },
-    { op: "local.set", index: iTmp },
-    { op: "br", depth: 0 },
-  ];
-
-  fctx.body.push({
-    op: "block",
-    blockType: { kind: "empty" },
-    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody }],
+  emitArrayIndexOfScan(fctx, {
+    fast: ctx.fast,
+    arrTypeIdx,
+    dataLocal: dataTmp,
+    indexLocal: iTmp,
+    effectiveLengthLocal: effLenTmp,
+    valueLocal: valTmp,
+    resultLocal: resTmp,
+    getOp,
+    equality: eqInstrs,
+    holeMap,
+    unroll: countedPushIndexOfUnroll(
+      fctx,
+      ts.isIdentifier(propAccess.expression) ? propAccess.expression.text : undefined,
+      elemType,
+    ),
   });
-
   fctx.body.push({ op: "local.get", index: resTmp });
-
-  if (ctx.fast) {
-    return { kind: "i32" };
-  }
-  return { kind: "f64" };
+  return ctx.fast ? { kind: "i32" } : { kind: "f64" };
 }
 
 /**

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -365,7 +365,7 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
   // #1197: detect `number[]` locals whose element storage can lower to i32.
   // Depends on the i32 scalar set so that `arr[i] = sum` (where `sum` is i32)
   // counts as an i32-safe write.
-  const i32SpecializedArrays = collectI32SpecializedArrays(decl, i32CoercedLocals);
+  const i32SpecializedArrays = collectI32SpecializedArrays(decl, i32CoercedLocals, ctx.oracle);
 
   // #2152 — a named function declaration whose body references `this` may be
   // passed by reference as an array-HOF callback (e.g.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -92,7 +92,7 @@ import {
   isDefinePropertyReceiverLiteral,
 } from "./struct-accessor-closure.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2 read chokepoint / S3b stable-regime minting)
-
+import { registerCountedPushArray } from "./array-indexof-scan.js";
 /**
  * Check if a TS expression is "undefined-like" — OmittedExpression (array hole),
  * undefined keyword, identifier `undefined`, void expression, or any of the
@@ -3281,7 +3281,7 @@ export function compileTupleLiteral(
  */
 function detectCountedPushLoop(
   expr: ts.ArrayLiteralExpression,
-): { tripCount: number; call: ts.CallExpression } | undefined {
+): { tripCount: number; call: ts.CallExpression; arrayName: string } | undefined {
   // Walk up: ArrayLiteralExpression → VariableDeclaration → VariableDeclarationList → VariableStatement → Block/SourceFile
   const varDecl = expr.parent;
   if (!varDecl || !ts.isVariableDeclaration(varDecl) || !ts.isIdentifier(varDecl.name)) return undefined;
@@ -3369,7 +3369,7 @@ function detectCountedPushLoop(
   if (callExpr.expression.expression.text !== arrName) return undefined;
   if (callExpr.arguments.length !== 1) return undefined;
 
-  return { tripCount, call: callExpr };
+  return { tripCount, call: callExpr, arrayName: arrName };
 }
 
 /**
@@ -3711,7 +3711,7 @@ export function compileArrayLiteral(
       return null;
     }
     if (countedPush) {
-      (fctx.presizedArrayPushCalls ??= new Map()).set(countedPush.call, vecTypeIdx);
+      registerCountedPushArray(fctx, countedPush, vecTypeIdx);
     }
 
     if (fillBoundExpr !== null) {

--- a/tests/equivalence/issue-1197.test.ts
+++ b/tests/equivalence/issue-1197.test.ts
@@ -9,6 +9,7 @@
 // disqualification rules applies).
 import { describe, expect, it } from "vitest";
 import { compile } from "../../src/index.js";
+import { buildImports } from "../../src/runtime.js";
 import { assertEquivalent } from "./helpers.js";
 
 async function compileWat(source: string): Promise<string> {
@@ -91,6 +92,51 @@ describe("#1197 i32 element specialization for number[]", () => {
         }`,
         [{ fn: "test", args: [] }],
       );
+    });
+
+    it("bounded permutation fill and indexOf agree with native JS", async () => {
+      const source = `export function test(): number {
+        const arr: number[] = [];
+        for (let i = 0; i < 10000; i = i + 1) {
+          arr.push((i * 7919) % 10000);
+        }
+        let sum = 0;
+        for (let i = 0; i < 1000; i = i + 1) {
+          sum = sum + arr.indexOf(i * 10);
+        }
+        return sum;
+      }`;
+      const result = await compile(source, { fast: true });
+      expect(result.success).toBe(true);
+      expect(result.wat).toContain("__arr_i32");
+      const imports = buildImports(result.imports, undefined, result.stringPool);
+      const { instance } = await WebAssembly.instantiate(result.binary, imports);
+      imports.setInstance?.(instance);
+      expect((instance.exports.test as () => number)()).toBe(4_995_000);
+    });
+
+    it("the counted-push unrolled scan preserves tails, misses, and fromIndex", async () => {
+      const source = `export function test(): number {
+        const arr: number[] = [];
+        for (let i = 0; i < 1031; i = i + 1) {
+          arr.push((i * 37) % 1031);
+        }
+        let passed = 0;
+        if (arr.indexOf(0) === 0) passed = passed + 1;
+        if (arr.indexOf(37) === 1) passed = passed + 1;
+        if (arr.indexOf((1030 * 37) % 1031) === 1030) passed = passed + 1;
+        if (arr.indexOf(2000) === -1) passed = passed + 1;
+        if (arr.indexOf(0, 2000) === -1) passed = passed + 1;
+        if (arr.indexOf(37, 2) === -1) passed = passed + 1;
+        if (arr.indexOf((1030 * 37) % 1031, -1) === 1030) passed = passed + 1;
+        return passed;
+      }`;
+      const result = await compile(source, { fast: true });
+      expect(result.success).toBe(true);
+      const imports = buildImports(result.imports, undefined, result.stringPool);
+      const { instance } = await WebAssembly.instantiate(result.binary, imports);
+      imports.setInstance?.(instance);
+      expect((instance.exports.test as () => number)()).toBe(7);
     });
 
     it("compound bitwise assignment on element preserves i32 semantics", async () => {
@@ -239,6 +285,53 @@ describe("#1197 i32 element specialization for number[]", () => {
             values[i] = i / 2; // f64 result, not i32-shaped
           }
           return values[5];
+        }`,
+      );
+      expect(wat).not.toContain("__arr_i32");
+    });
+
+    it("a fractional indexOf search keeps the f64 backing", async () => {
+      const wat = await compileWat(
+        `export function test(): number {
+          const values: number[] = [];
+          for (let i = 0; i < 10; i++) values.push(i & 7);
+          return values.indexOf(1.5);
+        }`,
+      );
+      expect(wat).not.toContain("__arr_i32");
+    });
+
+    it("an out-of-range indexOf search keeps the f64 backing", async () => {
+      const wat = await compileWat(
+        `export function test(): number {
+          const values: number[] = [];
+          for (let i = 0; i < 10; i++) values.push(i & 7);
+          return values.indexOf(2147483648);
+        }`,
+      );
+      expect(wat).not.toContain("__arr_i32");
+    });
+
+    it("range arithmetic that can produce negative zero keeps the f64 backing", async () => {
+      const wat = await compileWat(
+        `export function test(): number {
+          const values: number[] = [];
+          for (let i = 0; i < 10; i++) values.push(i * -1);
+          return 1 / values[0];
+        }`,
+      );
+      expect(wat).not.toContain("__arr_i32");
+    });
+
+    it("a loop-body counter write invalidates the static range", async () => {
+      const wat = await compileWat(
+        `export function test(): number {
+          const values: number[] = [];
+          for (let i = 0; i < 10; i++) {
+            if (i === 5) i = i + 1;
+            values.push((i * 7919) % 10000);
+          }
+          return values[0];
         }`,
       );
       expect(wat).not.toContain("__arr_i32");


### PR DESCRIPTION
## Summary

- retain exact bounded counted-loop arithmetic in signed-i32 array storage through the `TypeOracle` boundary
- emit a 32-wide `indexOf` main loop for numeric arrays whose counted-push construction proves at least 1,024 elements
- preserve scalar tails, `fromIndex`, sparse backing bounds, and conservative f64 fallbacks for fractional, out-of-range, negative-zero, or mutated-counter cases
- keep the code-growth heuristic in a dedicated array-search module instead of growing compiler god-files

## Why

V8's optimized JS lane dispatches the search to `ArrayIndexOfSmi`, which has one tight tagged-Smi scan. The emitted Wasm loop paid logical-length and WasmGC physical bounds/reference work per element. V8 already unrolled that scalar Wasm loop four ways, so reducing the element representation to i32 alone was only about a 1% win; a compiler-selected wide scan was needed to amortize the remaining per-iteration control overhead.

The unroll is deliberately limited to large numeric arrays recognized by the existing counted-push proof. Small/general searches keep the scalar lowering and avoid the binary-size cost.

## Performance

Exact base: `dda0d1dc72f4a701b98c09f74f1edd2573985d26`  
Candidate: `8e77e6740d472341aed05b6f39bd2b9ef9c16f19`  
Host: Node v24.4.1, darwin arm64  
Workload checksum: `4,995,000`

Alternating, same-process 20-pair measurement of the exact `array/indexOf` Wasm workload:

| Measurement | Base | Candidate | Change |
| --- | ---: | ---: | ---: |
| CPU median | 3.354 ms | 2.293 ms | 1.46x faster |
| Wall median | 10.526 ms | 6.828 ms | 1.54x faster |
| Doubled-work CPU control | — | 4.276 ms | 1.86x candidate |

The exact official harness pair was noisy under concurrent load but moved in the same direction: gc-native `3.201 ms` to `3.061 ms` while JS moved `1.467 ms` to `1.536 ms`. The candidate workload binary grows from 1,443 to 2,541 bytes; that cost is gated to the proven large counted-push shape.

## Validation

- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- complete pre-commit and pre-push hooks, including LOC/function/oracle/coercion ratchets
- 20 focused i32-specialization/indexOf tests
- sparse-array search coverage (`tests/issue-3201.test.ts`)
- array-method, `fromIndex`, and i32-soundness suites
- candidate and exact base both reproduce the same six unrelated existing `native-arrays` failures (82/88 pass)
