### PR TITLE
feat(linear): add native String.repeat support

### DIFF
--- a/plan/issues/3922-linear-missing-string-builtins.md
+++ b/plan/issues/3922-linear-missing-string-builtins.md
@@ -3,7 +3,7 @@ id: 3922
 title: "linear backend: 7 String builtins unimplemented — repeat, replace, toLowerCase/toUpperCase, substring, trim, endsWith, includes (blocks 7 benchmarks)"
 status: ready
 created: 2026-07-31
-updated: 2026-07-31
+updated: 2026-08-09
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -15,6 +15,8 @@ sprint: current
 horizon: l
 es_edition: multi
 related: [3908, 3904, 3923]
+loc-budget-allow:
+  - src/codegen-linear/index.ts
 ---
 
 # #3922 — linear lane: missing String builtins
@@ -58,6 +60,27 @@ prioritise by what those targets actually need rather than by benchmark count.
 3. Cross-reference #3899's i32-kernel work — the WasmGC lane's scan kernels
    (`__str_region_eq`, `__str_ws_start`/`__str_ws_end`) may inform the linear
    equivalents, though the storage model differs.
+
+## Repeat slice — 2026-08-09
+
+The first scoped slice adds a source-gated, host-free linear-memory
+`String.prototype.repeat` kernel. It keeps the count as `f64` through
+`ToIntegerOrInfinity`, copies the UTF-8 payload into one allocation, and rejects
+negative, positive-infinity, and implementation-size overflow counts before
+allocation. Valid counts, including `NaN`, negative zero, negative fractions
+that truncate to negative zero, fractional positives, zero, one, empty strings,
+and non-ASCII strings, are differentially checked against Node/V8.
+
+The linear backend still has no catchable JS exception representation
+(#1838/#1937), so the RangeError cases use a deterministic native trap. This is
+an explicit limitation of the slice, not a claim that a Wasm trap is a complete
+ECMAScript `RangeError` implementation.
+
+The exact `string/concat-long` benchmark now compiles with zero imports. Its
+first invocation still exhausts the 16 MiB arena because repeated immutable
+concatenation allocates quadratic intermediates, the same mechanism tracked by
+#3935. Once intra-call concatenation is fixed, the repeated benchmark harness
+still depends on #3924's between-call arena reclamation.
 
 ## Acceptance criteria
 

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -15,6 +15,7 @@ import * as linearCoercion from "./coercion-engine.js";
 import * as numberFormat from "./number-format.js";
 import { addLinearStackArenaRuntime } from "./runtime-stack-arena.js";
 import { compileLinearStringMethodCall } from "./string-methods.js";
+import { addLinearStringRepeatRuntime, sourceMayUseLinearStringRepeat } from "./string-repeat.js";
 import {
   addArrayRuntime,
   addFmodRuntime,
@@ -114,6 +115,7 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
   addUint8ArrayRuntime(mod);
   addArrayRuntime(mod);
   addStringRuntime(mod);
+  if (sourceMayUseLinearStringRepeat(ast.sourceFile)) addLinearStringRepeatRuntime(mod);
   addMapRuntime(mod);
   addSetRuntime(mod);
   addNumericMapRuntime(mod);
@@ -290,6 +292,7 @@ export function generateLinearMultiModule(multiAst: MultiTypedAST, opts: LinearO
   addUint8ArrayRuntime(mod);
   addArrayRuntime(mod);
   addStringRuntime(mod);
+  if (multiAst.sourceFiles.some(sourceMayUseLinearStringRepeat)) addLinearStringRepeatRuntime(mod);
   addMapRuntime(mod);
   addSetRuntime(mod);
   addNumericMapRuntime(mod);
@@ -3475,6 +3478,7 @@ function compileMethodCall(ctx: LinearContext, fctx: LinearFuncContext, expr: ts
     compileLinearStringMethodCall(ctx, fctx, expr, propAccess, methodName, {
       compileExpression,
       compileExprToI32,
+      compileExprToF64,
       compileStringLiteral,
       isStringExpr,
     })

--- a/src/codegen-linear/string-methods.ts
+++ b/src/codegen-linear/string-methods.ts
@@ -2,6 +2,7 @@
 import { ts } from "../ts-api.js";
 import type { LinearContext, LinearFuncContext } from "./context.js";
 import { addLocal } from "./context.js";
+import { compileLinearStringRepeatCall } from "./string-repeat.js";
 
 type CompileExpression = (ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Expression) => void;
 type CompileStringLiteral = (ctx: LinearContext, fctx: LinearFuncContext, value: string) => void;
@@ -9,6 +10,7 @@ type CompileStringLiteral = (ctx: LinearContext, fctx: LinearFuncContext, value:
 export interface LinearStringMethodCompiler {
   readonly compileExpression: CompileExpression;
   readonly compileExprToI32: CompileExpression;
+  readonly compileExprToF64: CompileExpression;
   readonly compileStringLiteral: CompileStringLiteral;
   readonly isStringExpr: (ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Expression) => boolean;
 }
@@ -136,20 +138,21 @@ export function compileLinearStringMethodCall(
   methodName: string,
   compiler: LinearStringMethodCompiler,
 ): boolean {
-  const { compileExpression, compileExprToI32, compileStringLiteral, isStringExpr } = compiler;
+  const { compileExpression, compileExprToI32, compileExprToF64, compileStringLiteral, isStringExpr } = compiler;
   if (!isStringExpr(ctx, fctx, propAccess.expression)) return false;
 
   if (methodName === "repeat") {
     const repeated = foldLiteralRepeat(propAccess.expression, expr.arguments);
-    if (repeated === undefined) {
-      ctx.errors.push({
-        message: `Unsupported String.repeat() in linear backend: expected a literal receiver and a non-negative integer literal producing at most ${MAX_FOLDED_REPEAT_BYTES} UTF-8 bytes`,
-        ...nodeLoc(expr),
-      });
-      fctx.body.push({ op: "i32.const", value: 0 });
-    } else {
-      compileStringLiteral(ctx, fctx, repeated);
-    }
+    if (repeated !== undefined) compileStringLiteral(ctx, fctx, repeated);
+    else
+      compileLinearStringRepeatCall(
+        ctx,
+        fctx,
+        propAccess.expression,
+        expr.arguments[0],
+        compileExpression,
+        compileExprToF64,
+      );
     return true;
   }
 

--- a/src/codegen-linear/string-repeat.ts
+++ b/src/codegen-linear/string-repeat.ts
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Host-free `String.prototype.repeat` support for the linear-memory backend
+ * (#3922).
+ *
+ * The linear backend stores strings as `[header:8][byteLength:u32][UTF-8]`.
+ * Repeat therefore copies the immutable byte payload into one freshly
+ * allocated record. The count stays f64 until this helper applies
+ * ToIntegerOrInfinity; converting it at the call site with `i32.trunc_f64_s`
+ * would incorrectly trap on NaN and would test negative fractions before
+ * truncation.
+ *
+ * Linear JS exception handling is still tracked by #1838/#1937. Until that
+ * substrate exists, the two spec RangeError paths (negative/+Infinity and an
+ * implementation-size overflow) use a deterministic `unreachable` trap. The
+ * guard runs before allocation, so an impossible request cannot wrap an i32
+ * length or partially overwrite the arena.
+ */
+
+import { ts, forEachChild } from "../ts-api.js";
+import {
+  LINEAR_STRING_PAYLOAD_PREFIX_BYTES,
+  LINEAR_STRING_PAYLOAD_SIZE_OFFSET,
+} from "../ir/analysis/linear-memory-plan.js";
+import type { Instr, WasmModule } from "../ir/types.js";
+import type { LinearContext, LinearFuncContext } from "./context.js";
+
+export const LINEAR_STRING_REPEAT_FN = "__str_repeat";
+
+const LINEAR_MEMORY_MAX_BYTES = 256 * 65_536;
+const STRING_RECORD_HEADER_BYTES = 12;
+const MAX_STRING_BYTE_LENGTH = LINEAR_MEMORY_MAX_BYTES - STRING_RECORD_HEADER_BYTES;
+
+type CompileExpression = (ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Expression) => void;
+
+/** True when direct linear codegen can encounter a `.repeat(...)` call. */
+export function sourceMayUseLinearStringRepeat(sourceFile: ts.SourceFile): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "repeat"
+    ) {
+      found = true;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/** Emit the direct call after the string-receiver proof in `compileMethodCall`. */
+export function compileLinearStringRepeatCall(
+  ctx: LinearContext,
+  fctx: LinearFuncContext,
+  receiver: ts.Expression,
+  count: ts.Expression | undefined,
+  compileExpression: CompileExpression,
+  compileCountToF64: CompileExpression,
+): void {
+  compileExpression(ctx, fctx, receiver);
+  if (count === undefined) fctx.body.push({ op: "f64.const", value: 0 });
+  else compileCountToF64(ctx, fctx, count);
+  // Resolve after operand compilation: it may register/insert functions, and
+  // a funcIdx captured before that work can become stale (#2150 class-3).
+  const funcIdx = ctx.funcMap.get(LINEAR_STRING_REPEAT_FN);
+  if (funcIdx === undefined) throw new Error("linear string repeat runtime was not registered");
+  fctx.body.push({ op: "call", funcIdx });
+}
+
+function findFuncIndex(mod: WasmModule, name: string): number {
+  const numImports = mod.imports.filter((entry) => entry.desc.kind === "func").length;
+  const index = mod.functions.findIndex((func) => func.name === name);
+  if (index < 0) throw new Error(`linear string repeat dependency missing: ${name}`);
+  return numImports + index;
+}
+
+/** Register the `(string, f64 count) -> string` native repeat kernel. */
+export function addLinearStringRepeatRuntime(mod: WasmModule): void {
+  if (mod.functions.some((func) => func.name === LINEAR_STRING_REPEAT_FN)) return;
+
+  const mallocIdx = findFuncIndex(mod, "__malloc");
+  const typeIdx = mod.types.length;
+  mod.types.push({
+    kind: "func",
+    name: `$type_${LINEAR_STRING_REPEAT_FN}`,
+    params: [{ kind: "i32" }, { kind: "f64" }],
+    results: [{ kind: "i32" }],
+  });
+
+  // params: string(0), count(1)
+  // locals: integerCount(2:f64), sourceLen(3), resultLen(4), result(5), i(6)
+  const integerCount = 2;
+  const sourceLen = 3;
+  const resultLen = 4;
+  const result = 5;
+  const i = 6;
+  const body: Instr[] = [
+    // n = ToIntegerOrInfinity(count). f64.trunc preserves NaN and infinities;
+    // NaN is normalized to +0 below, as required by ToIntegerOrInfinity.
+    { op: "local.get", index: 1 },
+    { op: "f64.trunc" },
+    { op: "local.set", index: integerCount },
+
+    // §22.1.3.18: n < 0 or n = +Infinity throws RangeError. Testing the
+    // truncated value makes -0.5 become -0 rather than a false RangeError.
+    { op: "local.get", index: integerCount },
+    { op: "f64.const", value: 0 },
+    { op: "f64.lt" },
+    { op: "local.get", index: integerCount },
+    { op: "f64.const", value: Infinity },
+    { op: "f64.eq" },
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "unreachable" }],
+      else: [],
+    },
+
+    // ToIntegerOrInfinity(NaN) = +0.
+    { op: "local.get", index: integerCount },
+    { op: "local.get", index: integerCount },
+    { op: "f64.ne" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "f64.const", value: 0 },
+        { op: "local.set", index: integerCount },
+      ],
+      else: [],
+    },
+
+    // The validity check precedes the empty-string fast path: "".repeat(-1)
+    // must still fail. A valid repeat of an empty string can reuse its record.
+    { op: "local.get", index: 0 },
+    { op: "i32.load", align: 2, offset: 8 },
+    { op: "local.tee", index: sourceLen },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: 0 }, { op: "return" }],
+      else: [],
+    },
+
+    // A count of one preserves the immutable source record and avoids an
+    // allocation. String primitives have no observable pointer identity.
+    { op: "local.get", index: integerCount },
+    { op: "f64.const", value: 1 },
+    { op: "f64.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: 0 }, { op: "return" }],
+      else: [],
+    },
+
+    // Compute in f64 and reject before narrowing. The cap mirrors the module's
+    // 256-page memory maximum; lower remaining capacity is handled by __malloc
+    // as the ordinary OOM trap.
+    { op: "local.get", index: sourceLen },
+    { op: "f64.convert_i32_u" },
+    { op: "local.get", index: integerCount },
+    { op: "f64.mul" },
+    { op: "local.tee", index: integerCount },
+    { op: "f64.const", value: MAX_STRING_BYTE_LENGTH },
+    { op: "f64.gt" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "unreachable" }],
+      else: [],
+    },
+    { op: "local.get", index: integerCount },
+    { op: "i32.trunc_f64_u" },
+    { op: "local.set", index: resultLen },
+
+    // Allocate and initialize the canonical linear-string record.
+    { op: "local.get", index: resultLen },
+    { op: "i32.const", value: STRING_RECORD_HEADER_BYTES },
+    { op: "i32.add" },
+    { op: "call", funcIdx: mallocIdx },
+    { op: "local.set", index: result },
+    { op: "local.get", index: result },
+    { op: "local.get", index: resultLen },
+    { op: "i32.const", value: LINEAR_STRING_PAYLOAD_PREFIX_BYTES },
+    { op: "i32.add" },
+    { op: "i32.store", align: 2, offset: LINEAR_STRING_PAYLOAD_SIZE_OFFSET },
+    { op: "local.get", index: result },
+    { op: "local.get", index: resultLen },
+    { op: "i32.store", align: 2, offset: 8 },
+
+    // result[i] = source[i % sourceLen]. This copies UTF-8 bytes, so repeating
+    // a non-ASCII string preserves its exact code-point/code-unit sequence.
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: i },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: i },
+            { op: "local.get", index: resultLen },
+            { op: "i32.ge_u" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: result },
+            { op: "local.get", index: i },
+            { op: "i32.add" },
+            { op: "local.get", index: 0 },
+            { op: "local.get", index: i },
+            { op: "local.get", index: sourceLen },
+            { op: "i32.rem_u" },
+            { op: "i32.add" },
+            { op: "i32.load8_u", align: 0, offset: 12 },
+            { op: "i32.store8", align: 0, offset: 12 },
+            { op: "local.get", index: i },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: i },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    { op: "local.get", index: result },
+  ];
+
+  mod.functions.push({
+    name: LINEAR_STRING_REPEAT_FN,
+    typeIdx,
+    locals: [
+      { name: "integerCount", type: { kind: "f64" } },
+      { name: "sourceLen", type: { kind: "i32" } },
+      { name: "resultLen", type: { kind: "i32" } },
+      { name: "result", type: { kind: "i32" } },
+      { name: "i", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  });
+}

--- a/tests/issue-3922-linear-string-repeat.test.ts
+++ b/tests/issue-3922-linear-string-repeat.test.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3922 — host-free String.prototype.repeat in the linear-memory backend.
+ *
+ * Valid counts are checked against Node/V8. The linear backend cannot yet
+ * materialize catchable JS RangeError objects (#1838/#1937), so the same
+ * invalid-count cases that V8 classifies as RangeError are required to take
+ * the native helper's deterministic pre-allocation trap instead.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { stringBenchmarks } from "../benchmarks/suites/strings.js";
+import { compile, compileMulti } from "../src/index.js";
+
+const ORIGINAL_LINEAR_IR = process.env.JS2WASM_LINEAR_IR;
+const SOURCE = `
+export function repeat(count: number): string { return "A😀".repeat(count); }
+export function repeatLength(count: number): number { return "A😀".repeat(count).length; }
+export function omitted(): string { return "ab".repeat(); }
+export function empty(count: number): string { return "".repeat(count); }
+`;
+
+afterEach(() => {
+  if (ORIGINAL_LINEAR_IR === undefined) Reflect.deleteProperty(process.env, "JS2WASM_LINEAR_IR");
+  else process.env.JS2WASM_LINEAR_IR = ORIGINAL_LINEAR_IR;
+});
+
+async function instantiateRepeat(overlay: boolean) {
+  process.env.JS2WASM_LINEAR_IR = overlay ? "1" : "0";
+  const result = await compile(SOURCE, {
+    target: "linear",
+    fileName: `issue-3922-${overlay ? "ir" : "direct"}.ts`,
+    emitWat: true,
+    optimize: false,
+    allocator: "arena-reset",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const module = new WebAssembly.Module(result.binary);
+  expect(WebAssembly.Module.imports(module)).toEqual([]);
+  expect(result.wat).toContain("$__str_repeat");
+
+  const instance = await WebAssembly.instantiate(module, {});
+  const memory = instance.exports.memory as WebAssembly.Memory;
+  const exports = instance.exports as unknown as {
+    repeat(count?: number): number;
+    repeatLength(count: number): number;
+    omitted(): number;
+    empty(count: number): number;
+    __arena_used(): number;
+  };
+  const decode = (pointer: number): string => {
+    const length = new DataView(memory.buffer).getUint32(pointer + 8, true);
+    return new TextDecoder().decode(new Uint8Array(memory.buffer, pointer + 12, length));
+  };
+  return { decode, exports, memory };
+}
+
+describe("#3922 linear String.prototype.repeat", () => {
+  it.each([false, true])("matches Node/V8 for valid ToIntegerOrInfinity counts (IR overlay=%s)", async (overlay) => {
+    const { decode, exports } = await instantiateRepeat(overlay);
+    const receiver = "A😀";
+    for (const count of [NaN, -0, -0.75, 0, 0.75, 1, 1.9, 2, 3.9, 32]) {
+      expect(decode(exports.repeat(count)), `count=${String(count)}`).toBe(receiver.repeat(count));
+      expect(exports.repeatLength(count), `length count=${String(count)}`).toBe(receiver.repeat(count).length);
+    }
+    expect(decode(exports.repeat())).toBe(receiver.repeat(undefined));
+    expect(decode(exports.omitted())).toBe("ab".repeat());
+    expect(decode(exports.empty(2 ** 53))).toBe("".repeat(2 ** 53));
+  });
+
+  it("traps invalid and oversized counts before allocating", async () => {
+    const { exports, memory } = await instantiateRepeat(true);
+    const invalid = [-1, -1.25, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, 2 ** 53];
+    exports.repeat(1); // Materialize the cached receiver; repeat(1) itself allocates nothing.
+    const arenaBefore = exports.__arena_used();
+    const bytesBefore = memory.buffer.byteLength;
+
+    for (const count of invalid) {
+      expect(() => "A😀".repeat(count), `Node oracle count=${String(count)}`).toThrow(RangeError);
+      expect(() => exports.repeat(count), `linear count=${String(count)}`).toThrow(WebAssembly.RuntimeError);
+      expect(exports.__arena_used(), `arena count=${String(count)}`).toBe(arenaBefore);
+    }
+    expect(memory.buffer.byteLength).toBe(bytesBefore);
+
+    expect(() => "".repeat(-1)).toThrow(RangeError);
+    expect(() => exports.empty(-1)).toThrow(WebAssembly.RuntimeError);
+  });
+
+  it("source-gates the helper and compiles the exact concat-long benchmark with no imports", async () => {
+    const control = await compile(`export function run(): number { return "ok".length; }`, {
+      target: "linear",
+      emitWat: true,
+    });
+    expect(control.success, control.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(control.wat).not.toContain("$__str_repeat");
+
+    const benchmark = stringBenchmarks.find((entry) => entry.name === "string/concat-long");
+    expect(benchmark?.source).toBeDefined();
+    const candidate = await compile(benchmark!.source, {
+      target: "linear",
+      fileName: "benchmark-string-concat-long.ts",
+      emitWat: true,
+      optimize: false,
+    });
+    expect(candidate.success, candidate.errors.map((error) => error.message).join("\n")).toBe(true);
+    const module = new WebAssembly.Module(candidate.binary);
+    expect(WebAssembly.Module.imports(module)).toEqual([]);
+    expect(WebAssembly.Module.exports(module).some((entry) => entry.name === "run")).toBe(true);
+    expect(candidate.wat).toContain("$__str_repeat");
+  });
+
+  it("registers the helper for multi-source linear compilation", async () => {
+    const result = await compileMulti(
+      {
+        "repeat.ts": `export function repeated(count: number): string { return "xy".repeat(count); }`,
+        "main.ts": `export { repeated } from "./repeat.js";`,
+      },
+      "main.ts",
+      { target: "linear", emitWat: true, optimize: false },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+    expect(result.wat).toContain("$__str_repeat");
+  });
+
+  it.each(["standalone", "wasi"] as const)("keeps the existing %s native lane host-free", async (target) => {
+    const result = await compile(`export function run(): number { return "ab".repeat(3) === "ababab" ? 1 : 0; }`, {
+      target,
+      fileName: `issue-3922-${target}.ts`,
+    });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    const module = new WebAssembly.Module(result.binary);
+    expect(WebAssembly.Module.imports(module)).toEqual([]);
+    const instance = await WebAssembly.instantiate(module, {});
+    expect((instance.exports.run as () => number)()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve the bounded literal `String.prototype.repeat` folding added on main, while routing non-foldable counts to a source-gated native linear-memory helper.
- Apply `ToIntegerOrInfinity` while the count is still `f64`, including `NaN`, signed zero, and fractional counts, then copy UTF-8 bytes into one canonical string allocation.
- Keep single-source, multi-source, standalone, and WASI compilation host-free with zero Wasm imports.
- Reject negative, positive-infinity, and implementation-size overflow counts before allocation. The linear backend cannot yet materialize catchable JS exceptions (#1838/#1937), so these RangeError paths intentionally use a deterministic Wasm trap.

This is one scoped slice of #3922; the umbrella issue remains open for the other missing string builtins.

## Exact-base verification

- Base: `aa22e6d8d1a03bd4a0bb737b95f80e73feea81ac`
- Candidate: `3b32621d73fb30ea1a440e9f809c08c9f97e0b45`

For the dynamic source below, the exact base rejects the call as unsupported. The candidate compiles with zero imports and `rep(3.9)` returns `"ababab"`:

```ts
export function rep(n: number): string {
  return "ab".repeat(n);
}
```

The exact `string/concat-long` benchmark also compiles with zero imports. Its first invocation still exhausts the 16 MiB arena because immutable concatenation retains quadratic intermediates (#3935); after that intra-call issue is fixed, repeated harness invocations still depend on between-call arena reclamation (#3924).

## Validation

- Focused and neighboring linear-string regression set: 5 files, 51/51 tests passed.
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- LOC, function-budget, oracle-ratchet, coercion-site, test262-hard-error, Prettier, and Biome gates passed.
- The full pre-push hook passed, including typecheck, lint, format, ratchets, and numeric-local IR parity.

`pnpm run check:linear-ir` reports the same pre-existing drift on both the exact base and candidate:

```text
IR compiled count: 8 -> 6
illegal:instr-vec.set_length: 0 -> 2
select:string-builder-candidate: 0 -> 2
```

This drift arrived with the current base and is unrelated to this change, so this PR deliberately does not update that baseline.
