### PR TITLE
perf(strings): specialize proven rope concatenation

### DIFF
--- a/src/codegen/analysis/static-string-constants.ts
+++ b/src/codegen/analysis/static-string-constants.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { ts } from "../../ts-api.js";
+import type { CodegenContext } from "../context/types.js";
+
+/**
+ * Resolve a compile-time constant, but only for truly immutable values.
+ * Unlike general constant folding, this does not resolve `let`/`var`
+ * declarations: only literals, `const` aliases, and expressions composed from
+ * those values are accepted.
+ */
+export function resolveStrictConstant(ctx: CodegenContext, expression: ts.Expression): string | number | undefined {
+  const expr = expression;
+  if (ts.isStringLiteral(expr)) return expr.text;
+  if (ts.isNumericLiteral(expr)) return Number(expr.text);
+  if (ts.isParenthesizedExpression(expr)) return resolveStrictConstant(ctx, expr.expression);
+
+  if (ts.isIdentifier(expr)) {
+    const initializer = ctx.oracle.constInitializerOf(expr);
+    return initializer ? resolveStrictConstant(ctx, initializer) : undefined;
+  }
+
+  if (ts.isBinaryExpression(expr)) {
+    const left = resolveStrictConstant(ctx, expr.left);
+    const right = resolveStrictConstant(ctx, expr.right);
+    if (left === undefined || right === undefined) return undefined;
+    if (typeof left === "string" || typeof right === "string") {
+      return expr.operatorToken.kind === ts.SyntaxKind.PlusToken ? String(left) + String(right) : undefined;
+    }
+    return expr.operatorToken.kind === ts.SyntaxKind.PlusToken ? left + right : undefined;
+  }
+
+  if (ts.isTemplateExpression(expr)) {
+    let result = expr.head.text;
+    for (const span of expr.templateSpans) {
+      const value = resolveStrictConstant(ctx, span.expression);
+      if (value === undefined) return undefined;
+      result += String(value) + span.literal.text;
+    }
+    return result;
+  }
+  if (ts.isNoSubstitutionTemplateLiteral(expr)) return expr.text;
+
+  return undefined;
+}
+
+/**
+ * Prove an exact compile-time string length without materializing its value.
+ *
+ * This deliberately recognizes only immutable expressions: literals, `const`
+ * aliases, and `String#repeat` with a compile-time numeric count. This lets a
+ * proven rope concat reuse the exact RHS length while avoiding a potentially
+ * huge repeated compiler-side string.
+ */
+export function staticStringLength(
+  ctx: CodegenContext,
+  expression: ts.Expression,
+  seen = new Set<ts.VariableDeclaration>(),
+): number | undefined {
+  let expr = expression;
+  while (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isNonNullExpression(expr) ||
+    ts.isSatisfiesExpression(expr) ||
+    ts.isTypeAssertionExpression(expr)
+  ) {
+    expr = expr.expression;
+  }
+
+  if (ts.isStringLiteralLike(expr)) return expr.text.length;
+
+  if (ts.isIdentifier(expr)) {
+    const declaration = ctx.oracle.variableDeclarationOf(expr);
+    const initializer = ctx.oracle.constInitializerOf(expr);
+    if (!declaration || !initializer || seen.has(declaration)) return undefined;
+    const nextSeen = new Set(seen);
+    nextSeen.add(declaration);
+    return staticStringLength(ctx, initializer, nextSeen);
+  }
+
+  if (
+    ts.isCallExpression(expr) &&
+    ts.isPropertyAccessExpression(expr.expression) &&
+    expr.expression.name.text === "repeat" &&
+    expr.arguments.length === 1 &&
+    ctx.oracle.staticJsTypeOf(expr.expression.expression) === "string"
+  ) {
+    const receiverLength = staticStringLength(ctx, expr.expression.expression, new Set(seen));
+    const rawCount = resolveStrictConstant(ctx, expr.arguments[0]!);
+    if (receiverLength === undefined || typeof rawCount !== "number" || !Number.isFinite(rawCount)) return undefined;
+    const count = Math.trunc(rawCount);
+    const length = receiverLength * count;
+    if (count < 0 || !Number.isSafeInteger(count) || !Number.isSafeInteger(length) || length > 0x7fffffff) {
+      return undefined;
+    }
+    return length;
+  }
+
+  return undefined;
+}

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -42,6 +42,7 @@ import {
 } from "./regexp-standalone.js";
 import { tryCompileStandaloneSplitSeparator, tryCompileStandaloneStringValueReplace } from "./string-search-value.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
+import { resolveStrictConstant, staticStringLength } from "./analysis/static-string-constants.js";
 import { staticConstStringValues } from "./analysis/static-string-values.js";
 import { staticIntegerRange } from "./analysis/static-numeric-range.js";
 import { tryEmitStaticI32Expression } from "./i32-static-range-expr.js";
@@ -1678,60 +1679,54 @@ function foldAdjacentConstantOperands(ctx: CodegenContext, operands: ts.Expressi
   return result;
 }
 
-/**
- * Resolve a compile-time constant, but only for truly immutable values.
- * Unlike resolveConstantExpression, this does NOT resolve let/var declarations —
- * only string/numeric literals, const variables, and expressions composed of those.
- * This prevents incorrect folding of mutable variables in loops.
- */
-function resolveStrictConstant(ctx: CodegenContext, expr: ts.Expression): string | number | undefined {
-  if (ts.isStringLiteral(expr)) return expr.text;
-  if (ts.isNumericLiteral(expr)) return Number(expr.text);
-  if (ts.isParenthesizedExpression(expr)) return resolveStrictConstant(ctx, expr.expression);
+/** Emit the branch-free ConsString construction licensed by a >=64 RHS proof. */
+function emitProvenRopeConcat(ctx: CodegenContext, fctx: FunctionContext, rhsLength: number): void {
+  const rhs = allocLocal(fctx, `__rope_rhs_${fctx.locals.length}`, nativeStringType(ctx));
+  const lhs = allocLocal(fctx, `__rope_lhs_${fctx.locals.length}`, nativeStringType(ctx));
+  fctx.body.push({ op: "local.set", index: rhs });
+  fctx.body.push({ op: "local.set", index: lhs });
+  fctx.body.push({ op: "local.get", index: lhs });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "i32.const", value: rhsLength });
+  fctx.body.push({ op: "i32.add" });
+  fctx.body.push({ op: "local.get", index: lhs });
+  fctx.body.push({ op: "local.get", index: rhs });
+  fctx.body.push({ op: "struct.new", typeIdx: ctx.consStrTypeIdx });
+}
 
-  // Only resolve const variable references
-  if (ts.isIdentifier(expr)) {
-    const sym = ctx.checker.getSymbolAtLocation(expr);
-    if (sym) {
-      const decl = sym.valueDeclaration;
-      if (decl && ts.isVariableDeclaration(decl) && decl.initializer) {
-        const declList = decl.parent;
-        if (ts.isVariableDeclarationList(declList) && (declList.flags & ts.NodeFlags.Const) !== 0) {
-          return resolveStrictConstant(ctx, decl.initializer);
-        }
-      }
-    }
-    return undefined;
+/** Compile native string `+`, including the statically-proven rope arm. */
+function compileNativeStringConcat(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+): ValType | null {
+  const constVal = resolveStrictConstant(ctx, expr);
+  if (typeof constVal === "string") return compileStringLiteral(ctx, fctx, constVal, expr);
+
+  // #1470 — `__str_concat` takes two native strings. Standalone/WASI must
+  // coerce mixed operands in Wasm; the legacy JS-host native-string mode keeps
+  // its established raw operand path.
+  if (noJsHost(ctx)) {
+    compileNativeConcatOperand(ctx, fctx, expr.left);
+    compileNativeConcatOperand(ctx, fctx, expr.right);
+  } else {
+    compileExpression(ctx, fctx, expr.left);
+    compileExpression(ctx, fctx, expr.right);
   }
 
-  // Binary expressions (recurse strictly)
-  if (ts.isBinaryExpression(expr)) {
-    const left = resolveStrictConstant(ctx, expr.left);
-    const right = resolveStrictConstant(ctx, expr.right);
-    if (left === undefined || right === undefined) return undefined;
-    if (typeof left === "string" || typeof right === "string") {
-      if (expr.operatorToken.kind === ts.SyntaxKind.PlusToken) {
-        return String(left) + String(right);
-      }
-      return undefined;
-    }
-    if (expr.operatorToken.kind === ts.SyntaxKind.PlusToken) return left + right;
-    return undefined;
+  const staticRhsLength = staticStringLength(ctx, expr.right);
+  if (process.env.JS2WASM_NATIVE_PROVEN_ROPE_CONCAT !== "0" && (staticRhsLength ?? 0) >= 64) {
+    emitProvenRopeConcat(ctx, fctx, staticRhsLength!);
+    return nativeStringType(ctx);
   }
 
-  // Template literals
-  if (ts.isTemplateExpression(expr)) {
-    let result = expr.head.text;
-    for (const span of expr.templateSpans) {
-      const val = resolveStrictConstant(ctx, span.expression);
-      if (val === undefined) return undefined;
-      result += String(val) + span.literal.text;
-    }
-    return result;
+  const funcIdx = ctx.nativeStrHelpers.get("__str_concat");
+  if (funcIdx === undefined) {
+    reportError(ctx, expr, `Unsupported string operator: ${ts.SyntaxKind[ts.SyntaxKind.PlusToken]}`);
+    return null;
   }
-  if (ts.isNoSubstitutionTemplateLiteral(expr)) return expr.text;
-
-  return undefined;
+  fctx.body.push({ op: "call", funcIdx });
+  return nativeStringType(ctx);
 }
 
 /** Create a synthetic TS string literal node for use in codegen. */
@@ -1884,42 +1879,8 @@ export function compileStringBinaryOp(
     const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
 
     switch (op) {
-      case ts.SyntaxKind.PlusToken: {
-        // Constant-fold if both sides are compile-time constants (#1004)
-        const constVal = resolveStrictConstant(ctx, expr);
-        if (typeof constVal === "string") {
-          return compileStringLiteral(ctx, fctx, constVal, expr);
-        }
-        // #1470 — `__str_concat` takes `(ref $AnyString, ref $AnyString)`. A
-        // non-string operand (number, boolean, object, `any`) must be coerced
-        // to a native string first or the module is invalid (the previous code
-        // pushed the raw f64/i32/struct ref and `__str_concat` rejected it).
-        //
-        // This issue targets the standalone / WASI surface (`noJsHost`), where
-        // there is no JS runtime to fall back on. There, every operand is
-        // lowered to a native `ref $AnyString` in pure Wasm via
-        // `compileNativeConcatOperand` (numbers → native `number_toString`,
-        // booleans/null/undefined → native literals, dynamic refs → the
-        // `$__any_to_string` dispatcher). The legacy JS-host `nativeStrings`
-        // path (explicit `nativeStrings: true` / `fast`) is left unchanged here:
-        // its mixed-operand handling has separate, pre-existing limitations and
-        // bridging through `__str_from_extern` mid-body corrupts function
-        // indices, so it stays on the original raw-push behavior.
-        if (noJsHost(ctx)) {
-          compileNativeConcatOperand(ctx, fctx, expr.left);
-          compileNativeConcatOperand(ctx, fctx, expr.right);
-        } else {
-          // concat accepts ref $AnyString — no flatten needed
-          compileExpression(ctx, fctx, expr.left);
-          compileExpression(ctx, fctx, expr.right);
-        }
-        const funcIdx = ctx.nativeStrHelpers.get("__str_concat");
-        if (funcIdx !== undefined) {
-          fctx.body.push({ op: "call", funcIdx });
-          return nativeStringType(ctx);
-        }
-        break;
-      }
+      case ts.SyntaxKind.PlusToken:
+        return compileNativeStringConcat(ctx, fctx, expr);
       case ts.SyntaxKind.EqualsEqualsEqualsToken:
       case ts.SyntaxKind.EqualsEqualsToken: {
         const funcIdx = ctx.nativeStrHelpers.get("__str_equals");

--- a/tests/issue-1004-proven-rope-concat.test.ts
+++ b/tests/issue-1004-proven-rope-concat.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1004 follow-up — when a concat RHS has a compile-time length at least the
+ * native 64-code-unit rope threshold, emit the ConsString construction
+ * directly. The general helper would re-read both lengths and branch on a
+ * threshold whose outcome is already proven.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const FLAG = "JS2WASM_NATIVE_PROVEN_ROPE_CONCAT";
+
+async function compileNative(source: string, enabled = true) {
+  const previous = process.env[FLAG];
+  try {
+    if (enabled) delete process.env[FLAG];
+    else process.env[FLAG] = "0";
+    const result = await compile(source, {
+      fileName: "proven-rope.ts",
+      fast: true,
+      target: "gc",
+      optimize: 0,
+      emitWat: true,
+    });
+    expect(result.success, result.errors?.map((error) => error.message).join("\n")).toBe(true);
+    return result;
+  } finally {
+    if (previous === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = previous;
+  }
+}
+
+async function instantiate(binary: Uint8Array): Promise<WebAssembly.Exports> {
+  const module = await WebAssembly.compile(binary);
+  return (await WebAssembly.instantiate(module, {})).exports;
+}
+
+function hasDirectRopeLocals(wat: string | undefined): boolean {
+  return wat?.includes("$__rope_rhs_") === true && wat.includes("$__rope_lhs_");
+}
+
+describe("#1004 proven native rope concat", () => {
+  it("specializes a const alias initialized by repeat and matches the generic helper", async () => {
+    const source = `
+      export function run(): number {
+        const chunk = "x".repeat(1024);
+        let value = "";
+        for (let i = 0; i < 1000; i = i + 1) value = value + chunk;
+        return value.length + value.charCodeAt(1023);
+      }
+    `;
+    const specialized = await compileNative(source);
+    const generic = await compileNative(source, false);
+    expect(hasDirectRopeLocals(specialized.wat)).toBe(true);
+    expect(hasDirectRopeLocals(generic.wat)).toBe(false);
+
+    const specializedExports = await instantiate(specialized.binary);
+    const genericExports = await instantiate(generic.binary);
+    expect((specializedExports.run as () => number)()).toBe(1_024_000 + 120);
+    expect((genericExports.run as () => number)()).toBe(1_024_000 + 120);
+  });
+
+  it("uses UTF-16 code-unit length and honors the exact 64-unit boundary", async () => {
+    const atThreshold = await compileNative(`
+      export function run(): number {
+        const chunk = "😀".repeat(32);
+        return ("prefix" + chunk).length;
+      }
+    `);
+    const belowThreshold = await compileNative(`
+      export function run(): number {
+        const chunk = "x".repeat(63);
+        return ("prefix" + chunk).length;
+      }
+    `);
+    expect(hasDirectRopeLocals(atThreshold.wat)).toBe(true);
+    expect(hasDirectRopeLocals(belowThreshold.wat)).toBe(false);
+    expect(((await instantiate(atThreshold.binary)).run as () => number)()).toBe(70);
+    expect(((await instantiate(belowThreshold.binary)).run as () => number)()).toBe(69);
+  });
+
+  it("does not specialize a mutable alias or an invalid repeat count", async () => {
+    const mutable = await compileNative(`
+      export function run(): number {
+        let chunk = "x".repeat(64);
+        chunk = "y";
+        return ("prefix" + chunk).length;
+      }
+    `);
+    const invalid = await compileNative(`
+      export function run(): number {
+        const chunk = "x".repeat(-1);
+        return ("prefix" + chunk).length;
+      }
+    `);
+    const dynamicReceiver = await compileNative(`
+      export function run(): number {
+        const chunk = ("x" as any).repeat(64);
+        return ("prefix" + chunk).length;
+      }
+    `);
+    expect(hasDirectRopeLocals(mutable.wat)).toBe(false);
+    expect(hasDirectRopeLocals(invalid.wat)).toBe(false);
+    expect(hasDirectRopeLocals(dynamicReceiver.wat)).toBe(false);
+    expect(((await instantiate(mutable.binary)).run as () => number)()).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

- prove exact UTF-16 lengths for immutable string expressions, including `const` aliases and constant-count `String.prototype.repeat`
- when the RHS is at least the native 64-code-unit rope threshold, emit the `ConsString` construction directly
- keep short/unknown concatenations on `__str_concat`, and keep `JS2WASM_NATIVE_PROVEN_ROPE_CONCAT=0` as an exact control
- move strict string-constant analysis out of the oversized string driver and through `ctx.oracle`

## Why

`string/concat-long` appends a 1,024-code-unit chunk. The generic native concat helper reloaded the already-known RHS length and tested a threshold whose result could never be false. That fixed dispatch cost was the remaining repeatable GC-native gap against V8 for this benchmark.

## Performance

Exact lane: Node 24.4.1, Darwin arm64, `fast: true`, optimizer level 4, fresh processes, checksum `1,024,000`.

- official benchmark harness, three alternating control/candidate pairs: `2.590 → 1.763 ns/op` by median, **31.9% faster**
- fixed CPU harness repeats: **39.4%**, **48.3%**, and **51.8% faster**
- doubled-work positive control in the least noisy repeat: `1.96×`
- optimized binary: `955 → 929 bytes`

The kill-switch build is byte-identical to the untouched compiler at base `517aa2d0debef17373eeadf36d42a775e4c6ddce`:

- base/control SHA-256: `9947356c22fe995231916dc7c5abd2d126d0a288ef827593d23eff2212f4ad6f`
- candidate SHA-256: `f002fe66f111a1a07e947b0a3d67b493b52612e73703b372f6ffda1e90c4aef8`

## Safety

- proof accepts immutable string receivers only; `any`, mutable aliases, invalid counts, and sub-threshold values retain the generic helper
- the direct path preserves operand evaluation order and allocates the same `ConsString` representation as the helper's proven rope arm
- tests cover the exact threshold, astral UTF-16 code units, repeat aliases, the kill switch, mutable values, and dynamic receivers

## Validation

- 63 focused string/equivalence tests
- TypeScript typecheck
- IR fallback, stack-balance, codegen-fallback, LOC, function, oracle, and coercion ratchets
- Prettier and `git diff --check`
- post-merge validation against `origin/main` at `5aa31ae6db2362a21967d2d2b5d0246135386a28`
