### PR TITLE
perf(runtime): streamline non-throwing leaf imports

### DIFF
--- a/plan/issues/3780-acorn-wasm-faster-than-node.md
+++ b/plan/issues/3780-acorn-wasm-faster-than-node.md
@@ -4,7 +4,7 @@ title: "Compile Acorn parse hot path to Wasm faster than native Node"
 status: in-progress
 sprint: current
 created: 2026-07-29
-updated: 2026-08-01
+updated: 2026-08-09
 priority: high
 horizon: l
 feasibility: hard
@@ -61,6 +61,7 @@ files:
   - tests/issue-3683-direct-calls.test.ts
   - tests/issue-3765-numeric-locals.test.ts
   - tests/issue-1712-exactfield-lane-guard.test.ts
+  - tests/issue-3780-fast-leaf-host-imports.test.ts
 loc-budget-allow:
   - src/codegen/closed-method-dispatch.ts
   - src/codegen/closures.ts
@@ -89,6 +90,7 @@ oracle-ratchet-allow:
   - src/codegen/property-access.ts
   - src/codegen/statements/control-flow.ts
 func-budget-allow:
+  - src/runtime.ts::buildImports
   - scripts/generate-npm-compat-report.mjs::compileStandaloneLane
   - src/codegen/closed-method-dispatch.ts::fillClosedMethodDispatch
   - src/codegen/closures.ts::compileArrowAsClosure
@@ -785,3 +787,61 @@ Ranked by measured share, the remaining work is:
 Reproduction: `.tmp/wat-census.mjs`, `.tmp/wat-funcs2.mjs`, `.tmp/hot-mix.mjs`,
 `.tmp/prof-buckets.mjs`, `.tmp/alloc-rate.mjs`, `.tmp/startup.mjs` against a
 WAT dump and the named standalone binary.
+
+## 2026-08-09 JS-host leaf-import checkpoint
+
+Current `main` (`517aa2d0debef17373eeadf36d42a775e4c6ddce`) still reports
+Acorn JS-host runtime-dynamic as the largest uncovered running npm gap. One
+parse makes 15,065,637 Wasm-to-host calls. The following proven leaf imports
+account for 5,702,030 of them (37.85%):
+
+| import | calls per parse |
+| --- | ---: |
+| `__get_undefined` | 1,753,050 |
+| `__typeof_number` | 1,321,342 |
+| `__is_truthy` | 1,310,240 |
+| `__box_number` | 772,126 |
+| `__box_boolean` | 545,250 |
+| `__typeof_string` | 22 |
+
+These operations only return `undefined`, apply `typeof`/ToBoolean, or return
+an identity/boolean box. They cannot throw, call user code, or re-enter Wasm.
+`buildImports` now gives zero- and one-argument imports with those safe intents
+a fixed-arity leaf wrapper instead of the general recursion-depth and
+`try`/`catch`/`finally` wrapper. The safety decision uses the closed import
+**intent**, not a caller-supplied name. Import counting remains enabled in the
+fast wrapper, and `JS2WASM_FAST_LEAF_HOST_IMPORTS=0` restores the guarded path.
+
+The performance comparison used one prebuilt artifact for both sides, fresh
+Node/tsx processes, one warm-up parse and one measured parse per process, eight
+alternating-order pairs, and checksum `422` on every sample. The only variable
+was the runtime kill switch:
+
+| runtime | median | mean |
+| --- | ---: | ---: |
+| guarded base (`=0`) | 1,618,772.167 us | 1,692,400.771 us |
+| leaf wrappers (`=1`) | 1,478,630.521 us | 1,554,253.896 us |
+| improvement | **1.095x / 8.66% less time** | **1.089x / 8.16% less time** |
+
+The process-level lane was noisy, including outliers on both sides; alternating
+fresh processes and reporting both median and mean keep the comparison paired.
+The exact samples, in pair order, were:
+
+- guarded: `1423286.125, 1702635.083, 1587498.625, 1356205.291,
+  1285319.708, 2505275.125, 1650045.708, 2028940.500` us;
+- leaf: `1616879.958, 1628955.959, 1413372.459, 2334727.958,
+  1278800.458, 1204033.333, 1470799.000, 1486462.042` us.
+
+This is a runtime-only change. A pristine rebuild before and after produced the
+same 347,063-byte binary and metadata, with SHA-256
+`3b256b8f371f9f05aa9c9d7af84920058ed736567dacf5521f1992a2400002c0`.
+The official nine-round harness also returned checksum `422`; appending a new
+top-level declaration after compilation returned checksum `423`, proving that
+the runtime source is still parsed rather than folded or memoized. Boundary
+count is unchanged; this checkpoint only reduces JS wrapper cost.
+
+Two broader ways to remove `__get_undefined` crossings were rejected and fully
+removed: a lazy Wasm cache regressed the paired median by about 10%, and an
+imported immutable externref global regressed it by about 14%. The remaining
+Acorn gap is still dominated by generic compare/equality, numeric coercion, and
+extern property operations; this checkpoint does not claim parity with Node.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15921,6 +15921,28 @@ function wrapWithContainment(
 }
 
 /**
+ * These intents resolve to leaf functions that cannot throw or call user code,
+ * so they cannot re-enter Wasm. Their import wrappers therefore do not need the
+ * recursion-depth or catch-all bookkeeping used by general host operations.
+ * Keep this predicate intent-based: `buildImports` is public and must not trust
+ * a caller-supplied import name to imply safe behaviour.
+ */
+function isFastLeafHostImport(imp: ImportDescriptor): boolean {
+  switch (imp.intent.type) {
+    case "box":
+    case "typeof_check":
+    case "truthy_check":
+      return true;
+    case "unbox":
+      return imp.intent.targetType === "boolean";
+    case "builtin":
+      return imp.intent.name === "__get_undefined";
+    default:
+      return false;
+  }
+}
+
+/**
  * Build the WebAssembly import object from a closed manifest.
  *
  * After instantiation, prefer `setInstance(instance)`. It proves the
@@ -16029,6 +16051,28 @@ export function buildImports(
       if (imp.intent.type === "declared_global" && imp.intent.name === "document") {
         fn = () => options.domRoot;
       }
+    }
+
+    // Acorn executes millions of these leaf calls per parse. They cannot throw
+    // or re-enter Wasm, so avoid constructing and invoking the general guarded
+    // wrapper. Preserve import diagnostics and the Wasm signature's fixed
+    // arity. The switch provides rollout containment.
+    const fastLeaf = process.env.JS2WASM_FAST_LEAF_HOST_IMPORTS !== "0" && isFastLeafHostImport(imp);
+    if (fastLeaf && imp.paramCount === 0) {
+      const original = fn;
+      env[imp.name] = function () {
+        if (importCounts) importCounts[importIndex]++;
+        return original();
+      };
+      continue;
+    }
+    if (fastLeaf && imp.paramCount === 1) {
+      const original = fn;
+      env[imp.name] = function (a: any) {
+        if (importCounts) importCounts[importIndex]++;
+        return original(a);
+      };
+      continue;
     }
 
     // Wrap host imports with recursion depth guard + exception capture for catch_all.

--- a/tests/issue-3780-fast-leaf-host-imports.test.ts
+++ b/tests/issue-3780-fast-leaf-host-imports.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { ImportDescriptor } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const manifest: ImportDescriptor[] = [
+  {
+    module: "env",
+    name: "__get_undefined",
+    kind: "func",
+    intent: { type: "builtin", name: "__get_undefined" },
+    paramCount: 0,
+  },
+  {
+    module: "env",
+    name: "__box_number",
+    kind: "func",
+    intent: { type: "box", targetType: "number" },
+    paramCount: 1,
+  },
+  {
+    module: "env",
+    name: "__box_boolean",
+    kind: "func",
+    intent: { type: "box", targetType: "boolean" },
+    paramCount: 1,
+  },
+  {
+    module: "env",
+    name: "__typeof_number",
+    kind: "func",
+    intent: { type: "typeof_check", targetType: "number" },
+    paramCount: 1,
+  },
+  {
+    module: "env",
+    name: "__is_truthy",
+    kind: "func",
+    intent: { type: "truthy_check" },
+    paramCount: 1,
+  },
+];
+
+const previousSwitch = process.env.JS2WASM_FAST_LEAF_HOST_IMPORTS;
+
+afterEach(() => {
+  if (previousSwitch === undefined) {
+    Reflect.deleteProperty(process.env, "JS2WASM_FAST_LEAF_HOST_IMPORTS");
+  } else {
+    process.env.JS2WASM_FAST_LEAF_HOST_IMPORTS = previousSwitch;
+  }
+});
+
+function exercise(flag: "0" | "1") {
+  process.env.JS2WASM_FAST_LEAF_HOST_IMPORTS = flag;
+  const imports = buildImports(manifest);
+  expect(imports.env.__get_undefined.length).toBe(0);
+  expect(imports.env.__box_number.length).toBe(1);
+  expect(imports.env.__box_boolean.length).toBe(1);
+  expect(imports.env.__typeof_number.length).toBe(1);
+  expect(imports.env.__is_truthy.length).toBe(1);
+
+  imports.startImportCounting?.();
+  const values = {
+    undefined: imports.env.__get_undefined(),
+    number: imports.env.__box_number(42.5),
+    booleanFalse: imports.env.__box_boolean(0),
+    booleanTrue: imports.env.__box_boolean(2),
+    typeofNumber: imports.env.__typeof_number(42),
+    typeofString: imports.env.__typeof_number("42"),
+    falsy: imports.env.__is_truthy(0),
+    truthy: imports.env.__is_truthy("x"),
+  };
+  return { values, counts: imports.takeImportCounts?.() };
+}
+
+describe("#3780 non-throwing leaf host imports", () => {
+  it("keeps values, fixed arities, and import diagnostics on the fast wrappers", () => {
+    expect(exercise("1")).toEqual({
+      values: {
+        undefined: undefined,
+        number: 42.5,
+        booleanFalse: false,
+        booleanTrue: true,
+        typeofNumber: 1,
+        typeofString: 0,
+        falsy: 0,
+        truthy: 1,
+      },
+      counts: {
+        __get_undefined: 1,
+        __box_number: 1,
+        __box_boolean: 2,
+        __typeof_number: 2,
+        __is_truthy: 2,
+      },
+    });
+  });
+
+  it("matches the generic guarded-wrapper kill switch", () => {
+    expect(exercise("1")).toEqual(exercise("0"));
+  });
+});


### PR DESCRIPTION
## Summary

- bypass the generic recursion-depth and exception wrapper for closed host-import intents that provably cannot throw, invoke user code, or re-enter Wasm
- keep fixed Wasm signature arity and import-count diagnostics in the fast wrappers
- add a rollout kill switch, focused runtime parity coverage, and the complete measurement record to plan issue 3780

## Why

Acorn's runtime-dynamic JS-host parse makes 15,065,637 Wasm-to-JavaScript calls. Safe leaf operations such as `__get_undefined`, `typeof`, ToBoolean, and number/boolean boxing account for 5,702,030 calls (37.85%). They were paying recursion and `try`/`catch`/`finally` bookkeeping whose observable cases cannot occur for these intents.

The safety predicate uses the closed import intent rather than trusting the import name. General host operations retain the existing guarded wrapper unchanged. Set `JS2WASM_FAST_LEAF_HOST_IMPORTS=0` to restore the prior path.

## Performance

Exact fresh-process A/B on base `517aa2d0debef17373eeadf36d42a775e4c6ddce`:

| Runtime | Median | Mean |
| --- | ---: | ---: |
| guarded base | 1,618,772.167 us | 1,692,400.771 us |
| leaf wrappers | 1,478,630.521 us | 1,554,253.896 us |
| improvement | **1.095x / 8.66% less time** | **1.089x / 8.16% less time** |

Protocol: one identical prebuilt artifact, fresh Node/tsx process per sample, one warm-up parse plus one measured parse, eight alternating-order pairs, and checksum 422 in every sample. The rebuilt base and candidate artifact is byte-identical at 347,063 bytes with SHA-256 `3b256b8f371f9f05aa9c9d7af84920058ed736567dacf5521f1992a2400002c0`.

This reduces wrapper cost without reducing boundary count. Acorn remains slower than native Node; the remaining gap is dominated by generic compare/equality, numeric coercion, and extern property operations.

## Correctness

- normal source returns checksum 422 in every A/B sample and the official nine-round harness
- source changed only after Wasm compilation returns checksum 423, proving the runtime input is still parsed
- compiler binary and metadata SHA are identical because this is runtime-only
- focused tests cover values, wrapper arity, import diagnostics, and kill-switch parity

## Validation

- `pnpm exec vitest run tests/issue-3780-fast-leaf-host-imports.test.ts tests/host-import-wrapper-arity.test.ts tests/issue-737.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot`
- `pnpm run benchmark:acorn:js-host`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- pre-push oracle/coercion ratchets, issue integrity, and `tests/issue-3765-numeric-locals.test.ts`

Refs #3780.
