### PR TITLE
perf(strings): inline constant-needle indexOf scans

### DIFF
--- a/src/codegen/static-needle-indexof.ts
+++ b/src/codegen/static-needle-indexof.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { Instr } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { flatStringType } from "./native-strings.js";
+import { emitFlattenWithInlineFlatFastPath } from "./string-materialize.js";
+
+interface StaticNeedleIndexOfInputs {
+  ctx: CodegenContext;
+  fctx: FunctionContext;
+  expr: ts.CallExpression;
+  receiverOverridePresent: boolean;
+  emit: readonly [
+    compileReceiverToLocal: (name: string) => number,
+    compileStringValueToLocal: (value: ts.Expression | undefined, fallback: string, name: string) => number,
+    compileIntegerValueToLocal: (value: ts.Expression | undefined, fallback: number, name: string) => number,
+  ];
+}
+
+/**
+ * Resolve only a literal or an immutable chain of `const` aliases to one exact
+ * string. This is deliberately narrower than the table-value oracle: an
+ * element access can enumerate possible values, but cannot prove which value a
+ * dynamic index produces. Fixed-needle search needs one exact value.
+ */
+function staticConstStringLiteralAlias(
+  ctx: CodegenContext,
+  expression: ts.Expression,
+  seen = new Set<ts.Node>(),
+): string | undefined {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+  if (ts.isStringLiteralLike(current)) return current.text;
+  if (!ts.isIdentifier(current)) return undefined;
+  if (seen.has(current)) return undefined;
+  seen.add(current);
+  const initializer = ctx.oracle.constInitializerOf(current);
+  return initializer ? staticConstStringLiteralAlias(ctx, initializer, seen) : undefined;
+}
+
+/**
+ * Inline `indexOf` for a short, compile-time-proven needle. V8's optimized
+ * string search embeds constant code units and removes the generic inner
+ * needle loop. For 2..8 UTF-16 code units, emitting the same fixed compare
+ * shape is small enough to win without unbounded code growth.
+ *
+ * Evaluation order is unchanged: receiver, search value, then position are
+ * each evaluated exactly once. Reading the search descriptor keeps TDZ/null
+ * traps observable even though the proven code units drive the scan. Dynamic
+ * values, mutable aliases, tables, long needles, and reflective receivers
+ * retain the generic helper path.
+ */
+export function tryEmitStaticNeedleIndexOf(inputs: StaticNeedleIndexOfInputs): boolean {
+  const { ctx, fctx, expr, receiverOverridePresent } = inputs;
+  const [compileReceiverToLocal, compileStringValueToLocal, compileIntegerValueToLocal] = inputs.emit;
+  if (receiverOverridePresent || expr.arguments.length < 1 || expr.arguments.length > 2) return false;
+  if (typeof process !== "undefined" && process.env.JS2WASM_NATIVE_CONST_NEEDLE_INDEXOF === "0") return false;
+  const needle = staticConstStringLiteralAlias(ctx, expr.arguments[0]!);
+  if (needle === undefined || needle.length < 2 || needle.length > 8) return false;
+
+  const receiverLocal = compileReceiverToLocal("__str_indexOf_const_recv");
+  const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_indexOf_const_search");
+  const fromLocal = compileIntegerValueToLocal(expr.arguments[1], 0, "__str_indexOf_const_from");
+
+  // Preserve the proven alias read (and its possible null/TDZ trap) even
+  // though the scan embeds its immutable code units.
+  fctx.body.push({ op: "local.get", index: searchLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "drop" });
+
+  const flatLocal = allocLocal(fctx, `__str_indexOf_const_flat_${fctx.locals.length}`, flatStringType(ctx));
+  const lenLocal = allocLocal(fctx, `__str_indexOf_const_len_${fctx.locals.length}`, { kind: "i32" });
+  const dataLocal = allocLocal(fctx, `__str_indexOf_const_data_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: ctx.nativeStrDataTypeIdx,
+  });
+  const offLocal = allocLocal(fctx, `__str_indexOf_const_off_${fctx.locals.length}`, { kind: "i32" });
+  const lastLocal = allocLocal(fctx, `__str_indexOf_const_last_${fctx.locals.length}`, { kind: "i32" });
+  const indexLocal = allocLocal(fctx, `__str_indexOf_const_i_${fctx.locals.length}`, { kind: "i32" });
+  const resultLocal = allocLocal(fctx, `__str_indexOf_const_result_${fctx.locals.length}`, { kind: "i32" });
+
+  fctx.body.push({ op: "local.get", index: receiverLocal });
+  emitFlattenWithInlineFlatFastPath(ctx, fctx, ctx.nativeStrHelpers.get("__str_flatten")!);
+  fctx.body.push({ op: "local.set", index: flatLocal });
+
+  fctx.body.push({ op: "local.get", index: flatLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "local.set", index: lenLocal });
+  fctx.body.push({ op: "local.get", index: flatLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 2 });
+  fctx.body.push({ op: "local.set", index: dataLocal });
+  fctx.body.push({ op: "local.get", index: flatLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 1 });
+  fctx.body.push({ op: "local.set", index: offLocal });
+
+  fctx.body.push({ op: "local.get", index: lenLocal });
+  fctx.body.push({ op: "i32.const", value: needle.length });
+  fctx.body.push({ op: "i32.sub" });
+  fctx.body.push({ op: "local.set", index: lastLocal });
+
+  // i = max(ToIntegerOrInfinity(fromIndex), 0)
+  fctx.body.push({ op: "local.get", index: fromLocal });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.get", index: fromLocal });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "i32.gt_s" });
+  fctx.body.push({ op: "select" });
+  fctx.body.push({ op: "local.set", index: indexLocal });
+  fctx.body.push({ op: "i32.const", value: -1 });
+  fctx.body.push({ op: "local.set", index: resultLocal });
+
+  const comparisons: Instr[] = [];
+  for (let offset = 0; offset < needle.length; offset++) {
+    comparisons.push(
+      { op: "local.get", index: dataLocal },
+      { op: "local.get", index: offLocal },
+      { op: "local.get", index: indexLocal },
+      { op: "i32.add" },
+    );
+    if (offset !== 0) comparisons.push({ op: "i32.const", value: offset }, { op: "i32.add" });
+    comparisons.push(
+      { op: "array.get_u", typeIdx: ctx.nativeStrDataTypeIdx },
+      { op: "i32.const", value: needle.charCodeAt(offset) },
+      { op: "i32.ne" },
+      { op: "br_if", depth: 0 },
+    );
+  }
+  comparisons.push(
+    { op: "local.get", index: indexLocal },
+    { op: "local.set", index: resultLocal },
+    { op: "br", depth: 2 },
+  );
+
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [
+      {
+        op: "loop",
+        blockType: { kind: "empty" },
+        body: [
+          { op: "local.get", index: indexLocal },
+          { op: "local.get", index: lastLocal },
+          { op: "i32.gt_s" },
+          { op: "br_if", depth: 1 },
+          { op: "block", blockType: { kind: "empty" }, body: comparisons },
+          { op: "local.get", index: indexLocal },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          { op: "local.set", index: indexLocal },
+          { op: "br", depth: 0 },
+        ],
+      },
+    ],
+  });
+  fctx.body.push({ op: "local.get", index: resultLocal });
+  return true;
+}

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -45,6 +45,7 @@ import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./re
 import { staticConstStringValues } from "./analysis/static-string-values.js";
 import { staticIntegerRange } from "./analysis/static-numeric-range.js";
 import { tryEmitStaticI32Expression } from "./i32-static-range-expr.js";
+import { tryEmitStaticNeedleIndexOf } from "./static-needle-indexof.js";
 import {
   getArrTypeIdxFromVec,
   getOrRegisterRefCellType,
@@ -2549,14 +2550,8 @@ export function compileNativeStringMethodCall(
     fctx.body.push({ op: "local.set", index: local });
     return local;
   };
-  // (#2160 wrapper-strmethod) Compile the RECEIVER into a native-string local
-  // honoring `receiverOverride`. The two-string-argument arms (indexOf /
-  // lastIndexOf / includes / startsWith / endsWith) store the receiver in a
-  // local before pushing args, so they cannot use `emitReceiver()` inline; they
-  // previously called `compileStringValueToLocal(propAccess.expression, …)`,
-  // which ignores the override and re-compiles the raw receiver expression — a
-  // trap for a `new String(x)` wrapper (the override extracts its primitive
-  // slot). Route the receiver through `emitReceiver()` so the override applies.
+  // Store two-string method receivers once and honor the wrapper-method
+  // override; recompiling the raw receiver would lose `new String(x)`'s slot.
   const compileReceiverToLocal = (name: string): number => {
     const local = allocLocal(fctx, `${name}_${fctx.locals.length}`, nativeStringType(ctx));
     emitReceiver();
@@ -2580,12 +2575,8 @@ export function compileNativeStringMethodCall(
     }
   }
 
-  // An immutable literal table sometimes feeds a string predicate whose
-  // result is identical for every entry. Preserve the receiver read/trap, but
-  // skip flattening and scanning when the full result is known. This is a
-  // narrow source-level constant propagation, not a benchmark-name special
-  // case: mutations, aliases, dynamic search values, and dynamic positions all
-  // retain the ordinary native helper path.
+  // Fold an immutable literal table only when every entry has the same result;
+  // mutations, aliases, and dynamic search/position values keep the helper.
   if (
     !receiverOverride &&
     (method === "startsWith" || method === "endsWith") &&
@@ -2980,9 +2971,18 @@ export function compileNativeStringMethodCall(
     fctx.body.push({ op: "call", funcIdx });
     return nativeStringType(ctx);
   }
-
-  // indexOf: native helper
   if (method === "indexOf") {
+    if (
+      tryEmitStaticNeedleIndexOf({
+        ctx,
+        fctx,
+        expr,
+        receiverOverridePresent: receiverOverride !== undefined,
+        emit: [compileReceiverToLocal, compileStringValueToLocal, compileIntegerValueToLocal],
+      })
+    ) {
+      return { kind: "i32" };
+    }
     const receiverLocal = compileReceiverToLocal("__str_indexOf_recv");
     const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_indexOf_search");
     const fromLocal = compileIntegerValueToLocal(expr.arguments[1], 0, "__str_indexOf_from");

--- a/tests/native-constant-indexof.test.ts
+++ b/tests/native-constant-indexof.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const KILL_SWITCH = "JS2WASM_NATIVE_CONST_NEEDLE_INDEXOF";
+const savedKillSwitch = process.env[KILL_SWITCH];
+
+afterEach(() => {
+  if (savedKillSwitch === undefined) delete process.env[KILL_SWITCH];
+  else process.env[KILL_SWITCH] = savedKillSwitch;
+});
+
+async function compileGc(source: string) {
+  const result = await compile(source, {
+    fast: true,
+    experimentalIR: false,
+    optimize: 4,
+    emitWat: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  return result;
+}
+
+async function runGc(source: string, ...args: number[]): Promise<number> {
+  const result = await compileGc(source);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  return (instance.exports.test as (...values: number[]) => number)(...args);
+}
+
+describe("native constant-needle indexOf", () => {
+  it("finds and misses a short const-alias needle from dynamic receivers and positions", async () => {
+    const source = `
+      export function test(which: number, from: number): number {
+        const texts: string[] = ["xxjumpyy", "no match", "jump", "jumpjump"];
+        const text = texts[which];
+        const needle = "jump";
+        return text.indexOf(needle, from);
+      }
+    `;
+    expect(await runGc(source, 0, 0)).toBe(2);
+    expect(await runGc(source, 1, 0)).toBe(-1);
+    expect(await runGc(source, 2, -20)).toBe(0);
+    expect(await runGc(source, 3, 1)).toBe(4);
+    expect(await runGc(source, 3, 20)).toBe(-1);
+  });
+
+  it("compares UTF-16 code units and flattens rope receivers", async () => {
+    const source = `
+      export function test(count: number): number {
+        let text = "head";
+        for (let i = 0; i < count; i = i + 1) text = text + "x";
+        text = text + "💡tail";
+        const needle = "💡";
+        return text.indexOf(needle);
+      }
+    `;
+    expect(await runGc(source, 0)).toBe(4);
+    expect(await runGc(source, 1)).toBe(5);
+    expect(await runGc(source, 7)).toBe(11);
+  });
+
+  it("emits the fixed compare shape by default and the generic helper with the kill switch", async () => {
+    const source = `
+      export function test(text: string): number {
+        const alias1 = "needle";
+        const alias2 = alias1;
+        return text.indexOf(alias2);
+      }
+    `;
+    delete process.env[KILL_SWITCH];
+    const enabled = await compileGc(source);
+    expect(enabled.wat).toContain("__str_indexOf_const_result");
+
+    process.env[KILL_SWITCH] = "0";
+    const disabled = await compileGc(source);
+    expect(disabled.wat).not.toContain("__str_indexOf_const_result");
+    expect(disabled.wat).toMatch(/call \$__str_indexOf|call \d+/);
+  });
+
+  it("declines mutable, table-selected, one-unit, and long needles", async () => {
+    const sources = [
+      `export function test(text: string, choose: number): number {
+         let needle = "jump";
+         if (choose) needle = "none";
+         return text.indexOf(needle);
+       }`,
+      `export function test(text: string, choose: number): number {
+         const needles = ["jump", "none"];
+         return text.indexOf(needles[choose]);
+       }`,
+      `export function test(text: string): number { return text.indexOf("x"); }`,
+      `export function test(text: string): number { return text.indexOf("123456789"); }`,
+    ];
+    delete process.env[KILL_SWITCH];
+    for (const source of sources) {
+      const result = await compileGc(source);
+      expect(result.wat).not.toContain("__str_indexOf_const_result");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- specialize native `String#indexOf` when the needle is a proven immutable 2–8 code-unit literal/const-alias
- emit a fixed UTF-16 comparison scan so Cranelift can see constant code units instead of compiling the generic nested needle loop
- preserve receiver/search/position evaluation order and observable descriptor traps
- conservatively retain the generic helper for mutable aliases, dynamic tables, reflective receivers, and needles outside the bounded size range
- add the default-on rollback switch `JS2WASM_NATIVE_CONST_NEEDLE_INDEXOF=0`

## Why

V8's optimized `mixed/text-search` function embeds the literal `jump` and uses a fixed search shape. The shipped GC-native module still called the generic `indexOf` helper, including its inner needle loop and descriptor path. The specialized Wasm now embeds code units `106, 117, 109, 112`; its Cranelift body drops from 953 to 865 lines and the benchmark module shrinks from 4,060 to 4,011 bytes.

## Performance

Exact official `runSuite("mixed", [textSearch], ["gc-native"])` harness, five alternating process pairs, checksum validation enabled:

| Revision | SHA | Median | ns/op |
| --- | --- | ---: | ---: |
| current `origin/main` | `d8cb67b5fd8e28d2956d3a196c0e2f2c643ef547` | 0.233089 ms | 5.827 |
| candidate | `8bc9fe00ddb9c669341139537ef445051a8a6261` | 0.174646 ms | 4.366 |

That is a **25.1% GC-native speedup**.

Three matched candidate runs of the official JS and GC-native lanes produced median-of-run medians of 0.259843 ms for Node/V8 and 0.189495 ms for GC-native: **GC-native is 27.1% faster than Node** on this lane.

Positive scaling check: doubling the benchmark work doubled the checksum from 235,000 to 470,000 and runtime scaled 2.009× (4.381 vs 4.401 ns/op), ruling out folded-away work.

## Validation

- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:codegen-fallbacks`
- `pnpm run check:stack-balance`
- `pnpm run check:func-budget`
- `pnpm run check:coercion-sites`
- `pnpm run check:loc-budget`
- `pnpm run check:oracle-ratchet`
- `pnpm exec vitest run tests/native-constant-indexof.test.ts` (4/4)
- `pnpm exec vitest run tests/equivalence/string-methods.test.ts` (42/42)
- pre-commit and pre-push hooks
