### PR TITLE
perf(strings): scalarize proven ASCII case conversions

### DIFF
--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -804,10 +804,10 @@ export interface FunctionContext {
   derivedStringArrayLengthLocals?: Map<ts.Symbol, number>;
   /** Static split arrays whose identity and elements are observed only by proven nested length reads. */
   derivedStaticSplitArrays?: Map<ts.Symbol, { length: number }>;
-  /** Scalar descriptors for const substring results with no identity escape. */
+  /** Scalar descriptors for const derived strings with no identity escape. */
   derivedSubstringReads?: Map<
-    ts.Symbol,
-    | { kind: "native"; dataLocal: number; offLocal: number; lenLocal: number; minLen: number }
+    ts.Declaration,
+    | { kind: "native" | "lower" | "upper"; dataLocal: number; offLocal: number; lenLocal: number; minLen: number }
     | { kind: "host"; receiverLocal: number; offLocal: number; lenLocal: number; minLen: number }
   >;
   /**

--- a/src/codegen/derived-ascii-case.ts
+++ b/src/codegen/derived-ascii-case.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Escape analysis and scalar projection for proven-ASCII case conversions.
+ *
+ * A const `toLowerCase()` / `toUpperCase()` result observed only through
+ * `.length` and `.charCodeAt()` does not need an allocated backing array. When
+ * the receiver can only be immutable ASCII literals, retain its flat
+ * (data, offset, length) descriptor and apply the one-code-unit case mapping
+ * at each character projection instead.
+ */
+import { forEachChild, ts } from "../ts-api.js";
+import type { Instr } from "../ir/types.js";
+import { staticConstStringValues } from "./analysis/static-string-values.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { ensureNativeStringHelpers, flatStringType } from "./native-strings.js";
+import { coerceType, compileExpression } from "./shared.js";
+import { emitTdzInit } from "./statements/tdz.js";
+
+export function tryCompileDerivedAsciiCaseBinding(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  stmt: ts.VariableStatement,
+  decl: ts.VariableDeclaration,
+): boolean {
+  if (
+    process.env.JS2WASM_NATIVE_ASCII_CASE_SCALAR === "0" ||
+    !ctx.nativeStrings ||
+    !(stmt.declarationList.flags & ts.NodeFlags.Const) ||
+    !ts.isIdentifier(decl.name) ||
+    !decl.initializer ||
+    !ts.isCallExpression(decl.initializer)
+  ) {
+    return false;
+  }
+  const call = decl.initializer;
+  if (
+    !ts.isPropertyAccessExpression(call.expression) ||
+    (call.expression.name.text !== "toLowerCase" && call.expression.name.text !== "toUpperCase") ||
+    call.arguments.length !== 0
+  ) {
+    return false;
+  }
+  ensureNativeStringHelpers(ctx);
+  if (ctx.nativeStrTypeIdx < 0 || ctx.nativeStrDataTypeIdx < 0) return false;
+  const receiver = call.expression.expression;
+  const receiverValues = staticConstStringValues(ctx, receiver);
+  if (!receiverValues?.length || !receiverValues.every(isAscii)) return false;
+
+  if (!caseResultHasDescriptorOnlyUses(ctx, decl)) return false;
+
+  const flatLocal = allocLocal(fctx, `__ascii_case_flat_${fctx.locals.length}`, flatStringType(ctx));
+  const receiverType = compileExpression(ctx, fctx, receiver);
+  if (receiverType?.kind === "externref" || receiverType?.kind === "ref_extern") {
+    coerceType(ctx, fctx, receiverType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+  }
+  // The immutable-literal proof excludes cons-string producers. The cast also
+  // preserves the ordinary null/OOB trap of evaluating the source expression.
+  fctx.body.push({ op: "ref.cast", typeIdx: ctx.nativeStrTypeIdx });
+  fctx.body.push({ op: "local.set", index: flatLocal });
+
+  const dataLocal = allocLocal(fctx, `__ascii_case_data_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: ctx.nativeStrDataTypeIdx,
+  });
+  const offLocal = allocLocal(fctx, `__ascii_case_off_${fctx.locals.length}`, { kind: "i32" });
+  const lenLocal = allocLocal(fctx, `__ascii_case_len_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push(
+    { op: "local.get", index: flatLocal },
+    { op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 2 },
+    { op: "local.set", index: dataLocal },
+    { op: "local.get", index: flatLocal },
+    { op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 1 },
+    { op: "local.set", index: offLocal },
+    { op: "local.get", index: flatLocal },
+    { op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 0 },
+    { op: "local.set", index: lenLocal },
+  );
+  (fctx.derivedSubstringReads ??= new Map()).set(decl, {
+    kind: call.expression.name.text === "toLowerCase" ? "lower" : "upper",
+    dataLocal,
+    offLocal,
+    lenLocal,
+    minLen: Math.min(...receiverValues.map((value) => value.length)),
+  });
+  emitTdzInit(ctx, fctx, decl.name.text);
+  return true;
+}
+
+export function emitDerivedNativeCharCodeRead(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  descriptor: { kind: "native" | "lower" | "upper"; dataLocal: number; offLocal: number },
+  idxLocal: number,
+): Instr[] {
+  const read: Instr[] = [
+    { op: "local.get", index: descriptor.dataLocal },
+    { op: "local.get", index: descriptor.offLocal },
+    { op: "local.get", index: idxLocal },
+    { op: "i32.add" },
+    { op: "array.get_u", typeIdx: ctx.nativeStrDataTypeIdx },
+  ];
+  if (descriptor.kind !== "native") {
+    const charLocal = allocLocal(fctx, `__ascii_case_char_${fctx.locals.length}`, { kind: "i32" });
+    const lo = descriptor.kind === "lower" ? 65 : 97;
+    const delta = descriptor.kind === "lower" ? 32 : -32;
+    read.push(
+      { op: "local.tee", index: charLocal },
+      { op: "i32.const", value: lo },
+      { op: "i32.sub" },
+      { op: "i32.const", value: 25 },
+      { op: "i32.le_u" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [{ op: "local.get", index: charLocal }, { op: "i32.const", value: delta }, { op: "i32.add" }],
+        else: [{ op: "local.get", index: charLocal }],
+      },
+    );
+  }
+  read.push({ op: "f64.convert_i32_u" });
+  return read;
+}
+
+export function selectProvenAsciiCaseHelper(
+  ctx: CodegenContext,
+  receiver: ts.Expression,
+  fallback: string,
+  proofAllowed: boolean,
+): string {
+  const values =
+    proofAllowed && process.env.JS2WASM_NATIVE_PROVEN_ASCII_CASE !== "0"
+      ? staticConstStringValues(ctx, receiver)
+      : undefined;
+  return values?.length && values.every(isAscii) ? `${fallback}_ascii` : fallback;
+}
+
+function isAscii(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) >= 0x80) return false;
+  }
+  return true;
+}
+
+function caseResultHasDescriptorOnlyUses(ctx: CodegenContext, declaration: ts.VariableDeclaration): boolean {
+  let safe = true;
+  let scope: ts.Node = declaration;
+  while (scope.parent && !ts.isFunctionLike(scope.parent) && !ts.isSourceFile(scope.parent)) scope = scope.parent;
+  scope = scope.parent ?? scope;
+  const visit = (node: ts.Node): void => {
+    if (!safe) return;
+    if (node !== scope && ts.isFunctionLike(node)) {
+      let captured = false;
+      const findCapture = (child: ts.Node): void => {
+        if (captured) return;
+        if (ts.isIdentifier(child) && ctx.oracle.valueDeclarationOf(child) === declaration) captured = true;
+        else forEachChild(child, findCapture);
+      };
+      forEachChild(node, findCapture);
+      if (captured) safe = false;
+      return;
+    }
+    if (ts.isIdentifier(node) && ctx.oracle.valueDeclarationOf(node) === declaration) {
+      if (node === declaration.name) return;
+      const property = node.parent;
+      if (!ts.isPropertyAccessExpression(property) || property.expression !== node) {
+        safe = false;
+        return;
+      }
+      if (property.name.text === "length") {
+        const use = property.parent;
+        if (
+          (ts.isBinaryExpression(use) &&
+            use.left === property &&
+            use.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+            use.operatorToken.kind <= ts.SyntaxKind.LastAssignment) ||
+          ((ts.isPrefixUnaryExpression(use) || ts.isPostfixUnaryExpression(use)) && use.operand === property) ||
+          (ts.isDeleteExpression(use) && use.expression === property)
+        ) {
+          safe = false;
+          return;
+        }
+      } else if (
+        property.name.text !== "charCodeAt" ||
+        !ts.isCallExpression(property.parent) ||
+        property.parent.expression !== property ||
+        property.parent.arguments.length > 1
+      ) {
+        safe = false;
+        return;
+      }
+    }
+    forEachChild(node, visit);
+  };
+  visit(scope);
+  return safe;
+}

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -423,8 +423,8 @@ function tryCompileDerivedHostSubstringCharCodeAt(
   method: string,
 ): ValType | null {
   if (ctx.nativeStrings || method !== "charCodeAt" || !ts.isIdentifier(propAccess.expression)) return null;
-  const symbol = ctx.checker.getSymbolAtLocation(propAccess.expression);
-  const substring = symbol ? fctx.derivedSubstringReads?.get(symbol) : undefined;
+  const declaration = ctx.oracle.valueDeclarationOf(propAccess.expression);
+  const substring = declaration ? fctx.derivedSubstringReads?.get(declaration) : undefined;
   const charCodeAtIdx = ctx.jsStringImports.get("charCodeAt");
   if (substring?.kind !== "host" || charCodeAtIdx === undefined) return null;
 
@@ -436,7 +436,7 @@ function tryCompileDerivedHostSubstringCharCodeAt(
     ts.isPropertyAccessExpression(arg.left) &&
     arg.left.name.text === "length" &&
     ts.isIdentifier(arg.left.expression) &&
-    ctx.checker.getSymbolAtLocation(arg.left.expression) === symbol &&
+    ctx.oracle.valueDeclarationOf(arg.left.expression) === declaration &&
     ts.isNumericLiteral(arg.right) &&
     Number(arg.right.text) === 1;
   const indexLocal = allocLocal(fctx, `__host_substring_char_idx_${fctx.locals.length}`, { kind: "i32" });

--- a/src/codegen/native-strings-transform.ts
+++ b/src/codegen/native-strings-transform.ts
@@ -40,6 +40,11 @@ export function emitStrCaseHelpers(shared: NativeStrShared): void {
     const typeIdx = addFuncType(ctx, [strRef], [strRef]);
     const funcIdx = mintDefinedFunc(ctx);
     ctx.nativeStrHelpers.set("__str_toLowerCase", funcIdx);
+    // Retain an explicit handle after the public name is re-pointed at the
+    // full-Unicode helper below. Proven-ASCII call sites can safely use this
+    // compact implementation without paying for the Unicode bail-out path.
+    ctx.nativeStrHelpers.set("__str_toLowerCase_ascii", funcIdx);
+    ctx.funcMap.set("__str_toLowerCase_ascii", funcIdx);
 
     // params: s(0)
     // locals: len(1), srcData(2), newArr(3), i(4), ch(5), sOff(6)
@@ -95,11 +100,9 @@ export function emitStrCaseHelpers(shared: NativeStrShared): void {
               { op: "local.get", index: 4 },
               { op: "local.get", index: 5 },
               { op: "i32.const", value: 65 },
-              { op: "i32.ge_u" },
-              { op: "local.get", index: 5 },
-              { op: "i32.const", value: 90 },
+              { op: "i32.sub" },
+              { op: "i32.const", value: 25 },
               { op: "i32.le_u" },
-              { op: "i32.and" },
               {
                 op: "if",
                 blockType: { kind: "val", type: { kind: "i32" } },
@@ -127,7 +130,7 @@ export function emitStrCaseHelpers(shared: NativeStrShared): void {
     ];
 
     pushDefinedFunc(ctx, funcIdx, {
-      name: "__str_toLowerCase",
+      name: "__str_toLowerCase_ascii",
       typeIdx,
       locals: [
         { name: "len", type: { kind: "i32" } },
@@ -148,6 +151,8 @@ export function emitStrCaseHelpers(shared: NativeStrShared): void {
     const typeIdx = addFuncType(ctx, [strRef], [strRef]);
     const funcIdx = mintDefinedFunc(ctx);
     ctx.nativeStrHelpers.set("__str_toUpperCase", funcIdx);
+    ctx.nativeStrHelpers.set("__str_toUpperCase_ascii", funcIdx);
+    ctx.funcMap.set("__str_toUpperCase_ascii", funcIdx);
 
     // params: s(0)
     // locals: len(1), srcData(2), newArr(3), i(4), ch(5), sOff(6)
@@ -203,11 +208,9 @@ export function emitStrCaseHelpers(shared: NativeStrShared): void {
               { op: "local.get", index: 4 },
               { op: "local.get", index: 5 },
               { op: "i32.const", value: 97 },
-              { op: "i32.ge_u" },
-              { op: "local.get", index: 5 },
-              { op: "i32.const", value: 122 },
+              { op: "i32.sub" },
+              { op: "i32.const", value: 25 },
               { op: "i32.le_u" },
-              { op: "i32.and" },
               {
                 op: "if",
                 blockType: { kind: "val", type: { kind: "i32" } },
@@ -235,7 +238,7 @@ export function emitStrCaseHelpers(shared: NativeStrShared): void {
     ];
 
     pushDefinedFunc(ctx, funcIdx, {
-      name: "__str_toUpperCase",
+      name: "__str_toUpperCase_ascii",
       typeIdx,
       locals: [
         { name: "len", type: { kind: "i32" } },

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -2260,7 +2260,7 @@ export function tryLengthAndNameReads(
 ): PADispatchResult {
   if (propName === "length" && ts.isIdentifier(expr.expression)) {
     const symbol = ctx.checker.getSymbolAtLocation(expr.expression);
-    const substring = symbol ? fctx.derivedSubstringReads?.get(symbol) : undefined;
+    const substring = symbol?.valueDeclaration ? fctx.derivedSubstringReads?.get(symbol.valueDeclaration) : undefined;
     if (substring !== undefined) {
       fctx.body.push({ op: "local.get", index: substring.lenLocal });
       return { kind: "i32" };

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -41,6 +41,7 @@ import { bindingHasMixedAssignmentCarrier } from "../analysis/mixed-assignment-c
 import { staticConstStringValues } from "../analysis/static-string-values.js";
 import { staticIntegerRange } from "../analysis/static-numeric-range.js";
 import { tryEmitStaticI32Expression } from "../i32-static-range-expr.js";
+import { tryCompileDerivedAsciiCaseBinding as tryAsciiCase } from "../derived-ascii-case.js";
 
 function symbolIsReadOnlyThroughLength(
   ctx: CodegenContext,
@@ -386,8 +387,6 @@ function tryCompileDerivedSubstringBinding(
   if (!ts.isPropertyAccessExpression(call.expression) || call.expression.name.text !== "substring") return false;
   if (call.arguments.length !== 2) return false;
 
-  const symbol = ctx.checker.getSymbolAtLocation(decl.name);
-  if (!symbol) return false;
   let descriptorOnly = true;
   const scope = (() => {
     let node: ts.Node = decl;
@@ -396,7 +395,7 @@ function tryCompileDerivedSubstringBinding(
   })();
   const visit = (node: ts.Node): void => {
     if (!descriptorOnly) return;
-    if (ts.isIdentifier(node) && ctx.checker.getSymbolAtLocation(node) === symbol) {
+    if (ts.isIdentifier(node) && ctx.oracle.valueDeclarationOf(node) === decl) {
       if (node === decl.name) return;
       const property = node.parent;
       if (!ts.isPropertyAccessExpression(property) || property.expression !== node) {
@@ -462,7 +461,7 @@ function tryCompileDerivedSubstringBinding(
     fctx.body.push({ op: "local.get", index: startLocal });
     fctx.body.push({ op: "i32.sub" });
     fctx.body.push({ op: "local.set", index: lenLocal });
-    (fctx.derivedSubstringReads ??= new Map()).set(symbol, {
+    (fctx.derivedSubstringReads ??= new Map()).set(decl, {
       kind: "host",
       receiverLocal,
       offLocal: startLocal,
@@ -563,7 +562,7 @@ function tryCompileDerivedSubstringBinding(
   fctx.body.push({ op: "i32.sub" });
   fctx.body.push({ op: "local.set", index: lenLocal });
   const minLen = orderedInBounds ? endRange!.min - startRange!.max : 0;
-  (fctx.derivedSubstringReads ??= new Map()).set(symbol, {
+  (fctx.derivedSubstringReads ??= new Map()).set(decl, {
     kind: "native",
     dataLocal,
     offLocal,
@@ -1372,10 +1371,9 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
         }
       }
     }
-
     if (tryCompileUniformSplitLengthBinding(ctx, fctx, stmt, decl)) continue;
     if (tryCompileSingleUnitSplitLengthBinding(ctx, fctx, stmt, decl)) continue;
-    if (tryCompileDerivedSubstringBinding(ctx, fctx, stmt, decl)) continue;
+    if (tryAsciiCase(ctx, fctx, stmt, decl) || tryCompileDerivedSubstringBinding(ctx, fctx, stmt, decl)) continue;
     if (tryCompileUniformIndexPresenceBinding(ctx, fctx, stmt, decl)) continue;
 
     // #1210: string-builder rewrite for `let s = "";` followed by an

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -44,6 +44,7 @@ import { tryCompileStandaloneSplitSeparator, tryCompileStandaloneStringValueRepl
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
 import { staticConstStringValues } from "./analysis/static-string-values.js";
 import { staticIntegerRange } from "./analysis/static-numeric-range.js";
+import { emitDerivedNativeCharCodeRead, selectProvenAsciiCaseHelper } from "./derived-ascii-case.js";
 import { tryEmitStaticI32Expression } from "./i32-static-range-expr.js";
 import {
   getArrTypeIdxFromVec,
@@ -2637,9 +2638,9 @@ export function compileNativeStringMethodCall(
   // the resulting position is outside [0, string length).
   if (method === "charCodeAt") {
     if (!receiverOverride && ts.isIdentifier(propAccess.expression)) {
-      const symbol = ctx.checker.getSymbolAtLocation(propAccess.expression);
-      const substring = symbol ? fctx.derivedSubstringReads?.get(symbol) : undefined;
-      if (substring?.kind === "native") {
+      const declaration = ctx.oracle.valueDeclarationOf(propAccess.expression);
+      const substring = declaration ? fctx.derivedSubstringReads?.get(declaration) : undefined;
+      if (substring && substring.kind !== "host") {
         const idxLocal = allocLocal(fctx, `__substring_char_idx_${fctx.locals.length}`, { kind: "i32" });
         const arg = expr.arguments[0];
         const isLengthMinusOne =
@@ -2649,7 +2650,7 @@ export function compileNativeStringMethodCall(
           ts.isPropertyAccessExpression(arg.left) &&
           arg.left.name.text === "length" &&
           ts.isIdentifier(arg.left.expression) &&
-          ctx.checker.getSymbolAtLocation(arg.left.expression) === symbol &&
+          ctx.oracle.valueDeclarationOf(arg.left.expression) === declaration &&
           ts.isNumericLiteral(arg.right) &&
           Number(arg.right.text) === 1;
         if (isLengthMinusOne) {
@@ -2668,14 +2669,7 @@ export function compileNativeStringMethodCall(
         const provenInBounds =
           (range !== undefined && range.min >= 0 && range.max < substring.minLen) ||
           (isLengthMinusOne && substring.minLen > 0);
-        const read: Instr[] = [
-          { op: "local.get", index: substring.dataLocal },
-          { op: "local.get", index: substring.offLocal },
-          { op: "local.get", index: idxLocal },
-          { op: "i32.add" },
-          { op: "array.get_u", typeIdx: ctx.nativeStrDataTypeIdx },
-          { op: "f64.convert_i32_u" },
-        ];
+        const read = emitDerivedNativeCharCodeRead(ctx, fctx, substring, idxLocal);
         if (provenInBounds) {
           fctx.body.push(...read);
         } else {
@@ -3262,7 +3256,8 @@ export function compileNativeStringMethodCall(
       if (argType) fctx.body.push({ op: "drop" });
     }
     const helperName = `__str_${method.replace("Locale", "")}`;
-    const funcIdx = ctx.nativeStrHelpers.get(helperName)!;
+    const selectedHelper = selectProvenAsciiCaseHelper(ctx, propAccess.expression, helperName, !receiverOverride);
+    const funcIdx = ctx.nativeStrHelpers.get(selectedHelper)!;
     fctx.body.push({ op: "call", funcIdx });
     return nativeStringType(ctx);
   }

--- a/tests/string-derived-length-fast-path.test.ts
+++ b/tests/string-derived-length-fast-path.test.ts
@@ -73,6 +73,103 @@ describe("native string derived-length fast paths", () => {
     expect(mutated.value).toBe(2);
   });
 
+  it("scalar-replaces non-escaping ASCII case results", async () => {
+    const source = `
+        export function run(): number {
+          const values: string[] = ["Hello", "WORLD"];
+          let sum = 0;
+          for (let i = 0; i < 10; i = i + 1) {
+            const value = values[i % 2];
+            const lower = value.toLowerCase();
+            const upper = value.toUpperCase();
+            sum = sum + lower.charCodeAt(i % 5) + upper.charCodeAt(i % 5);
+          }
+          return sum;
+        }
+      `;
+    const proven = await compileAndRun(source);
+    const saved = process.env.JS2WASM_NATIVE_ASCII_CASE_SCALAR;
+    let unicode: Awaited<ReturnType<typeof compileAndRun>>;
+    try {
+      process.env.JS2WASM_NATIVE_ASCII_CASE_SCALAR = "0";
+      unicode = await compileAndRun(source);
+    } finally {
+      if (saved === undefined) Reflect.deleteProperty(process.env, "JS2WASM_NATIVE_ASCII_CASE_SCALAR");
+      else process.env.JS2WASM_NATIVE_ASCII_CASE_SCALAR = saved;
+    }
+    expect(proven.value).toBe(1848);
+    expect(unicode.value).toBe(proven.value);
+    expect(proven.runWat).not.toBe(unicode.runWat);
+    expect(proven.runWat.match(/\bcall\b/g)?.length ?? 0).toBeLessThan(unicode.runWat.match(/\bcall\b/g)?.length ?? 0);
+  });
+
+  it("routes escaping proven-ASCII results through compact helpers", async () => {
+    const source = `
+      export function run(): number {
+        const values: string[] = ["Hello", "WORLD"];
+        const upper = values[0].toUpperCase();
+        return upper === "HELLO" ? upper.length : 0;
+      }
+    `;
+    const proven = await compileAndRun(source);
+    const saved = process.env.JS2WASM_NATIVE_PROVEN_ASCII_CASE;
+    let unicode: Awaited<ReturnType<typeof compileAndRun>>;
+    try {
+      process.env.JS2WASM_NATIVE_PROVEN_ASCII_CASE = "0";
+      unicode = await compileAndRun(source);
+    } finally {
+      if (saved === undefined) Reflect.deleteProperty(process.env, "JS2WASM_NATIVE_PROVEN_ASCII_CASE");
+      else process.env.JS2WASM_NATIVE_PROVEN_ASCII_CASE = saved;
+    }
+    expect(proven.value).toBe(5);
+    expect(unicode.value).toBe(proven.value);
+    expect(proven.runWat).not.toBe(unicode.runWat);
+  });
+
+  it("keeps non-ASCII and mutable case receivers on Unicode helpers", async () => {
+    const nonAscii = await compileAndRun(
+      `
+        export function run(): number {
+          const values: string[] = ["éx"];
+          return values[0].toUpperCase().charCodeAt(0);
+        }
+      `,
+    );
+    expect(nonAscii.value).toBe("É".charCodeAt(0));
+    expect(nonAscii.runWat).not.toContain("call $__str_toUpperCase_ascii");
+
+    const mutable = await compileAndRun(`
+      export function run(): number {
+        const values: string[] = ["ascii"];
+        values[0] = "ß";
+        return values[0].toUpperCase().length;
+      }
+    `);
+    expect(mutable.value).toBe(2);
+  });
+
+  it("preserves ASCII case charCodeAt bounds and declines escaping results", async () => {
+    const bounded = await compileAndRun(`
+      export function run(): number {
+        const lower = "Ab".toLowerCase();
+        const inBounds = lower.charCodeAt(0);
+        const below = lower.charCodeAt(-1);
+        const above = lower.charCodeAt(2);
+        return inBounds + (below !== below ? 1 : 0) + (above !== above ? 1 : 0);
+      }
+    `);
+    expect(bounded.value).toBe("a".charCodeAt(0) + 2);
+
+    const escaped = await compileAndRun(`
+      export function run(): number {
+        const upper = "ab".toUpperCase();
+        function read(): number { return upper.charCodeAt(0); }
+        return upper === "AB" ? read() : 0;
+      }
+    `);
+    expect(escaped.value).toBe("A".charCodeAt(0));
+  });
+
   it("elides equal-literal replacement only without substitution tokens", async () => {
     const equal = await compileAndRun(`export function run(): number { return "a fox".replace("fox", "cat").length; }`);
     expect(equal.value).toBe(5);


### PR DESCRIPTION
## Summary

- scalar-replace non-escaping, immutable ASCII `toLowerCase()` / `toUpperCase()` results when consumers only read `.length` or `charCodeAt()`
- route escaping proven-ASCII conversions through compact one-code-unit helpers while retaining the full Unicode helper for every unproven receiver
- key derived-string descriptors by oracle-backed declarations, removing six direct checker accesses from the touched codegen surface
- conservatively decline mutable, aliased, captured, non-ASCII, identity-observed, and receiver-override cases

## Performance

Exact official harness, Node v24.4.1 on darwin arm64:

```text
node --import tsx benchmarks/run.ts --suite strings --filter case-convert --strategy js,gc-native
```

Control used the same candidate tree with both new paths disabled:

```text
JS2WASM_NATIVE_ASCII_CASE_SCALAR=0 JS2WASM_NATIVE_PROVEN_ASCII_CASE=0
```

- base: `d8cb67b5fd8e28d2956d3a196c0e2f2c643ef547`
- candidate: `6dac7440ae8dcc83a49ad162f0ca3f5fba363d78`

Three alternating same-tree pairs:

| lane | run 1 | run 2 | run 3 | median |
| --- | ---: | ---: | ---: | ---: |
| control gc-native | 47.634 µs | 67.418 µs | 50.399 µs | 50.399 µs |
| candidate gc-native | 3.824 µs | 3.472 µs | 3.854 µs | 3.824 µs |
| candidate-run JS | 26.912 µs | 31.426 µs | 42.678 µs | 31.426 µs |

That is a **13.18× speedup / 92.41% time reduction** versus the disabled-path control. The optimized gc-native lane is **8.22× faster than Node** at the medians. The emitted module shrinks from **13,338 to 2,126 bytes** (**84.06%**).

Positive control on optimization commit `0d0335e` (the same 2,126-byte case-convert output before the freshness-only main merge) doubled both source loops and `opsPerCall` from 2,000 to 4,000. Median gc-native call time rose from 4.154 to 5.953 µs (1.43×) while JS rose from 28.253 to 54.328 µs (1.92×); the tiny Wasm lane retains more fixed call overhead. Cross-lane result/checksum validation passed in every run.

No benchmark source or generated benchmark data is included in this PR.

## Safety

- full Unicode conversion remains the fallback for non-ASCII or unproven inputs
- case receivers are evaluated exactly once
- `charCodeAt()` negative/out-of-range NaN behavior and null/OOB traps are preserved
- nested closure capture, mutation, deletion, identity observation, and extra-argument cases decline scalar replacement
- emergency kill switches: `JS2WASM_NATIVE_ASCII_CASE_SCALAR=0` and `JS2WASM_NATIVE_PROVEN_ASCII_CASE=0`

## Validation

- `pnpm run typecheck`
- 16 derived-string fast-path tests
- 18 Unicode/string-case tests
- 92 native-string tests
- pre-commit and pre-push hooks
- oracle, LOC, function-size, coercion-site, IR fallback, codegen fallback, and stack-balance ratchets
- Prettier, Biome lint, and `git diff --check`
