### PR TITLE
perf(runtime): collapse fixed host method call crossings

### DIFF
--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -40,6 +40,7 @@ import { pushBody } from "../context/bodies.js";
 import { allocLocal } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { resolveReceiverStruct } from "../fnctor-escape-gate.js";
+import { tryEmitFixedHostMethodCall } from "../fixed-host-method-call.js";
 import { hostFnctorCallableFallbackImportName, reserveHostFnctorMethodDriver } from "../host-fnctor-method-driver.js";
 import { observeHostDynamicMethodCallArity } from "../dynamic-method-call-arity.js";
 import { effectiveLocalCarrier } from "../analysis/mixed-assignment-carrier.js";
@@ -3533,19 +3534,13 @@ export function compileReceiverMethodCall(
       }
 
       // (#799 WI3) Generic host-delegated method call for any/externref receivers.
-      // Builds a JS array of arguments and calls __extern_method_call(obj, methodName, args).
-      // (#965) For known built-in class identifiers (Object, Array, Proxy, etc.) that would
-      // otherwise compile to ref.null.extern, use __get_builtin to get the real JS object.
+      // #965: resolve known built-in receivers through __get_builtin rather than null.
       {
         observeHostDynamicMethodCallArity(ctx, expr.arguments);
-        // (#1888 Slice 2) Under --target standalone the native
-        // __extern_method_call reads its args via __extern_length /
-        // __extern_get_idx over a $ObjVec (no JS array exists). Build the args
-        // list with the native $ObjVec builders instead of the host
-        // __js_array_new / __js_array_push. JS-host / WASI keep the host
-        // imports unchanged (byte-for-byte). Per the #1472 S3 note, the
-        // __js_array_* builders are NOT globally safe to alias (real JS arrays
-        // elsewhere depend on them) — so this is a per-call-site swap.
+        if (tryEmitFixedHostMethodCall(ctx, fctx, expr, propAccess, methodName)) return { kind: "externref" };
+        // #1888: standalone builds a native $ObjVec; fixed JS-host calls were
+        // handled above. Larger/spread host calls and WASI use the array bridge.
+        // #1472: the JS-array builders are not globally safe to alias.
         let arrNewIdx: number | undefined;
         let arrPushIdx: number | undefined;
         if (ctx.standalone) {

--- a/src/codegen/fixed-host-method-call.ts
+++ b/src/codegen/fixed-host-method-call.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { allocLocal } from "./context/locals.js";
+import { BUILTIN_CLASS_NAMES } from "./expressions/builtin-class-names.js";
+import { maybeStampCompiledFunctionArgName } from "./expressions/helpers.js";
+import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { compileExpression } from "./shared.js";
+
+const MAX_FIXED_HOST_METHOD_CALL_ARITY = 3;
+
+/**
+ * Emit one fixed-signature import for a small dynamic JS-host method call.
+ *
+ * The generic bridge otherwise crosses into JS once to allocate an argument
+ * array and once per argument to populate it before the actual method call.
+ * Passing evaluated arguments directly removes those crossings. The runtime
+ * companion still delegates to the canonical `__extern_method_call`, keeping
+ * receiver wrapping, callbacks, mutation reconciliation, and errors identical.
+ */
+export function tryEmitFixedHostMethodCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+  methodName: string,
+): boolean {
+  if (
+    ctx.standalone ||
+    ctx.wasi ||
+    process.env.JS2WASM_FIXED_HOST_METHOD_CALLS === "0" ||
+    expr.arguments.length > MAX_FIXED_HOST_METHOD_CALL_ARITY ||
+    expr.arguments.some((arg) => ts.isSpreadElement(arg))
+  ) {
+    return false;
+  }
+
+  const externref = { kind: "externref" as const };
+  const importName = `__extern_method_call_${expr.arguments.length}`;
+  const methodCallIdx = ensureLateImport(
+    ctx,
+    importName,
+    Array.from({ length: 2 + expr.arguments.length }, () => externref),
+    [externref],
+  );
+  const receiver = propAccess.expression;
+  const receiverIsBuiltin = ts.isIdentifier(receiver) && BUILTIN_CLASS_NAMES.has(receiver.text);
+  const getBuiltinIdx = receiverIsBuiltin
+    ? ensureLateImport(ctx, "__get_builtin", [externref], [externref])
+    : undefined;
+  flushLateImportShifts(ctx, fctx);
+  if (methodCallIdx === undefined || (receiverIsBuiltin && getBuiltinIdx === undefined)) return false;
+
+  if (receiverIsBuiltin) {
+    addStringConstantGlobal(ctx, (receiver as ts.Identifier).text);
+    fctx.body.push(...stringConstantExternrefInstrs(ctx, (receiver as ts.Identifier).text));
+    fctx.body.push({ op: "call", funcIdx: getBuiltinIdx! });
+  } else {
+    const recvType = compileExpression(ctx, fctx, receiver, externref);
+    if (recvType && recvType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
+  }
+  const recvLocal = allocLocal(fctx, `__emc_recv_${fctx.locals.length}`, externref);
+  fctx.body.push({ op: "local.set", index: recvLocal });
+
+  const argLocals: number[] = [];
+  for (const arg of expr.arguments) {
+    const argType = compileExpression(ctx, fctx, arg, externref);
+    if (argType && argType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
+    if (argType === null) fctx.body.push({ op: "ref.null.extern" });
+    maybeStampCompiledFunctionArgName(ctx, fctx, arg);
+    const argLocal = allocLocal(fctx, `__emc_arg_${fctx.locals.length}`, externref);
+    fctx.body.push({ op: "local.set", index: argLocal });
+    argLocals.push(argLocal);
+  }
+
+  fctx.body.push({ op: "local.get", index: recvLocal });
+  addStringConstantGlobal(ctx, methodName);
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, methodName));
+  for (const argLocal of argLocals) fctx.body.push({ op: "local.get", index: argLocal });
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get(importName) ?? methodCallIdx });
+  return true;
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -30,6 +30,7 @@ import {
   _installIteratorHelperPolyfills,
 } from "./runtime/iterator-polyfills.js";
 import { buildStringConstants, buildStringConstants16 } from "./runtime/string-constants.js";
+import { fixedExternMethodCallArity, makeFixedExternMethodCall } from "./runtime/fixed-extern-method-call.js";
 export { buildStringConstants, buildStringConstants16 };
 import {
   compiledClosureNativeSource,
@@ -9055,19 +9056,18 @@ function resolveImport(
     }
     case "builtin": {
       const name = intent.name;
-      // (#1644 Slice B) __bigint_ctor: §21.2.1.1 BigInt(value).
-      //   1. ToPrimitive(value, number)
-      //   2. If prim is a Number → NumberToBigInt: RangeError unless it is a
-      //      safe integer (NaN / ±Infinity / non-integer all throw RangeError).
-      //   3. Otherwise → ToBigInt(prim): bigint identity; boolean → 0n/1n;
-      //      string → StringToBigInt (SyntaxError on malformed numeric string);
-      //      Symbol → TypeError.
-      // Returns the bigint as a wasm i64 (JS-BigInt-integration).
-      // (#2678) Date.parse / new Date(<string>) in HOST mode. Host strings are
-      // real `wasm:js-string` externrefs, so the JS `Date.parse` runs directly
-      // (and is more format-complete than the native ISO parser). Registered
-      // up-front by collectDateParseHostImports (declarations.ts) so its funcidx
-      // is stable. Returns f64 ms (NaN on an unparseable string).
+      const fixedMethodArity = fixedExternMethodCallArity(name);
+      if (fixedMethodArity !== undefined) {
+        const canonical = resolveImport(
+          { type: "builtin", name: "__extern_method_call" },
+          deps,
+          callbackState,
+          globalSandbox,
+          instanceState,
+        );
+        return makeFixedExternMethodCall(fixedMethodArity, canonical);
+      }
+      // #1644/#2678: spec BigInt-to-i64 and host Date.parse for wasm:js-string externrefs.
       if (name === "__date_parse_host") return (s: any): number => Date.parse(s);
       if (name === "__bigint_ctor") {
         return (v: any): bigint => {

--- a/src/runtime/fixed-extern-method-call.ts
+++ b/src/runtime/fixed-extern-method-call.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+export function fixedExternMethodCallArity(name: string): 0 | 1 | 2 | 3 | undefined {
+  const match = /^__extern_method_call_([0-3])$/.exec(name);
+  return match ? (Number(match[1]) as 0 | 1 | 2 | 3) : undefined;
+}
+
+/**
+ * Pack fixed import arguments in JS and delegate to the canonical dispatcher.
+ *
+ * The reusable pack removes a per-call allocation. A synchronous callback can
+ * re-enter the same import, so nested calls use a fresh pack until the outer
+ * dispatch completes. Clearing retained values keeps object lifetimes equal to
+ * the allocating path.
+ */
+export function makeFixedExternMethodCall(arity: 0 | 1 | 2 | 3, call: Function): Function {
+  if (arity === 0) {
+    const args: unknown[] = [];
+    return (obj: unknown, method: string): unknown => call(obj, method, args);
+  }
+
+  const reusableArgs = new Array<unknown>(arity);
+  let active = false;
+  const invokeReusable = (obj: unknown, method: string): unknown => {
+    active = true;
+    try {
+      return call(obj, method, reusableArgs);
+    } finally {
+      for (let index = 0; index < arity; index++) reusableArgs[index] = undefined;
+      active = false;
+    }
+  };
+  if (arity === 1)
+    return (obj: unknown, method: string, a: unknown): unknown => {
+      if (active) return call(obj, method, [a]);
+      reusableArgs[0] = a;
+      return invokeReusable(obj, method);
+    };
+  if (arity === 2)
+    return (obj: unknown, method: string, a: unknown, b: unknown): unknown => {
+      if (active) return call(obj, method, [a, b]);
+      reusableArgs[0] = a;
+      reusableArgs[1] = b;
+      return invokeReusable(obj, method);
+    };
+  return (obj: unknown, method: string, a: unknown, b: unknown, c: unknown): unknown => {
+    if (active) return call(obj, method, [a, b, c]);
+    reusableArgs[0] = a;
+    reusableArgs[1] = b;
+    reusableArgs[2] = c;
+    return invokeReusable(obj, method);
+  };
+}

--- a/tests/fixed-host-method-calls.test.ts
+++ b/tests/fixed-host-method-calls.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { compile, type ImportDescriptor } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+const previousKillSwitch = process.env.JS2WASM_FIXED_HOST_METHOD_CALLS;
+
+afterEach(() => {
+  if (previousKillSwitch === undefined) process.env.JS2WASM_FIXED_HOST_METHOD_CALLS = undefined;
+  else process.env.JS2WASM_FIXED_HOST_METHOD_CALLS = previousKillSwitch;
+});
+
+describe("fixed-arity JS-host method calls", () => {
+  it("emits one fixed import instead of building an argument array through imports", async () => {
+    process.env.JS2WASM_FIXED_HOST_METHOD_CALLS = undefined;
+    const result = await compile(`export function invoke(receiver: any): number { return receiver.add(2, 3); }`, {
+      fileName: "fixed-host-method.ts",
+    });
+    expect(result.success, result.errors?.map((error) => error.message).join("\n")).toBe(true);
+    const imports = WebAssembly.Module.imports(await WebAssembly.compile(result.binary)).map((entry) => entry.name);
+    expect(imports).toContain("__extern_method_call_2");
+    expect(imports).not.toContain("__extern_method_call");
+    expect(imports).not.toContain("__js_array_new");
+    expect(imports).not.toContain("__js_array_push");
+  });
+
+  it("keeps receiver binding, argument order, and the observed return value", async () => {
+    process.env.JS2WASM_FIXED_HOST_METHOD_CALLS = undefined;
+    const exports = await compileAndInstantiate(
+      `export function invoke(receiver: any): number { return receiver.add(2, 3); }`,
+      { fileName: "fixed-host-method.ts" },
+    );
+    const receiver = {
+      base: 7,
+      add(this: { base: number }, a: number, b: number): number {
+        return this.base * 100 + a * 10 + b;
+      },
+    };
+    expect((exports.invoke as (receiver: unknown) => number)(receiver)).toBe(723);
+  });
+
+  it("supports arities zero through three through the canonical dispatcher", () => {
+    const descriptors: ImportDescriptor[] = [0, 1, 2, 3].map((arity) => ({
+      module: "env",
+      name: `__extern_method_call_${arity}`,
+      kind: "func",
+      intent: { type: "builtin", name: `__extern_method_call_${arity}` },
+      paramCount: 2 + arity,
+    }));
+    const built = buildImports(descriptors);
+    const receiver = {
+      base: 5,
+      m0(): number {
+        return this.base;
+      },
+      m1(a: number): number {
+        return this.base + a;
+      },
+      m2(a: number, b: number): number {
+        return this.base + a * 10 + b;
+      },
+      m3(a: number, b: number, c: number): number {
+        return this.base + a * 100 + b * 10 + c;
+      },
+    };
+    expect(built.env.__extern_method_call_0!(receiver, "m0")).toBe(5);
+    expect(built.env.__extern_method_call_1!(receiver, "m1", 2)).toBe(7);
+    expect(built.env.__extern_method_call_2!(receiver, "m2", 2, 3)).toBe(28);
+    expect(built.env.__extern_method_call_3!(receiver, "m3", 2, 3, 4)).toBe(239);
+  });
+
+  it("uses a fresh fallback pack when a host callback re-enters the same fixed import", () => {
+    const descriptor: ImportDescriptor = {
+      module: "env",
+      name: "__extern_method_call_2",
+      kind: "func",
+      intent: { type: "builtin", name: "__extern_method_call_2" },
+      paramCount: 4,
+    };
+    const call = buildImports([descriptor]).env.__extern_method_call_2!;
+    const receiver = {
+      inner(a: number, b: number): number {
+        return a * 10 + b;
+      },
+      outer(a: number, b: number): number {
+        return call(this, "inner", a + 1, b + 1) + a * 100 + b;
+      },
+    };
+    expect(call(receiver, "outer", 2, 3)).toBe(237);
+    expect(call(receiver, "inner", 4, 5)).toBe(45);
+  });
+
+  it("retains the array-building fallback behind the default-on kill switch", async () => {
+    process.env.JS2WASM_FIXED_HOST_METHOD_CALLS = "0";
+    const result = await compile(`export function invoke(receiver: any): number { return receiver.add(2, 3); }`, {
+      fileName: "fixed-host-method-kill-switch.ts",
+    });
+    expect(result.success, result.errors?.map((error) => error.message).join("\n")).toBe(true);
+    const imports = WebAssembly.Module.imports(await WebAssembly.compile(result.binary)).map((entry) => entry.name);
+    expect(imports).toContain("__extern_method_call");
+    expect(imports).toContain("__js_array_new");
+    expect(imports).toContain("__js_array_push");
+    expect(imports).not.toContain("__extern_method_call_2");
+  });
+});


### PR DESCRIPTION
## Summary

- Emit fixed-signature JS-host imports for dynamic receiver method calls with 0–3 non-spread arguments.
- Pack those arguments inside the runtime and delegate to the canonical `__extern_method_call` implementation, preserving receiver binding, WasmGC wrapping, callback behavior, vec reconciliation, errors, and result unwrapping.
- Reuse the host-side argument pack with a reentrancy-safe fallback.
- Keep the old array-building path behind the default-on kill switch `JS2WASM_FIXED_HOST_METHOD_CALLS=0`.

## Root cause

React 19.2.6 `createElement` spends substantial time crossing the Wasm/JS boundary just to construct method argument arrays. For every 100 pinned `createElement` iterations, the old path made:

- 300 `__js_array_new` calls
- 700 `__js_array_push` calls
- 300 `__extern_method_call` calls

The candidate replaces those 1,300 crossings with 300 fixed method-call imports. It does not recognize React, package names, source text, or benchmark inputs.

## Controlled A/B

Exact pinned React production source and driver, alternating 17 pairs after 7 warmups, 20,000 creates per sample:

| | Control | Candidate |
|---|---:|---:|
| Median | 350.028 ms | 322.485 ms |
| Relative | 1.000x | 1.085x |
| Wasm bytes | 67,315 | 66,876 |

That representative run is 7.87% faster; an independently repeated, more heavily loaded run was 6.75% faster.

Evidence:

- Branch base: `fba37d2df54a742b853cff3b69fc66adc752903a`
- Content commit: `c567006ba8fd970463b864a33285e95f3d13e5c6`
- Current main merge head: `8aa33de615d40a`
- Exact source SHA-256: `a0818b3ffe4ea7e782a280d01d5afa75eec42ae67b3abb66e1e2baf85037705f`
- Control Wasm SHA-256: `bffc1b1a172fda65f1f7f2aeacced06a06e41d37051b3211d834374c9d4f02d3`
- Candidate Wasm SHA-256: `348e62818e4362c74792e65f3faeb28500531dc6ebff8ae7bafb0caf7725b1f8`
- Main checksum at 20,000 creates: `346180000` in native V8, control Wasm, and candidate Wasm
- Changed-seed positive control: `126111` in all three
- Doubled-work positive control: `1092360000` in all three

The kill-switch build reproduces the control Wasm checksum and binary hash.

## Validation

- React 19.2.6 pinned upstream suite: 55/55 scored tests pass
- Focused dynamic-dispatch suite: 40/40 tests pass
- New import-shape, arity, receiver/argument, reentrancy, and kill-switch tests: 5/5 pass
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- Commit and push hooks, including changed-root tests and oracle/coercion ratchets

No benchmark data or package fixtures are changed.
