### PR TITLE
docs(conformance): map exact ES2015 gaps to IR work

### DIFF
--- a/plan/issues/3523-ir-r4-module-init-compile-once.md
+++ b/plan/issues/3523-ir-r4-module-init-compile-once.md
@@ -4,7 +4,7 @@ title: "IR-only R4: typed ordered module-init compile-once ownership"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-08-02
+updated: 2026-08-09
 priority: critical
 horizon: xl
 complexity: XL
@@ -20,7 +20,7 @@ model: gpt-5.6-sol
 parent: 3518
 depends_on: [3521, 3522]
 required_by: [3525]
-related: [1789, 2796, 2931, 2965, 2992, 3142, 3517, 3518]
+related: [1789, 2796, 2931, 2965, 2992, 3142, 3517, 3518, 3783, 4273, 4275]
 origin: "#3518 R4 — replace compile-first/patch-later __module_init with typed ordered prepare-before-emit ownership"
 files:
   - src/ir/module-init.ts
@@ -95,6 +95,22 @@ The existing module-init claim is an overlay over a legacy ABI and body:
 #3142 made a narrow initializer population claimable. #3517 removes the last
 measured Algorithms initializer residual. Neither proves compile-once
 ownership, includes the omitted side channels, or makes the legacy slot dead.
+
+### 2026-08-09 Test262 scoring dependency
+
+#4275 supplies a direct pass-rate witness for this structural boundary. Its 15
+resolved-target ES2015 `for-of` assignment-destructuring fixtures all place the
+target loop in the literal harness's source-owned `<module-init>` terminal. A
+production outcome report for `array-elem-iter-nrml-close.js` rejects that
+terminal at `vardecl-var-kind:FirstStatement`, emits the legacy init body, and
+emits no IR body. The loop cannot be selected as a smaller function terminal.
+
+Consequently a prepared iterator instruction and green function-local probe do
+not move those Test262 rows. R4 must consume #3783's genuine module-global
+`var`/hoisting representation and emit the complete ordered terminal once;
+wrapping the test body alone or shadowing its script globals would be false IR
+ownership. This is an exact conformance dependency, not a request to add
+Test262-shaped routing to R4.
 
 ## Typed `ModuleInitPlan` contract
 

--- a/plan/issues/3783-ir-function-local-var-declarations.md
+++ b/plan/issues/3783-ir-function-local-var-declarations.md
@@ -5,7 +5,7 @@ status: ready
 assignee: ttraenkler/codex-ir-var
 sprint: current
 created: 2026-07-29
-updated: 2026-07-29
+updated: 2026-08-09
 priority: high
 horizon: s
 feasibility: medium
@@ -13,7 +13,7 @@ task_type: feature
 area: ir, codegen
 language_feature: variable-declarations
 goal: ir-full-coverage
-related: [1372, 2856, 2949, 2952, 3583]
+related: [1372, 2856, 2949, 2952, 3523, 3583, 4273, 4275]
 loc-budget-allow:
   - src/ir/function-local-var.ts
   - src/ir/select.ts
@@ -148,3 +148,26 @@ Retirement parity still requires:
 - Decide whether uninitialized, destructuring, captured, or cross-block
   function-scoped forms should gain exact IR storage or remain explicit
   unsupported shapes.
+
+## 2026-08-09 exact ES2015 literal-harness evidence
+
+#4275's direct-iterator assignment-destructuring audit found a concrete
+pass-rate dependency on the remaining module-global arm. Its 15 resolved-target
+fixtures place the `for-of` statement at script top level. The non-empty forms
+declare `var x;` or `var _;` without an initializer; the empty `[]` forms still
+share the literal Test262 runtime/assert/sta prefix, which contains top-level
+`var` declarations.
+
+An authentic production compile of
+`language/statements/for-of/dstr/array-elem-iter-nrml-close.js` reports the
+source-owned `<module-init>` terminal as
+`body-shape-rejected / vardecl-var-kind:FirstStatement`, with
+`legacyBodyEmitted=true`, `irBodyEmitted=false`, and no IR-compiled function.
+The target loop has no smaller executable terminal in the current inventory.
+
+This evidence does not reopen the completed function-local slice. It freezes
+the next boundary: module-global `var` requires real hoisting/storage identity
+shared with legacy and IR functions, and must compose with #3523's ordered
+prepared module-init transaction. A function-local shadow is not a valid
+implementation. Until that boundary lands, #4275's iterator operation can be
+proved only as substrate and its 15 authentic Test262 rows remain uncredited.

--- a/plan/issues/4273-es2015-90pct-census-ir-lever-plan.md
+++ b/plan/issues/4273-es2015-90pct-census-ir-lever-plan.md
@@ -17,7 +17,7 @@ es_edition: 2015
 goal: es6
 assignee: "ttraenkler/codex-es6-census"
 test262_count: 11691
-related: [680, 869, 1355, 1430, 1645, 1691, 1750, 2046, 2566, 2662, 2669, 2864, 2866, 2872, 3031, 3177, 3371, 3488, 3531, 3575, 3949, 3975, 4167, 4259, 4274]
+related: [680, 869, 1355, 1430, 1645, 1691, 1750, 2046, 2566, 2662, 2669, 2864, 2866, 2872, 3031, 3177, 3371, 3488, 3531, 3575, 3949, 3975, 4167, 4259, 4274, 4275]
 origin: "2026-08-09 exact-edition ES2015 audit against frozen oracle-v13 two-lane JSONLs and the committed per-file edition map; requested target is 90% and all implementation work must be IR-path work"
 ---
 
@@ -125,7 +125,7 @@ historic issue's old counts remain current.
 | Cohort | Dominant measured mechanism | Repository Markdown owner(s) |
 | --- | --- | --- |
 | generators | eager host buffering breaks suspension; standalone rejects or leaks general state-machine and `yield*` shapes | #680 ready; #2662 blocked; #2864 in-progress |
-| destructuring | IteratorClose, undefined-only defaults, elision stepping, rest draining, generator over-consumption | #2669 ready; #1430 ready; #2566 blocked |
+| destructuring | IteratorClose, undefined-only defaults, elision stepping, rest draining, generator over-consumption | #2669 and #1430 ready; exact IR assignment-pattern child #4275 in-progress; #2566 blocked |
 | TypedArray | callback observation, descriptors, detached buffers, dynamic constructors, standalone concat imports | #2872, #3177, #1645, #3531, #3975, #3488 ready |
 | Symbol.iterator | custom iterator dispatch, spread argument formation, IteratorClose, generator overlap | #2669 and #1750 ready; #1691 blocked |
 | Proxy | ordinary forwarding, descriptor invariants, dynamic MOP/trap dispatch | #1355 in-progress; #3031 ready |
@@ -151,10 +151,13 @@ diagnosis and does not satisfy this issue.
    module-tag `WebAssembly.Exception` wrappers. The fix belongs under the
    `async.callback.wrap` provider contract and must unwrap only this module's
    tagged payload, not foreign Wasm exceptions or `WebAssembly.RuntimeError`.
-3. **Split and attack direct-iterator `for-of` destructuring.** The IR already
-   has `forof.iter`, `iter.*`, and `iter.return`; extend prepared binder
-   ownership for defaults, elisions, rest, and close-on-completion. Exclude
-   generator sources until the suspension substrate is real.
+3. **Split and attack direct-iterator `for-of` destructuring.** #4275 isolates
+   45 top-level assignment-pattern files behind one indexed-array impostor. Its
+   measured 16-file fixed-pattern slice fails in both lanes; 15 are safely
+   IR-routable without first implementing sloppy unresolvable assignment.
+   Repair `forof.iter` completion first, then add exact prepared ownership for
+   inner iterator stepping and assignment; exclude generator sources until
+   suspension is real.
 4. **Represent default-argument presence in the function IR ABI.** The exact
    cohort has 144 same-file non-passes. Add an argc/presence plan; do not carry
    the legacy signalling-NaN sentinel into IR.

--- a/plan/issues/4273-es2015-90pct-census-ir-lever-plan.md
+++ b/plan/issues/4273-es2015-90pct-census-ir-lever-plan.md
@@ -1,0 +1,186 @@
+---
+id: 4273
+title: "UMBRELLA: exact ES2015 → 90% — pinned two-lane census, root-cause map, and IR lever plan"
+status: in-progress
+sprint: current
+created: 2026-08-09
+updated: 2026-08-09
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+model: gpt-5.6-sol
+task_type: umbrella
+area: ir, conformance
+language_feature: es2015
+es_edition: 2015
+goal: es6
+assignee: "ttraenkler/codex-es6-census"
+test262_count: 11691
+related: [680, 869, 1355, 1430, 1645, 1691, 1750, 2046, 2566, 2662, 2669, 2864, 2866, 2872, 3031, 3177, 3371, 3488, 3531, 3575, 3949, 3975, 4167, 4259, 4274]
+origin: "2026-08-09 exact-edition ES2015 audit against frozen oracle-v13 two-lane JSONLs and the committed per-file edition map; requested target is 90% and all implementation work must be IR-path work"
+---
+
+# #4273 — Exact ES2015 to 90%: census, root causes, and IR lever plan
+
+## Scope and pinned authority
+
+This issue tracks **exact-edition ES2015**, not every test cumulatively through
+ES2015 and not every untagged legacy test. The authoritative cohort is the
+intersection of:
+
+1. paths present in the frozen baseline JSONLs;
+2. paths mapped to `ES2015` by
+   `website/public/benchmarks/results/test262-file-editions.json`; and
+3. the official standard or Annex B scopes already admitted by the baseline.
+
+Audit pin:
+
+- compiler baseline SHA: `fba37d2df54a742b853cff3b69fc66adc752903a`;
+- Test262 gitlink: `b363f29d3c43c626dc852744ad64a0b48a003693`;
+- baseline-repository snapshot: `3add20464a7353eefb17f2a34af2710bcf57d7e6`;
+- oracle: v13, generated `2026-08-09T06:31:03Z`; and
+- population: **11,691 files per lane** — 11,523 standard plus 168 Annex B.
+
+The two JSONLs each contain 48,619 unique rows, have identical file sets, have
+zero missing edition mappings, and reproduce their published report totals.
+They are therefore the status authority for this census. The checked-in
+aggregate edition reports are not substituted for their JSONL rows.
+
+## Current score and target gap
+
+Ninety percent of 11,691 requires at least **10,522 passing files**.
+
+| Lane | Pass | Fail | Compile error | Timeout | Skip | Pass rate | Passes needed for 90% |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| GC/host | 8,768 | 2,799 | 63 | 60 | 1 | 74.9979% | **+1,754** |
+| Standalone | 7,311 | 3,479 | 886 | 14 | 1 | 62.5353% | **+3,211** |
+
+The cross-lane matrix is:
+
+| Outcome | Files |
+| --- | ---: |
+| pass in both lanes | 7,004 |
+| non-pass in both lanes | 2,616 |
+| GC pass / standalone non-pass | 1,764 |
+| GC non-pass / standalone pass | 307 |
+
+The website's cumulative “through ES2015” view is a separate 20,622-file
+denominator. On that view GC is 15,923/20,622 (77.2137%, +2,637 to 90%) and
+standalone is 15,246/20,622 (73.9308%, +3,314). Work on this issue is scored
+against the exact-edition denominator above; cumulative movement may be
+reported additionally but must not replace it.
+
+## Why an earlier fresh count said 11,736
+
+The 11,736 result was not a new cohort. It classified July baseline paths using
+a stale March Test262 checkout at `63829c6`, while the baseline and repository
+gitlink both use `b363f29`. Exactly 179 relevant paths were absent from the
+stale checkout, so missing frontmatter fell into path heuristics:
+
+- 112 later-edition files incorrectly entered ES2015: Promise `allKeyed` (39),
+  `allSettledKeyed` (38), ArrayBuffer prototype (25), and TypedArray (10);
+- 67 genuine ES2015 files fell out: Iterator.prototype (54), Error.prototype
+  (11), and module namespace internals (2).
+
+The net error was `112 - 67 = +45`. All future reruns must first assert that
+the Test262 checkout is exactly the gitlink SHA and refuse to score a stale or
+missing source tree.
+
+## Measured feature cohorts
+
+These cohorts overlap heavily. They are useful prioritisation signals, but
+their counts **must never be summed**.
+
+| Rank | Feature cohort | Files | GC pass/fail/CE/timeout/skip | Standalone pass/fail/CE/timeout/skip | Non-pass in both |
+| ---: | --- | ---: | --- | --- | ---: |
+| 1 | generators | 2,485 | 1915/541/15/14/0 | 1746/428/308/3/0 | 487 |
+| 2 | destructuring-binding | 4,153 | 3562/548/1/42/0 | 3476/522/153/2/0 | 502 |
+| 3 | TypedArray | 1,047 | 742/302/1/2/0 | 243/600/203/1/0 | 290 |
+| 4 | Symbol.iterator | 795 | 446/304/3/41/1 | 338/327/128/1/1 | 336 |
+| 5 | Proxy | 431 | 186/242/1/2/0 | 74/279/78/0/0 | 226 |
+| 6 | Symbol | 600 | 430/170/0/0/0 | 254/311/35/0/0 | 162 |
+| 7 | default-parameters | 1,552 | 1376/157/4/15/0 | 1322/170/58/2/0 | 144 |
+| 8 | class | 410 | 224/171/14/1/0 | 227/155/28/0/0 | 175 |
+| 9 | Reflect | 330 | 191/138/1/0/0 | 110/129/89/2/0 | 130 |
+| 10 | Symbol.species | 185 | 86/98/0/1/0 | 34/129/22/0/0 | 94 |
+
+Their unique union covers 2,054 of 2,923 GC non-passes and 3,039 of 4,380
+standalone non-passes. The largest strategic union is generators plus
+destructuring: 4,941 files, 910 GC non-passes, 1,089 standalone non-passes, and
+816 same-file non-passes. Its most measurable directory slice is
+`test/language/statements/for-of/dstr/`: 524 files, 201 GC non-passes, 204
+standalone non-passes, and 193 same-file non-passes.
+
+Generator-backed members of that directory require real suspension and must be
+kept separate from direct custom-iterator, default, elision, rest, and
+IteratorClose work. Crediting the entire 524-file directory to a local binder
+fix would be a false projection.
+
+## Root-cause ownership map
+
+Status below is the repository status at this audit, not an assertion that the
+historic issue's old counts remain current.
+
+| Cohort | Dominant measured mechanism | Repository Markdown owner(s) |
+| --- | --- | --- |
+| generators | eager host buffering breaks suspension; standalone rejects or leaks general state-machine and `yield*` shapes | #680 ready; #2662 blocked; #2864 in-progress |
+| destructuring | IteratorClose, undefined-only defaults, elision stepping, rest draining, generator over-consumption | #2669 ready; #1430 ready; #2566 blocked |
+| TypedArray | callback observation, descriptors, detached buffers, dynamic constructors, standalone concat imports | #2872, #3177, #1645, #3531, #3975, #3488 ready |
+| Symbol.iterator | custom iterator dispatch, spread argument formation, IteratorClose, generator overlap | #2669 and #1750 ready; #1691 blocked |
+| Proxy | ordinary forwarding, descriptor invariants, dynamic MOP/trap dispatch | #1355 in-progress; #3031 ready |
+| Symbol | native symbol carrier, symbol-key property storage, agent-wide registry and cross-realm identity | #2866 ready; true realms now #4274 |
+| default parameters | omitted versus explicit `undefined`, argument presence/argc, TDZ, method lowering | #869 ready; #3949 in-progress; patterns also #2669 |
+| classes | captured outer binding writes from accessor setters were dropped at the class/module-init boundary | #4259 on ready PR #4290 |
+| Reflect | receiver/prototype semantics, descriptors, arbitrary distinct NewTarget | #2046 in-progress; #1355 in-progress; residual after done #3371 |
+| species | observable constructor/`@@species`, returned object validation, realm/prototype identity | #3575, #3177, #2623 ready |
+| cross-realm | `$262.createRealm` is an empty pseudo-realm, not a realm with distinct intrinsics | #4274 ready |
+
+## IR-first execution order
+
+Every implementation credited to this programme must have a genuine prepared
+IR owner for the affected source terminal. A direct-codegen special case, a
+Test262 filename check, or a legacy-only fallback improvement is useful only as
+diagnosis and does not satisfy this issue.
+
+1. **Bank the contained class-accessor writeback family.** #4259 / ready PR
+   #4290 moves exactly 72 files per lane and proves each targeted accessor body
+   is emitted once by prepared IR with no legacy body.
+2. **Preserve Promise rejection identity at the IR async callback boundary.**
+   #4167's contained ES2015 Promise slice has 28 host failures exposing raw
+   module-tag `WebAssembly.Exception` wrappers. The fix belongs under the
+   `async.callback.wrap` provider contract and must unwrap only this module's
+   tagged payload, not foreign Wasm exceptions or `WebAssembly.RuntimeError`.
+3. **Split and attack direct-iterator `for-of` destructuring.** The IR already
+   has `forof.iter`, `iter.*`, and `iter.return`; extend prepared binder
+   ownership for defaults, elisions, rest, and close-on-completion. Exclude
+   generator sources until the suspension substrate is real.
+4. **Represent default-argument presence in the function IR ABI.** The exact
+   cohort has 144 same-file non-passes. Add an argc/presence plan; do not carry
+   the legacy signalling-NaN sentinel into IR.
+5. **Work runtime/MOP families through explicit IR providers.** Reflect
+   descriptor/get/set subsets, TypedArray callback observation, and the
+   standalone concat/import boundary are contained before Proxy, species, or
+   complete realms.
+6. **Build the broad substrates deliberately.** Real generator suspension,
+   native Symbol/property keys, Proxy MOP, and true realms are large but needed
+   for the remaining ceiling. #4274 records the exact realm floor.
+
+After every landed slice, rerun the exact frozen cohort in both lanes, report
+file-by-file flips and regressions, refresh this issue's score table, and then
+re-rank from the residual rather than continuing from stale projections.
+
+## Acceptance criteria
+
+- [ ] Both lanes reach at least 10,522/11,691 passing exact-ES2015 files on one
+      pinned compiler/Test262/oracle tuple.
+- [ ] Every credited PR reports exact before/after file rows in both lanes and
+      distinguishes fail, compile error, timeout, and skip.
+- [ ] Overlapping feature tags are never added as if they were disjoint.
+- [ ] Every new root-cause cluster has a `plan/issues/<id>-<slug>.md` owner;
+      root causes are not tracked as GitHub Issues.
+- [ ] New conformance ownership is prepared IR ownership. Any transitional
+      boundary is named explicitly and no targeted source terminal is emitted
+      by both IR and legacy codegen.
+- [ ] The Test262 source checkout is verified at the repository gitlink before
+      classification, and a missing/stale source tree fails the census loudly.

--- a/plan/issues/4273-es2015-90pct-census-ir-lever-plan.md
+++ b/plan/issues/4273-es2015-90pct-census-ir-lever-plan.md
@@ -17,7 +17,7 @@ es_edition: 2015
 goal: es6
 assignee: "ttraenkler/codex-es6-census"
 test262_count: 11691
-related: [680, 869, 1355, 1430, 1645, 1691, 1750, 2046, 2566, 2662, 2669, 2864, 2866, 2872, 3031, 3177, 3371, 3488, 3531, 3575, 3949, 3975, 4167, 4259, 4274, 4275, 4277]
+related: [680, 869, 1355, 1430, 1645, 1691, 1750, 2046, 2566, 2662, 2669, 2864, 2866, 2872, 3031, 3177, 3371, 3488, 3523, 3531, 3575, 3783, 3949, 3975, 4167, 4259, 4274, 4275, 4277]
 origin: "2026-08-09 exact-edition ES2015 audit against frozen oracle-v13 two-lane JSONLs and the committed per-file edition map; requested target is 90% and all implementation work must be IR-path work"
 ---
 
@@ -125,7 +125,7 @@ historic issue's old counts remain current.
 | Cohort | Dominant measured mechanism | Repository Markdown owner(s) |
 | --- | --- | --- |
 | generators | eager host buffering breaks suspension; standalone rejects or leaks general state-machine and `yield*` shapes | #680 ready; #2662 blocked; #2864 in-progress |
-| destructuring | IteratorClose, undefined-only defaults, elision stepping, rest draining, generator over-consumption | #2669 and #1430 ready; exact IR assignment-pattern child #4275 in-progress; #2566 blocked |
+| destructuring | IteratorClose, undefined-only defaults, elision stepping, rest draining, generator over-consumption; literal-harness top-level loops also hit whole-module-init ownership | #2669 and #1430 ready; exact IR assignment-pattern child #4275 in-progress behind #3783/#3523; #2566 blocked |
 | TypedArray | callback observation, descriptors, detached buffers, dynamic constructors, standalone concat imports | #2872, #3177, #1645, #3531, #3975, #3488 ready |
 | Symbol.iterator | custom iterator dispatch, spread argument formation, IteratorClose, generator overlap | #2669 and #1750 ready; #1691 blocked |
 | Proxy | ordinary forwarding, descriptor invariants, dynamic MOP/trap dispatch | #1355 in-progress; #3031 ready |
@@ -151,18 +151,21 @@ diagnosis and does not satisfy this issue.
    module-tag `WebAssembly.Exception` wrappers. The fix belongs under the
    `async.callback.wrap` provider contract and must unwrap only this module's
    tagged payload, not foreign Wasm exceptions or `WebAssembly.RuntimeError`.
-3. **Split and attack direct-iterator `for-of` destructuring.** #4275 isolates
-   45 top-level assignment-pattern files behind one indexed-array impostor. Its
-   measured 16-file fixed-pattern slice fails in both lanes; 15 are safely
-   IR-routable without first implementing sloppy unresolvable assignment.
-   Repair `forof.iter` completion first, then add exact prepared ownership for
-   inner iterator stepping and assignment; exclude generator sources until
-   suspension is real.
-4. **Represent default-argument presence in the function IR ABI.** #4277
+3. **Represent default-argument presence in the function IR ABI.** #4277
    partitions the exact cohort's 144 pinned same-file non-passes and freezes a
    15-file dynamic-carrier slice (eight non-generator forms). Add a callee-side
    undefined-only plan; do not carry the legacy signalling-NaN sentinel into
    IR.
+4. **Build the direct-iterator `for-of` destructuring substrate, then unlock
+   its literal-harness terminal.** #4275 isolates 45 top-level
+   assignment-pattern files behind one indexed-array impostor. Its measured
+   16-file fixed-pattern slice fails in both lanes, but an authentic prepared
+   report now proves all of those loops live inside the one literal-harness
+   `<module-init>` terminal, which first rejects at `vardecl-var-kind` and emits
+   no IR body. Repair `forof.iter` completion and the structured inner iterator
+   operation without score credit, then use #3783/#3523's genuine module-global
+   and ordered module-init ownership before claiming the 15 resolved-target
+   rows. Exclude generator sources until suspension is real.
 5. **Work runtime/MOP families through explicit IR providers.** Reflect
    descriptor/get/set subsets, TypedArray callback observation, and the
    standalone concat/import boundary are contained before Proxy, species, or

--- a/plan/issues/4273-es2015-90pct-census-ir-lever-plan.md
+++ b/plan/issues/4273-es2015-90pct-census-ir-lever-plan.md
@@ -17,7 +17,7 @@ es_edition: 2015
 goal: es6
 assignee: "ttraenkler/codex-es6-census"
 test262_count: 11691
-related: [680, 869, 1355, 1430, 1645, 1691, 1750, 2046, 2566, 2662, 2669, 2864, 2866, 2872, 3031, 3177, 3371, 3488, 3531, 3575, 3949, 3975, 4167, 4259, 4274, 4275]
+related: [680, 869, 1355, 1430, 1645, 1691, 1750, 2046, 2566, 2662, 2669, 2864, 2866, 2872, 3031, 3177, 3371, 3488, 3531, 3575, 3949, 3975, 4167, 4259, 4274, 4275, 4277]
 origin: "2026-08-09 exact-edition ES2015 audit against frozen oracle-v13 two-lane JSONLs and the committed per-file edition map; requested target is 90% and all implementation work must be IR-path work"
 ---
 
@@ -130,7 +130,7 @@ historic issue's old counts remain current.
 | Symbol.iterator | custom iterator dispatch, spread argument formation, IteratorClose, generator overlap | #2669 and #1750 ready; #1691 blocked |
 | Proxy | ordinary forwarding, descriptor invariants, dynamic MOP/trap dispatch | #1355 in-progress; #3031 ready |
 | Symbol | native symbol carrier, symbol-key property storage, agent-wide registry and cross-realm identity | #2866 ready; true realms now #4274 |
-| default parameters | omitted versus explicit `undefined`, argument presence/argc, TDZ, method lowering | #869 ready; #3949 in-progress; patterns also #2669 |
+| default parameters | omitted versus explicit `undefined`, dynamic value identity, argument presence, TDZ, method lowering | exact IR child #4277 ready; legacy #869 ready; #3949 in-progress; patterns also #2669 |
 | classes | captured outer binding writes from accessor setters were dropped at the class/module-init boundary | #4259 on ready PR #4290 |
 | Reflect | receiver/prototype semantics, descriptors, arbitrary distinct NewTarget | #2046 in-progress; #1355 in-progress; residual after done #3371 |
 | species | observable constructor/`@@species`, returned object validation, realm/prototype identity | #3575, #3177, #2623 ready |
@@ -158,9 +158,11 @@ diagnosis and does not satisfy this issue.
    Repair `forof.iter` completion first, then add exact prepared ownership for
    inner iterator stepping and assignment; exclude generator sources until
    suspension is real.
-4. **Represent default-argument presence in the function IR ABI.** The exact
-   cohort has 144 same-file non-passes. Add an argc/presence plan; do not carry
-   the legacy signalling-NaN sentinel into IR.
+4. **Represent default-argument presence in the function IR ABI.** #4277
+   partitions the exact cohort's 144 pinned same-file non-passes and freezes a
+   15-file dynamic-carrier slice (eight non-generator forms). Add a callee-side
+   undefined-only plan; do not carry the legacy signalling-NaN sentinel into
+   IR.
 5. **Work runtime/MOP families through explicit IR providers.** Reflect
    descriptor/get/set subsets, TypedArray callback observation, and the
    standalone concat/import boundary are contained before Proxy, species, or

--- a/plan/issues/4274-es2015-true-realms-runtime-ir.md
+++ b/plan/issues/4274-es2015-true-realms-runtime-ir.md
@@ -1,0 +1,159 @@
+---
+id: 4274
+title: "ES2015 true realms: replace `$262.createRealm` pseudo-realm with IR/runtime realm identity (128 files)"
+status: ready
+sprint: current
+created: 2026-08-09
+updated: 2026-08-09
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+model: gpt-5.6-sol
+task_type: feature
+area: ir, runtime, test-runner
+language_feature: cross-realm
+es_edition: 2015
+goal: es6
+parent: 4273
+related: [500, 1355, 1523, 2763, 2866, 2940, 2996, 3371]
+assignee: "ttraenkler/codex-es6-realms"
+test262_count: 128
+origin: "2026-08-09 exact-ES2015 cross-realm feature cohort: GC 128/128 non-pass; standalone 121/128 non-pass. The completed $262 harness issue supplies only an empty self-referential object, not a distinct ECMAScript Realm."
+---
+
+# #4274 — Give `$262.createRealm()` real realm identity
+
+## Exact impact
+
+Against #4273's pinned exact-ES2015 population, the `cross-realm` feature tag
+selects **128 files**. The sorted path list has SHA-256
+`abb9905b0a56748eb3be2100d80d7cd408747bc5453ecce61f9885ac1f1d2aff`.
+
+| Lane | Pass | Fail | Compile error | Non-pass |
+| --- | ---: | ---: | ---: | ---: |
+| GC/host | 0 | 128 | 0 | **128** |
+| Standalone | 7 | 92 | 29 | **121** |
+
+The GC failures are unusually concentrated: 112 report `Cannot access property
+on null or undefined`, with another five location-decorated forms of the same
+error. In standalone, the pseudo-realm fans out into downstream failures:
+
+- 46 `__module_init` null dereferences;
+- 21 missing expected TypeErrors;
+- 15 values observed as `undefined` instead of the foreign object;
+- 14 distinct-NewTarget `Reflect.construct` refusals across three signatures;
+- 7 Array harness concat/import leaks; and
+- smaller `instanceof`, constructor, and object-carrier failures.
+
+All 128 files call `createRealm()` and read `.global`. Within the same cohort,
+58 inspect prototypes, 42 call `Reflect.construct`, 39 exercise Proxy, seven
+use `instanceof`, and two exercise `Symbol.for`. The largest path families are
+Proxy (36), Array (16), Function (13), Symbol (13), RegExp (8), NativeErrors
+(6), and TypedArray constructors (5).
+
+The seven standalone passes are not evidence of real realm support. They pass
+despite the stub or through narrow current-realm shortcuts; the cohort-level
+identity and intrinsic requirements remain absent.
+
+## Root cause
+
+#1523 correctly made `$262` available, but deliberately implemented
+`createRealm()` as an empty object whose `global` points back to itself:
+
+```ts
+const realm: any = {};
+realm.global = realm;
+```
+
+That object has no realm-local Array, Object, Function, Error, Proxy, RegExp,
+TypedArray, or other intrinsic constructors and prototypes. Consequently
+`$262.createRealm().global.Array` and similar reads are `undefined`, and
+prototype/constructor assertions fail before testing the intended operation.
+
+Standalone also contains a narrow property-access shortcut that treats a
+binding initialised from `$262.createRealm().global` as the current native
+global for a TypedArray constructor-prototype shape. That was useful for
+unblocking #3371, but it explicitly collapses the distinction this cohort
+tests. Adding more constructor names to the empty object or extending this
+shortcut would create more pseudo-passes while preserving the root defect.
+
+An ECMAScript Realm needs distinct intrinsic object identities and its own
+global object, while sharing agent-level facilities where the specification
+requires it. In particular, constructors and prototypes are realm-local, but
+the global Symbol registry used by `Symbol.for`/`Symbol.keyFor` is shared across
+realms in the same agent. This cannot be represented faithfully by a plain
+empty `$Object` or by aliasing every foreign intrinsic to the current one.
+
+## Required IR/runtime design
+
+This is an IR/runtime substrate, not a test-runner-only shim.
+
+1. Add an explicit realm carrier containing a stable realm identity, realm
+   global, and intrinsic constructor/prototype table. `createRealm` allocates a
+   new carrier; repeated access to its global and intrinsics is identity-stable.
+2. Add prepared IR operations/providers for realm creation, global access, and
+   intrinsic lookup. The `$262` preamble may call those providers, but it must
+   not embed compiler filename/path knowledge or construct the realm by a
+   legacy-only object-literal special case.
+3. Represent each foreign constructor as a callable/constructible facade tied
+   to its realm carrier. Its `.prototype` is the corresponding foreign
+   intrinsic, distinct from the current realm's intrinsic, while its executable
+   implementation can share code.
+4. Propagate the selected realm through allocation and construction, including
+   `Reflect.construct(target, args, newTarget)`. Objects must receive the
+   correct foreign prototype, and errors created by realm-defined operations
+   must carry the correct foreign Error prototype.
+5. Make dynamic property access, Proxy trap calls, `instanceof`,
+   `Object.getPrototypeOf`, and constructor/prototype reads understand realm
+   facades through normal runtime MOP dispatch. Remove the current-realm
+   TypedArray shortcut once the genuine path covers it.
+6. Keep well-known symbols and the `Symbol.for` registry in the correct
+   agent-wide store so same-key registry Symbols compare equal across realm
+   carriers, while ordinary `Symbol()` calls still create unique identities.
+7. Preserve host and standalone parity. Host embedding may delegate realm
+   execution to a host realm only if values cross the boundary through the same
+   explicit carrier/identity contract; standalone must require no `env::`
+   imports.
+
+Dynamic source evaluation is not exercised by this exact 128-file cohort, so a
+general `evalScript` engine is not required for the first scored slice. It must
+remain a separately explicit capability rather than being faked as a no-op.
+
+## Delivery slices
+
+1. **Realm carrier and identity controls:** create two realms; prove distinct
+   globals/intrinsics, stable repeated reads, and shared `Symbol.for` registry.
+2. **Constructor/prototype allocation:** Array/Object/Function and native Error
+   families, then the `proto-from-ctor-realm` tests that do not need Proxy.
+3. **Reflect construction and TypedArray facades:** preserve distinct
+   NewTarget/prototype semantics without current-realm aliases.
+4. **Proxy and error-realm semantics:** route traps, invariant errors, and
+   thrown TypeErrors through the correct realm.
+5. **Residual built-ins:** RegExp, Date, JSON, Map/Set, Promise, and the small
+   language tail; rerank after each exact two-lane measurement.
+
+Each slice must prove prepared IR ownership for its realm operations. A test
+that passes only because foreign and current identities were collapsed is a
+regression, not a win.
+
+## Acceptance criteria
+
+- [ ] The pinned 128-file list and both-lane baseline above are reproduced
+      before implementation; missing rows or a mismatched Test262 gitlink fail
+      the measurement loudly.
+- [ ] `$262.createRealm()` returns a distinct, identity-stable realm carrier
+      with a distinct global and realm-local intrinsic constructor/prototype
+      graph.
+- [ ] Cross-realm construction, prototype selection, ordinary property access,
+      Proxy dispatch, `instanceof`, and Error identity use normal IR/runtime
+      semantics rather than Test262-shaped shortcuts.
+- [ ] `Symbol.for`/`Symbol.keyFor` use one agent-wide registry across realms;
+      ordinary Symbols remain unique.
+- [ ] The current-realm TypedArray prototype alias is removed when its genuine
+      realm-backed replacement lands.
+- [ ] The exact 128-file cohort is rerun in both lanes after every slice, with
+      file-level flips and regressions reported. The eventual target is 128/128
+      pass in both lanes with zero new `env::` imports in standalone.
+- [ ] Targeted realm terminals are owned once by prepared IR; no targeted body
+      is also emitted by legacy codegen.

--- a/plan/issues/4275-es2015-forof-array-assignment-iterator-ir.md
+++ b/plan/issues/4275-es2015-forof-array-assignment-iterator-ir.md
@@ -16,7 +16,7 @@ language_feature: destructuring-binding
 es_edition: 2015
 goal: es6
 parent: 4273
-related: [680, 1169, 1182, 1347, 1430, 1642, 2566, 2669, 2952, 3643]
+related: [680, 1169, 1182, 1347, 1430, 1642, 2566, 2669, 2952, 3523, 3643, 3783]
 assignee: "ttraenkler/codex-es6-forof-dstr-ir"
 test262_count: 45
 origin: "2026-08-09 pinned exact-ES2015 census: 45 top-level for-of ArrayAssignmentPattern files consume a direct custom iterator; GC is 1 pass/44 fail and standalone is 0 pass/45 fail. Legacy lowering indexes the iterable instead of running the iterator protocol."
@@ -77,6 +77,45 @@ because this fixture happens not to reach it. Slice A0 therefore routes 15/15
 files through IR and leaves that one file on the coherent fallback until IR
 owns sloppy unresolvable assignment to the global object. Slice A may claim all
 16 through IR only after that separate language semantic is implemented.
+
+### Authentic literal-harness ownership blocker (2026-08-09)
+
+The 15-file A0 classification is a sound **language-operation** boundary, but
+it is not yet an immediately scoreable prepared-IR terminal. An authentic
+`runTest262File` assembly concatenates the runtime shim, `assert.js`, `sta.js`,
+and the untouched body at top level. The target `for` statement therefore
+belongs to the source's single `<module-init>` terminal; it is not a nested
+function that can be selected independently.
+
+A production compile of
+`array-elem-iter-nrml-close.js` with
+`JS2WASM_IR_SHAPE_DIAG=1`, `experimentalIR: true`, and
+`trackIrOutcomes: true` reports:
+
+```text
+unitKind=module-init
+displayName=<module-init>
+kind=unsupported
+code=body-shape-rejected
+detail=vardecl-var-kind:FirstStatement
+legacyBodyEmitted=true
+irBodyEmitted=false
+irCompiledFuncs=[]
+```
+
+The non-empty fixtures also declare their destinations as top-level
+uninitialized `var x;` / `var _;`. The four empty-pattern fixtures have no
+destination, but the literal harness prefix itself still contains top-level
+`var`, so they hit the same terminal gate. Allowing the loop selector alone
+does not change this outcome.
+
+#3783 owns genuine module-global `var` storage and hoisting; #3523 owns the
+typed ordered module-init plan and prepared emission transaction. Shadowing a
+script `var` with a function-local slot, wrapping only this Test262 body in a
+synthetic function, or crediting a synthetic unit test would change observable
+global semantics and is forbidden. The iterator substrate may land first, but
+none of the 15 A0 rows is credited until the authentic module-init terminal is
+IR-owned once.
 
 Slice A paths are:
 
@@ -196,8 +235,10 @@ file flips.
 
 - Introduce one exact source-site plan shared by selector and lowering, for
   example `forOfDestructuringPlan(stmt)`. It returns a frozen plan only for
-  Slice A0's 15 safely routable files and `undefined` otherwise. The 16th file
-  remains fallback until unresolved sloppy assignment is prepared.
+  Slice A0's resolved-target **operation shapes** and `undefined` otherwise.
+  The 16th file remains fallback until unresolved sloppy assignment is
+  prepared. Authentic Test262 ownership additionally requires #3783/#3523;
+  function-local probes are substrate evidence, not file flips.
 - Prove every non-empty target is an already-existing writable mutable slot.
   Do not create bindings. Reject const/TDZ, unresolved or module/global names,
   captures, duplicate/unsafe targets, defaults, rest, elisions, nesting,
@@ -315,6 +356,10 @@ cleanup, `tests/issue-1347.test.ts` for throw-wins precedence, and
       undeclared-target outlier remains a coherent fallback until sloppy
       unresolvable PutValue is owned; linear or otherwise unavailable backends
       reject before claim without host-import leakage or false credit.
+- [ ] The literal-harness `<module-init>` terminal containing each target loop
+      is emitted once by prepared IR through #3783/#3523-compatible
+      module-global storage; no local shadow, body-only wrapper, or synthetic
+      probe is counted as a Test262 pass-rate gain.
 - [ ] Targeted loop terminals and assignment stores are emitted once by
       prepared IR, with no legacy body and no Test262-shaped code path.
 - [ ] Slices B and C reach 27 and 33 files respectively without regressing prior

--- a/plan/issues/4275-es2015-forof-array-assignment-iterator-ir.md
+++ b/plan/issues/4275-es2015-forof-array-assignment-iterator-ir.md
@@ -1,0 +1,323 @@
+---
+id: 4275
+title: "ES2015 IR: evaluate for-of ArrayAssignmentPattern with the iterator protocol (45 files)"
+status: in-progress
+sprint: current
+created: 2026-08-09
+updated: 2026-08-09
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+model: gpt-5.6-sol
+task_type: bugfix
+area: ir, iterators, destructuring
+language_feature: destructuring-binding
+es_edition: 2015
+goal: es6
+parent: 4273
+related: [680, 1169, 1182, 1347, 1430, 1642, 2566, 2669, 2952, 3643]
+assignee: "ttraenkler/codex-es6-forof-dstr-ir"
+test262_count: 45
+origin: "2026-08-09 pinned exact-ES2015 census: 45 top-level for-of ArrayAssignmentPattern files consume a direct custom iterator; GC is 1 pass/44 fail and standalone is 0 pass/45 fail. Legacy lowering indexes the iterable instead of running the iterator protocol."
+---
+
+# #4275 — IR-own for-of ArrayAssignmentPattern iterator evaluation
+
+## Exact opportunity
+
+The exact ES2015 `test/language/statements/for-of/dstr/` population contains
+524 files, not the 569 physical paths currently in that directory. Its broad
+two-lane baseline is:
+
+| Lane | Pass | Fail | Compile error | Timeout | Total |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| GC/host | 323 | 195 | 1 | 5 | 524 |
+| standalone | 320 | 176 | 28 | 0 | 524 |
+
+This issue does not claim that whole heterogeneous directory. The strongest
+causal discriminator is an **assignment** array pattern whose value is a direct
+custom regular iterable:
+
+| Source shape | Files | GC | Standalone | Non-pass in both |
+| --- | ---: | --- | --- | ---: |
+| `for ([pattern] of [customIterable])` | 57 | 1P / 56F | 45F / 12CE | 56 |
+| declaration binding over the same source kind | 21 | 18P / 3TO | 18P / 3F | 3 |
+
+Twelve of the 57 assignment files execute the `for-of` inside a generator
+wrapper. They are excluded from the first programme because their standalone
+compile errors require the generator carrier/state machine first. The exact
+top-level target is therefore **45 files**:
+
+- GC/host: 1 pass / 44 fail;
+- standalone: 0 pass / 45 fail; and
+- 44 same-file non-passes plus one standalone-only non-pass.
+
+The 45-file family divides into exact prepared-IR slices:
+
+| Slice | Shape admitted cumulatively | Files | GC baseline | Standalone baseline | Sorted-list SHA-256 |
+| --- | --- | ---: | --- | --- | --- |
+| A | fixed flat identifiers plus `[]`; no default, elision, rest, nesting, or member target | 16 | 0P / 16F | 0P / 16F | `167dbe1f2ae4b78c9a72a5c2d160a85786a42241ab71443e95023886b6f2372e` |
+| A0 | A with only resolved identifier destinations | 15 | 0P / 15F | 0P / 15F | `28ec00e9aa79252e937d4d8a973215ef92191514b3a46320b0884327a4399f27` |
+| B | A plus elisions | 27 | 0P / 27F | 0P / 27F | `dd4e734842cb1d1150551035f29a5bada42b275039d6749d03f276f291ffcc7c` |
+| C | B plus identifier rest | 33 | 1P / 32F | 0P / 33F | `6113a313f3bad31c812cb84b88f06aeb2c05d2e4bc6af64e13799e565cbcbd53` |
+| D | C plus nested/property/abrupt-reference targets | 45 | 1P / 44F | 0P / 45F | to be frozen before Slice D |
+
+Hashes use sorted repo-relative paths joined by newline with one final newline.
+The four `[]` tests are intentionally in Slice A: an empty pattern has no
+identifier target, but it exercises the same fixed, default-free inner iterator
+acquisition and close semantics. Excluding them leaves a 12-file non-empty
+identifier core, 12/12 failing in both lanes, hash
+`324e04aada72c3eeb29e586ece2f49fea838b87224ab7ea454cd6779cdcdcad9`.
+
+One member of that 12-file core,
+`array-elem-iter-thrw-close-skip.js`, assigns to undeclared `x`. Its `next()`
+throws before `PutValue`, but a source-site selector may not discard the write
+because this fixture happens not to reach it. Slice A0 therefore routes 15/15
+files through IR and leaves that one file on the coherent fallback until IR
+owns sloppy unresolvable assignment to the global object. Slice A may claim all
+16 through IR only after that separate language semantic is implemented.
+
+Slice A paths are:
+
+- `array-elem-iter-get-err.js`;
+- `array-elem-iter-nrml-close-err.js`;
+- `array-elem-iter-nrml-close-null.js`;
+- `array-elem-iter-nrml-close-skip.js`;
+- `array-elem-iter-nrml-close.js`;
+- `array-elem-iter-thrw-close-skip.js`;
+- `array-elem-trlg-iter-get-err.js`;
+- `array-elem-trlg-iter-list-nrml-close-err.js`;
+- `array-elem-trlg-iter-list-nrml-close-null.js`;
+- `array-elem-trlg-iter-list-nrml-close-skip.js`;
+- `array-elem-trlg-iter-list-nrml-close.js`;
+- `array-elem-trlg-iter-list-thrw-close-skip.js`;
+- `array-empty-iter-close-err.js`;
+- `array-empty-iter-close-null.js`;
+- `array-empty-iter-close.js`; and
+- `array-empty-iter-get-err.js`.
+
+Every path is relative to `language/statements/for-of/dstr/`.
+
+## Root cause
+
+The transitional assignment-pattern paths
+`compileForOfAssignDestructuringExternref` and
+`compileForOfIteratorAssignDestructuring` in
+`src/codegen/statements/for-of-destructuring.ts` read each element as if the
+value were an indexed array-like object:
+
+```text
+__extern_get(elem, box(index))
+```
+
+They do not perform `GetIterator`, call `next`, observe `done`, validate the
+iterator result, step elisions, drain rest, or perform `IteratorClose`. This is
+why acquisition errors, step/value errors, call counts, invalid `return()`
+results, and close precedence all fail together. It is one mechanism, not a
+collection of unrelated assertion strings.
+
+The current IR path cannot own the source yet:
+
+1. `src/ir/select.ts::isPhase1ForOfInScope` rejects every destructuring or bare
+   assignment head and admits only a narrow declaration/identifier shape.
+2. `src/ir/from-ast.ts::lowerForOfStatement` throws unless the head resolves to
+   one identifier.
+3. mutated-slot discovery does not record identifiers written through an
+   assignment pattern, so the body contract can retain a stale carrier.
+4. granular `iter.next` / `iter.done` / `iter.value` nodes are stale after
+   `__iterator_next` changed to a `(done, value)` multi-value result;
+   `src/ir/lower.ts` deliberately rejects them. Only declarative `forof.iter`
+   consumes the current ABI.
+5. `forof.iter` currently calls `return()` after normal exhaustion and does not
+   close on a throw from the body. Its branch cleanup covers only selected
+   `break`/crossing-label paths. Destructuring can throw, so admitting the
+   pattern before repairing this would make abrupt completion observably wrong.
+6. the vec fast path is not an escape hatch: nested vec types are not prepared
+   through `resolveIrVecType`, `lowerArrayLiteral`, `vec.new_fixed`,
+   `prepared-vector-support`, or the Program ABI. It also would not implement
+   custom `Symbol.iterator` semantics.
+
+Historic #1642 and #1182 are done but do not own this residual: #1642 covered
+outer-loop close in transitional codegen, while #1182 deliberately shipped
+identifier-only IR `for-of`. #2669 and #1430 remain broad destructuring owners;
+this issue is their exact IR-native assignment-pattern child.
+
+## Required semantic split: outer and inner iterators
+
+Two independent iterator records exist in these tests:
+
+- the **outer** `for-of` iterator produces one value per loop iteration; and
+- the **inner** ArrayAssignmentPattern obtains a new iterator from that value.
+
+Normal exhaustion does not close the outer iterator. `break` or an abrupt body
+completion closes it exactly once while incomplete. The fixed inner pattern,
+however, must close its iterator when the pattern finishes before the inner
+iterator reports done; an empty `[]` therefore still acquires and normally
+closes an incomplete inner iterator. Elisions perform steps, and rest drains to
+done rather than closing early.
+
+The implementation must track these `done` states independently and preserve
+completion precedence. In particular, when destructuring throws, inner close is
+performed as required and then the outer iterator is closed; the original
+abrupt completion wins over an error thrown while closing the outer iterator.
+Normal inner close errors and non-object `return()` results remain observable
+where the specification requires them.
+
+## IR implementation programme
+
+### Slice 0 — make `forof.iter` completion-correct
+
+- Extend `IrInstrForOfIter` and its builder/from-AST plan with an explicit i32
+  outer-done slot and remove the stale single-result slot left from the old
+  pre-multi-value ABI.
+- Acquire the iterator outside the protected body and initialise done to false.
+  Set done to true **before each `next` call**, then replace it with the returned
+  done flag only after the atomic `(done, value)` step succeeds. A throw from
+  `next`, `done`, or `value` therefore does not call `return()`, while a later
+  body/destructuring throw sees the iterator as incomplete.
+- Run `return()` after the loop only when incomplete; do not call it after
+  normal exhaustion.
+- Before every close, mark done true. On a body throw, close the incomplete
+  outer iterator inside a nested try and rethrow the original completion even
+  if outer close throws. A normal `break`/truncation closes once and propagates
+  close errors. Carry the done slot through `CtrlFrame`/crossing-label cleanup
+  and use the same guarded, set-before-call recipe without double-close.
+- Mirror the proven direct-codegen throw-wins pattern covered by #1347, but own
+  the terminal through IR and record its prepared outcome.
+
+### Slice A — fixed flat assignment pattern
+
+The enumerated files use the existing outer array/vec route, so they exercise
+the shared close state machine through the new **inner** operation rather than
+through outer `forof.iter`. Slice 0 remains a required shared correction for
+future custom-outer-iterator ownership and must not be credited as these 15
+file flips.
+
+- Introduce one exact source-site plan shared by selector and lowering, for
+  example `forOfDestructuringPlan(stmt)`. It returns a frozen plan only for
+  Slice A0's 15 safely routable files and `undefined` otherwise. The 16th file
+  remains fallback until unresolved sloppy assignment is prepared.
+- Prove every non-empty target is an already-existing writable mutable slot.
+  Do not create bindings. Reject const/TDZ, unresolved or module/global names,
+  captures, duplicate/unsafe targets, defaults, rest, elisions, nesting,
+  member targets, generators, and override-uncertain iterator shapes.
+- Extend mutated-slot discovery for the exact planned identifiers and use a
+  value-based identifier-store helper rather than synthesising an AST right
+  hand side.
+- Add an explicit structured inner array-assignment operation, for example
+  `iter.destructure.fixed`, over the existing atomic
+  `(iterator) -> (i32 done, externref value)` step ABI. It carries the source
+  iterable, iterator/done/value slots, ordered assignment/elision steps, and
+  frozen `{getIterator, next, close}` provider references. Register it in the
+  IR structural walkers, effect/verifier tables, local allocation and use
+  collectors, preparation/dependency collectors, and relevant pass switches.
+  Do not model it as a `forof.iter` body prelude and do not revive the stale
+  split `iter.next/done/value` contract.
+- Keep values on the dynamic carrier. Do not infer number/string/vec semantics
+  from these test shapes.
+- Make inner iterator acquisition, result validation, early fixed-pattern
+  close, invalid `return()` result, and abrupt-completion precedence explicit in
+  the IR/provider contract.
+- An already-exhausted inner iterator assigns canonical `undefined`. Empty `[]`
+  still performs GetIterator and closes normally without calling `next`.
+- Preserve AssignmentElement order: resolve the destination before the
+  corresponding iterator step, then observe `done`/`value`, evaluate any later
+  default, and finally perform the write. The fixed identifier slice makes
+  destination resolution inert, but the IR shape must not prevent Slices B–D
+  from retaining the specified order.
+
+Do **not** implement Slice A with a host-only bounded materializer. A
+materializer front-loads all steps before the assignment writes, cannot preserve
+AssignmentElement ordering as the plan grows, hides the two independent done
+states/close precedence, and creates a second ABI that standalone cannot share.
+Current `_drainIterable` also fails to close a plain native iterator on finite
+stop. Both host and standalone must implement the same semantic operation over
+the atomic step contract before Slice A0 outcomes are claimed. Slice A's 16th
+outcome additionally requires sloppy unresolvable PutValue. A backend without
+the iterator provider rejects before selection; it does not leak imports or
+withdraw after claiming.
+
+### Provider and preparation prerequisites
+
+The semantic operation is not ready to select until both backends satisfy the
+same provider contract:
+
+- Host `__iterator` validates that GetIterator returned an Object.
+- Host `__iterator_next` validates the iterator result Object and does not read
+  `value` when `done` is true.
+- Host `__iterator_return` distinguishes an absent/null `return` method (a
+  no-op) from the result of calling a present method, and rejects every
+  non-Object call result, including null or undefined.
+- Standalone GetIterator and next apply the same Object checks instead of
+  degrading falsy/non-Object results. Its return dispatcher must expose method
+  presence separately from call result; the current null sentinel cannot
+  distinguish an absent method from `return() { return null; }`.
+- Preparation adds host iterator imports or ensures the native iterator runtime
+  before sealing. It traverses instructions deeply, freezes exact provider refs
+  after transforms, records them in prepared-component dependencies, and makes
+  lowering resolve those refs rather than hard-coded helper names.
+
+Selector capability is the frozen prepared plan itself, never a target-mode
+proxy. If any provider is unavailable, selection fails closed before claiming
+the terminal.
+
+### Slices B–D
+
+- B adds elision stepping without binding a value.
+- C adds identifier rest by draining the inner iterator to done.
+- D adds property/nested targets and their reference-evaluation/abrupt
+  completion rules through existing IR stores. Freeze its exact list/hash
+  before implementation.
+
+Each slice extends the same source-site plan monotonically. No slice may broaden
+the legacy indexed-array impostor or add Test262 filename checks.
+
+## Required tests and evidence
+
+- exact plan positive and negative matrices, including every rejected syntax,
+  target mutability, target backend, generator wrapper, and iterator-override
+  boundary;
+- prepared report proves each targeted terminal is `kind=emitted`,
+  `legacyBodyEmitted=false`, and `irBodyEmitted=true` with no post-claim
+  withdrawal;
+- two loop iterations write distinct values to the existing target slots;
+- normal outer exhaustion does not call outer `return`; `break` calls it once;
+- inner fixed completion closes an incomplete iterator once; empty `[]` has the
+  same acquisition/close behavior and does not call `next`;
+- acquisition, `next`, `done`, and `value` abrupt completions preserve source
+  order and close requirements;
+- `done: true` does not touch the value getter or call `return`;
+- destructuring/body throw closes the incomplete outer iterator once and the
+  original throw wins even if outer `return` throws or is non-callable;
+- inner `return()` returning a primitive throws TypeError where required;
+- iterator `return` observes the correct receiver and zero arguments;
+- the targeted IR route never calls the legacy indexed `__extern_get` path;
+- rejected standalone/linear/WASI cases gain no host imports and retain one
+  coherent fallback contract; and
+- the exact slice is rerun through the authentic Test262 harness in both lanes
+  with file-level gains and losses.
+
+Primary regression references are `tests/issue-2952-slice3.test.ts` for branch
+cleanup, `tests/issue-1347.test.ts` for throw-wins precedence, and
+`tests/issue-3643-array-dstr-getiterator.test.ts` for strict GetIterator.
+
+## Acceptance criteria
+
+- [ ] Slice 0 makes existing prepared `forof.iter` close exactly once while
+      incomplete, never after normal exhaustion, and on body throws with the
+      required completion precedence.
+- [ ] Slice A's measured 16-file list and Slice A0's safely routable 15-file
+      list are reproduced at their recorded hashes and measured before/after in
+      both lanes.
+- [ ] All 15 Slice A0 files pass in GC/host and standalone through the same
+      semantic IR operation and backend-specific prepared providers. The
+      undeclared-target outlier remains a coherent fallback until sloppy
+      unresolvable PutValue is owned; linear or otherwise unavailable backends
+      reject before claim without host-import leakage or false credit.
+- [ ] Targeted loop terminals and assignment stores are emitted once by
+      prepared IR, with no legacy body and no Test262-shaped code path.
+- [ ] Slices B and C reach 27 and 33 files respectively without regressing prior
+      slices; Slice D freezes its 45-file list before claiming it.
+- [ ] Generator-wrapper files remain owned by the generator programme rather
+      than being counted as failures of this slice.

--- a/plan/issues/4277-es2015-default-parameter-dynamic-carrier-ir.md
+++ b/plan/issues/4277-es2015-default-parameter-dynamic-carrier-ir.md
@@ -1,0 +1,244 @@
+---
+id: 4277
+title: "ES2015 IR: preserve dynamic default-parameter values and initialize only undefined (143 current same-file failures)"
+status: ready
+sprint: current
+created: 2026-08-09
+updated: 2026-08-09
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+model: gpt-5.6-sol
+task_type: bugfix
+area: ir, functions, dynamic-values
+language_feature: default-parameters
+es_edition: 2015
+goal: es6
+parent: 4273
+related: [869, 2106, 2121, 2669, 2713, 2949, 3949]
+assignee: "ttraenkler/codex-es6-default-param-ir"
+test262_count: 143
+origin: "2026-08-09 exact-ES2015 default-parameters audit: the frozen #4273 baseline has 144 same-file non-passes; the latest oracle-v13 rows have 143. A stable 15-file family fails both lanes because supplied false/string/NaN/zero/null/object values lose dynamic identity, while prepared IR rejects every initializer-bearing parameter."
+---
+
+# #4277 — prepared IR default-parameter presence and dynamic carrier
+
+## Exact opportunity
+
+The authoritative frozen #4273 census contains **1,552** exact ES2015 files
+tagged `default-parameters`:
+
+| Lane | Pass | Fail | Compile error | Timeout | Total |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| GC/host | 1,376 | 157 | 4 | 15 | 1,552 |
+| standalone | 1,322 | 170 | 58 | 2 | 1,552 |
+
+That snapshot has 144 same-file non-passes. A fresh oracle-v13 read on
+2026-08-09, after main advanced, contains 143:
+
+| Lane | Pass | Fail | Compile error | Timeout | Same-file non-pass |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| GC/host | 1,375 | 157 | 4 | 16 | 143 |
+| standalone | 1,324 | 170 | 58 | 0 | 143 |
+
+The one-row aggregate movement is not evidence that one mechanism was fixed:
+host timeout jitter and two standalone flips changed independently. The
+root-cause slices below therefore use sorted path hashes and file-level
+outcomes, not the rounded aggregate.
+
+Fresh-input authority:
+
+- Test262 gitlink: `b363f29d3c43c626dc852744ad64a0b48a003693`;
+- edition map SHA-256:
+  `bbdcdfdc5b64765a2cd826b87e5255000ed70314d8aad1f38c77849d99e7708f`;
+- host JSONL SHA-256:
+  `4359c56514f456a6f597fe679a4ddc6893610e9dda54cc0d9030642a3565c371`;
+  and
+- standalone JSONL SHA-256:
+  `e874fdd266f25a8f67fb5c6b879b2ed8af3fb856ce9b4c42db1fb2039b79beed`.
+
+The same-file failures are heterogeneous. The measured top partitions are:
+
+| Partition | Exact files | Both non-pass | Primary mechanism |
+| --- | ---: | ---: | --- |
+| destructuring forms | 1,350 | 74 | pattern iteration/defaults, generator overlap; owned by #2669/#4275 |
+| non-destructuring forms | 202 | 69 | carrier identity, function metadata, TDZ, arguments environment |
+| supplied non-`undefined` values | 15 | 15 | dynamic values coerced to one inferred scalar carrier |
+| `Function.length` with a default | 16 | 15 | expected-argument-count metadata ignores first initializer |
+| self-reference plus later-reference TDZ | 30 | 16 | parameter-environment initialization state is not represented |
+
+This issue owns the shared prepared-IR parameter substrate. It does not claim
+that all 143 rows have one assertion string or that fixing Slice A completes
+destructuring, generators, function metadata, and `arguments` semantics.
+
+## First exact slice: retain supplied value identity
+
+The procedurally generated `dflt-params-arg-val-not-undefined.js` family passes
+`false`, `""`, `NaN`, `0`, `null`, and an Object to six initialized parameters.
+No initializer may execute, and every parameter must retain its original value
+and type.
+
+| Slice | Shape | Files | GC/host | Standalone | Sorted-list SHA-256 |
+| --- | --- | ---: | --- | --- | --- |
+| A | every exact ES2015 function form | 15 | 0P / 15F | 0P / 15F | `3dda3aaad28cb2f5026f1c7a077f0c85d34d9987a75d81cc93177ef339c3bdc5` |
+| A0 | ordinary non-generator function/arrow/method forms | 8 | 0P / 8F | 0P / 8F | `5f1b3ef8b18f904ef1a610038dbcf8d9b328983bd2100365e08fdc53e13cf1f6` |
+
+Hashes use sorted paths relative to `test/`, joined by newline with one final
+newline. Slice A0 paths are:
+
+- `language/expressions/arrow-function/dflt-params-arg-val-not-undefined.js`;
+- `language/expressions/class/method-static/dflt-params-arg-val-not-undefined.js`;
+- `language/expressions/class/method/dflt-params-arg-val-not-undefined.js`;
+- `language/expressions/function/dflt-params-arg-val-not-undefined.js`;
+- `language/expressions/object/method-definition/meth-dflt-params-arg-val-not-undefined.js`;
+- `language/statements/class/method-static/dflt-params-arg-val-not-undefined.js`;
+- `language/statements/class/method/dflt-params-arg-val-not-undefined.js`; and
+- `language/statements/function/dflt-params-arg-val-not-undefined.js`.
+
+The other seven Slice A paths are generator functions or generator methods.
+They stay under the generator/state-machine programme until that carrier is
+prepared; they must not be counted as failures of A0.
+
+The first failing assertion in both lanes is representative and causal:
+
+```text
+Expected SameValue(«0», «false») to be true
+```
+
+The value supplied as boolean `false` reached the body as numeric `0`. This is
+not an initializer side-effect failure: execution stops before the later
+initializer-count assertions. One scalar parameter representation was chosen
+from incomplete inference and erased the distinct JavaScript values.
+
+## Root cause and IR gap
+
+The legacy function prologue in `src/codegen/function-body.ts` selects a
+different default test from the chosen Wasm parameter type:
+
+- `externref` calls `__extern_is_undefined`;
+- refs use `ref.is_null`;
+- `i32` consults the shared `__argc` global; and
+- `f64` combines `__argc` with the signalling-NaN magic value
+  `0x7FF00000DEADC0DE`.
+
+This representation-first split cannot preserve a JavaScript parameter that
+may receive false/string/number/null/Object values. The current failures expose
+the loss directly as `false -> 0`.
+
+Prepared IR does not currently provide an alternative:
+
+1. `src/ir/propagate.ts::seedParamType` correctly classifies any
+   initializer-bearing parameter as `DYNAMIC`.
+2. `src/ir/select.ts::whyNotIrClaimable` nevertheless rejects every
+   `p.initializer` as `param-shape-rejected` for identifier and binding-pattern
+   parameters.
+3. `src/ir/from-ast.ts::fromFunctionLike` mirrors that rejection so nested
+   function paths cannot accidentally drop the initializer.
+4. direct and closure call lowering requires exact fixed arity and has no
+   prepared rule for padding omitted formals with canonical `undefined`.
+5. IR has canonical dynamic carriers and strict-undefined providers from #2949
+   and #2106, but no function-entry operation that conditionally evaluates a
+   parameter initializer and rebinds the parameter before the body.
+
+The rejection is honest; deleting it alone would silently drop default
+semantics. The fix must add the missing function ABI and prologue plan.
+
+Historic #869 remains useful evidence against the sNaN sentinel, but its
+caller-side insertion proposal is not the semantic end state. Defaults can
+reference prior parameters, throw, mutate state, observe `arguments`, or hit a
+TDZ. They must be evaluated in the callee's parameter environment, left to
+right, only when the incoming value is JavaScript `undefined`. #3949 fixed a
+legacy object-method registration hole and retains its optional-parameter tail;
+it does not prepare this IR substrate.
+
+## Required IR programme
+
+### Slice 0 — explicit default-parameter plan
+
+- Build one frozen source-site `IrDefaultParameterPlan` shared by selection,
+  signature construction, call planning, and lowering. Each admitted entry
+  records its formal index, canonical incoming type, initializer ownership,
+  parameter-environment slot, and exact undefined-test provider.
+- Keep initializer-bearing unannotated JavaScript parameters on the canonical
+  `dynamic` carrier. Do not infer their ABI from the initializer result or from
+  one observed caller.
+- Make direct/method/closure call plans accept fewer actual arguments only when
+  every missing formal has a prepared default/optional entry. Pad omitted
+  positions with canonical JavaScript `undefined`; explicit `undefined` uses the
+  same carrier and must take the same callee branch.
+- Do not evaluate initializers at call sites. Constant folding may be a later
+  proven optimization over the semantic callee plan, not a second behavior.
+
+### Slice A0 — callee-side undefined-only initialization
+
+- At function entry, seed a mutable parameter-environment slot from each
+  incoming value before lowering initializer expressions or the body.
+- Add an explicit structured IR operation/region for `if IsUndefined(slot)
+  then evaluate initializer and write slot`. Reuse the prepared dynamic
+  undefined/tag provider; do not encode this as `dyn.truthy`, `ref.is_null`,
+  argc truthiness, or signalling NaN.
+- Evaluate entries left to right. Earlier initialized parameters are readable;
+  the current and later entries remain uninitialized for TDZ purposes. Slice A0
+  may keep TDZ-heavy shapes rejected, but its IR shape must preserve the state
+  transition needed by the later slice.
+- Box a concrete initializer result back into the slot's canonical dynamic
+  carrier. The non-default arm leaves the supplied value byte-for-byte on that
+  carrier, preserving `false`, `""`, `NaN`, `0`, `null`, and Object identity.
+- Make every user-body read of the parameter consume the post-prologue slot,
+  including reassignment and capture paths.
+- Freeze host and standalone provider refs during preparation. Standalone uses
+  the tagged undefined singleton, not null-ref equivalence; host uses the
+  canonical JS-undefined predicate. If either capability is absent, reject
+  before claim.
+
+### Later monotonic slices
+
+- add the seven generator forms only after the real generator/state-machine IR
+  carrier can run the same prologue;
+- add self/later TDZ rows by representing uninitialized parameter bindings;
+- add `arguments`-referencing defaults with an unmapped ES2015 arguments
+  environment; and
+- fix default-sensitive `Function.length` through prepared function-object
+  metadata, stopping the expected count at the first initialized parameter.
+
+Destructuring parameter defaults extend the same plan only after their iterator
+and reference-order contracts are prepared under #2669/#4275.
+
+## Required tests and evidence
+
+- selector/from-AST agreement for A0 plus negative matrices for generators,
+  rest, binding patterns, TDZ-heavy initializers, unknown callees, exports, and
+  unsupported providers;
+- prepared reports prove each claimed body is `kind=emitted`,
+  `irBodyEmitted=true`, `legacyBodyEmitted=false`, with no post-claim withdrawal;
+- supplied `false`, `""`, `NaN`, `0`, `null`, and Object retain SameValue and
+  identity, and initializer counters remain zero;
+- omitted and explicit `undefined` each evaluate the initializer exactly once;
+- a supplied null/false/zero/empty-string/NaN/Object never evaluates it;
+- multiple defaults run left to right and later defaults observe prior results;
+- initializer throw prevents the body; a prior parameter is visible while
+  current/later TDZ shapes remain rejected until explicitly owned;
+- direct calls, extracted closures, instance/static methods, and object methods
+  either share the prepared argument plan or fail closed before selection;
+- standalone emits no host imports and uses the same dynamic carrier semantics;
+- targeted IR bodies contain neither the sNaN sentinel nor the legacy global
+  `__argc` default decision; and
+- authentic Test262 before/after reports reproduce the A/A0 hashes and show
+  zero pass-to-non-pass changes across all 1,552 exact files.
+
+## Acceptance criteria
+
+- [ ] The frozen plan admits only semantically complete default-parameter
+      shapes and is consumed identically by selection, call lowering, and the
+      callee prologue.
+- [ ] All eight Slice A0 files pass in GC/host and standalone through prepared
+      IR with the recorded carrier identity and no legacy body.
+- [ ] The seven generator members remain coherent fallback and are not claimed
+      until their prepared state machine can run the same prologue.
+- [ ] Omitted and explicit undefined trigger defaults; every other JavaScript
+      value, including null and falsy values, does not.
+- [ ] No targeted function uses signalling NaN or shared mutable argc state to
+      decide the default branch.
+- [ ] The exact 1,552-file feature cohort has zero regressions in both lanes,
+      and gains are reported by file rather than projected from tags.


### PR DESCRIPTION
## Summary

- record the authoritative exact-ES2015 two-lane census: 11,691 files, 74.9979% GC/host and 62.5353% standalone
- reconcile the stale-source 11,736 miscount and pin the compiler, Test262 gitlink, baseline snapshot, and oracle
- map the ten largest overlapping cohorts to repository-local Markdown owners and rank genuinely IR-native implementation levers
- specify the 128-file true-realm substrate under `plan/issues/4274-...`
- freeze the 45-file for-of assignment-destructuring family and its safe 15-file prepared-IR slice under `plan/issues/4275-...`
- partition the current 143 same-file default-parameter failures and freeze the eight-file non-generator dynamic-carrier slice under `plan/issues/4277-...`
- record the authentic literal-harness ownership result: the for-of targets live in one rejected `<module-init>` terminal, link #3783/#3523, and rerank default parameters as the immediate score-producing IR lane

## Why

The ES2015 push lacked one exact denominator and a current root-cause map. Feature counts overlap, aggregate edition artifacts are stale, and a stale Test262 checkout had inflated a fresh classification by 45 files. Without a pinned census, local wins could not be translated honestly into progress toward 90%.

The added child records turn three high-impact clusters into implementation contracts:

- realms require distinct intrinsic identity instead of the current pseudo-realm;
- for-of assignment destructuring requires an outer/inner iterator state machine with IteratorClose and host/standalone provider parity; and
- default parameters require a prepared dynamic ABI with callee-side undefined-only initialization, not the legacy shared-argc/signalling-NaN protocol.

An authentic production outcome report also showed that the 15 resolved-target for-of files cannot yet be credited from a function-local iterator probe: the literal Test262 harness owns each loop inside `<module-init>`, which first rejects at `vardecl-var-kind`. The plan now explicitly requires genuine module-global `var` and ordered module-init ownership before counting those file flips.

## Impact

This PR changes planning Markdown only. It establishes the exact score and target gaps, names owners for dominant root causes, and requires every credited implementation to land through prepared IR with two-lane file-level measurement.

No GitHub Issue is created or updated; all records live under `plan/issues/`.

## Validation

- `pnpm exec prettier --check` on changed Markdown
- `node scripts/check-issue-ids.mjs`
- `node scripts/check-committed-issue-integrity.mjs HEAD`
- `git diff --check`
- full pre-commit and pre-push hooks, including typecheck, lint, formatting, oracle/coercion ratchets, numeric-local IR parity, and committed issue integrity
