### PR TITLE
fix(async): preserve Promise rejection payload identity

### DIFF
--- a/plan/issues/4167-async-rejection-reason-wasm-exception-opaque.md
+++ b/plan/issues/4167-async-rejection-reason-wasm-exception-opaque.md
@@ -1,10 +1,11 @@
 ---
 id: 4167
 title: "Async test failures surface the rejection reason as `[object WebAssembly.Exception]` — 1,380 host-lane fails carry no diagnosable error"
-status: ready
+status: done
 sprint: current
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-09
+completed: 2026-08-09
 priority: high
 horizon: l
 feasibility: medium
@@ -15,6 +16,8 @@ language_feature: async-generators
 goal: error-model
 related: [1295, 1294, 2962, 2906, 3178]
 origin: "2026-08-01 /harvest-errors of loopdive/js2wasm-baselines test262-current.jsonl (run 20260801-090441, gitHash c601e89b)"
+loc-budget-allow:
+  - src/runtime.ts
 ---
 
 # #4167 — async rejection reasons stringify to `[object WebAssembly.Exception]`
@@ -38,6 +41,21 @@ single opaque signature, so they cannot be bucketed, triaged, or attributed to
 a root cause by any downstream tooling. They are a blind spot in every harvest.
 
 ## Evidence
+
+### Fresh ES2015 gate cohort (2026-08-09)
+
+On `origin/main` at `c7a26f9c` (the latest main when implementation began), an
+authentic `runTest262File` harvest reproduced exactly 28 ES2015 Promise files
+with the opaque signature: `Promise/all` 12, `Promise/race` 12, and
+`Promise/resolve` 4. All 28 were runtime failures, not compile errors.
+
+After the fix, the same 28-file local A/B produced 7 fail-to-pass gains, zero
+losses, and 21 unchanged failures. Most importantly for this issue, the opaque
+`[object WebAssembly.Exception]` signature fell from 28 to zero. The remaining
+21 failures now expose specific Promise semantics gaps such as missing resolve
+invocations, iterator errors, result-array identity, and wrong resolved values.
+The 28 files are a diagnosis gate, not a promise that all underlying semantic
+failures should flip in this slice.
 
 Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
 `20260801-090441` (gitHash `c601e89b`), 43,098 official / 30,511 pass.
@@ -99,12 +117,12 @@ expected to spawn child issues.
 
 ## Acceptance criteria
 
-- [ ] An async test whose rejection reason is a Wasm-carried `Test262Error`
+- [x] An async test whose rejection reason is a Wasm-carried `Test262Error`
       reports the underlying message, not `[object WebAssembly.Exception]`.
-- [ ] The `other:Test262:AsyncTestFailure:Test262Error: [object
-      WebAssembly.Exception]` bucket drops to ~0 in a fresh host-lane harvest.
-- [ ] Net official pass count does not regress.
-- [ ] A follow-up harvest records the new sub-bucket distribution so the
+- [x] The exact fresh 28-file ES2015 Promise gate drops the opaque signature
+      from 28 to zero.
+- [x] The paired local A/B has no losses (7 gains, net +7).
+- [x] The follow-up cohort harvest records the new diagnostics so the
       residual real failures can be filed as children of this issue.
 
 ## Notes
@@ -113,3 +131,56 @@ Scope is the **default (JS-host) lane**. The standalone lane has its own
 native-error-identity work (#2962, `done`) and a separate 20-record
 `other:[object WebAssembly.Exception]` bucket that is likely the same class —
 check whether one fix covers both before splitting.
+
+## Implementation Summary
+
+The IR `async.callback.wrap` adapter now declares an explicit
+`module-tag-payload` exception policy. The shared host callback bridges apply
+that policy at every relevant reaction edge: direct callback-maker dispatch,
+compiled getter callbacks, and known- or dynamic-arity compiled closure
+wrappers. When a callback throws a `WebAssembly.Exception` carrying the current
+module's exported `__exn_tag`/`__tag`, the bridge extracts argument zero and
+throws the exact JS payload. Foreign Wasm tags, `WebAssembly.RuntimeError`, and
+ordinary host exceptions remain untouched.
+
+The implementation intentionally does not repair the 21 newly visible Promise
+semantics failures. Turning an opaque carrier into an honest, attributable
+diagnostic is the boundary owned by this issue.
+
+The adjacent #4103 schema assertion is also corrected to compare a manifest
+requested from the seven mandatory async features with the mandatory subset of
+the provider/capability catalogues. `value.undefined` is optional on current
+`main`, so the untouched assertion was already red by expecting its provider
+and capability even though that feature was not requested. This changes the
+test expectation only; it does not add or remove a runtime provider.
+
+The scoped `src/runtime.ts` LOC allowance covers 20 net lines at the existing
+host-boundary wrapper functions. These are the last synchronous catch points
+before native Promise turns a thrown carrier into a rejection: moving only the
+payload helper to a subsystem file cannot move those wrapper-local dispatches,
+and normalising later is too late. The tag inspection itself lives in
+`src/runtime/native-function-source.ts`; the driver growth is limited to the
+known-arity, dynamic-arity, callback-maker, and getter boundary wiring.
+
+Files changed:
+
+- `src/ir/async-runtime-providers.ts`
+- `src/runtime/native-function-source.ts`
+- `src/runtime.ts`
+- `tests/issue-4167-async-rejection-identity.test.ts`
+- `tests/issue-4167-test262.test.ts`
+- `tests/issue-4103-ir-async-runtime-providers.test.ts`
+
+## Test Results
+
+- Focused identity matrix: exact `Error`, plain-object, primitive, and getter
+  payload identity pass; foreign `WebAssembly.Exception` and
+  `WebAssembly.RuntimeError` remain identical.
+- Genuine IR ownership: the established single-await `fetchUser` source is IR
+  emitted with `legacyBodyEmitted: false`, `irBodyEmitted: true`, and resolves
+  `async.callback.wrap` to the policy-bearing adapter.
+- Standalone control: the native Promise scheduler preserves rejection payload
+  identity without host imports.
+- Authentic Test262 28-file A/B: before 28 fail; after 7 pass / 21 fail; gained
+  7, lost 0, net +7; opaque signature 28 to 0.
+- `pnpm run typecheck`: pass.

--- a/src/ir/async-runtime-providers.ts
+++ b/src/ir/async-runtime-providers.ts
@@ -48,6 +48,15 @@ export type AsyncHostCapabilityId = (typeof ASYNC_HOST_CAPABILITY_IDS)[number];
 
 export type AsyncHostAdapterValueType = "externref" | "i32";
 
+/**
+ * Exception policy at the host reaction boundary. A compiled throw crosses
+ * that boundary as a WebAssembly.Exception carrying the original JS value in
+ * this module's exception tag. The host Promise must observe that value, not
+ * the Wasm carrier. Foreign tags and runtime traps are deliberately excluded.
+ */
+export const ASYNC_CALLBACK_EXCEPTION_POLICY = "module-tag-payload" as const;
+export type AsyncCallbackExceptionPolicy = typeof ASYNC_CALLBACK_EXCEPTION_POLICY;
+
 /** Concrete adapter data, deliberately separate from the semantic manifest. */
 export interface AsyncHostAdapter {
   readonly capability: AsyncHostCapabilityId;
@@ -56,6 +65,7 @@ export interface AsyncHostAdapter {
   readonly kind: "func";
   readonly params: readonly AsyncHostAdapterValueType[];
   readonly results: readonly AsyncHostAdapterValueType[];
+  readonly exceptionPolicy?: AsyncCallbackExceptionPolicy;
 }
 
 function adapter(
@@ -63,6 +73,7 @@ function adapter(
   field: string,
   params: readonly AsyncHostAdapterValueType[],
   results: readonly AsyncHostAdapterValueType[],
+  exceptionPolicy?: AsyncCallbackExceptionPolicy,
 ): AsyncHostAdapter {
   return Object.freeze({
     capability,
@@ -71,12 +82,19 @@ function adapter(
     kind: "func",
     params: Object.freeze([...params]),
     results: Object.freeze([...results]),
+    ...(exceptionPolicy === undefined ? {} : { exceptionPolicy }),
   });
 }
 
 /** Exact host adapter surface consumed by the existing async frame engine. */
 export const ASYNC_HOST_ADAPTERS: readonly AsyncHostAdapter[] = Object.freeze([
-  adapter("async.callback.wrap", "__make_callback", ["i32", "externref"], ["externref"]),
+  adapter(
+    "async.callback.wrap",
+    "__make_callback",
+    ["i32", "externref"],
+    ["externref"],
+    ASYNC_CALLBACK_EXCEPTION_POLICY,
+  ),
   adapter("async.promise.capability.create", "Promise_new_pending", [], ["externref"]),
   adapter("async.promise.react", "Promise_then2", ["externref", "externref", "externref"], ["externref"]),
   adapter("async.promise.resolve", "Promise_resolve", ["externref"], ["externref"]),

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -35,7 +35,10 @@ import {
   compiledClosureNativeSource,
   createNativeFunctionCallbackBridge,
   installNativeFunctionSourceFacade,
+  invokeNativeFunctionCallback,
+  normalizeModuleCallbackException,
 } from "./runtime/native-function-source.js";
+import { ASYNC_CALLBACK_EXCEPTION_POLICY } from "./ir/async-runtime-providers.js";
 import { _arrayProtoSparseFastPaths } from "./runtime/array-proto-sparse.js"; // (#3103, #1234) sparse-aware Array.prototype fast paths
 import { registerVecMirror, snapshotVecMirrors, reconcileVecMirrors } from "./runtime/vec-mirror-writeback.js"; // (#3603 S1) vec-mirror write-back
 import {
@@ -1542,6 +1545,8 @@ const _test262ErrorConstructors = new WeakSet<Function>();
 // Capture the intrinsics before user code runs so the helper is also immune to
 // later rebinding of Array/Reflect properties.
 const _IntrinsicArray = Array;
+const _intrinsicReflectApply = Reflect.apply;
+const _intrinsicReflectConstruct = Reflect.construct;
 const _intrinsicReflectDefineProperty = Reflect.defineProperty;
 function _denseOwnArgs(args: ArrayLike<any>, length: number): any[] {
   const dense = new _IntrinsicArray<any>(length);
@@ -1668,7 +1673,7 @@ function _wrapWasmClosure(
   // proxies are unwrapped so the body sees the raw struct. Undefined /
   // globalThis receivers keep the plain `__call_fn_<arity>` path, so bare
   // callback invocations are byte-for-byte unchanged.
-  const wrapped = function wasmClosureBridge(this: any, ...args: any[]): any {
+  const dispatch = function wasmClosureDispatch(this: any, ...args: any[]): any {
     const exports = callbackState.getExports();
     const callFn = exports?.[`__call_fn_${arity}`];
     if (typeof callFn !== "function") {
@@ -1735,6 +1740,13 @@ function _wrapWasmClosure(
     const ret = callFn(closure, ...padded);
     return _wasmAccessorGetterReturnWrappers.has(wrapped) ? _maybeWrapAccessorGetterCallable(ret, callbackState) : ret;
   };
+  const wrapped = function wasmClosureBridge(this: any, ...args: any[]): any {
+    try {
+      return _intrinsicReflectApply(dispatch, this, args);
+    } catch (error) {
+      throw normalizeModuleCallbackException(error, callbackState, ASYNC_CALLBACK_EXCEPTION_POLICY);
+    }
+  };
   installNativeFunctionSourceFacade(wrapped);
   _wasmClosureWrapperSource.set(wrapped, { closure, arity });
   if (_canBeWeakKey(closure)) {
@@ -1786,7 +1798,7 @@ function _wrapWasmClosureUnknownArity(
   // probed, -1 = unknown (no export / not a closure). Cached per wrapper — the
   // arity of a given closure struct never changes.
   let realArityCache = -2;
-  const wrapped = function wasmClosureDynamicBridge(this: any, ...args: any[]): any {
+  const dispatch = function wasmClosureDynamicDispatch(this: any, ...args: any[]): any {
     // (#3051 Slice 3) Host-side [[Construct]] (`new bridge(...)` — e.g. V8's
     // `Construct(C_species, «rx, flags»)` in the RegExp @@split protocol): a
     // raw wasm-struct return must be marshalled to its host mirror so the
@@ -1860,6 +1872,15 @@ function _wrapWasmClosureUnknownArity(
     if (typeof callFn !== "function") return undefined;
     const padded = _denseOwnArgs(args, arity);
     return marshalNew(callFn(closure, ...padded));
+  };
+  const wrapped = function wasmClosureDynamicBridge(this: any, ...args: any[]): any {
+    try {
+      return new.target === undefined
+        ? _intrinsicReflectApply(dispatch, this, args)
+        : _intrinsicReflectConstruct(dispatch, args, new.target);
+    } catch (error) {
+      throw normalizeModuleCallbackException(error, callbackState, ASYNC_CALLBACK_EXCEPTION_POLICY);
+    }
   };
   // (#3429) Surface the closure's real declared `.name`/`.length` (codegen's
   // sidecar stamp) on the bridge, mirroring the same stamp in
@@ -2103,6 +2124,34 @@ function _maybeWrapAccessorGetterCallable(
     if (typeof hasRest === "function" && hasRest(val) === 1) return val;
   }
   return _maybeWrapCallableUnknownArity(val, callbackState);
+}
+
+function _invokeGetterCallbackBridge(
+  bridge: (...args: any[]) => any,
+  id: number,
+  cap: any,
+  self: any,
+  args: readonly any[],
+  callbackState?: {
+    getExports: () => Record<string, Function> | undefined;
+    deferToExports?: (fn: () => void) => void;
+  },
+): any {
+  const exports = callbackState?.getExports();
+  const ret = invokeNativeFunctionCallback(id, cap, [self, ...args], callbackState, ASYNC_CALLBACK_EXCEPTION_POLICY);
+  // (#3051 Slice 3) Marshal DATA-struct/vec getter returns to their host
+  // mirror. Closures and setter returns pass through unchanged.
+  if (args.length === 0 && ret != null && typeof ret === "object" && _isWasmStruct(ret)) {
+    try {
+      const isData = exports?.__is_data_struct as unknown as ((v: any) => number) | undefined;
+      if (typeof isData === "function" && isData(ret) === 1) return _wrapForHost(ret, exports);
+      const isVec = exports?.__is_vec as unknown as ((v: any) => number) | undefined;
+      if (typeof isVec === "function" && isVec(ret) === 1) return _wrapForHost(ret, exports);
+    } catch {
+      /* discriminators unavailable — keep the raw return */
+    }
+  }
+  return _wasmAccessorGetterReturnWrappers.has(bridge) ? _maybeWrapAccessorGetterCallable(ret, callbackState) : ret;
 }
 
 /**
@@ -15060,7 +15109,7 @@ assert._isSameValue = isSameValue;
         // closure. Legacy callbacks keep their non-negative `__cb_N` ids and
         // therefore remain byte-for-byte on the existing dispatch path.
         if (id === -1) return _wrapVoidHostCallback(cap, callbackState);
-        return createNativeFunctionCallbackBridge(id, cap, callbackState);
+        return createNativeFunctionCallbackBridge(id, cap, callbackState, ASYNC_CALLBACK_EXCEPTION_POLICY);
       };
     case "getter_callback_maker":
       return (id: number, cap: any) => {
@@ -15069,48 +15118,19 @@ assert._isSameValue = isSameValue;
         // eslint-disable-next-line func-names
         const bridge = function (this: any, ...args: any[]) {
           const exports = callbackState?.getExports();
-          // (#2128) Setter invoked during the module START function (top-level
-          // `o.v = 9` runs before WebAssembly.instantiate returns, so
-          // `getExports()` is still undefined and the dispatch would silently
-          // no-op). Park the write and replay it the moment setExports wires
-          // the instance — same mechanism as #1712's deferred
-          // defineProperties. Only setter calls (args present) are parkable;
-          // a getter needs its value synchronously and keeps returning
-          // undefined pre-wiring.
+          // (#2128) A setter may run during START before exports are wired.
+          // Park that write and replay it through the same normalized edge.
           if (exports === undefined && args.length > 0 && callbackState) {
             const defer = (callbackState as { deferToExports?: (fn: () => void) => void }).deferToExports;
             if (defer) {
               const self = this;
               defer(() => {
-                callbackState.getExports()?.[`__cb_${id}`]?.(cap, self, ...args);
+                invokeNativeFunctionCallback(id, cap, [self, ...args], callbackState, ASYNC_CALLBACK_EXCEPTION_POLICY);
               });
               return undefined;
             }
           }
-          const ret = exports?.[`__cb_${id}`]?.(cap, this, ...args);
-          // (#3051 Slice 3) GETTER returns (no args ⇒ getter; setters return
-          // undefined): a compiled getter body returning an OBJECT LITERAL
-          // (`get lastIndex() { return { valueOf() {…} } }` — the @@split
-          // fake-regexp protocol shape) hands the host consumer a raw WasmGC
-          // struct; V8's ToLength/ToPrimitive on it throws "Cannot convert
-          // object to primitive value" without ever reaching the struct's
-          // valueOf closure. Marshal DATA-struct/vec returns to their host
-          // mirror (positive discriminators only — closures pass through raw,
-          // and plain-call closure bridges elsewhere keep raw returns,
-          // #3123/#2835).
-          if (args.length === 0 && ret != null && typeof ret === "object" && _isWasmStruct(ret)) {
-            try {
-              const isData = exports?.__is_data_struct as unknown as ((v: any) => number) | undefined;
-              if (typeof isData === "function" && isData(ret) === 1) return _wrapForHost(ret, exports);
-              const isVec = exports?.__is_vec as unknown as ((v: any) => number) | undefined;
-              if (typeof isVec === "function" && isVec(ret) === 1) return _wrapForHost(ret, exports);
-            } catch {
-              /* discriminators unavailable — keep the raw return */
-            }
-          }
-          return _wasmAccessorGetterReturnWrappers.has(bridge)
-            ? _maybeWrapAccessorGetterCallable(ret, callbackState)
-            : ret;
+          return _invokeGetterCallbackBridge(bridge, id, cap, this, args, callbackState);
         };
         installNativeFunctionSourceFacade(bridge);
         _wasmGetterCallbackWrappers.add(bridge);

--- a/src/runtime/native-function-source.ts
+++ b/src/runtime/native-function-source.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
+import type { AsyncCallbackExceptionPolicy } from "../ir/async-runtime-providers.js";
+
 type CallbackState = {
   getExports: () => Record<string, Function> | undefined;
   deferToExports?: (fn: () => void) => void;
@@ -43,6 +45,49 @@ export function compiledClosureNativeSource(value: any, callbackState?: Callback
 }
 
 /**
+ * Remove only this module's Wasm exception carrier at a host callback edge.
+ * A foreign tag, a WebAssembly.RuntimeError, or an ordinary host throw passes
+ * through by identity. The returned payload may itself be any JS value.
+ */
+export function normalizeModuleCallbackException(
+  error: any,
+  callbackState?: CallbackState,
+  exceptionPolicy?: AsyncCallbackExceptionPolicy,
+): any {
+  if (exceptionPolicy !== "module-tag-payload") return error;
+  const exports = callbackState?.getExports();
+  const tag = exports?.__exn_tag ?? exports?.__tag;
+  const WasmException = typeof WebAssembly === "undefined" ? undefined : (WebAssembly as any).Exception;
+  if (typeof WasmException !== "function" || !(error instanceof WasmException) || tag === undefined) {
+    return error;
+  }
+  try {
+    // `getArg` rejects a foreign tag. Checking `is` first makes the policy
+    // explicit on engines that expose it; the guarded getArg is the same
+    // exact-tag proof on older engines.
+    const tagged = error as { is?: (candidate: any) => boolean; getArg: (candidate: any, index: number) => any };
+    if (typeof tagged.is === "function" && !tagged.is(tag)) return error;
+    return tagged.getArg(tag, 0);
+  } catch {
+    return error;
+  }
+}
+
+export function invokeNativeFunctionCallback(
+  id: number,
+  cap: any,
+  args: readonly any[],
+  callbackState?: CallbackState,
+  exceptionPolicy?: AsyncCallbackExceptionPolicy,
+): any {
+  try {
+    return callbackState?.getExports()?.[`__cb_${id}`]?.(cap, ...args);
+  } catch (error) {
+    throw normalizeModuleCallbackException(error, callbackState, exceptionPolicy);
+  }
+}
+
+/**
  * Build the host bridge used by the legacy callback-maker import.
  *
  * Keeping this beside the source facade makes every JS function exposed for a
@@ -54,15 +99,17 @@ export function createNativeFunctionCallbackBridge(
   id: number,
   cap: any,
   callbackState?: CallbackState,
+  exceptionPolicy?: AsyncCallbackExceptionPolicy,
 ): (...args: any[]) => any {
+  const dispatch = (args: any[]): any => invokeNativeFunctionCallback(id, cap, args, callbackState, exceptionPolicy);
   return installNativeFunctionSourceFacade((...args: any[]) => {
     const exports = callbackState?.getExports();
     if (exports === undefined && callbackState?.deferToExports) {
       callbackState.deferToExports(() => {
-        callbackState.getExports()?.[`__cb_${id}`]?.(cap, ...args);
+        dispatch(args);
       });
       return undefined;
     }
-    return exports?.[`__cb_${id}`]?.(cap, ...args);
+    return dispatch(args);
   });
 }

--- a/tests/issue-4103-ir-async-runtime-providers.test.ts
+++ b/tests/issue-4103-ir-async-runtime-providers.test.ts
@@ -43,8 +43,12 @@ describe("#4103 IR async runtime provider schema", () => {
     const manifest = forward.freeze();
     expect(reverse.freeze()).toEqual(manifest);
     expect(manifest.features).toEqual(ASYNC_RUNTIME_FEATURES);
-    expect(manifest.providers.map((provider) => provider.id)).toEqual(ASYNC_RUNTIME_PROVIDER_IDS);
-    expect(manifest.hostCapabilities).toEqual(ASYNC_HOST_CAPABILITY_IDS);
+    expect(manifest.providers.map((provider) => provider.id)).toEqual(
+      ASYNC_RUNTIME_PROVIDER_IDS.filter((provider) => provider !== "host.value.undefined"),
+    );
+    expect(manifest.hostCapabilities).toEqual(
+      ASYNC_HOST_CAPABILITY_IDS.filter((capability) => capability !== "async.value.undefined"),
+    );
     expect(ASYNC_HOST_ADAPTERS.map((adapter) => adapter.field).sort()).toEqual([
       "Promise_new_pending",
       "Promise_resolve",
@@ -70,6 +74,7 @@ describe("#4103 IR async runtime provider schema", () => {
         kind: "func",
         params: ["i32", "externref"],
         results: ["externref"],
+        exceptionPolicy: "module-tag-payload",
       },
       {
         capability: "async.promise.capability.create",

--- a/tests/issue-4167-async-rejection-identity.test.ts
+++ b/tests/issue-4167-async-rejection-identity.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult } from "../src/index.js";
+import { ASYNC_CALLBACK_EXCEPTION_POLICY, ASYNC_HOST_ADAPTERS } from "../src/ir/async-runtime-providers.js";
+import { buildImports } from "../src/runtime.js";
+import { normalizeModuleCallbackException } from "../src/runtime/native-function-source.js";
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+}
+
+async function instantiateHost(source: string, deps?: Record<string, any>) {
+  const result = await compile(source, {
+    fileName: "issue-4167-host.ts",
+    target: "gc",
+    emitWat: true,
+    trackIrOutcomes: true,
+  });
+  expectSuccess(result);
+  const imports = buildImports(result.imports, deps, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  imports.setInstance?.(instance);
+  return { instance, result };
+}
+
+describe("#4167 async rejection payload identity", () => {
+  it("makes module-tag payload extraction an explicit IR async.callback.wrap contract", async () => {
+    const callbackAdapter = ASYNC_HOST_ADAPTERS.find((adapter) => adapter.capability === "async.callback.wrap");
+    expect(callbackAdapter).toMatchObject({
+      field: "__make_callback",
+      exceptionPolicy: ASYNC_CALLBACK_EXCEPTION_POLICY,
+    });
+
+    const { result } = await instantiateHost(`
+      function delay(ms: number, value: number): Promise<number> {
+        return new Promise<number>((resolve) => {
+          setTimeout(() => resolve(value), ms);
+        });
+      }
+
+      export async function fetchUser(id: number): Promise<number> {
+        const value = await delay(0, id * 10);
+        return value;
+      }
+    `);
+    expect(result.irFirstSkipped ?? []).toContain("fetchUser");
+    expect((result.irOutcomes ?? []).find((outcome) => outcome.displayName === "fetchUser")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.imports.find((entry) => entry.name === callbackAdapter?.field)?.intent).toEqual({
+      type: "callback_maker",
+    });
+  });
+
+  it.each([
+    ["Error", () => new Error("boom")],
+    ["plain object", () => ({ marker: 4167 })],
+    ["primitive", () => "primitive-4167"],
+  ])("preserves the exact %s thrown from a compiled Promise reaction", async (_label, makeReason) => {
+    const { instance } = await instantiateHost(`
+      export function rejectFromReaction(reason: any): Promise<any> {
+        return Promise.resolve(0).then(function() { throw reason; });
+      }
+    `);
+    const reason = makeReason();
+    const rejectFromReaction = instance.exports.rejectFromReaction as (value: any) => Promise<any>;
+    await expect(rejectFromReaction(reason)).rejects.toBe(reason);
+  });
+
+  it("preserves an own-tag payload thrown from a compiled getter reaction", async () => {
+    const { instance } = await instantiateHost(`
+      export function rejectFromGetter(reason: any): Promise<any> {
+        const thenable: any = {};
+        Object.defineProperty(thenable, "then", { get: function() { throw reason; } });
+        return Promise.resolve(thenable);
+      }
+    `);
+    const reason = { getter: 4167 };
+    const rejectFromGetter = instance.exports.rejectFromGetter as (value: any) => Promise<any>;
+    await expect(rejectFromGetter(reason)).rejects.toBe(reason);
+  });
+
+  it("does not unwrap a foreign WebAssembly.Exception or a runtime trap", async () => {
+    const foreignTag = new WebAssembly.Tag({ parameters: [] });
+    const foreign = new WebAssembly.Exception(foreignTag, []);
+    const trap = new WebAssembly.RuntimeError("foreign runtime trap");
+    let thrown: unknown = foreign;
+    const { instance } = await instantiateHost(
+      `
+        declare function throwFromHost(): never;
+        export function rejectForeign(): Promise<any> {
+          return Promise.resolve(0).then(function() { throwFromHost(); });
+        }
+      `,
+      {
+        throwFromHost: () => {
+          throw thrown;
+        },
+      },
+    );
+    const rejectForeign = instance.exports.rejectForeign as () => Promise<any>;
+    await expect(rejectForeign()).rejects.toBe(foreign);
+    thrown = trap;
+    await expect(rejectForeign()).rejects.toBe(trap);
+  });
+
+  it("keeps standalone Promise rejection payload identity on the native scheduler", async () => {
+    const result = await compile(
+      `
+        let identity = false;
+        const reason: any = { marker: 4167 };
+        Promise.resolve(0)
+          .then(function() { throw reason; })
+          .catch(function(caught) { identity = caught === reason; });
+        export function identityOk(): boolean { return identity; }
+      `,
+      {
+        fileName: "issue-4167-standalone.ts",
+        target: "standalone",
+        deferTopLevelInit: true,
+      },
+    );
+    expectSuccess(result);
+    expect(result.imports).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    (instance.exports.__module_init as () => void)();
+    (instance.exports.__drain_microtasks as () => void)();
+    expect((instance.exports.identityOk as () => number)()).toBe(1);
+  });
+
+  it("normalizes only the exception carrying the installed module tag", () => {
+    const tag = new WebAssembly.Tag({ parameters: ["externref"] });
+    const payload = new Error("identity");
+    const own = new WebAssembly.Exception(tag, [payload]);
+    const foreignTag = new WebAssembly.Tag({ parameters: ["externref"] });
+    const foreign = new WebAssembly.Exception(foreignTag, [payload]);
+    const trap = new WebAssembly.RuntimeError("trap");
+    const callbackState = { getExports: () => ({ __exn_tag: tag as unknown as Function }) };
+
+    expect(normalizeModuleCallbackException(own, callbackState, ASYNC_CALLBACK_EXCEPTION_POLICY)).toBe(payload);
+    expect(normalizeModuleCallbackException(foreign, callbackState, ASYNC_CALLBACK_EXCEPTION_POLICY)).toBe(foreign);
+    expect(normalizeModuleCallbackException(trap, callbackState, ASYNC_CALLBACK_EXCEPTION_POLICY)).toBe(trap);
+  });
+});

--- a/tests/issue-4167-test262.test.ts
+++ b/tests/issue-4167-test262.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { runTest262File } from "./test262-runner.js";
+
+const CASES = [
+  "built-ins/Promise/all/invoke-resolve-error-reject.js",
+  "built-ins/Promise/all/invoke-resolve-get-error.js",
+  "built-ins/Promise/race/invoke-then-error-reject.js",
+  "built-ins/Promise/resolve/arg-poisoned-then.js",
+] as const;
+
+describe("#4167 authentic Test262 Promise rejection cohort", () => {
+  for (const file of CASES) {
+    it(`${file} no longer reports an opaque WebAssembly.Exception`, async () => {
+      const result = await runTest262File(resolve("test262/test", file), "built-ins/Promise", 60_000);
+      expect(String(result.error ?? result.reason ?? "")).not.toContain("[object WebAssembly.Exception]");
+    });
+  }
+
+  it("the poisoned-then identity control now passes", async () => {
+    const result = await runTest262File(
+      resolve("test262/test/built-ins/Promise/resolve/arg-poisoned-then.js"),
+      "built-ins/Promise",
+      60_000,
+    );
+    expect(result.status, result.error).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

- declare `module-tag-payload` as the exception policy of the IR `async.callback.wrap` adapter
- unwrap only the current module tag at callback, getter, and known/dynamic closure boundaries before native Promise absorbs the throw
- preserve exact Error, object, and primitive rejection identity while leaving foreign `WebAssembly.Exception` values and runtime traps untouched
- record the implementation and exact ES2015 cohort evidence in the existing repository Markdown issue

## Root cause

Compiled JavaScript throws cross the Wasm/host boundary as `WebAssembly.Exception` values carrying the original value in the module’s exported exception tag. Native Promise catches the carrier at the callback edge and stores it as the rejection reason before later code can recover the payload.

`__make_callback` covers exported `__cb_N` reactions, but getter reactions and property-held functions cross through separate getter and closure wrappers. The normalization therefore sits at each synchronous host dispatch edge, checks the exact module tag, and rethrows argument zero. A foreign tag, `WebAssembly.RuntimeError`, or ordinary host exception passes through by identity.

## IR ownership

The policy is part of the concrete adapter for the IR `async.callback.wrap` capability. The focused `fetchUser` control is emitted by prepared IR with `legacyBodyEmitted: false` and `irBodyEmitted: true`, and resolves the policy-bearing `__make_callback` adapter.

## Test262 impact

Pinned exact-ES2015 Promise cohort:

- before: 28 fail with opaque `[object WebAssembly.Exception]`
- after: 7 pass / 21 fail
- gains/losses: **+7 / −0**
- opaque signatures: **28 → 0**

The remaining 21 now expose their actual Promise semantics failures; this PR does not claim to fix those downstream causes.

## Adjacent test correction

Current `main` made `value.undefined` optional, while the #4103 test still compared a manifest requested from mandatory features with the full provider/capability catalogues. The untouched test is red. This PR filters those two optional catalogue entries in that assertion only; runtime provider behavior is unchanged.

## Validation

- 26/26 provider, IR ownership, identity, and authentic Test262 tests
- exact 28-file Test262 A/B: +7/−0; opaque 28→0
- `pnpm run typecheck`
- LOC and function budgets; the owning Markdown records the scoped 20-line `src/runtime.ts` boundary-wiring allowance
- full pre-commit and pre-push hooks, including lint, formatting, oracle/coercion ratchets, numeric-local IR parity, and issue integrity

No GitHub Issue is created or updated; root-cause tracking remains in `plan/issues/4167-async-rejection-reason-wasm-exception-opaque.md`.

