### PR TITLE
fix(benchmarks): verify array callback checksums

### DIFF
--- a/benchmarks/suites/arrays.ts
+++ b/benchmarks/suites/arrays.ts
@@ -22,19 +22,19 @@ function sortF64(): void {
   arr.sort((a, b) => a - b);
 }
 
-function mapFilter(): void {
+function mapFilter(): number {
   const arr: number[] = [];
   for (let i = 0; i < 10000; i++) arr.push(i);
   const mapped = arr.map((x) => x * 2);
   const filtered = mapped.filter((x) => x % 3 === 0);
-  void filtered.length;
+  return filtered.length;
 }
 
-function reduceSum(): void {
+function reduceSum(): number {
   const arr: number[] = [];
   for (let i = 0; i < 100000; i++) arr.push(i);
   const sum = arr.reduce((acc, x) => acc + x, 0);
-  void sum;
+  return sum;
 }
 
 function indexOfSearch(): void {
@@ -66,16 +66,17 @@ function reverseArr(): void {
   for (let i = 0; i < 1000; i++) arr.reverse();
 }
 
-function forEachSum(): void {
+function forEachSum(): number {
   const arr: number[] = [];
   for (let i = 0; i < 10000; i++) arr.push(i);
   let sum = 0;
   arr.forEach((x) => {
     sum += x;
   });
+  return sum;
 }
 
-function findElement(): void {
+function findElement(): number {
   const arr: number[] = [];
   for (let i = 0; i < 10000; i++) arr.push(i);
   let sum = 0;
@@ -83,6 +84,7 @@ function findElement(): void {
     const found = arr.find((x) => x === 5000);
     if (found !== undefined) sum += found;
   }
+  return sum;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/issue-3898.test.ts
+++ b/tests/issue-3898.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, it, expect } from "vitest";
 import { compile, buildImports, instantiateWasm } from "../src/index.js";
+import { arrayBenchmarks } from "../benchmarks/suites/arrays.js";
 import { stringBenchmarks } from "../benchmarks/suites/strings.js";
 import { mixedBenchmarks } from "../benchmarks/suites/mixed.js";
 import { flagImplausibleLanes, generateMarkdown, MIN_PLAUSIBLE_NS_PER_OP } from "../benchmarks/report.js";
@@ -246,4 +247,60 @@ describe("#3898 cross-lane equivalence", () => {
     },
     120_000,
   );
+});
+
+describe("#3898 array callback cross-lane checksums", () => {
+  const names = ["array/map-filter", "array/reduce", "array/forEach", "array/find"];
+  const defs = names.map((name) => arrayBenchmarks.find((def) => def.name === name)!);
+
+  it("keeps every JS callback baseline numeric so the harness compares it", () => {
+    for (const def of defs) {
+      expect(def, `${def?.name ?? "missing definition"} must exist`).toBeDefined();
+      const value = def.js();
+      expect(typeof value, `${def.name} must return its checksum`).toBe("number");
+      expect(Number.isFinite(value as number), `${def.name} returned ${value}`).toBe(true);
+    }
+  });
+
+  it.each(defs)(
+    "$name: optimized gc-native run() matches the JS checksum",
+    async (def) => {
+      const result = await compile(def.source, { fast: true, emitWat: false, optimize: 4 });
+      expect(result.success, `compile failed: ${result.errors?.[0]?.message}`).toBe(true);
+
+      const imports = buildImports(result.imports, {}, result.stringPool);
+      const { instance } = await instantiateWasm(result.binary, imports.env, imports.string_constants);
+      imports.setInstance?.(instance);
+
+      const run = (instance.exports as Record<string, () => number>).run!;
+      expect(run()).toBe(def.js());
+    },
+    120_000,
+  );
+
+  it("records a real callback benchmark checksum mismatch as a failed lane", async () => {
+    const original = defs.find((def) => def.name === "array/reduce")!;
+    const expected = original.js() as number;
+    const previousExitCode = process.exitCode;
+    try {
+      const results = await runBenchmark(
+        {
+          ...original,
+          name: "probe/array-reduce-mismatch",
+          iterations: 1,
+          warmup: 1,
+          js: () => expected + 1,
+        },
+        ["gc-native"],
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0]!.status).toBe("failed");
+      expect(results[0]!.failedPhase).toBe("cross-lane");
+      expect(results[0]!.error).toContain("cross-lane mismatch");
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  }, 120_000);
 });


### PR DESCRIPTION
## Summary

- Return the computed checksum from the JavaScript baselines for array map/filter, reduce, forEach, and find.
- Add optimized gc-native equivalence coverage for all four workloads.
- Prove a deliberately mismatched real array/reduce workload is recorded as a failed cross-lane result.
- Keep benchmark workloads, iterations, operation counts, and plausibility thresholds unchanged. No published benchmark data is included.

## Corrected local measurements

Official harness on Node v24.4.1, Darwin arm64. Base 7a8972f3ab8e0c; head 2e5bf05230cbb4. Figures are the median of three independent run medians.

| Benchmark | JavaScript | gc-native | Result |
| --- | ---: | ---: | --- |
| array/map-filter | 0.104 ms | 0.022 ms | gc-native 4.66x faster, but correctly rejected as implausible at 0.706-0.879 ns/op |
| array/reduce | 0.706 ms | 0.165 ms | gc-native 4.29x faster |
| array/forEach | 0.040 ms | 0.016 ms | gc-native 2.55x faster |
| array/find | 0.187 ms | 0.007 ms | gc-native 26.89x faster |

The corrected checksums are 3334, 4999950000, 49995000, and 500000 respectively. All measured gc-native lanes matched their JavaScript reference. No real compiler lag was exposed by activating the checksum guard.

gc-native artifact sizes were 3610 B, 2596 B, 2823 B, and 1202 B respectively.

## Validation

- issue-3898 focused suite: 24/24 passed
- TypeScript typecheck
- Prettier and Biome
- LOC, function-size, oracle, coercion-site, IR-fallback, codegen-fallback, and stack-balance gates
- Full pre-commit and pre-push hooks
