### PR TITLE
perf(strings): elide empty concat allocations

### DIFF
--- a/src/codegen/native-strings-basics.ts
+++ b/src/codegen/native-strings-basics.ts
@@ -51,6 +51,30 @@ export function emitStrConcatHelpers(shared: NativeStrShared): void {
       { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 },
       { op: "local.set", index: 3 }, // lenB
 
+      // Empty strings are the identity element for concatenation. Returning
+      // the other immutable string directly avoids allocating and copying a
+      // fresh flat string for common accumulator shapes such as
+      // `let out = ""; out += value`. Keep a compile-time kill switch so the
+      // optimization can be measured against the identical compiler tree.
+      ...(process.env.JS2WASM_STR_CONCAT_EMPTY_IDENTITY === "0"
+        ? []
+        : [
+            { op: "local.get" as const, index: 2 },
+            { op: "i32.eqz" as const },
+            {
+              op: "if" as const,
+              blockType: { kind: "empty" as const },
+              then: [{ op: "local.get" as const, index: 1 }, { op: "return" as const }],
+            },
+            { op: "local.get" as const, index: 3 },
+            { op: "i32.eqz" as const },
+            {
+              op: "if" as const,
+              blockType: { kind: "empty" as const },
+              then: [{ op: "local.get" as const, index: 0 }, { op: "return" as const }],
+            },
+          ]),
+
       // newLen = lenA + lenB
       { op: "local.get", index: 2 },
       { op: "local.get", index: 3 },

--- a/tests/native-string-empty-concat.test.ts
+++ b/tests/native-string-empty-concat.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Native strings are immutable values, so the general concat helper may return
+// the other operand when either side is empty. This is intentionally NOT an
+// optimization for __str_concat_owned: that helper needs private backing before
+// a later append can mutate in place.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const SOURCE = `
+function join(left: string, right: string): string {
+  return left + right;
+}
+
+export function run(seed: number): number {
+  const value = "value-" + seed;
+  const empty = value.substring(0, 0);
+  const long = join(value.repeat(8), value.repeat(8));
+  const left = join(empty, value);
+  const right = join(value, empty);
+  const ropeLeft = join(empty, long);
+  const ropeRight = join(long, empty);
+  return left.length + right.length + ropeLeft.length + ropeRight.length
+    + left.charCodeAt(0) + right.charCodeAt(right.length - 1);
+}
+
+export function build(count: number): number {
+  let value = "";
+  for (let index = 0; index < count; index++) value += "ab";
+  return value.length;
+}
+`;
+
+function functionWat(wat: string, name: string): string {
+  const start = wat.indexOf(`(func $${name}`);
+  expect(start, `func $${name} not found`).toBeGreaterThanOrEqual(0);
+  const next = wat.indexOf("\n  (func $", start + 1);
+  return wat.slice(start, next < 0 ? wat.length : next);
+}
+
+async function compileProbe(enabled: boolean) {
+  process.env.JS2WASM_STR_CONCAT_EMPTY_IDENTITY = enabled ? "1" : "0";
+  const result = await compile(SOURCE, {
+    fileName: "native-string-empty-concat.ts",
+    target: "standalone",
+    hostBridge: "always",
+  } as never);
+  expect(result.success, result.success ? undefined : result.errors?.[0]?.message).toBe(true);
+  expect(WebAssembly.validate(result.binary!)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary!, {});
+  (instance.exports.__module_init as (() => void) | undefined)?.();
+  return {
+    run: instance.exports.run as (seed: number) => number,
+    concatWat: functionWat(result.wat!, "__str_concat"),
+    ownedWat: result.wat!.includes("(func $__str_concat_owned")
+      ? functionWat(result.wat!, "__str_concat_owned")
+      : undefined,
+  };
+}
+
+afterEach(() => {
+  process.env.JS2WASM_STR_CONCAT_EMPTY_IDENTITY = undefined;
+});
+
+describe("native string empty-concat identity", () => {
+  it("preserves flat and rope results in both operand orders", async () => {
+    const optimized = await compileProbe(true);
+    const control = await compileProbe(false);
+    for (const seed of [0, 7, 42, -3]) {
+      expect(optimized.run(seed)).toBe(control.run(seed));
+    }
+  });
+
+  it("emits both identity returns behind the kill switch", async () => {
+    const optimized = await compileProbe(true);
+    const control = await compileProbe(false);
+    expect(optimized.concatWat).toMatch(/local\.get 2\s+i32\.eqz[\s\S]*local\.get 1\s+return/);
+    expect(optimized.concatWat).toMatch(/local\.get 3\s+i32\.eqz[\s\S]*local\.get 0\s+return/);
+    expect(control.concatWat).not.toMatch(/local\.get 2\s+i32\.eqz[\s\S]*local\.get 1\s+return/);
+  });
+
+  it("does not add the identity contract to the owned append helper", async () => {
+    const optimized = await compileProbe(true);
+    const control = await compileProbe(false);
+    expect(optimized.ownedWat).toBeDefined();
+    expect(optimized.ownedWat).toBe(control.ownedWat);
+  });
+});


### PR DESCRIPTION
## Summary

- return the other native-string operand when general string concatenation sees an empty side
- avoid flattening, allocating, and copying a fresh short string for accumulator shapes such as `let out = ""; out += value`
- leave `__str_concat_owned` unchanged because its later in-place append requires private backing
- add flat, rope, kill-switch, and owned-helper regression coverage

## Performance

Pinned `clsx@2.1.1`, standalone runtime-dynamic lane, five alternating pairs from the same compiler tree:

| | Median | Samples (µs/op) |
|---|---:|---|
| optimized | 0.1756 µs | 0.1781, 0.1756, 0.2208, 0.1753, 0.1715 |
| `JS2WASM_STR_CONCAT_EMPTY_IDENTITY=0` | 0.2261 µs | 0.3325, 0.2103, 0.2931, 0.2110, 0.2261 |

That is a **22.4% median runtime reduction**. Both paths returned the same checksum (`14`). The optimized standalone binary is 37,035 bytes versus 37,003 bytes for the control (+32 bytes).

Positive scaling control on the optimized binary:

- 1,000,000 iterations: 184.3 ms, checksum 18,888,890
- 2,000,000 iterations: 369.0 ms, checksum 38,888,890

The JS-host binary remains byte-identical at 2,126 bytes; that lane uses the host string-concat import and is structurally unaffected.

Measurement base: `7a8972f3ab8e0cd6cf26c21eca5687299e92cee6`  
Optimization commit: `572aba1f6052dcfe58cf51387b1b6ef4c3c63921`  
PR head after syncing current `main`: `38a4dfb5e0b5c3`

## Validation

- 3 focused empty-concat tests
- 117 native-string/concat regression tests
- pinned clsx differential: 17/18 equal, with only the pre-existing known #3749 row still throwing
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- LOC and function budgets
- pre-commit and pre-push hooks

## Kill switch

Set `JS2WASM_STR_CONCAT_EMPTY_IDENTITY=0` at compile time to restore the prior helper body.
