### PR TITLE
perf(array): batch numeric indexOf misses

### DIFF
--- a/src/codegen/array-indexof-scan.ts
+++ b/src/codegen/array-indexof-scan.ts
@@ -5,6 +5,14 @@ import type { FunctionContext } from "./context/types.js";
 
 const HOT_COUNTED_PUSH_TRIP_COUNT = 1024;
 const HOT_NUMERIC_INDEX_OF_UNROLL = 32;
+// Four pure comparisons share one miss branch. Eight elements (two batches)
+// kept the hot body compact while still amortizing its loop backedge.
+const HOT_NUMERIC_INDEX_OF_BATCHED_UNROLL = 8;
+const HOT_NUMERIC_INDEX_OF_BRANCH_BATCH = 4;
+
+function batchedIndexOfBranchesEnabled(): boolean {
+  return process.env.JS2WASM_ARRAY_INDEXOF_BATCHED_BRANCHES !== "0";
+}
 
 interface CountedPushProof {
   readonly tripCount: number;
@@ -27,8 +35,8 @@ interface IndexOfScan {
 }
 
 // This is code-selection metadata, not a semantic proof. Keeping it outside
-// FunctionContext avoids making every emitter subsystem depend on this one
-// benchmark-oriented heuristic, while WeakMap keeps its lifetime compile-local.
+// FunctionContext avoids making every emitter subsystem depend on this hot-scan
+// heuristic, while WeakMap keeps its lifetime compile-local.
 const countedPushTripCounts = new WeakMap<FunctionContext, Map<string, number>>();
 
 export function registerCountedPushArray(fctx: FunctionContext, proof: CountedPushProof, vecTypeIdx: number): void {
@@ -46,7 +54,8 @@ export function countedPushIndexOfUnroll(
 ): number {
   const numericElements = elemType.kind === "f64" || elemType.kind === "i32";
   const tripCount = receiverName === undefined ? undefined : countedPushTripCounts.get(fctx)?.get(receiverName);
-  return numericElements && (tripCount ?? 0) >= HOT_COUNTED_PUSH_TRIP_COUNT ? HOT_NUMERIC_INDEX_OF_UNROLL : 1;
+  if (!numericElements || (tripCount ?? 0) < HOT_COUNTED_PUSH_TRIP_COUNT) return 1;
+  return batchedIndexOfBranchesEnabled() ? HOT_NUMERIC_INDEX_OF_BATCHED_UNROLL : HOT_NUMERIC_INDEX_OF_UNROLL;
 }
 
 /** Emit a scalar scan or a wide main loop with a scalar tail. */
@@ -73,6 +82,14 @@ export function emitArrayIndexOfScan(fctx: FunctionContext, scan: IndexOfScan): 
         { op: "br", depth: breakDepth },
       ],
     },
+  ];
+  const equalityAtOffset = (offset: number): Instr[] => [
+    { op: "local.get", index: scan.dataLocal },
+    ...indexInstrs(offset),
+    { op: scan.getOp, typeIdx: scan.arrTypeIdx },
+    ...scan.holeMap,
+    { op: "local.get", index: scan.valueLocal },
+    ...scan.equality,
   ];
   const increment = (amount: number): Instr[] => [
     { op: "local.get", index: scan.indexLocal },
@@ -106,8 +123,27 @@ export function emitArrayIndexOfScan(fctx: FunctionContext, scan: IndexOfScan): 
     { op: "i32.lt_s" },
     { op: "br_if", depth: 1 },
   ];
-  for (let offset = 0; offset < scan.unroll; offset++) {
-    wideLoop.push(...compareAtOffset(offset, 3));
+  const batchBranches = batchedIndexOfBranchesEnabled();
+  for (let offset = 0; offset < scan.unroll; offset += HOT_NUMERIC_INDEX_OF_BRANCH_BATCH) {
+    const end = Math.min(offset + HOT_NUMERIC_INDEX_OF_BRANCH_BATCH, scan.unroll);
+    if (!batchBranches) {
+      for (let candidate = offset; candidate < end; candidate++) {
+        wideLoop.push(...compareAtOffset(candidate, 3));
+      }
+      continue;
+    }
+    for (let candidate = offset; candidate < end; candidate++) {
+      wideLoop.push(...equalityAtOffset(candidate));
+      if (candidate > offset) wideLoop.push({ op: "i32.or" });
+    }
+    // A miss takes one branch for the whole batch. A hit rechecks only that
+    // side-effect-free batch in source order so duplicate values still return
+    // the first matching index.
+    wideLoop.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: Array.from({ length: end - offset }, (_, index) => compareAtOffset(offset + index, 4)).flat(),
+    });
   }
   wideLoop.push(...increment(scan.unroll));
 

--- a/tests/equivalence/issue-1197.test.ts
+++ b/tests/equivalence/issue-1197.test.ts
@@ -139,6 +139,70 @@ describe("#1197 i32 element specialization for number[]", () => {
       expect((instance.exports.test as () => number)()).toBe(7);
     });
 
+    it("the batched miss path preserves f64 strict-equality search semantics", async () => {
+      const source = `export function test(): number {
+        const arr: number[] = [];
+        for (let i = 0; i < 1031; i = i + 1) {
+          arr.push(i + 0.25);
+        }
+        let passed = 0;
+        if (arr.indexOf(0.25) === 0) passed = passed + 1;
+        if (arr.indexOf(37.25) === 37) passed = passed + 1;
+        if (arr.indexOf(1030.25) === 1030) passed = passed + 1;
+        if (arr.indexOf(2000.25) === -1) passed = passed + 1;
+        if (arr.indexOf(NaN) === -1) passed = passed + 1;
+        if (arr.indexOf(37.25, 38) === -1) passed = passed + 1;
+        if (arr.indexOf(1030.25, -1) === 1030) passed = passed + 1;
+        return passed;
+      }`;
+      const result = await compile(source, { fast: true });
+      expect(result.success).toBe(true);
+      const imports = buildImports(result.imports, undefined, result.stringPool);
+      const { instance } = await WebAssembly.instantiate(result.binary, imports);
+      imports.setInstance?.(instance);
+      expect((instance.exports.test as () => number)()).toBe(7);
+    });
+
+    it("batches hot numeric misses while the kill switch restores the branch ladder", async () => {
+      const source = `export function test(): number {
+        const arr: number[] = [];
+        for (let i = 0; i < 1031; i = i + 1) {
+          arr.push((i * 37) % 1031);
+        }
+        return arr.indexOf(444);
+      }`;
+      const compileWithBatching = async (enabled: boolean) => {
+        const previous = process.env.JS2WASM_ARRAY_INDEXOF_BATCHED_BRANCHES;
+        try {
+          process.env.JS2WASM_ARRAY_INDEXOF_BATCHED_BRANCHES = enabled ? "1" : "0";
+          return await compile(source, { fast: true });
+        } finally {
+          if (previous === undefined) {
+            Reflect.deleteProperty(process.env, "JS2WASM_ARRAY_INDEXOF_BATCHED_BRANCHES");
+          } else process.env.JS2WASM_ARRAY_INDEXOF_BATCHED_BRANCHES = previous;
+        }
+      };
+      const candidate = await compileWithBatching(true);
+      const control = await compileWithBatching(false);
+      expect(candidate.success).toBe(true);
+      expect(control.success).toBe(true);
+
+      const functionBody = (wat: string): string => {
+        const start = wat.indexOf("(func $test ");
+        const end = wat.indexOf("\n  (func ", start + 1);
+        return wat.slice(start, end);
+      };
+      expect(functionBody(candidate.wat ?? "")).toContain("i32.or");
+      expect(functionBody(control.wat ?? "")).not.toContain("i32.or");
+
+      for (const compiled of [candidate, control]) {
+        const imports = buildImports(compiled.imports, undefined, compiled.stringPool);
+        const { instance } = await WebAssembly.instantiate(compiled.binary, imports);
+        imports.setInstance?.(instance);
+        expect((instance.exports.test as () => number)()).toBe(12);
+      }
+    });
+
     it("compound bitwise assignment on element preserves i32 semantics", async () => {
       await assertEquivalent(
         `export function test(): number {


### PR DESCRIPTION
## Summary

- group four side-effect-free numeric `indexOf` comparisons behind one miss branch
- use a compact eight-element hot loop instead of the previous 32-way branch ladder
- recheck only a matching batch in source order, preserving the first duplicate match
- retain `JS2WASM_ARRAY_INDEXOF_BATCHED_BRANCHES=0` as an exact same-tree control

This is a generic counted-push numeric-array optimization. It does not inspect benchmark, package, function, or source names.

## Same-tree measurement

- base: `c670f87dcaeb829190fddf19bdc3cb14d41dcc1e`
- candidate: `b9a6e462915dccdbaf30846306069522a65a6489`
- runtime: Node `v24.4.1`, Darwin arm64
- lane: `fast: true`, GC backend, `optimize: 4`
- method: separately compiled kill-switch artifacts, then 15 order-balanced blocks of 50 calls after 100 warmups in one process

| Artifact | Median per `run()` | Binary | Checksum per block |
| --- | ---: | ---: | ---: |
| control (`...BATCHED_BRANCHES=0`) | 1.9981 ms | 2,541 B | 249,750,000 |
| candidate | 1.9417 ms | 2,061 B | 249,750,000 |

That is **2.8% lower median runtime** and **480 B / 18.9% less code** for the focused artifact. Runtime samples on this shared machine remain noisy, so the code-size reduction is the stronger result. This checkpoint narrows the remaining `array/indexOf` gap; it does not claim Node/V8 parity yet.

Positive work-scaling control, using one candidate artifact and complete 1,000-search rounds:

| Rounds | Median | Checksum |
| ---: | ---: | ---: |
| 1 | 3.5028 ms | 4,995,000 |
| 2 | 8.1028 ms | 9,990,000 |
| 4 | 13.7474 ms | 19,980,000 |

The checksum scales exactly with work; the optimization is not folding away searches.

## Correctness

Coverage includes:

- signed-i32 and f64 element arrays
- hits at the head and tail, misses, and scalar tails
- duplicate/first-match ordering
- `NaN` strict-equality behavior
- positive and negative `fromIndex`
- kill-switch structure and behavior

## Validation

- `pnpm exec vitest run tests/equivalence/issue-1197.test.ts` — 22 passed
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- LOC and function budget gates
- targeted Biome and Prettier checks
- full pre-push typecheck, lint, format, oracle, coercion, numeric-local parity, and issue-integrity gates

Generated benchmark artifacts are not included.
