### PR TITLE
release: v0.69.0

### DIFF
--- a/docs/release-notes/v0.69.0.md
+++ b/docs/release-notes/v0.69.0.md
@@ -1,0 +1,805 @@
+# v0.69.0
+
+Lockstep release of `@loopdive/js2` and the `js2wasm` proxy: 0.68.0 → 0.69.0.
+
+## Features
+
+- perf(array): batch numeric indexOf misses
+- feat(ir): retire Builtins legacy bodies ✓
+- perf(strings): elide empty concat allocations
+- perf(runtime): collapse fixed host method call crossings
+- perf(strings): scalarize proven ASCII case conversions
+- perf(strings): inline constant-needle indexOf scans ✓
+- perf(runtime): streamline non-throwing leaf imports
+- perf(strings): specialize proven rope concatenation
+- feat(4269): bind receiver for runtime-key object-literal method calls
+- feat(linear): add native String.repeat support
+- perf(array): accelerate hot indexOf scans
+- perf(strings): avoid integer format scratch allocation
+- perf(strings): fuse native trim length scan
+- feat(linear): cache literals and lower string searches ✓
+- perf(codegen): cache ambient host globals per instance ✓
+- perf(strings): streamline ASCII case mapping
+- perf(runtime): fast-path host array lengths
+- perf(strings): keep proven search positions in i32
+- perf(runtime): avoid primitive argument bridge probes
+- perf(arguments): reuse extras vectors for zero-formal calls
+- perf(runtime): fast-path primitive string method calls
+- feat(website): npm-compat measured-at shows time, not only date ✓
+- perf(runtime): fast-path host array lengths
+- feat(#4250): whole-program per-field write-kind verdict — fixes main's literal-slot miscompile, flips JS2WASM_FNCTOR_CTOR_PARAM_SLOTS to unset⇒ON
+- feat(dogfood): complete React package test infrastructure
+- feat(hooks): commit-msg guard — Claude may be co-author, never AUTHOR ✓
+- perf(strings): keep proven search positions in i32
+- perf(host): remove redundant fixed-arity import call binding
+- feat(#743): derive types by default — flip the derivation flag family ON
+- perf(#4241): two missed $bag operand sites, semantics pins, and the measured result — the leak is on the INSTANCE side, not the closure side
+- feat(#4238): slice 1 — QuickJS eval engine behind JS2WASM_EVAL_ENGINE
+- perf(#4237): carrier-intrinsic $bag slot on the closure family — O(1) lookup, no registry entry, bag dies with its carrier
+- feat(#743): Parser.pos pin retirement — receiver provenance, locals, string substrate; acorn census 39→34 unknown
+- feat(#4236): quickjs-wasi artifact build — shim, build script, draft workflow ✓
+- feat(#3927): flip JS2WASM_FNCTOR_LAYOUT_EMIT default-ON (standalone) + the struct-typed fold's layout arm
+- feat(standalone): replace with a STRING search value — function replacers + ToString (#4224)
+- feat(#4194): layout/resid computed-write arms — the #3927 flag-ON composition
+- feat(standalone): instance expando substrate — declared-field write-through + expando bag + visibility (#4194) ✓
+- feat(standalone): String.prototype.replace function replacers + ToString replacements (#4224)
+- feat(interp): catch ObjectPattern minimal slice + annexB cancellation collectors (#2200)
+- feat(#3927): per-type fnctor layout EMISSION behind JS2WASM_FNCTOR_LAYOUT_EMIT (default OFF)
+- feat(interp): regex literals via BUILTIN_REGEXP_CREATE (#4137) ✓
+- feat(#743): Parser.pos pin-census instrument + builtin-receiver carve-out + arithmetic F64-producer
+- perf(#4157): hoist constant number boxing to module globals ✓
+- perf(#3927): call-weighted field ranking, and the split ships default ON ✓
+- feat(codegen): allocation-site-sensitive shape analysis for fnctor structs (#3927) ✓
+- perf(codegen): hot/cold split of the widened fnctor struct, flag-OFF (#3927) ✓
+- perf(regexp): reuse the standalone `.test` capture scratch and backtrack frames ✓
+- perf(#4187): fuse the member-delete pre-scan and gate name collection on standalone ✓
+- feat(ir): #743 satellite module-constant + condition-agnostic-conditional rules — Scope.flags flips, census 55/1/40 → 56/1/39 ✓
+- perf(codegen): make the #4205 global-object scan O(statements), not O(nodes) (#3437) ✓
+- feat(ir): #743 satellite i32/bitwise producer rule + the evaluator-extension hook ✓
+- feat(ir): #743 field↔param mutual fixpoint — field slots as lattice variables in the fnctor-graph satellite ✓
+- feat(ir): #743 graph-edge soundness refinements + acorn measurement — census 41→40, remaining slots characterized ✓
+- feat(ir): #743 call-graph completeness — method-call + new-this edges in a fnctor graph fixpoint ✓
+- perf(#3927): measure the fnctor union's true GC cost — pad probe + repriced slices
+- perf(#4174): flatten String(x) result once + inline flat fast path in charCodeAt
+- perf(#3926): hash-dispatch __extern_get's closed-struct field ladder via br_table
+- perf(#4157): post-campaign CPU profile of standalone acorn — reorder Workstream 2 ✓
+- feat(#3251): S2-residual + S3 ArraySetLength port — array-exotic length defines + accessor setter invoke ✓
+- feat(codegen): #2660 S3b fnctor-typed bindings — retype provably-monomorphic instance locals (flag-gated, default OFF)
+- feat(#743): .d.ts entrypoint seeds for exported implicit-any params — flag OFF, census measured null ✓
+- feat(codegen): wire #4155 Phase 2 typed fnctor field reads (flag-gated, default OFF) + census
+- feat(#2663): read-modify-write through a `with` scope (Slice 3) ✓
+- feat(#743): new-expression edges in the IR propagation fixpoint ✓
+- feat(#4155): census why a fnctor field slot is boxed ✓
+
+## Fixes
+
+- fix(codegen): host-free `instanceof Object` / `instanceof Function` in standalone (#4276)
+- fix(benchmarks): verify array callback checksums
+- fix(async): preserve Promise rejection payload identity
+- fix(#4266): vec own-key enumeration over the #3251 overlay + gOPN vec arm
+- fix(linear): reclaim safe call arenas between exports ✓
+- fix(dogfood): contain late jsdom host errors
+- fix(#4262): standalone error substrate — real TypeError, right ctor carrier
+- fix(ir): defer mutable class layouts until sealable ✓
+- fix(#4266): screen non-string overlay keys before the AnyStr cast
+- fix(#4261): a typed field access no longer erases a fnctor's prototype methods — clause B yields to a dynamic use (standalone)
+- fix(es5): with-statement value carriers (#4264) + ToString of a callable (#4265)
+- fix(with): widen with-assigned module globals and seed with-hoisted vars as undefined
+- fix(#4262): err.constructor answers the carrier the NAME reads (standalone)
+- fix(#4241): carrier-intrinsic $bag on un-split fnctors — acorn's registry leak goes 1 entry/parse to 0
+- fix(#2107): stop the union-undefined erasure being SILENT; file #4258
+- fix(#4257): re-declare late-spliced ref.func targets before dead-elim
+- fix(#4235): run the fnctor pipeline on the multi-file compile path
+- fix(website): point issue links at the markdown issues, not GitHub issues
+- fix(report): honour the edition slider in the standalone category table
+- fix(npm-compat): extend TypeScript compile budget
+- fix(codegen): bound recursive checker queries in object widening
+- fix(es3): canonicalize computed assignment keys
+- fix(#4248): an inherited builtin-proto method read is the prototype's own function
+- fix(#4247): route non-array-index element keys to the array's named store
+- fix(#4241): the two promise-executor settle-value sites never got the $bag operand — 115 host-free passes, the standalone floor breach
+- fix(#4252): invoke the callee on obj[runtimeKey]() with a plain-object receiver
+- fix(#4248): the three wrapper prototypes have a [[PrimitiveValue]]
+- fix(ci): prebuild the runtime-eval refusal provider before changed-root tests
+- fix(#4248): a builtin prototype's own members are visible to hasOwnProperty
+- fix(codegen): sloppy `this` is ToObject(thisArg), and an inlined callee keeps its receiver (#4246)
+- fix(codegen): `new <non-constructor>` must throw TypeError (#4246)
+- fix(#4249): inline a catch-body finally clone at the depth it was compiled at
+- fix(#4249): stop an eval-spliced object-literal accessor from crashing codegen
+- fix(#743): exclude the field-SLOT narrowing from the flip; file #4250
+- fix(hooks): budget ratchets run unconditionally at commit time ✓
+- fix(standalone): brand the boolean builtin statics — a closure-returned boolean is not the number 0
+- fix(#743): gate the ctor-param narrowing to the STANDALONE lane
+- fix(#4241): the closure header layout was stated TWICE — give it one owner in a leaf module
+- fix(#4232): gate the plain-Object ctor carrier separately; stop arming the host bridge everywhere
+- fix(#743): never narrow a PRESENCE-TRACKED fnctor field to a machine slot
+- fix(standalone): narrow #4233's `RegExp(R)` identity fold to a PROVABLE brand
+- fix(codegen): throw TypeError on strict-mode arguments.callee (#4229)
+- fix(standalone): RegExp ctor — `RegExp(R)` identity + undefined pattern/flags (#4233)
+- fix(#4232): reflective String.prototype.replace arm (#4224 leftover)
+- fix(standalone): `re.exec()` / `re.test()` match "undefined", not a refusal (#4233)
+- fix(codegen): install arguments.callee as a real own property (#4229)
+- fix(standalone): stop `exec` binding the `env::RegExp_exec` host import (#4233)
+- fix(standalone): scale StringToNumber against a 10^k table — 10 ulp drift to 1 (#4234)
+- fix(standalone): seed Number's §15.7.3 value constants onto the ctor carrier (#4234)
+- fix(report): stop proposal-scope failures leaking into published editions
+- fix(#4232): String exotic objects — §10.4.3 index reads and own properties
+- fix(#4232): Object(null)/Object(undefined) .constructor resolves to Object
+- fix(codegen): with-scoped `delete` is a boolean, `with(null)` throws, `typeof` a string binding is "string" (#4231)
+- fix(codegen): a `var` inside a `with` body must not shadow the object (#4231)
+- fix(codegen): a `with` fallback write must not shadow a global-object property (#4231)
+- fix(#4232): decline the Object .constructor fold for a primitive-wrapper receiver
+- fix(#4230): union the vec Properties key source, defer the receiver-carrier gate
+- fix(#4194): route write-arm value coercion through the single engine (#1917/#2108) — coercion-sites gate
+- fix(#4222): RangeError on an invalid `arr.length =`, per §10.4.2.4 step 3
+- fix(#4221): calling a non-callable throws TypeError; bound fns poison caller/arguments
+- fix(codegen): route local-varEnv function-declaring direct evals to the provider (#2929) ✓
+- fix(#4223): standalone primitive-wrapper `.constructor` identity
+- fix(#4194): route computed writes to closed-struct storage — closed-struct arms in __extern_set
+- fix(#4222): make `delete arr[k]` absent to every presence surface
+- fix(codegen): route global-varEnv declaring evals to the provider — own-property + CanDeclareGlobal semantics (#2929) ✓
+- fix(#4225): the folded-0 twin — hasOwnProperty was blind to the cold tail
+- fix(standalone): route the plural `length` define to the singular compiler
+- fix(#3927): use isFnctorLayoutStructName at the candidate skip (dead-exports); document the static in/hasOwn fold × split interaction as a default-ON gate ✓
+- fix(codegen): scoped lexical isolation for spliced eval bodies (#2929) ✓
+- fix(array): honour §15.4.4.20 per-index HasProperty + fresh Get in filter
+- fix(#4217): let an own `constructor` expando shadow the array carrier
+- fix(standalone): retire the instanceof / isPrototypeOf host-import leaks (#2916)
+- fix(codegen): standalone any+= string concat — SyntaxError renders text not NaN (#4137) ✓
+- fix(#4217): resolve <array>.constructor when the receiver is only known at runtime
+- fix(#4217): native String.prototype.split for the reflective standalone path
+- fix(interp): install control-stack scopes by slot mutation — provider self-compile drops index-store reuse (#2200)
+- fix(codegen): global-lexical collision guard for spliced sloppy eval (#2929) ✓
+- fix(standalone): enforce the array exotic [[DefineOwnProperty]] rejections
+- fix(interp): bitwise binary/compound operators via append-only opcodes (#4137) ✓
+- fix(#4216): inc/dec store temp for packed i16/i8 vec elements was declared with the raw packed elemType instead of the widened i32
+- fix(#4217): npm-compat refresh now redeploys Pages after publishing — the [skip ci] artifact commit could never trigger its own rebuild ✓
+- fix(scripts): sync-workspace-main must not detonate the pre-push chain on every hook fire ✓
+- fix(hooks): match the merge command's first line only; correct the diff-base note ✓
+- fix(hooks): the merge-proof gate failed OPEN when it could not compute the diff ✓
+- fix(hooks): resolve the repo root from CLAUDE_PROJECT_DIR instead of hardcoding it ✓
+- fix(#3920): the compile-time fold half — `in`/hasOwnProperty on a struct-typed receiver
+- fix(hooks): stop advising a direct merge to main; repair hook event logging ✓
+- fix(#3920): answer closed-struct own-presence from the presence word
+- fix(#3920): standalone reflection over closed structs enumerated nothing ✓
+- fix(#3927): cold-tail slots must veto the Phase-3 scalar read narrowing ✓
+- fix(#4187): route standalone hasOwnProperty past the const-fold when the receiver is deleted from ✓
+- fix(ci): sync the conformance docs AFTER the high-water raise, not before (#4211) ✓
+- fix(standalone): route a nullish member read to the dynamic method call when a builtin prototype carries named expandos (#4207) ✓
+- fix(standalone): consult the proto-property store for a PRIMITIVE receiver's inherited method (#4207) ✓
+- fix(#4206): move the with-target pin to its own module + regression test ✓
+- fix(codegen): refuse the Type() fold for a `++`/`--`-retyped Boolean binding (#4208 S1) ✓
+- fix(#4206): standalone dynamic `with` silently wrote past the object ✓
+- fix(codegen): fold the Type() decision into the promotion helper; RED-on-base tests (#4208 S1) ✓
+- fix(codegen): decide === from Type(), not the f64 slot, for Number vs Boolean (#4208 S1) ✓
+- fix(codegen): script-goal global object — nested/aliased writes and `this.x++` (#4205) ✓
+- fix(codegen): distinguish an explicitly-null receiver from an absent one (#4203) ✓
+- fix(codegen): widen a primitive-initialized module var provably assigned another JS type (#4204) ✓
+- fix(codegen): admit top-level `this` as a .call/.apply receiver (#4202) ✓
+- fix(#4201): standalone <wrapper>.valueOf() returns [[PrimitiveValue]], not the wrapper ✓
+- fix(#4196): guard the byte-neutrality memo against a synthesized new node ✓
+- fix(#4196): [[Construct]] through a bound function in standalone ✓
+- fix(codegen): standalone `<Builtin>.prototype.constructor` own property ✓
+- fix(#4199): keep top-level builtin-namespace expando writes in __module_init ✓
+- fix(#4182): declare the #3596 trap-growth-allow that auto-parked this PR ✓
+- fix(#4162): bump ORACLE_VERSION 12 -> 13 for the in-process-lane de-masking ✓
+- fix(#4195): name the target that actually refuses dynamic eval, and stop reporting top-level diagnostics twice ✓
+- fix(#4192): install the receiver for .call/.apply on a variable-held function expression ✓
+- fix(#4185): commit the missing closure-call-fast.ts implementation ✓
+- fix(#4190): ES5 10.4.3 — sloppy unbound `this` is the global object; an inlined IIFE keeps its own strictness
+- fix(ir): #4177 — '+' provability consumes the fixpoint's lattice facts
+- fix(#4176): per-brand proto-property store — named keys on builtin prototypes live through the chain (+76 on the 219-file ES5 lever) ✓
+- fix(#4180): stop fabricating a descriptor from a struct's internal wasm fields ✓
+- fix(#4179): top-level `with` statements were silently dropped from __module_init
+- fix(#4174): last stale cross-reference from the renumber ✓
+- fix(#4173,#4174): renumber from 4166/4167 — open PR #4124 already uses those ids ✓
+- fix(#3251): resolve the #4164 issue-id collision with open PR #4124 ✓
+- fix(#4163): make the standalone [[Prototype]] chain live for reassigned F.prototype
+- fix: stage the 4170/4171 frontmatter id rewrites that the renumber left unstaged
+- fix(codegen): expando own-properties on standalone RegExp/Date carriers (#4008)
+- fix(#4137): interpreter catch parameter gets its own Environment Record (B.3.5 exempt) ✓
+- fix(#4137): standalone WeakMap miss is null, not undefined — kills the setEvalVariableEnvironmentBinding null-deref ✓
+- fix(#2663): grant the with-rmw __unbox_number coercion site ✓
+- fix(#2875): wire borrowed String.prototype.slice in standalone (+4) ✓
+- fix(#743): biome noDelete ignore on the afterEach env restore ✓
+- fix(#3979): gate __closure_prop_set on live builtin name/length — writable:false is not a bag store
+- fix(#4154): PrivateBrandCheck throws a catchable TypeError instead of trapping
+- fix(#4149): declare the trap reclassification the merge queue caught; file #4154
+- fix(react-dom): preserve descriptor and cross-realm array values
+- fix(#3978): declare the coercion-sites allowance CI flagged, and record why it is a stopgap
+
+## Other
+
+- docs(#4276): record neighbouring-suite results and the pre-existing host-lane failures
+- test(codegen): #4276 instanceof Object/Function suite + measured deltas
+- Merge branch 'main' into issue-4256-multifile-proto-method-write
+- docs(conformance): record Test262 module-init blocker
+- docs(conformance): specify ES2015 default-parameter IR substrate
+- docs(conformance): specify ES2015 iterator destructuring IR slice
+- docs(conformance): map exact ES2015 gaps to IR work
+- test(ir): checkpoint Builtins retirement parity ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge remote-tracking branch 'upstream/main' into claude/test262-es5-pass-rate-vdseyg
+- style: format object-literal-method-receiver for prettier (#4269)
+- chore: merge origin/main into clsx optimization
+- Merge remote-tracking branch 'upstream/main' into claude/es5-wave5-followup
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge #4269 object-literal method receiver binding into the wave-5 follow-up
+- docs(4269): harness ratchet result and post-merge re-verification
+- Merge #4266 vec own-key enumeration into the wave-5 follow-up branch
+- docs(#4266): record the #4251 harness-selftest ratchet check (19/19, no flip)
+- Merge upstream/main into issue-recv-bind-objlit
+- Merge upstream/main into issue-recv-bind-objlit
+- Merge branch 'main' into codex/react-runtime-perf-20260809
+- docs(4269): issue file with root cause, admission rationale and measurements
+- docs(#4266): correct the measured base sha (e1aeff7c2)
+- docs(#4266): record the byte-identity proof and the equivalence A/B
+- chore: merge origin/main into React runtime optimization
+- chore(branch): merge current origin/main ✓
+- Merge remote-tracking branch 'origin/main' into codex/proven-ascii-case-20260809
+- chore(branch): merge current origin/main ✓
+- chore(branch): merge current origin/main ✓
+- Merge upstream/main into claude/test262-es5-pass-rate-vdseyg
+- Merge remote-tracking branch 'origin/main' into codex/3924-linear-arena-reset
+- chore(test262): scheduled baseline summary sync — 31651/43505 pass [skip ci] (#1951)
+- Merge remote-tracking branch 'origin/main' into codex/3924-linear-arena-reset
+- docs(plan): close linear call-arena issue ✓
+- Merge remote-tracking branch 'origin/main' into codex/native-concat-loop-20260809
+- Merge remote-tracking branch 'origin/main' into codex/3922-string-repeat
+- test(#4262): flip six harness self-test ratchet entries to pass
+- Merge upstream/main into issue-recv-bind-objlit
+- test(4269): receiver-binding suite + element-access literal-key arm
+- Merge branch 'senior-error-substrate-4262' into claude/test262-es5-pass-rate-vdseyg
+- Merge remote-tracking branch 'origin/main' into codex/ci-refresh-jsdom-notfound
+- Merge remote-tracking branch 'upstream/main' into senior-error-substrate-4262
+- wip: bind receiver for object-literal function-valued property calls
+- docs(ir): publish the cross-owner checkpoint handover ✓
+- refactor(ir): seal cross-owner bodies in one transaction ✓
+- test(ir): pin cross-owner class main retirement
+- Merge branch 'claude/es5-with-funcproto' into claude/test262-es5-pass-rate-vdseyg
+- docs(#4264): record the full A/B regression evidence table
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge remote-tracking branch 'upstream/main' into issue-4261-method-result-corruption
+- style: prettier formatting for the #4264 widening arm
+- Merge fork branch head (284d15fe8) into local
+- Merge upstream/main (08fc4ca00) into claude/test262-es5-pass-rate-vdseyg
+- test(#4251): yield the event loop between harness self-tests (#4003 CI flake)
+- test(#4266): vitest suite + issue file for vec own-key enumeration
+- Merge branch 'main' into claude/test262-es5-pass-rate-vdseyg
+- wip(#4230 L1): vec key enumeration over the #3251 overlay + gOPN vec arm
+- Merge branch 'main' into claude/test262-es5-pass-rate-vdseyg
+- Merge commit 'e1aeff7c2fd83ec2989f87185f0129cb1a59f67c' of https://github.com/loopdive/js2 into codex/cookie-lead-20260809
+- Merge remote-tracking branch 'upstream/main' into issue-4241-instance-carrier-bag-slot
+- Merge remote-tracking branch 'origin/main' into codex/cookie-lead-20260809
+- Merge upstream/main (803a68c13) into claude/test262-es5-pass-rate-vdseyg
+- docs(#4256): exonerate the analysis — approvedNames is identical on both paths
+- Merge upstream/main into claude/test262-es5-pass-rate-vdseyg
+- docs(#4256): narrow the multi-path proto-method write defect to the call helper
+- docs(ir): publish constructor checkpoint handover
+- refactor(ir): retire prepared class constructor bodies
+- Merge remote-tracking branch 'upstream/main' into issue-2107-typeof-undefined-union
+- Merge remote-tracking branch 'upstream/main' into issue-4235-multifile-fnctor-pipeline
+- Merge remote-tracking branch 'upstream/main' into claude/test262-es5-pass-rate-vdseyg
+- Merge remote-tracking branch 'origin/main' into claude/report-error-messages-es2026-nlp65r
+- docs(#4250): record the pre-existing issue-2107 undefined-any failure as main's, not this slice's
+- Merge remote-tracking branch 'upstream/main' into issue-4250-write-kind-verdict
+- Merge remote-tracking branch 'origin/main' into codex/react-infra
+- Merge remote-tracking branch 'origin/main' into codex/benchmark-v8-parity-20260809
+- Merge remote-tracking branch 'origin/main' into codex/react-infra
+- docs(#4253): record the triage — both red tests were stale pins
+- Merge remote-tracking branch 'upstream/main' into issue-4253-latent-red-root-tests
+- test(#4253): un-rot the two root tests that were red on main
+- Merge remote-tracking branch 'upstream/main' into claude/test262-es5-pass-rate-vdseyg
+- chore(#4252): budget grants for the call-tail-dispatch fallback routing
+- Merge remote-tracking branch 'origin/claude/issue-4252-computed-key-call' into claude/test262-es5-pass-rate-vdseyg
+- chore(#4247,#4248): aggregate-diff gate grants + permanent-repro citation
+- docs(#4252): equivalence-suite evidence for the gc/host lane
+- Merge remote-tracking branch 'origin/worktree-agent-aad3608823248b0b9' into claude/test262-es5-pass-rate-vdseyg
+- Merge remote-tracking branch 'origin/worktree-agent-a17ab49105f758896' into claude/test262-es5-pass-rate-vdseyg
+- chore(#4246): grant func-budget for compileCallExpression (+33) and compileNewExpression (+11)
+- chore(#4249): move the closures.ts loc-budget grant into this PR's issue file
+- docs(#4248): close the issue — +25 measured across three root causes
+- docs(#4255): file the standalone chained ctor→method→field wrong-value bug ✓
+- Merge remote-tracking branch 'upstream/main' into claude/issue-4249-es5-wave4
+- test(#4251): flip verifyProperty-restore.js canary to pass — fixed by the merged wave-3 descriptor work
+- chore(test262): refresh sharded baseline — 31633/43505 pass [skip ci]
+- Merge commit '12bfadd7' into claude/test262-es5-pass-rate-vdseyg
+- Merge remote-tracking branch 'origin/claude/issue-4246-new-and-sloppy-this' into claude/test262-es5-pass-rate-vdseyg
+- Merge remote-tracking branch 'upstream/main' into issue-743-derivation-defaults-on
+- test(#3683): un-rot two stale assertions so the changed-root gate is green
+- docs(#4254): file the floor-attribution gap — unmeasured merge_group crossings land on the next measuring PR ✓
+- docs(#4252): stage 3 blast radius — measured, both directions; mark done
+- chore(#4249): grant func-budget allowance for compileTryStatement (+18)
+- Merge commit '0be6c5a7a9de391bd91ef23f8281969bfcded66c' into worktree-agent-ab7965737a56138ba
+- docs(#4249): record wave-4 measurements and the error-string lever
+- Merge remote-tracking branch 'upstream/main' into issue-743-derivation-defaults-on
+- docs(#4246): record the gc-lane A/B
+- test(#4251): ratchet the standalone harness self-tests; diagnose the 72 failures
+- docs(#4252): stage 1 assessment — standalone Proxy trap support matrix + real root cause of the proxytrapshelper self-tests
+- test(es5): pin #4246's three root causes and their negative cases
+- refactor(codegen): use the oracle's existing isUnresolvableIdentifier (#4246)
+- Merge remote-tracking branch 'origin/claude/test262-es5-pass-rate-vdseyg' into claude/test262-es5-pass-rate-vdseyg
+- Merge branch 'main' into claude/test262-es5-pass-rate-vdseyg
+- Merge remote-tracking branch 'upstream/main' into claude/test262-es5-pass-rate-vdseyg
+- Merge branch 'issue-4237-receiver-stamp-dispatch' of https://github.com/ttraenkler/js2 into issue-4237-receiver-stamp-dispatch
+- Merge branch 'worktree-agent-a535dfc5152a09e28' into claude/test262-es5-pass-rate-vdseyg
+- refactor(#4241): split fillCarrierBagHelpers out of fillClosurePropHelpers; grant the one-line method-singleton operand
+- Merge branch 'main' into issue-4237-receiver-stamp-dispatch
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge branch 'main' into issue-4237-receiver-stamp-dispatch
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge branch 'issue-4237-receiver-stamp-dispatch' of https://github.com/ttraenkler/js2 into issue-4237-receiver-stamp-dispatch
+- Merge branch 'main' into issue-4237-receiver-stamp-dispatch
+- Merge remote-tracking branch 'upstream/main' into issue-4237-receiver-stamp-dispatch
+- Merge remote auto-refresh of claude/issues-quickjs-eval-migration
+- docs: renumber membrane issue 4243 → 4245 (second collision — open PR 4249)
+- Merge remote-tracking branch 'origin/claude/test262-es5-pass-rate-vdseyg' into worktree-agent-ae6125d43fde97e1e
+- Merge branch 'main' into claude/issues-quickjs-eval-migration
+- docs(#4244): file compile-timeout jitter issue — baseline promotions flip ±20 borderline tests
+- docs(#4233): record the identity-fold narrowing + the two NON-regressions
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs: renumber membrane issue 4241 → 4243 (id collision with open PR 4252)
+- test(#743): spell OFF explicitly wherever a suite used to unset the flag
+- arch(#4241): implementation plan — QuickJS eval membrane (inward exotic wrappers, outward Proxy live views, gc_mark/ownership lifetimes)
+- chore(test262): scheduled baseline summary sync — 31609/43505 pass [skip ci] (#1951)
+- docs(#743): record the 2026-08-08 stakeholder decision to derive types by default
+- chore: renumber arguments-object issue #4229 -> #4243 — id collided with playground-REPL issue landed on main
+- docs(#4241, #4242): file the QuickJS eval migration endgame — membrane + default flip, NO interpreter removal
+- chore(#4241): extend the loc-budget allowance to calls.ts for the second $__bound_fn operand
+- Merge remote-tracking branch 'upstream/main' into issue-4237-receiver-stamp-dispatch
+- Merge branch 'main' into claude/report-error-messages-es2026-nlp65r
+- Merge remote-tracking branch 'upstream/main' into claude/test262-es5-pass-rate-vdseyg
+- Merge commit 'fc591d3f' into claude/report-error-messages-es2026-nlp65r
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(ci): reconcile the required-checks record with the live ruleset
+- chore: grant wave-3 budget/gate allowances in owning issue files
+- chore(#4233): grant oracle-ratchet allowance — RegExp-type identity query
+- docs: record wave-3 outcomes (+63 measured) in ES5-standalone-90 spec
+- Merge branch 'worktree-agent-a68d90a7ab9e41640' into claude/test262-es5-pass-rate-vdseyg
+- docs(#4238): architect implementation plan — flag plumbing, GC-adapter bridge, value ABI, slice order
+- docs(#4229): mark done — 26->30 in language/arguments-object, 0 regressions
+- Merge branch 'main' into docs-census-findings
+- docs: durable homes for three session findings — census table, dispatch-gate artifact, presence unification ✓
+- chore(#4233): cite permanent repro test (issue-spec-coverage gate)
+- docs(#4238): file issue — QuickJS-backed runtime-eval provider behind a flag (#4236 variant C MVP)
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge branch 'worktree-agent-a5cd2a1683cb22ad1' into claude/test262-es5-pass-rate-vdseyg
+- Merge branch 'worktree-agent-afc087457cb6a06f5' into claude/test262-es5-pass-rate-vdseyg
+- docs(#743): record pr 4246 in frontmatter
+- Merge remote-tracking branch 'upstream/main' into issue-743-field-param-mutual-fixpoint
+- test(#743): value-flow suite + issue results — census 39→34, $AnyValue delta ZERO, flag stays OFF
+- docs(#4236, #4237): no-regex build + split regex module measurements; Irregexp bytecode-backend estimate
+- chore(#4237): grant the three god-files a loc-budget allowance for the $bag header operand
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(#4237, #4236): regex exploration issue + post-slice-1 regex measurements
+- docs(#4237): implementation-ready plan for the $bag slot — constant-driven closure-layout audit (the #3673 $arity precedent), mint-site list, helper-body swap keeps all consumers, semantic deltas to pin ✓
+- docs(#4237): three-instrument attribution lesson; the bag registry is a cross-parse LEAK (scan quadratic over a session, 75 ensures/parse, dead instances GC-pinned); pre-registered A/B caveats incl. the post-flip share-denominator shift ✓
+- docs(#4237): measured baseline reorders the plan — __closure_bag_lookup's linear registry scan is the top frame (12.25%), ahead of the receiver ladder; three-instrument caller disagreement resolved by the call census ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge branch 'worktree-agent-a0fc667fed6f8c739' into claude/test262-es5-pass-rate-vdseyg
+- docs(#4234): record the A/B-verified flip and regression numbers
+- docs(#4232): record the reflective-replace arm and the budget grants it needs
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(#4237): file the receiver-stamp dispatch issue — the #4157 bucket-1 residual after #3926 ✓
+- docs(#4236): adoption-review design notes — gc_mark cycle solution, acorn scoping, builtin routing, JSString-as-native-string recommendation
+- docs(#4236): slice-1 findings ✓
+- test(standalone): pin the #4233 ES5 RegExp semantics + issue record
+- docs(ci): reconcile the required-checks record with the live ruleset
+- Merge branch 'worktree-agent-a0494b7837c9f6b4e' into claude/test262-es5-pass-rate-vdseyg
+- chore(test262): refresh sharded baseline — 31623/43505 pass [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(#4236): record the linear-lane ADOPT decision — opaque JSValue + build-time tag extraction + engine-swap migration story
+- docs(#4236): variant C — QuickJS eval engine for the WasmGC lane via handle membrane, with staged effort estimate ✓
+- Merge branch 'main' into issue-3927-layout-default-on
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge remote-tracking branch 'upstream/main' into issue-3927-layout-default-on
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(#4236): spike findings — one-heap identity PROVEN (411, 1.86 ns trampoline), WASI-standalone link NOT ✓
+- docs(#4236): file linear-lane QuickJS boxed-tier exploration — Static-Hermes-shaped, with the 2026-08-08 benchmark triangle
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): scheduled baseline summary sync — 31630/43505 pass [skip ci] (#1951)
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(ci): correct cla-check's stale "informational" self-description
+- docs(#4229): file playground REPL issue — standalone runtime-eval interpreter as the demo surface
+- Merge remote-tracking branch 'origin/main' into claude/report-error-messages-es2026-nlp65r
+- Merge branch 'main' into claude/es-edition-landing-unfold-7wdp2z
+- chore(test262): refresh sharded baseline — 31607/43505 pass [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Expand ES edition sections on the landing page by default
+- docs(#4235): file the multi-file fnctor-pipeline-inert finding from the second-corpus census ✓
+- Merge remote-tracking branch 'origin/issue-4230-standalone-descriptor-bags' into claude/test262-es5-pass-rate-vdseyg
+- docs(#4230): correct the equivalence record — 5 failures, each chased down
+- ci(#3927): layout_emit dispatch input — flag-ON test262 measurement lane ✓
+- docs(#4231): record the measured A/B and the precisely-located leftovers
+- chore(test262): refresh sharded baseline — 31607/43505 pass [skip ci]
+- Merge branch 'wave3-staging' into claude/test262-es5-pass-rate-vdseyg
+- chore: refresh godfile profile after three waves of object-runtime arm growth
+- Merge remote-tracking branch 'origin/issue-4230-standalone-descriptor-bags' into wave3-staging
+- docs(#4230): record the full equivalence run and its one pre-existing failure
+- Merge upstream main (#4232) — reconcile duplicate #4194 implementations: #4232 owns declared-field write arms, instance-props keeps the expando bag half; flip the pinned expando residual to its documented target
+- test(#4231): script-goal regression suite for the `with` scope-resolution fixes
+- docs(#4230): record the +10 measurement, the gc byte-identity proof, and four leftovers
+- Merge branch 'main' into claude/test262-es5-pass-rate-vdseyg
+- chore(test262): refresh sharded baseline — 31610/43505 pass [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge branch 'main' into claude/test262-es5-pass-rate-vdseyg
+- Merge remote-tracking branch 'origin/main' into claude/es5-test262-eval-yu3duz
+- chore(#4220,#4223): cite permanent repro tests in issue bodies (issue-spec-coverage gate)
+- docs(#4230): design call on the props-bag soundness precondition
+- test(#4194): permanent instance-expando repro — #2093 spec-coverage gate
+- chore(#4222): grant coercion-sites allowance for the two new wave modules
+- Merge branch 'issue-4194-closed-struct-computed-write' of https://github.com/ttraenkler/js2 into issue-4194-closed-struct-computed-write
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge branch 'main' into issue-4194-closed-struct-computed-write
+- chore(test262): record 797/816 standalone eval-code run on merged session branch
+- chore(test262): refresh sharded baseline — 31604/43505 pass [skip ci]
+- docs: record wave 1+2 outcomes in ES5-standalone-90 spec (~+124 measured)
+- Merge branch 'worktree-agent-a18b3bcde18cb1fe9' into claude/test262-es5-pass-rate-vdseyg
+- Merge branch 'worktree-agent-ac3737ea72d19c559' into claude/test262-es5-pass-rate-vdseyg
+- Merge #2929 C+D slices: route global/local-varEnv declaring evals to provider — own-property + CanDeclareGlobal semantics (+14)
+- docs(#4227,#4228): file the two findings that would die with #4194's done status — js-host reflection drift (sidecar-only) and the acorn regex-descriptor for-in gap (incl. the minimal-fixture NON-repro); cross-link from #4194 ✓
+- docs(#2929): C+D implementation record — slices 1&2 measured, slice 3 blockers root-caused
+- Merge branch 'worktree-agent-a358f9a909a949afc' into claude/test262-es5-pass-rate-vdseyg
+- docs(#4194): record pr: 4232, status done ✓
+- Merge remote-tracking branch 'upstream/main' into issue-4225-cold-tail-fold-follow-up
+- docs(#4225): record why per-type layouts are not a third presence arm
+- Merge branch 'worktree-agent-a866040d514e70d0e' into claude/test262-es5-pass-rate-vdseyg
+- Merge #4194 instance expando substrate: write-through + bag + visibility — 24/24 annexB skip-early-err flip
+- Merge upstream/main (#4230 layout emission landed) into issue-4194 — keep both index.ts import/call sets ✓
+- docs(#4226): file compile-time-evaluation levers issue — copy-loop specialization, finite key sets, Tier-0 widening
+- Merge upstream/main into issue-4225-cold-tail-fold-follow-up
+- docs(#4194): verification results — 24/24 annexB, zero pass->fail, and #2200 follow-up 1 re-measured (NOT fixed, but better isolated)
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(#4194): implementation notes — 24/24 annexB flip, three spec departures + their receipts
+- chore(test262): refresh sharded baseline — 31618/43505 pass [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge remote-tracking branch 'upstream/main' into issue-4225-cold-tail-fold-follow-up
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(#4225,#3927): re-measure post-#4229 merge — repro now 101 (in fixed, hasOwnProperty folded-0 residual); restore direct #4219 link now that its file is on main ✓
+- Merge remote-tracking branch 'upstream/main' into issue-3927-per-type-emission
+- chore(test262): scheduled baseline summary sync — 31603/43505 pass [skip ci] (#1951)
+- chore(test262): refresh sharded baseline — 31603/43505 pass [skip ci]
+- docs(#3927): fix #1616 link-gate break (4219 file rides PR #4229's branch); add the split-retirement census-by-verdict gate item per coordinator ✓
+- Merge session base 328cf887 (#4137 NaN-render fix + #2200 layers 2/3 + #2929) into #4194 lane
+- docs(#4225): file the cold-tail folded-0 bug — static in/hasOwnProperty answer constant false for a cold-moved field on a struct-typed receiver (repro: native 111 vs wasm 001); cross-link from #3927 §6.2b ✓
+- Merge remote-tracking branch 'origin/claude/test262-es5-pass-rate-vdseyg' into worktree-agent-ac3737ea72d19c559
+- Merge commit '08bd1244' into worktree-agent-aef2ffda3aa340011
+- Merge branch 'worktree-agent-aee4a9da4e7d7f983' into claude/test262-es5-pass-rate-vdseyg
+- chore: renumber split issue #4218 -> #4220 — 4218 belongs to another session on the upstream book
+- Merge remote-tracking branch 'upstream/main' into issue-3927-per-type-emission
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge #2929 EvalDeclarationInstantiation slice: global-lexical collision guard + scoped lexical isolation (747->757)
+- docs(#2929): carry the EvalDeclarationInstantiation spec, record A/B results, file the C/D follow-on as a TODO
+- Merge branch 'worktree-agent-af79ebe9417e77f01' into claude/test262-es5-pass-rate-vdseyg
+- test(standalone): pin the Function(…)-valued instanceof RHS shape (#2916)
+- docs(#3927): record pr: 4230 ✓
+- Merge remote-tracking branch 'upstream/main' into issue-3927-per-type-emission
+- docs(#3927): emission results — census −31.4% struct bytes, 3-mode differential clean, §6 risk ordering re-derived; budget grants; status done
+- Merge remote-tracking branch 'upstream/main' into issue-3920-closed-struct-reflection
+- Merge branch 'worktree-agent-adb4984cd5ee2ee02' into claude/test262-es5-pass-rate-vdseyg
+- Merge branch 'main' into issue-4217-refresh-redeploys-pages
+- Merge #2200 interpreter-tier eval-code slice: control-stack slot mutation fix + catch ObjectPattern slice
+- chore: renumber split issue #4217 -> #4218 (4217 taken by in-flight PR #4225; 4218 is our upstream-book reservation)
+- docs(#2200): spec, B3 deferral, follow-up issues
+- Merge branch 'worktree-agent-aa978f3b8420a7078' into claude/test262-es5-pass-rate-vdseyg
+- test(#4217): workflow-shape pin for the Pages redeploy step
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(#4216): grant loc/func-budget allowances for the unary-updates type-selection fix
+- Merge branch 'worktree-agent-af79ebe9417e77f01' into claude/test262-es5-pass-rate-vdseyg
+- docs(#3920): file the two cells this does not close as #4219
+- Merge #4137 interpreter residuals: bitwise opcodes, regex builtin, NaN-render fix, Phase-2 deferrals
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(#4137): defer class/template emitter gaps to #2928 Phase 2 ✓
+- test(#4217): pin reflective String.prototype.split behaviour + file the issue
+- docs(#4218): file issue — in-house oracle backend to make the TS5 checker droppable
+- Merge branch 'main' into issue-4217-refresh-redeploys-pages
+- Merge upstream/main (refresh PR #4226 after main advance to 0830099d)
+- refactor(#3920): move the presence emission behind two call-site helpers
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): refresh sharded baseline — 31618/43505 pass [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(#743): implementation spec for receiver-provenance attribution slice
+- Merge upstream/main (refresh BEHIND PR #4226)
+- Merge main (refresh BEHIND PR #4226)
+- Merge upstream/main (PR #4224 merged at ab537618; carry 4bfa1e4d forward)
+- spec: refine reachable pool — 959 clean failures; call/apply are Function-ctor-gated
+- spec: ES5 standalone 90% plan — measured baseline, ranked work packages
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(#743): second-corpus census (pako) — acorn's exhaustion does not generalize; file #4216
+- docs(#4157): cross-runtime acorn profile — wasm vs Node bucketed side by side
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge remote-tracking branch 'origin/main' into claude/fix-hook-ci-bypass-advisory
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): refresh sharded baseline — 31600/43505 pass [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): scheduled baseline summary sync — 31597/43505 pass [skip ci] (#1951)
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge upstream/main into issue-3920-closed-struct-reflection
+- test(#3920): regression matrix + commit-only-on-confirmed-operand guard
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge remote-tracking branch 'origin/main' into claude/hoist-const-number-boxes
+- Merge origin/main into claude/hoist-const-number-boxes ✓
+- docs(#4157): record the code-size tradeoff, and route global allocation through nextModuleGlobalIdx ✓
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(handoff): complete the 2026-08-07 acorn-perf record; cross-reference #4157 ✓
+- Merge remote-tracking branch 'origin/main' into claude/issue-3927-ranking-and-generator
+- Merge remote-tracking branch 'origin/main' into claude/issue-3920-standalone-closed-struct-reflection
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(#3927): the gOPN builtin leak covers Date too, and the fix has one ordering ✓
+- docs(3927): verify the builtin-carrier leak — the working enumeration arms are not a template ✓
+- docs(#3927): un-contest the enumeration grouping — settled, with the seam ✓
+- docs(3927): settle the #3920 enumeration disagreement — my column was the confounded one ✓
+- docs(#3920): the failure GROUPING is contested — record both columns, not one ✓
+- docs(3927): point the enumeration prerequisite at #3920; replicate the matrix, record a disagreement ✓
+- Merge remote-tracking branch 'origin/claude/box-number-provability' into claude/box-number-provability
+- docs(handoff): record #4215 as a burned id; #3920 is the real home ✓
+- Merge remote-tracking branch 'origin/main' into claude/issue-3927-ranking-and-generator
+- docs(#3920): the enumeration gap is wider than filed, and is NOT one hole ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(3927): retract the copyNode mechanism; enumeration repair is a prerequisite ✓
+- Merge remote-tracking branch 'origin/main' into claude/issue-3927-ranking-and-generator
+- test(#3927): add the enumeration read mode — and report that it is VACUOUS ✓
+- Merge branch 'main' into claude/box-number-provability
+- chore(test262): scheduled baseline summary sync — 31622/43505 pass [skip ci] (#1951)
+- docs(handoff): acorn performance lane, 2026-08-07 ✓
+- docs(3927): correct the per-type-layout headline against the new default baseline ✓
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge remote-tracking branch 'origin/main' into claude/issue-3927-ranking-and-generator
+- Merge remote-tracking branch 'origin/main' into claude/box-number-provability
+- docs(#3927): record the gate results, with the baselining that backs them ✓
+- docs(#3927): record the order-reversed profile bucket measurement ✓
+- Merge origin/main into the #3927 ranking+generator branch
+- docs(#4157): price __box_number provability — 13.6% of calls, DON'T BUILD ✓
+- docs: session handoff — in-flight branches, follow-ups, and the traps ✓
+- test(#3927): commit the standalone differential + census harnesses ✓
+- test(#4047): flip the two DATE refusal pins — the "no substrate" premise expired ✓
+- Merge remote-tracking branch 'origin/main' into claude/issue-3927-per-type-layouts
+- docs(#4157,#3552): the i31 lever is already spent; byte-ranked census; root-test CI coverage ✓
+- test(codegen): pin the per-type layout plan's decisions + record the measurement (#3927) ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): refresh sharded baseline — 31614/43505 pass [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge remote-tracking branch 'origin/main' into claude/issue-3927-shape-split-impl
+- docs(3927): profile bucket share confirms the split's byte win in time ✓
+- refactor(#4187): drop the two wrappers the scan fusion orphaned ✓
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge remote-tracking branch 'origin/main' into issue-4165-reflective-mop-bags
+- docs(#4212): a missing argument becomes the ZERO VALUE of the unified param type ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): refresh sharded baseline — 31620/43505 pass [skip ci]
+- Merge remote-tracking branch 'origin/main' into issue-4185-regex-test-scratch-reuse
+- Merge remote-tracking branch 'origin/main' into issue-4165-reflective-mop-bags
+- docs(#4187): record the measured A/B — +1 / -0, exposure enumerated at 5 modules ✓
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(issues): #4186 record suspended work — projection module written, wiring lost ✓
+- Merge remote-tracking branch 'origin/main' into claude/issue-4186-parity-signature
+- docs(issues): #4157 disambiguate PR numbers from issue ids in the 08-07 profile section ✓
+- Merge remote-tracking branch 'origin/main' into claude/issue-743-locals-spec
+- Merge remote-tracking branch 'origin/main' into claude/issue-743-consumer-abi
+- chore(sync): repair main's current standalone drift — 28,257 -> 28,270 ✓
+- test(#4187): cover the fold-vs-delete cycle; close #4165 as superseded, file #4210 ✓
+- docs(issues): #4157 re-profile after the landed Workstream-2 slices — GC is now the binding bucket ✓
+- Merge branch 'main' into issue-4207-transferred-proto-method
+- test(#4211): permanent guard that the doc sync follows the high-water raise ✓
+- docs(issues): #743 ref/string consumer-ABI spec — measured DO-NOT-BUILD
+- Merge remote-tracking branch 'origin/main' into fix-conformance-sync
+- chore(sync): refresh the standalone conformance line — 28,257 -> 28,270 ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(docs): sync standalone conformance number in README ✓
+- docs(#4207): point the vacuous-pass handover at #4209 ✓
+- Merge remote-tracking branch 'origin/main' into issue-4207-transferred-proto-method
+- docs(#4207): record the full 1,344-file exposure A/B and the byte-identity proof ✓
+- Merge remote-tracking branch 'origin/main' into claude/issue-743-i32-producer
+- chore(test262): scheduled baseline summary sync — 31612/43505 pass [skip ci] (#1951)
+- test(#4207): RED-on-base regression cases + implementation notes correcting the filed root cause ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(#4209): file the refusal-vacuous-pass census + the dirty-gate exposure trap ✓
+- Merge remote-tracking branch 'origin/main' into claude/issue-743-i32-producer
+- Merge remote-tracking branch 'origin/main' into issue-4208-operator-abstract-ops
+- docs(#4208): re-cut every number on the merged tip; hand 17 crash files over, close 4 ✓
+- docs(memory): a standalone REFUSAL that throws TypeError is a vacuous-pass generator ✓
+- docs(memory): the REPAIRED provision run has its own silent trap ✓
+- docs(memory): two more ways the harness measures the wrong compiler ✓
+- docs(#4206): record the base-sha caveat and the merged-tip re-verification ✓
+- Merge remote-tracking branch 'origin/main' into issue-4206-with-statement-residue
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): refresh sharded baseline — 31598/43505 pass [skip ci]
+- Merge remote-tracking branch 'origin/main' into issue-4208-operator-abstract-ops
+- Merge remote-tracking branch 'origin/main' into issue-4208-operator-abstract-ops
+- docs(#4208): record the re-derived population, the crash-cluster attribution and the S1 A/B ✓
+- Merge remote-tracking branch 'origin/main' into issue-4204-heterogeneous-var-widening
+- docs(#4204): record the measured population and A/B; mark done ✓
+- chore(sync): refresh the standalone conformance line — 28,222 -> 28,227 ✓
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- chore(sync): refresh the standalone conformance line — 28,222 -> 28,227 ✓
+- chore(#3437): rebank the harness compile budget to main's actual 111,568 ✓
+- chore(sync): refresh the standalone conformance line — 28,222 -> 28,227 ✓
+- chore(sync): refresh the standalone conformance line — 28,222 -> 28,227 ✓
+- Merge remote-tracking branch 'origin/main' into issue-4203-receiver-boundness
+- docs(4168,4192): re-measure both against current main, clear dead-lane claims ✓
+- docs(#4205,#4206): retract the census masking analysis — measured 0 reclassified, not 96 ✓
+- docs(4203): result, decomposition correction, and the ToObject handoff ✓
+- Merge remote-tracking branch 'origin/main' into issue-4205-script-goal-global-object
+- test(4205): 30-case two-lane regression suite + measured implementation record ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): scheduled baseline summary sync — 31575/43505 pass [skip ci] (#1951)
+- Merge remote-tracking branch 'origin/main' into issue-4203-receiver-boundness
+- refactor(codegen): move the #4203 reader arm into the leaf module ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge remote-tracking branch 'origin/main' into census-es5-standalone-levers
+- docs(es5): mechanism census of the ES5 standalone failing residue + 4 unowned levers ✓
+- Merge remote-tracking branch 'origin/main' into issue-4201-standalone-wrapper-valueof
+- docs(memory): Fable can be out of credits — check before routing a spec ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge remote-tracking branch 'origin/main' into fix-4175-park
+- Merge remote-tracking branch 'origin/main' into docs-4202-census-correction-and-instrument-memory
+- docs(4202): correct the census attribution, record the tip re-measure, extend the instrument memory ✓
+- Merge remote-tracking branch 'origin/main' into issue-4201-standalone-wrapper-valueof
+- test(#4201): verify-first vitest + measured implementation notes (FIXED 12 / BROKE 0) ✓
+- chore(test262): refresh sharded baseline — 31567/43505 pass [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge remote-tracking branch 'origin/main' into issue-4201-standalone-wrapper-valueof
+- Merge branch 'main' into issue-4203-null-receiver-substrate
+- Merge remote-tracking branch 'origin/main' into issue-4202-toplevel-this-receiver
+- chore(gitignore): match .test262-cache as a symlink, not only a directory ✓
+- test(4190): discharge the function-EXPRESSION receiver canary — main is RED (#4202) ✓
+- docs(#4203): record the #4202 lane's handoff so it is not re-derived ✓
+- Merge remote-tracking branch 'origin/main' into issue-4202-toplevel-this-receiver
+- Merge remote-tracking branch 'origin/main' into issue-4203-null-receiver-substrate
+- refactor(#4201): move the valueOf call-site wiring into the subsystem module ✓
+- docs(#4203): file the explicit-null-vs-absent receiver substrate gap ✓
+- docs(memory): an error signature is not a bucket boundary ✓
+- docs(#4200): retract the global-object slice — it fragments, and the pointer was wrong ✓
+- Merge remote-tracking branch 'origin/main' into issue-4196-bind-construct
+- docs(#4196): record slice-1 result, control sweep, and the census refutation ✓
+- Merge remote-tracking branch 'origin/main' into issue-4196-bind-construct
+- Merge branch 'main' into claude/scratchpad-shared-across-lanes ✓
+- Merge remote-tracking branch 'origin/main' into issue-4200-builtin-own-property-descriptors
+- docs(4200): record the A/B RED-on-base evidence ✓
+- Merge remote-tracking branch 'origin/main' into issue-4200-builtin-own-property-descriptors
+- docs(memory): the default baseline path is the HOST lane — correct the cross-check ✓
+- Merge branch 'main' into issue-4159-typed-lane-overlay-routing ✓
+- Merge branch 'main' into claude/scratchpad-shared-across-lanes
+- Merge branch 'main' into issue-4197-consumer-mode-fn-decl-getter
+- Merge remote-tracking branch 'origin/main' into issue-4199-namespace-expando-keep
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore: retrigger CI — the pull_request event produced no ci.yml run ✓
+- Merge remote-tracking branch 'origin/main' into issue-4197-consumer-mode-fn-decl-getter
+- chore(test262): scheduled baseline summary sync — 31540/43505 pass [skip ci] (#1951)
+- docs(memory): the harness scratchpad is shared by every lane, not per-agent ✓
+- docs(issues): #743 satellite local-variable typing spec — flow-insensitive local lattice + evaluator ext hook + owner-resolved method returns; verified per-slot prediction ≈0 acorn movers, verdict: do not implement, pivot
+- Merge remote-tracking branch 'origin/main' into issue-4197-consumer-mode-fn-decl-getter
+- Merge remote-tracking branch 'origin/main' into issue-743-mutual-fixpoint-impl
+- Merge remote-tracking branch 'origin/issue-4197-impl-spec' into claude/model-routing-opus-implements-fable-specs
+- docs(issues): #743 implementation spec — field↔param mutual fixpoint slice (satellite field-slot lattice variables, both edge directions, soundness rules, per-slot targets, tests, measurement) ✓
+- docs(#4197): sizing caveat — re-measure the +50..119 only after #4163, through a validated instrument ✓
+- Merge remote-tracking branch 'origin/main' into issue-4159-typed-lane-overlay-routing
+- Merge remote-tracking branch 'origin/claude/es5id-census-method' into claude/es5id-census-method
+- Merge branch 'main' into issue-4181-modinit-telemetry-hole
+- Merge branch 'main' into issue-4182-annexb-global-blockfn
+- Merge branch 'main' into claude/issue-4177-lattice-plus
+- Merge branch 'main' into claude/es5-adjacent-defects
+- Merge branch 'main' into claude/issue-3927-shape-split
+- Merge branch 'main' into issue-4187-standalone-hasown-delete-fold
+- Merge branch 'main' into claude/issue-743-graph-edges
+- Merge branch 'main' into issue-4190-sloppy-this-binding
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- Merge branch 'main' into issue-4176-standalone-proto-named-keys ✓
+- docs(#4195): the dynamic-eval refusal names a target that supports it, and fires twice at top level ✓
+- chore(test262): refresh sharded baseline — 31459/43505 pass [skip ci]
+- docs(W14): annexB eval-code lever — 1/42 on main, 17/42 with #4182 stacked, 427/427 control both ways ✓
+- docs(#4194): standalone instances have no expando substrate — the real cause of compiled-acorn's `{ f }` rejection ✓
+- Merge branch 'main' into issue-4176-standalone-proto-named-keys
+- docs(#4190): W12 census (100% of the 1,766 ES5 standalone failures attributed by es5id clause) + PR body
+- Merge remote-tracking branch 'origin/main' into sync-4180-main
+- docs(#4187): fix issue-file link in W9 handoff (integrity gate) ✓
+- docs(#4186): issue file with captured functype pairs + enriched abi-parity diagnostic ✓
+- docs(#4187): W9 verdict — 44-file 'of prototype object' slice is 43/44 subsumed by unmerged #4176; residue root-caused to standalone hasOwn const-fold delete-hole; #4176×#4180 object-ops.ts conflict verified
+- docs(#4185): results — objvec stream −99.7% (census), call-dispatch −2pp both orders, wall 4/4 positive; status done ✓
+- test(#4185): pin fast .call arm semantics — this-binding, under/over-application, §10.2 override guard, flag-off parity ✓
+- docs(#4185): issue file — attributed allocation table + kill design; budget grants ✓
+- docs(#3927): correct the sensitivity verdict — block A's +29% was load contamination; demotion CONFIRMED
+- docs(#4183,#4184): file two adjacent defects found while fixing #4178 ✓
+- Merge remote-tracking branch 'origin/main' into claude/issue-4177-lattice-plus
+- docs(issues): #4177 results — status done, #743 trap blocker marked resolved
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- test(#4176): permanent repro for named keys on builtin prototypes ✓
+- chore(test262): refresh sharded baseline — 31457/43505 pass [skip ci]
+- docs(#4176): W4 agent-context handoff — PR body, measured +76, residue decomposition, traps ✓
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(#4174): results — flatten 3.75%→2.64%, scanner per-char flatten eliminated, 3/3 A/B pairs positive; status done
+- Merge remote-tracking branch 'origin/main' into claude/issue-4174-scanner-flatten
+- docs(#4180): PR body + measured findings for the next descriptor wave ✓
+- docs(#4179): remaining-bucket diagnosis — S12.10_A3.* is a with-body throw escaping top-level catch, not string concat
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- docs(memory): resume paused agents from transcript, not respawn ✓
+- refactor(#4174): move flatten-at-materialization helpers to string-materialize.ts
+- Merge remote-tracking branch 'origin/main' into issue-4176-standalone-proto-named-keys
+- docs: record the method correction — signature clustering was wrong 6/6 ✓
+- docs(#4178): mixed-type ternary — IR bails, legacy fallback miscompiles concat ✓
+- docs(#4177): file the IR-first lattice-narrowed + hard-fail found during #743 ✓
+- WIP(#4176): proto-index-store generalized to per-brand companions + named keys ✓
+- Merge remote-tracking branch 'origin/main' into issue-4176-standalone-proto-named-keys
+- docs(#3926): record hash-dispatch A/B results, mark done, tick #4157 workstream item
+- Merge remote-tracking branch 'origin/main' into claude/issue-3926-extern-get-hash-dispatch
+- chore(#4172): renumber from #4163 — collision with open PR #4124 ✓
+- Merge remote-tracking branch 'origin/main' into issue-4163-standalone-proto-chain-live
+- docs(#4166,#4167): file the two unowned profile buckets — dynamic-eq 7.1%, per-char str_flatten 3.7% ✓
+- docs(#4163): measured results (+95 on the 219-file lever, 0 sample regressions) + PR body
+- chore(#3251): func-budget allow for the object-ops static-gate growth ✓
+- docs(#3251): PR body for the S2/S3 port branch ✓
+- Merge remote-tracking branch 'origin/main' into issue-3251-s2-port
+- Merge remote-tracking branch 'origin/main' into claude/issue-2660-s3b-typed-bindings
+- test(2660): S3b typed-bindings suite + A/B verdict docs — flag stays OFF (measured wash)
+- docs(#4163): grant loc-budget allowances (scalar list form + reasons as comments)
+- Merge upstream/main: honor upstream's supersession of the MOP/annexB/apply work; graft the surviving pieces
+- Merge origin/main — issue-743 doc conflict resolved (main landed the sketch; branch keeps the results section) ✓
+- docs(#4137): L3 agent-context handoff — PR body, preserved probe pair for the SyntaxError: NaN diagnosis, and what was left undone ✓
+- chore(#3251): claim S2/S3 port lane — status in-progress ✓
+- chore: renumber 3977-3983 -> 4163-4168 (upstream collisions), measure #4164 (+39/0), file #4169, fix harvest-skill doc
+- docs: fix the broken issue link in the L2 handoff ✓
+- docs(memory): author vs committer — the two-identity rule ✓
+- Merge origin/main into claude/js2-cross-frame-capture-slot (PR #4106 refresh) ✓
+- docs(memory): record the resolved commit-author convention ✓
+- docs(#4162): file the in-process test262 runner's missing runtime-eval provider ✓
+- docs(#3251): L2 handoff — measured standalone baseline 1/162, CI-aligned scoped harness, and the unmerged S2+S3 port plan ✓
+- Merge remote-tracking branch 'origin/main' into issue-4137-interp-eval-residuals
+- Merge remote-tracking branch 'origin/main' into issue-4008-regexp-date-carrier-bag
+- docs(4008): pickup notes for the prototype-chain slice + regression evidence
+- docs(#4137): record the measured 0→40/185 result, the runtime-eval instrument, and the SyntaxError: NaN diagnosis; fold the two scope scans to hold the emitter LOC budget ✓
+- chore(test262): refresh sharded baseline — 31192/43505 pass [skip ci]
+- docs(memory): plain-language reports rule — gloss issue numbers and jargon ✓
+- Merge branch 'main' into issue-2663-with-compound-rmw
+- Merge remote-tracking branch 'origin/main' into claude/issue-2660-s3b-typed-bindings
+- docs(#743): implementation sketch for .d.ts entrypoint seeding ✓
+- docs(#743): fixpoint measured on acorn — zero slots beyond single-hop ✓
+- docs(#2663): L4 handoff — with-statement lever findings and measured Slice-3 result ✓
+- chore(test262): refresh sharded baseline — 31184/43505 pass [skip ci]
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- WIP checkpoint (#4155 Phase 2) — handing off: typed-receiver struct.get module, not yet wired ✓
+- docs(#4160): release stale claim, return issue to ready ✓
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): refresh sharded baseline — 31174/43505 pass [skip ci]
+- docs(#3979): aggregate confirmed — 1,625 -> 1,653 / 2,471 (+29/-1, net +28)
+- docs(#3979): narrow the -8 to delete/hasOwn, and say why no fix is landed
+- docs(#3979): real standalone A/B — net +21 (+29/-8), and the regressions are one family
+- docs(#3980,#3983): correct the lane labels — my measurements ran the HOST lane
+- docs(#4157): umbrella — close the acorn-vs-Node gap; schedule the program ✓
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- docs(#4150): PR #4106 suspension resolved — new owner, valve decision taken
+- Merge origin/main into claude/js2-cross-frame-capture-slot
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(test262): scheduled baseline summary sync — 31176/43505 pass [skip ci] (#1951)
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- chore(test262): refresh sharded baseline — 30968/43505 pass [skip ci]
+- Merge remote-tracking branch 'origin/main' into pr4079-merge
+- docs(#4150): suspension handover for PR #4106; queue #4154
+- Merge remote-tracking branch 'upstream/main' into claude/js2-cross-frame-capture-slot
+- Merge origin/main into codex/react-dom-upstream-tests
+- docs: final shepherd state into the handoff — #4100 queued, #4109 opened
+- chore(#4149/#4150): grant the loc/func budget allowances this change-set needs
+- chore(#4098): func-budget-allow for the three +1 wiring calls
+- Merge branch 'main' of https://github.com/loopdive/js2 into issue-4098-g1-build
+- Merge remote-tracking branch 'upstream/main' into claude/js2-cross-frame-capture-slot
+- chore(ci): refresh npm-compat artifacts [skip ci]
+- Merge remote-tracking branch 'origin/main' into claude/spec-4133-4134-capture-reachability
+- docs(#4133,#4134): architect specs for the shared capture-reachability remainder
+- Merge remote-tracking branch 'upstream/main' into claude/js2-cross-frame-capture-slot
+- chore(ci): refresh landing benchmark artifacts [skip ci]
+- style(report): white glowing sparklines + mini donut gauges
+- style(#4098): prettier on carrier-bag-delete.ts
+- wip(#3978): restore the standalone borrowed-String.prototype-receiver diff
+
+<!-- Drafted by scripts/release.mjs from v0.68.0..HEAD. Edit before merging: commit subjects are a starting point, not the announcement. Conformance numbers belong here with their denominators. -->

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.68.0"
+    "@loopdive/js2": "0.69.0"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
Lockstep release of `@loopdive/js2` and the `js2wasm` proxy: **0.68.0 → 0.69.0**.

Cut with `node scripts/release.mjs 0.69.0` per `docs/releasing.md` — one commit bumping `package.json`, `packages/js2wasm/package.json` and `jsr.json` together, plus generated `docs/release-notes/v0.69.0.md`.

## ⚠️ The tag is NOT pushed yet

`v0.69.0` exists **only locally**. `publish-npm.yml` fires on any `v*` tag push, so pushing it before this PR merges would publish unreviewed code. After merge:

```bash
git fetch upstream && git push --no-verify upstream refs/tags/v0.69.0:refs/tags/v0.69.0
```

`verify-version` then confirms the tag, both manifests and the proxy dependency all match before publishing.

## Headline: ES5 standalone conformance, 85.11 % → 89.24 %

This release is dominated by the ES5-standalone program (`plan/goals/es5-standalone-90.md`), run as five waves across ~20 issues. Every figure below is from the **promoted standalone baseline** after each wave merged, not from a wave's own A/B:

| point | pass / 8,115 | rate |
| --- | --- | --- |
| program start | 6,907 | 85.11 % |
| waves 1+2 (#4234) | 7,043 | 86.79 % |
| wave 3 (#4249) | 7,130 | 87.86 % |
| wave 4 (#4258) | 7,199 | 88.71 % |
| wave 5 + instanceof (#4299, #4302, #4311) | **7,242** | **89.24 %** |

**The 90 % goal was not reached — 62 tests short.** That is recorded honestly, with the reason, in the program-outcome section of `plan/goals/es5-standalone-90.md` (PR #4314): three separately-sized levers each collapsed under measurement (42→4, 44→0, ~105→6) because each was sized by counting files whose *error text* matched a pattern rather than by root cause. The rule that falls out — size a bucket by cause on a hand-read sample before committing to a target — is written into the doc.

## Notable in this release beyond the conformance numbers

- **#4269** — `obj.m()` did not bind its receiver, on **both** lanes; `obj.fact(4)` recursing through `this.fact` was a hard crash. Fixed, with a *measured* 0 conformance delta (test262 does not contain the idiom — a positive control fired 0 of 515 files). A real correctness win for ordinary JavaScript that no conformance number would have surfaced.
- **#4262** — standalone threw error **strings**, not `Error` objects, so `assert.throws` rejected them before comparing constructors; and `err.constructor` read the wrong one of two carrier globals.
- **#4264** — the `with` residue was a value-carrier defect, not scope resolution (+30).
- **#4276** — host-free `instanceof Object` / `instanceof Function` in standalone (+6).
- **#4257** — a latent codegen fault: late-spliced arms emitted `ref.func` targets that were never declared, so the full runtime-eval provider failed Wasm validation. Third instance of that class; now fixed systematically rather than per-arm.
- Plus substantial string/array/runtime performance work and IR migration from the other lane, listed in the generated notes.

## Review notes

- No source changes in this PR — version manifests and generated release notes only.
- The release commit sits on `b8bf227a5` (#4311's merge), so it contains all three conformance PRs; verified with `git merge-base --is-ancestor`.
- The tag travels with the branch and stays valid after merge because this queue uses merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmwHrtyzm28H9YuH2nYLYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmwHrtyzm28H9YuH2nYLYy)_