### PR TITLE
docs(#4305, #4306): two compiler defects found by #4238 slice 3

### DIFF
--- a/plan/issues/4305-direct-eval-then-throwing-eval-illegal-cast.md
+++ b/plan/issues/4305-direct-eval-then-throwing-eval-illegal-cast.md
@@ -1,0 +1,87 @@
+---
+id: 4305
+title: "RuntimeError: illegal cast — a succeeding direct eval followed by a throwing one with an `instanceof` catch traps in caller-side codegen (engine-independent)"
+status: ready
+sprint: current
+created: 2026-08-09
+updated: 2026-08-09
+priority: high
+horizon: m
+feasibility: medium
+model: opus
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: eval
+goal: runtime-eval
+related: [2928, 2929, 4238, 4242, 4245]
+# ids 4262/4263/4264/4265 were reserved and ABANDONED before this file was
+# written: claim-issue.mjs --allocate resolves "main" against `origin`, which in
+# this checkout is the FORK, and the fork's main was ~90 commits stale, so the
+# allocator minted ids already used upstream (4262/4264/4265 all exist on main;
+# true max was 4304). Fixed by fast-forwarding the fork's main to upstream and
+# re-allocating -> 4305. See the "allocator reads the fork" note in #4242.
+# Open-PR scan DEGRADED (no gh in this container) and GitHub code search was
+# returning 503, so this id is verified against upstream main + the assignment
+# ref only; the required check:issue-ids gate is the backstop.
+---
+
+# #4305 — `illegal cast` after a succeeding direct eval, when a later eval throws
+
+## Discovered by
+
+#4238 slice 3 (direct-eval scope snapshot). This was **unreachable before slice
+3** because direct eval always returned the typed refusal, so no direct eval
+ever *succeeded* and the two-eval sequence below could not occur.
+
+## The defect
+
+Within a single function:
+
+1. a **direct** `eval(...)` that **succeeds**, then
+2. a later `eval(...)` that **throws**, caught by a handler that does an
+   `instanceof` test
+
+traps with `RuntimeError: illegal cast`.
+
+**It is caller-side codegen, not the eval engine.** The slice-3 author
+reproduced it with a **six-line stub adapter** substituted for the real
+provider — no QuickJS, no interpreter — so it is engine-independent and will
+reproduce against any provider that can make a direct eval succeed.
+
+## Why this is priority: high
+
+It **will bite #4242's Phase-1 parity run**: the test262 harness wraps
+assertions in `assert.throws(...)`-shaped code with `instanceof` catches, and
+slice 3 has now made direct eval succeed under the quickjs engine, so the
+precondition is satisfied across a large slice of `language/eval-code/`. A
+parity measurement that trips this trap attributes engine-independent codegen
+failures to the engine under test — exactly the mis-attribution #4242's gate
+is designed to prevent, and it would land in the `unattributed` bucket (which
+always blocks).
+
+## Repro
+
+The precise repro is recorded in the `## Slice 3 — implementation record`
+section of `plan/issues/4238-quickjs-runtime-eval-provider-flag.md`, including
+the six-line stub adapter that removes the engine from the picture.
+
+## Acceptance criteria
+
+- [ ] Minimal repro lifted into a permanent test (`tests/issue-4305-*.test.ts`)
+      that fails on current main and passes after the fix, using the stub
+      adapter so the test needs no provider artifact.
+- [ ] Root cause identified in `src/codegen/` — name the cast site and why the
+      value's static type diverges from its runtime type on the
+      succeeded-then-threw path.
+- [ ] Fix does not regress the refusal path (eval that always throws) or the
+      no-eval path; default-path suites green.
+- [ ] Confirm the fix under BOTH engines (`JS2WASM_EVAL_ENGINE=quickjs` and
+      `TEST262_FULL_RUNTIME_EVAL=1`) — it is engine-independent, so both must
+      clear.
+- [ ] Re-run the scoped `language/eval-code/` measurement and record whether
+      the `unattributed` bucket shrinks (#4242 gate input).
+
+## Non-goals
+
+- The membrane (#4245) and the parity flip (#4242) — separate issues.

--- a/plan/issues/4306-boolean-array-parameter-reads-undefined.md
+++ b/plan/issues/4306-boolean-array-parameter-reads-undefined.md
@@ -1,0 +1,61 @@
+---
+id: 4306
+title: "A `boolean[]` passed as a function PARAMETER reads back `undefined` (string[] / any[] are fine)"
+status: ready
+sprint: current
+created: 2026-08-09
+updated: 2026-08-09
+priority: medium
+horizon: s
+feasibility: medium
+model: opus
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: arrays
+goal: core-semantics
+related: [4238]
+# id allocated after fast-forwarding the fork's main to upstream — see the
+# note in #4305 about claim-issue.mjs resolving "main" against the FORK and
+# minting already-used ids from a stale fork. Open-PR scan DEGRADED (no gh)
+# and code search 503 at authoring time; the required check:issue-ids gate is
+# the backstop.
+---
+
+# #4306 — `boolean[]` parameter reads back `undefined`
+
+## Discovered by
+
+#4238 slice 3, incidentally, while threading typed arrays through the
+direct-eval scope-snapshot plumbing. Not eval-specific — eval was only the
+context in which it surfaced.
+
+## The defect
+
+A `boolean[]` value passed as a **function parameter** reads back `undefined`
+at the callee. The same shape works when the array is a local or a module-level
+binding, and `string[]` / `any[]` parameters are unaffected — so it is specific
+to the boolean element type crossing the parameter boundary.
+
+## Why it matters
+
+Silent wrong-value (not a trap, not a throw): the callee sees `undefined` where
+a real array was passed, so it corrupts results rather than failing loudly.
+That is the worst failure mode to leave latent, and the narrowness of the
+trigger (boolean elements, parameter position only) is exactly what makes it
+survive casual testing.
+
+## Repro
+
+Recorded in the `## Slice 3 — implementation record` section of
+`plan/issues/4238-quickjs-runtime-eval-provider-flag.md`.
+
+## Acceptance criteria
+
+- [ ] Minimal repro as a permanent test failing on current main.
+- [ ] Root cause named in `src/codegen/` — why the boolean element type's
+      parameter lowering diverges from `string[]`/`any[]`.
+- [ ] Fix covers parameter position for boolean arrays; local/module positions
+      stay working; add coverage for all three positions × the element types
+      that share the lowering path.
+- [ ] Equivalence suite green; no test262 regressions.


### PR DESCRIPTION
## Description

Docs-only. Files two defects surfaced by #4238 slice 3, neither fixed there (that slice ran under a no-`src/` directive).

**#4305 (high) — `RuntimeError: illegal cast`.** Within one function: a **direct** eval that *succeeds*, then a later eval that *throws*, caught by a handler doing an `instanceof` test → trap. Reproduced with a **six-line stub adapter** in place of the real provider, so it is **caller-side codegen and engine-independent**. It was unreachable before slice 3 because direct eval always returned the typed refusal, so no direct eval ever succeeded.

Why it's high priority: it **will bite #4242's Phase-1 parity run**. The test262 harness wraps assertions in `assert.throws`-shaped code with `instanceof` catches, and slice 3 has now made direct eval succeed under the quickjs engine — so the precondition is met across a large slice of `language/eval-code/`. Those failures would land in the parity gate's `unattributed` bucket (which always blocks) and would mis-attribute engine-independent codegen faults to the engine under test, which is exactly what that gate exists to prevent.

**#4306 (medium) — `boolean[]` parameter reads back `undefined`.** Specific to boolean element type in *parameter* position; `string[]`/`any[]` and local/module positions are fine. Silent wrong-value rather than a trap, which is the worst mode to leave latent.

Both repros are recorded in #4238's `## Slice 3 — implementation record`.

## Process note (recorded in #4305's frontmatter)

`claim-issue.mjs --allocate` resolves "main" against `origin`, which in this checkout is the **fork**. With a ~90-commit-stale fork it minted ids **already used upstream** — 4262, 4264 and 4265 all exist on main, whose true max was 4304. Caught before any file was written by listing `plan/issues/` on freshly fetched upstream main; fixed by fast-forwarding the fork's main and re-allocating (→ 4305/4306). Ids 4262–4265 are abandoned reservations.

Open-PR scan was DEGRADED (no `gh` in this container) and GitHub code search returned 503 at authoring time, so these ids are verified against upstream main plus the assignment ref only — the required `check:issue-ids` gate is the backstop.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1RTKiL2tywvYQCTrFa1Yk)_