### PR TITLE
recover(claude/issue-3720-3721-package-probe-findings): fix(#3722): await-as-label check false-positives on ternary await bran

### DIFF
--- a/plan/issues/3720-mustache-late-import-index-shift-iswhitespace.md
+++ b/plan/issues/3720-mustache-late-import-index-shift-iswhitespace.md
@@ -1,0 +1,114 @@
+---
+id: 3720
+title: "Late-import index-shift crash compiling mustache@4.2.0's isWhitespace (RegExp.prototype.test.call indirection) — new #2043-class occurrence"
+status: ready
+sprint: current
+created: 2026-07-27
+updated: 2026-07-27
+priority: medium
+horizon: m
+feasibility: hard
+reasoning_effort: medium
+task_type: bugfix
+area: codegen, emit
+language_feature: compiler-internals
+goal: core-semantics
+origin: "ad-hoc probe of 3 more single-bundled-file npm packages (dayjs/mustache/diff), same shape as the acorn/marked dogfood pattern"
+related: [2043, 1710, 3716]
+---
+
+# #3720 — mustache compile crash: late-import index-shift in `isWhitespace`
+
+## Repro
+
+Pin: `mustache@4.2.0`, entry `mustache.js` (single self-contained UMD
+bundle, zero runtime deps, 772 lines — same "single pre-bundled dist file"
+shape as acorn/marked).
+
+```bash
+npm pack mustache@4.2.0
+tar -xzf mustache-4.2.0.tgz
+```
+
+```ts
+import { compile } from "./src/index.js";
+import { readFileSync } from "node:fs";
+const src = readFileSync("package/mustache.js", "utf-8");
+const result = await compile(src, { fileName: "mustache.js", skipSemanticDiagnostics: true });
+```
+
+Throws (does not return `success: false` — the emit step itself throws):
+
+```
+Binary emit error: RangeError: Codegen error: local index out of range — 3
+(valid: [0, 2)) at function 'isWhitespace'. This is the late-import
+index-shift class (#2043): a captured index went stale across a deferred
+flushLateImportShifts/addUnionImports/addStringImports shift, or a map
+lookup failed and baked -1/undefined. Re-resolve the index by name AFTER
+the last shift, or make the producer refuse loudly.
+```
+
+Stack: `emitBinaryWithSourceMapUnguarded` → `emitBinary` → `runPipeline` →
+`compileSourceSync` (`src/compiler.ts:1452`).
+
+## Offending source (mustache.js:61-64)
+
+```js
+var regExpTest = RegExp.prototype.test;
+function testRegExp (re, string) {
+  return regExpTest.call(re, string);
+}
+
+var nonSpaceRe = /\S/;
+function isWhitespace (string) {
+  return !testRegExp(nonSpaceRe, string);
+}
+```
+
+`isWhitespace` calls `testRegExp`, which invokes `RegExp.prototype.test`
+indirectly via `.call()` (a module-level `var` capturing the unbound
+method) rather than `re.test(string)` directly. That indirection is likely
+what triggers a late-added import (regex test intrinsic, or a `.call`
+dispatch helper) whose function index gets captured before a later
+shift (`addUnionImports`/`addStringImports`/`flushLateImportShifts`) moves
+it, and nothing re-resolves it by name afterward — exactly the failure
+mode #2043's own emit-time validation was built to catch loudly instead of
+silently emitting corrupt Wasm (see `CLAUDE.md` "addUnionImports": late
+import addition shifts function indices, and `ctx.currentFunc.body` must
+also be shifted).
+
+## Relationship to #2043
+
+**#2043 is `status: done`** — it added the always-on emit-time index
+validation that makes this failure LOUD (a clear `RangeError` naming the
+function and the bug class) instead of silently producing an invalid
+binary. It did not, and could not, retroactively fix every future producer
+that captures a stale index — this is a **new occurrence of the bug
+class** in a producer #2043 didn't touch, caught live by real-world code
+(mustache) exercising an indirect-`.call()`-through-a-captured-unbound-
+method pattern that the existing equivalence/test262 suites apparently
+don't cover.
+
+## Scope
+
+- [ ] Identify which specific late import (or emitter/temp-local
+      allocation) inside the codegen path for `isWhitespace`
+      (`RegExp.prototype.test.call(re, string)` pattern) captures a
+      pre-shift index.
+- [ ] Fix the producer to re-resolve by name after the last shift, per
+      #2043's own prescribed remedy, rather than caching the raw index
+      across a shift boundary.
+- [ ] Minimal repro reduced from the above (a standalone `.ts`/`.js` file
+      with just the `testRegExp`/`isWhitespace` pattern) for a fast
+      regression test.
+- [ ] Re-run mustache compile — expect `compile.success: true` (or a clean
+      `success: false` with real diagnostics, not a thrown `RangeError`).
+
+## Acceptance criteria
+
+- [ ] Minimal repro (isolated `.call()`-indirection-through-captured-
+      unbound-prototype-method pattern) compiles without throwing.
+- [ ] mustache@4.2.0's `mustache.js` compiles (`compile()` does not throw;
+      `success` is `true` or a clean diagnostic-only failure).
+- [ ] No regression in existing #2043-related pins
+      (`tests/issue-2043-*.test.ts` if present, or equivalent).

--- a/plan/issues/3721-diff-package-false-ts-syntax-errors.md
+++ b/plan/issues/3721-diff-package-false-ts-syntax-errors.md
@@ -1,0 +1,127 @@
+---
+id: 3721
+title: "diff@9.0.0's dist/diff.js rejected with TS8010/8017 'can only be used in TypeScript files' — false positive, real tsc reports zero errors on the same file"
+status: ready
+sprint: current
+created: 2026-07-27
+updated: 2026-07-27
+priority: medium
+horizon: m
+feasibility: hard
+reasoning_effort: medium
+task_type: bugfix
+area: checker
+language_feature: n/a
+goal: core-semantics
+origin: "ad-hoc probe of 3 more single-bundled-file npm packages (dayjs/mustache/diff), same shape as the acorn/marked dogfood pattern"
+related: [3717, 1710, 3716]
+---
+
+# #3721 — diff@9.0.0 false-positive TS syntax errors
+
+## Repro
+
+Pin: `diff@9.0.0`, entry `dist/diff.js` (self-contained UMD bundle, 2313
+lines, zero `require()` calls — same "single pre-bundled dist file" shape
+as acorn/marked; note the package's own `main`/`module` fields point at a
+multi-file `libcjs`/`libesm` source tree, but `dist/diff.js` is the
+pre-rolled bundle, same relationship as acorn's `dist/acorn.mjs`).
+
+```bash
+npm pack diff@9.0.0
+tar -xzf diff-9.0.0.tgz
+```
+
+```ts
+import { compile } from "./src/index.js";
+import { readFileSync } from "node:fs";
+const src = readFileSync("package/dist/diff.js", "utf-8");
+const result = await compile(src, { fileName: "diff.js", skipSemanticDiagnostics: true });
+// result.success === false, result.binary.length === 0
+// result.errors:
+//   TS8017 "Signature declarations can only be used in TypeScript files." @ line 1, col 1
+//   TS8010 "Type annotations can only be used in TypeScript files."       @ line 1, col 1  (x3)
+```
+
+All 4 diagnostics report `line: 1, column: 1` — a suspicious uniform
+position that looks like a fallback/default rather than a real located
+error.
+
+## This is confirmed a FALSE POSITIVE, not real content
+
+Ran the exact same file through real `tsc` directly (not js2wasm),
+matching js2wasm's own `allowJs` handling:
+
+```bash
+npx tsc --noEmit --allowJs --checkJs false --target es2022 --lib es2022 package/dist/diff.js
+```
+
+Zero errors on the file itself (only unrelated `@types/node` ambient-lib
+resolution noise, nothing referencing `diff.js`). Also grepped the file
+directly for any construct that could produce TS8010/8017 (parameter type
+annotations `(x: T)`, `interface`, `declare`, `readonly`, generic
+`function<T>`, ambient overload signatures ending in `;` with no body) —
+**none found**. The file is plain ES2015+ JS (UMD wrapper, `class`
+syntax), nothing TS-only.
+
+## What's been ruled out as the cause
+
+js2wasm has a known mechanism where a synthesized **TS source prelude**
+(`injectProcessStdinPrelude` / `injectIteratorStaticsPrelude`,
+`src/compiler.ts` around line 1287, `#2752`) gets prepended ahead of a
+`.js`-named user file and the combined unit must be parsed under
+`ts.ScriptKind.TS` (`forceTsGrammar`) or the prelude's own TS syntax gets
+rejected with these exact same codes (8010/8017) — that was the leading
+hypothesis. Traced both injectors' trigger conditions
+(`src/process-stdin-prelude.ts:179-189`,
+`src/iterator-statics-prelude.ts:162-182`):
+
+- `injectProcessStdinPrelude` requires both literal substrings `"process"`
+  and `"stdin"` present. `diff.js` contains `"process"` (in comments/an
+  identifier, e.g. `processIndex`) but **never** `"stdin"` — the cheap
+  pre-check short-circuits, `injected: false`.
+- `injectIteratorStaticsPrelude` requires the literal substring
+  `"Iterator"` (present — once, in a comment: `dist/diff.js:1516` "Iterator
+  that traverses...") AND one of `HELPERS = ["zip", "zipKeyed", "concat",
+  "from"]` (near-certainly present somewhere in a 111 KB bundle — "concat"
+  and "from" are common). This passes the cheap pre-check, but the
+  injector then does a real AST walk (`findIteratorHelperAccesses`)
+  looking for actual `Iterator.<helper>` property-access expressions —
+  diff.js has no real `Iterator.zip`/`.from`/etc. call sites (only the
+  unrelated comment), so `accesses.length === 0` and it should correctly
+  return `injected: false`.
+
+Both injectors *appear* to correctly no-op for this file based on reading
+their trigger logic — **not independently confirmed at runtime** (no
+instrumentation/breakpoint was added to verify `forceTsGrammar` is
+actually `false` for this compile). That verification step, plus checking
+whether some OTHER code path (a diagnostic-collection pass distinct from
+the main emit path — e.g. a `analyzeSource`/checker-layer parse that
+doesn't thread the same `forceTsGrammar` decision made in
+`compiler.ts:1293`) is where the mismatch actually happens, is the
+concrete next step.
+
+## Scope
+
+- [ ] Instrument/trace the actual `compile()` call for this file to
+      confirm whether `forceTsGrammar` and the resulting `scriptKind` are
+      what's expected (`false` / `ts.ScriptKind.JS`) at every parse site
+      that runs for a single-source compile — not just the main emit path.
+- [ ] If `forceTsGrammar` is correctly `false` throughout: find what other
+      mechanism is misclassifying real JS syntax in this file as TS-only
+      (the uniform `line:1,col:1` position across all 4 diagnostics is a
+      strong clue — likely a diagnostic-position-mapping bug, possibly
+      related to `PositionMap` used by the prelude-injection system even
+      when no prelude was actually inserted).
+- [ ] Minimal repro reduced from the 2313-line bundle (bisect which
+      specific construct near the file's `class Diff { diff(...) {`
+      opening, or elsewhere, trips this) — not yet attempted here.
+- [ ] Re-run — expect `compile.success: true` (or a legitimate diagnostic
+      unrelated to TS-syntax-in-JS-file).
+
+## Acceptance criteria
+
+- [ ] Root cause identified with a minimal (non-111KB) repro.
+- [ ] `diff@9.0.0`'s `dist/diff.js` compiles without the false TS8010/8017
+      diagnostics.
+- [ ] A regression test pins the minimal repro.

--- a/plan/issues/3722-await-ternary-label-false-positive.md
+++ b/plan/issues/3722-await-ternary-label-false-positive.md
@@ -1,0 +1,88 @@
+---
+id: 3722
+title: "Fix: await-as-label early-error false positive on `cond ? await x() : y` ternaries"
+status: done
+sprint: current
+created: 2026-07-27
+updated: 2026-07-27
+completed: 2026-07-27
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: checker
+language_feature: async-await
+goal: core-semantics
+origin: "found re-testing marked (#3715/#3716) with skipSemanticDiagnostics to see if it unblocks the same way #3717 unblocked acorn"
+related: [3715, 3716, 3717, 1068]
+---
+
+# #3722 — `cond ? await x() : y` false-flagged as `await:` label
+
+## How this was found
+
+Re-tested `marked@18.0.2` after #3717 (acorn's `skipSemanticDiagnostics`
+fix). Marked is still blocked by #3715 (evolving array types) under normal
+compilation, but compiling with `skipSemanticDiagnostics: true` (to see if
+it would unblock the same way it did for acorn) surfaced a DIFFERENT,
+real, previously-invisible bug: 5 diagnostics, all
+`'await' is not allowed as a label identifier in this context`, all
+pointing at the same construct.
+
+## Root cause
+
+`src/compiler/early-errors/node-checks.ts` — the await-as-label check
+(originally added for #1068, which correctly allows `await:` as a real
+label in *non*-async functions) flags any `AwaitExpression` immediately
+followed by `:` while inside an async function, **without excluding the
+case where that colon is a ternary's separator**, not a label colon:
+
+```js
+i.hooks ? await i.hooks.preprocess(n) : n
+//                                    ^ this colon — misread as a label colon
+```
+
+The sibling check for `yield` (same file, ~200 lines below) already has
+exactly this exclusion (`isInTernary`, checking whether the node's parent
+is a `ConditionalExpression`) — it was added there but never backported to
+`await`'s copy of the same check. A clear copy-paste divergence.
+
+Confirmed with exact source positions from marked's bundle — all 5 hits
+are `cond ? await obj.method(...) : fallback` shapes (e.g. `lib/marked.esm.js`
+line 75: `i.hooks?await i.hooks.preprocess(n):n`, `...await i.hooks.provideLexer(e):e?x.lex:x.lexInline`, etc.), each a legitimate async/sync
+dual-path pattern.
+
+## Fix
+
+Mirror the `yield` check's `isInTernary` guard onto the `await` check
+(`src/compiler/early-errors/node-checks.ts`, the "Also check await: label
+pattern" block): don't flag if the `AwaitExpression`'s parent (or
+grandparent through one layer of parens) is a `ConditionalExpression`.
+
+## Verification
+
+- New test `tests/issue-3722-await-ternary-label-false-positive.test.ts`
+  (4 cases): ternary-with-await true/false branches execute correctly, a
+  member/call-chain shape (closer to marked's real code) compiles, and a
+  genuine `await:` label inside an async function (no ternary) is still
+  correctly rejected as an error.
+- Re-ran `mustache`-adjacent (`tests/issue-1068.test.ts`,
+  `tests/labeled-loops.test.ts`, `tests/issue-2877.test.ts`) — no
+  regressions; pre-existing failures in `issue-2877`/`labeled-loops`
+  confirmed identical with the fix stashed out (unrelated: an IR
+  `SyntaxError` class gap and a `string_constants` import-wiring
+  environment issue, respectively).
+- Does **not** unblock marked's normal (non-`skipSemanticDiagnostics`)
+  compile — #3715 (evolving array types) still gates it earlier in the
+  pipeline. This fix only becomes externally visible once #3715 lands (or
+  when `skipSemanticDiagnostics: true` is used), but is a real, standalone
+  bug independent of that.
+
+## Acceptance criteria
+
+- [x] `cond ? await x() : y` inside an async function compiles and runs
+      correctly for both branches.
+- [x] A genuine `await:` label (no ternary) inside an async function is
+      still rejected.
+- [x] No regressions in existing await/yield/label test suites.

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -1361,12 +1361,22 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
         ctx.addError(node, "'await' is not allowed as an identifier in this context");
       }
     }
-    // Also check await: label pattern (TS parses await: as AwaitExpression + colon)
+    // Also check await: label pattern (TS parses await: as AwaitExpression + colon).
+    // Don't flag if the await is inside a ConditionalExpression (ternary ? await x : y)
+    // — the trailing colon there is the ternary's, not a label colon (mirrors the
+    // identical yield-as-label guard below).
     if (isInsideAsyncFunction(node) || isInsideClassStaticBlock(node)) {
       const endPos = node.end;
       const afterText = ctx.sourceFile.text.substring(endPos, endPos + 5).trimStart();
       if (afterText.startsWith(":")) {
-        ctx.addError(node, "'await' is not allowed as a label identifier in this context");
+        const isInTernary =
+          node.parent &&
+          (ts.isConditionalExpression(node.parent) ||
+            // Also check grandparent for nested parens: (await x) ? await y : await z
+            (ts.isParenthesizedExpression(node.parent) && ts.isConditionalExpression(node.parent.parent)));
+        if (!isInTernary) {
+          ctx.addError(node, "'await' is not allowed as a label identifier in this context");
+        }
       }
     }
     // ES spec: ClassStaticBlockBody: "It is a Syntax Error if ContainsAwait

--- a/tests/issue-3722-await-ternary-label-false-positive.test.ts
+++ b/tests/issue-3722-await-ternary-label-false-positive.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #3722 — the await-as-label early-error check (src/compiler/early-errors/
+// node-checks.ts) flagged ANY AwaitExpression immediately followed by `:` as
+// an invalid label, without excluding the case where that `:` is a ternary's
+// separator (`cond ? await expr : else`) rather than a label colon. The
+// sibling yield-as-label check already carried this exact exclusion; await's
+// check was missing it. Found compiling marked@18.0.2's bundled
+// marked.esm.js, which uses this pattern for its async/sync dual code path
+// (e.g. `i.hooks ? await i.hooks.preprocess(n) : n`).
+
+async function instantiate(src: string): Promise<Record<string, (...a: unknown[]) => unknown>> {
+  const result = await compile(src);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as WebAssembly.Imports);
+  const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;
+  if (imports.setExports) imports.setExports(exports as Record<string, Function>);
+  return exports;
+}
+
+describe("#3722 — await in a ternary's consequent branch is not a label", () => {
+  it("`cond ? await x() : y` compiles and runs (true branch)", async () => {
+    const exports = await instantiate(`
+      async function fetchIt(): Promise<number> { return 7; }
+      export async function pick(useAsync: boolean): Promise<number> {
+        return useAsync ? await fetchIt() : 3;
+      }
+    `);
+    expect(exports.pick(1)).toBe(7);
+  });
+
+  it("`cond ? await x() : y` compiles and runs (false branch)", async () => {
+    const exports = await instantiate(`
+      async function fetchIt(): Promise<number> { return 7; }
+      export async function pick(useAsync: boolean): Promise<number> {
+        return useAsync ? await fetchIt() : 3;
+      }
+    `);
+    expect(exports.pick(0)).toBe(3);
+  });
+
+  it("a member/call expression after await inside a ternary compiles", async () => {
+    const result = await compile(`
+      async function fetchIt(n: number): Promise<number> { return n + 1; }
+      const hooks = { preprocess: fetchIt };
+      export async function run(useHooks: boolean, n: number): Promise<number> {
+        return useHooks ? await hooks.preprocess(n) : n;
+      }
+    `);
+    expect(
+      result.success,
+      `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+    ).toBe(true);
+  });
+
+  it("a genuine await-as-label (no ternary) is still a real error", async () => {
+    const result = await compile(`
+      export async function foo(): Promise<number> {
+        await: for (let i = 0; i < 1; i++) {}
+        return 1;
+      }
+    `);
+    expect(result.success).toBe(false);
+    expect(result.errors.some((e) => /await.*not allowed/i.test(e.message))).toBe(true);
+  });
+});


### PR DESCRIPTION
Recovery PR opened by the branch sweep (2026-08-09): this branch carries **2 unlanded commit(s)** and had **never been PR'd**, so its work was invisible to the queue.

- last commit: `fix(#3722): await-as-label check false-positives on ternary await bran` (2026-07-27)
- files: plan/issues/3720-mustache-late-import-index-shift-iswhitespace.md, plan/issues/3721-diff-package-false-ts-syntax-errors.md, plan/issues/3722-await-ternary-label-false-positive.md, src/compiler/early-errors/node-checks.ts, tests/issue-3722-await-ternary-label-false-positive.test.ts
- behind main by 3109 commits at open time

Opened for triage, not blind merge: the branch is old, so expect a main-merge and a CI cycle before it is mergeable. If the work is superseded, close this PR and delete the branch — that is a valid outcome and better than the branch sitting invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAPpV5PjTA98gW2Tjqhrki