### PR TITLE
docs(release): add test262 conformance numbers to the v0.69.0 notes

### DIFF
--- a/docs/release-notes/v0.69.0.md
+++ b/docs/release-notes/v0.69.0.md
@@ -2,6 +2,36 @@
 
 Lockstep release of `@loopdive/js2` and the `js2wasm` proxy: 0.68.0 → 0.69.0.
 
+## Conformance (test262)
+
+Measured on `06b2394aa` — the release commit itself — by the `promote-baseline`
+job, official scope (standard + annex B, no proposals), honest oracle:
+
+| target | pass / total | rate |
+| --- | --- | --- |
+| js-host (gc) | 31,819 / 43,621 | **72.9 %** |
+| standalone (pure Wasm, no JS host) | 29,088 / 43,621 | **66.7 %** |
+
+The **honest gap is 2,731 tests** — passing under the JS host but not
+standalone. That gap is the thing to watch across releases; a js-host number
+alone does not describe what a host-free embedding gets.
+
+### ES5 subset, standalone
+
+The bulk of this release is the ES5-standalone program, measured on the
+`es5id:`-tagged subset:
+
+| point | pass / 8,115 | rate |
+| --- | --- | --- |
+| program start | 6,907 | 85.11 % |
+| this release | **7,242** | **89.24 %** |
+
+**The 90 % goal (7,304) was not met — 62 tests short.** The reason is recorded
+in the program-outcome section of `plan/goals/es5-standalone-90.md`: three
+separately-sized levers collapsed under measurement (42→4, 44→0, ~105→6), each
+because the bucket had been sized by counting files whose *error text* matched
+a pattern rather than by root cause.
+
 ## Features
 
 - perf(array): batch numeric indexOf misses


### PR DESCRIPTION
The generated `docs/release-notes/v0.69.0.md` carried a commit list but **no conformance figures** — so a release that is mostly ES5-conformance work said nothing about conformance. This adds them.

Numbers are from the committed baselines at `06b2394aa`, the v0.69.0 release commit itself (`promote-baseline` job, official scope, honest oracle):

| target | pass / total | rate |
| --- | --- | --- |
| js-host (gc) | 31,819 / 43,621 | 72.9 % |
| standalone (pure Wasm, no JS host) | 29,088 / 43,621 | 66.7 % |

Both lanes are reported deliberately, along with the **honest gap of 2,731 tests** — those passing under the JS host but not standalone. A js-host figure on its own does not describe what a host-free embedding actually gets, and this repo's dual-mode architecture makes that distinction the interesting one.

The ES5 subset is broken out separately, since it is what the release's headline work targeted: **85.11 % → 89.24 %** on the `es5id:`-tagged files, with the 90 % goal **missed by 62 tests**. The notes say so plainly and point at the program-outcome section of `plan/goals/es5-standalone-90.md` (landed in #4314) for why the estimates missed.

Docs-only; `prettier --check` clean.

**Timing note:** the `v0.69.0` tag has not been pushed yet (tag creation is refused for this session's credentials — 403 on `git-receive-pack`, while branch writes succeed). Since the GitHub Release is created with an empty body and populated afterwards from this file, landing this before the tag push means the published release notes carry the conformance numbers rather than needing a later edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmwHrtyzm28H9YuH2nYLYy

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmwHrtyzm28H9YuH2nYLYy)_