### PR TITLE
ci(npm-compat): promote artifacts through a PR, not a push to main

### DIFF
--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -113,4 +113,22 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
+          # AUTHOR-TRUST GATE (#2549/#2550) — add THIS app to the allowlist.
+          #
+          # `npm-compat-refresh.yml` promotes its artifacts through a PR opened
+          # by this same app, from an UPSTREAM head branch. That PR matches none
+          # of the gate's three layers by default: an app's `authorAssociation`
+          # is not OWNER/MEMBER/COLLABORATOR, its login is not `ttraenkler`, and
+          # its head repo owner is `loopdive` rather than the fork. It would be
+          # skipped `untrusted-author:…` on every sweep, forever — and since a
+          # skip is silent, the symptom would be the npm-compat dashboard
+          # quietly ceasing to move, which is exactly the failure that workflow
+          # exists to prevent.
+          #
+          # Derived from the minted token (`app-slug`), never hardcoded, so it
+          # cannot drift from the app that actually opens the PR. The trust
+          # delta is narrow: the only thing that can make this app author a PR
+          # is a workflow already on `main`, and the app already holds enqueue
+          # authority — an external contributor cannot reach either.
+          TRUSTED_AUTHOR_LOGINS: ttraenkler,${{ steps.app-token.outputs.app-slug }}[bot]
         run: node scripts/enqueue-green-prs.mjs

--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -8,15 +8,65 @@ name: Refresh npm-compat
 # #3977 kept showing `lit` as `not-integrated` after its suite landed), which is
 # the case for a mechanism rather than for remembering. See #3988.
 #
-# Deliberately push-only. The artifact is DATA, not a correctness gate, so there
-# is nothing for a PR run to decide — and a full generation is expensive (it
-# re-runs the React and lit upstream suites and re-measures three perf lanes),
-# which is exactly the cost that made the manual step get skipped.
+# Deliberately push-triggered. The artifact is DATA, not a correctness gate, so
+# there is nothing for a PR run to decide — and a full generation is expensive
+# (it re-runs the React and lit upstream suites and re-measures three perf
+# lanes), which is exactly the cost that made the manual step get skipped.
+#
+# ── PROMOTION IS A PULL REQUEST, NOT A PUSH TO main ──────────────────────
+# This workflow used to `git push deploykey HEAD:main`. It no longer does.
+#
+# ANY push to main — INCLUDING a `[skip ci]` one — makes GitHub rebuild every
+# in-flight `merge_group` on the new base and THROW AWAY the validation running
+# under it. `[skip ci]` suppresses workflows on the commit; it does not make the
+# push inert to the queue. Measured 2026-08-09: PR #4323's merge group started
+# 22:52 on f70b4eb2, this workflow's auto-commit landed 22:59:30, and the group
+# was rebuilt at 22:59:51 — a ~19-minute `Test262 Sharded` job discarded.
+# #4297 lost three windows the same day, #4300 one.
+#
+# `scripts/main-push-queue-gate.mjs` was supposed to prevent that, but it is a
+# gate with two DELIBERATE holes: `--stale-after-hours` OVERRIDES the queue
+# check once the served artifact is older than the floor (12h originally, cut
+# to 1h so a deferred measurement was not lost for a whole day), and a
+# malfunctioning gate fails OPEN. Both holes are correct for a direct push (a
+# gate that can freeze the artifact forever is worse than an occasional rebuild
+# — that is #4130), and both mean that on a busy day deferrals accumulate until
+# the staleness floor forces a push into a live merge group. Cutting the floor
+# to 1h made that MORE frequent, not less.
+#
+# Routing through a PR makes the whole class structurally impossible: main then
+# only ever advances via the merge queue, which is the project's own rule. There
+# is nothing left to defer, so the gate, the staleness floor and the fail-open
+# branch are all gone from this path. The script itself STAYS — `benchmark-
+# refresh.yml` and `refresh-baseline.yml` still push to main directly and still
+# call it (see the class-coverage test in tests/issue-3915-*.test.ts).
 on:
   push:
     branches: [main]
-  # Backstop for a quiet main (no pushes ⇒ no push-triggered refresh) and for a
-  # run lost to a deferred merge-queue gate.
+    # DO NOT re-trigger on our OWN landing. Both of the old loop-breakers are
+    # gone with the direct push: the promotion commit can no longer carry
+    # `[skip ci]` (the PR *needs* CI to run in order to become CLEAN and be
+    # picked up by auto-enqueue), and it lands as an ordinary merge-queue merge
+    # whose actor is not `github-actions[bot]`.
+    #
+    # That matters because the measurement includes perf timings, which differ
+    # on every run — so every run publishes something. Without this filter each
+    # landing would trigger the next refresh, forever: a 24-minute runner and a
+    # merge-queue entry every ~25 minutes, in perpetuity.
+    #
+    # `paths-ignore` is evaluated against the union of files changed by the
+    # push, so a merge that ALSO carries real work (the normal case — our PR
+    # batched with, or landing between, ordinary PRs) still runs the refresh.
+    # It is also evaluated before a runner is allocated, so the loop is broken
+    # for free rather than 24 minutes in.
+    paths-ignore:
+      - "benchmarks/results/npm-compat.json"
+      - "benchmarks/results/npm-compat-perf.json"
+      - "benchmarks/results/npm-compat-history.json"
+      - "website/public/benchmarks/results/npm-compat.json"
+      - "website/public/benchmarks/results/npm-compat-perf.json"
+      - "website/public/benchmarks/results/npm-compat-history.json"
+  # Backstop for a quiet main (no pushes ⇒ no push-triggered refresh).
   #
   # It is NOT a backstop against starvation by a busy main, which is what the
   # original comment here claimed. A cron run lands in the same concurrency
@@ -30,6 +80,12 @@ on:
 
 permissions:
   contents: read
+
+env:
+  # ONE reused branch, force-updated every cycle, with at most ONE open PR on
+  # it. Coalescing is the point: a queue of stale artifact PRs would be worse
+  # than the problem being fixed. Nobody else ever touches this ref.
+  PROMOTION_BRANCH: ci/npm-compat-refresh
 
 concurrency:
   group: npm-compat-refresh-${{ github.ref }}
@@ -51,20 +107,19 @@ concurrency:
 
 jobs:
   refresh:
-    # `github-actions[bot]` guard breaks the trigger loop: this job's own
-    # `[skip ci]` commit is a push to main. `[skip ci]` suppresses workflows on
-    # that commit, but the actor check is what makes the loop impossible rather
-    # than merely unlikely.
+    # The `paths-ignore` filter above is what actually breaks the trigger loop
+    # now (this job's own landing changes only artifact paths). The actor guard
+    # is kept as a second, cheaper line against any OTHER bot push to main.
     if: github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     environment: baseline-promote
     permissions:
-      contents: write
-      # actions:write lets the post-publish step dispatch deploy-pages (#4217).
-      # workflow_dispatch is one of the two event types the GITHUB_TOKEN is
-      # allowed to create runs for, so no PAT is needed.
-      actions: write
+      # The branch push uses MAIN_DEPLOY_KEY (SSH) and the PR is opened with a
+      # GitHub App token, so GITHUB_TOKEN needs no write scope here. `actions:
+      # write` is gone with the deploy-pages dispatch it existed for (#4217 —
+      # see the note at the end of this job).
+      contents: read
 
     steps:
       - name: Resolve immutable source revision
@@ -88,22 +143,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # (#4130) MUST run BEFORE the regeneration below. The staleness floor in
-      # the queue gate asks "how old is the artifact main is currently serving",
-      # and the only moment that question is answerable is before this job
-      # overwrites the file. Reading it afterwards yields the age of the
-      # measurement this job just took — always ~0 — so the floor could never
-      # fire and a permanently busy queue deferred the promotion forever. The
-      # workflow ran, reported success, and committed nothing for two days.
-      - name: Capture the COMMITTED artifact's age (before regenerating)
-        id: committed
-        shell: bash
-        run: |
-          set -euo pipefail
-          LAST_REFRESH="$(node -e 'try{const r=JSON.parse(require("fs").readFileSync("benchmarks/results/npm-compat.json","utf8"));process.stdout.write(String(r.generatedAt??""))}catch{process.stdout.write("")}')"
-          echo "last_refresh=${LAST_REFRESH}" >> "$GITHUB_OUTPUT"
-          echo "committed artifact generatedAt: ${LAST_REFRESH:-<unreadable>}"
-
+      # (#4130) The "capture the COMMITTED artifact's age before regenerating"
+      # step that used to sit here is GONE. It existed for exactly one consumer:
+      # the `--stale-after-hours` floor in the merge-queue gate, which asked
+      # "how old is the artifact main is currently serving" and could only be
+      # answered before this job overwrote the file. There is no gate and no
+      # floor on this path any more, so there is nothing to feed. The freshness
+      # invariant that DOES survive — never overwrite a newer artifact with an
+      # older measurement — is enforced in the publish step below by comparing
+      # `generatedAt` values, which is a different question.
       - name: Regenerate the npm-compat artifacts
         # No `--only`: a focused run never writes, because a partial file would
         # drop the other packages. Refreshing anything means regenerating all of
@@ -135,11 +183,11 @@ jobs:
       # the #4252 bag-slot merge — deferred their promote behind a busy queue,
       # and their numbers were unrecoverable: no commit, no artifact, logs
       # don't carry the JSON. Upload the generated artifacts unconditionally
-      # so every measurement is inspectable the moment the run ends, deferred
-      # or not. Paired change: the queue-gate staleness floor drops 12h → 1h,
-      # so a busy queue can hold the PUBLISHED artifact back at most an hour
-      # (worst-case ~1 queue rebuild per hour, vs the measured 3h+ blackout).
-      - name: Upload generated artifacts (always — deferred measurements must survive)
+      # so every measurement is inspectable the moment the run ends, published
+      # or not. Still worth keeping now that promotion goes through a PR: a run
+      # that skips its push (queued PR, or a fresher artifact already pending)
+      # still has a measurement worth reading.
+      - name: Upload generated artifacts (always — unpublished measurements must survive)
         if: always()
         uses: actions/upload-artifact@v6
         with:
@@ -151,43 +199,85 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      # (#3915) DO NOT DISCARD AN IN-FLIGHT merge_group VALIDATION. Any push to
-      # main — INCLUDING a `[skip ci]` one — makes GitHub rebuild every queued
-      # merge group on the new base and throw away the validation running under
-      # it. `[skip ci]` suppresses workflows on the commit; it does not make the
-      # push inert to the queue. Same gate the two sibling bots use.
-      - name: Gate the main push on the merge queue
-        id: queue_gate
+      # THE PR MUST BE OPENED BY AN ACTOR THAT IS NOT `GITHUB_TOKEN`. A pull
+      # request created with `GITHUB_TOKEN` fires NO `pull_request` and no
+      # `pull_request_target` events — GitHub's "a workflow run cannot trigger
+      # another workflow run" rule — so it gets neither `CI` nor `cla-check`,
+      # never reaches `mergeStateStatus == CLEAN`, and `auto-enqueue.yml` (which
+      # takes only CLEAN/HAS_HOOKS) never touches it. The result would be a
+      # green-looking PR that strands forever and an artifact that silently
+      # stops moving: the exact failure shape this workflow exists to prevent.
+      # Same rule that wedged the merge queue for a full night in #2523.
+      #
+      # A GitHub App installation token is a distinct actor, which is why
+      # `auto-enqueue.yml` already mints one. Reuse those secrets rather than a
+      # PAT: `AUTO_ENQUEUE_TOKEN` is NOT set on this repo (#2523 resolved by
+      # adopting the app instead), so a `secrets.AUTO_ENQUEUE_TOKEN || ...`
+      # fallback would silently select the broken path.
+      #
+      # Minted HERE, after the ~24-minute generation, because an installation
+      # token expires in one hour.
+      - name: Mint a GitHub App token for the promotion PR
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ENQUEUE_APP_ID }}
+          private-key: ${{ secrets.ENQUEUE_APP_PRIVATE_KEY }}
+
+      # Force-updating the promotion branch WHILE its PR is the in-flight merge
+      # group rebuilds that group and cancels its run — the same harm this whole
+      # change removes, just relocated. So look before pushing.
+      #
+      # FAIL-SAFE DIRECTION IS "PUSH ANYWAY". If the queue cannot be read we
+      # proceed: the harm of a wrong push is bounded (with
+      # `max_entries_to_build=1` the cancelled group contains only this PR), and
+      # the harm of a wrong skip is the artifact freezing behind an unreadable
+      # gate — which is #4130, the failure this repo has already paid for once.
+      - name: Check whether the promotion PR is already in the merge queue
+        id: queue_state
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
         run: |
           set -uo pipefail
-          # (#4130) From the step that ran BEFORE the regeneration — the age of
-          # what main is serving, not of the measurement just taken.
-          LAST_REFRESH="${{ steps.committed.outputs.last_refresh }}"
-          # `|| RC=$?`, not a bare call then `RC=$?`: the default step shell is
-          # `bash -e {0}`, so a bare non-zero exit aborts the step before the
-          # next line runs and the DEFER path would look like a step failure.
-          RC=0
-          node scripts/main-push-queue-gate.mjs \
-            --repo "$GITHUB_REPOSITORY" \
-            --last-refresh "$LAST_REFRESH" \
-            --stale-after-hours 1 \
-            --reason "landing npm-compat artifacts" || RC=$?
-          if [ "$RC" -eq 10 ]; then
-            echo "decision=defer" >> "$GITHUB_OUTPUT"
-          else
-            # 0 = proceed. Anything else is a gate malfunction, and a broken
-            # gate must never freeze the artifact — fail OPEN, loudly.
-            [ "$RC" -eq 0 ] || echo "::warning title=main-push-queue-gate::gate exited ${RC}; failing open"
-            echo "decision=proceed" >> "$GITHUB_OUTPUT"
-          fi
+          PR_NUMBER="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
+            --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
-      - name: Promote the refreshed artifacts to main
-        # A deferred refresh is not a failure: the next push to main (or the 6h
-        # cron) regenerates and promotes, and the staleness floor in the gate
-        # bounds how long a permanently busy queue can hold the artifact back.
-        if: steps.queue_gate.outputs.decision != 'defer'
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open promotion PR on ${PROMOTION_BRANCH}; nothing can be queued."
+            echo "skip=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Open promotion PR: #${PR_NUMBER}"
+
+          QUEUED="$(gh api graphql -f query="
+            query(\$owner: String!, \$name: String!) {
+              repository(owner: \$owner, name: \$name) {
+                mergeQueue(branch: \"main\") {
+                  entries(first: 100) { nodes { pullRequest { number } } }
+                }
+              }
+            }" -f owner="${GITHUB_REPOSITORY%%/*}" -f name="${GITHUB_REPOSITORY##*/}" \
+            --jq "[.data.repository.mergeQueue.entries.nodes[].pullRequest.number] | index(${PR_NUMBER}) != null" 2>/dev/null || echo "unreadable")"
+
+          case "$QUEUED" in
+            true)
+              echo "::notice title=npm-compat-refresh::PR #${PR_NUMBER} is in the merge queue; leaving it alone. This measurement is uploaded as an artifact and the next run publishes a fresher one."
+              echo "skip=1" >> "$GITHUB_OUTPUT"
+              ;;
+            false)
+              echo "PR #${PR_NUMBER} is not queued; safe to force-update its branch."
+              echo "skip=0" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::warning title=npm-compat-refresh::could not read the merge queue; proceeding (an unreadable gate must never freeze the artifact — #4130)."
+              echo "skip=0" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Publish the refreshed artifacts to the promotion branch
+        if: steps.queue_state.outputs.skip != '1'
         id: promote
         env:
           MAIN_DEPLOY_KEY: ${{ secrets.MAIN_DEPLOY_KEY }}
@@ -200,6 +290,10 @@ jobs:
             exit 1
           fi
 
+          # The branch push MUST NOT use GITHUB_TOKEN either, for the same
+          # reason as the PR: a `synchronize` from GITHUB_TOKEN would not
+          # re-run the PR's checks. A deploy key is a distinct credential and
+          # its pushes do trigger workflows.
           eval "$(ssh-agent -s)"
           echo "$MAIN_DEPLOY_KEY" | ssh-add -
           mkdir -p ~/.ssh
@@ -209,6 +303,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote add deploykey "git@github.com:${GITHUB_REPOSITORY}.git"
           git fetch deploykey main
+          git fetch deploykey "$PROMOTION_BRANCH" || true
 
           # Do NOT gate on "did main advance". It always advances — the job runs
           # ~24 min and main merges faster than that — so the sha-equality guard
@@ -219,19 +314,27 @@ jobs:
           #
           # The invariant that actually matters is FRESHNESS: never overwrite a
           # newer artifact with an older measurement. Compare `generatedAt`, not
-          # commit shas. A measurement taken a few commits behind head is still
-          # vastly better than one taken hours behind — that is the entire point
-          # of the job.
-          # Read the remote copy via `git show`, NOT `git checkout -- <path>`:
-          # the working tree currently holds the freshly generated artifact and
-          # a checkout would overwrite the very thing we are about to publish.
-          git show deploykey/main:benchmarks/results/npm-compat.json > /tmp/remote-npm-compat.json 2>/dev/null || true
-          REMOTE_STAMP="$(node -e 'try{const r=JSON.parse(require("fs").readFileSync("/tmp/remote-npm-compat.json","utf8"));process.stdout.write(String(r.generatedAt??""))}catch{process.stdout.write("")}')"
+          # commit shas. Both landed (main) and PENDING (the promotion branch)
+          # copies count — a measurement already waiting in the open PR is just
+          # as real as one on main, and clobbering it with an older one would
+          # move the dashboard backwards.
+          # Read remote copies via `git show`, NOT `git checkout -- <path>`: the
+          # work tree currently holds the freshly generated artifact and a
+          # checkout would overwrite the very thing we are about to publish.
+          stamp_of() {
+            git show "$1:benchmarks/results/npm-compat.json" 2>/dev/null > /tmp/other-npm-compat.json || : > /tmp/other-npm-compat.json
+            node -e 'try{const r=JSON.parse(require("fs").readFileSync("/tmp/other-npm-compat.json","utf8"));process.stdout.write(String(r.generatedAt??""))}catch{process.stdout.write("")}'
+          }
+          MAIN_STAMP="$(stamp_of deploykey/main)"
+          BRANCH_STAMP="$(stamp_of "deploykey/${PROMOTION_BRANCH}")"
           OURS_STAMP="$(node -e 'try{const r=JSON.parse(require("fs").readFileSync("benchmarks/results/npm-compat.json","utf8"));process.stdout.write(String(r.generatedAt??""))}catch{process.stdout.write("")}')"
-          if [ -n "$REMOTE_STAMP" ] && [ -n "$OURS_STAMP" ] && [[ "$REMOTE_STAMP" > "$OURS_STAMP" ]]; then
-            echo "main already carries a fresher artifact (${REMOTE_STAMP} > ${OURS_STAMP}); nothing to publish."
-            exit 0
-          fi
+          echo "generatedAt — main: ${MAIN_STAMP:-<none>} | ${PROMOTION_BRANCH}: ${BRANCH_STAMP:-<none>} | ours: ${OURS_STAMP:-<none>}"
+          for OTHER in "$MAIN_STAMP" "$BRANCH_STAMP"; do
+            if [ -n "$OTHER" ] && [ -n "$OURS_STAMP" ] && [[ "$OTHER" > "$OURS_STAMP" ]]; then
+              echo "A fresher artifact already exists (${OTHER} > ${OURS_STAMP}); nothing to publish."
+              exit 0
+            fi
+          done
 
           ARTIFACTS=(
             benchmarks/results/npm-compat.json
@@ -244,85 +347,120 @@ jobs:
 
           # Stash the generated artifacts OUTSIDE the work tree, then replay them
           # onto whatever main is now. The commit cannot be built on SOURCE_SHA:
-          # main has advanced during the ~24 min measurement, so a push from that
-          # base is a guaranteed non-fast-forward. This is the step that actually
-          # makes a long-running measurement publishable.
+          # main has advanced during the ~24 min measurement, so the PR would
+          # open behind main and immediately need a refresh. This is the step
+          # that actually makes a long-running measurement publishable.
           STAGE="$(mktemp -d)"
           for f in "${ARTIFACTS[@]}"; do
             mkdir -p "${STAGE}/$(dirname "$f")"
             cp "$f" "${STAGE}/$f"
           done
 
-          for attempt in 1 2 3 4 5; do
-            git fetch deploykey main
-            # `-f`: the work tree still holds the regenerated artifacts, which
-            # differ from main's committed copies, so a plain checkout would
-            # refuse with "local changes would be overwritten". Discarding them
-            # is safe — STAGE holds the only copy that matters.
-            git checkout -q -f -B npm-compat-publish deploykey/main
-            for f in "${ARTIFACTS[@]}"; do
-              mkdir -p "$(dirname "$f")"
-              cp "${STAGE}/$f" "$f"
-            done
-            git add -f -- "${ARTIFACTS[@]}"
-
-            if git diff --cached --quiet; then
-              echo "npm-compat artifacts are already current on main."
-              exit 0
-            fi
-
-            # (#4132/#4140) --no-verify on BOTH the commit and the push. This job
-            # installs dependencies, so husky's hooks are live:
-            #   pre-commit runs `test:changed-root`, which needs a merge base with
-            #     `origin/main`;
-            #   pre-push  runs the oracle ratchet, which fails here too.
-            # The checkout is `fetch-depth: 1` with `persist-credentials: false`
-            # and the push remote is `deploykey`, so `origin/main` does not exist
-            # and neither hook can do its job. The sibling `benchmark-refresh` is
-            # immune only structurally — its promote job is separate and never
-            # runs `pnpm install`, so no hook is installed. This workflow is
-            # deliberately a SINGLE job and has to opt out explicitly. Running
-            # either check over generated JSON artifacts would be meaningless.
-            git commit -q --no-verify -m "chore(ci): refresh npm-compat artifacts [skip ci]"
-
-            # (#4140) Distinguish a genuine mid-promotion race from any other push
-            # failure. Replaying only helps when main moved under us; for
-            # anything else the replay is guaranteed to fail identically, and it
-            # buries the real error under five rounds of a MISLEADING message.
-            # That is exactly how a rejected pre-push hook read as "main advanced
-            # mid-promotion" for a full cycle.
-            push_err="$(mktemp)"
-            if git push --no-verify deploykey HEAD:main 2>"$push_err"; then
-              echo "Published npm-compat artifacts measured at ${SOURCE_SHA}."
-              echo "published=1" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            cat "$push_err"
-            if ! grep -Eqi 'non-fast-forward|fetch first|behind its remote|stale info' "$push_err"; then
-              echo "::error::npm-compat push failed for a reason that replaying cannot fix (see above)."
-              exit 1
-            fi
-            echo "push rejected (main advanced mid-promotion); replaying onto the new head — attempt ${attempt}/5."
+          # `-f`: the work tree still holds the regenerated artifacts, which
+          # differ from main's committed copies, so a plain checkout would
+          # refuse with "local changes would be overwritten". Discarding them
+          # is safe — STAGE holds the only copy that matters.
+          git checkout -q -f -B "$PROMOTION_BRANCH" deploykey/main
+          for f in "${ARTIFACTS[@]}"; do
+            mkdir -p "$(dirname "$f")"
+            cp "${STAGE}/$f" "$f"
           done
+          git add -f -- "${ARTIFACTS[@]}"
 
-          echo "::error::could not publish npm-compat artifacts after 5 replay attempts."
-          exit 1
+          if git diff --cached --quiet; then
+            echo "npm-compat artifacts are already current on main; nothing to promote."
+            exit 0
+          fi
 
-      # (#4217) The artifact commit above carries `[skip ci]`, so it can never
-      # trigger its own Pages rebuild — the deployed npm-compat.html kept
-      # serving the previous JSON until the NEXT unrelated merge redeployed the
-      # site (observed 2026-08-08: artifact published 05:56, last deploy 05:34,
-      # page stale until a manual dispatch at 06:22). Dispatch the deploy
-      # explicitly after a real publish. Best-effort: the data is already
-      # safely on main, so a failed dispatch is a warning, not a job failure.
-      - name: Redeploy Pages so the site serves the fresh artifact
-        if: steps.queue_gate.outputs.decision != 'defer' && steps.promote.outputs.published == '1'
+          # (#4132/#4140) --no-verify on BOTH the commit and the push. This job
+          # installs dependencies, so husky's hooks are live:
+          #   pre-commit runs `test:changed-root`, which needs a merge base with
+          #     `origin/main`;
+          #   pre-push  runs the oracle ratchet, which fails here too.
+          # The checkout is `fetch-depth: 1` with `persist-credentials: false`
+          # and the push remote is `deploykey`, so `origin/main` does not exist
+          # and neither hook can do its job. The sibling `benchmark-refresh` is
+          # immune only structurally — its promote job is separate and never
+          # runs `pnpm install`, so no hook is installed. This workflow is
+          # deliberately a SINGLE job and has to opt out explicitly. Running
+          # either check over generated JSON artifacts would be meaningless.
+          #
+          # NO `[skip ci]`. The PR now NEEDS its checks to run to become CLEAN;
+          # a `[skip ci]` commit would leave it permanently unmergeable. Landing
+          # via the queue also means the merge to main is an ordinary,
+          # CI-visible push — which is what restores the Pages redeploy (#4217,
+          # see the note at the end of this job).
+          git commit -q --no-verify -m "chore(ci): refresh npm-compat artifacts"
+
+          # `--force` on purpose, and no replay loop. This is a bot-owned branch
+          # that nothing else authors; the five-attempt replay existed only
+          # because pushing to `main` races every other merge. Whatever is on
+          # the branch is a SUPERSEDED measurement (or an `auto-refresh-prs`
+          # merge of main into it), and the commit we just built is main's tip
+          # plus the newest artifacts — so overwriting is always the right
+          # answer and can never lose work.
+          git push --no-verify --force deploykey "HEAD:refs/heads/${PROMOTION_BRANCH}"
+          echo "Pushed npm-compat artifacts measured at ${SOURCE_SHA} to ${PROMOTION_BRANCH}."
+          echo "published=1" >> "$GITHUB_OUTPUT"
+
+      # Coalesce: open a PR only when none is open. An existing PR was just
+      # force-updated above, which fires `synchronize` and re-runs its checks —
+      # nothing more to do for it here.
+      #
+      # This workflow does NOT enqueue, by policy (#2786): `auto-enqueue.yml` is
+      # the single enqueuer and picks the PR up when its required checks go
+      # green. An artifact-only diff touches nothing on the `&test262-paths`
+      # anchor in test262-sharded.yml, so the ~19-minute shard matrix is skipped
+      # in the merge group (the `detect` job emits run_shards=false) — keep it
+      # that way: never let this PR touch `package.json`, `pnpm-lock.yaml`, or
+      # anything else on that list.
+      - name: Open the promotion PR if none is open
+        if: steps.promote.outputs.published == '1' && steps.queue_state.outputs.pr_number == ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SOURCE_SHA: ${{ steps.refs.outputs.source_sha }}
         shell: bash
         run: |
-          if gh workflow run deploy-pages.yml -R "${GITHUB_REPOSITORY}" --ref main; then
-            echo "deploy-pages dispatched."
-          else
-            echo "::warning title=npm-compat-refresh::deploy-pages dispatch failed; the site stays on the previous build until the next merge to main."
+          set -euo pipefail
+          # Re-check right before creating. `queue_state` ran before a ~1-minute
+          # push; a PR opened in that window would make `gh pr create` fail the
+          # job over a condition that is actually the desired end state.
+          EXISTING="$(gh pr list -R "$GITHUB_REPOSITORY" --head "$PROMOTION_BRANCH" \
+            --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          if [ -n "$EXISTING" ]; then
+            echo "PR #${EXISTING} already open on ${PROMOTION_BRANCH}; the force-update above is all it needed."
+            exit 0
           fi
+
+          # printf, not a heredoc: heredoc body lines would have to be indented
+          # to stay inside this YAML block scalar, and those leading spaces
+          # would land in the PR body as markdown code blocks.
+          BODY="$(printf '%s\n' \
+            'Automated by `.github/workflows/npm-compat-refresh.yml`.' \
+            '' \
+            "Regenerated \`benchmarks/results/npm-compat*.json\` and their \`website/public/\` twins from main at \`${SOURCE_SHA}\`." \
+            "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '' \
+            'This branch is reused and force-updated on every refresh, so this PR always carries the newest measurement — there is never a backlog of stale artifact PRs. Merging it through the queue is deliberate: a direct push to main rebuilds every in-flight merge group and discards its validation.' \
+            '' \
+            'Data only. Do not add source, `package.json` or lockfile changes here — they would pull the full test262 matrix into this PR'"'"'s merge group.')"
+          gh pr create -R "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$PROMOTION_BRANCH" \
+            --title "chore(ci): refresh npm-compat artifacts" \
+            --body "$BODY"
+
+      # (#4217) The explicit `deploy-pages.yml` dispatch that used to live here
+      # is GONE, and its root cause with it. That dispatch existed because the
+      # artifact commit carried `[skip ci]`, which suppresses EVERY workflow for
+      # that push — including `deploy-pages`, whose only relevant trigger is
+      # `push: branches: [main]` with no path filter. The site therefore kept
+      # serving the previous JSON until some later unrelated merge redeployed it
+      # (observed 2026-08-08: artifact published 05:56, last deploy 05:34).
+      #
+      # The artifact now lands as an ordinary merge-queue merge with no
+      # `[skip ci]`, so that same `push: main` trigger fires on the landing
+      # commit and Pages rebuilds from a tree that already contains the fresh
+      # artifact. Dispatching from THIS run would in fact be wrong now: the
+      # artifact is not on main yet when this job ends, so the deploy would
+      # rebuild the stale page and #3958/#3977 would be back.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ Be concise. Lead with the answer, then only the context needed to act on it.
 | `benchmarks/results/test262-current.json`                 | main repo (committed, ~kB)  | landing-page summary, pass/total badges                                                                                    | `test262-sharded.yml` `promote-baseline` job (every push to main)      | (none)                                                                                                                                                    |
 | `test262-current.jsonl` (in `loopdive/js2wasm-baselines`) | separate repo               | PR regression-gate baseline (fetched fresh per CI run); `dev-self-merge` Step 4 bucket-by-path regression analysis (#1528) | `test262-sharded.yml` `promote-baseline` job (every push to main)      | `test262-baseline-validate.yml` spot-checks 50 random `pass` entries on every PR (#1218); fails the PR if any sampled entry no longer passes on main HEAD |
 | `benchmarks/results/playground-benchmark-sidebar.json`    | main repo (committed, ~1KB) | landing-page sidebar wasm/js perf chart; `benchmark-refresh.yml` regression diff baseline                                  | `benchmark-refresh.yml` auto-commit step on every push to main (#1216) | (none)                                                                                                                                                    |
-| `benchmarks/results/npm-compat.json` (+ `-perf`, `-history`, and the `website/public/` twins) | main repo (committed) | the whole `npm-compat.html` dashboard — every package card's compile/validate, tests and perf | `npm-compat-refresh.yml` auto-commit on every push to main, 6h cron backstop (#3988) | pre-promote check in that workflow: refuses to publish <20 packages or entries missing `name`/`compile` |
+| `benchmarks/results/npm-compat.json` (+ `-perf`, `-history`, and the `website/public/` twins) | main repo (committed) | the whole `npm-compat.html` dashboard — every package card's compile/validate, tests and perf | `npm-compat-refresh.yml` on every push to main, 6h cron backstop (#3988); promotes via a **PR on `ci/npm-compat-refresh`**, not a direct push | pre-promote check in that workflow: refuses to publish <20 packages or entries missing `name`/`compile` |
 
 
 **`npm-compat.json` is refreshed by CI on every merge to main
@@ -221,8 +221,22 @@ nothing regenerated it, so changing `scripts/generate-npm-compat-report.mjs` and
 merging left `website/npm-compat.html` serving the previous JSON with green CI
 and no signal; that shipped stale twice in one day (#3958 rendered `39/null`;
 #3977 kept showing `lit` as `not-integrated` after its suite landed). The
-workflow now regenerates and auto-commits with `[skip ci]`, gated on the merge
-queue (#3915) and on a pre-promote sanity check.
+workflow regenerates, sanity-checks (refuses <20 packages, or entries missing
+`name`/`compile`), and **promotes through a pull request** on the single reused
+branch `ci/npm-compat-refresh` — force-updated each cycle, at most one PR open,
+enqueued by `auto-enqueue.yml` like any other PR.
+
+**It no longer pushes to `main`, and the merge-queue gate is gone from this
+path.** Any push to main — _including_ a `[skip ci]` one — rebuilds every
+in-flight `merge_group` and discards the ~19-minute `Test262 Sharded` job under
+it (2026-08-09: PR #4323 lost a window to this bot; #4297 lost three). The gate
+(`scripts/main-push-queue-gate.mjs`) only bounded that: its staleness floor
+_overrides_ the queue check, and it fails open, so a busy day accumulated
+deferrals until a push landed in a live group anyway. The artifact diff touches
+nothing on the `&test262-paths` anchor, so the PR's merge group skips the shard
+matrix — **never add `package.json`, `pnpm-lock.yaml` or any source file to that
+branch.** The gate script stays for `benchmark-refresh.yml` and
+`refresh-baseline.yml`, which still push directly. See `docs/ci-policy.md`.
 
 **The refresh job is ~24 min — LONGER than the interval between merges to main.
 That is load-bearing for anything you change about it (#3988).** Its first cut

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -354,6 +354,42 @@ Two design points that are easy to get wrong:
   reporting success. Pass a timestamp carried _inside_ the artifact
   (`benchmark-manifest.json` → `generatedAt`).
 
+**Better still: do not push to `main` at all — promote through a PR.** The gate
+above is damage control, and it is damage control with two deliberate holes: the
+staleness floor _overrides_ the queue check once the artifact is old enough, and
+a malfunctioning gate fails open. Both are the right call for a direct push, and
+both mean that on a busy day the deferrals accumulate until something forces a
+push into a live merge group anyway. Routing the artifact through a PR removes
+the class instead of bounding it: `main` then only ever advances via the queue,
+which is this document's own rule for everything else.
+
+`npm-compat-refresh.yml` is the reference implementation (2026-08-09). The shape
+that makes it cheap and non-blocking:
+
+- **One reused branch, force-updated, with at most one open PR on it.** Artifact
+  PRs coalesce; a backlog of stale ones would be worse than the problem.
+- **The diff must stay artifact-only.** `benchmarks/results/**` and
+  `website/public/**` are absent from the `&test262-paths` anchor in
+  `test262-sharded.yml`, so the merge_group `detect` job emits
+  `run_shards=false` and the ~19-minute shard matrix is skipped. One file on
+  that anchor — `package.json` is the easy mistake — puts the whole matrix back.
+- **No `[skip ci]`.** The PR needs its checks to run to reach `CLEAN`, and the
+  landing commit needs to be visible to `deploy-pages`.
+- **The PR must be opened by an actor that is not `GITHUB_TOKEN`** (mint a
+  GitHub App token). A `GITHUB_TOKEN`-created PR fires no `pull_request` /
+  `pull_request_target` events, so it never gets CI or `cla-check`, never
+  reaches `CLEAN`, and `auto-enqueue` never touches it — a PR that strands
+  forever while looking healthy.
+- **Do not enqueue from the workflow** (#2786). `auto-enqueue.yml` is the single
+  enqueuer.
+- **Do not force-update the branch while its PR is in the merge queue** — that
+  rebuilds the in-flight group and cancels its run, which is the same harm
+  relocated. If the queue cannot be read, push anyway: an unreadable gate must
+  never freeze the artifact.
+
+`benchmark-refresh.yml` and `refresh-baseline.yml` still push directly and still
+use the gate; the script stays for them.
+
 A **staleness floor** (`--stale-after-hours`, 6h) keeps a never-draining queue
 from freezing the artifact: past the floor the push proceeds anyway, trading at
 most one rebuild per floor-period against an unbounded freeze. A pusher whose

--- a/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
+++ b/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
@@ -24,6 +24,7 @@
  * there is no output to assert on — the workflow goes green and the damage
  * lands on somebody else's PR.
  */
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -170,5 +171,52 @@ describe("the pre-promote sanity check is unrelated to the PR switch and stays",
     expect(at("- name: Sanity-check the generated artifact")).toBeLessThan(
       at("- name: Publish the refreshed artifacts"),
     );
+  });
+});
+
+describe("the promotion PR must survive auto-enqueue's author-trust gate", () => {
+  // Without this the whole change is inert in the worst possible way: the PR
+  // opens, goes green, and is skipped `untrusted-author:…` on every sweep. A
+  // skip is silent, so the only symptom is a dashboard that stops moving.
+  const autoEnqueue = readFileSync(resolve(ROOT, ".github/workflows/auto-enqueue.yml"), "utf8");
+
+  it("allowlists the app that opens the PR, derived from the minted token", () => {
+    // An app's authorAssociation is not OWNER/MEMBER/COLLABORATOR, its login is
+    // not `ttraenkler`, and the promotion branch's head repo owner is
+    // `loopdive` rather than the fork — so none of the gate's three layers
+    // match by default.
+    expect(autoEnqueue).toContain("TRUSTED_AUTHOR_LOGINS:");
+    expect(autoEnqueue).toContain("${{ steps.app-token.outputs.app-slug }}[bot]");
+    // Hardcoding a login would drift from whichever app actually mints the
+    // token; deriving it cannot.
+    expect(autoEnqueue).not.toMatch(/TRUSTED_AUTHOR_LOGINS:[^\n]*merge-queue-bot\[bot\]/);
+  });
+
+  it("keeps the existing maintainer login (the env REPLACES the default)", () => {
+    expect(autoEnqueue).toMatch(/TRUSTED_AUTHOR_LOGINS:\s*ttraenkler,/);
+  });
+
+  it("the gate honours the env var end to end", () => {
+    // Plumbing check, not a restatement of #2550: the allowlist is read from
+    // `process.env` at module load, so it has to be exercised in a fresh
+    // process to prove the workflow's env actually reaches the decision.
+    const probe = [
+      "const { isTrustedAuthor } = await import('./scripts/enqueue-green-prs.mjs');",
+      "process.stdout.write(JSON.stringify(isTrustedAuthor(",
+      "  { assoc: 'NONE', authorLogin: 'some-app[bot]', headRepoOwner: 'loopdive' })));",
+    ].join("");
+    const withAllowlist = execFileSync("node", ["--input-type=module", "-e", probe], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: { ...process.env, TRUSTED_AUTHOR_LOGINS: "ttraenkler,some-app[bot]" },
+    });
+    expect(JSON.parse(withAllowlist).trusted).toBe(true);
+
+    const withoutAllowlist = execFileSync("node", ["--input-type=module", "-e", probe], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: { ...process.env, TRUSTED_AUTHOR_LOGINS: "ttraenkler" },
+    });
+    expect(JSON.parse(withoutAllowlist).trusted).toBe(false);
   });
 });

--- a/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
+++ b/tests/issue-4130-npm-compat-refresh-staleness-gate.test.ts
@@ -1,18 +1,28 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * (#4130) The npm-compat refresh workflow's staleness floor must measure the
- * COMMITTED artifact, not the one the job just regenerated.
+ * The npm-compat refresh promotes through a PULL REQUEST, never a direct push
+ * to main.
  *
- * The failure this guards against is invisible by construction: the workflow
- * ran on every push to main, reported **success**, and committed nothing for
- * two days. Nothing was red. The only symptom was a dashboard that quietly
- * stopped moving — precisely the class of bug the workflow's own header says it
- * exists to prevent ("shipped stale twice in one session").
+ * WHY THIS FILE STILL EXISTS UNDER THE #4130 NAME. #4130 was "the staleness
+ * floor in the merge-queue gate measures the wrong artifact, so a busy queue
+ * defers the promotion forever". The fix pinned the step ORDER that fed the
+ * floor. That whole mechanism is now GONE: the gate, `--stale-after-hours` and
+ * the fail-open branch existed only to make a DIRECT push to main survivable,
+ * and a PR does not push to main. Rather than delete the file and lose the
+ * history of what this workflow keeps getting wrong, it now pins the shape of
+ * the replacement.
  *
- * So the guard is structural: assert the step ORDER and the wiring, because
- * when this breaks there is no output to assert on. Raw-text assertions match
- * `ci-quality-failfast.test.ts`; the repo carries no YAML parser, and step order
- * is a property of the file's text anyway.
+ * THE BUG BEING PREVENTED (2026-08-09): any push to main — INCLUDING a
+ * `[skip ci]` one — makes GitHub rebuild every in-flight `merge_group` and
+ * discard the ~19-minute `Test262 Sharded` job running under it. PR #4323's
+ * group started 22:52 on f70b4eb2, this workflow's auto-commit landed 22:59:30,
+ * the group was rebuilt at 22:59:51. #4297 lost three windows the same day.
+ *
+ * The assertions are structural raw-text pins (matching
+ * `ci-quality-failfast.test.ts`): the repo carries no YAML parser, and step
+ * order / step wiring is a property of the file's text anyway. When this breaks
+ * there is no output to assert on — the workflow goes green and the damage
+ * lands on somebody else's PR.
  */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -25,83 +35,140 @@ const workflow = readFileSync(resolve(ROOT, ".github/workflows/npm-compat-refres
 
 const at = (needle: string): number => workflow.indexOf(needle);
 
-describe("#4130 — the staleness floor measures the committed artifact", () => {
-  it("captures the committed artifact's age BEFORE regenerating it", () => {
-    const capture = at("id: committed");
-    const regenerate = at("pnpm run generate:npm-compat");
+/**
+ * The workflow's comments deliberately NAME the things that must not happen
+ * ("HEAD:main", "[skip ci]", the gate script) so the next reader learns why
+ * they are absent. Assert against executable lines only — both YAML comments
+ * and shell comments inside `run:` blocks start with `#` after indentation.
+ */
+const code = workflow
+  .split("\n")
+  .filter((line) => !/^\s*#/.test(line))
+  .join("\n");
 
-    expect(capture, "a step with `id: committed` must exist").toBeGreaterThanOrEqual(0);
-    expect(regenerate, "the regeneration step must exist").toBeGreaterThanOrEqual(0);
-    // The whole bug in one assertion. Reading `generatedAt` after the
-    // regeneration yields the age of the measurement just taken — always ~0 —
-    // so the floor never fires and a busy queue defers forever.
-    expect(capture).toBeLessThan(regenerate);
+describe("npm-compat promotion never pushes to main", () => {
+  it("has no `HEAD:main` push anywhere in the workflow", () => {
+    // The single assertion that matters. `main-push-queue-gate.mjs` exists to
+    // make such a push survivable; removing the push removes the need for a
+    // gate, a staleness floor, and a fail-open branch all at once.
+    expect(code).not.toContain("HEAD:main");
+    expect(code).not.toMatch(/git push[^\n]*\bmain\b(?!-)/);
   });
 
-  it("feeds the gate from that captured value, not from a re-read of the file", () => {
-    expect(workflow).toContain("steps.committed.outputs.last_refresh");
-    // A re-read AFTER regeneration is the regression: it would silently restore
-    // the old behaviour while every assertion about the gate's flags still
-    // passed. Pin that the gate step no longer reads the file itself.
-    const gateBlock = workflow.slice(at("id: queue_gate"), at("- name: Promote"));
-    expect(gateBlock).not.toContain('readFileSync("benchmarks/results/npm-compat.json"');
+  it("does not call the merge-queue gate any more", () => {
+    // The script itself must STAY — `benchmark-refresh.yml` and
+    // `refresh-baseline.yml` still push to main directly and still call it.
+    // That is asserted by the class-coverage test in
+    // tests/issue-3915-main-push-queue-gate.test.ts; here we only assert that
+    // THIS path stopped calling it.
+    expect(code).not.toContain("main-push-queue-gate.mjs");
+    expect(code).not.toContain("--stale-after-hours");
+    // A vestigial `if:` on a deleted step evaluates to empty and silently
+    // enables the step it was meant to guard.
+    expect(code).not.toContain("steps.queue_gate");
+    expect(code).not.toContain("steps.committed");
   });
 
-  it("still passes a staleness floor to the gate", () => {
-    expect(workflow).toMatch(/--stale-after-hours\s+\d+/);
+  it("pushes the artifacts to ONE reused promotion branch", () => {
+    expect(workflow).toMatch(/PROMOTION_BRANCH:\s*\S+/);
+    const promote = workflow.slice(at("- name: Publish the refreshed artifacts"));
+    expect(promote).toMatch(/git push[^\n]*--force[^\n]*refs\/heads\/\$\{PROMOTION_BRANCH\}/);
   });
 
-  it("gates promotion on the queue decision", () => {
-    expect(workflow.slice(at("- name: Promote"))).toContain("steps.queue_gate.outputs.decision");
+  it("opens a PR only when none is open, so artifact PRs coalesce", () => {
+    const create = workflow.slice(at("- name: Open the promotion PR"));
+    expect(create).toContain("gh pr create");
+    // Guarded on "no PR number found" — a queue of stale artifact PRs would be
+    // worse than the problem being fixed.
+    expect(workflow).toMatch(
+      /if:\s*steps\.promote\.outputs\.published == '1' && steps\.queue_state\.outputs\.pr_number == ''/,
+    );
+  });
+
+  it("does not enqueue — auto-enqueue.yml is the single enqueuer (#2786)", () => {
+    expect(workflow).not.toContain("enqueuePullRequest");
+    expect(workflow).not.toContain("gh pr merge");
   });
 });
 
-describe("#4132 — the promotion commit must not run the pre-commit hook", () => {
-  it("commits with --no-verify", () => {
-    // This job installs dependencies, so husky's hook is live and runs
-    // `test:changed-root`, which needs a merge base with `origin/main`. The
-    // checkout is `fetch-depth: 1` with `persist-credentials: false` and the
-    // push remote is `deploykey`, so there is no `origin/main` and the hook
-    // aborts the commit. It stayed hidden until #4130 stopped the gate
-    // deferring on every run — the step had simply never executed.
-    const promote = workflow.slice(at("- name: Promote"));
+describe("the promotion commit must be visible to CI", () => {
+  it("drops [skip ci] from the artifact commit", () => {
+    // The PR now NEEDS its checks to run in order to reach `CLEAN` and be
+    // picked up by auto-enqueue. `[skip ci]` would leave it permanently
+    // unmergeable — and it is also what broke the Pages redeploy (#4217).
+    expect(code).not.toContain("[skip ci]");
+  });
+
+  it("still commits and pushes with --no-verify (#4132/#4140)", () => {
+    // This job runs `pnpm install`, so husky's hooks are live and neither can
+    // do its job here (fetch-depth 1, persist-credentials false, no
+    // origin/main). Unrelated to the PR switch; still required.
+    const promote = workflow.slice(at("- name: Publish the refreshed artifacts"));
     expect(promote).toMatch(/git commit[^\n]*--no-verify/);
+    expect(promote).toMatch(/git push[^\n]*--no-verify/);
   });
 
-  it("keeps the [skip ci] marker that breaks the trigger loop", () => {
-    expect(workflow.slice(at("- name: Promote"))).toContain("[skip ci]");
-  });
-
-  // (#4140) The commit was fixed and the PUSH was not, so the promotion still
-  // failed — on husky's pre-push hook (the oracle ratchet) instead of
-  // pre-commit. Both hooks are live in this job; both must be opted out.
-  it("also pushes with --no-verify", () => {
-    expect(workflow.slice(at("- name: Promote"))).toMatch(/git push[^\n]*--no-verify/);
-  });
-
-  it("does not replay a push failure that replaying cannot fix", () => {
-    // Replaying only helps when main moved under us. For any other failure the
-    // replay fails identically five times and buries the real error under a
-    // MISLEADING "main advanced mid-promotion" message — which is exactly how a
-    // rejected pre-push hook stayed hidden for a full cycle.
-    const promote = workflow.slice(at("- name: Promote"));
-    expect(promote).toMatch(/non-fast-forward\|fetch first/);
-    expect(promote).toContain("replaying cannot fix");
+  it("opens the PR with a non-GITHUB_TOKEN actor", () => {
+    // A PR created with GITHUB_TOKEN fires no pull_request /
+    // pull_request_target events, so it gets neither CI nor cla-check, never
+    // reaches CLEAN, and strands forever looking healthy. Same rule that
+    // wedged the merge queue in #2523.
+    expect(workflow).toContain("actions/create-github-app-token@v3");
+    const create = workflow.slice(at("- name: Open the promotion PR"));
+    expect(create).toContain("steps.app-token.outputs.token");
+    expect(create).not.toContain("secrets.GITHUB_TOKEN");
   });
 });
 
-describe("#4130 — the gate's own decision function", () => {
-  it("defers a busy queue only while the artifact is fresh, and proceeds once it is stale", async () => {
-    const { decide } = await import("../scripts/main-push-queue-gate.mjs");
-    const busy = { force: false, queueLen: 3, staleAfterHours: 12 };
+describe("the refresh cannot retrigger itself", () => {
+  it("ignores pushes that only change the npm-compat artifacts", () => {
+    // Both old loop-breakers are gone with the direct push: no `[skip ci]`, and
+    // the landing commit's actor is the merge queue rather than
+    // `github-actions[bot]`. Perf numbers differ on every run, so every run
+    // publishes — without this filter each landing would trigger the next
+    // refresh forever.
+    expect(workflow).toContain("paths-ignore:");
+    for (const p of [
+      "benchmarks/results/npm-compat.json",
+      "benchmarks/results/npm-compat-perf.json",
+      "benchmarks/results/npm-compat-history.json",
+      "website/public/benchmarks/results/npm-compat.json",
+      "website/public/benchmarks/results/npm-compat-perf.json",
+      "website/public/benchmarks/results/npm-compat-history.json",
+    ]) {
+      expect(workflow.slice(at("paths-ignore:"), at("  # Backstop for a quiet main"))).toContain(p);
+    }
+  });
 
-    // What the workflow produced before the fix: the just-regenerated file is
-    // always ~0h old, so a busy queue deferred every single run.
-    expect(decide({ ...busy, ageHours: 0 }).decision).toBe("defer");
-    // What it produces now — the committed artifact's real age clears the floor.
-    expect(decide({ ...busy, ageHours: 42 }).decision).toBe("proceed");
-    expect(decide({ ...busy, ageHours: 12 }).decision).toBe("proceed");
-    // A quiet queue never needed the floor at all.
-    expect(decide({ ...busy, queueLen: 0, ageHours: 0 }).decision).toBe("proceed");
+  it("does not force-update the branch while its PR is in the merge queue", () => {
+    // Force-pushing the head of the in-flight merge group rebuilds it and
+    // cancels its run — the exact harm this change removes, relocated.
+    const gate = workflow.slice(
+      at("- name: Check whether the promotion PR"),
+      at("- name: Publish the refreshed artifacts"),
+    );
+    expect(gate).toContain("mergeQueue");
+    // ...but an unreadable queue must PROCEED, never freeze the artifact.
+    // That is #4130's lesson and it survives the redesign.
+    expect(gate).toMatch(/skip=0[^\n]*GITHUB_OUTPUT[\s\S]*?;;\s*$/m);
+    expect(gate).toContain("must never freeze the artifact");
+  });
+});
+
+describe("the pre-promote sanity check is unrelated to the PR switch and stays", () => {
+  it("still refuses to publish fewer than 20 packages or entries missing name/compile", () => {
+    const check = workflow.slice(
+      at("- name: Sanity-check the generated artifact"),
+      at("- name: Upload generated artifacts"),
+    );
+    expect(check).toContain("packages.length < 20");
+    expect(check).toContain("entry.name && entry.compile");
+    expect(check).toContain("refusing to publish");
+  });
+
+  it("runs BEFORE anything is pushed", () => {
+    expect(at("- name: Sanity-check the generated artifact")).toBeLessThan(
+      at("- name: Publish the refreshed artifacts"),
+    );
   });
 });

--- a/tests/issue-4217-refresh-redeploys-pages.test.ts
+++ b/tests/issue-4217-refresh-redeploys-pages.test.ts
@@ -1,38 +1,61 @@
-// (#4217) npm-compat refresh must redeploy Pages after a real artifact
-// publish — the `[skip ci]` artifact commit cannot trigger its own rebuild,
-// so the workflow dispatches deploy-pages.yml explicitly.
+// (#4217) The npm-compat refresh must leave the deployed site serving the
+// artifact it just published.
 //
-// The fix is workflow YAML, so the permanent repro is a shape pin: if a
-// refactor drops the dispatch step, its publish guard, or the actions:write
-// permission that lets GITHUB_TOKEN create the workflow_dispatch run, the
-// page silently reverts to serving stale JSON until the next unrelated merge
-// (observed 2026-08-08: artifact 05:56Z, last deploy 05:34Z).
+// ORIGINAL BUG: the artifact commit carried `[skip ci]`, which suppresses EVERY
+// workflow for that push — including `deploy-pages.yml`, whose only relevant
+// trigger is `push: branches: [main]`. So the page kept serving the previous
+// JSON until some later unrelated merge redeployed it (observed 2026-08-08:
+// artifact published 05:56Z, last deploy 05:34Z, page stale until a manual
+// dispatch at 06:22Z). #4217 patched around it with an explicit
+// `gh workflow run deploy-pages.yml` after a successful push.
+//
+// WHY THE PIN CHANGED: promotion now goes through a PR and the merge queue, so
+// the artifact commit CANNOT carry `[skip ci]` (the PR needs its checks to run
+// to become mergeable) and it lands as an ordinary, CI-visible push to main.
+// `deploy-pages` fires on that push by itself. The explicit dispatch is not
+// just redundant now, it would be WRONG: at the moment this workflow finishes,
+// the artifact is on a PR branch and not yet on main, so a dispatch would
+// rebuild the STALE page and hand back #3958/#3977.
+//
+// So the invariant to pin is no longer "there is a dispatch step". It is the
+// property that actually keeps the page fresh: the landing commit is visible to
+// `deploy-pages`'s push trigger.
 
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const workflow = readFileSync(new URL("../.github/workflows/npm-compat-refresh.yml", import.meta.url), "utf-8");
+const deployPages = readFileSync(new URL("../.github/workflows/deploy-pages.yml", import.meta.url), "utf-8");
 
-describe("#4217 — npm-compat refresh redeploys Pages", () => {
-  it("grants the job actions:write so GITHUB_TOKEN may dispatch deploy-pages", () => {
-    expect(workflow).toMatch(/actions:\s*write/);
+// Executable lines only: the workflow's comments deliberately name `[skip ci]`
+// and the removed dispatch so the next reader learns why they are gone.
+const code = workflow
+  .split("\n")
+  .filter((line) => !/^\s*#/.test(line))
+  .join("\n");
+
+describe("#4217 — the site serves the artifact the refresh publishes", () => {
+  it("the artifact commit is not marked [skip ci]", () => {
+    // This single marker is the whole original bug. Re-adding it would silence
+    // deploy-pages again AND make the promotion PR permanently unmergeable.
+    expect(code).not.toContain("[skip ci]");
   });
 
-  it("marks the promote step and emits published=1 only on a real push", () => {
-    expect(workflow).toMatch(/id:\s*promote/);
-    // The output is written on the successful-push path (next to the publish
-    // log line), not unconditionally at step level.
-    expect(workflow).toMatch(/published=1.*GITHUB_OUTPUT|"published=1" >> "\$GITHUB_OUTPUT"/);
+  it("deploy-pages still redeploys on every push to main", () => {
+    // The mechanism the refresh now relies on. If someone adds a `paths:`
+    // filter here, the artifact landing stops redeploying the site and the
+    // staleness returns silently — hence the pin in this file rather than
+    // deploy-pages' own.
+    const on = deployPages.slice(deployPages.indexOf("on:"), deployPages.indexOf("permissions:"));
+    expect(on).toMatch(/push:\s*\n\s*branches:\s*\n\s*-\s*main/);
+    expect(on.slice(on.indexOf("push:"), on.indexOf("workflow_run:"))).not.toContain("paths");
   });
 
-  it("dispatches deploy-pages.yml guarded on publish AND non-deferred refresh", () => {
-    const dispatchStep = workflow.split(/\n {6}- name: /).find((s) => s.startsWith("Redeploy Pages"));
-    expect(dispatchStep, "the redeploy step exists").toBeDefined();
-    expect(dispatchStep).toMatch(/steps\.promote\.outputs\.published == '1'/);
-    expect(dispatchStep).toMatch(/steps\.queue_gate\.outputs\.decision != 'defer'/);
-    expect(dispatchStep).toMatch(/gh workflow run deploy-pages\.yml/);
-    // Best-effort by design: a failed dispatch warns, never fails the job —
-    // the artifact is already safely on main.
-    expect(dispatchStep).toMatch(/::warning/);
+  it("does not dispatch deploy-pages from the refresh run itself", () => {
+    // At that moment the artifact is on the PR branch, not on main; deploying
+    // would publish the pre-refresh tree.
+    expect(code).not.toContain("gh workflow run deploy-pages.yml");
+    // and the permission that existed only for that dispatch is gone
+    expect(code).not.toMatch(/actions:\s*write/);
   });
 });


### PR DESCRIPTION
## Summary

`npm-compat-refresh.yml` currently lands its refreshed artifact with a direct `git push --no-verify deploykey HEAD:main` (with `[skip ci]`). Any push to `main` — even a skipped one — makes GitHub rebuild every in-flight `merge_group`, cancelling their in-progress ~19-min `Test262 Sharded` job. This is the root cause of the queue-disruption behavior reported by the team.

This PR replaces the direct push with the normal PR + merge-queue path:

- Commit the refreshed artifact to a single reused branch `ci/npm-compat-refresh` (force-updated), opening a PR only when none is already open (coalescing multiple runs into one pending PR + one running PR, per the existing `concurrency: { group: npm-compat-refresh-*, cancel-in-progress: false }` block, which already bounds this correctly).
- Drop `[skip ci]` — the PR goes through normal CI and the merge queue like any other change.
- The PR is opened using the merge-queue GitHub App's token, not `GITHUB_TOKEN` — a `GITHUB_TOKEN`-authored PR fires no `pull_request`/`pull_request_target` events, never reaches CI, never reaches `mergeStateStatus: CLEAN`, and `auto-enqueue` would never touch it. `AUTO_ENQUEUE_TOKEN` is not configured on this repo, so there is deliberately no silent fallback to `GITHUB_TOKEN`.
- Adds the app's bot login to `auto-enqueue.yml`'s `TRUSTED_AUTHOR_LOGINS` — without this the promotion PR matches none of the three author-trust layers (app association isn't OWNER/MEMBER/COLLABORATOR; login isn't a listed human; head repo owner doesn't match `TRUSTED_FORK_OWNERS`) and would be silently skipped by every `auto-enqueue` sweep.
- Removes the now-unneeded queue-gate machinery at this call site (`main-push-queue-gate.mjs`, `--stale-after-hours`, its fail-open branch, the push-replay loop). `scripts/main-push-queue-gate.mjs` itself is kept — `benchmark-refresh.yml` and `refresh-baseline.yml` still call it.
- Adds `paths-ignore` on the artifact output paths to stop the workflow from re-triggering itself once the landing commit is an ordinary queue merge instead of a `[skip ci]` push.
- A guard against force-updating the promotion branch while its PR is in the merge queue (which would rebuild the in-flight group and cancel its run — the same class of harm, just relocated). Fails open (proceeds) if queue membership can't be read, per the #4130 lesson.
- Reworks the Pages-redeploy step: the explicit `workflow_dispatch` of `deploy-pages` existed only to work around `[skip ci]` suppressing that workflow's `push: main` trigger too. With `[skip ci]` gone, the ordinary unfiltered `push: branches: [main]` trigger on `deploy-pages` fires naturally once the artifact lands via the merge queue — no explicit dispatch needed, and dispatching from the refresh run itself would now be wrong (the artifact would still be on a PR branch, not `main`, at that point), reproducing the #3958/#3977 stale-serving bug. `tests/issue-4217-*.test.ts` is updated to pin this property directly instead of the removed dispatch step.

## Verification

- `pnpm run lint`, `npx tsc --noEmit`, `npx prettier --check`, `pnpm run check:dead-exports` — all clean.
- Full test suites covering the touched workflows: `issue-4130` (15), `issue-4217` (3), `issue-3915` (35) — all green.
- Every `run:` bash block syntax-checked; both workflow files re-parsed as YAML after formatting.

## Docs

- `CLAUDE.md` and a new subsection in `docs/ci-policy.md` ("Better still: do not push to `main` at all") document the change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmwHrtyzm28H9YuH2nYLYy)_