### PR TITLE
ci(test262): a version-only manifest bump no longer pulls in the shard matrix

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -36,6 +36,10 @@ on:
       - "scripts/compiler-pool.ts"
       - "scripts/diff-test262.ts"
       - "scripts/generate-editions.ts"
+      # Part of the merge_group gating logic (it decides which manifest
+      # changes the matcher never sees), so a change to it must be validated
+      # by exactly what it might skip.
+      - "scripts/manifest-version-only.mjs"
       - "scripts/test262-worker.mjs"
       - "tests/test262-chunk*.test.ts"
       - "tests/test262-runner.ts"
@@ -400,12 +404,40 @@ jobs:
             exit 0
           fi
 
+          # A VERSION-ONLY manifest bump cannot move conformance. `package.json`
+          # is on the allowlist above because a DEPENDENCY change genuinely can,
+          # but `node scripts/release.mjs <x.y.z>` touches it too — so every
+          # release PR dragged the full ~19-minute matrix through the queue for
+          # a one-line diff (measured on #4317 / v0.69.0: no source change, full
+          # matrix). This filter drops such a path from the list the matcher
+          # sees, and ONLY on positive proof that nothing outside the keys
+          # release.mjs moves differs; see scripts/manifest-version-only.mjs.
+          #
+          # Deliberately AFTER the empty-diff guard above: an empty RAW diff is
+          # suspicious and must still fail safe, whereas an empty FILTERED list
+          # is the legitimate "release-only group" answer and must reach the
+          # matcher (which prints false for empty input).
+          #
+          # Exit code, not emptiness, decides trust: empty stdout is a legal
+          # success here, so a crash must be detected some other way.
+          set +e
+          FILTERED=$(printf '%s\n' "$DIFF" | node scripts/manifest-version-only.mjs --base "$MG_BASE_SHA" --head "$MG_HEAD_SHA")
+          filter_rc=$?
+          set -e
+          if [ "$filter_rc" -ne 0 ]; then
+            echo "::warning::manifest-version-only filter exited ${filter_rc} — FAIL-SAFE, classifying the unfiltered diff."
+            FILTERED="$DIFF"
+          elif [ "$FILTERED" != "$DIFF" ]; then
+            echo "Paths after dropping version-only manifest bumps:"
+            printf '%s\n' "$FILTERED" | sed 's/^/  /'
+          fi
+
           # Per-lane classification. `run_shards` stays the OR of the two lanes,
           # so it keeps its exact previous value and meaning for every existing
           # consumer. A non-zero exit from the matcher (bad argument, unreadable
           # script) leaves RESULT empty → fail-safe to running everything.
-          HOST=$(printf '%s\n' "$DIFF" | bash scripts/test262-paths-match.sh --target host) || HOST=""
-          STANDALONE=$(printf '%s\n' "$DIFF" | bash scripts/test262-paths-match.sh --target standalone) || STANDALONE=""
+          HOST=$(printf '%s\n' "$FILTERED" | bash scripts/test262-paths-match.sh --target host) || HOST=""
+          STANDALONE=$(printf '%s\n' "$FILTERED" | bash scripts/test262-paths-match.sh --target standalone) || STANDALONE=""
           if [ "$HOST" != "true" ] && [ "$HOST" != "false" ]; then
             echo "::warning::unexpected host verdict '$HOST' from test262-paths-match.sh — FAIL-SAFE run_shards=true."
             emit_all true

--- a/scripts/manifest-version-only.mjs
+++ b/scripts/manifest-version-only.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// manifest-version-only.mjs — drop VERSION-ONLY manifest edits from a changed-
+// path list before it is classified by `scripts/test262-paths-match.sh`.
+//
+// WHY. `package.json` is on the `&test262-paths` allowlist in
+// test262-sharded.yml, and it belongs there: a dependency bump genuinely can
+// move conformance. But `node scripts/release.mjs <x.y.z>` touches
+// `package.json` too, and a version bump provably cannot. So every release PR
+// pulls in the full ~19-minute merge_group shard matrix for a one-line diff —
+// measured on PR #4317 (v0.69.0), which ran the whole matrix with no source
+// change at all.
+//
+// SCOPE, DELIBERATELY NARROW. This does NOT mean "skip when src/ is untouched".
+// The path allowlist is a curated set of things that affect test262 results and
+// several are outside `src/` (`scripts/test262-worker.mjs`,
+// `tests/test262-runner.ts`, the slow-test weight maps that change shard
+// assignment). Broadening the rule would silently disarm a conformance gate,
+// which is far worse than a wasted matrix run. The ONLY thing dropped here is a
+// manifest whose diff is provably confined to the keys `release.mjs` moves.
+//
+// FAIL-SAFE. The matcher's contract is "if detection is in any way uncertain →
+// run_shards=true". Every uncertainty here KEEPS the path, which keeps the
+// matrix: unparseable JSON on either side, a missing blob, a git failure, a
+// path not in the table, an unexpected exception. A path is dropped only on a
+// POSITIVE proof that nothing outside the allowed keys differs.
+//
+// Usage (mirrors test262-paths-match.sh: paths on stdin, result on stdout):
+//
+//   printf '%s\n' package.json src/x.ts \
+//     | node scripts/manifest-version-only.mjs --base <sha> --head <sha>
+//
+// Prints the FILTERED path list on stdout, one per line. Diagnostics go to
+// stderr so stdout stays pipeable straight into the matcher.
+//
+// EXIT CODE IS LOAD-BEARING, unlike the matcher's. An empty stdout is a LEGAL
+// success here ("every changed path was a version-only manifest"), so it cannot
+// also mean "the script died". Exit 0 ⇒ trust stdout. Exit non-zero ⇒ the
+// caller MUST fall back to its own unfiltered list; stdin is already consumed
+// by then, so this script cannot echo it back itself.
+
+import { execFileSync } from "node:child_process";
+
+/**
+ * Keys that `scripts/release.mjs` is allowed to move in each manifest, as
+ * key PATHS from the document root. Anything else differing — a dependency
+ * add/remove/bump, a script change, an `engines` change — keeps the file and
+ * therefore keeps the matrix.
+ *
+ * `release.mjs <x.y.z>` writes exactly: package.json, packages/js2wasm/
+ * package.json, jsr.json, docs/release-notes/vX.Y.Z.md. It does NOT touch
+ * pnpm-lock.yaml. Of these only `package.json` is currently on the
+ * `&test262-paths` allowlist, so only it can actually reach this filter; the
+ * other two are listed so the table stays correct if the allowlist grows, and
+ * because they document release.mjs's contract in one place.
+ *
+ * `packages/js2wasm/package.json` carries a second moved key: its pinned
+ * dependency on the canonical package, which release.mjs bumps in lockstep.
+ */
+export const RELEASE_MOVED_KEYS = new Map([
+  ["package.json", [["version"]]],
+  ["packages/js2wasm/package.json", [["version"], ["dependencies", "@loopdive/js2"]]],
+  ["jsr.json", [["version"]]],
+]);
+
+const isPlainObject = (v) => typeof v === "object" && v !== null && !Array.isArray(v);
+
+/**
+ * Collect the key paths at which two parsed JSON documents differ, including
+ * keys added on one side only. Arrays are compared as whole values: reordering
+ * or editing `keywords`/`files` is a difference at the array's own path, which
+ * is never in the allowlist and therefore keeps the file.
+ */
+export function differingKeyPaths(before, after, prefix = []) {
+  if (isPlainObject(before) && isPlainObject(after)) {
+    const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+    return [...keys].flatMap((k) => differingKeyPaths(before[k], after[k], [...prefix, k]));
+  }
+  return JSON.stringify(before) === JSON.stringify(after) ? [] : [prefix];
+}
+
+/**
+ * Is this manifest change provably confined to the keys a release bump moves?
+ *
+ * Returns `{ versionOnly, reason }`. `versionOnly: true` is a positive proof
+ * and is the ONLY value that drops a path; every other outcome keeps it.
+ */
+export function classifyManifestChange({ path, before, after }) {
+  const allowed = RELEASE_MOVED_KEYS.get(path);
+  if (!allowed) return { versionOnly: false, reason: "not-a-release-manifest" };
+  if (typeof before !== "string" || typeof after !== "string") {
+    return { versionOnly: false, reason: "blob-unavailable" };
+  }
+
+  let parsedBefore;
+  let parsedAfter;
+  try {
+    parsedBefore = JSON.parse(before);
+    parsedAfter = JSON.parse(after);
+  } catch {
+    // Includes the added/deleted-file cases, where one side is empty.
+    return { versionOnly: false, reason: "unparseable-json" };
+  }
+  if (!isPlainObject(parsedBefore) || !isPlainObject(parsedAfter)) {
+    return { versionOnly: false, reason: "not-a-json-object" };
+  }
+
+  const allowedSet = new Set(allowed.map((k) => JSON.stringify(k)));
+  const differing = differingKeyPaths(parsedBefore, parsedAfter);
+  const disallowed = differing.filter((k) => !allowedSet.has(JSON.stringify(k)));
+  if (disallowed.length > 0) {
+    return { versionOnly: false, reason: `changed:${disallowed.map((k) => k.join(".")).join(",")}` };
+  }
+  // Zero differences means the file is in `--name-only` for a non-content
+  // reason (a mode change); identical content cannot move conformance either.
+  return { versionOnly: true, reason: differing.length === 0 ? "no-key-differences" : "version-only" };
+}
+
+/** `git show <rev>:<path>`, or `null` when the blob cannot be read. */
+function readBlob(rev, path) {
+  try {
+    return execFileSync("git", ["show", `${rev}:${path}`], {
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const args = { base: "", head: "" };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--base") args.base = argv[++i] ?? "";
+    else if (argv[i] === "--head") args.head = argv[++i] ?? "";
+    else if (argv[i].startsWith("--base=")) args.base = argv[i].slice("--base=".length);
+    else if (argv[i].startsWith("--head=")) args.head = argv[i].slice("--head=".length);
+  }
+  return args;
+}
+
+async function main() {
+  const { base, head } = parseArgs(process.argv.slice(2));
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  const paths = chunks
+    .join("")
+    .split("\n")
+    .map((l) => l.replace(/\r$/, "").trim())
+    .filter(Boolean);
+
+  if (!base || !head) {
+    console.error("manifest-version-only: --base/--head missing; keeping every path (fail-safe).");
+    process.stdout.write(`${paths.join("\n")}\n`);
+    return;
+  }
+
+  const kept = paths.filter((path) => {
+    if (!RELEASE_MOVED_KEYS.has(path)) return true;
+    const verdict = classifyManifestChange({
+      path,
+      before: readBlob(base, path),
+      after: readBlob(head, path),
+    });
+    console.error(
+      verdict.versionOnly
+        ? `manifest-version-only: DROP ${path} (${verdict.reason}) — cannot move test262 results.`
+        : `manifest-version-only: KEEP ${path} (${verdict.reason}).`,
+    );
+    return !verdict.versionOnly;
+  });
+
+  process.stdout.write(kept.length > 0 ? `${kept.join("\n")}\n` : "");
+}
+
+// Importable for tests; the CLI only runs when executed directly.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    // An unexpected failure must never SHRINK the path list.
+    console.error(`manifest-version-only: ${err?.message ?? err} — keeping every path (fail-safe).`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test262-paths-match.sh
+++ b/scripts/test262-paths-match.sh
@@ -126,6 +126,10 @@ classify_test262_path() {
     # lanes so a change to the matcher always re-runs the full suite
     # (fail-safe: a matcher edit must be validated by what it might skip).
     scripts/test262-paths-match.sh) echo both ;;
+    # Same reasoning: this filter decides which version-only manifest changes
+    # are removed from the diff BEFORE this matcher ever sees them, so it is
+    # part of the same gating decision.
+    scripts/manifest-version-only.mjs) echo both ;;
     *) echo "" ;;
   esac
 }

--- a/tests/manifest-version-only.test.ts
+++ b/tests/manifest-version-only.test.ts
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * A release PR must not drag the full test262 matrix through the merge queue.
+ *
+ * `package.json` is on the `&test262-paths` allowlist because a DEPENDENCY
+ * change genuinely can move conformance. `node scripts/release.mjs <x.y.z>`
+ * touches it too, and a version bump provably cannot — so PR #4317 (v0.69.0)
+ * ran the whole ~19-minute matrix in its merge group for a one-line diff.
+ *
+ * The classifier's contract is the matcher's: **if detection is in any way
+ * uncertain, keep the path and run the shards.** Only a positive proof that
+ * nothing outside the keys `release.mjs` moves has changed may drop a path.
+ * The tests below are organised around that asymmetry — one case proves the
+ * skip, the rest prove the fallbacks.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { classifyManifestChange, differingKeyPaths, RELEASE_MOVED_KEYS } from "../scripts/manifest-version-only.mjs";
+
+const ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+
+const pkg = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    name: "@loopdive/js2",
+    version: "0.68.0",
+    keywords: ["webassembly", "typescript"],
+    dependencies: { binaryen: "1.2.3" },
+    scripts: { build: "tsc" },
+    engines: { node: ">=22" },
+    ...over,
+  });
+
+describe("classifyManifestChange — the skip", () => {
+  it("drops a version-only package.json bump", () => {
+    const verdict = classifyManifestChange({
+      path: "package.json",
+      before: pkg({ version: "0.68.0" }),
+      after: pkg({ version: "0.69.0" }),
+    });
+    expect(verdict.versionOnly).toBe(true);
+    expect(verdict.reason).toBe("version-only");
+  });
+
+  it("drops the lockstep version + pinned-dependency bump in packages/js2wasm/package.json", () => {
+    // release.mjs moves the proxy package's own version AND its pin on the
+    // canonical package together; both are in that file's allowlist.
+    const before = JSON.stringify({ name: "js2wasm", version: "0.68.0", dependencies: { "@loopdive/js2": "0.68.0" } });
+    const after = JSON.stringify({ name: "js2wasm", version: "0.69.0", dependencies: { "@loopdive/js2": "0.69.0" } });
+    expect(classifyManifestChange({ path: "packages/js2wasm/package.json", before, after }).versionOnly).toBe(true);
+  });
+
+  it("treats an identical-content diff entry as droppable", () => {
+    // A file can appear in `--name-only` for a mode change. Identical content
+    // cannot move conformance either.
+    const verdict = classifyManifestChange({ path: "package.json", before: pkg(), after: pkg() });
+    expect(verdict).toEqual({ versionOnly: true, reason: "no-key-differences" });
+  });
+});
+
+describe("classifyManifestChange — everything uncertain keeps the matrix", () => {
+  it("keeps a version bump that ALSO changes a dependency", () => {
+    const verdict = classifyManifestChange({
+      path: "package.json",
+      before: pkg({ version: "0.68.0" }),
+      after: pkg({ version: "0.69.0", dependencies: { binaryen: "1.3.0" } }),
+    });
+    expect(verdict.versionOnly).toBe(false);
+    expect(verdict.reason).toContain("dependencies.binaryen");
+  });
+
+  it.each([
+    ["an added dependency", { dependencies: { binaryen: "1.2.3", acorn: "8.0.0" } }],
+    ["a removed dependency", { dependencies: {} }],
+    ["a script change", { scripts: { build: "tsc --noEmit" } }],
+    ["an engines change", { engines: { node: ">=24" } }],
+    ["a keywords reorder", { keywords: ["typescript", "webassembly"] }],
+  ])("keeps %s", (_label, over) => {
+    expect(classifyManifestChange({ path: "package.json", before: pkg(), after: pkg(over) }).versionOnly).toBe(false);
+  });
+
+  it.each([
+    ["malformed on the after side", pkg(), "{ not json"],
+    ["malformed on the before side", "{ not json", pkg()],
+    ["empty on one side (added/deleted file)", "", pkg()],
+  ])("keeps a manifest %s", (_label, before, after) => {
+    const verdict = classifyManifestChange({ path: "package.json", before, after });
+    expect(verdict).toEqual({ versionOnly: false, reason: "unparseable-json" });
+  });
+
+  it("keeps a manifest whose blob could not be read", () => {
+    expect(classifyManifestChange({ path: "package.json", before: null, after: pkg() })).toEqual({
+      versionOnly: false,
+      reason: "blob-unavailable",
+    });
+  });
+
+  it("keeps a JSON document that is not an object", () => {
+    expect(classifyManifestChange({ path: "package.json", before: "[]", after: "[1]" }).reason).toBe(
+      "not-a-json-object",
+    );
+  });
+
+  it("leaves non-manifest paths alone", () => {
+    // Unchanged behaviour: only the table's paths are ever considered, so a
+    // source file is never even inspected.
+    for (const path of ["src/codegen/index.ts", "pnpm-lock.yaml", "tests/test262-runner.ts"]) {
+      expect(classifyManifestChange({ path, before: pkg(), after: pkg() })).toEqual({
+        versionOnly: false,
+        reason: "not-a-release-manifest",
+      });
+    }
+    expect(RELEASE_MOVED_KEYS.has("pnpm-lock.yaml")).toBe(false);
+  });
+});
+
+describe("differingKeyPaths", () => {
+  it("reports nested keys by full path and treats arrays as whole values", () => {
+    expect(differingKeyPaths({ a: { b: 1 }, k: [1, 2] }, { a: { b: 2 }, k: [2, 1] })).toEqual([["a", "b"], ["k"]]);
+  });
+
+  it("reports keys present on only one side", () => {
+    expect(differingKeyPaths({ a: 1 }, { a: 1, b: 2 })).toEqual([["b"]]);
+    expect(differingKeyPaths({ a: 1, b: 2 }, { a: 1 })).toEqual([["b"]]);
+  });
+});
+
+describe("CLI filtering", () => {
+  const run = (stdin: string, args: string[] = []) =>
+    execFileSync("node", [resolve(ROOT, "scripts/manifest-version-only.mjs"), ...args], {
+      input: stdin,
+      encoding: "utf8",
+      cwd: ROOT,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+  it("keeps every path when --base/--head are missing", () => {
+    // Fail-safe: with no revisions there is nothing to prove, so nothing drops.
+    expect(run("package.json\nsrc/x.ts\n").trim().split("\n")).toEqual(["package.json", "src/x.ts"]);
+  });
+
+  it("passes non-manifest paths through untouched", () => {
+    const out = run("src/x.ts\ntests/test262-runner.ts\n", ["--base", "HEAD", "--head", "HEAD"]);
+    expect(out.trim().split("\n")).toEqual(["src/x.ts", "tests/test262-runner.ts"]);
+  });
+});
+
+describe("wiring in test262-sharded.yml", () => {
+  const wf = readFileSync(resolve(ROOT, ".github/workflows/test262-sharded.yml"), "utf8");
+  const detect = wf.slice(wf.indexOf("- name: Detect test262-relevant changes"));
+
+  it("filters the diff and feeds the FILTERED list to the matcher", () => {
+    expect(detect).toContain("node scripts/manifest-version-only.mjs --base");
+    expect(detect).toMatch(/\$FILTERED[\s\S]*test262-paths-match\.sh --target host/);
+    expect(detect).toMatch(/\$FILTERED[\s\S]*test262-paths-match\.sh --target standalone/);
+  });
+
+  it("runs AFTER the empty-diff fail-safe, never before it", () => {
+    // An empty RAW diff is suspicious and must still force a full run; an
+    // empty FILTERED list is the legitimate release-only answer. Swapping the
+    // order would turn the second into the first and silently undo the fix.
+    expect(detect.indexOf("Empty diff for merge_group")).toBeLessThan(detect.indexOf("manifest-version-only.mjs"));
+  });
+
+  it("falls back to the unfiltered diff when the filter exits non-zero", () => {
+    expect(detect).toMatch(/filter_rc[\s\S]{0,400}FILTERED="\$DIFF"/);
+  });
+
+  it("keeps the filter itself on the test262-relevant path list", () => {
+    // It is part of the gating decision now, so a change to it must be
+    // validated by exactly what it might skip — same rule as the matcher.
+    expect(wf).toContain('- "scripts/manifest-version-only.mjs"');
+    expect(readFileSync(resolve(ROOT, "scripts/test262-paths-match.sh"), "utf8")).toContain(
+      "scripts/manifest-version-only.mjs) echo both ;;",
+    );
+  });
+});
+
+describe("the real #4317 release diff", () => {
+  // The control case from the report: v0.69.0 ran the full matrix with no
+  // source change. Read the actual commit rather than a reconstruction — a
+  // hand-written fixture would not catch release.mjs changing what it writes.
+  const RELEASE_COMMIT = "9b6968b3517b07717659e96b425974f9a9ab5e56";
+
+  const available = (() => {
+    try {
+      execFileSync("git", ["cat-file", "-e", `${RELEASE_COMMIT}^{commit}`], { cwd: ROOT, stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  const show = (rev: string, path: string) =>
+    execFileSync("git", ["show", `${rev}:${path}`], { cwd: ROOT, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
+
+  it.runIf(available)("touches only manifests plus release notes, and no lockfile", () => {
+    const changed = execFileSync("git", ["show", "--name-only", "--format=", RELEASE_COMMIT], {
+      cwd: ROOT,
+      encoding: "utf8",
+    })
+      .trim()
+      .split("\n");
+    expect(changed.sort()).toEqual([
+      "docs/release-notes/v0.69.0.md",
+      "jsr.json",
+      "package.json",
+      "packages/js2wasm/package.json",
+    ]);
+    expect(changed).not.toContain("pnpm-lock.yaml");
+  });
+
+  it.runIf(available)("classifies every manifest it touches as version-only", () => {
+    for (const path of ["package.json", "packages/js2wasm/package.json", "jsr.json"]) {
+      const verdict = classifyManifestChange({
+        path,
+        before: show(`${RELEASE_COMMIT}^`, path),
+        after: show(RELEASE_COMMIT, path),
+      });
+      expect(verdict, `${path}: ${verdict.reason}`).toEqual({ versionOnly: true, reason: "version-only" });
+    }
+  });
+
+  it.runIf(available)("leaves nothing test262-relevant, so the matrix would skip", () => {
+    // End to end through both stages: the filter drops package.json (the only
+    // one of the four on the allowlist) and the matcher then sees nothing
+    // relevant. `docs/` and `jsr.json` were never on the list.
+    const changed = "docs/release-notes/v0.69.0.md\njsr.json\npackage.json\npackages/js2wasm/package.json\n";
+    const filtered = execFileSync(
+      "node",
+      [resolve(ROOT, "scripts/manifest-version-only.mjs"), "--base", `${RELEASE_COMMIT}^`, "--head", RELEASE_COMMIT],
+      {
+        input: changed,
+        encoding: "utf8",
+        cwd: ROOT,
+      },
+    );
+    expect(filtered).not.toContain("package.json\n");
+    const verdict = execFileSync("bash", [resolve(ROOT, "scripts/test262-paths-match.sh")], {
+      input: filtered,
+      encoding: "utf8",
+      cwd: ROOT,
+    }).trim();
+    expect(verdict).toBe("false");
+    // Control: WITHOUT the filter the same diff is relevant — which is exactly
+    // what cost #4317 a full matrix.
+    expect(
+      execFileSync("bash", [resolve(ROOT, "scripts/test262-paths-match.sh")], {
+        input: changed,
+        encoding: "utf8",
+        cwd: ROOT,
+      }).trim(),
+    ).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary

`package.json` is on `test262-sharded.yml`'s `&test262-paths` anchor, so a merge_group entry whose only change is a version bump (a release PR, e.g. #4317) still runs the full ~19-min / 102-job test262 shard matrix even though it changes zero source.

Adds `scripts/manifest-version-only.mjs`, which filters the merge_group base..head diff before `test262-paths-match.sh` classifies it, dropping a manifest from consideration **only on positive proof** that it's version-only:

- `package.json` → only `version` changed
- `packages/js2wasm/package.json` → only `version` and/or `dependencies["@loopdive/js2"]` changed
- `jsr.json` → only `version` changed

Anything else — dependency changes, script/engine/keyword changes, unparseable JSON, a missing blob, a non-object document, or a path not in this short list — is conservatively kept (still triggers the matrix). This is wired **after** the existing empty-raw-diff fail-safe: an empty diff after filtering is a legitimate "nothing relevant changed" answer, but an empty *raw* diff must still force a run regardless. The filter script's own exit code is authoritative — its output is only trusted on exit 0, since empty stdout is itself a valid successful answer and can't double as a failure signal.

## Verified against #4317's actual diff (`9b6968b3`)

The whole diff is `docs/release-notes/v0.69.0.md`, `jsr.json`, `package.json`, `packages/js2wasm/package.json` — no `pnpm-lock.yaml`, no source. A test runs both stages over that real commit: the matcher says `true` (matrix runs) without the filter — exactly what cost #4317 the matrix — and `false` (matrix skips) with it.

## What still runs on an artifact-only / version-only merge_group entry

Confirmed by executing the classifier directly, not by reading it: `test262-shard-mg` (~19 min, 102 jobs) and the standalone runtime-eval provider build (gated on `run_shards`) both skip. `quality`, `equivalence-gate` + 8 shards, `cheap gate`, `cla-check`, and `Differential test` still run in full — `equivalence-gate`'s PR-level skip does not apply in `merge_group` (its `changes` detector short-circuits to `code=true` for any non-`pull_request` event), so this change does not weaken equivalence coverage for these entries, only the redundant conformance matrix.

Deliberately not taken: giving `ci.yml`'s `changes` job the same merge_group diff test262-sharded's `detect` already uses, which would also skip `equivalence-gate` here. Sound for this specific case but changes gating for every queue entry — left for separate review rather than folded in here.

## Verification

- `pnpm run lint`, `npx tsc --noEmit`, `npx prettier --check` — clean.
- `manifest-version-only` (26 tests), `test262-per-lane-gating` (16), plus the existing `issue-3431-mg-matrix`, `issue-3934`, `issue-3878`, `issue-1958`, `issue-2550`, `issue-1897`, `issue-3947`, `issue-3115` suites — all green.

Note: this PR's own merge_group entry runs the full matrix as normal, since it edits `test262-sharded.yml` itself and is on the anchor — a gating change should be validated by exactly what it might skip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmwHrtyzm28H9YuH2nYLYy)_