### PR TITLE
fix(pages): run generate-feature-examples under tsx, not type-stripping — unbreaks every Pages deploy since 10:00

### DIFF
--- a/scripts/run-pages-build.mjs
+++ b/scripts/run-pages-build.mjs
@@ -60,7 +60,15 @@ run(process.execPath, ["--experimental-strip-types", "scripts/sync-es-edition-fe
 // snippets; the generator never instantiates or executes the compiled Wasm,
 // so it carries none of the async-runtime hang risk that live execution
 // would).
-run(process.execPath, ["--experimental-strip-types", "scripts/generate-feature-examples.ts"]);
+// Runs under `tsx`, NOT `node --experimental-strip-types`. This generator is
+// the only script in this file that imports the compiler itself
+// (`../src/index.js`, needed to compile the snippets). Type-stripping does not
+// perform TypeScript's `.js` -> `.ts` specifier rewriting, so plain node fails
+// with ERR_MODULE_NOT_FOUND on `src/index.js` (which does not exist on disk —
+// only `src/index.ts` does) and takes the whole Pages deploy down with it.
+// `pnpm run generate:feature-examples` is the canonical invocation; reuse it
+// rather than duplicating the runner here.
+run("pnpm", ["run", "generate:feature-examples"]);
 
 run(process.execPath, ["--experimental-strip-types", "scripts/generate-editions.ts"]);
 


### PR DESCRIPTION
## Description

**Every GitHub Pages deploy has failed since ~10:00 UTC on 2026-08-10**, so the published site has been serving a build from baseline `3371fa1` (02:06) while the committed test262 data on `main` kept refreshing normally. The repo looks green; the only symptom is a number on the website silently going stale.

Root cause is a regression from #4342. That PR wired `scripts/generate-feature-examples.ts` into `scripts/run-pages-build.mjs` using `node --experimental-strip-types`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/…/src/index.js'
  imported from /…/scripts/generate-feature-examples.ts
Command failed: node --experimental-strip-types scripts/generate-feature-examples.ts
    at run (scripts/run-pages-build.mjs:10:3)
    at scripts/run-pages-build.mjs:63:1
```

That generator is the **only** step in the Pages build that imports the compiler itself (`../src/index.js`, needed to compile the ~90 feature snippets). Type-stripping does **not** perform TypeScript's `.js` → `.ts` specifier rewriting, and `src/index.js` does not exist on disk — only `src/index.ts` does. `run-pages-build.mjs` invokes steps with a bare `execFileSync` and no `try`/`catch` at this site, so the throw took the whole deploy down with it.

`package.json` already defines the canonical invocation (line 217):

```json
"generate:feature-examples": "npx tsx scripts/generate-feature-examples.ts"
```

Fix: call that instead of duplicating a runner that cannot resolve the import. One line plus an explanatory comment.

## Verification

Ran the full `node scripts/run-pages-build.mjs` locally against this branch. The previously-failing step now completes:

```
> npx tsx scripts/generate-feature-examples.ts
Generating feature examples → website/public/feature-examples.json
Wrote website/public/feature-examples.json
```

The build then stops at `generate-editions.ts` with `Missing test262 checkout … run 'git submodule update --init --recursive'` — that is solely because the scratch clone used for verification has no `test262` submodule. CI checks the submodule out (the deploy logs show `Entering 'test262'`), so that step is unaffected by this change.

Only `scripts/run-pages-build.mjs` is committed. The local verification run also regenerated a number of artifacts (`feature-examples.json`, `dashboard/data.js`, `graph-data.json`, the `plan/goals/*.md` tables); those were deliberately left unstaged.

## Follow-up worth considering (not in this PR)

The standalone-editions step immediately below this one is wrapped in `try`/`catch` precisely so a transient failure "skips the standalone editions file instead of failing the whole Pages build". That isolation should arguably extend to the other generators — as written, any one of them throwing silently costs every subsequent deploy, with no alert. Three separate silent-staleness failures surfaced in this area today (this one, the dead `refresh-baseline.yml` cron, and the frozen editions artifact in #3892), which suggests the deploy path needs a real failure signal rather than only a fix.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01No1w6atSHnGCKH6C968Luw)_