### PR TITLE
fix(ci): refresh-baseline must build the FULL runtime-eval provider, not --refusal-only (#4354)

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -233,13 +233,31 @@ jobs:
           ./node_modules/.bin/esbuild src/runtime.ts --bundle --platform=node --format=esm \
             --outfile=scripts/runtime-bundle.mjs --external:typescript --external:binaryen
 
-      # (#2928 E7) Mirror test262-sharded.yml: the standalone lane links the
-      # refusal runtime-eval provider so eval-mentioning modules instantiate.
-      # An emergency-heal baseline measured WITHOUT it would publish a
-      # standalone number the ordinary lane can no longer reproduce.
-      - name: Prebuild refusal runtime-eval provider (#2928)
+      # (#2928 E7 / #4013 / #4354) Mirror test262-sharded.yml: the standalone
+      # lane links the FULL Acorn+interpreter runtime-eval provider, so
+      # eval-dependent modules actually evaluate instead of refusing.
+      #
+      # This step used to pass `--refusal-only`, which silently made every
+      # baseline this workflow promoted ~740 standalone tests LOW: eval tests
+      # recorded `TypeError: dynamic code evaluation is not supported in this
+      # standalone build (no js2wasm:runtime-eval interpreter linked)` rather
+      # than their real result (ES5 standalone read 82.5 % instead of 89.1 %).
+      # `test262-sharded.yml` moved to the full provider in #4013; this
+      # workflow was left behind, so the two lanes disagreed and whichever ran
+      # last won. See #4354.
+      #
+      # test262-sharded.yml builds this ONCE in a dedicated job and fans the
+      # artifact out to its shards, because the build costs minutes and ~3 GB.
+      # Here it is built per standalone shard instead: this workflow's shards
+      # run in parallel, so the wall-clock cost is one build (~5 min), not N —
+      # at the price of extra runner-minutes on a workflow that fires at most
+      # every 8 h. Correctness first; if the runner-minutes matter, lift the
+      # build+upload/download job from test262-sharded.yml wholesale.
+      - name: Prebuild full runtime-eval provider (#2928/#4354)
         if: matrix.target.test262_target == 'standalone'
-        run: node scripts/build-runtime-eval-provider.mjs --refusal-only
+        env:
+          NODE_OPTIONS: --max-old-space-size=3072
+        run: node scripts/build-runtime-eval-provider.mjs
 
       - name: Run shard
         run: |


### PR DESCRIPTION
## Description

Fixes #4354.

`refresh-baseline.yml` prebuilt the standalone runtime-eval provider with `--refusal-only`, so **every baseline this workflow promoted recorded eval-dependent standalone tests as failures**:

```
TypeError: dynamic code evaluation is not supported in this standalone build
  (no js2wasm:runtime-eval interpreter linked)
```

`test262-sharded.yml` moved to the full Acorn+interpreter provider in #4013 (it builds it once in a dedicated `build standalone runtime-eval provider` job and fans the artifact out to its shards). This workflow was left behind on the refusal stub, so the two lanes measured different things and whichever ran last won the baseline.

## Measured

The 2026-08-10 16:47 normal-mode (`force_baseline_refresh=false`) dispatch promoted such a baseline. Diffing it against the previous sharded-produced baseline, same corpus both sides (`loopdive/js2wasm-baselines` `204e81f` vs `070071a`):

| status | before | after | Δ |
| --- | ---: | ---: | ---: |
| pass | 29,494 | 28,754 | **−740** |
| fail | 12,787 | 13,529 | +742 |
| compile_error | 6,331 | 6,331 | 0 |

746 files went pass → other, and **661 carry the "no runtime-eval interpreter linked" TypeError**. `compile_error` is unchanged, which is what confirms this was the missing provider rather than a compile or semantics change. The loss concentrates exactly where expected:

| n | bucket |
| ---: | --- |
| 431 | `test/annexB/language/eval-code` |
| 39 | `test/language/eval-code/direct` |
| 32 | `test/language/eval-code/indirect` |
| 16 | `test/annexB/language/global-code` |

ES5 standalone, same edition classifier both sides:

| baseline | ES5 pass / total | rate |
| --- | ---: | ---: |
| `070071a` (sharded, real provider) | 8,045 / 9,029 | **89.1 %** |
| `204e81f` (refresh-baseline, refusal stub) | 7,448 / 9,029 | 82.5 % |

The incorrect 82.5 % reached the published landing and report pages.

## Why this is urgent

The workflow was re-enabled on 2026-08-10 (requested in #4350, to restore its anti-staleness cron). Its schedule is `17 */8 * * *`, so **every 8 hours it would re-promote a ~740-test-low standalone baseline**, overwriting whatever the sharded path produced.

The failure is quiet in the dangerous direction: a too-low baseline makes subsequent PRs show ~740 phantom *improvements* in the eval buckets, inflating apparent gains and potentially masking genuine regressions inside that noise.

## The change

The compiler bundle is already built by the immediately preceding step, so dropping the flag is sufficient.

Unlike `test262-sharded.yml`, this builds the provider **per standalone shard** rather than once-and-fan-out. Those shards run in parallel, so the wall-clock cost is one build (~5 min), not N — at the price of extra runner-minutes on a workflow that fires at most every 8 h. Correctness first; the rationale is recorded inline so the build+upload/download job can be lifted from `test262-sharded.yml` later if runner-minutes matter. `NODE_OPTIONS=--max-old-space-size=3072` mirrors the sharded job's memory setting.

## Not damaged

The standalone high-water mark was **not** lowered — `benchmarks/results/test262-standalone-highwater.json` still reads `pass: 29494` at `8df798dd`. The #2097 step only ever raises the mark, and 28,754 < 29,494, so it was left alone.

## Verification

- `--refusal-only` is opt-in in `scripts/build-runtime-eval-provider.mjs` (line 220 early-returns before the full build), so removing the flag yields the full provider.
- `refresh-baseline.yml` re-parses as valid YAML with all three jobs (`validate-inputs`, `test262-shard`, `merge-and-promote`) intact.
- No live `--refusal-only` usage remains in the file (the only remaining occurrence is inside the explanatory comment).

After this merges, `refresh-baseline.yml` should be dispatched once in normal mode so the corrupted baseline is replaced by a correctly-measured one (expected: standalone back to ~29,494, ES5 to 89.1 %).

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01No1w6atSHnGCKH6C968Luw)_