### PR TITLE
fix(ci): set TEST262_FULL_RUNTIME_EVAL in refresh-baseline — #4354 part 2, the half that actually links the provider

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -195,6 +195,17 @@ jobs:
       # Namespace by target so host + standalone shards for the same chunk never
       # collide on the JSONL path / blob outfile / artifact name.
       RUN_TIMESTAMP: ${{ github.run_id }}-${{ matrix.target.name }}-chunk${{ matrix.chunk }}
+      # (#4354) Mirror test262-sharded.yml — BOTH halves are required, and this
+      # one is the actual switch. Building the full provider only puts the
+      # module on disk; the runner links it solely when this flag is set, so
+      # without it the standalone lane silently falls back to the refusal path
+      # and every eval-dependent test records
+      #   "no js2wasm:runtime-eval interpreter linked".
+      # The first #4354 fix changed the build to drop `--refusal-only` but
+      # missed this env, and the resulting baseline was byte-for-byte as wrong
+      # as before (standalone still 28,455 instead of ~29,494) with the
+      # provider build step reporting success — a green no-op.
+      TEST262_FULL_RUNTIME_EVAL: ${{ matrix.target.test262_target == 'standalone' && '1' || '' }}
 
     steps:
       - name: Checkout

--- a/tests/issue-2928-e6-provider-cache.test.ts
+++ b/tests/issue-2928-e6-provider-cache.test.ts
@@ -83,4 +83,23 @@ describe("#2928 E6 — runtime-eval provider seam", () => {
     expect(workflow.match(/--require-full-cache/g)).toHaveLength(2);
     expect(workflow).not.toContain("Prebuild refusal runtime-eval provider (#2928)");
   });
+
+  // (#4354) refresh-baseline.yml promotes the SAME standalone baseline that
+  // test262-sharded.yml does, so it must measure the same tier. It previously
+  // built the provider with `--refusal-only` and never set
+  // TEST262_FULL_RUNTIME_EVAL, so every baseline it promoted recorded
+  // eval-dependent standalone tests as "no js2wasm:runtime-eval interpreter
+  // linked" — 740 tests low (ES5 standalone 82.5 % instead of 89.1 %), and
+  // that figure reached the published site.
+  //
+  // The env var is the load-bearing half: building the provider only puts the
+  // module on disk, and without the flag the runner still links the refusal
+  // path. Fixing only the build produced a byte-identical wrong baseline with
+  // every step reporting success, so assert BOTH halves here.
+  it("measures the full runtime-eval tier in refresh-baseline too, not the refusal tier", () => {
+    const workflow = readFileSync(join(process.cwd(), ".github/workflows/refresh-baseline.yml"), "utf8");
+    expect(workflow).toContain("TEST262_FULL_RUNTIME_EVAL:");
+    expect(workflow).toContain("node scripts/build-runtime-eval-provider.mjs\n");
+    expect(workflow).not.toContain("build-runtime-eval-provider.mjs --refusal-only");
+  });
 });


### PR DESCRIPTION
## Description

Second half of #4354. #4355 dropped `--refusal-only` from the provider build, which was necessary but **not sufficient**, and the corrected refresh promoted a baseline that was byte-identically wrong.

There are two halves, and the env var is the load-bearing one:

| half | what it does | state before this PR |
| --- | --- | --- |
| `build-runtime-eval-provider.mjs` without `--refusal-only` | puts the real provider module on disk | fixed by #4355 |
| **`TEST262_FULL_RUNTIME_EVAL=1`** | **makes the runner actually link it** | **missing** |

`test262-sharded.yml` sets it per standalone shard (lines 786 and 958):

```yaml
TEST262_FULL_RUNTIME_EVAL: ${{ matrix.target.test262_target == 'standalone' && '1' || '' }}
```

`refresh-baseline.yml` never did. So the standalone lane silently kept linking the refusal path, and every eval-dependent test recorded `no js2wasm:runtime-eval interpreter linked`.

## Evidence that #4355 alone did not fix it

The refresh dispatched immediately after #4355 merged (run on `07ff62fd`, i.e. with the build fix in place) promoted `c93910e` in `loopdive/js2wasm-baselines`:

| baseline | standalone | note |
| --- | ---: | --- |
| `204e81f` (before #4355) | 28,455 | corrupted |
| `c93910e` (after #4355) | **28,455** | **identical — no improvement** |
| expected | ~29,494 | what the sharded lane measures |

The `Prebuild full runtime-eval provider (#2928/#4354)` step reported **success** in every standalone shard (verified on `test262 standalone shard 21`). A green no-op — the same failure shape as #4350 and #4351, where a step succeeds and the number it was supposed to move does not.

## Also: closing the gap that allowed the divergence

`tests/issue-2928-e6-provider-cache.test.ts` already asserted this invariant — but for `test262-sharded.yml` **only**. That is exactly why the two workflows drifted apart and nothing caught it. This PR adds a case asserting **both** halves for `refresh-baseline.yml`:

```ts
expect(workflow).toContain("TEST262_FULL_RUNTIME_EVAL:");
expect(workflow).toContain("node scripts/build-runtime-eval-provider.mjs\n");
expect(workflow).not.toContain("build-runtime-eval-provider.mjs --refusal-only");
```

## Verification

- **Anti-vacuity checked.** Removing the env var makes the new test fail (`AssertionError: expected 'name: Baseline Refresh…' to contain 'TEST262_FULL_RUNTIME_EVAL:'`); restoring it passes. So the test cannot silently stop guarding.
- `tests/issue-2928-e6-provider-cache.test.ts`: 6/6 pass.
- `refresh-baseline.yml` re-parses as valid YAML with all three jobs intact; the env resolves to `1` for standalone and empty for host, matching `test262-sharded.yml`.
- The flag is the documented switch: `scripts/run-test262-vitest.sh:189` — *"TEST262_FULL_RUNTIME_EVAL=1 — additionally build the real Acorn+interpreter [provider]"*.

After this merges, `refresh-baseline.yml` needs one more normal-mode dispatch. **Success criterion is the number, not the checkmarks**: the resulting baseline must report standalone ~29,494 (not 28,455), which restores ES5 standalone to 89.1 % (8,045/9,029) on the published pages instead of the incorrect 82.5 %.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01No1w6atSHnGCKH6C968Luw)_