### PR TITLE
perf(ci): build the refresh-baseline eval provider once and fan it out, not per shard

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -102,9 +102,51 @@ jobs:
             echo "✓ Manual NORMAL baseline refresh — records main's current test262 state (no force)."
           fi
 
+  # (#4354) Compile the real Acorn+interpreter provider ONCE and fan the
+  # resulting zero-import Wasm module out to all 57 standalone shards, exactly
+  # as test262-sharded.yml does.
+  #
+  # The first cut of this fix built it per standalone shard. That is correct
+  # but wasteful: the build costs ~5 min and ~3 GB, this matrix has 57
+  # standalone cells, and the workflow fires every 8 h — roughly 285 runner-
+  # minutes burned per refresh recompiling an identical artifact.
+  runtime-eval-provider:
+    name: build standalone runtime-eval provider
+    needs: validate-inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Setup Node and pnpm (cached)
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and verify full runtime-eval provider (#2928/#4354)
+        env:
+          NODE_OPTIONS: --max-old-space-size=3072
+        run: |
+          pnpm run build:compiler-bundle
+          node scripts/build-runtime-eval-provider.mjs
+
+      - name: Upload full runtime-eval provider
+        uses: actions/upload-artifact@v6
+        with:
+          name: runtime-eval-provider-${{ github.run_id }}
+          path: .test262-cache/runtime-eval-provider-*.wasm
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+
   test262-shard:
     name: test262 ${{ matrix.target.name }} shard ${{ matrix.chunk }}
-    needs: validate-inputs
+    needs: [validate-inputs, runtime-eval-provider]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -257,18 +299,25 @@ jobs:
       # workflow was left behind, so the two lanes disagreed and whichever ran
       # last won. See #4354.
       #
-      # test262-sharded.yml builds this ONCE in a dedicated job and fans the
-      # artifact out to its shards, because the build costs minutes and ~3 GB.
-      # Here it is built per standalone shard instead: this workflow's shards
-      # run in parallel, so the wall-clock cost is one build (~5 min), not N —
-      # at the price of extra runner-minutes on a workflow that fires at most
-      # every 8 h. Correctness first; if the runner-minutes matter, lift the
-      # build+upload/download job from test262-sharded.yml wholesale.
-      - name: Prebuild full runtime-eval provider (#2928/#4354)
+      # Built ONCE by the `runtime-eval-provider` job above and downloaded
+      # here, mirroring test262-sharded.yml — the build costs ~5 min and ~3 GB
+      # and this matrix has 57 standalone cells, so rebuilding it per shard
+      # burned ~285 runner-minutes per refresh for an identical artifact.
+      - name: Download full runtime-eval provider (#2928/#4354)
         if: matrix.target.test262_target == 'standalone'
-        env:
-          NODE_OPTIONS: --max-old-space-size=3072
-        run: node scripts/build-runtime-eval-provider.mjs
+        uses: actions/download-artifact@v7
+        with:
+          name: runtime-eval-provider-${{ github.run_id }}
+          path: .test262-cache
+
+      # Builds the cheap refusal fallback and fails loudly unless the
+      # downloaded full provider matches this cell's compiler-bundle content
+      # key, so a missing or stale artifact cannot silently drop the measured
+      # capability tier back to refusal — which is the exact failure this
+      # whole issue is about.
+      - name: Verify shared runtime-eval provider cache (#2928/#4354)
+        if: matrix.target.test262_target == 'standalone'
+        run: node scripts/build-runtime-eval-provider.mjs --require-full-cache
 
       - name: Run shard
         run: |

--- a/tests/issue-2928-e6-provider-cache.test.ts
+++ b/tests/issue-2928-e6-provider-cache.test.ts
@@ -102,4 +102,19 @@ describe("#2928 E6 — runtime-eval provider seam", () => {
     expect(workflow).toContain("node scripts/build-runtime-eval-provider.mjs\n");
     expect(workflow).not.toContain("build-runtime-eval-provider.mjs --refusal-only");
   });
+
+  // (#4354) …and builds it ONCE, fanning the artifact out to the 57 standalone
+  // shards rather than recompiling an identical ~3 GB / ~5 min artifact in
+  // every cell. `--require-full-cache` is the integrity half: it fails loudly
+  // if the downloaded artifact is missing or stale, so a broken fan-out cannot
+  // silently drop the measured tier back to refusal.
+  it("builds the refresh-baseline provider once and fans it out to the shards", () => {
+    const workflow = readFileSync(join(process.cwd(), ".github/workflows/refresh-baseline.yml"), "utf8");
+    expect(workflow).toContain("runtime-eval-provider:");
+    expect(workflow).toContain("path: .test262-cache/runtime-eval-provider-*.wasm");
+    expect(workflow).toContain("uses: actions/upload-artifact@v6");
+    expect(workflow).toContain("uses: actions/download-artifact@v7");
+    expect(workflow).toContain("--require-full-cache");
+    expect(workflow).toContain("needs: [validate-inputs, runtime-eval-provider]");
+  });
 });


### PR DESCRIPTION
## Description

Follow-up to #4354 / #4355 / #4356. Those made `refresh-baseline.yml` measure the correct capability tier; this makes it stop paying for that correctness 57 times over.

The #4354 fix built the full Acorn+interpreter provider **inside every standalone shard**. Correct, but wasteful — the build costs ~5 min and ~3 GB, this matrix is 57 chunks × 2 targets, and the workflow fires every 8 h:

| | before | after |
| --- | --- | --- |
| provider builds per refresh | 57 (one per standalone shard) | 1 |
| wasted runner-minutes per refresh | ~285 | ~0 |
| at the 8 h cron | ~14 h of runner time/day | ~15 min/day |

This lifts the pattern `test262-sharded.yml` has used since #4013: a dedicated `runtime-eval-provider` job builds and uploads the module once, and each standalone shard downloads it.

## `--require-full-cache` is not optional here

Each shard then runs:

```yaml
- name: Verify shared runtime-eval provider cache (#2928/#4354)
  if: matrix.target.test262_target == 'standalone'
  run: node scripts/build-runtime-eval-provider.mjs --require-full-cache
```

That step builds the cheap refusal fallback and **fails loudly** unless the downloaded artifact matches the cell's compiler-bundle content key. Without it, build-once would reintroduce exactly the failure this issue chain is about: a missing or stale artifact would silently drop the standalone lane back to the refusal tier, and the run would go green while promoting a ~740-test-low baseline. The integrity check is what makes fan-out safe rather than merely cheaper.

## Wall-clock

Unchanged to slightly better. The shards already ran in parallel, so each paid one build's latency; now they wait on one shared build plus an artifact download. The provider job carries `timeout-minutes: 12` and `NODE_OPTIONS=--max-old-space-size=3072`, mirroring `test262-sharded.yml`.

## Ratchet extended

`tests/issue-2928-e6-provider-cache.test.ts` gains a case pinning the fan-out structure — the provider job, upload, download, `--require-full-cache`, and the shard's `needs: [validate-inputs, runtime-eval-provider]` — so a future edit cannot quietly revert to per-shard builds or drop the integrity check.

## Verification

- `refresh-baseline.yml` re-parses as valid YAML with **four** jobs (`validate-inputs`, `runtime-eval-provider`, `test262-shard`, `merge-and-promote`); `test262-shard.needs` resolves to `['validate-inputs', 'runtime-eval-provider']`.
- Provider job steps resolve as: Checkout → Setup Node and pnpm → Install dependencies → Build and verify full provider → Upload.
- `tests/issue-2928-e6-provider-cache.test.ts`: **7/7 pass**.
- **Anti-vacuity checked**: neither `runtime-eval-provider:` nor `--require-full-cache` appears in the pre-change file, so the new case genuinely fails without this commit.

This is an optimisation only — it does not change what is measured. The correctness fix is already on main via #4355 + #4356.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01No1w6atSHnGCKH6C968Luw)_