### PR TITLE
ci(test262): record WHICH tests regressed, not just how many

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -2163,13 +2163,44 @@ jobs:
             echo "regressions=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # (#4352 triage gap) The gate above runs `--quiet`, which prints ONLY summary counts —
+      # diff-test262.ts emits the per-file list behind `if (!quiet …)`. So when
+      # auto-park (#2547) parks a PR for regressions, the evidence needed to
+      # triage it is discarded: the park comment says "222 regressions" and
+      # nothing anywhere records WHICH 222. Reconstructing them means
+      # re-downloading the 5 MB merged-report artifact (1-day retention) and
+      # re-diffing by hand, if it has not already expired.
+      #
+      # Emit a second, verbose copy purely as triage evidence. Deliberately
+      # separate from the gate invocation so the gate's stdout, exit-code
+      # contract (#3303) and artifact stay byte-identical — this step cannot
+      # change any verdict. `--all` (diff-test262.ts:1450 — NOT `--show-all`)
+      # lifts the default 20-row cap to Infinity, so a large diff is not
+      # truncated exactly when the detail matters most.
+      # Non-fatal: triage evidence must never fail the run that produces it.
+      - name: Enumerate regressed files for triage
+        if: always() && env.HOST_RAN == 'true'
+        continue-on-error: true
+        run: |
+          npx tsx scripts/diff-test262.ts "$BASELINE" merged-reports/test262-results-merged.jsonl --all $META_ARGS \
+            ${TEST262_SCOPE:+--path-filter "$TEST262_SCOPE"} \
+            > merged-reports/test262-regressions-detail.txt 2>&1 || true
+          echo "--- first 40 lines of the detailed report ---"
+          head -40 merged-reports/test262-regressions-detail.txt || true
+
       - name: Upload regressions report
         uses: actions/upload-artifact@v6
         if: always() && env.HOST_RAN == 'true'
         with:
           retention-days: 1
           name: test262-regressions-report
-          path: merged-reports/test262-regressions.txt
+          # (#4352 triage gap) Ship the verbose per-file listing alongside the quiet
+          # summary. Retention stays 1 day, matching the merged report — but a
+          # ~kB text file is far cheaper to keep than re-deriving the list from
+          # the 5 MB JSONL after the fact.
+          path: |
+            merged-reports/test262-regressions.txt
+            merged-reports/test262-regressions-detail.txt
           if-no-files-found: warn
 
       # #1853 — hard-error stability gate. Count malformed-Wasm / missing-


### PR DESCRIPTION
## Description

When `auto-park` (#2547) parks a PR for test262 regressions, **the evidence needed to triage it is discarded**. The park comment says *"222 regressions"* and nothing anywhere records **which** 222.

The regression gate invokes:

```
npx tsx scripts/diff-test262.ts "$BASELINE" merged-reports/test262-results-merged.jsonl --quiet …
  > merged-reports/test262-regressions.txt
```

`diff-test262.ts` only prints the per-file list when **not** quiet:

```ts
// scripts/diff-test262.ts:1811
console.log(`${regColor}=== Regressions (pass → other): ${regressions.length} ===`);
if (!quiet && regressions.length > 0) {
  const shown = regressions.slice(0, maxShow);
```

So the filenames reach neither the job log nor the uploaded `test262-regressions.txt` — that artifact **is** the quiet output.

## Why it matters

Hit while triaging #4313 (tracked in #4352). Answering the only question that matters for a parked PR — *is this churn fine, or does it need fixing?* — required downloading the 5 MB `test262-merged-report` artifact and re-diffing by hand, and only if it had not already expired (1-day retention). For #4313's 2026-08-09 run the window had nearly closed.

The counts alone are not enough to decide. #4313's diff was 222 regressions against **274 improvements** (net +52), categorised `other` 167 / `runtime_error` 25 / `assertion_fail` 15 / `type_error` 11 / `missing_builtin` 3 / `null_deref` 1. Whether that is acceptable churn for a 133-file PR or a real defect is unanswerable without the file list.

## The change

A second, verbose invocation written to `merged-reports/test262-regressions-detail.txt` and uploaded alongside the existing summary.

**Deliberately a separate step from the gate.** The gate's stdout, its exit-code contract (#3303) and its artifact stay byte-identical, so this cannot change any verdict — it only adds evidence. `continue-on-error: true` because triage evidence must never fail the run that produces it.

## One trap worth flagging

The flag is **`--all`** (`diff-test262.ts:1450`), *not* `--show-all`:

```ts
const showAll = args.includes("--all");
const maxShow = showAll ? Infinity : verbose ? 50 : 20;
```

I initially wrote `--show-all`. That is not rejected — it silently falls through to the default **20-row cap**, producing a truncated list that still looks like a complete report. Verified against the source rather than assumed, because a plausible-looking no-op is precisely the failure mode this change exists to prevent (cf. #4350, #4351, #4354, all logged today).

## Verification

- `test262-sharded.yml` re-parses as valid YAML; all 10 jobs intact.
- Step order in `regression-gate`: `Compare against current main baseline` → `Enumerate regressed files for triage` → `Upload regressions report`.
- The gate's own invocation is untouched — diff is additive apart from the upload path becoming a two-entry list.
- No `--show-all` remains except inside the explanatory comment documenting the trap.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01No1w6atSHnGCKH6C968Luw)_