### PR TITLE
docs(issues): add #4360/#4361 as plan/issues files

### DIFF
--- a/plan/issues/4360-host-arraybuffer-copy-typedarray-views.md
+++ b/plan/issues/4360-host-arraybuffer-copy-typedarray-views.md
@@ -1,0 +1,72 @@
+---
+id: 4360
+title: "host dynamic closure bind: copying bytes between host ArrayBuffers through host TypedArray views still fails (the one live residual of #3416)"
+status: ready
+sprint: current
+created: 2026-08-10
+updated: 2026-08-10
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bug
+area: codegen
+goal: correctness
+related: [3416, 3435, 4333]
+---
+
+# The one live residual of #3416
+
+Salvaged from #4333, which was closed as too stale to merge (5,098 commits
+behind, real `src/codegen/**` conflicts). Four of that branch's five bugs are
+**already fixed on main**; this is the only one that still reproduces, so it is
+carried forward rather than lost with the PR.
+
+## Evidence
+
+#4333's five test files, run unmodified against current `main`:
+
+| issue | result on main | verdict |
+| --- | --- | --- |
+| 3412 script top-level function redeclaration | 7/7 pass | fixed |
+| 3413 i32 loop counter dynamic bound validation | 3/3 pass | fixed |
+| 3414 top-level TypedArray constructor global | 2 pass, 1 fail (ENOENT — scratch clone had no `test262` submodule) | no live failure |
+| 3415 sandbox realm runtime errors | 1 pass, 1 fail (same ENOENT) | no live failure |
+| **3416 host dynamic closure bind** | 3 pass, **1 real assertion failure** | **still reproduces** |
+
+The failing case:
+
+```
+× #3416 host dynamic closure bind > copies bytes between host ArrayBuffers through host TypedArray views
+```
+
+roughly, from `tests/issue-3416.test.ts` on branch `codex/strict-harness-regressions`:
+
+```js
+const source = new sandbox.Uint8Array([1, 2, 3, 4]).buffer;
+const dest   = new sandbox.ArrayBuffer(4, { maxByteLength: 8 });
+expect(instance.exports.test(dest, source)).toBe(1234);
+```
+
+The second 3416 failure in that file is the same ENOENT submodule artefact, not
+a defect.
+
+## Relationship to #3435
+
+#4333's triage suspected all of #3416 was superseded by #3435 (`new TA()` on a
+JSDoc `Function`-typed callback param falling to the `__new_TA` extern import).
+That is **half right**: #3435 is `status: done` and does account for three of
+3416's five cases now passing — but not this one.
+
+Worth knowing for whoever picks this up: #4333's own #3416 fix routed through
+`checker.getTypeAtLocation` directly, the anti-pattern that trips the
+oracle-ratchet gate. #3435 solved adjacent ground correctly via `ctx.oracle`.
+A fix here should follow #3435's approach, not #4333's.
+
+## Suggested first step
+
+Lift the single failing case out of
+`codex/strict-harness-regressions:tests/issue-3416.test.ts` into a fresh
+`tests/` file against current main, confirm it still fails, then fix. The rest
+of that branch — the five issue files, the `src/` diff, the
+`scripts/test262-sandbox.mjs` extraction — is not worth carrying: written
+against a 2026-07-03 tree, and the test262 runner has been restructured since.

--- a/plan/issues/4361-extract-symphony-into-package.md
+++ b/plan/issues/4361-extract-symphony-into-package.md
@@ -1,0 +1,63 @@
+---
+id: 4361
+title: "Extract scripts/symphony.mjs (66 KB, untested) into packages/symphony — redo against current main"
+status: ready
+sprint: current
+created: 2026-08-10
+updated: 2026-08-10
+priority: medium
+horizon: l
+feasibility: medium
+task_type: refactor
+area: tooling
+goal: maintainability
+related: [4334, 3288]
+---
+
+# Extract the symphony orchestrator — redo, do not merge #4334
+
+Salvaged from #4334, closed as unmergeable but **not superseded**. The idea is
+worth doing; that branch's diff is not.
+
+`scripts/symphony.mjs` is a **66 KB single-file orchestrator** with **no test at
+all** on main. #4334 proposed splitting it into `packages/symphony/` with
+`lib/{orchestrator,workflow,dispatch-state,yaml,util}.mjs`, its own
+`package.json`, LICENSE/README, and a 192-line test suite.
+
+## Why #4334 could not be merged forward
+
+- **`packages/symphony/` does not exist on main** — only `packages/js2wasm/`.
+  It was never a merge; it introduces a layout that never landed.
+- **The orchestrator moved 10 substantive commits** since the branch's
+  2026-07-03 base, none cosmetic: continuation-slice isolation on fresh
+  branches, retry preservation after idle continuation (#3288),
+  prerequisite-branch rolling between owners (#3288), scoped sprint
+  dependencies (#3288), Porffor backend workflow scoping (#3288), multi-slice
+  continuation, PR discovery from agent branches, agent-PR reconciliation.
+- The PR **deletes 740 lines from that exact file while renaming it**, so git
+  sees a rename+modify conflict with substantial changes on both sides.
+  Resolving it means hand-porting those 10 commits into a new module layout —
+  re-implementation wearing a merge's clothing, with a live orchestrator as the
+  blast radius.
+- `plan/method/symphony-service.md` also conflicts: main has since grown an
+  "Agent Lanes" section (Codex/Claude lanes, `claude-channel`, `.mcp.json`
+  wiring) the branch's older doc has no notion of.
+
+## What to carry over — the shape, not the diff
+
+1. The `lib/` split (`orchestrator` / `workflow` / `dispatch-state` / `yaml` /
+   `util`), re-derived from **today's** `scripts/symphony.mjs`.
+2. **`tests/symphony.test.ts`** — arguably the most valuable artefact in #4334
+   and worth lifting **first and independently of the refactor**. A 66 KB
+   orchestrator driving agent dispatch, branch rolling and PR reconciliation
+   currently has zero coverage; landing tests against the current file would
+   also de-risk the extraction by giving it something to verify against.
+
+Reference for the intended structure: branch `codex-symphony-npm-package`
+(#4334). Do not merge it.
+
+## Suggested order
+
+1. Land `tests/symphony.test.ts` against the **current** `scripts/symphony.mjs`,
+   adapting as needed.
+2. Then extract into `packages/symphony/`, with those tests as the safety net.


### PR DESCRIPTION
## Description

Repo-side records for the two salvage issues opened when #4333 and #4334 were closed, keeping the `plan/issues/<id>-<slug>.md` convention (follows #4358, which did the same for #4350–#4354).

| id | subject | status |
| --- | --- | --- |
| **4360** | host dynamic closure bind: copying bytes between host ArrayBuffers through host TypedArray views — the one live residual of #3416 | `ready` |
| **4361** | extract `scripts/symphony.mjs` (66 KB, untested) into `packages/symphony` — redo against current main | `ready` |

### 4360 — measured, not assumed

#4333's five test files were run unmodified against current `main`:

| issue | result | verdict |
| --- | --- | --- |
| 3412 | 7/7 pass | fixed |
| 3413 | 3/3 pass | fixed |
| 3414 | 2 pass, 1 fail *(ENOENT — scratch clone had no `test262` submodule)* | no live failure |
| 3415 | 1 pass, 1 fail *(same ENOENT)* | no live failure |
| **3416** | 3 pass, **1 real assertion failure** | **still reproduces** |

Four of five are already fixed. The issue records that #3435 (`status: done`) accounts for three of 3416's five cases passing but not `copies bytes between host ArrayBuffers through host TypedArray views`, and that a fix should follow #3435's `ctx.oracle` route rather than #4333's direct `checker.getTypeAtLocation` (which trips the oracle ratchet).

### 4361 — the idea, not the diff

`packages/symphony/` never existed on main, and the orchestrator #4334 renames moved **10 substantive commits** since its 2026-07-03 base (continuation-slice isolation, retry preservation, prerequisite-branch rolling, scoped sprint dependencies, Porffor workflow scoping, multi-slice continuation, agent-branch PR discovery, agent-PR reconciliation). The PR deletes 740 lines from that file *while renaming it*, so resolving the rename+modify conflict is re-implementation in disguise, with a live orchestrator as the blast radius.

The issue flags `tests/symphony.test.ts` as worth lifting **first and independently of the refactor** — a 66 KB orchestrator driving agent dispatch and branch rolling currently has zero coverage, and landing tests against the current file would de-risk the extraction by giving it something to verify against.

## Id provenance

Ids came from GitHub, which allocates atomically from the shared PR/issue sequence. `claim-issue.mjs --allocate` is degraded in this environment — without `gh` the open-PR scan fails and it proposed an id that was already a live PR — and hand-picking risks a duplicate that is green at PR time and only fails in the `merge_group`.

## Gates

- `check:issue-ids --against-main` → exit 0
- `update-issues --check` → exit 0
- `check-issue-spec-coverage` → exit 0 (both are `status: ready`, so no done-flip probe requirement applies)

Docs-only: no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` changes.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01No1w6atSHnGCKH6C968Luw)_