### PR TITLE
chore(site): point the custom domain at js2wasm.loopdive.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ You do **not** need agents to contribute. Regular PRs from any contributor are w
 - `plan/issues/backlog/` — longer-term items that need more investigation first.
 - `plan/issues/wont-fix/` — decided against implementing (for context only).
 - `plan/log/dependency-graph.md` — current priorities and what's blocked on what.
-- [The dashboard](https://js2.loopdive.com/dashboard/) provides a filtered UI view of ready-to-pick issues.
+- [The dashboard](https://js2wasm.loopdive.com/dashboard/) provides a filtered UI view of ready-to-pick issues.
 
 **Protected paths** (changes to these go through CODEOWNERS review):
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The line above is the **JS-host path** (default `gc` target): runs alongside the
 
 The line above is the **standalone path** (`--target standalone`/`wasi`): pure WasmGC with no JS host, measured host-free on the same official denominator. Lower today and actively hardening — this is where the current gap is.
 
-Full breakdowns, the trend graph, and benchmarks are in **[STATUS.md](./STATUS.md)**, the [Playground](https://js2.loopdive.com/playground/), and the [Roadmap](./ROADMAP.md).
+Full breakdowns, the trend graph, and benchmarks are in **[STATUS.md](./STATUS.md)**, the [Playground](https://js2wasm.loopdive.com/playground/), and the [Roadmap](./ROADMAP.md).
 
 ## Value proposition
 
@@ -64,7 +64,7 @@ The structural observation behind the project is that this *combination* of trad
 What exists today:
 
 - a JS-hosted compilation path passing a substantial subset of Test262 (the figure above)
-- a public browser [Playground](https://js2.loopdive.com/playground/)
+- a public browser [Playground](https://js2wasm.loopdive.com/playground/)
 - continuous conformance and benchmark reporting on every change
 - a standalone (no-JS-host) path that is in progress — host-free conformance (see the figure above) is meaningfully lower than the JS-host path and actively hardening
 
@@ -238,7 +238,7 @@ output, see [docs/standalone-io.md](./docs/standalone-io.md).
 In a JS host, `js2wasm` passes a substantial subset of Test262 — enough that a
 large, useful slice of the language works — but there are real gaps, and you
 will hit them. The current pass rate lives in [STATUS.md](./STATUS.md) and the
-full [Test262 report](https://js2.loopdive.com/benchmarks/report.html);
+full [Test262 report](https://js2wasm.loopdive.com/benchmarks/report.html);
 this section is the qualitative high-level shape, and the report is the
 authoritative per-feature detail. Note that Test262 measures conformance to the
 ECMAScript *language* specification — it does **not** cover Web APIs, Node.js
@@ -272,7 +272,7 @@ high pass rate is necessary but not sufficient for "runs real JavaScript."
 - dropping in an arbitrary npm package unchanged
 
 If a pattern you rely on does not work, check the
-[Test262 report](https://js2.loopdive.com/benchmarks/report.html) or
+[Test262 report](https://js2wasm.loopdive.com/benchmarks/report.html) or
 open an issue.
 
 ## FAQ
@@ -339,7 +339,7 @@ For a long-form, technical account of the methodology — how the team is struct
 `js2wasm` validates correctness through three complementary test layers:
 
 - **Unit & equivalence tests** — `npm test` (vitest). Targeted regression coverage and JS↔Wasm equivalence assertions. See `tests/equivalence/`.
-- **Test262 conformance** — `pnpm run test:262` runs the ECMAScript test suite (~48k tests: ~43k official plus ~5k staging/proposal tests) and reports per-edition / per-path pass rates. The headline conformance figure is scored against the 43,106 official tests (proposals excluded); CI runs this sharded on every PR and the [report](https://js2.loopdive.com/benchmarks/report.html) is regenerated on each merge.
+- **Test262 conformance** — `pnpm run test:262` runs the ECMAScript test suite (~48k tests: ~43k official plus ~5k staging/proposal tests) and reports per-edition / per-path pass rates. The headline conformance figure is scored against the 43,106 official tests (proposals excluded); CI runs this sharded on every PR and the [report](https://js2wasm.loopdive.com/benchmarks/report.html) is regenerated on each merge.
 - **Differential testing vs V8** — `pnpm run test:diff` (#1203). For each program in `tests/differential/corpus/`, the harness runs Node-V8 directly and the compiled `.wasm` and compares stdout. test262 measures spec compliance; differential testing measures whether real programs actually produce the right answer. CI gates each PR on a delta against `benchmarks/results/diff-test-baseline.json` — no new mismatches allowed. Use `pnpm run test:diff:triage` to bucket mismatches by category for follow-up filing.
 
 ## Licensing
@@ -357,7 +357,7 @@ The foundational design choices behind `js2wasm` — why WasmGC instead of linea
 
 ## Further reading
 
-- [Playground](https://js2.loopdive.com/playground/)
+- [Playground](https://js2wasm.loopdive.com/playground/)
 - [Status & live numbers](./STATUS.md)
 - [Roadmap](./ROADMAP.md)
 - [Architecture Decisions](./docs/adr/README.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Across 69 development sprints and **2,700+ merged pull requests**, js2wasm has g
 
 <!-- AUTO:conformance-end -->
 
-- Automated conformance tracking with historical trend data and a public [conformance report](https://js2.loopdive.com/benchmarks/report.html)
+- Automated conformance tracking with historical trend data and a public [conformance report](https://js2wasm.loopdive.com/benchmarks/report.html)
 - 200+ project-level equivalence tests validating JS↔Wasm output parity
 
 ### Language Features (compiled to native Wasm)
@@ -48,7 +48,7 @@ Across 69 development sprints and **2,700+ merged pull requests**, js2wasm has g
 
 ### Tooling
 
-- **[Live Playground](https://js2.loopdive.com/playground/)** — compile and run TypeScript as WebAssembly in the browser
+- **[Live Playground](https://js2wasm.loopdive.com/playground/)** — compile and run TypeScript as WebAssembly in the browser
 - **WAT inspector** — view generated WebAssembly Text Format
 - **Module analyzer** — binary size treemap visualization
 - **CLI** with WAT, `.d.ts`, and imports helper output
@@ -123,7 +123,7 @@ Same TypeScript input produces the same Wasm binary output. No runtime behavior 
 ## Current Performance
 
 _Point-in-time snapshot for illustration — the live, auto-refreshed benchmark
-panels on the [landing page](https://js2.loopdive.com/) are canonical._
+panels on the [landing page](https://js2wasm.loopdive.com/) are canonical._
 
 ```
 Benchmark     WASM          JS        Ratio     n
@@ -141,8 +141,8 @@ Compute-intensive workloads (fibonacci, loops, array operations) already match o
 ## Get Involved
 
 - **Repository**: [github.com/loopdive/js2](https://github.com/loopdive/js2)
-- **Playground**: [Live demo](https://js2.loopdive.com/playground/)
-- **Conformance report**: [Historical compatibility tracking](https://js2.loopdive.com/benchmarks/report.html)
+- **Playground**: [Live demo](https://js2wasm.loopdive.com/playground/)
+- **Conformance report**: [Historical compatibility tracking](https://js2wasm.loopdive.com/benchmarks/report.html)
 - **License**: Apache 2.0 with LLVM Exceptions
 
 ---

--- a/STATUS.md
+++ b/STATUS.md
@@ -16,9 +16,9 @@ for current figures.
 
 | What | Live source |
 |------|-------------|
-| Test262 pass rate (overall + per category/edition) | The conformance dashboard on the [landing page](https://js2.loopdive.com/) and the [Test262 report](https://js2.loopdive.com/benchmarks/report.html). The underlying data is published to the [`loopdive/js2wasm-baselines`](https://github.com/loopdive/js2wasm-baselines) repo (`test262-current.json`) and refreshed by CI on every merge. |
-| Module size & cold-start characteristics | The benchmark charts on the [landing page](https://js2.loopdive.com/) (size and cold-start panels), regenerated from `benchmarks/results/` on every merge. |
-| Per-feature support detail | The feature tables and [Test262 report](https://js2.loopdive.com/benchmarks/report.html), which break results down by language feature and edition. |
+| Test262 pass rate (overall + per category/edition) | The conformance dashboard on the [landing page](https://js2wasm.loopdive.com/) and the [Test262 report](https://js2wasm.loopdive.com/benchmarks/report.html). The underlying data is published to the [`loopdive/js2wasm-baselines`](https://github.com/loopdive/js2wasm-baselines) repo (`test262-current.json`) and refreshed by CI on every merge. |
+| Module size & cold-start characteristics | The benchmark charts on the [landing page](https://js2wasm.loopdive.com/) (size and cold-start panels), regenerated from `benchmarks/results/` on every merge. |
+| Per-feature support detail | The feature tables and [Test262 report](https://js2wasm.loopdive.com/benchmarks/report.html), which break results down by language feature and edition. |
 
 If a number you see quoted elsewhere disagrees with these sources, the live
 sources win.

--- a/docs/landing-feature-table-audit.md
+++ b/docs/landing-feature-table-audit.md
@@ -1,7 +1,7 @@
 # Landing page feature support table — audit (#1583)
 
 This document explains what the "Compatibility" section on the
-[landing page](https://js2.loopdive.com/) shows, where its data comes
+[landing page](https://js2wasm.loopdive.com/) shows, where its data comes
 from, what its badges and fractions actually mean, and what was
 changed to make it more honest.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ahead-of-time",
     "javascript"
   ],
-  "homepage": "https://js2.loopdive.com",
+  "homepage": "https://js2wasm.loopdive.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/loopdive/js2.git"

--- a/packages/js2wasm/README.md
+++ b/packages/js2wasm/README.md
@@ -39,7 +39,7 @@ npx js2wasm input.ts --optimize -o output.wasm
 ## Links
 
 - Canonical package: [`@loopdive/js2`](https://www.npmjs.com/package/@loopdive/js2)
-- Homepage: https://js2.loopdive.com
+- Homepage: https://js2wasm.loopdive.com
 - Source: https://github.com/loopdive/js2
 - Issues: https://github.com/loopdive/js2/issues
 

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -11,7 +11,7 @@
     "aot",
     "javascript"
   ],
-  "homepage": "https://js2.loopdive.com",
+  "homepage": "https://js2wasm.loopdive.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/loopdive/js2.git",

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -480,11 +480,11 @@ copyFileIfExists(
 // Disable Jekyll processing so all generated assets are published as-is.
 writeFileSync(join(PAGES_DIST, ".nojekyll"), "");
 
-// Emit CNAME so the GitHub Pages custom domain (js2.loopdive.com) survives
+// Emit CNAME so the GitHub Pages custom domain (js2wasm.loopdive.com) survives
 // every re-deploy. GitHub Pages reads this file from the deployed artifact
 // and points the Pages site at the custom domain. Bare hostname only —
 // no scheme, trailing newline. See plan/issues/sprints/46/1188.md.
-writeFileSync(join(PAGES_DIST, "CNAME"), "js2.loopdive.com\n");
+writeFileSync(join(PAGES_DIST, "CNAME"), "js2wasm.loopdive.com\n");
 
 // Copy web components to pages-dist root and dashboard
 const COMPONENTS_DIR = join(WEBSITE, "components");

--- a/website/CNAME
+++ b/website/CNAME
@@ -1,1 +1,1 @@
-js2.loopdive.com
+js2wasm.loopdive.com

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -10,13 +10,13 @@
     />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="js2wasm" />
-    <meta property="og:url" content="https://js2.loopdive.com/blog/" />
+    <meta property="og:url" content="https://js2wasm.loopdive.com/blog/" />
     <meta property="og:title" content="Sandboxing untrusted JavaScript Modules · JS² Blog" />
     <meta
       property="og:description"
       content="JS² is a compiler that turns JavaScript and TypeScript into WebAssembly with no JS engine in the output, so code no one has read can run in a sandbox that reaches nothing it was not explicitly handed."
     />
-    <meta property="og:image" content="https://js2.loopdive.com/og-image.png" />
+    <meta property="og:image" content="https://js2wasm.loopdive.com/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="js2wasm — AOT JavaScript/TypeScript to WebAssembly GC" />
@@ -26,7 +26,7 @@
       name="twitter:description"
       content="A compiler that turns JS/TS into WebAssembly with no JS engine in the output — a sandbox that reaches nothing it wasn't explicitly handed."
     />
-    <meta name="twitter:image" content="https://js2.loopdive.com/og-image.png" />
+    <meta name="twitter:image" content="https://js2wasm.loopdive.com/og-image.png" />
     <style>
       :root {
         --bg: #060a14;

--- a/website/dashboard/issue.html
+++ b/website/dashboard/issue.html
@@ -180,7 +180,7 @@
     </article>
 
     <script>
-      // The site is served from the domain root (js2.loopdive.com) AND from a
+      // The site is served from the domain root (js2wasm.loopdive.com) AND from a
       // project subpath (loopdive.github.io/js2/). Absolute "/plan/issues/…"
       // fetches only work in the first case — under the subpath they resolve to
       // loopdive.github.io/plan/… and 404, so this viewer was unreachable there.

--- a/website/docs/whitepaper.html
+++ b/website/docs/whitepaper.html
@@ -1449,8 +1449,8 @@
         <div class="footer-grid">
           <div class="footer-left">
             <strong>Public surface</strong><br />
-            <span class="muted">Project page:</span> <a href="https://js2.loopdive.com">js2.loopdive.com</a><br />
-            <span class="muted">Playground:</span> <a href="https://js2.loopdive.com/playground">js2.loopdive.com/playground</a><br />
+            <span class="muted">Project page:</span> <a href="https://js2wasm.loopdive.com">js2wasm.loopdive.com</a><br />
+            <span class="muted">Playground:</span> <a href="https://js2wasm.loopdive.com/playground">js2wasm.loopdive.com/playground</a><br />
             <span class="muted">Repository:</span> <a href="https://github.com/loopdive/js2">github.com/loopdive/js2</a>
           </div>
           <div class="footer-right">

--- a/website/docs/whitepaper.md
+++ b/website/docs/whitepaper.md
@@ -224,7 +224,7 @@ That number should be interpreted correctly. It does not mean the compiler is fi
 
 The project exposes public artifacts that make progress inspectable:
 
-- public landing page: [js2.loopdive.com](https://js2.loopdive.com)
+- public landing page: [js2wasm.loopdive.com](https://js2wasm.loopdive.com)
 - browser playground
 - public compatibility reporting
 - public benchmark reporting
@@ -402,7 +402,7 @@ The current public milestone is enough to make the direction concrete. The next 
 
 ## Public Surface
 
-- Project page: [js2.loopdive.com](https://js2.loopdive.com)
-- Playground: [js2.loopdive.com/playground](https://js2.loopdive.com/playground)
+- Project page: [js2wasm.loopdive.com](https://js2wasm.loopdive.com)
+- Playground: [js2wasm.loopdive.com/playground](https://js2wasm.loopdive.com/playground)
 - Repository: [github.com/loopdive/js2](https://github.com/loopdive/js2)
 - Contact: `js2@loopdive.com`

--- a/website/getting-started/index.html
+++ b/website/getting-started/index.html
@@ -10,13 +10,13 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="js2wasm" />
-    <meta property="og:url" content="https://js2.loopdive.com/getting-started/" />
+    <meta property="og:url" content="https://js2wasm.loopdive.com/getting-started/" />
     <meta property="og:title" content="Get Started · JS²" />
     <meta
       property="og:description"
       content="Install the js2wasm compiler and compile your first TypeScript or JavaScript module to WebAssembly GC — run it in Node.js and the browser."
     />
-    <meta property="og:image" content="https://js2.loopdive.com/og-image.png" />
+    <meta property="og:image" content="https://js2wasm.loopdive.com/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="js2wasm — AOT JavaScript/TypeScript to WebAssembly GC" />
@@ -26,7 +26,7 @@
       name="twitter:description"
       content="Install js2wasm and compile your first TypeScript or JavaScript module to WebAssembly GC — run it in Node.js and the browser."
     />
-    <meta name="twitter:image" content="https://js2.loopdive.com/og-image.png" />
+    <meta name="twitter:image" content="https://js2wasm.loopdive.com/og-image.png" />
     <style>
       :root {
         --bg: #060a14;

--- a/website/index.html
+++ b/website/index.html
@@ -20,13 +20,13 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="js2wasm" />
-    <meta property="og:url" content="https://js2.loopdive.com/" />
+    <meta property="og:url" content="https://js2wasm.loopdive.com/" />
     <meta property="og:title" content="js2wasm — AOT JavaScript/TypeScript → WebAssembly GC" />
     <meta
       property="og:description"
       content="Direct ahead-of-time compilation to WebAssembly GC with no embedded JS engine — turning every module into a Wasm sandbox for untrusted / AI-generated code."
     />
-    <meta property="og:image" content="https://js2.loopdive.com/og-image.png" />
+    <meta property="og:image" content="https://js2wasm.loopdive.com/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="js2wasm — AOT JavaScript/TypeScript to WebAssembly GC" />
@@ -36,7 +36,7 @@
       name="twitter:description"
       content="Direct AOT compilation to WebAssembly GC. No embedded JS engine. A Wasm sandbox for untrusted / AI-generated code."
     />
-    <meta name="twitter:image" content="https://js2.loopdive.com/og-image.png" />
+    <meta name="twitter:image" content="https://js2wasm.loopdive.com/og-image.png" />
     <style>
       :root {
         --bg: #060a14;
@@ -4514,7 +4514,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
       // Pages site with an identical schema; the raw baseline URL stays as a
       // resilience fallback for the case where the same-origin file is missing
       // from a build. URLs stay relative so they resolve against the dynamic
-      // <base href> (loopdive.github.io/js2wasm vs js2.loopdive.com vs local).
+      // <base href> (loopdive.github.io/js2wasm vs js2wasm.loopdive.com vs local).
       const JSHOST_TEST262_REPORT_URLS = [
         "./benchmarks/results/test262-report.json",
         "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json",


### PR DESCRIPTION
## Description

The GitHub Pages custom domain was changed to `js2wasm.loopdive.com` in the repository settings. **That change does not survive on its own**, which is what makes this urgent rather than cosmetic.

The Pages artifact carries its own `CNAME` file, and `scripts/build-pages.js:487` hard-coded the old host:

```js
writeFileSync(join(PAGES_DIST, "CNAME"), "js2.loopdive.com\n");
```

`deploy-pages.yml` uploads `dist/pages` wholesale, so GitHub reads that `CNAME` back out of the artifact and **resets the custom domain on the next deploy**. A deploy fires on every merge to main, so the settings change would have reverted within the hour. That one line is the load-bearing fix; the other 15 files are references catching up.

### Changed — 16 files, 38 occurrences

| area | files |
| --- | --- |
| **the actual fix** | `scripts/build-pages.js` (emitted CNAME + its comment), `website/CNAME` |
| **npm metadata** | `package.json`, `packages/js2wasm/package.json` — `homepage`, which ships to the registry |
| **social cards** | `og:url` / `og:image` / `twitter:image` on `website/index.html`, `getting-started/`, `blog/` — a stale `og:url` makes every shared card resolve through the redirect |
| **prose links** | `README.md`, `ROADMAP.md`, `STATUS.md`, `CONTRIBUTING.md`, `website/docs/whitepaper.{md,html}`, `packages/js2wasm/README.md`, `docs/landing-feature-table-audit.md` |
| **comments naming the domain** | `website/index.html` (base-href note), `website/dashboard/issue.html` |

`website/CNAME` keeps its exact original shape — no trailing newline, as before — so the diff is one line and nothing else moves.

### Deliberately not changed

- **`plan/**` and `.claude/memory/**`** (~54 occurrences). These are historical records — issue files, retros, sprint logs. Editing a past retro to claim it linked a domain that did not exist at the time is a falsification of the record, and the Cloudflare redirect keeps those links resolving either way.
- **`website/public/graph-data.json`, `website/dashboard/data.js`, `website/dashboard/data/issues.json`.** Generated planning artifacts — minified by `build-planning-artifacts.mjs` and prettier-ignored. Hand-editing them desyncs them from their source and trips the "planning artifacts are committed" gate; they regenerate from `plan/` on their own.

### Verification

Run locally on this tree:

| gate | result |
| --- | --- |
| `pnpm run format:check` | exit 0 — *All matched files use Prettier code style!* |
| `pnpm run check:issues` | exit 0 |

Grep confirms 0 remaining `js2.loopdive.com` occurrences across the 16 changed files.

### Note on scope

This touches `package.json`, which pulls the full test262 shard matrix into this PR's merge group. That is a longer queue run than the diff deserves, but the `homepage` field is published to npm and would otherwise point at a redirected host.

### Out of scope — the redirect itself

The old host needs a Cloudflare Redirect Rule (proxied `AAAA js2 → 100::`, then a 301 to `https://js2wasm.loopdive.com` preserving the path). Nothing in this repo controls that.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal PR — the cla-check gate skips org-member PRs automatically. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01No1w6atSHnGCKH6C968Luw)_