### PR TITLE
docs(#4352): correct the framing — one failure, not two, and it no longer reproduces

### DIFF
--- a/plan/issues/4352-4313-oob-trap-ratchet-temporal-limits.md
+++ b/plan/issues/4352-4313-oob-trap-ratchet-temporal-limits.md
@@ -1,7 +1,7 @@
 ---
 id: 4352
 title: "#4313 is blocked by a reproducible oob trap-ratchet growth on Temporal/PlainDateTime/from/limits.js, plus a 221 > 200 catastrophic-guard trip on a net-POSITIVE diff"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-08-10
 updated: 2026-08-10
@@ -54,6 +54,55 @@ The diff is **net positive** (+41 / +52) yet trips a guard that counts raw
 regressions and ignores improvements. #4313 is large (133 files, 47 commits), so
 high churn in both directions is expected. Worth deciding whether the guard
 should consider net, or whether this PR genuinely needs splitting.
+
+## CORRECTION 2026-08-11 — the two failures are one failure and its consequence
+
+**Failure 2 is not independent of Failure 1.** The #1668 guard is subordinate to
+`diff-test262`'s own verdict, not a parallel check. From `test262-sharded.yml`:
+
+```bash
+if [ "$diff_exit" -eq 0 ]; then
+  echo "Catastrophic guard: diff-test262 gate PASS (exit 0, authoritative — #3303)"
+  if [ "$NET" -gt "$CATASTROPHIC_REGRESSION_THRESHOLD" ]; then
+    echo "Raw count exceeds ${CATASTROPHIC_REGRESSION_THRESHOLD} but the script's own gate approved it"
+  fi
+  exit 0        # passes regardless of the raw count
+fi
+# the coarse 200 threshold is consulted ONLY on diff_exit == 1
+```
+
+So the 221 > 200 trip is downstream of the trap-ratchet failure. Once the fine
+gate exits 0 the guard passes on 221 raw regressions by design. **No net-vs-raw
+policy change is required, and this issue should not be read as calling for
+one.** The fine gate is already net-aware — it waived the 84.4 % regression
+ratio on this very diff because "net conformance change is +41 … ratio is
+advisory on a net-positive diff" (#3457).
+
+## CORRECTION 2026-08-11 — Failure 1 does not reproduce on current main
+
+Measured by A/B on current `main` (`8b4c45b`) for
+`test/built-ins/Temporal/PlainDateTime/from/limits.js`:
+
+| target | main | #4313 |
+| --- | --- | --- |
+| gc / host | `RuntimeError: dereferencing a null pointer` (null_deref trap) | `Test262Error: Expected a RangeError but got a ReferenceError` — clean failure, no trap |
+| standalone | `compile_error` (#2046) | `compile_error`, identical — excluded by #3595 |
+
+The file moves *out* of the trap categories, matching the gate's own
+`null_deref 1629 → 145`. Swapping only #4313's `calls.ts` onto main reproduces
+the baseline exactly, so the missing-argument NaN sentinel and the
+`__extern_is_undefined` guard are **not** implicated.
+
+Why the recorded runs disagree: all three report byte-identical totals (221,
++52, 32533 → 32585) despite being a day apart, i.e. the measured state never
+moved. #4313 only reached current `main` on 2026-08-11.
+
+**No `trap-growth-allow` was declared, deliberately.** A declaration carrying
+`tests:` is machine-verified and verification can only refuse, never admit;
+declaring a reclassification that no longer occurs risks the
+`REFUSING baseline push` wedge of 2026-07-25 (#3644), and would permanently mask
+a genuine future regression on that file. The park-hold was removed instead so
+the queue re-measures against current `main`.
 
 ## Not part of this issue
 


### PR DESCRIPTION
## Description

Two corrections to #4352. Both change what someone acting on that issue would do, which is why they're worth a commit rather than a comment.

**1. "Failure 2" is not a second blocker.** The #1668 catastrophic guard is subordinate to `diff-test262`'s own verdict — the coarse 200 threshold is consulted *only* when the fine gate has already exited 1. On `diff_exit == 0` the guard passes regardless of raw count and says so explicitly. So the 221 > 200 trip was a consequence of the trap-ratchet failure, not an independent problem, and **no net-vs-raw policy change is required**. The fine gate is already net-aware: it waived the 84.4 % ratio on this very diff because net was +41 (#3457). As written, the issue sends the next reader looking for a policy fix that isn't needed.

**2. The `oob` growth does not reproduce against current `main`.** A/B on `8b4c45b` for `Temporal/PlainDateTime/from/limits.js`:

| target | main | #4313 |
| --- | --- | --- |
| gc / host | `RuntimeError: dereferencing a null pointer` (null_deref trap) | `Test262Error: Expected a RangeError but got a ReferenceError` — clean failure, no trap |
| standalone | `compile_error` (#2046) | `compile_error`, identical — excluded by #3595 |

The file moves *out* of the trap categories, consistent with the gate's own `null_deref 1629 → 145`. Swapping only #4313's `calls.ts` onto `main` reproduces the baseline exactly, so the missing-argument NaN sentinel and the `__extern_is_undefined` guard are not implicated — that was the first hypothesis and it was wrong.

All three recorded gate runs report byte-identical totals (221, +52, 32533 → 32585) despite being a day apart, i.e. the measured state never moved; #4313 only reached current `main` on 2026-08-11.

The issue also now records why **no `trap-growth-allow` was declared**: a `tests:`-bearing declaration is machine-verified and verification can only refuse, never admit, so declaring a reclassification that no longer occurs risks the #3644 `REFUSING baseline push` wedge — and would permanently mask a genuine future regression on that file. The park-hold was removed instead, so the queue re-measures against current `main`.

`status` moves `ready` → `in-progress` since the investigation is underway rather than unclaimed.

Docs only — no source file is touched.

## CLA

- [ ] I have read and agree to the CLA

<!-- Left unchecked: agreeing to the CLA is the author's act, not mine. The template notes org-member PRs skip this check automatically. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01DokCBn7r1nwVQ5UGeZsV2k)_