### PR TITLE
docs(#4352): retract the "does not reproduce" conclusion — it was wrong

### DIFF
--- a/plan/issues/4352-4313-oob-trap-ratchet-temporal-limits.md
+++ b/plan/issues/4352-4313-oob-trap-ratchet-temporal-limits.md
@@ -78,7 +78,33 @@ one.** The fine gate is already net-aware — it waived the 84.4 % regression
 ratio on this very diff because "net conformance change is +41 … ratio is
 advisory on a net-positive diff" (#3457).
 
-## CORRECTION 2026-08-11 — Failure 1 does not reproduce on current main
+## RETRACTED — "Failure 1 does not reproduce" was WRONG
+
+**Retraction, 2026-08-11, same day.** The section below concluded the `oob`
+growth was a stale measurement. It is not. `merge_group` run `31456242513`,
+built on a `main` that already contained #4366, reproduced it again — the
+FOURTH consecutive run, and the first against a merged state that genuinely
+included current `main`. #4313 was re-parked by the bot.
+
+Do not act on the conclusion below. Its measurements are real and are kept
+because they remain unexplained, but the inference was wrong and the
+recommendation that followed ("do not declare a `trap-growth-allow`") is
+withdrawn. CI reproduces the reclassification consistently, so a
+`tests:`-bearing declaration will now VERIFY rather than risk the #3644 wedge.
+That is the unblocking path.
+
+**The genuinely open question**, which the retracted section stumbled into
+without recognising it: all four runs report *byte-identical* numbers — 221
+regressions, +52, `32533 → 32585`, signature `b9d2b71f0d9944b5`,
+`48735 baseline → 48735 new tests` — across two days and three different merged
+states. A PR-caused delta moves as `main` moves; this one has not.
+`diff-test262` itself flags that shape ("Same signature on another PR ⇒
+identical cluster ⇒ likely baseline drift") while the #2562 detector in the
+sibling job asserts the baseline is content-current. Those signals contradict
+each other, and the baseline is fetched from `js2wasm-baselines` rather than
+produced by the run. Establish which is right before trusting these numbers.
+
+## (retained, but see retraction above) local A/B measurements
 
 Measured by A/B on current `main` (`8b4c45b`) for
 `test/built-ins/Temporal/PlainDateTime/from/limits.js`:


### PR DESCRIPTION
## Description

Retracts the central claim of #4367, which merged a few hours ago. That PR concluded the `oob` trap-ratchet growth on `Temporal/PlainDateTime/from/limits.js` was a stale measurement and recommended **against** declaring a `trap-growth-allow`. Both were wrong, and #4352 on `main` currently says so in my words.

`merge_group` run [31456242513](https://github.com/loopdive/js2wasm/actions/runs/31456242513) — built on a `main` that already contained #4366, i.e. the first merged state that genuinely included current `main` — reproduced the growth again. That is the fourth consecutive run, and #4313 was re-parked by the bot.

**What changes:** the section is marked retracted with the reason, and the withdrawn recommendation is replaced by the unblocking path. Because CI reproduces the reclassification consistently, a `tests:`-bearing declaration will now *verify* rather than risk the #3644 `REFUSING baseline push` wedge — which was my stated reason for refusing it, and no longer applies.

**What is retained:** the local A/B measurements, explicitly flagged as unexplained rather than deleted. They are real readings; the inference drawn from them was the error.

**One claim from #4367 stands** and is untouched here: the #1668 catastrophic guard is subordinate to `diff-test262`'s verdict. Run 31456242513 confirms it directly — `Catastrophic guard: diff-test262 gate FAIL (exit 1) — applying the coarse threshold`. The 221 > 200 trip is downstream of the trap gate, so there is no net-vs-raw policy decision to make.

**The open question this surfaced**, now recorded as a question rather than a conclusion: all four runs report byte-identical numbers — 221 regressions, +52, `32533 → 32585`, signature `b9d2b71f0d9944b5`, `48735 baseline → 48735 new tests` — across two days and three different merged states. A PR-caused delta moves as `main` moves; this one has not. `diff-test262` flags exactly that shape as likely baseline drift while the #2562 detector in the sibling job asserts the baseline is content-current. The baseline is fetched from `js2wasm-baselines`, not produced by the run. Someone should establish which signal is right before these numbers are trusted again.

Docs only — no source file is touched.

## CLA

- [ ] I have read and agree to the CLA

<!-- Left unchecked: agreeing to the CLA is the author's act, not mine. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01DokCBn7r1nwVQ5UGeZsV2k)_