### PR TITLE
fix(site): make the JS-host toggle actually re-measure (#4362)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -76,6 +76,7 @@ jobs:
             && git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone \
               /test262-current.json /test262-current.jsonl /test262-standalone-current.json /test262-standalone-current.jsonl \
               /runs/index.json /runs/editions-index.json /runs/standalone-index.json \
+              /runs/standalone-editions-index.json \
             && git -C /tmp/js2wasm-baselines checkout main; } 2>/dev/null || true
           if [ -f /tmp/js2wasm-baselines/test262-current.json ]; then
             mkdir -p website/public/benchmarks/results benchmarks/results/runs
@@ -118,6 +119,11 @@ jobs:
               cp /tmp/js2wasm-baselines/runs/editions-index.json benchmarks/results/runs/editions-index.json
             [ -f /tmp/js2wasm-baselines/runs/standalone-index.json ] && \
               cp /tmp/js2wasm-baselines/runs/standalone-index.json benchmarks/results/runs/standalone-index.json
+            # (#4362) Per-edition STANDALONE trend series — backs the edition
+            # pass-rate-over-time chart when the JS-host toggle is off.
+            [ -f /tmp/js2wasm-baselines/runs/standalone-editions-index.json ] && \
+              cp /tmp/js2wasm-baselines/runs/standalone-editions-index.json \
+                 benchmarks/results/runs/standalone-editions-index.json
             echo "Fetched baseline data from js2wasm-baselines."
           else
             echo "Warning: baselines repo not available — pages will build with stale/empty baseline."

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -2497,7 +2497,24 @@ jobs:
             --update --sha "${{ github.sha }}" || true
 
       - name: Regenerate edition buckets
-        run: node --experimental-strip-types scripts/generate-editions.ts --results benchmarks/results/test262-current.jsonl
+        run: |
+          node --experimental-strip-types scripts/generate-editions.ts --results benchmarks/results/test262-current.jsonl
+          # (#4362) Same classifier over the STANDALONE lane, host-free, so the
+          # landing page's host/standalone toggle has a per-edition standalone
+          # trend series to append below (`standalone-editions-index.json`) —
+          # not just the overall one. Best-effort: the standalone lane is
+          # conditional (steps.group.outputs.sa), so a missing JSONL must skip
+          # rather than fail the promote.
+          if [ -f benchmarks/results/test262-standalone-current.jsonl ]; then
+            node --experimental-strip-types scripts/generate-editions.ts \
+              --results benchmarks/results/test262-standalone-current.jsonl \
+              --output website/public/benchmarks/results/test262-standalone-editions.json \
+              --host-free \
+              --feature-examples-out website/public/feature-examples-standalone.json \
+              || echo "::warning::standalone edition buckets failed (non-fatal)"
+          else
+            echo "no standalone baseline JSONL on disk — skipping standalone edition buckets"
+          fi
 
       - name: Push baseline artifacts to js2wasm-baselines repo
         # (#3344) Bound the git-over-SSH clone/push to the baselines repo. Without
@@ -2637,6 +2654,7 @@ jobs:
           node scripts/append-run-history.mjs \
             --runs-dir /tmp/js2wasm-baselines/runs \
             --editions website/public/benchmarks/results/test262-editions.json \
+            --standalone-editions website/public/benchmarks/results/test262-standalone-editions.json \
             --standalone-report /tmp/js2wasm-baselines/test262-standalone-current.json \
             --sha "${{ github.sha }}" || echo "::warning::append-run-history failed (non-fatal)"
 

--- a/plan/issues/4362-landing-host-toggle-does-not-remeasure.md
+++ b/plan/issues/4362-landing-host-toggle-does-not-remeasure.md
@@ -1,0 +1,119 @@
+---
+id: 4362
+title: "Landing page: the JS-host toggle greys rows out but never re-measures them — feature counts, edition bars and edition trend all stay js-host"
+status: done
+completed: 2026-08-11
+created: 2026-08-11
+updated: 2026-08-11
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: website
+goal: dogfood
+sprint: current
+related: [2636, 2910, 2914, 4137, 2928, 2929]
+# id 4362 reserved via `claim-issue.mjs --allocate --allow-unscanned` on
+# 2026-08-11 (gh CLI unavailable in the container; pr_scan=degraded).
+# Equivalent open-PR scan via the GitHub MCP at reservation time: the sole open
+# PR was #4369 (`ci/npm-compat-refresh`, an artifact-refresh branch that
+# introduces no issue file), so the id universe was clean.
+---
+
+# #4362 — the landing page's "JS host" toggle does not re-measure anything
+
+Follow-up to the eval/JS-host copy fix (PR #4370). That PR removed a wrong
+`host` label from the `eval()` row; this one fixes the reason the label was
+load-bearing in the first place.
+
+## Problem
+
+The landing page has a "JS host" toggle that is meant to switch the whole
+conformance view between the JS-host lane and the standalone (host-free) lane.
+It only really did that in one of the three places it appears to:
+
+| Layer | Toggles? | Why |
+| --- | --- | --- |
+| Headline conformance donut + pass rate | **yes** | `hydrateConformanceEditionFilter` loads `test262-standalone-report.json` and applies `host_free_pass` |
+| Per-edition pass bars in the feature list | **no** | `loadEditionBuckets()` unconditionally fetched `test262-editions.json` and memoised it; the toggle re-ran the render over identical numbers |
+| Per-feature row badge / `N / M` chip / `NN%` | **no** | `hydrateFeatureBadges` read `feature-examples.json` once and never re-ran |
+| Edition pass-rate-over-time chart | **no** | for a specific edition with the toggle off it set `points = null` and hid the chart outright |
+
+So the toggle's only effect on the feature list was cosmetic: dim the rows
+tagged `feat-host` and rewrite their badge to a red `×` (`scoreRow` also scores
+them 0). Every number next to every other row kept describing the JS-host lane
+while the page claimed to be showing standalone.
+
+That is not a rounding-level discrepancy. Measured on `main` at the time of
+writing, 64 of 88 feature rows differ between lanes, and the direction is not
+always the one a reader would guess:
+
+| row | js-host | standalone |
+| --- | --- | --- |
+| `eval()` | 158 / 357 (44%) | **332 / 357 (93%)** |
+| `with statement` | 69 / 181 | **96 / 181** |
+| `arguments object (full)` | **184 / 263** | 118 / 263 |
+| `typeof / instanceof` | **42 / 59** | 36 / 59 |
+
+`eval()` was understated by more than 2x in the mode where it does best — the
+standalone interpreter provider (#2928/#2929) beats the JS-host meta-circular
+path on `language/eval-code`.
+
+## Fix
+
+**Data.** `generate-editions.ts` gains `--feature-examples-out <path>`: the
+standalone lane reads the host catalog and writes its host-free
+`passCount`/`totalCount` to a **separate** file
+(`website/public/feature-examples-standalone.json`) instead of being skipped.
+Patching in place was never an option — it would overwrite the host counts and
+show standalone numbers in *both* toggle positions, the same bug mirrored.
+
+The twin is **slim** (name, `testCategories`, and the two counts). The host
+catalog is ~4 MB, ~96% of it per-row `tests[]` failure lists that are
+lane-independent; duplicating them would ship megabytes to convey ~20 KB of
+differing numbers. Slim twin: 19.8 KB.
+
+**Trend history.** `append-run-history.mjs` gains `--standalone-editions`,
+writing `runs/standalone-editions-index.json` (same shape as the host
+`editions-index.json`). `test262-sharded.yml`'s promote-baseline step now
+generates the host-free edition buckets and feeds them in;
+`deploy-pages.yml` fetches the new file.
+
+**Page.** `loadEditionBuckets` is keyed by lane (memoised per lane, not
+globally); `updateEditionPassBars` reads the toggle; `hydrateFeatureBadges`
+becomes a re-appliable `applyFeatureBadges(hostEnabled)` that the toggle calls
+*before* the host-row `×` override (order is load-bearing — it rewrites every
+badge, so running it after would undo the override); the edition trend chart
+reads the standalone series instead of hiding.
+
+## Notes / deliberate limits
+
+- **The standalone edition trend series is not backfilled.** No historical
+  standalone edition snapshots exist, so the series starts empty and grows one
+  entry per promote. `buildHistoryPoints`'s existing `< 2 points` guard keeps
+  the chart hidden until there is something real to plot. It deliberately does
+  **not** fall back to the host series — a host curve under a "standalone"
+  label is exactly the class of quietly-wrong number this issue removes.
+- **Pre-existing, not fixed here:** `editions-index.json` and
+  `standalone-index.json` each hold exactly **one** entry on `main` today, so
+  the host per-edition trend is itself barely renderable. The append pipeline
+  works; it has simply run once. This issue does not change that, and the new
+  standalone series inherits the same thinness.
+- If `feature-examples-standalone.json` is missing (older deploy, or a local
+  build that never ran the standalone pass) the standalone view keeps showing
+  host numbers — the pre-#4362 behaviour, and strictly better than blank rows.
+  Pinned by a test.
+
+## Verification
+
+- `tests/issue-4362-landing-host-standalone-toggle.test.ts` — drives the real
+  `website/index.html` in jsdom with stubbed catalogs and asserts the chip,
+  percentage and report link all follow the toggle and round-trip. Confirmed
+  to **fail on the pre-fix page** (`expected '158 / 357' to be '332 / 357'`),
+  so it is not vacuous.
+- `tests/issue-4362-feature-examples-out.test.ts` — the twin gets the
+  recomputed counts, the source catalog stays byte-identical, the twin is slim,
+  and in-place patching still works when no out path is given.
+- Ran the real generator over the fetched standalone baseline JSONL
+  (48,735 entries): 51 tag-sliced, 29 path-scored, 8 headline-only rows.

--- a/scripts/append-run-history.mjs
+++ b/scripts/append-run-history.mjs
@@ -11,11 +11,13 @@
  * Usage:
  *   node scripts/append-run-history.mjs --runs-dir <dir> [--sha <sha>] \
  *     [--editions <test262-editions.json>] \
+ *     [--standalone-editions <test262-standalone-editions.json>] \
  *     [--standalone-report <test262-standalone-report.json>]
  *
  * Writes/updates (only for inputs that were passed and exist):
- *   <runs-dir>/editions-index.json    — [{ timestamp, gitHash, editions: [{edition, pass, total}] }]
- *   <runs-dir>/standalone-index.json  — [{ timestamp, gitHash, pass, fail, ce, skip, total }]
+ *   <runs-dir>/editions-index.json            — [{ timestamp, gitHash, editions: [{edition, pass, total}] }]
+ *   <runs-dir>/standalone-editions-index.json — same shape, host-free lane (#4362)
+ *   <runs-dir>/standalone-index.json          — [{ timestamp, gitHash, pass, fail, ce, skip, total }]
  *
  * Best-effort: each file is appended independently, and any failure (missing
  * or malformed input) is logged and skipped rather than failing the process —
@@ -67,9 +69,21 @@ function appendEntry(indexPath, entry, isDuplicate) {
   console.log(`append-run-history: appended to ${indexPath}`);
 }
 
-function appendEditions(runsDir, editionsPath, gitHash) {
+/**
+ * Append one per-ES-edition snapshot.
+ *
+ * `indexName` selects the lane: `editions-index.json` (JS-host) or
+ * `standalone-editions-index.json` (#4362, host-free). The two lanes are
+ * separate FILES rather than two series in one entry because they are produced
+ * by different runs at different times — the host editions file is regenerated
+ * in promote-baseline, the standalone one alongside it from the standalone
+ * baseline JSONL — and interleaving them in a single index would make the
+ * duplicate-suppression check compare a host snapshot against a standalone one
+ * and never dedupe.
+ */
+function appendEditions(runsDir, editionsPath, gitHash, indexName = "editions-index.json") {
   if (!editionsPath || typeof editionsPath !== "string" || !existsSync(editionsPath)) {
-    console.log("append-run-history: no editions file provided/found — skipping editions-index.json.");
+    console.log(`append-run-history: no editions file provided/found — skipping ${indexName}.`);
     return;
   }
   try {
@@ -84,7 +98,7 @@ function appendEditions(runsDir, editionsPath, gitHash) {
         total: Number(e?.total || 0),
       })),
     };
-    appendEntry(join(runsDir, "editions-index.json"), entry, (last, next) => {
+    appendEntry(join(runsDir, indexName), entry, (last, next) => {
       if (!Array.isArray(last.editions) || last.editions.length !== next.editions.length) return false;
       return last.editions.every(
         (e, i) =>
@@ -94,7 +108,7 @@ function appendEditions(runsDir, editionsPath, gitHash) {
       );
     });
   } catch (err) {
-    console.log(`append-run-history: editions-index.json append failed (non-fatal): ${err.message}`);
+    console.log(`append-run-history: ${indexName} append failed (non-fatal): ${err.message}`);
   }
 }
 
@@ -134,6 +148,7 @@ function main() {
     return;
   }
   appendEditions(runsDir, args["editions"], args["sha"]);
+  appendEditions(runsDir, args["standalone-editions"], args["sha"], "standalone-editions-index.json");
   appendStandalone(runsDir, args["standalone-report"], args["sha"]);
 }
 

--- a/scripts/generate-editions.ts
+++ b/scripts/generate-editions.ts
@@ -18,7 +18,7 @@
  * Issue: #959
  */
 
-import { existsSync, readdirSync, readFileSync, realpathSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
@@ -1162,12 +1162,20 @@ async function main() {
   // override, i.e. the run that owns test262-editions.json + feature-examples
   // .json). The standalone run passes --output and is skipped, keeping the
   // host-lane feature counts intact.
+  //
+  // (#4362) …UNLESS it also passes `--feature-examples-out`, which reads the
+  // host catalog and writes a SEPARATE standalone twin. Without a distinct out
+  // path the standalone lane must stay skipped: patching in place would
+  // overwrite the host counts with host-free ones and the landing page would
+  // then show standalone numbers in BOTH toggle positions — the mirror image
+  // of the bug this issue fixes.
   const featureExamplesPath = getArg(args, "--feature-examples") ?? FEATURE_EXAMPLES_PATH;
+  const featureExamplesOut = getArg(args, "--feature-examples-out");
   const wantFeatureExamples =
     !args.includes("--no-feature-examples") &&
-    (outputPath === OUTPUT_PATH || getArg(args, "--feature-examples") != null);
+    (outputPath === OUTPUT_PATH || getArg(args, "--feature-examples") != null || featureExamplesOut != null);
   if (wantFeatureExamples) {
-    patchFeatureExamples(featureExamplesPath, taggedTests, pathTests);
+    patchFeatureExamples(featureExamplesPath, taggedTests, pathTests, featureExamplesOut);
   }
 }
 
@@ -1181,10 +1189,11 @@ async function main() {
  * set to 0/0 so the runtime treats them as headline-only (no phantom count).
  * Best-effort: a missing map or catalog leaves the file untouched.
  */
-function patchFeatureExamples(
+export function patchFeatureExamples(
   examplesPath: string,
   taggedTests: ClassifiedTest[],
   pathTests: Array<{ file: string; status: StatusKey }>,
+  outPath?: string,
 ): void {
   if (!existsSync(examplesPath)) {
     console.warn(`[#2910] feature-examples not found at ${examplesPath} — skipping row reconciliation.`);
@@ -1277,9 +1286,31 @@ function patchFeatureExamples(
     }
   }
 
-  writeFileSync(examplesPath, JSON.stringify(examples, null, 2) + "\n");
+  const writePath = outPath ?? examplesPath;
+  mkdirSync(dirname(writePath), { recursive: true });
+  // (#4362) A twin written to a separate path is SLIM: only the fields the
+  // landing page reads off the ACTIVE catalog (row identity, report links, and
+  // the two counts). Everything else on a row — curated js/wat, the shiki
+  // `jsHtml`/`watHtml`, and above all the per-row `tests[]` failure list — is
+  // lane-independent and already present in the host catalog the page loads
+  // anyway. Carrying it twice would ship a second ~4 MB file to every visitor
+  // (the host catalog is ~4 MB, of which ~96% is `tests[]`) to convey ~10 KB of
+  // differing numbers. In-place patching (no out path) still writes the whole
+  // record, since there it IS the catalog.
+  const payload = outPath
+    ? {
+        ...examples,
+        features: examples.features.map((f) => ({
+          name: f.name,
+          testCategories: f.testCategories,
+          passCount: f.passCount,
+          totalCount: f.totalCount,
+        })),
+      }
+    : examples;
+  writeFileSync(writePath, JSON.stringify(payload, null, 2) + "\n");
   console.log(
-    `\n[#2910] Reconciled feature-examples row counts: ${reconciled} tag-sliced, ${pathScored} path-scored, ${headlineOnly} headline-only → ${examplesPath}`,
+    `\n[#2910] Reconciled feature-examples row counts: ${reconciled} tag-sliced, ${pathScored} path-scored, ${headlineOnly} headline-only → ${writePath}`,
   );
   if (unmapped.length > 0) {
     console.warn(

--- a/scripts/run-pages-build.mjs
+++ b/scripts/run-pages-build.mjs
@@ -102,6 +102,12 @@ try {
       // the per-edition slider counted leaky (host-import) passes and diverged
       // from the honest headline/floor.
       "--host-free",
+      // (#4362) Also emit the standalone twin of the landing-page feature-row
+      // counts. Reads the host catalog (for row names / testCategories /
+      // curated examples) and writes ONLY the recomputed host-free
+      // passCount/totalCount to a separate file, leaving the host one intact.
+      "--feature-examples-out",
+      resolve(ROOT, "website", "public", "feature-examples-standalone.json"),
     ]);
   } else {
     console.warn(

--- a/tests/issue-4362-feature-examples-out.test.ts
+++ b/tests/issue-4362-feature-examples-out.test.ts
@@ -1,0 +1,103 @@
+// #4362 — `generate-editions.ts --feature-examples-out` writes the standalone
+// twin of the landing-page feature-row counts.
+//
+// The contract that matters is the SEPARATION: the standalone lane reads the
+// host catalog (for row names, curated examples and `testCategories`) but must
+// write its host-free counts somewhere else. If it patched in place, the host
+// counts would be overwritten with standalone ones and the landing page would
+// show standalone numbers in BOTH toggle positions — the mirror image of the
+// bug #4362 fixes, and just as invisible.
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { patchFeatureExamples, type ClassifiedTest } from "../scripts/generate-editions.ts";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "js2-4362-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** A catalog with one path-scored row (no `features:` tag needed). */
+function writeCatalog(path: string, passCount: number, totalCount: number) {
+  writeFileSync(
+    path,
+    JSON.stringify({
+      features: [
+        {
+          name: "eval()",
+          edition: "ES5",
+          testCategories: ["language/eval-code"],
+          js: "eval('1 + 2')",
+          passCount,
+          totalCount,
+        },
+      ],
+    }),
+  );
+}
+
+const noTaggedTests: ClassifiedTest[] = [];
+/** 3 of 4 tests pass — a row the path-prefix scorer can score. */
+const pathTests = [
+  { file: "test/language/eval-code/a.js", status: "pass" as const },
+  { file: "test/language/eval-code/b.js", status: "pass" as const },
+  { file: "test/language/eval-code/c.js", status: "pass" as const },
+  { file: "test/language/eval-code/d.js", status: "fail" as const },
+];
+
+describe("#4362 patchFeatureExamples --feature-examples-out", () => {
+  it("writes the recomputed counts to the out path", () => {
+    const src = join(dir, "feature-examples.json");
+    const out = join(dir, "feature-examples-standalone.json");
+    writeCatalog(src, 999, 999);
+
+    patchFeatureExamples(src, noTaggedTests, pathTests, out);
+
+    const written = JSON.parse(readFileSync(out, "utf8"));
+    expect(written.features[0].passCount).toBe(3);
+    expect(written.features[0].totalCount).toBe(4);
+  });
+
+  it("leaves the SOURCE catalog byte-identical", () => {
+    const src = join(dir, "feature-examples.json");
+    const out = join(dir, "feature-examples-standalone.json");
+    writeCatalog(src, 999, 999);
+    const before = readFileSync(src, "utf8");
+
+    patchFeatureExamples(src, noTaggedTests, pathTests, out);
+
+    expect(readFileSync(src, "utf8")).toBe(before);
+  });
+
+  it("emits a SLIM twin — row identity and counts, nothing lane-independent", () => {
+    // The twin is a second file shipped to every visitor. The host catalog is
+    // ~4 MB, ~96% of it the per-row `tests[]` failure lists, which are NOT what
+    // differs between lanes. Duplicating them would cost megabytes to convey
+    // kilobytes of differing numbers, so the twin carries only what the page
+    // reads off the active catalog: name, testCategories, and the two counts.
+    const src = join(dir, "feature-examples.json");
+    const out = join(dir, "feature-examples-standalone.json");
+    writeCatalog(src, 0, 0);
+
+    patchFeatureExamples(src, noTaggedTests, pathTests, out);
+
+    const row = JSON.parse(readFileSync(out, "utf8")).features[0];
+    expect(row.name).toBe("eval()");
+    expect(row.testCategories).toEqual(["language/eval-code"]);
+    expect(Object.keys(row).sort()).toEqual(["name", "passCount", "testCategories", "totalCount"]);
+    expect(row.js).toBeUndefined();
+  });
+
+  it("still patches in place when no out path is given (host lane unchanged)", () => {
+    const src = join(dir, "feature-examples.json");
+    writeCatalog(src, 999, 999);
+
+    patchFeatureExamples(src, noTaggedTests, pathTests);
+
+    const row = JSON.parse(readFileSync(src, "utf8")).features[0];
+    expect(row.passCount).toBe(3);
+    expect(row.totalCount).toBe(4);
+  });
+});

--- a/tests/issue-4362-landing-host-standalone-toggle.test.ts
+++ b/tests/issue-4362-landing-host-standalone-toggle.test.ts
@@ -1,0 +1,151 @@
+// #4362 — the landing page's "JS host" toggle must actually re-measure the
+// feature list, not just grey out the rows tagged `feat-host`.
+//
+// Before this issue the three numeric layers behaved as follows:
+//   • the headline conformance donut swapped datasets (correct),
+//   • the per-edition pass bars re-rendered from a MEMOISED host-only fetch,
+//   • the per-feature rows were hydrated ONCE from `feature-examples.json`.
+// So a reader in standalone mode saw js-host numbers presented as standalone
+// ones. For `eval()` that understated the row by more than 2x (158/357 host vs
+// 332/357 standalone), which is the exact opposite of the direction anyone
+// would assume a "no JS host" toggle moves things.
+//
+// These tests drive the REAL website/index.html in jsdom with stubbed
+// catalogs, because the failure mode was entirely in the wiring: every
+// individual piece (fetch, badge derivation, toggle listener) worked, and the
+// bug was that the toggle never reached the row-level apply.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM, VirtualConsole } from "jsdom";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const INDEX_HTML = resolve(ROOT, "website", "index.html");
+
+const EVAL_ROW = '.feat-row[data-t262-paths="language/eval-code,built-ins/eval"]';
+
+const hostCatalog = {
+  features: [{ name: "eval()", testCategories: ["language/eval-code"], passCount: 158, totalCount: 357 }],
+};
+const standaloneCatalog = {
+  features: [{ name: "eval()", testCategories: ["language/eval-code"], passCount: 332, totalCount: 357 }],
+};
+
+/** Boot index.html with a fetch stub that serves the two feature catalogs. */
+async function bootPage(options: { withStandalone: boolean }) {
+  const html = readFileSync(INDEX_HTML, "utf8");
+  const virtualConsole = new VirtualConsole(); // swallow canvas/chart noise
+  const dom = new JSDOM(html, {
+    runScripts: "dangerously",
+    pretendToBeVisual: true,
+    url: "https://js2wasm.test/",
+    virtualConsole,
+    beforeParse(w: any) {
+      // jsdom lacks these; the page's chart/theme code throws without them and
+      // would abort the script before the feature hydration ever runs.
+      w.matchMedia = () => ({
+        matches: false,
+        addEventListener() {},
+        removeEventListener() {},
+        addListener() {},
+        removeListener() {},
+      });
+      w.scrollTo = () => {};
+      w.IntersectionObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+      w.fetch = async (url: unknown) => {
+        const s = String(url);
+        // Order matters: the standalone filename CONTAINS the host one.
+        const body = s.includes("feature-examples-standalone.json")
+          ? options.withStandalone
+            ? standaloneCatalog
+            : null
+          : s.includes("feature-examples.json")
+            ? hostCatalog
+            : null;
+        if (!body) return { ok: false, status: 404, json: async () => ({}) };
+        return { ok: true, status: 200, json: async () => body };
+      };
+    },
+  });
+  // Let the page's async hydration settle.
+  await new Promise((r) => setTimeout(r, 1500));
+  return dom;
+}
+
+/** Read the three places a row shows its pass count. */
+function readRow(dom: JSDOM) {
+  const row = dom.window.document.querySelector(EVAL_ROW);
+  return {
+    found: row != null,
+    chip: row?.querySelector(".feat-row-counts")?.textContent?.trim(),
+    pct: row?.querySelector(".feat-badge-pct")?.textContent?.trim(),
+    link: row?.querySelector(".feat-report-link a")?.textContent?.trim(),
+  };
+}
+
+async function setHostToggle(dom: JSDOM, checked: boolean) {
+  const w = dom.window as any;
+  const toggle = w.document.getElementById("host-support-toggle") as HTMLInputElement;
+  toggle.checked = checked;
+  toggle.dispatchEvent(new w.Event("change"));
+  await new Promise((r) => setTimeout(r, 600));
+}
+
+describe("#4362 landing feature list follows the JS-host toggle", () => {
+  let dom: JSDOM;
+  beforeAll(async () => {
+    dom = await bootPage({ withStandalone: true });
+  }, 60_000);
+  afterAll(() => dom?.window?.close());
+
+  it("hydrates the host catalog when the toggle is on", () => {
+    const row = readRow(dom);
+    expect(row.found).toBe(true);
+    expect(row.chip).toBe("158 / 357");
+    expect(row.pct).toBe("44%");
+  });
+
+  it("re-measures from the standalone catalog when the toggle is off", async () => {
+    await setHostToggle(dom, false);
+    const row = readRow(dom);
+    // The whole point: a DIFFERENT number, and specifically the higher one.
+    expect(row.chip).toBe("332 / 357");
+    expect(row.pct).toBe("93%");
+  });
+
+  it("updates the 'View test results' link too, not just the badge", async () => {
+    await setHostToggle(dom, false);
+    expect(readRow(dom).link).toBe("View test results (332/357) →");
+  });
+
+  it("round-trips back to the host numbers", async () => {
+    await setHostToggle(dom, false);
+    await setHostToggle(dom, true);
+    const row = readRow(dom);
+    // Regression guard for the re-apply name lookup: the first apply appends
+    // the "N / M" chip INTO `.feat-name`, so a re-apply that re-read
+    // `textContent` would search for "eval() 332 / 357", match nothing, and
+    // silently freeze the row on whichever lane it hydrated with first.
+    expect(row.chip).toBe("158 / 357");
+    expect(row.pct).toBe("44%");
+  });
+});
+
+describe("#4362 standalone catalog absent (older deploy)", () => {
+  let dom: JSDOM;
+  beforeAll(async () => {
+    dom = await bootPage({ withStandalone: false });
+  }, 60_000);
+  afterAll(() => dom?.window?.close());
+
+  it("degrades to the host numbers instead of blanking the rows", async () => {
+    expect((dom.window as any).__hasStandaloneFeatureData).toBe(false);
+    await setHostToggle(dom, false);
+    const row = readRow(dom);
+    expect(row.chip).toBe("158 / 357");
+  });
+});

--- a/website/index.html
+++ b/website/index.html
@@ -5077,18 +5077,38 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             if (strictToggle) tables.classList.toggle("strict-only", strictToggle.checked);
             if (hostToggle) tables.classList.toggle("host-off", !hostToggle.checked);
             const hostEnabled = hostToggle ? hostToggle.checked : true;
+            // (#4362) Re-apply the per-row counts for the selected lane FIRST.
+            // Order is load-bearing: this rewrites every badge from the lane's
+            // dataset, so it must run BEFORE the host-only override below —
+            // otherwise it would immediately undo the `×` those rows need.
+            if (typeof window.__applyFeatureBadges === "function") {
+              window.__applyFeatureBadges(hostEnabled);
+            }
             hostRows.forEach((row) => {
               const badge = row.querySelector(".feat-badge");
               if (!(badge instanceof HTMLElement)) return;
               const origClass = badge.dataset.origClass || "";
               const origText = badge.dataset.origText || "";
               badge.className = "feat-badge";
+              // Set only the leading glyph text node so an injected
+              // `.feat-badge-pct` child survives (assigning `textContent`
+              // would delete it, dropping the row's percentage on every
+              // toggle).
+              const setGlyph = (text) => {
+                const first = badge.firstChild;
+                if (first && first.nodeType === Node.TEXT_NODE) first.textContent = text;
+                else badge.insertBefore(document.createTextNode(text), badge.firstChild);
+              };
               if (hostEnabled) {
                 if (origClass) badge.classList.add(...origClass.split(/\s+/).filter(Boolean));
-                badge.textContent = origText;
+                setGlyph(origText);
               } else {
                 badge.classList.add("none");
-                badge.textContent = "×";
+                setGlyph("×");
+                // A host-only row is unsupported in standalone: its pass-rate
+                // chip/percentage describe the JS-host lane and would read as
+                // if the `×` row still scored.
+                badge.querySelector(".feat-badge-pct")?.remove();
               }
             });
             if (typeof window.updateEditionPassBars === "function") {
@@ -5283,13 +5303,22 @@ console.log(instance.exports.run()); // &rarr; 55</pre
               total: run?.total,
               timestampRaw: run?.timestamp,
             }));
-          } else if (!hostEnabled) {
-            // Specific ES edition + standalone: no per-edition standalone
-            // history exists yet (only an overall standalone series) — leave
-            // the chart hidden rather than substitute a misleading series.
-            points = null;
           } else {
-            const runs = await fetchJsonSafe("./benchmarks/results/runs/editions-index.json");
+            // (#4362) Specific ES edition. The standalone lane now has its own
+            // per-edition trend series (`standalone-editions-index.json`,
+            // appended by scripts/append-run-history.mjs from the host-free
+            // edition buckets), so the chart tracks the toggle instead of
+            // hiding itself. It is deliberately NOT backfilled — no historical
+            // standalone edition snapshots exist — so the series starts short
+            // and `buildHistoryPoints`'s own `< 2 points` guard keeps the chart
+            // hidden until it has something real to plot. Never fall back to
+            // the host series here: a host curve under a "standalone" label is
+            // exactly the kind of quietly-wrong number this issue is fixing.
+            const runs = await fetchJsonSafe(
+              hostEnabled
+                ? "./benchmarks/results/runs/editions-index.json"
+                : "./benchmarks/results/runs/standalone-editions-index.json",
+            );
             const label = normalizeEditionLabel(scope);
             points = buildHistoryPoints(runs, (run) => {
               if (!Array.isArray(run?.editions)) return null;
@@ -5332,12 +5361,22 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           ? date.getUTCFullYear()
           : date.getUTCFullYear() - 1;
       };
+      // (#4362) Keyed by lane: the JS-host toggle picks which edition buckets
+      // back the feature-list pass bars. This used to be a single memoised
+      // fetch of the host file, so flipping the toggle re-ran the render over
+      // identical numbers and the bars never moved. Each lane memoises
+      // separately (one fetch per lane, not per toggle).
       const loadEditionBuckets = (() => {
-        let pending;
-        return async () => {
+        const pendingByLane = new Map();
+        return async (hostEnabled = true) => {
+          const lane = hostEnabled ? "host" : "standalone";
+          let pending = pendingByLane.get(lane);
           if (!pending) {
             pending = (async () => {
-              const editionsResp = await fetch("./benchmarks/results/test262-editions.json");
+              const url = hostEnabled
+                ? "./benchmarks/results/test262-editions.json"
+                : "./benchmarks/results/test262-standalone-editions.json";
+              const editionsResp = await fetch(url);
               if (!editionsResp.ok) throw new Error("edition data unavailable");
               const editions = await editionsResp.json();
               if (!Array.isArray(editions) || editions.length === 0) {
@@ -5360,6 +5399,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
                 proposalBucket,
               };
             })();
+            pendingByLane.set(lane, pending);
           }
           return pending;
         };
@@ -6092,8 +6132,11 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         };
 
         const updateEditionPassBars = async () => {
+          // (#4362) Read the lane the JS-host toggle currently selects, so the
+          // per-edition bars show standalone numbers in standalone mode.
+          const hostEnabled = hostToggle ? hostToggle.checked : true;
           try {
-            const { editionList, editionMap, proposalBucket } = await loadEditionBuckets();
+            const { editionList, editionMap, proposalBucket } = await loadEditionBuckets(hostEnabled);
             const panel = document.querySelector(".feat-panel");
             if (panel instanceof HTMLElement) {
               editionList.forEach((edition) => {
@@ -6228,10 +6271,10 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           return (s || "").replace(/\s+/g, " ").trim();
         };
 
-        const fetchFeatures = async () => {
-          for (const url of ["./feature-examples.json", "/feature-examples.json", "../feature-examples.json"]) {
+        const fetchFeaturesFrom = async (file) => {
+          for (const base of ["./", "/", "../"]) {
             try {
-              const resp = await fetch(url);
+              const resp = await fetch(`${base}${file}`);
               if (!resp.ok) continue;
               const payload = await resp.json();
               if (Array.isArray(payload?.features) && payload.features.length > 0) return payload.features;
@@ -6241,6 +6284,15 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           }
           return null;
         };
+        const fetchFeatures = () => fetchFeaturesFrom("feature-examples.json");
+        // (#4362) Host-free twin, written by generate-editions.ts's
+        // `--feature-examples-out` on the standalone lane. Absent on an older
+        // deploy (or a local build that never ran the standalone pass) — in
+        // that case the standalone view keeps showing the host numbers, which
+        // is the pre-#4362 behaviour and strictly better than blanking the
+        // rows. `standaloneFeatures === null` is therefore a soft degrade, not
+        // an error.
+        const fetchStandaloneFeatures = () => fetchFeaturesFrom("feature-examples-standalone.json");
 
         const toneFor = (ratio) => {
           if (ratio >= 0.9) return "pass";
@@ -6254,130 +6306,188 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           fail: { cls: "none", glyph: "✗" },
         };
 
-        const features = await fetchFeatures();
+        const [features, standaloneFeatures] = await Promise.all([fetchFeatures(), fetchStandaloneFeatures()]);
         if (!features) return;
-        const byName = new Map();
-        for (const f of features) {
-          if (typeof f?.name === "string") byName.set(decodeEntities(f.name), f);
-        }
+        const indexByName = (list) => {
+          const map = new Map();
+          for (const f of list ?? []) {
+            if (typeof f?.name === "string") map.set(decodeEntities(f.name), f);
+          }
+          return map;
+        };
+        const hostByName = indexByName(features);
+        const standaloneByName = standaloneFeatures ? indexByName(standaloneFeatures) : null;
 
-        const rows = document.querySelectorAll(".feat-row");
-        for (const row of rows) {
-          const nameEl = row.querySelector(".feat-name");
-          if (!nameEl) continue;
-          const name = decodeEntities(nameEl.textContent);
-          const feature = byName.get(name);
-          if (!feature) continue;
+        // (#4362) Applying the counts is now a re-runnable function keyed by
+        // lane, not a one-shot pass. The JS-host toggle calls it, so the
+        // per-row badge / "N / M" chip / "NN%" all switch datasets instead of
+        // staying pinned to the js-host numbers they were hydrated with.
+        const applyFeatureBadges = (hostEnabled = true) => {
+          const byName = !hostEnabled && standaloneByName ? standaloneByName : hostByName;
+          applyRows(byName);
+          // Re-cache AFTER the rewrite so the host toggle restores this lane's
+          // derived badge, not the previous lane's.
+          if (typeof window.__recacheHostBadges === "function") window.__recacheHostBadges();
+        };
 
-          const paths = Array.isArray(feature.testCategories) ? feature.testCategories.filter(Boolean) : [];
-          const pass = Number(feature.passCount ?? 0);
-          const total = Number(feature.totalCount ?? 0);
-          const badge = row.querySelector(".feat-badge");
+        function applyRows(byName) {
+          const rows = document.querySelectorAll(".feat-row");
+          for (const row of rows) {
+            const nameEl = row.querySelector(".feat-name");
+            if (!nameEl) continue;
+            // (#4362) Cache the row's ORIGINAL name on first pass. A later pass
+            // must not re-read `nameEl.textContent`, because the first pass
+            // appends the "N / M" chip INTO this element — so on re-apply the
+            // text would read "eval() 294 / 357" and match nothing, silently
+            // leaving every row frozen on the lane it first hydrated with.
+            if (row.dataset.featName === undefined) row.dataset.featName = decodeEntities(nameEl.textContent);
+            const name = row.dataset.featName;
+            const feature = byName.get(name);
+            if (!feature) continue;
 
-          if (total <= 0) {
-            // No measurable test262 data — flag the row so the gap is visible
-            // (and auditable) rather than a misleading auto-derived status.
-            row.dataset.noT262Data = "";
-            if (badge && paths.length === 0) row.dataset.noT262Category = "";
-            // A `partial` (⚠) badge with no measurable data reads as a broken
-            // or still-loading warning (the yellow sign with no percentage).
-            // Downgrade it to a neutral "not individually measured" mark.
-            // Author-set ✓ (full) and ✗ (none) badges are unambiguous and stay.
-            if (badge instanceof HTMLElement && badge.classList.contains("partial")) {
-              badge.classList.remove("partial");
-              badge.classList.add("nodata");
-              badge.dataset.glyph = "–";
-              const firstChild = badge.firstChild;
-              if (firstChild && firstChild.nodeType === Node.TEXT_NODE) {
-                firstChild.textContent = "–";
-              } else {
-                badge.insertBefore(document.createTextNode("–"), badge.firstChild);
+            const paths = Array.isArray(feature.testCategories) ? feature.testCategories.filter(Boolean) : [];
+            const pass = Number(feature.passCount ?? 0);
+            const total = Number(feature.totalCount ?? 0);
+            const badge = row.querySelector(".feat-badge");
+
+            if (total <= 0) {
+              // No measurable test262 data — flag the row so the gap is visible
+              // (and auditable) rather than a misleading auto-derived status.
+              row.dataset.noT262Data = "";
+              if (badge && paths.length === 0) row.dataset.noT262Category = "";
+              // A `partial` (⚠) badge with no measurable data reads as a broken
+              // or still-loading warning (the yellow sign with no percentage).
+              // Downgrade it to a neutral "not individually measured" mark.
+              // Author-set ✓ (full) and ✗ (none) badges are unambiguous and stay.
+              if (badge instanceof HTMLElement && badge.classList.contains("partial")) {
+                badge.classList.remove("partial");
+                badge.classList.add("nodata");
+                badge.dataset.glyph = "–";
+                const firstChild = badge.firstChild;
+                if (firstChild && firstChild.nodeType === Node.TEXT_NODE) {
+                  firstChild.textContent = "–";
+                } else {
+                  badge.insertBefore(document.createTextNode("–"), badge.firstChild);
+                }
+                badge.title = "No isolated test262 subset scores this feature individually.";
               }
-              badge.title = "No isolated test262 subset scores this feature individually.";
-            }
-          } else {
-            const ratio = pass / total;
-            const tone = toneFor(ratio);
-            const { cls, glyph } = BADGE[tone];
+              // (#4362) Drop any chip/percentage left by the other lane — a row
+              // that is unmeasured here must not keep showing the other lane's
+              // "N / M".
+              nameEl.querySelector(".feat-row-counts")?.remove();
+              badge?.querySelector(".feat-badge-pct")?.remove();
+            } else {
+              delete row.dataset.noT262Data;
+              badge?.classList.remove("nodata");
+              const ratio = pass / total;
+              const tone = toneFor(ratio);
+              const { cls, glyph } = BADGE[tone];
 
-            // Derive the badge state from the live pass rate.
-            if (badge instanceof HTMLElement) {
-              badge.classList.remove("full", "partial", "none");
-              badge.classList.add(cls);
-              // Preserve any already-injected `.feat-badge-pct` child by
-              // setting only the leading text node (the glyph). Track the
-              // glyph in a dataset field so the host toggle restores it.
-              badge.dataset.glyph = glyph;
-              const firstChild = badge.firstChild;
-              if (firstChild && firstChild.nodeType === Node.TEXT_NODE) {
-                firstChild.textContent = glyph;
-              } else {
-                badge.insertBefore(document.createTextNode(glyph), badge.firstChild);
+              // Derive the badge state from the live pass rate.
+              if (badge instanceof HTMLElement) {
+                badge.classList.remove("full", "partial", "none");
+                badge.classList.add(cls);
+                // Preserve any already-injected `.feat-badge-pct` child by
+                // setting only the leading text node (the glyph). Track the
+                // glyph in a dataset field so the host toggle restores it.
+                badge.dataset.glyph = glyph;
+                const firstChild = badge.firstChild;
+                if (firstChild && firstChild.nodeType === Node.TEXT_NODE) {
+                  firstChild.textContent = glyph;
+                } else {
+                  badge.insertBefore(document.createTextNode(glyph), badge.firstChild);
+                }
+                badge.title = `Live test262 pass rate: ${pass}/${total} (${Math.round(ratio * 100)}%)`;
               }
-              badge.title = `Live test262 pass rate: ${pass}/${total} (${Math.round(ratio * 100)}%)`;
-            }
 
-            // Pass-count chip next to the feature name (within the grid cell).
-            if (!nameEl.querySelector(".feat-row-counts")) {
-              const span = document.createElement("span");
-              span.className = "feat-row-counts feature-test-count";
+              // Pass-count chip next to the feature name (within the grid cell).
+              // (#4362) Create-or-UPDATE: this used to bail whenever the chip
+              // already existed, which is correct for a one-shot hydration and
+              // wrong for a re-appliable one — the toggle would swap the badge
+              // while the chip kept the other lane's numbers.
+              let span = nameEl.querySelector(".feat-row-counts");
+              if (!span) {
+                span = document.createElement("span");
+                span.className = "feat-row-counts feature-test-count";
+                nameEl.appendChild(span);
+              }
               span.textContent = `${pass} / ${total}`;
               span.dataset.tone = tone;
-              nameEl.appendChild(span);
-            }
 
-            // Explicit `NN%` under the badge glyph when below 95% — gives an
-            // at-a-glance "not everything passes yet" signal even on green rows.
-            if (badge && ratio < 0.95 && !badge.querySelector(".feat-badge-pct")) {
-              const pct = Math.round(ratio * 100);
-              const pctEl = document.createElement("span");
-              pctEl.className = "feat-badge-pct";
-              pctEl.dataset.tone = tone;
-              pctEl.textContent = `${pct}%`;
-              pctEl.title = `Live test262 pass rate for ${name}: ${pass}/${total} (${pct}%)`;
-              badge.appendChild(pctEl);
-            }
-          }
-
-          // #1327 / #1583 — deep-link into the per-feature report and the
-          // test262 source for every mapped feature (regardless of total).
-          const details = row.querySelector("details");
-          if (details && paths.length > 0) {
-            if (!details.querySelector(".feat-report-link")) {
-              const linkWrap = document.createElement("div");
-              linkWrap.className = "feat-report-link";
-              const a = document.createElement("a");
-              a.href = `./benchmarks/feature-report.html?feature=${encodeURIComponent(paths[0])}`;
-              a.textContent = total > 0 ? `View test results (${pass}/${total}) →` : "View test results →";
-              a.rel = "noopener";
-              linkWrap.appendChild(a);
-              details.appendChild(linkWrap);
-            }
-            if (!details.querySelector(".feat-test262-paths")) {
-              const wrap = document.createElement("div");
-              wrap.className = "feat-test262-paths";
-              const label = document.createElement("span");
-              label.className = "feat-test262-paths-label";
-              label.textContent = "test262 source:";
-              wrap.appendChild(label);
-              for (const p of paths) {
-                const a = document.createElement("a");
-                a.href = `https://github.com/tc39/test262/tree/main/test/${p}`;
-                a.target = "_blank";
-                a.rel = "noopener";
-                a.textContent = p;
-                wrap.appendChild(a);
+              // Explicit `NN%` under the badge glyph when below 95% — gives an
+              // at-a-glance "not everything passes yet" signal even on green rows.
+              // Removed again when the other lane is at/above the threshold, so a
+              // stale percentage can't outlive the dataset that produced it.
+              if (badge) {
+                let pctEl = badge.querySelector(".feat-badge-pct");
+                if (ratio < 0.95) {
+                  const pct = Math.round(ratio * 100);
+                  if (!pctEl) {
+                    pctEl = document.createElement("span");
+                    pctEl.className = "feat-badge-pct";
+                    badge.appendChild(pctEl);
+                  }
+                  pctEl.dataset.tone = tone;
+                  pctEl.textContent = `${pct}%`;
+                  pctEl.title = `Live test262 pass rate for ${name}: ${pass}/${total} (${pct}%)`;
+                } else if (pctEl) {
+                  pctEl.remove();
+                }
               }
-              details.appendChild(wrap);
+            }
+
+            // #1327 / #1583 — deep-link into the per-feature report and the
+            // test262 source for every mapped feature (regardless of total).
+            const details = row.querySelector("details");
+            if (details && paths.length > 0) {
+              let linkWrap = details.querySelector(".feat-report-link");
+              if (!linkWrap) {
+                linkWrap = document.createElement("div");
+                linkWrap.className = "feat-report-link";
+                const a = document.createElement("a");
+                a.href = `./benchmarks/feature-report.html?feature=${encodeURIComponent(paths[0])}`;
+                a.rel = "noopener";
+                linkWrap.appendChild(a);
+                details.appendChild(linkWrap);
+              }
+              // (#4362) Refresh the count in the link label on every apply, so it
+              // agrees with the chip rather than keeping the first lane's numbers.
+              const reportLink = linkWrap.querySelector("a");
+              if (reportLink) {
+                reportLink.textContent = total > 0 ? `View test results (${pass}/${total}) →` : "View test results →";
+              }
+              if (!details.querySelector(".feat-test262-paths")) {
+                const wrap = document.createElement("div");
+                wrap.className = "feat-test262-paths";
+                const label = document.createElement("span");
+                label.className = "feat-test262-paths-label";
+                label.textContent = "test262 source:";
+                wrap.appendChild(label);
+                for (const p of paths) {
+                  const a = document.createElement("a");
+                  a.href = `https://github.com/tc39/test262/tree/main/test/${p}`;
+                  a.target = "_blank";
+                  a.rel = "noopener";
+                  a.textContent = p;
+                  wrap.appendChild(a);
+                }
+                details.appendChild(wrap);
+              }
             }
           }
         }
 
+        // Expose BEFORE the first apply so a toggle that fires mid-hydration
+        // still finds it.
+        window.__applyFeatureBadges = applyFeatureBadges;
+        window.__hasStandaloneFeatureData = standaloneByName != null;
+
         // The host-support toggle cached each host row's *static* badge
-        // class/glyph on init; re-cache now that the badges reflect the
-        // live data so toggling "JS host" off/on restores the derived
-        // state, not the stale static markup.
-        if (typeof window.__recacheHostBadges === "function") window.__recacheHostBadges();
+        // class/glyph on init; the apply re-caches once the badges reflect the
+        // live data, so toggling "JS host" off/on restores the derived state,
+        // not the stale static markup.
+        const hostToggleEl = document.getElementById("host-support-toggle");
+        applyFeatureBadges(hostToggleEl ? hostToggleEl.checked : true);
       })();
 
       (async function updateHowItWorksSizes() {

--- a/website/public/feature-examples-standalone.json
+++ b/website/public/feature-examples-standalone.json
@@ -1,0 +1,652 @@
+{
+  "generated": "2026-08-10T00:03:53.001Z",
+  "features": [
+    {
+      "name": "Primitive types (string, number, boolean, null, undefined)",
+      "testCategories": ["language/types", "language/literals"],
+      "passCount": 615,
+      "totalCount": 647
+    },
+    {
+      "name": "Operators (arithmetic, comparison, logical, bitwise)",
+      "testCategories": [
+        "language/expressions/addition",
+        "language/expressions/subtraction",
+        "language/expressions/multiplication",
+        "language/expressions/division",
+        "language/expressions/modulus",
+        "language/expressions/bitwise-and",
+        "language/expressions/bitwise-or",
+        "language/expressions/bitwise-xor",
+        "language/expressions/bitwise-not",
+        "language/expressions/left-shift",
+        "language/expressions/right-shift",
+        "language/expressions/unsigned-right-shift",
+        "language/expressions/equals",
+        "language/expressions/does-not-equals",
+        "language/expressions/strict-equals",
+        "language/expressions/strict-does-not-equals",
+        "language/expressions/less-than",
+        "language/expressions/less-than-or-equal",
+        "language/expressions/greater-than",
+        "language/expressions/greater-than-or-equal",
+        "language/expressions/logical-and",
+        "language/expressions/logical-or",
+        "language/expressions/logical-not",
+        "language/expressions/unary-plus",
+        "language/expressions/unary-minus",
+        "language/expressions/conditional",
+        "language/expressions/grouping",
+        "language/expressions/postfix-increment",
+        "language/expressions/postfix-decrement",
+        "language/expressions/prefix-increment",
+        "language/expressions/prefix-decrement",
+        "language/expressions/in",
+        "language/expressions/void",
+        "language/expressions/concatenation",
+        "language/expressions/relational"
+      ],
+      "passCount": 916,
+      "totalCount": 1083
+    },
+    {
+      "name": "typeof / instanceof",
+      "testCategories": ["language/expressions/typeof", "language/expressions/instanceof"],
+      "passCount": 36,
+      "totalCount": 59
+    },
+    {
+      "name": "delete operator",
+      "testCategories": ["language/expressions/delete"],
+      "passCount": 59,
+      "totalCount": 69
+    },
+    {
+      "name": "Comma operator",
+      "testCategories": ["language/expressions/comma"],
+      "passCount": 5,
+      "totalCount": 6
+    },
+    {
+      "name": "Labeled statements (break / continue)",
+      "testCategories": ["language/statements/labeled"],
+      "passCount": 21,
+      "totalCount": 24
+    },
+    {
+      "name": "for-in",
+      "testCategories": ["language/statements/for-in"],
+      "passCount": 102,
+      "totalCount": 119
+    },
+    {
+      "name": "arguments object (full)",
+      "testCategories": ["language/arguments-object"],
+      "passCount": 118,
+      "totalCount": 263
+    },
+    {
+      "name": "eval()",
+      "testCategories": ["language/eval-code", "built-ins/eval"],
+      "passCount": 332,
+      "totalCount": 357
+    },
+    {
+      "name": "with statement",
+      "testCategories": ["language/statements/with", "annexB/language/statements/with"],
+      "passCount": 96,
+      "totalCount": 181
+    },
+    {
+      "name": "Variables (var, let, const)",
+      "testCategories": [
+        "language/statements/let",
+        "language/statements/const",
+        "language/statements/variable",
+        "language/block-scope"
+      ],
+      "passCount": 526,
+      "totalCount": 604
+    },
+    {
+      "name": "Functions & closures",
+      "testCategories": ["language/statements/function", "language/function-code", "built-ins/Function"],
+      "passCount": 869,
+      "totalCount": 1177
+    },
+    {
+      "name": "Control flow",
+      "testCategories": [
+        "language/statements/if",
+        "language/statements/switch",
+        "language/statements/while",
+        "language/statements/do-while",
+        "language/statements/for",
+        "language/statements/break",
+        "language/statements/continue",
+        "language/statements/return"
+      ],
+      "passCount": 612,
+      "totalCount": 699
+    },
+    {
+      "name": "try / catch / finally",
+      "testCategories": ["language/statements/try"],
+      "passCount": 180,
+      "totalCount": 201
+    },
+    {
+      "name": "throw",
+      "testCategories": ["language/statements/throw"],
+      "passCount": 12,
+      "totalCount": 14
+    },
+    {
+      "name": "Objects",
+      "testCategories": ["language/expressions/object", "built-ins/Object"],
+      "passCount": 3865,
+      "totalCount": 4581
+    },
+    {
+      "name": "Strings",
+      "testCategories": ["built-ins/String", "built-ins/StringIteratorPrototype"],
+      "passCount": 999,
+      "totalCount": 1230
+    },
+    {
+      "name": "Numbers",
+      "testCategories": ["built-ins/Number", "built-ins/Math"],
+      "passCount": 610,
+      "totalCount": 667
+    },
+    {
+      "name": "JSON",
+      "testCategories": ["built-ins/JSON"],
+      "passCount": 90,
+      "totalCount": 165
+    },
+    {
+      "name": "Error types",
+      "testCategories": [
+        "built-ins/Error",
+        "built-ins/NativeErrors",
+        "built-ins/AggregateError",
+        "built-ins/SuppressedError"
+      ],
+      "passCount": 83,
+      "totalCount": 234
+    },
+    {
+      "name": "Arrays",
+      "testCategories": ["built-ins/Array", "built-ins/ArrayIteratorPrototype", "language/expressions/array"],
+      "passCount": 1696,
+      "totalCount": 3161
+    },
+    {
+      "name": "Regular expressions",
+      "testCategories": ["built-ins/RegExp", "built-ins/RegExpStringIteratorPrototype"],
+      "passCount": 1589,
+      "totalCount": 1896
+    },
+    {
+      "name": "Property accessors (get / set)",
+      "testCategories": ["language/expressions/property-accessors"],
+      "passCount": 15,
+      "totalCount": 21
+    },
+    {
+      "name": "Object.defineProperty (full)",
+      "testCategories": ["built-ins/Object/defineProperty"],
+      "passCount": 1053,
+      "totalCount": 1131
+    },
+    {
+      "name": "Arrow functions",
+      "testCategories": ["language/expressions/arrow-function", "language/expressions/async-arrow-function"],
+      "passCount": 341,
+      "totalCount": 440
+    },
+    {
+      "name": "Template literals",
+      "testCategories": ["language/expressions/template-literal", "language/expressions/tagged-template"],
+      "passCount": 0,
+      "totalCount": 1
+    },
+    {
+      "name": "Destructuring",
+      "testCategories": ["language/destructuring"],
+      "passCount": 3618,
+      "totalCount": 4290
+    },
+    {
+      "name": "Spread / rest operators",
+      "testCategories": ["language/rest-parameters"],
+      "passCount": 60,
+      "totalCount": 60
+    },
+    {
+      "name": "Default parameters",
+      "testCategories": ["language/statements/function/default-parameter"],
+      "passCount": 1328,
+      "totalCount": 1552
+    },
+    {
+      "name": "Computed property names",
+      "testCategories": ["language/computed-property-names"],
+      "passCount": 70,
+      "totalCount": 133
+    },
+    {
+      "name": "for-of",
+      "testCategories": ["language/statements/for-of"],
+      "passCount": 2,
+      "totalCount": 4
+    },
+    {
+      "name": "Generators (function*, yield)",
+      "testCategories": [
+        "language/statements/generators",
+        "language/expressions/generators",
+        "language/expressions/yield",
+        "built-ins/GeneratorFunction",
+        "built-ins/GeneratorPrototype"
+      ],
+      "passCount": 1751,
+      "totalCount": 2486
+    },
+    {
+      "name": "Classes",
+      "testCategories": [
+        "language/expressions/class",
+        "language/statements/class",
+        "language/expressions/super",
+        "language/expressions/new",
+        "language/expressions/new.target"
+      ],
+      "passCount": 321,
+      "totalCount": 461
+    },
+    {
+      "name": "Map / Set",
+      "testCategories": [
+        "built-ins/Map",
+        "built-ins/Set",
+        "built-ins/MapIteratorPrototype",
+        "built-ins/SetIteratorPrototype",
+        "built-ins/WeakMap",
+        "built-ins/WeakSet"
+      ],
+      "passCount": 110,
+      "totalCount": 129
+    },
+    {
+      "name": "Symbol",
+      "testCategories": ["built-ins/Symbol"],
+      "passCount": 697,
+      "totalCount": 1955
+    },
+    {
+      "name": "TypedArray / ArrayBuffer",
+      "testCategories": [
+        "built-ins/TypedArray",
+        "built-ins/TypedArrayConstructors",
+        "built-ins/ArrayBuffer",
+        "built-ins/DataView",
+        "built-ins/Uint8Array"
+      ],
+      "passCount": 290,
+      "totalCount": 1106
+    },
+    {
+      "name": "Modules (import / export)",
+      "testCategories": ["language/module-code", "language/import", "language/export"],
+      "passCount": 0,
+      "totalCount": 0
+    },
+    {
+      "name": "Proxy / Reflect",
+      "testCategories": ["built-ins/Proxy", "built-ins/Reflect"],
+      "passCount": 447,
+      "totalCount": 1072
+    },
+    {
+      "name": "Promise .then / .catch / .finally",
+      "testCategories": ["built-ins/Promise"],
+      "passCount": 2,
+      "totalCount": 3
+    },
+    {
+      "name": "async / await",
+      "testCategories": [
+        "built-ins/AsyncFunction",
+        "language/expressions/await",
+        "language/expressions/async-function",
+        "language/statements/async-function"
+      ],
+      "passCount": 284,
+      "totalCount": 348
+    },
+    {
+      "name": "Object.entries / values",
+      "testCategories": ["built-ins/Object/entries", "built-ins/Object/values"],
+      "passCount": 0,
+      "totalCount": 0
+    },
+    {
+      "name": "SharedArrayBuffer / Atomics",
+      "testCategories": ["built-ins/SharedArrayBuffer", "built-ins/Atomics"],
+      "passCount": 60,
+      "totalCount": 342
+    },
+    {
+      "name": "Object spread / rest",
+      "testCategories": ["language/expressions/object/spread"],
+      "passCount": 173,
+      "totalCount": 401
+    },
+    {
+      "name": "Async iteration (for-await-of)",
+      "testCategories": [
+        "built-ins/AsyncGeneratorFunction",
+        "built-ins/AsyncGeneratorPrototype",
+        "built-ins/AsyncIteratorPrototype",
+        "built-ins/AsyncFromSyncIteratorPrototype",
+        "language/expressions/async-generator",
+        "language/statements/async-generator"
+      ],
+      "passCount": 2520,
+      "totalCount": 3812
+    },
+    {
+      "name": "Optional chaining (?.)",
+      "testCategories": ["language/expressions/optional-chaining"],
+      "passCount": 33,
+      "totalCount": 52
+    },
+    {
+      "name": "Nullish coalescing (??)",
+      "testCategories": ["language/expressions/coalesce"],
+      "passCount": 22,
+      "totalCount": 25
+    },
+    {
+      "name": "globalThis",
+      "testCategories": ["built-ins/global", "built-ins/globalThis"],
+      "passCount": 96,
+      "totalCount": 122
+    },
+    {
+      "name": "BigInt",
+      "testCategories": ["built-ins/BigInt"],
+      "passCount": 262,
+      "totalCount": 1048
+    },
+    {
+      "name": "Dynamic import()",
+      "testCategories": ["language/expressions/dynamic-import"],
+      "passCount": 152,
+      "totalCount": 557
+    },
+    {
+      "name": "WeakRef / FinalizationRegistry",
+      "testCategories": ["built-ins/WeakRef", "built-ins/FinalizationRegistry"],
+      "passCount": 32,
+      "totalCount": 82
+    },
+    {
+      "name": "Class fields (public, private, static)",
+      "testCategories": ["language/statements/class/fields"],
+      "passCount": 3300,
+      "totalCount": 4979
+    },
+    {
+      "name": "Error.cause",
+      "testCategories": ["built-ins/Error/cause"],
+      "passCount": 0,
+      "totalCount": 5
+    },
+    {
+      "name": "Array.at / String.at",
+      "testCategories": ["built-ins/Array/prototype/at", "built-ins/String/prototype/at"],
+      "passCount": 16,
+      "totalCount": 36
+    },
+    {
+      "name": "Top-level await",
+      "testCategories": ["language/module-code/top-level-await"],
+      "passCount": 176,
+      "totalCount": 257
+    },
+    {
+      "name": "Array.prototype.includes",
+      "testCategories": ["built-ins/Array/prototype/includes"],
+      "passCount": 16,
+      "totalCount": 29
+    },
+    {
+      "name": "Exponentiation operator (**)",
+      "testCategories": ["language/expressions/exponentiation"],
+      "passCount": 50,
+      "totalCount": 72
+    },
+    {
+      "name": "Optional catch binding",
+      "testCategories": ["language/statements/try/optional-catch-binding"],
+      "passCount": 4,
+      "totalCount": 5
+    },
+    {
+      "name": "Array.prototype.flat / flatMap",
+      "testCategories": ["built-ins/Array/prototype/flat", "built-ins/Array/prototype/flatMap"],
+      "passCount": 9,
+      "totalCount": 35
+    },
+    {
+      "name": "Object.fromEntries",
+      "testCategories": ["built-ins/Object/fromEntries"],
+      "passCount": 6,
+      "totalCount": 25
+    },
+    {
+      "name": "Array.findLast / findLastIndex",
+      "testCategories": ["built-ins/Array/prototype/findLast", "built-ins/Array/prototype/findLastIndex"],
+      "passCount": 34,
+      "totalCount": 109
+    },
+    {
+      "name": "Change array by copy (toSorted, toReversed, toSpliced)",
+      "testCategories": [
+        "built-ins/Array/prototype/toSorted",
+        "built-ins/Array/prototype/toReversed",
+        "built-ins/Array/prototype/toSpliced"
+      ],
+      "passCount": 42,
+      "totalCount": 132
+    },
+    {
+      "name": "Hashbang (#!) comments",
+      "testCategories": ["language/comments/hashbang", "language/source-text"],
+      "passCount": 28,
+      "totalCount": 29
+    },
+    {
+      "name": "Promise.withResolvers",
+      "testCategories": ["built-ins/Promise/withResolvers"],
+      "passCount": 2,
+      "totalCount": 9
+    },
+    {
+      "name": "Resizable ArrayBuffer",
+      "testCategories": ["built-ins/ArrayBuffer/prototype/resize"],
+      "passCount": 0,
+      "totalCount": 18
+    },
+    {
+      "name": "RegExp v flag",
+      "testCategories": ["built-ins/RegExp/unicodeSets"],
+      "passCount": 180,
+      "totalCount": 187
+    },
+    {
+      "name": "Set methods (union, intersection, difference)",
+      "testCategories": [
+        "built-ins/Set/prototype/union",
+        "built-ins/Set/prototype/intersection",
+        "built-ins/Set/prototype/difference",
+        "built-ins/Set/prototype/symmetricDifference",
+        "built-ins/Set/prototype/isSubsetOf",
+        "built-ins/Set/prototype/isSupersetOf",
+        "built-ins/Set/prototype/isDisjointFrom"
+      ],
+      "passCount": 151,
+      "totalCount": 186
+    },
+    {
+      "name": "Iterator helpers (map, filter, take)",
+      "testCategories": ["built-ins/Iterator"],
+      "passCount": 109,
+      "totalCount": 393
+    },
+    {
+      "name": "RegExp duplicate named groups",
+      "testCategories": ["built-ins/RegExp/named-groups"],
+      "passCount": 0,
+      "totalCount": 16
+    },
+    {
+      "name": "Error.isError",
+      "testCategories": [],
+      "passCount": 2,
+      "totalCount": 12
+    },
+    {
+      "name": "Upsert (Map.getOrInsert)",
+      "testCategories": [],
+      "passCount": 47,
+      "totalCount": 72
+    },
+    {
+      "name": "Array.fromAsync",
+      "testCategories": [],
+      "passCount": 4,
+      "totalCount": 95
+    },
+    {
+      "name": "Math.sumPrecise",
+      "testCategories": [],
+      "passCount": 0,
+      "totalCount": 10
+    },
+    {
+      "name": "Iterator sequencing (Iterator.concat)",
+      "testCategories": [],
+      "passCount": 10,
+      "totalCount": 32
+    },
+    {
+      "name": "Uint8Array to/from Base64",
+      "testCategories": [],
+      "passCount": 7,
+      "totalCount": 68
+    },
+    {
+      "name": "JSON.parse source text access",
+      "testCategories": [],
+      "passCount": 15,
+      "totalCount": 21
+    },
+    {
+      "name": "var hoisting",
+      "testCategories": ["language/statements/variable", "language/statements/var"],
+      "passCount": 157,
+      "totalCount": 178
+    },
+    {
+      "name": "arguments.callee",
+      "testCategories": ["language/arguments-object/callee"],
+      "passCount": 0,
+      "totalCount": 0
+    },
+    {
+      "name": "__proto__ accessor",
+      "testCategories": ["annexB/language/expressions/object/__proto__"],
+      "passCount": 0,
+      "totalCount": 0
+    },
+    {
+      "name": "String.prototype.substr",
+      "testCategories": ["annexB/built-ins/String/prototype/substr"],
+      "passCount": 13,
+      "totalCount": 15
+    },
+    {
+      "name": "Octal literals (0777)",
+      "testCategories": ["annexB/language/literals/numeric"],
+      "passCount": 0,
+      "totalCount": 0
+    },
+    {
+      "name": "escape() / unescape()",
+      "testCategories": ["annexB/built-ins/escape", "annexB/built-ins/unescape"],
+      "passCount": 19,
+      "totalCount": 35
+    },
+    {
+      "name": "Function.prototype.caller",
+      "testCategories": ["annexB/built-ins/Function/prototype/caller"],
+      "passCount": 0,
+      "totalCount": 0
+    },
+    {
+      "name": "HTML string methods (.bold(), .anchor())",
+      "testCategories": [
+        "annexB/built-ins/String/prototype/anchor",
+        "annexB/built-ins/String/prototype/big",
+        "annexB/built-ins/String/prototype/blink",
+        "annexB/built-ins/String/prototype/bold",
+        "annexB/built-ins/String/prototype/fixed",
+        "annexB/built-ins/String/prototype/fontcolor",
+        "annexB/built-ins/String/prototype/fontsize",
+        "annexB/built-ins/String/prototype/italics",
+        "annexB/built-ins/String/prototype/link",
+        "annexB/built-ins/String/prototype/small",
+        "annexB/built-ins/String/prototype/strike",
+        "annexB/built-ins/String/prototype/sub",
+        "annexB/built-ins/String/prototype/sup"
+      ],
+      "passCount": 4,
+      "totalCount": 82
+    },
+    {
+      "name": "RegExp.$1 static properties",
+      "testCategories": ["annexB/built-ins/RegExp/legacy-accessors"],
+      "passCount": 1,
+      "totalCount": 24
+    },
+    {
+      "name": "Hono-style router (Map + closures + classes)",
+      "testCategories": [],
+      "passCount": 0,
+      "totalCount": 0
+    },
+    {
+      "name": "Temporal",
+      "testCategories": ["built-ins/Temporal"],
+      "passCount": 0,
+      "totalCount": 0
+    },
+    {
+      "name": "Decorators",
+      "testCategories": [],
+      "passCount": 0,
+      "totalCount": 0
+    },
+    {
+      "name": "Pattern matching",
+      "testCategories": [],
+      "passCount": 0,
+      "totalCount": 0
+    }
+  ],
+  "features_generated": "2026-08-09T23:53:24.533Z"
+}


### PR DESCRIPTION
## Description

Follow-up to #4370. That PR removed a wrong `host` label from the `eval()` row; this one fixes *why* the label was load-bearing.

The "JS host" toggle looks like it switches the whole conformance view between the js-host and standalone lanes. It only did that for the headline donut:

| Layer | Toggled? | Why not |
| --- | --- | --- |
| Headline donut + pass rate | ✅ | — |
| Per-edition pass bars | ❌ | `loadEditionBuckets()` unconditionally fetched `test262-editions.json` and memoised it — the toggle re-rendered identical numbers |
| Row badge / `N / M` chip / `NN%` | ❌ | `hydrateFeatureBadges` ran once and never re-ran |
| Edition pass-rate-over-time | ❌ | set `points = null` with the toggle off and hid the chart outright |

So the toggle's only real effect on the feature list was cosmetic: dim rows tagged `feat-host` and rewrite their badge to a red `×`. **64 of 88 rows differ between lanes**, and not always in the guessable direction:

| row | js-host | standalone |
| --- | --- | --- |
| `eval()` | 158 / 357 (44%) | **332 / 357 (93%)** |
| `with statement` | 69 / 181 | **96 / 181** |
| `arguments object (full)` | **184 / 263** | 118 / 263 |
| `typeof / instanceof` | **42 / 59** | 36 / 59 |

## Changes

**Data** — `generate-editions.ts` gains `--feature-examples-out`, so the standalone lane writes host-free counts to a separate `feature-examples-standalone.json` instead of being skipped. Patching in place was not an option: it would overwrite the host counts and show standalone numbers in *both* toggle positions — the same bug mirrored. The twin is **slim** (name, `testCategories`, two counts): the host catalog is ~4 MB, ~96% of it lane-independent `tests[]` failure lists, so duplicating them would ship megabytes to convey ~20 KB of differing numbers. 4 MB → **19.8 KB**.

**History** — `append-run-history.mjs` gains `--standalone-editions` → `runs/standalone-editions-index.json`; the promote-baseline step generates host-free edition buckets and feeds them in; `deploy-pages.yml` fetches it.

**Page** — `loadEditionBuckets` memoised per lane; `updateEditionPassBars` reads the toggle; `hydrateFeatureBadges` becomes a re-appliable `applyFeatureBadges(hostEnabled)` that the toggle calls **before** the host-row `×` override (order is load-bearing — it rewrites every badge, so running it after would undo the override); the edition trend chart reads the standalone series.

## Deliberate limits

- **The standalone edition trend series is not backfilled** — no historical standalone edition snapshots exist, so it starts empty and grows one entry per promote. The existing `< 2 points` guard hides the chart until there's something real. It deliberately does **not** fall back to the host series; a host curve under a "standalone" label is the class of quietly-wrong number this PR removes.
- **Pre-existing, not fixed here:** `editions-index.json` and `standalone-index.json` each hold exactly **one** entry on `main`, so the *host* per-edition trend is itself barely renderable. The append pipeline works; it has simply run once. The new standalone series inherits that thinness.
- A missing twin (older deploy) degrades to host numbers rather than blank rows — pinned by a test.

## Verification

- `tests/issue-4362-landing-host-standalone-toggle.test.ts` drives the **real** `website/index.html` in jsdom and asserts chip, percentage and report link all follow the toggle and round-trip. **Confirmed to fail on the pre-fix page** (`expected '158 / 357' to be '332 / 357'`) — not vacuous.
- `tests/issue-4362-feature-examples-out.test.ts` — twin gets recomputed counts, source catalog stays byte-identical, twin is slim, in-place patching still works.
- Ran the real generator over the fetched standalone baseline JSONL (48,735 entries): 51 tag-sliced, 29 path-scored, 8 headline-only.
- 25 tests pass across the new and neighbouring suites; `tsc --noEmit` and prettier clean; both edited workflows parse. All pre-commit and pre-push gates ran (no `--no-verify` this time).

Issue file: `plan/issues/4362-landing-host-toggle-does-not-remeasure.md`. Id reserved via `claim-issue.mjs --allocate`; `gh` is unavailable in this container so the open-PR scan was degraded — I ran the equivalent scan via the GitHub MCP (only #4369, an artifact-refresh branch introducing no issue file), as precedent in #4242.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: agreeing to a CLA is the human author's call. Per the template, internal/org-member PRs skip this check automatically. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2956JSaqQyDp3s5TAXCLh)_