### PR TITLE
fix(site): correct 9 false "host" labels + compact the test262 source lists (#4362)

### DIFF
--- a/plan/issues/4362-landing-host-toggle-does-not-remeasure.md
+++ b/plan/issues/4362-landing-host-toggle-does-not-remeasure.md
@@ -105,6 +105,66 @@ reads the standalone series instead of hiding.
   host numbers — the pre-#4362 behaviour, and strictly better than blank rows.
   Pinned by a test.
 
+## Phase 2 — content audit of the feature table (2026-08-11)
+
+With the toggle actually re-measuring, the **static** `feat-host` labels became
+auditable against data for the first time. `feat-host` renders a row as a red
+`×` scored 0 when the toggle is off, i.e. it asserts *"not available without a
+JS host"*. Of 24 labelled rows, **9 were measurably false**:
+
+| row | js-host | standalone (host-free) |
+| --- | --- | --- |
+| Map / Set | 88% | **85%** |
+| Regular expressions | 95% | **84%** |
+| async / await | 85% | **82%** |
+| Set methods (union, intersection, difference) | 90% | **81%** |
+| globalThis | 39% | **79%** |
+| Promise .then / .catch / .finally | 67% | **67%** |
+| Async iteration (for-await-of) | 67% | **66%** |
+| JSON | 73% | **55%** |
+| Arrays | 64% | **54%** |
+
+Confirmed by compiling one snippet per row with `target: "standalone"` and
+inspecting the module: **each produced a binary with ZERO imports that
+instantiated and ran**. A feature that compiles to a zero-import module is not
+host-dependent, whatever the label said.
+
+Labels removed from those 9. Two prose claims were disproven by the same probes
+and rewritten:
+
+- *"ES2025 Set methods. Requires host import for Set operations."* — no host
+  import is involved; a standalone build has no imports at all.
+- *"Chained .then/.catch/.finally callbacks need the host microtask queue to
+  run."* — they run on a Wasm-native microtask queue; the probe ran host-free.
+
+**Left in place, deliberately:** the 15 rows still labelled `host` all sit
+below 50% host-free (WeakRef 39% down to Resizable ArrayBuffer 0%). The `×`
+arguably still overstates the gap for the mid-range ones (Symbol 36%,
+TypedArray 26%), but "how a partially-working feature should render in
+standalone" is a design question about the badge vocabulary, not a false
+statement to correct. Filed as a follow-up thought rather than changed here.
+
+**Checked and NOT changed** — four rows make specific "not implemented" claims;
+all four were verified **still true** by compiling and running them, so the
+prose stands:
+
+| row | probe result |
+| --- | --- |
+| Uint8Array to/from Base64 | `fromBase64 is not a function` |
+| Math.sumPrecise | `sumPrecise is not a function` |
+| Iterator sequencing | `Iterator.concat` yields an empty sequence |
+| Array.fromAsync | resolves to an empty array (`len=0`) |
+
+## Phase 2b — compact test262 source lists
+
+The "test262 source:" block in an expanded row printed every mapped path in
+full. The Operators row maps **35** paths, all repeating
+`language/expressions/` — 1,150 characters, making the list the tallest element
+in the row. Now the shared directory is factored into the label and stripped
+from each link (full path preserved in `href` + `title`), and only the first 6
+render, with the rest behind a `+N` button: **~83 characters, 93% less text**.
+Font/gap/margins tightened to match. Single-path rows are unchanged.
+
 ## Verification
 
 - `tests/issue-4362-landing-host-standalone-toggle.test.ts` — drives the real
@@ -117,3 +177,9 @@ reads the standalone series instead of hiding.
   and in-place patching still works when no out path is given.
 - Ran the real generator over the fetched standalone baseline JSONL
   (48,735 entries): 51 tag-sliced, 29 path-scored, 8 headline-only rows.
+- `tests/issue-4362-test262-paths-compact.test.ts` — prefix factoring, the
+  6-link cap, the `+N` reveal, that `+N` does not collapse the row it sits in
+  (the row toggles `<details>` on click, so the button must stop propagation),
+  and that a single-path row is left alone.
+- Every Phase-2 label removal and prose rewrite is backed by a
+  `target: "standalone"` compile producing a zero-import module that ran.

--- a/tests/issue-4362-test262-paths-compact.test.ts
+++ b/tests/issue-4362-test262-paths-compact.test.ts
@@ -1,0 +1,130 @@
+// #4362 follow-up — the "test262 source:" block inside an expanded feature row
+// must stay compact.
+//
+// Rows map to as many as 35 test262 paths (the Operators row), and the block
+// printed every one in full. Since those paths share a long directory
+// (`language/expressions/` repeated 35 times), the list became the tallest
+// element in an expanded row while carrying very little distinguishing text.
+//
+// Two mechanisms keep it small, and both are pinned here because both are easy
+// to regress into "just print the paths":
+//   1. the shared directory is factored into the label and stripped from each
+//      link (full path stays in href + title, so nothing is lost),
+//   2. only the first 6 links render; the rest sit behind a `+N` button.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM, VirtualConsole } from "jsdom";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const INDEX_HTML = resolve(import.meta.dirname, "..", "website", "index.html");
+
+const MANY_PATHS = [
+  "language/expressions/addition",
+  "language/expressions/subtraction",
+  "language/expressions/multiplication",
+  "language/expressions/division",
+  "language/expressions/modulus",
+  "language/expressions/bitwise-and",
+  "language/expressions/bitwise-or",
+  "language/expressions/bitwise-xor",
+  "language/expressions/left-shift",
+  "language/expressions/right-shift",
+];
+const OPERATORS_ROW = "Operators (arithmetic, comparison, logical, bitwise)";
+
+const catalog = {
+  features: [
+    { name: OPERATORS_ROW, testCategories: MANY_PATHS, passCount: 936, totalCount: 1083 },
+    // Single-path row: nothing to factor, nothing to hide.
+    { name: "JSON", testCategories: ["built-ins/JSON"], passCount: 120, totalCount: 165 },
+  ],
+};
+
+let dom: JSDOM;
+
+beforeAll(async () => {
+  const html = readFileSync(INDEX_HTML, "utf8");
+  dom = new JSDOM(html, {
+    runScripts: "dangerously",
+    pretendToBeVisual: true,
+    url: "https://js2wasm.test/",
+    virtualConsole: new VirtualConsole(),
+    beforeParse(w: any) {
+      w.matchMedia = () => ({
+        matches: false,
+        addEventListener() {},
+        removeEventListener() {},
+        addListener() {},
+        removeListener() {},
+      });
+      w.scrollTo = () => {};
+      w.IntersectionObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+      w.fetch = async (u: unknown) => {
+        const s = String(u);
+        return s.includes("feature-examples.json") && !s.includes("standalone")
+          ? { ok: true, status: 200, json: async () => catalog }
+          : { ok: false, status: 404, json: async () => ({}) };
+      };
+    },
+  });
+  await new Promise((r) => setTimeout(r, 1500));
+}, 60_000);
+afterAll(() => dom?.window?.close());
+
+function box(name: string) {
+  const row = [...dom.window.document.querySelectorAll(".feat-row")].find(
+    (r) => (r as HTMLElement).dataset.featName === name,
+  );
+  const el = row?.querySelector(".feat-test262-paths");
+  return {
+    row,
+    el,
+    label: el?.querySelector(".feat-test262-paths-label")?.textContent,
+    links: [...(el?.querySelectorAll("a") ?? [])] as HTMLAnchorElement[],
+    more: el?.querySelector(".feat-test262-paths-more") as HTMLButtonElement | null,
+  };
+}
+
+describe("#4362 compact test262 source list", () => {
+  it("factors the shared directory into the label", () => {
+    expect(box(OPERATORS_ROW).label).toBe("test262 language/expressions/");
+  });
+
+  it("renders at most 6 links, with the rest behind +N", () => {
+    const b = box(OPERATORS_ROW);
+    expect(b.links).toHaveLength(MANY_PATHS.length);
+    expect(b.links.filter((a) => !a.hidden)).toHaveLength(6);
+    expect(b.more?.textContent).toBe("+4");
+  });
+
+  it("strips the prefix from link text but keeps the full path addressable", () => {
+    const b = box(OPERATORS_ROW);
+    expect(b.links[0].textContent).toBe("addition");
+    // Nothing is lost: href and tooltip still carry the full path.
+    expect(b.links[0].title).toBe("language/expressions/addition");
+    expect(b.links[0].getAttribute("href")).toBe(
+      "https://github.com/tc39/test262/tree/main/test/language/expressions/addition",
+    );
+  });
+
+  it("+N expands without collapsing the row it sits in", () => {
+    const b = box(OPERATORS_ROW);
+    const detailsOpenBefore = b.row?.querySelector("details")?.hasAttribute("open");
+    b.more!.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+    expect(b.links.filter((a) => !a.hidden)).toHaveLength(MANY_PATHS.length);
+    // The row toggles <details> on click, so the button must stop propagation
+    // — otherwise expanding the list collapses the row that contains it.
+    expect(b.row?.querySelector("details")?.hasAttribute("open")).toBe(detailsOpenBefore);
+  });
+
+  it("leaves a single-path row alone (no prefix, no +N)", () => {
+    const b = box("JSON");
+    expect(b.label).toBe("test262");
+    expect(b.links[0].textContent).toBe("built-ins/JSON");
+    expect(b.more).toBeNull();
+  });
+});

--- a/website/index.html
+++ b/website/index.html
@@ -1546,19 +1546,21 @@
       /* #1583 — test262 source-path links inside an expanded feat-row
          `<details>` body. */
       .feat-test262-paths {
-        margin: 8px 0 4px;
-        font-size: 12px;
+        margin: 5px 0 2px;
+        font-size: 10px;
+        line-height: 1.45;
         font-family: var(--mono);
         color: var(--fg-faint);
         display: flex;
         flex-wrap: wrap;
-        gap: 6px 10px;
+        gap: 1px 6px;
         align-items: baseline;
       }
       .feat-test262-paths-label {
         text-transform: uppercase;
-        letter-spacing: 0.08em;
-        font-size: 10px;
+        letter-spacing: 0.06em;
+        font-size: 9px;
+        opacity: 0.75;
       }
       .feat-test262-paths a {
         color: var(--accent, #60a5fa);
@@ -1568,6 +1570,22 @@
       .feat-test262-paths a:hover {
         opacity: 1;
         text-decoration: underline;
+      }
+      /* "+N" reveals the long tail; sized to sit inline with the links. */
+      .feat-test262-paths-more {
+        font-family: inherit;
+        font-size: inherit;
+        line-height: inherit;
+        color: var(--fg-faint);
+        background: rgba(255, 255, 255, 0.06);
+        border: 0;
+        border-radius: 3px;
+        padding: 0 4px;
+        cursor: pointer;
+      }
+      .feat-test262-paths-more:hover {
+        color: var(--fg);
+        background: rgba(255, 255, 255, 0.12);
       }
 
       @media (max-width: 980px) {
@@ -2216,7 +2234,6 @@ parseInt("42");
               </div>
               <div class="feat-row" data-t262-paths="built-ins/JSON">
                 <span class="feat-badge partial">⚠</span>
-                <span class="feat-host">host</span>
                 <span class="feat-name">JSON</span>
                 <span class="feat-desc">Parse and stringify JSON data</span>
                 <details>
@@ -2260,7 +2277,6 @@ throw new RangeError("out of bounds");</pre
                 data-t262-paths="built-ins/Array,built-ins/ArrayIteratorPrototype,language/expressions/array"
               >
                 <span class="feat-badge partial">⚠</span>
-                <span class="feat-host">host</span>
                 <span class="feat-name">Arrays</span>
                 <span class="feat-desc">Array methods and iteration helpers</span>
                 <details>
@@ -2287,7 +2303,6 @@ const found = arr.find(x =&gt; x &gt; 5);</pre
               </div>
               <div class="feat-row" data-t262-paths="built-ins/RegExp,built-ins/RegExpStringIteratorPrototype">
                 <span class="feat-badge full">✓</span>
-                <span class="feat-host">host</span>
                 <span class="feat-name">Regular expressions</span>
                 <span class="feat-desc">Pattern matching and string search</span>
                 <details>
@@ -2581,7 +2596,6 @@ class Dog extends Animal { }</pre
                 data-t262-paths="built-ins/Map,built-ins/Set,built-ins/MapIteratorPrototype,built-ins/SetIteratorPrototype"
               >
                 <span class="feat-badge partial">⚠</span>
-                <span class="feat-host">host</span>
                 <span class="feat-name">Map / Set</span>
                 <span class="feat-desc">Key-value and unique-value collections</span>
                 <details>
@@ -2696,15 +2710,15 @@ new Proxy(t, handler);      // trap dispatch not yet</pre
               </div>
               <div class="feat-row" data-t262-paths="built-ins/Promise">
                 <span class="feat-badge partial">⚠</span>
-                <span class="feat-host">host</span>
                 <span class="feat-name">Promise .then / .catch / .finally</span>
                 <span class="feat-desc">Promise chaining and error handling</span>
                 <details>
                   <summary></summary>
-                  <pre>Promise.resolve(1).then(v => v + 1); // callbacks need host microtasks</pre>
+                  <pre>Promise.resolve(1).then(v => v + 1);</pre>
                   <div class="feat-explain">
-                    Promise construction and Promise.resolve/all/race work. Chained .then/.catch/.finally callbacks need
-                    the host microtask queue to run.
+                    Promise construction, Promise.resolve/all/race and chained .then/.catch/.finally callbacks all run
+                    on a Wasm-native microtask queue — a standalone build of this compiles to a module with no imports
+                    at all. The remaining gaps are unsettled-rejection and ordering edge cases.
                   </div>
                 </details>
               </div>
@@ -2716,7 +2730,6 @@ new Proxy(t, handler);      // trap dispatch not yet</pre
                 data-t262-paths="built-ins/AsyncFunction,built-ins/AsyncGeneratorFunction,built-ins/AsyncGeneratorPrototype,built-ins/AsyncIteratorPrototype,built-ins/AsyncFromSyncIteratorPrototype"
               >
                 <span class="feat-badge partial">⚠</span>
-                <span class="feat-host">host</span>
                 <span class="feat-name">async / await</span>
                 <span class="feat-desc">Asynchronous functions with synchronous-style syntax</span>
                 <details>
@@ -2796,7 +2809,6 @@ const { a, ...rest } = obj;</pre
                 data-t262-paths="built-ins/AsyncGeneratorFunction,built-ins/AsyncGeneratorPrototype,built-ins/AsyncIteratorPrototype,built-ins/AsyncFromSyncIteratorPrototype,language/expressions/async-generator,language/statements/async-generator"
               >
                 <span class="feat-badge partial">⚠</span>
-                <span class="feat-host">host</span>
                 <span class="feat-name">Async iteration (for-await-of)</span>
                 <span class="feat-desc">Iterate over async data sources</span>
                 <details>
@@ -2858,7 +2870,6 @@ const { a, ...rest } = obj;</pre
               </div>
               <div class="feat-row" data-t262-paths="built-ins/global,built-ins/globalThis">
                 <span class="feat-badge partial">⚠</span>
-                <span class="feat-host">host</span>
                 <span class="feat-name">globalThis</span>
                 <span class="feat-desc">Universal global object reference</span>
                 <details>
@@ -3213,7 +3224,6 @@ buf.resize(16);</pre
                 data-t262-paths="built-ins/Set/prototype/union,built-ins/Set/prototype/intersection,built-ins/Set/prototype/difference,built-ins/Set/prototype/symmetricDifference,built-ins/Set/prototype/isSubsetOf,built-ins/Set/prototype/isSupersetOf,built-ins/Set/prototype/isDisjointFrom"
               >
                 <span class="feat-badge partial">⚠</span>
-                <span class="feat-host">host</span>
                 <span class="feat-name">Set methods (union, intersection, difference)</span>
                 <span class="feat-desc">Built-in set operations</span>
 
@@ -3224,7 +3234,10 @@ const a = new Set([1, 2, 3]);
 const b = new Set([2, 3, 4]);
 a.union(b); // {1,2,3,4}</pre
                   >
-                  <div class="feat-explain">ES2025 Set methods. Requires host import for Set operations.</div>
+                  <div class="feat-explain">
+                    ES2025 Set methods, compiled natively — no host import is involved, and a standalone build emits a
+                    module with no imports.
+                  </div>
                 </details>
               </div>
               <div class="feat-row" data-t262-paths="built-ins/Iterator">
@@ -6457,19 +6470,63 @@ console.log(instance.exports.run()); // &rarr; 55</pre
                 reportLink.textContent = total > 0 ? `View test results (${pass}/${total}) →` : "View test results →";
               }
               if (!details.querySelector(".feat-test262-paths")) {
+                // Compact rendering. Rows map to as many as 35 test262 paths
+                // (Operators), and printing each in full — every one repeating
+                // `language/expressions/` — turned this block into the tallest
+                // thing in an expanded row. Factor the shared directory out
+                // into the label and show only what differs; the full path
+                // stays in each link's `title` and in its href.
+                const commonDir = (list) => {
+                  if (list.length < 2) return "";
+                  const segs = list.map((p) => p.split("/"));
+                  const first = segs[0];
+                  let n = 0;
+                  while (n < first.length - 1 && segs.every((s) => s.length > n + 1 && s[n] === first[n])) n++;
+                  return n > 0 ? first.slice(0, n).join("/") + "/" : "";
+                };
+                const prefix = commonDir(paths);
                 const wrap = document.createElement("div");
                 wrap.className = "feat-test262-paths";
                 const label = document.createElement("span");
                 label.className = "feat-test262-paths-label";
-                label.textContent = "test262 source:";
+                label.textContent = prefix ? `test262 ${prefix}` : "test262";
                 wrap.appendChild(label);
-                for (const p of paths) {
+
+                const VISIBLE = 6;
+                const links = paths.map((p) => {
                   const a = document.createElement("a");
                   a.href = `https://github.com/tc39/test262/tree/main/test/${p}`;
                   a.target = "_blank";
                   a.rel = "noopener";
-                  a.textContent = p;
+                  a.textContent = prefix && p.startsWith(prefix) ? p.slice(prefix.length) : p;
+                  a.title = p;
+                  return a;
+                });
+                links.forEach((a, i) => {
+                  if (i >= VISIBLE) a.hidden = true;
                   wrap.appendChild(a);
+                });
+                // Keep the long tail one click away rather than always-on.
+                if (links.length > VISIBLE) {
+                  const more = document.createElement("button");
+                  more.type = "button";
+                  more.className = "feat-test262-paths-more";
+                  const hidden = links.length - VISIBLE;
+                  more.textContent = `+${hidden}`;
+                  more.title = `Show ${hidden} more test262 path${hidden === 1 ? "" : "s"}`;
+                  more.addEventListener("click", (event) => {
+                    // The row itself toggles <details> on click — this button
+                    // must not collapse the row it just expanded.
+                    event.stopPropagation();
+                    event.preventDefault();
+                    const expanded = more.dataset.expanded === "true";
+                    links.forEach((a, i) => {
+                      if (i >= VISIBLE) a.hidden = expanded;
+                    });
+                    more.dataset.expanded = expanded ? "false" : "true";
+                    more.textContent = expanded ? `+${hidden}` : "−";
+                  });
+                  wrap.appendChild(more);
                 }
                 details.appendChild(wrap);
               }


### PR DESCRIPTION
## Description

Content audit of the `#goals` feature table, now that #4372 made the toggle actually re-measure. Two independent changes.

### 1. Nine `host` labels were measurably false

`feat-host` renders a row as a red `×` scored 0 when the JS-host toggle is off — it asserts *"not available without a JS host"*. Of 24 labelled rows, **9 were wrong**:

| row | js-host | standalone (host-free) |
| --- | --- | --- |
| Map / Set | 88% | **85%** |
| Regular expressions | 95% | **84%** |
| async / await | 85% | **82%** |
| Set methods (union, intersection, difference) | 90% | **81%** |
| globalThis | 39% | **79%** |
| Promise .then / .catch / .finally | 67% | **67%** |
| Async iteration (for-await-of) | 67% | **66%** |
| JSON | 73% | **55%** |
| Arrays | 64% | **54%** |

Not inferred from pass rates alone — I compiled a snippet per row with `target: "standalone"` and inspected the module. **Each produced a binary with ZERO imports that instantiated and ran.** A feature that compiles to a zero-import module is not host-dependent, whatever the label said.

Two prose claims were disproven by the same probes and rewritten:
- *"ES2025 Set methods. Requires host import for Set operations."* — no host import is involved.
- *"Chained .then/.catch/.finally callbacks need the host microtask queue to run."* — they run on a Wasm-native microtask queue; the probe ran host-free with no imports.

**Checked and deliberately NOT changed.** Four rows claim a specific runtime gap. All four were compiled and run, and all four are **still true**, so the prose stands:

| row | probe result |
| --- | --- |
| Uint8Array to/from Base64 | `fromBase64 is not a function` |
| Math.sumPrecise | `sumPrecise is not a function` |
| Iterator sequencing | `Iterator.concat` yields an empty sequence |
| Array.fromAsync | resolves to an empty array (`len=0`) |

The 15 rows still labelled `host` all sit below 50% host-free (WeakRef 39% → Resizable ArrayBuffer 0%). The `×` arguably overstates the gap for mid-range ones like Symbol (36%) and TypedArray (26%), but that is a design question about the badge vocabulary rather than a false statement, so I left it and noted it in the issue file.

### 2. Compact test262 source lists

The "test262 source:" block printed every mapped path in full. The Operators row maps **35** paths, all repeating `language/expressions/` — 1,150 characters, making it the tallest element in an expanded row.

Now the shared directory is factored into the label (`test262 language/expressions/`) and stripped from each link, only the first 6 render, and the rest sit behind a `+N` button. **~83 characters — 93% less text.** Full paths are preserved in each link's `href` and `title`, so nothing is lost. Font size, gaps and margins tightened to match; single-path rows are unchanged.

## Verification

- `tests/issue-4362-test262-paths-compact.test.ts` (new, 5 tests) — prefix factoring, the 6-link cap, the `+N` reveal, that `+N` does **not** collapse the row it sits in (the row toggles `<details>` on click, so the button must stop propagation), and that single-path rows are left alone.
- Existing #4362 toggle tests still pass — the label removals change which rows the toggle overrides, so this is the regression surface that mattered.
- All pre-commit and pre-push gates ran clean (typecheck, lint, prettier, oracle ratchet, coercion-site ratchet, LOC/func budgets).

Issue file updated with the full audit, including the negative results.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: agreeing to a CLA is the human author's call. Per the template, internal/org-member PRs skip this check automatically. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2956JSaqQyDp3s5TAXCLh)_