### PR TITLE
docs(issues): harvest test262 errors — 4 new issues, 2 closed, 4 regression flags

### DIFF
--- a/plan/issues/1073-scope-injection-for-extern-eval.md
+++ b/plan/issues/1073-scope-injection-for-extern-eval.md
@@ -249,3 +249,39 @@ Modified `src/runtime.ts::__extern_eval` handler (Option A — JS-side harness s
 
 Removed blanket `annexB/language/eval-code/` skip filter in `tests/test262-runner.ts`.
 Gap 2 (export syntax) and Gap 3 (indirect eval wiring) tests fail naturally.
+
+---
+
+## Harvest note — 2026-08-11 (residual, `status: done` but not resolved)
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260811-103533` (gitHash `9268d5a5`).
+
+`annexB/language/eval-code` still carries **184 official failures** with the
+same root-cause shape this issue was opened for — harness identifiers not
+visible inside the eval'd string:
+
+| Signature | Count | Directory |
+|---|---|---|
+| `assert is not defined` | 120 | `annexB/language/eval-code` (all) |
+| `null is not a function [in __module_init()]` | 64 | `annexB/language/eval-code` |
+
+The original scoping table recorded **179** failures in this same directory
+("Harness visibility 107 / invalid eval body 48 / indirect-eval wiring 24").
+The count has **not gone down** — it is now 184.
+
+What did change is the identifier: the fix targeted the rewritten names
+(`assert_throws`, `assert_sameValue`, `__assert_count`, `fnGlobalObject`), and
+the failing tests now report the **un-rewritten** `assert`. That is consistent
+with the harness text-rewrite having changed since this fix landed, leaving the
+JS-side shim list matching names the harness no longer emits.
+
+Samples:
+
+- `test/annexB/language/eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js`
+- `test/annexB/language/eval-code/direct/global-switch-case-eval-global-skip-early-err-try.js`
+- `test/annexB/language/eval-code/direct/global-block-decl-eval-global-existing-block-fn-no-init.js`
+
+**Action:** re-open, or file a successor that re-derives the shim list from the
+harness rewrite rather than hard-coding names. Left as `done` pending a
+maintainer call — flagged here so it is not invisible.

--- a/plan/issues/1524-test262-harness-resizable-buffer-ctors-fixture.md
+++ b/plan/issues/1524-test262-harness-resizable-buffer-ctors-fixture.md
@@ -168,3 +168,25 @@ additionally the upstream root cause of the **1,496** default-lane
 before the assertion callback runs). Blast radius is materially larger than
 the recorded 434. Reiterating: cheap, `feasibility: easy`, high-leverage —
 strongest single non-substrate default-lane candidate for `sprint: current`.
+
+---
+
+## Harvest note — 2026-08-11 (symptom moved, family still failing → see #4364)
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260811-103533` (gitHash `9268d5a5`).
+
+`ctors is not defined` is **gone** — that part of the fix holds. But the same
+test family now fails one layer later, at dependency injection:
+
+```
+No dependency provided for extern class "ctor"      (172 records)
+```
+
+**224 official failures** total across 9 distinct extern-class names, dominated
+by callback parameters (`ctor`, `TA`, `sourceCtor`, `targetCtor`,
+`badArrayType`, `nonSharedArrayType`) rather than globals. Directory profile
+matches this issue's family: `built-ins/TypedArray/prototype` (91),
+`built-ins/Array/prototype` (68).
+
+Original scope was 202 tests; the successor bucket is 224. Filed as **#4364**.

--- a/plan/issues/1644-spec-gap-bigint-typed-paths.md
+++ b/plan/issues/1644-spec-gap-bigint-typed-paths.md
@@ -538,3 +538,25 @@ Residual Slice E work after this PR:
 - Native standalone dynamic string parser for non-literal `BigInt(string)` inputs.
 - Native standalone `BigInt.prototype.toString(radix)` helper parity with Slice D
   host imports.
+
+---
+
+## Harvest note — 2026-08-11 (count grew after close → see #4363)
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260811-103533` (gitHash `9268d5a5`).
+
+This issue closed scoped at **47 test262 fails**. The BigInt typed-path family
+now carries **287 official failures**, all one signature:
+
+```
+TypeError: Cannot convert N to a BigInt (Testing with BigInt64Array and makeArray.)
+```
+
+concentrated in `built-ins/TypedArray/prototype` (222) and
+`built-ins/TypedArrayConstructors/internals` (54).
+
+Whether this is a regression of this fix or an always-present adjacent bucket
+that this issue never covered is **not yet determined**. Filed as **#4363** for
+that determination; the leading hypothesis there is the same "typed paths assume
+f64 too eagerly" failure mode this issue was named for.

--- a/plan/issues/4020-test262-js-sources-rejected-with-typescript-diagnostics.md
+++ b/plan/issues/4020-test262-js-sources-rejected-with-typescript-diagnostics.md
@@ -1,10 +1,11 @@
 ---
 id: 4020
 title: "test262 .js sources rejected with TS8010/8017 'can only be used in TypeScript files' at L1:1 — 153 tests (112 Atomics, 29 module-code, 12 import)"
-status: ready
+status: done
 sprint: current
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-11
+completed: 2026-08-11
 priority: medium
 horizon: m
 feasibility: medium
@@ -97,3 +98,31 @@ sees, rather than the test file on disk. That dump is the whole diagnosis.
       recorded — a genuine `SharedArrayBuffer`/Atomics gap is #674/#1354, not
       this issue.
 - [ ] Net official pass count does not regress.
+
+
+---
+
+## Harvest note — 2026-08-11 — RESOLVED, and this issue has a duplicate
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260811-103533` (gitHash `9268d5a5`).
+
+**The TS8010/8017 bucket is now 0 records.** No official failing test in either
+lane reports `can only be used in TypeScript files`.
+
+Permanent conformance repro (this issue's own named sample):
+`test262/test/built-ins/Atomics/notify/notify-zero.js`, which now reads:
+
+```
+fail | runtime_error | Cannot read properties of null (reading 'bind') [in __module_init()]
+```
+
+The file compiles; it now fails on the *next* blocker. That satisfies the
+acceptance criterion "Whatever those tests then do (pass, or fail for a real
+Atomics reason) is recorded". Successor filed as **#4365** (`$262.agent` is
+null, same 112 Atomics tests).
+
+**Duplicate:** #4020 and #4170 are the same issue — identical title and body,
+both filed by the 2026-08-01 harvest, and #4020's body header reads `# #3973`,
+so the pattern was filed three times. Both are closed here; treat #4020 as the
+canonical record and #4170 as the duplicate.

--- a/plan/issues/4170-test262-js-sources-rejected-with-typescript-diagnostics.md
+++ b/plan/issues/4170-test262-js-sources-rejected-with-typescript-diagnostics.md
@@ -1,10 +1,11 @@
 ---
 id: 4170
 title: "test262 .js sources rejected with TS8010/8017 'can only be used in TypeScript files' at L1:1 — 153 tests (112 Atomics, 29 module-code, 12 import)"
-status: ready
+status: done
 sprint: current
 created: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-11
+completed: 2026-08-11
 priority: medium
 horizon: m
 feasibility: medium
@@ -97,3 +98,31 @@ sees, rather than the test file on disk. That dump is the whole diagnosis.
       recorded — a genuine `SharedArrayBuffer`/Atomics gap is #674/#1354, not
       this issue.
 - [ ] Net official pass count does not regress.
+
+
+---
+
+## Harvest note — 2026-08-11 — RESOLVED, and this issue has a duplicate
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260811-103533` (gitHash `9268d5a5`).
+
+**The TS8010/8017 bucket is now 0 records.** No official failing test in either
+lane reports `can only be used in TypeScript files`.
+
+Permanent conformance repro (this issue's own named sample):
+`test262/test/built-ins/Atomics/notify/notify-zero.js`, which now reads:
+
+```
+fail | runtime_error | Cannot read properties of null (reading 'bind') [in __module_init()]
+```
+
+The file compiles; it now fails on the *next* blocker. That satisfies the
+acceptance criterion "Whatever those tests then do (pass, or fail for a real
+Atomics reason) is recorded". Successor filed as **#4365** (`$262.agent` is
+null, same 112 Atomics tests).
+
+**Duplicate:** #4020 and #4170 are the same issue — identical title and body,
+both filed by the 2026-08-01 harvest, and #4020's body header reads `# #3973`,
+so the pattern was filed three times. Both are closed here; treat #4020 as the
+canonical record and #4170 as the duplicate.

--- a/plan/issues/4363-bigint-typedarray-makearray-harness-coercion.md
+++ b/plan/issues/4363-bigint-typedarray-makearray-harness-coercion.md
@@ -1,0 +1,97 @@
+---
+id: 4363
+title: "spec gap: BigInt TypedArray paths reject harness `makeArray` values — 287 tests `Cannot convert N to a BigInt`"
+status: ready
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen+runtime
+language_feature: bigint, typed-array
+goal: spec-completeness
+related: [1644, 1515, 1645, 1700]
+origin: "2026-08-11 /harvest-errors of loopdive/js2wasm-baselines test262-current.jsonl (run 20260811-103533, gitHash 9268d5a5)"
+---
+
+# #4363 — BigInt TypedArray paths reject the harness's own `makeArray` values
+
+## TL;DR
+
+**287 official failing tests** in the **default (JS-host)** lane fail with a
+single `type_error` signature:
+
+```
+TypeError: Cannot convert 4 to a BigInt (Testing with BigInt64Array and makeArray.)
+```
+
+The number varies per test (`4`, `40`, `42`, …); the parenthetical is constant.
+This is the **largest single named-category bucket in the default lane** and the
+third-largest bucket overall.
+
+## Evidence
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260811-103533` (gitHash `9268d5a5`), 48,735 entries / 43,621 official.
+
+| Directory | Count |
+|---|---|
+| `built-ins/TypedArray/prototype` | 222 |
+| `built-ins/TypedArrayConstructors/internals` | 54 |
+| `built-ins/TypedArrayConstructors/from` | 8 |
+| `built-ins/TypedArrayConstructors/ctors-bigint` | 3 |
+| **Total** | **287** |
+
+Samples:
+
+- `test262/test/built-ins/TypedArray/prototype/sort/BigInt/sorted-values.js`
+- `test262/test/built-ins/TypedArray/prototype/subarray/BigInt/minus-zero.js`
+- `test262/test/built-ins/TypedArray/prototype/reduce/BigInt/callbackfn-arguments-default-accumulator.js`
+- `test262/test/built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/detached-buffer-throws.js`
+- `test262/test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-ctor-inherited.js`
+
+## Root cause hypothesis
+
+The `(Testing with BigInt64Array and makeArray.)` suffix comes from
+`testTypedArray.js`'s `testWithBigIntTypedArrayConstructors` helper, which
+iterates the BigInt TypedArray constructors and builds inputs with `makeArray`.
+The message says our runtime refused to convert a **plain Number** (`4`) to a
+BigInt.
+
+Per spec that refusal is *correct* for `ToBigInt(4)` — but the harness is
+supposed to be handing these paths **BigInt** values in the first place. So the
+defect is upstream of the throw: either
+
+1. `makeArray` / the harness's BigInt element factory is producing f64 elements
+   because our compiled path lost the `n` literal suffix or the `BigInt(...)`
+   call, or
+2. the TypedArray element read/write path eagerly coerces the element to f64
+   (the exact "typed paths assume f64 too eagerly" failure mode of **#1644**)
+   and then feeds that f64 back into a `ToBigInt` slot.
+
+(2) is the stronger hypothesis and makes this a **likely regression or
+incomplete fix of #1644** — that issue is `status: done`, was scoped at *47*
+test262 fails, and the count in this family is now 287. See the regression note
+added to #1644.
+
+## Acceptance criteria
+
+- [ ] Determine whether the f64 value reaching `ToBigInt` originates in
+      `makeArray` (harness lowering) or in the TypedArray element path
+      (codegen coercion). Name the site.
+- [ ] A BigInt64Array/BigUint64Array element round-trip
+      (`ta[0] = 1n; ta[0]`) preserves BigInt through the compiled path with no
+      intermediate f64.
+- [ ] The `Cannot convert N to a BigInt (Testing with …)` bucket goes to 0, or
+      the residual is re-bucketed under a genuine spec-required TypeError with
+      the count stated.
+- [ ] No regression in `built-ins/BigInt/**` or `built-ins/TypedArray/**`.
+
+## Notes
+
+Do not "fix" this by making `ToBigInt` accept Numbers — that would be a spec
+violation and would silently pass tests that assert the TypeError. The fix is to
+stop producing the Number.

--- a/plan/issues/4364-test262-extern-class-dependency-not-provided.md
+++ b/plan/issues/4364-test262-extern-class-dependency-not-provided.md
@@ -1,0 +1,115 @@
+---
+id: 4364
+title: "test262 harness: `No dependency provided for extern class` — 224 tests, 172 on the `ctor` fixture (successor to #1524)"
+status: ready
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: test-runner
+language_feature: test262-harness, typed-array
+goal: test-infrastructure
+related: [1524, 1645, 1354, 4020]
+origin: "2026-08-11 /harvest-errors of loopdive/js2wasm-baselines test262-current.jsonl (run 20260811-103533, gitHash 9268d5a5)"
+---
+
+# #4364 — harness fixture identifiers compile to unresolvable `extern class`
+
+## TL;DR
+
+**224 official failing tests** in the **default (JS-host)** lane fail at the
+dependency-injection boundary with `error_category: missing_dependency`:
+
+```
+No dependency provided for extern class "ctor"
+```
+
+This is the direct successor to **#1524** (`status: done`, "ctors fixture not
+exposed in resizable-buffer tests", scoped at 202 tests). That fix changed the
+*symptom* — `ctors is not defined` is gone — but the same test family still
+fails, now one layer later: the identifier now resolves to an **extern class
+declaration** for which no dependency is ever supplied.
+
+## Evidence
+
+Source: `test262-current.jsonl` from `loopdive/js2wasm-baselines`, run
+`20260811-103533` (gitHash `9268d5a5`).
+
+Missing extern-class names (9 distinct):
+
+| Name | Count |
+|---|---|
+| `ctor` | 172 |
+| `badArrayType` | 23 |
+| `FinalizationRegistry` | 21 |
+| `nonSharedArrayType` | 3 |
+| `Other` | 2 |
+| `TA`, `sourceCtor`, `targetCtor`, `eval` | 1 each |
+| **Total** | **224** |
+
+By directory:
+
+| Directory | Count |
+|---|---|
+| `built-ins/TypedArray/prototype` | 91 |
+| `built-ins/Array/prototype` | 68 |
+| `built-ins/FinalizationRegistry/prototype` | 15 |
+| `language/statements/for-of` | 5 |
+| `built-ins/Atomics/{wait,waitAsync,compareExchange}` | 9 |
+| `built-ins/Object/defineProperty` | 3 |
+
+Samples:
+
+- `test262/test/built-ins/TypedArray/prototype/indexOf/coerced-searchelement-fromindex-grow.js`
+- `test262/test/built-ins/Array/prototype/keys/resizable-buffer.js`
+- `test262/test/built-ins/TypedArray/prototype/join/coerced-separator-grow.js`
+- `test262/test/built-ins/Atomics/waitAsync/validate-arraytype-before-index-coercion.js`
+
+## Root cause hypothesis
+
+These are all **test-local loop variables**, not globals:
+
+```js
+testWithTypedArrayConstructors(function(TA) { ... });
+// or
+[Int8Array, Uint8Array].forEach(function(ctor) { ... });
+```
+
+The names (`ctor`, `TA`, `sourceCtor`, `targetCtor`, `badArrayType`,
+`nonSharedArrayType`) are **callback parameters**. `FinalizationRegistry` and
+`eval` are genuinely-global but unimplemented.
+
+So the compiler appears to be treating an unresolved *binding* as an ambient
+`extern class` needing host injection, rather than as a local parameter already
+in scope. That points at the harness-assembly / type-resolution step rather than
+at codegen: whatever declares `ctors` for #1524 is likely declaring the callback
+parameter too, shadowing the real binding with an extern declaration that the
+runner then can't satisfy.
+
+Two distinct fixes are probably needed:
+
+1. **The 200 callback-parameter names** — stop emitting an `extern class` for a
+   binding that is lexically in scope. This is the bulk.
+2. **`FinalizationRegistry` (21) and `eval` (1)** — genuinely missing globals;
+   route to the relevant feature issues rather than fixing here.
+
+## Acceptance criteria
+
+- [ ] A test using `testWithTypedArrayConstructors(function(TA) {...})` compiles
+      with `TA` bound to the callback parameter, no extern-class declaration
+      emitted.
+- [ ] The `No dependency provided for extern class` bucket drops to at most the
+      genuinely-global residual (`FinalizationRegistry`, `eval`), with that
+      residual re-routed to its own issue.
+- [ ] #1524's resizable-buffer family is re-measured and the surviving failures
+      (if any) are attributed to a real spec gap, not to fixture plumbing.
+
+## Notes
+
+Worth checking against **#1645** (`spec gap: ArrayBuffer resizable and TypedArray
+detached`, `status: ready`) — that issue owns the *semantics* of these tests;
+this one owns only the fixture plumbing that stops them from running at all.

--- a/plan/issues/4365-test262-262-agent-missing-atomics.md
+++ b/plan/issues/4365-test262-262-agent-missing-atomics.md
@@ -1,0 +1,101 @@
+---
+id: 4365
+title: "test262: `$262.agent` is null — 112 Atomics agent tests fail on `.bind` (successor to #4020/#4170)"
+status: ready
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: test-runner
+language_feature: test262-harness, atomics
+goal: test-infrastructure
+related: [1523, 1354, 3405, 4020, 4170]
+origin: "2026-08-11 /harvest-errors of loopdive/js2wasm-baselines test262-current.jsonl (run 20260811-103533, gitHash 9268d5a5)"
+---
+
+# #4365 — `$262.agent` host object is absent, so every Atomics agent test dies at init
+
+## TL;DR
+
+**112 official failing tests** in the **default (JS-host)** lane fail with:
+
+```
+Cannot read properties of null (reading 'bind') [in __module_init()]
+```
+
+All 112 are in `built-ins/Atomics`. The failure is at **module init**, before
+any test logic runs — the harness does something shaped like
+`$262.agent.start.bind($262.agent)` and `$262.agent` is `null`.
+
+## This is the successor to #4020 / #4170 — and evidence they are DONE
+
+#4020 and #4170 are **duplicate issues** (identical title and body, both
+`status: ready`, both filed by the 2026-08-01 harvest; #4020's body header even
+reads `# #3973`, so this was a triple). Both describe a TS8010/8017
+"can only be used in TypeScript files" rejection covering **112 Atomics** tests
+plus 41 others.
+
+That bucket is now **0 records** in the current baseline — the TypeScript-parse
+rejection is fixed. #4020's own named sample,
+`test262/test/built-ins/Atomics/notify/notify-zero.js`, now reads:
+
+```
+fail | runtime_error | Cannot read properties of null (reading 'bind') [in __module_init()]
+```
+
+Same 112 files, same count, next blocker. This satisfies #4020's own acceptance
+criterion ("Whatever those tests then do … is recorded"), so **#4020 and #4170
+should be closed** and the work continues here.
+
+## Evidence
+
+| Directory | Count |
+|---|---|
+| `built-ins/Atomics/waitAsync` | 53 |
+| `built-ins/Atomics/wait` | 43 |
+| `built-ins/Atomics/notify` | 16 |
+| **Total** | **112** |
+
+Samples:
+
+- `test262/test/built-ins/Atomics/wait/negative-timeout-agent.js`
+- `test262/test/built-ins/Atomics/waitAsync/poisoned-object-for-timeout-throws-agent.js`
+- `test262/test/built-ins/Atomics/notify/count-defaults-to-infinity-undefined.js`
+
+Cross-lane: **0** of the 112 pass in the standalone lane either — this is not a
+host-only gap.
+
+## Root cause
+
+`$262.agent` is the test262 host hook for spawning **worker agents**
+(`$262.agent.start`, `.broadcast`, `.getReport`, `.sleep`, `.monotonicNow`).
+**#1523** (`status: done`) built the `$262` host object but evidently left
+`agent` as `null` rather than implementing or omitting it — and the harness
+dereferences it unconditionally at init.
+
+## Scope decision needed
+
+Two legitimate outcomes, and the cheap one should be evaluated first:
+
+1. **Cheap (recommended first):** stop failing at *init*. A `null` `agent` that
+   is dereferenced during module init turns a would-be `skip`/targeted failure
+   into a hard crash for all 112. Making the harness degrade gracefully lets each
+   test report its real status; some non-agent tests in these directories may
+   then pass outright.
+2. **Full:** implement `$262.agent` over real workers. That is a substantial
+   piece of work and overlaps **#1354** (`spec-backlog-sharedarraybuffer-atomics`,
+   `status: backlog`) and **#3405** (`jshost-atomics-i64-vec-bigint-bridge`,
+   `status: ready`). Do not start it under this issue without a scoping decision.
+
+## Acceptance criteria
+
+- [ ] No test fails with `Cannot read properties of null (reading 'bind')` at
+      `__module_init()`.
+- [ ] Each of the 112 reports a status attributable to a real cause (pass, or a
+      named Atomics/agent gap), not to harness init.
+- [ ] #4020 and #4170 are closed as done, with one of them noted as the duplicate.
+- [ ] The chosen scope (1 vs 2 above) is recorded here before implementation.

--- a/plan/issues/4366-standalone-array-host-helper-leak.md
+++ b/plan/issues/4366-standalone-array-host-helper-leak.md
@@ -1,0 +1,121 @@
+---
+id: 4366
+title: "standalone: array host-helper leak (`__js_array_new`/`__js_array_push`/`__array_concat_any`) — 542 tests, 195 already pass in the host lane"
+status: ready
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+priority: high
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: codegen
+language_feature: array, typed-array
+goal: standalone-mode
+related: [1781, 2860, 2961, 1472, 1094]
+origin: "2026-08-11 /harvest-errors of loopdive/js2wasm-baselines test262-standalone-current.jsonl (run 20260811-103533, gitHash 9268d5a5)"
+---
+
+# #4366 — the array runtime still routes through JS host imports in standalone mode
+
+## TL;DR
+
+**542 official failing tests** in the **standalone** lane are refused by the
+#2961 strict leak scan because codegen emitted array host imports:
+
+```
+standalone target emitted host imports: env::__array_concat_any,
+  env::__js_array_new, env::__js_array_push (#2961)
+```
+
+**195 of the 542 already pass in the default (JS-host) lane**, so they are
+directly recoverable by giving these three helpers a Wasm-native lowering — this
+is the largest single recoverable block in the standalone lane.
+
+## Evidence
+
+Source: `test262-standalone-current.jsonl` from `loopdive/js2wasm-baselines`,
+run `20260811-103533` (gitHash `9268d5a5`).
+
+Leaked imports across the bucket:
+
+| Import | Records |
+|---|---|
+| `env::__js_array_new` | 542 |
+| `env::__array_concat_any` | 532 |
+| `env::__js_array_push` | 530 |
+| `env::__tagged_template` | 10 |
+| `env::Uint8ClampedArray_{sort,keys,values,entries}` | 19 |
+
+The three core helpers co-occur in almost every record — they are one lowering
+path, not three independent gaps.
+
+By directory:
+
+| Directory | Count |
+|---|---|
+| `built-ins/TypedArray/prototype` | 316 |
+| `built-ins/Array/prototype` | 97 |
+| `built-ins/TypedArrayConstructors/internals` | 66 |
+| `built-ins/TypedArrayConstructors/ctors` + `ctors-bigint` | 20 |
+| `language/module-code/top-level-await` | 9 |
+| other | 34 |
+
+Cross-lane split:
+
+| | Count |
+|---|---|
+| Pass in host lane → **recoverable here** | **195** |
+| Fail in both lanes (needs a separate semantic fix) | 347 |
+
+Samples:
+
+- `test262/test/built-ins/Array/prototype/find/resizable-buffer.js`
+- `test262/test/built-ins/Array/prototype/concat/S15.4.4.4_A1_T1.js`
+- `test262/test/built-ins/TypedArray/prototype/reverse/prop-desc.js`
+- `test262/test/built-ins/TypedArray/prototype/some/length.js`
+
+## Context
+
+This is the **largest leak family in the standalone lane after generators**. Of
+the 2,607 records citing #2961, the array-helper set is 542; the generator
+family (`__gen_*`, `__create_generator`, `__create_async_generator`) is the
+other large block and is already owned by **#680** / **#2864**.
+
+`__js_array_new` / `__js_array_push` / `__array_concat_any` are the JS-host
+fast path from the era of **#1094** (`shrink-runtime-ts-host-boundary`). Per the
+project's dual-mode principle, they need a WasmGC-native counterpart selected
+under `--target standalone` / `--no-host-imports`.
+
+## Implementation direction
+
+The three helpers are a small, well-defined surface:
+
+- `__js_array_new` — allocate a growable JS-visible array
+- `__js_array_push` — append, growing as needed
+- `__array_concat_any` — concat with spreadable/any-element handling
+
+A WasmGC-native array object with a backing `(array (ref null any))` plus
+length/capacity fields covers all three. The `Uint8ClampedArray_*` and
+`__tagged_template` leaks (29 records) ride along in the same tests but are
+separate, much smaller gaps — split them out rather than growing this issue.
+
+## Acceptance criteria
+
+- [ ] `--target standalone` emits no `env::__js_array_new`,
+      `env::__js_array_push`, or `env::__array_concat_any` import.
+- [ ] The #2961 leak scan for this import set reports 0.
+- [ ] Standalone pass count rises by roughly the 195 host-lane-passing files;
+      report the measured delta (not the estimate).
+- [ ] No default-lane regression — the host fast path stays available in JS-host
+      mode.
+- [ ] The 347 fail-in-both files are re-measured and their residual errors
+      bucketed to follow-up issues.
+
+## Notes
+
+Deliberately scoped to the array-helper set only. Do **not** fold in the
+generator leak family (#680/#2864), the `SharedArrayBuffer_new` leak (425
+records — see #3178/#1354), or the `Promise_*` leaks (#3178); they are separate
+lowering problems with separate owners.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -775,3 +775,72 @@ generic 1,720) → #2961 (in-progress) umbrella; new-Function/indirect-eval →
 (30, `compound-assignment/S11.13.2_A5.*`) → #1387 (done) niche; import-attributes
 early-SyntaxError (35, sub-50) → #1805 (done) residual. Temporal / ShadowRealm /
 import.defer|source / Atomics.waitAsync = non-official proposals, excluded.
+
+## 2026-08-11 /harvest-errors run (oracle-13 "honest", both lanes)
+
+Baselines run `20260811-103533` (gitHash `9268d5a5`), oracle_version 13
+`honest`. Default lane 31,776 / 43,621 official pass; standalone lane 29,519
+passing records of the same 43,621 official. Cross-referenced both lanes;
+**every standalone cluster >50 maps to an existing tracked issue** — the new
+issues are three default-lane clusters plus one standalone leak family.
+
+New issues:
+
+- [#4363](../4363-bigint-typedarray-makearray-harness-coercion.md) — **NEW.**
+  BigInt TypedArray paths reject the harness's own `makeArray` values —
+  **287 default-lane fails**, all
+  `TypeError: Cannot convert N to a BigInt (Testing with BigInt64Array and makeArray.)`.
+  Largest named-category bucket in the default lane. Likely the same eager-f64
+  failure mode as #1644 (`done`, scoped at 47) — see the regression note there.
+- [#4364](../4364-test262-extern-class-dependency-not-provided.md) — **NEW.**
+  `No dependency provided for extern class` — **224 default-lane fails** across
+  9 names, 172 on `ctor`. Direct successor to #1524 (`done`): `ctors is not
+  defined` is gone, but the family now fails one layer later at dependency
+  injection. Most names are callback *parameters*, not globals.
+- [#4365](../4365-test262-262-agent-missing-atomics.md) — **NEW.** `$262.agent`
+  is `null`, so all **112 Atomics agent tests** die at `__module_init()` on
+  `.bind`. Successor to #4020/#4170 (both closed, see below).
+- [#4366](../4366-standalone-array-host-helper-leak.md) — **NEW.** Standalone
+  array host-helper leak (`__js_array_new` / `__js_array_push` /
+  `__array_concat_any`) — **542 standalone fails**, of which **195 already pass
+  in the host lane** and are directly recoverable. Largest standalone leak
+  family after generators.
+
+Closed as already-fixed:
+
+- **#4020 and #4170** — the TS8010/8017 "can only be used in TypeScript files"
+  bucket is now **0 records** in both lanes; verified against #4020's own named
+  sample. These two are **duplicates of each other** (identical title and body,
+  same 2026-08-01 harvest; #4020's body header reads `# #3973`, so the pattern
+  was filed three times). Both set `done`; #4020 is the canonical record.
+
+Regression / residual flags on `done` issues (notes appended, status left as-is
+pending a maintainer call):
+
+- **#1073** (`done`) — `annexB/language/eval-code` still carries **184** fails
+  with this issue's own root-cause shape (`assert is not defined` 120,
+  `null is not a function` 64) vs **179** at close. The fix's JS-side shim list
+  targets the *rewritten* harness names (`assert_throws`, …); the harness now
+  emits bare `assert`, so the shim no longer matches. Not a count improvement.
+- **#1644** (`done`, scoped 47) — family now 287; see #4363.
+- **#1524** (`done`, scoped 202) — symptom moved, family now 224; see #4364.
+- **#1171** (`done`) — **84** `compile_timeout (10s)` records remain, spread
+  thinly (max 12 per directory). Sub-50 per family; no new issue.
+
+Verified-tracked, no new issue (safe-refill pointers): standalone dynamic import
+(402) → #3494 (blocked); native generator sequential-yield limit (317) → #680
+(ready) / #2864 (in-progress); async completion marker not observed (264
+standalone / 72 default) → #3421 (ready); `__get_builtin` dynamic-shape (118) →
+#1472 (ready); `$262.detachArrayBuffer` (89) → #3975 (ready); with-statement
+closed-shape refusal (66) → #1387 (done) / #2663 (in-progress);
+`SharedArrayBuffer_new` leak (425) → #3178 (ready) / #1354 (backlog);
+`Promise_*` leaks → #3178 (ready); generator `__gen_*` leaks → #680 / #2864.
+`verifyProperty` null-receiver (112 default) spans many directories with mixed
+root causes — aggregator, not one bug; not filed. ShadowRealm / Temporal =
+non-official proposals, excluded by design.
+
+**negative_test_fail**: 14 per lane, identical file set in both. 12 are
+"expected runtime ReferenceError but succeeded" (TDZ / lexical-scope early
+errors: `switch/scope-lex-*`, `global-use-before-initialization-*`), 2 are
+early-SyntaxError-not-detected. Sub-50; covered by existing early-error
+spec-gap issues (#1315/#1435); no new issue.


### PR DESCRIPTION
## Description

`/harvest-errors` against `loopdive/js2wasm-baselines` run `20260811-103533` (gitHash `9268d5a5`, `oracle_version` 13 "honest"), **both lanes**, 43,621 official tests each. Default lane 31,776 pass / 11,826 official failures; standalone lane 29,519 pass / 14,382 official failures. Docs-only — touches `plan/issues/` and nothing else.

### New issues (all >50 occurrences, none previously tracked)

| Issue | Lane | Count | Pattern |
|---|---|---|---|
| **#4363** | default | **287** | BigInt TypedArray paths reject the harness's own `makeArray` values — `Cannot convert N to a BigInt (Testing with BigInt64Array and makeArray.)`. Largest named-category bucket in the default lane. |
| **#4364** | default | **224** | `No dependency provided for extern class` across 9 names, 172 on `ctor`. Successor to #1524 — that fix removed `ctors is not defined`, but the family now fails one layer later at dependency injection, and most names are callback *parameters*, not globals. |
| **#4365** | default | **112** | `$262.agent` is `null`, so every Atomics agent test dies at `__module_init()` on `.bind`. Successor to #4020/#4170. |
| **#4366** | standalone | **542** | Array host-helper leak (`__js_array_new` / `__js_array_push` / `__array_concat_any`). **195 of the 542 already pass in the host lane** and are directly recoverable — largest standalone leak family after generators. |

### Closed as already-fixed

**#4020 and #4170** — the TS8010/8017 "can only be used in TypeScript files" bucket is now **0 records in both lanes**. Verified against #4020's own named sample, `test262/test/built-ins/Atomics/notify/notify-zero.js`, which now compiles and fails on the successor blocker instead — exactly the issue's own acceptance criterion.

These two are also **duplicates of each other**: identical title and body from the same 2026-08-01 harvest, and #4020's body header reads `# #3973`, so the pattern was filed three times. #4020 is kept as the canonical record.

### Regression / residual flags

Notes appended; `status` left as-is for a maintainer call.

| Issue | At close | Now | Note |
|---|---|---|---|
| **#1073** (done) | 179 | **184** | `annexB/language/eval-code` still fails with this issue's own root-cause shape. The JS-side shim list targets the *rewritten* harness names; the harness now emits bare `assert`, so the shim no longer matches. Not a count improvement. |
| **#1644** (done) | 47 | **287** | See #4363. |
| **#1524** (done) | 202 | **224** | Symptom moved, family still failing. See #4364. |
| **#1171** (done) | — | **84** | `compile_timeout (10s)` residual, spread thinly (max 12/dir). Sub-50 per family; no new issue. |

### Verified-tracked (no new issue)

Every standalone cluster >50 already maps to an open issue: dynamic import (402) → #3494; native generator sequential-yield limit (317) → #680/#2864; async completion marker (264) → #3421; `__get_builtin` (118) → #1472; `$262.detachArrayBuffer` (89) → #3975; with-statement closed-shape refusal (66) → #1387/#2663; `SharedArrayBuffer_new` (425) and `Promise_*` leaks → #3178/#1354.

`negative_test_fail` is 14 per lane on an identical file set (12 TDZ/lexical-scope ReferenceError, 2 early-SyntaxError) — sub-50, covered by #1315/#1435.

### Separate observation, not addressed here

`runs/index.json` shows the newest promotion dropping **31,934 → 31,776 pass (-158)** between gitHash `1a4cacc1` and `9268d5a5`. This appears **declared rather than silent**: commit `d2c0c11c` documents a verified #3596 trap reclassification landing with PR #4313, moving `null_deref` from 1,629 to 145. Flagging it because the *pass* count still moved down by 158 and that is worth a maintainer's eye; no change made in this PR.

### Gates

`update-issues.mjs --check` OK · `check-issue-ids` OK · `check-done-status-integrity` OK · `check-committed-issue-integrity` OK · `check-issue-spec-coverage` OK · pre-commit fast gates (lint-staged + LOC/function budgets) OK.

Issue ids were reserved via `claim-issue.mjs --allocate`. The open-PR scan degraded (no `gh` CLI in this environment), so `--allow-unscanned` was used — the open-PR set was verified independently via the GitHub API first: 2 open PRs, neither adding issue files.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: this is a legal attestation for the repository owner to make, not the agent. Internal/org-member PRs skip the CLA check automatically. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGZbavAWPPqnbRF8Bm8Rvw)_