### PR TITLE
fix(ir): preserve ES5 update and OrdinaryToPrimitive coercions

### DIFF
--- a/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
+++ b/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
@@ -474,6 +474,23 @@ The six are the prefix/postfix increment/decrement string cases plus the two
 Boolean-wrapper increment cases. The Boolean-primitive correctness proof and
 sloppy-redeclaration coverage live in the focused unit suite.
 
+The same implementation also closes the update-expression overlap with S3.
+Four object-operand files previously catalogued as red now exercise user
+`valueOf` through the canonical coercion path and pass in both lanes:
+
+- `postfix-decrement/S11.3.2_A2.2_T1.js`
+- `postfix-increment/S11.3.1_A2.2_T1.js`
+- `prefix-decrement/S11.4.5_A2.2_T1.js`
+- `prefix-increment/S11.4.4_A2.2_T1.js`
+
+| lane | after | run id |
+| --- | ---: | --- |
+| host GC | **4 / 4** | `20260811-201901` |
+| standalone | **4 / 4** | `20260811-202024` |
+
+That makes ten previously-red update-expression files verified green in both
+lanes. The remaining S3 population covers other operators and stays open.
+
 ### Verification
 
 - `issue-4208-update-to-number-ir`, `issue-4208-strict-eq-type-disjoint`,
@@ -484,5 +501,6 @@ sloppy-redeclaration coverage live in the focused unit suite.
 
 Fresh whole-suite baselines contain 9,029 ES5 tests: standalone is 8,052 pass,
 880 fail, 93 compile-error and 4 timeout; host GC is 7,218 pass, 1,760 fail and
-51 compile-error. S2 removes a verified six-file slice from that residue; this
-issue remains open for S3–S7 rather than claiming the overall ES5 goal complete.
+51 compile-error. This change removes a verified ten-file update-expression
+slice from that residue; this issue remains open for the rest of S3–S7 rather
+than claiming the overall ES5 goal complete.

--- a/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
+++ b/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
@@ -18,10 +18,24 @@ goal: es5
 related: [3055, 4183, 4173, 2733, 3216, 3397, 4205, 4204]
 assignee: ttraenkler/codex-4208
 loc-budget-allow:
+  - src/codegen/context/types.ts
+  - src/codegen/declarations.ts
+  - src/codegen/declarations/object-shape-widening.ts
+  - src/codegen/index.ts
+  - src/codegen/literals.ts
+  - src/codegen/statements/variables.ts
+  - src/ir/integration.ts
   - src/ir/module-bindings.ts
   - src/ir/select.ts
   - src/codegen/binary-ops-typed-dispatch.ts
   - src/ir/from-ast.ts
+  - src/runtime.ts
+func-budget-allow:
+  - src/codegen/context/create-context.ts::createCodegenContext
+  - src/codegen/declarations.ts::collectDeclarations
+  - src/codegen/literals.ts::compileObjectLiteral
+  - src/codegen/statements/variables.ts::compileVariableStatement
+  - src/runtime.ts::resolveImport
 origin: "2026-08-07 W23 census of the ES5 standalone failing residue. #3055 covers only `any === any` on boxed numbers; nothing covers ToNumber/ToPrimitive in update, compound-assignment and relational operators."
 ---
 
@@ -504,3 +518,81 @@ Fresh whole-suite baselines contain 9,029 ES5 tests: standalone is 8,052 pass,
 51 compile-error. This change removes a verified ten-file update-expression
 slice from that residue; this issue remains open for the rest of S3–S7 rather
 than claiming the overall ES5 goal complete.
+
+---
+
+## S3/S7 first OrdinaryToPrimitive slice — 2026-08-11
+
+Continued from the ready #4377 head on `origin/main@6c1117f8767e9b43ab9eefa0bd0084bf9c980a7d`,
+fetched from the renamed canonical repository `loopdive/js2wasm` in the same
+isolated worktree.
+
+The first five S3/S7 crash cases shared a representation failure, not five
+operator bugs. Test262's wrapper repeatedly declares one function-scoped
+`var object` with different anonymous object shapes. Each declaration denotes
+the same JS binding, but legacy allocation selected a different closed WasmGC
+struct for every initializer; a later guarded assignment stored null when the
+shapes disagreed, and unary/bitwise coercion dereferenced it.
+
+The compatibility prepass now groups declarations by exact checker symbol and
+widens only the bounded shape where all repeated initializers are method-only
+`valueOf`/`toString` function literals and the binding has a coercive numeric
+use. Those exact declarations and literals share the open object carrier. The
+host bridge also treats its exact `__is_closure` classifier as authoritative
+and wraps OrdinaryToPrimitive methods with the zero-argument dispatcher before
+storing them.
+
+### IR ownership boundary
+
+The real Test262 wrapper is still deliberately legacy-owned: duplicate `var`
+bindings are outside the current IR declaration model, and its unannotated JS
+function expressions are outside the typed closure surface. It is therefore
+reported as a selector rejection rather than falsely counted as IR coverage.
+
+A focused typed source is genuinely IR-emitted in both lanes:
+
+```ts
+export function probe(): number {
+  const object = { valueOf: function (): number { return 1; } };
+  return +object;
+}
+```
+
+The selector admits only zero-argument, explicitly typed `valueOf`/`toString`
+function properties. From-AST lowering builds an open object through symbolic
+`__new_plain_object`/`__extern_set` calls, packs the closure through the
+canonical callable ABI, and lowers unary ToNumber as
+`__to_primitive(value, null)` followed by `__unbox_number`. Runtime providers
+are preregistered before Phase 3 for both host imports and the standalone native
+object runtime. Mixed method/data objects remain a pre-claim rejection.
+
+### Maintained-runner measurement
+
+Node 25.9.0, Test262 `b363f29d3c43c626dc852744ad64a0b48a003693`,
+maintained `pnpm run test:262` runner:
+
+| lane | before | after | after run id |
+| --- | ---: | ---: | --- |
+| host GC | 0 / 5 | **5 / 5** | `20260811-205948` |
+| standalone | 0 / 5 | **5 / 5** | `20260811-210129` |
+
+The five previously crashing files are:
+
+- `unary-plus/S11.4.6_A2.2_T1.js`
+- `unary-minus/S11.4.7_A2.2_T1.js`
+- `bitwise-not/S11.4.8_A2.2_T1.js`
+- `bitwise-not/S9.5_A3.1_T4.js`
+- `unsigned-right-shift/S9.6_A3.1_T4.js`
+
+### Verification
+
+- Focused host/standalone IR ownership, repeated-`var`, and selector-boundary
+  suite: **6 / 6**.
+- Related #4208 and object-method suites: **41 / 41**.
+- `pnpm run typecheck`: pass.
+- `pnpm run check:ir-fallbacks`: pass; no unintended, post-claim, or
+  module-level fallback increase.
+
+This is a five-file slice, not closure of S3/S7 or the ES5 goal. Relational,
+addition, abstract-equality, Date/function operands, and wider
+OrdinaryToPrimitive shapes remain to be measured and implemented.

--- a/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
+++ b/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
@@ -649,7 +649,9 @@ The exact 15-file S3/S7 cluster was measured with the maintained
 slice passed **5 / 15**. The first candidate run (`20260811-220314`) passed
 **14 / 15** and exposed the early `{} + {}` numeric-folder bypass above. The
 exact failing file is now covered by the focused suite and passes; the final
-rerun (`20260811-221344`) passes **15 / 15**. This is a measured ten-file
+rerun (`20260811-221344`) passes **15 / 15**. After the runtime ToPrimitive
+emission was centralized in the coercion engine, the post-refactor control run
+(`20260811-223059`) also passes **15 / 15**. This is a measured ten-file
 improvement over the ready PR head, not an extrapolation to the remaining ES5
 population.
 

--- a/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
+++ b/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
@@ -2,7 +2,7 @@
 id: 4208
 title: "Operator abstract-ops are lowered from the STATIC type: ToNumber / ToPrimitive / Type() are skipped for string, wrapper and `{valueOf}` operands — 59 ES5 files, `1 === true` answers true"
 status: in-progress
-completed_slice: "S1 (Type() for ===/!==) and S2 (update-expression ToNumber) — 2026-08-11"
+completed_slice: "S1 (Type), S2 (updates), and S3/S7 numeric/default OrdinaryToPrimitive slices — 2026-08-11"
 sprint: current
 created: 2026-08-07
 updated: 2026-08-11
@@ -28,6 +28,10 @@ loc-budget-allow:
   - src/ir/module-bindings.ts
   - src/ir/select.ts
   - src/codegen/binary-ops-typed-dispatch.ts
+  - src/codegen/binary-ops.ts
+  - src/codegen/expressions/misc.ts
+  - src/codegen/string-ops.ts
+  - src/codegen/type-coercion.ts
   - src/ir/from-ast.ts
   - src/runtime.ts
 func-budget-allow:
@@ -35,6 +39,8 @@ func-budget-allow:
   - src/codegen/declarations.ts::collectDeclarations
   - src/codegen/literals.ts::compileObjectLiteral
   - src/codegen/statements/variables.ts::compileVariableStatement
+  - src/codegen/binary-ops.ts::compileBinaryExpression
+  - src/ir/from-ast.ts::lowerBinary
   - src/runtime.ts::resolveImport
 origin: "2026-08-07 W23 census of the ES5 standalone failing residue. #3055 covers only `any === any` on boxed numbers; nothing covers ToNumber/ToPrimitive in update, compound-assignment and relational operators."
 ---
@@ -596,3 +602,66 @@ The five previously crashing files are:
 This is a five-file slice, not closure of S3/S7 or the ES5 goal. Relational,
 addition, abstract-equality, Date/function operands, and wider
 OrdinaryToPrimitive shapes remain to be measured and implemented.
+
+---
+
+## S3/S7 binary OrdinaryToPrimitive slice — 2026-08-11
+
+The next slice extends the same coercion frontier to `+`, abstract equality,
+and the four relational operators. It fixes three independent ways the
+primitive family was lost:
+
+1. Concrete Object operands were excluded from the dynamic add/compare route
+   after `$AnyValue` had been registered. They then fell through to an f64
+   hint, applying ToNumber before `+` could choose concatenation.
+2. Native string concatenation used the string hint (`toString` first) instead
+   of the default hint (`valueOf` first). Standalone relational comparison now
+   performs ToPrimitive(number) before choosing its string or numeric arm.
+3. `tryStaticToNumber` folded `{} + {}` as `NaN + NaN`. That skipped
+   ToPrimitive entirely even though both objects first become
+   `"[object Object]"`, forcing string concatenation. Object/unknown `+` values
+   now decline both that folder and the long-chain numeric flattener.
+
+Direct empty-object and function literals use their fixed inherited string
+primitives before crossing the standalone externref boundary. Repeated ES5
+`var` declarations retain the bounded open-object compatibility carrier from
+the first slice, and method-only direct literals use the same default-hint
+dispatcher. Mixed method/data objects still reject before an IR claim.
+
+### IR ownership boundary
+
+Numeric/default method-only object literals are now branded by the IR
+front-end and lowered through the canonical ToPrimitive/ToNumber operations for
+binary arithmetic, loose equality, and relational comparison. Both the host
+and standalone focused probes prove `legacyBodyEmitted: true` and
+`irBodyEmitted: true`.
+
+String-producing object binary expressions remain a clean legacy fallback
+until the IR has a carrier that preserves the runtime string-versus-number
+result of ToPrimitive. The duplicate-`var` Test262 wrapper likewise remains a
+selector rejection. These are explicit ownership boundaries, not silent
+post-claim fallbacks.
+
+### Maintained-runner measurement
+
+The exact 15-file S3/S7 cluster was measured with the maintained
+`pnpm run test:262` runner in the standalone lane. The ready PR head before this
+slice passed **5 / 15**. The first candidate run (`20260811-220314`) passed
+**14 / 15** and exposed the early `{} + {}` numeric-folder bypass above. The
+exact failing file is now covered by the focused suite and passes; the final
+rerun (`20260811-221344`) passes **15 / 15**. This is a measured ten-file
+improvement over the ready PR head, not an extrapolation to the remaining ES5
+population.
+
+### Focused verification
+
+- Host and standalone IR-emission probes cover unary and numeric binary
+  method-only literals.
+- Standalone compatibility probes cover duplicate `var` objects, default-hint
+  ordering, loose equality, direct empty objects/functions, all four
+  relational forms, and the exact `{} + {}` Test262 shape.
+- The mixed method/data negative control remains a pre-claim IR rejection in
+  both lanes.
+
+This slice does not close the whole issue. Compound assignment, Date-specific
+ToPrimitive behavior, and broader dynamic object shapes remain open.

--- a/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
+++ b/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
@@ -2,10 +2,10 @@
 id: 4208
 title: "Operator abstract-ops are lowered from the STATIC type: ToNumber / ToPrimitive / Type() are skipped for string, wrapper and `{valueOf}` operands — 59 ES5 files, `1 === true` answers true"
 status: in-progress
-completed_slice: "S1 (Type() for ===/!==, Number ⊥ Boolean) — 2026-08-07"
+completed_slice: "S1 (Type() for ===/!==) and S2 (update-expression ToNumber) — 2026-08-11"
 sprint: current
 created: 2026-08-07
-updated: 2026-08-07
+updated: 2026-08-11
 priority: high
 horizon: xl
 feasibility: hard
@@ -16,7 +16,12 @@ es_edition: 5
 language_feature: abstract-operations, value-representation
 goal: es5
 related: [3055, 4183, 4173, 2733, 3216, 3397, 4205, 4204]
-assignee: ttraenkler/W27
+assignee: ttraenkler/codex-4208
+loc-budget-allow:
+  - src/ir/module-bindings.ts
+  - src/ir/select.ts
+  - src/codegen/binary-ops-typed-dispatch.ts
+  - src/ir/from-ast.ts
 origin: "2026-08-07 W23 census of the ES5 standalone failing residue. #3055 covers only `any === any` on boxed numbers; nothing covers ToNumber/ToPrimitive in update, compound-assignment and relational operators."
 ---
 
@@ -121,7 +126,7 @@ they are strictly narrower.
       the two lanes do not double-count the same files.
 - [x] **S1 (`Type()` for `===`/`!==`) — DONE.** Scoped by measurement to
       Number ⊥ Boolean, the only broken pair; see the W27 notes below.
-- [ ] **S2 must DELETE `isUpdateRetypedBoolean` from
+- [x] **S2 must DELETE `isUpdateRetypedBoolean` from
       `src/codegen/strict-eq-type-disjoint.ts` in the same PR.** S1 left that
       guard in place so a Boolean binding that is a `++`/`--` target does not
       get its `Type()` folded, because the binding's `i32` slot still holds a
@@ -423,3 +428,61 @@ never stores it, so it cannot be fixed inside the update operator.
 
 Session-wide context, including the census-reliability record that bears on this
 issue's own file counts: `plan/agent-context/session-2026-08-07-lead-handoff.md`.
+
+---
+
+## S2 closure — 2026-08-11
+
+Base: `origin/main@70d531bcccc8a608da45b90998a2f6f2d4efb73e`, fetched from
+`loopdive/js2wasm` and checked out in an isolated worktree.
+
+S2 is no longer blocked. Update-retyped top-level `var` bindings now use a
+single checker-identity analysis shared by IR selection and compatibility
+allocation. Primitive initializers are represented by the IR dynamic carrier,
+the module initializer boxes them through the existing IR producer, and
+`++`/`--` calls the canonical ToNumber lowering before storing the resulting
+Number. Object and wrapper initializers retain the same widened global but
+conservatively demote module initialization until IR has a general
+object-to-dynamic materializer; the update itself still uses the canonical
+coercion path.
+
+The original S2 population was eight files. Six were red on current main; the
+two Boolean cases were green only because `isUpdateRetypedBoolean` suppressed
+the strict-equality optimization after the update stored the wrong logical
+type. The implementation deletes that workaround and proves those cases now
+pass because the binding actually contains Number `0`.
+
+Sloppy duplicate `var` declarations need one extra compatibility rule because
+Test262 redeclares the same module binding. The analysis marks every declaration
+sharing that symbol, and equality dispatch recognizes the widened module slot
+instead of trusting the stale initializer type. A simple non-redeclared source
+probe separately proves that `<module-init>` is emitted through IR with no
+post-claim error; duplicate-declaration harness shapes remain on the conservative
+compatibility path.
+
+### Maintained-runner measurement
+
+Node 25.9.0, Test262 `b363f29d3c43c626dc852744ad64a0b48a003693`,
+maintained `pnpm run test:262` runner, exact six-file current-red filter:
+
+| lane | before | after | run id |
+| --- | ---: | ---: | --- |
+| host GC | 0 / 6 | **6 / 6** | `20260811-194844` |
+| standalone | 0 / 6 | **6 / 6** | `20260811-194926` |
+
+The six are the prefix/postfix increment/decrement string cases plus the two
+Boolean-wrapper increment cases. The Boolean-primitive correctness proof and
+sloppy-redeclaration coverage live in the focused unit suite.
+
+### Verification
+
+- `issue-4208-update-to-number-ir`, `issue-4208-strict-eq-type-disjoint`,
+  `issue-4204-module-var-widening`, and `issue-1379`: **58 / 58** tests.
+- `pnpm run typecheck`: pass.
+- `pnpm run check:ir-fallbacks`: pass; no unintended, post-claim, or
+  module-level fallback increase.
+
+Fresh whole-suite baselines contain 9,029 ES5 tests: standalone is 8,052 pass,
+880 fail, 93 compile-error and 4 timeout; host GC is 7,218 pass, 1,760 fail and
+51 compile-error. S2 removes a verified six-file slice from that residue; this
+issue remains open for S3–S7 rather than claiming the overall ES5 goal complete.

--- a/src/codegen/binary-ops-typed-dispatch.ts
+++ b/src/codegen/binary-ops-typed-dispatch.ts
@@ -16,6 +16,7 @@ import { ensureAnyFromExternHelper, undefinedSingletonActive } from "./any-helpe
 import { reportError } from "./context/errors.js";
 import { allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { moduleGlobalIsDynamicButStaticallyPrimitive } from "./declarations/heterogeneous-scalar-var-widening.js";
 import { ensureLateImport } from "./expressions/late-imports.js";
 import { ensureNativeStringHelpers } from "./native-strings.js";
 import { emitNativeParseNumber } from "./parse-number-native.js";
@@ -30,6 +31,13 @@ import {
   compileI64BinaryOp,
   compileNumericBinaryOp,
 } from "./binary-ops.js";
+
+function equalityOperandHasStaleStaticType(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression): boolean {
+  return (
+    ts.isIdentifier(expr) &&
+    (fctx.forInIdentifierVars?.has(expr.text) === true || moduleGlobalIsDynamicButStaticallyPrimitive(ctx, expr))
+  );
+}
 
 /**
  * Type-directed dispatch for a binary expression whose operands have already
@@ -549,18 +557,18 @@ export function compileTypedBinaryDispatch(
   if ((leftType.kind === "externref" || rightType.kind === "externref") && (isEqOp || isNeqOp)) {
     const isStrict = op === ts.SyntaxKind.EqualsEqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
     const isStrictNeq = op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
-    // A function-scoped var used as a bare for-in target is dynamically a
-    // property-key string during the loop even when a later initializer makes
-    // TypeScript report `number` at every use. Do not constant-fold equality
-    // from that stale static type; compare the actual boxed value.
-    const leftIsDynamicForIn = ts.isIdentifier(expr.left) && fctx.forInIdentifierVars?.has(expr.left.text) === true;
-    const rightIsDynamicForIn = ts.isIdentifier(expr.right) && fctx.forInIdentifierVars?.has(expr.right.text) === true;
-    const leftIsString = !leftIsDynamicForIn && isStringType(leftTsType);
-    const rightIsString = !rightIsDynamicForIn && isStringType(rightTsType);
-    const leftIsNumber = !leftIsDynamicForIn && isNumberType(leftTsType);
-    const rightIsNumber = !rightIsDynamicForIn && isNumberType(rightTsType);
-    const leftIsBool = !leftIsDynamicForIn && isBooleanType(leftTsType);
-    const rightIsBool = !rightIsDynamicForIn && isBooleanType(rightTsType);
+    // A for-in target and a representation-widened module binding both carry
+    // runtime tags that can disagree with TypeScript's initializer-derived
+    // type. Do not constant-fold equality from that stale type; compare the
+    // actual boxed value.
+    const leftHasStaleType = equalityOperandHasStaleStaticType(ctx, fctx, expr.left);
+    const rightHasStaleType = equalityOperandHasStaleStaticType(ctx, fctx, expr.right);
+    const leftIsString = !leftHasStaleType && isStringType(leftTsType);
+    const rightIsString = !rightHasStaleType && isStringType(rightTsType);
+    const leftIsNumber = !leftHasStaleType && isNumberType(leftTsType);
+    const rightIsNumber = !rightHasStaleType && isNumberType(rightTsType);
+    const leftIsBool = !leftHasStaleType && isBooleanType(leftTsType);
+    const rightIsBool = !rightHasStaleType && isBooleanType(rightTsType);
 
     // #1776: standalone / WASI (no-JS-host) dynamic equality.
     //
@@ -1064,7 +1072,7 @@ export function compileTypedBinaryDispatch(
       return { kind: "i32" };
     }
 
-    if (!noJsHost && (leftIsDynamicForIn || rightIsDynamicForIn)) {
+    if (!noJsHost && (leftHasStaleType || rightHasStaleType)) {
       return emitHostEqualityFromStack(ctx, fctx, leftType, rightType, isStrict, isNeqOp);
     }
 

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -18,7 +18,7 @@ import {
 import type { Instr, ValType } from "../ir/types.js";
 import { ensureAnyFromExternHelper, isAnyValue, undefinedSingletonActive } from "./any-helpers.js";
 import { reportError } from "./context/errors.js";
-import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
+import { allocLocal, allocTempLocal, getLocalType, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { compileAssignment } from "./expressions/assignment.js";
 import {
@@ -33,7 +33,7 @@ import {
 } from "./expressions/helpers.js";
 import { ensureExternIsUndefinedImport, ensureLateImport } from "./expressions/late-imports.js";
 import { ensureFmod } from "./fmod.js";
-import { ensureNativeStringHelpers } from "./native-strings.js";
+import { ensureNativeStringHelpers, stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitNewTargetClassId, getOrAssignClassNewTargetId } from "./new-target.js"; // (#2023)
 import { compileLogicalAnd, compileLogicalOr, compileNullishCoalescing } from "./expressions/logical-ops.js";
 import { tryStaticToNumber } from "./expressions/misc.js";
@@ -50,6 +50,7 @@ import {
   emitLooseEq,
   emitStrictEq,
   ensureExternrefToNumberProvider,
+  runtimeToPrimitiveInstrs,
 } from "./coercion-engine.js";
 import { compileInstanceOf, compileTypeofComparison } from "./typeof-delete.js";
 import { compileTypedBinaryDispatch } from "./binary-ops-typed-dispatch.js";
@@ -57,6 +58,8 @@ import { foldTypeDisjointThenPromote } from "./strict-eq-type-disjoint.js";
 import { compileInOperator } from "./binary-ops-in.js";
 import { moduleGlobalIsDynamicButStaticallyPrimitive } from "./declarations/heterogeneous-scalar-var-widening.js";
 import { emitIsUndefF64 } from "./value-tags.js";
+import { NATIVE_FUNCTION_SOURCE } from "./callable-to-string.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
 
 // ── Binary operations ─────────────────────────────────────────────────
 
@@ -223,6 +226,11 @@ function tryFlattenBinaryChain(
     if (isStringType(tsType)) return null;
     if (isBigIntType(tsType)) return null;
     if ((tsType.flags & ts.TypeFlags.Any) !== 0) return null;
+    // `+` is not numeric-only: Object/unknown operands may ToPrimitive to a
+    // string and force concatenation. Keep those chains on the dynamic path.
+    if (op === ts.SyntaxKind.PlusToken && (tsType.flags & (ts.TypeFlags.Object | ts.TypeFlags.Unknown)) !== 0) {
+      return null;
+    }
   }
 
   // Determine numeric hint — also check if all operands use native i32 type annotations
@@ -1270,7 +1278,7 @@ export function compileBinaryExpression(
     isEqualityOp && ts.isIdentifier(expr.left) && moduleGlobalIsDynamicButStaticallyPrimitive(ctx, expr.left);
   const rightIsAbstractNonString =
     !rightIsStrLike &&
-    (rightTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0 &&
+    (rightTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Object)) !== 0 &&
     ctx.nativeStrings &&
     ctx.anyStrTypeIdx >= 0;
   if (
@@ -1621,26 +1629,27 @@ export function compileBinaryExpression(
     op === ts.SyntaxKind.GreaterThanGreaterThanToken ||
     op === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken;
 
-  // (#2058) `+` where an operand is statically `any`/`unknown` (so it lowers to a
-  // dynamic externref that may hold a runtime string). §13.15.3 requires
+  // (#2058/#4208) `+` where an operand is statically `any`/`unknown`, or is a
+  // concrete object/function that must run ToPrimitive. §13.15.3 requires
   // concatenation when either ToPrimitive result is a string, but the numeric
   // paths below compile both operands with an f64 hint — ToNumber-coercing a
   // runtime string, so `1 + "2"` wrongly produced `3` instead of `"12"`. Route
-  // these through a runtime-dispatched add BEFORE the f64 hint is applied. We
-  // require at least one `any`/`unknown` operand: provably-numeric and
-  // provably-string `+` were already handled above (string concat at the
-  // isStringType gate, numeric via the typed fast paths), so this leaves their
-  // codegen untouched. `ctx.fast` mode keeps its i32/f64 numeric semantics for
-  // statically-typed operands and is unaffected (those aren't `any`/`unknown`).
+  // these through a runtime-dispatched add BEFORE the f64 hint is applied.
   //
-  // Fast mode (`anyValueTypeIdx >= 0`) is excluded: there `any + any` is routed
-  // through `compileAnyBinaryDispatch` (the AnyValue `__any_add` helper) earlier,
-  // and the `__host_add` host import isn't part of that ABI. Per the #2058 design
-  // rule, this per-site recovery is **default-mode only**.
-  if (op === ts.SyntaxKind.PlusToken && ctx.anyValueTypeIdx < 0) {
-    const leftIsAnyish = (leftTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
-    const rightIsAnyish = (rightTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
-    if ((leftIsAnyish || rightIsAnyish) && !isBigIntType(leftTsType) && !isBigIntType(rightTsType)) {
+  // Fast mode still owns `any + any` through `compileAnyBinaryDispatch`, but a
+  // concrete Object operand is not admitted to that gate. It must use this
+  // path in every mode or the later numeric hint erases its primitive family.
+  if (op === ts.SyntaxKind.PlusToken) {
+    const abstractOperandFlags = ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Object;
+    const leftIsAnyish = (leftTsType.flags & abstractOperandFlags) !== 0;
+    const rightIsAnyish = (rightTsType.flags & abstractOperandFlags) !== 0;
+    const hasConcreteObject =
+      (leftTsType.flags & ts.TypeFlags.Object) !== 0 || (rightTsType.flags & ts.TypeFlags.Object) !== 0;
+    if (
+      (hasConcreteObject || (ctx.anyValueTypeIdx < 0 && (leftIsAnyish || rightIsAnyish))) &&
+      !isBigIntType(leftTsType) &&
+      !isBigIntType(rightTsType)
+    ) {
       return emitAnyAdd(ctx, fctx, expr);
     }
   }
@@ -1652,20 +1661,25 @@ export function compileBinaryExpression(
   // `("a" as any) < ("b" as any)` wrongly yielded `false`. Route these through a
   // runtime-dispatched compare BEFORE the f64 hint is applied.
   //
-  // CRITICAL (#1374 lesson): gate on **statically any/unknown** operands only,
-  // NOT on "any non-numeric TS type". The closed PR #1374 gated on
-  // `!isPrimNumericish` (both sides), which routed object/class relationals to
-  // the host comparator — host `<` then threw on opaque WasmGC structs (14
-  // runtime_error regressions). A concrete object/class operand is NOT
-  // any/unknown, so it keeps its existing relational path.
+  // Concrete object/function operands are also runtime-dispatched now. The old
+  // #1374 attempt could not do this safely because the host comparator received
+  // opaque WasmGC structs directly. `host_compare` now performs the required
+  // ToPrimitive(number) walk first, while standalone does the same below before
+  // its string-vs-number split.
   //
-  // Fast mode (`anyValueTypeIdx >= 0`) is excluded for the same reason as the
-  // `+` gate — the AnyValue helpers own that ABI. Per-site recovery is
-  // default-mode only.
-  if (isRelational && ctx.anyValueTypeIdx < 0) {
-    const leftIsAnyish = (leftTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
-    const rightIsAnyish = (rightTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
-    if ((leftIsAnyish || rightIsAnyish) && !isBigIntType(leftTsType) && !isBigIntType(rightTsType)) {
+  // As with `+`, fast mode keeps its AnyValue dispatch for genuinely dynamic
+  // operands, while concrete Object operands always take this runtime path.
+  if (isRelational) {
+    const abstractOperandFlags = ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Object;
+    const leftIsAnyish = (leftTsType.flags & abstractOperandFlags) !== 0;
+    const rightIsAnyish = (rightTsType.flags & abstractOperandFlags) !== 0;
+    const hasConcreteObject =
+      (leftTsType.flags & ts.TypeFlags.Object) !== 0 || (rightTsType.flags & ts.TypeFlags.Object) !== 0;
+    if (
+      (hasConcreteObject || (ctx.anyValueTypeIdx < 0 && (leftIsAnyish || rightIsAnyish))) &&
+      !isBigIntType(leftTsType) &&
+      !isBigIntType(rightTsType)
+    ) {
       return emitAnyRelational(ctx, fctx, expr, op);
     }
   }
@@ -2232,6 +2246,37 @@ function structHasStaticNumericToPrimitive(ctx: CodegenContext, name: string | u
 }
 
 /**
+ * Emit the exact OrdinaryToPrimitive(default/number) result for the two direct
+ * literal families whose inherited conversion is statically fixed. This keeps
+ * an empty object or closure from crossing the externref boundary as an opaque
+ * nominal struct that the standalone `$Object` runtime cannot recognize.
+ */
+function emitKnownLiteralPrimitive(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression): boolean {
+  let inner = expr;
+  while (
+    ts.isParenthesizedExpression(inner) ||
+    ts.isAsExpression(inner) ||
+    ts.isNonNullExpression(inner) ||
+    ts.isSatisfiesExpression(inner) ||
+    ts.isTypeAssertionExpression(inner)
+  ) {
+    inner = inner.expression;
+  }
+
+  let text: string | undefined;
+  if (ts.isObjectLiteralExpression(inner) && inner.properties.length === 0) {
+    text = "[object Object]";
+  } else if (ts.isFunctionExpression(inner) || ts.isArrowFunction(inner) || ts.isClassExpression(inner)) {
+    text = NATIVE_FUNCTION_SOURCE;
+  }
+  if (text === undefined) return false;
+
+  addStringConstantGlobal(ctx, text);
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, text));
+  return true;
+}
+
+/**
  * (#2358) Compile one `+` operand into a fresh externref temp and return its
  * index (or null if the operand failed to compile).
  *
@@ -2267,8 +2312,15 @@ function emitAddOperand(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Exp
   ) {
     inner = (inner as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression).expression;
   }
+  const localIdx = ts.isIdentifier(inner) ? fctx.localMap.get(inner.text) : undefined;
+  const liveExternrefBinding = localIdx !== undefined && getLocalType(fctx, localIdx)?.kind === "externref";
+  if (emitKnownLiteralPrimitive(ctx, fctx, inner)) {
+    const tmp = allocTempLocal(fctx, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: tmp });
+    return tmp;
+  }
   const structName = noJsHost ? resolveStructNameForExpr(ctx, fctx, inner) : undefined;
-  if (noJsHost && structHasStaticNumericToPrimitive(ctx, structName)) {
+  if (noJsHost && !liveExternrefBinding && structHasStaticNumericToPrimitive(ctx, structName)) {
     const opType = compileExpression(ctx, fctx, inner);
     if (!opType) return null;
     if (opType.kind === "ref" || opType.kind === "ref_null") {
@@ -2524,13 +2576,22 @@ export function emitAnyRelational(
 ): ValType {
   const noJsHost = ctx.standalone === true || ctx.wasi === true;
 
+  // Standalone needs the same OrdinaryToPrimitive frontier as host_compare.
+  // Register it before operand emission so defined-function indices remain
+  // stable while this function body is assembled.
+  if (noJsHost) ensureObjectRuntime(ctx);
+
   // Compile both operands to externref temps (keep runtime strings boxed).
-  const lType = compileExpression(ctx, fctx, expr.left, { kind: "externref" });
+  const lType = emitKnownLiteralPrimitive(ctx, fctx, expr.left)
+    ? ({ kind: "externref" } as const)
+    : compileExpression(ctx, fctx, expr.left, { kind: "externref" });
   if (!lType) return { kind: "i32" };
   if (lType.kind !== "externref") coerceType(ctx, fctx, lType, { kind: "externref" });
   const lTmp = allocTempLocal(fctx, { kind: "externref" });
   fctx.body.push({ op: "local.set", index: lTmp });
-  const rType = compileExpression(ctx, fctx, expr.right, { kind: "externref" });
+  const rType = emitKnownLiteralPrimitive(ctx, fctx, expr.right)
+    ? ({ kind: "externref" } as const)
+    : compileExpression(ctx, fctx, expr.right, { kind: "externref" });
   if (!rType) {
     releaseTempLocal(fctx, lTmp);
     return { kind: "i32" };
@@ -2538,6 +2599,14 @@ export function emitAnyRelational(
   if (rType.kind !== "externref") coerceType(ctx, fctx, rType, { kind: "externref" });
   const rTmp = allocTempLocal(fctx, { kind: "externref" });
   fctx.body.push({ op: "local.set", index: rTmp });
+
+  if (noJsHost) {
+    const toPrimitive = runtimeToPrimitiveInstrs(ctx, "number");
+    if (toPrimitive !== null) {
+      fctx.body.push({ op: "local.get", index: lTmp }, ...toPrimitive, { op: "local.set", index: lTmp });
+      fctx.body.push({ op: "local.get", index: rTmp }, ...toPrimitive, { op: "local.set", index: rTmp });
+    }
+  }
 
   // Map a -1/0/1/2 `cmp` (or an f64 comparison) to the operator's boolean result.
   // The `2` (incomparable) sentinel must make ALL four operators yield 0, so we

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -90,6 +90,34 @@ export function runtimeToPrimitiveInstrs(ctx: CodegenContext, hint: "string" | "
   return [...stringConstantExternrefInstrs(ctx, hint), { op: "call", funcIdx }];
 }
 
+/**
+ * Ensure the canonical runtime ToPrimitive provider exists, then emit its ABI
+ * for the value already on the stack. AST codegen sites use this entry point
+ * instead of spelling the helper import and hint protocol themselves.
+ */
+export function emitRuntimeToPrimitive(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  hint: "string" | "number" | "default",
+): boolean {
+  const provisionalIdx = ensureLateImport(
+    ctx,
+    "__to_primitive",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  const funcIdx = ctx.funcMap.get("__to_primitive") ?? provisionalIdx;
+  if (funcIdx === undefined) return false;
+  if (hint === "default") {
+    fctx.body.push({ op: "ref.null.extern" }, { op: "call", funcIdx });
+    return true;
+  }
+  addStringConstantGlobal(ctx, hint);
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, hint), { op: "call", funcIdx });
+  return true;
+}
+
 /** True when the active mode represents strings as a native `$AnyString` GC ref. */
 function isNativeStringMode(mode: CoercionMode): boolean {
   return mode === "standalone" || mode === "native-strings-host";

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -276,6 +276,8 @@ export function createCodegenContext(
     objectHashConsumerTypes: new Set(),
     dynamicObjectReturnFunctions: new Set(),
     growableObjectLiteralVars: new Set(),
+    ordinaryToPrimitiveObjectDeclarations: new Set(),
+    ordinaryToPrimitiveObjectLiterals: new Set(),
     externrefAccessorVars: new Set(),
     pendingMathMethods: new Set(),
     pendingMethodTrampolines: [],

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2923,6 +2923,19 @@ export interface CodegenContext {
    */
   growableObjectLiteralVars: Set<string>;
   /**
+   * (#4208) Exact declarations whose shared `var` binding is repeatedly
+   * initialized with different OrdinaryToPrimitive method shapes. These
+   * literals must use the open `$Object` carrier: a closed anonymous struct
+   * cannot safely receive a later sibling shape, and the guarded reassignment
+   * otherwise stores null before `valueOf` / `toString` can run.
+   *
+   * Declaration identity is intentional. A bare-name set would poison every
+   * unrelated local named `object` in the same compilation unit.
+   */
+  ordinaryToPrimitiveObjectDeclarations: Set<ts.VariableDeclaration>;
+  /** Initializer-node twin of `ordinaryToPrimitiveObjectDeclarations`. */
+  ordinaryToPrimitiveObjectLiterals: Set<ts.ObjectLiteralExpression>;
+  /**
    * (#1239) Variable names whose initializer is an object literal carrying
    * `get`/`set` accessors. Such variables are stored as plain JS host
    * objects (via `__new_plain_object` + `__defineProperty_accessor`) and

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1726,6 +1726,7 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
    */
   function moduleInitForcesExternref(decl: ts.VariableDeclaration): boolean {
     if (!decl.initializer) return false;
+    if (ctx.ordinaryToPrimitiveObjectDeclarations.has(decl)) return true;
     // (#3365) Script top-level `this` is the host global object. The checker
     // describes it as the enormous structural `typeof globalThis` type, but
     // module init receives a genuine host externref. Keep the storage and all

--- a/src/codegen/declarations/heterogeneous-scalar-var-widening.ts
+++ b/src/codegen/declarations/heterogeneous-scalar-var-widening.ts
@@ -38,6 +38,11 @@
  */
 import type { JsTag } from "../../checker/oracle.js";
 import type { ValType } from "../../ir/types.js";
+import {
+  updateRetypesModuleBinding,
+  updateRetypesModuleBindingName,
+  updateRetypesModuleIdentifier,
+} from "../../ir/update-retyped-bindings.js";
 import { ts } from "../../ts-api.js";
 import type { CodegenContext } from "../context/types.js";
 import { localGlobalIdx } from "../registry/imports.js";
@@ -60,6 +65,13 @@ export function heterogeneousWidenedModuleGlobalType(
   decl: ts.VariableDeclaration,
 ): ValType | undefined {
   if (!ts.isIdentifier(decl.name)) return undefined;
+  // #4208 S2 — `++` / `--` always stores the result of ToNumeric back into
+  // the target. A string, Boolean, wrapper or ordinary object initializer may
+  // therefore need to coexist with a later Number even without an explicit
+  // assignment. IR owns the binding-identity proof; direct codegen uses the
+  // same verdict so a conservatively demoted module initializer keeps the
+  // representation chosen during selection.
+  if (updateRetypesModuleBinding(ctx.oracle, decl)) return { kind: "externref" };
   let perFile = analysisCache.get(ctx);
   if (perFile === undefined) {
     perFile = new Map();
@@ -106,6 +118,17 @@ export function moduleGlobalIsDynamicButStaticallyPrimitive(ctx: CodegenContext,
   const globalIdx = ctx.moduleGlobals.get(id.text);
   if (globalIdx === undefined) return false;
   if (ctx.mod.globals[localGlobalIdx(ctx, globalIdx)]?.type.kind !== "externref") return false;
+  // Sloppy-script `var` redeclarations make the oracle's singular declaration
+  // lookup intentionally return undefined. The update analysis is
+  // symbol/declaration-set based, so it remains exact for that legal binding
+  // shape and prevents stale checker types from selecting a string/Boolean
+  // comparison after the update has stored a Number.
+  if (
+    updateRetypesModuleIdentifier(ctx.oracle, id) ||
+    (isModuleScoped(id) && updateRetypesModuleBindingName(ctx.oracle, id.getSourceFile(), id.text))
+  ) {
+    return true;
+  }
   const decl = ctx.oracle.variableDeclarationOf(id);
   if (decl === undefined || !ts.isIdentifier(decl.name) || !isModuleScoped(decl)) return false;
   const tag = ctx.oracle.staticJsTypeOf(id);

--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -586,6 +586,41 @@ function isNumericOrdinaryToPrimitiveUse(identifier: ts.Identifier): boolean {
   }
 }
 
+function isDirectOrdinaryToPrimitiveLiteralUse(literal: ts.ObjectLiteralExpression): boolean {
+  const parent = literal.parent;
+  if (!parent) return false;
+  if (ts.isPrefixUnaryExpression(parent) && parent.operand === literal) {
+    return (
+      parent.operator === ts.SyntaxKind.PlusToken ||
+      parent.operator === ts.SyntaxKind.MinusToken ||
+      parent.operator === ts.SyntaxKind.TildeToken
+    );
+  }
+  if (!ts.isBinaryExpression(parent) || (parent.left !== literal && parent.right !== literal)) return false;
+  switch (parent.operatorToken.kind) {
+    case ts.SyntaxKind.PlusToken:
+    case ts.SyntaxKind.MinusToken:
+    case ts.SyntaxKind.AsteriskToken:
+    case ts.SyntaxKind.SlashToken:
+    case ts.SyntaxKind.PercentToken:
+    case ts.SyntaxKind.LessThanToken:
+    case ts.SyntaxKind.LessThanEqualsToken:
+    case ts.SyntaxKind.GreaterThanToken:
+    case ts.SyntaxKind.GreaterThanEqualsToken:
+    case ts.SyntaxKind.EqualsEqualsToken:
+    case ts.SyntaxKind.ExclamationEqualsToken:
+    case ts.SyntaxKind.AmpersandToken:
+    case ts.SyntaxKind.BarToken:
+    case ts.SyntaxKind.CaretToken:
+    case ts.SyntaxKind.LessThanLessThanToken:
+    case ts.SyntaxKind.GreaterThanGreaterThanToken:
+    case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
+      return true;
+    default:
+      return false;
+  }
+}
+
 /**
  * #4208 — find one exact ES3/ES5 idiom before local-slot allocation:
  *
@@ -608,7 +643,17 @@ function collectRepeatedOrdinaryToPrimitiveObjects(
   const declarationsBySymbol = new Map<ts.Symbol, ts.VariableDeclaration[]>();
   const coerciveSymbols = new Set<ts.Symbol>();
   const visit = (node: ts.Node): void => {
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+    if (
+      ts.isObjectLiteralExpression(node) &&
+      isOrdinaryToPrimitiveLiteralCandidate(node) &&
+      isDirectOrdinaryToPrimitiveLiteralUse(node)
+    ) {
+      // A directly-coerced method-only literal has no closed-struct consumer:
+      // its first observable operation is ToPrimitive itself. Build it in the
+      // same open carrier as repeated declarations so runtime loose equality
+      // can distinguish an Object from the primitive returned by valueOf.
+      ctx.ordinaryToPrimitiveObjectLiterals.add(node);
+    } else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
       const list = node.parent;
       const isVar =
         ts.isVariableDeclarationList(list) &&

--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -527,6 +527,127 @@ function recordOpenObjectConsumerTypes(
   if (sig) ctx.objectHashConsumerTypes.add(checker.getReturnTypeOfSignature(sig));
 }
 
+function ordinaryToPrimitivePropertyName(property: ts.ObjectLiteralElementLike): string | undefined {
+  if (!ts.isPropertyAssignment(property)) return undefined;
+  const name = property.name;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  return undefined;
+}
+
+function isOrdinaryToPrimitiveLiteralCandidate(literal: ts.ObjectLiteralExpression): boolean {
+  if (literal.properties.length === 0) return false;
+  let hasMethod = false;
+  for (const property of literal.properties) {
+    const name = ordinaryToPrimitivePropertyName(property);
+    if (name === undefined) return false;
+    if (name !== "valueOf" && name !== "toString") return false;
+    const initializer = (property as ts.PropertyAssignment).initializer;
+    if (!ts.isFunctionExpression(initializer) || initializer.name || initializer.parameters.length !== 0) return false;
+    hasMethod = true;
+  }
+  return hasMethod;
+}
+
+function isNumericOrdinaryToPrimitiveUse(identifier: ts.Identifier): boolean {
+  const parent = identifier.parent;
+  if (!parent) return false;
+  if (ts.isPrefixUnaryExpression(parent) && parent.operand === identifier) {
+    return (
+      parent.operator === ts.SyntaxKind.PlusToken ||
+      parent.operator === ts.SyntaxKind.MinusToken ||
+      parent.operator === ts.SyntaxKind.TildeToken
+    );
+  }
+  if ((ts.isPrefixUnaryExpression(parent) || ts.isPostfixUnaryExpression(parent)) && parent.operand === identifier) {
+    return parent.operator === ts.SyntaxKind.PlusPlusToken || parent.operator === ts.SyntaxKind.MinusMinusToken;
+  }
+  if (!ts.isBinaryExpression(parent) || (parent.left !== identifier && parent.right !== identifier)) return false;
+  switch (parent.operatorToken.kind) {
+    case ts.SyntaxKind.PlusToken:
+    case ts.SyntaxKind.MinusToken:
+    case ts.SyntaxKind.AsteriskToken:
+    case ts.SyntaxKind.SlashToken:
+    case ts.SyntaxKind.PercentToken:
+    case ts.SyntaxKind.LessThanLessThanToken:
+    case ts.SyntaxKind.GreaterThanGreaterThanToken:
+    case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
+    case ts.SyntaxKind.AmpersandToken:
+    case ts.SyntaxKind.BarToken:
+    case ts.SyntaxKind.CaretToken:
+    case ts.SyntaxKind.LessThanToken:
+    case ts.SyntaxKind.LessThanEqualsToken:
+    case ts.SyntaxKind.GreaterThanToken:
+    case ts.SyntaxKind.GreaterThanEqualsToken:
+    case ts.SyntaxKind.EqualsEqualsToken:
+    case ts.SyntaxKind.ExclamationEqualsToken:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * #4208 — find one exact ES3/ES5 idiom before local-slot allocation:
+ *
+ *   var object = { valueOf: function () { ... } };
+ *   ... ToNumber(object) ...
+ *   var object = { toString: function () { ... } };
+ *
+ * Every `var` declaration denotes the same function-scoped binding, but the
+ * old representation selected a different closed anonymous struct at each
+ * initializer. The later guarded store therefore produced null. Keep this
+ * bounded to checker-identical bindings, compatible method-only literals, and
+ * an observed coercive use, then pin every declaration/literal to the open
+ * `$Object` representation used by the canonical OrdinaryToPrimitive runtime.
+ */
+function collectRepeatedOrdinaryToPrimitiveObjects(
+  ctx: CodegenContext,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+): void {
+  const declarationsBySymbol = new Map<ts.Symbol, ts.VariableDeclaration[]>();
+  const coerciveSymbols = new Set<ts.Symbol>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      const list = node.parent;
+      const isVar =
+        ts.isVariableDeclarationList(list) &&
+        (list.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const | ts.NodeFlags.Using | ts.NodeFlags.AwaitUsing)) === 0;
+      const symbol = isVar ? checker.getSymbolAtLocation(node.name) : undefined;
+      if (symbol) {
+        const declarations = declarationsBySymbol.get(symbol) ?? [];
+        declarations.push(node);
+        declarationsBySymbol.set(symbol, declarations);
+      }
+    } else if (ts.isIdentifier(node) && isNumericOrdinaryToPrimitiveUse(node)) {
+      const symbol = checker.getSymbolAtLocation(node);
+      if (symbol) coerciveSymbols.add(symbol);
+    }
+    forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  for (const [symbol, declarations] of declarationsBySymbol) {
+    if (declarations.length < 2 || !coerciveSymbols.has(symbol)) continue;
+    if (
+      declarations.some(
+        (declaration) =>
+          !declaration.initializer ||
+          !ts.isObjectLiteralExpression(declaration.initializer) ||
+          !isOrdinaryToPrimitiveLiteralCandidate(declaration.initializer),
+      )
+    ) {
+      continue;
+    }
+    for (const declaration of declarations) {
+      const literal = declaration.initializer as ts.ObjectLiteralExpression;
+      ctx.ordinaryToPrimitiveObjectDeclarations.add(declaration);
+      ctx.ordinaryToPrimitiveObjectLiterals.add(literal);
+      recordOpenObjectConsumerTypes(ctx, checker, declaration, (declaration.name as ts.Identifier).text);
+    }
+  }
+}
+
 /**
  * (#2837) Detection pre-pass: mark variables initialized by a NON-EMPTY object
  * literal that later receive an OUT-OF-SHAPE property write, so `compileObjectLiteral`
@@ -559,6 +680,7 @@ export function collectGrowableObjectLiterals(
   checker: ts.TypeChecker,
   sourceFile: ts.SourceFile,
 ): void {
+  collectRepeatedOrdinaryToPrimitiveObjects(ctx, checker, sourceFile);
   // Emergency rollback for the closed-outer-table refinement below. Keeping
   // this narrow switch makes the performance claim directly A/B measurable:
   // `0` restores the old "every depth-2 write opens the root" policy.

--- a/src/codegen/expressions/misc.ts
+++ b/src/codegen/expressions/misc.ts
@@ -392,6 +392,18 @@ export function tryStaticToNumber(
   }
   // Binary expressions: fold constant operands at compile time
   if (ts.isBinaryExpression(expr)) {
+    // `+` selects concatenation after ToPrimitive(default), before ToNumber.
+    // Folding an Object operand through this numeric helper loses whether its
+    // primitive was a string: for example `{} + {}` was folded as NaN + NaN,
+    // even though both objects first become "[object Object]" strings. Keep
+    // object/unknown additions on the runtime string-or-number dispatcher.
+    if (expr.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+      const leftFact = ctx.oracle.typeFactOf(expr.left).kind;
+      const rightFact = ctx.oracle.typeFactOf(expr.right).kind;
+      if (leftFact === "object" || rightFact === "object" || leftFact === "unknown" || rightFact === "unknown") {
+        return undefined;
+      }
+    }
     // Don't fold string + anything as numeric — JS semantics requires string concat
     if (
       expr.operatorToken.kind === ts.SyntaxKind.PlusToken &&

--- a/src/codegen/expressions/unary-updates.ts
+++ b/src/codegen/expressions/unary-updates.ts
@@ -17,6 +17,7 @@ import { reportSilentFallback } from "../fallback-telemetry.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { compileWithUpdateExpression } from "../with-rmw.js";
+import { emitToNumber } from "../coercion-engine.js";
 import {
   addStringConstantGlobal,
   addUnionImports,
@@ -98,9 +99,12 @@ function unwrapParens(node: ts.Expression): ts.Expression {
  * Expects one externref on the stack; leaves one f64.
  */
 function emitToNumericForUpdate(ctx: CodegenContext, fctx: FunctionContext): void {
-  addUnionImports(ctx);
-  const unboxIdx = ctx.funcMap.get("__unbox_number")!;
-  fctx.body.push({ op: "call", funcIdx: unboxIdx });
+  // Use the same canonical coercion engine as IR `dyn.to_number`. In the JS
+  // host lane this remains the existing `__unbox_number` call; standalone
+  // first runs native OrdinaryToPrimitive("number") and only then unboxes.
+  // Calling `__unbox_number` directly skipped user valueOf/toString and the
+  // primitive slots of Boolean/Number wrappers.
+  emitToNumber(ctx, fctx, { kind: "externref" });
 }
 
 /**
@@ -1152,32 +1156,6 @@ function compilePrefixUpdate(
         // Check module globals for prefix ++
         const ppModIdx = ctx.moduleGlobals.get(ppOperand.text);
         if (ppModIdx !== undefined) {
-          const ppModGlobalDef = ctx.mod.globals[localGlobalIdx(ctx, ppModIdx)];
-          if (ppModGlobalDef?.type.kind === "externref") {
-            // externref global: safe unbox to f64, add 1, box back
-            fctx.body.push({ op: "global.get", index: ppModIdx });
-            emitToNumericForUpdate(ctx, fctx);
-            fctx.body.push({ op: "f64.const", value: 1 });
-            fctx.body.push({ op: "f64.add" });
-            addUnionImports(ctx);
-            fctx.body.push({
-              op: "call",
-              funcIdx: ctx.funcMap.get("__box_number")!,
-            });
-            fctx.body.push({ op: "global.set", index: ppModIdx });
-            fctx.body.push({ op: "global.get", index: ppModIdx });
-            return { kind: "externref" };
-          }
-          if (ppModGlobalDef && (ppModGlobalDef.type.kind === "ref" || ppModGlobalDef.type.kind === "ref_null")) {
-            // ref global: coerce via valueOf, result is NaN+1 = NaN for plain objects
-            fctx.body.push({ op: "global.get", index: ppModIdx });
-            coerceType(ctx, fctx, ppModGlobalDef.type, { kind: "f64" });
-            fctx.body.push({ op: "f64.const", value: 1 });
-            fctx.body.push({ op: "f64.add" });
-            return { kind: "f64" };
-          }
-          // (#4079) f64 OR i32 backing slot — the shared helper owns the
-          // read/store coercion so the i32 case cannot be forgotten again.
           return compileGlobalIncDec(ctx, fctx, ppModIdx, "f64.add", "prefix");
         }
         // Check captured globals for prefix ++
@@ -1358,29 +1336,6 @@ function compilePrefixUpdate(
         // Check module globals for prefix --
         const mmModIdx = ctx.moduleGlobals.get(mmOperand.text);
         if (mmModIdx !== undefined) {
-          const mmModGlobalDef = ctx.mod.globals[localGlobalIdx(ctx, mmModIdx)];
-          if (mmModGlobalDef?.type.kind === "externref") {
-            fctx.body.push({ op: "global.get", index: mmModIdx });
-            emitToNumericForUpdate(ctx, fctx);
-            fctx.body.push({ op: "f64.const", value: 1 });
-            fctx.body.push({ op: arithOp });
-            addUnionImports(ctx);
-            fctx.body.push({
-              op: "call",
-              funcIdx: ctx.funcMap.get("__box_number")!,
-            });
-            fctx.body.push({ op: "global.set", index: mmModIdx });
-            fctx.body.push({ op: "global.get", index: mmModIdx });
-            return { kind: "externref" };
-          }
-          if (mmModGlobalDef && (mmModGlobalDef.type.kind === "ref" || mmModGlobalDef.type.kind === "ref_null")) {
-            fctx.body.push({ op: "global.get", index: mmModIdx });
-            coerceType(ctx, fctx, mmModGlobalDef.type, { kind: "f64" });
-            fctx.body.push({ op: "f64.const", value: 1 });
-            fctx.body.push({ op: arithOp });
-            return { kind: "f64" };
-          }
-          // (#4079) f64 OR i32 backing slot — see compileGlobalIncDec.
           return compileGlobalIncDec(ctx, fctx, mmModIdx, arithOp, "prefix");
         }
         // Check captured globals for prefix --
@@ -1468,31 +1423,6 @@ function compilePostfixUnary(
       // Check module globals for postfix ++/--
       const postModIdx = ctx.moduleGlobals.get(postOperand.text);
       if (postModIdx !== undefined) {
-        const postModGlobalDef = ctx.mod.globals[localGlobalIdx(ctx, postModIdx)];
-        if (postModGlobalDef?.type.kind === "externref") {
-          // externref global: safe unbox old value, compute new, box and store back
-          fctx.body.push({ op: "global.get", index: postModIdx });
-          emitToNumericForUpdate(ctx, fctx);
-          const postOldTmp = allocLocal(fctx, `__post_old_${fctx.locals.length}`, { kind: "f64" });
-          fctx.body.push({ op: "local.tee", index: postOldTmp });
-          fctx.body.push({ op: "f64.const", value: 1 });
-          fctx.body.push({ op: arithOp });
-          addUnionImports(ctx);
-          fctx.body.push({
-            op: "call",
-            funcIdx: ctx.funcMap.get("__box_number")!,
-          });
-          fctx.body.push({ op: "global.set", index: postModIdx });
-          fctx.body.push({ op: "local.get", index: postOldTmp });
-          return { kind: "f64" };
-        }
-        if (postModGlobalDef && (postModGlobalDef.type.kind === "ref" || postModGlobalDef.type.kind === "ref_null")) {
-          // ref global: coerce via valueOf, postfix returns old numeric value
-          fctx.body.push({ op: "global.get", index: postModIdx });
-          coerceType(ctx, fctx, postModGlobalDef.type, { kind: "f64" });
-          return { kind: "f64" };
-        }
-        // (#4079) f64 OR i32 backing slot — see compileGlobalIncDec.
         return compileGlobalIncDec(ctx, fctx, postModIdx, arithOp, "postfix");
       }
       // Check captured globals for postfix ++/--

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -9068,6 +9068,9 @@ function hoistVarDecl(ctx: CodegenContext, fctx: FunctionContext, decl: ts.Varia
     // resolveStructNameForExpr sees the override at every later access.
     let initForcesExternref = false;
     if (decl.initializer && ts.isObjectLiteralExpression(decl.initializer)) {
+      if (ctx.ordinaryToPrimitiveObjectDeclarations.has(decl)) {
+        initForcesExternref = true;
+      }
       // (#802 Slice A) A proto-receiver object literal is built as an open
       // `$Object` (externref, standalone-only) in compileObjectLiteral; the
       // hoisted `var` slot must be externref to match (mirrors the let/const path
@@ -9769,7 +9772,12 @@ function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: t
           decl.initializer !== undefined &&
           ts.isObjectLiteralExpression(decl.initializer) &&
           ctx.dynamicProtoLiteralNodes.has(decl.initializer);
-        const initForcesExternref = initIsAccessorLiteral || initIsHostSpreadLiteral || initIsProtoReceiverLiteral;
+        const initIsOrdinaryToPrimitiveObjectLiteral = ctx.ordinaryToPrimitiveObjectDeclarations.has(decl);
+        const initForcesExternref =
+          initIsAccessorLiteral ||
+          initIsHostSpreadLiteral ||
+          initIsOrdinaryToPrimitiveObjectLiteral ||
+          initIsProtoReceiverLiteral;
         if (initForcesExternref) {
           ctx.externrefAccessorVars.add(name);
         }

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1653,6 +1653,16 @@ export function compileObjectLiteral(
     // fall through to the struct path if the $Object builder declined.
   }
 
+  // (#4208) A checker-identical `var` binding repeatedly initialized with
+  // different valueOf/toString-only literal shapes cannot use a closed struct:
+  // the sibling shape fails the guarded store and the next coercion sees null.
+  // The pre-pass pins only the exact initializer nodes, so unrelated locals
+  // named `object` retain their existing representation.
+  if (ctx.ordinaryToPrimitiveObjectLiterals.has(expr)) {
+    const ordinaryObject = compileObjectLiteralAsExternref(ctx, fctx, expr);
+    if (ordinaryObject) return ordinaryObject;
+  }
+
   // (#2837) A NON-EMPTY object literal initializing a variable that the detection
   // pre-pass (collectGrowableObjectLiterals) marked growable — i.e. it later
   // receives an OUT-OF-SHAPE property write (direct unknown key, or a nested

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -651,6 +651,7 @@ function localTypeForDeclaration(ctx: CodegenContext, type: ts.Type, decl?: ts.V
   // It is a user assertion and outranks every inference below it.
   const nativeLocal = nativeTypeOfDeclaration(ctx.checker, decl);
   if (nativeLocal) return nativeLocal;
+  if (decl && ctx.ordinaryToPrimitiveObjectDeclarations.has(decl)) return { kind: "externref" };
   if (decl && bindingHasMixedAssignmentCarrier(ctx, decl)) return { kind: "externref" };
   if (isNullablePrimitiveType(type)) return { kind: "externref" };
   // (#2806) A `var x = (void 0)` binding needs an externref slot (the same one
@@ -687,6 +688,7 @@ function localTypeForDeclaration(ctx: CodegenContext, type: ts.Type, decl?: ts.V
 export function resolveSpillLocalValType(ctx: CodegenContext, decl: ts.VariableDeclaration): ValType | null {
   if (!ts.isIdentifier(decl.name)) return null;
   const name = decl.name.text;
+  if (ctx.ordinaryToPrimitiveObjectDeclarations.has(decl)) return { kind: "externref" };
   // Names the main-body analysis already routed to a host / externref slot
   // (accessor literal, host-spread literal, growable / out-of-shape object).
   if (ctx.externrefAccessorVars.has(name)) return { kind: "externref" };
@@ -844,6 +846,7 @@ export function hoistedVarRetypesToConcreteRef(ctx: CodegenContext, decl: ts.Var
   if (
     decl.initializer !== undefined &&
     ts.isObjectLiteralExpression(decl.initializer) &&
+    !ctx.ordinaryToPrimitiveObjectDeclarations.has(decl) &&
     !(ts.isIdentifier(decl.name) && ctx.growableObjectLiteralVars.has(decl.name.text)) &&
     objectLiteralIsStandaloneAnyObjectCarrier(ctx, decl.initializer)
   ) {
@@ -1690,6 +1693,7 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       ts.isObjectLiteralExpression(decl.initializer) &&
       ts.isIdentifier(decl.name) &&
       ctx.growableObjectLiteralVars.has(decl.name.text);
+    const initIsOrdinaryToPrimitiveObjectLiteral = ctx.ordinaryToPrimitiveObjectDeclarations.has(decl);
     // (#802 Slice A) A proto-receiver object literal is built as an open `$Object`
     // (externref) in compileObjectLiteral so `Object.setPrototypeOf(o, p)` &
     // inherited reads work; the local must be externref so reads/writes route
@@ -1701,7 +1705,13 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       decl.initializer !== undefined &&
       ts.isObjectLiteralExpression(decl.initializer) &&
       ctx.dynamicProtoLiteralNodes.has(decl.initializer);
-    if (initIsAccessorLiteral || initIsHostSpreadLiteral || initIsGrowableObjectLiteral || initIsProtoReceiverLiteral) {
+    if (
+      initIsAccessorLiteral ||
+      initIsHostSpreadLiteral ||
+      initIsGrowableObjectLiteral ||
+      initIsOrdinaryToPrimitiveObjectLiteral ||
+      initIsProtoReceiverLiteral
+    ) {
       ctx.externrefAccessorVars.add(name);
     }
 
@@ -1740,6 +1750,7 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
     const initIsAnyObjectCarrier =
       decl.initializer !== undefined &&
       ts.isObjectLiteralExpression(decl.initializer) &&
+      !initIsOrdinaryToPrimitiveObjectLiteral &&
       !(ts.isIdentifier(decl.name) && ctx.growableObjectLiteralVars.has(decl.name.text)) &&
       // (#802 Slice A) A proto receiver keeps the externref carrier (below), not
       // the tag-6 `ref $Object` carrier — its reads/setPrototypeOf go through the

--- a/src/codegen/strict-eq-type-disjoint.ts
+++ b/src/codegen/strict-eq-type-disjoint.ts
@@ -41,16 +41,12 @@
  *   one is never given a scalar slot. It is boxed — `externref` in the JS-host
  *   lane, `$AnyValue` in standalone — precisely because the representation has
  *   to carry a tag. Those operands never reach this arm.
- * - The three known escapes where a scalar slot outlives a truthful static type
- *   are all excluded: a bare `var` used as a **for-in target** (dynamically a
+ * - The known escape where a scalar slot outlives a truthful static type is
+ *   excluded: a bare `var` used as a **for-in target** (dynamically a
  *   property-key string while TypeScript still reports the initializer's type
- *   — the same `forInIdentifierVars` guard the `#296` externref arm carries);
- *   a **heterogeneously-assigned binding**, which #4204 routes onto the
- *   `(mut externref)` path and therefore also cannot arrive here as `i32`/`f64`;
- *   and a **Boolean binding that is a `++`/`--` target**, which §13.4 turns into
- *   a Number at runtime while the slot stays `i32` (see
- *   {@link isUpdateRetypedBoolean} — that one was found by measurement, not by
- *   reasoning, and it is the only guard here that a plain A/B would have caught).
+ *   — the same `forInIdentifierVars` guard the `#296` externref arm carries).
+ *   Heterogeneously-assigned bindings and non-Number `++`/`--` targets are
+ *   routed onto dynamic storage, so they cannot arrive here as `i32`/`f64`.
  * - `i32` is not a boolean marker on its own: a `type i32 = number` annotation
  *   and `string.length` both produce `i32` with a *number* static type. The
  *   boolean side therefore demands `isBooleanType` **and** the absence of every
@@ -103,74 +99,6 @@ export function isDynamicForInOperand(fctx: FunctionContext, expr: ts.Expression
   return ts.isIdentifier(expr) && fctx.forInIdentifierVars?.has(expr.text) === true;
 }
 
-/** Names used as the operand of a `++`/`--` anywhere in a given scope, cached per scope node. */
-const updateTargetsByScope = new WeakMap<ts.Node, Set<string>>();
-
-function enclosingScope(node: ts.Node): ts.Node {
-  let n: ts.Node = node;
-  while (n.parent && !ts.isSourceFile(n) && !ts.isFunctionLike(n)) n = n.parent;
-  return n;
-}
-
-function updateTargetNames(scope: ts.Node): Set<string> {
-  const cached = updateTargetsByScope.get(scope);
-  if (cached) return cached;
-  const names = new Set<string>();
-  const visit = (n: ts.Node): void => {
-    if (
-      (ts.isPrefixUnaryExpression(n) || ts.isPostfixUnaryExpression(n)) &&
-      (n.operator === ts.SyntaxKind.PlusPlusToken || n.operator === ts.SyntaxKind.MinusMinusToken) &&
-      ts.isIdentifier(n.operand)
-    ) {
-      names.add(n.operand.text);
-    }
-    ts.forEachChild(n, visit);
-  };
-  visit(scope);
-  updateTargetsByScope.set(scope, names);
-  return names;
-}
-
-/**
- * A Boolean-typed identifier that is ALSO the operand of a `++`/`--` somewhere
- * in the same scope has a **stale** static type, and the fold must decline.
- *
- * §13.4 defines `x--` as `x = ToNumeric(x) - 1`, so after it runs `x` holds a
- * *Number* no matter what TypeScript inferred from the initializer. The
- * compiler currently keeps such a binding in its initializer-derived `i32`
- * boolean slot (that is #4208's own S2 defect, which needs #4204's binding
- * widening to fix), so the representation-agreement argument this module rests
- * on does not hold for it: the slot is `i32`, the static type says Boolean, and
- * the runtime value is a Number.
- *
- * Measured, not anticipated: without this guard,
- * `postfix-decrement/S11.3.2_A3_T1.js` and `prefix-decrement/S11.4.5_A3_T1.js`
- * flip pass→fail. Both were passing *vacuously* — `var x = true; x--` left `x`
- * as the boolean `false` and `x !== 0` was answered by the very f64 collapse
- * this module removes. Folding there would trade one wrong answer for another,
- * so the honest move is to refuse until S2 lands and makes the binding a real
- * Number.
- *
- * Name-keyed within the scope, like the `forInIdentifierVars` guard. That
- * over-approximates (a same-named binding in a nested scope also suppresses the
- * fold), and over-approximating means *refusing* a fold, which is the safe
- * direction.
- *
- * **DELETE THIS when #4208's S2 lands.** Verified load-bearing today, not
- * assumed: on `origin/main@745f6066b7` with #4204 already merged, disabling
- * only this guard makes both files fail again, so #4204's widening does not
- * cover an update target. But once its predicate grows an UpdateExpression arm,
- * `x` will hold a real Number `0`, `x !== 0` will compare correctly at runtime,
- * and this guard will be a dead constraint that reads as live. The removal is
- * also an acceptance criterion on #4208, because whoever does S2 will be
- * working in `heterogeneous-scalar-var-widening` and would never open this file.
- */
-export function isUpdateRetypedBoolean(tsType: ts.Type, expr: ts.Expression): boolean {
-  if (!ts.isIdentifier(expr)) return false;
-  if (!isBooleanType(tsType)) return false;
-  return updateTargetNames(enclosingScope(expr)).has(expr.text);
-}
-
 /**
  * Emit the §7.2.16 step-1 constant when the two SCALAR operands are provably
  * of different §6.1 types, or return `undefined` to let the caller proceed.
@@ -193,10 +121,10 @@ function tryFoldStrictEqTypeDisjoint(
   const isStrictNeq = op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
   if (!isStrictEq && !isStrictNeq) return undefined;
 
-  const leftStale = isDynamicForInOperand(fctx, expr.left) || isUpdateRetypedBoolean(leftTsType, expr.left);
+  const leftStale = isDynamicForInOperand(fctx, expr.left);
   const leftClass = scalarJsTypeClass(leftTsType, leftType, leftStale);
   if (leftClass === undefined) return undefined;
-  const rightStale = isDynamicForInOperand(fctx, expr.right) || isUpdateRetypedBoolean(rightTsType, expr.right);
+  const rightStale = isDynamicForInOperand(fctx, expr.right);
   const rightClass = scalarJsTypeClass(rightTsType, rightType, rightStale);
   if (rightClass === undefined) return undefined;
   if (leftClass === rightClass) return undefined;

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -12,7 +12,7 @@ import { compileNumericBinaryOp } from "./binary-ops.js";
 import { callableToStringLiteral } from "./callable-to-string.js";
 import { reserveClosedMethodDispatch } from "./closed-method-dispatch.js";
 import { getClosureFuncSelfTypeIdx } from "./closures.js";
-import { compileAndEmitToString, emitToString } from "./coercion-engine.js";
+import { compileAndEmitToString, emitRuntimeToPrimitive, emitToString } from "./coercion-engine.js";
 import { registerStringHelperEmitters } from "./string-emitter-registry.js";
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
@@ -367,17 +367,7 @@ function compileNativeConcatOperand(ctx: CodegenContext, fctx: FunctionContext, 
     // Dynamic externref (boxed string / any / $Object) →
     // ToPrimitive(default), then ToString. `+` uses valueOf-first even though
     // this operand is about to feed string concatenation.
-    const toPrimIdx = ensureLateImport(
-      ctx,
-      "__to_primitive",
-      [{ kind: "externref" }, { kind: "externref" }],
-      [{ kind: "externref" }],
-    );
-    flushLateImportShifts(ctx, fctx);
-    const finalToPrimIdx = ctx.funcMap.get("__to_primitive") ?? toPrimIdx;
-    if (finalToPrimIdx !== undefined) {
-      fctx.body.push({ op: "ref.null.extern" }, { op: "call", funcIdx: finalToPrimIdx });
-    }
+    emitRuntimeToPrimitive(ctx, fctx, "default");
     const dynToStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
     flushLateImportShifts(ctx, fctx);
     if (dynToStrIdx !== undefined) {

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -62,6 +62,7 @@ import {
   emitGuardedRefCast,
   pushDefaultValue,
   pushParamSentinel,
+  tryStructDefaultToStringAsExternref,
   tryStructToString,
 } from "./type-coercion.js";
 
@@ -363,9 +364,20 @@ function compileNativeConcatOperand(ctx: CodegenContext, fctx: FunctionContext, 
       compileStringLiteral(ctx, fctx, "undefined", operand);
       return true;
     }
-    // Dynamic externref (boxed string / any / $Object) → runtime ToString.
-    // For standalone $Object values this routes through native
-    // OrdinaryToPrimitive("string") before the native-string concat helper.
+    // Dynamic externref (boxed string / any / $Object) →
+    // ToPrimitive(default), then ToString. `+` uses valueOf-first even though
+    // this operand is about to feed string concatenation.
+    const toPrimIdx = ensureLateImport(
+      ctx,
+      "__to_primitive",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    const finalToPrimIdx = ctx.funcMap.get("__to_primitive") ?? toPrimIdx;
+    if (finalToPrimIdx !== undefined) {
+      fctx.body.push({ op: "ref.null.extern" }, { op: "call", funcIdx: finalToPrimIdx });
+    }
     const dynToStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
     flushLateImportShifts(ctx, fctx);
     if (dynToStrIdx !== undefined) {
@@ -381,6 +393,13 @@ function compileNativeConcatOperand(ctx: CodegenContext, fctx: FunctionContext, 
     // "[object Object]" fallthrough. The concrete vec type is known here, so
     // emit the join lowering inline (index-shift-safe — see #1448).
     if (tryCompileNativeVecConcatOperand(ctx, fctx, opType)) {
+      return true;
+    }
+    // A method-bearing object literal needs the same DEFAULT method order as
+    // the dynamic externref arm. The existing tryStructToString helper is a
+    // genuine ToString(string) path and therefore checks toString first.
+    if (tryStructDefaultToStringAsExternref(ctx, fctx, opType)) {
+      emitNativeStringRefFromExternref(ctx, fctx);
       return true;
     }
     // #1806 Phase 1 (string-hint): when the operand is a compile-time-resolvable

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -304,6 +304,7 @@ function tryStructStringHintExternrefDispatch(
   from: ValType,
   typeIdx: number,
   name: string,
+  hint: "string" | "default" = "string",
 ): boolean {
   const fields = ctx.structFields.get(name);
   if (!fields) return false;
@@ -343,15 +344,29 @@ function tryStructStringHintExternrefDispatch(
 
   let primaryFieldIdx: number;
   let secondaryFieldIdx: number | undefined;
-  if (supportsDispatch(toStringFieldIdx)) {
+  const valueOfFieldIdx = fields.findIndex((field) => field.name === "valueOf");
+  if (hint === "default") {
+    // `+` uses OrdinaryToPrimitive(default): valueOf precedes toString. Keep
+    // the static dispatcher bounded to literals with an own toString fallback;
+    // an absent fallback would need to synthesize inherited
+    // Object.prototype.toString and belongs to the dynamic runtime path.
+    if (valueOfFieldIdx >= 0 && supportsDispatch(valueOfFieldIdx)) {
+      if (!supportsDispatch(toStringFieldIdx)) return false;
+      primaryFieldIdx = valueOfFieldIdx;
+      secondaryFieldIdx = toStringFieldIdx;
+    } else if (valueOfFieldIdx < 0 || !isCallableField(fields[valueOfFieldIdx]!)) {
+      if (!supportsDispatch(toStringFieldIdx)) return false;
+      primaryFieldIdx = toStringFieldIdx;
+    } else {
+      return false;
+    }
+  } else if (supportsDispatch(toStringFieldIdx)) {
     primaryFieldIdx = toStringFieldIdx;
-    const valueOfFieldIdx = fields.findIndex((field) => field.name === "valueOf");
     if (valueOfFieldIdx >= 0 && supportsDispatch(valueOfFieldIdx)) {
       secondaryFieldIdx = valueOfFieldIdx;
     }
   } else if (!isCallableField(fields[toStringFieldIdx]!)) {
     // An own non-callable toString is skipped before trying valueOf.
-    const valueOfFieldIdx = fields.findIndex((field) => field.name === "valueOf");
     if (valueOfFieldIdx < 0 || !supportsDispatch(valueOfFieldIdx)) return false;
     primaryFieldIdx = valueOfFieldIdx;
   } else {
@@ -566,6 +581,23 @@ function tryStructStringHintExternrefDispatch(
     else: stringify(primaryResult),
   });
   return true;
+}
+
+/**
+ * Compile a nominal object-literal struct through
+ * OrdinaryToPrimitive(default) and leave its ToString result as externref.
+ * Used by native `+` concatenation before converting the result back to the
+ * native string carrier.
+ */
+export function tryStructDefaultToStringAsExternref(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  from: ValType,
+): boolean {
+  if (from.kind !== "ref" && from.kind !== "ref_null") return false;
+  const typeIdx = from.typeIdx;
+  const name = ctx.typeIdxToStructName.get(typeIdx);
+  return name !== undefined && tryStructStringHintExternrefDispatch(ctx, fctx, from, typeIdx, name, "default");
 }
 
 /**
@@ -2557,7 +2589,7 @@ export function coerceType(
       }
       if (
         toPrimitiveHint === "string" &&
-        (tryStructStringHintExternrefDispatch(ctx, fctx, from, typeIdx, name) ||
+        (tryStructStringHintExternrefDispatch(ctx, fctx, from, typeIdx, name, "string") ||
           tryStructPrimitiveToStringAsExternref(ctx, fctx, from, typeIdx, name))
       ) {
         return;

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -4610,7 +4610,18 @@ function lowerOrdinaryToPrimitiveObjectLiteral(expr: ts.ObjectLiteralExpression,
   }
   if (properties.length === 0) return null;
 
-  const objectType: IrType = { kind: "extern", className: "Object" };
+  const preferred = properties.find((property) => property.name === "valueOf") ?? properties[0]!;
+  const primitiveKind =
+    preferred.initializer.type?.kind === ts.SyntaxKind.StringKeyword
+      ? "string"
+      : preferred.initializer.type?.kind === ts.SyntaxKind.BooleanKeyword
+        ? "boolean"
+        : "number";
+  // Preserve the selector-proven default/number-hint primitive family in the
+  // internal extern brand. This is not a JS class name; it lets later binary
+  // lowering distinguish numeric/default object coercion from arbitrary host
+  // externrefs without consulting the checker after the literal was lowered.
+  const objectType: IrType = { kind: "extern", className: `Object:${primitiveKind}` };
   const object = cx.builder.emitCall(irRuntimeFuncRef("__new_plain_object"), [], objectType);
   if (object === null) {
     throw new Error(`ir/from-ast: __new_plain_object produced no value in ${cx.funcName}`);
@@ -8825,7 +8836,7 @@ function emitUnaryToNumber(rand: IrValueId, randType: IrType, cx: LowerCtx): IrV
   // not silently widen every host-class externref unary expression. A null
   // hint selects the default/number method order; the returned primitive then
   // flows through the canonical lane-specific ToNumber helper.
-  if (randType.kind === "extern" && randType.className === "Object") {
+  if (randType.kind === "extern" && randType.className.startsWith("Object:")) {
     const externref = irVal({ kind: "externref" });
     const hint = cx.builder.emitConst({ kind: "null", ty: externref }, externref);
     const primitive = cx.builder.emitCall(irRuntimeFuncRef("__to_primitive"), [rand, hint], externref);
@@ -8985,6 +8996,8 @@ function classifyPrimitiveProof(t: ts.Type): "number" | "string" | "unprovable" 
  * no checker there is no specialization whose unsoundness we would be masking).
  */
 function proveAdditiveOperand(node: ts.Expression, cx: LowerCtx): "number" | "string" | "unprovable" | "no-checker" {
+  const ordinaryLiteral = ordinaryToPrimitiveAdditiveProof(node);
+  if (ordinaryLiteral !== "unprovable") return ordinaryLiteral;
   const checker = cx.checker;
   if (!checker) return "no-checker";
   const byChecker = classifyPrimitiveProof(checker.getTypeAtLocation(node));
@@ -9000,6 +9013,30 @@ function proveAdditiveOperand(node: ts.Expression, cx: LowerCtx): "number" | "st
   // the lattice's bool atom is i32-branded and deliberately unmapped there).
   // See src/ir/lattice-param-facts.ts for the full soundness argument.
   return latticeAdditiveFact(node, cx) ?? "unprovable";
+}
+
+function ordinaryToPrimitiveAdditiveProof(node: ts.Expression): "number" | "string" | "unprovable" {
+  const candidate = peelParensExpr(node);
+  if (!ts.isObjectLiteralExpression(candidate)) return "unprovable";
+  let valueOfMethod: ts.FunctionExpression | undefined;
+  let toStringMethod: ts.FunctionExpression | undefined;
+  for (const property of candidate.properties) {
+    if (!ts.isPropertyAssignment(property) || !ts.isFunctionExpression(property.initializer)) return "unprovable";
+    const name = phase1PropertyName(property.name);
+    if (name === "valueOf") valueOfMethod = property.initializer;
+    else if (name === "toString") toStringMethod = property.initializer;
+    else return "unprovable";
+  }
+  const preferred = valueOfMethod ?? toStringMethod;
+  if (!preferred) return "unprovable";
+  if (preferred.type?.kind === ts.SyntaxKind.StringKeyword) return "string";
+  if (preferred.type?.kind === ts.SyntaxKind.NumberKeyword || preferred.type?.kind === ts.SyntaxKind.BooleanKeyword) {
+    // After ToPrimitive(default), a boolean participates in `+`'s numeric arm
+    // whenever the other primitive is non-string, so it shares the numeric
+    // specialization proof here (the emitted coercion still performs ToNumber).
+    return "number";
+  }
+  return "unprovable";
 }
 
 /**
@@ -9460,14 +9497,50 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
     isIrBitwiseOperatorToken(op) &&
     isI32PureExprIR(expr.left, cx.i32PureNames) &&
     isI32PureExprIR(expr.right, cx.i32PureNames);
-  const lhs = i32PureBitwiseOperands
-    ? emitI32PureExpr(expr.left, cx)
-    : lowerExpr(expr.left, cx, irVal({ kind: "f64" }));
-  const rhs = i32PureBitwiseOperands
+  let lhs = i32PureBitwiseOperands ? emitI32PureExpr(expr.left, cx) : lowerExpr(expr.left, cx, irVal({ kind: "f64" }));
+  let rhs = i32PureBitwiseOperands
     ? emitI32PureExpr(expr.right, cx)
     : lowerExpr(expr.right, cx, irVal({ kind: "f64" }));
-  const lt = typeOfValue(lhs, cx);
-  const rt = typeOfValue(rhs, cx);
+  let lt = typeOfValue(lhs, cx);
+  let rt = typeOfValue(rhs, cx);
+
+  // #4208 S3/S7 — numeric/default binary abstract operations over the exact
+  // OrdinaryToPrimitive IR object. Strict equality deliberately does not enter
+  // this path (Object vs primitive is false without coercion). `+` is admitted
+  // only for the number/boolean primitive brands; a string-producing object
+  // needs the future concat carrier unification and remains a clean fallback.
+  const coerceOrdinaryObject = (value: IrValueId, type: IrType): IrValueId | null => {
+    if (type.kind !== "extern" || !type.className.startsWith("Object:")) return null;
+    if (type.className === "Object:string") return null;
+    const looseEquality = op === ts.SyntaxKind.EqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken;
+    const numericOrRelational =
+      op === ts.SyntaxKind.PlusToken ||
+      op === ts.SyntaxKind.MinusToken ||
+      op === ts.SyntaxKind.AsteriskToken ||
+      op === ts.SyntaxKind.SlashToken ||
+      op === ts.SyntaxKind.PercentToken ||
+      op === ts.SyntaxKind.AmpersandToken ||
+      op === ts.SyntaxKind.BarToken ||
+      op === ts.SyntaxKind.CaretToken ||
+      op === ts.SyntaxKind.LessThanLessThanToken ||
+      op === ts.SyntaxKind.GreaterThanGreaterThanToken ||
+      op === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken ||
+      op === ts.SyntaxKind.LessThanToken ||
+      op === ts.SyntaxKind.LessThanEqualsToken ||
+      op === ts.SyntaxKind.GreaterThanToken ||
+      op === ts.SyntaxKind.GreaterThanEqualsToken;
+    return numericOrRelational || looseEquality ? emitUnaryToNumber(value, type, cx) : null;
+  };
+  const coercedLhs = coerceOrdinaryObject(lhs, lt);
+  const coercedRhs = coerceOrdinaryObject(rhs, rt);
+  if (coercedLhs !== null) {
+    lhs = coercedLhs;
+    lt = typeOfValue(lhs, cx);
+  }
+  if (coercedRhs !== null) {
+    rhs = coercedRhs;
+    rt = typeOfValue(rhs, cx);
+  }
 
   // #2949 S5.2 — dynamic equality: `===`/`!==`/`==`/`!=` where either operand
   // is a boxed-any carrier. The concrete operand is boxed into the carrier

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -4521,6 +4521,8 @@ function lowerObjectLiteral(expr: ts.ObjectLiteralExpression, cx: LowerCtx): IrV
   if (expr.properties.length === 0) {
     throw new Error(`ir/from-ast: empty object literal not in slice 2 (${cx.funcName})`);
   }
+  const ordinaryToPrimitive = lowerOrdinaryToPrimitiveObjectLiteral(expr, cx);
+  if (ordinaryToPrimitive !== null) return ordinaryToPrimitive;
   const built: { name: string; type: IrType; value: IrValueId }[] = [];
   const seen = new Set<string>();
   for (const prop of expr.properties) {
@@ -4574,6 +4576,56 @@ function lowerObjectLiteral(expr: ts.ObjectLiteralExpression, cx: LowerCtx): IrV
     shape,
     built.map((b) => b.value),
   );
+}
+
+/**
+ * #4208 S3/S7 — lower the selector-certified OrdinaryToPrimitive literal as
+ * an open object rather than a closed structural `object.new`:
+ *
+ *   { valueOf: function(): number { return 1; } }
+ *
+ * A closed IR object has a compile-time field layout and cannot participate in
+ * the runtime OrdinaryToPrimitive protocol. The open object stores canonical
+ * callable externrefs, so both the JS-host and host-free object runtimes can
+ * invoke the methods through their existing zero-arity closure dispatcher.
+ */
+function lowerOrdinaryToPrimitiveObjectLiteral(expr: ts.ObjectLiteralExpression, cx: LowerCtx): IrValueId | null {
+  const properties: { name: "valueOf" | "toString"; initializer: ts.FunctionExpression }[] = [];
+  const seen = new Set<string>();
+  for (const property of expr.properties) {
+    if (!ts.isPropertyAssignment(property) || !ts.isFunctionExpression(property.initializer)) return null;
+    const name = phase1PropertyName(property.name);
+    if (
+      (name !== "valueOf" && name !== "toString") ||
+      seen.has(name) ||
+      property.initializer.parameters.length !== 0 ||
+      (property.initializer.type?.kind !== ts.SyntaxKind.NumberKeyword &&
+        property.initializer.type?.kind !== ts.SyntaxKind.StringKeyword &&
+        property.initializer.type?.kind !== ts.SyntaxKind.BooleanKeyword)
+    ) {
+      return null;
+    }
+    seen.add(name);
+    properties.push({ name, initializer: property.initializer });
+  }
+  if (properties.length === 0) return null;
+
+  const objectType: IrType = { kind: "extern", className: "Object" };
+  const object = cx.builder.emitCall(irRuntimeFuncRef("__new_plain_object"), [], objectType);
+  if (object === null) {
+    throw new Error(`ir/from-ast: __new_plain_object produced no value in ${cx.funcName}`);
+  }
+  for (const property of properties) {
+    const key = cx.builder.emitCoerceToExternref(cx.builder.emitStringConst(property.name));
+    const closure = lowerClosureExpression(property.initializer, cx);
+    const closureType = cx.builder.typeOf(closure);
+    if (closureType.kind !== "closure") {
+      throw new Error(`ir/from-ast: OrdinaryToPrimitive property is not an IR closure in ${cx.funcName}`);
+    }
+    const callable = cx.builder.emitCallablePack(closure, closureType.signature);
+    cx.builder.emitCall(irRuntimeFuncRef("__extern_set"), [object, key, callable], null);
+  }
+  return object;
 }
 
 /**
@@ -8767,6 +8819,24 @@ function emitUnaryToNumber(rand: IrValueId, randType: IrType, cx: LowerCtx): IrV
   if (randType.kind === "string") {
     const boxed = cx.builder.emitBox(rand, irDynamic(JsTag.String));
     return cx.builder.emitDynToNumber(boxed);
+  }
+  // #4208 S3/S7 — the open OrdinaryToPrimitive object produced above. Keep
+  // this branded as `extern:Object` so enabling the abstract operation does
+  // not silently widen every host-class externref unary expression. A null
+  // hint selects the default/number method order; the returned primitive then
+  // flows through the canonical lane-specific ToNumber helper.
+  if (randType.kind === "extern" && randType.className === "Object") {
+    const externref = irVal({ kind: "externref" });
+    const hint = cx.builder.emitConst({ kind: "null", ty: externref }, externref);
+    const primitive = cx.builder.emitCall(irRuntimeFuncRef("__to_primitive"), [rand, hint], externref);
+    if (primitive === null) {
+      throw new Error(`ir/from-ast: __to_primitive produced no value in ${cx.funcName}`);
+    }
+    const number = cx.builder.emitCall(irRuntimeFuncRef("__unbox_number"), [primitive], irVal({ kind: "f64" }));
+    if (number === null) {
+      throw new Error(`ir/from-ast: __unbox_number produced no value in ${cx.funcName}`);
+    }
+    return number;
   }
   return null;
 }

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -765,6 +765,32 @@ export interface LoweredFunctionResult {
   readonly liftedUnitProvenance: readonly IrDerivedUnitProvenance[];
 }
 
+function isDirectSourceVarStatement(statement: ts.Statement): boolean {
+  return (
+    ts.isVariableStatement(statement) &&
+    (statement.declarationList.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0
+  );
+}
+
+/** Direct module `var`s have persistent globals; nested/for-init `var`s still need hoisting support. */
+function moduleInitContainsNestedVar(statements: readonly ts.Statement[]): boolean {
+  const findVarDecl = (node: ts.Node): boolean => {
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node)
+    ) {
+      return false;
+    }
+    if (ts.isVariableDeclarationList(node) && (node.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0) {
+      return true;
+    }
+    return ts.forEachChild(node, findVarDecl) === true;
+  };
+  return statements.some((statement) => !isDirectSourceVarStatement(statement) && findVarDecl(statement));
+}
+
 export function lowerFunctionAstToIr(
   fn:
     | ts.FunctionDeclaration
@@ -1072,30 +1098,8 @@ export function lowerFunctionAstToIr(
     if (returnType !== null) {
       throw new Error(`ir/from-ast: module-init unit must be void (${name})`);
     }
-    // `var` gate: a `var` anywhere in the unit (including for-init /
-    // nested blocks, where the lowering below would bind it as a
-    // loop-local slot) is FUNCTION-scoped on the legacy path — it hoists
-    // to a module global other functions can observe. Slice 2 does not
-    // model that; demote the whole unit. `var`s inside nested
-    // function-likes are local to those functions and stay fine.
-    const findVarDecl = (node: ts.Node): boolean => {
-      if (
-        ts.isFunctionDeclaration(node) ||
-        ts.isFunctionExpression(node) ||
-        ts.isArrowFunction(node) ||
-        ts.isMethodDeclaration(node)
-      ) {
-        return false;
-      }
-      if (ts.isVariableDeclarationList(node) && (node.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0) {
-        return true;
-      }
-      return ts.forEachChild(node, findVarDecl) === true;
-    };
-    for (const s of stmts) {
-      if (findVarDecl(s)) {
-        throw new Error(`ir/from-ast: module-init unit contains a var declaration — not in Slice 2 scope (${name})`);
-      }
+    if (moduleInitContainsNestedVar(stmts)) {
+      throw new Error(`ir/from-ast: module-init unit contains a nested var declaration (${name})`);
     }
     for (const s of stmts) {
       lowerStmt(s, cx);
@@ -3014,7 +3018,7 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
     // the slot) would double-evaluate any side effect in `let s = f() | 0`.
     // Every other hint source wins: an explicit annotation, an empty-array
     // inference and a module binding each pin the representation.
-    const widenDynamic = cx.dynamicStringLocals.has(name);
+    const widenDynamic = cx.dynamicStringLocals.has(name) || moduleBinding?.type.kind === "dynamic";
     const promoteI32Slot =
       annotated === undefined &&
       inferredEmptyArrayHint === undefined &&
@@ -3039,7 +3043,7 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
         throw new IrUnsupportedError(
           "operand-coercion-unsupported",
           "build",
-          `ir/from-ast: proven dynamic local '${name}' initializer has no dynamic string carrier (${cx.funcName})`,
+          `ir/from-ast: proven dynamic binding '${name}' initializer has no supported carrier (${cx.funcName})`,
         );
       }
       value = boxed;
@@ -3429,6 +3433,10 @@ function resolveIrType(node: ts.TypeNode | undefined, override: IrType | undefin
 /** True when two logical IR types use the same already-allocated global slot. */
 function moduleStorageCompatible(actual: IrType, expected: IrType): boolean {
   if (irTypeEquals(actual, expected)) return true;
+  // Dynamic tag refinements describe the value partition, not a different
+  // physical carrier. A `dynamic<tag:String>` initializer and the unrefined
+  // dynamic module global therefore use the same slot.
+  if (actual.kind === "dynamic" && expected.kind === "dynamic") return true;
   if (expected.kind !== "extern") return false;
   if (actual.kind === "extern") return true;
   return asVal(actual)?.kind === "externref";

--- a/src/ir/function-local-var.ts
+++ b/src/ir/function-local-var.ts
@@ -155,3 +155,23 @@ export function collectIrSafeVarDeclarationLists(
   }
   return safeLists;
 }
+
+/**
+ * Top-level `var` lists are already backed by exact persistent module globals,
+ * so the synthetic module initializer can model them without pretending they
+ * are lexical locals. The ordinary module selector still rejects duplicate
+ * declarations, missing initializers, use-before-declaration, and any binding
+ * the module-global resolver cannot represent; this helper only removes the
+ * function-local hoisting gate from direct source-file statements.
+ */
+export function collectIrSafeModuleVarDeclarationLists(
+  statements: readonly ts.Statement[],
+): ReadonlySet<ts.VariableDeclarationList> {
+  const safe = new Set<ts.VariableDeclarationList>();
+  for (const statement of statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    if (!isVarDeclarationList(statement.declarationList)) continue;
+    safe.add(statement.declarationList);
+  }
+  return safe;
+}

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -5522,6 +5522,13 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
   // that legacy registers on demand via `ensureLateImport` — another
   // dual-compile side effect IR-first skips. Detect + register the same way.
   let usesExternIsUndefined = false;
+  // #4208 S3/S7 — explicit runtime refs emitted for the IR-owned open
+  // OrdinaryToPrimitive literal. These providers must exist before Phase 3:
+  // host mode registers late imports, while standalone/wasi materialize the
+  // native object runtime. `__unbox_number` comes from the union family in
+  // every lane.
+  let usesOrdinaryToPrimitiveObjectRuntime = false;
+  let usesRuntimeUnboxNumber = false;
   const dynamicRuntimeNeeds = new Set<IrDynamicRuntimeNeed>();
   for (const entry of fns) {
     for (const block of entry.fn.blocks) {
@@ -5538,6 +5545,14 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
           }
           if (i.kind === "call" && i.target.binding.kind === "runtime") {
             switch (i.target.binding.symbol) {
+              case "__new_plain_object":
+              case "__extern_set":
+              case "__to_primitive":
+                usesOrdinaryToPrimitiveObjectRuntime = true;
+                break;
+              case "__unbox_number":
+                usesRuntimeUnboxNumber = true;
+                break;
               case IR_DYN_ADD_FN:
                 dynamicRuntimeNeeds.add("add");
                 break;
@@ -5568,6 +5583,17 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
       }
     }
   }
+  if (usesOrdinaryToPrimitiveObjectRuntime) {
+    if (ctx.standalone || ctx.wasi) {
+      ensureObjectRuntime(ctx);
+    } else {
+      ensureLateImport(ctx, "__new_plain_object", [], [{ kind: "externref" }]);
+      ensureLateImport(ctx, "__extern_set", [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }], []);
+      ensureLateImport(ctx, "__to_primitive", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, null);
+    }
+  }
+  if (usesRuntimeUnboxNumber) addUnionImports(ctx);
   // (#3143) A named union-import call needs the host/native import family
   // registered even when no `dyn.*` op is present (the boxing-coercion path).
   // `addUnionImports` covers host (env imports) AND wasi/standalone (native

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -6,6 +6,7 @@
 
 import { isExternalDeclaredClass } from "../checker/type-mapper.js";
 import { ts } from "../ts-api.js";
+import { updateRetypesModuleBinding } from "./update-retyped-bindings.js";
 import { isBoundedPreparedAccessorClass } from "./class-accessor-safety.js";
 import { irModuleGlobalBindingId, irModuleTdzGlobalBindingId } from "./abi-bindings.js";
 import type { IrBindingId, IrClassId, IrSourceId, IrUnitId } from "./identity.js";
@@ -796,7 +797,12 @@ function directTopLevelDeclaration(node: ts.Identifier, checker: ts.TypeChecker)
   // source-owned capability.
   if (!ts.isExternalModule(sourceFile)) return undefined;
   const declaredType = checker.getTypeAtLocation(declaration.name);
-  if ((declaredType.flags & (ts.TypeFlags.NumberLike | ts.TypeFlags.BooleanLike)) === 0) return undefined;
+  if (
+    (declaredType.flags & (ts.TypeFlags.NumberLike | ts.TypeFlags.BooleanLike)) === 0 &&
+    !updateRetypesModuleBinding(checker, declaration)
+  ) {
+    return undefined;
+  }
   const sameSourceDeclarations = new Set(
     candidates.filter(
       (candidate): candidate is ts.Declaration =>
@@ -1186,8 +1192,16 @@ function writeValueMatches(
   targetKind: IrModuleBindingValueKind,
   value: ts.Expression,
   options: IrModuleBindingResolverOptions,
+  classifyPrimitiveExpression: (expr: ts.Expression) => IrPrimitiveExpressionFamily | undefined,
 ): boolean {
   const valueExpr = unwrapParens(value);
+  if (targetKind.kind === "dynamic") {
+    // The current IR boxing producer accepts exactly the three primitive
+    // families. Object/wrapper initializers still receive the same widened
+    // compatibility slot but cause module-init selection to demote until IR
+    // has an object-to-dynamic materializer.
+    return classifyPrimitiveExpression(valueExpr) !== undefined;
+  }
   if (targetKind.kind === "extern") {
     if (moduleExternValueNeedsLegacy(valueExpr)) return false;
     if (valueExpr.kind === ts.SyntaxKind.NullKeyword) return true;
@@ -1800,6 +1814,7 @@ export function makeIrLegacyModuleBindingResolver(
   options: IrModuleBindingResolverOptions,
 ): IrLegacyModuleBindingResolver {
   const isAmbientBinding = makeIrAmbientBindingPredicate(checker);
+  const classifyPrimitiveExpression = makeIrPrimitiveExpressionClassifier(checker);
   const stableFunctionCallPlans = new Map<ts.FunctionDeclaration, IrStableFunctionCallPlan | null>();
   const inspectDirectBinding = (node: ts.Identifier, writeValue?: ts.Expression): IrLegacyModuleBindingInspection => {
     const declaration = directTopLevelDeclaration(node, checker);
@@ -1822,7 +1837,15 @@ export function makeIrLegacyModuleBindingResolver(
     if (writeValue !== undefined && !mutable) return { kind: "unsupported", declaration };
 
     const declaredType = checker.getTypeAtLocation(declaration.name);
-    let valueKind = scalarKind(declaredType, options);
+    // #4208 S2 — a non-fast update target whose initializer representation
+    // cannot hold the Number written by `++` / `--` uses the IR dynamic
+    // carrier. Fast mode has a `$AnyValue` dynamic carrier while compatibility
+    // allocation currently widens these globals to externref, so it stays on
+    // direct codegen until that ABI is unified.
+    let valueKind =
+      options.numberStorage === "f64" && updateRetypesModuleBinding(checker, declaration)
+        ? ({ kind: "dynamic" } as const)
+        : scalarKind(declaredType, options);
     if (!valueKind && !isModuleVar && options.allowHostExterns) {
       const className = externClassNameForType(declaredType, checker, options);
       if (className) {
@@ -1830,7 +1853,10 @@ export function makeIrLegacyModuleBindingResolver(
       }
     }
     if (!valueKind) return { kind: "unsupported", declaration };
-    if (writeValue !== undefined && !writeValueMatches(checker, declaredType, valueKind, writeValue, options)) {
+    if (
+      writeValue !== undefined &&
+      !writeValueMatches(checker, declaredType, valueKind, writeValue, options, classifyPrimitiveExpression)
+    ) {
       return { kind: "unsupported", declaration };
     }
     return { kind: "supported", identity: { declaration, mutable, valueKind } };
@@ -1946,7 +1972,14 @@ export function makeIrLegacyModuleBindingResolver(
         const identity = resolve(node);
         if (!identity) return false;
         const declaredType = checker.getTypeAtLocation(identity.declaration.name);
-        return writeValueMatches(checker, declaredType, identity.valueKind, value, options);
+        return writeValueMatches(
+          checker,
+          declaredType,
+          identity.valueKind,
+          value,
+          options,
+          classifyPrimitiveExpression,
+        );
       } catch {
         return false;
       }

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -63,7 +63,7 @@ import {
   type IrAsyncSelectionOptions,
 } from "./async-selection.js";
 export { isAsyncIrReady } from "./async-selection.js";
-import { collectIrSafeVarDeclarationLists } from "./function-local-var.js";
+import { collectIrSafeModuleVarDeclarationLists, collectIrSafeVarDeclarationLists } from "./function-local-var.js";
 import { collectDynamicStringLocalWidening } from "./dynamic-local-widening.js";
 import { stringBuilderForcedLegacy } from "./string-builder-shape.js";
 // (#1373b C-1) Pure-syntactic async helpers from the LEAF module (safe for
@@ -4978,6 +4978,11 @@ function obviousModuleValueFamily(expr: ts.Expression): ObviousModuleValueFamily
   if (binding?.valueKind.kind === "f64") return "f64";
   if (binding?.valueKind.kind === "i32") return "boolean";
   if (binding?.valueKind.kind === "extern") return "extern";
+  // A #4208 update-retyped module binding has deliberately stale checker
+  // evidence: after `value--`, a Boolean/string initializer now holds a
+  // Number. Do not fall through to scalarExpressionFamily and resurrect the
+  // initializer's static family after the binding resolver chose dynamic.
+  if (binding?.valueKind.kind === "dynamic") return undefined;
   const scalarAlias = moduleScalarAliasFamily(candidate);
   if (scalarAlias) return scalarAlias;
   if (isModuleMapGetAlias(candidate)) return "extern";
@@ -7379,7 +7384,28 @@ export function assessModuleInit(
   currentDynMemberEqualitySubject = null;
   currentStableFunctionCallSubject = null;
   currentStableDynamicRootNames = new Set<string>();
-  currentIrSafeVarDeclarationLists = new Set();
+  // #4208 S2 opens the direct top-level `var` gate only for a source that
+  // genuinely contains an update-retyped module binding. The exact binding
+  // resolver rejects same-named locals and ordinary narrow module globals, so
+  // unrelated modules retain the existing conservative `var` demotion.
+  let hasDynamicModuleUpdate = false;
+  const findDynamicModuleUpdate = (node: ts.Node): void => {
+    if (hasDynamicModuleUpdate) return;
+    if (
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken) &&
+      ts.isIdentifier(node.operand) &&
+      currentModuleBindingResolver?.(node.operand)?.valueKind.kind === "dynamic"
+    ) {
+      hasDynamicModuleUpdate = true;
+      return;
+    }
+    forEachChild(node, findDynamicModuleUpdate);
+  };
+  findDynamicModuleUpdate(sourceFile);
+  currentIrSafeVarDeclarationLists = hasDynamicModuleUpdate
+    ? collectIrSafeModuleVarDeclarationLists(population)
+    : new Set();
   currentModuleMapGetAliases = new Set<ts.VariableDeclaration>();
   currentModuleScalarAliasFamilies = new Map<ts.VariableDeclaration, "f64" | "boolean">();
   const scope = new Set<string>();

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -7210,6 +7210,38 @@ function isPhase1ObjectLiteral(
   // overrides pass would skip them when shape resolution failed.
   if (expr.properties.length === 0) return shapeNo("objectlit-empty", expr);
 
+  // Function-valued data properties have no general closed-object IR
+  // representation. The one certified exception is the exact #4208
+  // OrdinaryToPrimitive shape; require EVERY property to belong to it so a
+  // mixed `{ valueOf: function... , data: 1 }` literal is rejected before
+  // claim instead of claimed and demoted by lowerObjectLiteral.
+  if (
+    expr.properties.some(
+      (property) => ts.isPropertyAssignment(property) && ts.isFunctionExpression(property.initializer),
+    )
+  ) {
+    const seenMethods = new Set<string>();
+    for (const property of expr.properties) {
+      if (!ts.isPropertyAssignment(property) || !ts.isFunctionExpression(property.initializer)) {
+        return shapeNo("objectlit-ordinary-to-primitive-mixed", property);
+      }
+      const name = phase1PropertyName(property.name);
+      if (
+        (name !== "valueOf" && name !== "toString") ||
+        seenMethods.has(name) ||
+        property.initializer.parameters.length !== 0 ||
+        (property.initializer.type?.kind !== ts.SyntaxKind.NumberKeyword &&
+          property.initializer.type?.kind !== ts.SyntaxKind.StringKeyword &&
+          property.initializer.type?.kind !== ts.SyntaxKind.BooleanKeyword) ||
+        !isPhase1ClosureLiteral(property.initializer, scope, localClasses)
+      ) {
+        return shapeNo("objectlit-ordinary-to-primitive-method", property.initializer);
+      }
+      seenMethods.add(name);
+    }
+    return true;
+  }
+
   const seen = new Set<string>();
   for (const prop of expr.properties) {
     if (ts.isPropertyAssignment(prop)) {

--- a/src/ir/update-retyped-bindings.ts
+++ b/src/ir/update-retyped-bindings.ts
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Binding-identity analysis for `++` / `--` targets whose initializer-shaped
+ * storage cannot hold the numeric value written by the update.
+ *
+ * The analysis lives in IR because both selection and AST-to-IR lowering must
+ * agree that the binding is dynamic before `dyn.to_number` can own the update.
+ * Direct codegen consumes the same verdict when allocating the compatibility
+ * module global, so an IR demotion cannot reintroduce the narrow-slot bug.
+ */
+import { TsCheckerOracle, type TypeOracle } from "../checker/oracle.js";
+import { ts } from "../ts-api.js";
+
+type UpdateRetypeOracle = Pick<TypeOracle, "declarationsOf" | "typeFactOf">;
+type UpdateRetypeQuerySource = ts.TypeChecker | UpdateRetypeOracle;
+
+const checkerOracles = new WeakMap<ts.TypeChecker, UpdateRetypeOracle>();
+const cache = new WeakMap<object, WeakMap<ts.SourceFile, ReadonlySet<ts.VariableDeclaration>>>();
+
+function queryOracle(source: UpdateRetypeQuerySource): UpdateRetypeOracle {
+  if ("declarationsOf" in source && "typeFactOf" in source) return source;
+  let oracle = checkerOracles.get(source);
+  if (!oracle) {
+    oracle = new TsCheckerOracle(source);
+    checkerOracles.set(source, oracle);
+  }
+  return oracle;
+}
+
+function unwrap(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function exactTopLevelDeclarations(
+  oracle: UpdateRetypeOracle,
+  identifier: ts.Identifier,
+  sourceFile: ts.SourceFile,
+): readonly ts.VariableDeclaration[] {
+  const declarations = new Set(
+    oracle
+      .declarationsOf(identifier)
+      .filter(
+        (candidate): candidate is ts.VariableDeclaration =>
+          ts.isVariableDeclaration(candidate) &&
+          candidate.getSourceFile() === sourceFile &&
+          ts.isIdentifier(candidate.name) &&
+          ts.isVariableDeclarationList(candidate.parent) &&
+          ts.isVariableStatement(candidate.parent.parent) &&
+          candidate.parent.parent.parent === sourceFile,
+      ),
+  );
+  return [...declarations];
+}
+
+function updateReplacesInitializerRepresentation(
+  oracle: UpdateRetypeOracle,
+  declaration: ts.VariableDeclaration,
+): boolean {
+  if (!declaration.initializer || !ts.isVariableDeclarationList(declaration.parent)) return false;
+  if ((declaration.parent.flags & ts.NodeFlags.Const) !== 0) return false;
+  try {
+    const initializerType = oracle.typeFactOf(unwrap(declaration.initializer));
+    // Number already has the update result's representation. BigInt updates
+    // also remain BigInt under ToNumeric and therefore must not be widened to
+    // the Number-oriented dynamic path.
+    return initializerType.kind !== "number" && initializerType.kind !== "bigint";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Exact top-level declarations that need a dynamic module slot because some
+ * source update writes a Number over a non-Number initializer.
+ *
+ * The walk intentionally crosses nested function boundaries: a function may
+ * update a module binding. Checker identity prevents a same-named local from
+ * widening the global.
+ */
+export function collectUpdateRetypedModuleBindings(
+  source: UpdateRetypeQuerySource,
+  sourceFile: ts.SourceFile,
+): ReadonlySet<ts.VariableDeclaration> {
+  const oracle = queryOracle(source);
+  let bySource = cache.get(oracle);
+  if (!bySource) {
+    bySource = new WeakMap();
+    cache.set(oracle, bySource);
+  }
+  const cached = bySource.get(sourceFile);
+  if (cached) return cached;
+
+  const declarations = new Set<ts.VariableDeclaration>();
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken) &&
+      ts.isIdentifier(node.operand)
+    ) {
+      const bindingDeclarations = exactTopLevelDeclarations(oracle, node.operand, sourceFile);
+      // Sloppy-script `var` redeclarations are one binding. Test262 commonly
+      // reuses `var x` for several checks in the same file, so a uniqueness
+      // requirement would miss the exact conformance shape. If any declaration
+      // establishes a non-numeric representation, every declaration of the
+      // shared binding must request the same dynamic slot.
+      if (bindingDeclarations.some((declaration) => updateReplacesInitializerRepresentation(oracle, declaration))) {
+        for (const declaration of bindingDeclarations) declarations.add(declaration);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  bySource.set(sourceFile, declarations);
+  return declarations;
+}
+
+export function updateRetypesModuleBinding(
+  source: UpdateRetypeQuerySource,
+  declaration: ts.VariableDeclaration,
+): boolean {
+  return collectUpdateRetypedModuleBindings(source, declaration.getSourceFile()).has(declaration);
+}
+
+/** Whether this exact identifier resolves to an update-retyped module binding. */
+export function updateRetypesModuleIdentifier(source: UpdateRetypeQuerySource, identifier: ts.Identifier): boolean {
+  const sourceFile = identifier.getSourceFile();
+  const oracle = queryOracle(source);
+  const retyped = collectUpdateRetypedModuleBindings(oracle, sourceFile);
+  return exactTopLevelDeclarations(oracle, identifier, sourceFile).some((declaration) => retyped.has(declaration));
+}
+
+/** Name fallback for a caller that has already proved the use is module-scoped. */
+export function updateRetypesModuleBindingName(
+  source: UpdateRetypeQuerySource,
+  sourceFile: ts.SourceFile,
+  name: string,
+): boolean {
+  for (const declaration of collectUpdateRetypedModuleBindings(source, sourceFile)) {
+    if (ts.isIdentifier(declaration.name) && declaration.name.text === name) return true;
+  }
+  return false;
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2059,6 +2059,10 @@ function _maybeWrapCallable(
           const wrapped = _wrapWasmClosure(val, arity, callbackState);
           return wrapped ?? val;
         }
+        // The exact runtime classifier is authoritative. Falling through to
+        // the opaque-struct heuristic would turn an ordinary data struct into
+        // a callable merely because it is an object.
+        return val;
       } catch {
         // Fall through to the older opaque-struct heuristic below.
       }
@@ -9675,7 +9679,13 @@ assert._isSameValue = isSameValue;
           // struct — `p1.then = fn; Promise.race([p1])` traps with
           // "object is not a function". Wrap it via __call_fn_<arity> so
           // host-driven invocation reaches the closure body.
-          let wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+          // OrdinaryToPrimitive methods have a fixed zero-argument call shape.
+          // Prefer the exact dispatcher so a method-only object literal does
+          // not depend on the broader unknown-arity export family being live.
+          let wrappedVal =
+            key === "valueOf" || key === "toString"
+              ? _maybeWrapCallable(val, 0, callbackState)
+              : _maybeWrapCallableUnknownArity(val, callbackState);
           // (#3051) `regexp.exec = fn` override: the native RegExp protocol
           // (@@replace/@@split/@@match/@@search) calls this and reads the
           // returned match-result object via Get + ToXxx. A compiled result
@@ -9699,7 +9709,10 @@ assert._isSameValue = isSameValue;
       // throw catchable by the user's try/catch.
       if (name === "__extern_set_strict")
         return (obj: any, key: any, val: any) => {
-          let wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+          let wrappedVal =
+            key === "valueOf" || key === "toString"
+              ? _maybeWrapCallable(val, 0, callbackState)
+              : _maybeWrapCallableUnknownArity(val, callbackState);
           // (#3051) See __extern_set: wrap a `regexp.exec` override's return so
           // the native RegExp protocol can read the compiled result object.
           // (Slice 3) Widened to any object receiver — see __extern_set.
@@ -15398,7 +15411,10 @@ assert._isSameValue = isSameValue;
       return (obj: any, key: any, val: any) => {
         // (#860) Wrap closure-as-value before storing — see __extern_set
         // binding above. Mirrors the by-name path.
-        let wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+        let wrappedVal =
+          key === "valueOf" || key === "toString"
+            ? _maybeWrapCallable(val, 0, callbackState)
+            : _maybeWrapCallableUnknownArity(val, callbackState);
         // (#3051) `regexp.exec = fn` override — wrap the return so the native
         // RegExp protocol (@@replace/@@split/@@match/@@search) can read the
         // compiled match-result object (a WasmGC struct) via Get + ToXxx.
@@ -15414,7 +15430,10 @@ assert._isSameValue = isSameValue;
       // `obj.k = v` accessor writes here (ESM is always strict); the throw is
       // catchable in the user's try/catch via the host-import exception bridge.
       return (obj: any, key: any, val: any) => {
-        let wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+        let wrappedVal =
+          key === "valueOf" || key === "toString"
+            ? _maybeWrapCallable(val, 0, callbackState)
+            : _maybeWrapCallableUnknownArity(val, callbackState);
         // (#3051) See extern_set — wrap a `regexp.exec` override's return so the
         // native RegExp protocol can read the compiled result object.
         if (typeof wrappedVal === "function" && key === "exec" && obj instanceof RegExp) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15556,12 +15556,21 @@ assert._isSameValue = isSameValue;
       //        comparison yielding `undefined` makes the relational expression
       //        false, so callers treat 2 as "no operator matches".
       return (a: any, b: any) => {
-        if (a < b) return -1;
-        if (a > b) return 1;
+        // Native JS cannot invoke compiled valueOf/toString fields on an opaque
+        // WasmGC struct. IsLessThan requires ToPrimitive(number) on both sides
+        // before deciding between string and numeric comparison, so mirror the
+        // host_add/host_loose_eq bridge here instead of feeding the raw structs
+        // to V8's relational operators.
+        const av =
+          a != null && typeof a === "object" && _isWasmStruct(a) ? _toPrimitiveSync(a, "number", callbackState) : a;
+        const bv =
+          b != null && typeof b === "object" && _isWasmStruct(b) ? _toPrimitiveSync(b, "number", callbackState) : b;
+        if (av < bv) return -1;
+        if (av > bv) return 1;
         // Equal, OR incomparable (NaN involved). `a <= b` distinguishes:
         // `a <= b` is true only when equal; false when a NaN/undefined operand
         // makes every comparison false.
-        return a <= b ? 0 : 2;
+        return av <= bv ? 0 : 2;
       };
     case "same_value_zero":
       // #1360 — SameValueZero comparison (§7.2.11).

--- a/tests/issue-4208-ordinary-to-primitive-ir.test.ts
+++ b/tests/issue-4208-ordinary-to-primitive-ir.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+
+type CompileTarget = undefined | "standalone";
+
+async function instantiate(result: CompileResult): Promise<Record<string, (...args: unknown[]) => unknown>> {
+  const imports = (result.importObject ?? {}) as WebAssembly.Imports & {
+    setExports?: (exports: WebAssembly.Exports) => void;
+    __setExports?: (exports: WebAssembly.Exports) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports);
+  imports.__setExports?.(instance.exports);
+  return instance.exports as Record<string, (...args: unknown[]) => unknown>;
+}
+
+function probeOutcome(result: CompileResult): IrObservedOutcome | undefined {
+  return result.irOutcomes?.find((outcome) => outcome.displayName === "probe");
+}
+
+describe("#4208 S3/S7 — OrdinaryToPrimitive object literals", () => {
+  it.each<CompileTarget>([undefined, "standalone"])(
+    "emits focused valueOf/toString coercion through IR (%s)",
+    async (target) => {
+      const result = await compile(
+        `export function probe(): number {
+          const valueObject = { valueOf: function (): number { return 1; } };
+          const stringObject = { toString: function (): string { return "2"; } };
+          return +valueObject + +stringObject;
+        }`,
+        {
+          fileName: "issue-4208-ordinary-to-primitive-ir.ts",
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          ...(target ? { target } : {}),
+        },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(probeOutcome(result)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: true,
+        irBodyEmitted: true,
+      });
+      if (target === "standalone") {
+        expect(WebAssembly.Module.imports(await WebAssembly.compile(result.binary))).toEqual([]);
+      }
+      const exports = await instantiate(result);
+      expect(exports.probe!()).toBe(3);
+    },
+  );
+
+  it.each<CompileTarget>([undefined, "standalone"])(
+    "keeps repeated ES5 var declarations on legacy while sharing one open object carrier (%s)",
+    async (target) => {
+      const result = await compile(
+        `export function probe() {
+          var object = { valueOf: function () { return 1; } };
+          var a = +object;
+          var object = { toString: function () { return 2; } };
+          var b = -object;
+          var object = {
+            valueOf: function () { return 3; },
+            toString: function () { return 30; }
+          };
+          var c = ~object;
+          var object = { toString: function () { return 4; } };
+          var d = object >>> 0;
+          return a + b + c + d;
+        }`,
+        {
+          fileName: "issue-4208-repeated-var.js",
+          allowJs: true,
+          skipSemanticDiagnostics: true,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          ...(target ? { target } : {}),
+        },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(probeOutcome(result)).toMatchObject({
+        kind: "unsupported",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      const exports = await instantiate(result);
+      expect(exports.probe!()).toBe(-1);
+    },
+  );
+
+  it.each<CompileTarget>([undefined, "standalone"])(
+    "rejects mixed method/data objects before the IR claim (%s)",
+    async (target) => {
+      const result = await compile(
+        `export function probe(): number {
+          const object = {
+            valueOf: function (): number { return 1; },
+            data: 2
+          };
+          return +object;
+        }`,
+        {
+          fileName: "issue-4208-mixed-object.ts",
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          ...(target ? { target } : {}),
+        },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(probeOutcome(result)).toMatchObject({
+        kind: "unsupported",
+        code: "body-shape-rejected",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      const exports = await instantiate(result);
+      expect(exports.probe!()).toBe(1);
+    },
+  );
+});

--- a/tests/issue-4208-ordinary-to-primitive-ir.test.ts
+++ b/tests/issue-4208-ordinary-to-primitive-ir.test.ts
@@ -40,7 +40,7 @@ describe("#4208 S3/S7 — OrdinaryToPrimitive object literals", () => {
       );
 
       expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-      expect(probeOutcome(result)).toMatchObject({
+      expect(probeOutcome(result), JSON.stringify(probeOutcome(result), null, 2)).toMatchObject({
         kind: "emitted",
         legacyBodyEmitted: true,
         irBodyEmitted: true,
@@ -50,6 +50,39 @@ describe("#4208 S3/S7 — OrdinaryToPrimitive object literals", () => {
       }
       const exports = await instantiate(result);
       expect(exports.probe!()).toBe(3);
+    },
+  );
+
+  it.each<CompileTarget>([undefined, "standalone"])(
+    "emits numeric binary OrdinaryToPrimitive operations through IR (%s)",
+    async (target) => {
+      const result = await compile(
+        `export function probe(): number {
+          const sum: number = { valueOf: function (): number { return 4; } } + 2;
+          const less = { valueOf: function (): number { return 4; } } < 5;
+          const equal = { valueOf: function (): number { return 4; } } == 4;
+          return sum + (less ? 10 : 0) + (equal ? 100 : 0);
+        }`,
+        {
+          fileName: "issue-4208-ordinary-to-primitive-binary-ir.ts",
+          skipSemanticDiagnostics: true,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          ...(target ? { target } : {}),
+        },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(probeOutcome(result), JSON.stringify(probeOutcome(result), null, 2)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: true,
+        irBodyEmitted: true,
+      });
+      if (target === "standalone") {
+        expect(WebAssembly.Module.imports(await WebAssembly.compile(result.binary))).toEqual([]);
+      }
+      const exports = await instantiate(result);
+      expect(exports.probe!()).toBe(116);
     },
   );
 
@@ -89,6 +122,123 @@ describe("#4208 S3/S7 — OrdinaryToPrimitive object literals", () => {
       });
       const exports = await instantiate(result);
       expect(exports.probe!()).toBe(-1);
+    },
+  );
+
+  it.each<CompileTarget>(["standalone"])(
+    "uses the default hint for repeated ES5 objects in addition and comparison (%s)",
+    async (target) => {
+      const result = await compile(
+        `export function probe() {
+          var object = { valueOf: function () { return 1; }, toString: function () { return 0; } };
+          if (object + "" !== "1") return 1;
+          var object = { valueOf: function () { return "-2"; }, toString: function () { return -2; } };
+          if (object + 0 !== "-20") return 3;
+          if (object < "-1") return 2;
+          return 0;
+        }`,
+        {
+          fileName: "issue-4208-repeated-var-binary.js",
+          allowJs: true,
+          skipSemanticDiagnostics: true,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          ...(target ? { target } : {}),
+        },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(probeOutcome(result)).toMatchObject({
+        kind: "unsupported",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      const exports = await instantiate(result);
+      expect(exports.probe!()).toBe(0);
+    },
+  );
+
+  it.each<CompileTarget>(["standalone"])(
+    "coerces direct method-only literals for loose equality (%s)",
+    async (target) => {
+      const result = await compile(
+        `export function probe() {
+          if (!("+1" == { valueOf: function () { return 1; }, toString: function () { return {}; } })) return 1;
+          if ("+1" != { valueOf: function () { return 1; }, toString: function () { return {}; } }) return 2;
+          return 0;
+        }`,
+        {
+          fileName: "issue-4208-inline-loose-equality.js",
+          allowJs: true,
+          skipSemanticDiagnostics: true,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          ...(target ? { target } : {}),
+        },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      const exports = await instantiate(result);
+      expect(exports.probe!()).toBe(0);
+    },
+  );
+
+  it.each<CompileTarget>([undefined, "standalone"])(
+    "uses inherited object/function stringification in abstract operators (%s)",
+    async (target) => {
+      const result = await compile(
+        `export function probe() {
+        if (({} + function(){ return 1; }) !== ({}.toString() + function(){ return 1; }.toString())) return 1;
+        if (({} < function(){ return 1; }) !== ({}.toString() < function(){ return 1; }.toString())) return 2;
+        if ((function(){ return 1; } > {}) !== (function(){ return 1; }.toString() > {}.toString())) return 3;
+        if (({} + {}) !== "[object Object][object Object]") return 4;
+        if (({}.toString() + {}.toString()) !== "[object Object][object Object]") return 5;
+        return 0;
+      }`,
+        {
+          fileName: "issue-4208-object-function-binary.js",
+          allowJs: true,
+          skipSemanticDiagnostics: true,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          ...(target ? { target } : {}),
+        },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      if (target === "standalone") {
+        expect(WebAssembly.Module.imports(await WebAssembly.compile(result.binary))).toEqual([]);
+      }
+      const exports = await instantiate(result);
+      expect(exports.probe!(), JSON.stringify(probeOutcome(result), null, 2)).toBe(0);
+    },
+  );
+
+  it.each<CompileTarget>([undefined, "standalone"])(
+    "uses valueOf before toString for native string concatenation (%s)",
+    async (target) => {
+      const result = await compile(
+        `export function probe() {
+          var object = {
+            toNumber: function () { return 12345; },
+            toString: function () { return 67890; },
+            valueOf: function () { return "[object MyObj]"; }
+          };
+          return object + "" === "[object MyObj]" ? 1 : 0;
+        }`,
+        {
+          fileName: "issue-4208-default-hint-concat.js",
+          allowJs: true,
+          skipSemanticDiagnostics: true,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          ...(target ? { target } : {}),
+        },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      const exports = await instantiate(result);
+      expect(exports.probe!()).toBe(1);
     },
   );
 

--- a/tests/issue-4208-strict-eq-type-disjoint.test.ts
+++ b/tests/issue-4208-strict-eq-type-disjoint.test.ts
@@ -90,18 +90,14 @@ describe("#4208 S1 — === decides Type() before the f64 slot merges Number and 
     expect(await evalStandalone("var __r = (0 != false);")).toBe(FALSE);
   });
 
-  it("keeps-update-retyped-boolean — a `++`/`--` target's Boolean static type is stale", async () => {
+  it("stores a Number when `++`/`--` updates a Boolean-initialized binding", async () => {
     // §13.4: `x--` is `x = ToNumeric(x) - 1`, so `x` holds a Number afterwards
-    // however TypeScript typed the initializer. The compiler still keeps it in
-    // the initializer-derived i32 boolean slot (#4208 S2, blocked on #4204), so
-    // the representation-agreement argument does not hold and the fold must
-    // decline. Found by A/B, not by reasoning: without this guard
-    // `postfix-decrement/S11.3.2_A3_T1.js` and `prefix-decrement/S11.4.5_A3_T1.js`
-    // flip pass→fail.
+    // however TypeScript typed the initializer. #4208 S2 therefore gives the
+    // binding dynamic storage; strict equality now observes the real Number
+    // rather than relying on a Boolean-only fold suppression.
     expect(await evalStandalone("var x = true; x--; var __r = (x !== 0);")).toBe(FALSE);
     expect(await evalStandalone("var x = true; --x; var __r = (x === 1 - 1);")).toBe(TRUE);
-    // The suppression is scoped to the retyped binding — an unrelated Boolean
-    // in the same scope still folds.
+    // An unrelated Boolean in the same scope still folds against Number.
     expect(await evalStandalone("var x = true; x--; var b = false; var n = 0; var __r = (b === n);")).toBe(FALSE);
   });
 

--- a/tests/issue-4208-update-to-number-ir.test.ts
+++ b/tests/issue-4208-update-to-number-ir.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4208 S2 — update expressions replace their target with a Number.
+ *
+ * These cases are deliberately module-scoped: the ES5 Test262 files execute
+ * the update from the script body, so the synthetic module initializer must
+ * own the primitive cases through IR. Object carriers may still demote, but
+ * they share the same update-retyped storage decision and must keep the
+ * resulting Number rather than the initializer's object representation.
+ */
+import { describe, expect, it } from "vitest";
+import { compile, type CompileOptions, type CompileResult } from "../src/index.js";
+import { collectUpdateRetypedModuleBindings } from "../src/ir/update-retyped-bindings.js";
+import { ts } from "../src/ts-api.js";
+
+type Lane = readonly [string, CompileOptions];
+
+const LANES: readonly Lane[] = [
+  ["gc", { experimentalIR: true, trackIrOutcomes: true }],
+  [
+    "standalone",
+    {
+      target: "standalone",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+      hostBridge: "always",
+    },
+  ],
+];
+
+async function compileProbe(
+  body: string,
+  options: CompileOptions,
+  probeExpression = "__result ? 1 : 0",
+): Promise<CompileResult> {
+  const result = await compile(`${body}\nexport function probe(): number { return ${probeExpression}; }\n`, {
+    ...options,
+    allowJs: true,
+    fileName: "issue-4208-update-to-number.ts",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  return result;
+}
+
+async function runProbe(result: CompileResult): Promise<number> {
+  const { instance } = await WebAssembly.instantiate(result.binary!, result.importObject ?? {});
+  return (instance.exports as Record<string, () => number>).probe!();
+}
+
+function analyzeUpdateBindings(source: string): number {
+  const fileName = "/repo/update.ts";
+  const options: ts.CompilerOptions = { module: ts.ModuleKind.ESNext, noLib: true, target: ts.ScriptTarget.ES2022 };
+  const host: ts.CompilerHost = {
+    fileExists: (candidate) => candidate === fileName,
+    readFile: (candidate) => (candidate === fileName ? source : undefined),
+    getSourceFile: (candidate, languageVersion) =>
+      candidate === fileName
+        ? ts.createSourceFile(candidate, source, languageVersion, true, ts.ScriptKind.TS)
+        : undefined,
+    getDefaultLibFileName: () => "/repo/lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/repo",
+    getDirectories: () => [],
+    getCanonicalFileName: (candidate) => candidate,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+  };
+  const program = ts.createProgram([fileName], options, host);
+  const sourceFile = program.getSourceFile(fileName)!;
+  return collectUpdateRetypedModuleBindings(program.getTypeChecker(), sourceFile).size;
+}
+
+describe("#4208 S2 — update targets use dynamic storage and IR ToNumber", () => {
+  it("marks every declaration that shares a sloppy var binding", () => {
+    expect(analyzeUpdateBindings('var value = "1"; value++; var value = "3"; --value; export {};')).toBe(2);
+  });
+
+  for (const [lane, options] of LANES) {
+    it(`${lane}: decrements a string target and IR-owns module init`, async () => {
+      const result = await compileProbe('var value = "1"; value--; var __result = value === 0;', options);
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+      expect(result.irOutcomes?.find((outcome) => outcome.displayName === "<module-init>")).toMatchObject({
+        kind: "emitted",
+      });
+      expect(result.irCompiledFuncs ?? []).toContain("<module-init>");
+      expect(await runProbe(result)).toBe(1);
+    });
+
+    it(`${lane}: increments a string target and stores the Number`, async () => {
+      const result = await compileProbe('var value = "1"; ++value; var __result = value === 2;', options);
+      expect(result.irCompiledFuncs ?? []).toContain("<module-init>");
+      expect(await runProbe(result)).toBe(1);
+    });
+
+    it(`${lane}: retypes a Boolean target before strict equality`, async () => {
+      const result = await compileProbe("var value = true; value--; var __result = value === 0;", options);
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+      expect(result.irOutcomes?.find((outcome) => outcome.displayName === "<module-init>")).toMatchObject({
+        kind: "emitted",
+      });
+      expect(result.irCompiledFuncs ?? []).toContain("<module-init>");
+      expect(await runProbe(result)).toBe(1);
+    });
+
+    it(`${lane}: preserves the Number written over a Boolean wrapper`, async () => {
+      const result = await compileProbe("var value = new Boolean(true); value++; var __result = value === 2;", options);
+      expect(await runProbe(result)).toBe(1);
+    });
+
+    it(`${lane}: stores NaN after updating a plain object target`, async () => {
+      const result = await compileProbe(
+        "var value = {}; var previous = value--; var __result = previous !== previous && value !== value;",
+        options,
+      );
+      expect(await runProbe(result)).toBe(1);
+    });
+
+    it(`${lane}: shares dynamic storage across sloppy var redeclarations`, async () => {
+      const result = await compileProbe(
+        'var value = "1"; value++; var first = value === 2; var value = "3"; --value; var __result = (first ? 1 : 0) + (value === 2 ? 2 : 0);',
+        options,
+        "__result",
+      );
+      expect(await runProbe(result)).toBe(3);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- classify non-Number `++` / `--` module targets by binding identity and give primitive cases IR dynamic storage
- preserve repeated ES5 `var` object carriers across differing `valueOf` / `toString` literal shapes
- route object addition, loose equality, and relational comparison through OrdinaryToPrimitive before choosing string or numeric behavior
- extend the IR path for explicitly typed method-only object literals while keeping unsupported string-producing and duplicate-`var` shapes as honest selector rejections
- centralize runtime ToPrimitive emission in the coercion engine and prevent object addition from being claimed by numeric folding or chain flattening

## Root causes

Module globals inherited Wasm storage from their initializer's static TypeScript type even though update expressions write a Number back. Separately, repeated ES5 `var` declarations could allocate incompatible closed object layouts and later store null instead of the next object shape.

Binary lowering also used the static Object type to bypass dynamic addition/comparison after `$AnyValue` registration, native concatenation used the wrong ToPrimitive hint, and the constant folder incorrectly reduced `{} + {}` through ToNumber.

## IR ownership

Simple primitive update initializers and explicitly typed, numeric/default method-only object literals are emitted through IR in host and standalone. Their coercions use canonical ToPrimitive/ToNumber operations and prepared runtime providers.

String-producing object binary expressions remain a clean legacy fallback until IR has a carrier for the runtime string-versus-number result. The Test262 duplicate-`var` wrapper also remains legacy-owned because duplicate declarations and unannotated JS closures are outside the current IR declaration model.

## Impact

- ten previously-red prefix/postfix update files are green in host and standalone
- five previously-crashing unary/bitwise/shift OrdinaryToPrimitive files are green in host and standalone
- the next standalone S3/S7 binary cluster improves from **5/15 to 15/15**

## Validation

- maintained Test262 update files: host GC **10/10**, standalone **10/10**
- maintained Test262 unary/bitwise/shift files: host GC **5/5**, standalone **5/5**
- maintained Test262 standalone binary cluster: **15/15** (`20260811-223059`, post-refactor control)
- changed #4208 root suites: **43/43**
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks` — no unintended, post-claim, or module-level increase
- LOC/function budgets, oracle/coercion ratchets, Prettier, Biome, and numeric-local IR parity

The issue remains open for compound assignment, Date-specific ToPrimitive behavior, and broader dynamic object shapes.
