### PR TITLE
fix(codegen): collect wrapped accessor imports

### DIFF
--- a/plan/issues/4367-jest-parenthesized-accessor-descriptor-import.md
+++ b/plan/issues/4367-jest-parenthesized-accessor-descriptor-import.md
@@ -1,0 +1,68 @@
+---
+id: 4367
+title: "Jest parenthesized accessor descriptors miss the getter-callback import"
+status: in-progress
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: object-reflection, accessors, transparent-expressions
+goal: npm-library-support
+related: [1027, 3048, 3995, 4302]
+loc-budget-allow:
+  - src/codegen/declarations/import-collector.ts
+---
+
+# Preserve accessor-descriptor shape through transparent wrappers
+
+## Problem
+
+The pinned Jest 30.4.2 entry graph reports fourteen
+`Missing __make_getter_callback import` diagnostics. They are duplicate-pass
+copies of seven unique Webpack export getters:
+
+- `@jest/core/build/index.js:4191`, `:4197`, `:4203`, and `:4209`
+- `jest-cli/build/index.js:781`, `:787`, and `:793`
+
+Each site has the same real-source shape:
+
+```js
+Object.defineProperty(exports, "run", ({
+  enumerable: true,
+  get: function () {
+    return _run.run;
+  },
+}));
+```
+
+The emitter unwraps the parenthesized descriptor and lowers the getter through
+`__make_getter_callback`. The import collector calls `isAccessorDescriptor`
+on the outer `ParenthesizedExpression`, rejects it as non-object, and therefore
+does not register the import. This is a transparent-wrapper residual after the
+completed accessor-import work in #3048, not a Jest-specific semantic rule.
+
+## Acceptance criteria
+
+- [x] The import collector recognizes accessor descriptors behind parentheses
+      and TypeScript-transparent expression wrappers.
+- [x] A focused Webpack-shaped `Object.defineProperty` fixture compiles to a
+      valid host-lane module and declares `env::__make_getter_callback`.
+- [x] Existing direct descriptor cases and standalone host-import exclusions
+      remain green.
+- [x] The pinned Jest entry graph no longer reports the fourteen missing-import
+      diagnostics; any independent async blocker remains explicit.
+
+## Implementation result (2026-08-11)
+
+`isAccessorDescriptor` now delegates transparent-wrapper removal to the shared
+descriptor analysis before testing the object-literal fields. The real pinned
+Jest entry graph moves from fifteen compile diagnostics to one: all fourteen
+missing `__make_getter_callback` reports are gone, and only the independently
+tracked async-in-`try` refusal remains. The graph still emits no binary until
+that async slice lands, so this result is compile-frontier evidence rather than
+runtime correctness evidence.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -2,6 +2,13 @@
 
 Lightweight pointer index for unscheduled issues that need sprint candidacy. Authoritative status lives in each issue file's frontmatter.
 
+## 2026-08-11 — Jest accessor descriptor import
+
+- [#4367](../4367-jest-parenthesized-accessor-descriptor-import.md) — unwrap
+  transparent parentheses/type wrappers before the accessor-descriptor import
+  pre-pass decides whether Jest's Webpack export getters need the
+  `__make_getter_callback` bridge.
+
 ## 2026-08-09 — Prepared provider transaction rollback
 
 - [#4260](../4260-prepared-provider-plans-leak-across-aborted-component-seal.md)

--- a/src/codegen/declarations/import-collector.ts
+++ b/src/codegen/declarations/import-collector.ts
@@ -17,6 +17,7 @@ import { ensureWrapperTypes } from "../any-helpers.js";
 import { ASYNC_CPS_ENABLED, analyzeAsyncBody, asyncFnNeedsCps } from "../async-cps.js";
 import { asyncFnNeedsHostDrive, asyncGenDrivableUnderCarrier, asyncGenStem } from "../async-frame.js";
 import { isStandalonePromiseActive } from "../async-scheduler.js";
+import { unwrapTransparentExpression } from "../object-descriptor-analysis.js";
 import {
   functionBodyReferencesThis,
   genBodyReferencesSuper,
@@ -2018,6 +2019,7 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
  * they are widened like data descriptors so the property appears in for-in and hasOwnProperty
  * (matching baseline behavior where all Object.defineProperty targets are widened). (#929) */
 function isAccessorDescriptor(descArg: ts.Expression): boolean {
+  descArg = unwrapTransparentExpression(descArg);
   if (!ts.isObjectLiteralExpression(descArg)) return false;
   for (const prop of descArg.properties) {
     // Method shorthand: get() {...} or set(v) {...} — always a real accessor

--- a/tests/issue-4367-jest-parenthesized-accessor-import.test.ts
+++ b/tests/issue-4367-jest-parenthesized-accessor-import.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4367 — Webpack wraps Object.defineProperty descriptor literals in
+ * parentheses. The emitter unwraps them, so the import collector must make the
+ * same decision before the getter body requests __make_getter_callback.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+describe("#4367 parenthesized accessor descriptor imports", () => {
+  it("registers the getter callback bridge for Jest's Webpack export shape", async () => {
+    const result = await compile(
+      `
+const moduleExports: Record<string, unknown> = {};
+const dependency = { run: 42 };
+Object.defineProperty(moduleExports, "run", ({
+  enumerable: true,
+  get: function () {
+    return dependency.run;
+  }
+}));
+export function test(): number {
+  return moduleExports.run as number;
+}`,
+      { fileName: "webpack-export.ts", skipSemanticDiagnostics: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.imports).toContainEqual(expect.objectContaining({ module: "env", name: "__make_getter_callback" }));
+  });
+
+  it("recognizes TypeScript-transparent wrappers around the descriptor", async () => {
+    const result = await compile(
+      `
+const target: Record<string, unknown> = {};
+Object.defineProperty(target, "value", ({
+  get: () => 7
+} satisfies PropertyDescriptor)!);
+export function test(): number { return target.value as number; }
+`,
+      { fileName: "wrapped-descriptor.ts", skipSemanticDiagnostics: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- unwrap transparent descriptor expressions before the accessor import pre-pass classifies them
- align import planning with the existing Object.defineProperty emitter
- cover Jest/Webpack parenthesized getters and TypeScript-transparent wrappers

The pinned Jest 30.4.2 entry graph moves from 15 compile diagnostics to 1: all 14 missing `__make_getter_callback` reports disappear. The remaining async refusal is independently tracked by [#4302](https://github.com/loopdive/js2wasm/blob/main/plan/issues/4302-package-async-await-inside-try-shapes.md).

Plan: [#4367](https://github.com/loopdive/js2wasm/blob/03b0ce248ae5095af5417bf227f99d42998cd8ce/plan/issues/4367-jest-parenthesized-accessor-descriptor-import.md)

## Verification
- `pnpm run typecheck`
- `pnpm exec vitest run tests/issue-4367-jest-parenthesized-accessor-import.test.ts tests/issue-3048.test.ts tests/issue-1027.test.ts`
- pinned Jest catalog harness: 15 diagnostics -> 1
- full local pre-push checks