### PR TITLE
fix(codegen): preserve class-expression receiver identity

### DIFF
--- a/plan/issues/4301-hono-private-router-brand.md
+++ b/plan/issues/4301-hono-private-router-brand.md
@@ -4,7 +4,7 @@ title: "Hono router methods lose the private #routes brand at runtime"
 status: ready
 sprint: current
 created: 2026-08-09
-updated: 2026-08-09
+updated: 2026-08-11
 priority: high
 horizon: m
 feasibility: medium
@@ -67,6 +67,30 @@ router instance carries the wrong class tag/struct representation.
 Resume by reducing `App.router -> Router.match -> this.#routes`, then add one
 nested `SmartRouter`/`RegExpRouter` case. Inspect the emitted method receiver
 and runtime class tag before changing the brand predicate.
+
+## Implementation checkpoint (2026-08-11)
+
+The failure was receiver identity, not the private-brand predicate. A
+variable-bound class expression has both a source-binding carrier and a
+declaration-identity carrier. Structural method selection could choose the
+former while the method body and its captured `this` expected the latter. A
+private method was also allowed to enter inheritance/virtual-candidate lookup,
+although private names are lexically bound and cannot be overridden.
+
+Receiver resolution now canonicalizes public class-expression carriers, keeps
+private methods tied to their lexical declaration, and selects a duplicate
+captured-`this` alias only when both the receiver struct and method self ABI
+match exactly. Ambiguous matches are rejected rather than guessed. Five focused
+runtime cases cover anonymous-class fields, structural calls, private methods,
+captured `this`, and same-spelled private methods in a subclass; the focused and
+adjacent suites pass 30/30.
+
+The unchanged Hono workload still compiles and validates, and it now advances
+past the `#routes` TypeError. It reaches a distinct `illegal cast` in
+`__closure_156` while evaluating the dynamic `r[method]` path inside
+`#buildMatcher`. That next compiler defect is being tracked separately; this
+issue remains open until the complete pinned route-matching differential can be
+rerun.
 
 ## Acceptance criteria
 

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -121,12 +121,14 @@ import { compileExternMethodCall } from "./extern.js";
 import { tryEmitDynamicValueOfCall } from "../wrapper-valueof.js"; // (#4201) dynamic-receiver valueOf
 import {
   buildThrowJsErrorInstrs,
+  canonicalClassExpressionName,
   emitThrowTypeError,
   getFuncParamTypes,
   getWasmFuncReturnType,
   isEffectivelyVoidReturn,
   maybeStampCompiledFunctionArgName,
   noJsHost,
+  resolveReceiverMethodClassName,
   wasmFuncReturnsVoid,
 } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
@@ -1127,12 +1129,8 @@ export function compileReceiverMethodCall(
     }
   }
 
-  // Check if receiver is a local class instance
-  let receiverClassName = receiverType.getSymbol()?.name;
-  // Map class expression symbol names to their synthetic names
-  if (receiverClassName && !ctx.classSet.has(receiverClassName)) {
-    receiverClassName = ctx.classExprNameMap.get(receiverClassName) ?? receiverClassName;
-  }
+  // Check if receiver is a local class instance.
+  let receiverClassName = resolveReceiverMethodClassName(ctx, fctx, propAccess, receiverType);
   // Fallback for union types, interfaces, abstract classes:
   // When the direct symbol name is not a known class, try to resolve via
   // union members, apparent type, or base types.
@@ -1143,10 +1141,7 @@ export function compileReceiverMethodCall(
     // Try union type members: for `A | B`, check each member for a known class
     if (receiverType.isUnion()) {
       for (const memberType of (receiverType as ts.UnionType).types) {
-        let memberName = memberType.getSymbol()?.name;
-        if (memberName && !ctx.classSet.has(memberName)) {
-          memberName = ctx.classExprNameMap.get(memberName) ?? memberName;
-        }
+        const memberName = canonicalClassExpressionName(ctx, memberType.getSymbol()?.name);
         if (memberName && ctx.classSet.has(memberName)) {
           const fullName = `${memberName}_${methodName}`;
           if (ctx.funcMap.has(fullName)) {
@@ -1170,10 +1165,7 @@ export function compileReceiverMethodCall(
     if (!receiverClassName || !ctx.classSet.has(receiverClassName)) {
       const apparentType = ctx.checker.getApparentType(receiverType);
       if (apparentType !== receiverType) {
-        let apparentName = apparentType.getSymbol()?.name;
-        if (apparentName && !ctx.classSet.has(apparentName)) {
-          apparentName = ctx.classExprNameMap.get(apparentName) ?? apparentName;
-        }
+        const apparentName = canonicalClassExpressionName(ctx, apparentType.getSymbol()?.name);
         if (apparentName && ctx.classSet.has(apparentName) && ctx.funcMap.has(`${apparentName}_${methodName}`)) {
           receiverClassName = apparentName;
         }
@@ -1184,10 +1176,7 @@ export function compileReceiverMethodCall(
       const baseTypes = receiverType.getBaseTypes?.();
       if (baseTypes) {
         for (const baseType of baseTypes) {
-          let baseName = baseType.getSymbol()?.name;
-          if (baseName && !ctx.classSet.has(baseName)) {
-            baseName = ctx.classExprNameMap.get(baseName) ?? baseName;
-          }
+          const baseName = canonicalClassExpressionName(ctx, baseType.getSymbol()?.name);
           if (baseName && ctx.classSet.has(baseName) && ctx.funcMap.has(`${baseName}_${methodName}`)) {
             receiverClassName = baseName;
             break;
@@ -1197,7 +1186,7 @@ export function compileReceiverMethodCall(
     }
     // Try struct name from the receiver's wasm type
     if (!receiverClassName || !ctx.classSet.has(receiverClassName)) {
-      const structName = resolveStructName(ctx, receiverType);
+      const structName = canonicalClassExpressionName(ctx, resolveStructName(ctx, receiverType));
       if (structName && ctx.classSet.has(structName) && ctx.funcMap.has(`${structName}_${methodName}`)) {
         receiverClassName = structName;
       }
@@ -1216,7 +1205,10 @@ export function compileReceiverMethodCall(
       // dynamic so their runtime identity selects the method.
       const canInferClass =
         recvProps.length > 0 && (receiverType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) === 0;
-      for (const className of canInferClass ? ctx.classSet : []) {
+      const canonicalClasses = canInferClass
+        ? new Set([...ctx.classSet].map((name) => canonicalClassExpressionName(ctx, name) ?? name))
+        : [];
+      for (const className of canonicalClasses) {
         if (!ctx.funcMap.has(`${className}_${methodName}`)) continue;
         // (#3123) Never INFER a fnctor-subclass (`class C extends F`, F a
         // top-level plain function) for an any/unknown-typed receiver: the
@@ -1283,7 +1275,7 @@ export function compileReceiverMethodCall(
     let fullName = `${receiverClassName}_${methodName}`;
     let funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)); // (#1983)
     // Walk inheritance chain to find the method in a parent class
-    if (funcIdx === undefined) {
+    if (funcIdx === undefined && !ts.isPrivateIdentifier(propAccess.name)) {
       let ancestor = ctx.classParentMap.get(receiverClassName);
       while (ancestor && funcIdx === undefined) {
         fullName = `${ancestor}_${methodName}`;
@@ -1297,7 +1289,7 @@ export function compileReceiverMethodCall(
     // exists. Without this, a base-typed receiver would unconditionally
     // call the first subclass's method regardless of runtime type.
     let virtualCandidates: { className: string; funcIdx: number; classTag: number }[] | undefined;
-    if (funcIdx === undefined) {
+    if (funcIdx === undefined && !ts.isPrivateIdentifier(propAccess.name)) {
       const candidates: { className: string; funcIdx: number; classTag: number }[] = [];
       const baseClass = fullName.split("_")[0];
       for (const [childClass, parentClass] of ctx.classParentMap) {
@@ -1318,7 +1310,10 @@ export function compileReceiverMethodCall(
         fullName = `${candidates[0]!.className}_${methodName}`;
         funcIdx = candidates[0]!.funcIdx;
       }
-    } else {
+    } else if (funcIdx !== undefined && !ts.isPrivateIdentifier(propAccess.name)) {
+      // Private names are lexically bound and cannot be overridden. Dispatch
+      // exactly to their declaring body; treating a same-spelled private name
+      // on a subclass as an override violates both the brand and self ABI.
       // Method exists on receiver class — also check for subclass overrides.
       const candidates: { className: string; funcIdx: number; classTag: number }[] = [];
       const recvTag = ctx.classTagMap.get(receiverClassName);

--- a/src/codegen/expressions/helpers.ts
+++ b/src/codegen/expressions/helpers.ts
@@ -11,6 +11,7 @@
 import { ts } from "../../ts-api.js";
 import { isVoidType, unwrapPromiseType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
+import { classMemberFuncKey } from "../class-member-keys.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { funcSignatureOf } from "../func-space.js";
@@ -320,8 +321,14 @@ export function classifyPrivateMember(
   // of method / accessor / field sets in turn.
   let current: ts.Node | undefined = name.parent;
   while (current) {
-    if ((ts.isClassDeclaration(current) || ts.isClassExpression(current)) && current.name) {
-      const className = current.name.text;
+    if (ts.isClassDeclaration(current) || ts.isClassExpression(current)) {
+      const className = ts.isClassExpression(current)
+        ? (ctx.anonClassExprNames.get(current) ?? current.name?.text)
+        : current.name?.text;
+      if (!className) {
+        current = current.parent;
+        continue;
+      }
       const fullName = `${className}_${fieldName}`;
       // Method: registered in classMethodSet (instance) or staticMethodSet (static).
       if (ctx.classMethodSet.has(fullName) || ctx.staticMethodSet.has(fullName)) {
@@ -344,6 +351,65 @@ export function classifyPrivateMember(
     current = current.parent;
   }
   return undefined;
+}
+
+export function canonicalClassExpressionName(ctx: CodegenContext, className: string | undefined): string | undefined {
+  return className === undefined ? undefined : (ctx.classExprNameMap.get(className) ?? className);
+}
+
+/**
+ * Resolve the class body whose method ABI can consume this call's receiver.
+ *
+ * Variable-bound class expressions have a source-binding carrier and a
+ * declaration-identity carrier. Public structural calls use the latter. A
+ * private call normally uses its lexical declarer, except while compiling the
+ * duplicate source body: there the captured `this` must call the equivalent
+ * method whose self parameter has the exact same struct type. Descendants are
+ * deliberately excluded because private names are never virtual overrides.
+ */
+export function resolveReceiverMethodClassName(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  receiverType: ts.Type,
+): string | undefined {
+  const symbolClassName = receiverType.getSymbol()?.name;
+  if (!ts.isPrivateIdentifier(propAccess.name)) {
+    return canonicalClassExpressionName(ctx, symbolClassName);
+  }
+
+  const privateMember = classifyPrivateMember(ctx, propAccess.name);
+  if (privateMember?.kind !== "method") {
+    return canonicalClassExpressionName(ctx, symbolClassName);
+  }
+  const lexicalClassName = privateMember.className;
+  if (propAccess.expression.kind !== ts.SyntaxKind.ThisKeyword) return lexicalClassName;
+
+  const thisLocalIdx = fctx.localMap.get("this");
+  const thisType = thisLocalIdx === undefined ? undefined : getLocalType(fctx, thisLocalIdx);
+  if (thisType?.kind !== "ref" && thisType?.kind !== "ref_null") return lexicalClassName;
+
+  const privateMethodName = `__priv_${propAccess.name.text.slice(1)}`;
+  const owners: string[] = [];
+  for (const [className, typeIdx] of ctx.structMap) {
+    if (className !== lexicalClassName && ctx.classExprNameMap.get(className) !== lexicalClassName) continue;
+    if (typeIdx !== thisType.typeIdx) continue;
+    const fullName = `${className}_${privateMethodName}`;
+    const methodHandle = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)) ?? ctx.funcMap.get(fullName);
+    const methodSelfType = methodHandle === undefined ? undefined : getFuncParamTypes(ctx, methodHandle)?.[0];
+    if (
+      (methodSelfType?.kind === "ref" || methodSelfType?.kind === "ref_null") &&
+      methodSelfType.typeIdx === thisType.typeIdx
+    ) {
+      owners.push(className);
+    }
+  }
+  if (owners.length > 1) {
+    throw new Error(
+      `private receiver owner is ambiguous for ${propAccess.name.text} in ${fctx.name}: ${owners.join(", ")}`,
+    );
+  }
+  return owners[0] ?? lexicalClassName;
 }
 
 /**

--- a/tests/issue-4301-class-expression-private-receiver.test.ts
+++ b/tests/issue-4301-class-expression-private-receiver.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "class-expression-private-receiver.ts",
+    platform: "node",
+    skipSemanticDiagnostics: true,
+    target: "gc",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    result.binary,
+    imports.env,
+    imports.string_constants,
+    imports.string_constants16,
+  );
+  imports.setInstance?.(instance);
+  return (instance.exports.runCase as () => number)();
+}
+
+describe("#4301 class-expression private receiver identity", () => {
+  it("reads a private field through a var-bound anonymous class method", async () => {
+    expect(
+      await run(`
+        var Router = class {
+          #routes = [1, 2];
+          size() { return this.#routes.length; }
+        };
+        export function runCase() { return new Router().size(); }
+      `),
+    ).toBe(2);
+  });
+
+  it("selects the canonical class-expression method for a structural receiver", async () => {
+    expect(
+      await run(`
+        interface RouterShape { buildAllMatchers(): number; }
+        var Router = class {
+          #routes = [1, 2, 3];
+          buildAllMatchers() { return this.#routes.length; }
+        };
+        function invoke<R extends RouterShape>(router: R): number {
+          return router.buildAllMatchers();
+        }
+        export function runCase() { return invoke(new Router()); }
+      `),
+    ).toBe(3);
+  });
+
+  it("resolves an anonymous class private method on a dynamically typed receiver", async () => {
+    expect(
+      await run(`
+        var Router = class {
+          #routes = [1, 2, 3, 4];
+          #buildMatcher(method: string) { return this.#routes.length + method.length; }
+          buildAllMatchers(receiver: any) { return receiver.#buildMatcher("GET"); }
+        };
+        export function runCase() {
+          const router = new Router();
+          return router.buildAllMatchers(router);
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("keeps a captured this tied to each duplicate class-expression body", async () => {
+    expect(
+      await run(`
+        var Router = class {
+          #routes = [1, 2, 3, 4, 5];
+          #buildMatcher(method: string) { return this.#routes.length + method.length; }
+          buildAllMatchers() {
+            return ["GET"].map((method) => this.#buildMatcher(method))[0];
+          }
+        };
+        export function runCase() { return new Router().buildAllMatchers(); }
+      `),
+    ).toBe(8);
+  });
+
+  it("dispatches inherited private calls to the lexical base declaration", async () => {
+    expect(
+      await run(`
+        class Base {
+          #value = 3;
+          #read() { return this.#value; }
+          read() { return this.#read(); }
+        }
+        class Derived extends Base {
+          #read() { return 100; }
+        }
+        export function runCase() { return new Derived().read(); }
+      `),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- canonicalize variable-bound class-expression carriers before selecting a receiver method
- keep private methods tied to their lexical declaration and exact receiver ABI instead of inheritance/virtual dispatch
- reject ambiguous duplicate captured-`this` owners instead of guessing
- add five runtime regressions and record the package checkpoint in [plan issue 4301](https://github.com/loopdive/js2wasm/blob/codex/4301-hono-private-fields-current/plan/issues/4301-hono-private-router-brand.md)

## Root cause

A variable-bound class expression has both a source-binding carrier and a declaration-identity carrier. Hono's structural method call could select the first while the method body and captured `this` expected the second. Private methods could also enter inheritance/virtual lookup even though private names are lexically bound and cannot be overridden.

The generic resolver now canonicalizes public class-expression identities. For private calls it selects the lexical declaration, or a duplicate source body only when both the receiver struct and method-self parameter have the exact same Wasm type.

## Package impact

The unchanged Hono 4.12.16 workload compiles and validates, then advances past the former `#routes` private-brand TypeError. It now reaches a separate dynamic `r[method]` illegal cast inside `#buildMatcher`; that next defect is being investigated independently. The markdown issue remains open until the full route-matching differential succeeds.

## Validation

- focused regressions: 5/5 passed
- focused plus adjacent private-field/class-expression suites: 30/30 passed
- typecheck, IR fallback, Prettier, Biome, LOC/function budgets, oracle/coercion/numeric-local and issue-ID gates passed
- four unrelated adjacent failures reproduced identically on pristine `origin/main`
