### PR TITLE
fix(codegen): store self-capturing initializers through live cells

### DIFF
--- a/plan/issues/4368-self-referential-object-literal-capture-cell-init.md
+++ b/plan/issues/4368-self-referential-object-literal-capture-cell-init.md
@@ -1,0 +1,87 @@
+---
+id: 4368
+title: "Self-referential object-literal initializer writes through stale pre-capture local and emits invalid Wasm"
+status: done
+assignee: ttraenkler/codex
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+completed: 2026-08-11
+priority: high
+horizon: s
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: closures
+goal: npm-library-support
+related: [3128, 3534, 3715, 4369]
+files:
+  - src/codegen/statements/variables.ts
+  - tests/issue-4368-self-referential-object-capture.test.ts
+loc-budget-allow:
+  - src/codegen/statements/variables.ts
+func-budget-allow:
+  - src/codegen/statements/variables.ts::compileVariableStatement
+origin: "marked@18.0.2 pinned dogfood bundle after bypassing #3715 diagnostics"
+---
+
+# #4368 — Self-referential object-literal initializer uses a stale capture slot
+
+## Problem
+
+Marked's regex-builder helper initializes an object whose closures capture the
+object being initialized:
+
+```js
+let n = {
+  replace: () => n,
+  getRegex: () => new RegExp(source),
+};
+```
+
+The initializer creates a mutable capture cell for `n` and re-aims
+`localMap["n"]` at that cell. The variable-declaration path, however, resolved
+the local index before compiling the initializer and later used that stale raw
+object slot as the receiver of `struct.set <ref-cell> 0`. The resulting Wasm is
+invalid: the validator expects the ref-cell type but sees the initialized
+object's struct type.
+
+The 12 KB minimized binary and Marked's 4.1 MB binary fail with the same shape:
+
+```text
+struct.set[0] expected type (ref null <capture-cell>),
+found local.get of type (ref null <object-struct>)
+```
+
+This is the declaration-initializer sibling of the assignment repair in
+[#3128](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3128-assignment-rhs-closure-capture-aliasing.md):
+both paths must resolve live storage after compiling a RHS that can create a
+capture.
+
+## Acceptance criteria
+
+- [x] The minimized self-referential object literal emits valid Wasm.
+- [x] Calling through the captured methods returns the expected value, proving
+      the initialized object and captured reference alias the same cell.
+- [x] The real pinned Marked bundle advances past this validator failure.
+- [x] Adjacent closure-capture and variable-initialization suites remain green.
+
+## Implementation direction
+
+When a declaration initializer leaves `boxedCaptures[name]` live, resolve the
+current `localMap[name]` after initializer compilation and use that ref-cell
+local for the null guard and `struct.set`. Keep the pre-initializer local only
+as a fallback for the already-boxed-before-declaration case.
+
+## Result
+
+The declaration path now resolves the live local after initializer compilation
+before emitting the null guard and ref-cell store. The minimized module
+validates and executes to `7`, proving that the object returned through its
+self-capturing closure is the initialized object.
+
+The focused test and four adjacent capture/initialization suites pass 44/44.
+With semantic diagnostics bypassed only to measure this backend stage, the
+unchanged pinned Marked bundle compiles in 23.013 seconds to 4,086,843 bytes and
+advances to the separate dynamic-`in` stack defect tracked by
+[#4369](./4369-dynamic-in-physical-struct-field-stack-imbalance.md).

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -2243,20 +2243,29 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       const boxedForInitStore = fctx.boxedCaptures?.get(name);
       if (boxedForInitStore) {
         const boxedForInit = boxedForInitStore;
+        // (#4368) The initializer itself may be what first captures `name`.
+        // In that case closure construction boxes the binding mid-expression
+        // and re-aims localMap[name] from the raw pre-hoisted value slot to the
+        // new ref-cell slot. `localIdx` was resolved before compiling the
+        // initializer, so using it here writes a struct value where the cell
+        // reference belongs and produces invalid Wasm for shapes such as
+        // `let n = { again: () => n }`. Resolve the live storage after the
+        // initializer, exactly as the ordinary assignment path does (#3128).
+        const boxedLocalIdx = fctx.localMap.get(name) ?? localIdx;
         // Coerce stack to value type if needed.
         if (!valTypesMatch(stackType, boxedForInit.valType)) {
           coerceType(ctx, fctx, stackType, boxedForInit.valType);
         }
         const tmpVal = allocLocal(fctx, `__box_init_tmp_${fctx.locals.length}`, boxedForInit.valType);
         fctx.body.push({ op: "local.set", index: tmpVal });
-        fctx.body.push({ op: "local.get", index: localIdx });
+        fctx.body.push({ op: "local.get", index: boxedLocalIdx });
         fctx.body.push({ op: "ref.is_null" });
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
           then: [],
           else: [
-            { op: "local.get", index: localIdx },
+            { op: "local.get", index: boxedLocalIdx },
             { op: "local.get", index: tmpVal },
             {
               op: "struct.set",

--- a/tests/issue-4368-self-referential-object-capture.test.ts
+++ b/tests/issue-4368-self-referential-object-capture.test.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+const SOURCE = `
+  export function run() {
+    let chain = {
+      get: () => chain,
+    };
+    return chain.get() === chain ? 7 : 0;
+  }
+`;
+
+describe("#4368 — self-referential object-literal capture initialization", () => {
+  it("writes the initialized object through the live capture cell", async () => {
+    const result = await compile(SOURCE, {
+      fileName: "self-capture.js",
+      skipSemanticDiagnostics: true,
+      experimentalIR: false,
+    });
+
+    expect(result.success).toBe(true);
+    await expect(WebAssembly.compile(result.binary)).resolves.toBeInstanceOf(WebAssembly.Module);
+
+    const importObject = result.importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+    importObject.__setInstance?.(instance);
+    const exports = wrapExports(instance, { signatures: result.exportSignatures });
+    expect(exports.run()).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve a declaration binding again after an initializer creates its capture cell
- store a self-referential object literal through the live cell instead of the stale pre-capture local
- add a runtime regression and complete [plan issue 4368](https://github.com/loopdive/js2wasm/blob/52cdc44c0abb7aece8a357455156b43690df8e49/plan/issues/4368-self-referential-object-literal-capture-cell-init.md)

## Root cause

Compiling an initializer such as `let chain = { get: () => chain }` can create a mutable capture cell and re-aim `localMap["chain"]` during the initializer. The declaration path had cached the old local index before compilation and later used that stale raw-object slot as the receiver of `struct.set <capture-cell>`, producing invalid Wasm.

The assignment path already resolves live storage after compiling a potentially capturing right-hand side. This change gives declaration initializers the same rule.

## Package impact

The minimized module validates and executes to `7`, proving that the object returned through its self-capturing closure is the initialized object. With semantic diagnostics bypassed only to expose the backend sequence, the unchanged pinned Marked 18.0.2 bundle compiles in 23.013 seconds to 4,086,843 bytes and advances to the independent dynamic-`in` stack defect documented in [plan issue 4369](https://github.com/loopdive/js2wasm/blob/837e2b4ffd14c88e2573f084b17c9b531bba17e9/plan/issues/4369-dynamic-in-physical-struct-field-stack-imbalance.md).

This does not claim that Marked's normal compile path is green; its evolving-array semantic inference remains tracked in [plan issue 3715](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3715-evolving-array-type-never-inference.md).

## Validation

- focused and adjacent capture/initialization suites: 44/44 passed
- rebased focused runtime regression: 1/1 passed
- pinned Marked backend probe: previous capture-cell validator failure removed; exact next failure recorded
- typecheck, IR fallback, Prettier, Biome, LOC/function budgets, oracle/coercion/numeric-local and issue-ID gates passed
