### PR TITLE
feat(runtime): isolate host eval without moving AOT Wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ The imports a module needs depend on the compile target:
   const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
   (instance.exports as any).add(2, 3); // → 5
   ```
+
+  Dynamic `eval` / `new Function` can instead use an isolated JS evaluator
+  while the AOT Wasm instance stays in its original host. See
+  [Isolated JS-host eval](docs/js-host-eval-isolation.md).
 - **Standalone mode** (`target: "standalone"`, also `target: "wasi"`) emits a
   pure WasmGC module with Wasm-native intrinsics and **no host imports**, so it
   instantiates with `WebAssembly.instantiate(binary, {})` and runs anywhere

--- a/docs/js-host-eval-isolation.md
+++ b/docs/js-host-eval-isolation.md
@@ -1,0 +1,130 @@
+# Isolated JS-host eval
+
+Dynamic `eval` and `new Function` can use another JavaScript realm while the
+ahead-of-time compiled Wasm module remains in its original host. The runtime
+accepts an explicit synchronous evaluator through `buildImports`:
+
+```ts
+const imports = buildImports(result.imports, undefined, result.stringPool, {
+  dynamicCode: "evaluator",
+  dynamicCodeEvaluator: evaluator,
+});
+const { instance } = await WebAssembly.instantiate(result.binary, imports);
+imports.setInstance?.(instance);
+```
+
+The evaluator is synchronous because a normal Wasm import is synchronous. The
+runtime also supports `dynamicCode: "deny"` for a fail-closed host and preserves
+the existing `"compat"` behavior by default.
+
+## Node.js eval Worker
+
+Node can keep only the evaluator in a dedicated Worker. The AOT Wasm instance,
+its memory, and the rest of the runtime stay in the calling thread. A small
+`SharedArrayBuffer`/`Atomics` control channel makes the Worker request
+synchronous; remote functions and objects are represented by synchronous
+proxies backed by Worker handles.
+
+Worker entry:
+
+```ts
+import { parentPort } from "node:worker_threads";
+import { serveNodeEvalWorker } from "@loopdive/js2/runtime/node-eval-worker";
+
+if (!parentPort) throw new Error("missing parentPort");
+serveNodeEvalWorker(parentPort);
+```
+
+Host:
+
+```ts
+import { Worker } from "node:worker_threads";
+import { compile } from "@loopdive/js2";
+import { buildImports } from "@loopdive/js2/runtime";
+import { connectNodeEvalWorker } from "@loopdive/js2/runtime/node-eval-worker";
+
+const result = await compile(`
+  export function run(source: any): any {
+    let value: any = 40;
+    eval(source);
+    return value;
+  }
+`, { directEval: "reified-host" });
+const worker = new Worker(new URL("./eval-worker.js", import.meta.url));
+const evaluator = await connectNodeEvalWorker(worker, { timeoutMs: 1_000 });
+const imports = buildImports(result.imports, undefined, result.stringPool, {
+  dynamicCode: "evaluator",
+  dynamicCodeEvaluator: evaluator,
+});
+const { instance } = await WebAssembly.instantiate(result.binary, imports);
+imports.setInstance?.(instance);
+
+console.log((instance.exports.run as Function)("value += 2")); // 42
+await evaluator.terminate();
+```
+
+A deadline terminates the eval Worker, so infinite dynamic code cannot consume a
+thread indefinitely. The calling Node thread is synchronously blocked until the
+request completes or reaches that deadline; this preserves the Wasm import ABI.
+
+## Browser iframe realm
+
+A same-origin iframe provides a synchronous second realm without moving the AOT
+module:
+
+```ts
+import { createRealmDynamicCodeEvaluator } from "@loopdive/js2/runtime/evaluator";
+
+const evaluator = createRealmDynamicCodeEvaluator(iframe.contentWindow!);
+```
+
+Functions and objects can cross this boundary as ordinary cross-realm
+references. The iframe has separate globals and intrinsic prototypes, but it is
+not a security boundary: same-origin code can still reach `parent`, the DOM,
+storage, and origin capabilities, and an infinite loop blocks the page thread.
+
+An opaque-origin sandboxed iframe or browser Worker provides a stronger
+boundary, but communication is asynchronous. Supporting either while the Wasm
+module stays on the window thread requires suspending/resuming the Wasm call
+(for example through a future stack-switching/async transform); the window
+agent cannot use `Atomics.wait` to turn Worker messaging into a synchronous
+import.
+
+## Direct eval environments
+
+The standalone interpreter already establishes the reusable direct-eval ABI:
+the compiler materializes eval-visible bindings as mutable cells in activation,
+lexical, and outer layers. Opt in to the JS-host route at compile time:
+
+```ts
+const result = await compile(source, { directEval: "reified-host" });
+```
+
+The AOT module and its WasmGC cells remain in the main host. The main-realm
+import registers each cell under an opaque binding id; the Node evaluator's
+scope proxy performs synchronous get/set callbacks through those ids. An
+eval-created escaping closure therefore observes later AOT writes, and its own
+writes immediately update the canonical AOT cell—even when eval subsequently
+throws. Activation, lexical, and captured-outer layers retain their compiler
+shadowing order.
+
+This first direct-eval slice covers existing binding reads/writes and live
+escaping closures. Full EvalDeclarationInstantiation remains follow-up work:
+eval-created sloppy `var`/function persistence, caller `const`/TDZ attributes,
+delete semantics, mapped arguments, and private names need the declaration
+metadata/state-pool part of the standalone ABI. Arbitrary main-owned objects
+also need the reverse membrane described below. Unsupported crossings fail
+loudly instead of copying object identity.
+
+## Boundary and security model
+
+- A Node Worker is a separate realm, heap, and thread, but not an OS or
+  capability sandbox. It still has Node capabilities unless the host restricts
+  them.
+- Values created by Node Worker eval remain in its handle table. Primitive
+  arguments and Worker-owned proxies cross synchronously; arbitrary AOT-host
+  objects need the planned reverse membrane before they can be passed in.
+- Browser native eval requires Content Security Policy to allow
+  `'unsafe-eval'` in the evaluator realm.
+- Errors are reconstructed in the AOT host realm so compiled `try`/`catch` and
+  constructor checks observe the expected standard error family.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
       "types": "./dist/runtime.d.ts",
       "import": "./dist/runtime.js"
     },
+    "./runtime/evaluator": {
+      "types": "./dist/runtime-isolated-evaluator.d.ts",
+      "import": "./dist/runtime-isolated-evaluator.js"
+    },
+    "./runtime/node-eval-worker": {
+      "types": "./dist/runtime-node-eval-worker.d.ts",
+      "import": "./dist/runtime-node-eval-worker.js"
+    },
     "./optimize": {
       "types": "./dist/optimize.d.ts",
       "import": "./dist/optimize.js"

--- a/plan/issues/1006-support-eval-via-js-host.md
+++ b/plan/issues/1006-support-eval-via-js-host.md
@@ -3,7 +3,7 @@ id: 1006
 title: "Support eval via JS host import"
 status: done
 created: 2026-04-09
-updated: 2026-04-09
+updated: 2026-08-11
 completed: 2026-04-28
 priority: medium
 feasibility: medium
@@ -14,6 +14,18 @@ goal: spec-completeness
 sprint: 42
 required_by: [1073, 1584]
 es_edition: multi
+loc-budget-allow:
+  - src/runtime.ts
+  - src/compiler.ts
+  - src/codegen/context/types.ts
+  - src/codegen/expressions/calls.ts
+func-budget-allow:
+  - src/runtime.ts::resolveImport
+  - src/runtime.ts::buildImports
+  - src/codegen/expressions/calls.ts::compileCallExpression
+  - src/codegen/context/create-context.ts::createCodegenContext
+  - "src/runtime.ts::<anonymous>#89"
+  - src/codegen/expressions/runtime-eval-provider.ts::emitStandaloneDirectEvalRuntime
 ---
 # #1006 -- Support `eval` via JS host import
 
@@ -116,3 +128,17 @@ convert 107 harness-visibility regressions → pass.
 - `built-ins/eval/length-value.js`: PASS
 - `indirect/always-non-strict.js`: FAIL (harness scope gap — `count` not visible in eval'd code)
 - `built-ins/eval/name.js`: CE (type-checker false positive, not eval-related)
+
+## 2026-08-11 isolated-host follow-up
+
+The host lane now has an opt-in evaluator policy that can execute dynamic code
+outside the main process realm without moving the compiled AOT Wasm instance.
+The Node adapter uses a Worker only for `eval`/`Function`; live direct-eval
+bindings remain cells owned by the main Wasm instance and cross the boundary as
+opaque binding identifiers.
+
+The shipped slice covers live reads and writes, escaping eval-created closures,
+write-before-throw behavior, error reconstruction, timeouts, and a deny policy.
+Full `EvalDeclarationInstantiation` behavior and a browser Worker transport for
+synchronous Wasm imports remain follow-up work. A same-origin browser realm
+adapter is included for the synchronous browser case.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -327,6 +327,7 @@ export function createCodegenContext(
     nodeFsReadSyncIdx: -1,
     nodeFsWriteSyncIdx: -1,
     standalone: options?.standalone ?? false,
+    directEvalMode: options?.directEval ?? "legacy",
     // (#2141 S1) Honest generic any-boxing regime — default OFF (legacy tag-5
     // box-the-externref ABI, byte-identical modules). Flips in S4.
     honestAnyBoxing: options?.honestAnyBoxing ?? false,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -113,6 +113,8 @@ export interface CodegenOptions {
    *  `__unbox_string` JS-host string imports. Used so the compiled module is
    *  runnable under pure-Wasm engines (wasmtime, wasmer) without a JS host. */
   standalone?: boolean;
+  /** JS-host direct-eval lowering; see `CompileOptions.directEval`. */
+  directEval?: "legacy" | "reified-host";
   /**
    * (#4035) Host-bridge export policy — see `CompileOptions.hostBridge`.
    * `"auto"` (default) resolves to `"always"` for js-host and `"off"` for
@@ -3153,6 +3155,10 @@ export interface CodegenContext {
    *  `__unbox_string`, `__str_from_mem`, `__str_to_mem`,
    *  `__str_extern_len`). Implies `nativeStrings === true`. */
   standalone: boolean;
+  /** Resolved JS-host direct-eval lowering. */
+  directEvalMode: "legacy" | "reified-host";
+  /** Private externref-array carrier used only by reified JS-host direct eval. */
+  hostRuntimeEvalVecTypeIdx?: number;
   /** (#2141 S1) Honest generic `any` boxing regime flag — see the
    *  `CodegenOptions.honestAnyBoxing` doc. Default false (legacy tag-5
    *  box-the-externref ABI, byte-identical). */

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6326,9 +6326,11 @@ function compileCallExpression(
         evalKind === "direct"
           ? directEvalRunsAtScriptGlobal(expr, ctx)
             ? emitStandaloneIndirectEvalRuntime(ctx, fctx, expr.arguments)
-            : ensureRuntimeEvalCallableCarrier(ctx, fctx)
+            : ctx.directEvalMode === "reified-host"
               ? emitStandaloneDirectEvalRuntime(ctx, fctx, expr)
-              : undefined
+              : ensureRuntimeEvalCallableCarrier(ctx, fctx)
+                ? emitStandaloneDirectEvalRuntime(ctx, fctx, expr)
+                : undefined
           : emitStandaloneIndirectEvalRuntime(ctx, fctx, expr.arguments);
       if (runtimeEval !== undefined) return runtimeEval;
       // (#2960) WASI (until its linker grows the provider), or a standalone

--- a/src/codegen/expressions/runtime-eval-provider.ts
+++ b/src/codegen/expressions/runtime-eval-provider.ts
@@ -41,6 +41,11 @@ export const RUNTIME_EVAL_IMPORT_MODULE = "js2wasm:runtime-eval";
 const DIRECT_EVAL_STATE_BINDING_CAPACITY = 64;
 const RUNTIME_EVAL_PUSH_GLOBALS = "__runtime_eval_push_globals";
 const RUNTIME_EVAL_PULL_GLOBALS = "__runtime_eval_pull_globals";
+export const HOST_RUNTIME_EVAL_VEC_LEN = "__runtime_eval_vec_len";
+export const HOST_RUNTIME_EVAL_VEC_GET = "__runtime_eval_vec_get";
+export const HOST_RUNTIME_EVAL_CELL_GET = "__runtime_eval_cell_get";
+export const HOST_RUNTIME_EVAL_CELL_SET = "__runtime_eval_cell_set";
+export const HOST_RUNTIME_DIRECT_EVAL_IMPORT = "__extern_direct_eval";
 /** Private global-object slot carrying `[name, EvalBindingCell, ...]`. The
  * provider reads the structurally canonical cells into ENV_GLOBAL.names/slots;
  * the slot itself is deliberately non-enumerable and non-configurable. */
@@ -77,6 +82,97 @@ function directEvalCallerIsFunctionScoped(call: ts.CallExpression): boolean {
     node = node.parent;
   }
   return false;
+}
+
+/**
+ * Export the narrow main-realm bridge needed by an isolated JS-host evaluator.
+ *
+ * The Worker never receives these WasmGC references. `buildImports` invokes the
+ * four exports in the AOT module's host realm and exposes only opaque binding
+ * ids/value handles to the evaluator. Dedicated exports keep the bridge alive
+ * when the general host-inspection surface is disabled.
+ */
+function ensureReifiedHostEvalBridgeExports(ctx: CodegenContext, cellTypeIdx: number): void {
+  const vecTypeIdx = ensureReifiedHostEvalVecType(ctx);
+  const externref: ValType = { kind: "externref" };
+
+  const register = (
+    name: string,
+    params: ValType[],
+    results: ValType[],
+    body: Instr[],
+    locals: { name: string; type: ValType }[] = [],
+  ): void => {
+    if (ctx.funcMap.has(name)) return;
+    const typeIdx = addFuncType(ctx, params, results, `$${name}_type`);
+    const funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals, body, exported: true });
+    ctx.funcMap.set(name, funcIdx);
+    ctx.mod.exports.push({ name, desc: { kind: "func", index: funcIdx } });
+  };
+
+  register(
+    HOST_RUNTIME_EVAL_VEC_LEN,
+    [externref],
+    [{ kind: "i32" }],
+    [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: vecTypeIdx },
+      { op: "array.len" },
+    ],
+  );
+  register(
+    HOST_RUNTIME_EVAL_VEC_GET,
+    [externref, { kind: "i32" }],
+    [externref],
+    [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: vecTypeIdx },
+      { op: "local.get", index: 1 },
+      { op: "array.get", typeIdx: vecTypeIdx },
+    ],
+  );
+  register(
+    HOST_RUNTIME_EVAL_CELL_GET,
+    [externref],
+    [externref],
+    [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: cellTypeIdx },
+      { op: "struct.get", typeIdx: cellTypeIdx, fieldIdx: 0 },
+    ],
+  );
+  register(
+    HOST_RUNTIME_EVAL_CELL_SET,
+    [externref, externref],
+    [],
+    [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: cellTypeIdx },
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 2 },
+      { op: "local.get", index: 1 },
+      { op: "struct.set", typeIdx: cellTypeIdx, fieldIdx: 0 },
+    ],
+    [{ name: "__cell", type: { kind: "ref", typeIdx: cellTypeIdx } }],
+  );
+}
+
+function ensureReifiedHostEvalVecType(ctx: CodegenContext): number {
+  if (ctx.hostRuntimeEvalVecTypeIdx !== undefined) return ctx.hostRuntimeEvalVecTypeIdx;
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "array",
+    name: "$HostRuntimeEvalVec",
+    element: { kind: "externref" },
+    mutable: false,
+  });
+  ctx.hostRuntimeEvalVecTypeIdx = typeIdx;
+  return typeIdx;
 }
 const RUNTIME_EVAL_GLOBAL_LEXICAL_CELL_GLOBAL_PREFIX = "\0runtime-eval-global-lexical-cell:";
 const RUNTIME_EVAL_INTRINSIC_GLOBALS = [
@@ -525,18 +621,19 @@ function directEvalCellWrapInstrs(
 }
 
 /**
- * Standalone direct eval route. The caller supplies three name/cell vector
+ * Direct eval route. The caller supplies three name/cell vector
  * pairs: a persistent current-activation environment, fresh call-site lexical
- * shadows, and captured outer bindings. The provider links those records in
- * that order, so eval-created sloppy vars persist without overwriting an outer
- * capture and interpreter stores still update canonical AOT cells directly.
+ * shadows, and captured outer bindings. Standalone links those records into
+ * its runtime provider. The opt-in JS-host lane sends the same canonical cells
+ * to a main-realm bridge; an isolated evaluator sees only opaque binding ids.
  */
 export function emitStandaloneDirectEvalRuntime(
   ctx: CodegenContext,
   fctx: FunctionContext,
   call: ts.CallExpression,
 ): ValType | undefined {
-  if (!ctx.standalone) return undefined;
+  const reifiedHost = !ctx.standalone && ctx.directEvalMode === "reified-host";
+  if (!ctx.standalone && !reifiedHost) return undefined;
   const args = call.arguments;
   if (args.length === 0) {
     emitUndefined(ctx, fctx);
@@ -545,7 +642,7 @@ export function emitStandaloneDirectEvalRuntime(
 
   const callerStrict = isStrictContext(call, ctx.inferModuleStrictArguments);
   const externref: ValType = { kind: "externref" };
-  if (!callerStrict) {
+  if (!callerStrict && !reifiedHost) {
     ensureLateImport(ctx, "__extern_is_undefined", [externref], [{ kind: "i32" }]);
     flushLateImportShifts(ctx, fctx);
   }
@@ -554,13 +651,14 @@ export function emitStandaloneDirectEvalRuntime(
   // Register the builders before emitting argument expressions: doing so can
   // mint functions, and keeping that mutation ahead of the call operands makes
   // late-index repair straightforward.
-  ensureObjVecBuilders(ctx);
+  const hostVecTypeIdx = reifiedHost ? ensureReifiedHostEvalVecType(ctx) : undefined;
+  if (!reifiedHost) ensureObjVecBuilders(ctx);
   const bindings = currentDirectEvalBindings(ctx, fctx);
   for (const layer of [bindings.activation, bindings.lexical, bindings.outer]) {
     for (const binding of layer) addStringConstantGlobal(ctx, binding.name);
   }
   const functionScopedCaller = directEvalCallerIsFunctionScoped(call);
-  if (functionScopedCaller) addStringConstantGlobal(ctx, RUNTIME_EVAL_NON_GLOBAL_SENTINEL);
+  if (functionScopedCaller && !reifiedHost) addStringConstantGlobal(ctx, RUNTIME_EVAL_NON_GLOBAL_SENTINEL);
 
   const sourceLocal = allocLocal(fctx, `__runtime_direct_eval_source_${fctx.locals.length}`, externref);
   const sourceType = compileExpression(ctx, fctx, args[0]!);
@@ -580,12 +678,12 @@ export function emitStandaloneDirectEvalRuntime(
   const objVecNewIdx = ctx.funcMap.get("__objvec_new")!;
   const objVecPushIdx = ctx.funcMap.get("__objvec_push")!;
 
-  const wrapCallableIdx = ensureRuntimeEvalCallableWrapHelper(ctx);
+  const wrapCallableIdx = reifiedHost ? undefined : ensureRuntimeEvalCallableWrapHelper(ctx);
   const bindingPushInstrs = (namesLocal: number, slotsLocal: number, layer: typeof bindings.activation): Instr[] => {
     const instrs: Instr[] = [];
     const cellTypeIdx = fctx.directEvalRefCellTypeIdx;
     for (const binding of layer) {
-      if (cellTypeIdx !== undefined) {
+      if (cellTypeIdx !== undefined && wrapCallableIdx !== undefined) {
         instrs.push(...directEvalCellWrapInstrs(ctx, binding.cellLocal, cellTypeIdx, wrapCallableIdx));
       }
       instrs.push(
@@ -604,6 +702,23 @@ export function emitStandaloneDirectEvalRuntime(
   const freshLayer = (label: string, layer: typeof bindings.activation): [number, number] => {
     const namesLocal = allocLocal(fctx, `__runtime_direct_eval_${label}_names_${fctx.locals.length}`, externref);
     const slotsLocal = allocLocal(fctx, `__runtime_direct_eval_${label}_slots_${fctx.locals.length}`, externref);
+    if (hostVecTypeIdx !== undefined) {
+      for (const binding of layer) fctx.body.push(...stringConstantExternrefInstrs(ctx, binding.name));
+      fctx.body.push(
+        { op: "array.new_fixed", typeIdx: hostVecTypeIdx, length: layer.length },
+        { op: "extern.convert_any" },
+        { op: "local.set", index: namesLocal },
+      );
+      for (const binding of layer) {
+        fctx.body.push({ op: "local.get", index: binding.cellLocal }, { op: "extern.convert_any" });
+      }
+      fctx.body.push(
+        { op: "array.new_fixed", typeIdx: hostVecTypeIdx, length: layer.length },
+        { op: "extern.convert_any" },
+        { op: "local.set", index: slotsLocal },
+      );
+      return [namesLocal, slotsLocal];
+    }
     fctx.body.push(
       { op: "call", funcIdx: objVecNewIdx },
       { op: "local.set", index: namesLocal },
@@ -615,54 +730,61 @@ export function emitStandaloneDirectEvalRuntime(
   };
   const stateCellTypeIdx = fctx.directEvalRefCellTypeIdx ?? getOrRegisterRefCellType(ctx, externref);
   fctx.directEvalRefCellTypeIdx = stateCellTypeIdx;
-  if (fctx.directEvalActivationStateCellLocals === undefined) {
-    fctx.directEvalActivationStateCellLocals = [];
-    for (let i = 0; i < DIRECT_EVAL_STATE_BINDING_CAPACITY * 2; i += 1) {
-      fctx.directEvalActivationStateCellLocals.push(
-        allocLocal(fctx, `__runtime_direct_eval_state_cell_${i}_${fctx.locals.length}`, {
-          kind: "ref_null",
-          typeIdx: stateCellTypeIdx,
-        }),
-      );
-    }
-  }
-  const activationStateCellLocals = fctx.directEvalActivationStateCellLocals;
-  for (const cellLocal of activationStateCellLocals) {
-    fctx.body.push(
-      { op: "local.get", index: cellLocal },
-      { op: "ref.is_null" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [
-          { op: "ref.null.extern" },
-          { op: "struct.new", typeIdx: stateCellTypeIdx },
-          { op: "local.set", index: cellLocal },
-        ],
-      },
-    );
-  }
   const activationStatePoolLocal = allocLocal(
     fctx,
     `__runtime_direct_eval_activation_state_pool_${fctx.locals.length}`,
     externref,
   );
-  fctx.body.push({ op: "call", funcIdx: objVecNewIdx }, { op: "local.set", index: activationStatePoolLocal });
-  for (const cellLocal of activationStateCellLocals) {
-    fctx.body.push(
-      { op: "local.get", index: activationStatePoolLocal },
-      { op: "local.get", index: cellLocal },
-      { op: "ref.as_non_null" },
-      { op: "extern.convert_any" },
-      { op: "call", funcIdx: objVecPushIdx },
-    );
+  if (reifiedHost) {
+    // Eval-created declaration persistence is a provider-owned concern. The
+    // first host slice bridges existing canonical caller cells only, so avoid
+    // allocating standalone's 128 spare state cells in every AOT activation.
+    fctx.body.push({ op: "ref.null.extern" }, { op: "local.set", index: activationStatePoolLocal });
+  } else {
+    if (fctx.directEvalActivationStateCellLocals === undefined) {
+      fctx.directEvalActivationStateCellLocals = [];
+      for (let i = 0; i < DIRECT_EVAL_STATE_BINDING_CAPACITY * 2; i += 1) {
+        fctx.directEvalActivationStateCellLocals.push(
+          allocLocal(fctx, `__runtime_direct_eval_state_cell_${i}_${fctx.locals.length}`, {
+            kind: "ref_null",
+            typeIdx: stateCellTypeIdx,
+          }),
+        );
+      }
+    }
+    const activationStateCellLocals = fctx.directEvalActivationStateCellLocals;
+    for (const cellLocal of activationStateCellLocals) {
+      fctx.body.push(
+        { op: "local.get", index: cellLocal },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "ref.null.extern" },
+            { op: "struct.new", typeIdx: stateCellTypeIdx },
+            { op: "local.set", index: cellLocal },
+          ],
+        },
+      );
+    }
+    fctx.body.push({ op: "call", funcIdx: objVecNewIdx }, { op: "local.set", index: activationStatePoolLocal });
+    for (const cellLocal of activationStateCellLocals) {
+      fctx.body.push(
+        { op: "local.get", index: activationStatePoolLocal },
+        { op: "local.get", index: cellLocal },
+        { op: "ref.as_non_null" },
+        { op: "extern.convert_any" },
+        { op: "call", funcIdx: objVecPushIdx },
+      );
+    }
   }
   const [activationNamesLocal, activationSlotsLocal] = freshLayer("activation_seed", bindings.activation);
   // (#4308 slice C) The caller-kind sentinel. Its cell is FRESH rather than
   // borrowed from the state pool: nothing writes the sentinel binding, but a
   // shared cell would make that assumption load-bearing for the pool's own
   // name/value pairs.
-  if (functionScopedCaller) {
+  if (functionScopedCaller && !reifiedHost) {
     fctx.body.push(
       { op: "local.get", index: activationNamesLocal },
       ...stringConstantExternrefInstrs(ctx, RUNTIME_EVAL_NON_GLOBAL_SENTINEL),
@@ -689,7 +811,9 @@ export function emitStandaloneDirectEvalRuntime(
     externref,
   );
   const mappedArgsInfo = fctx.mappedArgsInfo;
-  if (mappedArgsInfo) {
+  if (reifiedHost) {
+    fctx.body.push({ op: "ref.null.extern" }, { op: "local.set", index: mappedParamNamesLocal });
+  } else if (mappedArgsInfo) {
     if (mappedArgsInfo.runtimeMappedNamesLocalIdx === undefined) {
       mappedArgsInfo.runtimeMappedNamesLocalIdx = allocLocal(
         fctx,
@@ -746,32 +870,43 @@ export function emitStandaloneDirectEvalRuntime(
   }
 
   fctx.body.push({ op: "local.get", index: sourceLocal });
-  if (emitGlobalEnvironmentObject(ctx, fctx) === null) fctx.body.push({ op: "ref.null.extern" });
-  const globalLocal = allocLocal(fctx, `__runtime_direct_eval_global_${fctx.locals.length}`, externref);
-  fctx.body.push({ op: "local.tee", index: globalLocal });
-  const thisType = compileExpression(ctx, fctx, ts.factory.createThis());
-  if (thisType === null) {
-    emitUndefined(ctx, fctx);
-  } else if (thisType.kind !== "externref") {
-    coerceType(ctx, fctx, thisType, externref);
-  }
-  if (!callerStrict) {
-    const thisLocal = allocLocal(fctx, `__runtime_direct_eval_this_${fctx.locals.length}`, externref);
-    const liveIsUndefinedIdx = ctx.funcMap.get("__extern_is_undefined");
-    fctx.body.push({ op: "local.set", index: thisLocal }, { op: "local.get", index: thisLocal }, { op: "ref.is_null" });
-    if (liveIsUndefinedIdx !== undefined) {
-      fctx.body.push(
-        { op: "local.get", index: thisLocal },
-        { op: "call", funcIdx: liveIsUndefinedIdx },
-        { op: "i32.or" },
-      );
+  if (reifiedHost) {
+    // The isolated evaluator owns its global object, and host values need a
+    // separate reverse membrane. Keep both ABI positions explicit without
+    // constructing standalone's native global-object/callable substrate.
+    fctx.body.push({ op: "ref.null.extern" }, { op: "ref.null.extern" });
+  } else {
+    if (emitGlobalEnvironmentObject(ctx, fctx) === null) fctx.body.push({ op: "ref.null.extern" });
+    const globalLocal = allocLocal(fctx, `__runtime_direct_eval_global_${fctx.locals.length}`, externref);
+    fctx.body.push({ op: "local.tee", index: globalLocal });
+    const thisType = compileExpression(ctx, fctx, ts.factory.createThis());
+    if (thisType === null) {
+      emitUndefined(ctx, fctx);
+    } else if (thisType.kind !== "externref") {
+      coerceType(ctx, fctx, thisType, externref);
     }
-    fctx.body.push({
-      op: "if",
-      blockType: { kind: "val", type: externref },
-      then: [{ op: "local.get", index: globalLocal }],
-      else: [{ op: "local.get", index: thisLocal }],
-    });
+    if (!callerStrict) {
+      const thisLocal = allocLocal(fctx, `__runtime_direct_eval_this_${fctx.locals.length}`, externref);
+      const liveIsUndefinedIdx = ctx.funcMap.get("__extern_is_undefined");
+      fctx.body.push(
+        { op: "local.set", index: thisLocal },
+        { op: "local.get", index: thisLocal },
+        { op: "ref.is_null" },
+      );
+      if (liveIsUndefinedIdx !== undefined) {
+        fctx.body.push(
+          { op: "local.get", index: thisLocal },
+          { op: "call", funcIdx: liveIsUndefinedIdx },
+          { op: "i32.or" },
+        );
+      }
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: externref },
+        then: [{ op: "local.get", index: globalLocal }],
+        else: [{ op: "local.get", index: thisLocal }],
+      });
+    }
   }
   fctx.body.push(
     { op: "local.get", index: activationStatePoolLocal },
@@ -785,9 +920,11 @@ export function emitStandaloneDirectEvalRuntime(
     { op: "local.get", index: mappedParamNamesLocal },
   );
 
+  if (reifiedHost) ensureReifiedHostEvalBridgeExports(ctx, stateCellTypeIdx);
+  const importName = reifiedHost ? HOST_RUNTIME_DIRECT_EVAL_IMPORT : "__runtime_direct_eval";
   const evalIdx = ensureLateImport(
     ctx,
-    "__runtime_direct_eval",
+    importName,
     [
       externref,
       externref,
@@ -803,7 +940,7 @@ export function emitStandaloneDirectEvalRuntime(
       externref,
     ],
     [externref],
-    RUNTIME_EVAL_IMPORT_MODULE,
+    reifiedHost ? "env" : RUNTIME_EVAL_IMPORT_MODULE,
   );
   flushLateImportShifts(ctx, fctx);
   if (evalIdx === undefined) {
@@ -822,11 +959,12 @@ export function emitStandaloneDirectEvalRuntime(
       { op: "drop" },
       { op: "ref.null.extern" },
     );
-    emitRuntimeEvalProviderActive(ctx, fctx, false);
+    if (!reifiedHost) emitRuntimeEvalProviderActive(ctx, fctx, false);
     return externref;
   }
-  const liveIdx = ctx.funcMap.get("__runtime_direct_eval") ?? evalIdx;
+  const liveIdx = ctx.funcMap.get(importName) ?? evalIdx;
   fctx.body.push({ op: "call", funcIdx: liveIdx });
+  if (reifiedHost) return externref;
   return emitRuntimeEvalResultUnwrap(ctx, fctx);
 }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -718,6 +718,12 @@ function buildCodegenOptions(
         `default gc-host lane (vacuous ${key} coverage). Use { target: "${key}" }. (#86)`,
     );
   }
+  if (options.directEval === "reified-host" && options.target !== undefined && options.target !== "gc") {
+    throw new Error(
+      `Compile option directEval: "reified-host" requires the WasmGC JavaScript-host target; ` +
+        `target: "${options.target}" does not use that cell bridge.`,
+    );
+  }
   return {
     sourceMap: emitSourceMap,
     fast: options.fast,
@@ -731,6 +737,7 @@ function buildCodegenOptions(
     // boolean was removed.
     link: [...new Set(options.link ?? [])],
     standalone: options.target === "standalone",
+    directEval: options.directEval,
     // (#2141 S1) honest any-boxing regime flag (default off = legacy tag-5 ABI).
     honestAnyBoxing: options.honestAnyBoxing,
     unionAnyRep: options.unionAnyRep,

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,6 +318,21 @@ export interface CompileOptions {
    *  `env` JS-host string imports. */
   target?: "gc" | "linear" | "wasi" | "standalone";
   /**
+   * Dynamic direct-eval lowering for the WasmGC JavaScript-host target.
+   *
+   * `"legacy"` (default) preserves the historical `(source, isDirect)` host
+   * import, which cannot observe Wasm locals. `"reified-host"` promotes the
+   * caller-visible bindings into the same canonical mutable cells used by the
+   * standalone runtime-eval provider and passes those cells to the host through
+   * `env::__extern_direct_eval`. The AOT module remains in its original host;
+   * an isolated evaluator receives only opaque binding/value handles.
+   *
+   * This option is invalid for linear/WASI/standalone targets. The no-JS-host
+   * lanes own their runtime-eval routing, while the linear backend does not use
+   * the WasmGC cell carrier.
+   */
+  directEval?: "legacy" | "reified-host";
+  /**
    * (#743) Declaration source text for the entry module's shipped sibling
    * `.d.ts` (e.g. acorn's `dist/acorn.d.ts` when compiling `dist/acorn.mjs`).
    * Only consulted while `JS2WASM_DTS_ENTRYPOINT_SEEDS` is enabled (**ON by

--- a/src/runtime-isolated-evaluator.ts
+++ b/src/runtime-isolated-evaluator.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Synchronous JS-realm evaluators that keep the AOT Wasm instance in place. */
+
+import type { DynamicCodeBinding, DynamicCodeEvaluationContext, DynamicCodeEvaluator } from "./runtime.js";
+
+/** Minimal same-origin realm surface exposed by an iframe's `contentWindow`. */
+export interface JavaScriptEvalRealm {
+  eval(source: string): unknown;
+  Function: FunctionConstructor;
+}
+
+const SCOPE_PARAM = "__js2wasm_eval_scope__";
+const SOURCE_PARAM = "__js2wasm_eval_source__";
+
+function createBindingScope(
+  realm: JavaScriptEvalRealm,
+  bindings: readonly DynamicCodeBinding[],
+): Record<PropertyKey, unknown> {
+  const byName = new Map<string, DynamicCodeBinding>();
+  for (const binding of bindings) byName.set(binding.name, binding);
+  const globalObject = realm as unknown as Record<PropertyKey, unknown>;
+  return new Proxy(Object.create(null) as Record<PropertyKey, unknown>, {
+    has(_target, key) {
+      if (key === "eval" || key === SCOPE_PARAM || key === SOURCE_PARAM) return false;
+      return typeof key === "string" && (byName.has(key) || Reflect.has(globalObject, key));
+    },
+    get(_target, key) {
+      if (key === Symbol.unscopables) return undefined;
+      const binding = typeof key === "string" ? byName.get(key) : undefined;
+      return binding ? binding.get() : Reflect.get(globalObject, key);
+    },
+    set(_target, key, value) {
+      const binding = typeof key === "string" ? byName.get(key) : undefined;
+      if (binding) binding.set(value);
+      else Reflect.set(globalObject, key, value);
+      return true;
+    },
+    deleteProperty(_target, key) {
+      if (typeof key === "string" && byName.has(key)) return false;
+      return Reflect.deleteProperty(globalObject, key);
+    },
+  });
+}
+
+/**
+ * Use another same-origin JavaScript realm for eval and Function construction.
+ *
+ * The compiled Wasm module remains in its current host. Values cross the realm
+ * boundary as ordinary JavaScript references, so this stays synchronous and
+ * supports functions and objects without structured cloning.
+ *
+ * This is realm/heap separation, not a security boundary: same-origin iframe
+ * code can still reach its parent and origin capabilities. An opaque sandboxed
+ * iframe requires asynchronous messaging and cannot satisfy a synchronous Wasm
+ * import without a suspension transform.
+ */
+export function createRealmDynamicCodeEvaluator(realm: JavaScriptEvalRealm): DynamicCodeEvaluator {
+  const realmEval = realm.eval;
+  const RealmFunction = realm.Function;
+  if (typeof realmEval !== "function" || typeof RealmFunction !== "function") {
+    throw new TypeError("dynamic-code realm must expose eval and Function");
+  }
+  const scopedEval = Reflect.construct(RealmFunction, [
+    SCOPE_PARAM,
+    SOURCE_PARAM,
+    `with (${SCOPE_PARAM}) { return eval(${SOURCE_PARAM}); }`,
+  ]) as (scope: Record<PropertyKey, unknown>, source: string) => unknown;
+
+  return {
+    evaluate(source: string, context: DynamicCodeEvaluationContext): unknown {
+      if (context.direct && context.bindings !== undefined) {
+        const scope = createBindingScope(realm, context.bindings);
+        const directSource = context.strict ? `"use strict";\n${source}` : source;
+        return Reflect.apply(scopedEval, undefined, [scope, directSource]);
+      }
+      return Reflect.apply(realmEval, realm, [source]);
+    },
+    createFunction(parameters: string, body: string): Function {
+      return Reflect.construct(RealmFunction, [parameters, body]) as Function;
+    },
+  };
+}

--- a/src/runtime-node-eval-worker.ts
+++ b/src/runtime-node-eval-worker.ts
@@ -1,0 +1,531 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Synchronous eval-only Node Worker transport; the AOT Wasm stays in its host. */
+
+import { MessageChannel, type MessagePort, type Worker, receiveMessageOnPort } from "node:worker_threads";
+import type { DynamicCodeBinding, DynamicCodeEvaluationContext, DynamicCodeEvaluator } from "./runtime.js";
+
+const PROTOCOL = "js2wasm:node-eval-worker:v1";
+const REMOTE_VALUE = Symbol("js2wasm.remote-eval-value");
+const SCOPE_PARAM = "__js2wasm_eval_scope__";
+const SOURCE_PARAM = "__js2wasm_eval_source__";
+
+type Primitive = undefined | null | boolean | number | string | bigint;
+type WireSymbol = { wire: "symbol"; key: string; global: boolean };
+type WireHandle = { wire: "handle"; id: number; callable: boolean };
+type WireValue = Primitive | WireSymbol | WireHandle;
+type WireBinding = { id: number; name: string };
+
+type SerializedError = { name: string; message: string; stack?: string };
+type Request =
+  | {
+      id: number;
+      op: "eval";
+      source: string;
+      direct: boolean;
+      strict: boolean;
+      bindings?: WireBinding[];
+    }
+  | { id: number; op: "function"; parameters: string; body: string }
+  | { id: number; op: "get"; handle: number; key: WireValue }
+  | { id: number; op: "set"; handle: number; key: WireValue; value: WireValue }
+  | {
+      id: number;
+      op: "apply";
+      handle: number;
+      thisArg: WireValue;
+      args: WireValue[];
+    }
+  | { id: number; op: "construct"; handle: number; args: WireValue[] }
+  | { id: number; op: "has"; handle: number; key: WireValue }
+  | { id: number; op: "delete"; handle: number; key: WireValue };
+type Response =
+  | { channel: "worker"; id: number; ok: true; value: WireValue }
+  | { channel: "worker"; id: number; ok: false; error: SerializedError };
+type HostRequest =
+  | { channel: "host"; id: number; op: "binding-get"; binding: number }
+  | {
+      channel: "host";
+      id: number;
+      op: "binding-set";
+      binding: number;
+      value: WireValue;
+    };
+type HostRequestBody =
+  | { op: "binding-get"; binding: number }
+  | { op: "binding-set"; binding: number; value: WireValue };
+type HostResponse =
+  | { channel: "host-response"; id: number; ok: true; value: WireValue }
+  | { channel: "host-response"; id: number; ok: false; error: SerializedError };
+
+type ConnectMessage = {
+  protocol: typeof PROTOCOL;
+  type: "connect";
+  port: MessagePort;
+  signal: SharedArrayBuffer;
+  hostSignal: SharedArrayBuffer;
+};
+
+export interface NodeEvalWorkerOptions {
+  /** Synchronous request deadline. A timeout terminates the Worker. Default: 30 seconds. */
+  timeoutMs?: number;
+  /** Worker connection deadline. Default: 30 seconds. */
+  initializationTimeoutMs?: number;
+}
+
+export interface NodeEvalWorkerEvaluator extends DynamicCodeEvaluator {
+  terminate(): Promise<void>;
+}
+
+function serializeError(value: unknown): SerializedError {
+  if (value instanceof Error) {
+    return {
+      name: value.name || "Error",
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+  return {
+    name: "Error",
+    message: typeof value === "string" ? value : String(value),
+  };
+}
+
+function restoreError(record: SerializedError): Error {
+  const constructors: Record<string, new (message?: string) => Error> = {
+    Error,
+    EvalError,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+    URIError,
+  };
+  const Ctor = constructors[record.name] ?? Error;
+  const error = new Ctor(record.message);
+  error.name = record.name;
+  if (record.stack) error.stack = record.stack;
+  return error;
+}
+
+function encodeSymbol(value: symbol): WireSymbol {
+  const globalKey = Symbol.keyFor(value);
+  if (globalKey !== undefined) return { wire: "symbol", key: globalKey, global: true };
+  for (const key of Object.getOwnPropertyNames(Symbol) as Array<keyof SymbolConstructor>) {
+    if (typeof Symbol[key] === "symbol" && Symbol[key] === value) {
+      return { wire: "symbol", key: String(key), global: false };
+    }
+  }
+  throw new TypeError("non-global symbols cannot cross the eval Worker boundary");
+}
+
+function decodeSymbol(value: WireSymbol): symbol {
+  if (value.global) return Symbol.for(value.key);
+  const candidate = Symbol[value.key as keyof SymbolConstructor];
+  if (typeof candidate !== "symbol") throw new TypeError(`unknown well-known Symbol.${value.key}`);
+  return candidate;
+}
+
+function isWireHandle(value: WireValue): value is WireHandle {
+  return typeof value === "object" && value !== null && "wire" in value && value.wire === "handle";
+}
+
+function isWireSymbol(value: WireValue): value is WireSymbol {
+  return typeof value === "object" && value !== null && "wire" in value && value.wire === "symbol";
+}
+
+/**
+ * Connect an eval-only Node Worker and return a synchronous evaluator suitable
+ * for `buildImports(..., { dynamicCode: "evaluator" })`.
+ *
+ * Calls block the current Node thread with `Atomics.wait` because Wasm imports
+ * are synchronous. The Worker can be hard-terminated at the deadline. Remote
+ * functions and objects stay in the Worker and are represented by synchronous
+ * proxies in the AOT module's host realm.
+ */
+export async function connectNodeEvalWorker(
+  worker: Worker,
+  options: NodeEvalWorkerOptions = {},
+): Promise<NodeEvalWorkerEvaluator> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const initializationTimeoutMs = options.initializationTimeoutMs ?? 30_000;
+  const { port1, port2 } = new MessageChannel();
+  const signalBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+  const signal = new Int32Array(signalBuffer);
+  const hostSignalBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+  const hostSignal = new Int32Array(hostSignalBuffer);
+  const connect: ConnectMessage = {
+    protocol: PROTOCOL,
+    type: "connect",
+    port: port2,
+    signal: signalBuffer,
+    hostSignal: hostSignalBuffer,
+  };
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      port1.off("message", onReady);
+      worker.off("error", onError);
+      port1.close();
+      void worker.terminate();
+      const error = new Error(`eval Worker initialization timed out after ${initializationTimeoutMs}ms`);
+      error.name = "TimeoutError";
+      reject(error);
+    }, initializationTimeoutMs);
+    const onReady = (message: unknown): void => {
+      if ((message as { protocol?: string; type?: string })?.protocol !== PROTOCOL) return;
+      if ((message as { type?: string }).type !== "ready") return;
+      port1.off("message", onReady);
+      worker.off("error", onError);
+      clearTimeout(timer);
+      resolve();
+    };
+    const onError = (error: Error): void => {
+      port1.off("message", onReady);
+      clearTimeout(timer);
+      reject(error);
+    };
+    port1.on("message", onReady);
+    worker.once("error", onError);
+    worker.postMessage(connect, [port2]);
+  });
+
+  let nextId = 1;
+  let closedError: Error | undefined;
+  const proxyByHandle = new Map<number, object>();
+  const handleByProxy = new WeakMap<object, WireHandle>();
+  const bindingById = new Map<number, DynamicCodeBinding>();
+  const idByBinding = new WeakMap<DynamicCodeBinding, number>();
+  let nextBindingId = 1;
+
+  const closeWith = (error: Error): void => {
+    if (closedError) return;
+    closedError = error;
+    port1.close();
+    void worker.terminate();
+  };
+  worker.on("error", (error) => closeWith(error));
+  worker.on("exit", (code) => {
+    if (!closedError) closeWith(new Error(`eval Worker exited with code ${code}`));
+  });
+
+  const encode = (value: unknown): WireValue => {
+    if (typeof value === "symbol") return encodeSymbol(value);
+    if ((typeof value === "object" && value !== null) || typeof value === "function") {
+      const handle = handleByProxy.get(value as object);
+      if (handle) return handle;
+      throw new TypeError(
+        "objects from the AOT host cannot cross into the eval Worker yet; pass primitives or Worker-owned proxies",
+      );
+    }
+    return value as Primitive;
+  };
+
+  const decode = (value: WireValue): unknown => {
+    if (isWireSymbol(value)) return decodeSymbol(value);
+    if (!isWireHandle(value)) return value;
+    const existing = proxyByHandle.get(value.id);
+    if (existing) return existing;
+    const target = value.callable ? function remoteEvalFunction(): void {} : Object.create(null);
+    const proxy = new Proxy(target, {
+      get(_target, key) {
+        if (key === REMOTE_VALUE) return value;
+        return request({
+          op: "get",
+          handle: value.id,
+          key: encode(key),
+        } as Omit<Request, "id">);
+      },
+      set(_target, key, nextValue) {
+        return request({
+          op: "set",
+          handle: value.id,
+          key: encode(key),
+          value: encode(nextValue),
+        } as Omit<Request, "id">) as boolean;
+      },
+      has(_target, key) {
+        return request({
+          op: "has",
+          handle: value.id,
+          key: encode(key),
+        } as Omit<Request, "id">) as boolean;
+      },
+      deleteProperty(_target, key) {
+        return request({
+          op: "delete",
+          handle: value.id,
+          key: encode(key),
+        } as Omit<Request, "id">) as boolean;
+      },
+      apply(_target, thisArg, args) {
+        return request({
+          op: "apply",
+          handle: value.id,
+          thisArg: encode(thisArg),
+          args: args.map(encode),
+        } as Omit<Request, "id">);
+      },
+      construct(_target, args) {
+        return request({
+          op: "construct",
+          handle: value.id,
+          args: args.map(encode),
+        } as Omit<Request, "id">) as object;
+      },
+    });
+    proxyByHandle.set(value.id, proxy);
+    handleByProxy.set(proxy, value);
+    return proxy;
+  };
+
+  function request(body: Omit<Request, "id">): unknown {
+    if (closedError) throw closedError;
+    const id = nextId++;
+    const message = { ...body, id } as Request;
+    port1.postMessage(message);
+    const deadline = Date.now() + timeoutMs;
+    let observedSignal = Atomics.load(signal, 0);
+    let response: Response | undefined;
+
+    while (!response) {
+      for (let packet = receiveMessageOnPort(port1)?.message as Response | HostRequest | undefined; packet; ) {
+        if (packet.channel === "host") {
+          let hostResponse: HostResponse;
+          try {
+            const binding = bindingById.get(packet.binding);
+            if (!binding) throw new ReferenceError(`unknown AOT eval binding ${packet.binding}`);
+            let value: unknown;
+            if (packet.op === "binding-get") value = binding.get();
+            else binding.set(decode(packet.value));
+            hostResponse = {
+              channel: "host-response",
+              id: packet.id,
+              ok: true,
+              value: encode(value),
+            };
+          } catch (error) {
+            hostResponse = {
+              channel: "host-response",
+              id: packet.id,
+              ok: false,
+              error: serializeError(error),
+            };
+          }
+          port1.postMessage(hostResponse);
+          Atomics.add(hostSignal, 0, 1);
+          Atomics.notify(hostSignal, 0);
+        } else if (packet.channel === "worker" && packet.id === id) {
+          response = packet;
+        } else {
+          const error = new Error("eval Worker response protocol desynchronized");
+          closeWith(error);
+          throw error;
+        }
+        packet = receiveMessageOnPort(port1)?.message as Response | HostRequest | undefined;
+      }
+      if (response) break;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        const error = new Error(`eval Worker request timed out after ${timeoutMs}ms`);
+        error.name = "TimeoutError";
+        closeWith(error);
+        throw error;
+      }
+      Atomics.wait(signal, 0, observedSignal, Math.min(remaining, 50));
+      observedSignal = Atomics.load(signal, 0);
+    }
+    if (!response.ok) throw restoreError(response.error);
+    return decode(response.value);
+  }
+
+  return {
+    evaluate(source: string, context: DynamicCodeEvaluationContext) {
+      const bindings = context.bindings?.map((binding) => {
+        let id = idByBinding.get(binding);
+        if (id === undefined) {
+          id = nextBindingId++;
+          idByBinding.set(binding, id);
+          bindingById.set(id, binding);
+        }
+        return { id, name: binding.name };
+      });
+      return request({
+        op: "eval",
+        source,
+        direct: context.direct,
+        strict: context.strict === true,
+        bindings,
+      } as Omit<Request, "id">);
+    },
+    createFunction(parameters, body) {
+      return request({ op: "function", parameters, body } as Omit<Request, "id">) as Function;
+    },
+    async terminate() {
+      if (!closedError) {
+        closedError = new Error("eval Worker terminated");
+        port1.close();
+      }
+      await worker.terminate();
+    },
+  };
+}
+
+/** Start the eval-only server inside a Node Worker. */
+export function serveNodeEvalWorker(parent: Worker | MessagePort): void {
+  parent.on("message", (message: unknown) => {
+    const connect = message as Partial<ConnectMessage>;
+    if (
+      connect.protocol !== PROTOCOL ||
+      connect.type !== "connect" ||
+      !connect.port ||
+      !connect.signal ||
+      !connect.hostSignal
+    )
+      return;
+    const port = connect.port;
+    const signal = new Int32Array(connect.signal);
+    const hostSignal = new Int32Array(connect.hostSignal);
+    const handles = new Map<number, unknown>();
+    const ids = new WeakMap<object, number>();
+    let nextHandle = 1;
+    let nextHostRequestId = 1;
+
+    const encode = (value: unknown): WireValue => {
+      if (typeof value === "symbol") return encodeSymbol(value);
+      if ((typeof value === "object" && value !== null) || typeof value === "function") {
+        const object = value as object;
+        let id = ids.get(object);
+        if (id === undefined) {
+          id = nextHandle++;
+          ids.set(object, id);
+          handles.set(id, value);
+        }
+        return { wire: "handle", id, callable: typeof value === "function" };
+      }
+      return value as Primitive;
+    };
+    const decode = (value: WireValue): unknown => {
+      if (isWireSymbol(value)) return decodeSymbol(value);
+      if (isWireHandle(value)) {
+        if (!handles.has(value.id)) throw new ReferenceError(`unknown eval Worker handle ${value.id}`);
+        return handles.get(value.id);
+      }
+      return value;
+    };
+    const handle = (id: number): any => {
+      if (!handles.has(id)) throw new ReferenceError(`unknown eval Worker handle ${id}`);
+      return handles.get(id);
+    };
+
+    const hostRequest = (body: HostRequestBody): unknown => {
+      const id = nextHostRequestId++;
+      const observedSignal = Atomics.load(hostSignal, 0);
+      port.postMessage({ channel: "host", id, ...body } as HostRequest);
+      Atomics.add(signal, 0, 1);
+      Atomics.notify(signal, 0);
+      for (;;) {
+        const packet = receiveMessageOnPort(port)?.message as HostResponse | undefined;
+        if (packet) {
+          if (packet.channel !== "host-response" || packet.id !== id) {
+            throw new Error("eval host callback protocol desynchronized");
+          }
+          if (!packet.ok) throw restoreError(packet.error);
+          return decode(packet.value);
+        }
+        Atomics.wait(hostSignal, 0, observedSignal);
+      }
+    };
+
+    const createBindingScope = (bindings: readonly WireBinding[]): Record<PropertyKey, unknown> => {
+      const byName = new Map<string, number>();
+      for (const binding of bindings) byName.set(binding.name, binding.id);
+      return new Proxy(Object.create(null) as Record<PropertyKey, unknown>, {
+        has(_target, key) {
+          if (key === "eval" || key === SCOPE_PARAM || key === SOURCE_PARAM) return false;
+          return typeof key === "string" && (byName.has(key) || Reflect.has(globalThis, key));
+        },
+        get(_target, key) {
+          if (key === Symbol.unscopables) return undefined;
+          const binding = typeof key === "string" ? byName.get(key) : undefined;
+          return binding === undefined
+            ? Reflect.get(globalThis as Record<PropertyKey, unknown>, key)
+            : hostRequest({ op: "binding-get", binding });
+        },
+        set(_target, key, value) {
+          const binding = typeof key === "string" ? byName.get(key) : undefined;
+          if (binding === undefined) Reflect.set(globalThis as Record<PropertyKey, unknown>, key, value);
+          else hostRequest({ op: "binding-set", binding, value: encode(value) });
+          return true;
+        },
+        deleteProperty(_target, key) {
+          if (typeof key === "string" && byName.has(key)) return false;
+          return Reflect.deleteProperty(globalThis as Record<PropertyKey, unknown>, key);
+        },
+      });
+    };
+
+    const scopedEval = new Function(
+      SCOPE_PARAM,
+      SOURCE_PARAM,
+      `with (${SCOPE_PARAM}) { return eval(${SOURCE_PARAM}); }`,
+    ) as (scope: Record<PropertyKey, unknown>, source: string) => unknown;
+
+    port.on("message", (request: Request) => {
+      let response: Response;
+      try {
+        let value: unknown;
+        switch (request.op) {
+          case "eval":
+            if (request.direct && request.bindings !== undefined) {
+              const source = request.strict ? `"use strict";\n${request.source}` : request.source;
+              value = Reflect.apply(scopedEval, undefined, [createBindingScope(request.bindings), source]);
+            } else {
+              // biome-ignore lint/style/noCommaOperator: explicit indirect eval in the isolated Worker realm
+              // biome-ignore lint/security/noGlobalEval: this Worker is the selected dynamic-code evaluator
+              value = (0, eval)(request.source);
+            }
+            break;
+          case "function":
+            value = new Function(request.parameters, request.body);
+            break;
+          case "get":
+            value = Reflect.get(handle(request.handle), decode(request.key) as PropertyKey);
+            break;
+          case "set":
+            value = Reflect.set(handle(request.handle), decode(request.key) as PropertyKey, decode(request.value));
+            break;
+          case "apply":
+            value = Reflect.apply(handle(request.handle), decode(request.thisArg), request.args.map(decode));
+            break;
+          case "construct":
+            value = Reflect.construct(handle(request.handle), request.args.map(decode));
+            break;
+          case "has":
+            value = Reflect.has(handle(request.handle), decode(request.key) as PropertyKey);
+            break;
+          case "delete":
+            value = Reflect.deleteProperty(handle(request.handle), decode(request.key) as PropertyKey);
+            break;
+        }
+        response = {
+          channel: "worker",
+          id: request.id,
+          ok: true,
+          value: encode(value),
+        };
+      } catch (error) {
+        response = {
+          channel: "worker",
+          id: request.id,
+          ok: false,
+          error: serializeError(error),
+        };
+      }
+      port.postMessage(response);
+      Atomics.add(signal, 0, 1);
+      Atomics.notify(signal, 0);
+    });
+    port.start();
+    port.postMessage({ protocol: PROTOCOL, type: "ready" });
+  });
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8406,6 +8406,8 @@ function resolveImport(
   // the leading `self` for `extern_class` members. Lets the generic method shim
   // below drop its rest parameter. Undefined when unknown → rest form kept.
   paramCount?: number,
+  dynamicCode: DynamicCodePolicy = "compat",
+  dynamicCodeEvaluator?: DynamicCodeEvaluator,
 ): Function {
   switch (intent.type) {
     case "string_literal":
@@ -9128,6 +9130,9 @@ function resolveImport(
           callbackState,
           globalSandbox,
           instanceState,
+          undefined,
+          dynamicCode,
+          dynamicCodeEvaluator,
         );
         return makeFixedExternMethodCall(fixedMethodArity, canonical);
       }
@@ -9324,7 +9329,108 @@ function resolveImport(
           const root: any = { "": unfiltered };
           return _internalizeJSONProperty(root, "", reviver, callbackState);
         };
+      if (name === "__extern_direct_eval") {
+        const bindingByCell = new WeakMap<object, DynamicCodeBinding>();
+        return (
+          src: any,
+          _globalObject: any,
+          _thisArg: any,
+          _activationState: any,
+          activationNames: any,
+          activationSlots: any,
+          lexicalNames: any,
+          lexicalSlots: any,
+          outerNames: any,
+          outerSlots: any,
+          callerStrict: number,
+          _mappedParamNames: any,
+        ): any => {
+          if (typeof src !== "string") return src;
+          if (dynamicCode === "deny") throw new EvalError("dynamic code generation is disabled by the host");
+          if (dynamicCode !== "evaluator" || !dynamicCodeEvaluator) {
+            throw new EvalError(
+              'reified host direct eval requires buildImports(..., { dynamicCode: "evaluator", dynamicCodeEvaluator })',
+            );
+          }
+          const exports = callbackState?.getExports();
+          const vecLen = exports?.__runtime_eval_vec_len;
+          const vecGet = exports?.__runtime_eval_vec_get;
+          const cellGet = exports?.__runtime_eval_cell_get;
+          const cellSet = exports?.__runtime_eval_cell_set;
+          if (
+            typeof vecLen !== "function" ||
+            typeof vecGet !== "function" ||
+            typeof cellGet !== "function" ||
+            typeof cellSet !== "function"
+          ) {
+            throw new EvalError("reified host direct-eval bridge exports are unavailable on the AOT instance");
+          }
+
+          const bindings: DynamicCodeBinding[] = [];
+          const appendLayer = (names: any, slots: any): void => {
+            if (names == null || slots == null) return;
+            const count = vecLen(names) >>> 0;
+            if (count !== vecLen(slots) >>> 0) {
+              throw new EvalError("reified host direct-eval binding vectors are misaligned");
+            }
+            for (let index = 0; index < count; index++) {
+              const bindingName = String(vecGet(names, index));
+              if (bindingName === "__js2wasm_eval_nonglobal__") continue;
+              const cell = vecGet(slots, index);
+              if ((typeof cell !== "object" || cell === null) && typeof cell !== "function") {
+                throw new EvalError(`reified host direct-eval binding '${bindingName}' has no canonical cell`);
+              }
+              let binding = bindingByCell.get(cell as object);
+              if (!binding) {
+                binding = {
+                  name: bindingName,
+                  get: () => cellGet(cell),
+                  set: (value: unknown) => cellSet(cell, value),
+                };
+                bindingByCell.set(cell as object, binding);
+              }
+              bindings.push(binding);
+            }
+          };
+
+          // Environment lookup is inner-to-outer. Build the list outer-first;
+          // the evaluator's later duplicate wins for a lexical shadow.
+          appendLayer(outerNames, outerSlots);
+          appendLayer(activationNames, activationSlots);
+          appendLayer(lexicalNames, lexicalSlots);
+          return dynamicCodeEvaluator.evaluate(src, {
+            direct: true,
+            strict: callerStrict !== 0,
+            bindings,
+          });
+        };
+      }
       if (name === "__extern_eval") {
+        if (dynamicCode === "deny") {
+          return (src: any) => {
+            if (typeof src !== "string") return src;
+            throw new EvalError("dynamic code generation is disabled by the host");
+          };
+        }
+        if (dynamicCode === "native") {
+          return (src: any) => {
+            if (typeof src !== "string") return src;
+            // A Wasm host-import boundary cannot carry the caller's lexical
+            // environment, so this is necessarily indirect eval. When the
+            // module is hosted in a Worker, the global below is the Worker
+            // realm rather than the main page/process realm.
+            // biome-ignore lint/style/noCommaOperator: (0, eval) forces indirect eval
+            // biome-ignore lint/security/noGlobalEval: explicit opt-in host-eval engine
+            return (0, eval)(src);
+          };
+        }
+        if (dynamicCode === "evaluator") {
+          return (src: any, isDirect: number = 0) => {
+            if (typeof src !== "string") return src;
+            if (!dynamicCodeEvaluator) throw new EvalError("no dynamic-code evaluator was supplied by the host");
+            return dynamicCodeEvaluator.evaluate(src, { direct: isDirect !== 0 });
+          };
+        }
         // #1164: dynamic eval via Wasm module compilation.  The primary
         // path compiles the eval string through js2wasm and instantiates
         // it as a fresh Wasm module via the JS Wasm API — no `(0, eval)`,
@@ -9516,6 +9622,21 @@ assert._isSameValue = isSameValue;
         }
       }
       if (name === "__extern_new_function") {
+        if (dynamicCode === "deny") {
+          return () => {
+            throw new EvalError("dynamic code generation is disabled by the host");
+          };
+        }
+        if (dynamicCode === "native") {
+          // biome-ignore lint/security/noGlobalEval: explicit opt-in host-eval engine
+          return (params: any, body: any) => new Function(String(params ?? ""), String(body ?? ""));
+        }
+        if (dynamicCode === "evaluator") {
+          return (params: any, body: any) => {
+            if (!dynamicCodeEvaluator) throw new EvalError("no dynamic-code evaluator was supplied by the host");
+            return dynamicCodeEvaluator.createFunction(String(params ?? ""), String(body ?? ""));
+          };
+        }
         // (#2960) Dynamic `new Function(params, body)` — meta-circular
         // construction via js2wasm's own compiler (see createNewFunctionShim).
         // Returns a real JS-callable function the parent module can invoke.
@@ -10017,6 +10138,9 @@ assert._isSameValue = isSameValue;
           callbackState,
           globalSandbox,
           instanceState,
+          undefined,
+          dynamicCode,
+          dynamicCodeEvaluator,
         ) as (o: any, k: any) => number;
         const getProp = resolveImport(
           { type: "extern_get" } as ImportIntent,
@@ -10024,6 +10148,9 @@ assert._isSameValue = isSameValue;
           callbackState,
           globalSandbox,
           instanceState,
+          undefined,
+          dynamicCode,
+          dynamicCodeEvaluator,
         ) as (o: any, k: any) => any;
         const toBool = resolveImport(
           { type: "builtin", name: "__to_boolean" } as ImportIntent,
@@ -10031,6 +10158,9 @@ assert._isSameValue = isSameValue;
           callbackState,
           globalSandbox,
           instanceState,
+          undefined,
+          dynamicCode,
+          dynamicCodeEvaluator,
         ) as (v: any) => number;
         return (obj: any, key: any): number => {
           // (1)+(2) value-independent HasProperty.
@@ -15977,11 +16107,47 @@ function isFastLeafHostImport(imp: ImportDescriptor): boolean {
  * `setExports(instance.exports)` remains available for legacy callback, vec,
  * closure, and string wiring.
  */
+export interface BuildImportsOptions {
+  domRoot?: Element | ShadowRoot;
+  globalSandbox?: Record<string, any>;
+  /**
+   * Runtime implementation for dynamic eval and new Function.
+   *
+   * `compat` preserves the existing meta-circular-first path and its native
+   * fallback. `native` delegates directly to the current realm's eval/Function.
+   * `evaluator` delegates to the explicit evaluator below. `deny` fails closed.
+   */
+  dynamicCode?: DynamicCodePolicy;
+  /** Synchronous evaluator used only when `dynamicCode` is `evaluator`. */
+  dynamicCodeEvaluator?: DynamicCodeEvaluator;
+}
+
+export type DynamicCodePolicy = "compat" | "native" | "evaluator" | "deny";
+
+/** Live caller binding retained by the AOT module's host realm. */
+export interface DynamicCodeBinding {
+  readonly name: string;
+  get(): unknown;
+  set(value: unknown): void;
+}
+
+export interface DynamicCodeEvaluationContext {
+  direct: boolean;
+  strict?: boolean;
+  /** Present only for `CompileOptions.directEval: "reified-host"`. */
+  bindings?: readonly DynamicCodeBinding[];
+}
+
+export interface DynamicCodeEvaluator {
+  evaluate(source: string, context: DynamicCodeEvaluationContext): unknown;
+  createFunction(parameters: string, body: string): Function;
+}
+
 export function buildImports(
   manifest: ImportDescriptor[],
   deps?: Record<string, any>,
   stringPool?: string[],
-  options?: { domRoot?: Element | ShadowRoot; globalSandbox?: Record<string, any> },
+  options?: BuildImportsOptions,
 ): {
   env: Record<string, Function>;
   "wasm:js-string": typeof jsString;
@@ -16068,7 +16234,16 @@ export function buildImports(
       continue;
     }
 
-    fn = resolveImport(imp.intent, deps, callbackState, options?.globalSandbox, instanceState, imp.paramCount);
+    fn = resolveImport(
+      imp.intent,
+      deps,
+      callbackState,
+      options?.globalSandbox,
+      instanceState,
+      imp.paramCount,
+      options?.dynamicCode,
+      options?.dynamicCodeEvaluator,
+    );
 
     // DOM containment wrapping
     if (options?.domRoot) {

--- a/tests/fixtures/node-eval-worker.mjs
+++ b/tests/fixtures/node-eval-worker.mjs
@@ -1,0 +1,6 @@
+import { parentPort } from "node:worker_threads";
+import { serveNodeEvalWorker } from "../../src/runtime-node-eval-worker.ts";
+
+if (parentPort === null) throw new Error("eval Worker fixture requires worker_threads");
+
+serveNodeEvalWorker(parentPort);

--- a/tests/runtime-host-eval-isolation.test.ts
+++ b/tests/runtime-host-eval-isolation.test.ts
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Eval-only Worker isolation while the AOT Wasm instance stays in the host. */
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
+import { build } from "esbuild";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { type CompileResult, compile } from "../src/index.js";
+import { type NodeEvalWorkerEvaluator, connectNodeEvalWorker } from "../src/runtime-node-eval-worker.js";
+import { buildImports, instantiateWasm, wrapExports } from "../src/runtime.js";
+
+const MAIN_ONLY = "__js2wasm_eval_main_only__";
+const WORKER_ONLY = "__js2wasm_eval_worker_only__";
+
+let workerBuildDir: string;
+let workerEntryUrl: URL;
+let compiled: CompileResult;
+let activeEvaluator: NodeEvalWorkerEvaluator | undefined;
+
+beforeAll(async () => {
+  const temporaryRoot = join(process.cwd(), ".tmp");
+  await mkdir(temporaryRoot, { recursive: true });
+  workerBuildDir = await mkdtemp(join(temporaryRoot, "eval-worker-"));
+  const outfile = join(workerBuildDir, "worker.mjs");
+  await build({
+    entryPoints: [fileURLToPath(new URL("./fixtures/node-eval-worker.mjs", import.meta.url))],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    packages: "external",
+    outfile,
+  });
+  workerEntryUrl = pathToFileURL(outfile);
+
+  compiled = await compile(
+    `
+      export function evalSource(source: any): any {
+        return (0, eval)(source);
+      }
+
+      export function evalObjectProperty(source: any): any {
+        const object: any = (0, eval)(source);
+        return object.answer;
+      }
+
+      export function evalAndCall(source: any, value: any): any {
+        const fn: any = (0, eval)(source);
+        return fn(value);
+      }
+
+      export function makeFunction(body: any): any {
+        const fn: any = new Function("value", body);
+        return fn(41);
+      }
+
+      export function directEvalLocal(source: any): any {
+        let value: any = 40;
+        const result: any = eval(source);
+        return value * 100 + result;
+      }
+
+      export function directEvalClosure(source: any): any {
+        let value: any = 40;
+        const fn: any = eval(source);
+        value = 41;
+        return fn();
+      }
+
+      export function directEvalWriteBeforeThrow(source: any): any {
+        let value: any = 40;
+        try {
+          eval(source);
+        } catch {}
+        return value;
+      }
+
+      export function directEvalMissing(source: any): any {
+        return eval(source);
+      }
+
+      export function catchesSyntaxError(source: any): number {
+        try {
+          (0, eval)(source);
+          return 0;
+        } catch (error: any) {
+          return error instanceof SyntaxError ? 1 : 2;
+        }
+      }
+    `,
+    { skipSemanticDiagnostics: true, directEval: "reified-host" },
+  );
+  expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(compiled.imports.some((descriptor) => descriptor.name === "__extern_eval")).toBe(true);
+  expect(compiled.imports.some((descriptor) => descriptor.name === "__extern_direct_eval")).toBe(true);
+  expect(compiled.imports.some((descriptor) => descriptor.name === "__extern_new_function")).toBe(true);
+});
+
+afterEach(async () => {
+  await activeEvaluator?.terminate();
+  activeEvaluator = undefined;
+  delete (globalThis as Record<string, unknown>)[MAIN_ONLY];
+  delete (globalThis as Record<string, unknown>)[WORKER_ONLY];
+});
+
+afterAll(async () => {
+  await rm(workerBuildDir, { recursive: true, force: true });
+});
+
+async function instantiateWithEvalWorker(timeoutMs = 30_000): Promise<Record<string, Function>> {
+  activeEvaluator = await connectNodeEvalWorker(new Worker(workerEntryUrl), {
+    timeoutMs,
+  });
+  const imports = buildImports(compiled.imports, undefined, compiled.stringPool, {
+    dynamicCode: "evaluator",
+    dynamicCodeEvaluator: activeEvaluator,
+  });
+  const { instance } = await instantiateWasm(
+    compiled.binary,
+    imports.env,
+    imports.string_constants,
+    imports.string_constants16,
+  );
+  imports.setInstance?.(instance);
+  return wrapExports(instance, { signatures: compiled.exportSignatures });
+}
+
+describe("isolated JS-host evaluator", () => {
+  it("keeps the legacy direct-eval lowering byte-identical by default", async () => {
+    const source = `export function run(source: any): any { let value: any = 1; return eval(source); }`;
+    const implicit = await compile(source, { skipSemanticDiagnostics: true });
+    const explicit = await compile(source, {
+      skipSemanticDiagnostics: true,
+      directEval: "legacy",
+    });
+
+    expect(implicit.success).toBe(true);
+    expect(explicit.success).toBe(true);
+    expect(Buffer.from(explicit.binary)).toEqual(Buffer.from(implicit.binary));
+    expect(implicit.imports.some((descriptor) => descriptor.name === "__extern_direct_eval")).toBe(false);
+  });
+
+  it("keeps the AOT module in the host and eval globals in the Worker realm", async () => {
+    (globalThis as Record<string, unknown>)[MAIN_ONLY] = 91;
+    const exports = await instantiateWithEvalWorker();
+
+    expect(exports.evalSource(`typeof globalThis.${MAIN_ONLY}`)).toBe("undefined");
+    expect(exports.evalSource(`globalThis.${WORKER_ONLY} = 41; globalThis.${WORKER_ONLY}`)).toBe(41);
+    expect(exports.evalSource(`globalThis.${WORKER_ONLY} + 1`)).toBe(42);
+    expect((globalThis as Record<string, unknown>)[MAIN_ONLY]).toBe(91);
+    expect((globalThis as Record<string, unknown>)[WORKER_ONLY]).toBeUndefined();
+  });
+
+  it("keeps Worker objects and functions remote while compiled code uses them synchronously", async () => {
+    const exports = await instantiateWithEvalWorker();
+
+    expect(exports.evalObjectProperty("({ answer: 42 })")).toBe(42);
+    expect(exports.evalAndCall("(value) => value + 1", 41)).toBe(42);
+    exports.evalSource(`globalThis.${WORKER_ONLY} = 1`);
+    expect(exports.makeFunction(`return value + globalThis.${WORKER_ONLY}`)).toBe(42);
+  });
+
+  it("keeps reified direct-eval cells live in the main AOT instance", async () => {
+    const exports = await instantiateWithEvalWorker();
+
+    expect(exports.directEvalLocal("value = value + 2; value")).toBe(4242);
+    expect(exports.directEvalClosure("() => ++value")).toBe(42);
+    expect(exports.directEvalWriteBeforeThrow("value = 42; throw new Error('after write')")).toBe(42);
+    expect(() => exports.directEvalMissing("missingDirectEvalName")).toThrowError(
+      expect.objectContaining({ name: "ReferenceError" }),
+    );
+  });
+
+  it("reconstructs standard errors for compiled catch and host escape", async () => {
+    const exports = await instantiateWithEvalWorker();
+
+    expect(exports.catchesSyntaxError("@")).toBe(1);
+    expect(() => exports.evalSource("throw new RangeError('isolated boom')")).toThrowError(
+      expect.objectContaining({ name: "RangeError", message: "isolated boom" }),
+    );
+  });
+
+  it("hard-terminates an eval Worker at the synchronous deadline", async () => {
+    const exports = await instantiateWithEvalWorker(250);
+
+    expect(() => exports.evalSource("for (;;) {}")).toThrowError(expect.objectContaining({ name: "TimeoutError" }));
+    expect(() => exports.evalSource("1 + 1")).toThrowError(expect.objectContaining({ name: "TimeoutError" }));
+  });
+
+  it("supports a fail-closed host without starting an evaluator", async () => {
+    const imports = buildImports(compiled.imports, undefined, compiled.stringPool, { dynamicCode: "deny" });
+    const { instance } = await instantiateWasm(
+      compiled.binary,
+      imports.env,
+      imports.string_constants,
+      imports.string_constants16,
+    );
+    imports.setInstance?.(instance);
+    const exports = wrapExports(instance);
+
+    expect(exports.evalSource(41)).toBe(41);
+    expect(() => exports.evalSource("1 + 1")).toThrow(/dynamic code generation is disabled/);
+    expect(() => exports.makeFunction("return value + 1")).toThrow(/dynamic code generation is disabled/);
+  });
+});

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -34,6 +34,8 @@ export default defineConfig({
         index: "src/index.ts",
         cli: "src/cli.ts",
         runtime: "src/runtime.ts",
+        "runtime-isolated-evaluator": "src/runtime-isolated-evaluator.ts",
+        "runtime-node-eval-worker": "src/runtime-node-eval-worker.ts",
         optimize: "src/optimize.ts",
       },
       formats: ["es"],


### PR DESCRIPTION
## Summary

- keep the compiled AOT Wasm instance in the original host and move only dynamic JavaScript evaluation into an isolated evaluator
- add an opt-in Node Worker transport for `eval` / `Function`, including persistent remote object/function handles, timeouts, and standard error reconstruction
- add `directEval: "reified-host"`, reusing the standalone interpreter's canonical direct-eval cells through opaque live binding IDs so reads and writes remain owned by the main Wasm instance
- add same-origin browser-realm support, package exports, public documentation, and acceptance coverage

## Semantics covered

The reified-host path preserves live caller-local reads and writes, write-before-throw behavior, and eval-created closures that observe later AOT mutations. Worker globals remain isolated from both the main JS realm and the Wasm module.

The existing default remains `directEval: "legacy"`; compiling with the explicit legacy option is byte-identical to the default.

## Deliberate follow-ups

- full `EvalDeclarationInstantiation` behavior, including sloppy `var` / function persistence, complete lexical/TDZ/delete semantics, mapped arguments, and private names
- a true browser Worker transport for synchronous Wasm imports; the included browser adapter uses a same-origin realm because a Worker round trip needs async suspension/JSPI
- a reverse membrane for arbitrary main-owned objects beyond the binding-cell bridge

The AOT Wasm module is never transferred into the evaluator Worker.

Related: #1006

## Validation

- `pnpm exec vitest run tests/runtime-host-eval-isolation.test.ts` — 7/7 passed after merging latest `origin/main`
- eval compatibility slice — 69 passed, 9 skipped
- `pnpm run typecheck` — passed after the merge
- `pnpm run build` — passed
- commit/pre-push gates — lint, changed-root tests, LOC/function budgets, oracle/coercion ratchets, numeric-local parity, and issue integrity passed
- `git diff --check` — passed
