### PR TITLE
fix(codegen): balance dynamic in comparisons

### DIFF
--- a/plan/issues/4369-dynamic-in-physical-struct-field-stack-imbalance.md
+++ b/plan/issues/4369-dynamic-in-physical-struct-field-stack-imbalance.md
@@ -1,0 +1,103 @@
+---
+id: 4369
+title: "Dynamic `in` over a class instance leaves compiler-only struct fields on the Wasm stack"
+status: done
+assignee: ttraenkler/codex
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+completed: 2026-08-11
+priority: high
+horizon: s
+feasibility: easy
+task_type: bugfix
+area: codegen
+language_feature: in-operator
+goal: npm-library-support
+related: [166, 722, 3715, 4368]
+files:
+  - src/codegen/binary-ops-in.ts
+  - tests/issue-4369-dynamic-in-stack-balance.test.ts
+origin: "marked@18.0.2 pinned dogfood bundle after the capture-cell repair tracked in plan issue 4368"
+---
+
+# #4369 — Dynamic `in` compares compiler-only physical fields
+
+## Problem
+
+Marked's extension registration loops dynamically check whether a `for...in`
+key exists on its renderer, tokenizer, and hooks class instances:
+
+```js
+for (const key in extension.renderer) {
+  if (!(key in renderer)) throw new Error("unknown renderer property");
+}
+```
+
+The legacy backend builds a string-equality OR chain for a dynamic `key in
+knownStruct`. It obtains candidate names from the physical Wasm struct, which
+contains the compiler's hidden `__tag` slot before the public fields. The
+string-import collector correctly registers only JavaScript-visible TypeScript
+properties, so there is no string global for `__tag`.
+
+The emitter nevertheless pushes the dynamic key before checking whether the
+candidate has a string global. That first key remains on the operand stack and
+the following public-field comparison feeds an `externref` to `i32.or`:
+
+```wat
+i32.const 0
+local.get $key          ;; hidden __tag candidate, no comparison follows
+local.get $key
+global.get $options
+call $string_equals
+i32.or                  ;; expects i32, sees the stranded externref
+```
+
+The six-line minimized class repro and Marked's 4.1 MB bundle fail with the
+same validator error. In Marked the first occurrence is function
+`__closure_27` in `Marked.use()`.
+
+## Root cause
+
+`src/codegen/binary-ops-in.ts` and the import collector use different sources
+of truth:
+
+- the emitter walks every physical struct field, including hidden compiler
+  representation;
+- the collector walks `rightType.getProperties()`, the public TypeScript
+  property surface;
+- the emitter loads the key before discovering that a physical-only name has
+  no registered string.
+
+This is not caused by Marked's adjacent `Array.prototype.includes()` call. It
+is a generic class-instance dynamic-`in` stack imbalance.
+
+## Implementation direction
+
+Filter physical struct candidates through the receiver's public TypeScript
+property names, and emit each `key + field-name + equals + or` unit atomically:
+do not push the key until the field-name string is available. This also keeps
+the internal `__tag` slot from becoming observable as a JavaScript property.
+
+## Acceptance criteria
+
+- [x] A dynamic `key in new Class()` repro emits valid Wasm.
+- [x] Public fields return `true`; a missing field returns `false`.
+- [x] The compiler-only `__tag` field returns `false`, including when that
+      spelling exists elsewhere as a real string literal.
+- [x] A key produced by `for...in` takes the same valid, correct path.
+- [x] The pinned Marked bundle advances past `__closure_27` after composing
+      with the capture-cell fix.
+- [x] Adjacent dynamic/static `in` operator suites remain green.
+
+## Verification
+
+- The focused regression and six adjacent `in`/closed-struct suites pass: 72
+  tests total.
+- TypeScript project type-checking and focused formatting checks pass.
+- The exact pinned Marked compile, with the capture-cell repair from
+  [PR #4382](https://github.com/loopdive/js2wasm/pull/4382) composed only for
+  measurement, moves from function 510 `__closure_27`
+  (`externref` under `i32.or`) to the later function 564 method-trampoline
+  result mismatch. The emitted binary shrinks from 4,086,843 to 4,086,823
+  bytes; no Marked source or compiler options changed.

--- a/src/codegen/binary-ops-in.ts
+++ b/src/codegen/binary-ops-in.ts
@@ -10,7 +10,7 @@
  * change (prove-emit-identity IDENTICAL across gc/standalone/wasi).
  */
 import { ts } from "../ts-api.js";
-import type { Instr, ValType } from "../ir/types.js";
+import type { FieldDef, Instr, ValType } from "../ir/types.js";
 import { popBody, pushBody } from "./context/bodies.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
@@ -41,6 +41,19 @@ function buildThrowTypeErrorBranch(ctx: CodegenContext, fctx: FunctionContext, m
   const throwInstrs = fctx.body;
   popBody(fctx, saved);
   return throwInstrs;
+}
+
+/**
+ * Keep a dynamic `key in value` comparison on the JavaScript property surface.
+ * Physical structs also contain compiler-only fields such as `__tag`; unlike
+ * public TypeScript properties, the import collector intentionally has no
+ * string constant for those fields.
+ */
+function publicPhysicalFieldNames(rightType: ts.Type, fields: FieldDef[]): string[] {
+  const publicPropertyNames = new Set(rightType.getProperties().map((property) => property.name));
+  return fields
+    .map((field) => field.name)
+    .filter((name): name is string => name !== undefined && publicPropertyNames.has(name));
 }
 
 /**
@@ -201,7 +214,7 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
         isVecType = true;
         vecTypeIdx = typeIdx;
       } else {
-        structFieldNames = structDef.fields.map((f) => f.name).filter((n): n is string => n !== undefined);
+        structFieldNames = publicPhysicalFieldNames(rightType, structDef.fields);
         structWasm = rightWasm;
       }
     }
@@ -444,10 +457,9 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
         // Start with false (0)
         fctx.body.push({ op: "i32.const", value: 0 });
         for (const fieldName of structFieldNames) {
-          // Load the key and the field name string, compare
-          fctx.body.push({ op: "local.get", index: keyLocal });
           const strGlobal = ctx.stringGlobalMap.get(fieldName);
           if (strGlobal !== undefined) {
+            fctx.body.push({ op: "local.get", index: keyLocal });
             fctx.body.push({ op: "global.get", index: strGlobal });
             fctx.body.push({ op: "call", funcIdx: eqFunc });
             fctx.body.push({ op: "i32.or" }); // OR with accumulated result

--- a/tests/issue-4369-dynamic-in-stack-balance.test.ts
+++ b/tests/issue-4369-dynamic-in-stack-balance.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+const SOURCE = `
+  class Registry {
+    options = 1;
+    parser = 2;
+  }
+
+  export function has(key) {
+    return key in new Registry();
+  }
+
+  export function hasFromEnumeration(input) {
+    for (const key in input) {
+      if (key in new Registry()) return 1;
+    }
+    return 0;
+  }
+
+  export function hidesCompilerTag() {
+    const key = /** @type {any} */ ("__tag");
+    return key in new Registry();
+  }
+`;
+
+async function compileAndRun(): Promise<Record<string, (...args: any[]) => any>> {
+  const result = await compile(SOURCE, {
+    fileName: "dynamic-in-internal-field.js",
+    skipSemanticDiagnostics: true,
+    experimentalIR: false,
+  });
+
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  await expect(WebAssembly.compile(result.binary)).resolves.toBeInstanceOf(WebAssembly.Module);
+
+  const importObject = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setInstance?.(instance);
+  return wrapExports(instance, { signatures: result.exportSignatures }) as Record<string, (...args: any[]) => any>;
+}
+
+describe("#4369 — dynamic `in` checks ignore compiler-only struct fields", () => {
+  it("keeps every dynamic comparison stack-balanced and returns the public-field answer", async () => {
+    const exports = await compileAndRun();
+
+    expect(exports.has!("options")).toBe(1);
+    expect(exports.has!("parser")).toBe(1);
+    expect(exports.has!("missing")).toBe(0);
+    expect(exports.hidesCompilerTag!()).toBe(0);
+  });
+
+  it("handles the for-in-fed key shape used by Marked", async () => {
+    const exports = await compileAndRun();
+
+    expect(exports.hasFromEnumeration!({ options: true })).toBe(1);
+    expect(exports.hasFromEnumeration!({ missing: true })).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- filter known-struct `in` candidates through the public TypeScript property surface
- emit each dynamic-key comparison atomically so a missing string constant cannot strand a value on the Wasm stack
- hide compiler-only physical fields such as `__tag` from JavaScript `in`
- add runtime/for-in regressions and complete [plan issue 4369](https://github.com/loopdive/js2wasm/blob/6729d1144276612a3917124531c4e9f9fdc5feb0/plan/issues/4369-dynamic-in-physical-struct-field-stack-imbalance.md)

## Root cause

The dynamic `key in knownStruct` emitter walked every physical Wasm field, including compiler-only `__tag`. The string importer correctly registered only JavaScript-visible properties. The emitter loaded `key` before discovering that `__tag` had no string global, leaving an `externref` beneath the next comparison's `i32.or`.

The emitter now uses the receiver type's public properties to filter physical fields, and loads the key only after the corresponding field-name string is available.

## Package impact

Composed only for measurement with the capture-cell repair in [PR #4382](https://github.com/loopdive/js2wasm/pull/4382), the unchanged pinned Marked 18.0.2 bundle advances past function 510 `__closure_27`. The binary shrinks from 4,086,843 to 4,086,823 bytes and reaches a later, independent function-564 method-trampoline result mismatch.

This does not claim Marked's normal semantic compile path is green; the evolving-array inference frontier remains in [plan issue 3715](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3715-evolving-array-type-never-inference.md).

## Validation

- focused and adjacent dynamic/static `in` suites: 72/72 passed
- rebased focused runtime regressions: 2/2 passed
- public fields return true; missing and compiler-only fields return false; for-in-fed keys follow the same path
- typecheck, formatting, LOC/function budgets, oracle/coercion/numeric-local and issue-ID gates passed
