### PR TITLE
fix(function): preserve strict caller state across synthetic activations

### DIFF
--- a/plan/issues/3017-function-poison-pill-and-eval-freevar-capture.md
+++ b/plan/issues/3017-function-poison-pill-and-eval-freevar-capture.md
@@ -1,11 +1,10 @@
 ---
 id: 3017
 title: "Function .caller/.arguments poison-pill throw + free-variable capture in Function/eval shim child module"
-status: done
-completed: 2026-07-28
+status: in-progress
 sprint: Backlog
 created: 2026-07-03
-updated: 2026-07-28
+updated: 2026-08-11
 priority: medium
 horizon: l
 feasibility: hard
@@ -20,6 +19,10 @@ loc-budget-allow:
   - src/codegen/closures.ts
   - src/codegen/context/types.ts
   - src/codegen/expressions/assignment.ts
+  - src/codegen/expressions/call-tail-dispatch.ts
+  - src/codegen/expressions/calls.ts
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/function-poison-pill.ts
   - src/codegen/index.ts
   - src/codegen/literals.ts
   - src/codegen/property-access.ts
@@ -30,6 +33,12 @@ func-budget-allow:
   - src/codegen/context/create-context.ts::createCodegenContext
   - src/codegen/expressions/assignment.ts::compileElementAssignment
   - src/codegen/expressions/assignment.ts::compilePropertyAssignment
+  - src/codegen/expressions/call-tail-dispatch.ts::compileTailDispatch
+  - src/codegen/expressions/calls.ts::compileIIFE
+  - src/codegen/expressions/new-super.ts::compileNewFunctionDeclaration
+  - src/codegen/expressions/new-super.ts::compileNewFunctionExpression
+  - src/codegen/expressions/new-super.ts::compileNewExpression
+  - src/codegen/function-poison-pill.ts::finalizeFunctionPoisonPillCalls
   - src/codegen/function-body.ts::compileFunctionBody
   - src/codegen/index.ts::generateModule
   - src/codegen/index.ts::generateMultiModule
@@ -171,6 +180,40 @@ Gap 2 (global-environment resolution for free variables in the eval/Function
 shim child module) is intentionally unchanged and remains open. Accordingly,
 this combined tracking issue stays `in-progress`; the Gap 1 source-function
 slice is independently landable.
+
+## 2026-08-11 standalone follow-up
+
+The remaining ordinary-source activation routes now preserve strict caller
+state when their source function boundary does not coincide with a normal Wasm
+function body:
+
+- inlined function-expression IIFEs record their own strictness on the nested
+  instruction region, and the final call-site pass honors that override instead
+  of inheriting the containing Wasm function's strictness;
+- synthesized declaration- and expression-based constructor bodies are
+  registered as source activations before prologue/body emission;
+- parenthesized anonymous constructors (`new (function () { ... })()`) now run
+  through the existing source-body constructor lowering instead of collapsing
+  to a null placeholder without executing the body.
+
+Fresh maintained standalone measurement used the full runtime-eval interpreter
+and official scope. For the complete 97-file
+`built-ins/Function/15.3.5.4_2-*` family:
+
+- before (`20260811-214733`, `origin/main@6c1117f8767e9b`): **83/97 pass**,
+  14 fail, 0 compile errors;
+- after (`20260811-221556`): **92/97 pass**, 5 fail, 0 compile errors;
+- exact FAIL → PASS rows: `6gs`, `16gs`, `18gs`, `19gs`, `20gs`, `38gs`,
+  `41gs`, `44gs`, and `47gs` (9 total);
+- the five unchanged residuals are dynamic `Function` constructor calls
+  (`8gs`, `10gs`, `95gs`), getter-accessor activation (`96gs`), and bound-call
+  forwarding (`97gs`).
+
+All nine flips belong to the freshly harvested 98-row ES5 Function-object
+standalone root-cause bucket, reducing that assigned residue to **89**. The
+separate 73-row ES5 `with` residue is unchanged; its dominant 39-row compiler
+gate requires closure capture of an object environment and is tracked by
+#4206/#4264 rather than this bounded Function activation slice.
 
 ## Notes
 

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2167,7 +2167,7 @@ export interface CodegenContext {
   callerStrictGlobalIdx: number;
   /** Source function name → source strictness, consumed by the final call-site pass. */
   sourceFunctionStrictness: Map<string, boolean>;
-  /** Root source-function body → strictness; avoids collisions between shadowed names. */
+  /** Source-function or inlined-IIFE instruction region → strictness. */
   sourceFunctionStrictnessByBody: Map<Instr[], boolean>;
   /** Idempotence guard for the final call-site instrumentation pass. */
   functionPoisonPillCallsFinalized?: boolean;

--- a/src/codegen/expressions/call-tail-dispatch.ts
+++ b/src/codegen/expressions/call-tail-dispatch.ts
@@ -40,6 +40,7 @@ import { brandExternMethodResult, coerceType, compileExpression, VOID_RESULT } f
 import { compileStatement, hoistFunctionDeclarations } from "../statements.js";
 import { ensureExtrasArgvGlobal, maybeSetArgcForKnownCall } from "../statements/nested-declarations.js";
 import { isStaticUndefinedArg } from "../string-ops.js";
+import { isStrictFunction } from "../helpers/is-strict-function.js";
 import {
   defaultValueInstrs,
   emitGuardedFuncRefCast,
@@ -500,6 +501,16 @@ export function compileTailDispatch(
               const savedBody = fctx.body;
               fctx.savedBodies.push(savedBody);
               const blockBody: Instr[] = [];
+              // (#3017) An inlined IIFE has no Wasm FunctionContext of its own,
+              // but it remains a source function boundary for legacy
+              // Function#caller semantics. Preserve the region's strictness so
+              // the final call-site pass does not inherit the containing Wasm
+              // function's bit (for example, a strict IIFE inside a sloppy
+              // Test262 wrapper).
+              ctx.sourceFunctionStrictnessByBody.set(
+                blockBody,
+                isStrictFunction(callee, ctx.inferModuleStrictArguments),
+              );
               fctx.body = blockBody;
 
               // Save and override returnType so that return statements inside the
@@ -581,6 +592,12 @@ export function compileTailDispatch(
               const savedBody = fctx.body;
               fctx.savedBodies.push(savedBody);
               const blockBody: Instr[] = [];
+              // Keep the source-level boundary even though the IIFE is inlined;
+              // see the returning arm above.
+              ctx.sourceFunctionStrictnessByBody.set(
+                blockBody,
+                isStrictFunction(callee, ctx.inferModuleStrictArguments),
+              );
               fctx.body = blockBody;
 
               // Save and override returnType: void IIFE has no return value,

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -22,6 +22,7 @@ import type { Instr, ValType } from "../../ir/types.js";
 import { compileArrayMethodCall, compileArrayPrototypeCall, resolveArrayInfo } from "../array-methods.js";
 import { emitGlobalThisGopdFold } from "../dyn-read.js"; // (#2984)
 import { mintDefinedFunc, pushDefinedFunc } from "../func-space.js"; // (#1916 S3b) stable-regime minting
+import { initializeFunctionPoisonPillContext } from "../function-poison-pill.js";
 import { buildClosureResultBoxing } from "../closures/result-boxing.js"; // (#4082) the single closure-result→externref decision
 import { emitCollectionIteratorVec, ensureMapGroupBy } from "../map-runtime.js"; // (#42) native Set/Map → vec, shared with spread / Array.from; (#3149) native Map.groupBy
 import { isCollectionReflectiveCallShape, tryCompileCollectionReflectiveCall } from "../collections-brand.js"; // (#2604/#3171) {Map,Set,WeakMap,WeakSet}.prototype.METHOD.call brand-check
@@ -8600,6 +8601,9 @@ function compileIIFE(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallEx
     labelMap: new Map(),
     savedBodies: [],
   };
+  // This fallback emits a real Wasm function instead of using the inline-IIFE
+  // fast path, so register its source strictness like every other source body.
+  initializeFunctionPoisonPillContext(ctx, liftedFctx, funcExpr);
 
   for (let i = 0; i < liftedFctx.params.length; i++) {
     liftedFctx.localMap.set(liftedFctx.params[i]!.name, i);

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -13,6 +13,7 @@ import {
   isOwnParamName,
 } from "../closures.js";
 import { installFrameTrap } from "../frame-trap.js";
+import { initializeFunctionPoisonPillContext } from "../function-poison-pill.js";
 import { emitCachedFuncClosureAccess } from "../closures/method-trampolines.js"; // (#3486) fnctor ctor-closure singleton
 import {
   provablyNonConstructableStatically,
@@ -1576,6 +1577,10 @@ function compileNewFunctionDeclaration(
     labelMap: new Map(),
     savedBodies: [],
   };
+  // The synthesized fnctor body is still the source function's activation for
+  // legacy Function#caller. Register it before any prologue/body emission so
+  // outgoing calls carry the constructor source's strictness.
+  initializeFunctionPoisonPillContext(ctx, ctorFctx, funcDecl);
 
   // Set up param locals
   installFrameTrap(ctorFctx, ctorName);
@@ -1840,6 +1845,9 @@ function compileNewFunctionExpression(
     labelMap: new Map(),
     savedBodies: [],
   };
+  // `new (function () { ... })` lowers to a synthetic lifted function, but its
+  // body keeps the function expression's source strictness.
+  initializeFunctionPoisonPillContext(ctx, liftedFctx, funcExpr);
 
   for (let i = 0; i < liftedFctx.params.length; i++) {
     liftedFctx.localMap.set(liftedFctx.params[i]!.name, i);
@@ -3150,11 +3158,6 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
   // outer allocation degrades to the union layout (fat, never narrow).
   maybeEmitLayoutHint(ctx, fctx, expr);
 
-  // Handle `new function() { ... }(args)` — constructor with function expression
-  if (ts.isFunctionExpression(expr.expression)) {
-    return compileNewFunctionExpression(ctx, fctx, expr, expr.expression);
-  }
-
   // (#1528b) Unwrap parens AND `as`/`!`/type-assertion wrappers so the static
   // non-constructor guards below still fire on `new ((() => {}) as any)()` etc.
   // — the bare paren-only unwrap let cast arrows slip through to the dynamic
@@ -3177,6 +3180,15 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     }
     return cur;
   };
+
+  // Handle `new function() { ... }(args)` and the canonical parenthesized
+  // `new (function() { ... })(args)` spelling through the same source-body
+  // constructor path. The paren-only form previously fell through to a null
+  // placeholder without evaluating the constructor body at all.
+  const unwrappedLiteralCtor = unwrapNewTarget(expr.expression);
+  if (ts.isFunctionExpression(unwrappedLiteralCtor)) {
+    return compileNewFunctionExpression(ctx, fctx, expr, unwrappedLiteralCtor);
+  }
 
   // TextEncoder/TextDecoder are standard Web/Node classes, but standalone and
   // WASI builds cannot depend on host `env.TextEncoder_*` imports. The instance

--- a/src/codegen/function-poison-pill.ts
+++ b/src/codegen/function-poison-pill.ts
@@ -185,10 +185,11 @@ export function finalizeFunctionPoisonPillCalls(ctx: CodegenContext): void {
   ];
 
   const instrument = (body: Instr[], strict: boolean): void => {
-    const stack: Instr[][] = [body];
+    const stack: { body: Instr[]; strict: boolean }[] = [{ body, strict }];
     const seen = new Set<Instr[]>();
     while (stack.length > 0) {
-      const instrs = stack.pop()!;
+      const region = stack.pop()!;
+      const instrs = region.body;
       if (seen.has(instrs)) continue;
       seen.add(instrs);
       for (let i = 0; i < instrs.length; i++) {
@@ -197,11 +198,16 @@ export function finalizeFunctionPoisonPillCalls(ctx: CodegenContext): void {
           (instr.op === "call" || instr.op === "return_call") && sourceFuncIdxs.has(instr.funcIdx);
         const dynamicSourceCall = instr.op === "call_ref" || instr.op === "return_call_ref";
         if (directSourceCall || dynamicSourceCall) {
-          const prefix = marker(strict);
+          const prefix = marker(region.strict);
           instrs.splice(i, 0, ...prefix);
           i += prefix.length;
         }
-        walkChildren(instr, (child) => stack.push(child));
+        walkChildren(instr, (child) =>
+          stack.push({
+            body: child,
+            strict: ctx.sourceFunctionStrictnessByBody.get(child) ?? region.strict,
+          }),
+        );
       }
     }
   };

--- a/tests/issue-3017-function-poison-pill.test.ts
+++ b/tests/issue-3017-function-poison-pill.test.ts
@@ -64,6 +64,81 @@ const IMMEDIATE_CALLER_STRICTNESS = `
   }
 `;
 
+const STRICT_FUNCTION_EXPRESSION_CALLER = `
+  export function test(): number {
+    function probe(): number {
+      try {
+        (probe as any).caller;
+        return 0;
+      } catch (error) {
+        return 1;
+      }
+    }
+
+    return (function(): number {
+      "use strict";
+      return probe();
+    })();
+  }
+`;
+
+const STRICT_CONSTRUCTOR_CALLER = `
+  export function test(): number {
+    function probe(): void {
+      (probe as any).caller;
+    }
+    function StrictConstructor(): void {
+      "use strict";
+      probe();
+    }
+
+    try {
+      new StrictConstructor();
+      return 0;
+    } catch (error) {
+      return 1;
+    }
+  }
+`;
+
+const STRICT_ANONYMOUS_CONSTRUCTOR_CALLER = `
+  export function test(): number {
+    function probe(): void {
+      (probe as any).caller;
+    }
+
+    try {
+      new (function(): void {
+        "use strict";
+        probe();
+      })();
+      return 0;
+    } catch (error) {
+      return 1;
+    }
+  }
+`;
+
+const INHERITED_STRICT_FUNCTION_EXPRESSION_CALLER = `
+  export function test(): number {
+    function probe(): number {
+      try {
+        (probe as any).caller;
+        return 0;
+      } catch (error) {
+        return 1;
+      }
+    }
+
+    return (function(): number {
+      "use strict";
+      return (function(): number {
+        return probe();
+      })();
+    })();
+  }
+`;
+
 describe("#3017 — Function poison-pill semantics", () => {
   for (const target of [undefined, "standalone"] as const) {
     const lane = target ?? "host";
@@ -74,6 +149,22 @@ describe("#3017 — Function poison-pill semantics", () => {
 
     it(`${lane}: only the immediate strict caller poisons a sloppy self-read`, async () => {
       expect(await run(IMMEDIATE_CALLER_STRICTNESS, target)).toBe(10);
+    });
+
+    it(`${lane}: a strict anonymous function expression poisons its sloppy callee`, async () => {
+      expect(await run(STRICT_FUNCTION_EXPRESSION_CALLER, target)).toBe(1);
+    });
+
+    it(`${lane}: a strict constructor poisons its sloppy callee`, async () => {
+      expect(await run(STRICT_CONSTRUCTOR_CALLER, target)).toBe(1);
+    });
+
+    it(`${lane}: a strict anonymous constructor poisons its sloppy callee`, async () => {
+      expect(await run(STRICT_ANONYMOUS_CONSTRUCTOR_CALLER, target)).toBe(1);
+    });
+
+    it(`${lane}: a function expression inherits strictness from its enclosing function`, async () => {
+      expect(await run(INHERITED_STRICT_FUNCTION_EXPRESSION_CALLER, target)).toBe(1);
     });
   }
 


### PR DESCRIPTION
## Summary

- preserve source strictness inside inlined function-expression IIFE instruction regions
- register synthesized declaration- and expression-constructor bodies as source activations
- execute parenthesized anonymous constructor bodies instead of lowering them to a null placeholder
- add focused GC and standalone regressions and update the #3017 implementation record

## Root cause

The legacy `Function#caller` pass classified an entire Wasm function body with one strictness bit. Inlined IIFEs and synthesized constructor bodies do not align one-to-one with ordinary Wasm source bodies, so calls emitted from those activations inherited the wrong strictness or were never executed.

## Test262 impact

Maintained standalone, official scope, full runtime-eval interpreter:

- before: **83/97 pass**, 14 fail, 0 compile errors
- after: **92/97 pass**, 5 fail, 0 compile errors
- exact FAIL → PASS: `6gs`, `16gs`, `18gs`, `19gs`, `20gs`, `38gs`, `41gs`, `44gs`, `47gs`
- remaining: dynamic Function constructor (`8gs`, `10gs`, `95gs`), getter activation (`96gs`), bound-call forwarding (`97gs`)

This reduces the freshly harvested ES5 Function-object residual from 98 to 89. The separate ES5 `with` residual remains 73; its dominant closure-capture compiler gate is tracked by #4206/#4264.

## Verification

- focused GC + standalone poison-pill and construct suites: **28/28 pass**
- maintained `built-ins/Function/15.3.5.4_2-*`: **92/97 pass**
- `pnpm run typecheck`
- targeted Biome lint
- issue integrity
- LOC/function budgets
- complete pre-push gate

Refs #3017