### PR TITLE
fix(annexb): preserve repeated block function identity

### DIFF
--- a/plan/issues/2552-annexb-phase2-rework-tdz-var-hotpath-regression.md
+++ b/plan/issues/2552-annexb-phase2-rework-tdz-var-hotpath-regression.md
@@ -13,6 +13,11 @@ language_feature: annex-b, block-functions
 goal: es5
 parent: 2200
 related: [2200, 1764]
+loc-budget-allow:
+  - src/codegen/context/types.ts
+  - src/codegen/expressions/call-identifier.ts
+  - src/codegen/expressions/call-tail-dispatch.ts
+  - src/codegen/expressions/eval-inline.ts
 origin: "2026-06-19 — #2200 Phase 2 (PR #1769) failed the full test262-regression gate -1180; parked Phase-1-only. This is the rework follow-up."
 ---
 
@@ -243,3 +248,61 @@ read/assignment-read and the mutable-binding read/`f = 123` value semantics
 
 Expected merge_group delta: the -10 recovered, no new regressions → **net ≥ 0**.
 On landing, `#2200` closes (both Annex B phases complete).
+
+## Repeated declaration-object slice (2026-08-11, standalone refresh)
+
+The latest forced standalone baseline (`2026-08-11 19:17`, oracle v13,
+48,661 raw rows) does not contain the historical “91” as an exact maintained
+population. Rebuilding the repository report's first-match
+`annex-b-function-eval` heuristic yields **122** non-passing rows: **89 ES5**,
+20 ES2015, and 13 ES2027. The ES5 89 is the reproducible selector/denominator
+for this work; it is a mixed Annex-B/eval bucket rather than one mechanism.
+
+The highest-yield coherent mechanism inside it was the generated function-scope
+`*-existing-block-fn-update.js` family. The current Test262 checkout has eight
+such function-code rows, all failing on main because the second declaration
+stored the first declaration's function object again. The fresh maintained
+baseline contains seven of those rows; the eighth
+(`if-decl-else-decl-b-func-existing-block-fn-update.js`) arrived after that
+baseline snapshot and was therefore measured from the current corpus rather
+than silently dropped.
+
+**Root cause.** Function-scope Annex B correctly has a live, flag-gated outer
+binding, but `ctx.funcMap` and capture metadata are keyed by bare function name.
+The hoist pass therefore compiled only one body for multiple same-named block
+declarations. Every declaration-site assignment fetched that same `funcMap`
+entry, and a direct call bypassed the live outer binding entirely. This is an
+AST-hoist/codegen binding-identity defect, not an IR-selection defect; adding a
+new IR route would not restore declaration identity.
+
+**Implementation boundary.** Multiple eligible, capture-free, zero-parameter
+ordinary declarations now compile declaration-specific function objects. Their
+name is recorded as a repeated Annex B outer binding, and direct calls dispatch
+through the live local so a skipped branch cannot pin the statically last body.
+The eligibility scan includes block, Annex-B `if`, and switch declaration
+positions, while excluding inner same-named block functions whose `var`
+substitution would be an early error. Lone declarations keep the existing
+direct-call path. Capturing/parameterized/async/generator duplicates remain
+parked because capture metadata is still name-keyed; widening this slice without
+per-declaration capture records produced an illegal/null closure path in the
+local canary.
+
+**Maintained A/B.** With the full standalone interpreter provider and one worker,
+the exact 40-row selector (eight function-code targets plus 32 already-passing
+global/eval controls) moved **32/40 → 40/40**. The final candidate also passed
+the two broader-sweep canaries for the nested-cancellation and lone-catch cases
+(**42/42** combined). A full current function-code sweep is **120/159** (38
+runtime failures, one compile error). Against the 155 overlapping fresh-baseline
+rows it is **110 → 117 pass**, with seven baseline failures recovered and **zero
+pass-to-nonpass regressions**; three of four newly added corpus rows pass,
+including the eighth target. Focused unit coverage passes on both GC and
+standalone (15/15).
+
+**Residuals.** The fresh ES5 report selector retains **82/89** baseline rows
+outside this slice. In the narrower current function-code directory, **39/159**
+remain non-passing: default-parameter skip (8), binding init (8), catch/try
+no-skip (7), existing-function update (5), existing-function no-init (3),
+mutable block scoping (3), early-error skip (3), `arguments` (1), and switch
+redeclaration diagnostics (1). The next repeated-declaration slice must first
+make capture/signature metadata declaration-keyed; it must not broaden the
+capture-free gate opportunistically.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -950,6 +950,14 @@ export interface FunctionContext {
    */
   annexBOuterBindings?: Set<string>;
   /**
+   * Subset of `annexBOuterBindings` whose name is shared by multiple eligible,
+   * capture-free declaration sites in the same var scope. Direct calls for
+   * these names must dispatch through the live outer-binding local because the
+   * executed branch, rather than the name-keyed funcMap winner, determines the
+   * callee.
+   */
+  annexBRepeatedOuterBindings?: Set<string>;
+  /**
    * For TDZ flag locals that have been boxed in an i32 ref cell so that
    * mutations propagate to closures that captured the flag (#1177).
    *

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -128,6 +128,14 @@ function localBindingShadowsCapturingFunction(
   return !!(callSignatures?.length || (declaration && ts.isParameter(declaration)));
 }
 
+function hasLiveFunctionBinding(ctx: CodegenContext, fctx: FunctionContext, name: string): boolean {
+  if (fctx.annexBRepeatedOuterBindings?.has(name)) return true;
+  const hasModuleBinding =
+    ctx.runtimeEvalGlobalFunctionBindings ||
+    (ctx.annexBModuleBindings?.has(name) === true && fctx.localMap.get(name) === undefined);
+  return hasModuleBinding && ctx.liveFuncBindingGlobals?.has(name) === true;
+}
+
 /**
  * (#742) Identifier-callee call dispatch — extracted verbatim from
  * compileCallExpression. Handles the cases where the call target is a bare
@@ -984,15 +992,13 @@ export function compileIdentifierCall(
     // interpreted closure. Such a binding must call its live externref global
     // through the generic apply bridge; a direct call to the declaration's
     // immutable funcIdx would ignore the replacement entirely.
-    // (#4182) A module-scope Annex B B.3.3.2 block-fn binding is live the same
-    // way: the value a call must invoke is whatever the last-evaluated
-    // declaration stored in the global (a direct funcMap call would pin the
-    // GDI winner forever). Locally-shadowed names keep their local resolution.
-    if (
-      (ctx.runtimeEvalGlobalFunctionBindings ||
-        (ctx.annexBModuleBindings?.has(funcName) === true && fctx.localMap.get(funcName) === undefined)) &&
-      ctx.liveFuncBindingGlobals?.has(funcName)
-    ) {
+    // (#4182/#2552) Annex B block-fn bindings are live the same way: the value
+    // a call must invoke is whatever declaration most recently evaluated. At
+    // module scope that value lives in a global; inside a function it lives in
+    // the flag-gated outer-binding local. A direct funcMap call would instead
+    // pin whichever declaration happened to compile last, even when its branch
+    // did not execute. Locally-shadowed names keep their local resolution.
+    if (hasLiveFunctionBinding(ctx, fctx, funcName)) {
       const liveCall = tryEmitInlineDynamicCall(ctx, fctx, expr, true);
       if (liveCall !== null) return liveCall;
     }

--- a/src/codegen/expressions/call-tail-dispatch.ts
+++ b/src/codegen/expressions/call-tail-dispatch.ts
@@ -154,6 +154,7 @@ function enterInlineIifeBindingScope(fctx: FunctionContext, names: ReadonlySet<s
       ? new Map(Array.from(fctx.annexBCancelled, ([name, ranges]) => [name, ranges.map((range) => ({ ...range }))]))
       : undefined,
     annexBOuterBindings: cloneNameSet(fctx.annexBOuterBindings),
+    annexBRepeatedOuterBindings: cloneNameSet(fctx.annexBRepeatedOuterBindings),
     moduleBindingShadowLocals: cloneNameMap(fctx.moduleBindingShadowLocals),
   };
 
@@ -179,6 +180,7 @@ function enterInlineIifeBindingScope(fctx: FunctionContext, names: ReadonlySet<s
     fctx.fnctorWidenedLocals?.delete(name);
     fctx.annexBCancelled?.delete(name);
     fctx.annexBOuterBindings?.delete(name);
+    fctx.annexBRepeatedOuterBindings?.delete(name);
     fctx.moduleBindingShadowLocals?.delete(name);
   }
 
@@ -220,6 +222,11 @@ function enterInlineIifeBindingScope(fctx: FunctionContext, names: ReadonlySet<s
     fctx.fnctorWidenedLocals = restoreNameSet(fctx.fnctorWidenedLocals, snapshot.fnctorWidenedLocals, names);
     fctx.annexBCancelled = restoreNameMap(fctx.annexBCancelled, snapshot.annexBCancelled, names);
     fctx.annexBOuterBindings = restoreNameSet(fctx.annexBOuterBindings, snapshot.annexBOuterBindings, names);
+    fctx.annexBRepeatedOuterBindings = restoreNameSet(
+      fctx.annexBRepeatedOuterBindings,
+      snapshot.annexBRepeatedOuterBindings,
+      names,
+    );
     fctx.moduleBindingShadowLocals = restoreNameMap(
       fctx.moduleBindingShadowLocals,
       snapshot.moduleBindingShadowLocals,

--- a/src/codegen/expressions/eval-inline.ts
+++ b/src/codegen/expressions/eval-inline.ts
@@ -1256,6 +1256,7 @@ function compileInlinedEvalStatements(
         preHoistedLetConstSlots: fctx.preHoistedLetConstSlots,
         annexBCancelled: fctx.annexBCancelled,
         annexBOuterBindings: fctx.annexBOuterBindings,
+        annexBRepeatedOuterBindings: fctx.annexBRepeatedOuterBindings,
       }
     : undefined;
 
@@ -1267,6 +1268,7 @@ function compileInlinedEvalStatements(
     fctx.preHoistedLetConstSlots = undefined;
     fctx.annexBCancelled = undefined;
     fctx.annexBOuterBindings = undefined;
+    fctx.annexBRepeatedOuterBindings = undefined;
   }
 
   try {
@@ -1317,6 +1319,7 @@ function compileInlinedEvalStatements(
       fctx.preHoistedLetConstSlots = savedBindingState.preHoistedLetConstSlots;
       fctx.annexBCancelled = savedBindingState.annexBCancelled;
       fctx.annexBOuterBindings = savedBindingState.annexBOuterBindings;
+      fctx.annexBRepeatedOuterBindings = savedBindingState.annexBRepeatedOuterBindings;
     }
   }
 }

--- a/src/codegen/statements.ts
+++ b/src/codegen/statements.ts
@@ -15,9 +15,15 @@
  *   - statements/shared.ts         — utilities shared across all sub-modules
  */
 import { ts } from "../ts-api.js";
-import { annexBUpdatesExistingVarBinding } from "./annexb-cancel.js";
+import {
+  annexBDeclaringRange,
+  annexBUpdatesExistingVarBinding,
+  enclosingVarScope,
+  hasInterveningLexicalBinder,
+} from "./annexb-cancel.js";
 import { tryCompileAnnexBModuleBlockFnEvaluation } from "./annexb-global-live-binding.js";
-import { emitCachedFuncClosureAccess } from "./closures.js";
+import { addFunctionOwnLocals } from "./binding-info.js";
+import { collectReferencedIdentifiers, emitCachedFuncClosureAccess } from "./closures.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { getLocalType } from "./context/locals.js";
 import { attachSourcePos, getSourcePos } from "./context/source-pos.js";
@@ -77,6 +83,100 @@ function markStatementPos(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.S
   if (pos && fctx.body.length > bodyLenBefore) {
     attachSourcePos(fctx.body[bodyLenBefore]!, pos);
   }
+}
+
+/**
+ * Can a repeated Annex B declaration safely claim its own funcMap slot without
+ * changing the capture layout? The current closure metadata is keyed by bare
+ * function name, so compiling a second CAPTURING declaration would replace the
+ * first declaration's capture record. Keep this slice on zero-parameter,
+ * capture-free ordinary functions; the generated B.3.3 `existing-block-fn-
+ * update` family is exactly that shape. Other declarations retain the previous
+ * valid (but first-body) behavior until capture metadata becomes per-decl.
+ */
+function canCompileDistinctAnnexBFunction(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  stmt: ts.FunctionDeclaration,
+): boolean {
+  if (stmt.parameters.length > 0 || stmt.asteriskToken) return false;
+  if (stmt.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword)) return false;
+  if (!stmt.body) return false;
+
+  const ownLocals = new Set<string>();
+  addFunctionOwnLocals(stmt, ownLocals);
+  const referenced = new Set<string>();
+  for (const bodyStmt of stmt.body.statements) {
+    collectReferencedIdentifiers(bodyStmt, referenced, ownLocals);
+  }
+  for (const name of referenced) {
+    if (name === "eval" || fctx.localMap.has(name) || (ctx.nestedFuncCaptures.get(name)?.length ?? 0) > 0) return false;
+  }
+  return true;
+}
+
+/**
+ * Which eligible declarations share this declaration's Annex B outer binding
+ * in the same function/script scope? A name-only test is not
+ * enough: a deeper same-named block declaration can be cancelled by Annex B's
+ * early-error substitution rule, and a lone declaration may temporarily lose
+ * funcMap ownership while its surrounding catch/block is lowered. Neither case
+ * should claim a declaration-specific slot.
+ */
+function eligibleAnnexBOuterBindingDeclarations(stmt: ts.FunctionDeclaration): ts.FunctionDeclaration[] {
+  const name = stmt.name?.text;
+  if (!name || !isEligibleAnnexBOuterBindingDeclaration(stmt, name)) return [];
+
+  let scope: ts.Node = stmt.parent;
+  while (!ts.isSourceFile(scope) && !ts.isFunctionLike(scope)) {
+    if (!scope.parent) return [];
+    scope = scope.parent;
+  }
+  const scanRoot = ts.isSourceFile(scope) ? scope : (scope as ts.FunctionLikeDeclarationBase).body;
+  if (!scanRoot) return [];
+
+  const declarations: ts.FunctionDeclaration[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name?.text === name &&
+      isEligibleAnnexBOuterBindingDeclaration(node, name)
+    ) {
+      declarations.push(node);
+    }
+    if (ts.isFunctionLike(node)) return;
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(scanRoot, visit);
+  return declarations;
+}
+
+function isEligibleAnnexBOuterBindingDeclaration(stmt: ts.FunctionDeclaration, name: string): boolean {
+  if (annexBDeclaringRange(stmt) === null || hasInterveningSameNameBlockFunction(stmt, name)) return false;
+  const scope = enclosingVarScope(stmt);
+  return scope !== null && !hasInterveningLexicalBinder(stmt.parent, name, scope);
+}
+
+/**
+ * Replacing an inner block function with `var name` is an early error when an
+ * enclosing block already lexically declares a same-named function. Such an
+ * inner declaration is block-local only, even though the legacy name-keyed
+ * hoist analysis conservatively associates it with the outer Annex B name.
+ */
+function hasInterveningSameNameBlockFunction(stmt: ts.FunctionDeclaration, name: string): boolean {
+  let node: ts.Node | undefined = stmt.parent.parent;
+  while (node && !ts.isSourceFile(node) && !ts.isFunctionLike(node)) {
+    if (
+      ts.isBlock(node) &&
+      node.statements.some(
+        (candidate) => candidate !== stmt && ts.isFunctionDeclaration(candidate) && candidate.name?.text === name,
+      )
+    ) {
+      return true;
+    }
+    node = node.parent;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -237,6 +337,26 @@ function compileStatementInner(ctx: CodegenContext, fctx: FunctionContext, stmt:
     if (funcName && fctx.annexBOuterBindings?.has(funcName)) {
       const outerLocal = fctx.localMap.get(funcName);
       const flagLocal = fctx.tdzFlagLocals?.get(funcName);
+      const repeatedDeclarations = eligibleAnnexBOuterBindingDeclarations(stmt);
+      const repeatedSafe =
+        repeatedDeclarations.length > 1 &&
+        repeatedDeclarations.every((declaration) => canCompileDistinctAnnexBFunction(ctx, fctx, declaration));
+      if (repeatedSafe) {
+        if (!fctx.annexBRepeatedOuterBindings) fctx.annexBRepeatedOuterBindings = new Set();
+        fctx.annexBRepeatedOuterBindings.add(funcName);
+      }
+      // (#2552) `funcMap` is keyed by bare name, so the hoist pre-pass keeps
+      // only one body for multiple same-named block declarations. Annex B
+      // requires EACH declaration to produce its own function object when its
+      // statement evaluates: a later block must replace the outer binding with
+      // its own body, not store the first block's closure again. Compile this
+      // exact declaration when another node currently owns the name. The
+      // declaration compiler updates funcMap/owner atomically, and the closure
+      // singleton is target-index-aware, so later declarations receive distinct
+      // cached wrappers while the single-declaration hot path is unchanged.
+      if (ctx.funcMapOwnerDecl.get(funcName) !== stmt && repeatedSafe) {
+        compileNestedFunctionDeclaration(ctx, fctx, stmt);
+      }
       const fnIdx = ctx.funcMap.get(funcName);
       if (outerLocal !== undefined && flagLocal !== undefined && fnIdx !== undefined) {
         const closureType = emitCachedFuncClosureAccess(ctx, fctx, funcName, fnIdx);

--- a/tests/issue-2552-annexb-phase2.test.ts
+++ b/tests/issue-2552-annexb-phase2.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
 import { compileToWasm } from "./equivalence/helpers.js";
 
 /**
@@ -29,6 +30,24 @@ async function runString(src: string): Promise<unknown> {
 async function runNumber(src: string): Promise<number> {
   const exports = await compileToWasm(src);
   return (exports.test as () => number)();
+}
+
+async function runForTarget(src: string, target: "gc" | "standalone"): Promise<number> {
+  const result = await compile(src, {
+    target,
+    fileName: "/issue-2552-repeated-blockfn.js",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments: false,
+  });
+  expect(result.success, result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const imports = target === "standalone" ? {} : buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  if ("setExports" in imports && typeof imports.setExports === "function") {
+    imports.setExports(instance.exports);
+  }
+  return (instance.exports.test as () => number)();
 }
 
 describe("#2552 Phase 2 — case-B outer-binding lifecycle (observed)", () => {
@@ -74,6 +93,39 @@ describe("#2552 Phase 2 — case-B outer-binding lifecycle (observed)", () => {
         let r: any; { function f() { return 1; } } r = f;
         return typeof r; }`),
     ).toBe("function");
+  });
+});
+
+describe("#2552 Phase 2 — repeated block declarations update the live outer binding", () => {
+  it.each(["gc", "standalone"] as const)("%s: each declaration contributes its own function object", async (target) => {
+    const value = await runForTarget(
+      `export function test() {
+        let score = 0;
+
+        { function f1() { return 1; } }
+        { function f1() { return 2; } }
+        if (f1() === 2) score += 1;
+        const f1Value = f1;
+        if (f1Value() === 2) score += 2;
+
+        { function f2() { return 1; } }
+        if (false) { function f2() { return 2; } }
+        if (f2() === 1) score += 4;
+
+        function nestedCancellation() {
+          {
+            function f3() { return 1; }
+            { function f3() { return 2; } }
+          }
+          return f3();
+        }
+        if (nestedCancellation() === 1) score += 8;
+
+        return score;
+      }`,
+      target,
+    );
+    expect(value).toBe(15);
   });
 });
 


### PR DESCRIPTION
## Summary

- compile declaration-specific function objects for safe repeated Annex B B.3.3.1 block/if/switch declaration sites
- route repeated direct calls through the live outer binding while retaining the existing path for lone and capture-bearing declarations
- record the fresh maintained selector, A/B evidence, exact residuals, and declaration-keyed capture boundary in plan issue #2552

## Measurement

- fresh maintained ES5 report selector: **89 rows** (not the historical heuristic 91)
- exact current family: **32/40 → 40/40**; all 32 controls preserved
- function-code overlap: **110/155 → 117/155** with zero pass-to-nonpass regressions
- current full function-code: **120/159**; 39 honest residuals

## IR ownership

This defect occurs before IR selection: name-keyed AST hoist metadata discarded which repeated declaration produced each function object. Adding an IR route would not recover that identity. The fix is therefore scoped to declaration identity and live-binding dispatch; it does not add a competing legacy implementation of an IR semantic operation.

## Validation

- focused GC + standalone Vitest: **15/15**
- final maintained standalone selector plus canaries: **42/42** (`20260811-223547`)
- maintained standalone full function-code: **120/159** (`20260811-222551`)
- typecheck, Prettier, Biome, LOC/function budgets, oracle/coercion ratchets, issue integrity, and diff checks

Plan issue: `plan/issues/2552-annexb-phase2-rework-tdz-var-hotpath-regression.md`
