### PR TITLE
fix(eval): defer live global calls to runtime dispatch

### DIFF
--- a/plan/issues/4221-non-callable-call-typeerror-and-bound-fn-poison.md
+++ b/plan/issues/4221-non-callable-call-typeerror-and-bound-fn-poison.md
@@ -3,6 +3,7 @@ id: 4221
 title: "Calling a non-callable answers undefined instead of throwing TypeError; bound functions do not poison caller/arguments"
 status: done
 completed: 2026-08-08
+updated: 2026-08-11
 sprint: current
 created: 2026-08-08
 priority: high
@@ -11,7 +12,7 @@ feasibility: medium
 task_type: bug
 area: codegen
 goal: es5
-related: [1888, 2106, 2151, 3673, 4220]
+related: [1888, 2106, 2151, 2552, 2929, 3673, 4137, 4220]
 loc-budget-allow:
   # object-runtime.ts (+43): the absent-callee TypeError has to be emitted at
   # the site that RESOLVES the method — `__extern_method_call`'s $Object arm,
@@ -195,3 +196,49 @@ pass of this very measurement reported **38** of them.
   `length`/`name` on bound functions; out of the ES5 pool.
 - `language/arguments-object` — `arguments.callee` as a real own property with
   descriptor attributes, and `arguments.constructor`. Untouched.
+
+## Follow-up — 2026-08-11: runtime eval invalidates a primitive callee fact
+
+The fresh 48,661-row standalone baseline left 89 exact ES5 Annex B residuals.
+After excluding the seven `function-code/*-existing-block-fn-update` rows owned
+by PR #4387, the largest coherent eval family was the 16 direct+indirect
+`eval-code/global-*-eval-global-existing-var-update.js` files. Every one failed
+with `TypeError: f is not a function` for this shape:
+
+```js
+var f = 123;
+eval('{ function f() { return 1; } }');
+f();
+```
+
+The provider and global pull-sync were already correct: the assertion
+`typeof f === "function"` passed after eval. The throw came **before IR
+selection**. `tryNonCallableValueCall` trusted the checker's fact for the
+original numeric initializer and emitted an unconditional TypeError, so the
+updated live global never reached the native IsCallable dispatcher. There is
+therefore no competing IR lowering to repair or prefer for this slice; the
+pre-IR guard must yield when a linked standalone eval can replace the binding.
+
+The follow-up adds that narrow exception. It applies only when all of these are
+true: standalone runtime eval is enabled, the callee is a bare identifier, it
+is not shadowed by a local, and it is a caller/provider-synchronised global
+`var` or global lexical binding. The ordinary primitive-callee rule remains in
+force for modules without runtime eval, local primitive bindings, and the host
+lane. A still-non-callable live value reaches the runtime dispatcher and throws
+the same TypeError after the specified callee/argument evaluation order.
+
+Maintained standalone A/B, full interpreter provider, one worker, exact filter
+`global-existing-var-update`:
+
+| build | pass / 24 | eval failures | controls / other |
+| --- | ---: | ---: | ---: |
+| fresh `origin/main` (`ebba42dfff7ceb`) | 5 | 16 | 5 pass, 3 fail |
+| follow-up | 21 | **0** | 5 pass, 3 fail |
+
+The delta is exactly **+16, 0 regressions**. The three surviving failures are
+the non-eval `global-code/{block,switch-*}-global-existing-var-update.js` rows;
+they are a separate AOT Annex B publication gap and are deliberately not folded
+into this call-guard change. The focused regression executes both direct and
+indirect eval through the linked interpreter provider, while the original 14
+#4221 tests preserve primitive TypeErrors, evaluation order, dynamic-call
+controls, bound-function guards, and host compilation safety.

--- a/src/codegen/expressions/calls-guards.ts
+++ b/src/codegen/expressions/calls-guards.ts
@@ -62,6 +62,20 @@ export const NEVER_CALLABLE_FACT_KINDS = new Set([
 ]);
 
 /**
+ * Standalone runtime-eval global pull-sync can replace an AOT binding after
+ * the checker has classified its initializer. In particular, Annex B B.3.3.3
+ * turns `var f = 123` into a callable when global eval executes a block-level
+ * `function f(){}`. The primitive-callee guard runs before call IR selection,
+ * so it must leave those live globals to the native IsCallable dispatcher.
+ */
+function runtimeEvalMayReplaceCallee(ctx: CodegenContext, fctx: FunctionContext, callee: ts.Expression): boolean {
+  if (!ctx.standalone || ctx.runtimeEvalGlobalFunctionBindings !== true || !ts.isIdentifier(callee)) return false;
+  const name = callee.text;
+  if (fctx.localMap.has(name)) return false;
+  return (ctx.globalObjectVarBindings?.has(name) ?? false) || (ctx.globalLexicalBindings?.has(name) ?? false);
+}
+
+/**
  * (#4221) §13.3.6.2 EvaluateCall steps 4-5 — calling a value that is provably
  * NOT callable must throw a TypeError. Before this guard the callee fell to
  * `compileCallExpression`'s last-resort arm, which compiles the callee + args
@@ -91,6 +105,11 @@ export function tryNonCallableValueCall(
   const callee = unwrapCallee(expr.expression);
   // `super(...)` / `import(...)` are not value calls.
   if (callee.kind === ts.SyntaxKind.SuperKeyword || callee.kind === ts.SyntaxKind.ImportKeyword) return undefined;
+
+  // Global eval can change the value and representation of these bindings
+  // after static type analysis. Preserve runtime IsCallable semantics instead
+  // of baking the initializer's primitive fact into an unconditional throw.
+  if (runtimeEvalMayReplaceCallee(ctx, fctx, callee)) return undefined;
 
   const fact = ctx.oracle.typeFactOf(callee);
   if (!NEVER_CALLABLE_FACT_KINDS.has(fact.kind) && !isFreshlyConstructedNonCallable(ctx, callee, fact.kind)) {

--- a/tests/issue-2929-cd-global-materialization.test.ts
+++ b/tests/issue-2929-cd-global-materialization.test.ts
@@ -123,6 +123,28 @@ if (d.configurable) throw new Error('a script var stays configurable:false acros
     );
   });
 
+  it("Annex B eval functions replace and call an existing primitive script var", async () => {
+    // The provider already published both closures correctly: `typeof direct`
+    // and `typeof indirect` read "function" after pull-sync. The pre-IR
+    // primitive-callee guard nevertheless trusted the original numeric
+    // initializers and emitted unconditional TypeErrors at both call sites.
+    // These bindings are runtime-mutable, so their calls must reach the native
+    // IsCallable dispatcher instead.
+    await runScript(
+      `var direct = 123;
+eval('{ function direct() { return 41; } }');
+if (typeof direct !== 'function') throw new Error('direct binding was not updated');
+if (direct() !== 41) throw new Error('direct eval closure was not callable');
+
+var indirect = 123;
+(0,eval)('{ function indirect() { return 42; } }');
+if (typeof indirect !== 'function') throw new Error('indirect binding was not updated');
+if (indirect() !== 42) throw new Error('indirect eval closure was not callable');
+`,
+      "cd/annexb-existing-primitive-call",
+    );
+  });
+
   it("delete of an eval-created global severs the compiled read path", async () => {
     // No static storage was ever allocated for the name, so the AOT read is the
     // HasProperty-guarded dynamic global read — removing the property makes it


### PR DESCRIPTION
## Summary

- stop the pre-IR non-callable guard from baking stale primitive facts for standalone globals synchronized by runtime eval
- let the existing native IsCallable dispatcher decide after direct or indirect eval replaces the binding
- document the exact pre-IR boundary and the three separate AOT Annex B publication residuals in plan issue #4221

## Test262 impact

- maintained `global-existing-var-update` selector: 5/24 -> 21/24
- all 16 direct and indirect eval failures now pass
- five existing controls remain pass
- zero pass regressions

## Validation

- full interpreter provider integration: 12/12
- #4221 non-callable and dispatch controls: 14/14
- maintained standalone selector: 21/24 with the three distinct AOT publication rows unchanged
- typecheck, formatting, lint, IR fallback, stack balance, LOC, issue integrity, and pre-push gates

## IR boundary

The static primitive-callee guard executes before call IR selection. A linked eval can mutate the live global after the checker classifies its initializer, so IR never receives a valid call if this guard throws early. This narrow exception preserves the single native runtime IsCallable implementation instead of adding competing call semantics.