### PR TITLE
feat(with): capture object environments in closures

### DIFF
--- a/plan/issues/4206-with-statement-es5-standalone-residue.md
+++ b/plan/issues/4206-with-statement-es5-standalone-residue.md
@@ -1,10 +1,10 @@
 ---
 id: 4206
-title: "`with` statement, ES5 standalone: 105 failing files (39 `#1387` gate refusals + 66 runtime wrong-answers). Tier-2 dynamic `with` was measured BLIND in standalone and is fixed; the residue is blocked by a non-`with` global-binding defect"
+title: "`with` statement, ES5 standalone: 73-row residue reduced to 51; first IR closure-environment slice converts 22/39 legacy gate rows"
 status: ready
 sprint: current
 created: 2026-08-07
-updated: 2026-08-07
+updated: 2026-08-11
 priority: high
 horizon: xl
 feasibility: hard
@@ -14,7 +14,7 @@ area: codegen
 es_edition: 5
 language_feature: with-statement
 goal: es5
-related: [671, 1387, 3025, 4179, 4205, 1472]
+related: [671, 1387, 3025, 4179, 4205, 4231, 4264, 1472]
 origin: "2026-08-07 W23 census of the ES5 standalone failing residue (published standalone baseline 20260807, oracle v13). Supersedes the 2026-03 stub #671."
 loc-budget-allow:
   # +5 lines of WIRING only (one import, one call, a 3-line pointer comment).
@@ -24,6 +24,16 @@ loc-budget-allow:
   # any hook at all trips it; moving an unrelated sibling marker out purely to
   # buy back 5 lines would enlarge the diff for a budget technicality.
   - src/codegen/declarations/object-shape-widening.ts
+  # #4206 closure slice: the backend-neutral contract and codegen adapter live
+  # in new modules. These are the unavoidable IR selector/lowerer hooks plus
+  # the FunctionContext field and selector/lowerer hooks.
+  - src/ir/from-ast.ts
+  - src/ir/select.ts
+  - src/codegen/context/types.ts
+func-budget-allow:
+  # Four-line statement-dispatch hook; all selection logic is in the dedicated
+  # isPhase1WithStatement helper and ir/with-environment subsystem.
+  - src/ir/select.ts::isPhase1StatementListInScope
 ---
 
 # #4206 — the `with` statement residue, correctly sized
@@ -118,11 +128,10 @@ Representative: `language/statements/with/S12.10_A1.12_T1.js`,
 
 ## Acceptance criteria
 
-- [x] **Measured count per rejection reason** for the 39 gate-refusal files:
-      39/39 are `body contains a nested function or class`; the predicted
-      ~6 spread/accessor/computed-key/non-literal-target files do not exist.
-      Not compiled — cohort A is measured DOWNSTREAM of cohort D (see the W26
-      record), so it is deliberately deferred rather than attempted.
+- [x] **Measured count and outcome for the 39 gate-refusal files:** 39/39 were
+      the nested-function/class gate. The first callable function-expression
+      slice now yields **22 pass / 7 runtime fail / 10 explicit constructor
+      refusals**; see the 2026-08-11 record.
 - [ ] The 5 `S10.2.2_A1_T*` scope-chain files resolve identifiers through the
       object environment record. **Not attempted.**
 - [ ] `with(null)` / `with(undefined)` throw TypeError. **Not attempted**
@@ -346,3 +355,106 @@ environment would land those 39 on exactly the failures cohort D already has, so
 expected yield ≈ 0. Sequence it after D, or not at all until D moves.
 
 Session-wide context: `plan/agent-context/session-2026-08-07-lead-handoff.md`.
+
+---
+
+# 2026-08-11 — first closure-captured Object Environment Record slice
+
+## Outcome
+
+The fresh program residue was **73 failing ES5 standalone rows**. The original
+39-row closure gate was re-run on canonical `main@ebba42dfff7ceb` with the FULL
+interpreter provider. This slice converts **22/39** to pass, so the ES5 residue
+falls to **51**. It is a real semantic slice, not a diagnostic deletion:
+
+| original 39-row gate cohort | base | head |
+| --- | ---: | ---: |
+| pass | 0 | **22** |
+| runtime fail | 0 | 7 |
+| compile error | 39 | **10** |
+
+The ten remaining compile errors are the `S12.10_A{1,3}.8_T*` constructor
+rows. `new` needs a constructible-closure ABI that carries the captured
+environment, so the shared selector retains an explicit `constructible closure
+capture` refusal rather than compiling to a runtime `TypeError`.
+
+## Root cause and contract
+
+The statement compiler already kept an active `withScopes` entry while
+compiling the body, but closure construction captured only identifier values.
+Once control left the statement, the lifted function had no Object Environment
+Record and bare names could not perform invocation-time `HasBinding`/Get/Set.
+
+`src/ir/with-environment.ts` now owns the backend-neutral contract:
+
+- capture the environment **receiver reference**, never a property snapshot;
+- preserve outer-to-inner scope ordering;
+- admit ordinary synchronous function expressions only;
+- explicitly refuse arrows, declarations/hoisting, async/generators,
+  classes/methods/accessors, and construction.
+
+`src/ir/select.ts` and `src/ir/from-ast.ts` exercise that contract through an
+actual first IR slice: a closed inline object literal, block body, no
+field/declaration collision, and at least one admitted closure. The IR binds
+fields as `withField` entries, emits ordinary `object.get`/`object.set`, captures
+the receiver in `closure.new`, and rehydrates the property binding in the lifted
+body. The regression test asserts `irBodyEmitted: true` and executes the module
+host-free; this is not a legacy-only bypass.
+
+The maintained standalone lowering consumes the same contract for the larger
+measured surface (struct and dynamic externref receivers). Its normal WasmGC
+closure ABI and JS-host callback capture struct carry the hidden receiver, then
+recreate `withScopes` before body compilation. The lifted function's parameters
+and own `var` bindings are added to the scope's blocked names because its own
+Declarative Environment precedes the captured Object Environment Record.
+
+## Maintained A/B and controls
+
+Command (both arms, same 190 exact paths):
+
+```sh
+TEST262_TARGET=standalone TEST262_FULL_RUNTIME_EVAL=1 \
+TEST262_PATH_FILTER='language/statements/with|language/statements/function/S13.2.2_A17_T2.js|language/statements/function/S13.2.2_A19_' \
+TEST262_REPORTER=dot pnpm run test:262 -- --official-scope-only
+```
+
+| full filtered matrix | base | head | delta |
+| --- | ---: | ---: | ---: |
+| pass | 97 | **121** | **+24** |
+| pass→non-pass | — | **0** | 0 |
+
+The extra two improvements outside the 39-row ES5 cohort are the ES6
+`has-property-err.js` and `scope-var-close.js` rows. All **97/97 passing
+controls remain pass**. The maintained diff gate reports +24 net, zero
+regressions, and no compile-timeout noise.
+
+Full artifacts:
+
+- base: `test262-standalone-results-20260811-225827.jsonl` (97/190);
+- head: `test262-standalone-results-20260811-232846.jsonl` (121/190).
+
+After the full run, the constructor selector was narrowed so `new
+Test262Error(...)` does not look like construction of the captured closure. A
+maintained one-row rerun of `S13.2.2_A19_T8.js` confirms the only status change:
+the over-broad selector's compile error returns to its pre-existing assertion
+failure. Pass and regression arithmetic is unchanged; inferred final broad
+status is 121 pass / 54 fail / 15 compile error.
+
+## Remaining 17 rows in the original cohort
+
+- **10 constructor refusals:** constructible closure/environment ABI, named
+  above.
+- **2 early-return rows** (`A1.7_T3`, `A1.12_T3`): the function-local `var`
+  correctly shadows the object, but its uninitialized value is represented as
+  `null`, not `undefined`.
+- **2 abrupt-completion rows** (`A3.7_T4/T5`): the assertion-message path traps
+  in the pre-existing `__str_concat` null handling after an implicit-global
+  result mismatch.
+- **`S13.2.2_A17_T2`:** assigning a function value through the object
+  environment loses the callable carrier (`getRight()` returns `null`).
+- **`S13.2.2_A19_T7/T8`:** script-global ownership/hoisting assertions fail
+  before or outside the captured-environment read.
+
+This issue stays `ready`: the callable environment slice is complete and
+measured, while constructor capture and those independently named runtime
+mechanisms remain follow-up work.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -135,6 +135,11 @@ export { emitFuncRefAsClosure };
 import { spliceNullGuarded, emitDefaultReturnValue } from "./closures/param-emit-helpers.js";
 import type { ArrowClosureCapture } from "./closures/arrow-phases.js";
 import {
+  addWithEnvironmentCaptureNames,
+  planAdditionalWithEnvironmentCaptureNames,
+  rehydrateWithEnvironmentScopes,
+} from "./with-environment-capture.js";
+import {
   planClosureCaptures,
   mintClosureStructTypes,
   emitClosureParamDestructuring,
@@ -2253,7 +2258,7 @@ export function compileLiftedClosureBody(
       liftedFctx.body.push({ op: "local.set", index: localIdx });
     }
   }
-
+  rehydrateWithEnvironmentScopes(fctx, liftedFctx, closureName, arrowOwnLocals(arrow));
   // #1177: For TDZ-flagged captures, also extract the boxed flag ref into a
   // local in the lifted fctx and register it in `boxedTdzFlags` +
   // `tdzFlagLocals`. This makes existing TDZ-check call sites (calls.ts,
@@ -2851,13 +2856,8 @@ export function compileArrowAsClosure(
   // 2. Analyze captured variables (referenced/written free vars, outer-write +
   //    TDZ-flag boxing) and the self-recursive binding — see planClosureCaptures.
   const reachesDirectEval = functionMayReachDirectEval(arrow, ctx.oracle);
-  const { captures, selfBindingName } = planClosureCaptures(
-    ctx,
-    fctx,
-    arrow,
-    body,
-    reachesDirectEval ? fctx.boxedCaptures?.keys() : undefined,
-  );
+  const additionalCaptureNames = planAdditionalWithEnvironmentCaptureNames(fctx, reachesDirectEval);
+  const { captures, selfBindingName } = planClosureCaptures(ctx, fctx, arrow, body, additionalCaptureNames);
 
   // 3. Create struct type: field 0 = funcref, fields 1..N = captured vars
   //    For mutable captures, the field type is a ref cell (struct { value: T })
@@ -3329,7 +3329,7 @@ export function compileArrowAsCallback(
   // nested-function walk below. A transitive name is a real environment value
   // needed by that nested function even when a same-spelled user function is
   // present in the global `funcMap`.
-  const directReferencedNames = new Set(referencedNames);
+  const directReferencedNames = addWithEnvironmentCaptureNames(referencedNames, fctx);
 
   // A host callback can call a capturing nested declaration. Its callback
   // frame must carry that declaration's environment just like a lifted Wasm
@@ -3561,7 +3561,7 @@ export function compileArrowAsCallback(
       }
     }
   }
-
+  rehydrateWithEnvironmentScopes(fctx, cbFctx, cbName, ownLocals);
   // 4b. Convert ref/ref_null params from externref to their resolved types.
   //     The JS host passes all GC ref types as externref, so we need to convert
   //     them back at the start of the body.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -892,6 +892,8 @@ export interface FunctionContext {
         // into a local; bare names matching a field route to direct struct
         // get/set.
         kind: "static";
+        /** Hidden by-reference closure capture selected by ir/with-environment. */
+        captureName: string;
         localIdx: number;
         structTypeIdx: number;
         fields: FieldDef[];
@@ -903,6 +905,8 @@ export interface FunctionContext {
         // HasBinding gate (`__extern_has`) + `Get` (`emitDynGet`), falling back
         // to the outer lexical lowering when absent.
         kind: "dynamic";
+        /** Hidden by-reference closure capture selected by ir/with-environment. */
+        captureName: string;
         localIdx: number;
         blockedNames: Set<string>;
       }

--- a/src/codegen/with-environment-capture.ts
+++ b/src/codegen/with-environment-capture.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Codegen adapter for the backend-neutral `with` environment capture plan. */
+import { planWithEnvironmentCaptures } from "../ir/with-environment.js";
+import type { FunctionContext } from "./context/types.js";
+
+/** Merge hidden environment receivers with any direct-eval-forced captures. */
+export function planAdditionalWithEnvironmentCaptureNames(
+  fctx: FunctionContext,
+  includeBoxedCaptures: boolean,
+): ReadonlySet<string> | undefined {
+  const names = new Set<string>();
+  if (includeBoxedCaptures) {
+    for (const name of fctx.boxedCaptures?.keys() ?? []) names.add(name);
+  }
+  const plan = planWithEnvironmentCaptures(fctx.withScopes?.map((scope) => scope.captureName) ?? []);
+  for (const capture of plan) names.add(capture.bindingName);
+  return names.size > 0 ? names : undefined;
+}
+
+/** Add hidden environment receivers, then snapshot the callback worklist. */
+export function addWithEnvironmentCaptureNames(names: Set<string>, fctx: FunctionContext): Set<string> {
+  const plan = planWithEnvironmentCaptures(fctx.withScopes?.map((scope) => scope.captureName) ?? []);
+  for (const capture of plan) names.add(capture.bindingName);
+  return new Set(names);
+}
+
+/**
+ * Recreate the ordered Object Environment Record chain in a lifted body.
+ * Function-local bindings are added to each blocked set because the new
+ * declarative environment precedes the captured outer object environments.
+ */
+export function rehydrateWithEnvironmentScopes(
+  outerFctx: FunctionContext,
+  liftedFctx: FunctionContext,
+  ownerName: string,
+  ownBindings: ReadonlySet<string>,
+): void {
+  if (!outerFctx.withScopes?.length) return;
+  liftedFctx.withScopes = outerFctx.withScopes.map((scope) => {
+    const localIdx = liftedFctx.localMap.get(scope.captureName);
+    if (localIdx === undefined) {
+      throw new Error(`with-environment capture ${scope.captureName} was not materialized in ${ownerName}`);
+    }
+    return { ...scope, localIdx, blockedNames: new Set([...scope.blockedNames, ...ownBindings]) };
+  });
+}

--- a/src/codegen/with-scope.ts
+++ b/src/codegen/with-scope.ts
@@ -10,6 +10,7 @@
  */
 import { ts, forEachChild } from "../ts-api.js";
 import type { FieldDef, Instr, ValType } from "../ir/types.js";
+import { selectWithEnvironmentClosures } from "../ir/with-environment.js";
 import { reportError } from "./context/errors.js";
 import { pushBody, popBody } from "./context/bodies.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
@@ -174,12 +175,17 @@ export function compileWithBindingAssignment(
 }
 
 export function compileWithStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.WithStatement): void {
+  const closureSelection = selectWithEnvironmentClosures(stmt.statement);
+  if (!closureSelection.ok) {
+    reportWithStatementDiagnostic(ctx, stmt, closureSelection.reason);
+    return;
+  }
   const proof = proveObjectLiteralWithTarget(fctx, stmt.expression);
   // (#2663 Slice 1) Tier-1 (static closed-shape) is the zero-overhead fast path.
-  // A body with a nested function/class boundary is deferred (the closure can't
-  // capture the object environment yet) — route it to the dynamic path, which
-  // emits the matching diagnostic.
-  if (proof.ok && !containsNestedFunctionBoundary(stmt.statement)) {
+  // Ordinary synchronous function expressions may capture the receiver through
+  // the #4206 environment contract. The selector above refuses every other
+  // nested function/class boundary before either target tier is considered.
+  if (proof.ok) {
     const targetType = compileClosedObjectLiteralTarget(ctx, fctx, proof.expr);
     finalizeStaticWithScope(ctx, fctx, stmt, targetType, proof.keys, proof.integrity, /* guardInheritedKeys */ true);
     return;
@@ -194,19 +200,17 @@ export function compileWithStatement(ctx: CodegenContext, fctx: FunctionContext,
   // host `in`/get reflection), so without this every own-field read misses and
   // resolves to a bare global → ReferenceError. Conservative gates (all →
   // fall through to Tier-2, never a compile error): see `proveStructTypedWithTarget`.
-  if (!containsNestedFunctionBoundary(stmt.statement)) {
-    const structProof = proveStructTypedWithTarget(ctx, stmt);
-    if (structProof) {
-      const targetType = compileExpression(ctx, fctx, stmt.expression, undefined);
-      if (targetType && (targetType.kind === "ref" || targetType.kind === "ref_null")) {
-        finalizeStaticWithScope(ctx, fctx, stmt, targetType, new Set(), "plain", /* guardInheritedKeys */ false);
-        return;
-      }
-      // The proof said struct-typed but lowering did not yield a struct ref. The
-      // target is a side-effect-free identifier, so dropping it and re-routing to
-      // the dynamic path below re-evaluates it harmlessly (no double side effect).
-      if (targetType) fctx.body.push({ op: "drop" });
+  const structProof = proveStructTypedWithTarget(ctx, stmt);
+  if (structProof) {
+    const targetType = compileExpression(ctx, fctx, stmt.expression, undefined);
+    if (targetType && (targetType.kind === "ref" || targetType.kind === "ref_null")) {
+      finalizeStaticWithScope(ctx, fctx, stmt, targetType, new Set(), "plain", /* guardInheritedKeys */ false);
+      return;
     }
+    // The proof said struct-typed but lowering did not yield a struct ref. The
+    // target is a side-effect-free identifier, so dropping it and re-routing to
+    // the dynamic path below re-evaluates it harmlessly (no double side effect).
+    if (targetType) fctx.body.push({ op: "drop" });
   }
 
   // Any non-proven target — `with(fn())`, host objects, `any`-typed, etc. —
@@ -245,7 +249,8 @@ function finalizeStaticWithScope(
   }
 
   const structTypeIdx = targetType.typeIdx;
-  const localIdx = allocLocal(fctx, `__with_scope_${fctx.locals.length}`, targetType);
+  const captureName = `__with_scope_${fctx.locals.length}`;
+  const localIdx = allocLocal(fctx, captureName, targetType);
   fctx.body.push({ op: "local.set", index: localIdx });
 
   const typeName = ctx.typeIdxToStructName.get(structTypeIdx);
@@ -292,7 +297,7 @@ function finalizeStaticWithScope(
     }
   }
   const scopeFields = integrity === "frozen" ? fields.map((field) => ({ ...field, mutable: false })) : fields;
-  const scope = { kind: "static" as const, localIdx, structTypeIdx, fields: scopeFields, blockedNames };
+  const scope = { kind: "static" as const, captureName, localIdx, structTypeIdx, fields: scopeFields, blockedNames };
   (fctx.withScopes ??= []).push(scope);
   try {
     compileStatement(ctx, fctx, stmt.statement);
@@ -404,23 +409,11 @@ function proveStructTypedWithTarget(ctx: CodegenContext, stmt: ts.WithStatement)
  * reads inside the body are resolved at runtime via `emitDynamicWithGet`
  * (HasBinding gate + Get, falling back to the outer lowering when absent).
  *
- * Scope of THIS slice (READ only): writes/compound/inc-dec/`typeof`/`delete`
- * (Slices 2-3) still take their non-with lowering — they don't consult the
- * dynamic scope yet. `@@unscopables` (Slice 4) is not consulted; HasProperty is
- * treated as HasBinding. A body containing a nested function/class boundary is
- * rejected (the closure can't capture the object environment at runtime yet),
- * matching the Tier-1 boundary refusal.
+ * Ordinary synchronous function expressions may retain this scope entry via
+ * the #4206 environment capture contract. Other nested function/class forms
+ * are refused by the shared selector before dynamic lowering begins.
  */
 function compileDynamicWithStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.WithStatement): void {
-  if (containsNestedFunctionBoundary(stmt.statement)) {
-    reportWithStatementDiagnostic(
-      ctx,
-      stmt,
-      "body contains a nested function or class that could capture the object environment (Tier-2 dynamic with: deferred)",
-    );
-    return;
-  }
-
   // §14.11.7 step 1-3: evaluate the target and coerce to a uniform externref
   // receiver (struct ref / boxed any / host object all normalize to externref).
   const targetType = compileExpression(ctx, fctx, stmt.expression, { kind: "externref" });
@@ -431,7 +424,8 @@ function compileDynamicWithStatement(ctx: CodegenContext, fctx: FunctionContext,
   if (targetType.kind !== "externref") {
     coerceType(ctx, fctx, targetType, { kind: "externref" });
   }
-  const localIdx = allocLocal(fctx, `__with_dyn_${fctx.locals.length}`, { kind: "externref" });
+  const captureName = `__with_dyn_${fctx.locals.length}`;
+  const localIdx = allocLocal(fctx, captureName, { kind: "externref" });
   fctx.body.push({ op: "local.set", index: localIdx });
 
   // §14.11.7: ToObject(undefined|null) throws TypeError. A JS `undefined`/`null`
@@ -468,7 +462,7 @@ function compileDynamicWithStatement(ctx: CodegenContext, fctx: FunctionContext,
   // ⇒ falls to the hoisted var). (#2663 Slice 2 var-precedence refinement.)
   const blockedNames = collectBodyLexicalNames(stmt.statement);
 
-  (fctx.withScopes ??= []).push({ kind: "dynamic", localIdx, blockedNames });
+  (fctx.withScopes ??= []).push({ kind: "dynamic", captureName, localIdx, blockedNames });
   try {
     compileStatement(ctx, fctx, stmt.statement);
   } finally {
@@ -1031,20 +1025,6 @@ function bodyContainsIdentifierDelete(stmt: ts.Statement): boolean {
         found = true;
         return;
       }
-    }
-    forEachChild(node, walk);
-  };
-  walk(stmt);
-  return found;
-}
-
-function containsNestedFunctionBoundary(stmt: ts.Statement): boolean {
-  let found = false;
-  const walk = (node: ts.Node): void => {
-    if (found) return;
-    if (node !== stmt && isFunctionOrClassBoundary(node)) {
-      found = true;
-      return;
     }
     forEachChild(node, walk);
   };

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1436,6 +1436,10 @@ function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void 
       }
       throw new Error(`ir/from-ast: unsupported ExpressionStatement shape in ${cx.funcName}`);
     }
+    if (ts.isWithStatement(s)) {
+      lowerWithStatement(s, cx);
+      continue;
+    }
     // Slice 6 part 2 (#1181): for-of statement (always non-tail). The
     // body is shape-checked by `isPhase1ForOf` and lowered via a
     // separate `lowerStmt` body-statement dispatcher (no nested
@@ -1853,6 +1857,17 @@ type ScopeBinding =
   | { kind: "local"; value: IrValueId; type: IrType; stringEncoding?: Encoding }
   | {
       /**
+       * #4206 static `with` binding. The receiver is captured by reference;
+       * reads/writes stay object.get/object.set operations at the point of use.
+       */
+      kind: "withField";
+      receiver: IrValueId;
+      name: string;
+      type: IrType;
+      stringEncoding?: Encoding;
+    }
+  | {
+      /**
        * (#3142 Slice 2) A module-scope binding inside the `<module-init>`
        * unit. Reads emit a symbolic `global.get` and writes a symbolic
        * `global.set` against the legacy-allocated `__mod_<name>` global, so
@@ -1919,9 +1934,12 @@ type ScopeBinding =
  */
 interface NestedCapture {
   readonly name: string;
+  /** Stored capture type. For a with-field this is the object receiver type. */
   readonly type: IrType;
   readonly mutable: boolean;
   readonly outerValue: IrValueId;
+  /** Rehydrate an invocation-time object-property binding, not a value snapshot. */
+  readonly withField?: { readonly name: string; readonly type: IrType };
 }
 
 interface LowerCtx {
@@ -2170,6 +2188,8 @@ function sameScopeStorage(a: StringEncodingScopeBinding, b: ScopeBinding | undef
       return b.kind === "local" && b.value === a.value;
     case "moduleGlobal":
       return b.kind === "moduleGlobal" && sameIrGlobalBinding(b.globalRef.binding, a.globalRef.binding);
+    case "withField":
+      return b.kind === "withField" && b.receiver === a.receiver && b.name === a.name;
     case "slot":
       return b.kind === "slot" && b.slotIndex === a.slotIndex;
   }
@@ -3657,6 +3677,9 @@ function lowerExpr(expr: ts.Expression, cx: LowerCtx, hint: IrType): IrValueId {
     // reads come from the legacy-allocated global (symbolic ref).
     if (p.kind === "moduleGlobal") {
       return cx.builder.emitGlobalGet(p.globalRef, p.type);
+    }
+    if (p.kind === "withField") {
+      return cx.builder.emitObjectGet(p.receiver, p.name, p.type);
     }
     if (p.kind !== "local") {
       // Slice 3 (#1169c): nestedFunc bindings are name-only — they have
@@ -8171,6 +8194,10 @@ function lowerStmt(stmt: ts.Statement, cx: LowerCtx): void {
     }
     throw new Error(`ir/from-ast: unsupported body ExpressionStatement shape in ${cx.funcName}`);
   }
+  if (ts.isWithStatement(stmt)) {
+    lowerWithStatement(stmt, cx);
+    return;
+  }
   if (ts.isForOfStatement(stmt)) {
     lowerForOfStatement(stmt, cx);
     return;
@@ -8233,6 +8260,35 @@ function lowerStmt(stmt: ts.Statement, cx: LowerCtx): void {
     return;
   }
   throw new Error(`ir/from-ast: unsupported body statement ${ts.SyntaxKind[stmt.kind]} in ${cx.funcName}`);
+}
+
+/**
+ * #4206 first IR slice: a closed inline object literal plus an ordinary
+ * synchronous function expression. Each literal field becomes a `withField`
+ * scope binding backed by the one receiver SSA value. A closure captures that
+ * receiver and rehydrates the field binding in `liftClosureBody`, so reads and
+ * writes remain invocation-time object operations after this statement exits.
+ */
+function lowerWithStatement(stmt: ts.WithStatement, cx: LowerCtx): void {
+  if (!ts.isObjectLiteralExpression(stmt.expression) || !ts.isBlock(stmt.statement)) {
+    throw new Error(`ir/from-ast: with target/body outside the closed-object IR slice (${cx.funcName})`);
+  }
+  const receiver = lowerObjectLiteral(stmt.expression, cx);
+  const receiverType = cx.builder.typeOf(receiver);
+  if (receiverType.kind !== "object") {
+    throw new Error(`ir/from-ast: with target did not lower to an object (${cx.funcName})`);
+  }
+
+  const bodyCx: LowerCtx = { ...cx, scope: new Map(cx.scope) };
+  for (const field of receiverType.shape.fields) {
+    bodyCx.scope.set(field.name, {
+      kind: "withField",
+      receiver,
+      name: field.name,
+      type: field.type,
+    });
+  }
+  for (const bodyStatement of stmt.statement.statements) lowerStmt(bodyStatement, bodyCx);
 }
 
 /**
@@ -8501,6 +8557,16 @@ function lowerIdentifierAssignment(id: ts.Identifier, rhs: ts.Expression, cx: Lo
     }
     cx.builder.emitGlobalSet(binding.globalRef, newValue);
     cx.scope.set(id.text, { ...binding, stringEncoding: inferStringEncoding(rhs, cx) });
+    return;
+  }
+  if (binding.kind === "withField") {
+    const newValue = lowerExpr(rhs, cx, binding.type);
+    if (!irTypeAssignable(cx.builder.typeOf(newValue), binding.type)) {
+      throw new Error(
+        `ir/from-ast: assignment to with binding "${id.text}" (${describeIrType(binding.type)}) has incompatible value in ${cx.funcName}`,
+      );
+    }
+    cx.builder.emitObjectSet(binding.receiver, binding.name, newValue);
     return;
   }
   if (binding.kind !== "slot") {
@@ -10483,6 +10549,11 @@ function lowerClosureExpressionWithSignature(
   const captureArgs: IrValueId[] = [];
   const captureFieldTypes: IrType[] = [];
   for (const cap of captures) {
+    if (cap.withField) {
+      captureFieldTypes.push(cap.type);
+      captureArgs.push(cap.outerValue);
+      continue;
+    }
     if (cap.mutable) {
       const innerVal = asVal(cap.type);
       if (!innerVal) {
@@ -10705,7 +10776,16 @@ function liftClosureBody(
     const cap = captures[i]!;
     const fieldType = captureFieldTypes[i]!;
     const v = builder.emitClosureCap(selfV, i, fieldType);
-    scope.set(cap.name, { kind: "local", value: v, type: fieldType });
+    if (cap.withField) {
+      scope.set(cap.name, {
+        kind: "withField",
+        receiver: v,
+        name: cap.withField.name,
+        type: cap.withField.type,
+      });
+    } else {
+      scope.set(cap.name, { kind: "local", value: v, type: fieldType });
+    }
   }
 
   const innerCx: LowerCtx = {
@@ -10849,6 +10929,20 @@ function analyseCaptures(
     if (ownParams.has(name)) continue;
     const binding = cx.scope.get(name);
     if (!binding) continue;
+    if (binding.kind === "withField") {
+      const receiverType = cx.builder.typeOf(binding.receiver);
+      if (receiverType.kind !== "object") {
+        throw new Error(`ir/from-ast: with binding "${name}" has a non-object receiver in ${cx.funcName}`);
+      }
+      captures.push({
+        name,
+        type: receiverType,
+        mutable: false,
+        outerValue: binding.receiver,
+        withField: { name: binding.name, type: binding.type },
+      });
+      continue;
+    }
     if (binding.kind !== "local") {
       // Slice 3 doesn't yet capture closure / nested-fn bindings — that
       // would require either lifting the inner closure to a top-level

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -66,6 +66,7 @@ export { isAsyncIrReady } from "./async-selection.js";
 import { collectIrSafeModuleVarDeclarationLists, collectIrSafeVarDeclarationLists } from "./function-local-var.js";
 import { collectDynamicStringLocalWidening } from "./dynamic-local-widening.js";
 import { stringBuilderForcedLegacy } from "./string-builder-shape.js";
+import { selectWithEnvironmentClosures } from "./with-environment.js";
 // (#1373b C-1) Pure-syntactic async helpers from the LEAF module (safe for
 // ir/* — async-static.ts imports only ts-api, so no codegen/index cycle).
 import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "../codegen/async-static.js";
@@ -156,7 +157,7 @@ export type IrFallbackReason =
   // body-shape rejections that apply to top-level FunctionDeclarations too.
   | "class-method"
   | "string-builder-candidate" // (#3740/#3744) kill-switch-forced legacy — see ./string-builder-shape.ts
-  | "deferred-feature"; // permanently excluded (eval, with, import(), Proxy)
+  | "deferred-feature"; // excluded here (eval, non-selected with shapes, import(), Proxy)
 
 export interface IrFallback {
   readonly name: string;
@@ -3142,6 +3143,10 @@ function isPhase1StatementListInScope(
         return shapeNo("nontail-if-then-guard", s.thenStatement);
       continue;
     }
+    if (ts.isWithStatement(s)) {
+      if (!isPhase1WithStatement(s, scope, localClasses)) return false;
+      continue;
+    }
     // Slice 6 part 2 (#1181) — for-of statement (always non-tail). The
     // body is itself shape-checked. The bridge in `from-ast.ts` lowers
     // the iterable expression and dispatches to the vec fast path when
@@ -3864,6 +3869,65 @@ function isPhase1ForInStatement(
 }
 
 /**
+ * #4206 first IR `with` slice. Selection is deliberately exact:
+ *
+ * - a closed inline object literal target (therefore every binding is a known
+ *   object field and needs no runtime HasBinding fallback),
+ * - a block body containing at least one ordinary synchronous function
+ *   expression selected by `ir/with-environment`,
+ * - no body declaration may collide with a target field in this slice.
+ *
+ * The field names join the nested selector scope so a function expression can
+ * capture them. AST→IR lowering captures the receiver reference and restores
+ * each property as an invocation-time `object.get`/`object.set` binding.
+ */
+function isPhase1WithStatement(
+  stmt: ts.WithStatement,
+  scope: Set<string>,
+  localClasses: ReadonlySet<string>,
+  inLoop: boolean = false,
+  labels: ReadonlySet<string> = NO_LABELS,
+  breaks: BreakScope = NO_BREAKS,
+): boolean {
+  if (!ts.isObjectLiteralExpression(stmt.expression)) return shapeNo("with-target-not-objectlit", stmt.expression);
+  if (!ts.isBlock(stmt.statement)) return shapeNo("with-body-not-block", stmt.statement);
+  const body = stmt.statement;
+  const selection = selectWithEnvironmentClosures(body);
+  if (!selection.ok) return shapeNo("with-closure-boundary", body);
+  if (selection.closureCount === 0) return shapeNo("with-no-closure", stmt.statement);
+  if (!isPhase1ObjectLiteral(stmt.expression, scope, localClasses))
+    return shapeNo("with-target-shape", stmt.expression);
+
+  const fieldNames = new Set<string>();
+  for (const property of stmt.expression.properties) {
+    const name =
+      ts.isPropertyAssignment(property) || ts.isShorthandPropertyAssignment(property)
+        ? phase1PropertyName(property.name)
+        : null;
+    if (name === null) return shapeNo("with-target-field", property);
+    fieldNames.add(name);
+  }
+  for (const bodyStatement of body.statements) {
+    if (!ts.isVariableStatement(bodyStatement)) continue;
+    for (const declaration of bodyStatement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name)) return shapeNo("with-declaration-pattern", declaration.name);
+      if (fieldNames.has(declaration.name.text)) return shapeNo("with-field-shadow", declaration.name);
+    }
+  }
+
+  return withProjectionEvidenceScope(() =>
+    withLexicalValueBindingScope(body.statements, () => {
+      const bodyScope = new Set(scope);
+      for (const name of fieldNames) bodyScope.add(name);
+      for (const bodyStatement of body.statements) {
+        if (!isPhase1BodyStatement(bodyStatement, bodyScope, localClasses, inLoop, labels, breaks)) return false;
+      }
+      return true;
+    }),
+  );
+}
+
+/**
  * Slice 6 part 2 (#1181): recogniser for body statements inside a for-of
  * loop. Narrower than `isPhase1StatementList` — no nested closures, no
  * nested function decls, no fall-through if/else patterns. Accepts:
@@ -3905,6 +3969,9 @@ function isPhase1BodyStatement(
   }
   if (ts.isVariableStatement(stmt)) {
     return isPhase1VarDecl(stmt, scope, localClasses);
+  }
+  if (ts.isWithStatement(stmt)) {
+    return isPhase1WithStatement(stmt, scope, localClasses, inLoop, labels, breaks);
   }
   if (ts.isExpressionStatement(stmt)) {
     if (ts.isCallExpression(stmt.expression)) {

--- a/src/ir/with-environment.ts
+++ b/src/ir/with-environment.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Backend-neutral selection contract for capturing a `with` Object Environment
+ * Record in a closure.
+ *
+ * A supported closure captures the environment's receiver by reference. The
+ * backend may use a struct ref for a proven closed object or an externref for a
+ * dynamic object; either way the closure must rehydrate the same ordered scope
+ * entry rather than snapshotting individual property values.
+ *
+ * This first slice deliberately accepts only ordinary synchronous function
+ * expressions. Function declarations, arrows, classes, methods, generators,
+ * constructors, and async functions remain explicit selector refusals until their own
+ * creation/hoisting contracts can carry the environment record.
+ */
+import { forEachChild, ts } from "../ts-api.js";
+
+export type IrWithEnvironmentSelection =
+  | { readonly ok: true; readonly closureCount: number }
+  | { readonly ok: false; readonly reason: string };
+
+export interface IrWithEnvironmentCapture {
+  /** Hidden binding that carries the object-environment receiver. */
+  readonly bindingName: string;
+  /** Outer-to-inner ordering within the active `with` scope chain. */
+  readonly scopeIndex: number;
+}
+
+/**
+ * Select the exact nested-boundary surface supported by the first IR contract.
+ * The walk is complete: an unseen nested boundary is never treated as safe.
+ */
+export function selectWithEnvironmentClosures(statement: ts.Statement): IrWithEnvironmentSelection {
+  let closureCount = 0;
+  let refusal: string | null = null;
+  const closureBindingNames = new Set<string>();
+
+  const visit = (node: ts.Node): void => {
+    if (refusal !== null) return;
+    if (node !== statement) {
+      if (ts.isFunctionExpression(node)) {
+        if (node.asteriskToken) {
+          refusal = "generator function expression capture is not in the with-environment IR slice";
+          return;
+        }
+        if (node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword)) {
+          refusal = "async function expression capture is not in the with-environment IR slice";
+          return;
+        }
+        closureCount++;
+        let bindingExpression: ts.Expression = node;
+        while (ts.isParenthesizedExpression(bindingExpression.parent)) bindingExpression = bindingExpression.parent;
+        const parent = bindingExpression.parent;
+        if (
+          ts.isVariableDeclaration(parent) &&
+          parent.initializer === bindingExpression &&
+          ts.isIdentifier(parent.name)
+        ) {
+          closureBindingNames.add(parent.name.text);
+        } else if (
+          ts.isBinaryExpression(parent) &&
+          parent.right === bindingExpression &&
+          parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+          ts.isIdentifier(parent.left)
+        ) {
+          closureBindingNames.add(parent.left.text);
+        }
+      } else if (ts.isArrowFunction(node)) {
+        refusal = "arrow-function capture is not in the with-environment IR slice";
+        return;
+      } else if (ts.isFunctionDeclaration(node)) {
+        refusal = "function-declaration hoisting is not in the with-environment IR slice";
+        return;
+      } else if (
+        ts.isClassDeclaration(node) ||
+        ts.isClassExpression(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node)
+      ) {
+        refusal = "class or method capture is not in the with-environment IR slice";
+        return;
+      }
+    }
+    forEachChild(node, visit);
+  };
+
+  visit(statement);
+  if (refusal === null && closureCount > 0) {
+    const visitConstructors = (node: ts.Node): void => {
+      if (refusal !== null) return;
+      if (ts.isNewExpression(node)) {
+        let callee: ts.Expression = node.expression;
+        while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
+        if (ts.isFunctionExpression(callee) || (ts.isIdentifier(callee) && closureBindingNames.has(callee.text))) {
+          refusal = "constructible closure capture is not in the with-environment IR slice";
+          return;
+        }
+      }
+      forEachChild(node, visitConstructors);
+    };
+    visitConstructors(statement);
+  }
+  return refusal === null ? { ok: true, closureCount } : { ok: false, reason: refusal };
+}
+
+/** Create the ordered capture contract consumed by backend closure lowering. */
+export function planWithEnvironmentCaptures(bindingNames: readonly string[]): readonly IrWithEnvironmentCapture[] {
+  return bindingNames.map((bindingName, scopeIndex) => ({ bindingName, scopeIndex }));
+}

--- a/tests/issue-4206-with-closure-ir.test.ts
+++ b/tests/issue-4206-with-closure-ir.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4206 — closures created inside `with` capture the Object Environment Record.
+ *
+ * The IR contract captures the receiver reference, not property snapshots. The
+ * runtime probes therefore mutate the object after closure creation and require
+ * invocation-time reads/writes through the captured environment.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { selectWithEnvironmentClosures } from "../src/ir/with-environment.js";
+import { buildImports, wrapExports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+
+async function runModule(source: string, target?: "standalone"): Promise<unknown> {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "issue-4206-with-closure.js",
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments: false,
+    ...(target ? { target } : {}),
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  if (target === "standalone") {
+    expect(result.imports.map((entry) => `${entry.module}::${entry.name}`)).toEqual([]);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.__setExports?.(instance.exports);
+  if ("setExports" in imports && typeof imports.setExports === "function") {
+    imports.setExports(instance.exports);
+  }
+  const exports = wrapExports(instance.exports, { signatures: result.exportSignatures }) as { test: () => unknown };
+  return exports.test();
+}
+
+function selectBody(source: string) {
+  const sf = ts.createSourceFile("selection.js", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const withStatement = sf.statements.find(ts.isWithStatement);
+  if (!withStatement) throw new Error("probe has no with statement");
+  return selectWithEnvironmentClosures(withStatement.statement);
+}
+
+describe("#4206 with-environment closure IR contract", () => {
+  it("selects, lowers, and executes the closed-object closure slice through IR", async () => {
+    const result = await compile(
+      `
+        export function test(): number {
+          let out = 0;
+          with ({ value: 42 }) {
+            const read = function (): number { return value; };
+            out = read();
+          }
+          return out;
+        }
+      `,
+      {
+        allowJs: true,
+        fileName: "issue-4206-with-closure-ir.ts",
+        skipSemanticDiagnostics: true,
+        inferModuleStrictArguments: false,
+        target: "standalone",
+        trackIrOutcomes: true,
+      },
+    );
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irOutcomes).toEqual([
+      expect.objectContaining({ displayName: "test", kind: "emitted", irBodyEmitted: true }),
+    ]);
+    expect(result.imports.map((entry) => `${entry.module}::${entry.name}`)).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports as { test: () => number }).test()).toBe(42);
+  });
+
+  it("captures a dynamic object environment by reference after the with exits", async () => {
+    const source = `
+      export function test() {
+        var o = { prop: 1, valueOf: function () { return 0; } };
+        var f;
+        with (o) { f = function () { return prop; }; }
+        o.prop = 8;
+        return f();
+      }
+    `;
+    expect(await runModule(source, "standalone")).toBe(8);
+  });
+
+  it("writes through the captured environment instead of the outer binding", async () => {
+    const source = `
+      export function test() {
+        var value = 1;
+        var o = { value: 2, valueOf: function () { return 0; } };
+        var f;
+        with (o) { f = function () { value = 9; }; }
+        f();
+        return o.value * 10 + value;
+      }
+    `;
+    expect(await runModule(source, "standalone")).toBe(91);
+  });
+
+  it("preserves outer-to-inner scope order across two captured with environments", async () => {
+    const source = `
+      export function test() {
+        var outer = { a: 4 };
+        var inner = { b: 2 };
+        var f;
+        with (outer) { with (inner) { f = function () { return a * 10 + b; }; } }
+        return f();
+      }
+    `;
+    expect(await runModule(source, "standalone")).toBe(42);
+  });
+
+  it("resolves a lifted function's own var before the captured object environment", async () => {
+    const source = `
+      export function test() {
+        var o = { value: 2 };
+        var f;
+        with (o) { f = function () { var value = 9; return value; }; }
+        return f() * 10 + o.value;
+      }
+    `;
+    expect(await runModule(source, "standalone")).toBe(92);
+  });
+
+  it("keeps the same behavior on the JS-host lane", async () => {
+    expect(
+      await runModule(`
+        export function test() {
+          var o = { prop: 7, valueOf: function () { return 0; } };
+          var f;
+          with (o) { f = function () { return prop; }; }
+          return f();
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("carries the environment through the JS-host callback bridge", async () => {
+    expect(
+      await runModule(`
+        export function test() {
+          var observed = 0;
+          var o = { value: 7 };
+          with (o) {
+            JSON.parse("0", function (_key, parsed) { observed = value; return parsed; });
+          }
+          return observed;
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("selects only ordinary synchronous function expressions", () => {
+    expect(selectBody(`with (o) { f = function () { return p; }; }`)).toEqual({ ok: true, closureCount: 1 });
+    expect(selectBody(`with (o) { f = () => p; }`)).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("arrow"),
+    });
+    expect(selectBody(`with (o) { function f() { return p; } }`)).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("hoisting"),
+    });
+    expect(selectBody(`with (o) { f = async function () { return p; }; }`)).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("async"),
+    });
+    expect(selectBody(`with (o) { f = function () { return p; }; new f(); }`)).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("constructible"),
+    });
+    expect(selectBody(`with (o) { class C { m() { return p; } } }`)).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("class"),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a backend-neutral IR selector/capture contract for ordinary synchronous function expressions inside `with`
- lower the supported closed object-literal shape through the real IR path and capture the receiver by reference
- rehydrate static/dynamic object-environment receivers through ordinary closures and JS-host callback bridges
- keep constructible closures, arrows, declarations, async/generator functions, and class/member boundaries as explicit refusals

## Why

The remaining ES5 standalone `with` cohort was dominated by closures that outlive the statement. Legacy lowering could resolve bindings while inside the block, but it did not retain the object environment for later invocation. This change carries the receiver through the existing closure ABI so reads and writes remain dynamic after scope exit, while keeping unsupported callable semantics out of the slice.

## Impact and boundaries

The maintained FULL-interpreter comparison improved 97/190 to 121/190: +24 passes, zero pass regressions, and all 97 passing controls preserved. Within the original 39-row ES5 closure cohort, 22 now pass, reducing the documented ES5 residue from 73 to 51.

A final selector refinement after the complete comparison changes one unrelated `new Test262Error` row from an over-broad compile refusal back to its existing runtime assertion failure; it does not change the pass or regression totals.

Explicit residuals remain documented in #4206: 10 constructible-closure rows are refused; two rows depend on undefined-vs-null local initialization; five expose existing implicit-global/string/global-ownership or callable-carrier gaps.

## Validation

- `pnpm exec vitest run tests/issue-4206-with-closure-ir.test.ts --reporter=dot` — 8/8
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- `pnpm run check:ir-adoption`
- maintained standalone FULL-runtime A/B and pass-regression diff — +24 / 0 regressions
- pre-push typecheck/lint, oracle and coercion ratchets, numeric-local parity (18/18), and issue integrity

The repository-wide `check:ir-only` audit reports 37/37 terminal units emitted with zero unsupported/invariant failures, while retaining its existing NOT READY verdict for 10 legacy-body emissions.
