### PR TITLE
fix(react): preserve dynamic callable semantics

### DIFF
--- a/plan/issues/4371-dynamic-class-static-method-bridge.md
+++ b/plan/issues/4371-dynamic-class-static-method-bridge.md
@@ -1,0 +1,85 @@
+---
+id: 4371
+title: "Dynamic class-object reads expose throwing placeholders for declared static methods"
+status: complete
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: classes, static-methods, dynamic-property-access
+goal: npm-library-support
+related: [1395, 3024, 3961, 3995]
+loc-budget-allow:
+  - src/codegen/expressions/extern.ts
+  - src/codegen/index.ts
+  - src/runtime.ts
+func-budget-allow:
+  - src/codegen/index.ts::generateModule
+  - src/runtime.ts::resolveImport
+---
+
+# Bridge declared static methods through dynamic class-object values
+
+## Problem
+
+React's original `ReactJSXTransformIntegration` suite carries a component class
+through an element record and invokes a declared static method through the
+record's dynamic `type` field:
+
+```ts
+class StaticMethodComponent {
+  static someStaticMethod(): string { return "someReturnValue"; }
+}
+return createElement(StaticMethodComponent).type.someStaticMethod();
+```
+
+The direct `StaticMethodComponent.someStaticMethod()` path calls the compiled
+Wasm function. The dynamic path materializes the class-object singleton, but
+`__register_class_object` records only a CSV list of method names. The runtime
+therefore exposes a descriptor-compatible placeholder JavaScript function whose
+body deliberately throws. The compiled static method is present in the module,
+but the dynamic class-object surface has no connection to it.
+
+This is a generic class-value defect, not React-specific behavior. A static
+method added later with `C.m = fn` already works because it is stored in the
+sidecar; a static method declared in the class body must reach the same real
+callable surface without changing the class object's Wasm identity.
+
+## Acceptance criteria
+
+- [x] A class carried through an `any`-typed object field can invoke its
+      declared static method with zero or multiple arguments.
+- [x] Reading the same declared static method as a value yields a callable
+      backed by the compiled Wasm body, not a throwing placeholder.
+- [x] Static-method descriptor flags remain writable, non-enumerable, and
+      configurable, and existing delete/reassignment semantics remain intact.
+- [x] Class objects retain their existing singleton and closed-struct identity;
+      dynamic `new K()` and standalone no-host behavior do not regress.
+- [x] React's original static-method integration test passes.
+
+## Design
+
+Keep the existing class-object singleton and name allowlist. In JS-host builds,
+register each declared static method's real closure alongside the class object
+when the singleton is first materialized. Store that closure in the class
+object's descriptor-aware sidecar with normal class-method attributes. Host
+property reads can then use the existing Wasm-closure wrapper and callback
+dispatch rather than inventing a second static-call ABI or guessing an export
+name. Standalone remains unchanged: it has no host registration imports and
+already calls statically known class methods inside Wasm.
+
+## Evidence
+
+- `tests/issue-4371-dynamic-class-static-method-bridge.test.ts`: 3/3 pass.
+- Adjacent class-object, reflection, dynamic-construction, and static-method
+  regressions: 37/37 pass.
+- React's original `ReactCreateElement` and
+  `ReactJSXTransformIntegration` static-method tests both pass against compiled
+  Wasm. The third matching `ReactJSXRuntime` test remains native-harness
+  incompatible because that harness does not yet provide `ReactJSXRuntime`;
+  it is not a compiled-runtime divergence.

--- a/plan/issues/4373-js-property-call-arguments.md
+++ b/plan/issues/4373-js-property-call-arguments.md
@@ -1,0 +1,88 @@
+---
+id: 4373
+title: "JavaScript callable-property and host bridges truncate arguments beyond declared arity"
+status: complete
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: functions, arguments-object, dynamic-method-call
+goal: npm-library-support
+related: [1712, 2664, 2687, 3958, 4371]
+loc-budget-allow:
+  - src/codegen/expressions/calls-closures.ts
+  - src/codegen/expressions/calls.ts
+  - tests/issue-4373-js-property-call-arguments.test.ts
+func-budget-allow:
+  - src/codegen/expressions/calls-closures.ts::compileCallablePropertyCall
+---
+
+# Preserve overflow arguments across JavaScript property-call bridges
+
+## Problem
+
+React's production `createElement(type, config, children)` function deliberately
+declares three formals and reads every additional child through `arguments`.
+Calling it with five children therefore supplies seven runtime arguments.
+
+Two generic compiler defects independently discarded those trailing values:
+
+1. TypeScript's checker adds a synthetic rest-like parameter to an unannotated
+   JavaScript function that reads `arguments`. Callable-property lowering
+   treated that checker-only symbol as a real Wasm formal, selected the wrong
+   closure shape, and dropped overflow values instead of using the existing
+   `__argc` / `__extras_argv` protocol.
+2. A callable reached through `__extern_method_call` was wrapped with the
+   largest emitted `__call_fn_method_N` dispatcher. Module finalization did not
+   observe this wrapper call site's arity, so a module whose real closures had
+   at most five formals emitted no dispatcher above five. Seven arguments were
+   silently truncated to five before the three-formal closure ran.
+
+The result was observable as `arguments.length === 5` instead of `7`, and React
+lost two children. This is a generic JavaScript call-semantics defect, not a
+React-specific special case.
+
+## Acceptance criteria
+
+- [x] Source declarations, rather than checker-synthetic symbols, determine a
+      non-declaration JavaScript closure's real formal arity.
+- [x] Callable-property calls preserve the exact runtime argument count and all
+      overflow values through the canonical arguments protocol.
+- [x] Host dynamic method calls cause module finalization to emit a dispatcher
+      wide enough for their non-spread argument count (within the existing
+      supported dispatcher range).
+- [x] A three-formal JavaScript function called with seven arguments observes
+      `arguments.length === 7` and the correct fifth and seventh values.
+- [x] The direct and experimental-IR compilation routes agree.
+- [x] React's two previously divergent original ReactChildren tests pass.
+
+## Design
+
+For a real source function, trim only checker parameters that have no matching
+source declaration parameter. Preserve real source rest parameters and all
+declaration-file signatures. When a callable-property ladder targets the
+resulting lower-arity closure, use the existing arguments globals rather than
+evaluating and dropping overflow expressions.
+
+For host dynamic method calls, feed the call expression's argument count into
+the existing `maxHostDynamicMethodCallArity` accounting. The existing module
+finalizer already includes that value when deciding which
+`__call_fn_method_N` exports to emit; the missing step was observing this
+particular wrapper path.
+
+## Evidence
+
+- `tests/issue-4373-js-property-call-arguments.test.ts`: 4/4 pass, covering
+  callable-property and JS-host dynamic-method dispatch on both direct and
+  experimental-IR compilation routes.
+- React's original `ReactChildren` flat-structure and key-combination tests:
+  2/2 pass against compiled Wasm.
+- Complete current React extraction: 64/64 runnable/scored original tests pass,
+  with zero runtime divergences. Eight further tests remain compile-quarantined
+  by the independently tracked async-in-try limitation, and 200 require missing
+  upstream Jest/DOM test infrastructure.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -135,6 +135,30 @@ export function sourceDefinesFunctionMember(sf: ts.SourceFile, name: string): bo
 type FuncCandidate = { funcTypeIdx: number; structTypeIdx: number; returnType: ValType | null };
 
 /**
+ * TypeScript gives an unannotated JavaScript function that reads `arguments`
+ * a synthetic trailing rest symbol in its checker signature. That symbol is
+ * not a source formal and is not present in the lifted Wasm closure ABI: the
+ * real overflow values travel through `__argc` / `__extras_argv` instead.
+ *
+ * Use the source declaration's smaller arity when it proves that the final
+ * checker symbols are synthetic. Real source rest parameters remain present
+ * in `declaration.parameters`, and declaration-file signatures keep their
+ * checker-authored parameter list unchanged.
+ */
+function runtimeSignatureParameters(sig: ts.Signature): readonly ts.Symbol[] {
+  const declaration = sig.getDeclaration();
+  if (
+    declaration !== undefined &&
+    ts.isFunctionLike(declaration) &&
+    !declaration.getSourceFile().isDeclarationFile &&
+    declaration.parameters.length < sig.parameters.length
+  ) {
+    return sig.parameters.slice(0, declaration.parameters.length);
+  }
+  return sig.parameters;
+}
+
+/**
  * (#3205) Build the funcref-type candidate set for a callable-property dispatch.
  *
  * A closure stored in an object field / array element may have a DIFFERENT
@@ -229,6 +253,7 @@ function collectPropertyCallArgLocals(
   fctx: FunctionContext,
   expr: ts.CallExpression,
   paramTypes: ValType[],
+  evaluateOverflow = true,
 ): number[] {
   const argLocals: number[] = [];
   const paramCount = paramTypes.length;
@@ -238,10 +263,14 @@ function collectPropertyCallArgLocals(
     fctx.body.push({ op: "local.set", index: al });
     argLocals.push(al);
   }
-  // Excess args: evaluate for side effects, drop.
-  for (let i = paramCount; i < expr.arguments.length; i++) {
-    const extraType = compileExpression(ctx, fctx, expr.arguments[i]!);
-    if (extraType !== null) fctx.body.push({ op: "drop" });
+  // Some callers preserve excess values through the canonical arguments
+  // protocol after this helper returns. The legacy element-call path still
+  // evaluates and drops them here until it adopts that protocol too.
+  if (evaluateOverflow) {
+    for (let i = paramCount; i < expr.arguments.length; i++) {
+      const extraType = compileExpression(ctx, fctx, expr.arguments[i]!);
+      if (extraType !== null) fctx.body.push({ op: "drop" });
+    }
   }
   // Pad missing args with defaults.
   for (let i = expr.arguments.length; i < paramCount; i++) {
@@ -1117,12 +1146,13 @@ export function compileCallablePropertyCall(
   }
 
   const sig = callSigs[0]!;
-  const sigParamCount = sig.parameters.length;
+  const sigParameters = runtimeSignatureParameters(sig);
+  const sigParamCount = sigParameters.length;
   const sigRetType = ctx.checker.getReturnTypeOfSignature(sig);
   const sigRetWasm = isVoidType(sigRetType) ? null : resolveWasmType(ctx, sigRetType);
   const sigParamWasmTypes: ValType[] = [];
   for (let i = 0; i < sigParamCount; i++) {
-    const paramType = ctx.checker.getTypeOfSymbol(sig.parameters[i]!);
+    const paramType = ctx.checker.getTypeOfSymbol(sigParameters[i]!);
     sigParamWasmTypes.push(resolveWasmType(ctx, paramType));
   }
 
@@ -1315,11 +1345,30 @@ export function compileCallablePropertyCall(
       fctx.body.push({ op: "drop" });
 
       // Save args to locals so each dispatch arm can re-push them.
-      const argLocals = collectPropertyCallArgLocals(ctx, fctx, expr, matchedClosureInfo.paramTypes);
+      const argLocals = collectPropertyCallArgLocals(ctx, fctx, expr, matchedClosureInfo.paramTypes, false);
+
+      // (#4373) A property value can be a lower-arity JavaScript closure whose
+      // body reads `arguments`. Preserve every overflow value and the exact
+      // call-site count instead of dropping the values before the funcref
+      // ladder. All candidates in this ladder share the declared formal arity,
+      // so one setup is valid for every arm.
+      emitClosureCallArgcExtras(ctx, fctx, expr.arguments, matchedClosureInfo.paramTypes.length);
 
       // After the args (they may read the caller's `this`), before the ladder.
       if (bind) emitObjectLiteralMethodThisInstall(ctx, fctx, bind);
       emitRootFuncrefDispatch(ctx, fctx, closureLocal, rootIdx, funcCandidates, argLocals, expectedReturn);
+
+      // A target that does not itself read `arguments` leaves the module
+      // globals untouched. Clear them after the indirect call while preserving
+      // its result on the stack.
+      if (expectedReturn === null) {
+        emitResetArgcExtras(ctx, fctx);
+      } else {
+        const returnLocal = allocLocal(fctx, `__cp_ret_${fctx.locals.length}`, expectedReturn);
+        fctx.body.push({ op: "local.set", index: returnLocal });
+        emitResetArgcExtras(ctx, fctx);
+        fctx.body.push({ op: "local.get", index: returnLocal });
+      }
       return finishObjectLiteralMethodCall(ctx, fctx, bind, expectedReturn ?? VOID_RESULT);
     }
   }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -33,6 +33,7 @@ import {
 } from "../iterator-native.js"; // (#2169c) native Array.from drain / (#3146) Iterator-statics intrinsics / (#3206) native Array.from(src, mapFn)
 import { reserveClosedMethodDispatch, reserveClosedMethodDispatchVararg } from "../closed-method-dispatch.js";
 import { emitNativeDateParse } from "../date-parse-native.js"; // (#2164) pure-Wasm Date.parse / new Date(str)
+import { observeHostDynamicMethodCallArity } from "../dynamic-method-call-arity.js";
 import { NATIVE_HOF_METHODS } from "../hof-native.js";
 import { ensureTaMapFilterHelper } from "../ta-hof-map-filter.js";
 import { LAZY_ITER_METHODS } from "../iter-lazy-native.js"; // (#2903 R3b) flatMap closure-path exemption
@@ -2764,6 +2765,12 @@ export function emitWrapperDynamicMethodCall(
   methodName: string,
   callExpr?: ts.CallExpression,
 ): ValType | null {
+  // (#4373) The host wrapper can only preserve arguments that have a matching
+  // `__call_fn_method_N` dispatcher. Record the real dynamic call-site width
+  // before module finalization; otherwise modules whose declared closures are
+  // all narrower retain the historical five-argument cap and truncate extras.
+  if (callExpr) observeHostDynamicMethodCallArity(ctx, callExpr.arguments);
+
   // (#1888 Slice 2) Standalone routes __extern_method_call native, which reads
   // its args over a $ObjVec — build the (empty) args list with the native
   // $ObjVec builder, not the host __js_array_new. JS-host keeps the host import.

--- a/src/codegen/expressions/extern.ts
+++ b/src/codegen/expressions/extern.ts
@@ -21,6 +21,8 @@ import { noJsHost } from "../js-errors.js";
 import { tryEmitStaticOrNativeIsPrototypeOf } from "../native-is-prototype-of.js";
 import { addStringConstantGlobal } from "../registry/imports.js";
 import { emitStandaloneClassProtoObject } from "../class-proto-object.js"; // (#3976) standalone proto as a real $Object
+import { classMemberFuncKey } from "../class-member-keys.js";
+import { emitFuncRefAsClosure } from "../closures.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
 import { pushDefaultValue } from "../type-coercion.js";
@@ -405,6 +407,49 @@ export function emitLazyClassObjectGet(ctx: CodegenContext, fctx: FunctionContex
     initBody.push({ op: "global.get", index: classObjectGlobalIdx });
     initBody.push({ op: "global.get", index: csvGlobalIdx });
     initBody.push({ op: "call", funcIdx: registerClassFuncIdx });
+  }
+
+  // (#4371) Install the REAL compiled closures behind declared static-method
+  // reads on a dynamically carried class object. The legacy registration above
+  // provides the own-key/descriptor allowlist but its host bridge is only a
+  // throwing placeholder. A descriptor-aware sidecar value preserves the
+  // class object's closed-struct identity (needed by dynamic `new K()`) while
+  // letting the existing host closure wrapper dispatch back into Wasm.
+  //
+  // Build this inside `initBody`: the singleton guard means each closure is
+  // created once, and sidecar reads/reassign/delete all observe that same value.
+  const registerStaticMethodIdx = ctx.funcMap.get("__register_class_static_method");
+  if (registerStaticMethodIdx !== undefined) {
+    const staticMethodNames = ctx.classStaticMethodNames.get(className) ?? [];
+    const savedBody = fctx.body;
+    fctx.body = initBody;
+    ctx.liveBodies.add(savedBody);
+    try {
+      for (const methodName of staticMethodNames) {
+        const fullName = `${className}_${methodName}`;
+        const methodIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
+        if (methodIdx === undefined) continue;
+        addStringConstantGlobal(ctx, methodName);
+        const methodNameGlobalIdx = ctx.stringGlobalMap.get(methodName);
+        if (methodNameGlobalIdx === undefined) continue;
+
+        fctx.body.push({ op: "global.get", index: classObjectGlobalIdx });
+        fctx.body.push({ op: "global.get", index: methodNameGlobalIdx });
+        const closureType = emitFuncRefAsClosure(ctx, fctx, fullName, methodIdx);
+        if (closureType === null) {
+          // Leave reflection on the established placeholder path if this
+          // method cannot be represented as a closure. Do not install a wrong
+          // value or change the class-object allowlist.
+          fctx.body.splice(fctx.body.length - 2, 2);
+          continue;
+        }
+        fctx.body.push({ op: "extern.convert_any" });
+        fctx.body.push({ op: "call", funcIdx: registerStaticMethodIdx });
+      }
+    } finally {
+      fctx.body = savedBody;
+      ctx.liveBodies.delete(savedBody);
+    }
   }
 
   // Emit: if global is null, init it; then get it.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3992,6 +3992,21 @@ export function generateModule(
       // registered up-front so `emitLazyClassObjectGet` finds it in funcMap.
       const regClassTypeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], []);
       addImport(ctx, "env", "__register_class_object", { kind: "func", typeIdx: regClassTypeIdx });
+      // (#4371) A name-only class-object registration can make reflection
+      // report a static method, but it cannot invoke that method after the
+      // class value crosses an `any`/host boundary. Register the real compiled
+      // closure on the singleton as well. This import is host-only for the same
+      // reason as __register_class_object; standalone/wasi keep their zero-host
+      // class representation and direct in-Wasm calls.
+      const regStaticMethodTypeIdx = addFuncType(
+        ctx,
+        [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+        [],
+      );
+      addImport(ctx, "env", "__register_class_static_method", {
+        kind: "func",
+        typeIdx: regStaticMethodTypeIdx,
+      });
     }
 
     // #1677 — reconcile native-string helper func indices before emitting more

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10343,6 +10343,18 @@ assert._isSameValue = isSameValue;
           const names = typeof csv === "string" && csv.length > 0 ? csv.split(",") : [];
           _staticMethodNames.set(classObj, names);
         };
+      if (name === "__register_class_static_method")
+        return function registerClassStaticMethod(classObj: any, methodName: any, closure: any): void {
+          // (#4371) Pair the class object's existing name allowlist with the
+          // actual compiled closure. Keeping the value in the descriptor-aware
+          // sidecar preserves the WasmGC class singleton/type (dynamic `new`
+          // relies on it), while `_wrapForHost` already knows how to turn this
+          // raw closure struct into a callable JavaScript function on read.
+          if (classObj == null || typeof classObj !== "object") return;
+          if (typeof methodName !== "string" || methodName.length === 0) return;
+          _sidecarSet(classObj, methodName, closure);
+          _getSidecarDescs(classObj).set(methodName, _SC_DEFINED | _SC_WRITABLE | _SC_CONFIGURABLE);
+        };
       if (name === "__unbox_string")
         return (s: any): any => {
           if (typeof s === "string") return s; // already a string primitive
@@ -11331,7 +11343,30 @@ assert._isSameValue = isSameValue;
           }
           // (#1629 S1) WasmGC struct: single canonical read-back path, shared
           // with Object.getOwnPropertyDescriptors.
-          return _readOwnDescriptor(obj, prop, callbackState?.getExports());
+          const desc = _readOwnDescriptor(obj, prop, callbackState?.getExports());
+          // (#4371) A declared class static is stored as its raw Wasm closure
+          // so compiled reads/calls stay in the existing closure ABI. A
+          // descriptor object, however, is an ordinary host object; expose its
+          // `value` with the same callable JS wrapper a normal property read
+          // would produce. This preserves the public `typeof desc.value ===
+          // "function"` contract without replacing the canonical sidecar
+          // value (which the in-Wasm extracted-call path needs).
+          if (desc && "value" in desc) {
+            const staticMethods = _staticMethodNames.get(obj);
+            if (staticMethods?.includes(String(prop))) {
+              // Reuse the canonical class-object proxy read. Besides the
+              // generic __is_closure route, it has the per-name
+              // `__call_<method>` bridge needed by modules whose only closure
+              // value is this static and therefore do not export a generic
+              // closure discriminator.
+              const wrapped = _wrapForHost(obj, callbackState?.getExports());
+              const callable = wrapped?.[prop];
+              desc.value = typeof callable === "function" ? callable : _getClassMethodBridge(obj, String(prop));
+            } else {
+              desc.value = _maybeWrapCallableUnknownArity(desc.value, callbackState);
+            }
+          }
+          return desc;
         };
       if (name === "__getOwnPropertyNames")
         return (obj: any) => {
@@ -12258,6 +12293,16 @@ assert._isSameValue = isSameValue;
           for (const key of _ownStructKeys(obj, exports)) {
             const desc = _readOwnDescriptor(obj, key, exports);
             if (desc !== undefined) {
+              if ("value" in desc) {
+                const staticMethods = _staticMethodNames.get(obj);
+                if (staticMethods?.includes(String(key))) {
+                  const wrapped = _wrapForHost(obj, exports);
+                  const callable = wrapped?.[key];
+                  desc.value = typeof callable === "function" ? callable : _getClassMethodBridge(obj, String(key));
+                } else {
+                  desc.value = _maybeWrapCallableUnknownArity(desc.value, callbackState);
+                }
+              }
               // Per spec, the result is an ordinary object whose own
               // properties are enumerable, writable, configurable data
               // properties holding each descriptor object. Plain assignment

--- a/tests/dogfood/react-upstream-suite.mjs
+++ b/tests/dogfood/react-upstream-suite.mjs
@@ -134,7 +134,7 @@ function quarantineFromErrors(moduleSource, tests, errors) {
   return offenders;
 }
 
-export async function runHarness({ quiet = false } = {}) {
+export async function runHarness({ quiet = false, filter = process.env.DOGFOOD_REACT_FILTER || "" } = {}) {
   const log = quiet ? () => {} : (...values) => console.log(...values);
   installReactTestEnvironment();
 
@@ -167,17 +167,25 @@ export async function runHarness({ quiet = false } = {}) {
   // a test filtered out before it runs is invisible. Only the structural
   // rejection left is a `done`-callback signature, which has no scheduler to
   // invoke it. Async bodies DO run — see buildTestFunction / the awaits below.
-  const extracted = extractReactUpstreamTests({
+  const extractedAll = extractReactUpstreamTests({
     root: suiteRoot,
     testFiles: suitePin.testFiles,
     admitAll: process.env.DOGFOOD_REACT_ADMIT_ALL !== "0",
   });
+  const filterPattern = filter ? new RegExp(filter, "i") : null;
+  const extracted = filterPattern
+    ? {
+        ...extractedAll,
+        tests: extractedAll.tests.filter((test) => filterPattern.test(test.fullName)),
+      }
+    : extractedAll;
   report.extraction = {
-    upstreamTestsSeen: extracted.tests.length + extracted.rejected.length,
+    upstreamTestsSeen: extractedAll.tests.length + extractedAll.rejected.length,
     admitted: extracted.tests.length,
-    rejected: extracted.rejected.length,
-    rejectionCounts: extracted.rejectionCounts,
-    rejectedTests: extracted.rejected,
+    rejected: extractedAll.rejected.length,
+    rejectionCounts: extractedAll.rejectionCounts,
+    rejectedTests: extractedAll.rejected,
+    ...(filterPattern ? { filter } : {}),
   };
   log(
     `[dogfood] react@${version} upstream @ ${suitePin.tag}: ` +

--- a/tests/issue-4371-dynamic-class-static-method-bridge.test.ts
+++ b/tests/issue-4371-dynamic-class-static-method-bridge.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4371 — a declared static method carried through a dynamic class-object
+// value must remain the real compiled callable. The old class-object registry
+// recorded only the method name and exposed a descriptor-only JavaScript
+// placeholder whose body deliberately threw.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, wrapExports } from "../src/runtime.js";
+
+async function run(source: string): Promise<Record<string, any>> {
+  const result = await compile(source, {
+    fileName: "issue-4371.ts",
+  });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  await expect(WebAssembly.compile(result.binary)).resolves.toBeDefined();
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  return wrapExports(instance, { signatures: result.exportSignatures });
+}
+
+describe("#4371 — dynamic class-object static method bridge", () => {
+  it("calls a declared static method after the class crosses an object field", async () => {
+    const exports = await run(`
+      function carry(type: any): any { return { type }; }
+      export function probe(): number {
+        class Component {
+          static someStaticMethod(): number { return 7; }
+        }
+        return carry(Component).type.someStaticMethod();
+      }
+    `);
+
+    expect(exports.probe()).toBe(7);
+  });
+
+  it("keeps the extracted method callable and forwards arguments", async () => {
+    const exports = await run(`
+      function carry(type: any): any { return { type }; }
+      export function probe(): number {
+        class Component {
+          static add(a: number, b: number): number { return a * 10 + b; }
+        }
+        const fn: any = carry(Component).type.add;
+        return fn(4, 2);
+      }
+    `);
+
+    expect(exports.probe()).toBe(42);
+  });
+
+  it("preserves static method descriptor attributes", async () => {
+    const exports = await run(`
+      function carry(type: any): any { return { type }; }
+      export function flags(): number {
+        class Component { static method(): number { return 1; } }
+        const desc: any = Object.getOwnPropertyDescriptor(carry(Component).type, "method");
+        return (desc.writable ? 100 : 0) + (desc.enumerable ? 10 : 0) + (desc.configurable ? 1 : 0);
+      }
+    `);
+
+    expect(exports.flags()).toBe(101);
+  });
+});

--- a/tests/issue-4373-js-property-call-arguments.test.ts
+++ b/tests/issue-4373-js-property-call-arguments.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4373 — overflow arguments must survive both a JavaScript callable-property
+// dispatch and the JS-host dynamic method bridge. React.createElement declares
+// three formals but consumes every trailing child through `arguments`.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, wrapExports } from "../src/runtime.js";
+
+async function run(
+  source: string,
+  options: { fileName: string; experimentalIR: boolean },
+): Promise<Record<string, any>> {
+  const result = await compile(source, {
+    ...options,
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  await expect(WebAssembly.compile(result.binary)).resolves.toBeDefined();
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setInstance?.(instance);
+  return wrapExports(instance, { signatures: result.exportSignatures });
+}
+
+describe("#4373 — JavaScript property-call arguments", () => {
+  for (const experimentalIR of [false, true]) {
+    it(`preserves checker-synthetic overflow arguments (IR=${experimentalIR})`, async () => {
+      const exports = await run(
+        `
+          var api = {};
+          api.capture = function (first, second, third) {
+            return arguments.length * 100 + arguments[4] * 10 + arguments[6];
+          };
+          export function probe() {
+            return api.capture(1, 2, 3, 4, 5, 6, 7);
+          }
+        `,
+        { fileName: "issue-4373.js", experimentalIR },
+      );
+
+      expect(exports.probe()).toBe(757);
+    });
+
+    it(`sizes the JS-host method dispatcher from the call site (IR=${experimentalIR})`, async () => {
+      const exports = await run(
+        `
+          const api: any = {};
+          api.capture = function (first: any, second: any, third: any): number {
+            return arguments.length * 100 + arguments[4] * 10 + arguments[6];
+          };
+          function invoke(receiver: any): number {
+            return receiver.capture(1, 2, 3, 4, 5, 6, 7);
+          }
+          export function probe(): number { return invoke(api); }
+        `,
+        { fileName: "issue-4373.ts", experimentalIR },
+      );
+
+      expect(exports.probe()).toBe(757);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- register declared class static methods with their real compiled closures when class values cross the JS-host boundary
- preserve overflow arguments and exact `arguments.length` for unannotated JavaScript callable properties
- size JS-host method dispatchers from dynamic call-site arity so seven-argument calls are not truncated to five
- add a filter to the original React test harness for fast, exact regression validation

## Evidence

- complete current React extraction: 64/64 runnable and scored original upstream tests pass against compiled Wasm, with zero runtime divergences
- the two previously failing original ReactChildren tests pass 2/2
- the two runnable original static-method tests pass 2/2; the third matching test remains native-harness incompatible because `ReactJSXRuntime` is not provided
- new focused regressions pass 7/7 across the direct and experimental-IR routes
- adjacent class/reflection/dynamic-construction regressions pass 37/37
- formatting, typecheck, issue-ID, issue-spec, LOC-budget, function-budget, oracle-ratchet, and changed-root hooks pass

The full extraction still reports eight compile-quarantined tests behind the existing async-in-try limitation and 200 tests needing additional upstream Jest/DOM infrastructure. Those are kept separate from the eliminated runtime divergences.

## Tracking

- [#4371](https://github.com/loopdive/js2wasm/blob/codex/npm-compat-audit-20260811/plan/issues/4371-dynamic-class-static-method-bridge.md)
- [#4373](https://github.com/loopdive/js2wasm/blob/codex/npm-compat-audit-20260811/plan/issues/4373-js-property-call-arguments.md)
