### PR TITLE
fix(function): initialize defaults in lifted IIFEs

### DIFF
--- a/plan/issues/165-function-statement-hoisting-and-edge.md
+++ b/plan/issues/165-function-statement-hoisting-and-edge.md
@@ -3,11 +3,13 @@ id: 165
 title: "Issue #165: function statement hoisting and edge cases"
 status: done
 created: 2026-03-11
-updated: 2026-04-14
+updated: 2026-08-12
 completed: 2026-03-13
 priority: low
 goal: compilable
 sprint: 0
+loc-budget-allow:
+  - src/codegen/expressions/calls.ts
 files:
   src/codegen/expressions.ts:
     new:
@@ -69,3 +71,52 @@ Function declarations may not be hoisted correctly in all positions. Function de
 - **What didn't**: Captures of `const` locals from hoisted functions called before the `const` initializer runs (returns 0 -- consistent with hoisting semantics where the variable exists but hasn't been assigned yet).
 - **Files changed**: `tests/issue-165.test.ts` (new), `plan/issues/sprints/0/165.md` (moved from ready)
 - **Tests now passing**: 19/19 in `tests/issue-165.test.ts`
+
+## 2026-08-12: defaults in synthesized IIFEs
+
+### Root cause and fix
+
+`compileIIFE()` synthesizes a Wasm function for an immediately invoked function
+expression. It padded omitted numeric arguments with `NaN`, but entered the
+synthesized body without running the default-parameter prologue used by nested
+function declarations. As a result, `(function (value = 123) { return value;
+})()` observed `NaN` instead of `123`.
+
+The synthesized function now reuses `emitDefaultParamInit()`, and its direct
+call site publishes the exact supplied-argument count through the existing argc
+carrier. This is generic function behavior; there is no Annex B-specific value
+or test-name special case.
+
+The LOC allowance above is deliberately limited to the IIFE dispatcher. The
+shared default-parameter semantics remain in
+`src/codegen/statements/nested-declarations.ts`; the added dispatcher code only
+connects the synthesized activation to that shared operation and its argc
+input.
+
+### Test262 impact and edition accounting
+
+The current Test262 edition classifier assigns Annex B paths without explicit
+edition metadata to ES5. The eight affected generated files have neither
+`es5id` nor `es6id` nor `features`; their maintained `ES5` label therefore
+comes from the `/annexB/` path rule in `scripts/generate-editions.ts`. Although
+their generated source uses a default-parameter-shaped setup, all eight count
+in the maintained `<= ES5` report.
+
+On baseline `c0b422b3792699e9b0d3f28a46714dd5c393dd97`, an exact local-vs-local
+standalone probe of the 22 Test262 files with statically exposed IIFE defaults
+had 2 passes, 14 runtime failures, 4 compile errors, and 2 skips. The candidate
+worktree had 10 passes, 6 runtime failures, 4 compile errors, and 2 skips:
+**+8 passes / 0 regressions**. The host lane produced the same +8/0 diff. The
+eight matching non-default Annex B controls remained passing.
+
+### IR ownership boundary
+
+The affected programs invoke the function expression from the top-level script
+body. Today that body is lowered into the synthesized `__module_init` path, and
+the lifted IIFE is another synthesized function; neither is a source-function
+body selected and owned by the function IR pipeline. The bug therefore occurs
+before there is an IR-owned source function body that could repair it. This
+change only wires the existing default-parameter semantic operation into that
+legacy synthesis boundary. If module initialization and synthesized IIFEs move
+under IR ownership, this operation should move with them rather than gaining a
+second implementation.

--- a/plan/issues/165-function-statement-hoisting-and-edge.md
+++ b/plan/issues/165-function-statement-hoisting-and-edge.md
@@ -102,12 +102,16 @@ comes from the `/annexB/` path rule in `scripts/generate-editions.ts`. Although
 their generated source uses a default-parameter-shaped setup, all eight count
 in the maintained `<= ES5` report.
 
-On baseline `c0b422b3792699e9b0d3f28a46714dd5c393dd97`, an exact local-vs-local
-standalone probe of the 22 Test262 files with statically exposed IIFE defaults
-had 2 passes, 14 runtime failures, 4 compile errors, and 2 skips. The candidate
-worktree had 10 passes, 6 runtime failures, 4 compile errors, and 2 skips:
-**+8 passes / 0 regressions**. The host lane produced the same +8/0 diff. The
-eight matching non-default Annex B controls remained passing.
+After rebasing, an exact local-vs-local comparison used canonical-main commit
+`2a7152fb28e890ed536a2a8a18ff081db83bd74b` as the control and implementation
+commit `251c957dbc0dc3b849c6f0b5723065ab93e714bd` as the candidate. The standalone
+probe of all 22 Test262 files with statically exposed IIFE defaults moved from
+2 passes, 14 runtime failures, 4 compile errors, and 2 skips to 10 passes, 6
+runtime failures, 4 compile errors, and 2 skips: **+8 passes / 0 regressions**.
+The host lane produced the same +8/0 diff. A separate 16-file standalone probe
+combined the eight affected Annex B files with their eight matching
+non-default controls; it moved from 8 passes / 8 failures to 16 passes, so all
+eight controls remained passing.
 
 ### IR ownership boundary
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -192,6 +192,7 @@ import {
 } from "../builtin-static-gopd.js"; // (#2984 Phase 3 + bucket-1 alias receivers + arg-2 name coercion + @@species)
 import { compileStatement, hoistFunctionDeclarations } from "../statements.js";
 import {
+  emitDefaultParamInit,
   emitSetExtrasArgv,
   ensureArgcGlobal,
   ensureExtrasArgvGlobal,
@@ -8637,6 +8638,13 @@ function compileIIFE(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallEx
   if (savedFunc) ctx.funcStack.push(savedFunc);
   ctx.currentFunc = liftedFctx;
 
+  // A lifted IIFE is a real function activation. Its parameter defaults must
+  // run in the synthesized callee before the body, just like defaults on a
+  // source FunctionDeclaration. The old path only padded missing numeric
+  // arguments with NaN and entered the body directly, so `function (x = 1)`
+  // observed NaN whenever the call omitted `x`.
+  emitDefaultParamInit(ctx, liftedFctx, funcExpr, paramTypes, captures.length);
+
   if (ts.isBlock(body)) {
     // Hoist var declarations and let/const with TDZ flags (#790)
     hoistVarDeclarations(ctx, liftedFctx, body.statements);
@@ -8736,6 +8744,15 @@ function compileIIFE(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallEx
     else if (pt.kind === "i32") fctx.body.push({ op: "i32.const", value: 0 });
     else if (pt.kind === "externref") fctx.body.push({ op: "ref.null.extern" });
     else if (pt.kind === "ref" || pt.kind === "ref_null") fctx.body.push({ op: "ref.null", typeIdx: pt.typeIdx });
+  }
+
+  // Numeric defaults use the exact call-site argc rather than treating an
+  // arbitrary NaN payload as the missing-argument sentinel. The synthesized
+  // callee consumes this value once and resets the shared carrier to -1.
+  if (funcExpr.parameters.some((param) => param.initializer)) {
+    const argcGlobalIdx = ensureArgcGlobal(ctx);
+    fctx.body.push({ op: "i32.const", value: Math.min(flatIIFEArgs.length, paramCount) });
+    fctx.body.push({ op: "global.set", index: argcGlobalIdx });
   }
 
   // Re-lookup in case addUnionImports shifted indices

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -2260,10 +2260,10 @@ export function hoistFunctionDeclarations(
  * so compile the initializer.
  * @param paramOffset - number of prepended params (captures) before the user params
  */
-function emitDefaultParamInit(
+export function emitDefaultParamInit(
   ctx: CodegenContext,
   liftedFctx: FunctionContext,
-  stmt: ts.FunctionDeclaration,
+  stmt: ts.FunctionLikeDeclarationBase,
   paramTypes: ValType[],
   paramOffset: number,
 ): void {

--- a/tests/issue-165.test.ts
+++ b/tests/issue-165.test.ts
@@ -108,6 +108,18 @@ describe("Issue #165: function statement hoisting and edge cases", () => {
     expect(result).toBe(7);
   });
 
+  it("IIFE applies a numeric default when the argument is omitted", async () => {
+    const result = await run(
+      `
+      export function test(): number {
+        return (function(value: number = 123): number { return value; })();
+      }
+      `,
+      "test",
+    );
+    expect(result).toBe(123);
+  });
+
   it("arrow IIFE (concise body)", async () => {
     const result = await run(
       `
@@ -264,7 +276,7 @@ describe("Issue #165: function statement hoisting and edge cases", () => {
     expect(result).toBe(42);
   });
 
-  it("IIFE with fewer arguments than params (defaults to 0)", async () => {
+  it("IIFE with fewer arguments leaves an omitted plain parameter undefined", async () => {
     const result = await run(
       `
       export function test(): number {
@@ -273,8 +285,9 @@ describe("Issue #165: function statement hoisting and edge cases", () => {
       `,
       "test",
     );
-    // b defaults to 0 when not provided
-    expect(result).toBe(5);
+    // `b` has no initializer, so ordinary JS leaves it undefined and the
+    // numeric addition produces NaN. This is distinct from a defaulted param.
+    expect(result).toBeNaN();
   });
 
   it("function hoisting order: later declaration shadows earlier in same scope", async () => {


### PR DESCRIPTION
## Summary

- reuse the shared default-parameter prologue for synthesized IIFE activations
- publish the exact supplied-argument count before direct IIFE dispatch
- correct the plain omitted-parameter expectation and add a numeric-default regression
- document the maintained ES5 classifier nuance and the current pre-IR ownership boundary in issue 165

## Test262 evidence

Exact local-vs-local control: canonical main 2a7152fb28e890ed536a2a8a18ff081db83bd74b versus implementation 251c957dbc0dc3b849c6f0b5723065ab93e714bd.

- standalone 22-file exposed set: 2 pass / 14 fail / 4 compile_error / 2 skip -> 10 pass / 6 fail / 4 compile_error / 2 skip
- host 22-file exposed set: identical +8 pass / 0 lost / 14 unchanged
- standalone target/control set: 8 pass / 8 fail -> 16 pass; all eight matching non-default controls stay green
- both harness probes passed built-in must-pass and must-fail controls

The eight gained files are maintained as ES5 through the Annex B path classifier; their Test262 frontmatter has no es5id, es6id, or features entry.

## Validation

- issue 165 + Annex B related Vitest: 49/49
- pnpm run typecheck
- pnpm run check:ir-fallbacks
- pnpm run check:loc-budget
- pnpm run check:func-budget
- oracle ratchet and pre-push typecheck/lint/format/issue-integrity hooks

## IR boundary

These failures originate in top-level script IIFEs synthesized under module init, not in a source-function body selected by the function IR pipeline. The fix reuses the existing semantic operation at that synthesis boundary. Issue 165 records that this operation should move with synthesized IIFEs once that boundary becomes IR-owned.