### PR TITLE
feat(arraybuffer): implement native transfer operations

### DIFF
--- a/plan/issues/1595-arraybuffer-transfer-methods-not-implemented.md
+++ b/plan/issues/1595-arraybuffer-transfer-methods-not-implemented.md
@@ -1,9 +1,9 @@
 ---
 id: 1595
 title: "ArrayBuffer.prototype.transfer / transferToFixedLength / transferToImmutable not implemented (~40 fails)"
-status: blocked
+status: ready
 created: 2026-05-24
-updated: 2026-05-24
+updated: 2026-08-11
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -14,6 +14,15 @@ goal: spec-completeness
 sprint: Backlog
 test262_fail: 40
 test262_category: built-ins/ArrayBuffer
+loc-budget-allow:
+  - src/codegen/dataview-native.ts
+  - src/codegen/property-access-dispatch.ts
+  - src/codegen/expressions/call-receiver-method.ts
+  - src/codegen/expressions/calls.ts
+  - src/codegen/array-object-proto.ts
+func-budget-allow:
+  - src/codegen/property-access-dispatch.ts::tryBufferViewAttributeReads
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
 ---
 # #1595 — ArrayBuffer.prototype.transfer / transferToFixedLength / transferToImmutable
 
@@ -105,3 +114,70 @@ ops must honor.
 
 Marking `status: blocked` (depends on #1645). No source changed; worktree
 `issue-1595-arraybuffer-transfer` left in place (only this doc edit committed).
+
+## Implementation update (2026-08-11)
+
+#1645's resizable/detached ArrayBuffer representation is now available. This
+slice implements the ES2024 `transfer` and `transferToFixedLength` operations
+on that representation and fixes the detached-buffer observations needed by
+the maintained standalone residual. PR #4386 is the prerequisite harness
+change that lets `$262.detachArrayBuffer` mark the native standalone buffer;
+the measurements below use its exact head commit (`9383f0dddac7`) as A.
+
+The implementation is deliberately native and shared rather than an AST-only
+Test262 interception:
+
+- direct calls and reflective
+  `ArrayBuffer.prototype.transfer[ToFixedLength].call(...)` both delegate to
+  one canonical `ArrayBufferCopyAndDetach` helper;
+- the helper performs ordinary `ToIndex` coercion, validates real
+  `TypeError`/`RangeError` objects, copies `min(oldLength, newLength)` bytes,
+  preserves resizability and `maxByteLength` only for `transfer`, and detaches
+  the source through the representation's negative-length marker;
+- `byteLength`, `maxByteLength`, `resizable`, `resize`, and `slice` now observe
+  that same detached state; and
+- the checker loads `lib.es2024.arraybuffer.d.ts`, keeping transfer results on
+  the typed ArrayBuffer path instead of widening into the generic `any` MOP.
+
+### Focused verification
+
+- `tests/issue-1595.test.ts`: **7/7 pass** with zero imports (fixed and
+  resizable transfer, fixed-length conversion, reflective calls and receiver
+  errors, null/undefined optional-length distinction, detached/range errors,
+  and observable coercion ordering).
+- `tests/issue-3054-c-resizable.test.ts`: **22/22 pass**; combined focused run
+  **29/29 pass**.
+
+### Maintained residual A/B
+
+The process-isolated `scripts/harness-flip-probe.ts` instrument was run over
+the exact 12 arrays/buffers detach residuals left after #4386. Its must-pass and
+must-fail controls both behaved correctly on every run.
+
+| Target | A | B | Change |
+| --- | ---: | ---: | ---: |
+| standalone | 0/12 | 6/12 | **+6 / -0, net +6** |
+| host control | 7/12 | 7/12 | **+0 / -0** |
+
+The six standalone gains are:
+
+- `ArrayBuffer/prototype/byteLength/detached-buffer.js`
+- `ArrayBuffer/prototype/maxByteLength/detached-buffer.js`
+- `ArrayBuffer/prototype/resizable/detached-buffer.js`
+- `ArrayBuffer/prototype/resize/this-is-detached.js`
+- `ArrayBuffer/prototype/transfer/this-is-detached.js`
+- `ArrayBuffer/prototype/transferToFixedLength/this-is-detached.js`
+
+The six unchanged standalone residuals remain explicitly out of this slice:
+
+- detached `DataView` construction;
+- `sliceToImmutable` and `transferToImmutable` immutable-buffer semantics; and
+- detached `Uint8Array.prototype.toHex`, `setFromBase64`, and `setFromHex`.
+
+A broader standalone smoke over the two transfer-method directories was
+**20 pass / 26 fail / 2 compile-error (48 total)**. The native helper's focused
+copy/grow/shrink and metadata cases pass, while much of the remaining family
+currently fails before reaching it due to the pre-existing top-level global
+TypedArray-view representation path. SharedArrayBuffer receiver cases are the
+two host-import compile errors. Immutable-buffer cases remain part of this
+issue's open acceptance criteria, so #1595 stays `ready`, not `done`.

--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -246,6 +246,12 @@ const ES_BASE_LIB_NAMES = [
   "lib.es2023.collection.d.ts",
   "lib.es2023.intl.d.ts",
   // ES2024
+  // ArrayBuffer resize/transfer + maxByteLength/resizable/detached. Keeping the
+  // checker aware of these built-ins is semantic, not merely diagnostic: the
+  // return type of `buffer.transfer()` must remain ArrayBuffer so downstream
+  // native buffer getters and TypedArray-on-buffer construction stay on their
+  // canonical typed paths instead of widening to the generic `any` MOP.
+  "lib.es2024.arraybuffer.d.ts",
   "lib.es2024.collection.d.ts",
   // ES2024 String.prototype.isWellFormed / toWellFormed (#3068) — required so
   // the checker types these methods' results as boolean/string (else `X === y`

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -33,7 +33,7 @@ import {
 } from "./native-proto.js";
 import { pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
 import { emitThrowTypeError } from "./expressions/helpers.js";
-import { emitDataViewProtoMemberBody } from "./dataview-native.js"; // (#3173) reflective DataView member bodies
+import { emitArrayBufferProtoMemberBody, emitDataViewProtoMemberBody } from "./dataview-native.js";
 import { emitDateProtoMemberBody } from "./expressions/builtins.js"; // (#3219) reflective Date getter bodies
 import { emitDateReflectiveSetterBody } from "./date-reflective-setters.js"; // (#3174) reflective Date setter/toISOString bodies
 import { allocLocal } from "./context/locals.js";
@@ -1906,16 +1906,21 @@ export function ensureArrayBufferNativeProtoGlue(ctx: CodegenContext): number | 
   const brand = getBuiltinBrand(ctx, "ArrayBuffer");
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
-    registerNativeProtoBuiltin(
-      ctx,
-      makeGlueWithGetters(
-        brand,
-        "ArrayBuffer",
-        ARRAYBUFFER_PROTO_METHODS,
-        ARRAYBUFFER_PROTO_GETTERS,
-        ARRAYBUFFER_PROTO_METHOD_LENGTH,
-      ),
+    const glue = makeGlueWithGetters(
+      brand,
+      "ArrayBuffer",
+      ARRAYBUFFER_PROTO_METHODS,
+      ARRAYBUFFER_PROTO_GETTERS,
+      ARRAYBUFFER_PROTO_METHOD_LENGTH,
     );
+    // (#1595) `transfer` and `transferToFixedLength` have an optional
+    // newLength parameter even though their spec `.length` is 0. Give the
+    // reflective closure a real argument slot, then delegate its body to the
+    // same native ArrayBufferCopyAndDetach helper used by direct calls.
+    glue.memberParamSlots = (member) =>
+      member === "transfer" || member === "transferToFixedLength" ? 1 : member === "slice" ? 2 : 0;
+    glue.emitMemberBody = (c, fctx, member) => emitArrayBufferProtoMemberBody(c, fctx, member);
+    registerNativeProtoBuiltin(ctx, glue);
   }
   return brand;
 }

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -129,6 +129,11 @@ export function emitArrayBufferSlice(
   const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" }); // (#2835) packed byte buffer
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
   if (arrTypeIdx < 0) return null;
+  const detachedThrow = buildThrowJsErrorInstrs(
+    ctx,
+    "TypeError",
+    "TypeError: ArrayBuffer.prototype.slice called on a detached buffer",
+  );
 
   // Recover the source vec struct from the receiver (externref → struct).
   const srcVecLocal = allocLocal(fctx, `__abs_src_${fctx.locals.length}`, {
@@ -153,6 +158,9 @@ export function emitArrayBufferSlice(
   fctx.body.push({ op: "local.get", index: srcVecLocal });
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
   fctx.body.push({ op: "local.set", index: srcLenLocal });
+  // §25.1.5.3 step 4 — validate detachment before coercing begin/end. The
+  // native detached state is the shared buffer vec's negative length marker.
+  emitArrayBufferDetachedCheck(fctx, srcVecLocal, vecTypeIdx, detachedThrow);
   const srcArrLocal = allocLocal(fctx, `__abs_srcarr_${fctx.locals.length}`, {
     kind: "ref",
     typeIdx: arrTypeIdx,
@@ -274,8 +282,26 @@ export function emitArrayBufferResize(
   compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
 ): ValType | null {
   const rabTypeIdx = getOrRegisterResizableAbType(ctx);
-  const arrTypeIdx = getArrTypeIdxFromVec(ctx, getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" }));
+  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" });
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
   if (arrTypeIdx < 0) return null;
+  // Build real JS error objects before compiling operands so any helper
+  // registration happens before later function indices are captured.
+  const brandThrow = buildThrowJsErrorInstrs(
+    ctx,
+    "TypeError",
+    "TypeError: ArrayBuffer.prototype.resize called on non-resizable buffer",
+  );
+  const detachedThrow = buildThrowJsErrorInstrs(
+    ctx,
+    "TypeError",
+    "TypeError: ArrayBuffer.prototype.resize called on a detached buffer",
+  );
+  const rangeThrow = buildThrowJsErrorInstrs(
+    ctx,
+    "RangeError",
+    "RangeError: ArrayBuffer.prototype.resize length exceeds maxByteLength",
+  );
 
   // Recover the receiver as anyref, then require it to be a $__resizable_ab.
   const recvType = compileExpr(receiver);
@@ -291,17 +317,7 @@ export function emitArrayBufferResize(
   fctx.body.push({ op: "local.get", index: anyLocal });
   fctx.body.push({ op: "ref.test", typeIdx: rabTypeIdx });
   fctx.body.push({ op: "i32.eqz" });
-  {
-    const msg = "TypeError: ArrayBuffer.prototype.resize called on non-resizable buffer";
-    addStringConstantGlobal(ctx, msg);
-    const tagIdx = ensureExnTag(ctx);
-    fctx.body.push({
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [...stringConstantExternrefInstrs(ctx, msg), { op: "throw", tagIdx }],
-      else: [],
-    });
-  }
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: brandThrow, else: [] });
 
   // rab = ref.cast $__resizable_ab (the checked receiver).
   const rabLocal = allocLocal(fctx, `__rabz_rab_${fctx.locals.length}`, { kind: "ref", typeIdx: rabTypeIdx });
@@ -338,26 +354,26 @@ export function emitArrayBufferResize(
   fctx.body.push({ op: "i32.trunc_sat_f64_s" });
   fctx.body.push({ op: "local.set", index: newLen });
 
-  // RangeError if newLen < 0 OR newLen > maxByteLength (field 2).
-  fctx.body.push({ op: "local.get", index: newLen });
-  fctx.body.push({ op: "i32.const", value: 0 });
-  fctx.body.push({ op: "i32.lt_s" });
+  // ToIndex range validation happens before the detached check.
+  fctx.body.push({ op: "local.get", index: newLenF64 });
+  fctx.body.push({ op: "f64.const", value: 0 });
+  fctx.body.push({ op: "f64.lt" });
+  fctx.body.push({ op: "local.get", index: newLenF64 });
+  fctx.body.push({ op: "f64.const", value: 9007199254740991 });
+  fctx.body.push({ op: "f64.gt" });
+  fctx.body.push({ op: "i32.or" });
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rangeThrow, else: [] });
+
+  // §25.1.6.4 step 5 — the shared negative-length marker is checked after
+  // ToIndex, before the declared maxByteLength bound.
+  emitArrayBufferDetachedCheck(fctx, rabLocal, vecTypeIdx, detachedThrow);
+
+  // RangeError if newLen > maxByteLength (field 2).
   fctx.body.push({ op: "local.get", index: newLen });
   fctx.body.push({ op: "local.get", index: rabLocal });
   fctx.body.push({ op: "struct.get", typeIdx: rabTypeIdx, fieldIdx: 2 });
   fctx.body.push({ op: "i32.gt_s" });
-  fctx.body.push({ op: "i32.or" });
-  {
-    const msg = "RangeError: ArrayBuffer.prototype.resize length exceeds maxByteLength";
-    addStringConstantGlobal(ctx, msg);
-    const tagIdx = ensureExnTag(ctx);
-    fctx.body.push({
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [...stringConstantExternrefInstrs(ctx, msg), { op: "throw", tagIdx }],
-      else: [],
-    });
-  }
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rangeThrow, else: [] });
 
   // oldLen = min(rab.length, newLen) — bytes to preserve.
   const oldLen = allocLocal(fctx, `__rabz_ol_${fctx.locals.length}`, { kind: "i32" });
@@ -396,6 +412,344 @@ export function emitArrayBufferResize(
   fctx.body.push({ op: "struct.set", typeIdx: rabTypeIdx, fieldIdx: 0 });
 
   return null;
+}
+
+/**
+ * Shared native IsDetachedBuffer check for ArrayBuffer operations. Standalone
+ * detachment is represented by field 0 (`length`) being negative; every
+ * operation consumes this same state instead of maintaining method-specific
+ * sidecars or AST-only flags.
+ */
+function emitArrayBufferDetachedCheck(
+  fctx: FunctionContext,
+  bufferLocal: number,
+  vecTypeIdx: number,
+  detachedThrow: Instr[],
+): void {
+  fctx.body.push({ op: "local.get", index: bufferLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "i32.lt_s" });
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: detachedThrow, else: [] });
+}
+
+type ArrayBufferTransferMethod = "transfer" | "transferToFixedLength";
+
+function arrayBufferTransferHelperName(method: ArrayBufferTransferMethod): string {
+  return method === "transfer" ? "__ab_transfer" : "__ab_transfer_fixed";
+}
+
+/**
+ * Native ArrayBufferCopyAndDetach core shared by direct instance calls and
+ * reflective `ArrayBuffer.prototype.<method>.call(...)` closures.
+ *
+ * ABI: `(receiver: externref, newLengthOrUndefined: externref) -> externref`.
+ * The canonical standalone undefined singleton distinguishes an omitted or
+ * explicit `undefined` length from an explicit JS `null` (which ToIndex maps
+ * to zero).
+ * The helper performs the observable ToIndex conversion before checking the
+ * shared detached marker, allocates/copies a new native byte vec, preserves
+ * resizability only for `transfer`, and finally detaches the source by setting
+ * its length to -1. All semantics live here; AST and reflective call surfaces
+ * are thin adapters to the same native runtime operation.
+ */
+export function ensureArrayBufferTransferHelper(
+  ctx: CodegenContext,
+  method: ArrayBufferTransferMethod,
+): number | undefined {
+  if (!noJsHost(ctx)) return undefined;
+  const helperName = arrayBufferTransferHelperName(method);
+  const existing = ctx.funcMap.get(helperName);
+  if (existing !== undefined) return existing;
+
+  // ArrayBufferCopyAndDetach distinguishes undefined from null. Reserve the
+  // canonical standalone undefined predicate before constructing the helper;
+  // both direct and reflective adapters pass the same singleton for omission.
+  ensureObjectRuntime(ctx);
+  const isUndefinedIdx = ctx.funcMap.get("__extern_is_undefined");
+
+  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" });
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) return undefined;
+  const rabTypeIdx = getOrRegisterResizableAbType(ctx);
+
+  const params: ValType[] = [{ kind: "externref" }, { kind: "externref" }];
+  const fctx: FunctionContext = {
+    name: helperName,
+    params: [
+      { name: "receiver", type: params[0]! },
+      { name: "newLength", type: params[1]! },
+    ],
+    locals: [],
+    localMap: new Map(),
+    returnType: { kind: "externref" },
+    body: [],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  };
+
+  // Error constructors are resolved before operand coercion freezes any
+  // function indices. These templates throw real catchable Error instances.
+  const brandThrow = buildThrowJsErrorInstrs(
+    ctx,
+    "TypeError",
+    `TypeError: ArrayBuffer.prototype.${method} called on an incompatible receiver`,
+  );
+  const detachedThrow = buildThrowJsErrorInstrs(
+    ctx,
+    "TypeError",
+    `TypeError: ArrayBuffer.prototype.${method} called on a detached buffer`,
+  );
+  const rangeThrow = buildThrowJsErrorInstrs(ctx, "RangeError", "RangeError: Invalid array buffer length");
+
+  const anyLocal = allocLocal(fctx, "receiverAny", { kind: "anyref" });
+  const srcLocal = allocLocal(fctx, "source", { kind: "ref", typeIdx: vecTypeIdx });
+  fctx.body.push({ op: "local.get", index: 0 });
+  fctx.body.push({ op: "any.convert_extern" });
+  fctx.body.push({ op: "local.tee", index: anyLocal });
+  fctx.body.push({ op: "ref.test", typeIdx: vecTypeIdx });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: anyLocal },
+      { op: "ref.cast", typeIdx: vecTypeIdx },
+      { op: "local.set", index: srcLocal },
+    ],
+    else: brandThrow,
+  });
+
+  const oldLenLocal = allocLocal(fctx, "oldLength", { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: srcLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "local.set", index: oldLenLocal });
+
+  // Missing/undefined newLength defaults to the current byte length. An
+  // explicit value takes the ordinary ToPrimitive(number) / ToNumber route.
+  const hasLengthLocal = allocLocal(fctx, "hasLength", { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: 1 });
+  if (isUndefinedIdx !== undefined) {
+    fctx.body.push({ op: "call", funcIdx: isUndefinedIdx });
+  } else {
+    // Flag-disabled compatibility: standalone historically conflated null and
+    // undefined. Default builds always use the distinct singleton above.
+    fctx.body.push({ op: "ref.is_null" });
+  }
+  fctx.body.push({ op: "i32.eqz" });
+  fctx.body.push({ op: "local.set", index: hasLengthLocal });
+
+  const newLenF64Local = allocLocal(fctx, "newLengthF64", { kind: "f64" });
+  fctx.body.push({ op: "local.get", index: hasLengthLocal });
+  const explicitLength: Instr[] = [];
+  const savedBody = fctx.body;
+  fctx.body = explicitLength;
+  fctx.body.push({ op: "local.get", index: 1 });
+  coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" });
+  fctx.body = savedBody;
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "f64" } },
+    then: explicitLength,
+    else: [
+      // A detached source uses -1 internally, but the spec's detached
+      // [[ArrayBufferByteLength]] default is observed as zero before the
+      // subsequent IsDetachedBuffer TypeError.
+      { op: "local.get", index: oldLenLocal },
+      { op: "i32.const", value: 0 },
+      { op: "local.get", index: oldLenLocal },
+      { op: "i32.const", value: 0 },
+      { op: "i32.ge_s" },
+      { op: "select" },
+      { op: "f64.convert_i32_s" },
+    ],
+  });
+  fctx.body.push({ op: "local.set", index: newLenF64Local });
+
+  // ToIndex: NaN -> +0, truncate toward zero, then reject negative or values
+  // above Number.MAX_SAFE_INTEGER before reading the detached state.
+  fctx.body.push({ op: "local.get", index: newLenF64Local });
+  fctx.body.push({ op: "f64.const", value: 0 });
+  fctx.body.push({ op: "local.get", index: newLenF64Local });
+  fctx.body.push({ op: "local.get", index: newLenF64Local });
+  fctx.body.push({ op: "f64.eq" });
+  fctx.body.push({ op: "select" });
+  fctx.body.push({ op: "f64.trunc" });
+  fctx.body.push({ op: "local.set", index: newLenF64Local });
+  fctx.body.push({ op: "local.get", index: newLenF64Local });
+  fctx.body.push({ op: "f64.const", value: 0 });
+  fctx.body.push({ op: "f64.lt" });
+  fctx.body.push({ op: "local.get", index: newLenF64Local });
+  fctx.body.push({ op: "f64.const", value: 9007199254740991 });
+  fctx.body.push({ op: "f64.gt" });
+  fctx.body.push({ op: "i32.or" });
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rangeThrow, else: [] });
+
+  const newLenLocal = allocLocal(fctx, "newLengthI32", { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: newLenF64Local });
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+  fctx.body.push({ op: "local.set", index: newLenLocal });
+
+  // ArrayBufferCopyAndDetach checks detachment after argument conversion.
+  emitArrayBufferDetachedCheck(fctx, srcLocal, vecTypeIdx, detachedThrow);
+
+  const preserveResizableLocal = allocLocal(fctx, "preserveResizable", { kind: "i32" });
+  if (method === "transfer") {
+    fctx.body.push({ op: "local.get", index: srcLocal });
+    fctx.body.push({ op: "ref.test", typeIdx: rabTypeIdx });
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 });
+  }
+  fctx.body.push({ op: "local.set", index: preserveResizableLocal });
+
+  const maxLenLocal = allocLocal(fctx, "maxLength", { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: preserveResizableLocal });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: srcLocal },
+      { op: "ref.cast", typeIdx: rabTypeIdx },
+      { op: "struct.get", typeIdx: rabTypeIdx, fieldIdx: 2 },
+      { op: "local.tee", index: maxLenLocal },
+      { op: "local.get", index: newLenLocal },
+      { op: "i32.lt_s" },
+      { op: "if", blockType: { kind: "empty" }, then: rangeThrow, else: [] },
+    ],
+    else: [],
+  });
+
+  const srcArrLocal = allocLocal(fctx, "sourceData", { kind: "ref", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "local.get", index: srcLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
+  fctx.body.push({ op: "local.set", index: srcArrLocal });
+
+  const dstArrLocal = allocLocal(fctx, "destinationData", { kind: "ref", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "local.get", index: newLenLocal });
+  fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "local.set", index: dstArrLocal });
+
+  const copyLenLocal = allocLocal(fctx, "copyLength", { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: oldLenLocal });
+  fctx.body.push({ op: "local.get", index: newLenLocal });
+  fctx.body.push({ op: "local.get", index: oldLenLocal });
+  fctx.body.push({ op: "local.get", index: newLenLocal });
+  fctx.body.push({ op: "i32.lt_s" });
+  fctx.body.push({ op: "select" });
+  fctx.body.push({ op: "local.set", index: copyLenLocal });
+  fctx.body.push({ op: "local.get", index: dstArrLocal });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.get", index: srcArrLocal });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.get", index: copyLenLocal });
+  fctx.body.push({ op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx });
+
+  // Detach the source only after allocation and copying succeed.
+  fctx.body.push({ op: "local.get", index: srcLocal });
+  fctx.body.push({ op: "i32.const", value: -1 });
+  fctx.body.push({ op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 });
+
+  // `transfer` preserves a resizable source's maxByteLength;
+  // `transferToFixedLength` and fixed sources return the parent vec type.
+  fctx.body.push({ op: "local.get", index: preserveResizableLocal });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "externref" } },
+    then: [
+      { op: "local.get", index: newLenLocal },
+      { op: "local.get", index: dstArrLocal },
+      { op: "local.get", index: maxLenLocal },
+      { op: "struct.new", typeIdx: rabTypeIdx },
+      { op: "extern.convert_any" },
+    ],
+    else: [
+      { op: "local.get", index: newLenLocal },
+      { op: "local.get", index: dstArrLocal },
+      { op: "struct.new", typeIdx: vecTypeIdx },
+      { op: "extern.convert_any" },
+    ],
+  });
+
+  flushLateImportShifts(ctx, fctx);
+  const typeIdx = addFuncType(ctx, params, [{ kind: "externref" }]);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set(helperName, funcIdx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: helperName,
+    typeIdx,
+    locals: fctx.locals,
+    body: fctx.body,
+    exported: false,
+  });
+  return funcIdx;
+}
+
+/** Thin direct-call adapter to the shared native transfer helper. */
+export function emitArrayBufferTransfer(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  method: ArrayBufferTransferMethod,
+  receiver: import("../ts-api.js").ts.Expression,
+  args: readonly import("../ts-api.js").ts.Expression[],
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  if (!noJsHost(ctx) || ensureArrayBufferTransferHelper(ctx, method) === undefined) return null;
+
+  const receiverType = compileExpr(receiver);
+  if (!receiverType) return null;
+  coerceType(ctx, fctx, receiverType, { kind: "externref" });
+  const receiverLocal = allocLocal(fctx, `__abt_recv_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: receiverLocal });
+
+  const lengthLocal = allocLocal(fctx, `__abt_len_${fctx.locals.length}`, { kind: "externref" });
+  const omittedLength = undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" } as Instr];
+  if (args.length > 0) {
+    const argType = compileExpr(args[0]!);
+    if (argType) {
+      coerceType(ctx, fctx, argType, { kind: "externref" });
+    } else {
+      fctx.body.push(...omittedLength);
+    }
+  } else {
+    fctx.body.push(...omittedLength);
+  }
+  fctx.body.push({ op: "local.set", index: lengthLocal });
+
+  // Extra arguments are ignored by the operation but still evaluated.
+  for (let i = 1; i < args.length; i++) {
+    const extraType = compileExpr(args[i]!);
+    if (extraType) fctx.body.push({ op: "drop" });
+  }
+
+  flushLateImportShifts(ctx, fctx);
+  const helperIdx = ctx.funcMap.get(arrayBufferTransferHelperName(method));
+  if (helperIdx === undefined) return null;
+  fctx.body.push({ op: "local.get", index: receiverLocal });
+  fctx.body.push({ op: "local.get", index: lengthLocal });
+  fctx.body.push({ op: "call", funcIdx: helperIdx });
+  return { kind: "externref" };
+}
+
+/** Reflective member-closure adapter to the same native transfer helper. */
+export function emitArrayBufferProtoMemberBody(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  member: string,
+): ValType | null {
+  if (member !== "transfer" && member !== "transferToFixedLength") return null;
+  const helperIdx = ensureArrayBufferTransferHelper(ctx, member);
+  if (helperIdx === undefined) return null;
+  // Closure ABI: param 0 = wrapper, param 1 = this, param 2 = optional length.
+  fctx.body.push({ op: "local.get", index: 1 });
+  if (fctx.params.length > 2) {
+    fctx.body.push({ op: "local.get", index: 2 });
+  } else {
+    fctx.body.push({ op: "ref.null.extern" });
+  }
+  fctx.body.push({ op: "call", funcIdx: helperIdx });
+  return { kind: "externref" };
 }
 
 /**

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -49,6 +49,7 @@ import { staticIntegerRange } from "../analysis/static-numeric-range.js";
 import {
   emitArrayBufferResize,
   emitArrayBufferSlice,
+  emitArrayBufferTransfer,
   emitDataViewAccessor,
   ensureDvAccessorHelper,
   ensureTaDynCopyWithinHelper,
@@ -686,6 +687,25 @@ export function compileReceiverMethodCall(
         compileExpression(ctx, fctx, e, hint),
       );
       return VOID_RESULT;
+    }
+  }
+
+  // (#1595) Direct-call adapter to the canonical native
+  // ArrayBufferCopyAndDetach helper. The operation itself is shared with the
+  // reflective ArrayBuffer.prototype member closures; this surface only
+  // compiles the receiver/argument expressions into that common ABI.
+  if (noJsHost(ctx) && (propAccess.name.text === "transfer" || propAccess.name.text === "transferToFixedLength")) {
+    const recvSym = receiverType.getSymbol()?.name;
+    if (recvSym === "ArrayBuffer") {
+      const transferResult = emitArrayBufferTransfer(
+        ctx,
+        fctx,
+        propAccess.name.text,
+        propAccess.expression,
+        expr.arguments,
+        (e, hint) => compileExpression(ctx, fctx, e, hint),
+      );
+      if (transferResult) return transferResult;
     }
   }
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -159,6 +159,7 @@ import {
 } from "../shared.js";
 // (#2193 PR-B) reflective `m.call(thisArg, …)` on a `$NativeProto` member-closure value.
 import {
+  ensureArrayBufferNativeProtoGlue,
   ensureArrayNativeProtoGlue,
   ensureDataViewNativeProtoGlue,
   ensureDateNativeProtoGlue,
@@ -1067,6 +1068,8 @@ function tryEmitNativeProtoReflectiveCall(
     brand = ensureStringNativeProtoGlue(ctx); // (#2875)
   else if (ifaceName === "DataView")
     brand = ensureDataViewNativeProtoGlue(ctx); // (#3173)
+  else if (ifaceName === "ArrayBuffer")
+    brand = ensureArrayBufferNativeProtoGlue(ctx); // (#1595)
   else if (ifaceName === "Date") brand = ensureDateNativeProtoGlue(ctx); // (#3219)
   if (brand === undefined) return undefined;
 
@@ -1181,6 +1184,13 @@ function emitReflectiveNativeProtoClosureCall(
   fctx.body.push({ op: "local.get", index: closureLocal });
 
   const paramTypes = closureInfo.paramTypes; // excludes the self param
+  // ArrayBufferCopyAndDetach must distinguish an omitted/undefined newLength
+  // from explicit null. This native-proto call surface normally pads optional
+  // externrefs with null, so use the canonical standalone undefined singleton
+  // for ArrayBuffer members; their shared helper applies the corresponding
+  // runtime predicate. Other builtin families retain their existing ABI.
+  const arrayBufferUndefinedPad =
+    getNativeProtoBuiltinGlue(ctx, brand)?.name === "ArrayBuffer" ? undefinedExternInstrs(ctx) : undefined;
   for (let i = 0; i < paramTypes.length; i++) {
     const pType = paramTypes[i]!;
     if (i < userArgs.length) {
@@ -1189,7 +1199,7 @@ function emitReflectiveNativeProtoClosureCall(
         coerceType(ctx, fctx, aType, pType);
       }
     } else if (pType.kind === "externref") {
-      fctx.body.push({ op: "ref.null.extern" });
+      fctx.body.push(...(arrayBufferUndefinedPad ?? [{ op: "ref.null.extern" }]));
     } else {
       pushDefaultValue(fctx, pType, ctx);
     }

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -743,28 +743,41 @@ export function tryBufferViewAttributeReads(
       const abAny = allocLocal(fctx, `__rab_any_${fctx.locals.length}`, { kind: "anyref" });
       fctx.body.push({ op: "local.set", index: abAny });
       if (propName === "resizable") {
+        // IsResizableArrayBuffer is the native subtype identity and is
+        // intentionally unaffected by detachment. Keep the boolean tag on the
+        // ValType so an escaped value boxes as true/false, not numeric 1/0.
         fctx.body.push({ op: "local.get", index: abAny });
         fctx.body.push({ op: "ref.test", typeIdx: rabTypeIdx });
-        // Boolean result. In non-fast mode surface it as an f64 0/1 (truthy in
-        // conditionals, and `=== true` compares fold correctly downstream).
-        if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
-        return ctx.fast ? { kind: "i32", boolean: true } : { kind: "f64" };
+        return { kind: "i32", boolean: true };
       }
-      // maxByteLength: if resizable read field 2, else the byteLength (field 0).
+      // maxByteLength: detached -> 0; otherwise resizable field 2 or fixed
+      // byteLength field 0.
       fctx.body.push({ op: "local.get", index: abAny });
-      fctx.body.push({ op: "ref.test", typeIdx: rabTypeIdx });
+      fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx });
+      fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+      fctx.body.push({ op: "i32.const", value: 0 });
+      fctx.body.push({ op: "i32.lt_s" });
       fctx.body.push({
         op: "if",
         blockType: { kind: "val", type: { kind: "i32" } as ValType },
-        then: [
-          { op: "local.get", index: abAny },
-          { op: "ref.cast", typeIdx: rabTypeIdx },
-          { op: "struct.get", typeIdx: rabTypeIdx, fieldIdx: 2 },
-        ],
+        then: [{ op: "i32.const", value: 0 }],
         else: [
           { op: "local.get", index: abAny },
-          { op: "ref.cast", typeIdx: vecTypeIdx },
-          { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+          { op: "ref.test", typeIdx: rabTypeIdx },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } as ValType },
+            then: [
+              { op: "local.get", index: abAny },
+              { op: "ref.cast", typeIdx: rabTypeIdx },
+              { op: "struct.get", typeIdx: rabTypeIdx, fieldIdx: 2 },
+            ],
+            else: [
+              { op: "local.get", index: abAny },
+              { op: "ref.cast", typeIdx: vecTypeIdx },
+              { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+            ],
+          },
         ],
       });
       if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
@@ -967,6 +980,15 @@ export function tryBufferViewAttributeReads(
             { op: "local.get", index: lenTmpBL },
             { op: "ref.cast", typeIdx: vecTypeIdx },
             { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+            // A detached ArrayBuffer stores -1 as its canonical native marker;
+            // the public byteLength accessor observes zero.
+            { op: "i32.const", value: 0 },
+            { op: "local.get", index: lenTmpBL },
+            { op: "ref.cast", typeIdx: vecTypeIdx },
+            { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+            { op: "i32.const", value: 0 },
+            { op: "i32.ge_s" },
+            { op: "select" },
           ],
           else: [{ op: "i32.const", value: 0 }],
         });

--- a/tests/issue-1595.test.ts
+++ b/tests/issue-1595.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string, exportName = "test"): Promise<number> {
+  const result = await compile(source, { fileName: "test.ts", target: "standalone" });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const module = await WebAssembly.compile(result.binary);
+  expect(WebAssembly.Module.imports(module)).toEqual([]);
+  const instance = await WebAssembly.instantiate(module, {});
+  return (instance.exports[exportName] as () => number)();
+}
+
+describe("#1595 ArrayBuffer transfer operations (standalone)", () => {
+  it("transfers bytes into a grown fixed buffer and detaches the source", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const source = new ArrayBuffer(4);
+          const sourceBytes = new Uint8Array(source);
+          sourceBytes[0] = 1;
+          sourceBytes[1] = 2;
+          sourceBytes[2] = 3;
+          sourceBytes[3] = 4;
+
+          const dest = source.transfer(5);
+          const destBytes = new Uint8Array(dest);
+          let detachedSlice = 0;
+          try { source.slice(); }
+          catch (error) { detachedSlice = error instanceof TypeError ? 1 : 9; }
+
+          return source.byteLength * 1000000
+            + dest.byteLength * 100000
+            + dest.maxByteLength * 10000
+            + (dest.resizable ? 1000 : 0)
+            + destBytes[0] * 100
+            + destBytes[3] * 10
+            + destBytes[4]
+            + detachedSlice;
+        }
+      `),
+    ).toBe(550141);
+  });
+
+  it("preserves a resizable buffer's maxByteLength for transfer", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const source = new ArrayBuffer(4, { maxByteLength: 8 });
+          new Uint8Array(source)[0] = 7;
+          const dest = source.transfer(5);
+          return source.byteLength * 10000
+            + dest.byteLength * 1000
+            + dest.maxByteLength * 100
+            + (dest.resizable ? 10 : 0)
+            + new Uint8Array(dest)[0];
+        }
+      `),
+    ).toBe(5817);
+  });
+
+  it("transferToFixedLength drops resizability and can outgrow the old maximum", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const source = new ArrayBuffer(2, { maxByteLength: 4 });
+          new Uint8Array(source)[0] = 6;
+          const dest = source.transferToFixedLength(5);
+          return source.byteLength * 10000
+            + dest.byteLength * 1000
+            + dest.maxByteLength * 100
+            + (dest.resizable ? 10 : 0)
+            + new Uint8Array(dest)[0];
+        }
+      `),
+    ).toBe(5506);
+  });
+
+  it("distinguishes null from omitted and undefined lengths on direct and reflective calls", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const directNull = new ArrayBuffer(4).transfer(null as any);
+          const directUndefined = new ArrayBuffer(3).transfer(undefined);
+          const reflectiveNull = ArrayBuffer.prototype.transfer.call(new ArrayBuffer(2), null as any);
+          const reflectiveOmitted = ArrayBuffer.prototype.transfer.call(new ArrayBuffer(5));
+          return directNull.byteLength * 1000
+            + directUndefined.byteLength * 100
+            + reflectiveNull.byteLength * 10
+            + reflectiveOmitted.byteLength;
+        }
+      `),
+    ).toBe(305);
+  });
+
+  it("shares the native operation with reflective prototype calls and brand checks", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const source = new ArrayBuffer(4);
+          new Uint8Array(source)[0] = 9;
+          const dest = ArrayBuffer.prototype.transfer.call(source, 3);
+          let wrongReceiver = 0;
+          try { ArrayBuffer.prototype.transfer.call({}); }
+          catch (error) { wrongReceiver = error instanceof TypeError ? 1 : 9; }
+          return source.byteLength * 1000
+            + dest.byteLength * 10
+            + new Uint8Array(dest)[0]
+            + wrongReceiver;
+        }
+      `),
+    ).toBe(40);
+  });
+
+  it("throws real JS error objects for detached operations and excessive lengths", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const source = new ArrayBuffer(4, { maxByteLength: 8 });
+          source.transfer(3);
+          let result = 0;
+          try { source.resize(1); }
+          catch (error) { if (error instanceof TypeError) result += 1; }
+          try { source.slice(); }
+          catch (error) { if (error instanceof TypeError) result += 2; }
+          try { source.transferToFixedLength(); }
+          catch (error) { if (error instanceof TypeError) result += 4; }
+          try { new ArrayBuffer(0).transfer(9007199254740992); }
+          catch (error) { if (error instanceof RangeError) result += 8; }
+          return result;
+        }
+      `),
+    ).toBe(15);
+  });
+
+  it("runs ToPrimitive(number) once and propagates its TypeError", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          let log = 0;
+          const newLength: any = {
+            valueOf() { log = log * 10 + 1; return {}; },
+            toString() { log = log * 10 + 2; return {}; }
+          };
+          try { new ArrayBuffer(0).transfer(newLength); return 0; }
+          catch (error) { return log * 10 + (error instanceof TypeError ? 1 : 2); }
+        }
+      `),
+    ).toBe(121);
+  });
+});


### PR DESCRIPTION
Implements shared standalone ArrayBuffer copy-and-detach semantics for transfer and transferToFixedLength, including direct and reflective calls, detached byteLength/maxByteLength/resizable/resize observations, byte copying, error behavior, and ES2024 checker typing. Exact post-#4386 residual A/B: standalone 0/12 to 6/12 (+6/-0); host controls remain 7/12. Focused validation: #1595 7/7, resizable ArrayBuffer 22/22, DataView 8/8, typecheck, IR fallback, LOC/function gates, and repository hooks pass. Immutable-buffer methods, detached DataView construction, and detached Uint8Array conversion methods remain documented follow-ups in repo issue #1595.