### PR TITLE
fix(array): preserve inherited filter elements

### DIFF
--- a/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
+++ b/plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md
@@ -4,7 +4,7 @@ title: "Per-call \"clean elements\" protector cell for Array.prototype traversal
 status: ready
 sprint: current
 created: 2026-08-05
-updated: 2026-08-06
+updated: 2026-08-12
 priority: high
 horizon: l
 feasibility: hard
@@ -30,6 +30,7 @@ loc-budget-allow:
   - src/codegen/object-runtime.ts
   - src/codegen/index.ts
   - src/codegen/context/types.ts
+  - src/codegen/vec-overlay.ts
 # (#1917/#2108 coercion-sites gate) proto-index-store.ts's `__protoidx_norm_key`
 # DELEGATES to the engine's own helpers by funcMap name (number_toString /
 # __str_to_number / __unbox_number — the same trio __to_property_key composes);
@@ -60,6 +61,7 @@ func-budget-allow:
   - src/codegen/object-runtime.ts::fillExternArrayLikeStructArms
   - src/codegen/index.ts::generateModule
   - src/codegen/index.ts::generateMultiModule
+  - src/codegen/vec-overlay.ts::fillVecOverlayHelpers
 ---
 
 # #4160 — "clean elements" protector cell for Array.prototype traversal
@@ -70,6 +72,40 @@ Back to `ready`. The frontmatter said `in-progress` / `assignee:
 ttraenkler/sendev-4160-read`, but that agent no longer exists and its work
 merged; the claim on `origin/issue-assignments` was **released** on 2026-08-06
 so the remainder can be picked up. Nobody is working on this right now.
+
+## Follow-up (2026-08-12) — typed `filter` live-delete route
+
+The own-array descriptor dependency has now landed far enough to expose a
+smaller coherent Test262 slice. A fresh standalone <=ES5 census (oracle v13,
+48,735 baseline rows, 8,680 in goal scope) measured two `filter` rows whose
+remaining failure was the same shared index MOP gap:
+
+- `15.4.4.20-9-b-13.js`
+- `15.4.4.20-9-6.js`
+
+Both delete an own array index during iteration while the same index exists on
+`Array.prototype`. The typed filter loop stayed on its dense route because
+`overlayRouteActive` did not include `protoIndexDirty`; once routed, the
+`FLAG_DELETED_INDEX` overlay tombstone answered `undefined` / absent directly,
+incorrectly terminating the required prototype walk.
+
+The follow-up adds `protoIndexDirty` to the existing typed-lane route and makes
+the canonical `__extern_get_idx` / `__extern_has_idx` overlay prologues continue
+through the #4160 prototype-index companions after a deleted-own hit. The same
+helpers are emitted once in a hybrid prepared-IR module; there is no parallel
+IR-only implementation. Exact focused A/B is **0/7 -> 2/7**, with the two rows
+above flipping fail->pass and no pass->fail transition.
+The full 242-file `Array.prototype.filter` directory, run locally through the
+same instrument on exact `origin/main` `81ff7c4` and this rebased branch, moved
+from `{pass:162, fail:77, compile_error:3}` to
+`{pass:164, fail:75, compile_error:3}`; those same two rows were the only
+transitions.
+
+The other five measured rows are explicitly not claimed here. Two borrowed
+array-like rows require a different object-carrier model; two sparse numeric
+array rows collapse holes and `undefined` into the same f64 sentinel; and one
+row needs a filter result carrier capable of preserving an inherited string.
+Those are distinct roots, not safe extensions of this route patch.
 
 **Landed** (merged to main):
 

--- a/src/codegen/typed-lane-overlay-route.ts
+++ b/src/codegen/typed-lane-overlay-route.ts
@@ -53,14 +53,18 @@ import { emitRuntimeEvalSharedValueUnwrap } from "./global-environment.js";
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 
 /**
- * Single gate for both directions — standalone, plus either pre-scan flag that
- * says the overlay companion may hold something the dense backing does not:
- * `vecAccessorDescriptorDirty` (#4159, an accessor / non-writable descriptor) or
- * `vecIndexDeleteDirty` (#4222, a `delete arr[i]` tombstone). Either one alone
- * makes the raw `array.get` / `i < length` answer wrong.
+ * Single gate for both directions — standalone, plus any pre-scan flag that
+ * says the dense backing alone cannot answer indexed Get / HasProperty:
+ * `vecAccessorDescriptorDirty` (#4159, an accessor / non-writable descriptor),
+ * `vecIndexDeleteDirty` (#4222, a `delete arr[i]` tombstone), or
+ * `protoIndexDirty` (#4160, an inherited numeric property). Any one alone makes
+ * the raw `array.get` / `i < length` answer wrong.
  */
 export function overlayRouteActive(ctx: CodegenContext): boolean {
-  return ctx.standalone === true && (ctx.vecAccessorDescriptorDirty === true || ctx.vecIndexDeleteDirty === true);
+  return (
+    ctx.standalone === true &&
+    (ctx.vecAccessorDescriptorDirty === true || ctx.vecIndexDeleteDirty === true || ctx.protoIndexDirty === true)
+  );
 }
 
 /**

--- a/src/codegen/vec-overlay-presence.ts
+++ b/src/codegen/vec-overlay-presence.ts
@@ -74,6 +74,8 @@ export interface VecPresenceDeps {
   objFindIdx: number;
   /** `FLAG_DELETED_INDEX` — owned by `vec-overlay.ts`. */
   deletedIndexFlag: number;
+  /** Prototype-chain HasProperty answer for a deleted own index. */
+  deletedIndexMiss?: Instr[];
 }
 
 /**
@@ -86,7 +88,8 @@ export interface VecPresenceDeps {
  *     comp = __vec_overlay_lookup(v);
  *     if (comp != null) {
  *       e = __obj_find(comp, ToString(idx));
- *       if (e != null && (e.flags & FLAG_DELETED_INDEX)) return 0;
+ *       if (e != null && (e.flags & FLAG_DELETED_INDEX))
+ *         return prototypeHas(idx); // or 0 when the proto store is inactive
  *     }
  *   }
  * }
@@ -148,7 +151,7 @@ export function buildVecHasIdxPresencePrologue(fn: WasmFunction, d: VecPresenceD
                     {
                       op: "if",
                       blockType: { kind: "empty" },
-                      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+                      then: [...(d.deletedIndexMiss ?? [{ op: "i32.const", value: 0 }]), { op: "return" }],
                     },
                   ],
                 },

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -90,6 +90,7 @@ import {
   fillVecHasOwnHelpers,
 } from "./vec-bag-seed.js";
 import { buildVecHasIdxPresencePrologue } from "./vec-overlay-presence.js";
+import { protoIndexGetIdxMissInstrs, protoIndexHasIdxInstrs } from "./proto-index-store.js";
 import { undefinedExternInstrs } from "./any-helpers.js";
 import { nonExtensibleFreshIndexGuard, nonWritableLengthIndexGuard } from "./vec-define-rejections.js";
 import { nativeStringLiteralInstrs } from "./native-strings.js";
@@ -2023,6 +2024,21 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
                       op: "if",
                       blockType: { kind: "empty" },
                       then: [
+                        // A deleted own index does not terminate prototype
+                        // lookup. Get must continue at Array.prototype (then
+                        // Object.prototype); only a true chain miss is
+                        // undefined. Check this before COMPANION_VALUE because
+                        // tombstones deliberately carry both flags.
+                        { op: "local.get", index: pE },
+                        { op: "ref.as_non_null" },
+                        { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+                        { op: "i32.const", value: FLAG_DELETED_INDEX },
+                        { op: "i32.and" },
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [...(protoIndexGetIdxMissInstrs(ctx, 0, 1, 1) ?? missExtern()), { op: "return" }],
+                        },
                         // accessor → invoke getter with the VEC as `this`
                         { op: "local.get", index: pE },
                         { op: "ref.as_non_null" },
@@ -2240,6 +2256,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         numToStringIdx,
         objFindIdx,
         deletedIndexFlag: FLAG_DELETED_INDEX,
+        deletedIndexMiss: protoIndexHasIdxInstrs(ctx, 1, 1),
       });
     }
   }

--- a/tests/issue-4160-filter-live-prototype-index.test.ts
+++ b/tests/issue-4160-filter-live-prototype-index.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4160 follow-up — typed Array#filter must route each live indexed read through
+ * the same standalone Has/Get MOP used by the dynamic lane when a module can
+ * mutate builtin prototype indices. In particular, deleting an own element
+ * exposes an inherited element; the vec-overlay tombstone must not terminate
+ * prototype lookup.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+
+function outcome(result: CompileResult, name: string): IrObservedOutcome | undefined {
+  return result.irOutcomes?.find((candidate) => candidate.displayName === name);
+}
+
+describe("#4160 live prototype indices in typed filter", () => {
+  it("shares the standalone indexed MOP across a hybrid prepared-IR module", async () => {
+    const result = await compile(
+      `
+        export function filterDeletedOwn(): number {
+          (Array.prototype as any)[1] = 1;
+          const arr = [0, 111, 2];
+          Object.defineProperty(arr, "0", {
+            get: function () { delete arr[1]; return 0; },
+            configurable: true,
+          });
+          const filtered = arr.filter(function (value) { return value < 3; });
+          return filtered.length * 100 + filtered[1] * 10 + filtered[2];
+        }
+
+        export function filterRepeatedDeletes(): number {
+          (Array.prototype as any)[4] = 5;
+          const source = [1, 2, 3, 4, 5];
+          const filtered = source.filter(function (value) {
+            delete source[2];
+            delete source[4];
+            return value > 0;
+          });
+          return filtered.length * 100 + filtered[0] * 10 + filtered[3];
+        }
+
+        export function prepared(value: number): number { return value + 1; }
+      `,
+      {
+        fileName: "issue-4160-filter-live-prototype-index.ts",
+        target: "standalone",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(WebAssembly.Module.imports(await WebAssembly.compile(result.binary))).toEqual([]);
+
+    // The filter bodies still use the legacy body producer, while a prepared
+    // IR body coexists in the same module. Both see the one module-level pair
+    // of canonical indexed MOP helpers; no parallel IR-only runtime is minted.
+    for (const name of ["filterDeletedOwn", "filterRepeatedDeletes"]) {
+      expect(outcome(result, name)).toMatchObject({
+        kind: "unsupported",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+    }
+    expect(outcome(result, "prepared")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.wat.match(/\(func \$__extern_has_idx\b/g)).toHaveLength(1);
+    expect(result.wat.match(/\(func \$__extern_get_idx\b/g)).toHaveLength(1);
+
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+    const exports = instance.exports as {
+      filterDeletedOwn: () => number;
+      filterRepeatedDeletes: () => number;
+      prepared: (value: number) => number;
+    };
+    expect(exports.filterDeletedOwn()).toBe(312); // [0, inherited 1, 2]
+    expect(exports.filterRepeatedDeletes()).toBe(415); // [1, 2, 4, inherited 5]
+    expect(exports.prepared(9)).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary

- route typed `Array.prototype.filter` element access through the canonical indexed MOP when builtin prototype indices may be mutated
- let deleted-own vec tombstones continue through `Array.prototype` and `Object.prototype` for both `Get` and `HasProperty`
- add hybrid prepared-IR/legacy coverage and record the measured remaining carrier boundaries in the repository's #4160 markdown issue

## Root cause

`protoIndexDirty` did not activate the typed-lane overlay route, so `filter` kept reading the dense backing after prototype-index writes. Once an own index was deleted, the overlay tombstone also returned `undefined`/absent immediately instead of continuing the required prototype lookup.

## Test262 impact

Exact local A/B used detached `origin/main` `81ff7c4` and this rebased branch with the same maintained harness, controls, standalone target, and refusal provider across all 242 `Array.prototype.filter` tests:

- main: `{pass:162, fail:77, compile_error:3}`
- branch: `{pass:164, fail:75, compile_error:3}`
- only transitions: `15.4.4.20-9-6.js` and `15.4.4.20-9-b-13.js`, both fail -> pass
- pass -> fail: 0

The other five candidate rows are documented as separate roots: borrowed object-like carriers, sparse f64 hole identity, or filter result carrier widening.

## Validation

- focused + existing #4160 Vitest coverage: 11/11 passed
- hybrid module proves one prepared-IR body and the legacy filter bodies share one standalone `__extern_has_idx` / `__extern_get_idx` pair with zero imports
- exact seven-row probe: 0/7 -> 2/7, harness pass/fail controls green
- full 242-file exact-main A/B: +2/-0
- typecheck, lint, format check, LOC/function budgets, oracle/coercion ratchets, issue integrity, and numeric-local IR parity passed in commit/pre-push hooks

## Repository tracking

Updated `plan/issues/4160-elements-protector-cell-prototype-chain-index-inheritance.md`; no GitHub issue was created.
