### PR TITLE
fix(object): support native Error own properties

### DIFF
--- a/plan/issues/4098-standalone-instance-fields-not-own-properties-of-the-instance.md
+++ b/plan/issues/4098-standalone-instance-fields-not-own-properties-of-the-instance.md
@@ -6,7 +6,7 @@ assignee: ttraenkler/dev-4098-g1
 blocked_by: []
 sprint: current
 created: 2026-08-02
-updated: 2026-08-04
+updated: 2026-08-12
 # (#4098 G1 stage 1) The three screen call sites live in `object-runtime.ts`
 # because that is where the closed-struct ladders they screen are BUILT — a
 # screen has to be emitted ahead of the arms it narrows, and those arms return
@@ -665,3 +665,70 @@ Both pre-existing on `main` (present in the before-arm), neither touched here:
 
 Worth their own issue ids; not filed here to avoid burning a reservation on a
 lane that is standing down.
+
+---
+
+## Native Error `$props` slice, 2026-08-12
+
+The residual Object/property census exposed a separate, bounded #4098-shaped
+carrier gap: native Error-family instances already had a nullable
+`$Error_struct.$props` field, but assignment, define, reflection, enumeration
+and delete did not agree that it was the Error instance's ordinary-own-property
+store.
+
+The fix makes that existing field authoritative across the shared standalone
+runtime MOP:
+
+- assignment and reads route through Error-specific get/set helpers;
+- `Object.defineProperty` and `Object.defineProperties` substitute the same bag
+  into the existing `$Object` descriptor engine;
+- `hasOwnProperty`, `Object.hasOwn`, `in`, gOPD, keys, names and for-in see the
+  bag through `__carrier_bag_of`;
+- delete delegates to the existing ordinary `$Object` delete implementation;
+- accessors are invoked with the original Error receiver, not the hidden bag,
+  so `this === err` remains true;
+- object-integrity operations resolve the same bag, so
+  `Object.preventExtensions(err)` blocks later named and indexed expandos;
+- the multi-source finalizer fills both the shared helpers and the Error read
+  splice, keeping `compileMulti` write/read behavior aligned with `compile`;
+- only bag entries are visible. Native struct fields such as `tag`,
+  `userClassId` and `props` are not fabricated as JavaScript keys.
+
+### Exact same-SHA A/B
+
+Both runs used standalone, official scope, and base SHA
+`803ab26e36c2dea1ae617614ff60ecdec714acf3`.
+
+| slice | before | after | delta |
+| --- | ---: | ---: | ---: |
+| ES5 `Object/{create,defineProperty,defineProperties}` failures containing a native Error-family instance | 0 / 23 | **23 / 23** | **+23, -0** |
+| broader Error-family control population in those directories | — | **43 / 43** | no observed regression |
+| Error `Object.preventExtensions` controls (`15.2.3.10-3-{10,20}`) | 2 / 2 | **2 / 2** | **0, preserved** |
+
+The focused regression suite also proves stored-null presence, coherent
+define/read/descriptor/enumerate/delete behavior, Error-as-descriptor and
+Error-as-`Properties` operation, receiver-correct getters/setters, and absence
+of leaked native internals.
+
+### IR boundary
+
+This is shared runtime ABI, not a second AST-only property model. A prepared
+dynamic member read emits IR (`irBodyEmitted: true`, `stage: patch`) and reaches
+`__dyn_member_get -> __extern_get ->` the Error bag MOP. Some surrounding
+dynamic assignment/reflection source shapes remain selector-rejected and retain
+the existing legacy compile-twice fallback; this slice does not claim those
+frontend selectors are complete.
+
+### Bounded scope
+
+This slice covers native Error-family instances only. Date, RegExp, Arguments
+and other closed carriers have distinct representations and remain separate
+work. It does not claim the broader class-instance population in #4098 is
+complete.
+
+Two Error-adjacent residuals remain explicit and are not claimed here:
+
+- `propertyIsEnumerable` still has a separate non-`$Object` dispatch path that
+  does not consult the Error bag;
+- strict-mode assignment to a non-writable Error property is refused, but the
+  current non-`$Object` strict-set path cannot surface the required throw.

--- a/src/codegen/carrier-bag-define.ts
+++ b/src/codegen/carrier-bag-define.ts
@@ -1,8 +1,9 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * (#4161) DEFINE-side closure-bag arms — `Object.defineProperty(fn, k, desc)` /
- * `Object.defineProperties(fn, props)` store into the #3468 closure
- * own-property side-table bag (`--target standalone` / `--target wasi` only).
+ * (#4161, #4098) DEFINE-side carrier-bag arms —
+ * `Object.defineProperty(receiver, k, desc)` / `Object.defineProperties`
+ * store into the authoritative own-property bag for closures and native Error
+ * values (`--target standalone` / `--target wasi` only).
  *
  * ## The gap this closes
  * #4010 S2/S3 and #4055 made the READ half of the MOP see the carrier bags
@@ -40,12 +41,14 @@
  * uses `__closure_bag_ensure`. The read-only builder for the `Properties`
  * gate ({@link closurePropertiesBagArm}) keeps the lookup rule.
  *
- * ## Deliberately closure-only
+ * ## Deliberately bounded carriers
  * `$Vec` receivers are owned by the #3251 overlay (which knows about index
  * keys and `length`) — the appliers consult `vecOverlayArm` BEFORE this arm.
  * And a `$Vec` `Properties` bag stays NON-authoritative (defines on an array
  * land in the overlay, not the bag — the #4047 soundness argument), so the
- * `Properties` widening here admits closures only.
+ * `Properties` widening here admits closures and native Error values only.
+ * Error uses its existing `$Error_struct.$props` slot; Date, RegExp and other
+ * closed carriers still have no authoritative bag and remain out of scope.
  *
  * ## Byte-neutrality
  * Every builder returns `undefined` when the #3468 substrate is absent
@@ -61,16 +64,30 @@ import type { CodegenContext } from "./context/types.js";
 const IS_CLOSURE_PROP_CARRIER = "__is_closure_prop_carrier";
 const CLOSURE_BAG_LOOKUP = "__closure_bag_lookup";
 const CLOSURE_BAG_ENSURE = "__closure_bag_ensure";
+/** (#4098) Native `$Error_struct.$props` substrate (`error-props.ts`). */
+const IS_ERROR_PROP_CARRIER = "__is_error_prop_carrier";
+const ERROR_PROP_BAG_LOOKUP = "__error_prop_bag_lookup";
+const ERROR_PROP_BAG_ENSURE = "__error_prop_bag_ensure";
 
 /**
- * Emit `[] -> [externref]`: the closure receiver's own-property bag, CREATING
- * it when absent, or a null externref for a non-closure receiver.
+ * Emit `[] -> [externref]`: a supported define carrier's own-property bag,
+ * CREATING it when absent, or a null externref for another receiver.
  * `undefined` when the substrate is absent.
  */
-export function closureBagEnsureInstrs(ctx: CodegenContext, recvLocalIdx: number): Instr[] | undefined {
+export function defineCarrierBagEnsureInstrs(ctx: CodegenContext, recvLocalIdx: number): Instr[] | undefined {
   const isClosureIdx = ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER);
   const ensureIdx = ctx.funcMap.get(CLOSURE_BAG_ENSURE);
-  if (isClosureIdx === undefined || ensureIdx === undefined) return undefined;
+  const errorEnsureIdx = ctx.funcMap.get(ERROR_PROP_BAG_ENSURE);
+  const errorFallback: Instr[] =
+    errorEnsureIdx === undefined
+      ? [{ op: "ref.null.extern" }]
+      : [
+          { op: "local.get", index: recvLocalIdx },
+          { op: "call", funcIdx: errorEnsureIdx },
+        ];
+  if (isClosureIdx === undefined || ensureIdx === undefined) {
+    return errorEnsureIdx === undefined ? undefined : errorFallback;
+  }
   return [
     { op: "local.get", index: recvLocalIdx },
     { op: "call", funcIdx: isClosureIdx },
@@ -81,27 +98,27 @@ export function closureBagEnsureInstrs(ctx: CodegenContext, recvLocalIdx: number
         { op: "local.get", index: recvLocalIdx },
         { op: "call", funcIdx: ensureIdx },
       ],
-      else: [{ op: "ref.null.extern" }],
+      else: errorFallback,
     },
   ];
 }
 
 /**
- * The define appliers' non-`$Object` arm for a CLOSURE receiver: ensure the
- * bag and substitute it for the receiver, so the applier's unchanged
+ * The define appliers' non-`$Object` arm for a supported carrier receiver:
+ * ensure the bag and substitute it for the receiver, so the unchanged
  * `$Object` path (including the #2042-S4 preflight) defines into the same
- * table `__extern_get`/gOPD read from. Non-closure receivers run `fallback`
+ * table `__extern_get`/gOPD read from. Unsupported receivers run `fallback`
  * (the applier's pre-existing lenient no-op), which must return on its own.
  *
  * `anyLocalIdx` is the applier's cached `any.convert_extern(obj)` local — the
  * one its `$Object` path casts. `bagLocalIdx` must be a fresh externref local
  * APPENDED to the applier's local vector.
  */
-export function closureBagSubstitutionArm(
+export function defineCarrierBagSubstitutionArm(
   ctx: CodegenContext,
   opts: { recvLocalIdx: number; anyLocalIdx: number; bagLocalIdx: number; fallback: Instr[] },
 ): Instr[] | undefined {
-  const ensure = closureBagEnsureInstrs(ctx, opts.recvLocalIdx);
+  const ensure = defineCarrierBagEnsureInstrs(ctx, opts.recvLocalIdx);
   if (ensure === undefined) return undefined;
   return [
     ...ensure,
@@ -116,21 +133,26 @@ export function closureBagSubstitutionArm(
 }
 
 /**
- * Emit `[] -> [i32]`: is the value in `localIdx` a closure carrier (#3468)?
+ * Emit `[] -> [i32]`: is the value in `localIdx` a supported define carrier?
  * `undefined` when the substrate is absent.
  */
-export function isClosureCarrierInstrs(ctx: CodegenContext, localIdx: number): Instr[] | undefined {
+export function isDefineCarrierInstrs(ctx: CodegenContext, localIdx: number): Instr[] | undefined {
   const isClosureIdx = ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER);
-  if (isClosureIdx === undefined) return undefined;
-  return [
-    { op: "local.get", index: localIdx },
-    { op: "call", funcIdx: isClosureIdx },
-  ];
+  const isErrorIdx = ctx.funcMap.get(IS_ERROR_PROP_CARRIER);
+  if (isClosureIdx === undefined && isErrorIdx === undefined) return undefined;
+  const test = (idx: number | undefined): Instr[] =>
+    idx === undefined
+      ? [{ op: "i32.const", value: 0 }]
+      : [
+          { op: "local.get", index: localIdx },
+          { op: "call", funcIdx: idx },
+        ];
+  return [...test(isClosureIdx), ...test(isErrorIdx), { op: "i32.or" }];
 }
 
 /**
- * `__defineProperties`' non-`$Object` `Properties` arm for a CLOSURE
- * `Properties` map: substitute its own-property bag (LOOKUP, never ensure —
+ * `__defineProperties`' non-`$Object` `Properties` arm for a supported carrier
+ * map: substitute its own-property bag (LOOKUP, never ensure —
  * this is a read) for the map and fall through into the unchanged
  * `$Object` key walk. Sound because, with the applier arms above, the closure
  * bag IS the complete own-NAMED-property store: assignments reach it via
@@ -139,13 +161,13 @@ export function isClosureCarrierInstrs(ctx: CodegenContext, localIdx: number): I
  * non-enumerable — so §20.1.2.3.1's key walk is empty and returning `O`
  * unchanged is the complete spec answer, not a degraded one.)
  *
- * Emits: if the value in `propsLocalIdx` is a closure carrier — bag lookup;
+ * Emits: if the value in `propsLocalIdx` is a supported carrier — bag lookup;
  * null bag → `emptyMapFallback` (must return/throw on its own); otherwise
  * re-point `descsAnyLocalIdx` at the bag. Non-closure values run
  * `nonClosureFallback` (the pre-existing refusal), which must return/throw on
  * its own. Returns `undefined` when the substrate is absent.
  */
-export function closurePropertiesBagArm(
+export function definePropertiesCarrierBagArm(
   ctx: CodegenContext,
   opts: {
     propsLocalIdx: number;
@@ -157,16 +179,48 @@ export function closurePropertiesBagArm(
 ): Instr[] | undefined {
   const isClosureIdx = ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER);
   const lookupIdx = ctx.funcMap.get(CLOSURE_BAG_LOOKUP);
-  if (isClosureIdx === undefined || lookupIdx === undefined) return undefined;
+  const isErrorIdx = ctx.funcMap.get(IS_ERROR_PROP_CARRIER);
+  const errorLookupIdx = ctx.funcMap.get(ERROR_PROP_BAG_LOOKUP);
+  if (
+    (isClosureIdx === undefined || lookupIdx === undefined) &&
+    (isErrorIdx === undefined || errorLookupIdx === undefined)
+  ) {
+    return undefined;
+  }
+  const carrierTest = isDefineCarrierInstrs(ctx, opts.propsLocalIdx);
+  if (carrierTest === undefined) return undefined;
+  const lookup: Instr[] =
+    isClosureIdx !== undefined && lookupIdx !== undefined
+      ? [
+          { op: "local.get", index: opts.propsLocalIdx },
+          { op: "call", funcIdx: isClosureIdx },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: [
+              { op: "local.get", index: opts.propsLocalIdx },
+              { op: "call", funcIdx: lookupIdx },
+            ],
+            else:
+              errorLookupIdx === undefined
+                ? [{ op: "ref.null.extern" }]
+                : [
+                    { op: "local.get", index: opts.propsLocalIdx },
+                    { op: "call", funcIdx: errorLookupIdx },
+                  ],
+          },
+        ]
+      : [
+          { op: "local.get", index: opts.propsLocalIdx },
+          { op: "call", funcIdx: errorLookupIdx! },
+        ];
   return [
-    { op: "local.get", index: opts.propsLocalIdx },
-    { op: "call", funcIdx: isClosureIdx },
+    ...carrierTest,
     {
       op: "if",
       blockType: { kind: "empty" },
       then: [
-        { op: "local.get", index: opts.propsLocalIdx },
-        { op: "call", funcIdx: lookupIdx },
+        ...lookup,
         { op: "local.tee", index: opts.bagLocalIdx },
         { op: "ref.is_null" },
         { op: "if", blockType: { kind: "empty" }, then: opts.emptyMapFallback },

--- a/src/codegen/carrier-bag-delete.ts
+++ b/src/codegen/carrier-bag-delete.ts
@@ -79,6 +79,9 @@ const CLOSURE_BAG_LOOKUP = "__closure_bag_lookup";
 /** #3537 array-expando side table (`vec-props.ts`). */
 const IS_VEC_PROP_CARRIER = "__is_vec_prop_carrier";
 const VEC_BAG_LOOKUP = "__vec_bag_lookup";
+/** (#4098) Native `$Error_struct.$props` carrier (`error-props.ts`). */
+const IS_ERROR_PROP_CARRIER = "__is_error_prop_carrier";
+const ERROR_PROP_BAG_LOOKUP = "__error_prop_bag_lookup";
 
 /** Sole local of `__carrier_bag_delete` (params are 0=obj, 1=key). */
 const BAG = 2;
@@ -94,7 +97,9 @@ export function reserveCarrierBagDelete(ctx: CodegenContext): number | undefined
   const existing = ctx.funcMap.get(CARRIER_BAG_DELETE);
   if (existing !== undefined) return existing;
   const hasCarrier =
-    ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER) !== undefined || ctx.funcMap.get(IS_VEC_PROP_CARRIER) !== undefined;
+    ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER) !== undefined ||
+    ctx.funcMap.get(IS_VEC_PROP_CARRIER) !== undefined ||
+    ctx.funcMap.get(IS_ERROR_PROP_CARRIER) !== undefined;
   if (!hasCarrier) return undefined;
 
   const externref = { kind: "externref" } as const;
@@ -178,7 +183,7 @@ export function buildNonObjectDeleteArms(
 
 /**
  * Fill `__carrier_bag_delete` at FINALIZE, once `__delete_property` /
- * `__obj_find` and both carrier substrates are in `funcMap`:
+ * `__obj_find` and the carrier substrates are in `funcMap`:
  *
  * ```
  * bag = closure-carrier ? __closure_bag_lookup(obj)
@@ -229,12 +234,14 @@ export function fillCarrierBagDelete(ctx: CodegenContext): void {
 
   const closureArm = lookupArm(ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER), ctx.funcMap.get(CLOSURE_BAG_LOOKUP));
   const vecArm = lookupArm(ctx.funcMap.get(IS_VEC_PROP_CARRIER), ctx.funcMap.get(VEC_BAG_LOOKUP));
-  if (closureArm.length === 0 && vecArm.length === 0) return;
+  const errorArm = lookupArm(ctx.funcMap.get(IS_ERROR_PROP_CARRIER), ctx.funcMap.get(ERROR_PROP_BAG_LOOKUP));
+  if (closureArm.length === 0 && vecArm.length === 0 && errorArm.length === 0) return;
 
   const notHandled: Instr[] = [{ op: "i32.const", value: -1 }, { op: "return" }];
   fn.body = [
     ...closureArm,
     ...vecArm,
+    ...errorArm,
     { op: "local.get", index: BAG },
     { op: "ref.is_null" },
     { op: "if", blockType: { kind: "empty" }, then: notHandled.map((i) => ({ ...i })) },

--- a/src/codegen/carrier-bag-visibility.ts
+++ b/src/codegen/carrier-bag-visibility.ts
@@ -55,7 +55,7 @@
  * returning, so `{name,length}` on a builtin never reaches the bag.
  *
  * ## LOOKUP, never ENSURE
- * `__carrier_bag_of` uses `__closure_bag_lookup` / `__vec_bag_lookup`. A
+ * `__carrier_bag_of` uses the carrier-specific LOOKUP helper. A
  * *query* must never allocate a bag: merely asking whether a receiver has a
  * property would otherwise hand a later `__integrity_bag` consumer a carrier
  * that previously had none (the `carrier-bag-hasown.ts` rule).
@@ -66,10 +66,10 @@
  * surfaces. Nothing here re-implements delete semantics.
  *
  * ## What deliberately does NOT move
- * - **Date / RegExp / Error / class instances** have no bag, so
+ * - **Date / RegExp** have no bag, so
  *   `__carrier_bag_of` answers null and every surface keeps its current answer.
- *   Their expando substrate is still greenfield (#4010's matrix rows 4-7);
- *   #4098 is the issue that needs it.
+ *   Native Error values now use their existing `$Error_struct.$props` slot;
+ *   class-instance expandos use the identity-keyed instance substrate.
  * - **Builtin internals never leak into `keys`.** #4071 measured a -5 for
  *   letting closed-struct fields into `Object.keys` and reverted it. The bag is
  *   not a struct: it only ever holds keys a user assignment put there, so
@@ -108,6 +108,9 @@ const VEC_BAG_LOOKUP = "__vec_bag_lookup";
  * consumes {@link buildBagMarkerTestInstrs}.
  */
 const IS_INSTANCE_EXPANDO_CARRIER = "__is_instance_expando_carrier";
+/** (#4098) Native `$Error_struct.$props` carrier (`error-props.ts`). */
+const IS_ERROR_PROP_CARRIER = "__is_error_prop_carrier";
+const ERROR_PROP_BAG_LOOKUP = "__error_prop_bag_lookup";
 
 /** Abbreviated heap type `eq` (`closure-props.ts` uses the same encoding). */
 const EQ_HEAP_TYPE = -19;
@@ -135,7 +138,9 @@ const I32: ValType = { kind: "i32" };
 export function reserveCarrierBagVisibility(ctx: CodegenContext): void {
   if (ctx.funcMap.get(CARRIER_BAG_OF) !== undefined) return;
   const hasCarrier =
-    ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER) !== undefined || ctx.funcMap.get(IS_VEC_PROP_CARRIER) !== undefined;
+    ctx.funcMap.get(IS_CLOSURE_PROP_CARRIER) !== undefined ||
+    ctx.funcMap.get(IS_VEC_PROP_CARRIER) !== undefined ||
+    ctx.funcMap.get(IS_ERROR_PROP_CARRIER) !== undefined;
   if (!hasCarrier) return;
 
   const reserve = (name: string, params: ValType[], results: ValType[], placeholder: Instr[]): void => {
@@ -419,11 +424,15 @@ export function fillCarrierBagVisibility(ctx: CodegenContext): void {
     // header warns this arm is "inert alone" — it ships in the same change as
     // the write path (`instance-props.ts` S1/S2), never on its own.
     const instanceArm = arm(IS_INSTANCE_EXPANDO_CARRIER, CLOSURE_BAG_LOOKUP);
-    if (closureArm.length === 0 && vecArm.length === 0 && instanceArm.length === 0) return;
+    // (#4098) Error's bag is the existing `$props` slot, not the identity-keyed
+    // closure side table. Only user-created entries live there, so widening
+    // visibility cannot fabricate `$Error_struct` internals.
+    const errorArm = arm(IS_ERROR_PROP_CARRIER, ERROR_PROP_BAG_LOOKUP);
+    if (closureArm.length === 0 && vecArm.length === 0 && instanceArm.length === 0 && errorArm.length === 0) return;
     setFn(
       CARRIER_BAG_OF,
       [{ name: "bag", type: EXT }],
-      [...closureArm, ...vecArm, ...instanceArm, { op: "ref.null.extern" }],
+      [...closureArm, ...vecArm, ...instanceArm, ...errorArm, { op: "ref.null.extern" }],
     );
   }
 

--- a/src/codegen/error-props.ts
+++ b/src/codegen/error-props.ts
@@ -1,0 +1,294 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4098) Native `$Error_struct` own-property substrate.
+ *
+ * Native Error values are not open `$Object`s, but they already carry a
+ * nullable `$props` field (field 5) for user Error-subclass fields. This module
+ * makes that field the single ordinary-own-property store for Error expandos
+ * too. The helpers are reserved before `__extern_get` / `__extern_set` and the
+ * reflective MOP are emitted, then filled after the complete type table exists.
+ *
+ * Reads and writes deliberately do not recurse through the bag as the receiver:
+ * an accessor installed on `err` must observe `this === err`, not the hidden
+ * `$Object` sidecar. Data mutation still delegates to `__extern_set` on the bag,
+ * so descriptor flags and integrity checks remain owned by the ordinary object
+ * runtime rather than being reimplemented here.
+ *
+ * This is shared runtime ABI, not an AST lowering: prepared IR and legacy
+ * callers both reach the same `__extern_*` / descriptor / enumeration helpers.
+ */
+import type { Instr, ValType, WasmFunction } from "../ir/types.js";
+import { CALL_ACCESSOR_GET, CALL_ACCESSOR_SET } from "./accessor-driver.js";
+import { undefinedExternInstrs } from "./any-helpers.js";
+import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { addFuncType } from "./registry/types.js";
+
+export const IS_ERROR_PROP_CARRIER = "__is_error_prop_carrier";
+export const ERROR_PROP_BAG_LOOKUP = "__error_prop_bag_lookup";
+export const ERROR_PROP_BAG_ENSURE = "__error_prop_bag_ensure";
+export const ERROR_PROP_GET = "__error_prop_get";
+export const ERROR_PROP_SET = "__error_prop_set";
+
+const EXT: ValType = { kind: "externref" };
+const I32: ValType = { kind: "i32" };
+const ANY: ValType = { kind: "anyref" };
+const FLAG_ACCESSOR = 0x08;
+
+/** Reserve stable helper indices before the object-runtime call sites bake them. */
+export function reserveErrorPropHelpers(ctx: CodegenContext): void {
+  if (!(ctx.standalone || ctx.wasi)) return;
+  if (ctx.funcMap.has(IS_ERROR_PROP_CARRIER)) return;
+
+  const reserve = (name: string, params: ValType[], results: ValType[], body: Instr[]): void => {
+    const typeIdx = addFuncType(ctx, params, results, `$${name}_type`);
+    const funcIdx = mintDefinedFunc(ctx);
+    const fn: WasmFunction = { name, typeIdx, locals: [], body, exported: false };
+    pushDefinedFunc(ctx, funcIdx, fn);
+    ctx.funcMap.set(name, funcIdx);
+  };
+
+  reserve(IS_ERROR_PROP_CARRIER, [EXT], [I32], [{ op: "i32.const", value: 0 }]);
+  reserve(ERROR_PROP_BAG_LOOKUP, [EXT], [EXT], [{ op: "ref.null.extern" }]);
+  reserve(ERROR_PROP_BAG_ENSURE, [EXT], [EXT], [{ op: "ref.null.extern" }]);
+  reserve(ERROR_PROP_GET, [EXT, EXT], [EXT], [{ op: "ref.null.extern" }]);
+  reserve(ERROR_PROP_SET, [EXT, EXT, EXT], [], []);
+}
+
+/**
+ * `__extern_set`'s native Error arm. It is terminal only for a real
+ * `$Error_struct`; all other non-object receivers fall through unchanged.
+ */
+export function buildErrorPropSetArm(ctx: CodegenContext): Instr[] {
+  const isIdx = ctx.funcMap.get(IS_ERROR_PROP_CARRIER);
+  const setIdx = ctx.funcMap.get(ERROR_PROP_SET);
+  if (isIdx === undefined || setIdx === undefined) return [];
+  return [
+    { op: "local.get", index: 0 },
+    { op: "call", funcIdx: isIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 0 },
+        { op: "local.get", index: 1 },
+        { op: "local.get", index: 2 },
+        { op: "call", funcIdx: setIdx },
+        { op: "return" },
+      ],
+    },
+  ];
+}
+
+/** Fill the Error carrier predicate, sidecar accessors, and receiver-aware get/set. */
+export function fillErrorPropHelpers(ctx: CodegenContext): void {
+  const errTypeIdx = ctx.errorStructTypeIdx;
+  const types = ctx.objectRuntimeTypes;
+  if (errTypeIdx < 0 || !types) return;
+  const { objectTypeIdx, propEntryTypeIdx } = types;
+  const newObjectIdx = ctx.funcMap.get("__new_plain_object");
+  const objFindIdx = ctx.funcMap.get("__obj_find");
+  const externSetIdx = ctx.funcMap.get("__extern_set");
+  const lookupIdx = ctx.funcMap.get(ERROR_PROP_BAG_LOOKUP);
+  const ensureIdx = ctx.funcMap.get(ERROR_PROP_BAG_ENSURE);
+  const callGetIdx = ctx.funcMap.get(CALL_ACCESSOR_GET);
+  const callSetIdx = ctx.funcMap.get(CALL_ACCESSOR_SET);
+  if (
+    newObjectIdx === undefined ||
+    objFindIdx === undefined ||
+    externSetIdx === undefined ||
+    lookupIdx === undefined ||
+    ensureIdx === undefined ||
+    callGetIdx === undefined ||
+    callSetIdx === undefined
+  ) {
+    return;
+  }
+
+  const setFn = (name: string, locals: { name: string; type: ValType }[], body: Instr[]): void => {
+    const idx = ctx.funcMap.get(name);
+    if (idx === undefined) return;
+    const fn = definedFuncAt(ctx, idx);
+    if (!fn) return;
+    fn.locals = locals;
+    fn.body = body;
+  };
+  const errorRef = (anyLocal: number): Instr[] => [
+    { op: "local.get", index: anyLocal },
+    { op: "ref.cast", typeIdx: errTypeIdx },
+  ];
+  const requireError = (anyLocal: number, miss: Instr[]): Instr[] => [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.tee", index: anyLocal },
+    { op: "ref.test", typeIdx: errTypeIdx },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: miss },
+  ];
+  const nullMiss = (): Instr[] => [{ op: "ref.null.extern" }, { op: "return" }];
+
+  setFn(
+    IS_ERROR_PROP_CARRIER,
+    [{ name: "any", type: ANY }],
+    [{ op: "local.get", index: 0 }, { op: "any.convert_extern" }, { op: "ref.test", typeIdx: errTypeIdx }],
+  );
+
+  // `$props` lookup is query-only: merely inspecting an Error must not allocate.
+  setFn(
+    ERROR_PROP_BAG_LOOKUP,
+    [{ name: "any", type: ANY }],
+    [...requireError(1, nullMiss()), ...errorRef(1), { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 5 }],
+  );
+
+  setFn(
+    ERROR_PROP_BAG_ENSURE,
+    [
+      { name: "any", type: ANY },
+      { name: "err", type: { kind: "ref_null", typeIdx: errTypeIdx } },
+      { name: "bag", type: EXT },
+    ],
+    [
+      ...requireError(1, nullMiss()),
+      ...errorRef(1),
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 2 },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 5 },
+      { op: "local.tee", index: 3 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 2 },
+          { op: "ref.as_non_null" },
+          { op: "call", funcIdx: newObjectIdx },
+          { op: "local.tee", index: 3 },
+          { op: "struct.set", typeIdx: errTypeIdx, fieldIdx: 5 },
+        ],
+      },
+      { op: "local.get", index: 3 },
+    ],
+  );
+
+  const GET_BAG = 3;
+  const GET_ENTRY = 4;
+  const GET_GETTER = 5;
+  setFn(
+    ERROR_PROP_GET,
+    [
+      { name: "any", type: ANY },
+      { name: "bag", type: EXT },
+      { name: "entry", type: { kind: "ref_null", typeIdx: propEntryTypeIdx } },
+      { name: "getter", type: EXT },
+    ],
+    [
+      ...requireError(2, nullMiss()),
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: lookupIdx },
+      { op: "local.tee", index: GET_BAG },
+      { op: "ref.is_null" },
+      { op: "if", blockType: { kind: "empty" }, then: nullMiss() },
+      { op: "local.get", index: GET_BAG },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: objFindIdx },
+      { op: "local.tee", index: GET_ENTRY },
+      { op: "ref.is_null" },
+      { op: "if", blockType: { kind: "empty" }, then: nullMiss() },
+      { op: "local.get", index: GET_ENTRY },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+      { op: "i32.const", value: FLAG_ACCESSOR },
+      { op: "i32.and" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: GET_ENTRY },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 4 },
+          { op: "extern.convert_any" },
+          { op: "local.tee", index: GET_GETTER },
+          { op: "ref.is_null" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [...(undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }]), { op: "return" }],
+          },
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: GET_GETTER },
+          { op: "call", funcIdx: callGetIdx },
+          { op: "return" },
+        ],
+      },
+      { op: "local.get", index: GET_ENTRY },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+      { op: "extern.convert_any" },
+    ],
+  );
+
+  const SET_BAG = 4;
+  const SET_ENTRY = 5;
+  const SET_SETTER = 6;
+  setFn(
+    ERROR_PROP_SET,
+    [
+      { name: "any", type: ANY },
+      { name: "bag", type: EXT },
+      { name: "entry", type: { kind: "ref_null", typeIdx: propEntryTypeIdx } },
+      { name: "setter", type: EXT },
+    ],
+    [
+      ...requireError(3, [{ op: "return" }]),
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: ensureIdx },
+      { op: "local.tee", index: SET_BAG },
+      { op: "ref.is_null" },
+      { op: "if", blockType: { kind: "empty" }, then: [{ op: "return" }] },
+      { op: "local.get", index: SET_BAG },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: objFindIdx },
+      { op: "local.tee", index: SET_ENTRY },
+      { op: "ref.is_null" },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: SET_ENTRY },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+          { op: "i32.const", value: FLAG_ACCESSOR },
+          { op: "i32.and" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: SET_ENTRY },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 5 },
+              { op: "extern.convert_any" },
+              { op: "local.tee", index: SET_SETTER },
+              { op: "ref.is_null" },
+              { op: "if", blockType: { kind: "empty" }, then: [{ op: "return" }] },
+              { op: "local.get", index: 0 },
+              { op: "local.get", index: SET_SETTER },
+              { op: "local.get", index: 2 },
+              { op: "call", funcIdx: callSetIdx },
+              { op: "return" },
+            ],
+          },
+        ],
+      },
+      { op: "local.get", index: SET_BAG },
+      { op: "local.get", index: 1 },
+      { op: "local.get", index: 2 },
+      { op: "call", funcIdx: externSetIdx },
+    ],
+  );
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -251,6 +251,7 @@ import { unshiftExternGetProtoMethodArm } from "./native-proto-instance-method-r
 import { fillClosurePropHelpers } from "./closure-props.js"; // (#3468 C-core) closure-own-property side table
 import { fillInstanceTombstones } from "./instance-tombstones.js"; // (#4098 G1 s1) per-instance own-property deletability
 import { fillInstanceProps } from "./instance-props.js"; // (#4194) instance expando bag substrate
+import { fillErrorPropHelpers } from "./error-props.js"; // (#4098) native Error `$props` shared MOP
 import { fillVecPropHelpers } from "./vec-props.js"; // (#3537) array ($Vec) expando side table
 import { fillProtoIndexStore } from "./proto-index-store.js"; // (#4160) prototype-index companions
 import { finalizeFunctionPoisonPillCalls } from "./function-poison-pill.js";
@@ -4720,6 +4721,7 @@ export function generateModule(
 
     // Closed compiler structs are not `$Object` hash maps. Fill the native
     // Object.hasOwn / hasOwnProperty predicates from the complete shape table.
+    fillErrorPropHelpers(ctx); // (#4098) fill reserved Error bag ABI before its MOP consumers finalize
     fillInstanceTombstones(ctx); // (#4098 G1 s1) BEFORE the ladders below: they bake its call
     fillInstanceProps(ctx); // (#4194) instance expando carrier + bag get/set + tombstone resurrect
     fillClosedStructHasOwnArms(ctx);
@@ -7071,6 +7073,7 @@ export function generateMultiModule(
     fillTypedMemberGetF64Dispatch(ctx); // (#3673) typed f64 twins
 
     // Mirror the single-source closed-struct own-property finalizer.
+    fillErrorPropHelpers(ctx); // (#4098) multi-source parity for the shared Error bag ABI
     fillInstanceTombstones(ctx); // (#4098 G1 s1) BEFORE the ladders below: they bake its call
     fillInstanceProps(ctx); // (#4194) instance expando carrier + bag get/set + tombstone resurrect
     fillClosedStructHasOwnArms(ctx);
@@ -7115,6 +7118,9 @@ export function generateMultiModule(
     fillExternGetIdxVecArms(ctx);
     // (#3666/#3251) Multi-source parity after every carrier/dynamic reader is complete.
     fillObjVecReflectionHelpers(ctx);
+    // (#4098) Multi-source parity: the helper bodies were filled above; now
+    // splice the native Error reader after the other dynamic-reader fills.
+    fillExternGetErrorProps(ctx);
     // (#3371) Reflect.construct reserves the same host-free constructor
     // classifier and native-view prototype overrides in project compilation as
     // in the single-source pipeline. Keep native views after generic vec fills
@@ -7170,6 +7176,9 @@ export function generateMultiModule(
       const cap = Math.min(maxClosureArity, 8);
       for (let n = 0; n <= cap; n++) emitClosureMethodCallExportN(ctx, n);
     }
+    // (#4098) Error sidecar accessors reserve receiver-aware drivers while the
+    // MOP is built. Refill them only after multi-source method dispatchers exist.
+    fillAccessorDrivers(ctx);
 
     // Unknown-arity host wrappers use this classifier to choose a dispatcher
     // wide enough for the closure's declared parameters.

--- a/src/codegen/object-integrity-carrier.ts
+++ b/src/codegen/object-integrity-carrier.ts
@@ -30,8 +30,9 @@
  * ## The fix — two independent halves, and deliberately NO new side table
  *
  * **(a) Storage: reuse the bags that already exist.** `__vec_bag_ensure`
- * (#3537, Array expando bag) and `__closure_bag_ensure` (#3468, closure
- * own-property bag) already map a carrier to a per-object `$Object`. A `$Object`
+ * (#3537, Array expando bag), `__closure_bag_ensure` (#3468, closure
+ * own-property bag), and `__error_prop_bag_ensure` (#4098, native Error's
+ * existing `$props` slot) map a carrier to a per-object `$Object`. A `$Object`
  * *has* a real flags slot, so the bag **is** the missing storage.
  * {@link registerIntegrityBagResolver} adds one native that resolves a receiver
  * to its bag, and both the predicates and the mutators route through it.
@@ -94,6 +95,7 @@ export const OBJECT_INTEGRITY_OBJ_PREDICATES: readonly string[] = [
  * Register `__integrity_bag(externref v) -> externref`:
  *   vec carrier     → `__vec_bag_ensure(v)`
  *   closure carrier → `__closure_bag_ensure(v)`
+ *   Error carrier   → `__error_prop_bag_ensure(v)`
  *   otherwise       → `ref.null.extern`
  *
  * Returns `undefined` when the bag substrates are absent (host mode), which is
@@ -104,6 +106,8 @@ export function registerIntegrityBagResolver(ctx: CodegenContext, registerNative
   const vecBagEnsureIdx = ctx.funcMap.get("__vec_bag_ensure");
   const isClosureCarrierIdx = ctx.funcMap.get("__is_closure_prop_carrier");
   const closureBagEnsureIdx = ctx.funcMap.get("__closure_bag_ensure");
+  const isErrorCarrierIdx = ctx.funcMap.get("__is_error_prop_carrier");
+  const errorBagEnsureIdx = ctx.funcMap.get("__error_prop_bag_ensure");
   if (
     isVecCarrierIdx === undefined ||
     vecBagEnsureIdx === undefined ||
@@ -132,6 +136,17 @@ export function registerIntegrityBagResolver(ctx: CodegenContext, registerNative
         blockType: { kind: "empty" },
         then: [{ op: "local.get", index: 0 }, { op: "call", funcIdx: closureBagEnsureIdx }, { op: "return" }],
       },
+      ...(isErrorCarrierIdx === undefined || errorBagEnsureIdx === undefined
+        ? []
+        : ([
+            { op: "local.get", index: 0 },
+            { op: "call", funcIdx: isErrorCarrierIdx },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "local.get", index: 0 }, { op: "call", funcIdx: errorBagEnsureIdx }, { op: "return" }],
+            },
+          ] satisfies Instr[])),
       { op: "ref.null.extern" },
     ],
   );

--- a/src/codegen/object-runtime-descriptors.ts
+++ b/src/codegen/object-runtime-descriptors.ts
@@ -40,9 +40,11 @@ import { reserveVecOverlayHelpers } from "./vec-overlay.js";
 import { buildIntegrityPredicate, registerIntegrityBagResolver } from "./object-integrity-carrier.js";
 import { buildObjectIntegrityMutationHelpers } from "./object-runtime-integrity.js";
 import { bagGopdBetween, bagKeysIf } from "./carrier-bag-visibility.js"; // (#4010 S3) visibility over the bags
-// (#4161) DEFINE-side closure-bag arms — Object.defineProperty/defineProperties
-// on a FUNCTION receiver store into the #3468 own-property bag.
-import { closureBagSubstitutionArm, closurePropertiesBagArm, isClosureCarrierInstrs } from "./carrier-bag-define.js";
+import {
+  defineCarrierBagSubstitutionArm,
+  definePropertiesCarrierBagArm,
+  isDefineCarrierInstrs,
+} from "./carrier-bag-define.js";
 // (#4230) VEC `Properties` maps — a complete own-key source built from the
 // #3537 bag ∪ the #3251 overlay companion.
 import { reserveVecPropsKeySource, vecPropertiesKeySourceArm } from "./vec-props-key-source.js";
@@ -373,11 +375,10 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
       },
     ];
 
-    // (#4161) Closure-receiver bag substitution; bag local APPENDED at index 13
-    // (standalone/wasi only — `undefined` in gc/host keeps the body and local
-    // vector byte-identical). Runs AFTER the vec overlay (#3251 owns vec
+    // (#4161, #4098) Carrier-bag substitution; bag local APPENDED at index 13
+    // Runs AFTER the vec overlay (#3251 owns vec
     // receivers) and carries the lenient no-op as its bag-absent fallback.
-    const dpValueClosureArm = closureBagSubstitutionArm(ctx, {
+    const dpValueClosureArm = defineCarrierBagSubstitutionArm(ctx, {
       recvLocalIdx: 0,
       anyLocalIdx: 5,
       bagLocalIdx: 13,
@@ -386,8 +387,8 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
     const body: Instr[] = [
       // any = any.convert_extern(obj) ; if !$Object → vec receivers route to
       // the #3251 overlay (per-index/expando descriptor storage on a
-      // companion $Object); a CLOSURE receiver defines into its #3468
-      // own-property bag (#4161) and falls through into the unchanged
+      // companion $Object); a closure or native Error receiver defines into
+      // its authoritative own-property bag and falls through into the unchanged
       // `$Object` path below — including the #2042-S4
       // ValidateAndApplyPropertyDescriptor preflight, which a function
       // receiver previously skipped entirely via the lenient no-op; anything
@@ -702,9 +703,9 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
       { op: "i32.const", value: 0 },
       { op: "i32.ne" },
     ];
-    // (#4161) Closure-receiver bag substitution; bag local APPENDED at index 16
+    // (#4161, #4098) Carrier-bag substitution; bag local APPENDED at index 16
     // (standalone/wasi only) — same shape as the `__defineProperty_value` arm.
-    const dpAccessorClosureArm = closureBagSubstitutionArm(ctx, {
+    const dpAccessorClosureArm = defineCarrierBagSubstitutionArm(ctx, {
       recvLocalIdx: 0,
       anyLocalIdx: 6,
       bagLocalIdx: 16,
@@ -712,8 +713,8 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
     });
     const body: Instr[] = [
       // any = any.convert_extern(obj) ; if !$Object → vec receivers route to
-      // the #3251 overlay; a CLOSURE receiver defines into its #3468
-      // own-property bag (#4161); anything else keeps the lenient no-op.
+      // the #3251 overlay; a closure or native Error receiver defines into its
+      // own-property bag; anything else keeps the lenient no-op.
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
       { op: "local.tee", index: 6 },
@@ -724,7 +725,7 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
         blockType: { kind: "empty" },
         then: [
           ...vecOverlayArm(6, vecOverlay?.dpAccessorIdx ?? -1, 5),
-          // The closure arm carries the lenient-no-op return as its own
+          // The carrier arm carries the lenient-no-op return as its own
           // bag-absent fallback and otherwise FALLS THROUGH to the `$Object`
           // path — so it must not be followed by an unconditional return.
           ...(dpAccessorClosureArm ?? [{ op: "local.get", index: 0 }, { op: "return" }]),
@@ -1174,10 +1175,10 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
     const throwPropertiesNotCoercible = (): Instr[] =>
       throwTypeError("TypeError: Cannot convert undefined or null to object");
 
-    // (#4161) closure `Properties` bag substitution (LOOKUP, never ensure).
-    // `undefined` when the #3468 substrate is absent — the gate then keeps its
+    // (#4161, #4098) carrier `Properties` bag substitution (LOOKUP, never ensure).
+    // `undefined` when every supported substrate is absent — the gate keeps its
     // pre-existing refusal and the local vector stays byte-identical.
-    const propsClosureArm = closurePropertiesBagArm(ctx, {
+    const propsClosureArm = definePropertiesCarrierBagArm(ctx, {
       propsLocalIdx: 1,
       descsAnyLocalIdx: L_DESCS_ANY,
       bagLocalIdx: L_BAG,
@@ -1187,8 +1188,7 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
 
     // (#4230) VEC `Properties` map. Tried BEFORE the closure arm (a vec is
     // never a closure, so the order is only about which fallback wraps which)
-    // and carrying the closure arm as its own non-vec fallback, so the two
-    // compose into one chain ending in the unchanged refusal. The key source is
+    // The arms compose into one chain ending in the unchanged refusal. The key source is
     // the #3537 bag ∪ the #3251 overlay companion — see
     // `vec-props-key-source.ts` for why a UNION is as sound as the "one
     // authoritative store" the old comment demanded, and why an indexed vec
@@ -1219,7 +1219,7 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
             { op: "local.get", index: 0 },
             { op: "call", funcIdx: isVecCarrierIdx },
           ] satisfies Instr[])),
-      ...(isClosureCarrierInstrs(ctx, 0) ?? ([{ op: "i32.const", value: 0 }] satisfies Instr[])),
+      ...(isDefineCarrierInstrs(ctx, 0) ?? ([{ op: "i32.const", value: 0 }] satisfies Instr[])),
       { op: "i32.or" },
     ];
     /**
@@ -1396,8 +1396,8 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
             then: throwTypeError("Object.defineProperties called on non-object"),
           },
           // An object, but is there anywhere to STORE a descriptor? The vec
-          // carrier (#3251 overlay) and — since #4161 — the closure carrier
-          // (the appliers' own-property-bag arm) both have applier arms; pass 2
+          // carrier (#3251 overlay), closure carrier, and native Error carrier
+          // (the appliers' own-property-bag arms) have applier arms; pass 2
           // passes the raw `local.get 0` receiver to the appliers, which carry
           // their own dispatch, so admission is all that is needed here.
           // Anything else (Date/RegExp/closed struct) keeps the loud refusal:
@@ -1428,7 +1428,7 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
                   ],
                 },
               ] satisfies Instr[])
-            : isVecCarrierIdx === undefined && isClosureCarrierInstrs(ctx, 0) === undefined
+            : isVecCarrierIdx === undefined && isDefineCarrierInstrs(ctx, 0) === undefined
               ? throwUnsupported(" [SITE-O-NO-CARRIER]")
               : ([
                   ...oCarrierPresentTest,
@@ -1559,21 +1559,21 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
             blockType: { kind: "empty" },
             then: [{ op: "local.get", index: 0 }, { op: "return" }],
           },
-          // (d) a CLOSURE (function) `Properties` map (#4161): substitute its
-          //     #3468 own-property bag for the map and fall through into the
+          // (d) a closure or native Error `Properties` map: substitute its
+          //     authoritative own-property bag and fall through into the
           //     unchanged `$Object` key walk. SOUND NOW, and only now: the
           //     #4047-era measurement that reverted bag-enumeration found the
           //     bag was not the complete own-property store because
           //     `Object.defineProperty(props,"p",…)` on a Function landed
           //     NOWHERE (`__defineProperty_value`'s terminal arm was a lenient
           //     no-op for closures). With the #4161 applier arms, defines land
-          //     in the same bag `__extern_set` writes, so the closure bag IS
-          //     the complete own-NAMED-property store. A closure with no bag
+          //     in the same bag `__extern_set` writes, so the carrier bag IS
+          //     the complete own-NAMED-property store. A carrier with no bag
           //     has no own enumerable named properties (builtin `name`/
           //     `length` metadata is non-enumerable), so "define nothing,
           //     return O" is the complete spec answer.
           //
-          // (e) any OTHER object — Array, arguments, Date, RegExp, Error, a
+          // (e) any OTHER object — Array, arguments, Date, RegExp, a
           //     closed struct — KEEPS REFUSING. The ARRAY half of the
           //     #4047-era unsoundness still holds: a vec's defines land in the
           //     SEPARATE #3251 overlay companion, not in its #3537 bag, so

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -102,6 +102,7 @@ import {
   buildInstancePropGetArm,
   reserveInstanceProps,
 } from "./instance-props.js";
+import { buildErrorPropSetArm, reserveErrorPropHelpers } from "./error-props.js"; // (#4098) native Error `$props` MOP
 import {
   INSTANCE_FIELD_DELETED,
   buildTombstoneScreen,
@@ -891,6 +892,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     // (#3537) reserve the array-expando side table right after — same
     // reserve-before-arms-bake discipline, appended indices only.
     reserveVecPropHelpers(ctx);
+    reserveErrorPropHelpers(ctx); // (#4098) before every write/define/visibility call site bakes its funcIdx
     reserveCarrierBagVisibility(ctx); // (#4010 S3) visibility over both bags — see that module
     reserveInstanceTombstones(ctx); // (#4098 G1 s1) per-instance delete over the SAME bag
     reserveInstanceProps(ctx); // (#4194) per-instance WRITE-through + expando over that bag
@@ -2546,7 +2548,10 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         // prologue (`fillClosedStructExternSetArms`) missed, so a declared name
         // can never be deposited in the bag — the invariant that structurally
         // excludes the #4055 v1 -684 shape.
-        then: buildInstanceOrVecOrClosurePropSetMissArm(ctx),
+        // (#4098) Native Error values own an open `$props` sidecar. Its arm
+        // precedes the disjoint instance/vec/closure carriers and preserves the
+        // original Error receiver when an accessor is invoked.
+        then: [...buildErrorPropSetArm(ctx), ...buildInstanceOrVecOrClosurePropSetMissArm(ctx)],
       },
       // o = cast<$Object>(any)
       { op: "local.get", index: 6 },

--- a/src/codegen/registry/error-types.ts
+++ b/src/codegen/registry/error-types.ts
@@ -50,6 +50,8 @@ import { userErrorCtorCarrierGlobal } from "../error-ctor-carrier.js"; // (#4262
 import { addFuncType, getOrRegisterErrorStructType } from "./types.js";
 import { addStringConstantGlobal } from "./imports.js";
 import { nativeStringLiteralInstrs, stringConstantExternrefInstrs } from "../native-strings.js";
+import { CARRIER_BAG_HAS } from "../carrier-bag-visibility.js";
+import { ERROR_PROP_GET } from "../error-props.js";
 
 // (#2962) `getOrRegisterErrorStructType` moved to registry/types.ts so
 // native-strings.ts can import it without an import cycle (this module imports
@@ -319,33 +321,24 @@ export function fillExternGetErrorProps(ctx: CodegenContext): void {
   if (errTypeIdx < 0) return; // no native Error structs in this module
   const fn = ctx.mod.functions.find((f) => f.name === "__extern_get");
   if (!fn) return; // object runtime never emitted (nothing reads dynamically)
-  const externGetIdx = ctx.funcMap.get("__extern_get");
   const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
   const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals");
   const newObjectIdx = ctx.funcMap.get("__new_plain_object");
-  if (
-    externGetIdx === undefined ||
-    strFlattenIdx === undefined ||
-    strEqualsIdx === undefined ||
-    newObjectIdx === undefined
-  ) {
+  if (strFlattenIdx === undefined || strEqualsIdx === undefined || newObjectIdx === undefined) {
     return;
   }
   if (ctx.anyStrTypeIdx < 0 || ctx.nativeStrTypeIdx < 0) return;
-  // (#2106 S1) Under the undefined-singleton regime the recursive $props read
-  // answers the singleton on a miss (non-null), so presence is "non-nullish";
-  // legacy regime: miss = null.
-  const isNullishIdx = ctx.funcMap.get("__extern_is_nullish");
+  const bagHasIdx = ctx.funcMap.get(CARRIER_BAG_HAS);
+  const errorPropGetIdx = ctx.funcMap.get(ERROR_PROP_GET);
+  if (bagHasIdx === undefined || errorPropGetIdx === undefined) return;
 
   // __extern_get: params 0=obj 1=key; existing locals o(2) e(3) any(4)
   // getter(5) bfmeta(6). Append ours — never renumber existing ones.
   const anyL = 2 + fn.locals.length;
   const fkeyL = anyL + 1;
-  const scratchL = anyL + 2;
   fn.locals.push(
     { name: "__err_any", type: { kind: "anyref" } },
     { name: "__err_fkey", type: { kind: "ref_null", typeIdx: ctx.nativeStrTypeIdx } },
-    { name: "__err_scratch", type: { kind: "externref" } },
   );
 
   const errRef = (): Instr[] => [
@@ -512,15 +505,6 @@ export function fillExternGetErrorProps(ctx: CodegenContext): void {
     );
   }
 
-  // "is the $props read a miss?" — leaves an i32 on the stack.
-  const propsMiss = (): Instr[] =>
-    isNullishIdx !== undefined
-      ? [
-          { op: "local.get", index: scratchL },
-          { op: "call", funcIdx: isNullishIdx },
-        ]
-      : [{ op: "local.get", index: scratchL }, { op: "ref.is_null" }];
-
   const arm: Instr[] = [
     { op: "local.get", index: 0 },
     { op: "any.convert_extern" },
@@ -530,28 +514,21 @@ export function fillExternGetErrorProps(ctx: CodegenContext): void {
       op: "if",
       blockType: { kind: "empty" },
       then: [
-        // 1) $props sidecar first — subclass own fields / dynamic writes shadow
-        //    the builtin surface (JS shadowing order).
-        ...errRef(),
-        { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 5 },
-        { op: "local.tee", index: scratchL },
-        { op: "ref.is_null" },
-        { op: "i32.eqz" },
+        // 1) `$props` own entry first — dynamic writes/defines shadow the
+        //    builtin surface. Presence and value are separate so a stored null
+        //    is still a handled value. The getter helper receives the ORIGINAL
+        //    Error receiver, not the hidden sidecar, preserving accessor `this`.
+        { op: "local.get", index: 0 },
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: bagHasIdx },
         {
           op: "if",
           blockType: { kind: "empty" },
           then: [
-            { op: "local.get", index: scratchL },
+            { op: "local.get", index: 0 },
             { op: "local.get", index: 1 },
-            { op: "call", funcIdx: externGetIdx }, // recursive: $props IS a plain $Object
-            { op: "local.set", index: scratchL },
-            ...propsMiss(),
-            { op: "i32.eqz" },
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [{ op: "local.get", index: scratchL }, { op: "return" }],
-            },
+            { op: "call", funcIdx: errorPropGetIdx },
+            { op: "return" },
           ],
         },
         // 2) Named-key dispatch — string keys only. A Symbol / boxed-number key

--- a/tests/issue-4098-error-expando.test.ts
+++ b/tests/issue-4098-error-expando.test.ts
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #4098 — native Error instances use their existing `$props` slot as the one
+// ordinary-own-property store shared by prepared IR and every reflective MOP.
+import { describe, expect, it } from "vitest";
+import { compile, compileMulti } from "../src/index.js";
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    fileName: "issue-4098-error-expando.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    trackIrOutcomes: true,
+    emitWat: true,
+  });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const module = await WebAssembly.compile(result.binary);
+  expect(WebAssembly.Module.imports(module)).toEqual([]);
+  const instance = await WebAssembly.instantiate(module, {});
+  return { result, exports: instance.exports as Record<string, () => number> };
+}
+
+describe("#4098 native Error own-property substrate", () => {
+  it("round-trips an assigned expando through get / hasOwn / in on prepared IR", async () => {
+    const { result, exports } = await compileStandalone(`
+function exercise(error: Error): number {
+  const carrier: any = error;
+  carrier.value = 12;
+  return carrier.value;
+}
+function reflect(error: any): number {
+  let mask = 0;
+  if (error.hasOwnProperty("value")) mask = mask + 10;
+  if ("value" in error) mask = mask + 100;
+  return mask;
+}
+function legacyRoundTrip(): number {
+  const error: any = new Error("x");
+  const value = exercise(error);
+  return (value === 12 ? 1 : 0) + reflect(error);
+}
+export function test(): number { return legacyRoundTrip(); }
+export function preparedRead(error: any): any { return error.value; }
+`);
+
+    expect(exports.test()).toBe(111);
+    expect(
+      result.irOutcomes?.find((outcome) => outcome.displayName === "preparedRead"),
+      JSON.stringify(result.irOutcomes),
+    ).toMatchObject({
+      kind: "emitted",
+      irBodyEmitted: true,
+      stage: "patch",
+    });
+    expect(result.wat).toContain("__dyn_member_get");
+    expect(result.wat).toContain("__extern_get");
+  });
+
+  it("keeps define/read/descriptor/enumeration/delete on one authoritative store", async () => {
+    const { exports } = await compileStandalone(`
+export function test(): number {
+  const error: any = new Error("x");
+  Object.defineProperty(error, "p", {
+    value: 7, writable: true, enumerable: true, configurable: true
+  });
+  if (error.p !== 7 || !error.hasOwnProperty("p") || !("p" in error)) return 2;
+  const d: any = Object.getOwnPropertyDescriptor(error, "p");
+  if (d === undefined || d.value !== 7 || !d.writable || !d.enumerable || !d.configurable) return 3;
+  const keys: any = Object.keys(error);
+  if (keys.length !== 1 || keys[0] !== "p") return 4;
+  let seen = 0;
+  for (const key in error) { if (key === "p") seen = seen + 1; else seen = seen + 100; }
+  if (seen !== 1) return 5;
+  error.nil = null;
+  if (!error.hasOwnProperty("nil") || error.nil !== null) return 8;
+  if (!(delete error.p)) return 6;
+  if (error.hasOwnProperty("p") || ("p" in error) || error.p !== undefined) return 7;
+  if (!(delete error.nil)) return 9;
+  if (error.hasOwnProperty("nil") || ("nil" in error) || error.nil !== undefined) return 10;
+  return 1;
+}
+`);
+    expect(exports.test()).toBe(1);
+  });
+
+  it("invokes sidecar accessors with the original Error receiver", async () => {
+    const { exports } = await compileStandalone(`
+export function test(): number {
+  const error: any = new Error("x");
+  let getThis = 0;
+  let setThis = 0;
+  let stored = 0;
+  Object.defineProperty(error, "p", {
+    get: function (): number { if (this === error) getThis = 1; return stored; },
+    set: function (value: number): void { if (this === error) setThis = 1; stored = value; },
+    enumerable: true,
+    configurable: true
+  });
+  error.p = 9;
+  if (error.p !== 9) return 2;
+  if (getThis !== 1 || setThis !== 1) return 3;
+  return 1;
+}
+`);
+    expect(exports.test()).toBe(1);
+  });
+
+  it("uses the Error bag for preventExtensions integrity state", async () => {
+    const { exports } = await compileStandalone(`
+export function test(): number {
+  const error: any = new Error("x");
+  if (!Object.isExtensible(error)) return 2;
+  Object.preventExtensions(error);
+  if (Object.isExtensible(error)) return 3;
+  try { error.named = 1; } catch (_) {}
+  try { error["0"] = 2; } catch (_) {}
+  if (error.hasOwnProperty("named") || error.hasOwnProperty("0")) return 4;
+  return 1;
+}
+`);
+    expect(exports.test()).toBe(1);
+  });
+
+  it("keeps dynamic Error writes and reads coherent through compileMulti", async () => {
+    const result = await compileMulti(
+      {
+        "entry.ts": `
+export function test(): number {
+  const error: any = new Error("x");
+  error.value = 14;
+  return error.value;
+}
+`,
+      },
+      "entry.ts",
+      { target: "standalone", skipSemanticDiagnostics: true },
+    );
+    expect(result.success, JSON.stringify(result.errors)).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const module = await WebAssembly.compile(result.binary);
+    expect(WebAssembly.Module.imports(module)).toEqual([]);
+    const instance = await WebAssembly.instantiate(module, {});
+    expect((instance.exports.test as () => number)()).toBe(14);
+  });
+
+  it("keeps compileMulti Error accessors receiver-correct", async () => {
+    const result = await compileMulti(
+      {
+        "entry.ts": `
+export function test(): number {
+  const error: any = new Error("x");
+  let mask = 0;
+  let stored = 0;
+  Object.defineProperty(error, "value", {
+    get: function (): number { if (this === error) mask = mask + 1; return stored; },
+    set: function (value: number): void { if (this === error) mask = mask + 10; stored = value; },
+    configurable: true
+  });
+  error.value = 17;
+  if (error.value !== 17) return 2;
+  return mask;
+}
+`,
+      },
+      "entry.ts",
+      { target: "standalone", skipSemanticDiagnostics: true },
+    );
+    expect(result.success, JSON.stringify(result.errors)).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const module = await WebAssembly.compile(result.binary);
+    expect(WebAssembly.Module.imports(module)).toEqual([]);
+    const instance = await WebAssembly.instantiate(module, {});
+    expect((instance.exports.test as () => number)()).toBe(11);
+  });
+
+  it("accepts Error instances as descriptors, Properties maps, and define targets", async () => {
+    const { exports } = await compileStandalone(`
+export function test(): number {
+  const descriptor: any = new Error();
+  descriptor.value = 8;
+  descriptor.writable = true;
+  descriptor.enumerable = true;
+  descriptor.configurable = true;
+  const first: any = {};
+  Object.defineProperty(first, "a", descriptor);
+  if (first.a !== 8) return 2;
+
+  const properties: any = new Error();
+  let correctThis = 0;
+  Object.defineProperty(properties, "b", {
+    get: function (): any { if (this === properties) correctThis = 1; return { value: 9, enumerable: true }; },
+    enumerable: true,
+    configurable: true
+  });
+  const second: any = {};
+  Object.defineProperties(second, properties);
+  if (second.b !== 9 || correctThis !== 1) return 3;
+
+  const target: any = new Error();
+  Object.defineProperties(target, { c: { value: 10, enumerable: true, configurable: true } });
+  if (target.c !== 10 || Object.keys(target)[0] !== "c") return 4;
+  return 1;
+}
+`);
+    expect(exports.test()).toBe(1);
+  });
+
+  it("does not fabricate native Error struct internals as own enumerable keys", async () => {
+    const { exports } = await compileStandalone(`
+export function test(): number {
+  const fresh: any = new Error("x");
+  if (Object.keys(fresh).length !== 0) return 2;
+  const names: any = Object.getOwnPropertyNames(fresh);
+  for (let i = 0; i < names.length; i = i + 1) {
+    if (names[i] === "tag" || names[i] === "userClassId" || names[i] === "props") return 3;
+  }
+  fresh.user = 1;
+  const keys: any = Object.keys(fresh);
+  if (keys.length !== 1 || keys[0] !== "user") return 4;
+  return 1;
+}
+`);
+    expect(exports.test()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- make the existing native Error `$props` slot the authoritative standalone own-property store
- route assignment, reads, defineProperty/defineProperties, reflection, enumeration, deletion, and integrity through the shared runtime MOP
- preserve the original Error receiver for getter/setter `this`, including compileMulti parity
- document the bounded result and remaining Error-specific residuals in the repo issue

## Test262 impact

- exact same-SHA ES5 Error-carrier A/B (`803ab26e`): **0/23 -> 23/23** (+23, -0)
- final Error-family Object control on rebased head: **43/43**
- preventExtensions Error controls: **2/2 -> 2/2** (preserved)

## Verification

- focused Error suite: **8/8**
- neighboring carrier suites: **91/91**
- typecheck, Biome, format check
- IR fallback gate, stack-balance gate
- LOC/function budgets and pre-push ratchets

## Scope

This does not claim Date, RegExp, Arguments, or all of repo issue 4098. `propertyIsEnumerable` on Error bags and strict-mode throwing for non-writable Error assignment remain explicitly documented residuals.