### PR TITLE
feat(site): link js2wasm X profile

### DIFF
--- a/website/components/site-nav.js
+++ b/website/components/site-nav.js
@@ -233,7 +233,7 @@ class SiteNav extends HTMLElement {
         }
 
         /* ── Responsive ── */
-        @media (max-width: 768px) {
+        @media (max-width: 1280px) {
           .site-nav {
             padding: 0 20px;
           }
@@ -340,6 +340,13 @@ class SiteNav extends HTMLElement {
             </span>
             <span>GitHub</span>
           </a>
+          <a class="btn-outline" href="https://x.com/js2wasm" aria-label="js2wasm on X">
+            <span class="btn-icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" focusable="false">
+                <path d="M12.6.75h2.45L9.7 6.86 16 15.25h-4.93L7.21 10.2l-4.42 5.05H.34l5.72-6.54L0 .75h5.05l3.49 4.62L12.6.75Zm-.86 12.97h1.35L4.31 2.2H2.86l8.88 11.52Z"></path>
+              </svg>
+            </span>
+          </a>
           <a class="btn-outline" href="https://discord.gg/fZWxnBjzSj">
             <span class="btn-icon" aria-hidden="true">
               <svg viewBox="0 0 16 16" focusable="false">
@@ -366,6 +373,14 @@ class SiteNav extends HTMLElement {
               </svg>
             </span>
             <span>GitHub</span>
+          </a>
+          <a class="btn-outline" href="https://x.com/js2wasm" aria-label="js2wasm on X">
+            <span class="btn-icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" focusable="false">
+                <path d="M12.6.75h2.45L9.7 6.86 16 15.25h-4.93L7.21 10.2l-4.42 5.05H.34l5.72-6.54L0 .75h5.05l3.49 4.62L12.6.75Zm-.86 12.97h1.35L4.31 2.2H2.86l8.88 11.52Z"></path>
+              </svg>
+            </span>
+            <span>@js2wasm</span>
           </a>
           <a class="btn-outline" href="https://discord.gg/fZWxnBjzSj">
             <span class="btn-icon" aria-hidden="true">


### PR DESCRIPTION
## Summary

- add an accessible X profile action to the desktop landing-page navigation
- expose `@js2wasm` in the compact/mobile menu
- switch to the compact menu at 1280px to prevent the expanded social actions from crowding or clipping the navigation

## Why

The project’s X profile was not linked from the landing-page menu. Adding another desktop action also exceeded the available navigation width on narrower laptop layouts, so the responsive breakpoint now activates before clipping occurs.

## Validation

- `node --check website/components/site-nav.js`
- Prettier formatting check
- desktop and mobile browser verification at 1440px, 1200px, and 390px widths
- pre-push typecheck, lint, format, oracle/coercion ratchets, issue integrity, and numeric-local IR parity checks

## CLA

- [ ] I have read and agree to the [Contributor License Agreement](../blob/main/CLA.md)
