### PR TITLE
IR: finalize forward class callable ABIs before body emission

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -41,6 +41,7 @@ files:
   - src/ir/prepared-component-dependencies.ts
   - src/ir/prepared-component-sealing.ts
   - src/codegen/class-bodies.ts
+  - src/codegen/class-callable-abi.ts
   - src/codegen/function-body.ts
   - src/codegen/class-constructor-wrapper.ts
   - src/codegen/closures.ts
@@ -80,6 +81,7 @@ func-budget-allow:
   - src/codegen/class-bodies.ts::collectClassDeclaration
   - src/codegen/function-body.ts::compileFunctionBody
   - src/codegen/index.ts::buildIrClassShapes
+  - src/codegen/index.ts::generateModule
   - src/ir/from-ast.ts::lowerMethodCall
   - src/ir/integration.ts::compileIrPathFunctions
   - src/ir/integration.ts::makeFromAstResolver
@@ -975,6 +977,64 @@ failures whose baseline rows are passes, but an isolated worktree at the exact
 `4227031433a964` baseline commit reproduces the same three failures with identical
 error signatures on this host; they are platform-control differences, not
 #4402 changes. The merge queue remains the authoritative Linux comparison.
+
+### Forward/exact class-reference ABI checkpoint (2026-08-12)
+
+The next R3 family moves exact class references out of body-time ABI repair.
+TypeScript permits a constructor, method, or accessor in an earlier class to
+refer to a class declared later in the same source. Class callable slots were
+historically reserved before that later struct existed and therefore received
+provisional `externref` positions. The direct class-body compiler repaired the
+signature while emitting the body. A Prepared owner correctly skips that
+compiler, which exposed the phase violation as both missing symbolic class
+bindings and a final callable-signature mismatch.
+
+`orderIrClassShapeDeclarationsForProjection` now performs a stable,
+identity-based topological projection for acyclic local class-position
+dependencies. It preserves the authoritative published class order and does
+not widen the heritage policy. After all class structs are registered, the
+dedicated backend-neutral `class-callable-abi.ts` phase finalizes fixed
+constructor, method, getter, setter, and static-method slots before IR planning
+or either body emitter can run. The direct compiler's late re-resolution stays
+temporarily as an idempotent hybrid assertion and remains live for families not
+covered here.
+
+The exact `Holder -> Value` fixture establishes the measured boundary. On
+current main, all five `Holder` terminals (`_new`, instance method, getter,
+setter, and static method) report `legacyBodyEmitted:true` and IR false in both
+targets; the combined constructing caller then fails the final provisional ABI
+invariant. This checkpoint makes all five compile once through IR (**5 -> 0
+legacy bodies**) and the complete seven-terminal fixture validates and returns
+`5` in WasmGC and standalone. Direct-class-body poison covers every migrated
+member, so an emitted legacy body cannot satisfy the positive test.
+
+Optimization and representation parity are explicit. Every migrated callable
+uses the exact `(ref null $Value)` ABI and the WAT rejects `externref`,
+`any.convert_extern`, `extern.convert_any`, `ref.test`, `ref.cast`, `call_ref`,
+and `call_indirect`. The exact class-typed field fixture likewise accepts a
+field only when its already-committed struct index matches the projected class
+identity. Prepared artifacts are smaller than the same-source direct artifacts:
+
+| Fixture | Target | Direct | Prepared IR | Delta |
+| --- | --- | ---: | ---: | ---: |
+| forward callable positions | WasmGC | 1,720 bytes | 1,261 bytes | -459 bytes (-26.7%) |
+| forward callable positions | standalone | 47,614 bytes | 21,490 bytes | -26,124 bytes (-54.9%) |
+| exact class-typed field | WasmGC | 1,562 bytes | 1,224 bytes | -338 bytes (-21.6%) |
+| exact class-typed field | standalone | 46,973 bytes | 21,466 bytes | -25,507 bytes (-54.3%) |
+
+Two fail-closed controls define what this PR does not claim. A field that
+refers to a later class remains direct because the legacy class collector has
+already committed that storage slot as `externref`; fixing callable order must
+not silently rewrite object layout. A mutually recursive `Left <-> Right`
+constructor ABI also remains direct because immutable recursive class-shape
+cells do not exist yet. Default/rest/optional parameters, unsafe `super`,
+externref/builtin classes, and nested/class-expression owners retain their
+existing typed route.
+
+No shared legacy implementation is deleted in this checkpoint. Forward fields,
+recursive layouts, the direct-only mode, and the other excluded class families
+still consume the late class ABI/body paths. The next exact R3 transaction is
+forward class-field layout commitment; recursive cells follow separately.
 
 ## Exhaustive source-unit census
 

--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -1036,6 +1036,17 @@ recursive layouts, the direct-only mode, and the other excluded class families
 still consume the late class ABI/body paths. The next exact R3 transaction is
 forward class-field layout commitment; recursive cells follow separately.
 
+Qualification after rebasing onto current `origin/main` is green. The complete
+focused R2/R3 matrix passes **122/122**. Hybrid and fail-closed IR-only shadows
+both report **37/37 IR, 0 legacy bodies, 0 Unsupported, and 0 Invariants**. The
+ordinary fallback gate has zero unintended, post-claim, or module-level
+rejections; the shape diagnostic has zero attributed body-shape rejections.
+All eight equivalence shards report **1,645 passing, 24 known failures, and zero
+new regressions** (twelve stale baseline entries now pass but are deliberately
+not mixed into this PR). Cross-backend differential is **29/29**. Typecheck,
+lint, formatting, issue/optimization-retirement integrity, oracle separation,
+IR adoption, verdict-oracle, LOC, and function-budget gates also pass.
+
 ## Exhaustive source-unit census
 
 Before preparing any body, walk the source once in lexical/source order and

--- a/src/codegen/class-callable-abi.ts
+++ b/src/codegen/class-callable-abi.ts
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Pre-emission ABI finalization for class-owned callables.
+ *
+ * Prepared IR and the temporary direct route consume the same allocator-owned
+ * slots. Neither backend may discover or repair their signatures while
+ * emitting a source body. All type identity crosses the TypeOracle boundary;
+ * this planning phase never reads the TypeScript checker directly.
+ */
+import type { FuncTypeDef, ValType, WasmFunction } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import { findConstructorImplementation, hasStaticModifier } from "./ast-modifiers.js";
+import { classMemberFuncKey } from "./class-member-keys.js";
+import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt } from "./func-space.js";
+import { addFuncType } from "./registry/types.js";
+
+function hasFixedForwardClassAbiParameters(parameters: readonly ts.ParameterDeclaration[]): boolean {
+  return parameters.every(
+    (parameter) =>
+      ts.isIdentifier(parameter.name) &&
+      parameter.dotDotDotToken === undefined &&
+      parameter.questionToken === undefined &&
+      parameter.initializer === undefined,
+  );
+}
+
+function hasClassCallableModifier(
+  node: ts.Node & { readonly modifiers?: ts.NodeArray<ts.ModifierLike> },
+  kind: ts.SyntaxKind,
+): boolean {
+  return node.modifiers?.some((modifier) => modifier.kind === kind) === true;
+}
+
+function forwardLocalClassRef(
+  ctx: CodegenContext,
+  owner: ts.ClassDeclaration,
+  typeNode: ts.TypeNode | undefined,
+): ValType | undefined {
+  const identity = ctx.irPlanningIdentityContext;
+  if (!identity || !typeNode || !ts.isTypeReferenceNode(typeNode) || !ts.isIdentifier(typeNode.typeName)) {
+    return undefined;
+  }
+  const declaration = ctx.oracle
+    .declarationsOf(typeNode.typeName)
+    .find((candidate): candidate is ts.ClassDeclaration => ts.isClassDeclaration(candidate));
+  if (
+    !declaration?.name ||
+    declaration.getSourceFile() !== owner.getSourceFile() ||
+    declaration.getStart(owner.getSourceFile()) <= owner.getStart(owner.getSourceFile())
+  ) {
+    return undefined;
+  }
+  const classId = identity.classIdByDeclaration.get(declaration);
+  if (classId === undefined || identity.declarationByClassId.get(classId) !== declaration) return undefined;
+  const typeIdx = ctx.structMap.get(declaration.name.text);
+  return typeIdx === undefined ? undefined : { kind: "ref", typeIdx };
+}
+
+function classCallable(
+  ctx: CodegenContext,
+  fullName: string,
+): { readonly func: WasmFunction; readonly signature: FuncTypeDef } | undefined {
+  const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
+  const func = funcIdx === undefined ? undefined : definedFuncAt(ctx, funcIdx);
+  const signature = func === undefined ? undefined : ctx.mod.types[func.typeIdx];
+  return func && signature?.kind === "func" ? { func, signature } : undefined;
+}
+
+function setFinalClassCallableType(
+  ctx: CodegenContext,
+  fullName: string,
+  func: WasmFunction,
+  params: readonly ValType[],
+  results: readonly ValType[],
+): void {
+  func.typeIdx = addFuncType(ctx, [...params], [...results], `${fullName}_type`);
+}
+
+function replaceForwardParameters(
+  ctx: CodegenContext,
+  owner: ts.ClassDeclaration,
+  declarations: readonly ts.ParameterDeclaration[],
+  existing: readonly ValType[],
+  offset: number,
+): { readonly params: ValType[]; readonly changed: boolean } {
+  const params = [...existing];
+  let changed = false;
+  for (const [index, declaration] of declarations.entries()) {
+    const projected = forwardLocalClassRef(ctx, owner, declaration.type);
+    if (projected === undefined) continue;
+    params[index + offset] = projected;
+    changed = true;
+  }
+  return { params, changed };
+}
+
+/**
+ * Finalize callable slots whose fixed source ABI refers to a later local class.
+ *
+ * Class collection reserves slots in source order before the later class struct
+ * exists, so those positions are provisionally `externref`. This pass replaces
+ * only exact forward-class positions in the already-resolved signature. Every
+ * unrelated primitive/native/dynamic position stays byte-for-byte unchanged.
+ */
+export function finalizeForwardClassCallableAbis(ctx: CodegenContext, sourceFile: ts.SourceFile): void {
+  if (!ctx.irPlanningIdentityContext) return;
+  for (const statement of sourceFile.statements) {
+    if (!ts.isClassDeclaration(statement) || !statement.name) continue;
+    const className = statement.name.text;
+    const structTypeIdx = ctx.structMap.get(className);
+    if (structTypeIdx === undefined || ctx.classExternrefBackedSet.has(className)) continue;
+    const receiver: ValType = { kind: "ref", typeIdx: structTypeIdx };
+
+    const ctor = findConstructorImplementation(statement);
+    const newName = `${className}_new`;
+    const newCallable = classCallable(ctx, newName);
+    if (ctor && newCallable && hasFixedForwardClassAbiParameters(ctor.parameters)) {
+      const replacement = replaceForwardParameters(ctx, statement, ctor.parameters, newCallable.signature.params, 0);
+      if (replacement.changed) {
+        setFinalClassCallableType(ctx, newName, newCallable.func, replacement.params, [receiver]);
+        const initName = `${className}_init`;
+        const initCallable = classCallable(ctx, initName);
+        if (initCallable) {
+          setFinalClassCallableType(ctx, initName, initCallable.func, [...replacement.params, receiver], [receiver]);
+        }
+      }
+    }
+
+    const methodKinds = new Map<string, number>();
+    for (const member of statement.members) {
+      if (!ts.isMethodDeclaration(member) || !ts.isIdentifier(member.name)) continue;
+      methodKinds.set(member.name.text, (methodKinds.get(member.name.text) ?? 0) | (hasStaticModifier(member) ? 2 : 1));
+    }
+
+    for (const member of statement.members) {
+      if (
+        ts.isMethodDeclaration(member) &&
+        member.body &&
+        ts.isIdentifier(member.name) &&
+        !member.asteriskToken &&
+        !hasClassCallableModifier(member, ts.SyntaxKind.AsyncKeyword) &&
+        !hasClassCallableModifier(member, ts.SyntaxKind.AbstractKeyword) &&
+        methodKinds.get(member.name.text) !== 3 &&
+        hasFixedForwardClassAbiParameters(member.parameters)
+      ) {
+        const fullName = `${className}_${member.name.text}`;
+        const callable = classCallable(ctx, fullName);
+        if (!callable) continue;
+        const replacement = replaceForwardParameters(
+          ctx,
+          statement,
+          member.parameters,
+          callable.signature.params,
+          hasStaticModifier(member) ? 0 : 1,
+        );
+        const result = forwardLocalClassRef(ctx, statement, member.type);
+        if (replacement.changed || result !== undefined) {
+          setFinalClassCallableType(
+            ctx,
+            fullName,
+            callable.func,
+            replacement.params,
+            result === undefined ? callable.signature.results : [result],
+          );
+        }
+        continue;
+      }
+      if (
+        ts.isGetAccessorDeclaration(member) &&
+        member.body &&
+        ts.isIdentifier(member.name) &&
+        !hasStaticModifier(member)
+      ) {
+        const result = forwardLocalClassRef(ctx, statement, member.type);
+        const fullName = `${className}_get_${member.name.text}`;
+        const callable = result === undefined ? undefined : classCallable(ctx, fullName);
+        if (result && callable)
+          setFinalClassCallableType(ctx, fullName, callable.func, callable.signature.params, [result]);
+        continue;
+      }
+      if (
+        ts.isSetAccessorDeclaration(member) &&
+        member.body &&
+        ts.isIdentifier(member.name) &&
+        !hasStaticModifier(member) &&
+        member.parameters.length === 1 &&
+        hasFixedForwardClassAbiParameters(member.parameters)
+      ) {
+        const fullName = `${className}_set_${member.name.text}`;
+        const callable = classCallable(ctx, fullName);
+        if (!callable) continue;
+        const replacement = replaceForwardParameters(ctx, statement, member.parameters, callable.signature.params, 1);
+        if (replacement.changed) setFinalClassCallableType(ctx, fullName, callable.func, replacement.params, []);
+      }
+    }
+  }
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -148,6 +148,7 @@ import {
 import {
   collectIrClassShapeDeclarations,
   createIrClassShapeSidecar,
+  orderIrClassShapeDeclarationsForProjection,
   projectIrClassCallableTarget,
   resolveIrClassShapeFromType,
   resolveIrClassShapeFromTypeReference,
@@ -344,6 +345,7 @@ import {
   compileClassBodies,
   resolveClassMemberName,
 } from "./class-bodies.js";
+import { finalizeForwardClassCallableAbis } from "./class-callable-abi.js";
 import { classMemberFuncKey, fnctorAncestorOfClass, moduleHasFnctorSubclass } from "./class-member-keys.js"; // (#1983 / #3123)
 import {
   applyShapeInference,
@@ -1284,7 +1286,16 @@ function buildIrClassShapes(
 ): IrClassShapeSidecar {
   const out = new Map<IrClassId, IrClassShapeEntry>();
   const lookup: IrClassShapeLookup = { identityContext, byClassId: out };
-  for (const { classId, declaration: stmt } of collectIrClassShapeDeclarations(sourceFile, identityContext)) {
+  const declarationsInCollectionOrder = collectIrClassShapeDeclarations(sourceFile, identityContext);
+  const collectionPosition = new Map(
+    declarationsInCollectionOrder.map((entry, index) => [entry.classId, index] as const),
+  );
+  const declarations = orderIrClassShapeDeclarationsForProjection(
+    ctx.oracle,
+    declarationsInCollectionOrder,
+    identityContext,
+  );
+  for (const { classId, declaration: stmt } of declarations) {
     const className = ts.isClassExpression(stmt) ? ctx.anonClassExprNames.get(stmt) : stmt.name?.text;
     if (!className) continue;
     // The selector needs a provisional descriptor population in order to
@@ -1304,8 +1315,14 @@ function buildIrClassShapes(
     let parentShape: import("../ir/nodes.js").IrClassShape | undefined;
     const parentClassId = resolveIrParentClassId(ctx.checker, stmt, identityContext);
     if (parentClassId !== null) {
+      const parentPosition = parentClassId === undefined ? undefined : collectionPosition.get(parentClassId);
+      const currentPosition = collectionPosition.get(classId)!;
+      // Dependency ordering may move a later type-position dependency before
+      // this class. It must not also widen the heritage policy: a parent that
+      // was not earlier in the authoritative collection remains direct.
+      if (parentPosition === undefined || parentPosition >= currentPosition) continue;
       const parentEntry = parentClassId === undefined ? undefined : out.get(parentClassId);
-      if (!parentEntry) continue; // parent isn't this exact projected class (builtin, foreign, or declared later)
+      if (!parentEntry) continue; // parent isn't this exact projected earlier class (builtin, foreign, or unsupported)
       parentShape = parentEntry.shape;
     }
     if (!ctx.classSet.has(className)) continue;
@@ -1653,7 +1670,15 @@ function buildIrClassShapes(
     };
     out.set(classId, { classId, legacyName: className, declaration: stmt, shape });
   }
-  return createIrClassShapeSidecar(out, identityContext);
+  // Dependency construction order is an internal planning detail. Publish the
+  // registry in the authoritative collection order so type/global planning and
+  // legacy compatibility views remain byte-stable for existing programs.
+  const published = new Map<IrClassId, IrClassShapeEntry>();
+  for (const { classId } of declarationsInCollectionOrder) {
+    const entry = out.get(classId);
+    if (entry) published.set(classId, entry);
+  }
+  return createIrClassShapeSidecar(published, identityContext);
 }
 
 /**
@@ -1716,12 +1741,16 @@ function valTypeToIrField(_ctx: CodegenContext, vt: import("../ir/types.js").Val
  * versus legacy-compiled callers, and the #1370 method-signature parity guard
  * (`integration.ts`) sees identical typeIdx on both sides.
  *
- * Scope is intentionally narrow: primitives (`f64`/`i32`) and `string`. The
- * `string` arm mirrors `resolveWasmType`'s string arm + the `ref`→`ref_null`
- * field widening in `collectClassDeclaration` (native → `(ref/ref_null
- * $AnyString)`; host → `externref`), which is exactly what `resolveString()`
- * resolves an `IrType.string` to at lower time. Any other IR kind returns
- * false → the caller falls back to the ValType path.
+ * Scope is intentionally narrow: primitives (`f64`/`i32`), `string`, and an
+ * exact local `class` whose identity-projected shape resolves to the same
+ * committed struct index. The `string` arm mirrors `resolveWasmType`'s string
+ * arm + the `ref`→`ref_null` field widening in `collectClassDeclaration`
+ * (native → `(ref/ref_null $AnyString)`; host → `externref`), which is exactly
+ * what `resolveString()` resolves an `IrType.string` to at lower time. The
+ * class arm likewise accepts either nullability of the same struct index
+ * because class fields are nullable storage while source parameters/results
+ * remain non-null class references. Any other IR kind returns false → the
+ * caller falls back to the ValType path.
  */
 function irFieldTypeMatchesLegacyValType(
   ctx: CodegenContext,
@@ -1741,6 +1770,10 @@ function irFieldTypeMatchesLegacyValType(
       return (vt.kind === "ref" || vt.kind === "ref_null") && vt.typeIdx === ctx.anyStrTypeIdx;
     }
     return vt.kind === "externref";
+  }
+  if (ir.kind === "class") {
+    const structTypeIdx = ctx.structMap.get(ir.shape.className);
+    return structTypeIdx !== undefined && (vt.kind === "ref" || vt.kind === "ref_null") && vt.typeIdx === structTypeIdx;
   }
   return false;
 }
@@ -4518,6 +4551,11 @@ export function generateModule(
     scanForArrayHoles(ctx, ast.sourceFile);
 
     collectDeclarations(ctx, ast.sourceFile);
+    // #3522 R3: callable slots with exact references to a later local class
+    // must receive their final struct ABI before prepared IR planning decides
+    // which direct bodies will never run. The direct body compiler retains its
+    // idempotent re-resolution as a temporary hybrid assertion.
+    finalizeForwardClassCallableAbis(ctx, ast.sourceFile);
     // #2847: declaration collection has now materialized the initial struct
     // field table. Brand proven boolean i32 slots before compiling bodies so
     // direct/dynamic reads preserve JS boolean identity at their use sites.

--- a/src/codegen/ir-class-shapes.ts
+++ b/src/codegen/ir-class-shapes.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { ts } from "../ts-api.js";
+import type { TypeOracle } from "../checker/oracle.js";
 import { irUnitFuncRef } from "../ir/callable-bindings.js";
 import type { IrClassId, IrSourceId, IrUnitKind } from "../ir/identity.js";
 import type { IrClassShape, IrFuncRef } from "../ir/nodes.js";
@@ -273,6 +274,134 @@ export function collectIrClassShapeDeclarations(
     }
   }
   return selected;
+}
+
+function hasModifier(
+  node: ts.Node & { readonly modifiers?: ts.NodeArray<ts.ModifierLike> },
+  kind: ts.SyntaxKind,
+): boolean {
+  return node.modifiers?.some((modifier) => modifier.kind === kind) === true;
+}
+
+function hasFixedClassShapeParameters(parameters: readonly ts.ParameterDeclaration[]): boolean {
+  return parameters.every(
+    (parameter) =>
+      ts.isIdentifier(parameter.name) &&
+      parameter.dotDotDotToken === undefined &&
+      parameter.questionToken === undefined &&
+      parameter.initializer === undefined,
+  );
+}
+
+/**
+ * Order exact class-shape candidates so every acyclic, local class type used by
+ * a shape position is projected before its consumer. TypeScript permits a type
+ * annotation to reference a later declaration; the legacy struct registry is
+ * already complete before IR planning, so source-order projection was an
+ * accidental restriction rather than an ABI constraint.
+ *
+ * Dependencies are identity-based and local to the candidate population.
+ * Cycles deliberately retain their original order and therefore remain on the
+ * typed direct path until recursive class-shape cells are planned explicitly.
+ */
+export function orderIrClassShapeDeclarationsForProjection(
+  oracle: TypeOracle,
+  declarations: readonly IrClassShapeDeclaration[],
+  context: IrPlanningIdentityContext,
+): readonly IrClassShapeDeclaration[] {
+  const byClassId = new Map(declarations.map((entry) => [entry.classId, entry] as const));
+  const sourcePosition = new Map(declarations.map((entry, index) => [entry.classId, index] as const));
+  const dependencies = new Map<IrClassId, Set<IrClassId>>();
+
+  for (const entry of declarations) {
+    const required = new Set<IrClassId>();
+    const addTypeNode = (typeNode: ts.TypeNode | undefined): void => {
+      if (!typeNode || !ts.isTypeReferenceNode(typeNode) || !ts.isIdentifier(typeNode.typeName)) return;
+      const declaration = oracle
+        .declarationsOf(typeNode.typeName)
+        .find((candidate): candidate is ts.ClassDeclaration => ts.isClassDeclaration(candidate));
+      const dependency = declaration === undefined ? undefined : context.classIdByDeclaration.get(declaration);
+      if (dependency !== undefined && dependency !== entry.classId && byClassId.has(dependency)) {
+        required.add(dependency);
+      }
+    };
+
+    for (const member of entry.declaration.members) {
+      if (ts.isConstructorDeclaration(member)) {
+        if (hasFixedClassShapeParameters(member.parameters)) {
+          for (const parameter of member.parameters) addTypeNode(parameter.type);
+        }
+        continue;
+      }
+      if (ts.isPropertyDeclaration(member)) {
+        if (
+          !hasModifier(member, ts.SyntaxKind.StaticKeyword) &&
+          (ts.isIdentifier(member.name) || ts.isPrivateIdentifier(member.name))
+        ) {
+          addTypeNode(member.type);
+        }
+        continue;
+      }
+      if (ts.isMethodDeclaration(member)) {
+        if (
+          !ts.isIdentifier(member.name) ||
+          member.asteriskToken ||
+          hasModifier(member, ts.SyntaxKind.AbstractKeyword) ||
+          !hasFixedClassShapeParameters(member.parameters)
+        ) {
+          continue;
+        }
+        for (const parameter of member.parameters) addTypeNode(parameter.type);
+        addTypeNode(member.type);
+        continue;
+      }
+      if (ts.isGetAccessorDeclaration(member)) {
+        addTypeNode(member.type);
+        continue;
+      }
+      if (ts.isSetAccessorDeclaration(member) && member.parameters.length === 1) {
+        const parameter = member.parameters[0]!;
+        if (hasFixedClassShapeParameters([parameter])) addTypeNode(parameter.type);
+      }
+    }
+    dependencies.set(entry.classId, required);
+  }
+
+  const dependents = new Map<IrClassId, Set<IrClassId>>();
+  const remaining = new Map<IrClassId, number>();
+  for (const entry of declarations) {
+    const required = dependencies.get(entry.classId) ?? new Set<IrClassId>();
+    remaining.set(entry.classId, required.size);
+    for (const dependency of required) {
+      const consumers = dependents.get(dependency) ?? new Set<IrClassId>();
+      consumers.add(entry.classId);
+      dependents.set(dependency, consumers);
+    }
+  }
+
+  const ready = declarations.filter((entry) => remaining.get(entry.classId) === 0);
+  const ordered: IrClassShapeDeclaration[] = [];
+  const emitted = new Set<IrClassId>();
+  while (ready.length > 0) {
+    ready.sort((left, right) => sourcePosition.get(left.classId)! - sourcePosition.get(right.classId)!);
+    const entry = ready.shift()!;
+    if (emitted.has(entry.classId)) continue;
+    emitted.add(entry.classId);
+    ordered.push(entry);
+    for (const dependent of dependents.get(entry.classId) ?? []) {
+      const count = (remaining.get(dependent) ?? 0) - 1;
+      remaining.set(dependent, count);
+      if (count === 0) ready.push(byClassId.get(dependent)!);
+    }
+  }
+
+  // A non-empty residue is an exact class-type cycle. Retain its declaration
+  // order so the existing shape builder refuses it without inventing mutable
+  // placeholders or weakening prepare-before-emit immutability.
+  for (const entry of declarations) {
+    if (!emitted.has(entry.classId)) ordered.push(entry);
+  }
+  return ordered;
 }
 
 /** Create the only name-keyed class-shape view, omitting every ambiguous label. */

--- a/tests/issue-3520-class-shape-identity.test.ts
+++ b/tests/issue-3520-class-shape-identity.test.ts
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { describe, expect, it } from "vitest";
+
+import { TsCheckerOracle } from "../src/checker/oracle.js";
 import {
   collectIrClassShapeDeclarations,
   createIrClassShapeSidecar,
+  orderIrClassShapeDeclarationsForProjection,
   requireIrClassShapeClassId,
   resolveIrClassShapeFromType,
   resolveIrClassShapeFromTypeReference,
@@ -107,6 +110,32 @@ function expectPlanningError(run: () => unknown, code: IrPlanningIdentityInvaria
 }
 
 describe("#3520 exact class-shape identity", () => {
+  it("orders acyclic forward class-position dependencies by exact identity and leaves cycles stable", () => {
+    const graph = fixture({
+      "/repo/a.ts": `
+        class Holder {
+          current: Value;
+          constructor(current: Value) { this.current = current; }
+          replace(next: Value): Value { return next; }
+          get held(): Value { return this.current; }
+          set held(next: Value) { this.current = next; }
+          static keep(next: Value): Value { return next; }
+        }
+        class Value { amount: number; }
+        class Left { constructor(right: Right) {} }
+        class Right { constructor(left: Left) {} }
+      `,
+    });
+    const sourceFile = graph.byName.get("/repo/a.ts")!;
+    const collected = collectIrClassShapeDeclarations(sourceFile, graph.context);
+    expect(collected.map((entry) => entry.legacyName)).toEqual(["Holder", "Value", "Left", "Right"]);
+    expect(
+      orderIrClassShapeDeclarationsForProjection(new TsCheckerOracle(graph.checker), collected, graph.context).map(
+        (entry) => entry.legacyName,
+      ),
+    ).toEqual(["Value", "Holder", "Left", "Right"]);
+  });
+
   it("keeps same-label entries exact while omitting the ambiguous legacy projection", () => {
     const graph = fixture({
       "/repo/a.ts": `

--- a/tests/issue-3522-ir-class-compile-once.test.ts
+++ b/tests/issue-3522-ir-class-compile-once.test.ts
@@ -227,7 +227,7 @@ describe("#3522 instance class-method compile-once ownership", () => {
         });
         expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
         for (const name of ["Animal_new", "Dog_new"]) {
-          expect(classMemberOutcome(prepared, name)).toMatchObject({
+          expect(classMemberOutcome(prepared, name), `${name} must compile once through IR`).toMatchObject({
             kind: "emitted",
             legacyBodyEmitted: false,
             irBodyEmitted: true,
@@ -697,25 +697,178 @@ describe("#3522 instance class-method compile-once ownership", () => {
   );
 
   it.each(["gc", "standalone"] as const)(
-    "keeps a forward-class constructor parameter direct until its finalized ABI is exact in the %s lane",
+    "prepares every exact forward-class callable ABI position once in the %s lane",
     async (target) => {
       const source = `
-        class A { constructor(b: B) {} }
-        class B {}
-        export function marker(): number { return 1; }
+        class Holder {
+          constructor(current: Value) { current.amount = current.amount; }
+          replace(next: Value): Value { return next; }
+          get held(): Value { return new Value(5); }
+          set held(next: Value) { next.amount = next.amount; }
+          static keep(next: Value): Value { return next; }
+        }
+        class Value {
+          amount: number;
+          constructor(amount: number) { this.amount = amount; }
+        }
+        export function run(): number {
+          const holder = new Holder(new Value(3));
+          holder.held = holder.replace(new Value(4));
+          return Holder.keep(holder.held).amount;
+        }
       `;
       const previous = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
       try {
         Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
         const direct = await compile(source, {
           fileName: `forward-class-constructor-param-${target}.ts`,
+          experimentalIR: false,
+          emitWat: true,
+          target,
+        });
+        const prepared = await compile(source, {
+          fileName: `forward-class-constructor-param-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          emitWat: true,
+          target,
+        });
+        expect(direct.success, direct.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(direct.binary)).toBe(true);
+        expect(WebAssembly.validate(prepared.binary)).toBe(true);
+        expect((await instantiate(direct)).run!()).toBe(5);
+        expect((await instantiate(prepared)).run!()).toBe(5);
+        for (const name of [
+          "Holder_new",
+          "Holder_replace",
+          "Holder_get_held",
+          "Holder_set_held",
+          "Holder_keep",
+          "Value_new",
+        ]) {
+          const observed = classMemberOutcome(prepared, name);
+          expect(observed, `${name} must compile once through IR: ${JSON.stringify(observed)}`).toMatchObject({
+            kind: "emitted",
+            legacyBodyEmitted: false,
+            irBodyEmitted: true,
+          });
+        }
+        expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+        expect(prepared.binary.length).toBeLessThanOrEqual(direct.binary.length);
+
+        const valueTypeIdx = watNullableRefResultTypeIndex(watFunctionBody(prepared.wat, "Value_new"), "Value_new");
+        for (const name of ["Holder_init", "Holder_replace", "Holder_get_held", "Holder_set_held", "Holder_keep"]) {
+          const body = watFunctionBody(prepared.wat, name);
+          expect(body.split("\n")[0], `${name} forward-class ABI`).toContain(`(ref null ${valueTypeIdx})`);
+          expect(body).not.toMatch(
+            /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.(?:test|cast)/,
+          );
+        }
+
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY =
+          "Holder_new,Holder_replace,Holder_get_held,Holder_set_held,Holder_keep,Value_new";
+        const poisoned = await compile(source, {
+          fileName: `forward-class-constructor-param-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          target,
+        });
+        expect(poisoned.success, poisoned.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect((await instantiate(poisoned)).run!()).toBe(5);
+      } finally {
+        if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previous;
+      }
+    },
+  );
+
+  it.each(["gc", "standalone"] as const)(
+    "prepares an exact class-typed field only when its committed struct ABI matches in the %s lane",
+    async (target) => {
+      const source = `
+        class Value {
+          amount: number;
+          constructor(amount: number) { this.amount = amount; }
+        }
+        class Holder {
+          current: Value;
+          constructor(current: Value) { this.current = current; }
+          read(): number { return this.current.amount; }
+        }
+        export function run(): number { return new Holder(new Value(42)).read(); }
+      `;
+      const direct = await compile(source, {
+        fileName: `exact-class-field-abi-${target}.ts`,
+        experimentalIR: false,
+        emitWat: true,
+        target,
+      });
+      const previous = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Value_new,Holder_new,Holder_read";
+        prepared = await compile(source, {
+          fileName: `exact-class-field-abi-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          emitWat: true,
+          target,
+        });
+      } finally {
+        if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previous;
+      }
+
+      for (const result of [direct, prepared]) {
+        expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(result.binary)).toBe(true);
+        expect((await instantiate(result)).run!()).toBe(42);
+      }
+      for (const name of ["Value_new", "Holder_new", "Holder_read"]) {
+        expect(classMemberOutcome(prepared, name)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+      }
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.binary.length).toBeLessThanOrEqual(direct.binary.length);
+
+      const valueTypeIdx = watNullableRefResultTypeIndex(watFunctionBody(prepared.wat, "Value_new"), "Value_new");
+      expect(watTypeDefinition(prepared.wat, "Holder")).toContain(`(field $current (mut (ref null ${valueTypeIdx})))`);
+      for (const name of ["Holder_init", "Holder_read"]) {
+        const body = watFunctionBody(prepared.wat, name);
+        expect(body).not.toMatch(
+          /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.(?:test|cast)/,
+        );
+      }
+    },
+  );
+
+  it.each(["gc", "standalone"] as const)(
+    "keeps a forward class field direct while its committed storage ABI is externref in the %s lane",
+    async (target) => {
+      const source = `
+        class Holder {
+          current: Value;
+          constructor(current: Value) { this.current = current; }
+        }
+        class Value { amount: number; }
+        export function marker(): number { return 1; }
+      `;
+      const previous = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      try {
+        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        const direct = await compile(source, {
+          fileName: `forward-class-field-abi-${target}.ts`,
           experimentalIR: true,
           trackIrOutcomes: true,
           target,
         });
         expect(direct.success, direct.errors.map((error) => error.message).join("\n")).toBe(true);
         expect(WebAssembly.validate(direct.binary)).toBe(true);
-        expect(classMemberOutcome(direct, "A_new")).toMatchObject({
+        expect(classMemberOutcome(direct, "Holder_new")).toMatchObject({
           kind: "unsupported",
           stage: "select",
           legacyBodyEmitted: true,
@@ -723,23 +876,64 @@ describe("#3522 instance class-method compile-once ownership", () => {
         });
         expect(direct.irPostClaimErrors ?? []).toEqual([]);
 
-        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "A_new";
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Holder_new";
         const poisoned = await compile(source, {
-          fileName: `forward-class-constructor-param-${target}.ts`,
+          fileName: `forward-class-field-abi-${target}.ts`,
           experimentalIR: true,
           trackIrOutcomes: true,
           target,
         });
         expect(poisoned.success).toBe(false);
-        expect(classMemberOutcome(poisoned, "A_new")).toMatchObject({
-          kind: "unsupported",
-          stage: "select",
-          legacyBodyEmitted: true,
-          irBodyEmitted: false,
-        });
         expect(
-          poisoned.errors.some((error) => error.message.includes("injected direct class-body poison: A_new")),
+          poisoned.errors.some((error) => error.message.includes("injected direct class-body poison: Holder_new")),
         ).toBe(true);
+      } finally {
+        if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previous;
+      }
+    },
+  );
+
+  it.each(["gc", "standalone"] as const)(
+    "keeps cyclic class ABIs on one typed direct path in the %s lane",
+    async (target) => {
+      const source = `
+        class Left { constructor(right: Right) {} }
+        class Right { constructor(left: Left) {} }
+        export function marker(): number { return 1; }
+      `;
+      const previous = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      try {
+        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        const direct = await compile(source, {
+          fileName: `cyclic-class-constructor-abi-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          target,
+        });
+        expect(direct.success, direct.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(direct.binary)).toBe(true);
+        for (const name of ["Left_new", "Right_new"]) {
+          expect(classMemberOutcome(direct, name)).toMatchObject({
+            kind: "unsupported",
+            stage: "select",
+            legacyBodyEmitted: true,
+            irBodyEmitted: false,
+          });
+        }
+        expect(direct.irPostClaimErrors ?? []).toEqual([]);
+
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Left_new,Right_new";
+        const poisoned = await compile(source, {
+          fileName: `cyclic-class-constructor-abi-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          target,
+        });
+        expect(poisoned.success).toBe(false);
+        expect(poisoned.errors.some((error) => error.message.includes("injected direct class-body poison:"))).toBe(
+          true,
+        );
       } finally {
         if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
         else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previous;


### PR DESCRIPTION
## Summary

- order acyclic local class-shape dependencies by exact identity while preserving the published/source order
- finalize forward class constructor, method, getter, setter, and static-method ABIs before either backend emits a body
- keep all new type queries behind the TypeOracle boundary
- migrate the exact Holder → Value family from 5 legacy bodies to 0
- retain fail-closed direct controls for forward class fields and recursive class ABI cycles

## Optimization parity

The migrated WAT uses exact typed class references and rejects externref conversion, ref.test/ref.cast, call_ref, and call_indirect.

| Fixture | Target | Direct | Prepared IR | Delta |
| --- | --- | ---: | ---: | ---: |
| forward callable positions | WasmGC | 1,720 B | 1,261 B | -26.7% |
| forward callable positions | standalone | 47,614 B | 21,490 B | -54.9% |
| exact class-typed field | WasmGC | 1,562 B | 1,224 B | -21.6% |
| exact class-typed field | standalone | 46,973 B | 21,466 B | -54.3% |

## Validation

- focused R2/R3 matrix: 122/122
- strict IR-only shadow: 37/37 IR, 0 legacy, 0 Unsupported, 0 Invariant
- fallback gates: zero unintended, post-claim, module-level, or shape rejections
- equivalence: 8/8 shards, 1,645 passing, 24 known failures, 0 regressions
- cross-backend differential: 29/29
- typecheck, lint, formatting, oracle, adoption, issue integrity, LOC/function budgets: green
- pre-push numeric-local parity: 18/18

The resumable ownership and next-family boundary are recorded in `plan/issues/3522-ir-r3-classes-closures-compile-once.md`. No GitHub issue is used.

Forward class-field layout commitment and recursive class-shape cells remain follow-up R3 families. Shared direct implementations remain because those and other typed-direct consumers are still live.
