### PR TITLE
docs(plan): define compiler capability hardening roadmap

### DIFF
--- a/plan/issues/2514-runtime-helpers-as-shared-linkable-module.md
+++ b/plan/issues/2514-runtime-helpers-as-shared-linkable-module.md
@@ -1,19 +1,22 @@
 ---
 id: 2514
-title: "Runtime helpers (number_toString, string/array/GC helpers) as a shared linkable module via a canonical runtime-type rec-group ABI"
+title: "Link-gated shared core-Wasm runtime providers with a versioned runtime ABI"
 status: backlog
 sprint: Backlog
 created: 2026-06-19
-updated: 2026-06-19
-priority: medium
+updated: 2026-08-12
+priority: high
 feasibility: hard
 reasoning_effort: high
-task_type: architecture
-area: codegen
+task_type: refactor
+area: runtime, linking, codegen, codegen-linear
 language_feature: runtime-helpers
+es_edition: n/a
 goal: architecture
-related: [2512, 1046]
+related: [1046, 2512, 2524, 2525, 2783, 3526, 3678, 4382]
 ---
+
+# #2514 — Link-gated shared core-Wasm runtime providers
 
 > **Linking mechanism (decided):** **core-wasm module linking in a shared store**
 > + a frozen canonical rec group — see **#2524** (chosen). The Component Model is
@@ -28,8 +31,31 @@ string/array/vec helpers, boxing helpers, GC struct accessors, etc. — **inline
 into every compiled module** (each only when used, via DCE). Across multiple
 compiled modules this duplicates the same helper code.
 
-Proposal: compile the runtime helpers once into a shared `runtime.wasm` and have
-user modules **import** them, instead of re-emitting per module.
+Proposal: compile stable provider families into shared core-Wasm modules and
+have user modules import only the families required by their frozen runtime
+feature manifest, instead of re-emitting those providers per module. Preserve
+the existing inline path until size, startup, and engine-compatibility evidence
+shows that a linked provider is a net improvement for the selected target.
+
+## Link-gated provider plan
+
+#3526 becomes the sole semantic authority for provider selection. Its frozen
+`RuntimeFeature` closure is mapped to versioned provider units before body
+lowering. The linker then chooses one of three explicit outcomes per unit:
+
+1. backend-native lowering, requiring no provider import;
+2. inline/self-host provider, preserving the current single-module artifact;
+3. shared core-Wasm provider import with an exact ABI version.
+
+Do not replace conditional inline emission with one monolithic always-linked
+runtime. Provider units must be feature-granular enough that unused regex,
+collections, async, dynamic-value, or host-adapter families add neither imports
+nor required side modules. The final compile/capability manifest records the
+selected units, versions, and transitive host capabilities for #4382.
+
+The module import set and provider versions freeze before lowering. A missing
+provider, ABI mismatch, unexpected late import, or unsupported target adapter
+is a typed pre-emission failure, not a retry through inline or legacy code.
 
 ## This is NOT blocked on a missing standard — it's an ABI engineering project
 
@@ -110,6 +136,41 @@ required.
 - Phase 1: factor out **non-GC** helpers behind a stable interface (no
   identity concern) — and/or the `--nativeStrings` linear path.
 - Phase 2: GC-typed helpers via the canonical rec-group ABI once #2 is solved.
+- Phase 3: integrate #3526 feature-closure selection, provider-unit packaging,
+  ABI/version checks, and #4382 manifest projection. Promote each family only
+  after differential correctness and artifact/startup-size evidence is green.
+
+## Acceptance criteria
+
+- [ ] A versioned provider registry maps frozen #3526 `RuntimeFeature`s to
+      backend-native, inline, or shared core-Wasm implementations without
+      inspecting source AST or emitted import spellings.
+- [ ] Provider selection and the complete import set freeze before body
+      lowering; late demand, missing adapters, and ABI mismatches fail with
+      typed #3678 diagnostics before artifacts are published.
+- [ ] A minimal program imports no shared provider, and focused programs import
+      only their exact feature-granular provider units and dependencies.
+- [ ] Non-GC/linear providers land first with JS-host and standalone/WASI
+      differential parity, import-leak checks, and multi-module integration
+      tests in every supported runtime.
+- [ ] WasmGC provider exchange proves canonical rec-group identity across
+      separately compiled modules on every supported engine and fails closed on
+      ABI or Binaryen rec-group drift.
+- [ ] Release artifacts distribute provider modules and ABI metadata
+      atomically; incompatible combinations fail deterministically.
+- [ ] Per-family measurements compare inline and linked code size, startup,
+      steady-state performance, and cache reuse. Linking remains opt-in for a
+      family until the target-specific tradeoff is documented.
+- [ ] #4382 reports selected provider units/versions and never hides a linked
+      runtime or host capability behind a generic successful-build status.
+
+## Out of scope
+
+- Rewriting runtime providers in C or adopting a second semantic runtime.
+- Using the Component Model where its ABI would copy WasmGC values.
+- Shipping one always-linked runtime blob that defeats feature gating.
+- Adding a general JavaScript engine fallback or changing the supported
+  language contract to simplify the provider boundary.
 
 ## Notes
 

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -18,7 +18,7 @@ complexity: XL
 es_edition: n/a
 lane: ir-retirement
 model: gpt-5.6-sol
-related: [1373b, 2855, 2950, 3090, 3142, 3143, 3341, 3517, 3529, 3520, 3521, 3522, 3523, 3525, 3526, 3527, 3528]
+related: [1373b, 2855, 2950, 3090, 3142, 3143, 3341, 3517, 3529, 3520, 3521, 3522, 3523, 3525, 3526, 3527, 3528, 3678, 3681, 4382]
 origin: "2026-07-21 explicit user directive: enable IR-only by default and retire the old direct codegen path"
 ---
 # #3518 — IR-only default and direct front-end retirement
@@ -51,6 +51,12 @@ through semantic IR intents rather than `compileExpression` /
 `compileStatement`. Features intentionally outside the compiler's supported
 language fail with a stable source-located `Unsupported` diagnostic; they do
 not resurrect the direct path.
+
+`PreparedIrProgram` is also the versioned, validated, losslessly serializable
+handoff between frontend preparation and backend emission. Both backends
+consume the same frozen program snapshot. Deserialization re-runs structural,
+type, ABI, effect, and runtime-manifest verification before any artifact side
+effect; it never reparses source, reselects features, or invokes a legacy path.
 
 ## Current truth (audited 2026-08-09)
 
@@ -125,7 +131,7 @@ their order and acceptance boundaries.
 | **R0a — #3529 (done)**       | Restore typed-producer equivalence parity without weakening unknown-throw-to-Invariant classification | #3143; exposed by #3519               | 154 new compile failures return to the committed baseline through preclaim/typed Unsupported or true invariant fixes; no baseline expansion                     |
 | **R0b — #3519 (done)**       | Typed `Prepared` / `Unsupported` / `Invariant` outcomes plus an honest `check:ir-only` readiness gate | #3143, #3529; informed by #2855/#3341 | No TypeMap or compile failures are skipped; `result.errors` and every unit outcome are accounted for; hybrid vs IR-only policy is tested                        |
 | **R1 — #3520 (in progress)** | Source-qualified `IrUnitId` and a whole-program `ProgramAbiMap`                                       | R0                                    | Same-named units across files/classes cannot collide; signatures, globals, imports, types, exports, and synthetic units are planned once                        |
-| **R2 — #3521 (in progress)** | `PreparedIrProgram` and prepare-before-emit compile-once pipeline                                     | #3520                                 | Prepared free functions never call legacy body compilation; unsupported units are decided before any body emitter side effect                                   |
+| **R2 — #3521 (in progress)** | `PreparedIrProgram` and prepare-before-emit compile-once pipeline                                     | #3520                                 | Prepared free functions never call legacy body compilation; the versioned validated program round-trips losslessly; unsupported units are decided before emission |
 | **R3 — #3522 (in progress)** | Classes and class members are Prepared/compile-once                                                   | #3521                                 | Constructors, instance/static methods, fields, inheritance, wrappers, and type indices no longer depend on legacy body compilation                              |
 | **R4 — #3523 (in progress)** | Module init is Prepared/compile-once                                                                  | #3521, #3522                          | One program-owned module-init unit replaces the compile-first/patch-later `__module_init` overlay, including top-level binding/TDZ/export effects               |
 | **R5 — #3525 (blocked)**     | Whole-program single- and multi-source Prepared ownership                                             | #3520–#3523                           | Cross-file calls/imports, fast mode, collisions, module init, and class members use one `PreparedIrProgram`; no per-source overlay loop remains                 |
@@ -174,6 +180,10 @@ above.
 8. **Deletion follows reachability.** No direct handler is removed until the
    new gate proves it unreachable in every supported policy/backend and the
    #3090 audit confirms the call edge is gone.
+9. **One serializable backend handoff.** The prepared program schema is
+   versioned and deterministic. WasmGC and linear accept the same verified
+   snapshot; backend incapability is a typed pre-emission outcome, never a
+   request to reparse, reselect, or fall back.
 
 ## Acceptance criteria
 
@@ -186,6 +196,13 @@ above.
       before backend emission; no class/module/M0 exception remains.
 - [ ] WasmGC and linear consume the same IR and `ProgramAbiMap`; their only
       divergence is backend lowering/runtime representation.
+- [ ] The versioned `PreparedIrProgram` serialization round-trips all semantic
+      values, source identities, ABI/effect data, and frozen runtime intents
+      without loss. Malformed or incompatible input fails validation before
+      artifact emission.
+- [ ] A differential backend-input fixture proves WasmGC and linear consume the
+      exact same prepared-program snapshot. Backend incapability returns a
+      typed diagnostic and cannot trigger frontend reconstruction or fallback.
 - [ ] Unsupported source produces stable source-located diagnostics. There is
       no silent selector fallback, post-claim demotion, skipped-slot escape, or
       legacy catch path.

--- a/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
+++ b/plan/issues/3521-ir-r2-prepared-program-free-function-compile-once.md
@@ -4,7 +4,7 @@ title: "IR-only R2: prepare-before-emit free-function ownership"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-08-09
+updated: 2026-08-12
 priority: critical
 horizon: xl
 complexity: XL
@@ -20,7 +20,7 @@ model: gpt-5.6-sol
 parent: 3518
 depends_on: [3520]
 required_by: [3522, 3523, 3525, 3526]
-related: [2138, 2855, 3143, 3203, 3518, 3519, 4260]
+related: [2138, 2855, 3143, 3203, 3518, 3519, 3678, 4260, 4382]
 origin: "#3518 R2 — invert single-source free functions from compile/patch to prepare/emit"
 files:
   - src/ir/program.ts
@@ -157,11 +157,39 @@ but the contract is fixed:
   cross-unit ABI/call edge cannot be proven safe, the entire component becomes
   typed `Unsupported` before emission rather than partially emitting and
   discovering the mismatch later.
+- `formatVersion` and `decisionSchemaVersion` — explicit compatibility keys for
+  a deterministic serialized handoff. No AST node, compiler callback, live
+  registry, concrete Wasm index, or backend-owned mutable object may cross this
+  boundary.
 
 `Prepared` means AST→IR build, verification, hygiene, inline/mono transforms,
 symbolic resolution validation, support-intent collection, target legality,
 and final ABI/signature checks succeeded. Backend body emission is a consumer,
 not another capability probe.
+
+## Versioned serialized handoff
+
+Define a canonical encoder/decoder for the frozen `PreparedIrProgram`. This is
+an architectural boundary and cache/tooling primitive, not permission to make
+serialized IR a stable public language before its compatibility policy is
+documented.
+
+- Canonical ordering makes equivalent programs byte-identical regardless of
+  source/map traversal order.
+- Tagged scalar encoding preserves `NaN`, infinities, negative zero, bigint,
+  nullish values, strings, and stable symbol/type/unit identities without JSON
+  coercion loss.
+- Source identity includes normalized paths/IDs, content hashes, and exact
+  locations needed by #3678 diagnostics without embedding mutable TypeScript
+  nodes.
+- Decode reconstructs immutable data and re-runs structural, type, ABI, effect,
+  component, support-intent, runtime-manifest, and target-legality verification
+  before returning `Prepared`.
+- Unknown versions, malformed fields, missing provider/capability decisions,
+  and target/backend mismatches fail with typed diagnostics before any module,
+  slot, import, cache entry, or output file is published.
+- Backend-specific lowering state is excluded. R8 must prove WasmGC and linear
+  consume the exact same decoded snapshot rather than reparsing or reselecting.
 
 ## Prepare/emit split
 
@@ -919,6 +947,12 @@ R3–R8 issue instead of absorbing it.
    the temporary direct policy but never cause `direct=1, IR=1`.
 7. Inventory, outcome, and emission denominators reconcile; duplicate/missing
    counters and a shipping placeholder fail the test.
+8. Encode/decode round-trips a fixture containing all supported scalar and ID
+   forms, including `NaN`, infinities, negative zero, bigint, source spans,
+   support intents, and component ownership, with semantic deep equality.
+9. Reordered construction produces byte-identical serialization. Corruption,
+   unknown versions, forged outcome/provider data, and backend mismatch fail
+   before an emitter or publication hook can run.
 
 Run these with `tests/issue-3143.test.ts`, `tests/issue-3203.test.ts`,
 `tests/issue-3214-imported-hof.test.ts`, the inline/mono pass suites, and the
@@ -928,6 +962,12 @@ full equivalence/cross-backend gates.
 
 - [ ] `PreparedIrProgram` is complete and immutable before any R2
       free-function body emission starts.
+- [ ] Its canonical, versioned serialization round-trips without scalar,
+      source-identity, ABI, effect, support-intent, component, or decision loss;
+      equivalent input orderings produce byte-identical output.
+- [ ] Decoding is fail-closed and re-verifies the complete prepared contract.
+      Invalid/incompatible snapshots emit typed #3678 diagnostics before any
+      artifact, cache entry, registry state, or output file is published.
 - [ ] Preparation includes final typed IR, verification/passes, target legality,
       ABI validation, and every support intent; emission performs no new
       capability decision.

--- a/plan/issues/3526-ir-r6-semantic-runtime-contract.md
+++ b/plan/issues/3526-ir-r6-semantic-runtime-contract.md
@@ -4,7 +4,7 @@ title: "IR-only R6: typed semantic runtime contract and frozen feature manifest"
 status: blocked
 sprint: Backlog
 created: 2026-07-21
-updated: 2026-08-02
+updated: 2026-08-12
 priority: critical
 horizon: xl
 complexity: XL
@@ -19,8 +19,8 @@ lane: ir-retirement-r6
 model: gpt-5.6-sol
 parent: 3518
 depends_on: [3521]
-required_by: [3527, 3528]
-related: [1713, 2094, 2520, 2855, 2954, 2956, 3090, 3143, 3226, 3233, 3518]
+required_by: [3527, 3528, 4382]
+related: [1713, 2094, 2514, 2520, 2855, 2954, 2956, 3090, 3143, 3226, 3233, 3518, 3678, 4382]
 origin: "#3518 R6 — replace AST-driven lazy runtime registration with typed semantic intents"
 files:
   - src/ir/intrinsics.ts
@@ -190,6 +190,12 @@ from `HostCapability` for the public compile result; non-`env` semantic imports
 such as string builtins/constants receive an explicit typed projection rather
 than disappearing. `classifyImport` may remain temporarily as a debug parity
 oracle, but it is never production authority.
+
+The same immutable contract exposes a stable read-only decision projection for
+#4382. That public report may add source-facing explanations and #3678
+diagnostics, but it cannot maintain a second support table or infer capability
+from emitted helper/import names. `unknown` is the required public result when
+an internal decision has not yet received a schema projection.
 
 After freeze, resolver/import/type/global/helper registration is lookup-only.
 Any lazy mutation, undeclared intrinsic, transitive feature, host import, type,
@@ -392,6 +398,9 @@ Run M1 with `tests/math-inline.test.ts`, `tests/math-minmax.test.ts`,
       backend/body lowering.
 - [ ] `ImportIntent` is solely a projection of the frozen capability manifest;
       emitted-import string classification is not production authority.
+- [ ] The manifest exposes deterministic decision IDs and source/provenance data
+      sufficient for #4382 to generate its capability report without a parallel
+      feature table or post-emission inference.
 - [ ] Resolver/import/type/global/literal/helper state is lookup-only after
       freeze. Every undeclared or late request is a fatal typed Invariant.
 - [ ] The exact twelve-method pure-Math M1 uses typed intents, has no legacy

--- a/plan/issues/3678-ir-rejection-diagnostics-error-codes.md
+++ b/plan/issues/3678-ir-rejection-diagnostics-error-codes.md
@@ -1,73 +1,107 @@
 ---
 id: 3678
-title: "Actionable rejection diagnostics for the IR path — error code + code frame + rewrite hint (scriptc-inspired)"
+title: "Stable, actionable compiler diagnostics — code, source frame, and remediation"
 status: backlog
 sprint: Backlog
 created: 2026-07-26
-priority: medium
+updated: 2026-08-12
+priority: high
 horizon: m
 feasibility: medium
 reasoning_effort: medium
 task_type: feature
-area: compiler
+area: compiler, cli
 language_feature: compiler-internals
+es_edition: n/a
 goal: developer-experience
-related: [2855, 1376]
+required_by: [4382]
+related: [1376, 1590, 1928, 1929, 2135, 2855, 3518, 3519, 3526, 4382]
 ---
 
-# #3678 — Actionable rejection diagnostics for the IR path
+# #3678 — Stable, actionable compiler diagnostics
 
-## Context / provenance
+## Objective
 
-From a 2026-07-26 comparison with [vercel-labs/scriptc](https://github.com/vercel-labs/scriptc)
-(Vercel's TypeScript→native compiler). scriptc's headline DX property: when a
-construct can't compile, the user gets **"a specific error code, a code frame,
-and usually a rewrite hint. Nothing is ever silently miscompiled."**
-
-We are on the opposite end today: when the IR path rejects a node kind, the
-failure **silently demotes to the legacy AST→Wasm path** via a warning channel
-(#1376 fallback budget), and the only visibility is the aggregate bucket counts
-in `scripts/ir-fallback-baseline.json`. A user (or dev agent) compiling a file
-has no per-site signal of *what* was rejected, *where*, or *what to change*.
+Give every compiler capability failure a stable, source-located, structured
+diagnostic that tells a user what happened and what they can do next. Expected
+unsupported source, compiler invariants, target-policy failures, runtime-
+provider gaps, and backend-legality failures must remain distinguishable from
+TypeScript's own numeric diagnostics.
 
 ## Problem
 
-As #2855 ratchets unintended fallback buckets to zero and promotes reasons into
-`STRICT_IR_REASONS`, rejections stop being silent demotions and become **hard
-compile errors**. The current error surface for that promotion is a bare reason
-string (e.g. `body-shape-rejected`) — accurate for CI gating, useless for a
-human deciding how to fix their source.
+Today, several internal systems expose reason strings or aggregate buckets,
+while `CompileError.code` primarily reflects optional TypeScript numeric codes.
+Fallback telemetry is useful for CI budgets, but a developer compiling one file
+still may not learn which source site failed, whether the failure is an
+intentional target limitation or compiler defect, or which rewrite or target
+would make progress.
 
-## Proposal
+This becomes a release blocker for the IR-only transition: once temporary
+hybrid demotion is removed, every expected capability gap becomes a hard error.
+A bare internal reason such as `body-shape-rejected` is accurate enough for a
+counter but not an acceptable public diagnostic.
 
-Give every IR rejection (and every `STRICT_IR_REASONS` hard error) a structured
-diagnostic:
+## Diagnostic contract
 
-1. **Stable error code** per rejection reason — e.g. `JS2W-IR-001
-   body-shape-rejected`, `JS2W-IR-004 param-shape-rejected` — so codes are
-   greppable, documentable, and stable across refactors of the reason strings.
-2. **Code frame** — file, line/col span of the offending node, with a 2–3 line
-   source excerpt. The IR builder already has the `ts.Node`; thread its
-   position through the rejection instead of dropping it at
-   `trackFallbacks` aggregation time.
-3. **Rewrite hint** where one exists — e.g. `param-shape-rejected` →
-   "destructure inside the body instead of the parameter list (until #1372)";
-   `external-call` → "only whitelisted builtins (Math.*, parseInt) are
-   IR-compilable (#1371)".
-4. A `--explain JS2W-IR-XXX` CLI mode (or a docs table) mapping each code to
-   its meaning, tracking issue, and workaround.
+Define a typed diagnostic registry with stable project codes such as
+`JS2W-IR-001`. The mnemonic/internal reason may evolve independently; the code
+and documented meaning follow compatibility rules.
 
-Keep the fallback-budget machinery unchanged — this is a presentation layer on
-data the rejection path already produces; it must not alter which nodes fall
-back.
+Each diagnostic carries:
+
+- `code`, `category`, and `severity`;
+- a primary file/line/column span plus related spans where needed;
+- a concise message that states the failed capability or invariant;
+- the selected target/backend and typed outcome (`Unsupported` or `Invariant`);
+- an optional actionable hint, alternative target/provider, and tracking issue;
+- structured details safe for JSON output without parsing human prose.
+
+The initial registry covers every reason in the #1376 fallback census and the
+typed preparation/legality outcomes introduced by #3519/#3518. Hints are
+specific and conditional: for example, a parameter-shape rejection can suggest
+moving destructuring into the function body, while a missing host capability
+can name targets that intentionally provide it. A compiler invariant never
+pretends a source rewrite is the remedy.
+
+Human-readable output includes a compact source frame. JSON output uses the
+same typed object and stable codes. `check:ir-fallbacks --verbose`, compile
+results, CLI errors, and #4382's `explain` workflow all consume the registry;
+none maintains its own code/message table.
+
+## Compatibility and completeness
+
+- Codes are never reassigned. Retired codes remain documented as retired.
+- Unknown internal reasons map to a dedicated invariant diagnostic and fail the
+  registry-completeness test; they are not printed as unstructured strings.
+- TypeScript numeric codes remain available in a separate field rather than
+  sharing the project-code namespace.
+- Adding a fallback, typed outcome, host-capability rule, or backend-legality
+  rejection requires a diagnostic registry entry in the same change.
+- Presentation must not change fallback or target-selection behavior. Behavior
+  changes belong to their semantic owner and are validated independently.
 
 ## Acceptance criteria
 
-- [ ] Every rejection reason in the #1376 table has a stable `JS2W-IR-NNN` code
-- [ ] `trackFallbacks: true` (and strict-reason hard errors) emit file:line:col
-      plus a source excerpt for each rejection site
-- [ ] At least the four unintended buckets with tracking issues
-      (`body-shape-rejected`, `external-call`, `param-shape-rejected`,
-      `call-graph-closure`) carry rewrite hints citing the tracking issue
-- [ ] `check:ir-fallbacks --verbose` output includes the codes
-- [ ] No change to fallback *behavior* — baseline counts identical before/after
+- [ ] Every #1376 rejection reason and every production typed compiler outcome
+      has a stable project diagnostic code and category.
+- [ ] Every source-caused `Unsupported` includes file/line/column and a compact
+      source frame; multi-site errors include deterministic related locations.
+- [ ] All known actionable gaps have a tested hint or alternative target;
+      invariants clearly identify compiler defects without blaming source.
+- [ ] Compile results expose project codes separately from TypeScript numeric
+      codes, with one documented JSON schema used by CLI and tooling.
+- [ ] `check:ir-fallbacks --verbose` includes the stable codes and locations.
+- [ ] Registry completeness fails on an unregistered reason/outcome, duplicate
+      code, reassigned code, or message-table drift.
+- [ ] Human and JSON snapshots cover Unsupported, Invariant, host-policy,
+      runtime-provider, and backend-legality examples.
+- [ ] Baseline selection, fallback counts, emitted artifacts, and Test262
+      results are unchanged by the presentation-layer landing.
+
+## Out of scope
+
+- Claiming that a diagnostic category is a conformance result.
+- Hiding unsupported source by silently changing the requested target.
+- Preserving legacy fallback after the IR-only retirement boundary solely to
+  avoid emitting a diagnostic.

--- a/plan/issues/3681-differential-whole-program-corpus-testing.md
+++ b/plan/issues/3681-differential-whole-program-corpus-testing.md
@@ -1,97 +1,144 @@
 ---
 id: 3681
-title: "Differential whole-program corpus testing — diff stdout/stderr/exit-code against Node (scriptc-inspired)"
+title: "Differential whole-program target matrix — Node oracle vs JS-host, standalone, WASI, and linear"
 status: backlog
 sprint: Backlog
-updated: 2026-07-27
 created: 2026-07-26
-priority: medium
+updated: 2026-08-12
+priority: high
 horizon: m
-feasibility: easy
+feasibility: medium
 reasoning_effort: medium
 task_type: test
-area: testing
-language_feature: n/a
+area: testing, compiler, codegen-linear
+language_feature: whole-program-semantics
+es_edition: multi
 goal: test-infrastructure
+related: [1203, 1854, 1941, 2711, 3518, 3781]
 ---
 
-# #3681 — Differential whole-program corpus testing
+# #3681 — Differential whole-program target matrix
 
-## Context / provenance
+## Objective
 
-From the 2026-07-26 [vercel-labs/scriptc](https://github.com/vercel-labs/scriptc)
-comparison. scriptc's primary correctness harness is **differential testing**:
-800+ corpus programs run under both Node and the compiled binary, and
-**stdout, stderr, and exit codes must match byte-for-byte**. They make no
-test262 claims at all — the corpus diff *is* their conformance story.
+Extend the existing differential corpus into one explicit target matrix that
+compares observable whole-program behavior against Node while keeping Test262
+as the standards oracle. Every applicable compiler lane must either run the
+program or report a typed, visible reason that the lane is inapplicable.
 
-## Why we want it too (not instead of test262)
+## Existing foundation
 
-test262 measures spec conformance one assertion at a time; it is our roadmap
-metric (29,568/43,097). But its shape has blind spots a whole-program diff
-catches:
+The repository already has the harness proposed by this issue's first draft:
+`tests/differential/corpus/`, `scripts/diff-test.ts`, and the #1203 delta gate.
+The JS-host lane compares Node and compiled-Wasm stdout and writes
+`benchmarks/results/diff-test.json`; CI blocks regressions while allowing known
+failures to remain visible. The corpus currently contains roughly 120 source
+programs.
 
-- **Miscompilations that don't trip an assertion** — wrong-but-plausible
-  output, ordering bugs, output interleaving, exit-code paths.
-- **Feature *interaction* bugs** — test262 files are deliberately minimal;
-  real programs compose closures + classes + async + string ops in one flow.
-  Our sprint history is full of bugs that only manifested in composition.
-- **stderr/exit-code semantics** — essentially untested today; matters for the
-  WASI/CLI target (`fd_write`, `proc_exit`).
+The open work is therefore an extension, not a second harness:
 
-We already have the seed: `tests/equivalence.test.ts` compares compiled
-results against host evaluation, and `playground/examples/` is a ready-made
-corpus (already walked by `check:ir-fallbacks`). This issue scales the idea
-from expression-level equivalence to **process-level** equivalence.
+- stderr and exit status are not compared;
+- standalone/WASI and linear applicability are not a first-class matrix;
+- observable thrown-error class and exported results are not captured where a
+  lane exposes them;
+- deliberate normalizations and target-specific divergences need a maintained
+  ledger with owners and evidence.
 
-## Proposal
+## Target matrix
 
-1. **Harness** (`tests/differential.test.ts` or standalone runner): for each
-   corpus program, run (a) under Node (tsx/ts-node), (b) compiled to wasm and
-   executed in both JS-host and standalone/WASI modes. Diff stdout, stderr,
-   exit code. Byte-for-byte, with a small documented normalization list
-   (e.g. stack-trace frames) — every normalization is a numbered, deliberate
-   divergence, scriptc-style: "nothing diverges silently."
-2. **Corpus**: start with `playground/examples/` (zero new content), then grow
-   with programs written to *compose* features. Target ~100 programs first,
-   scaling toward scriptc's 800+.
-3. **CI**: run in `quality` or as its own cheap job — this is minutes, not the
-   test262 shard matrix. Failures block like equivalence failures.
-4. **Divergence ledger**: `docs/divergences.md` — numbered list of deliberate
-   Node/js2wasm output differences with rationale (mirrors scriptc's "a few
-   dozen documented divergences" practice).
+For each corpus program, record an explicit row for:
 
-## Non-goals
+| Lane | Oracle / comparison | Minimum observables |
+| --- | --- | --- |
+| Node | reference execution | stdout, stderr, exit status, thrown error |
+| JS-host WasmGC | Node | byte output, exit/error class, exposed exports |
+| standalone/WASI WasmGC | Node where portable | byte output, exit/error class |
+| JS-host linear | Node and WasmGC | byte output, exit/error class, exports |
+| standalone/WASI linear | Node and WasmGC where portable | byte output, exit/error class |
 
-- Not a replacement for test262 or the equivalence suite
-- No fuzzing in v1 (a fuzzer feeding this differential oracle is the natural
-  follow-up — file separately when the harness exists)
+Target-inapplicable source is a measured result with a stable diagnostic code,
+not a missing row. The artifact reports per-lane denominators and counts for
+pass, known divergence, unsupported, compile failure, runtime failure, and
+harness failure. A zero-sized or silently skipped lane fails anti-vacuity
+checks.
+
+## Observable contract
+
+- Compare stdout and stderr as bytes, preserving ordering when the runner can
+  observe it, plus exact exit status.
+- Capture thrown error name/class and stable message portions without treating
+  engine-specific stack paths as semantics.
+- Compare exported primitive/structured results when both runners expose them;
+  use the repository's established canonicalization rather than ad hoc string
+  conversion.
+- Keep every normalization narrow, numbered, documented, and tested with a
+  positive control proving the unnormalized difference would be detected.
+- Separate compiler semantic divergences from host API/WASI environment
+  differences. A capability absent from a target is not normalized into a pass.
+
+## Corpus growth and safety
+
+Grow the corpus with real multi-feature programs and minimized regressions from
+Test262/npm work. Give priority to feature interactions, initialization order,
+exceptions, async scheduling, closures/classes, dynamic values, host adapters,
+and lifetime/rooting stress. Where native sanitizer tooling is not applicable
+to WasmGC, add equivalent allocation/collection/rooting stress and engine
+validation; do not claim sanitizer coverage that the lane did not execute.
+
+Generated cases record seed and generator version. Handwritten cases state the
+behavioral interaction they protect. Test262 remains authoritative for
+language conformance, and its license/metadata rules are preserved when a
+minimized case is derived from it.
+
+## Reusable corpus interchange
+
+Define a small, documented fixture manifest for source files, arguments,
+environment, expected observables, target applicability, normalization IDs,
+seed/generator data, license, and provenance. Keep the runner repository-native,
+but make individual fixtures portable enough for compiler/runtime/tooling
+projects to exchange minimized failures and feature-interaction cases without
+adopting one another's architecture or support policy.
+
+Imported fixtures retain attribution and are reviewed against this project's
+language contract. Exported fixtures contain no repository-only absolute paths,
+secrets, or implicit host setup. Shared cases improve the oracle; another
+implementation's pass/fail classification never becomes authoritative here.
+
+## Divergence ledger
+
+Maintain a machine-readable ledger and a rendered documentation view. Each
+entry includes a stable ID, affected lanes, exact normalization or intentional
+difference, motivation, owner/follow-up issue, first and last verified commit,
+and a focused regression fixture. Expired or unmatched entries fail CI; broad
+wildcards and output deletion are forbidden.
 
 ## Acceptance criteria
 
-- [ ] Runner executes a corpus program under Node and under compiled wasm
-      (JS-host mode) and reports a unified diff of stdout/stderr/exit-code
-- [ ] Standalone/WASI lane included or explicitly deferred with a follow-up id
-- [ ] `playground/examples/` corpus onboarded; count reported per run
-- [ ] Wired into CI as a blocking check on a lane that runs per-PR
-- [ ] `docs/divergences.md` exists; every normalization in the harness cites a
-      numbered entry
+- [ ] The existing runner captures stdout, stderr, exit status, and thrown
+      error class for Node and JS-host WasmGC without weakening the #1203 gate.
+- [ ] Standalone/WASI, JS-host linear, and standalone/WASI linear are explicit
+      lanes with per-program applicability and typed reasons for unsupported
+      rows.
+- [ ] Result artifacts report the corpus revision plus per-lane denominators
+      and pass/divergence/unsupported/compile/runtime/harness failure counts.
+- [ ] Applicable target lanes compare exports where observable and distinguish
+      compile failure, trap, exception, nonzero exit, and harness failure.
+- [ ] Every normalization/divergence has a stable ledger entry, owner, focused
+      test, and positive control; stale or unused entries fail the gate.
+- [ ] CI blocks new regressions in every established lane. A new lane may begin
+      advisory only with a committed baseline and a named promotion issue/date.
+- [ ] Corpus growth includes feature-composition and lifetime/rooting cases;
+      generated cases record reproducible seeds and versions.
+- [ ] A versioned fixture manifest can import/export a focused case without
+      losing arguments, observables, applicability, seed, license, or
+      provenance; at least one round-trip fixture proves the interchange.
+- [ ] Test262 remains a separate, authoritative standards signal; differential
+      pass counts are not labeled conformance.
 
-## 2026-07-27 update — the proposed harness already exists
+## Out of scope
 
-Filed independently the same day: **the runner this issue proposes already
-exists** — `tests/differential/corpus/` + `scripts/diff-test.ts` (#1203),
-predating this issue. It already does exactly item 1 (Node vs compiled-wasm
-stdout diff, JS-host mode, `benchmarks/results/diff-test.json`) and item 3
-(`scripts/diff-test-gate.ts` delta gate, wired in `.github/workflows/diff-test.yml`).
-#3690 grew its corpus (generators/, private-fields/, deeper regex/symbol —
-also scriptc-inspired) and found the existing gate design already matches
-this issue's "failures block like equivalence failures" goal, scoped to
-regressions only (new/still-failing corpus entries are informational, not
-blocking, so the corpus can grow ahead of the compiler).
-
-**Still genuinely open from this proposal**: no `stderr`/exit-code diffing
-(stdout only today), no standalone/WASI lane, no `docs/divergences.md`
-ledger, and the corpus is ~120 programs vs the ~100+ target. Worth
-re-scoping this issue as "extend the existing harness" rather than "build
-a harness" to avoid a future duplicate build.
+- Replacing Test262, equivalence, import-leak, or artifact-validity gates.
+- Treating target-inapplicable programs as passes or omitting them from the
+  denominator.
+- Normalizing away host capability gaps, error classes, or substantive output.
+- Adding another backend solely to increase the number of matrix columns.

--- a/plan/issues/4382-compiler-capability-manifest-explain-workflow.md
+++ b/plan/issues/4382-compiler-capability-manifest-explain-workflow.md
@@ -1,0 +1,149 @@
+---
+id: 4382
+title: "Compiler-derived capability manifest and per-program explain workflow"
+status: backlog
+sprint: Backlog
+created: 2026-08-12
+updated: 2026-08-12
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: compiler, cli, docs
+language_feature: compiler-capabilities
+es_edition: multi
+goal: developer-experience
+depends_on: [3526, 3678]
+related: [1590, 2135, 2634, 3518, 3519, 3681]
+origin: "2026-08-12 compiler architecture and user-trust review"
+---
+
+# #4382 — Compiler-derived capability manifest and per-program explain workflow
+
+## Objective
+
+Make every compilation answer two questions from the compiler's actual plan:
+
+1. What execution substrate does this program require for the selected target?
+2. Why did each relevant source feature receive that classification?
+
+The public result uses a small, stable vocabulary:
+
+- `host-free-wasm` — the selected program can execute without host-provided
+  JavaScript capabilities.
+- `declared-host-capability` — compilation succeeds with an explicit, minimal
+  set of typed host capabilities.
+- `runtime-provider` — compilation requires a named in-repository runtime
+  provider, including the runtime-evaluation provider when applicable.
+- `unsupported` — the requested target cannot compile the construct and emits
+  a stable source-located diagnostic.
+- `unknown` — the compiler has not projected an internal decision into the
+  public schema. Unknown is visible and fails any completeness claim.
+
+These statuses describe placement and capability requirements. They are not
+claims of ECMAScript conformance or semantic correctness.
+
+## Problem
+
+The compiler already knows much of this information, but it is distributed
+among selector predicates, IR preparation, runtime-feature planning, import
+collection, target legality, fallback telemetry, and documentation tables.
+That fragmentation creates three trust problems:
+
+- a successful build does not provide one deterministic explanation of the
+  selected execution path, providers, and host requirements;
+- website and release capability tables can drift from production compiler
+  decisions;
+- an absent entry is ambiguous between unsupported, unmeasured, unprojected,
+  and accidentally omitted.
+
+## Architecture
+
+### One compiler-owned decision record
+
+Consume the capability predicates from #2135 and the frozen
+`IntrinsicId -> RuntimeFeature -> HostCapability` contract from #3526. Do not
+create another hand-maintained support table. For each relevant source site,
+record:
+
+- stable feature and decision IDs;
+- selected target/backend and public status;
+- source range and stable diagnostic code from #3678 when rejected;
+- required runtime providers and host capabilities;
+- concise explanation and actionable hint where one exists;
+- provenance identifying the selector, verifier, provider, or legality rule
+  that made the decision.
+
+The report is deterministic, versioned, serializable, and embedded in or
+adjacent to the compile result. Backend emission may consume this frozen plan;
+it may not revise the public classification after artifacts have started.
+
+### Repository-wide projections
+
+Generate machine-readable release and website artifacts from the same registry.
+Every documented row must be one of the explicit statuses above and link to
+measured evidence where available. A detector miss or missing projection is
+`unknown`, never an implicit success. Generated artifacts include schema,
+compiler version, target, denominator, and provenance so comparisons across
+releases remain meaningful.
+
+### Per-program CLI workflow
+
+Expose the shared analysis through a coherent command surface:
+
+```text
+js2wasm build app.ts --target standalone
+js2wasm run app.ts --target standalone
+js2wasm explain app.ts --target standalone
+js2wasm explain app.ts --target standalone --json
+```
+
+`build`, `run`, and `explain` must consume the same frozen decision record.
+`run` may orchestrate an existing supported runtime, but it must not silently
+change the target, add a JavaScript engine, or select capabilities different
+from `build`. Preserve the current positional invocation during migration and
+document its replacement rather than breaking existing automation abruptly.
+
+## Landing sequence
+
+1. Define the versioned decision/report schema and compiler API after #3526's
+   manifest boundary is available.
+2. Project stable diagnostics from #3678 and add deterministic text/JSON
+   `explain` output.
+3. Make release artifacts, documentation, and website capability tables
+   generated consumers with staleness checks.
+4. Add `build` and `run` subcommands as thin consumers of the same analysis and
+   compilation pipeline; retain compatibility aliases for the current CLI.
+
+## Acceptance criteria
+
+- [ ] One versioned compiler-owned schema represents target, backend, source
+      decisions, providers, host capabilities, diagnostics, and provenance.
+- [ ] The report is derived from #2135/#3526 production decisions; no parallel
+      support matrix or emitted-import name heuristic becomes authoritative.
+- [ ] Focused fixtures cover host-free Wasm, declared host capability,
+      runtime-evaluation provider, unsupported source, and deliberately
+      unprojected/unknown source for every supported target mode.
+- [ ] `js2wasm explain` has stable human-readable and JSON output with source
+      locations, codes, reasons, providers, capabilities, and rewrite hints.
+- [ ] Repeated builds and reordered internal maps produce byte-identical JSON;
+      schema or semantic changes require an explicit version change.
+- [ ] `build`, `run`, and `explain` agree on the selected target and capability
+      set. `run` cannot add a hidden engine/provider or choose another lane.
+- [ ] Website/docs/release tables are generated from the compiler artifact and
+      fail a staleness check when production decisions change.
+- [ ] Summary counts always state denominators and expose `unknown`; statement
+      or feature detection is never described as proof of correctness or
+      conformance.
+- [ ] Existing Test262, differential, standalone, import-leak, and artifact
+      validity gates remain authoritative for semantic and target correctness.
+
+## Out of scope
+
+- Narrowing the supported language to make the report look complete.
+- Adding a general embedded JavaScript engine as an implicit fallback.
+- Treating source-feature occurrence, statement coverage, or successful
+  compilation as a conformance claim.
+- Copying dynamic JavaScript values across a new boundary solely for reporting
+  or CLI convenience.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -2,6 +2,35 @@
 
 Lightweight pointer index for unscheduled issues that need sprint candidacy. Authoritative status lives in each issue file's frontmatter.
 
+## 2026-08-12 — Compiler capability, diagnostics, and portability hardening
+
+- [#3518](../3518-ir-only-default-and-direct-frontend-retirement.md) and
+  [#3521](../3521-ir-r2-prepared-program-free-function-compile-once.md) — make
+  one versioned, validated, losslessly serializable `PreparedIrProgram` the
+  sole frontend-to-backend handoff; backend inability must fail typed before
+  emission rather than reparse, reselect, or fall back.
+- [#3678](../3678-ir-rejection-diagnostics-error-codes.md) — replace internal
+  reason strings with stable project codes, source frames, typed categories,
+  JSON diagnostics, and actionable remediation shared by compiler and tooling.
+- [#4382](../4382-compiler-capability-manifest-explain-workflow.md) — project
+  production compiler decisions into an explicit capability schema and a
+  coherent `build`/`run`/`explain` workflow, with visible `unknown` results and
+  generated documentation rather than hand-maintained support claims.
+- [#3681](../3681-differential-whole-program-corpus-testing.md) — extend the
+  existing differential harness across JS-host, standalone/WASI, and linear
+  lanes, comparing stdout, stderr, exit/error behavior, and observable exports
+  with explicit denominators and owned divergences.
+- [#2514](../2514-runtime-helpers-as-shared-linkable-module.md) — factor stable
+  runtime families into feature-granular, link-gated core-Wasm providers whose
+  ABI/version and capability requirements are selected by the frozen runtime
+  manifest; keep inline providers until measurements justify promotion.
+
+Recommended dependency order: prepared-program/semantic-manifest ownership
+(#3518/#3521/#3526), stable diagnostics (#3678), public capability projection
+(#4382), target-matrix promotion (#3681), then broader linked-provider rollout
+(#2514). Differential corpus and ABI experiments can proceed in bounded slices
+while the earlier architectural gates remain active.
+
 ## 2026-08-12 — Deno primordials bootstrap
 
 - [#4378](../4378-deno-primordials-array-prototype-iterator.md) — let the


### PR DESCRIPTION
## Summary

- add #4382 for a compiler-derived capability manifest and shared `build` / `run` / `explain` workflow
- strengthen existing diagnostics, differential testing, prepared-program, semantic-manifest, and link-gated runtime-provider issue contracts
- document the dependency order in the backlog and add a neutral differential-fixture interchange seam

## Motivation

Compiler support and target requirements are currently distributed across selectors, IR preparation, runtime planning, import collection, fallback telemetry, and documentation. This roadmap makes those decisions explicit, machine-readable, source-located, and testable without narrowing the language contract or introducing a hidden engine fallback.

The differential-test work also creates a bounded collaboration surface through portable fixtures while keeping compiler IR, runtime representation, memory management, and policy independent.

## Impact

This is a planning-only change. It adds or refines acceptance criteria and dependency ownership; it does not change compiler behavior.

## Validation

- `git diff --check`
- Prettier check for all eight changed Markdown files
- `node scripts/update-issues.mjs --check` (`would update 0 issue files`; existing generated-index drift remains)
- commit hooks: LOC budget, function budget, changed-root tests, and oracle ratchet
- verified the updated issue/backlog text contains no comparison-specific project references
