### PR TITLE
fix(es5): make Function.prototype callable standalone

### DIFF
--- a/plan/issues/4385-function-prototype-callable.md
+++ b/plan/issues/4385-function-prototype-callable.md
@@ -1,7 +1,7 @@
 ---
 id: 4385
 title: "Standalone ES5: Function.prototype itself is not callable"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-12
 updated: 2026-08-12
@@ -72,11 +72,35 @@ point on the IR path rather than adding a legacy-only exception.
 
 ## Acceptance criteria
 
-- [ ] The four named ES5 Test262 files change from compile error to pass in the
+- [x] The four named ES5 Test262 files change from compile error to pass in the
       standalone lane.
-- [ ] A direct call accepts zero or multiple arguments, evaluates them for
+- [x] A direct call accepts zero or multiple arguments, evaluates them for
       effects, and returns real `undefined`.
-- [ ] The exact call is genuinely IR-emitted with no post-claim demotion.
-- [ ] A shadowing local named `Function` is not intercepted.
-- [ ] The standalone module remains valid and has zero host imports.
-- [ ] The reachable ES5 `Function/prototype` control set has zero regressions.
+- [x] The exact call is genuinely IR-emitted with no post-claim demotion.
+- [x] A shadowing local named `Function` is not intercepted.
+- [x] The standalone module remains valid and has zero host imports.
+- [x] The reachable ES5 `Function/prototype` control set has zero regressions.
+
+## Validation
+
+Baseline commit `8c9f889680730001c08d0290bc40234514277505` and candidate
+`a3fcafc959fdb2e` were compared with the authoritative standalone Test262
+runner. A causal ablation of the new exact-call branch reproduced the baseline
+`env::__get_builtin` compile error for all four files; enabling it changed all
+four to pass. The runner used the local refusal runtime-eval provider, which is
+not CI-comparable for dynamic-code tests, but these four sources do not invoke
+eval or the Function constructor.
+
+The full 19-file reachable ES5 `Function/prototype` failure control set had
+zero regressions: five files advanced in phase (the four target files reached
+pass) and fourteen retained their prior status. The exact executable ES5
+`Function.prototype(...)` trigger population is the four target files.
+
+Focused validation:
+
+- `pnpm exec vitest run tests/issue-4385-function-prototype-callable.test.ts`
+  — 3/3 pass
+- `pnpm exec tsc --noEmit --pretty false` — pass
+- `pnpm run check:ir-fallbacks` — pass, no fallback or post-claim increases
+- `pnpm run check:loc-budget` — pass with issue-scoped allowances
+- `pnpm run check:func-budget` — pass with issue-scoped allowances

--- a/plan/issues/4385-function-prototype-callable.md
+++ b/plan/issues/4385-function-prototype-callable.md
@@ -1,0 +1,82 @@
+---
+id: 4385
+title: "Standalone ES5: Function.prototype itself is not callable"
+status: in-progress
+sprint: current
+created: 2026-08-12
+updated: 2026-08-12
+priority: high
+horizon: s
+feasibility: high
+reasoning_effort: medium
+task_type: bugfix
+area: ir, codegen
+es_edition: 5
+language_feature: function-prototype
+goal: es5
+assignee: ttraenkler/codex-es5-function-prototype
+related: [1472, 2378, 4265]
+files:
+  - src/codegen/function-prototype-callable.ts
+  - src/codegen/expressions/call-builtin-static.ts
+  - src/ir/backend/legality.ts
+  - src/ir/select.ts
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - tests/issue-4385-function-prototype-callable.test.ts
+loc-budget-allow:
+  - src/codegen/expressions/call-builtin-static.ts
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/codegen/expressions/call-builtin-static.ts::compileBuiltinStaticCall
+  - src/ir/from-ast.ts::lowerMethodCall
+  - src/ir/integration.ts::makeFromAstResolver
+  - src/ir/select.ts::isPhase1Expr
+---
+
+# Standalone ES5: `Function.prototype` itself is not callable
+
+## Problem
+
+ES5 §15.3.4 defines `%Function.prototype%` as a Function object whose
+`[[Call]]` accepts any arguments and returns `undefined`. The standalone
+compiler instead treats `Function.prototype(...)` as a dynamic
+`Namespace.member(...)` lookup and refuses it through `env::__get_builtin`.
+
+The fresh 2026-08-12 standalone Test262 baseline contains four ES5 failures at
+this exact call site:
+
+- `built-ins/Function/prototype/S15.3.4_A2_T1.js`
+- `built-ins/Function/prototype/S15.3.4_A2_T2.js`
+- `built-ins/Function/prototype/S15.3.4_A2_T3.js`
+- `built-ins/Function/prototype/S15.3.3.1_A1.js`
+
+The surrounding `Function/prototype` directory has 59 ES5 failures. Forty use
+dynamic `Function`/eval and are outside the current ex-dynamic-code goal. Of
+the 19 reachable cases, six belong to already-claimed bind issue #4196. This
+four-file family is the largest coherent unclaimed root cause.
+
+## Fix
+
+Recognise only the exact ambient `Function.prototype(...)` call. Both the
+legacy and IR front-ends evaluate every argument left-to-right and discard its
+value, then invoke one host-free runtime provider that returns the existing
+standalone `undefined` singleton. A local binding named `Function` declines the
+intrinsic and keeps ordinary method-call semantics.
+
+The IR selector has an explicit standalone-WasmGC backend capability, and the
+AST-to-IR lowerer emits a symbolic runtime call. This keeps the semantic entry
+point on the IR path rather than adding a legacy-only exception.
+
+## Acceptance criteria
+
+- [ ] The four named ES5 Test262 files change from compile error to pass in the
+      standalone lane.
+- [ ] A direct call accepts zero or multiple arguments, evaluates them for
+      effects, and returns real `undefined`.
+- [ ] The exact call is genuinely IR-emitted with no post-claim demotion.
+- [ ] A shadowing local named `Function` is not intercepted.
+- [ ] The standalone module remains valid and has zero host imports.
+- [ ] The reachable ES5 `Function/prototype` control set has zero regressions.

--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -27,6 +27,7 @@ import {
 } from "../array-object-proto.js";
 import { undefinedExternInstrs } from "../any-helpers.js";
 import { BUILTIN_STATIC_METHOD_ARITY, pushBuiltinFnSingletonValueInstrs } from "../builtin-fn-meta.js";
+import { ensureFunctionPrototypeCallHelper } from "../function-prototype-callable.js";
 import {
   allocJoinFoldLocals,
   emitStringJoinFold,
@@ -264,6 +265,29 @@ export function compileBuiltinStaticCall(
   expr: ts.CallExpression,
   propAccess: ts.PropertyAccessExpression,
 ): InnerResult | undefined {
+  // #4385 — ES5 §15.3.4: `%Function.prototype%` is itself callable, ignores
+  // its arguments, and returns undefined. The generic `Namespace.member()`
+  // path otherwise asks `__get_builtin` for a dynamic property and hard-refuses
+  // in standalone. Keep this exact to the ambient `Function` binding: a local
+  // object named Function must retain ordinary member-call semantics.
+  if (
+    noJsHost(ctx) &&
+    ts.isIdentifier(propAccess.expression) &&
+    propAccess.expression.text === "Function" &&
+    propAccess.name.text === "prototype" &&
+    isGlobalBuiltinIdentifier(ctx, fctx, propAccess.expression)
+  ) {
+    for (const argument of expr.arguments) {
+      const argumentType = compileExpression(ctx, fctx, argument);
+      if (argumentType) fctx.body.push({ op: "drop" });
+    }
+    const helperIdx = ensureFunctionPrototypeCallHelper(ctx);
+    if (helperIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      return { kind: "externref" };
+    }
+  }
+
   if (ts.isIdentifier(propAccess.expression) && propAccess.expression.text === "Math") {
     const mathResult = compileMathCall(ctx, fctx, propAccess.name.text, expr);
     if (mathResult !== undefined) return mathResult;

--- a/src/codegen/function-prototype-callable.ts
+++ b/src/codegen/function-prototype-callable.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Native callable entry point for the ES5 `%Function.prototype%` object. */
+
+import type { Instr, WasmFunction } from "../ir/types.js";
+import { undefinedExternInstrs } from "./any-helpers.js";
+import type { CodegenContext } from "./context/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { addFuncType } from "./registry/types.js";
+
+/**
+ * `%Function.prototype%.[[Call]]` ignores every argument and returns
+ * `undefined` (ES5 §15.3.4). Calls use a zero-parameter helper because both
+ * front-ends evaluate and discard source arguments before invoking it.
+ */
+export const FUNCTION_PROTOTYPE_CALL_HELPER = "__function_prototype_call";
+
+export function ensureFunctionPrototypeCallHelper(ctx: CodegenContext): number | undefined {
+  if (!(ctx.standalone || ctx.wasi)) return undefined;
+  const existing = ctx.funcMap.get(FUNCTION_PROTOTYPE_CALL_HELPER);
+  if (existing !== undefined) return existing;
+
+  const body: Instr[] = undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
+  const typeIdx = addFuncType(ctx, [], [{ kind: "externref" }], `$${FUNCTION_PROTOTYPE_CALL_HELPER}_type`);
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: FUNCTION_PROTOTYPE_CALL_HELPER,
+    typeIdx,
+    locals: [],
+    body,
+    exported: false,
+  } satisfies WasmFunction);
+  ctx.funcMap.set(FUNCTION_PROTOTYPE_CALL_HELPER, funcIdx);
+  return funcIdx;
+}

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -19,6 +19,7 @@ export type IrBackendTargetCapability =
   | "host-date-snapshot"
   | "host-regexp-constructor"
   | "host-object-define-property"
+  | "standalone-function-prototype-call"
   | "standalone-native-regexp-test-carrier"
   | "legacy-numeric-array-global";
 
@@ -54,6 +55,8 @@ export function supportsIrBackendTargetCapability(
       return profile.backend === "wasmgc" && profile.target === "gc" && profile.allowHostImports;
     case "host-object-define-property":
       return profile.backend === "wasmgc" && profile.target === "gc" && profile.allowHostImports;
+    case "standalone-function-prototype-call":
+      return profile.backend === "wasmgc" && profile.target === "standalone" && !profile.allowHostImports;
     case "standalone-native-regexp-test-carrier":
       return profile.backend === "wasmgc" && profile.target === "standalone" && !profile.allowHostImports;
     case "legacy-numeric-array-global":

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -315,6 +315,8 @@ export interface IrExternClassMeta {
  * until Phase 3, so from-ast doesn't see them.
  */
 export interface IrFromAstResolver extends PreparedAsyncFromAstResolver {
+  /** Resolve the host-free `%Function.prototype%.[[Call]]` entry point. */
+  functionPrototypeCallTarget?(): IrFuncRef | null;
   /**
    * Resolve the canonical host ToPropertyDescriptor entry point for an
    * ambient `Object.defineProperty(target, key, descriptor)` call.
@@ -5910,6 +5912,40 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
   const receiverIdentifier = ts.isIdentifier(expr.expression.expression) ? expr.expression.expression : undefined;
   const receiverIsDirectModuleBinding =
     receiverIdentifier !== undefined && cx.resolver?.isDirectModuleBinding?.(receiverIdentifier) === true;
+
+  // #4385 — ES5 §15.3.4. `%Function.prototype%` is a callable intrinsic
+  // object. Evaluate arguments left-to-right for effects, discard them, then
+  // call the symbolic zero-arg provider which returns the lane's real
+  // undefined carrier. Intercept before receiver lowering: ambient Function
+  // has no general IR value representation, and treating `prototype` as an
+  // instance method is the original category error.
+  if (
+    receiverIdentifier?.text === "Function" &&
+    methodName === "prototype" &&
+    !receiverIsDirectModuleBinding &&
+    cx.scope.get("Function") === undefined &&
+    cx.resolver?.isAmbientBinding?.(receiverIdentifier) !== false
+  ) {
+    if (expr.arguments.some(ts.isSpreadElement)) {
+      throw new IrUnsupportedError(
+        "method-call-unsupported",
+        "build",
+        `ir/from-ast: Function.prototype spread call is not supported (${cx.funcName})`,
+      );
+    }
+    const target = cx.resolver?.functionPrototypeCallTarget?.();
+    if (!target) {
+      throw new IrUnsupportedError(
+        "method-call-unsupported",
+        "build",
+        `ir/from-ast: Function.prototype call provider unavailable (${cx.funcName})`,
+      );
+    }
+    for (const argument of expr.arguments) lowerDiscardedExpression(argument, cx);
+    const result = cx.builder.emitCall(target, [], irVal({ kind: "externref" }));
+    if (result === null) throw new Error(`ir/from-ast: Function.prototype helper returned void (${cx.funcName})`);
+    return result;
+  }
 
   const preparedDateNow = lowerPreparedAsyncDateNow(expr, cx, methodName, receiverIdentifier);
   if (preparedDateNow !== null) return preparedDateNow;

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -59,6 +59,10 @@ import {
   TYPED_ARRAY_NAMES,
 } from "../codegen/index.js";
 import { ensureObjectRuntime } from "../codegen/object-runtime.js";
+import {
+  ensureFunctionPrototypeCallHelper,
+  FUNCTION_PROTOTYPE_CALL_HELPER,
+} from "../codegen/function-prototype-callable.js";
 import { boxToAny } from "../codegen/value-tags.js"; // (#2949 slice 3) THE canonical boxing entry point (D4)
 // (#2949 S5.1) THE canonical ToBoolean engine — one truthiness path for legacy and IR (D4).
 import {
@@ -4010,6 +4014,12 @@ function makeFromAstResolver(
     objectDefinePropertyTarget() {
       if (ctx.standalone || ctx.wasi || ctx.strictNoHostImports) return null;
       return irImportFuncRef("env", "__defineProperty_desc");
+    },
+    functionPrototypeCallTarget() {
+      if (!ctx.standalone || ctx.wasi) return null;
+      return ensureFunctionPrototypeCallHelper(ctx) === undefined
+        ? null
+        : irRuntimeFuncRef(FUNCTION_PROTOTYPE_CALL_HELPER);
     },
     resolveDynamic() {
       return resolveIrDynamicCarrierType(ctx);

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -513,6 +513,7 @@ export interface IrSelectionOptions extends IrAsyncSelectionOptions {
       | "host-date-snapshot"
       | "host-regexp-constructor"
       | "host-object-define-property"
+      | "standalone-function-prototype-call"
       | "standalone-native-regexp-test-carrier"
       | "legacy-numeric-array-global",
   ) => boolean;
@@ -6626,6 +6627,25 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     // `methodName`. If not, the function falls back to legacy.
     if (ts.isPropertyAccessExpression(expr.expression)) {
       if (!ts.isIdentifier(expr.expression.name)) return false;
+      // #4385 — exact ambient `%Function.prototype%()` call. This is a
+      // callable intrinsic object, not a dynamic method lookup. Its arguments
+      // are still ordinary evaluated expressions; the runtime entry point
+      // ignores their values and returns undefined.
+      if (
+        ts.isIdentifier(expr.expression.expression) &&
+        expr.expression.expression.text === "Function" &&
+        expr.expression.name.text === "prototype" &&
+        selectorSeesAmbientBinding(expr.expression.expression) &&
+        !scope.has("Function")
+      ) {
+        if (currentSelectionOptions?.supportsBackendCapability?.("standalone-function-prototype-call") !== true) {
+          return capabilityNo("call-resolution-unsupported", "expr-function-prototype-call-target", expr);
+        }
+        if (expr.arguments.some(ts.isSpreadElement)) {
+          return shapeNo("expr-function-prototype-call-spread", expr);
+        }
+        return expr.arguments.every((argument) => isPhase1Expr(argument, scope, localClasses));
+      }
       if (
         isPristineEs5IntrinsicIsFrozenCall(expr, (node) => selectorSeesAmbientBinding(node) && !scope.has(node.text))
       ) {

--- a/tests/issue-4385-function-prototype-callable.test.ts
+++ b/tests/issue-4385-function-prototype-callable.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** #4385 — `%Function.prototype%` is itself callable in ES5. */
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileAndRun(source: string, experimentalIR: boolean): Promise<{ value: unknown; ir: string[] }> {
+  const result = await compile(source, {
+    target: "standalone",
+    experimentalIR,
+    trackIrOutcomes: true,
+    fileName: "issue-4385.ts",
+  });
+  expect(result.success, result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")).toBe(true);
+  expect(result.imports ?? [], "standalone call must remain host-free").toEqual([]);
+  expect(WebAssembly.validate(result.binary!), "compiler must emit valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary!, {});
+  const value = (instance.exports as { main: () => unknown }).main();
+  return { value, ir: result.irCompiledFuncs ?? [] };
+}
+
+describe("#4385 Function.prototype callable intrinsic", () => {
+  it("returns undefined after evaluating and ignoring its arguments on the legacy path", async () => {
+    const { value } = await compileAndRun(
+      `
+        export function main() {
+          var side = 0;
+          var result = Function.prototype(side++, null, void 0);
+          return (result === undefined ? 10 : 0) + side;
+        }
+      `,
+      false,
+    );
+    expect(value).toBe(11);
+  });
+
+  it("is selected and emitted through the IR path", async () => {
+    const { value, ir } = await compileAndRun(
+      `
+        export function main(): number {
+          Function.prototype(null, void 0);
+          return 1;
+        }
+      `,
+      true,
+    );
+    expect(ir).toContain("main");
+    expect(value).toBe(1);
+  });
+
+  it("does not intercept a shadowing local named Function", async () => {
+    const { value } = await compileAndRun(
+      `
+        export function main() {
+          var Function = { prototype: function () { return 7; } };
+          return Function.prototype();
+        }
+      `,
+      false,
+    );
+    expect(value).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

- recognize exact ambient `Function.prototype(...)` calls in standalone legacy codegen
- select and lower the same semantics through a symbolic host-free IR runtime provider
- preserve argument evaluation order, real `undefined`, and shadowed `Function` bindings
- close repo issue #4385 with measured Test262 evidence

## Test262

- 4/4 exact ES5 targets: compile error -> pass in authoritative standalone runner
- 19-file reachable `Function/prototype` control set: 5 phase improvements, 14 unchanged, 0 regressions
- exact ES5 executable trigger population: all green

## Validation

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run tests/issue-4385-function-prototype-callable.test.ts` (3/3)
- `pnpm run check:ir-fallbacks`
- LOC/function budgets and full pre-push gates