### PR TITLE
fix(string): compare dynamic native strings by value

### DIFF
--- a/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
+++ b/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
@@ -47,6 +47,8 @@ func-budget-allow:
   - src/codegen/index.ts::generateMultiModule
   - src/codegen/string-ops.ts::compileNativeStringMethodCall
   - src/codegen/binary-ops-typed-dispatch.ts::compileTypedBinaryDispatch
+coercion-sites-allow:
+  - src/codegen/binary-ops-typed-dispatch.ts
 ---
 
 # #2742 — String.prototype generic-receiver `ToString(this)` coercion
@@ -919,7 +921,9 @@ routes mixed `$AnyValue`/native-String pairs through the canonical
 `__any_strict_eq` engine. That is the same tag-aware equality engine used by IR
 `dyn.eq`; the regression suite additionally requires the dynamic concat/equality
 control to appear in `irCompiledFuncs`, so the semantic contract stays live on
-the IR path.
+the IR path. The `coercion-sites-allow` entry records this reviewed call-site
+increase: it reuses that canonical engine instead of introducing another
+coercion or equality implementation.
 
 Exact fresh-baseline A/B over the 44-file residual:
 

--- a/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
+++ b/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
@@ -1,11 +1,11 @@
 ---
 id: 2742
 title: "String.prototype methods: ToString(this) generic-receiver coercion, RequireObjectCoercible, and function `.length` own property"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-06-27
-updated: 2026-08-01
-assignee: ttraenkler/s78-dev2
+updated: 2026-08-12
+assignee: ttraenkler/codex-es5-string
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -39,11 +39,14 @@ loc-budget-allow:
   - src/codegen/context/types.ts
   - src/codegen/index.ts
   - src/codegen/string-ops.ts
+  - src/codegen/binary-ops-typed-dispatch.ts
+  - tests/issue-2742-native-string-equality.test.ts
 func-budget-allow:
   - src/runtime.ts::resolveImport
   - src/codegen/index.ts::generateModule
   - src/codegen/index.ts::generateMultiModule
   - src/codegen/string-ops.ts::compileNativeStringMethodCall
+  - src/codegen/binary-ops-typed-dispatch.ts::compileTypedBinaryDispatch
 ---
 
 # #2742 — String.prototype generic-receiver `ToString(this)` coercion
@@ -893,3 +896,40 @@ times here.
 - **#3254** — reopened 2026-07-31 as false-`done`: it claims to generalise beyond
   `trim` and left `trim` itself on the pre-fix `"[object Object]"` terminal.
 - **#3887 / #3888** — "TypeError never raised" family, separate from this one.
+
+## Standalone residual: native String carrier equality (2026-08-12)
+
+Fresh ≤ES5 standalone clustering on `main` @
+`8c9f889680730001c08d0290bc40234514277505` left 44 failures under
+`test/built-ins/String/prototype/`. Five shared one representation defect: the
+reported actual value had the expected text, but the inline strict comparison
+returned false.
+
+Two physical shapes reached the same wrong terminal:
+
+- a dynamic concatenation returned `(ref $AnyValue)` and was compared with a
+  native String literal;
+- a dynamically-dispatched String method returned `(ref null $AnyString)` and
+  was compared with a separately allocated native String literal.
+
+`compileTypedBinaryDispatch` treated both as ordinary object refs and emitted
+raw `ref.eq`. The fix preserves `ref.eq` for actual objects, but routes native
+String-ref pairs through the null-safe `__str_equals` content comparator and
+routes mixed `$AnyValue`/native-String pairs through the canonical
+`__any_strict_eq` engine. That is the same tag-aware equality engine used by IR
+`dyn.eq`; the regression suite additionally requires the dynamic concat/equality
+control to appear in `irCompiledFuncs`, so the semantic contract stays live on
+the IR path.
+
+Exact fresh-baseline A/B over the 44-file residual:
+
+- base: 0 pass / 44 non-pass;
+- candidate: 5 pass / 39 non-pass;
+- fail → pass: 5; pass → fail: 0 within the fixed residual;
+- flipped files: the two `charAt` rows `S15.5.4.4_A1_T1/T2`,
+  `slice/S15.5.4.13_A3_T3`, `toLowerCase/S15.5.4.16_A1_T3`, and
+  `toUpperCase/S15.5.4.18_A1_T3`.
+
+The remaining 39 rows retain distinct causes (RegExp-backed methods, concat and
+split coverage, ToPrimitive/object branding, and missing transferred-method
+semantics); they are not attributed to this equality fix.

--- a/src/codegen/binary-ops-typed-dispatch.ts
+++ b/src/codegen/binary-ops-typed-dispatch.ts
@@ -77,6 +77,93 @@ export function compileTypedBinaryDispatch(
       const isStrictNeq = op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
       if (isStrictEq || isStrictNeq) {
         if (leftIsRef && rightIsRef) {
+          // (#2742) Native strings are structs, but JS String strict equality
+          // compares values. Dynamic String methods can retain a native-string
+          // ValType while the checker calls the expression `any`, bypassing the
+          // syntax-directed string path and reaching this ref dispatch. Compare
+          // the physical native-string pair by content, with null refs retaining
+          // their undefined-sentinel identity semantics.
+          const isNativeStringRef = (type: ValType): boolean =>
+            (type.kind === "ref" || type.kind === "ref_null") &&
+            (type.typeIdx === ctx.anyStrTypeIdx || type.typeIdx === ctx.nativeStrTypeIdx);
+          if (
+            ctx.nativeStrings &&
+            ctx.anyStrTypeIdx >= 0 &&
+            isNativeStringRef(leftType) &&
+            isNativeStringRef(rightType)
+          ) {
+            ensureNativeStringHelpers(ctx);
+            const strEqIdx = ctx.nativeStrHelpers.get("__str_equals");
+            if (strEqIdx !== undefined) {
+              const nullableString: ValType = { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx };
+              const tmpRightString = allocTempLocal(fctx, nullableString);
+              const tmpLeftString = allocTempLocal(fctx, nullableString);
+              fctx.body.push({ op: "local.set", index: tmpRightString });
+              fctx.body.push({ op: "local.set", index: tmpLeftString });
+              fctx.body.push({ op: "local.get", index: tmpLeftString });
+              fctx.body.push({ op: "ref.is_null" });
+              fctx.body.push({ op: "local.get", index: tmpRightString });
+              fctx.body.push({ op: "ref.is_null" });
+              fctx.body.push({ op: "i32.or" });
+              fctx.body.push({
+                op: "if",
+                blockType: { kind: "val", type: { kind: "i32" } },
+                then: [
+                  { op: "local.get", index: tmpLeftString },
+                  { op: "local.get", index: tmpRightString },
+                  { op: "ref.eq" },
+                ],
+                else: [
+                  { op: "local.get", index: tmpLeftString },
+                  { op: "ref.as_non_null" },
+                  { op: "local.get", index: tmpRightString },
+                  { op: "ref.as_non_null" },
+                  { op: "call", funcIdx: strEqIdx },
+                ],
+              });
+              releaseTempLocal(fctx, tmpLeftString);
+              releaseTempLocal(fctx, tmpRightString);
+              if (isStrictNeq) fctx.body.push({ op: "i32.eqz" });
+              return { kind: "i32" };
+            }
+          }
+
+          // (#2742) Dynamic `+` returns `$AnyValue`, so compare a mixed
+          // `$AnyValue`/native-string pair through the canonical tag-aware
+          // engine used by IR `dyn.eq`, never through carrier identity.
+          const isAnyValueRef = (type: ValType): boolean =>
+            (type.kind === "ref" || type.kind === "ref_null") &&
+            ctx.anyValueTypeIdx >= 0 &&
+            type.typeIdx === ctx.anyValueTypeIdx;
+          const leftIsAnyValue = isAnyValueRef(leftType);
+          const rightIsAnyValue = isAnyValueRef(rightType);
+          const mixedAnyValueNativeString =
+            (ctx.standalone === true || ctx.wasi === true) &&
+            ctx.nativeStrings &&
+            leftIsAnyValue !== rightIsAnyValue &&
+            ((leftIsAnyValue && isNativeStringRef(rightType)) ||
+              (rightIsAnyValue && isNativeStringRef(leftType)));
+          if (mixedAnyValueNativeString) {
+            const honestFromExternIdx = ensureAnyFromExternHelper(ctx, { forceHonest: true });
+            ensureAnyHelpers(ctx);
+            const strictEqIdx = ctx.funcMap.get("__any_strict_eq");
+            if (honestFromExternIdx !== undefined && strictEqIdx !== undefined) {
+              if (leftIsAnyValue) {
+                coerceType(ctx, fctx, rightType, { kind: "externref" });
+                fctx.body.push({ op: "call", funcIdx: honestFromExternIdx });
+              } else {
+                const tmpRightAnyValue = allocTempLocal(fctx, rightType);
+                fctx.body.push({ op: "local.set", index: tmpRightAnyValue });
+                coerceType(ctx, fctx, leftType, { kind: "externref" });
+                fctx.body.push({ op: "call", funcIdx: honestFromExternIdx });
+                fctx.body.push({ op: "local.get", index: tmpRightAnyValue });
+                releaseTempLocal(fctx, tmpRightAnyValue);
+              }
+              fctx.body.push({ op: "call", funcIdx: strictEqIdx });
+              if (isStrictNeq) fctx.body.push({ op: "i32.eqz" });
+              return { kind: "i32" };
+            }
+          }
           // (#3037 CS1b(ii)) When BOTH operands are the tagged `$AnyValue` box (in
           // standalone), raw `ref.eq` is the WRONG strict-eq: `$AnyValue` is a
           // discriminated union, so two boxes of the same logical value have

--- a/src/codegen/binary-ops-typed-dispatch.ts
+++ b/src/codegen/binary-ops-typed-dispatch.ts
@@ -141,8 +141,7 @@ export function compileTypedBinaryDispatch(
             (ctx.standalone === true || ctx.wasi === true) &&
             ctx.nativeStrings &&
             leftIsAnyValue !== rightIsAnyValue &&
-            ((leftIsAnyValue && isNativeStringRef(rightType)) ||
-              (rightIsAnyValue && isNativeStringRef(leftType)));
+            ((leftIsAnyValue && isNativeStringRef(rightType)) || (rightIsAnyValue && isNativeStringRef(leftType)));
           if (mixedAnyValueNativeString) {
             const honestFromExternIdx = ensureAnyFromExternHelper(ctx, { forceHonest: true });
             ensureAnyHelpers(ctx);

--- a/tests/issue-2742-native-string-equality.test.ts
+++ b/tests/issue-2742-native-string-equality.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2742 — String results that reach equality through a dynamic carrier still
+ * obey JavaScript String value equality. In standalone mode both `$AnyValue`
+ * and `$AnyString` are WasmGC refs; their carrier identity is not observable.
+ */
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const ES5_STRING_EQUALITY_FILES = [
+  "built-ins/String/prototype/charAt/S15.5.4.4_A1_T1.js",
+  "built-ins/String/prototype/charAt/S15.5.4.4_A1_T2.js",
+  "built-ins/String/prototype/slice/S15.5.4.13_A3_T3.js",
+  "built-ins/String/prototype/toLowerCase/S15.5.4.16_A1_T3.js",
+  "built-ins/String/prototype/toUpperCase/S15.5.4.18_A1_T3.js",
+] as const;
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  expect(result.imports).toEqual([]);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  return result;
+}
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compileStandalone(source);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#2742 — standalone native String value equality", () => {
+  it.each(ES5_STRING_EQUALITY_FILES)(
+    "passes the exact ES5 Test262 row %s",
+    async (file) => {
+      const result = await runTest262File(
+        join("test262/test", file),
+        "String.prototype",
+        20_000,
+        "standalone",
+      );
+      expect(result.status, result.error).toBe("pass");
+    },
+  );
+
+  it("compares an inline borrowed-method concatenation by value in both operand orders", async () => {
+    expect(
+      await runStandalone(`
+        var receiver = new Boolean();
+        receiver.charAt = String.prototype.charAt;
+        export function test(): number {
+          return receiver.charAt(false) + receiver.charAt(true) + receiver.charAt(true + 1) === "fal" &&
+            "fal" === receiver.charAt(false) + receiver.charAt(true) + receiver.charAt(true + 1) &&
+            receiver.charAt(false) + receiver.charAt(true) !== "fail" ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("keeps dynamic String concatenation and equality genuinely IR-emitted", async () => {
+    const result = await compileStandalone(`
+      function identity(value: any): any { return value; }
+      export function test(): number {
+        return identity("f") + identity("a") + identity("l") === "fal" ? 1 : 0;
+      }
+    `);
+    expect(result.irCompiledFuncs).toEqual(
+      expect.arrayContaining(["identity", "test"]),
+    );
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(1);
+  });
+});

--- a/tests/issue-2742-native-string-equality.test.ts
+++ b/tests/issue-2742-native-string-equality.test.ts
@@ -35,18 +35,10 @@ async function runStandalone(source: string): Promise<number> {
 }
 
 describe("#2742 — standalone native String value equality", () => {
-  it.each(ES5_STRING_EQUALITY_FILES)(
-    "passes the exact ES5 Test262 row %s",
-    async (file) => {
-      const result = await runTest262File(
-        join("test262/test", file),
-        "String.prototype",
-        20_000,
-        "standalone",
-      );
-      expect(result.status, result.error).toBe("pass");
-    },
-  );
+  it.each(ES5_STRING_EQUALITY_FILES)("passes the exact ES5 Test262 row %s", async (file) => {
+    const result = await runTest262File(join("test262/test", file), "String.prototype", 20_000, "standalone");
+    expect(result.status, result.error).toBe("pass");
+  });
 
   it("compares an inline borrowed-method concatenation by value in both operand orders", async () => {
     expect(
@@ -69,9 +61,7 @@ describe("#2742 — standalone native String value equality", () => {
         return identity("f") + identity("a") + identity("l") === "fal" ? 1 : 0;
       }
     `);
-    expect(result.irCompiledFuncs).toEqual(
-      expect.arrayContaining(["identity", "test"]),
-    );
+    expect(result.irCompiledFuncs).toEqual(expect.arrayContaining(["identity", "test"]));
     const { instance } = await WebAssembly.instantiate(result.binary, {});
     expect((instance.exports.test as () => number)()).toBe(1);
   });


### PR DESCRIPTION
## Summary

- compare native String refs by content instead of Wasm carrier identity
- route mixed AnyValue/native-string strict equality through the canonical engine used by IR dyn.eq
- add exact ES5 Test262 regressions plus a genuine IR-emission guard
- record the measured residual and remaining causes in plan/issues/2742

## Test262 impact

Fresh 44-file <=ES5 standalone String.prototype residual: 0 -> 5 passing, with 39 unchanged. The five flips are charAt A1_T1/T2, slice A3_T3, and toLowerCase/toUpperCase A1_T3.

## Validation

- issue 2742 focused suites: 19/19
- new native-string equality suite: 7/7 post-rebase
- strict-equality equivalence suite: 8/8
- pnpm run typecheck
- pnpm run check:ir-fallbacks

Ready for review; this PR is intentionally not a draft.