### PR TITLE
fix(array): retain inherited fnctor filter semantics

### DIFF
--- a/plan/issues/4387-fnctor-array-prototype-reconstruction-regression.md
+++ b/plan/issues/4387-fnctor-array-prototype-reconstruction-regression.md
@@ -1,0 +1,103 @@
+---
+id: 4387
+title: "ES5: retain Array-valued live fnctor prototypes across `$Object` reconstruction"
+status: ready
+assignee: ttraenkler/codex-es5-array-cluster
+sprint: current
+created: 2026-08-12
+updated: 2026-08-12
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen, ir
+language_feature: arrays, prototype-chain
+goal: es5-conformance
+related: [3772, 4163]
+loc-budget-allow:
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/fnctor-escape-gate.ts
+  - src/codegen/index.ts
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/module-bindings.ts
+  - src/ir/select.ts
+func-budget-allow:
+  - src/codegen/index.ts::planIrOverlay
+  - src/ir/integration.ts::compileIrPathFunctions
+  - src/ir/integration.ts::makeFromAstResolver
+---
+
+# #4387 — Array-valued fnctor prototypes must survive reconstruction
+
+## Problem
+
+Seven current standalone <=ES5 Test262 files fail with `called value is not a
+function`:
+
+- `built-ins/Array/prototype/filter/15.4.4.20-6-2.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-3.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-4.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-5.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-6.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-7.js`
+- `built-ins/Array/prototype/filter/15.4.4.20-6-8.js`
+
+They share one shape:
+
+```js
+F.prototype = new Array(1, 2, 3);
+function F() {}
+var value = new F();
+value.length = false;
+var result = value.filter(function () {});
+```
+
+This family originally landed under #3772. #4163 later widened fnctor
+reconstruction to module-global externref bindings. The reconstructed `$Object`
+can retain only an open `$Object` in its typed `$proto` slot; an Array carrier is
+therefore replaced with null by `__object_create`. The existing shared
+closed-method dispatcher still knows how to recognize a raw fnctor whose live
+prototype is an Array, but reconstruction removes that evidence first.
+
+## Direction
+
+Extend the frozen whole-program fnctor verdict with a conservative positive
+proof for exactly one unconditional top-level `F.prototype = <Array>` write.
+Those sites retain the raw fnctor representation; all aliases, conditional or
+multiple assignments, and shadowed `Array` bindings remain "unknown" and keep
+the existing reconstruction decision.
+
+The runtime semantics remain shared with IR: an IR-owned exported function must
+call `filter` through the existing symbolic dynamic-method provider against the
+same retained carrier, with no legacy-only duplicate implementation.
+
+## Acceptance
+
+- [x] All seven focused standalone Test262 files pass (`0/7 -> 7/7` against
+      exact `origin/main` `8c9f8896807300`).
+- [x] No focused pass-to-fail transition.
+- [x] The four standalone #3772 regression assertions are green again. The
+      pre-existing host-only inherited-filter assertion remains outside this
+      standalone slice.
+- [x] An exported function that performs the inherited `filter` call is
+      genuinely emitted through IR (`irCompiledFuncs`) with no post-claim error.
+- [x] Shadowed `Array`, aliases, computed writes, and multiple prototype
+      assignments do not receive the
+      positive proof.
+- [x] Typecheck, issue, IR fallback, LOC/function budget, and focused tests pass.
+
+## Verification
+
+- Exact detached `origin/main` (`8c9f8896807300`) standalone Test262 control:
+  `0/7` pass.
+- Candidate standalone Test262 result on the same seven files: `7/7` pass.
+- `pnpm run typecheck`
+- `pnpm run check:ir-fallbacks`
+- `pnpm run check:loc-budget`
+- `pnpm run check:func-budget`
+- `pnpm run check:issues`
+- Focused Vitest: 26 passed, 1 host-only assertion intentionally skipped.
+- The two already-red standalone #3014 local-function assertions remain red on
+  both exact base and candidate; this slice introduces no transition there.

--- a/plan/issues/4387-fnctor-array-prototype-reconstruction-regression.md
+++ b/plan/issues/4387-fnctor-array-prototype-reconstruction-regression.md
@@ -2,6 +2,7 @@
 id: 4387
 title: "ES5: retain Array-valued live fnctor prototypes across `$Object` reconstruction"
 status: ready
+pr: 4423
 assignee: ttraenkler/codex-es5-array-cluster
 sprint: current
 created: 2026-08-12

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1418,6 +1418,7 @@ function compileNewFunctionDeclaration(
 ): ValType | null {
   const body = funcDecl.body;
   if (!body) return null;
+  const fnctorKey = resolveFnctorSymbol(ctx.checker, expr.expression)?.name ?? funcName;
 
   // (#2660 S3a) Reconstruct an APPROVED, EMPTY-BODY `new F()` as a native
   // `$Object` (standalone) so its inherited-prototype reads route through the
@@ -1446,6 +1447,11 @@ function compileNewFunctionDeclaration(
   //        receiver. Reading the REAL local type (not the TS annotation) is the
   //        load-bearing safety check — returning externref into a struct-ref
   //        local would `ref.cast`-trap (that retype ripple is S3b).
+  //   (G5) the one proven live `F.prototype` value is not an Array carrier
+  //        (#4387). `__object_create` can seed only its `$Object` `$proto`
+  //        slot, so reconstructing an Array-valued prototype discards the
+  //        chain. Keep that exact shape on the raw fnctor representation,
+  //        whose shared closed-method runtime recognizes the live Array.
   //
   // Cache-order note: this gate sits at the cache-MISS entry. If a NON-approved
   // sibling `new F()` of the same fnctor compiled first, it populated
@@ -1457,11 +1463,11 @@ function compileNewFunctionDeclaration(
   if (
     ctx.standalone &&
     ctx.fnctorEscapeGate?.approved.has(expr) &&
+    !ctx.fnctorEscapeGate.stableArrayPrototypeNames.has(fnctorKey) &&
     body.statements.length === 0 &&
     (expr.arguments?.length ?? 0) === 0 &&
     fnctorNewResultConsumedAsExternref(ctx, fctx, expr)
   ) {
-    const fnctorKey = resolveFnctorSymbol(ctx.checker, expr.expression)?.name ?? funcName;
     const reconstructed = compileFnctorNewAsObject(ctx, fctx, fnctorKey);
     if (reconstructed) return reconstructed;
     // Helper declined (e.g. `__object_create` unavailable) → fall through to the

--- a/src/codegen/fnctor-array-prototype-analysis.ts
+++ b/src/codegen/fnctor-array-prototype-analysis.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { forEachChild, ts } from "../ts-api.js";
+
+type FnctorResolver = (checker: ts.TypeChecker, expression: ts.Expression) => ts.Symbol | undefined;
+
+function unwrapExpression(expression: ts.Expression): ts.Expression {
+  while (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isNonNullExpression(expression)
+  ) {
+    expression = expression.expression;
+  }
+  return expression;
+}
+
+/** Closed-world positive proof for #4387's Array-valued fnctor prototype. */
+export function analyzeStableArrayPrototypeNames(
+  checker: ts.TypeChecker,
+  sourceFiles: readonly ts.SourceFile[],
+  resolveFnctor: FnctorResolver,
+): ReadonlySet<string> {
+  interface Verdict {
+    readonly symbol: ts.Symbol;
+    readonly name: string;
+    count: number;
+    array: boolean;
+    poisoned: boolean;
+  }
+  const verdicts = new Map<ts.Symbol, Verdict>();
+
+  const isAmbientArrayCtor = (node: ts.Expression): boolean => {
+    const value = unwrapExpression(node);
+    if (ts.isArrayLiteralExpression(value)) return true;
+    if (!ts.isNewExpression(value) && !ts.isCallExpression(value)) return false;
+    const callee = unwrapExpression(value.expression);
+    if (!ts.isIdentifier(callee) || callee.text !== "Array") return false;
+    const declarations = checker.getSymbolAtLocation(callee)?.getDeclarations();
+    return (
+      declarations !== undefined &&
+      declarations.length > 0 &&
+      declarations.every((declaration) => declaration.getSourceFile().isDeclarationFile)
+    );
+  };
+
+  const collectWrites = (node: ts.Node): void => {
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(node.left) &&
+      !ts.isPrivateIdentifier(node.left.name) &&
+      node.left.name.text === "prototype"
+    ) {
+      const owner = resolveFnctor(checker, node.left.expression);
+      if (owner) {
+        const topLevel = ts.isExpressionStatement(node.parent) && ts.isSourceFile(node.parent.parent);
+        const verdict = verdicts.get(owner) ?? {
+          symbol: owner,
+          name: owner.name,
+          count: 0,
+          array: true,
+          poisoned: false,
+        };
+        verdict.count++;
+        verdict.array &&= topLevel && isAmbientArrayCtor(node.right);
+        verdicts.set(owner, verdict);
+      }
+    }
+    forEachChild(node, collectWrites);
+  };
+  for (const sourceFile of sourceFiles) collectWrites(sourceFile);
+
+  // The consumer is still name-keyed, so same-named symbols decline. Any
+  // constructor reference outside its declaration, the direct assignment, or
+  // zero-argument construction also declines: aliases and computed writes can
+  // otherwise mutate `prototype` behind this deliberately narrow scan.
+  const symbolsByName = new Map<string, number>();
+  for (const verdict of verdicts.values()) {
+    symbolsByName.set(verdict.name, (symbolsByName.get(verdict.name) ?? 0) + 1);
+  }
+  const inspectReference = (node: ts.Node): void => {
+    if (ts.isIdentifier(node)) {
+      const symbol = checker.getSymbolAtLocation(node);
+      const verdict = symbol ? verdicts.get(symbol) : undefined;
+      if (verdict) {
+        const declarationName = verdict.symbol.getDeclarations()?.some((declaration) => {
+          if (ts.isFunctionDeclaration(declaration)) return declaration.name === node;
+          if (ts.isVariableDeclaration(declaration)) return declaration.name === node;
+          return false;
+        });
+        const prototypeAssignment =
+          ts.isPropertyAccessExpression(node.parent) &&
+          node.parent.expression === node &&
+          node.parent.name.text === "prototype" &&
+          ts.isBinaryExpression(node.parent.parent) &&
+          node.parent.parent.left === node.parent &&
+          node.parent.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken;
+        const zeroArgumentConstruction =
+          ts.isNewExpression(node.parent) &&
+          node.parent.expression === node &&
+          (node.parent.arguments?.length ?? 0) === 0;
+        if (!declarationName && !prototypeAssignment && !zeroArgumentConstruction) verdict.poisoned = true;
+      }
+    }
+    forEachChild(node, inspectReference);
+  };
+  for (const sourceFile of sourceFiles) inspectReference(sourceFile);
+
+  return new Set(
+    [...verdicts.values()]
+      .filter(
+        (verdict) => verdict.count === 1 && verdict.array && !verdict.poisoned && symbolsByName.get(verdict.name) === 1,
+      )
+      .map((verdict) => verdict.name),
+  );
+}

--- a/src/codegen/fnctor-array-prototype-analysis.ts
+++ b/src/codegen/fnctor-array-prototype-analysis.ts
@@ -71,6 +71,11 @@ export function analyzeStableArrayPrototypeNames(
   };
   for (const sourceFile of sourceFiles) collectWrites(sourceFile);
 
+  // Most programs, including the Test262 harness, do not assign an Array to a
+  // constructor prototype. Avoid the symbol-heavy reference pass entirely in
+  // that common case; an empty candidate set cannot produce a positive proof.
+  if (verdicts.size === 0) return new Set();
+
   // The consumer is still name-keyed, so same-named symbols decline. Any
   // constructor reference outside its declaration, the direct assignment, or
   // zero-argument construction also declines: aliases and computed writes can

--- a/src/codegen/fnctor-escape-gate.ts
+++ b/src/codegen/fnctor-escape-gate.ts
@@ -47,6 +47,7 @@ import type { FieldDef, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { appendFnctorInternalFields } from "./fnctor-identity-fields.js";
 import { type AllocLabelResult, analyzeFnctorAllocLabels, fnctorLayoutsEnabled } from "./fnctor-alloc-labels.js"; // (#3927) per-type layout plan
+import { analyzeStableArrayPrototypeNames } from "./fnctor-array-prototype-analysis.js";
 import { applyColdTailSplit } from "./fnctor-cold-tail.js";
 import { applyFnctorLayoutSplit, fnctorLayoutEmitEnabled } from "./fnctor-layout-emit.js"; // (#3927) per-type layout EMISSION
 import { recordFnctorFieldProvenance } from "./fnctor-field-provenance.js";
@@ -82,6 +83,14 @@ export interface FnctorEscapeGateResult {
    * interception caused).
    */
   readonly approvedNames: ReadonlySet<string>;
+  /**
+   * #4387 — fnctors whose one provable top-level `F.prototype = ...` write
+   * installs an Array carrier. `$Object` reconstruction cannot retain that
+   * carrier in its typed `$proto` slot, so `new-super` keeps these allocation
+   * sites on the raw fnctor representation consumed by the Array-HOF runtime
+   * predicate. Empty means "no proof", never "no Array prototype".
+   */
+  readonly stableArrayPrototypeNames: ReadonlySet<string>;
   /**
    * #2660 PART-1 — receiver-expression → `__fnctor_<Name>` struct-name flow map.
    *
@@ -235,6 +244,7 @@ function emptyResult(compilePath: FnctorCompilePath, sourceFileCount: number): F
     sites: new Map(),
     approved: new Set(),
     approvedNames: new Set(),
+    stableArrayPrototypeNames: new Set(),
     receiverStruct: new Map(),
     newThisOwnerNames: new Set(),
     ctorDeclByName: new Map(),
@@ -1460,6 +1470,7 @@ export function analyzeFnctorEscapeGate(
   const sites = new Map<ts.NewExpression, FnctorGateClass>();
   const approved = new Set<ts.NewExpression>();
   const approvedNames = new Set<string>();
+  const stableArrayPrototypeNames = analyzeStableArrayPrototypeNames(checker, sourceFiles, resolveFnctorSymbol);
   const refusals = new Map<string, number>();
   const refusedNames = new Set<string>();
   const refuse = (name: string, reason: string): void => {
@@ -1712,6 +1723,7 @@ export function analyzeFnctorEscapeGate(
     sites,
     approved,
     approvedNames,
+    stableArrayPrototypeNames,
     receiverStruct,
     newThisOwnerNames,
     ctorDeclByName,

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2071,8 +2071,11 @@ function makeIrImplicitParamTypeResolver(
       const onlyStatement = declaration.body?.statements.length === 1 ? declaration.body.statements[0] : undefined;
       const returned = onlyStatement && ts.isReturnStatement(onlyStatement) ? onlyStatement.expression : undefined;
       const returnedCall = returned && ts.isCallExpression(returned) ? returned : undefined;
-      const retainedPlan = returnedCall ? moduleBindingResolver?.retainedFunctionMethodPlan(returnedCall) : undefined;
-      if (retainedPlan && returnedCall) {
+      const receiverFirstPlan = returnedCall
+        ? (moduleBindingResolver?.retainedFunctionMethodPlan(returnedCall) ??
+          moduleBindingResolver?.fnctorArrayMethodPlan(returnedCall))
+        : undefined;
+      if (receiverFirstPlan && returnedCall) {
         const projected = new Set(candidates);
         for (let index = 0; index < declaration.parameters.length; index++) {
           const argument = returnedCall.arguments[index];
@@ -2219,6 +2222,7 @@ function planIrOverlay(
             allowHostExterns: jsHostExterns && !ctx.nativeStrings,
             allowBuiltinMapExtern: jsHostExterns && !ctx.nativeStrings,
             allowBoundedTopLevelAccessorSelectionCandidates: true,
+            stableFnctorArrayPrototypeNames: ctx.fnctorEscapeGate?.stableArrayPrototypeNames,
           },
           identityContext,
         );
@@ -2273,7 +2277,8 @@ function planIrOverlay(
     if (
       returned &&
       ts.isCallExpression(returned) &&
-      resolveModuleBinding?.retainedFunctionMethodPlan(returned) !== undefined
+      (resolveModuleBinding?.retainedFunctionMethodPlan(returned) !== undefined ||
+        resolveModuleBinding?.fnctorArrayMethodPlan(returned) !== undefined)
     ) {
       // #3793 — the exact retained wrapper uses the existing receiver-first
       // externref dispatcher and the implicit-param resolver above projects

--- a/src/ir/fnctor-array-method.ts
+++ b/src/ir/fnctor-array-method.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import type { IrBindingId, IrSourceId, IrUnitId } from "./identity.js";
+
+/** Exact stable module carrier whose user constructor inherits an Array HOF. */
+export interface IrFnctorArrayMethodPlan {
+  readonly receiverDeclaration: ts.VariableDeclaration;
+  readonly receiverName: string;
+  readonly constructorDeclaration: ts.FunctionDeclaration;
+  readonly constructorName: string;
+  readonly methodName: "filter";
+  readonly arity: 1;
+  readonly receiverGlobalBindingId?: IrBindingId;
+  readonly receiverStorageOwnerUnitId?: IrUnitId;
+  readonly receiverSourceId?: IrSourceId;
+  readonly receiverDeclarationOrdinal?: number;
+}
+
+function unwrapExpression(expression: ts.Expression): ts.Expression {
+  while (ts.isParenthesizedExpression(expression)) expression = expression.expression;
+  return expression;
+}
+
+function exactTopLevelVariableDeclaration(
+  node: ts.Identifier,
+  checker: ts.TypeChecker,
+): ts.VariableDeclaration | undefined {
+  const symbol = checker.getSymbolAtLocation(node);
+  if (!symbol) return undefined;
+  const sourceFile = node.getSourceFile();
+  const declarations = new Set(
+    [symbol.valueDeclaration, ...(symbol.declarations ?? [])].filter(
+      (candidate): candidate is ts.VariableDeclaration =>
+        candidate !== undefined &&
+        ts.isVariableDeclaration(candidate) &&
+        candidate.getSourceFile() === sourceFile &&
+        ts.isIdentifier(candidate.name) &&
+        ts.isVariableDeclarationList(candidate.parent) &&
+        ts.isVariableStatement(candidate.parent.parent) &&
+        candidate.parent.parent.parent === sourceFile,
+    ),
+  );
+  return declarations.size === 1 ? [...declarations][0] : undefined;
+}
+
+function exactTopLevelFunctionDeclaration(
+  node: ts.Identifier,
+  checker: ts.TypeChecker,
+): ts.FunctionDeclaration | undefined {
+  const symbol = checker.getSymbolAtLocation(node);
+  if (!symbol) return undefined;
+  const sourceFile = node.getSourceFile();
+  const declarations = new Set(
+    [symbol.valueDeclaration, ...(symbol.declarations ?? [])].filter(
+      (candidate): candidate is ts.FunctionDeclaration =>
+        candidate !== undefined &&
+        ts.isFunctionDeclaration(candidate) &&
+        candidate.getSourceFile() === sourceFile &&
+        candidate.parent === sourceFile &&
+        candidate.name !== undefined,
+    ),
+  );
+  if (declarations.size !== 1) return undefined;
+  const declaration = [...declarations][0]!;
+  return checker.getSymbolAtLocation(declaration.name!) === symbol ? declaration : undefined;
+}
+
+function identifierIsWritten(node: ts.Identifier): boolean {
+  let target: ts.Node = node;
+  let parent = target.parent;
+  while (
+    (ts.isParenthesizedExpression(parent) && parent.expression === target) ||
+    (ts.isArrayLiteralExpression(parent) && parent.elements.includes(target as ts.Expression)) ||
+    (ts.isObjectLiteralExpression(parent) && parent.properties.includes(target as ts.ObjectLiteralElementLike)) ||
+    (ts.isPropertyAssignment(parent) && parent.initializer === target) ||
+    (ts.isShorthandPropertyAssignment(parent) && parent.name === target) ||
+    (ts.isSpreadElement(parent) && parent.expression === target) ||
+    (ts.isSpreadAssignment(parent) && parent.expression === target)
+  ) {
+    target = parent;
+    parent = target.parent;
+  }
+  if (
+    ts.isBinaryExpression(parent) &&
+    parent.left === target &&
+    parent.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+    parent.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+  ) {
+    return true;
+  }
+  if (
+    (ts.isPrefixUnaryExpression(parent) || ts.isPostfixUnaryExpression(parent)) &&
+    (parent.operator === ts.SyntaxKind.PlusPlusToken || parent.operator === ts.SyntaxKind.MinusMinusToken)
+  ) {
+    return true;
+  }
+  return (ts.isForInStatement(parent) || ts.isForOfStatement(parent)) && parent.initializer === target;
+}
+
+function sourceBindingIsStable(checker: ts.TypeChecker, declaration: ts.VariableDeclaration): boolean {
+  if (!ts.isIdentifier(declaration.name)) return false;
+  const symbol = checker.getSymbolAtLocation(declaration.name);
+  if (!symbol) return false;
+  let stable = true;
+  const visit = (node: ts.Node): void => {
+    if (stable && ts.isIdentifier(node) && checker.getSymbolAtLocation(node) === symbol && identifierIsWritten(node)) {
+      stable = false;
+      return;
+    }
+    if (stable) node.forEachChild(visit);
+  };
+  declaration.getSourceFile().forEachChild(visit);
+  return stable;
+}
+
+function sourceModuleExportsSymbol(sourceFile: ts.SourceFile, symbol: ts.Symbol, checker: ts.TypeChecker): boolean {
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) return true;
+  try {
+    return checker.getExportsOfModule(moduleSymbol).some((exported) => {
+      const target = (exported.flags & ts.SymbolFlags.Alias) !== 0 ? checker.getAliasedSymbol(exported) : exported;
+      return target === symbol;
+    });
+  } catch {
+    return true;
+  }
+}
+
+function argumentIsBridgeable(checker: ts.TypeChecker, argument: ts.Expression): boolean {
+  const type = checker.getTypeAtLocation(unwrapExpression(argument));
+  return (
+    (type.flags &
+      (ts.TypeFlags.Any |
+        ts.TypeFlags.Unknown |
+        ts.TypeFlags.NumberLike |
+        ts.TypeFlags.StringLike |
+        ts.TypeFlags.Object |
+        ts.TypeFlags.NonPrimitive)) !==
+    0
+  );
+}
+
+/** Build the selector-safe #4387 source plan; ambiguity always declines. */
+export function makeFnctorArrayMethodPlan(
+  checker: ts.TypeChecker,
+  call: ts.CallExpression,
+  stablePrototypeNames: ReadonlySet<string> | undefined,
+): IrFnctorArrayMethodPlan | undefined {
+  if (
+    !stablePrototypeNames ||
+    call.questionDotToken ||
+    call.typeArguments?.length ||
+    call.arguments.length !== 1 ||
+    call.arguments.some(ts.isSpreadElement) ||
+    !ts.isPropertyAccessExpression(call.expression) ||
+    call.expression.questionDotToken ||
+    !ts.isIdentifier(call.expression.expression) ||
+    call.expression.name.text !== "filter" ||
+    !argumentIsBridgeable(checker, call.arguments[0]!)
+  ) {
+    return undefined;
+  }
+
+  const receiver = call.expression.expression;
+  const receiverDeclaration = exactTopLevelVariableDeclaration(receiver, checker);
+  const initializer = receiverDeclaration?.initializer ? unwrapExpression(receiverDeclaration.initializer) : undefined;
+  if (
+    !receiverDeclaration ||
+    !initializer ||
+    !ts.isNewExpression(initializer) ||
+    initializer.arguments?.length !== 0 ||
+    !ts.isIdentifier(initializer.expression) ||
+    !ts.isVariableDeclarationList(receiverDeclaration.parent) ||
+    (receiverDeclaration.parent.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) !== 0 ||
+    !sourceBindingIsStable(checker, receiverDeclaration)
+  ) {
+    return undefined;
+  }
+
+  const receiverSymbol = checker.getSymbolAtLocation(receiver);
+  const declarationSymbol = checker.getSymbolAtLocation(receiverDeclaration.name);
+  const constructorDeclaration = exactTopLevelFunctionDeclaration(initializer.expression, checker);
+  const constructorSymbol = constructorDeclaration?.name
+    ? checker.getSymbolAtLocation(constructorDeclaration.name)
+    : undefined;
+  const sourceFile = receiverDeclaration.getSourceFile();
+  if (
+    !receiverSymbol ||
+    receiverSymbol !== declarationSymbol ||
+    !constructorDeclaration?.name ||
+    !constructorSymbol ||
+    checker.getSymbolAtLocation(initializer.expression) !== constructorSymbol ||
+    constructorDeclaration.getSourceFile() !== sourceFile ||
+    !ts.isExternalModule(sourceFile) ||
+    sourceModuleExportsSymbol(sourceFile, receiverSymbol, checker) ||
+    sourceModuleExportsSymbol(sourceFile, constructorSymbol, checker) ||
+    !stablePrototypeNames.has(constructorDeclaration.name.text)
+  ) {
+    return undefined;
+  }
+
+  return {
+    receiverDeclaration,
+    receiverName: receiver.text,
+    constructorDeclaration,
+    constructorName: constructorDeclaration.name.text,
+    methodName: "filter",
+    arity: 1,
+  };
+}

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -597,6 +597,10 @@ export interface IrFromAstResolver extends PreparedAsyncFromAstResolver {
   retainedFunctionMethodPlan?(
     call: ts.CallExpression,
   ): { readonly receiverGlobal: IrGlobalRef; readonly funcName: string } | null;
+  /** #4387 — stable fnctor instance inheriting one intrinsic Array prototype. */
+  fnctorArrayMethodPlan?(
+    call: ts.CallExpression,
+  ): { readonly receiverGlobal: IrGlobalRef; readonly funcName: string } | null;
   /** #3791 exact stable module numeric vec at a direct-call boundary. */
   staticNumericArrayRead?(
     expression: ts.Expression,
@@ -5902,6 +5906,41 @@ function lowerPreparedAsyncDateNow(
   return result;
 }
 
+function lowerReceiverFirstDynamicMethod(
+  expr: ts.CallExpression,
+  cx: LowerCtx,
+  plan: { readonly receiverGlobal: IrGlobalRef; readonly funcName: string },
+  description: string,
+): IrValueId {
+  const receiver = cx.builder.emitGlobalGet(plan.receiverGlobal, irVal({ kind: "externref" }));
+  const args: IrValueId[] = [receiver];
+  for (const argument of expr.arguments) {
+    if (ts.isSpreadElement(argument)) {
+      throw new IrUnsupportedError(
+        "method-call-unsupported",
+        "build",
+        `ir/from-ast: ${description} spread is unsupported (${cx.funcName})`,
+      );
+    }
+    const value = lowerExpr(argument, cx, irDynamic());
+    const type = cx.builder.typeOf(value);
+    const scalar = asVal(type);
+    const carrier =
+      scalar?.kind === "f64" || scalar?.kind === "i32" ? boxConcreteToDynamic(value, type, argument, cx) : value;
+    if (carrier === null) {
+      throw new IrUnsupportedError(
+        "operand-coercion-unsupported",
+        "build",
+        `ir/from-ast: ${description} scalar argument has no dynamic box (${cx.funcName})`,
+      );
+    }
+    args.push(cx.builder.typeOf(carrier).kind === "dynamic" ? carrier : cx.builder.emitCoerceToExternref(carrier));
+  }
+  const result = cx.builder.emitCall(irRuntimeFuncRef(plan.funcName), args, irDynamic());
+  if (result === null) throw new Error(`ir/from-ast: ${description} returned void (${cx.funcName})`);
+  return result;
+}
+
 function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = false): IrValueId | null {
   if (!ts.isPropertyAccessExpression(expr.expression) || !ts.isIdentifier(expr.expression.name)) {
     throw new Error(`ir/from-ast: malformed method call in ${cx.funcName}`);
@@ -5914,6 +5953,15 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
   const preparedDateNow = lowerPreparedAsyncDateNow(expr, cx, methodName, receiverIdentifier);
   if (preparedDateNow !== null) return preparedDateNow;
 
+  // #4387 — a stable `var value = new F()` whose one proven `F.prototype`
+  // write installs an intrinsic Array stays in the legacy raw-fnctor global.
+  // IR owns the call by loading that exact carrier and invoking the same
+  // receiver-first closed dispatcher used by the direct path.
+  const fnctorArrayMethod = cx.resolver?.fnctorArrayMethodPlan?.(expr) ?? null;
+  if (fnctorArrayMethod !== null) {
+    return lowerReceiverFirstDynamicMethod(expr, cx, fnctorArrayMethod, "fnctor Array method");
+  }
+
   // #3793 — Acorn's public wrappers call static properties on the retained
   // `Parser` function object. Load the exact existing module carrier and
   // route through the already-reserved closed method dispatcher. That keeps
@@ -5921,35 +5969,7 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
   // does not turn the assigned FunctionExpression into a bare direct call.
   const retainedMethod = cx.resolver?.retainedFunctionMethodPlan?.(expr) ?? null;
   if (retainedMethod !== null) {
-    const receiver = cx.builder.emitGlobalGet(retainedMethod.receiverGlobal, irVal({ kind: "externref" }));
-    const args: IrValueId[] = [receiver];
-    for (const argument of expr.arguments) {
-      if (ts.isSpreadElement(argument)) {
-        throw new IrUnsupportedError(
-          "method-call-unsupported",
-          "build",
-          `ir/from-ast: retained function method spread is unsupported (${cx.funcName})`,
-        );
-      }
-      const value = lowerExpr(argument, cx, irDynamic());
-      const type = cx.builder.typeOf(value);
-      const scalar = asVal(type);
-      const carrier =
-        scalar?.kind === "f64" || scalar?.kind === "i32" ? boxConcreteToDynamic(value, type, argument, cx) : value;
-      if (carrier === null) {
-        throw new IrUnsupportedError(
-          "operand-coercion-unsupported",
-          "build",
-          `ir/from-ast: retained function method scalar argument has no dynamic box (${cx.funcName})`,
-        );
-      }
-      args.push(cx.builder.typeOf(carrier).kind === "dynamic" ? carrier : cx.builder.emitCoerceToExternref(carrier));
-    }
-    const result = cx.builder.emitCall(irRuntimeFuncRef(retainedMethod.funcName), args, irDynamic());
-    if (result === null) {
-      throw new Error(`ir/from-ast: retained function method returned void (${cx.funcName})`);
-    }
-    return result;
+    return lowerReceiverFirstDynamicMethod(expr, cx, retainedMethod, "retained function method");
   }
 
   // #3791 — standalone native RegExp `.test` on one exact, stable top-level

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -195,6 +195,7 @@ import {
   makeIrRegExpExpressionPredicate,
   type IrLegacyModuleBindingIdentity,
   type IrLegacyModuleBindingResolver,
+  type IrFnctorArrayMethodPlan,
   type IrModuleBindingIdentity,
   type IrModuleBindingResolver,
   type IrRetainedFunctionMethodPlan,
@@ -858,6 +859,7 @@ export function compileIrPathFunctions(
     numberStorage: ctx.fast ? ("i32" as const) : ("f64" as const),
     allowHostExterns: jsHostExterns && !ctx.nativeStrings,
     allowBuiltinMapExtern: jsHostExterns && !ctx.nativeStrings,
+    stableFnctorArrayPrototypeNames: ctx.fnctorEscapeGate?.stableArrayPrototypeNames,
   };
   // Direct compatibility callers share this context; structural globals never fall back to declaration names.
   const compatibilityInventory = loweringPlans
@@ -3901,6 +3903,91 @@ function resolveRetainedFunctionMethod(
   return { receiverGlobal, funcName };
 }
 
+function resolveFnctorArrayMethod(
+  ctx: CodegenContext,
+  plan: IrFnctorArrayMethodPlan,
+): { readonly receiverGlobal: IrGlobalRef; readonly funcName: string } {
+  if (
+    plan.receiverGlobalBindingId === undefined ||
+    plan.receiverStorageOwnerUnitId === undefined ||
+    plan.receiverSourceId === undefined ||
+    plan.receiverDeclarationOrdinal === undefined ||
+    !ts.isIdentifier(plan.receiverDeclaration.name) ||
+    plan.receiverDeclaration.name.text !== plan.receiverName ||
+    !plan.constructorDeclaration.name ||
+    plan.constructorDeclaration.name.text !== plan.constructorName ||
+    plan.methodName !== "filter" ||
+    plan.arity !== 1 ||
+    ctx.fnctorEscapeGate?.stableArrayPrototypeNames.has(plan.constructorName) !== true
+  ) {
+    throw new IrInvariantError(
+      "selection-preparation-mismatch",
+      "build",
+      "fnctor Array method plan has no exact structural carrier identity",
+    );
+  }
+
+  const globalName = `__mod_${plan.receiverName}`;
+  const observed = ctx.programAbiGlobals?.moduleBinding(plan.receiverDeclaration);
+  let receiverGlobalDef: GlobalDef | undefined;
+  if (ctx.programAbiGlobals) {
+    if (!observed || observed.displayName !== plan.receiverName) {
+      throw new IrInvariantError(
+        "unknown-global-ref",
+        "build",
+        `fnctor Array receiver ${plan.receiverName} has no allocator-owned module global`,
+      );
+    }
+    receiverGlobalDef = observed.value;
+  } else {
+    const globalIdx = ctx.moduleGlobals.get(plan.receiverName);
+    receiverGlobalDef = globalIdx === undefined ? undefined : ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
+  }
+  if (
+    !receiverGlobalDef ||
+    receiverGlobalDef.name !== globalName ||
+    receiverGlobalDef.type.kind !== "externref" ||
+    !receiverGlobalDef.mutable
+  ) {
+    throw new IrInvariantError(
+      "unknown-global-ref",
+      "build",
+      `fnctor Array receiver ${plan.receiverName} is not the legacy externref module slot`,
+    );
+  }
+  const receiverGlobal = irSourceGlobalRef(plan.receiverGlobalBindingId, globalName);
+  planProgramAbiGlobal(ctx, {
+    ref: receiverGlobal,
+    anchor: { kind: "source", sourceId: plan.receiverSourceId },
+    storageOwnerUnitId: plan.receiverStorageOwnerUnitId,
+    roleOrdinal: PROGRAM_ABI_GLOBAL_ROLE.moduleValue,
+    derivedOrdinal: plan.receiverDeclarationOrdinal,
+    global: receiverGlobalDef,
+  });
+
+  const funcName = `__call_m_${plan.methodName}_${plan.arity}`;
+  const dispatcherIdx = ctx.funcMap.get(funcName);
+  const dispatcher = dispatcherIdx === undefined ? undefined : definedFuncAt(ctx, dispatcherIdx);
+  const signature = dispatcher ? ctx.mod.types[dispatcher.typeIdx] : undefined;
+  if (
+    !dispatcher ||
+    dispatcher.name !== funcName ||
+    !signature ||
+    signature.kind !== "func" ||
+    signature.params.length !== 2 ||
+    signature.params.some((param) => param.kind !== "externref") ||
+    signature.results.length !== 1 ||
+    signature.results[0]?.kind !== "externref"
+  ) {
+    throw new IrInvariantError(
+      "abi-type-index-mismatch",
+      "build",
+      `fnctor Array ${plan.receiverName}.${plan.methodName} dispatcher does not have the exact receiver-first externref ABI`,
+    );
+  }
+  return { receiverGlobal, funcName };
+}
+
 function resolveStaticNumericArrayGlobal(
   ctx: CodegenContext,
   plan: IrStaticNumericArrayPlan,
@@ -3975,6 +4062,17 @@ function makeFromAstResolver(
     );
   return {
     ...preparedIrAsyncFromAstResolver(ctx),
+    fnctorArrayMethodPlan(call: ts.CallExpression) {
+      if (
+        !supportsBackendCapability("standalone-native-regexp-test-carrier") ||
+        !supportsBackendCapability("legacy-numeric-array-global") ||
+        !moduleBindingResolver
+      ) {
+        return null;
+      }
+      const plan = moduleBindingResolver.fnctorArrayMethodPlan(call);
+      return plan ? resolveFnctorArrayMethod(ctx, plan) : null;
+    },
     retainedFunctionMethodPlan(call: ts.CallExpression) {
       if (
         !supportsBackendCapability("standalone-native-regexp-test-carrier") ||

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -11,6 +11,8 @@ import { isBoundedPreparedAccessorClass } from "./class-accessor-safety.js";
 import { irModuleGlobalBindingId, irModuleTdzGlobalBindingId } from "./abi-bindings.js";
 import type { IrBindingId, IrClassId, IrSourceId, IrUnitId } from "./identity.js";
 import type { IrClassShape } from "./nodes.js";
+import { makeFnctorArrayMethodPlan, type IrFnctorArrayMethodPlan } from "./fnctor-array-method.js";
+export type { IrFnctorArrayMethodPlan } from "./fnctor-array-method.js";
 import {
   IrPlanningIdentityInvariantError,
   requireIrPlanningOwnerUnitId,
@@ -699,6 +701,8 @@ interface IrModuleBindingResolverSurface<TIdentity, TInspection> {
   readonly staticNumericArrayPlan: (node: ts.Expression) => IrStaticNumericArrayPlan | undefined;
   /** Exact retained function-object method call whose receiver must stay live. */
   readonly retainedFunctionMethodPlan: (call: ts.CallExpression) => IrRetainedFunctionMethodPlan | undefined;
+  /** Exact inherited Array HOF call on a stable user-constructor instance. */
+  readonly fnctorArrayMethodPlan: (call: ts.CallExpression) => IrFnctorArrayMethodPlan | undefined;
   /**
    * Exact top-level function whose complete reference population is
    * fixed-arity `.call(thisArg, ...args)`. Accepts either the declaration or
@@ -731,6 +735,8 @@ export interface IrModuleBindingResolverOptions {
   readonly allowBuiltinMapExtern: boolean;
   /** Provisional selector-only access to the bounded top-level accessor family. */
   readonly allowBoundedTopLevelAccessorSelectionCandidates?: boolean;
+  /** Whole-program fnctor gate proof for one-write intrinsic Array prototypes. */
+  readonly stableFnctorArrayPrototypeNames?: ReadonlySet<string>;
 }
 
 const selectedTopLevelAccessorUnitIdsByContext = new WeakMap<IrPlanningIdentityContext, ReadonlySet<IrUnitId>>();
@@ -2005,6 +2011,13 @@ export function makeIrLegacyModuleBindingResolver(
         return undefined;
       }
     },
+    fnctorArrayMethodPlan(call: ts.CallExpression): IrFnctorArrayMethodPlan | undefined {
+      try {
+        return makeFnctorArrayMethodPlan(checker, call, options.stableFnctorArrayPrototypeNames);
+      } catch {
+        return undefined;
+      }
+    },
     stableFunctionCallPlan(node: ts.FunctionDeclaration | ts.CallExpression): IrStableFunctionCallPlan | undefined {
       if (options.numberStorage !== "f64") return undefined;
       try {
@@ -2219,6 +2232,19 @@ export function makeIrModuleBindingResolver(
         receiverDeclarationOrdinal: receiverLocation.declarationOrdinal,
       };
     },
+    fnctorArrayMethodPlan(call: ts.CallExpression): IrFnctorArrayMethodPlan | undefined {
+      ownerAt(call);
+      const plan = legacy.fnctorArrayMethodPlan(call);
+      if (!plan) return undefined;
+      const receiverLocation = bindingLocation(plan.receiverDeclaration);
+      return {
+        ...plan,
+        receiverGlobalBindingId: receiverLocation.globalBindingId,
+        receiverStorageOwnerUnitId: receiverLocation.storageOwnerUnitId,
+        receiverSourceId: receiverLocation.sourceId,
+        receiverDeclarationOrdinal: receiverLocation.declarationOrdinal,
+      };
+    },
     stableFunctionCallPlan(node: ts.FunctionDeclaration | ts.CallExpression): IrStableFunctionCallPlan | undefined {
       ownerAt(node);
       const plan = legacy.stableFunctionCallPlan(node);
@@ -2284,6 +2310,7 @@ export function projectIrModuleBindingResolverToLegacy(
     staticRegExpTestPlan: (node: ts.Expression) => resolver.staticRegExpTestPlan(node),
     staticNumericArrayPlan: (node: ts.Expression) => resolver.staticNumericArrayPlan(node),
     retainedFunctionMethodPlan: (call: ts.CallExpression) => resolver.retainedFunctionMethodPlan(call),
+    fnctorArrayMethodPlan: (call: ts.CallExpression) => resolver.fnctorArrayMethodPlan(call),
     stableFunctionCallPlan: (node: ts.FunctionDeclaration | ts.CallExpression) => {
       const plan = resolver.stableFunctionCallPlan(node);
       if (!plan) return undefined;

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1813,7 +1813,7 @@ function whyNotIrClaimable(
     dynNames.size > 0 ||
     isDynamicReturn ||
     currentStableFunctionCallSubject !== null ||
-    containsRetainedFunctionMethodCall(body)
+    containsReceiverFirstDynamicMethodCall(body)
   ) {
     const dynamicStringLocals = collectDynamicStringLocalWidening(fn, new Set(dynNames));
     if (!dynamicUsesAreMoveOnly(fn, dynNames, isDynamicReturn, typeMap, dynamicStringLocals)) {
@@ -2313,7 +2313,8 @@ function concreteDynamicAssignmentOperandIsBuildable(candidate: ts.Expression): 
 }
 
 /**
- * True when the current body contains a #3793 retained method call.
+ * True when the current body contains an exact receiver-first dynamic method
+ * call (#3793 retained function object or #4387 inherited Array HOF).
  *
  * Such calls always use the boxed-dynamic closed-dispatch ABI, so they must
  * run through {@link dynamicUsesAreMoveOnly} even when the enclosing
@@ -2321,12 +2322,19 @@ function concreteDynamicAssignmentOperandIsBuildable(candidate: ts.Expression): 
  * result position and every argument bridge before the selector claims the
  * function.
  */
-function containsRetainedFunctionMethodCall(body: ts.Block): boolean {
+function receiverFirstDynamicMethodPlan(call: ts.CallExpression): { readonly arity: number } | undefined {
+  return (
+    currentModuleBindingResolver?.retainedFunctionMethodPlan(call) ??
+    currentModuleBindingResolver?.fnctorArrayMethodPlan(call)
+  );
+}
+
+function containsReceiverFirstDynamicMethodCall(body: ts.Block): boolean {
   let found = false;
   const visit = (node: ts.Node): void => {
     if (found) return;
     if (node !== body && isFunctionLike(node)) return;
-    if (ts.isCallExpression(node) && currentModuleBindingResolver?.retainedFunctionMethodPlan(node) !== undefined) {
+    if (ts.isCallExpression(node) && receiverFirstDynamicMethodPlan(node) !== undefined) {
       found = true;
       return;
     }
@@ -2393,7 +2401,7 @@ function dynamicUsesAreMoveOnly(
     if (
       ts.isCallExpression(e) &&
       ts.isPropertyAccessExpression(e.expression) &&
-      currentModuleBindingResolver?.retainedFunctionMethodPlan(e) !== undefined
+      receiverFirstDynamicMethodPlan(e) !== undefined
     ) {
       return true;
     }
@@ -2473,9 +2481,9 @@ function dynamicUsesAreMoveOnly(
       return dynNames.has(e.text) === expectDyn;
     }
     if (ts.isCallExpression(e)) {
-      const retainedMethod = currentModuleBindingResolver?.retainedFunctionMethodPlan(e);
-      if (retainedMethod !== undefined) {
-        if (!expectDyn || e.arguments.length !== retainedMethod.arity) return false;
+      const receiverFirstMethod = receiverFirstDynamicMethodPlan(e);
+      if (receiverFirstMethod !== undefined) {
+        if (!expectDyn || e.arguments.length !== receiverFirstMethod.arity) return false;
         for (const argument of e.arguments) {
           if (ts.isSpreadElement(argument)) return false;
           const dynamic = isDynShaped(argument);
@@ -6642,8 +6650,8 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         currentSelectionOptions?.supportsBackendCapability?.("standalone-native-regexp-test-carrier") === true &&
         currentSelectionOptions.supportsBackendCapability?.("legacy-numeric-array-global") === true
       ) {
-        const retainedMethod = currentModuleBindingResolver?.retainedFunctionMethodPlan(expr);
-        if (retainedMethod !== undefined) {
+        const receiverFirstMethod = receiverFirstDynamicMethodPlan(expr);
+        if (receiverFirstMethod !== undefined) {
           for (const arg of expr.arguments) {
             if (ts.isSpreadElement(arg) || !isPhase1Expr(arg, scope, localClasses)) return false;
           }

--- a/tests/issue-2660-fnctor-escape-gate.test.ts
+++ b/tests/issue-2660-fnctor-escape-gate.test.ts
@@ -157,3 +157,34 @@ describe("#2660 S1 — fnctor escape/dynamic-use gate (inert analysis)", () => {
     expect(result.approved.size).toBe(1); // only `a`
   });
 });
+
+describe("#4387 — stable Array-valued fnctor prototype proof", () => {
+  it("recognizes one direct top-level intrinsic Array literal assignment", () => {
+    const { sf, checker } = checkerFor(`
+      F.prototype = [1, 2, 3];
+      function F() {}
+      var value: any = new F();
+    `);
+    expect(analyzeFnctorEscapeGate(checker, [sf]).stableArrayPrototypeNames).toEqual(new Set(["F"]));
+  });
+
+  it("declines multiple or computed prototype writes", () => {
+    const { sf, checker } = checkerFor(`
+      F.prototype = [1, 2, 3];
+      F["prototype"] = [4, 5, 6];
+      function F() {}
+      var value: any = new F();
+    `);
+    expect(analyzeFnctorEscapeGate(checker, [sf]).stableArrayPrototypeNames).toEqual(new Set());
+  });
+
+  it("declines constructor aliases outside the closed proof", () => {
+    const { sf, checker } = checkerFor(`
+      F.prototype = [1, 2, 3];
+      function F() {}
+      var Alias = F;
+      var value: any = new Alias();
+    `);
+    expect(analyzeFnctorEscapeGate(checker, [sf]).stableArrayPrototypeNames).toEqual(new Set());
+  });
+});

--- a/tests/issue-4387-fnctor-array-prototype-ir.test.ts
+++ b/tests/issue-4387-fnctor-array-prototype-ir.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    fileName: "issue-4387.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+    deferTopLevelInit: true,
+    experimentalIR: true,
+    trackIrOutcomes: true,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  expect(
+    WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).filter((entry) => entry.module === "env"),
+  ).toEqual([]);
+  return result;
+}
+
+describe("#4387 — Array-valued live fnctor prototype", () => {
+  it("keeps inherited filter callable on the standalone module-init path", async () => {
+    const result = await compileStandalone(`
+      F.prototype = new Array(11, 22, 33);
+      function F() {}
+      var value: any = new F();
+      value.length = false;
+      var filtered: any = value.filter(function () { return true; });
+
+      export function test(): number {
+        return (Array.isArray(filtered) ? 10 : 0) + filtered.length;
+      }
+    `);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    const exports = instance.exports as Record<string, WebAssembly.ExportValue>;
+    (exports.__module_init as () => void)();
+    expect((exports.test as () => number)()).toBe(10);
+  });
+
+  it("routes the inherited filter call inside an IR-owned function", async () => {
+    const result = await compileStandalone(`
+      F.prototype = new Array(11, 22, 33);
+      function F() {}
+      var value: any = new F();
+      value.length = 1;
+
+      export function filterInherited(callback: any): any {
+        return value.filter(callback);
+      }
+
+      export function run(): number {
+        var filtered: any = filterInherited(function (value: number): boolean { return true; });
+        return filtered[0];
+      }
+    `);
+    expect(result.irCompiledFuncs, JSON.stringify(result.irOutcomes, null, 2)).toContain("filterInherited");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    const exports = instance.exports as Record<string, WebAssembly.ExportValue>;
+    (exports.__module_init as () => void)();
+    expect((exports.run as () => number)()).toBe(11);
+  });
+
+  it("does not treat a shadowed Array constructor as the intrinsic", async () => {
+    const result = await compileStandalone(`
+      function Array() {}
+      function F() {}
+      F.prototype = new Array();
+      var value: any = new F();
+
+      export function read(): number {
+        return value.missing === undefined ? 1 : 0;
+      }
+    `);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    const exports = instance.exports as Record<string, WebAssembly.ExportValue>;
+    (exports.__module_init as () => void)();
+    expect((exports.read as () => number)()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve raw fnctor instances when a closed-world proof finds one intrinsic Array prototype assignment
- route exact module-local inherited filter calls through the IR receiver-first dispatcher
- decline aliases, shadowed Array constructors, computed writes, multiple assignments, and ambiguous identities

## Test262 impact

Exact standalone A/B for built-ins/Array/prototype/filter/15.4.4.20-6-{2..8}.js:

- origin/main control: 0/7
- candidate: 7/7

## Verification

- pnpm run typecheck
- pnpm run check:ir-fallbacks
- pnpm run check:loc-budget
- pnpm run check:func-budget
- pnpm run check:issues
- 26 focused tests passed; one pre-existing host-only assertion skipped
- IR test confirms filterInherited is emitted in irCompiledFuncs with no post-claim errors

Repo issue: plan/issues/4387-fnctor-array-prototype-reconstruction-regression.md