### PR TITLE
fix(es5): dispatch under-applied property accessors

### DIFF
--- a/plan/issues/4392-standalone-accessor-underapplication.md
+++ b/plan/issues/4392-standalone-accessor-underapplication.md
@@ -1,0 +1,78 @@
+---
+id: 4392
+title: "Standalone: property accessors with unused trailing parameters never run"
+status: ready
+assignee: ttraenkler/codex-es5-defineproperty
+created: 2026-08-12
+updated: 2026-08-12
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen-standalone
+language_feature: property-descriptors
+goal: es5
+es_edition: 5
+sprint: current
+related: [1888, 2668, 3592]
+---
+
+# #4392 — accessors must tolerate omitted arguments
+
+## Problem
+
+The standalone property runtime invokes a getter through
+`__call_accessor_get -> __call_fn_method_0` and a setter through
+`__call_accessor_set -> __call_fn_method_1`. Those dispatchers contain only
+closures whose declared arity is no greater than the dispatcher arity. As a
+result, a getter that declares an unused parameter, or a setter that declares a
+second unused parameter, does not match any dispatch arm and silently returns
+the fallback value instead of executing.
+
+JavaScript calls are allowed to supply fewer arguments than a function declares;
+the omitted formals receive `undefined`. The generic dynamic-call bridge already
+implements that rule by widening to the closure's declared arity (#3592), but
+the accessor-specific drivers bypass it.
+
+## Confirmed ES5 impact
+
+Fresh standalone `runTest262File` results on `origin/main`
+`a28c6bfcb3df2e61dcfd63a7baddfb0d5d33c711`, using the assembled upstream
+Test262 harness and passing must-pass/must-fail controls:
+
+- `Object/defineProperty/15.2.3.6-4-567.js` — one-parameter getter is not called.
+- `Object/defineProperty/15.2.3.6-4-568.js` — two-parameter getter is not called.
+- `Object/defineProperty/15.2.3.6-4-574.js` — two-parameter setter is not called;
+  after fixing dispatch, its first assignment becomes correct and the test moves
+  to a separate module-global value-widening failure for the omitted second
+  parameter.
+
+The exact ES5 non-pass census contains three files with this source shape. The
+two getter files are wholly explained by this root. The setter file also has
+this root, but fixing it exposes an independent `undefined`-to-f64 storage bug;
+this issue claims the accessor-dispatch behavior and does not overstate that
+second root as fixed.
+
+## Implementation
+
+Make both accessor drivers use the existing `__closure_arity` authority. Seed
+`__argc` with the actual accessor argument count (zero for get, one for set),
+select `__call_fn_method_N` at `max(actual, declared)`, and fill omitted
+arguments with the canonical standalone `undefined` carrier. This keeps
+`arguments.length` at the real call-site count while using the same runtime
+closure dispatch reached by IR `dyn.member_get` / `dyn.member_set`.
+
+## Acceptance
+
+- Both confirmed getter files flip fail -> pass in standalone mode.
+- The confirmed setter file executes its body, observes the assigned first
+  argument, and advances to the separately documented module-global
+  representation failure without being counted as a pass here.
+- Getter/setter calls with exact or lower declared arity remain green.
+- Omitted accessor formals receive `undefined`; `arguments.length` remains 0/1.
+- A tracked compile proves a dynamic member-read consumer is genuinely emitted
+  through IR and reaches the shared native accessor runtime; the same runtime
+  driver also serves legacy member reads and writes.
+- Relevant focused tests, typecheck, format, issue checks, and IR fallback gates
+  pass with no control regression.

--- a/src/codegen/accessor-driver.ts
+++ b/src/codegen/accessor-driver.ts
@@ -36,8 +36,10 @@
  */
 import type { Instr, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { undefinedExternInstrs } from "./any-helpers.js";
 import { addFuncType } from "./registry/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2 read chokepoint / S3b stable-regime minting)
+import { ensureArgcGlobal } from "./statements/nested-declarations.js";
 
 /** Reserved name for the accessor-get driver (arity-0 getter wrapper). */
 export const CALL_ACCESSOR_GET = "__call_accessor_get";
@@ -58,6 +60,83 @@ export const CALL_TO_JSON = "__call_to_json";
  * method wrapper: `replacer.call(holder, key, value)`).
  */
 export const CALL_REPLACER = "__call_replacer";
+
+/**
+ * (#4392) Build an accessor call that tolerates fewer supplied arguments than
+ * the accessor declares. `__call_fn_method_N` only contains closures whose
+ * declared arity is <= N, so a getter with one unused formal cannot be sent to
+ * `__call_fn_method_0` and a two-formal setter cannot be sent to
+ * `__call_fn_method_1`.
+ *
+ * Select the dispatcher at `max(actualArity, declaredArity)`, padding omitted
+ * formals with the canonical undefined carrier. Seed `__argc` with the ACTUAL
+ * accessor argument count before dispatch: the closure-method dispatcher then
+ * preserves `arguments.length` while accepting the padded transport signature.
+ * This mirrors the already-proven generic dynamic-call and host-fnctor-driver
+ * under-application rule (#3592 / #1712).
+ */
+function buildAccessorCall(
+  ctx: CodegenContext,
+  actualArity: 0 | 1,
+  receiverLocal: number,
+  callableLocal: number,
+  argumentLocals: readonly number[],
+): { body: Instr[]; locals: WasmFunction["locals"] } {
+  const closureArityIdx = ctx.funcMap.get("__closure_arity");
+  const argcGlobalIdx = ensureArgcGlobal(ctx);
+  const paramCount = actualArity + 2;
+  const declaredLocal = paramCount;
+
+  const undefinedArg = (): Instr[] =>
+    undefinedExternInstrs(ctx)?.map((instr) => ({ ...instr })) ?? [{ op: "ref.null.extern" }];
+
+  const callAtArity = (dispatchArity: number): Instr[] => {
+    const target = ctx.funcMap.get(`__call_fn_method_${dispatchArity}`);
+    if (target === undefined) return [{ op: "ref.null.extern" }];
+    const call: Instr[] = [
+      { op: "local.get", index: receiverLocal },
+      { op: "local.get", index: callableLocal },
+    ];
+    for (let arg = 0; arg < dispatchArity; arg++) {
+      const local = argumentLocals[arg];
+      call.push(...(local === undefined ? undefinedArg() : [{ op: "local.get", index: local } satisfies Instr]));
+    }
+    call.push({ op: "call", funcIdx: target });
+    return call;
+  };
+
+  // Non-closure callables report -1. Preserve the historical actual-arity
+  // dispatcher for them; its runtime-callable front guard remains authoritative.
+  let dispatch = callAtArity(actualArity);
+  for (let declared = 8; declared > actualArity; declared--) {
+    dispatch = [
+      { op: "local.get", index: declaredLocal },
+      { op: "i32.const", value: declared },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: callAtArity(declared),
+        else: dispatch,
+      },
+    ];
+  }
+
+  if (closureArityIdx === undefined) {
+    return { body: callAtArity(actualArity), locals: [] };
+  }
+  return {
+    locals: [{ name: "__declared_arity", type: { kind: "i32" } }],
+    body: [
+      { op: "i32.const", value: actualArity },
+      { op: "global.set", index: argcGlobalIdx },
+      { op: "local.get", index: callableLocal },
+      { op: "call", funcIdx: closureArityIdx },
+      { op: "local.set", index: declaredLocal },
+      ...dispatch,
+    ],
+  };
+}
 
 /**
  * Reserve the `__call_accessor_get` driver placeholder and return its funcIdx.
@@ -237,15 +316,17 @@ export function reserveReplacerDriver(ctx: CodegenContext): number {
 
 /**
  * Fill the reserved accessor driver bodies in post-processing, AFTER
- * `emitClosureMethodCallExportN(0)` / `(1)` have registered
- * `__call_fn_method_0` / `__call_fn_method_1` in `funcMap`. Each driver is a
- * thin wrapper that forwards to the matching closure-method dispatcher, reusing
- * the proven re-entrancy-safe `__current_this` install/restore (#1636-S1)
- * instead of duplicating funcref-type dispatch inside the object runtime:
+ * `emitClosureMethodCallExportN` and `emitClosureArityExport` have registered
+ * the closure-method dispatchers and declared-arity authority. Each driver
+ * selects a dispatcher wide enough for the accessor closure, reusing the proven
+ * re-entrancy-safe `__current_this` install/restore (#1636-S1) instead of
+ * duplicating funcref-type dispatch inside the object runtime:
  *
- *   __call_accessor_get(recv, getter) = return __call_fn_method_0(recv, getter)
+ *   __call_accessor_get(recv, getter) =
+ *       return __call_fn_method_max(0, getter.length)(recv, getter, undefined...)
  *   __call_accessor_set(recv, setter, value) =
- *       __call_fn_method_1(recv, setter, value)  ; drop result
+ *       __call_fn_method_max(1, setter.length)(recv, setter, value, undefined...)
+ *       ; drop result
  *
  * No-op when the corresponding driver was never reserved (no accessor arm
  * needs it). When the driver WAS reserved but the matching dispatcher was never
@@ -260,21 +341,9 @@ export function fillAccessorDrivers(ctx: CodegenContext): void {
     if (driverIdx !== undefined) {
       const driverFn = definedFuncAt(ctx, driverIdx);
       if (driverFn) {
-        const callMethod0 = ctx.funcMap.get("__call_fn_method_0");
-        if (callMethod0 === undefined) {
-          // No arity-0 closure dispatcher — the getter driver is unreachable
-          // from any live accessor arm in that case (no arity-0 closure ⇒ no
-          // getter closure installed), but keep a valid body so the module
-          // verifies: return undefined (null externref).
-          driverFn.body = [{ op: "ref.null.extern" }];
-        } else {
-          driverFn.body = [
-            { op: "local.get", index: 0 }, // recv (bound as `this`)
-            { op: "local.get", index: 1 }, // getter closure
-            { op: "call", funcIdx: callMethod0 },
-            // getter result (externref) stays on the stack as the return value
-          ];
-        }
+        const call = buildAccessorCall(ctx, 0, 0, 1, []);
+        driverFn.locals = call.locals;
+        driverFn.body = call.body;
       }
     }
   }
@@ -284,22 +353,14 @@ export function fillAccessorDrivers(ctx: CodegenContext): void {
     if (driverIdx !== undefined) {
       const driverFn = definedFuncAt(ctx, driverIdx);
       if (driverFn) {
-        const callMethod1 = ctx.funcMap.get("__call_fn_method_1");
-        if (callMethod1 === undefined) {
-          // No arity-1 closure dispatcher — setter driver unreachable; empty
-          // body (bare return via implicit fallthrough) verifies for () result.
-          driverFn.body = [];
-        } else {
-          driverFn.body = [
-            { op: "local.get", index: 0 }, // recv (bound as `this`)
-            { op: "local.get", index: 1 }, // setter closure
-            { op: "local.get", index: 2 }, // value argument
-            { op: "call", funcIdx: callMethod1 },
-            // __call_fn_method_1 returns an externref result; the setter's
-            // return value is discarded per §10.1.5.3 (Set ignores it).
-            { op: "drop" },
-          ];
-        }
+        const call = buildAccessorCall(ctx, 1, 0, 1, [2]);
+        driverFn.locals = call.locals;
+        driverFn.body = [
+          ...call.body,
+          // The closure-method dispatchers return an externref result; the
+          // setter's return value is discarded per §10.1.5.3.
+          { op: "drop" },
+        ];
       }
     }
   }

--- a/tests/issue-4392-accessor-underapplication.test.ts
+++ b/tests/issue-4392-accessor-underapplication.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+const SOURCE = `
+export function irRead(receiver) {
+  return receiver.value;
+}
+
+export function getterProof() {
+  var receiver = {};
+  Object.defineProperty(receiver, "value", {
+    get: function (unusedA, unusedB) {
+      return arguments.length === 0 && unusedA === undefined && unusedB === undefined ? 42 : -1;
+    }
+  });
+  return irRead(receiver);
+}
+
+export function setterProof() {
+  var receiver = {};
+  var seen = 0;
+  var argc = 0;
+  Object.defineProperty(receiver, "value", {
+    set: function (value, unused) {
+      seen = value;
+      argc = arguments.length;
+    }
+  });
+  receiver.value = 37;
+  return seen === 37 && argc === 1 ? 1 : 0;
+}
+
+export function exactArityControl() {
+  var receiver = {};
+  var seen = 0;
+  Object.defineProperty(receiver, "value", {
+    get: function () { return seen; },
+    set: function (value) { seen = value; }
+  });
+  receiver.value = 19;
+  return receiver.value;
+}
+`;
+
+describe("#4392 standalone property accessor under-application", () => {
+  it("pads omitted accessor formals while preserving the real arguments.length", async () => {
+    const result = await compile(SOURCE, {
+      fileName: "issue-4392-accessor-underapplication.js",
+      target: "standalone",
+      skipSemanticDiagnostics: true,
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs ?? [], JSON.stringify(result.irOutcomes, null, 2)).toContain("irRead");
+
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+    const exports = instance.exports as Record<string, () => number>;
+    expect(exports.getterProof!()).toBe(42);
+    expect(exports.setterProof!()).toBe(1);
+    expect(exports.exactArityControl!()).toBe(19);
+  });
+});


### PR DESCRIPTION
## Summary

- Select standalone property-accessor closure dispatch by declared arity.
- Pad omitted transport formals with the canonical undefined carrier while preserving source `arguments.length`.
- Add focused runtime coverage and a tracked IR dynamic-member-read consumer proof.
- Document the measured scope in `plan/issues/4392-standalone-accessor-underapplication.md`.

## Test262 A/B

Authoritative assembled-harness standalone matrix:

- Before: 0 pass / 8 fail
- After: 2 pass / 6 fail
- Gained: 2
- Lost: 0

The gained tests are `Object/defineProperty/15.2.3.6-4-567.js` and `15.2.3.6-4-568.js`. The related setter case `15.2.3.6-4-574.js` now executes and receives its first argument correctly, then remains red on a separate omitted-undefined module-global representation root; this PR does not claim that adjacent fix.

Must-pass and must-fail harness controls both reported their expected outcomes.

## Validation

- Focused accessor regressions: 17/17 pass
- New changed-root hook: 1/1 pass
- TypeScript typecheck
- Formatting and Biome lint
- LOC and function budgets
- Issue integrity
- IR fallback gate
- Oracle and coercion-site ratchets
- Numeric-local IR parity: 18/18 pass

Commit: `3926ea6a5b2c01cdd9c4b564783460459e88507e`