### PR TITLE
fix(standalone): reify ES5 global function properties

### DIFF
--- a/plan/issues/4390-standalone-global-function-object-properties.md
+++ b/plan/issues/4390-standalone-global-function-object-properties.md
@@ -1,0 +1,101 @@
+---
+id: 4390
+title: "Standalone global object omits ES5 function-valued own properties"
+status: done
+assignee: ttraenkler/codex-es5-global-function-descriptors
+sprint: current
+created: 2026-08-12
+updated: 2026-08-12
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: global-object, property-descriptors, function-objects
+goal: es5
+related: [1462, 2896, 2996, 3053, 4205, 4230]
+loc-budget-allow:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/expressions/identifiers.ts
+func-budget-allow:
+  - src/codegen/expressions/identifiers.ts::compileIdentifierCore
+coercion-sites-allow:
+  - src/codegen/standalone-global-functions.ts
+---
+# #4390 — Standalone global function object properties
+
+## Problem
+
+The native standalone realm object is a real, identity-stable `$Object`, but it
+starts empty. In ES5 Script code this makes both sides of the descriptor value
+check collapse to `undefined`:
+
+```js
+var global = this;
+var desc = Object.getOwnPropertyDescriptor(global, "parseInt");
+desc.value === global.parseInt; // vacuously true: undefined === undefined
+desc.writable;                  // undefined, expected true
+```
+
+All seven ES5 Test262 files
+`built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-{5..11}.js`
+therefore fail on `desc.writable`. The missing property is the root cause, not
+descriptor-field materialisation: the native `__getOwnPropertyDescriptor`
+already returns correct fields for genuine `$Object` entries.
+
+## Scope
+
+Install genuine, identity-stable callable values for the seven assigned ES5
+global function properties on the native realm object:
+
+- `parseInt`, `parseFloat`
+- `isNaN`, `isFinite`
+- `decodeURI`, `decodeURIComponent`, `encodeURIComponent`
+
+Each property is an own data property with attributes
+`{ writable: true, enumerable: false, configurable: true }`. The value must be a
+real callable closure, not a null/undefined carrier that makes identity checks
+pass accidentally. Direct global calls and reads through `globalThis` must
+share the same native implementation and singleton identity.
+
+## IR ownership
+
+The values live on the native realm `$Object` and are read by the shared
+`__extern_get` / `__getOwnPropertyDescriptor` runtime. Prepared IR
+`dyn.member_get` lowers through `__dyn_member_get` to the same runtime read, so
+the regression suite must prove an IR-emitted function observes the seeded
+function value rather than adding a legacy-only AST fold.
+
+## Acceptance criteria
+
+- [x] All seven assigned standalone Test262 files flip fail → pass.
+- [x] The descriptor value is callable and identity-stable across descriptor,
+      `globalThis.<name>`, and repeated dynamic reads.
+- [x] The descriptor attributes are `writable:true`, `enumerable:false`, and
+      `configurable:true`.
+- [x] Different global functions have distinct identities.
+- [x] A prepared-IR function is recorded as emitted and reads the same property
+      through `dyn.member_get` / `__dyn_member_get`.
+- [x] A paired standalone A/B includes both verdict controls and reports all
+      seven rows on both commits.
+
+## Verification
+
+At exact base `a28c6bfcb3df2e61dcfd63a7baddfb0d5d33c711`, the assembled
+standalone harness reported all seven assigned files failing. The candidate
+reported all seven passing: **7 fail → pass, 0 pass → fail**. Seven already
+passing `Object.getOwnPropertyDescriptor` controls remained **7/7 pass** on
+both revisions, and the probe's synthetic must-pass/must-fail verdict controls
+were correct on every run.
+
+The focused Vitest suite passes 9/9 tests. It rejects the historical
+undefined-identity tautology by requiring each descriptor value to be callable,
+invoking all seven functions, checking stable and distinct identities, and
+checking all three descriptor attributes. Its IR proof records
+`readGlobalFunction` as emitted and observes `__dyn_member_get`, `__extern_get`,
+and the native global-function closure in WAT.
+
+Final local gates: `typecheck`, `check:ir-fallbacks`, `check:stack-balance`,
+`check:loc-budget`, `check:func-budget`, and `check:oracle-ratchet` pass.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -65,6 +65,7 @@ import { emitStringSubstringMemberBody } from "./string-proto-substring.js";
 import { emitStringSplitMemberBody } from "./string-proto-split.js"; // (#4220) reflective String.prototype.split
 import { emitStringReplaceMemberBody } from "./string-proto-replace-transfer.js"; // (#4232) reflective String.prototype.replace
 import { NO_ARG_STRING_MEMBER_HELPER, emitStringProtoToStringFlat } from "./string-proto-tostring.js"; // (#3992)
+import { standaloneGlobalFunctionSeedInstrs } from "./standalone-global-functions.js";
 
 /**
  * `Array.prototype`'s own enumerable+non-enumerable method names (ES2024
@@ -2449,9 +2450,6 @@ export function emitGeneratorFunctionPrototypeSingleton(ctx: CodegenContext, fct
  */
 export function emitNativeGlobalThisObject(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
   ensureObjectRuntime(ctx);
-  const newObjectIdx = ctx.funcMap.get("__new_plain_object");
-  if (newObjectIdx === undefined) return null;
-
   const globalName = "__native_globalThis";
   let globalIdx = ctx.builtinObjectGlobals.get(globalName);
   if (globalIdx === undefined) {
@@ -2465,12 +2463,16 @@ export function emitNativeGlobalThisObject(ctx: CodegenContext, fctx: FunctionCo
     ctx.builtinObjectGlobals.set(globalName, globalIdx);
   }
 
-  // Lazy init: `if (global == null) global = __new_plain_object();` then read it.
-  // The init body is nested directly inside the `if` (part of `fctx.body`), so
-  // any later late-import funcIdx shift walks it naturally — no detached-body
-  // (`liveBodies`) registration needed.
+  const objLocal = allocLocal(fctx, `__native_globalThis_obj_${fctx.locals.length}`, { kind: "externref" });
+  const seeds = standaloneGlobalFunctionSeedInstrs(ctx, objLocal);
+  const newObjectIdx = ctx.funcMap.get("__new_plain_object");
+  if (!seeds || newObjectIdx === undefined) return null;
+  // Lazy-init the singleton only after all ES5 function seeds are available.
   const initBody: Instr[] = [
     { op: "call", funcIdx: newObjectIdx },
+    { op: "local.set", index: objLocal },
+    ...seeds,
+    { op: "local.get", index: objLocal },
     { op: "global.set", index: globalIdx },
   ];
   fctx.body.push({ op: "global.get", index: globalIdx });

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -69,6 +69,7 @@ import {
 import { runtimeEvalStateMayShadowBinding } from "../direct-eval-environment.js";
 import { emitStandaloneIntrinsicEvalValue, emitStandaloneIntrinsicFunctionValue } from "./eval-inline.js";
 import { definedFuncAt } from "../func-space.js";
+import { tryEmitStandaloneGlobalFunctionIdentifier } from "../standalone-global-functions.js";
 
 /**
  * #1473 — Build the set of `$Error_struct` `$tag` values compatible with an
@@ -910,6 +911,8 @@ function compileIdentifierCore(
       if (valueType !== undefined) return valueType;
     }
   }
+  const globalFunction = tryEmitStandaloneGlobalFunctionIdentifier(ctx, fctx, name, id);
+  if (globalFunction) return globalFunction;
   if (ctx.sloppyImplicitGlobals?.has(name)) return emitImplicitGlobalRead(ctx, fctx, name);
   // Standalone built-in namespace values (Array/Object) materialize as lazy
   // open-object singletons before ambient lib declarations can route them to

--- a/src/codegen/standalone-global-functions.ts
+++ b/src/codegen/standalone-global-functions.ts
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Native first-class values for the ES5 global function properties.
+ *
+ * Direct calls already have pure-Wasm lowerings, but a value read (`parseInt`
+ * or `globalThis.parseInt`) used to be `undefined` in standalone mode. The
+ * realm `$Object` therefore had no own property for descriptor reflection.
+ * This module reifies the same native entries as identity-stable builtin
+ * closure values and seeds them onto the native global object with the spec
+ * attributes `{ writable:true, enumerable:false, configurable:true }`.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import { ensureBuiltinFnMetaType, pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
+import { getOrCreateFuncRefWrapperTypes } from "./closures.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { emitNativeParseNumber } from "./parse-number-native.js";
+import { addStringConstantGlobal, addUnionImports } from "./registry/imports.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { emitNativeUriDecode, emitNativeUriEncode, URI_DECODE_MASK, URI_ENCODE_MASK } from "./uri-encoding-native.js";
+
+export const STANDALONE_ES5_GLOBAL_FUNCTION_NAMES = [
+  "parseInt",
+  "parseFloat",
+  "isNaN",
+  "isFinite",
+  "decodeURI",
+  "decodeURIComponent",
+  "encodeURIComponent",
+] as const;
+
+export type StandaloneEs5GlobalFunctionName = (typeof STANDALONE_ES5_GLOBAL_FUNCTION_NAMES)[number];
+
+const GLOBAL_FUNCTION_ARITY: Readonly<Record<StandaloneEs5GlobalFunctionName, number>> = Object.freeze({
+  parseInt: 2,
+  parseFloat: 1,
+  isNaN: 1,
+  isFinite: 1,
+  decodeURI: 1,
+  decodeURIComponent: 1,
+  encodeURIComponent: 1,
+});
+
+const GLOBAL_FUNCTION_SET: ReadonlySet<string> = new Set(STANDALONE_ES5_GLOBAL_FUNCTION_NAMES);
+
+export function isStandaloneEs5GlobalFunctionName(name: string): name is StandaloneEs5GlobalFunctionName {
+  return GLOBAL_FUNCTION_SET.has(name);
+}
+
+function makeClosureFctx(name: string, selfType: ValType, paramTypes: ValType[], returnType: ValType): FunctionContext {
+  const fctx: FunctionContext = {
+    name,
+    params: [{ name: "__self", type: selfType }, ...paramTypes.map((type, i) => ({ name: `arg${i}`, type }))],
+    locals: [],
+    localMap: new Map(),
+    returnType,
+    body: [],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  };
+  for (let i = 0; i < fctx.params.length; i++) fctx.localMap.set(fctx.params[i]!.name, i);
+  return fctx;
+}
+
+/** Resolve the ambient parse helper without letting a same-named user binding
+ * in `funcMap` replace the realm builtin. Mirrors import-collector's
+ * shadow-save protocol. */
+function ensureAmbientParseHelper(
+  ctx: CodegenContext,
+  name: "parseInt" | "parseFloat" | "__str_to_number",
+): number | undefined {
+  const ambient = ctx.ambientBuiltinFuncMap.get(name);
+  if (ambient !== undefined) return ambient;
+
+  const shadowed = ctx.funcMap.get(name);
+  if (shadowed !== undefined) ctx.funcMap.delete(name);
+  emitNativeParseNumber(ctx, new Set([name]));
+  const builtin = ctx.funcMap.get(name);
+  if (builtin !== undefined) ctx.ambientBuiltinFuncMap.set(name, builtin);
+  if (shadowed !== undefined) ctx.funcMap.set(name, shadowed);
+  return builtin;
+}
+
+export interface StandaloneGlobalFunctionClosure {
+  readonly type: { kind: "ref"; typeIdx: number };
+  readonly funcIdx: number;
+}
+
+/** Build the genuine callable used by both a bare global-function value read
+ * and the corresponding property on the native realm object. */
+export function ensureStandaloneGlobalFunctionClosure(
+  ctx: CodegenContext,
+  name: StandaloneEs5GlobalFunctionName,
+): StandaloneGlobalFunctionClosure | null {
+  if (!ctx.standalone && !ctx.wasi) return null;
+
+  const arity = GLOBAL_FUNCTION_ARITY[name];
+  const paramTypes = Array.from({ length: arity }, () => ({ kind: "externref" }) as ValType);
+  const returnsBoolean = name === "isNaN" || name === "isFinite";
+  const returnType: ValType =
+    name === "parseInt" || name === "parseFloat"
+      ? { kind: "f64" }
+      : returnsBoolean
+        ? { kind: "i32", boolean: true }
+        : { kind: "externref" };
+
+  // Settle body dependencies before wrapper/function indices are captured.
+  let nativeIdx: number | undefined;
+  if (name === "parseInt" || name === "parseFloat") {
+    nativeIdx = ensureAmbientParseHelper(ctx, name);
+    addUnionImports(ctx);
+  } else if (returnsBoolean) {
+    // Native __unbox_number performs the shared ToNumber conversion, including
+    // native strings when __str_to_number exists before union-helper emission.
+    ensureAmbientParseHelper(ctx, "__str_to_number");
+    addUnionImports(ctx);
+  } else if (name === "decodeURI" || name === "decodeURIComponent") {
+    emitNativeUriDecode(ctx);
+    nativeIdx = ctx.funcMap.get("__uri_decode");
+  } else {
+    emitNativeUriEncode(ctx);
+    nativeIdx = ctx.funcMap.get("__uri_encode");
+  }
+
+  const wrappers = getOrCreateFuncRefWrapperTypes(ctx, paramTypes, [returnType]);
+  if (!wrappers) return null;
+
+  const helperName = `__standalone_global_function_${name}`;
+  let funcIdx = ctx.funcMap.get(helperName);
+  if (funcIdx === undefined) {
+    const selfType: ValType = { kind: "ref", typeIdx: wrappers.liftedSelfTypeIdx };
+    const closureFctx = makeClosureFctx(helperName, selfType, paramTypes, returnType);
+
+    if (name === "parseFloat" && nativeIdx !== undefined) {
+      closureFctx.body.push({ op: "local.get", index: 1 }, { op: "call", funcIdx: nativeIdx });
+    } else if (name === "parseInt" && nativeIdx !== undefined) {
+      const unboxIdx = ctx.funcMap.get("__unbox_number");
+      if (unboxIdx === undefined) return null;
+      closureFctx.body.push(
+        { op: "local.get", index: 1 },
+        { op: "local.get", index: 2 },
+        { op: "call", funcIdx: unboxIdx },
+        { op: "call", funcIdx: nativeIdx },
+      );
+    } else if (returnsBoolean) {
+      const unboxIdx = ctx.funcMap.get("__unbox_number");
+      if (unboxIdx === undefined) return null;
+      const valueLocal = allocLocal(closureFctx, "value", { kind: "f64" });
+      closureFctx.body.push(
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: unboxIdx },
+        { op: "local.set", index: valueLocal },
+        { op: "local.get", index: valueLocal },
+        { op: "local.get", index: valueLocal },
+        { op: name === "isNaN" ? "f64.ne" : "f64.sub" },
+      );
+      if (name === "isFinite") {
+        closureFctx.body.push({ op: "f64.const", value: 0 }, { op: "f64.eq" });
+      }
+    } else if (nativeIdx !== undefined) {
+      // __extern_toString is the shared standalone ToString boundary. The URI
+      // helpers then receive the same native-string carrier as direct calls.
+      const toStringIdx = ctx.funcMap.get("__extern_toString");
+      if (toStringIdx === undefined) return null;
+      const mask = name === "encodeURIComponent" ? URI_ENCODE_MASK[name] : URI_DECODE_MASK[name];
+      closureFctx.body.push(
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: toStringIdx },
+        { op: "i32.const", value: mask },
+        { op: "call", funcIdx: nativeIdx },
+      );
+    } else {
+      return null;
+    }
+
+    funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, {
+      name: helperName,
+      typeIdx: wrappers.liftedFuncTypeIdx,
+      locals: closureFctx.locals,
+      body: closureFctx.body,
+      exported: false,
+    });
+    ctx.funcMap.set(helperName, funcIdx);
+  }
+
+  const metaTypeIdx = ensureBuiltinFnMetaType(
+    ctx,
+    wrappers.structTypeIdx,
+    wrappers.closureInfo,
+    `global:${name}`,
+    name,
+    arity,
+  );
+  return { type: { kind: "ref", typeIdx: metaTypeIdx }, funcIdx };
+}
+
+export function emitStandaloneGlobalFunctionValue(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  name: StandaloneEs5GlobalFunctionName,
+): ValType | null {
+  const closure = ensureStandaloneGlobalFunctionClosure(ctx, name);
+  if (!closure) return null;
+  fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, closure));
+  return closure.type;
+}
+
+export function tryEmitStandaloneGlobalFunctionIdentifier(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  name: string,
+  node: Parameters<CodegenContext["oracle"]["valueDeclarationOf"]>[0],
+): ValType | null {
+  if (!ctx.standalone || !isStandaloneEs5GlobalFunctionName(name)) return null;
+  const declaration = ctx.oracle.valueDeclarationOf(node);
+  if (declaration !== undefined && !declaration.getSourceFile().isDeclarationFile) return null;
+  return emitStandaloneGlobalFunctionValue(ctx, fctx, name);
+}
+
+/** Build the one-time seeds for the native realm object in `objectLocal`. */
+export function standaloneGlobalFunctionSeedInstrs(ctx: CodegenContext, objectLocal: number): Instr[] | null {
+  if (!ctx.standalone && !ctx.wasi) return [];
+
+  // Settle every possible late import before capturing any function index in
+  // the detached initialization body returned below.
+  for (const name of STANDALONE_ES5_GLOBAL_FUNCTION_NAMES) {
+    if (!ensureStandaloneGlobalFunctionClosure(ctx, name)) return null;
+  }
+  const closures = new Map<StandaloneEs5GlobalFunctionName, StandaloneGlobalFunctionClosure>();
+  for (const name of STANDALONE_ES5_GLOBAL_FUNCTION_NAMES) {
+    const closure = ensureStandaloneGlobalFunctionClosure(ctx, name);
+    if (!closure) return null;
+    closures.set(name, closure);
+  }
+
+  const defineIdx = ctx.funcMap.get("__defineProperty_value");
+  if (defineIdx === undefined) return null;
+  const body: Instr[] = [];
+
+  for (const name of STANDALONE_ES5_GLOBAL_FUNCTION_NAMES) {
+    const closure = closures.get(name)!;
+    body.push({ op: "local.get", index: objectLocal });
+    addStringConstantGlobal(ctx, name);
+    body.push(...stringConstantExternrefInstrs(ctx, name));
+    body.push(...pushBuiltinFnSingletonValueInstrs(ctx, closure), { op: "extern.convert_any" });
+    // Host flag bits: writable=1, enumerable=2, configurable=4.
+    body.push({ op: "f64.const", value: 0x05 }, { op: "call", funcIdx: defineIdx }, { op: "drop" });
+  }
+  return body;
+}

--- a/tests/issue-4390-global-function-descriptors.test.ts
+++ b/tests/issue-4390-global-function-descriptors.test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    fileName: "issue-4390-global-functions.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+    trackIrOutcomes: true,
+    emitWat: true,
+  });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const module = await WebAssembly.compile(result.binary);
+  expect(WebAssembly.Module.imports(module)).toEqual([]);
+  const instance = await WebAssembly.instantiate(module, {});
+  return { result, exports: instance.exports as Record<string, Function> };
+}
+
+describe("#4390 standalone ES5 global function properties", () => {
+  it("materializes genuine callable descriptor values with stable identities", async () => {
+    const { exports } = await compileStandalone(`
+function descriptorIsCorrect(name: any): boolean {
+  const d: any = Object.getOwnPropertyDescriptor(globalThis, name);
+  return typeof d.value === "function" &&
+    d.value === globalThis[name] &&
+    d.writable === true &&
+    d.enumerable === false &&
+    d.configurable === true;
+}
+export function test(): number {
+  let mask = 0;
+  if (descriptorIsCorrect("parseInt")) mask += 1;
+  if (descriptorIsCorrect("parseFloat")) mask += 2;
+  if (descriptorIsCorrect("isNaN")) mask += 4;
+  if (descriptorIsCorrect("isFinite")) mask += 8;
+  if (descriptorIsCorrect("decodeURI")) mask += 16;
+  if (descriptorIsCorrect("decodeURIComponent")) mask += 32;
+  if (descriptorIsCorrect("encodeURIComponent")) mask += 64;
+
+  const parseInteger: any = globalThis.parseInt;
+  const parseDecimal: any = globalThis.parseFloat;
+  const nanPredicate: any = globalThis.isNaN;
+  const finitePredicate: any = globalThis.isFinite;
+  const decodeWhole: any = globalThis.decodeURI;
+  const decodeComponent: any = globalThis.decodeURIComponent;
+  const encodeComponent: any = globalThis.encodeURIComponent;
+  if (parseInteger === globalThis.parseInt && parseInteger === parseInt && parseInteger !== parseDecimal) mask += 128;
+  if (parseInteger("42", 10) === 42 && parseDecimal("3.5") === 3.5) mask += 256;
+  if (nanPredicate(NaN) && !nanPredicate(1) && finitePredicate(1) && !finitePredicate(Infinity)) mask += 512;
+  if (
+    encodeComponent("a b") === "a%20b" &&
+    decodeWhole("a%20b") === "a b" &&
+    decodeComponent("a%20b") === "a b"
+  ) mask += 1024;
+  return mask;
+}
+`);
+
+    expect(exports.test()).toBe(2047);
+  });
+
+  it("is observable through an IR-emitted dyn.member_get consumer", async () => {
+    const { result } = await compileStandalone(`
+export function readGlobalFunction(receiver: any): any {
+  return receiver.parseInt;
+}
+export function descriptorValue(): any {
+  return Object.getOwnPropertyDescriptor(globalThis, "parseInt").value;
+}
+`);
+
+    expect(
+      result.irOutcomes?.find((outcome) => outcome.displayName === "readGlobalFunction"),
+      JSON.stringify(result.irOutcomes),
+    ).toMatchObject({ kind: "emitted", irBodyEmitted: true, stage: "patch" });
+    expect(result.wat).toContain("__dyn_member_get");
+    expect(result.wat).toContain("__extern_get");
+    expect(result.wat).toContain("__standalone_global_function_parseInt");
+  });
+
+  const test262Cases = [5, 6, 7, 8, 9, 10, 11].map(
+    (suffix) => `built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-${suffix}.js`,
+  );
+  for (const relative of test262Cases) {
+    it(`passes ${relative} in the assembled standalone harness`, async () => {
+      const result = await runTest262File(resolve("test262/test", relative), "issue-4390", 120_000, "standalone");
+      expect(result.status, result.reason ?? result.error).toBe("pass");
+    }, 130_000);
+  }
+});


### PR DESCRIPTION
## Summary

- install genuine callable, identity-stable values for seven ES5 global function properties on the standalone realm object
- reuse the shared native parse, numeric coercion, and URI implementations
- expose the same singleton identity to bare identifier reads and IR/runtime property reads
- record the root cause, exact A/B evidence, and structural gate allowances in repository plan issue 4390

## Root cause

The native standalone realm object existed but started empty. Descriptor tests compared undefined to undefined and then failed on the absent writable/configurable attributes. This change seeds real own data properties instead of accepting that identity tautology.

## Test262 impact

- assigned Object.getOwnPropertyDescriptor cases: 0/7 pass to 7/7 pass
- net: +7, with 0 losses
- same-directory controls: 7/7 pass before and after
- harness must-pass/must-fail controls: correct on both arms

## IR proof

The focused regression records the dynamic member reader as IR-emitted and verifies the generated WAT contains the dynamic member/runtime property path and native global-function closure.

## Validation

- focused Vitest suite: 9/9 pass
- typecheck
- IR fallback gate
- stack-balance gate
- LOC and function budgets
- oracle and coercion-site ratchets
- pre-commit and pre-push hooks
