### PR TITLE
docs(#4157): __extern_get decomposed 73/27; helper-level acorn work closed out, one lever specced

### DIFF
--- a/plan/agent-context/session-2026-08-07-acorn-perf-handoff.md
+++ b/plan/agent-context/session-2026-08-07-acorn-perf-handoff.md
@@ -238,3 +238,92 @@ What finally converged it, named independently by both lanes:
 verified pre-existing by swapping base blobs. See #3552 for why CI does not
 surface these, and its still-open follow-up: detection exists (`issue-tests.yml`
 post-merge), nothing consumes it.
+
+---
+
+# Update — 2026-08-12
+
+**The allocation program described above is finished, and the picture has
+changed.** Full detail is in #4157 under the four `2026-08-12` headings; this is
+the short version so the next lane knows what is still true.
+
+**Standing: still ~7× on `standalone-dynamic`.** The wins landed, but they moved
+GC, not the total.
+
+## What changed
+
+| bucket | 08-07 | 08-12 |
+| --- | ---: | ---: |
+| gc-engine | 23.1 % | **2.97 %** |
+| dynamic-lookup | 13.5 % | **21.15 %** |
+| call-dispatch | 8.1 % | **11.39 %** |
+
+GC went from largest bucket to ninth. `__extern_get` (9.22 %) is now the hottest
+frame in the profile — ahead of every compiled acorn function. The two buckets
+this handoff flagged as "untouched by anything" are now 32.5 % together, and are
+the whole remaining addressable story. Of the 100.3 ms gap in the 08-08
+cross-runtime table, ~9 ms is closed; helpers with no Node counterpart carry
+about 55 % of what remains.
+
+## Do NOT re-attempt (two more nulls, same helper)
+
+The exhaustion list above grows by two, and this pair is stronger than the
+others because they attack from opposite ends and both land on zero:
+
+| lever | result |
+| --- | --- |
+| skip the declared-field ladder for plain-`$Object` receivers | null, ±0.3 pp |
+| abstract-`eq` casts instead of RTT casts on the cache hit path | null, ±0.5 pp |
+
+The first removed **14,770 instructions** of provably-dead work from the miss
+path; the second removed two RTT checks from the hit path and shrank the binary.
+Neither moved the bucket. **`__extern_get`'s 9 % is not made of instructions
+removable from inside it** — at 21.7 ns / ~45 cycles per call, what is left is
+call overhead, the props-array pointer chase, and branch behaviour. Do not spend
+another A/B cycle on the body.
+
+Both experiments are written up in #4157 in enough detail to rebuild; neither is
+in the tree.
+
+## The one thing that is priced above the measurement floor
+
+**Site- or name-local inline caching — remove the CALL, not the work inside it.**
+
+The numbers that make it the only live candidate:
+
+- **506,752 `__extern_get` calls per parse**, **87.24 % served from the existing
+  per-key cache** (#3673). First time that cache has been measured.
+- Thrash (populated but owner/props missed) is only **3.77 %**, so "make the
+  cache smarter" — N-way, shape-keyed — is priced out too.
+- Serving 87 % of half a million calls from ~10 inline instructions instead of a
+  call plus ~40 is worth **on the order of 5 % of runtime**.
+- **1,812 static call sites**, but the top **15 callers carry 90.6 %** of the
+  time — so inline at the hot callers, not everywhere (all 1,812 would cost
+  roughly +40 KB). The selection rule must be corpus-independent for the same
+  reason #3927's field ranking had to be.
+
+What it needs: an entry-returning form of `__extern_get` (caching the *value* is
+unsound — in-place value updates must stay visible, which is why the existing
+cache stores the `$PropEntry`), per-name cache globals, and correct fallback for
+accessor / tombstone / non-`$Object` receivers. Note the hot acorn names
+(`locations`, `ranges`, `ecmaVersion`, `onToken`) get **no**
+`__get_member_<name>` dispatcher today because no closed struct carries them —
+which is exactly the condition for emitting a direct `__extern_get` call, so the
+slice has to widen dispatcher reservation as well.
+
+## Instrument note
+
+**`JS2WASM_ALLOC_CENSUS_CALLS` is broken** — it instruments, then emits a module
+that fails to compile with a stack-type error at an instrumented call. It fails
+loudly rather than miscounting, but per-caller attribution is unavailable, and
+that is the instrument the slice above wants for verifying its caller targeting.
+The per-type census (`JS2WASM_ALLOC_CENSUS=1`) is unaffected. Not filed as its
+own issue: `claim-issue.mjs --allocate` reports the open-PR scan DEGRADED in this
+container (no `gh`), and reserving against a degraded universe is how #4215 was
+burned.
+
+## Still true from above
+
+`#3920` (the `in`-operator / enumeration defect) and the known-red root tests are
+unchanged. Wall-clock A/Bs under ~10 % remain unresolvable on this box — every
+number here is bucket share with order-reversal controls.

--- a/plan/issues/4157-close-the-acorn-node-performance-gap.md
+++ b/plan/issues/4157-close-the-acorn-node-performance-gap.md
@@ -1186,3 +1186,55 @@ slice needs to verify its caller targeting. The per-type census
 Not filed as its own issue: `claim-issue.mjs --allocate` reports the open-PR scan
 DEGRADED in this container (no `gh`), and reserving an id against a degraded
 universe is how #4215 was burned. It should get one when allocation is healthy.
+
+## 2026-08-12 (4) — second null on the same helper: instruction-shaving `__extern_get` is exhausted
+
+A second, independent attempt at `__extern_get`, aimed at the **hit** path this
+time (the previous one only ever reached the 12.76 % that miss).
+
+Two of the ~40 instructions on the hit path are `ref.cast`s that exist **only**
+to make an `anyref` cache field acceptable to `ref.eq` — nothing downstream
+reads a field off either result. Replacing them with the abstract
+`ref.cast_null (ref null eq)` is strictly safe in the direction that matters:
+`ref.eq` is identity, so a value that is not the owner cannot compare equal, and
+a mismatch that used to trap simply misses the cache and takes the slow path.
+The build is **14 bytes smaller** and checksum 422 holds.
+
+Order-reversed **ON → OFF → OFF → ON**:
+
+| block | order | `__extern_get` self | dynamic-lookup |
+| --- | --- | ---: | ---: |
+| onA | 1 | 9.24 % | 20.96 % |
+| offA | 2 | 9.23 % | 21.50 % |
+| offB | 3 | 8.85 % | 20.52 % |
+| onB | 4 | 9.75 % | 20.76 % |
+
+Mean 9.50 % ON vs 9.04 % OFF — trending the *wrong* way, with the ON blocks
+scattering 0.51 pp and the OFF blocks 0.38 pp. This run was noisier than the
+morning's (whose ON blocks replicated to 0.11 pp), so the honest bound here is
+about **±0.5 pp**: null. Reverted, for the same reason as the screen — no
+measured benefit, and the concrete cast at least documents the invariant that
+the cached owner really is a `$Object`.
+
+### What two nulls in a row establish
+
+The first attempt removed 14,770 instructions of provably-dead ladder from the
+miss path. The second removed two RTT checks from the hit path. Neither moved
+the bucket. Taken together they say the same thing:
+
+**`__extern_get`'s 9 % is not made of instructions that can be removed from
+inside it.** At 21.7 ns / ~45 cycles per call it is already tight; what is left
+is call overhead, the pointer-chase through the props array, and branch
+behaviour — none of which shrinks by editing the body. Micro-optimisation of
+this helper is **exhausted at this box's ±0.3–0.5 pp resolution**, and future
+lanes should not spend another A/B cycle on it.
+
+That does **not** retire the bucket — it retires one approach to it. Dynamic
+lookup is still ~25 ms/parse and the largest addressable line in the gap. The
+lever is the one already named above: **remove the CALL**, via site- or
+name-local inline caching, which is a structural change to how reads are emitted
+rather than an edit to the helper. It remains unbuilt, and it is now the only
+priced candidate in this issue above the measurement floor.
+
+Both reverted experiments are described here in enough detail to rebuild without
+rediscovering them; neither is in the tree.

--- a/plan/issues/4157-close-the-acorn-node-performance-gap.md
+++ b/plan/issues/4157-close-the-acorn-node-performance-gap.md
@@ -1238,3 +1238,92 @@ priced candidate in this issue above the measurement floor.
 
 Both reverted experiments are described here in enough detail to rebuild without
 rediscovering them; neither is in the tree.
+
+## 2026-08-12 (5) — call dispatch (11.39 %) opened for the first time, and it has ONE root cause worth fixing
+
+Nothing in this umbrella had ever looked inside the second-largest helper bucket.
+Doing so found a single defect that explains three separate things, and it is a
+**correctness** bug with a performance unlock behind it — not a speculative
+optimisation.
+
+### The bucket
+
+| frame family | self % | what it is |
+| --- | ---: | --- |
+| `__call_fn_method_{0,1,7}` | 3.37 % | generic closure-call trampolines by arity |
+| `__dc_Parser_<method>_<arity>[_g]` | **≈ 4.09 %** | #3683 S3 devirtualised direct-call trampolines |
+| `__call_m_<name>_<arity>` | ≈ 1.6 % | method-call dispatchers |
+| `__builtinfn_get_meta` | 0.54 % | builtin-fn metadata |
+| `__named_this_call_*` | 0.54 % | named-`this` call bridge |
+
+**Self time in a trampoline is pure overhead** — a trampoline exists to adapt a
+call, so every cycle in it is a cycle not spent on the callee's work. The
+`__dc_*` family alone is ~4 % of total runtime, spread across ~25 tiny functions.
+
+### The root cause
+
+`typed-this.ts`'s ABI note (the "why the RECEIVER parameter is `externref`, not
+`(ref $__fnctor_F)`" block) documents exactly why that overhead exists. The
+natural signature — receiver already in a typed register at every call site —
+**cannot be used** because of a latent imprecision in `applyRefNullFixups`
+(`src/codegen/fixups.ts`, the backward walk near the end): from a `call`, it
+walks backwards mapping **one instruction per parameter**, special-casing only
+`local.tee`, `struct.new`, `array.new_fixed` and nested `call`. Any argument
+produced by a sequence it does not special-case desynchronises the walk and
+lands a `ref.null.extern` rewrite on the wrong parameter.
+
+So `__dc_*` pays, per the note, "one `extern.convert_any` per call site and one
+`any.convert_extern; ref.cast` per trampoline" purely to keep its signature
+outside the hazard. The note calls that cost "trivial against the bridge being
+removed" — **which was right about the bridge and wrong about the cost**: the
+profile now puts the family at ~4 %.
+
+### The census defect is NOT diagnosed — an earlier draft of this entry got it wrong
+
+A first pass at this write-up asserted that the broken `JS2WASM_ALLOC_CENSUS_CALLS`
+recorded in entry (3) is the **same** walk. That claim does not survive checking
+and is withdrawn:
+
+- The walk's only mutation is `ref.null.extern` → `ref.null <typeIdx>`. It cannot
+  produce the observed error, `call[1] expected type f64, found local.get of type
+  i32` — that says an **i32 local** sits at a parameter expecting **f64**, which
+  is an argument-position shift, not a retyped null.
+- The census splice itself is stack-neutral by inspection: `incrementInstrs` is
+  `global.get` / `i32.const 1` / `i32.add` / `global.set` (net 0), inserted
+  immediately before the `call`, i.e. after every argument is already on the
+  stack. That alone should not desynchronise anything.
+
+So the census defect stands as an **undiagnosed** bug (entry 3), not as evidence
+for this one. Recording the disproof because the wrong version is the more
+attractive story — one root cause explaining two symptoms — and the next lane
+should not inherit it.
+
+The `__dc_*` finding below does **not** depend on it. That one rests on quoted
+source, not inference: `typed-this.ts`'s ABI note states the constraint and names
+the fixup itself.
+
+### Why the fix is tractable
+
+`fixups.ts` **already contains a real stack model**: `instrPopsPushes(instr, mod)`
+(same file, ~line 842) returns exact `{pops, pushes}` for locals, struct/array
+producers, `call` / `call_ref` / `call_indirect` and structured blocks, and
+**returns `null` — refuse to model — for anything unrecognised**. The backward
+walk simply does not use it. Rewriting the walk to accumulate stack effect via
+`instrPopsPushes`, and to leave the fixup unapplied whenever it answers `null`,
+replaces the "one instruction per argument" approximation with the operand-count
+model the ABI note says is missing, and keeps the conservative behaviour on
+anything it cannot model.
+
+The note declined this on the grounds that a shared fixup "would need a real
+operand-count model (and whose current approximations other lowerings may depend
+on)". Half of that objection is now answered — the model exists. The other half
+is real and is what makes this a change needing broad test coverage rather than a
+quick edit: it must be validated against every lowering that reaches the fixup,
+which this container cannot do (the full equivalence suite OOMs here).
+
+**This is the recommended next slice, ahead of the inline-cache one named in
+entry (2).** It is smaller, it is a correctness fix rather than an optimisation,
+and the typed-receiver ABI it enables is worth a cast per call on ~4 % of
+runtime. Its acceptance test is a `__dc_*` trampoline reserved with a
+`(ref $__fnctor_F)` receiver that validates — the case the ABI note says fails
+today with `call[1] expected type externref`.


### PR DESCRIPTION
## Description

Docs-only follow-up to #4424. Seven commits, two `.md` files, no `src/` change — every experiment below was built, measured, and reverted.

**Superseded description:** this PR originally covered three commits. It now carries the whole session, including a **retraction of one of its own original claims** (§4).

### 1. Five measured attempts on `__extern_get`, and what they add up to

| # | attempt | result |
| --- | --- | --- |
| 1 | skip the declared-field ladder for plain-`$Object` receivers (in #4424) | **null**, ±0.3 pp |
| 2 | abstract-`eq` casts instead of RTT casts on the hit path | **null**, ±0.5 pp |
| 3 | outline the cold path so `wasm-opt` can inline the rest | **net null**, −0.13 pp |

Each was order-reversed ON/OFF/OFF/ON on `standalone-dynamic`, checksum 422 held throughout, and each is written up in enough detail to rebuild.

### 2. The result that pays for the other two

Attempt 3 is a bad optimisation and a good instrument. Splitting `__extern_get` at the cache arm decomposes it for the first time:

| half | self % | share |
| --- | ---: | ---: |
| cache-hit prologue | **6.38 %** | **73 %** |
| entire cold path — 15,032-instruction ladder, own-property walk, proto walk | 2.20 % | 27 % |

`__extern_get` alone fell 8.71 % → 6.38 % with both ON blocks cleanly below both OFF blocks — the only real separation of the session. But the 2.2 pp reappeared in `__extern_get_cold`: relocation, not saving, and only the **bucket total** exposed that. `wasm-opt` declined to inline the prologue because I had sized it wrong — "four instructions" was four *top-level* ones, one an `if` carrying ~45.

This retroactively explains attempts 1 and 2: **attempt 1 optimised the 27 %, attempt 2 shaved two instructions off a path that is ~45.** Neither could have worked.

Also first-measured here: the per-key cache (#3673) runs at **87.24 % of 506,752 calls per parse**, with 3.77 % thrash — which prices out "make the cache smarter" as well.

### 3. Levers priced out without building

| lever | verdict |
| --- | --- |
| smarter per-key cache | thrash is only 3.77 % |
| rewrite the `applyRefNullFixups` walk | 1.36 % of calls, nearly all in dead code |
| typed-receiver `__dc_*` ABI | ≈ 0.6 %, below floor |

The typed-receiver entry also records a **soundness fact**: guarded `__dc_*_g` trampolines *cannot* take a typed receiver. Their `ref.test` exists because the receiver's shape is a whole-program inference; a typed parameter would force the call site to cast, reintroducing exactly the trap the guard prevents.

### 4. Retraction of this PR's own §2 (as originally filed)

The original §2 said the `__dc_*` trampolines are stuck on an `externref` ABI because `applyRefNullFixups` walks backwards one instruction per parameter, and prescribed rewriting that walk. **The rewrite already exists.** #4077 added `locateCallArgProducers`, an exact *forward* stack model; the backward walk is only its fallback, and the ABI note in `typed-this.ts` predates it. Measured: **48,670 calls modelled exactly, 672 (1.36 %) falling through**, and the abandons are on terminators (`return` 5,812, `throw` 4,316, `br` 1,445) after which the code is unreachable.

Left as a written retraction rather than silently amended. The **~4 % self-time figure stands** — that came from the profile; only the diagnosis was wrong.

### 5. Where this leaves acorn

Helper-level work is finished. The 2026-08-08 cross-runtime table already gave the floor: Node spends 92.9 % of its parse inside acorn's own code, this build 37.1 %; removing **every** helper, GC and regexp millisecond still leaves ≈ **3.0×**. That residue is register allocation, inlining and IC-class work on emitted code — which nothing in #4157 targets.

One lever survives above the measurement floor: **call-site inline caching**, now aimed at the 6.38 pp prologue. §10 of the issue is its executable spec — verified insertion point (`fillMemberGetDispatch`, per-name rather than per-site), the full instruction sequence with field indices checked against source, the required widening of dispatcher reservation, and the four traps this session paid for once each.

### Verification

- prettier clean; `git diff --stat origin/main...HEAD -- src/ tests/ scripts/ .github/ benchmarks/` is empty.
- Every experiment checksum-verified at 422 before being reverted; none is in the tree.

## CLA

- [x] I have read and agree to the CLA