### PR TITLE
fix(array): materialize externref map receivers

### DIFF
--- a/plan/issues/4370-object-keys-any-map-host-array-cast.md
+++ b/plan/issues/4370-object-keys-any-map-host-array-cast.md
@@ -1,0 +1,81 @@
+---
+id: 4370
+title: "codegen: materialize externref array receivers for Array.prototype.map"
+status: in-progress
+sprint: current
+created: 2026-08-11
+updated: 2026-08-11
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: arrays
+goal: dogfood
+related: [3996, 4301]
+loc-budget-allow:
+  - src/codegen/array-methods.ts
+func-budget-allow:
+  - src/codegen/array-methods.ts::compileArrayMethodCall
+  - src/codegen/array-methods.ts::compileArrayMap
+---
+
+# codegen: materialize externref array receivers for Array.prototype.map
+
+## Problem
+
+The JS-host `Object.keys(any)` path returns a real JavaScript array as
+`externref`. TypeScript still describes that expression as `string[]`, so
+`compileArrayMethodCall` selects the native WasmGC array-map loop. The receiver
+probe correctly records `receiverIsExternref`, but the `map` arm does not pass
+that fact to `setupArrayLoop`. The loop therefore emits an unconditional
+`ref.cast` from the host array to the compiler's native vec and traps with
+`RuntimeError: illegal cast` before invoking the callback.
+
+Minimal reproducer:
+
+```ts
+export function runCase() {
+  const method = "GET";
+  const routes: any = { GET: { a: 1, b: 2 } };
+  return Object.keys(routes[method]).map((key) => key).length;
+}
+```
+
+This is Hono 4.12.16's `RegExpRouter.#buildMatcher` shape. After #4301 fixes
+the preceding class-expression private receiver mismatch, Hono compiles and
+validates but traps in the callback containing
+`Object.keys(r[method]).map(...)`.
+
+## Ownership
+
+The externref-to-vec materialization already exists in `setupArrayLoop` and was
+introduced with the Redux work recorded by #3996. `filter` and `forEach` thread
+the receiver flag into that helper; `map` is the missing sibling. Issue #3996
+does not describe or own this residual, so #4370 owns the narrow map routing
+gap rather than reopening the unrelated local-index work.
+
+## Acceptance criteria
+
+- `Object.keys(any).map(...)` materializes the externref receiver once instead
+  of casting the host array directly to a WasmGC vec.
+- A runtime differential covers the dynamic computed-key reducer in both
+  JS-host and standalone modes, including mapped values rather than only
+  `.length`.
+- Existing native-vec `map`, `filter`, and `forEach` paths remain green.
+- The pinned Hono workload advances past the `__closure_156` illegal cast; any
+  next independent failure is reported separately.
+- Typecheck, IR-fallback, LOC, and function-budget gates pass.
+
+## Implementation result
+
+`compileArrayMethodCall` now threads the probed `receiverIsExternref` fact into
+`compileArrayMap`, which delegates to the existing one-time
+externref-to-native-vec materialization in `setupArrayLoop`. Runtime
+differentials cover both the minimized computed-key case and Hono's exact
+mapped `[path, route]` tuple shape in JS-host and zero-import standalone modes.
+
+The pinned Hono workload no longer traps in `__closure_156`. It compiles and
+validates, then advances to the independent router-state failure
+`No active router has been determined yet.`

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -1728,7 +1728,7 @@ export function compileArrayMethodCall(
         elemType.kind === "externref" ||
         elemType.kind === "ref" ||
         elemType.kind === "ref_null"
-          ? compileArrayMap(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType)
+          ? compileArrayMap(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType, receiverIsExternref)
           : undefined;
       break;
     case "reduce":
@@ -5914,6 +5914,7 @@ function compileArrayMap(
   vecTypeIdx: number,
   arrTypeIdx: number,
   elemType: ValType,
+  receiverIsExternref = false,
 ): ValType | null {
   // ES spec: throw TypeError if callback is not a function
   if (emitCallbackTypeCheck(ctx, fctx, callExpr, "Array.prototype.map")) {
@@ -5971,7 +5972,7 @@ function compileArrayMap(
   // callback), unchanged from pre-S2. The other skip methods
   // (forEach/filter/some/every/reduce/indexOf/lastIndexOf) are hole-correct.
 
-  const loop = setupArrayLoop(ctx, fctx, propAccess, vecTypeIdx, arrTypeIdx, elemType, "map");
+  const loop = setupArrayLoop(ctx, fctx, propAccess, vecTypeIdx, arrTypeIdx, elemType, "map", receiverIsExternref);
 
   const resData = allocLocal(fctx, `__arr_map_rd_${fctx.locals.length}`, { kind: "ref_null", typeIdx: mapArrTypeIdx });
 

--- a/tests/issue-4370-object-keys-any-map-host-array-cast.test.ts
+++ b/tests/issue-4370-object-keys-any-map-host-array-cast.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+type Target = "gc" | "standalone";
+
+async function run(source: string, target: Target): Promise<number> {
+  const result = await compile(source, {
+    fileName: "issue-4370.ts",
+    platform: "node",
+    skipSemanticDiagnostics: true,
+    target,
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  const module = new WebAssembly.Module(result.binary);
+
+  let instance: WebAssembly.Instance;
+  if (target === "standalone") {
+    expect(result.imports).toEqual([]);
+    instance = await WebAssembly.instantiate(module, {});
+  } else {
+    const imports = buildImports(result.imports, undefined, result.stringPool);
+    instance = await WebAssembly.instantiate(module, imports);
+    imports.setInstance?.(instance);
+  }
+  return (instance.exports.runCase as () => number)();
+}
+
+describe.each<Target>(["gc", "standalone"])("#4370 Object.keys(any).map [%s]", (target) => {
+  it("materializes the dynamic Object.keys result and preserves mapped values", async () => {
+    const actual = await run(
+      `
+        export function runCase() {
+          const method = "GET";
+          const routes: any = { GET: { a: 3, bb: 4 } };
+          const mapped = Object.keys(routes[method]).map(
+            (path) => path.length * 10 + routes[method][path]
+          );
+          return mapped[0] * 100 + mapped[1];
+        }
+      `,
+      target,
+    );
+    const routes = { GET: { a: 3, bb: 4 } };
+    const method = "GET";
+    const mapped = Object.keys(routes[method]).map((path) => path.length * 10 + routes[method][path]);
+    expect(actual).toBe(mapped[0]! * 100 + mapped[1]!);
+  });
+
+  it("covers Hono's mapped path/value tuple shape", async () => {
+    const actual = await run(
+      `
+        export function runCase() {
+          const method = "GET";
+          const routes: any = { GET: { alpha: 7, b: 9 } };
+          const ownRoute = routes[method]
+            ? Object.keys(routes[method]).map((path) => [path, routes[method][path]])
+            : [];
+          return ownRoute.length * 100 + ownRoute[0][0].length * 10 + ownRoute[1][1];
+        }
+      `,
+      target,
+    );
+    const routes = { GET: { alpha: 7, b: 9 } };
+    const method = "GET";
+    const ownRoute = Object.keys(routes[method]).map((path) => [path, routes[method][path]] as const);
+    expect(actual).toBe(ownRoute.length * 100 + ownRoute[0]![0].length * 10 + ownRoute[1]![1]);
+  });
+
+  it("keeps native typed-array map behavior unchanged", async () => {
+    expect(
+      await run(
+        `
+          export function runCase() {
+            const mapped = [1, 2, 3].map((value) => value * 4);
+            return mapped[0] * 100 + mapped[1] * 10 + mapped[2];
+          }
+        `,
+        target,
+      ),
+    ).toBe(492);
+  });
+});


### PR DESCRIPTION
## Summary

- materialize host-owned `Object.keys(any)` arrays before the native `Array.prototype.map` loop
- preserve mapped values for computed Hono route tables in both JS-host and standalone Wasm
- document the next independent Hono router-state blocker without claiming the full workload passes

## Measured result

- focused runtime differentials: 6/6 pass across JS-host and zero-import standalone
- adjacent functional Array methods: 24/24 pass; the dedicated fast `map` control also passes
- pinned Hono 4.12.16 package: compiles a 367,190-byte binary in 3.48 s and validates
- workload advances from `RuntimeError: illegal cast` to `No active router has been determined yet`
- runtime correctness remains unverified until that later router blocker is fixed

## Validation

- `pnpm exec vitest run tests/issue-4370-object-keys-any-map-host-array-cast.test.ts tests/issue-4301-class-expression-private-receiver.test.ts tests/fast-arrays.test.ts tests/functional-array-methods.test.ts` (48/49; the existing `Array.find` semantic-diagnostic test is unrelated, while all changed-path tests pass)
- `pnpm run typecheck`
- `node --import tsx scripts/check-ir-fallbacks.ts`
- `pnpm run check:loc-budget`
- targeted Prettier check

Plan issue: [#4370](https://github.com/loopdive/js2wasm/blob/codex/4370-hono-array-receiver/plan/issues/4370-object-keys-any-map-host-array-cast.md)
