### PR TITLE
feat(ir): finalize forward class field layouts

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -4,7 +4,7 @@ title: "IR-only R3: compile-once classes, members, and closures"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-08-12
+updated: 2026-08-13
 priority: critical
 horizon: xl
 complexity: XL
@@ -42,6 +42,7 @@ files:
   - src/ir/prepared-component-sealing.ts
   - src/codegen/class-bodies.ts
   - src/codegen/class-callable-abi.ts
+  - src/codegen/class-field-layout.ts
   - src/codegen/function-body.ts
   - src/codegen/class-constructor-wrapper.ts
   - src/codegen/closures.ts
@@ -1046,6 +1047,63 @@ new regressions** (twelve stale baseline entries now pass but are deliberately
 not mixed into this PR). Cross-backend differential is **29/29**. Typecheck,
 lint, formatting, issue/optimization-retirement integrity, oracle separation,
 IR adoption, verdict-oracle, LOC, and function-budget gates also pass.
+
+### Forward class-field layout checkpoint (2026-08-13)
+
+Exact forward class references now cross the physical storage boundary before
+any source body emits. Class collection still reserves structs in source order,
+so `Holder.current: Value` is initially an `externref` slot when `Value` is
+declared later. The new post-collection `class-field-layout.ts` phase resolves
+the exact declaration through the Type Oracle and mutates that already-observed
+field in place to `(ref null $Value)` before callable finalization and class
+shape planning. It does not pre-reserve or reorder types, and it does not
+replace the `StructTypeDef` object held by the Program ABI type cell.
+
+This checkpoint is deliberately bounded to explicit identifier/private fields
+on unique, flat, top-level classes in one source. The reference must be a bare,
+non-generic `TypeReferenceNode` to a later unique local class, and the complete
+field dependency graph must be acyclic. Classes participating in inheritance,
+recursive/self layouts, nested/class-expression owners, optional/union/generic
+annotations, constructor-only inferred fields, and externref-backed targets
+remain on the typed direct route. Multi-source finalization remains R5 work.
+
+The primary `Holder -> Value` fixture now gives all four source bodies
+(`Holder_new`, `Holder_replace`, `Value_new`, and `run`) one prepared IR owner in
+WasmGC and standalone under both direct-class and direct-function poison. It
+validates and returns `25`, and the committed field plus constructor assignment,
+method read/write, and constructing caller contain no `externref` conversion,
+cast/test, or indirect-call traffic. Separate parity controls prove:
+
+- an initialized `current: Value = new Value(2)` retains the established typed
+  instance-field initialization optimization and per-instance behavior;
+- multiple public/private fields retain their exact shared target layout;
+- an adjacent default-parameter method can remain a typed direct fallback while
+  consuming the same finalized physical field ABI; and
+- mutual field recursion and any inheritance participant remain direct, with
+  the unresolved forward slot still physically `externref`.
+
+The exact A/B driver runs the same allocation, field replacement, and two field
+reads per iteration. Three repeated local measurements produced identical
+artifact sizes and correct checksums:
+
+| Target | Direct binary | Prepared IR binary | Delta | Direct median | Prepared median |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| WasmGC | 2,836 bytes | 1,292 bytes | -1,544 bytes (-54.4%) | 3.318-3.684 us | 0.010-0.011 us |
+| standalone | 47,714 bytes | 21,531 bytes | -26,183 bytes (-54.9%) | 0.011-0.012 us | 0.010-0.011 us |
+
+The WasmGC direct lane's host-carrier path explains its much larger runtime
+gap; the relevant retirement requirement is satisfied in both targets: prepared
+IR is no larger and no slower than direct. A forward field forms a valid WasmGC
+recursive group spanning the owner-to-target type interval; binary validation,
+exact WAT assertions, and the artifact reduction guard that representation
+effect. The direct-only lane is unchanged and remains the A/B control.
+
+No shared legacy implementation is deleted here. The same direct layout/body
+code still has live consumers in every excluded family, and deleting it would
+violate the retirement rule. The next serial R3 transaction is immutable
+recursive class-layout cells for self and mutually recursive class fields;
+after that, extend the same proof to inheritance participants before nested and
+multi-source owners.
 
 ## Exhaustive source-unit census
 

--- a/src/codegen/class-field-layout.ts
+++ b/src/codegen/class-field-layout.ts
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Pre-emission finalization for exact forward class-field layouts.
+ *
+ * Class collection reserves structs in source order. A field on an earlier
+ * class that names a later local class is therefore provisionally collected as
+ * `externref`. Prepared IR must see the final storage ABI before it can decide
+ * that the direct class-body emitter will never run.
+ */
+import { ts } from "../ts-api.js";
+import type { FieldDef, StructTypeDef } from "../ir/types.js";
+import { ProgramAbiInvariantError } from "../ir/program-abi.js";
+import type { CodegenContext } from "./context/types.js";
+
+function hasStaticModifier(node: ts.Node & { readonly modifiers?: ts.NodeArray<ts.ModifierLike> }): boolean {
+  return node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword) === true;
+}
+
+function fixedFieldName(name: ts.PropertyName): string | undefined {
+  if (ts.isIdentifier(name)) return name.text;
+  if (ts.isPrivateIdentifier(name)) return `__priv_${name.text.slice(1)}`;
+  return undefined;
+}
+
+function isFlatClass(declaration: ts.ClassDeclaration): boolean {
+  return declaration.heritageClauses === undefined || declaration.heritageClauses.length === 0;
+}
+
+function exactLocalClassReference(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  typeNode: ts.TypeNode | undefined,
+): ts.ClassDeclaration | undefined {
+  const identity = ctx.irPlanningIdentityContext;
+  if (
+    !identity ||
+    !typeNode ||
+    !ts.isTypeReferenceNode(typeNode) ||
+    !ts.isIdentifier(typeNode.typeName) ||
+    (typeNode.typeArguments?.length ?? 0) !== 0
+  ) {
+    return undefined;
+  }
+  const declarations = ctx.oracle.declarationsOf(typeNode.typeName);
+  if (declarations.length !== 1) return undefined;
+  const declaration = declarations[0];
+  if (!declaration || !ts.isClassDeclaration(declaration) || !declaration.name || declaration.parent !== sourceFile) {
+    return undefined;
+  }
+  const classId = identity.classIdByDeclaration.get(declaration);
+  return classId !== undefined && identity.declarationByClassId.get(classId) === declaration ? declaration : undefined;
+}
+
+function fieldDependencies(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  declarations: readonly ts.ClassDeclaration[],
+): ReadonlyMap<ts.ClassDeclaration, ReadonlySet<ts.ClassDeclaration>> {
+  const local = new Set(declarations);
+  const dependencies = new Map<ts.ClassDeclaration, ReadonlySet<ts.ClassDeclaration>>();
+  for (const declaration of declarations) {
+    const required = new Set<ts.ClassDeclaration>();
+    for (const member of declaration.members) {
+      if (!ts.isPropertyDeclaration(member) || hasStaticModifier(member) || fixedFieldName(member.name) === undefined) {
+        continue;
+      }
+      const target = exactLocalClassReference(ctx, sourceFile, member.type);
+      if (target && local.has(target)) required.add(target);
+    }
+    dependencies.set(declaration, required);
+  }
+  return dependencies;
+}
+
+function inheritanceParticipants(
+  ctx: CodegenContext,
+  declarations: readonly ts.ClassDeclaration[],
+): ReadonlySet<ts.ClassDeclaration> {
+  const local = new Set(declarations);
+  const participants = new Set<ts.ClassDeclaration>();
+  for (const declaration of declarations) {
+    for (const clause of declaration.heritageClauses ?? []) {
+      if (clause.token !== ts.SyntaxKind.ExtendsKeyword) continue;
+      participants.add(declaration);
+      for (const inherited of clause.types) {
+        const parents = ctx.oracle.declarationsOf(inherited.expression);
+        if (parents.length !== 1) continue;
+        const parent = parents[0];
+        if (parent && ts.isClassDeclaration(parent) && local.has(parent)) participants.add(parent);
+      }
+    }
+  }
+  return participants;
+}
+
+function reachesClass(
+  dependencies: ReadonlyMap<ts.ClassDeclaration, ReadonlySet<ts.ClassDeclaration>>,
+  start: ts.ClassDeclaration,
+  expected: ts.ClassDeclaration,
+  visited = new Set<ts.ClassDeclaration>(),
+): boolean {
+  if (start === expected) return true;
+  if (visited.has(start)) return false;
+  visited.add(start);
+  for (const dependency of dependencies.get(start) ?? []) {
+    if (reachesClass(dependencies, dependency, expected, visited)) return true;
+  }
+  return false;
+}
+
+function requireCommittedField(
+  ctx: CodegenContext,
+  declaration: ts.ClassDeclaration,
+  fieldName: string,
+): FieldDef | undefined {
+  const className = declaration.name!.text;
+  const typeIdx = ctx.structMap.get(className);
+  const type = typeIdx === undefined ? undefined : ctx.mod.types[typeIdx];
+  const fields = ctx.structFields.get(className);
+  if (!type || type.kind !== "struct" || !fields || type.fields !== fields) {
+    throw new ProgramAbiInvariantError(
+      "type-remap-mismatch",
+      `forward field ${className}.${fieldName} has no exact committed class layout`,
+    );
+  }
+  const field = fields.find((candidate) => candidate.name === fieldName);
+  if (field && !type.fields.includes(field)) {
+    throw new ProgramAbiInvariantError(
+      "type-remap-mismatch",
+      `forward field ${className}.${fieldName} is detached from its observed class layout`,
+    );
+  }
+  return field;
+}
+
+/**
+ * Commit exact, acyclic references from flat top-level fields to later local
+ * classes without replacing an observed StructTypeDef or changing type order.
+ *
+ * Recursive, inherited, nested, generic, union, optional, inferred, and
+ * externref-backed layouts deliberately remain on the typed direct route.
+ */
+export function finalizeForwardClassFieldLayouts(ctx: CodegenContext, sourceFile: ts.SourceFile): void {
+  if (!ctx.irPlanningIdentityContext) return;
+  const declarations = sourceFile.statements.filter(
+    (statement): statement is ts.ClassDeclaration => ts.isClassDeclaration(statement) && statement.name !== undefined,
+  );
+  const nameCounts = new Map<string, number>();
+  for (const declaration of declarations) {
+    const name = declaration.name!.text;
+    nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
+  }
+  const dependencies = fieldDependencies(ctx, sourceFile, declarations);
+  const inherited = inheritanceParticipants(ctx, declarations);
+
+  for (const owner of declarations) {
+    const ownerName = owner.name!.text;
+    if (
+      !isFlatClass(owner) ||
+      inherited.has(owner) ||
+      nameCounts.get(ownerName) !== 1 ||
+      ctx.classExternrefBackedSet.has(ownerName)
+    ) {
+      continue;
+    }
+    const fieldNameCounts = new Map<string, number>();
+    for (const member of owner.members) {
+      if (!ts.isPropertyDeclaration(member) || hasStaticModifier(member)) continue;
+      const name = fixedFieldName(member.name);
+      if (name !== undefined) fieldNameCounts.set(name, (fieldNameCounts.get(name) ?? 0) + 1);
+    }
+
+    for (const member of owner.members) {
+      if (!ts.isPropertyDeclaration(member) || hasStaticModifier(member)) continue;
+      const fieldName = fixedFieldName(member.name);
+      const target = exactLocalClassReference(ctx, sourceFile, member.type);
+      if (
+        fieldName === undefined ||
+        fieldNameCounts.get(fieldName) !== 1 ||
+        !target?.name ||
+        target.getStart(sourceFile) <= owner.getStart(sourceFile) ||
+        !isFlatClass(target) ||
+        inherited.has(target) ||
+        nameCounts.get(target.name.text) !== 1 ||
+        ctx.classExternrefBackedSet.has(target.name.text) ||
+        reachesClass(dependencies, target, owner)
+      ) {
+        continue;
+      }
+      const targetTypeIdx = ctx.structMap.get(target.name.text);
+      if (targetTypeIdx === undefined) continue;
+      const targetType = ctx.mod.types[targetTypeIdx];
+      if (!targetType || targetType.kind !== "struct" || targetType.name !== target.name.text) continue;
+
+      const field = requireCommittedField(ctx, owner, fieldName);
+      if (field?.type.kind !== "externref") continue;
+      field.type = { kind: "ref_null", typeIdx: targetTypeIdx };
+    }
+  }
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -347,6 +347,7 @@ import {
   resolveClassMemberName,
 } from "./class-bodies.js";
 import { finalizeForwardClassCallableAbis } from "./class-callable-abi.js";
+import { finalizeForwardClassFieldLayouts } from "./class-field-layout.js";
 import { classMemberFuncKey, fnctorAncestorOfClass, moduleHasFnctorSubclass } from "./class-member-keys.js"; // (#1983 / #3123)
 import {
   applyShapeInference,
@@ -4557,6 +4558,10 @@ export function generateModule(
     scanForArrayHoles(ctx, ast.sourceFile);
 
     collectDeclarations(ctx, ast.sourceFile);
+    // #3522 R3: exact fields that reference a later local class are collected
+    // provisionally as externref. Finalize their already-observed storage slot
+    // in place before class-shape planning snapshots the Program ABI layout.
+    finalizeForwardClassFieldLayouts(ctx, ast.sourceFile);
     // #3522 R3: callable slots with exact references to a later local class
     // must receive their final struct ABI before prepared IR planning decides
     // which direct bodies will never run. The direct body compiler retains its

--- a/tests/issue-3522-ir-class-compile-once.test.ts
+++ b/tests/issue-3522-ir-class-compile-once.test.ts
@@ -15,6 +15,14 @@ function classMemberOutcome(result: CompileResult, name: string): IrObservedOutc
   return observed[0]!;
 }
 
+function functionOutcome(result: CompileResult, name: string): IrObservedOutcome {
+  const observed = (result.irOutcomes ?? []).filter(
+    (candidate) => candidate.unitKind === "function" && candidate.displayName === name,
+  );
+  expect(observed, `terminal outcome count for ${name}`).toHaveLength(1);
+  return observed[0]!;
+}
+
 async function instantiate(result: CompileResult, deps?: Record<string, unknown>): Promise<Record<string, Function>> {
   const imports = buildImports(result.imports, deps, result.stringPool);
   const { instance } = await WebAssembly.instantiate(result.binary, imports);
@@ -847,50 +855,299 @@ describe("#3522 instance class-method compile-once ownership", () => {
   );
 
   it.each(["gc", "standalone"] as const)(
-    "keeps a forward class field direct while its committed storage ABI is externref in the %s lane",
+    "commits an exact forward class field before prepared bodies in the %s lane",
     async (target) => {
       const source = `
         class Holder {
           current: Value;
           constructor(current: Value) { this.current = current; }
+          replace(next: Value): Value {
+            const previous = this.current;
+            this.current = next;
+            return previous;
+          }
         }
+        class Value {
+          amount: number;
+          constructor(amount: number) { this.amount = amount; }
+        }
+        export function run(): number {
+          const holder = new Holder(new Value(2));
+          const previous = holder.replace(new Value(5));
+          return previous.amount * 10 + holder.current.amount;
+        }
+      `;
+      const direct = await compile(source, {
+        fileName: `forward-class-field-abi-${target}.ts`,
+        experimentalIR: false,
+        emitWat: true,
+        target,
+      });
+      const previousClassPoison = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      const previousFunctionPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Holder_new,Holder_replace,Value_new";
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+        prepared = await compile(source, {
+          fileName: `forward-class-field-abi-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          emitWat: true,
+          target,
+        });
+      } finally {
+        if (previousClassPoison === undefined) {
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        } else {
+          process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClassPoison;
+        }
+        if (previousFunctionPoison === undefined) {
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        } else {
+          process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunctionPoison;
+        }
+      }
+
+      for (const result of [direct, prepared]) {
+        expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(result.binary)).toBe(true);
+        expect((await instantiate(result)).run!()).toBe(25);
+      }
+      for (const name of ["Holder_new", "Holder_replace", "Value_new"]) {
+        expect(classMemberOutcome(prepared, name)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+      }
+      expect(functionOutcome(prepared, "run")).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.binary.length).toBeLessThanOrEqual(direct.binary.length);
+      expect(watTypeDefinition(direct.wat, "Holder")).toContain("(field $current (mut externref))");
+
+      const valueTypeIdx = watNullableRefResultTypeIndex(watFunctionBody(prepared.wat, "Value_new"), "Value_new");
+      expect(watTypeDefinition(prepared.wat, "Holder")).toContain(`(field $current (mut (ref null ${valueTypeIdx})))`);
+      for (const name of ["Holder_init", "Holder_replace", "run"]) {
+        expect(watFunctionBody(prepared.wat, name)).not.toMatch(
+          /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.(?:test|cast)/,
+        );
+      }
+    },
+  );
+
+  it.each(["gc", "standalone"] as const)(
+    "preserves typed forward-field initialization without a direct body in the %s lane",
+    async (target) => {
+      const source = `
+        class Holder {
+          current: Value = new Value(2);
+          read(): number { return this.current.amount; }
+        }
+        class Value {
+          amount: number;
+          constructor(amount: number) { this.amount = amount; }
+        }
+        export function run(): number {
+          const holder = new Holder();
+          const before = holder.read();
+          holder.current = new Value(5);
+          return before * 10 + holder.read();
+        }
+      `;
+      const previousClassPoison = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      const previousFunctionPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Holder_new,Holder_read,Value_new";
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+        prepared = await compile(source, {
+          fileName: `forward-class-field-initializer-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          emitWat: true,
+          target,
+        });
+      } finally {
+        if (previousClassPoison === undefined) {
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        } else {
+          process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClassPoison;
+        }
+        if (previousFunctionPoison === undefined) {
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        } else {
+          process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunctionPoison;
+        }
+      }
+
+      expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(prepared.binary)).toBe(true);
+      expect((await instantiate(prepared)).run!()).toBe(25);
+      for (const name of ["Holder_new", "Holder_read", "Value_new"]) {
+        expect(classMemberOutcome(prepared, name)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+      }
+      expect(functionOutcome(prepared, "run")).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      const valueTypeIdx = watNullableRefResultTypeIndex(watFunctionBody(prepared.wat, "Value_new"), "Value_new");
+      expect(watTypeDefinition(prepared.wat, "Holder")).toContain(`(field $current (mut (ref null ${valueTypeIdx})))`);
+      for (const name of ["Holder_init", "Holder_read", "run"]) {
+        expect(watFunctionBody(prepared.wat, name)).not.toMatch(
+          /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.(?:test|cast)/,
+        );
+      }
+    },
+  );
+
+  it.each(["gc", "standalone"] as const)(
+    "keeps multiple public and private forward fields on exact storage in the %s lane",
+    async (target) => {
+      const source = `
+        class Holder {
+          first: Value;
+          #second: Value;
+          constructor(first: Value, second: Value) {
+            this.first = first;
+            this.#second = second;
+          }
+          total(): number { return this.first.amount + this.#second.amount; }
+        }
+        class Value {
+          amount: number;
+          constructor(amount: number) { this.amount = amount; }
+        }
+        export function run(): number { return new Holder(new Value(2), new Value(5)).total(); }
+      `;
+      const previousClassPoison = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      const previousFunctionPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Holder_new,Holder_total,Value_new";
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+        prepared = await compile(source, {
+          fileName: `forward-class-private-fields-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          emitWat: true,
+          target,
+        });
+      } finally {
+        if (previousClassPoison === undefined) {
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        } else {
+          process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClassPoison;
+        }
+        if (previousFunctionPoison === undefined) {
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        } else {
+          process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunctionPoison;
+        }
+      }
+
+      expect(prepared.success, prepared.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(prepared.binary)).toBe(true);
+      expect((await instantiate(prepared)).run!()).toBe(7);
+      for (const name of ["Holder_new", "Holder_total", "Value_new"]) {
+        expect(classMemberOutcome(prepared, name)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+      }
+      expect(functionOutcome(prepared, "run")).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+      });
+      const valueTypeIdx = watNullableRefResultTypeIndex(watFunctionBody(prepared.wat, "Value_new"), "Value_new");
+      const holderType = watTypeDefinition(prepared.wat, "Holder");
+      expect(holderType).toContain(`(field $first (mut (ref null ${valueTypeIdx})))`);
+      expect(holderType).toContain(`(field $__priv_second (mut (ref null ${valueTypeIdx})))`);
+      expect(watFunctionBody(prepared.wat, "Holder_total")).not.toMatch(
+        /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.(?:test|cast)/,
+      );
+    },
+  );
+
+  it.each(["gc", "standalone"] as const)(
+    "shares the finalized forward-field ABI with an adjacent typed direct fallback in the %s lane",
+    async (target) => {
+      const source = `
+        class Holder {
+          current: Value;
+          constructor(current: Value) { this.current = current; }
+          read(extra: number = 0): number { return this.current.amount + extra; }
+        }
+        class Value {
+          amount: number;
+          constructor(amount: number) { this.amount = amount; }
+        }
+        export function run(): number { return new Holder(new Value(40)).read(2); }
+      `;
+      const result = await compile(source, {
+        fileName: `forward-class-field-hybrid-${target}.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        emitWat: true,
+        target,
+      });
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(result.binary)).toBe(true);
+      expect((await instantiate(result)).run!()).toBe(42);
+      expect(classMemberOutcome(result, "Holder_read")).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      const valueTypeIdx = watNullableRefResultTypeIndex(watFunctionBody(result.wat, "Value_new"), "Value_new");
+      expect(watTypeDefinition(result.wat, "Holder")).toContain(`(field $current (mut (ref null ${valueTypeIdx})))`);
+      expect(watFunctionBody(result.wat, "Holder_read")).toContain("struct.get");
+      expect(watFunctionBody(result.wat, "Holder_read")).not.toContain("__extern_get");
+    },
+  );
+
+  it.each(["gc", "standalone"] as const)(
+    "keeps forward-field inheritance outside this layout checkpoint in the %s lane",
+    async (target) => {
+      const source = `
+        class Base {
+          current: Value;
+          constructor(current: Value) { this.current = current; }
+        }
+        class Child extends Base {}
         class Value { amount: number; }
         export function marker(): number { return 1; }
       `;
-      const previous = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
-      try {
-        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
-        const direct = await compile(source, {
-          fileName: `forward-class-field-abi-${target}.ts`,
-          experimentalIR: true,
-          trackIrOutcomes: true,
-          target,
-        });
-        expect(direct.success, direct.errors.map((error) => error.message).join("\n")).toBe(true);
-        expect(WebAssembly.validate(direct.binary)).toBe(true);
-        expect(classMemberOutcome(direct, "Holder_new")).toMatchObject({
-          kind: "unsupported",
-          stage: "select",
-          legacyBodyEmitted: true,
-          irBodyEmitted: false,
-        });
-        expect(direct.irPostClaimErrors ?? []).toEqual([]);
+      const result = await compile(source, {
+        fileName: `forward-class-field-inheritance-${target}.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        emitWat: true,
+        target,
+      });
 
-        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Holder_new";
-        const poisoned = await compile(source, {
-          fileName: `forward-class-field-abi-${target}.ts`,
-          experimentalIR: true,
-          trackIrOutcomes: true,
-          target,
-        });
-        expect(poisoned.success).toBe(false);
-        expect(
-          poisoned.errors.some((error) => error.message.includes("injected direct class-body poison: Holder_new")),
-        ).toBe(true);
-      } finally {
-        if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
-        else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previous;
-      }
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(result.binary)).toBe(true);
+      expect(classMemberOutcome(result, "Base_new")).toMatchObject({
+        kind: "unsupported",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(watTypeDefinition(result.wat, "Base")).toContain("(field $current (mut externref))");
+      expect(watTypeDefinition(result.wat, "Child")).toContain("(field $current (mut externref))");
     },
   );
 
@@ -898,8 +1155,14 @@ describe("#3522 instance class-method compile-once ownership", () => {
     "keeps cyclic class ABIs on one typed direct path in the %s lane",
     async (target) => {
       const source = `
-        class Left { constructor(right: Right) {} }
-        class Right { constructor(left: Left) {} }
+        class Left {
+          right: Right;
+          constructor(right: Right) { this.right = right; }
+        }
+        class Right {
+          left: Left;
+          constructor(left: Left) { this.left = left; }
+        }
         export function marker(): number { return 1; }
       `;
       const previous = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
@@ -909,6 +1172,7 @@ describe("#3522 instance class-method compile-once ownership", () => {
           fileName: `cyclic-class-constructor-abi-${target}.ts`,
           experimentalIR: true,
           trackIrOutcomes: true,
+          emitWat: true,
           target,
         });
         expect(direct.success, direct.errors.map((error) => error.message).join("\n")).toBe(true);
@@ -922,6 +1186,7 @@ describe("#3522 instance class-method compile-once ownership", () => {
           });
         }
         expect(direct.irPostClaimErrors ?? []).toEqual([]);
+        expect(watTypeDefinition(direct.wat, "Left")).toContain("(field $right (mut externref))");
 
         process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Left_new,Right_new";
         const poisoned = await compile(source, {


### PR DESCRIPTION
## Summary

- finalize exact, acyclic forward class-field layouts after declaration collection and before Program ABI shape planning
- preserve the observed StructTypeDef/type-cell identity while changing only the committed field carrier from externref to (ref null $Target)
- keep recursive, inherited, nested, generic, multi-source, and externref-backed layouts fail-closed for the next serial slices
- update plan/issues/3522-ir-r3-classes-closures-compile-once.md with the measured boundary and recursive-layout handoff

## Optimization parity

The prepared path preserves constructor assignment, instance-field initialization, public/private struct fields, exact typed field reads/writes, and hybrid direct-fallback compatibility. The positive WAT rejects externref conversions, casts/tests, and indirect calls.

Paired exact-driver artifacts:

| Target | Direct | Prepared IR | Delta |
| --- | ---: | ---: | ---: |
| WasmGC | 2,836 bytes | 1,292 bytes | -54.4% |
| standalone | 47,714 bytes | 21,531 bytes | -54.9% |

Prepared IR was no slower in three repeated local runs.

## Validation

- focused R2/R3 matrix: 124/124
- class checkpoint: 40/40
- hybrid shadow: 37/37 IR, 0 legacy, 0 Unsupported, 0 Invariant
- IR-only shadow: 37/37 IR, 0 legacy, 0 Unsupported, 0 Invariant
- fallback + shape gate: zero unintended, post-claim, or module-level increases
- equivalence: all 8 shards, zero new regressions
- cross-backend differential: 29/29
- typecheck, changed-file lint, formatting, oracle, issue, optimization-retirement, LOC, and function-budget gates

## Retirement boundary

No shared legacy implementation is deleted in this checkpoint because excluded recursive/inherited/nested/multi-source consumers remain. The next production slice adds immutable recursive class-layout cells, then inheritance parity. Work is tracked in plan/issues/3522-ir-r3-classes-closures-compile-once.md, not GitHub Issues.

## CLA

- [x] I have read and agree to the CLA