### PR TITLE
docs(es5): include dynamic semantics in completion scope

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -42,7 +42,7 @@ Team setup/budget/spawn/comms: **`plan/method/team-setup.md`**. Agent defs: **`.
 - project_test262_lane_parity_program · project_acorn_dogfood_regression_20260723
 - project_bigint_i64_brand_gate · project_linear_backend_no_console_log · project_proxy_no_ts_type_brand · project_1917_coercion_engine_byte_diff_gate · project_2106_undefined_singleton_s1_atomic
 - project_2602_forawait_rest_aliases_source_recompile · project_2602_forof_assign_rest_write_unimplemented
-- [es5-standalone-goal-ex-dynamic-code](project_es5_standalone_goal_restated_ex_dynamic_code.md) — goal restated 2026-08-01: ~95.4% ES5+untagged standalone **EX-DYNAMIC-CODE**; the 317 dynamic-code files are OUT OF SCOPE, not failures
+- [es5-full-scope-including-dynamic-code](project_es5_standalone_goal_restated_ex_dynamic_code.md) — current 2026-08-13 ruling: 100% of all 9,029 ES5-and-earlier tests in both lanes; `eval`, `Function`, and `with` are IN SCOPE
 
 ### Team & agents
 

--- a/.claude/memory/project_es5_standalone_goal_restated_ex_dynamic_code.md
+++ b/.claude/memory/project_es5_standalone_goal_restated_ex_dynamic_code.md
@@ -1,60 +1,51 @@
 ---
 name: project_es5_standalone_goal_restated_ex_dynamic_code
-description: "Project-lead ruling 2026-08-01: the ES5+untagged standalone goal is ~95.4% EX-DYNAMIC-CODE, not 100%. The 317 dynamic-code files are out of scope, not failures."
-metadata: 
+description: "Superseded boundary: as of 2026-08-13 the ES5 test262 goal is 100% in both host and standalone, including eval, Function, and with."
+metadata:
   node_type: memory
   type: project
   originSessionId: 31a336a9-7fce-4c41-9a15-3e10d02eca44
-  modified: 2026-08-01T20:54:07.705Z
+  modified: 2026-08-13T00:00:00.000Z
 ---
 
-**Stakeholder ruling, project lead, 2026-08-01 — option (b), "b for now"**
-(revisitable, not permanent).
+# ES5 completion scope includes dynamic code and `with`
 
-The goal **"100% test262 standalone pass rate for ES5 and untagged tests" is
-arithmetically unreachable** and has been restated as:
+**Current stakeholder ruling, project lead, 2026-08-13 — supersedes the
+temporary 2026-08-01 carveout below.**
 
-> **~95.4%, ex-dynamic-code** — target **8,150 of 8,545** reachable
-> (6,176 passing + 1,974 non-dynamic failures).
+The goal is **100% test262 conformance for the complete ES5-and-earlier corpus
+in both execution lanes**. At the current pinned corpus that means:
 
-## The 317 excluded files are DECLINE-BY-DEPENDENCY, not failures
+- host lane: **9,029 / 9,029 pass**;
+- standalone lane: **9,029 / 9,029 pass**;
+- zero failures, compile errors, compile timeouts, or skips in that population.
 
-| blocker | files | needs |
-|---|---:|---|
-| eval / `Function` | ~144 | real eval — the Acorn interpreter provider (#2928); minutes to compile, unaffordable per shard. A **packaging** problem (#2527) as much as semantics. |
-| `with` — object environment records with first-class Reference identity | ~162 | a **front-end substrate**, same weight class as the 795-file descriptor MOP |
-
-Near-disjoint; 13 files need both. **Funding eval does NOT deliver `with`** — the
-census originally filed `with` as "blocked on #2928", which was wrong and has
-been corrected on `main`.
+`eval`, indirect eval, the `Function` constructor, and `with` are all inside
+the completion boundary. They are implementation work, not exclusions.
 
 ## Operational consequences
 
-- **Do not dispatch agents at the 317.**
-- **Do not measure progress against 8,545, and do not report "100%".** A run at
-  95.4% is **success**, not a 4.6% shortfall.
-- **95.4% is an UPPER BOUND, not a forecast** — 202 files remain unpriced, and
-  diffuse usually means expensive per file.
+- Dispatch and prioritize `eval`, `Function`, and `with` defects normally.
+- Count every one of the 9,029 ES5-and-earlier rows in both lanes when reporting
+  completion.
+- Dynamic-source and `with` cohorts may be used as diagnostic partitions, but
+  never as denominator exclusions or a substitute completion target.
+- Do not report the former ~95.4% ex-dynamic-code target as current.
 
-## Why the exclusion is sound (this is the load-bearing control)
+## Superseded historical ruling
 
-A **non-circularity control**: the same detector run over the 6,176 goal-scope
-**passes** finds **248 files that use `eval`/`with`/`Function` and pass anyway**.
-So "dynamic code is fatal" was never assumed — the 317 were identified by
-**engine refusal**, not by mentioning the feature.
+On 2026-08-01 the goal was temporarily described as approximately 95.4%, with
+317 dynamic-code/`with` files excluded because the then-current eval packaging
+and object-environment-record substrate were considered too expensive. That was
+explicitly revisitable and is now obsolete. Its measurements remain useful as
+historical routing evidence only; they no longer define scope.
 
-Also: `with` is **168 of 175 host-lane too**, so it is shared front-end
-scope-analysis work, not a standalone-gap item. The agent that measured it
-recommended against funding it as a conformance lever at all.
+Historical provenance:
+`plan/log/analysis-2026-08-01-es5-untagged-tail-census.md`, baseline
+`d8c30f3b7df0`, js2 main `bc54c09da`.
 
-## Revisit trigger
+Current goal source: `plan/goals/es5.md`.
 
-Reopen option (a) if #2527 packaging ever makes real eval affordable per shard —
-that is the gate on the 144.
-
-Provenance: `plan/log/analysis-2026-08-01-es5-untagged-tail-census.md`, baselines
-`d8c30f3b7df0` (2026-08-01T17:14:04Z), js2 main `bc54c09da`.
-
-Related: [[reference_cached_baseline_jsonl_goes_stale_within_hours]],
+Related: [[project_test262_lane_parity_program]],
 [[feedback_measure_never_extrapolate]],
 [[feedback_file_defects_as_issue_markdown_not_tasklist]].


### PR DESCRIPTION
## Summary

- supersede the temporary ~95.4% ex-dynamic-code ruling in repository memory
- set the completion denominator to all 9,029 ES5-and-earlier tests in both host and standalone lanes
- explicitly include `eval`, indirect eval, `Function`, and `with` as required implementation work
- retain the previous ruling only as historical routing context

## Why

The earlier exclusion is no longer the project boundary. Leaving it in the memory index would continue steering agents away from required ES5 work and produce progress reports against the wrong denominator.

The canonical goal-page correction is already queued with #4434; this PR makes the same boundary unambiguous in the repository memory that agents read before substantial work.

## Validation

- `pnpm exec prettier --check .claude/memory/MEMORY.md .claude/memory/project_es5_standalone_goal_restated_ex_dynamic_code.md`
- commit hooks: LOC budget, function budget, changed-root tests, oracle ratchet
- pre-push gates: typecheck, lint, full Prettier check, oracle/coercion ratchets, 18/18 numeric-local IR parity tests, issue integrity

Documentation-only; no test262 row gain is claimed.
