### PR TITLE
fix(ir): lower primitive-wrapper loose equality

### DIFF
--- a/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
+++ b/plan/issues/4208-operator-abstract-ops-lowered-from-static-type.md
@@ -2,10 +2,10 @@
 id: 4208
 title: "Operator abstract-ops are lowered from the STATIC type: ToNumber / ToPrimitive / Type() are skipped for string, wrapper and `{valueOf}` operands — 59 ES5 files, `1 === true` answers true"
 status: in-progress
-completed_slice: "S1 (Type() for ===/!==) and S2 (update-expression ToNumber) — 2026-08-11"
+completed_slice: "S1, S2, the first S3/S7 OrdinaryToPrimitive slice, and S4 wrapper loose equality — 2026-08-13"
 sprint: current
 created: 2026-08-07
-updated: 2026-08-11
+updated: 2026-08-13
 priority: high
 horizon: xl
 feasibility: hard
@@ -28,6 +28,8 @@ loc-budget-allow:
   - src/ir/module-bindings.ts
   - src/ir/select.ts
   - src/codegen/binary-ops-typed-dispatch.ts
+  - src/codegen/binary-ops.ts
+  - src/ir/backend/legality.ts
   - src/ir/from-ast.ts
   - src/runtime.ts
 func-budget-allow:
@@ -596,3 +598,92 @@ The five previously crashing files are:
 This is a five-file slice, not closure of S3/S7 or the ES5 goal. Relational,
 addition, abstract-equality, Date/function operands, and wider
 OrdinaryToPrimitive shapes remain to be measured and implemented.
+
+---
+
+## S4 closure — primitive-wrapper abstract equality (2026-08-13)
+
+Base: exact `origin/main@81125e5e248847a5df94c3e2a3a20016782e1df4`,
+with Test262 pinned at `b363f29d3c43c626dc852744ad64a0b48a003693` in
+an isolated worktree.
+
+### Re-grounded lever and root cause
+
+The filed S4 population still reproduces exactly: eight standalone failures,
+all host-pass, all reporting `illegal cast in __str_to_number()` through the
+assembled Test262 harness. The files are `S11.9.1_A7.{2,3,4,5}.js` and
+`S11.9.2_A7.{2,3,4,5}.js`. Six adjacent controls — A7.1, A7.6, and A7.7 for
+both `==` and `!=` — pass in both lanes.
+
+The compatibility-path defect occurs before the already-correct native
+Object→ToPrimitive equality cascade. The early mixed-primitive shortcut asks
+the checker whether an operand is a String/Boolean/Number; a real
+`new String(...)` wrapper therefore enters the String shortcut from its static
+type, even though its runtime `Type` is Object. Standalone then feeds the
+wrapper externref directly to `__str_to_number`, whose `$AnyString` cast traps.
+
+Wrapper equality now bypasses that static primitive shortcut. The typed
+externref dispatcher receives the real operands and uses its existing
+IsLooselyEqual sequence: detect exactly one Object, call canonical
+`__to_primitive(value, default)`, then compare the resulting primitive through
+the shared number/boolean/string carrier cascade. Host mode retains its
+canonical `__host_loose_eq` wrapper route. Strict equality, wrapper identity,
+and wrapper-vs-string behavior are unchanged.
+
+### IR ownership boundary
+
+As in the first S3/S7 slice, the full assembled Test262 module initializer is
+still compatibility-owned because unrelated harness declarations are outside
+the current module-init selector. The IR proof therefore uses a focused typed
+source rather than claiming that the entire harness wrapper is IR-emitted.
+
+The focused producer admits only a fresh ambient `Boolean`/`Number`/`String`
+wrapper compared with `==`/`!=` to a proven Boolean or Number, in either operand
+order. Constructor identity is checker-backed, the constructor argument must
+already have its exact primitive family, and the current producer is limited to
+the non-fast externref dynamic carrier. From-AST allocates the real wrapper via
+`__new_Boolean`/`__new_Number`/`__new_String`, calls `__to_primitive`, boxes the
+returned primitive and the concrete counterpart into the canonical dynamic
+carrier, and emits `dyn.eq`. It does not compute the answer from AST shape.
+
+Focused functions are genuinely IR-emitted in host and standalone, with no
+post-claim errors; standalone has zero imports. Wrapper-vs-wrapper identity and
+wrapper-vs-string remain pre-claim legacy boundaries, and local-variable
+wrapper probes pin the compatibility fix independently of the fresh-wrapper IR
+producer.
+
+### Same-base A/B
+
+The assembled-harness instrument proved both verdict directions before each
+arm. Both arms contain the identical 14-file set, so the partition denominator
+is exact.
+
+| lane | before | after | gained | lost | unchanged |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| host GC | 14 / 14 | **14 / 14** | 0 | 0 | 14 |
+| standalone | 6 / 14 | **14 / 14** | **8** | 0 | 6 |
+
+Standalone gained exactly:
+
+- `language/expressions/equals/S11.9.1_A7.{2,3,4,5}.js`
+- `language/expressions/does-not-equals/S11.9.2_A7.{2,3,4,5}.js`
+
+The project-wide ES5 goal denominator is the full **9,029 tests in each lane**.
+This bounded S4 result does not exclude eval, `Function`, `with`, or any other
+ES5 category, and it does not claim closure of that full goal or of the remaining
+S3/S5/S6/S7 operator families.
+
+### Verification
+
+- Maintained filtered Test262 runner: host GC **8 / 8**
+  (`20260813-062253`) and standalone **8 / 8** (`20260813-062426`). The
+  standalone filter used the supported interpreter eval provider because this
+  machine lacks the `clang-18` required to build the default QuickJS provider;
+  these eight equality files do not invoke eval. This does not narrow the full
+  9,029-test ES5 target, and no full sweep is claimed here.
+- Focused wrapper loose-equality IR ownership and legacy-boundary suite:
+  **4 / 4**.
+- Related wrapper/object OrdinaryToPrimitive suites: **19 / 19**.
+- `pnpm run typecheck`: pass.
+- `pnpm run check:ir-fallbacks`: pass; no unintended, post-claim, or
+  module-level fallback increase.

--- a/plan/log/ir-adoption.md
+++ b/plan/log/ir-adoption.md
@@ -139,6 +139,7 @@ and Algorithms' top-level generic Map initializer are both IR-owned.
 | `primitive-method-unsupported`           | unintended | All checker-identified primitive method surfaces and arities have typed IR lowering (#3518)                                                           |
 | `function-invocation-method-unsupported` | unintended | `Function.call` / `Function.apply` receiver and argument semantics are represented in typed IR (#3518)                                                |
 | `logical-value-unsupported`              | unintended | Logical value/result families and JavaScript short-circuit coercions are represented in typed IR (#3518)                                              |
+| `operand-coercion-unsupported`           | unintended | Every supported operand coercion is represented through the canonical typed IR coercion engine (#4208)                                                |
 | `template-substitution-unsupported`      | unintended | Template substitutions support the remaining typed coercion families (#3518)                                                                          |
 | `error-constructor-unsupported`          | unintended | Error-family constructor identity, arity, and runtime intent are represented in typed IR (#3518)                                                      |
 | `typed-array-constructor-unsupported`    | unintended | TypedArray constructor identity, arity, and backend capability are represented in typed IR (#3518)                                                    |

--- a/scripts/gen-ir-adoption.mjs
+++ b/scripts/gen-ir-adoption.mjs
@@ -240,6 +240,10 @@ const BUCKETS = {
     "unintended",
     "Logical value/result families and JavaScript short-circuit coercions are represented in typed IR (#3518)",
   ],
+  "operand-coercion-unsupported": [
+    "unintended",
+    "Every supported operand coercion is represented through the canonical typed IR coercion engine (#4208)",
+  ],
   "template-substitution-unsupported": [
     "unintended",
     "Template substitutions support the remaining typed coercion families (#3518)",

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -813,6 +813,14 @@ export function compileBinaryExpression(
   // Regular binary ops: evaluate both sides
   const leftTsType = ctx.checker.getTypeAtLocation(expr.left);
   const rightTsType = ctx.checker.getTypeAtLocation(expr.right);
+  const isEqualityOp =
+    op === ts.SyntaxKind.EqualsEqualsToken ||
+    op === ts.SyntaxKind.ExclamationEqualsToken ||
+    op === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+    op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
+  const leftIsWrapperObj = isWrapperObjectType(leftTsType);
+  const rightIsWrapperObj = isWrapperObjectType(rightTsType);
+  const wrapperEquality = isEqualityOp && (leftIsWrapperObj || rightIsWrapperObj);
 
   // ── Loose equality (== / !=) with mixed types ──
   // JS loose equality coerces types before comparing. Handle common cases:
@@ -821,7 +829,7 @@ export function compileBinaryExpression(
   //   string == boolean / boolean == string → coerce both to number
   const isLooseEq = op === ts.SyntaxKind.EqualsEqualsToken;
   const isLooseNeq = op === ts.SyntaxKind.ExclamationEqualsToken;
-  if (isLooseEq || isLooseNeq) {
+  if ((isLooseEq || isLooseNeq) && !wrapperEquality) {
     const leftIsNum = isNumberType(leftTsType);
     const leftIsBool = isBooleanType(leftTsType);
     const leftIsStr = isStringType(leftTsType);
@@ -1060,15 +1068,6 @@ export function compileBinaryExpression(
   // Equality ops involving a wrapper object (Number/String/Boolean) are not
   // simple string/number ops — they have object-identity / ToPrimitive
   // semantics. Route them through the externref/wrapper path below (#1111).
-  const isEqualityOp =
-    op === ts.SyntaxKind.EqualsEqualsToken ||
-    op === ts.SyntaxKind.ExclamationEqualsToken ||
-    op === ts.SyntaxKind.EqualsEqualsEqualsToken ||
-    op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
-  const leftIsWrapperObj = isWrapperObjectType(leftTsType);
-  const rightIsWrapperObj = isWrapperObjectType(rightTsType);
-  const wrapperEquality = isEqualityOp && (leftIsWrapperObj || rightIsWrapperObj);
-
   // (#3688) Statically-`number` equality gets the SAME numeric operand hint the
   // relational ops already get.
   //

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -22,6 +22,7 @@ export type IrBackendTargetCapability =
   | "standalone-function-prototype-call"
   | "standalone-native-regexp-test-carrier"
   | "standalone-wrapper-instanceof"
+  | "primitive-wrapper-loose-equality"
   | "legacy-numeric-array-global";
 
 /**
@@ -69,6 +70,18 @@ export function supportsIrBackendTargetCapability(
         profile.target === "standalone" &&
         !profile.allowHostImports &&
         profile.fast === true
+      );
+    case "primitive-wrapper-loose-equality":
+      // #4208 S4 — the focused producer crosses the wrapper object's
+      // externref through the canonical `__to_primitive` runtime boundary,
+      // then boxes that primitive into the dynamic carrier. That boundary is
+      // representation-exact only for the non-fast externref carrier today.
+      // Host gc and host-free standalone/WASI both provide the wrapper ctor +
+      // OrdinaryToPrimitive runtime family; strict-no-host gc does not.
+      return (
+        profile.backend === "wasmgc" &&
+        profile.fast !== true &&
+        (profile.allowHostImports || profile.target === "standalone" || profile.target === "wasi")
       );
     case "legacy-numeric-array-global":
       return profile.backend === "wasmgc" && profile.fast !== true;

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -5653,6 +5653,8 @@ function lowerNestedFuncCall(
 function lowerNewExpression(expr: ts.NewExpression, cx: LowerCtx): IrValueId {
   const promiseDelay = tryLowerPromiseDelayConstruction(expr, cx.promiseDelays, () => makePromiseDelayLoweringHost(cx));
   if (promiseDelay !== undefined) return promiseDelay;
+  const primitiveWrapper = lowerPrimitiveWrapperConstruction(expr, cx);
+  if (primitiveWrapper !== null) return primitiveWrapper.value;
   if (!ts.isIdentifier(expr.expression)) {
     throw new Error(`ir/from-ast: only direct constructor names supported in slice 4 (${cx.funcName})`);
   }
@@ -5737,6 +5739,80 @@ function lowerNewExpression(expr: ts.NewExpression, cx: LowerCtx): IrValueId {
     args.push(argVal);
   }
   return cx.builder.emitClassNew(shape, args);
+}
+
+type PrimitiveWrapperConstructorName = "Boolean" | "Number" | "String";
+
+interface LoweredPrimitiveWrapper {
+  readonly kind: PrimitiveWrapperConstructorName;
+  readonly value: IrValueId;
+}
+
+/**
+ * #4208 S4 — checker-identity-backed ambient primitive-wrapper constructor.
+ * Selection admits this only as one operand of the bounded loose-equality
+ * producer; keeping the recognizer here exact prevents a textual shadow from
+ * being routed to the runtime wrapper family.
+ */
+function primitiveWrapperConstructorName(
+  expression: ts.Expression,
+  cx: LowerCtx,
+): PrimitiveWrapperConstructorName | null {
+  const candidate = peelParensExpr(expression);
+  if (!ts.isNewExpression(candidate) || !ts.isIdentifier(candidate.expression)) return null;
+  const name = candidate.expression.text;
+  if (name !== "Boolean" && name !== "Number" && name !== "String") return null;
+  const ambient =
+    name === "String"
+      ? cx.resolver?.isAmbientStringBinding?.(candidate.expression) === true
+      : cx.resolver?.isAmbientBinding?.(candidate.expression) === true;
+  return ambient ? name : null;
+}
+
+/**
+ * Materialize the real wrapper object through the existing host/native
+ * constructor provider. The result stays branded `extern:Object`: loose
+ * equality must still run the canonical `__to_primitive` protocol and may not
+ * substitute the constructor argument as an AST shortcut.
+ */
+function lowerPrimitiveWrapperConstruction(expr: ts.NewExpression, cx: LowerCtx): LoweredPrimitiveWrapper | null {
+  const kind = primitiveWrapperConstructorName(expr, cx);
+  if (kind === null) return null;
+  const args = expr.arguments ?? [];
+  if (args.length !== 1 || ts.isSpreadElement(args[0]!)) {
+    throw new IrUnsupportedError(
+      "constructor-arity-unsupported",
+      "build",
+      `ir/from-ast: primitive wrapper ${kind} requires one exact primitive argument in ${cx.funcName}`,
+    );
+  }
+
+  let argument: IrValueId;
+  if (kind === "Number") {
+    argument = lowerExpr(args[0]!, cx, irVal({ kind: "f64" }));
+    if (asVal(cx.builder.typeOf(argument))?.kind !== "f64") {
+      throw new Error(`ir/from-ast: new Number argument is not f64 in ${cx.funcName}`);
+    }
+  } else if (kind === "Boolean") {
+    const boolean = lowerExpr(args[0]!, cx, irVal({ kind: "i32", boolean: true }));
+    if (asVal(cx.builder.typeOf(boolean))?.kind !== "i32") {
+      throw new Error(`ir/from-ast: new Boolean argument is not i32 in ${cx.funcName}`);
+    }
+    argument = cx.builder.emitUnary("f64.convert_i32_s", boolean, irVal({ kind: "f64" }));
+  } else {
+    const string = lowerExpr(args[0]!, cx, { kind: "string" });
+    if (cx.builder.typeOf(string).kind !== "string") {
+      throw new Error(`ir/from-ast: new String argument is not string in ${cx.funcName}`);
+    }
+    argument = cx.builder.emitCoerceToExternref(string);
+  }
+
+  const resultType: IrType = { kind: "extern", className: "Object" };
+  const value = cx.builder.emitCall(irRuntimeFuncRef(`__new_${kind}`), [argument], resultType);
+  if (value === null) {
+    throw new Error(`ir/from-ast: __new_${kind} produced no value in ${cx.funcName}`);
+  }
+  return { kind, value };
 }
 
 /**
@@ -9776,9 +9852,11 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
   // path below (a `dyn === "s"` mixes dynamic + string). The payload-less
   // STRICT `dyn === null`/`dyn === undefined` cases were already handled by
   // `tryFoldNullCompare`/`tryLowerUndefinedCompare`'s dynamic arms (cheaper
-  // exact `tag.test`), so they never reach here. Reachable only once the S5.P
-  // selector scan admits dynamic-eq bodies; today the move-only gate rejects
-  // them, so this arm is byte-inert.
+  // exact `tag.test`), so they never reach here. The generic dynamic-operand
+  // arm stays byte-inert until S5.P opens its selector; #4208's focused
+  // fresh-wrapper producer shares this dispatcher after canonical ToPrimitive.
+  const dynEq = tryLowerDynamicEq(expr, op, lhs, rhs, lt, rt, cx);
+  if (dynEq !== null) return dynEq;
   if (lt.kind === "dynamic" || rt.kind === "dynamic") {
     if (op === ts.SyntaxKind.PlusToken) {
       const dynL = lt.kind === "dynamic" ? lhs : boxConcreteToDynamic(lhs, lt, expr.left, cx);
@@ -9789,8 +9867,6 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
         return added;
       }
     }
-    const dynEq = tryLowerDynamicEq(expr, op, lhs, rhs, lt, rt, cx);
-    if (dynEq !== null) return dynEq;
     // #2949 S5.3 — dynamic relational: `<`/`>`/`<=`/`>=` where either operand
     // is a boxed-any carrier. Each dynamic operand is ToNumber'd to f64 via
     // `dyn.to_number` (routing to the CANONICAL `__any_to_f64` gc /
@@ -10441,15 +10517,10 @@ function tryFoldNullCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: Lo
 }
 
 /**
- * #2949 S5.2 — lower `dyn === x` / `dyn !== x` / `dyn == x` / `dyn != x` (either
- * or both operands dynamic) to a `dyn.eq` node. Boxes the concrete operand into
- * the boxed-any carrier (refining the box tag from a literal's kind where
- * known) and leaves the dyn operand as-is, so `dyn.eq` sees two carriers — the
- * `(ref null $AnyValue, ref null $AnyValue)` shape the canonical
- * `__any_strict_eq`/`__any_eq` helpers take. Returns `null` (clean demote) for a
- * concrete operand this slice cannot soundly box into the carrier (union / ref /
- * an un-refinable non-literal `i32` whose number-vs-boolean brand is ambiguous),
- * or for a non-equality operator.
+ * #2949 S5.2 / #4208 S4 — lower equality through the canonical dynamic
+ * carrier. The focused wrapper producer first performs Object→ToPrimitive;
+ * otherwise at least one operand must already be dynamic. Returns `null`
+ * (clean demote) for an unboxable concrete operand or non-equality operator.
  */
 function tryLowerDynamicEq(
   expr: ts.BinaryExpression,
@@ -10460,6 +10531,9 @@ function tryLowerDynamicEq(
   rt: IrType,
   cx: LowerCtx,
 ): IrValueId | null {
+  const wrapperLooseEq = tryLowerPrimitiveWrapperLooseEquality(expr, op, lhs, rhs, lt, rt, cx);
+  if (wrapperLooseEq !== null) return wrapperLooseEq;
+  if (lt.kind !== "dynamic" && rt.kind !== "dynamic") return null;
   const loose = op === ts.SyntaxKind.EqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken;
   const strict = op === ts.SyntaxKind.EqualsEqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
   if (!loose && !strict) return null;
@@ -10470,6 +10544,67 @@ function tryLowerDynamicEq(
   const dynR = rt.kind === "dynamic" ? rhs : boxConcreteToDynamic(rhs, rt, expr.right, cx);
   if (dynR === null) return null;
   return cx.builder.emitDynEq(dynL, dynR, { loose, negate });
+}
+
+/**
+ * #4208 S4 — lower the selector-certified fresh-wrapper loose equality.
+ * This is intentionally an AST-shape producer for a canonical IR/runtime
+ * sequence, not an AST-computed answer: the wrapper is allocated, then
+ * `__to_primitive` observes its real [[PrimitiveValue]], then `dyn.eq` owns
+ * Boolean/Number/String coercion exactly as it does for other dynamic values.
+ * Both source operands were evaluated in order before this helper runs. The
+ * selector restricts this to the non-fast externref carrier, so the primitive
+ * result crosses `box` without a representation guess; wrapper-vs-wrapper and
+ * wrapper-vs-string retain their legacy paths.
+ */
+function tryLowerPrimitiveWrapperLooseEquality(
+  expr: ts.BinaryExpression,
+  op: ts.SyntaxKind,
+  lhs: IrValueId,
+  rhs: IrValueId,
+  lt: IrType,
+  rt: IrType,
+  cx: LowerCtx,
+): IrValueId | null {
+  if (op !== ts.SyntaxKind.EqualsEqualsToken && op !== ts.SyntaxKind.ExclamationEqualsToken) return null;
+  const leftKind = primitiveWrapperConstructorName(expr.left, cx);
+  const rightKind = primitiveWrapperConstructorName(expr.right, cx);
+  if ((leftKind === null) === (rightKind === null)) return null;
+  if (cx.resolver?.dynamicCarrierIsExternref?.() !== true) {
+    throw new Error(
+      `ir/from-ast: primitive-wrapper loose equality requires the externref dynamic carrier (${cx.funcName})`,
+    );
+  }
+
+  const wrapperOnLeft = leftKind !== null;
+  const wrapperKind = (leftKind ?? rightKind)!;
+  const wrapper = wrapperOnLeft ? lhs : rhs;
+  const wrapperType = wrapperOnLeft ? lt : rt;
+  const primitiveOperand = wrapperOnLeft ? rhs : lhs;
+  const primitiveType = wrapperOnLeft ? rt : lt;
+  const primitiveExpression = wrapperOnLeft ? expr.right : expr.left;
+  if (wrapperType.kind !== "extern" || wrapperType.className !== "Object") {
+    throw new Error(`ir/from-ast: primitive wrapper did not lower to extern:Object in ${cx.funcName}`);
+  }
+
+  const externref = irVal({ kind: "externref" });
+  const hint = cx.builder.emitConst({ kind: "null", ty: externref }, externref);
+  const primitive = cx.builder.emitCall(irRuntimeFuncRef("__to_primitive"), [wrapper, hint], externref);
+  if (primitive === null) {
+    throw new Error(`ir/from-ast: __to_primitive produced no value in ${cx.funcName}`);
+  }
+  const primitiveTag =
+    wrapperKind === "Boolean" ? JsTag.Boolean : wrapperKind === "Number" ? JsTag.NumberF64 : JsTag.String;
+  const wrapperDynamic = cx.builder.emitBox(primitive, irDynamic(primitiveTag));
+  const otherDynamic = boxConcreteToDynamic(primitiveOperand, primitiveType, primitiveExpression, cx);
+  if (otherDynamic === null) {
+    throw new Error(`ir/from-ast: wrapper loose-equality primitive operand was not boxable in ${cx.funcName}`);
+  }
+  return cx.builder.emitDynEq(
+    wrapperOnLeft ? wrapperDynamic : otherDynamic,
+    wrapperOnLeft ? otherDynamic : wrapperDynamic,
+    { loose: true, negate: op === ts.SyntaxKind.ExclamationEqualsToken },
+  );
 }
 
 /**

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -5733,6 +5733,7 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
   // every lane.
   let usesOrdinaryToPrimitiveObjectRuntime = false;
   let usesRuntimeUnboxNumber = false;
+  const primitiveWrapperConstructors = new Set<"Boolean" | "Number" | "String">();
   const dynamicRuntimeNeeds = new Set<IrDynamicRuntimeNeed>();
   for (const entry of fns) {
     for (const block of entry.fn.blocks) {
@@ -5756,6 +5757,15 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
                 break;
               case "__unbox_number":
                 usesRuntimeUnboxNumber = true;
+                break;
+              case "__new_Boolean":
+                primitiveWrapperConstructors.add("Boolean");
+                break;
+              case "__new_Number":
+                primitiveWrapperConstructors.add("Number");
+                break;
+              case "__new_String":
+                primitiveWrapperConstructors.add("String");
                 break;
               case IR_DYN_ADD_FN:
                 dynamicRuntimeNeeds.add("add");
@@ -5794,6 +5804,25 @@ function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef
       ensureLateImport(ctx, "__new_plain_object", [], [{ kind: "externref" }]);
       ensureLateImport(ctx, "__extern_set", [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }], []);
       ensureLateImport(ctx, "__to_primitive", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, null);
+    }
+  }
+  if (primitiveWrapperConstructors.size > 0) {
+    // #4208 S4 — explicit runtime refs for the focused primitive-wrapper
+    // construction. Host-free lanes materialize the real `$Object` wrappers
+    // (including [[PrimitiveValue]]) through the existing object runtime;
+    // host mode registers only the exact wrapper imports observed in IR.
+    if (ctx.standalone || ctx.wasi) {
+      ensureObjectRuntime(ctx);
+    } else {
+      for (const wrapperConstructor of primitiveWrapperConstructors) {
+        ensureLateImport(
+          ctx,
+          `__new_${wrapperConstructor}`,
+          [{ kind: wrapperConstructor === "String" ? "externref" : "f64" }],
+          [{ kind: "externref" }],
+        );
+      }
       flushLateImportShifts(ctx, null);
     }
   }

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -135,6 +135,7 @@ export type IrFallbackReason =
   | "primitive-method-unsupported"
   | "function-invocation-method-unsupported"
   | "logical-value-unsupported"
+  | "operand-coercion-unsupported"
   | "template-substitution-unsupported"
   | "error-constructor-unsupported"
   | "typed-array-constructor-unsupported"
@@ -516,6 +517,7 @@ export interface IrSelectionOptions extends IrAsyncSelectionOptions {
       | "standalone-function-prototype-call"
       | "standalone-native-regexp-test-carrier"
       | "standalone-wrapper-instanceof"
+      | "primitive-wrapper-loose-equality"
       | "legacy-numeric-array-global",
   ) => boolean;
   /**
@@ -5421,6 +5423,59 @@ function selectorSupportsStandaloneWrapperInstanceOf(node: ts.Identifier): boole
   );
 }
 
+/**
+ * #4208 S4 — recognize only the ambient primitive-wrapper constructions used
+ * by the residual ES5 abstract-equality family. The constructor argument must
+ * already have the exact primitive family consumed by the legacy wrapper ABI;
+ * general constructor coercion remains legacy-owned.
+ */
+function selectorPrimitiveWrapperConstruction(
+  expression: ts.Expression,
+  scope: ReadonlySet<string>,
+  localClasses: ReadonlySet<string>,
+): ts.NewExpression | null {
+  const candidate = unwrapPhase1Parens(expression);
+  if (
+    !ts.isNewExpression(candidate) ||
+    !ts.isIdentifier(candidate.expression) ||
+    !selectorSeesAmbientWrapperConstructor(candidate.expression) ||
+    candidate.arguments?.length !== 1 ||
+    ts.isSpreadElement(candidate.arguments[0]!)
+  ) {
+    return null;
+  }
+  const argument = candidate.arguments[0]!;
+  const expectedFamily =
+    candidate.expression.text === "Boolean" ? "boolean" : candidate.expression.text === "Number" ? "number" : "string";
+  if (obviousSelectorValueFamily(argument, scope) !== expectedFamily) return null;
+  return isPhase1Expr(argument, scope, localClasses) ? candidate : null;
+}
+
+/** #4208 S4 — bounded wrapper coercion followed by the generic binary tail. */
+function selectorPrimitiveWrapperOrGenericBinary(
+  expr: ts.BinaryExpression,
+  binOp: ts.SyntaxKind,
+  scope: ReadonlySet<string>,
+  localClasses: ReadonlySet<string>,
+): boolean {
+  if (binOp === ts.SyntaxKind.EqualsEqualsToken || binOp === ts.SyntaxKind.ExclamationEqualsToken) {
+    const leftWrapper = selectorPrimitiveWrapperConstruction(expr.left, scope, localClasses);
+    const rightWrapper = selectorPrimitiveWrapperConstruction(expr.right, scope, localClasses);
+    if ((leftWrapper === null) !== (rightWrapper === null)) {
+      const primitive = leftWrapper === null ? expr.left : expr.right;
+      const family = obviousSelectorValueFamily(primitive, scope);
+      if (family === "boolean" || family === "number") {
+        if (currentSelectionOptions?.supportsBackendCapability?.("primitive-wrapper-loose-equality") !== true) {
+          return capabilityNo("operand-coercion-unsupported", "expr-wrapper-loose-equality-target", expr);
+        }
+        return isPhase1Expr(primitive, scope, localClasses);
+      }
+    }
+  }
+  if (!isPhase1BinaryOp(binOp)) return shapeNo(`expr-binary-op-${ts.tokenToString(binOp) ?? binOp}`, expr);
+  return isPhase1Expr(expr.left, scope, localClasses) && isPhase1Expr(expr.right, scope, localClasses);
+}
+
 function selectorSupportsMathPlan(plan: IrMathMethodPlan): boolean {
   return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
 }
@@ -6593,8 +6648,7 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     ) {
       return isPhase1Expr(expr.left, scope, localClasses);
     }
-    if (!isPhase1BinaryOp(binOp)) return shapeNo(`expr-binary-op-${ts.tokenToString(binOp) ?? binOp}`, expr);
-    return isPhase1Expr(expr.left, scope, localClasses) && isPhase1Expr(expr.right, scope, localClasses);
+    return selectorPrimitiveWrapperOrGenericBinary(expr, binOp, scope, localClasses);
   }
   if (ts.isConditionalExpression(expr)) {
     if (expressionTouchesTrackedModuleValue(expr.whenTrue) || expressionTouchesTrackedModuleValue(expr.whenFalse)) {
@@ -7688,7 +7742,9 @@ export function buildLocalCallGraph(
           (localClasses.has(node.expression.text) ||
             (isKnownExternClass(node.expression.text) &&
               (currentModuleBindingResolver === null ||
-                currentModuleBindingResolver.isAmbientBinding(node.expression))))
+                currentModuleBindingResolver.isAmbientBinding(node.expression))) ||
+            (selectorSeesAmbientWrapperConstructor(node.expression) &&
+              currentSelectionOptions?.supportsBackendCapability?.("primitive-wrapper-loose-equality") === true))
         ) {
           // Slice 4: local class — `<Class>_new` has a stable signature.
           // Slice 10 (#1169i): known extern class — `<Class>_new` is

--- a/tests/issue-4208-wrapper-loose-equality-ir.test.ts
+++ b/tests/issue-4208-wrapper-loose-equality-ir.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+
+type CompileTarget = undefined | "standalone";
+
+const LEVER_SOURCE = `
+export function eqBooleanForward(): number {
+  return (new Boolean(true) == true ? 1 : 0)
+    + (new Number(1) == true ? 2 : 0)
+    + (new String("1") == true ? 4 : 0);
+}
+export function eqBooleanReverse(): number {
+  return (true == new Boolean(true) ? 1 : 0)
+    + (true == new Number(1) ? 2 : 0)
+    + (true == new String("+1") ? 4 : 0);
+}
+export function eqNumberForward(): number {
+  return (new Boolean(true) == 1 ? 1 : 0)
+    + (new Number(-1) == -1 ? 2 : 0)
+    + (new String("-1") == -1 ? 4 : 0);
+}
+export function eqNumberReverse(): number {
+  return (1 == new Boolean(true) ? 1 : 0)
+    + (-1 == new Number(-1) ? 2 : 0)
+    + (-1 == new String("-1") ? 4 : 0);
+}
+export function neqBooleanForward(): number {
+  return (new Boolean(true) != true ? 1 : 0)
+    + (new Number(1) != true ? 2 : 0)
+    + (new String("1") != true ? 4 : 0);
+}
+export function neqBooleanReverse(): number {
+  return (true != new Boolean(true) ? 1 : 0)
+    + (true != new Number(1) ? 2 : 0)
+    + (true != new String("+1") ? 4 : 0);
+}
+export function neqNumberForward(): number {
+  return (new Boolean(true) != 1 ? 1 : 0)
+    + (new Number(-1) != -1 ? 2 : 0)
+    + (new String("-1") != -1 ? 4 : 0);
+}
+export function neqNumberReverse(): number {
+  return (1 != new Boolean(true) ? 1 : 0)
+    + (-1 != new Number(-1) ? 2 : 0)
+    + (-1 != new String("-1") ? 4 : 0);
+}
+`;
+
+const LEVER_NAMES = [
+  "eqBooleanForward",
+  "eqBooleanReverse",
+  "eqNumberForward",
+  "eqNumberReverse",
+  "neqBooleanForward",
+  "neqBooleanReverse",
+  "neqNumberForward",
+  "neqNumberReverse",
+] as const;
+
+async function instantiate(result: CompileResult): Promise<Record<string, (...args: unknown[]) => unknown>> {
+  const imports = (result.importObject ?? {}) as WebAssembly.Imports & {
+    setExports?: (exports: WebAssembly.Exports) => void;
+    __setExports?: (exports: WebAssembly.Exports) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports);
+  imports.__setExports?.(instance.exports);
+  return instance.exports as Record<string, (...args: unknown[]) => unknown>;
+}
+
+function outcome(result: CompileResult, name: string): IrObservedOutcome | undefined {
+  return result.irOutcomes?.find((entry) => entry.displayName === name);
+}
+
+async function compileTarget(source: string, target: CompileTarget): Promise<CompileResult> {
+  const result = await compile(source, {
+    fileName: "issue-4208-wrapper-loose-equality-ir.ts",
+    experimentalIR: true,
+    trackIrOutcomes: true,
+    skipSemanticDiagnostics: true,
+    ...(target ? { target } : {}),
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(result.irPostClaimErrors ?? []).toEqual([]);
+  return result;
+}
+
+describe("#4208 S4 — primitive-wrapper loose equality", () => {
+  it.each<CompileTarget>([undefined, "standalone"])(
+    "emits Object→ToPrimitive→dynamic equality through IR (%s)",
+    async (target) => {
+      const result = await compileTarget(LEVER_SOURCE, target);
+      for (const name of LEVER_NAMES) {
+        expect(outcome(result, name), name).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: true,
+          irBodyEmitted: true,
+        });
+      }
+      if (target === "standalone") {
+        expect(WebAssembly.Module.imports(await WebAssembly.compile(result.binary))).toEqual([]);
+      } else {
+        const functionImports = WebAssembly.Module.imports(await WebAssembly.compile(result.binary))
+          .filter((entry) => entry.kind === "function")
+          .map((entry) => entry.name);
+        expect(functionImports).toEqual(
+          expect.arrayContaining([
+            "__new_Boolean",
+            "__new_Number",
+            "__new_String",
+            "__to_primitive",
+            "__host_loose_eq",
+          ]),
+        );
+      }
+
+      const exports = await instantiate(result);
+      for (const name of LEVER_NAMES.slice(0, 4)) expect(exports[name]!(), name).toBe(7);
+      for (const name of LEVER_NAMES.slice(4)) expect(exports[name]!(), name).toBe(0);
+    },
+  );
+
+  it.each<CompileTarget>([undefined, "standalone"])(
+    "keeps wrapper identity and wrapper-vs-string on the legacy boundary (%s)",
+    async (target) => {
+      const result = await compileTarget(
+        `
+          export function wrapperIdentity(): boolean {
+            return new Boolean(true) == new Boolean(true);
+          }
+          export function wrapperString(): boolean {
+            return new Boolean(true) == "1";
+          }
+          export function stringWrapperBooleanViaLocal(): boolean {
+            const wrapper = new String("1");
+            return wrapper == true;
+          }
+          export function stringWrapperNumberViaLocal(): boolean {
+            const wrapper = new String("-1");
+            return -1 == wrapper;
+          }
+        `,
+        target,
+      );
+      for (const name of [
+        "wrapperIdentity",
+        "wrapperString",
+        "stringWrapperBooleanViaLocal",
+        "stringWrapperNumberViaLocal",
+      ]) {
+        expect(outcome(result, name), name).toMatchObject({
+          kind: "unsupported",
+          legacyBodyEmitted: true,
+          irBodyEmitted: false,
+        });
+      }
+      const exports = await instantiate(result);
+      expect(exports.wrapperIdentity!()).toBe(0);
+      expect(exports.wrapperString!()).toBe(1);
+      expect(exports.stringWrapperBooleanViaLocal!()).toBe(1);
+      expect(exports.stringWrapperNumberViaLocal!()).toBe(1);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- route primitive-wrapper `==`/`!=` around the unsound static mixed-primitive shortcut and through the canonical Object-to-primitive equality dispatcher
- add narrow IR lowering for fresh ambient Boolean/Number/String wrappers compared with proven Boolean or Number values
- preserve wrapper identity and wrapper-vs-string shapes on the conservative compatibility boundary
- record exact same-base Test262 evidence in the existing operator issue

## Root cause

The compatibility path classified `new String(...)` from its static type as a primitive String. Standalone then passed the wrapper externref directly to `__str_to_number`, causing an illegal cast before the already-correct dynamic equality dispatcher could perform `ToPrimitive`.

The IR producer is deliberately narrower: it accepts only checker-proven ambient wrapper constructors and exact primitive counterparts, allocates the real wrapper, invokes canonical `__to_primitive`, and emits dynamic equality. User-defined constructors and broader wrapper comparisons remain outside the claim.

## Measured result

Exact identical 14-row partition at Test262 `b363f29d3c43c626dc852744ad64a0b48a003693`:

| lane | before | after | gained | lost |
| --- | ---: | ---: | ---: | ---: |
| host GC | 14/14 | 14/14 | 0 | 0 |
| standalone | 6/14 | 14/14 | 8 | 0 |

The eight gains are the ES5 `S11.9.1_A7.{2,3,4,5}` and `S11.9.2_A7.{2,3,4,5}` files. The assembled Test262 module initializer remains compatibility-owned because unrelated harness declarations are not yet selectable by IR; the focused producer separately proves genuine IR emission. This PR claims an eight-row slice, not completion of the 9,029-test-per-lane ES5 goal.

## Validation

- `pnpm exec vitest run tests/issue-4208-wrapper-loose-equality-ir.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism` — 4/4
- maintained filtered Test262 runner — host 8/8, standalone 8/8
- same-base 14-row A/B — eight standalone gains, zero losses in either lane
- `pnpm run typecheck`
- `pnpm run check:ir-fallbacks`
- pre-push typecheck, lint, Prettier, oracle/coercion ratchets, 18/18 numeric-local IR parity tests, issue integrity
