### PR TITLE
feat(ir): prepare recursive class layouts

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -1105,6 +1105,61 @@ recursive class-layout cells for self and mutually recursive class fields;
 after that, extend the same proof to inheritance participants before nested and
 multi-source owners.
 
+### Recursive class-layout cell checkpoint (2026-08-13)
+
+Self and mutually recursive flat class graphs now cross the same prepare-before-
+emit boundary. `buildIrClassShapes` allocates compiler-branded, identity-stable
+descriptor cells for every eligible exact class before projecting constructor,
+field, and method positions. It fills those cells once, removes any incomplete
+cell plus every transitive consumer before publication, and preserves source
+order in the public sidecar. Selection can therefore resolve `Node.next: Node`
+and `Left.right: Right -> Right.left: Left` without a name fallback or a late
+body-time ABI repair.
+
+The physical layout finalizer now admits the same exact recursive field edges.
+It mutates only the pre-existing field object after every struct is registered,
+so WasmGC forms the required recursive type group without replacing a Program
+ABI type cell or changing type order. Inheritance participants, nested/class-
+expression owners, optional/union/generic annotations, inferred constructor
+fields, externref-backed targets, and multi-source graphs remain excluded.
+
+Prepared ownership remains fail-closed. Recursive shape cells carry a private
+compiler symbol; the immutable prepared-data copier may preserve a back-edge
+only through a structurally valid branded class shape. Arbitrary object, map,
+set, and class-lookalike cycles still raise `invalid-prepared-data`. Backend
+legality and linear-memory layout discovery now track visited exact shape
+objects, so a valid class cycle terminates while visiting every nominal class
+once. A unit test proves the linear planner interns two distinct layouts for a
+mutual cycle; linear legality continues to reject the unsupported `class` atom
+with finite, stable diagnostics rather than recursing.
+
+The executable GC/standalone matrix covers both a mutual cycle and a self
+cycle. The mutual fixture prepares **six** terminal source bodies (`Left_new`,
+`Left_attach`, `Left_value`, `Right_new`, `Right_attach`, and `run`) with
+`direct=0, IR=1`; the self fixture prepares **four** (`Node_new`, `Node_link`,
+`Node_sum`, and `run`) with the same counters. Direct class/function poison is
+active, both binaries validate, and runtime returns `14` and `7`. Exact WAT
+assertions require nullable nominal field refs plus typed `struct.get`/
+`struct.set` and direct calls; the migrated bodies reject extern conversions,
+casts/tests, and indirect calls. The mutual-cycle IR artifact is no larger than
+the same-source direct artifact in either target.
+
+The focused R2/R3 completion matrix is green at **126/126**. The complete class
+file is **42/42**, exact shape/program ownership suites are **29/29**, and the
+hybrid plus strict shadows remain **37/37 IR, 0 legacy bodies, 0 Unsupported,
+and 0 Invariants**. Ordinary and shape-diagnostic fallback gates report zero
+unintended/post-claim/module-level increases and zero attributed body-shape
+rejections. Typecheck, changed-file lint, and formatting pass. Wider
+equivalence, cross-backend, optimization-retirement, integrity, adoption,
+oracle, and budget gates remain required before publication.
+
+No shared direct implementation is deleted in this checkpoint. Inheritance
+participants and the other excluded class families still consume it. The next
+serial R3 transaction extends exact field-layout finalization through local
+inheritance without allowing recursive heritage, then tackles nested/class-
+expression ownership. The obsolete direct implementation is removed in the
+same later transaction that proves its last consumer is gone.
+
 ## Exhaustive source-unit census
 
 Before preparing any body, walk the source once in lexical/source order and

--- a/src/codegen/class-field-layout.ts
+++ b/src/codegen/class-field-layout.ts
@@ -23,7 +23,7 @@ function fixedFieldName(name: ts.PropertyName): string | undefined {
 }
 
 function isFlatClass(declaration: ts.ClassDeclaration): boolean {
-  return declaration.heritageClauses === undefined || declaration.heritageClauses.length === 0;
+  return declaration.heritageClauses?.every((clause) => clause.token !== ts.SyntaxKind.ExtendsKeyword) ?? true;
 }
 
 function exactLocalClassReference(
@@ -51,27 +51,6 @@ function exactLocalClassReference(
   return classId !== undefined && identity.declarationByClassId.get(classId) === declaration ? declaration : undefined;
 }
 
-function fieldDependencies(
-  ctx: CodegenContext,
-  sourceFile: ts.SourceFile,
-  declarations: readonly ts.ClassDeclaration[],
-): ReadonlyMap<ts.ClassDeclaration, ReadonlySet<ts.ClassDeclaration>> {
-  const local = new Set(declarations);
-  const dependencies = new Map<ts.ClassDeclaration, ReadonlySet<ts.ClassDeclaration>>();
-  for (const declaration of declarations) {
-    const required = new Set<ts.ClassDeclaration>();
-    for (const member of declaration.members) {
-      if (!ts.isPropertyDeclaration(member) || hasStaticModifier(member) || fixedFieldName(member.name) === undefined) {
-        continue;
-      }
-      const target = exactLocalClassReference(ctx, sourceFile, member.type);
-      if (target && local.has(target)) required.add(target);
-    }
-    dependencies.set(declaration, required);
-  }
-  return dependencies;
-}
-
 function inheritanceParticipants(
   ctx: CodegenContext,
   declarations: readonly ts.ClassDeclaration[],
@@ -91,21 +70,6 @@ function inheritanceParticipants(
     }
   }
   return participants;
-}
-
-function reachesClass(
-  dependencies: ReadonlyMap<ts.ClassDeclaration, ReadonlySet<ts.ClassDeclaration>>,
-  start: ts.ClassDeclaration,
-  expected: ts.ClassDeclaration,
-  visited = new Set<ts.ClassDeclaration>(),
-): boolean {
-  if (start === expected) return true;
-  if (visited.has(start)) return false;
-  visited.add(start);
-  for (const dependency of dependencies.get(start) ?? []) {
-    if (reachesClass(dependencies, dependency, expected, visited)) return true;
-  }
-  return false;
 }
 
 function requireCommittedField(
@@ -134,10 +98,10 @@ function requireCommittedField(
 }
 
 /**
- * Commit exact, acyclic references from flat top-level fields to later local
+ * Commit exact references from flat top-level fields to later local
  * classes without replacing an observed StructTypeDef or changing type order.
  *
- * Recursive, inherited, nested, generic, union, optional, inferred, and
+ * Inherited, nested, generic, union, optional, inferred, and
  * externref-backed layouts deliberately remain on the typed direct route.
  */
 export function finalizeForwardClassFieldLayouts(ctx: CodegenContext, sourceFile: ts.SourceFile): void {
@@ -150,7 +114,6 @@ export function finalizeForwardClassFieldLayouts(ctx: CodegenContext, sourceFile
     const name = declaration.name!.text;
     nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
   }
-  const dependencies = fieldDependencies(ctx, sourceFile, declarations);
   const inherited = inheritanceParticipants(ctx, declarations);
 
   for (const owner of declarations) {
@@ -182,8 +145,7 @@ export function finalizeForwardClassFieldLayouts(ctx: CodegenContext, sourceFile
         !isFlatClass(target) ||
         inherited.has(target) ||
         nameCounts.get(target.name.text) !== 1 ||
-        ctx.classExternrefBackedSet.has(target.name.text) ||
-        reachesClass(dependencies, target, owner)
+        ctx.classExternrefBackedSet.has(target.name.text)
       ) {
         continue;
       }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -38,6 +38,7 @@ import { irSupportFuncRef } from "../ir/callable-bindings.js";
 import { compileIrPathFunctions, type IrIntegrationError, type IrIntegrationReport } from "../ir/integration.js";
 import {
   asVal,
+  IR_CLASS_SHAPE_CELL,
   irDynamic,
   isDynamic,
   irVal,
@@ -1297,6 +1298,42 @@ function buildIrClassShapes(
     declarationsInCollectionOrder,
     identityContext,
   );
+  // Flat local classes are allocated as identity-stable descriptor cells
+  // before any member type is projected. TypeScript permits self-recursive and
+  // mutually recursive annotations, so a later class must be resolvable while
+  // its descriptor is still being filled. The cells are planning-only: only
+  // completely populated dependency-closed shapes are published below.
+  const provisionalEntries = new Map<IrClassId, IrClassShapeEntry>();
+  const populatedProvisionalIds = new Set<IrClassId>();
+  for (const { classId, declaration } of declarationsInCollectionOrder) {
+    if (
+      !ts.isClassDeclaration(declaration) ||
+      !declaration.name ||
+      declaration.parent !== sourceFile ||
+      declaration.heritageClauses?.some((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword) === true
+    ) {
+      continue;
+    }
+    const className = declaration.name.text;
+    if (
+      !ctx.classSet.has(className) ||
+      !ctx.structFields.has(className) ||
+      ctx.classExternrefBackedSet.has(className)
+    ) {
+      continue;
+    }
+    const shape: import("../ir/nodes.js").IrClassShape = {
+      [IR_CLASS_SHAPE_CELL]: true,
+      classId,
+      className,
+      fields: [],
+      methods: [],
+      constructorParams: [],
+    };
+    const entry = { classId, legacyName: className, declaration, shape };
+    provisionalEntries.set(classId, entry);
+    out.set(classId, entry);
+  }
   for (const { classId, declaration: stmt } of declarations) {
     const className = ts.isClassExpression(stmt) ? ctx.anonClassExprNames.get(stmt) : stmt.name?.text;
     if (!className) continue;
@@ -1670,7 +1707,70 @@ function buildIrClassShapes(
       // #3000-E: present only for a single-level subclass of a local user class.
       ...(parentShape ? { parent: parentShape } : {}),
     };
-    out.set(classId, { classId, legacyName: className, declaration: stmt, shape });
+    const provisional = provisionalEntries.get(classId);
+    if (provisional) {
+      Object.assign(provisional.shape, shape);
+      populatedProvisionalIds.add(classId);
+    } else {
+      out.set(classId, { classId, legacyName: className, declaration: stmt, shape });
+    }
+  }
+  for (const classId of provisionalEntries.keys()) {
+    if (!populatedProvisionalIds.has(classId)) out.delete(classId);
+  }
+
+  // A provisional target can fail after another descriptor already consumed
+  // its cell. Remove that owner as well; publishing a dangling class identity
+  // would turn an atomic typed fallback into a late lowering invariant.
+  const directShapeDependencies = (shape: import("../ir/nodes.js").IrClassShape): ReadonlySet<IrClassId> => {
+    const dependencies = new Set<IrClassId>();
+    const seen = new Set<IrType>();
+    const addType = (type: IrType): void => {
+      if (seen.has(type)) return;
+      seen.add(type);
+      switch (type.kind) {
+        case "class":
+          dependencies.add(type.shape.classId);
+          return;
+        case "object":
+          for (const field of type.shape.fields) addType(field.type);
+          return;
+        case "vec":
+          addType(type.elementType);
+          return;
+        case "closure":
+        case "callable":
+          for (const parameter of type.signature.params) addType(parameter);
+          if (type.signature.returnType) addType(type.signature.returnType);
+          return;
+        case "union":
+          for (const member of type.members) addType(member);
+          return;
+        case "boxed":
+          addType(type.inner);
+          return;
+        default:
+          return;
+      }
+    };
+    for (const field of shape.fields) addType(field.type);
+    for (const parameter of shape.constructorParams) addType(parameter);
+    for (const method of shape.methods) {
+      for (const parameter of method.params) addType(parameter);
+      if (method.returnType) addType(method.returnType);
+    }
+    if (shape.parent) dependencies.add(shape.parent.classId);
+    return dependencies;
+  };
+  let removedDanglingShape = true;
+  while (removedDanglingShape) {
+    removedDanglingShape = false;
+    for (const [classId, entry] of out) {
+      if ([...directShapeDependencies(entry.shape)].some((dependency) => !out.has(dependency))) {
+        out.delete(classId);
+        removedDanglingShape = true;
+      }
+    }
   }
   // Dependency construction order is an internal planning detail. Publish the
   // registry in the authoritative collection order so type/global planning and

--- a/src/codegen/ir-class-shapes.ts
+++ b/src/codegen/ir-class-shapes.ts
@@ -301,8 +301,9 @@ function hasFixedClassShapeParameters(parameters: readonly ts.ParameterDeclarati
  * accidental restriction rather than an ABI constraint.
  *
  * Dependencies are identity-based and local to the candidate population.
- * Cycles deliberately retain their original order and therefore remain on the
- * typed direct path until recursive class-shape cells are planned explicitly.
+ * Cycles deliberately retain their original order. The descriptor builder
+ * resolves them through preallocated exact class-shape cells; stable residue
+ * order keeps planning deterministic without pretending a cycle is a DAG.
  */
 export function orderIrClassShapeDeclarationsForProjection(
   oracle: TypeOracle,

--- a/src/ir/analysis/linear-memory-plan.ts
+++ b/src/ir/analysis/linear-memory-plan.ts
@@ -856,15 +856,21 @@ function collectModuleFacts(
   return { allocations };
 }
 
-function collectLayoutsFromType(type: IrType, layouts: Map<string, LinearLayoutPlan>): void {
+function collectLayoutsFromType(
+  type: IrType,
+  layouts: Map<string, LinearLayoutPlan>,
+  seenClassShapes = new Set<IrClassShape>(),
+): void {
   switch (type.kind) {
     case "object":
       internLayout(layouts, recordLayoutForObject(type.shape));
-      for (const field of type.shape.fields) collectLayoutsFromType(field.type, layouts);
+      for (const field of type.shape.fields) collectLayoutsFromType(field.type, layouts, seenClassShapes);
       return;
     case "class":
       internLayout(layouts, recordLayoutForClass(type.shape));
-      for (const field of type.shape.fields) collectLayoutsFromType(field.type, layouts);
+      if (seenClassShapes.has(type.shape)) return;
+      seenClassShapes.add(type.shape);
+      for (const field of type.shape.fields) collectLayoutsFromType(field.type, layouts, seenClassShapes);
       return;
     case "boxed":
       internLayout(
@@ -873,22 +879,23 @@ function collectLayoutsFromType(type: IrType, layouts: Map<string, LinearLayoutP
           { name: "value", storage: linearStorageForIrType(type.inner) },
         ]),
       );
-      collectLayoutsFromType(type.inner, layouts);
+      collectLayoutsFromType(type.inner, layouts, seenClassShapes);
       return;
     case "string":
       internLayout(layouts, planLinearStringLayout());
       return;
     case "vec":
       internLayout(layouts, planLinearVectorLayout(type.elementType));
-      collectLayoutsFromType(type.elementType, layouts);
+      collectLayoutsFromType(type.elementType, layouts, seenClassShapes);
       return;
     case "closure":
     case "callable":
-      for (const param of type.signature.params) collectLayoutsFromType(param, layouts);
-      if (type.signature.returnType !== null) collectLayoutsFromType(type.signature.returnType, layouts);
+      for (const param of type.signature.params) collectLayoutsFromType(param, layouts, seenClassShapes);
+      if (type.signature.returnType !== null)
+        collectLayoutsFromType(type.signature.returnType, layouts, seenClassShapes);
       return;
     case "union":
-      for (const member of type.members) collectLayoutsFromType(member, layouts);
+      for (const member of type.members) collectLayoutsFromType(member, layouts, seenClassShapes);
       return;
     default:
       return;

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -8,7 +8,7 @@
 // surfaces a localized diagnostic instead of a late raw-emitter throw or
 // malformed Wasm/bytecode.
 
-import type { IrBinop, IrBlock, IrFunction, IrInstr, IrType } from "../nodes.js";
+import type { IrBinop, IrBlock, IrClassShape, IrFunction, IrInstr, IrType } from "../nodes.js";
 import { asVal } from "../nodes.js";
 import type { ValType } from "../types.js";
 
@@ -84,10 +84,11 @@ export interface IrBackendLegalityError {
 
 export function verifyIrBackendLegality(func: IrFunction, backend: IrBackendKind): IrBackendLegalityError[] {
   const errors: IrBackendLegalityError[] = [];
+  const checkedClassShapes = new Set<IrClassShape>();
   const checkType = (type: IrType, block: number | undefined, where: string): void => {
     const msg = backendTypeError(backend, type);
     if (msg) errors.push({ message: `${where}: ${msg}`, func: func.name, block });
-    checkNestedTypeShapes(type, block, where, checkType);
+    checkNestedTypeShapes(type, block, where, checkType, checkedClassShapes);
   };
 
   for (const p of func.params) checkType(p.type, undefined, `param ${p.name}`);
@@ -512,6 +513,7 @@ function checkNestedTypeShapes(
   block: number | undefined,
   where: string,
   checkType: (type: IrType, block: number | undefined, where: string) => void,
+  checkedClassShapes: Set<IrClassShape>,
 ): void {
   switch (type.kind) {
     case "object":
@@ -524,6 +526,8 @@ function checkNestedTypeShapes(
       if (type.signature.returnType) checkType(type.signature.returnType, block, `${where}.return`);
       return;
     case "class":
+      if (checkedClassShapes.has(type.shape)) return;
+      checkedClassShapes.add(type.shape);
       for (const field of type.shape.fields) checkType(field.type, block, `${where}.${field.name}`);
       for (const method of type.shape.methods) {
         for (let i = 0; i < method.params.length; i++)

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -268,7 +268,15 @@ export interface IrClassMethodDescriptor {
  * the resolver returns an exact typed callable reference for the selected
  * allocator-owned slot.
  */
+export const IR_CLASS_SHAPE_CELL: unique symbol = Symbol("IR_CLASS_SHAPE_CELL");
+
 export interface IrClassShape {
+  /**
+   * Compiler-owned identity cell for a shape that may participate in a
+   * recursive class graph. The prepared-data copier recognizes cycles only
+   * through this explicit brand; arbitrary cyclic input remains invalid.
+   */
+  readonly [IR_CLASS_SHAPE_CELL]?: true;
   readonly classId: IrClassId;
   /** Compatibility/debug label; never the semantic identity. */
   readonly className: string;

--- a/src/ir/program.ts
+++ b/src/ir/program.ts
@@ -2,6 +2,7 @@
 
 import type { IrBackendKind } from "./backend/legality.js";
 import type { IrBindingId, IrSourceId, IrUnitId } from "./identity.js";
+import { IR_CLASS_SHAPE_CELL } from "./nodes.js";
 import type { ProgramAbiCallableSignature, ProgramAbiPlanEntry } from "./program-abi.js";
 
 export type PreparedIrCandidateRoute = "ir" | "direct" | "neither";
@@ -286,45 +287,74 @@ function invalidPreparedData(detail: string): never {
   throw new PreparedIrProgramInvariantError("invalid-prepared-data", detail);
 }
 
-function immutableCopy(value: unknown, ancestors = new Set<object>()): unknown {
+function isRecursiveIrClassShape(value: object): boolean {
+  const candidate = value as Record<PropertyKey, unknown>;
+  return (
+    candidate[IR_CLASS_SHAPE_CELL] === true &&
+    typeof candidate.classId === "string" &&
+    candidate.classId.startsWith("ir-class:v1:") &&
+    typeof candidate.className === "string" &&
+    Array.isArray(candidate.fields) &&
+    Array.isArray(candidate.methods) &&
+    Array.isArray(candidate.constructorParams)
+  );
+}
+
+function immutableCopy(
+  value: unknown,
+  ancestors = new Set<object>(),
+  activeCopies = new Map<object, unknown>(),
+): unknown {
   if (typeof value === "function") invalidPreparedData("prepared data cannot contain executable functions");
   if (value === null || typeof value !== "object") return value;
-  if (ancestors.has(value)) invalidPreparedData("prepared data must be acyclic");
+  if (ancestors.has(value)) {
+    const recursiveShapeCopy = activeCopies.get(value);
+    if (recursiveShapeCopy !== undefined && isRecursiveIrClassShape(value)) return recursiveShapeCopy;
+    invalidPreparedData("prepared data must be acyclic outside exact IR class shapes");
+  }
   const nextAncestors = new Set(ancestors).add(value);
   if (value instanceof FrozenMap) {
     return preparedIrReadonlyMap(
-      [...value].map(([key, item]) => [immutableCopy(key, nextAncestors), immutableCopy(item, nextAncestors)] as const),
+      [...value].map(
+        ([key, item]) =>
+          [immutableCopy(key, nextAncestors, activeCopies), immutableCopy(item, nextAncestors, activeCopies)] as const,
+      ),
     );
   }
   if (value instanceof FrozenSet) {
-    return new FrozenSet([...value].map((item) => immutableCopy(item, nextAncestors)));
+    return new FrozenSet([...value].map((item) => immutableCopy(item, nextAncestors, activeCopies)));
   }
-  if (Array.isArray(value)) return Object.freeze(value.map((item) => immutableCopy(item, nextAncestors)));
+  if (Array.isArray(value)) return Object.freeze(value.map((item) => immutableCopy(item, nextAncestors, activeCopies)));
   if (value instanceof Map) {
     return preparedIrReadonlyMap(
-      [...value].map(([key, item]) => [immutableCopy(key, nextAncestors), immutableCopy(item, nextAncestors)] as const),
+      [...value].map(
+        ([key, item]) =>
+          [immutableCopy(key, nextAncestors, activeCopies), immutableCopy(item, nextAncestors, activeCopies)] as const,
+      ),
     );
   }
   if (value instanceof Set) {
-    return new FrozenSet([...value].map((item) => immutableCopy(item, nextAncestors)));
+    return new FrozenSet([...value].map((item) => immutableCopy(item, nextAncestors, activeCopies)));
   }
   const prototype = Object.getPrototypeOf(value);
   if (prototype !== Object.prototype && prototype !== null) {
     invalidPreparedData(`prepared data contains unsupported mutable ${prototype?.constructor?.name ?? "object"}`);
   }
   const copy = Object.create(null) as Record<PropertyKey, unknown>;
+  activeCopies.set(value, copy);
   for (const key of Reflect.ownKeys(value)) {
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (!descriptor || !("value" in descriptor)) {
       invalidPreparedData(`prepared data property ${String(key)} must be a non-executable data property`);
     }
     Object.defineProperty(copy, key, {
-      value: immutableCopy(descriptor.value, nextAncestors),
+      value: immutableCopy(descriptor.value, nextAncestors, activeCopies),
       enumerable: descriptor.enumerable,
       configurable: false,
       writable: false,
     });
   }
+  activeCopies.delete(value);
   return Object.freeze(copy);
 }
 

--- a/tests/issue-3520-class-shape-identity.test.ts
+++ b/tests/issue-3520-class-shape-identity.test.ts
@@ -110,7 +110,7 @@ function expectPlanningError(run: () => unknown, code: IrPlanningIdentityInvaria
 }
 
 describe("#3520 exact class-shape identity", () => {
-  it("orders acyclic forward class-position dependencies by exact identity and leaves cycles stable", () => {
+  it("orders acyclic forward dependencies and keeps recursive-cell groups stable by exact identity", () => {
     const graph = fixture({
       "/repo/a.ts": `
         class Holder {

--- a/tests/issue-3520-class-shape-type-identity.test.ts
+++ b/tests/issue-3520-class-shape-type-identity.test.ts
@@ -13,6 +13,7 @@ import {
   irTypeEquals,
   irUnitFuncRef,
   planLinearMemory,
+  verifyIrBackendLegality,
   type IrClassShape,
   type IrFunction,
   type IrType,
@@ -138,5 +139,35 @@ describe("#3520 source-qualified class-shape type identity", () => {
     expect(secondLayout).toBeDefined();
     expect(firstLayout?.id).not.toBe(secondLayout?.id);
     expect(plan.layouts.filter((layout) => layout.id.startsWith("record:class:"))).toHaveLength(2);
+  });
+
+  it("plans and verifies mutually recursive class layouts without losing nominal identity", () => {
+    const left = sameLabelShape("@test/recursive-left.ts");
+    const right = sameLabelShape("@test/recursive-right.ts");
+    (left.fields as { name: string; type: IrType }[]).push({ name: "right", type: { kind: "class", shape: right } });
+    (right.fields as { name: string; type: IrType }[]).push({ name: "left", type: { kind: "class", shape: left } });
+    const leftType: IrType = { kind: "class", shape: left };
+    const registry = new AllocSiteRegistry();
+    const builder = new IrFunctionBuilder(identities.next("recursive-layout"), [leftType], false, registry);
+    const value = builder.addParam("value", leftType);
+    builder.openBlock();
+    builder.terminate({ kind: "return", values: [value] });
+    const func = builder.finish();
+
+    const linearErrors = verifyIrBackendLegality(func, "linear");
+    expect(linearErrors).toHaveLength(4);
+    expect(linearErrors.every((error) => error.message.includes("does not support IR type 'class'"))).toBe(true);
+    expect(linearErrors.map((error) => error.message)).toContain(
+      "param value.right.left: linear backend does not support IR type 'class'",
+    );
+    expect(verifyIrBackendLegality(func, "wasmgc")).toEqual([]);
+    const plan = planLinearMemory({ functions: [func] }, registry);
+    expect(plan.layoutForClassShape(left)?.id).not.toBe(plan.layoutForClassShape(right)?.id);
+    expect(plan.layouts.filter((layout) => layout.id.startsWith("record:class:")).map((layout) => layout.id)).toEqual(
+      expect.arrayContaining([
+        `record:class:${JSON.stringify(left.classId)}`,
+        `record:class:${JSON.stringify(right.classId)}`,
+      ]),
+    );
   });
 });

--- a/tests/issue-3521-prepared-ir-program.test.ts
+++ b/tests/issue-3521-prepared-ir-program.test.ts
@@ -14,6 +14,7 @@ import {
   type IrUnitId,
 } from "../src/ir/identity.js";
 import { PreparedIrProgramBuilder, type PreparedIrIrCandidateInput } from "../src/ir/prepare.js";
+import { IR_CLASS_SHAPE_CELL, type IrClassShape } from "../src/ir/nodes.js";
 import {
   createPreparedIrCandidateProgram,
   preparedIrReadonlyMap,
@@ -791,6 +792,59 @@ describe("#3521 PreparedIrProgram structural ownership", () => {
           supportIntentCandidates: program.supportIntentCandidates,
           allocationCandidates: program.allocationCandidates,
           provenanceCandidates: program.provenanceCandidates,
+        }),
+      "invalid-prepared-data",
+    );
+  });
+
+  it("owns exact recursive class-shape cells while rejecting unbranded lookalike cycles", () => {
+    const { abi, alpha, beta, legacy } = preparedCoreFixture();
+    const left = {
+      [IR_CLASS_SHAPE_CELL]: true,
+      classId: "ir-class:v1:test:root:class:0",
+      className: "Left",
+      fields: [],
+      methods: [],
+      constructorParams: [],
+    } as unknown as IrClassShape;
+    const right = {
+      [IR_CLASS_SHAPE_CELL]: true,
+      classId: "ir-class:v1:test:root:class:1",
+      className: "Right",
+      fields: [],
+      methods: [],
+      constructorParams: [],
+    } as unknown as IrClassShape;
+    (left.fields as { name: string; type: unknown }[]).push({ name: "right", type: { kind: "class", shape: right } });
+    (right.fields as { name: string; type: unknown }[]).push({ name: "left", type: { kind: "class", shape: left } });
+
+    const builder = new PreparedIrProgramBuilder(abi);
+    builder.recordIrCandidate({ ...preparedInput(alpha.id, "alpha"), irCandidate: { shape: left } });
+    builder.recordIrCandidate(preparedInput(beta.id, "beta"));
+    builder.recordDirectCandidate({ unitId: legacy.id, code: "x", stage: "select", detail: "x" });
+    const program = builder.seal();
+    const ownedLeft = (program.irCandidates.get(alpha.id)?.irCandidate as { shape: IrClassShape }).shape;
+    const ownedRight = (ownedLeft.fields[0]!.type as { kind: "class"; shape: IrClassShape }).shape;
+    expect((ownedRight.fields[0]!.type as { kind: "class"; shape: IrClassShape }).shape).toBe(ownedLeft);
+    expect(Object.isFrozen(ownedLeft)).toBe(true);
+    expect(Object.isFrozen(ownedRight)).toBe(true);
+
+    const lookalike = {
+      classId: "ir-class:v1:test:root:class:2",
+      className: "Forged",
+      fields: [],
+      methods: [],
+      constructorParams: [],
+    } as Record<string, unknown>;
+    lookalike.self = lookalike;
+    const rejectedFixture = preparedCoreFixture();
+    const rejected = new PreparedIrProgramBuilder(rejectedFixture.abi);
+    const rejectedUnit = rejectedFixture.alpha;
+    expectPreparedInvariant(
+      () =>
+        rejected.recordIrCandidate({
+          ...preparedInput(rejectedUnit.id, "alpha"),
+          irCandidate: { shape: lookalike },
         }),
       "invalid-prepared-data",
     );

--- a/tests/issue-3522-ir-class-compile-once.test.ts
+++ b/tests/issue-3522-ir-class-compile-once.test.ts
@@ -1152,56 +1152,149 @@ describe("#3522 instance class-method compile-once ownership", () => {
   );
 
   it.each(["gc", "standalone"] as const)(
-    "keeps cyclic class ABIs on one typed direct path in the %s lane",
+    "prepares mutually recursive class layouts exactly once in the %s lane",
     async (target) => {
       const source = `
         class Left {
-          right: Right;
-          constructor(right: Right) { this.right = right; }
+          right!: Right;
+          constructor() {}
+          attach(right: Right): void { this.right = right; }
+          value(): number { return this.right.amount; }
         }
         class Right {
-          left: Left;
-          constructor(left: Left) { this.left = left; }
+          left!: Left;
+          amount: number;
+          constructor(amount: number) { this.amount = amount; }
+          attach(left: Left): void { this.left = left; }
         }
-        export function marker(): number { return 1; }
+        export function run(): number {
+          const left = new Left();
+          const right = new Right(7);
+          left.attach(right);
+          right.attach(left);
+          return left.value() + right.left.value();
+        }
       `;
-      const previous = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      const direct = await compile(source, {
+        fileName: `cyclic-class-constructor-abi-${target}.ts`,
+        experimentalIR: false,
+        emitWat: true,
+        target,
+      });
+      expect(direct.success, direct.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(direct.binary)).toBe(true);
+      expect((await instantiate(direct)).run!()).toBe(14);
+      const previousClassPoison = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      const previousFunctionPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
       try {
-        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
-        const direct = await compile(source, {
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = [
+          "Left_new",
+          "Left_attach",
+          "Left_value",
+          "Right_new",
+          "Right_attach",
+        ].join(",");
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+        const result = await compile(source, {
           fileName: `cyclic-class-constructor-abi-${target}.ts`,
           experimentalIR: true,
           trackIrOutcomes: true,
           emitWat: true,
           target,
         });
-        expect(direct.success, direct.errors.map((error) => error.message).join("\n")).toBe(true);
-        expect(WebAssembly.validate(direct.binary)).toBe(true);
-        for (const name of ["Left_new", "Right_new"]) {
-          expect(classMemberOutcome(direct, name)).toMatchObject({
-            kind: "unsupported",
-            stage: "select",
-            legacyBodyEmitted: true,
-            irBodyEmitted: false,
+        expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(result.binary)).toBe(true);
+        for (const name of ["Left_new", "Left_attach", "Left_value", "Right_new", "Right_attach"]) {
+          expect(classMemberOutcome(result, name)).toMatchObject({
+            kind: "emitted",
+            legacyBodyEmitted: false,
+            irBodyEmitted: true,
           });
         }
-        expect(direct.irPostClaimErrors ?? []).toEqual([]);
-        expect(watTypeDefinition(direct.wat, "Left")).toContain("(field $right (mut externref))");
+        expect(functionOutcome(result, "run")).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+        expect(result.irPostClaimErrors ?? []).toEqual([]);
+        expect(watTypeDefinition(result.wat, "Left")).toContain("(field $right (mut (ref null");
+        expect(watTypeDefinition(result.wat, "Right")).toContain("(field $left (mut (ref null");
+        for (const name of ["Left_attach", "Left_value", "Right_attach", "run"]) {
+          expect(watFunctionBody(result.wat, name)).not.toMatch(
+            /any\.convert_extern|extern\.convert_any|ref\.(?:test|cast)|call_ref|call_indirect/,
+          );
+        }
+        expect((await instantiate(result)).run!()).toBe(14);
+        expect(result.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+      } finally {
+        if (previousClassPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClassPoison;
+        if (previousFunctionPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunctionPoison;
+      }
+    },
+  );
 
-        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Left_new,Right_new";
-        const poisoned = await compile(source, {
-          fileName: `cyclic-class-constructor-abi-${target}.ts`,
+  it.each(["gc", "standalone"] as const)(
+    "prepares a self-recursive class layout exactly once in the %s lane",
+    async (target) => {
+      const source = `
+        class Node {
+          next!: Node;
+          value: number;
+          constructor(value: number) { this.value = value; }
+          link(next: Node): void { this.next = next; }
+          sum(): number { return this.value + this.next.value; }
+        }
+        export function run(): number {
+          const first = new Node(3);
+          const second = new Node(4);
+          first.link(second);
+          return first.sum();
+        }
+      `;
+      const previousClassPoison = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      const previousFunctionPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Node_new,Node_link,Node_sum";
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+        const result = await compile(source, {
+          fileName: `self-recursive-class-layout-${target}.ts`,
           experimentalIR: true,
           trackIrOutcomes: true,
+          emitWat: true,
           target,
         });
-        expect(poisoned.success).toBe(false);
-        expect(poisoned.errors.some((error) => error.message.includes("injected direct class-body poison:"))).toBe(
-          true,
-        );
+        expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(result.binary)).toBe(true);
+        for (const name of ["Node_new", "Node_link", "Node_sum"]) {
+          expect(classMemberOutcome(result, name)).toMatchObject({
+            kind: "emitted",
+            legacyBodyEmitted: false,
+            irBodyEmitted: true,
+          });
+        }
+        expect(functionOutcome(result, "run")).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+        expect(watTypeDefinition(result.wat, "Node")).toContain("(field $next (mut (ref null");
+        for (const name of ["Node_link", "Node_sum", "run"]) {
+          expect(watFunctionBody(result.wat, name)).not.toMatch(
+            /any\.convert_extern|extern\.convert_any|ref\.(?:test|cast)|call_ref|call_indirect/,
+          );
+        }
+        expect((await instantiate(result)).run!()).toBe(7);
       } finally {
-        if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
-        else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previous;
+        if (previousClassPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClassPoison;
+        if (previousFunctionPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunctionPoison;
       }
     },
   );


### PR DESCRIPTION
## Description

- preallocate exact compiler-branded class-shape cells so self and mutually recursive flat classes prepare through IR
- finalize recursive physical field references before body emission without replacing Program ABI type cells
- preserve prepared-data safety by admitting cycles only through branded class shapes, and make legality/layout analysis cycle-safe
- keep inheritance, nested/class-expression, generic, inferred, externref-backed, and multi-source families on their existing direct route

## Migration evidence

- mutual cycle: 6 terminal bodies move from legacy to IR; self cycle: 4 terminal bodies use IR
- direct class/function poison active in GC and standalone; runtime results are 14 and 7
- exact migrated bodies use nullable nominal refs, typed struct access, and direct calls with no extern conversions, casts/tests, or indirect calls
- prepared mutual-cycle artifacts are no larger than the same-source direct artifacts
- IR-only hybrid and strict shadows: 37/37 IR, 0 legacy, 0 unsupported, 0 invariants
- fallback and shape gates: zero unintended/post-claim/module-level increases and zero attributed shape rejections

## Validation

- focused R2/R3 matrix: 126/126
- changed root suites after final rebase: 71/71
- equivalence: 1,645 pass, 24 known failures, zero new regressions (12 stale baseline failures now pass)
- cross-backend differential: 29/29
- typecheck, lint, formatting, issue integrity, oracle, adoption, optimization-retirement, LOC, and function-budget gates pass

Tracked in [plan/issues/3522-ir-r3-classes-closures-compile-once.md](../blob/codex/3522-recursive-class-layout/plan/issues/3522-ir-r3-classes-closures-compile-once.md).

## CLA

- [x] I have read and agree to the CLA
