### PR TITLE
feat(ir): prepare inherited forward class layouts

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -1160,6 +1160,43 @@ inheritance without allowing recursive heritage, then tackles nested/class-
 expression ownership. The obsolete direct implementation is removed in the
 same later transaction that proves its last consumer is gone.
 
+### Inherited class-layout checkpoint (2026-08-13)
+
+Exact forward class fields now remain typed through local user inheritance.
+The physical class collector deliberately shares each parent's `FieldDef`
+objects with its descendants, so the post-collection finalizer updates a
+parent-owned forward slot once and every already-collected subtype observes
+the same `(ref null $Target)` storage. A forward field declared by the child is
+finalized independently. No struct is replaced, no type is reordered, and
+externref-backed, nested, generic, optional, union, or inferred layouts remain
+outside this transaction.
+
+Derived classes now receive the same identity-stable provisional class-shape
+cells as flat classes. Projection adds the exact heritage parent as a
+dependency, guaranteeing that implicit constructor forwarding reads a fully
+populated parent ABI while recursive field edges still use stable cells. The
+existing earlier-parent rule rejects later, foreign, builtin, and unresolved
+heritage, so this does not admit recursive inheritance or widen the supported
+extends surface.
+
+The GC/standalone proof uses an exact three-level hierarchy. `Base.current`
+references later `Value`, `Child.other` references the same target, and
+`Value` itself extends an earlier `Amount`. All six class terminals plus the
+top-level caller record `legacyBodyEmitted:false, irBodyEmitted:true` while
+both direct-body poison seams are active. Direct and IR binaries validate and
+return `13`; the IR artifact is no larger than direct. WAT requires exact typed
+storage in both `Base` and the inherited prefix of `Child`, rejects externref
+and indirect dispatch in migrated bodies, and pins the derived initializer to
+one static parent narrowing plus one direct parent call before its typed
+`struct.set`.
+
+The complete class compile-once file passes **42/42** after the change. This
+checkpoint does not delete a shared direct implementation: nested/class-
+expression owners and the remaining typed fallback policies still consume the
+class collector/body machinery. After publication, the next serial R3 family
+is exact nested/class-expression ownership; shared code is removed only with
+the last proven consumer.
+
 ## Exhaustive source-unit census
 
 Before preparing any body, walk the source once in lexical/source order and

--- a/src/codegen/class-field-layout.ts
+++ b/src/codegen/class-field-layout.ts
@@ -22,10 +22,6 @@ function fixedFieldName(name: ts.PropertyName): string | undefined {
   return undefined;
 }
 
-function isFlatClass(declaration: ts.ClassDeclaration): boolean {
-  return declaration.heritageClauses?.every((clause) => clause.token !== ts.SyntaxKind.ExtendsKeyword) ?? true;
-}
-
 function exactLocalClassReference(
   ctx: CodegenContext,
   sourceFile: ts.SourceFile,
@@ -49,27 +45,6 @@ function exactLocalClassReference(
   }
   const classId = identity.classIdByDeclaration.get(declaration);
   return classId !== undefined && identity.declarationByClassId.get(classId) === declaration ? declaration : undefined;
-}
-
-function inheritanceParticipants(
-  ctx: CodegenContext,
-  declarations: readonly ts.ClassDeclaration[],
-): ReadonlySet<ts.ClassDeclaration> {
-  const local = new Set(declarations);
-  const participants = new Set<ts.ClassDeclaration>();
-  for (const declaration of declarations) {
-    for (const clause of declaration.heritageClauses ?? []) {
-      if (clause.token !== ts.SyntaxKind.ExtendsKeyword) continue;
-      participants.add(declaration);
-      for (const inherited of clause.types) {
-        const parents = ctx.oracle.declarationsOf(inherited.expression);
-        if (parents.length !== 1) continue;
-        const parent = parents[0];
-        if (parent && ts.isClassDeclaration(parent) && local.has(parent)) participants.add(parent);
-      }
-    }
-  }
-  return participants;
 }
 
 function requireCommittedField(
@@ -98,11 +73,14 @@ function requireCommittedField(
 }
 
 /**
- * Commit exact references from flat top-level fields to later local
- * classes without replacing an observed StructTypeDef or changing type order.
+ * Commit exact references from top-level fields to later local classes
+ * without replacing an observed StructTypeDef or changing type order.
  *
- * Inherited, nested, generic, union, optional, inferred, and
- * externref-backed layouts deliberately remain on the typed direct route.
+ * A derived layout reuses the exact FieldDef objects from its parent prefix,
+ * so finalizing a parent-owned slot in place also finalizes every collected
+ * descendant without rebuilding its subtype. Nested, generic, union,
+ * optional, inferred, and externref-backed layouts remain on the typed direct
+ * route.
  */
 export function finalizeForwardClassFieldLayouts(ctx: CodegenContext, sourceFile: ts.SourceFile): void {
   if (!ctx.irPlanningIdentityContext) return;
@@ -114,16 +92,9 @@ export function finalizeForwardClassFieldLayouts(ctx: CodegenContext, sourceFile
     const name = declaration.name!.text;
     nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
   }
-  const inherited = inheritanceParticipants(ctx, declarations);
-
   for (const owner of declarations) {
     const ownerName = owner.name!.text;
-    if (
-      !isFlatClass(owner) ||
-      inherited.has(owner) ||
-      nameCounts.get(ownerName) !== 1 ||
-      ctx.classExternrefBackedSet.has(ownerName)
-    ) {
+    if (nameCounts.get(ownerName) !== 1 || ctx.classExternrefBackedSet.has(ownerName)) {
       continue;
     }
     const fieldNameCounts = new Map<string, number>();
@@ -142,8 +113,6 @@ export function finalizeForwardClassFieldLayouts(ctx: CodegenContext, sourceFile
         fieldNameCounts.get(fieldName) !== 1 ||
         !target?.name ||
         target.getStart(sourceFile) <= owner.getStart(sourceFile) ||
-        !isFlatClass(target) ||
-        inherited.has(target) ||
         nameCounts.get(target.name.text) !== 1 ||
         ctx.classExternrefBackedSet.has(target.name.text)
       ) {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1298,7 +1298,7 @@ function buildIrClassShapes(
     declarationsInCollectionOrder,
     identityContext,
   );
-  // Flat local classes are allocated as identity-stable descriptor cells
+  // Local classes are allocated as identity-stable descriptor cells
   // before any member type is projected. TypeScript permits self-recursive and
   // mutually recursive annotations, so a later class must be resolvable while
   // its descriptor is still being filled. The cells are planning-only: only
@@ -1306,12 +1306,7 @@ function buildIrClassShapes(
   const provisionalEntries = new Map<IrClassId, IrClassShapeEntry>();
   const populatedProvisionalIds = new Set<IrClassId>();
   for (const { classId, declaration } of declarationsInCollectionOrder) {
-    if (
-      !ts.isClassDeclaration(declaration) ||
-      !declaration.name ||
-      declaration.parent !== sourceFile ||
-      declaration.heritageClauses?.some((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword) === true
-    ) {
+    if (!ts.isClassDeclaration(declaration) || !declaration.name || declaration.parent !== sourceFile) {
       continue;
     }
     const className = declaration.name.text;

--- a/src/codegen/ir-class-shapes.ts
+++ b/src/codegen/ir-class-shapes.ts
@@ -327,6 +327,29 @@ export function orderIrClassShapeDeclarationsForProjection(
       }
     };
 
+    // A derived descriptor consumes its exact parent shape in addition to its
+    // annotated member types. Keep the source-authoritative earlier-parent
+    // policy in buildIrClassShapes, but order an admitted parent before its
+    // child so implicit constructor forwarding never observes an unpopulated
+    // provisional cell.
+    const heritage = entry.declaration.heritageClauses?.find((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword);
+    const parentExpression = heritage?.types[0]?.expression;
+    if (parentExpression) {
+      const parentDeclarations = oracle.declarationsOf(parentExpression);
+      if (parentDeclarations.length === 1) {
+        const parentDeclaration = parentDeclarations[0];
+        if (
+          parentDeclaration &&
+          (ts.isClassDeclaration(parentDeclaration) || ts.isClassExpression(parentDeclaration))
+        ) {
+          const dependency = context.classIdByDeclaration.get(parentDeclaration);
+          if (dependency !== undefined && dependency !== entry.classId && byClassId.has(dependency)) {
+            required.add(dependency);
+          }
+        }
+      }
+    }
+
     for (const member of entry.declaration.members) {
       if (ts.isConstructorDeclaration(member)) {
         if (hasFixedClassShapeParameters(member.parameters)) {

--- a/tests/issue-3522-ir-class-compile-once.test.ts
+++ b/tests/issue-3522-ir-class-compile-once.test.ts
@@ -1120,34 +1120,120 @@ describe("#3522 instance class-method compile-once ownership", () => {
   );
 
   it.each(["gc", "standalone"] as const)(
-    "keeps forward-field inheritance outside this layout checkpoint in the %s lane",
+    "prepares an inherited forward-field layout exactly once in the %s lane",
     async (target) => {
       const source = `
+        class Amount {
+          amount: number;
+          constructor(amount: number) { this.amount = amount; }
+        }
         class Base {
           current: Value;
           constructor(current: Value) { this.current = current; }
+          read(): number { return this.current.amount; }
         }
-        class Child extends Base {}
-        class Value { amount: number; }
-        export function marker(): number { return 1; }
+        class Child extends Base {
+          other: Value;
+          constructor(current: Value, other: Value) {
+            super(current);
+            this.other = other;
+          }
+          combined(): number { return this.current.amount + this.other.amount; }
+        }
+        class Value extends Amount {
+          constructor(amount: number) { super(amount); }
+        }
+        export function run(): number {
+          const child = new Child(new Value(4), new Value(5));
+          return child.read() + child.combined();
+        }
       `;
-      const result = await compile(source, {
+      const direct = await compile(source, {
         fileName: `forward-class-field-inheritance-${target}.ts`,
-        experimentalIR: true,
-        trackIrOutcomes: true,
+        experimentalIR: false,
         emitWat: true,
         target,
       });
+      const previousClassPoison = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+      const previousFunctionPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let result: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY =
+          "Amount_new,Base_new,Base_read,Child_new,Child_combined,Value_new";
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+        result = await compile(source, {
+          fileName: `forward-class-field-inheritance-${target}.ts`,
+          experimentalIR: true,
+          trackIrOutcomes: true,
+          emitWat: true,
+          target,
+        });
+      } finally {
+        if (previousClassPoison === undefined) {
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+        } else {
+          process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClassPoison;
+        }
+        if (previousFunctionPoison === undefined) {
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        } else {
+          process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunctionPoison;
+        }
+      }
 
-      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-      expect(WebAssembly.validate(result.binary)).toBe(true);
-      expect(classMemberOutcome(result, "Base_new")).toMatchObject({
-        kind: "unsupported",
-        legacyBodyEmitted: true,
-        irBodyEmitted: false,
+      for (const compiled of [direct, result]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!()).toBe(13);
+      }
+      for (const name of ["Amount_new", "Base_new", "Base_read", "Child_new", "Child_combined", "Value_new"]) {
+        expect(classMemberOutcome(result, name)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+        });
+      }
+      expect(functionOutcome(result, "run")).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
       });
-      expect(watTypeDefinition(result.wat, "Base")).toContain("(field $current (mut externref))");
-      expect(watTypeDefinition(result.wat, "Child")).toContain("(field $current (mut externref))");
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+      expect(result.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+      expect(watTypeDefinition(direct.wat, "Base")).toContain("(field $current (mut externref))");
+      expect(watTypeDefinition(direct.wat, "Child")).toContain("(field $current (mut externref))");
+
+      const valueTypeIdx = watNullableRefResultTypeIndex(watFunctionBody(result.wat, "Value_new"), "Value_new");
+      expect(watTypeDefinition(result.wat, "Base")).toContain(`(field $current (mut (ref null ${valueTypeIdx})))`);
+      expect(watTypeDefinition(result.wat, "Child")).toContain(`(field $current (mut (ref null ${valueTypeIdx})))`);
+      expect(watTypeDefinition(result.wat, "Child")).toContain(`(field $other (mut (ref null ${valueTypeIdx})))`);
+      for (const name of ["Base_init", "Base_read", "Child_combined"]) {
+        expect(watFunctionBody(result.wat, name)).not.toMatch(
+          /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.(?:test|cast)/,
+        );
+      }
+      // Preserve the direct-super optimization: the derived initializer uses
+      // one static subtype-to-parent narrowing and one direct call, never a
+      // dynamic dispatch ladder or an externref conversion.
+      const childInit = watFunctionBody(result.wat, "Child_init");
+      expect(watInstructionOpcodes(childInit)).toEqual([
+        "local.get",
+        "local.get",
+        "ref.cast",
+        "call",
+        "drop",
+        "local.get",
+        "local.get",
+        "struct.set",
+        "local.get",
+        "return",
+      ]);
+      expect(childInit).not.toMatch(
+        /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.test/,
+      );
+      const runBody = watFunctionBody(result.wat, "run");
+      expect(runBody).not.toMatch(/externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.test/);
+      expect(runBody.match(/ref\.cast/g) ?? []).toHaveLength(1);
     },
   );
 


### PR DESCRIPTION
## Summary
- extend exact forward class-field layout finalization through local user inheritance without replacing Program ABI type cells
- preallocate derived class-shape cells and order exact parent projection before child projection
- preserve typed field storage, direct super lowering, runtime behavior, and smaller-or-equal IR artifacts in GC and standalone
- update the Markdown migration issue with the checkpoint and remaining handoff

## Validation
- focused R2/R3 matrix: 155/155
- class compile-once suite: 42/42
- strict IR-only shadow: 37/37 IR, 0 legacy, 0 unsupported, 0 invariant
- fallback and shape gates: zero unintended/post-claim/module-level/shape increases
- cross-backend differential: 29/29
- equivalence: 1,645 pass, 24 known failure, zero new regressions, 12 stale baseline passes
- typecheck, lint, formatting, issue integrity, oracle, LOC/function budget, and pre-push gates passed

Tracks the active work in `plan/issues/3522-ir-r3-classes-closures-compile-once.md`; no GitHub issue is used.