### PR TITLE
feat(ir): prepare bounded nested class components

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -70,16 +70,19 @@ files:
   - tests/issue-3792-ir-optimization-retirement-gate.test.ts
 loc-budget-allow:
   - src/codegen/class-bodies.ts
+  - src/codegen/declarations.ts
   - src/codegen/index.ts
   - src/codegen/program-abi-session.ts
   - src/ir/builder.ts
   - src/ir/from-ast.ts
   - src/ir/integration.ts
+  - src/ir/module-bindings.ts
   - src/ir/nodes.ts
   - src/ir/prepared-component-dependencies.ts
   - src/ir/select.ts
 func-budget-allow:
   - src/codegen/class-bodies.ts::collectClassDeclaration
+  - src/codegen/declarations.ts::compileDeclarations
   - src/codegen/function-body.ts::compileFunctionBody
   - src/codegen/index.ts::buildIrClassShapes
   - src/codegen/index.ts::generateModule
@@ -87,6 +90,8 @@ func-budget-allow:
   - src/ir/integration.ts::compileIrPathFunctions
   - src/ir/integration.ts::makeFromAstResolver
   - src/ir/prepared-component-dependencies.ts::collectFunctionEvidence
+  - src/ir/select-identity.ts::planIrCompilationByIdentity
+  - src/ir/select.ts::isPhase1StatementListInScope
   - src/ir/select.ts::whyNotIrClaimable
 ---
 
@@ -1196,6 +1201,71 @@ expression owners and the remaining typed fallback policies still consume the
 class collector/body machinery. After publication, the next serial R3 family
 is exact nested/class-expression ownership; shared code is removed only with
 the last proven consumer.
+
+### Bounded nested ordinary-class ownership checkpoint (2026-08-13)
+
+Named ordinary classes declared inside a function can now join the same
+prepare-before-emit transaction as their containing caller. The admitted
+family is deliberately effect-free at class-definition time: no heritage,
+decorators, static elements, computed keys, field initializers, async/generator
+methods, optional/rest/default parameters, or body captures. It has one fixed
+constructor and at least one fixed-name instance method. Those restrictions
+let the IR body treat the declaration as a lexical class binding while Program
+ABI owns every executable member before the containing body lowers.
+
+Identity inventory promotes the nested constructor and methods to exact
+terminal units with their containing function as owner. Selection is atomic:
+the caller, constructor, and every method must all claim with one projected
+class layout and exact callable graph, or the complete component stays direct.
+Prepared dependency sealing may borrow that nested layout only for exact
+members of the same containing owner. Declaration/body routing then visits the
+fully prepared class solely to correlate its skipped slots; neither the
+enclosing direct function compiler nor nested class-body compiler may emit the
+source bodies.
+
+The GC/standalone proof uses `run -> Calculator { constructor, add, scale }`.
+All four terminals share one prepared component and report
+`legacyBodyEmitted:false, irBodyEmitted:true` while both direct function and
+direct class-body poison seams are active. Both targets validate and return
+`715`; the prepared artifact is no larger than the same-source direct artifact.
+The constructor uses typed `struct.set`, both methods use typed `struct.get`,
+and migrated bodies reject extern conversions, casts/tests, `call_ref`, and
+`call_indirect`. A captured outer `offset` is the fail-closed control: the
+caller and every class member remain one Unsupported/direct component and
+return `42`, so a mixed caller/member policy cannot satisfy the test.
+
+The implementation preserves the separate nested-accessor policy. A focused
+audit initially exposed that projecting every nested class changed a TDZ/
+writeback accessor control from typed fallback into a late ABI failure. The
+candidate resolver and structural class-name set now widen only for this
+bounded ordinary family; all **21/21** accessor writeback tests pass, including
+the injected sibling-TDZ rejection, and the existing top-level default-
+parameter class retains its exact `class-projection-unsupported` outcome.
+
+Qualification after the inherited-layout checkpoint landed is green:
+
+- focused R2/R3 ownership matrix: **129/129**;
+- nested ordinary ownership plus accessor audit: **24/24**;
+- cross-backend differential: **29/29**;
+- equivalence: **1,645 passing, 24 known failures, zero new regressions**;
+- hybrid and strict shadows: **37/37 IR bodies, 0 legacy bodies, 0
+  Unsupported, 0 Invariants**;
+- ordinary fallback gate: zero unintended, post-claim, or module-level
+  increases; shape diagnostic: zero attributed body-shape rejections; and
+- typecheck, lint, and formatting pass.
+
+No shared direct implementation is deleted in this checkpoint. Class
+expressions and nested classes with inheritance, static/effectful elements,
+computed keys, initializers, flexible parameters, or captures still consume
+the nested class/body machinery. The remaining serial R3 checklist is:
+
+1. class-expression ownership and the remaining effect-free declaration
+   positions;
+2. closures, object methods/accessors, and cross-owner callable support;
+3. module initialization under #3523;
+4. runtime and linear-memory helpers; and
+5. delete each direct implementation when its final typed consumer reaches
+   zero, then enable IR-only as the default.
 
 ## Exhaustive source-unit census
 

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -1761,13 +1761,14 @@ function skipPreparedClassConstructorBody(
       return true;
     }
   }
-  if (!routing?.skipBodies.has(ctorName)) return false;
+  const unitId = ctx.irPlanningIdentityContext?.unitIdByDeclaration.get(declaration ?? classDeclaration);
+  const exactSkip = unitId !== undefined && routing?.skipBodyUnitIds?.has(unitId) === true;
+  if (!routing?.skipBodies.has(ctorName) && !exactSkip) return false;
   const newFuncIdx = ctx.funcMap.get(classMemberFuncKey(ctx, ctorName));
   const initKey = classMemberFuncKey(ctx, `${className}_init`);
   const initLocalIdx = funcByName.get(initKey);
   const initFuncIdx = ctx.funcMap.get(initKey);
   const initFunc = initLocalIdx === undefined ? undefined : ctx.mod.functions[initLocalIdx];
-  const unitId = ctx.irPlanningIdentityContext?.unitIdByDeclaration.get(declaration ?? classDeclaration);
   const terminal = unitId ? ctx.irPlanningIdentityContext?.terminalByUnitId.get(unitId) : undefined;
   const allocated = unitId ? ctx.programAbiClassCallables?.functionForUnit(unitId) : undefined;
   if (
@@ -1781,7 +1782,10 @@ function skipPreparedClassConstructorBody(
     throw new Error(`prepared constructor ${ctorName} has no exact source init owner`);
   }
   const preserveExactBody = routing.preserveSkippedBodyUnitIds?.has(unitId) === true;
-  if (preserveExactBody !== (routing.preserveSkippedBodies?.has(ctorName) === true)) {
+  if (
+    routing.skipBodies.has(ctorName) &&
+    preserveExactBody !== (routing.preserveSkippedBodies?.has(ctorName) === true)
+  ) {
     throw new Error(`prepared constructor ${ctorName} has inconsistent exact and legacy preserve ownership`);
   }
   if (preserveExactBody) {

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2636,6 +2636,35 @@ export function compileDeclarations(
       const isAmbient = hasDeclareModifier(stmt) || stmt.getSourceFile().isDeclarationFile;
       if (ts.isClassDeclaration(stmt) && stmt.name && !isAmbient) {
         if (insideFunction) {
+          const preparedBodyUnits = stmt.members
+            .filter(
+              (
+                member,
+              ): member is
+                | ts.ConstructorDeclaration
+                | ts.MethodDeclaration
+                | ts.GetAccessorDeclaration
+                | ts.SetAccessorDeclaration =>
+                (ts.isConstructorDeclaration(member) ||
+                  ts.isMethodDeclaration(member) ||
+                  ts.isGetAccessorDeclaration(member) ||
+                  ts.isSetAccessorDeclaration(member)) &&
+                member.body !== undefined,
+            )
+            .map((member) => ctx.irPlanningIdentityContext?.unitIdByDeclaration.get(member));
+          const fullyPrepared =
+            preparedBodyUnits.length > 0 &&
+            preparedBodyUnits.every(
+              (unitId) => unitId !== undefined && classBodyRouting?.skipBodyUnitIds?.has(unitId) === true,
+            );
+          if (fullyPrepared) {
+            // The enclosing IR body will not execute the direct nested-class
+            // statement. Visit the exact class here so the declaration pass
+            // correlates every skipped slot while preserving the bodies that
+            // the prepared transaction already installed.
+            compileClassBodies(ctx, stmt, funcByName, undefined, classBodyRouting);
+            continue;
+          }
           // Defer body compilation — will be compiled in compileNestedClassDeclaration
           // when the enclosing function is compiled (so captured locals are available)
           ctx.deferredClassBodies.add(stmt.name.text);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1306,7 +1306,7 @@ function buildIrClassShapes(
   const provisionalEntries = new Map<IrClassId, IrClassShapeEntry>();
   const populatedProvisionalIds = new Set<IrClassId>();
   for (const { classId, declaration } of declarationsInCollectionOrder) {
-    if (!ts.isClassDeclaration(declaration) || !declaration.name || declaration.parent !== sourceFile) {
+    if (!ts.isClassDeclaration(declaration) || !declaration.name) {
       continue;
     }
     const className = declaration.name.text;

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import type { IrHostVoidCallbackLoweringPlan, IrIntegrationLoweringPlans } from "../ir/ast-lowering-plans.js";
+import { isBoundedPreparedAccessorClass, isBoundedPreparedNestedOrdinaryClass } from "../ir/class-accessor-safety.js";
 import type { IrClassId, IrUnitId } from "../ir/identity.js";
 import { compileIrPathFunctions, type IrIntegrationReport, type IrTypeOverrideMap } from "../ir/integration.js";
 import { asVal, type IrClassShape, type IrType } from "../ir/nodes.js";
@@ -15,7 +16,6 @@ import { constructorHasIrSafeReceiverSemantics, type IrSelection } from "../ir/s
 import { MODULE_INIT_UNIT_NAME } from "../ir/module-init.js";
 import type { ValType, WasmFunction } from "../ir/types.js";
 import { ts } from "../ts-api.js";
-import { isBoundedPreparedAccessorClass } from "../ir/class-accessor-safety.js";
 import { withSelectedTopLevelAccessorUnitIds } from "../ir/module-bindings.js";
 import { resolveIrDynamicCarrierType } from "./any-helpers.js";
 import type { CodegenContext } from "./context/types.js";
@@ -203,11 +203,17 @@ export function selectPreparedClassMemberUnitIds(
     const staticAccessorBody = terminal?.kind === "class-static-getter" || terminal?.kind === "class-static-setter";
     const nestedAccessorBody =
       (instanceAccessorBody || staticAccessorBody) && terminal?.containingTerminalOwnerId !== undefined;
+    const nestedOrdinaryBody =
+      terminal?.containingTerminalOwnerId !== undefined &&
+      owner !== undefined &&
+      (ts.isClassDeclaration(owner) || ts.isClassExpression(owner)) &&
+      isBoundedPreparedNestedOrdinaryClass(owner);
     const selectedTopLevelStaticAccessorBody = staticAccessorBody && terminal?.containingTerminalOwnerId === undefined;
     if (
       (selectedUnitIds ? selectedUnitIds.has(claim.unitId) : selectedNames.has(claim.legacyMatchName)) &&
       (terminal?.kind === "class-static-method" ||
         ((instanceBody || constructorBody) && instanceHierarchyIsPreparable) ||
+        ((instanceBody || constructorBody) && nestedOrdinaryBody && classOwnerIsPreparable) ||
         ((nestedAccessorBody || selectedTopLevelStaticAccessorBody) && classOwnerIsPreparable)) &&
       declaration !== undefined &&
       (ts.isMethodDeclaration(declaration) ||

--- a/src/codegen/ir-prepared-nested-executable-syntax.ts
+++ b/src/codegen/ir-prepared-nested-executable-syntax.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import type { IrHostVoidCallbackLoweringPlan } from "../ir/ast-lowering-plans.js";
+import { isBoundedPreparedNestedOrdinaryClass } from "../ir/class-accessor-safety.js";
 import type { IrUnitId } from "../ir/identity.js";
 import { ts } from "../ts-api.js";
 
@@ -42,6 +43,9 @@ export function containsUnplannedNestedExecutableSyntax(
       seen.add(plan);
       ordinals.add(plan.liftedOrdinal);
       ts.forEachChild(node.body, visit);
+      return;
+    }
+    if ((ts.isClassDeclaration(node) || ts.isClassExpression(node)) && isBoundedPreparedNestedOrdinaryClass(node)) {
       return;
     }
     if (

--- a/src/codegen/program-abi-session.ts
+++ b/src/codegen/program-abi-session.ts
@@ -2399,7 +2399,9 @@ export class ProgramAbiSession {
       const classTypeIdx = classType ? this.module.types.indexOf(classType) : -1;
       const exactConsumers = terminals.every((terminal) => {
         if (!terminal || !classIntent) return false;
-        const accessor =
+        const exactNestedMember =
+          terminal.kind === "class-constructor" ||
+          terminal.kind === "class-instance-method" ||
           terminal.kind === "class-instance-getter" ||
           terminal.kind === "class-static-getter" ||
           terminal.kind === "class-instance-setter" ||
@@ -2415,7 +2417,7 @@ export class ProgramAbiSession {
           parsedFirstParam = undefined;
         }
         return (
-          accessor &&
+          exactNestedMember &&
           terminal.containingTerminalOwnerId !== undefined &&
           terminal.lexicalOwnerId === classIntent.classId &&
           this.terminalOwnerForKnownClass(classIntent.classId) === terminal.containingTerminalOwnerId &&

--- a/src/ir/class-accessor-safety.ts
+++ b/src/ir/class-accessor-safety.ts
@@ -57,6 +57,70 @@ export function isBoundedPreparedAccessorClass(declaration: ts.ClassDeclaration 
   });
 }
 
+function hasModifier(node: ts.Node, kind: ts.SyntaxKind): boolean {
+  return ts.canHaveModifiers(node) && (ts.getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false);
+}
+
+function hasFixedPreparedParameters(parameters: readonly ts.ParameterDeclaration[]): boolean {
+  return parameters.every(
+    (parameter) =>
+      ts.isIdentifier(parameter.name) &&
+      parameter.dotDotDotToken === undefined &&
+      parameter.questionToken === undefined &&
+      parameter.initializer === undefined &&
+      !hasDecorators(parameter),
+  );
+}
+
+/**
+ * Exact flat ordinary class family whose constructor and instance methods may
+ * be prepared independently of a still-direct containing executable.
+ *
+ * The restriction makes ClassDefinitionEvaluation inert: no heritage,
+ * decorators, computed keys, static work, or field initializers can execute in
+ * the containing frame. Body capture/type safety remains the structural
+ * selector's responsibility, and the identity selector admits the class only
+ * when every body-bearing member claims atomically.
+ */
+export function isBoundedPreparedNestedOrdinaryClass(declaration: ts.ClassDeclaration | ts.ClassExpression): boolean {
+  if (declaration.heritageClauses?.length || hasDecorators(declaration) || declaration.members.length === 0) {
+    return false;
+  }
+  let constructorCount = 0;
+  let methodCount = 0;
+  for (const member of declaration.members) {
+    if (hasDecorators(member) || hasModifier(member, ts.SyntaxKind.StaticKeyword)) return false;
+    if (ts.isPropertyDeclaration(member)) {
+      if (member.initializer !== undefined || (!ts.isIdentifier(member.name) && !ts.isPrivateIdentifier(member.name))) {
+        return false;
+      }
+      continue;
+    }
+    if (ts.isConstructorDeclaration(member)) {
+      if (!member.body) continue; // Type-only overload signature.
+      constructorCount++;
+      if (constructorCount !== 1 || !hasFixedPreparedParameters(member.parameters)) return false;
+      continue;
+    }
+    if (ts.isMethodDeclaration(member)) {
+      if (
+        !member.body ||
+        !ts.isIdentifier(member.name) ||
+        member.asteriskToken !== undefined ||
+        hasModifier(member, ts.SyntaxKind.AsyncKeyword) ||
+        hasModifier(member, ts.SyntaxKind.AbstractKeyword) ||
+        !hasFixedPreparedParameters(member.parameters)
+      ) {
+        return false;
+      }
+      methodCount++;
+      continue;
+    }
+    return false;
+  }
+  return constructorCount === 1 && methodCount > 0;
+}
+
 type LiteralComputedKeyValue = string | number;
 
 function literalOnlyComputedKeyValue(expression: ts.Expression): LiteralComputedKeyValue | undefined {

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1427,6 +1427,13 @@ function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void 
       lowerNestedFunctionDeclaration(s, cx);
       continue;
     }
+    if (ts.isClassDeclaration(s) && s.name && cx.classShapes?.has(s.name.text)) {
+      // The bounded nested-class selector proved ClassDefinitionEvaluation is
+      // effect-free and Program ABI preparation already installed every body.
+      // No runtime instruction is required; retain the lexical name only in
+      // the selector's class-shape registry.
+      continue;
+    }
     // Slice 3 (#1169c): bare call expression statement — lower the
     // call, drop the result. Lets `inc(); inc(); inc();` work.
     //

--- a/src/ir/identity.ts
+++ b/src/ir/identity.ts
@@ -2,6 +2,7 @@
 
 import { ts } from "../ts-api.js";
 import type { CompilerSourceOrigin, CompilerSourceProducer } from "../position-map.js";
+import { isBoundedPreparedNestedOrdinaryClass } from "./class-accessor-safety.js";
 import { collectModuleInitPopulation, MODULE_INIT_UNIT_NAME } from "./module-init.js";
 import type { IrPreparationFailure } from "./outcomes.js";
 
@@ -1043,16 +1044,21 @@ class SourceInventoryBuilder {
       const promoteNestedAccessor =
         directNestedClass &&
         (ts.isGetAccessorDeclaration(functionalMember) || ts.isSetAccessorDeclaration(functionalMember));
+      const promoteNestedOrdinary =
+        directNestedClass &&
+        isBoundedPreparedNestedOrdinaryClass(node) &&
+        (ts.isConstructorDeclaration(functionalMember) || ts.isMethodDeclaration(functionalMember));
+      const promoteNestedMember = promoteNestedAccessor || promoteNestedOrdinary;
 
       const unit =
-        topLevelDeclaration || promoteNestedAccessor
+        topLevelDeclaration || promoteNestedMember
           ? this.addTerminalUnit(
               ts.isConstructorDeclaration(functionalMember)
                 ? "class-constructor"
                 : this.classMemberKind(functionalMember),
               classRecord.id,
               member,
-              promoteNestedAccessor
+              promoteNestedMember
                 ? `${legacyName}@nested:${classRecord.declarationStart}:${member.getStart(this.sourceFile)}`
                 : legacyName,
               "class-member",
@@ -1060,7 +1066,7 @@ class SourceInventoryBuilder {
               anonymousFailure,
               true,
               memberSyntheticRole,
-              promoteNestedAccessor ? (inheritedTerminalOwnerId ?? undefined) : undefined,
+              promoteNestedMember ? (inheritedTerminalOwnerId ?? undefined) : undefined,
             )
           : this.addSupportUnit(
               ts.isConstructorDeclaration(functionalMember)
@@ -1076,7 +1082,7 @@ class SourceInventoryBuilder {
       this.scanCallable(
         functionalMember,
         unit.id,
-        topLevelDeclaration || promoteNestedAccessor ? unit.id : inheritedTerminalOwnerId,
+        topLevelDeclaration || promoteNestedMember ? unit.id : inheritedTerminalOwnerId,
       );
     }
 

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -7,7 +7,7 @@
 import { isExternalDeclaredClass } from "../checker/type-mapper.js";
 import { ts } from "../ts-api.js";
 import { updateRetypesModuleBinding } from "./update-retyped-bindings.js";
-import { isBoundedPreparedAccessorClass } from "./class-accessor-safety.js";
+import { isBoundedPreparedAccessorClass, isBoundedPreparedNestedOrdinaryClass } from "./class-accessor-safety.js";
 import { irModuleGlobalBindingId, irModuleTdzGlobalBindingId } from "./abi-bindings.js";
 import type { IrBindingId, IrClassId, IrSourceId, IrUnitId } from "./identity.js";
 import type { IrClassShape } from "./nodes.js";
@@ -189,12 +189,19 @@ export function makeIrIdentityLocalClassExpressionResolver(
   const declarationCounts = new Map<ts.ClassDeclaration, number>();
   const symbolCounts = new Map<ts.Symbol, number>();
   const candidates: ProjectedClass[] = [];
-  for (const statement of sourceFile.statements) {
-    if (!ts.isClassDeclaration(statement) || !statement.name) continue;
+  for (const record of identityContext.inventory.classes) {
+    if (record.sourceId !== sourceId) continue;
+    const statement = identityContext.declarationByClassId.get(record.id);
+    if (!statement || !ts.isClassDeclaration(statement) || !statement.name) continue;
+    // Existing nested accessor preparation intentionally leaves its containing
+    // function on the direct path. Only the bounded ordinary-class family owns
+    // the constructor/method/caller graph atomically, so only that family may
+    // widen local-class expression resolution beyond source-file declarations.
+    if (statement.parent !== sourceFile && !isBoundedPreparedNestedOrdinaryClass(statement)) continue;
     const legacyName = statement.name.text;
     const shape = projectedShapes.get(legacyName);
-    if (!shape || shape.className !== legacyName) continue;
-    const classId = identityContext.classIdByDeclaration.get(statement);
+    if (!shape || shape.className !== legacyName || shape.classId !== record.id) continue;
+    const classId = record.id;
     if (classId === undefined || identityContext.declarationByClassId.get(classId) !== statement) {
       return planningInvariant(
         "missing-class-declaration",

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -815,15 +815,17 @@ function addClassLayout(
     return;
   }
   const terminal = terminalInventoryUnit(inventory, evidence.terminalOwnerUnitId);
-  const borrowsOwnNestedAccessorLayout =
+  const borrowsOwnNestedClassLayout =
     terminalOwner !== null &&
     terminal?.containingTerminalOwnerId === terminalOwner &&
     terminal.lexicalOwnerId === shape.classId &&
-    (terminal.kind === "class-instance-getter" ||
+    (terminal.kind === "class-constructor" ||
+      terminal.kind === "class-instance-method" ||
+      terminal.kind === "class-instance-getter" ||
       terminal.kind === "class-static-getter" ||
       terminal.kind === "class-instance-setter" ||
       terminal.kind === "class-static-setter");
-  if (terminalOwner !== null && !candidateTerminalUnitIds.has(terminalOwner) && !borrowsOwnNestedAccessorLayout) {
+  if (terminalOwner !== null && !candidateTerminalUnitIds.has(terminalOwner) && !borrowsOwnNestedClassLayout) {
     addFailure(evidence, {
       code: "foreign-source-class",
       ownerUnitId: evidence.terminalOwnerUnitId,
@@ -839,7 +841,7 @@ function addClassLayout(
     structuralReferenceKey: irTypeBindingKey(ref.binding),
     expected: (intent) => intent.kind === "class" && intent.classId === shape.classId,
   });
-  if (borrowsOwnNestedAccessorLayout && !candidateTerminalUnitIds.has(terminalOwner)) {
+  if (borrowsOwnNestedClassLayout && !candidateTerminalUnitIds.has(terminalOwner)) {
     const key = `class-layout\u0000${ref.binding.bindingId}`;
     const dependency = evidence.abiDependencies.get(key);
     if (dependency) {

--- a/src/ir/select-identity.ts
+++ b/src/ir/select-identity.ts
@@ -12,7 +12,11 @@ import {
 import type { IrUnitTypeMap, TypeMap, TypeMapEntry } from "./propagate.js";
 import type { IrRecursiveTypeEvidence } from "./type-evidence.js";
 import type { IrClassMethodDescriptor } from "./nodes.js";
-import { exactPreparedAccessorSyntaxKey, isBoundedPreparedAccessorClass } from "./class-accessor-safety.js";
+import {
+  exactPreparedAccessorSyntaxKey,
+  isBoundedPreparedAccessorClass,
+  isBoundedPreparedNestedOrdinaryClass,
+} from "./class-accessor-safety.js";
 import {
   assessIrImplicitConstructorSubject,
   assessIrStructuralSelectorSubject,
@@ -627,7 +631,15 @@ export function planIrCompilationByIdentity(
   }
 
   const uniqueFunctions = uniqueDeclarationsByName(functionsByName);
-  const uniqueClasses = uniqueClassDeclarationsByName(classesByName);
+  const projectedClassCandidates = new Map(classesByName);
+  for (const candidate of classes) {
+    if (!ts.isClassDeclaration(candidate.declaration) || !candidate.declaration.name) continue;
+    if (candidate.declaration.parent === sourceFile) continue;
+    if (!isBoundedPreparedNestedOrdinaryClass(candidate.declaration)) continue;
+    if (options.projectedClassShapesById?.has(candidate.classId) !== true) continue;
+    addNameIndex(projectedClassCandidates, candidate.declaration.name.text, candidate);
+  }
+  const uniqueClasses = uniqueClassDeclarationsByName(projectedClassCandidates);
   const localClasses = new Set(uniqueClasses.keys());
   const asyncUnitIds = new Set(
     functions
@@ -692,22 +704,31 @@ export function planIrCompilationByIdentity(
       const parentName = extendsParentName(declaration);
       const parentIsLocal = parentName !== null && localClasses.has(parentName);
       const boundedAccessorClass = isBoundedPreparedAccessorClass(declaration);
+      const boundedNestedOrdinaryClass = nestedClass && isBoundedPreparedNestedOrdinaryClass(declaration);
       const boundedTopLevelAccessorClass =
         !nestedClass && ts.isClassDeclaration(declaration) && declaration.parent === sourceFile && boundedAccessorClass;
       const exactAccessorClass = nestedClass || boundedTopLevelAccessorClass;
       selectImplicitConstructorClaim(implicitSelection, { classId, declaration }, nestedClass, candidates.length);
-      const markExactAccessorClassFallback = (): void => {
+      const markBoundedClassFallback = (): void => {
         if (!trackFallbacks) return;
         for (const member of declaration.members) {
-          if ((!ts.isGetAccessorDeclaration(member) && !ts.isSetAccessorDeclaration(member)) || !member.body) continue;
+          if (
+            (!ts.isConstructorDeclaration(member) &&
+              !ts.isMethodDeclaration(member) &&
+              !ts.isGetAccessorDeclaration(member) &&
+              !ts.isSetAccessorDeclaration(member)) ||
+            !member.body
+          ) {
+            continue;
+          }
           const unitId = identityContext.unitIdByDeclaration.get(member);
           if (unitId !== undefined && identityContext.terminalByUnitId.has(unitId)) {
             reasons.set(unitId, "class-member-unsupported");
           }
         }
       };
-      if (nestedClass && !boundedAccessorClass) {
-        markExactAccessorClassFallback();
+      if (nestedClass && !boundedAccessorClass && !boundedNestedOrdinaryClass) {
+        markBoundedClassFallback();
         continue;
       }
       const exactAccessorDescriptors = new Map<
@@ -763,11 +784,11 @@ export function planIrCompilationByIdentity(
           accessorPlacementByKey.set(descriptor.name, staticPlacement);
         }
         if (hasAccessorSlotCollision || hasAccessorPlacementCollision || hasUnsafeComputedKey) {
-          markExactAccessorClassFallback();
+          markBoundedClassFallback();
           continue;
         }
       }
-      const pendingExactAccessorClaims = new Map<IrUnitId, IrIdentityClassMemberClaim>();
+      const pendingBoundedClassClaims = new Map<IrUnitId, IrIdentityClassMemberClaim>();
       for (const member of declaration.members) {
         if (
           (!ts.isConstructorDeclaration(member) &&
@@ -834,18 +855,20 @@ export function planIrCompilationByIdentity(
             : ts.isGetAccessorDeclaration(member)
               ? "getter"
               : "setter";
-          const descriptors = exactAccessorClass
+          const exactAccessorMember =
+            exactAccessorClass && (ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member));
+          const descriptors = exactAccessorMember
             ? exactAccessorDescriptors.get(member as ts.GetAccessorDeclaration | ts.SetAccessorDeclaration)
               ? [exactAccessorDescriptors.get(member as ts.GetAccessorDeclaration | ts.SetAccessorDeclaration)!]
               : []
             : descriptorName === null
               ? []
-              : (options.projectedClassShapes
-                  ?.get(className)
-                  ?.methods.filter(
-                    (candidate) =>
-                      candidate.name === descriptorName && (candidate.memberKind ?? "method") === descriptorKind,
-                  ) ?? []);
+              : ((exactClassShape ?? options.projectedClassShapes?.get(className))?.methods.filter(
+                  (candidate) =>
+                    candidate.name === descriptorName &&
+                    (candidate.memberKind ?? "method") === descriptorKind &&
+                    (!nestedClass || candidate.placement?.classId === classId),
+                ) ?? []);
           exactMemberDescriptor = descriptors.length === 1 ? descriptors[0] : undefined;
           if (!exactMemberDescriptor) {
             if (trackFallbacks) reasons.set(unit.unitId, "class-member-unsupported");
@@ -867,7 +890,7 @@ export function planIrCompilationByIdentity(
             : undefined;
         if (
           nestedClass &&
-          (ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member)) &&
+          (boundedNestedOrdinaryClass || ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member)) &&
           options.nestedClassMemberCallableAvailable?.(unit.unitId) !== true
         ) {
           if (trackFallbacks) reasons.set(unit.unitId, "class-member-unsupported");
@@ -889,23 +912,57 @@ export function planIrCompilationByIdentity(
           exactAccessorEvidence,
         );
         if (assessment.reason === null) {
-          if (exactAccessorClass) pendingExactAccessorClaims.set(unit.unitId, unit);
+          if (boundedAccessorClass || boundedNestedOrdinaryClass) pendingBoundedClassClaims.set(unit.unitId, unit);
           else classClaims.set(unit.unitId, unit);
         } else if (trackFallbacks) {
           reasons.set(unit.unitId, assessment.reason);
           if (assessment.detail !== undefined) details.set(unit.unitId, assessment.detail);
         }
       }
-      if (exactAccessorClass) {
-        const accessorCount = declaration.members.filter(
-          (member) => (ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member)) && !!member.body,
-        ).length;
-        if (pendingExactAccessorClaims.size === accessorCount) {
-          for (const [unitId, claim] of pendingExactAccessorClaims) classClaims.set(unitId, claim);
+      if (boundedAccessorClass || boundedNestedOrdinaryClass) {
+        const expectedCount = declaration.members.filter((member) => {
+          if (boundedAccessorClass) {
+            return (
+              (ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member)) && member.body !== undefined
+            );
+          }
+          return (ts.isConstructorDeclaration(member) || ts.isMethodDeclaration(member)) && member.body !== undefined;
+        }).length;
+        if (pendingBoundedClassClaims.size === expectedCount) {
+          for (const [unitId, claim] of pendingBoundedClassClaims) classClaims.set(unitId, claim);
         } else {
-          markExactAccessorClassFallback();
+          markBoundedClassFallback();
         }
       }
+    }
+  }
+
+  // Ordinary nested classes are one ownership atom with their containing
+  // function. Unlike the accessor-only writeback family, their constructor,
+  // methods, and every call site share one exact class-layout/callable graph.
+  // If any body rejects—or the enclosing function itself rejects—withdraw the
+  // complete class plus owner before lowering can observe a mixed component.
+  for (const { classId, declaration } of classes) {
+    if (!isBoundedPreparedNestedOrdinaryClass(declaration)) continue;
+    const terminals = identityContext.inventory.terminalUnits.filter(
+      (terminal) =>
+        terminal.lexicalOwnerId === classId &&
+        terminal.observedKind === "class-member" &&
+        terminal.containingTerminalOwnerId !== undefined,
+    );
+    if (terminals.length === 0) continue;
+    const ownerUnitId = terminals[0]!.containingTerminalOwnerId!;
+    const exactOwner = terminals.every((terminal) => terminal.containingTerminalOwnerId === ownerUnitId);
+    const allMembersClaimed = exactOwner && terminals.every((terminal) => classClaims.has(terminal.id));
+    const ownerClaimed = individuallyClaimed.has(ownerUnitId);
+    if (allMembersClaimed && ownerClaimed) continue;
+    for (const terminal of terminals) {
+      classClaims.delete(terminal.id);
+      if (trackFallbacks) reasons.set(terminal.id, "class-member-unsupported");
+    }
+    if (!allMembersClaimed && ownerClaimed) {
+      individuallyClaimed.delete(ownerUnitId);
+      if (trackFallbacks) reasons.set(ownerUnitId, "class-member-unsupported");
     }
   }
 

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -2988,6 +2988,16 @@ function isPhase1StatementListInScope(
       if (!isPhase1NestedFunc(s, scope, localClasses)) return false;
       continue;
     }
+    // #3522 — a strictly bounded nested class has no runtime definition
+    // effects. Exact Program ABI preparation owns its constructor/method
+    // bodies; this statement only introduces the class binding used by later
+    // `new` and method expressions in the enclosing IR body.
+    if (ts.isClassDeclaration(s) && s.name) {
+      const projected = currentLocalClassDeclarations.get(s.name.text);
+      if (projected !== s || !localClasses.has(s.name.text)) return shapeNo("nontail-class-unprepared", s);
+      scope.add(s.name.text);
+      continue;
+    }
     // Slice 3 (#1169c): bare call expression statement (drop the result).
     // Lets `inc(); inc(); inc();` patterns work for closures with side
     // effects through ref-cell captures.
@@ -6146,7 +6156,12 @@ function projectedConstructorArity(className: string): number | undefined {
 }
 
 function localClassValueIsUnshadowed(name: string, scope: ReadonlySet<string>): boolean {
-  return !scope.has(name) && !currentNestedFunctionNames.has(name) && !currentLexicalValueBindingNames.has(name);
+  const exactNestedClassBinding = scope.has(name) && currentLocalClassDeclarations.get(name)?.name !== undefined;
+  return (
+    (!scope.has(name) || exactNestedClassBinding) &&
+    !currentNestedFunctionNames.has(name) &&
+    (!currentLexicalValueBindingNames.has(name) || exactNestedClassBinding)
+  );
 }
 
 function localClassNameForExpression(expression: ts.Expression, scope: ReadonlySet<string>): string | null {

--- a/tests/issue-3522-ir-nested-class-ownership.test.ts
+++ b/tests/issue-3522-ir-nested-class-ownership.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const TARGETS = ["gc", "standalone"] as const;
+
+const SOURCE = `
+export function run(): number {
+  class Calculator {
+    value: number;
+    constructor(value: number) { this.value = value; }
+    add(delta: number): number { return this.value + delta; }
+    scale(factor: number): number { return this.value * factor; }
+  }
+  const calculator = new Calculator(5);
+  return calculator.add(2) * 100 + calculator.scale(3);
+}
+`;
+
+function outcome(result: CompileResult, name: string): IrObservedOutcome {
+  const observed = (result.irOutcomes ?? []).filter((candidate) => candidate.displayName.startsWith(name));
+  expect(observed, `terminal outcome count for ${name}`).toHaveLength(1);
+  return observed[0]!;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, Function>;
+  imports.setExports?.(exports);
+  return exports;
+}
+
+function watFunctionBody(wat: string, name: string): string {
+  const start = wat.indexOf(`  (func $${name}`);
+  expect(start, `missing $${name}`).toBeGreaterThanOrEqual(0);
+  const next = wat.indexOf("\n  (func $", start + 1);
+  return wat.slice(start, next < 0 ? wat.length : next);
+}
+
+describe("#3522 nested ordinary class ownership", () => {
+  it.each(TARGETS)("prepares the enclosing function, constructor, and methods once in the %s lane", async (target) => {
+    const direct = await compile(SOURCE, {
+      fileName: `nested-class-direct-${target}.ts`,
+      experimentalIR: false,
+      emitWat: true,
+      target,
+    });
+    const previousClassPoison = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+    const previousFunctionPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "Calculator_new,Calculator_add,Calculator_scale";
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+      prepared = await compile(SOURCE, {
+        fileName: `nested-class-prepared-${target}.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        emitWat: true,
+        target,
+      });
+    } finally {
+      if (previousClassPoison === undefined)
+        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClassPoison;
+      if (previousFunctionPoison === undefined)
+        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunctionPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!()).toBe(715);
+    }
+    const observed = [
+      outcome(prepared, "run"),
+      outcome(prepared, "Calculator_new"),
+      outcome(prepared, "Calculator_add"),
+      outcome(prepared, "Calculator_scale"),
+    ];
+    expect(new Set(observed.map((candidate) => candidate.preparedComponentId)).size).toBe(1);
+    for (const candidate of observed) {
+      expect(candidate).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+    }
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    for (const name of ["Calculator_init", "Calculator_add", "Calculator_scale", "run"]) {
+      expect(watFunctionBody(prepared.wat, name)).not.toMatch(
+        /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.(?:test|cast)/,
+      );
+    }
+    expect(watFunctionBody(prepared.wat, "Calculator_init")).toContain("struct.set");
+    expect(watFunctionBody(prepared.wat, "Calculator_add")).toContain("struct.get");
+    expect(watFunctionBody(prepared.wat, "Calculator_scale")).toContain("struct.get");
+  });
+
+  it("withdraws the complete nested class component when one body captures its enclosing frame", async () => {
+    const result = await compile(
+      `
+      export function run(): number {
+        let offset: number = 1;
+        class Calculator {
+          value: number;
+          constructor(value: number) { this.value = value + offset; }
+          scale(factor: number): number { return this.value * factor; }
+        }
+        return new Calculator(20).scale(2);
+      }
+      `,
+      { fileName: "nested-class-capture-fallback.ts", trackIrOutcomes: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    for (const name of ["run", "Calculator_new", "Calculator_scale"]) {
+      expect(outcome(result, name)).toMatchObject({
+        kind: "unsupported",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+    }
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- prepare a bounded, effect-free nested ordinary class together with its containing caller
- allocate exact Program ABI class layouts and constructor/method callables before any body emitter runs
- withdraw the complete component when a member captures or otherwise fails preparation
- preserve the separate nested-accessor fallback policy and document the remaining retirement checklist in plan/issues/3522

## Parity and optimization proof
- direct function/class-body poison proves the four positive fixture bodies are IR-only
- WasmGC and standalone return 715; captured fallback returns 42
- typed struct.get/struct.set remain; no extern conversion, cast/test, call_ref, or call_indirect in migrated bodies
- prepared binaries are no larger than the same-source direct binaries

## Validation
- focused R2/R3 ownership matrix: 129/129
- nested/accessor audit: 24/24
- post-rebase focused matrix: 49/49
- cross-backend differential: 29/29
- equivalence: 1,645 pass, 24 known failures, zero new regressions
- strict IR-only shadow: 37/37 IR, zero legacy/Unsupported/Invariant
- typecheck, lint, formatting, fallback, shape, LOC/function budget, issue integrity, oracle/coercion ratchets green

Refs #3522