### PR TITLE
docs(es5): specify eval and sparse-array IR slices

### DIFF
--- a/plan/issues/1164-dynamic-eval-via-js-host.md
+++ b/plan/issues/1164-dynamic-eval-via-js-host.md
@@ -3,7 +3,7 @@ id: 1164
 title: "Dynamic eval via JS host import — compile eval string to ad-hoc Wasm module (~416 tests)"
 status: done
 created: 2026-04-22
-updated: 2026-04-25
+updated: 2026-08-13
 completed: 2026-04-25
 priority: medium
 feasibility: medium
@@ -151,11 +151,14 @@ Provide `evalMode: "worker"` as an opt-in for security-sensitive contexts that
 already have Cross-Origin-Isolation headers. Document both modes in
 `src/runtime-eval.ts`.
 
-## Out of scope
+## Out of scope for the original host increment
 
-- Standalone/WASI eval — see #1165
+- The original implementation did not provide Standalone/WASI eval; #1165
+  owns that provider. Standalone eval is nevertheless inside the current
+  `plan/goals/es5.md` completion boundary and must be counted by the full-lane
+  acceptance gate below.
 - Scope capture (caller variables visible inside eval string) — see #1073
-- `new Function(...)` — follow-up
+- `new Function(...)` — follow-up, also inside the current ES5 goal boundary
 
 ## Acceptance criteria
 
@@ -248,3 +251,197 @@ properly closed.
 - Equivalence suite: 1186 / 1291 pass, 105 fail (pre-existing baseline; the
   pre-#1163 baseline was 1185 / 1291 — so this branch is net +1 with no new
   regressions)
+
+## Implementation Plan — 2026-08-13 ES5 residual
+
+### Architecture verdict
+
+Candidate `64b8f831151efe4c11f241b2889cc7eedbebd7f7` is a useful reference,
+not a merge-ready patch. Its two changes solve different problems and must be
+measured separately:
+
+1. The Test262 gain comes from making the existing legacy host-eval fallback
+   install its already-defined raw `assert.*` object.
+2. The IR change gives one exact **indirect**, result-discarded host eval shape
+   explicit import ownership. It does not implement direct-eval lexical scope,
+   value-producing eval, or standalone eval.
+
+The candidate's 121-row result is head-only evidence against an older
+baseline. Re-run both arms from the same current-main population before
+crediting any flip. In particular, do not describe the 88 direct-eval rows as
+IR wins: they continue through the legacy/reified dynamic-code path.
+
+### Root causes
+
+`wrapTest` cannot rewrite identifiers embedded in source strings. When such a
+string reaches `src/runtime.ts::_legacyHostEval`, raw calls such as
+`assert.sameValue(...)` are invisible to the current `needsShim` detector,
+even though the generated shim already defines `assert`. The fallback then
+executes the source in the global realm and throws `ReferenceError`.
+
+Separately, an IR-emitted body skips the legacy body emitter that used to
+register `env.__extern_eval`. An exact `(0, eval)(source);` statement can only
+be owned by IR if selection, call-graph classification, early import
+collection, lowering, and provider resolution agree on one certified shape.
+The candidate selector accepts any Phase-1 argument while the lowerer later
+rejects non-strings; that is a post-claim demotion and must be removed.
+
+### Changes
+
+**File: `src/runtime-eval.ts` — beside `createEvalShim` (line ~133)**
+
+- Add a small exported classifier for Test262 raw-assert syntax. Parse the
+  eval source with the existing `ts` import and return true only for an active
+  unshadowed `assert(...)`, `assert.<method>(...)`, or
+  `assert["<known method>"](...)` reference.
+- Treat any binding declaration named `assert` as a conservative no-match.
+  Comments and string/template text containing `assert.` must not match.
+- Keep this classifier harness-only; it must not change ordinary
+  `PerformEval` semantics or select an execution engine.
+
+**File: `src/runtime.ts` — `resolveImport` / `_legacyHostEval` (lines
+~8431 / ~9505)**
+
+- In `resolveImport`, inside the `name === "__extern_eval"` branch and
+  `_legacyHostEval`, include the raw-assert classifier in `needsShim` beside
+  the existing rewritten harness identifiers.
+- Reuse the existing shim body. Do not add another `assert` implementation,
+  expose host globals, or change the `dynamicCode` policy.
+- Preserve ES5.1 §15.1.2.1: a non-string eval argument returns unchanged.
+  This follow-up's IR statement slice may reject that shape, but the runtime
+  import must retain the general rule.
+
+**File: `src/eval-call-shape.ts` — `exactIndirectEvalIdentifier` (candidate
+line ~10; new file)**
+
+- Keep `exactIndirectEvalIdentifier` as the syntax recognizer for only the
+  canonical comma form `(0, eval)(source)` after parentheses are stripped.
+  The left operand must be the numeric literal zero and the right operand the
+  identifier `eval`.
+- Add or expose one shared shape check for: expression-statement position,
+  exactly one non-spread argument, and the exact callee above. Semantic checks
+  (ambient binding, host capability, proven string carrier) remain at the
+  phases that own those facts.
+
+**File: `src/ir/select.ts` — `isPhase1Expr` / `buildLocalCallGraph`
+(candidate lines ~6351 / ~7669)**
+
+- In `isPhase1Expr`, claim the exact indirect-eval statement only when all of
+  these are true: JS-host externs are enabled; `eval` resolves to the ambient
+  intrinsic and is not in the current scope; there is one non-spread argument;
+  the call's value is discarded; `expressionIsProvenString(argument)` is true;
+  and the argument is otherwise Phase-1 lowerable.
+- In `buildLocalCallGraph`, exempt the call from `hasExternalCall` only under
+  that same certified predicate. A broader graph exemption can incorrectly
+  admit a body the lowerer cannot build.
+- Direct `eval(source)`, result-producing indirect eval, shadowed eval,
+  optional/spread calls, and non-proven-string arguments must demote before an
+  IR claim.
+
+**File: `src/codegen/declarations/import-collector.ts` —
+`UnifiedCollectorState`, `unifiedVisitNode`, `finalizeUnifiedCollector`
+(candidate lines ~87 / ~228 / ~1355)**
+
+- Extend `UnifiedCollectorState` with the exact host-indirect-eval need and set
+  it in `unifiedVisitNode` only for the same statement/arity/ambient/string
+  slice. Use checker-backed string classification; do not arm the import for
+  every syntactic comma-eval in the module.
+- In `finalizeUnifiedCollector`, reserve
+  `env.__extern_eval : (externref, i32) -> externref` before body planning.
+  Reuse an existing function-map entry if one was already registered.
+
+**File: `src/ir/from-ast.ts` — `lowerCall` (candidate line ~5266)**
+
+- In `lowerCall`, repeat the certified checks defensively and lower the source
+  as a host-backed string. A failed invariant is a selection bug, not an
+  expected post-claim fallback.
+- Emit the symbolic call below with `isDirect = 0`. The expression statement
+  discards the returned `externref`; do not invent a result coercion contract
+  in this slice.
+
+**File: `src/ir/integration.ts` — `makeFromAstResolver` /
+`resolveAndObserveCallableProvider` (candidate lines ~4055 / ~4486)**
+
+- In `makeFromAstResolver`, expose only the existing host-extern, ambient
+  binding, and host-string facts needed by selection/lowering. Resolve the
+  symbolic import through the finalized function map; do not mutate import
+  indices while materializing an IR body.
+
+### Wasm IR ownership
+
+```text
+%source = lower_string(source)
+%boxed  = coerce_to_externref(%source)
+%result = call @env.__extern_eval(%boxed, i32.const 0)
+drop %result
+```
+
+This is a host-only IR path because the import is the capability. Direct eval
+must use the reified-binding path from #2925/#1073: a plain host import cannot
+observe the caller's lexical and variable environments. Standalone still
+needs #1165's runtime/compiler provider. Neither lane is excluded from the
+ES5 goal or from the full 9,029-row gate.
+
+### Semantic boundaries and controls
+
+- Positive IR probe: ambient `(0, eval)(source);` with a proven host string;
+  require `irBodyEmitted: true`, `legacyBodyEmitted: false`, one symbolic
+  `env.__extern_eval` import, and successful `assert.sameValue` execution.
+- Demotion controls: direct eval; used return value; non-string/dynamic union;
+  zero/two/spread arguments; shadowed `eval`; nonzero comma lhs; optional call.
+- Runtime controls: raw `assert.sameValue`, `assert.throws`, and callable
+  `assert`; rewritten `assert_sameValue`; a local `let assert`; and inert
+  `"assert."`, template text, and comments. The last three must not activate
+  or collide with the shim.
+- Preserve indirect global-scope behavior and direct lexical-scope behavior.
+  A passing Test262 assertion-visibility row is not evidence for either scope
+  rule unless the test actually observes it.
+- Preserve non-string passthrough, syntax/runtime exception identity, strict
+  caller behavior, nested eval, and dynamic-code deny/native/evaluator modes.
+
+### Same-population A/B and zero-loss gates
+
+At implementation start, record the exact latest `origin/main` SHA and use it
+as the base arm. The comparison arm is the exact implementation SHA. Both
+arms must use Test262 corpus gitlink
+`b363f29d3c43c626dc852744ad64a0b48a003693`, the same oracle revision,
+harness, target flags, timeout, and maintained file list.
+
+Run four focused arms on the maintained 120-file `assert is not defined`
+population plus passing and negative controls:
+
+1. current-main base;
+2. runtime raw-assert classifier only;
+3. full implementation;
+4. full implementation with the raw-assert classifier disabled as an
+   attribution kill switch.
+
+Require exact row accounting. Expected attribution is that the runtime-only
+arm owns the Test262 flips; the IR arm owns the inventory probe and must add no
+unexplained row changes. Report pass/fail/compile-error/timeout/skip totals and
+every transition, including unchanged runner errors.
+
+Finally run all **9,029** `<= ES5` tests in each lane through the authoritative
+original harness:
+
+- host/gc: 9,029 pass, zero fail/compile error/timeout/skip for goal closure;
+- standalone: 9,029 pass, zero fail/compile error/timeout/skip for goal closure;
+- for an incremental PR, at minimum zero `pass -> non-pass` in either lane and
+  no newly unmeasured rows.
+
+Eval, `Function`, and `with` rows are included. For standalone dynamic-code
+measurement, rebuild the compiler/runtime bundle and the configured evaluator
+provider, clear any provider cache, and report the provider tier; a trap-only
+instrumentation stub is not a passing eval implementation.
+
+### Candidate disposition and implementation handoff
+
+- Rebase/rederive from current main; use candidate `64b8f831...` only as a
+  reference.
+- Retain the narrow import-first IR design after aligning every predicate and
+  adding negative controls.
+- Replace the raw `jsSrc.includes("assert.")` heuristic with the syntax-aware
+  classifier above.
+- Do not claim direct eval, value-producing eval, or standalone eval from this
+  increment. Record their remaining exact rows under #2925/#1165 and keep them
+  inside the ES5 completion denominator.

--- a/plan/issues/4222-vec-index-delete-and-sparse-array-semantics.md
+++ b/plan/issues/4222-vec-index-delete-and-sparse-array-semantics.md
@@ -5,7 +5,7 @@ status: done
 completed: 2026-08-08
 sprint: current
 created: 2026-08-08
-updated: 2026-08-08
+updated: 2026-08-13
 priority: high
 horizon: l
 feasibility: medium
@@ -239,3 +239,236 @@ worth its own issue.
 
 **`arr.toString()` returns `undefined` in standalone** (gc: `"1,2,3"`). Not
 touched.
+
+## Implementation Plan — 2026-08-13 `new Array(n)` hole carrier
+
+### Architecture verdict
+
+Candidate `19a2cf0fdf86caff3da64bf4d2d7d193d15879e2` must not land as-is. It
+changes 18 files by roughly +830/-45 for exactly two Test262 gains per lane.
+More importantly, it uses module-global `ctx.usesArrayHoles` to change generic
+externref-vector allocation, growth, reads, `HasProperty`, and HOF behavior.
+The scan may identify an exact `new Array(n)` binding, but that identity is
+lost at the generic mutation/runtime boundaries, so unrelated externref vecs
+in the same module inherit sparse-array semantics.
+
+Reimplement this as a carrier-specific slice. If a dedicated holey-array
+identity cannot be preserved through constructor, writes, `HasProperty`,
+`Get`, and `filter`, reject/demote the shape; do not recover correctness by
+arming global vec behavior. The old candidate's A/B is useful provisional
+evidence only: it used base `81125e5...`, not the latest main.
+
+### Root cause
+
+ES5.1 §15.4.2.2 says one numeric `Array` argument sets `length` without
+creating indexed properties. The dense vec representation initializes every
+slot, so it cannot distinguish an absent hole from a present property whose
+value is `undefined`. ES5.1 §15.4.4.20 `filter` captures the initial length,
+then performs `HasProperty(O, Pk)` and only performs `Get`/callback when that
+answer is true. A value-only vector therefore calls the callback for holes.
+
+The representation must also preserve ordinary prototype lookup: an absent
+own slot can be present through `Array.prototype[k]` or an inherited accessor.
+A JS host helper cannot infer that relationship merely from an opaque WasmGC
+vec. Either the carrier/provider models the Array prototype chain explicitly,
+or selection must reject modules whose indexed prototype state can matter.
+
+### Required representation boundary
+
+Introduce a planned **holey Array carrier**, not a module-wide mode:
+
+- `HoleyArrayPlan` records exact constructor and variable-declaration identity,
+  the chosen carrier, supported filter call sites, and unsupported escapes.
+- A dedicated allocator initializes backing slots to the existing `$Hole`
+  sentinel while setting logical length to `n`.
+- A dedicated set/grow provider fills only gaps in this carrier with `$Hole`.
+- Dedicated `HasProperty` and `Get` providers distinguish absent, present
+  `undefined`, overlay/tombstone, and inherited indexed properties.
+- Ordinary `__vec_externref`, numeric-buffer `__vec_f64`, and generic
+  `__extern_get_idx` / `__extern_has_idx` remain byte-for-byte unchanged when
+  no already-landed feature requires them.
+
+An explicit runtime brand/struct type is preferable. If current type plumbing
+cannot support it, a sidecar keyed by exact carrier identity is acceptable
+only with alias-safe lookup and proof that unrelated vecs cannot enter it.
+
+### Changes
+
+**File: `src/codegen/array-holes.ts` — `scanForArrayHoles` (candidate line
+~59)**
+
+- In `scanForArrayHoles`, build the per-site `HoleyArrayPlan` for an ambient,
+  untyped, directly-bound `new Array(n)` and exact `.filter(...)` consumers.
+- Track by `ts.VariableDeclaration`/node identity, not variable spelling.
+- Reject or mark unsupported any alias, reassignment, escape, destructuring,
+  computed method dispatch, shadowed `Array`, or mutation route that cannot
+  preserve carrier identity. Do not set `ctx.usesArrayHoles` merely because
+  this new constructor shape exists.
+
+**Files: `src/codegen/context/types.ts`,
+`src/codegen/context/create-context.ts` — `CodegenContext` hole fields /
+`createCodegenContext` (candidate lines ~1468 / ~130)**
+
+- Store the exact plan and carrier/provider indices. A boolean may gate byte
+  emission, but it must never decide whether an arbitrary externref vec uses
+  hole semantics.
+
+**File: `src/codegen/expressions/new-indexed.ts` —
+`tryCompileIndexedBuiltinNew` (candidate line ~28)**
+
+- In `tryCompileIndexedBuiltinNew`, consult the constructor-node plan and call
+  the dedicated holey allocator only for that site.
+- Validate the ES5 array-length domain before allocation. The initial narrow
+  IR slice may accept an integer literal representable by the current vec and
+  must demote all other lengths; do not imply support for the full uint32
+  range.
+
+**File: `src/codegen/statements/variables.ts` — `inferArrayVecType` (candidate
+line ~526)**
+
+- In `inferArrayVecType`, force externref only for a declaration in the exact
+  holey plan. A filter-free `new Array(n); a[0] = 5` must retain its existing
+  numeric-buffer representation.
+
+**File: `src/codegen/vec-elem-set.ts` — `ensureHoleyExternrefVecNew` /
+`ensureVecElemSet` (candidate lines ~46 / ~161)**
+
+- Keep/create `ensureHoleyExternrefVecNew` for the dedicated allocator.
+- Add a carrier-specific set/grow helper. Remove candidate logic that makes
+  generic `ensureVecElemSet` choose `$Hole` solely from
+  `ctx.usesArrayHoles && elem.kind === "externref"`.
+- On an out-of-bounds write, fill `[oldLength, index)` with `$Hole`, store the
+  value at `index`, and update logical length. Storing JavaScript `undefined`
+  creates a present slot and must never store `$Hole`.
+
+**File: `src/codegen/expressions/assignment.ts` —
+`compileElementAssignment` (candidate line ~4516)**
+
+- Route assignments through the holey set provider only when the receiver is
+  proven to be the planned carrier. Unsupported aliases demote before this
+  point. Remove module-global gap-fill decisions from generic assignments.
+
+**Files: `src/codegen/array-filter-spec-access.ts`,
+`src/codegen/array-methods.ts`, `src/codegen/hof-native.ts` —
+`overlayFilterAccess`, `compileArrayFilter`, `ensureNativeArrayHof` (candidate
+lines ~97 / ~5821 / ~75)**
+
+- Make `compileArrayFilter` and `overlayFilterAccess` consume the same
+  carrier-specific `HasProperty`/`Get` contract.
+- Capture `len` once. For each `k`, call `HasProperty`; call `Get` and the
+  callback only when present. Append selected values densely to a fresh array.
+- If indexed prototype state is dirty, either perform real prototype-aware
+  lookup through the provider or demote. Do not send an opaque WasmGC vec to a
+  JS host helper and call that prototype-correct.
+- `ensureNativeArrayHof("filter")` must resolve the dedicated provider only
+  for the planned carrier. Remove the candidate's global
+  `usesArrayHoles && methodName === "filter"` gate.
+
+**File: `src/codegen/object-runtime.ts` — `spliceExternHasIdxHoleVecArm` /
+`fillExternGetIdxVecArms` (candidate lines ~6468 / ~6546)**
+
+- Do not splice hole arms into generic `fillExternGetIdxVecArms` or
+  `spliceExternHasIdxHoleVecArm` on account of this slice. Add dedicated holey
+  Array `Get`/`HasProperty` helpers, or dispatch on an unambiguous runtime
+  carrier brand before any ordinary vec arm.
+- Preserve existing overlay tombstone semantics from the completed delete
+  portion of this issue.
+
+**Files: `src/ir/select.ts`, `src/ir/from-ast.ts`,
+`src/ir/integration.ts`, `src/ir/vector-runtime.ts` — `isPhase1Expr`,
+`lowerNewExpression`, `lowerMethodCall`, `makeFromAstResolver`, and
+`resolveAndObserveCallableProvider` (candidate lines ~6372 / ~5656 / ~5994 /
+~4065 / ~4498)**
+
+- Selection claims only an exact planned constructor/filter pair, ambient
+  `Array`, one bounded integer literal length, a scope-owned callback, and no
+  unsupported alias/escape/reassignment. Every fact required by lowering and
+  provider resolution must be known before claim.
+- `lowerNewExpression` emits the symbolic holey allocator;
+  `lowerMethodCall` emits the symbolic holey-filter provider. Both carry the
+  planned representation identity rather than rediscovering it by element
+  type.
+- `makeFromAstResolver` / `resolveAndObserveCallableProvider` resolve those
+  symbols to the dedicated providers without mutating generic vec semantics.
+- Host may remain on the legacy top-level/module-initializer emitter until a
+  host IR provider exists, but document that ownership honestly. Standalone
+  supported functions must report `irBodyEmitted: true` and
+  `legacyBodyEmitted: false`.
+
+### Wasm IR pattern
+
+```text
+%array   = call @runtime.holey_array_new(i32.const n)
+call @runtime.holey_array_set(%array, i32.const index, %boxed_value)
+%result  = call @runtime.holey_array_filter(%array, %callback)
+
+;; Inside filter, with len captured before the loop:
+%present = call @runtime.holey_array_has_property(%array, %k)
+if %present
+  %value = call @runtime.holey_array_get(%array, %k)
+  %keep  = call_ref %callback(%value, %k, %array)
+  if %keep
+    call @runtime.holey_array_append_present(%result, %value)
+  end
+end
+```
+
+The providers may inline this sequence, but `HasProperty` and `Get` remain
+separate semantic operations. `$Hole` is internal and must never escape as a
+callback value, property value, or host externref.
+
+### Edge cases and required tests
+
+- Both exact Test262 rows in both lanes:
+  `filter/15.4.4.20-9-5.js` and `filter/15.4.4.20-9-b-1.js`.
+- `new Array(10)` has length 10 and no own index properties; a stored
+  `undefined` is present and visited while untouched slots are skipped.
+- `filter` captures length once; writes beyond captured length are ignored,
+  while creation/deletion of not-yet-visited indices follows `HasProperty` at
+  visit time.
+- An inherited numeric data property and inherited numeric accessor at a hole
+  are observed and visited. Own present `undefined` shadows the prototype.
+- Sparse growth preserves intermediate holes; delete tombstones stay absent.
+- `Array` shadowing, dynamic/unrepresentable lengths, aliases, reassignment,
+  escaped carriers, and computed `filter` access either work through the same
+  provider or visibly demote before IR selection.
+- A filter-free numeric buffer remains `$__vec_f64`. An unrelated externref
+  vec in the same module has identical bytes and behavior. Include a
+  mixed-module test containing both carriers.
+- Run the original Test262 top-level/module-initializer shape, not only an
+  exported-function rewrite; these paths have differed historically.
+
+### Same-population A/B and zero-loss gates
+
+Record the exact latest `origin/main` SHA at implementation start and compare
+it with the exact implementation SHA. Use Test262 corpus gitlink
+`b363f29d3c43c626dc852744ad64a0b48a003693`, identical oracle, harness,
+timeouts, target flags, maintained file list, and freshly built bundles in
+both arms.
+
+First run the exact 44-row ES5 `built-ins/Array/prototype/**` residual
+partition used by the candidate, plus the positive/negative controls above.
+Report all status totals and every row transition. Require only the two named
+`fail -> pass` transitions per lane, zero `pass -> non-pass`, identical runner
+errors, and no entered/left/unmeasured rows. Add a carrier-brand kill switch:
+disabling only the dedicated holey provider must remove the two gains without
+changing unrelated vec controls.
+
+Then run all **9,029** `<= ES5` tests through the authoritative original
+harness in each lane, including eval, `Function`, and `with`:
+
+- host/gc: goal closure is 9,029 pass and zero other statuses;
+- standalone: goal closure is 9,029 pass and zero other statuses;
+- an incremental change may land only with zero `pass -> non-pass`, zero new
+  compile errors/timeouts/skips, and exact accounting of every changed row.
+
+### Candidate disposition and Terra implementation handoff
+
+- Rebase/rederive from current main; candidate `19a2cf0f...` is read-only
+  evidence, not a patch to merge wholesale.
+- Reject the module-global `usesArrayHoles` correctness gate and generic vec
+  rewrites. Preserve only pieces that remain valid after carrier identity is
+  explicit (likely the allocator and focused Test262 fixtures).
+- Keep the change proportional. Every touched compiler file must be justified
+  by the carrier dataflow above; if the two-row slice still needs broad generic
+  rewrites, stop and return an architecture blocker rather than landing it.


### PR DESCRIPTION
## Summary

- define the sound selector, IR ownership boundary, lowering contract, and same-population A/B gate for the remaining ES5 raw-Test262-assert eval slice
- record the measured 120-row host and real-QuickJS standalone cohorts, kill-switch attribution, and the disposition of the 90 semantic residuals
- reject a broad `new Array(n)` vector-carrier rewrite and specify a carrier-specific sparse-Array design that leaves generic vectors untouched

## Why

The completion boundary now includes `eval`, `Function`, and `with`. These plans make the next implementation slices explicit and prevent gains from being credited to an unsound substring detector or a module-wide array representation change.

## Validation

- documentation-only change
- grounded against `origin/main` at `bd71baaf840f4b8e0a53e8f78d8b48c905d040ce`
- eval cohort records host `0/120 -> 30/120` for the classified runtime shim, with the IR slice owning the exact discarded indirect-eval form
- real QuickJS standalone control remains `120/120 -> 120/120`
- array plan requires exact dual-lane A/B and zero regressions before implementation can land