### PR TITLE
fix(eval): handle raw Test262 asserts in host eval

### DIFF
--- a/plan/issues/1164-dynamic-eval-via-js-host.md
+++ b/plan/issues/1164-dynamic-eval-via-js-host.md
@@ -526,18 +526,21 @@ it does not close standalone eval or substitute for its full-lane gate.
 ### Post-rebase focused validation
 
 The implementation was rebased cleanly onto `origin/main`
-`cb4d4d7ca2f151ba69f26cff517417e003428df7` before this focused validation:
+`5cbbd881148171595265f06775989d1212573c6b` as implementation commit
+`21dcc859a50438785dd23c1e7904f2b22277f592` before this focused validation:
 
-- `pnpm exec vitest run tests/issue-1164-es5-eval-slice.test.ts` — **28 / 28**
+- `pnpm exec vitest run tests/issue-1164-es5-eval-slice.test.ts` — **29 / 29**
   pass, including scope-correct raw-assert controls, host-import inventory,
   and standalone demotion.
 - `pnpm exec vitest run tests/issue-1164.test.ts` — **17 / 17** pass for the
   pre-existing dynamic-eval Wasm-module path.
 - `pnpm exec vitest run tests/issue-1163.test.ts` — 7 / 8 pass; the unchanged,
   pre-existing `eval()` no-argument fallback returns `0` rather than
-  `undefined`. Clean `origin/main` at `cb4d4d7ca2f151ba69f26cff517417e003428df7`
-  produces the identical 7 / 8 result. This slice accepts exactly one argument
-  and cannot select that shape.
+  `undefined`. Clean `origin/main` at
+  `993a6d9f2c08a2a788eec9c830b8eb6a57a15b64` produces the identical 7 / 8
+  result. The only intervening main change is the #671 planning markdown, so
+  the tested compiler/runtime tree is unchanged. This slice accepts exactly
+  one argument and cannot select that shape.
 - `pnpm run typecheck` — pass.
 - `pnpm run check:ir-fallbacks` — pass.
 - `pnpm run check:ir-adoption` — pass.

--- a/plan/issues/1164-dynamic-eval-via-js-host.md
+++ b/plan/issues/1164-dynamic-eval-via-js-host.md
@@ -4,7 +4,7 @@ title: "Dynamic eval via JS host import — compile eval string to ad-hoc Wasm m
 status: done
 created: 2026-04-22
 updated: 2026-08-13
-completed: 2026-04-25
+completed: 2026-08-13
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -15,6 +15,21 @@ goal: spec-completeness
 sprint: 45
 depends_on: [1163]
 required_by: [1066, 1165]
+loc-budget-allow:
+  - src/codegen/declarations/import-collector.ts
+  - src/codegen/index.ts
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
+  - src/ir/select.ts
+  - src/runtime.ts
+func-budget-allow:
+  - src/codegen/declarations/import-collector.ts::finalizeUnifiedCollector
+  - src/codegen/declarations/import-collector.ts::unifiedVisitNode
+  - src/codegen/index.ts::planIrOverlay
+  - src/ir/integration.ts::compileIrPathFunctions
+  - src/ir/integration.ts::makeFromAstResolver
+  - src/ir/select.ts::isPhase1Expr
+  - src/runtime.ts::resolveImport
 ---
 # #1164 — Dynamic eval via JS host import: compile eval string to ad-hoc Wasm module
 
@@ -445,3 +460,117 @@ instrumentation stub is not a passing eval implementation.
 - Do not claim direct eval, value-producing eval, or standalone eval from this
   increment. Record their remaining exact rows under #2925/#1165 and keep them
   inside the ES5 completion denominator.
+
+## 2026-08-13 ES5 residual implementation record
+
+### Delivered slice
+
+This increment has two deliberately narrow, independently attributable parts:
+
+1. The legacy host-eval fallback recognizes an *active, unshadowed* raw Test262
+   `assert(...)`, `assert.<known method>(...)`, or known bracket-method call by
+   parsing the eval text and resolving its receiver in a no-lib checker. It does
+   not activate for comments, strings/template text, optional calls, unknown
+   members, or a local `assert` binding.
+2. IR owns only an ambient, JS-host, proven-string, result-discarded
+   `(0, eval)(source);` statement. Collection reserves the existing
+   `env.__extern_eval : (externref, i32) -> externref` capability before body
+   planning; lowering emits `isDirect = 0` and drops the `externref` result.
+
+Direct eval, a used indirect-eval result, non-proven strings, optional/spread
+calls, shadowed `eval`, native-string mode, and standalone remain legacy-owned.
+
+### Exact same-population host A/B
+
+The maintained population is the 120 ES5 `annexB/language/eval-code` rows that
+reported `assert is not defined` from same-SHA base
+`1fcb363695415ff3a09e338feade66132c93dd50`. Every arm used the same local
+harness, file list, host target, timeout, corpus gitlink
+`b363f29d3c43c626dc852744ad64a0b48a003693`, and mandatory passing/negative
+controls. The ignored per-row records are retained as
+`.tmp/issue-1164-{base,runtime,full,killswitch}-host.jsonl`.
+
+| arm | pass | fail | compile error | timeout | skip | runner error |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| base | 0 | 120 | 0 | 0 | 0 | 0 |
+| raw-assert runtime classifier only | 30 | 90 | 0 | 0 | 0 | 0 |
+| full implementation | 30 | 90 | 0 | 0 | 0 | 0 |
+| full with `JS2WASM_DISABLE_RAW_TEST262_ASSERT_SHIM=1` | 0 | 120 | 0 | 0 | 0 | 0 |
+
+- Base → runtime-only is exactly **30 fail → pass** and 90 unchanged.
+- Runtime-only → full is 120 unchanged: the IR ownership slice does not claim
+  an unexplained Test262 gain.
+- Full → kill switch is exactly those 30 pass → fail rows; kill-switch → base
+  is 120 unchanged.
+- The failing negative control and the passing control settled in every chunk.
+  This is focused attribution evidence only; the full 9,029-row lane was not
+  run and is not claimed here.
+
+### Real standalone zero-loss check
+
+The exact same 120 files were run from clean base and the full implementation
+with the real QuickJS evaluator, not a trap stub. Both arms were **120 / 120
+pass**, with every one of the 120 rows unchanged and zero entered/left/status
+transitions. The retained ignored records are
+`.tmp/issue-1164-{base,full}-standalone.jsonl`.
+
+The provider was GitHub Actions run `31660362908`, artifact
+`9165959972` (`quickjs-wasi-7f939fdc`), locally verified from
+`/private/tmp/js2wasm-quickjs-wasi-7f939fdc`: QuickJS
+`954dc53628e36891f93c359aa60895c2ae3dac6b`, wasi-libc
+`8d8348ec24253d0638a693b8af82445c13d92d32`, artifact SHA-256
+`b0662069c241d0430d91c53a3b0e2d1281fd9eb78dd1c93490b0a9dfa70eec5b`, and
+adapter key `1429ec7ecf2163fd`. This proves no targeted standalone regression;
+it does not close standalone eval or substitute for its full-lane gate.
+
+### Post-rebase focused validation
+
+The implementation was rebased cleanly onto `origin/main`
+`cb4d4d7ca2f151ba69f26cff517417e003428df7` before this focused validation:
+
+- `pnpm exec vitest run tests/issue-1164-es5-eval-slice.test.ts` — **28 / 28**
+  pass, including scope-correct raw-assert controls, host-import inventory,
+  and standalone demotion.
+- `pnpm exec vitest run tests/issue-1164.test.ts` — **17 / 17** pass for the
+  pre-existing dynamic-eval Wasm-module path.
+- `pnpm exec vitest run tests/issue-1163.test.ts` — 7 / 8 pass; the unchanged,
+  pre-existing `eval()` no-argument fallback returns `0` rather than
+  `undefined`. Clean `origin/main` at `cb4d4d7ca2f151ba69f26cff517417e003428df7`
+  produces the identical 7 / 8 result. This slice accepts exactly one argument
+  and cannot select that shape.
+- `pnpm run typecheck` — pass.
+- `pnpm run check:ir-fallbacks` — pass.
+- `pnpm run check:ir-adoption` — pass.
+
+These are implementation checks, not a substitute for the deferred 9,029-row
+ES5 acceptance lane.
+
+### Exact 90-row residual disposition
+
+All 90 remaining host failures parse cleanly and each contains one outer eval
+literal. The classifier resolves all **295** raw `assert` receivers as
+unbound harness globals; none is a lexical-shadow false negative. No remaining
+row reports `assert is not defined`: each reaches the shim and then fails its
+actual Annex B/eval assertion.
+
+- 68 are `direct` rows: 49 function-scope and 19 global-scope. The 49
+  function-scope rows remain with
+  [#2925](2925-direct-eval-scope-reification-host.md), whose reified caller
+  environment is the required direct-eval substrate.
+- 22 are indirect global rows, and the 19 direct-global rows also exercise the
+  unresolved Annex B declaration/visibility boundary documented in
+  [#3633](3633-extern-eval-cannot-see-compiled-module-bindings.md). Its
+  resolution explains why assertion visibility is only an unmasking gate;
+  these rows now need their actual B.3.3/EvalDeclarationInstantiation
+  semantics, not another `assert` heuristic.
+- The real-QuickJS standalone comparison has no residual in this 120-row host
+  population. It is therefore not evidence to close or broaden
+  [#2929](2929-interpreter-direct-eval-with-proxy-mop.md), which owns the
+  standalone direct-eval environment model.
+
+The failure signatures are 43 function-scope `assert.throws` assertions, 12
+global `assert.throws` assertions, 15 `undefined` expectations, 14 function
+expectations, and 6 function-scope `sameValue` assertions. Candidate
+`64b8f831151efe4c11f241b2889cc7eedbebd7f7`'s reported +120 is not
+reproducible: its raw `"assert."` substring heuristic cannot solve rows that
+already reach the shim and fail their semantic assertion.

--- a/src/codegen/declarations/import-collector.ts
+++ b/src/codegen/declarations/import-collector.ts
@@ -13,6 +13,7 @@ import {
   isStringType,
 } from "../../checker/type-mapper.js";
 import { forEachChild, ts } from "../../ts-api.js";
+import { exactIndirectEvalStatement } from "../../eval-call-shape.js";
 import { ensureWrapperTypes } from "../any-helpers.js";
 import { ASYNC_CPS_ENABLED, analyzeAsyncBody, asyncFnNeedsCps } from "../async-cps.js";
 import { asyncFnNeedsHostDrive, asyncGenDrivableUnderCarrier, asyncGenStem } from "../async-frame.js";
@@ -79,6 +80,10 @@ interface UnifiedCollectorState {
   // `__date_parse_host` (delegates to JS Date.parse). Registered up-front to
   // avoid the #2043 late-import shift; standalone/WASI use the native parser.
   dateParseHostNeeded: boolean;
+  // #1164 — the exact `(0, eval)(string);` statement owned by the IR host
+  // import slice. This is collected before body planning because an IR body
+  // bypasses the legacy emitter that otherwise registers __extern_eval.
+  hostIndirectEvalNeeded: boolean;
   // -- collectURIImports --
   uriNeeded: Set<string>;
   // -- collectEscapeImports (#3063) — legacy global escape/unescape (§B.2.1/.2) --
@@ -181,6 +186,7 @@ export function createUnifiedCollectorState(sourceFile: ts.SourceFile): UnifiedC
     mathNeedsToUint32: false,
     parseNeeded: new Set(),
     dateParseHostNeeded: false,
+    hostIndirectEvalNeeded: false,
     uriNeeded: new Set(),
     escapeNeeded: new Set(),
     needsFromCharCode: false,
@@ -212,8 +218,80 @@ export function createUnifiedCollectorState(sourceFile: ts.SourceFile): UnifiedC
   };
 }
 
+function collectorSeesAmbientEval(ctx: CodegenContext, identifier: ts.Identifier): boolean {
+  const declarations = ctx.oracle.declarationsOf(identifier);
+  // Match `makeIrAmbientBindingPredicate`: a merged lib symbol may carry
+  // several declarations, and the selector/lowerer accept it when one is an
+  // ambient declaration. A source-owned shadow has no declaration-file arm.
+  return declarations.some((declaration) => declaration.getSourceFile().isDeclarationFile);
+}
+
+function collectorHostStringFact(ctx: CodegenContext, expression: ts.Expression): boolean {
+  const fact = ctx.oracle.typeFactOf(expression);
+  return (
+    fact.kind === "string" ||
+    (fact.kind === "union" &&
+      !fact.nullable &&
+      !fact.undefinable &&
+      fact.parts.length > 0 &&
+      fact.parts.every((part) => part.kind === "string"))
+  );
+}
+
+function stripHostEvalTypeAssertions(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/**
+ * Match the selector's proven-string discipline closely enough that the
+ * collector cannot omit an import from a claimed IR body. In particular,
+ * diagnostics-off annotations do not make `const s: string = 1` look like a
+ * host string merely because its declared type says so.
+ */
+function collectorProvesHostEvalString(
+  ctx: CodegenContext,
+  expression: ts.Expression,
+  seen = new Set<ts.VariableDeclaration>(),
+): boolean {
+  const candidate = stripHostEvalTypeAssertions(expression);
+  if (ts.isStringLiteral(candidate) || ts.isNoSubstitutionTemplateLiteral(candidate)) return true;
+  if (!collectorHostStringFact(ctx, candidate)) return false;
+  if (!ts.isIdentifier(candidate)) return true;
+  const declaration = ctx.oracle.variableDeclarationOf(candidate);
+  if (!declaration) return true; // typed parameter / non-local checker binding
+  if (!declaration.initializer || seen.has(declaration)) return false;
+  const nextSeen = new Set(seen);
+  nextSeen.add(declaration);
+  return collectorProvesHostEvalString(ctx, declaration.initializer, nextSeen);
+}
+
+function needsHostIndirectEvalImport(ctx: CodegenContext, node: ts.Node): boolean {
+  if (ctx.standalone || ctx.wasi || ctx.strictNoHostImports || ctx.nativeStrings || !ts.isCallExpression(node)) {
+    return false;
+  }
+  const shape = exactIndirectEvalStatement(node);
+  return (
+    !!shape && collectorSeesAmbientEval(ctx, shape.evalIdentifier) && collectorProvesHostEvalString(ctx, shape.source)
+  );
+}
+
 /** Single-pass visitor called on every AST node */
 export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorState, node: ts.Node): void {
+  // #1164 — `__extern_eval` is an IR-owned host capability only for the exact
+  // certified statement shape. Do not arm it for direct eval, a discarded
+  // non-string, a shadowed callee, or a value-producing call that stays legacy.
+  if (needsHostIndirectEvalImport(ctx, node)) state.hostIndirectEvalNeeded = true;
+
   // ── collectStringLiterals (skip computed property names) ──
   if (state.insideComputedPropertyName === 0) {
     if (ts.isStringLiteral(node)) {
@@ -1331,6 +1409,14 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
 
 /** Run all post-walk finalization (register imports based on collected state) */
 export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedCollectorState): void {
+  // #1164 — reserve the host eval import before IR bodies are planned. The
+  // existing legacy scan may already have supplied the identical funcMap slot;
+  // preserve it rather than perturbing the function index space a second time.
+  if (state.hostIndirectEvalNeeded && ctx.funcMap.get("__extern_eval") === undefined) {
+    const typeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "i32" }], [{ kind: "externref" }]);
+    addImport(ctx, "env", "__extern_eval", { kind: "func", typeIdx });
+  }
+
   // ── collectConsoleImports finalize ──
   // In WASI mode, console.log/error use fd_write — skip JS host console imports.
   // (#3436) In standalone mode there is no JS host either, so emitting the

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2464,6 +2464,7 @@ function planIrOverlay(
       supportsSymbolicMathHelpers: true,
       supportsLiteralStringReplace: true,
       supportsHostStringArrayLiterals: jsHostExterns && !ctx.nativeStrings,
+      supportsHostIndirectEval: jsHostExterns && !ctx.nativeStrings,
       ...backendCapabilitySelectionOptions,
       ...(jsHostExterns && legacyImportedFunctions ? { importedFunctions: legacyImportedFunctions } : {}),
       // (#1373b C-1) Async claim gate: IR claims an async fn IFF the ONE

--- a/src/eval-call-shape.ts
+++ b/src/eval-call-shape.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "./ts-api.js";
+
+/**
+ * The one indirect-eval spelling this increment may route through the host
+ * import. Binding, capability, and carrier proofs stay with their owning
+ * compiler phases; this module owns syntax only.
+ */
+export interface ExactIndirectEvalStatement {
+  readonly evalIdentifier: ts.Identifier;
+  readonly source: ts.Expression;
+}
+
+function stripParentheses(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (ts.isParenthesizedExpression(current)) current = current.expression;
+  return current;
+}
+
+/**
+ * Return the identifier from exactly `(0, eval)(source)`, after stripping
+ * parentheses around the comma operands. Direct eval, aliases, and arbitrary
+ * comma expressions intentionally return undefined.
+ */
+export function exactIndirectEvalIdentifier(call: ts.CallExpression): ts.Identifier | undefined {
+  const callee = stripParentheses(call.expression);
+  if (!ts.isBinaryExpression(callee) || callee.operatorToken.kind !== ts.SyntaxKind.CommaToken) return undefined;
+  const left = stripParentheses(callee.left);
+  const right = stripParentheses(callee.right);
+  if (!ts.isNumericLiteral(left) || Number(left.text) !== 0 || !ts.isIdentifier(right) || right.text !== "eval") {
+    return undefined;
+  }
+  return right;
+}
+
+/**
+ * Return the complete statement-position shape accepted by the host-only IR
+ * slice. The call result must be directly discarded by an expression statement
+ * and the one source argument must not be spread.
+ */
+export function exactIndirectEvalStatement(call: ts.CallExpression): ExactIndirectEvalStatement | undefined {
+  if (call.questionDotToken || !ts.isExpressionStatement(call.parent) || call.parent.expression !== call)
+    return undefined;
+  const evalIdentifier = exactIndirectEvalIdentifier(call);
+  const source = call.arguments.length === 1 ? call.arguments[0] : undefined;
+  if (!evalIdentifier || !source || ts.isSpreadElement(source)) return undefined;
+  return { evalIdentifier, source };
+}

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -36,6 +36,7 @@
 //     with arg types validated against the propagated callee param types.
 
 import { ts, forEachChild } from "../ts-api.js";
+import { exactIndirectEvalStatement } from "../eval-call-shape.js";
 
 import { TsCheckerOracle } from "../checker/oracle.js";
 import {
@@ -158,7 +159,7 @@ import {
 // #4177 — fixpoint-fact consumption for the `+` operand proof.
 import { collectLatticeParamFacts, latticeAdditiveFact, type LatticeParamFacts } from "./lattice-param-facts.js";
 import { tryEmitUnrolledReduction } from "./reduction-unroll.js";
-import { demoteToLegacy, IrUnsupportedError } from "./outcomes.js";
+import { demoteToLegacy, IrInvariantError, IrUnsupportedError } from "./outcomes.js";
 import { isPristineEs5IntrinsicIsFrozenCall } from "./object-integrity.js";
 import { effectiveIrParamTypeNode, effectiveIrReturnTypeNode, IR_MATH_METHOD_TABLE } from "./select.js";
 import { JsTag } from "./js-tag.js"; // #2949 S5.2 — box-refinement tags for dynamic equality operands
@@ -315,6 +316,8 @@ export interface IrExternClassMeta {
  * until Phase 3, so from-ast doesn't see them.
  */
 export interface IrFromAstResolver extends PreparedAsyncFromAstResolver {
+  /** Resolve the pre-collected exact JS-host indirect-eval import. */
+  hostIndirectEvalTarget?(): IrFuncRef | null;
   /** Resolve the host-free `%Function.prototype%.[[Call]]` entry point. */
   functionPrototypeCallTarget?(): IrFuncRef | null;
   /**
@@ -5283,6 +5286,50 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = fa
   // optional-call IR support is a follow-up.
   if (expr.questionDotToken) {
     throw new Error(`ir/from-ast: optional call (?.()) not in slice 11 (${cx.funcName})`);
+  }
+  const indirectEval = exactIndirectEvalStatement(expr);
+  if (indirectEval) {
+    const target = cx.resolver?.hostIndirectEvalTarget?.();
+    if (
+      !statementPosition ||
+      cx.resolver?.jsHostExterns?.() !== true ||
+      cx.resolver?.isAmbientBinding?.(indirectEval.evalIdentifier) !== true ||
+      cx.scope.has("eval") ||
+      cx.resolver?.stringIsExternref?.() !== true ||
+      !target
+    ) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "build",
+        `ir/from-ast: certified host indirect eval lost an owning predicate (${cx.funcName})`,
+      );
+    }
+    const source = lowerExpr(indirectEval.source, cx, { kind: "string" });
+    if (cx.builder.typeOf(source).kind !== "string") {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "build",
+        `ir/from-ast: certified host indirect eval source is not a string (${cx.funcName})`,
+      );
+    }
+    const result = cx.builder.emitCall(
+      target,
+      [
+        cx.builder.emitCoerceToExternref(source),
+        cx.builder.emitConst({ kind: "i32", value: 0 }, irVal({ kind: "i32" })),
+      ],
+      irVal({ kind: "externref" }),
+    );
+    if (result === null) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "build",
+        `ir/from-ast: host indirect eval provider returned void (${cx.funcName})`,
+      );
+    }
+    // Statement-position lowering records this as a zero-use side-effecting
+    // call; the backend emits the mandated Wasm `drop` for its externref result.
+    return result;
   }
   const preparedPromiseAll = tryLowerPreparedAsyncPromiseAll({
     expression: expr,

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -1009,6 +1009,7 @@ export function compileIrPathFunctions(
       supportsSymbolicMathHelpers: true,
       supportsLiteralStringReplace: true,
       supportsHostStringArrayLiterals: jsHostExterns && !ctx.nativeStrings,
+      supportsHostIndirectEval: jsHostExterns && !ctx.nativeStrings,
       ...backendCapabilitySelectionOptions,
     });
   const integrationPopulation = loweringPlans
@@ -4070,6 +4071,13 @@ function makeFromAstResolver(
     );
   return {
     ...preparedIrAsyncFromAstResolver(ctx),
+    hostIndirectEvalTarget() {
+      if (ctx.standalone || ctx.wasi || ctx.strictNoHostImports || ctx.nativeStrings) return null;
+      const functionIndex = ctx.funcMap.get("__extern_eval");
+      const exactIndex = exactCallableImportIndex(ctx, "env", "__extern_eval");
+      if (functionIndex === undefined || exactIndex === undefined || functionIndex !== exactIndex) return null;
+      return irImportFuncRef("env", "__extern_eval");
+    },
     standaloneWrapperInstanceOfPlan(ctorName: string) {
       if (
         !supportsBackendCapability("standalone-wrapper-instanceof") ||

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -55,6 +55,7 @@
 //     `localClasses` set drives that exemption.
 
 import { ts, forEachChild } from "../ts-api.js";
+import { exactIndirectEvalStatement } from "../eval-call-shape.js";
 import { collectIrClassInstanceInitializers } from "./class-instance-initializers.js";
 import type { IrClassId, IrUnitId } from "./identity.js";
 import {
@@ -448,6 +449,12 @@ export interface IrSelectionOptions extends IrAsyncSelectionOptions {
    * on the legacy path instead of failing after an IR claim.
    */
   readonly supportsHostStringArrayLiterals?: boolean;
+  /**
+   * The active backend has both the JS-host eval capability and the host
+   * externref string carrier needed by the exact indirect-eval import ABI.
+   * Omitted means unproven, so the selector leaves eval on the legacy path.
+   */
+  readonly supportsHostIndirectEval?: boolean;
   /**
    * (#3053 U2) True iff the unified gc member-read primitive `__dyn_member_get`
    * (#3053 U0) has a SOUND body in this compile config. The gc `$AnyValue` body
@@ -5528,6 +5535,39 @@ function expressionIsProvenString(expr: ts.Expression, seen = new Set<ts.Variabl
   return expressionIsProvenString(declaration.initializer, seen);
 }
 
+/**
+ * Eval needs a string value whose IR carrier is known to be the host
+ * externref string. The shared primitive classifier proves typed parameters
+ * and valid local flows; the literal-proven helper preserves the existing
+ * diagnostics-off guard for malformed local annotations.
+ */
+function expressionIsProvenHostEvalString(expr: ts.Expression): boolean {
+  return expressionIsProvenString(expr) || currentSelectionOptions?.classifyPrimitiveExpression?.(expr) === "string";
+}
+
+/**
+ * Every selection-side consumer of the host eval import uses this exact
+ * predicate. The optional scope argument adds the function-local shadow proof
+ * owned by Phase 1; the call graph has checker identity instead.
+ */
+function certifiedHostIndirectEval(
+  expr: ts.CallExpression,
+  scope?: ReadonlySet<string>,
+): ReturnType<typeof exactIndirectEvalStatement> {
+  const shape = exactIndirectEvalStatement(expr);
+  if (
+    !shape ||
+    currentSelectionOptions?.jsHostExterns !== true ||
+    currentSelectionOptions?.supportsHostIndirectEval !== true ||
+    !selectorSeesAmbientBinding(shape.evalIdentifier) ||
+    (scope?.has("eval") ?? false) ||
+    !expressionIsProvenHostEvalString(shape.source)
+  ) {
+    return undefined;
+  }
+  return shape;
+}
+
 function typeNodeIsStringOnly(typeNode: ts.TypeNode): boolean {
   if (typeNode.kind === ts.SyntaxKind.StringKeyword) return true;
   if (ts.isParenthesizedTypeNode(typeNode)) return typeNodeIsStringOnly(typeNode.type);
@@ -6686,6 +6726,14 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     if (isOptionalModuleExternCall(expr)) {
       return shapeNo("expr-module-extern-optional-call", expr);
     }
+    const indirectEvalStatement = exactIndirectEvalStatement(expr);
+    if (indirectEvalStatement) {
+      const certified = certifiedHostIndirectEval(expr, scope);
+      if (!certified) {
+        return capabilityNo("call-resolution-unsupported", "expr-indirect-eval-host-statement", expr);
+      }
+      return isPhase1Expr(certified.source, scope, localClasses);
+    }
     // #3000-E: `super(args)` — a derived ctor chaining to its parent. `super` is
     // a keyword, not an identifier/property-access the generic receiver checks
     // below handle, so recognise the shape here. Args must be Phase-1 exprs; the
@@ -7781,6 +7829,11 @@ export function buildLocalCallGraph(
         return;
       }
       if (ts.isCallExpression(node)) {
+        const indirectEval = certifiedHostIndirectEval(node);
+        if (indirectEval) {
+          visit(indirectEval.source);
+          return;
+        }
         if (ts.isIdentifier(node.expression)) {
           const imported = certifyImportedIrCall(node, currentSelectionOptions?.importedFunctions);
           if (imported) {

--- a/src/runtime-eval.ts
+++ b/src/runtime-eval.ts
@@ -117,6 +117,113 @@ export interface EvalShimOptions {
   onCompiled?: (info: { src: string; binarySize: number; isDirect: boolean }) => void;
 }
 
+const TEST262_ASSERT_METHODS = new Set([
+  "sameValue",
+  "notSameValue",
+  "throws",
+  "throwsAsync",
+  "compareArray",
+  "_isSameValue",
+]);
+
+const ASSERT_PROBE_FILE_NAME = "__eval_assert_probe__.js";
+const DISABLE_RAW_TEST262_ASSERT_SHIM_ENV = "JS2WASM_DISABLE_RAW_TEST262_ASSERT_SHIM";
+
+/**
+ * Keep the attribution-only kill switch safe in browser hosts, where Node's
+ * `process` global does not exist. An absent environment means the shim is
+ * enabled, matching the normal production path.
+ */
+export function rawTest262AssertShimEnabled(
+  environment: Readonly<Record<string, string | undefined>> | undefined = typeof process === "undefined"
+    ? undefined
+    : process.env,
+): boolean {
+  return environment?.[DISABLE_RAW_TEST262_ASSERT_SHIM_ENV] !== "1";
+}
+
+function stripAssertReferenceParentheses(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (ts.isParenthesizedExpression(current)) current = current.expression;
+  return current;
+}
+
+function rawTest262AssertReceiver(expression: ts.Expression): ts.Identifier | undefined {
+  const callee = stripAssertReferenceParentheses(expression);
+  if (ts.isIdentifier(callee)) return callee.text === "assert" ? callee : undefined;
+  if (ts.isPropertyAccessExpression(callee)) {
+    if (callee.questionDotToken) return undefined;
+    const receiver = stripAssertReferenceParentheses(callee.expression);
+    return ts.isIdentifier(receiver) && receiver.text === "assert" && TEST262_ASSERT_METHODS.has(callee.name.text)
+      ? receiver
+      : undefined;
+  }
+  if (ts.isElementAccessExpression(callee)) {
+    if (callee.questionDotToken) return undefined;
+    const receiver = stripAssertReferenceParentheses(callee.expression);
+    const key = callee.argumentExpression && stripAssertReferenceParentheses(callee.argumentExpression);
+    return ts.isIdentifier(receiver) &&
+      receiver.text === "assert" &&
+      key !== undefined &&
+      ts.isStringLiteralLike(key) &&
+      TEST262_ASSERT_METHODS.has(key.text)
+      ? receiver
+      : undefined;
+  }
+  return undefined;
+}
+
+function makeAssertProbeProgram(source: string): { sourceFile: ts.SourceFile; checker: ts.TypeChecker } | undefined {
+  const parsed = ts.createSourceFile(ASSERT_PROBE_FILE_NAME, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const diagnostics = (parsed as unknown as { parseDiagnostics?: readonly ts.Diagnostic[] }).parseDiagnostics;
+  if (diagnostics && diagnostics.length > 0) return undefined;
+
+  const host: ts.CompilerHost = {
+    getSourceFile: (fileName) => (fileName === ASSERT_PROBE_FILE_NAME ? parsed : undefined),
+    getDefaultLibFileName: () => "",
+    writeFile: () => {},
+    getCurrentDirectory: () => "",
+    getCanonicalFileName: (fileName) => fileName,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: (fileName) => fileName === ASSERT_PROBE_FILE_NAME,
+    readFile: (fileName) => (fileName === ASSERT_PROBE_FILE_NAME ? source : undefined),
+    directoryExists: () => true,
+    getDirectories: () => [],
+  };
+  const program = ts.createProgram(
+    [ASSERT_PROBE_FILE_NAME],
+    { allowJs: true, checkJs: false, noLib: true, noResolve: true, target: ts.ScriptTarget.Latest, types: [] },
+    host,
+  );
+  const sourceFile = program.getSourceFile(ASSERT_PROBE_FILE_NAME);
+  return sourceFile ? { sourceFile, checker: program.getTypeChecker() } : undefined;
+}
+
+/**
+ * Detect an executable, unshadowed raw Test262 assert call in eval text.
+ * A no-lib checker resolves each receiver in its own lexical scope, so a
+ * local assertion remains local without suppressing a sibling harness call.
+ */
+export function hasActiveUnshadowedTest262Assert(source: string): boolean {
+  const probe = makeAssertProbeProgram(source);
+  if (!probe) return false;
+
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    const receiver =
+      ts.isCallExpression(node) && !node.questionDotToken ? rawTest262AssertReceiver(node.expression) : undefined;
+    if (receiver && probe.checker.getSymbolAtLocation(receiver) === undefined) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(probe.sourceFile, visit);
+  return found;
+}
+
 /**
  * Build a `__extern_eval` host import for a JS-host runtime.
  *

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -16,7 +16,12 @@
  */
 import { compileSource } from "./compiler.js";
 import type { ImportDescriptor, ImportIntent, ImportPolicy } from "./index.js";
-import { createEvalShim, createNewFunctionShim } from "./runtime-eval.js";
+import {
+  createEvalShim,
+  createNewFunctionShim,
+  hasActiveUnshadowedTest262Assert,
+  rawTest262AssertShimEnabled,
+} from "./runtime-eval.js";
 import * as wsh from "./runtime/wasm-struct-host-semantics.js";
 import { STRING_CONSTANTS16_NS } from "./string-surrogate.js";
 import {
@@ -9545,7 +9550,17 @@ function resolveImport(
           // Strip TypeScript annotations that wrapTest injects (e.g. `as number`,
           // `as any`) — the eval'd code runs as plain JS and rejects TS syntax.
           const jsSrc = src.replace(/\bas\s+number\b/g, "").replace(/\bas\s+any\b/g, "");
-          const needsShim = harnessIds.some((id) => jsSrc.includes(id));
+          // Raw Test262 `assert(...)` / `assert.<knownMember>(...)` calls
+          // survive some wrapTest paths unchanged.  Detect executable,
+          // unshadowed calls from syntax rather than treating comment/string
+          // text (or a locally-bound `assert`) as a harness dependency.
+          // Measurement kill switch: preserves the prior runtime behavior for
+          // same-population attribution runs without changing the classifier's
+          // syntax contract or any non-harness dynamic-code policy.
+          const rawAssertShimEnabled = rawTest262AssertShimEnabled();
+          const needsShim =
+            (rawAssertShimEnabled && hasActiveUnshadowedTest262Assert(jsSrc)) ||
+            harnessIds.some((id) => jsSrc.includes(id));
           // biome-ignore lint/style/noCommaOperator: (0, eval) forces indirect eval (global scope) per §19.2.1.1
           // biome-ignore lint/security/noGlobalEval: intentional test262 runtime eval for harness compatibility
           if (!needsShim) return (0, eval)(jsSrc);

--- a/tests/issue-1164-es5-eval-slice.test.ts
+++ b/tests/issue-1164-es5-eval-slice.test.ts
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1164 ES5 residual — raw Test262 assert fallback plus the deliberately
+ * narrow IR-owned `(0, eval)(string);` host call.
+ *
+ * The call is intentionally statement-only and JS-host-only. These tests pin
+ * its positive ABI/inventory path and the syntax/runtime boundaries that must
+ * remain legacy-owned until #2925/#1165.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { exactIndirectEvalStatement } from "../src/eval-call-shape.js";
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+import { hasActiveUnshadowedTest262Assert, rawTest262AssertShimEnabled } from "../src/runtime-eval.js";
+import { ts } from "../src/ts-api.js";
+
+function outcomeFor(result: CompileResult, name = "probe"): IrObservedOutcome | undefined {
+  return result.irOutcomes?.find((outcome) => outcome.displayName === name);
+}
+
+function errorsOf(result: CompileResult): string {
+  return result.errors.map((error) => error.message).join("\n");
+}
+
+async function compileTracked(source: string, target?: "standalone"): Promise<CompileResult> {
+  const result = await compile(source, {
+    fileName: "issue-1164-es5-eval-slice.ts",
+    experimentalIR: true,
+    trackIrOutcomes: true,
+    skipSemanticDiagnostics: true,
+    ...(target ? { target } : {}),
+  });
+  expect(result.success, errorsOf(result)).toBe(true);
+  return result;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    result.binary,
+    imports.env,
+    imports.string_constants,
+    imports.string_constants16,
+  );
+  imports.setInstance?.(instance);
+  return instance.exports as Record<string, Function>;
+}
+
+function firstCall(source: string): ts.CallExpression {
+  const sourceFile = ts.createSourceFile(
+    "issue-1164-call-shape.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  let found: ts.CallExpression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && ts.isCallExpression(node)) found = node;
+    if (!found) ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  expect(found, source).toBeDefined();
+  return found!;
+}
+
+async function hostEvalImport(): Promise<(source: unknown, isDirect: number) => unknown> {
+  const result = await compile(`export function hostEval(source: any): any { return (0, eval)(source); }`, {
+    fileName: "issue-1164-host-eval-import.ts",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success, errorsOf(result)).toBe(true);
+  expect(result.imports.some((descriptor) => descriptor.name === "__extern_eval")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  return imports.env.__extern_eval as (source: unknown, isDirect: number) => unknown;
+}
+
+async function withoutGlobalAssert<T>(run: () => Promise<T> | T): Promise<T> {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "assert");
+  expect(Reflect.deleteProperty(globalThis, "assert")).toBe(true);
+  try {
+    return await run();
+  } finally {
+    Reflect.deleteProperty(globalThis, "assert");
+    if (previous) Object.defineProperty(globalThis, "assert", previous);
+  }
+}
+
+describe("#1164 ES5 eval slice — raw Test262 assert classifier", () => {
+  it("keeps the attribution switch safe when a browser has no process environment", () => {
+    expect(rawTest262AssertShimEnabled(undefined)).toBe(true);
+    expect(rawTest262AssertShimEnabled({})).toBe(true);
+    expect(rawTest262AssertShimEnabled({ JS2WASM_DISABLE_RAW_TEST262_ASSERT_SHIM: "1" })).toBe(false);
+  });
+
+  it.each([
+    ["callable assert", "assert(true);"],
+    ["known dot member", "assert.sameValue(1, 1);"],
+    ["known bracket member", 'assert["throws"](Error, function () {});'],
+    [
+      "outer harness call beside a nested local binding",
+      "assert.sameValue(1, 1); (function (assert) { assert.sameValue(1, 1); })({ sameValue: function () {} });",
+    ],
+    [
+      "outer harness call beside a block-local binding",
+      "if (false) { let assert = { sameValue: function () {} }; assert.sameValue(1, 1); } assert.sameValue(1, 1);",
+    ],
+  ])("recognizes %s", (_label, source) => {
+    expect(hasActiveUnshadowedTest262Assert(source)).toBe(true);
+  });
+
+  it.each([
+    ["comment", "/* assert.sameValue(1, 1) */"],
+    ["string", '"assert.sameValue(1, 1)"'],
+    ["template text", "`assert.sameValue(1, 1)`"],
+    ["non-call reference", "assert.sameValue;"],
+    ["unknown member", "assert.custom(1);"],
+    ["optional call", "assert?.sameValue(1, 1);"],
+    ["local binding", "let assert = { sameValue() {} }; assert.sameValue();"],
+    ["parameter binding", "(function (assert) { assert.sameValue(); })(undefined);"],
+    ["catch binding", "try {} catch (assert) { assert.sameValue(); }"],
+  ])("does not activate for %s", (_label, source) => {
+    expect(hasActiveUnshadowedTest262Assert(source)).toBe(false);
+  });
+
+  it("runs raw callable/dot/bracket Test262 assertions through the legacy fallback shim", async () => {
+    await withoutGlobalAssert(async () => {
+      const evaluate = await hostEvalImport();
+
+      expect(evaluate("assert(true);", 0)).toBeUndefined();
+      expect(evaluate("assert.sameValue(1, 1);", 0)).toBeUndefined();
+      expect(evaluate('assert["sameValue"](1, 1);', 0)).toBeUndefined();
+      expect(
+        evaluate("assert.throws(TypeError, function () { throw new TypeError('expected'); });", 0),
+      ).toBeUndefined();
+      expect(() => evaluate("assert.sameValue(1, 2);", 0)).toThrow(/eval harness assertion/);
+      expect(
+        evaluate(
+          "assert.sameValue(1, 1); (function (assert) { assert.sameValue(1, 1); })({ sameValue: function () {} });",
+          0,
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  it("retains a measurement-only raw-assert kill switch", async () => {
+    const previous = process.env.JS2WASM_DISABLE_RAW_TEST262_ASSERT_SHIM;
+    process.env.JS2WASM_DISABLE_RAW_TEST262_ASSERT_SHIM = "1";
+    try {
+      await withoutGlobalAssert(async () => {
+        const evaluate = await hostEvalImport();
+        expect(() => evaluate("assert.sameValue(1, 1);", 0)).toThrow(/assert is not defined/);
+      });
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_DISABLE_RAW_TEST262_ASSERT_SHIM");
+      else process.env.JS2WASM_DISABLE_RAW_TEST262_ASSERT_SHIM = previous;
+    }
+  });
+
+  it("does not inject a raw-assert shim for inert text or a local binding", async () => {
+    await withoutGlobalAssert(async () => {
+      const evaluate = await hostEvalImport();
+      // `with` keeps these on the legacy fallback path, where a raw
+      // substring detector would otherwise prepend `var assert`.
+      expect(evaluate('with ({}) { "assert.sameValue(1, 1)"; }', 0)).toBeUndefined();
+      expect((globalThis as Record<string, unknown>).assert).toBeUndefined();
+      expect(
+        evaluate("let assert = { sameValue: function () {} }; with ({}) { assert.sameValue(); }", 0),
+      ).toBeUndefined();
+      expect((globalThis as Record<string, unknown>).assert).toBeUndefined();
+    });
+  });
+});
+
+describe("#1164 ES5 eval slice — exact host IR ownership", () => {
+  it("recognizes only the canonical statement spelling", () => {
+    expect(exactIndirectEvalStatement(firstCall("(0, eval)(source);"))).toBeDefined();
+    expect(exactIndirectEvalStatement(firstCall("((0), (eval))(source);"))).toBeDefined();
+
+    for (const source of [
+      "eval(source);",
+      "const result = (0, eval)(source);",
+      "(1, eval)(source);",
+      "(0, eval)();",
+      "(0, eval)(source, source);",
+      "(0, eval)(...sources);",
+      "(0, eval)?.(source);",
+    ]) {
+      expect(exactIndirectEvalStatement(firstCall(source)), source).toBeUndefined();
+    }
+  });
+
+  it("owns a proven-string indirect statement through IR, reserves one import, and executes raw asserts", async () => {
+    const result = await compileTracked(`
+      export function probe(source: string): number {
+        (0, eval)(source);
+        return 1;
+      }
+    `);
+
+    expect(outcomeFor(result)).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.imports.filter((descriptor) => descriptor.name === "__extern_eval")).toHaveLength(1);
+    expect(
+      WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).filter(
+        (entry) => entry.module === "env" && entry.name === "__extern_eval",
+      ),
+    ).toEqual([{ module: "env", name: "__extern_eval", kind: "function" }]);
+
+    await withoutGlobalAssert(async () => {
+      const exports = await instantiate(result);
+      const probe = exports.probe as (source: string) => number;
+      expect(probe("assert.sameValue(1, 1);")).toBe(1);
+      expect(probe("assert.throws(TypeError, function () { throw new TypeError(); });")).toBe(1);
+      expect(() => probe("assert.sameValue(1, 2);")).toThrow(/eval harness assertion/);
+    });
+  });
+
+  it.each([
+    ["direct eval", `export function probe(source: string): number { eval(source); return 1; }`],
+    ["value-producing indirect eval", `export function probe(source: string): unknown { return (0, eval)(source); }`],
+    ["non-string union", `export function probe(source: string | number): number { (0, eval)(source); return 1; }`],
+    ["zero arguments", `export function probe(): number { (0, eval)(); return 1; }`],
+    ["two arguments", `export function probe(source: string): number { (0, eval)(source, source); return 1; }`],
+    ["spread argument", `export function probe(sources: string[]): number { (0, eval)(...sources); return 1; }`],
+    ["nonzero comma lhs", `export function probe(source: string): number { (1, eval)(source); return 1; }`],
+    [
+      "shadowed eval",
+      `export function probe(eval: (source: string) => unknown, source: string): number { (0, eval)(source); return 1; }`,
+    ],
+  ])("demotes %s before IR emission", async (_label, source) => {
+    const result = await compileTracked(source);
+    expect(outcomeFor(result)).toMatchObject({ legacyBodyEmitted: true, irBodyEmitted: false });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps the host-only statement form out of standalone IR", async () => {
+    const result = await compileTracked(
+      `export function probe(source: string): number { (0, eval)(source); return 1; }`,
+      "standalone",
+    );
+    expect(outcomeFor(result)).toMatchObject({ legacyBodyEmitted: true, irBodyEmitted: false });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(
+      WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).some(
+        (entry) => entry.module === "env" && entry.name === "__extern_eval",
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- classify only active, unshadowed raw Test262 harness `assert` calls before the existing host-eval fallback
- lower the exact discarded indirect-eval statement through the IR path and reserve its host import during collection
- keep direct eval, value-producing calls, non-string source, shadowed bindings, optional/spread shapes, and standalone compilation on their existing paths
- make the runtime classifier kill switch browser-safe

## Impact

On the exact same maintained 120-row ES5 eval cohort:

- host: `0/120 -> 30/120` (**+30, 0 lost**)
- host with classifier kill switch: `0/120`, attributing all 30 gains to the runtime raw-assert classifier
- real QuickJS standalone: `120/120 -> 120/120` (**0 changed, 0 lost**)

The remaining 90 rows all reach the shim and fail semantic assertions; they are routed to the existing eval declaration-instantiation work rather than being misclassified as detector misses.

## Validation

- focused #1164 slice: 29/29
- existing #1164 suite: 17/17
- numeric-local IR parity: 18/18
- typecheck
- IR adoption and fallback gates
- complete pre-push quality, format, oracle, coercion, numeric-local, and issue-integrity gates

Stacked on #4442, which contains the Sol architecture and measured acceptance contract.