### PR TITLE
docs(es5): specify complete with-statement IR plan

### DIFF
--- a/plan/issues/671-with-statement-support.md
+++ b/plan/issues/671-with-statement-support.md
@@ -1,29 +1,557 @@
 ---
 id: 671
-title: "with statement support"
-status: backlog
+title: "ES5 `with`: complete Object Environment Record semantics on the IR path"
+status: ready
 created: 2026-03-20
-updated: 2026-04-28
-priority: low
-feasibility: medium
+updated: 2026-08-13
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: ir, codegen, runtime
+es_edition: 5
+language_feature: with-statement
 goal: es5
-sprint: Backlog
-test262_fail: 272
-files:
-  src/codegen/statements.ts:
-    new:
-      - "compile with() via dynamic scope chain lookup"
+sprint: current
+test262_fail: 67
+related: [1387, 2663, 3025, 4179, 4206, 4231, 4264, 1472]
 ---
-# #671 — with statement support
 
-## Status: open
+# #671 — ES5 `with`: complete Object Environment Record semantics on the IR path
 
-~272 tests use `with(obj) { prop }` which requires dynamic scope lookup.
+## Status
 
-### Approach
-Compile `with(obj) { x }` as: check if obj has property "x" (via hasOwnProperty or struct field check), if so use obj.x, otherwise use the enclosing scope's x. This is a compile-time if/else at each variable reference inside the with block.
+Ready for staged implementation. This is the live umbrella for finishing
+`with`; it supersedes the original “~272 tests / compile-time `if`” stub and the
+stale limitations in #1387 and #4206. It does **not** close until every direct
+`WithStatement` row passes in both lanes and the unpartitioned ES5 goal reaches
+9,029/9,029 in each lane.
 
-For struct-backed objects: emit `struct.get` with field existence check.
-For externref objects: emit `__extern_has(obj, "x")` + `__extern_get(obj, "x")`.
+This implementation plan was re-grounded by a Sol/max architecture pass on
+`origin/main@c26670fdc0d567203d95b68553d9393279608a96`.
 
-## Complexity: M
+## Exact current population
+
+The population is the intersection of:
+
+1. official test262 rows whose edition label is ES5 or earlier; and
+2. files whose parsed source contains a real TypeScript `WithStatement` node.
+
+That produces **201 exact rows per lane**, not the old 272/294 source-shape
+estimates. On the pinned current artifacts:
+
+| lane | pass | fail | compile error | timeout / skip | non-pass |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| JS host | 134 | 57 | 10 | 0 | **67** |
+| standalone | 150 | 41 | 10 | 0 | **51** |
+
+Cross-lane matrix: 113 both-pass, 37 host-nonpass/standalone-pass, 21
+host-pass/standalone-nonpass, and 30 both-nonpass.
+
+Provenance:
+
+- compiler artifact source: `b9f6277e534340b20199fd3cb8acbb204f84071c`;
+  this is an ancestor of the planning base, with no later `src/` or `test/`
+  changes;
+- test262 corpus: `b363f29d3c43c626dc852744ad64a0b48a003693`;
+- baseline repository: `d3c4816e68282d2c3e0e3c95fc11551640ffbf43`;
+- oracle: v13;
+- host artifact: `.test262-cache/test262-current.jsonl`;
+- standalone artifact: `.test262-cache/test262-standalone-current.jsonl`;
+- edition denominator: **9,029 rows per lane**, including `eval`, the
+  `Function` constructor, and `with`, as fixed in `plan/goals/es5.md`.
+
+A textual `\bwith\s*\(` scan finds 220 rows, but 19 are comments, generated
+strings, or eval-source shapes rather than a direct statement. Keep that
+overlapping cohort for eval routing; do not use it as this feature's causal
+denominator.
+
+### Ranked measured slices
+
+These are measured rows affected by a coherent mechanism, not promised
+fail-to-pass conversions. Every slice must prove its own A/B result.
+
+| rank | bounded mechanism | host rows | standalone rows | current evidence |
+| ---: | --- | ---: | ---: | --- |
+| 1 | runtime `DeleteBinding` over a closed-struct target splits the host sidecar from later direct field reads | **21 non-pass** | **21 pass controls** | all host rows end at `myObj.p3 === undefined`, actual `'c'` |
+| 2 | constructible function-expression capture of the object environment | **10 compile errors** | **10 compile errors** | exact diagnostic: `constructible closure capture is not in the with-environment IR slice` |
+| 3 | identifier scope-chain precedence | **5 non-pass** | **5 non-pass** | `language/identifier-resolution/S10.2.2_A1_T{5..9}.js` |
+| 4 | remaining direct-With residue after 1–3 | remeasure | remeasure | signatures overlap unrelated value-carrier/global/call defects |
+
+The 21-row first slice is exactly:
+
+- `S12.10_A1.1_T{1,2}`;
+- `S12.10_A1.2_T{1,2,4}`;
+- `S12.10_A1.3_T{1,2,4}`;
+- `S12.10_A1.4_T{1,2,4}`;
+- `S12.10_A1.5_T{1,2,4}`;
+- `S12.10_A1.6_T{1,2}`;
+- `S12.10_A1.9_T{1,2}`; and
+- `S12.10_A1.10_T{1,2,4}`
+
+under `test/language/statements/with/`.
+
+## ES5 semantic contract
+
+Use the [ECMA-262 5.1 specification](https://262.ecma-international.org/5.1/),
+not a later-edition `with` sketch.
+
+### Entering and leaving `with`
+
+[§12.10](https://262.ecma-international.org/5.1/#sec-12.10) requires:
+
+1. evaluate the head expression once and apply `GetValue`;
+2. apply `ToObject` once; `null` and `undefined` throw `TypeError`, while
+   number/string/boolean primitives get wrapper objects;
+3. create an Object Environment Record whose outer environment is the old
+   `LexicalEnvironment` and whose `provideThis` flag is true;
+4. evaluate the body; and
+5. restore the old `LexicalEnvironment` on normal **and every abrupt**
+   completion.
+
+The compiler does not need a mutable process-global scope stack when it can
+encode the environment chain structurally in IR. A closure that escapes must
+capture the environment receiver/chain by reference; it must not snapshot
+property values.
+
+### LexicalEnvironment is not VariableEnvironment
+
+The `with` statement changes **LexicalEnvironment only**. The execution
+context's **VariableEnvironment never changes**. Consequently:
+
+- `var` and hoisted function bindings are created in the surrounding
+  VariableEnvironment; they are not members of the with-object merely because
+  their declaration text appears in the body;
+- evaluating a `var` initializer still performs ordinary identifier reference
+  resolution through the current LexicalEnvironment. Therefore
+  `with ({x: 1}) { var x = 2; }` writes the object property while the hoisted
+  variable binding remains outside the object record; and
+- function expressions created inside the body capture the current
+  LexicalEnvironment, while a function created outside and merely called from
+  inside does not acquire dynamic access to the with-object.
+
+Do not retain #1387's blanket “body declaration blocks the object” or “var /
+function declarations are architectural blockers” rules. Lexical declarations
+shadow according to their own environment; VariableEnvironment declarations
+need correct instantiation plus reference resolution, not a hard refusal.
+
+### Object Environment Record operations
+
+[§10.2.1.2](https://262.ecma-international.org/5.1/#sec-10.2.1.2) defines the
+required operations:
+
+- `HasBinding(N)` calls the binding object's `[[HasProperty]](N)`, including its
+  prototype chain;
+- `GetBindingValue(N, S)` performs `[[Get]]` after `HasProperty`;
+- `SetMutableBinding(N, V, S)` performs `[[Put]]` with the caller's strictness;
+- `DeleteBinding(N)` performs `[[Delete]](N, false)` and returns a Boolean; and
+- `ImplicitThisValue()` returns the binding object because `provideThis` is
+  true.
+
+`Symbol.unscopables` is **not part of ES5**. Existing modern-language support
+may preserve it behind an explicit later-edition policy, but it is not an ES5
+`HasBinding` step and must not appear in ES5 proofs, diagnostics, or acceptance
+criteria. Likewise, `hasOwnProperty` is wrong: inherited properties bind.
+
+### References, not just values
+
+Identifier resolution follows
+[§10.2.2.1](https://262.ecma-international.org/5.1/#sec-10.2.2.1). The lowering
+must preserve the selected **Reference** until the consuming operation:
+
+- read: `GetValue` from the selected object or outer binding;
+- simple assignment: resolve the LHS before evaluating the RHS, then store to
+  that same selected base;
+- compound assignment and prefix/postfix update: resolve once, get once,
+  evaluate RHS/coercions, and put back to the same base; getters/proxies may
+  mutate the property between steps;
+- `delete name`: if the selected base is the Object Environment Record, call
+  its `DeleteBinding`; if it is a declarative binding return false; if it is
+  unresolvable return true in sloppy code;
+- `typeof name`: an unresolvable reference yields `"undefined"`, but an object
+  getter's abrupt completion must propagate; and
+- bare `f()` call: when `f` resolved through the Object Environment Record,
+  [§11.2.3](https://262.ecma-international.org/5.1/#sec-11.2.3) obtains
+  `thisValue` from `ImplicitThisValue`, so the with-object is `this`.
+
+Resolving a name separately for the read and the write, or compiling a bare
+call as an ordinary closure call with `undefined`/global `this`, is unsound.
+
+## Root causes on current main
+
+### 1. Only a narrow static closure shape is actually on middle IR
+
+`src/ir/select.ts:isPhase1WithStatement` (line ~3950) requires an inline object
+literal, block body, and at least one ordinary synchronous function expression.
+`src/ir/from-ast.ts:lowerWithStatement` (line ~8456) then installs one
+`withField` binding per known field and emits `object.get`/`object.set`.
+
+That slice has no runtime `HasBinding`, prototype lookup, delete, call-`this`,
+or general reference model. Almost all currently passing `with` rows still use
+the legacy `FunctionContext.withScopes` path. The completion criterion is not
+“legacy handles it”; the semantic path must move into IR.
+
+### 2. The 21-row host delete family is split representation, not a bad delete helper
+
+`src/codegen/with-scope.ts:proveStructTypedWithTarget` (line ~330) deliberately
+rejects a body containing `delete <Identifier>`. Those rows therefore use
+`compileDynamicWithStatement` and `emitDynamicWithDelete` (line ~767):
+
+```text
+HasBinding(externref(myObj), "p3")
+  ? __delete_property(externref(myObj), "p3")
+  : delete the outer reference
+```
+
+In the host lane, `myObj` remains a fixed WasmGC struct. The runtime helper
+correctly tombstones the externref/sidecar view, but the later statically typed
+`myObj.p3` read is a direct `struct.get` and still sees `'c'`.
+
+Standalone already passes all 21 counterparts because
+`src/codegen/declarations/dynamic-with-shape.ts` and
+`object-shape-widening.ts` pin this exact target shape to the canonical open
+`$Object`. The file explicitly makes that decision standalone-only. Therefore:
+
+- do **not** patch `__delete_property` globally;
+- do **not** add a second tombstone engine; and
+- make IR planning choose one MOP-capable object identity in both lanes before
+  allocation whenever a `with` reference needs runtime HasBinding/DeleteBinding.
+
+### 3. Constructible closures are refused before lowering
+
+`src/ir/with-environment.ts:selectWithEnvironmentClosures` (line ~33) records
+ordinary function-expression captures, then rejects `new <capturedFn>()` at
+line ~96. Existing IR closure signatures contain only params/result, and
+`closure.new` / `closure.call` have no `[[Construct]]` operation or constructible
+brand. Legacy already has constructible wrapper and `__construct_closure`
+machinery; IR must expose it without snapshotting the with-object.
+
+## Implementation plan
+
+### Slice W1 — IR-owned open-object plan for runtime DeleteBinding (21 host rows)
+
+This is the first implementation handoff. Keep it bounded to the exact
+bare-identifier-delete trigger and its representation consequences.
+
+**File: `src/ir/with-environment.ts` (lines ~18–110)**
+
+- Add a backend-neutral target-representation planner, for example:
+
+  ```ts
+  interface IrWithTargetPlan {
+    readonly representation: "closed-fields" | "open-object";
+    readonly reasons: readonly ("runtime-has-binding" | "runtime-delete-binding")[];
+  }
+  ```
+
+- Move the function/class-boundary-safe scan for a direct
+  `delete <Identifier>` into this IR subsystem. Parentheses are transparent;
+  member deletes (`delete o.p`) are not this trigger; nested callable/class
+  bodies belong to the environment they execute in and are not attributed to
+  the outer statement.
+- For W1, return `open-object` only for `with (<identifier>)` whose directly
+  executing body contains that delete shape. Do not broaden to all `with`
+  targets without a new census and A/B.
+- Unit-test the planner with direct, parenthesized, nested-with, member-delete,
+  and nested-function controls.
+
+**File: `src/codegen/declarations/dynamic-with-shape.ts` (lines ~76–135)**
+
+- Retire the standalone-specific semantic scan. Keep at most a thin adapter to
+  the IR planner while callers migrate; there must be one decision engine.
+- Rename documentation away from “standalone pinning”: this is a lane-neutral
+  requirement for one object identity whenever runtime environment operations
+  and ordinary property reads meet.
+
+**File: `src/codegen/declarations/object-shape-widening.ts` (lines ~735–805)**
+
+- Consult `IrWithTargetPlan` before object-literal representation allocation in
+  **both** lanes.
+- Put a W1 target into the existing open-object / hash-consumer set and record
+  its checker type in the existing representation-refusal set, exactly as the
+  current standalone arm does. This keeps declaration storage, aliases,
+  with-environment operations, and later dot reads on one representation.
+- Preserve the existing concrete-struct-consumer safety gate. If the target
+  also flows to a genuinely struct-typed ABI position, refuse the W1 claim
+  before allocation rather than inserting an unchecked cast or silently
+  splitting identity.
+- Do not special-case `p3`, the test names, or host mode.
+
+**Files: `src/codegen/literals.ts` (function
+`compileObjectLiteralAsExternref`, line ~383), `src/codegen/statements/variables.ts`,
+and `src/codegen/declarations.ts` (function `moduleGlobalWasmType`, line ~1818)**
+
+- Reuse the existing `__new_plain_object` + `__extern_set` builder and existing
+  externref local/global typing. Add no new object store.
+- Verify function-valued data properties in the measured object literal retain
+  callable identity; W1 must not fix delete while breaking `valueOf`, `eval`,
+  or the other properties in the same test files.
+
+**Expected lowering shape**
+
+```wasm
+;; One canonical open object is allocated and stored in myObj.
+global.get $__mod_myObj
+global.set $__with_receiver
+
+;; ES5 HasBinding; inherited properties count.
+global.get $__with_receiver
+<const "p3">
+call $__extern_has
+if (result i32)
+  global.get $__with_receiver
+  <const "p3">
+  call $__delete_property
+else
+  ;; outer declarative/unresolvable DeleteBinding result
+  i32.const 0
+end
+
+;; Later myObj.p3 reads the same open object/tombstone-aware MOP.
+global.get $__mod_myObj
+<const "p3">
+call $__extern_get
+```
+
+The exact helper spelling may differ by lane, but both must implement the same
+IR plan and operate on the same identity.
+
+**W1 pre-claim refusals**
+
+- target is not a single checker-resolved identifier;
+- alias/escape analysis cannot prove every later consumer accepts the open
+  representation;
+- a concrete struct ABI consumer exists;
+- object construction contains an unsupported property form; or
+- the planner and allocator disagree about the exact declaration identity.
+
+These are selector/planning refusals, not late `from-ast` throws and not
+silent fallback after partially allocating a struct.
+
+### Slice W2 — first-class dynamic environment/reference operations
+
+W1 fixes identity coherence. W2 moves name resolution itself off
+`FunctionContext.withScopes` and onto middle IR.
+
+**File: `src/ir/nodes.ts` (dynamic nodes around lines ~1150–1202)**
+
+- Add backend-neutral primitives beside `dyn.member_get` / `dyn.member_set`:
+  - `dyn.member_has(recv, key) -> bool`, using `[[HasProperty]]`;
+  - `dyn.member_delete(recv, key, strict) -> bool`;
+  - make dynamic member set carry `strict`, or add an explicit sloppy variant;
+    a `with` statement is forbidden in strict code, so its ES5 store uses
+    `[[Put]](..., false)`;
+  - `dyn.call_with_this(callee, thisValue, args) -> dynamic` (or an equivalent
+    general call node) so a bare with-bound call preserves the object base.
+- Do not encode “with” into the object MOP nodes. The with-specific part is
+  reference selection; the property operations are reusable dynamic IR.
+- Add every node to the instruction union, result-kind tables, operand-use
+  collection, cloning/printing, and allocation-site classification where
+  applicable.
+
+**File: `src/ir/builder.ts` (dynamic builder methods around lines ~596–652)**
+
+- Add typed constructors for the new nodes. Require canonical `dynamic`
+  carriers (or an explicit object carrier accepted by the resolver), Boolean
+  brand the has/delete results, and reject mismatched operands immediately.
+- Preserve evaluation order in the builder API: receiver, key, then value/args.
+
+**File: `src/ir/verify.ts` (dynamic verification around lines ~833–885)**
+
+- Verify operand/result types, Boolean result branding, call arity, and that a
+  reference selector result dominates every get/set/delete/call that consumes
+  it.
+- Verify a compound/update plan uses one selection result for both read and
+  write; two independent HasBinding nodes are an invalid IR shape.
+
+**File: `src/ir/effects.ts` (dynamic effects around lines ~174–180)**
+
+- `has`, `get`, `set`, `delete`, and dynamic call may invoke proxy/accessor/user
+  code and may throw. Mark them effectful; never DCE, duplicate, or reorder them
+  across RHS evaluation.
+
+**File: `src/ir/from-ast.ts` (`ScopeBinding` around line ~1905,
+`lowerCall` ~5265, `lowerWithStatement` ~8456, and identifier assignment
+~8707)**
+
+- Replace “one `withField` per known property” as the general model with an
+  ordered environment descriptor:
+
+  ```ts
+  interface IrWithEnvironmentBinding {
+    readonly receiver: IrValueId;
+    readonly outer: ScopeBinding | undefined;
+    readonly mode: "closed" | "dynamic";
+  }
+  ```
+
+- Add a reference-planning helper that resolves a bare identifier to an
+  ordered list of with candidates plus its checker-resolved outer binding.
+- For a dynamic chain, emit HasBinding **once, before the RHS or call args**,
+  and materialize a selector SSA value (innermost match, otherwise outer).
+  Nested HasBinding checks must short-circuit; do not eagerly probe outer
+  objects after an inner match.
+- Reads, writes, delete, typeof, calls, compound assignments, and updates must
+  consume that saved selector. Use structured `IrInstrIf` arms to keep outer
+  bindings in their existing typed representations; box only at the explicit
+  dynamic boundary.
+- Closed fields may fold HasBinding only when IR proves the complete own and
+  prototype shape cannot change. Otherwise demote to the dynamic operations.
+- Evaluate/ToObject the with head once. Keep its receiver live through the body
+  and capture it in escaping closures.
+
+**File: `src/ir/select.ts` (`isPhase1WithStatement`, line ~3950)**
+
+- Select by supported reference operations, target carrier, and closure
+  environment ABI—not by “must contain a closure”. Non-closure with bodies
+  belong on IR too.
+- Inspect every identifier use by operation kind. Claim only when every
+  reachable reference consumer has a W2 lowering.
+- Remove blanket refusals for `var` and function declarations. Coordinate
+  declaration instantiation with VariableEnvironment; only unsupported
+  reference/capture shapes are legitimate refusals.
+- Strict-mode `with` must already be rejected by
+  `src/compiler/early-errors/node-checks.ts` (line ~400). Hardened mode's
+  deliberate all-`with` policy in `src/compiler/validation.ts` remains separate
+  from language conformance.
+
+**Files: `src/ir/lower.ts` (dynamic lowering around lines ~1965–2015),
+`src/ir/backend/handles.ts` (`IrDynamicLowering`, line ~266), and
+`src/ir/integration.ts` (`preregisterDynamicSupport`, lines ~5840–5893)**
+
+- Extend `IrDynamicLowering` with has/delete/sloppy-set/explicit-this-call
+  emitters.
+- Pre-register every helper/import before Phase 3; resolve function indices by
+  name at emission time. No mid-emission late-import shifts.
+- Host and standalone must expose identical logical operations despite their
+  different carriers (`externref` vs `$AnyValue`).
+
+**Runtime contracts**
+
+- Reuse `__extern_has`, `__extern_get`, `__extern_set`, and
+  `__delete_property` as the semantic engines where their strictness matches.
+- Add only thin carrier adapters such as `__dyn_member_has` or
+  `__dyn_member_delete`; do not duplicate property descriptor, prototype,
+  proxy, tombstone, or ToPropertyKey logic.
+- Existing `__ir_dyn_method_call_0/1` is the pattern for preserving a receiver,
+  but the IR contract must handle the arities selected by the source rather
+  than silently dropping arguments.
+
+### Slice W3 — constructible closure environment capture (10 + 10 CEs)
+
+**File: `src/ir/with-environment.ts` (lines ~88–103)**
+
+- Replace the constructible-closure refusal with a positive plan only after the
+  IR closure ABI below exists. Keep generator/async/class-method refusals until
+  their environment ABIs are independently supported.
+
+**File: `src/ir/nodes.ts` (`IrClosureSignature` ~192 and closure nodes
+~1389–1445)**
+
+- Add constructibility to closure identity/allocation metadata; arrows remain
+  non-constructible.
+- Add `closure.construct` with explicit args and a dynamic/object result. It
+  invokes the same lifted body and capture fields as `closure.call`, while
+  supplying fresh `this`, prototype linkage, constructor return override, and
+  instance→constructor identity.
+
+**Files: `src/ir/builder.ts`, `src/ir/verify.ts`, `src/ir/lower.ts`, and
+`src/ir/integration.ts`**
+
+- Wire construction through the existing constructible wrapper family in
+  `src/codegen/closures/funcref-wrapper-types.ts` (line ~150) and the existing
+  native/host construction engines in `src/codegen/expressions/new-super.ts`.
+- Capture the ordered with-environment receiver(s) in `closure.new`; lifted
+  bodies rehydrate environment descriptors, not individual property values.
+- Extend `lowerNewExpression` to resolve a closure-typed identifier before the
+  local-class/extern-class arms.
+- Verify ordinary calls still use the call ABI and `new` uses the construct ABI.
+
+Exact acceptance files are `S12.10_A1.8_T{1..5}` and
+`S12.10_A3.8_T{1..5}`.
+
+### Slice W4 — declaration environments, direct eval, and remaining forms
+
+- Model declaration instantiation explicitly enough that VariableEnvironment
+  bindings remain outside the object environment while initializer references
+  traverse it.
+- Function declarations/Annex B declarations must follow their own hoisting
+  plan; do not treat them like function expressions created at the statement
+  position.
+- Direct eval must receive the active ordered LexicalEnvironment descriptors;
+  indirect eval and the Function constructor must not capture them.
+- Add arrow, generator, async, method, and class capture only with their existing
+  `this`/`super`/suspension semantics intact.
+- Re-run the direct 201-row census after every landed slice, recluster the
+  residue by first causal failure, and split unrelated global/value-carrier
+  defects to their existing repo issues rather than claiming them here.
+
+## Edge cases and required regression coverage
+
+- `with (null)` and `with (undefined)` throw before the body; primitives other
+  than null/undefined are object-coerced.
+- target expression and every HasBinding probe execute once in source order.
+- inherited properties bind; own-only probing is rejected.
+- property added/deleted while the body runs changes later independent
+  identifier resolution.
+- nested with scopes choose the innermost current match and fall outward.
+- lexical `let`/`const`/class/catch bindings shadow as specified; `var` storage
+  remains in VariableEnvironment.
+- abrupt `throw`, `return`, `break`, and `continue` do not leak an active
+  environment into following code.
+- closure created inside captures; closure created outside does not.
+- bare call through object environment uses the object as `this`; outer-bound
+  call uses its ordinary this rule.
+- `delete`, `typeof`, simple assignment, compound assignment, and postfix /
+  prefix update preserve one resolved reference.
+- non-configurable delete returns false in sloppy code; strict `with` is an
+  early SyntaxError.
+- a successful delete is visible through dot/bracket read, `in`,
+  `hasOwnProperty`, descriptor queries, and enumeration in both lanes.
+- function-valued properties and accessors retain call identity and abrupt
+  behavior when an open-object plan is selected.
+
+## Measurement and acceptance
+
+For every slice:
+
+1. fetch exact current `origin/main` and run in an isolated worktree;
+2. derive the ES5-or-earlier direct-With population from parsed AST plus the
+   edition index—never error-string grep alone;
+3. record compiler SHA, corpus SHA, baseline SHA, oracle version, lane, and
+   exact file manifest;
+4. run base/head over the **same population in both lanes**;
+5. require zero pass→nonpass changes in the 201-row direct-With control and in
+   the full 9,029-row lane denominator;
+6. separately report compile-error removals, fail→pass conversions, and
+   changed-but-still-failing signatures; and
+7. run unit/integration tests for IR construction, verification, lowering,
+   strict early errors, nested/abrupt scope behavior, and object-store parity.
+
+Final acceptance:
+
+- [ ] 201/201 direct-With rows pass in the JS-host lane.
+- [ ] 201/201 direct-With rows pass in standalone.
+- [ ] no `#1387` hard refusal remains for a valid ES5 with shape.
+- [ ] IR shape diagnostics show the supported bodies on middle IR; legacy
+      fallback is not counted as completion.
+- [ ] full ES5-or-earlier results are 9,029 pass, zero fail/CE/timeout/skip in
+      each lane, including overlapping eval/Function/with rows.
+
+## Risks and active overlap
+
+- [PR #4437](https://github.com/loopdive/js2wasm/pull/4437) also edits
+  `src/ir/from-ast.ts`, `src/ir/select.ts`, `src/ir/integration.ts`, and IR
+  legality around dynamic equality.
+- [PR #4438](https://github.com/loopdive/js2wasm/pull/4438) also edits
+  `src/ir/nodes.ts`, `src/ir/integration.ts`, legality, and class/codegen files.
+
+Rebase after those heads move or merge, then re-ground line numbers and dynamic
+carrier APIs before W2/W3. The semantic topics do not overlap, but the IR hot
+files will conflict mechanically. W1 is intentionally centered in
+`ir/with-environment.ts` and representation planning so it can land with less
+collision risk.
+
+Do not revive a second legacy-only implementation while resolving conflicts.
+`FunctionContext.withScopes` remains a compatibility adapter until its last
+consumer migrates, then should be deleted.


### PR DESCRIPTION
## Summary

- re-ground all 201 direct ES5 `with` rows in both lanes
- specify Object Environment Record semantics, reference preservation, open-object carrier planning, constructible closure capture, declaration environments, and direct eval
- divide delivery into W1–W4, with exact refusals and zero-loss 9,029×2 gates

## Current evidence

- direct `with` population: 201 rows per lane
- host: 134 pass / 67 non-pass
- standalone: 150 pass / 51 non-pass
- W1 exact DeleteBinding carrier slice: 21 rows

## Validation

- docs-only Sol Max architecture
- rebased onto server `origin/main@bd71baaf840f4b8e0a53e8f78d8b48c905d040ce`
- complete pre-push typecheck, lint, format, oracle, coercion, numeric-local IR parity, and issue-integrity gates passed

The Terra W1 implementation is stacked separately and this PR is ready, not a draft.