### PR TITLE
fix(with): preserve open targets through direct member access

### DIFF
--- a/plan/issues/671-with-statement-support.md
+++ b/plan/issues/671-with-statement-support.md
@@ -1,7 +1,7 @@
 ---
 id: 671
 title: "ES5 `with`: complete Object Environment Record semantics on the IR path"
-status: ready
+status: in-progress
 created: 2026-03-20
 updated: 2026-08-13
 priority: high
@@ -11,6 +11,19 @@ task_type: feature
 area: ir, codegen, runtime
 es_edition: 5
 language_feature: with-statement
+loc-budget-allow:
+  - src/codegen/context/types.ts
+  - src/codegen/declarations/object-shape-widening.ts
+  - src/codegen/literals.ts
+  - src/codegen/expressions/assignment.ts
+  - src/codegen/expressions/calls.ts
+  - src/codegen/property-access.ts
+func-budget-allow:
+  - src/codegen/declarations/object-shape-widening.ts::collectGrowableObjectLiterals
+  - src/codegen/literals.ts::compileObjectLiteral
+  - src/codegen/expressions/assignment.ts::compilePropertyAssignment
+  - src/codegen/expressions/calls.ts::compileCallExpression
+  - src/codegen/context/create-context.ts::createCodegenContext
 goal: es5
 sprint: current
 test262_fail: 67
@@ -21,14 +34,79 @@ related: [1387, 2663, 3025, 4179, 4206, 4231, 4264, 1472]
 
 ## Status
 
-Ready for staged implementation. This is the live umbrella for finishing
-`with`; it supersedes the original “~272 tests / compile-time `if`” stub and the
-stale limitations in #1387 and #4206. It does **not** close until every direct
+W1 is in progress. This is the live umbrella for finishing `with`; it
+supersedes the original “~272 tests / compile-time `if`” stub and the stale
+limitations in #1387 and #4206. It does **not** close until every direct
 `WithStatement` row passes in both lanes and the unpartitioned ES5 goal reaches
 9,029/9,029 in each lane.
 
 This implementation plan was re-grounded by a Sol/max architecture pass on
 `origin/main@c26670fdc0d567203d95b68553d9393279608a96`.
+
+### W1 implementation evidence — 2026-08-13
+
+W1 now has one IR-owned direct-`DeleteBinding` target plan, a
+declaration-identity pre-claim, and one canonical open-object carrier. The
+property selector is also declaration-keyed: all public direct member reads,
+writes, and callable-member calls on the selected target consume the raw
+open-object MOP value rather than the stale checker-derived field type. A
+same-named binding in another scope remains on its existing representation.
+
+The measured manifest was the exact 21-file slice below, comparing the local
+base artifact from
+`origin/main@cb4d4d7ca2f151ba69f26cff517417e003428df7` with the rebased implementation
+`491898a4dfa4129478c8a7cd2ddec00ba28574e7` on
+`origin/main@bd71baaf840f4b8e0a53e8f78d8b48c905d040ce`.
+Both arms used `scripts/harness-flip-probe.ts` and demonstrated its mandatory
+must-pass and must-fail controls.
+
+| lane | base | head | gained | lost | net |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| JS host | 21 fail | 6 pass / 15 fail | 6 | 0 | **+6** |
+| standalone | 21 pass | 21 pass | 0 | 0 | **0** |
+
+The host gains are `S12.10_A1.2_T{1,2,4}` and
+`S12.10_A1.3_T{1,2,4}`. The focused regression test covers host and standalone
+direct readback, post-`with` direct writes, function-valued member identity and
+arguments, deferred module initialization, capture refusal, a `for-in`
+consumer refusal, and one authentic gained host control.
+
+The 15 unchanged host rows are intentionally not folded into W1's claim:
+
+- twelve stop at assertion #18 (`value === undefined`, observed `null`), which
+  is `var` / VariableEnvironment declaration routing rather than target
+  representation and belongs to W4;
+- `S12.10_A1.5_T{1,2,4}` remains at the old deleted-`p3` observation because
+  its `for-in` target consumer fails W1's pre-allocation safety proof. W1 does
+  not widen that consumer without an explicit open-object iteration contract.
+
+The standalone pair has no transitions and remains 21/21 passing. The head arm
+used the canary-verified QuickJS artifact `b0662069c241…` and the compiler-keyed
+adapter `69f9752001f47bd7` for compiler bundle `66bbd7933576be22`; its runtime banner confirmed that provider before
+the population ran. An earlier candidate-only run that reported 21 failures
+was discarded because the worktree lacked that provider, while the baseline
+had it. Provider availability must match across both arms. W2/W4 retain the
+remaining environment and declaration work outside this exact W1 family.
+
+Root review caught and fixed one pre-publication carrier leak: the first W1
+candidate also inserted the target's bare spelling into the legacy
+`growableObjectLiteralVars` / `externrefAccessorVars` sets. A separate
+same-named local passed to a concrete struct parameter then trapped instead of
+returning `7`. W1 now uses its declaration key for the literal route as well as
+member operations and does not populate those name-wide sets. The compiled
+dual-lane regression returns `17` (the W1 mutation contributes `10`, the
+unrelated closed struct contributes `7`).
+
+## Test Results
+
+- `pnpm exec vitest run tests/issue-671-with-w1.test.ts` — 14/14 passed.
+- `pnpm run typecheck` — passed.
+- `pnpm run check:issues` — passed.
+- `pnpm run check:loc-budget` and `pnpm run check:func-budget` — passed with
+  the W1 allowances above.
+- `pnpm run check:ir-fallbacks` and `pnpm run check:ir-adoption` — passed.
+- Exact harness A/B controls passed in both lanes; the 21-row deltas are
+  recorded in the W1 evidence table above.
 
 ## Exact current population
 
@@ -232,6 +310,22 @@ machinery; IR must expose it without snapshotting the with-object.
 
 This is the first implementation handoff. Keep it bounded to the exact
 bare-identifier-delete trigger and its representation consequences.
+
+#### LOC budget allowance
+
+`src/codegen/declarations/object-shape-widening.ts` receives a narrowly scoped
+allowance for W1's declaration-identity, open-carrier, and
+concrete-struct-consumer safety boundary. The matching keyed selector lives in
+`property-access.ts`, with one small selection arm each in assignment and call
+codegen plus its context registration. Those paths are required to consume the
+same carrier for direct reads, writes, and callable members; they do not widen
+unrelated objects or add a runtime store.
+
+The corresponding function allowances cover only that atomic selection path:
+planner result, declaration identity, consumer-ABI refusal, pre-allocation
+carrier choice, and use-site MOP selection. Extracting only a helper would
+separate those interdependent decisions without shrinking the proof surface;
+broader shape analysis remains explicitly refused.
 
 **File: `src/ir/with-environment.ts` (lines ~18–110)**
 

--- a/plan/issues/671-with-statement-support.md
+++ b/plan/issues/671-with-statement-support.md
@@ -54,12 +54,18 @@ same-named binding in another scope remains on its existing representation.
 
 The final measured manifest was the exact 21-file slice below, comparing a
 fresh detached base at
-`origin/main@17606867782907257c9fd26e4a4bc3e4e735a679` with implementation commit
-`83afdac8778499586928feebfc6767d9daf2ab45` on that base. The intervening
-main commit merged only the #2668 planning markdown; the compiler, runtime,
-harness, and fixture inputs remain byte-identical to the measured base.
-Both arms used `scripts/harness-flip-probe.ts` and demonstrated its mandatory
-must-pass and must-fail controls.
+`origin/main@8a2baecf3bc39d7ac5de16ea0c65361e3b73aca9` with candidate tree
+`746fc27287e535cc4e39e8f03c3761639de8ed9a`. The compiler-bearing W1 commit is
+`d664215b9256d77ba5772439a751c848c9ef8ccd`; every later W1 commit through the
+measured candidate changes only this issue's evidence. This remeasurement
+therefore includes both the merged #4447 class-expression ownership changes
+and #4443 runtime-eval/compiler-IR changes in both arms instead of extrapolating
+from either earlier main. Both arms used
+`scripts/harness-flip-probe.ts`, demonstrated its mandatory must-pass and
+must-fail controls, and produced all 21 rows with no entered or missing files.
+The manifest SHA-256 is
+`386db0dde30a647a81965c673ab4f635c70da74e39a49ce6c733499502e0c4be`; the
+test262 corpus is `b363f29d3c43c626dc852744ad64a0b48a003693`.
 
 | lane | base | head | gained | lost | net |
 | --- | ---: | ---: | ---: | ---: | ---: |
@@ -82,14 +88,25 @@ The 15 unchanged host rows are intentionally not folded into W1's claim:
   not widen that consumer without an explicit open-object iteration contract.
 
 The standalone pair has no transitions and remains 21/21 passing. Both arms
-used the canary-verified QuickJS artifact `b0662069c241…`. The base used adapter
-`d7929c0b71a19b0c` for compiler bundle `106b0cabd7ae6de3`; the head used adapter
-`69f9752001f47bd7` for compiler bundle `66bbd7933576be22`. Each runtime banner
-confirmed its matching provider before the population ran. An earlier
-candidate-only run that reported 21 failures was discarded because its
-worktree lacked that provider. Provider availability must match across both
-arms. W2/W4 retain the remaining environment and declaration work outside this
-exact W1 family.
+freshly built their compiler and runtime bundles, then compiled and
+canary-verified a matching real-QuickJS adapter before the population ran:
+
+| artifact | base | candidate |
+| --- | --- | --- |
+| compiler bundle SHA-256 | `c60f2481bbc8e454ea3c6f91c5c1ade1bc111c4d77f42b72e3d162a82ce66875` | `cb7a02b9e00e900e6c6d0a33047fc9857a202ba9f2067f59c3f713de51781720` |
+| runtime bundle SHA-256 | `015635d37dcfb16467ff846857a1dab3589838d4232f9eb982d167add120d011` | `e1d1d8bac4917fd5e8584f4404145a48414bb58657ec3d861eda57620087ee2b` |
+| QuickJS adapter key | `d9b6dcbecd8aab90` | `3f69394285448486` |
+
+Both adapters have SHA-256
+`ce3688616ca764f82990b4792bd7f10b46a7ed4eadc4d4745fc330c908391b08`;
+their distinct keys prove each was selected against its arm's bundle. Both use
+the immutable QuickJS artifact
+`b0662069c241d0430d91c53a3b0e2d1281fd9eb78dd1c93490b0a9dfa70eec5b`.
+Each runtime banner confirmed the corresponding key before the 21 rows ran.
+An earlier candidate-only run that reported 21 failures was discarded because
+its worktree lacked that provider. Provider availability must match across
+both arms. W2/W4 retain the remaining environment and declaration work outside
+this exact W1 family.
 
 Root review caught and fixed one pre-publication carrier leak: the first W1
 candidate also inserted the target's bare spelling into the legacy
@@ -108,8 +125,10 @@ unrelated closed struct contributes `7`).
 - `pnpm run check:loc-budget` and `pnpm run check:func-budget` — passed with
   the W1 allowances above.
 - `pnpm run check:ir-fallbacks` and `pnpm run check:ir-adoption` — passed.
-- Exact harness A/B controls passed in both lanes; the 21-row deltas are
-  recorded in the W1 evidence table above.
+- Exact same-current-main harness A/B controls passed in both lanes. Host was
+  21 fail on base versus 6 pass / 15 fail on W1; standalone was 21 pass in both
+  arms. Both partitions verified `21 == 21`, with no other status changes,
+  entered rows, or missing rows.
 
 ## Exact current population
 

--- a/plan/issues/671-with-statement-support.md
+++ b/plan/issues/671-with-statement-support.md
@@ -52,11 +52,12 @@ writes, and callable-member calls on the selected target consume the raw
 open-object MOP value rather than the stale checker-derived field type. A
 same-named binding in another scope remains on its existing representation.
 
-The measured manifest was the exact 21-file slice below, comparing the local
-base artifact from
-`origin/main@cb4d4d7ca2f151ba69f26cff517417e003428df7` with the rebased implementation
-`491898a4dfa4129478c8a7cd2ddec00ba28574e7` on
-`origin/main@bd71baaf840f4b8e0a53e8f78d8b48c905d040ce`.
+The final measured manifest was the exact 21-file slice below, comparing a
+fresh detached base at
+`origin/main@17606867782907257c9fd26e4a4bc3e4e735a679` with implementation commit
+`83afdac8778499586928feebfc6767d9daf2ab45` on that base. The intervening
+main commit merged only the #2668 planning markdown; the compiler, runtime,
+harness, and fixture inputs remain byte-identical to the measured base.
 Both arms used `scripts/harness-flip-probe.ts` and demonstrated its mandatory
 must-pass and must-fail controls.
 
@@ -80,13 +81,15 @@ The 15 unchanged host rows are intentionally not folded into W1's claim:
   its `for-in` target consumer fails W1's pre-allocation safety proof. W1 does
   not widen that consumer without an explicit open-object iteration contract.
 
-The standalone pair has no transitions and remains 21/21 passing. The head arm
-used the canary-verified QuickJS artifact `b0662069c241…` and the compiler-keyed
-adapter `69f9752001f47bd7` for compiler bundle `66bbd7933576be22`; its runtime banner confirmed that provider before
-the population ran. An earlier candidate-only run that reported 21 failures
-was discarded because the worktree lacked that provider, while the baseline
-had it. Provider availability must match across both arms. W2/W4 retain the
-remaining environment and declaration work outside this exact W1 family.
+The standalone pair has no transitions and remains 21/21 passing. Both arms
+used the canary-verified QuickJS artifact `b0662069c241…`. The base used adapter
+`d7929c0b71a19b0c` for compiler bundle `106b0cabd7ae6de3`; the head used adapter
+`69f9752001f47bd7` for compiler bundle `66bbd7933576be22`. Each runtime banner
+confirmed its matching provider before the population ran. An earlier
+candidate-only run that reported 21 failures was discarded because its
+worktree lacked that provider. Provider availability must match across both
+arms. W2/W4 retain the remaining environment and declaration work outside this
+exact W1 family.
 
 Root review caught and fixed one pre-publication carrier leak: the first W1
 candidate also inserted the target's bare spelling into the legacy

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -277,6 +277,7 @@ export function createCodegenContext(
     objectHashConsumerTypes: new Set(),
     dynamicObjectReturnFunctions: new Set(),
     growableObjectLiteralVars: new Set(),
+    irWithOpenObjectTargetKeys: new Set(),
     ordinaryToPrimitiveObjectDeclarations: new Set(),
     ordinaryToPrimitiveObjectLiterals: new Set(),
     externrefAccessorVars: new Set(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2974,6 +2974,14 @@ export interface CodegenContext {
    */
   growableObjectLiteralVars: Set<string>;
   /**
+   * (#671 W1) Declaration-site keys for direct-DeleteBinding `with` targets
+   * whose planner/proof selected the canonical open-object carrier. Member
+   * reads and writes consult this keyed set rather than the bare-name
+   * growable-object set: a same-named local in another scope must retain its
+   * pre-existing representation and static member lowering.
+   */
+  irWithOpenObjectTargetKeys: Set<string>;
+  /**
    * (#4208) Exact declarations whose shared `var` binding is repeatedly
    * initialized with different OrdinaryToPrimitive method shapes. These
    * literals must use the open `$Object` carrier: a closed anonymous struct

--- a/src/codegen/declarations/dynamic-with-shape.ts
+++ b/src/codegen/declarations/dynamic-with-shape.ts
@@ -1,65 +1,18 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * (#4206) Representation pinning for `with` targets that lower on the Tier-2
- * DYNAMIC path under `--target standalone`.
+ * Compatibility adapter from declaration collection to the IR-owned W1 `with`
+ * target planner.
  *
- * ## Why this exists
- *
- * `compileWithStatement` (with-scope.ts) has two tiers. Tier-1 proves a closed
- * shape and rewrites bare identifiers to direct `struct.get`/`struct.set`.
- * Everything Tier-1 declines falls to Tier-2, which resolves the Object
- * Environment Record at runtime through `__extern_has` (HasBinding),
- * `__extern_get`, `__extern_set` and `__delete_property`.
- *
- * In standalone there is no JS host, so `ensureLateImport` binds those four
- * names to the NATIVE `$Object` open-hash helpers (object-runtime.ts). Those
- * helpers walk `$Object` links — and **a WasmGC struct is not an `$Object`**.
- * The walk therefore terminates immediately and HasBinding answers 0 for EVERY
- * name in the body. Tier-2 degrades to a silent no-op: reads fall through to
- * the outer scope, and writes CASCADE PAST the object onto the outer/global
- * binding.
- *
- * Measured before this pin:
- *
- * ```js
- * this.p1 = 1;
- * var o = {p1: 'a', p3: 'c'};
- * var del;
- * with (o) { p1 = 'x1'; del = delete p3; }
- * // global p1 became 'x1'  (spec: stays 1)
- * // o.p1     stayed  'a'   (spec: becomes 'x1')
- * ```
- *
- * This is unsoundness rather than a coverage gap — Tier-2 is supposed to be the
- * semantic backstop for everything Tier-1 declines, and here it is structurally
- * blind. It is also silent in both directions: no refused import, no
- * diagnostic, and `imports: []` on the compiled module. That is why the
- * standalone host-import-leak cohort measures ZERO across this whole family
- * even though the dynamic `with` path is entirely non-functional there.
- *
- * Keeping the target variable as a `$Object` gives the native helpers a store
- * they can actually see, so HasBinding / Get / Set / Delete resolve against the
- * real own properties, and aliasing through `o.p` observes the same object.
- *
- * ## Why the trigger is a bare-identifier `delete`
- *
- * That is the exact syntactic condition under which `proveStructTypedWithTarget`
- * declines Tier-1 (the static struct scope cannot express DeleteBinding's
- * "absent name ⇒ false" or the outer-scope cascade), so it is precisely the set
- * of `with` statements that reach the blind Tier-2 path *and* can be recognised
- * without type information — this pre-pass runs before struct registration.
- *
- * Deliberately narrow. A `with` target that already proves Tier-1 keeps the
- * zero-overhead struct path; widening this to "any `with` target" would move
- * currently-correct Tier-1 files onto Tier-2 for no measured gain.
- *
- * Host lane is byte-inert: there `__extern_has` consults the `_wasmStructProps`
- * sidecar (runtime.ts), so a struct receiver is already visible and no demotion
- * is needed. The single caller is standalone-gated.
+ * The planner deliberately lives in `ir/with-environment.ts`: it describes the
+ * language-level reason a target needs an identity-bearing open object, without
+ * choosing a host or standalone carrier. This adapter adds the one codegen-only
+ * proof needed before allocation: the `with` target must resolve to this exact
+ * declaration symbol, not merely share its spelling.
  */
-import { ts } from "../../ts-api.js";
+import { irWithTargetIdentifier, planIrWithTarget } from "../../ir/with-environment.js";
+import { forEachChild, ts } from "../../ts-api.js";
 
-/** Function/class boundary test — mirrors `isFunctionOrClassBoundary` in with-scope.ts. */
+/** Function/class bodies run under a separate declaration scan. */
 function isFunctionOrClassBoundary(node: ts.Node): boolean {
   return (
     ts.isFunctionDeclaration(node) ||
@@ -74,62 +27,128 @@ function isFunctionOrClassBoundary(node: ts.Node): boolean {
 }
 
 /**
- * True if `body` contains a `delete <Identifier>` on a BARE name — the Tier-1
- * disqualifier. Mirrors `bodyContainsIdentifierDelete` in with-scope.ts,
- * including its function/class boundary stop: a `delete` inside a nested
- * function is not this body's DeleteBinding.
+ * Does this declaration own a W1-planned `with` target in the same executable
+ * statement list? Name equality is deliberately insufficient: a shadowed `o`
+ * must not cause an unrelated literal to be widened. Function-local bodies are
+ * scanned by their own declaration pass; a module binding is the intentional
+ * exception because its module-global carrier is shared with nested functions.
  */
-function bodyHasBareIdentifierDelete(body: ts.Statement): boolean {
+export function bindingHasIrPlannedOpenWithTarget(
+  statements: readonly ts.Statement[],
+  checker: ts.TypeChecker,
+  declaration: ts.Identifier,
+): boolean {
+  const bindingSymbol = checker.getSymbolAtLocation(declaration);
+  if (!bindingSymbol) return false;
+  const moduleBinding = isModuleScopedDeclaration(declaration);
+
   let found = false;
-  const walk = (n: ts.Node): void => {
+  const visit = (node: ts.Node, isStatementRoot: boolean): void => {
     if (found) return;
-    if (n !== body && isFunctionOrClassBoundary(n)) return;
-    if (ts.isDeleteExpression(n)) {
-      let operand: ts.Expression = n.expression;
-      while (ts.isParenthesizedExpression(operand)) operand = operand.expression;
-      if (ts.isIdentifier(operand)) {
+    if (!isStatementRoot && !moduleBinding && isFunctionOrClassBoundary(node)) return;
+    if (ts.isWithStatement(node) && planIrWithTarget(node).representation === "open-object") {
+      const target = irWithTargetIdentifier(node);
+      if (target && checker.getSymbolAtLocation(target) === bindingSymbol) {
         found = true;
         return;
       }
     }
-    ts.forEachChild(n, walk);
+    forEachChild(node, (child) => visit(child, false));
   };
-  walk(body);
+
+  for (const statement of statements) visit(statement, true);
   return found;
 }
 
+/** Module globals retain their one carrier across ordinary nested functions. */
+function isModuleScopedDeclaration(declaration: ts.Identifier): boolean {
+  let current: ts.Node | undefined = declaration.parent;
+  while (current && !ts.isSourceFile(current)) {
+    if (
+      ts.isFunctionDeclaration(current) ||
+      ts.isFunctionExpression(current) ||
+      ts.isArrowFunction(current) ||
+      ts.isMethodDeclaration(current) ||
+      ts.isGetAccessorDeclaration(current) ||
+      ts.isSetAccessorDeclaration(current) ||
+      ts.isClassDeclaration(current) ||
+      ts.isClassExpression(current)
+    ) {
+      return false;
+    }
+    current = current.parent;
+  }
+  return current !== undefined;
+}
+
 /**
- * (#4206, standalone-only caller) Add `varName` to `poisonSet` when it is the
- * target of a `with (varName)` whose body contains a bare-identifier `delete`.
- *
- * Matched (parentheses unwrapped, like the sibling collectors in
- * object-shape-widening.ts):
- * ```js
- * with (o) { delete p; }          // → poison `o`
- * with ((o)) { x = delete (p); }  // → poison `o`
- * ```
- * NOT matched — a MEMBER delete is not a with-binding delete and does not
- * disqualify Tier-1; `markStandaloneDeleteTargets` already owns that shape:
- * ```js
- * with (o) { delete o.p; }
- * ```
- * A nested function/class in the body is also not matched: that shape is a hard
- * `#1387` refusal before any lowering runs, so demoting the variable would
- * change representation for a module that never compiles.
- *
- * Name-based, matching the rest of the widening pre-pass — aliasing is the same
- * shared, documented limitation.
+ * W1 must decline before allocation unless every observable use is already
+ * covered by the canonical open-object carrier. An alias, return, assignment,
+ * or ordinary call could retain the concrete struct ABI; this pre-pass does not
+ * guess at conversions or split identity. The narrow accepted surface is the
+ * target itself, direct dot operations, and callers the supplied MOP predicate
+ * explicitly recognizes.
  */
-export function markStandaloneDynamicWithTargets(node: ts.Node, varName: string, poisonSet: Set<string>): void {
-  const visit = (n: ts.Node): void => {
-    if (ts.isWithStatement(n)) {
-      let target: ts.Expression = n.expression;
-      while (ts.isParenthesizedExpression(target)) target = target.expression;
-      if (ts.isIdentifier(target) && target.text === varName && bodyHasBareIdentifierDelete(n.statement)) {
-        poisonSet.add(varName);
+export function bindingUsesOnlyIrPlannedOpenObjectOperations(
+  checker: ts.TypeChecker,
+  statements: readonly ts.Statement[],
+  declaration: ts.Identifier,
+  isOpenObjectPropertyReceiver: (id: ts.Identifier) => boolean,
+  isObjectMopCallArg: (id: ts.Identifier) => boolean,
+): boolean {
+  const symbol = checker.getSymbolAtLocation(declaration);
+  if (!symbol) return false;
+  // A function-local object can be captured by a nested callable/class that
+  // still expects its original concrete carrier. W1 has no capture-ABI proof,
+  // so decline before allocation. Module bindings are the narrow exception:
+  // their one module-global carrier is shared with nested ordinary functions.
+  const moduleBinding = isModuleScopedDeclaration(declaration);
+
+  let safe = true;
+  const visit = (node: ts.Node, crossedNestedCallable: boolean): void => {
+    if (!safe) return;
+    const insideNestedCallable = crossedNestedCallable || isFunctionOrClassBoundary(node);
+    if (ts.isIdentifier(node) && node !== declaration && checker.getSymbolAtLocation(node) === symbol) {
+      if (
+        (insideNestedCallable && !moduleBinding) ||
+        (!isIrWithTargetIdentifier(node) && !isOpenObjectPropertyReceiver(node) && !isObjectMopCallArg(node))
+      ) {
+        safe = false;
+        return;
       }
     }
-    ts.forEachChild(n, visit);
+    forEachChild(node, (child) => visit(child, insideNestedCallable));
   };
-  visit(node);
+
+  for (const statement of statements) visit(statement, false);
+  return safe;
+}
+
+function unwrapTransparentExpression(expr: ts.Expression): ts.Expression {
+  let current = expr;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/** Is `id` the (possibly parenthesized) target of a `with` statement? */
+function isIrWithTargetIdentifier(id: ts.Identifier): boolean {
+  let current: ts.Expression = id;
+  while (
+    ts.isParenthesizedExpression(current.parent) ||
+    ts.isAsExpression(current.parent) ||
+    ts.isNonNullExpression(current.parent) ||
+    ts.isSatisfiesExpression(current.parent) ||
+    ts.isTypeAssertionExpression(current.parent)
+  ) {
+    current = current.parent as ts.Expression;
+  }
+  return ts.isWithStatement(current.parent) && unwrapTransparentExpression(current.parent.expression) === id;
 }

--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -14,7 +14,10 @@ import { widenedVarKeyFromDecl } from "../widened-var-key.js";
 import type { FieldDef, ValType } from "../../ir/types.js";
 import type { CodegenContext } from "../context/types.js";
 import { createDeclaredNestedWriteClassifier } from "./declared-nested-write.js";
-import { markStandaloneDynamicWithTargets } from "./dynamic-with-shape.js";
+import {
+  bindingHasIrPlannedOpenWithTarget,
+  bindingUsesOnlyIrPlannedOpenObjectOperations,
+} from "./dynamic-with-shape.js";
 
 function isUnboxedPrimitiveCarrier(type: ValType): boolean {
   return ["f64", "f32", "i64", "i32", "i16", "i8"].includes(type.kind);
@@ -495,6 +498,7 @@ function recordOpenObjectConsumerTypes(
   checker: ts.TypeChecker,
   decl: ts.VariableDeclaration,
   varName: string,
+  recordNameBasedGrowableVar = true,
 ): void {
   if (!decl.initializer) return;
   const initializerDeclaration = decl.initializer as unknown as ts.Declaration;
@@ -512,7 +516,10 @@ function recordOpenObjectConsumerTypes(
   ) {
     ctx.objectHashConsumerTypes.add(it);
   }
-  if (ctx.standalone) ctx.growableObjectLiteralVars.add(varName);
+  // The open-object plan is lane-neutral. `compileObjectLiteralAsExternref`
+  // uses the existing host MOP in the host lane and the native `$Object` MOP in
+  // standalone; both require the declaration slot to select the same carrier.
+  if (recordNameBasedGrowableVar) ctx.growableObjectLiteralVars.add(varName);
 
   // Fnctor field derivation can run before collectDeclarations reaches the
   // function declaration, so record the inferred return carrier here too.
@@ -732,6 +739,37 @@ export function collectGrowableObjectLiterals(
           const shape = literalShapeNames(decl.initializer);
           if (!shape) continue; // not a pure data literal → skip (externref builder would decline)
 
+          // (#671 W1) A direct bare-identifier DeleteBinding in `with (varName)`
+          // makes the legacy static scope fall through to runtime HasBinding /
+          // DeleteBinding. That runtime path and a later `varName.p` read must
+          // see one MOP-capable object identity in BOTH lanes. The IR planner
+          // supplies the language trigger; this allocator adds the binding- and
+          // ABI-safety proof before ANY struct type/allocation can be created.
+          //
+          // Deliberately refuse rather than insert a cast or follow an alias:
+          // an escaped concrete-struct consumer would otherwise observe a
+          // second representation or null. The measured test262 family uses
+          // only direct dot reads and is admitted here; every broader shape is
+          // left on its existing path for a later slice to model explicitly.
+          if (
+            bindingHasIrPlannedOpenWithTarget(stmts, checker, decl.name) &&
+            bindingUsesOnlyIrPlannedOpenObjectOperations(
+              checker,
+              stmts,
+              decl.name,
+              isOpenObjectPropertyReceiver,
+              isObjectMopCallArg,
+            )
+          ) {
+            // W1 routes member operations through its declaration-keyed set.
+            // Do not also populate the legacy bare-name growable/accessor sets:
+            // that would change an unrelated same-named binding in another
+            // scope and can break its concrete-struct ABI consumers.
+            recordOpenObjectConsumerTypes(ctx, checker, decl, varName, false);
+            ctx.irWithOpenObjectTargetKeys.add(widenedVarKeyFromDecl(decl.name));
+            continue;
+          }
+
           // (#2992 S6, standalone) `delete varName.k` / `delete varName[e]` or
           // an ACCESSOR-descriptor define on a NON-EMPTY pure-data literal var:
           // the closed-struct representation cannot observe the deletion (the
@@ -752,15 +790,15 @@ export function collectGrowableObjectLiterals(
           // struct path") is a HOST-lane discipline — in standalone the struct
           // path is precisely what cannot serve these consumers, so this arm
           // runs first. Host lane is untouched (byte-inert).
-          // (#4206) A Tier-2-bound `with (varName)` joins the same set — the
-          // native `$Object` helpers that serve it cannot see a WasmGC struct.
-          // Rationale + measured repro: ./dynamic-with-shape.ts.
+          // The #671 W1 `with` target has its own lane-neutral planner above.
+          // Keep this standalone-only block for its existing direct receiver
+          // delete/accessor paths; it must not re-admit a W1 target whose alias
+          // or ABI proof declined the open-object promotion.
           if (ctx.standalone) {
             const mopSet = new Set<string>();
             for (const s of stmts) {
               markStandaloneDeleteTargets(s, varName, mopSet);
               markStandaloneAccessorDefineTargets(s, varName, mopSet);
-              markStandaloneDynamicWithTargets(s, varName, mopSet);
             }
             // Consumer-safety (#1897/#2837): when the var ALSO flows into a
             // CONCRETE nominal-struct-typed position (call/new arg, return,
@@ -1018,6 +1056,21 @@ function isObjectMopCallArg(id: ts.Identifier): boolean {
   return (
     ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.expression) && callee.expression.text === "Object"
   );
+}
+
+/** A direct dot read/write/delete is served by the existing externref MOP. */
+function isOpenObjectPropertyReceiver(id: ts.Identifier): boolean {
+  let current: ts.Expression = id;
+  while (
+    ts.isParenthesizedExpression(current.parent) ||
+    ts.isAsExpression(current.parent) ||
+    ts.isNonNullExpression(current.parent) ||
+    ts.isSatisfiesExpression(current.parent) ||
+    ts.isTypeAssertionExpression(current.parent)
+  ) {
+    current = current.parent as ts.Expression;
+  }
+  return ts.isPropertyAccessExpression(current.parent) && current.parent.expression === current;
 }
 
 /** (#2837) The identifier is used as a value (arg / return / RHS), not as an

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -47,6 +47,7 @@ import {
   emitCapturedBoxGlobalWrite,
   emitNullGuardedStructGet,
   getCapturedBoxGlobal,
+  isIrWithOpenObjectTargetReceiver,
   isNumericIndexExpression,
   isProvablyNonNull,
   isSafeBoundsEliminated,
@@ -3495,6 +3496,16 @@ function compilePropertyAssignment(
 
   const poisonResult = tryCompileStrictFunctionPoisonAssignment(ctx, fctx, target, value);
   if (poisonResult !== undefined) return poisonResult;
+
+  // (#671 W1) The direct-DeleteBinding `with` planner selected one canonical
+  // open object for this exact declaration. A checker-derived struct.set here
+  // would split it from the raw member-read MOP (and can silently retain a
+  // stale field after the `with` body mutates it), so preserve the dynamic
+  // carrier through the matching runtime [[Set]] path. The key predicate is
+  // declaration-scoped; unrelated same-named locals do not reach this arm.
+  if (!ts.isPrivateIdentifier(target.name) && isIrWithOpenObjectTargetReceiver(ctx, target.expression)) {
+    return compilePropertyAssignmentExternSet(ctx, fctx, target, value, target.name.text, true);
+  }
 
   // (#3872) Non-writable DATA property — `defineProperty(o,"p",{writable:false})`
   // then `o.p = v`. Sits at the TOP, before any lowering-path selection, because

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -149,6 +149,7 @@ import {
   BUILTIN_CTOR_NAMES,
   emitArrayIsArrayExternrefPredicate,
   emitNullCheckThrow,
+  isIrWithOpenObjectTargetReceiver,
   receiverIsCaughtErrorStringRead,
   receiverIsNativeStringValType,
   receiverMayBeNativeStringAtRuntime,
@@ -6645,6 +6646,16 @@ function compileCallExpression(
   // Handle property access calls: console.log, Math.xxx, extern methods
   if (ts.isPropertyAccessExpression(expr.expression)) {
     const propAccess = expr.expression;
+
+    // (#671 W1) A callable field on the planner-selected open `with` target
+    // is runtime state just like a data field. Use the canonical open-object
+    // method provider instead of resolving the literal's stale static method;
+    // this retains both post-with replacement, repeated-read identity, and
+    // the full argument list in both lanes.
+    if (!ts.isPrivateIdentifier(propAccess.name) && isIrWithOpenObjectTargetReceiver(ctx, propAccess.expression)) {
+      const openTargetCall = emitFnctorSubclassDynamicMethodCall(ctx, fctx, expr, propAccess, propAccess.name.text);
+      if (openTargetCall !== undefined) return openTargetCall;
+    }
 
     // (#2838 L6) Dynamic-`this` method-call dispatch. When the receiver is `this`
     // and the runtime `this` is DYNAMIC (the fctx `this` local is not a concrete

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1689,7 +1689,8 @@ export function compileObjectLiteral(
     expr.properties.length > 0 &&
     ts.isVariableDeclaration(expr.parent) &&
     ts.isIdentifier(expr.parent.name) &&
-    ctx.growableObjectLiteralVars.has(expr.parent.name.text)
+    (ctx.growableObjectLiteralVars.has(expr.parent.name.text) ||
+      ctx.irWithOpenObjectTargetKeys.has(widenedVarKeyFromDecl(expr.parent.name)))
   ) {
     const growableResult = compileObjectLiteralAsExternref(ctx, fctx, expr);
     if (growableResult) return growableResult;

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -783,6 +783,28 @@ export function chainRootIsGrowable(ctx: CodegenContext, expr: ts.Expression): b
 }
 
 /**
+ * (#671 W1) Is this direct member receiver the exact declaration selected by
+ * the IR `with` planner? Unlike `chainRootIsGrowable`, this is deliberately
+ * declaration-keyed: opening `outer.target` must not change a shadowed
+ * `target` in another function.
+ */
+export function isIrWithOpenObjectTargetReceiver(ctx: CodegenContext, expr: ts.Expression): boolean {
+  let e = expr;
+  while (
+    ts.isParenthesizedExpression(e) ||
+    ts.isAsExpression(e) ||
+    ts.isNonNullExpression(e) ||
+    ts.isSatisfiesExpression(e) ||
+    ts.isTypeAssertionExpression(e)
+  ) {
+    e = e.expression;
+  }
+  if (!ts.isIdentifier(e)) return false;
+  const key = resolveWidenedVarKey(ctx, e);
+  return key !== undefined && ctx.irWithOpenObjectTargetKeys.has(key);
+}
+
+/**
  * Resolve a struct name for a property access/assignment target expression,
  * with fallbacks for widened variables and `this` in function constructors.
  */
@@ -3048,33 +3070,30 @@ export function taViewReceiverTypeIdx(
 }
 
 /**
- * (#2992 S6, standalone) Dynamic member READ off a growable-object-literal
- * receiver (a non-empty pure-data literal var poisoned by the S6 delete /
- * accessor-define pre-pass in object-shape-widening.ts). The receiver is an
- * externref `$Object`, but the CHECKER still types `o.a` with the literal's
- * static prop type — so the default read coerces the native `__extern_get`
- * result to f64 (`__unbox_number`), turning a tombstoned/undefined read into
- * NaN, and the `!== undefined` comparison arm then const-folds on the number
- * type (the exact #2179 gc-lane bug, which is `!ctx.standalone`-gated). Return
- * the RAW externref instead — real `undefined` stays observable, `typeof`
- * stays dynamic, and numeric consumers coerce through the normal any→f64
- * path. Reserved accessors and callable props keep their dedicated lowerings
- * (mirrors tryEmitDeleteAwareDynamicGet's gates).
+ * Dynamic member READ off an open-object carrier. The established standalone
+ * growable-object case keeps its reserved-accessor/callable exclusions. The
+ * #671 W1 case is stricter: the exact planner-selected declaration has already
+ * abandoned its checker-derived closed shape, so every public direct member
+ * read must return the raw MOP value in both lanes. In particular, a host
+ * harness can otherwise contribute an unrelated numeric `p1` field candidate
+ * and make a string read run through `__unbox_number` ("x1" → NaN).
  */
-function tryStandaloneGrowableDynamicGet(
+function tryOpenObjectDynamicGet(
   ctx: CodegenContext,
   fctx: FunctionContext,
   expr: ts.PropertyAccessExpression,
   propName: string,
 ): ValType | null | undefined {
-  if (!ctx.standalone) return undefined;
-  if (!chainRootIsGrowable(ctx, expr.expression)) return undefined;
+  const irWithTarget = isIrWithOpenObjectTargetReceiver(ctx, expr.expression);
+  if (!irWithTarget && !ctx.standalone) return undefined;
+  if (!irWithTarget && !chainRootIsGrowable(ctx, expr.expression)) return undefined;
   if (
-    propName === "length" ||
-    propName === "constructor" ||
-    propName === "__proto__" ||
-    propName === "prototype" ||
-    propName === "name"
+    !irWithTarget &&
+    (propName === "length" ||
+      propName === "constructor" ||
+      propName === "__proto__" ||
+      propName === "prototype" ||
+      propName === "name")
   ) {
     return undefined;
   }
@@ -3082,7 +3101,7 @@ function tryStandaloneGrowableDynamicGet(
   // (#1930): `signatureOf` is `undefined` exactly when the checker type has no
   // call signature — the same gate tryEmitDeleteAwareDynamicGet expresses via
   // the raw checker's `getCallSignatures().length > 0`.
-  if (ctx.oracle.signatureOf(expr) !== undefined) return undefined;
+  if (!irWithTarget && ctx.oracle.signatureOf(expr) !== undefined) return undefined;
   const getIdx = ensureLateImport(
     ctx,
     "__extern_get",
@@ -3264,7 +3283,7 @@ export function compilePropertyAccess(
   }
 
   {
-    const __r = tryStandaloneGrowableDynamicGet(ctx, fctx, expr, propName);
+    const __r = tryOpenObjectDynamicGet(ctx, fctx, expr, propName);
     if (__r !== undefined) return __r;
   }
 

--- a/src/codegen/with-scope.ts
+++ b/src/codegen/with-scope.ts
@@ -10,7 +10,7 @@
  */
 import { ts, forEachChild } from "../ts-api.js";
 import type { FieldDef, Instr, ValType } from "../ir/types.js";
-import { selectWithEnvironmentClosures } from "../ir/with-environment.js";
+import { planIrWithTarget, selectWithEnvironmentClosures } from "../ir/with-environment.js";
 import { reportError } from "./context/errors.js";
 import { pushBody, popBody } from "./context/bodies.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
@@ -383,11 +383,10 @@ function proveStructTypedWithTarget(ctx: CodegenContext, stmt: ts.WithStatement)
   // @@unscopables blocklist. The struct scope cannot see it, so defer to Tier-2.
   if (targetReceivesDynamicElementWrite(ident)) return null;
 
-  // `delete name` inside a `with` body has cascade / configurability semantics
-  // (§8.5.2 DeleteBinding, §13.5.1.2) that only the Tier-2 dynamic path
-  // implements; the static struct scope cannot express "absent name ⇒ false" or
-  // the outer-scope cascade. Defer any body containing a bare-identifier delete.
-  if (bodyContainsIdentifierDelete(stmt.statement)) return null;
+  // W1's IR-owned target plan is also the static-projection disqualifier: a
+  // bare `delete name` needs runtime HasBinding/DeleteBinding and one canonical
+  // open object identity for the later direct readback.
+  if (planIrWithTarget(stmt).representation === "open-object") return null;
 
   // Gates (a)/(b): a body-referenced name the static struct scope cannot route
   // but the object actually binds ⇒ defer to Tier-2.
@@ -1003,32 +1002,6 @@ function targetReceivesDynamicElementWrite(ident: ts.Identifier): boolean {
     forEachChild(node, walk);
   };
   walk(scope);
-  return found;
-}
-
-/**
- * (#3025 W1) True if the `with` body contains a `delete <Identifier>` on a bare
- * identifier (which could resolve to a with-binding). `delete obj.prop` (member
- * delete) is unaffected and does not count. Used to keep such bodies on the
- * Tier-2 dynamic path, which implements the DeleteBinding cascade / configurability
- * semantics the static struct scope cannot.
- */
-function bodyContainsIdentifierDelete(stmt: ts.Statement): boolean {
-  let found = false;
-  const walk = (node: ts.Node): void => {
-    if (found) return;
-    if (node !== stmt && isFunctionOrClassBoundary(node)) return;
-    if (ts.isDeleteExpression(node)) {
-      let operand: ts.Expression = node.expression;
-      while (ts.isParenthesizedExpression(operand)) operand = operand.expression;
-      if (ts.isIdentifier(operand)) {
-        found = true;
-        return;
-      }
-    }
-    forEachChild(node, walk);
-  };
-  walk(stmt);
   return found;
 }
 

--- a/src/ir/with-environment.ts
+++ b/src/ir/with-environment.ts
@@ -15,6 +15,87 @@
  */
 import { forEachChild, ts } from "../ts-api.js";
 
+/**
+ * Representation required by a `with` target before any object allocation.
+ *
+ * `closed-fields` is the existing static fast path. `open-object` means the
+ * body needs the ordinary Object Environment Record MOP: the target, the
+ * dynamic `with` operations, and later ordinary property reads must all share
+ * the same identity-bearing open object.
+ */
+export type IrWithTargetRepresentation = "closed-fields" | "open-object";
+
+export type IrWithTargetPlanReason = "runtime-has-binding" | "runtime-delete-binding";
+
+export interface IrWithTargetPlan {
+  readonly representation: IrWithTargetRepresentation;
+  readonly reasons: readonly IrWithTargetPlanReason[];
+}
+
+const CLOSED_WITH_TARGET_PLAN: IrWithTargetPlan = { representation: "closed-fields", reasons: [] };
+const DELETE_WITH_TARGET_PLAN: IrWithTargetPlan = {
+  representation: "open-object",
+  reasons: ["runtime-has-binding", "runtime-delete-binding"],
+};
+
+/** Unwrap the transparent parentheses allowed around a `with` target. */
+export function irWithTargetIdentifier(statement: ts.WithStatement): ts.Identifier | undefined {
+  let target: ts.Expression = statement.expression;
+  while (ts.isParenthesizedExpression(target)) target = target.expression;
+  return ts.isIdentifier(target) ? target : undefined;
+}
+
+/** Executable boundary: an inner callable/class owns its own `with` environment. */
+function isFunctionOrClassBoundary(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isClassDeclaration(node) ||
+    ts.isClassExpression(node)
+  );
+}
+
+/**
+ * The exact W1 trigger. A `delete <Identifier>` is a DeleteBinding operation,
+ * so the static field projection cannot model its HasBinding cascade or its
+ * post-delete readback. Parentheses do not alter that reference; member deletes
+ * do. Nested functions/classes execute in their own environment and are not
+ * attributed to this statement.
+ */
+function bodyContainsBareIdentifierDelete(body: ts.Statement): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (node !== body && isFunctionOrClassBoundary(node)) return;
+    if (ts.isDeleteExpression(node)) {
+      let operand: ts.Expression = node.expression;
+      while (ts.isParenthesizedExpression(operand)) operand = operand.expression;
+      if (ts.isIdentifier(operand)) {
+        found = true;
+        return;
+      }
+    }
+    forEachChild(node, visit);
+  };
+  visit(body);
+  return found;
+}
+
+/**
+ * Plan only the W1 slice: a single identifier target whose directly executing
+ * body uses bare-identifier DeleteBinding. This is intentionally independent
+ * of host/standalone representation details; allocation consumes the plan in
+ * the codegen pre-pass before it can create a closed struct.
+ */
+export function planIrWithTarget(statement: ts.WithStatement): IrWithTargetPlan {
+  if (!irWithTargetIdentifier(statement)) return CLOSED_WITH_TARGET_PLAN;
+  return bodyContainsBareIdentifierDelete(statement.statement) ? DELETE_WITH_TARGET_PLAN : CLOSED_WITH_TARGET_PLAN;
+}
+
 export type IrWithEnvironmentSelection =
   | { readonly ok: true; readonly closureCount: number }
   | { readonly ok: false; readonly reason: string };

--- a/tests/issue-671-with-w1.test.ts
+++ b/tests/issue-671-with-w1.test.ts
@@ -1,0 +1,347 @@
+// #671 W1 — direct DeleteBinding through an ES5 `with` target.
+//
+// The W1 contract is decided in IR before allocation: a direct `delete name`
+// needs the open-object MOP in both lanes so the runtime `HasBinding` /
+// `DeleteBinding` path and later static-looking `target.name` reads observe the
+// same identity. This deliberately does not claim aliases or broader escaping
+// shapes; those remain explicit refusals for a later slice.
+import { describe, expect, it } from "vitest";
+import {
+  bindingHasIrPlannedOpenWithTarget,
+  bindingUsesOnlyIrPlannedOpenObjectOperations,
+} from "../src/codegen/declarations/dynamic-with-shape.js";
+import { planIrWithTarget } from "../src/ir/with-environment.js";
+import { compile } from "../src/index.js";
+import { forEachChild, ts } from "../src/ts-api.js";
+import { wrapExports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
+
+function withStatements(source: string): ts.WithStatement[] {
+  const sourceFile = ts.createSourceFile("issue-671-w1.js", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const found: ts.WithStatement[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isWithStatement(node)) found.push(node);
+    forEachChild(node, visit);
+  };
+  forEachChild(sourceFile, visit);
+  return found;
+}
+
+function firstWithStatement(source: string): ts.WithStatement {
+  const [found] = withStatements(source);
+  if (!found) throw new Error("expected a with statement");
+  return found;
+}
+
+function checkerFor(source: string): { sourceFile: ts.SourceFile; checker: ts.TypeChecker } {
+  const fileName = "issue-671-w1-preclaim.js";
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) => (name === fileName ? sourceFile : undefined),
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "",
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: (name) => name === fileName,
+    readFile: (name) => (name === fileName ? source : undefined),
+  };
+  const program = ts.createProgram([fileName], { noLib: true, allowJs: true, checkJs: false, strict: false }, host);
+  return { sourceFile: program.getSourceFile(fileName)!, checker: program.getTypeChecker() };
+}
+
+function declarationNamed(sourceFile: ts.SourceFile, name: string): ts.VariableDeclaration {
+  let found: ts.VariableDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === name) {
+      found = node;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(sourceFile, visit);
+  if (!found) throw new Error(`expected declaration for ${name}`);
+  return found;
+}
+
+function isDirectPropertyReceiver(id: ts.Identifier): boolean {
+  return ts.isPropertyAccessExpression(id.parent) && id.parent.expression === id;
+}
+
+async function run(
+  source: string,
+  target?: "standalone",
+  deferTopLevelInit = false,
+): Promise<Record<string, () => number>> {
+  const result: any = await compile(source, {
+    fileName: "issue-671-w1.ts",
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments: false,
+    hostBridge: "always",
+    ...(deferTopLevelInit ? { deferTopLevelInit: true } : {}),
+    ...(target ? { target } : {}),
+  } as any);
+  expect(result.success, result.errors.map((error: { message: string }) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "module failed WebAssembly.validate").toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  if (deferTopLevelInit) {
+    (instance.exports as { __module_init?: () => void }).__module_init?.();
+  }
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#671 W1 — IR-owned direct DeleteBinding planning", () => {
+  it("opens only a simple identifier target with a directly executing bare delete", () => {
+    expect(planIrWithTarget(firstWithStatement("with ((target)) { delete (p); }"))).toEqual({
+      representation: "open-object",
+      reasons: ["runtime-has-binding", "runtime-delete-binding"],
+    });
+
+    expect(planIrWithTarget(firstWithStatement("with (target) { delete target.p; }"))).toEqual({
+      representation: "closed-fields",
+      reasons: [],
+    });
+    expect(planIrWithTarget(firstWithStatement("with (target) { function later() { delete p; } }"))).toEqual({
+      representation: "closed-fields",
+      reasons: [],
+    });
+    expect(planIrWithTarget(firstWithStatement("with (getTarget()) { delete p; }"))).toEqual({
+      representation: "closed-fields",
+      reasons: [],
+    });
+
+    // The inner DeleteBinding can cascade to the outer object environment, so
+    // each synchronously active target needs the same open-object plan.
+    expect(withStatements("with (outer) { with (inner) { delete p; } }").map(planIrWithTarget)).toEqual([
+      { representation: "open-object", reasons: ["runtime-has-binding", "runtime-delete-binding"] },
+      { representation: "open-object", reasons: ["runtime-has-binding", "runtime-delete-binding"] },
+    ]);
+  });
+});
+
+describe("#671 W1 — pre-allocation capture refusal", () => {
+  it.each([
+    ["nested ordinary function", "function later() { return target.p; }"],
+    ["nested class method", "class Later { value() { return target.p; } }"],
+  ])("declines a function-local target captured by a %s", (_kind, nestedUse) => {
+    const { sourceFile, checker } = checkerFor(`
+      function outer() {
+        var target = { p: 1 };
+        with (target) { delete p; }
+        ${nestedUse}
+      }
+    `);
+    const target = declarationNamed(sourceFile, "target");
+    const outer = sourceFile.statements.find(ts.isFunctionDeclaration);
+    expect(outer?.body).toBeDefined();
+    const statements = outer!.body!.statements;
+
+    // The language-level W1 trigger is present; only the pre-allocation ABI
+    // proof rejects this capture shape.
+    expect(bindingHasIrPlannedOpenWithTarget(statements, checker, target.name as ts.Identifier)).toBe(true);
+    expect(
+      bindingUsesOnlyIrPlannedOpenObjectOperations(
+        checker,
+        statements,
+        target.name as ts.Identifier,
+        isDirectPropertyReceiver,
+        () => false,
+      ),
+    ).toBe(false);
+  });
+
+  it("allows a module target through its shared carrier in a nested ordinary function", () => {
+    const { sourceFile, checker } = checkerFor(`
+      var target = { p: 1 };
+      function mutate() { with (target) { delete p; } }
+      target.p;
+    `);
+    const target = declarationNamed(sourceFile, "target");
+
+    expect(bindingHasIrPlannedOpenWithTarget(sourceFile.statements, checker, target.name as ts.Identifier)).toBe(true);
+    expect(
+      bindingUsesOnlyIrPlannedOpenObjectOperations(
+        checker,
+        sourceFile.statements,
+        target.name as ts.Identifier,
+        isDirectPropertyReceiver,
+        () => false,
+      ),
+    ).toBe(true);
+  });
+
+  it("declines a for-in target consumer that W1 does not yet route through the open MOP", () => {
+    const { sourceFile, checker } = checkerFor(`
+      var target = { p: 1 };
+      for (var key in target) {
+        with (target) { delete p; }
+      }
+    `);
+    const target = declarationNamed(sourceFile, "target");
+
+    expect(bindingHasIrPlannedOpenWithTarget(sourceFile.statements, checker, target.name as ts.Identifier)).toBe(true);
+    expect(
+      bindingUsesOnlyIrPlannedOpenObjectOperations(
+        checker,
+        sourceFile.statements,
+        target.name as ts.Identifier,
+        isDirectPropertyReceiver,
+        () => false,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("#671 W1 — direct DeleteBinding readback", () => {
+  const sameNameShadowSource = `
+    function consume(value: { n: number }): number { return value.n; }
+    function mutate(): number {
+      var target = { p1: 1, p3: 3 };
+      with (target) { delete p3; }
+      return target.p3 === undefined ? 1 : 0;
+    }
+    export function test(): number {
+      var target = { n: 7 };
+      return mutate() * 10 + consume(target);
+    }
+  `;
+
+  it.each([undefined, "standalone"] as const)(
+    "does not widen an unrelated same-named struct consumer in the %s lane",
+    async (target) => {
+      const exports = await run(sameNameShadowSource, target);
+      expect(exports.test()).toBe(17);
+    },
+  );
+
+  const source = `
+    export function test(): number {
+      var target = {
+        p1: 7,
+        p2: "kept",
+        p3: "deleted",
+        valueOf: function (): number { return 29; },
+        hook: function (n: number): number { return n + 31; },
+      };
+      var deleted = false;
+      with (target) {
+        p1 = 11;
+        p2 = "changed";
+        hook = function (n: number): number { return n + 41; };
+        deleted = delete p3;
+      }
+      target.p2 = "directly changed";
+      target.hook = function (n: number): number { return n + 47; };
+      return deleted &&
+        target.p1 === 11 &&
+        target.p2 === "directly changed" &&
+        target.p3 === undefined &&
+        target.valueOf === target.valueOf &&
+        target.valueOf() === 29 &&
+        target.hook === target.hook &&
+        target.hook(2) === 49
+        ? 1
+        : 0;
+    }
+  `;
+
+  it.each([undefined, "standalone"] as const)("keeps a single open target identity in the %s lane", async (target) => {
+    const exports = await run(source, target);
+    expect(exports.test()).toBe(1);
+  });
+
+  const moduleTargetSource = `
+    var target = {
+      p1: 7,
+      p2: "kept",
+      p3: "deleted",
+      valueOf: function (): number { return 29; },
+      eval: function (): number { return 37; },
+      hook: function (n: number): number { return n + 41; },
+    };
+    function mutate(): boolean {
+      var deleted = false;
+      with (target) {
+        p1 = 11;
+        p2 = "changed";
+        hook = function (n: number): number { return n + 43; };
+        deleted = delete p3;
+      }
+      return deleted;
+    }
+    export function test(): number {
+      var mutated = mutate();
+      target.p2 = "directly changed";
+      target.hook = function (n: number): number { return n + 47; };
+      return mutated &&
+        target.p1 === 11 &&
+        target.p2 === "directly changed" &&
+        target.p3 === undefined &&
+        target.valueOf === target.valueOf &&
+        target.valueOf() === 29 &&
+        target.eval === target.eval &&
+        target.eval() === 37 &&
+        target.hook === target.hook &&
+        target.hook(2) === 49
+        ? 1
+        : 0;
+    }
+  `;
+
+  it.each([undefined, "standalone"] as const)(
+    "keeps a module target open when a nested ordinary function executes the with body in the %s lane",
+    async (target) => {
+      const exports = await run(moduleTargetSource, target);
+      expect(exports.test()).toBe(1);
+    },
+  );
+
+  const deferredModuleInitSource = `
+    var target = {
+      p1: "before",
+      p2: "kept",
+      p3: "deleted",
+      hook: function (n: number): number { return n + 41; },
+    };
+    var deleted = false;
+    var status = 0;
+    with (target) {
+      p1 = "after";
+      p2 = "changed";
+      hook = function (n: number): number { return n + 43; };
+      deleted = delete p3;
+    }
+    target.p2 = "directly changed";
+    target.hook = function (n: number): number { return n + 47; };
+    status = deleted &&
+      target.p1 === "after" &&
+      target.p2 === "directly changed" &&
+      target.p3 === undefined &&
+      target.hook === target.hook &&
+      target.hook(2) === 49
+      ? 1
+      : 0;
+    export function test(): number { return status; }
+  `;
+
+  it.each([undefined, "standalone"] as const)(
+    "keeps post-with strings and callable identity dynamic during deferred module init in the %s lane",
+    async (target) => {
+      const exports = await run(deferredModuleInitSource, target, true);
+      expect(exports.test()).toBe(1);
+    },
+  );
+
+  it("flips an authentic ES5 function-context DeleteBinding control on the host lane", async () => {
+    const result = await runTest262File(
+      "test262/test/language/statements/with/S12.10_A1.2_T1.js",
+      "language/statements/with",
+      120_000,
+    );
+    expect(result.status).toBe("pass");
+  });
+});


### PR DESCRIPTION
## Summary

- plan the exact W1 bare-Identifier `DeleteBinding` target in the IR subsystem before allocation
- use one lane-neutral open-object carrier for runtime HasBinding/DeleteBinding and later direct reads, writes, and method calls
- key W1 routing by declaration identity, avoiding the legacy bare-name side tables
- refuse aliases, captures, for-in consumers, and concrete-struct ABI escapes before allocation

## Measured impact

Exact same 21-row Test262 W1 population on `main@8a2baecf3bc39d`:

- host: `0/21 -> 6/21` (**+6, 0 lost**)
- standalone with real QuickJS: `21/21 -> 21/21` (**0 changed, 0 lost**)
- QuickJS artifact: `b0662069c241d043`
- candidate adapter: `3f69394285448486`, keyed to freshly rebuilt compiler bundle `cb7a02b9e00e900e`

The six host gains are `S12.10_A1.2_T{1,2,4}` and `S12.10_A1.3_T{1,2,4}`. Both 21-row partitions are complete with no entered or missing rows. Full immutable hashes are recorded in the issue file.

## Review repair

A pre-publication review probe found the first candidate contaminated an unrelated same-named local through name-wide growable/accessor sets: baseline returned 7 while the candidate trapped. The final implementation keeps W1 carrier selection declaration-keyed. A compiled dual-lane regression now returns 17 (W1 mutation 10 + unrelated closed struct 7).

## Validation

- focused W1 suite: 14/14
- typecheck
- IR adoption and fallback gates
- LOC/function/issue gates
- oracle and coercion ratchets
- numeric-local IR parity
- complete pre-push quality and format gates
- exact host and real-QuickJS standalone A/B with structural pass/fail controls and complete partitions

The Sol architecture from PR #4445 is merged. This implementation is ready, not a draft.
