### PR TITLE
feat(ir): prepare bounded nested class expressions

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -52,6 +52,7 @@ files:
   - src/codegen/ir-plain-implicit-constructors.ts
   - src/codegen/ir-prepared-free-functions.ts
   - src/codegen/ir-overlay-outcomes.ts
+  - src/codegen/ir-class-shapes.ts
   - src/codegen/program-abi-class-callable-planning.ts
   - src/codegen/program-abi-session.ts
   - src/codegen/program-abi-type-planning.ts
@@ -60,6 +61,7 @@ files:
   - scripts/ir-only-baseline.json
   - plan/log/ir-optimization-retirement-ledger.md
   - tests/class-expressions.test.ts
+  - tests/issue-3522-ir-nested-class-expression-ownership.test.ts
   - tests/issue-3520-inherited-class-integration-abi.test.ts
   - tests/issue-3521-prepared-free-function-routing.test.ts
   - tests/issue-3522-ir-class-compile-once.test.ts
@@ -1259,13 +1261,59 @@ expressions and nested classes with inheritance, static/effectful elements,
 computed keys, initializers, flexible parameters, or captures still consume
 the nested class/body machinery. The remaining serial R3 checklist is:
 
-1. class-expression ownership and the remaining effect-free declaration
-   positions;
-2. closures, object methods/accessors, and cross-owner callable support;
-3. module initialization under #3523;
-4. runtime and linear-memory helpers; and
-5. delete each direct implementation when its final typed consumer reaches
+1. closures, object methods/accessors, and cross-owner callable support;
+2. module initialization under #3523;
+3. runtime and linear-memory helpers; and
+4. delete each direct implementation when its final typed consumer reaches
    zero, then enable IR-only as the default.
+
+### Const-bound nested class-expression ownership checkpoint (2026-08-13)
+
+The next nested-class family is now a prepare-before-emit transaction for the
+exact effect-free `const C = class { ... }` and `const C = class C { ... }`
+forms. The class expression keeps its synthetic legacy callable/layout label,
+while the exact const binding is published as a selector/lowerer alias. The
+identity selector, checker-backed class resolver, Program ABI constructor
+support transaction, and declaration skip audit all correlate through the
+same `IrClassId`; the surrounding function, `_init`, AST-free `_new`, and every
+method either prepare as one component or remain direct together.
+
+The bounded family does not turn a class object into an IR runtime value.
+Selection proves every reference to the const binding is the callee of direct
+`new C(...)`. Passing, comparing, returning, or otherwise reading `C` keeps the
+whole component direct. Mutable bindings, differently named inner class
+expressions, captures, inheritance, decorators, static/effectful elements,
+computed keys, field initializers, flexible parameters, and unsupported member
+bodies also remain fail-closed.
+
+Explicit parity evidence covers both GC and standalone:
+
+- the enclosing `run`, constructor, `add`, and `scale` terminals share one
+  prepared component with `legacyBodyEmitted:false` and
+  `irBodyEmitted:true` while both direct-body poison seams are active;
+- both targets validate and return `715`, with typed `struct.set`/`struct.get`
+  bodies and no extern conversions, casts/tests, `call_ref`, or
+  `call_indirect` in migrated functions;
+- prepared binary size is **1,232 vs 1,557 bytes** direct on GC and **21,536
+  vs 47,058 bytes** direct on standalone; and
+- first-class-value, mutable-binding, and differently-named controls preserve
+  direct runtime semantics and record no post-claim failures.
+
+Focused class/expression/accessor qualification is **71/71**, including all
+42 class compile-once tests and all 21 nested-accessor writeback tests. The
+broader R2/R3 ownership matrix is **134/134**, cross-backend differential is
+**29/29**, and equivalence is **1,645 passing, 24 known failures, zero new
+regressions** (12 baseline failures now pass). Hybrid and strict shadows remain
+READY at **37/37 IR bodies, 0 legacy bodies, 0 Unsupported, 0 Invariants**.
+The fallback gate has zero unintended, post-claim, or module-level increases;
+typecheck, lint, formatting, optimization retirement, LOC, and function-budget
+gates pass.
+
+No shared direct class-expression implementation is deleted yet. First-class,
+module-level, inline, capturing, and effectful class-expression consumers still
+use it. The next serial R3 owner is closures/object methods/cross-owner callable
+support; after those consumers reach zero, the obsolete direct branches must be
+deleted in the same checkpoint that proves their last use is gone.
 
 ## Exhaustive source-unit census
 

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2692,6 +2692,38 @@ export function compileDeclarations(
         for (const decl of stmt.declarationList.declarations) {
           if (ts.isIdentifier(decl.name) && decl.initializer && ts.isClassExpression(decl.initializer)) {
             if (insideFunction) {
+              const preparedBodyUnits = decl.initializer.members
+                .filter(
+                  (
+                    member,
+                  ): member is
+                    | ts.ConstructorDeclaration
+                    | ts.MethodDeclaration
+                    | ts.GetAccessorDeclaration
+                    | ts.SetAccessorDeclaration =>
+                    (ts.isConstructorDeclaration(member) ||
+                      ts.isMethodDeclaration(member) ||
+                      ts.isGetAccessorDeclaration(member) ||
+                      ts.isSetAccessorDeclaration(member)) &&
+                    member.body !== undefined,
+                )
+                .map((member) => ctx.irPlanningIdentityContext?.unitIdByDeclaration.get(member));
+              const fullyPrepared =
+                preparedBodyUnits.length > 0 &&
+                preparedBodyUnits.every(
+                  (unitId) => unitId !== undefined && classBodyRouting?.skipBodyUnitIds?.has(unitId) === true,
+                );
+              if (fullyPrepared) {
+                const syntheticName = ctx.anonClassExprNames.get(decl.initializer);
+                compileClassBodies(
+                  ctx,
+                  decl.initializer,
+                  funcByName,
+                  syntheticName ?? decl.name.text,
+                  classBodyRouting,
+                );
+                continue;
+              }
               // (#3045 Bug 2) Defer the class-expression BODY compilation to the
               // in-scope variable path so its constructor/method bodies can
               // capture the enclosing function scope — call enclosing functions

--- a/src/codegen/ir-class-shapes.ts
+++ b/src/codegen/ir-class-shapes.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import { ts } from "../ts-api.js";
+import { boundedPreparedNestedOrdinaryClassBindingName } from "../ir/class-accessor-safety.js";
 import type { TypeOracle } from "../checker/oracle.js";
 import { irUnitFuncRef } from "../ir/callable-bindings.js";
 import type { IrClassId, IrSourceId, IrUnitKind } from "../ir/identity.js";
@@ -451,6 +452,24 @@ export function createIrClassShapeSidecar(
   const legacyProjection = new Map<string, IrClassShape>();
   for (const entry of byClassId.values()) {
     if (occurrences.get(entry.legacyName) === 1) legacyProjection.set(entry.legacyName, entry.shape);
+  }
+  // A bounded nested class expression keeps its synthetic legacy callable and
+  // struct label, but source expressions address it through the exact const
+  // binding. Publish that binding as a selector/lowerer alias only when it is
+  // unique and cannot shadow an existing class label.
+  const boundedExpressionAliases = new Map<string, IrClassShapeEntry[]>();
+  for (const entry of byClassId.values()) {
+    if (!ts.isClassExpression(entry.declaration)) continue;
+    const bindingName = boundedPreparedNestedOrdinaryClassBindingName(entry.declaration);
+    if (bindingName === undefined) continue;
+    const candidates = boundedExpressionAliases.get(bindingName) ?? [];
+    candidates.push(entry);
+    boundedExpressionAliases.set(bindingName, candidates);
+  }
+  for (const [bindingName, candidates] of boundedExpressionAliases) {
+    if (candidates.length === 1 && !legacyProjection.has(bindingName)) {
+      legacyProjection.set(bindingName, candidates[0]!.shape);
+    }
   }
   return { identityContext: context, byClassId, legacyProjection };
 }

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -1129,7 +1129,7 @@ function prepareIrClassMemberPopulation(input: {
     const declaration = input.identityPlan.identityContext.declarationByUnitId.get(unitId);
     const owner = terminal.kind === "class-implicit-constructor" ? declaration : declaration?.parent;
     const classId =
-      owner !== undefined && ts.isClassDeclaration(owner)
+      owner !== undefined && (ts.isClassDeclaration(owner) || ts.isClassExpression(owner))
         ? input.identityPlan.identityContext.classIdByDeclaration.get(owner)
         : undefined;
     const shape = classId === undefined ? undefined : shapeByClassId.get(classId);

--- a/src/ir/class-accessor-safety.ts
+++ b/src/ir/class-accessor-safety.ts
@@ -121,6 +121,34 @@ export function isBoundedPreparedNestedOrdinaryClass(declaration: ts.ClassDeclar
   return constructorCount === 1 && methodCount > 0;
 }
 
+/**
+ * Stable lexical name for the bounded ordinary-class transaction.
+ *
+ * Class declarations own their source name. Class expressions are admitted
+ * only in the exact `const C = class { ... }` / `const C = class C { ... }`
+ * form: the binding is immutable, ClassDefinitionEvaluation is inert under
+ * the ordinary-class gate above, and a differently named inner class cannot
+ * be confused with the outer constructor binding.
+ */
+export function boundedPreparedNestedOrdinaryClassBindingName(
+  declaration: ts.ClassDeclaration | ts.ClassExpression,
+): string | undefined {
+  if (!isBoundedPreparedNestedOrdinaryClass(declaration)) return undefined;
+  if (ts.isClassDeclaration(declaration)) return declaration.name?.text;
+  const variable = declaration.parent;
+  if (
+    !ts.isVariableDeclaration(variable) ||
+    variable.initializer !== declaration ||
+    !ts.isIdentifier(variable.name) ||
+    !ts.isVariableDeclarationList(variable.parent) ||
+    (variable.parent.flags & ts.NodeFlags.Const) === 0
+  ) {
+    return undefined;
+  }
+  const bindingName = variable.name.text;
+  return declaration.name === undefined || declaration.name.text === bindingName ? bindingName : undefined;
+}
+
 type LiteralComputedKeyValue = string | number;
 
 function literalOnlyComputedKeyValue(expression: ts.Expression): LiteralComputedKeyValue | undefined {

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -51,6 +51,7 @@ import {
 import { STANDALONE_REGEXP_CARRIER_TEST_HELPER } from "../codegen/regexp-runtime-contract.js";
 // (#1373b C-1) Leaf-module async helpers (no codegen/index cycle).
 import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "../codegen/async-static.js";
+import { boundedPreparedNestedOrdinaryClassBindingName } from "./class-accessor-safety.js";
 import { remainderFastPathPlan } from "../codegen/analysis/remainder-fast-path.js";
 import { evaluateConstantCondition } from "../codegen/statements/control-flow.js";
 import type { IrClassInstanceInitializer } from "./class-instance-initializers.js";
@@ -3024,6 +3025,17 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
     }
     if (!d.initializer) {
       throw new Error(`ir/from-ast: Phase 1 requires an initializer for '${name}' in ${cx.funcName}`);
+    }
+    if (
+      ts.isClassExpression(d.initializer) &&
+      isConst &&
+      boundedPreparedNestedOrdinaryClassBindingName(d.initializer) === name &&
+      cx.classShapes?.has(name)
+    ) {
+      // Selection proved the class definition inert and the exact Program ABI
+      // component already installed every constructor/method body. The class
+      // binding is a compile-time constructor identity in this bounded family.
+      continue;
     }
     // (#3142 Slice 2) A module-scope binding initialized with a
     // function-like value: the legacy path stores its closure where other

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -7,7 +7,11 @@
 import { isExternalDeclaredClass } from "../checker/type-mapper.js";
 import { ts } from "../ts-api.js";
 import { updateRetypesModuleBinding } from "./update-retyped-bindings.js";
-import { isBoundedPreparedAccessorClass, isBoundedPreparedNestedOrdinaryClass } from "./class-accessor-safety.js";
+import {
+  boundedPreparedNestedOrdinaryClassBindingName,
+  isBoundedPreparedAccessorClass,
+  isBoundedPreparedNestedOrdinaryClass,
+} from "./class-accessor-safety.js";
 import { irModuleGlobalBindingId, irModuleTdzGlobalBindingId } from "./abi-bindings.js";
 import type { IrBindingId, IrClassId, IrSourceId, IrUnitId } from "./identity.js";
 import type { IrClassShape } from "./nodes.js";
@@ -181,26 +185,30 @@ export function makeIrIdentityLocalClassExpressionResolver(
   }
 
   interface ProjectedClass extends IrLocalClassExpressionIdentity {
-    readonly declaration: ts.ClassDeclaration;
+    readonly declaration: ts.ClassDeclaration | ts.ClassExpression;
     readonly symbol: ts.Symbol;
   }
 
   const projectedByClassId = new Map<IrClassId, ProjectedClass>();
-  const declarationCounts = new Map<ts.ClassDeclaration, number>();
+  const declarationCounts = new Map<ts.ClassDeclaration | ts.ClassExpression, number>();
   const symbolCounts = new Map<ts.Symbol, number>();
   const candidates: ProjectedClass[] = [];
   for (const record of identityContext.inventory.classes) {
     if (record.sourceId !== sourceId) continue;
     const statement = identityContext.declarationByClassId.get(record.id);
-    if (!statement || !ts.isClassDeclaration(statement) || !statement.name) continue;
+    if (!statement || (!ts.isClassDeclaration(statement) && !ts.isClassExpression(statement))) continue;
     // Existing nested accessor preparation intentionally leaves its containing
     // function on the direct path. Only the bounded ordinary-class family owns
     // the constructor/method/caller graph atomically, so only that family may
     // widen local-class expression resolution beyond source-file declarations.
     if (statement.parent !== sourceFile && !isBoundedPreparedNestedOrdinaryClass(statement)) continue;
-    const legacyName = statement.name.text;
+    const legacyName =
+      statement.parent === sourceFile && ts.isClassDeclaration(statement)
+        ? statement.name?.text
+        : boundedPreparedNestedOrdinaryClassBindingName(statement);
+    if (legacyName === undefined) continue;
     const shape = projectedShapes.get(legacyName);
-    if (!shape || shape.className !== legacyName || shape.classId !== record.id) continue;
+    if (!shape || shape.classId !== record.id) continue;
     const classId = record.id;
     if (classId === undefined || identityContext.declarationByClassId.get(classId) !== statement) {
       return planningInvariant(
@@ -214,7 +222,9 @@ export function makeIrIdentityLocalClassExpressionResolver(
         `projected local class ${legacyName} carries ${shape.classId} instead of ${classId}`,
       );
     }
-    const symbol = checker.getSymbolAtLocation(statement.name);
+    const symbol = statement.name
+      ? checker.getSymbolAtLocation(statement.name)
+      : checker.getTypeAtLocation(statement).getSymbol();
     if (!symbol) continue;
     const candidate = { classId, legacyName, declaration: statement, symbol };
     candidates.push(candidate);

--- a/src/ir/select-identity.ts
+++ b/src/ir/select-identity.ts
@@ -13,6 +13,7 @@ import type { IrUnitTypeMap, TypeMap, TypeMapEntry } from "./propagate.js";
 import type { IrRecursiveTypeEvidence } from "./type-evidence.js";
 import type { IrClassMethodDescriptor } from "./nodes.js";
 import {
+  boundedPreparedNestedOrdinaryClassBindingName,
   exactPreparedAccessorSyntaxKey,
   isBoundedPreparedAccessorClass,
   isBoundedPreparedNestedOrdinaryClass,
@@ -419,8 +420,8 @@ function uniqueDeclarationsByName(
 }
 
 function uniqueClassDeclarationsByName(
-  classesByName: ReadonlyMap<string, readonly { classId: IrClassId; declaration: ts.ClassDeclaration }[]>,
-): Map<string, ts.ClassDeclaration> {
+  classesByName: ReadonlyMap<string, readonly IndexedClass[]>,
+): Map<string, ts.ClassDeclaration | ts.ClassExpression> {
   return new Map(
     [...classesByName]
       .filter(([, candidates]) => candidates.length === 1)
@@ -619,7 +620,7 @@ export function planIrCompilationByIdentity(
 
   const classes = collectClasses(sourceFile, sourceId, identityContext);
   populateClassMemberUnits(sourceId, classes, identityContext, units);
-  const classesByName = new Map<string, { classId: IrClassId; declaration: ts.ClassDeclaration }[]>();
+  const classesByName = new Map<string, IndexedClass[]>();
   for (const indexed of classes) {
     if (
       indexed.declaration.parent === sourceFile &&
@@ -633,11 +634,11 @@ export function planIrCompilationByIdentity(
   const uniqueFunctions = uniqueDeclarationsByName(functionsByName);
   const projectedClassCandidates = new Map(classesByName);
   for (const candidate of classes) {
-    if (!ts.isClassDeclaration(candidate.declaration) || !candidate.declaration.name) continue;
     if (candidate.declaration.parent === sourceFile) continue;
-    if (!isBoundedPreparedNestedOrdinaryClass(candidate.declaration)) continue;
+    const bindingName = boundedPreparedNestedOrdinaryClassBindingName(candidate.declaration);
+    if (bindingName === undefined) continue;
     if (options.projectedClassShapesById?.has(candidate.classId) !== true) continue;
-    addNameIndex(projectedClassCandidates, candidate.declaration.name.text, candidate);
+    addNameIndex(projectedClassCandidates, bindingName, candidate);
   }
   const uniqueClasses = uniqueClassDeclarationsByName(projectedClassCandidates);
   const localClasses = new Set(uniqueClasses.keys());

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1250,7 +1250,7 @@ let currentIrSafeVarDeclarationLists: ReadonlySet<ts.VariableDeclarationList> = 
 // Current-run state shared by the deep isPhase1* recursion. The structural
 // selector configures the same predicates through the narrow hooks below.
 let currentSelectionOptions: IrSelectionOptions | undefined;
-let currentLocalClassDeclarations: ReadonlyMap<string, ts.ClassDeclaration> = new Map();
+let currentLocalClassDeclarations: ReadonlyMap<string, ts.ClassDeclaration | ts.ClassExpression> = new Map();
 let currentClaimClassName: string | null = null;
 // #2949 Acorn follow-up — the current top-level function's return expressions
 // may be provably boolean even while its unannotated JS callable ABI remains
@@ -1325,7 +1325,7 @@ let currentNumericParamNames = new Set<string>();
 export function configureIrStructuralSelectorPredicates(
   sourceFile: ts.SourceFile,
   options: IrSelectionOptions | undefined,
-  localClassDeclarations: ReadonlyMap<string, ts.ClassDeclaration>,
+  localClassDeclarations: ReadonlyMap<string, ts.ClassDeclaration | ts.ClassExpression>,
   functionDeclarations: ReadonlyMap<string, ts.FunctionDeclaration>,
   asyncDeclarationNames: ReadonlySet<string>,
 ): void {
@@ -1525,8 +1525,10 @@ function whyNotIrClaimable(
   currentModuleScalarAliasFamilies = new Map<ts.VariableDeclaration, "f64" | "boolean">();
   typedShapeRejectReason = null;
   currentClaimClassName =
-    isMethod && fn.parent && (ts.isClassDeclaration(fn.parent) || ts.isClassExpression(fn.parent)) && fn.parent.name
-      ? fn.parent.name.text
+    isMethod && fn.parent && (ts.isClassDeclaration(fn.parent) || ts.isClassExpression(fn.parent))
+      ? ([...currentLocalClassDeclarations].find(([, declaration]) => declaration === fn.parent)?.[0] ??
+        fn.parent.name?.text ??
+        null)
       : null;
   currentClassBindings = new Map<string, string>();
   currentCallableArities = new Map<string, number>();
@@ -3303,6 +3305,38 @@ function isPhase1StatementListInScope(
   return isPhase1Tail(stmts[stmts.length - 1]!, scope, localClasses, isGenerator, isVoidReturn);
 }
 
+function boundedClassExpressionBindingHasOnlyStaticConstructionUses(
+  declaration: ts.VariableDeclaration,
+  classExpression: ts.ClassExpression,
+): boolean {
+  if (!ts.isIdentifier(declaration.name)) return false;
+  let owner: ts.Node | undefined = declaration;
+  while (owner && !ts.isFunctionDeclaration(owner) && !ts.isFunctionExpression(owner) && !ts.isArrowFunction(owner)) {
+    owner = owner.parent;
+  }
+  if (
+    !owner ||
+    (!ts.isFunctionDeclaration(owner) && !ts.isFunctionExpression(owner) && !ts.isArrowFunction(owner)) ||
+    !owner.body
+  ) {
+    return false;
+  }
+  const bindingName = declaration.name.text;
+  let accepted = true;
+  const visit = (node: ts.Node): void => {
+    if (!accepted || node === classExpression) return;
+    if (ts.isIdentifier(node) && node.text === bindingName) {
+      if (node === declaration.name) return;
+      if (ts.isNewExpression(node.parent) && node.parent.expression === node) return;
+      accepted = false;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  visit(owner.body);
+  return accepted;
+}
+
 /**
  * Slice 9 (#1169h): shape-check a `throw <expr>;` statement. Bare
  * `throw;` (no expression) is rejected — the legacy path handles that
@@ -4447,6 +4481,21 @@ function isPhase1VarDecl(stmt: ts.VariableStatement, scope: Set<string>, localCl
     clearProjectionBinding(d.name.text);
     const initializerScope = new Set(scope);
     initializerScope.add(d.name.text);
+    if (ts.isClassExpression(d.initializer)) {
+      if (
+        !isConst ||
+        currentLocalClassDeclarations.get(d.name.text) !== d.initializer ||
+        !localClasses.has(d.name.text) ||
+        !boundedClassExpressionBindingHasOnlyStaticConstructionUses(d, d.initializer)
+      ) {
+        return shapeNo("vardecl-class-expression-unprepared", d.initializer);
+      }
+      // The exact prepared class has inert definition evaluation. Its
+      // constructor binding is consumed only by the dedicated `new C(...)`
+      // and static-member selector arms, never as a first-class IR value.
+      scope.add(d.name.text);
+      continue;
+    }
     const declarationList = d.parent;
     const declarationStatement = ts.isVariableDeclarationList(declarationList) ? declarationList.parent : undefined;
     const directModuleDeclaration =
@@ -5999,7 +6048,7 @@ function preflightClassPropertyWrite(expression: ts.PropertyAccessExpression, sc
 
 function classPositionTypeMayProject(
   type: ts.TypeNode | undefined,
-  owner: ts.ClassDeclaration,
+  owner: ts.ClassDeclaration | ts.ClassExpression,
   allowVoid: boolean = false,
 ): boolean {
   if (!type) return false;
@@ -6039,7 +6088,10 @@ function classPositionTypeMayProject(
   return false;
 }
 
-function classInitializerMayProject(initializer: ts.Expression | undefined, owner: ts.ClassDeclaration): boolean {
+function classInitializerMayProject(
+  initializer: ts.Expression | undefined,
+  owner: ts.ClassDeclaration | ts.ClassExpression,
+): boolean {
   if (!initializer) return false;
   const candidate = unwrapProjectionExpression(initializer);
   if (
@@ -6058,14 +6110,17 @@ function classInitializerMayProject(initializer: ts.Expression | undefined, owne
   return false;
 }
 
-function classFieldMayProject(field: ts.PropertyDeclaration, owner: ts.ClassDeclaration): boolean {
+function classFieldMayProject(field: ts.PropertyDeclaration, owner: ts.ClassDeclaration | ts.ClassExpression): boolean {
   if (!ts.isIdentifier(field.name) && !ts.isPrivateIdentifier(field.name)) return false;
   return field.type
     ? classPositionTypeMayProject(field.type, owner)
     : classInitializerMayProject(field.initializer, owner);
 }
 
-function classMethodSignatureMayProject(method: ts.MethodDeclaration, owner: ts.ClassDeclaration): boolean {
+function classMethodSignatureMayProject(
+  method: ts.MethodDeclaration,
+  owner: ts.ClassDeclaration | ts.ClassExpression,
+): boolean {
   return (
     hasFixedIrParameters(method.parameters) &&
     method.parameters.every((parameter) => classPositionTypeMayProject(parameter.type, owner)) &&
@@ -6075,7 +6130,7 @@ function classMethodSignatureMayProject(method: ts.MethodDeclaration, owner: ts.
 
 function classAccessorMayProject(
   accessor: ts.GetAccessorDeclaration | ts.SetAccessorDeclaration,
-  owner: ts.ClassDeclaration,
+  owner: ts.ClassDeclaration | ts.ClassExpression,
 ): boolean {
   if (ts.isGetAccessorDeclaration(accessor)) {
     return accessor.parameters.length === 0 && classPositionTypeMayProject(accessor.type, owner);
@@ -6156,7 +6211,7 @@ function projectedConstructorArity(className: string): number | undefined {
 }
 
 function localClassValueIsUnshadowed(name: string, scope: ReadonlySet<string>): boolean {
-  const exactNestedClassBinding = scope.has(name) && currentLocalClassDeclarations.get(name)?.name !== undefined;
+  const exactNestedClassBinding = scope.has(name) && currentLocalClassDeclarations.has(name);
   return (
     (!scope.has(name) || exactNestedClassBinding) &&
     !currentNestedFunctionNames.has(name) &&
@@ -7957,8 +8012,10 @@ function implicitParameterHasOnlyStringCallArguments(
  * doesn't accept their use). Anonymous classes (no `name`) are skipped. The
  * declaration values preserve the identity needed by #3529 projection checks.
  */
-function collectLocalClassDeclarations(sourceFile: ts.SourceFile): Map<string, ts.ClassDeclaration> {
-  const declarations = new Map<string, ts.ClassDeclaration>();
+function collectLocalClassDeclarations(
+  sourceFile: ts.SourceFile,
+): Map<string, ts.ClassDeclaration | ts.ClassExpression> {
+  const declarations = new Map<string, ts.ClassDeclaration | ts.ClassExpression>();
   for (const stmt of sourceFile.statements) {
     if (ts.isClassDeclaration(stmt) && stmt.name) declarations.set(stmt.name.text, stmt);
   }

--- a/tests/issue-3522-ir-nested-class-expression-ownership.test.ts
+++ b/tests/issue-3522-ir-nested-class-expression-ownership.test.ts
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const TARGETS = ["gc", "standalone"] as const;
+
+const SOURCE = `
+export function run(): number {
+  const Calculator = class {
+    value: number;
+    constructor(value: number) { this.value = value; }
+    add(delta: number): number { return this.value + delta; }
+    scale(factor: number): number { return this.value * factor; }
+  };
+  const calculator = new Calculator(5);
+  return calculator.add(2) * 100 + calculator.scale(3);
+}
+`;
+
+function outcome(result: CompileResult, name: string): IrObservedOutcome {
+  const observed = (result.irOutcomes ?? []).filter((candidate) => candidate.displayName.startsWith(name));
+  expect(observed, `terminal outcome count for ${name}`).toHaveLength(1);
+  return observed[0]!;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, Function>;
+  imports.setExports?.(exports);
+  return exports;
+}
+
+function watFunctionBody(wat: string, name: string): string {
+  const start = wat.indexOf(`  (func $${name}`);
+  expect(start, `missing $${name}`).toBeGreaterThanOrEqual(0);
+  const next = wat.indexOf("\n  (func $", start + 1);
+  return wat.slice(start, next < 0 ? wat.length : next);
+}
+
+describe("#3522 nested class-expression ownership", () => {
+  it.each(TARGETS)("prepares an exact const-bound class expression atomically in the %s lane", async (target) => {
+    const direct = await compile(SOURCE, {
+      fileName: `nested-class-expression-direct-${target}.ts`,
+      experimentalIR: false,
+      emitWat: true,
+      target,
+    });
+    const previousClassPoison = process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY;
+    const previousFunctionPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = "__anonClass_0_new,__anonClass_0_add,__anonClass_0_scale";
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+      prepared = await compile(SOURCE, {
+        fileName: `nested-class-expression-prepared-${target}.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        emitWat: true,
+        target,
+      });
+    } finally {
+      if (previousClassPoison === undefined)
+        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_CLASS_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_CLASS_BODY = previousClassPoison;
+      if (previousFunctionPoison === undefined)
+        Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousFunctionPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!()).toBe(715);
+    }
+    const observed = [
+      outcome(prepared, "run"),
+      outcome(prepared, "<anonymous-class>_new"),
+      outcome(prepared, "<anonymous-class>_add"),
+      outcome(prepared, "<anonymous-class>_scale"),
+    ];
+    expect(new Set(observed.map((candidate) => candidate.preparedComponentId)).size).toBe(1);
+    for (const candidate of observed) {
+      expect(candidate).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+    }
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    for (const name of ["__anonClass_0_init", "__anonClass_0_add", "__anonClass_0_scale", "run"]) {
+      expect(watFunctionBody(prepared.wat, name)).not.toMatch(
+        /externref|any\.convert_extern|extern\.convert_any|call_ref|call_indirect|ref\.(?:test|cast)/,
+      );
+    }
+    expect(watFunctionBody(prepared.wat, "__anonClass_0_init")).toContain("struct.set");
+    expect(watFunctionBody(prepared.wat, "__anonClass_0_add")).toContain("struct.get");
+    expect(watFunctionBody(prepared.wat, "__anonClass_0_scale")).toContain("struct.get");
+  });
+
+  it("withdraws the whole component when the class constructor binding is used as a first-class value", async () => {
+    const result = await compile(
+      `
+      export function run(): number {
+        const Calculator = class {
+          value: number;
+          constructor(value: number) { this.value = value; }
+          read(): number { return this.value; }
+        };
+        return Calculator === Calculator ? 1 : 0;
+      }
+      `,
+      { fileName: "nested-class-expression-value-fallback.ts", trackIrOutcomes: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(1);
+    for (const name of ["run", "<anonymous-class>_new", "<anonymous-class>_read"]) {
+      expect(outcome(result, name)).toMatchObject({
+        kind: "unsupported",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+    }
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps a same-named inner class identity on the exact binding", async () => {
+    const result = await compile(
+      `
+      export function run(): number {
+        const Calculator = class Calculator {
+          value: number;
+          constructor(value: number) { this.value = value; }
+          read(): number { return this.value; }
+        };
+        return new Calculator(42).read();
+      }
+      `,
+      { fileName: "nested-class-expression-same-name.ts", trackIrOutcomes: true },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!()).toBe(42);
+    for (const candidate of result.irOutcomes ?? []) {
+      expect(candidate).toMatchObject({ kind: "emitted", legacyBodyEmitted: false, irBodyEmitted: true });
+    }
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("does not widen mutable or differently named class-expression bindings", async () => {
+    for (const [fileName, declaration] of [
+      ["mutable", "let Calculator = class"],
+      ["different-inner-name", "const Calculator = class Inner"],
+    ] as const) {
+      const result = await compile(
+        `
+        export function run(): number {
+          ${declaration} {
+            value: number;
+            constructor(value: number) { this.value = value; }
+            read(): number { return this.value; }
+          };
+          return new Calculator(42).read();
+        }
+        `,
+        { fileName: `nested-class-expression-${fileName}-fallback.ts`, trackIrOutcomes: true },
+      );
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect((await instantiate(result)).run!()).toBe(42);
+      expect(outcome(result, "run")).toMatchObject({
+        kind: "unsupported",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- project exact const-bound ordinary class expressions into the Program ABI and IR selector as one atomic owner component
- preserve the synthetic class layout while resolving constructor uses through the source binding identity
- fail closed for mutable, effectful, differently named, captured, and first-class class-object uses
- record the checkpoint and next serial families in plan/issues/3522-ir-r3-classes-closures-compile-once.md

## Migration evidence

- prepared class expression and enclosing owner: legacy bodies 4 to 0; IR bodies 0 to 4
- hybrid and strict IR-only validation: 37/37 emitted, 0 legacy, 0 unsupported/invariant
- artifact size: GC 1557 to 1232 bytes; standalone 47058 to 21536 bytes
- migrated WAT contains no extern conversions, casts, or indirect calls
- direct and IR runtime result: 715 in GC and standalone lanes

## Validation

- focused and adjacent class suites: 12/12 after rebase
- broader R2/R3 selection: 134/134 before rebase
- equivalence: 1645 pass, 24 known failures, 0 regressions; 12 baseline failures now pass
- cross-backend parity: 29/29
- typecheck, lint, format, fallback, IR-only, LOC/function-budget, issue-integrity, oracle, and optimization-retirement gates pass

Closes the bounded class-expression checkpoint of #3522; the Markdown issue remains the source of truth.