### PR TITLE
feat(ir): prepare lifted nested functions

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -88,6 +88,7 @@ func-budget-allow:
   - src/codegen/function-body.ts::compileFunctionBody
   - src/codegen/index.ts::buildIrClassShapes
   - src/codegen/index.ts::generateModule
+  - src/ir/from-ast.ts::lowerFunctionAstToIr
   - src/ir/from-ast.ts::lowerMethodCall
   - src/ir/integration.ts::compileIrPathFunctions
   - src/ir/integration.ts::makeFromAstResolver
@@ -1314,6 +1315,51 @@ module-level, inline, capturing, and effectful class-expression consumers still
 use it. The next serial R3 owner is closures/object methods/cross-owner callable
 support; after those consumers reach zero, the obsolete direct branches must be
 deleted in the same checkpoint that proves their last use is gone.
+
+### Lifted nested-function ownership checkpoint (2026-08-13)
+
+Ordinary nested function declarations can now enter the enclosing terminal's
+prepare-before-emit transaction. The enclosing function and each admitted
+nested declaration lower together before the direct function-body compiler
+runs. If any nested body or prepared dependency fails, the transaction remains
+typed Unsupported and the existing direct route owns it once.
+
+The important accounting fix is structural: a lifted nested declaration now
+keeps its exact inventoried `nested-function` `IrUnitId`. It is no longer
+reported as a pass-created derived unit that happens to share the parent's
+display-name namespace. Lowering records its exact lexical parent, terminal
+owner, and source ordinal; integration verifies those fields against the
+frozen inventory. Only genuinely compiler-created lifts (including the narrow
+Promise-delay closure support) register `ProgramAbiDerivedUnitRecord`s.
+
+The bounded proof uses `run -> add`, with one captured scalar and one direct
+call. With direct `run` emission poisoned, GC and standalone both prepare the
+owner, allocate the nested source callable through the scoped Program ABI,
+validate, and return `42`. Optimized IR artifacts are no larger than their
+same-source direct artifacts. An independent AST-to-IR assertion proves the
+lifted function's ID is exactly the inventory ID rather than a newly derived
+ID.
+
+Focused nested/closure ABI evidence is **40/40** across this proof, the exact
+Promise-delay closure compile-once suite, prepared-scope sealing, and exact
+artifact/report identity. The broader closure/recursion matrix is **47/47**;
+the structural identity/Program ABI matrix is **51/51**; cross-backend parity
+is **29/29**; equivalence is **1,645 passing, 24 known failures, zero new
+regressions**; strict shadow remains **37/37 IR, zero legacy/Unsupported/
+Invariant**; and fallback, typecheck, lint, formatting, issue integrity, and
+optimization-retirement gates pass.
+
+Generic arrow/function-expression closure literals remain on the transitional
+late-overlay route in this checkpoint. The first combined probe was
+semantically correct but exposed a GC closure-support size regression, so their
+source-unit identities and support optimizations must land as their own
+measured slice. Object methods/accessors and cross-owner callable values remain
+after that.
+
+No shared direct nested-function implementation is deleted yet. Unsupported
+nested forms and the unretired closure-literal/object-method families still use
+the same direct compiler. Delete it only when the final typed consumer reaches
+zero.
 
 ## Exhaustive source-unit census
 

--- a/src/codegen/ir-prepared-nested-executable-syntax.ts
+++ b/src/codegen/ir-prepared-nested-executable-syntax.ts
@@ -6,10 +6,14 @@ import type { IrUnitId } from "../ir/identity.js";
 import { ts } from "../ts-api.js";
 
 /**
- * R2 may own nested executable syntax only when every nested callable is the
- * exact zero-argument host callback already certified by the TypedAST plan.
- * The map key is the authoritative AST identity; owner and ordinal checks keep
- * the synthetic closure namespace complete, gap-free, and source ordered.
+ * R3 may own nested executable syntax when the structural selector has already
+ * admitted the enclosing terminal and every special host callback still
+ * matches its exact TypedAST plan. Ordinary nested function declarations are
+ * lowered into their inventoried source units under the terminal owner's
+ * prepared transaction; generic closure literals, object members, and class
+ * static blocks remain outside this checkpoint. The host-callback map key is
+ * the authoritative AST identity; owner and ordinal checks keep that special
+ * synthetic namespace complete, gap-free, and source ordered.
  */
 export function containsUnplannedNestedExecutableSyntax(
   declaration: ts.FunctionLikeDeclaration,
@@ -42,6 +46,14 @@ export function containsUnplannedNestedExecutableSyntax(
       }
       seen.add(plan);
       ordinals.add(plan.liftedOrdinal);
+      ts.forEachChild(node.body, visit);
+      return;
+    }
+    if (ts.isFunctionDeclaration(node)) {
+      if (!node.body) {
+        invalid = true;
+        return;
+      }
       ts.forEachChild(node.body, visit);
       return;
     }

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -150,6 +150,7 @@ import {
   type IrLiftedFunctionArtifactIdentity,
   type IrUnitId,
 } from "./identity.js";
+import type { IrPlanningIdentityContext } from "./planning-identity.js";
 import {
   computeI32PureNames,
   type I32PureNames,
@@ -714,6 +715,8 @@ export interface AstToIrOptions {
   readonly hostDateGetters?: ReadonlyMap<ts.CallExpression, IrHostDateGetterLoweringPlan>;
   /** (#2856) Exact Promise-delay construction/timer/resolve node plans. */
   readonly promiseDelays?: IrPromiseDelayLoweringPlans;
+  /** Exact source-unit identities for nested executable declarations. */
+  readonly identityContext?: IrPlanningIdentityContext;
   /**
    * Slice 4 (#1169d): map from class name to that class's IR shape
    * (fields + methods + constructor signature). Consulted when lowering
@@ -1117,6 +1120,7 @@ export function lowerFunctionAstToIr(
     hostDateSnapshots: options.hostDateSnapshots,
     hostDateGetters: options.hostDateGetters,
     promiseDelays: options.promiseDelays,
+    identityContext: options.identityContext,
     classShapes: options.classShapes,
     resolver: options.resolver,
     lifted,
@@ -2015,6 +2019,7 @@ interface LowerCtx {
   readonly hostDateSnapshots?: ReadonlyMap<ts.NewExpression, IrHostDateSnapshotLoweringPlan>;
   readonly hostDateGetters?: ReadonlyMap<ts.CallExpression, IrHostDateGetterLoweringPlan>;
   readonly promiseDelays?: IrPromiseDelayLoweringPlans;
+  readonly identityContext?: IrPlanningIdentityContext;
   /** Slice 4 (#1169d) — class shape registry, keyed by className. */
   readonly classShapes?: ReadonlyMap<string, IrClassShape>;
   /**
@@ -10826,7 +10831,39 @@ function recordLiftedUnitProvenance(identity: IrLiftedFunctionArtifactIdentity, 
     parentId: identity.parentId,
     role: identity.role,
     ordinal: identity.ordinal,
+    ...(identity.sourceUnit ? { sourceUnit: true } : {}),
   });
+}
+
+function allocateLoweredLiftedFunctionArtifact(
+  declaration: ts.FunctionDeclaration | ts.FunctionExpression | ts.ArrowFunction,
+  cx: LowerCtx,
+  displayNameForOrdinal: (ordinal: number) => string,
+): IrLiftedFunctionArtifactIdentity {
+  const sourceUnitId = ts.isFunctionDeclaration(declaration)
+    ? cx.identityContext?.unitIdByDeclaration.get(declaration)
+    : undefined;
+  const sourceUnit = sourceUnitId ? cx.identityContext?.unitByUnitId.get(sourceUnitId) : undefined;
+  if (sourceUnitId && sourceUnit) {
+    if (
+      sourceUnit.kind !== "nested-function" ||
+      sourceUnit.terminalOwnerId !== cx.ownerUnitId ||
+      sourceUnit.lexicalOwnerId === null ||
+      !cx.identityContext?.unitByUnitId.has(sourceUnit.lexicalOwnerId as IrUnitId)
+    ) {
+      throw new Error(`ir/from-ast: lifted source identity diverged (${cx.funcName})`);
+    }
+    const displayOrdinal = cx.liftedCounter.value++;
+    return {
+      unitId: sourceUnitId,
+      name: displayNameForOrdinal(displayOrdinal),
+      parentId: sourceUnit.lexicalOwnerId as IrUnitId,
+      role: "lifted-closure",
+      ordinal: sourceUnit.ordinal,
+      sourceUnit: true,
+    };
+  }
+  return allocateLiftedFunctionArtifact(cx, displayNameForOrdinal);
 }
 
 /**
@@ -10910,7 +10947,7 @@ function lowerClosureExpressionWithSignature(
     }
   }
 
-  const liftedIdentity = allocateLiftedFunctionArtifact(cx, (ordinal) =>
+  const liftedIdentity = allocateLoweredLiftedFunctionArtifact(expr, cx, (ordinal) =>
     exactClosureLiftedName(cx.funcName, ordinal, exact?.expectedLiftedName),
   );
   recordLiftedUnitProvenance(liftedIdentity, cx);
@@ -11020,7 +11057,8 @@ function lowerNestedFunctionDeclaration(fn: ts.FunctionDeclaration, cx: LowerCtx
   const signature: IrClosureSignature = { params, returnType };
 
   const captures = analyseCaptures(fn, cx);
-  const liftedIdentity = allocateLiftedFunctionArtifact(
+  const liftedIdentity = allocateLoweredLiftedFunctionArtifact(
+    fn,
     cx,
     (ordinal) => `${cx.funcName}__nested_${innerName}_${ordinal}`,
   );
@@ -11085,6 +11123,7 @@ function liftNestedFunction(
     hostDateSnapshots: cx.hostDateSnapshots,
     hostDateGetters: cx.hostDateGetters,
     promiseDelays: cx.promiseDelays,
+    identityContext: cx.identityContext,
     classShapes: cx.classShapes,
     resolver: cx.resolver,
     lifted: cx.lifted,
@@ -11194,6 +11233,7 @@ function liftClosureBody(
     hostDateSnapshots: cx.hostDateSnapshots,
     hostDateGetters: cx.hostDateGetters,
     promiseDelays: cx.promiseDelays,
+    identityContext: cx.identityContext,
     classShapes: cx.classShapes,
     resolver: cx.resolver,
     lifted: cx.lifted,

--- a/src/ir/identity.ts
+++ b/src/ir/identity.ts
@@ -33,6 +33,8 @@ export interface IrLiftedFunctionArtifactIdentity extends IrFunctionIdentity {
   readonly parentId: IrUnitId;
   readonly role: "lifted-closure";
   readonly ordinal: number;
+  /** Present when the lifted artifact is an inventoried source body, not a pass-created unit. */
+  readonly sourceUnit?: true;
 }
 
 export interface IrLiftedFunctionArtifactOwner {
@@ -41,12 +43,23 @@ export interface IrLiftedFunctionArtifactOwner {
 }
 
 /** Exact producer-side provenance for one pass-created executable unit. */
-export interface IrDerivedUnitProvenance {
+export interface IrSyntheticUnitProvenance {
   readonly id: IrUnitId;
   readonly parentId: IrUnitId;
   readonly role: IrSyntheticUnitRole;
   readonly ordinal: number;
 }
+
+/** Exact lowering-side provenance for an inventoried nested source body. */
+export interface IrLiftedSourceUnitProvenance {
+  readonly id: IrUnitId;
+  readonly parentId: IrUnitId;
+  readonly role: "lifted-closure";
+  readonly ordinal: number;
+  readonly sourceUnit: true;
+}
+
+export type IrDerivedUnitProvenance = IrSyntheticUnitProvenance | IrLiftedSourceUnitProvenance;
 
 /** Closed role families for compiler/pass-created executable units. */
 export type IrSyntheticUnitRole =

--- a/src/ir/integration-report.ts
+++ b/src/ir/integration-report.ts
@@ -18,7 +18,11 @@ export interface IrIntegrationReport {
   readonly terminalEvidence?: readonly IrIntegrationTerminalEvidence[];
   /** Public compiled entries that are exact terminal owners. */
   readonly terminalCompiledOwners?: readonly string[];
-  /** Public compiled entries that are synthetic artifacts, not terminal rows. */
+  /**
+   * Historical compatibility field for every non-terminal compiled artifact.
+   * This includes pass-created units and inventoried nested source bodies;
+   * exact source/synthetic classification lives in compiledArtifactEvidence.
+   */
   readonly syntheticCompiledArtifacts?: readonly string[];
 }
 

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -907,7 +907,7 @@ export function compileIrPathFunctions(
     }
     const records = new Map<IrUnitId, ProgramAbiDerivedUnitRecord>();
     for (const provenance of result.liftedUnitProvenance) {
-      if (provenance.parentId !== parentUnitId || !isLiftedExecutableRole(provenance.role)) {
+      if (!isLiftedExecutableRole(provenance.role)) {
         throw new IrInvariantError(
           "selection-preparation-mismatch",
           "build",
@@ -920,6 +920,30 @@ export function compileIrPathFunctions(
           "selection-preparation-mismatch",
           "build",
           `ir/integration: lifted unit ${provenance.id} has no exact inventory parent and terminal owner`,
+        );
+      }
+      if ("sourceUnit" in provenance) {
+        const sourceUnit = inventoryUnitById.get(provenance.id);
+        if (
+          !sourceUnit ||
+          sourceUnit.terminal ||
+          sourceUnit.lexicalOwnerId !== provenance.parentId ||
+          sourceUnit.terminalOwnerId !== terminalOwnerId ||
+          sourceUnit.ordinal !== provenance.ordinal
+        ) {
+          throw new IrInvariantError(
+            "selection-preparation-mismatch",
+            "build",
+            `ir/integration: lifted source unit ${provenance.id} has inconsistent inventory provenance`,
+          );
+        }
+        continue;
+      }
+      if (provenance.parentId !== parentUnitId) {
+        throw new IrInvariantError(
+          "selection-preparation-mismatch",
+          "build",
+          `ir/integration: derived lifted unit ${provenance.id} has an unexpected parent`,
         );
       }
       if (records.has(provenance.id)) {
@@ -936,7 +960,8 @@ export function compileIrPathFunctions(
       });
     }
     for (const lifted of result.lifted) {
-      if (!records.has(lifted.unitId)) {
+      const sourceUnit = inventoryUnitById.get(lifted.unitId);
+      if (!records.has(lifted.unitId) && (!sourceUnit || sourceUnit.terminalOwnerId !== terminalOwnerId)) {
         throw new IrInvariantError(
           "selection-preparation-mismatch",
           "build",
@@ -1309,6 +1334,7 @@ export function compileIrPathFunctions(
         hostDateSnapshots: loweringPlans?.hostDateSnapshots,
         hostDateGetters: loweringPlans?.hostDateGetters,
         promiseDelays: loweringPlans?.promiseDelays,
+        identityContext: moduleBindingIdentityContext,
         classShapes,
         // Slice 6 part 4 refactor (#1185): thread the from-ast subset
         // of the IR resolver. Replaces the per-feature `nativeStrings:
@@ -1359,7 +1385,7 @@ export function compileIrPathFunctions(
           name: lifted.name,
           ownerName: owner.legacyName,
           fn: lifted,
-          derivedUnit: liftedAbiRecords.get(lifted.unitId)!,
+          derivedUnit: liftedAbiRecords.get(lifted.unitId),
           synthesized: true,
         });
       }
@@ -1528,6 +1554,7 @@ export function compileIrPathFunctions(
           hostVoidCallbacks: loweringPlans?.hostVoidCallbacks,
           hostDateSnapshots: loweringPlans?.hostDateSnapshots,
           hostDateGetters: loweringPlans?.hostDateGetters,
+          identityContext: moduleBindingIdentityContext,
           classShapes,
           resolver: fromAstResolver,
           allocRegistry,
@@ -1596,7 +1623,7 @@ export function compileIrPathFunctions(
             name: lifted.name,
             ownerName: owner.legacyName,
             fn: lifted,
-            derivedUnit: liftedAbiRecords.get(lifted.unitId)!,
+            derivedUnit: liftedAbiRecords.get(lifted.unitId),
             synthesized: true,
           });
         }
@@ -1724,6 +1751,7 @@ export function compileIrPathFunctions(
             hostVoidCallbacks: loweringPlans?.hostVoidCallbacks,
             hostDateSnapshots: loweringPlans?.hostDateSnapshots,
             hostDateGetters: loweringPlans?.hostDateGetters,
+            identityContext: moduleBindingIdentityContext,
             classShapes,
             resolver: fromAstResolver,
             allocRegistry,
@@ -1772,7 +1800,7 @@ export function compileIrPathFunctions(
               name: lifted.name,
               ownerName: owner.legacyName,
               fn: lifted,
-              derivedUnit: liftedAbiRecords.get(lifted.unitId)!,
+              derivedUnit: liftedAbiRecords.get(lifted.unitId),
               synthesized: true,
             });
           }
@@ -1876,6 +1904,7 @@ export function compileIrPathFunctions(
         hostVoidCallbacks: loweringPlans?.hostVoidCallbacks,
         hostDateSnapshots: loweringPlans?.hostDateSnapshots,
         hostDateGetters: loweringPlans?.hostDateGetters,
+        identityContext: moduleBindingIdentityContext,
         classShapes,
         resolver: fromAstResolver,
         allocRegistry,
@@ -1917,7 +1946,7 @@ export function compileIrPathFunctions(
               name: lifted.name,
               ownerName: moduleInitOwner.legacyName,
               fn: lifted,
-              derivedUnit: liftedAbiRecords.get(lifted.unitId)!,
+              derivedUnit: liftedAbiRecords.get(lifted.unitId),
               synthesized: true,
             });
           }

--- a/tests/issue-3522-ir-lifted-closure-ownership.test.ts
+++ b/tests/issue-3522-ir-lifted-closure-ownership.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { buildIrUnitInventory } from "../src/ir/identity.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { buildIrPlanningIdentityContext } from "../src/ir/planning-identity.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+
+const TARGETS = ["gc", "standalone"] as const;
+
+const SOURCE = `
+export function run(input: number): number {
+  const offset = 2;
+  function add(value: number): number { return value + offset; }
+  return add(input);
+}
+`;
+
+function outcome(result: CompileResult, name: string): IrObservedOutcome {
+  const observed = (result.irOutcomes ?? []).filter((candidate) => candidate.displayName === name);
+  expect(observed, `terminal outcome count for ${name}`).toHaveLength(1);
+  return observed[0]!;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, Function>;
+  imports.setExports?.(exports);
+  return exports;
+}
+
+describe("#3522 lifted nested-function ownership", () => {
+  it("uses the exact inventoried nested source-unit ID instead of a derived synthetic ID", () => {
+    const sourceFile = ts.createSourceFile("lifted-source-identity.ts", SOURCE, ts.ScriptTarget.Latest, true);
+    const identityContext = buildIrPlanningIdentityContext(
+      buildIrUnitInventory([sourceFile], { entrySource: sourceFile }),
+    );
+    const owner = sourceFile.statements.find(ts.isFunctionDeclaration)!;
+    const nested = owner.body!.statements.find(ts.isFunctionDeclaration)!;
+    const ownerUnitId = identityContext.unitIdByDeclaration.get(owner)!;
+    const nestedUnitId = identityContext.unitIdByDeclaration.get(nested)!;
+    const lowered = lowerFunctionAstToIr(owner, { ownerUnitId, identityContext });
+
+    expect(lowered.lifted).toHaveLength(1);
+    expect(lowered.lifted[0]!.unitId).toBe(nestedUnitId);
+    expect(lowered.liftedUnitProvenance).toEqual([
+      expect.objectContaining({
+        id: nestedUnitId,
+        parentId: ownerUnitId,
+        role: "lifted-closure",
+        sourceUnit: true,
+      }),
+    ]);
+  });
+
+  it.each(TARGETS)("prepares a nested declaration and its owner atomically in the %s lane", async (target) => {
+    const direct = await compile(SOURCE, {
+      fileName: `lifted-closure-direct-${target}.ts`,
+      experimentalIR: false,
+      emitWat: true,
+      optimize: true,
+      target,
+    });
+    const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+      prepared = await compile(SOURCE, {
+        fileName: `lifted-closure-prepared-${target}.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        emitWat: true,
+        optimize: true,
+        target,
+      });
+    } finally {
+      if (previousPoison === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!(40)).toBe(42);
+    }
+    expect(outcome(prepared, "run")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["run", "run__nested_add_0"]));
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+  });
+
+  it("keeps generic closure literals and unsupported nested declarations on direct ownership", async () => {
+    for (const [fileName, body, expectedResult, expected] of [
+      [
+        "arrow-literal",
+        `const add = (value: number): number => value + 1; return add(input);`,
+        42,
+        { kind: "emitted", legacyBodyEmitted: true, irBodyEmitted: true },
+      ],
+      [
+        "optional-nested-parameter",
+        `function add(value?: number): number { return value ?? 0; } return add(input);`,
+        41,
+        { kind: "unsupported", legacyBodyEmitted: true, irBodyEmitted: false },
+      ],
+    ] as const) {
+      const result = await compile(`export function run(input: number): number { ${body} }`, {
+        fileName: `lifted-closure-${fileName}-fallback.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      });
+
+      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect((await instantiate(result)).run!(41)).toBe(expectedResult);
+      expect(outcome(result, "run")).toMatchObject(expected);
+      expect(outcome(result, "run")).not.toHaveProperty("preparedComponentId");
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- prepare ordinary nested function declarations atomically with their enclosing IR owner before direct body emission
- preserve exact inventoried nested-function identities and validate lexical parent, terminal owner, and source ordinal provenance
- keep compiler-created lifts in the derived-unit namespace while source lifts use their frozen source-unit identity
- document the checkpoint and remaining closure/object/cross-owner families in the Markdown sprint issue

## Verification

- focused prepared closure/identity suites: 9/9 after rebase
- broader closure/recursion: 47/47
- structural identity/Program ABI: 51/51
- cross-backend parity: 29/29
- equivalence: 1,645 pass, 24 known failures, zero regressions
- strict IR-only shadow: 37/37 IR, zero legacy/Unsupported/Invariant
- optimized GC and standalone artifacts no larger than direct
- typecheck, formatting, fallback, issue-integrity, optimization-retirement, oracle, coercion, and numeric-local parity gates pass

Closes the lifted nested-function checkpoint of Markdown issue #3522; generic closure literals and object/cross-owner callable families remain tracked there.