### PR TITLE
feat(ir): prepare closure literal components

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -1361,6 +1361,54 @@ nested forms and the unretired closure-literal/object-method families still use
 the same direct compiler. Delete it only when the final typed consumer reaches
 zero.
 
+### Arrow/function-expression closure-literal checkpoint (2026-08-13)
+
+Ordinary arrow functions and function expressions now join their enclosing
+terminal's prepare-before-emit component instead of forcing the owner through
+the transitional direct-body overlay. Each literal keeps its exact inventoried
+`arrow-function` or `function-expression` source ID, including checker/usage
+transforms that clone a nested node. The source span, kind, source owner, and
+terminal owner must all match; genuinely synthesized lifts still use derived
+Program ABI provenance. Exact Promise-delay and one-shot host callbacks also
+retain their preplanned derived target IDs: those are compiler-owned artifacts
+whose plans are frozen before AST lowering, even though an arrow supplies their
+syntax.
+
+Mutable primitive captures now participate in the same sealed contract. Their
+canonical physical ref-cell struct is planned by semantic inner IR type, owns
+an explicit remappable Program ABI type ref, and is attached by object identity
+to the final boxed type plus every `refcell.new/get/set`. Missing, empty, stale,
+or unrelated evidence remains a typed preparation failure. Sibling closures
+share one cell and observe each other's writes. Closure carrier structs remain
+outside the user-data struct registry, preserving the direct backend's absence
+of `__sget_cap*`, `__struct_field_names`, and GC `__is_data_struct` reflection
+helpers.
+
+The anti-vacuity proof covers one immutable captured arrow plus a no-capture
+function expression, two sibling literals that share a mutable f64 capture,
+and an outer arrow that owns another captured arrow. With direct owner emission
+poisoned, GC and standalone prepare each complete tree atomically, validate,
+and return the same values as direct codegen. Every nested literal has its exact
+source ID. Optimized IR binaries are no larger than their same-source direct
+binaries. The exact Promise-delay regression suite proves its executor and
+timer callbacks keep their derived plan identities and execute in both
+optimized and unoptimized builds.
+
+Program ABI planner and dependency fail-closed coverage is **35/35**; focused
+closure ownership is **12/12**; exact Promise planning and execution is
+**8/8**; the adjacent direct closure/function-expression matrix is **56/56**
+after its legacy bare-import helpers were updated to link the compiler-declared
+runtime imports; typecheck, formatting, and the fallback ratchet pass with no
+unintended/post-claim/module-level increase. Hybrid and strict shadows remain
+**37/37 IR bodies, 0 legacy bodies, 0 Unsupported, and 0 Invariants**.
+
+Recursive named/self-bound literals, default/destructured parameter forms,
+returned closure values, and other cross-owner callable escapes remain on the
+typed direct route. Object-literal methods/accessors are the next serial R3
+family. No shared direct closure implementation is deleted yet; retire each
+branch with the final consumer and keep its optimization/parity assertions in
+that deletion checkpoint.
+
 ## Exhaustive source-unit census
 
 Before preparing any body, walk the source once in lexical/source order and

--- a/src/codegen/closures/funcref-as-closure.ts
+++ b/src/codegen/closures/funcref-as-closure.ts
@@ -17,6 +17,7 @@ import { popBody, pushBody } from "../context/bodies.js";
 import { getOrRegisterRefCellType } from "../index.js";
 import { mintDefinedFunc, pushDefinedFunc } from "../func-space.js";
 import { observeProgramAbiFunctionValue } from "../program-abi-source-callable-planning.js";
+import { emitCachedFuncClosureAccess } from "./method-trampolines.js";
 import {
   CLOSURE_CAPTURE_FIELD_BASE,
   closureArityField,
@@ -504,7 +505,16 @@ export function materializeHoistedFunctionValueBinding(
   const funcIdx = ctx.funcMap.get(name);
   if (localIdx === undefined || funcIdx === undefined) return false;
 
-  const valueType = emitFuncRefAsClosure(ctx, fctx, name, funcIdx);
+  // Capture-free declarations share the canonical lazy module singleton used
+  // by ordinary identifier reads. Besides preserving JavaScript identity, the
+  // singleton publishes the exact source-owned trampoline + cache pair to the
+  // Program ABI. Capture-carrying declarations remain activation-local and
+  // continue through the memoized per-frame closure path below.
+  const nestedCaptures = ctx.nestedFuncCaptures.get(name);
+  const valueType =
+    !nestedCaptures || nestedCaptures.length === 0
+      ? emitCachedFuncClosureAccess(ctx, fctx, name, funcIdx)
+      : emitFuncRefAsClosure(ctx, fctx, name, funcIdx);
   if (!valueType) return false;
   if (valueType.kind !== "externref" && valueType.kind !== "ref_extern") {
     fctx.body.push({ op: "extern.convert_any" });

--- a/src/codegen/ir-prepared-nested-executable-syntax.ts
+++ b/src/codegen/ir-prepared-nested-executable-syntax.ts
@@ -31,21 +31,31 @@ export function containsUnplannedNestedExecutableSyntax(
     if (ts.isArrowFunction(node)) {
       const plan = hostVoidCallbacks.get(node);
       if (
-        !plan ||
-        plan.ownerUnitId !== ownerUnitId ||
-        plan.ownerName !== ownerName ||
-        node.parameters.length !== 0 ||
-        plan.signature.params.length !== 0 ||
-        plan.signature.returnType !== null ||
-        !Number.isSafeInteger(plan.liftedOrdinal) ||
-        plan.liftedOrdinal < 0 ||
-        ordinals.has(plan.liftedOrdinal)
+        plan &&
+        (plan.ownerUnitId !== ownerUnitId ||
+          plan.ownerName !== ownerName ||
+          node.parameters.length !== 0 ||
+          plan.signature.params.length !== 0 ||
+          plan.signature.returnType !== null ||
+          !Number.isSafeInteger(plan.liftedOrdinal) ||
+          plan.liftedOrdinal < 0 ||
+          ordinals.has(plan.liftedOrdinal))
       ) {
         invalid = true;
         return;
       }
-      seen.add(plan);
-      ordinals.add(plan.liftedOrdinal);
+      if (plan) {
+        seen.add(plan);
+        ordinals.add(plan.liftedOrdinal);
+      }
+      ts.forEachChild(node.body, visit);
+      return;
+    }
+    if (ts.isFunctionExpression(node)) {
+      if (!node.body) {
+        invalid = true;
+        return;
+      }
       ts.forEachChild(node.body, visit);
       return;
     }

--- a/src/codegen/program-abi-type-planning.ts
+++ b/src/codegen/program-abi-type-planning.ts
@@ -30,6 +30,7 @@ const PROGRAM_ABI_TYPE_ROLE = Object.freeze({
   closureCapturedSubtype: 7,
   dynamicCarrier: 8,
   exceptionTagType: 9,
+  refCell: 10,
   classLayout: 0,
 } as const);
 
@@ -58,6 +59,21 @@ export interface ProgramAbiClosureSupportLayout {
   readonly allocationWrapperRef: IrTypeRef;
   readonly liftedFuncRef: IrTypeRef;
   readonly capturedSubtypeRef: IrTypeRef;
+}
+
+export interface ProgramAbiRefCellSupportRequest {
+  readonly innerType: IrType;
+  readonly cellType: StructTypeDef;
+}
+
+export interface ProgramAbiRefCellSupport {
+  readonly semanticInnerTypeKey: string;
+  readonly cellTypeRef: IrTypeRef;
+}
+
+interface ObservedRefCellSupport {
+  readonly request: ProgramAbiRefCellSupportRequest;
+  readonly support: ProgramAbiRefCellSupport;
 }
 
 interface ObservedClosureSupportLayout {
@@ -165,6 +181,11 @@ export function canonicalProgramAbiClosureLayoutKey(
   });
 }
 
+/** Backend-neutral semantic key for one mutable-capture cell payload. */
+export function canonicalProgramAbiRefCellKey(innerType: IrType): string {
+  return JSON.stringify(canonicalClosureSupportIrType(innerType, new Set<object>()));
+}
+
 interface ProgramAbiClassLayoutObservation {
   readonly classId: IrClassId;
   readonly displayName: string;
@@ -230,6 +251,7 @@ export class ProgramAbiTypeRegistry {
     }
   >();
   private readonly closureSupportLayouts = new Map<string, ObservedClosureSupportLayout>();
+  private readonly refCellSupport = new Map<string, ObservedRefCellSupport>();
   private dynamicCarrierSupport?: {
     readonly support: ProgramAbiDynamicCarrierSupport;
     readonly type?: TypeDef;
@@ -237,6 +259,7 @@ export class ProgramAbiTypeRegistry {
   };
   private exceptionTagTypeRefValue?: IrTypeRef;
   private closureSupportBatchPlanned = false;
+  private refCellSupportBatchPlanned = false;
   private planned = false;
 
   constructor(
@@ -719,6 +742,90 @@ export class ProgramAbiTypeRegistry {
     }
     this.closureSupportBatchPlanned = true;
     return canonical.map(({ layoutKey }) => resultByLayout.get(layoutKey)!);
+  }
+
+  /**
+   * Plan the canonical physical ref-cell structs used by mutable IR captures.
+   * Semantic payload keys are sorted before ordinals are assigned so nested
+   * function traversal cannot perturb the Program ABI.
+   */
+  prepareRefCellSupportTypes(
+    requests: readonly ProgramAbiRefCellSupportRequest[],
+  ): readonly ProgramAbiRefCellSupport[] {
+    if (this.planned) {
+      throw new ProgramAbiInvariantError("planning-sealed", "cannot prepare ref-cell support after retained planning");
+    }
+    if (requests.length === 0) return [];
+
+    const canonical = requests.map((request) => {
+      const semanticInnerTypeKey = canonicalProgramAbiRefCellKey(request.innerType);
+      const index = this.requireUniqueAllocatedType(request.cellType, `ref-cell ${semanticInnerTypeKey}`);
+      const field = request.cellType.fields[0];
+      if (
+        request.cellType.fields.length !== 1 ||
+        field?.name !== "value" ||
+        field.mutable !== true ||
+        request.cellType.superTypeIdx !== undefined ||
+        index < 0
+      ) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `ref-cell ${semanticInnerTypeKey} does not use the canonical mutable value-field layout`,
+        );
+      }
+      return { request, semanticInnerTypeKey };
+    });
+
+    if (this.refCellSupportBatchPlanned) {
+      return canonical.map(({ request, semanticInnerTypeKey }) => {
+        const observed = this.refCellSupport.get(semanticInnerTypeKey);
+        if (!observed) {
+          throw new ProgramAbiInvariantError(
+            "planning-sealed",
+            `ref-cell support ${semanticInnerTypeKey} was requested after the canonical batch was planned`,
+          );
+        }
+        if (observed.request.cellType !== request.cellType) {
+          throw new ProgramAbiInvariantError(
+            "type-remap-mismatch",
+            `ref-cell support ${semanticInnerTypeKey} maps to different physical type objects`,
+          );
+        }
+        return observed.support;
+      });
+    }
+
+    const byKey = new Map<string, ProgramAbiRefCellSupportRequest>();
+    for (const { request, semanticInnerTypeKey } of canonical) {
+      const previous = byKey.get(semanticInnerTypeKey);
+      if (previous && previous.cellType !== request.cellType) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `ref-cell support ${semanticInnerTypeKey} maps to different physical type objects`,
+        );
+      }
+      byKey.set(semanticInnerTypeKey, request);
+    }
+
+    const supportByKey = new Map<string, ProgramAbiRefCellSupport>();
+    [...byKey]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .forEach(([semanticInnerTypeKey, request], ordinal) => {
+        const entrySourceId = canonicalEntrySource(this.session);
+        const cellTypeRef = irSupportTypeRef(
+          entrySourceId,
+          `ref-cell:${semanticInnerTypeKey}`,
+          `__ir_ref_cell_${ordinal}`,
+          ordinal,
+        );
+        const cell = this.session.typeCellFor(request.cellType) ?? this.session.createTypeCell(request.cellType);
+        this.planPreparedSupportType(cellTypeRef, request.cellType, cell, PROGRAM_ABI_TYPE_ROLE.refCell, ordinal);
+        const support = Object.freeze({ semanticInnerTypeKey, cellTypeRef });
+        this.refCellSupport.set(semanticInnerTypeKey, Object.freeze({ request, support }));
+        supportByKey.set(semanticInnerTypeKey, support);
+      });
+    this.refCellSupportBatchPlanned = true;
+    return canonical.map(({ semanticInnerTypeKey }) => supportByKey.get(semanticInnerTypeKey)!);
   }
 
   /** Plan all source classes plus every retained allocator type after DCE. */

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -8890,6 +8890,17 @@ function lowerIdentifierAssignment(id: ts.Identifier, rhs: ts.Expression, cx: Lo
     cx.scope.set(id.text, { ...binding, stringEncoding: inferStringEncoding(rhs, cx) });
     return;
   }
+  if (binding.kind === "local" && binding.type.kind === "boxed") {
+    const newValue = lowerExpr(rhs, cx, binding.type.inner);
+    const newType = cx.builder.typeOf(newValue);
+    if (!irTypeAssignable(newType, binding.type.inner)) {
+      throw new Error(
+        `ir/from-ast: assignment to captured "${id.text}" (${describeIrType(binding.type.inner)}) got ${describeIrType(newType)} in ${cx.funcName}`,
+      );
+    }
+    cx.builder.emitRefCellSet(binding.value, newValue);
+    return;
+  }
   if (binding.kind === "withField") {
     const newValue = lowerExpr(rhs, cx, binding.type);
     if (!irTypeAssignable(cx.builder.typeOf(newValue), binding.type)) {
@@ -8948,25 +8959,31 @@ function lowerCompoundAssignment(id: ts.Identifier, compoundOp: ts.SyntaxKind, r
   if (!binding) {
     throw new Error(`ir/from-ast: compound assign to undeclared identifier "${id.text}" in ${cx.funcName}`);
   }
-  if (binding.kind !== "slot" && binding.kind !== "moduleGlobal") {
+  const capturedCell = binding.kind === "local" && binding.type.kind === "boxed" ? binding : undefined;
+  if (binding.kind !== "slot" && binding.kind !== "moduleGlobal" && !capturedCell) {
     throw new Error(
       `ir/from-ast: compound assign to non-slot binding "${id.text}" — mutation pre-pass should have detected it (${cx.funcName})`,
     );
   }
+  const storage = binding.kind === "slot" || binding.kind === "moduleGlobal" ? binding : capturedCell!;
+  const capturedCellType = storage.kind === "local" && storage.type.kind === "boxed" ? storage.type : undefined;
   // (#3741) i32-promoted slot — invariant W. `planI32Slots` only admits the
   // compound shapes handled here (bitwise compounds, plus `+=`/`-=` by an
   // integer literal on a `detectI32LoopVar`-proven counter); anything else
   // demotes rather than approximating.
-  if (binding.kind === "slot" && binding.i32Storage) {
-    lowerPromotedI32CompoundAssignment(id, binding.slotIndex, compoundOp, rhs, cx);
+  if (storage.kind === "slot" && storage.i32Storage) {
+    lowerPromotedI32CompoundAssignment(id, storage.slotIndex, compoundOp, rhs, cx);
     return;
   }
-  const logicalType = binding.kind === "slot" ? (binding.asType ?? binding.type) : binding.type;
+  const logicalType =
+    storage.kind === "slot" ? (storage.asType ?? storage.type) : (capturedCellType?.inner ?? storage.type);
   if (compoundOp === ts.SyntaxKind.PlusEqualsToken && logicalType.kind === "string") {
     const lhs =
-      binding.kind === "moduleGlobal"
-        ? cx.builder.emitGlobalGet(binding.globalRef, logicalType)
-        : cx.builder.emitSlotReadAs(binding.slotIndex, logicalType);
+      storage.kind === "moduleGlobal"
+        ? cx.builder.emitGlobalGet(storage.globalRef, logicalType)
+        : storage.kind === "slot"
+          ? cx.builder.emitSlotReadAs(storage.slotIndex, logicalType)
+          : cx.builder.emitRefCellGet(storage.value, capturedCellType!.inner);
     const rhsValue = lowerExpr(rhs, cx, logicalType);
     const rhsType = cx.builder.typeOf(rhsValue);
     if (checkerOperandFamily(rhs, cx) === "string" && rhsType.kind !== "string") {
@@ -8975,7 +8992,7 @@ function lowerCompoundAssignment(id: ts.Identifier, compoundOp: ts.SyntaxKind, r
       );
     }
     const proof = proveTypedStringAppend(
-      typedValueEvidence(id, binding.type, binding.stringEncoding, cx, logicalType),
+      typedValueEvidence(id, storage.type, storage.stringEncoding, cx, logicalType),
       typedValueEvidence(rhs, rhsType, inferStringEncoding(rhs, cx), cx),
     );
     if (!proof) {
@@ -8988,28 +9005,32 @@ function lowerCompoundAssignment(id: ts.Identifier, compoundOp: ts.SyntaxKind, r
     const symbol = cx.checker?.getSymbolAtLocation(id);
     const concatMode = symbol && cx.ownedStringAppendSymbols.has(symbol) ? "owned-append" : "immutable";
     const result = cx.builder.emitStringConcat(lhs, rhsValue, proof.resultEncoding, concatMode);
-    if (binding.kind === "moduleGlobal") {
-      cx.builder.emitGlobalSet(binding.globalRef, result);
+    if (storage.kind === "moduleGlobal") {
+      cx.builder.emitGlobalSet(storage.globalRef, result);
+    } else if (storage.kind === "slot") {
+      cx.builder.emitSlotWrite(storage.slotIndex, result);
     } else {
-      cx.builder.emitSlotWrite(binding.slotIndex, result);
+      cx.builder.emitRefCellSet(storage.value, result);
     }
-    cx.scope.set(id.text, { ...binding, stringEncoding: proof.resultEncoding });
+    cx.scope.set(id.text, { ...storage, stringEncoding: proof.resultEncoding });
     return;
   }
-  const slotValType = asVal(binding.type);
+  const slotValType = asVal(logicalType);
   if (!slotValType || slotValType.kind !== "f64") {
     throw new Error(
-      `ir/from-ast: compound assign to non-f64 slot "${id.text}" (${describeIrType(binding.type)}) not in slice 6 (${cx.funcName})`,
+      `ir/from-ast: compound assign to non-f64 slot "${id.text}" (${describeIrType(logicalType)}) not in slice 6 (${cx.funcName})`,
     );
   }
 
   // Desugar: read the slot (or, #3142, the module-binding global), lower the
   // RHS, apply the binop, write back.
   const lhs =
-    binding.kind === "moduleGlobal"
-      ? cx.builder.emitGlobalGet(binding.globalRef, binding.type)
-      : cx.builder.emitSlotRead(binding.slotIndex);
-  const rhsValue = lowerExpr(rhs, cx, binding.type);
+    storage.kind === "moduleGlobal"
+      ? cx.builder.emitGlobalGet(storage.globalRef, storage.type)
+      : storage.kind === "slot"
+        ? cx.builder.emitSlotRead(storage.slotIndex)
+        : cx.builder.emitRefCellGet(storage.value, capturedCellType!.inner);
+  const rhsValue = lowerExpr(rhs, cx, logicalType);
   const rhsType = cx.builder.typeOf(rhsValue);
   if (asVal(rhsType)?.kind !== "f64") {
     // (#3565) DESIGNED demote: the f64 slot is fine, but the RHS lowered to a
@@ -9044,11 +9065,15 @@ function lowerCompoundAssignment(id: ts.Identifier, compoundOp: ts.SyntaxKind, r
       throw new Error(`ir/from-ast: unsupported compound assign op ${ts.SyntaxKind[compoundOp]} in ${cx.funcName}`);
   }
   const result = cx.builder.emitBinary(binop, lhs, rhsValue, irVal({ kind: "f64" }));
-  if (binding.kind === "moduleGlobal") {
-    cx.builder.emitGlobalSet(binding.globalRef, result);
+  if (storage.kind === "moduleGlobal") {
+    cx.builder.emitGlobalSet(storage.globalRef, result);
     return;
   }
-  cx.builder.emitSlotWrite(binding.slotIndex, result);
+  if (storage.kind === "slot") {
+    cx.builder.emitSlotWrite(storage.slotIndex, result);
+    return;
+  }
+  cx.builder.emitRefCellSet(storage.value, result);
 }
 
 /**
@@ -9065,26 +9090,32 @@ function lowerIncrementDecrement(id: ts.Identifier, op: ts.SyntaxKind, cx: Lower
   if (!binding) {
     throw new Error(`ir/from-ast: increment/decrement of undeclared "${id.text}" in ${cx.funcName}`);
   }
-  if (binding.kind !== "slot" && binding.kind !== "moduleGlobal") {
+  const capturedCell = binding.kind === "local" && binding.type.kind === "boxed" ? binding : undefined;
+  if (binding.kind !== "slot" && binding.kind !== "moduleGlobal" && !capturedCell) {
     throw new Error(
       `ir/from-ast: increment/decrement of non-slot "${id.text}" — mutation pre-pass should have detected it (${cx.funcName})`,
     );
   }
+  const storage = binding.kind === "slot" || binding.kind === "moduleGlobal" ? binding : capturedCell!;
+  const capturedCellType = storage.kind === "local" && storage.type.kind === "boxed" ? storage.type : undefined;
   // (#3741) i32-promoted slot — `i32.add`/`i32.sub` of 1, exactly what legacy
   // has emitted for a promoted counter since #1120.
-  if (binding.kind === "slot" && binding.i32Storage) {
-    const cur = cx.builder.emitSlotRead(binding.slotIndex);
+  if (storage.kind === "slot" && storage.i32Storage) {
+    const cur = cx.builder.emitSlotRead(storage.slotIndex);
     const one = cx.builder.emitConst({ kind: "i32", value: 1 }, IR_I32);
     const next = cx.builder.emitBinary(op === ts.SyntaxKind.PlusPlusToken ? "i32.add" : "i32.sub", cur, one, IR_I32);
-    cx.builder.emitSlotWrite(binding.slotIndex, next);
+    cx.builder.emitSlotWrite(storage.slotIndex, next);
     return;
   }
-  const logicalType = binding.kind === "slot" ? (binding.asType ?? binding.type) : binding.type;
+  const logicalType =
+    storage.kind === "slot" ? (storage.asType ?? storage.type) : (capturedCellType?.inner ?? storage.type);
   if (logicalType.kind === "dynamic") {
     const current =
-      binding.kind === "moduleGlobal"
-        ? cx.builder.emitGlobalGet(binding.globalRef, logicalType)
-        : cx.builder.emitSlotReadAs(binding.slotIndex, logicalType);
+      storage.kind === "moduleGlobal"
+        ? cx.builder.emitGlobalGet(storage.globalRef, logicalType)
+        : storage.kind === "slot"
+          ? cx.builder.emitSlotReadAs(storage.slotIndex, logicalType)
+          : cx.builder.emitRefCellGet(storage.value, capturedCellType!.inner);
     const numeric = cx.builder.emitDynToNumber(current);
     const one = cx.builder.emitConst({ kind: "f64", value: 1 }, irVal({ kind: "f64" }));
     const updated = cx.builder.emitBinary(
@@ -9094,37 +9125,45 @@ function lowerIncrementDecrement(id: ts.Identifier, op: ts.SyntaxKind, cx: Lower
       irVal({ kind: "f64" }),
     );
     const boxed = cx.builder.emitBox(updated, irDynamic(JsTag.NumberF64));
-    if (binding.kind === "moduleGlobal") {
-      cx.builder.emitGlobalSet(binding.globalRef, boxed);
+    if (storage.kind === "moduleGlobal") {
+      cx.builder.emitGlobalSet(storage.globalRef, boxed);
+    } else if (storage.kind === "slot") {
+      cx.builder.emitSlotWrite(storage.slotIndex, boxed);
     } else {
-      cx.builder.emitSlotWrite(binding.slotIndex, boxed);
+      cx.builder.emitRefCellSet(storage.value, boxed);
     }
     return;
   }
-  const slotValType = asVal(binding.type);
+  const slotValType = asVal(logicalType);
   // The IR's binop set only includes f64 arithmetic — i32 add/sub
   // would need additional binop variants. For now, restrict to f64
   // counters (the common case for `let i = 0; i++` where `i: number`).
   // i32-typed counters fall back to legacy via the lowerer's throw.
   if (!slotValType || slotValType.kind !== "f64") {
     throw new Error(
-      `ir/from-ast: increment/decrement of non-f64 slot "${id.text}" (${describeIrType(binding.type)}) not in slice 12 (${cx.funcName})`,
+      `ir/from-ast: increment/decrement of non-f64 slot "${id.text}" (${describeIrType(logicalType)}) not in slice 12 (${cx.funcName})`,
     );
   }
   const lhs =
-    binding.kind === "moduleGlobal"
-      ? cx.builder.emitGlobalGet(binding.globalRef, binding.type)
-      : cx.builder.emitSlotRead(binding.slotIndex);
+    storage.kind === "moduleGlobal"
+      ? cx.builder.emitGlobalGet(storage.globalRef, storage.type)
+      : storage.kind === "slot"
+        ? cx.builder.emitSlotRead(storage.slotIndex)
+        : cx.builder.emitRefCellGet(storage.value, capturedCellType!.inner);
   const isAdd = op === ts.SyntaxKind.PlusPlusToken;
   const oneIr: IrType = irVal({ kind: "f64" });
   const one = cx.builder.emitConst({ kind: "f64", value: 1 }, oneIr);
   const binop: IrBinop = isAdd ? "f64.add" : "f64.sub";
   const result = cx.builder.emitBinary(binop, lhs, one, oneIr);
-  if (binding.kind === "moduleGlobal") {
-    cx.builder.emitGlobalSet(binding.globalRef, result);
+  if (storage.kind === "moduleGlobal") {
+    cx.builder.emitGlobalSet(storage.globalRef, result);
     return;
   }
-  cx.builder.emitSlotWrite(binding.slotIndex, result);
+  if (storage.kind === "slot") {
+    cx.builder.emitSlotWrite(storage.slotIndex, result);
+    return;
+  }
+  cx.builder.emitRefCellSet(storage.value, result);
 }
 
 function lowerConditional(expr: ts.ConditionalExpression, cx: LowerCtx): IrValueId {
@@ -10886,14 +10925,53 @@ function allocateLoweredLiftedFunctionArtifact(
   declaration: ts.FunctionDeclaration | ts.FunctionExpression | ts.ArrowFunction,
   cx: LowerCtx,
   displayNameForOrdinal: (ordinal: number) => string,
+  preserveDerivedIdentity = false,
 ): IrLiftedFunctionArtifactIdentity {
-  const sourceUnitId = ts.isFunctionDeclaration(declaration)
-    ? cx.identityContext?.unitIdByDeclaration.get(declaration)
-    : undefined;
+  // Exact host plans allocate their targets before AST lowering and compare
+  // against those derived identities when the plan is consumed. They are
+  // compiler-owned artifacts even though their syntax is a source closure;
+  // do not replace their planned target with the source node's unit ID.
+  if (preserveDerivedIdentity) return allocateLiftedFunctionArtifact(cx, displayNameForOrdinal);
+
+  // Mutable-capture/usage transforms may retain the terminal declaration but
+  // clone a nested function-like. TypeScript preserves the exact pre-transform
+  // node through getOriginalNode; consult it before classifying the lift as a
+  // compiler-created artifact, otherwise a real source arrow incorrectly
+  // escapes into the derived-unit namespace.
+  const originalDeclaration = ts.getOriginalNode(declaration);
+  const expectedSourceKind = ts.isFunctionDeclaration(declaration)
+    ? "nested-function"
+    : ts.isFunctionExpression(declaration)
+      ? "function-expression"
+      : "arrow-function";
+  let sourceUnitId =
+    cx.identityContext?.unitIdByDeclaration.get(declaration) ??
+    (originalDeclaration !== declaration
+      ? cx.identityContext?.unitIdByDeclaration.get(originalDeclaration)
+      : undefined);
+  if (!sourceUnitId && cx.identityContext) {
+    // A few checker/usage transforms clone the nested node without preserving
+    // TypeScript's original-node link. Recover only one exact-span source
+    // record under this terminal owner; kind, source, owner, and offsets must
+    // all agree with the frozen inventory.
+    const owner = cx.identityContext.unitByUnitId.get(cx.ownerUnitId);
+    const sourceFile = declaration.getSourceFile();
+    const candidates = owner
+      ? cx.identityContext.inventory.allUnits.filter(
+          (unit) =>
+            unit.sourceId === owner.sourceId &&
+            unit.kind === expectedSourceKind &&
+            unit.terminalOwnerId === cx.ownerUnitId &&
+            unit.declarationStart === declaration.getStart(sourceFile) &&
+            unit.declarationEnd === declaration.end,
+        )
+      : [];
+    if (candidates.length === 1) sourceUnitId = candidates[0]!.id;
+  }
   const sourceUnit = sourceUnitId ? cx.identityContext?.unitByUnitId.get(sourceUnitId) : undefined;
   if (sourceUnitId && sourceUnit) {
     if (
-      sourceUnit.kind !== "nested-function" ||
+      sourceUnit.kind !== expectedSourceKind ||
       sourceUnit.terminalOwnerId !== cx.ownerUnitId ||
       sourceUnit.lexicalOwnerId === null ||
       !cx.identityContext?.unitByUnitId.has(sourceUnit.lexicalOwnerId as IrUnitId)
@@ -10994,8 +11072,11 @@ function lowerClosureExpressionWithSignature(
     }
   }
 
-  const liftedIdentity = allocateLoweredLiftedFunctionArtifact(expr, cx, (ordinal) =>
-    exactClosureLiftedName(cx.funcName, ordinal, exact?.expectedLiftedName),
+  const liftedIdentity = allocateLoweredLiftedFunctionArtifact(
+    expr,
+    cx,
+    (ordinal) => exactClosureLiftedName(cx.funcName, ordinal, exact?.expectedLiftedName),
+    exact?.expectedLiftedTarget !== undefined || exact?.hostOneShot === true,
   );
   recordLiftedUnitProvenance(liftedIdentity, cx);
   const liftedTarget = irUnitFuncRef(liftedIdentity);

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -459,6 +459,7 @@ interface BuiltFn {
 
 interface PreparedClosureTransaction {
   readonly registry: ClosureStructRegistry;
+  readonly refCells: RefCellRegistry;
   readonly freshSlots: readonly PreparedDerivedCallableSlot[];
   readonly componentIds: ReadonlyMap<IrUnitId, string>;
   bindLowerResolver(resolver: IrLowerResolver): void;
@@ -610,9 +611,10 @@ function prepareClosureTransaction(input: {
   readonly callableImports: ReadonlyMap<string, Import>;
   readonly onSealFailure: (terminalUnitId: IrUnitId, error: IrUnsupportedError) => void;
 }): PreparedClosureTransaction {
-  let resolveValType: (type: IrType) => ValType = (type) => lowerPreparedClosureSupportType(input.ctx, type);
+  const refCells = new RefCellRegistry(input.ctx);
+  let resolveValType: (type: IrType) => ValType = (type) => lowerPreparedClosureSupportType(input.ctx, type, refCells);
   const registry = new ClosureStructRegistry(input.ctx, (type) => resolveValType(type));
-  const closureSupport = prepareDependencyCompleteClosureSupport(input.ctx, input.entries, registry);
+  const closureSupport = prepareDependencyCompleteClosureSupport(input.ctx, input.entries, registry, refCells);
   const freshSlots = allocatePreparedDerivedCallableSlots(
     input.ctx,
     input.entries,
@@ -631,6 +633,7 @@ function prepareClosureTransaction(input: {
   });
   return {
     registry,
+    refCells,
     freshSlots,
     componentIds,
     bindLowerResolver: (resolver) => {
@@ -2957,7 +2960,7 @@ export function compileIrPathFunctions(
     deferredCl.resolveBase = (sig) => closureRegistry.resolveBase(sig);
     deferredCl.resolveSubtype = (sig, fields, hostOneShot) =>
       closureRegistry.resolveSubtype(sig, fields, hostOneShot ? "host-one-shot" : "ordinary");
-    const refCellRegistry = new RefCellRegistry(ctx);
+    const refCellRegistry = preparedClosure?.refCells ?? new RefCellRegistry(ctx);
     deferredCell.resolve = (inner) => refCellRegistry.resolve(inner);
     // Slice 4 (#1169d): the class registry is a thin lookup over the
     // legacy class-collection state — `ctx.structMap`, `ctx.structFields`,
@@ -6579,7 +6582,11 @@ class ClosureStructRegistry {
     } as StructTypeDef);
     this.ctx.structMap.set(subName, subIdx);
     this.ctx.typeIdxToStructName.set(subIdx, subName);
-    this.ctx.structFields.set(subName, fields);
+    // Closure subtypes are private callable carriers, not user-visible data
+    // structs. Keep them out of structFields just like legacy captured
+    // closures: registering them there makes finalize emit __sget_capN,
+    // __struct_field_names, and __is_data_struct, both bloating the module and
+    // misclassifying an IR closure as an object at the host boundary.
 
     const baseInfo = this.ctx.closureInfoByTypeIdx.get(base.structTypeIdx);
     if (!baseInfo) {
@@ -6631,6 +6638,10 @@ class RefCellRegistry {
   resolve(inner: ValType): IrRefCellLowering | null {
     const typeIdx = getOrRegisterRefCellType(this.ctx, inner);
     return { typeIdx, fieldIdx: 0 };
+  }
+
+  resolveIr(inner: IrType): IrRefCellLowering | null {
+    return this.resolve(lowerPreparedClosureSupportType(this.ctx, inner, this));
   }
 }
 

--- a/src/ir/prepared-closure-support.ts
+++ b/src/ir/prepared-closure-support.ts
@@ -6,6 +6,7 @@ import { mintDefinedFunc, pushDefinedFunc } from "../codegen/func-space.js";
 import type {
   ProgramAbiClosureSupportLayout,
   ProgramAbiClosureSupportLayoutRequest,
+  ProgramAbiRefCellSupportRequest,
 } from "../codegen/program-abi-type-planning.js";
 import { addFuncType } from "../codegen/registry/types.js";
 import { irTypeBindingKey } from "./abi-bindings.js";
@@ -20,7 +21,7 @@ import {
   type IrType,
   type IrTypeRef,
 } from "./nodes.js";
-import type { IrClosureLowering } from "./lower.js";
+import type { IrClosureLowering, IrRefCellLowering } from "./lower.js";
 import type { FuncTypeDef, StructTypeDef, ValType, WasmFunction } from "./types.js";
 
 export interface PreparedClosureRegistry {
@@ -32,7 +33,15 @@ export interface PreparedClosureRegistry {
   ): IrClosureLowering | null;
 }
 
-export function lowerPreparedClosureSupportType(ctx: CodegenContext, type: IrType): ValType {
+export interface PreparedRefCellRegistry {
+  resolveIr(inner: IrType): IrRefCellLowering | null;
+}
+
+export function lowerPreparedClosureSupportType(
+  ctx: CodegenContext,
+  type: IrType,
+  refCells?: PreparedRefCellRegistry,
+): ValType {
   if (type.kind === "val" && type.val.kind !== "ref" && type.val.kind !== "ref_null") return type.val;
   if (type.kind === "extern" || type.kind === "callable") return { kind: "externref" };
   if (type.kind === "string" && type.carrierRef && ctx.programAbiSession) {
@@ -61,6 +70,10 @@ export function lowerPreparedClosureSupportType(ctx: CodegenContext, type: IrTyp
         irTypeBindingKey(type.layout.carrierType.binding),
       ),
     };
+  }
+  if (type.kind === "boxed" && refCells) {
+    const cell = refCells.resolveIr(type.inner);
+    if (cell) return { kind: "ref", typeIdx: cell.typeIdx };
   }
   throw new Error(`closure support type ${type.kind} requires the complete IR resolver`);
 }
@@ -173,6 +186,7 @@ export function prepareDependencyCompleteClosureSupport(
   ctx: CodegenContext,
   entries: readonly { readonly fn: IrFunction }[],
   registry: PreparedClosureRegistry,
+  refCells: PreparedRefCellRegistry,
 ): PreparedComponentClosureSupportEvidence {
   const typeRefs = new Map<IrType, readonly IrTypeRef[]>();
   const instructionRefs = new Map<IrInstr, readonly IrTypeRef[]>();
@@ -181,6 +195,19 @@ export function prepareDependencyCompleteClosureSupport(
     readonly request: ProgramAbiClosureSupportLayoutRequest;
     readonly publish: (refs: readonly IrTypeRef[]) => void;
   }> = [];
+  const pendingRefCells: Array<{
+    readonly request: ProgramAbiRefCellSupportRequest;
+    readonly publish: (refs: readonly IrTypeRef[]) => void;
+  }> = [];
+  const scheduleRefCell = (
+    boxedType: Extract<IrType, { readonly kind: "boxed" }>,
+    publish: (refs: readonly IrTypeRef[]) => void,
+  ): void => {
+    const lowering = refCells.resolveIr(boxedType.inner);
+    const cellType = lowering ? ctx.mod.types[lowering.typeIdx] : undefined;
+    if (!lowering || cellType?.kind !== "struct") return;
+    pendingRefCells.push({ request: { innerType: boxedType.inner, cellType }, publish });
+  };
   const schedule = (
     signature: IrClosureSignature,
     captureFieldTypes: readonly IrType[],
@@ -217,6 +244,7 @@ export function prepareDependencyCompleteClosureSupport(
       ...fn.params.map((param) => param.type),
       ...fn.resultTypes,
       ...fn.blocks.flatMap((block) => block.blockArgTypes),
+      ...(fn.closureSubtype?.captureFieldTypes ?? []),
     ]);
     for (const block of fn.blocks) {
       block.blockArgs.forEach((value, index) => {
@@ -231,8 +259,11 @@ export function prepareDependencyCompleteClosureSupport(
       }
     }
     for (const type of exactTypes) {
-      if (type.kind !== "closure" && type.kind !== "callable") continue;
-      schedule(type.signature, [], (refs) => typeRefs.set(type, refs));
+      if (type.kind === "closure" || type.kind === "callable") {
+        schedule(type.signature, [], (refs) => typeRefs.set(type, refs));
+      } else if (type.kind === "boxed") {
+        scheduleRefCell(type, (refs) => typeRefs.set(type, refs));
+      }
     }
     if (fn.closureSubtype) {
       schedule(
@@ -256,6 +287,13 @@ export function prepareDependencyCompleteClosureSupport(
             const calleeType = valueTypes.get(nested.callee);
             if (calleeType?.kind === "closure" || calleeType?.kind === "callable") {
               schedule(calleeType.signature, [], (refs) => instructionRefs.set(nested, refs));
+            }
+          } else if (nested.kind === "refcell.new" && nested.resultType?.kind === "boxed") {
+            scheduleRefCell(nested.resultType, (refs) => instructionRefs.set(nested, refs));
+          } else if (nested.kind === "refcell.get" || nested.kind === "refcell.set") {
+            const cellType = valueTypes.get(nested.cell);
+            if (cellType?.kind === "boxed") {
+              scheduleRefCell(cellType, (refs) => instructionRefs.set(nested, refs));
             }
           }
         });
@@ -281,6 +319,19 @@ export function prepareDependencyCompleteClosureSupport(
       );
     }
     layouts.forEach((layout, index) => pending[index]!.publish(distinctRefs(layout)));
+  }
+
+  if (pendingRefCells.length > 0) {
+    const programAbiTypes = ctx.programAbiTypes;
+    if (!programAbiTypes) {
+      throw new IrInvariantError(
+        "selection-preparation-mismatch",
+        "resolve",
+        "prepared ref-cell support requires one canonical Program ABI type registry",
+      );
+    }
+    const support = programAbiTypes.prepareRefCellSupportTypes(pendingRefCells.map(({ request }) => request));
+    support.forEach((entry, index) => pendingRefCells[index]!.publish(Object.freeze([entry.cellTypeRef])));
   }
   return Object.freeze({ typeRefs, instructionRefs, functionRefs });
 }

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -637,7 +637,7 @@ function samePreparedVecLayout(left: IrVecLayoutRef, right: IrVecLayoutRef): boo
 function implicitSupportRequirement(
   instr: IrInstr,
   valueTypes: ReadonlyMap<IrValueId, IrType>,
-  hasPreparedClosureSupport = false,
+  hasPreparedSupport = false,
   exceptionSupportPrepared = false,
 ): string | null {
   switch (instr.kind) {
@@ -685,13 +685,15 @@ function implicitSupportRequirement(
     case "closure.new":
     case "closure.cap":
     case "closure.call":
-      return hasPreparedClosureSupport
+      return hasPreparedSupport
         ? null
         : `${instr.kind} resolves closure wrapper/type support beyond its explicit callable ref`;
     case "refcell.new":
     case "refcell.get":
     case "refcell.set":
-      return `${instr.kind} resolves ref-cell type support without an explicit symbolic type ref`;
+      return hasPreparedSupport
+        ? null
+        : `${instr.kind} resolves ref-cell type support without an explicit symbolic type ref`;
     case "vec.len":
     case "vec.get":
     case "vec.set":
@@ -1321,11 +1323,15 @@ function collectFunctionEvidence(
     }
     const preparedRefs = input.closureSupport?.typeRefs.get(type);
     if (
-      (type.kind === "closure" || type.kind === "callable") &&
+      (type.kind === "closure" || type.kind === "callable" || type.kind === "boxed") &&
       recordPreparedClosureRefs(preparedRefs, `prepared IR ${type.kind} type must use Program ABI support refs`)
     ) {
-      for (const param of type.signature.params) collectType(param);
-      if (type.signature.returnType) collectType(type.signature.returnType);
+      if (type.kind === "boxed") {
+        collectType(type.inner);
+      } else {
+        for (const param of type.signature.params) collectType(param);
+        if (type.signature.returnType) collectType(type.signature.returnType);
+      }
       return;
     }
     recordImplicitTypeRequirement(
@@ -1364,7 +1370,7 @@ function collectFunctionEvidence(
         instructionClosureSupport,
         `prepared IR ${nested.kind} must use Program ABI support refs`,
       );
-      const hasPreparedClosureSupport =
+      const hasPreparedSupport =
         nested.kind === "closure.cap"
           ? (functionClosureSupport?.length ?? 0) > 0
           : (instructionClosureSupport?.length ?? 0) > 0;
@@ -1381,7 +1387,7 @@ function collectFunctionEvidence(
       const implicitSupport = implicitSupportRequirement(
         nested,
         valueTypes,
-        hasPreparedClosureSupport,
+        hasPreparedSupport,
         input.exceptionSupportPrepared === true || exceptionTagTypeRef !== undefined,
       );
       if (implicitSupport) {

--- a/tests/helpers/compile.ts
+++ b/tests/helpers/compile.ts
@@ -215,9 +215,10 @@ export async function compileAndRunBuildImportsExpect(source: string) {
 }
 
 /**
- * Cluster K (2 files — function-expressions, issue-280):
- * {@link compileAndRunStubs} plus a no-op `__make_callback` stub and an
- * instantiation try/catch that rethrows with the WAT.
+ * Cluster K (2 files — function-expressions, issue-280): compile and link the
+ * full declared runtime-import surface, then rethrow instantiation failures
+ * with the WAT. Prepared closure bodies can require string constants and
+ * arity-padding helpers even when the old direct body needed only callbacks.
  */
 export async function compileAndRunStubsCallback(source: string) {
   const result = await compile(source);
@@ -225,16 +226,10 @@ export async function compileAndRunStubsCallback(source: string) {
     result.success,
     `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
   ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-      __make_callback: () => {},
-    },
-  };
+  const imports = buildImports(result.imports, undefined, result.stringPool);
   try {
     const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    imports.setInstance?.(instance);
     return instance.exports as Record<string, Function>;
   } catch (e) {
     throw new Error(`Instantiation failed: ${e}\nWAT:\n${result.wat}`);

--- a/tests/issue-3521-prepared-component-dependencies.test.ts
+++ b/tests/issue-3521-prepared-component-dependencies.test.ts
@@ -1385,6 +1385,56 @@ describe("#3521 post-pass prepared-component dependency evidence", () => {
     );
   });
 
+  it("requires exact Program ABI evidence for boxed mutable captures and each ref-cell operation", () => {
+    const f = fixture();
+    const boxedType: IrType = { kind: "boxed", inner: irVal({ kind: "f64" }) };
+    const supportRef = irSupportTypeRef(f.first.id, "test-ref-cell-f64", "__test_ref_cell_f64");
+    const refCellSet: IrInstr = {
+      kind: "refcell.set",
+      cell: asValueId(0),
+      value: asValueId(1),
+      result: null,
+      resultType: null,
+    };
+    const fn: IrFunction = {
+      ...irFunction(f.first, [refCellSet]),
+      params: [
+        { value: asValueId(0), name: "cell", type: boxedType },
+        { value: asValueId(1), name: "value", type: irVal({ kind: "f64" }) },
+      ],
+      valueCount: 2,
+    };
+    const dependencies = (instruction: IrInstr, refs: readonly IrTypeRef[]) =>
+      derivePreparedComponentDependencies({
+        module: { functions: [fn] },
+        terminalUnitIds: new Set([f.first.id]),
+        inventory: f.inventory,
+        closureSupport: {
+          typeRefs: new Map([[boxedType, refs]]),
+          instructionRefs: new Map([[instruction, refs]]),
+          functionRefs: new Map(),
+        },
+        abi: abiLookup([sourceCallableEntry(f.first.id), supportTypeEntry(supportRef)]),
+      }).components[0]!;
+
+    expect(dependencies(refCellSet, [])).toMatchObject({ status: "blocked" });
+    const unrelated = dependencies({ ...refCellSet }, [supportRef]);
+    expect(unrelated.status).toBe("blocked");
+    expect(unrelated.failures).toContainEqual(
+      expect.objectContaining({
+        code: "implicit-support-reference-unavailable",
+        detail: expect.stringContaining("refcell.set resolves ref-cell type support"),
+      }),
+    );
+
+    const prepared = dependencies(refCellSet, [supportRef]);
+    expect(prepared.status).toBe("complete");
+    expect(prepared.failures).toEqual([]);
+    expect(prepared.abiDependencies).toContainEqual(
+      expect.objectContaining({ kind: "support", bindingId: supportRef.binding.bindingId }),
+    );
+  });
+
   it("fails closed for an unresolved exact unit ref and for a foreign terminal owner", () => {
     const f = fixture();
     const unknownUnitId = createDerivedIrUnitId({

--- a/tests/issue-3521-prepared-free-function-routing.test.ts
+++ b/tests/issue-3521-prepared-free-function-routing.test.ts
@@ -515,7 +515,7 @@ describe("#3521 prepare-before-emit free-function routing", () => {
     expect((await instantiate(classOwned)).readClass!()).toBe(42);
   });
 
-  it("keeps nested callable owners off the retrying preparation route", async () => {
+  it("prepares nested callable owners atomically", async () => {
     const result = await compile(
       `
       export function run(value: number): number {
@@ -533,11 +533,12 @@ describe("#3521 prepare-before-emit free-function routing", () => {
     );
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-    expect(result.irFirstSkipped ?? []).not.toContain("run");
+    expect(result.irFirstSkipped ?? []).toContain("run");
     expect(outcome(result, "run")).toMatchObject({
       kind: "emitted",
-      legacyBodyEmitted: true,
+      legacyBodyEmitted: false,
       irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
     });
     expect((await instantiate(result)).run!(7)).toBe(24);
   });

--- a/tests/issue-3522-ir-closure-literal-ownership.test.ts
+++ b/tests/issue-3522-ir-closure-literal-ownership.test.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { buildIrUnitInventory } from "../src/ir/identity.js";
+import { buildIrPlanningIdentityContext } from "../src/ir/planning-identity.js";
+import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
+
+const TARGETS = ["gc", "standalone"] as const;
+
+const SOURCE = `
+export function run(input: number): number {
+  const offset = 2;
+  const add = (value: number): number => value + offset;
+  const twice = function (value: number): number { return value * 2; };
+  return twice(add(input));
+}
+`;
+
+const MUTABLE_SOURCE = `
+export function run(input: number): number {
+  let total = input;
+  const add = (value: number): number => {
+    total += value;
+    return total;
+  };
+  const read = function (): number { return total; };
+  return add(2) + read();
+}
+`;
+
+const NESTED_SOURCE = `
+export function run(input: number): number {
+  const outer = (offset: number): number => {
+    const inner = (value: number): number => value + offset;
+    return inner(input);
+  };
+  return outer(2);
+}
+`;
+
+function outcome(result: CompileResult): IrObservedOutcome {
+  const observed = (result.irOutcomes ?? []).filter((candidate) => candidate.displayName === "run");
+  expect(observed).toHaveLength(1);
+  return observed[0]!;
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  const exports = instance.exports as Record<string, Function>;
+  imports.setExports?.(exports);
+  return exports;
+}
+
+describe("#3522 closure-literal ownership", () => {
+  it("keeps arrow and function-expression artifacts on their exact inventoried source IDs", () => {
+    const sourceFile = ts.createSourceFile("closure-literal-source-identity.ts", SOURCE, ts.ScriptTarget.Latest, true);
+    const identityContext = buildIrPlanningIdentityContext(
+      buildIrUnitInventory([sourceFile], { entrySource: sourceFile }),
+    );
+    const owner = sourceFile.statements.find(ts.isFunctionDeclaration)!;
+    const declarations = owner
+      .body!.statements.filter(ts.isVariableStatement)
+      .flatMap((statement) => statement.declarationList.declarations.map((declaration) => declaration.initializer));
+    const arrow = declarations.find((declaration): declaration is import("typescript").ArrowFunction =>
+      ts.isArrowFunction(declaration),
+    )!;
+    const functionExpression = declarations.find(
+      (declaration): declaration is import("typescript").FunctionExpression => ts.isFunctionExpression(declaration),
+    )!;
+    const lowered = lowerFunctionAstToIr(owner, {
+      ownerUnitId: identityContext.unitIdByDeclaration.get(owner)!,
+      identityContext,
+    });
+
+    expect(lowered.lifted.map((candidate) => candidate.unitId)).toEqual([
+      identityContext.unitIdByDeclaration.get(arrow),
+      identityContext.unitIdByDeclaration.get(functionExpression),
+    ]);
+    expect(lowered.liftedUnitProvenance).toEqual([
+      expect.objectContaining({ sourceUnit: true, role: "lifted-closure" }),
+      expect.objectContaining({ sourceUnit: true, role: "lifted-closure" }),
+    ]);
+  });
+
+  it("keeps a nested closure tree on exact source IDs under one terminal owner", () => {
+    const sourceFile = ts.createSourceFile(
+      "nested-closure-source-identity.ts",
+      NESTED_SOURCE,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const identityContext = buildIrPlanningIdentityContext(
+      buildIrUnitInventory([sourceFile], { entrySource: sourceFile }),
+    );
+    const owner = sourceFile.statements.find(ts.isFunctionDeclaration)!;
+    const arrows: import("typescript").ArrowFunction[] = [];
+    const visit = (node: import("typescript").Node): void => {
+      if (ts.isArrowFunction(node)) arrows.push(node);
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(owner.body!, visit);
+    const lowered = lowerFunctionAstToIr(owner, {
+      ownerUnitId: identityContext.unitIdByDeclaration.get(owner)!,
+      identityContext,
+    });
+
+    expect(arrows).toHaveLength(2);
+    expect(new Set(lowered.lifted.map((candidate) => candidate.unitId))).toEqual(
+      new Set(arrows.map((arrow) => identityContext.unitIdByDeclaration.get(arrow))),
+    );
+    expect(lowered.liftedUnitProvenance).toEqual([
+      expect.objectContaining({ sourceUnit: true, role: "lifted-closure" }),
+      expect.objectContaining({ sourceUnit: true, role: "lifted-closure" }),
+    ]);
+  });
+
+  it.each(TARGETS)("prepares closure literals and their owner in the %s lane", async (target) => {
+    const direct = await compile(SOURCE, {
+      fileName: `closure-literal-direct-${target}.ts`,
+      experimentalIR: false,
+      optimize: true,
+      emitWat: true,
+      target,
+    });
+    const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+      prepared = await compile(SOURCE, {
+        fileName: `closure-literal-prepared-${target}.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        optimize: true,
+        emitWat: true,
+        target,
+      });
+    } finally {
+      if (previousPoison === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!(40)).toBe(84);
+    }
+    expect(outcome(prepared)).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["run", "run__closure_0", "run__closure_1"]));
+    expect(prepared.wat).not.toContain("__sget_cap");
+    expect(prepared.wat).not.toContain("__struct_field_names");
+    if (target === "gc") expect(prepared.wat).not.toContain("__is_data_struct");
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+  });
+
+  it.each(TARGETS)("shares one prepared mutable capture across sibling closures in the %s lane", async (target) => {
+    const direct = await compile(MUTABLE_SOURCE, {
+      fileName: `closure-literal-mutable-direct-${target}.ts`,
+      experimentalIR: false,
+      optimize: true,
+      emitWat: true,
+      target,
+    });
+    const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+      prepared = await compile(MUTABLE_SOURCE, {
+        fileName: `closure-literal-mutable-prepared-${target}.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        optimize: true,
+        emitWat: true,
+        target,
+      });
+    } finally {
+      if (previousPoison === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!(5)).toBe(14);
+    }
+    expect(outcome(prepared)).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["run", "run__closure_0", "run__closure_1"]));
+    expect(prepared.wat).toContain("__ref_cell_f64");
+    expect(prepared.wat).not.toContain("__sget_cap");
+    expect(prepared.wat).not.toContain("__struct_field_names");
+    if (target === "gc") expect(prepared.wat).not.toContain("__is_data_struct");
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+  });
+
+  it.each(TARGETS)("prepares nested closure trees atomically in the %s lane", async (target) => {
+    const direct = await compile(NESTED_SOURCE, {
+      fileName: `nested-closure-direct-${target}.ts`,
+      experimentalIR: false,
+      optimize: true,
+      target,
+    });
+    const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run";
+      prepared = await compile(NESTED_SOURCE, {
+        fileName: `nested-closure-prepared-${target}.ts`,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        optimize: true,
+        target,
+      });
+    } finally {
+      if (previousPoison === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!(40)).toBe(42);
+    }
+    expect(outcome(prepared)).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.irCompiledFuncs ?? []).toEqual(
+      expect.arrayContaining(["run", "run__closure_0", "run__closure_0__closure_1"]),
+    );
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+  });
+});

--- a/tests/issue-3522-ir-lifted-closure-ownership.test.ts
+++ b/tests/issue-3522-ir-lifted-closure-ownership.test.ts
@@ -98,32 +98,27 @@ describe("#3522 lifted nested-function ownership", () => {
     expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
   });
 
-  it("keeps generic closure literals and unsupported nested declarations on direct ownership", async () => {
-    for (const [fileName, body, expectedResult, expected] of [
-      [
-        "arrow-literal",
-        `const add = (value: number): number => value + 1; return add(input);`,
-        42,
-        { kind: "emitted", legacyBodyEmitted: true, irBodyEmitted: true },
-      ],
-      [
-        "optional-nested-parameter",
-        `function add(value?: number): number { return value ?? 0; } return add(input);`,
-        41,
-        { kind: "unsupported", legacyBodyEmitted: true, irBodyEmitted: false },
-      ],
-    ] as const) {
-      const result = await compile(`export function run(input: number): number { ${body} }`, {
-        fileName: `lifted-closure-${fileName}-fallback.ts`,
+  it("keeps an unsupported nested declaration on direct ownership", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        function add(value?: number): number { return value ?? 0; }
+        return add(input);
+      }`,
+      {
+        fileName: "lifted-closure-optional-nested-parameter-fallback.ts",
         experimentalIR: true,
         trackIrOutcomes: true,
-      });
+      },
+    );
 
-      expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-      expect((await instantiate(result)).run!(41)).toBe(expectedResult);
-      expect(outcome(result, "run")).toMatchObject(expected);
-      expect(outcome(result, "run")).not.toHaveProperty("preparedComponentId");
-      expect(result.irPostClaimErrors ?? []).toEqual([]);
-    }
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!(41)).toBe(41);
+    expect(outcome(result, "run")).toMatchObject({
+      kind: "unsupported",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(outcome(result, "run")).not.toHaveProperty("preparedComponentId");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 });

--- a/tests/issue-4102-program-abi-closure-support.test.ts
+++ b/tests/issue-4102-program-abi-closure-support.test.ts
@@ -7,6 +7,7 @@ import { createCodegenContext } from "../src/codegen/context/create-context.js";
 import {
   canonicalProgramAbiClosureLayoutKey,
   canonicalProgramAbiClosureSignatureKey,
+  canonicalProgramAbiRefCellKey,
   type ProgramAbiClosureSupportLayoutRequest,
 } from "../src/codegen/program-abi-type-planning.js";
 import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
@@ -258,6 +259,75 @@ describe("#4102 Program ABI prepared closure support types", () => {
     });
     expect(layout!.semanticLayoutKey).toBe(
       canonicalProgramAbiClosureLayoutKey(executor.signature, executor.captureFieldTypes),
+    );
+  });
+
+  it("plans, deduplicates, and remaps mutable-capture ref cells by semantic payload type", () => {
+    const f = fixture();
+    const f64Cell: StructTypeDef = {
+      kind: "struct",
+      name: "__ref_cell_f64",
+      fields: [{ name: "value", type: { kind: "f64" }, mutable: true }],
+    };
+    const i32Cell: StructTypeDef = {
+      kind: "struct",
+      name: "__ref_cell_i32",
+      fields: [{ name: "value", type: { kind: "i32" }, mutable: true }],
+    };
+    f.module.types.push(f64Cell, i32Cell);
+    const f64Request = { innerType: F64, cellType: f64Cell };
+    const i32Type = irVal({ kind: "i32" });
+    const i32Request = { innerType: i32Type, cellType: i32Cell };
+
+    const [f64Support, i32Support, duplicateF64] = f.registry.prepareRefCellSupportTypes([
+      f64Request,
+      i32Request,
+      f64Request,
+    ]);
+    expect(duplicateF64).toBe(f64Support);
+    expect(f64Support!.semanticInnerTypeKey).toBe(canonicalProgramAbiRefCellKey(F64));
+    expect(i32Support!.semanticInnerTypeKey).toBe(canonicalProgramAbiRefCellKey(i32Type));
+    expect(f.registry.prepareRefCellSupportTypes([i32Request, f64Request])).toEqual([i32Support, f64Support]);
+
+    const originalIndex = f.module.types.indexOf(f64Cell);
+    const replacement: StructTypeDef = { ...f64Cell, name: "__ref_cell_f64_after_remap", fields: [...f64Cell.fields] };
+    f.session.remapTypeObject(f64Cell, replacement);
+    f.module.types[originalIndex] = replacement;
+    f.registry.planRetained();
+    const publication = f.session.publish(f.module);
+    expect(publication.abi.resolveFinalIndex(f64Support!.cellTypeRef.binding.bindingId)).toEqual({
+      space: "type",
+      index: originalIndex,
+    });
+  });
+
+  it("rejects a non-canonical or conflicting physical ref-cell layout", () => {
+    const f = fixture();
+    const immutable: StructTypeDef = {
+      kind: "struct",
+      name: "bad_ref_cell",
+      fields: [{ name: "value", type: { kind: "f64" }, mutable: false }],
+    };
+    f.module.types.push(immutable);
+    expectProgramAbiInvariant(
+      () => f.registry.prepareRefCellSupportTypes([{ innerType: F64, cellType: immutable }]),
+      "type-remap-mismatch",
+    );
+
+    const first: StructTypeDef = {
+      kind: "struct",
+      name: "first_ref_cell",
+      fields: [{ name: "value", type: { kind: "f64" }, mutable: true }],
+    };
+    const second: StructTypeDef = { ...first, name: "second_ref_cell", fields: [...first.fields] };
+    f.module.types.push(first, second);
+    expectProgramAbiInvariant(
+      () =>
+        f.registry.prepareRefCellSupportTypes([
+          { innerType: F64, cellType: first },
+          { innerType: F64, cellType: second },
+        ]),
+      "type-remap-mismatch",
     );
   });
 });

--- a/tests/test-call-ref.test.ts
+++ b/tests/test-call-ref.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { assertEquivalent, buildImports } from "./equivalence/helpers.js";
+import { assertEquivalent, instantiateWithRuntime } from "./equivalence/helpers.js";
 import { compile } from "../src/index.js";
 
 describe("callable parameter dispatch (#446)", () => {
@@ -51,8 +51,7 @@ export function test(): number {
     `;
     const result = await compile(src);
     expect(result.errors).toHaveLength(0);
-    const imports = buildImports(result);
-    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    const instance = await instantiateWithRuntime(result);
     expect((instance.exports as any).test()).toBe(42);
   });
 
@@ -70,8 +69,7 @@ export function test(): number {
     `;
     const result = await compile(src);
     expect(result.errors).toHaveLength(0);
-    const imports = buildImports(result);
-    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    const instance = await instantiateWithRuntime(result);
     expect((instance.exports as any).test()).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- prepare ordinary arrow/function-expression closure bodies with their enclosing IR owner
- preserve exact source-unit identities, while retaining derived IDs for exact Promise/host callback plans
- plan mutable ref-cell capture types through the remappable Program ABI and keep closure carriers out of user-data reflection
- prove nested closure trees, mutable sibling captures, runtime parity, and non-regressing optimized binary size
- update the #3522 Markdown migration checklist and stale direct-test import harnesses

## Validation

- focused closure/Promise/Program ABI/dependency suites: 47/47 after rebase
- changed-root hook suites: green
- hybrid IR-only shadow: 37/37 IR, 0 legacy, 0 Unsupported, 0 Invariants
- fallback ratchet: no unintended, post-claim, or module-level increase
- typecheck, lint, formatting, issue integrity, optimization retirement, LOC/function budgets, oracle/coercion ratchets: green
- pre-push numeric-local parity: 18/18
- GC and standalone runtime parity; optimized prepared binaries no larger than direct controls

Tracks plan/issues/3522-ir-r3-classes-closures-compile-once.md (no GitHub issue).
