### PR TITLE
feat(ir): prepare destructured method values

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -2054,3 +2054,55 @@ standalone remains zero-import, GC introduces no import absent from the direct
 control (and commonly removes generic call/destructuring bridges), and the WAT
 checks reject `__call_m_*` dispatch. All admitted fixtures retain runtime,
 validation, exact IR ownership, and optimized-size parity.
+
+### Destructured object-method value checkpoint (2026-08-13)
+
+Exact object-method values may now flow through a const object binding pattern,
+including renaming and immutable local alias chains: `const { add: selected } =
+operations; const invoke = selected; invoke(input)`. The module-binding
+resolver exposes the exact same-source value declaration for binding elements,
+parameters, nested declarations, and variables, so the selector and local call
+graph compare lexical identities instead of names. Incremental Programs retain
+the established stable file/position identity fallback; a changed-snapshot
+warm-up followed by fresh and reused target compiles produces byte-identical
+artifacts and does not let a block-local destructured `parseInt` hide the later
+ambient call.
+
+The new projection is fail-closed and atomic. Every destructuring use of the
+exact const all-method receiver must name represented own methods, the receiver
+must be unwritten and unescaped, and each projected value/const-alias chain may
+be used only by direct non-optional calls in the same lexical owner. Mixed or
+inherited fields, sibling unsafe patterns, object aliases, property writes,
+cross-owner captures, callback/value escapes, mutable links, and optional calls
+stay on a typed select-stage direct body with zero post-claim errors. Optional
+invocation is also rejected by the general call selector because AST-to-IR does
+not lower `?.()` yet; a later valid projection can no longer expose that
+pre-existing select/build mismatch.
+
+Direct-body poison proves `run` and its lifted method are IR-owned with
+`direct=0, IR=1` for both admitted patterns. Both optimized artifacts validate,
+execute, use `call_ref`, and contain no `__call_m_*` dispatcher. Exact output
+and import measurements are:
+
+| Pattern | Target | Direct bytes | IR bytes | Direct imports | IR imports |
+| --- | --- | ---: | ---: | --- | --- |
+| `{ add }` | GC | 3,306 | 2,262 | box, throw-type-error, unbox | box, unbox |
+| `{ add }` | standalone | 6,830 | 5,893 | none | none |
+| `{ add: selected }` plus two const aliases | GC | 3,419 | 2,262 | box, generic-call/array, throw-type-error, unbox | box, unbox |
+| `{ add: selected }` plus two const aliases | standalone | 6,830 | 5,893 | none | none |
+
+The focused object-method suite is **24/24** and the adjacent six-file
+closure/object matrix is **46/46**. Hybrid and strict IR-only shadow validation
+remain **37/37 IR bodies, 0 legacy bodies, 0 Unsupported, and 0 Invariants**;
+cross-backend differential coverage is **29/29**; the fallback ratchet has zero
+unintended, post-claim, or module-level increases; and native-first host-import
+policy remains **379 imports, 0 legacy-semantic, 0 unknown**. Typecheck,
+formatting, LOC/function budgets, oracle, and coercion-site gates are green.
+Full equivalence reports **1,645 passing, 24 known failures, 12 baseline cases
+now passing, and zero new regressions**.
+
+Remaining R3 boundary: cross-owner object-method values and general callable
+escapes still require a planned capture/runtime-value ABI before admission.
+Receiver-sensitive methods, accessors, mixed/open objects, optional calls, and
+mutable callable fields remain explicit later families; their live direct
+implementations cannot be deleted at this checkpoint.

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -699,6 +699,8 @@ interface IrModuleBindingResolverSurface<TIdentity, TInspection> {
   readonly isAmbientBinding: (node: ts.Identifier) => boolean;
   /** Resolve a local variable use to its exact declaration for alias tracking. */
   readonly localVariableDeclaration: (node: ts.Identifier) => ts.VariableDeclaration | undefined;
+  /** Resolve any same-source local value use to its exact lexical declaration. */
+  readonly localValueDeclaration: (node: ts.Identifier) => ts.Declaration | undefined;
   /** Module extern arguments must keep their exact branded parameter ABI. */
   readonly externCallArgumentsMatch: (call: ts.CallExpression | ts.NewExpression) => boolean;
   /** True when a value can cross an extern member boundary without GC-ref boxing. */
@@ -843,6 +845,24 @@ function localVariableDeclaration(node: ts.Identifier, checker: ts.TypeChecker):
   return candidates.find(
     (candidate): candidate is ts.VariableDeclaration =>
       candidate !== undefined && ts.isVariableDeclaration(candidate) && candidate.getSourceFile() === sourceFile,
+  );
+}
+
+function localValueDeclaration(node: ts.Identifier, checker: ts.TypeChecker): ts.Declaration | undefined {
+  const symbol = checker.getSymbolAtLocation(node);
+  if (!symbol) return undefined;
+  const sourceFile = node.getSourceFile();
+  const candidates = [symbol.valueDeclaration, ...(symbol.declarations ?? [])];
+  return candidates.find(
+    (
+      candidate,
+    ): candidate is ts.VariableDeclaration | ts.BindingElement | ts.ParameterDeclaration | ts.FunctionDeclaration =>
+      candidate !== undefined &&
+      candidate.getSourceFile() === sourceFile &&
+      (ts.isVariableDeclaration(candidate) ||
+        ts.isBindingElement(candidate) ||
+        ts.isParameter(candidate) ||
+        ts.isFunctionDeclaration(candidate)),
   );
 }
 
@@ -1911,6 +1931,13 @@ export function makeIrLegacyModuleBindingResolver(
         return undefined;
       }
     },
+    localValueDeclaration(node: ts.Identifier): ts.Declaration | undefined {
+      try {
+        return localValueDeclaration(node, checker);
+      } catch {
+        return undefined;
+      }
+    },
     externCallArgumentsMatch(call: ts.CallExpression | ts.NewExpression): boolean {
       try {
         const containsModuleExtern = (node: ts.Node): boolean => {
@@ -2194,6 +2221,10 @@ export function makeIrModuleBindingResolver(
       ownerAt(node);
       return legacy.localVariableDeclaration(node);
     },
+    localValueDeclaration(node: ts.Identifier): ts.Declaration | undefined {
+      ownerAt(node);
+      return legacy.localValueDeclaration(node);
+    },
     externCallArgumentsMatch(call: ts.CallExpression | ts.NewExpression): boolean {
       ownerAt(call);
       return legacy.externCallArgumentsMatch(call);
@@ -2319,6 +2350,7 @@ export function projectIrModuleBindingResolverToLegacy(
     isDirectModuleBinding: (node: ts.Identifier) => resolver.isDirectModuleBinding(node),
     isAmbientBinding: (node: ts.Identifier) => resolver.isAmbientBinding(node),
     localVariableDeclaration: (node: ts.Identifier) => resolver.localVariableDeclaration(node),
+    localValueDeclaration: (node: ts.Identifier) => resolver.localValueDeclaration(node),
     externCallArgumentsMatch: (call: ts.CallExpression | ts.NewExpression) => resolver.externCallArgumentsMatch(call),
     externValueIsPassable: (value: ts.Expression) => resolver.externValueIsPassable(value),
     scalarExpressionFamily: (expr: ts.Expression) => resolver.scalarExpressionFamily(expr),

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -4495,6 +4495,9 @@ function isPhase1VarDecl(stmt: ts.VariableStatement, scope: Set<string>, localCl
       // back to legacy.
       if (!isPhase1Expr(d.initializer, initializerScope, localClasses))
         return shapeNo("vardecl-dstr-init", d.initializer);
+      if (ts.isObjectBindingPattern(d.name)) {
+        recordDestructuredObjectMethodProjections(d.name, d.initializer, scope);
+      }
       // Pre-add every leaf identifier to scope so subsequent statements
       // see the new names.
       collectPatternNames(d.name, scope);
@@ -5336,6 +5339,15 @@ function isOptionalModuleExternCall(expr: ts.CallExpression): boolean {
     expr.expression.questionDotToken !== undefined &&
     expressionIsModuleExternAccessChain(expr.expression.expression)
   );
+}
+
+function phase1CallPreambleIsBuildable(expr: ts.CallExpression): boolean {
+  // AST-to-IR deliberately treats optional invocation as a hard invariant.
+  if (expr.questionDotToken) return shapeNo("expr-optional-call", expr);
+  if (currentModuleBindingResolver && !currentModuleBindingResolver.externCallArgumentsMatch(expr)) {
+    return shapeNo("expr-module-extern-call-brand", expr);
+  }
+  return !isOptionalModuleExternCall(expr) || shapeNo("expr-module-extern-optional-call", expr);
 }
 
 /** True when a method-call receiver ultimately comes from a module extern. */
@@ -6596,6 +6608,16 @@ type DirectObjectMethodValueProjection = {
   readonly returnType: ts.TypeNode | undefined;
 };
 
+type DirectObjectMethodReceiver = {
+  readonly declaration: ts.VariableDeclaration;
+  readonly object: ts.ObjectLiteralExpression;
+};
+
+type DirectDestructuredObjectMethodProjection = {
+  readonly element: ts.BindingElement & { readonly name: ts.Identifier };
+  readonly method: ts.MethodDeclaration;
+};
+
 /**
  * Resolve `const fn = object.method` against one exact preceding const object
  * literal. The declaration was already fully selector-certified in source
@@ -6609,7 +6631,36 @@ function directObjectMethodValueProjection(
 ): DirectObjectMethodValueProjection | null {
   const candidate = unwrapProjectionExpression(expression);
   if (!ts.isPropertyAccessExpression(candidate) || !ts.isIdentifier(candidate.name)) return null;
-  const receiver = unwrapProjectionExpression(candidate.expression);
+  const method = directObjectMethodDeclaration(candidate.expression, candidate.name.text, scope);
+  if (!method) return null;
+  return {
+    arity: exactCallableArity(method.parameters.length),
+    returnType: method.type,
+  };
+}
+
+/** Resolve one method on an exact preceding const all-shorthand-method object. */
+function directObjectMethodDeclaration(
+  receiverExpression: ts.Expression,
+  propertyName: string,
+  scope: ReadonlySet<string>,
+): ts.MethodDeclaration | null {
+  const resolved = directObjectMethodReceiver(receiverExpression, scope);
+  if (!resolved) return null;
+  const method = resolved.object.properties.find(
+    (property): property is ts.MethodDeclaration =>
+      ts.isMethodDeclaration(property) &&
+      property.name !== undefined &&
+      phase1PropertyName(property.name) === propertyName,
+  );
+  return method ?? null;
+}
+
+function directObjectMethodReceiver(
+  receiverExpression: ts.Expression,
+  scope: ReadonlySet<string>,
+): DirectObjectMethodReceiver | null {
+  const receiver = unwrapProjectionExpression(receiverExpression);
   if (!ts.isIdentifier(receiver) || !scope.has(receiver.text)) return null;
   const declaration = currentModuleBindingResolver?.localVariableDeclaration(receiver);
   if (!declaration || !declaration.initializer) return null;
@@ -6617,17 +6668,227 @@ function directObjectMethodValueProjection(
   if (!ts.isVariableDeclarationList(declarationList) || !(declarationList.flags & ts.NodeFlags.Const)) return null;
   const object = unwrapProjectionExpression(declaration.initializer);
   if (!ts.isObjectLiteralExpression(object) || !object.properties.every(ts.isMethodDeclaration)) return null;
-  const method = object.properties.find(
-    (property): property is ts.MethodDeclaration =>
-      ts.isMethodDeclaration(property) &&
-      property.name !== undefined &&
-      phase1PropertyName(property.name) === candidate.name.text,
+  return { declaration, object };
+}
+
+function localDeclarationsMatch(left: ts.Declaration, right: ts.Declaration): boolean {
+  return (
+    left === right ||
+    (left.pos === right.pos &&
+      left.end === right.end &&
+      left.getSourceFile().fileName === right.getSourceFile().fileName)
   );
-  if (!method) return null;
-  return {
-    arity: exactCallableArity(method.parameters.length),
-    returnType: method.type,
+}
+
+function enclosingProjectionOwner(node: ts.Node): ts.Node | undefined {
+  for (let current = node.parent; current; current = current.parent) {
+    if (isFunctionLike(current)) return current;
+  }
+  return undefined;
+}
+
+function propertyAccessIsWriteTarget(expression: ts.PropertyAccessExpression): boolean {
+  const parent = expression.parent;
+  return (
+    (ts.isBinaryExpression(parent) &&
+      parent.left === expression &&
+      parent.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+      parent.operatorToken.kind <= ts.SyntaxKind.LastAssignment) ||
+    ((ts.isPrefixUnaryExpression(parent) || ts.isPostfixUnaryExpression(parent)) && parent.operand === expression) ||
+    (ts.isDeleteExpression(parent) && parent.expression === expression) ||
+    ((ts.isForInStatement(parent) || ts.isForOfStatement(parent)) && parent.initializer === expression)
+  );
+}
+
+function objectBindingPatternReadsOnlyOwnMethods(
+  pattern: ts.ObjectBindingPattern,
+  ownMethodNames: ReadonlySet<string>,
+): boolean {
+  return pattern.elements.every((element) => {
+    if (element.dotDotDotToken || element.initializer || !ts.isIdentifier(element.name)) return false;
+    const propertyName = element.propertyName
+      ? ts.isIdentifier(element.propertyName) || ts.isStringLiteral(element.propertyName)
+        ? element.propertyName.text
+        : null
+      : element.name.text;
+    return propertyName !== null && ownMethodNames.has(propertyName);
+  });
+}
+
+/**
+ * The destructuring projection is sound only while the exact object binding
+ * remains local and immutable. Permit own-method reads and direct object
+ * destructuring; aliases, escapes, computed access, nested-owner uses, and
+ * writes all keep this new surface on the direct path.
+ */
+function directObjectMethodReceiverUsesAreStable(receiver: DirectObjectMethodReceiver): boolean {
+  const bindingName = receiver.declaration.name;
+  if (!ts.isIdentifier(bindingName)) return false;
+  const owner = enclosingProjectionOwner(receiver.declaration);
+  if (!owner) return false;
+  const ownMethodNames = new Set(
+    receiver.object.properties
+      .filter(ts.isMethodDeclaration)
+      .map((method) => (method.name ? phase1PropertyName(method.name) : null))
+      .filter((name): name is string => name !== null),
+  );
+  let stable = true;
+  const visit = (node: ts.Node): void => {
+    if (!stable) return;
+    if (ts.isIdentifier(node) && node !== bindingName && node.text === bindingName.text) {
+      if (!identifierIsValueReference(node)) return;
+      const declaration = currentModuleBindingResolver?.localValueDeclaration(node);
+      if (!declaration) {
+        stable = false;
+        return;
+      }
+      if (!localDeclarationsMatch(receiver.declaration, declaration)) return;
+      if (enclosingProjectionOwner(node) !== owner) {
+        stable = false;
+        return;
+      }
+      const parent = node.parent;
+      if (
+        ts.isPropertyAccessExpression(parent) &&
+        parent.expression === node &&
+        ownMethodNames.has(parent.name.text) &&
+        !propertyAccessIsWriteTarget(parent)
+      ) {
+        return;
+      }
+      if (
+        ts.isVariableDeclaration(parent) &&
+        parent.initializer === node &&
+        ts.isObjectBindingPattern(parent.name) &&
+        objectBindingPatternReadsOnlyOwnMethods(parent.name, ownMethodNames)
+      ) {
+        return;
+      }
+      stable = false;
+      return;
+    }
+    forEachChild(node, visit);
   };
+  forEachChild(owner, visit);
+  return stable;
+}
+
+/**
+ * Bound this new callable surface to immutable aliases and direct calls inside
+ * the declaring function. This excludes cross-owner capture, return/pass
+ * escapes, and mutation while still preserving same-owner const alias chains.
+ */
+function destructuredMethodAliasChainHasOnlyOwnerDirectCalls(element: ts.BindingElement): boolean {
+  if (!ts.isIdentifier(element.name)) return false;
+  const owner = enclosingProjectionOwner(element);
+  if (!owner || !currentModuleBindingResolver) return false;
+  const declarations = new Set<ts.Declaration>([element]);
+  const declarationNames = new Set<string>([element.name.text]);
+  let proofFailed = false;
+
+  let changed = true;
+  while (changed && !proofFailed) {
+    changed = false;
+    const collectAliases = (node: ts.Node): void => {
+      if (proofFailed) return;
+      if (ts.isIdentifier(node) && declarationNames.has(node.text) && identifierIsValueReference(node)) {
+        const source = currentModuleBindingResolver?.localValueDeclaration(node);
+        if (!source) {
+          proofFailed = true;
+          return;
+        }
+        if (source && localClosureDeclarationsContain(declarations, source)) {
+          const declaration = node.parent;
+          const list = ts.isVariableDeclaration(declaration) ? declaration.parent : undefined;
+          if (
+            ts.isVariableDeclaration(declaration) &&
+            declaration.initializer === node &&
+            ts.isIdentifier(declaration.name) &&
+            list !== undefined &&
+            ts.isVariableDeclarationList(list) &&
+            !!(list.flags & ts.NodeFlags.Const) &&
+            !localClosureDeclarationsContain(declarations, declaration)
+          ) {
+            declarations.add(declaration);
+            declarationNames.add(declaration.name.text);
+            changed = true;
+          }
+        }
+      }
+      forEachChild(node, collectAliases);
+    };
+    forEachChild(owner, collectAliases);
+  }
+  if (proofFailed) return false;
+
+  let accepted = true;
+  const validateUses = (node: ts.Node): void => {
+    if (!accepted) return;
+    if (ts.isIdentifier(node) && declarationNames.has(node.text) && identifierIsValueReference(node)) {
+      const declaration = currentModuleBindingResolver?.localValueDeclaration(node);
+      if (!declaration) {
+        accepted = false;
+        return;
+      }
+      if (localClosureDeclarationsContain(declarations, declaration)) {
+        if (enclosingProjectionOwner(node) !== owner) {
+          accepted = false;
+          return;
+        }
+        const parent = node.parent;
+        if (
+          (ts.isVariableDeclaration(parent) &&
+            parent.initializer === node &&
+            localClosureDeclarationsContain(declarations, parent)) ||
+          (ts.isCallExpression(parent) && parent.expression === node && parent.questionDotToken === undefined)
+        ) {
+          return;
+        }
+        accepted = false;
+        return;
+      }
+    }
+    forEachChild(node, validateUses);
+  };
+  forEachChild(owner, validateUses);
+  return accepted;
+}
+
+/** Certify the entire pattern before exposing any callable projection. */
+function directDestructuredObjectMethodProjections(
+  pattern: ts.ObjectBindingPattern,
+  initializer: ts.Expression,
+  scope: ReadonlySet<string>,
+): readonly DirectDestructuredObjectMethodProjection[] | null {
+  const receiver = directObjectMethodReceiver(initializer, scope);
+  if (!receiver || !directObjectMethodReceiverUsesAreStable(receiver)) return null;
+  const projections: DirectDestructuredObjectMethodProjection[] = [];
+  for (const element of pattern.elements) {
+    if (!ts.isIdentifier(element.name)) return null;
+    const propertyName = element.propertyName
+      ? ts.isIdentifier(element.propertyName) || ts.isStringLiteral(element.propertyName)
+        ? element.propertyName.text
+        : null
+      : element.name.text;
+    if (propertyName === null || !destructuredMethodAliasChainHasOnlyOwnerDirectCalls(element)) return null;
+    const method = directObjectMethodDeclaration(initializer, propertyName, scope);
+    if (!method) return null;
+    projections.push({ element: element as ts.BindingElement & { readonly name: ts.Identifier }, method });
+  }
+  return projections.length > 0 ? projections : null;
+}
+
+/** Carry exact method signatures through `const { method: local } = object`. */
+function recordDestructuredObjectMethodProjections(
+  pattern: ts.ObjectBindingPattern,
+  initializer: ts.Expression,
+  scope: ReadonlySet<string>,
+): void {
+  const projections = directDestructuredObjectMethodProjections(pattern, initializer, scope);
+  if (!projections) return;
+  for (const { element, method } of projections) {
+    recordCallableProjection(element.name.text, method.parameters.length, method.type);
+  }
 }
 
 function directCallParamUsesNumericVecAbi(
@@ -7056,12 +7317,7 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     );
   }
   if (ts.isCallExpression(expr)) {
-    if (currentModuleBindingResolver && !currentModuleBindingResolver.externCallArgumentsMatch(expr)) {
-      return shapeNo("expr-module-extern-call-brand", expr);
-    }
-    if (isOptionalModuleExternCall(expr)) {
-      return shapeNo("expr-module-extern-optional-call", expr);
-    }
+    if (!phase1CallPreambleIsBuildable(expr)) return false;
     const indirectEvalStatement = exactIndirectEvalStatement(expr);
     if (indirectEvalStatement) {
       const certified = certifiedHostIndirectEval(expr, scope);
@@ -8247,10 +8503,11 @@ export function buildLocalCallGraph(
             return;
           }
           const callee = node.expression.text;
-          const localVariable = currentModuleBindingResolver?.localVariableDeclaration(node.expression);
+          const localDeclaration = currentModuleBindingResolver?.localValueDeclaration(node.expression);
           if (
-            localBindings.names.has(callee) ||
-            (localVariable !== undefined && localClosureDeclarationsContain(localBindings.declarations, localVariable))
+            (currentModuleBindingResolver === null && localBindings.names.has(callee)) ||
+            (localDeclaration !== undefined &&
+              localClosureDeclarationsContain(localBindings.declarations, localDeclaration))
           ) {
             // Slice 3: closure / nested-fn binding within this outer.
             // Variable-backed callables use checker-resolved declaration
@@ -8441,11 +8698,11 @@ function collectLocalClassDeclarations(
  */
 function collectLocalClosureBindings(fn: ts.FunctionDeclaration): {
   readonly names: Set<string>;
-  readonly declarations: Set<ts.VariableDeclaration>;
+  readonly declarations: Set<ts.Declaration>;
 } {
   const names = new Set<string>();
   const materializableNames = new Set<string>();
-  const declarations = new Set<ts.VariableDeclaration>();
+  const declarations = new Set<ts.Declaration>();
   if (!fn.body) return { names, declarations };
   const localValueNames = new Set<string>();
   for (const parameter of fn.parameters) collectBindingNameTexts(parameter.name, localValueNames);
@@ -8473,6 +8730,7 @@ function collectLocalClosureBindings(fn: ts.FunctionDeclaration): {
     ) {
       names.add(p.name.text);
       materializableNames.add(p.name.text);
+      declarations.add(p);
     }
   }
   // Top-level walk: only direct children of the outer body. Nested
@@ -8485,24 +8743,37 @@ function collectLocalClosureBindings(fn: ts.FunctionDeclaration): {
   const visit = (node: ts.Node): void => {
     if (ts.isFunctionDeclaration(node) && node !== fn && node.name) {
       names.add(node.name.text);
+      declarations.add(node);
       return;
     }
     if (node !== fn && isFunctionLike(node)) return;
     if (ts.isVariableStatement(node)) {
       const isConst = !!(node.declarationList.flags & ts.NodeFlags.Const);
       for (const d of node.declarationList.declarations) {
-        if (!ts.isIdentifier(d.name) || !d.initializer) continue;
+        if (!d.initializer) continue;
+        if (ts.isObjectBindingPattern(d.name) && isConst) {
+          const projections = directDestructuredObjectMethodProjections(d.name, d.initializer, localValueNames);
+          if (projections) {
+            for (const { element } of projections) {
+              names.add(element.name.text);
+              materializableNames.add(element.name.text);
+              declarations.add(element);
+            }
+          }
+          continue;
+        }
+        if (!ts.isIdentifier(d.name)) continue;
         const literal = ts.isArrowFunction(d.initializer) || ts.isFunctionExpression(d.initializer);
         const objectMethodValue = isConst && directObjectMethodValueProjection(d.initializer, localValueNames) !== null;
         const aliasInitializer = unwrapProjectionExpression(d.initializer);
         const aliasDeclaration = ts.isIdentifier(aliasInitializer)
-          ? currentModuleBindingResolver?.localVariableDeclaration(aliasInitializer)
+          ? currentModuleBindingResolver?.localValueDeclaration(aliasInitializer)
           : undefined;
         const callableAlias =
           isConst &&
           ts.isIdentifier(aliasInitializer) &&
           ((aliasDeclaration !== undefined && localClosureDeclarationsContain(declarations, aliasDeclaration)) ||
-            materializableNames.has(aliasInitializer.text));
+            (currentModuleBindingResolver === null && materializableNames.has(aliasInitializer.text)));
         // Literal closures retain the existing const-only rule. A direct
         // returned-callable binding already passed the ordinary variable
         // statement shape walk for var/let as well; an exact const
@@ -8517,6 +8788,8 @@ function collectLocalClosureBindings(fn: ts.FunctionDeclaration): {
           callableAlias ||
           directReturnedCallableSignature(d.initializer, localValueNames) !== null
         ) {
+          names.add(d.name.text);
+          materializableNames.add(d.name.text);
           declarations.add(d);
         }
       }
@@ -8533,8 +8806,8 @@ function collectLocalClosureBindings(fn: ts.FunctionDeclaration): {
  * identity, while still excluding unrelated same-text bindings.
  */
 function localClosureDeclarationsContain(
-  declarations: ReadonlySet<ts.VariableDeclaration>,
-  candidate: ts.VariableDeclaration,
+  declarations: ReadonlySet<ts.Declaration>,
+  candidate: ts.Declaration,
 ): boolean {
   for (const declaration of declarations) {
     if (declaration === candidate) return true;

--- a/tests/issue-3522-ir-object-method-call-ownership.test.ts
+++ b/tests/issue-3522-ir-object-method-call-ownership.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { compile, type CompileResult, type IrObservedOutcome } from "../src/index.js";
+import { compile, createIncrementalCompiler, type CompileResult, type IrObservedOutcome } from "../src/index.js";
 import { buildImports } from "../src/runtime.js";
 
 const TARGETS = ["gc", "standalone"] as const;
@@ -37,6 +37,30 @@ export function run(input: number): number {
   };
   const add = operations.add;
   const alias = add;
+  const invoke = alias;
+  return invoke(input);
+}
+`;
+
+const DESTRUCTURED_METHOD_VALUE_SOURCE = `
+export function run(input: number): number {
+  const offset: number = 2;
+  const operations = {
+    add(value: number): number { return value - offset; }
+  };
+  const { add } = operations;
+  return add(input);
+}
+`;
+
+const RENAMED_DESTRUCTURED_METHOD_VALUE_SOURCE = `
+export function run(input: number): number {
+  const offset: number = 2;
+  const operations = {
+    add(value: number): number { return value + offset; }
+  };
+  const { add: selected } = operations;
+  const alias = selected;
   const invoke = alias;
   return invoke(input);
 }
@@ -202,6 +226,94 @@ describe("#3522 object-method call ownership", () => {
     expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
   });
 
+  it.each(TARGETS)("prepares a destructured exact object-method value in the %s lane", async (target) => {
+    const direct = await compile(DESTRUCTURED_METHOD_VALUE_SOURCE, {
+      fileName: `object-method-value-destructured-direct-${target}.ts`,
+      emitWat: true,
+      experimentalIR: false,
+      optimize: true,
+      target,
+    });
+    const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run,run__closure_0";
+      prepared = await compile(DESTRUCTURED_METHOD_VALUE_SOURCE, {
+        fileName: `object-method-value-destructured-prepared-${target}.ts`,
+        emitWat: true,
+        experimentalIR: true,
+        optimize: true,
+        target,
+        trackIrOutcomes: true,
+      });
+    } finally {
+      if (previousPoison === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!(40)).toBe(38);
+    }
+    expect(outcome(prepared)).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["run", "run__closure_0"]));
+    expect(prepared.wat).toContain("call_ref");
+    expect(prepared.wat).not.toContain("__call_m_");
+    expectNoImportRegression(direct, prepared, target);
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+  });
+
+  it.each(TARGETS)("preserves a renamed destructured method through const aliases in the %s lane", async (target) => {
+    const direct = await compile(RENAMED_DESTRUCTURED_METHOD_VALUE_SOURCE, {
+      fileName: `object-method-value-destructured-alias-direct-${target}.ts`,
+      emitWat: true,
+      experimentalIR: false,
+      optimize: true,
+      target,
+    });
+    const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run,run__closure_0";
+      prepared = await compile(RENAMED_DESTRUCTURED_METHOD_VALUE_SOURCE, {
+        fileName: `object-method-value-destructured-alias-prepared-${target}.ts`,
+        emitWat: true,
+        experimentalIR: true,
+        optimize: true,
+        target,
+        trackIrOutcomes: true,
+      });
+    } finally {
+      if (previousPoison === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!(40)).toBe(42);
+    }
+    expect(outcome(prepared)).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["run", "run__closure_0"]));
+    expect(prepared.wat).toContain("call_ref");
+    expect(prepared.wat).not.toContain("__call_m_");
+    expectNoImportRegression(direct, prepared, target);
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+  });
+
   it("keeps mutable object-method value aliases on the direct path", async () => {
     const result = await compile(
       `export function run(input: number): number {
@@ -259,6 +371,234 @@ describe("#3522 object-method call ownership", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
+  it("keeps destructuring through an untracked object alias on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const copy = operations;
+        const { add } = copy;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-object-alias-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      code: "call-resolution-unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps mixed exact and inherited destructuring atomic on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add, toString } = operations;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-mixed-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps receiver-wide destructuring atomic across declarations", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { toString } = operations;
+        const { add } = operations;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-receiver-atomic-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps optional calls through destructured methods on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        add?.(input);
+        return 42;
+      }`,
+      {
+        fileName: "object-method-value-destructured-optional-call-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("does not let a later destructured projection mask an earlier optional call", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const other = (value: number): number => value + 1;
+        other?.(input);
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        operations.add?.(input);
+        const { add } = operations;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-prior-optional-call-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      code: "body-shape-rejected",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps destructured method values captured by nested closures on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const invoke = (value: number): number => add(value);
+        return invoke(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-captured-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps captured destructured method alias chains on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const selected = add;
+        const invoke = (value: number): number => selected(value);
+        return invoke(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-alias-captured-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps reassigned method fields destructured later on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 1; }
+        };
+        operations.add = (value: number): number => value + 2;
+        const { add } = operations;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-reassigned-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
   it("keeps a bare nested-function alias on the direct path", async () => {
     const result = await compile(
       `export function run(input: number): number {
@@ -285,32 +625,50 @@ describe("#3522 object-method call ownership", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it("does not let a block-local callable alias hide a later ambient call", async () => {
-    const result = await compile(
-      `export function run(input: number): number {
-        for (let i: number = 0; i < 1; i++) {
-          const local = (value: number): number => value + 1;
-          const parseInt = local;
-          parseInt(input);
-        }
-        return parseInt("42");
-      }`,
+  it("does not let a block-local destructured method hide a later ambient call after compiler reuse", async () => {
+    const source = `export function run(input: number): number {
       {
-        fileName: "block-local-callable-alias-shadow.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      },
-    );
+        const operations = {
+          add(value: number): number { return value + 1; }
+        };
+        const { add: parseInt } = operations;
+        parseInt(input);
+      }
+      return parseInt("42");
+    }`;
+    const options = {
+      fileName: "block-local-destructured-method-shadow.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    } as const;
 
-    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-    expect((await instantiate(result)).run!(0)).toBe(42);
-    expect(outcome(result)).toMatchObject({
-      kind: "unsupported",
-      stage: "select",
-      legacyBodyEmitted: true,
-      irBodyEmitted: false,
-    });
-    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    const fresh = await compile(source, options);
+    const compiler = createIncrementalCompiler(options);
+    try {
+      const contaminant = source
+        .replace("add(value", "sub(value")
+        .replace("{ add: parseInt }", "{ sub: parseNum }")
+        .replace("parseInt(input)", "parseNum(input)");
+      const warmup = await compiler.compile(contaminant);
+      expect(warmup.success, warmup.errors.map((error) => error.message).join("\n")).toBe(true);
+      const warmed = await compiler.compile(source);
+      const reused = await compiler.compile(source);
+      for (const result of [fresh, warmed, reused]) {
+        expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect((await instantiate(result)).run!(0)).toBe(42);
+        expect(outcome(result)).toMatchObject({
+          kind: "unsupported",
+          stage: "select",
+          legacyBodyEmitted: true,
+          irBodyEmitted: false,
+        });
+        expect(result.irPostClaimErrors ?? []).toEqual([]);
+      }
+      expect(Buffer.from(warmed.binary)).toEqual(Buffer.from(fresh.binary));
+      expect(Buffer.from(reused.binary)).toEqual(Buffer.from(fresh.binary));
+    } finally {
+      compiler.dispose();
+    }
   });
 
   it("keeps receiver-sensitive object methods on the direct path", async () => {


### PR DESCRIPTION
## Summary

- prepare exact const object-method values reached through object binding patterns, renaming, and immutable same-owner alias chains
- use checker-resolved declaration identity in selection and call-graph ownership, including changed incremental Program snapshots
- require an atomic own-method pattern, an unwritten and unescaped receiver, and direct non-optional same-owner calls; unsupported mutation, capture, escape, inherited fields, and optional invocation remain typed direct fallbacks
- record the checkpoint and remaining boundary in `plan/issues/3522-ir-r3-classes-closures-compile-once.md`

## Optimization parity

- `{ add }`, GC: 3,306 direct bytes -> 2,262 IR bytes; IR removes the throw-type-error import
- `{ add }`, standalone: 6,830 -> 5,893 bytes; zero imports in both
- renamed binding plus two const aliases, GC: 3,419 -> 2,262 bytes; IR removes generic call/array and throw-type-error imports
- renamed binding plus aliases, standalone: 6,830 -> 5,893 bytes; zero imports in both
- admitted WAT uses `call_ref`, contains no `__call_m_*`, and poison proves both source and lifted bodies are IR-owned

## Validation

- focused object-method ownership: 24/24
- adjacent closure/object matrix: 46/46
- equivalence: 1,645 passing, 24 known failures, 12 baseline improvements, zero new regressions
- hybrid and strict IR-only shadow: 37/37 IR, zero legacy bodies, zero Unsupported, zero Invariants
- cross-backend differential: 29/29
- native-first host-import policy: 379 imports, zero legacy-semantic, zero unknown
- typecheck, formatting, fallback, LOC/function budgets, oracle, coercion-site, issue-integrity, and pre-push gates pass

## Remaining boundary

Cross-owner method values and general callable escapes still need a planned capture/runtime-value ABI. Receiver-sensitive methods, accessors, mixed/open objects, mutable callable fields, and optional calls remain direct and are not deleted by this checkpoint.