### PR TITLE
feat(ir): prepare one-hop object method aliases

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -2106,3 +2106,60 @@ escapes still require a planned capture/runtime-value ABI before admission.
 Receiver-sensitive methods, accessors, mixed/open objects, optional calls, and
 mutable callable fields remain explicit later families; their live direct
 implementations cannot be deleted at this checkpoint.
+
+### One-hop object-alias destructuring checkpoint (2026-08-13)
+
+The destructuring-only projection now follows exactly one immutable local
+object alias: `const copy = operations; const { add } = copy; add(input)`. The
+root remains an exact preceding `const` all-method object literal, and both the
+root and alias are resolved by declaration identity in the same lexical owner
+and in source order. General property reads through aliases are deliberately
+unchanged; this does not admit `copy.add` as a new callable-value family.
+
+The proof is receiver-wide and fail-closed. It scans both identities and
+permits exactly the selected root-to-alias edge plus represented own-method
+destructures. Mutation through either name, a mutable or second alias, another
+independent alias of the same root, escape, shorthand storage, nested capture,
+unsafe sibling destructuring, computed access, optional invocation, an
+unresolved checker reference, or changed-snapshot shadowing keeps the complete
+function on the direct path with zero post-claim errors. A static binding key
+whose spelling collides with the alias is correctly treated as a property key,
+not a value read; `const { copy: invoke } = copy` is an explicit positive
+control.
+
+No AST-to-IR, Program ABI, runtime, or Wasm lowering change is needed. The
+ordinary alias retains the same closed object SSA value, destructuring uses the
+existing closure-valued `object.get`, and invocation remains a typed
+`call_ref`. Direct-body poison proves the owner and lifted method are both
+IR-emitted with no legacy body in GC and standalone. The focused suite is
+**39/39** and the adjacent eight-file closure/object matrix is **77/77**.
+Hybrid and strict IR-only shadow
+validation remain **37/37 IR bodies, 0 legacy bodies, 0 Unsupported, and 0
+Invariants**; the fallback ratchet remains clean with only the two existing
+deferred string-builder candidates. Cross-backend differential coverage is
+**29/29** and native-first host-import policy remains **379 imports, 0
+legacy-semantic, and 0 unknown**. Full equivalence reports **1,645 passing, 24
+known failures, 12 baseline cases now passing, and zero new regressions**.
+Typecheck, lint, formatting, LOC/function budgets, oracle, coercion-site, issue,
+and optimization-retirement gates are green.
+
+Optimization parity is explicit rather than inferred. The admitted alias
+artifact validates, returns 42, uses `call_ref`, contains no `__call_m_*`
+dispatcher, and introduces no import absent from the direct control. GC keeps
+exactly the box/unbox imports and standalone remains zero-import. In each
+target the optimized IR binary is byte-for-byte identical to the equivalent
+IR source without the object alias (**2,262 bytes GC; 5,893 standalone**) and
+smaller than direct (**3,306 bytes GC; 6,830 standalone**), proving that the
+source-level alias is erased without losing the existing optimization.
+
+Next resumable R3 slice: migrate the existing destructured method captured by
+a nested closure. The value flow and typed closure call already lower through
+IR; the remaining preparation blocker is that `prepareClosureTransaction` does
+not yet pass its `ClosureStructRegistry` while resolving closure-valued capture
+fields. Bootstrap that registry, preserve the canonical closure wrapper-root
+reference in the capture ABI, then convert the existing negative fixture with
+poison/parity/size/import coverage. This should move one focused terminal body
+from legacy to IR. Bare nested-function values, receiver-sensitive methods,
+accessors, mutable callable slots, optional calls, and broader escapes remain
+later families. No shared direct implementation has zero consumers at this
+checkpoint, so none is deleted here.

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -6613,6 +6613,11 @@ type DirectObjectMethodReceiver = {
   readonly object: ts.ObjectLiteralExpression;
 };
 
+type DirectDestructuredObjectMethodReceiver = {
+  readonly root: DirectObjectMethodReceiver;
+  readonly alias: ts.VariableDeclaration | null;
+};
+
 type DirectDestructuredObjectMethodProjection = {
   readonly element: ts.BindingElement & { readonly name: ts.Identifier };
   readonly method: ts.MethodDeclaration;
@@ -6669,6 +6674,50 @@ function directObjectMethodReceiver(
   const object = unwrapProjectionExpression(declaration.initializer);
   if (!ts.isObjectLiteralExpression(object) || !object.properties.every(ts.isMethodDeclaration)) return null;
   return { declaration, object };
+}
+
+/**
+ * Resolve the direct receiver used by destructuring, or one exact preceding
+ * `const alias = receiver` edge. Keep this separate from the general receiver
+ * resolver: property reads through object aliases are a wider callable-value
+ * surface and need their own ownership proof.
+ */
+function directDestructuredObjectMethodReceiver(
+  receiverExpression: ts.Expression,
+  scope: ReadonlySet<string>,
+): DirectDestructuredObjectMethodReceiver | null {
+  const direct = directObjectMethodReceiver(receiverExpression, scope);
+  if (direct) return { root: direct, alias: null };
+
+  const receiver = unwrapProjectionExpression(receiverExpression);
+  if (!ts.isIdentifier(receiver) || !scope.has(receiver.text) || !currentModuleBindingResolver) return null;
+  const alias = currentModuleBindingResolver.localVariableDeclaration(receiver);
+  if (!alias || !ts.isIdentifier(alias.name) || !alias.initializer || !ts.isIdentifier(alias.initializer)) return null;
+  const declarationList = alias.parent;
+  if (!ts.isVariableDeclarationList(declarationList) || !(declarationList.flags & ts.NodeFlags.Const)) return null;
+  const root = directObjectMethodReceiver(alias.initializer, scope);
+  if (!root) return null;
+  const resolvedRoot = currentModuleBindingResolver.localValueDeclaration(alias.initializer);
+  const resolvedAlias = currentModuleBindingResolver.localValueDeclaration(receiver);
+  if (
+    !resolvedRoot ||
+    !resolvedAlias ||
+    !localDeclarationsMatch(root.declaration, resolvedRoot) ||
+    !localDeclarationsMatch(alias, resolvedAlias)
+  ) {
+    return null;
+  }
+  const owner = enclosingProjectionOwner(root.declaration);
+  if (
+    !owner ||
+    enclosingProjectionOwner(alias) !== owner ||
+    enclosingProjectionOwner(receiver) !== owner ||
+    root.declaration.end > alias.pos ||
+    alias.end > receiver.pos
+  ) {
+    return null;
+  }
+  return { root, alias };
 }
 
 function localDeclarationsMatch(left: ts.Declaration, right: ts.Declaration): boolean {
@@ -6749,6 +6798,81 @@ function directObjectMethodReceiverUsesAreStable(receiver: DirectObjectMethodRec
       }
       const parent = node.parent;
       if (
+        ts.isPropertyAccessExpression(parent) &&
+        parent.expression === node &&
+        ownMethodNames.has(parent.name.text) &&
+        !propertyAccessIsWriteTarget(parent)
+      ) {
+        return;
+      }
+      if (
+        ts.isVariableDeclaration(parent) &&
+        parent.initializer === node &&
+        ts.isObjectBindingPattern(parent.name) &&
+        objectBindingPatternReadsOnlyOwnMethods(parent.name, ownMethodNames)
+      ) {
+        return;
+      }
+      stable = false;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(owner, visit);
+  return stable;
+}
+
+/**
+ * Certify a destructuring-only object alias atomically with its root. The root
+ * may have its existing safe own-method reads/destructures plus this one alias
+ * edge; the alias itself may only feed safe own-method destructures. A second
+ * alias, escape, write, computed access, nested-owner capture, or unresolved
+ * checker reference rejects the complete projection family.
+ */
+function directDestructuredObjectMethodReceiverUsesAreStable(
+  receiver: DirectDestructuredObjectMethodReceiver,
+): boolean {
+  if (!receiver.alias) return directObjectMethodReceiverUsesAreStable(receiver.root);
+  const rootName = receiver.root.declaration.name;
+  const aliasName = receiver.alias.name;
+  if (!ts.isIdentifier(rootName) || !ts.isIdentifier(aliasName)) return false;
+  const owner = enclosingProjectionOwner(receiver.root.declaration);
+  if (!owner || enclosingProjectionOwner(receiver.alias) !== owner) return false;
+  const ownMethodNames = new Set(
+    receiver.root.object.properties
+      .filter(ts.isMethodDeclaration)
+      .map((method) => (method.name ? phase1PropertyName(method.name) : null))
+      .filter((name): name is string => name !== null),
+  );
+  let stable = true;
+  const visit = (node: ts.Node): void => {
+    if (!stable) return;
+    if (
+      ts.isIdentifier(node) &&
+      node !== rootName &&
+      node !== aliasName &&
+      (node.text === rootName.text || node.text === aliasName.text) &&
+      identifierIsValueReference(node)
+    ) {
+      if (ts.isBindingElement(node.parent) && node.parent.propertyName === node) return;
+      const declaration = currentModuleBindingResolver?.localValueDeclaration(node);
+      if (!declaration) {
+        stable = false;
+        return;
+      }
+      const isRoot = localDeclarationsMatch(receiver.root.declaration, declaration);
+      const isAlias = localDeclarationsMatch(receiver.alias!, declaration);
+      if (!isRoot && !isAlias) return;
+      if (enclosingProjectionOwner(node) !== owner) {
+        stable = false;
+        return;
+      }
+      const parent = node.parent;
+      if (isRoot && ts.isVariableDeclaration(parent) && parent === receiver.alias && parent.initializer === node) {
+        return;
+      }
+      if (
+        isRoot &&
         ts.isPropertyAccessExpression(parent) &&
         parent.expression === node &&
         ownMethodNames.has(parent.name.text) &&
@@ -6860,8 +6984,8 @@ function directDestructuredObjectMethodProjections(
   initializer: ts.Expression,
   scope: ReadonlySet<string>,
 ): readonly DirectDestructuredObjectMethodProjection[] | null {
-  const receiver = directObjectMethodReceiver(initializer, scope);
-  if (!receiver || !directObjectMethodReceiverUsesAreStable(receiver)) return null;
+  const receiver = directDestructuredObjectMethodReceiver(initializer, scope);
+  if (!receiver || !directDestructuredObjectMethodReceiverUsesAreStable(receiver)) return null;
   const projections: DirectDestructuredObjectMethodProjection[] = [];
   for (const element of pattern.elements) {
     if (!ts.isIdentifier(element.name)) return null;
@@ -6871,7 +6995,12 @@ function directDestructuredObjectMethodProjections(
         : null
       : element.name.text;
     if (propertyName === null || !destructuredMethodAliasChainHasOnlyOwnerDirectCalls(element)) return null;
-    const method = directObjectMethodDeclaration(initializer, propertyName, scope);
+    const method = receiver.root.object.properties.find(
+      (property): property is ts.MethodDeclaration =>
+        ts.isMethodDeclaration(property) &&
+        property.name !== undefined &&
+        phase1PropertyName(property.name) === propertyName,
+    );
     if (!method) return null;
     projections.push({ element: element as ts.BindingElement & { readonly name: ts.Identifier }, method });
   }

--- a/tests/issue-3522-ir-object-method-call-ownership.test.ts
+++ b/tests/issue-3522-ir-object-method-call-ownership.test.ts
@@ -66,6 +66,40 @@ export function run(input: number): number {
 }
 `;
 
+const OBJECT_ALIAS_DESTRUCTURED_METHOD_VALUE_SOURCE = `
+export function run(input: number): number {
+  const offset: number = 2;
+  const operations = {
+    add(value: number): number { return value + offset; }
+  };
+  const copy = operations;
+  const { add } = copy;
+  return add(input);
+}
+`;
+
+const NO_OBJECT_ALIAS_DESTRUCTURED_METHOD_VALUE_SOURCE = `
+export function run(input: number): number {
+  const offset: number = 2;
+  const operations = {
+    add(value: number): number { return value + offset; }
+  };
+  const { add } = operations;
+  return add(input);
+}
+`;
+
+const COLLIDING_OBJECT_ALIAS_AND_METHOD_NAME_SOURCE = `
+export function run(input: number): number {
+  const operations = {
+    copy(value: number): number { return value + 2; }
+  };
+  const copy = operations;
+  const { copy: invoke } = copy;
+  return invoke(input);
+}
+`;
+
 function outcome(result: CompileResult): IrObservedOutcome {
   const observed = (result.irOutcomes ?? []).filter((candidate) => candidate.displayName === "run");
   expect(observed).toHaveLength(1);
@@ -371,33 +405,496 @@ describe("#3522 object-method call ownership", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it("keeps destructuring through an untracked object alias on the direct path", async () => {
+  it.each(TARGETS)(
+    "prepares a destructured method through one immutable object alias in the %s lane",
+    async (target) => {
+      const direct = await compile(OBJECT_ALIAS_DESTRUCTURED_METHOD_VALUE_SOURCE, {
+        fileName: `object-method-value-destructured-object-alias-direct-${target}.ts`,
+        emitWat: true,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      let noAliasControl: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run,run__closure_0";
+        prepared = await compile(OBJECT_ALIAS_DESTRUCTURED_METHOD_VALUE_SOURCE, {
+          fileName: `object-method-value-destructured-object-alias-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+        noAliasControl = await compile(NO_OBJECT_ALIAS_DESTRUCTURED_METHOD_VALUE_SOURCE, {
+          fileName: `object-method-value-destructured-no-object-alias-control-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
+
+      for (const compiled of [direct, prepared, noAliasControl]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      for (const compiled of [prepared, noAliasControl]) {
+        expect(outcome(compiled)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+          preparedComponentId: expect.stringMatching(/^prepared-component:/),
+        });
+        expect(compiled.irPostClaimErrors ?? []).toEqual([]);
+        expect(compiled.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["run", "run__closure_0"]));
+      }
+      expect(prepared.wat).toContain("call_ref");
+      expect(prepared.wat).not.toContain("__call_m_");
+      expectNoImportRegression(direct, prepared, target);
+      const exactPreparedImports = target === "gc" ? ["env::__box_number", "env::__unbox_number"] : [];
+      expect(importLabels(prepared)).toEqual(exactPreparedImports);
+      expect(importLabels(noAliasControl)).toEqual(exactPreparedImports);
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+      expect(Buffer.from(prepared.binary)).toEqual(Buffer.from(noAliasControl.binary));
+    },
+  );
+
+  it.each(TARGETS)(
+    "distinguishes a method property name from its colliding object alias in the %s lane",
+    async (target) => {
+      const direct = await compile(COLLIDING_OBJECT_ALIAS_AND_METHOD_NAME_SOURCE, {
+        fileName: `object-method-value-destructured-object-alias-name-collision-direct-${target}.ts`,
+        emitWat: true,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run,run__closure_0";
+        prepared = await compile(COLLIDING_OBJECT_ALIAS_AND_METHOD_NAME_SOURCE, {
+          fileName: `object-method-value-destructured-object-alias-name-collision-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
+
+      for (const compiled of [direct, prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      expect(outcome(prepared)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["run", "run__closure_0"]));
+      expect(prepared.wat).toContain("call_ref");
+      expect(prepared.wat).not.toContain("__call_m_");
+      expectNoImportRegression(direct, prepared, target);
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
+
+  it("keeps destructuring through a mutable object alias on the direct path", async () => {
     const result = await compile(
       `export function run(input: number): number {
         const operations = {
           add(value: number): number { return value + 2; }
         };
-        const copy = operations;
+        let copy = operations;
         const { add } = copy;
         return add(input);
       }`,
       {
-        fileName: "object-method-value-destructured-object-alias-direct.ts",
+        fileName: "object-method-value-destructured-let-object-alias-direct.ts",
         experimentalIR: true,
         trackIrOutcomes: true,
       },
     );
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
     expect((await instantiate(result)).run!(40)).toBe(42);
     expect(outcome(result)).toMatchObject({
       kind: "unsupported",
-      code: "call-resolution-unsupported",
       stage: "select",
       legacyBodyEmitted: true,
       irBodyEmitted: false,
     });
     expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("does not widen property-value projection through an object alias", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const copy = operations;
+        const add = copy.add;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-property-through-object-alias-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps method writes through an object alias on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 1; }
+        };
+        const copy = operations;
+        copy.add = (value: number): number => value + 2;
+        const { add } = copy;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-written-object-alias-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps an object alias captured by a nested closure on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const copy = operations;
+        const invoke = (value: number): number => {
+          const { add } = copy;
+          return add(value);
+        };
+        return invoke(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-captured-object-alias-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps a second object alias before destructuring on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const copy = operations;
+        const second = copy;
+        const { add } = second;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-second-object-alias-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps root method writes after aliasing on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 1; }
+        };
+        const copy = operations;
+        operations.add = (value: number): number => value + 2;
+        const { add } = copy;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-root-written-after-alias-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps a root captured after aliasing on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const copy = operations;
+        const observe = (): number => operations.add(input);
+        observe();
+        const { add } = copy;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-root-captured-after-alias-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps an object alias escaped through shorthand on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const copy = operations;
+        const escaped = { copy };
+        const { add } = copy;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-object-alias-shorthand-escape-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps an unsafe sibling destructure through the root on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { toString } = operations;
+        const copy = operations;
+        const { add } = copy;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-root-unsafe-sibling-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps an unsafe sibling destructure through the alias on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const copy = operations;
+        const { toString } = copy;
+        const { add } = copy;
+        return add(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-alias-unsafe-sibling-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps two independent aliases of the same root on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const first = operations;
+        const second = operations;
+        const { add } = first;
+        const { add: again } = second;
+        return add(input) + again(0) - 2;
+      }`,
+      {
+        fileName: "object-method-value-destructured-two-root-aliases-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("does not reuse a certified alias for a mutable block-local shadow after a changed snapshot", async () => {
+    const source = `export function run(input: number): number {
+      {
+        const operations = {
+          add(value: number): number { return value + 1; }
+        };
+        let copy = operations;
+        const { add } = copy;
+        add(input);
+      }
+      const operations = {
+        add(value: number): number { return value + 2; }
+      };
+      const copy = operations;
+      const { add } = copy;
+      return add(input);
+    }`;
+    const options = {
+      fileName: "object-method-value-destructured-object-alias-shadow-reuse.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    } as const;
+
+    const fresh = await compile(source, options);
+    const compiler = createIncrementalCompiler(options);
+    try {
+      const warmup = await compiler.compile(OBJECT_ALIAS_DESTRUCTURED_METHOD_VALUE_SOURCE);
+      expect(warmup.success, warmup.errors.map((error) => error.message).join("\n")).toBe(true);
+      const warmed = await compiler.compile(source);
+      const reused = await compiler.compile(source);
+      for (const result of [fresh, warmed, reused]) {
+        expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(result.binary)).toBe(true);
+        expect((await instantiate(result)).run!(40)).toBe(42);
+        expect(outcome(result)).toMatchObject({
+          kind: "unsupported",
+          stage: "select",
+          legacyBodyEmitted: true,
+          irBodyEmitted: false,
+        });
+        expect(result.irPostClaimErrors ?? []).toEqual([]);
+      }
+      expect(Buffer.from(warmed.binary)).toEqual(Buffer.from(fresh.binary));
+      expect(Buffer.from(reused.binary)).toEqual(Buffer.from(fresh.binary));
+    } finally {
+      compiler.dispose();
+    }
   });
 
   it("keeps mixed exact and inherited destructuring atomic on the direct path", async () => {


### PR DESCRIPTION
## Summary

- follow one exact checker-resolved `const` object alias before method destructuring
- keep mutation, escape, multiple aliases, nested capture, and general alias property reads on the direct path
- preserve the zero-cost alias optimization with explicit GC/standalone poison, import, WAT, incremental, and binary-size parity coverage
- update the #3522 Markdown checkpoint and resumable handoff

## Validation

- focused object-method suite: 39/39
- adjacent closure/object matrix: 77/77
- hybrid and strict IR-only shadow: 37/37 IR, 0 legacy, 0 blockers
- cross-backend differential: 29/29
- equivalence: 1,645 passing, 24 known failures, 12 baseline improvements, 0 regressions
- fallback, host-import, typecheck, lint, formatting, LOC/function, oracle, coercion, issue-integrity, and optimization-retirement gates pass
- optimized alias artifact is byte-identical to the no-alias IR control: 2,262 bytes GC and 5,893 bytes standalone; both are smaller than direct

Tracks the work in `plan/issues/3522-ir-r3-classes-closures-compile-once.md` (no GitHub Issue).