### PR TITLE
feat(ir): prepare captured object method values

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -4,7 +4,7 @@ title: "IR-only R3: compile-once classes, members, and closures"
 status: in-progress
 sprint: current
 created: 2026-07-21
-updated: 2026-08-13
+updated: 2026-08-14
 priority: critical
 horizon: xl
 complexity: XL
@@ -2243,3 +2243,62 @@ runtime, and optimized-size parity in GC and standalone. The unused
 callable-child-wrapper defect does not block that allocation-backed slice; it
 must be repaired with usage-sensitive closure-support roles before
 carrier/invoke-only callable passing is admitted.
+
+### Bounded sibling method-capture checkpoint (2026-08-14)
+
+The capture proof now admits any finite set of immediately nested local
+closures that capture an exact object-method value. Each sibling is still an
+exact `const` arrow or function-expression initializer in the projection
+owner, declared before use, invoked only by a direct non-optional call in that
+owner, and forbidden from escaping. Removing the former one-owner cardinality
+limit does not admit deeper nesting, mutation, object storage, callback
+passing, returns, or optional invocation.
+
+Direct-property aliases and destructured aliases share the same proof. Three
+GC/standalone fixtures cover a direct-property alias captured by two siblings,
+a destructured alias captured by two siblings, and heterogeneous numeric and
+boolean methods from one destructuring pattern captured by distinct siblings.
+They poison every physical body (four, four, and five bodies respectively),
+require exact IR function inventories with no legacy body or post-claim
+demotion, validate and return 42, and inspect each sibling's typed `call_ref`.
+The heterogeneous fixture additionally proves that both capture subtypes store
+the canonical callable wrapper-root reference despite their distinct physical
+signatures. Identical sibling layouts deduplicate to one closure subtype rather
+than growing the type graph. Another fixture gives the object method its own
+readonly numeric capture before two siblings capture that concrete method
+closure, proving that canonical-root fields safely carry a captured allocation
+subtype. A changed-snapshot incremental fixture warms the compiler with an
+escaped sibling, then proves fresh, warmed, and reused safe artifacts have
+exact body inventories and byte-identical binaries; a mixed safe/escaped
+sibling fixture proves the projection remains atomic. There is no generic
+dispatcher, `call_indirect`, extern/any conversion, or new import surface.
+
+The focused object-method suite is **65/65** and the adjacent eight-file
+closure/object matrix is **103/103**. Optimization parity remains explicit:
+
+| Pattern | Target | Direct bytes | IR bytes | IR imports |
+| --- | --- | ---: | ---: | --- |
+| direct-property alias, two siblings | GC | 3,653 | 2,282 | box/unbox number |
+| direct-property alias, two siblings | standalone | 7,066 | 5,913 | none |
+| destructured alias, two siblings | GC | 3,659 | 2,282 | box/unbox number |
+| destructured alias, two siblings | standalone | 7,066 | 5,913 | none |
+| heterogeneous pattern, two siblings | GC | 4,362 | 2,827 | box boolean/number, unbox number |
+| heterogeneous pattern, two siblings | standalone | 7,707 | 6,245 | none |
+
+Hybrid and strict IR-only shadow validation remain **37/37 IR bodies, 0
+legacy bodies, 0 Unsupported, and 0 Invariants**. The fallback ratchet remains
+clean with only the two unchanged deferred string-builder candidates;
+cross-backend differential coverage is **29/29**; and native-first host-import
+policy remains **379 imports, 0 legacy-semantic, and 0 unknown**. LOC/function
+budgets, oracle, coercion-site, issue-integrity, IR-adoption, and
+optimization-retirement gates are green. Full equivalence remains **1,645
+passing, 24 known failures, 12 baseline improvements, and zero new
+regressions**.
+
+The unused call-only child-wrapper/DCE defect remains outside this
+allocation-backed slice. Carrier/invoke-only callable passing still requires
+usage-sensitive closure-support roles before admission. Deeper cross-owner
+flows, closure escapes, mutable callable ref cells, receiver-sensitive methods,
+accessors, open or mutable objects, and optional calls remain direct. No shared
+legacy implementation has zero consumers at this checkpoint, so none is
+deleted here.

--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -2163,3 +2163,83 @@ from legacy to IR. Bare nested-function values, receiver-sensitive methods,
 accessors, mutable callable slots, optional calls, and broader escapes remain
 later families. No shared direct implementation has zero consumers at this
 checkpoint, so none is deleted here.
+
+### Captured object-method-value checkpoint (2026-08-14)
+
+An exact object-method value, read either as `const add = operations.add` or
+through destructuring, may now flow through an immutable local alias chain and
+be captured by one immediately nested local closure. Both the method and the
+capturing closure remain in the same Prepared component, and the outer
+function may call that closure directly without retaining any legacy body.
+
+The selector keeps this surface deliberately narrow. The capturing closure
+must be an exact `const` arrow or function-expression initializer in the
+destructuring owner's lexical scope, it must be called directly and
+non-optionally after its declaration, and neither the method-value chain nor
+the capture closure may escape. The whole binding pattern is limited to one
+capture owner, not merely each projected method. Mutation, shadowing, two
+capture owners, deeper nesting, callback passing, return or object-storage
+escape, optional invocation, and mutable ref-cell capture all remain typed
+select-stage fallbacks with zero post-claim failures. Direct-property and
+destructured projections share this exact declaration/alias/owner proof, so a
+deeper direct-property capture cannot pass selection and then fail during IR
+planning. One admitted closure may capture multiple represented methods from
+the same binding pattern, but distinct capture owners remain deferred.
+
+`prepareClosureTransaction` now resolves closure-valued capture fields through
+the transaction's existing `ClosureStructRegistry`. This is a bootstrap of the
+already canonical registry, not a second type family: a capture field stores
+the canonical wrapper-root reference, while the exact method wrapper remains
+its allocation subtype. A deliberately non-vacuous fixture registers a live
+boolean method family before the captured numeric method, poisons all four
+direct bodies, and inspects WAT to prove that the numeric capture uses the
+canonical root rather than the distinct numeric child wrapper. A second
+heterogeneous fixture captures numeric and boolean methods in one closure and
+proves that both capture fields use that same canonical root. Invocation is
+still a typed `call_ref`; there is no generic dispatcher, `call_indirect`,
+extern/any conversion, or new import surface.
+
+The focused object-method suite is **58/58** and the adjacent eight-file
+closure/object matrix is **96/96**. Both GC and standalone artifacts validate
+and return 42. For the basic captured-method fixture, optimized GC is **2,262
+bytes versus 3,423 direct** and optimized standalone is **5,893 versus 6,951
+direct**. GC keeps exactly the number box/unbox imports; standalone remains
+zero-import. The live wrapper-order fixture also requires optimized IR to be
+no larger than direct and produces **3,053 bytes GC** and **6,223 bytes
+standalone**. The two-field heterogeneous capture produces **2,964 bytes GC**
+and **6,385 bytes standalone**, remains no larger than its direct controls,
+and adds no imports beyond boolean/number boxing and numeric unboxing in GC;
+standalone remains zero-import.
+
+Hybrid and strict IR-only shadow validation remain **37/37 IR bodies, 0
+legacy bodies, 0 Unsupported, and 0 Invariants**. The fallback ratchet has
+zero unintended, post-claim, or module-level increases; cross-backend
+differential coverage is **29/29**; and native-first host-import policy remains
+**379 imports, 0 legacy-semantic, and 0 unknown**. Full equivalence reports
+**1,645 passing, 24 known failures, 12 baseline cases now passing, and zero new
+regressions**. Typecheck, lint, formatting, LOC/function budgets, oracle,
+coercion-site, issue-integrity, IR-adoption, and optimization-retirement gates
+are green.
+
+Remaining boundary: multiple immediate capture owners, deeper cross-owner
+flow, closure escapes, mutable captured callable cells, receiver-sensitive
+methods, accessors, open or mutable method objects, and optional calls remain
+direct. A pre-existing Program-ABI defect was exposed by an unused top-level
+callable-parameter function: preparation can require an allocation wrapper
+that DCE later removes even though only its call/carrier role is live. It does
+not affect the physically used capture fixture and is not caused by this
+slice. The size-preserving follow-up is usage-sensitive closure-support roles
+(carrier, invoke, and allocate), not pinning every speculative prepared type.
+No shared direct implementation has zero consumers here, so none is deleted in
+this checkpoint.
+
+Next resumable R3 slice: admit bounded sibling capture fan-out. Remove only the
+one-owner cardinality limits while retaining the exact immediate-owner,
+declaration-before-call, direct non-optional invocation, and no-escape proof
+for every sibling. Promote both a shared numeric method captured by two local
+closures and heterogeneous destructured methods captured by distinct local
+closures, with every owner/method body poisoned and canonical-root, import,
+runtime, and optimized-size parity in GC and standalone. The unused
+callable-child-wrapper defect does not block that allocation-backed slice; it
+must be repaired with usage-sensitive closure-support roles before
+carrier/invoke-only callable passing is admitted.

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -627,6 +627,7 @@ function prepareClosureTransaction(input: {
   const refCells = new RefCellRegistry(input.ctx);
   let resolveValType: (type: IrType) => ValType = (type) => lowerPreparedClosureSupportType(input.ctx, type, refCells);
   const registry = new ClosureStructRegistry(input.ctx, (type) => resolveValType(type));
+  resolveValType = (type) => lowerPreparedClosureSupportType(input.ctx, type, refCells, registry);
   const closureSupport = prepareDependencyCompleteClosureSupport(input.ctx, input.entries, registry, refCells);
   const freshSlots = allocatePreparedDerivedCallableSlots(
     input.ctx,

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -4604,7 +4604,7 @@ function isPhase1VarDecl(stmt: ts.VariableStatement, scope: Set<string>, localCl
     if (!isPhase1Expr(d.initializer, initializerScope, localClasses))
       return shapeNo("vardecl-init-expr", d.initializer);
     const initializer = unwrapPhase1Parens(d.initializer);
-    const objectMethodValue = isConst ? directObjectMethodValueProjection(initializer, initializerScope) : null;
+    const objectMethodValue = isConst ? directObjectMethodValueProjection(d, initializer, initializerScope) : null;
     const returnedCallable = objectMethodValue ? null : directReturnedCallableSignature(initializer, initializerScope);
     const callableAlias =
       isConst &&
@@ -6631,13 +6631,15 @@ type DirectDestructuredObjectMethodProjection = {
  * borrowing another object's method signature.
  */
 function directObjectMethodValueProjection(
+  declaration: ts.VariableDeclaration,
   expression: ts.Expression,
   scope: ReadonlySet<string>,
 ): DirectObjectMethodValueProjection | null {
+  if (!ts.isIdentifier(declaration.name)) return null;
   const candidate = unwrapProjectionExpression(expression);
   if (!ts.isPropertyAccessExpression(candidate) || !ts.isIdentifier(candidate.name)) return null;
   const method = directObjectMethodDeclaration(candidate.expression, candidate.name.text, scope);
-  if (!method) return null;
+  if (!method || !methodValueAliasChainHasOnlyBoundedDirectCalls(declaration, new Set())) return null;
   return {
     arity: exactCallableArity(method.parameters.length),
     returnType: method.type,
@@ -6898,16 +6900,20 @@ function directDestructuredObjectMethodReceiverUsesAreStable(
 }
 
 /**
- * Bound this new callable surface to immutable aliases and direct calls inside
- * the declaring function. This excludes cross-owner capture, return/pass
- * escapes, and mutation while still preserving same-owner const alias chains.
+ * Bound this callable surface to immutable aliases and direct calls. One
+ * immediately nested, directly-called const closure may capture the value;
+ * broader cross-owner flow, return/pass escapes, and mutation remain direct.
  */
-function destructuredMethodAliasChainHasOnlyOwnerDirectCalls(element: ts.BindingElement): boolean {
-  if (!ts.isIdentifier(element.name)) return false;
-  const owner = enclosingProjectionOwner(element);
+function methodValueAliasChainHasOnlyBoundedDirectCalls(
+  seed: ts.VariableDeclaration | ts.BindingElement,
+  projectionCaptureOwners: Set<ts.Node>,
+): boolean {
+  if (!ts.isIdentifier(seed.name)) return false;
+  const owner = enclosingProjectionOwner(seed);
   if (!owner || !currentModuleBindingResolver) return false;
-  const declarations = new Set<ts.Declaration>([element]);
-  const declarationNames = new Set<string>([element.name.text]);
+  const declarations = new Set<ts.Declaration>([seed]);
+  const declarationNames = new Set<string>([seed.name.text]);
+  const capturedCallOwners = new Set<ts.Node>();
   let proofFailed = false;
 
   let changed = true;
@@ -6955,8 +6961,20 @@ function destructuredMethodAliasChainHasOnlyOwnerDirectCalls(element: ts.Binding
         return;
       }
       if (localClosureDeclarationsContain(declarations, declaration)) {
-        if (enclosingProjectionOwner(node) !== owner) {
-          accepted = false;
+        const useOwner = enclosingProjectionOwner(node);
+        if (useOwner !== owner) {
+          const parent = node.parent;
+          if (
+            !useOwner ||
+            enclosingProjectionOwner(useOwner) !== owner ||
+            !ts.isCallExpression(parent) ||
+            parent.expression !== node ||
+            parent.questionDotToken !== undefined
+          ) {
+            accepted = false;
+            return;
+          }
+          capturedCallOwners.add(useOwner);
           return;
         }
         const parent = node.parent;
@@ -6975,7 +6993,67 @@ function destructuredMethodAliasChainHasOnlyOwnerDirectCalls(element: ts.Binding
     forEachChild(node, validateUses);
   };
   forEachChild(owner, validateUses);
-  return accepted;
+  for (const capturedOwner of capturedCallOwners) projectionCaptureOwners.add(capturedOwner);
+  return (
+    accepted &&
+    capturedCallOwners.size <= 1 &&
+    projectionCaptureOwners.size <= 1 &&
+    [...capturedCallOwners].every((capturedOwner) => capturingClosureHasOnlyOuterDirectCalls(capturedOwner, owner))
+  );
+}
+
+/** Keep the new capture surface inside one immediately-invoked local closure. */
+function capturingClosureHasOnlyOuterDirectCalls(capturedOwner: ts.Node, outerOwner: ts.Node): boolean {
+  if (!ts.isArrowFunction(capturedOwner) && !ts.isFunctionExpression(capturedOwner)) return false;
+  const declaration = capturedOwner.parent;
+  const declarationList = ts.isVariableDeclaration(declaration) ? declaration.parent : undefined;
+  if (
+    !ts.isVariableDeclaration(declaration) ||
+    declaration.initializer !== capturedOwner ||
+    !ts.isIdentifier(declaration.name) ||
+    !declarationList ||
+    !ts.isVariableDeclarationList(declarationList) ||
+    !(declarationList.flags & ts.NodeFlags.Const) ||
+    enclosingProjectionOwner(declaration) !== outerOwner
+  ) {
+    return false;
+  }
+  const declarationName = declaration.name;
+  let accepted = true;
+  let observedCall = false;
+  const visit = (node: ts.Node): void => {
+    if (!accepted) return;
+    if (
+      ts.isIdentifier(node) &&
+      node !== declarationName &&
+      node.text === declarationName.text &&
+      identifierIsValueReference(node)
+    ) {
+      if (ts.isBindingElement(node.parent) && node.parent.propertyName === node) return;
+      const resolved = currentModuleBindingResolver?.localValueDeclaration(node);
+      if (!resolved) {
+        accepted = false;
+        return;
+      }
+      if (!localDeclarationsMatch(declaration, resolved)) return;
+      const parent = node.parent;
+      if (
+        enclosingProjectionOwner(node) === outerOwner &&
+        declaration.end <= node.pos &&
+        ts.isCallExpression(parent) &&
+        parent.expression === node &&
+        parent.questionDotToken === undefined
+      ) {
+        observedCall = true;
+        return;
+      }
+      accepted = false;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(outerOwner, visit);
+  return accepted && observedCall;
 }
 
 /** Certify the entire pattern before exposing any callable projection. */
@@ -6987,6 +7065,7 @@ function directDestructuredObjectMethodProjections(
   const receiver = directDestructuredObjectMethodReceiver(initializer, scope);
   if (!receiver || !directDestructuredObjectMethodReceiverUsesAreStable(receiver)) return null;
   const projections: DirectDestructuredObjectMethodProjection[] = [];
+  const captureOwners = new Set<ts.Node>();
   for (const element of pattern.elements) {
     if (!ts.isIdentifier(element.name)) return null;
     const propertyName = element.propertyName
@@ -6994,7 +7073,9 @@ function directDestructuredObjectMethodProjections(
         ? element.propertyName.text
         : null
       : element.name.text;
-    if (propertyName === null || !destructuredMethodAliasChainHasOnlyOwnerDirectCalls(element)) return null;
+    if (propertyName === null || !methodValueAliasChainHasOnlyBoundedDirectCalls(element, captureOwners)) {
+      return null;
+    }
     const method = receiver.root.object.properties.find(
       (property): property is ts.MethodDeclaration =>
         ts.isMethodDeclaration(property) &&
@@ -8893,7 +8974,8 @@ function collectLocalClosureBindings(fn: ts.FunctionDeclaration): {
         }
         if (!ts.isIdentifier(d.name)) continue;
         const literal = ts.isArrowFunction(d.initializer) || ts.isFunctionExpression(d.initializer);
-        const objectMethodValue = isConst && directObjectMethodValueProjection(d.initializer, localValueNames) !== null;
+        const objectMethodValue =
+          isConst && directObjectMethodValueProjection(d, d.initializer, localValueNames) !== null;
         const aliasInitializer = unwrapProjectionExpression(d.initializer);
         const aliasDeclaration = ts.isIdentifier(aliasInitializer)
           ? currentModuleBindingResolver?.localValueDeclaration(aliasInitializer)

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -6639,7 +6639,7 @@ function directObjectMethodValueProjection(
   const candidate = unwrapProjectionExpression(expression);
   if (!ts.isPropertyAccessExpression(candidate) || !ts.isIdentifier(candidate.name)) return null;
   const method = directObjectMethodDeclaration(candidate.expression, candidate.name.text, scope);
-  if (!method || !methodValueAliasChainHasOnlyBoundedDirectCalls(declaration, new Set())) return null;
+  if (!method || !methodValueAliasChainHasOnlyBoundedDirectCalls(declaration)) return null;
   return {
     arity: exactCallableArity(method.parameters.length),
     returnType: method.type,
@@ -6900,14 +6900,11 @@ function directDestructuredObjectMethodReceiverUsesAreStable(
 }
 
 /**
- * Bound this callable surface to immutable aliases and direct calls. One
- * immediately nested, directly-called const closure may capture the value;
- * broader cross-owner flow, return/pass escapes, and mutation remain direct.
+ * Bound this callable surface to immutable aliases and direct calls.
+ * Immediately nested, directly-called const closures may capture the value;
+ * deeper cross-owner flow, return/pass escapes, and mutation remain direct.
  */
-function methodValueAliasChainHasOnlyBoundedDirectCalls(
-  seed: ts.VariableDeclaration | ts.BindingElement,
-  projectionCaptureOwners: Set<ts.Node>,
-): boolean {
+function methodValueAliasChainHasOnlyBoundedDirectCalls(seed: ts.VariableDeclaration | ts.BindingElement): boolean {
   if (!ts.isIdentifier(seed.name)) return false;
   const owner = enclosingProjectionOwner(seed);
   if (!owner || !currentModuleBindingResolver) return false;
@@ -6993,16 +6990,13 @@ function methodValueAliasChainHasOnlyBoundedDirectCalls(
     forEachChild(node, validateUses);
   };
   forEachChild(owner, validateUses);
-  for (const capturedOwner of capturedCallOwners) projectionCaptureOwners.add(capturedOwner);
   return (
     accepted &&
-    capturedCallOwners.size <= 1 &&
-    projectionCaptureOwners.size <= 1 &&
     [...capturedCallOwners].every((capturedOwner) => capturingClosureHasOnlyOuterDirectCalls(capturedOwner, owner))
   );
 }
 
-/** Keep the new capture surface inside one immediately-invoked local closure. */
+/** Keep each captured owner inside one immediately-invoked local closure. */
 function capturingClosureHasOnlyOuterDirectCalls(capturedOwner: ts.Node, outerOwner: ts.Node): boolean {
   if (!ts.isArrowFunction(capturedOwner) && !ts.isFunctionExpression(capturedOwner)) return false;
   const declaration = capturedOwner.parent;
@@ -7065,7 +7059,6 @@ function directDestructuredObjectMethodProjections(
   const receiver = directDestructuredObjectMethodReceiver(initializer, scope);
   if (!receiver || !directDestructuredObjectMethodReceiverUsesAreStable(receiver)) return null;
   const projections: DirectDestructuredObjectMethodProjection[] = [];
-  const captureOwners = new Set<ts.Node>();
   for (const element of pattern.elements) {
     if (!ts.isIdentifier(element.name)) return null;
     const propertyName = element.propertyName
@@ -7073,7 +7066,7 @@ function directDestructuredObjectMethodProjections(
         ? element.propertyName.text
         : null
       : element.name.text;
-    if (propertyName === null || !methodValueAliasChainHasOnlyBoundedDirectCalls(element, captureOwners)) {
+    if (propertyName === null || !methodValueAliasChainHasOnlyBoundedDirectCalls(element)) {
       return null;
     }
     const method = receiver.root.object.properties.find(

--- a/tests/issue-3522-ir-object-method-call-ownership.test.ts
+++ b/tests/issue-3522-ir-object-method-call-ownership.test.ts
@@ -118,6 +118,94 @@ function importLabels(result: CompileResult): string[] {
   return result.imports.map((entry) => `${entry.module}::${entry.name}`).sort();
 }
 
+function watFunctionBody(wat: string | undefined, name: string): string {
+  expect(wat).toBeDefined();
+  const start = wat!.indexOf(`(func $${name}`);
+  expect(start, `missing WAT body for ${name}`).toBeGreaterThanOrEqual(0);
+  const next = wat!.indexOf("\n  (func $", start + 1);
+  return wat!.slice(start, next < 0 ? undefined : next);
+}
+
+function watTypeLines(wat: string): string[] {
+  return wat
+    .split("\n")
+    .map((line) => line.trimStart())
+    .filter((line) => line.startsWith("(type "));
+}
+
+function expectCanonicalCapturedMethodAbi(wat: string): void {
+  const types = watTypeLines(wat);
+  const rootStructs = types.filter((line) => /\$__fn_wrap_\d+_struct \(sub \(struct/.test(line));
+  expect(rootStructs, "expected one canonical callable wrapper root").toHaveLength(1);
+  const rootStruct = rootStructs[0]!;
+  expect(rootStruct).not.toContain("(sub final");
+
+  const rootSuffix = rootStruct.match(/\$__fn_wrap_(\d+)_struct/)?.[1];
+  expect(rootSuffix, "canonical callable wrapper root has no suffix").toBeDefined();
+  const rootLifted = types.find((line) => line.includes(`$__fn_wrap_${rootSuffix}_type`));
+  expect(rootLifted, "canonical callable wrapper root has no lifted function type").toBeDefined();
+  expect(rootLifted).toContain("(result i32)");
+  const rootIdxText = rootLifted!.match(/\(ref(?: null)? (\d+)\)/)?.[1];
+  expect(rootIdxText, "canonical callable wrapper root has no self type").toBeDefined();
+  const rootIdx = Number(rootIdxText);
+
+  const exactFuncType = types.find((line) =>
+    new RegExp(
+      `\\$__fn_wrap_(\\d+)_type \\(func \\(param \\(ref(?: null)? ${rootIdx}\\) f64\\) \\(result f64\\)\\)`,
+    ).test(line),
+  );
+  expect(exactFuncType, "number method wrapper has no exact lifted function type").toBeDefined();
+  const exactSuffix = exactFuncType!.match(/\$__fn_wrap_(\d+)_type/)?.[1];
+  expect(exactSuffix).toBeDefined();
+  const exactWrapper = types.find((line) => line.includes(`$__fn_wrap_${exactSuffix}_struct`));
+  expect(exactWrapper, "number method wrapper has no allocation type").toBeDefined();
+  expect(exactWrapper).toContain(`(sub $type${rootIdx}`);
+
+  const capturedTypes = types.filter((line) => line.includes("(type $__ir_closure_"));
+  expect(capturedTypes, "only invoke should need an IR capture subtype").toHaveLength(1);
+  const invokeSubtype = capturedTypes[0]!;
+  const exactWrapperIdx = Number(invokeSubtype.match(/\(sub final \$type(\d+)/)?.[1]);
+  expect(exactWrapperIdx, "fixture did not force a non-root number wrapper").not.toBe(rootIdx);
+  expect(invokeSubtype).toMatch(new RegExp(`\\(field \\$cap0 \\(ref(?: null)? ${rootIdx}\\)\\)`));
+  expect(invokeSubtype).not.toMatch(new RegExp(`\\(field \\$cap0 \\(ref(?: null)? ${exactWrapperIdx}\\)\\)`));
+
+  const invokeBody = watFunctionBody(wat, "run__closure_2");
+  expect(invokeBody).toMatch(/ref\.cast \(ref (\d+)\)\s+struct\.get \1 3/);
+  expect(invokeBody).toMatch(
+    new RegExp(`struct\\.get ${rootIdx} 0\\s+ref\\.cast \\(ref (\\d+)\\)\\s+(?:return_)?call_ref \\1`),
+  );
+  expect(invokeBody).not.toMatch(
+    /any\.convert_extern|extern\.convert_any|ref\.test|call_indirect|__call_m_|__call_function|\bcall \d+/,
+  );
+}
+
+function expectCanonicalMultiCapturedMethodAbi(wat: string): void {
+  const types = watTypeLines(wat);
+  const rootStructs = types.filter((line) => /\$__fn_wrap_\d+_struct \(sub \(struct/.test(line));
+  expect(rootStructs, "expected one canonical callable wrapper root").toHaveLength(1);
+  const rootSuffix = rootStructs[0]!.match(/\$__fn_wrap_(\d+)_struct/)?.[1];
+  expect(rootSuffix).toBeDefined();
+  const rootLifted = types.find((line) => line.includes(`$__fn_wrap_${rootSuffix}_type`));
+  const rootIdxText = rootLifted?.match(/\(ref(?: null)? (\d+)\)/)?.[1];
+  expect(rootIdxText, "canonical callable wrapper root has no self type").toBeDefined();
+  const rootIdx = Number(rootIdxText);
+
+  const capturedTypes = types.filter((line) => line.includes("(type $__ir_closure_"));
+  expect(capturedTypes, "only invoke should need an IR capture subtype").toHaveLength(1);
+  const invokeSubtype = capturedTypes[0]!;
+  expect(invokeSubtype).toMatch(new RegExp(`\\(field \\$cap0 \\(ref(?: null)? ${rootIdx}\\)\\)`));
+  expect(invokeSubtype).toMatch(new RegExp(`\\(field \\$cap1 \\(ref(?: null)? ${rootIdx}\\)\\)`));
+
+  const invokeBody = watFunctionBody(wat, "run__closure_2");
+  expect(invokeBody).toMatch(/struct\.get \d+ 3/);
+  expect(invokeBody).toMatch(/struct\.get \d+ 4/);
+  expect((invokeBody.match(new RegExp(`struct\\.get ${rootIdx} 0`, "g")) ?? []).length).toBeGreaterThanOrEqual(2);
+  expect((invokeBody.match(/call_ref \d+/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  expect(invokeBody).not.toMatch(
+    /any\.convert_extern|extern\.convert_any|ref\.test|call_indirect|__call_m_|__call_function|\bcall \d+/,
+  );
+}
+
 function expectNoImportRegression(
   direct: CompileResult,
   prepared: CompileResult,
@@ -1011,24 +1099,85 @@ describe("#3522 object-method call ownership", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it("keeps destructured method values captured by nested closures on the direct path", async () => {
+  it.each(TARGETS)("prepares a captured direct-property method alias chain in the %s lane", async (target) => {
+    const source = `export function run(input: number): number {
+      const operations = {
+        add(value: number): number { return value + 2; }
+      };
+      const add = operations.add;
+      const selected = add;
+      const invoke = (value: number): number => selected(value);
+      return invoke(input);
+    }`;
+    const direct = await compile(source, {
+      fileName: `object-method-value-property-alias-captured-direct-${target}.ts`,
+      emitWat: true,
+      experimentalIR: false,
+      optimize: true,
+      target,
+    });
+    const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run,run__closure_0,run__closure_1";
+      prepared = await compile(source, {
+        fileName: `object-method-value-property-alias-captured-prepared-${target}.ts`,
+        emitWat: true,
+        experimentalIR: true,
+        optimize: true,
+        target,
+        trackIrOutcomes: true,
+      });
+    } finally {
+      if (previousPoison === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!(40)).toBe(42);
+    }
+    expect(outcome(prepared)).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["run", "run__closure_0", "run__closure_1"]));
+
+    const invokeBody = watFunctionBody(prepared.wat, "run__closure_1");
+    expect(invokeBody).toMatch(/struct\.get \d+ 3[\s\S]*struct\.get \d+ 0[\s\S]*call_ref \d+/);
+    expect(invokeBody).not.toMatch(/any\.convert_extern|extern\.convert_any|call_indirect|\bcall \d+/);
+    expect(prepared.wat).not.toContain("__call_m_");
+    expectNoImportRegression(direct, prepared, target);
+    expect(importLabels(prepared)).toEqual(target === "gc" ? ["env::__box_number", "env::__unbox_number"] : []);
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+  });
+
+  it("keeps a direct-property method capture two closure owners deep on the direct path", async () => {
     const result = await compile(
       `export function run(input: number): number {
         const operations = {
           add(value: number): number { return value + 2; }
         };
-        const { add } = operations;
-        const invoke = (value: number): number => add(value);
-        return invoke(input);
+        const add = operations.add;
+        const outer = (value: number): number => {
+          const inner = (nested: number): number => add(nested);
+          return inner(value);
+        };
+        return outer(input);
       }`,
       {
-        fileName: "object-method-value-destructured-captured-direct.ts",
+        fileName: "object-method-value-property-two-owner-depth-direct.ts",
         experimentalIR: true,
         trackIrOutcomes: true,
       },
     );
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
     expect((await instantiate(result)).run!(40)).toBe(42);
     expect(outcome(result)).toMatchObject({
       kind: "unsupported",
@@ -1039,9 +1188,191 @@ describe("#3522 object-method call ownership", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it("keeps captured destructured method alias chains on the direct path", async () => {
+  it("keeps a direct-property method captured by two sibling closures on the direct path", async () => {
     const result = await compile(
       `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const add = operations.add;
+        const first = (value: number): number => add(value);
+        const second = (value: number): number => add(value);
+        return first(input) + second(0) - 2;
+      }`,
+      {
+        fileName: "object-method-value-property-two-capture-owners-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps an escaped direct-property method capture closure on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const add = operations.add;
+        const invoke = (value: number): number => add(value);
+        const escaped = { invoke };
+        return escaped.invoke(input);
+      }`,
+      {
+        fileName: "object-method-value-property-capture-escape-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it.each(TARGETS)(
+    "prepares a destructured method value captured by a nested closure in the %s lane",
+    async (target) => {
+      const source = `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const invoke = (value: number): number => add(value);
+        return invoke(input);
+      }`;
+      const direct = await compile(source, {
+        fileName: `object-method-value-destructured-captured-direct-${target}.ts`,
+        emitWat: true,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run,run__closure_0,run__closure_1";
+        prepared = await compile(source, {
+          fileName: `object-method-value-destructured-captured-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
+
+      for (const compiled of [direct, prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      expect(outcome(prepared)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.irCompiledFuncs ?? []).toEqual(
+        expect.arrayContaining(["run", "run__closure_0", "run__closure_1"]),
+      );
+
+      const runBody = watFunctionBody(prepared.wat, "run");
+      const invokeBody = watFunctionBody(prepared.wat, "run__closure_1");
+      expect((runBody.match(/\bstruct\.new\b/g) ?? []).length).toBeGreaterThanOrEqual(2);
+      expect(invokeBody).toMatch(/struct\.get \d+ 3[\s\S]*struct\.get \d+ 0[\s\S]*call_ref \d+/);
+      expect(invokeBody).not.toMatch(/any\.convert_extern|extern\.convert_any|call_indirect|\bcall \d+/);
+      expect(prepared.wat).not.toContain("__call_m_");
+      expectNoImportRegression(direct, prepared, target);
+      expect(importLabels(prepared)).toEqual(target === "gc" ? ["env::__box_number", "env::__unbox_number"] : []);
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
+
+  it("keeps a mutable destructured method capture on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        let { add } = operations;
+        const invoke = (value: number): number => add(value);
+        add = (value: number): number => value + 3;
+        return invoke(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-mutable-capture-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(43);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("does not confuse a shadowing callable parameter with the destructured method declaration", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const invoke = (add: (value: number) => number, value: number): number => add(value);
+        return invoke((value: number): number => value + 3, input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-capture-shadow-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(43);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it.each(TARGETS)("prepares a captured destructured method alias chain in the %s lane", async (target) => {
+    const source = `export function run(input: number): number {
         const operations = {
           add(value: number): number { return value + 2; }
         };
@@ -1049,15 +1380,75 @@ describe("#3522 object-method call ownership", () => {
         const selected = add;
         const invoke = (value: number): number => selected(value);
         return invoke(input);
+      }`;
+    const direct = await compile(source, {
+      fileName: `object-method-value-destructured-alias-captured-direct-${target}.ts`,
+      emitWat: true,
+      experimentalIR: false,
+      optimize: true,
+      target,
+    });
+    const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+    let prepared: CompileResult;
+    try {
+      process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run,run__closure_0,run__closure_1";
+      prepared = await compile(source, {
+        fileName: `object-method-value-destructured-alias-captured-prepared-${target}.ts`,
+        emitWat: true,
+        experimentalIR: true,
+        optimize: true,
+        target,
+        trackIrOutcomes: true,
+      });
+    } finally {
+      if (previousPoison === undefined) Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+      else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+    }
+
+    for (const compiled of [direct, prepared]) {
+      expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(compiled.binary)).toBe(true);
+      expect((await instantiate(compiled)).run!(40)).toBe(42);
+    }
+    expect(outcome(prepared)).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: false,
+      irBodyEmitted: true,
+      preparedComponentId: expect.stringMatching(/^prepared-component:/),
+    });
+    expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+    expect(prepared.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["run", "run__closure_0", "run__closure_1"]));
+
+    const invokeBody = watFunctionBody(prepared.wat, "run__closure_1");
+    expect(invokeBody).toMatch(/struct\.get \d+ 3[\s\S]*struct\.get \d+ 0[\s\S]*call_ref \d+/);
+    expect(invokeBody).not.toMatch(/any\.convert_extern|extern\.convert_any|call_indirect|\bcall \d+/);
+    expect(prepared.wat).not.toContain("__call_m_");
+    expectNoImportRegression(direct, prepared, target);
+    expect(importLabels(prepared)).toEqual(target === "gc" ? ["env::__box_number", "env::__unbox_number"] : []);
+    expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+  });
+
+  it("keeps one captured method alias shared by two nested closure owners on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const selected = add;
+        const first = (value: number): number => selected(value);
+        const second = (value: number): number => selected(value);
+        return first(input) + second(0) - 2;
       }`,
       {
-        fileName: "object-method-value-destructured-alias-captured-direct.ts",
+        fileName: "object-method-value-destructured-two-capture-owners-direct.ts",
         experimentalIR: true,
         trackIrOutcomes: true,
       },
     );
 
     expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
     expect((await instantiate(result)).run!(40)).toBe(42);
     expect(outcome(result)).toMatchObject({
       kind: "unsupported",
@@ -1067,6 +1458,286 @@ describe("#3522 object-method call ownership", () => {
     });
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
+
+  it("keeps one destructuring pattern captured by two nested closure owners on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; },
+          positive(value: number): boolean { return value > 0; }
+        };
+        const { add, positive } = operations;
+        const invokeAdd = (value: number): number => add(value);
+        const invokePositive = (value: number): boolean => positive(value);
+        return invokeAdd(input) + (invokePositive(input) ? 0 : 1);
+      }`,
+      {
+        fileName: "object-method-value-destructured-pattern-two-capture-owners-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps a captured method closure that escapes through object storage on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const invoke = (value: number): number => add(value);
+        const escaped = { invoke };
+        return escaped.invoke(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-capture-escape-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps a captured method closure passed as a value on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const invoke = (value: number): number => add(value);
+        const consume = (fn: (value: number) => number, value: number): number => fn(value);
+        return consume(invoke, input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-capture-passed-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps a method call captured two nested closure owners deep on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const outer = (value: number): number => {
+          const inner = (next: number): number => add(next);
+          return inner(value);
+        };
+        return outer(input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-two-owner-depth-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps an optional call through a captured method closure on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const invoke = (value: number): number => add(value);
+        invoke?.(input);
+        return 42;
+      }`,
+      {
+        fileName: "object-method-value-destructured-captured-optional-call-direct.ts",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it.each(TARGETS)(
+    "captures heterogeneous destructured methods in one canonical closure in the %s lane",
+    async (target) => {
+      const source = `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; },
+          positive(value: number): boolean { return value > 0; }
+        };
+        const { add, positive } = operations;
+        const invoke = (value: number): number => add(value) + (positive(value) ? 0 : 1);
+        return invoke(input);
+      }`;
+      const direct = await compile(source, {
+        fileName: `object-method-value-multi-capture-direct-${target}.ts`,
+        emitWat: true,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run,run__closure_0,run__closure_1,run__closure_2";
+        prepared = await compile(source, {
+          fileName: `object-method-value-multi-capture-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
+
+      for (const compiled of [direct, prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      expect(outcome(prepared)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.irCompiledFuncs ?? []).toEqual(
+        expect.arrayContaining(["run", "run__closure_0", "run__closure_1", "run__closure_2"]),
+      );
+      expectCanonicalMultiCapturedMethodAbi(prepared.wat!);
+      expect(prepared.wat).not.toContain("__call_m_");
+      expectNoImportRegression(direct, prepared, target);
+      expect(importLabels(prepared)).toEqual(
+        target === "gc" ? ["env::__box_boolean", "env::__box_number", "env::__unbox_number"] : [],
+      );
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
+
+  it.each(TARGETS)(
+    "captures a method through the canonical wrapper root when another signature is registered first in the %s lane",
+    async (target) => {
+      const source = `export function run(input: number): number {
+        const checks = {
+          positive(value: number): boolean { return value > 0; }
+        };
+        const allowed = checks.positive(input);
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const invoke = (value: number): number => add(value);
+        return invoke(input) + (allowed ? 0 : 0);
+      }`;
+      const direct = await compile(source, {
+        fileName: `object-method-value-canonical-capture-direct-${target}.ts`,
+        emitWat: true,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = "run,run__closure_0,run__closure_1,run__closure_2";
+        prepared = await compile(source, {
+          fileName: `object-method-value-canonical-capture-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
+
+      for (const compiled of [direct, prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      expect(outcome(prepared)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.irCompiledFuncs ?? []).toEqual(
+        expect.arrayContaining(["run", "run__closure_0", "run__closure_1", "run__closure_2"]),
+      );
+      expectCanonicalCapturedMethodAbi(prepared.wat!);
+      expect(prepared.wat).not.toContain("__call_m_");
+      expectNoImportRegression(direct, prepared, target);
+      expect(importLabels(prepared)).toEqual(
+        target === "gc" ? ["env::__box_boolean", "env::__box_number", "env::__unbox_number"] : [],
+      );
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
 
   it("keeps reassigned method fields destructured later on the direct path", async () => {
     const result = await compile(

--- a/tests/issue-3522-ir-object-method-call-ownership.test.ts
+++ b/tests/issue-3522-ir-object-method-call-ownership.test.ts
@@ -206,6 +206,74 @@ function expectCanonicalMultiCapturedMethodAbi(wat: string): void {
   );
 }
 
+function expectTypedCapturedSiblingCalls(wat: string, names: readonly string[]): void {
+  for (const name of names) {
+    const body = watFunctionBody(wat, name);
+    expect(body).toMatch(
+      /struct\.get \d+ 3[\s\S]*struct\.get \d+ 0\s+ref\.cast \(ref (\d+)\)\s+(?:return_)?call_ref \1/,
+    );
+    expect(body).not.toMatch(
+      /any\.convert_extern|extern\.convert_any|ref\.test|call_indirect|__call_m_|__call_function|\bcall \d+/,
+    );
+  }
+}
+
+function expectCanonicalSiblingCapturedMethodAbi(wat: string, names: readonly string[]): void {
+  const types = watTypeLines(wat);
+  const rootStructs = types.filter((line) => /\$__fn_wrap_\d+_struct \(sub \(struct/.test(line));
+  expect(rootStructs, "expected one canonical callable wrapper root").toHaveLength(1);
+  const rootSuffix = rootStructs[0]!.match(/\$__fn_wrap_(\d+)_struct/)?.[1];
+  expect(rootSuffix).toBeDefined();
+  const rootLifted = types.find((line) => line.includes(`$__fn_wrap_${rootSuffix}_type`));
+  const rootIdxText = rootLifted?.match(/\(ref(?: null)? (\d+)\)/)?.[1];
+  expect(rootIdxText, "canonical callable wrapper root has no self type").toBeDefined();
+  const rootIdx = Number(rootIdxText);
+
+  const liftedTypes = types.filter((line) => /\$__fn_wrap_\d+_type \(func/.test(line));
+  expect(
+    liftedTypes.some((line) => line.includes("(result f64)")),
+    "number wrapper is missing",
+  ).toBe(true);
+  expect(
+    liftedTypes.some((line) => line.includes("(result i32)")),
+    "boolean wrapper is missing",
+  ).toBe(true);
+  const capturedTypes = types.filter((line) => line.includes("(type $__ir_closure_"));
+  expect(capturedTypes, "each sibling should have one IR capture subtype").toHaveLength(names.length);
+  for (const capturedType of capturedTypes) {
+    expect(capturedType).toMatch(new RegExp(`\\(field \\$cap0 \\(ref(?: null)? ${rootIdx}\\)\\)`));
+  }
+
+  expectTypedCapturedSiblingCalls(wat, names);
+  for (const name of names) {
+    expect(watFunctionBody(wat, name)).toContain(`struct.get ${rootIdx} 0`);
+  }
+}
+
+function expectSiblingCaptureOfCapturedMethodAbi(wat: string, names: readonly string[]): void {
+  const types = watTypeLines(wat);
+  const rootStructs = types.filter((line) => /\$__fn_wrap_\d+_struct \(sub \(struct/.test(line));
+  expect(rootStructs, "expected one canonical callable wrapper root").toHaveLength(1);
+  const rootSuffix = rootStructs[0]!.match(/\$__fn_wrap_(\d+)_struct/)?.[1];
+  expect(rootSuffix).toBeDefined();
+  const rootLifted = types.find((line) => line.includes(`$__fn_wrap_${rootSuffix}_type`));
+  const rootIdxText = rootLifted?.match(/\(ref(?: null)? (\d+)\)/)?.[1];
+  expect(rootIdxText, "canonical callable wrapper root has no self type").toBeDefined();
+  const rootIdx = Number(rootIdxText);
+
+  const capturedTypes = types.filter((line) => line.includes("(type $__ir_closure_"));
+  expect(capturedTypes, "method and identical siblings need two semantic capture layouts").toHaveLength(2);
+  expect(capturedTypes.some((line) => /\(field \$cap0 f64\)/.test(line))).toBe(true);
+  expect(
+    capturedTypes.some((line) => new RegExp(`\\(field \\$cap0 \\(ref(?: null)? ${rootIdx}\\)\\)`).test(line)),
+  ).toBe(true);
+
+  expectTypedCapturedSiblingCalls(wat, names);
+  for (const name of names) {
+    expect(watFunctionBody(wat, name)).toContain(`struct.get ${rootIdx} 0`);
+  }
+}
+
 function expectNoImportRegression(
   direct: CompileResult,
   prepared: CompileResult,
@@ -1188,35 +1256,65 @@ describe("#3522 object-method call ownership", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it("keeps a direct-property method captured by two sibling closures on the direct path", async () => {
-    const result = await compile(
-      `export function run(input: number): number {
+  it.each(TARGETS)(
+    "prepares a direct-property method captured by two sibling closures in the %s lane",
+    async (target) => {
+      const source = `export function run(input: number): number {
         const operations = {
           add(value: number): number { return value + 2; }
         };
         const add = operations.add;
-        const first = (value: number): number => add(value);
-        const second = (value: number): number => add(value);
+        const selected = add;
+        const first = (value: number): number => selected(value);
+        const second = (value: number): number => selected(value);
         return first(input) + second(0) - 2;
-      }`,
-      {
-        fileName: "object-method-value-property-two-capture-owners-direct.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      },
-    );
+      }`;
+      const exactBodies = ["run", "run__closure_0", "run__closure_1", "run__closure_2"];
+      const direct = await compile(source, {
+        fileName: `object-method-value-property-two-capture-owners-direct-${target}.ts`,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = exactBodies.join(",");
+        prepared = await compile(source, {
+          fileName: `object-method-value-property-two-capture-owners-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
 
-    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-    expect(WebAssembly.validate(result.binary)).toBe(true);
-    expect((await instantiate(result)).run!(40)).toBe(42);
-    expect(outcome(result)).toMatchObject({
-      kind: "unsupported",
-      stage: "select",
-      legacyBodyEmitted: true,
-      irBodyEmitted: false,
-    });
-    expect(result.irPostClaimErrors ?? []).toEqual([]);
-  });
+      for (const compiled of [direct, prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      expect(outcome(prepared)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.irCompiledFuncs ?? []).toEqual(exactBodies);
+      expect(watTypeLines(prepared.wat!).filter((line) => line.includes("(type $__ir_closure_"))).toHaveLength(1);
+      expectTypedCapturedSiblingCalls(prepared.wat!, ["run__closure_1", "run__closure_2"]);
+      expect(prepared.wat).not.toContain("__call_m_");
+      expectNoImportRegression(direct, prepared, target);
+      expect(importLabels(prepared)).toEqual(target === "gc" ? ["env::__box_number", "env::__unbox_number"] : []);
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
 
   it("keeps an escaped direct-property method capture closure on the direct path", async () => {
     const result = await compile(
@@ -1428,9 +1526,10 @@ describe("#3522 object-method call ownership", () => {
     expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
   });
 
-  it("keeps one captured method alias shared by two nested closure owners on the direct path", async () => {
-    const result = await compile(
-      `export function run(input: number): number {
+  it.each(TARGETS)(
+    "prepares one captured method alias shared by two sibling closures in the %s lane",
+    async (target) => {
+      const source = `export function run(input: number): number {
         const operations = {
           add(value: number): number { return value + 2; }
         };
@@ -1439,29 +1538,117 @@ describe("#3522 object-method call ownership", () => {
         const first = (value: number): number => selected(value);
         const second = (value: number): number => selected(value);
         return first(input) + second(0) - 2;
-      }`,
-      {
-        fileName: "object-method-value-destructured-two-capture-owners-direct.ts",
-        experimentalIR: true,
-        trackIrOutcomes: true,
-      },
-    );
+      }`;
+      const exactBodies = ["run", "run__closure_0", "run__closure_1", "run__closure_2"];
+      const direct = await compile(source, {
+        fileName: `object-method-value-destructured-two-capture-owners-direct-${target}.ts`,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = exactBodies.join(",");
+        prepared = await compile(source, {
+          fileName: `object-method-value-destructured-two-capture-owners-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
 
-    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
-    expect(WebAssembly.validate(result.binary)).toBe(true);
-    expect((await instantiate(result)).run!(40)).toBe(42);
-    expect(outcome(result)).toMatchObject({
-      kind: "unsupported",
-      stage: "select",
-      legacyBodyEmitted: true,
-      irBodyEmitted: false,
-    });
-    expect(result.irPostClaimErrors ?? []).toEqual([]);
-  });
+      for (const compiled of [direct, prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      expect(outcome(prepared)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.irCompiledFuncs ?? []).toEqual(exactBodies);
+      expect(watTypeLines(prepared.wat!).filter((line) => line.includes("(type $__ir_closure_"))).toHaveLength(1);
+      expectTypedCapturedSiblingCalls(prepared.wat!, ["run__closure_1", "run__closure_2"]);
+      expect(prepared.wat).not.toContain("__call_m_");
+      expectNoImportRegression(direct, prepared, target);
+      expect(importLabels(prepared)).toEqual(target === "gc" ? ["env::__box_number", "env::__unbox_number"] : []);
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
 
-  it("keeps one destructuring pattern captured by two nested closure owners on the direct path", async () => {
-    const result = await compile(
-      `export function run(input: number): number {
+  it.each(TARGETS)(
+    "captures a method with its own readonly capture through two sibling closures in the %s lane",
+    async (target) => {
+      const source = `export function run(input: number): number {
+        const offset: number = 2;
+        const operations = {
+          add(value: number): number { return value + offset; }
+        };
+        const { add } = operations;
+        const first = (value: number): number => add(value);
+        const second = (value: number): number => add(value);
+        return first(input) + second(0) - offset;
+      }`;
+      const exactBodies = ["run", "run__closure_0", "run__closure_1", "run__closure_2"];
+      const direct = await compile(source, {
+        fileName: `object-method-value-captured-method-siblings-direct-${target}.ts`,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = exactBodies.join(",");
+        prepared = await compile(source, {
+          fileName: `object-method-value-captured-method-siblings-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
+
+      for (const compiled of [direct, prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      expect(outcome(prepared)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.irCompiledFuncs ?? []).toEqual(exactBodies);
+      expectSiblingCaptureOfCapturedMethodAbi(prepared.wat!, ["run__closure_1", "run__closure_2"]);
+      expect(prepared.wat).not.toContain("__call_m_");
+      expectNoImportRegression(direct, prepared, target);
+      expect(importLabels(prepared)).toEqual(target === "gc" ? ["env::__box_number", "env::__unbox_number"] : []);
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
+
+  it.each(TARGETS)(
+    "prepares one heterogeneous destructuring pattern captured by two sibling closures in the %s lane",
+    async (target) => {
+      const source = `export function run(input: number): number {
         const operations = {
           add(value: number): number { return value + 2; },
           positive(value: number): boolean { return value > 0; }
@@ -1470,9 +1657,129 @@ describe("#3522 object-method call ownership", () => {
         const invokeAdd = (value: number): number => add(value);
         const invokePositive = (value: number): boolean => positive(value);
         return invokeAdd(input) + (invokePositive(input) ? 0 : 1);
+      }`;
+      const exactBodies = ["run", "run__closure_0", "run__closure_1", "run__closure_2", "run__closure_3"];
+      const direct = await compile(source, {
+        fileName: `object-method-value-destructured-pattern-two-capture-owners-direct-${target}.ts`,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = exactBodies.join(",");
+        prepared = await compile(source, {
+          fileName: `object-method-value-destructured-pattern-two-capture-owners-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
+
+      for (const compiled of [direct, prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      expect(outcome(prepared)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.irCompiledFuncs ?? []).toEqual(exactBodies);
+      expectCanonicalSiblingCapturedMethodAbi(prepared.wat!, ["run__closure_2", "run__closure_3"]);
+      expect(prepared.wat).not.toContain("__call_m_");
+      expectNoImportRegression(direct, prepared, target);
+      expect(importLabels(prepared)).toEqual(
+        target === "gc" ? ["env::__box_boolean", "env::__box_number", "env::__unbox_number"] : [],
+      );
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
+
+  it("keeps sibling capture fan-out stable across changed incremental snapshots", async () => {
+    const source = `export function run(input: number): number {
+      const operations = {
+        add(value: number): number { return value + 2; }
+      };
+      const { add } = operations;
+      const selected = add;
+      const first = (value: number): number => selected(value);
+      const second = (value: number): number => selected(value);
+      return first(input) + second(0) - 2;
+    }`;
+    const unsafe = source.replace(
+      "return first(input) + second(0) - 2;",
+      "const escaped = { second }; return first(input) + escaped.second(0) - 2;",
+    );
+    const options = {
+      fileName: "object-method-value-sibling-capture-reuse.ts",
+      emitWat: true,
+      experimentalIR: true,
+      optimize: true,
+      trackIrOutcomes: true,
+    } as const;
+
+    const fresh = await compile(source, options);
+    const compiler = createIncrementalCompiler(options);
+    try {
+      const warmup = await compiler.compile(unsafe);
+      expect(warmup.success, warmup.errors.map((error) => error.message).join("\n")).toBe(true);
+      expect((await instantiate(warmup)).run!(40)).toBe(42);
+      expect(outcome(warmup)).toMatchObject({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      });
+      expect(warmup.irPostClaimErrors ?? []).toEqual([]);
+
+      const warmed = await compiler.compile(source);
+      const reused = await compiler.compile(source);
+      const exactBodies = ["run", "run__closure_0", "run__closure_1", "run__closure_2"];
+      for (const result of [fresh, warmed, reused]) {
+        expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(result.binary)).toBe(true);
+        expect((await instantiate(result)).run!(40)).toBe(42);
+        expect(outcome(result)).toMatchObject({
+          kind: "emitted",
+          legacyBodyEmitted: false,
+          irBodyEmitted: true,
+          preparedComponentId: expect.stringMatching(/^prepared-component:/),
+        });
+        expect(result.irPostClaimErrors ?? []).toEqual([]);
+        expect(result.irCompiledFuncs ?? []).toEqual(exactBodies);
+      }
+      expect(Buffer.from(warmed.binary)).toEqual(Buffer.from(fresh.binary));
+      expect(Buffer.from(reused.binary)).toEqual(Buffer.from(fresh.binary));
+    } finally {
+      compiler.dispose();
+    }
+  });
+
+  it("keeps mixed safe and escaped sibling captures atomic on the direct path", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const first = (value: number): number => add(value);
+        const second = (value: number): number => add(value);
+        const escaped = { second };
+        return first(input) + escaped.second(0) - 2;
       }`,
       {
-        fileName: "object-method-value-destructured-pattern-two-capture-owners-direct.ts",
+        fileName: "object-method-value-mixed-safe-escaped-sibling-direct.ts",
         experimentalIR: true,
         trackIrOutcomes: true,
       },


### PR DESCRIPTION
## Summary

- resolve closure-valued capture fields through the canonical prepared closure registry
- admit exact direct-property and destructured object-method values captured by bounded immediately nested const closures
- support sibling capture fan-out while preserving exact declaration identity, source order, mutation, escape, optional-call, and nesting guards
- keep canonical wrapper-root fields and deduplicate identical sibling closure subtypes
- update the #3522 Markdown checklist and next resumable boundary

## Optimization and parity evidence

- poison every migrated physical body in GC and standalone
- validate exact IR inventories, runtime result, typed `call_ref`, canonical-root ABI, and zero post-claim demotions
- standalone remains zero-import; GC adds no import absent from direct
- all optimized IR artifacts are no larger than direct; sibling cases improve 3,653→2,282 GC and 7,066→5,913 standalone, heterogeneous fan-out 4,362→2,827 GC and 7,707→6,245 standalone
- changed-snapshot incremental safe/unsafe compiles are byte-identical to fresh output

## Validation

- focused object-method suite: 65/65
- adjacent closure/object matrix: 103/103
- hybrid and strict IR-only shadow: 37/37 IR, 0 legacy, 0 blockers
- cross-backend differential: 29/29
- equivalence: 1,645 passing, 24 known failures, 12 baseline improvements, 0 new regressions
- fallback, host-import, typecheck, lint, formatting, LOC/function, oracle, coercion, issue-integrity, IR-adoption, and optimization-retirement gates pass

Tracks the migration in `plan/issues/3522-ir-r3-classes-closures-compile-once.md` (no GitHub Issue).