### PR TITLE
fix(ci): repair the retarget self-check broken by the js2 → js2wasm rename

### DIFF
--- a/scripts/hooks/push-remote-classify.sh
+++ b/scripts/hooks/push-remote-classify.sh
@@ -17,8 +17,9 @@
 #                                                  (loopdive/js2wasm-labs)
 #                                     public       a known public destination
 #                                                  (canonical loopdive/js2wasm,
-#                                                  legacy loopdive/js2wasm, or a
-#                                                  public fork <owner>/js2)
+#                                                  pre-rename legacy loopdive/js2,
+#                                                  or a public fork <owner>/js2wasm
+#                                                  or <owner>/js2)
 #                                     unknown      cannot be confirmed private
 #   run_labs_guard <remote> <url> reads pre-push ref lines on stdin; returns 0
 #                                 (allow) or 1 (block) and prints a diagnostic
@@ -33,8 +34,8 @@ LABS_PRIVATE_REPO="js2wasm-labs"
 # The canonical public repo name, and its pre-rename legacy alias. A remote
 # whose repo segment normalizes to the canonical name is public regardless of
 # owner, so upstream and public forks are both covered.
-PUBLIC_REPO_CANONICAL="js2"
-PUBLIC_REPO_LEGACY="js2wasm"
+PUBLIC_REPO_CANONICAL="js2wasm"
+PUBLIC_REPO_LEGACY="js2"
 NULL_OID="0000000000000000000000000000000000000000"
 
 # normalize_owner_repo <url> -> "owner/repo" | ""

--- a/scripts/retarget-stacked-pr-children.mjs
+++ b/scripts/retarget-stacked-pr-children.mjs
@@ -665,7 +665,7 @@ async function selfCheck() {
     baseSha: "9".repeat(40),
   });
 
-  assert.deepEqual(parseRepository(repo), { owner: "loopdive", name: "js2", fullName: repo });
+  assert.deepEqual(parseRepository(repo), { owner: "loopdive", name: "js2wasm", fullName: repo });
   assert.equal(parseParentNumber("10"), 10);
   assert.throws(() => parseRepository("loopdive/js2wasm/extra"), /owner\/name/);
   assert.throws(() => parseParentNumber("0"), /positive integer/);


### PR DESCRIPTION
## Description

Every PR merged since `be2ca8a6` ("chore: update repository references after the js2 → js2wasm rename") shows a red X. The failing job is **`retarget`** in `passive-stack-retarget.yml`. It runs on `pull_request_target: closed`, so it is only ever reported against a PR *after* it merges — nothing catches it beforehand and it cannot block the queue, which is why it went unnoticed.

**Root cause.** That sweep's substitution was deliberately anchored on `loopdive/js2` so it would not clobber the `@loopdive/js2` package name. That anchoring meant it rewrote the self-check's repo constant to `loopdive/js2wasm` but left the bare `"js2"` the assertion compares against:

```js
const repo = "loopdive/js2wasm";
…
assert.deepEqual(parseRepository(repo), { owner: "loopdive", name: "js2", fullName: repo });
```

`parseRepository` now correctly returns `js2wasm`, the assertion throws, and the job exits 1 at its **first** step — before it mints its App token or reaches the retarget call:

```
retarget-stacked-pr-children: Expected values to be strictly deep-equal:
+   name: 'js2wasm'
-   name: 'js2'
##[error]Process completed with exit code 1.
```

So stacked children have **not** been retargeted onto the default branch when their parent merges since that commit. This is a functional outage, not only a cosmetic X.

**Second file, same cause.** `scripts/hooks/push-remote-classify.sh` was hit by the same anchoring: the sweep rewrote the *legacy* alias to `js2wasm`, leaving canonical and legacy both naming the new repo and the header comment reading "canonical loopdive/js2wasm, legacy loopdive/js2wasm". Both names sit in one `case` branch, so classification was never wrong — swapping them restores the labels' meaning and is behaviour-neutral.

### Verification

- All three CI self-checks pass: `retarget-stacked-pr-children`, `enqueue-green-prs`, `auto-park-merge-group-failure` (the first fails on `main` today).
- `tests/hooks/pre-push-labs-remote.test.ts` — 34/34.
- Swept the tree for other bare `js2` literals orphaned by the same anchoring; the remaining hits are the fork name `ttraenkler/js2` (genuinely still named that) and unrelated benchmark lane IDs.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_018GMmrmDdsDNtRRTnvJrDeU)_