### PR TITLE
feat(website): plot both conformance lanes over time; unbreak standalone per-edition history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,7 +540,7 @@ jobs:
           # Sparse + blob-filtered clone (#3028): a plain --depth=1 clone pulls
           # every tip blob incl. the ~500 MB runs/ tree — minutes for one file.
           { git clone --depth=1 --filter=blob:none --no-checkout https://github.com/loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines \
-            && git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone /runs/index.json /runs/editions-index.json /runs/standalone-index.json \
+            && git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone /runs/index.json /runs/editions-index.json /runs/standalone-index.json /runs/standalone-editions-index.json \
             && git -C /tmp/js2wasm-baselines checkout main; } 2>/dev/null || true
           if [ -f /tmp/js2wasm-baselines/runs/index.json ]; then
             mkdir -p benchmarks/results/runs
@@ -552,6 +552,14 @@ jobs:
           [ -f /tmp/js2wasm-baselines/runs/standalone-index.json ] && \
             mkdir -p benchmarks/results/runs && \
             cp /tmp/js2wasm-baselines/runs/standalone-index.json benchmarks/results/runs/standalone-index.json
+          # (#4362) Per-edition STANDALONE trend series — the host-free twin of
+          # editions-index.json. The landing-page conformance chart plots both
+          # lanes at once, so a missing file here silently drops the standalone
+          # curve from every per-edition view.
+          [ -f /tmp/js2wasm-baselines/runs/standalone-editions-index.json ] && \
+            mkdir -p benchmarks/results/runs && \
+            cp /tmp/js2wasm-baselines/runs/standalone-editions-index.json \
+               benchmarks/results/runs/standalone-editions-index.json
 
       - name: Regenerate planning artifacts
         if: steps.npm_compat.outputs.only != 'true' && github.event_name == 'push'

--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -583,7 +583,7 @@ jobs:
           # fix in test262-sharded.yml promote-baseline). New runs/<sha> files
           # are staged via `git add -A --sparse`.
           git clone --depth=1 --filter=blob:none --no-checkout git@github.com:loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines
-          git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone '/*' '!/runs/*' '/runs/index.json' '/runs/editions-index.json' '/runs/standalone-index.json'
+          git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone '/*' '!/runs/*' '/runs/index.json' '/runs/editions-index.json' '/runs/standalone-index.json' '/runs/standalone-editions-index.json'
           git -C /tmp/js2wasm-baselines checkout main
 
           # (#3335) Trap-growth gate: refuse to bake a main-side increase of any

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -2677,7 +2677,14 @@ jobs:
           # so `git add -A` cannot stage them as deletions, and NEW runs/<sha>
           # cache files are staged explicitly via `git add -A --sparse`.
           git clone --depth=1 --filter=blob:none --no-checkout git@github.com:loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines
-          git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone '/*' '!/runs/*' '/runs/index.json' '/runs/editions-index.json' '/runs/standalone-index.json'
+          # (#4362) `/runs/standalone-editions-index.json` MUST be materialized
+          # here: append-run-history.mjs reads the existing array off disk and
+          # rewrites it. Left out of the sparse spec the file reads as absent,
+          # the append starts a FRESH one-entry array, and `git add -A --sparse`
+          # commits that over the real history — capping the standalone
+          # per-edition trend at a single point forever (and a one-point series
+          # is below the chart's 2-point floor, so the curve never renders).
+          git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone '/*' '!/runs/*' '/runs/index.json' '/runs/editions-index.json' '/runs/standalone-index.json' '/runs/standalone-editions-index.json'
           git -C /tmp/js2wasm-baselines checkout main
           cp /tmp/js2wasm-baselines/test262-current.jsonl /tmp/js2wasm-baselines/test262-current.before.jsonl 2>/dev/null || true
           cp /tmp/js2wasm-baselines/test262-standalone-current.jsonl /tmp/js2wasm-baselines/test262-standalone-current.before.jsonl 2>/dev/null || true
@@ -3106,6 +3113,17 @@ jobs:
             # feature-examples.json and wedge generate:feature-badges:check.
             [ -f website/public/feature-examples.json ] && \
               git add -f website/public/feature-examples.json || true
+            # (#4362) The STANDALONE (host-free) twins of the two artifacts
+            # above, written by the same "Regenerate edition buckets" step.
+            # They back the per-edition pass bars and feature rows whenever the
+            # "JS host" toggle is off. Unstaged, they froze at whatever the
+            # #4362 PR happened to commit while their host counterparts were
+            # refreshed on every promote — so the standalone lane silently
+            # served older numbers than the host lane on the same page.
+            [ -f website/public/benchmarks/results/test262-standalone-editions.json ] && \
+              git add -f website/public/benchmarks/results/test262-standalone-editions.json || true
+            [ -f website/public/feature-examples-standalone.json ] && \
+              git add -f website/public/feature-examples-standalone.json || true
             # Landing-page feature-support badges, re-derived from the promoted
             # baseline just above. Staged so the badges and the committed
             # test262-current.json land in ONE atomic commit (keeps
@@ -3538,8 +3556,16 @@ jobs:
           # Metadata-only clone, materialize root files + runs/index.json (skip
           # the huge runs/ blob history — #3392). NEW runs/<sha> files are staged
           # explicitly with `git add -A --sparse` below.
+          # (#4362) `/runs/standalone-editions-index.json` is listed even though
+          # this job never writes it: an index entry that exists on the remote
+          # but is NOT materialized here can be staged as a DELETION by the
+          # `git add -A --sparse` below, which is how the file promote-baseline
+          # appends kept disappearing from the baselines repo (it re-appears as
+          # "create mode" on the next promote, then gets removed again — so the
+          # standalone per-edition trend never accumulated a second point and
+          # the chart's 2-point floor kept the curve permanently hidden).
           git clone --depth=1 --filter=blob:none --no-checkout git@github.com:loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines
-          git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone '/*' '!/runs/*' '/runs/index.json' '/runs/editions-index.json' '/runs/standalone-index.json'
+          git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone '/*' '!/runs/*' '/runs/index.json' '/runs/editions-index.json' '/runs/standalone-index.json' '/runs/standalone-editions-index.json'
           git -C /tmp/js2wasm-baselines checkout main
 
           # Snapshot the pre-refresh JSONLs for the #3335 trap-growth gate.

--- a/website/components/trend-chart.js
+++ b/website/components/trend-chart.js
@@ -367,12 +367,25 @@ class TrendChart extends HTMLElement {
     const leftSeries = seriesDef.filter((s) => (s.axis || "left") !== "right");
     const rightSeries = seriesDef.filter((s) => s.axis === "right");
 
+    // A point may legitimately have NO value for a series — e.g. the
+    // conformance chart plots the js-host and standalone lanes together and
+    // the standalone lane starts later than the host one. `null` / `undefined`
+    // / non-numeric means "no measurement here": the line breaks instead of
+    // diving to zero, and the point contributes nothing to the y domain.
+    const valueAt = (series, i) => {
+      const raw = data[i]?.[series.key];
+      if (raw === null || raw === undefined || raw === "") return null;
+      const value = Number(raw);
+      return Number.isFinite(value) ? value : null;
+    };
+
     const calcDomain = (series) => {
       let min = Infinity;
       let max = -Infinity;
       for (const s of series) {
-        for (const d of data) {
-          const v = Number(d[s.key] || 0);
+        for (let i = 0; i < n; i++) {
+          const v = valueAt(s, i);
+          if (v === null) continue;
           if (v < min) min = v;
           if (v > max) max = v;
         }
@@ -395,13 +408,36 @@ class TrendChart extends HTMLElement {
     const yRight = rightDomain ? makeY(rightDomain) : null;
     const yForSeries = (series) => (series.axis === "right" && yRight ? yRight : yLeft);
 
-    const linePath = (valFn) => {
-      let p = `M ${x(0)} ${valFn(0)}`;
-      for (let i = 1; i < n; i++) {
+    // Split a series into runs of consecutive points that HAVE a value, so a
+    // gap renders as a break in the line rather than a plunge through zero.
+    const buildSegments = (series) => {
+      const y = yForSeries(series);
+      const segments = [];
+      let current = null;
+      for (let i = 0; i < n; i++) {
+        const v = valueAt(series, i);
+        if (v === null) {
+          current = null;
+          continue;
+        }
+        if (!current) {
+          current = [];
+          segments.push(current);
+        }
+        current.push({ i, y: y(v) });
+      }
+      return segments;
+    };
+
+    const segmentPath = (segment) => {
+      let p = `M ${x(segment[0].i)} ${segment[0].y}`;
+      for (let k = 1; k < segment.length; k++) {
+        const prev = segment[k - 1];
+        const point = segment[k];
         if (stepped) {
-          p += ` L ${x(i)} ${valFn(i - 1)} L ${x(i)} ${valFn(i)}`;
+          p += ` L ${x(point.i)} ${prev.y} L ${x(point.i)} ${point.y}`;
         } else {
-          p += ` L ${x(i)} ${valFn(i)}`;
+          p += ` L ${x(point.i)} ${point.y}`;
         }
       }
       return p;
@@ -434,11 +470,15 @@ class TrendChart extends HTMLElement {
       const width = s.lineWidth ?? (si === 0 ? 2 : 1.5);
       const opacity = s.lineOpacity ?? 1;
       const dasharray = s.dasharray ? ` stroke-dasharray="${s.dasharray}"` : "";
-      const y = yForSeries(s);
+      const segments = buildSegments(s);
 
-      paths += `<path d="${linePath((i) => y(Number(data[i][s.key] || 0)))}" fill="none" stroke="${color}" stroke-width="${width}" opacity="${opacity}"${dasharray}/>`;
+      for (const segment of segments) {
+        paths += `<path d="${segmentPath(
+          segment,
+        )}" fill="none" stroke="${color}" stroke-width="${width}" opacity="${opacity}"${dasharray}/>`;
+      }
 
-      if (s.fill) {
+      if (s.fill && segments.length > 0) {
         const gradId = `grad-${si}`;
         paths =
           `<defs><linearGradient id="${gradId}" x1="0" y1="0" x2="0" y2="1">
@@ -446,9 +486,14 @@ class TrendChart extends HTMLElement {
           <stop offset="100%" stop-color="${color}" stop-opacity="0"/>
         </linearGradient></defs>` + paths;
 
-        let fillPath = linePath((i) => y(Number(data[i][s.key] || 0)));
-        fillPath += ` L ${x(n - 1)} ${PAD.top + plotH} L ${x(0)} ${PAD.top + plotH} Z`;
-        paths += `<path d="${fillPath}" fill="url(#${gradId})"/>`;
+        // Fill each contiguous run separately — a single closed path across a
+        // gap would shade a stretch the series has no data for.
+        for (const segment of segments) {
+          const fillPath = `${segmentPath(segment)} L ${x(segment.at(-1).i)} ${PAD.top + plotH} L ${x(
+            segment[0].i,
+          )} ${PAD.top + plotH} Z`;
+          paths += `<path d="${fillPath}" fill="url(#${gradId})"/>`;
+        }
       }
     }
 
@@ -457,10 +502,11 @@ class TrendChart extends HTMLElement {
     if (seriesDef.length > 0) {
       const s = seriesDef[0];
       const y = yForSeries(s);
-      let peakIdx = 0;
+      let peakIdx = null;
       let peakVal = -Infinity;
       for (let i = 0; i < n; i++) {
-        const v = Number(data[i][s.key] || 0);
+        const v = valueAt(s, i);
+        if (v === null) continue;
         dots += `<circle cx="${x(i)}" cy="${y(v)}" r="2.5" fill="rgba(255,255,255,0.9)"/>`;
         if (v > peakVal) {
           peakVal = v;
@@ -468,8 +514,10 @@ class TrendChart extends HTMLElement {
         }
       }
       // Show value label above the peak point
-      const peakLabel = peakVal % 1 !== 0 ? peakVal.toFixed(1) + "%" : peakVal.toLocaleString();
-      dots += `<text x="${x(peakIdx)}" y="${y(peakVal) - 8}" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-size="10" font-weight="600" font-family="monospace">${peakLabel}</text>`;
+      if (peakIdx !== null) {
+        const peakLabel = peakVal % 1 !== 0 ? peakVal.toFixed(1) + "%" : peakVal.toLocaleString();
+        dots += `<text x="${x(peakIdx)}" y="${y(peakVal) - 8}" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-size="10" font-weight="600" font-family="monospace">${peakLabel}</text>`;
+      }
     }
 
     this.shadowRoot.innerHTML = `

--- a/website/index.html
+++ b/website/index.html
@@ -534,14 +534,23 @@
         height: 0;
         border-top: 2px solid rgba(255, 255, 255, 0.9);
       }
-      .diagram-legend-line.total {
+      /* The conformance trend plots both lanes at once: the selected one (the
+         "JS host" toggle) is the thick white line, the other a thinner solid
+         line. The legend mirrors that weighting so the two are told apart
+         without a colour key. */
+      .diagram-legend-item[data-selected="false"] .diagram-legend-line {
         border-top-width: 1px;
-        border-top-color: rgba(141, 154, 184, 1);
-        border-top-style: dotted;
+        border-top-color: rgba(255, 255, 255, 0.62);
       }
-      .diagram-legend-line.passed {
-        border-top-width: 1px;
-        border-top-color: rgba(255, 255, 255, 0.82);
+      .diagram-legend-item[data-selected="true"] {
+        color: var(--fg);
+      }
+      .diagram-legend-item[data-available="false"] {
+        opacity: 0.4;
+      }
+      .diagram-legend-note {
+        font-size: 9px;
+        letter-spacing: 0.02em;
       }
 
       .host-bench-copy {
@@ -1792,18 +1801,16 @@
           <div class="diagram-panel">
             <h3 class="diagram-title">ECMAScript Conformance Pass Rate Over Time</h3>
             <trend-chart id="conformance-history-chart" mode="step" height="260" x-key="time"></trend-chart>
-            <div class="diagram-legend">
-              <span class="diagram-legend-item">
+            <div class="diagram-legend" id="conformance-history-legend">
+              <span class="diagram-legend-item" data-lane="host" data-selected="true" data-available="true">
                 <span class="diagram-legend-line"></span>
-                <span>Pass rate</span>
+                <span>JS host pass rate</span>
+                <span class="diagram-legend-note"></span>
               </span>
-              <span class="diagram-legend-item">
-                <span class="diagram-legend-line passed"></span>
-                <span>Tests passed</span>
-              </span>
-              <span class="diagram-legend-item">
-                <span class="diagram-legend-line total"></span>
-                <span>Total tests run</span>
+              <span class="diagram-legend-item" data-lane="standalone" data-selected="false" data-available="true">
+                <span class="diagram-legend-line"></span>
+                <span>Standalone pass rate</span>
+                <span class="diagram-legend-note"></span>
               </span>
             </div>
           </div>
@@ -5287,59 +5294,115 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         return points;
       };
 
-      const CONFORMANCE_HISTORY_SERIES = JSON.stringify([
-        { key: "rate", color: "#ffffff", fill: true },
-        { key: "pass", color: "rgba(255,255,255,0.82)", axis: "right", lineWidth: 1, lineOpacity: 0.5 },
-        {
-          key: "total",
-          color: "rgba(141, 154, 184, 1)",
-          axis: "right",
-          lineWidth: 1,
-          lineOpacity: 1,
-          dasharray: "1 3",
-        },
-      ]);
+      // Both lanes on one axis: the SELECTED lane (the "JS host" toggle) is the
+      // thick white line with the gradient fill, the other lane the thinner
+      // solid line. The selected lane is listed FIRST because <trend-chart>
+      // attaches its point dots and peak label to seriesDef[0].
+      //
+      // The old third/fourth series ("Tests passed" and a dashed "Total tests
+      // run", both on a right-hand count axis) are gone: the chart now answers
+      // one question — how the two lanes' pass RATES compare over time — and
+      // the count axis only made the two rate lines harder to read. Absolute
+      // counts are still on the donut and the per-edition bars.
+      const conformanceHistorySeries = (hostEnabled) => {
+        const selected = { key: hostEnabled ? "hostRate" : "standaloneRate", color: "#ffffff", fill: true };
+        const other = {
+          key: hostEnabled ? "standaloneRate" : "hostRate",
+          color: "rgba(255,255,255,0.62)",
+          lineWidth: 1.25,
+        };
+        return JSON.stringify([selected, other]);
+      };
+
+      // Interleave the two lanes onto one x axis. The lanes are measured by
+      // different CI jobs at different times, so a given timestamp usually has
+      // a value for only one of them: carry each lane's last known value
+      // forward across the other's points (a step chart of a cumulative
+      // measure — the rate holds until the next run says otherwise), but leave
+      // a lane null BEFORE its first run so <trend-chart> breaks the line
+      // instead of drawing a fabricated leading segment.
+      const mergeConformanceLanes = (hostPoints, standalonePoints) => {
+        const byTime = new Map();
+        const collect = (points, key) => {
+          for (const point of points ?? []) {
+            const existing = byTime.get(point.time) ?? {
+              label: point.label,
+              timestamp: point.timestamp,
+              time: point.time,
+            };
+            existing[key] = point.rate;
+            byTime.set(point.time, existing);
+          }
+        };
+        collect(hostPoints, "hostRate");
+        collect(standalonePoints, "standaloneRate");
+
+        const merged = [...byTime.values()].sort((a, b) => a.time - b.time);
+        for (const key of ["hostRate", "standaloneRate"]) {
+          let last = null;
+          for (const point of merged) {
+            if (typeof point[key] === "number") last = point[key];
+            else point[key] = last;
+          }
+        }
+        return merged.length >= 2 ? merged : null;
+      };
+
+      const updateConformanceHistoryLegend = (hostEnabled, availability) => {
+        const legend = document.getElementById("conformance-history-legend");
+        if (!legend) return;
+        for (const item of legend.querySelectorAll(".diagram-legend-item")) {
+          const lane = item.dataset.lane;
+          const available = lane === "host" ? availability.host : availability.standalone;
+          item.dataset.selected = String(lane === (hostEnabled ? "host" : "standalone"));
+          item.dataset.available = String(!!available);
+          const note = item.querySelector(".diagram-legend-note");
+          if (note) note.textContent = available ? "" : "(no history yet)";
+        }
+      };
 
       async function updateConformanceHistoryChart(scope, hostEnabled) {
         const chart = document.getElementById("conformance-history-chart");
         if (!chart) return;
         try {
           const isOverallScope = !scope || scope === "overall" || scope === "overall+proposal";
-          let points = null;
 
-          if (isOverallScope) {
-            const runs = await fetchJsonSafe(
-              hostEnabled ? "./benchmarks/results/runs/index.json" : "./benchmarks/results/runs/standalone-index.json",
-            );
-            points = buildHistoryPoints(runs, (run) => ({
-              pass: run?.pass,
-              total: run?.total,
-              timestampRaw: run?.timestamp,
-            }));
-          } else {
-            // (#4362) Specific ES edition. The standalone lane now has its own
-            // per-edition trend series (`standalone-editions-index.json`,
-            // appended by scripts/append-run-history.mjs from the host-free
-            // edition buckets), so the chart tracks the toggle instead of
-            // hiding itself. It is deliberately NOT backfilled — no historical
-            // standalone edition snapshots exist — so the series starts short
-            // and `buildHistoryPoints`'s own `< 2 points` guard keeps the chart
-            // hidden until it has something real to plot. Never fall back to
-            // the host series here: a host curve under a "standalone" label is
-            // exactly the kind of quietly-wrong number this issue is fixing.
-            const runs = await fetchJsonSafe(
-              hostEnabled
-                ? "./benchmarks/results/runs/editions-index.json"
+          // BOTH lanes are always fetched for the current scope — the toggle
+          // now picks which curve is emphasised, not which one exists. Each
+          // lane keeps its OWN history file; a lane is never substituted for
+          // the other (a host curve under a "standalone" label is exactly the
+          // quietly-wrong number #4362 set out to kill), it just goes missing
+          // from the chart and is marked "(no history yet)" in the legend.
+          //
+          // (#4362) Per-edition standalone history lives in
+          // `standalone-editions-index.json`, appended by
+          // scripts/append-run-history.mjs from the host-free edition buckets.
+          // It is deliberately not backfilled, so that lane starts short.
+          const [hostRuns, standaloneRuns] = await Promise.all([
+            fetchJsonSafe(
+              isOverallScope ? "./benchmarks/results/runs/index.json" : "./benchmarks/results/runs/editions-index.json",
+            ),
+            fetchJsonSafe(
+              isOverallScope
+                ? "./benchmarks/results/runs/standalone-index.json"
                 : "./benchmarks/results/runs/standalone-editions-index.json",
-            );
-            const label = normalizeEditionLabel(scope);
-            points = buildHistoryPoints(runs, (run) => {
-              if (!Array.isArray(run?.editions)) return null;
-              const entry = run.editions.find((e) => normalizeEditionLabel(String(e?.edition || "")) === label);
-              if (!entry) return null;
-              return { pass: entry.pass, total: entry.total, timestampRaw: run.timestamp };
-            });
-          }
+            ),
+          ]);
+
+          const extract = isOverallScope
+            ? (run) => ({ pass: run?.pass, total: run?.total, timestampRaw: run?.timestamp })
+            : (run) => {
+                const label = normalizeEditionLabel(scope);
+                if (!Array.isArray(run?.editions)) return null;
+                const entry = run.editions.find((e) => normalizeEditionLabel(String(e?.edition || "")) === label);
+                if (!entry) return null;
+                return { pass: entry.pass, total: entry.total, timestampRaw: run.timestamp };
+              };
+
+          const hostPoints = buildHistoryPoints(hostRuns, extract);
+          const standalonePoints = buildHistoryPoints(standaloneRuns, extract);
+          const points = mergeConformanceLanes(hostPoints, standalonePoints);
+          updateConformanceHistoryLegend(hostEnabled, { host: !!hostPoints, standalone: !!standalonePoints });
 
           if (!points) {
             chart.hidden = true;
@@ -5347,7 +5410,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           }
 
           chart.setAttribute("labels-key", "label");
-          chart.setAttribute("series", CONFORMANCE_HISTORY_SERIES);
+          chart.setAttribute("series", conformanceHistorySeries(hostEnabled));
           chart.data = points;
           chart.hidden = false;
         } catch {


### PR DESCRIPTION
## Description

The landing page's **ECMAScript Conformance Pass Rate Over Time** chart plotted only the lane the `JS host` toggle selected, plus a right-axis "Tests passed" line and a dashed "Total tests run" line. For an individual ES edition in **standalone** mode it plotted nothing at all — the per-edition standalone history file it reads (`runs/standalone-editions-index.json`) has never existed in `loopdive/js2wasm-baselines`.

### Chart (`website/index.html`)

- Both lanes are drawn for the current scope. The **selected** lane is the thick white line with the gradient fill; the other lane reuses the old second line's weight, made a little more salient.
- The count series ("Tests passed", dashed "Total tests run") are removed, along with the right-hand count axis they needed. The chart answers one question now — how the two lanes' pass *rates* compare over time. Absolute counts remain on the donut and the per-edition bars. The legend names the two lanes instead of the three old series.
- A lane with no history is marked `(no history yet)` in the legend instead of hiding the whole chart. A lane is never substituted for the other (a host curve under a "standalone" label is the quietly-wrong number #4362 set out to kill).

### `website/components/trend-chart.js`

- Series values may now be `null`/absent, meaning "not measured here": the line breaks, the fill stops at the gap, and the point is excluded from the y domain, the dots and the peak label — instead of the old `Number(v || 0)` plunge to zero. Needed because the two lanes are measured by different CI jobs at different times and the standalone lane starts later, so gaps are the normal case.

### Data pipeline (root cause of the missing standalone edition trend)

- `runs/standalone-editions-index.json` is now materialized by **every** sparse-checkout of the baselines repo. It was missing from the per-SHA promote job's sparse spec, so `git add -A --sparse` in that job staged its **deletion**, undoing the append `promote-baseline` had just made. The file kept reappearing as `create mode` in one job and vanishing in the next, so it never accumulated a second point — and a one-point series is below the chart's 2-point floor, which is why the curve was permanently absent.
- `test262-standalone-editions.json` and `feature-examples-standalone.json` are now staged in the promote commit like their host twins. Unstaged, they were frozen at whatever #4362 committed (15 edition buckets vs the host lane's current 17) while the host files refreshed on every promote — so the standalone lane served older numbers than the host lane on the same page.

### Verification

Driven in a headless browser against the real baselines-repo history (`runs/index.json`, `runs/editions-index.json`, `runs/standalone-index.json`), with a synthesized `standalone-editions-index.json` for the per-edition lane:

- overall + host, overall + standalone, ES2015 + host, ES2015 + standalone — both lines render, correct weighting follows the toggle, y domain spans both series, peak label tracks the selected lane;
- with `standalone-editions-index.json` removed (production's current state) the chart degrades to the host line plus a `(no history yet)` legend note rather than disappearing.

No console/page errors. `prettier --check` clean; `biome` does not scan `website/`.

The standalone per-edition curve starts appearing once two promotes have landed with the sparse fix in place — the history is deliberately not backfilled, since no historical standalone edition snapshots exist.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmfiGERvoPX7QevNBTtvLY)_