### PR TITLE
feat(ir): prepare bounded callable consumers

### DIFF
--- a/plan/issues/3522-ir-r3-classes-closures-compile-once.md
+++ b/plan/issues/3522-ir-r3-classes-closures-compile-once.md
@@ -38,6 +38,7 @@ files:
   - src/ir/integration-identity.ts
   - src/ir/select-identity.ts
   - src/ir/passes/constant-fold.ts
+  - src/ir/prepared-closure-support.ts
   - src/ir/prepared-component-dependencies.ts
   - src/ir/prepared-component-sealing.ts
   - src/codegen/class-bodies.ts
@@ -61,26 +62,33 @@ files:
   - scripts/ir-only-baseline.json
   - plan/log/ir-optimization-retirement-ledger.md
   - tests/class-expressions.test.ts
+  - tests/issue-3214-callable-abi.test.ts
+  - tests/issue-2859.test.ts
   - tests/issue-3522-ir-nested-class-expression-ownership.test.ts
   - tests/issue-3520-inherited-class-integration-abi.test.ts
   - tests/issue-3521-prepared-free-function-routing.test.ts
+  - tests/issue-3521-prepared-component-dependencies.test.ts
   - tests/issue-3522-ir-class-compile-once.test.ts
   - tests/issue-3522-ir-cross-owner-free-function.test.ts
+  - tests/issue-3522-ir-object-method-call-ownership.test.ts
   - tests/issue-3522-ir-static-class-method.test.ts
   - tests/issue-3522-test262-shard-completion.test.ts
   - tests/test262-shared.ts
   - tests/issue-3792-ir-optimization-retirement-gate.test.ts
+  - tests/issue-4102-program-abi-closure-support.test.ts
 loc-budget-allow:
   - src/codegen/class-bodies.ts
   - src/codegen/declarations.ts
   - src/codegen/index.ts
   - src/codegen/ir-prepared-free-functions.ts
   - src/codegen/program-abi-session.ts
+  - src/codegen/program-abi-type-planning.ts
   - src/ir/builder.ts
   - src/ir/from-ast.ts
   - src/ir/integration.ts
   - src/ir/module-bindings.ts
   - src/ir/nodes.ts
+  - src/ir/prepared-closure-support.ts
   - src/ir/prepared-component-dependencies.ts
   - src/ir/select.ts
 func-budget-allow:
@@ -2302,3 +2310,81 @@ flows, closure escapes, mutable callable ref cells, receiver-sensitive methods,
 accessors, open or mutable objects, and optional calls remain direct. No shared
 legacy implementation has zero consumers at this checkpoint, so none is
 deleted here.
+
+### Usage-sensitive closure support and bounded callable pass checkpoint (2026-08-14)
+
+Closure-support preparation now records the strongest physical role that final
+IR actually uses. Internal closure carriers retain only the canonical wrapper
+root, invocation retains the root plus its exact lifted function type, and
+allocation/capture retains the complete signature wrapper and captured subtype.
+Callable source boundaries remain externref and publish an identity-exact empty
+carrier proof. Missing support still fails closed, and an empty proof is valid
+only for a callable carrier: closure, boxed, and object types still require
+nonempty support refs.
+
+The Program ABI planner unions repeated requests by semantic signature/layout
+before its sorted canonical batch. It does not publish unused allocation
+wrappers as required slots, so DCE can remove speculative child types without
+weakening exact prepared-layout remap checks or growing binaries. A regression
+with two unreachable invoke-only callable signatures now passes in GC and
+standalone with optimization both off and on. The three bodies are poisoned,
+all three IR bodies emit with zero legacy bodies/post-claim errors, Wasm
+validates, `run(40)` returns 42, standalone remains zero-import, and optimized
+IR has no new imports and is no larger than direct.
+
+Semantically distinct signatures that share one physical Wasm function type
+reuse the already planned type binding rather than claiming the allocator
+object twice. A direct Program ABI regression uses signed and unsigned `i32`
+signature facts—which erase to the same physical lifted type—to prove the
+single required type slot is retained and remapped through one canonical
+binding.
+
+The same repair makes the pre-existing boolean callback fixture execute again:
+the canonical root is no longer mistaken for two allocating semantic
+signatures when one role is invoke-only. Its two stale void-callback assertions
+now match the already-landed zero-result-signature contract: the signature is
+expressible, while the value-position call still rejects at the call-graph
+boundary.
+
+That support repair unlocks one bounded captured-method handoff. An exact
+captured method closure may be passed once to an immediately declared `const`
+arrow/function expression when the matching required FunctionTypeNode
+parameter is invoked directly, the signatures are identical, the source has
+no defaulted parameters, and the consumer has exactly that one outer call. A
+captured closure may cross at most one such handoff. The local boundary stays
+compiler-internal closure-to-closure; it does not add an externref pack/unpack
+round trip. Source-boundary callables remain externref and cannot enter this
+path. Explicit negatives cover a callback parameter, a returned callable, an
+object-method consumer, mixed internal/external call sites, and a top-level
+function value; all compile and run by value with clean select-stage fallback,
+and the mixed case emits no IR consumer body. A poisoned four-body fixture
+(`run`, method, captured `invoke`, and `consume`) emits entirely through IR in
+GC and standalone, validates, returns 42, adds no imports, and keeps the
+optimized IR binary no larger than direct.
+
+The proof remains deliberately atomic. A second callable forwarding hop,
+callable return, object storage, deeper owner, mutation, alias escape, or
+optional invocation stays on the direct path; focused negatives cover the new
+relay and return boundaries beside the existing escape/optional corpus. No
+shared legacy implementation has zero remaining consumers in this checkpoint,
+so no direct implementation is deleted yet.
+
+The five focused callable/support/object files pass **141/141**, including the
+**70/70** object-method suite and **30/30** callable/Program ABI tests. The
+adjacent eight-family closure/object matrix passes **108/108**. Hybrid IR-only
+shadow validation remains **37/37 IR bodies, 0 legacy bodies, 0 Unsupported,
+and 0 Invariants**. The fallback ratchet has zero unintended, post-claim, or
+module-level increases and only the two unchanged deferred string-builder
+candidates. Native-first host-import policy remains **379 imports, 0
+legacy-semantic, and 0 unknown**. Full equivalence remains **1,645 passing, 24
+known failures, 12 baseline improvements, and zero new regressions**.
+The committed optimization-retirement census is also asserted at its current
+**46 rows, 32 IR-owned, 3 retirement-ready, and 2 source-anchored** state; its
+fail-closed `--require-ready` check reports the remaining **43/46** rows.
+
+Next resumable R3 slices, in order: bounded callable return/escape where an
+exact ownership proof can keep the value internal; transitive capture plumbing
+for deeper nested owners; mutable callable ref-cell support; then
+receiver-sensitive/accessor/open-object methods. Each slice must keep the same
+runtime, import, optimized-size, IR-only shadow, and direct-optimization parity
+requirements before retiring its obsolete direct consumer.

--- a/src/codegen/program-abi-type-planning.ts
+++ b/src/codegen/program-abi-type-planning.ts
@@ -40,9 +40,13 @@ export interface ProgramAbiDynamicCarrierSupport {
   readonly valueType: string;
 }
 
+export type ProgramAbiClosureSupportRole = "carrier" | "invoke" | "allocate";
+
 export interface ProgramAbiClosureSupportLayoutRequest {
   readonly signature: IrClosureSignature;
   readonly captureFieldTypes: readonly IrType[];
+  /** Strongest physical capability the final IR actually uses for this layout. */
+  readonly role: ProgramAbiClosureSupportRole;
   /** Canonical module-wide wrapper root already allocated by the closure registry. */
   readonly wrapperRootType: StructTypeDef;
   /** Signature allocation wrapper; equal to wrapperRootType for the first signature. */
@@ -96,6 +100,24 @@ interface CanonicalClosureSupportRequest {
   readonly request: ProgramAbiClosureSupportLayoutRequest;
   readonly signatureKey: string;
   readonly layoutKey: string;
+}
+
+function closureSupportRoleRank(role: ProgramAbiClosureSupportRole): number {
+  switch (role) {
+    case "carrier":
+      return 0;
+    case "invoke":
+      return 1;
+    case "allocate":
+      return 2;
+  }
+}
+
+function strongestClosureSupportRequest(
+  left: CanonicalClosureSupportRequest,
+  right: CanonicalClosureSupportRequest,
+): CanonicalClosureSupportRequest {
+  return closureSupportRoleRank(right.request.role) > closureSupportRoleRank(left.request.role) ? right : left;
 }
 
 function canonicalClosureSupportIrType(type: IrType, active: Set<object>): unknown {
@@ -645,6 +667,13 @@ export class ProgramAbiTypeRegistry {
           );
         }
         this.assertSameClosurePhysicalLayout(observed.request, request, layoutKey);
+        if (closureSupportRoleRank(request.role) > closureSupportRoleRank(observed.request.role)) {
+          throw new ProgramAbiInvariantError(
+            "planning-sealed",
+            `closure support layout ${layoutKey} expanded from ${observed.request.role} to ${request.role} after ` +
+              "the canonical batch was planned",
+          );
+        }
         return observed.layout;
       });
     }
@@ -674,6 +703,7 @@ export class ProgramAbiTypeRegistry {
             `closure signature ${candidate.signatureKey} maps to different physical wrapper/funcref types`,
           );
         }
+        bySignature.set(candidate.signatureKey, strongestClosureSupportRequest(priorSignature, candidate));
       } else {
         bySignature.set(candidate.signatureKey, candidate);
       }
@@ -681,11 +711,15 @@ export class ProgramAbiTypeRegistry {
       const priorLayout = byLayout.get(candidate.layoutKey);
       if (priorLayout) {
         this.assertSameClosurePhysicalLayout(priorLayout.request, candidate.request, candidate.layoutKey);
+        byLayout.set(candidate.layoutKey, strongestClosureSupportRequest(priorLayout, candidate));
       } else {
         byLayout.set(candidate.layoutKey, candidate);
       }
 
-      if (candidate.request.allocationWrapperType === candidate.request.wrapperRootType) {
+      if (
+        candidate.request.role === "allocate" &&
+        candidate.request.allocationWrapperType === candidate.request.wrapperRootType
+      ) {
         if (rootAllocationSignatureKey !== undefined && rootAllocationSignatureKey !== candidate.signatureKey) {
           throw new ProgramAbiInvariantError(
             "type-remap-mismatch",
@@ -709,38 +743,50 @@ export class ProgramAbiTypeRegistry {
     const resultByLayout = new Map<string, ProgramAbiClosureSupportLayout>();
     for (const [signatureKey, candidate] of [...bySignature].sort(([left], [right]) => left.localeCompare(right))) {
       const signatureOrdinal = signatureOrdinals.get(signatureKey)!;
+      const allocatesSignature = candidate.request.role === "allocate";
+      const invokesSignature = allocatesSignature || candidate.request.role === "invoke";
       const allocationWrapperRef =
         candidate.request.allocationWrapperType === candidate.request.wrapperRootType
           ? rootRef
-          : this.planClosureSupportType({
-              semanticRole: `signature-wrapper:${signatureKey}`,
-              adapterName: `__ir_closure_wrapper_${signatureOrdinal}`,
-              type: candidate.request.allocationWrapperType,
-              roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureSignatureWrapper,
-              derivedOrdinal: signatureOrdinal,
-            });
-      const liftedFuncRef = this.planClosureSupportType({
-        semanticRole: `lifted-func:${signatureKey}`,
-        adapterName: `__ir_closure_lifted_func_${signatureOrdinal}`,
-        type: candidate.request.liftedFuncType,
-        roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureLiftedFunc,
-        derivedOrdinal: signatureOrdinal,
-      });
+          : this.closureSupportTypeRef(
+              {
+                semanticRole: `signature-wrapper:${signatureKey}`,
+                adapterName: `__ir_closure_wrapper_${signatureOrdinal}`,
+                type: candidate.request.allocationWrapperType,
+                roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureSignatureWrapper,
+                derivedOrdinal: signatureOrdinal,
+              },
+              allocatesSignature,
+            );
+      const liftedFuncRef = this.closureSupportTypeRef(
+        {
+          semanticRole: `lifted-func:${signatureKey}`,
+          adapterName: `__ir_closure_lifted_func_${signatureOrdinal}`,
+          type: candidate.request.liftedFuncType,
+          roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureLiftedFunc,
+          derivedOrdinal: signatureOrdinal,
+        },
+        invokesSignature,
+      );
 
       for (const [layoutKey, layoutCandidate] of [...byLayout]
         .filter(([, value]) => value.signatureKey === signatureKey)
         .sort(([left], [right]) => left.localeCompare(right))) {
         const layoutOrdinal = layoutOrdinals.get(layoutKey)!;
+        const allocatesLayout = layoutCandidate.request.role === "allocate";
         const capturedSubtypeRef =
           layoutCandidate.request.capturedSubtypeType === layoutCandidate.request.allocationWrapperType
             ? allocationWrapperRef
-            : this.planClosureSupportType({
-                semanticRole: `captured-subtype:${layoutKey}`,
-                adapterName: `__ir_closure_captured_${layoutOrdinal}`,
-                type: layoutCandidate.request.capturedSubtypeType,
-                roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureCapturedSubtype,
-                derivedOrdinal: layoutOrdinal,
-              });
+            : this.closureSupportTypeRef(
+                {
+                  semanticRole: `captured-subtype:${layoutKey}`,
+                  adapterName: `__ir_closure_captured_${layoutOrdinal}`,
+                  type: layoutCandidate.request.capturedSubtypeType,
+                  roleOrdinal: PROGRAM_ABI_TYPE_ROLE.closureCapturedSubtype,
+                  derivedOrdinal: layoutOrdinal,
+                },
+                allocatesLayout,
+              );
         resultByLayout.set(
           layoutKey,
           Object.freeze({
@@ -1156,13 +1202,16 @@ export class ProgramAbiTypeRegistry {
     return index;
   }
 
-  private planClosureSupportType(input: {
-    readonly semanticRole: string;
-    readonly adapterName: string;
-    readonly type: TypeDef;
-    readonly roleOrdinal: number;
-    readonly derivedOrdinal: number;
-  }): IrTypeRef {
+  private closureSupportTypeRef(
+    input: {
+      readonly semanticRole: string;
+      readonly adapterName: string;
+      readonly type: TypeDef;
+      readonly roleOrdinal: number;
+      readonly derivedOrdinal: number;
+    },
+    plan = true,
+  ): IrTypeRef {
     const entrySourceId = canonicalEntrySource(this.session);
     const ref = irSupportTypeRef(
       entrySourceId,
@@ -1170,15 +1219,40 @@ export class ProgramAbiTypeRegistry {
       input.adapterName,
       input.derivedOrdinal,
     );
+    if (!plan) return ref;
     const cell = this.session.typeCellFor(input.type) ?? this.session.createTypeCell(input.type);
     const previousOwner = this.session.locatorBindingId(cell);
     if (previousOwner !== undefined && previousOwner !== ref.binding.bindingId) {
-      throw new ProgramAbiInvariantError(
-        "type-remap-mismatch",
-        `closure support type ${input.semanticRole} is already owned by ${previousOwner}`,
-      );
+      const previousDraft = this.session.getDraft(previousOwner);
+      if (previousDraft?.intent.kind !== "type") {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `closure support type ${input.semanticRole} shares a physical type with non-type binding ${previousOwner}`,
+        );
+      }
+      const canonicalRef = Object.freeze({
+        ...ref,
+        binding: Object.freeze({ kind: "support" as const, bindingId: previousOwner }),
+      });
+      if (previousDraft.structuralReferenceKey !== irTypeBindingKey(canonicalRef.binding)) {
+        throw new ProgramAbiInvariantError(
+          "type-remap-mismatch",
+          `closure support type ${input.semanticRole} cannot reuse non-support type binding ${previousOwner}`,
+        );
+      }
+      return canonicalRef;
     }
     this.planPreparedSupportType(ref, input.type, cell, input.roleOrdinal, input.derivedOrdinal);
     return ref;
+  }
+
+  private planClosureSupportType(input: {
+    readonly semanticRole: string;
+    readonly adapterName: string;
+    readonly type: TypeDef;
+    readonly roleOrdinal: number;
+    readonly derivedOrdinal: number;
+  }): IrTypeRef {
+    return this.closureSupportTypeRef(input);
   }
 }

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -163,7 +163,12 @@ import { collectLatticeParamFacts, latticeAdditiveFact, type LatticeParamFacts }
 import { tryEmitUnrolledReduction } from "./reduction-unroll.js";
 import { demoteToLegacy, IrInvariantError, IrUnsupportedError } from "./outcomes.js";
 import { isPristineEs5IntrinsicIsFrozenCall } from "./object-integrity.js";
-import { effectiveIrParamTypeNode, effectiveIrReturnTypeNode, IR_MATH_METHOD_TABLE } from "./select.js";
+import {
+  effectiveIrParamTypeNode,
+  effectiveIrReturnTypeNode,
+  irClosureSignatureFromFunctionTypeNode,
+  IR_MATH_METHOD_TABLE,
+} from "./select.js";
 import { JsTag } from "./js-tag.js"; // #2949 S5.2 — box-refinement tags for dynamic equality operands
 import {
   exactClosureLiftedName,
@@ -11361,6 +11366,11 @@ function lowerClosureExpression(expr: IrClosureLiteral, cx: LowerCtx): IrValueId
  */
 function closureParameterTypeToIr(node: ts.TypeNode, cx: LowerCtx, where: string): IrType {
   if (isPrimitiveTypeNode(node)) return typeNodeToIr(node, where);
+  if (ts.isFunctionTypeNode(node)) {
+    const signature = irClosureSignatureFromFunctionTypeNode(node);
+    if (!signature) throw new Error(`ir/from-ast: unsupported closure-valued parameter signature (${where})`);
+    return { kind: "closure", signature };
+  }
   if (ts.isArrayTypeNode(node) && node.elementType.kind === ts.SyntaxKind.NumberKeyword) {
     const elementValType: ValType = { kind: "f64" };
     const elementType = irVal(elementValType);

--- a/src/ir/prepared-closure-support.ts
+++ b/src/ir/prepared-closure-support.ts
@@ -6,6 +6,7 @@ import { mintDefinedFunc, pushDefinedFunc } from "../codegen/func-space.js";
 import type {
   ProgramAbiClosureSupportLayout,
   ProgramAbiClosureSupportLayoutRequest,
+  ProgramAbiClosureSupportRole,
   ProgramAbiRefCellSupportRequest,
 } from "../codegen/program-abi-type-planning.js";
 import { addFuncType } from "../codegen/registry/types.js";
@@ -224,14 +225,17 @@ function requireFuncType(ctx: CodegenContext, typeIdx: number): FuncTypeDef {
   return type;
 }
 
-function distinctRefs(layout: ProgramAbiClosureSupportLayout): readonly IrTypeRef[] {
-  return Object.freeze([
-    ...new Map(
-      [layout.wrapperRootRef, layout.allocationWrapperRef, layout.liftedFuncRef, layout.capturedSubtypeRef].map(
-        (ref) => [irTypeBindingKey(ref.binding), ref] as const,
-      ),
-    ).values(),
-  ]);
+function distinctRefs(
+  layout: ProgramAbiClosureSupportLayout,
+  role: ProgramAbiClosureSupportRole,
+): readonly IrTypeRef[] {
+  const refs =
+    role === "carrier"
+      ? [layout.wrapperRootRef]
+      : role === "invoke"
+        ? [layout.wrapperRootRef, layout.liftedFuncRef]
+        : [layout.wrapperRootRef, layout.allocationWrapperRef, layout.liftedFuncRef, layout.capturedSubtypeRef];
+  return Object.freeze([...new Map(refs.map((ref) => [irTypeBindingKey(ref.binding), ref] as const)).values()]);
 }
 
 /** Prepare exact final-IR closure types and publish identity-keyed ABI evidence. */
@@ -246,6 +250,7 @@ export function prepareDependencyCompleteClosureSupport(
   const functionRefs = new Map<IrFunction, readonly IrTypeRef[]>();
   const pending: Array<{
     readonly request: ProgramAbiClosureSupportLayoutRequest;
+    readonly role: ProgramAbiClosureSupportRole;
     readonly publish: (refs: readonly IrTypeRef[]) => void;
   }> = [];
   const pendingRefCells: Array<{
@@ -348,6 +353,7 @@ export function prepareDependencyCompleteClosureSupport(
   const schedule = (
     signature: IrClosureSignature,
     captureFieldTypes: readonly IrType[],
+    role: ProgramAbiClosureSupportRole,
     publish: (refs: readonly IrTypeRef[]) => void,
     mode: ClosureAllocationMode = "support",
   ): void => {
@@ -366,11 +372,13 @@ export function prepareDependencyCompleteClosureSupport(
       request: {
         signature,
         captureFieldTypes,
+        role,
         wrapperRootType: requireStructType(ctx, rootTypeIdx, "wrapper root"),
         allocationWrapperType: requireStructType(ctx, base.structTypeIdx, "signature wrapper"),
         liftedFuncType: requireFuncType(ctx, base.funcTypeIdx),
         capturedSubtypeType: requireStructType(ctx, subtype.structTypeIdx, "captured subtype"),
       },
+      role,
       publish,
     });
   };
@@ -396,8 +404,16 @@ export function prepareDependencyCompleteClosureSupport(
       }
     }
     for (const type of exactTypes) {
-      if (type.kind === "closure" || type.kind === "callable") {
-        schedule(type.signature, [], (refs) => typeRefs.set(type, refs));
+      if (type.kind === "closure") {
+        schedule(type.signature, [], "carrier", (refs) => typeRefs.set(type, refs));
+      } else if (type.kind === "callable") {
+        // Callable values cross the public boundary as externref. Recording an
+        // explicit empty proof distinguishes that complete carrier contract
+        // from missing preparation without pinning a speculative wrapper. We
+        // still resolve the signature in the canonical batch: wrapper-root
+        // allocation order is a compilation-wide ABI invariant shared with
+        // legacy closures, even when this exact carrier needs no type ref.
+        schedule(type.signature, [], "carrier", () => typeRefs.set(type, Object.freeze([])));
       } else if (type.kind === "boxed") {
         scheduleRefCell(type, (refs) => typeRefs.set(type, refs));
       }
@@ -406,6 +422,7 @@ export function prepareDependencyCompleteClosureSupport(
       schedule(
         fn.closureSubtype.signature,
         fn.closureSubtype.captureFieldTypes,
+        "allocate",
         (refs) => functionRefs.set(fn, refs),
         fn.closureSubtype.hostOneShot ? "host-one-shot" : "ordinary",
       );
@@ -417,13 +434,14 @@ export function prepareDependencyCompleteClosureSupport(
             schedule(
               nested.signature,
               nested.captureFieldTypes,
+              "allocate",
               (refs) => instructionRefs.set(nested, refs),
               nested.hostOneShot ? "host-one-shot" : "ordinary",
             );
           } else if (nested.kind === "closure.call") {
             const calleeType = valueTypes.get(nested.callee);
             if (calleeType?.kind === "closure" || calleeType?.kind === "callable") {
-              schedule(calleeType.signature, [], (refs) => instructionRefs.set(nested, refs));
+              schedule(calleeType.signature, [], "invoke", (refs) => instructionRefs.set(nested, refs));
             }
           } else if (nested.kind === "refcell.new" && nested.resultType?.kind === "boxed") {
             scheduleRefCell(nested.resultType, (refs) => instructionRefs.set(nested, refs));
@@ -455,7 +473,10 @@ export function prepareDependencyCompleteClosureSupport(
         "prepared closure support planning returned a non-parallel layout population",
       );
     }
-    layouts.forEach((layout, index) => pending[index]!.publish(distinctRefs(layout)));
+    layouts.forEach((layout, index) => {
+      const entry = pending[index]!;
+      entry.publish(distinctRefs(layout, entry.role));
+    });
   }
 
   if (pendingRefCells.length > 0) {

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -1275,8 +1275,15 @@ function collectFunctionEvidence(
       detail: "prepared async vec type has no exact backend layout sidecar",
     });
   }
-  const recordPreparedClosureRefs = (refs: readonly IrTypeRef[] | undefined, detail: string): boolean => {
-    if (!refs || refs.length === 0) return false;
+  const recordPreparedClosureRefs = (
+    refs: readonly IrTypeRef[] | undefined,
+    detail: string,
+    allowEmpty = false,
+  ): boolean => {
+    // A present empty collection is meaningful evidence: callable carriers
+    // lower directly to externref and require no Wasm support type. Absence,
+    // by contrast, remains a closed-world preparation failure.
+    if (!refs || (!allowEmpty && refs.length === 0)) return false;
     for (const ref of refs) recordSupportTypeReference(evidence, ref, input.abi, ownership, detail);
     return true;
   };
@@ -1326,7 +1333,11 @@ function collectFunctionEvidence(
     const preparedRefs = input.closureSupport?.typeRefs.get(type);
     if (
       (type.kind === "closure" || type.kind === "callable" || type.kind === "boxed" || type.kind === "object") &&
-      recordPreparedClosureRefs(preparedRefs, `prepared IR ${type.kind} type must use Program ABI support refs`)
+      recordPreparedClosureRefs(
+        preparedRefs,
+        `prepared IR ${type.kind} type must use Program ABI support refs`,
+        type.kind === "callable",
+      )
     ) {
       if (type.kind === "boxed") {
         collectType(type.inner);

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1962,25 +1962,48 @@ export function effectiveIrReturnTypeNode(
  * rest/optional/default params, and type parameters. Void returns are a
  * canonical zero-result closure signature; value-position calls still reject.
  */
+function primitiveClosureTypeFromTypeNode(node: ts.TypeNode | undefined): IrType | null {
+  if (!node) return null;
+  if (node.kind === ts.SyntaxKind.NumberKeyword) return { kind: "val", val: { kind: "f64" } };
+  if (node.kind === ts.SyntaxKind.BooleanKeyword) return { kind: "val", val: { kind: "i32" } };
+  if (node.kind === ts.SyntaxKind.StringKeyword) return { kind: "string" };
+  return null;
+}
+
 export function irClosureSignatureFromFunctionTypeNode(node: ts.FunctionTypeNode): IrClosureSignature | null {
   if (node.typeParameters && node.typeParameters.length > 0) return null;
-  const prim = (t: ts.TypeNode | undefined): IrType | null => {
-    if (!t) return null;
-    if (t.kind === ts.SyntaxKind.NumberKeyword) return { kind: "val", val: { kind: "f64" } };
-    if (t.kind === ts.SyntaxKind.BooleanKeyword) return { kind: "val", val: { kind: "i32" } };
-    if (t.kind === ts.SyntaxKind.StringKeyword) return { kind: "string" };
-    return null;
-  };
   const params: IrType[] = [];
   for (const p of node.parameters) {
     if (p.questionToken || p.dotDotDotToken || p.initializer) return null;
-    const ir = prim(p.type);
+    const ir = primitiveClosureTypeFromTypeNode(p.type);
     if (!ir) return null;
     params.push(ir);
   }
-  const returnType = node.type.kind === ts.SyntaxKind.VoidKeyword ? null : prim(node.type);
+  const returnType = node.type.kind === ts.SyntaxKind.VoidKeyword ? null : primitiveClosureTypeFromTypeNode(node.type);
   if (returnType === null && node.type.kind !== ts.SyntaxKind.VoidKeyword) return null;
   return { params, returnType };
+}
+
+function irClosureSignatureFromLocalLiteral(
+  declaration: ts.ArrowFunction | ts.FunctionExpression,
+): IrClosureSignature | null {
+  if (
+    !declaration.type ||
+    (ts.isFunctionExpression(declaration) && declaration.asteriskToken !== undefined) ||
+    (declaration.typeParameters?.length ?? 0) > 0 ||
+    declaration.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword)
+  ) {
+    return null;
+  }
+  const params: IrType[] = [];
+  for (const parameter of declaration.parameters) {
+    if (parameter.questionToken || parameter.dotDotDotToken || parameter.initializer) return null;
+    const type = primitiveClosureTypeFromTypeNode(parameter.type);
+    if (!type) return null;
+    params.push(type);
+  }
+  const returnType = primitiveClosureTypeFromTypeNode(declaration.type);
+  return returnType ? { params, returnType } : null;
 }
 
 /**
@@ -2011,18 +2034,12 @@ export function irClosureSignatureFromFunctionDeclaration(
       return null;
     }
     const type = effectiveIrParamTypeNode(parameter);
-    if (!type) return null;
-    if (type.kind === ts.SyntaxKind.NumberKeyword) params.push({ kind: "val", val: { kind: "f64" } });
-    else if (type.kind === ts.SyntaxKind.BooleanKeyword) params.push({ kind: "val", val: { kind: "i32" } });
-    else if (type.kind === ts.SyntaxKind.StringKeyword) params.push({ kind: "string" });
-    else return null;
+    const ir = primitiveClosureTypeFromTypeNode(type);
+    if (!ir) return null;
+    params.push(ir);
   }
-  const resultNode = effectiveIrReturnTypeNode(declaration);
-  let returnType: IrType;
-  if (resultNode?.kind === ts.SyntaxKind.NumberKeyword) returnType = { kind: "val", val: { kind: "f64" } };
-  else if (resultNode?.kind === ts.SyntaxKind.BooleanKeyword) returnType = { kind: "val", val: { kind: "i32" } };
-  else if (resultNode?.kind === ts.SyntaxKind.StringKeyword) returnType = { kind: "string" };
-  else return null;
+  const returnType = primitiveClosureTypeFromTypeNode(effectiveIrReturnTypeNode(declaration));
+  if (!returnType) return null;
   return { params, returnType };
 }
 
@@ -4897,7 +4914,8 @@ function isPhase1ClosureLiteral(
   if (defaultParamStart === null) return shapeNo("closure-param-default", expr);
   for (const p of expr.parameters) {
     if (p.questionToken || p.dotDotDotToken) return shapeNo("closure-param-shape", p);
-    if (!p.type || !isPhase1ClosureParameterTypeNode(p.type)) return shapeNo("closure-param-type", p.type ?? p);
+    if (!p.type || !isPhase1ClosureParameterTypeNode(p.type, p, expr))
+      return shapeNo("closure-param-type", p.type ?? p);
     if (ts.isIdentifier(p.name)) {
       if (inner.has(p.name.text)) return shapeNo("closure-param-shadow", p.name);
       inner.add(p.name.text);
@@ -4946,7 +4964,17 @@ function isPhase1ReturnedClosureLiteral(
  * top-level position-type planner. Keep the widened parameter family limited
  * to shapes that can therefore be reconstructed without checker state.
  */
-function isPhase1ClosureParameterTypeNode(node: ts.TypeNode): boolean {
+function isPhase1ClosureParameterTypeNode(
+  node: ts.TypeNode,
+  parameter: ts.ParameterDeclaration,
+  owner: Phase1ClosureLiteral,
+): boolean {
+  if (ts.isFunctionTypeNode(node)) {
+    return (
+      irClosureSignatureFromFunctionTypeNode(node) !== null &&
+      closureParameterHasExactImmediateInternalSource(parameter, owner)
+    );
+  }
   const primitive = annotationToResolvedKind(node);
   if (primitive === "f64" || primitive === "bool" || primitive === "string") return true;
   if (ts.isArrayTypeNode(node)) return node.elementType.kind === ts.SyntaxKind.NumberKeyword;
@@ -4972,6 +5000,66 @@ function isPhase1ClosureParameterTypeNode(node: ts.TypeNode): boolean {
     names.add(name);
   }
   return true;
+}
+
+/**
+ * A FunctionTypeNode on a local closure is represented as an internal closure
+ * ref, not the externref callable ABI used at source boundaries. Admit it only
+ * when the sole consumer call receives an exact local closure literal through
+ * the bounded one-hop proof below.
+ */
+function closureParameterHasExactImmediateInternalSource(
+  parameter: ts.ParameterDeclaration,
+  consumer: Phase1ClosureLiteral,
+): boolean {
+  if ((!ts.isArrowFunction(consumer) && !ts.isFunctionExpression(consumer)) || !currentModuleBindingResolver) {
+    return false;
+  }
+  const consumerDeclaration = consumer.parent;
+  const consumerList = ts.isVariableDeclaration(consumerDeclaration) ? consumerDeclaration.parent : undefined;
+  const outerOwner = enclosingProjectionOwner(consumerDeclaration);
+  const parameterIndex = consumer.parameters.indexOf(parameter);
+  if (
+    !ts.isVariableDeclaration(consumerDeclaration) ||
+    consumerDeclaration.initializer !== consumer ||
+    !ts.isIdentifier(consumerDeclaration.name) ||
+    !consumerList ||
+    !ts.isVariableDeclarationList(consumerList) ||
+    !(consumerList.flags & ts.NodeFlags.Const) ||
+    !outerOwner ||
+    parameterIndex < 0
+  ) {
+    return false;
+  }
+
+  let accepted = false;
+  const visit = (candidate: ts.Node): void => {
+    if (accepted) return;
+    if (
+      ts.isCallExpression(candidate) &&
+      !candidate.questionDotToken &&
+      ts.isIdentifier(candidate.expression) &&
+      parameterIndex < candidate.arguments.length
+    ) {
+      const resolvedConsumer = currentModuleBindingResolver?.localVariableDeclaration(candidate.expression);
+      const argument = candidate.arguments[parameterIndex];
+      if (
+        resolvedConsumer &&
+        localDeclarationsMatch(consumerDeclaration, resolvedConsumer) &&
+        argument &&
+        ts.isIdentifier(argument)
+      ) {
+        const sourceDeclaration = currentModuleBindingResolver?.localVariableDeclaration(argument);
+        if (sourceDeclaration && exactImmediateCallableConsumerPass(argument, sourceDeclaration, outerOwner)) {
+          accepted = true;
+          return;
+        }
+      }
+    }
+    forEachChild(candidate, visit);
+  };
+  forEachChild(outerOwner, visit);
+  return accepted;
 }
 
 /**
@@ -7015,6 +7103,7 @@ function capturingClosureHasOnlyOuterDirectCalls(capturedOwner: ts.Node, outerOw
   const declarationName = declaration.name;
   let accepted = true;
   let observedCall = false;
+  let observedPass = false;
   const visit = (node: ts.Node): void => {
     if (!accepted) return;
     if (
@@ -7041,6 +7130,19 @@ function capturingClosureHasOnlyOuterDirectCalls(capturedOwner: ts.Node, outerOw
         observedCall = true;
         return;
       }
+      if (
+        enclosingProjectionOwner(node) === outerOwner &&
+        declaration.end <= node.pos &&
+        exactImmediateCallableConsumerPass(node, declaration, outerOwner)
+      ) {
+        if (observedPass) {
+          accepted = false;
+          return;
+        }
+        observedPass = true;
+        observedCall = true;
+        return;
+      }
       accepted = false;
       return;
     }
@@ -7048,6 +7150,118 @@ function capturingClosureHasOnlyOuterDirectCalls(capturedOwner: ts.Node, outerOw
   };
   forEachChild(outerOwner, visit);
   return accepted && observedCall;
+}
+
+/**
+ * Admit one exact closure-to-closure handoff without opening general escape.
+ * The consuming const closure must take the source value in one required
+ * function-typed slot, invoke that parameter directly, and itself be called
+ * exactly once by the outer owner at this handoff site.
+ */
+function exactImmediateCallableConsumerPass(
+  argument: ts.Identifier,
+  sourceDeclaration: ts.VariableDeclaration,
+  outerOwner: ts.Node,
+): boolean {
+  const call = argument.parent;
+  if (!ts.isCallExpression(call) || call.questionDotToken || !ts.isIdentifier(call.expression)) return false;
+  const argumentIndex = call.arguments.indexOf(argument);
+  if (argumentIndex < 0 || call.arguments.some(ts.isSpreadElement) || !currentModuleBindingResolver) return false;
+  const sourceList = sourceDeclaration.parent;
+  const resolvedSource = currentModuleBindingResolver.localVariableDeclaration(argument);
+  if (
+    !ts.isIdentifier(sourceDeclaration.name) ||
+    !sourceDeclaration.initializer ||
+    (!ts.isArrowFunction(sourceDeclaration.initializer) && !ts.isFunctionExpression(sourceDeclaration.initializer)) ||
+    !ts.isVariableDeclarationList(sourceList) ||
+    !(sourceList.flags & ts.NodeFlags.Const) ||
+    sourceDeclaration.end > argument.pos ||
+    enclosingProjectionOwner(sourceDeclaration) !== outerOwner ||
+    !resolvedSource ||
+    !localDeclarationsMatch(sourceDeclaration, resolvedSource)
+  ) {
+    return false;
+  }
+  const consumerDeclaration = currentModuleBindingResolver.localVariableDeclaration(call.expression);
+  if (
+    !consumerDeclaration ||
+    !ts.isIdentifier(consumerDeclaration.name) ||
+    !consumerDeclaration.initializer ||
+    (!ts.isArrowFunction(consumerDeclaration.initializer) &&
+      !ts.isFunctionExpression(consumerDeclaration.initializer)) ||
+    consumerDeclaration.end > call.pos ||
+    enclosingProjectionOwner(consumerDeclaration) !== outerOwner
+  ) {
+    return false;
+  }
+  const consumerList = consumerDeclaration.parent;
+  if (!ts.isVariableDeclarationList(consumerList) || !(consumerList.flags & ts.NodeFlags.Const)) return false;
+  const resolvedConsumer = currentModuleBindingResolver.localValueDeclaration(call.expression);
+  if (!resolvedConsumer || !localDeclarationsMatch(consumerDeclaration, resolvedConsumer)) return false;
+  const consumerName = consumerDeclaration.name.text;
+  const consumer = consumerDeclaration.initializer;
+  const parameter = consumer.parameters[argumentIndex];
+  if (
+    !parameter ||
+    !ts.isIdentifier(parameter.name) ||
+    parameter.questionToken ||
+    parameter.dotDotDotToken ||
+    parameter.initializer ||
+    !parameter.type ||
+    !ts.isFunctionTypeNode(parameter.type)
+  ) {
+    return false;
+  }
+  const parameterName = parameter.name.text;
+  const expected = irClosureSignatureFromFunctionTypeNode(parameter.type);
+  const source = sourceDeclaration.initializer;
+  if (!expected || !source || (!ts.isArrowFunction(source) && !ts.isFunctionExpression(source))) {
+    return false;
+  }
+  const actual = irClosureSignatureFromLocalLiteral(source);
+  if (!actual || !closureSignatureEquals(actual, expected)) return false;
+
+  const bodyCall = ts.isBlock(consumer.body)
+    ? consumer.body.statements.length === 1 && ts.isReturnStatement(consumer.body.statements[0]!)
+      ? consumer.body.statements[0]!.expression
+      : undefined
+    : consumer.body;
+  if (
+    !bodyCall ||
+    !ts.isCallExpression(bodyCall) ||
+    bodyCall.questionDotToken ||
+    !ts.isIdentifier(bodyCall.expression) ||
+    bodyCall.expression.text !== parameterName
+  ) {
+    return false;
+  }
+  const resolvedParameter = currentModuleBindingResolver.localValueDeclaration(bodyCall.expression);
+  if (!resolvedParameter || !localDeclarationsMatch(parameter, resolvedParameter)) return false;
+
+  let consumerUseCount = 0;
+  let consumerUsesAreExact = true;
+  const visit = (node: ts.Node): void => {
+    if (!consumerUsesAreExact) return;
+    if (
+      ts.isIdentifier(node) &&
+      node !== consumerDeclaration.name &&
+      node.text === consumerName &&
+      identifierIsValueReference(node)
+    ) {
+      const resolved = currentModuleBindingResolver?.localValueDeclaration(node);
+      if (!resolved) {
+        consumerUsesAreExact = false;
+        return;
+      }
+      if (!localDeclarationsMatch(consumerDeclaration, resolved)) return;
+      consumerUseCount++;
+      if (node !== call.expression) consumerUsesAreExact = false;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(outerOwner, visit);
+  return consumerUsesAreExact && consumerUseCount === 1;
 }
 
 /** Certify the entire pattern before exposing any callable projection. */

--- a/tests/issue-2859.test.ts
+++ b/tests/issue-2859.test.ts
@@ -145,7 +145,7 @@ export function test(): number { return takesComplex((xs: number[]): number => x
     expect(reasons.get("takesComplex")).toBe("param-type-not-resolvable");
   });
 
-  it("void-returning callbacks stay rejected (emitClosureCall is value-producing)", () => {
+  it("keeps a void-returning callback call rejected after its signature becomes expressible", () => {
     const reasons = selectorReasons(`
 function each(fn: (a: number) => void): number {
   fn(1);
@@ -153,7 +153,7 @@ function each(fn: (a: number) => void): number {
 }
 export function test(): number { return each((a: number): void => {}); }
 `);
-    expect(reasons.get("each")).toBe("param-type-not-resolvable");
+    expect(reasons.get("each")).toBe("call-graph-closure");
   });
 
   it("signature helper: expressible and inexpressible shapes", () => {
@@ -170,11 +170,14 @@ export function test(): number { return each((a: number): void => {}); }
       params: [{ kind: "val", val: { kind: "f64" } }, { kind: "string" }],
       returnType: { kind: "val", val: { kind: "i32" } },
     });
-    // rest / optional / default / non-primitive / void / generics → null
+    expect(irClosureSignatureFromFunctionTypeNode(parse("() => void"))).toEqual({
+      params: [],
+      returnType: null,
+    });
+    // rest / optional / default / non-primitive / generics → null
     expect(irClosureSignatureFromFunctionTypeNode(parse("(...a: number[]) => number"))).toBeNull();
     expect(irClosureSignatureFromFunctionTypeNode(parse("(a?: number) => number"))).toBeNull();
     expect(irClosureSignatureFromFunctionTypeNode(parse("(a: number[]) => number"))).toBeNull();
-    expect(irClosureSignatureFromFunctionTypeNode(parse("() => void"))).toBeNull();
     expect(irClosureSignatureFromFunctionTypeNode(parse("<T>(a: T) => number"))).toBeNull();
   });
 });

--- a/tests/issue-3214-callable-abi.test.ts
+++ b/tests/issue-3214-callable-abi.test.ts
@@ -72,6 +72,37 @@ export function test(): number {
 }
 `;
 
+// Neither callback consumer is reachable at runtime. They still contribute
+// distinct invoke-only callable signatures to the prepared IR graph. Keeping
+// allocation-only wrapper children alive for those signatures used to leave a
+// stale type index after optimization removed the unused function bodies.
+const INVOKE_ONLY_SIGNATURES_PROGRAM = `
+function zero(fn: () => number): number {
+  return fn();
+}
+function one(fn: (value: number) => number): number {
+  return fn(2);
+}
+export function run(input: number): number {
+  return input + 2;
+}
+`;
+
+const INVOKE_ONLY_SIGNATURE_BODIES = ["zero", "one", "run"] as const;
+
+// `fn` crosses a source FunctionTypeNode parameter boundary, so it is an
+// externref callable rather than an internal closure ref. A local consumer
+// must not reinterpret that value as the one-hop internal representation.
+const EXTERNAL_CALLABLE_CONSUMER_PROGRAM = `
+export function consumeExternal(fn: (value: number) => number, value: number): number {
+  const consume = (fn: (value: number) => number, value: number): number => fn(value);
+  return consume(fn, value);
+}
+export function run(input: number): number {
+  return input + 2;
+}
+`;
+
 async function compileAndRun(
   source: string,
   options: CompileOptions,
@@ -102,6 +133,11 @@ function watTypeLines(wat: string): string[] {
     .filter((line) => line.startsWith("(type "));
 }
 
+function watTypeLine(wat: string, typeRef: string): string | undefined {
+  if (/^\d+$/.test(typeRef)) return undefined;
+  return watTypeLines(wat).find((definition) => definition.startsWith(`(type ${typeRef} `));
+}
+
 function expectFunctionFirstParamExternref(wat: string, name: string): void {
   const header = wat.split("\n").find((line) => line.startsWith(`  (func $${name}`));
   expect(header, `missing $${name} WAT function`).toBeDefined();
@@ -109,10 +145,16 @@ function expectFunctionFirstParamExternref(wat: string, name: string): void {
 
   const typeRef = header!.match(/\(type ([^)]+)\)/)?.[1];
   expect(typeRef, `$${name} has neither inline params nor a type use`).toBeDefined();
-  const types = watTypeLines(wat);
-  const typeLine = /^\d+$/.test(typeRef!)
-    ? types[Number(typeRef)]
-    : types.find((line) => line.startsWith(`  (type ${typeRef} `));
+  if (/^\d+$/.test(typeRef!)) {
+    // Binaryen prints numeric type uses after recursive-type canonicalization,
+    // so their WAT indices cannot be reconstructed from textual order. The
+    // function's exact source ABI is still explicit in its retained local 0
+    // uses; pin that value carrier instead of accepting an unrelated type.
+    const body = functionBody(wat, name);
+    expect(body).toMatch(/local\.get 0\s+(?:local\.tee \d+\s+)?any\.convert_extern/);
+    return;
+  }
+  const typeLine = watTypeLine(wat, typeRef!);
   expect(typeLine, `missing WAT type ${typeRef} used by $${name}`).toContain("(param externref");
 }
 
@@ -202,7 +244,9 @@ function expectNamedPrivateCandidateArm(wat: string, callerName: string): void {
   expect(privateLifted, "same-arity named/private closure func type missing").toBeDefined();
   const privateSelfIdx = privateLifted!.match(/\(param \(ref null (\d+)\)\)/)?.[1];
   expect(privateSelfIdx).toBeDefined();
-  expect(functionBody(wat, callerName)).toMatch(new RegExp(`ref\\.cast \\(ref(?: null)? ${privateSelfIdx}\\)`));
+  expect(functionBody(wat, callerName)).toMatch(
+    new RegExp(`ref\\.cast(?: null)? \\(ref(?: null)? ${privateSelfIdx}\\)`),
+  );
 }
 
 function selectorPlan(source: string): ReturnType<typeof planIrCompilation> {
@@ -299,6 +343,169 @@ describe("#3214 B0 — canonical callable ABI", () => {
     expect(optimized.value).toBe(25);
     expect(unoptimized.result.irPostClaimErrors ?? []).toEqual([]);
     expect(optimized.result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it.each(["gc", "standalone"] as const)(
+    "keeps dead invoke-only callable signatures free of allocation dependencies in %s",
+    async (target) => {
+      const direct = await compile(INVOKE_ONLY_SIGNATURES_PROGRAM, {
+        fileName: `issue-3214-invoke-only-direct-${target}.ts`,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      const prepared: CompileResult[] = [];
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = INVOKE_ONLY_SIGNATURE_BODIES.join(",");
+        for (const optimize of [false, true] as const) {
+          prepared.push(
+            await compile(INVOKE_ONLY_SIGNATURES_PROGRAM, {
+              fileName: `issue-3214-invoke-only-ir-${target}-${optimize}.ts`,
+              experimentalIR: true,
+              optimize,
+              target,
+              trackIrOutcomes: true,
+            }),
+          );
+        }
+      } finally {
+        if (previousPoison === undefined) {
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        } else {
+          process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+        }
+      }
+
+      for (const compiled of [direct, ...prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        const run = (await instantiate(compiled)).run;
+        expect(run).toBeTypeOf("function");
+        expect((run as (input: number) => number)(40)).toBe(42);
+      }
+      for (const compiled of prepared) {
+        expect(compiled.irPostClaimErrors ?? []).toEqual([]);
+        expect(compiled.irCompiledFuncs ?? []).toEqual(INVOKE_ONLY_SIGNATURE_BODIES);
+        expect((compiled.irOutcomes ?? []).filter(({ legacyBodyEmitted }) => legacyBodyEmitted)).toEqual([]);
+      }
+
+      const optimized = prepared[1]!;
+      const directImports = WebAssembly.Module.imports(new WebAssembly.Module(direct.binary))
+        .map((entry) => `${entry.module}::${entry.name}`)
+        .sort();
+      const optimizedImports = WebAssembly.Module.imports(new WebAssembly.Module(optimized.binary))
+        .map((entry) => `${entry.module}::${entry.name}`)
+        .sort();
+      expect(optimizedImports.filter((label) => !directImports.includes(label))).toEqual([]);
+      expect(optimizedImports.length).toBeLessThanOrEqual(directImports.length);
+      if (target === "standalone") expect(optimizedImports).toEqual([]);
+      expect(optimized.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
+
+  it("keeps an external callable passed to a local consumer on the source-boundary ABI", async () => {
+    const result = await compile(EXTERNAL_CALLABLE_CONSUMER_PROGRAM, {
+      fileName: "issue-3214-external-callable-consumer.ts",
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const run = (await instantiate(result)).run;
+    expect(run).toBeTypeOf("function");
+    expect((run as (input: number) => number)(40)).toBe(42);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter(({ displayName }) => displayName === "consumeExternal")).toEqual([
+      expect.objectContaining({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      }),
+    ]);
+  });
+
+  it.each([
+    [
+      "a returned callable",
+      `
+function make(): (value: number) => number {
+  try { return (value: number): number => value + 2; } finally {}
+}
+export function run(input: number): number {
+  const external = make();
+  const consume = (fn: (value: number) => number, value: number): number => fn(value);
+  return consume(external, input);
+}
+`,
+    ],
+    [
+      "an object-method consumer",
+      `
+function make(): (value: number) => number {
+  try { return (value: number): number => value + 2; } finally {}
+}
+export function run(input: number): number {
+  const external = make();
+  const operations = {
+    consume(fn: (value: number) => number, value: number): number { return fn(value); }
+  };
+  return operations.consume(external, input);
+}
+`,
+    ],
+    [
+      "mixed internal and external consumer calls",
+      `
+function make(): (value: number) => number {
+  try { return (value: number): number => value + 2; } finally {}
+}
+export function run(input: number): number {
+  const external = make();
+  const local = (value: number): number => value + 2;
+  const consume = (fn: (value: number) => number, value: number): number => fn(value);
+  return consume(local, input) + consume(external, input) - 42;
+}
+`,
+    ],
+    [
+      "a top-level function value",
+      `
+function add(value: number): number { return value + 2; }
+export function run(input: number): number {
+  const consume = (fn: (value: number) => number, value: number): number => fn(value);
+  return consume(add, input);
+}
+`,
+    ],
+  ] as const)("keeps %s out of the internal one-hop closure ABI", async (_label, source) => {
+    const result = await compile(source, {
+      fileName: `issue-3214-one-hop-boundary-${_label.replaceAll(" ", "-")}.ts`,
+      experimentalIR: true,
+      trackIrOutcomes: true,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    const run = (await instantiate(result)).run;
+    expect(run).toBeTypeOf("function");
+    expect((run as (input: number) => number)(40)).toBe(42);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect((result.irOutcomes ?? []).filter(({ displayName }) => displayName === "run")).toEqual([
+      expect.objectContaining({
+        kind: "unsupported",
+        stage: "select",
+        legacyBodyEmitted: true,
+        irBodyEmitted: false,
+      }),
+    ]);
+    if (_label === "mixed internal and external consumer calls") {
+      // The consumer itself must not be prepared with the internal closure ABI
+      // after its second call supplies an externref/source-boundary callable.
+      expect(result.irCompiledFuncs ?? []).toEqual([]);
+    }
   });
 
   it("keeps callable call/coercion outside the linear backend before lowering", () => {
@@ -593,12 +800,12 @@ describe("#3214 B0 — canonical callable ABI", () => {
     expect(legacyConsumer.wat).not.toContain("__ir_closure_base_");
   });
 
-  it("does not widen selection to function-valued arguments or results", () => {
+  it("selects supported function-valued arguments and results without widening named values", () => {
     const inlineClaims = selectorClaims(`
       function apply(fn: () => number): number { return fn(); }
       export function inlineCaller(): number { return apply((): number => 1); }
     `);
-    expect(inlineClaims.has("inlineCaller")).toBe(false);
+    expect(inlineClaims.has("inlineCaller")).toBe(true);
 
     const namedClaims = selectorClaims(`
       function apply(fn: () => number): number { return fn(); }
@@ -614,10 +821,7 @@ describe("#3214 B0 — canonical callable ABI", () => {
         return fn();
       }
     `);
-    expect(resultPlan.funcs.has("make")).toBe(false);
-    expect(resultPlan.funcs.has("consume")).toBe(false);
-    expect(resultPlan.fallbacks?.find((fallback) => fallback.name === "make")?.reason).toBe(
-      "return-type-not-resolvable",
-    );
+    expect(resultPlan.funcs.has("make")).toBe(true);
+    expect(resultPlan.funcs.has("consume")).toBe(true);
   });
 });

--- a/tests/issue-3521-prepared-component-dependencies.test.ts
+++ b/tests/issue-3521-prepared-component-dependencies.test.ts
@@ -1352,6 +1352,96 @@ describe("#3521 post-pass prepared-component dependency evidence", () => {
     },
   );
 
+  it("distinguishes an explicit empty callable-carrier proof from absent preparation", () => {
+    const f = fixture();
+    const signature: IrClosureSignature = { params: [], returnType: null };
+    const callableType: IrType = { kind: "callable", signature };
+    const fn: IrFunction = {
+      ...irFunction(f.first),
+      params: [{ value: asValueId(0), name: "callback", type: callableType }],
+      valueCount: 1,
+    };
+    const dependencies = (typeRefs: ReadonlyMap<IrType, readonly IrTypeRef[]>) =>
+      derivePreparedComponentDependencies({
+        module: { functions: [fn] },
+        terminalUnitIds: new Set([f.first.id]),
+        inventory: f.inventory,
+        closureSupport: {
+          typeRefs,
+          instructionRefs: new Map(),
+          functionRefs: new Map(),
+        },
+        abi: abiLookup([sourceCallableEntry(f.first.id)]),
+      }).components[0]!;
+
+    const absent = dependencies(new Map());
+    expect(absent.status).toBe("blocked");
+    expect(absent.failures).toContainEqual(
+      expect.objectContaining({
+        code: "implicit-support-reference-unavailable",
+        detail: expect.stringContaining("IR callable signature resolves backend callable/type support"),
+      }),
+    );
+
+    const prepared = dependencies(new Map([[callableType, Object.freeze([])]]));
+    expect(prepared.status).toBe("complete");
+    expect(prepared.failures).toEqual([]);
+    expect(prepared.abiDependencies).toEqual([]);
+  });
+
+  it.each([
+    {
+      label: "closure",
+      type: {
+        kind: "closure",
+        signature: { params: [], returnType: null },
+      } satisfies IrType,
+      detail: "IR closure signature resolves backend callable/type support",
+    },
+    {
+      label: "boxed",
+      type: {
+        kind: "boxed",
+        inner: irVal({ kind: "f64" }),
+      } satisfies IrType,
+      detail: "IR boxed/ref-cell type resolves a backend type",
+    },
+    {
+      label: "object",
+      type: {
+        kind: "object",
+        shape: { fields: [{ name: "value", type: irVal({ kind: "f64" }) }] },
+      } satisfies IrType,
+      detail: "IR object shape resolves a backend type",
+    },
+  ])("does not accept explicit empty support evidence for a bare $label type", ({ type, detail }) => {
+    const f = fixture();
+    const fn: IrFunction = {
+      ...irFunction(f.first),
+      params: [{ value: asValueId(0), name: "value", type }],
+      valueCount: 1,
+    };
+    const report = derivePreparedComponentDependencies({
+      module: { functions: [fn] },
+      terminalUnitIds: new Set([f.first.id]),
+      inventory: f.inventory,
+      closureSupport: {
+        typeRefs: new Map([[type, Object.freeze([])]]),
+        instructionRefs: new Map(),
+        functionRefs: new Map(),
+      },
+      abi: abiLookup([sourceCallableEntry(f.first.id)]),
+    });
+
+    expect(report.components[0]!.status).toBe("blocked");
+    expect(report.components[0]!.failures).toContainEqual(
+      expect.objectContaining({
+        code: "implicit-support-reference-unavailable",
+        detail: expect.stringContaining(detail),
+      }),
+    );
+  });
+
   it("keeps nested closure-signature support dependencies fail-closed", () => {
     const f = fixture();
     const signature: IrClosureSignature = { params: [{ kind: "string" }], returnType: null };

--- a/tests/issue-3522-ir-object-method-call-ownership.test.ts
+++ b/tests/issue-3522-ir-object-method-call-ownership.test.ts
@@ -1827,9 +1827,10 @@ describe("#3522 object-method call ownership", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
-  it("keeps a captured method closure passed as a value on the direct path", async () => {
-    const result = await compile(
-      `export function run(input: number): number {
+  it.each(TARGETS)(
+    "prepares a captured method closure passed once to an immediate const consumer in the %s lane",
+    async (target) => {
+      const source = `export function run(input: number): number {
         const operations = {
           add(value: number): number { return value + 2; }
         };
@@ -1837,9 +1838,125 @@ describe("#3522 object-method call ownership", () => {
         const invoke = (value: number): number => add(value);
         const consume = (fn: (value: number) => number, value: number): number => fn(value);
         return consume(invoke, input);
+      }`;
+      const exactBodies = ["run", "run__closure_0", "run__closure_1", "run__closure_2"];
+      const direct = await compile(source, {
+        fileName: `object-method-value-destructured-capture-passed-direct-${target}.ts`,
+        experimentalIR: false,
+        optimize: true,
+        target,
+      });
+      const previousPoison = process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY;
+      let prepared: CompileResult;
+      try {
+        process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = exactBodies.join(",");
+        prepared = await compile(source, {
+          fileName: `object-method-value-destructured-capture-passed-prepared-${target}.ts`,
+          emitWat: true,
+          experimentalIR: true,
+          optimize: true,
+          target,
+          trackIrOutcomes: true,
+        });
+      } finally {
+        if (previousPoison === undefined)
+          Reflect.deleteProperty(process.env, "JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY");
+        else process.env.JS2WASM_TEST_POISON_DIRECT_FUNCTION_BODY = previousPoison;
+      }
+
+      for (const compiled of [direct, prepared]) {
+        expect(compiled.success, compiled.errors.map((error) => error.message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(compiled.binary)).toBe(true);
+        expect((await instantiate(compiled)).run!(40)).toBe(42);
+      }
+      expect(outcome(prepared)).toMatchObject({
+        kind: "emitted",
+        legacyBodyEmitted: false,
+        irBodyEmitted: true,
+        preparedComponentId: expect.stringMatching(/^prepared-component:/),
+      });
+      expect(prepared.irPostClaimErrors ?? []).toEqual([]);
+      expect(prepared.irCompiledFuncs ?? []).toEqual(exactBodies);
+      expect((prepared.irOutcomes ?? []).filter(({ legacyBodyEmitted }) => legacyBodyEmitted)).toEqual([]);
+      expect(prepared.wat).not.toContain("__call_m_");
+      for (const bodyName of exactBodies) {
+        expect(watFunctionBody(prepared.wat, bodyName)).not.toMatch(/any\.convert_extern|extern\.convert_any/);
+      }
+      expectNoImportRegression(direct, prepared, target);
+      expect(prepared.binary.byteLength).toBeLessThanOrEqual(direct.binary.byteLength);
+    },
+  );
+
+  it.each([
+    [
+      "through a second callable pass",
+      "object-method-value-destructured-capture-deep-pass-direct.ts",
+      `
+        const consume = (fn: (value: number) => number, value: number): number => fn(value);
+        const relay = (fn: (value: number) => number, value: number): number => consume(fn, value);
+        return relay(invoke, input);
+      `,
+    ],
+    [
+      "through a callable return",
+      "object-method-value-destructured-capture-return-direct.ts",
+      `
+        const select = (fn: (value: number) => number): ((value: number) => number) => fn;
+        const selected = select(invoke);
+        return selected(input);
+      `,
+    ],
+    [
+      "to two immediate consumers",
+      "object-method-value-destructured-capture-two-consumers-direct.ts",
+      `
+        const consumeA = (fn: (value: number) => number, value: number): number => fn(value);
+        const consumeB = (fn: (value: number) => number, value: number): number => fn(value);
+        return consumeA(invoke, input) + consumeB(invoke, input) - 42;
+      `,
+    ],
+  ] as const)("keeps a captured method closure passed %s on the direct path", async (_label, fileName, body) => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const invoke = (value: number): number => add(value);
+        ${body}
       }`,
       {
-        fileName: "object-method-value-destructured-capture-passed-direct.ts",
+        fileName,
+        experimentalIR: true,
+        trackIrOutcomes: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect((await instantiate(result)).run!(40)).toBe(42);
+    expect(outcome(result)).toMatchObject({
+      kind: "unsupported",
+      stage: "select",
+      legacyBodyEmitted: true,
+      irBodyEmitted: false,
+    });
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps a defaulted captured method closure on the direct path across a callable pass", async () => {
+    const result = await compile(
+      `export function run(input: number): number {
+        const operations = {
+          add(value: number): number { return value + 2; }
+        };
+        const { add } = operations;
+        const invoke = (value: number = 40): number => add(value);
+        const consume = (fn: (value: number) => number, value: number): number => fn(value);
+        return consume(invoke, input);
+      }`,
+      {
+        fileName: "object-method-value-destructured-capture-defaulted-pass-direct.ts",
         experimentalIR: true,
         trackIrOutcomes: true,
       },

--- a/tests/issue-3792-ir-optimization-retirement-gate.test.ts
+++ b/tests/issue-3792-ir-optimization-retirement-gate.test.ts
@@ -73,9 +73,9 @@ function inventoryFixture(source: string, rows: unknown[], options: { marker?: b
 describe("#3792 IR optimization retirement ledger gate", () => {
   it("accepts the committed ledger and reports a non-empty measured inventory", () => {
     const summary = checkLedgerFile("plan/log/ir-optimization-retirement-ledger.md");
-    expect(summary.rows).toBe(37);
-    expect(summary.complete).toBe(24);
-    expect(summary.retirementReady).toBe(1);
+    expect(summary.rows).toBe(46);
+    expect(summary.complete).toBe(32);
+    expect(summary.retirementReady).toBe(3);
     expect(summary.sourceAnchors).toBe(2);
     expect(summary.sourceInventoryVersion).toBe("v1");
 
@@ -367,7 +367,7 @@ function malformedOptimization() {}
       { encoding: "utf8" },
     );
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("36/37 rows are not ready");
+    expect(result.stderr).toContain("43/46 rows are not ready");
     expect(result.stderr).toContain("IR-OPT-NUMERIC-SWITCH-PROOF");
   });
 });

--- a/tests/issue-4102-program-abi-closure-support.test.ts
+++ b/tests/issue-4102-program-abi-closure-support.test.ts
@@ -14,7 +14,7 @@ import {
 import { ProgramAbiSession } from "../src/codegen/program-abi-session.js";
 import { irSupportTypeRef, irTypeBindingKey } from "../src/ir/abi-bindings.js";
 import { buildIrUnitInventory } from "../src/ir/identity.js";
-import { irVal, type IrClosureSignature, type IrType } from "../src/ir/nodes.js";
+import { irVal, irValSigned, type IrClosureSignature, type IrType } from "../src/ir/nodes.js";
 import { buildIrPlanningIdentityContext } from "../src/ir/planning-identity.js";
 import { lowerPreparedClosureSupportType } from "../src/ir/prepared-closure-support.js";
 import { ProgramAbiInvariantError } from "../src/ir/program-abi.js";
@@ -97,6 +97,7 @@ function appendLayout(
   return {
     signature: input.signature,
     captureFieldTypes: input.captures,
+    role: "allocate",
     wrapperRootType: root,
     allocationWrapperType: wrapper,
     liftedFuncType: lifted,
@@ -208,6 +209,133 @@ describe("#4102 Program ABI prepared closure support types", () => {
       );
     }
     expect(f.registry.prepareClosureSupportLayouts([executor, timer])).toEqual([executorLayout, timerLayout]);
+  });
+
+  it("plans only the root and lifted function for invoke-only closure support", () => {
+    const f = fixture();
+    const { timer } = promiseLayouts(f);
+    const invoke = { ...timer, role: "invoke" as const };
+    const [layout] = f.registry.prepareClosureSupportLayouts([invoke]);
+
+    expect(f.session.getDraft(layout!.wrapperRootRef.binding.bindingId)).toMatchObject({
+      slotPolicy: "required",
+      slotSpace: "type",
+    });
+    expect(f.session.getDraft(layout!.liftedFuncRef.binding.bindingId)).toMatchObject({
+      slotPolicy: "required",
+      slotSpace: "type",
+    });
+    expect(f.session.getDraft(layout!.allocationWrapperRef.binding.bindingId)).toBeUndefined();
+    expect(f.session.getDraft(layout!.capturedSubtypeRef.binding.bindingId)).toBeUndefined();
+  });
+
+  it("unions repeated closure roles to allocate within one batch and rejects a later expansion", () => {
+    const f = fixture();
+    const { timer } = promiseLayouts(f);
+    const carrier = { ...timer, role: "carrier" as const };
+    const invoke = { ...timer, role: "invoke" as const };
+    const [carrierLayout, invokeLayout, allocateLayout] = f.registry.prepareClosureSupportLayouts([
+      carrier,
+      invoke,
+      timer,
+    ]);
+
+    expect(carrierLayout).toBe(allocateLayout);
+    expect(invokeLayout).toBe(allocateLayout);
+    for (const ref of [
+      allocateLayout!.wrapperRootRef,
+      allocateLayout!.allocationWrapperRef,
+      allocateLayout!.liftedFuncRef,
+      allocateLayout!.capturedSubtypeRef,
+    ]) {
+      expect(f.session.getDraft(ref.binding.bindingId)).toMatchObject({
+        slotPolicy: "required",
+        slotSpace: "type",
+      });
+    }
+
+    const late = fixture();
+    const { timer: lateTimer } = promiseLayouts(late);
+    late.registry.prepareClosureSupportLayouts([{ ...lateTimer, role: "invoke" }]);
+    expectProgramAbiInvariant(() => late.registry.prepareClosureSupportLayouts([lateTimer]), "planning-sealed");
+  });
+
+  it("keeps a carrier-only sibling layout free of an allocation-only captured subtype", () => {
+    const f = fixture();
+    const { executor } = promiseLayouts(f);
+    const wrapperIndex = f.module.types.indexOf(executor.allocationWrapperType);
+    const carrierSubtype: StructTypeDef = {
+      kind: "struct",
+      name: "executor_carrier_only_capture",
+      fields: [...WRAPPER_FIELDS, { name: "cap0", type: { kind: "externref" }, mutable: false }],
+      superTypeIdx: wrapperIndex,
+    };
+    f.module.types.push(carrierSubtype);
+    const carrierLayout = {
+      ...executor,
+      captureFieldTypes: [EXTERNREF],
+      capturedSubtypeType: carrierSubtype,
+      role: "carrier" as const,
+    };
+
+    const [allocated, carrier] = f.registry.prepareClosureSupportLayouts([executor, carrierLayout]);
+    expect(carrier!.wrapperRootRef.binding.bindingId).toBe(allocated!.wrapperRootRef.binding.bindingId);
+    expect(carrier!.allocationWrapperRef.binding.bindingId).toBe(allocated!.allocationWrapperRef.binding.bindingId);
+    expect(carrier!.liftedFuncRef.binding.bindingId).toBe(allocated!.liftedFuncRef.binding.bindingId);
+    expect(f.session.getDraft(allocated!.allocationWrapperRef.binding.bindingId)).toMatchObject({
+      slotPolicy: "required",
+      slotSpace: "type",
+    });
+    expect(f.session.getDraft(allocated!.liftedFuncRef.binding.bindingId)).toMatchObject({
+      slotPolicy: "required",
+      slotSpace: "type",
+    });
+    expect(f.session.getDraft(carrier!.capturedSubtypeRef.binding.bindingId)).toBeUndefined();
+  });
+
+  it("reuses one physical lifted type across semantically distinct support signatures", () => {
+    const f = fixture();
+    const signedSignature: IrClosureSignature = {
+      params: [irValSigned({ kind: "i32" }, true)],
+      returnType: null,
+    };
+    const unsignedSignature: IrClosureSignature = {
+      params: [irValSigned({ kind: "i32" }, false)],
+      returnType: null,
+    };
+    const signed = appendLayout(f.module.types, {
+      signature: signedSignature,
+      captures: [],
+      name: "signed",
+    });
+    const unsignedAllocated = appendLayout(f.module.types, {
+      signature: unsignedSignature,
+      captures: [],
+      root: signed.wrapperRootType,
+      name: "unsigned",
+    });
+    const duplicateLiftedIndex = f.module.types.indexOf(unsignedAllocated.liftedFuncType);
+    expect(duplicateLiftedIndex).toBeGreaterThanOrEqual(0);
+    f.module.types.splice(duplicateLiftedIndex, 1);
+    const unsigned = { ...unsignedAllocated, liftedFuncType: signed.liftedFuncType, role: "invoke" as const };
+    const invokeSigned = { ...signed, role: "invoke" as const };
+
+    expect(canonicalProgramAbiClosureSignatureKey(signedSignature)).not.toBe(
+      canonicalProgramAbiClosureSignatureKey(unsignedSignature),
+    );
+    const [signedLayout, unsignedLayout] = f.registry.prepareClosureSupportLayouts([invokeSigned, unsigned]);
+    expect(signedLayout!.liftedFuncRef.binding.bindingId).toBe(unsignedLayout!.liftedFuncRef.binding.bindingId);
+    expect(f.session.getDraft(signedLayout!.liftedFuncRef.binding.bindingId)).toMatchObject({
+      intent: { kind: "type" },
+      slotPolicy: "required",
+      slotSpace: "type",
+    });
+    f.registry.planRetained();
+    const publication = f.session.publish(f.module);
+    const signedIndex = publication.abi.resolveFinalIndex(signedLayout!.liftedFuncRef.binding.bindingId);
+    const unsignedIndex = publication.abi.resolveFinalIndex(unsignedLayout!.liftedFuncRef.binding.bindingId);
+    expect(signedIndex).toEqual(unsignedIndex);
+    expect(signedIndex).toEqual({ space: "type", index: f.module.types.indexOf(signed.liftedFuncType) });
   });
 
   it("rejects one semantic layout mapping to different physical type objects before planning", () => {


### PR DESCRIPTION
## Summary

- plan prepared closure support by its strongest live role (`carrier`, `invoke`, or `allocate`) so optimization can remove unused wrapper children without leaving stale Program ABI type references
- migrate one exact captured-method closure handoff to IR when a matching `const` local consumer invokes the callback directly and has exactly one call site
- keep source-boundary callables on the externref ABI and fail closed for returned, imported/top-level, object-method, mixed-source, escaping, relayed, optional, or multiply consumed values
- record the checkpoint and remaining R3 order in `plan/issues/3522-ir-r3-classes-closures-compile-once.md`

## Why

Invoke-only callable signatures were prepared as if they allocated closures. That pinned wrapper and capture types which optimization could legitimately remove, leaving an exact Program ABI remap pointing at an eliminated type. Tracking the live role fixes that mismatch without retaining speculative types or growing binaries.

With that support fixed, the selector can prove one internal closure-to-closure handoff. The proof is deliberately narrow: exact primitive signature, preceding `const` source and consumer, direct required callback invocation, one resolved consumer call, and no source defaults or escape.

## Parity and safety

- poisoned-body GC and standalone fixtures emit all targeted bodies through IR with zero legacy bodies or post-claim failures
- runtime returns the same value and every Wasm artifact validates
- standalone remains zero-import; GC adds no imports over direct
- optimized IR binaries are no larger than their direct controls
- emitted one-hop bodies contain no externref pack/unpack and keep typed `call_ref`
- physical type reuse is proven through final Program ABI publication and exact final-index resolution
- no obsolete direct implementation has zero remaining consumers yet, so this checkpoint deletes no shared legacy code

## Validation

- focused callable/support/object matrix: 141/141
- adjacent closure/object matrix: 108/108
- IR-only shadow: 37/37 IR bodies, 0 legacy, 0 unsupported, 0 invariants
- fallback ratchet: 0 unintended, 0 post-claim, 2 unchanged deferred string-builder candidates
- equivalence: 1,645 passing, 24 known failures, 12 baseline improvements, 0 regressions
- host-import policy: 379 native-first imports, 0 legacy-semantic, 0 unknown
- typecheck, lint, formatting, LOC/function budgets, issue integrity, oracle, coercion, and pre-push gates pass

