### PR TITLE
test(dogfood): run Redux upstream suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ tests/dogfood/report/
 /.clsx-upstream-suite-generated/
 /.cookie-upstream-suite-generated/
 /.marked-upstream-suite-generated/
+/.redux-upstream-suite-generated/
 /.lodash-upstream-suite-generated/
 /.lodash-es-upstream-suite-generated/
 /.moment-upstream-suite-generated/

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "dogfood:typescript": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package typescript",
     "dogfood:redux": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package redux",
     "dogfood:redux-workload": "npx tsx tests/dogfood/redux-workload-harness.mjs",
+    "dogfood:redux-upstream-suite": "node --import tsx tests/dogfood/redux-upstream-suite.mjs",
     "dogfood:jest": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package jest",
     "dogfood:styled-components": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package styled-components",
     "dogfood:moment": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package moment",

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -221,3 +221,20 @@ scores and pins directly. Remaining packages with no runtime adapter stay
 explicitly `adapter-pending`; the next slices should expand the unified runner
 in ascending harness complexity (Redux/Axios first, then jsdom/Prettier and the
 large compiler/tooling suites).
+
+## 2026-08-14 Redux complete runtime suite
+
+Redux 5.0.1 now uses all nine original `*.spec.ts` runtime files from
+`reduxjs/redux@v5.0.1` (commit
+`50b010210df25c470386f7e39a9389a4a77b3842`). All 82 callbacks register and
+all nine generated test modules compile to valid Wasm. The synchronous Node
+oracle reproduces 78 callbacks; the four promise-returning callbacks are
+explicitly harness-incompatible until the shared runner supports async Wasm
+tests. The measured Wasm baseline is **5/78**: ten callbacks reach an assertion
+and diverge, while 63 encounter a module-level runtime trap in the larger
+`bindActionCreators`, `combineReducers`, and `createStore` files. The existing
+1/1 package API workload remains visible as a separate secondary result.
+
+Vitest's spy/assertion surface and the one RxJS protocol test use narrow test
+infrastructure shims; the original callback bodies and inputs are unchanged.
+The next unadapted package remains Axios.

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -44,6 +44,7 @@ import { runHarness as runEslint } from "../tests/dogfood/eslint-harness.mjs";
 import { runHarness as runEslintWorkload } from "../tests/dogfood/eslint-workload-harness.mjs";
 import { runHarness as runEslintUpstreamSuite } from "../tests/dogfood/eslint-upstream-suite.mjs";
 import { runHarness as runReduxWorkload } from "../tests/dogfood/redux-workload-harness.mjs";
+import { runHarness as runReduxUpstreamSuite } from "../tests/dogfood/redux-upstream-suite.mjs";
 import { runHarness as runJsdomWorkload } from "../tests/dogfood/jsdom-harness.mjs";
 import { runHarness as runPrettier } from "../tests/dogfood/prettier-harness.mjs";
 import { runHarness as runReact } from "../tests/dogfood/react-harness.mjs";
@@ -1858,9 +1859,11 @@ for (const entry of NPM_COMPAT_CATALOG) {
           ? (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash-es" })
           : entry.name === "uuid"
             ? runUuidUpstreamSuite
-            : entry.name === "moment"
-              ? runMomentUpstreamSuite
-              : null;
+            : entry.name === "redux"
+              ? runReduxUpstreamSuite
+              : entry.name === "moment"
+                ? runMomentUpstreamSuite
+                : null;
   const catalogUpstreamReport = catalogUpstreamRunner ? await catalogUpstreamRunner({ quiet: true }) : null;
   const upstreamSuite = entry.upstreamSuite;
   const upstreamTests = upstreamSuite
@@ -1888,7 +1891,6 @@ for (const entry of NPM_COMPAT_CATALOG) {
       }
     : null;
   const tests =
-    workload?.tests ??
     (catalogUpstreamReport
       ? {
           kind: "upstream-suite",
@@ -1905,7 +1907,7 @@ for (const entry of NPM_COMPAT_CATALOG) {
             catalogUpstreamReport.extraction?.upstreamTestsSeen ??
             catalogUpstreamReport.results?.scored ??
             null,
-          harnessIncompatible: 0,
+          harnessIncompatible: catalogUpstreamReport.extraction?.nativeFailed ?? 0,
           quarantined: 0,
           sourceIssue: 3995,
           upstreamPin: {
@@ -1913,8 +1915,10 @@ for (const entry of NPM_COMPAT_CATALOG) {
             tag: catalogUpstreamReport.upstreamSuite?.tag ?? null,
             commit: catalogUpstreamReport.upstreamSuite?.commit ?? null,
           },
+          packageApiWorkload: workload?.tests ?? undefined,
         }
       : null) ??
+    workload?.tests ??
     upstreamTests ??
     (hasApiWorkload
       ? {

--- a/tests/dogfood/README.md
+++ b/tests/dogfood/README.md
@@ -25,12 +25,13 @@ vectors or implies that validation is a test pass. Matching upstream source
 suites can be pinned and adapted package by package, following the existing
 Acorn/React precedent.
 
-ESLint, jsdom, and Redux are the explicit runtime-workload exceptions. Their npm
+ESLint and jsdom are the explicit runtime-workload exceptions. Their npm
 tarballs still omit the upstream suites, but each has a separate API workload
 that is only scored after the generated Wasm driver actually runs and matches
 a native Node oracle. ESLint additionally pins one complete original upstream
-unit file as a deliberately named slice. A compile timeout or invalid module
-remains an unverified workload, never a pass.
+unit file as a deliberately named slice. Redux retains its API workload as a
+secondary signal and now also runs its complete original runtime unit suite. A
+compile timeout or invalid module remains an unverified workload, never a pass.
 
 The extracted catalog fixture is also given the installed package's importer
 context (`node_modules`), including pnpm's private dependency links. This keeps
@@ -166,17 +167,26 @@ The 2026-08-12 initial baselines are **Hono 25/31**, **Lodash 0/11**, and
 generated module compiles and validates. Lodash fails at the callback-runner
 boundary; Moment reaches the callbacks but differs on their assertions.
 
-## Redux 5.0.1 API workload (#3996)
+## Redux 5.0.1 upstream suite and API workload
+
+Tracked by [issue 3995](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).
 
 ```bash
+pnpm run dogfood:redux-upstream-suite
 pnpm run dogfood:redux-workload
 ```
 
-The generated driver imports the pinned published bundle and consumes
-`combineReducers`, `createStore`, `subscribe`, and `bindActionCreators`. It
-returns one numeric summary after dispatch and unsubscribe operations; the
-same operations run against the installed package in native Node. This is an
-API workload, not a substitute for Redux's original upstream suite.
+The upstream lane verifies all nine original runtime test files at
+`reduxjs/redux@v5.0.1` and registers all 82 callbacks against the matching
+published bundle. Node reproduces 78 synchronous callbacks; four async
+callbacks remain explicitly harness-incompatible. All nine generated modules
+compile and validate, and the initial Wasm baseline is **5/78**. Per-file
+runtime traps and assertion differences are retained in the JSON report.
+
+The smaller generated API driver remains as an independent secondary signal.
+It consumes `combineReducers`, `createStore`, `subscribe`, and
+`bindActionCreators`, then compares one numeric summary with the same package
+running in native Node.
 
 ## acorn (#1710)
 

--- a/tests/dogfood/npm-compat-upstream-sources.json
+++ b/tests/dogfood/npm-compat-upstream-sources.json
@@ -239,6 +239,7 @@
     "commit": "50b010210df25c470386f7e39a9389a4a77b3842",
     "cacheKey": "redux",
     "compileScript": "dogfood:redux",
+    "suiteScript": "dogfood:redux-upstream-suite",
     "inventory": {
       "directory": "test",
       "include": "^test/.*\\.spec\\.ts$",

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -20,7 +20,7 @@ function run(name: string) {
 }
 
 describe("small npm package upstream suites", () => {
-  it("pins complete clsx and cookie unit-file inventories", () => {
+  it("pins complete clsx, cookie, and Redux unit-file inventories", () => {
     expect(pin("clsx")).toMatchObject({
       tag: "v2.1.1",
       commit: "925494cf31bcd97d3337aacd34e659e80cae7fe2",
@@ -31,6 +31,12 @@ describe("small npm package upstream suites", () => {
       tag: "v2.0.1",
       commit: "51c485421a95ee796de6d8dab53a5ade0a20db8a",
       testFileCount: 4,
+    });
+    expect(pin("redux")).toMatchObject({
+      tag: "v5.0.1",
+      commit: "50b010210df25c470386f7e39a9389a4a77b3842",
+      testFileCount: 9,
+      registrationSites: 82,
     });
   });
 
@@ -54,5 +60,20 @@ describe("small npm package upstream suites", () => {
     });
     expect(report.results.scored).toBe(63_672);
     expect(report.results.passed).toBeGreaterThanOrEqual(63_625);
+  });
+
+  const reduxHeavy = process.env.DOGFOOD_REDUX_UPSTREAM_SUITE === "1" ? it : it.skip;
+  reduxHeavy("runs Redux's complete original runtime callback inventory", { timeout: 600_000 }, () => {
+    const report = run("redux");
+    expect(report.extraction).toMatchObject({
+      filesSeen: 9,
+      filesSelected: 9,
+      testsRegistered: 82,
+      nativePassed: 78,
+      nativeFailed: 4,
+    });
+    expect(report.compile).toMatchObject({ modules: 9, succeeded: 9, validated: 9 });
+    expect(report.results).toMatchObject({ scored: 78 });
+    expect(report.results.passed).toBeGreaterThanOrEqual(5);
   });
 });

--- a/tests/dogfood/redux-upstream-suite-pin.json
+++ b/tests/dogfood/redux-upstream-suite-pin.json
@@ -1,0 +1,21 @@
+{
+  "name": "redux",
+  "version": "5.0.1",
+  "repo": "https://github.com/reduxjs/redux.git",
+  "tag": "v5.0.1",
+  "commit": "50b010210df25c470386f7e39a9389a4a77b3842",
+  "testFileCount": 9,
+  "testFilePathSha256": "48798789f3f825fd0d4fd18dd1a7017c642de12e5e1587fff76db217dd3d5245",
+  "registrationSites": 82,
+  "selectedFiles": [
+    "test/applyMiddleware.spec.ts",
+    "test/bindActionCreators.spec.ts",
+    "test/combineReducers.spec.ts",
+    "test/compose.spec.ts",
+    "test/createStore.spec.ts",
+    "test/utils/formatProdErrorMessage.spec.ts",
+    "test/utils/isAction.spec.ts",
+    "test/utils/isPlainObject.spec.ts",
+    "test/utils/warning.spec.ts"
+  ]
+}

--- a/tests/dogfood/redux-upstream-suite.mjs
+++ b/tests/dogfood/redux-upstream-suite.mjs
@@ -1,0 +1,156 @@
+// Redux 5.0.1's complete original runtime unit suite against the pinned npm tarball.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import * as ts from "typescript";
+
+import { setupNpmCompatCatalogPackage } from "./npm-compat-catalog.mjs";
+import { setupReduxUpstreamSuite } from "./setup-redux-upstream-suite.mjs";
+import {
+  UPSTREAM_TEST_EXPORTS,
+  UPSTREAM_TEST_SHIM,
+  cliUpstreamHarness,
+  compileAndRunUpstreamModule,
+  summarizeUpstreamRuns,
+  writeUpstreamReport,
+} from "./upstream-suite-runner.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GENERATED_ROOT = resolve(HERE, "..", "..", ".redux-upstream-suite-generated");
+const REPORT_PATH = join(HERE, "report", "redux-upstream-suite.json");
+
+const SUPPORT_FILES = [
+  "test/helpers/actionTypes.ts",
+  "test/helpers/actionCreators.ts",
+  "test/helpers/reducers.ts",
+  "test/helpers/middleware.ts",
+  "src/utils/formatProdErrorMessage.ts",
+  "src/utils/isAction.ts",
+  "src/utils/isPlainObject.ts",
+  "src/utils/warning.ts",
+  "src/utils/symbol-observable.ts",
+];
+
+// Redux has one RxJS interoperability test. Keep its original callback and
+// Observable protocol interaction, while supplying the narrow `from`/`map`
+// test dependency at the same seam where Vitest's globals are supplied.
+const RXJS_TEST_SHIM = String.raw`
+function map(project) {
+  return function(source) {
+    return {
+      subscribe(observer) {
+        return source.subscribe(function(value) { observer(project(value)); });
+      },
+    };
+  };
+}
+function from(input) {
+  const observableKey = typeof Symbol === "function" && Symbol.observable ? Symbol.observable : "@@observable";
+  const source = input[observableKey]();
+  return {
+    pipe(operator) { return operator(this); },
+    subscribe(observer) {
+      const target = typeof observer === "function" ? { next: observer } : observer;
+      return source.subscribe(target);
+    },
+  };
+}
+`;
+
+function moduleSpecifier(fromDirectory, target) {
+  let value = relative(fromDirectory, target).replace(/\\/g, "/");
+  if (!value.startsWith(".")) value = `./${value}`;
+  return value;
+}
+
+function emittedSupportPath(relativePath) {
+  return join(GENERATED_ROOT, relativePath.replace(/\.ts$/, ".mjs"));
+}
+
+function rewriteLocalExtension(source) {
+  return source.replace(/from\s+(["'])(\.\.?\/[^"']+)(?:\.ts)?\1/g, (_match, quote, specifier) => {
+    const withExtension = /\.[cm]?js$/.test(specifier) ? specifier : `${specifier}.mjs`;
+    return `from ${quote}${withExtension}${quote}`;
+  });
+}
+
+function emitSupportFiles(sourceRoot) {
+  for (const file of SUPPORT_FILES) {
+    const sourcePath = join(sourceRoot, file);
+    const outputPath = emittedSupportPath(file);
+    const transpiled = ts.transpileModule(readFileSync(sourcePath, "utf-8"), {
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.ES2022,
+      },
+      fileName: sourcePath,
+    });
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, rewriteLocalExtension(transpiled.outputText));
+  }
+}
+
+function transformReduxTest(source, generatedPath, packageEntryPath) {
+  source = source.replace(/^import\s+\{\s*vi\s*\}\s+from\s+['"]vitest['"];?\s*$/gm, "");
+  source = source.replace(/^import\s+\{[^\n]+\}\s+from\s+['"]rxjs(?:\/operators)?['"];?\s*$/gm, "");
+
+  source = source.replace(/from\s+(["'])(?:redux|\.\.\/src)\1/g, (_match, quote) => {
+    return `from ${quote}${moduleSpecifier(dirname(generatedPath), packageEntryPath)}${quote}`;
+  });
+  source = source.replace(/from\s+(["'])(\.\/helpers\/[^"']+)\1/g, (_match, quote, specifier) => {
+    const target = emittedSupportPath(`test/${specifier.slice(2)}.ts`);
+    return `from ${quote}${moduleSpecifier(dirname(generatedPath), target)}${quote}`;
+  });
+  source = source.replace(/from\s+(["'])@internal\/utils\/([^"']+)\1/g, (_match, quote, name) => {
+    const target = emittedSupportPath(`src/utils/${name}.ts`);
+    return `from ${quote}${moduleSpecifier(dirname(generatedPath), target)}${quote}`;
+  });
+  source = source.replace(
+    /from\s+(["'])\.\.\/src\/utils\/symbol-observable\1/g,
+    (_match, quote) =>
+      `from ${quote}${moduleSpecifier(dirname(generatedPath), emittedSupportPath("src/utils/symbol-observable.ts"))}${quote}`,
+  );
+
+  return source;
+}
+
+export async function runHarness({ quiet = false } = {}) {
+  const log = quiet ? () => {} : (...values) => console.log(...values);
+  const packageSetup = setupNpmCompatCatalogPackage("redux");
+  const suite = setupReduxUpstreamSuite();
+  const runs = [];
+
+  emitSupportFiles(suite.root);
+  log(`[dogfood] redux@${packageSetup.version} upstream ${suite.pin.tag} (${suite.pin.commit.slice(0, 12)})`);
+  for (const filePath of suite.selectedPaths) {
+    const file = suite.relativePath(filePath);
+    const generatedPath = join(GENERATED_ROOT, file);
+    const transformed = transformReduxTest(
+      readFileSync(filePath, "utf-8"),
+      generatedPath,
+      packageSetup.entryModulePath,
+    );
+    const source = `${UPSTREAM_TEST_SHIM}\n${RXJS_TEST_SHIM}\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 240_000 });
+    runs.push({ file, result });
+    log(
+      `[dogfood] ${file}: ${result.native.statuses.filter(Boolean).length}/${result.native.count} native; ` +
+        `${result.wasm?.statuses.filter(Boolean).length ?? 0}/${result.native.count} Wasm`,
+    );
+  }
+
+  const report = summarizeUpstreamRuns({
+    name: `redux@${packageSetup.version}`,
+    pin: suite.pin,
+    testFiles: suite.testFiles,
+    selectedFiles: suite.pin.selectedFiles,
+    runs,
+  });
+  writeUpstreamReport(REPORT_PATH, report);
+  log(`[dogfood] ${report.summary.headline}`);
+  log(`[dogfood] report → ${REPORT_PATH}`);
+  return report;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) cliUpstreamHarness(runHarness);

--- a/tests/dogfood/setup-redux-upstream-suite.mjs
+++ b/tests/dogfood/setup-redux-upstream-suite.mjs
@@ -1,0 +1,17 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { setupPinnedUpstreamSuite } from "./setup-pinned-upstream-suite.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function setupReduxUpstreamSuite(options = {}) {
+  return setupPinnedUpstreamSuite({
+    here: HERE,
+    pinFile: "redux-upstream-suite-pin.json",
+    cacheDirectory: ".npm-upstream-suites/redux",
+    inventoryDirectory: "test",
+    accept: (path) => /^test\/(?:[^/]+|utils\/[^/]+)\.spec\.ts$/.test(path),
+    force: options.force,
+  });
+}

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -63,6 +63,10 @@ function __upstreamExpect(actual) {
     toBeDefined() { const n = ++__upstreamAssertion; if (actual === undefined) __upstreamFail("assertion " + n + " expected defined value"); },
     toBeNull() { const n = ++__upstreamAssertion; if (actual !== null) __upstreamFail("assertion " + n + " expected null, got " + __upstreamValue(actual)); },
     toHaveLength(expected) { const n = ++__upstreamAssertion; if (actual == null || actual.length !== expected) __upstreamFail("assertion " + n + " length mismatch"); },
+    toContain(expected) { const n = ++__upstreamAssertion; if (actual == null || typeof actual.includes !== "function" || !actual.includes(expected)) __upstreamFail("assertion " + n + " expected contained value"); },
+    toHaveProperty(expected) { const n = ++__upstreamAssertion; if (actual == null || !(expected in Object(actual))) __upstreamFail("assertion " + n + " missing property " + String(expected)); },
+    toMatch(expected) { const n = ++__upstreamAssertion; const value = String(actual); if (expected instanceof RegExp ? !expected.test(value) : !value.includes(String(expected))) __upstreamFail("assertion " + n + " pattern mismatch"); },
+    toBeCalledWith() { const n = ++__upstreamAssertion; const expected = Array.prototype.slice.call(arguments); const calls = actual && actual.mock && actual.mock.calls; let matched = false; if (calls) for (let i = 0; i < calls.length; i++) if (__upstreamSame(calls[i], expected)) matched = true; if (!matched) __upstreamFail("assertion " + n + " expected matching spy call"); },
     toMatchSnapshot() { __upstreamFail("snapshot assertion requires a package-specific snapshot adapter"); },
     toThrow(expected) { const n = ++__upstreamAssertion; if (typeof actual !== "function" || !__upstreamThrownMatches(__upstreamThrown(actual), expected)) __upstreamFail("assertion " + n + " expected matching throw"); },
     toThrowError(expected) { const n = ++__upstreamAssertion; if (typeof actual !== "function" || !__upstreamThrownMatches(__upstreamThrown(actual), expected)) __upstreamFail("assertion " + n + " expected matching throw"); },
@@ -76,6 +80,18 @@ function __upstreamExpect(actual) {
   return positive;
 }
 const expect = __upstreamExpect;
+const vi = {
+  fn(implementation) {
+    function spy() {
+      const args = Array.prototype.slice.call(arguments);
+      spy.mock.calls.push(args);
+      if (typeof implementation === "function") return implementation.apply(this, args);
+    }
+    spy.mock = { calls: [] };
+    spy.mockClear = function() { spy.mock.calls.length = 0; return spy; };
+    return spy;
+  },
+};
 const __upstreamBeforeEach = [];
 function describe(_name, body) {
   const hookCount = __upstreamBeforeEach.length;
@@ -144,7 +160,13 @@ export function runUpstreamTests(): number[] {
     __upstreamAssertion = 0;
     try {
       const result = __upstreamTests[i].body(__qunitAssert);
-      if (result && typeof result.then === "function") throw new Error("async upstream callback is not admitted");
+      if (result && typeof result.then === "function") {
+        // The synchronous Wasm runner cannot score async callbacks yet. Attach
+        // a rejection sink before classifying the callback so an intentionally
+        // unawaited upstream promise cannot crash the surrounding harness.
+        if (typeof result.catch === "function") result.catch(function() {});
+        throw new Error("async upstream callback is not admitted");
+      }
       statuses.push(1);
       __upstreamErrors.push("");
     } catch (error) {


### PR DESCRIPTION
## Summary

- run all nine original Redux 5.0.1 runtime unit files against the matching published package in Node and Wasm
- extend the shared upstream runner with the Vitest assertions/spies required by Redux and explicit async-test classification
- publish the upstream suite as the card's primary correctness evidence while retaining the 1/1 API workload separately

Measured baseline: 82 callbacks registered, 78 synchronously reproducible in Node, all 9 generated modules compile and validate, and 5/78 pass in Wasm. Four promise-returning callbacks are reported as harness-incompatible.

Depends on #4470. Tracks [the npm upstream-suite catalog issue](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).

## Verification

- DOGFOOD_REDUX_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts
- pnpm run generate:npm-compat -- --only redux --no-write
- pnpm run typecheck
- pnpm run lint
- full pre-push gate