### PR TITLE
refactor(website): share the conformance trend chart between both pages, add ?mode/?edition, fix standalone edition sparklines

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -546,7 +546,29 @@ jobs:
             --update --sha "${{ github.sha }}" || true
 
       - name: Regenerate edition buckets
-        run: node --experimental-strip-types scripts/generate-editions.ts --results benchmarks/results/test262-current.jsonl
+        run: |
+          node --experimental-strip-types scripts/generate-editions.ts --results benchmarks/results/test262-current.jsonl
+          # (#4362) The STANDALONE twin. This job — not promote-baseline — is
+          # what actually lands runs/editions-index.json in the baselines repo
+          # (measured 2026-08-14: every commit touching that file is a
+          # "scheduled baseline refresh", ~3/day, while promote-baseline's
+          # baselines push is superseded by the per-SHA promote job and drops).
+          # So the standalone per-edition history can only accrue if it is
+          # generated and appended HERE too; without it the landing page and
+          # report page have no standalone curve to draw at any ES edition, and
+          # the sparse-checkout fix alone never gets a file to preserve.
+          # Best-effort, mirroring promote-baseline: a missing/corrupt
+          # standalone JSONL must skip, never fail the refresh.
+          if [ -f benchmarks/results/test262-standalone-current.jsonl ]; then
+            node --experimental-strip-types scripts/generate-editions.ts \
+              --results benchmarks/results/test262-standalone-current.jsonl \
+              --output website/public/benchmarks/results/test262-standalone-editions.json \
+              --host-free \
+              --feature-examples-out website/public/feature-examples-standalone.json \
+              || echo "::warning::standalone edition buckets failed (non-fatal)"
+          else
+            echo "no standalone baseline JSONL on disk — skipping standalone edition buckets"
+          fi
 
       - name: Deploy to baselines repo
         env:
@@ -647,6 +669,7 @@ jobs:
           node scripts/append-run-history.mjs \
             --runs-dir /tmp/js2wasm-baselines/runs \
             --editions website/public/benchmarks/results/test262-editions.json \
+            --standalone-editions website/public/benchmarks/results/test262-standalone-editions.json \
             --standalone-report /tmp/js2wasm-baselines/test262-standalone-current.json \
             --sha "${{ github.sha }}" || echo "::warning::append-run-history failed (non-fatal)"
 
@@ -805,6 +828,12 @@ jobs:
             website/public/benchmarks/results/test262-category-editions.json
           # #2871 follow-up — per-file edition index (Error Patterns / Skipped Tests filter).
           git add -f website/public/benchmarks/results/test262-file-editions.json 2>/dev/null || true
+          # (#4362) Standalone twins of the edition buckets + feature-row counts,
+          # regenerated above. They back the per-edition pass bars and feature
+          # rows whenever the "JS host" toggle is off, so they must refresh with
+          # their host counterparts instead of freezing at whatever last landed.
+          git add -f website/public/benchmarks/results/test262-standalone-editions.json 2>/dev/null || true
+          git add -f website/public/feature-examples-standalone.json 2>/dev/null || true
           # #3381 — the #2097 standalone high-water mark (raised earlier). Tolerant
           # add: present on main, but never let a missing file abort the stage.
           git add -f benchmarks/results/test262-standalone-highwater.json 2>/dev/null || true

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -491,6 +491,8 @@ const COMPONENTS_DIR = join(WEBSITE, "components");
 for (const file of [
   "site-nav.js",
   "t262-charts.js",
+  "t262-conformance-trend.js",
+  "t262-view-state.js",
   "trend-chart.js",
   "perf-benchmark-chart.js",
   "npm-compat-chart.js",

--- a/website/components/t262-charts.js
+++ b/website/components/t262-charts.js
@@ -1795,5 +1795,6 @@ export {
   T262_EDITION_SCOPE_RANK,
   t262IsEditionScope,
   t262LatestPublishedEditionYear,
+  t262NormalizeEditionLabel,
   t262ResolveLatestPublishedEdition,
 };

--- a/website/components/t262-conformance-trend.js
+++ b/website/components/t262-conformance-trend.js
@@ -1,0 +1,378 @@
+/**
+ * <t262-conformance-trend> — test262 pass-rate-over-time chart.
+ *
+ * Shared by the landing page (website/index.html) and the conformance report
+ * (website/public/benchmarks/report.html), which each carried their own copy of
+ * this logic — same history files, same point-building, two legends that had
+ * already drifted apart.
+ *
+ *   <t262-conformance-trend
+ *     mode="host|standalone"                 which lane is emphasised
+ *     scope="overall|overall+proposal|ES2015|…"
+ *     runs-base="./benchmarks/results/runs"  directory holding the index files
+ *     height="260">
+ *   </t262-conformance-trend>
+ *
+ * BOTH lanes are always plotted for the current scope; `mode` picks which one
+ * is the thick white line with the gradient fill and which is the thinner
+ * solid line. A lane is never substituted for the other — a host curve under a
+ * "standalone" label is exactly the quietly-wrong number #4362 set out to kill
+ * — so a lane with no history is simply absent from the plot and marked
+ * "(no history yet)" in the legend.
+ *
+ * Requires <trend-chart> (components/trend-chart.js) to be loaded; the data is
+ * applied via customElements.whenDefined so load order does not matter.
+ */
+import { t262NormalizeEditionLabel } from "./t262-charts.js";
+
+const CONFORMANCE_PROJECT_START = new Date("2026-02-27T00:00:00Z");
+
+// One file per (scope kind × lane). The two lanes are separate FILES rather
+// than two series in one file because they are produced by different CI jobs at
+// different times — see scripts/append-run-history.mjs.
+const LANE_FILES = {
+  overall: { host: "index.json", standalone: "standalone-index.json" },
+  edition: { host: "editions-index.json", standalone: "standalone-editions-index.json" },
+};
+
+const LANE_LABEL = { host: "JS host pass rate", standalone: "Standalone pass rate" };
+
+const parseRunTimestamp = (value) => {
+  const raw = String(value || "");
+  if (!raw) return null;
+  const isoDate = new Date(raw);
+  if (Number.isFinite(isoDate.getTime())) return isoDate;
+  const compact = raw.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})$/);
+  if (compact) {
+    const [, y, m, d, hh, mm, ss] = compact;
+    return new Date(`${y}-${m}-${d}T${hh}:${mm}:${ss}Z`);
+  }
+  return null;
+};
+
+const formatHistoryLabel = (date) =>
+  `${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+
+const runsCache = new Map();
+const fetchRuns = (url) => {
+  if (!runsCache.has(url)) {
+    runsCache.set(
+      url,
+      (async () => {
+        try {
+          const resp = await fetch(url);
+          if (!resp.ok) return null;
+          const data = await resp.json();
+          return Array.isArray(data) ? data : null;
+        } catch {
+          return null;
+        }
+      })(),
+    );
+  }
+  return runsCache.get(url);
+};
+
+/**
+ * Turn a runs[] history array into chart points. `extract(run)` returns
+ * `{ pass, total, timestampRaw }` or null to skip the run — that indirection is
+ * what lets the same gap-filling / stale-endpoint / sparse-run handling serve
+ * the overall history AND one ES edition's slice of an editions index.
+ * Returns null when there isn't enough real data to draw.
+ */
+export function t262BuildHistoryPoints(runs, extract) {
+  if (!Array.isArray(runs)) return null;
+
+  const extracted = runs
+    .map((run) => extract(run))
+    .filter((r) => r && Number(r.total ?? 0) > 1 && Number(r.pass ?? 0) >= 0)
+    .map((r) => ({ pass: Number(r.pass || 0), total: Number(r.total || 0), timestampRaw: r.timestampRaw }))
+    .sort((a, b) => {
+      const ta = parseRunTimestamp(a.timestampRaw)?.getTime() ?? Number.POSITIVE_INFINITY;
+      const tb = parseRunTimestamp(b.timestampRaw)?.getTime() ?? Number.POSITIVE_INFINITY;
+      return ta - tb;
+    });
+
+  const rawPoints = extracted
+    .map((run) => {
+      const ts = String(run.timestampRaw || "");
+      const date = parseRunTimestamp(ts);
+      return {
+        label: date ? formatHistoryLabel(date) : "",
+        timestamp: ts,
+        time: date?.getTime() ?? 0,
+        pass: run.pass,
+        total: run.total,
+        rate: run.total > 0 ? (run.pass / run.total) * 100 : 0,
+      };
+    })
+    .filter((point) => point.total > 0 && point.rate >= 5);
+
+  // A run whose corpus suddenly shrank by a quarter is a partial/aborted run,
+  // not a conformance cliff — drop it rather than plotting the dive.
+  const points = [];
+  for (const point of rawPoints) {
+    const prev = points.at(-1);
+    if (prev && point.total < prev.total * 0.75) continue;
+    points.push(point);
+  }
+
+  const firstPoint = points[0];
+  if (firstPoint?.timestamp) {
+    const firstDate = new Date(firstPoint.timestamp);
+    if (
+      Number.isFinite(firstDate.getTime()) &&
+      firstDate.getTime() - CONFORMANCE_PROJECT_START.getTime() > 12 * 60 * 60 * 1000
+    ) {
+      points.unshift({
+        label: formatHistoryLabel(CONFORMANCE_PROJECT_START),
+        timestamp: CONFORMANCE_PROJECT_START.toISOString(),
+        time: CONFORMANCE_PROJECT_START.getTime(),
+        pass: 0,
+        total: 0,
+        rate: 0,
+      });
+    }
+  }
+
+  // Hold the last measured value out to "now" when the newest run is stale, so
+  // the line doesn't stop short and imply the project went quiet.
+  const lastRun = extracted.at(-1);
+  if (lastRun) {
+    const ts = String(lastRun.timestampRaw || "");
+    const lastRate = lastRun.total > 0 ? (lastRun.pass / lastRun.total) * 100 : 0;
+    const lastDate = ts ? new Date(ts) : null;
+    const now = new Date();
+    if (
+      Number.isFinite(lastRate) &&
+      lastRate >= 5 &&
+      lastDate instanceof Date &&
+      Number.isFinite(lastDate.getTime()) &&
+      now.getTime() - lastDate.getTime() > 12 * 60 * 60 * 1000
+    ) {
+      points.push({
+        label: formatHistoryLabel(now),
+        timestamp: now.toISOString(),
+        time: now.getTime(),
+        pass: lastRun.pass,
+        total: lastRun.total,
+        rate: lastRate,
+      });
+    }
+  }
+
+  if (points.length < 2) return null;
+  return points;
+}
+
+/**
+ * Interleave the two lanes onto one x axis. A given timestamp usually has a
+ * value for only one lane, so each lane's last known value is carried forward
+ * across the other's points (a step chart of a cumulative measure — the rate
+ * holds until the next run says otherwise). A lane stays null BEFORE its first
+ * run so <trend-chart> breaks the line instead of drawing a fabricated leading
+ * segment.
+ */
+export function t262MergeConformanceLanes(hostPoints, standalonePoints) {
+  const byTime = new Map();
+  const collect = (points, key) => {
+    for (const point of points ?? []) {
+      const existing = byTime.get(point.time) ?? {
+        label: point.label,
+        timestamp: point.timestamp,
+        time: point.time,
+      };
+      existing[key] = point.rate;
+      byTime.set(point.time, existing);
+    }
+  };
+  collect(hostPoints, "hostRate");
+  collect(standalonePoints, "standaloneRate");
+
+  const merged = [...byTime.values()].sort((a, b) => a.time - b.time);
+  for (const key of ["hostRate", "standaloneRate"]) {
+    let last = null;
+    for (const point of merged) {
+      if (typeof point[key] === "number") last = point[key];
+      else point[key] = last;
+    }
+  }
+  return merged.length >= 2 ? merged : null;
+}
+
+class T262ConformanceTrend extends HTMLElement {
+  static get observedAttributes() {
+    return ["mode", "scope", "runs-base", "height"];
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._renderToken = 0;
+    this._built = false;
+  }
+
+  connectedCallback() {
+    this._build();
+    this._queueRender();
+  }
+
+  attributeChangedCallback() {
+    if (!this.isConnected) return;
+    this._build();
+    this._queueRender();
+  }
+
+  get mode() {
+    return this.getAttribute("mode") === "standalone" ? "standalone" : "host";
+  }
+
+  get scope() {
+    return this.getAttribute("scope") || "overall";
+  }
+
+  _build() {
+    if (this._built) return;
+    this._built = true;
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: block; }
+        :host([hidden]) { display: none; }
+        .chart { display: block; width: 100%; min-height: var(--t262-trend-min-height, 260px); }
+        .chart[hidden] { display: none; }
+        .legend {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 16px;
+          margin-top: 14px;
+          font-family: var(--t262-trend-font-mono, monospace);
+          font-size: var(--t262-trend-legend-size, 10px);
+          color: var(--t262-trend-text-muted, rgba(255, 255, 255, 0.46));
+          letter-spacing: 0.04em;
+        }
+        .item { display: inline-flex; align-items: center; gap: 8px; }
+        /* The selected lane is the thick white line; the other lane is thinner
+           and dimmer. The legend mirrors that weighting so the two curves are
+           told apart without a colour key. */
+        .swatch { width: 18px; height: 0; border-top: 2px solid rgba(255, 255, 255, 0.9); }
+        .item[data-selected="false"] .swatch {
+          border-top-width: 1px;
+          border-top-color: rgba(255, 255, 255, 0.62);
+        }
+        .item[data-selected="true"] { color: var(--t262-trend-text, #fff); }
+        .item[data-available="false"] { opacity: 0.4; }
+        .note { font-size: 0.9em; letter-spacing: 0.02em; }
+        .empty {
+          font-family: var(--t262-trend-font-mono, monospace);
+          font-size: var(--t262-trend-legend-size, 10px);
+          color: var(--t262-trend-text-muted, rgba(255, 255, 255, 0.46));
+        }
+        .empty[hidden] { display: none; }
+      </style>
+      <trend-chart class="chart" mode="step" x-key="time"></trend-chart>
+      <div class="empty" hidden>No conformance history available yet.</div>
+      <div class="legend">
+        <span class="item" data-lane="host" data-selected="true" data-available="true">
+          <span class="swatch"></span><span class="label"></span><span class="note"></span>
+        </span>
+        <span class="item" data-lane="standalone" data-selected="false" data-available="true">
+          <span class="swatch"></span><span class="label"></span><span class="note"></span>
+        </span>
+      </div>
+    `;
+    this._chart = this.shadowRoot.querySelector("trend-chart");
+    this._empty = this.shadowRoot.querySelector(".empty");
+    for (const item of this.shadowRoot.querySelectorAll(".item")) {
+      item.querySelector(".label").textContent = LANE_LABEL[item.dataset.lane];
+    }
+  }
+
+  _queueRender() {
+    const token = ++this._renderToken;
+    queueMicrotask(() => {
+      if (token !== this._renderToken) return;
+      this._render(token);
+    });
+  }
+
+  async _render(token) {
+    const base = (this.getAttribute("runs-base") || "./benchmarks/results/runs").replace(/\/$/, "");
+    const scope = this.scope;
+    const isOverallScope = !scope || scope === "overall" || scope === "overall+proposal";
+    const files = isOverallScope ? LANE_FILES.overall : LANE_FILES.edition;
+
+    const [hostRuns, standaloneRuns] = await Promise.all([
+      fetchRuns(`${base}/${files.host}`),
+      fetchRuns(`${base}/${files.standalone}`),
+    ]);
+    if (token !== this._renderToken) return;
+
+    const extract = isOverallScope
+      ? (run) => ({ pass: run?.pass, total: run?.total, timestampRaw: run?.timestamp })
+      : (run) => {
+          const label = t262NormalizeEditionLabel(scope);
+          if (!Array.isArray(run?.editions)) return null;
+          const entry = run.editions.find((e) => t262NormalizeEditionLabel(String(e?.edition || "")) === label);
+          if (!entry) return null;
+          return { pass: entry.pass, total: entry.total, timestampRaw: run.timestamp };
+        };
+
+    const hostPoints = t262BuildHistoryPoints(hostRuns, extract);
+    const standalonePoints = t262BuildHistoryPoints(standaloneRuns, extract);
+    const points = t262MergeConformanceLanes(hostPoints, standalonePoints);
+
+    const selectedLane = this.mode;
+    for (const item of this.shadowRoot.querySelectorAll(".item")) {
+      const lane = item.dataset.lane;
+      const available = lane === "host" ? !!hostPoints : !!standalonePoints;
+      item.dataset.selected = String(lane === selectedLane);
+      item.dataset.available = String(available);
+      item.querySelector(".note").textContent = available ? "" : "(no history yet)";
+    }
+
+    const height = this.getAttribute("height") || "260";
+    this._chart.setAttribute("height", height);
+    this.style.setProperty("--t262-trend-min-height", `${Number(height) || 260}px`);
+
+    if (!points) {
+      this._chart.hidden = true;
+      this._empty.hidden = false;
+      return;
+    }
+    this._empty.hidden = true;
+    this._chart.hidden = false;
+
+    // The selected lane is listed FIRST: <trend-chart> attaches its point dots
+    // and peak label to seriesDef[0].
+    const series = [
+      { key: selectedLane === "host" ? "hostRate" : "standaloneRate", color: "#ffffff", fill: true },
+      {
+        key: selectedLane === "host" ? "standaloneRate" : "hostRate",
+        color: "rgba(255,255,255,0.62)",
+        lineWidth: 1.25,
+      },
+    ];
+    this._chart.setAttribute("labels-key", "label");
+    this._chart.setAttribute("series", JSON.stringify(series));
+
+    const applyData = () => {
+      if (token !== this._renderToken) return;
+      this._chart.data = points;
+    };
+    if (customElements.get("trend-chart")) applyData();
+    else
+      customElements
+        .whenDefined("trend-chart")
+        .then(applyData)
+        .catch(() => {});
+  }
+}
+
+// `typeof customElements.get` is checked because t262-charts.js installs a
+// bare `{ define() {} }` shim under Node so its pure helpers stay unit-testable
+// (#1777) — importing this module there must not throw.
+if (typeof customElements.get !== "function" || !customElements.get("t262-conformance-trend")) {
+  customElements.define("t262-conformance-trend", T262ConformanceTrend);
+}
+
+export { T262ConformanceTrend };

--- a/website/components/t262-view-state.js
+++ b/website/components/t262-view-state.js
@@ -1,0 +1,85 @@
+/**
+ * Shared ?mode= / ?edition= URL state for the two conformance surfaces
+ * (website/index.html and website/public/benchmarks/report.html).
+ *
+ * Both pages show the same two knobs — the JS-host/standalone lane and the ES
+ * edition scope — so a link should be able to carry them:
+ *
+ *   /?mode=standalone&edition=ES2015
+ *   /benchmarks/report.html?mode=standalone&edition=ES2020
+ *
+ * Loaded as a plain (non-module) script so page inline scripts can call it
+ * synchronously; it attaches `window.t262ViewState`.
+ *
+ * The edition value is whatever scope string the <t262-edition-timeline>
+ * itself uses ("overall", "overall+proposal", "ES2015", "ES3 / Core", …), so a
+ * URL round-trips exactly. Callers MUST validate an incoming edition against
+ * the timeline's own scope map before applying it — an unknown scope would
+ * otherwise leave the slider showing a selection nothing else honours.
+ */
+(function attachT262ViewState(global) {
+  const MODE_PARAM = "mode";
+  const EDITION_PARAM = "edition";
+  const VALID_MODES = new Set(["host", "standalone"]);
+
+  const params = () => {
+    try {
+      return new URLSearchParams(global.location?.search || "");
+    } catch {
+      return new URLSearchParams("");
+    }
+  };
+
+  /** Reads the URL knobs. Missing/invalid values come back as null, never a guess. */
+  const read = () => {
+    const search = params();
+    const rawMode = (search.get(MODE_PARAM) || "").trim().toLowerCase();
+    const rawEdition = (search.get(EDITION_PARAM) || "").trim();
+    return {
+      mode: VALID_MODES.has(rawMode) ? rawMode : null,
+      edition: rawEdition || null,
+    };
+  };
+
+  /**
+   * Writes the knobs back with replaceState — the page's own toggles are not
+   * navigation, so they must not stack history entries the Back button then
+   * has to unwind one edition at a time.
+   *
+   * `mode: "host"` and `edition: "overall"` are the defaults and are DROPPED
+   * from the URL rather than written out, so the common case stays a clean
+   * link and a shared URL only ever names what actually differs.
+   */
+  const write = ({ mode, edition } = {}) => {
+    const search = params();
+    if (mode === "standalone") search.set(MODE_PARAM, "standalone");
+    else if (mode === "host") search.delete(MODE_PARAM);
+
+    if (typeof edition === "string" && edition && edition !== "overall") search.set(EDITION_PARAM, edition);
+    else if (edition === "overall" || edition === null) search.delete(EDITION_PARAM);
+
+    const query = search.toString();
+    const next = `${global.location.pathname}${query ? `?${query}` : ""}${global.location.hash || ""}`;
+    try {
+      global.history.replaceState(global.history.state, "", next);
+    } catch {
+      // Non-browser / sandboxed context (file:// in some engines) — the knobs
+      // still work, they just don't survive a reload.
+    }
+  };
+
+  /**
+   * Builds a link to the OTHER conformance surface carrying this view — both
+   * pages read the same two params, so following the link keeps the lane and
+   * edition the reader is looking at. Defaults are dropped, same as write().
+   */
+  const linkTo = (href, { mode, edition } = {}) => {
+    const search = new URLSearchParams();
+    if (mode === "standalone") search.set(MODE_PARAM, "standalone");
+    if (typeof edition === "string" && edition && edition !== "overall") search.set(EDITION_PARAM, edition);
+    const query = search.toString();
+    return query ? `${href}?${query}` : href;
+  };
+
+  global.t262ViewState = { read, write, linkTo };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/website/index.html
+++ b/website/index.html
@@ -514,43 +514,12 @@
         --t262-edition-text: var(--fg);
         --t262-edition-text-muted: var(--fg-faint);
       }
-      .diagram-legend {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 16px;
-        margin-top: 14px;
-        font-family: var(--mono);
-        font-size: 10px;
-        color: var(--fg-faint);
-        letter-spacing: 0.04em;
-      }
-      .diagram-legend-item {
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-      }
-      .diagram-legend-line {
-        width: 18px;
-        height: 0;
-        border-top: 2px solid rgba(255, 255, 255, 0.9);
-      }
-      /* The conformance trend plots both lanes at once: the selected one (the
-         "JS host" toggle) is the thick white line, the other a thinner solid
-         line. The legend mirrors that weighting so the two are told apart
-         without a colour key. */
-      .diagram-legend-item[data-selected="false"] .diagram-legend-line {
-        border-top-width: 1px;
-        border-top-color: rgba(255, 255, 255, 0.62);
-      }
-      .diagram-legend-item[data-selected="true"] {
-        color: var(--fg);
-      }
-      .diagram-legend-item[data-available="false"] {
-        opacity: 0.4;
-      }
-      .diagram-legend-note {
-        font-size: 9px;
-        letter-spacing: 0.02em;
+      /* The chart and its legend live in <t262-conformance-trend>'s shadow
+         DOM (shared with the report page); the page only supplies the theme. */
+      .conformance-trend {
+        --t262-trend-font-mono: var(--mono);
+        --t262-trend-text: var(--fg);
+        --t262-trend-text-muted: var(--fg-faint);
       }
 
       .host-bench-copy {
@@ -1750,7 +1719,9 @@
             has a curated demo.
           </p>
           <p style="margin-top: 1.25rem">
-            <a class="btn-outline" href="./benchmarks/report.html">Compatibility Test Report</a>
+            <a class="btn-outline" id="conformance-report-link" href="./benchmarks/report.html">
+              Compatibility Test Report
+            </a>
             <a class="btn-outline" href="./npm-compat.html">Real npm Packages</a>
           </p>
         </div>
@@ -1800,19 +1771,17 @@
           </div>
           <div class="diagram-panel">
             <h3 class="diagram-title">ECMAScript Conformance Pass Rate Over Time</h3>
-            <trend-chart id="conformance-history-chart" mode="step" height="260" x-key="time"></trend-chart>
-            <div class="diagram-legend" id="conformance-history-legend">
-              <span class="diagram-legend-item" data-lane="host" data-selected="true" data-available="true">
-                <span class="diagram-legend-line"></span>
-                <span>JS host pass rate</span>
-                <span class="diagram-legend-note"></span>
-              </span>
-              <span class="diagram-legend-item" data-lane="standalone" data-selected="false" data-available="true">
-                <span class="diagram-legend-line"></span>
-                <span>Standalone pass rate</span>
-                <span class="diagram-legend-note"></span>
-              </span>
-            </div>
+            <!-- Shared with the conformance report page — see
+                 components/t262-conformance-trend.js. Both lanes are plotted;
+                 `mode` picks which one is the thick white line. -->
+            <t262-conformance-trend
+              id="conformance-history-chart"
+              class="conformance-trend"
+              runs-base="./benchmarks/results/runs"
+              height="260"
+              mode="host"
+              scope="overall"
+            ></t262-conformance-trend>
           </div>
         </div>
         <div class="edition-timeline-section">
@@ -4533,6 +4502,10 @@ console.log(instance.exports.run()); // &rarr; 55</pre
     <script type="module" src="./components/t262-charts.js"></script>
     <script type="module" src="./components/perf-benchmark-chart.js"></script>
     <script src="./components/trend-chart.js"></script>
+    <!-- Plain script (not a module) so the inline page scripts below can call
+         window.t262ViewState synchronously. -->
+    <script src="./components/t262-view-state.js"></script>
+    <script type="module" src="./components/t262-conformance-trend.js"></script>
 
     <script>
       // #3071 — Prefer the same-origin deployed copy of the JS-host test262
@@ -5176,249 +5149,17 @@ console.log(instance.exports.run()); // &rarr; 55</pre
 
       // Conformance diagrams are now rendered by <t262-donut> and <t262-edition-bars> web components.
 
-      // Primary trend graph (next to the donut) — scope-aware. Called once at
-      // load for the default "overall" / js-host scope, then re-called by
-      // applyScopeFromDetail() whenever the ES-edition timeline slider or the
-      // standalone/host toggle changes, so it always matches the donut.
-      const conformanceHistoryProjectStart = new Date("2026-02-27T00:00:00Z");
-      const parseRunTimestamp = (value) => {
-        const raw = String(value || "");
-        if (!raw) return null;
-        const isoDate = new Date(raw);
-        if (Number.isFinite(isoDate.getTime())) return isoDate;
-        const compact = raw.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})$/);
-        if (compact) {
-          const [, y, m, d, hh, mm, ss] = compact;
-          return new Date(`${y}-${m}-${d}T${hh}:${mm}:${ss}Z`);
-        }
-        return null;
-      };
-      const formatHistoryLabel = (date) =>
-        `${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
-
-      const fetchJsonSafe = async (url) => {
-        try {
-          const resp = await fetch(url);
-          if (!resp.ok) return null;
-          const data = await resp.json();
-          return Array.isArray(data) ? data : null;
-        } catch {
-          return null;
-        }
-      };
-
-      // Builds trend-chart points from an arbitrary runs[] history array.
-      // `extract(run)` returns `{ pass, total, timestampRaw }` for a run, or
-      // null/undefined to skip it — this is what lets the same point-building
-      // (gap-filling, stale-endpoint extension, sparse-run filtering) serve
-      // the overall/standalone histories AND a single ES edition's slice of
-      // editions-index.json. Returns null when there isn't enough real data.
-      const buildHistoryPoints = (runs, extract) => {
-        if (!Array.isArray(runs)) return null;
-
-        const extracted = runs
-          .map((run) => extract(run))
-          .filter((r) => r && Number(r.total ?? 0) > 1 && Number(r.pass ?? 0) >= 0)
-          .map((r) => ({ pass: Number(r.pass || 0), total: Number(r.total || 0), timestampRaw: r.timestampRaw }))
-          .sort((a, b) => {
-            const ta = parseRunTimestamp(a.timestampRaw)?.getTime() ?? Number.POSITIVE_INFINITY;
-            const tb = parseRunTimestamp(b.timestampRaw)?.getTime() ?? Number.POSITIVE_INFINITY;
-            return ta - tb;
-          });
-
-        const rawPoints = extracted
-          .map((run) => {
-            const ts = String(run.timestampRaw || "");
-            const date = parseRunTimestamp(ts);
-            return {
-              label: date ? formatHistoryLabel(date) : "",
-              timestamp: ts,
-              time: date?.getTime() ?? 0,
-              pass: run.pass,
-              total: run.total,
-              rate: run.total > 0 ? (run.pass / run.total) * 100 : 0,
-            };
-          })
-          .filter((point) => point.total > 0 && point.rate >= 5);
-
-        const points = [];
-        for (const point of rawPoints) {
-          const prev = points.at(-1);
-          if (prev && point.total < prev.total * 0.75) continue;
-          points.push(point);
-        }
-
-        const firstPoint = points[0];
-        if (firstPoint?.timestamp) {
-          const firstDate = new Date(firstPoint.timestamp);
-          if (
-            Number.isFinite(firstDate.getTime()) &&
-            firstDate.getTime() - conformanceHistoryProjectStart.getTime() > 12 * 60 * 60 * 1000
-          ) {
-            points.unshift({
-              label: formatHistoryLabel(conformanceHistoryProjectStart),
-              timestamp: conformanceHistoryProjectStart.toISOString(),
-              time: conformanceHistoryProjectStart.getTime(),
-              pass: 0,
-              total: 0,
-              rate: 0,
-            });
-          }
-        }
-
-        const lastRun = extracted.at(-1);
-        if (lastRun) {
-          const ts = String(lastRun.timestampRaw || "");
-          const lastRate = lastRun.total > 0 ? (lastRun.pass / lastRun.total) * 100 : 0;
-          const lastDate = ts ? new Date(ts) : null;
-          const now = new Date();
-          if (
-            Number.isFinite(lastRate) &&
-            lastRate >= 5 &&
-            lastDate instanceof Date &&
-            Number.isFinite(lastDate.getTime()) &&
-            now.getTime() - lastDate.getTime() > 12 * 60 * 60 * 1000
-          ) {
-            points.push({
-              label: formatHistoryLabel(now),
-              timestamp: now.toISOString(),
-              time: now.getTime(),
-              pass: lastRun.pass,
-              total: lastRun.total,
-              rate: lastRate,
-            });
-          }
-        }
-
-        if (points.length < 2) return null;
-        return points;
-      };
-
-      // Both lanes on one axis: the SELECTED lane (the "JS host" toggle) is the
-      // thick white line with the gradient fill, the other lane the thinner
-      // solid line. The selected lane is listed FIRST because <trend-chart>
-      // attaches its point dots and peak label to seriesDef[0].
-      //
-      // The old third/fourth series ("Tests passed" and a dashed "Total tests
-      // run", both on a right-hand count axis) are gone: the chart now answers
-      // one question — how the two lanes' pass RATES compare over time — and
-      // the count axis only made the two rate lines harder to read. Absolute
-      // counts are still on the donut and the per-edition bars.
-      const conformanceHistorySeries = (hostEnabled) => {
-        const selected = { key: hostEnabled ? "hostRate" : "standaloneRate", color: "#ffffff", fill: true };
-        const other = {
-          key: hostEnabled ? "standaloneRate" : "hostRate",
-          color: "rgba(255,255,255,0.62)",
-          lineWidth: 1.25,
-        };
-        return JSON.stringify([selected, other]);
-      };
-
-      // Interleave the two lanes onto one x axis. The lanes are measured by
-      // different CI jobs at different times, so a given timestamp usually has
-      // a value for only one of them: carry each lane's last known value
-      // forward across the other's points (a step chart of a cumulative
-      // measure — the rate holds until the next run says otherwise), but leave
-      // a lane null BEFORE its first run so <trend-chart> breaks the line
-      // instead of drawing a fabricated leading segment.
-      const mergeConformanceLanes = (hostPoints, standalonePoints) => {
-        const byTime = new Map();
-        const collect = (points, key) => {
-          for (const point of points ?? []) {
-            const existing = byTime.get(point.time) ?? {
-              label: point.label,
-              timestamp: point.timestamp,
-              time: point.time,
-            };
-            existing[key] = point.rate;
-            byTime.set(point.time, existing);
-          }
-        };
-        collect(hostPoints, "hostRate");
-        collect(standalonePoints, "standaloneRate");
-
-        const merged = [...byTime.values()].sort((a, b) => a.time - b.time);
-        for (const key of ["hostRate", "standaloneRate"]) {
-          let last = null;
-          for (const point of merged) {
-            if (typeof point[key] === "number") last = point[key];
-            else point[key] = last;
-          }
-        }
-        return merged.length >= 2 ? merged : null;
-      };
-
-      const updateConformanceHistoryLegend = (hostEnabled, availability) => {
-        const legend = document.getElementById("conformance-history-legend");
-        if (!legend) return;
-        for (const item of legend.querySelectorAll(".diagram-legend-item")) {
-          const lane = item.dataset.lane;
-          const available = lane === "host" ? availability.host : availability.standalone;
-          item.dataset.selected = String(lane === (hostEnabled ? "host" : "standalone"));
-          item.dataset.available = String(!!available);
-          const note = item.querySelector(".diagram-legend-note");
-          if (note) note.textContent = available ? "" : "(no history yet)";
-        }
-      };
-
-      async function updateConformanceHistoryChart(scope, hostEnabled) {
+      // Primary trend graph (next to the donut) — scope- and lane-aware.
+      // The chart, its two-lane point building and its legend now live in the
+      // shared <t262-conformance-trend> component (components/
+      // t262-conformance-trend.js), which the conformance report page renders
+      // too; this page only tells it which scope and lane are selected.
+      const updateConformanceHistoryChart = (scope, hostEnabled) => {
         const chart = document.getElementById("conformance-history-chart");
         if (!chart) return;
-        try {
-          const isOverallScope = !scope || scope === "overall" || scope === "overall+proposal";
-
-          // BOTH lanes are always fetched for the current scope — the toggle
-          // now picks which curve is emphasised, not which one exists. Each
-          // lane keeps its OWN history file; a lane is never substituted for
-          // the other (a host curve under a "standalone" label is exactly the
-          // quietly-wrong number #4362 set out to kill), it just goes missing
-          // from the chart and is marked "(no history yet)" in the legend.
-          //
-          // (#4362) Per-edition standalone history lives in
-          // `standalone-editions-index.json`, appended by
-          // scripts/append-run-history.mjs from the host-free edition buckets.
-          // It is deliberately not backfilled, so that lane starts short.
-          const [hostRuns, standaloneRuns] = await Promise.all([
-            fetchJsonSafe(
-              isOverallScope ? "./benchmarks/results/runs/index.json" : "./benchmarks/results/runs/editions-index.json",
-            ),
-            fetchJsonSafe(
-              isOverallScope
-                ? "./benchmarks/results/runs/standalone-index.json"
-                : "./benchmarks/results/runs/standalone-editions-index.json",
-            ),
-          ]);
-
-          const extract = isOverallScope
-            ? (run) => ({ pass: run?.pass, total: run?.total, timestampRaw: run?.timestamp })
-            : (run) => {
-                const label = normalizeEditionLabel(scope);
-                if (!Array.isArray(run?.editions)) return null;
-                const entry = run.editions.find((e) => normalizeEditionLabel(String(e?.edition || "")) === label);
-                if (!entry) return null;
-                return { pass: entry.pass, total: entry.total, timestampRaw: run.timestamp };
-              };
-
-          const hostPoints = buildHistoryPoints(hostRuns, extract);
-          const standalonePoints = buildHistoryPoints(standaloneRuns, extract);
-          const points = mergeConformanceLanes(hostPoints, standalonePoints);
-          updateConformanceHistoryLegend(hostEnabled, { host: !!hostPoints, standalone: !!standalonePoints });
-
-          if (!points) {
-            chart.hidden = true;
-            return;
-          }
-
-          chart.setAttribute("labels-key", "label");
-          chart.setAttribute("series", conformanceHistorySeries(hostEnabled));
-          chart.data = points;
-          chart.hidden = false;
-        } catch {
-          chart.hidden = true;
-        }
-      }
-
-      updateConformanceHistoryChart("overall", true);
+        chart.setAttribute("scope", scope || "overall");
+        chart.setAttribute("mode", hostEnabled ? "host" : "standalone");
+      };
 
       const PROPOSAL_LABEL = "Proposals";
       const isEditionScope = (edition) =>
@@ -5489,6 +5230,12 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         const rateEl = document.getElementById("compat-pass-rate");
         const rateLabelEl = document.getElementById("compat-pass-rate-label");
         if (!donutSlot || !(editionTimeline instanceof HTMLElement)) return;
+
+        // Snapshot ?mode=/?edition= BEFORE anything writes back to the URL —
+        // the first scope render replaces the query string with the CURRENT
+        // knobs, which would erase the incoming link's state a moment before
+        // we got round to reading it.
+        const initialViewState = window.t262ViewState?.read?.() ?? { mode: null, edition: null };
 
         // #3071 — same-origin first to avoid raw.githubusercontent 429s; the
         // raw baseline URL stays as a resilience fallback.
@@ -5889,7 +5636,19 @@ console.log(instance.exports.run()); // &rarr; 55</pre
 
             const currentScope = detail.scope || "overall";
             window.__conformanceEditionScope = currentScope;
-            updateConformanceHistoryChart(currentScope, hostToggle ? hostToggle.checked : true);
+            const hostEnabled = hostToggle ? hostToggle.checked : true;
+            updateConformanceHistoryChart(currentScope, hostEnabled);
+            // Keep ?mode=/?edition= in step with the two knobs so the view can
+            // be linked to. Shared with the report page — components/
+            // t262-view-state.js.
+            const viewState = { mode: hostEnabled ? "host" : "standalone", edition: currentScope };
+            window.t262ViewState?.write(viewState);
+            // Carry the same view over to the report page, which reads the
+            // identical params — following the link keeps the lane and edition
+            // the reader is currently looking at.
+            const reportLink = document.getElementById("conformance-report-link");
+            if (reportLink)
+              reportLink.setAttribute("href", window.t262ViewState.linkTo("./benchmarks/report.html", viewState));
             if (currentScope === "overall") {
               renderSelectedConformance("overall", overall, "ECMAScript", { exactStrictSummary: strictSummary });
               applyFeatureEditionScope("overall");
@@ -5912,8 +5671,38 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           strictToggle?.addEventListener("change", window.updateConformanceDonut);
           hostToggle?.addEventListener("change", window.updateConformanceDonut);
 
+          // (?mode=/?edition=) Apply the incoming URL state once, as soon as
+          // the timeline has published its own scopes. Driven off the first
+          // detail we see rather than `edition-ready`, because this hydration
+          // is async and that event has usually already fired by now.
+          //
+          // The edition is VALIDATED against the timeline's scope map rather
+          // than trusted: an unknown value would otherwise leave the slider on
+          // a selection the donut, feature rows and trend chart all ignore.
+          let urlStateApplied = false;
+          const applyUrlStateOnce = (detail) => {
+            if (urlStateApplied) return;
+            urlStateApplied = true;
+            const { mode, edition } = initialViewState;
+            if (!mode && !edition) return;
+            // Dispatch a real `change` rather than calling the donut update
+            // directly: the same checkbox also drives the per-edition pass
+            // bars and the feature-row badges, which listen for the event.
+            if (mode && hostToggle && hostToggle.checked !== (mode !== "standalone")) {
+              hostToggle.checked = mode !== "standalone";
+              hostToggle.dispatchEvent(new Event("change", { bubbles: true }));
+            }
+            const scopeMap = detail?.scopeMap;
+            const isKnownScope =
+              edition === "overall" ||
+              edition === "overall+proposal" ||
+              (scopeMap instanceof Map && scopeMap.has(edition));
+            if (edition && isKnownScope && edition !== detail?.scope) editionTimeline.value = edition;
+          };
+
           editionTimeline.addEventListener("edition-change", (event) => {
             applyScopeFromDetail(event.detail);
+            applyUrlStateOnce(event.detail);
           });
 
           if (report.timestamp) {

--- a/website/public/benchmarks/report.html
+++ b/website/public/benchmarks/report.html
@@ -126,9 +126,6 @@
         gap: 0.875rem;
         align-content: start;
       }
-      .summary-history-chart {
-        min-height: 260px;
-      }
       .summary-meta {
         position: absolute;
         right: 0;
@@ -167,33 +164,13 @@
         color: var(--text-muted);
         margin: 0 0 1.25rem;
       }
-      .diagram-legend {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 1rem;
-        font-family: var(--mono);
-        font-size: 0.68rem;
-        color: var(--text-muted);
-        letter-spacing: 0.04em;
-      }
-      .diagram-legend-item {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-      }
-      .diagram-legend-line {
-        width: 18px;
-        height: 0;
-        border-top: 2px solid rgba(255, 255, 255, 0.9);
-      }
-      .diagram-legend-line.total {
-        border-top-width: 1px;
-        border-top-color: rgba(141, 154, 184, 1);
-        border-top-style: dotted;
-      }
-      .diagram-legend-line.passed {
-        border-top-width: 1px;
-        border-top-color: rgba(255, 255, 255, 0.82);
+      /* The chart and its legend live in <t262-conformance-trend>'s shadow DOM
+         (shared with the landing page); the page only supplies the theme. */
+      .summary-history-chart {
+        --t262-trend-font-mono: var(--mono);
+        --t262-trend-text: var(--text);
+        --t262-trend-text-muted: var(--text-muted);
+        --t262-trend-legend-size: 0.68rem;
       }
       .edition-section {
         margin: -0.35rem 0 2rem;
@@ -640,6 +617,10 @@
     <script src="../components/site-nav.js"></script>
     <script type="module" src="../components/t262-charts.js"></script>
     <script src="../components/trend-chart.js"></script>
+    <!-- Plain script (not a module) so the inline page script can call
+         window.t262ViewState synchronously. -->
+    <script src="../components/t262-view-state.js"></script>
+    <script type="module" src="../components/t262-conformance-trend.js"></script>
     <script>
       const REPORT_JSON = "results/test262-report.json";
       const RESULTS_JSONL = "results/test262-results.jsonl";
@@ -660,6 +641,12 @@
       const HOST_EDITIONS_JSON = "results/test262-editions.json";
       const PROPOSAL_LABEL = "Proposals";
       const BASE_PATH = window.location.pathname.replace(/\/benchmarks\/.*$/, "");
+
+      // Snapshot ?mode=/?edition= BEFORE the first render writes the CURRENT
+      // knobs back to the query string, which would erase an incoming link's
+      // state a moment before it was read. Shared with the landing page —
+      // components/t262-view-state.js.
+      const initialViewState = window.t262ViewState?.read?.() ?? { mode: null, edition: null };
 
       function assetPath(path) {
         if (!BASE_PATH) return `/${path}`;
@@ -819,174 +806,10 @@
         }
       }
 
-      const CONFORMANCE_PROJECT_START = new Date("2026-02-27T00:00:00Z");
-
-      function parseConformanceRunTimestamp(value) {
-        const raw = String(value || "");
-        if (!raw) return null;
-        const isoDate = new Date(raw);
-        if (Number.isFinite(isoDate.getTime())) return isoDate;
-        const compact = raw.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})$/);
-        if (compact) {
-          const [, y, m, d, hh, mm, ss] = compact;
-          return new Date(`${y}-${m}-${d}T${hh}:${mm}:${ss}Z`);
-        }
-        return null;
-      }
-
-      function formatConformanceHistoryLabel(date) {
-        return `${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
-      }
-
-      function buildConformanceHistoryPoints(runs) {
-        const comparableRuns = Array.isArray(runs)
-          ? runs
-              .filter((run) => Number(run?.total ?? 0) > 1 && Number(run?.pass ?? 0) >= 0)
-              .sort((a, b) => {
-                const ta = parseConformanceRunTimestamp(a.timestamp)?.getTime() ?? Number.POSITIVE_INFINITY;
-                const tb = parseConformanceRunTimestamp(b.timestamp)?.getTime() ?? Number.POSITIVE_INFINITY;
-                return ta - tb;
-              })
-          : [];
-
-        const rawPoints = comparableRuns
-          .map((run) => {
-            const total = Number(run.total || 0);
-            const pass = Number(run.pass || 0);
-            const ts = String(run.timestamp || "");
-            const date = parseConformanceRunTimestamp(ts);
-            return {
-              label: date ? formatConformanceHistoryLabel(date) : "",
-              timestamp: ts,
-              time: date?.getTime() ?? 0,
-              pass,
-              total,
-              rate: total > 0 ? (pass / total) * 100 : 0,
-            };
-          })
-          .filter((point) => point.total > 0 && point.rate >= 5);
-
-        const points = [];
-        for (const point of rawPoints) {
-          const prev = points.at(-1);
-          if (prev && point.total < prev.total * 0.75) continue;
-          points.push(point);
-        }
-
-        const firstPoint = points[0];
-        if (firstPoint?.timestamp) {
-          const firstDate = new Date(firstPoint.timestamp);
-          if (
-            Number.isFinite(firstDate.getTime()) &&
-            firstDate.getTime() - CONFORMANCE_PROJECT_START.getTime() > 12 * 60 * 60 * 1000
-          ) {
-            points.unshift({
-              label: formatConformanceHistoryLabel(CONFORMANCE_PROJECT_START),
-              timestamp: CONFORMANCE_PROJECT_START.toISOString(),
-              time: CONFORMANCE_PROJECT_START.getTime(),
-              pass: 0,
-              total: 0,
-              rate: 0,
-            });
-          }
-        }
-
-        const lastRun = comparableRuns.at(-1);
-        if (lastRun) {
-          const ts = String(lastRun.timestamp || "");
-          const total = Number(lastRun.total || 0);
-          const pass = Number(lastRun.pass || 0);
-          const lastRate = total > 0 ? (pass / total) * 100 : 0;
-          const lastDate = ts ? new Date(ts) : null;
-          const now = new Date();
-          if (
-            Number.isFinite(lastRate) &&
-            lastRate >= 5 &&
-            lastDate instanceof Date &&
-            Number.isFinite(lastDate.getTime()) &&
-            now.getTime() - lastDate.getTime() > 12 * 60 * 60 * 1000
-          ) {
-            points.push({
-              label: formatConformanceHistoryLabel(now),
-              timestamp: now.toISOString(),
-              time: now.getTime(),
-              pass,
-              total,
-              rate: lastRate,
-            });
-          }
-        }
-
-        if (points.length === 0) {
-          const now = new Date();
-          points.push(
-            {
-              label: formatConformanceHistoryLabel(CONFORMANCE_PROJECT_START),
-              timestamp: CONFORMANCE_PROJECT_START.toISOString(),
-              time: CONFORMANCE_PROJECT_START.getTime(),
-              pass: 0,
-              total: 0,
-              rate: 0,
-            },
-            {
-              label: formatConformanceHistoryLabel(now),
-              timestamp: now.toISOString(),
-              time: now.getTime(),
-              pass: 0,
-              total: 0,
-              rate: 0,
-            },
-          );
-        }
-
-        return points.length >= 2 ? points : null;
-      }
-
-      function configureConformanceHistoryChart(chart, runs) {
-        const points = buildConformanceHistoryPoints(runs);
-        if (!(chart instanceof HTMLElement) || !points) return;
-
-        chart.setAttribute("labels-key", "label");
-        chart.setAttribute(
-          "series",
-          JSON.stringify([
-            {
-              key: "rate",
-              color: "#ffffff",
-              fill: true,
-            },
-            {
-              key: "pass",
-              color: "rgba(255,255,255,0.82)",
-              axis: "right",
-              lineWidth: 1,
-              lineOpacity: 0.5,
-            },
-            {
-              key: "total",
-              color: "rgba(141, 154, 184, 1)",
-              axis: "right",
-              lineWidth: 1,
-              lineOpacity: 1,
-              dasharray: "1 3",
-            },
-          ]),
-        );
-
-        const applyData = () => {
-          chart.data = points;
-        };
-
-        if (customElements.get("trend-chart")) {
-          applyData();
-          return;
-        }
-
-        customElements
-          .whenDefined("trend-chart")
-          .then(applyData)
-          .catch(() => {});
-      }
+      // The pass-rate-over-time chart (point building, two-lane merge, legend)
+      // now lives in the shared <t262-conformance-trend> component, which the
+      // landing page renders too — see components/t262-conformance-trend.js.
+      const CONFORMANCE_RUNS_BASE = assetPath("benchmarks/results/runs");
 
       function shortName(cat) {
         return cat
@@ -1036,8 +859,12 @@
 
       // Per-ES-edition pass-rate trend history for the mini sparklines in the
       // edition legend, sourced from benchmarks/results/runs/editions-index.json
-      // (see scripts/append-run-history.mjs). Host-mode only — no per-edition
-      // standalone history exists yet.
+      // and its host-free twin standalone-editions-index.json (see
+      // scripts/append-run-history.mjs). The caller picks the file matching the
+      // active view: the standalone view used to pass `null` here, so its
+      // edition cards showed a donut with no sparkline at all — and feeding it
+      // the HOST series instead would have put a js-host curve under a
+      // standalone number, which is worse than showing nothing.
       function buildEditionTrendSeries(editionRuns) {
         const seriesByEdition = new Map();
         if (!Array.isArray(editionRuns)) return seriesByEdition;
@@ -1535,8 +1362,8 @@
         });
       }
 
-      function renderConformance(view, container, conformanceRuns, editionRuns) {
-        const editionTrendSeries = view.mode === "host" ? buildEditionTrendSeries(editionRuns) : null;
+      function renderConformance(view, container, editionRunsByLane) {
+        const editionTrendSeries = buildEditionTrendSeries(editionRunsByLane?.[view.mode]);
         const data = view.report;
         // Point per-file detail/error-pattern lookups at this view's source.
         activeFileResultsSrc = view.fileResultsSrc;
@@ -1549,6 +1376,9 @@
           editionScope: "overall",
         };
         let editionDetail = null;
+        // Assigned when the history panel is built below; declared here so
+        // applyEditionScope() can push the slider's scope into it.
+        let historyTrendChart = null;
 
         let summaryStamp = null;
         if (data.timestamp || data.baseline_generated_at) {
@@ -1641,6 +1471,11 @@
           syncToggleStyles();
           renderSummaryCard();
           renderEditionSection();
+          // The shared trend chart follows the slider, like the donut does.
+          historyTrendChart?.setAttribute("scope", scoreState.editionScope);
+          // Keep ?mode=/?edition= in step so the view can be linked to —
+          // shared with the landing page (components/t262-view-state.js).
+          window.t262ViewState?.write({ mode: view.mode, edition: scoreState.editionScope });
           // (#1398) Re-filter the category table when the edition scope
           // changes. `applyFilters` is hoisted (declared via function
           // statement later in this scope) so it's safe to call here even
@@ -1704,38 +1539,18 @@
 
         const historyPanel = el("div", { className: "summary-visual-panel summary-history-panel" });
         historyPanel.appendChild(el("h3", { className: "diagram-title" }, "Test Pass Rate Over Time"));
-        const historyChart = el("trend-chart", {
+        // Shared with the landing page. Both lanes are plotted; `mode` picks
+        // which one is the thick white line, and `scope` follows the edition
+        // slider — the chart used to ignore both, showing the js-host overall
+        // curve even in the standalone view at an ES2015 selection.
+        historyTrendChart = el("t262-conformance-trend", {
           className: "summary-history-chart",
-          mode: "step",
           height: "260",
-          "x-key": "time",
+          mode: view.mode,
+          scope: scoreState.editionScope,
+          "runs-base": CONFORMANCE_RUNS_BASE,
         });
-        historyPanel.appendChild(historyChart);
-        historyPanel.appendChild(
-          el(
-            "div",
-            { className: "diagram-legend" },
-            el(
-              "span",
-              { className: "diagram-legend-item" },
-              el("span", { className: "diagram-legend-line" }),
-              el("span", null, "Pass rate"),
-            ),
-            el(
-              "span",
-              { className: "diagram-legend-item" },
-              el("span", { className: "diagram-legend-line passed" }),
-              el("span", null, "Tests passed"),
-            ),
-            el(
-              "span",
-              { className: "diagram-legend-item" },
-              el("span", { className: "diagram-legend-line total" }),
-              el("span", null, "Total tests run"),
-            ),
-          ),
-        );
-        configureConformanceHistoryChart(historyChart, conformanceRuns);
+        historyPanel.appendChild(historyTrendChart);
         summaryVisuals.appendChild(historyPanel);
 
         summary.appendChild(summaryVisuals);
@@ -1768,8 +1583,28 @@
         } else {
           editionTimeline.removeAttribute("show-proposals");
         }
+        // (?edition=) Apply the incoming URL scope once the timeline has
+        // published its own scope map, and VALIDATE against it — an unknown
+        // value would leave the slider on a selection the donut, category
+        // table and trend chart all ignore. The snapshot is taken in main()
+        // before any render writes the query string back.
+        let urlEditionApplied = false;
+        const applyUrlEditionOnce = (detail) => {
+          if (urlEditionApplied) return;
+          urlEditionApplied = true;
+          const edition = initialViewState.edition;
+          if (!edition) return;
+          const scopeMap = detail?.scopeMap;
+          const isKnownScope =
+            edition === "overall" ||
+            edition === "overall+proposal" ||
+            (scopeMap instanceof Map && scopeMap.has(edition));
+          if (isKnownScope && edition !== detail?.scope) editionTimeline.value = edition;
+        };
+
         editionTimeline.addEventListener("edition-change", (event) => {
           applyEditionScope(event.detail);
+          applyUrlEditionOnce(event.detail);
         });
         editionTimeline.setAttribute("value", "overall");
 
@@ -2553,13 +2388,20 @@
       }
 
       async function main() {
-        const [conformance, standaloneReport, conformanceRuns, categoryEditions, editionRuns] = await Promise.all([
-          loadReportWithFallback(),
-          loadJSON(STANDALONE_REPORT_JSON),
-          loadJSON(assetPath("benchmarks/results/runs/index.json")),
-          loadJSON(CATEGORY_EDITIONS_JSON),
-          loadJSON(assetPath("benchmarks/results/runs/editions-index.json")),
-        ]);
+        // The overall pass-rate history is fetched by the shared
+        // <t262-conformance-trend> component itself; what main() still needs is
+        // the PER-EDITION history for the edition-legend sparklines — one file
+        // per lane, so the standalone view gets standalone sparklines instead
+        // of none (#4362).
+        const [conformance, standaloneReport, categoryEditions, hostEditionRuns, standaloneEditionRuns] =
+          await Promise.all([
+            loadReportWithFallback(),
+            loadJSON(STANDALONE_REPORT_JSON),
+            loadJSON(CATEGORY_EDITIONS_JSON),
+            loadJSON(assetPath("benchmarks/results/runs/editions-index.json")),
+            loadJSON(assetPath("benchmarks/results/runs/standalone-editions-index.json")),
+          ]);
+        const editionRunsByLane = { host: hostEditionRuns, standalone: standaloneEditionRuns };
         const app = document.getElementById("app");
         app.textContent = "";
 
@@ -2610,12 +2452,15 @@
             : null;
 
           // Mode switch (only shown when standalone data is available).
+          // ?mode= wins over the remembered choice: an explicit link should
+          // show what it says regardless of what this browser last looked at.
           const conformanceHost = el("div");
-          let activeMode = standaloneView && localStorage.getItem("t262-mode") === "standalone" ? "standalone" : "host";
+          const preferredMode = initialViewState.mode || localStorage.getItem("t262-mode");
+          let activeMode = standaloneView && preferredMode === "standalone" ? "standalone" : "host";
           const renderActive = () => {
             conformanceHost.textContent = "";
             const view = activeMode === "standalone" && standaloneView ? standaloneView : hostView;
-            renderConformance(view, conformanceHost, conformanceRuns, editionRuns);
+            renderConformance(view, conformanceHost, editionRunsByLane);
           };
           if (standaloneView) {
             const modeSwitch = el("div", { className: "mode-switch" });
@@ -2630,6 +2475,7 @@
                 if (activeMode === mode) return;
                 activeMode = mode;
                 localStorage.setItem("t262-mode", mode);
+                window.t262ViewState?.write({ mode });
                 modeSwitch.querySelectorAll("button").forEach((x) => x.classList.remove("active"));
                 b.classList.add("active");
                 renderActive();


### PR DESCRIPTION
## Description

Follow-up to #4466. The landing page and the conformance report page show the same three conformance widgets. The donut (`<t262-donut>`) and the ES-edition slider (`<t262-edition-timeline>`) were already shared web components; the pass-rate trend chart was not — each page carried its own copy of the point building, the series config and the legend, and the two had drifted apart:

- the landing page's chart followed the edition slider and the lane toggle; **the report page's ignored both**, plotting the js-host *overall* curve even in the standalone view at an ES2015 selection;
- the report page still had the old "Tests passed" / dashed "Total tests run" count series on a right-hand axis;
- the two `buildHistoryPoints` implementations had diverged in their handling of the empty case.

### Shared component

New `<t262-conformance-trend>` (`website/components/t262-conformance-trend.js`) owns the four history files, the two-lane merge, the series weighting and the legend. Both pages render it and pass only `mode`, `scope` and `runs-base` — net **−370 lines** across the two pages. `t262NormalizeEditionLabel` is exported from `t262-charts.js` so the component shares the single definition instead of adding a third copy.

### `?mode=` / `?edition=`

`website/components/t262-view-state.js`, used by both pages, so a conformance view can be linked to:

- `/?mode=standalone&edition=ES2015`
- `/benchmarks/report.html?mode=standalone&edition=ES2020`

Details that matter:

- Defaults (`host`, `overall`) are dropped from the query string, so ordinary URLs stay clean and a shared link only names what actually differs.
- Writes use `replaceState` — the toggles are not navigation and must not stack history entries the Back button unwinds one edition at a time.
- An incoming `?edition=` is **validated against the timeline's own scope map**; an unknown value is ignored rather than leaving the slider on a selection the donut, feature rows and chart all ignore.
- Each page snapshots the URL **before** its first render, because that render writes the current knobs back and would otherwise erase the incoming link's state a moment before it was read.
- On the report page `?mode=` wins over the `localStorage`-remembered choice: an explicit link should show what it says.
- Applying `?mode=` on the landing page dispatches a real `change` event, since the same checkbox also drives the per-edition pass bars and the feature-row badges.
- The landing page's "Compatibility Test Report" link carries the current view across, since the report page reads the same two params.

### Report-page edition sparklines

The mini per-edition trends in the edition legend were built from the host editions index and passed as `null` in standalone mode, so **every standalone edition card showed a donut with no trend at all**. They now read the lane's own history file (`standalone-editions-index.json` for the standalone view) — which is what makes them showable; feeding them the host series instead would have put a js-host curve under a standalone number.

### Verification

Headless-browser driven on both pages against the real baselines-repo history:

- lane toggle × edition slider drive the shared chart in all four combinations, on both pages;
- URL round-trips, including a bogus `?edition=` being ignored and cleaned out;
- the cross-page link carries the view (`./benchmarks/report.html?mode=standalone&edition=ES2022`);
- report-page sparklines render in both lanes (14 edition cards each; was 14 host / 0 standalone), and the standalone cards read the `≤ ES3`-bearing standalone buckets rather than the host ones;
- with the standalone per-edition history absent, the chart still degrades to the host line plus a `(no history yet)` legend note.

No console/page errors. `prettier --check` clean; `biome` does not scan `website/`.

Not touched: `benchmarks/results/report.html`, a separate legacy "Conformance Trend" page that plots raw pass/fail/CE counts from `runs/index.json` and has no mode or edition concept.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmfiGERvoPX7QevNBTtvLY)_