### PR TITLE
test(dogfood): publish Jest upstream results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ tests/dogfood/report/
 /.webpack-upstream-suite-generated/
 /.jest-upstream-suite-generated/
 /.tailwindcss-upstream-suite-generated/
+/.typescript-upstream-suite-generated/
 /check-*.ts
 /check-*.mts
 /debug-*.ts

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ tests/dogfood/report/
 /.styled-components-upstream-suite-generated/
 /.webpack-upstream-suite-generated/
 /.jest-upstream-suite-generated/
+/.tailwindcss-upstream-suite-generated/
 /check-*.ts
 /check-*.mts
 /debug-*.ts

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ tests/dogfood/report/
 /.jsdom-upstream-suite-generated/
 /.styled-components-upstream-suite-generated/
 /.webpack-upstream-suite-generated/
+/.jest-upstream-suite-generated/
 /check-*.ts
 /check-*.mts
 /debug-*.ts

--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
     "dogfood:lit-upstream-suite": "npx tsx tests/dogfood/lit-upstream-suite.mjs",
     "dogfood:react-dom-upstream-suite": "npx tsx tests/dogfood/react-dom-upstream-suite.mjs",
     "dogfood:tailwindcss": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package tailwindcss",
+    "dogfood:tailwindcss-upstream-suite": "node --import tsx tests/dogfood/tailwindcss-upstream-suite.mjs",
     "dogfood:npm-compat-upstream-sources": "node tests/dogfood/npm-compat-upstream-sources.mjs",
     "dogfood:npm-compat-upstream": "node tests/dogfood/npm-compat-upstream.mjs",
     "generate:npm-compat": "node --import tsx scripts/generate-npm-compat-report.mjs",

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "dogfood:react-dom-upstream-suite": "npx tsx tests/dogfood/react-dom-upstream-suite.mjs",
     "dogfood:tailwindcss": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package tailwindcss",
     "dogfood:tailwindcss-upstream-suite": "node --import tsx tests/dogfood/tailwindcss-upstream-suite.mjs",
+    "dogfood:typescript-upstream-suite": "node --import tsx tests/dogfood/typescript-upstream-suite.mjs",
     "dogfood:npm-compat-upstream-sources": "node tests/dogfood/npm-compat-upstream-sources.mjs",
     "dogfood:npm-compat-upstream": "node tests/dogfood/npm-compat-upstream.mjs",
     "generate:npm-compat": "node --import tsx scripts/generate-npm-compat-report.mjs",

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "dogfood:redux-workload": "npx tsx tests/dogfood/redux-workload-harness.mjs",
     "dogfood:redux-upstream-suite": "node --import tsx tests/dogfood/redux-upstream-suite.mjs",
     "dogfood:jest": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package jest",
+    "dogfood:jest-upstream-suite": "node --import tsx tests/dogfood/jest-upstream-suite.mjs",
     "dogfood:styled-components": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package styled-components",
     "dogfood:styled-components-upstream-suite": "node --import tsx tests/dogfood/styled-components-upstream-suite.mjs",
     "dogfood:moment": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package moment",

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -413,6 +413,24 @@ remain explicit deferred inventory. The npm-compat generator invokes the
 adapter directly so the merge-only refresh publishes numeric results and
 cannot fall back to `adapter pending`.
 
+## 2026-08-14 TypeScript base64 slice
+
+TypeScript 5.9.3 now verifies all 256 files and 1,761 static registrations under
+`src/testRunner/unittests` from `microsoft/TypeScript@v5.9.3` (commit
+`c63de15a992d37f0d6cec03ac7631872838602cb`). The first runtime adapter runs the
+original `base64.ts` callback unchanged. At setup time it projects the exact
+base64 declarations from the matching release's `src/compiler/utilities.ts`,
+avoiding the unrelated full compiler graph that exceeds the bounded catalog
+compile budget.
+
+The adapter registers one callback. It passes in native Node and after the
+release-tag source and original callback are compiled to Wasm.
+
+The remaining 255 compiler, server, watch, evaluator, snapshot, async, and
+filesystem-heavy files remain explicit deferred inventory. The npm-compat
+generator invokes this adapter directly, so the merge-only refresh publishes a
+numeric result and cannot fall back to `adapter pending`.
+
 ## 2026-08-14 webpack synchronous utility slice
 
 webpack 5.109.2 now verifies all 98 top-level `test/*.unittest.js` files and

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -373,6 +373,28 @@ explicit deferred inventory. The npm-compat generator invokes the adapter
 directly so the merge-only refresh publishes numeric results and cannot fall
 back to `adapter pending`.
 
+## 2026-08-14 Jest get-type slice
+
+Jest 30.4.2 now verifies all 241 matching files under
+`packages/**/__tests__` and 3,288 static registrations from
+`jestjs/jest@v30.4.2` (commit
+`746f2a0f57c56e3bba555280f0587d40f3db95c0`). The first runtime adapter runs
+the original `@jest/get-type` `getType` and `isPrimitive` test files directly
+against their matching release-tag TypeScript implementation without changing
+callback bodies or inputs.
+
+Both selected modules compile and validate. Native Node passes **32/32**
+callbacks and Wasm passes **16/32**. The failures share a representation cause:
+several primitive values reach the generic `unknown` helper boxed as objects,
+so JavaScript `typeof` and `Object(value) !== value` checks misclassify them.
+The native oracle also confirmed all 32 callbacks after the shared `test.each`
+shim learned to distinguish a table of scalar cases from a table of tuples.
+
+Runner, snapshot, filesystem, worker, async, DOM, and larger package graphs
+remain explicit deferred inventory. The npm-compat generator invokes the
+adapter directly so the merge-only refresh publishes numeric results and
+cannot fall back to `adapter pending`.
+
 ## 2026-08-14 webpack synchronous utility slice
 
 webpack 5.109.2 now verifies all 98 top-level `test/*.unittest.js` files and

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -395,6 +395,24 @@ remain explicit deferred inventory. The npm-compat generator invokes the
 adapter directly so the merge-only refresh publishes numeric results and
 cannot fall back to `adapter pending`.
 
+## 2026-08-14 Tailwind CSS segment utility slice
+
+Tailwind CSS 4.3.3 now verifies all 42 matching tests under
+`packages/tailwindcss` and 1,376 static registrations from
+`tailwindlabs/tailwindcss@v4.3.3` (commit
+`c2b24dd15fed1c59dd521bd86082f520c9f5ad0d`). The first runtime adapter runs
+the original `segment.test.ts` and `to-key-path.test.ts` callbacks directly
+against their matching release-tag TypeScript implementations without changing
+callback bodies or inputs.
+
+The adapter registers 13 callbacks. All 13 pass in native Node and all 13 pass
+after compiling the release-tag sources and original callbacks to Wasm.
+
+Scanner, Rust/native, CSS pipeline, snapshot, async, UI, and larger graph files
+remain explicit deferred inventory. The npm-compat generator invokes the
+adapter directly so the merge-only refresh publishes numeric results and
+cannot fall back to `adapter pending`.
+
 ## 2026-08-14 webpack synchronous utility slice
 
 webpack 5.109.2 now verifies all 98 top-level `test/*.unittest.js` files and

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -431,6 +431,25 @@ filesystem-heavy files remain explicit deferred inventory. The npm-compat
 generator invokes this adapter directly, so the merge-only refresh publishes a
 numeric result and cannot fall back to `adapter pending`.
 
+## 2026-08-14 complete workflow wiring
+
+All 24 packages rendered on npm-compat now declare an executable `suiteScript`.
+The report generator uses one registry for those 24 adapters and refuses to
+start if the configured and executable package sets differ. Catalog packages
+no longer pass through a nullable conditional chain that could silently fall
+back to `adapter pending` after an adapter had shipped.
+
+The merge-only npm-compat workflow independently rejects its generated artifact
+unless every configured adapter produces numeric `passed` and `total` fields.
+Performance measurements and regressions remain reporting data rather than unit
+test gates.
+
+The complete `generate:npm-compat --no-write` path was run locally after this
+wiring change. It completed all 24 packages, left one numeric suite report per
+package, and exited successfully. Its aggregate correctness rollup reported 8
+verified, 14 divergent, and 2 unverified packages; those compatibility gaps are
+reported data, not hidden or converted into performance gates.
+
 ## 2026-08-14 webpack synchronous utility slice
 
 webpack 5.109.2 now verifies all 98 top-level `test/*.unittest.js` files and

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -66,6 +66,7 @@ import { runHarness as runStyledComponentsUpstreamSuite } from "../tests/dogfood
 import { runHarness as runWebpackUpstreamSuite } from "../tests/dogfood/webpack-upstream-suite.mjs";
 import { runHarness as runJestUpstreamSuite } from "../tests/dogfood/jest-upstream-suite.mjs";
 import { runHarness as runTailwindcssUpstreamSuite } from "../tests/dogfood/tailwindcss-upstream-suite.mjs";
+import { runHarness as runTypescriptUpstreamSuite } from "../tests/dogfood/typescript-upstream-suite.mjs";
 import { NPM_COMPAT_CATALOG, NPM_COMPAT_CATALOG_NAMES } from "../tests/dogfood/npm-compat-catalog.mjs";
 import { runNpmCompatCatalogHarness } from "../tests/dogfood/npm-compat-catalog-harness.mjs";
 
@@ -1935,7 +1936,9 @@ for (const entry of NPM_COMPAT_CATALOG) {
                               ? runJestUpstreamSuite
                               : entry.name === "tailwindcss"
                                 ? runTailwindcssUpstreamSuite
-                                : null;
+                                : entry.name === "typescript"
+                                  ? runTypescriptUpstreamSuite
+                                  : null;
   const catalogUpstreamReport = catalogUpstreamRunner ? await catalogUpstreamRunner({ quiet: true }) : null;
   const upstreamSuite = entry.upstreamSuite;
   const upstreamTests = upstreamSuite

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -69,6 +69,7 @@ import { runHarness as runTailwindcssUpstreamSuite } from "../tests/dogfood/tail
 import { runHarness as runTypescriptUpstreamSuite } from "../tests/dogfood/typescript-upstream-suite.mjs";
 import { NPM_COMPAT_CATALOG, NPM_COMPAT_CATALOG_NAMES } from "../tests/dogfood/npm-compat-catalog.mjs";
 import { runNpmCompatCatalogHarness } from "../tests/dogfood/npm-compat-catalog-harness.mjs";
+import { NPM_COMPAT_UPSTREAM_SOURCES } from "../tests/dogfood/npm-compat-upstream-sources.mjs";
 
 import { setupAcorn } from "../tests/dogfood/setup-acorn.mjs";
 import { setupClsx } from "../tests/dogfood/setup-clsx.mjs";
@@ -90,6 +91,48 @@ const ROOT = resolve(import.meta.dirname, "..");
 const PACKAGE_NAMES = [
   ...new Set(["acorn", "marked", "clsx", "cookie", "eslint", "prettier", "react", ...NPM_COMPAT_CATALOG_NAMES]),
 ];
+const UPSTREAM_SUITE_RUNNERS = new Map([
+  ["acorn", runAcornOfficialSuite],
+  ["axios", runAxiosUpstreamSuite],
+  ["clsx", runClsxUpstreamSuite],
+  ["cookie", runCookieUpstreamSuite],
+  ["eslint", runEslintUpstreamSuite],
+  ["hono", runHonoUpstreamSuite],
+  ["jest", runJestUpstreamSuite],
+  ["jsdom", runJsdomUpstreamSuite],
+  ["lit", runLitUpstreamSuite],
+  ["lodash", (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash" })],
+  ["lodash-es", (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash-es" })],
+  ["marked", runMarkedUpstreamSuite],
+  ["moment", runMomentUpstreamSuite],
+  ["prettier", runPrettierUpstreamSuite],
+  ["react", runReactUpstreamSuite],
+  ["react-dom", runReactDomUpstreamSuite],
+  ["redux", runReduxUpstreamSuite],
+  ["styled-components", runStyledComponentsUpstreamSuite],
+  ["stylelint", runStylelintUpstreamSuite],
+  ["tailwindcss", runTailwindcssUpstreamSuite],
+  ["three", runThreeUpstreamSuite],
+  ["typescript", runTypescriptUpstreamSuite],
+  ["uuid", runUuidUpstreamSuite],
+  ["webpack", runWebpackUpstreamSuite],
+]);
+
+const CONFIGURED_UPSTREAM_NAMES = NPM_COMPAT_UPSTREAM_SOURCES.filter((entry) => entry.suiteScript)
+  .map((entry) => entry.name)
+  .sort();
+const WIRED_UPSTREAM_NAMES = [...UPSTREAM_SUITE_RUNNERS.keys()].sort();
+if (JSON.stringify(CONFIGURED_UPSTREAM_NAMES) !== JSON.stringify(WIRED_UPSTREAM_NAMES)) {
+  throw new Error(
+    `npm-compat upstream runner registry mismatch\nconfigured: ${CONFIGURED_UPSTREAM_NAMES.join(", ")}\nwired: ${WIRED_UPSTREAM_NAMES.join(", ")}`,
+  );
+}
+
+function runConfiguredUpstreamSuite(name, options) {
+  const runner = UPSTREAM_SUITE_RUNNERS.get(name);
+  if (!runner) throw new Error(`npm-compat has no upstream suite runner for ${name}`);
+  return runner(options);
+}
 // Committed npm API snapshot keeps report generation deterministic and offline.
 // Refresh these together from:
 // https://api.npmjs.org/downloads/point/last-week/{package}
@@ -1480,7 +1523,7 @@ if (selectedPackages.has("acorn")) {
   } else {
     console.log("[npm-compat] acorn — compile/validate/diff + official test suite (this takes ~1 min)...");
     const acornReport = await runAcorn({ quiet: true });
-    const acornSuite = await runAcornOfficialSuite({ quiet: true });
+    const acornSuite = await runConfiguredUpstreamSuite("acorn", { quiet: true });
     const acornPerf = await perfAcorn();
     packages.push(
       await buildPackageEntry({
@@ -1506,7 +1549,7 @@ if (selectedPackages.has("acorn")) {
 if (selectedPackages.has("marked")) {
   console.log("[npm-compat] marked — package entry + selected original upstream unit tests...");
   const markedReport = await runMarked({ quiet: true });
-  const markedSuite = await runMarkedUpstreamSuite({ quiet: true });
+  const markedSuite = await runConfiguredUpstreamSuite("marked", { quiet: true });
   packages.push(
     await buildPackageEntry({
       name: "marked",
@@ -1563,7 +1606,7 @@ if (selectedPackages.has("clsx")) {
   } else {
     console.log("[npm-compat] clsx — compile/validate/diff + complete original upstream unit suite + perf...");
     const clsxReport = await runClsx({ quiet: true });
-    const clsxSuite = await runClsxUpstreamSuite({ quiet: true });
+    const clsxSuite = await runConfiguredUpstreamSuite("clsx", { quiet: true });
     const clsxPerf = await perfClsx();
     packages.push(
       await buildPackageEntry({
@@ -1619,7 +1662,7 @@ if (selectedPackages.has("cookie")) {
   } else {
     console.log("[npm-compat] cookie — compile/validate/diff + complete original upstream unit suite + perf...");
     const cookieReport = await runCookie({ quiet: true });
-    const cookieSuite = await runCookieUpstreamSuite({ quiet: true });
+    const cookieSuite = await runConfiguredUpstreamSuite("cookie", { quiet: true });
     const cookiePerf = await perfCookie();
     packages.push(
       await buildPackageEntry({
@@ -1662,7 +1705,7 @@ if (selectedPackages.has("cookie")) {
 if (selectedPackages.has("eslint")) {
   console.log("[npm-compat] eslint — bounded package entry + selected original upstream unit...");
   const eslintReport = await runEslint({ quiet: true });
-  const eslintSuite = await runEslintUpstreamSuite({ quiet: true });
+  const eslintSuite = await runConfiguredUpstreamSuite("eslint", { quiet: true });
   // Do not spend a second bounded compile on a package-entry failure. Once
   // lib/api.js is a valid module, the workload harness compiles a generated
   // driver that calls the real Linter.verify API and compares its primitive
@@ -1708,7 +1751,7 @@ if (selectedPackages.has("eslint")) {
 if (selectedPackages.has("prettier")) {
   console.log("[npm-compat] prettier — package entry + selected original upstream unit tests...");
   const prettierReport = await runPrettier({ quiet: true });
-  const prettierSuite = await runPrettierUpstreamSuite({ quiet: true });
+  const prettierSuite = await runConfiguredUpstreamSuite("prettier", { quiet: true });
   packages.push(
     await buildPackageEntry({
       name: "prettier",
@@ -1744,7 +1787,7 @@ if (selectedPackages.has("prettier")) {
 if (selectedPackages.has("react")) {
   console.log("[npm-compat] react — package entry + React's own upstream unit tests...");
   const reactReport = await runReact({ quiet: true });
-  const reactSuite = await runReactUpstreamSuite({ quiet: true });
+  const reactSuite = await runConfiguredUpstreamSuite("react", { quiet: true });
   packages.push(
     await buildPackageEntry({
       name: "react",
@@ -1793,7 +1836,7 @@ if (selectedPackages.has("lit")) {
   } else {
     console.log("[npm-compat] lit — package entry + lit's own upstream unit tests...");
     const litReport = await runNpmCompatCatalogHarness("lit", { quiet: true });
-    const litSuite = await runLitUpstreamSuite({ quiet: true });
+    const litSuite = await runConfiguredUpstreamSuite("lit", { quiet: true });
     packages.push(
       await buildPackageEntry({
         name: "lit",
@@ -1835,7 +1878,7 @@ if (selectedPackages.has("react-dom")) {
   console.log("[npm-compat] react-dom — package entry + react-dom's own upstream unit tests...");
   const reactDomEntry = NPM_COMPAT_CATALOG.find((entry) => entry.name === "react-dom");
   const reactDomReport = await runNpmCompatCatalogHarness("react-dom", { quiet: true });
-  const reactDomSuite = await runReactDomUpstreamSuite({ quiet: true });
+  const reactDomSuite = await runConfiguredUpstreamSuite("react-dom", { quiet: true });
   const reactDomImplementationReport = {
     ...reactDomReport,
     // The package-entry probe only compiles the small environment selector.
@@ -1907,39 +1950,7 @@ for (const entry of NPM_COMPAT_CATALOG) {
       ? await workloadRunner({ quiet: true })
       : null;
   const hasApiWorkload = workloadRunner !== null;
-  const catalogUpstreamRunner =
-    entry.name === "hono"
-      ? runHonoUpstreamSuite
-      : entry.name === "lodash"
-        ? (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash" })
-        : entry.name === "lodash-es"
-          ? (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash-es" })
-          : entry.name === "uuid"
-            ? runUuidUpstreamSuite
-            : entry.name === "redux"
-              ? runReduxUpstreamSuite
-              : entry.name === "jsdom"
-                ? runJsdomUpstreamSuite
-                : entry.name === "axios"
-                  ? runAxiosUpstreamSuite
-                  : entry.name === "moment"
-                    ? runMomentUpstreamSuite
-                    : entry.name === "stylelint"
-                      ? runStylelintUpstreamSuite
-                      : entry.name === "three"
-                        ? runThreeUpstreamSuite
-                        : entry.name === "styled-components"
-                          ? runStyledComponentsUpstreamSuite
-                          : entry.name === "webpack"
-                            ? runWebpackUpstreamSuite
-                            : entry.name === "jest"
-                              ? runJestUpstreamSuite
-                              : entry.name === "tailwindcss"
-                                ? runTailwindcssUpstreamSuite
-                                : entry.name === "typescript"
-                                  ? runTypescriptUpstreamSuite
-                                  : null;
-  const catalogUpstreamReport = catalogUpstreamRunner ? await catalogUpstreamRunner({ quiet: true }) : null;
+  const catalogUpstreamReport = await runConfiguredUpstreamSuite(entry.name, { quiet: true });
   const upstreamSuite = entry.upstreamSuite;
   const upstreamTests = upstreamSuite
     ? {

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -65,6 +65,7 @@ import { runHarness as runThreeUpstreamSuite } from "../tests/dogfood/three-upst
 import { runHarness as runStyledComponentsUpstreamSuite } from "../tests/dogfood/styled-components-upstream-suite.mjs";
 import { runHarness as runWebpackUpstreamSuite } from "../tests/dogfood/webpack-upstream-suite.mjs";
 import { runHarness as runJestUpstreamSuite } from "../tests/dogfood/jest-upstream-suite.mjs";
+import { runHarness as runTailwindcssUpstreamSuite } from "../tests/dogfood/tailwindcss-upstream-suite.mjs";
 import { NPM_COMPAT_CATALOG, NPM_COMPAT_CATALOG_NAMES } from "../tests/dogfood/npm-compat-catalog.mjs";
 import { runNpmCompatCatalogHarness } from "../tests/dogfood/npm-compat-catalog-harness.mjs";
 
@@ -1932,7 +1933,9 @@ for (const entry of NPM_COMPAT_CATALOG) {
                             ? runWebpackUpstreamSuite
                             : entry.name === "jest"
                               ? runJestUpstreamSuite
-                              : null;
+                              : entry.name === "tailwindcss"
+                                ? runTailwindcssUpstreamSuite
+                                : null;
   const catalogUpstreamReport = catalogUpstreamRunner ? await catalogUpstreamRunner({ quiet: true }) : null;
   const upstreamSuite = entry.upstreamSuite;
   const upstreamTests = upstreamSuite

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -64,6 +64,7 @@ import { runHarness as runStylelintUpstreamSuite } from "../tests/dogfood/stylel
 import { runHarness as runThreeUpstreamSuite } from "../tests/dogfood/three-upstream-suite.mjs";
 import { runHarness as runStyledComponentsUpstreamSuite } from "../tests/dogfood/styled-components-upstream-suite.mjs";
 import { runHarness as runWebpackUpstreamSuite } from "../tests/dogfood/webpack-upstream-suite.mjs";
+import { runHarness as runJestUpstreamSuite } from "../tests/dogfood/jest-upstream-suite.mjs";
 import { NPM_COMPAT_CATALOG, NPM_COMPAT_CATALOG_NAMES } from "../tests/dogfood/npm-compat-catalog.mjs";
 import { runNpmCompatCatalogHarness } from "../tests/dogfood/npm-compat-catalog-harness.mjs";
 
@@ -1929,7 +1930,9 @@ for (const entry of NPM_COMPAT_CATALOG) {
                           ? runStyledComponentsUpstreamSuite
                           : entry.name === "webpack"
                             ? runWebpackUpstreamSuite
-                            : null;
+                            : entry.name === "jest"
+                              ? runJestUpstreamSuite
+                              : null;
   const catalogUpstreamReport = catalogUpstreamRunner ? await catalogUpstreamRunner({ quiet: true }) : null;
   const upstreamSuite = entry.upstreamSuite;
   const upstreamTests = upstreamSuite

--- a/tests/dogfood/README.md
+++ b/tests/dogfood/README.md
@@ -133,6 +133,7 @@ then compares its result with the same operation in native Node.
 | **styled-components upstream suite**    | #3995 | `src/utils/*.ts`        | pinned original utility callbacks; complete source-unit inventory tracked |
 | **webpack upstream suite**              | #3995 | `lib/util/*.js`         | pinned original utility callbacks; complete top-level unit inventory tracked |
 | **jest upstream suite**                 | #3995 | `jest-get-type/src/index.ts` | pinned original get-type callbacks; complete monorepo unit inventory tracked |
+| **tailwindcss upstream suite**          | #3995 | `src/utils/{segment,to-key-path}.ts` | pinned original utility callbacks; complete package test inventory tracked |
 | **redux** (state container)             | #3996 | `dist/redux.mjs`          | consumed store/reducer/subscription/action-creator API workload             |
 
 ## uuid v14.0.1 upstream suite (#3995)

--- a/tests/dogfood/README.md
+++ b/tests/dogfood/README.md
@@ -134,6 +134,7 @@ then compares its result with the same operation in native Node.
 | **webpack upstream suite**              | #3995 | `lib/util/*.js`         | pinned original utility callbacks; complete top-level unit inventory tracked |
 | **jest upstream suite**                 | #3995 | `jest-get-type/src/index.ts` | pinned original get-type callbacks; complete monorepo unit inventory tracked |
 | **tailwindcss upstream suite**          | #3995 | `src/utils/{segment,to-key-path}.ts` | pinned original utility callbacks; complete package test inventory tracked |
+| **typescript upstream suite**           | #3995 | `unittests/base64.ts`   | pinned original base64 callback; complete compiler-unit inventory tracked |
 | **redux** (state container)             | #3996 | `dist/redux.mjs`          | consumed store/reducer/subscription/action-creator API workload             |
 
 ## uuid v14.0.1 upstream suite (#3995)

--- a/tests/dogfood/README.md
+++ b/tests/dogfood/README.md
@@ -132,6 +132,7 @@ then compares its result with the same operation in native Node.
 | **jsdom upstream suite**                | #3995 | `lib/jsdom/virtual-console.js` | pinned original VirtualConsole callbacks; complete `test/api` inventory tracked |
 | **styled-components upstream suite**    | #3995 | `src/utils/*.ts`        | pinned original utility callbacks; complete source-unit inventory tracked |
 | **webpack upstream suite**              | #3995 | `lib/util/*.js`         | pinned original utility callbacks; complete top-level unit inventory tracked |
+| **jest upstream suite**                 | #3995 | `jest-get-type/src/index.ts` | pinned original get-type callbacks; complete monorepo unit inventory tracked |
 | **redux** (state container)             | #3996 | `dist/redux.mjs`          | consumed store/reducer/subscription/action-creator API workload             |
 
 ## uuid v14.0.1 upstream suite (#3995)

--- a/tests/dogfood/jest-upstream-suite-pin.json
+++ b/tests/dogfood/jest-upstream-suite-pin.json
@@ -1,0 +1,15 @@
+{
+  "name": "jest",
+  "version": "30.4.2",
+  "repo": "https://github.com/jestjs/jest.git",
+  "tag": "v30.4.2",
+  "commit": "746f2a0f57c56e3bba555280f0587d40f3db95c0",
+  "testFileCount": 241,
+  "testFilePathSha256": "28c5ee1496f45562053a8dbcb6ea14a922180b55a3f1eeb5dcb42928528ed7e7",
+  "registrationSites": 3288,
+  "selectedFiles": [
+    "packages/jest-get-type/src/__tests__/getType.test.ts",
+    "packages/jest-get-type/src/__tests__/isPrimitive.test.ts"
+  ],
+  "_note": "The complete packages/**/__tests__ inventory is verified. This first adapter runs the two original synchronous @jest/get-type unit files against their matching release-tag TypeScript implementation. Runner, snapshot, filesystem, worker, async, DOM, and larger package graphs remain explicit deferred coverage."
+}

--- a/tests/dogfood/jest-upstream-suite.mjs
+++ b/tests/dogfood/jest-upstream-suite.mjs
@@ -1,0 +1,79 @@
+// Jest 30.4.2 original @jest/get-type unit slice.
+
+import { readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { setupJestUpstreamSuite } from "./setup-jest-upstream-suite.mjs";
+import {
+  UPSTREAM_TEST_EXPORTS,
+  UPSTREAM_TEST_SHIM,
+  cliUpstreamHarness,
+  compileAndRunUpstreamModule,
+  summarizeUpstreamRuns,
+  writeUpstreamReport,
+} from "./upstream-suite-runner.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GENERATED_ROOT = resolve(HERE, "..", "..", ".jest-upstream-suite-generated");
+const REPORT_PATH = join(HERE, "report", "jest-upstream-suite.json");
+
+function moduleSpecifier(fromDirectory, target) {
+  let value = relative(fromDirectory, target).replace(/\\/g, "/");
+  if (!value.startsWith(".")) value = `./${value}`;
+  return value;
+}
+
+function transformJestTest(source, filePath, generatedPath, { normalizeCjs = false } = {}) {
+  let importIndex = 0;
+  return source.replace(
+    /import\s+\{([^}]+)\}\s+from\s+(["'])(\.\.?\/?[^"']*)\2;?/g,
+    (_match, bindings, quote, specifier) => {
+      const target = resolve(dirname(filePath), specifier, "index.ts");
+      const rewritten = moduleSpecifier(dirname(generatedPath), target);
+      if (!normalizeCjs) return `import {${bindings}} from ${quote}${rewritten}${quote};`;
+      const namespaceName = `__jestImport${importIndex++}`;
+      return (
+        `import * as ${namespaceName} from ${quote}${rewritten}${quote};\n` +
+        `const {${bindings}} = ${namespaceName}.default || ${namespaceName};`
+      );
+    },
+  );
+}
+
+export async function runHarness({ quiet = false } = {}) {
+  const log = quiet ? () => {} : (...values) => console.log(...values);
+  const suite = setupJestUpstreamSuite();
+  const runs = [];
+
+  log(`[dogfood] jest@${suite.pin.version} upstream ${suite.pin.tag} (${suite.pin.commit.slice(0, 12)})`);
+  for (const filePath of suite.selectedPaths) {
+    const file = suite.relativePath(filePath);
+    const generatedPath = join(GENERATED_ROOT, file);
+    const original = readFileSync(filePath, "utf-8");
+    const transformed = transformJestTest(original, filePath, generatedPath);
+    const nativeTransformed = transformJestTest(original, filePath, generatedPath, { normalizeCjs: true });
+    const source = `${UPSTREAM_TEST_SHIM}\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const nativeSource = `${UPSTREAM_TEST_SHIM}\n${nativeTransformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const result = await compileAndRunUpstreamModule({ generatedPath, source, nativeSource, timeoutMs: 240_000 });
+    runs.push({ file, result });
+    log(
+      `[dogfood] ${file}: ${result.native.statuses.filter(Boolean).length}/${result.native.count} native; ` +
+        `${result.wasm?.statuses.filter(Boolean).length ?? 0}/${result.native.count} Wasm`,
+    );
+  }
+
+  const report = summarizeUpstreamRuns({
+    name: `jest@${suite.pin.version}`,
+    pin: suite.pin,
+    testFiles: suite.testFiles,
+    selectedFiles: suite.pin.selectedFiles,
+    runs,
+  });
+  writeUpstreamReport(REPORT_PATH, report);
+  log(`[dogfood] ${report.summary.headline}; ${report.extraction.filesDeferred} upstream files explicitly deferred`);
+  log(`[dogfood] report → ${REPORT_PATH}`);
+  return report;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) cliUpstreamHarness(runHarness);

--- a/tests/dogfood/npm-compat-upstream-sources.json
+++ b/tests/dogfood/npm-compat-upstream-sources.json
@@ -114,6 +114,7 @@
     "commit": "c2b24dd15fed1c59dd521bd86082f520c9f5ad0d",
     "cacheKey": "tailwindcss",
     "compileScript": "dogfood:tailwindcss",
+    "suiteScript": "dogfood:tailwindcss-upstream-suite",
     "inventory": {
       "directory": "packages/tailwindcss",
       "include": "^packages/tailwindcss/(?:src|tests)/.*\\.(?:test|spec)\\.(?:js|ts|tsx)$",

--- a/tests/dogfood/npm-compat-upstream-sources.json
+++ b/tests/dogfood/npm-compat-upstream-sources.json
@@ -219,6 +219,7 @@
     "commit": "746f2a0f57c56e3bba555280f0587d40f3db95c0",
     "cacheKey": "jest",
     "compileScript": "dogfood:jest",
+    "suiteScript": "dogfood:jest-upstream-suite",
     "inventory": {
       "directory": "packages",
       "include": "^packages/.*/__tests__/.*\\.(?:test|spec)\\.(?:js|jsx|ts|tsx)$",

--- a/tests/dogfood/npm-compat-upstream-sources.json
+++ b/tests/dogfood/npm-compat-upstream-sources.json
@@ -17,6 +17,7 @@
     "commit": "c63de15a992d37f0d6cec03ac7631872838602cb",
     "cacheKey": "typescript",
     "compileScript": "dogfood:typescript",
+    "suiteScript": "dogfood:typescript-upstream-suite",
     "inventory": {
       "directory": "src/testRunner/unittests",
       "include": "^src/testRunner/unittests/.*\\.ts$",

--- a/tests/dogfood/npm-compat-upstream-sources.test.ts
+++ b/tests/dogfood/npm-compat-upstream-sources.test.ts
@@ -30,9 +30,8 @@ describe("npm-compat upstream GitHub source pins", () => {
         expect(pin.inventory.fileCount).toBeGreaterThan(0);
         expect(pin.inventory.pathSha256).toMatch(/^[0-9a-f]{64}$/);
       }
-      if (pin.suiteScript) {
-        expect(packageJson.scripts[pin.suiteScript]).toBeTypeOf("string");
-      }
+      expect(pin.suiteScript).toBeTypeOf("string");
+      expect(packageJson.scripts[pin.suiteScript]).toBeTypeOf("string");
     }
   });
 
@@ -47,5 +46,12 @@ describe("npm-compat upstream GitHub source pins", () => {
     expect(workflow).toContain("suitePins.filter(entry => entry.suiteScript)");
     expect(workflow).toContain("its unit-test result is absent");
     expect(workflow).toContain("still reports adapter pending");
+  });
+
+  it("makes report generation reject configured suites missing from its executable registry", () => {
+    const generator = readFileSync(join(HERE, "../../scripts/generate-npm-compat-report.mjs"), "utf-8");
+    expect(generator).toContain("UPSTREAM_SUITE_RUNNERS");
+    expect(generator).toContain("npm-compat upstream runner registry mismatch");
+    expect(generator).toContain("runConfiguredUpstreamSuite(entry.name");
   });
 });

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -86,6 +86,12 @@ describe("small npm package upstream suites", () => {
       testFileCount: 98,
       registrationSites: 1357,
     });
+    expect(pin("jest")).toMatchObject({
+      tag: "v30.4.2",
+      commit: "746f2a0f57c56e3bba555280f0587d40f3db95c0",
+      testFileCount: 241,
+      registrationSites: 3288,
+    });
   });
 
   const clsxHeavy = process.env.DOGFOOD_CLSX_UPSTREAM_SUITE === "1" ? it : it.skip;
@@ -245,5 +251,20 @@ describe("small npm package upstream suites", () => {
     });
     expect(report.compile.modules).toBe(3);
     expect(report.results.scored).toBe(16);
+  });
+
+  const jestHeavy = process.env.DOGFOOD_JEST_UPSTREAM_SUITE === "1" ? it : it.skip;
+  jestHeavy("runs Jest's original get-type units", { timeout: 600_000 }, () => {
+    const report = run("jest");
+    expect(report.extraction).toMatchObject({
+      filesSeen: 241,
+      filesSelected: 2,
+      filesDeferred: 239,
+      testsRegistered: 32,
+      nativePassed: 32,
+      nativeFailed: 0,
+    });
+    expect(report.compile.modules).toBe(2);
+    expect(report.results.scored).toBe(32);
   });
 });

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -98,6 +98,12 @@ describe("small npm package upstream suites", () => {
       testFileCount: 42,
       registrationSites: 1376,
     });
+    expect(pin("typescript")).toMatchObject({
+      tag: "v5.9.3",
+      commit: "c63de15a992d37f0d6cec03ac7631872838602cb",
+      testFileCount: 256,
+      registrationSites: 1761,
+    });
   });
 
   const clsxHeavy = process.env.DOGFOOD_CLSX_UPSTREAM_SUITE === "1" ? it : it.skip;
@@ -287,5 +293,20 @@ describe("small npm package upstream suites", () => {
     });
     expect(report.compile.modules).toBe(2);
     expect(report.results.scored).toBe(13);
+  });
+
+  const typescriptHeavy = process.env.DOGFOOD_TYPESCRIPT_UPSTREAM_SUITE === "1" ? it : it.skip;
+  typescriptHeavy("runs TypeScript's original base64 unit", { timeout: 600_000 }, () => {
+    const report = run("typescript");
+    expect(report.extraction).toMatchObject({
+      filesSeen: 256,
+      filesSelected: 1,
+      filesDeferred: 255,
+      testsRegistered: 1,
+      nativePassed: 1,
+      nativeFailed: 0,
+    });
+    expect(report.compile.modules).toBe(1);
+    expect(report.results.scored).toBe(1);
   });
 });

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -92,6 +92,12 @@ describe("small npm package upstream suites", () => {
       testFileCount: 241,
       registrationSites: 3288,
     });
+    expect(pin("tailwindcss")).toMatchObject({
+      tag: "v4.3.3",
+      commit: "c2b24dd15fed1c59dd521bd86082f520c9f5ad0d",
+      testFileCount: 42,
+      registrationSites: 1376,
+    });
   });
 
   const clsxHeavy = process.env.DOGFOOD_CLSX_UPSTREAM_SUITE === "1" ? it : it.skip;
@@ -266,5 +272,20 @@ describe("small npm package upstream suites", () => {
     });
     expect(report.compile.modules).toBe(2);
     expect(report.results.scored).toBe(32);
+  });
+
+  const tailwindcssHeavy = process.env.DOGFOOD_TAILWINDCSS_UPSTREAM_SUITE === "1" ? it : it.skip;
+  tailwindcssHeavy("runs Tailwind CSS's original segment utilities", { timeout: 600_000 }, () => {
+    const report = run("tailwindcss");
+    expect(report.extraction).toMatchObject({
+      filesSeen: 42,
+      filesSelected: 2,
+      filesDeferred: 40,
+      testsRegistered: 13,
+      nativePassed: 13,
+      nativeFailed: 0,
+    });
+    expect(report.compile.modules).toBe(2);
+    expect(report.results.scored).toBe(13);
   });
 });

--- a/tests/dogfood/setup-jest-upstream-suite.mjs
+++ b/tests/dogfood/setup-jest-upstream-suite.mjs
@@ -1,0 +1,17 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { setupPinnedUpstreamSuite } from "./setup-pinned-upstream-suite.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function setupJestUpstreamSuite(options = {}) {
+  return setupPinnedUpstreamSuite({
+    here: HERE,
+    pinFile: "jest-upstream-suite-pin.json",
+    cacheDirectory: ".npm-upstream-suites/jest",
+    inventoryDirectory: "packages",
+    accept: (path) => /^packages\/.*\/__tests__\/.*\.(?:test|spec)\.(?:js|jsx|ts|tsx)$/.test(path),
+    force: options.force,
+  });
+}

--- a/tests/dogfood/setup-tailwindcss-upstream-suite.mjs
+++ b/tests/dogfood/setup-tailwindcss-upstream-suite.mjs
@@ -1,0 +1,17 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { setupPinnedUpstreamSuite } from "./setup-pinned-upstream-suite.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function setupTailwindcssUpstreamSuite(options = {}) {
+  return setupPinnedUpstreamSuite({
+    here: HERE,
+    pinFile: "tailwindcss-upstream-suite-pin.json",
+    cacheDirectory: ".npm-upstream-suites/tailwindcss",
+    inventoryDirectory: "packages/tailwindcss",
+    accept: (path) => /^packages\/tailwindcss\/.*\.(?:test|spec)\.(?:js|ts|tsx)$/.test(path),
+    force: options.force,
+  });
+}

--- a/tests/dogfood/setup-typescript-upstream-suite.mjs
+++ b/tests/dogfood/setup-typescript-upstream-suite.mjs
@@ -1,0 +1,17 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { setupPinnedUpstreamSuite } from "./setup-pinned-upstream-suite.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function setupTypescriptUpstreamSuite(options = {}) {
+  return setupPinnedUpstreamSuite({
+    here: HERE,
+    pinFile: "typescript-upstream-suite-pin.json",
+    cacheDirectory: ".npm-upstream-suites/typescript",
+    inventoryDirectory: "src/testRunner/unittests",
+    accept: (path) => /^src\/testRunner\/unittests\/.*\.ts$/.test(path),
+    force: options.force,
+  });
+}

--- a/tests/dogfood/tailwindcss-upstream-suite-pin.json
+++ b/tests/dogfood/tailwindcss-upstream-suite-pin.json
@@ -1,0 +1,15 @@
+{
+  "name": "tailwindcss",
+  "version": "4.3.3",
+  "repo": "https://github.com/tailwindlabs/tailwindcss.git",
+  "tag": "v4.3.3",
+  "commit": "c2b24dd15fed1c59dd521bd86082f520c9f5ad0d",
+  "testFileCount": 42,
+  "testFilePathSha256": "99c9e7c4483c38fb1ec9f25ff6c9d05e4bdaac65f8991138cb494812c7b98cf1",
+  "registrationSites": 1376,
+  "selectedFiles": [
+    "packages/tailwindcss/src/utils/segment.test.ts",
+    "packages/tailwindcss/src/utils/to-key-path.test.ts"
+  ],
+  "_note": "The complete packages/tailwindcss test inventory is verified. This first adapter runs the two original synchronous segment and key-path utility files against their matching release-tag TypeScript implementations. Scanner, Rust/native, CSS pipeline, snapshot, async, UI, and larger graph files remain explicit deferred coverage."
+}

--- a/tests/dogfood/tailwindcss-upstream-suite.mjs
+++ b/tests/dogfood/tailwindcss-upstream-suite.mjs
@@ -1,0 +1,82 @@
+// Tailwind CSS 4.3.3 original synchronous utility-unit slice.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { setupTailwindcssUpstreamSuite } from "./setup-tailwindcss-upstream-suite.mjs";
+import {
+  UPSTREAM_TEST_EXPORTS,
+  UPSTREAM_TEST_SHIM,
+  cliUpstreamHarness,
+  compileAndRunUpstreamModule,
+  summarizeUpstreamRuns,
+  writeUpstreamReport,
+} from "./upstream-suite-runner.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GENERATED_ROOT = resolve(HERE, "..", "..", ".tailwindcss-upstream-suite-generated");
+const REPORT_PATH = join(HERE, "report", "tailwindcss-upstream-suite.json");
+
+function moduleSpecifier(fromDirectory, target) {
+  let value = relative(fromDirectory, target).replace(/\\/g, "/");
+  if (!value.startsWith(".")) value = `./${value}`;
+  return value;
+}
+
+function transformTailwindcssTest(source, filePath, generatedPath, { normalizeCjs = false } = {}) {
+  source = source.replace(/^import\s+\{[^\n]+\}\s+from\s+["']vitest["'];?\s*$/gm, "");
+  let importIndex = 0;
+  return source.replace(
+    /import\s+\{([^}]+)\}\s+from\s+(["'])(\.\.?\/[^"']+)\2;?/g,
+    (_match, bindings, quote, specifier) => {
+      let target = resolve(dirname(filePath), specifier);
+      if (existsSync(`${target}.ts`)) target = `${target}.ts`;
+      else if (existsSync(`${target}.tsx`)) target = `${target}.tsx`;
+      const rewritten = moduleSpecifier(dirname(generatedPath), target);
+      if (!normalizeCjs) return `import {${bindings}} from ${quote}${rewritten}${quote};`;
+      const namespaceName = `__tailwindImport${importIndex++}`;
+      return (
+        `import * as ${namespaceName} from ${quote}${rewritten}${quote};\n` +
+        `const {${bindings}} = ${namespaceName}.default || ${namespaceName};`
+      );
+    },
+  );
+}
+
+export async function runHarness({ quiet = false } = {}) {
+  const log = quiet ? () => {} : (...values) => console.log(...values);
+  const suite = setupTailwindcssUpstreamSuite();
+  const runs = [];
+
+  log(`[dogfood] tailwindcss@${suite.pin.version} upstream ${suite.pin.tag} (${suite.pin.commit.slice(0, 12)})`);
+  for (const filePath of suite.selectedPaths) {
+    const file = suite.relativePath(filePath);
+    const generatedPath = join(GENERATED_ROOT, file);
+    const original = readFileSync(filePath, "utf-8");
+    const transformed = transformTailwindcssTest(original, filePath, generatedPath);
+    const nativeTransformed = transformTailwindcssTest(original, filePath, generatedPath, { normalizeCjs: true });
+    const source = `${UPSTREAM_TEST_SHIM}\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const nativeSource = `${UPSTREAM_TEST_SHIM}\n${nativeTransformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const result = await compileAndRunUpstreamModule({ generatedPath, source, nativeSource, timeoutMs: 240_000 });
+    runs.push({ file, result });
+    log(
+      `[dogfood] ${file}: ${result.native.statuses.filter(Boolean).length}/${result.native.count} native; ` +
+        `${result.wasm?.statuses.filter(Boolean).length ?? 0}/${result.native.count} Wasm`,
+    );
+  }
+
+  const report = summarizeUpstreamRuns({
+    name: `tailwindcss@${suite.pin.version}`,
+    pin: suite.pin,
+    testFiles: suite.testFiles,
+    selectedFiles: suite.pin.selectedFiles,
+    runs,
+  });
+  writeUpstreamReport(REPORT_PATH, report);
+  log(`[dogfood] ${report.summary.headline}; ${report.extraction.filesDeferred} upstream files explicitly deferred`);
+  log(`[dogfood] report → ${REPORT_PATH}`);
+  return report;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) cliUpstreamHarness(runHarness);

--- a/tests/dogfood/typescript-upstream-suite-pin.json
+++ b/tests/dogfood/typescript-upstream-suite-pin.json
@@ -1,0 +1,12 @@
+{
+  "name": "typescript",
+  "version": "5.9.3",
+  "repo": "https://github.com/microsoft/TypeScript.git",
+  "tag": "v5.9.3",
+  "commit": "c63de15a992d37f0d6cec03ac7631872838602cb",
+  "testFileCount": 256,
+  "testFilePathSha256": "5f735da50b2a27e0e9274a21d759cedf845e7b91c1896bc817aaa5f940e97743",
+  "registrationSites": 1761,
+  "selectedFiles": ["src/testRunner/unittests/base64.ts"],
+  "_note": "The complete src/testRunner/unittests inventory is verified. This first adapter runs the original base64 callback against an exact projection of the release-tag base64 implementation. Compiler, server, watch, evaluator, snapshot, async, and filesystem-heavy files remain explicit deferred coverage."
+}

--- a/tests/dogfood/typescript-upstream-suite.mjs
+++ b/tests/dogfood/typescript-upstream-suite.mjs
@@ -1,0 +1,82 @@
+// TypeScript 5.9.3 original base64 unit slice.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { setupTypescriptUpstreamSuite } from "./setup-typescript-upstream-suite.mjs";
+import {
+  UPSTREAM_TEST_EXPORTS,
+  UPSTREAM_TEST_SHIM,
+  cliUpstreamHarness,
+  compileAndRunUpstreamModule,
+  summarizeUpstreamRuns,
+  writeUpstreamReport,
+} from "./upstream-suite-runner.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GENERATED_ROOT = resolve(HERE, "..", "..", ".typescript-upstream-suite-generated");
+const REPORT_PATH = join(HERE, "report", "typescript-upstream-suite.json");
+
+function moduleSpecifier(fromDirectory, target) {
+  let value = relative(fromDirectory, target).replace(/\\/g, "/");
+  if (!value.startsWith(".")) value = `./${value}`;
+  return value;
+}
+
+function exactBase64Projection(utilitiesSource) {
+  utilitiesSource = utilitiesSource.replace(/\r\n/g, "\n");
+  const startMarker = "/**\n * Replace each instance of non-ascii characters";
+  const endMarker = "/** @internal */\nexport function readJsonOrUndefined";
+  const start = utilitiesSource.indexOf(startMarker);
+  const end = utilitiesSource.indexOf(endMarker, start);
+  if (start < 0 || end < 0) throw new Error("TypeScript base64 implementation markers changed");
+  const declarations = utilitiesSource.slice(start, end);
+  return `const Debug = { assert(value: boolean, message?: string) { if (!value) throw new Error(message || "Debug assertion failed"); } };\n${declarations}`;
+}
+
+function transformTypescriptTest(source, projectionSpecifier) {
+  return source.replace(
+    /^import\s+\*\s+as\s+ts\s+from\s+["']\.\.\/_namespaces\/ts\.js["'];?\s*$/m,
+    `import { base64decode, convertToBase64 } from ${JSON.stringify(projectionSpecifier)};\nconst ts = { base64decode, convertToBase64 };`,
+  );
+}
+
+export async function runHarness({ quiet = false } = {}) {
+  const log = quiet ? () => {} : (...values) => console.log(...values);
+  const suite = setupTypescriptUpstreamSuite();
+  const utilitiesPath = join(suite.root, "src", "compiler", "utilities.ts");
+  const projectionPath = join(GENERATED_ROOT, "release-base64.ts");
+  mkdirSync(dirname(projectionPath), { recursive: true });
+  writeFileSync(projectionPath, exactBase64Projection(readFileSync(utilitiesPath, "utf-8")));
+  const runs = [];
+
+  log(`[dogfood] typescript@${suite.pin.version} upstream ${suite.pin.tag} (${suite.pin.commit.slice(0, 12)})`);
+  for (const filePath of suite.selectedPaths) {
+    const file = suite.relativePath(filePath);
+    const generatedPath = join(GENERATED_ROOT, file);
+    const original = readFileSync(filePath, "utf-8");
+    const transformed = transformTypescriptTest(original, moduleSpecifier(dirname(generatedPath), projectionPath));
+    const source = `${UPSTREAM_TEST_SHIM}\nconst assert = __qunitAssert;\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 240_000 });
+    runs.push({ file, result });
+    log(
+      `[dogfood] ${file}: ${result.native.statuses.filter(Boolean).length}/${result.native.count} native; ` +
+        `${result.wasm?.statuses.filter(Boolean).length ?? 0}/${result.native.count} Wasm`,
+    );
+  }
+
+  const report = summarizeUpstreamRuns({
+    name: `typescript@${suite.pin.version}`,
+    pin: suite.pin,
+    testFiles: suite.testFiles,
+    selectedFiles: suite.pin.selectedFiles,
+    runs,
+  });
+  writeUpstreamReport(REPORT_PATH, report);
+  log(`[dogfood] ${report.summary.headline}; ${report.extraction.filesDeferred} upstream files explicitly deferred`);
+  log(`[dogfood] report → ${REPORT_PATH}`);
+  return report;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) cliUpstreamHarness(runHarness);

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -120,8 +120,9 @@ function it(name, body) { __upstreamRegister(name, body); }
 function test(name, body) { __upstreamRegister(name, body); }
 function __upstreamEach(cases) {
   return function(name, body) {
+    const expandRows = cases.length > 0 && cases.every(function(value) { return Array.isArray(value); });
     for (let index = 0; index < cases.length; index++) {
-      const row = Array.isArray(cases[index]) ? cases[index] : [cases[index]];
+      const row = expandRows ? cases[index] : [cases[index]];
       const displayName = String(name).replace(/%s/g, function() { return String(row[0]); });
       it(displayName, function() {
         if (row.length === 0) return body();


### PR DESCRIPTION
## Checkpoint

- verify Jest 30.4.2's complete 241-file / 3,288-registration monorepo unit inventory
- run the two original `@jest/get-type` unit files against their matching release-tag TypeScript implementation
- publish the measured Node 32/32 and Wasm 16/32 result through the merge-only npm-compat refresh

The failures consistently show primitives being boxed when they cross an `unknown` representation boundary, which makes JavaScript `typeof` and `Object(value) !== value` checks misclassify them. The shared `test.each` shim also now distinguishes scalar-case tables from tuple tables. The remaining 239 files stay explicit deferred coverage.

Tracks [#3995](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).

## Verification

- `pnpm run dogfood:jest-upstream-suite`
- `DOGFOOD_JEST_UPSTREAM_SUITE=1 pnpm exec vitest run tests/dogfood/npm-small-upstream-suites.test.ts`
- `node --import tsx scripts/generate-npm-compat-report.mjs --only jest --no-write`
- `pnpm run typecheck`
- `pnpm run lint`
- `.husky/pre-push`
