### PR TITLE
test(npm-compat): run TypeScript upstream base64 unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ tests/dogfood/report/
 /.webpack-upstream-suite-generated/
 /.jest-upstream-suite-generated/
 /.tailwindcss-upstream-suite-generated/
+/.typescript-upstream-suite-generated/
 /check-*.ts
 /check-*.mts
 /debug-*.ts

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "dogfood:react-dom-upstream-suite": "npx tsx tests/dogfood/react-dom-upstream-suite.mjs",
     "dogfood:tailwindcss": "npx tsx tests/dogfood/npm-compat-catalog-harness.mjs --package tailwindcss",
     "dogfood:tailwindcss-upstream-suite": "node --import tsx tests/dogfood/tailwindcss-upstream-suite.mjs",
+    "dogfood:typescript-upstream-suite": "node --import tsx tests/dogfood/typescript-upstream-suite.mjs",
     "dogfood:npm-compat-upstream-sources": "node tests/dogfood/npm-compat-upstream-sources.mjs",
     "dogfood:npm-compat-upstream": "node tests/dogfood/npm-compat-upstream.mjs",
     "generate:npm-compat": "node --import tsx scripts/generate-npm-compat-report.mjs",

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -413,6 +413,24 @@ remain explicit deferred inventory. The npm-compat generator invokes the
 adapter directly so the merge-only refresh publishes numeric results and
 cannot fall back to `adapter pending`.
 
+## 2026-08-14 TypeScript base64 slice
+
+TypeScript 5.9.3 now verifies all 256 files and 1,761 static registrations under
+`src/testRunner/unittests` from `microsoft/TypeScript@v5.9.3` (commit
+`c63de15a992d37f0d6cec03ac7631872838602cb`). The first runtime adapter runs the
+original `base64.ts` callback unchanged. At setup time it projects the exact
+base64 declarations from the matching release's `src/compiler/utilities.ts`,
+avoiding the unrelated full compiler graph that exceeds the bounded catalog
+compile budget.
+
+The adapter registers one callback. It passes in native Node and after the
+release-tag source and original callback are compiled to Wasm.
+
+The remaining 255 compiler, server, watch, evaluator, snapshot, async, and
+filesystem-heavy files remain explicit deferred inventory. The npm-compat
+generator invokes this adapter directly, so the merge-only refresh publishes a
+numeric result and cannot fall back to `adapter pending`.
+
 ## 2026-08-14 webpack synchronous utility slice
 
 webpack 5.109.2 now verifies all 98 top-level `test/*.unittest.js` files and

--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -431,6 +431,25 @@ filesystem-heavy files remain explicit deferred inventory. The npm-compat
 generator invokes this adapter directly, so the merge-only refresh publishes a
 numeric result and cannot fall back to `adapter pending`.
 
+## 2026-08-14 complete workflow wiring
+
+All 24 packages rendered on npm-compat now declare an executable `suiteScript`.
+The report generator uses one registry for those 24 adapters and refuses to
+start if the configured and executable package sets differ. Catalog packages
+no longer pass through a nullable conditional chain that could silently fall
+back to `adapter pending` after an adapter had shipped.
+
+The merge-only npm-compat workflow independently rejects its generated artifact
+unless every configured adapter produces numeric `passed` and `total` fields.
+Performance measurements and regressions remain reporting data rather than unit
+test gates.
+
+The complete `generate:npm-compat --no-write` path was run locally after this
+wiring change. It completed all 24 packages, left one numeric suite report per
+package, and exited successfully. Its aggregate correctness rollup reported 8
+verified, 14 divergent, and 2 unverified packages; those compatibility gaps are
+reported data, not hidden or converted into performance gates.
+
 ## 2026-08-14 webpack synchronous utility slice
 
 webpack 5.109.2 now verifies all 98 top-level `test/*.unittest.js` files and

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -66,6 +66,7 @@ import { runHarness as runStyledComponentsUpstreamSuite } from "../tests/dogfood
 import { runHarness as runWebpackUpstreamSuite } from "../tests/dogfood/webpack-upstream-suite.mjs";
 import { runHarness as runJestUpstreamSuite } from "../tests/dogfood/jest-upstream-suite.mjs";
 import { runHarness as runTailwindcssUpstreamSuite } from "../tests/dogfood/tailwindcss-upstream-suite.mjs";
+import { runHarness as runTypescriptUpstreamSuite } from "../tests/dogfood/typescript-upstream-suite.mjs";
 import { NPM_COMPAT_CATALOG, NPM_COMPAT_CATALOG_NAMES } from "../tests/dogfood/npm-compat-catalog.mjs";
 import { runNpmCompatCatalogHarness } from "../tests/dogfood/npm-compat-catalog-harness.mjs";
 
@@ -1935,7 +1936,9 @@ for (const entry of NPM_COMPAT_CATALOG) {
                               ? runJestUpstreamSuite
                               : entry.name === "tailwindcss"
                                 ? runTailwindcssUpstreamSuite
-                                : null;
+                                : entry.name === "typescript"
+                                  ? runTypescriptUpstreamSuite
+                                  : null;
   const catalogUpstreamReport = catalogUpstreamRunner ? await catalogUpstreamRunner({ quiet: true }) : null;
   const upstreamSuite = entry.upstreamSuite;
   const upstreamTests = upstreamSuite

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -69,6 +69,7 @@ import { runHarness as runTailwindcssUpstreamSuite } from "../tests/dogfood/tail
 import { runHarness as runTypescriptUpstreamSuite } from "../tests/dogfood/typescript-upstream-suite.mjs";
 import { NPM_COMPAT_CATALOG, NPM_COMPAT_CATALOG_NAMES } from "../tests/dogfood/npm-compat-catalog.mjs";
 import { runNpmCompatCatalogHarness } from "../tests/dogfood/npm-compat-catalog-harness.mjs";
+import { NPM_COMPAT_UPSTREAM_SOURCES } from "../tests/dogfood/npm-compat-upstream-sources.mjs";
 
 import { setupAcorn } from "../tests/dogfood/setup-acorn.mjs";
 import { setupClsx } from "../tests/dogfood/setup-clsx.mjs";
@@ -90,6 +91,48 @@ const ROOT = resolve(import.meta.dirname, "..");
 const PACKAGE_NAMES = [
   ...new Set(["acorn", "marked", "clsx", "cookie", "eslint", "prettier", "react", ...NPM_COMPAT_CATALOG_NAMES]),
 ];
+const UPSTREAM_SUITE_RUNNERS = new Map([
+  ["acorn", runAcornOfficialSuite],
+  ["axios", runAxiosUpstreamSuite],
+  ["clsx", runClsxUpstreamSuite],
+  ["cookie", runCookieUpstreamSuite],
+  ["eslint", runEslintUpstreamSuite],
+  ["hono", runHonoUpstreamSuite],
+  ["jest", runJestUpstreamSuite],
+  ["jsdom", runJsdomUpstreamSuite],
+  ["lit", runLitUpstreamSuite],
+  ["lodash", (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash" })],
+  ["lodash-es", (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash-es" })],
+  ["marked", runMarkedUpstreamSuite],
+  ["moment", runMomentUpstreamSuite],
+  ["prettier", runPrettierUpstreamSuite],
+  ["react", runReactUpstreamSuite],
+  ["react-dom", runReactDomUpstreamSuite],
+  ["redux", runReduxUpstreamSuite],
+  ["styled-components", runStyledComponentsUpstreamSuite],
+  ["stylelint", runStylelintUpstreamSuite],
+  ["tailwindcss", runTailwindcssUpstreamSuite],
+  ["three", runThreeUpstreamSuite],
+  ["typescript", runTypescriptUpstreamSuite],
+  ["uuid", runUuidUpstreamSuite],
+  ["webpack", runWebpackUpstreamSuite],
+]);
+
+const CONFIGURED_UPSTREAM_NAMES = NPM_COMPAT_UPSTREAM_SOURCES.filter((entry) => entry.suiteScript)
+  .map((entry) => entry.name)
+  .sort();
+const WIRED_UPSTREAM_NAMES = [...UPSTREAM_SUITE_RUNNERS.keys()].sort();
+if (JSON.stringify(CONFIGURED_UPSTREAM_NAMES) !== JSON.stringify(WIRED_UPSTREAM_NAMES)) {
+  throw new Error(
+    `npm-compat upstream runner registry mismatch\nconfigured: ${CONFIGURED_UPSTREAM_NAMES.join(", ")}\nwired: ${WIRED_UPSTREAM_NAMES.join(", ")}`,
+  );
+}
+
+function runConfiguredUpstreamSuite(name, options) {
+  const runner = UPSTREAM_SUITE_RUNNERS.get(name);
+  if (!runner) throw new Error(`npm-compat has no upstream suite runner for ${name}`);
+  return runner(options);
+}
 // Committed npm API snapshot keeps report generation deterministic and offline.
 // Refresh these together from:
 // https://api.npmjs.org/downloads/point/last-week/{package}
@@ -1480,7 +1523,7 @@ if (selectedPackages.has("acorn")) {
   } else {
     console.log("[npm-compat] acorn — compile/validate/diff + official test suite (this takes ~1 min)...");
     const acornReport = await runAcorn({ quiet: true });
-    const acornSuite = await runAcornOfficialSuite({ quiet: true });
+    const acornSuite = await runConfiguredUpstreamSuite("acorn", { quiet: true });
     const acornPerf = await perfAcorn();
     packages.push(
       await buildPackageEntry({
@@ -1506,7 +1549,7 @@ if (selectedPackages.has("acorn")) {
 if (selectedPackages.has("marked")) {
   console.log("[npm-compat] marked — package entry + selected original upstream unit tests...");
   const markedReport = await runMarked({ quiet: true });
-  const markedSuite = await runMarkedUpstreamSuite({ quiet: true });
+  const markedSuite = await runConfiguredUpstreamSuite("marked", { quiet: true });
   packages.push(
     await buildPackageEntry({
       name: "marked",
@@ -1563,7 +1606,7 @@ if (selectedPackages.has("clsx")) {
   } else {
     console.log("[npm-compat] clsx — compile/validate/diff + complete original upstream unit suite + perf...");
     const clsxReport = await runClsx({ quiet: true });
-    const clsxSuite = await runClsxUpstreamSuite({ quiet: true });
+    const clsxSuite = await runConfiguredUpstreamSuite("clsx", { quiet: true });
     const clsxPerf = await perfClsx();
     packages.push(
       await buildPackageEntry({
@@ -1619,7 +1662,7 @@ if (selectedPackages.has("cookie")) {
   } else {
     console.log("[npm-compat] cookie — compile/validate/diff + complete original upstream unit suite + perf...");
     const cookieReport = await runCookie({ quiet: true });
-    const cookieSuite = await runCookieUpstreamSuite({ quiet: true });
+    const cookieSuite = await runConfiguredUpstreamSuite("cookie", { quiet: true });
     const cookiePerf = await perfCookie();
     packages.push(
       await buildPackageEntry({
@@ -1662,7 +1705,7 @@ if (selectedPackages.has("cookie")) {
 if (selectedPackages.has("eslint")) {
   console.log("[npm-compat] eslint — bounded package entry + selected original upstream unit...");
   const eslintReport = await runEslint({ quiet: true });
-  const eslintSuite = await runEslintUpstreamSuite({ quiet: true });
+  const eslintSuite = await runConfiguredUpstreamSuite("eslint", { quiet: true });
   // Do not spend a second bounded compile on a package-entry failure. Once
   // lib/api.js is a valid module, the workload harness compiles a generated
   // driver that calls the real Linter.verify API and compares its primitive
@@ -1708,7 +1751,7 @@ if (selectedPackages.has("eslint")) {
 if (selectedPackages.has("prettier")) {
   console.log("[npm-compat] prettier — package entry + selected original upstream unit tests...");
   const prettierReport = await runPrettier({ quiet: true });
-  const prettierSuite = await runPrettierUpstreamSuite({ quiet: true });
+  const prettierSuite = await runConfiguredUpstreamSuite("prettier", { quiet: true });
   packages.push(
     await buildPackageEntry({
       name: "prettier",
@@ -1744,7 +1787,7 @@ if (selectedPackages.has("prettier")) {
 if (selectedPackages.has("react")) {
   console.log("[npm-compat] react — package entry + React's own upstream unit tests...");
   const reactReport = await runReact({ quiet: true });
-  const reactSuite = await runReactUpstreamSuite({ quiet: true });
+  const reactSuite = await runConfiguredUpstreamSuite("react", { quiet: true });
   packages.push(
     await buildPackageEntry({
       name: "react",
@@ -1793,7 +1836,7 @@ if (selectedPackages.has("lit")) {
   } else {
     console.log("[npm-compat] lit — package entry + lit's own upstream unit tests...");
     const litReport = await runNpmCompatCatalogHarness("lit", { quiet: true });
-    const litSuite = await runLitUpstreamSuite({ quiet: true });
+    const litSuite = await runConfiguredUpstreamSuite("lit", { quiet: true });
     packages.push(
       await buildPackageEntry({
         name: "lit",
@@ -1835,7 +1878,7 @@ if (selectedPackages.has("react-dom")) {
   console.log("[npm-compat] react-dom — package entry + react-dom's own upstream unit tests...");
   const reactDomEntry = NPM_COMPAT_CATALOG.find((entry) => entry.name === "react-dom");
   const reactDomReport = await runNpmCompatCatalogHarness("react-dom", { quiet: true });
-  const reactDomSuite = await runReactDomUpstreamSuite({ quiet: true });
+  const reactDomSuite = await runConfiguredUpstreamSuite("react-dom", { quiet: true });
   const reactDomImplementationReport = {
     ...reactDomReport,
     // The package-entry probe only compiles the small environment selector.
@@ -1907,39 +1950,7 @@ for (const entry of NPM_COMPAT_CATALOG) {
       ? await workloadRunner({ quiet: true })
       : null;
   const hasApiWorkload = workloadRunner !== null;
-  const catalogUpstreamRunner =
-    entry.name === "hono"
-      ? runHonoUpstreamSuite
-      : entry.name === "lodash"
-        ? (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash" })
-        : entry.name === "lodash-es"
-          ? (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash-es" })
-          : entry.name === "uuid"
-            ? runUuidUpstreamSuite
-            : entry.name === "redux"
-              ? runReduxUpstreamSuite
-              : entry.name === "jsdom"
-                ? runJsdomUpstreamSuite
-                : entry.name === "axios"
-                  ? runAxiosUpstreamSuite
-                  : entry.name === "moment"
-                    ? runMomentUpstreamSuite
-                    : entry.name === "stylelint"
-                      ? runStylelintUpstreamSuite
-                      : entry.name === "three"
-                        ? runThreeUpstreamSuite
-                        : entry.name === "styled-components"
-                          ? runStyledComponentsUpstreamSuite
-                          : entry.name === "webpack"
-                            ? runWebpackUpstreamSuite
-                            : entry.name === "jest"
-                              ? runJestUpstreamSuite
-                              : entry.name === "tailwindcss"
-                                ? runTailwindcssUpstreamSuite
-                                : entry.name === "typescript"
-                                  ? runTypescriptUpstreamSuite
-                                  : null;
-  const catalogUpstreamReport = catalogUpstreamRunner ? await catalogUpstreamRunner({ quiet: true }) : null;
+  const catalogUpstreamReport = await runConfiguredUpstreamSuite(entry.name, { quiet: true });
   const upstreamSuite = entry.upstreamSuite;
   const upstreamTests = upstreamSuite
     ? {

--- a/tests/dogfood/README.md
+++ b/tests/dogfood/README.md
@@ -134,6 +134,7 @@ then compares its result with the same operation in native Node.
 | **webpack upstream suite**              | #3995 | `lib/util/*.js`         | pinned original utility callbacks; complete top-level unit inventory tracked |
 | **jest upstream suite**                 | #3995 | `jest-get-type/src/index.ts` | pinned original get-type callbacks; complete monorepo unit inventory tracked |
 | **tailwindcss upstream suite**          | #3995 | `src/utils/{segment,to-key-path}.ts` | pinned original utility callbacks; complete package test inventory tracked |
+| **typescript upstream suite**           | #3995 | `unittests/base64.ts`   | pinned original base64 callback; complete compiler-unit inventory tracked |
 | **redux** (state container)             | #3996 | `dist/redux.mjs`          | consumed store/reducer/subscription/action-creator API workload             |
 
 ## uuid v14.0.1 upstream suite (#3995)

--- a/tests/dogfood/npm-compat-upstream-sources.json
+++ b/tests/dogfood/npm-compat-upstream-sources.json
@@ -17,6 +17,7 @@
     "commit": "c63de15a992d37f0d6cec03ac7631872838602cb",
     "cacheKey": "typescript",
     "compileScript": "dogfood:typescript",
+    "suiteScript": "dogfood:typescript-upstream-suite",
     "inventory": {
       "directory": "src/testRunner/unittests",
       "include": "^src/testRunner/unittests/.*\\.ts$",

--- a/tests/dogfood/npm-compat-upstream-sources.test.ts
+++ b/tests/dogfood/npm-compat-upstream-sources.test.ts
@@ -30,9 +30,8 @@ describe("npm-compat upstream GitHub source pins", () => {
         expect(pin.inventory.fileCount).toBeGreaterThan(0);
         expect(pin.inventory.pathSha256).toMatch(/^[0-9a-f]{64}$/);
       }
-      if (pin.suiteScript) {
-        expect(packageJson.scripts[pin.suiteScript]).toBeTypeOf("string");
-      }
+      expect(pin.suiteScript).toBeTypeOf("string");
+      expect(packageJson.scripts[pin.suiteScript]).toBeTypeOf("string");
     }
   });
 
@@ -47,5 +46,12 @@ describe("npm-compat upstream GitHub source pins", () => {
     expect(workflow).toContain("suitePins.filter(entry => entry.suiteScript)");
     expect(workflow).toContain("its unit-test result is absent");
     expect(workflow).toContain("still reports adapter pending");
+  });
+
+  it("makes report generation reject configured suites missing from its executable registry", () => {
+    const generator = readFileSync(join(HERE, "../../scripts/generate-npm-compat-report.mjs"), "utf-8");
+    expect(generator).toContain("UPSTREAM_SUITE_RUNNERS");
+    expect(generator).toContain("npm-compat upstream runner registry mismatch");
+    expect(generator).toContain("runConfiguredUpstreamSuite(entry.name");
   });
 });

--- a/tests/dogfood/npm-small-upstream-suites.test.ts
+++ b/tests/dogfood/npm-small-upstream-suites.test.ts
@@ -98,6 +98,12 @@ describe("small npm package upstream suites", () => {
       testFileCount: 42,
       registrationSites: 1376,
     });
+    expect(pin("typescript")).toMatchObject({
+      tag: "v5.9.3",
+      commit: "c63de15a992d37f0d6cec03ac7631872838602cb",
+      testFileCount: 256,
+      registrationSites: 1761,
+    });
   });
 
   const clsxHeavy = process.env.DOGFOOD_CLSX_UPSTREAM_SUITE === "1" ? it : it.skip;
@@ -287,5 +293,20 @@ describe("small npm package upstream suites", () => {
     });
     expect(report.compile.modules).toBe(2);
     expect(report.results.scored).toBe(13);
+  });
+
+  const typescriptHeavy = process.env.DOGFOOD_TYPESCRIPT_UPSTREAM_SUITE === "1" ? it : it.skip;
+  typescriptHeavy("runs TypeScript's original base64 unit", { timeout: 600_000 }, () => {
+    const report = run("typescript");
+    expect(report.extraction).toMatchObject({
+      filesSeen: 256,
+      filesSelected: 1,
+      filesDeferred: 255,
+      testsRegistered: 1,
+      nativePassed: 1,
+      nativeFailed: 0,
+    });
+    expect(report.compile.modules).toBe(1);
+    expect(report.results.scored).toBe(1);
   });
 });

--- a/tests/dogfood/setup-typescript-upstream-suite.mjs
+++ b/tests/dogfood/setup-typescript-upstream-suite.mjs
@@ -1,0 +1,17 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { setupPinnedUpstreamSuite } from "./setup-pinned-upstream-suite.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function setupTypescriptUpstreamSuite(options = {}) {
+  return setupPinnedUpstreamSuite({
+    here: HERE,
+    pinFile: "typescript-upstream-suite-pin.json",
+    cacheDirectory: ".npm-upstream-suites/typescript",
+    inventoryDirectory: "src/testRunner/unittests",
+    accept: (path) => /^src\/testRunner\/unittests\/.*\.ts$/.test(path),
+    force: options.force,
+  });
+}

--- a/tests/dogfood/typescript-upstream-suite-pin.json
+++ b/tests/dogfood/typescript-upstream-suite-pin.json
@@ -1,0 +1,12 @@
+{
+  "name": "typescript",
+  "version": "5.9.3",
+  "repo": "https://github.com/microsoft/TypeScript.git",
+  "tag": "v5.9.3",
+  "commit": "c63de15a992d37f0d6cec03ac7631872838602cb",
+  "testFileCount": 256,
+  "testFilePathSha256": "5f735da50b2a27e0e9274a21d759cedf845e7b91c1896bc817aaa5f940e97743",
+  "registrationSites": 1761,
+  "selectedFiles": ["src/testRunner/unittests/base64.ts"],
+  "_note": "The complete src/testRunner/unittests inventory is verified. This first adapter runs the original base64 callback against an exact projection of the release-tag base64 implementation. Compiler, server, watch, evaluator, snapshot, async, and filesystem-heavy files remain explicit deferred coverage."
+}

--- a/tests/dogfood/typescript-upstream-suite.mjs
+++ b/tests/dogfood/typescript-upstream-suite.mjs
@@ -1,0 +1,82 @@
+// TypeScript 5.9.3 original base64 unit slice.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { setupTypescriptUpstreamSuite } from "./setup-typescript-upstream-suite.mjs";
+import {
+  UPSTREAM_TEST_EXPORTS,
+  UPSTREAM_TEST_SHIM,
+  cliUpstreamHarness,
+  compileAndRunUpstreamModule,
+  summarizeUpstreamRuns,
+  writeUpstreamReport,
+} from "./upstream-suite-runner.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GENERATED_ROOT = resolve(HERE, "..", "..", ".typescript-upstream-suite-generated");
+const REPORT_PATH = join(HERE, "report", "typescript-upstream-suite.json");
+
+function moduleSpecifier(fromDirectory, target) {
+  let value = relative(fromDirectory, target).replace(/\\/g, "/");
+  if (!value.startsWith(".")) value = `./${value}`;
+  return value;
+}
+
+function exactBase64Projection(utilitiesSource) {
+  utilitiesSource = utilitiesSource.replace(/\r\n/g, "\n");
+  const startMarker = "/**\n * Replace each instance of non-ascii characters";
+  const endMarker = "/** @internal */\nexport function readJsonOrUndefined";
+  const start = utilitiesSource.indexOf(startMarker);
+  const end = utilitiesSource.indexOf(endMarker, start);
+  if (start < 0 || end < 0) throw new Error("TypeScript base64 implementation markers changed");
+  const declarations = utilitiesSource.slice(start, end);
+  return `const Debug = { assert(value: boolean, message?: string) { if (!value) throw new Error(message || "Debug assertion failed"); } };\n${declarations}`;
+}
+
+function transformTypescriptTest(source, projectionSpecifier) {
+  return source.replace(
+    /^import\s+\*\s+as\s+ts\s+from\s+["']\.\.\/_namespaces\/ts\.js["'];?\s*$/m,
+    `import { base64decode, convertToBase64 } from ${JSON.stringify(projectionSpecifier)};\nconst ts = { base64decode, convertToBase64 };`,
+  );
+}
+
+export async function runHarness({ quiet = false } = {}) {
+  const log = quiet ? () => {} : (...values) => console.log(...values);
+  const suite = setupTypescriptUpstreamSuite();
+  const utilitiesPath = join(suite.root, "src", "compiler", "utilities.ts");
+  const projectionPath = join(GENERATED_ROOT, "release-base64.ts");
+  mkdirSync(dirname(projectionPath), { recursive: true });
+  writeFileSync(projectionPath, exactBase64Projection(readFileSync(utilitiesPath, "utf-8")));
+  const runs = [];
+
+  log(`[dogfood] typescript@${suite.pin.version} upstream ${suite.pin.tag} (${suite.pin.commit.slice(0, 12)})`);
+  for (const filePath of suite.selectedPaths) {
+    const file = suite.relativePath(filePath);
+    const generatedPath = join(GENERATED_ROOT, file);
+    const original = readFileSync(filePath, "utf-8");
+    const transformed = transformTypescriptTest(original, moduleSpecifier(dirname(generatedPath), projectionPath));
+    const source = `${UPSTREAM_TEST_SHIM}\nconst assert = __qunitAssert;\n${transformed}\n${UPSTREAM_TEST_EXPORTS}`;
+    const result = await compileAndRunUpstreamModule({ generatedPath, source, timeoutMs: 240_000 });
+    runs.push({ file, result });
+    log(
+      `[dogfood] ${file}: ${result.native.statuses.filter(Boolean).length}/${result.native.count} native; ` +
+        `${result.wasm?.statuses.filter(Boolean).length ?? 0}/${result.native.count} Wasm`,
+    );
+  }
+
+  const report = summarizeUpstreamRuns({
+    name: `typescript@${suite.pin.version}`,
+    pin: suite.pin,
+    testFiles: suite.testFiles,
+    selectedFiles: suite.pin.selectedFiles,
+    runs,
+  });
+  writeUpstreamReport(REPORT_PATH, report);
+  log(`[dogfood] ${report.summary.headline}; ${report.extraction.filesDeferred} upstream files explicitly deferred`);
+  log(`[dogfood] report → ${REPORT_PATH}`);
+  return report;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) cliUpstreamHarness(runHarness);


### PR DESCRIPTION
## What changed

- pin TypeScript 5.9.3 to its exact GitHub release commit
- inventory all 256 compiler unit files and 1,761 static registrations
- run the original `src/testRunner/unittests/base64.ts` callback unchanged
- project the exact base64 declarations from the pinned release's `src/compiler/utilities.ts` at setup time
- wire the adapter into the npm-compat generator and required merge-only workflow result path

## Result

- native Node: 1/1
- compiled Wasm: 1/1
- unit adapter compile: about 0.5 seconds and validates
- deferred inventory: 255 files, called out explicitly in the report
- the full published TypeScript entry still fails with the known compiler stack-overflow diagnostic; this does not erase the passing upstream unit result

## Validation

- `pnpm run dogfood:typescript-upstream-suite`
- focused upstream-suite contract test
- npm-compat generation for TypeScript
- all 24 configured packages now have a `suiteScript`
- typecheck and lint
- full pre-push checks

This is a stacked checkpoint based on PR #4483. It completes the initial numeric adapter path in [the original-upstream-suite plan](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).
