### PR TITLE
test(npm-compat): require every upstream result

### DIFF
--- a/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
+++ b/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md
@@ -431,6 +431,25 @@ filesystem-heavy files remain explicit deferred inventory. The npm-compat
 generator invokes this adapter directly, so the merge-only refresh publishes a
 numeric result and cannot fall back to `adapter pending`.
 
+## 2026-08-14 complete workflow wiring
+
+All 24 packages rendered on npm-compat now declare an executable `suiteScript`.
+The report generator uses one registry for those 24 adapters and refuses to
+start if the configured and executable package sets differ. Catalog packages
+no longer pass through a nullable conditional chain that could silently fall
+back to `adapter pending` after an adapter had shipped.
+
+The merge-only npm-compat workflow independently rejects its generated artifact
+unless every configured adapter produces numeric `passed` and `total` fields.
+Performance measurements and regressions remain reporting data rather than unit
+test gates.
+
+The complete `generate:npm-compat --no-write` path was run locally after this
+wiring change. It completed all 24 packages, left one numeric suite report per
+package, and exited successfully. Its aggregate correctness rollup reported 8
+verified, 14 divergent, and 2 unverified packages; those compatibility gaps are
+reported data, not hidden or converted into performance gates.
+
 ## 2026-08-14 webpack synchronous utility slice
 
 webpack 5.109.2 now verifies all 98 top-level `test/*.unittest.js` files and

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -69,6 +69,7 @@ import { runHarness as runTailwindcssUpstreamSuite } from "../tests/dogfood/tail
 import { runHarness as runTypescriptUpstreamSuite } from "../tests/dogfood/typescript-upstream-suite.mjs";
 import { NPM_COMPAT_CATALOG, NPM_COMPAT_CATALOG_NAMES } from "../tests/dogfood/npm-compat-catalog.mjs";
 import { runNpmCompatCatalogHarness } from "../tests/dogfood/npm-compat-catalog-harness.mjs";
+import { NPM_COMPAT_UPSTREAM_SOURCES } from "../tests/dogfood/npm-compat-upstream-sources.mjs";
 
 import { setupAcorn } from "../tests/dogfood/setup-acorn.mjs";
 import { setupClsx } from "../tests/dogfood/setup-clsx.mjs";
@@ -90,6 +91,48 @@ const ROOT = resolve(import.meta.dirname, "..");
 const PACKAGE_NAMES = [
   ...new Set(["acorn", "marked", "clsx", "cookie", "eslint", "prettier", "react", ...NPM_COMPAT_CATALOG_NAMES]),
 ];
+const UPSTREAM_SUITE_RUNNERS = new Map([
+  ["acorn", runAcornOfficialSuite],
+  ["axios", runAxiosUpstreamSuite],
+  ["clsx", runClsxUpstreamSuite],
+  ["cookie", runCookieUpstreamSuite],
+  ["eslint", runEslintUpstreamSuite],
+  ["hono", runHonoUpstreamSuite],
+  ["jest", runJestUpstreamSuite],
+  ["jsdom", runJsdomUpstreamSuite],
+  ["lit", runLitUpstreamSuite],
+  ["lodash", (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash" })],
+  ["lodash-es", (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash-es" })],
+  ["marked", runMarkedUpstreamSuite],
+  ["moment", runMomentUpstreamSuite],
+  ["prettier", runPrettierUpstreamSuite],
+  ["react", runReactUpstreamSuite],
+  ["react-dom", runReactDomUpstreamSuite],
+  ["redux", runReduxUpstreamSuite],
+  ["styled-components", runStyledComponentsUpstreamSuite],
+  ["stylelint", runStylelintUpstreamSuite],
+  ["tailwindcss", runTailwindcssUpstreamSuite],
+  ["three", runThreeUpstreamSuite],
+  ["typescript", runTypescriptUpstreamSuite],
+  ["uuid", runUuidUpstreamSuite],
+  ["webpack", runWebpackUpstreamSuite],
+]);
+
+const CONFIGURED_UPSTREAM_NAMES = NPM_COMPAT_UPSTREAM_SOURCES.filter((entry) => entry.suiteScript)
+  .map((entry) => entry.name)
+  .sort();
+const WIRED_UPSTREAM_NAMES = [...UPSTREAM_SUITE_RUNNERS.keys()].sort();
+if (JSON.stringify(CONFIGURED_UPSTREAM_NAMES) !== JSON.stringify(WIRED_UPSTREAM_NAMES)) {
+  throw new Error(
+    `npm-compat upstream runner registry mismatch\nconfigured: ${CONFIGURED_UPSTREAM_NAMES.join(", ")}\nwired: ${WIRED_UPSTREAM_NAMES.join(", ")}`,
+  );
+}
+
+function runConfiguredUpstreamSuite(name, options) {
+  const runner = UPSTREAM_SUITE_RUNNERS.get(name);
+  if (!runner) throw new Error(`npm-compat has no upstream suite runner for ${name}`);
+  return runner(options);
+}
 // Committed npm API snapshot keeps report generation deterministic and offline.
 // Refresh these together from:
 // https://api.npmjs.org/downloads/point/last-week/{package}
@@ -1480,7 +1523,7 @@ if (selectedPackages.has("acorn")) {
   } else {
     console.log("[npm-compat] acorn — compile/validate/diff + official test suite (this takes ~1 min)...");
     const acornReport = await runAcorn({ quiet: true });
-    const acornSuite = await runAcornOfficialSuite({ quiet: true });
+    const acornSuite = await runConfiguredUpstreamSuite("acorn", { quiet: true });
     const acornPerf = await perfAcorn();
     packages.push(
       await buildPackageEntry({
@@ -1506,7 +1549,7 @@ if (selectedPackages.has("acorn")) {
 if (selectedPackages.has("marked")) {
   console.log("[npm-compat] marked — package entry + selected original upstream unit tests...");
   const markedReport = await runMarked({ quiet: true });
-  const markedSuite = await runMarkedUpstreamSuite({ quiet: true });
+  const markedSuite = await runConfiguredUpstreamSuite("marked", { quiet: true });
   packages.push(
     await buildPackageEntry({
       name: "marked",
@@ -1563,7 +1606,7 @@ if (selectedPackages.has("clsx")) {
   } else {
     console.log("[npm-compat] clsx — compile/validate/diff + complete original upstream unit suite + perf...");
     const clsxReport = await runClsx({ quiet: true });
-    const clsxSuite = await runClsxUpstreamSuite({ quiet: true });
+    const clsxSuite = await runConfiguredUpstreamSuite("clsx", { quiet: true });
     const clsxPerf = await perfClsx();
     packages.push(
       await buildPackageEntry({
@@ -1619,7 +1662,7 @@ if (selectedPackages.has("cookie")) {
   } else {
     console.log("[npm-compat] cookie — compile/validate/diff + complete original upstream unit suite + perf...");
     const cookieReport = await runCookie({ quiet: true });
-    const cookieSuite = await runCookieUpstreamSuite({ quiet: true });
+    const cookieSuite = await runConfiguredUpstreamSuite("cookie", { quiet: true });
     const cookiePerf = await perfCookie();
     packages.push(
       await buildPackageEntry({
@@ -1662,7 +1705,7 @@ if (selectedPackages.has("cookie")) {
 if (selectedPackages.has("eslint")) {
   console.log("[npm-compat] eslint — bounded package entry + selected original upstream unit...");
   const eslintReport = await runEslint({ quiet: true });
-  const eslintSuite = await runEslintUpstreamSuite({ quiet: true });
+  const eslintSuite = await runConfiguredUpstreamSuite("eslint", { quiet: true });
   // Do not spend a second bounded compile on a package-entry failure. Once
   // lib/api.js is a valid module, the workload harness compiles a generated
   // driver that calls the real Linter.verify API and compares its primitive
@@ -1708,7 +1751,7 @@ if (selectedPackages.has("eslint")) {
 if (selectedPackages.has("prettier")) {
   console.log("[npm-compat] prettier — package entry + selected original upstream unit tests...");
   const prettierReport = await runPrettier({ quiet: true });
-  const prettierSuite = await runPrettierUpstreamSuite({ quiet: true });
+  const prettierSuite = await runConfiguredUpstreamSuite("prettier", { quiet: true });
   packages.push(
     await buildPackageEntry({
       name: "prettier",
@@ -1744,7 +1787,7 @@ if (selectedPackages.has("prettier")) {
 if (selectedPackages.has("react")) {
   console.log("[npm-compat] react — package entry + React's own upstream unit tests...");
   const reactReport = await runReact({ quiet: true });
-  const reactSuite = await runReactUpstreamSuite({ quiet: true });
+  const reactSuite = await runConfiguredUpstreamSuite("react", { quiet: true });
   packages.push(
     await buildPackageEntry({
       name: "react",
@@ -1793,7 +1836,7 @@ if (selectedPackages.has("lit")) {
   } else {
     console.log("[npm-compat] lit — package entry + lit's own upstream unit tests...");
     const litReport = await runNpmCompatCatalogHarness("lit", { quiet: true });
-    const litSuite = await runLitUpstreamSuite({ quiet: true });
+    const litSuite = await runConfiguredUpstreamSuite("lit", { quiet: true });
     packages.push(
       await buildPackageEntry({
         name: "lit",
@@ -1835,7 +1878,7 @@ if (selectedPackages.has("react-dom")) {
   console.log("[npm-compat] react-dom — package entry + react-dom's own upstream unit tests...");
   const reactDomEntry = NPM_COMPAT_CATALOG.find((entry) => entry.name === "react-dom");
   const reactDomReport = await runNpmCompatCatalogHarness("react-dom", { quiet: true });
-  const reactDomSuite = await runReactDomUpstreamSuite({ quiet: true });
+  const reactDomSuite = await runConfiguredUpstreamSuite("react-dom", { quiet: true });
   const reactDomImplementationReport = {
     ...reactDomReport,
     // The package-entry probe only compiles the small environment selector.
@@ -1907,39 +1950,7 @@ for (const entry of NPM_COMPAT_CATALOG) {
       ? await workloadRunner({ quiet: true })
       : null;
   const hasApiWorkload = workloadRunner !== null;
-  const catalogUpstreamRunner =
-    entry.name === "hono"
-      ? runHonoUpstreamSuite
-      : entry.name === "lodash"
-        ? (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash" })
-        : entry.name === "lodash-es"
-          ? (options) => runLodashUpstreamSuite({ ...options, packageName: "lodash-es" })
-          : entry.name === "uuid"
-            ? runUuidUpstreamSuite
-            : entry.name === "redux"
-              ? runReduxUpstreamSuite
-              : entry.name === "jsdom"
-                ? runJsdomUpstreamSuite
-                : entry.name === "axios"
-                  ? runAxiosUpstreamSuite
-                  : entry.name === "moment"
-                    ? runMomentUpstreamSuite
-                    : entry.name === "stylelint"
-                      ? runStylelintUpstreamSuite
-                      : entry.name === "three"
-                        ? runThreeUpstreamSuite
-                        : entry.name === "styled-components"
-                          ? runStyledComponentsUpstreamSuite
-                          : entry.name === "webpack"
-                            ? runWebpackUpstreamSuite
-                            : entry.name === "jest"
-                              ? runJestUpstreamSuite
-                              : entry.name === "tailwindcss"
-                                ? runTailwindcssUpstreamSuite
-                                : entry.name === "typescript"
-                                  ? runTypescriptUpstreamSuite
-                                  : null;
-  const catalogUpstreamReport = catalogUpstreamRunner ? await catalogUpstreamRunner({ quiet: true }) : null;
+  const catalogUpstreamReport = await runConfiguredUpstreamSuite(entry.name, { quiet: true });
   const upstreamSuite = entry.upstreamSuite;
   const upstreamTests = upstreamSuite
     ? {

--- a/tests/dogfood/npm-compat-upstream-sources.test.ts
+++ b/tests/dogfood/npm-compat-upstream-sources.test.ts
@@ -30,9 +30,8 @@ describe("npm-compat upstream GitHub source pins", () => {
         expect(pin.inventory.fileCount).toBeGreaterThan(0);
         expect(pin.inventory.pathSha256).toMatch(/^[0-9a-f]{64}$/);
       }
-      if (pin.suiteScript) {
-        expect(packageJson.scripts[pin.suiteScript]).toBeTypeOf("string");
-      }
+      expect(pin.suiteScript).toBeTypeOf("string");
+      expect(packageJson.scripts[pin.suiteScript]).toBeTypeOf("string");
     }
   });
 
@@ -47,5 +46,12 @@ describe("npm-compat upstream GitHub source pins", () => {
     expect(workflow).toContain("suitePins.filter(entry => entry.suiteScript)");
     expect(workflow).toContain("its unit-test result is absent");
     expect(workflow).toContain("still reports adapter pending");
+  });
+
+  it("makes report generation reject configured suites missing from its executable registry", () => {
+    const generator = readFileSync(join(HERE, "../../scripts/generate-npm-compat-report.mjs"), "utf-8");
+    expect(generator).toContain("UPSTREAM_SUITE_RUNNERS");
+    expect(generator).toContain("npm-compat upstream runner registry mismatch");
+    expect(generator).toContain("runConfiguredUpstreamSuite(entry.name");
   });
 });


### PR DESCRIPTION
## What changed

- replace the nullable catalog adapter switch with one executable 24-package upstream-suite registry
- compare that registry with the pinned source configuration at generator startup and fail on any mismatch
- require every package pin to declare a real `suiteScript`
- retain the merge-only workflow check that rejects artifacts without numeric `passed` and `total` results
- document the complete end-to-end checkpoint in the markdown issue

## Why

Adding an adapter in one file was previously insufficient: forgetting the generator switch could silently leave the package card at `adapter pending` until the expensive post-merge workflow exposed it. There is now one explicit executable registry whose package set must exactly match configuration.

## Full result

The complete 24-package generator ran with `--no-write` and exited successfully. It produced one numeric suite report per package and an aggregate correctness rollup of:

- verified: 8
- divergent: 14
- unverified: 2

Compatibility failures remain report data. Performance comparison remains advisory and is not a gate.

## Validation

- complete `generate:npm-compat --no-write` run for all 24 packages
- upstream source/registry contract tests
- focused TypeScript npm-compat generation through the registry
- typecheck and lint
- full pre-push checks

This is the final stacked checkpoint based on PR #4485. It completes the initial workflow wiring in [the original-upstream-suite plan](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3995-pin-and-adapt-original-upstream-test-suites-for-catalog.md).
