### PR TITLE
fix(#4218): oracle parity check was vacuous (18/21, not 21/21) + differential spike

### DIFF
--- a/scripts/audit-oracle-differential.mts
+++ b/scripts/audit-oracle-differential.mts
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4218) Differential-oracle spike — the evidence the checker-retirement
+ * plan was missing.
+ *
+ * `scripts/audit-ts5-checker-usage.mts` counts CHECKER CALLS. That is the
+ * wrong instrument for the question "can the in-house backend replace the
+ * checker?", because `InHouseOracle`'s contract is *never widen a guess into
+ * a fact*: when it cannot answer it returns `unresolvable`, which every
+ * consumer accepts as "use the dynamic representation". So the in-house
+ * backend can reach ZERO checker calls while silently losing every type
+ * specialization, and a call counter would show only success.
+ *
+ * This script measures the two things that actually gate retirement:
+ *
+ *  1. **Fact divergence** — runs the corpus under `oracleBackend:
+ *     "differential"` (answers from the checker, records where the in-house
+ *     backend disagrees) and reports `conflicting` (in-house claims a
+ *     DIFFERENT fact — a bug) vs `weakened` (in-house declines to answer —
+ *     safe but lossy), broken down per query so the output is a worklist.
+ *
+ *  2. **Emitted-code quality** — compiles each input under `checker` and
+ *     `inhouse` and diffs the generated WAT for the signatures of lost
+ *     typing: unboxed scalar locals (f64/i32) traded for `externref`, and
+ *     added boxing/unboxing traffic. A backend that "agrees" on facts but
+ *     emits boxed code has not replaced the checker in any useful sense.
+ *
+ * Usage:
+ *   npx tsx scripts/audit-oracle-differential.mts [--json <out.json>] [--samples N]
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), "..", "..");
+
+const { compile } = await import("../src/index.js");
+const { globalDivergenceLedger } = await import("../src/checker/oracle-backend.js");
+
+interface Input {
+  name: string;
+  source: string;
+  annotated: boolean;
+}
+
+/** Corpus: annotated TS (where the checker actually knows things — the only
+ * place a weakened in-house answer can cost anything) plus plain JS. */
+function collectCorpus(): Input[] {
+  const corpus: Input[] = [];
+  const root = join(REPO_ROOT, "website/playground/examples");
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const p = join(dir, entry);
+      if (statSync(p).isDirectory()) walk(p);
+      else if (p.endsWith(".ts") && !p.endsWith(".d.ts")) {
+        corpus.push({ name: relative(REPO_ROOT, p), source: readFileSync(p, "utf8"), annotated: true });
+      }
+    }
+  };
+  walk(root);
+
+  const plainJs: Record<string, string> = {
+    "<js> fib": "function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); } console.log(fib(20));",
+    "<js> arrays":
+      "const xs = [3, 1, 4, 1, 5]; let t = 0; for (const x of xs) { t += x * 2; } console.log(t / xs.length);",
+    "<js> class":
+      "class P { constructor(x, y) { this.x = x; this.y = y; } d() { return Math.sqrt(this.x * this.x + this.y * this.y); } } console.log(new P(3, 4).d());",
+  };
+  for (const [name, source] of Object.entries(plainJs)) corpus.push({ name, source, annotated: false });
+
+  // Annotated shapes the checker is *supposed* to pay off on: the in-house
+  // backend must read these from the annotations alone.
+  const annotatedTs: Record<string, string> = {
+    "<ts> typed params":
+      "export function area(w: number, h: number): number { return w * h; } export function go(): number { let acc = 0; for (let i = 0; i < 10; i++) acc += area(i, 2); return acc; }",
+    "<ts> class fields":
+      "class Vec { x: number; y: number; constructor(x: number, y: number) { this.x = x; this.y = y; } len(): number { return Math.sqrt(this.x * this.x + this.y * this.y); } } export function run(): number { return new Vec(3, 4).len(); }",
+    "<ts> native i32":
+      "type i32 = number; export function addI(a: i32, b: i32): i32 { return (a + b) | 0; } export function loop(): i32 { let s: i32 = 0; for (let i = 0; i < 100; i++) s = addI(s, i); return s; }",
+    "<ts> arrays typed":
+      "export function total(xs: number[]): number { let t = 0; for (let i = 0; i < xs.length; i++) t += xs[i]; return t; }",
+    "<ts> bool + string":
+      "export function pick(flag: boolean, s: string): string { return flag ? s.toUpperCase() : s; }",
+  };
+  for (const [name, source] of Object.entries(annotatedTs)) corpus.push({ name, source, annotated: true });
+  return corpus;
+}
+
+// ── Emitted-code quality proxies ──────────────────────────────────────
+//
+// Read off the WAT text. These are proxies, not a full cost model, but they
+// are the exact signatures of "the compiler stopped knowing the type":
+// scalar locals demoted to externref, and boxing traffic added to compensate.
+interface CodeShape {
+  bytes: number;
+  f64Locals: number;
+  i32Locals: number;
+  externrefLocals: number;
+  boxCalls: number;
+  unboxCalls: number;
+  externConverts: number;
+}
+
+function shapeOfWat(wat: string, bytes: number): CodeShape {
+  const count = (re: RegExp) => (wat.match(re) ?? []).length;
+  return {
+    bytes,
+    // `(local $x f64)` and `(local f64)` forms, plus multi-type local decls.
+    f64Locals: count(/\(local(?:\s+\$[^\s)]+)?\s+f64\)/g),
+    i32Locals: count(/\(local(?:\s+\$[^\s)]+)?\s+i32\)/g),
+    externrefLocals: count(/\(local(?:\s+\$[^\s)]+)?\s+externref\)/g),
+    boxCalls: count(/call\s+\$?__box_[a-z]+/g),
+    unboxCalls: count(/call\s+\$?__unbox_[a-z]+/g),
+    externConverts: count(/(?:extern\.convert_any|any\.convert_extern)/g),
+  };
+}
+
+async function compileShape(source: string, backend: "checker" | "inhouse"): Promise<CodeShape | string> {
+  try {
+    const r = (await compile(source, { oracleBackend: backend, emitWat: true })) as {
+      success?: boolean;
+      binary?: Uint8Array;
+      wat?: string;
+      errors?: { message: string }[];
+    };
+    if (!r.success || !r.binary) return `ERR:${r.errors?.[0]?.message?.slice(0, 90) ?? "unknown"}`;
+    return shapeOfWat(r.wat ?? "", r.binary.byteLength);
+  } catch (e) {
+    return `THREW:${(e instanceof Error ? e.message : String(e)).slice(0, 90)}`;
+  }
+}
+
+const args = process.argv.slice(2);
+const sampleLimit = args.includes("--samples") ? Number(args[args.indexOf("--samples") + 1]) : 12;
+const corpus = collectCorpus();
+console.log(`corpus: ${corpus.length} inputs (${corpus.filter((c) => c.annotated).length} annotated)\n`);
+
+// ── Phase 1: fact divergence ──────────────────────────────────────────
+console.log("=".repeat(72));
+console.log("PHASE 1 — fact divergence (differential backend: checker answers, inhouse recorded)");
+console.log("=".repeat(72));
+
+interface PerFile {
+  file: string;
+  annotated: boolean;
+  agreements: number;
+  weakened: number;
+  conflicting: number;
+}
+const perFile: PerFile[] = [];
+const totalsByQuery = new Map<string, { agreements: number; weakened: number; conflicting: number }>();
+const conflictSamples: { file: string; query: string; checker: string; inhouse: string; node: string }[] = [];
+
+for (const input of corpus) {
+  globalDivergenceLedger.reset();
+  try {
+    await compile(input.source, { oracleBackend: "differential" });
+  } catch {
+    /* a compile failure still leaves whatever was recorded */
+  }
+  const s = globalDivergenceLedger.summary();
+  perFile.push({ file: input.name, annotated: input.annotated, ...s });
+  for (const [q, v] of globalDivergenceLedger.byQuery) {
+    const t = totalsByQuery.get(q) ?? { agreements: 0, weakened: 0, conflicting: 0 };
+    t.agreements += v.agreements;
+    t.weakened += v.weakened;
+    t.conflicting += v.conflicting;
+    totalsByQuery.set(q, t);
+  }
+  for (const d of globalDivergenceLedger.samples) {
+    // Samples include weakened ones; keep only genuine conflicts (bugs).
+    const weak = ["unresolvable", "undefined", "mixed", "[]"].includes(d.inhouse);
+    if (!weak && conflictSamples.length < sampleLimit) {
+      conflictSamples.push({ file: input.name, ...d });
+    }
+  }
+}
+
+const grand = perFile.reduce(
+  (a, f) => ({
+    agreements: a.agreements + f.agreements,
+    weakened: a.weakened + f.weakened,
+    conflicting: a.conflicting + f.conflicting,
+  }),
+  { agreements: 0, weakened: 0, conflicting: 0 },
+);
+const grandTotal = grand.agreements + grand.weakened + grand.conflicting;
+const pct = (n: number) => (grandTotal === 0 ? "0.0" : ((n / grandTotal) * 100).toFixed(1));
+console.log(`\nqueries compared: ${grandTotal}`);
+console.log(`  agree       ${String(grand.agreements).padStart(7)}  (${pct(grand.agreements)}%)`);
+console.log(
+  `  weakened    ${String(grand.weakened).padStart(7)}  (${pct(grand.weakened)}%)   inhouse declined — safe, lossy`,
+);
+console.log(
+  `  CONFLICTING ${String(grand.conflicting).padStart(7)}  (${pct(grand.conflicting)}%)   inhouse claimed a DIFFERENT fact — bug`,
+);
+
+console.log("\n--- by query (the worklist) ---");
+const qw = Math.max(...[...totalsByQuery.keys()].map((k) => k.length), 12);
+console.log(`${"query".padEnd(qw)}  ${"agree".padStart(8)}  ${"weakened".padStart(8)}  ${"conflict".padStart(8)}`);
+for (const [q, v] of [...totalsByQuery].sort(
+  (a, b) => b[1].conflicting - a[1].conflicting || b[1].weakened - a[1].weakened,
+)) {
+  console.log(
+    `${q.padEnd(qw)}  ${String(v.agreements).padStart(8)}  ${String(v.weakened).padStart(8)}  ${String(v.conflicting).padStart(8)}`,
+  );
+}
+
+if (conflictSamples.length > 0) {
+  console.log("\n--- conflicting samples (these are bugs, not weakening) ---");
+  for (const c of conflictSamples) {
+    console.log(`  ${c.file}  ${c.query}`);
+    console.log(`      checker=${c.checker}  inhouse=${c.inhouse}  node=${c.node}`);
+  }
+}
+
+// ── Phase 2: emitted-code quality ─────────────────────────────────────
+console.log(`\n${"=".repeat(72)}`);
+console.log("PHASE 2 — emitted code: does the inhouse backend lose type specialization?");
+console.log("=".repeat(72));
+
+interface Row {
+  file: string;
+  annotated: boolean;
+  checker: CodeShape | string;
+  inhouse: CodeShape | string;
+}
+const rows: Row[] = [];
+for (const input of corpus) {
+  rows.push({
+    file: input.name,
+    annotated: input.annotated,
+    checker: await compileShape(input.source, "checker"),
+    inhouse: await compileShape(input.source, "inhouse"),
+  });
+}
+
+const num = (v: CodeShape | string, k: keyof CodeShape) => (typeof v === "string" ? 0 : v[k]);
+const ok = (r: Row) => typeof r.checker !== "string" && typeof r.inhouse !== "string";
+const usable = rows.filter(ok);
+
+const fields: (keyof CodeShape)[] = [
+  "bytes",
+  "f64Locals",
+  "i32Locals",
+  "externrefLocals",
+  "boxCalls",
+  "unboxCalls",
+  "externConverts",
+];
+console.log(`\n--- totals over ${usable.length} compilable inputs ---`);
+console.log(`${"metric".padEnd(17)}  ${"checker".padStart(10)}  ${"inhouse".padStart(10)}  ${"delta".padStart(10)}`);
+for (const f of fields) {
+  const c = usable.reduce((a, r) => a + num(r.checker, f), 0);
+  const i = usable.reduce((a, r) => a + num(r.inhouse, f), 0);
+  const d = i - c;
+  const flag =
+    d === 0
+      ? ""
+      : f === "bytes" ||
+          f.startsWith("box") ||
+          f.startsWith("unbox") ||
+          f === "externrefLocals" ||
+          f === "externConverts"
+        ? d > 0
+          ? "  ← WORSE"
+          : "  ← better"
+        : d < 0
+          ? "  ← WORSE"
+          : "  ← better";
+  console.log(
+    `${f.padEnd(17)}  ${String(c).padStart(10)}  ${String(i).padStart(10)}  ${(d > 0 ? `+${d}` : String(d)).padStart(10)}${flag}`,
+  );
+}
+
+const differing = usable.filter((r) => fields.some((f) => num(r.checker, f) !== num(r.inhouse, f)));
+console.log(`\ninputs with ANY emitted-shape difference: ${differing.length} / ${usable.length}`);
+for (const r of differing) {
+  const parts = fields
+    .filter((f) => num(r.checker, f) !== num(r.inhouse, f))
+    .map((f) => `${f} ${num(r.checker, f)}→${num(r.inhouse, f)}`);
+  console.log(`  ${r.file}: ${parts.join(", ")}`);
+}
+const failed = rows.filter((r) => !ok(r));
+if (failed.length > 0) {
+  console.log(`\ncompile failures (excluded from totals): ${failed.length}`);
+  for (const r of failed) {
+    console.log(
+      `  ${r.file}: checker=${typeof r.checker === "string" ? r.checker : "ok"} inhouse=${typeof r.inhouse === "string" ? r.inhouse : "ok"}`,
+    );
+  }
+}
+
+const jsonIdx = args.indexOf("--json");
+if (jsonIdx >= 0) {
+  writeFileSync(
+    args[jsonIdx + 1],
+    JSON.stringify(
+      { divergence: { grand, byQuery: [...totalsByQuery], perFile, conflictSamples }, codeShape: rows },
+      null,
+      2,
+    ),
+  );
+  console.log(`\nwrote ${args[jsonIdx + 1]}`);
+}

--- a/scripts/audit-ts5-checker-usage.mts
+++ b/scripts/audit-ts5-checker-usage.mts
@@ -91,11 +91,19 @@ async function runBackend(backend: Backend, corpus: { name: string; source: stri
   for (const { name, source } of corpus) {
     try {
       const result = await compile(source, { oracleBackend: backend });
-      const wasm: Uint8Array | undefined = (result as { wasm?: Uint8Array }).wasm;
+      // (#4218) The result field is `binary`, NOT `wasm`. Reading `.wasm` gave
+      // `undefined` for every input, so the parity check compared
+      // `undefined === undefined` and reported a vacuous 21/21 match. Treat a
+      // missing binary as a hard failure rather than silently "identical".
+      const binary: Uint8Array | undefined = (result as { binary?: Uint8Array }).binary;
+      if (!binary) {
+        outcomes.push({ file: name, ok: false, error: "compile returned no binary" });
+        continue;
+      }
       outcomes.push({
         file: name,
         ok: true,
-        wasmSha: wasm ? createHash("sha256").update(wasm).digest("hex").slice(0, 16) : undefined,
+        wasmSha: createHash("sha256").update(binary).digest("hex").slice(0, 16),
       });
     } catch (err) {
       outcomes.push({ file: name, ok: false, error: err instanceof Error ? err.message.slice(0, 200) : String(err) });

--- a/src/checker/oracle-backend.ts
+++ b/src/checker/oracle-backend.ts
@@ -70,24 +70,55 @@ export interface OracleDivergence {
  * counts the ones where both backends claim a fact and the facts differ —
  * those ARE bugs and are what the parity tests assert on.
  */
+/** Per-query tally — which oracle question diverges, not just how often. */
+export interface QueryDivergence {
+  agreements: number;
+  weakened: number;
+  conflicting: number;
+}
+
 export class DivergenceLedger {
   agreements = 0;
   weakened = 0;
   conflicting = 0;
   readonly samples: OracleDivergence[] = [];
+  /**
+   * (#4218) Per-query breakdown. The global counters answer "is the in-house
+   * backend safe?"; this answers "which query do I fix next?" — the whole
+   * point of a differential run is to produce a worklist, and a single total
+   * cannot. Unbounded by design: the key space is the oracle's frozen query
+   * vocabulary (~15 names plus `propertyFactOf:<name>`), not the node count.
+   */
+  readonly byQuery = new Map<string, QueryDivergence>();
   private readonly maxSamples: number;
 
   constructor(maxSamples = 200) {
     this.maxSamples = maxSamples;
   }
 
+  private tally(query: string): QueryDivergence {
+    let entry = this.byQuery.get(query);
+    if (!entry) {
+      entry = { agreements: 0, weakened: 0, conflicting: 0 };
+      this.byQuery.set(query, entry);
+    }
+    return entry;
+  }
+
   record(query: string, checkerAnswer: string, inhouseAnswer: string, node: string): void {
+    const perQuery = this.tally(query);
     if (checkerAnswer === inhouseAnswer) {
       this.agreements++;
+      perQuery.agreements++;
       return;
     }
-    if (isWeaker(inhouseAnswer)) this.weakened++;
-    else this.conflicting++;
+    if (isWeaker(inhouseAnswer)) {
+      this.weakened++;
+      perQuery.weakened++;
+    } else {
+      this.conflicting++;
+      perQuery.conflicting++;
+    }
     if (this.samples.length < this.maxSamples) {
       this.samples.push({ query, checker: checkerAnswer, inhouse: inhouseAnswer, node });
     }
@@ -96,6 +127,15 @@ export class DivergenceLedger {
   summary(): { agreements: number; weakened: number; conflicting: number; total: number } {
     const total = this.agreements + this.weakened + this.conflicting;
     return { agreements: this.agreements, weakened: this.weakened, conflicting: this.conflicting, total };
+  }
+
+  /** Reset between corpus files so a run can attribute divergence per input. */
+  reset(): void {
+    this.agreements = 0;
+    this.weakened = 0;
+    this.conflicting = 0;
+    this.samples.length = 0;
+    this.byQuery.clear();
   }
 }
 


### PR DESCRIPTION
## Description

Two things — the first is a correction to a measurement I published in #4481/#4486.

### 1. The oracle parity check was vacuous

`scripts/audit-ts5-checker-usage.mts` read `result.wasm`, but the compile result field is **`binary`**. Every hash was therefore `undefined`, the comparison was `undefined === undefined`, and the script reported a perfect **21/21 byte-identical** match for free. That number was quoted in #4481, #4486 and #4218's issue file. It was evidence of nothing.

Fixed to read `.binary`, and to treat a missing binary as a hard failure rather than silently "identical". **Real result:**

```
byte-identical: 18, divergent: 3 (of 21)
  benchmarks/string.ts, benchmarks.ts, js/async.ts
```

Compilation is deterministic (verified: same source + backend hashes identically across repeats; `emitWat` does not perturb output), so those three are genuine backend differences, not noise.

**What still holds:** the checker-call reductions (−87% / −94.4%) were measured by the `JS2WASM_TRACE_TS5` proxy, independent of this comparison; and the merges were gated by real behavioral evidence — the equivalence gate and the `merge_group` test262 run over 48,735 tests. Those did the work. The byte-identity claim was a bonus assertion that turned out to measure nothing.

### 2. Differential spike — the evidence the retirement plan was missing

`DifferentialOracle` and `DivergenceLedger` existed with **zero consumers**. Nothing measured whether the in-house backend answers as *well* as the checker — only how often the checker is called. Since `InHouseOracle`'s contract is *never widen a guess into a fact*, it can reach zero checker calls while silently losing every specialization, and a call counter would show only success.

- `checker/oracle-backend.ts` — per-query tally (`byQuery`) + `reset()`, so a run yields a worklist instead of one global number.
- `scripts/audit-oracle-differential.mts` — phase 1 reports `conflicting` vs `weakened` per query; phase 2 diffs emitted WAT between backends for the signatures of lost typing (scalar locals traded for `externref`, added box/unbox traffic).

**First run — 6,849 queries:**

| | count | share |
|---|---|---|
| agree | 4,609 | 67.3% |
| weakened (declined — safe, lossy) | 2,240 | 32.7% |
| **conflicting (different fact — bug)** | **0** | **0.0%** |

Weakening is sharply concentrated, which is the worklist: `declarationsOf` 1,259 of 1,274 (effectively unimplemented), `valueDeclarationOf` 830, `staticJsTypeOf`/`typeFactOf`/`declaredNameOf` 151 combined — and **nine other queries weaken zero times**.

**Emitted code:** 18/21 identical; the three differing files trade `externref` locals for `i32` and total 262 bytes smaller. Deliberately **not** reported as "better" — weaker type knowledge producing leaner output is a suspicious direction, not a win, until behavior is verified. An equivalence run under `JS2WASM_ORACLE_BACKEND=inhouse` is in flight to settle it.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHo1sZKsmZinYGbscm1pft

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHo1sZKsmZinYGbscm1pft)_