### PR TITLE
feat(website): default both conformance surfaces to standalone, align the report page's widgets with the landing page

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -532,6 +532,14 @@ jobs:
           cp merged-reports/test262-standalone-report-merged.json benchmarks/results/test262-standalone-report.json
           cp merged-reports/test262-standalone-results-merged.jsonl benchmarks/results/test262-standalone-results.jsonl
           cp merged-reports/test262-standalone-report-merged.json public/benchmarks/results/test262-standalone-report.json
+          # …and the SERVED copy under website/public (the vite publicDir since
+          # #1656), mirroring the host line above. The landing page reads this
+          # path FIRST for its standalone donut — the default lane now — so a
+          # committed copy that never refreshes is a stale-headline trap
+          # whenever a deploy's baselines fetch fails.
+          mkdir -p website/public/benchmarks/results
+          cp merged-reports/test262-standalone-report-merged.json \
+            website/public/benchmarks/results/test262-standalone-report.json
 
       - name: Raise standalone pass-count high-water mark (#2097)
         run: |
@@ -826,6 +834,9 @@ jobs:
             public/benchmarks/results/test262-standalone-report.json \
             website/public/benchmarks/results/test262-editions.json \
             website/public/benchmarks/results/test262-category-editions.json
+          # The SERVED standalone report (website/public, copied above) — the
+          # landing page's first source for its standalone donut.
+          git add -f website/public/benchmarks/results/test262-standalone-report.json 2>/dev/null || true
           # #2871 follow-up — per-file edition index (Error Patterns / Skipped Tests filter).
           git add -f website/public/benchmarks/results/test262-file-editions.json 2>/dev/null || true
           # (#4362) Standalone twins of the edition buckets + feature-row counts,

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -3001,8 +3001,27 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
           # Add a dedicated SSH remote for the deploy-key push + its rebase fetch.
           # The checkout's origin is HTTPS; we don't rewrite it (other steps may
-          # rely on it). github.repository is owner/name (e.g. loopdive/js2wasm).
-          MAIN_SSH_REMOTE="git@github.com:${{ github.repository }}.git"
+          # rely on it). $GITHUB_REPOSITORY is owner/name (e.g. loopdive/js2wasm).
+          #
+          # It is the RUNNER ENV VAR, deliberately not an Actions expression
+          # interpolation, and that is LOAD-BEARING. A `run:` script containing
+          # even one interpolation is compiled into a single format expression
+          # capped at 21,000 characters. This script is ~25 kB, so the lone
+          # interpolation that used to sit here put the step over the cap and
+          # GitHub rejected the whole file:
+          #   Invalid workflow file … Exceeded max expression length 21000
+          # That is not a normal test failure — the run fails instantly with
+          # ZERO jobs, so the required `merge shard reports` and `check for
+          # test262 regressions` contexts are never published for the merged
+          # state, the merge-queue entry can never satisfy them, and it sits at
+          # the queue head forever blocking every PR behind it. PR #4498 stalled
+          # ~2h this way, tipped over the cap by a two-line addition elsewhere
+          # in this same script. With no interpolation left the script is a
+          # plain string and the limit does not apply. Keep it that way: read
+          # workflow context here through env vars only — and note the ban
+          # covers COMMENTS too, since the expression compiler scans the whole
+          # script (spelling the token out in this comment re-broke the file).
+          MAIN_SSH_REMOTE="git@github.com:${GITHUB_REPOSITORY}.git"
           git remote remove deploykey 2>/dev/null || true
           git remote add deploykey "$MAIN_SSH_REMOTE"
           PASS=$(node -e "console.log(JSON.parse(require('fs').readFileSync('benchmarks/results/test262-current.json','utf8')).summary.pass)")

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -2608,6 +2608,16 @@ jobs:
           cp shard-artifacts/test262-report-merged.json public/benchmarks/results/test262-report.json
           cp shard-artifacts/test262-results-merged.jsonl public/benchmarks/results/test262-results.jsonl
           cp shard-artifacts/test262-standalone-report-merged.json public/benchmarks/results/test262-standalone-report.json
+          # …and the SERVED copy under website/public (the vite publicDir since
+          # #1656). Its host twin is refreshed here, but the standalone one only
+          # ever landed via deploy-pages, so the committed file sat at a
+          # 2026-06-07 snapshot (16,298 pass, no host_free_pass field). The
+          # landing page reads this path FIRST for its standalone donut, so if a
+          # deploy's baselines fetch ever fails it serves that June number —
+          # now the site's default headline, since standalone is the default lane.
+          mkdir -p website/public/benchmarks/results
+          cp shard-artifacts/test262-standalone-report-merged.json \
+            website/public/benchmarks/results/test262-standalone-report.json
 
       # #2097 — ratchet the absolute standalone high-water mark UP when this
       # push improved standalone conformance. Only ever raises (never lowers);
@@ -3074,6 +3084,9 @@ jobs:
               benchmarks/results/test262-report.json \
               public/benchmarks/results/test262-report.json \
               public/benchmarks/results/test262-standalone-report.json
+            # The SERVED standalone report (website/public, copied above) — the
+            # landing page's first source for its standalone donut.
+            git add -f website/public/benchmarks/results/test262-standalone-report.json 2>/dev/null || true
             # #1853 — hard-error stability baseline, refreshed just above.
             git add -f scripts/test262-hard-error-baseline.json 2>/dev/null || true
             # #2108 — coercion-site drift baseline, refreshed just above. Staged

--- a/website/components/t262-view-state.js
+++ b/website/components/t262-view-state.js
@@ -46,14 +46,16 @@
    * navigation, so they must not stack history entries the Back button then
    * has to unwind one edition at a time.
    *
-   * `mode: "host"` and `edition: "overall"` are the defaults and are DROPPED
-   * from the URL rather than written out, so the common case stays a clean
-   * link and a shared URL only ever names what actually differs.
+   * `mode: "standalone"` and `edition: "overall"` are the DEFAULTS on both
+   * pages and are dropped from the URL rather than written out, so the common
+   * case stays a clean link and a shared URL only ever names what differs. The
+   * mode default follows the pages: standalone (pure Wasm) is the lane both
+   * surfaces open on, so `?mode=host` is the explicit opt-in.
    */
   const write = ({ mode, edition } = {}) => {
     const search = params();
-    if (mode === "standalone") search.set(MODE_PARAM, "standalone");
-    else if (mode === "host") search.delete(MODE_PARAM);
+    if (mode === "host") search.set(MODE_PARAM, "host");
+    else if (mode === "standalone") search.delete(MODE_PARAM);
 
     if (typeof edition === "string" && edition && edition !== "overall") search.set(EDITION_PARAM, edition);
     else if (edition === "overall" || edition === null) search.delete(EDITION_PARAM);
@@ -75,7 +77,7 @@
    */
   const linkTo = (href, { mode, edition } = {}) => {
     const search = new URLSearchParams();
-    if (mode === "standalone") search.set(MODE_PARAM, "standalone");
+    if (mode === "host") search.set(MODE_PARAM, "host");
     if (typeof edition === "string" && edition && edition !== "overall") search.set(EDITION_PARAM, edition);
     const query = search.toString();
     return query ? `${href}?${query}` : href;

--- a/website/index.html
+++ b/website/index.html
@@ -1758,9 +1758,13 @@
                  ~5k TC39 proposal tests on top of the ~43k current-standard
                  baseline. Off by default so the headline number reflects
                  shipped ECMAScript only. -->
+            <!-- Standalone (pure Wasm, no JS host imports) is the DEFAULT lane:
+                 it is the honest floor of what the compiler produces on its
+                 own, so the headline number is not propped up by host imports.
+                 Ticking "JS host" opts into the host-assisted lane. -->
             <div class="feat-filter conformance-scope-toggle">
               <label class="feat-toggle">
-                <input type="checkbox" id="host-support-toggle" checked />
+                <input type="checkbox" id="host-support-toggle" />
                 <span>JS host</span>
               </label>
               <label class="feat-toggle">
@@ -1785,6 +1789,11 @@
           </div>
         </div>
         <div class="edition-timeline-section">
+          <!-- src is swapped to the standalone edition buckets when the "JS
+               host" toggle is off, matching the report page. The host file is
+               the safe initial value: it is always published, and the swap
+               happens during hydration (which also falls back to it if the
+               standalone buckets are unavailable). -->
           <t262-edition-timeline
             id="conformance-edition-timeline"
             src="./benchmarks/results/test262-editions.json"
@@ -5668,8 +5677,49 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           window.updateConformanceDonut = () => {
             if (lastDetail) applyScopeFromDetail(lastDetail);
           };
+
+          // The edition slider is built from the SELECTED lane's edition
+          // buckets, the same as the report page — otherwise the standalone
+          // view (now the default) would derive its stops, published-edition
+          // limit and cumulative scope sums from js-host data. Falls back to
+          // the host file if the standalone buckets aren't published, so a
+          // missing artifact degrades to the previous behaviour instead of an
+          // "Unavailable" slider.
+          const EDITION_TIMELINE_SRC = {
+            host: "./benchmarks/results/test262-editions.json",
+            standalone: "./benchmarks/results/test262-standalone-editions.json",
+          };
+          let standaloneEditionsAvailable = null;
+          // Token guard: the standalone branch awaits an availability probe, so
+          // a call started earlier can resolve AFTER a later one and clobber
+          // its result — which is exactly what happens on a `?mode=host` load,
+          // where the default-lane sync is already in flight when the URL state
+          // flips the toggle. Only the newest call may write the attribute.
+          let editionSrcToken = 0;
+          const syncEditionTimelineSrc = async () => {
+            const token = ++editionSrcToken;
+            const hostEnabled = hostToggle ? hostToggle.checked : true;
+            let src = EDITION_TIMELINE_SRC.host;
+            if (!hostEnabled) {
+              if (standaloneEditionsAvailable === null) {
+                try {
+                  const resp = await fetch(EDITION_TIMELINE_SRC.standalone);
+                  standaloneEditionsAvailable = resp.ok;
+                } catch {
+                  standaloneEditionsAvailable = false;
+                }
+              }
+              if (standaloneEditionsAvailable) src = EDITION_TIMELINE_SRC.standalone;
+            }
+            if (token !== editionSrcToken) return;
+            if (editionTimeline.getAttribute("src") !== src) editionTimeline.setAttribute("src", src);
+          };
+
           strictToggle?.addEventListener("change", window.updateConformanceDonut);
-          hostToggle?.addEventListener("change", window.updateConformanceDonut);
+          hostToggle?.addEventListener("change", () => {
+            syncEditionTimelineSrc();
+            window.updateConformanceDonut();
+          });
 
           // (?mode=/?edition=) Apply the incoming URL state once, as soon as
           // the timeline has published its own scopes. Driven off the first
@@ -5715,6 +5765,10 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           } else {
             editionTimeline.removeAttribute("show-proposals");
           }
+          // Point the slider at the default lane's buckets before the first
+          // scope is published, so the standalone default doesn't render a
+          // js-host slider for one frame.
+          syncEditionTimelineSrc();
           editionTimeline.setAttribute("value", "overall");
 
           // #106 toggle removed (2026-05-24): the "Include TC39 proposals" scope

--- a/website/public/benchmarks/report.html
+++ b/website/public/benchmarks/report.html
@@ -1443,7 +1443,20 @@
           donutEl.setAttribute("skip", String(summary?.skip || 0));
           donutEl.setAttribute("total", String(summary?.total || 0));
           donutEl.setAttribute("caption-main", captionMain);
-          donutEl.setAttribute("caption-sub", "conformance");
+          // Same caption wording as the landing page: the sub-line names the
+          // lane and the strict filter, so a standalone or strict number is
+          // never presented as if it were the plain host one. This matters
+          // more now that standalone is the default view.
+          donutEl.setAttribute("caption-sub", conformanceCaptionSub());
+        }
+
+        // Mirrors the landing page's `conformanceOptions().captionSub`.
+        function conformanceCaptionSub() {
+          const strictOnly = strictCheckbox.checked;
+          const standalone = view.mode === "standalone";
+          if (strictOnly && standalone) return "strict standalone conformance";
+          if (strictOnly) return "strict conformance";
+          return standalone ? "standalone conformance" : "conformance";
         }
 
         function renderEditionSection() {
@@ -1492,7 +1505,11 @@
 
         function renderSummaryCard() {
           if (scoreState.editionScope === "overall") {
-            const overallCaption = editionDetail?.captionMain || "ECMAScript";
+            // Plain "ECMAScript" at overall scope, matching the landing page.
+            // The slider's own caption for this stop names the latest published
+            // edition ("ECMAScript 2026"), which reads as an edition FILTER
+            // rather than the unfiltered headline this scope actually is.
+            const overallCaption = "ECMAScript";
             if (strictCheckbox.checked && data.strict_summary) {
               setDonutSummary(data.strict_summary, overallCaption);
             } else {
@@ -1504,7 +1521,10 @@
             return;
           }
           if (scoreState.editionScope === "overall+proposal") {
-            setDonutSummary(fullSummary, PROPOSAL_LABEL);
+            // "ECMAScript + proposals", matching the landing page — the scope is
+            // the standard PLUS proposals, not proposals alone (which is what
+            // the bare slider label PROPOSAL_LABEL suggests).
+            setDonutSummary(fullSummary, "ECMAScript + proposals");
             return;
           }
           const scope =
@@ -2454,9 +2474,14 @@
           // Mode switch (only shown when standalone data is available).
           // ?mode= wins over the remembered choice: an explicit link should
           // show what it says regardless of what this browser last looked at.
+          // Standalone (pure Wasm, no JS host imports) is the DEFAULT lane on
+          // both surfaces — the honest floor of what the compiler produces on
+          // its own. Host mode is the opt-in, via the switch, `?mode=host`, or
+          // a remembered choice. It still falls back to host when no standalone
+          // report was published.
           const conformanceHost = el("div");
-          const preferredMode = initialViewState.mode || localStorage.getItem("t262-mode");
-          let activeMode = standaloneView && preferredMode === "standalone" ? "standalone" : "host";
+          const preferredMode = initialViewState.mode || localStorage.getItem("t262-mode") || "standalone";
+          let activeMode = standaloneView && preferredMode !== "host" ? "standalone" : "host";
           const renderActive = () => {
             conformanceHost.textContent = "";
             const view = activeMode === "standalone" && standaloneView ? standaloneView : hostView;


### PR DESCRIPTION
## Description

**Standalone (pure Wasm, no JS host imports) is now the lane both pages open on** — the honest floor of what the compiler produces on its own, rather than a number propped up by host imports. "JS host" becomes the opt-in: the landing page's checkbox, the report page's mode switch, or `?mode=host`.

The shared URL contract flips with it — `?mode=host` is now the explicit param and standalone is dropped as the default, so an ordinary link stays clean and only ever names what differs from what a reader gets by default.

### Widget parity

The report page's **donut**, **pass-rate trend chart** and **ES-edition slider** now match the landing page's setup exactly. Verified by driving both pages through the same interactions — every donut pass count, caption, chart mode/scope and timeline source agrees between the two:

| view | donut | landing | report |
|---|---|---|---|
| default (standalone, overall) | `ECMAScript / standalone conformance` | 30,334 | 30,334 |
| `?mode=host` | `ECMAScript / conformance` | 32,373 | 32,373 |
| standalone, ES2015 | `ECMAScript 2015 / standalone conformance` | 15,984 | 15,984 |

- **Donut caption** — the report page hardcoded `"conformance"` for every lane, so a standalone or strict number read as if it were the plain host one (worse now that standalone is the default). It now uses the landing page's wording (`standalone conformance` / `strict conformance` / `strict standalone conformance`). At overall scope it also says plain `ECMAScript` rather than the slider's `ECMAScript 2026` — which read as an edition *filter* rather than the unfiltered headline it is — and `ECMAScript + proposals` rather than the bare `Proposals` (the scope is the standard *plus* proposals, not proposals alone).
- **Edition slider** — the landing page pinned its `src` to the **host** edition buckets, so the standalone view derived its stops, published-edition limit and cumulative scope sums from js-host data. It now follows the selected lane, like the report page already did, falling back to the host file when the standalone buckets aren't published. A token guard stops an in-flight availability probe from clobbering a newer lane selection — exactly what a `?mode=host` load hit during testing.
- **Trend chart** — already the shared `<t262-conformance-trend>` on both pages since #4479; it just follows the new default.

### Stale served standalone report (found while making standalone the default)

`website/public/benchmarks/results/test262-standalone-report.json` is the landing page's **first** source for its standalone donut, but unlike its host twin nothing refreshed it: the committed copy sat at a **2026-06-07** snapshot (16,298 pass, no `host_free_pass` field — about 31 points below current). Only `deploy-pages`' baselines fetch kept the live page right; if that fetch ever failed, the site would serve the June number as its **default headline**. Both promote paths (`test262-sharded.yml`, `refresh-baseline.yml`) now write and stage it alongside the host copy.

### Verification

Headless browser, both pages: default lane, mode switch/toggle in both directions, `?mode=host` round-trip, edition selection, and strict mode. No console errors, and the two pages report identical numbers at every step.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmfiGERvoPX7QevNBTtvLY)_