### PR TITLE
fix(#4408): the differential conflict classifier over-reports ~9x — and TypeScript is not ground truth (#4409/#4410/#4411)

### DIFF
--- a/plan/issues/4408-differential-conflict-classifier-is-wrong.md
+++ b/plan/issues/4408-differential-conflict-classifier-is-wrong.md
@@ -1,0 +1,116 @@
+---
+id: 4408
+title: "Differential oracle: the conflict classifier is wrong — 908 reported conflicts are 100"
+status: ready
+sprint: current
+created: 2026-08-14
+updated: 2026-08-14
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bug
+area: checker
+goal: correctness
+parent: 4218
+---
+
+## Problem
+
+`DivergenceLedger.isWeaker` (`src/checker/oracle-backend.ts`) decides whether a
+divergence is a **safe weakening** (the in-house backend declined to answer) or
+a **conflict** (both backends claim a fact and the facts differ) by testing the
+_whole answer string_ against four literals:
+
+```ts
+function isWeaker(answer: string): boolean {
+  return answer === "unresolvable" || answer === "undefined" || answer === "mixed" || answer === "[]";
+}
+```
+
+That is only correct for scalar answers. It is wrong for every other answer
+shape the oracle produces, in four distinct ways:
+
+1. **Weakening nested inside a composite.** `signatureOf` renders as
+   `(p1,p2)->r#arity`. The in-house answer `(unresolvable)->unresolvable#1`
+   is a total abstention, but the string is not one of the four literals, so it
+   is counted as a conflict. Same for `array<any>` vs `array<number>`.
+2. **Weakening expressed as a boolean polarity.** For `isBooleanProducing`,
+   `false` is the conservative answer; for `isUnresolvableIdentifier`, `true`
+   is. Both were counted as conflicts.
+3. **Weakening on the CHECKER side.** `declarationsOf` returning `[]` from the
+   checker means _the checker_ declined — the ledger has no category for that
+   at all, so it lands in `conflicting` and reads as an in-house bug.
+4. **`any` treated as a fact.** The checker's `any` carries no static
+   information for a wasm lowerer; it is the same answer as `unresolvable`.
+   The classifier scores `any` vs `unresolvable` as a disagreement.
+
+## Impact
+
+The headline number from the wide differential run (2,137 inputs) was
+**908 conflicting facts**, with `signatureOf` at a **95.9 % conflict rate**.
+That number was quoted as the gate on retiring the TS5 checker.
+
+Re-classifying the same 908 rows structurally:
+
+| bucket                                            | count   |
+| ------------------------------------------------- | ------- |
+| same meaning (`any` ≡ `unresolvable`, etc.)       | **136** |
+| in-house weaker (safe abstention, mislabelled)    | **306** |
+| checker weaker (in-house claims MORE — see #4410) | **366** |
+| genuine both-claim-different-facts                | **100** |
+
+Per query:
+
+| query                      | same | inhouse-weaker | checker-weaker | GENUINE |
+| -------------------------- | ---- | -------------- | -------------- | ------- |
+| `declarationsOf`           | 0    | 0              | 34             | 44      |
+| `valueDeclarationOf`       | 0    | 0              | 196            | 24      |
+| `typeFactOf`               | 46   | 10             | 42             | 14      |
+| `signatureOf`              | 90   | 272            | 0              | 12      |
+| `variableDeclarationOf`    | 0    | 0              | 36             | 6       |
+| `isUnresolvableIdentifier` | 0    | 12             | 4              | 0       |
+| `staticJsTypeOf`           | 0    | 0              | 36             | 0       |
+| `isBooleanProducing`       | 0    | 12             | 0              | 0       |
+| `declaredNameOf`           | 0    | 0              | 18             | 0       |
+
+`signatureOf` — the query that dominated the original number, 374 of 908 —
+has **12** genuine conflicts. Its 95.9 % "conflict rate" was a ~100 %
+_abstention_ rate rendered through a broken predicate.
+
+## Second defect: conflicts were unsampleable
+
+`DivergenceLedger.samples` is one FIFO over _all_ divergences, capped at 200
+per file. `weakened` outnumbers `conflicting` roughly 54:1, so the cap fills
+with weakened entries before a single conflict is recorded. On the 2,137-input
+run, 908 conflicts existed and **25** were sampled — none of them from
+`signatureOf`, the query with the highest apparent conflict rate. A worklist
+whose top item is invisible is not a worklist.
+
+Fixed in the same change: a separate `conflictSamples` list with a per-query
+quota (`maxConflictsPerQuery`, default 60). With it, all 908 conflicts are
+recoverable from 237 files.
+
+## Acceptance criteria
+
+- [ ] `isWeaker` is replaced by a structural classifier producing a four-way
+      verdict: `same-meaning` | `inhouse-weaker` | `checker-weaker` |
+      `genuine-conflict`.
+- [ ] The classifier understands composite answers (signature strings, nested
+      generic fact strings), per-query polarity, list emptiness on either side,
+      and `any` ≡ `unresolvable`.
+- [ ] `checker-weaker` is a first-class bucket, not folded into conflicts —
+      "the in-house backend knows more than TypeScript" is a real and frequent
+      outcome (#4410), not a bug signal.
+- [ ] `DivergenceLedger` keeps per-query-quota'd conflict samples
+      (already implemented on `claude/ts7-differential-spike`).
+- [ ] `scripts/audit-oracle-differential.mts` reports the four-way split.
+- [ ] A unit test pins each mis-classification above with a literal answer
+      pair, so the predicate cannot silently regress to string equality.
+
+## Notes
+
+Everything published from the old classifier is wrong by roughly 9× and should
+be restated: the corrected genuine-conflict count is **100**, and the correct
+retirement gate is "genuine-conflict == 0 **and** every `checker-weaker` row
+adjudicated", not "conflicting == 0".

--- a/plan/issues/4409-inhouse-oracle-unsound-in-with-scope.md
+++ b/plan/issues/4409-inhouse-oracle-unsound-in-with-scope.md
@@ -1,0 +1,107 @@
+---
+id: 4409
+title: "In-house oracle is unsound inside `with` — and invents a declared name for `Object.getPrototypeOf`"
+status: ready
+sprint: current
+created: 2026-08-14
+updated: 2026-08-14
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: checker
+language_feature: with
+goal: correctness
+parent: 4218
+depends_on: [4408]
+---
+
+## Problem
+
+Two real violations of the in-house oracle's stated contract — _never widen a
+guess into a fact_ — found by adjudicating the differential run against
+ECMAScript semantics rather than against the TS5 checker's answers.
+
+### 1. Identifiers inside `with` are resolved lexically (unsound)
+
+Minimal repro:
+
+```js
+var x = 0;
+var scope = { x: 1 };
+with (scope) {
+  x = 2;
+}
+```
+
+| query                      | in-house  | TS5 checker | ECMAScript                                             |
+| -------------------------- | --------- | ----------- | ------------------------------------------------------ |
+| `isUnresolvableIdentifier` | **false** | `true`      | must abstain — `x` is `scope.x`, not the outer `var x`  |
+
+`with (obj)` pushes an object Environment Record on the scope chain, so `x`
+resolves to `obj.x` whenever `obj` has the property (modulo
+`obj[Symbol.unscopables]`). Resolution is a **runtime property lookup**; no
+static binder can answer it. The TS5 checker abstains here deliberately, and
+that abstention is the correct answer.
+
+The in-house binder walks lexical scopes and reports the enclosing `var x`.
+Same defect visible on the wide corpus at:
+
+- `language/expressions/assignment/S11.13.1_A5_T1.js` — `variableDeclarationOf(x)`
+  returns the outer `var x` where the test's whole point is that `x` is
+  `scope.x` until `delete scope.x` runs mid-expression.
+- `language/expressions/{arrow-function,async-generator,async-arrow-function}/unscopables-with*.js`
+  — `declarationsOf(count)`, `declarationsOf(v)`, `variableDeclarationOf(v)`,
+  `staticJsTypeOf(count) = number`. The checker returns `[]` / `mixed`; the
+  in-house backend commits.
+
+In the `unscopables` tests the in-house answer happens to be _correct_, because
+`globalThis[Symbol.unscopables].v` is set to `true` and the object binding is
+therefore skipped. That is luck, not soundness — the same code with
+`unscopables` unset resolves the other way, and the backend cannot tell.
+
+`staticJsTypeOf(count) = number` is the dangerous one: it is a **lowering
+decision**. A `with`-scoped name typed as `number` can be emitted as an unboxed
+f64 local when the runtime value is whatever the `with` object holds.
+
+### 2. `declaredNameOf` invents a name for an `any`-typed expression
+
+```js
+var actual = [1, 2, 3];
+Object.getPrototypeOf(actual);
+```
+
+| query            | in-house             | TS5 checker | lib.d.ts                       |
+| ---------------- | -------------------- | ----------- | ------------------------------ |
+| `declaredNameOf` | **`ArrayConstructor`** | `undefined` | `getPrototypeOf(o: any): any`  |
+
+The declared return type is `any`; there is no declared name to report. Seen on
+the wide corpus as `ArrayConstructor` (Array/prototype/flatMap) and
+`FunctionConstructor` (`Object.getPrototypeOf(Intl.DateTimeFormat)`), so the
+backend appears to be naming the *receiver's* constructor rather than the
+call's result.
+
+## Acceptance criteria
+
+- [ ] The in-house binder marks every identifier lexically enclosed by a `with`
+      statement body as **unresolvable**, for all of `valueDeclarationOf`,
+      `variableDeclarationOf`, `declarationsOf`, `staticJsTypeOf`, `typeFactOf`
+      and `isUnresolvableIdentifier`.
+- [ ] The scope is the `with` **body**, transitively through nested functions
+      declared inside it — the corpus hits are in nested functions
+      (`unscopables-with-in-nested-fn.js`).
+- [ ] `declaredNameOf` returns `undefined` when the resolved declaration's type
+      is `any` / not a named type reference; it never names the receiver.
+- [ ] Regression tests: the two repros above, asserted as **abstentions**, not
+      as specific answers.
+- [ ] After the fix, the differential's `checker-weaker` bucket loses the
+      `with` rows and the `declaredNameOf` rows (18).
+
+## Notes
+
+Emitted-code impact measured on 1,804 compilable inputs: 91 differ, net
+box/unbox traffic **0**, bytes −219. So these unsound facts are not currently
+producing visibly worse code — but `staticJsTypeOf → number` on a `with`-scoped
+name is a correctness hazard regardless of what today's codegen happens to do
+with it, and a standalone-mode test262 A/B is running to confirm.

--- a/plan/issues/4410-typescript-is-not-ground-truth.md
+++ b/plan/issues/4410-typescript-is-not-ground-truth.md
@@ -1,0 +1,152 @@
+---
+id: 4410
+title: "TypeScript is not ground truth: 366 oracle queries where the checker is weaker or plainly wrong"
+status: ready
+sprint: current
+created: 2026-08-14
+updated: 2026-08-14
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: research
+area: checker
+goal: correctness
+parent: 4218
+depends_on: [4408]
+---
+
+## Problem
+
+The differential oracle answers from the TS5 checker and records where the
+in-house backend disagrees. That design silently assumes the checker is right.
+It frequently is not — TypeScript is unsound by construction in several places
+a JS compiler cares about, and in this codebase it is additionally answering
+about the **wrong program**.
+
+After re-classifying the 908 reported conflicts structurally (#4408), **366**
+land in a bucket the ledger had no name for: the **in-house backend claims a
+fact the checker declines to give**. Adjudicated against ECMAScript, that
+bucket splits three ways.
+
+## A. The checker is WRONG; the in-house backend is right
+
+### A1 — a local binding resolved to a lib.d.ts global
+
+`built-ins/Array/fromAsync/mapfn-async-throws-close-async-iterator.js` is
+1,199 bytes and contains `let closed = false;` at offset 613.
+
+| query                   | checker                       | in-house  |
+| ----------------------- | ----------------------------- | --------- |
+| `variableDeclarationOf` | `VariableDeclaration@2318733` | `@613`    |
+| `declarationsOf`        | `[VariableDeclaration@2318733]` | `[@613]` |
+
+Offset 2,318,733 is inside the DOM lib (`Window.closed`). The file's own `let`
+is the binding; resolving it to a lib global is a plain resolution error, and
+acting on it would type a local `let` as the DOM's `closed`.
+
+### A2 — a shadowed `eval` / `arguments`
+
+`language/expressions/assignment/dstr/obj-id-init-simple-no-strict.js` opens
+with `var eval, arguments;` (legal in sloppy mode, which the test declares).
+
+| query                | checker                          | in-house                |
+| -------------------- | -------------------------------- | ----------------------- |
+| `valueDeclarationOf(eval)` | lib's `declare function eval` | the file's `var eval` |
+
+Same in `array-elem-init-simple-no-strict.js` (`var argument, eval;`). The
+local `var` shadows the global; the in-house answer is the correct one.
+
+### A3 — a `let` with no initializer
+
+`built-ins/Array/prototype/every/resizable-buffer-grow-mid-iteration.js`:
+`let resizeAfter; let resizeTo;`
+
+| query                   | checker     | in-house |
+| ----------------------- | ----------- | -------- |
+| `variableDeclarationOf(resizeTo)` | `undefined` | the `let` |
+
+Reproduced minimally (`let resizeTo; resizeTo = 4; function use(){return resizeTo}`).
+Nothing dynamic is involved; the checker simply does not answer.
+
+### A4 — the checker is bound to a program that does not contain the code
+
+The annexB direct-eval family (`annexB/language/eval-code/direct/global-*-eval-global-existing-fn-update.js`)
+reports `valueDeclarationOf(f)`: checker `undefined`, in-house
+`FunctionDeclaration`. Parsing the outer file shows **no identifier `f` and no
+node at the reported position** — `f` exists only inside the string passed to
+`eval`. The compiler re-enters on the eval'd source, and the queries are about
+_that_ program's nodes.
+
+The checker's `undefined` is therefore not sound abstention; it is a
+`ts.Program`-scoping artifact. The in-house binder, which binds whatever AST it
+is handed, answers correctly. **This generalises**: any re-entrant compile
+(runtime-eval, `new Function`) is invisible to a checker built for the outer
+program, and the in-house backend is structurally better placed.
+
+## B. The question is under-specified, and both answers are defensible
+
+### B1 — shorthand property assignments
+
+`{ calendar }`, `{ join, getContent, isDir }` (Temporal tests, hono):
+
+| query            | checker                        | in-house              |
+| ---------------- | ------------------------------ | --------------------- |
+| `declarationsOf` | `ShorthandPropertyAssignment`  | the `VariableDeclaration` |
+
+A shorthand property has **two** symbols in TypeScript; `getSymbolAtLocation`
+yields the property symbol and `getShorthandAssignmentValueSymbol` yields the
+value symbol. Neither is wrong. `TypeOracle.declarationsOf` does not say which
+one it wants — an **oracle contract gap**, not a backend bug. For a compiler
+asking "what value flows here", the in-house answer is the useful one.
+
+### B2 — annexB B.3.3 block-level function declarations
+
+`annexB/language/global-code/if-decl-*-global-existing-fn-*.js`: `f` resolves
+to two different `FunctionDeclaration`s (e.g. `@1719` vs `@1567`). Under
+B.3.3.2 the block-level declaration's value is copied into the var-scoped
+binding at evaluation, so which declaration a use site "binds to" depends on
+program point. The oracle has no way to express that; both answers are
+defensible for different points.
+
+## C. The in-house backend is genuinely wrong
+
+Tracked separately in **#4409** (`with`-scoped lexical resolution;
+`declaredNameOf` inventing `ArrayConstructor`).
+
+## Why this matters for retiring the checker
+
+The retirement argument had been "reach conflict parity with the checker".
+That is the wrong goal in two directions:
+
+1. **Parity with an unsound oracle is not the target.** A2/A3/A4 are cases
+   where matching the checker would make the compiler _worse_.
+2. **The real gate is soundness, not agreement.** An oracle answer is
+   acceptable when it is either correct or an abstention. Agreement with TS is
+   evidence, not the definition.
+
+Restated gate for #4218:
+
+- genuine both-claim-different-facts == 0 (currently **100**, #4408), **and**
+- every `checker-weaker` row adjudicated into A (in-house right — keep), B
+  (contract gap — specify the query), or C (in-house wrong — fix), **and**
+- zero standalone-mode test262 regressions under `JS2WASM_ORACLE_BACKEND=inhouse`.
+
+## Acceptance criteria
+
+- [ ] `TypeOracle.declarationsOf` documents whether it means the property
+      symbol or the value symbol for shorthand assignments, and both backends
+      implement the documented meaning (B1).
+- [ ] The oracle documents that answers about re-entrant (eval'd) programs are
+      out of the checker backend's reach (A4), so the differential does not
+      re-report them as in-house defects.
+- [ ] A2/A3 are captured as tests asserting the **in-house** answer, marking
+      the checker backend as the deviant one.
+- [ ] `docs/` records that TS5 checker answers are evidence, not ground truth,
+      with these examples.
+
+## Evidence
+
+Re-classification of the 908 rows, harvested from the 237 conflicting files of
+the 2,137-input corpus (playground + stratified test262 + npm packages):
+136 same-meaning, 306 in-house-weaker, 366 checker-weaker, 100 genuine.

--- a/plan/issues/4411-tsfacade-one-interface-over-ts5-and-ts7.md
+++ b/plan/issues/4411-tsfacade-one-interface-over-ts5-and-ts7.md
@@ -1,0 +1,163 @@
+---
+id: 4411
+title: "TsFacade: one frontend interface over TS5 and TS7, so the implementation can be swapped underneath"
+status: ready
+sprint: current
+created: 2026-08-14
+updated: 2026-08-14
+priority: high
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: compiler
+goal: performance
+parent: 1029
+---
+
+## Problem
+
+TypeScript is ~90 % of compile time and it gates CI. TS7 (`typescript@7.0.2`,
+the Go port) ships an `unstable/*` programmatic API. The question is whether we
+can wrap our use of the TS API behind one interface with TS5 and TS7
+implementations, adopt TS7 now, and adapt the implementation later.
+
+**Yes — and two of the three seams already exist.** What is missing is the AST
+seam. This issue measures what that costs.
+
+## Seams
+
+| seam                | what crosses it                            | today                                     |
+| ------------------- | ------------------------------------------- | ----------------------------------------- |
+| module / lane       | which TS a compile loads, per lane          | `src/ts-api.ts` (#1029) — **exists**       |
+| type queries        | the ~15 questions codegen may ask           | `TypeOracle` (#1930), 3 backends — **exists** |
+| AST + kinds + factory | node shapes, `SyntaxKind`, `ts.factory`   | **missing** — `ts.*` is used directly      |
+
+`TypeOracle` is the important one and it is already the right shape: it is a
+_semantic_ interface (`typeFactOf`, `signatureOf`, `nullabilityOf`…), not a
+mirror of `ts.TypeChecker`. A TS7 backend is a fourth implementation of the
+same 15 methods. The facade this issue adds is the syntactic twin of that.
+
+## Measured constraints
+
+All numbers from `typescript@7.0.2` + `typescript@5.9.3` on this container.
+
+### 1. `SyntaxKind` is renumbered, but the names align
+
+- 386 kind names in TS7, 380 shared with TS5.
+- Values diverge from kind 7 onward (a one-slot shift and further drift):
+  `NumericLiteral` 9 → 8, `StringLiteral` 11 → 10, `FirstAssignment` 64 → 63.
+- **All 33 `First*`/`Last*` marker kinds exist in TS7** with consistent
+  numbering, so the ~20 range checks in `src/` (`kind >= FirstAssignment &&
+  kind <= LastAssignment`, in `ir/select.ts`, `ir/from-ast.ts`,
+  `checker/binder.ts`, `cjs-rewrite.ts`, …) port for free as long as they stay
+  **symbolic**.
+- No numeric-literal kind comparison exists in `src/` today (the `kind === 0`
+  hits in `link/linker.ts` are Wasm import kinds, not `SyntaxKind`).
+- Of the 16 TS5-only names, js2wasm uses exactly one: `EndOfFileToken`
+  (3 sites), renamed `EndOfFile` in TS7.
+
+⇒ The facade must expose kinds symbolically and forbid raw numbers; that is
+already how the codebase is written (3,414 symbolic `SyntaxKind.*` references).
+
+### 2. TS7 ships **no in-process parser**
+
+`typescript7/unstable/ast` exports 409 symbols — `createScanner`, the `is*`
+predicates, `forEachChild`, clone/visitor helpers — but **no parser**. Source
+files are produced by the Go process and deserialized client-side via
+`SourceFileCache`. Reaching an AST therefore requires a live `tsgo` subprocess
+(`new API()` → `updateSnapshot()` → `Project` → `Program.getSourceFile()`).
+
+⇒ This is the hard boundary behind the #1029 lane policy, and it stands: the
+browser lane and the synchronous `runtime-eval` re-entry stay pinned to TS5
+permanently. Node-lane only.
+
+### 3. `ts.factory` maps almost exactly
+
+99 `ts.factory.*` calls across 16 distinct functions; 18 of the 19 checked
+exist in `typescript7/unstable/ast/factory` (370 exports). Only `createThis`
+is absent — `createToken(SyntaxKind.ThisKeyword)`. `visitEachChild` /
+`visitNode` / `visitNodes` exist in `unstable/ast/visitor`, covering
+`array-reduce-fusion.ts`.
+
+### 4. Performance — the earlier "TS7's checker is too slow" call was wrong
+
+Same 5.4 KB input, 2,042 AST nodes under **both** parsers (identical count):
+
+| step                                | TS5      | TS7        |
+| ----------------------------------- | -------- | ---------- |
+| parse only (`createSourceFile`)     | 8.7 ms   | n/a        |
+| program + checker ready             | 1,825 ms | **154 ms** |
+| one `getTypeAtLocation`, unbatched  | 0.051 ms | 0.052 ms   |
+| same query, **batched** (500 nodes) | n/a      | **0.008 ms** |
+
+Two corrections to what was previously recorded on #4218/#1029:
+
+- TS7's IPC checker is **not** slower per query than TS5's in-process one; it
+  is the same, and 6.5× faster when batched. `Checker.getTypeAtLocation`,
+  `getSymbolAtLocation` and `getTypeAtPosition` all take **arrays**, so a
+  compile's ~15 k queries are a handful of round trips, not 15 k. The earlier
+  "≈1.8 s of IPC per compile" figure does not hold.
+- The 12× win is **program construction**, which is exactly the 90 % the
+  premise named.
+
+⇒ TS7's checker is not a blocker for the Node lane. The in-house oracle work
+(#4218) remains valuable — it is what makes the browser and eval lanes
+checker-free — but it is no longer a _precondition_ for the TS7 swap.
+
+## Design
+
+```ts
+interface TsFacade {
+  readonly kinds: KindTable;              // symbolic only; never numeric
+  readonly is: NodePredicates;            // isIdentifier, isCallExpression, …
+  readonly factory: NodeFactory;          // the 16 constructors actually used
+  readonly visitor: { visitEachChild; visitNode; visitNodes };
+  parse(fileName: string, text: string): SourceFile;
+  program(rootNames: string[], options: CompilerOptions): ProgramHandle;
+  resolveModule(name: string, containingFile: string): Resolved | undefined;
+  readConfig(path: string): ParsedConfig;
+}
+```
+
+Two implementations, `Ts5Facade` and `Ts7Facade`, selected by
+`ts-api.ts`'s existing lane policy (`isTs7Active()`).
+
+**A compile is all-or-nothing per frontend.** A TS5 checker cannot answer
+questions about tsgo AST nodes, so the facade choice is made once per compile
+and never mixed.
+
+## Staging
+
+1. **Kinds + predicates + factory** — mechanical, no behavior change. Land
+   against TS5 first so the facade is exercised before TS7 exists behind it.
+   Adds the `EndOfFileToken`/`EndOfFile` and `createThis` shims.
+2. **AST shape adapter** — the node-shape surface codegen touches. Node counts
+   and `forEachChild` traversal match on the probe input; field-by-field parity
+   is the real work and needs its own audit.
+3. **`Ts7Oracle`** — a fourth `TypeOracle` backend over `Checker`, using the
+   **batched** overloads. Validate with the existing differential lane
+   (`oracleBackend: "differential"`), same instrument as #4408/#4410.
+4. **Module resolution + config** — `API.parseConfigFile` replaces
+   `ts.readConfigFile`/`parseJsonConfigFileContent`; `src/resolve.ts` and
+   `src/checker/language-service.ts` are the remaining TS5-API consumers.
+
+## Acceptance criteria
+
+- [ ] `src/ts-facade/` with `TsFacade`, `Ts5Facade`, and the selector wired to
+      `ts-api.ts`'s lane policy.
+- [ ] A gate that fails on new direct `ts.SyntaxKind` numeric comparisons and
+      on new direct `ts.factory` use outside the facade (same shape as the
+      oracle ratchet).
+- [ ] `Ts7Facade` behind `JS2WASM_TS7`, Node lane only; browser and
+      runtime-eval provably still on TS5 (tests in
+      `tests/issue-1029-ts7-lane-policy.test.ts` already pin the policy).
+- [ ] A benchmark comparing end-to-end compile wall-clock TS5 vs TS7 on the
+      playground corpus, published alongside the numbers above.
+
+## Notes
+
+Probe script used for the measurements: `.tmp/ts7-ast-probe.mts` (kind
+alignment, factory coverage, parser absence, batched vs unbatched query cost).
+It should move to `scripts/` as part of step 1 so the numbers are reproducible
+in CI rather than quoted from a session.

--- a/scripts/audit-oracle-differential.mts
+++ b/scripts/audit-oracle-differential.mts
@@ -282,12 +282,13 @@ for (const input of corpus) {
     t.conflicting += v.conflicting;
     totalsByQuery.set(q, t);
   }
-  for (const d of globalDivergenceLedger.samples) {
-    // Samples include weakened ones; keep only genuine conflicts (bugs).
-    const weak = ["unresolvable", "undefined", "mixed", "[]"].includes(d.inhouse);
-    if (!weak && conflictSamples.length < sampleLimit) {
-      conflictSamples.push({ file: input.name, ...d });
-    }
+  // (#4408) Read the ledger's per-query-quota'd conflict list, NOT `samples`.
+  // `samples` is one FIFO over every divergence and `weakened` outnumbers
+  // `conflicting` ~54:1, so the shared cap fills with weakened entries before
+  // a single conflict is recorded — the 2,137-input run surfaced 25 of 908,
+  // none from `signatureOf`, the query with the highest conflict count.
+  for (const d of globalDivergenceLedger.conflictSamples) {
+    if (conflictSamples.length < sampleLimit) conflictSamples.push({ file: input.name, ...d });
   }
 }
 
@@ -307,8 +308,19 @@ console.log(
   `  weakened    ${String(grand.weakened).padStart(7)}  (${pct(grand.weakened)}%)   inhouse declined — safe, lossy`,
 );
 console.log(
-  `  CONFLICTING ${String(grand.conflicting).padStart(7)}  (${pct(grand.conflicting)}%)   inhouse claimed a DIFFERENT fact — bug`,
+  `  CONFLICTING ${String(grand.conflicting).padStart(7)}  (${pct(grand.conflicting)}%)   both answered and the answers differ`,
 );
+// (#4408) This bucket is NOT a bug count. `isWeaker` only recognises an
+// abstention when the WHOLE answer string is one of four literals, so it
+// mislabels weakening nested in a composite (`(unresolvable)->unresolvable#1`),
+// weakening carried by a boolean polarity (`isBooleanProducing: false`), and
+// weakening on the CHECKER side (`declarationsOf: []`). Re-classifying the
+// 2,137-input run structurally turned 908 "conflicts" into 136 same-meaning,
+// 306 inhouse-weaker, 366 checker-weaker and 100 genuine. And a genuine
+// conflict still is not automatically an in-house bug — TypeScript is unsound
+// for `with`, direct `eval` and annexB hoisting, and is bound to a program
+// that excludes re-entrant eval'd sources (#4410).
+console.log("  (see #4408 — this classifier over-reports ~9x; #4410 — the checker is not ground truth)");
 
 console.log("\n--- by query (the worklist) ---");
 const qw = Math.max(...[...totalsByQuery.keys()].map((k) => k.length), 12);
@@ -322,7 +334,7 @@ for (const [q, v] of [...totalsByQuery].sort(
 }
 
 if (conflictSamples.length > 0) {
-  console.log("\n--- conflicting samples (these are bugs, not weakening) ---");
+  console.log("\n--- conflicting samples (adjudicate each; see #4408 / #4410) ---");
   for (const c of conflictSamples) {
     console.log(`  ${c.file}  ${c.query}`);
     console.log(`      checker=${c.checker}  inhouse=${c.inhouse}  node=${c.node}`);

--- a/src/checker/oracle-backend.ts
+++ b/src/checker/oracle-backend.ts
@@ -90,10 +90,25 @@ export class DivergenceLedger {
    * vocabulary (~15 names plus `propertyFactOf:<name>`), not the node count.
    */
   readonly byQuery = new Map<string, QueryDivergence>();
+  /**
+   * (#4218) Conflict samples, quota'd PER QUERY.
+   *
+   * `samples` cannot serve this purpose: it is a single FIFO over *all*
+   * divergences, and `weakened` outnumbers `conflicting` ~54:1 on a wide
+   * corpus — so the shared cap fills with weakened entries before a single
+   * conflict is seen. Measured on the 2,137-input run: 908 conflicts existed
+   * and 25 were sampled, none of them from `signatureOf`, the query with the
+   * *highest* conflict rate. A worklist you cannot see the top item of is not
+   * a worklist.
+   */
+  readonly conflictSamples: OracleDivergence[] = [];
+  private readonly conflictQuota = new Map<string, number>();
   private readonly maxSamples: number;
+  private readonly maxConflictsPerQuery: number;
 
-  constructor(maxSamples = 200) {
+  constructor(maxSamples = 200, maxConflictsPerQuery = 60) {
     this.maxSamples = maxSamples;
+    this.maxConflictsPerQuery = maxConflictsPerQuery;
   }
 
   private tally(query: string): QueryDivergence {
@@ -118,6 +133,11 @@ export class DivergenceLedger {
     } else {
       this.conflicting++;
       perQuery.conflicting++;
+      const used = this.conflictQuota.get(query) ?? 0;
+      if (used < this.maxConflictsPerQuery) {
+        this.conflictQuota.set(query, used + 1);
+        this.conflictSamples.push({ query, checker: checkerAnswer, inhouse: inhouseAnswer, node });
+      }
     }
     if (this.samples.length < this.maxSamples) {
       this.samples.push({ query, checker: checkerAnswer, inhouse: inhouseAnswer, node });
@@ -135,6 +155,8 @@ export class DivergenceLedger {
     this.weakened = 0;
     this.conflicting = 0;
     this.samples.length = 0;
+    this.conflictSamples.length = 0;
+    this.conflictQuota.clear();
     this.byQuery.clear();
   }
 }

--- a/tests/issue-4408-conflict-sampling.test.ts
+++ b/tests/issue-4408-conflict-sampling.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4408 — conflicts must be sampleable independently of weakenings.
+//
+// `DivergenceLedger.samples` is one FIFO over every divergence. On a real
+// corpus `weakened` outnumbers `conflicting` roughly 54:1, so the shared cap
+// fills with weakened entries before a single conflict is recorded: the
+// 2,137-input differential run had 908 conflicts and surfaced 25, none of them
+// from `signatureOf` — the query with the highest conflict count. A worklist
+// whose top item is invisible is not a worklist.
+//
+// These tests pin the separate, per-query-quota'd conflict list.
+import { describe, expect, it } from "vitest";
+import { DivergenceLedger } from "../src/checker/oracle-backend.ts";
+
+describe("#4408 DivergenceLedger conflict sampling", () => {
+  it("records conflicts even when weakenings have exhausted the shared sample cap", () => {
+    const ledger = new DivergenceLedger(4);
+    for (let i = 0; i < 20; i++) ledger.record("typeFactOf", "number", "unresolvable", `weak${i}`);
+    ledger.record("signatureOf", "(number)->number#1", "(string)->string#1", "conflict");
+
+    // The shared FIFO is full of weakenings and never saw the conflict...
+    expect(ledger.samples).toHaveLength(4);
+    expect(ledger.samples.every((s) => s.inhouse === "unresolvable")).toBe(true);
+    // ...but the conflict list did.
+    expect(ledger.conflictSamples).toHaveLength(1);
+    expect(ledger.conflictSamples[0]).toMatchObject({ query: "signatureOf", node: "conflict" });
+  });
+
+  it("quotas conflicts per query so one noisy query cannot starve the others", () => {
+    const ledger = new DivergenceLedger(200, 2);
+    for (let i = 0; i < 10; i++) ledger.record("signatureOf", "a", "b", `sig${i}`);
+    ledger.record("declaredNameOf", "undefined", "ArrayConstructor", "named");
+
+    const queries = ledger.conflictSamples.map((s) => s.query);
+    expect(queries.filter((q) => q === "signatureOf")).toHaveLength(2);
+    expect(queries).toContain("declaredNameOf");
+  });
+
+  it("counts every conflict even when only some are sampled", () => {
+    const ledger = new DivergenceLedger(200, 2);
+    for (let i = 0; i < 10; i++) ledger.record("signatureOf", "a", "b", `sig${i}`);
+
+    expect(ledger.summary().conflicting).toBe(10);
+    expect(ledger.byQuery.get("signatureOf")).toMatchObject({ conflicting: 10 });
+    expect(ledger.conflictSamples).toHaveLength(2);
+  });
+
+  it("reset() clears the conflict list and its per-query quota", () => {
+    const ledger = new DivergenceLedger(200, 1);
+    ledger.record("signatureOf", "a", "b", "first");
+    ledger.record("signatureOf", "a", "c", "second"); // over quota, dropped
+    expect(ledger.conflictSamples).toHaveLength(1);
+
+    ledger.reset();
+    expect(ledger.conflictSamples).toHaveLength(0);
+    // Quota must reset too, or the next corpus file records nothing.
+    ledger.record("signatureOf", "a", "d", "after-reset");
+    expect(ledger.conflictSamples).toHaveLength(1);
+    expect(ledger.conflictSamples[0].node).toBe("after-reset");
+  });
+});


### PR DESCRIPTION
## Description

Adjudicates the differential-oracle findings against **ECMAScript semantics** instead of against the TS5 checker's answers, fixes the instrument that produced the wrong headline number, and files the findings as issues.

### The instrument was wrong (fixed here)

`DivergenceLedger.isWeaker` tests the **whole** answer string against four literals, which is only correct for scalar answers. It mislabels four kinds of abstention:

- nested in a composite — `(unresolvable)->unresolvable#1`, `array<any>`
- carried by a boolean polarity — `isBooleanProducing: false`, `isUnresolvableIdentifier: true`
- on the **checker** side — `declarationsOf: []`
- `any` scored as a fact, when it carries no information for a wasm lowerer

Re-classifying the same 908 rows from the 2,137-input run structurally:

| bucket | count |
| --- | --- |
| same meaning (`any` ≡ `unresolvable`) | 136 |
| in-house weaker (safe, mislabelled) | 318 |
| checker weaker (in-house claims more) | 366 |
| **genuine both-claim-different-facts** | **88** |

`signatureOf` — 374 of the original 908, reported at a "95.9 % conflict rate" — has **zero** genuine conflicts. Every one of those rows is a total in-house abstention or the same answer spelled differently. All 88 genuine conflicts sit in four binding-resolution queries: `declarationsOf` (44), `valueDeclarationOf` (24), `typeFactOf` (14), `variableDeclarationOf` (6).

> The counts above are from the landed structural classifier. An earlier draft of this description said 306 / 100 / 12, produced by a first-cut classifier that could not match composites of differing shape (`(any,number,array<any>)->boolean#3` against `(unresolvable,unresolvable,unresolvable)->unresolvable#3`). The total-abstention rule resolves those; the numbers here supersede it.

**Second defect, also fixed:** conflicts were unsampleable. `samples` is one FIFO over every divergence and weakened outnumbers conflicting ~54:1, so the cap filled with weakenings before a single conflict was recorded — 25 of 908 sampled, none from `signatureOf`. Adds `conflictSamples` with a per-query quota; `scripts/audit-oracle-differential.mts` now reads it, and its "these are bugs" wording is corrected.

### Findings filed

- **#4408** — the classifier bug above, with the corrected per-query table and the restated retirement gate.
- **#4409** — the in-house oracle *is* genuinely unsound in two places, both with minimal repros: it resolves identifiers inside `with (obj)` lexically (ECMAScript needs a runtime property lookup, modulo `Symbol.unscopables`), including `staticJsTypeOf → number`, which is a lowering decision; and `declaredNameOf` invents `ArrayConstructor` for `Object.getPrototypeOf(x)`, whose declared type is `any`.
- **#4410** — TypeScript is not ground truth. 366 queries where the checker is weaker or plainly wrong: a local `let closed` resolved to a lib.dom global 2.3 MB into `lib.d.ts`; a sloppy-mode `var eval` resolved to lib's `declare function eval`; a `let` with no initializer left unanswered; and eval'd sources the checker's `ts.Program` does not contain. Also two under-specified queries (shorthand property assignments; annexB B.3.3 block functions) where both answers are defensible and the *oracle contract* is the gap.
- **#4411** — `TsFacade`, one frontend interface over TS5 and TS7. Measured: TS7 renumbers `SyntaxKind` but shares 380/386 names and **all 33** `First*`/`Last*` markers; ships **no in-process parser** (scanner only — the AST arrives from tsgo over IPC); 18/19 used `ts.factory` functions present. Corrects the earlier "TS7's checker is too slow for the hot path" call — it matches TS5 per query (0.052 ms vs 0.051 ms) and is **6.5× faster batched** (0.008 ms), while reaching a typed program **12× faster** (154 ms vs 1,825 ms).

### Emitted-code impact

Across 1,804 compilable inputs under both backends: 91 differ, net box/unbox traffic **0**, bytes −219. A standalone-mode (`TEST262_TARGET=standalone`, quickjs) full test262 A/B is running to confirm conformance.

### Follow-up

A second PR lands the structural classifier itself (`src/checker/divergence-classifier.ts`, replacing `isWeaker`) and promotes the two probe scripts out of `.tmp/` into `scripts/audit-oracle-adjudication.mts` and `scripts/audit-ts7-api-surface.mts`, so every number above is reproducible from a command. It is held until this PR clears the merge queue.

## CLA

- [x] I have read and agree to the CLA