### PR TITLE
fix(#4412) + perf(#4413): guard the committed trend index, and parallelise the unit suite (2x)

### DIFF
--- a/plan/issues/4412-scoped-test262-run-writes-committed-trend-index.md
+++ b/plan/issues/4412-scoped-test262-run-writes-committed-trend-index.md
@@ -1,0 +1,88 @@
+---
+id: 4412
+title: "A scoped local test262 run silently writes the committed trend index"
+status: done
+sprint: current
+created: 2026-08-14
+updated: 2026-08-14
+completed: 2026-08-14
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: low
+task_type: bug
+area: ci
+goal: correctness
+---
+
+## Problem
+
+`scripts/run-test262-vitest.sh` appends a summary row to
+`benchmarks/results/runs/index.json` whenever a run reaches `COMPLETED`. That
+file is **committed** and is what the report page reads for its conformance
+trend graph.
+
+The append had no notion of a **scoped** run. The runner supports two
+scope-narrowing knobs:
+
+- `TEST262_PATH_FILTER` — pipe-separated substrings, applied per test
+- `TEST262_LOCAL_SHARD_GLOB` — run a subset of the 16 shard files
+
+With either set, the run still reaches `COMPLETED`, and the row it posts is a
+**partial total presented as a full pass**.
+
+## Observed
+
+2026-08-14, during the #4218 oracle A/B: a single-shard local run appended
+
+```json
+{ "timestamp": "20260814-165702", "pass": 1902, "fail": 573, "ce": 236,
+  "skip": 1, "total": 2713, "strict_pass": 1782, "strict_total": 2556 }
+```
+
+next to real ~30,000-test entries. The planned 32-invocation sharded
+experiment would have written 32 such rows.
+
+**Nothing downstream would have caught it.** The row is well-formed and
+schema-valid; only its *meaning* is wrong. It surfaced solely because a local
+stop hook noticed `git status` was dirty — which is not a control, and would
+not have fired in a context that commits routinely or in CI.
+
+## Fix
+
+`scripts/should-publish-run-history.mjs` — a single decision function, called
+by the runner (exit 0 = publish, 1 = skip, reason on stdout):
+
+| condition                                | result                  |
+| ---------------------------------------- | ----------------------- |
+| no scope var set                         | publish                 |
+| `TEST262_LOCAL_SHARD_GLOB` = the default | publish                 |
+| `TEST262_PATH_FILTER` non-empty          | **skip**                |
+| `TEST262_LOCAL_SHARD_GLOB` narrowed      | **skip**                |
+| `TEST262_PUBLISH_HISTORY=1`              | publish, naming the scope |
+| `TEST262_PUBLISH_HISTORY=0`              | skip                    |
+
+The default is to **refuse**: a scoped run has to opt in, not opt out. Only
+the literal `"1"` forces publication — `"yes"`/`"true"` are treated as unset,
+so a sloppy override cannot smuggle a partial row through.
+
+The decision lives in its own module rather than inline in the shell script so
+it is unit-testable; a guard nobody can test is a guard that rots.
+
+## Acceptance criteria
+
+- [x] A path-filtered run does not append to `runs/index.json`.
+- [x] A narrowed-shard-glob run does not append.
+- [x] An unscoped run still appends (no behaviour change for CI or a real
+      local full run).
+- [x] The skip prints why, so it does not read as a failure.
+- [x] `TEST262_PUBLISH_HISTORY=1` can force it; only the literal `"1"` counts.
+- [x] Unit tests in `tests/issue-4412-run-history-guard.test.ts`, including
+      the exact single-shard case that produced the bad row.
+
+## Notes
+
+Found while running a scoped standalone A/B for #4218/#4410 on a container
+where a full pass is ~8h per backend. The same class of hazard applies to any
+artifact a local run can write — worth a sweep of the other
+`benchmarks/results/` writers for scope-awareness.

--- a/plan/issues/4413-unit-suite-runs-serially-one-fork.md
+++ b/plan/issues/4413-unit-suite-runs-serially-one-fork.md
@@ -1,0 +1,97 @@
+---
+id: 4413
+title: "The unit suite runs strictly serially — maxForks=1 with no describe.concurrent to compensate"
+status: done
+sprint: current
+created: 2026-08-14
+updated: 2026-08-14
+completed: 2026-08-14
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: performance
+area: ci
+goal: velocity
+---
+
+## Problem
+
+`vitest.config.ts` pinned `poolOptions.forks.maxForks = 1`, commented as
+
+> Each test file gets its own fork process … (same strategy as the test262
+> chunk runner). maxForks=1 ensures only one fork at a time (no parallel OOM).
+
+That reads the test262 runner backwards. test262's throughput does **not**
+come from forks — it comes from `describe.concurrent` plus a CompilerPool of
+worker processes running *inside* a single fork, which is exactly what the
+neighbouring `maxConcurrency: 32` is for.
+
+The unit suite inherited the one-fork restriction **without** the compensating
+mechanism. Measured: **0 of 2,928** files under `tests/` use
+`describe.concurrent` or `it.concurrent`, so `maxConcurrency: 32` does nothing
+for any of them. The suite therefore ran strictly serially — one file at a
+time, one test at a time — using ~25 % of a 4-core box.
+
+## Measurements
+
+24 representative files (`tests/issue-30xx*.test.ts`), 164 tests, on 4 cores /
+16 GB. **Identical results at every setting** (155 passed / 9 failed), so this
+is pure scheduling, not flakiness:
+
+| `maxForks` | wall   | speedup | peak RAM        |
+| ---------- | ------ | ------- | --------------- |
+| 1          | 229 s  | 1.00x   | —               |
+| 3          | 117 s  | 1.96x   | —               |
+| 4          | 110 s  | 2.08x   | —               |
+| 8          | 116 s  | 1.97x   | 5.7 GB of 16 GB |
+
+Two things fall out:
+
+- **The OOM concern does not hold at these fork counts.** Eight concurrent
+  forks peaked at 5.7 GB of 16 GB, with `--max-old-space-size=512` per fork
+  (CI raises it to 1024).
+- **Past 4 there is nothing to win** on a 4-core box; 8 is marginally slower
+  than 4 from context-switching.
+
+## Fix
+
+`maxForks` is now derived:
+
+```ts
+const isTest262Run = Boolean(process.env.TEST262_TARGET || process.env.TEST262_RESULT_PREFIX);
+const maxForks = isTest262Run ? 1 : Math.max(1, Number(process.env.VITEST_MAX_FORKS) || availableParallelism() - 1);
+```
+
+`parallelism - 1` leaves a core for the editor/agent; `VITEST_MAX_FORKS`
+overrides for constrained environments.
+
+**test262 runs stay pinned to 1, and that half of the original reasoning IS
+load-bearing.** `run-test262-vitest.sh` hands vitest 16 shard files, each of
+which spins up its own CompilerPool. Three shard files at once would put ~9
+compiler workers on 4 cores — oversubscribed, and the memory profile the
+single-fork rule was genuinely protecting. The carve-out keys off the env vars
+that runner already exports.
+
+## Acceptance criteria
+
+- [x] The unit suite parallelises across files by default.
+- [x] test262 runs still use exactly one fork.
+- [x] `VITEST_MAX_FORKS` overrides the default.
+- [x] Results unchanged — same pass/fail set at 1, 3, 4 and 8 forks.
+
+## Follow-up (not done here)
+
+The bigger remaining lever is **intra-file** concurrency: with 0 of 2,928
+files using `describe.concurrent`, every test within a file still runs
+sequentially even though `maxConcurrency: 32` is already configured and the
+CompilerPool can absorb the load. Compile-and-assert tests are largely
+independent, so converting the heaviest files is likely worth more than the
+2x won here. Wants its own issue and a per-file audit — some tests share
+module-level state and would need isolating first.
+
+Also unrelated but observed while measuring: `tests/issue-3009.test.ts`,
+`tests/issue-3014.test.ts`, `tests/issue-3000-c.test.ts` and
+`tests/issue-3017-function-poison-pill.test.ts` fail on `origin/main` today
+(9 tests). Pre-existing, not caused by this change — verified by running them
+in a clean worktree at `origin/main`.

--- a/scripts/run-test262-vitest.sh
+++ b/scripts/run-test262-vitest.sh
@@ -386,8 +386,35 @@ if [ "$COMPLETED" = true ]; then
   echo "Results: $RUN_JSONL"
   echo "Symlinks updated."
 
-  # Append to historical index
-  if [ -f "$RUN_REPORT" ]; then
+  # Append to historical index.
+  #
+  # (#4412) ONLY for a full-corpus run. `runs/index.json` is COMMITTED and
+  # feeds the report page's conformance trend graph, but this append had no
+  # notion of a scoped run: with `TEST262_PATH_FILTER` or a narrowed
+  # `TEST262_LOCAL_SHARD_GLOB`, a partial run posted a partial total as if it
+  # were a full pass. Measured 2026-08-14: a single-shard local run wrote
+  # `pass: 1902 / total: 2713` beside real ~30,000-test entries, and a
+  # 32-invocation sharded experiment would have written 32 such rows. Nothing
+  # in CI would have caught it — it surfaced only because a local stop hook
+  # noticed the dirty file.
+  #
+  # Default is to REFUSE when the run is scoped. `TEST262_PUBLISH_HISTORY=1`
+  # forces the append for the rare case where a deliberately scoped run should
+  # still be recorded; `TEST262_PUBLISH_HISTORY=0` suppresses it outright.
+  # The decision lives in scripts/should-publish-run-history.mjs so it can be
+  # unit-tested; exit 0 = publish, 1 = skip, reason on stdout.
+  if PUBLISH_REASON=$(TEST262_LOCAL_SHARD_GLOB="$LOCAL_SHARD_GLOB" \
+      node "$MAIN_DIR/scripts/should-publish-run-history.mjs"); then
+    PUBLISH_HISTORY=1
+  else
+    PUBLISH_HISTORY=0
+  fi
+
+  if [ "$PUBLISH_HISTORY" != "1" ]; then
+    echo "Historical index: SKIPPED — $PUBLISH_REASON."
+    echo "  runs/index.json is committed and drives the trend graph; a partial"
+    echo "  run must not post a partial total. Override with TEST262_PUBLISH_HISTORY=1."
+  elif [ -f "$RUN_REPORT" ]; then
     RUNS_DIR="$RESULTS_DIR/runs"
     mkdir -p "$RUNS_DIR"
     INDEX_FILE="$RUNS_DIR/index.json"

--- a/scripts/should-publish-run-history.mjs
+++ b/scripts/should-publish-run-history.mjs
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4412) Decide whether a finished test262 run may append to
+ * `benchmarks/results/runs/index.json`.
+ *
+ * That file is COMMITTED and drives the report page's conformance trend graph,
+ * so only a FULL-CORPUS run belongs in it. The append used to be
+ * unconditional-on-completion, with no notion of a scoped run: with
+ * `TEST262_PATH_FILTER` or a narrowed `TEST262_LOCAL_SHARD_GLOB`, a partial
+ * run posted a partial total as if it were a full pass. Measured 2026-08-14, a
+ * single-shard local run wrote `pass: 1902 / total: 2713` next to real
+ * ~30,000-test entries, and a 32-invocation sharded experiment would have
+ * written 32 such rows. Nothing in CI catches this — the row is well-formed,
+ * just wrong — so the guard has to live at the write site.
+ *
+ * Lives in its own file rather than inline in `run-test262-vitest.sh` so the
+ * decision is unit-testable; a guard nobody can test is a guard that rots.
+ *
+ * Exit code is the answer: 0 = publish, 1 = skip. The reason goes to stdout.
+ *
+ * Usage (from the runner):
+ *   node scripts/should-publish-run-history.mjs
+ */
+
+import { pathToFileURL } from "node:url";
+
+/** The unnarrowed default in `run-test262-vitest.sh`. */
+export const FULL_SHARD_GLOB = "tests/test262-local-shard*.test.ts";
+
+/**
+ * @param {Record<string, string | undefined>} env
+ * @returns {{ publish: boolean; reason: string }}
+ */
+export function shouldPublishRunHistory(env) {
+  const explicit = env.TEST262_PUBLISH_HISTORY;
+  // An explicit 0 wins over everything: "do not record this run".
+  if (explicit === "0") return { publish: false, reason: "TEST262_PUBLISH_HISTORY=0" };
+
+  const filter = (env.TEST262_PATH_FILTER ?? "").trim();
+  const glob = (env.TEST262_LOCAL_SHARD_GLOB ?? "").trim();
+  let scope = "";
+  if (filter) scope = `TEST262_PATH_FILTER=${filter}`;
+  else if (glob && glob !== FULL_SHARD_GLOB) scope = `TEST262_LOCAL_SHARD_GLOB=${glob}`;
+
+  // An explicit 1 forces the append even for a deliberately scoped run, but
+  // still says so, because the resulting row will not be comparable.
+  if (explicit === "1") {
+    return {
+      publish: true,
+      reason: scope ? `TEST262_PUBLISH_HISTORY=1 overrides scope (${scope})` : "full-corpus run",
+    };
+  }
+  if (scope) return { publish: false, reason: `scoped run (${scope})` };
+  return { publish: true, reason: "full-corpus run" };
+}
+
+// Only act as a CLI when invoked directly, so the test can import it freely.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { publish, reason } = shouldPublishRunHistory(process.env);
+  console.log(reason);
+  process.exit(publish ? 0 : 1);
+}

--- a/tests/issue-4412-run-history-guard.test.ts
+++ b/tests/issue-4412-run-history-guard.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4412 — a scoped test262 run must not append to the committed trend index.
+//
+// `benchmarks/results/runs/index.json` is committed and drives the report
+// page's conformance trend graph. The append in `run-test262-vitest.sh` used
+// to fire on any completed run, with no notion of scope, so a partial run
+// posted a partial total as if it were a full pass. Observed 2026-08-14: a
+// single-shard local run wrote `pass: 1902 / total: 2713` beside real
+// ~30,000-test rows. The row is well-formed, so no downstream check rejects
+// it — the only defence is refusing to write it.
+import { describe, expect, it } from "vitest";
+import { FULL_SHARD_GLOB, shouldPublishRunHistory } from "../scripts/should-publish-run-history.mjs";
+
+describe("#4412 run-history publish guard", () => {
+  it("publishes an unscoped full-corpus run", () => {
+    expect(shouldPublishRunHistory({})).toMatchObject({ publish: true });
+    expect(shouldPublishRunHistory({ TEST262_LOCAL_SHARD_GLOB: FULL_SHARD_GLOB })).toMatchObject({ publish: true });
+  });
+
+  it("refuses a path-filtered run", () => {
+    const v = shouldPublishRunHistory({ TEST262_PATH_FILTER: "with|annexB" });
+    expect(v.publish).toBe(false);
+    // The reason must name the variable, or the skip looks like a bug.
+    expect(v.reason).toContain("TEST262_PATH_FILTER");
+  });
+
+  it("refuses a narrowed shard glob — the exact 2026-08-14 case", () => {
+    const v = shouldPublishRunHistory({ TEST262_LOCAL_SHARD_GLOB: "tests/test262-local-shard1.test.ts" });
+    expect(v.publish).toBe(false);
+    expect(v.reason).toContain("shard1");
+  });
+
+  it("ignores an empty or whitespace filter — that is not a scope", () => {
+    expect(shouldPublishRunHistory({ TEST262_PATH_FILTER: "" })).toMatchObject({ publish: true });
+    expect(shouldPublishRunHistory({ TEST262_PATH_FILTER: "   " })).toMatchObject({ publish: true });
+    expect(shouldPublishRunHistory({ TEST262_LOCAL_SHARD_GLOB: "" })).toMatchObject({ publish: true });
+  });
+
+  it("lets an explicit 1 override the scope, but says the run was scoped", () => {
+    const v = shouldPublishRunHistory({ TEST262_PATH_FILTER: "with", TEST262_PUBLISH_HISTORY: "1" });
+    expect(v.publish).toBe(true);
+    expect(v.reason).toContain("TEST262_PATH_FILTER=with");
+  });
+
+  it("lets an explicit 0 suppress an otherwise-publishable full run", () => {
+    expect(shouldPublishRunHistory({ TEST262_PUBLISH_HISTORY: "0" })).toMatchObject({ publish: false });
+  });
+
+  it("treats a junk TEST262_PUBLISH_HISTORY as unset, not as consent", () => {
+    // Only "1" forces. Anything else must not smuggle a scoped run through.
+    expect(shouldPublishRunHistory({ TEST262_PATH_FILTER: "with", TEST262_PUBLISH_HISTORY: "yes" })).toMatchObject({
+      publish: false,
+    });
+    expect(shouldPublishRunHistory({ TEST262_PATH_FILTER: "with", TEST262_PUBLISH_HISTORY: "true" })).toMatchObject({
+      publish: false,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,39 @@
+import { availableParallelism } from "node:os";
 import { defineConfig } from "vitest/config";
 
 const forkMaxOldSpaceSize = process.env.VITEST_FORK_MAX_OLD_SPACE_SIZE || "512";
+
+/**
+ * (#4413) How many test files may run at once.
+ *
+ * This was hard-wired to 1, described as "the same strategy as the test262
+ * chunk runner". It is not: test262's throughput comes from
+ * `describe.concurrent` plus a CompilerPool of worker processes running
+ * INSIDE one fork. The unit suite inherited the one-fork restriction without
+ * that compensating mechanism — and **0 of its 2,928 files use
+ * `describe.concurrent`**, so `maxConcurrency: 32` below does nothing for
+ * them. The result was a strictly serial suite: one file at a time, one test
+ * at a time, ~25% utilisation of a 4-core box.
+ *
+ * Measured on 24 representative files (4 cores / 16 GB), identical results
+ * (155 passed / 9 failed) at every setting:
+ *
+ *   maxForks=1   229 s   1.00x
+ *   maxForks=4   110 s   2.08x
+ *   maxForks=8   116 s   1.97x   peak 5.7 GB of 16 GB
+ *
+ * So the OOM worry does not hold at these fork counts, and past 4 there is
+ * nothing left to win on 4 cores. Default to `parallelism - 1`, leaving a
+ * core for the editor/agent; `VITEST_MAX_FORKS` overrides.
+ *
+ * **test262 runs stay at 1**, and that part of the original reasoning IS
+ * load-bearing: `run-test262-vitest.sh` hands vitest 16 shard files, each of
+ * which spins up its own CompilerPool. Letting three of those run at once
+ * would put ~9 compiler workers on 4 cores — oversubscribed, and the memory
+ * profile the single-fork rule was actually protecting.
+ */
+const isTest262Run = Boolean(process.env.TEST262_TARGET || process.env.TEST262_RESULT_PREFIX);
+const maxForks = isTest262Run ? 1 : Math.max(1, Number(process.env.VITEST_MAX_FORKS) || availableParallelism() - 1);
 
 export default defineConfig({
   test: {
@@ -26,10 +59,10 @@ export default defineConfig({
     poolOptions: {
       forks: {
         // Each test file gets its own fork process — when it finishes, the OS
-        // reclaims all memory (same strategy as the test262 chunk runner).
-        // maxForks=1 ensures only one fork at a time (no parallel OOM).
+        // reclaims all memory. See the `maxForks` derivation above for why
+        // this is no longer pinned to 1 outside test262 runs.
         singleFork: false,
-        maxForks: 1,
+        maxForks,
         minForks: 0,
         execArgv: [`--max-old-space-size=${forkMaxOldSpaceSize}`, "--expose-gc"],
       },


### PR DESCRIPTION
## Description

Two independent fixes, both found while running the #4218 oracle A/B on this container.

### #4412 — a scoped test262 run could write the committed trend index

`run-test262-vitest.sh` appended a summary row to `benchmarks/results/runs/index.json` on any `COMPLETED` run. That file is **committed** and drives the report page's conformance trend graph, and the append had no notion of scope: with `TEST262_PATH_FILTER` or a narrowed `TEST262_LOCAL_SHARD_GLOB`, a partial run posted a partial total as if it were a full pass.

Observed 2026-08-14 — a single-shard local run wrote `pass: 1902 / total: 2713` beside real ~30,000-test entries, and a planned 32-invocation sharded experiment would have written 32 such rows. **Nothing downstream would have rejected them**: the row is well-formed and schema-valid, only its meaning is wrong. It surfaced solely because a local stop hook noticed a dirty `git status`, which is not a control.

The decision now lives in `scripts/should-publish-run-history.mjs` — one function, called by the runner (exit 0 publish / 1 skip, reason on stdout), in its own module so it is unit-testable rather than buried in shell.

| condition | result |
| --- | --- |
| no scope var set | publish |
| `TEST262_PATH_FILTER` non-empty | **skip** |
| `TEST262_LOCAL_SHARD_GLOB` narrowed | **skip** |
| `TEST262_PUBLISH_HISTORY=1` | publish, naming the scope |
| `TEST262_PUBLISH_HISTORY=0` | skip |

Default is to refuse; only the literal `"1"` forces, so `"yes"`/`"true"` cannot smuggle a partial row through. Unscoped runs are unchanged, so CI and real local full runs behave exactly as before.

### #4413 — the unit suite ran strictly serially

`maxForks` was hard-wired to 1, commented as *"the same strategy as the test262 chunk runner"*. That reads the runner backwards: test262's throughput comes from `describe.concurrent` plus a CompilerPool of workers running **inside** one fork, which is what the neighbouring `maxConcurrency: 32` exists for. The unit suite inherited the one-fork restriction without the compensating mechanism — and **0 of its 2,928 files** use `describe.concurrent`, so `maxConcurrency` does nothing for any of them.

Measured on 24 files / 164 tests, 4 cores / 16 GB, **identical results at every setting** (155 passed / 9 failed):

| `maxForks` | wall | speedup | peak RAM |
| --- | --- | --- | --- |
| 1 | 229 s | 1.00× | — |
| 3 | 117 s | 1.96× | — |
| 4 | 110 s | 2.08× | — |
| 8 | 116 s | 1.97× | 5.7 GB of 16 GB |

The OOM concern does not hold at these fork counts, and past 4 there is nothing to win on 4 cores.

**test262 runs stay pinned to one fork**, and that half of the original reasoning *is* load-bearing: the runner hands vitest 16 shard files, each spinning up its own CompilerPool, so three at once would put ~9 compiler workers on 4 cores. The carve-out keys off `TEST262_TARGET` / `TEST262_RESULT_PREFIX`, which that runner already exports.

Default is `availableParallelism() - 1`; `VITEST_MAX_FORKS` overrides.

## Notes for the reviewer

- The larger remaining lever is **intra-file** concurrency — the CompilerPool sits ready and no test file uses it. Left as follow-up in #4413; it needs a per-file audit for shared module state rather than a blanket change.
- Unrelated but observed while measuring: `issue-3009`, `issue-3014`, `issue-3000-c` and `issue-3017-function-poison-pill` fail on `origin/main` today (9 tests). Verified pre-existing by running them in a clean worktree at `origin/main` — **main is red on those**, independent of this PR.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHo1sZKsmZinYGbscm1pft)_