### PR TITLE
fix(react): preserve boxed captures across shadowed locals

### DIFF
--- a/plan/issues/4407-react-dom-wasm-capture.md
+++ b/plan/issues/4407-react-dom-wasm-capture.md
@@ -1,0 +1,40 @@
+---
+id: 4407
+title: "React and React DOM WasmGC capture forwarding"
+status: in-review
+sprint: current
+created: 2026-08-14
+priority: high
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen
+loc-budget-allow:
+  - src/codegen/expressions/call-identifier.ts
+func-budget-allow:
+  - src/codegen/expressions/call-identifier.ts::compileIdentifierCall
+---
+
+# #4407 — React and React DOM WasmGC capture forwarding
+
+## Problem
+
+React DOM contains nested functions that capture a module binding while a
+nearby function declares a local with the same name. The compiler previously
+looked up the capture by name in the current frame and forwarded the shadowing
+local instead of the leading capture cell. That produced an invalid WasmGC
+call signature during React DOM compilation.
+
+## Fix
+
+At a capture boundary, prefer the recorded lifted-capture slot. When the slot
+contains a raw value rather than the shared cell expected by the callee,
+materialize the cell and update the local binding map so subsequent reads and
+writes use the same storage.
+
+## Verification
+
+- React and React DOM compilation no longer fail with the invalid
+  `externref`/`ref` call mismatch.
+- The bridge regression suites for issues 2714 and 2804 pass with the real
+  `setInstance` lifecycle hook.

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -2120,8 +2120,41 @@ export function compileIdentifierCall(
             fctx.body.push({ op: "ref.as_non_null" });
           } else if (fctx.boxedCaptures?.has(cap.name) || candidateIsBoxed) {
             // Already a ref cell — pass the ref cell reference directly
-            const currentLocalIdx = fctx.localMap.get(cap.name) ?? cap.outerLocalIdx;
-            fctx.body.push({ op: "local.get", index: currentLocalIdx });
+            // A nested function can capture a module binding whose name is
+            // shadowed by a local `var` in the current function (for example,
+            // React's `forceStoreRerender` has a local `root` while a sibling
+            // function still captures the module-level `root`).  The leading
+            // capture parameter is the cell we must forward; the name-based
+            // localMap entry is the shadow value and has the wrong ABI type.
+            const currentLocalIdx = fctx.liftedCaptureSlots?.has(cap.name)
+              ? captureSourceSlot(fctx, cap)
+              : (fctx.localMap.get(cap.name) ?? cap.outerLocalIdx);
+            const refCellType: ValType = { kind: "ref", typeIdx: refCellTypeIdx };
+            const sourceType = getLocalType(fctx, currentLocalIdx);
+            const sourceIsSameCell =
+              sourceType !== undefined &&
+              (sourceType.kind === "ref" || sourceType.kind === "ref_null") &&
+              sourceType.typeIdx === refCellTypeIdx;
+            if (sourceIsSameCell) {
+              fctx.body.push({ op: "local.get", index: currentLocalIdx });
+              if (sourceType.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" });
+            } else if (sourceType !== undefined) {
+              // The source frame may expose the capture as its raw value
+              // (usually a leading i32/f64/externref parameter) even though
+              // this callee needs the shared mutable cell.  Materialize the
+              // cell at this forwarding boundary and re-aim the current
+              // binding so later reads/writes use the same storage.
+              fctx.body.push({ op: "local.get", index: currentLocalIdx });
+              if (!valTypesMatch(sourceType, cap.valType)) coerceType(ctx, fctx, sourceType, cap.valType);
+              const boxedLocalIdx = allocLocal(fctx, `__boxed_${cap.name}`, refCellType);
+              fctx.body.push({ op: "struct.new", typeIdx: refCellTypeIdx });
+              fctx.body.push({ op: "local.tee", index: boxedLocalIdx });
+              fctx.localMap.set(cap.name, boxedLocalIdx);
+              if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
+              fctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: cap.valType });
+            } else {
+              fctx.body.push({ op: "local.get", index: currentLocalIdx });
+            }
             // Backfill boxedCaptures only when we hit the new candidateIsBoxed
             // branch — preserves invariants for downstream helpers that key on
             // boxedCaptures membership.

--- a/tests/issue-2714.test.ts
+++ b/tests/issue-2714.test.ts
@@ -20,7 +20,9 @@ async function run(source: string, fn = "test"): Promise<unknown> {
   }
   const imports = buildImports(result.imports, undefined, result.stringPool);
   const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  imports.setExports?.(instance.exports as Record<string, Function>);
+  // `setInstance` preserves the compiler-authored data-struct bridge manifest;
+  // a raw `setExports` record is deliberately not trusted to establish it.
+  imports.setInstance?.(instance);
   return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]();
 }
 

--- a/tests/issue-2804.test.ts
+++ b/tests/issue-2804.test.ts
@@ -35,7 +35,10 @@ async function run(source: string, opts: { standalone?: boolean } = {}): Promise
   expect(WebAssembly.validate(result.binary)).toBe(true);
   const built = buildImports(result.imports, {}, result.stringPool);
   const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
-  built.setExports?.(instance.exports as Record<string, Function>);
+  // The data-struct field projection is authenticated from the genuine
+  // instance, so use the preferred lifecycle hook rather than a raw export
+  // record (which intentionally cannot establish bridge authority).
+  built.setInstance?.(instance);
   return (instance.exports as any).test();
 }
 


### PR DESCRIPTION
## What changed

- forward the compiler-authored boxed capture cell when a nested function shadows a module binding;
- materialize a shared ref cell when a raw captured value crosses that ABI boundary;
- update the two bridge regressions to use the authenticated `setInstance` lifecycle hook;
- document the React/React DOM defect and its scoped budget allowances.

## Why

React DOM could emit an invalid WasmGC call when a nested closure captured a module binding whose name was shadowed by a local. The compiler selected the shadowing local by name instead of the leading capture slot, producing an `externref`/`ref` mismatch.

## Verification

- `pnpm run typecheck`
- `pnpm exec vitest run tests/issue-2714.test.ts tests/issue-2804.test.ts --reporter=dot` (21 passed, 10 skipped)
- pre-push typecheck, lint, formatting, oracle/coercion ratchets, numeric-local parity, and issue-integrity gates

The pull request is based on `main` and is ready for review.