### PR TITLE
test(#4409): the with-scope unsoundness costs 37 standalone test262 passes — #4218's gate is not met

### DIFF
--- a/plan/issues/4409-inhouse-oracle-unsound-in-with-scope.md
+++ b/plan/issues/4409-inhouse-oracle-unsound-in-with-scope.md
@@ -98,10 +98,74 @@ call's result.
 - [ ] After the fix, the differential's `checker-weaker` bucket loses the
       `with` rows and the `declaredNameOf` rows (18).
 
+## Confirmed: this costs real conformance (standalone A/B, 2026-08-14)
+
+The emitted-code proxies said the unsound facts were harmless — on 1,804
+compilable inputs, 91 differed, net box/unbox traffic **0**, bytes −219. That
+was the wrong instrument. A **standalone-mode test262 A/B** (no JS host to
+absorb a de-specialised value, `JS2WASM_EVAL_ENGINE=quickjs`) run under each
+backend over the divergence areas — 3,137 tests,
+`TEST262_PATH_FILTER=with|unscopables|eval-code|annexB|resizable-buffer|fromAsync`:
+
+| status          | checker  | inhouse  |
+| --------------- | -------- | -------- |
+| pass            | **1891** | **1854** |
+| fail            | 757      | 791      |
+| compile_error   | 489      | 492      |
+
+**−37 pass. 42 `pass`→`fail`, 5 `fail`→`pass`.** Where they land:
+
+| count | family                                            |
+| ----- | ------------------------------------------------- |
+| 27    | `language/statements/with/S12.10_A1.*`            |
+| 11    | `annexB/language/function-code/` (B.3.3 hoisting) |
+| 1     | `annexB/language/expressions/`                    |
+| 3     | neither — see below                               |
+
+So the two classes this issue and #4410 B2 identified account for **39 of 42**.
+
+A representative failure, `language/statements/with/S12.10_A1.1_T1.js`, is the
+minimal repro at full size: outer `var result = "result"`, then
+`with (myObj) { … }` where `myObj` carries properties of the same names
+(including `eval`, `parseInt`, `NaN`). The in-house binder resolves those
+lexically; ECMAScript resolves them against the object. Because
+`staticJsTypeOf` feeds a lowering decision, the compiler does not merely hold
+a wrong fact — it emits wrong code.
+
+### The 3 unexplained regressions
+
+These match the path filter on their **filenames** and contain no `with`
+statement at all (verified: zero `^\s*with\s*\(` in each):
+
+- `built-ins/Object/prototype/setPrototypeOf-with-same-value.js`
+- `built-ins/Array/prototype/with/ignores-species.js` — `Array.prototype.with()`,
+  the method, not the statement
+- `built-ins/TypedArray/prototype/subarray/results-with-empty-length.js`
+
+They are a **separate, undiagnosed class** and must not be assumed fixed by the
+`with`-scope work. Diagnose before closing this issue.
+
+### The 5 improvements
+
+All TypedArray, all `fail`→`pass`: `reduce`/`reduceRight`
+`empty-instance-with-no-initialvalue-throws` (×4) and
+`slice/BigInt/results-with-empty-length`. Consistent with #4410 — the in-house
+backend is genuinely better in places, which is why "match the checker" was
+never the right gate.
+
+## Consequence for #4218
+
+The retirement gate is **not met**. `zero standalone-mode test262 regressions
+under JS2WASM_ORACLE_BACKEND=inhouse` currently reads **−37**, and this issue
+is the bulk of it.
+
 ## Notes
 
-Emitted-code impact measured on 1,804 compilable inputs: 91 differ, net
-box/unbox traffic **0**, bytes −219. So these unsound facts are not currently
-producing visibly worse code — but `staticJsTypeOf → number` on a `with`-scoped
-name is a correctness hazard regardless of what today's codegen happens to do
-with it, and a standalone-mode test262 A/B is running to confirm.
+Scope: a full standalone pass is ~8h **per backend** on a 4-core container
+(measured 98 tests/min), so this A/B was filtered to the areas where the
+differential showed the backends diverge at all. 39 of 42 regressions landed
+inside that filter, which is evidence the scoping was right rather than lucky —
+but the remaining 3 show it is not a proof of completeness. **A full-corpus
+standalone A/B belongs in CI** (`test262-sharded.yml` already runs that lane
+across many runners in ~19 min); wiring `JS2WASM_ORACLE_BACKEND` in as a
+`workflow_dispatch` input is the durable form of this gate.

--- a/plan/issues/4410-typescript-is-not-ground-truth.md
+++ b/plan/issues/4410-typescript-is-not-ground-truth.md
@@ -134,7 +134,12 @@ Restated gate for #4218:
 - genuine both-claim-different-facts == 0 (currently **88**, #4408), **and**
 - every `checker-weaker` row adjudicated into A (in-house right — keep), B
   (contract gap — specify the query), or C (in-house wrong — fix), **and**
-- zero standalone-mode test262 regressions under `JS2WASM_ORACLE_BACKEND=inhouse`.
+- zero standalone-mode test262 regressions under `JS2WASM_ORACLE_BACKEND=inhouse`
+  — **currently −37** (1891 → 1854 pass over 3,137 tests in the divergence
+  areas, 2026-08-14). 39 of the 42 regressions are the `with`-scope class
+  (#4409, 27) and annexB B.3.3 block-function hoisting (12, i.e. B2 below);
+  3 are undiagnosed. Five tests improve. So the gate is **not met**, and B2 is
+  not merely an "under-specified question" — it costs conformance.
 
 ## Acceptance criteria
 

--- a/scripts/audit-oracle-standalone-ab.sh
+++ b/scripts/audit-oracle-standalone-ab.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Standalone test262 A/B — checker vs inhouse oracle backend (#4218/#4410).
+#
+# RESUMABLE BY SHARD. Three previous attempts at a single long run all died:
+# nohup, setsid and a plain background task were all reaped or lost to a
+# container restart before finishing. Ephemeral containers do not host a
+# multi-hour process, so do not try. Instead
+# each of the 16 shards runs as its own invocation and checkpoints to
+# shards/<backend>-shard<N>.jsonl; a restart costs one shard, and re-running
+# this script skips everything already on disk.
+#
+# Per-shard overhead is a worktree + bundle rebuild (~20s); 32 invocations pay
+# ~11 min for that, which is cheap against losing a long pass.
+#
+# SCOPED to the risk areas, because a full pass is not affordable here. Shard 1
+# alone took 31 min for 3,045 tests (~98 tests/min on 4 cores), so all 53,575
+# tests is ~8h PER BACKEND — ~16h for the pair. (An earlier estimate of 2h10m
+# was wrong: it read the runner's "Chunk N/16" lines as chunks COMPLETED, but
+# vitest prints them as each shard file STARTS, all within the first minutes.)
+#
+# The filter keeps every area where the two backends actually diverge:
+#   with / unscopables  the `with`-scope unsoundness (#4409) — the only
+#                       divergence that reaches a LOWERING decision
+#                       (`staticJsTypeOf → number` on a with-scoped name)
+#   annexB, eval-code   B.3.3 hoisting and the eval'd-program binding rows
+#                       that dominate `valueDeclarationOf` (#4410 A4)
+#   resizable-buffer,   the Array callback signature rows
+#   fromAsync           and the `let closed` mis-resolution (#4410 A1)
+# 3,512 tests — ~36 min per backend. Everything outside it queried the two
+# backends identically in the differential run, so it cannot discriminate.
+# A FULL standalone A/B belongs in CI (test262-sharded.yml), not this box.
+export TEST262_PATH_FILTER="with|unscopables|eval-code|annexB|resizable-buffer|fromAsync"
+set -u
+cd "$(dirname "$0")/.." || exit 1
+S="${JS2WASM_AB_OUT:-$PWD/.tmp/oracle-ab}"
+mkdir -p "$S"
+R="$PWD/benchmarks/results"
+OUT="$S/shards"
+mkdir -p "$OUT"
+
+log () { echo "[$(date -u +%H:%M:%S)] $*"; }
+
+# The runner unconditionally appends a summary row to
+# benchmarks/results/runs/index.json — the COMMITTED history that feeds the
+# report page's trend graph. It has no notion of a scoped run, so each of
+# these 32 shard invocations would post a partial result (shard 1 wrote
+# "pass: 1902 / total: 2713") next to real ~30k-test runs and bend the graph.
+# Treat the file as read-only for this experiment: restore it after every
+# invocation. Worth fixing upstream — a local scoped run should not be able to
+# write a published artifact at all — but not on a branch with a queued PR.
+restore_index () { git checkout -- benchmarks/results/runs/index.json 2>/dev/null || true; }
+
+run_shard () {
+  local backend="$1" n="$2"
+  local dest="$OUT/$backend-shard$n.jsonl"
+  if [ -s "$dest" ]; then
+    log "skip $backend/shard$n ($(wc -l < "$dest") rows already on disk)"
+    return 0
+  fi
+  rm -rf /tmp/js2wasm-test262.lockdir
+  local before
+  before=$(date +%s)
+  TEST262_TARGET=standalone JS2WASM_EVAL_ENGINE=quickjs \
+  JS2WASM_ORACLE_BACKEND="$backend" COMPILER_POOL_SIZE=3 TEST262_REPORTER=dot \
+  TEST262_LOCAL_SHARD_GLOB="tests/test262-local-shard$n.test.ts" \
+    pnpm run test:262 > "$S/shard-$backend-$n.log" 2>&1
+  local rc=$?
+  # Newest results file written since this invocation started.
+  local newest
+  newest=$(find "$R" -maxdepth 1 -name 'test262-standalone-results-*.jsonl' -newermt "@$before" -print 2>/dev/null | sort | tail -1)
+  if [ -n "$newest" ] && [ -s "$newest" ]; then
+    cp "$newest" "$dest"
+    log "done $backend/shard$n rc=$rc rows=$(wc -l < "$dest")"
+  else
+    log "FAILED $backend/shard$n rc=$rc — no results file; see shard-$backend-$n.log"
+  fi
+  restore_index
+}
+
+for backend in checker inhouse; do
+  for n in $(seq 1 16); do
+    run_shard "$backend" "$n"
+  done
+done
+
+# ── Merge + diff ──────────────────────────────────────────────────────
+for backend in checker inhouse; do
+  cat "$OUT/$backend-shard"*.jsonl > "$S/t262-sa-$backend.jsonl" 2>/dev/null
+  log "$backend total rows: $(wc -l < "$S/t262-sa-$backend.jsonl" 2>/dev/null || echo 0)"
+done
+
+missing=$(ls "$OUT"/checker-shard*.jsonl 2>/dev/null | wc -l)
+missing2=$(ls "$OUT"/inhouse-shard*.jsonl 2>/dev/null | wc -l)
+log "shards present: checker=$missing/16 inhouse=$missing2/16"
+if [ "$missing" -ne 16 ] || [ "$missing2" -ne 16 ]; then
+  log "INCOMPLETE — re-run this script to fill the gaps before trusting any diff"
+  exit 1
+fi
+
+npx tsx scripts/diff-test262.ts "$S/t262-sa-checker.jsonl" "$S/t262-sa-inhouse.jsonl" --all \
+  > "$S/t262-sa-ab-diff.txt" 2>&1
+log "diff exit=$? — see t262-sa-ab-diff.txt"
+restore_index
+log "COMPLETE"


### PR DESCRIPTION
## Description

Closes the evidence loop on #4218/#4409/#4410. The answer to "does the in-house oracle backend lose anything real?" is **yes, and it is measurable**.

### The emitted-code proxies were the wrong instrument

They said these unsound facts were harmless: 91 of 1,804 inputs differed, net box/unbox traffic **0**, bytes −219. But boxing is not how this failure shows up.

A **standalone-mode** A/B — no JS host to absorb a de-specialised value, `JS2WASM_EVAL_ENGINE=quickjs` — run under each oracle backend over the divergence areas, 3,137 tests:

| status | checker | inhouse |
| --- | --- | --- |
| pass | **1891** | **1854** |
| fail | 757 | 791 |
| compile_error | 489 | 492 |

**−37 pass. 42 `pass`→`fail`, 5 `fail`→`pass`.**

| count | family |
| --- | --- |
| 27 | `language/statements/with/S12.10_A1.*` |
| 11 | `annexB/language/function-code/` (B.3.3 block-function hoisting) |
| 1 | `annexB/language/expressions/` |
| 3 | neither — see below |

So #4409 plus #4410's B2 account for **39 of 42**. The representative failure is the minimal repro at full size: outer `var result = "result"`, then `with (myObj) { … }` where `myObj` carries properties of the same names. Because `staticJsTypeOf` feeds a **lowering** decision, the compiler doesn't merely hold a wrong fact — it emits wrong code.

This upgrades #4409 from "unsound in principle" to a confirmed conformance cost, and it means **#4218's retirement gate is not met**: "zero standalone regressions under `JS2WASM_ORACLE_BACKEND=inhouse`" currently reads −37.

### Three regressions are NOT explained by this

They matched the path filter on their **filenames** and contain no `with` statement (verified zero `^\s*with\s*\(` in each):

- `built-ins/Object/prototype/setPrototypeOf-with-same-value.js`
- `built-ins/Array/prototype/with/ignores-species.js` — `Array.prototype.with()`, the *method*
- `built-ins/TypedArray/prototype/subarray/results-with-empty-length.js`

Recorded as a separate undiagnosed class so the `with`-scope fix cannot be assumed to cover them.

### Five tests improve

All TypedArray `reduce`/`reduceRight`/`slice`. Consistent with #4410: the in-house backend is genuinely better in places, which is why "match the checker" was never the right gate.

## Scope, stated plainly

A full standalone pass is **~8 h per backend** on this 4-core container (measured: 98 tests/min), so this A/B was filtered to the areas where the differential showed the backends diverge at all. 39 of 42 regressions landed inside the filter — evidence the scoping was sound rather than lucky — **but the other 3 show it is not a proof of completeness.** The full-corpus form belongs in CI; `test262-sharded.yml` already runs the standalone lane across many runners in ~19 min, and wiring `JS2WASM_ORACLE_BACKEND` in as a `workflow_dispatch` input is the durable version of this gate.

`scripts/audit-oracle-standalone-ab.sh` is the driver, promoted from scratch: repo-relative, and **resumable per shard** because `nohup`, `setsid` and a plain background task were each reaped or lost to a container restart mid-run. Re-running it skips completed shards.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHo1sZKsmZinYGbscm1pft)_