### PR TITLE
fix(#4414): honour the boolean brand at the three static-type-only stringification sites

### DIFF
--- a/plan/issues/4414-boolean-returns-minted-as-f64-numeric-twins.md
+++ b/plan/issues/4414-boolean-returns-minted-as-f64-numeric-twins.md
@@ -1,15 +1,19 @@
 ---
 id: 4414
 title: "devirtualized prototype-method call returns a boolean as a number — live standalone miscompile"
-status: ready
+status: done
 sprint: current
 created: 2026-08-14
+completed: 2026-08-14
 priority: high
 horizon: s
 feasibility: medium
 task_type: bug
 area: codegen
 related: [4406, 4405, 3754, 4157]
+loc-budget-allow:
+  - src/codegen/string-ops.ts
+  - src/codegen/expressions/call-identifier.ts
 ---
 
 # #4414 — devirtualized boolean return typed as a number: `("" + p.eat(5)).length` → 1, not 4
@@ -131,3 +135,42 @@ prototype-method call in the direct-call fill path (`recordDirectCallTwin` /
 the standalone lane, with typed-this twins OFF. Find who decides the callee's
 result is numeric there. Repro test (currently failing, do not add to CI until
 it passes): `.tmp/issue-4407-repro-test.ts`.
+
+## Root cause + fix (2026-08-14, impl PR)
+
+The direct-call machinery was **innocent** — its result type was correct all
+along. Instrumented at the trampoline reservation
+(`tryEmitDirectTwinCall`, typed-this.ts): `sig.returnType` for `P.eat` arrives
+as `{"kind":"i32","boolean":true}` — the #1788 **boolean brand on the i32
+carrier**, exactly right — and `tryEmitDirectTwinCall` reports it faithfully
+to the caller.
+
+The defect was three **stringification consumers deciding boolean-ness from
+the static TS type alone**, ignoring the runtime brand:
+
+1. `compileNativeConcatOperand` (string-ops.ts) — the standalone `+`-concat
+   cascade, deliberately not migrated to the coercion engine (its #1917 note).
+2. The template-literal span path (string-ops.ts, `spanIsBool`).
+3. The `String(x)` builtin lowering's i32 arm (call-identifier.ts).
+
+`p.eat(5)` on an untyped constructor instance is `any` to the checker, so
+`isBooleanType(tsType)` is false and the branded i32 fell into each site's
+numeric arm → `number_toString` → `"1"`. This explains the whole shape table
+above: every passing shape has a *statically known* boolean type; only
+devirtualization surfaces a branded i32 under static `any`. And
+`JS2WASM_DIRECT_CALLS=0` "fixes" it only because the dynamic dispatcher
+returns a boxed externref that stringifies at runtime — the numeric fixpoint
+(`refinedTwinReturnType`) never fired at all in the repro (`refined=undefined`,
+measured).
+
+Fix: all three sites now check `isBooleanType(tsType) || valType.boolean`,
+matching what the binary-op concat path (string-ops.ts ~2047/2122) and the
+migrated coercion engine (`emitToString`, coercion-engine.ts:236) already did.
+
+Verified: repro 4 ✓; siblings `String()` 4 ✓, template 10 ✓, `=== true` ✓,
+`typeof` ✓ (the last two passed before the fix — strict-eq/typeof compare the
+i32 numerically, which is correct for booleans). The js-host lane cannot run
+the repro shape at all (`value is not callable`, byte-identical on unmodified
+HEAD — #4227 family), so the new equivalence test
+(`tests/issue-4414-boolean-direct-call-stringify.test.ts`) oracles standalone
+against plain JS.

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -787,9 +787,9 @@ export function compileIdentifierCall(
       }
 
       if (argType?.kind === "i32") {
-        // Check if it's a boolean type → "true"/"false"
+        // (#4414) `|| .boolean` — a devirtualized call is `any` statically but returns a BRANDED boolean i32
         const argTsType = ctx.checker.getTypeAtLocation(strArg0);
-        if (isBooleanType(argTsType)) {
+        if (isBooleanType(argTsType) || argType.boolean === true) {
           return emitBoolToString(ctx, fctx);
         }
         // number (i32) → string via f64 conversion

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -315,7 +315,14 @@ function compileNativeConcatOperand(ctx: CodegenContext, fctx: FunctionContext, 
 
   const toStrIdx = ctx.funcMap.get("number_toString");
 
-  if (opType.kind === "i32" && isBooleanType(tsType)) {
+  // (#4414) `|| opType.boolean` — the static type alone misses a devirtualized
+  // prototype-method call: `p.eat(5)` on an untyped constructor is `any` to the
+  // checker, but the direct-call trampoline returns the callee's BRANDED i32
+  // (`{kind:"i32", boolean:true}`). Without the brand check the value fell into
+  // the numeric arm below and `("" + p.eat(5))` printed "1", not "true". The
+  // binary-op concat path already checks the brand; this cascade and the
+  // template-span path did not.
+  if (opType.kind === "i32" && (isBooleanType(tsType) || opType.boolean === true)) {
     // Boolean → "true"/"false" native literal selected at runtime.
     const trueInstrs = nativeStringLiteralInstrs(ctx, "true");
     const falseInstrs = nativeStringLiteralInstrs(ctx, "false");
@@ -816,7 +823,10 @@ export function compileNativeTemplateExpression(
 
     const spanType = compileExpression(ctx, fctx, span.expression);
     const spanIsScalarNullish = (spanNativeIsUndef || spanNativeIsNull) && spanType && spanType.kind !== "externref";
-    const spanIsBool = spanType && spanType.kind === "i32" && isBooleanType(spanNativeTsType);
+    // (#4414) brand check mirrors the binary-op concat path — see
+    // compileNativeConcatOperand.
+    const spanIsBool =
+      spanType && spanType.kind === "i32" && (isBooleanType(spanNativeTsType) || spanType.boolean === true);
     if (spanIsScalarNullish) {
       // Scalar-lowered null/undefined → drop the placeholder, build the native
       // string constant inline (#2005/#2006). Leaves the native string ref on

--- a/tests/issue-4414-boolean-direct-call-stringify.test.ts
+++ b/tests/issue-4414-boolean-direct-call-stringify.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4414 — a devirtualized prototype-method call returns the callee's BRANDED
+// boolean i32 (`{kind:"i32", boolean:true}`) under a static type of `any` (the
+// receiver is an untyped constructor-function instance). Three stringification
+// sites decided "is this a boolean?" from the static TS type alone and fell
+// into their numeric arm, so `true` printed as "1":
+//
+//   - `compileNativeConcatOperand` (the standalone `+`-concat cascade,
+//     deliberately NOT migrated to the coercion engine — see its #1917 note)
+//   - the template-literal span path in string-ops.ts
+//   - the `String(x)` builtin lowering's i32 arm (call-identifier.ts)
+//
+// The migrated coercion engine (`emitToString`) and the binary-op concat path
+// already honoured the brand; these three now do too. The repro needs the
+// DIRECT-CALL path (default-ON, standalone) — `JS2WASM_DIRECT_CALLS=0` never
+// exhibited the bug because the dynamic dispatcher returns a boxed boolean
+// externref that stringifies at runtime.
+//
+// Lane note: the equivalence oracle here is plain JS (`new Function`), not the
+// js-host wasm lane — that lane cannot yet CALL an untyped-constructor
+// prototype method in this harness at all (`TypeError: value is not callable`
+// from `externCallRawCallable`, reproduced byte-identically on unmodified
+// HEAD; the #4227 js-host reflection drift family). Nothing boolean-specific.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const PROTO_PREAMBLE = `
+function P(n) { this.n = n; }
+P.prototype.eat = function (x) { return this.n === x; };
+`;
+
+async function runStandalone(body: string): Promise<unknown> {
+  const src = `${PROTO_PREAMBLE}
+export function test() { var p = new P(5); ${body} }
+`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+/** Assert the standalone build matches what plain JS evaluates the body to. */
+async function matchesJs(body: string): Promise<void> {
+  const oracle = new Function(`${PROTO_PREAMBLE}
+var p = new P(5); ${body}`)();
+  expect(await runStandalone(body), `standalone vs JS oracle for: ${body}`).toStrictEqual(oracle);
+}
+
+describe("#4414 devirtualized boolean return keeps its brand at stringification", () => {
+  // Every body returns a NUMBER — a standalone module's string return is a
+  // native WasmGC struct, opaque to the JS harness, so assert on .length.
+  it('("" + p.eat(5)) is "true" (length 4), not "1"', async () => {
+    await matchesJs(`return ("" + p.eat(5)).length;`);
+  });
+
+  it('("" + p.eat(6)) is "false" (length 5), not "0"', async () => {
+    await matchesJs(`return ("" + p.eat(6)).length;`);
+  });
+
+  it("template literal spans stringify to true/false", async () => {
+    // "true|false".length === 10
+    await matchesJs("return `${p.eat(5)}|${p.eat(6)}`.length;");
+  });
+
+  it('String(p.eat(5)) is "true" (length 4)', async () => {
+    await matchesJs(`return String(p.eat(5)).length;`);
+  });
+
+  it("strict equality against true observes a boolean, not 1", async () => {
+    await matchesJs(`return p.eat(5) === true ? 10 : 20;`);
+  });
+
+  it("typeof the devirtualized result is boolean", async () => {
+    await matchesJs(`return typeof p.eat(5) === "boolean" ? 10 : 20;`);
+  });
+});


### PR DESCRIPTION
## Problem (#4414)

A devirtualized prototype-method call (`p.eat(5)` on an untyped constructor instance) returns the callee's **branded** boolean i32 (`{kind:"i32", boolean:true}`) under a static TS type of `any`. Three stringification sites decided boolean-ness **from the static type alone**, so the branded value fell into their numeric arm and `("" + p.eat(5))` printed `"1"` instead of `"true"` (standalone, default flags — a live miscompile on main).

## Root cause

The direct-call machinery was innocent: measured at the trampoline reservation, its result type was the correctly-branded i32 all along (`refinedTwinReturnType` never fired — `refined=undefined`). The brand was dropped by three consumers:

1. `compileNativeConcatOperand` (string-ops.ts) — the standalone `+`-concat cascade (deliberately not migrated to the coercion engine, see its #1917 note)
2. the template-literal span path (string-ops.ts)
3. the `String(x)` builtin's i32 arm (call-identifier.ts)

All three now check `isBooleanType(tsType) || valType.boolean`, matching the binary-op concat path and the migrated `emitToString` engine, which already did.

## Verification

- repro `("" + p.eat(5)).length` → 4 ✓ (was 1); `false` → 5 ✓; template ✓; `String()` ✓; `=== true` ✓; `typeof` ✓
- acorn: checksum **422** unchanged, pass rate 99.2%, `twins=488 declinedTwin=0` unchanged
- equivalence gate: no regressions, **2 symbol-basic tests newly fixed**
- tsc clean; 66/66 scoped string/template tests
- new test `tests/issue-4414-boolean-direct-call-stringify.test.ts` (6/6) oracles standalone against plain JS — the js-host lane cannot run the repro shape at all (`value is not callable`, byte-identical on unmodified HEAD; #4227 family)

Sets #4414 `status: done` (self-merge path). LOC-budget growth granted in the issue file frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Mjntn1rYJ7sH8kgfFDoqM