### PR TITLE
fix(react-dom): preserve boxed constructor captures

### DIFF
--- a/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
+++ b/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md
@@ -4,7 +4,7 @@ title: "Run react-dom's own unit tests against compiled react-dom"
 status: in-progress
 sprint: current
 created: 2026-08-01
-updated: 2026-08-13
+updated: 2026-08-15
 priority: high
 horizon: m
 feasibility: medium
@@ -267,6 +267,17 @@ reaches ReactDOM's client renderer but fails in the constructor bridge with
 finding, not a Wasm validation failure. A full pass-rate claim is not made
 until that constructor value is preserved and the server-renderer slice has its
 own valid module path.
+
+## Capture-continuation checkpoint (2026-08-15)
+
+The constructor-capture fix is now on the draft follow-up. It preserves
+immutable boxed captures across lifted closure frames and lazily materializes
+nullable cells from their raw binding before a conditional closure is called.
+The client module remains valid Wasm, but the first admitted upstream probe now
+reaches a separate null-cell dereference in the generated constructor closure.
+The follow-up therefore stays draft until that runtime path is fixed; this
+checkpoint intentionally records the remaining failure instead of claiming a
+pass-rate improvement.
 
 ## Remaining blockers (skipped tests in `tests/issue-3982.test.ts`)
 

--- a/src/codegen/closures/arrow-phases.ts
+++ b/src/codegen/closures/arrow-phases.ts
@@ -32,9 +32,9 @@ import {
   getOrCreateConstructibleFuncRefWrapperTypes,
   getOrCreateFuncRefWrapperTypes,
 } from "./funcref-wrapper-types.js";
-import { allocLocal } from "../context/locals.js";
+import { allocLocal, getLocalType } from "../context/locals.js";
 import { closureObservesBindingValue, collectTransitiveCaptureNames } from "../function-declaration-observation.js";
-import { emitBoundsCheckedArrayGet } from "../shared.js";
+import { emitBoundsCheckedArrayGet, valTypesMatch } from "../shared.js";
 import { spliceNullGuarded } from "./param-emit-helpers.js";
 import { materializeHoistedFunctionValueBinding } from "./funcref-as-closure.js";
 import {
@@ -1060,6 +1060,60 @@ export function emitClosureParamDestructuring(
  * value (boxing mutable captures into ref cells, re-aiming the outer local),
  * then the TDZ-flag ref cells, then `struct.new` the closure struct.
  */
+function findUnboxedCaptureLocal(
+  fctx: FunctionContext,
+  name: string,
+  boxedLocalIdx: number,
+  valueType: ValType,
+): number | undefined {
+  for (let localOffset = 0; localOffset < fctx.locals.length; localOffset++) {
+    const localIdx = fctx.params.length + localOffset;
+    if (localIdx === boxedLocalIdx) continue;
+    const local = fctx.locals[localOffset];
+    if (local?.name === name && valTypesMatch(local.type, valueType)) return localIdx;
+  }
+  return undefined;
+}
+
+/**
+ * Push a live capture cell, repairing a nullable cell which was allocated by
+ * an earlier conditional closure site but did not execute on this path. The
+ * cell itself is the shared identity used by all later closures; only its
+ * first value comes from the original unboxed slot. This keeps lazy closure
+ * construction safe without snapshotting a mutable binding into a fresh cell.
+ */
+function pushCaptureCell(ctx: CodegenContext, fctx: FunctionContext, cap: ArrowClosureCapture): void {
+  const boxed = fctx.boxedCaptures?.get(cap.name);
+  const boxedLocalIdx = cap.localIdx;
+  const boxedType = getLocalType(fctx, boxedLocalIdx);
+  const valueType = boxed?.valType;
+  const rawLocalIdx = valueType ? findUnboxedCaptureLocal(fctx, cap.name, boxedLocalIdx, valueType) : undefined;
+  const nullableBox =
+    boxed !== undefined &&
+    valueType !== undefined &&
+    (boxedType?.kind === "ref" || boxedType?.kind === "ref_null") &&
+    boxedType.typeIdx === boxed.refCellTypeIdx &&
+    rawLocalIdx !== undefined;
+  if (!nullableBox) {
+    fctx.body.push({ op: "local.get", index: boxedLocalIdx });
+    return;
+  }
+
+  const refCellTypeIdx = boxed.refCellTypeIdx;
+  fctx.body.push({ op: "local.get", index: boxedLocalIdx });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "ref_null", typeIdx: refCellTypeIdx } },
+    then: [
+      { op: "local.get", index: rawLocalIdx },
+      { op: "struct.new", typeIdx: refCellTypeIdx },
+      { op: "local.tee", index: boxedLocalIdx },
+    ],
+    else: [{ op: "local.get", index: boxedLocalIdx }],
+  });
+}
+
 export function emitClosureConstruction(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1105,8 +1159,10 @@ export function emitClosureConstruction(
     if (cap.mutable) {
       // Check if the outer scope already has this variable boxed (nested closure case)
       if (fctx.boxedCaptures?.has(cap.name)) {
-        // Already a ref cell — pass the ref cell reference directly
-        fctx.body.push({ op: "local.get", index: cap.localIdx });
+        // Already a ref cell — pass the shared cell reference directly. If a
+        // conditional closure site allocated the nullable cell but did not
+        // execute, lazily repair that same cell from the raw binding.
+        pushCaptureCell(ctx, fctx, cap);
       } else {
         // Wrap the current value in a ref cell
         const refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.type);
@@ -1122,7 +1178,11 @@ export function emitClosureConstruction(
         fctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: cap.type });
       }
     } else {
-      fctx.body.push({ op: "local.get", index: cap.localIdx });
+      if (cap.alreadyBoxed && fctx.boxedCaptures?.has(cap.name)) {
+        pushCaptureCell(ctx, fctx, cap);
+      } else {
+        fctx.body.push({ op: "local.get", index: cap.localIdx });
+      }
     }
   }
 

--- a/src/codegen/closures/funcref-as-closure.ts
+++ b/src/codegen/closures/funcref-as-closure.ts
@@ -156,6 +156,16 @@ function emitMemoizedNestedFnClosure(
       (liveBoxType?.kind === "ref" || liveBoxType?.kind === "ref_null") &&
       liveBoxType.typeIdx === liveBox.refCellTypeIdx &&
       !recordedSlotHasLiveBoxType;
+    const useLiveImmutableBoxValue =
+      !cap.mutable &&
+      liveBoxLocalIdx !== undefined &&
+      liveBox !== undefined &&
+      liveBoxType !== undefined &&
+      (liveBoxType.kind === "ref" || liveBoxType.kind === "ref_null") &&
+      liveBoxType.typeIdx === liveBox.refCellTypeIdx &&
+      cap.valType !== undefined &&
+      cap.valType.kind !== "ref" &&
+      cap.valType.kind !== "ref_null";
     if (cap.mutable && cap.valType) {
       const refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.valType);
       const boxGlobal = capUnresolvedHere ? ctx.capturedBoxGlobals?.get(cap.name) : undefined;
@@ -190,6 +200,9 @@ function emitMemoizedNestedFnClosure(
         if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
         fctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: cap.valType });
       }
+    } else if (useLiveImmutableBoxValue) {
+      fctx.body.push({ op: "local.get", index: liveBoxLocalIdx! });
+      fctx.body.push({ op: "struct.get", typeIdx: liveBox!.refCellTypeIdx, fieldIdx: 0 });
     } else if (useLiveImmutableBox) {
       fctx.body.push({ op: "local.get", index: liveBoxLocalIdx });
     } else if (capUnresolvedHere && ctx.capturedGlobals.has(cap.name)) {
@@ -202,7 +215,27 @@ function emitMemoizedNestedFnClosure(
       }
     } else {
       const capSourceIdx = captureSourceSlot(fctx, cap);
+      const sourceType = getLocalType(fctx, capSourceIdx);
+      // The enclosing frame may expose an immutable capture through the
+      // canonical ref-cell created for a sibling/earlier nested function. The
+      // closure ABI for this capture remains its raw value type, so store the
+      // cell's value in the new closure rather than the cell object itself.
+      // Without this unwrap a later `new CapturedConstructor()` receives a
+      // Wasm struct and the host constructor bridge reports "not a
+      // constructor".
+      const sourceIsCanonicalBox =
+        !cap.mutable &&
+        liveBox !== undefined &&
+        sourceType !== undefined &&
+        (sourceType.kind === "ref" || sourceType.kind === "ref_null") &&
+        sourceType.typeIdx === liveBox.refCellTypeIdx &&
+        cap.valType !== undefined &&
+        cap.valType.kind !== "ref" &&
+        cap.valType.kind !== "ref_null";
       fctx.body.push({ op: "local.get", index: capSourceIdx });
+      if (sourceIsCanonicalBox) {
+        fctx.body.push({ op: "struct.get", typeIdx: liveBox!.refCellTypeIdx, fieldIdx: 0 });
+      }
     }
   }
   // #1205 Stage 3: after all value captures, push the boxed TDZ flag refs

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -2234,13 +2234,49 @@ export function compileIdentifierCall(
           // sound cross-frame case is a name explicitly recorded as THIS
           // lifted function's leading capture parameter.)
           const capSourceIdx = captureSourceSlot(fctx, cap);
-          fctx.body.push({ op: "local.get", index: capSourceIdx });
-          // Coerce capture value to expected param type if they differ
+          const actualType = getLocalType(fctx, capSourceIdx);
+          const boxed = fctx.boxedCaptures?.get(cap.name);
           const expectedCapType = captureParamTypes?.[capIdx];
+          const liveBoxLocalIdx = fctx.localMap.get(cap.name);
+          const liveBoxType = liveBoxLocalIdx !== undefined ? getLocalType(fctx, liveBoxLocalIdx) : undefined;
+          const liveBoxIsCanonical =
+            !cap.mutable &&
+            boxed !== undefined &&
+            liveBoxLocalIdx !== undefined &&
+            liveBoxType !== undefined &&
+            (liveBoxType.kind === "ref" || liveBoxType.kind === "ref_null") &&
+            liveBoxType.typeIdx === boxed.refCellTypeIdx &&
+            expectedCapType !== undefined &&
+            expectedCapType.kind !== "ref" &&
+            expectedCapType.kind !== "ref_null";
+          // A read-only nested function can still cross a frame whose copy of
+          // the binding is boxed because a sibling/earlier function required a
+          // shared cell.  `captureSourceSlot` quite correctly selects that
+          // live leading capture, but the callee's ABI is still the raw value
+          // (`externref`, f64, ...).  Passing the cell itself is especially
+          // harmful for constructors: `new C()` receives a Wasm struct instead
+          // of the host constructor.  Unwrap exactly the current canonical
+          // cell before forwarding the immutable capture.
+          const sourceIsCanonicalBox =
+            !cap.mutable &&
+            boxed !== undefined &&
+            actualType !== undefined &&
+            (actualType.kind === "ref" || actualType.kind === "ref_null") &&
+            actualType.typeIdx === boxed.refCellTypeIdx &&
+            expectedCapType !== undefined &&
+            expectedCapType.kind !== "ref" &&
+            expectedCapType.kind !== "ref_null";
+          const sourceIdx = liveBoxIsCanonical ? liveBoxLocalIdx! : capSourceIdx;
+          const sourceIsBox = liveBoxIsCanonical || sourceIsCanonicalBox;
+          fctx.body.push({ op: "local.get", index: sourceIdx });
+          if (sourceIsBox) {
+            fctx.body.push({ op: "struct.get", typeIdx: boxed!.refCellTypeIdx, fieldIdx: 0 });
+          }
+          // Coerce capture value to expected param type if they differ
           if (expectedCapType) {
-            const actualType = getLocalType(fctx, capSourceIdx);
-            if (actualType && !valTypesMatch(actualType, expectedCapType)) {
-              coerceType(ctx, fctx, actualType, expectedCapType);
+            const forwardedType = sourceIsBox ? boxed!.valType : actualType;
+            if (forwardedType && !valTypesMatch(forwardedType, expectedCapType)) {
+              coerceType(ctx, fctx, forwardedType, expectedCapType);
             }
           }
         }


### PR DESCRIPTION
## Summary

- unwrap immutable captures that cross a frame through a canonical ref cell
- lazily repair a nullable shared cell from the matching raw binding when a conditional closure is materialized
- preserve shared-cell identity while keeping constructor/host-value captures aligned with the callee ABI

## Verification

- `pnpm run typecheck` passes
- pre-push typecheck, lint, formatting, oracle/coercion ratchets, numeric-local IR parity, and issue-integrity checks pass
- the bounded ReactDOM upstream suite still reports a null-dereference in the remaining capture path; this PR is intentionally draft while that path is traced

Related: [ReactDOM compiled-Wasm upstream unit tests](https://github.com/loopdive/js2wasm/blob/main/plan/issues/3982-react-dom-own-unit-tests-against-compiled-wasm.md)