### PR TITLE
perf(#4416): call-site param inference was quadratic — 4.35× on a 512-function module

### DIFF
--- a/plan/issues/4416-param-inference-is-quadratic.md
+++ b/plan/issues/4416-param-inference-is-quadratic.md
@@ -1,0 +1,122 @@
+---
+id: 4416
+title: "Call-site param inference is quadratic — 4.35x on a 512-function module"
+status: done
+sprint: current
+created: 2026-08-14
+updated: 2026-08-14
+completed: 2026-08-14
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: performance
+area: codegen
+goal: velocity
+---
+
+## Problem
+
+`inferParamTypeFromCallSites(ctx, funcName, paramIndex, sourceFile)` walked the
+**entire source file** with `forEachChild` looking for calls to one function,
+and it is invoked once per (function, parameter) from three call sites
+(`codegen/index.ts`, `fnctor-ctor-param-types.ts`, and
+`inferImplicitAnyParamType` in its own module).
+
+That is O(functions × params × programSize). Instrumented:
+
+| units | `inferParamTypeFromCallSites` calls | AST nodes visited |
+| ----- | ----------------------------------- | ----------------- |
+| 32    | 128                                 | 184,448           |
+| 128   | 512                                 | 2,949,632         |
+| 512   | 2,048                               | **47,187,968**    |
+
+4× the input, 16× the work — textbook quadratic. 47 million node visits for a
+61 KB input.
+
+## How it was found
+
+Compile time was measured against input size, warm process, one synthetic unit
+= one 2-param function plus one call:
+
+| units | bytes  | ms   | ms/KB | implied exponent |
+| ----- | ------ | ---- | ----- | ---------------- |
+| 32    | 3,663  | 226  | 63.1  | —                |
+| 64    | 7,375  | 385  | 53.5  | 0.77             |
+| 128   | 14,940 | 688  | 47.2  | 0.84             |
+| 256   | 30,428 | 1930 | 65.0  | **1.49**         |
+| 512   | 61,404 | 6041 | 100.8 | **1.65**         |
+
+The tell is `ms/KB`: it falls while the compiler is amortising fixed cost, then
+**rises again** past ~128 units. A CPU profile of the 512-unit compile put a
+single `visit` in this module at **25.2% of total compile time**, with
+TypeScript's `forEachChild`/`visitNode` underneath it accounting for most of
+the next 20%.
+
+Fixed cost is not the issue and was ruled out separately: an empty program
+compiles in **6.8 ms**, 1% of the 512-unit compile.
+
+## Fix
+
+Build a `Map<calleeName, (CallExpression | NewExpression)[]>` **once per source
+file**, cached in a `WeakMap` keyed on the `SourceFile` object.
+`inferParamTypeFromCallSites` then iterates its own bucket instead of walking
+the program. O(programSize + functions × params).
+
+The node test it replaces was already exactly indexable:
+
+```ts
+(ts.isCallExpression(node) || (ctorSitesEnabled && ts.isNewExpression(node))) &&
+  ts.isIdentifier(node.expression) &&
+  node.expression.text === funcName;
+```
+
+Only the `ctorSitesEnabled` half stays at the call site, because that is a
+runtime flag rather than a property of the node — both kinds are indexed and
+`NewExpression`s are filtered on lookup.
+
+Three properties are preserved deliberately:
+
+- **Coverage.** The index is built with the same `forEachChild(sourceFile, …)`
+  traversal the old code used, so it sees exactly the same node set.
+- **Order.** Buckets keep document order, so the order-dependent
+  `agreed` / `conflict` / `sawUnderApplied` accumulation resolves identically.
+- **Invalidation.** Keying on the `SourceFile` object means a new program — or
+  a rewritten file, e.g. cjs-rewrite — gets a fresh index automatically. There
+  is nothing to invalidate and no cross-compile leak.
+
+## Result
+
+| units | before  | after   | speedup   |
+| ----- | ------- | ------- | --------- |
+| 32    | 226 ms  | 207 ms  | 1.09×     |
+| 64    | 385 ms  | 337 ms  | 1.14×     |
+| 128   | 688 ms  | 454 ms  | 1.52×     |
+| 256   | 1930 ms | 750 ms  | 2.57×     |
+| 512   | 6041 ms | 1388 ms | **4.35×** |
+
+The implied exponent drops from **1.65 to 0.89**, and `ms/KB` now falls
+monotonically (58.0 → 23.1) instead of turning back up. It is linear.
+
+**Small inputs are unchanged** (test262 bench: 429 ms before and after). A
+harness-wrapped test262 file has too few distinct functions for the quadratic
+term to dominate, which is exactly why this never showed up in the test262
+profile and only appeared once compile time was measured *against input size*.
+The win is on real-world code — the same code that measured 51 KB/s in the
+self-hosting sweep.
+
+## Verification
+
+22 files covering the param-inference surface (`743`, `3548`, `3961`, `fnctor`,
+`param`, `inference`, `ctor-param`, `4155`, `4235`), run on this change and on
+`origin/main`: **131 passed / 19 failed on both**, identical. Those 19 are
+pre-existing on `origin/main` (`i32-loop-inference` and others).
+
+## Follow-up
+
+The same shape may exist elsewhere — any `inferX(name, …, sourceFile)` that
+scans the file per query is a candidate. `inferNumericReturnTypes` and
+`inferBindingAwareNumericReturnTypes` in this module take a whole `sourceFile`
+and should be checked for the same pattern. Worth a sweep with the same
+instrument: measure compile time against input size and look for `ms/KB`
+turning back up.

--- a/src/codegen/declarations/param-return-inference.ts
+++ b/src/codegen/declarations/param-return-inference.ts
@@ -192,6 +192,51 @@ export interface CallSiteParamInference {
  * whether the function is called internally at all (see #3471 and
  * {@link inferParamTypeFromBody}).
  */
+/**
+ * (#4416) Call sites bucketed by callee name, built ONCE per source file.
+ *
+ * `inferParamTypeFromCallSites` used to walk the entire source file looking for
+ * calls to one function, and it is invoked once per (function, parameter). That
+ * is O(functions x params x programSize) — measured quadratic:
+ *
+ *     units   calls   AST nodes visited
+ *        32     128             184,448
+ *       128     512           2,949,632
+ *       512    2048          47,187,968     <- 4x input, 16x work
+ *
+ * 47 million node visits for a 61 KB input, and a CPU profile put this one
+ * `visit` at **25.2% of a large compile** (with TypeScript's `forEachChild`
+ * underneath it accounting for most of the rest). One walk per source file
+ * turns it into O(programSize + functions x params).
+ *
+ * Keyed on the `SourceFile` object, so a new program (or a rewritten file, e.g.
+ * cjs-rewrite) gets a fresh index automatically and nothing needs invalidating.
+ * The index holds only nodes reachable from `forEachChild(sourceFile, ...)` —
+ * exactly what the old walk saw — so coverage is unchanged, and buckets keep
+ * document order so an order-dependent `agreed`/`conflict` accumulation
+ * resolves identically.
+ */
+type CalleeSite = ts.CallExpression | ts.NewExpression;
+const callSiteIndexBySourceFile = new WeakMap<ts.SourceFile, Map<string, CalleeSite[]>>();
+
+function calleeNameIndex(sourceFile: ts.SourceFile): Map<string, CalleeSite[]> {
+  const cached = callSiteIndexBySourceFile.get(sourceFile);
+  if (cached) return cached;
+  const index = new Map<string, CalleeSite[]>();
+  const visit = (node: ts.Node): void => {
+    if ((ts.isCallExpression(node) || ts.isNewExpression(node)) && ts.isIdentifier(node.expression)) {
+      const name = node.expression.text;
+      const bucket = index.get(name);
+      if (bucket) bucket.push(node as CalleeSite);
+      else index.set(name, [node as CalleeSite]);
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(sourceFile, visit);
+  callSiteIndexBySourceFile.set(sourceFile, index);
+  return index;
+}
+
 export function inferParamTypeFromCallSites(
   ctx: CodegenContext,
   funcName: string,
@@ -214,7 +259,7 @@ export function inferParamTypeFromCallSites(
     return false;
   };
 
-  function visit(node: ts.Node) {
+  function visit(node: CalleeSite) {
     // (#743) `new F(…)` is a call site for F's PARAMETERS exactly as `F(…)` is —
     // same arity rules, same argument-to-parameter mapping, same under-application
     // semantics. Until now only `isCallExpression` matched, so every
@@ -233,12 +278,11 @@ export function inferParamTypeFromCallSites(
     // slot stays `externref` re-boxes on every store and measured strictly
     // WORSE than doing nothing (+27 bytes on a one-field fixture).
     // **ON by default since 2026-08-08** — see that module for the acorn numbers.
+    // The name and node-kind halves of this test are now the index's job; only
+    // the ctor gate is left, because it is a runtime flag rather than a
+    // property of the node.
     const ctorSitesEnabled = fnctorCtorParamTypesFlagEnabled();
-    if (
-      (ts.isCallExpression(node) || (ctorSitesEnabled && ts.isNewExpression(node))) &&
-      ts.isIdentifier(node.expression) &&
-      node.expression.text === funcName
-    ) {
+    if (ts.isCallExpression(node) || (ctorSitesEnabled && ts.isNewExpression(node))) {
       // A matching call exists regardless of arg types — the function IS invoked
       // internally, so its params are determined by runtime call args, not the
       // body-usage fallback. Record this before any conflict short-circuit.
@@ -339,10 +383,10 @@ export function inferParamTypeFromCallSites(
         }
       }
     }
-    forEachChild(node, visit);
   }
 
-  forEachChild(sourceFile, visit);
+  // Was `forEachChild(sourceFile, visit)` — a whole-program walk per call.
+  for (const site of calleeNameIndex(sourceFile).get(funcName) ?? []) visit(site);
   // (TS control-flow can't see the closure mutation of `agreed` — assert its
   // declared type so the property narrowing below typechecks.)
   let type: ValType | null = conflict ? null : (agreed as ValType | null);


### PR DESCRIPTION
## Description

Follow-up to #4516. That PR fixed constant-factor costs; this one fixes an actual **complexity** bug.

`inferParamTypeFromCallSites(ctx, funcName, paramIndex, sourceFile)` walked the **entire source file** with `forEachChild` looking for calls to one function — and it's invoked once per (function, parameter) from three call sites. O(functions × params × programSize).

| units | calls | AST nodes visited |
| --- | --- | --- |
| 32 | 128 | 184,448 |
| 128 | 512 | 2,949,632 |
| 512 | 2,048 | **47,187,968** |

4× the input, 16× the work. 47 million node visits for a 61 KB input.

### How it was found

By measuring compile time **against input size** rather than at one size. The tell is `ms/KB`: it falls while fixed cost amortises, then **turns back up** past ~128 units.

| units | ms | ms/KB | implied exponent |
| --- | --- | --- | --- |
| 64 | 385 | 53.5 | 0.77 |
| 128 | 688 | 47.2 | 0.84 |
| 256 | 1930 | 65.0 | **1.49** |
| 512 | 6041 | 100.8 | **1.65** |

A CPU profile of the 512-unit compile put a single `visit` in this module at **25.2% of total compile time**, with TypeScript's `forEachChild`/`visitNode` underneath it accounting for most of the next 20%. Fixed cost was ruled out separately — an empty program compiles in **6.8 ms**, 1% of that run.

### Fix

Index call sites by callee name **once per source file**, cached in a `WeakMap` keyed on the `SourceFile` object. The node test being replaced was already exactly indexable; only the `ctorSitesEnabled` half stays at the lookup, since that's a runtime flag rather than a property of the node.

Three properties preserved deliberately:

- **Coverage** — the index is built with the same `forEachChild(sourceFile, …)` traversal, so it sees the same node set.
- **Order** — buckets keep document order, so the order-dependent `agreed` / `conflict` / `sawUnderApplied` accumulation resolves identically.
- **Invalidation** — keying on the `SourceFile` object means a new program, or a cjs-rewritten file, gets a fresh index. Nothing to invalidate, no cross-compile leak.

### Result

| units | before | after | speedup |
| --- | --- | --- | --- |
| 128 | 688 ms | 454 ms | 1.52× |
| 256 | 1930 ms | 750 ms | 2.57× |
| 512 | **6041 ms** | **1388 ms** | **4.35×** |

Exponent **1.65 → 0.89**; `ms/KB` now falls monotonically (58.0 → 23.1). Linear.

**Small inputs are unchanged** (test262 bench: 429 ms before and after). A harness-wrapped test262 file has too few distinct functions for the quadratic term to dominate — which is exactly why this never surfaced in the test262 profile and only appeared once compile time was measured against input size. The win is on real-world code.

### Verification

22 files across the param-inference surface (`743`, `3548`, `3961`, `fnctor`, `param`, `inference`, `ctor-param`, `4155`, `4235`), run on this change **and** on `origin/main`: **131 passed / 19 failed on both**, identical. Those 19 are pre-existing on `origin/main`.

### Corroboration

An independent self-hosting investigation (compiling js2wasm with js2wasm) measured `src/ir/lower.ts` at **97.9 s inside a 71-file graph vs 18.4 s standalone** — a 5.3× in-graph inflation — against `239cad0b`, i.e. before this fix. That is the same signature: per-function whole-program walks inflating with graph size. Re-measuring that case on this commit is the obvious next step.

### Follow-up

`inferNumericReturnTypes` and `inferBindingAwareNumericReturnTypes` in this module also take a whole `sourceFile` and should be checked for the same scan-per-query shape.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHo1sZKsmZinYGbscm1pft)_