### PR TITLE
perf(#4425): WIP — kind-indexed dispatch for runNodeChecks [SUSPENDED, unvalidated]

### DIFF
--- a/plan/agent-context/ts7-migration-and-compile-perf-2026-08-14.md
+++ b/plan/agent-context/ts7-migration-and-compile-perf-2026-08-14.md
@@ -1,0 +1,96 @@
+# Handoff — TS7 migration lane, oracle adjudication, compile performance
+
+Session 2026-08-14 → 08-15. Branch `claude/typescript-7-migration-9kperg`.
+Everything below is **merged** unless marked otherwise.
+
+## What landed
+
+| PR | What |
+| --- | --- |
+| #4500 / #4501 | Conflict sampling in the oracle ledger + `src/checker/divergence-classifier.ts` — a four-way structural verdict (`same-meaning` / `inhouse-weaker` / `checker-weaker` / `genuine-conflict`) |
+| #4503 | A local scoped test262 run could append to the committed trend index — guarded (`scripts/should-publish-run-history.mjs`) |
+| #4516 | Compile hot path **−17%** (#4415) — three allocation/env-read fixes |
+| #4517 | Unit-suite parallelism — `vitest.config.ts` unpinned from `maxForks: 1` |
+| #4518 | Three ES early-error false positives (#4417) — 130 → 0 across our own `src/**` |
+| #4519 | Compile was **quadratic** in program size — **4.7×** at 512 functions (#4423) |
+| #4521 | *(open)* corrects a wrong claim in #4423's note — see "Corrections" |
+
+## The headline findings
+
+### 1. The "908 oracle conflicts" number was mostly a broken classifier
+
+Corrected split: **136** same-meaning, **318** in-house-weaker, **366**
+checker-weaker, **88** genuine. `signatureOf` — 374 of the original 908, once
+quoted as a "95.9% conflict rate" — has **zero** genuine conflicts.
+
+### 2. TypeScript is not ground truth (#4410)
+
+Adjudicated against ECMAScript, the checker is **wrong** for: a local `let`
+resolved to a lib.dom global, a shadowed `var eval`, an unanswered `let`, and
+any program reached through `eval` (its `ts.Program` excludes it). The in-house
+backend is **wrong** for `with`-scoped lexical resolution and `declaredNameOf`
+inventing `ArrayConstructor` (#4409).
+
+**Consequence for #4218:** parity with the checker is the wrong retirement
+gate. The restated gate is in #4410.
+
+### 3. #4218's retirement gate is NOT met
+
+Scoped standalone test262 A/B, 3,137 tests in the divergence areas: checker
+**1891** vs inhouse **1854** = **−37**. 42 regressions (27 `with`, 12 annexB
+B.3.3, 3 undiagnosed), 5 improvements.
+
+### 4. "TypeScript is 90% of compile time" is false on the path that matters
+
+True only with semantic diagnostics ON (one `getSemanticDiagnostics()` = 365 ms
+of a 404 ms compile). test262's production path already passes
+`skipSemanticDiagnostics: true`, so TS is ~1% there. **The compiler itself is
+the cost**, and it was quadratic.
+
+### 5. Self-hosting: three concrete walls
+
+730 files / 23.7 MB resolve in 4.6 s and the early-error gate now passes.
+Codegen does not finish. Largest validating subgraph is `src/interp/**`
+(10 files → 366 KB of valid Wasm).
+
+## Corrections worth carrying forward
+
+**The `runNodeChecks` early-out is fixable — the note in #4423 said otherwise
+and was wrong.** The first attempt lost 1,185 diagnostics not because the kind
+set was incomplete, but because the recursion is the *last statement of the
+function*, so an early `return` pruned whole subtrees. Done correctly
+(traverse/check split) it loses **0**. It is still reverted, on measurement:
+1295 → 1285 ms, i.e. noise. That also weakens the `switch (node.kind)`
+follow-up — the Set gate is a proxy for half the switch's benefit and that half
+measured zero. #4521 lands the corrected text.
+
+**Do not read a green PR-level `check for test262 regressions` as conformance
+evidence.** It is a designed no-op on `pull_request`.
+
+## Open, in priority order
+
+| # | What | Size |
+| --- | --- | --- |
+| **4421** | `{ ...spread, method() {} }` → `Missing __make_getter_callback import`. Blocks `src/ts-api.ts` → **657 of 768 files**. The thing that actually unblocks self-hosting past 10 files. | m |
+| **4419** | `compileFiles` silently binds `node:*` to `ref.null extern` and reports success. Small, localized. | s |
+| **4420** | Gate scoreboards on `WebAssembly.compile`, not on "no exception"; root-cause the `encodeInstr` struct.get/f64 mismatch. | s |
+| 4422 | Module-object externals. | Backlog |
+| 4418 | Dominator tree / dominance frontier — **another lane has PR #4520 open on this**, check before starting. | xl |
+| 1029 / 4411 | The TsFacade — one interface over TS5 and TS7. TaskList item #9, still pending. | m |
+| 4410 | Adjudicate the remaining `checker-weaker` rows into A/B/C. | m |
+
+## Loose ends
+
+- **GC is ~10% of compile time** and has never been heap-profiled
+  (`--heap-prof` was never run). The CPU profile cannot attribute allocation.
+- **`shiftGlobalIndices` is quadratic**, still 1.5% — 32 calls walking 89,281
+  instructions per compile. Batching is *provably* equivalent (see #4415); what
+  blocks it is the flush protocol across 259 scattered call sites.
+- Next profile candidates: `canonicalProgramAbiValType` 2.1%, `fixupInstrs`
+  1.4%, `locateOperandProducers` 1.4%. `src/codegen` is still ~56%.
+
+## Reproduce
+
+`.tmp/` is gitignored and did not survive; the drivers are described in #4415
+("Reproduce") and #4423. The one non-obvious step: burn a distinctive frame
+before the measured loop, or ~22% of CPU samples are tsx module loading.

--- a/plan/issues/4423-quadratic-param-inference-and-import-scan.md
+++ b/plan/issues/4423-quadratic-param-inference-and-import-scan.md
@@ -97,24 +97,45 @@ All those failures are **pre-existing on `origin/main`**.
 
 ## Rejected: an early-out in `runNodeChecks`
 
-`runNodeChecks` is a sequential chain of ~55 `ts.isX(node)` predicates run for
-every AST node, at 4.4% **self** time. The obvious fix is to bail immediately
-for kinds no check can act on. I derived the kind set mechanically from the
-function body — every `ts.isX(node)` guard and every
-`node.kind === ts.SyntaxKind.X` test, 57 kinds, all resolving cleanly — and it
-was still **wrong**.
+`runNodeChecks` is a sequential chain of ~95 guarded checks run for every AST
+node, at 4.4% **self** time. The obvious fix is to bail immediately for kinds
+no check can act on. I derived the kind set mechanically from the function body
+— every `ts.isX(node)` guard and every `node.kind === ts.SyntaxKind.X` test,
+57 kinds, all resolving cleanly.
 
-A differential over 7,854 files (test262 `language` + `annexB` + `src`) showed
-diagnostics dropping **2,571 → 1,386**. Checks like "Function declarations are
-not allowed in statement position" key off `DoStatement` / `WhileStatement`,
-which never appear as a literal `ts.isX(node)` guard in the source, so no
-text-derived list can be complete.
+**First attempt lost 1,185 diagnostics** in a differential over 7,854 files
+(test262 `language` + `annexB` + `src`): **2,571 → 1,386**.
 
-Reverted; the revert reproduces 2,571 byte-identically. Recorded here because
-the *next* person to profile this will have the same idea. Doing it safely
-means restructuring the chain into a `switch (node.kind)` so the dispatch set
-is the code rather than a parallel list — a mechanical but large refactor of a
-1,900-line function, and worth its own issue.
+**My first diagnosis of that loss was wrong, and it is worth recording why.** I
+concluded that checks keying off `DoStatement`/`WhileStatement` never appear as
+a literal `ts.isX(node)` guard, so "no text-derived list can be complete". That
+is false — *"Function declarations are not allowed in statement position"* is
+guarded by `ts.isFunctionDeclaration(node)`, kind 263, which **was** in the
+derived set. The real bug was structural: the recursion
+`forEachChild(node, (child) => runNodeChecks(ctx, child))` is the **last
+statement of the function**, so an early `return` pruned entire subtrees rather
+than skipping one node's checks.
+
+Re-implemented correctly — `runNodeChecks` traverses unconditionally,
+`runNodeChecksSelf` holds the 95 guards and is called only for kinds in the
+set — the same differential loses **0 diagnostics**.
+
+**Reverted anyway, on measurement.** 512 units 1295 → 1285 ms; small inputs
+~424 → ~421 ms. Both inside noise. A 57-element parallel list that drifts
+silently and disables conformance checks when it does is not worth zero
+measured gain.
+
+**This also argues against the `switch (node.kind)` refactor**, which was the
+recommended follow-up in the first version of this note. The Set gate is a
+cheap proxy for *half* of what a switch buys — skipping nodes no check handles.
+That half measured zero. The other half (dispatching directly to the handful of
+checks for a handled kind, instead of running all 95 guards) is the remaining
+upside, but the structure is favourable for it: 95 guards, exactly one non-`if`
+top-level statement (the recursion), no shared state between guards, no union
+predicates, and every guard leads with a kind test (30 bare `ts.isX(node)`,
+65 that plus a further condition). So a switch is *mechanically feasible* — it
+just has a much smaller expected payoff than the profile line suggests, and
+should be measured on a prototype before anyone commits to the refactor.
 
 ## Reproduce
 

--- a/plan/issues/4425-node-checks-switch-dispatch.md
+++ b/plan/issues/4425-node-checks-switch-dispatch.md
@@ -1,0 +1,135 @@
+---
+id: 4425
+title: "runNodeChecks kind-indexed dispatch — mechanical restructure of the 95-block early-error guard chain"
+status: suspended
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: compiler
+goal: velocity
+loc-budget-allow:
+  - src/compiler/early-errors/node-checks.ts
+---
+
+# #4425 — kind-indexed dispatch for `runNodeChecks`
+
+Follow-up to #4423 (PR #4519, merged) and its corrected rejected-early-out note
+(PR #4521): restructure `src/compiler/early-errors/node-checks.ts` from a flat
+chain of ~95 guarded checks evaluated for EVERY AST node into a
+`SyntaxKind`-indexed dispatch table, so a node runs only the checks registered
+for its kind.
+
+## Why (measurements from this session, 2026-08-15)
+
+All numbers from the corpus = test262 `language` + `annexB` + this repo's
+`src/**/*.ts` (25,863 files, or a 1-in-3 sample of 8,621 files / 22.9 MB).
+The box was heavily loaded (another session's 7 vitest workers + an acorn
+compile), so wall-clock was abandoned in favour of process-CPU and
+deterministic counting; treat CPU numbers as approximate, ratios as reliable.
+
+- `detectEarlyErrors` baseline over the 8,621-file sample: **~38 s CPU** (best
+  of 3, decreasing trend — treat as upper bound).
+- Same with **all 95 check blocks removed, traversal + all other passes
+  kept**: **~3.0 s CPU**. So the per-node check machinery is ~92% of
+  detectEarlyErrors.
+- CPU profile (1-in-9 sample): `runNodeChecks` **self** 5.7 s, the ~30
+  distinct `ts.isX` guard calls ~2.5–3 s combined, the per-node recursion
+  closure `(child) => runNodeChecks(ctx, child)` ~3.1 s, GC 1.15 s. The guard
+  chain + traversal machinery is roughly **40% of detect CPU**; the remaining
+  ~60% is fired check bodies (`isStrictMode` ancestor walks on every
+  identifier, `isInsideClassWithPrivateName` 0.6 s, per-visit
+  `new Set([...])`/array allocations, `getText`/substring).
+- Context (PR #4521): a Set-based early-out that only SKIPPED no-check kinds
+  measured **zero** on full compiles — most nodes have ≥1 registered check, so
+  skipping alone buys nothing. The dispatch win must come from running ~1–6
+  checks per node instead of evaluating 95 guards. The profile above says that
+  guard-evaluation overhead is real (~40% of detect), unlike the skip-half.
+
+## Design (implemented, NOT yet validated)
+
+`on([kinds], (ctx, node) => { <original block, verbatim> })` registrations +
+`NODE_CHECKS: NodeCheck[][]` indexed by `node.kind`; `runNodeChecks` hoists
+one `visit` closure per file (was one per node) and runs only
+`NODE_CHECKS[node.kind]`. Two safety invariants:
+
+1. **Every block keeps its original top-level guard verbatim** — an
+   over-registered kind is rejected by the guard, so the registered kind list
+   can only LOSE diagnostics (caught by the differential), never admit new
+   ones.
+2. **Registration in original chain order** ⇒ per-kind execution order is
+   exactly the original relative order (checks of other kinds could never fire
+   on the same node anyway).
+3. **Traversal is unconditional** — dispatch selects checks, never whether a
+   subtree is visited. (The #4423 first early-out attempt returned before the
+   recursion and lost 46% of diagnostics; that is the failure mode to avoid.)
+
+The file was **generated, not hand-edited**: `.tmp/gen-dispatch.mts` (in the
+worktree, gitignored) parses the original with the TS parser, slices each of
+the 95 top-level if-statements out by exact source range (leading comments
+included — no transcription of `  ` regexes or anything else), derives
+each block's kind set from its own guard, and cross-checks against a
+hand-written 95-entry catalog. Both derivations agreed on all 95 blocks.
+Hand-transcription was attempted first and immediately produced a corrupted
+`/[  ]/` regex — do not hand-edit this transformation.
+
+## Suspended Work
+
+- **Worktree**: `/workspace/.claude/worktrees/issue-4425-node-checks-switch-dispatch`
+- **Branch**: `issue-4425-node-checks-switch-dispatch` (based on upstream/main
+  at `adfa21c32`, with PR #4521's branch merged in)
+- **State**: the generated dispatch version of
+  `src/compiler/early-errors/node-checks.ts` is committed on this branch.
+  **No gate has passed yet.** The PR carrying this is a DRAFT and must not be
+  un-drafted until the checklist below is green.
+- **Gitignored artifacts in the worktree's `.tmp/`** (lost if the worktree is
+  deleted — regenerate as described):
+  - `node-checks.base.ts` — pristine pre-refactor copy (= the file at merge
+    base; recover with `git show <base>:src/compiler/early-errors/node-checks.ts`)
+  - `gen-dispatch.mts` — the generator (rerun:
+    `npx tsx .tmp/gen-dispatch.mts .tmp/node-checks.base.ts <out>`)
+  - `ee-diff.mts` — diagnostics differential harness; dumps one JSONL row per
+    diagnostic over the corpus in deterministic file order
+  - `ee-base.jsonl` — **baseline differential output on the pre-refactor
+    tree**: 25,863 files, 23,979 diagnostics, 0 exceptions
+  - `ee-time.mts` — CPU-time harness (parse once, time detect only)
+  - `ee-count.mts` — deterministic guard-evaluation counter (written, NEVER
+    RUN — the box was taxed and the session was suspended here)
+
+### Resume checklist (in order)
+
+1. `npx tsc --noEmit` in the worktree — was started, killed before finishing;
+   **completely unverified**. Fix any type errors (the generated wrappers use
+   `(ctx, node)` params shadowing nothing; `node` is `ts.Node`, original
+   guards narrow).
+2. `pnpm exec prettier --write src/compiler/early-errors/node-checks.ts` (the
+   generated layout is not prettier-clean).
+3. Re-run the differential: `npx tsx .tmp/ee-diff.mts .tmp/ee-new.jsonl`, then
+   `cmp .tmp/ee-base.jsonl .tmp/ee-new.jsonl`. **Byte-identical or the change
+   does not ship.** If the baseline file is gone, regenerate it from the merge
+   base's node-checks.ts (swap the file, run, swap back — file-copy A/B, no
+   stash).
+4. Run `.tmp/ee-count.mts` for the load-independent numbers (guard evaluations
+   before = 95 × nodes; after = Σ registered checks per node; expected
+   somewhere around 10–30× fewer — REPORT THE MEASURED NUMBER, this predicted
+   range is not evidence).
+5. Early-error test files: `npm test -- tests/issue-4417-early-error-false-positives.test.ts`
+   plus grep `tests/` for other early-error suites.
+6. On a quiet box (or CI), optionally re-measure detect CPU A/B for the PR
+   body; under load use only CPU-time ratios and the counter.
+7. Un-draft the PR, let auto-enqueue take it. The issue frontmatter status
+   flips to `done` in that same PR (self-merge path).
+
+### Known open questions
+
+- Whether the ~40% guard-machinery share translates into a comparable
+  detect-time reduction (indirect-call overhead of the closure array vs the
+  inlined predicate chain is unmeasured).
+- The remaining ~60% (check bodies) is untouched here and is the larger prize:
+  `isStrictMode` memoization, hoisting per-visit `new Set`/array constants,
+  `isInsideClassWithPrivateName`. Deliberately out of scope for this
+  mechanical PR — file follow-ups with measurements.

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -74,15 +74,56 @@ function hasLegacyStringEscape(raw: string): boolean {
   }
   return false;
 }
+type NodeCheck = (ctx: EarlyErrorContext, node: ts.Node) => void;
+
+/**
+ * Per-node checks indexed by ts.SyntaxKind (#4425). Each check registers, via
+ * `on([kinds], fn)`, the SyntaxKinds its top-level guard can accept, and
+ * `runNodeChecks` runs only the checks registered for `node.kind`. Until
+ * #4425 this was a flat chain of ~95 guarded checks evaluated for EVERY node —
+ * the guard chain itself (95 `ts.isX(node)` calls per node) plus a fresh
+ * recursion closure per node were a large share of detectEarlyErrors' CPU.
+ *
+ * Two invariants make the dispatch behaviour-preserving:
+ *   1. Every check body keeps its original `ts.isX(node)` guard, so
+ *      over-registering a kind is harmless (the guard rejects it) and the
+ *      registered kind list can never ADMIT a node the old chain rejected.
+ *   2. Registration happens in the original chain order, so for any kind the
+ *      checks run in exactly the original relative order.
+ *
+ * When you ADD a check: wrap it in `on([...kinds], (ctx, node) => { ... })`
+ * with the kind(s) its guard tests, keep the guard in the body, and place it
+ * in document order relative to other checks of the same kind.
+ */
+const NODE_CHECKS: NodeCheck[][] = [];
+
+function on(kinds: readonly ts.SyntaxKind[], check: NodeCheck): void {
+  for (const kind of kinds) (NODE_CHECKS[kind] ??= []).push(check);
+}
 
 /**
  * Run all per-node early-error checks rooted at `node`, recursing into its
  * descendants. Equivalent to the original detectEarlyErrors `visit` closure.
+ * Traversal is unconditional — dispatch only selects which CHECKS run for a
+ * node, never whether its subtree is visited (an early-out that returned
+ * before the recursion pruned whole subtrees and lost 46% of all diagnostics
+ * — see #4423's rejected-early-out note).
  */
-export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
-  // Check prefix/postfix increment/decrement on arguments/eval in strict mode
-  // Also check increment/decrement on optional chaining (always invalid)
-  // Also check increment/decrement on non-simple assignment targets
+export function runNodeChecks(ctx: EarlyErrorContext, root: ts.Node): void {
+  const visit = (node: ts.Node): void => {
+    const checks = NODE_CHECKS[node.kind];
+    if (checks !== undefined) {
+      for (const check of checks) check(ctx, node);
+    }
+    forEachChild(node, visit);
+  };
+  visit(root);
+}
+
+// Check prefix/postfix increment/decrement on arguments/eval in strict mode
+// Also check increment/decrement on optional chaining (always invalid)
+// Also check increment/decrement on non-simple assignment targets
+on([ts.SyntaxKind.PrefixUnaryExpression], (ctx, node) => {
   if (
     ts.isPrefixUnaryExpression(node) &&
     (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)
@@ -99,7 +140,9 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "Invalid left-hand side expression in prefix operation");
     }
   }
+});
 
+on([ts.SyntaxKind.PostfixUnaryExpression], (ctx, node) => {
   if (
     ts.isPostfixUnaryExpression(node) &&
     (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)
@@ -126,9 +169,11 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "No line terminator allowed before postfix operator");
     }
   }
+});
 
-  // Check assignment to arguments/eval in strict mode
-  // Also check assignment to non-simple targets
+// Check assignment to arguments/eval in strict mode
+// Also check assignment to non-simple targets
+on([ts.SyntaxKind.BinaryExpression], (ctx, node) => {
   if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
     const name = isArgumentsOrEval(node.left);
     if (name && isStrictMode(node)) {
@@ -149,9 +194,11 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       validateObjectAssignmentPattern(ctx, lhs, isStrictMode(node));
     }
   }
+});
 
-  // Check compound assignment to arguments/eval in strict mode
-  // Also check logical assignment (&&=, ||=, ??=) to non-simple targets
+// Check compound assignment to arguments/eval in strict mode
+// Also check logical assignment (&&=, ||=, ??=) to non-simple targets
+on([ts.SyntaxKind.BinaryExpression], (ctx, node) => {
   if (ts.isBinaryExpression(node)) {
     const op = node.operatorToken.kind;
     const compoundOps = [
@@ -190,8 +237,10 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // Check for-in/for-of with non-simple assignment target as LHS
+// Check for-in/for-of with non-simple assignment target as LHS
+on([ts.SyntaxKind.ForInStatement, ts.SyntaxKind.ForOfStatement], (ctx, node) => {
   if ((ts.isForInStatement(node) || ts.isForOfStatement(node)) && !ts.isVariableDeclarationList(node.initializer)) {
     const lhs = node.initializer as ts.Expression;
     const isCallTarget = isCallExpressionTarget(lhs);
@@ -205,14 +254,22 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       validateObjectAssignmentPattern(ctx, lhs, isStrictMode(node));
     }
   }
+});
 
-  // Check duplicate parameters in strict mode functions
+// Check duplicate parameters in strict mode functions
+on([ts.SyntaxKind.FunctionDeclaration], (ctx, node) => {
   if (ts.isFunctionDeclaration(node) && node.parameters) {
     checkDuplicateParams(ctx, node.parameters, node);
   }
+});
+
+on([ts.SyntaxKind.FunctionExpression], (ctx, node) => {
   if (ts.isFunctionExpression(node) && node.parameters) {
     checkDuplicateParams(ctx, node.parameters, node);
   }
+});
+
+on([ts.SyntaxKind.ArrowFunction], (ctx, node) => {
   if (ts.isArrowFunction(node) && node.parameters) {
     checkDuplicateParams(ctx, node.parameters, node);
     // ── Arrow function ASI restriction ────────────────────────────
@@ -250,15 +307,20 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
+
+on([ts.SyntaxKind.MethodDeclaration], (ctx, node) => {
   if (ts.isMethodDeclaration(node) && node.parameters) {
     checkDuplicateParams(ctx, node.parameters, node);
   }
+});
 
-  // ── YieldExpression in generator default parameters ──────────────
-  // ES spec: It is a SyntaxError if FormalParameters of a generator
-  // function Contains YieldExpression. Default parameter values are
-  // evaluated before the generator body, so yield is not valid there.
-  // Same applies to async generators (AwaitExpression in params).
+// ── YieldExpression in generator default parameters ──────────────
+// ES spec: It is a SyntaxError if FormalParameters of a generator
+// function Contains YieldExpression. Default parameter values are
+// evaluated before the generator body, so yield is not valid there.
+// Same applies to async generators (AwaitExpression in params).
+on([ts.SyntaxKind.YieldExpression], (ctx, node) => {
   if (ts.isYieldExpression(node)) {
     if (isInsideGeneratorParams(node)) {
       ctx.addError(node, "Yield expression is not allowed in generator function parameters");
@@ -285,13 +347,18 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "A 'yield' expression is only allowed within a generator body");
     }
   }
+});
+
+on([ts.SyntaxKind.AwaitExpression], (ctx, node) => {
   if (ts.isAwaitExpression(node)) {
     if (isInsideAsyncParams(node)) {
       ctx.addError(node, "Await expression is not allowed in async function parameters");
     }
   }
+});
 
-  // Check yield used as identifier in generator functions/methods
+// Check yield used as identifier in generator functions/methods
+on([ts.SyntaxKind.VariableDeclaration], (ctx, node) => {
   if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === "yield") {
     // Check if inside a generator function/method
     let parent: ts.Node | undefined = node.parent;
@@ -317,12 +384,14 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       parent = parent.parent;
     }
   }
+});
 
-  // Check function declarations in statement position
-  // ES spec: GeneratorDeclaration and AsyncFunctionDeclaration are never valid in
-  // SingleStatement position. Regular FunctionDeclaration is SyntaxError in strict mode.
-  // Annex B relaxes this ONLY for IfStatement in sloppy mode — iteration statements
-  // (for, while, do, for-in, for-of) and with statements always forbid it.
+// Check function declarations in statement position
+// ES spec: GeneratorDeclaration and AsyncFunctionDeclaration are never valid in
+// SingleStatement position. Regular FunctionDeclaration is SyntaxError in strict mode.
+// Annex B relaxes this ONLY for IfStatement in sloppy mode — iteration statements
+// (for, while, do, for-in, for-of) and with statements always forbid it.
+on([ts.SyntaxKind.FunctionDeclaration], (ctx, node) => {
   if (ts.isFunctionDeclaration(node)) {
     const parent = node.parent;
     if (parent && isStatementPosition(parent, node)) {
@@ -340,19 +409,23 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // Check class declaration in statement position — always a SyntaxError
-  // ES spec: ClassDeclaration is not a Statement — only allowed in StatementList
+// Check class declaration in statement position — always a SyntaxError
+// ES spec: ClassDeclaration is not a Statement — only allowed in StatementList
+on([ts.SyntaxKind.ClassDeclaration], (ctx, node) => {
   if (ts.isClassDeclaration(node)) {
     const parent = node.parent;
     if (parent && isStatementPosition(parent, node)) {
       ctx.addError(node, "Class declaration not allowed in statement position");
     }
   }
+});
 
-  // Check labeled function declarations in iteration/if statement positions
-  // ES spec: IsLabelledFunction — a labeled function declaration (at any label depth)
-  // in the Statement position of for/while/do-while/if/with is always a SyntaxError.
+// Check labeled function declarations in iteration/if statement positions
+// ES spec: IsLabelledFunction — a labeled function declaration (at any label depth)
+// in the Statement position of for/while/do-while/if/with is always a SyntaxError.
+on([ts.SyntaxKind.LabeledStatement], (ctx, node) => {
   if (ts.isLabeledStatement(node)) {
     const parent = node.parent;
     if (parent && isStatementPosition(parent, node)) {
@@ -367,8 +440,10 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // Check private name (#x) used outside its declaring class
+// Check private name (#x) used outside its declaring class
+on([ts.SyntaxKind.PrivateIdentifier], (ctx, node) => {
   if (ts.isPrivateIdentifier(node)) {
     // A PrivateIdentifier is only valid as a MemberExpression private reference
     // (`this.#x`, `#x in obj`) or a class-member name. It cannot appear as a
@@ -390,42 +465,55 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, `Private field '${node.text}' must be declared in an enclosing class`);
     }
   }
+});
 
-  // Check var redeclaration conflicts with lexical declarations in block/module scope
-  // ES spec: It is a Syntax Error if any element of VarDeclaredNames also occurs
-  // in LexicallyDeclaredNames of the StatementList.
+// Check var redeclaration conflicts with lexical declarations in block/module scope
+// ES spec: It is a Syntax Error if any element of VarDeclaredNames also occurs
+// in LexicallyDeclaredNames of the StatementList.
+on([ts.SyntaxKind.Block, ts.SyntaxKind.SourceFile], (ctx, node) => {
   if (ts.isBlock(node) || ts.isSourceFile(node)) {
     checkVarLexicalConflicts(ctx, node);
   }
+});
 
-  // Check TDZ violations for let/const in block-like scopes
-  // These are also caught by TS checker (2448/2474) as downgraded warnings.
-  // We emit them as warnings here so compilation continues — tests expect runtime ReferenceError.
-  if (ts.isSourceFile(node) || ts.isBlock(node) || ts.isCaseClause(node) || ts.isDefaultClause(node)) {
-    const stmts = ts.isSourceFile(node) ? node.statements : ts.isBlock(node) ? node.statements : node.statements;
-    checkTDZInStatements(ctx, stmts);
-  }
+// Check TDZ violations for let/const in block-like scopes
+// These are also caught by TS checker (2448/2474) as downgraded warnings.
+// We emit them as warnings here so compilation continues — tests expect runtime ReferenceError.
+on(
+  [ts.SyntaxKind.SourceFile, ts.SyntaxKind.Block, ts.SyntaxKind.CaseClause, ts.SyntaxKind.DefaultClause],
+  (ctx, node) => {
+    if (ts.isSourceFile(node) || ts.isBlock(node) || ts.isCaseClause(node) || ts.isDefaultClause(node)) {
+      const stmts = ts.isSourceFile(node) ? node.statements : ts.isBlock(node) ? node.statements : node.statements;
+      checkTDZInStatements(ctx, stmts);
+    }
+  },
+);
 
-  // Check references to a switch-case lexical binding outside the switch (#1805).
-  // ES spec: the LexicallyDeclaredNames of a CaseBlock are scoped to that block.
-  // `switch (0) { default: const x = 1; } x;` therefore throws a runtime
-  // ReferenceError on `x` — the binding does not exist in the enclosing scope.
-  // TS would flag this (TS2304 "Cannot find name 'x'") but the test262 runner
-  // compiles with skipSemanticDiagnostics, so we re-detect it syntactically and
-  // emit a warning (the runtime-negative path treats any warning as the expected
-  // error). We don't descend into nested functions; var-hoisting is unaffected.
+// Check references to a switch-case lexical binding outside the switch (#1805).
+// ES spec: the LexicallyDeclaredNames of a CaseBlock are scoped to that block.
+// `switch (0) { default: const x = 1; } x;` therefore throws a runtime
+// ReferenceError on `x` — the binding does not exist in the enclosing scope.
+// TS would flag this (TS2304 "Cannot find name 'x'") but the test262 runner
+// compiles with skipSemanticDiagnostics, so we re-detect it syntactically and
+// emit a warning (the runtime-negative path treats any warning as the expected
+// error). We don't descend into nested functions; var-hoisting is unaffected.
+on([ts.SyntaxKind.SourceFile, ts.SyntaxKind.Block], (ctx, node) => {
   if (ts.isSourceFile(node) || ts.isBlock(node)) {
     checkSwitchLexicalLeak(ctx, node.statements);
   }
+});
 
-  // Check 'with' statement — SyntaxError in strict mode (all modules are strict)
+// Check 'with' statement — SyntaxError in strict mode (all modules are strict)
+on([ts.SyntaxKind.WithStatement], (ctx, node) => {
   if (ts.isWithStatement(node) && isStrictMode(node)) {
     ctx.addError(node, "Strict mode code may not include a with statement");
   }
+});
 
-  // Check legacy octal literals (e.g. 077) and non-octal decimal integers (e.g. 08, 09)
-  // — SyntaxError in strict mode
-  // ES2015+ octal (0o77) is fine; only legacy forms are illegal
+// Check legacy octal literals (e.g. 077) and non-octal decimal integers (e.g. 08, 09)
+// — SyntaxError in strict mode
+// ES2015+ octal (0o77) is fine; only legacy forms are illegal
+on([ts.SyntaxKind.NumericLiteral], (ctx, node) => {
   if (ts.isNumericLiteral(node) && isStrictMode(node)) {
     const text = node.getText(ctx.sourceFile);
     // Legacy octal: starts with 0, followed by digits 0-7
@@ -440,21 +528,25 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // #2708 — Legacy string-literal escapes are a SyntaxError in strict mode
-  // (ES Annex B §12.9.4 only enables them in non-strict code). The TS scanner's
-  // 1487/1488 errors are downgraded in compiler.ts so sloppy code compiles, so we
-  // re-raise them here for strict code — mirroring the numeric-octal check above.
-  //   • LegacyOctalEscapeSequence:    \1–\7, \0 followed by an octal/decimal digit
-  //   • NonOctalDecimalEscapeSequence: \8 \9
-  // The lone `\0` NUL escape (not followed by a decimal digit) stays legal.
+// #2708 — Legacy string-literal escapes are a SyntaxError in strict mode
+// (ES Annex B §12.9.4 only enables them in non-strict code). The TS scanner's
+// 1487/1488 errors are downgraded in compiler.ts so sloppy code compiles, so we
+// re-raise them here for strict code — mirroring the numeric-octal check above.
+//   • LegacyOctalEscapeSequence:    \1–\7, \0 followed by an octal/decimal digit
+//   • NonOctalDecimalEscapeSequence: \8 \9
+// The lone `\0` NUL escape (not followed by a decimal digit) stays legal.
+on([ts.SyntaxKind.StringLiteral], (ctx, node) => {
   if (ts.isStringLiteral(node) && isStrictMode(node)) {
     if (hasLegacyStringEscape(node.getText(ctx.sourceFile))) {
       ctx.addError(node, "Octal escape sequences are not allowed in strict mode");
     }
   }
+});
 
-  // Check 'delete' of an unqualified identifier — SyntaxError in strict mode
+// Check 'delete' of an unqualified identifier — SyntaxError in strict mode
+on([ts.SyntaxKind.DeleteExpression], (ctx, node) => {
   if (ts.isDeleteExpression(node) && isStrictMode(node)) {
     let operand: ts.Expression = node.expression;
     while (ts.isParenthesizedExpression(operand)) {
@@ -464,11 +556,13 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, `Delete of an unqualified identifier in strict mode`);
     }
   }
+});
 
-  // Check 'delete' on private names — always a SyntaxError
-  // ES spec: delete MemberExpression.PrivateName and delete CallExpression.PrivateName
-  // are early errors (class bodies are always strict mode).
-  // Covers: delete this.#x, delete (this.#x), delete g().#x, delete (g().#x)
+// Check 'delete' on private names — always a SyntaxError
+// ES spec: delete MemberExpression.PrivateName and delete CallExpression.PrivateName
+// are early errors (class bodies are always strict mode).
+// Covers: delete this.#x, delete (this.#x), delete g().#x, delete (g().#x)
+on([ts.SyntaxKind.DeleteExpression], (ctx, node) => {
   if (ts.isDeleteExpression(node)) {
     let operand: ts.Expression = node.expression;
     while (ts.isParenthesizedExpression(operand)) {
@@ -478,10 +572,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, `Deleting a private field is a SyntaxError`);
     }
   }
+});
 
-  // Check for-in loop with initializer — SyntaxError in strict mode for var,
-  // always a SyntaxError for let/const (ES2015+)
-  // Also: var with destructuring pattern + initializer is always SyntaxError (Annex B)
+// Check for-in loop with initializer — SyntaxError in strict mode for var,
+// always a SyntaxError for let/const (ES2015+)
+// Also: var with destructuring pattern + initializer is always SyntaxError (Annex B)
+on([ts.SyntaxKind.ForInStatement], (ctx, node) => {
   if (ts.isForInStatement(node)) {
     const init = node.initializer;
     if (ts.isVariableDeclarationList(init)) {
@@ -520,10 +616,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // Check for-of loop: declarations may not have initializers; lexical must be single binding
-  // ES spec: ForInOfStatement: for (var ForBinding of AssignmentExpression) — no initializer.
-  // Also for let/const: no initializer and only one binding.
+// Check for-of loop: declarations may not have initializers; lexical must be single binding
+// ES spec: ForInOfStatement: for (var ForBinding of AssignmentExpression) — no initializer.
+// Also for let/const: no initializer and only one binding.
+on([ts.SyntaxKind.ForOfStatement], (ctx, node) => {
   if (ts.isForOfStatement(node)) {
     const init = node.initializer;
     if (ts.isVariableDeclarationList(init)) {
@@ -574,27 +672,36 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // Check labeled function declarations in strict mode
-  // e.g. label: function f() {} is a SyntaxError in strict mode
+// Check labeled function declarations in strict mode
+// e.g. label: function f() {} is a SyntaxError in strict mode
+on([ts.SyntaxKind.LabeledStatement], (ctx, node) => {
   if (ts.isLabeledStatement(node) && isStrictMode(node)) {
     if (ts.isFunctionDeclaration(node.statement)) {
       ctx.addError(node, "In strict mode code, functions can only be declared at top level or inside a block");
     }
   }
+});
 
-  // ── Rest element early errors ──────────────────────────────────────
-  // ES spec: Rest element cannot have an initializer (default value).
-  // e.g. function f(...a = []) {}, const [...a = []] = arr;
+// ── Rest element early errors ──────────────────────────────────────
+// ES spec: Rest element cannot have an initializer (default value).
+// e.g. function f(...a = []) {}, const [...a = []] = arr;
+on([ts.SyntaxKind.Parameter], (ctx, node) => {
   if (ts.isParameter(node) && node.dotDotDotToken && node.initializer) {
     ctx.addError(node, "Rest parameter may not have a default initializer");
   }
+});
+
+on([ts.SyntaxKind.BindingElement], (ctx, node) => {
   if (ts.isBindingElement(node) && node.dotDotDotToken && node.initializer) {
     ctx.addError(node, "Rest element may not have a default initializer");
   }
+});
 
-  // ES spec: Rest element must be last — no trailing elements after rest.
-  // e.g. const [...a, b] = arr;  function f(...a, b) {}
+// ES spec: Rest element must be last — no trailing elements after rest.
+// e.g. const [...a, b] = arr;  function f(...a, b) {}
+on([ts.SyntaxKind.ArrayBindingPattern], (ctx, node) => {
   if (ts.isArrayBindingPattern(node)) {
     let foundRest = false;
     for (const element of node.elements) {
@@ -614,11 +721,13 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(lastEl, "A rest element must be last in a destructuring pattern");
     }
   }
+});
 
-  // ES spec: an object binding rest (`{...x}`) must be last — no element may
-  // follow it (`const {...rest, b} = y`) and no trailing comma (`{...x,}`).
-  // BindingRestProperty must be the final BindingProperty. TS's parser accepts
-  // both forms silently under skipSemanticDiagnostics, so detect them here.
+// ES spec: an object binding rest (`{...x}`) must be last — no element may
+// follow it (`const {...rest, b} = y`) and no trailing comma (`{...x,}`).
+// BindingRestProperty must be the final BindingProperty. TS's parser accepts
+// both forms silently under skipSemanticDiagnostics, so detect them here.
+on([ts.SyntaxKind.ObjectBindingPattern], (ctx, node) => {
   if (ts.isObjectBindingPattern(node)) {
     let foundRest = false;
     for (const element of node.elements) {
@@ -635,46 +744,61 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(lastEl, "A rest element must be last in a destructuring pattern");
     }
   }
+});
 
-  // ES spec: Trailing comma after rest parameter is a SyntaxError.
-  // e.g. function f(...a,) {}
-  // TypeScript's parser accepts this, but ES spec forbids it.
-  if (
-    (ts.isFunctionDeclaration(node) ||
-      ts.isFunctionExpression(node) ||
-      ts.isArrowFunction(node) ||
-      ts.isMethodDeclaration(node) ||
-      ts.isConstructorDeclaration(node) ||
-      ts.isGetAccessorDeclaration(node) ||
-      ts.isSetAccessorDeclaration(node)) &&
-    node.parameters.length > 0
-  ) {
-    const lastParam = node.parameters[node.parameters.length - 1]!;
-    if (lastParam.dotDotDotToken) {
-      // Check if there's a trailing comma after the rest parameter.
-      // The trailing comma is indicated by a comma after the last parameter
-      // in the source text.
-      const paramEnd = lastParam.end;
-      const parenClose = node.parameters.end; // end of the parameter list
-      const textBetween = ctx.sourceFile.text.substring(paramEnd, parenClose);
-      if (textBetween.includes(",")) {
-        ctx.addError(lastParam, "A rest parameter or binding pattern may not have a trailing comma");
+// ES spec: Trailing comma after rest parameter is a SyntaxError.
+// e.g. function f(...a,) {}
+// TypeScript's parser accepts this, but ES spec forbids it.
+on(
+  [
+    ts.SyntaxKind.FunctionDeclaration,
+    ts.SyntaxKind.FunctionExpression,
+    ts.SyntaxKind.ArrowFunction,
+    ts.SyntaxKind.MethodDeclaration,
+    ts.SyntaxKind.Constructor,
+    ts.SyntaxKind.GetAccessor,
+    ts.SyntaxKind.SetAccessor,
+  ],
+  (ctx, node) => {
+    if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isConstructorDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node)) &&
+      node.parameters.length > 0
+    ) {
+      const lastParam = node.parameters[node.parameters.length - 1]!;
+      if (lastParam.dotDotDotToken) {
+        // Check if there's a trailing comma after the rest parameter.
+        // The trailing comma is indicated by a comma after the last parameter
+        // in the source text.
+        const paramEnd = lastParam.end;
+        const parenClose = node.parameters.end; // end of the parameter list
+        const textBetween = ctx.sourceFile.text.substring(paramEnd, parenClose);
+        if (textBetween.includes(",")) {
+          ctx.addError(lastParam, "A rest parameter or binding pattern may not have a trailing comma");
+        }
+      }
+      // ES spec: a rest parameter (`...b`) must be the LAST parameter — no
+      // parameter may follow it (`function f(a, ...b, c) {}`). TS drops this as a
+      // semantic diagnostic under skipSemanticDiagnostics, so re-detect it.
+      for (let i = 0; i < node.parameters.length - 1; i++) {
+        if (node.parameters[i]!.dotDotDotToken) {
+          ctx.addError(node.parameters[i]!, "A rest parameter must be last in a parameter list");
+          break;
+        }
       }
     }
-    // ES spec: a rest parameter (`...b`) must be the LAST parameter — no
-    // parameter may follow it (`function f(a, ...b, c) {}`). TS drops this as a
-    // semantic diagnostic under skipSemanticDiagnostics, so re-detect it.
-    for (let i = 0; i < node.parameters.length - 1; i++) {
-      if (node.parameters[i]!.dotDotDotToken) {
-        ctx.addError(node.parameters[i]!, "A rest parameter must be last in a parameter list");
-        break;
-      }
-    }
-  }
+  },
+);
 
-  // ── await/yield as identifier in async/generator contexts ──────────
-  // ES spec: 'await' is a reserved word inside async functions/generators.
-  // 'yield' is a reserved word inside generator functions.
+// ── await/yield as identifier in async/generator contexts ──────────
+// ES spec: 'await' is a reserved word inside async functions/generators.
+// 'yield' is a reserved word inside generator functions.
+on([ts.SyntaxKind.Identifier], (ctx, node) => {
   if (ts.isIdentifier(node) && (node.text === "await" || node.text === "yield")) {
     // Skip if this is the yield/await *expression* (keyword usage, not identifier)
     const parent = node.parent;
@@ -701,10 +825,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Strict mode reserved words as identifiers ──────────────────────
-  // ES spec: implements, interface, let, package, private, protected,
-  // public, static, yield are reserved in strict mode.
+// ── Strict mode reserved words as identifiers ──────────────────────
+// ES spec: implements, interface, let, package, private, protected,
+// public, static, yield are reserved in strict mode.
+on([ts.SyntaxKind.Identifier], (ctx, node) => {
   if (ts.isIdentifier(node) && isStrictMode(node)) {
     const strictReserved = new Set(["implements", "interface", "package", "private", "protected", "public", "static"]);
     if (strictReserved.has(node.text)) {
@@ -747,79 +873,110 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── "use strict" + non-simple parameters ─────────────────────────
-  // ES spec: It is a SyntaxError if ContainsUseStrict of FunctionBody is true
-  // and IsSimpleParameterList of FormalParameters is false.
-  // Non-simple: default values, destructuring patterns, or rest parameters.
-  if (
-    (ts.isFunctionDeclaration(node) ||
-      ts.isFunctionExpression(node) ||
-      ts.isArrowFunction(node) ||
-      ts.isMethodDeclaration(node) ||
-      ts.isConstructorDeclaration(node) ||
-      ts.isGetAccessorDeclaration(node) ||
-      ts.isSetAccessorDeclaration(node)) &&
-    node.body &&
-    ts.isBlock(node.body)
-  ) {
-    const hasNonSimpleParams = node.parameters.some(
-      (p) => p.initializer !== undefined || p.dotDotDotToken !== undefined || !ts.isIdentifier(p.name), // destructuring pattern
-    );
-    if (hasNonSimpleParams) {
-      // Check if body starts with "use strict" directive
-      for (const stmt of node.body.statements) {
-        if (ts.isExpressionStatement(stmt) && ts.isStringLiteral(stmt.expression)) {
-          if (stmt.expression.text === "use strict") {
-            ctx.addError(stmt, "Illegal 'use strict' directive in function with non-simple parameter list");
-            break;
+// ── "use strict" + non-simple parameters ─────────────────────────
+// ES spec: It is a SyntaxError if ContainsUseStrict of FunctionBody is true
+// and IsSimpleParameterList of FormalParameters is false.
+// Non-simple: default values, destructuring patterns, or rest parameters.
+on(
+  [
+    ts.SyntaxKind.FunctionDeclaration,
+    ts.SyntaxKind.FunctionExpression,
+    ts.SyntaxKind.ArrowFunction,
+    ts.SyntaxKind.MethodDeclaration,
+    ts.SyntaxKind.Constructor,
+    ts.SyntaxKind.GetAccessor,
+    ts.SyntaxKind.SetAccessor,
+  ],
+  (ctx, node) => {
+    if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isConstructorDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node)) &&
+      node.body &&
+      ts.isBlock(node.body)
+    ) {
+      const hasNonSimpleParams = node.parameters.some(
+        (p) => p.initializer !== undefined || p.dotDotDotToken !== undefined || !ts.isIdentifier(p.name), // destructuring pattern
+      );
+      if (hasNonSimpleParams) {
+        // Check if body starts with "use strict" directive
+        for (const stmt of node.body.statements) {
+          if (ts.isExpressionStatement(stmt) && ts.isStringLiteral(stmt.expression)) {
+            if (stmt.expression.text === "use strict") {
+              ctx.addError(stmt, "Illegal 'use strict' directive in function with non-simple parameter list");
+              break;
+            }
+          } else {
+            break; // Directives must be at the top
           }
-        } else {
-          break; // Directives must be at the top
         }
       }
     }
-  }
+  },
+);
 
-  // ── Parameter names conflicting with lexical body declarations ─────
-  // ES spec: It is a SyntaxError if BoundNames of FormalParameters also
-  // occurs in the LexicallyDeclaredNames of FunctionBody (for arrow,
-  // async, generator, method, constructor, getter, setter).
-  if (
-    (ts.isFunctionDeclaration(node) ||
-      ts.isFunctionExpression(node) ||
-      ts.isArrowFunction(node) ||
-      ts.isMethodDeclaration(node) ||
-      ts.isConstructorDeclaration(node) ||
-      ts.isGetAccessorDeclaration(node) ||
-      ts.isSetAccessorDeclaration(node)) &&
-    node.body &&
-    ts.isBlock(node.body)
-  ) {
-    const paramNames = new Set<string>();
-    for (const p of node.parameters) {
-      collectBindingNames(p.name, paramNames);
-    }
-    if (paramNames.size > 0) {
-      for (const stmt of node.body.statements) {
-        if (ts.isVariableStatement(stmt)) {
-          const flags = stmt.declarationList.flags;
-          if ((flags & ts.NodeFlags.Let) !== 0 || (flags & ts.NodeFlags.Const) !== 0) {
-            for (const decl of stmt.declarationList.declarations) {
-              if (ts.isIdentifier(decl.name) && paramNames.has(decl.name.text)) {
-                ctx.addError(decl.name, `Duplicate identifier '${decl.name.text}' — parameter and lexical declaration`);
+// ── Parameter names conflicting with lexical body declarations ─────
+// ES spec: It is a SyntaxError if BoundNames of FormalParameters also
+// occurs in the LexicallyDeclaredNames of FunctionBody (for arrow,
+// async, generator, method, constructor, getter, setter).
+on(
+  [
+    ts.SyntaxKind.FunctionDeclaration,
+    ts.SyntaxKind.FunctionExpression,
+    ts.SyntaxKind.ArrowFunction,
+    ts.SyntaxKind.MethodDeclaration,
+    ts.SyntaxKind.Constructor,
+    ts.SyntaxKind.GetAccessor,
+    ts.SyntaxKind.SetAccessor,
+  ],
+  (ctx, node) => {
+    if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isConstructorDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node)) &&
+      node.body &&
+      ts.isBlock(node.body)
+    ) {
+      const paramNames = new Set<string>();
+      for (const p of node.parameters) {
+        collectBindingNames(p.name, paramNames);
+      }
+      if (paramNames.size > 0) {
+        for (const stmt of node.body.statements) {
+          if (ts.isVariableStatement(stmt)) {
+            const flags = stmt.declarationList.flags;
+            if ((flags & ts.NodeFlags.Let) !== 0 || (flags & ts.NodeFlags.Const) !== 0) {
+              for (const decl of stmt.declarationList.declarations) {
+                if (ts.isIdentifier(decl.name) && paramNames.has(decl.name.text)) {
+                  ctx.addError(
+                    decl.name,
+                    `Duplicate identifier '${decl.name.text}' — parameter and lexical declaration`,
+                  );
+                }
               }
             }
           }
         }
       }
     }
-  }
+  },
+);
 
-  // ── Labeled declarations (not function declarations) ──────────────
-  // ES spec: LabelledItem only allows Statement or FunctionDeclaration.
-  // LexicalDeclarations (let, const), class declarations, async generators,
-  // and async functions in labeled position are SyntaxErrors.
+// ── Labeled declarations (not function declarations) ──────────────
+// ES spec: LabelledItem only allows Statement or FunctionDeclaration.
+// LexicalDeclarations (let, const), class declarations, async generators,
+// and async functions in labeled position are SyntaxErrors.
+on([ts.SyntaxKind.LabeledStatement], (ctx, node) => {
   if (ts.isLabeledStatement(node)) {
     const stmt = node.statement;
     // label: let x; or label: const x;
@@ -837,10 +994,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "Class declaration cannot appear in a labeled statement");
     }
   }
+});
 
-  // ── let/const in single-statement positions ──────────────────────
-  // ES spec: LetOrConst is not allowed in the Statement position of
-  // if, else, while, do-while, for bodies.
+// ── let/const in single-statement positions ──────────────────────
+// ES spec: LetOrConst is not allowed in the Statement position of
+// if, else, while, do-while, for bodies.
+on([ts.SyntaxKind.VariableStatement], (ctx, node) => {
   if (ts.isVariableStatement(node)) {
     const flags = node.declarationList.flags;
     if ((flags & ts.NodeFlags.Let) !== 0 || (flags & ts.NodeFlags.Const) !== 0) {
@@ -850,14 +1009,16 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── const without initializer ──────────────────────────────────
-  // ES spec: LexicalBinding for `const` must have an Initializer.
-  // Exception: `for (const x of ...)` and `for (const x in ...)` — the
-  // variable gets its value from the iterable/object, not an initializer.
-  // Exception: `declare const x: T` — ambient declarations have no initializer
-  // by design (they describe external bindings, not local variables). These are
-  // generated by preprocessImports for unused imported bindings (#951).
+// ── const without initializer ──────────────────────────────────
+// ES spec: LexicalBinding for `const` must have an Initializer.
+// Exception: `for (const x of ...)` and `for (const x in ...)` — the
+// variable gets its value from the iterable/object, not an initializer.
+// Exception: `declare const x: T` — ambient declarations have no initializer
+// by design (they describe external bindings, not local variables). These are
+// generated by preprocessImports for unused imported bindings (#951).
+on([ts.SyntaxKind.VariableDeclaration], (ctx, node) => {
   if (ts.isVariableDeclaration(node) && !node.initializer) {
     const declList = node.parent;
     if (ts.isVariableDeclarationList(declList) && (declList.flags & ts.NodeFlags.Const) !== 0) {
@@ -872,9 +1033,11 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── 'let' as binding name in lexical declarations ──────────────
-  // ES spec: It is a SyntaxError if BoundNames of LetOrConst contains "let".
+// ── 'let' as binding name in lexical declarations ──────────────
+// ES spec: It is a SyntaxError if BoundNames of LetOrConst contains "let".
+on([ts.SyntaxKind.VariableDeclaration], (ctx, node) => {
   if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === "let") {
     const declList = node.parent;
     if (ts.isVariableDeclarationList(declList)) {
@@ -883,9 +1046,11 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── for loop head lexical var conflict ─────────────────────────
-  // ES spec: for (let x; ...) { var x; } — var x conflicts with let x
+// ── for loop head lexical var conflict ─────────────────────────
+// ES spec: for (let x; ...) { var x; } — var x conflicts with let x
+on([ts.SyntaxKind.ForStatement, ts.SyntaxKind.ForInStatement, ts.SyntaxKind.ForOfStatement], (ctx, node) => {
   if (ts.isForStatement(node) || ts.isForInStatement(node) || ts.isForOfStatement(node)) {
     const init = ts.isForStatement(node) ? node.initializer : node.initializer;
     if (init && ts.isVariableDeclarationList(init)) {
@@ -908,10 +1073,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── eval/arguments as binding names in strict mode ────────────────
-  // ES spec: It is a SyntaxError to use eval or arguments as a binding
-  // identifier in strict mode code (variable declarations, function names, etc.)
+// ── eval/arguments as binding names in strict mode ────────────────
+// ES spec: It is a SyntaxError to use eval or arguments as a binding
+// identifier in strict mode code (variable declarations, function names, etc.)
+on([ts.SyntaxKind.Identifier], (ctx, node) => {
   if (ts.isIdentifier(node) && (node.text === "eval" || node.text === "arguments") && isStrictMode(node)) {
     const parent = node.parent;
     // Check if used as a binding name (variable, parameter, function name, catch binding)
@@ -932,47 +1099,55 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, `Binding '${node.text}' in strict mode is not allowed`);
     }
   }
+});
 
-  // ── Switch case duplicate lexical declarations ────────────────────
-  // ES spec: It is a Syntax Error if the LexicallyDeclaredNames of CaseBlock
-  // contains any duplicate entries.
+// ── Switch case duplicate lexical declarations ────────────────────
+// ES spec: It is a Syntax Error if the LexicallyDeclaredNames of CaseBlock
+// contains any duplicate entries.
+on([ts.SyntaxKind.CaseBlock], (ctx, node) => {
   if (ts.isCaseBlock(node)) {
     checkSwitchCaseLexicalDuplicates(ctx, node);
     checkDuplicateDefaultClause(ctx, node);
   }
+});
 
-  // ── throw [no LineTerminator here] Expression ─────────────────────
-  // ES spec: ThrowStatement : throw [no LineTerminator here] Expression ;
-  // `throw` requires an Expression on the SAME line. A LineTerminator right
-  // after `throw` triggers ASI — which would leave `throw;` (no operand), a
-  // SyntaxError — after which TS reparses the trailing expression as its own
-  // statement and synthesizes a zero-width (missing) throw operand. A bare
-  // `throw;` with no operand at all produces the same missing node. Either way,
-  // a ThrowStatement whose Expression is missing (zero width) is an early error;
-  // a valid `throw <expr>` always has a non-empty operand, even when the
-  // expression itself wraps across lines (`throw new Error(\n …)`). Covers
-  // test262 language/asi/S7.9_A4.js.
+// ── throw [no LineTerminator here] Expression ─────────────────────
+// ES spec: ThrowStatement : throw [no LineTerminator here] Expression ;
+// `throw` requires an Expression on the SAME line. A LineTerminator right
+// after `throw` triggers ASI — which would leave `throw;` (no operand), a
+// SyntaxError — after which TS reparses the trailing expression as its own
+// statement and synthesizes a zero-width (missing) throw operand. A bare
+// `throw;` with no operand at all produces the same missing node. Either way,
+// a ThrowStatement whose Expression is missing (zero width) is an early error;
+// a valid `throw <expr>` always has a non-empty operand, even when the
+// expression itself wraps across lines (`throw new Error(\n …)`). Covers
+// test262 language/asi/S7.9_A4.js.
+on([ts.SyntaxKind.ThrowStatement], (ctx, node) => {
   if (ts.isThrowStatement(node) && node.expression.getFullWidth() === 0) {
     ctx.addError(node, "Illegal newline after throw / missing throw operand");
   }
+});
 
-  // ── MetaProperty contextual keyword must not contain escapes ──────
-  // ES grammar (5.1.5 Grammar Notation): terminal symbols must appear exactly
-  // as written, with no Unicode escape sequences. The `target` of `new.target`
-  // and the `meta` of `import.meta` are such terminals, so `new.target` /
-  // `import.meta` are SyntaxErrors. TypeScript parses these as a
-  // MetaProperty whose name node has the canonical `.text` ("target"/"meta")
-  // but a raw `.getText()` that still carries the escape — with no parse
-  // diagnostic — so nothing detected it. Covers test262
-  // language/expressions/new.target/escaped-target.js (and, in module code,
-  // language/expressions/import.meta/syntax/escape-sequence-meta.js).
+// ── MetaProperty contextual keyword must not contain escapes ──────
+// ES grammar (5.1.5 Grammar Notation): terminal symbols must appear exactly
+// as written, with no Unicode escape sequences. The `target` of `new.target`
+// and the `meta` of `import.meta` are such terminals, so `new.target` /
+// `import.meta` are SyntaxErrors. TypeScript parses these as a
+// MetaProperty whose name node has the canonical `.text` ("target"/"meta")
+// but a raw `.getText()` that still carries the escape — with no parse
+// diagnostic — so nothing detected it. Covers test262
+// language/expressions/new.target/escaped-target.js (and, in module code,
+// language/expressions/import.meta/syntax/escape-sequence-meta.js).
+on([ts.SyntaxKind.MetaProperty], (ctx, node) => {
   if (ts.isMetaProperty(node) && node.name.getText(ctx.sourceFile) !== node.name.text) {
     ctx.addError(node, "The meta property keyword must not contain escape sequences");
   }
+});
 
-  // ── Class body: static prototype method/field ─────────────────────
-  // ES spec: It is a SyntaxError if the PropName of a static method or
-  // field is "prototype".
+// ── Class body: static prototype method/field ─────────────────────
+// ES spec: It is a SyntaxError if the PropName of a static method or
+// field is "prototype".
+on([ts.SyntaxKind.ClassDeclaration, ts.SyntaxKind.ClassExpression], (ctx, node) => {
   if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
     for (const member of node.members) {
       if (member.name && !ts.isPrivateIdentifier(member.name)) {
@@ -992,28 +1167,34 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Duplicate private names in class body ─────────────────────────
-  // ES spec: It is a Syntax Error if PrivateBoundNames of ClassBody contains
-  // any duplicate entries, unless the name is used once for a getter and once
-  // for a setter and in no other entries.
+// ── Duplicate private names in class body ─────────────────────────
+// ES spec: It is a Syntax Error if PrivateBoundNames of ClassBody contains
+// any duplicate entries, unless the name is used once for a getter and once
+// for a setter and in no other entries.
+on([ts.SyntaxKind.ClassDeclaration, ts.SyntaxKind.ClassExpression], (ctx, node) => {
   if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
     checkDuplicatePrivateNames(ctx, node);
   }
+});
 
-  // ── Private name `#constructor` is always forbidden ───────────────
-  // ES spec: ClassElementName : PrivateName
-  //   It is a Syntax Error if StringValue of PrivateName is "#constructor".
-  // This applies to fields, methods, getters, setters regardless of static.
+// ── Private name `#constructor` is always forbidden ───────────────
+// ES spec: ClassElementName : PrivateName
+//   It is a Syntax Error if StringValue of PrivateName is "#constructor".
+// This applies to fields, methods, getters, setters regardless of static.
+on([ts.SyntaxKind.PrivateIdentifier], (ctx, node) => {
   if (ts.isPrivateIdentifier(node) && node.text === "#constructor") {
     ctx.addError(node, "Private field '#constructor' is not allowed");
   }
+});
 
-  // ── Regex literal validation ────────────────────────────────────
-  // Validate regex literals using the native RegExp constructor.
-  // This catches invalid flags, duplicate flags, invalid Unicode property
-  // escapes, invalid modifiers, etc. that TS's semantic checker would
-  // catch but we skip with skipSemanticDiagnostics in the worker pool.
+// ── Regex literal validation ────────────────────────────────────
+// Validate regex literals using the native RegExp constructor.
+// This catches invalid flags, duplicate flags, invalid Unicode property
+// escapes, invalid modifiers, etc. that TS's semantic checker would
+// catch but we skip with skipSemanticDiagnostics in the worker pool.
+on([ts.SyntaxKind.RegularExpressionLiteral], (ctx, node) => {
   if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {
     const text = (node as ts.RegularExpressionLiteral).text;
     const lastSlash = text.lastIndexOf("/");
@@ -1027,10 +1208,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Class method named "constructor" restrictions ─────────────────
-  // ES spec: It is a SyntaxError if PropName of a MethodDefinition is "constructor" and
-  // the method is a generator, async, getter, or setter.
+// ── Class method named "constructor" restrictions ─────────────────
+// ES spec: It is a SyntaxError if PropName of a MethodDefinition is "constructor" and
+// the method is a generator, async, getter, or setter.
+on([ts.SyntaxKind.ClassDeclaration, ts.SyntaxKind.ClassExpression], (ctx, node) => {
   if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
     for (const member of node.members) {
       const memberName = getMemberName(member);
@@ -1063,17 +1246,21 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Direct super() call outside constructor ──────────────────────
-  // ES spec: super() is only valid inside a class constructor.
+// ── Direct super() call outside constructor ──────────────────────
+// ES spec: super() is only valid inside a class constructor.
+on([ts.SyntaxKind.CallExpression], (ctx, node) => {
   if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.SuperKeyword) {
     if (!isInsideClassConstructor(node)) {
       ctx.addError(node, "super() is only valid inside a class constructor");
     }
   }
+});
 
-  // ── Direct super property outside method ──────────────────────────
-  // super.x and super[x] are only valid in methods (including constructors)
+// ── Direct super property outside method ──────────────────────────
+// super.x and super[x] are only valid in methods (including constructors)
+on([ts.SyntaxKind.PropertyAccessExpression, ts.SyntaxKind.ElementAccessExpression], (ctx, node) => {
   if (
     (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) &&
     node.expression.kind === ts.SyntaxKind.SuperKeyword
@@ -1087,11 +1274,13 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "Private fields cannot be accessed via super");
     }
   }
+});
 
-  // ── Strict mode reserved words as assignment targets ─────────────
-  // ES spec: It is a SyntaxError if the LeftHandSideExpression of a simple
-  // assignment is a strict mode reserved word (public, private, protected, etc.)
-  // and the code is in strict mode.
+// ── Strict mode reserved words as assignment targets ─────────────
+// ES spec: It is a SyntaxError if the LeftHandSideExpression of a simple
+// assignment is a strict mode reserved word (public, private, protected, etc.)
+// and the code is in strict mode.
+on([ts.SyntaxKind.BinaryExpression], (ctx, node) => {
   if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken && isStrictMode(node)) {
     let lhs: ts.Node = node.left;
     while (ts.isParenthesizedExpression(lhs)) lhs = lhs.expression;
@@ -1112,8 +1301,10 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Duplicate __proto__ in object literal ────────────────────────
+// ── Duplicate __proto__ in object literal ────────────────────────
+on([ts.SyntaxKind.ObjectLiteralExpression], (ctx, node) => {
   if (ts.isObjectLiteralExpression(node)) {
     let protoCount = 0;
     for (const prop of node.properties) {
@@ -1133,21 +1324,27 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Getter with parameters ─────────────────────────────────────
-  // ES spec: A getter must have exactly zero parameters.
+// ── Getter with parameters ─────────────────────────────────────
+// ES spec: A getter must have exactly zero parameters.
+on([ts.SyntaxKind.GetAccessor], (ctx, node) => {
   if (ts.isGetAccessorDeclaration(node) && node.parameters.length > 0) {
     ctx.addError(node, "Getter must not have any formal parameters");
   }
+});
 
-  // ── Setter with wrong param count ──────────────────────────────
-  // ES spec: A setter must have exactly one parameter.
+// ── Setter with wrong param count ──────────────────────────────
+// ES spec: A setter must have exactly one parameter.
+on([ts.SyntaxKind.SetAccessor], (ctx, node) => {
   if (ts.isSetAccessorDeclaration(node) && node.parameters.length !== 1) {
     ctx.addError(node, "Setter must have exactly one formal parameter");
   }
+});
 
-  // ── Setter param with destructuring + "use strict" body ────────
-  // ES spec: setter parameter is eval/arguments in strict mode
+// ── Setter param with destructuring + "use strict" body ────────
+// ES spec: setter parameter is eval/arguments in strict mode
+on([ts.SyntaxKind.SetAccessor], (ctx, node) => {
   if (ts.isSetAccessorDeclaration(node) && node.parameters.length === 1) {
     const param = node.parameters[0]!;
     // Check for setter with "use strict" body — this triggers strict mode
@@ -1170,12 +1367,14 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Cover initialized name in object literal ───────────────────
-  // ES spec: PropertyDefinition : CoverInitializedName always throws SyntaxError.
-  // ({ x = 1 }) is a CoverInitializedName — only valid in destructuring context.
-  // ShorthandPropertyAssignment with an objectAssignmentInitializer is the TS
-  // representation of CoverInitializedName.
+// ── Cover initialized name in object literal ───────────────────
+// ES spec: PropertyDefinition : CoverInitializedName always throws SyntaxError.
+// ({ x = 1 }) is a CoverInitializedName — only valid in destructuring context.
+// ShorthandPropertyAssignment with an objectAssignmentInitializer is the TS
+// representation of CoverInitializedName.
+on([ts.SyntaxKind.ShorthandPropertyAssignment], (ctx, node) => {
   if (ts.isShorthandPropertyAssignment(node) && node.objectAssignmentInitializer) {
     // Check if the parent object literal is NOT in an assignment pattern position
     const objLit = node.parent;
@@ -1185,16 +1384,18 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── 'async' prefix on a shorthand property ─────────────────────
-  // ES spec: PropertyDefinition : IdentifierReference (shorthand) is a bare
-  // IdentifierReference and admits no modifier. `async` is only valid as the
-  // prefix of an AsyncMethod (which requires a `(` parameter list). TypeScript's
-  // parser silently accepts `({async async})` / `({async x = 1})` as a
-  // ShorthandPropertyAssignment carrying an AsyncKeyword modifier with NO parse
-  // diagnostic (unlike `get`/`set`/`*`, which it already flags), so nothing
-  // detects it. Covers test262
-  // language/expressions/object/prop-def-invalid-async-prefix.
+// ── 'async' prefix on a shorthand property ─────────────────────
+// ES spec: PropertyDefinition : IdentifierReference (shorthand) is a bare
+// IdentifierReference and admits no modifier. `async` is only valid as the
+// prefix of an AsyncMethod (which requires a `(` parameter list). TypeScript's
+// parser silently accepts `({async async})` / `({async x = 1})` as a
+// ShorthandPropertyAssignment carrying an AsyncKeyword modifier with NO parse
+// diagnostic (unlike `get`/`set`/`*`, which it already flags), so nothing
+// detects it. Covers test262
+// language/expressions/object/prop-def-invalid-async-prefix.
+on([ts.SyntaxKind.ShorthandPropertyAssignment], (ctx, node) => {
   if (
     ts.isShorthandPropertyAssignment(node) &&
     (node as unknown as { modifiers?: ts.NodeArray<ts.ModifierLike> }).modifiers?.some(
@@ -1203,15 +1404,19 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
   ) {
     ctx.addError(node, "'async' is not a valid prefix of a shorthand property");
   }
+});
 
-  // ── 'let' as shorthand property in strict mode ─────────────────
-  // ES spec: 'let' is not a reserved word but cannot be used as a binding
-  // identifier in strict mode, and shorthand property acts as IdentifierReference.
+// ── 'let' as shorthand property in strict mode ─────────────────
+// ES spec: 'let' is not a reserved word but cannot be used as a binding
+// identifier in strict mode, and shorthand property acts as IdentifierReference.
+on([ts.SyntaxKind.ShorthandPropertyAssignment], (ctx, node) => {
   if (ts.isShorthandPropertyAssignment(node) && node.name.text === "let" && isStrictMode(node)) {
     ctx.addError(node, "'let' is not allowed as a shorthand property in strict mode");
   }
+});
 
-  // ── Catch clause parameter early errors ─────────────────────────
+// ── Catch clause parameter early errors ─────────────────────────
+on([ts.SyntaxKind.CatchClause], (ctx, node) => {
   if (ts.isCatchClause(node) && node.variableDeclaration) {
     const catchParam = node.variableDeclaration;
     // Check for duplicate names in catch parameter destructuring
@@ -1248,23 +1453,29 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Duplicate lexical declarations in same block ─────────────────
-  // Covers class+class, let+let, const+const, class+let, etc.
+// ── Duplicate lexical declarations in same block ─────────────────
+// Covers class+class, let+let, const+const, class+let, etc.
+on([ts.SyntaxKind.Block, ts.SyntaxKind.SourceFile], (ctx, node) => {
   if (ts.isBlock(node) || ts.isSourceFile(node)) {
     checkDuplicateLexicalDeclarations(ctx, node, ctx.moduleGoal);
   }
+});
 
-  // ── Duplicate labels in class static blocks ────────────────────
-  // ES spec: ClassStaticBlockBody — It is a Syntax Error if
-  // ContainsDuplicateLabels of ClassStaticBlockStatementList is true.
+// ── Duplicate labels in class static blocks ────────────────────
+// ES spec: ClassStaticBlockBody — It is a Syntax Error if
+// ContainsDuplicateLabels of ClassStaticBlockStatementList is true.
+on([ts.SyntaxKind.ClassStaticBlockDeclaration], (ctx, node) => {
   if (ts.isClassStaticBlockDeclaration(node)) {
     checkDuplicateLabelsInBlock(ctx, node.body);
   }
+});
 
-  // ── break/continue outside valid context ──────────────────────────
-  // TS catches these as semantic errors (1104, 1105) but we skip semantic
-  // diagnostics in the test262 worker, so detect them here.
+// ── break/continue outside valid context ──────────────────────────
+// TS catches these as semantic errors (1104, 1105) but we skip semantic
+// diagnostics in the test262 worker, so detect them here.
+on([ts.SyntaxKind.ContinueStatement], (ctx, node) => {
   if (ts.isContinueStatement(node)) {
     if (!isInsideIteration(node, node.label?.text)) {
       ctx.addError(
@@ -1275,6 +1486,9 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       );
     }
   }
+});
+
+on([ts.SyntaxKind.BreakStatement], (ctx, node) => {
   if (ts.isBreakStatement(node)) {
     if (!isInsideBreakable(node, node.label?.text)) {
       ctx.addError(
@@ -1285,25 +1499,27 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       );
     }
   }
+});
 
-  // ── import.X meta-property validation — covers Stage 3 proposals + unknown names ──
-  // ES spec (§13.3.10): the only standardized `import.<name>` meta-property is
-  // `import.meta`. The Stage 3 proposals add `import.source(...)` (source-phase
-  // imports) and `import.defer(...)` (import-defer). Any other meta-property
-  // name like `import.UNKNOWN` is a SyntaxError.
-  //
-  // Test262 has ~190 negative tests under
-  // `language/expressions/dynamic-import/syntax/invalid/` covering bare
-  // `import.source`, `import.source.X`, `import.UNKNOWN(...)`, `typeof
-  // import.source`, etc. The sharded test runner compiles with
-  // `skipSemanticDiagnostics: true`, suppressing TS's own diagnostics for these
-  // shapes, so the SyntaxError must be emitted by this syntactic pass (#1512).
-  //
-  // We catch the MetaProperty node itself, which fires for every position the
-  // meta-property appears in (call target, bare expression, typeof operand,
-  // PropertyAccessExpression base, etc.). The earlier call-only check (#1315)
-  // is subsumed by this. The walk runs over the whole AST including
-  // unreferenced bodies so we catch dead-code constructs too.
+// ── import.X meta-property validation — covers Stage 3 proposals + unknown names ──
+// ES spec (§13.3.10): the only standardized `import.<name>` meta-property is
+// `import.meta`. The Stage 3 proposals add `import.source(...)` (source-phase
+// imports) and `import.defer(...)` (import-defer). Any other meta-property
+// name like `import.UNKNOWN` is a SyntaxError.
+//
+// Test262 has ~190 negative tests under
+// `language/expressions/dynamic-import/syntax/invalid/` covering bare
+// `import.source`, `import.source.X`, `import.UNKNOWN(...)`, `typeof
+// import.source`, etc. The sharded test runner compiles with
+// `skipSemanticDiagnostics: true`, suppressing TS's own diagnostics for these
+// shapes, so the SyntaxError must be emitted by this syntactic pass (#1512).
+//
+// We catch the MetaProperty node itself, which fires for every position the
+// meta-property appears in (call target, bare expression, typeof operand,
+// PropertyAccessExpression base, etc.). The earlier call-only check (#1315)
+// is subsumed by this. The walk runs over the whole AST including
+// unreferenced bodies so we catch dead-code constructs too.
+on([ts.SyntaxKind.MetaProperty], (ctx, node) => {
   if (ts.isMetaProperty(node) && node.keywordToken === ts.SyntaxKind.ImportKeyword && node.name.text !== "meta") {
     const name = node.name.text;
     if (name === "defer" || name === "source") {
@@ -1315,13 +1531,15 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, `SyntaxError: 'import.${name}' is not a valid meta-property; only 'import.meta' is allowed`);
     }
   }
+});
 
-  // ── new import() — always a SyntaxError ────────────────────────
-  // ES spec: ImportCall is a CallExpression, not a NewExpression target.
-  // Also applies to import.source() and import.defer() proposals.
-  // TS parser splits "new import('x')" into a broken NewExpression (empty identifier)
-  // followed by an import CallExpression. We detect this by checking for
-  // NewExpression with a missing/empty expression where the source text shows "new import".
+// ── new import() — always a SyntaxError ────────────────────────
+// ES spec: ImportCall is a CallExpression, not a NewExpression target.
+// Also applies to import.source() and import.defer() proposals.
+// TS parser splits "new import('x')" into a broken NewExpression (empty identifier)
+// followed by an import CallExpression. We detect this by checking for
+// NewExpression with a missing/empty expression where the source text shows "new import".
+on([ts.SyntaxKind.NewExpression], (ctx, node) => {
   if (ts.isNewExpression(node)) {
     const expr = node.expression;
     if (ts.isIdentifier(expr) && expr.text === "") {
@@ -1332,11 +1550,13 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── typeof import — always a SyntaxError ────────────────────────
-  // ES spec: `import` is not a valid UnaryExpression operand (not an identifier).
-  // TS parser creates a TypeOfExpression with an empty Identifier when parsing
-  // `typeof import`. Detect this by checking source text.
+// ── typeof import — always a SyntaxError ────────────────────────
+// ES spec: `import` is not a valid UnaryExpression operand (not an identifier).
+// TS parser creates a TypeOfExpression with an empty Identifier when parsing
+// `typeof import`. Detect this by checking source text.
+on([ts.SyntaxKind.TypeOfExpression], (ctx, node) => {
   if (ts.isTypeOfExpression(node)) {
     const expr = node.expression;
     if (ts.isIdentifier(expr) && expr.text === "") {
@@ -1347,12 +1567,14 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── `arguments` in class field initializers ──────────────────────
-  // ES spec: FieldDefinition — It is a Syntax Error if ContainsArguments
-  // of Initializer is true. `arguments` is not allowed in any class field
-  // initializer (instance or static), because field initializers are not
-  // "real" function bodies and don't bind `arguments`.
+// ── `arguments` in class field initializers ──────────────────────
+// ES spec: FieldDefinition — It is a Syntax Error if ContainsArguments
+// of Initializer is true. `arguments` is not allowed in any class field
+// initializer (instance or static), because field initializers are not
+// "real" function bodies and don't bind `arguments`.
+on([ts.SyntaxKind.PropertyDeclaration], (ctx, node) => {
   if (ts.isPropertyDeclaration(node) && node.initializer) {
     if (ts.isClassDeclaration(node.parent) || ts.isClassExpression(node.parent)) {
       if (containsArguments(node.initializer)) {
@@ -1360,21 +1582,25 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── `arguments` in class static blocks ──────────────────────────
-  // ES spec: ClassStaticBlockBody — It is a Syntax Error if
-  // ContainsArguments of ClassStaticBlockStatementList is true.
+// ── `arguments` in class static blocks ──────────────────────────
+// ES spec: ClassStaticBlockBody — It is a Syntax Error if
+// ContainsArguments of ClassStaticBlockStatementList is true.
+on([ts.SyntaxKind.ClassStaticBlockDeclaration], (ctx, node) => {
   if (ts.isClassStaticBlockDeclaration(node)) {
     if (containsArguments(node.body)) {
       ctx.addError(node, "'arguments' is not allowed in class static initialization blocks");
     }
   }
+});
 
-  // ── await with empty operand in async functions ───────────────
-  // When TS parses `void await`, `await:`, or just `await` (as identifier ref)
-  // inside an async function, it creates AwaitExpression with empty Identifier
-  // operand. This means `await` was used as an identifier, not as the keyword.
-  // ES spec: await is a reserved word in async function bodies.
+// ── await with empty operand in async functions ───────────────
+// When TS parses `void await`, `await:`, or just `await` (as identifier ref)
+// inside an async function, it creates AwaitExpression with empty Identifier
+// operand. This means `await` was used as an identifier, not as the keyword.
+// ES spec: await is a reserved word in async function bodies.
+on([ts.SyntaxKind.AwaitExpression], (ctx, node) => {
   if (ts.isAwaitExpression(node)) {
     const operand = node.expression;
     if (ts.isIdentifier(operand) && operand.text === "") {
@@ -1421,20 +1647,24 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "'await' expressions are only allowed in async functions");
     }
   }
+});
 
-  // ── yield with empty operand in generator functions ──────────
-  // Similar to await: when `yield` is used as identifier reference in a generator,
-  // TS may create YieldExpression with empty operand.
+// ── yield with empty operand in generator functions ──────────
+// Similar to await: when `yield` is used as identifier reference in a generator,
+// TS may create YieldExpression with empty operand.
+on([ts.SyntaxKind.YieldExpression], (ctx, node) => {
   if (ts.isYieldExpression(node) && isInsideGeneratorFunction(node)) {
     const operand = node.expression;
     if (operand && ts.isIdentifier(operand) && operand.text === "") {
       ctx.addError(node, "'yield' is not allowed as an identifier in a generator function");
     }
   }
+});
 
-  // ── yield * with newline before * ──────────────────────────────
-  // ES spec: YieldExpression : yield [no LineTerminator here] * AssignmentExpression
-  // A newline before the `*` makes it a distinct statement — SyntaxError.
+// ── yield * with newline before * ──────────────────────────────
+// ES spec: YieldExpression : yield [no LineTerminator here] * AssignmentExpression
+// A newline before the `*` makes it a distinct statement — SyntaxError.
+on([ts.SyntaxKind.YieldExpression], (ctx, node) => {
   if (ts.isYieldExpression(node) && node.asteriskToken && isInsideGeneratorFunction(node)) {
     const yieldEnd = node.getStart(ctx.sourceFile) + 5; // length of "yield"
     const starStart = node.asteriskToken.getStart(ctx.sourceFile);
@@ -1443,13 +1673,15 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "A newline may not precede the '*' token in a yield expression");
     }
   }
+});
 
-  // ── yield in class static blocks ──────────────────────────────
-  // ES spec: ClassStaticBlockStatementList uses [~Yield], meaning yield
-  // is not allowed inside static blocks even if nested within a generator.
-  // TS parses `yield;` in static blocks as Identifier("yield"), not
-  // YieldExpression, because class bodies are strict mode. TS diagnostic
-  // 1214 is downgraded for sloppy-mode compat, so check explicitly.
+// ── yield in class static blocks ──────────────────────────────
+// ES spec: ClassStaticBlockStatementList uses [~Yield], meaning yield
+// is not allowed inside static blocks even if nested within a generator.
+// TS parses `yield;` in static blocks as Identifier("yield"), not
+// YieldExpression, because class bodies are strict mode. TS diagnostic
+// 1214 is downgraded for sloppy-mode compat, so check explicitly.
+on([ts.SyntaxKind.Identifier], (ctx, node) => {
   if (ts.isIdentifier(node) && node.text === "yield") {
     if (isInsideClassStaticBlock(node) && !isInsideGeneratorFunction(node)) {
       const parent = node.parent;
@@ -1465,12 +1697,14 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Escaped keyword detection ─────────────────────────────────
-  // ES spec: Keywords containing Unicode escape sequences are not valid.
-  // e.g., \u0061wait is NOT a valid `await` keyword, im\u0070ort is NOT
-  // a valid `import` keyword, etc.
-  // Check if the raw source text of keyword-like nodes contains \u escapes.
+// ── Escaped keyword detection ─────────────────────────────────
+// ES spec: Keywords containing Unicode escape sequences are not valid.
+// e.g., \u0061wait is NOT a valid `await` keyword, im\u0070ort is NOT
+// a valid `import` keyword, etc.
+// Check if the raw source text of keyword-like nodes contains \u escapes.
+on([ts.SyntaxKind.AwaitExpression, ts.SyntaxKind.YieldExpression], (ctx, node) => {
   if (ts.isAwaitExpression(node) || ts.isYieldExpression(node)) {
     const start = node.getStart(ctx.sourceFile);
     const rawText = ctx.sourceFile.text.substring(start, start + 10);
@@ -1478,30 +1712,43 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "Keyword must not contain escaped characters");
     }
   }
-  // Escaped 'async' modifier
-  if (
-    (ts.isArrowFunction(node) ||
-      ts.isFunctionDeclaration(node) ||
-      ts.isFunctionExpression(node) ||
-      ts.isMethodDeclaration(node)) &&
-    node.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword)
-  ) {
-    for (const mod of node.modifiers!) {
-      if (mod.kind === ts.SyntaxKind.AsyncKeyword) {
-        const modStart = mod.getStart(ctx.sourceFile);
-        const rawText = ctx.sourceFile.text.substring(modStart, modStart + 10);
-        if (/\\u[0-9a-fA-F]{4}/.test(rawText)) {
-          ctx.addError(mod, "Keyword must not contain escaped characters");
+});
+
+// Escaped 'async' modifier
+on(
+  [
+    ts.SyntaxKind.ArrowFunction,
+    ts.SyntaxKind.FunctionDeclaration,
+    ts.SyntaxKind.FunctionExpression,
+    ts.SyntaxKind.MethodDeclaration,
+  ],
+  (ctx, node) => {
+    if (
+      (ts.isArrowFunction(node) ||
+        ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isMethodDeclaration(node)) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword)
+    ) {
+      for (const mod of node.modifiers!) {
+        if (mod.kind === ts.SyntaxKind.AsyncKeyword) {
+          const modStart = mod.getStart(ctx.sourceFile);
+          const rawText = ctx.sourceFile.text.substring(modStart, modStart + 10);
+          if (/\\u[0-9a-fA-F]{4}/.test(rawText)) {
+            ctx.addError(mod, "Keyword must not contain escaped characters");
+          }
         }
       }
     }
-  }
+  },
+);
 
-  // ── Escaped reserved/contextual keywords in export/import ──────
-  // ES spec: It is a SyntaxError if the source text of an IdentifierName
-  // in keyword position contains a UnicodeEscapeSequence.
-  // Covers: `export { x \u0061s y }`, `export { x as \u0064efault }`,
-  //         `export {} \u0066rom "./x"`, etc.
+// ── Escaped reserved/contextual keywords in export/import ──────
+// ES spec: It is a SyntaxError if the source text of an IdentifierName
+// in keyword position contains a UnicodeEscapeSequence.
+// Covers: `export { x \u0061s y }`, `export { x as \u0064efault }`,
+//         `export {} \u0066rom "./x"`, etc.
+on([ts.SyntaxKind.ExportDeclaration, ts.SyntaxKind.ImportDeclaration], (ctx, node) => {
   if (ts.isExportDeclaration(node) || ts.isImportDeclaration(node)) {
     const nodeStart = node.getStart(ctx.sourceFile);
     const nodeText = ctx.sourceFile.text.substring(nodeStart, node.end);
@@ -1509,6 +1756,9 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "Keyword must not contain escaped characters");
     }
   }
+});
+
+on([ts.SyntaxKind.ExportSpecifier], (ctx, node) => {
   if (ts.isExportSpecifier(node)) {
     // Check the exported name and the local name for escaped keywords
     const checkEscape = (n: ts.Identifier | ts.StringLiteral) => {
@@ -1521,18 +1771,20 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
     checkEscape(node.name);
     if (node.propertyName) checkEscape(node.propertyName);
   }
+});
 
-  // ── import/export in invalid positions ──────────────────────────
-  // NOTE: These checks are intentionally REMOVED (#952).
-  // Our test262 runner wraps module tests inside `export function test() { try { ... } }`,
-  // which places import/export declarations inside a function body. TypeScript's parser
-  // doesn't flag this (it's a semantic error, code 1258), and the compiler handles it
-  // gracefully. Re-adding these checks would cause ~97 test regressions.
-  // TypeScript semantic diagnostics (1258, 1232) catch real cases if needed.
+// ── import/export in invalid positions ──────────────────────────
+// NOTE: These checks are intentionally REMOVED (#952).
+// Our test262 runner wraps module tests inside `export function test() { try { ... } }`,
+// which places import/export declarations inside a function body. TypeScript's parser
+// doesn't flag this (it's a semantic error, code 1258), and the compiler handles it
+// gracefully. Re-adding these checks would cause ~97 test regressions.
+// TypeScript semantic diagnostics (1258, 1232) catch real cases if needed.
 
-  // ── dynamic import() as assignment target ──────────────────────
-  // ES spec: ImportCall is not a valid LeftHandSideExpression for assignment.
-  // e.g., import('x')++, import('x') = 1, ++import('x')
+// ── dynamic import() as assignment target ──────────────────────
+// ES spec: ImportCall is not a valid LeftHandSideExpression for assignment.
+// e.g., import('x')++, import('x') = 1, ++import('x')
+on([ts.SyntaxKind.CallExpression], (ctx, node) => {
   if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
     const parent = node.parent;
     if (parent) {
@@ -1558,10 +1810,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── await in class static initializer blocks ──────────────────
-  // ES spec: It is a Syntax Error if the code matched by this production is
-  // nested within a ClassStaticBlock and StringValue of Identifier is "await".
+// ── await in class static initializer blocks ──────────────────
+// ES spec: It is a Syntax Error if the code matched by this production is
+// nested within a ClassStaticBlock and StringValue of Identifier is "await".
+on([ts.SyntaxKind.Identifier], (ctx, node) => {
   if (ts.isIdentifier(node) && node.text === "await") {
     if (isInsideClassStaticBlock(node) && !isInsideAsyncFunction(node)) {
       const parent = node.parent;
@@ -1577,13 +1831,15 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── return outside function ──────────────────────────────────
-  // ES spec: A ReturnStatement can only appear in a FunctionBody.
-  // ES spec: ClassStaticBlockStatementList uses [~Return], meaning
-  // 'return' is not valid directly inside a static block even if the
-  // block is nested inside a function. Only returns inside functions
-  // WITHIN the static block are valid.
+// ── return outside function ──────────────────────────────────
+// ES spec: A ReturnStatement can only appear in a FunctionBody.
+// ES spec: ClassStaticBlockStatementList uses [~Return], meaning
+// 'return' is not valid directly inside a static block even if the
+// block is nested inside a function. Only returns inside functions
+// WITHIN the static block are valid.
+on([ts.SyntaxKind.ReturnStatement], (ctx, node) => {
   if (ts.isReturnStatement(node)) {
     if (!isInsideFunction(node)) {
       ctx.addError(node, "A 'return' statement can only be used within a function body");
@@ -1591,11 +1847,13 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "A 'return' statement is not allowed in a class static initialization block");
     }
   }
+});
 
-  // ── yield-as-label (TS parses yield: as YieldExpression in generators)
-  // Only flag if the colon is a label colon, not a ternary operator colon.
-  // A ternary colon is preceded by `?` somewhere before it. Check if the
-  // yield is the consequent/alternate of a ConditionalExpression.
+// ── yield-as-label (TS parses yield: as YieldExpression in generators)
+// Only flag if the colon is a label colon, not a ternary operator colon.
+// A ternary colon is preceded by `?` somewhere before it. Check if the
+// yield is the consequent/alternate of a ConditionalExpression.
+on([ts.SyntaxKind.YieldExpression], (ctx, node) => {
   if (ts.isYieldExpression(node) && isInsideGeneratorFunction(node)) {
     const endPos = node.end;
     const afterText = ctx.sourceFile.text.substring(endPos, endPos + 5).trimStart();
@@ -1611,9 +1869,11 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Escaped 'let' keyword ─────────────────────────────────────
-  // \u006Cet is not valid as a keyword
+// ── Escaped 'let' keyword ─────────────────────────────────────
+// \u006Cet is not valid as a keyword
+on([ts.SyntaxKind.Identifier], (ctx, node) => {
   if (ts.isIdentifier(node) && node.text === "let") {
     const start = node.getStart(ctx.sourceFile);
     const rawText = ctx.sourceFile.text.substring(start, start + 10);
@@ -1621,25 +1881,27 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "Keyword must not contain escaped characters");
     }
   }
+});
 
-  // ── private name escape sequences ─────────────────────────────
-  // ES spec: It is a Syntax Error if any code point in the PrivateIdentifier
-  // is expressed by a UnicodeEscapeSequence, unless it's for a valid start/part.
-  // For keywords like 'async', 'generator', 'field' — private names with
-  // escape sequences like #\u0061sync are SyntaxErrors.
-  // Note: TS represents private identifiers with ts.isPrivateIdentifier.
-  // The "cannot-escape-token" tests check that keywords used in private name
-  // positions cannot use Unicode escapes.
+// ── private name escape sequences ─────────────────────────────
+// ES spec: It is a Syntax Error if any code point in the PrivateIdentifier
+// is expressed by a UnicodeEscapeSequence, unless it's for a valid start/part.
+// For keywords like 'async', 'generator', 'field' — private names with
+// escape sequences like #\u0061sync are SyntaxErrors.
+// Note: TS represents private identifiers with ts.isPrivateIdentifier.
+// The "cannot-escape-token" tests check that keywords used in private name
+// positions cannot use Unicode escapes.
 
-  // ── Duplicate export names ────────────────────────────────────
-  // ES spec: It is a Syntax Error if the ExportedNames of ModuleBody contains
-  // any duplicate entries.
-  // This is checked at the source file level.
+// ── Duplicate export names ────────────────────────────────────
+// ES spec: It is a Syntax Error if the ExportedNames of ModuleBody contains
+// any duplicate entries.
+// This is checked at the source file level.
 
-  // ── import() argument validation ──────────────────────────────
-  // ES spec: ImportCall takes exactly one AssignmentExpression (plus an
-  // optional second options argument per the import-attributes proposal).
-  // import() with 0 args, spread args, or 3+ args is a SyntaxError.
+// ── import() argument validation ──────────────────────────────
+// ES spec: ImportCall takes exactly one AssignmentExpression (plus an
+// optional second options argument per the import-attributes proposal).
+// import() with 0 args, spread args, or 3+ args is a SyntaxError.
+on([ts.SyntaxKind.CallExpression], (ctx, node) => {
   if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
     if (node.arguments.length === 0) {
       ctx.addError(node, "import() requires at least one argument");
@@ -1656,12 +1918,15 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
-  // Same arg-count / spread restrictions for the Stage 3 `import.source(...)` and
-  // `import.defer(...)` calls. The meta-property itself is already rejected as a
-  // SyntaxError above, but test262 has negative tests that combine the bare
-  // proposal with extra args or spread, e.g. `import.source('a', {}, '')`. Emit
-  // an additional error so the test still fails parse phase even if the prior
-  // meta-property diagnostic is later relaxed for the proposal. (#1512)
+});
+
+// Same arg-count / spread restrictions for the Stage 3 `import.source(...)` and
+// `import.defer(...)` calls. The meta-property itself is already rejected as a
+// SyntaxError above, but test262 has negative tests that combine the bare
+// proposal with extra args or spread, e.g. `import.source('a', {}, '')`. Emit
+// an additional error so the test still fails parse phase even if the prior
+// meta-property diagnostic is later relaxed for the proposal. (#1512)
+on([ts.SyntaxKind.CallExpression], (ctx, node) => {
   if (
     ts.isCallExpression(node) &&
     ts.isMetaProperty(node.expression) &&
@@ -1681,9 +1946,11 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Escaped 'import' keyword in dynamic import() ──────────────
-  // im\u0070ort('x') — escaped form of import keyword is not valid
+// ── Escaped 'import' keyword in dynamic import() ──────────────
+// im\u0070ort('x') — escaped form of import keyword is not valid
+on([ts.SyntaxKind.CallExpression], (ctx, node) => {
   if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
     const start = node.getStart(ctx.sourceFile);
     const rawText = ctx.sourceFile.text.substring(start, start + 15);
@@ -1691,13 +1958,15 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "Keyword must not contain escaped characters");
     }
   }
+});
 
-  // ── VoidExpression / TypeOfExpression with empty operand ─────────
-  // When TS encounters `void yield` or `void await` in a generator/async context,
-  // it splits them into two statements: void(empty) and yield/await.
-  // The void/typeof gets an empty Identifier operand (text === "").
-  // In ES spec, `void` always requires a UnaryExpression, so this indicates
-  // a parse issue — the construct is a SyntaxError.
+// ── VoidExpression / TypeOfExpression with empty operand ─────────
+// When TS encounters `void yield` or `void await` in a generator/async context,
+// it splits them into two statements: void(empty) and yield/await.
+// The void/typeof gets an empty Identifier operand (text === "").
+// In ES spec, `void` always requires a UnaryExpression, so this indicates
+// a parse issue — the construct is a SyntaxError.
+on([ts.SyntaxKind.VoidExpression], (ctx, node) => {
   if (ts.isVoidExpression(node)) {
     const expr = node.expression;
     if (ts.isIdentifier(expr) && expr.text === "") {
@@ -1709,6 +1978,9 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
+
+on([ts.SyntaxKind.TypeOfExpression], (ctx, node) => {
   if (ts.isTypeOfExpression(node)) {
     const expr = node.expression;
     if (ts.isIdentifier(expr) && expr.text === "") {
@@ -1722,11 +1994,13 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Unary prefix (+, -, ~, !) with yield/await in generator/async ──
-  // Same issue: `+yield`, `-yield`, etc. TS splits the expression.
-  // If a PrefixUnaryExpression (not ++/--) has an empty Identifier operand,
-  // check if it's followed by yield/await.
+// ── Unary prefix (+, -, ~, !) with yield/await in generator/async ──
+// Same issue: `+yield`, `-yield`, etc. TS splits the expression.
+// If a PrefixUnaryExpression (not ++/--) has an empty Identifier operand,
+// check if it's followed by yield/await.
+on([ts.SyntaxKind.PrefixUnaryExpression], (ctx, node) => {
   if (
     ts.isPrefixUnaryExpression(node) &&
     node.operator !== ts.SyntaxKind.PlusPlusToken &&
@@ -1741,11 +2015,13 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Nullish coalescing (??) mixed with || or && without parens ──
-  // ES spec: It is a Syntax Error if ShortCircuitExpression includes both
-  // CoalesceExpression (??) and LogicalORExpression/LogicalANDExpression
-  // without explicit parenthesization.
+// ── Nullish coalescing (??) mixed with || or && without parens ──
+// ES spec: It is a Syntax Error if ShortCircuitExpression includes both
+// CoalesceExpression (??) and LogicalORExpression/LogicalANDExpression
+// without explicit parenthesization.
+on([ts.SyntaxKind.BinaryExpression], (ctx, node) => {
   if (ts.isBinaryExpression(node)) {
     const op = node.operatorToken.kind;
     if (op === ts.SyntaxKind.QuestionQuestionToken) {
@@ -1777,10 +2053,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Optional chaining with tagged template literal ───────────────
-  // ES spec: OptionalChain : ?.TemplateLiteral and OptionalChain TemplateLiteral
-  // are always SyntaxErrors. Tagged templates cannot be used with optional chaining.
+// ── Optional chaining with tagged template literal ───────────────
+// ES spec: OptionalChain : ?.TemplateLiteral and OptionalChain TemplateLiteral
+// are always SyntaxErrors. Tagged templates cannot be used with optional chaining.
+on([ts.SyntaxKind.TaggedTemplateExpression], (ctx, node) => {
   if (ts.isTaggedTemplateExpression(node)) {
     // Check if the tag uses optional chaining
     if (hasOptionalChain(node.tag)) {
@@ -1793,10 +2071,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       ctx.addError(node, "Tagged template cannot be used in an optional chain");
     }
   }
+});
 
-  // ── new.target outside function ─────────────────────────────────
-  // ES spec: new.target is only valid inside functions (including arrow functions
-  // which inherit from enclosing function) and class static blocks.
+// ── new.target outside function ─────────────────────────────────
+// ES spec: new.target is only valid inside functions (including arrow functions
+// which inherit from enclosing function) and class static blocks.
+on([ts.SyntaxKind.MetaProperty], (ctx, node) => {
   if (node.kind === ts.SyntaxKind.MetaProperty) {
     const meta = node as ts.MetaProperty;
     if (meta.keywordToken === ts.SyntaxKind.NewKeyword && meta.name.text === "target") {
@@ -1805,10 +2085,12 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── super() in constructor of class without extends ──────────────
-  // ES spec: It is a Syntax Error if ConstructorMethod of ClassBody contains
-  // SuperCall and ClassHeritage is not present.
+// ── super() in constructor of class without extends ──────────────
+// ES spec: It is a Syntax Error if ConstructorMethod of ClassBody contains
+// SuperCall and ClassHeritage is not present.
+on([ts.SyntaxKind.CallExpression], (ctx, node) => {
   if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.SuperKeyword) {
     // Find the enclosing class
     let current: ts.Node | undefined = node.parent;
@@ -1829,17 +2111,19 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       current = current.parent;
     }
   }
+});
 
-  // ── ASI: postfix ++/-- with line terminator before operator ─────
-  // ES spec: no LineTerminator between LeftHandSideExpression and ++/--.
-  // If a line terminator separates the operand from the operator, ASI applies
-  // and the ++ is parsed as a prefix on the next line. But if there's no
-  // next operand, it's a SyntaxError.
-  // NOTE: This only applies to LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029)
-  // because regular \n and \r are handled by TS parser's ASI behavior.
-  // After wrapTest resolves Unicode escapes, these characters appear literally.
+// ── ASI: postfix ++/-- with line terminator before operator ─────
+// ES spec: no LineTerminator between LeftHandSideExpression and ++/--.
+// If a line terminator separates the operand from the operator, ASI applies
+// and the ++ is parsed as a prefix on the next line. But if there's no
+// next operand, it's a SyntaxError.
+// NOTE: This only applies to LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029)
+// because regular \n and \r are handled by TS parser's ASI behavior.
+// After wrapTest resolves Unicode escapes, these characters appear literally.
 
-  // ── 'using' / 'await using' placement restrictions ───────────────
+// ── 'using' / 'await using' placement restrictions ───────────────
+on([ts.SyntaxKind.VariableStatement], (ctx, node) => {
   if (isUsingDeclarationStatement(node)) {
     const parent = node.parent;
     if (parent && (ts.isCaseClause(parent) || ts.isDefaultClause(parent))) {
@@ -1869,29 +2153,29 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       }
     }
   }
+});
 
-  // ── Fields named "constructor" in class ──────────────────────────
-  // ES spec: ClassElement: FieldDefinition ;
-  //   It is a Syntax Error if PropName of FieldDefinition is "constructor".
-  // ES spec: ClassElement: static FieldDefinition ;
-  //   It is a Syntax Error if PropName of FieldDefinition is "prototype" or "constructor".
-  // So "constructor" is always forbidden as a field name (static or not).
+// ── Fields named "constructor" in class ──────────────────────────
+// ES spec: ClassElement: FieldDefinition ;
+//   It is a Syntax Error if PropName of FieldDefinition is "constructor".
+// ES spec: ClassElement: static FieldDefinition ;
+//   It is a Syntax Error if PropName of FieldDefinition is "prototype" or "constructor".
+// So "constructor" is always forbidden as a field name (static or not).
+on([ts.SyntaxKind.PropertyDeclaration], (ctx, node) => {
   if (ts.isPropertyDeclaration(node)) {
     const name = ts.isIdentifier(node.name) ? node.name.text : ts.isStringLiteral(node.name) ? node.name.text : null;
     if (name === "constructor") {
       ctx.addError(node, "Classes may not have a field named 'constructor'");
     }
   }
+});
 
-  // ── Duplicate constructor methods ────────────────────────────────
-  // ES spec: It is a Syntax Error if PrototypePropertyNameList of ClassElementList
-  // contains more than one occurrence of "constructor".
-  // Handled by checkDuplicateConstructors in the class-level check.
+// ── Duplicate constructor methods ────────────────────────────────
+// ES spec: It is a Syntax Error if PrototypePropertyNameList of ClassElementList
+// contains more than one occurrence of "constructor".
+// Handled by checkDuplicateConstructors in the class-level check.
 
-  // ── HTML single-line close comment in module ─────────────────────
-  // ES spec: HTML-like comments (<!-- and -->) are only valid in scripts.
-  // We're always in module mode. Check for --> at the start of a line.
-  // Note: TS parser doesn't flag this.
-
-  forEachChild(node, (child) => runNodeChecks(ctx, child));
-}
+// ── HTML single-line close comment in module ─────────────────────
+// ES spec: HTML-like comments (<!-- and -->) are only valid in scripts.
+// We're always in module mode. Check for --> at the start of a line.
+// Note: TS parser doesn't flag this.


### PR DESCRIPTION
## Status: SUSPENDED — draft on purpose, do not un-draft or enqueue

WIP handoff of #4425. The refactor is fully generated and committed, but **no gate has run**: no typecheck, no differential, no tests. The complete resume checklist and all measurement evidence live in `plan/issues/4425-node-checks-switch-dispatch.md` (in this PR's diff) under **Suspended Work**.

## What this is

Mechanical restructure of `src/compiler/early-errors/node-checks.ts` (follow-up to #4423 / PR #4519 and the corrected rejected-early-out note in PR #4521): the flat chain of 95 guarded checks — all evaluated for every AST node — becomes `on([kinds], fn)` registrations indexed by `node.kind`, plus one traversal closure per file instead of one per node.

Safety design: every block keeps its original guard **verbatim** (over-registration is harmless; under-registration loses diagnostics and is caught by the differential), registration order preserves per-kind execution order, and traversal is unconditional (the failure mode that sank the first #4423 early-out).

The file was **generated by a TS-parser slicer**, not hand-edited — hand transcription corrupted a `  ` regex on the first attempt. The generator derives each block's kind set from its own guard and cross-checks a hand catalog: 95/95 agree.

## Evidence so far (loaded box — CPU-time & ratios only)

- `detectEarlyErrors` over an 8,621-file / 22.9 MB corpus sample: ~38 s CPU; with all 95 blocks removed (traversal + other passes kept): ~3.0 s CPU → check machinery ≈ 92% of detect.
- Profile: guard chain + `ts.isX` calls + per-node recursion closure ≈ 40% of detect CPU; fired check bodies ≈ 60% (that larger prize is deliberately out of scope here).
- Differential baseline (pre-refactor): 25,863 files, 23,979 diagnostics, 0 exceptions — the gate for this PR is **byte-identical** output.

## Resume

Worktree `/workspace/.claude/worktrees/issue-4425-node-checks-switch-dispatch` holds the gitignored harnesses (`.tmp/gen-dispatch.mts`, `ee-diff.mts`, `ee-base.jsonl`, `ee-count.mts`). Follow the checklist in the issue file top to bottom; un-draft only when the differential is byte-identical and tests pass.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
