### PR TITLE
docs(#4308): flip orphaned in-review to done — slices A–D all merged

### DIFF
--- a/plan/issues/4308-quickjs-eval-declaration-instantiation.md
+++ b/plan/issues/4308-quickjs-eval-declaration-instantiation.md
@@ -1,15 +1,15 @@
 ---
 id: 4308
 title: "EvalDeclarationInstantiation + Annex B B.3.3 for the QuickJS eval engine — the bucket that dominates the remaining 256 eval-code failures"
-# Slices A–D are all implemented and measured (see the four implementation
-# records below); the branch is handed off for PR + merge, so this is the
-# HANDOFF case of the status lifecycle — whoever observes the merge flips it to
-# `done`.
-status: in-review
+# Slices A–D all merged: A #4340, B #4343 (2026-08-10), C+D via #4366
+# (2026-08-11, superseding fork-head #4348 whose commits it carried verbatim).
+# This flip is the deferred HANDOFF-case observation of those merges.
+status: done
 assignee: ttraenkler/senior-dev
 sprint: current
 created: 2026-08-09
-updated: 2026-08-10
+updated: 2026-08-15
+completed: 2026-08-11
 priority: high
 horizon: xl
 feasibility: hard


### PR DESCRIPTION
Docs-only, one issue file. Shepherd sweep follow-up.

#4308's frontmatter deliberately used the HANDOFF case of the status lifecycle: `status: in-review` with a comment asking "whoever observes the merge" to flip it to `done`. All four slices merged days ago — A via #4340 and B via #4343 on 2026-08-10, C+D via #4366 on 2026-08-11 (which superseded the fork-head PR #4348 and carried its commits verbatim; #4348's closing comment explicitly notes "That flip has not happened yet") — but the observation was never made, leaving a merged issue orphaned at `in-review`, the exact state the lifecycle doc warns about (#1602/#1603/#1606).

This sets `status: done`, `completed: 2026-08-11` (the date the final slice landed), and replaces the stale handoff comment with a record of where each slice merged.

Not batched onto the open docs PRs (#4512/#4521) because both belong to other active sessions and this session is mandated to its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTRarwaxPuesuuN4499V4m

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTRarwaxPuesuuN4499V4m)_