### PR TITLE
ci: arm merge-when-ready at PR open + stop auto-refresh restarting in-flight CI

### DIFF
--- a/.github/workflows/auto-arm-merge.yml
+++ b/.github/workflows/auto-arm-merge.yml
@@ -1,0 +1,153 @@
+name: Arm merge-when-ready on eligible PRs
+
+# WHY (the #4520 livelock, 2026-08-15): auto-enqueue.yml enqueues a PR only when
+# its checks are all-green AT SWEEP TIME. On a busy evening every merge to main
+# knocked open PRs BEHIND, auto-refresh-prs restarted their ~10-min PR CI, and
+# main merged faster than a CI cycle — so #4520's checks were never all-green at
+# any sweep and it cycled 70+ minutes without ever being enqueueable. GitHub's
+# native merge-when-ready (auto-merge) closes that race CATEGORICALLY: armed
+# once at PR-open time, GitHub itself adds the PR to the merge queue the instant
+# its requirements pass — continuous evaluation, no sweep to race, and the armed
+# state survives refresh pushes and check restarts. (The companion 2026-08-15
+# change to auto-refresh-prs.yml stops restarting in-flight CI, so checks
+# actually get to finish.)
+#
+# RELATIONSHIP TO auto-enqueue.yml: additive belt-and-suspenders, NOT a
+# replacement. The sweep still covers PRs that predate this workflow, PRs whose
+# arming GitHub dropped (it auto-disables auto-merge when a merge group fails —
+# which also means a parked PR canNOT re-enter the queue in a loop; the #2547
+# auto-park flow is unchanged), and the #3889 allowlist gap. This workflow
+# mirrors the sweep's author-trust and hold-label gates because native
+# auto-merge knows nothing about either.
+#
+# WHY ARMING AT OPEN TIME AVOIDS THE KNOWN --auto TRAP: `gh pr merge --auto`
+# no-ops on an already-green PR (documented in auto-enqueue.yml's header) — but
+# at PR-open/ready time the checks are still ahead, so there is always a
+# transition left to fire on. The already-clean race is handled below by
+# treating "clean status" errors as success: a green PR is the sweep's to take.
+#
+# SECURITY: pull_request_target grants secrets, so this job NEVER checks out or
+# executes PR code — it only reads event metadata and calls the merge API.
+# The author-trust gate (#2549 parity) arms only OWNER/MEMBER/COLLABORATOR PRs;
+# external-contributor PRs still require a deliberate maintainer act.
+#
+# HOLD LABELS: native auto-merge is label-blind, so `labeled` with a hold label
+# DISARMS (covers a manual hold set while CI is pending — auto-park's hold
+# arrives after GitHub already dequeued+disarmed, so no conflict there), and
+# `unlabeled` re-arms once no hold label remains. That makes the auto-park bot's
+# standing instruction — "fix the failure and remove the `hold` label to
+# re-enqueue" — literally true again with no manual enqueue step.
+#
+# TOKEN: the same GitHub App as auto-enqueue/auto-refresh. A distinct actor, so
+# the eventual queue entry fires merge_group events normally (GITHUB_TOKEN's
+# would not — the reason auto-refresh was once disabled).
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  # Per-PR single-flight; never cancel — a disarm must not be lost to a
+  # just-started arm run.
+  group: auto-arm-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  arm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ENQUEUE_APP_ID }}
+          private-key: ${{ secrets.ENQUEUE_APP_PRIVATE_KEY }}
+
+      - name: Arm or disarm merge-when-ready
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+          PR_NODE: ${{ github.event.pull_request.node_id }}
+          EVENT_ACTION: ${{ github.event.action }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          # Label CURRENTLY on the PR (post-event snapshot), comma-joined.
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          # The label this event added/removed (empty for non-label events).
+          EVENT_LABEL: ${{ github.event.label.name }}
+        run: |
+          set -uo pipefail
+
+          # Mirrors HOLD_LABELS in scripts/enqueue-green-prs.mjs — keep in sync.
+          is_hold_label() {
+            case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+              hold|do-not-merge|"do not merge"|wip|blocked|stack-retarget-pending) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+          has_hold() {
+            local IFS=',' l
+            for l in $LABELS; do is_hold_label "$l" && return 0; done
+            return 1
+          }
+
+          disarm() {
+            out=$(gh api graphql \
+              -f query='mutation($id: ID!) { disablePullRequestAutoMerge(input: {pullRequestId: $id}) { clientMutationId } }' \
+              -f id="$PR_NODE" 2>&1) && { echo "disarmed #$PR"; return 0; }
+            # Not armed in the first place is a fine end state.
+            echo "disarm #$PR: $(printf '%s' "$out" | head -c 200)"
+            return 0
+          }
+
+          arm() {
+            out=$(gh api graphql \
+              -f query='mutation($id: ID!) { enablePullRequestAutoMerge(input: {pullRequestId: $id, mergeMethod: MERGE}) { clientMutationId } }' \
+              -f id="$PR_NODE" 2>&1) && { echo "armed merge-when-ready on #$PR"; return 0; }
+            if printf '%s' "$out" | grep -qi 'clean status'; then
+              # Already green: nothing left to arm on — auto-enqueue's sweep owns
+              # green PRs (its workflow_run trigger fires within ~a startup).
+              echo "#$PR already green — leaving to auto-enqueue sweep"
+              return 0
+            fi
+            if printf '%s' "$out" | grep -qi 'already enabled\|auto merge is enabled'; then
+              echo "#$PR already armed"
+              return 0
+            fi
+            echo "arm #$PR failed: $(printf '%s' "$out" | head -c 300)"
+            return 1
+          }
+
+          # --- event routing -------------------------------------------------
+          if [ "$EVENT_ACTION" = "labeled" ]; then
+            if [ -n "${EVENT_LABEL:-}" ] && is_hold_label "$EVENT_LABEL"; then
+              disarm; exit 0
+            fi
+            echo "non-hold label event — no-op"; exit 0
+          fi
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "draft — not arming (ready_for_review will re-fire)"; exit 0
+          fi
+          if has_hold; then
+            echo "hold label present — not arming"; exit 0
+          fi
+          case "$AUTHOR_ASSOC" in
+            OWNER|MEMBER|COLLABORATOR) ;;
+            *) echo "author association $AUTHOR_ASSOC — not arming (trust gate, #2549 parity)"; exit 0 ;;
+          esac
+
+          if [ "$EVENT_ACTION" = "unlabeled" ]; then
+            if [ -n "${EVENT_LABEL:-}" ] && is_hold_label "$EVENT_LABEL"; then
+              arm; exit $?
+            fi
+            echo "non-hold unlabel event — no-op"; exit 0
+          fi
+
+          # opened / reopened / ready_for_review
+          arm

--- a/.github/workflows/auto-refresh-prs.yml
+++ b/.github/workflows/auto-refresh-prs.yml
@@ -23,7 +23,19 @@ name: Auto-refresh BEHIND PR branches with main
 #     forming merge group's membership, which rebuilds it and CANCELS the head's
 #     in-flight merge_group run (project_merge_queue_requeue_cancels_run, #1758);
 #   - skip DIRTY (conflicting) PRs — update-branch 409s on a real conflict; those
-#     need manual resolution.
+#     need manual resolution;
+#   - skip PRs whose current head has CI IN FLIGHT (2026-08-15, the #4520
+#     livelock): refreshing a BEHIND PR restarts its ~10-min PR CI from zero,
+#     and on a busy evening main merges faster than that, so the PR's checks
+#     NEVER complete and it is never enqueueable — #4520 cycled 70+ minutes
+#     this way. Behind-ness does NOT block enqueue (#4094: enqueue-green-prs
+#     derives eligibility from checks + mergeable, and the merge queue builds
+#     the group against main anyway), so the right move for an in-flight head
+#     is to LET ITS CI FINISH. A 2-hour staleness bound keeps a wedged run
+#     from suppressing refresh forever;
+#   - skip PRs whose current head is already ALL-GREEN and quiescent — those are
+#     enqueue-eligible RIGHT NOW (#4094 behind-eligible); a refresh would only
+#     knock them back to pending and reopen the livelock window.
 #
 # TRIGGER: cron only (every 20 min) + manual dispatch — NOT push:main. A per-merge
 # push trigger races the SERIAL merge queue's merge_group formation (the churn
@@ -92,23 +104,64 @@ jobs:
           }
 
           # BEHIND, non-draft, non-hold open PRs. The label filter mirrors
-          # auto-enqueue.yml's HOLD_LABELS set.
+          # auto-enqueue.yml's HOLD_LABELS set. headRefOid rides along so the
+          # in-flight/green-head classification below can query this head's
+          # check runs without a second PR lookup.
           mapfile -t BEHIND < <(gh pr list --state open --limit 200 \
-            --json number,mergeStateStatus,isDraft,labels \
+            --json number,mergeStateStatus,isDraft,labels,headRefOid \
             --jq '.[]
                     | select(.mergeStateStatus == "BEHIND")
                     | select(.isDraft == false)
                     | select([.labels[].name]
                         | any(. == "hold" or . == "do-not-merge" or . == "do not merge" or . == "wip" or . == "blocked")
                         | not)
-                    | .number')
+                    | "\(.number) \(.headRefOid)"')
+
+          # CI-in-flight guard (#4520 livelock): count check runs on this head
+          # that are queued/in_progress AND recent (2h bound so one wedged run
+          # cannot suppress refresh forever). >0 ⇒ let CI finish; the enqueue
+          # sweep takes green PRs even when behind (#4094).
+          active_ci() {
+            # NB: `gh api --jq` takes only an expression — no jq --arg — so the
+            # cutoff is interpolated. ISO-8601 UTC strings compare lexically.
+            local sha="$1"
+            local cutoff; cutoff=$(date -u -d '-2 hours' +%Y-%m-%dT%H:%M:%SZ)
+            gh api "/repos/$GH_REPO/commits/$sha/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select((.status == "queued" or .status == "in_progress")
+                                       and ((.started_at // "1970-01-01T00:00:00Z") > "'"$cutoff"'"))] | length' \
+              2>/dev/null || echo 0
+          }
+          # Green-head guard: a quiescent head with check runs present and zero
+          # non-green conclusions is enqueue-eligible as-is — refreshing it only
+          # restarts CI and reopens the livelock window. success/skipped/neutral
+          # count as green (a SKIPPED required check satisfies the ruleset).
+          green_quiescent() {
+            local sha="$1" total notgreen
+            total=$(gh api "/repos/$GH_REPO/commits/$sha/check-runs?per_page=100" \
+              --jq '.check_runs | length' 2>/dev/null || echo 0)
+            [ "$total" -gt 0 ] || return 1
+            notgreen=$(gh api "/repos/$GH_REPO/commits/$sha/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.status != "completed"
+                       or ((.conclusion // "none") | IN("success","skipped","neutral") | not))] | length' \
+              2>/dev/null || echo 1)
+            [ "$notgreen" -eq 0 ]
+          }
 
           echo "queued=[${QUEUED[*]:-}] behind=[${BEHIND[*]:-}]"
           ok=0; skip=0; fail=0
-          for pr in "${BEHIND[@]:-}"; do
-            [ -n "$pr" ] || continue
+          for entry in "${BEHIND[@]:-}"; do
+            [ -n "$entry" ] || continue
+            pr="${entry%% *}"; sha="${entry##* }"
             if is_queued "$pr"; then
               echo "skip #$pr (already in merge queue)"
+              skip=$((skip+1)); continue
+            fi
+            if [ "$(active_ci "$sha")" -gt 0 ]; then
+              echo "skip #$pr (CI in flight on $sha — let it finish; enqueue takes green-behind PRs, #4094)"
+              skip=$((skip+1)); continue
+            fi
+            if green_quiescent "$sha"; then
+              echo "skip #$pr (head already all-green — enqueue-eligible as-is, refresh would restart CI)"
               skip=$((skip+1)); continue
             fi
             if out=$(gh api --method PUT "/repos/$GH_REPO/pulls/$pr/update-branch" 2>&1); then


### PR DESCRIPTION
Permanent fix for the refresh livelock that stuck #4520 (stakeholder request, 2026-08-15).

## The livelock, measured

Main merged 8 PRs between 22:08 and 01:36 — faster than a ~10-minute PR CI cycle during the burst. Each merge knocked every open PR `BEHIND`; `auto-refresh-prs` (cron */20) merged main into them and restarted their CI from zero; `auto-enqueue` only takes PRs whose checks are all-green **at sweep time**. #4520's checks restarted three times (00:42, 01:27, 01:53) and were never all-green at any sweep — 70+ minutes open without ever being enqueueable, until merge-when-ready was armed manually.

The key prior fact: since #4094, **behind-ness does not block enqueue** (`enqueue-green-prs.mjs` derives eligibility from checks + `mergeable`, and the queue builds groups against main anyway). So restarting a behind PR's in-flight CI buys nothing and costs the entire green window. The refresh churn *is* the livelock.

## Two composing changes

**`auto-arm-merge.yml` (new)** — arms GitHub's native merge-when-ready on every eligible PR at `opened`/`reopened`/`ready_for_review`. GitHub evaluates continuously server-side, so the instant checks pass the PR enters the merge queue — no sweep to race, and the armed state survives refresh pushes and check restarts. Arming at open time also sidesteps the documented `--auto` no-op trap (there is always a green transition still ahead; the already-clean race is handled as success and left to the sweep). Safety parity with the sweep:
- author-trust gate (OWNER/MEMBER/COLLABORATOR only, #2549 parity);
- hold labels: native auto-merge is label-blind, so `labeled` with a hold label **disarms** and removing the last hold label **re-arms** — which makes the auto-park bot's standing instruction ("fix the failure and remove the `hold` label to re-enqueue") literally true with no manual enqueue step;
- drafts never armed; GitHub itself disarms on merge-group ejection, so auto-park (#2547) still parks terminally — no re-enqueue loop is possible;
- `pull_request_target` with **no checkout of PR code** (metadata + merge API only); same GitHub App token as auto-enqueue/auto-refresh so queue entry fires `merge_group` events.

**`auto-refresh-prs.yml`** — two new skip conditions in the sweep, with the WHY recorded in the header:
- skip a BEHIND PR whose current head has CI **in flight** (queued/in_progress check runs started within the last 2h — the staleness bound keeps one wedged run from suppressing refresh forever): let its CI finish; the enqueue sweep takes green-behind PRs;
- skip a BEHIND PR whose head is already **all-green and quiescent**: it is enqueue-eligible as-is; a refresh would only knock it back to pending and reopen the livelock window.

`auto-enqueue.yml` is untouched — it remains the sweep/backstop for PRs that predate arming, lose their arming to a queue ejection, or hit the #3889 allowlist gap.

## Validation

- Both workflow YAMLs parse; both embedded bash scripts pass `bash -n`.
- The two jq classifiers smoke-tested against fabricated check-run payloads: a recent in-flight run counts as active while a stale one doesn't; success/skipped-only heads classify green, a failure head doesn't.
- Caught during review: `gh api --jq` takes no jq `--arg`, and the `|| echo 0` fallback would have masked that failure into a permanently-dead guard — the cutoff is interpolated instead (ISO-8601 UTC compares lexically), and the constraint is now a comment at the call site.
- Live precedent for the mechanism: merge-when-ready armed manually on #4520 at 01:55 after two livelock cycles — the exact behavior this workflow makes automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTRarwaxPuesuuN4499V4m

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTRarwaxPuesuuN4499V4m)_