### PR TITLE
fix(codegen): ES5 standalone conformance — array-length write lane, Array(x) single-arg, ToPrimitive dispatch, string += wrapper (#4426)

### DIFF
--- a/plan/issues/4426-es5-standalone-array-length-toprimitive-fixes.md
+++ b/plan/issues/4426-es5-standalone-array-length-toprimitive-fixes.md
@@ -12,6 +12,7 @@ es_edition: ES5
 task_type: bug
 loc-budget-allow:
   - src/codegen/expressions/assignment.ts
+  - src/codegen/expressions/operator-assignment.ts
   - src/codegen/literals.ts
   - src/codegen/type-coercion.ts
 func-budget-allow:

--- a/plan/issues/4426-es5-standalone-array-length-toprimitive-fixes.md
+++ b/plan/issues/4426-es5-standalone-array-length-toprimitive-fixes.md
@@ -1,0 +1,97 @@
+---
+id: 4426
+title: "ES5 standalone: array-length write lane + ToPrimitive closure-dispatch conformance fixes"
+status: done
+created: 2026-08-15
+updated: 2026-08-15
+completed: 2026-08-15
+priority: high
+goal: standalone-gap
+sprint: current
+es_edition: ES5
+task_type: bug
+loc-budget-allow:
+  - src/codegen/expressions/assignment.ts
+  - src/codegen/literals.ts
+  - src/codegen/type-coercion.ts
+func-budget-allow:
+  - src/codegen/expressions/new-indexed.ts::tryCompileIndexedBuiltinNew
+  - src/codegen/expressions/assignment.ts::compilePropertyAssignment
+  - src/codegen/type-coercion.ts::coerceType
+---
+
+# #4426 — ES5 standalone: array-length write lane + ToPrimitive closure-dispatch conformance fixes
+
+## Problem
+
+Four independent defects clustered in the ES5 standalone failure list
+(`benchmarks/results/test262-standalone-current.json`, buckets
+`object-property-semantics` / `array-typedarray-buffer` /
+`object-to-primitive`), together worth ~10+ es5id-tagged tests plus
+non-ES5 collateral:
+
+1. **`arr.length = n` receiver trap after evolving reassignment.** The
+   static length-set lowering (`expressions/assignment.ts`) typed the
+   receiver local with the checker's *flow-typed* vec (`$__vec_f64` after
+   `x = [0]`), while an evolving `var x = []` global is *stored* as
+   `$__vec_externref`. The local-set-coerce repair then emitted a sibling
+   `ref.cast` that always traps: every `x.length = n` after reassignment
+   died with `illegal cast` (test262 `S15.4.5.1_A1.3_T1` family).
+
+2. **`arr.length = <non-number>` skipped ToNumber.** Wrapper objects,
+   strings, booleans and null either no-oped (dynamic `__extern_set` arm:
+   bare `__unbox_number`, no ToPrimitive) or stored garbage (static lane:
+   value fell to the local-set-coerce repair). Spec (§10.4.2.4 step 3 /
+   ES5 §15.4.5.1) applies ToUint32(ToNumber(value)) with a RangeError on
+   invalid lengths (`S15.4.5.1_A1.3_T1/T2`, `S15.4.5.1_A1.1_T2`).
+
+3. **`new Array(x)` / `Array(x)` single non-Number argument.** §23.1.1.1
+   step 5 (ES5 §15.4.2.2): a single argument is a LENGTH only when it is
+   a Number; otherwise the result is the one-element array `[x]`.
+   Both lowerings unconditionally length-coerced with an f64 hint
+   (`S15.4.2.2_A2.3_T1–T5`).
+
+4. **ToNumber valueOf closure dispatch null-deref.** Zero-capture closure
+   wrapper structs canonicalize structurally to ONE runtime type, so
+   `ref.test closureTypeIdx` passing does not prove the stored funcref has
+   that candidate's signature. Two same-shaped object literals assigned to
+   one var made the inline valueOf dispatch (type-coercion.ts) hit a
+   funcref-signature miss, where the guarded cast manufactured `ref.null`
+   into `ref.as_non_null` → `dereferencing a null pointer` at module init
+   (`S9.1_A1_T1`, `S8.12.8_A3`, `S15.10.6.2_A4_T12` and the rest of the
+   null-deref-in-`__module_init` bucket).
+
+## Fix
+
+- `assignment.ts` length-set: receiver local + `struct.set` now use
+  `$__vec_base` (length is field 0 of the shared supertype — every
+  concrete vec upcasts safely); non-numeric values coerce through the
+  real ToNumber chain (`coerceType → __to_primitive + __unbox_number`)
+  and then get the §10.4.2.4 RangeError validation.
+- `vec-length-set.ts` dynamic arm: value goes through
+  `__to_primitive("number")` before `__unbox_number` when the standalone
+  object runtime is present (both funcs already exist at finalize — no
+  minting, no funcidx shift).
+- `new-indexed.ts` / `literals.ts`: single argument with a *provably*
+  non-number static tag (`ctx.oracle.staticJsTypeOf ≠ number/mixed`)
+  builds the one-element externref-vec array; `mixed`/number keep the
+  historical length lowering.
+- `type-coercion.ts` valueOf dispatch: a funcref-signature miss inside a
+  matched closure-struct candidate now falls through to the next
+  candidate (mirrors the documented eqref-path rule) instead of trapping.
+
+## Verification
+
+- `S15.4.5.1_A1.3_T1/T2`, `S15.4.5.1_A1.1_T2`, `S15.4.2.2_A2.3_T1/T4/T5`,
+  `S9.1_A1_T1`, `S8.12.8_A3`, `S15.10.6.2_A4_T12` flip fail→pass under
+  `--target standalone` (runner-verified locally).
+- `tests/es5-standalone-array-filter.test.ts` green;
+  `tests/issue-2679-toprimitive-this.test.ts` /
+  `tests/es5-array-new-filter-holes.test.ts` failures reproduced at the
+  merge-base (pre-existing, one of them fixed by this change-set).
+
+## LOC-budget note
+
+`loc-budget-allow` covers the three god-files above: the fixes live at
+the existing length-set / valueOf-dispatch sites and are comment-heavy
+per house style; net growth is +26/+19/+13.

--- a/plan/issues/4426-es5-standalone-array-length-toprimitive-fixes.md
+++ b/plan/issues/4426-es5-standalone-array-length-toprimitive-fixes.md
@@ -19,6 +19,9 @@ func-budget-allow:
   - src/codegen/expressions/new-indexed.ts::tryCompileIndexedBuiltinNew
   - src/codegen/expressions/assignment.ts::compilePropertyAssignment
   - src/codegen/type-coercion.ts::coerceType
+coercion-sites-allow:
+  - src/codegen/expressions/operator-assignment.ts
+  - src/codegen/vec-length-set.ts
 ---
 
 # #4426 — ES5 standalone: array-length write lane + ToPrimitive closure-dispatch conformance fixes
@@ -90,6 +93,14 @@ non-ES5 collateral:
   `tests/issue-2679-toprimitive-this.test.ts` /
   `tests/es5-array-new-filter-holes.test.ts` failures reproduced at the
   merge-base (pre-existing, one of them fixed by this change-set).
+
+## Coercion-sites note
+
+The two `coercion-sites-allow` entries are new CALL SITES of the existing
+engine helpers (`__to_primitive` in the vec length arm, `__extern_toString`
+in the compound-assign wrapper miss arm) — no fresh
+ToString/ToNumber/ToPrimitive matrix is introduced; both routes delegate to
+the #1917/#2108 engine's canonical implementations.
 
 ## LOC-budget note
 

--- a/plan/issues/4427-compound-assign-chain-invalid-module.md
+++ b/plan/issues/4427-compound-assign-chain-invalid-module.md
@@ -1,0 +1,97 @@
+---
+id: 4427
+title: "Compound `+=` chain with boolean RHS emits a non-validating module (any.convert_extern fed a (ref null $AnyString) if)"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: compound-assignment
+goal: standalone-gap
+related: [4426, 3989, 1999]
+origin: "2026-08-15 ES5-standalone session — found while fixing S11.13.2_A4.4_T1.4; reproduces at merge-base 63785cb (pre-existing, NOT introduced by #4426)."
+---
+
+# #4427 — compound `+=` chain with boolean RHS emits a non-validating module
+
+## Problem
+
+Two `+=` statements on the same var, where at least one RHS is a boolean,
+produce a module that FAILS `WebAssembly.validate`:
+
+```js
+var x;
+x = true;  x += "1";   // CHECK#1 of S11.13.2_A4.4_T2.7
+x = "1";   x += true;  // CHECK#2  → module invalid
+```
+
+V8: `any.convert_extern[0] expected type externref, found if of type
+(ref null $AnyString) @… in __module_init`. Verified combinations (probe
+`.tmp/probe-t27d.mjs`, session 2026-08-15): `p12` (`+= "1"` then `+= true`)
+and `p24` (`+= true` then `+= new Boolean(true)`) invalid; every
+single-statement variant validates. Reproduces at merge-base `63785cb`.
+
+Additionally, sibling WRONG-VALUE bugs in the same family (same test files,
+`fail` not CE): `x = 1; x += "1"` → `2` (numeric lane chosen over concat,
+S11.13.2_A4.4_T2.6 CHECK#2); `x = undefined; x += "1"` → `undefined`
+(T2.8); `x = null; x += "1"` → `null` (T2.9). Fixing the lane choice for a
+union-typed `x` whose runtime value is non-string is in scope if it falls
+out of the same dispatch; otherwise file the residual.
+
+test262 (ES5 standalone): S11.13.2_A4.4_T2.6–T2.9, plus the
+`expressions/addition/S11.6.1_A2.2_*` non-CE siblings.
+
+## Implementation Plan
+
+1. Reproduce: `npx tsx .tmp/probe-t27d.mjs` (copy from the main checkout's
+   `.tmp/`, or re-create: compile the two-statement pairs above with
+   `{ target: "standalone", allowJs: true, skipSemanticDiagnostics: true,
+   deferTopLevelInit: true, hostBridge: "always" }` and print
+   `WebAssembly.validate`). Emit WAT (`emitWat: true`) and find the `if`
+   whose result is `(ref null $AnyString)` feeding `any.convert_extern`.
+2. The suspect emitters, all in
+   `src/codegen/expressions/operator-assignment.ts`
+   `compileNativeStringCompoundAssignment` (~line 1277):
+   - the boolean-RHS arm (`emitBoolToString` → `any.convert_extern` +
+     `ref.cast $AnyString`),
+   - the (#3989) `bridgeSlot` store-back (`emitAnyStrToExternrefSlot`) — the
+     documented hazard is exactly "a `ref $AnyString` result lands in an
+     externref slot"; a UNION-typed `x` (boolean|string) stores as externref,
+     so a second `+=` on the same slot exercises the bridge in both
+     directions.
+   - the #4426 wrapper-miss arm added 2026-08-15 (an `if` with
+     `(ref null $AnyString)` result) — check whether the invalid `if` is the
+     PRE-EXISTING guarded arm elsewhere or this one composed with the bridge.
+3. Likely fix shape: whichever arm leaves `(ref null $AnyString)` on the
+   stack for an externref-slot store-back must `extern.convert_any` first
+   (or the `if` blockType must be externref in the bridge-slot case). Keep
+   the non-bridge path byte-identical.
+4. The wrong-lane siblings (T2.6/T2.8/T2.9): the `+=` lane choice for a
+   union-typed LHS is made in `compileOperatorAssignment` (~line 1695:
+   `isStr` = `isStringType(leftTsType)` or `hasStringAssignment`) and the
+   #2058/#4137 any-compound-add recovery (~line 1730). `x = 1; x += "1"`
+   with `x` union-typed picks the numeric path; the §13.15.3-correct
+   dispatcher for "either side may be a runtime string" is
+   `compileAnyCompoundAdd` / `emitAnyAddFromExternTemps`
+   (`binary-ops.ts:2420`) — widen the eligibility test to unions of
+   string|non-string, not only `any`/`unknown`, if measurement confirms.
+5. Verify: the four probe pairs validate AND run correctly; runner flips for
+   S11.13.2_A4.4_T2.6–T2.9 (use the single-test driver pattern:
+   `runTest262File(path, category, 15000, "standalone")` from
+   `tests/test262-runner.js`); `npm test -- tests/equivalence/string-*` and
+   `tests/issue-3989*` (if present) green.
+
+## Acceptance criteria
+
+- `p12`/`p24` probe modules validate and produce `"1true"`/`"1true"`.
+- S11.13.2_A4.4_T2.7 flips CE→pass standalone; T2.6/T2.8/T2.9 pass or the
+  residual is filed with the exact failing lane documented.
+- No regression in the scoped standalone filter
+  `language/expressions/compound-assignment|language/expressions/addition`.

--- a/plan/issues/4428-single-arg-array-ctor-wrapper-identity.md
+++ b/plan/issues/4428-single-arg-array-ctor-wrapper-identity.md
@@ -1,0 +1,79 @@
+---
+id: 4428
+title: "`new Array(<wrapper>)` element loses object identity — x[0] comes back as the unwrapped primitive"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: array-constructor
+goal: standalone-gap
+related: [4426, 2987, 3962]
+origin: "2026-08-15 ES5-standalone session — residual of the #4426 §23.1.1.1 single-non-number-argument fix."
+---
+
+# #4428 — `new Array(<wrapper>)` element loses object identity
+
+## Problem
+
+After #4426, `new Array(x)` with a provably non-number single argument
+builds the one-element array `[x]` (length 1 — correct). But when `x` is a
+WRAPPER OBJECT, the stored element is the unwrapped primitive, so identity
+asserts fail:
+
+```js
+var obj = new Boolean(false);
+var x = new Array(obj);
+x.length === 1;      // ✓ (fixed by #4426)
+x[0] === obj;        // ✗ — x[0] is primitive false (test262 S15.4.2.2_A2.3_T2)
+```
+
+Same for `new String("0")` (S15.4.2.2_A2.3_T3: `x[0]` is `"0"`, SameValue
+against the wrapper fails). `new Number(0)` (T4) PASSES — so Number
+wrappers survive the same lane while Boolean/String wrappers don't.
+
+test262 (ES5 standalone): S15.4.2.2_A2.3_T2, S15.4.2.2_A2.3_T3.
+
+## Implementation Plan
+
+1. Establish WHERE identity is lost — three candidates, probe each:
+   a. `new Boolean(false)` / `new String("0")` construction: do these even
+      produce a distinct object in standalone, or do they lower to the
+      primitive/box directly? Probe `var a = new Boolean(false);
+      var b = new Boolean(false); a === b` (must be false — distinct
+      objects) and `typeof a` (must be "object"). If construction itself is
+      primitive-collapsing, THAT is the bug and the Array test is
+      collateral — re-scope to the wrapper constructors
+      (`expressions/new-indexed.ts` / `standalone-subclass-ctors.ts`,
+      compare with the working `new Number` lane, and check
+      `standalone-wrapper-instanceof.ts` (#4276 follow-up) for the current
+      wrapper representation contract).
+   b. The #4426 one-element path (`new-indexed.ts` `args.length === 1`
+      non-number branch): `compileExpression(arg, { kind: "externref" })` —
+      does the externref coercion unwrap? Compare the WAT for the `new
+      Number` (passing) vs `new Boolean` (failing) arg.
+   c. The read side: `x[0]` on an externref vec through the dynamic lane —
+      does `__extern_get_idx`/unbox demote a stored wrapper to primitive?
+2. Fix at the narrowest failing layer; do NOT introduce a new wrapper
+   representation (that is #4276-adjacent substrate — coordinate via the
+   issue files if the fix would collide with
+   `src/codegen/standalone-wrapper-instanceof.ts`).
+3. Verify with the single-test driver
+   (`runTest262File(path, cat, 15000, "standalone")`):
+   S15.4.2.2_A2.3_T2/T3 flip; T1/T4/T5 stay green; scoped filter
+   `built-ins/Array/length` shows no regression.
+
+## Acceptance criteria
+
+- S15.4.2.2_A2.3_T2 and _T3 pass standalone; _T1/_T4/_T5 remain passing.
+- `a === b` for two `new Boolean(false)` is `false`, `typeof` is
+  `"object"` — or, if wrapper-construction identity is deliberately out of
+  scope, the issue documents the layer where identity is lost and files the
+  residual against the wrapper-constructor issue.

--- a/plan/issues/4429-string-hint-toprimitive-this-binding-residual.md
+++ b/plan/issues/4429-string-hint-toprimitive-this-binding-residual.md
@@ -1,0 +1,73 @@
+---
+id: 4429
+title: "String-hint ToPrimitive drops the receiver `this` — `'' + a` / `String(a)` call toString with wrong this (in-tree #2679 tests failing)"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: to-primitive
+goal: standalone-gap
+related: [2679, 4426]
+origin: "2026-08-15 ES5-standalone session — tests/issue-2679-toprimitive-this.test.ts has 2 failing cases, reproduced identically at merge-base 63785cb (silent regression of the #2679 fix, string-hint half)."
+---
+
+# #4429 — string-hint ToPrimitive drops the receiver `this`
+
+## Problem
+
+Two cases of the COMMITTED test `tests/issue-2679-toprimitive-this.test.ts`
+fail on current main (vitest, no test262 involved):
+
+- `'' + a` calls `toString` with `this === a` → expected 1, got 0
+- `String(a)` calls `toString` with `this === a` → expected 1, got 0
+
+for `var tv; var a = { toString() { tv = this; return "x"; } }`. The
+`@@toPrimitive` and every NUMBER-hint case in the same file pass — the
+number-hint dispatch installs `__current_this` around the call
+(`type-coercion.ts` ~3153, the #2679 fix); the string-hint path was
+documented there as "static-dispatches the raw method with the receiver as
+param-0, was correct", which is evidently no longer true. test262 tests are
+not the trigger here but the same defect underlies `Object.prototype`-level
+`toString` receivers across the ES5 standalone `object-to-primitive`
+bucket (36 ES5 rows).
+
+## Implementation Plan
+
+1. Reproduce: `npm test -- tests/issue-2679-toprimitive-this.test.ts` —
+   2 failures expected. These are vitest tests; fastest loop available.
+2. The string-hint dispatch emitters live in `src/codegen/type-coercion.ts`:
+   - `tryStructPrimitiveToString*` (~line 180–290): the toString-first
+     OrdinaryToPrimitive(string) static dispatch — closure-ref arm (~225,
+     `emitGuardedFuncRefCast` + `call_ref`) and eqref candidate-chain arm
+     (~280).
+   - `tryStructToString` (~3496) and its `normaliseToString`.
+   Determine which arm the test's shape takes (object-literal method → the
+   `__obj_meth_tramp_*` trampoline reads `this` from the `__current_this`
+   GLOBAL, not param-0 — the exact mechanism the number-hint fix (#2679)
+   documents at ~3132). The probable root cause: object-literal methods
+   moved to trampolines after the string-hint path was written, so the
+   "receiver as param-0" claim silently rotted.
+3. Fix: mirror the #2679 `__current_this` save/install/restore around the
+   string-hint dispatch arms (both closure-ref and eqref chains), reading
+   `ctx.currentThisGlobalIdx` FRESH at each global op (the ~3156 comment
+   documents the mid-dispatch global-shift hazard — copy that discipline,
+   and note the #4426 session restructured the number-hint candidate chain
+   at ~3082, so diff against that shape, not the pre-#4426 one).
+4. Sanity: whole `tests/issue-2679-toprimitive-this.test.ts` green (13/13);
+   `tests/es5-standalone-callable-tostring.test.ts` and
+   `tests/issue-4208-ordinary-to-primitive-ir.test.ts` stay green; scoped
+   standalone run over `language/types/object|built-ins/Object/prototype`
+   for flips in the object-to-primitive bucket.
+
+## Acceptance criteria
+
+- All 13 cases of `tests/issue-2679-toprimitive-this.test.ts` pass.
+- No regression in the ToPrimitive-adjacent suites named above.

--- a/plan/issues/4430-array-new-filter-holes-ir-invalid-module.md
+++ b/plan/issues/4430-array-new-filter-holes-ir-invalid-module.md
@@ -1,0 +1,67 @@
+---
+id: 4430
+title: "Bounded sparse `new Array(n)` + filter holes: standalone IR route emits a non-validating module (in-tree #4222 test failing)"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ir
+es_edition: 5
+language_feature: array-holes
+goal: standalone-gap
+related: [4222, 4426]
+origin: "2026-08-15 ES5-standalone session — tests/es5-array-new-filter-holes.test.ts case 'claims the bounded sparse route in standalone IR' fails WebAssembly.validate, reproduced identically at merge-base 63785cb."
+---
+
+# #4430 — bounded sparse route (standalone IR) emits a non-validating module
+
+## Problem
+
+The COMMITTED test `tests/es5-array-new-filter-holes.test.ts` case
+"**claims the bounded sparse route in standalone IR**" (`#4222 —
+representation and IR ownership` describe block) fails on current main:
+`compile()` reports success but `WebAssembly.validate(result.binary)` is
+false. A compile that hands back an invalid binary is strictly worse than a
+compile error — the runner records it as CE with an opaque V8 message, and
+in production it is a crash at instantiate.
+
+Reproduced identically at merge-base `63785cb` (pre-existing; found during
+the #4426 session's regression sweep).
+
+## Implementation Plan
+
+1. Reproduce: `npm test -- tests/es5-array-new-filter-holes.test.ts` — read
+   the failing case's compile options in the test (it pins the IR/standalone
+   route). Then get the REAL validation error: instantiate via
+   `new WebAssembly.Module(result.binary)` in a probe and capture the V8
+   message naming the function and instruction (`emitWat: true` on the same
+   compile to read the body).
+2. Suspect surface: the #4222 bounded-sparse lowering for `new Array(n)`
+   holes on the IR path — `src/ir/` lowering for the array-holes route plus
+   `src/codegen/expressions/new-indexed.ts` `holeyCarrier` branch
+   (`getOrRegisterHoleyArrayType` / `ensureHoleyArrayNew`). Note the #4426
+   session added a one-element branch ABOVE the `args.length === 1` length
+   lowering in `new-indexed.ts` — confirm the failure predates it (it does —
+   merge-base repro) but keep the branch in mind when reading the WAT.
+3. Typical failure classes for this shape (check in order): a `struct.new`
+   arg type vs holey-vec field mismatch; a `local.set` whose local was typed
+   from the non-holey vec while the value is the holey type (sibling-cast
+   hazard — same family as the #4426 length-set fix); an IR-emitted block
+   type that disagrees with the legacy helper's result type.
+4. Fix at the emission site; do not paper over with a stack-balance repair.
+5. Verify: the whole `tests/es5-array-new-filter-holes.test.ts` file green;
+   `tests/es5-standalone-array-filter.test.ts` green;
+   `pnpm run check:ir-fallbacks` unchanged (no bucket growth); scoped
+   standalone run over `built-ins/Array/prototype/filter` for collateral.
+
+## Acceptance criteria
+
+- All cases of `tests/es5-array-new-filter-holes.test.ts` pass (the module
+  validates).
+- No IR-fallback bucket growth; filter-adjacent suites stay green.

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -31,7 +31,13 @@ import {
   resolveWasmType,
   TYPED_ARRAY_NAMES,
 } from "../index.js";
-import { getSubviewArrTypeIdx, isHoleyArrayType, isSubviewTypeIdx, isTaViewTypeIdx } from "../registry/types.js"; // (#2357/#47) subview write; (#3054 B1) TA view write
+import {
+  getOrRegisterVecBaseType,
+  getSubviewArrTypeIdx,
+  isHoleyArrayType,
+  isSubviewTypeIdx,
+  isTaViewTypeIdx,
+} from "../registry/types.js"; // (#2357/#47) subview write; (#3054 B1) TA view write; vec-base length write
 import { emitTaDynViewElementSet, emitTaViewElementSet } from "../dataview-native.js"; // (#3054 B1) shared-backing TA view write; (#3057) dynamic view element write
 import { buildDestructureNullThrow, emitNativeObjectRest, patternIteratorStepCount } from "../destructuring-params.js";
 import { resolveComputedKeyExpression } from "../literals.js";
@@ -3901,21 +3907,41 @@ function compilePropertyAssignment(
   if (target.name.text === "length") {
     const arrInfo = resolveArrayInfo(ctx, objType);
     if (arrInfo) {
-      const { vecTypeIdx } = arrInfo;
+      // The checker's FLOW type picks `vecTypeIdx`, but the receiver's runtime
+      // representation can be a sibling vec (an evolving `var x = []` global is
+      // stored as `$__vec_externref` while a later `x = [0]` narrows the flow
+      // type to `number[]` → `$__vec_f64`; the local-set-coerce repair then
+      // emits a sibling `ref.cast` that always traps — `illegal cast` on every
+      // `x.length = n` after reassignment, test262 S15.4.5.1_A1.3_T1). The
+      // write only touches field 0 (`length`), which lives on the shared
+      // `$__vec_base` supertype, so type the receiver as the base: every
+      // concrete vec upcasts safely and the store is identical.
+      const vecBaseIdx = getOrRegisterVecBaseType(ctx);
       // Compile receiver (vec struct ref)
       const structObjResult = compileExpression(ctx, fctx, target.expression);
       if (!structObjResult) return null;
       const vecTmp = allocLocal(fctx, `__arr_len_set_vec_${fctx.locals.length}`, {
         kind: "ref_null",
-        typeIdx: vecTypeIdx,
+        typeIdx: vecBaseIdx,
       });
       fctx.body.push({ op: "local.set", index: vecTmp });
       // Compile value (the new length)
       const valType = compileExpression(ctx, fctx, value);
       if (!valType) return null;
+      // §10.4.2.4 step 3: ToUint32(ToNumber(value)). A non-numeric value
+      // (`arr.length = "1"` / `null` / `new Number(1)`) used to fall to the
+      // local-set-coerce repair, whose bare `__unbox_number` reads wrapper
+      // objects as NaN and stored 0 (test262 S15.4.5.1_A1.3_T1). Coerce
+      // ref-ish values through the real ToNumber chain (ToPrimitive + unbox)
+      // so wrappers and strings get their valueOf/parse, then validate.
+      let lenValKind = valType.kind;
+      if (lenValKind !== "i32" && lenValKind !== "f64") {
+        coerceType(ctx, fctx, valType, { kind: "f64" });
+        lenValKind = "f64";
+      }
       // Convert f64 to i32 if needed
       const newLenTmp = allocLocal(fctx, `__arr_len_set_nl_${fctx.locals.length}`, { kind: "i32" });
-      if (valType.kind === "f64") {
+      if (lenValKind === "f64") {
         // (#4222) §10.4.2.4 ArraySetLength step 3 — RangeError, not a clamp;
         // body in array-length-define.ts, which owns the defineProperty forms.
         emitArraySetLengthValidation(ctx, fctx);
@@ -3924,7 +3950,7 @@ function compilePropertyAssignment(
       // Set vec.length = newLen
       fctx.body.push({ op: "local.get", index: vecTmp });
       fctx.body.push({ op: "local.get", index: newLenTmp });
-      fctx.body.push({ op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 });
+      fctx.body.push({ op: "struct.set", typeIdx: vecBaseIdx, fieldIdx: 0 });
       // Return the new length as the assignment expression result
       fctx.body.push({ op: "local.get", index: newLenTmp });
       if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });

--- a/src/codegen/expressions/new-indexed.ts
+++ b/src/codegen/expressions/new-indexed.ts
@@ -602,6 +602,34 @@ export function tryCompileIndexedBuiltinNew(
     }
 
     if (args.length === 1) {
+      // §23.1.1.1 step 5 (ES5 §15.4.2.2): a single argument is a LENGTH only
+      // when it is a Number. `new Array(null)` / `new Array("1")` / `new
+      // Array(new Number(0))` construct the one-element array `[arg]` with
+      // length 1 (test262 S15.4.2.2_A2.3_T1–T4). The length lowering below
+      // compiled the arg with an f64 hint (ToNumber), silently turning those
+      // into empty length-coerced arrays. Provably-non-number args (the tag is
+      // static and ≠ number) take the one-element path; `mixed` (any-typed)
+      // args keep the historical length behavior.
+      const argTag = ctx.oracle.staticJsTypeOf(args[0]!);
+      if (argTag !== "number" && argTag !== "mixed") {
+        let oneVecIdx = vecTypeIdx;
+        let oneArrIdx = arrTypeIdx;
+        if (elemWasm.kind !== "externref") {
+          oneVecIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+          oneArrIdx = getArrTypeIdxFromVec(ctx, oneVecIdx);
+        }
+        compileExpression(ctx, fctx, args[0]!, { kind: "externref" });
+        fctx.body.push({ op: "array.new_fixed", typeIdx: oneArrIdx, length: 1 });
+        const oneData = allocLocal(fctx, `__arr_data_${fctx.locals.length}`, {
+          kind: "ref",
+          typeIdx: oneArrIdx,
+        });
+        fctx.body.push({ op: "local.set", index: oneData });
+        fctx.body.push({ op: "i32.const", value: 1 });
+        fctx.body.push({ op: "local.get", index: oneData });
+        fctx.body.push({ op: "struct.new", typeIdx: oneVecIdx });
+        return { kind: "ref_null", typeIdx: oneVecIdx };
+      }
       // new Array(n) → array with capacity n, length 0
       // For test262 patterns like `var a = new Array(16); a[0] = x;`
       // we create an array of size n with default values and set length to n

--- a/src/codegen/expressions/operator-assignment.ts
+++ b/src/codegen/expressions/operator-assignment.ts
@@ -1384,9 +1384,40 @@ function compileNativeStringCompoundAssignment(
       }
     }
   } else if (rhsType.kind === "externref") {
-    // externref → ref $AnyString: convert + cast (e.g. host charAt result).
-    fctx.body.push({ op: "any.convert_extern" });
-    fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx });
+    // externref → ref $AnyString. The value is usually already a native string
+    // (host charAt result), but a STRING-typed RHS can also be a String
+    // WRAPPER OBJECT — `x += new String("1")` types as String while the
+    // runtime value is the $Object wrapper, and the old unconditional
+    // `ref.cast` trapped with `illegal cast` (test262 S11.13.2_A4.4_T1.4).
+    // Test first; on a non-string, run the §7.1.17 walker `__extern_toString`
+    // (ToPrimitive → ToString — unwraps wrappers, stringifies objects).
+    const externToStrIdx = ctx.standalone || ctx.wasi ? ctx.funcMap.get("__extern_toString") : undefined;
+    if (externToStrIdx !== undefined) {
+      const extTmp = allocTempLocal(fctx, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: extTmp });
+      fctx.body.push({ op: "local.get", index: extTmp });
+      fctx.body.push({ op: "any.convert_extern" });
+      fctx.body.push({ op: "ref.test", typeIdx: ctx.anyStrTypeIdx });
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx } },
+        then: [
+          { op: "local.get", index: extTmp },
+          { op: "any.convert_extern" },
+          { op: "ref.cast_null", typeIdx: ctx.anyStrTypeIdx },
+        ],
+        else: [
+          { op: "local.get", index: extTmp },
+          { op: "call", funcIdx: externToStrIdx },
+          { op: "any.convert_extern" },
+          { op: "ref.cast_null", typeIdx: ctx.anyStrTypeIdx },
+        ],
+      });
+      releaseTempLocal(fctx, extTmp);
+    } else {
+      fctx.body.push({ op: "any.convert_extern" });
+      fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx });
+    }
   }
 
   // Call __str_concat — returns ref $AnyString

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -5110,6 +5110,25 @@ export function compileArrayConstructorCall(
   }
 
   if (args.length === 1) {
+    // §23.1.1.1 step 5: a single NON-Number argument is an element, not a
+    // length — `Array(null)` / `Array("1")` / `Array(new Number(0))` build the
+    // one-element array `[arg]` (test262 S15.4.2.2_A2.3_T1–T4; the call and
+    // `new` forms behave identically). Provably-non-number args (static tag ≠
+    // number) take this path; `mixed` (any-typed) keeps length behavior.
+    const argTag = ctx.oracle.staticJsTypeOf(args[0]!);
+    if (argTag !== "number" && argTag !== "mixed" && !ts.isSpreadElement(args[0]!)) {
+      const oneVecIdx =
+        elemWasm.kind === "externref" ? vecTypeIdx : getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+      const oneArrIdx = getArrTypeIdxFromVec(ctx, oneVecIdx);
+      compileExpression(ctx, fctx, args[0]!, { kind: "externref" });
+      fctx.body.push({ op: "array.new_fixed", typeIdx: oneArrIdx, length: 1 });
+      const oneData = allocLocal(fctx, `__arr_data_${fctx.locals.length}`, { kind: "ref", typeIdx: oneArrIdx });
+      fctx.body.push({ op: "local.set", index: oneData });
+      fctx.body.push({ op: "i32.const", value: 1 });
+      fctx.body.push({ op: "local.get", index: oneData });
+      fctx.body.push({ op: "struct.new", typeIdx: oneVecIdx });
+      return { kind: "ref_null", typeIdx: oneVecIdx };
+    }
     // Array(n) → sparse array of length n with default values.
     // #2000 — §23.1.1.1 step 4.b: when the single argument is a Number it is a
     // length, and `len !== ToUint32(len)` must throw a RangeError ("Invalid

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -3079,29 +3079,11 @@ export function coerceType(
                 typeIdx: closureTypeIdx,
               });
               const funcTmp = allocLocal(fctx, `__vo_fn_${fctx.locals.length}`, { kind: "funcref" } as ValType);
-              const thenInstrs: Instr[] = [
-                { op: "local.get", index: eqLocal },
-                { op: "ref.cast", typeIdx: closureTypeIdx },
-                { op: "local.tee", index: closureLocal },
-                { op: "local.get", index: closureLocal },
-                { op: "struct.get", typeIdx: closureTypeIdx, fieldIdx: 0 },
-                // Guarded funcref cast to avoid illegal cast traps
-                { op: "local.tee", index: funcTmp },
-                { op: "ref.test", typeIdx: info.funcTypeIdx },
-                {
-                  op: "if",
-                  blockType: { kind: "val", type: { kind: "ref_null", typeIdx: info.funcTypeIdx } as ValType },
-                  then: [
-                    { op: "local.get", index: funcTmp },
-                    { op: "ref.cast_null", typeIdx: info.funcTypeIdx },
-                  ],
-                  else: [{ op: "ref.null", typeIdx: info.funcTypeIdx }],
-                },
-                { op: "ref.as_non_null" },
-                { op: "call_ref", typeIdx: info.funcTypeIdx },
-              ];
+              // Post-call result normalization (return-type dependent), built
+              // first so it can be spliced after the call inside the guarded if.
+              const postCallInstrs: Instr[] = [];
               if (info.returnType?.kind === "i32") {
-                thenInstrs.push({ op: "f64.convert_i32_s" });
+                postCallInstrs.push({ op: "f64.convert_i32_s" });
               } else if (info.returnType?.kind === "externref" || info.returnType?.kind === "ref_extern") {
                 // valueOf returned externref — could be a primitive (string,
                 // number, bool) OR an object. Per ECMA-262 §7.1.1.1, if the
@@ -3114,28 +3096,59 @@ export function coerceType(
                 // __to_primitive helper using the ORIGINAL struct, which
                 // re-runs valueOf, tries toString, and throws TypeError if
                 // appropriate.
-                thenInstrs.push({ op: "drop" });
-                thenInstrs.push({ op: "local.get", index: structLocal });
+                postCallInstrs.push({ op: "drop" });
+                postCallInstrs.push({ op: "local.get", index: structLocal });
                 const hintExtRet = toPrimitiveHint ?? "number";
                 for (const i of toPrimitiveHostCallInstrs(ctx, fctx, "f64", hintExtRet)) {
-                  thenInstrs.push(i);
+                  postCallInstrs.push(i);
                 }
               } else if (!info.returnType) {
                 // void return — call was for side effects; push NaN
-                thenInstrs.push({ op: "f64.const", value: NaN });
+                postCallInstrs.push({ op: "f64.const", value: NaN });
               } else if (info.returnType.kind !== "f64") {
                 // valueOf returned a non-primitive (object ref). Per ECMA-262
                 // §7.1.1.1 OrdinaryToPrimitive step 2.b.ii: continue to the
                 // next method (toString); step 3: throw TypeError if neither
                 // returns a primitive. Both behaviours live in the host
                 // __to_primitive helper. Pre-#1253 we silently pushed NaN.
-                thenInstrs.push({ op: "drop" });
-                thenInstrs.push({ op: "local.get", index: structLocal });
+                postCallInstrs.push({ op: "drop" });
+                postCallInstrs.push({ op: "local.get", index: structLocal });
                 const hint2 = toPrimitiveHint ?? "number";
                 for (const i of toPrimitiveHostCallInstrs(ctx, fctx, "f64", hint2)) {
-                  thenInstrs.push(i);
+                  postCallInstrs.push(i);
                 }
               }
+              // Zero-capture closure wrappers share one CANONICAL struct type
+              // (field 0 is plain `funcref`), so `ref.test closureTypeIdx`
+              // passing does NOT prove the stored function has THIS candidate's
+              // signature — two same-shape object literals assigned to one var
+              // land here with each other's canonical type. A funcref-signature
+              // miss therefore means "try the next candidate", not "manufacture
+              // null and trap" (the old guarded-cast + ref.as_non_null pair
+              // null-deref'd on the second literal's `Number(object)` —
+              // test262 S9.1_A1_T1).
+              const thenInstrs: Instr[] = [
+                { op: "local.get", index: eqLocal },
+                { op: "ref.cast", typeIdx: closureTypeIdx },
+                { op: "local.set", index: closureLocal },
+                { op: "local.get", index: closureLocal },
+                { op: "struct.get", typeIdx: closureTypeIdx, fieldIdx: 0 },
+                { op: "local.set", index: funcTmp },
+                { op: "local.get", index: funcTmp },
+                { op: "ref.test", typeIdx: info.funcTypeIdx },
+                {
+                  op: "if",
+                  blockType: { kind: "val" as const, type: { kind: "f64" as const } },
+                  then: [
+                    { op: "local.get", index: closureLocal },
+                    { op: "local.get", index: funcTmp },
+                    { op: "ref.cast", typeIdx: info.funcTypeIdx },
+                    { op: "call_ref", typeIdx: info.funcTypeIdx },
+                    ...postCallInstrs,
+                  ],
+                  else: buildDispatch(idx + 1),
+                },
+              ];
               return [
                 { op: "local.get", index: eqLocal },
                 { op: "ref.test", typeIdx: closureTypeIdx },

--- a/src/codegen/vec-length-set.ts
+++ b/src/codegen/vec-length-set.ts
@@ -45,8 +45,9 @@
  */
 import type { Instr } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
-import { nativeStringLiteralInstrs } from "./native-strings.js";
+import { nativeStringLiteralInstrs, stringConstantExternrefInstrs } from "./native-strings.js";
 import { NON_ARRAY_BYTE_VEC_ELEM_KINDS } from "./object-runtime.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
 import { getArrTypeIdxFromVec, getOrRegisterVecBaseType } from "./registry/types.js";
 
 /** `key == "length"` over an externref key (param `keyParam`); i32 on stack. */
@@ -83,6 +84,26 @@ export function fillVecLengthDynamicArms(ctx: CodegenContext): void {
   const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals");
   const unboxNumIdx = ctx.funcMap.get("__unbox_number");
   if (strFlattenIdx === undefined || strEqualsIdx === undefined || unboxNumIdx === undefined) return;
+  // §10.4.2.4 step 3 applies ToUint32(ToNumber(value)) — and ToNumber runs
+  // ToPrimitive first, so `arr.length = new Number(1)` / `new String("1")` /
+  // `new Boolean(false)` must unwrap through valueOf before the numeric
+  // validation (test262 S15.4.5.1_A1.3_T1/T2). `__unbox_number` alone only
+  // answers already-primitive boxes, so wrapper-object writes read as invalid
+  // and silently no-oped. `__to_primitive` is a defined function whenever the
+  // standalone object runtime is present; when it is absent (no object support
+  // compiled in), wrapper objects cannot exist either, so the bare unbox is
+  // still complete. Both funcs already exist at finalize — no minting, no
+  // funcidx shift (the #4221 hazard this fill is written around).
+  const toPrimIdx = ctx.funcMap.get("__to_primitive");
+  if (toPrimIdx !== undefined) addStringConstantGlobal(ctx, "number");
+  const toNumberInstrs: Instr[] =
+    toPrimIdx !== undefined
+      ? [
+          ...stringConstantExternrefInstrs(ctx, "number"),
+          { op: "call", funcIdx: toPrimIdx },
+          { op: "call", funcIdx: unboxNumIdx },
+        ]
+      : [{ op: "call", funcIdx: unboxNumIdx }];
   const vecBaseIdx = getOrRegisterVecBaseType(ctx);
   const findFn = (name: string) => ctx.mod.functions.find((f) => f.name === name);
 
@@ -181,9 +202,9 @@ export function fillVecLengthDynamicArms(ctx: CodegenContext): void {
             op: "if",
             blockType: { kind: "empty" },
             then: [
-              // n = ToNumber(value); valid: integral ∧ 0 ≤ n ≤ 2**32-1.
+              // n = ToNumber(ToPrimitive(value)); valid: integral ∧ 0 ≤ n ≤ 2**32-1.
               { op: "local.get", index: 2 },
-              { op: "call", funcIdx: unboxNumIdx },
+              ...toNumberInstrs,
               { op: "local.tee", index: lN },
               { op: "f64.floor" },
               { op: "local.get", index: lN },


### PR DESCRIPTION
## Description

Five targeted `--target standalone` conformance fixes toward closing the ES5 gap (issue #4426, es5id-tagged standalone failures were 677/8115 at the 2026-08-15 baseline). Scoped standalone re-run over the touched areas: **16 → 24 pass / 34** (`built-ins/Array/length` + `Number/S9.1` + `Number/S8.12` filter), zero regressions in scope; runner-verified flips also include `S11.13.2_A4.4_T1.4`, `S15.10.6.2_A4_T12`, `S8.12.8_A3`.

1. **Array `.length =` receiver cast** (`expressions/assignment.ts`): the static length-set lowering typed the receiver with the checker's *flow-typed* vec (`$__vec_f64` after `x = [0]`) while an evolving `var x = []` global stores a sibling `$__vec_externref` — the local-set-coerce repair then emitted a sibling `ref.cast` that always traps. The write only touches field 0 (`length`), which lives on `$__vec_base`, so the receiver is now typed as the base (S15.4.5.1_A1.3_T1 illegal-cast family).
2. **Array `.length =` value coercion** (`assignment.ts` + `vec-length-set.ts`): non-numeric length values (wrappers, strings, booleans, null) now coerce through the real ToNumber chain (`__to_primitive` + `__unbox_number`) and get the §10.4.2.4 RangeError validation, in both the static lane and the dynamic `__extern_set` vec arm, instead of no-oping or storing 0.
3. **`new Array(x)` / `Array(x)` single non-Number argument** (`new-indexed.ts` / `literals.ts`): per §23.1.1.1 step 5, a single argument is a length only when it is a Number. A *provably* non-number arg (`ctx.oracle.staticJsTypeOf ≠ number/mixed`) now builds the one-element array `[x]`; `mixed`/number keep the historical length lowering (S15.4.2.2_A2.3_T1/T4/T5).
4. **ToNumber valueOf closure dispatch** (`type-coercion.ts`): zero-capture closure wrappers canonicalize to one struct type, so a funcref-signature miss inside a matched closure-struct candidate now falls through to the next candidate (mirrors the documented eqref-path rule) instead of manufacturing `ref.null` into `ref.as_non_null` — this was the whole "dereferencing a null pointer in `__module_init`" bucket for two same-shaped object literals assigned to one var (S9.1_A1_T1 family).
5. **`string += <String wrapper>`** (`operator-assignment.ts`): the externref RHS arm cast unconditionally to `$AnyString`; a String *wrapper object* RHS trapped. Now `ref.test` first, with `__extern_toString` (ToPrimitive → ToString) as the miss arm; host lane and modules without the object runtime keep the old emission.

LOC/function-budget growth is granted by `plan/issues/4426-…md` frontmatter (`loc-budget-allow` / `func-budget-allow`). Pre-existing failures in `tests/issue-2679-toprimitive-this.test.ts` (2, string-hint `this` binding) and `tests/es5-array-new-filter-holes.test.ts` reproduce identically at the merge-base; one merge-base failure in that set is fixed by this change-set.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_