### PR TITLE
fix(#4157): a loop-carrying callee is not a loop-leaf — landing WASI fib 0.76x -> 1.50x V8

### DIFF
--- a/plan/issues/4157-close-the-acorn-node-performance-gap.md
+++ b/plan/issues/4157-close-the-acorn-node-performance-gap.md
@@ -4694,3 +4694,106 @@ Not accounted for: 1 `wasm_compile` + the 3 `assertion_fail` rows. The sweep
 compiles only the PRIMARY harness variant and never executes, so it cannot see a
 strict-rerun-only failure or a wrong-answer one; the merge-group re-run is the
 authoritative check on those.
+
+## 2026-08-15 (47) — the flip's first RUNTIME regression: the loop-leaf rule inlined a loop, and the landing WASI `fib` lane went 1.50x V8 → 0.76x
+
+Entry (37) flipped the tuned eleven ON and named the risk it could not cover:
+"this is the first time these eleven face the test262 merge-group
+re-validation". They passed it. What no gate covered is the landing benchmark
+lane, and that is where the flip's first real regression landed — visible only
+in a committed artifact three refreshes later.
+
+### The number, and how it was isolated from machine noise
+
+`benchmarks/results/wasm-host-wasmtime-hot-runtime.json` is refreshed by CI on
+two runner classes, which the JS lane identifies unambiguously: class A reads
+`js ≈ 16.8 ms` on `fib` warm, class B `js ≈ 18.68 ms`. Comparing only within
+class B, so the CPU is held fixed:
+
+| refresh (class B)  | fib warm | fib-recursive | array-sum | string-hash |
+| ------------------ | -------- | ------------- | --------- | ----------- |
+| 8695ae8 / d9cef66  | 12,442   | 7,565         | 926       | 238         |
+| f2c52ab .. 412cda7 | 24,888   | 7,565         | 1,243     | 238         |
+
+`fib` exactly 2.0x, `array-sum` 1.34x, the other two untouched — and the JS lane
+moved 18,683 → 18,682 µs across the same boundary. A machine change cannot
+produce that pattern; the two survivors are what named the rule. `fib-recursive`
+is self-recursive (already declined) and `string-hash` is not a leaf. Both
+regressing programs are a small **exported leaf that is one `for` loop**.
+
+The `fib` COLD lane did not move (18.8 → 18.8 ms), and its module is
+byte-identical across the boundary — the cold binary is 104 bytes on both
+sides. Only the WARM module, which appends the timing driver, changed.
+
+### Root cause
+
+Rule 1's `loop-leaf`: `weight ≥ 10` (the site is in the driver's measurement
+loop), `isLeaf` (fib's `run` calls nothing), `effSize ≈ 30 ≤ loopBudget 60`. So
+`run` was inlined into `warm` at both of its sites. `JS2WASM_IR_INLINE=on,verbose`
+prints it directly:
+
+```
+[ir-inline]   loop-leaf: run -> warm
+[ir-inline]   loop-leaf: run -> warm
+```
+
+Cranelift then had to keep `n`, `__best` and `__t0` in stack slots — every one
+of them is live across the driver's `performance.now()` calls, and xmm
+registers are caller-saved. The inner loop's back edge picked up three
+`movdqu` reloads it never had as its own function:
+
+```
+0x1ef: vxorpd %xmm0,%xmm0,%xmm0 ; vcvtsi2sdl %eax,%xmm0,%xmm0
+       movdqu (%rsp),%xmm1                 ; n, reloaded per iteration
+       vucomisd %xmm0,%xmm1 ; ja 0x2ed
+0x2ed: movdqu 0x10(%rsp),%xmm0             ; __best, not even read here
+       movdqu 0x20(%rsp),%xmm1             ; __t0,   not even read here
+       addl $1,%eax ; leal (%rcx,%r12),%edx ; movq %rcx,%r12 ; movq %rdx,%rcx
+       jmp 0x1ef
+```
+
+20,000,000 iterations of that is the whole 12.4 ms.
+
+### Fix — rule 5 in `src/codegen/ir-inline.ts`
+
+A callee that contains a `loop` is not a loop-leaf. The loop-leaf trade buys the
+call sequence at a hot site; it needs the callee's per-call cost to be
+comparable to the call, and a callee with its own loop covers its whole trip
+count per call, so the overhead removed is a vanishing fraction of it — while
+the register pressure it adds to the caller's inner loop is not. This is the
+same line Binaryen draws with "lightweight (no loops or function calls)",
+reached from the cost side rather than the safety side.
+
+The near-miss gets its own decline bucket, `loop-in-callee`, rather than
+disappearing into `no-rule`: it is the one decline whose cause is a cost-model
+judgement, and a future retune needs to see what rule 5 costs.
+
+### Verification
+
+- Both warm modules are now **byte-identical to the pre-flip build**
+  (`JS2WASM_IR_INLINE=0`) at the landing lane's own options
+  (`target: wasi, nativeStrings, optimize: 3`): fib 449 B, array-sum 475 B.
+  So the CI lane returns to 12,442 / 926 µs by construction, not by prediction.
+- Local wasmtime 46.0.1 (the pinned version, `benchmarks/wasmtime-cold-host`),
+  min of 5, pinned core: array-sum warm 1.79 → 1.49 ms.
+  **`fib` ranks the OTHER WAY on this container** (24.2 ms inlined vs 30.4 ms
+  not) — the spill cost is µarch-dependent, and this box is not the CI runner.
+  That is why the regression test pins the inline DECISION, not a wall clock.
+- Acorn standalone, `report` mode: 348 of 8,292 candidate sites become
+  `loop-in-callee` (4.2 %); `adapter=3820`, `loop-leaf=2297`,
+  `specialised=1174`, `single-caller=653` are all retained. The −12.0 % wall of
+  entry (34) rests on the adapter/helper mass, which rule 5 does not touch.
+- `tests/issue-4157-ir-inline.test.ts` 21/21; new
+  `tests/issue-4157-ir-inline-loop-callee.test.ts` pins both directions —
+  the fib shape unchanged by the loop rule, a loop-FREE two-site leaf still
+  inlined by it (isolated against `adapters,single,specialise`, so the other
+  three rules cannot mask the result).
+- LOC budget, function budget, stack-balance fixup gate: OK.
+
+### The gap this leaves
+
+Nothing in CI would have caught this, and nothing does now: the landing
+benchmark artifact is refreshed on merge to `main` and read by humans. A
+per-program regression gate on `wasm-host-wasmtime-hot-runtime.json` — comparing
+within a runner class, keyed on the JS lane as the machine fingerprint — is the
+missing check. Filed as a follow-up rather than bundled here.

--- a/src/codegen/ir-inline.ts
+++ b/src/codegen/ir-inline.ts
@@ -47,6 +47,29 @@
  *    a caller is judged too fat to inline on the strength of code that never
  *    runs.
  *
+ * 5. **A callee that CONTAINS a loop is not a loop-leaf.** Rule 1 estimates how
+ *    often a SITE runs; the loop-leaf rule then trades code growth for the call
+ *    sequence that site pays. That trade needs the callee's per-call cost to be
+ *    comparable to the call itself — true of a small straight-line leaf, false
+ *    the moment the callee carries a loop of its own, because then one call
+ *    covers the whole trip count and the overhead removed is a vanishing
+ *    fraction of it. What is NOT vanishing is the cost of moving that loop into
+ *    the caller: every value the CALLER holds live across a call of its own
+ *    lives in a stack slot (f64/v128 registers are caller-saved), and the
+ *    inlined loop then re-loads them on the back edge, per iteration, forever.
+ *    This is the same line Binaryen draws with "lightweight (no loops or
+ *    function calls)", reached from the cost side rather than the safety side.
+ *
+ *    Measured on the landing WASI host lane: its `fib` program is `export function
+ *    run(n)`, one `for` loop, ~30 instructions and a leaf — so it passed every
+ *    other loop-leaf test and was inlined into the benchmark's `warm` driver at
+ *    both of its sites. Cranelift then spilled `n`, `__best` and `__t0` (all
+ *    live across the driver's `performance.now()` calls) and reloaded three
+ *    xmm words inside the 20M-iteration inner loop: 12.44 ms -> 24.89 ms, a
+ *    lane that read 1.50x V8 turned into 0.76x. `array-sum` lost 34 % the same
+ *    way; `fib-recursive` (self-recursive, already declined) and `string-hash`
+ *    (not a leaf) were untouched, which is what identified the rule.
+ *
  * ## Correctness — what is proven and what is declined
  *
  * Inlining at the wasm level rewrites three things, and a wrong answer on any
@@ -156,7 +179,7 @@ export interface InlineOptions {
   adapters: boolean;
   /** Single-direct-caller user functions. */
   single: boolean;
-  /** Small leaf callees whose site sits inside a loop. */
+  /** Small loop-free leaf callees whose site sits inside a loop (rules 1 + 5). */
   loop: boolean;
   /** Rule 2 — accept whenever the SPECIALISED size is <= the call site's cost. */
   specialise: boolean;
@@ -409,6 +432,7 @@ export type DeclineReason =
   | "import"
   | "budget"
   | "growth-cap"
+  | "loop-in-callee"
   | "no-rule";
 
 function calleeIsSafe(fn: WasmFunction, results: ValType[]): DeclineReason | null {
@@ -701,6 +725,8 @@ interface CalleeFacts {
   rawSize: number;
   effSize: number;
   isLeaf: boolean;
+  /** Rule 5 — the callee's own body contains a `loop`. See `hasLoop`. */
+  loops: boolean;
 }
 
 /**
@@ -898,6 +924,7 @@ export function inlineUserFunctions(ctx: CodegenContext): void {
             rawSize: countInstrs(calleeBody),
             effSize: effectiveSize(calleeBody),
             isLeaf: !hasCall(calleeBody),
+            loops: hasLoop(calleeBody),
           };
           calleeFacts.set(cp, facts);
         }
@@ -939,10 +966,19 @@ export function inlineUserFunctions(ctx: CodegenContext): void {
         else if (opts.specialise && specSize <= siteCost) rule = "specialised";
         else if (opts.single && callerCount[cp] === 1 && !addressTaken[cp] && effSize <= opts.singleMax)
           rule = "single-caller";
-        else if (opts.loop && weight >= LOOP_WEIGHT && isLeaf && effSize <= loopBudget) rule = "loop-leaf";
+        else if (opts.loop && weight >= LOOP_WEIGHT && isLeaf && !facts.loops && effSize <= loopBudget)
+          rule = "loop-leaf";
 
         if (!rule) {
-          declined(callee.name, "no-rule");
+          // Report the loop-leaf near-miss under its own name: "no-rule" would
+          // hide the one decline whose CAUSE is a cost-model judgement rather
+          // than a missing rule, and this bucket is how a future retune finds
+          // out what rule 5 is actually costing.
+          const nearMiss =
+            opts.loop && weight >= LOOP_WEIGHT && isLeaf && facts.loops && effSize <= loopBudget
+              ? "loop-in-callee"
+              : "no-rule";
+          declined(callee.name, nearMiss);
           continue;
         }
         if (growth + rawSize > opts.growth) {
@@ -1021,6 +1057,18 @@ function hasCall(body: Instr[]): boolean {
   let found = false;
   forEachInstr(body, (i) => {
     if (i.op === "call" || i.op === "call_ref" || i.op === "call_indirect") found = true;
+  });
+  return found;
+}
+
+/**
+ * Rule 5 — does the callee's own body contain a `loop`? See the module header
+ * for why a loop-carrying callee is excluded from the loop-leaf rule.
+ */
+function hasLoop(body: Instr[]): boolean {
+  let found = false;
+  forEachInstr(body, (i) => {
+    if (i.op === "loop") found = true;
   });
   return found;
 }

--- a/tests/issue-4157-ir-inline-loop-callee.test.ts
+++ b/tests/issue-4157-ir-inline-loop-callee.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4157, rule 5) The loop-leaf rule must NOT inline a callee that carries a loop of
+ * its own — rule 5 in `src/codegen/ir-inline.ts`.
+ *
+ * The shape below is the landing-page WASI `fib` benchmark reduced to its
+ * essentials: an exported kernel that is a leaf, small, and one `for` loop,
+ * called from inside a driver's own loop. Every other loop-leaf precondition
+ * holds, so before rule 5 the kernel was inlined into the driver at each site.
+ * Cranelift then had to keep the driver's live f64 state in stack slots
+ * (caller-saved across the driver's calls) and reloaded them inside the
+ * kernel's 20M-iteration inner loop: the lane went 1.50x V8 -> 0.76x.
+ *
+ * Pinned structurally, by the `call` surviving in the driver, rather than by a
+ * timing: a wall-clock assertion for a register-allocation effect is not
+ * reproducible across the machines CI runs on (the same two binaries rank in
+ * opposite orders on some hosts), whereas "the kernel is still a call" is
+ * exactly the property rule 5 is there to keep.
+ */
+import { describe, expect, test } from "vitest";
+import { compile } from "../src/index.js";
+import { parseInlineOptions } from "../src/codegen/ir-inline.js";
+
+const FLAG = "JS2WASM_IR_INLINE";
+
+/** The landing `fib` kernel plus a driver that calls it from its own loop. */
+const SOURCE = `
+export function run(n: number): number {
+  let a = 0;
+  let b = 1;
+  for (let i = 0; i < n; i++) {
+    const next = (a + b) | 0;
+    a = b;
+    b = next;
+  }
+  return a | 0;
+}
+
+export function drive(n: number): number {
+  let sink = 0;
+  for (let m = 0; m < 3; m++) {
+    sink = (sink + run(n)) | 0;
+  }
+  return sink | 0;
+}
+`;
+
+/**
+ * The control: the same driver, but the kernel is loop-FREE. Two call sites so
+ * the single-caller rule cannot claim it — the loop-leaf rule is then the only
+ * one that can reach the site, which is what makes the pair a clean isolation.
+ */
+const LEAF_SOURCE = `
+function kernel(a: number, b: number): number { return a * 3 + b - 1; }
+
+export function drive(n: number): number {
+  let acc = 0;
+  for (let i = 0; i < n; i++) acc = kernel(acc, i) + kernel(i, acc);
+  return acc;
+}
+`;
+
+async function build(source: string): Promise<Uint8Array> {
+  const r = await compile(source, {
+    fileName: "loop-callee-probe.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    optimize: 0,
+  });
+  if (!r.binary?.length) throw new Error(`compile failed: ${JSON.stringify((r.errors ?? []).slice(0, 2))}`);
+  return r.binary;
+}
+
+async function instantiate(source: string): Promise<WebAssembly.Exports> {
+  const binary = await build(source);
+  const { exports } = await WebAssembly.instantiate(await WebAssembly.compile(binary), {});
+  return exports;
+}
+
+describe("#4157 rule 5 — a loop-carrying callee is not a loop-leaf", () => {
+  // Isolating the loop-leaf rule: the same rule set MINUS `loop`. Whatever the
+  // other three rules do lands in both builds, so a difference between them is
+  // the loop-leaf rule and nothing else. (Byte-identity against `=0` would not
+  // work here — this probe compiles at `optimize: 0`, where the module's helper
+  // inlines survive instead of being normalised away by `wasm-opt`.)
+  const WITHOUT_LOOP_RULE = "adapters,single,specialise";
+
+  test("the shipped default leaves `run` a call inside the driver's loop", async () => {
+    delete process.env[FLAG];
+    const shipped = await build(SOURCE);
+    process.env[FLAG] = WITHOUT_LOOP_RULE;
+    const withoutLoopRule = await build(SOURCE);
+    delete process.env[FLAG];
+    expect(
+      Buffer.from(shipped).equals(Buffer.from(withoutLoopRule)),
+      "the loop-leaf rule must find nothing to do in a driver whose only leaf carries a loop",
+    ).toBe(true);
+  });
+
+  test("a loop-FREE leaf at a hot site is still inlined", async () => {
+    delete process.env[FLAG];
+    const shipped = await build(LEAF_SOURCE);
+    process.env[FLAG] = WITHOUT_LOOP_RULE;
+    const withoutLoopRule = await build(LEAF_SOURCE);
+    delete process.env[FLAG];
+    expect(
+      Buffer.from(shipped).equals(Buffer.from(withoutLoopRule)),
+      "rule 5 must narrow the loop-leaf rule, not retire it",
+    ).toBe(false);
+  });
+
+  test("`loop` is still one of the rules the `on` preset selects", () => {
+    expect(parseInlineOptions(undefined).loop).toBe(true);
+    expect(parseInlineOptions("on").loop).toBe(true);
+    expect(parseInlineOptions("0").loop).toBe(false);
+  });
+
+  test("both shapes still compute the right answer at the default", async () => {
+    delete process.env[FLAG];
+    const exports = await instantiate(SOURCE);
+    // fib(30) = 832040, summed over three driver iterations.
+    expect((exports.run as (n: number) => number)(30)).toBe(832_040);
+    expect((exports.drive as (n: number) => number)(30)).toBe(2_496_120);
+
+    const leaf = await instantiate(LEAF_SOURCE);
+    process.env[FLAG] = "0";
+    const leafOff = await instantiate(LEAF_SOURCE);
+    delete process.env[FLAG];
+    expect((leaf.drive as (n: number) => number)(64)).toBe((leafOff.drive as (n: number) => number)(64));
+  });
+});


### PR DESCRIPTION
## Description

The landing page's WASI-host **Fibonacci loop** warm lane regressed from **1.50x V8 to 0.76x**. Root cause: the tuned-set flip (#4157 entry 37) turned the IR inliner on by default, and its `loop-leaf` rule inlined the benchmark's `fib` kernel into the timing driver.

`run` passed every test the rule applies — it is a leaf, ~30 instructions, and its call site sits inside the driver's measurement loop. What the rule never asked is whether the **callee** has a loop of its own.

### Isolating it from machine noise

`wasm-host-wasmtime-hot-runtime.json` is refreshed on two runner classes, which the JS lane identifies unambiguously (class B reads `js ≈ 18.68 ms`). Holding the class fixed:

| refresh (class B)  | fib warm | fib-recursive | array-sum | string-hash |
| ------------------ | -------- | ------------- | --------- | ----------- |
| 8695ae8 / d9cef66  | 12,442   | 7,565         | 926       | 238         |
| f2c52ab .. 412cda7 | 24,888   | 7,565         | 1,243     | 238         |

`fib` exactly 2.0x, `array-sum` 1.34x, the other two untouched, and the JS lane moved 18,683 → 18,682 µs across the same boundary. The two survivors are what named the rule: `fib-recursive` is self-recursive (already declined) and `string-hash` is not a leaf. Both regressing programs are a small exported leaf that is one `for` loop. The `fib` **cold** lane did not move — its module is byte-identical (104 B) on both sides; only the warm module, which appends the timing driver, changed.

### Why inlining cost 2x

`n`, `__best` and `__t0` are all live across the driver's `performance.now()` calls, and xmm registers are caller-saved, so Cranelift had nowhere to keep them. The inner loop's back edge picked up three per-iteration reloads it never had as its own function:

```
0x1ef: vxorpd %xmm0,%xmm0,%xmm0 ; vcvtsi2sdl %eax,%xmm0,%xmm0
       movdqu (%rsp),%xmm1                 ; n, reloaded per iteration
       vucomisd %xmm0,%xmm1 ; ja 0x2ed
0x2ed: movdqu 0x10(%rsp),%xmm0             ; __best, not even read here
       movdqu 0x20(%rsp),%xmm1             ; __t0,   not even read here
       addl $1,%eax ; leal (%rcx,%r12),%edx ; movq %rcx,%r12 ; movq %rdx,%rcx
       jmp 0x1ef
```

20,000,000 iterations of that is the whole 12.4 ms.

### The fix — rule 5

A callee that contains a `loop` is not a loop-leaf. The loop-leaf trade buys the call sequence at a hot site, so it needs the callee's per-call cost to be comparable to the call itself; a callee carrying its own loop covers the whole trip count per call, so the overhead removed is a vanishing fraction of it — while the register pressure it adds to the caller's inner loop is not. Binaryen draws the same line with "lightweight (no loops or function calls)"; this reaches it from the cost side rather than the safety side.

The near-miss gets its own decline bucket, `loop-in-callee`, rather than disappearing into `no-rule` — it is the only decline whose cause is a cost-model judgement, and a future retune has to be able to price it.

**Scope note — rule 5 gates `loop-leaf` only, NOT the `hot` rule** that landed in entry (48) while this was in flight. `hot` is the same frequency-rule shape and would readmit exactly this callee (the `fib` kernel clears `hotMax` comfortably), but it is flag-gated OFF and still being measured; narrowing another lane's in-flight experiment inside a merge resolution would invalidate its numbers. Called out in the module header so whoever flips it on owns that decision.

### Verification

- Both warm modules are now **byte-identical to the pre-flip (`JS2WASM_IR_INLINE=0`) build** at the lane's own options (`target: wasi`, `nativeStrings`, `optimize: 3`): fib 449 B, array-sum 475 B. Re-checked after merging `main`. The CI numbers return by construction, not by prediction.
- **Acorn standalone** (`report` mode): 348 of 8,292 candidate sites become `loop-in-callee` (4.2 %). `adapter=3820`, `loop-leaf=2297`, `specialised=1174`, `single-caller=653` are all retained — entry (34)'s −12.0 % wall rests on that mass, which rule 5 does not touch.
- Local wasmtime 46.0.1 (the pinned version), min of 5, pinned core: `array-sum` warm 1.79 → 1.49 ms. **`fib` ranks the other way on this container** (24.2 ms inlined vs 30.4 ms not) — the spill cost is microarchitectural and this box is not the CI runner. That is exactly why the new test pins the inline **decision**, not a wall clock.
- `tests/issue-4157-ir-inline.test.ts` 21/21. New `tests/issue-4157-ir-inline-loop-callee.test.ts` pins both directions, isolating the loop rule against `adapters,single,specialise` so the other three rules cannot mask the result.
- **Whole `tests/equivalence` suite run locally in chunks** (the container OOMs on a single pass): 24 failures across 10 files, **every one reproduced identically on the pre-change compiler** by file-copy A/B — `arguments-nested-and-loops`, `array-inline-return`, `delete-sentinel`, `logical-conditional-identity` (3), `misc-small-patterns`, `new-non-constructor` (2), `null-dereference-guards` (5), `optional-direct-closure-call` (2), `reflect-api`, `tdz-reference-error` (6), `yield-as-expression`. Pre-existing on `main`, none from this change. `multi-file-compilation` OOMs in this container on both sides. CI's sharded `equivalence-gate` remains the authority.
- Typecheck, LOC budget, function budget, oracle-ratchet and stack-balance fixup gates: OK. The merge pushed `inlineUserFunctions` over the 300-LOC gate, so the loop-leaf preconditions are hoisted into one `loopLeafFits` boolean (the near-miss test was re-stating them anyway) rather than taking an allowance.

### Follow-up not in this PR

Nothing in CI would have caught this. The landing benchmark artifact is refreshed on merge to `main` and read by humans only. A per-program regression gate on `wasm-host-wasmtime-hot-runtime.json` — comparing within a runner class, keyed on the JS lane as the machine fingerprint — is the missing check.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: agreeing to a legal document is the author's call, not the agent's. This is an org-member PR, so `cla-check` should skip automatically; if it does not, tick the box. -->