### PR TITLE
perf(#4431): early-error check-body costs — isStrictMode memoization, class private-name cache, hoisted per-visit sets (~2.5x detect)

### DIFF
--- a/plan/issues/4431-early-error-check-body-costs.md
+++ b/plan/issues/4431-early-error-check-body-costs.md
@@ -1,0 +1,83 @@
+---
+id: 4431
+title: "early-error check-body costs — isStrictMode memoization, class private-name cache, hoisted per-visit allocations"
+status: done
+completed: 2026-08-15
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: compiler
+goal: velocity
+loc-budget-allow:
+  - src/compiler/early-errors/predicates.ts
+  - src/compiler/early-errors/node-checks.ts
+---
+
+# #4431 — early-error check-body costs (the ~60% left by #4425)
+
+Follow-up to #4425 (PR #4525, merged): the kind-indexed dispatch removed the
+guard-chain overhead (~40% of detect CPU); this issue targets the fired check
+BODIES — the larger prize #4425 deliberately left out of scope.
+
+## Measurements (2026-08-15, quiet 4-core box, this session)
+
+Per-block instrumentation (each `on()` registration wrapped with a
+`performance.now()` accumulator; 1-in-9 corpus sample = 2,874 files,
+in-block total 1,668 ms):
+
+| share | block | cost driver |
+| ----- | ----- | ----------- |
+| 34.3% | PrivateIdentifier enclosing-class check | `isInsideClassWithPrivateName`: re-scans EVERY member of EVERY enclosing class per private-name reference |
+| 14.2% | strict reserved words (every Identifier) | `isStrictMode` ancestor re-walk + `new Set([...7 strings])` allocated per identifier |
+| 10.1% | `checkTDZInStatements` (SourceFile/Block/Case/Default) | not addressed here — see open follow-ups |
+|  6.7% | `checkVarLexicalConflicts` (Block/SourceFile) | not addressed here — see open follow-ups |
+|  ~9%  | other `isStrictMode` consumers (eval/arguments, octal literals, legacy escapes) + static-block walks | ancestor re-walks |
+
+`isStrictMode` is queried by 4 hot blocks (every Identifier ×2, every
+String/NumericLiteral in strict scans) plus `duplicates.ts` / `module-rules.ts`
+— each call re-walked the full ancestor chain re-scanning directive prologues.
+
+## Fix (this change-set)
+
+1. **`isStrictMode` memoized** (`predicates.ts`): strictness is a pure
+   function of the ancestor chain, so cache per node in a `WeakMap` — walk up
+   only to the first cached ancestor or terminal (SourceFile / class /
+   function with `"use strict"`), then backfill the visited chain. O(1)
+   amortized; semantics preserved exactly (module ≠ strict rule untouched).
+2. **Class private-name cache** (`predicates.ts`): `WeakMap<ClassLike,
+   ReadonlySet<string>>` built once per class; `isInsideClassWithPrivateName`
+   consults the set instead of re-scanning members per reference. Heritage-
+   clause exclusion (§15.7.14 outer-PrivateEnvironment rule) unchanged.
+3. **Hoisted per-visit allocations** (`node-checks.ts`):
+   `COMPOUND_ASSIGNMENT_OPS`, `STRICT_RESERVED_WORDS`,
+   `STRICT_RESERVED_ASSIGN_TARGETS` moved to module consts (were rebuilt per
+   matching node — the reserved-word Set on every identifier in strict code).
+
+## Validation
+
+- Differential (same harness as #4425, corpus 25,862 files = test262
+  `language`+`annexB` + `src/**/*.ts`): unmodified HEAD vs optimized —
+  23,983 diagnostics each, 0 exceptions, **byte-identical JSONL**.
+- Detect CPU A/B (1-in-3 sample = 8,621 files, parse-once/time-detect-only,
+  3 iters × 2 interleaved rounds): HEAD ~6.0–6.6 s CPU steady-state →
+  optimized ~2.4–2.9 s — **~2.5× faster**. Combined with #4425:
+  detectEarlyErrors ~11.9 s → ~2.5 s on this box (**~4.7× total**).
+- Early-error suites (issue-4417 / 1931 / 2929 / 3632): 65/67 — the 2
+  issue-3632 failures are the standalone `js2wasm:runtime-eval` wasm-import
+  environment issue, reproduced identically on unmodified base (pre-existing).
+- `pnpm run typecheck` (TS7) clean.
+
+## Open follow-ups (measured, not addressed here)
+
+- `checkTDZInStatements` 10.1% + `checkVarLexicalConflicts` 6.7% +
+  `checkDuplicateLexicalDeclarations` 3.0%: each re-collects binding names
+  over the same statement lists per scope node. A per-scope collected-names
+  cache is the next lever; needs care because these mutate ctx error state.
+- `isInsideClassStaticBlock` / `isInsideAsyncFunction` /
+  `isInsideGeneratorFunction` ancestor walks (~3.4% combined across the
+  await/yield identifier blocks) — same WeakMap pattern would apply.

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -101,6 +101,49 @@ function on(kinds: readonly ts.SyntaxKind[], check: NodeCheck): void {
   for (const kind of kinds) (NODE_CHECKS[kind] ??= []).push(check);
 }
 
+// Hoisted per-visit constants (#4431): these were allocated inside check
+// bodies on every matching node — the strict-reserved sets on EVERY
+// identifier in strict code — and showed up in the fired-check-body profile.
+const COMPOUND_ASSIGNMENT_OPS = [
+  ts.SyntaxKind.PlusEqualsToken,
+  ts.SyntaxKind.MinusEqualsToken,
+  ts.SyntaxKind.AsteriskEqualsToken,
+  ts.SyntaxKind.SlashEqualsToken,
+  ts.SyntaxKind.PercentEqualsToken,
+  ts.SyntaxKind.AmpersandEqualsToken,
+  ts.SyntaxKind.BarEqualsToken,
+  ts.SyntaxKind.CaretEqualsToken,
+  ts.SyntaxKind.LessThanLessThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.AsteriskAsteriskEqualsToken,
+  ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+  ts.SyntaxKind.BarBarEqualsToken,
+  ts.SyntaxKind.QuestionQuestionEqualsToken,
+];
+
+const STRICT_RESERVED_WORDS = new Set([
+  "implements",
+  "interface",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "static",
+]);
+
+const STRICT_RESERVED_ASSIGN_TARGETS = new Set([
+  "implements",
+  "interface",
+  "let",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "static",
+  "yield",
+]);
+
 /**
  * Run all per-node early-error checks rooted at `node`, recursing into its
  * descendants. Equivalent to the original detectEarlyErrors `visit` closure.
@@ -201,24 +244,7 @@ on([ts.SyntaxKind.BinaryExpression], (ctx, node) => {
 on([ts.SyntaxKind.BinaryExpression], (ctx, node) => {
   if (ts.isBinaryExpression(node)) {
     const op = node.operatorToken.kind;
-    const compoundOps = [
-      ts.SyntaxKind.PlusEqualsToken,
-      ts.SyntaxKind.MinusEqualsToken,
-      ts.SyntaxKind.AsteriskEqualsToken,
-      ts.SyntaxKind.SlashEqualsToken,
-      ts.SyntaxKind.PercentEqualsToken,
-      ts.SyntaxKind.AmpersandEqualsToken,
-      ts.SyntaxKind.BarEqualsToken,
-      ts.SyntaxKind.CaretEqualsToken,
-      ts.SyntaxKind.LessThanLessThanEqualsToken,
-      ts.SyntaxKind.GreaterThanGreaterThanEqualsToken,
-      ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
-      ts.SyntaxKind.AsteriskAsteriskEqualsToken,
-      ts.SyntaxKind.AmpersandAmpersandEqualsToken,
-      ts.SyntaxKind.BarBarEqualsToken,
-      ts.SyntaxKind.QuestionQuestionEqualsToken,
-    ];
-    if (compoundOps.includes(op)) {
+    if (COMPOUND_ASSIGNMENT_OPS.includes(op)) {
       const isLogicalAssignment =
         op === ts.SyntaxKind.AmpersandAmpersandEqualsToken ||
         op === ts.SyntaxKind.BarBarEqualsToken ||
@@ -832,8 +858,7 @@ on([ts.SyntaxKind.Identifier], (ctx, node) => {
 // public, static, yield are reserved in strict mode.
 on([ts.SyntaxKind.Identifier], (ctx, node) => {
   if (ts.isIdentifier(node) && isStrictMode(node)) {
-    const strictReserved = new Set(["implements", "interface", "package", "private", "protected", "public", "static"]);
-    if (strictReserved.has(node.text)) {
+    if (STRICT_RESERVED_WORDS.has(node.text)) {
       // Skip property names — they're fine in strict mode
       const parent = node.parent;
       const isPropertyName =
@@ -1285,18 +1310,7 @@ on([ts.SyntaxKind.BinaryExpression], (ctx, node) => {
     let lhs: ts.Node = node.left;
     while (ts.isParenthesizedExpression(lhs)) lhs = lhs.expression;
     if (ts.isIdentifier(lhs)) {
-      const strictReservedAssign = new Set([
-        "implements",
-        "interface",
-        "let",
-        "package",
-        "private",
-        "protected",
-        "public",
-        "static",
-        "yield",
-      ]);
-      if (strictReservedAssign.has(lhs.text)) {
+      if (STRICT_RESERVED_ASSIGN_TARGETS.has(lhs.text)) {
         ctx.addError(lhs, `Assignment to reserved word '${lhs.text}' in strict mode`);
       }
     }

--- a/src/compiler/early-errors/predicates.ts
+++ b/src/compiler/early-errors/predicates.ts
@@ -28,46 +28,64 @@ export function findInnermostNodeAtPosition(node: ts.Node, position: number): ts
  * sloppy-mode scripts, so we deliberately do not treat module = strict (see the
  * SourceFile branch below, which returns false).
  */
+// Strictness of a node is a pure function of its ancestor chain, and the
+// per-node walk was ~20% of detectEarlyErrors CPU (#4431) — four checks call
+// this on every Identifier/literal. Memoize per node: walk up only until a
+// cached ancestor or a terminal (SourceFile/class/strict function), then
+// backfill the whole visited chain, so repeated queries are O(1) amortized.
+const strictModeCache = new WeakMap<ts.Node, boolean>();
+
+/** Leading "use strict" directive scan (directives must be at the top). */
+function hasUseStrictDirective(stmts: readonly ts.Statement[]): boolean {
+  for (const stmt of stmts) {
+    if (ts.isExpressionStatement(stmt) && ts.isStringLiteral(stmt.expression)) {
+      if (stmt.expression.text === "use strict") return true;
+    } else {
+      break; // Directives must be at the top
+    }
+  }
+  return false;
+}
+
 export function isStrictMode(node: ts.Node): boolean {
   // Check for "use strict" directives and class context
+  const chain: ts.Node[] = [];
+  let result: boolean | undefined;
   let current: ts.Node | undefined = node;
   while (current) {
+    const cached = strictModeCache.get(current);
+    if (cached !== undefined) {
+      result = cached;
+      break;
+    }
+    chain.push(current);
     if (ts.isSourceFile(current)) {
-      // Check for "use strict" directive at file level
-      for (const stmt of current.statements) {
-        if (ts.isExpressionStatement(stmt) && ts.isStringLiteral(stmt.expression)) {
-          if (stmt.expression.text === "use strict") return true;
-        } else {
-          break; // Directives must be at the top
-        }
-      }
       // Don't assume module = strict. We add export {} synthetically for TS,
       // but the source may be a sloppy-mode script (test262 noStrict tests).
-      return false;
+      result = hasUseStrictDirective(current.statements);
+      break;
     }
     if (ts.isClassDeclaration(current) || ts.isClassExpression(current)) {
-      return true;
+      result = true;
+      break;
     }
     if (
-      ts.isFunctionDeclaration(current) ||
-      ts.isFunctionExpression(current) ||
-      ts.isArrowFunction(current) ||
-      ts.isMethodDeclaration(current)
+      (ts.isFunctionDeclaration(current) ||
+        ts.isFunctionExpression(current) ||
+        ts.isArrowFunction(current) ||
+        ts.isMethodDeclaration(current)) &&
+      current.body &&
+      ts.isBlock(current.body) &&
+      hasUseStrictDirective(current.body.statements)
     ) {
-      // Check for "use strict" directive in function body
-      if (current.body && ts.isBlock(current.body)) {
-        for (const stmt of current.body.statements) {
-          if (ts.isExpressionStatement(stmt) && ts.isStringLiteral(stmt.expression)) {
-            if (stmt.expression.text === "use strict") return true;
-          } else {
-            break; // Directives must be at the top
-          }
-        }
-      }
+      result = true;
+      break;
     }
     current = current.parent;
   }
-  return false;
+  const final = result ?? false;
+  for (const n of chain) strictModeCache.set(n, final);
+  return final;
 }
 
 export function isArgumentsOrEval(node: ts.Node): string | null {
@@ -734,6 +752,27 @@ export function hasAsyncModifier(node: ts.FunctionDeclaration): boolean {
 }
 
 /** Check if a private identifier is inside a class that declares it. */
+// The per-reference member scan was the single hottest early-error cost
+// (~34% of in-block CPU, #4431): every PrivateIdentifier re-walked every
+// member of every enclosing class. The declared private names of a class are
+// immutable per AST, so compute them once per class and cache.
+const classPrivateNamesCache = new WeakMap<ts.ClassLikeDeclaration, ReadonlySet<string>>();
+
+function privateNamesOf(cls: ts.ClassLikeDeclaration): ReadonlySet<string> {
+  let names = classPrivateNamesCache.get(cls);
+  if (names === undefined) {
+    const set = new Set<string>();
+    for (const member of cls.members) {
+      if (member.name && ts.isPrivateIdentifier(member.name)) {
+        set.add(member.name.escapedText as string);
+      }
+    }
+    names = set;
+    classPrivateNamesCache.set(cls, names);
+  }
+  return names;
+}
+
 export function isInsideClassWithPrivateName(node: ts.Node, privateName: string): boolean {
   let current: ts.Node | undefined = node.parent;
   while (current) {
@@ -748,12 +787,8 @@ export function isInsideClassWithPrivateName(node: ts.Node, privateName: string)
       const inHeritage = current.heritageClauses?.some((hc) => isNodeWithin(node, hc)) ?? false;
       if (!inHeritage) {
         // Check if this class declares the private name
-        for (const member of current.members) {
-          if (member.name && ts.isPrivateIdentifier(member.name)) {
-            if ((member.name.escapedText as string) === privateName) {
-              return true;
-            }
-          }
+        if (privateNamesOf(current).has(privateName)) {
+          return true;
         }
       }
       // Also check parent classes (super), but we can't easily resolve inheritance


### PR DESCRIPTION
## Description

The fired-check-body ~60 % that #4425 (PR #4525, merged) deliberately left out of scope, now measured and fixed (issue #4431, filed in this PR).

**Measurement first**: each `on()` registration was wrapped with a `performance.now()` accumulator over the corpus (1-in-9 sample). Ranking: private-name enclosing-class check **34.3 %** (re-scans every member of every enclosing class per `#name` reference), strict-reserved identifier check **14.2 %** (`isStrictMode` ancestor re-walk + a `new Set([...])` allocated per identifier), other `isStrictMode` consumers ~9 %, TDZ/var-lexical scope collectors ~17 % (left as measured follow-ups in the issue).

**Fixes** (all semantics-preserving):

1. `isStrictMode` memoized per node in a `WeakMap` — walk up only to the first cached ancestor or terminal (SourceFile / class / `"use strict"` function), backfill the visited chain; O(1) amortized. The deliberate module ≠ strict rule is untouched.
2. `isInsideClassWithPrivateName` consults a per-class `WeakMap<ClassLike, ReadonlySet<string>>` of declared private names instead of re-scanning members per reference; the §15.7.14 heritage-clause exclusion is unchanged.
3. `COMPOUND_ASSIGNMENT_OPS`, `STRICT_RESERVED_WORDS`, `STRICT_RESERVED_ASSIGN_TARGETS` hoisted to module consts.

## Validation

- **Differential** (same ship gate as #4425): unmodified HEAD vs optimized over 25,862 files (test262 `language`+`annexB` + `src/**/*.ts`) — 23,983 diagnostics each, 0 exceptions, **byte-identical JSONL**.
- **Detect CPU A/B** (1-in-3 sample = 8,621 files, parse once, time detect only, interleaved rounds): HEAD ~6.0–6.6 s CPU steady-state → **~2.4–2.9 s (~2.5× faster)**. Combined with #4425: `detectEarlyErrors` ~11.9 s → ~2.5 s on the same box (**~4.7× total**).
- **Early-error suites** (issue-4417 / 1931 / 2929 / 3632): 65/67 — the 2 issue-3632 failures are the standalone `js2wasm:runtime-eval` wasm-import environment issue, reproduced identically on unmodified base.
- `pnpm run typecheck` (TS7) clean. LOC growth granted by the issue file's `loc-budget-allow`.

Issue #4431 status → done in this PR (self-merge path); its "Open follow-ups" section records the measured remaining levers (TDZ/var-lexical collectors, static-block/async/generator ancestor walks).

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm)_