### PR TITLE
perf(#4432): early-error scope-collector costs — TDZ single traversal, var-scope-root index, predicate memoization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,12 @@ rejection breakdown.
 
 ## Team & Workflow
 
+**Plan/implement split (project-lead order, 2026-08-15): every issue gets an
+`## Implementation Plan` written by the Fable lane before implementation, and
+the implementation itself is done by an Opus subagent working from that plan.**
+Fable writes plans (measurements, exact functions/files, order-preservation
+constraints, acceptance criteria); Opus implements and validates against them.
+
 See [plan/method/team-setup.md](plan/method/team-setup.md) for full team config, roles, memory budget, communication protocol, and merge lessons. Agent preferences and rules are in `.claude/memory/` (MEMORY.md index).
 
 **Checklists** (read at the right moment, not at spawn time):

--- a/plan/issues/4432-early-error-scope-collector-costs.md
+++ b/plan/issues/4432-early-error-scope-collector-costs.md
@@ -1,0 +1,262 @@
+---
+id: 4432
+title: "early-error scope-collector costs — TDZ per-name re-traversal, var/lexical conflict re-walks, ancestor-walk predicate memoization"
+status: done
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+completed: 2026-08-15
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: compiler
+goal: velocity
+loc-budget-allow:
+  - src/compiler/early-errors/tdz.ts
+  - src/compiler/early-errors/duplicates.ts
+  - src/compiler/early-errors/predicates.ts
+---
+
+# #4432 — early-error scope-collector costs (the tail left by #4431)
+
+Follow-up to #4425 (dispatch, merged PR #4525) and #4431 (check-body top-2,
+PR #4529). Per-block instrumentation on 2026-08-15 (pre-#4431 shares of
+in-block time; these grow proportionally once #4431's top-2 shrink):
+
+- `checkTDZInStatements` (SourceFile/Block/CaseClause/DefaultClause): **10.1%**
+- `checkVarLexicalConflicts` (Block/SourceFile): **6.7%**
+- `checkDuplicateLexicalDeclarations` (Block/SourceFile): **3.0%**
+- `isInsideClassStaticBlock` / `isInsideAsyncFunction` /
+  `isInsideGeneratorFunction` ancestor walks (await/yield identifier blocks):
+  **~3.4%** combined
+
+## Hard constraint (same ship gate as #4425/#4431)
+
+**Byte-identical differential.** `.tmp/ee-diff.mts` in the worktree
+`/home/user/js2wasm/.claude/worktrees/compiler-speedup` runs
+`detectEarlyErrors` over test262 `language`+`annexB` + `src/**/*.ts`
+(25,862 files, 23,983 diagnostics, 0 exceptions) and dumps one JSONL row per
+diagnostic in deterministic order. Baseline vs optimized must `cmp` equal.
+Every optimization below is designed to preserve **error text, node,
+count (one row per reference occurrence), and emission order** — read the
+order notes carefully; they are where naive rewrites break.
+
+## Implementation Plan (Fable, 2026-08-15)
+
+### 1. `checkTDZInStatements` — one traversal per statement, not one per pending name
+
+`src/compiler/early-errors/tdz.ts:18`. Current shape: for each
+non-declaration statement, the loop `for (const [name] of letConstDecls) {
+if (!declaredSoFar.has(name)) checkForTDZRef(ctx, stmt, name) }` re-traverses
+the statement subtree **once per pending name** — O(pending × subtree).
+
+Replace with one traversal per statement that collects matches for ALL
+pending names, then emits grouped by name:
+
+- Compute `pending = [...letConstDecls.keys()].filter(n => !declaredSoFar.has(n))`
+  (keep **Map insertion order** — it is the emission order).
+- Single visitor over the statement subtree, exact port of `checkForTDZRef`'s
+  logic generalized to a name set: at an Identifier whose text is in
+  `pending`, apply the two parent exclusions (PropertyAccessExpression name,
+  PropertyAssignment name) and record the node into
+  `matches: Map<string, ts.Node[]>` (encounter order per name); do NOT
+  recurse into Identifier children (there are none — the original returns
+  after the match check, same effect). Stop descent at the same five
+  boundaries (FunctionDeclaration/FunctionExpression/ArrowFunction/
+  ClassDeclaration/ClassExpression). Non-matching identifiers fall through
+  to recursion exactly as before.
+- Emit AFTER the traversal, iterating `pending` in order and each name's
+  recorded nodes in order, pushing the same
+  `Cannot access '${name}' before initialization` warning rows via
+  `ctx.pos(node)`.
+
+**Order rationale**: the original emits grouped by name (outer loop = map
+order) then by node encounter (inner traversal). A single-pass
+emit-at-the-identifier rewrite interleaves names in node order and BREAKS the
+differential whenever one statement references two pending names. The
+grouped-collect-then-emit shape above reproduces the original order exactly.
+
+The initializer self-reference arm (`checkForTDZRef(ctx, decl.initializer,
+varName)`) is single-name — either leave it calling the original
+`checkForTDZRef` (keep the function; other callers may exist — grep first)
+or route it through the generalized visitor with a one-element set.
+
+### 2. `checkVarLexicalConflicts` — per-var-scope-root var-declaration index
+
+`src/compiler/early-errors/duplicates.ts:364` +
+`collectVarDeclaredNamesInBlock`. Current shape: EVERY Block/SourceFile with
+≥1 lexical name re-walks its entire subtree (stopping at function/class
+boundaries) hunting `var` statements — nested blocks make this
+O(depth × nodes).
+
+Build, once per **var-scope root**, a DFS-ordered index of var-declared
+identifiers, then answer each block's query by position range:
+
+- Var-scope root of a Block = nearest ancestor that is a SourceFile, a
+  function-like body owner, or a ClassStaticBlockDeclaration (the roots at
+  which `var` hoisting stops — mirror `collectVarDeclaredNamesInBlock`'s
+  boundary list exactly: FunctionDeclaration, FunctionExpression,
+  ArrowFunction, MethodDeclaration, ConstructorDeclaration, Get/Set accessor,
+  ClassDeclaration, ClassExpression).
+- `WeakMap<ts.Node /*root*/, Array<{ name: string; node: ts.Identifier }>>`,
+  built lazily on first query by ONE walk from the root using the SAME
+  boundary rules, recording each var-declaration Identifier in DFS order
+  (only `var` lists: neither Let nor Const flag — port the flag test
+  verbatim).
+- A block's conflicts: iterate the root's index entries whose
+  `node.getStart()`… wait — use `node.pos`/`node.end` **containment in the
+  block's [pos, end)** (binary-search the DFS-ordered array for the range
+  start; entries are position-sorted because the walk is DFS over a single
+  file). For each entry in range with `lexicalNames.has(name)`, emit
+  `ctx.addError(node, "Cannot redeclare block-scoped variable '<name>'")`.
+- **Order rationale**: the original emits in DFS order of the block's
+  subtree, names interleaved. The DFS index filtered by range IS that order.
+  Note the original starts its walk AT the block node itself
+  (`collectVarDeclaredNamesInBlock(ctx, block, …)` — a SourceFile/Block is
+  never a VariableStatement, so starting from the block vs. filtering the
+  root index by the block's range is equivalent).
+- **Correctness subtlety**: entries inside a nested function under the block
+  are already excluded from the root's index (the index walk stops at
+  boundaries), and a nested function's own blocks resolve to a DIFFERENT
+  root — so range-filtering never leaks across scopes. Assert this in a test
+  with `{ let x; function f() { var x; } }` (no error — verify against
+  current behavior first) vs `{ let x; { var x; } }` (error).
+
+### 3. `checkDuplicateLexicalDeclarations` — same index idea, measure first
+
+`duplicates.ts:82` (3.0%). Re-run the per-block instrumentation AFTER #4431
+lands (see "How to measure" below) and only restructure if it still ranks;
+its internals differ (it also reads `isStrictMode`, now memoized, so its
+residual cost may already be small). Do not force it into the pattern
+blindly.
+
+### 4. Ancestor-walk predicates — memoize like `isStrictMode`
+
+`predicates.ts`: `isInsideClassStaticBlock` (line ~216),
+`isInsideAsyncFunction` (~675), `isInsideGeneratorFunction` (~692) are pure
+ancestor-chain functions called per await/yield identifier. Apply the exact
+`strictModeCache` pattern #4431 added (WeakMap + chain backfill). Read each
+function first: memoize ONLY if the function is a pure function of the node
+(no extra params); any predicate taking a second argument does not fit the
+single-key WeakMap shape.
+
+### How to measure (before/after, in the worktree)
+
+- Per-block ranking: apply the instrumentation patch to `on()` in
+  `node-checks.ts` (wrap each check with a `performance.now()` accumulator —
+  see `.tmp/ee-blocktime.mts` header + the session notes in #4431), run
+  `npx tsx .tmp/ee-blocktime.mts 9`, then RESTORE the file (`git checkout` /
+  file copy). Never commit the instrumented file.
+- Wall/CPU A/B: `npx tsx .tmp/ee-time.mts <label> 3` with file-copy swaps of
+  the touched files (HEAD copies vs optimized copies), interleaved rounds.
+- Ship gate: `npx tsx .tmp/ee-diff.mts .tmp/ee-<label>.jsonl` + `cmp` against
+  a baseline regenerated from unmodified HEAD **in the same tree state**.
+
+### Acceptance criteria
+
+1. Differential byte-identical (the ship gate) — HEAD vs optimized.
+2. Measured per-block or A/B numbers in the PR body (no predicted ranges).
+3. Early-error suites green modulo the 2 known pre-existing issue-3632
+   standalone failures (`js2wasm:runtime-eval` import — environmental).
+4. `pnpm run typecheck` clean; prettier clean.
+5. No behavior flags, no new exports beyond what the index/caches need.
+
+## Results (measured 2026-08-15, worktree `compiler-speedup`, HEAD `1fe631e` = #4431)
+
+### Ship gate
+
+Byte-identical. `.tmp/ee-diff.mts` over test262 `language`+`annexB` +
+`src/**/*.ts`: **25,862 files, 23,983 diagnostics, 0 exceptions** on both sides;
+`cmp .tmp/ee-4432-base.jsonl .tmp/ee-4432-opt-final.jsonl` exits 0. The baseline
+was regenerated from unmodified HEAD in the same tree, via file-copy A/B (no
+`git stash`).
+
+### CPU A/B (`.tmp/ee-time.mts`, 8,621-file sample, iter0 discarded as cold-JIT)
+
+Interleaved base/opt rounds; each cell is the mean of the iter1+iter2
+steady-state samples across all runs of that variant.
+
+| variant | runs | wall | cpu | vs HEAD (wall) |
+| --- | --- | --- | --- | --- |
+| HEAD | 3 | 2.270 s | 2.387 s | — |
+| **optimized (all four items)** | 4 | **1.938 s** | **2.058 s** | **−14.6 %** |
+| tdz + duplicates only (no predicate memo) | 3 | 1.900 s | 2.027 s | −16.3 % |
+| predicate memo only | 1 | 2.270 s | 2.385 s | −0.0 % |
+
+Run-to-run spread within a variant is ±0.08 s, so the optimized vs
+tdz+duplicates-only difference (0.038 s) is inside the noise band.
+
+### Per-block ranking (`.tmp/ee-blocktime.mts 3`, 8,621 files)
+
+| block | HEAD | optimized | delta |
+| --- | --- | --- | --- |
+| `checkTDZInStatements` (SourceFile/Block/CaseClause/DefaultClause) | 375.5 ms (8.9 %) | 214.7 ms (5.4 %) | **−42.8 %** |
+| `checkVarLexicalConflicts` (Block/SourceFile) | 314.2 ms (7.5 %) | 278.7 ms (7.0 %) | **−11.3 %** |
+| `checkDuplicateLexicalDeclarations` (Block/SourceFile) — untouched | 126.4 ms (3.0 %) | 141.4 ms (3.5 %) | +11.9 % (noise) |
+| `yield` identifier block (`isInsideClassStaticBlock`/`isInsideGeneratorFunction`) | 75.8 ms (1.8 %) | 79.3 ms (2.0 %) | +4.6 % (noise) |
+| `await` identifier block (`isInsideClassStaticBlock`/`isInsideAsyncFunction`) | 74.1 ms (1.8 %) | 78.2 ms (2.0 %) | +5.5 % (noise) |
+| total in-block | 4,213 ms | 4,001 ms | −5.0 % |
+
+The untouched control block moved ±12 % between runs, which sets this harness's
+resolution floor — its `performance.now()` pair is charged per invocation, so
+high-frequency low-cost blocks are inflated (the strict-reserved-word identifier
+block reads as ~47 % of in-block time for that reason). Treat the CPU A/B as the
+headline and the block ranking as attribution.
+
+### Per item
+
+1. **`checkTDZInStatements` — one traversal per statement.** Implemented as
+   planned: `collectTDZRefs` records matches for all pending names into
+   `Map<string, ts.Node[]>` in node encounter order, and emission iterates the
+   `letConstDecls` key order and each name's node list afterwards. `pending`
+   (a Set) replaces `declaredSoFar` as the complement, so both call sites read
+   the same state. −42.8 % on its block; the largest single contributor.
+2. **`checkVarLexicalConflicts` — per-var-scope-root index.** Implemented as
+   planned: lazy `WeakMap<root, VarDeclIndex>`, DFS walk with
+   `collectVarDeclaredNamesInBlock`'s boundary list ported verbatim, block
+   queries answered by binary search over the DFS-ordered positions plus a
+   `[pos, end)` containment filter. Parallel arrays (`names`/`nodes`/`poss`/
+   `ends`) instead of objects. `varScopeRootOf` returns `null` — routing to the
+   original direct walk — if the upward walk meets a VariableStatement before a
+   boundary, since the index walk never descends into one. −11.3 %; smaller
+   than item 1 because the corpus is dominated by small files where the block
+   IS the root and the index build costs the same walk it replaces (the win is
+   in nested blocks, which no longer re-walk what their parents already did).
+3. **`checkDuplicateLexicalDeclarations` — SKIPPED after measuring.** It still
+   ranks (126.4 ms, 3.0 %), but the plan's index idea does not apply: it never
+   re-traverses a subtree. It iterates `block.statements` once, and every
+   statement belongs to exactly one block, so the work is already linear in the
+   file. What remains is per-statement work plus the three collections and one
+   closure it allocates for every Block/SourceFile — a hoisting/lazy-allocation
+   change in the #4431 style, i.e. a different optimization than this issue
+   describes, and worth ~1 % of in-block time at best. Left for a follow-up
+   rather than forced into the pattern.
+4. **Ancestor-walk predicates — implemented, measured NEUTRAL.** All three are
+   pure single-node functions, so all three were memoized. The cache is keyed by
+   the ancestor the walk STARTS from (`node.parent`), not by the queried node,
+   because these predicates — unlike `isStrictMode` — do not test the node
+   itself; the terminal node belongs in the backfilled chain, the queried node
+   does not. Measured on its own it is a 0.0 % wall / −0.1 % CPU change, and the
+   per-block numbers move inside the noise band: the ancestor chains in this
+   corpus are 1–3 nodes deep, so a WeakMap lookup costs about what the direct
+   `ts.isX` tests cost. Kept because it is behaviour-identical (it is inside the
+   byte-identical differential), it matches the pattern already in the file, and
+   it bounds the deep-chain case that the corpus does not exercise — but it is
+   **not** where this issue's speedup comes from, and a reviewer who wants the
+   diff smaller can drop it at no measured cost.
+
+### Tests
+
+- `tests/issue-4432-scope-collectors.test.ts` (new, 8 tests) — pins the two
+  things a byte-identical corpus run could still hide if the corpus lacks the
+  shape: var-scope leak boundaries (`{ let x; function f() { var x; } }` clean
+  vs `{ let x; { var x; } }` flagged, plus class-static-block and sibling-block
+  cases) and TDZ emission order when one statement references two pending names
+  (`a, a, b, b` — not the interleaved `a, b, a, b` a naive single-pass rewrite
+  produces). All 8 pass on HEAD too, i.e. they pin existing behaviour.
+- `issue-4417` / `issue-1931` / `issue-2929` / `issue-3632`: **65 / 67**. The
+  two failures are the known pre-existing `issue-3632` `js2wasm:runtime-eval`
+  import failures (host + standalone), unrelated to this change.
+- `pnpm run typecheck` exits 0; prettier clean.

--- a/src/compiler/early-errors/duplicates.ts
+++ b/src/compiler/early-errors/duplicates.ts
@@ -360,6 +360,101 @@ function isFunctionBodyBlock(block: ts.Block | ts.SourceFile): boolean {
   );
 }
 
+/**
+ * Nodes at which `var` hoisting stops — the descent boundaries of
+ * `collectVarDeclaredNamesInBlock`, ported verbatim (#4432).
+ */
+function isVarScopeBoundary(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isConstructorDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isClassDeclaration(node) ||
+    ts.isClassExpression(node)
+  );
+}
+
+/**
+ * A DFS-ordered index of the var-declaration identifiers reachable from one
+ * var-scope root without crossing a `isVarScopeBoundary` node (#4432).
+ *
+ * Parallel arrays rather than objects: the query path only needs positions for
+ * the range filter and touches `names`/`nodes` for the few in-range entries.
+ * `sorted` records whether `poss` is non-decreasing (it is, for a DFS over a
+ * single file); when it is, the range query binary-searches, otherwise it falls
+ * back to a linear scan so DFS emission order is preserved either way.
+ */
+interface VarDeclIndex {
+  names: string[];
+  nodes: ts.Identifier[];
+  poss: number[];
+  ends: number[];
+  sorted: boolean;
+}
+
+const varDeclIndexCache = new WeakMap<ts.Node, VarDeclIndex>();
+
+function buildVarDeclIndex(root: ts.Node): VarDeclIndex {
+  const names: string[] = [];
+  const nodes: ts.Identifier[] = [];
+  const poss: number[] = [];
+  const ends: number[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableStatement(node)) {
+      const flags = node.declarationList.flags;
+      if ((flags & ts.NodeFlags.Let) === 0 && (flags & ts.NodeFlags.Const) === 0) {
+        for (const decl of node.declarationList.declarations) {
+          if (ts.isIdentifier(decl.name)) {
+            names.push(decl.name.text);
+            nodes.push(decl.name);
+            poss.push(decl.name.pos);
+            ends.push(decl.name.end);
+          }
+        }
+      }
+      return;
+    }
+    // Don't cross function boundaries (var doesn't hoist past functions)
+    if (isVarScopeBoundary(node)) return;
+    forEachChild(node, visit);
+  };
+  // A boundary root (function-like / class) would stop `visit` immediately, so
+  // descend into its children; a SourceFile root is walked directly.
+  if (isVarScopeBoundary(root)) forEachChild(root, visit);
+  else visit(root);
+  let sorted = true;
+  for (let i = 1; i < poss.length; i++) {
+    if (poss[i]! < poss[i - 1]!) {
+      sorted = false;
+      break;
+    }
+  }
+  return { names, nodes, poss, ends, sorted };
+}
+
+/**
+ * The nearest enclosing var-scope root of `block`, or `null` when the upward
+ * walk hits a VariableStatement first. `collectVarDeclaredNamesInBlock` never
+ * descends into a VariableStatement, so a block underneath one is not reachable
+ * from the root index; that shape cannot occur without an intervening
+ * function/class boundary, but the null result routes it to the direct walk
+ * rather than relying on that argument.
+ */
+function varScopeRootOf(block: ts.Block | ts.SourceFile): ts.Node | null {
+  if (ts.isSourceFile(block)) return block;
+  let current: ts.Node | undefined = block.parent;
+  while (current) {
+    if (ts.isSourceFile(current) || isVarScopeBoundary(current)) return current;
+    if (ts.isVariableStatement(current)) return null;
+    current = current.parent;
+  }
+  return null;
+}
+
 /** Check for var/lexical declaration conflicts in a block or source file. */
 export function checkVarLexicalConflicts(ctx: EarlyErrorContext, block: ts.Block | ts.SourceFile): void {
   // A FunctionDeclaration contributes a lexical binding (that a same-name `var`
@@ -397,7 +492,52 @@ export function checkVarLexicalConflicts(ctx: EarlyErrorContext, block: ts.Block
 
   // Check var declarations against lexical names — including vars in nested blocks
   // (var hoists to the enclosing function/module scope, so `{ let x; { var x; } }` is a conflict)
-  collectVarDeclaredNamesInBlock(ctx, block, lexicalNames);
+  //
+  // #4432: instead of re-walking this block's whole subtree (every nested block
+  // re-walked what its parents already had), index the var-declaration
+  // identifiers ONCE per var-scope root and answer each block by position
+  // range. The index is DFS-ordered, which is exactly the order the direct
+  // walk emitted in, and entries under a nested function are already excluded
+  // from the index (the index walk stops at the same boundaries), so
+  // range-filtering never leaks across scopes.
+  const root = varScopeRootOf(block);
+  if (root === null) {
+    collectVarDeclaredNamesInBlock(ctx, block, lexicalNames);
+    return;
+  }
+  let index = varDeclIndexCache.get(root);
+  if (index === undefined) {
+    index = buildVarDeclIndex(root);
+    varDeclIndexCache.set(root, index);
+  }
+  const { names, nodes, poss, ends, sorted } = index;
+  const count = poss.length;
+  if (count === 0) return;
+  const lo = block.pos;
+  const hi = block.end;
+  let i = 0;
+  if (sorted) {
+    let a = 0;
+    let b = count;
+    while (a < b) {
+      const mid = (a + b) >> 1;
+      if (poss[mid]! < lo) a = mid + 1;
+      else b = mid;
+    }
+    i = a;
+  }
+  for (; i < count; i++) {
+    const pos = poss[i]!;
+    if (pos >= hi) {
+      if (sorted) break;
+      continue;
+    }
+    if (pos < lo || ends[i]! > hi) continue;
+    const name = names[i]!;
+    if (lexicalNames.has(name)) {
+      ctx.addError(nodes[i]!, `Cannot redeclare block-scoped variable '${name}'`);
+    }
+  }
 }
 
 export function collectVarDeclaredNamesInBlock(ctx: EarlyErrorContext, node: ts.Node, lexicalNames: Set<string>): void {

--- a/src/compiler/early-errors/predicates.ts
+++ b/src/compiler/early-errors/predicates.ts
@@ -230,11 +230,34 @@ export function isUsingDeclarationStatement(node: ts.Node): node is ts.VariableS
   return (node.declarationList.flags & ts.NodeFlags.Using) !== 0;
 }
 
+// Each of the three predicates below is a pure function of a node's ancestor
+// chain and is queried per await/yield token (#4432, ~3.4% of in-block time).
+// They are memoized with the strictModeCache pattern from #4431, with one
+// difference: the walk starts at `node.parent`, so the cache is keyed by the
+// ANCESTOR the walk starts from and holds "the answer for a walk beginning at
+// this node (inclusive)". The terminal node is part of the backfilled chain —
+// its own answer is the terminal value — while the queried node itself is not
+// a key, since its answer is the value stored for its parent.
+const insideClassStaticBlockCache = new WeakMap<ts.Node, boolean>();
+const insideAsyncFunctionCache = new WeakMap<ts.Node, boolean>();
+const insideGeneratorFunctionCache = new WeakMap<ts.Node, boolean>();
+
 /** Check if a node is inside a class static initializer block. */
 export function isInsideClassStaticBlock(node: ts.Node): boolean {
+  const chain: ts.Node[] = [];
+  let result: boolean | undefined;
   let current: ts.Node | undefined = node.parent;
   while (current) {
-    if (ts.isClassStaticBlockDeclaration(current)) return true;
+    const cached = insideClassStaticBlockCache.get(current);
+    if (cached !== undefined) {
+      result = cached;
+      break;
+    }
+    chain.push(current);
+    if (ts.isClassStaticBlockDeclaration(current)) {
+      result = true;
+      break;
+    }
     // ALL function boundaries stop the search, including arrow functions.
     // ES spec: ContainsAwait returns false for ArrowFunction, meaning
     // `await` as an identifier inside an arrow within a static block is valid.
@@ -247,11 +270,14 @@ export function isInsideClassStaticBlock(node: ts.Node): boolean {
       ts.isGetAccessorDeclaration(current) ||
       ts.isSetAccessorDeclaration(current)
     ) {
-      return false;
+      result = false;
+      break;
     }
     current = current.parent;
   }
-  return false;
+  const final = result ?? false;
+  for (const n of chain) insideClassStaticBlockCache.set(n, final);
+  return final;
 }
 
 /** Check if a node is inside any function (for return statement validation). */
@@ -691,41 +717,72 @@ export function isInsideAsyncParams(node: ts.Node): boolean {
 
 /** Check if a node is inside an async function (including async generators). */
 export function isInsideAsyncFunction(node: ts.Node): boolean {
+  const chain: ts.Node[] = [];
+  let result: boolean | undefined;
   let current: ts.Node | undefined = node.parent;
   while (current) {
+    const cached = insideAsyncFunctionCache.get(current);
+    if (cached !== undefined) {
+      result = cached;
+      break;
+    }
+    chain.push(current);
     // Class static blocks create a new scope — stop searching
-    if (ts.isClassStaticBlockDeclaration(current)) return false;
+    if (ts.isClassStaticBlockDeclaration(current)) {
+      result = false;
+      break;
+    }
     if (ts.isFunctionDeclaration(current) || ts.isFunctionExpression(current) || ts.isMethodDeclaration(current)) {
-      return current.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+      result = current.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+      break;
     }
     if (ts.isArrowFunction(current)) {
-      return current.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+      result = current.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+      break;
     }
     current = current.parent;
   }
-  return false;
+  const final = result ?? false;
+  for (const n of chain) insideAsyncFunctionCache.set(n, final);
+  return final;
 }
 
 /** Check if a node is inside a generator function (including async generators). */
 export function isInsideGeneratorFunction(node: ts.Node): boolean {
+  const chain: ts.Node[] = [];
+  let result: boolean | undefined;
   let current: ts.Node | undefined = node.parent;
   while (current) {
+    const cached = insideGeneratorFunctionCache.get(current);
+    if (cached !== undefined) {
+      result = cached;
+      break;
+    }
+    chain.push(current);
     // Class static blocks create a new scope — stop searching
-    if (ts.isClassStaticBlockDeclaration(current)) return false;
+    if (ts.isClassStaticBlockDeclaration(current)) {
+      result = false;
+      break;
+    }
     if ((ts.isFunctionDeclaration(current) || ts.isFunctionExpression(current)) && current.asteriskToken) {
-      return true;
+      result = true;
+      break;
     }
     if (ts.isMethodDeclaration(current) && current.asteriskToken) {
-      return true;
+      result = true;
+      break;
     }
     // Arrow functions are never generators, but they don't create a new yield scope
     // If we hit an arrow, keep going up — arrows inherit the generator context
     if (ts.isFunctionDeclaration(current) || ts.isFunctionExpression(current) || ts.isMethodDeclaration(current)) {
-      return false; // Found a non-generator function boundary
+      result = false; // Found a non-generator function boundary
+      break;
     }
     current = current.parent;
   }
-  return false;
+  const final = result ?? false;
+  for (const n of chain) insideGeneratorFunctionCache.set(n, final);
+  return final;
 }
 
 /** Check if a function declaration is in a single-statement position (not a block). */

--- a/src/compiler/early-errors/tdz.ts
+++ b/src/compiler/early-errors/tdz.ts
@@ -35,9 +35,16 @@ export function checkTDZInStatements(ctx: EarlyErrorContext, stmts: ts.NodeArray
 
   if (letConstDecls.size === 0) return;
 
-  // For each statement, check if it uses a let/const variable that is declared later
-  // We need to track which variables have been declared so far
-  const declaredSoFar = new Set<string>();
+  // For each statement, check if it uses a let/const variable that is declared later.
+  // #4432: the pending set (declared-later names) is traversed ONCE per statement
+  // instead of once per pending name — the old shape was O(pending × subtree).
+  // `pendingOrder` preserves letConstDecls' Map insertion order and `pending`
+  // tracks which of those are still un-declared; together they reproduce the
+  // original emission order exactly (grouped by name in map order, then by node
+  // encounter order within each name).
+  const pendingOrder = [...letConstDecls.keys()];
+  const pending = new Set<string>(pendingOrder);
+  const matches = new Map<string, ts.Node[]>();
 
   for (const stmt of stmts) {
     // Before processing this statement's declarations, check for references
@@ -51,13 +58,13 @@ export function checkTDZInStatements(ctx: EarlyErrorContext, stmts: ts.NodeArray
           if (ts.isIdentifier(decl.name) && decl.initializer) {
             // Check the initializer for self-references (e.g., `let x = x + 1`)
             const varName = decl.name.text;
-            if (letConstDecls.has(varName) && !declaredSoFar.has(varName)) {
+            if (letConstDecls.has(varName) && pending.has(varName)) {
               checkForTDZRef(ctx, decl.initializer, varName);
             }
           }
           // Now mark this declaration as available
           if (ts.isIdentifier(decl.name)) {
-            declaredSoFar.add(decl.name.text);
+            pending.delete(decl.name.text);
           }
         }
         continue;
@@ -66,12 +73,67 @@ export function checkTDZInStatements(ctx: EarlyErrorContext, stmts: ts.NodeArray
 
     // For non-declaration statements, check if they reference any
     // let/const variable not yet declared
-    for (const [name] of letConstDecls) {
-      if (!declaredSoFar.has(name)) {
-        checkForTDZRef(ctx, stmt, name);
+    if (pending.size === 0) continue;
+    matches.clear();
+    collectTDZRefs(stmt, pending, matches);
+    if (matches.size === 0) continue;
+    for (const name of pendingOrder) {
+      if (!pending.has(name)) continue;
+      const nodes = matches.get(name);
+      if (nodes === undefined) continue;
+      for (const refNode of nodes) {
+        // Emit as warning — test262 expects runtime ReferenceError, not compile error
+        const p = ctx.pos(refNode);
+        ctx.errors.push({
+          message: `Cannot access '${name}' before initialization`,
+          line: p.line,
+          column: p.column,
+          severity: "warning",
+        });
       }
     }
   }
+}
+
+/**
+ * Single-traversal generalization of `checkForTDZRef` (#4432): records every
+ * identifier reference to ANY name in `names`, bucketed by name in node
+ * encounter order. The match test, the two property-name exclusions and the
+ * five nested-scope descent boundaries are ported verbatim from
+ * `checkForTDZRef`; only emission is deferred to the caller so that the
+ * original grouped-by-name ordering is preserved.
+ */
+function collectTDZRefs(node: ts.Node, names: Set<string>, matches: Map<string, ts.Node[]>): void {
+  if (ts.isIdentifier(node)) {
+    const text = node.text;
+    if (names.has(text)) {
+      // Make sure this isn't a property name or type reference
+      const parent = node.parent;
+      if (parent && ts.isPropertyAccessExpression(parent) && parent.name === node) {
+        return; // It's a property name like obj.x, not a variable reference
+      }
+      if (parent && ts.isPropertyAssignment(parent) && parent.name === node) {
+        return; // It's a property name in an object literal
+      }
+      const bucket = matches.get(text);
+      if (bucket === undefined) matches.set(text, [node]);
+      else bucket.push(node);
+      return;
+    }
+    // Non-matching identifiers have no children to descend into; falling
+    // through matches the original (forEachChild on an Identifier is a no-op).
+  }
+  // Don't descend into nested function scopes -- they create their own TDZ
+  if (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isClassDeclaration(node) ||
+    ts.isClassExpression(node)
+  ) {
+    return;
+  }
+  forEachChild(node, (child: ts.Node) => collectTDZRefs(child, names, matches));
 }
 
 /**

--- a/tests/issue-4432-scope-collectors.test.ts
+++ b/tests/issue-4432-scope-collectors.test.ts
@@ -1,0 +1,86 @@
+// #4432 — pins the scope-boundary behaviour of the per-var-scope-root var
+// declaration index that replaced `checkVarLexicalConflicts`' per-block subtree
+// re-walk, and the emission order of the single-traversal TDZ collector that
+// replaced its per-pending-name re-walk.
+//
+// Both rewrites answer a block's query from data indexed at an ancestor, so the
+// two things that could silently break are (a) leaking a `var` from a nested
+// function into an enclosing block's conflict set and (b) reordering
+// diagnostics when one statement references two pending TDZ names. Neither
+// shows up in a pass/fail count — only in which node is flagged and in what
+// order — so they are asserted directly here.
+import { describe, it, expect } from "vitest";
+import { ts } from "../src/ts-api.js";
+import { createEarlyErrorContext } from "../src/compiler/early-errors/context.js";
+import { checkVarLexicalConflicts } from "../src/compiler/early-errors/duplicates.js";
+import { checkTDZInStatements } from "../src/compiler/early-errors/tdz.js";
+
+function parse(src: string): ts.SourceFile {
+  return ts.createSourceFile("test.ts", src, ts.ScriptTarget.Latest, /*setParentNodes*/ true, ts.ScriptKind.TS);
+}
+
+/** Run checkVarLexicalConflicts over every Block/SourceFile in `src`, in document order. */
+function varLexicalMessages(src: string): string[] {
+  const sf = parse(src);
+  const ctx = createEarlyErrorContext(sf);
+  const walk = (node: ts.Node): void => {
+    if (ts.isBlock(node) || ts.isSourceFile(node)) checkVarLexicalConflicts(ctx, node);
+    ts.forEachChild(node, walk);
+  };
+  walk(sf);
+  return ctx.errors.map((e) => e.message);
+}
+
+function tdzMessages(src: string): string[] {
+  const sf = parse(src);
+  const ctx = createEarlyErrorContext(sf);
+  checkTDZInStatements(ctx, sf.statements);
+  return ctx.errors.map((e) => `${e.message}@${e.column}`);
+}
+
+describe("#4432 var/lexical conflict index — scope boundaries", () => {
+  it("a nested block's var conflicts with an enclosing block's lexical name", () => {
+    expect(varLexicalMessages("{ let x; { var x; } }")).toEqual(["Cannot redeclare block-scoped variable 'x'"]);
+  });
+
+  it("a var inside a nested function does NOT leak into the enclosing block", () => {
+    expect(varLexicalMessages("{ let x; function f() { var x; } }")).toEqual([]);
+  });
+
+  it("sibling blocks under one var-scope root do not see each other's vars", () => {
+    expect(varLexicalMessages("function g() { { let x; } { var x; } }")).toEqual([]);
+  });
+
+  it("a var inside a class static block does not leak out of the class", () => {
+    expect(varLexicalMessages("{ let x; class C { static { var x; } } }")).toEqual([]);
+  });
+
+  it("one shared index answers several blocks without cross-contamination", () => {
+    expect(varLexicalMessages("function g() { { let a; { var a; } } { let b; { var b; } } }")).toEqual([
+      "Cannot redeclare block-scoped variable 'a'",
+      "Cannot redeclare block-scoped variable 'b'",
+    ]);
+  });
+});
+
+describe("#4432 TDZ single-traversal collector — emission order", () => {
+  it("groups by declaration order, then by node encounter order", () => {
+    // One statement referencing both pending names twice each. The original
+    // per-name re-traversal emitted both `a` rows before both `b` rows; a naive
+    // single-pass rewrite would interleave them in node order (a, b, a, b).
+    expect(tdzMessages("f(a, b, a, b); let a; let b;")).toEqual([
+      "Cannot access 'a' before initialization@3",
+      "Cannot access 'a' before initialization@9",
+      "Cannot access 'b' before initialization@6",
+      "Cannot access 'b' before initialization@12",
+    ]);
+  });
+
+  it("stops at nested function scopes and skips property names", () => {
+    expect(tdzMessages("obj.a; ({ a: 1 }); function f() { a; } let a;")).toEqual([]);
+  });
+
+  it("still flags a self-reference in the declaration's own initializer", () => {
+    expect(tdzMessages("let a = a + 1;")).toEqual(["Cannot access 'a' before initialization@9"]);
+  });
+});


### PR DESCRIPTION
## Description

Third PR in the `detectEarlyErrors` lane (#4425 dispatch → #4431 check-body top-2 → this), and the first under the new plan/implement split: the implementation plan in `plan/issues/4432-early-error-scope-collector-costs.md` was written by the Fable lane, the implementation done by an Opus subagent against it (the split is recorded in `CLAUDE.md` in this PR).

**Changes** (all semantics-preserving; the ship gate is the byte-identical differential):

1. `checkTDZInStatements` (`tdz.ts`): one traversal per statement collecting matches for all pending names, emitted grouped by declaration-map order then node encounter order — replaces the O(pending-names × subtree) re-traversal. `checkForTDZRef` kept verbatim for the initializer self-reference arm.
2. `checkVarLexicalConflicts` (`duplicates.ts`): lazy per-var-scope-root DFS index of var-declaration identifiers (`WeakMap`, parallel position-sorted arrays), block queries answered by binary-searched `[pos, end)` containment — replaces the per-block subtree re-walk. Boundary rules ported verbatim; a conservative fallback routes to the original walk when the root resolution is ambiguous.
3. `isInsideClassStaticBlock` / `isInsideAsyncFunction` / `isInsideGeneratorFunction` (`predicates.ts`): memoized with the #4431 WeakMap chain-backfill pattern. **Measured neutral** — kept for the deep-chain bound and pattern consistency.
4. `checkDuplicateLexicalDeclarations`: **deliberately not restructured** after measuring — it is already linear per file (statements iterated once per owning block); the plan's index idea does not apply. Recorded in the issue.

## Validation (measured, quiet 4-core box)

- **Differential**: unmodified HEAD (with #4431) vs optimized over 25,862 files — 23,983 diagnostics each, 0 exceptions, **byte-identical JSONL**, re-verified at the committed file state.
- **Detect CPU A/B** (8,621-file sample, interleaved rounds, cold iteration discarded): **−14.6 % wall / −13.8 % CPU** vs HEAD. Per-block: `checkTDZInStatements` −42.8 %, `checkVarLexicalConflicts` −11.3 %; untouched control block moves ±12 % between runs (harness noise floor), so the CPU A/B is the headline number.
- **Tests**: new `tests/issue-4432-scope-collectors.test.ts` (8 tests) pins the var-scope leak boundaries (`{ let x; function f() { var x; } }` clean vs `{ let x; { var x; } }` flagged, class static blocks, sibling blocks) and the TDZ grouped emission order (`a, a, b, b` — the order a naive single-pass rewrite breaks); all 8 also pass on unmodified HEAD, i.e. they pin existing behavior. Early-error suites 65/67 — the 2 issue-3632 failures are the known pre-existing `js2wasm:runtime-eval` environment issue.
- `pnpm run typecheck` clean; prettier/biome clean; LOC/function budgets granted by the issue file.

Issue #4432 → done with full `## Results` in this PR (self-merge path).

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm)_