### PR TITLE
fix(codegen): ES5 standalone wave 3 — var-rebind element widening, ToPrimitive this-binding, compound-assign lane, holey carrier (#4428 #4429 #4427 #4430)

### DIFF
--- a/plan/issues/4427-compound-assign-chain-invalid-module.md
+++ b/plan/issues/4427-compound-assign-chain-invalid-module.md
@@ -1,11 +1,21 @@
 ---
 id: 4427
 title: "Compound `+=` chain with boolean RHS emits a non-validating module (any.convert_extern fed a (ref null $AnyString) if)"
-status: in-progress
+status: done
+completed: 2026-08-15
 sprint: current
 assignee: ttraenkler/claude-es5-standalone
 created: 2026-08-15
 updated: 2026-08-15
+# The lane decision + operand bridging moved OUT to the new subsystem module
+# src/codegen/string-compound-lane.ts; what stays in the driver is the hoisted
+# left/right checker types (shared with the #2058 block below it, net zero raw
+# checker sites) and the three-line call into that module. +2 file lines /
+# +6 function lines is the irreducible residue of that call.
+loc-budget-allow:
+  - src/codegen/expressions/operator-assignment.ts
+func-budget-allow:
+  - src/codegen/expressions/operator-assignment.ts::compileCompoundAssignment
 priority: high
 horizon: m
 feasibility: medium
@@ -95,3 +105,104 @@ test262 (ES5 standalone): S11.13.2_A4.4_T2.6–T2.9, plus the
   residual is filed with the exact failing lane documented.
 - No regression in the scoped standalone filter
   `language/expressions/compound-assignment|language/expressions/addition`.
+
+## Resolution (2026-08-15)
+
+Two INDEPENDENT defects, both in the standalone (nativeStrings) `+=` lowering.
+The plan's suspicion that the #3989 bridge-slot store-back or the #4426
+wrapper-miss arm produced the bad `if` was wrong on both counts — the culprit
+is older and simpler.
+
+### 1. Invalid module — `emitBoolToString` is DUAL-LANE, its callers were not
+
+Minimal repro is a SINGLE statement, not a chain: `var x = "1"; x += true;`.
+
+```wat
+i32.const 1
+(if (result (ref null 6))          ;; 6 = $AnyString — emitBoolToString, native lane
+  (then global.get 44) (else global.get 45))
+any.convert_extern                 ;; ← operand must be externref. INVALID.
+ref.cast (ref 6)
+```
+
+`emitBoolToString` (string-ops.ts:1618) returns an **externref** string-constant
+global in the JS-host lane but a native `$AnyString` when
+`ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0`. Both native-string coercion
+sites — `compileNativeStringCompoundAssignment`'s boolean-RHS arm and
+`compileAndCoerceToAnyStr` (the #1210 builder path) — appended the host lane's
+`any.convert_extern` + `ref.cast` **unconditionally**, ignoring the ValType
+`emitBoolToString` returns. The comment at the first site even asserted the
+wrong half ("emitBoolToString returns externref").
+
+Fixed by `emitBoolToAnyStr` (new module `src/codegen/string-compound-lane.ts`),
+which branches on the reported type: externref keeps the host tail; the native
+lane emits `ref.as_non_null`, correct for both shapes that lane can produce
+(`ref.as_non_null` accepts a non-null operand). The `p12`/`p24` chains were
+never a separate bug — they simply contained this statement.
+
+### 2. Wrong lane — the concat gate only ever looked at the LHS
+
+The sibling wrong-value bugs turned out to be ONE bug, and it did fall out of
+the same dispatch. §13.15.3 defers to §13.5.3, whose step 3 concatenates as
+soon as **either** operand's ToPrimitive is a String. The gate in
+`compileCompoundAssignment` tested `isStringType(leftTsType)` and then, only
+for an `any` LHS, `hasStringAssignment`. With the checker narrowing `x` to
+`number` immediately after `x = 1`, `x += "1"` failed both tests and fell
+through to the f64 lane, which ToNumber-coerced the string: `2`, not `"11"`.
+Same mechanism for the `undefined` / `null` LHS rows.
+
+`rhsStringForcesConcatLane` adds the missing half: a statically String-typed
+RHS (string primitive, string literal, or a `String` WRAPPER object — all
+ToPrimitive to a string) settles the lane on its own.
+
+**Deliberately restricted to the case the concat lane can SERVE**, via
+`slotNeedsExternrefBridge` (no JS host + externref slot):
+
+- Its inbound half `emitExternrefSlotToAnyStr` (#3472) runs the §7.1.17
+  ToString walker on the loaded value, which is what makes a number / boolean /
+  `undefined` / `null` / wrapper in the slot stringify instead of trap.
+- An f64/i32 slot cannot hold the concat result at all, so it keeps the
+  numeric lane.
+- The JS-host lane's `compileStringCompoundAssignment` loads the slot RAW into
+  js-string concat — no ToString on the LHS — so it keeps the numeric lane too.
+  Widening this rule to the host lane is a separate change and would need its
+  own LHS ToString.
+
+### Residual (out of scope, not fixed)
+
+- **JS-host lane**: `x = 1; x += "1"` with a JS host still takes the numeric
+  lane, per the gate above. Only the standalone/WASI native-string lane is
+  fixed here. Not observable in the ES5-standalone conformance target.
+- `tests/issue-1999.test.ts` "captured string += inside an async function
+  appends" times out at 35 s. **Pre-existing** — verified failing identically
+  with both source files reverted to the merge-base. Untouched by this issue.
+
+## Test Results (2026-08-15)
+
+Scoped standalone run,
+`language/expressions/compound-assignment` + `language/expressions/addition`
+(502 files, `.tmp/run-dir.mts`, before/after on the same tree):
+
+| | pass | fail | compile_error |
+| --- | --- | --- | --- |
+| before | 463 | 28 | 11 |
+| after | **467** | 24 | 11 |
+
+Per-file delta: **+4, zero regressions.**
+
+```
+FAIL -> PASS  S11.13.2_A4.4_T2.6.js
+FAIL -> PASS  S11.13.2_A4.4_T2.7.js
+FAIL -> PASS  S11.13.2_A4.4_T2.8.js
+FAIL -> PASS  S11.13.2_A4.4_T2.9.js
+```
+
+Probes (`.tmp/p4427.mts`) — `p1`/`p2`/`p12`/`p24` all `validate true`; before,
+`p2` (the single statement), `p12` and `p24` each failed with
+`any.convert_extern[0] expected type externref, found if of type (ref null 6)`.
+
+Suites: `tests/issue-4427-compound-assign-chain.test.ts` 8/8 new · the eight
+string/compound `tests/equivalence/*` suites 55/55 · `tests/issue-3989-*`,
+`tests/issue-3472-*`, `tests/issue-2058-*`, `tests/compound-assignment-*` green
+· `npm run typecheck`, `biome lint` on the changed files, `check:oracle-ratchet`
+(net −1 `getTypeAtLocation`, −1 `ctx.checker`) all clean.

--- a/plan/issues/4428-single-arg-array-ctor-wrapper-identity.md
+++ b/plan/issues/4428-single-arg-array-ctor-wrapper-identity.md
@@ -168,8 +168,19 @@ before AND after on this branch):
 The other 9 failures are unchanged and unrelated (length-overflow, `toString`
 tag, defineProperty coercion order, a missing quickjs provider).
 
+`language/statements/variable` is 55 pass / 26 fail on BOTH sides — the
+widening changes nothing there.
+
 `npm test -- tests/es5-standalone-wrapper-exotics-replace.test.ts
 tests/es5-standalone-ctor-identity.test.ts` — 19/19 green before and after.
+
+Equivalence: the 14 array/object-shaped files under `tests/equivalence/`
+(92 tests) are 91 pass / 1 fail, and that one failure —
+`array-inline-return.test.ts > find does not hijack return`, a checker
+diagnostic `Type 'number | undefined' is not assignable to type 'number'` —
+reproduces identically with both hooks reverted. Pre-existing, not chased.
+(The full 214-file `tests/equivalence` run OOMs in this container with other
+agents' suites running concurrently, per CLAUDE.md's note; CI runs it.)
 New pin: `tests/issue-4428.test.ts`, 12 tests, including a
 `homogeneous-array-is-NOT-widened` case that guards the predicate's narrowness
 and a `.length === 1` case that rules out the carrier widening.

--- a/plan/issues/4428-single-arg-array-ctor-wrapper-identity.md
+++ b/plan/issues/4428-single-arg-array-ctor-wrapper-identity.md
@@ -1,11 +1,17 @@
 ---
 id: 4428
 title: "`new Array(<wrapper>)` element loses object identity — x[0] comes back as the unwrapped primitive"
-status: in-progress
+status: done
 sprint: current
 assignee: ttraenkler/claude-es5-standalone
 created: 2026-08-15
 updated: 2026-08-15
+completed: 2026-08-15
+loc-budget-allow:
+  - src/codegen/typeof-delete.ts
+  - src/codegen/declarations.ts
+func-budget-allow:
+  - src/codegen/declarations.ts::collectDeclarations
 priority: medium
 horizon: m
 feasibility: medium
@@ -77,3 +83,115 @@ test262 (ES5 standalone): S15.4.2.2_A2.3_T2, S15.4.2.2_A2.3_T3.
   `"object"` — or, if wrapper-construction identity is deliberately out of
   scope, the issue documents the layer where identity is lost and files the
   residual against the wrapper-constructor issue.
+
+## Localization — all three suspects are INNOCENT
+
+Step 1's three candidates were probed individually (`.tmp/p1.mjs`,
+standalone + `hostBridge: always`, module-init driven). Every one is fine:
+
+| Probe                                              | Result |
+| -------------------------------------------------- | ------ |
+| `new Boolean(false) === new Boolean(false)`        | false — distinct objects |
+| `typeof new Boolean(false)`, `new String("0")`     | `"object"` |
+| `new Boolean(false) === false` / `new String("0") === "0"` | false — no primitive collapse |
+| (a) construction                                    | OK for Boolean, String **and** Number |
+| (b) #4426 one-element path, in isolation<br>`var o = new Boolean(false); var x = new Array(o); x[0] === o` | **true** — identity preserved |
+| (c) read side (`x[0]`, `typeof x[0]`) off an externref vec | OK |
+
+So neither the wrapper constructors nor #4426's `compileExpression(arg,
+{kind:"externref"})` lose anything, and the `new Number` lane is not special.
+
+## The layer identity is actually lost at — the SLOT, not the array
+
+The failing tests write the same `var` **twice**:
+
+```js
+var x = new Array(true);      // checker: boolean[]  → (mut $__vec_i32)
+var obj = new Boolean(false);
+var x = new Array(obj);       // builds a $__vec_externref …
+```
+
+TypeScript keeps declaration #1's type for a redeclared `var` in a `.js`
+source (verified directly against the checker: both declarations report
+`boolean[]`, and `x[0]` reports `boolean` — no union). `moduleGlobalWasmType`
+pins the global from that type, so the second store is a **vec→vec coercion**
+(`emitSafeStructConversion` → `emitVecToVecBody`, type-coercion.ts) that copies
+element-by-element through `ToNumber` + `i32.trunc_sat_f64_s` — visible in the
+emitted WAT of the T2 shape. The Boolean wrapper arrives as i32 `0`.
+
+That also explains the T4/T5-pass / T2/T3-fail split exactly: T4 and T5 have
+**no primitive-array predecessor** to pin the slot, so their arrays stay
+externref-element vecs. It is not a Number-vs-Boolean/String difference at all
+— `var x = new Array(1); var x = new Array(new Number(0))` passes, and
+`var x = [true]; var x = [obj]` (plain array literals, no `Array` constructor
+involved) fails identically. The bug has nothing to do with `new Array`.
+
+## Fix
+
+New module `src/codegen/declarations/array-rebind-element-widening.ts`, hooked
+into `moduleGlobalWasmType` (declarations.ts). When a module-scoped binding is
+written with BOTH an object-element array and a primitive-element array, the
+slot keeps its vec type and its **element** type widens to `externref`.
+
+Widening the CARRIER instead (the #4204 / `bindingHasMixedAssignmentCarrier`
+answer, plain `externref`) was measured and rejected: it preserves `x[0]`'s
+identity but breaks `x.length` (reads `0`), trading one failing assertion in
+these very tests for another.
+
+The predicate is deliberately narrow — it needs two SEPARATE writes with
+disagreeing domains, every element tag non-`mixed`, and each write
+syntactically classifiable (array literal, or `Array(...)`/`new Array(...)` in
+its element form, with the §23.1.1.1 single-Number-argument LENGTH form
+excluded). One unclassifiable write to a binding abandons the analysis for that
+binding. Mixing within a single write (`[obj, true]`) is left to the
+array-literal element-typing lane.
+
+Companion soundness guard in `typeof-delete.ts`: a widened binding keeps its
+first declaration's checker type, so `typeof x[0]` const-folded to `"boolean"`
+without reading the value. Both fold sites now take the runtime path for an
+element read off a widened binding — the exact analogue of #4204's
+`moduleGlobalIsDynamicButStaticallyPrimitive`. Folds that LOWER from the
+checker type (`===`, `.length`, the indexed read itself) were verified sound.
+
+## Test Results
+
+test262 standalone, `built-ins/Array/length` (30 files, runner-verified
+before AND after on this branch):
+
+| | before | after |
+| --- | --- | --- |
+| bucket | 19 pass / 11 fail | **21 pass / 9 fail** |
+| S15.4.2.2_A2.3_T2 | fail (`x[0]` is primitive `false`) | **pass** |
+| S15.4.2.2_A2.3_T3 | fail (`x[0]` is primitive `"0"`) | **pass** |
+| _T1 / _T4 / _T5 | pass | pass |
+
+The other 9 failures are unchanged and unrelated (length-overflow, `toString`
+tag, defineProperty coercion order, a missing quickjs provider).
+
+`npm test -- tests/es5-standalone-wrapper-exotics-replace.test.ts
+tests/es5-standalone-ctor-identity.test.ts` — 19/19 green before and after.
+New pin: `tests/issue-4428.test.ts`, 12 tests, including a
+`homogeneous-array-is-NOT-widened` case that guards the predicate's narrowness
+and a `.length === 1` case that rules out the carrier widening.
+
+## Residuals (not fixed here)
+
+1. **Function-local bindings take the same loss.** The hook is on
+   `moduleGlobalWasmType` only; the local-slot minting sites
+   (`localTypeForDeclaration` in statements/variables.ts and the var-hoist path
+   in index.ts) still pin the vec from declaration #1. `function f() { var x =
+   [true]; var obj = new Boolean(false); x = [obj]; return x[0] === obj; }`
+   remains false. Not reachable from the target tests (test262 top-level code
+   is module-scoped), and the local sites carry extra constraints — a slot
+   retype has to agree with closure-capture ABI (#3123) and the hoist-time seed
+   (#3316) — so it wants its own slice rather than a drive-by.
+2. **Disagreement between two OBJECT element types is out of the predicate's
+   scope** — it fires only on object-vs-primitive, the identity-destroying case
+   these tests exercise. Probed and NOT currently broken:
+   `var x = [new Boolean(false)]; var obj = new String("0"); var x = [obj];
+   x[0] === obj` is already true without the widening. Left alone rather than
+   widened speculatively.
+3. **`x.length` on a boxed-externref array carrier reads `0`** — measured while
+   evaluating the rejected carrier widening (`var x = 1; x = new Array(obj);
+   x.length`). Pre-existing, independent of this issue, and the reason the fix
+   widens the element type instead.

--- a/plan/issues/4429-string-hint-toprimitive-this-binding-residual.md
+++ b/plan/issues/4429-string-hint-toprimitive-this-binding-residual.md
@@ -12,6 +12,11 @@ horizon: s
 feasibility: medium
 reasoning_effort: high
 task_type: bug
+loc-budget-allow:
+  # emitWithCurrentThis + the three wrapped dispatch arms live at the existing
+  # string-hint sites in the coercion engine; extracting them would split the
+  # __current_this save/install/restore across modules mid-dispatch.
+  - src/codegen/type-coercion.ts
 area: codegen
 es_edition: 5
 language_feature: to-primitive

--- a/plan/issues/4429-string-hint-toprimitive-this-binding-residual.md
+++ b/plan/issues/4429-string-hint-toprimitive-this-binding-residual.md
@@ -1,11 +1,12 @@
 ---
 id: 4429
 title: "String-hint ToPrimitive drops the receiver `this` — `'' + a` / `String(a)` call toString with wrong this (in-tree #2679 tests failing)"
-status: in-progress
+status: done
 sprint: current
 assignee: ttraenkler/claude-es5-standalone
 created: 2026-08-15
 updated: 2026-08-15
+completed: 2026-08-15
 priority: high
 horizon: s
 feasibility: medium
@@ -71,3 +72,89 @@ bucket (36 ES5 rows).
 
 - All 13 cases of `tests/issue-2679-toprimitive-this.test.ts` pass.
 - No regression in the ToPrimitive-adjacent suites named above.
+
+## Root cause
+
+The suspicion in step 2 of the plan was right. Object-literal methods are stored
+as `__obj_meth_tramp_*` trampolines whose FIRST instruction is
+`global.get $__current_this` — param-0 is the closure self/env, not the
+receiver. The string-hint dispatch emitters `call_ref` that trampoline directly
+and never installed the global, so the trampoline read whatever `__current_this`
+happened to hold. The "static-dispatches the raw method with the receiver as
+param-0, was correct" claim at `type-coercion.ts` ~3157 rotted silently when
+object-literal methods moved to trampolines.
+
+Both failing cases take the SAME arm — `tryStructStringHintExternrefDispatch`,
+eqref candidate chain (verified from the emitted WAT: `__primitive_host_eq_*`
+locals, trampoline reading global `$__current_this`). `String(a)` and `'' + a`
+funnel through it identically, which is why one fix closes both.
+
+The standalone (native-strings) lane was worse than "wrong `this`": there
+`__current_this` is NULL at the dispatch, so the trampoline's `ref.cast` trapped
+at runtime — `RuntimeError: dereferencing a null pointer` for **any**
+`this`-reading `toString`, not just identity-sensitive ones. Verified by A/B on
+`{ x: 7, toString() { return "v" + this.x; } }`: trap before, `"v7"` after.
+
+## Fix
+
+New `emitWithCurrentThis(ctx, fctx, receiverLocal, resultType, emitDispatch)`
+helper in `src/codegen/type-coercion.ts` — save `__current_this`, install the
+receiver (`extern.convert_any` of the struct), run the dispatch, capture the
+result, restore, re-push. Applied to all three string-hint dispatch arms:
+
+- `tryStructStringHintExternrefDispatch` — wraps the primary+secondary
+  OrdinaryToPrimitive attempt (this is the arm both failing tests take).
+- `tryStructPrimitiveToStringAsExternref` — closure-ref arm and eqref
+  candidate-chain arm.
+
+It reads `ctx.currentThisGlobalIdx` FRESH at every global op and never caches it
+across the sub-emission (the #2679/#2078 mid-dispatch global-shift hazard), and
+degrades to the plain dispatch when the global was never registered.
+
+Also mirrored the #4426 candidate-chain restructure into
+`tryStructPrimitiveToStringAsExternref`'s eqref chain: zero-capture closure
+wrappers canonicalize to one struct type, so a passing `ref.test closureTypeIdx`
+does not prove the stored funcref has that candidate's signature. A signature
+miss now falls through to the next candidate instead of manufacturing
+`ref.null` + `ref.as_non_null` and trapping.
+
+## Test Results
+
+| Suite                                            | Before          | After           |
+| ------------------------------------------------ | --------------- | --------------- |
+| `tests/issue-2679-toprimitive-this.test.ts`      | 13/15           | **15/15**       |
+| `tests/issue-4429-string-hint-toprimitive-this.test.ts` (new) | 1/5 | **5/5** |
+| `es5-standalone-callable-tostring` + `issue-4208-ordinary-to-primitive-ir` + `es5-standalone-number-format` | 33/33 | 33/33 |
+| 13-file ToPrimitive/toString sweep                | 114/116         | 114/116         |
+| 12-file `tests/equivalence/` coercion subset      | 82/82           | 82/82           |
+
+(The issue text says "13 cases"; the file actually holds 15 — 13 passed, 2
+failed. Both now pass.)
+
+The 2 remaining failures in the sweep are `issue-2638-toprimitive-class-arm`
+(class-instance `__to_primitive` arm) and are **pre-existing on this base** —
+confirmed by an A/B revert of `type-coercion.ts` alone.
+
+New regression test `tests/issue-4429-string-hint-toprimitive-this.test.ts`
+pins the STANDALONE lane (uncovered by the #2679 file, which is JS-host only),
+including a nesting case that asserts `__current_this` is RESTORED so coercing
+an inner object does not clobber an enclosing method's `this`. It fails 4/5 on
+the pre-fix compiler.
+
+## Residuals
+
+- **`tv === a` still fails in STANDALONE** for `var tv; ...toString(){ tv = this; }`.
+  This is object IDENTITY across the struct→externref materialization, not the
+  `this` binding — the same probe reading `this.x` returns the right value. The
+  JS-host cases (the ones the issue names) pass.
+- **`tryStructToString`'s own section-1 arms** (ref-field ~3610, eqref-field
+  ~3647) still `call_ref` a trampoline without installing `__current_this`.
+  Left alone deliberately: instrumented probes over method-shorthand,
+  function-expression, valueOf-only and prototype-toString shapes never reach
+  them (the wrapped `tryStructStringHintExternrefDispatch` delegation at ~3496
+  claims all of them first), so wrapping them would be unexercised code.
+- **No test262 flips measured** in a 19-file `language/types/object` standalone
+  spot-check or a targeted `this`-in-`toString` sample — byte-identical
+  before/after. Those buckets fail on other gaps (property attributes, `with`).
+  The conformance win, if any, is in rows whose `toString` reads `this`; CI's
+  merge_group run is the real measurement.

--- a/plan/issues/4430-array-new-filter-holes-ir-invalid-module.md
+++ b/plan/issues/4430-array-new-filter-holes-ir-invalid-module.md
@@ -1,7 +1,8 @@
 ---
 id: 4430
 title: "Bounded sparse `new Array(n)` + filter holes: standalone IR route emits a non-validating module (in-tree #4222 test failing)"
-status: in-progress
+status: done
+completed: 2026-08-15
 sprint: current
 assignee: ttraenkler/claude-es5-standalone
 created: 2026-08-15
@@ -65,3 +66,68 @@ the #4426 session's regression sweep).
 - All cases of `tests/es5-array-new-filter-holes.test.ts` pass (the module
   validates).
 - No IR-fallback bucket growth; filter-adjacent suites stay green.
+
+## Resolution (2026-08-15)
+
+**Root cause — the branded carrier is invisible to the IR type system, so the
+CALL to the element-store helper was unrepresentable.**
+
+V8's real message (probe `.tmp/p4430.mts`, `new WebAssembly.Module(binary)`):
+
+```
+Compiling function #50:"test" failed:
+  local.set[0] expected type (ref null 45), found local.tee of type (ref null 2)
+```
+
+with `45 = $__holey_array`, `2 = $__vec_externref`. Reading the WAT:
+
+```wat
+(block (result (ref null 45)) … struct.new 45)   ;; __ir_holey_array_new
+local.tee 0                                      ;; $$ir3 : (ref null 2)  ← erased here
+…
+local.set 2                                      ;; __inl14_p0 : (ref null 45)
+```
+
+`local.tee`'s result type is the LOCAL's type, not the value's, so the holey
+brand is erased at the binding and the (inlined) call to
+`__vec_elem_set_<holeyIdx>` receives the parent type. The inliner only changed
+the wording — the un-inlined `call` was equally invalid.
+
+The binding is typed from the IR's logical `vec<externref>` `IrType`, which
+carries **no brand**: `from-ast.ts` gives `__ir_holey_array_new` the result type
+`irVec(irVal({kind:"externref"}), true)`. Legacy does not have this problem
+because `inferArrayVecType` / `moduleGlobalWasmType` pin the slot to
+`$__holey_array` from `ctx.holeyArrayDeclarations`. Pinning the same carrier in
+the IR is **not** reachable from here: `IrType.vec`'s `layout` is keyed by
+ELEMENT type during Program-ABI preparation, and `attachIrVecLayouts` throws
+`"IR vec type already carries a different prepared layout"` if a site
+pre-attaches a different carrier for the same element.
+
+**Fix (`src/codegen/vec-elem-set.ts`) — take the PARENT carrier in the helper.**
+`$__holey_array` is a `final` subtype of `$__vec_externref`, and BOTH fields
+this helper touches (`length`, `data`) are declared on that parent. So the
+signature and every `struct.get`/`struct.set` now use `vecDef.superTypeIdx` for
+the holey carrier. A holey instance is a valid argument by subtyping, so the
+legacy path (which does type its binding `$__holey_array`) is unaffected, and no
+cast is introduced in either direction. The hole-preserving growth semantics —
+`$Hole`-filled `array.new`, the `[oldLength, idx)` `array.fill` — are untouched
+and still keyed on `isHoleyArrayType`. Same idiom as the #4426 `.length=`
+receiver fix: type the receiver at the level that owns the fields being written.
+
+**Residual (deliberate, filed here, not fixed):** the IR still has no way to
+express "this logical `vec<externref>` is the branded sparse carrier". Nothing
+today needs it — the IR dispatches holes from the AST
+(`isHoleyArrayConstructor` / `isHoleyArrayFilterCall` /
+`isHoleyArrayElementStore`), and the filter helper takes `externref` — but a
+future holey-only WasmGC operation that needs the concrete type at a call
+boundary would hit the same wall. Closing it means keying vec layouts on more
+than the element type.
+
+## Test Results (2026-08-15)
+
+| Check | Before | After |
+| --- | --- | --- |
+| `tests/es5-array-new-filter-holes.test.ts` | 8 pass / 1 fail (`claims the bounded sparse route in standalone IR`: `WebAssembly.validate` false) | 9 pass |
+| `tests/es5-standalone-array-filter.test.ts` | 7 pass | 7 pass |
+| `pnpm run check:ir-fallbacks` | OK | OK — no unintended / post-claim / module-level increases |
+| probe `.tmp/p4430.mts` | `validate false` + the `local.set` message above | `validate true` |

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -114,6 +114,7 @@ import {
   pushProgramAbiNestedFunctionDeclaration,
   pushProgramAbiTopLevelCallable,
 } from "./program-abi-source-callable-planning.js";
+import { rebindWidenedArrayVecType } from "./declarations/array-rebind-element-widening.js";
 import { heterogeneousWidenedModuleGlobalType } from "./declarations/heterogeneous-scalar-var-widening.js";
 import { withBodyHoistedModuleVarNames } from "./declarations/with-body-var-hoisting.js";
 import { inferStandaloneRegExpMatchGlobalType } from "./regexp-standalone.js";
@@ -2000,7 +2001,11 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
     // (externref-widened globals round-trip through __extern_get_idx,
     // which can't see typed vecs and returns null).
     // (#4204) `var x = 2; x = this` cannot live in the `(mut f64)` slot.
+    // (#4428) A binding rebound to arrays of disagreeing element domains keeps
+    // its vec slot but widens the ELEMENT type — a boxed carrier would preserve
+    // `x[0]`'s identity and lose `x.length`.
     return (
+      rebindWidenedArrayVecType(ctx, sourceFile, decl) ??
       heterogeneousWidenedModuleGlobalType(ctx, sourceFile, decl) ??
       inferStandaloneRegExpMatchGlobalType(ctx, decl) ??
       resolveWasmType(ctx, varType)

--- a/src/codegen/declarations/array-rebind-element-widening.ts
+++ b/src/codegen/declarations/array-rebind-element-widening.ts
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4428) Module-global element-representation widening for a `var` that is
+ * REBOUND to arrays whose elements live in different JS domains.
+ *
+ * ## The defect
+ *
+ * `moduleGlobalWasmType` pins an array binding's vec type from the checker type
+ * of its FIRST declaration. For a `.js` source TypeScript never revisits that:
+ * a redeclared `var` keeps declaration #1's type even when declaration #2
+ * initializes it with something else entirely.
+ *
+ * ```js
+ * var x = new Array(true);          // checker: boolean[]  → (mut $__vec_i32)
+ * var obj = new Boolean(false);
+ * var x = new Array(obj);           // builds a $__vec_externref …
+ * x[0] === obj;                     // … which is then CONVERTED into the i32 vec
+ * ```
+ *
+ * The second store is a vec→vec coercion (`emitSafeStructConversion`,
+ * type-coercion.ts), which copies element-by-element through `ToNumber`. The
+ * Boolean wrapper arrives as the i32 `0` and its object identity is gone —
+ * test262 `S15.4.2.2_A2.3_T2` / `_T3` fail on `x[0] === obj` while `_T4` /
+ * `_T5` (Number wrapper, no primitive-array predecessor) pass. Nothing is
+ * wrong with the wrapper constructors or with #4426's one-element
+ * `new Array(<non-number>)` path: both were verified to preserve identity in
+ * isolation. The loss is entirely in the coercion the too-narrow slot forces.
+ *
+ * ## Why widening the ELEMENT type, not the carrier
+ *
+ * The existing dynamic-carrier widenings (#4204 here, `bindingHasMixedAssignmentCarrier`
+ * for locals) answer `externref` — the whole array becomes a boxed value. That
+ * does preserve `x[0]`'s identity, but a boxed vec loses `.length` (measured:
+ * `x.length === 1` reads `0`), so it trades one failing assertion for another.
+ * Keeping the slot a vec and widening only its ELEMENT type to `externref`
+ * keeps the length field on the static path and makes the second store a
+ * no-op coercion.
+ *
+ * ## Why the predicate is deliberately narrow
+ *
+ * Widening an element type is a representation change on every read of the
+ * array, so this fires only on a PROVED disagreement between two SEPARATE
+ * writes: one that stores an array of objects, another that stores an array of
+ * primitives. Both must be syntactically classifiable (array literal, or an
+ * `Array(...)` / `new Array(...)` in its element form) with non-`mixed` tags
+ * for every element — a single unclassifiable write to the binding abandons the
+ * analysis for that binding entirely, leaving today's type in place. Mixing
+ * WITHIN one write (`[obj, true]`) is the array-literal element-typing lane's
+ * job and is not touched here.
+ */
+import type { JsTag } from "../../checker/oracle.js";
+import type { ValType } from "../../ir/types.js";
+import { ts } from "../../ts-api.js";
+import type { CodegenContext } from "../context/types.js";
+import { getOrRegisterVecType } from "../registry/types.js";
+
+/** Per-(context, file) memo — `moduleGlobalWasmType` asks once per declaration. */
+const analysisCache = new WeakMap<CodegenContext, Map<ts.SourceFile, ReadonlySet<string>>>();
+
+/** The domain a single whole-array write stores into the binding. */
+type WriteDomain = "object" | "primitive";
+
+/** Tags whose values are references with observable identity. */
+const OBJECT_TAGS: ReadonlySet<JsTag> = new Set<JsTag>(["object", "function"]);
+
+/**
+ * The widened slot type for `decl`, or `undefined` to leave the type picker's
+ * decision alone.
+ */
+export function rebindWidenedArrayVecType(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  decl: ts.VariableDeclaration,
+): ValType | undefined {
+  if (!ts.isIdentifier(decl.name)) return undefined;
+  let perFile = analysisCache.get(ctx);
+  if (perFile === undefined) {
+    perFile = new Map();
+    analysisCache.set(ctx, perFile);
+  }
+  let widened = perFile.get(sourceFile);
+  if (widened === undefined) {
+    widened = collectElementRebindWidenedVars(ctx, sourceFile);
+    perFile.set(sourceFile, widened);
+  }
+  if (!widened.has(decl.name.text)) return undefined;
+  return { kind: "ref_null", typeIdx: getOrRegisterVecType(ctx, "externref", { kind: "externref" }) };
+}
+
+/**
+ * (#4428) Is `expr` an indexed read off a binding whose element representation
+ * was widened here, while the checker still describes the element as a
+ * primitive?
+ *
+ * A widened binding keeps its first declaration's checker type — `var x = new
+ * Array(true)` stays `boolean[]` even after the slot's elements become
+ * `externref`. Any consumer that CONST-FOLDS from that type is unsound on the
+ * widened array, and `typeof` is the one that shows: it folds `typeof x[0]` to
+ * the literal `"boolean"` and never reads the value, so a stored wrapper object
+ * reports as a boolean. Folds that instead LOWER from the checker type are fine
+ * — they go through the ordinary externref coercions and observe the real value
+ * (`===`, `.length` and the indexed read itself are all verified).
+ *
+ * Mirrors {@link moduleGlobalIsDynamicButStaticallyPrimitive} (#4204), which
+ * carries the identical disagreement one level up, at the binding itself.
+ */
+export function elementReadOfRebindWidenedArray(ctx: CodegenContext, expr: ts.Expression): boolean {
+  if (!ts.isElementAccessExpression(expr) || !ts.isIdentifier(expr.expression)) return false;
+  const base = expr.expression;
+  const decl = ctx.oracle.variableDeclarationOf(base);
+  if (decl === undefined || !ts.isIdentifier(decl.name) || !isModuleScoped(decl)) return false;
+  const sourceFile = decl.getSourceFile();
+  const perFile = analysisCache.get(ctx);
+  const widened = perFile?.get(sourceFile) ?? collectElementRebindWidenedVars(ctx, sourceFile);
+  if (perFile !== undefined && !perFile.has(sourceFile)) perFile.set(sourceFile, widened);
+  return widened.has(decl.name.text);
+}
+
+/** True when `node` is hoisted to module scope — i.e. no function-like ancestor. */
+function isModuleScoped(node: ts.Node): boolean {
+  for (let p = node.parent; p !== undefined && !ts.isSourceFile(p); p = p.parent) {
+    if (
+      ts.isFunctionDeclaration(p) ||
+      ts.isFunctionExpression(p) ||
+      ts.isArrowFunction(p) ||
+      ts.isMethodDeclaration(p) ||
+      ts.isGetAccessorDeclaration(p) ||
+      ts.isSetAccessorDeclaration(p) ||
+      ts.isConstructorDeclaration(p) ||
+      ts.isClassDeclaration(p) ||
+      ts.isClassExpression(p) ||
+      ts.isModuleDeclaration(p)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * The element tags a whole-array write stores, or `null` when the expression is
+ * not a syntactically classifiable array construction.
+ *
+ * `undefined` means "an array with no statically known elements" (`[]`, or the
+ * `new Array(len)` length form): carries no element evidence, and — unlike
+ * `null` — does not abandon the binding.
+ */
+function writtenElementTags(ctx: CodegenContext, expr: ts.Expression): readonly JsTag[] | undefined | null {
+  if (ts.isArrayLiteralExpression(expr)) {
+    if (expr.elements.length === 0) return undefined;
+    const tags: JsTag[] = [];
+    for (const element of expr.elements) {
+      if (ts.isSpreadElement(element) || ts.isOmittedExpression(element)) return null;
+      const tag = ctx.oracle.staticJsTypeOf(element);
+      if (tag === "mixed") return null;
+      tags.push(tag);
+    }
+    return tags;
+  }
+  if (ts.isNewExpression(expr) || ts.isCallExpression(expr)) {
+    const callee = expr.expression;
+    if (!ts.isIdentifier(callee) || callee.text !== "Array") return null;
+    const args = expr.arguments;
+    if (args === undefined || args.length === 0) return undefined;
+    const tags: JsTag[] = [];
+    for (const argument of args) {
+      if (ts.isSpreadElement(argument)) return null;
+      const tag = ctx.oracle.staticJsTypeOf(argument);
+      if (tag === "mixed") return null;
+      tags.push(tag);
+    }
+    // §23.1.1.1 step 5 / ES5 §15.4.2.2: a SINGLE Number argument is a LENGTH,
+    // so the array has no statically known elements. Every other single
+    // argument, and every multi-argument form, is an element list (#4426).
+    if (tags.length === 1 && tags[0] === "number") return undefined;
+    return tags;
+  }
+  return null;
+}
+
+/** The domain of one write, or `undefined` when it carries no element evidence. */
+function writeDomain(tags: readonly JsTag[] | undefined): WriteDomain | undefined {
+  if (tags === undefined || tags.length === 0) return undefined;
+  const objectElements = tags.filter((tag) => OBJECT_TAGS.has(tag)).length;
+  if (objectElements === tags.length) return "object";
+  if (objectElements === 0) return "primitive";
+  // Mixed within a single write — the array-literal element-typing lane's job.
+  return undefined;
+}
+
+/**
+ * Names of module-scoped bindings written with BOTH an object-element array and
+ * a primitive-element array, so no single non-`externref` element type can carry
+ * every stored value.
+ */
+function collectElementRebindWidenedVars(ctx: CodegenContext, sourceFile: ts.SourceFile): ReadonlySet<string> {
+  /** name → domains seen, or `null` once an unclassifiable write abandons it. */
+  const seen = new Map<string, Set<WriteDomain> | null>();
+
+  const record = (name: string, value: ts.Expression): void => {
+    if (seen.get(name) === null) return;
+    const tags = writtenElementTags(ctx, value);
+    if (tags === null) {
+      seen.set(name, null);
+      return;
+    }
+    const domain = writeDomain(tags);
+    if (domain === undefined) {
+      if (!seen.has(name)) seen.set(name, new Set());
+      return;
+    }
+    const domains = seen.get(name) ?? new Set<WriteDomain>();
+    domains.add(domain);
+    seen.set(name, domains);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined &&
+      isModuleScoped(node)
+    ) {
+      record(node.name.text, node.initializer);
+    } else if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)
+    ) {
+      // Binding identity from the oracle, never the bare name (#3364): a
+      // same-named function local must not widen a module global.
+      const target = ctx.oracle.variableDeclarationOf(node.left);
+      if (target !== undefined && target.getSourceFile() === sourceFile && isModuleScoped(target)) {
+        record(node.left.text, node.right);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  const widened = new Set<string>();
+  for (const [name, domains] of seen) {
+    if (domains !== null && domains.has("object") && domains.has("primitive")) widened.add(name);
+  }
+  return widened;
+}

--- a/src/codegen/declarations/array-rebind-element-widening.ts
+++ b/src/codegen/declarations/array-rebind-element-widening.ts
@@ -73,6 +73,16 @@ export function rebindWidenedArrayVecType(
   decl: ts.VariableDeclaration,
 ): ValType | undefined {
   if (!ts.isIdentifier(decl.name)) return undefined;
+  if (!widenedVarsOf(ctx, sourceFile).has(decl.name.text)) return undefined;
+  return { kind: "ref_null", typeIdx: getOrRegisterVecType(ctx, "externref", { kind: "externref" }) };
+}
+
+/**
+ * Memoized analysis result for one file. Both entry points go through here:
+ * `typeof` asks per OPERAND, so an uncached recompute would walk the whole file
+ * once per `typeof x[i]` in it.
+ */
+function widenedVarsOf(ctx: CodegenContext, sourceFile: ts.SourceFile): ReadonlySet<string> {
   let perFile = analysisCache.get(ctx);
   if (perFile === undefined) {
     perFile = new Map();
@@ -83,8 +93,7 @@ export function rebindWidenedArrayVecType(
     widened = collectElementRebindWidenedVars(ctx, sourceFile);
     perFile.set(sourceFile, widened);
   }
-  if (!widened.has(decl.name.text)) return undefined;
-  return { kind: "ref_null", typeIdx: getOrRegisterVecType(ctx, "externref", { kind: "externref" }) };
+  return widened;
 }
 
 /**
@@ -109,11 +118,7 @@ export function elementReadOfRebindWidenedArray(ctx: CodegenContext, expr: ts.Ex
   const base = expr.expression;
   const decl = ctx.oracle.variableDeclarationOf(base);
   if (decl === undefined || !ts.isIdentifier(decl.name) || !isModuleScoped(decl)) return false;
-  const sourceFile = decl.getSourceFile();
-  const perFile = analysisCache.get(ctx);
-  const widened = perFile?.get(sourceFile) ?? collectElementRebindWidenedVars(ctx, sourceFile);
-  if (perFile !== undefined && !perFile.has(sourceFile)) perFile.set(sourceFile, widened);
-  return widened.has(decl.name.text);
+  return widenedVarsOf(ctx, decl.getSourceFile()).has(decl.name.text);
 }
 
 /** True when `node` is hoisted to module scope — i.e. no function-like ancestor. */

--- a/src/codegen/expressions/operator-assignment.ts
+++ b/src/codegen/expressions/operator-assignment.ts
@@ -38,6 +38,7 @@ import {
   getCapturedBoxGlobal,
 } from "../property-access.js";
 import { coerceType, compileExpression } from "../shared.js";
+import { emitBoolToAnyStr, rhsStringForcesConcatLane } from "../string-compound-lane.js";
 import { compileStringLiteral, emitBoolToString } from "../string-ops.js";
 import { patchStructNewForDynamicField } from "./extern.js";
 import {
@@ -1363,10 +1364,7 @@ function compileNativeStringCompoundAssignment(
   } else if (rhsType.kind === "f64" || rhsType.kind === "i32") {
     const rhsTsType = ctx.checker.getTypeAtLocation(expr.right);
     if (isBooleanType(rhsTsType) && rhsType.kind === "i32") {
-      // bool → "true"/"false" string. emitBoolToString returns externref.
-      emitBoolToString(ctx, fctx);
-      fctx.body.push({ op: "any.convert_extern" });
-      fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx });
+      emitBoolToAnyStr(ctx, fctx);
     } else {
       if (rhsType.kind === "i32") fctx.body.push({ op: "f64.convert_i32_s" });
       const toStr = ctx.funcMap.get("number_toString");
@@ -1478,9 +1476,7 @@ function compileAndCoerceToAnyStr(ctx: CodegenContext, fctx: FunctionContext, ex
   if (rhsType.kind === "f64" || rhsType.kind === "i32") {
     const rhsTsType = ctx.checker.getTypeAtLocation(expr);
     if (isBooleanType(rhsTsType) && rhsType.kind === "i32") {
-      emitBoolToString(ctx, fctx);
-      fctx.body.push({ op: "any.convert_extern" });
-      fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx });
+      emitBoolToAnyStr(ctx, fctx);
       return anyStrType;
     }
     if (rhsType.kind === "i32") fctx.body.push({ op: "f64.convert_i32_s" });
@@ -1723,16 +1719,22 @@ export function compileCompoundAssignment(
   // compileStringCompoundAssignment uses bare local.get/local.tee, which would
   // pass the `(struct (mut externref))` ref cell straight into js-string concat
   // (→ illegal cast / invalid wasm). #1999.
-  if (op === ts.SyntaxKind.PlusEqualsToken && !fctx.boxedCaptures?.has(name)) {
-    const leftTsType = ctx.checker.getTypeAtLocation(expr.left);
-    let isStr = isStringType(leftTsType);
-    if (!isStr && (leftTsType.flags & ts.TypeFlags.Any) !== 0) {
+  const plusEqualsUnboxed = op === ts.SyntaxKind.PlusEqualsToken && !fctx.boxedCaptures?.has(name);
+  const plusLeftTsType = plusEqualsUnboxed ? ctx.checker.getTypeAtLocation(expr.left) : undefined;
+  const plusRightTsType = plusEqualsUnboxed ? ctx.checker.getTypeAtLocation(expr.right) : undefined;
+  if (plusEqualsUnboxed && plusLeftTsType && plusRightTsType) {
+    let isStr = isStringType(plusLeftTsType);
+    if (!isStr && (plusLeftTsType.flags & ts.TypeFlags.Any) !== 0) {
       // For `any`-typed variables (e.g. `var __str; __str=""`), check if
       // the variable is ever assigned a string value in the enclosing scope.
       // This handles the common test262 pattern where `var x; x=""` followed
       // by `x += numericVar` should do string concatenation.
       isStr = hasStringAssignment(name, expr);
     }
+    // (#4427) A statically String-typed RHS forces concat on its own (§13.5.3
+    // step 3) — see `rhsStringForcesConcatLane` for why the LHS-only gate above
+    // mis-lowered `x = 1; x += "1"` to `2`, and for the slot restriction.
+    if (!isStr) isStr = rhsStringForcesConcatLane(ctx, fctx, name, plusRightTsType);
     if (isStr) {
       return compileStringCompoundAssignment(ctx, fctx, expr, name);
     }
@@ -1758,9 +1760,9 @@ export function compileCompoundAssignment(
   // FALSE for a runtime STRING — which is how acorn's `message += " (" + …`
   // rendered as the number NaN. Mirrors `emitAnyAdd`'s own `noJsHost` test.
   const anyCompoundAddEligible = ctx.anyValueTypeIdx < 0 || ctx.standalone === true || ctx.wasi === true;
-  if (op === ts.SyntaxKind.PlusEqualsToken && !fctx.boxedCaptures?.has(name) && anyCompoundAddEligible) {
-    const leftTsType = ctx.checker.getTypeAtLocation(expr.left);
-    const rightTsType = ctx.checker.getTypeAtLocation(expr.right);
+  if (plusEqualsUnboxed && plusLeftTsType && plusRightTsType && anyCompoundAddEligible) {
+    const leftTsType = plusLeftTsType;
+    const rightTsType = plusRightTsType;
     const leftIsAnyish = (leftTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
     const rightIsAnyish = (rightTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
     const isBigInt =

--- a/src/codegen/string-compound-lane.ts
+++ b/src/codegen/string-compound-lane.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4427) Lane selection + operand bridging for native-string `+=`.
+//
+// Two decisions that `compileCompoundAssignment` / the native-string compound
+// path used to make inline, both of which were wrong in the standalone
+// (nativeStrings) lane:
+//
+//   1. WHICH lane `x += y` takes when only the RHS is statically a string.
+//   2. HOW a boolean RHS lands as the `ref $AnyString` the concat boundary
+//      wants, given `emitBoolToString` is dual-lane.
+//
+// Both live here so the decision is stated once and the god-file driver keeps
+// only the call.
+import ts from "typescript";
+
+import { isStringType } from "../checker/type-mapper.js";
+import type { ValType } from "../ir/types.js";
+import { getLocalType } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { slotNeedsExternrefBridge } from "./native-string-slot-bridge.js";
+import { localGlobalIdx } from "./registry/imports.js";
+import { emitBoolToString } from "./string-ops.js";
+
+/**
+ * The physical ValType of the slot a compound assignment writes back into —
+ * local, captured global, or module global, in the same precedence order
+ * `compileNativeStringCompoundAssignment` resolves them. `undefined` when the
+ * name has no slot in any of the three (the graceful-fallback case).
+ */
+export function compoundSlotValType(ctx: CodegenContext, fctx: FunctionContext, name: string): ValType | undefined {
+  const localIdx = fctx.localMap.get(name);
+  if (localIdx !== undefined) return getLocalType(fctx, localIdx);
+  const capturedIdx = ctx.capturedGlobals.get(name);
+  if (capturedIdx !== undefined) return ctx.mod.globals[localGlobalIdx(ctx, capturedIdx)]?.type;
+  const moduleIdx = ctx.moduleGlobals.get(name);
+  if (moduleIdx !== undefined) return ctx.mod.globals[localGlobalIdx(ctx, moduleIdx)]?.type;
+  return undefined;
+}
+
+/**
+ * True when a statically String-typed RHS forces `name += rhs` into the string
+ * concat lane even though the LHS is not statically a string.
+ *
+ * §13.15.3 defers to §13.5.3, whose step 3 concatenates as soon as EITHER
+ * operand's ToPrimitive is a String. A statically String-typed RHS — string
+ * primitive, string literal, or a `String` WRAPPER object, all of which
+ * ToPrimitive to a string — settles that without knowing the LHS, so
+ * `x = 1; x += "1"` is `"11"`, never `2`. The lane gate only ever consulted
+ * the LHS, so a NARROWED non-string LHS (the checker types `x` as `number`
+ * right after `x = 1`, even for a `var x` whose slot is externref) silently
+ * took the numeric lane and ToNumber-coerced the string operand: test262
+ * S11.13.2_A4.4_T2.6 CHECK#2 `2`, T2.7 CHECK#1 `2`, T2.8 `undefined`,
+ * T2.9 `null`.
+ *
+ * Restricted to the case the concat lane can actually SERVE: a slot the
+ * native-string bridge accepts. `slotNeedsExternrefBridge` is that exact test
+ * (no JS host + externref slot), and its inbound half
+ * (`emitExternrefSlotToAnyStr`, #3472) runs the §7.1.17 ToString walker on the
+ * loaded value — so a number / boolean / undefined / null / wrapper sitting in
+ * the slot stringifies instead of trapping. An f64/i32 slot cannot hold the
+ * concat result at all, and the JS-host lane's js-string concat has no
+ * ToString on the LHS, so both keep the numeric lane.
+ */
+export function rhsStringForcesConcatLane(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  name: string,
+  rightTsType: ts.Type,
+): boolean {
+  if (!ctx.nativeStrings || ctx.nativeStrTypeIdx < 0) return false;
+  if (!isStringType(rightTsType)) return false;
+  return slotNeedsExternrefBridge(ctx, compoundSlotValType(ctx, fctx, name));
+}
+
+/**
+ * Land `emitBoolToString`'s result as a non-null `ref $AnyString`.
+ *
+ * `emitBoolToString` is DUAL-LANE: the JS-host lane selects an externref
+ * string-constant global, while the nativeStrings/standalone lane selects a
+ * native `$AnyString` struct directly (string-ops.ts). Both native-string `+=`
+ * coercion sites hard-coded the host lane's tail — `any.convert_extern` +
+ * `ref.cast` — so in standalone the `if` producing a `(ref null $AnyString)`
+ * was fed straight into `any.convert_extern`, whose operand must be an
+ * externref. That is a MODULE-level validation failure, not a statement-level
+ * one: `var x = "1"; x += true;` cost the whole file (test262
+ * S11.13.2_A4.4_T2.7 family, and any `+=` chain containing it).
+ *
+ * Bridge on the type `emitBoolToString` actually reports instead. In the
+ * native lane only nullability can differ from the `ref $AnyString` the
+ * `__str_concat` / builder-append boundary requires, and `ref.as_non_null`
+ * accepts a non-null operand too — so it is correct for both shapes that lane
+ * can produce.
+ */
+export function emitBoolToAnyStr(ctx: CodegenContext, fctx: FunctionContext): void {
+  const produced = emitBoolToString(ctx, fctx);
+  if (produced.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" });
+    fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx });
+    return;
+  }
+  fctx.body.push({ op: "ref.as_non_null" });
+}

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -136,6 +136,66 @@ function guardedRefCastInstrs(
 export type CompileStringLiteralFn = (ctx: CodegenContext, fctx: FunctionContext, value: string) => void;
 
 /**
+ * (#4429) Run an inline OrdinaryToPrimitive dispatch with `__current_this`
+ * bound to the RECEIVER (§7.1.1.1 step 4.b `Call(method, O)`), then restore the
+ * previous binding.
+ *
+ * Object-literal methods are stored as `__obj_meth_tramp_*` trampolines that
+ * read `this` from the `__current_this` module GLOBAL — param-0 is the closure
+ * self/env, not the receiver. The NUMBER-hint valueOf dispatch has installed it
+ * since #2679; the STRING-hint dispatches did not (their comment claimed they
+ * "static-dispatch the raw method with the receiver as param-0", which stopped
+ * being true once object-literal methods moved to trampolines). So `'' + a` /
+ * `String(a)` called `toString` with a stale receiver in JS-host mode, and in
+ * standalone mode `__current_this` was outright NULL, making the trampoline's
+ * `ref.cast` trap ("dereferencing a null pointer") for any `this`-reading
+ * `toString`.
+ *
+ * `emitDispatch` must leave exactly one value of `resultType` on the stack.
+ *
+ * INDEX DISCIPLINE (#2679 / `project_type_index_shift_and_deadelim`):
+ * `ctx.currentThisGlobalIdx` is read FRESH at every global op and never cached
+ * across `emitDispatch()`. Compiling the dispatch can flush a late string-
+ * constant IMPORT, which inserts an imported global and shifts the defined-
+ * global index space; the shift pass bumps both `ctx.currentThisGlobalIdx` and
+ * the already-emitted save/install ops in `fctx.body` in lockstep, but a
+ * captured local would go stale and make the RESTORE `global.set` target a
+ * different (differently typed) global — invalid Wasm, which is what park-held
+ * #2078 with a 30-test regression.
+ *
+ * A negative `ctx.currentThisGlobalIdx` (global never registered) degrades to
+ * the plain dispatch — no worse than the pre-#4429 behaviour.
+ */
+function emitWithCurrentThis(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiverLocal: number,
+  resultType: ValType,
+  emitDispatch: () => void,
+): void {
+  if (ctx.currentThisGlobalIdx < 0) {
+    emitDispatch();
+    return;
+  }
+  const prevThisLocal = allocTempLocal(fctx, { kind: "externref" });
+  const resultLocal = allocTempLocal(fctx, resultType);
+  // save __current_this, install the receiver (struct ref → externref)
+  fctx.body.push({ op: "global.get", index: ctx.currentThisGlobalIdx });
+  fctx.body.push({ op: "local.set", index: prevThisLocal });
+  fctx.body.push({ op: "local.get", index: receiverLocal });
+  fctx.body.push({ op: "extern.convert_any" });
+  fctx.body.push({ op: "global.set", index: ctx.currentThisGlobalIdx });
+  emitDispatch();
+  // capture the result, restore __current_this (FRESH index), re-push
+  fctx.body.push({ op: "local.set", index: resultLocal });
+  fctx.body.push({ op: "local.get", index: prevThisLocal });
+  fctx.body.push({ op: "global.set", index: ctx.currentThisGlobalIdx });
+  fctx.body.push({ op: "local.get", index: resultLocal });
+  releaseTempLocal(fctx, prevThisLocal);
+  releaseTempLocal(fctx, resultLocal);
+}
+
+/**
  * (#2358) Does a nominal OBJECT-LITERAL struct carry a USER ToPrimitive method —
  * `valueOf` / `@@toPrimitive` / `toString` — as a struct FIELD (stored as an
  * eqref/ref closure)? Used to gate the ref-struct→externref materialization:
@@ -217,15 +277,18 @@ function tryStructPrimitiveToStringAsExternref(
     const structLocal = allocLocal(fctx, `__primitive_ts_struct_${fctx.locals.length}`, from);
     const closureLocal = allocLocal(fctx, `__primitive_ts_closure_${fctx.locals.length}`, field.type);
     fctx.body.push({ op: "local.set", index: structLocal });
-    fctx.body.push({ op: "local.get", index: structLocal });
-    fctx.body.push({ op: "struct.get", typeIdx, fieldIdx });
-    fctx.body.push({ op: "local.tee", index: closureLocal });
-    fctx.body.push({ op: "local.get", index: closureLocal });
-    fctx.body.push({ op: "struct.get", typeIdx: closureTypeIdx, fieldIdx: 0 });
-    emitGuardedFuncRefCast(fctx, closureInfo.funcTypeIdx);
-    fctx.body.push({ op: "ref.as_non_null" });
-    fctx.body.push({ op: "call_ref", typeIdx: closureInfo.funcTypeIdx });
-    if (isVoid(closureInfo)) pushStringHint(ctx, fctx, "undefined");
+    // (#4429) bind `this` = receiver across the trampoline call.
+    emitWithCurrentThis(ctx, fctx, structLocal, { kind: "externref" }, () => {
+      fctx.body.push({ op: "local.get", index: structLocal });
+      fctx.body.push({ op: "struct.get", typeIdx, fieldIdx });
+      fctx.body.push({ op: "local.tee", index: closureLocal });
+      fctx.body.push({ op: "local.get", index: closureLocal });
+      fctx.body.push({ op: "struct.get", typeIdx: closureTypeIdx, fieldIdx: 0 });
+      emitGuardedFuncRefCast(fctx, closureInfo.funcTypeIdx);
+      fctx.body.push({ op: "ref.as_non_null" });
+      fctx.body.push({ op: "call_ref", typeIdx: closureInfo.funcTypeIdx });
+      if (isVoid(closureInfo)) pushStringHint(ctx, fctx, "undefined");
+    });
     return true;
   }
 
@@ -261,29 +324,38 @@ function tryStructPrimitiveToStringAsExternref(
         then: [
           { op: "local.get", index: eqLocal },
           { op: "ref.cast", typeIdx: closureTypeIdx },
-          { op: "local.tee", index: closureLocal },
+          { op: "local.set", index: closureLocal },
           { op: "local.get", index: closureLocal },
           { op: "struct.get", typeIdx: closureTypeIdx, fieldIdx: 0 },
-          { op: "local.tee", index: funcLocal },
+          { op: "local.set", index: funcLocal },
+          { op: "local.get", index: funcLocal },
           { op: "ref.test", typeIdx: info.funcTypeIdx },
           {
             op: "if",
-            blockType: { kind: "val", type: { kind: "ref_null", typeIdx: info.funcTypeIdx } },
+            blockType: { kind: "val", type: { kind: "externref" } },
             then: [
+              { op: "local.get", index: closureLocal },
               { op: "local.get", index: funcLocal },
-              { op: "ref.cast_null", typeIdx: info.funcTypeIdx },
+              { op: "ref.cast", typeIdx: info.funcTypeIdx },
+              { op: "call_ref", typeIdx: info.funcTypeIdx },
+              ...(isVoid(info) ? undefinedString.map((instr) => ({ ...instr })) : []),
             ],
-            else: [{ op: "ref.null", typeIdx: info.funcTypeIdx }],
+            // (#4429) Zero-capture closure wrappers share one CANONICAL struct
+            // type, so a passing `ref.test closureTypeIdx` does NOT prove the
+            // stored funcref has THIS candidate's signature. Mirror the sibling
+            // chains (#4426 / the host-lane one below): a signature miss means
+            // "try the next candidate", not "manufacture null and trap".
+            else: buildDispatch(candidateIdx + 1),
           },
-          { op: "ref.as_non_null" },
-          { op: "call_ref", typeIdx: info.funcTypeIdx },
-          ...(isVoid(info) ? undefinedString.map((instr) => ({ ...instr })) : []),
         ],
         else: buildDispatch(candidateIdx + 1),
       },
     ];
   };
-  fctx.body.push(...buildDispatch(0));
+  // (#4429) bind `this` = receiver across the candidate chain.
+  emitWithCurrentThis(ctx, fctx, structLocal, { kind: "externref" }, () => {
+    fctx.body.push(...buildDispatch(0));
+  });
   return true;
 }
 
@@ -549,22 +621,29 @@ function tryStructStringHintExternrefDispatch(
   ];
 
   fctx.body.push({ op: "local.set", index: structLocal });
-  fctx.body.push(...primaryDispatch, { op: "local.set", index: primaryResult }, ...isObjectLike(primaryResult));
-  fctx.body.push({
-    op: "if",
-    blockType: { kind: "val", type: { kind: "externref" } },
-    then: [
-      ...secondaryDispatch,
-      { op: "local.set", index: secondaryResult },
-      ...isObjectLike(secondaryResult),
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "externref" } },
-        then: throwTypeError,
-        else: stringify(secondaryResult),
-      },
-    ],
-    else: stringify(primaryResult),
+  // (#4429) `primaryDispatch` / `secondaryDispatch` `call_ref` the method's
+  // `__obj_meth_tramp_*` trampoline, which reads `this` from `__current_this`.
+  // Bind the receiver across BOTH attempts (§7.1.1.1 step 4.b). The stringify /
+  // TypeError arms sit inside the wrap only because they are part of the same
+  // stack-balanced expression; neither re-enters user code.
+  emitWithCurrentThis(ctx, fctx, structLocal, { kind: "externref" }, () => {
+    fctx.body.push(...primaryDispatch, { op: "local.set", index: primaryResult }, ...isObjectLike(primaryResult));
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [
+        ...secondaryDispatch,
+        { op: "local.set", index: secondaryResult },
+        ...isObjectLike(secondaryResult),
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          then: throwTypeError,
+          else: stringify(secondaryResult),
+        },
+      ],
+      else: stringify(primaryResult),
+    });
   });
   return true;
 }

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -10,6 +10,7 @@ import { resolveWidenedVarKey } from "./widened-var-key.js";
 import { isBooleanType, isStringType, isSymbolType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { reportError } from "./context/errors.js";
+import { elementReadOfRebindWidenedArray } from "./declarations/array-rebind-element-widening.js";
 import { moduleGlobalIsDynamicButStaticallyPrimitive } from "./declarations/heterogeneous-scalar-var-widening.js";
 import { typeofFoldContradictedByFieldVerdict } from "./fnctor-ctor-param-types.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
@@ -1692,6 +1693,11 @@ export function compileTypeofExpression(
     if (ts.isIdentifier(bareTdz) && moduleGlobalIsDynamicButStaticallyPrimitive(ctx, bareTdz)) {
       forceRuntimeTypeof = true;
     }
+    // (#4428) Same disagreement one level down: `typeof x[0]` on an array whose
+    // element representation was widened must read the value, not the type.
+    if (elementReadOfRebindWidenedArray(ctx, bareTdz)) {
+      forceRuntimeTypeof = true;
+    }
     // (#4394) JSDoc-typed JS parameter — the declared type is not enforced at
     // runtime, so the fold is unsound (see typeofFoldUnsoundForJsParam).
     if (!forceRuntimeTypeof && typeofFoldUnsoundForJsParam(ctx, bareTdz)) {
@@ -1926,6 +1932,11 @@ export function compileTypeofComparison(
   }
   // (#4204) Same unsound-fold guard as compileTypeofExpression.
   if (staticTypeof !== null && ts.isIdentifier(operand) && moduleGlobalIsDynamicButStaticallyPrimitive(ctx, operand)) {
+    staticTypeof = null;
+  }
+  // (#4428) Element read off an array whose ELEMENT representation was widened
+  // — the checker still reports the first declaration's element type.
+  if (staticTypeof !== null && elementReadOfRebindWidenedArray(ctx, operand)) {
     staticTypeof = null;
   }
   // (#2623 P-7) Same unsound-fold guard as compileTypeofExpression: a

--- a/src/codegen/vec-elem-set.ts
+++ b/src/codegen/vec-elem-set.ts
@@ -166,8 +166,24 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
   const elem = arrDef.element;
   if (elem.kind === "i8" || elem.kind === "i16") return null;
 
+  const holeyCarrier = isHoleyArrayType(ctx, vecTypeIdx) && elem.kind === "externref";
+  // (#4430) The branded sparse carrier is a FINAL subtype of the ordinary
+  // externref vec, and BOTH fields this helper touches (`length`, `data`) are
+  // declared on that parent. The IR path types the receiving binding from the
+  // logical `vec<externref>` IrType, which carries no brand, so a holey-typed
+  // parameter made the call itself unrepresentable — V8 rejected the module
+  // with `local.set expected type (ref null $__holey_array), found (ref null
+  // $__vec_externref)`. Take the PARENT carrier in the signature and in every
+  // struct access: a holey instance is a valid argument by subtyping (the
+  // legacy path, which does type its binding `$__holey_array`, is unaffected),
+  // the hole-preserving growth semantics below are unchanged, and no cast is
+  // needed in either direction. Same idiom as the #4426 `.length=` receiver
+  // fix — type the receiver at the level that owns the fields being written.
+  const parentTypeIdx = vecDef.superTypeIdx;
+  const carrierTypeIdx = holeyCarrier && parentTypeIdx !== undefined ? parentTypeIdx : vecTypeIdx;
+
   const tagIdx = ensureExnTag(ctx);
-  const vecParam: ValType = { kind: "ref_null", typeIdx: vecTypeIdx };
+  const vecParam: ValType = { kind: "ref_null", typeIdx: carrierTypeIdx };
   const sigIdx = addFuncType(ctx, [vecParam, { kind: "i32" }, elem], [], `$${name}_type`);
   const funcIdx = mintDefinedFunc(ctx);
 
@@ -180,7 +196,6 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
   const NDATA = 5;
   const OCAP = 6;
   const OLEN = 7;
-  const holeyCarrier = isHoleyArrayType(ctx, vecTypeIdx) && elem.kind === "externref";
 
   const body: Instr[] = [
     // ── Null guard (#441 parity): if (vec == null) throw TypeError ─────────
@@ -194,7 +209,7 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
     },
     // ── data = vec.data ─────────────────────────────────────────────────────
     { op: "local.get", index: VEC },
-    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+    { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 1 },
     { op: "local.set", index: DATA },
     // ── Grow when idx >= capacity (legacy sequence) ─────────────────────────
     { op: "local.get", index: IDX },
@@ -260,7 +275,7 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
         { op: "local.get", index: VEC },
         { op: "local.get", index: NDATA },
         { op: "ref.as_non_null" },
-        { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 1 },
+        { op: "struct.set", typeIdx: carrierTypeIdx, fieldIdx: 1 },
         // data = newData
         { op: "local.get", index: NDATA },
         { op: "local.set", index: DATA },
@@ -271,7 +286,7 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
           // A write beyond logical length can land in already-allocated spare
           // capacity. Preserve absence in the full [oldLength, idx) gap.
           { op: "local.get", index: VEC },
-          { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+          { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 0 },
           { op: "local.set", index: OLEN },
           { op: "local.get", index: IDX },
           { op: "local.get", index: OLEN },
@@ -301,7 +316,7 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
     { op: "i32.const", value: 1 },
     { op: "i32.add" },
     { op: "local.get", index: VEC },
-    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+    { op: "struct.get", typeIdx: carrierTypeIdx, fieldIdx: 0 },
     { op: "i32.gt_s" },
     {
       op: "if",
@@ -311,7 +326,7 @@ export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): numbe
         { op: "local.get", index: IDX },
         { op: "i32.const", value: 1 },
         { op: "i32.add" },
-        { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 },
+        { op: "struct.set", typeIdx: carrierTypeIdx, fieldIdx: 0 },
       ],
     },
   ];

--- a/tests/issue-4427-compound-assign-chain.test.ts
+++ b/tests/issue-4427-compound-assign-chain.test.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #4427 — two independent defects in the standalone (nativeStrings) `+=`
+ * lowering, both reachable from test262 S11.13.2_A4.4_T2.6–T2.9.
+ *
+ * 1. INVALID MODULE. `emitBoolToString` is dual-lane: JS-host selects an
+ *    externref string-constant global, standalone selects a native
+ *    `$AnyString`. Both native-string coercion sites appended the host lane's
+ *    `any.convert_extern` + `ref.cast` unconditionally, so V8 rejected the
+ *    whole module with
+ *      `any.convert_extern[0] expected type externref,
+ *       found if of type (ref null $AnyString)`
+ *    for `var x = "1"; x += true;` — a MODULE-level failure, i.e. every
+ *    function in the file is lost, not just the statement.
+ *
+ * 2. WRONG LANE. `+` concatenates as soon as EITHER operand's ToPrimitive is a
+ *    String (§13.5.3 step 3), but the lane gate only consulted the LHS. With
+ *    the checker narrowing `x` to `number` right after `x = 1`, `x += "1"`
+ *    took the numeric lane and ToNumber-coerced the string: `2` instead of
+ *    `"11"`. Same for an `undefined` / `null` LHS.
+ */
+
+async function instantiateStandalone(source: string) {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
+  // Empty import object — proves the module is JS-host-free (pure Wasm).
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as Record<string, () => number>;
+}
+
+describe("#4427 standalone compound `+=` with boolean / string operands", () => {
+  it("emits a VALID module for a boolean RHS on a string LHS", async () => {
+    const ex = await instantiateStandalone(`
+      var x = "1";
+      x += true;
+      export function test(): number { return (x === "1true") ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("emits a VALID module for a two-statement `+=` chain (the CE repro)", async () => {
+    const ex = await instantiateStandalone(`
+      var x;
+      x = true; x += "1";
+      x = "1";  x += true;
+      export function test(): number { return (x === "1true") ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("concatenates a number LHS with a string RHS (S11.13.2_A4.4_T2.6 #2)", async () => {
+    const ex = await instantiateStandalone(`
+      var x;
+      x = 1;
+      x += "1";
+      export function test(): number { return (x === "11") ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("concatenates a boolean LHS with a string RHS (S11.13.2_A4.4_T2.7 #1)", async () => {
+    const ex = await instantiateStandalone(`
+      var x;
+      x = true;
+      x += "1";
+      export function test(): number { return (x === "true1") ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("stringifies an undefined LHS (S11.13.2_A4.4_T2.8)", async () => {
+    const ex = await instantiateStandalone(`
+      var x;
+      x = undefined;
+      x += "1";
+      export function test(): number { return (x === "undefined1") ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("stringifies a null LHS (S11.13.2_A4.4_T2.9)", async () => {
+    const ex = await instantiateStandalone(`
+      var x;
+      x = null;
+      x += "1";
+      export function test(): number { return (x === "null1") ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("keeps a provably numeric `+=` on the numeric lane", async () => {
+    // The RHS-is-string rule must not widen to numeric RHS: this stays `2`.
+    const ex = await instantiateStandalone(`
+      var x;
+      x = 1;
+      x += 1;
+      export function test(): number { return (x === 2) ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("keeps a Number-wrapper `+=` numeric (#3989 regression guard)", async () => {
+    const ex = await instantiateStandalone(`
+      var n = new Number(1);
+      n += 1;
+      export function test(): number { return (n === 2) ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+});

--- a/tests/issue-4428.test.ts
+++ b/tests/issue-4428.test.ts
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4428) `new Array(<wrapper>)` element identity across a REBOUND `var`.
+//
+// What actually broke, and why the obvious suspects are innocent
+// --------------------------------------------------------------
+// `new Boolean(false)` builds a genuine distinct object (two of them compare
+// `!==`, `typeof` is `"object"`), and #4426's one-element `new Array(<non-number>)`
+// path stores it into a `$__vec_externref` with identity intact. Both were
+// measured in isolation and both are fine.
+//
+// The loss is in the SLOT. test262 S15.4.2.2_A2.3_T2 writes the same `var` twice:
+//
+//   var x = new Array(true);        // checker: boolean[] → an i32-element vec
+//   var obj = new Boolean(false);
+//   var x = new Array(obj);         // an externref-element vec …
+//
+// TypeScript keeps declaration #1's type for the redeclared `var` in a `.js`
+// source, so the second store is a vec→vec coercion that copies element-wise
+// through `ToNumber` — the wrapper arrives as i32 `0`. `_T4`/`_T5` passed only
+// because they have no primitive-array predecessor to pin the slot.
+//
+// Each identity assertion below is paired with a check that the element is an
+// OBJECT (`typeof`, and a cross-comparison against a second distinct wrapper).
+// Without that, a build that collapsed every wrapper to one shared value — or
+// to `null` — would satisfy `x[0] === obj` vacuously.
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { runTest262File } from "./test262-runner.js";
+
+const OPTS = {
+  target: "standalone",
+  allowJs: true,
+  skipSemanticDiagnostics: true,
+  deferTopLevelInit: true,
+  hostBridge: "always",
+  fileName: "issue-4428.js",
+} as const;
+
+async function runJs(source: string): Promise<number> {
+  const r = await compile(source, OPTS);
+  expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const exports = instance.exports as Record<string, () => number>;
+  if (typeof exports.__module_init === "function") exports.__module_init();
+  return exports.test!();
+}
+
+describe("#4428 — array element identity survives a rebound var", () => {
+  it("Boolean wrapper: x[0] === obj after a primitive-array predecessor", async () => {
+    expect(
+      await runJs(`var x = new Array(true);
+var obj = new Boolean(false);
+var x = new Array(obj);
+var ok = (x[0] === obj) ? 1 : 0;
+export function test() { return ok; }`),
+    ).toBe(1);
+  });
+
+  it("String wrapper: x[0] === obj after a primitive-array predecessor", async () => {
+    expect(
+      await runJs(`var x = new Array("1");
+var obj = new String("0");
+var x = new Array(obj);
+var ok = (x[0] === obj) ? 1 : 0;
+export function test() { return ok; }`),
+    ).toBe(1);
+  });
+
+  it("the stored element is an OBJECT, not a re-boxed primitive", async () => {
+    // Cross check: a second, distinct wrapper of the SAME value must NOT match,
+    // so `x[0] === obj` cannot be passing because everything collapsed to one
+    // shared boxed `false`.
+    expect(
+      await runJs(`var x = new Array(true);
+var obj = new Boolean(false);
+var other = new Boolean(false);
+var x = new Array(obj);
+var isObject = (typeof x[0] === "object") ? 1 : 0;
+var notOther = (x[0] === other) ? 0 : 1;
+export function test() { return isObject + notOther; }`),
+    ).toBe(2);
+  });
+
+  it("length still reads 1 — the slot stays a vec, only its ELEMENT widens", async () => {
+    // A boxed-externref carrier (the other candidate widening) preserves the
+    // element identity and breaks `.length`. This assertion is what rules it out.
+    expect(
+      await runJs(`var x = new Array(true);
+var obj = new Boolean(false);
+var x = new Array(obj);
+var ok = (x.length === 1) ? 1 : 0;
+export function test() { return ok; }`),
+    ).toBe(1);
+  });
+
+  it("plain assignment (no redeclaration) widens too", async () => {
+    expect(
+      await runJs(`var obj = new Boolean(false);
+var x = new Array(true);
+x = new Array(obj);
+var ok = (x[0] === obj) ? 1 : 0;
+export function test() { return ok; }`),
+    ).toBe(1);
+  });
+
+  it("array literals take the same widening", async () => {
+    expect(
+      await runJs(`var x = [true];
+var obj = new Boolean(false);
+var x = [obj];
+var ok = (x[0] === obj) ? 1 : 0;
+export function test() { return ok; }`),
+    ).toBe(1);
+  });
+
+  it("a homogeneous primitive array is NOT widened — the predicate needs both domains", async () => {
+    // Guards the narrowness of the analysis: without a proven object-element
+    // write the slot must keep its element type, so the boolean reads back as a
+    // boolean and `x[0] === 1` stays false (no numeric re-box).
+    expect(
+      await runJs(`var x = new Array(true);
+var x = new Array(false);
+var ok = (x[0] === false && x.length === 1) ? 1 : 0;
+export function test() { return ok; }`),
+    ).toBe(1);
+  });
+});
+
+const HARNESS = join(__dirname, "..", "test262", "harness", "assert.js");
+const TEST262 = existsSync(HARNESS);
+
+describe.skipIf(!TEST262)("#4428 — test262 files", () => {
+  // T2/T3 flip with this fix; T1/T4/T5 were already passing and must stay so —
+  // they are the control that the widening did not disturb the ordinary lanes.
+  const files = [
+    "built-ins/Array/length/S15.4.2.2_A2.3_T1.js",
+    "built-ins/Array/length/S15.4.2.2_A2.3_T2.js",
+    "built-ins/Array/length/S15.4.2.2_A2.3_T3.js",
+    "built-ins/Array/length/S15.4.2.2_A2.3_T4.js",
+    "built-ins/Array/length/S15.4.2.2_A2.3_T5.js",
+  ];
+  for (const rel of files) {
+    it(`${rel} passes on the standalone lane`, { timeout: 60_000 }, async () => {
+      const abs = join(__dirname, "..", "test262", "test", rel);
+      const r = await runTest262File(abs, "issue-4428", 30_000, "standalone");
+      expect(`${r.status}: ${r.reason ?? ""}`).toBe("pass: ");
+    });
+  }
+});

--- a/tests/issue-4429-string-hint-toprimitive-this.test.ts
+++ b/tests/issue-4429-string-hint-toprimitive-this.test.ts
@@ -1,0 +1,72 @@
+// #4429 — the STRING-hint OrdinaryToPrimitive dispatch must call `toString`
+// with the RECEIVER as `this` (§7.1.1.1 step 4.b `Call(method, O)`).
+//
+// Object-literal methods are stored as `__obj_meth_tramp_*` trampolines that
+// read `this` from the `__current_this` module GLOBAL — param-0 is the closure
+// self/env, not the receiver. The NUMBER-hint valueOf dispatch installs that
+// global (#2679); the string-hint dispatches did not, so `'' + a` / `String(a)`
+// saw a stale receiver. The JS-host half of that is asserted by
+// `tests/issue-2679-toprimitive-this.test.ts`; this file pins the STANDALONE
+// (native-strings) lane, where a missing binding did not merely read the wrong
+// object but left `__current_this` NULL — the trampoline's `ref.cast` then
+// trapped with "dereferencing a null pointer" at runtime.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const OPTS = {
+  target: "standalone",
+  allowJs: true,
+  skipSemanticDiagnostics: true,
+  deferTopLevelInit: true,
+  hostBridge: "always",
+  fileName: "test.ts",
+} as const;
+
+async function runStandalone(body: string): Promise<number> {
+  const result: any = await compile(`export function test(): any { ${body} }`, OPTS as any);
+  expect(result.success).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  return (instance.exports as any).test();
+}
+
+describe("#4429 — string-hint ToPrimitive binds `this` (standalone)", () => {
+  it("`'' + a` reads `this` inside a method-shorthand toString", async () => {
+    // Pre-fix: RuntimeError "dereferencing a null pointer" in
+    // __obj_meth_tramp_*_toString (global __current_this was never installed).
+    expect(
+      await runStandalone(`var a = { x: 7, toString() { return "v" + this.x; } }; return ("" + a) === "v7" ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("`String(a)` reads `this` inside a method-shorthand toString", async () => {
+    expect(
+      await runStandalone(`var a = { x: 3, toString() { return "v" + this.x; } }; return String(a) === "v3" ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("a template literal reads `this` inside a function-expression toString", async () => {
+    expect(
+      await runStandalone(
+        `var a = { x: 5, toString: function () { return "v" + this.x; } }; return \`\${a}\` === "v5" ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("the toString call still returns the right value and runs exactly once", async () => {
+    expect(
+      await runStandalone(
+        `var n = 0; var a = { toString() { n = n + 1; return "x"; } }; var s = "" + a; return (n === 1 && s === "x") ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("`__current_this` is RESTORED after the dispatch (no leak into an enclosing method)", async () => {
+    // The outer method's `this` must survive coercing an inner object.
+    expect(
+      await runStandalone(
+        `var outer = { x: 1, m() { var inner = { x: 2, toString() { return "i" + this.x; } }; var s = "" + inner; return s + "/" + this.x; } };` +
+          ` return outer.m() === "i2/1" ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

Third wave of the #4426 ES5-standalone campaign (after #4527 and #4530): four issues implemented in parallel worktrees against the plans filed in `plan/issues/442{7,8,9}-…` / `4430-…`, merged and cross-verified together (34/34 combined pin tests; runner-verified test262 flips listed per issue file).

- **#4428 — `new Array(<wrapper>)` element identity.** None of the three suspected layers was at fault: TypeScript keeps declaration #1's type for a redeclared `var`, so the slot pinned a primitive-element vec and the second store went through an element-wise ToNumber copy. New `declarations/array-rebind-element-widening.ts` widens only the **element** type to externref when a binding is written with both object-element and primitive-element arrays (carrier widening was measured and rejected — it breaks `.length`). Companion `typeof` fold guard. Flips `S15.4.2.2_A2.3_T2/T3`; 12-test pin (`tests/issue-4428.test.ts`).
- **#4429 — string-hint ToPrimitive `this`.** Object-literal methods are `__obj_meth_tramp_*` trampolines reading `$__current_this`; the string-hint dispatch never installed it — in standalone that was a hard null-deref for *any* `this`-reading `toString`, not just wrong identity. New `emitWithCurrentThis` save/install/restore wraps all three dispatch arms (fresh `currentThisGlobalIdx` read at every global op per the #2679 shift hazard); the funcref-miss fall-through from #4527's candidate-chain restructure is mirrored into the start-safe eqref chain. `issue-2679` suite 15/15; new 5-test standalone pin.
- **#4427 — compound `+=` invalid module + wrong lane.** Two root causes: `emitBoolToString` is dual-lane and both native-string coercion sites appended the host lane's bridging unconditionally (the `WebAssembly.validate` failure), and the concat-lane gate consulted only the LHS (so `x = 1; x += "1"` ToNumber'd the string → `2`). New `string-compound-lane.ts`; flips `S11.13.2_A4.4_T2.6–T2.9`; scoped 502-file test262 run: **+4, zero regressions**; 8-test pin.
- **#4430 — holey sparse route emitted a non-validating module.** The IR types a binding from the unbranded `vec<externref>` `IrType`, erasing the `$__holey_array` brand at `local.tee`; the element-store helper now takes the parent vec carrier (both touched fields are declared on the parent; the holey type is a final subtype). `es5-array-new-filter-holes` 9/9.

Issue files carry root-cause writeups, A/B measurements, residuals, and the budget-gate allowances (`loc-budget-allow`/`func-budget-allow`) for the dispatch-site lines; all new logic is in new subsystem modules.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_