### PR TITLE
feat(codegen): native dynamic-RHS instanceof for standalone — retires the __instanceof_check host-import leak (#2916)

### DIFF
--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -1,8 +1,9 @@
 ---
 id: 2916
 title: "[SUBSTRATE][ARCH] Standalone native instanceof operator + isPrototypeOf residual (~31 leaky-PASS conversions)"
-status: ready
-updated: 2026-08-08
+status: in-progress
+assignee: ttraenkler/claude-es5-standalone
+updated: 2026-08-15
 loc-budget-allow:
   - src/codegen/expressions/identifiers.ts
 sprint: current
@@ -755,3 +756,155 @@ those eight files depend on — the §7.3.20-step-1 non-callable rule must DECLI
 for a `Function(…)`/`new Function(…)`-valued RHS — across all three declaration
 spellings, so the real hazard is caught in the fast lane instead of only in a
 lane that has the interpreter linked.
+
+---
+
+## SLICE B LANDED 2026-08-15 — the fully-dynamic RHS is host-free (`native-dynamic-instanceof.ts`)
+
+`env::__instanceof_check` is **gone from every dynamic-RHS shape**. The residual
+arm `emitDynamicInstanceOf` now calls a DEFINED native tri-state helper
+(`__instanceof_dynamic`) instead of the host predicate. `emitInstanceofThrowGuard`
+is reused unchanged — the helper returns the SAME 0/1/2 contract the import did.
+
+### PRIMARY acceptance — met, measured per shape (not on one sample)
+
+Instrument: `compile(src, { target: "standalone" })`, reading the module's
+`imports` list. Verified against the standalone baseline JSONL first — the raw-file
+import probe reproduces the baseline's `compile_error` set for
+`language/expressions/instanceof` **exactly** (same 11 files), so it is the same
+instrument CI applies.
+
+| shape                                            | before                    | after     |
+| ------------------------------------------------ | ------------------------- | --------- |
+| `a instanceof K`, `K` an `any`-typed local       | `env::__instanceof_check` | **clean** |
+| `x instanceof K`, `K` a fn-valued param          | `env::__instanceof_check` | **clean** |
+| `a instanceof holder.K` (property access)        | `env::__instanceof_check` | **clean** |
+| `a instanceof mk()` (call result)                | `env::__instanceof_check` | **clean** |
+| `o instanceof (o = 0, Object)` (comma expr)      | `env::__instanceof_check` | **clean** |
+| `p.isPrototypeOf(a)`, `p` a dynamic receiver     | clean (Slice C, 08-08)    | clean     |
+| builtin-name RHS · user-class RHS · Error family | clean                     | clean     |
+| static `C.prototype.isPrototypeOf(a)`            | clean                     | clean     |
+
+Corpus sweeps on this branch:
+
+- `language/expressions/instanceof` — **43 files, 0 leaking** (was 11 leaking).
+- The **59 files that name `env::__instanceof_check` as their SOLE host import**
+  on the 2026-08-15 standalone baseline — **0 leaking, 0 compile-refused,
+  0 invalid Wasm** (each binary was `WebAssembly.compile`d).
+- gc/host **byte-identical**: sha256 of the compiled binary matched base for all
+  10 probe shapes (file-copy A/B on `identifiers.ts`).
+
+### The answer table, and why each arm is the least-wrong one available
+
+Full rationale in the module header of `src/codegen/native-dynamic-instanceof.ts`.
+
+| RHS at runtime                           | answer       | basis                                                                                     |
+| ---------------------------------------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `null` / `undefined`                     | 0            | host dynamic-path parity (`runtime.ts:2353`); keeps `S15.3.5.3_A1_T1…T8` at `false`         |
+| callable, OWNS a `prototype` property    | §7.3.20 full | an own-property read on a real `$Object` is authoritative: present-but-non-object ⇒ 2, else the `$proto` chain walk decides |
+| callable, no modelled `prototype`        | 0            | prototype not modelled — **the documented residual**                                        |
+| anything else, incl. genuine primitives  | 0            | there is no SOUND runtime primitive test in this backend — see "no wrong throws" below      |
+
+Three design points worth keeping:
+
+1. **IsCallable is asked of `__typeof_function`, not of a snapshotted type list.**
+   That native is finalize-corrected (`typeof-natives-finalize.ts`), so it sees
+   every closure root and every branded carrier regardless of where in the module
+   the `instanceof` site lowers. A membership snapshot taken at build time is the
+   order-dependence #4276 documents; this helper cannot inherit it.
+2. **The brand bit is read DIRECTLY** (`$Object.flags & OBJ_FLAG_CALLABLE`) rather
+   than through `buildBuiltinBrandTestArm`, whose emptiness depends on whether any
+   carrier had been branded YET — and the helper is minted at the FIRST dynamic
+   site, which can precede every carrier.
+3. **The `prototype` arm is gated on `__hasOwnProperty`, not on `Get` returning
+   something.** `Get` returning nothing has two causes the spec treats oppositely:
+   the program set `F.prototype = undefined` (§7.3.20 step 5 ⇒ TypeError), or the
+   backend does not model a `prototype` on that carrier (⇒ nothing is known). The
+   own-property probe separates them.
+
+### No wrong throws — the measurement that changed the design mid-flight
+
+The first cut threw (tri-state `2`) whenever the target was not classifiable as an
+object, per §13.10.2 steps 1/4. **That is unsound in this backend.** An unmodelled
+builtin constructor is lowered to a boxed-primitive carrier, so the shared
+classifiers answer **`typeof Int8Array === "boolean"`** (probe-verified on this
+branch) — every "is the target a primitive" predicate built on them mistakes a
+real constructor for a primitive.
+
+Caught by the corpus sweep, not by reasoning:
+`built-ins/TypedArrayConstructors/ctors/object-arg/iterator-is-null-as-array-like.js`
+went from the host's `false` to `TypeError: Right-hand side of 'instanceof' is not
+callable` at `assert(typedArray instanceof TypedArray)`. A wrong THROW is
+observable in a `catch` and passes/fails tests for the wrong reason; a wrong
+`false` is only a missed conversion. The arm was removed.
+
+**Nothing provable was lost.** A statically-primitive RHS and a provably
+non-callable object RHS both still throw at codegen, one dispatch step earlier
+(`compileHostInstanceOf`'s §13.10.2-step-1 fold and `tryEmitNonCallableRhsThrow`),
+where the evidence is the static TYPE rather than a runtime representation the
+backend gets wrong. Both shapes are pinned in
+`tests/es5-standalone-instanceof.test.ts`, along with the `Int8Array` regression
+pin for the misfire itself.
+
+**Follow-up worth filing separately:** `typeof Int8Array === "boolean"` under
+`--target standalone` is a real bare-value representation gap (the TypedArray
+constructors have no `__builtin_ctor_*` carrier, unlike the #3006/#4223 set). It
+is not caused by this change and is not fixed by it, but any future runtime
+primitive/callable predicate will trip on it exactly as this one did.
+
+Index-space discipline: `mintDefinedFunc` + `pushDefinedFunc` in one call, so the
+handle is stable-regime (shifter-immune) and the body's baked callee indices are
+walked by the ordinary late-import body shifter. **Nothing is minted at finalize**
+(the #4221 hazard).
+
+### SECONDARY acceptance — rows
+
+`language/expressions/instanceof` (43 files), standalone. The before/after
+*answer* runs are **byte-identical** — every one of the 11 previously-refused
+files produces exactly the answer the host `__instanceof_check` produced. That is
+the correctness evidence: the native tri-state reproduces the host's observable
+behaviour on this corpus, it does not merely stop leaking.
+
+CI delta for the directory: 11 × `compile_error` → 1 `pass` + 10 `fail`,
+**0 regressions**. The one conversion is `S11.8.6_A2.4_T3`.
+
+### Deliberately left, with reasons
+
+- **A closure RHS answers `false`, not the spec's `true`/TypeError.** A standalone
+  function value is a WasmGC closure-wrapper struct and its prototype object lives
+  in a per-fnctor module global keyed by the COMPILE-TIME symbol name
+  (`fnctor-prototype.ts`); there is no runtime edge from the value to that global.
+  Probe-verified on this branch: a dynamic `k["prototype"]` read answers
+  `undefined` for a `function` declaration, a `var F = function(){}` and a `class`
+  alike. So `S15.3.5.3_A2_T2/T5/T6` (want a TypeError for a non-object
+  `F.prototype`) and `_A3_T1/T2` (want a chain-walk `true`) keep failing.
+  Answering `2` would assert "F.prototype really is a non-object" and `1` would
+  assert membership — neither is known, and both are worse than a missed
+  conversion. Closing this needs the #2660 M3 closure→prototype substrate.
+- **`@@hasInstance` dispatch** — unchanged, still out of scope
+  (`symbol-hasinstance-*`, 4 files).
+- **`instanceof Object` on a `$Object`** — #4276's lane, deliberately untouched
+  (`S11.8.6_A1`, and `S11.8.6_A6_T4` CHECK#3 which blocks that file regardless).
+
+### Adjacent defect found while measuring — NOT caused by this change
+
+**A bare `lhs() instanceof rhs();` expression STATEMENT is eliminated whole,
+including both operands' side effects.** Reproduced with a builtin RHS (which
+never reaches this substrate) and on base `identifiers.ts`, so it predates Slice B.
+
+It matters here because it is a *second* reason `S15.3.5.3_A2_T2/T5/T6` cannot
+pass: each spells the operator as a bare statement inside a `try` and expects the
+TypeError from it — if the statement is dropped, no tri-state can ever throw.
+Anyone attributing those three to the prototype gap alone will fix the wrong
+thing. The order-of-evaluation regression test in
+`tests/es5-standalone-instanceof.test.ts` binds its result for exactly this reason.
+
+### Instrument note for the next measurer
+
+`runTest262File`'s ORIGINAL-HARNESS lane does **not** apply
+`standaloneHostImportError` (the guard has a single call site, in the legacy
+wrapper lane). A leaking module therefore still RUNS locally with the host
+supplying the import, while CI records it as `compile_error`. A local pass/fail on
+a leaking file is an upper bound on the host answer, **not** the verdict CI
+scores. This is what makes the identical before/after answer runs above meaningful
+rather than vacuous — and it is a trap for any "these tests pass locally" claim.

--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -859,14 +859,37 @@ walked by the ordinary late-import body shifter. **Nothing is minted at finalize
 
 ### SECONDARY acceptance — rows
 
-`language/expressions/instanceof` (43 files), standalone. The before/after
-*answer* runs are **byte-identical** — every one of the 11 previously-refused
-files produces exactly the answer the host `__instanceof_check` produced. That is
-the correctness evidence: the native tri-state reproduces the host's observable
+**The 59 sole-leak files** (the directly addressable population, from the
+2026-08-15 standalone baseline where all 59 are `compile_error`
+`host_import_leak`), re-run on this branch:
+
+| after       | rows |
+| ----------- | ---: |
+| **pass**    |    4 |
+| fail        |   31 |
+| skip        |   24 |
+
+59 × `compile_error` → **4 pass**, 0 regressions (a `compile_error` cannot
+regress). The four: `built-ins/Array/fromAsync/this-constructor`,
+`built-ins/Promise/prototype/finally/subclass-species-constructor-{reject,resolve}-count`,
+`language/expressions/instanceof/S11.8.6_A2.4_T3`. The 24 skips are Temporal
+proposal files.
+
+**`language/expressions/instanceof` (43 files).** The before/after *answer* runs
+are **byte-identical** — every one of the 11 previously-refused files produces
+exactly the answer the host `__instanceof_check` produced. That is the
+correctness evidence: the native tri-state reproduces the host's observable
 behaviour on this corpus, it does not merely stop leaking.
 
-CI delta for the directory: 11 × `compile_error` → 1 `pass` + 10 `fail`,
-**0 regressions**. The one conversion is `S11.8.6_A2.4_T3`.
+(The one diff that DID appear between the two intermediate corpus runs was the
+`%TypedArray%` wrong throw described above, and the fix restored exact host
+parity there too — a single line changed back to `Expected true but got false`.)
+
+Also green on this branch: all **8 equivalence shards**
+(`scripts/equivalence-gate.mjs`, "No new equivalence regressions"), and
+`tests/es5-standalone-instanceof.test.ts` (20),
+`tests/issue-3962-native-user-instanceof.test.ts`,
+`tests/issue-4276-instanceof-object-family.test.ts`, `tests/issue-2994.test.ts`.
 
 ### Deliberately left, with reasons
 
@@ -885,6 +908,17 @@ CI delta for the directory: 11 × `compile_error` → 1 `pass` + 10 `fail`,
   (`symbol-hasinstance-*`, 4 files).
 - **`instanceof Object` on a `$Object`** — #4276's lane, deliberately untouched
   (`S11.8.6_A1`, and `S11.8.6_A6_T4` CHECK#3 which blocks that file regardless).
+- **The §13.10.2 step 1/4 TypeError for a RUNTIME non-object / non-callable RHS**
+  — see "no wrong throws" above. Statically provable cases still throw.
+
+### What is left to close this issue
+
+Slice B's substrate is in place; the issue stays `in-progress` because the
+closure arm is still conservative. The one dependency is a **runtime edge from a
+closure value to its prototype object** (#2660 M3). With it, the
+`ownedPrototypeOrdinaryHasInstance` arm applies unchanged to closures and the
+`S15.3.5.3_A2_*` / `_A3_*` family becomes answerable — modulo the
+expression-statement elimination below, which must be fixed too.
 
 ### Adjacent defect found while measuring — NOT caused by this change
 

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -47,6 +47,7 @@ import { reportSilentFallback } from "../fallback-telemetry.js";
 import { annexBReadEscapesFunctionScope, annexBReadIsUnbound, collectAnnexBCancelSites } from "../annexb-cancel.js";
 import { emitAnnexBUnboundReferenceError } from "../js-errors.js";
 import { resolveBuiltinCtorAliasName, tryEmitNonCallableRhsThrow } from "../native-ordinary-instanceof.js";
+import { tryEmitNativeDynamicInstanceOf } from "../native-dynamic-instanceof.js";
 import { isObjectFamilyCtorName, tryEmitNativeObjectFamilyInstanceOf } from "../native-object-family-instanceof.js";
 import { emitTaCtorValue } from "../dataview-native.js";
 import { taCtorKindOf } from "../registry/types.js";
@@ -1713,6 +1714,19 @@ function emitDynamicInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
   // throws. Declines (null) in gc/host mode — see native-ordinary-instanceof.ts.
   const nonCallableThrow = tryEmitNonCallableRhsThrow(ctx, fctx, expr);
   if (nonCallableThrow) return nonCallableThrow;
+
+  // (#2916 Slice B) Host-free §13.10.2 + §7.3.20 for the fully-dynamic RHS.
+  // Returns the SAME 0/1/2 tri-state `__instanceof_check` did, so the throw
+  // guard below is reused unchanged. Declines (null) in gc/host mode — that lane
+  // keeps the host predicate byte-identically. See native-dynamic-instanceof.ts
+  // for the per-representation answer table and the documented residual (a
+  // closure RHS has no runtime edge to its prototype object, so it answers
+  // `false` rather than guessing).
+  const nativeDynamic = tryEmitNativeDynamicInstanceOf(ctx, fctx, expr);
+  if (nativeDynamic) {
+    emitInstanceofThrowGuard(ctx, fctx);
+    return nativeDynamic;
+  }
 
   // (#2702) `__instanceof_check` implements §13.10.2 InstanceofOperator +
   // §7.3.20 OrdinaryHasInstance and returns a tri-state (0/1/2) so the

--- a/src/codegen/native-dynamic-instanceof.ts
+++ b/src/codegen/native-dynamic-instanceof.ts
@@ -1,0 +1,403 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2916 Slice B) The host-free substrate for the FULLY-DYNAMIC `instanceof`
+ * right-hand side under `--target standalone` / `--target wasi`.
+ *
+ * ## The leak this closes
+ *
+ * `emitDynamicInstanceOf` (identifiers.ts) is the residual arm for an RHS whose
+ * constructor identity is NOT knowable at compile time — an `any`-typed local, a
+ * function-valued parameter, a property access, a call result, a comma
+ * expression. Every static rule ahead of it (the #2998 primitive-LHS fold, the
+ * #2916 non-callable-RHS throw, the builtin-alias rewrite, #3962's user-fnctor
+ * arm, Slice A's builtin membership) declines there by construction, so the arm
+ * fell through to `ensureLateImport(ctx, "__instanceof_check", …)` and emitted
+ * `env::__instanceof_check`. A host-free binary cannot satisfy that import, so
+ * the module does not instantiate and the #2961 leak guard refuses the test.
+ *
+ * Measured on the 2026-08-15 standalone baseline: **59 files name
+ * `env::__instanceof_check` as their SOLE host import** and **1,560 name it at
+ * all**. It is the single import standing between ordinary `instanceof` code and
+ * a genuinely host-free module — which is the deliverable here. Conformance rows
+ * are the secondary metric (see the issue's tiering).
+ *
+ * ## What the runtime can actually decide, and what it cannot
+ *
+ * The helper is a DEFINED function, so every question it asks must be answerable
+ * from the VALUE. Three classifiers already exist and are shared rather than
+ * re-derived here (a second, silently-diverging copy is the hazard
+ * `closure-classifier.ts` was created to end):
+ *
+ *  - `__typeof_function` — IsCallable. Finalize-corrected
+ *    (`typeof-natives-finalize.ts`), so it sees EVERY closure root registered
+ *    anywhere in the module plus the #4120 `OBJ_FLAG_CALLABLE`-branded builtin
+ *    constructor carriers. Calling it instead of snapshotting
+ *    `closureInfoByTypeIdx` at build time is what makes this helper immune to
+ *    the order-dependence that #4276 documents for a membership list.
+ *  - `__typeof_object` / `__typeof_undefined` — Type(V) is Object, and the
+ *    `undefined` singleton (#2106 S1).
+ *  - `__isPrototypeOf` — the §7.3.20 step 6/7 chain walk over `$Object.$proto`
+ *    with `ref.eq` per level (object-runtime-prototype.ts). ONE walk, shared
+ *    with #3962 and Slice C; no parallel `[[Prototype]]` mechanism.
+ *
+ * What it cannot decide is `Get(C, "prototype")` for a **closure**: a standalone
+ * function value is a WasmGC closure-wrapper struct, and its prototype object
+ * lives in a per-fnctor module GLOBAL keyed by the COMPILE-TIME symbol name
+ * (`fnctor-prototype.ts`). There is no runtime edge from the closure value to
+ * that global. Verified by probe on this branch: a dynamic `k["prototype"]` read
+ * off a function value answers `undefined` for a `function` declaration, a
+ * `var F = function(){}` and a `class` alike.
+ *
+ * ## The answers, and why each is the least-wrong one available
+ *
+ * The tri-state is the one `emitInstanceofThrowGuard` already consumes: 0 false,
+ * 1 true, 2 throw a wasm-level TypeError.
+ *
+ * | RHS at runtime                                 | answer       | why                                                                                                       |
+ * | ---------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------- |
+ * | `null` / `undefined`                           | 0            | host dynamic-path parity (`runtime.ts:2353`). This backend still lowers some `Function(a,b)` forms to null, and `primitive instanceof FACTORY` must stay `false`, not throw (`S15.3.5.3_A1_T1…T8`). |
+ * | callable, OWNS a `prototype` property          | full §7.3.20 | an own-property read on a real `$Object` is authoritative: a present-but-non-object `prototype` is genuinely the program's state ⇒ 2, otherwise the chain walk decides. |
+ * | callable, no modelled `prototype`              | 0            | **documented residual**, see below.                                                                        |
+ * | anything else (incl. genuine primitives)       | 0            | there is no SOUND runtime primitive test in this backend — see the "no wrong throws" section.               |
+ *
+ * ### The residual, stated plainly
+ *
+ * `obj instanceof FACTORY` where `FACTORY` holds a runtime closure answers
+ * **`false`, not the spec's true/TypeError** — `S15.3.5.3_A2_T2/T5/T6` (which
+ * want a TypeError for a non-object `F.prototype`) and `_A3_T1/T2` (which want a
+ * chain-walk `true`) keep failing. That is deliberate. Both alternatives are
+ * WORSE: answering `2` asserts "F.prototype really is a non-object", and
+ * answering `1` asserts membership — neither is known. A missed conversion is a
+ * missed conversion; a wrong `true` passes a test vacuously and a wrong throw is
+ * observable in a `catch`. Closing it needs a runtime closure→prototype edge
+ * (the #2660 M3 substrate), not this module.
+ *
+ * ### No wrong throws — the second thing this module measured and changed
+ *
+ * §13.10.2 steps 1/4 mandate a TypeError for a non-object / non-callable RHS,
+ * and the first cut emitted one whenever the target was not classifiable as an
+ * object. That is unsound HERE, because an unmodelled builtin constructor is
+ * lowered to a boxed-primitive carrier: the shared classifiers answer
+ * `typeof Int8Array === "boolean"` (probe-verified on this branch). So every
+ * "is the target a primitive" predicate built on them mistakes a real
+ * constructor for a primitive. Measured consequence:
+ * `typedArray instanceof TypedArray` threw "Right-hand side of 'instanceof' is
+ * not callable" where the host predicate answers `false`
+ * (`built-ins/TypedArrayConstructors/ctors/object-arg/iterator-is-null-as-array-like.js`).
+ *
+ * Nothing PROVABLE was lost by dropping it: a statically-primitive RHS and a
+ * provably non-callable object RHS both still throw at codegen, one dispatch
+ * step earlier, where the evidence is the static TYPE rather than a runtime
+ * representation the backend gets wrong.
+ *
+ * ## Why this cannot regress a passing test
+ *
+ * The arm runs ONLY under `noJsHost`, and ONLY where the code it replaces
+ * emitted `env::__instanceof_check`. Under the authoritative measurement (the CI
+ * worker / `scripts/test262-worker.mjs`, which applies `standaloneHostImportError`)
+ * every reaching test is already a `compile_error`: a leaking module never
+ * instantiates. So a native answer can only CONVERT such a test, never turn a
+ * passing one into a failure. The JS-host lane never enters this module and is
+ * byte-identical.
+ *
+ * NOTE for anyone re-measuring locally: `runTest262File`'s ORIGINAL-HARNESS lane
+ * does NOT apply that guard, so a leaking module still runs there with the host
+ * supplying the import. A local pass/fail on a leaking file is therefore an
+ * upper bound on the host answer, NOT the lane CI scores.
+ *
+ * ## Index-space discipline
+ *
+ * The helper is minted with `mintDefinedFunc` (a STABLE handle — no shifter
+ * touches it, `resolveLayout` resolves it once at emit) and pushed in the same
+ * call, so its baked callee indices are walked by the late-import body shifter
+ * like any other defined function. Nothing is minted at finalize (the #4221
+ * hazard); the only finalize-time correction it depends on is a BODY rewrite of
+ * `__typeof_function`, which changes no index at all.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { ts } from "../ts-api.js";
+import { OBJ_FLAG_CALLABLE } from "./builtin-callable-brand.js";
+import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { noJsHost } from "./js-errors.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { ensureObjectRuntime } from "./object-runtime.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { addFuncType } from "./registry/types.js";
+import { coerceType, compileExpression } from "./shared.js";
+
+const EXTERNREF: ValType = { kind: "externref" };
+const I32: ValType = { kind: "i32" };
+
+/** `__instanceof_dynamic(value, target) -> i32` — the 0/1/2 tri-state helper. */
+const HELPER_NAME = "__instanceof_dynamic";
+
+/** Param / local slots of the helper body. */
+const P_VALUE = 0;
+const P_TARGET = 1;
+const L_TARGET_ANY = 2;
+const L_PROTO = 3;
+
+/**
+ * Register (once) the native `__instanceof_dynamic` helper and return its stable
+ * function handle, or `undefined` when the standalone substrate it needs is
+ * unavailable — in which case the caller MUST keep its existing lowering rather
+ * than emit a partial answer.
+ */
+function ensureDynamicInstanceOfHelper(ctx: CodegenContext): number | undefined {
+  const existing = ctx.funcMap.get(HELPER_NAME);
+  if (existing !== undefined) return existing;
+
+  // Every callee must be registered BEFORE the body bakes its index. Under
+  // `noJsHost` each of these routes to a DEFINED function (no `env::` import is
+  // added), so this registration cannot itself shift the index space.
+  ensureObjectRuntime(ctx);
+  const typeofFunctionIdx = ensureLateImport(ctx, "__typeof_function", [EXTERNREF], [I32]);
+  const typeofObjectIdx = ensureLateImport(ctx, "__typeof_object", [EXTERNREF], [I32]);
+  const typeofUndefinedIdx = ensureLateImport(ctx, "__typeof_undefined", [EXTERNREF], [I32]);
+  const externGetIdx = ensureLateImport(ctx, "__extern_get", [EXTERNREF, EXTERNREF], [EXTERNREF]);
+  const isProtoOfIdx = ensureLateImport(ctx, "__isPrototypeOf", [EXTERNREF, EXTERNREF], [I32]);
+  const hasOwnIdx = ensureLateImport(ctx, "__hasOwnProperty", [EXTERNREF, EXTERNREF], [I32]);
+  // The four POSITIVE primitive classifiers. The throw arm needs proof that the
+  // target IS a primitive, not the absence of proof that it is an object — see
+  // `isProvenPrimitive` below.
+  const primitiveIdxs = (["__typeof_number", "__typeof_string", "__typeof_boolean", "__typeof_bigint"] as const).map(
+    (n) => ensureLateImport(ctx, n, [EXTERNREF], [I32]),
+  );
+  flushLateImportShifts(ctx, null);
+
+  const objectTypeIdx = ctx.objectRuntimeTypes?.objectTypeIdx;
+  if (
+    typeofFunctionIdx === undefined ||
+    typeofObjectIdx === undefined ||
+    typeofUndefinedIdx === undefined ||
+    externGetIdx === undefined ||
+    isProtoOfIdx === undefined ||
+    hasOwnIdx === undefined ||
+    objectTypeIdx === undefined ||
+    primitiveIdxs.some((i) => i === undefined)
+  ) {
+    return undefined;
+  }
+
+  /** `slot` is an OBJECT value (§7.3.20's Type(x) is Object) — closures included. */
+  const isObjectValue = (slot: number): Instr[] => [
+    { op: "local.get", index: slot },
+    { op: "call", funcIdx: typeofObjectIdx },
+    { op: "local.get", index: slot },
+    { op: "call", funcIdx: typeofFunctionIdx },
+    { op: "i32.or" },
+  ];
+  /** `slot` is `null` or the `undefined` singleton. */
+  const isNullish = (slot: number): Instr[] => [
+    { op: "local.get", index: slot },
+    { op: "ref.is_null" },
+    { op: "local.get", index: slot },
+    { op: "call", funcIdx: typeofUndefinedIdx },
+    { op: "i32.or" },
+  ];
+  /**
+   * `slot` is PROVABLY a primitive — number / string / boolean / bigint.
+   *
+   * Deliberately positive. The first cut inferred "primitive" from
+   * `__typeof_object(slot) === 0`, which is NOT the same claim: that native
+   * answers 0 for anything it does not model, so an intrinsic the classifiers do
+   * not recognise read as a primitive and the operator threw where the spec (and
+   * the host predicate) answer `false`. Measured on
+   * `built-ins/TypedArrayConstructors/ctors/object-arg/iterator-is-null-as-array-like.js`,
+   * whose `typedArray instanceof TypedArray` (the `%TypedArray%` intrinsic
+   * reached through `Object.getPrototypeOf(Int8Array)`) turned into
+   * "Right-hand side of 'instanceof' is not callable". A wrong THROW is
+   * observable in a `catch`; an unproven case must fall to the conservative
+   * `false` instead.
+   */
+  const isProvenPrimitive = (slot: number): Instr[] => {
+    const out: Instr[] = [
+      { op: "local.get", index: slot },
+      { op: "call", funcIdx: primitiveIdxs[0]! },
+    ];
+    for (const idx of primitiveIdxs.slice(1)) {
+      out.push({ op: "local.get", index: slot }, { op: "call", funcIdx: idx! }, { op: "i32.or" });
+    }
+    return out;
+  };
+  const returnConst = (value: number): Instr[] => [{ op: "i32.const", value }, { op: "return" }];
+
+  addStringConstantGlobal(ctx, "prototype");
+
+  // §7.3.20 steps 4–7 for a target that OWNS a `prototype` property.
+  //
+  // The own-property gate is load-bearing, not a micro-optimisation. `Get`
+  // returning nothing has TWO causes that the spec treats oppositely: the
+  // program really set `F.prototype = undefined` (§7.3.20 step 5 ⇒ TypeError),
+  // or this backend simply does not model a `prototype` on that carrier
+  // (⇒ nothing is known). `__hasOwnProperty` separates them. Measured without
+  // it: `typedArray instanceof TypedArray` — the `%TypedArray%` intrinsic
+  // reached through `Object.getPrototypeOf(Int8Array)`, a callable carrier with
+  // no modelled `prototype` — threw "Right-hand side of 'instanceof' is not
+  // callable" where the host predicate answers `false`
+  // (`built-ins/TypedArrayConstructors/ctors/object-arg/iterator-is-null-as-array-like.js`).
+  //
+  // A non-object P is likewise refused only when PROVABLY primitive, for the
+  // same reason as `isProvenPrimitive`: an unrecognised P is simply not in V's
+  // chain, and the walk already answers 0 for a non-`$Object`.
+  const ownedPrototypeOrdinaryHasInstance: Instr[] = [
+    { op: "local.get", index: P_TARGET },
+    ...stringConstantExternrefInstrs(ctx, "prototype"),
+    { op: "call", funcIdx: hasOwnIdx },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: returnConst(0) },
+    { op: "local.get", index: P_TARGET },
+    ...stringConstantExternrefInstrs(ctx, "prototype"),
+    { op: "call", funcIdx: externGetIdx },
+    { op: "local.set", index: L_PROTO },
+    ...isNullish(L_PROTO),
+    ...isProvenPrimitive(L_PROTO),
+    { op: "i32.or" },
+    { op: "if", blockType: { kind: "empty" }, then: returnConst(2) },
+    { op: "local.get", index: L_PROTO },
+    { op: "local.get", index: P_VALUE },
+    { op: "call", funcIdx: isProtoOfIdx },
+    { op: "return" },
+  ];
+
+  const body: Instr[] = [
+    // §13.10.2 step 1, with the host dynamic path's ONE documented divergence:
+    // null / undefined answer `false` instead of throwing, because this backend
+    // still lowers some `Function(params, body)` forms to null and
+    // `primitive instanceof FACTORY` must stay `false` (S15.3.5.3_A1_T1…T8).
+    ...isNullish(P_TARGET),
+    { op: "if", blockType: { kind: "empty" }, then: returnConst(0) },
+
+    // IsCallable(C) — the shared, finalize-corrected classifier.
+    { op: "local.get", index: P_TARGET },
+    { op: "call", funcIdx: typeofFunctionIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        // §7.3.20 step 3: Type(V) is not Object → false, BEFORE any prototype
+        // read. Order matters: a primitive V must not fire a `prototype`
+        // accessor nor throw on a non-object prototype (#2702).
+        ...isNullish(P_VALUE),
+        { op: "if", blockType: { kind: "empty" }, then: returnConst(0) },
+        ...isObjectValue(P_VALUE),
+        { op: "i32.eqz" },
+        { op: "if", blockType: { kind: "empty" }, then: returnConst(0) },
+        // A #4120-branded builtin constructor carrier is a real `$Object`, so
+        // its `prototype` own property is an authoritative read. Tested by
+        // reading the brand bit DIRECTLY rather than through
+        // `buildBuiltinBrandTestArm`, whose emptiness depends on whether any
+        // carrier had been branded YET at build time — an order dependence this
+        // helper must not inherit (it is minted at the first dynamic-instanceof
+        // site, which can precede every carrier).
+        { op: "local.get", index: P_TARGET },
+        { op: "any.convert_extern" },
+        { op: "local.set", index: L_TARGET_ANY },
+        { op: "local.get", index: L_TARGET_ANY },
+        { op: "ref.test", typeIdx: objectTypeIdx },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: L_TARGET_ANY },
+            { op: "ref.cast", typeIdx: objectTypeIdx },
+            { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
+            { op: "i32.const", value: OBJ_FLAG_CALLABLE },
+            { op: "i32.and" },
+            { op: "if", blockType: { kind: "empty" }, then: ownedPrototypeOrdinaryHasInstance },
+          ],
+        },
+        // Callable, but its `[[Prototype]]` source is a per-fnctor compile-time
+        // global with no runtime edge from the value — see the module header's
+        // "residual". Conservative `false`, never a wrong `true` or a wrong throw.
+        ...returnConst(0),
+      ],
+    },
+
+    // NOT CALLABLE ⇒ conservative `false`. §13.10.2 steps 1/4 say TypeError, and
+    // this arm deliberately does not emit one. Three independent reasons, each
+    // sufficient on its own:
+    //
+    //  1. **There is no sound runtime primitive test here.** An unmodelled
+    //     builtin constructor is lowered to a boxed-primitive carrier, so the
+    //     shared classifiers answer `typeof Int8Array === "boolean"`
+    //     (probe-verified on this branch). Every "is C a primitive" predicate
+    //     built on them therefore mistakes a real constructor for a primitive.
+    //     The first cut did throw here and turned `typedArray instanceof
+    //     TypedArray` into "Right-hand side of 'instanceof' is not callable"
+    //     where the host predicate answers `false`
+    //     (`built-ins/TypedArrayConstructors/ctors/object-arg/iterator-is-null-as-array-like.js`).
+    //  2. **Class VALUES are `typeof "object"`** in this backend, so a blanket
+    //     "not callable ⇒ TypeError" would turn `x instanceof C` — a legitimate
+    //     true/false — into a spurious, catchable TypeError. Host dynamic-path
+    //     parity (`runtime.ts:2400` keeps exactly this conservatism).
+    //  3. A wrong THROW is observable in a `catch` and passes/fails tests for
+    //     the wrong reason; a wrong `false` is a missed conversion.
+    //
+    // Nothing that is PROVABLE is lost: a statically-primitive RHS and a
+    // provably non-callable object RHS both still throw at codegen, one dispatch
+    // step earlier (`compileHostInstanceOf`'s §13.10.2-step-1 fold and
+    // `tryEmitNonCallableRhsThrow`), where the evidence is the static type
+    // rather than a representation the backend gets wrong.
+    { op: "i32.const", value: 0 },
+  ];
+
+  const typeIdx = addFuncType(ctx, [EXTERNREF, EXTERNREF], [I32]);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set(HELPER_NAME, funcIdx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: HELPER_NAME,
+    typeIdx,
+    locals: [
+      { name: "targetAny", type: { kind: "anyref" } },
+      { name: "proto", type: { kind: "externref" } },
+    ],
+    body,
+    exported: false,
+  });
+  return funcIdx;
+}
+
+/**
+ * Emit `expr.left instanceof expr.right` for a fully-dynamic RHS as a host-free
+ * i32 TRI-STATE (0 / 1 / 2) — the caller runs `emitInstanceofThrowGuard` over
+ * it exactly as it did for `env::__instanceof_check`. Returns `null` to decline,
+ * in which case the caller keeps its existing (host-import) lowering.
+ *
+ * Both operands are compiled in source order (§13.10.1 evaluates
+ * RelationalExpression then ShiftExpression), so side effects, a RHS
+ * ReferenceError and accessor throws are preserved.
+ */
+export function tryEmitNativeDynamicInstanceOf(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+): ValType | null {
+  if (!noJsHost(ctx)) return null;
+  // Reserve the helper (and everything it calls) BEFORE either operand is
+  // compiled, so any index shift it triggers reaches the already-emitted
+  // instructions through `currentFunc`.
+  const helperIdx = ensureDynamicInstanceOfHelper(ctx);
+  if (helperIdx === undefined) return null;
+  flushLateImportShifts(ctx, fctx);
+
+  const leftType = compileExpression(ctx, fctx, expr.left);
+  if (!leftType) {
+    fctx.body.push({ op: "ref.null.extern" });
+  } else if (leftType.kind !== "externref") {
+    coerceType(ctx, fctx, leftType, EXTERNREF);
+  }
+
+  const rightType = compileExpression(ctx, fctx, expr.right);
+  if (!rightType) {
+    fctx.body.push({ op: "ref.null.extern" });
+  } else if (rightType.kind !== "externref") {
+    coerceType(ctx, fctx, rightType, EXTERNREF);
+  }
+
+  // Re-read the handle: compiling the operands may have registered helpers.
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get(HELPER_NAME) ?? helperIdx });
+  return { kind: "i32" };
+}

--- a/tests/es5-standalone-instanceof.test.ts
+++ b/tests/es5-standalone-instanceof.test.ts
@@ -75,27 +75,36 @@ describe("#2916 — host-free instanceof in standalone", () => {
     // `interface Function` with NO call signature, so a naive
     // "no signatures ⇒ not callable" test would emit an unconditional TypeError
     // for a real function value — a WRONG answer, not a missed conversion.
-    // The observable proof that the rule DECLINED is that the shape keeps the
-    // documented-not-covered host predicate (a runtime `.prototype` read off an
-    // arbitrary callable is not modelled yet), rather than becoming a throw.
-    const compiled = await compile(
-      `var f: Function = function(){};\nvar obj = {};\nexport function test(): number { return (obj instanceof (f as any)) ? 1 : 0; }\n`,
-      { allowJs: true, fileName: "fn-typed-rhs.ts", skipSemanticDiagnostics: true, target: "standalone" },
+    //
+    // The observable used to be the PRESENCE of `env::__instanceof_check`,
+    // i.e. exactly the leak #2916 Slice B retires. Same property, stated by the
+    // ANSWER instead: the operator evaluates to `false` (the documented residual
+    // for a closure RHS whose prototype object has no runtime edge) rather than
+    // throwing, and the binary is host-free.
+    const o = await run(
+      `var f: Function = function(){};\nvar obj = {};\n` +
+        `try { result = (obj instanceof (f as any)) ? 1 : 0; } catch (e) { result = 9; }`,
     );
-    expect(compiled.success).toBe(true);
-    const imports = (compiled.imports ?? []).map((i) => `${i.module}::${i.name}`);
-    expect(imports, "a Function-typed RHS must not be treated as non-callable").toContain("env::__instanceof_check");
+    expect(o.result, "a Function-typed RHS must not be treated as non-callable").toBe(0);
+    expect(o.imports).toEqual([]);
   });
 
   // The `S15.3.5.3_A1_T1…T8` RHS shape — a binding holding a `Function(…)`
   // value. Those tests run their RHS through the runtime-eval interpreter, so
-  // they cannot be executed here; the COMPILE-LEVEL property that keeps them
-  // correct is checkable instead. The §7.3.20-step-1 rule must DECLINE, leaving
-  // the host predicate in place — a `new Function(…)` initializer must never be
-  // mistaken for the "fresh ordinary object" it syntactically resembles. If the
-  // rule ever fired here it would emit an unconditional TypeError where the spec
-  // requires a plain `false`, and the failure would surface ONLY in a lane with
-  // the interpreter tier linked (`TEST262_FULL_RUNTIME_EVAL=1`).
+  // they cannot be executed here (a bare `WebAssembly.instantiate` has no
+  // `js2wasm:runtime-eval` module to link); the COMPILE-LEVEL property that
+  // keeps them correct is checkable instead. The §7.3.20-step-1 rule must
+  // DECLINE — a `new Function(…)` initializer must never be mistaken for the
+  // "fresh ordinary object" it syntactically resembles. If the rule ever fired
+  // here it would emit an unconditional TypeError where the spec requires a
+  // plain `false`, and the failure would surface ONLY in a lane with the
+  // interpreter tier linked (`TEST262_FULL_RUNTIME_EVAL=1`).
+  //
+  // The evidence is that the operator still routes to the §13.10.2 evaluator —
+  // `__instanceof_dynamic`, whose name survives into the WAT whether or not the
+  // inliner folds it into the caller. A fired rule emits an unconditional throw
+  // and never reaches that helper at all. (The pre-Slice-B spelling of this same
+  // evidence was "the host import is still there", which the substrate removed.)
   //
   // The LHS is an OBJECT on purpose: the upstream files spell it `1 instanceof
   // FACTORY`, which the #2998 statically-primitive-LHS fold answers `false`
@@ -109,13 +118,21 @@ describe("#2916 — host-free instanceof in standalone", () => {
     it(`declines the non-callable rule for an RHS ${name}`, async () => {
       const compiled = await compile(
         `${decl}\nvar obj = {};\nexport function test(): number { return (obj instanceof (FACTORY as any)) ? 1 : 0; }\n`,
-        { allowJs: true, fileName: "fnctor-rhs.ts", skipSemanticDiagnostics: true, target: "standalone" },
+        {
+          allowJs: true,
+          fileName: "fnctor-rhs.ts",
+          skipSemanticDiagnostics: true,
+          target: "standalone",
+          emitWat: true,
+        },
       );
       expect(compiled.success, compiled.errors.map((e) => e.message).join("; ")).toBe(true);
       const imports = (compiled.imports ?? []).map((i) => `${i.module}::${i.name}`);
-      expect(imports, "a Function(…)-valued RHS must not be treated as non-callable").toContain(
-        "env::__instanceof_check",
-      );
+      expect(imports, "the dynamic-RHS operator must stay host-free").toEqual([]);
+      expect(
+        (compiled as { wat?: string }).wat ?? "",
+        "a Function(…)-valued RHS must not be treated as non-callable",
+      ).toContain("instanceof_dynamic");
     });
   }
 
@@ -131,6 +148,123 @@ describe("#2916 — host-free instanceof in standalone", () => {
     // The alias rewrite must never capture a USER constructor (its `typeof F`
     // type is not an `XConstructor` interface) — #3962's native answer stands.
     const o = await run(`function F(){ this.x = 1; }\nvar f = new F();\nresult = (f instanceof F) ? 1 : 0;`);
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+});
+
+/**
+ * (#2916 Slice B) The fully-dynamic RHS substrate — `native-dynamic-instanceof.ts`.
+ *
+ * Every case here reaches `emitDynamicInstanceOf` (no static rule can resolve
+ * the RHS), which used to be the sole remaining `env::__instanceof_check` site.
+ * Each asserts BOTH halves: the answer AND a zero-import binary.
+ *
+ * The `as any` on the RHS is load-bearing — it is what defeats every
+ * compile-time classification (the primitive-RHS throw, the builtin-alias
+ * rewrite, #3962's user-fnctor arm) and forces the dynamic path.
+ */
+describe("#2916 Slice B — fully-dynamic instanceof RHS, host-free", () => {
+  it("answers a runtime-null RHS `false` rather than throwing", async () => {
+    // Host dynamic-path parity (`runtime.ts:2353`). This backend still lowers
+    // some `Function(params, body)` forms to null, and `S15.3.5.3_A1_T1…T8`
+    // require `primitive instanceof FACTORY === false`, not a TypeError.
+    const o = await run(
+      `var C: any = null;\nvar obj: any = {};\n` +
+        `try { result = (obj instanceof C) ? 1 : 0; } catch (e) { result = 9; }`,
+    );
+    expect(o.result).toBe(0);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("does NOT throw for a RUNTIME-primitive RHS, even though §13.10.2 step 1 says TypeError", async () => {
+    // Pinned as a deliberate divergence, not an oversight. There is no sound
+    // runtime primitive test in this backend: an unmodelled builtin constructor
+    // is lowered to a boxed-primitive carrier, so the shared classifiers answer
+    // `typeof Int8Array === "boolean"` — see the sibling assertion below. A
+    // throw arm built on them mistakes real constructors for primitives, which
+    // is a WRONG answer observable in a `catch`; a conservative `false` is only
+    // a missed conversion.
+    //
+    // The provable cases are unaffected: a statically-primitive RHS still throws
+    // at codegen (asserted by the `S11.8.6_A6_*` family and #2702's tests).
+    const o = await run(
+      `var C: any = 42;\nvar obj: any = {};\n` +
+        `try { result = (obj instanceof C) ? 1 : 0; } catch (e) { result = 9; }`,
+    );
+    expect(o.result).toBe(0);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("does NOT throw for a builtin constructor reached dynamically", async () => {
+    // The measured wrong-throw that removed the arm above:
+    // `built-ins/TypedArrayConstructors/ctors/object-arg/iterator-is-null-as-array-like.js`
+    // answered "Right-hand side of 'instanceof' is not callable" where the host
+    // predicate answers `false`. `Int8Array`'s bare value classifies as
+    // `typeof "boolean"` standalone (a separate representation gap), so this
+    // shape is the direct regression pin for it.
+    const o = await run(
+      `var C: any = Int8Array;\nvar a: any = new Int8Array(2);\n` +
+        `try { result = (a instanceof C) ? 1 : 0; } catch (e) { result = 9; }`,
+    );
+    expect(o.result, "a dynamically-reached builtin constructor must not throw").not.toBe(9);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("answers a primitive LHS `false` before reading the RHS prototype (§7.3.20 step 3)", async () => {
+    // Step 3 precedes step 4, so a primitive V short-circuits WITHOUT the
+    // `prototype` read — the ordering #2702 documents. Both operands are `any`
+    // so neither static fold applies.
+    const o = await run(
+      `var C: any = function(){};\nvar v: any = 7;\n` +
+        `try { result = (v instanceof C) ? 1 : 0; } catch (e) { result = 9; }`,
+    );
+    expect(o.result).toBe(0);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("answers a callable RHS with an unmodelled prototype `false`, never a throw", async () => {
+    // THE DOCUMENTED RESIDUAL. A standalone closure has no runtime edge to its
+    // per-fnctor prototype global, so §7.3.20 step 4 is unanswerable. Both
+    // alternatives are worse than `false`: `1` asserts membership and `2`
+    // asserts "F.prototype really is a non-object" — neither is known.
+    const o = await run(
+      `function F(){ this.x = 1; }\nvar C: any = F;\nvar f: any = new F();\n` +
+        `try { result = (f instanceof C) ? 1 : 0; } catch (e) { result = 9; }`,
+    );
+    expect(o.result).toBe(0);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("does NOT throw for a non-callable GC struct of unknown callability", async () => {
+    // Class VALUES are `typeof "object"` in this backend, so a blanket
+    // "not callable ⇒ TypeError" would turn `x instanceof C` — a legitimate
+    // true/false — into a spurious catchable TypeError. Host parity
+    // (`runtime.ts:2400`). The provably-non-callable cases still throw, one
+    // dispatch step earlier, via `tryEmitNonCallableRhsThrow` (asserted above).
+    const o = await run(
+      `class K { m(): number { return 1; } }\nvar C: any = K;\nvar obj: any = new K();\n` +
+        `try { result = (obj instanceof C) ? 1 : 0; } catch (e) { result = 9; }`,
+    );
+    expect(o.result).not.toBe(9);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("evaluates BOTH operands, in source order, before answering (§13.10.1)", async () => {
+    // The tri-state replaced a two-argument host call, so operand order is a
+    // property of the emitter, not of the helper. A RHS-first evaluation would
+    // read `order` as "RL".
+    //
+    // The result is BOUND on purpose. A bare `lhs() instanceof rhs();`
+    // expression statement is dropped whole — including both calls' side
+    // effects — by a statement-level elimination that predates this substrate
+    // (reproduced on a builtin RHS, which never reaches this code). Binding it
+    // isolates the property under test from that separate defect.
+    const o = await run(
+      `var order = "";\nfunction lhs(): any { order = order + "L"; return {}; }\n` +
+        `function rhs(): any { order = order + "R"; return null; }\n` +
+        `var q: any = lhs() instanceof rhs();\nresult = order === "LR" ? 1 : 0;`,
+    );
     expect(o.result).toBe(1);
     expect(o.imports).toEqual([]);
   });


### PR DESCRIPTION
## Description

Wave 4 of the #4426 ES5-standalone campaign (after #4527, #4530, #4532): the #2916 Slice B substrate. New `src/codegen/native-dynamic-instanceof.ts` — a DEFINED tri-state helper `__instanceof_dynamic(externref, externref) -> i32` implementing §13.10.2 InstanceofOperator + §7.3.20 OrdinaryHasInstance for a fully-dynamic RHS — dispatched in `emitDynamicInstanceOf` before the `ensureLateImport("__instanceof_check", …)` fall-through that leaked an unsatisfiable host import under `--target standalone`.

Measured on the branch (full writeup + corpus ledger appended to `plan/issues/2916-…md`):
- `language/expressions/instanceof`: **11 leaking files → 0**; the 59-file corpus naming `env::__instanceof_check` as its SOLE host import: 0 leaking, 0 compile-refused, 0 invalid Wasm; 4 immediate fail→pass flips including `S11.8.6_A2.4_T3`.
- Before/after answer runs over the instanceof directory are byte-identical — the native tri-state reproduces the host predicate's behaviour rather than merely dropping the import.
- gc/host lane **byte-identical** (sha256 A/B over 10 shapes).
- All 8 equivalence shards: no new regressions; instanceof-family unit suites 84/84 on the integrated branch.

Two findings recorded for follow-up in the issue file: unmodelled builtin constructors lower to boxed-primitive carriers (`typeof Int8Array === "boolean"` standalone — a trap for any runtime callable-predicate; the unsound step-1 TypeError arm this implied was caught by the corpus sweep and removed), and a pre-existing DCE bug that deletes bare `lhs() instanceof rhs();` expression statements with their side effects (now filed as #4433, in progress). Deliberate residual: a closure RHS answers `false` pending #2660 M3 (no runtime edge from a function value to its fnctor-prototype global); `@@hasInstance` and `instanceof Object` stay in #4276's lane.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_