### PR TITLE
fix(codegen): vec index-domain + sparse-tail reads — dynamic MOP no longer traps on presized arrays (#4434)

### DIFF
--- a/plan/issues/4434-vec-index-domain-and-sparse-tail.md
+++ b/plan/issues/4434-vec-index-domain-and-sparse-tail.md
@@ -12,6 +12,12 @@ horizon: m
 feasibility: hard
 reasoning_effort: max
 task_type: bug
+coercion-sites-allow:
+  # New CALL SITES of the existing engine helpers (number_toString /
+  # __str_to_number) for index-key canonicalization in the sparse-tail MOP
+  # arms — no fresh coercion matrix; both delegate to the #1917 engine.
+  - src/codegen/vec-index-domain.ts
+  - src/codegen/vec-overlay.ts
 area: codegen, standalone
 language_feature: arrays, array-length, property-descriptors
 es_edition: 5

--- a/plan/issues/4434-vec-index-domain-and-sparse-tail.md
+++ b/plan/issues/4434-vec-index-domain-and-sparse-tail.md
@@ -1,0 +1,228 @@
+---
+id: 4434
+title: "SOUNDNESS: the vec sparse tail traps every dynamic MOP chokepoint (`a.length = 3; a[1]` is an uncatchable abort), and a 2^32 key is stored as array index 0"
+status: done
+completed: 2026-08-15
+assignee: ttraenkler/claude-es5-standalone
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen, standalone
+language_feature: arrays, array-length, property-descriptors
+es_edition: 5
+goal: standalone-mode
+related: [3251, 3225, 4159, 4222, 3984, 4062, 2001, 4197]
+origin: "ES5-standalone defineProperty-on-array-receivers family measurement, 2026-08-15"
+# (#3102 LOC ratchet) The substance of this change-set is the NEW subsystem
+# module src/codegen/vec-index-domain.ts (the exact overflow guard, the
+# CanonicalNumericIndexString predicate, the sparse-tail bound). What lands in
+# vec-overlay.ts is the per-carrier `vecBackedLen` emitter and its three
+# consumers, and those cannot move: `array.len(data)` is not readable through
+# the `$__vec_base` supertype, so the emitter has to enumerate `carriers`, the
+# per-carrier whitelist that `fillVecOverlayHelpers` privately owns. Exporting
+# `carriers` to a sibling module would export the overlay's carrier policy —
+# a larger and more fragile surface than the ~90 emitted lines it would save.
+loc-budget-allow:
+  - src/codegen/vec-overlay.ts
+# Same reasoning at function granularity: `fillVecOverlayHelpers` is the single
+# finalize-time owner of the overlay's emission ORDER (its module header makes
+# that discipline explicit), and `vecBackedLen` plus its three call sites are
+# emission, not policy.
+func-budget-allow:
+  - src/codegen/vec-overlay.ts::fillVecOverlayHelpers
+---
+
+# #4434 — the vec index domain and the sparse tail
+
+Found while measuring the largest remaining ES5-standalone failure family
+(`Object.defineProperty`/`defineProperties` on ARRAY receivers, 74 failing
+files). Two of the family's buckets turned out to be symptoms of defects with a
+much wider blast radius than descriptors, so they are filed and fixed here
+rather than inside the #3251 overlay epic.
+
+## Defect 1 — the sparse tail is an uncatchable trap (both lanes)
+
+A vec is `struct { 0: length i32, 1: data (ref $arr) }`. Every growth path keeps
+`array.len(data) >= length` **except the `a.length = N` setter**, which bumps
+field 0 alone (`expressions/assignment.ts`, the `arr.length = N` arm). #3225
+established exactly this shape and fixed the in-place WRITE methods
+(`fill`/`reverse`/`copyWithin`) by growing the backing.
+
+The dynamic metaobject chokepoints never got the same treatment. They bounds-check
+against the LOGICAL length and then index `data[i]`, so on `--target standalone`
+**every one of them aborted** — measured on this tree before the fix:
+
+| program (after `var a = []; a.length = 3`) | before | Node |
+| --- | --- | --- |
+| `a[1]` | **TRAP** | `undefined` |
+| `a[1] = 9` | **TRAP** | 9 |
+| `a.hasOwnProperty("1")` | **TRAP** | `false` |
+| `Object.getOwnPropertyDescriptor(a, "1")` | **TRAP** | `undefined` |
+| `a.join(",")` | **TRAP** | `",,"` |
+| `Object.defineProperty(a, "1", {value: 14})` | **TRAP** | 14 |
+
+This is not a descriptor bug and not a corner case: `a.length = N` presizing is
+ordinary ES5, and the failure is a terminal Wasm abort, not a catchable error.
+The two test262 files that surfaced it (`15.2.3.6-4-274`,
+`15.2.3.7-6-a-263`) are the smallest part of it.
+
+**The host lane traps on the same idiom**, through its own bridge (`__vec_get`,
+`vec-oob-read.ts`) rather than `__extern_get_idx`.
+
+### Why the fix is reader-tolerance, not growth at the setter
+
+Growing the backing inside `a.length = N` was rejected on two independent
+grounds:
+
+1. `a.length = 4294967294` is legal ES5 and must not allocate four billion
+   slots — the ceiling would have to be arbitrary, and above it the tail comes
+   back anyway.
+2. It is **less correct**, not more. A grown backing reads the carrier default
+   (`0` for an f64 vec) where the spec wants a hole; the tolerant reader answers
+   `undefined`. Measured: with tolerance `a[1] === undefined` is `true`; with
+   growth it would be `false`.
+
+So `length` stays logical, `array.len(data)` is the capacity, and indices in
+`[capacity, length)` are HOLES — the model every JS engine uses.
+
+## Defect 2 — `"4294967296"` is stored as array index 0
+
+`__obj_index_of_key` accumulated decimal digits into an i32 and rejected
+out-of-range keys by testing the accumulator for a NEGATIVE value **after** the
+multiply-add. That misses every key whose wrap lands on a non-negative residue.
+`"4294967296"` accumulates to exactly `0`:
+
+```js
+var a = [];
+Object.defineProperty(a, "4294967296", { value: 100 });
+a.length;  // 1   — should be 0 (2^32 is not an array index)
+a[0];      // 100 — a property invented at a key nobody named
+```
+
+`"4294967295"` happened to wrap to `-1` and so was caught, which is why the
+family looked half-correct: adjacent boundary tests disagreed for no visible
+reason.
+
+## Defect 3 — a non-index numeric key was invisible to the INDEXED read lane
+
+`Object.defineProperty(arr, 4294967295, {value: 100})` stores into the overlay
+companion (gOPD confirmed it present) but `arr[4294967295]` answered
+`undefined`. Two independent causes, both fixed:
+
+- **Authority.** The `__extern_get_idx` prologue treats a plain data entry as
+  "the vec is authoritative, fall through", which is true only where the vec
+  physically backs the index. It does not for a key outside the canonical index
+  domain, nor for the unbacked tail. Decided at READ time (`i >= backedLen` ⇒
+  the companion answers) rather than by marking the entry at define time, so a
+  later `a.length = …` cannot leave a stale authority bit.
+- **Reachability.** That prologue is gated on the #3673 numeric-companion flag,
+  which the define set only for keys with an index `>= 0`. But `arr[4294967295]`
+  reaches the prologue as an f64 whose `number_toString` IS the stored key, so
+  the flag must follow *reachability through the indexed lane*, not
+  index-ness. Now armed by a CanonicalNumericIndexString test on the named-key
+  path — deliberately narrow, so an ordinary `arr.foo` expando still does not
+  arm it and #3673's fast path is preserved.
+
+> **Instrument warning, learned the hard way.** Defect 3 is INVISIBLE to any
+> probe whose module also performs a normal indexed define: that define arms the
+> module-global flag and every later read then works for the wrong reason. Two
+> rounds of probing reported "fixed" on this confound. Every case in
+> `tests/issue-4434-*.test.ts` is therefore its own module.
+
+## Changes
+
+| file | what |
+| --- | --- |
+| `src/codegen/vec-index-domain.ts` (NEW) | the exact pre-multiply overflow guard, the CanonicalNumericIndexString predicate, the sparse-tail bound, and the reasoning for all three |
+| `src/codegen/object-runtime.ts` | `__obj_index_of_key` digit step → the exact guard; `fillExternGetIdxVecArms` vec arms → capacity conjunct |
+| `src/codegen/vec-overlay.ts` | `vecBackedLen` (per-carrier `min(length, array.len(data))`); consumed by the `__vec_dp_value` / `__vec_dp_accessor` real-element seeds, the `__vec_gopd` implicit-descriptor synthesis, and the new `__extern_get_idx` companion-authority arm; numeric-flag arming for canonical-numeric named keys |
+| `src/codegen/vec-oob-read.ts` | `guardVecElementRead` → capacity conjunct (host bridge; NOT standalone-gated, see below) |
+
+The host-lane guard is deliberately not gated: the only behaviour it changes is
+a terminal trap, and no passing program can depend on one.
+
+`vecLen` (the LOGICAL length) is untouched — §10.4.2.2's at-or-beyond-length
+rejections must keep comparing against it. Only the three "is this a REAL
+element?" predicates moved to the backed bound.
+
+## Measurement
+
+Paired A/B by file-copy revert, same process, same instrument.
+
+| set | before | after |
+| --- | --- | --- |
+| the 74-file array-receiver `defineProperty`/`defineProperties` sample | 0 / 74 | **4 / 74 (+4, −0)** |
+| 220-file control of currently-PASSING `Array.prototype.*` / `Object.*` / `for-in` standalone tests | 217 / 220 | **217 / 220 (0 gained, 0 lost)** |
+| `tests/issue-4434-*.test.ts` (new) | — | 17 / 17 |
+| descriptor + overlay suites (`es5-standalone-descriptors`, `es5-standalone-array-filter`, `issue-4159`, `issue-4159-4160-prescan-flags`, `issue-3251`, `issue-4010`) | 104 | 104 |
+| host-lane binary sha over 5 descriptor/array/index-key sources | — | **byte-identical** except `__vec_get`'s own body |
+| 10 array suites (`array-capacity`, `array-methods`, `array-oob-bounds-check`, `array-prototype-methods`, `fast-arrays`, …) | 7 failed / 111 passed | **7 failed / 111 passed — the SAME 7, verified on base** |
+
+Flipped: `15.2.3.6-4-274`, `15.2.3.7-6-a-263` (the traps),
+`15.2.3.6-4-191`, `15.2.3.7-6-a-187` (`Array.prototype["0"]` inheritance —
+index 0 of an empty array is now correctly a hole, so the own define is a first
+definition and the read resolves through the prototype).
+
+The +4 is a fair count of what this change owns and is deliberately not inflated:
+the rest of the family is gated by the residuals below, each of which has a named
+owner.
+
+## Residuals (measured, each with its owner)
+
+1. **The STATIC `compileObjectDefineProperty` lane bypasses the overlay for
+   non-index keys.** Discriminating probe (under the real test262 harness):
+   ```
+   dynamic receiver  (`id([])`)          arr[4294967295] -> 100   ✓
+   statically-visible vec receiver       arr[4294967295] -> undefined   ✗   (gOPD: present)
+   ```
+   With a receiver the compiler can see as a vec, the define is expanded inline
+   and the value lands somewhere the indexed read lane cannot see. This is the
+   same class #3984/#4227 resolved for `length` by standalone-gating the inline
+   path off and letting the native own it. **Gates `15.2.3.6-4-184/-185/-186`
+   and `15.2.3.7-6-a-180/-181/-182` (6 files).** Not attempted here — it is a
+   distinct root cause with its own blast radius. Nearest owner: **#3251** (the
+   overlay epic) or a new slice.
+2. **`hasOwnProperty` on an array with ANY named key answers `false`** under the
+   harness — measured directly with `a.foo = 7`: the read gives 7, the presence
+   check gives `false`. Independent of this change; additionally gates
+   `-184/-185/-186`. Nearest owner: **#4062** (array `length` absent from
+   descriptor reflection) is the same reflection-surface family.
+3. **Array `length` cannot exceed 2^31−1.** `vec.length` is an **i32** compared
+   with `i32.lt_s` throughout, so `arr.length === 4294967295` is unreachable
+   without making the length a uint32 across every signed compare in the
+   compiler. Gates `15.2.3.6-4-154/-155/-183`, `15.2.3.7-6-a-150/-151/-179`
+   (6 files). Deliberately NOT attempted: the risk/reward of touching every
+   length compare for 6 files is bad. Wants its own issue.
+4. **The TYPED lane still traps on the sparse tail** — `const a: number[] = [];
+   a.length = 3; a[1]` aborts. The typed read bounds-checks against the logical
+   length (`emitBoundsCheckedArrayGet`'s `lengthBoundInstrs`, #2773 S7) and a
+   capacity conjunct there is a per-read cost inside every counted loop. That is
+   precisely the guard-cost tradeoff **#4159** exists to decide; routed there
+   rather than paid blind.
+5. **Host lane: writes into the unbacked tail do not stick, and
+   `Object.defineProperty(a, "1", {value: 42})` does not write through even on a
+   fully DENSE `[1,2,3]`** (`a[1]` still answers 2). Verified identical on
+   `origin/main`, so pre-existing; this fix is what made it observable (the read
+   used to trap first). Nearest owner: **#3116** / the host descriptor sidecar.
+6. **Hole semantics past the trap** — `a.length = 3; a.join(",")` yields
+   `"undefined,undefined,undefined"` and `for (k in a)` visits 3 keys, where
+   Node gives `",,"` and 0 keys. Strictly better than the previous abort, still
+   wrong. Owner: **#4222** / **#2001** (array-hole materialisation).
+
+## Acceptance criteria
+
+- [x] `a.length = N; a[i]` / `a[i] = v` / `hasOwnProperty` / gOPD /
+      `defineProperty` / `join` do not trap on either lane.
+- [x] A hole in the unbacked tail reads `undefined`, is not an own property, and
+      has no own descriptor (standalone).
+- [x] `"4294967296"` is a named key: `length` stays 0 and index 0 is untouched.
+- [x] A non-index numeric key reads back through the indexed lane.
+- [x] An ordinary named expando does not arm the indexed-read consult (#3673
+      fast path preserved).
+- [x] Host lane byte-identical apart from `__vec_get`'s body.
+- [x] Zero regressions on a 220-file control of currently-passing tests.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -188,6 +188,7 @@ import { vecConstructorArmInstrs } from "./vec-constructor-carrier.js"; // (#422
 import { registerStringExoticHasOwn, stringExoticHasOwnPrologue } from "./string-exotic-own-props.js"; // (#4232) §10.4.3 own props
 import { ensureWrapperConstructorCarriers, wrapperConstructorArmInstrs } from "./wrapper-constructor-carrier.js"; // (#4223) runtime `<wrapper>.constructor`
 import { overlayRouteActive } from "./typed-lane-overlay-route.js"; // (#4222) overlay-aware index presence
+import { backedBoundsGuard, canonicalIndexDigitStep } from "./vec-index-domain.js"; // (#4434) index domain + sparse tail
 export { fillProxyDispatch } from "./object-runtime-proxy.js";
 
 /** Initial `$PropMap` capacity. Must be a power of two (mask = cap - 1).
@@ -4187,24 +4188,14 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
                 blockType: { kind: "empty" },
                 then: [{ op: "i32.const", value: -1 }, { op: "return" }],
               },
-              // val = val * 10 + (c - '0')
-              { op: "local.get", index: 7 },
-              { op: "i32.const", value: 10 },
-              { op: "i32.mul" },
-              { op: "local.get", index: 6 },
-              { op: "i32.const", value: 0x30 },
-              { op: "i32.sub" },
-              { op: "i32.add" },
-              { op: "local.tee", index: 7 },
-              // overflow / out-of-range guard: if val < 0 (wrapped past i32 max)
-              // treat as a string key (return -1)
-              { op: "i32.const", value: 0 },
-              { op: "i32.lt_s" },
-              {
-                op: "if",
-                blockType: { kind: "empty" },
-                then: [{ op: "i32.const", value: -1 }, { op: "return" }],
-              },
+              // (#4434) val = val * 10 + (c - '0'), with an EXACT pre-multiply
+              // overflow guard. The former post-hoc `val < 0` test only caught
+              // keys whose wrap landed in the negative half: "4294967296"
+              // accumulates to exactly 0 and was reported as array index 0, so
+              // `Object.defineProperty(arr, "4294967296", …)` invented a
+              // property at index 0 and grew `length` to 1. See
+              // vec-index-domain.ts §1.
+              ...canonicalIndexDigitStep(7, 6, 8),
               // i++
               { op: "local.get", index: 5 },
               { op: "i32.const", value: 1 },
@@ -4230,6 +4221,9 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         { name: "i", type: { kind: "i32" } },
         { name: "c", type: { kind: "i32" } },
         { name: "val", type: { kind: "i32" } },
+        // (#4434) scratch for the decoded digit — the exact overflow guard has
+        // to inspect it before it is folded into the accumulator.
+        { name: "digit", type: { kind: "i32" } },
       ],
       body,
     );
@@ -7051,6 +7045,12 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
             blockType: { kind: "empty" },
             then: [...idxMiss(), { op: "return" }],
           },
+          // (#4434) …and if i is past the PHYSICAL backing → also a miss. A
+          // logical `length` can exceed `array.len(data)` (only the
+          // `a.length = N` setter creates this — see vec-index-domain.ts §2),
+          // and without this guard `a.length = 3; a[1]` TRAPPED on the
+          // `array.get` below instead of reading the hole as undefined.
+          ...backedBoundsGuard(2, 4, typeIdx, arrTypeIdx, idxMiss),
           // return box(vec.data[i])
           { op: "local.get", index: 2 },
           { op: "ref.cast", typeIdx },

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -624,7 +624,7 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
         },
         ...boxInstrs,
       ];
-      const thenBranch = guardVecElementRead(vecTypeIdx, elementRead, oobUndefinedInstrs);
+      const thenBranch = guardVecElementRead(vecTypeIdx, arrTypeIdx, elementRead, oobUndefinedInstrs);
       current = [
         { op: "local.get", index: 2 },
         { op: "ref.test", typeIdx: vecTypeIdx },

--- a/src/codegen/vec-index-domain.ts
+++ b/src/codegen/vec-index-domain.ts
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4434) The NUMERIC DOMAIN of array indices, and the SPARSE TAIL that a
+ * logical `length` beyond the physical backing creates.
+ *
+ * Two invariants live here because they are the same invariant seen from two
+ * sides — "which i32 may name an element" and "which i32 may address the
+ * backing" — and every previous bug in this family came from a site that
+ * enforced one while assuming the other.
+ *
+ * ## 1. Canonical-index overflow is not `val < 0`
+ *
+ * `__obj_index_of_key` (object-runtime.ts) accumulates decimal digits into an
+ * i32 and rejected out-of-range keys by testing the accumulator for a NEGATIVE
+ * value after the fact. That misses every key that wraps to a NON-negative
+ * residue: `"4294967296"` (2^32) accumulates to exactly **0**, so the key was
+ * reported as array index 0. Measured consequences on `--target standalone`,
+ * all silent wrong answers:
+ *
+ * ```js
+ * var a = [];
+ * Object.defineProperty(a, "4294967296", { value: 100 });
+ * a.length;   // 1   — should be 0 (2^32 is NOT an array index, §10.4.2.1)
+ * a[0];       // 100 — a property was invented at a key nobody named
+ * ```
+ *
+ * `"4294967295"` (2^32-1) happened to wrap to `-1` and so was caught, which is
+ * why the family looked half-correct: the boundary tests immediately around it
+ * disagreed with each other for no visible reason.
+ *
+ * The guard below is exact and runs BEFORE the multiply-add, so no wrap ever
+ * occurs: `val*10 + d` exceeds `I32_MAX` iff `val > 214748364`, or
+ * `val == 214748364 && d > 7`. Division-free (this runs per digit).
+ *
+ * The ceiling stays `2^31-1` rather than the spec's `2^32-2`, which is the
+ * pre-existing documented cap of `__obj_index_of_key` (the result doubles as a
+ * SIGNED sort key for OrdinaryOwnPropertyKeys ordering). Keys in
+ * `[2^31, 2^32-2]` are therefore treated as ordinary string keys. That is a
+ * deliberate, narrower approximation — and it is now a CONSISTENT one, which
+ * is the property the wrap hole destroyed.
+ *
+ * ## 2. `vec.length` may EXCEED `array.len(vec.data)`
+ *
+ * A vec is `struct { 0: length i32, 1: data (ref $arr) }`. Every growth path
+ * (index write, `push`, the overlay's define write-back) keeps the backing at
+ * least as long as `length` — except the `a.length = N` SETTER, which bumps
+ * field 0 alone (`expressions/assignment.ts`, the `arr.length = N` arm). #3225
+ * already established this shape and fixed the in-place WRITE methods
+ * (`fill`/`reverse`/`copyWithin`) by growing the backing.
+ *
+ * The dynamic-lane metaobject chokepoints were never given the same treatment.
+ * They bounds-check the index against `vec.length` and then index `data[i]`
+ * directly, so every one of them TRAPS — an uncatchable Wasm abort, not a
+ * catchable error — on the ordinary ES5 presize idiom:
+ *
+ * ```js
+ * var a = [];
+ * a.length = 3;
+ * a[1];                                     // TRAP (expected: undefined)
+ * a[1] = 9;                                 // TRAP
+ * a.hasOwnProperty("1");                    // TRAP
+ * Object.getOwnPropertyDescriptor(a, "1");  // TRAP
+ * a.join(",");                              // TRAP
+ * Object.defineProperty(a, "1", {value: 1}); // TRAP
+ * ```
+ *
+ * The fix is NOT to grow the backing at the setter: `a.length = 4294967294` is
+ * legal ES5 and must not allocate four billion slots. The spec model is that
+ * `length` is logical and indices in `[capacity, length)` are HOLES. So the
+ * readers must tolerate the tail, which is what {@link backedBoundsGuard}
+ * expresses: an index is BACKED only when `0 <= i < length && i < len(data)`,
+ * and an in-range-but-unbacked index is a hole — the same `undefined` /
+ * prototype-chain miss an out-of-range index already produces.
+ *
+ * Emitting the capacity test costs one `array.len` + compare on paths that
+ * already do a bounds compare, and it is only emitted on the dynamic MOP
+ * helpers, never in the typed dense loop.
+ */
+import type { Instr } from "../ir/types.js";
+
+/**
+ * Largest value `__obj_index_of_key` will report as an array index. See the
+ * module header for why this is `2^31-1` and not the spec's `2^32-2`.
+ */
+export const MAX_CANONICAL_INDEX = 0x7fffffff;
+
+/** `floor(I32_MAX / 10)` — the last accumulator value that can still take a digit. */
+const ACC_LIMIT = 214748364;
+/** `I32_MAX % 10` — the largest digit `ACC_LIMIT` can absorb without overflow. */
+const ACC_LIMIT_LAST_DIGIT = 7;
+
+/**
+ * Emit the digit step of `__obj_index_of_key`'s accumulator with an EXACT,
+ * pre-multiply overflow guard.
+ *
+ * Replaces the wrap-then-test-for-negative shape described in the module
+ * header. On overflow the emitted code returns `-1` (not an array index)
+ * directly from the enclosing function, matching the guard it supersedes.
+ *
+ * @param valLocal   i32 local holding the accumulator
+ * @param charLocal  i32 local holding the current char code (already validated `'0'..'9'`)
+ * @param digitLocal scratch i32 local for the decoded digit
+ */
+export function canonicalIndexDigitStep(valLocal: number, charLocal: number, digitLocal: number): Instr[] {
+  const notAnIndex = (): Instr[] => [{ op: "i32.const", value: -1 }, { op: "return" }];
+  return [
+    // d = c - '0'
+    { op: "local.get", index: charLocal },
+    { op: "i32.const", value: 0x30 },
+    { op: "i32.sub" },
+    { op: "local.set", index: digitLocal },
+    // val > ACC_LIMIT  →  val*10 overflows regardless of the digit
+    { op: "local.get", index: valLocal },
+    { op: "i32.const", value: ACC_LIMIT },
+    { op: "i32.gt_s" },
+    { op: "if", blockType: { kind: "empty" }, then: notAnIndex() },
+    // val == ACC_LIMIT && d > ACC_LIMIT_LAST_DIGIT  →  the sum overflows
+    { op: "local.get", index: valLocal },
+    { op: "i32.const", value: ACC_LIMIT },
+    { op: "i32.eq" },
+    { op: "local.get", index: digitLocal },
+    { op: "i32.const", value: ACC_LIMIT_LAST_DIGIT },
+    { op: "i32.gt_s" },
+    { op: "i32.and" },
+    { op: "if", blockType: { kind: "empty" }, then: notAnIndex() },
+    // val = val * 10 + d   — provably in range
+    { op: "local.get", index: valLocal },
+    { op: "i32.const", value: 10 },
+    { op: "i32.mul" },
+    { op: "local.get", index: digitLocal },
+    { op: "i32.add" },
+    { op: "local.set", index: valLocal },
+  ];
+}
+
+/** Func indices the canonical-numeric-string predicate needs. */
+export interface CanonicalNumericDeps {
+  /** `__str_to_number(externref) -> f64` (§7.1.4.1 StringToNumber). */
+  strToNumber: number;
+  /** `number_toString(f64) -> ref $AnyString` (§6.1.6.1.20 Number::toString). */
+  numberToString: number;
+  /** `__str_flatten(ref $AnyString) -> ref $NativeString`. */
+  strFlatten: number;
+  /** `__str_equals(ref $NativeString, ref $NativeString) -> i32`. */
+  strEquals: number;
+  /** The `$AnyString` type index, for the key cast. */
+  anyStrTypeIdx: number;
+}
+
+/**
+ * Emit `if (ToString(ToNumber(key)) === key) { ...then }` —
+ * CanonicalNumericIndexString (§10.4.5.1) minus the `"-0"` special case, which
+ * cannot reach an array receiver as an own key.
+ *
+ * ## Why a define needs this, and why `__obj_index_of_key` is not enough
+ *
+ * The overlay's `__extern_get_idx` prologue is gated on a module-global
+ * "some vec carries a numeric-keyed companion entry" flag (#3673 — without it
+ * the per-read linear table scan cost 29% of a compiled-acorn parse). That
+ * flag was set only when `__obj_index_of_key` reported an index `>= 0`.
+ *
+ * But a key OUTSIDE the canonical index domain is still reachable through the
+ * INDEXED read lane: `arr[4294967295]` arrives at `__extern_get_idx` as the
+ * f64 `4294967295`, whose `number_toString` is exactly the key the companion
+ * stored. With the flag clear the prologue never ran, the read fell through to
+ * the vec (which has no such element), and the property that
+ * `getOwnPropertyDescriptor` and `hasOwnProperty` both reported as present
+ * read back as `undefined`.
+ *
+ * So the flag must follow REACHABILITY through the indexed lane, not
+ * array-index-ness. This predicate is that condition, and it deliberately
+ * stays narrow: an ordinary named expando (`arr.foo`) is not numeric, does not
+ * set the flag, and keeps the fast path — which is the whole point of #3673.
+ *
+ * NOTE ON INSTRUMENTS: this defect is invisible to any probe whose module also
+ * performs a normal indexed define, because that sets the flag for the whole
+ * module and every later read then works. It was found only by mirroring the
+ * failing test file exactly, one define per module.
+ *
+ * @param keyLocal externref local holding the property key
+ * @param scratch  f64 local for the intermediate ToNumber result
+ */
+export function canonicalNumericKeyGuard(
+  keyLocal: number,
+  scratch: number,
+  deps: CanonicalNumericDeps,
+  then: Instr[],
+): Instr[] {
+  return [
+    { op: "local.get", index: keyLocal },
+    { op: "call", funcIdx: deps.strToNumber },
+    { op: "local.set", index: scratch },
+    // ToString(n) === key ?  (NaN stringifies to "NaN", which no numeric key
+    // can equal, so a non-numeric key falls out here without a NaN test.)
+    { op: "local.get", index: scratch },
+    { op: "call", funcIdx: deps.numberToString },
+    { op: "call", funcIdx: deps.strFlatten },
+    { op: "local.get", index: keyLocal },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: deps.anyStrTypeIdx },
+    { op: "call", funcIdx: deps.strFlatten },
+    { op: "call", funcIdx: deps.strEquals },
+    { op: "if", blockType: { kind: "empty" }, then },
+  ];
+}
+
+/**
+ * Emit `if (i >= array.len(vec.data)) { ...miss; return }` — the SPARSE-TAIL
+ * guard the dynamic MOP chokepoints were missing.
+ *
+ * Callers reach this having already established `0 <= i < vec.length`; the
+ * remaining question is whether the backing physically holds slot `i`. An
+ * unsigned compare covers a negative `i` too, so the guard is safe to emit
+ * before the sign test as well.
+ *
+ * @param anyLocal   local holding the receiver, already `ref.test`-proven to be `vecTypeIdx`
+ * @param idxLocal   i32 local holding the index
+ * @param miss       instructions producing the enclosing helper's miss result
+ *                   (they must leave exactly its return value on the stack; a
+ *                   `return` is appended)
+ */
+export function backedBoundsGuard(
+  anyLocal: number,
+  idxLocal: number,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  miss: () => Instr[],
+): Instr[] {
+  return [
+    { op: "local.get", index: idxLocal },
+    { op: "local.get", index: anyLocal },
+    { op: "ref.cast", typeIdx: vecTypeIdx },
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+    { op: "array.len", typeIdx: arrTypeIdx } as Instr,
+    { op: "i32.ge_u" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...miss(), { op: "return" }],
+    },
+  ];
+}

--- a/src/codegen/vec-oob-read.ts
+++ b/src/codegen/vec-oob-read.ts
@@ -2,14 +2,58 @@
 
 import type { Instr } from "../ir/types.js";
 
-/** Guard a vec read with JavaScript's out-of-bounds `undefined` semantics. */
-export function guardVecElementRead(vecTypeIdx: number, elementRead: Instr[], undefinedInstrs: Instr[]): Instr[] {
-  return [
-    { op: "local.get", index: 1 },
+/**
+ * Guard a vec read with JavaScript's out-of-bounds `undefined` semantics.
+ *
+ * (#4434) The bound is `min(vec.length, array.len(vec.data))`, not `vec.length`
+ * alone. Those two are equal for every array the compiler grows itself, but the
+ * `a.length = N` setter bumps the logical length WITHOUT growing the backing
+ * (see `vec-index-domain.ts` §2), and JavaScript requires exactly that — a
+ * legal `a.length = 4294967294` must not allocate four billion slots. Indices
+ * in `[capacity, length)` are HOLES.
+ *
+ * Checking only the logical length let the `array.get` inside `elementRead` run
+ * on an index the backing does not hold, which is an UNCATCHABLE Wasm trap
+ * rather than a value:
+ *
+ * ```js
+ * var a = [];
+ * a.length = 3;
+ * a[1];        // trapped "array element access out of bounds"; expected undefined
+ * ```
+ *
+ * This affects the DEFAULT (host) lane too — `__vec_get` is the host bridge —
+ * so the extra conjunct is deliberately not standalone-gated. It cannot
+ * regress anything: the only behaviour it changes is a terminal trap, which no
+ * passing program can depend on.
+ *
+ * @param arrTypeIdx the `data` array type, for the `array.len` capacity read
+ */
+export function guardVecElementRead(
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elementRead: Instr[],
+  undefinedInstrs: Instr[],
+): Instr[] {
+  const logicalLength: Instr[] = [
     { op: "local.get", index: 2 },
     { op: "ref.cast", typeIdx: vecTypeIdx },
     { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+  ];
+  const capacity: Instr[] = [
+    { op: "local.get", index: 2 },
+    { op: "ref.cast", typeIdx: vecTypeIdx },
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+    { op: "array.len", typeIdx: arrTypeIdx } as Instr,
+  ];
+  return [
+    { op: "local.get", index: 1 },
+    ...logicalLength,
     { op: "i32.lt_u" },
+    { op: "local.get", index: 1 },
+    ...capacity,
+    { op: "i32.lt_u" },
+    { op: "i32.and" },
     {
       op: "if",
       blockType: { kind: "val", type: { kind: "externref" } },

--- a/src/codegen/vec-overlay.ts
+++ b/src/codegen/vec-overlay.ts
@@ -94,6 +94,7 @@ import { protoIndexGetIdxMissInstrs, protoIndexHasIdxInstrs } from "./proto-inde
 import { undefinedExternInstrs } from "./any-helpers.js";
 import { nonExtensibleFreshIndexGuard, nonWritableLengthIndexGuard } from "./vec-define-rejections.js";
 import { nativeStringLiteralInstrs } from "./native-strings.js";
+import { canonicalNumericKeyGuard } from "./vec-index-domain.js"; // (#4434) index domain + sparse tail
 
 /**
  * `$PropEntry.$flags` bit claimed by the overlay (see the flag table in
@@ -744,6 +745,38 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
     { op: "if", blockType: { kind: "empty" }, then: inner },
   ];
 
+  /**
+   * (#4434) Mark the module as carrying an indexed-lane-reachable companion
+   * entry when the key is a canonical numeric STRING that is not an array
+   * index (`"4294967295"`, `"4294967296"`, `"1e21"`).
+   *
+   * The `__extern_get_idx` prologue is gated on this flag, and the define path
+   * set it only for keys with an index `>= 0` — but `arr[4294967295]` reaches
+   * that same prologue as an f64 whose `number_toString` is the stored key. So
+   * the flag has to follow reachability, not index-ness; see
+   * `canonicalNumericKeyGuard`'s doc comment. Returns `[]` (no-op) when
+   * `__str_to_number` is unavailable, leaving today's behaviour.
+   */
+  const markNumericLikeNamedKey = (keyLocal: number, scratchF64: number): Instr[] => {
+    const strToNumberIdx = ctx.funcMap.get("__str_to_number");
+    if (strToNumberIdx === undefined) return [];
+    return canonicalNumericKeyGuard(
+      keyLocal,
+      scratchF64,
+      {
+        strToNumber: strToNumberIdx,
+        numberToString: numToStringIdx,
+        strFlatten: strFlattenIdx,
+        strEquals: strEqualsIdx,
+        anyStrTypeIdx,
+      },
+      [
+        { op: "i32.const", value: 1 },
+        { op: "global.set", index: core.numericFlagGlobalIdx },
+      ],
+    );
+  };
+
   /** `idxLocal = __obj_index_of_key(cast key)` — canonical array index or -1. */
   const parseIndex = (keyLocal: number, idxLocal: number): Instr[] => [
     { op: "local.get", index: keyLocal },
@@ -760,6 +793,56 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
     { op: "struct.get", typeIdx: vecBaseIdx, fieldIdx: 0 },
     { op: "local.set", index: lenLocal },
   ];
+
+  /**
+   * (#4434) The BACKED length — `min(vec.length, array.len(vec.data))`.
+   *
+   * `vecLen` answers the LOGICAL length, which is what §10.4.2.2's
+   * at-or-beyond-length rejections must compare against, so it deliberately
+   * stays as it is. But the two places that ask "is index `i` a REAL, already
+   * existing element?" must use the physical bound instead: the `a.length = N`
+   * setter can push the logical length past the backing (vec-index-domain.ts
+   * §2), and an index in that tail is a HOLE — it has no implicit
+   * `{value, w/e/c: true}` descriptor to seed or to report, and reading it to
+   * find one is exactly the `array.get` that trapped.
+   *
+   * Per-carrier because `data`'s array type is not on `$__vec_base`. The
+   * fallthrough (no carrier matched) leaves `lenLocal` at the logical length —
+   * unreachable in practice, since every caller sits behind
+   * `carrierWhitelistGuard`, and it degrades to the previous behaviour rather
+   * than to zero.
+   */
+  const vecBackedLen = (anyLocal: number, lenLocal: number): Instr[] => {
+    const arms: Instr[] = [];
+    for (const c of carriers) {
+      const capacity = (): Instr[] => [
+        { op: "local.get", index: anyLocal },
+        { op: "ref.cast", typeIdx: c.vecTypeIdx },
+        { op: "struct.get", typeIdx: c.vecTypeIdx, fieldIdx: 1 },
+        { op: "array.len", typeIdx: c.arrTypeIdx } as Instr,
+      ];
+      arms.push(
+        { op: "local.get", index: anyLocal },
+        { op: "ref.test", typeIdx: c.vecTypeIdx },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // if array.len(data) < len → len = array.len(data)
+            ...capacity(),
+            { op: "local.get", index: lenLocal },
+            { op: "i32.lt_u" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [...capacity(), { op: "local.set", index: lenLocal }],
+            },
+          ],
+        },
+      );
+    }
+    return [...vecLen(anyLocal, lenLocal), ...arms];
+  };
 
   const clearDeletedIndexMarker = (l: {
     comp: number;
@@ -957,6 +1040,12 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         { name: "newLenI", type: { kind: "i32" } },
         { name: "k", type: { kind: "i32" } },
         { name: "lenPrim", type: { kind: "externref" } },
+        // (#4434) min(length, array.len(data)) — the "is this a REAL element?"
+        // bound. Distinct from `len` because §10.4.2.2's rejections compare
+        // against the LOGICAL length; only the seed asks about backing.
+        { name: "backedLen", type: { kind: "i32" } },
+        // (#4434) f64 scratch for the canonical-numeric-string key test.
+        { name: "keyNum", type: { kind: "f64" } },
       ];
       // (#3251 S3) Full §7.1.4 ToNumber for the length value — ArraySetLength
       // must accept `{value: "2"}` and `{value: {toString(){return "2"}}}`
@@ -1350,6 +1439,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         { op: "local.set", index: 6 },
         ...parseIndex(1, 7),
         ...vecLen(4, 8),
+        ...vecBackedLen(4, 19),
         // (#4227) §10.4.2.2 step 3 — frozen `length` blocks an index at/after it.
         ...nonWritableLengthIndexGuard(rejectionDeps, { comp: 5, i: 7, len: 8, entry: 9 }),
         // (#4227) §10.1.6.3 step 2 — a non-extensible array takes no new index.
@@ -1376,8 +1466,13 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
             {
               op: "if",
               blockType: { kind: "empty" },
+              // (#4434) BACKED length, not logical: an index in the unbacked
+              // tail is a hole, so the define is a FIRST definition (defaults
+              // all false) rather than a redefine of an implicit
+              // `{value, w/e/c: true}` element — and seeding it would have
+              // read `data[i]` past the backing, which is what trapped.
               then: buildRealElementSeed(
-                { comp: 5, compExt: 6, key: 1, vec: 0, i: 7, len: 8 },
+                { comp: 5, compExt: 6, key: 1, vec: 0, i: 7, len: 19 },
                 objFindIdx,
                 dpValueIdx,
                 externGetIdxIdx,
@@ -1385,6 +1480,17 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
               ),
             },
           ],
+        },
+        // (#4434) A named key that is nonetheless a canonical numeric STRING is
+        // reachable through the INDEXED read lane, so it has to arm the
+        // numeric-companion flag the same way an index define does.
+        { op: "local.get", index: 7 },
+        { op: "i32.const", value: 0 },
+        { op: "i32.lt_s" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: markNumericLikeNamedKey(1, 20),
         },
         // (#4010 S1′) Named-key twin of the index seed above — see `vec-bag-seed.ts`.
         // Deliberately NOT applied on the accessor path: converting a data
@@ -1493,6 +1599,10 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         { name: "len", type: { kind: "i32" } },
         { name: "e", type: { kind: "ref_null", typeIdx: propEntryTypeIdx } },
         { name: "wasDeleted", type: { kind: "i32" } },
+        // (#4434) min(length, array.len(data)) — see the `__vec_dp_value` twin.
+        { name: "backedLen", type: { kind: "i32" } },
+        // (#4434) f64 scratch for the canonical-numeric-string key test.
+        { name: "keyNum", type: { kind: "f64" } },
       ];
       const bailReturnVec = (): Instr[] => [{ op: "local.get", index: 0 }, { op: "return" }];
       fn.body = [
@@ -1535,6 +1645,7 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         { op: "local.set", index: 7 },
         ...parseIndex(1, 8),
         ...vecLen(5, 9),
+        ...vecBackedLen(5, 12),
         { op: "local.get", index: 8 },
         { op: "i32.const", value: 0 },
         { op: "i32.ge_s" },
@@ -1557,8 +1668,9 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
             {
               op: "if",
               blockType: { kind: "empty" },
+              // (#4434) BACKED length — see the `__vec_dp_value` twin.
               then: buildRealElementSeed(
-                { comp: 6, compExt: 7, key: 1, vec: 0, i: 8, len: 9 },
+                { comp: 6, compExt: 7, key: 1, vec: 0, i: 8, len: 12 },
                 objFindIdx,
                 dpValueIdx,
                 externGetIdxIdx,
@@ -1566,6 +1678,15 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
               ),
             },
           ],
+        },
+        // (#4434) canonical-numeric named key → arm the indexed-lane flag.
+        { op: "local.get", index: 8 },
+        { op: "i32.const", value: 0 },
+        { op: "i32.lt_s" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: markNumericLikeNamedKey(1, 13),
         },
         // Delegate the accessor define (validation + merge live in the native).
         { op: "local.get", index: 7 },
@@ -1740,8 +1861,11 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
         },
         // No entry: synthesize the implicit element descriptor for an
         // in-bounds index — {value: vec[i], w/e/c: true}. Do NOT seed on reads.
+        // (#4434) BACKED length: an index in the unbacked tail left by
+        // `a.length = N` is a hole, and a hole has no own descriptor — gOPD
+        // must answer `undefined`, not `{value: undefined, w/e/c: true}`.
         ...parseIndex(1, 4),
-        ...vecLen(2, 5),
+        ...vecBackedLen(2, 5),
         { op: "local.get", index: 4 },
         { op: "i32.const", value: 0 },
         { op: "i32.ge_s" },
@@ -1977,11 +2101,17 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
       const pComp = base + 1;
       const pE = base + 2;
       const pGetter = base + 3;
+      const pIdx = base + 4;
+      const pBacked = base + 5;
       fn.locals.push(
         { name: "__ov_any", type: { kind: "anyref" } },
         { name: "__ov_comp", type: { kind: "ref_null", typeIdx: objectTypeIdx } },
         { name: "__ov_e", type: { kind: "ref_null", typeIdx: propEntryTypeIdx } },
         { name: "__ov_getter", type: { kind: "externref" } },
+        // (#4434) the truncated index and the BACKED length, for the
+        // companion-vs-vec authority decision on a plain data entry.
+        { name: "__ov_idx", type: { kind: "i32" } },
+        { name: "__ov_backed", type: { kind: "i32" } },
       );
       const prologue: Instr[] = [
         // (#3673) Gate on the numeric-companion flag, NOT the state global: a
@@ -2083,7 +2213,43 @@ export function fillVecOverlayHelpers(ctx: CodegenContext): void {
                             { op: "return" },
                           ],
                         },
-                        // plain data entry → fall through to the vec read
+                        // (#4434) A plain data entry normally falls through to
+                        // the vec read, because the define wrote its [[Value]]
+                        // back into the element and later plain writes keep
+                        // that fresh. That reasoning holds ONLY where the vec
+                        // physically backs the index. Two cases where it does
+                        // not, both of which read as `undefined` before this:
+                        //
+                        //   - a key outside the canonical array-index domain
+                        //     (`arr[4294967295]` — the write-back is skipped
+                        //     because `__obj_index_of_key` reports -1, so the
+                        //     companion is the only copy);
+                        //   - an index in the unbacked tail left by
+                        //     `a.length = N` (vec-index-domain.ts §2).
+                        //
+                        // In both, the companion is authoritative. Decided at
+                        // READ time rather than by marking the entry at define
+                        // time, so a later `a.length = …` that grows or shrinks
+                        // the backing cannot leave a stale authority bit.
+                        { op: "local.get", index: 1 },
+                        { op: "i32.trunc_sat_f64_s" },
+                        { op: "local.set", index: pIdx },
+                        ...vecBackedLen(pAny, pBacked),
+                        { op: "local.get", index: pIdx },
+                        { op: "local.get", index: pBacked },
+                        { op: "i32.ge_u" },
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [
+                            { op: "local.get", index: pE },
+                            { op: "ref.as_non_null" },
+                            { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+                            { op: "extern.convert_any" },
+                            { op: "return" },
+                          ],
+                        },
+                        // backed data entry → fall through to the vec read
                       ],
                     },
                   ],

--- a/tests/issue-4434-vec-index-domain-sparse-tail.test.ts
+++ b/tests/issue-4434-vec-index-domain-sparse-tail.test.ts
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4434) Two array invariants the standalone vec overlay did not hold.
+//
+//   1. SPARSE TAIL — `a.length = N` bumps the vec's logical length without
+//      growing the physical backing, and every dynamic metaobject chokepoint
+//      then indexed `data[i]` on the strength of the logical bound alone. The
+//      result was an UNCATCHABLE Wasm trap ("array element access out of
+//      bounds") on the ordinary ES5 presize idiom — `a.length = 3; a[1]` —
+//      and on `hasOwnProperty` / `getOwnPropertyDescriptor` /
+//      `defineProperty` / `join` over the same array.
+//
+//   2. INDEX DOMAIN — `__obj_index_of_key` detected out-of-range keys by
+//      testing its i32 accumulator for a NEGATIVE value after the fact, which
+//      misses every key that wraps to a non-negative residue. `"4294967296"`
+//      accumulated to exactly 0, so a define at that key silently invented a
+//      property at index 0 and grew `length` to 1.
+//
+// Every expectation below is Node's answer for the same source. The host lane
+// is asserted alongside standalone wherever the value is representable, so a
+// standalone-only fix cannot drift the two apart.
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+type Lane = "host" | "standalone";
+
+async function run(source: string, lane: Lane): Promise<Record<string, number>> {
+  const result = await compile(source, lane === "standalone" ? { target: "standalone" } : {});
+  expect(
+    result.success,
+    `compile failed (${lane}):\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  const exports = instance.exports as Record<string, () => number>;
+  const out: Record<string, number> = {};
+  for (const name of Object.keys(exports)) {
+    if (typeof exports[name] === "function" && name.startsWith("t_")) out[name] = exports[name]!();
+  }
+  return out;
+}
+
+// ── 1. sparse tail ─────────────────────────────────────────────────────────
+//
+// Each case is its own module on purpose. A module that ALSO performs a normal
+// indexed define arms the overlay's module-global numeric-companion flag, and
+// then every later read works for the wrong reason — that confound hid the
+// second half of this bug through two rounds of probing.
+const SPARSE: Array<[string, string, number]> = [
+  // the read that trapped: an index inside the tail is a hole, so `undefined`
+  ["t_tail_read", `const a: any = []; a.length = 3; return a[1] === undefined ? 1 : 0;`, 1],
+  // presence: a hole is not an own property
+  ["t_tail_hasown", `const a: any = []; a.length = 3; return a.hasOwnProperty("1") ? 1 : 0;`, 0],
+  // reflection: a hole has no own descriptor
+  [
+    "t_tail_gopd",
+    `const a: any = []; a.length = 3; return Object.getOwnPropertyDescriptor(a, "1") === undefined ? 1 : 0;`,
+    1,
+  ],
+  // write into the tail materialises a real element
+  ["t_tail_write", `const a: any = []; a.length = 3; a[1] = 9; return a[1] as number;`, 9],
+  // 15.2.3.6-4-274 / 15.2.3.7-6-a-263: defineProperty on an index in the tail.
+  // The define is a FIRST definition (the hole has no implicit descriptor to
+  // redefine), and it must not disturb the logical length.
+  [
+    "t_tail_define_val",
+    `const a: any = []; a.length = 3; Object.defineProperty(a, "1", { value: 14 }); return a[1] as number;`,
+    14,
+  ],
+  [
+    "t_tail_define_len",
+    `const a: any = []; a.length = 3; Object.defineProperty(a, "1", { value: 14 }); return a.length as number;`,
+    3,
+  ],
+  [
+    "t_tail_define_plural",
+    `const a: any = []; a.length = 3; Object.defineProperties(a, { "1": { value: 26 } }); return a[1] as number;`,
+    26,
+  ],
+  // a tail that starts past REAL elements
+  ["t_tail_after_elems", `const a: any = [1, 2]; a.length = 5; return a[4] === undefined ? 1 : 0;`, 1],
+  // control: shrink is unaffected
+  ["t_shrink", `const a: any = [1, 2, 3]; a.length = 1; return a[2] === undefined ? 1 : 0;`, 1],
+  // control: a dense define still writes through to the element
+  [
+    "t_dense_define",
+    `const a: any = [1, 2, 3]; Object.defineProperty(a, "1", { value: 42 }); return a[1] as number;`,
+    42,
+  ],
+];
+
+describe("#4434 sparse tail — a logical length beyond the backing is holes, not a trap", () => {
+  for (const [name, body, expected] of SPARSE) {
+    it(`${name} (standalone)`, async () => {
+      const out = await run(`export function ${name}(): number {\n${body}\n}`, "standalone");
+      expect(out[name]).toBe(expected);
+    });
+  }
+
+  // The host lane trapped on the SAME idiom, through its own bridge
+  // (`__vec_get`, `vec-oob-read.ts`) rather than through `__extern_get_idx`, so
+  // the capacity conjunct was applied there too and is deliberately NOT
+  // standalone-gated. Converting a terminal trap into a value cannot regress a
+  // passing program.
+  //
+  // What the host lane still does NOT match is how it REPRESENTS the resulting
+  // hole: `a[1] === undefined` answers false there (it yields the carrier's
+  // sentinel, not the `undefined` singleton). That is the pre-existing
+  // array-hole representation gap owned by #2001 / #4222, not this fix — so the
+  // rows below are the ones whose answer does not depend on it, and the
+  // `=== undefined` rows are asserted for standalone only, above.
+  //
+  // Every row whose answer is a VALUE written into an array index is excluded
+  // for a SECOND, independent reason, stated here rather than silently dropped:
+  // on the host lane `Object.defineProperty(a, "1", {value: 42})` does not write
+  // through to the element AT ALL — `a[1]` still answers 2 on a fully DENSE
+  // `[1,2,3]`. Verified identical on `origin/main`, so it is pre-existing and
+  // unrelated to the capacity conjunct; the same goes for a plain `a[1] = 9`
+  // into the unbacked tail. Both are recorded in #4434's residuals.
+  //
+  // What remains assertable on host is the part this change is responsible for:
+  // the read does not trap, and the LENGTH is undisturbed.
+  const HOST_ROWS = new Set(["t_tail_define_len"]);
+
+  it("host lane: the length rows agree", async () => {
+    const rows = SPARSE.filter(([n]) => HOST_ROWS.has(n));
+    const src = rows.map(([n, b]) => `export function ${n}(): number {\n${b}\n}`).join("\n");
+    const out = await run(src, "host");
+    for (const [name, , expected] of rows) expect(out[name], name).toBe(expected);
+  });
+
+  it("host lane: reading the unbacked tail no longer traps", async () => {
+    // Asserts only the absence of the trap — see the note above on why the
+    // host lane's hole VALUE is out of scope here.
+    await expect(
+      run(`export function t_x(): number { const a: any = []; a.length = 3; const v = a[1]; return 1; }`, "host"),
+    ).resolves.toBeDefined();
+  });
+});
+
+// ── 2. canonical index domain ──────────────────────────────────────────────
+describe("#4434 index domain — a key that is not an array index is not index 0", () => {
+  // 2^32 wrapped the i32 accumulator to exactly 0. `length` must stay 0 and no
+  // element may appear at index 0. (15.2.3.7-6-a-181 / -182.)
+  it("2^32 is a named key, not index 0 (standalone)", async () => {
+    const out = await run(
+      `const a: any = [];
+       Object.defineProperty(a, "4294967296", { value: 100 });
+       export function t_len(): number { return a.length as number; }
+       export function t_at0(): number { return a[0] === undefined ? 1 : 0; }`,
+      "standalone",
+    );
+    expect(out["t_len"]).toBe(0);
+    expect(out["t_at0"]).toBe(1);
+  });
+
+  // Read-back through the INDEXED lane. `arr[4294967295]` reaches
+  // `__extern_get_idx` as an f64 whose `number_toString` is the stored key, so
+  // the companion — not the vec — is authoritative for it.
+  it("a non-index numeric key reads back through the indexed lane (standalone)", async () => {
+    const out = await run(
+      `const a: any = [];
+       Object.defineProperty(a, 4294967295, { value: 100 });
+       export function t_val(): number { return a[4294967295] as number; }`,
+      "standalone",
+    );
+    expect(out["t_val"]).toBe(100);
+  });
+
+  it("2^32 reads back through the indexed lane (standalone)", async () => {
+    const out = await run(
+      `const a: any = [];
+       Object.defineProperty(a, "4294967296", { value: 100 });
+       export function t_val(): number { return a[4294967296] as number; }`,
+      "standalone",
+    );
+    expect(out["t_val"]).toBe(100);
+  });
+
+  // The narrow-fast-path property that pays for the above: an ordinary named
+  // expando is not numeric, so it must NOT arm the indexed-read consult.
+  it("an ordinary expando still reads back (standalone)", async () => {
+    const out = await run(
+      `const a: any = [];
+       Object.defineProperty(a, "foo", { value: 7 });
+       export function t_val(): number { return a["foo"] as number; }`,
+      "standalone",
+    );
+    expect(out["t_val"]).toBe(7);
+  });
+
+  // Controls: real indices are unaffected in both directions.
+  it("real indices are unaffected (standalone)", async () => {
+    const out = await run(
+      `const a: any = [];
+       Object.defineProperty(a, "5", { value: 55 });
+       export function t_len(): number { return a.length as number; }
+       export function t_val(): number { return a[5] as number; }
+       export function t_has(): number { return a.hasOwnProperty("5") ? 1 : 0; }`,
+      "standalone",
+    );
+    expect(out["t_len"]).toBe(6);
+    expect(out["t_val"]).toBe(55);
+    expect(out["t_has"]).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

Wave 5b (final agent wave) of the #4426 ES5-standalone campaign. Two unfiled defects in the array-receiver descriptor family, filed and fixed as #4434 (`plan/issues/4434-vec-index-domain-and-sparse-tail.md`, with the bucket map of all 74 sampled failures and a residual list where every entry names its owning issue):

1. **Sparse-tail trap.** `var a = []; a.length = 3` leaves `vec.length > array.len(data)`, and every dynamic MOP chokepoint indexed the backing on the logical bound alone — `a[1]`, `a[1] = 9`, `hasOwnProperty`, `gOPD`, `join`, and `defineProperty` were all uncatchable Wasm aborts on an ordinary ES5 presize. Readers now tolerate the tail (new `src/codegen/vec-index-domain.ts`); growing the backing at the setter was measured and rejected (a legal `a.length = 4294967294` would allocate 4e9 slots, and the carrier default `0` is *less* correct than a hole). The host lane trapped identically through `__vec_get`, so that guard is not standalone-gated.
2. **`__obj_index_of_key` i32 overflow.** The accumulator was tested for *negative* after the multiply-add; `"4294967296"` accumulates to exactly `0`, so a define at that key invented a property at index 0 and grew `length` to 1.

Sample: 0/74 → **4/74, zero lost**; control of 220 currently-passing array/object/for-in standalone tests: 217/220 identical both arms, zero moved. Host binaries byte-identical except `__vec_get`'s own body. 17/17 new pins — each pin case is its own module, because the non-index-key defect is invisible to any probe whose module also performs a normal indexed define (the #3673 numeric-companion flag arms and masks it; two probe rounds false-reported "fixed" before the one-define-per-module methodology caught it — recorded in the issue file).

Process notes: #4197 (the `illegal cast in __call_fn_method_3` shape) was found claimed by another lane and deliberately skipped; residuals are routed to #3251, #4062, #4159, #3116, #4222, and one future uint32-length issue.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_