### PR TITLE
docs(#2916/#4433): cross-lane audit records — WASI gate measured, host-lane population measured

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,19 @@ Be concise. Lead with the answer, then only the context needed to act on it.
     cp .tmp/base.ts src/foo.ts    # measure baseline
     cp .tmp/new.ts  src/foo.ts    # restore
     ```
+  - **Capture `.tmp/base.ts` at the FIRST edit — the measurement rationale is
+    stronger than the stash-safety one (2026-08-15, #2916/#4433 cross-audit).**
+    Of ~11 documentation corrections across those two issues, the large
+    majority were ONE defect: a figure inherited from an artifact (stale
+    baseline, stale skip list, unjustified scan filter, never-run lane),
+    restated as a measurement — and the skips tracked PRICE, not care: the
+    before-state check that got run cost one `cp`, the one that got skipped
+    cost a corpus compile, with a plausible artifact offering a free answer
+    exactly where measuring cost most. Capturing the revert copy up front
+    makes every later base run one `cp` away, so "measure the before-state
+    yourself" stops being a decision. Corollary: when you quote a number, name
+    the artifact it came from and when that artifact was made; a delta claimed
+    without a base run you executed is attribution, not measurement.
   - **Recovery if it already happened**: `git fsck --unreachable | grep commit`, then `git log -1 --format=%s <sha>` on each — a stash entry's message is `WIP on worktree-agent-<id>`, which identifies the **owner** unambiguously. Restore with `git checkout <sha> -- <paths>`. Tell the lead so the commit can be pinned (`git update-ref refs/recovered/<name> <sha>`) before garbage collection takes it; unreachable objects are collectable.
   - The hazard is **worse than it looks** because the failure is silent and delayed: `pop` succeeds, you keep working, and you only notice when the file you expected is someone else's. The victim usually suspects their own change first.
 - **Worktree cleanup after merge**: after a dev self-merges their PR, they remove their own worktree (`git worktree remove /workspace/.claude/worktrees/<branch>`) before claiming the next task. Tech-lead only removes worktrees for suspended or abandoned branches.

--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -912,6 +912,40 @@ Also green on this branch: all **8 equivalence shards**
 `tests/issue-3962-native-user-instanceof.test.ts`,
 `tests/issue-4276-instanceof-object-family.test.ts`, `tests/issue-2994.test.ts`.
 
+### Was the 59-file population itself a hiding filter? Checked — no, but it exposed a stale scale claim
+
+The conversion count came from the **59 sole-leak** files, which is a FILTER: the
+baseline also lists **1,501 files naming `env::__instanceof_check` alongside other
+imports**, excluded on the assumption "they keep leaking the others, so they can't
+convert". That assumption was never measured, and it is derived from the
+baseline's error STRINGS rather than from compiling on this branch's base — so if
+another lane eliminated a co-occurring import after the baseline was captured, the
+file is effectively sole-leak now and this change converts it. That would be a
+conversion the count MISSES.
+
+Measured: 150-file deterministic sample (seed 20260815) of the 1,501, compiled on
+branch and on base.
+
+| | branch | base |
+| --- | ---: | ---: |
+| zero-import | 131 | 131 |
+| still leaking | 19 | 19 |
+| **still emitting `__instanceof_check`** | **0** | **0** |
+
+Output byte-identical between the two trees. **Two findings:**
+
+1. **The filter hid nothing attributable to this change** — zero delta on the
+   sample, so 59 stands as the population this change converts.
+2. **The baseline's co-leak population is materially STALE, and the "1,560 files
+   name it" figure must not be quoted as scale.** Not one sampled file still
+   emits `__instanceof_check` on current main; earlier slices (#2998, #3962,
+   Slice A, #4276) resolve those sites statically now. Corrected in the module
+   header, which had quoted 1,560.
+
+The check was worth running for the second finding alone, and the reasoning that
+would have skipped it — "those files keep leaking anyway, it wouldn't move the
+number" — is exactly the reasoning that keeps an unexamined filter alive.
+
 ### The WASI half of the gate, measured rather than inferred
 
 `noJsHost` is `ctx.wasi || ctx.standalone` (`js-errors.ts:29`) — **two** targets,

--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -790,7 +790,9 @@ Corpus sweeps on this branch:
 - `language/expressions/instanceof` — **43 files, 0 leaking** (was 11 leaking).
 - The **59 files that name `env::__instanceof_check` as their SOLE host import**
   on the 2026-08-15 standalone baseline — **0 leaking, 0 compile-refused,
-  0 invalid Wasm** (each binary was `WebAssembly.compile`d).
+  0 invalid Wasm** (each binary was `WebAssembly.compile`d). Of those 59, **20
+  actually still leak on this branch's base**; the other 39 are stale baseline
+  entries already clean before this change (see SECONDARY acceptance).
 - gc/host **byte-identical**: sha256 of the compiled binary matched base on all
   10 probe shapes (file-copy A/B on `identifiers.ts`). That is a SAMPLE, and it
   is stated as one; what makes it a general claim is structural — the call site
@@ -864,20 +866,35 @@ walked by the ordinary late-import body shifter. **Nothing is minted at finalize
 
 ### SECONDARY acceptance — rows
 
-**The 59 sole-leak files** (the directly addressable population, from the
-2026-08-15 standalone baseline where all 59 are `compile_error`
-`host_import_leak`), re-run on this branch **with `TEST262_INCLUDE_PROPOSALS=1`**
-— see the scope note below, which is load-bearing:
+**+3 conversions, 0 regressions.** The live population is **20 files, not 59** —
+that correction is the last one on this issue and it came from applying the
+provenance habit to my own headline number.
 
-| after    | rows |
-| -------- | ---: |
-| **pass** |    4 |
-| fail     |   55 |
+The 59 came from the 2026-08-15 baseline, which records them as `compile_error`
+`host_import_leak`. Compiled on THIS BRANCH'S BASE, only **20 still emit
+`env::__instanceof_check`**; the other 39 are already import-free (stale entries,
+resolved by earlier slices). So 39 of the 59 were never mine to convert.
 
-59 × `compile_error` → **4 pass**, 0 regressions (a `compile_error` cannot
-regress). The four: `built-ins/Array/fromAsync/this-constructor`,
-`built-ins/Promise/prototype/finally/subclass-species-constructor-{reject,resolve}-count`,
-`language/expressions/instanceof/S11.8.6_A2.4_T3`.
+| the 20 that genuinely leak on base | after |
+| ---------------------------------- | ----: |
+| **pass**                           | **3** |
+| fail                               |    17 |
+
+The three: `built-ins/Promise/prototype/finally/subclass-species-constructor-{reject,resolve}-count`
+and `language/expressions/instanceof/S11.8.6_A2.4_T3`. All three leak on base ⇒
+CI scores them `compile_error` ⇒ pass-after is a genuine conversion.
+
+**`built-ins/Array/fromAsync/this-constructor` is NOT a conversion** and was
+counted as one in the first cut. It does not leak on base, and A/B measurement
+shows it PASSES on base and on branch. It is a stale baseline entry that my
+change cannot touch — the code only fires where the import would have been
+emitted.
+
+Why the first cut got it wrong: I measured the 59 only AFTER, then attributed
+every pass to the change because the baseline said they were all `compile_error`.
+The baseline was the artifact; "all 59 leak" was the figure inherited from it.
+The fix is one extra run — the same corpus on base — and it is the run that turns
+"4 files pass now" into "3 of them pass BECAUSE of this".
 
 **Scope note — the first cut of this table reported 24 `skip` and was NOT
 CI-comparable.** The local runner's DEFAULT scope excludes proposals, so 21

--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -791,8 +791,13 @@ Corpus sweeps on this branch:
 - The **59 files that name `env::__instanceof_check` as their SOLE host import**
   on the 2026-08-15 standalone baseline — **0 leaking, 0 compile-refused,
   0 invalid Wasm** (each binary was `WebAssembly.compile`d).
-- gc/host **byte-identical**: sha256 of the compiled binary matched base for all
-  10 probe shapes (file-copy A/B on `identifiers.ts`).
+- gc/host **byte-identical**: sha256 of the compiled binary matched base on all
+  10 probe shapes (file-copy A/B on `identifiers.ts`). That is a SAMPLE, and it
+  is stated as one; what makes it a general claim is structural — the call site
+  is behind `noJsHost(ctx)`, which is exactly `ctx.wasi || ctx.standalone`
+  (`js-errors.ts:29`), so no gc/host compile can reach the new code at all. The
+  10 shapes are chosen to exercise every dispatch arm, i.e. they test the GATE,
+  not the population.
 
 ### The answer table, and why each arm is the least-wrong one available
 
@@ -906,6 +911,28 @@ Also green on this branch: all **8 equivalence shards**
 `tests/es5-standalone-instanceof.test.ts` (20),
 `tests/issue-3962-native-user-instanceof.test.ts`,
 `tests/issue-4276-instanceof-object-family.test.ts`, `tests/issue-2994.test.ts`.
+
+### The WASI half of the gate, measured rather than inferred
+
+`noJsHost` is `ctx.wasi || ctx.standalone` (`js-errors.ts:29`) — **two** targets,
+and the test262 lane measures only the first. The "cannot regress a passing test"
+argument was therefore verified for standalone (leak guard + baseline) and merely
+INFERRED for WASI ("an unsatisfiable `env::` import cannot instantiate under
+wasmtime"). That inference is sound but it is not a measurement, and a WASI unit
+test can assert compile-time properties without ever instantiating — so the
+inference does not even cover the shape most likely to notice.
+
+Measured instead. All **199 test files that compile with `target: "wasi"`**, run
+on this branch and on base (file-copy revert of `identifiers.ts`), comparing
+sorted failing-test NAMES rather than counts:
+
+| batch          | base | branch | name-set diff |
+| -------------- | ---: | -----: | ------------- |
+| files 1–67     |   49 |     49 | **identical** |
+| files 68–199   |   55 |     55 | **identical** |
+
+104 pre-existing failures (linear-IR families unrelated to this issue), **zero
+delta**. The WASI lane is inert to this change, as measured.
 
 ### Deliberately left, with reasons
 

--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -1067,3 +1067,18 @@ supplying the import, while CI records it as `compile_error`. A local pass/fail 
 a leaking file is an upper bound on the host answer, **not** the verdict CI
 scores. This is what makes the identical before/after answer runs above meaningful
 rather than vacuous — and it is a trap for any "these tests pass locally" claim.
+
+**Every A/B above reverted through `.tmp/identifiers.base.ts`, and that artifact
+was verified byte-identical to base commit `88ff8c4` (`diff` against
+`git show 88ff8c4:…`), not assumed.** One diff validates the whole chain — the
+WASI 199-file run, the 59-file base sweep, the 150-file sample, the gc/host
+shas, and the `%TypedArray%` wrong-throw diagnosis all rest on that one file
+being what it claims to be.
+
+**Operational rule, better than "always measure the before-state": make the
+before-state CHEAP before you start.** Capture the revert copy at the FIRST
+edit, when it costs one `cp` (CLAUDE.md's file-copy A/B pattern). Whether the
+before-run happens turns out to depend less on discipline than on its price at
+the moment you face it: the 11-file directory A/B got run because it was cheap,
+the 59-file one got skipped because it was a corpus compile and the baseline was
+sitting right there claiming to already know the answer.

--- a/plan/issues/4433-expression-statement-side-effect-elimination.md
+++ b/plan/issues/4433-expression-statement-side-effect-elimination.md
@@ -239,6 +239,31 @@ believed instead of measured**. A population filter is exactly such a claim, and
 the word "exhaustive" is what makes it dangerous: it tells the next reader not to
 re-check. The conclusion did not move; the warrant for it did.
 
+**A third check, on the denominator itself — which lane makes these statements
+top-level.** `find-affected.mts` classifies the top-level statements of the
+**raw** `.js` file, but the runner's legacy wrapper lane emits a test body
+**inside `export function test() { try { … } }`**. If that were the lane doing
+the compiling, the raw-file scan would be measuring statements the collector
+never sees, and "83 affected files" would be a scan artifact rather than a
+population. Verified rather than argued, in two steps:
+
+1. Feeding `S11.14_A3.js` through `wrapTest` gives a module whose top-level
+   statement kinds are `{VariableStatement: 4, ClassDeclaration: 1,
+   FunctionDeclaration: 5}` — **zero** top-level ExpressionStatements. So the
+   wrapper lane alone cannot explain the conversion.
+2. Instrumenting the collect path and running that file through the runner
+   prints the collected statement as
+   `[…]/test262/test/language/expressions/comma/S11.14_A3.js "x = 1, y = 2, z = 3;"`
+   — the **raw** test path. The runner's original-harness lane compiles the file
+   as a real module, so its top-level statements genuinely are top-level.
+
+The scan is therefore the right proxy **for the lane that does the compiling**,
+and the conversions run through the collector rather than the `typeof` site —
+confirmed by reverting each half independently: with only the collector fix all
+three conversions hold; with only the `typeof` fix none do. Worth stating
+because the wrapper is the more visible of the two lanes, and reading it alone
+would say this fix cannot affect test262 at all.
+
 **A second, independent narrowing in the same section: the lane.** Every corpus
 run here passed `"standalone"` to `runTest262File`, chosen by habit because the
 issue arrived from a standalone-lane investigation — but neither changed site is

--- a/plan/issues/4433-expression-statement-side-effect-elimination.md
+++ b/plan/issues/4433-expression-statement-side-effect-elimination.md
@@ -198,6 +198,23 @@ expected direction — the change can only add evaluation, and a negative test i
 scored on whether an error is raised — but it is now measured rather than
 assumed.
 
+**Both groups, in the JS-host / GC lane.** Neither changed site is target-gated —
+`collectOrRecordUnnamedExpressionStatement` and `compileExpressionStatement` run
+for every target — so the standalone runs above measure the behaviour but not
+the other lane's outcome. All 83 re-run with no `target` argument:
+
+| | pass | fail | compile_error | skip |
+| --- | --- | --- | --- | --- |
+| before | 55 | 26 | 1 | 1 |
+| after | 57 | 24 | 1 | 1 |
+
+**Net +2 (+3 / −1)** — and the second lane is not a formality: it converts a
+file the standalone lane never shows, `built-ins/Proxy/has/call-object-create.js`
+(fail → pass), on top of the same `comma/S11.14_A3.js` and `void-await-expr.js`.
+The one regression is the same `await-expr-regexp.js` misparse in both lanes.
+
+Combined: **standalone +1, host/GC +2, no lane negative.**
+
 The `typeof` site is measured separately because it also fires inside function
 bodies, which the top-level scan cannot see: `.tmp/find-typeof-affected.mts`
 finds **3** affected files in the same corpus, and all three are byte-identical
@@ -221,6 +238,17 @@ reporting it. The shared shape across all four incidents — two of theirs, my
 believed instead of measured**. A population filter is exactly such a claim, and
 the word "exhaustive" is what makes it dangerous: it tells the next reader not to
 re-check. The conclusion did not move; the warrant for it did.
+
+**A second, independent narrowing in the same section: the lane.** Every corpus
+run here passed `"standalone"` to `runTest262File`, chosen by habit because the
+issue arrived from a standalone-lane investigation — but neither changed site is
+target-gated, so half the story was a lane the numbers never touched. Prompted by
+the #2916 lane's own audit of the identical defect (`noJsHost` is
+`ctx.wasi || ctx.standalone` — two targets, one measured). Adding the host/GC
+lane above did not merely confirm the standalone result: it converted a file the
+standalone lane cannot show at all. **A narrowed population hides evidence for
+the conclusion as readily as against it**, which is why "the conclusion didn't
+change" is not a reason to skip the check.
 
 ### Suites
 

--- a/src/codegen/native-dynamic-instanceof.ts
+++ b/src/codegen/native-dynamic-instanceof.ts
@@ -15,17 +15,18 @@
  * `env::__instanceof_check`. A host-free binary cannot satisfy that import, so
  * the module does not instantiate and the #2961 leak guard refuses the test.
  *
- * Measured on the 2026-08-15 standalone baseline: **59 files name
- * `env::__instanceof_check` as their SOLE host import**. It is the single import
- * standing between ordinary `instanceof` code and a genuinely host-free module —
- * which is the deliverable here. Conformance rows are the secondary metric (see
- * the issue's tiering).
+ * **Scale, measured on the branch base rather than quoted from the baseline.**
+ * The 2026-08-15 standalone baseline lists 59 files naming
+ * `env::__instanceof_check` as their SOLE host import, and ~1,500 more naming it
+ * alongside others. Both figures are STALE and neither should be quoted. Compiled
+ * on current main: **20** of the 59 still emit it, and of a 150-file
+ * deterministic sample of the ~1,500, **zero** do — earlier slices (#2998,
+ * #3962, Slice A, #4276) resolve those sites statically now.
  *
- * The baseline ALSO lists ~1,500 files naming it alongside other imports, but do
- * not quote that as scale: it is stale. A 150-file deterministic sample of that
- * population, compiled on current main, has **zero** files still emitting
- * `__instanceof_check` — earlier slices (#2998, #3962, Slice A, #4276) resolve
- * those sites statically now. Only the 59 are live.
+ * So the live population is **20 files**, and this closes all of them. It is the
+ * single import standing between ordinary `instanceof` code and a genuinely
+ * host-free module — which is the deliverable. Conformance rows are the secondary
+ * metric (see the issue's tiering); the measured yield is +3.
  *
  * ## What the runtime can actually decide, and what it cannot
  *

--- a/src/codegen/native-dynamic-instanceof.ts
+++ b/src/codegen/native-dynamic-instanceof.ts
@@ -16,10 +16,16 @@
  * the module does not instantiate and the #2961 leak guard refuses the test.
  *
  * Measured on the 2026-08-15 standalone baseline: **59 files name
- * `env::__instanceof_check` as their SOLE host import** and **1,560 name it at
- * all**. It is the single import standing between ordinary `instanceof` code and
- * a genuinely host-free module — which is the deliverable here. Conformance rows
- * are the secondary metric (see the issue's tiering).
+ * `env::__instanceof_check` as their SOLE host import**. It is the single import
+ * standing between ordinary `instanceof` code and a genuinely host-free module —
+ * which is the deliverable here. Conformance rows are the secondary metric (see
+ * the issue's tiering).
+ *
+ * The baseline ALSO lists ~1,500 files naming it alongside other imports, but do
+ * not quote that as scale: it is stale. A 150-file deterministic sample of that
+ * population, compiled on current main, has **zero** files still emitting
+ * `__instanceof_check` — earlier slices (#2998, #3962, Slice A, #4276) resolve
+ * those sites statically now. Only the 59 are live.
  *
  * ## What the runtime can actually decide, and what it cannot
  *


### PR DESCRIPTION
## Description

The final audit records from the #4426 campaign's cross-lane verification, appended to the #2916 and #4433 issue files, plus docstring corrections in `native-dynamic-instanceof.ts` (comment-only).

- **#2916** — three audits, each tightening a claim shipped in #4533:
  - The WASI half of the dispatch gate's safety argument is now *measured* (199 WASI-compiling files, zero failing-name-set delta), and the "gc/host byte-identical" claim is scoped to its evidence.
  - The baseline's ~1,500-file co-leak population is stale (150-file sample: zero files still emit `__instanceof_check` on current main); the scale claim quoting it is removed.
  - **Headline corrected: +3 conversions from a live population of 20, not +4 from 59.** Compiling the 59 baseline sole-leak files on the merge base shows only 20 still leaked (earlier slices had cleaned the rest); one previously-claimed conversion passes on both trees. The docstring and issue file now quote only measured-on-base figures. The substrate's effect is unchanged: every genuinely-leaking file compiles clean, 0 invalid Wasm, 0 regressions.
- **#4433** — two audits: the habitual standalone lane filter concealed a host-lane improvement (host/GC is **+2**, including a Proxy test the standalone lane cannot exhibit), and the "83 affected files" denominator is now verified against the lane that actually compiles test bodies (the original-harness lane compiles raw modules — established two independent ways, and cross-linked to the same lane property #2916's instrument note flags from the opposite direction).

The shared methodological record, now in both issue files: five of the campaign's seven documentation corrections were one defect — *a figure inherited from an artifact, restated as a measurement*. The mechanical check that catches it: which artifact, when was it made, and has the before-state been measured directly.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7