### PR TITLE
fix(codegen): function instance own-property reflection + §15.1.5 prefix arity (#4436)

### DIFF
--- a/plan/issues/4436-function-instance-own-properties-residual.md
+++ b/plan/issues/4436-function-instance-own-properties-residual.md
@@ -1,0 +1,197 @@
+---
+id: 4436
+title: "ES5 standalone: `length` as an own property of a function instance + §15.1.5 ExpectedArgumentCount"
+status: in-progress
+assignee: ttraenkler/claude-es5-standalone
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: function-objects, property-descriptors, own-properties
+goal: standalone-gap
+related: [2896, 3017, 3468, 4010, 4098, 4194, 4241, 4390]
+umbrella: 2860
+loc-budget-allow:
+  - src/codegen/index.ts
+  - src/codegen/object-runtime.ts
+func-budget-allow:
+  - src/codegen/index.ts::generateModule
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
+---
+
+# #4436 — Function-instance own properties (`function-object-semantics` residual)
+
+Residual of the ES5-standalone `function-object-semantics` bucket after #2896
+(builtin function-object metadata) and #4390 (global function properties), both
+`done`. Those two moved **builtin** function values and the **realm object**;
+neither touched a **user** function instance, which is what the remaining
+failures are about.
+
+## Bucket map (measured 2026-08-15)
+
+Source: `.test262-cache/test262-standalone-current.jsonl` (48,735 entries,
+18,029 non-pass) plus a 25-file driver run at base `b5159d3`.
+
+### Corpus-wide, by failure message
+
+| bucket                                          | count | in scope |
+| ----------------------------------------------- | ----: | -------- |
+| `name should be an own property`                |    74 | partial  |
+| `length should be an own property`              |    32 | **yes**  |
+| `<other> should be an own property`             |   399 | no — 266 are `language/{statements,expressions}/class` (class-field/method descriptors, a different stratum) |
+| `prototype should be an own property`           |     8 | no       |
+| `f.hasOwnProperty('length')` (Function/length/*) |     7 | no — `new Function(...)`, eval lane |
+| `Expected obj[length] NOT to be writable`       |     4 | no — same eval lane |
+
+### The 25-file driver sample, before → after
+
+| bucket                                                        | before | after | note |
+| ------------------------------------------------------------- | -----: | ----: | ---- |
+| `length should be an own property`                            |     12 |     0 | **cause removed** |
+| `length descriptor value should be 0` (new, narrower message) |      0 |     9 | residual R2 — one step away |
+| `name should be an own property`                              |      3 |     3 | residual R1 |
+| passing                                                       |      6 |     8 | +2 flips |
+| unrelated fails (proto chain, `arguments.callee`, TypeError)  |      4 |     4 | untouched |
+
+The nine `-dflt` files did **not** flip, but their failure moved from "the
+property does not exist" to "the property exists, is configurable, is
+non-writable, is non-enumerable, and its value is N instead of 0". Every step
+of `verifyProperty` now passes except the value comparison — see R2.
+
+## Root causes
+
+Two independent defects, both confirmed by direct probe, not inferred.
+
+### C1 — the reflective surface did not know function instances have `length`
+
+`f.length` folded to a constant for a typed receiver, but every **reflective**
+surface — the one `propertyHelper.js` actually uses, because its receiver and
+key are runtime parameters — said the property was absent:
+
+| read on `function f(a,b){}` (standalone) | before | spec |
+| ----------------------------------------- | ------ | ---- |
+| `f.length` (static fold)                 | 2      | 2    |
+| `f["length"]` (dynamic key)              | **0**  | 2    |
+| `f.hasOwnProperty("length")`             | false  | true |
+| `Object.getOwnPropertyDescriptor(f,…)`   | undef  | desc |
+| `Object.getOwnPropertyNames(f)` ∋ length | false  | true |
+
+The dynamic `0` was deliberate: `dyn-read.ts`'s closure arm returned a flat
+`box_number(0)` for any closure `__builtinfn_get_meta` declined, commented
+*"arity not statically tracked"*. It **is** tracked — every struct in the
+funcref-wrapper hierarchy carries the declared formal count in the `$arity`
+header slot (#3673).
+
+### C2 — `ExpectedArgumentCount` was computed as a FILTER, not a PREFIX
+
+`property-access-dispatch.ts` counted parameters with
+
+```js
+sig.parameters.filter((p) => !decl.dotDotDotToken && !decl.questionToken && !decl.initializer).length
+```
+
+justified by *"TS forbids required-after-optional, so filtering is equivalent to
+iterating until the first one."* That premise does not hold for the JavaScript
+this compiler accepts (`allowJs: true`, and every Test262 file):
+
+| source                     | filter | §15.1.5 |
+| -------------------------- | -----: | ------: |
+| `function f(x = 42, y) {}` |  **1** |   **0** |
+| `function f(x, y=4, z) {}` |  **2** |   **1** |
+
+§15.1.5 stops at the first parameter that HasInitializer; parameters to its
+right never count, **even when they are themselves required**. These are exactly
+the `f2`/`f4` cases of `function/length-dflt.js`.
+
+## What shipped
+
+- **`src/codegen/function-expected-argument-count.ts`** (new) — §15.1.5 as a
+  prefix walk, stated once so the static fold and any future runtime carrier
+  cannot disagree about one observable value. Wired into the `<fn>.length` fold.
+- **`src/codegen/function-instance-props.ts`** (new) — a **generic closure arm**
+  appended to the three #2896 helpers every reflective surface already funnels
+  through, so `hasOwnProperty` / `getOwnPropertyDescriptor` /
+  `getOwnPropertyNames` / `delete` / the non-writable `__extern_set` refusal /
+  the dynamic `fn[key]` read all move together and cannot disagree:
+  - `__builtinfn_get_meta(fn,"length")` → `box_number($arity)`
+  - `__builtinfn_delete(fn,"length")` → #4098 self-referential bag tombstone
+  - `__builtinfn_push_ownnames(fn,vec)` → push `"length"`
+  - `__builtinfn_gopd` derives `{writable:false, enumerable:false,
+    configurable:true}` from `get_meta` + `FLAG_CONFIGURABLE` — §10.2.4 by
+    construction, not by a second spelling of the flags.
+
+### Three things that were load-bearing and are easy to get wrong
+
+1. **Ordering.** `fillFunctionInstanceProps` runs *before* `fillBuiltinFnMeta`;
+   both splice at body index 0, so the builtin arms end up in **front**. A
+   #2896 meta struct is itself a funcref-wrapper-root descendant, so the generic
+   `ref.test` matches it too — the builtin arms always `return` (including the
+   deleted case), which is what stops a raw `$arity` shadowing a builtin's spec
+   arity. Verified by control: 51/51 `built-ins/**/{length,name,prop-desc}.js`
+   still pass.
+2. **Deletability ships with visibility (#4010's ordering law).**
+   `propertyHelper`'s `isConfigurable` is `delete obj[name]; return
+   !hasOwnProperty(obj,name)`, so a visible-but-undeletable `length` fails every
+   `verifyProperty` naming `configurable: true` — i.e. all of them. #4055 v1
+   ignored this and the queue parked it at **-684**. The delete arm is in the
+   same change.
+3. **`push_ownnames` must PUSH AND FALL THROUGH, not return 1.** Its caller
+   reads a `1` as "this receiver's own names are complete" and returns the
+   vector, skipping the `bagKeysIf` carrier-bag key source. Correct for a
+   builtin, wrong for a user closure, which also has #3468 expandos — the first
+   cut dropped `p` from `getOwnPropertyNames(f)` after `f.p = 12`. Caught by
+   `issue-4010.test.ts`, not by the new tests; fixed and now commented at the
+   site.
+
+## Verification
+
+- **Target sample** (25 files, `--target standalone`, real runner): **6 → 8
+  pass, 0 regressions**; the 12-file "length should be an own property" cause is
+  gone.
+- **Controls, 122 files, 122/122 pass**: 71 currently-passing files sampled by
+  stride from `language/{statements,expressions}/{function,arrow-function,generators,class}`
+  ∪ `built-ins/Function` ∪ `Object/{getOwnPropertyDescriptor,getOwnPropertyNames,keys,defineProperty}`
+  (pool 9,458), plus 51 sampled from `built-ins/**/{length,name,prop-desc}.js`
+  (pool 952) specifically to catch builtin-metadata shadowing.
+- **Vitest**: `tests/issue-4436.test.ts` new, 23/23. `issue-2896`,
+  `issue-3468-closure-own-props`, `issue-4010`, `issue-4194-instance-expando`,
+  `issue-4241-carrier-bag-slot`, `issue-4098-error-expando`,
+  `es5-standalone-function-semantics`, `es5-standalone-arguments-callee` all
+  green.
+- **Pre-existing, NOT caused by this change**:
+  `tests/issue-3017-function-poison-pill.test.ts` fails 4/16 — identical count
+  and identical tests on base `b5159d3` (A/B'd with file-copy revert). #3017 is
+  in-progress in another lane; not touched here.
+- **Gates**: `typecheck`, `check:oracle-ratchet` (+0/+0),
+  `check:stack-balance`, `check:ir-fallbacks` all OK. `check:loc-budget` /
+  `check:func-budget` need the allowances in this file's frontmatter — the
+  growth is 8 lines in `index.ts` and 2 in `object-runtime.ts`, entirely the
+  reserve/fill wiring a new subsystem module requires; all new logic is in the
+  two new modules.
+
+### One test expectation was updated, deliberately
+
+`issue-3468-closure-own-props.test.ts` — *"does not let a custom own property
+shadow the builtin metadata path"* asserted `(g as any).length === 0` for a
+two-parameter arrow. The `0` was the flat `box_number(0)` defect, not the
+invariant under test (which is "writing a custom property must not disturb
+`.length`"). Updated to `2`, with the reasoning recorded at the site. Pinning
+`0` would have pinned the bug.
+
+## Residuals, with owners
+
+| id | residual | why it is not fixed here | owner |
+| -- | -------- | ------------------------ | ----- |
+| **R1** | `name` is not an own property of a user closure (`hasOwnProperty("name")` false; the static fold answers). 74 corpus files, though most also need class/async/destructuring work. | `name` has no runtime carrier on a user closure. Adding one needs either a new closure-header field (changes gc-mode bytes — #2896's standing constraint) or a **per-function meta subtype**, which is the real design: generalize `ensureBuiltinFnMetaType` to append `bfnstate`/`bfnid` after the base's OWN fields (the constructible wrapper has 4, capture subtypes have 3+N, so the hardcoded `BFN_STATE_FIELD_IDX`/`BFN_ID_FIELD_IDX` must become per-entry indices in `ctx.builtinFnMetaByTypeIdx`). Then every existing arm answers `name` AND an exact `length` with no new runtime code. | **unowned — file as the next slice of #2860** |
+| **R2** | The reflective `length` VALUE is `$arity` (declared formal count), not §15.1.5, for a function with a defaulted/optional parameter. 9 of 25 sample files stop here. Rest params are already correct (the allocation site pushes `max(0, params-1)`). | `$arity` cannot simply be re-pointed at the spec value: `closure-exports.ts` widens an under-applied dispatch to `max(n, $arity)` and would stop padding omitted arguments. Same per-function meta subtype as R1 fixes it — R1 and R2 are **one** slice. | **unowned — same slice as R1** |
+| **R3** | `new function f(){ this.p = 1; }` (an INLINE function expression as the `new` callee) traps with a null dereference; `var F = function f(){…}; new F()` works. 3+ files (`S13.2.2_A16_T1/T2/T3`). | Separate construct-path defect, unrelated to own properties. Confirmed by probe. | **unowned — file separately** |
+| **R4** | `f.constructor === Function`, `Function.hasOwnProperty("length")` need the `Function` intrinsic as a real object. | eval / `new Function` lane. | **out of scope by instruction** |
+| **R5** | `f.hasOwnProperty("prototype")` false; `propertyIsEnumerable` on a closure expando returns false. | Adjacent own-property surfaces on function instances; same substrate, not measured into a bucket here. | **unowned** |
+| **R6** | Accessor `.length` reads `NaN` (`gOPD(o,"s").set.length`). | Accessor-extraction defect, not a function-object one. | **unowned** |
+| **R7** | `caller`/`arguments` poison pills. | #3017, in-progress in another lane. | **#3017** |

--- a/src/codegen/function-expected-argument-count.ts
+++ b/src/codegen/function-expected-argument-count.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4436) ECMA-262 §15.1.5 **ExpectedArgumentCount** — the value a function
+ * object's `length` own property must carry.
+ *
+ * ## The defect this replaces
+ * The `<fn>.length` static fold (`property-access-dispatch.ts`) counted the
+ * parameters that are *not* optional/defaulted/rest with a `filter().length`,
+ * justified in a comment by:
+ *
+ * > TS forbids required-after-optional, so filtering out optional/default/rest
+ * > is equivalent to iterating until the first one.
+ *
+ * That premise is **false for the JavaScript this compiler actually accepts**
+ * (`allowJs: true`, and every Test262 file). TypeScript rejects
+ * `function f(x?: number, y: number) {}`, but plain JS
+ * `function f(x = 42, y) {}` is legal and pervasive — and for it the two
+ * formulations disagree:
+ *
+ * | source                  | filter() | §15.1.5 | spec `f.length` |
+ * | ----------------------- | -------- | ------- | --------------- |
+ * | `function f(x, y)`      | 2        | 2       | 2               |
+ * | `function f(x = 42)`    | 0        | 0       | 0               |
+ * | `function f(x = 42, y)` | **1**    | **0**   | **0**           |
+ * | `function f(x, y = 4)`  | 1        | 1       | 1               |
+ * | `function f(x, y=4, z)` | **2**    | **1**   | **1**           |
+ *
+ * §15.1.5 is a *prefix* count, not a *filter*: it walks the FormalsList and
+ * returns at the first `FormalParameter` that HasInitializer. A defaulted
+ * parameter therefore truncates the count for every parameter to its right,
+ * including required ones. Measured on `main` 2026-08-15 (standalone): rows 3
+ * and 5 above are exactly the `f2`/`f4` cases of
+ * `language/{statements,expressions}/function/length-dflt.js`.
+ *
+ * ## Why a leaf module
+ * The same count is needed by the static fold AND by any runtime metadata
+ * carrier for a function instance (the `length` own property is one value, so
+ * the fold and the descriptor must not be able to disagree — that divergence is
+ * precisely what #2896's header warns about for `name`/`length`). Stating it
+ * once, in a module that imports only `typescript`, lets both sides call it
+ * without either importing the other.
+ *
+ * A rest parameter also terminates the walk: §15.1.5's FunctionRestParameter
+ * production yields 0 and contributes nothing. `questionToken` (a TS-only
+ * spelling of "has no expected argument") is treated as an initializer, which
+ * is what the previous filter did too.
+ */
+import { ts } from "../ts-api.js";
+
+/**
+ * §15.1.5 ExpectedArgumentCount over a parameter list: the number of leading
+ * parameters before the first defaulted, optional or rest parameter.
+ *
+ * Accepts the declaration nodes directly, so both a `ts.Signature`'s resolved
+ * parameters (via each symbol's `valueDeclaration`) and a raw
+ * `SignatureDeclaration.parameters` can be measured by the same rule. A
+ * parameter whose declaration is unavailable is counted as expected — the
+ * conservative direction, and the one the previous `filter` took.
+ */
+export function expectedArgumentCountOfParams(params: readonly (ts.ParameterDeclaration | undefined)[]): number {
+  let count = 0;
+  for (const decl of params) {
+    // No declaration to inspect ⇒ treat as an ordinary required formal.
+    if (decl === undefined) {
+      count++;
+      continue;
+    }
+    if (decl.dotDotDotToken !== undefined || decl.questionToken !== undefined || decl.initializer !== undefined) {
+      // §15.1.5: the walk STOPS here — parameters to the right never count,
+      // even when they are themselves required.
+      return count;
+    }
+    count++;
+  }
+  return count;
+}
+
+/**
+ * §15.1.5 over a resolved `ts.Signature`. Each parameter symbol's
+ * `valueDeclaration` is the `ts.ParameterDeclaration` when the signature came
+ * from real source; ambient/library signatures may lack one, and those count as
+ * expected (see {@link expectedArgumentCountOfParams}).
+ */
+export function expectedArgumentCountOfSignature(sig: ts.Signature): number {
+  return expectedArgumentCountOfParams(
+    sig.parameters.map((p) => {
+      const decl = (p as ts.Symbol).valueDeclaration;
+      return decl !== undefined && ts.isParameter(decl) ? decl : undefined;
+    }),
+  );
+}

--- a/src/codegen/function-instance-props.ts
+++ b/src/codegen/function-instance-props.ts
@@ -1,0 +1,460 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4436) `length` as a genuine OWN property of a **user function instance**
+ * under `--target standalone`.
+ *
+ * ## What was missing
+ * #2896 gave *builtin* function values reflective `name`/`length` by minting a
+ * per-(builtin, member) meta SUBTYPE and answering from
+ * `ctx.builtinFnMetaByTypeIdx`. A **user** closure gets no meta subtype, so
+ * every reflective surface saw nothing (measured on `main` 2026-08-15,
+ * `--target standalone`):
+ *
+ * | read on `function f(a,b){}`                      | before | spec |
+ * | ------------------------------------------------ | ------ | ---- |
+ * | `f.length` (STATIC fold, typed receiver)         | 2      | 2    |
+ * | `f["length"]` (DYNAMIC key — `verifyProperty`)   | **0**  | 2    |
+ * | `f.hasOwnProperty("length")`                     | false  | true |
+ * | `Object.getOwnPropertyDescriptor(f,"length")`    | undef  | desc |
+ * | `Object.getOwnPropertyNames(f)` ∋ `"length"`     | false  | true |
+ *
+ * The dynamic read's `0` is not an accident: `dyn-read.ts`'s closure arm
+ * deliberately returned a flat `box_number(0)` for any closure
+ * `__builtinfn_get_meta` declined ("arity not statically tracked"). It IS
+ * tracked — every struct in the funcref-wrapper hierarchy carries the closure's
+ * declared formal count in the `$arity` header slot (#3673). This module reads
+ * it.
+ *
+ * ## Mechanism — one generic arm, six surfaces
+ * Rather than a new reflective path, this appends a **generic closure arm** to
+ * the three #2896 helpers that every reflective surface already funnels
+ * through. Adding it there means `hasOwnProperty`, `getOwnPropertyDescriptor`,
+ * `getOwnPropertyNames`, `delete`, the non-writable `__extern_set` refusal
+ * (`buildBuiltinFnSetRefusalArm`) and the dynamic `fn[key]` read all move
+ * together, and cannot disagree with each other:
+ *
+ * ```
+ * __builtinfn_get_meta(fn, "length")  → box_number($arity)   (the descriptor VALUE)
+ * __builtinfn_delete(fn, "length")    → bag tombstone, 1     (configurable: true)
+ * __builtinfn_push_ownnames(fn, vec)  → push "length"        (getOwnPropertyNames)
+ * ```
+ *
+ * `__builtinfn_gopd` derives its descriptor from `get_meta` with
+ * `FLAG_CONFIGURABLE`, i.e. `{writable:false, enumerable:false,
+ * configurable:true}` — exactly §10.2.4 for a function's `length`. So the
+ * descriptor is right by construction, not by a second spelling of the flags.
+ *
+ * ## Ordering — the builtin arms MUST win
+ * `fillFunctionInstanceProps` runs **before** `fillBuiltinFnMeta`, and both
+ * splice at body index 0, so the builtin arms end up in FRONT of the generic
+ * one. That is required, not incidental: a builtin meta struct is itself a
+ * descendant of the funcref-wrapper root, so the generic `ref.test` matches it
+ * too. The builtin arm always `return`s (including the deleted case, where it
+ * returns null explicitly), so the generic arm is unreachable for any receiver
+ * #2896 owns and builtin metadata is never shadowed by a raw `$arity`.
+ *
+ * ## Deletability before visibility — the #4010 ordering law
+ * #4010 records it as a law, with a receipt: #4055 v1 widened `hasOwnProperty`
+ * over a side table without a working `delete` underneath and the merge queue
+ * parked it for **-684** host-free passes. `propertyHelper.js`'s
+ * `isConfigurable` is `delete obj[name]; return !hasOwnProperty(obj, name)`, so
+ * a visible-but-undeletable `length` fails every `verifyProperty` that names
+ * `configurable: true` — which is all of them. This module therefore ships the
+ * delete arm in the same change as the visibility arm.
+ *
+ * The tombstone is #4098's **self-referential bag entry** (`bag[k] === bag`),
+ * reused rather than reinvented: the closure `$bag` is keyed by `eqref`
+ * identity, the marker is unforgeable (a bag is unreachable from user source),
+ * and #4194 already filters it out of `gOPD` / `Object.keys` / for-in through
+ * `buildBagMarkerTestInstrs`. Reusing it means `delete f.length` cannot leak a
+ * phantom own property into enumeration.
+ *
+ * ## Why presence is checked MARKER-INCLUSIVE
+ * The generic arm answers only while the bag holds **no** entry for the key —
+ * `__fninst_bag_owns` deliberately does NOT filter the tombstone, unlike
+ * `__carrier_bag_has`. That one predicate covers both post-`delete` states in
+ * the same shape:
+ *
+ * - after `delete f.length` the bag holds the marker ⇒ `get_meta` declines ⇒
+ *   `hasOwnProperty` is false (the bag surfaces filter the marker);
+ * - after a subsequent `f.length = 5` the marker is overwritten with `5` ⇒
+ *   `get_meta` still declines ⇒ the bag's own value answers, so the resurrected
+ *   property is not shadowed by `$arity`.
+ *
+ * Filtering the marker here would make the first case answer `$arity` again and
+ * silently un-delete the property.
+ *
+ * ## Scope — `length` only, and why `name` is NOT here
+ * `$arity` is a per-INSTANCE field, so `length` needs no per-function type.
+ * `name` has no runtime carrier on a user closure and cannot be added without
+ * either a new header field (which changes gc-mode bytes — #2896's standing
+ * constraint) or a per-function meta subtype. Left as a measured residual on
+ * the issue rather than half-answered here.
+ *
+ * ## Known value divergence (documented, not hidden)
+ * `$arity` is the **declared formal count**, which equals §15.1.5
+ * ExpectedArgumentCount for every parameter list without a defaulted or
+ * optional parameter (rest is already excluded at the allocation site, which
+ * pushes `max(0, params - 1)`). For `function f(x = 42) {}` the spec `length`
+ * is 0 while `$arity` is 1. `$arity` cannot simply be re-pointed at the spec
+ * value: `closure-exports.ts`'s under-application widening dispatches at
+ * `max(n, $arity)` and would stop padding omitted arguments. The exact-value
+ * fix needs the per-function meta subtype above; it is tracked as this issue's
+ * residual.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { addFuncType } from "./registry/types.js";
+import { CLOSURE_ARITY_FIELD_IDX, getFuncRefWrapperRootTypeIdx } from "./closures/funcref-wrapper-types.js";
+import { nativeStringLiteralInstrs } from "./native-string-literals.js";
+
+/** `(externref fn, externref key) -> i32` — 1 iff fn's bag holds ANY entry for key. */
+export const FNINST_BAG_OWNS = "__fninst_bag_owns";
+/** `(externref fn, externref key) -> i32` — 1 iff the #4098 marker was written. */
+export const FNINST_TOMBSTONE = "__fninst_tombstone";
+
+const CLOSURE_BAG_LOOKUP = "__closure_bag_lookup";
+const CLOSURE_BAG_ENSURE = "__closure_bag_ensure";
+
+const EXT: ValType = { kind: "externref" };
+const I32: ValType = { kind: "i32" };
+
+/**
+ * `{writable:false, enumerable:false, configurable:true}` — §10.2.4, the
+ * attribute set of a function object's `length`. Same literal
+ * `object-runtime.ts` uses for the #2896 builtin descriptors, so the two paths
+ * cannot drift apart in what they claim about the same property.
+ */
+const FLAG_CONFIGURABLE = 0x04;
+
+/**
+ * Reserve the two natives as placeholder defined funcs so the spliced arms can
+ * bake a `call <idx>` before the fill knows their bodies. Append-only mint (no
+ * funcIdx shifts), idempotent, and a no-op outside standalone — in gc/host mode
+ * the `env::__extern_*` imports own the dynamic-property path and registering
+ * these would only shift `funcMap` indices.
+ */
+export function reserveFunctionInstanceProps(ctx: CodegenContext): void {
+  if (!ctx.standalone) return;
+  if (ctx.funcMap.get(FNINST_BAG_OWNS) !== undefined) return;
+
+  const reserve = (name: string): void => {
+    const typeIdx = addFuncType(ctx, [EXT, EXT], [I32], `$${name}_type`);
+    const funcIdx = mintDefinedFunc(ctx);
+    // Locals are assigned at FILL; the "nothing to add" placeholder uses none.
+    pushDefinedFunc(ctx, funcIdx, {
+      name,
+      typeIdx,
+      locals: [],
+      body: [{ op: "i32.const", value: 0 }],
+      exported: false,
+    });
+    ctx.funcMap.set(name, funcIdx);
+  };
+
+  reserve(FNINST_BAG_OWNS);
+  reserve(FNINST_TOMBSTONE);
+}
+
+/**
+ * Fill the two natives and splice the generic closure arms into the three
+ * #2896 helpers.
+ *
+ * MUST run before `fillBuiltinFnMeta` — see the module header's ordering note.
+ * Every dependency is resolved BY NAME (funcIdx math across phases is
+ * shift-sensitive) and a missing one leaves the `0` placeholders in place, so a
+ * skipped fill degrades to exactly today's behaviour instead of trapping.
+ */
+export function fillFunctionInstanceProps(ctx: CodegenContext): void {
+  if (!ctx.standalone) return;
+  const bagOwnsIdx = ctx.funcMap.get(FNINST_BAG_OWNS);
+  const tombstoneIdx = ctx.funcMap.get(FNINST_TOMBSTONE);
+  if (bagOwnsIdx === undefined || tombstoneIdx === undefined) return;
+
+  const rootIdx = getFuncRefWrapperRootTypeIdx(ctx);
+  const objectTypeIdx = ctx.objectRuntimeTypes?.objectTypeIdx;
+  const lookupIdx = ctx.funcMap.get(CLOSURE_BAG_LOOKUP);
+  const ensureIdx = ctx.funcMap.get(CLOSURE_BAG_ENSURE);
+  const objFindIdx = ctx.funcMap.get("__obj_find");
+  const externSetIdx = ctx.funcMap.get("__extern_set");
+  const boxNumIdx = ctx.funcMap.get("__box_number");
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push");
+  const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals");
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  if (
+    rootIdx === undefined ||
+    objectTypeIdx === undefined ||
+    lookupIdx === undefined ||
+    ensureIdx === undefined ||
+    objFindIdx === undefined ||
+    externSetIdx === undefined ||
+    boxNumIdx === undefined ||
+    strFlattenIdx === undefined ||
+    strEqualsIdx === undefined ||
+    anyStrTypeIdx < 0
+  ) {
+    return;
+  }
+
+  const setFn = (name: string, locals: { name: string; type: ValType }[], body: Instr[]): void => {
+    const idx = ctx.funcMap.get(name);
+    if (idx === undefined) return;
+    const fn = definedFuncAt(ctx, idx);
+    if (!fn) return;
+    fn.locals = locals;
+    fn.body = body;
+  };
+
+  // ── __fninst_bag_owns(fn, key) -> i32 ─────────────────────────────────────
+  // LOOKUP, never ENSURE: a presence *query* must not allocate a bag, or merely
+  // reading `f.length` would mutate the side table and hand a later
+  // `__integrity_bag` consumer a carrier that previously had none
+  // (`carrier-bag-hasown.ts`'s rule). Marker-INCLUSIVE by design — see header.
+  setFn(
+    FNINST_BAG_OWNS,
+    [{ name: "__bag", type: EXT }],
+    [
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: lookupIdx },
+      { op: "local.tee", index: 2 },
+      { op: "ref.is_null" },
+      { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
+      // The bag is a `__new_plain_object` product; screen before the cast so a
+      // future substrate change can never trap inside a helper that must not
+      // throw (#3468 S1 discipline).
+      { op: "local.get", index: 2 },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
+      { op: "local.get", index: 2 },
+      { op: "any.convert_extern" },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: objFindIdx },
+      { op: "ref.is_null" },
+      { op: "i32.eqz" },
+    ],
+  );
+
+  // ── __fninst_tombstone(fn, key) -> i32 ────────────────────────────────────
+  // ENSURE (not lookup): a delete is a mutation, and it is the one operation
+  // that legitimately has to create the receiver's bag. The stored value is the
+  // bag ITSELF — #4098's unforgeable marker.
+  setFn(
+    FNINST_TOMBSTONE,
+    [{ name: "__bag", type: EXT }],
+    [
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: ensureIdx },
+      { op: "local.tee", index: 2 },
+      { op: "ref.is_null" },
+      { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
+      { op: "local.get", index: 2 }, // receiver = the bag
+      { op: "local.get", index: 1 }, // key
+      { op: "local.get", index: 2 }, // value = the bag  ← the marker
+      { op: "call", funcIdx: externSetIdx },
+      { op: "i32.const", value: 1 },
+    ],
+  );
+
+  /**
+   * `local.get <recvAny>; ref.test $root` — is the receiver a closure in the
+   * funcref-wrapper hierarchy? Closure shapes OUTSIDE it (fnctor ctor closures)
+   * are deliberately not matched; they keep today's answers.
+   */
+  const isClosure = (anyLocal: number): Instr[] => [
+    { op: "local.get", index: anyLocal },
+    { op: "ref.test", typeIdx: rootIdx },
+  ];
+
+  /**
+   * `i32`: is param 1 the string `"length"`?
+   *
+   * Classified HERE rather than read from `fillBuiltinFnMeta`'s shared
+   * `isLen` local (5): that preamble returns early when the module
+   * materialized no builtin closure at all (`metaMap.size === 0`), which would
+   * leave local 5 unset and silently disable this arm for exactly the programs
+   * that have only user functions. A non-string key can never be `"length"`,
+   * so the `ref.test` guard also keeps the flatten/compare off every
+   * numeric-key read.
+   *
+   * A FACTORY (fresh `Instr` objects per call): the same shape goes into two
+   * different function bodies, and aliasing one `Instr[]` into both would
+   * double-remap on a later import shift (see
+   * `reference_shared_instr_object_dce_double_remap`).
+   */
+  const keyIsLength = (): Instr[] => [
+    { op: "local.get", index: 1 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: anyStrTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: I32 },
+      then: [
+        { op: "local.get", index: 1 },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: anyStrTypeIdx },
+        { op: "call", funcIdx: strFlattenIdx },
+        { op: "ref.as_non_null" },
+        ...nativeStringLiteralInstrs(ctx, "length"),
+        { op: "call", funcIdx: strEqualsIdx },
+      ],
+      else: [{ op: "i32.const", value: 0 }],
+    },
+  ];
+
+  /** `!__fninst_bag_owns(param0, param1)` — the bag has not taken the key over. */
+  const bagFree = (): Instr[] => [
+    { op: "local.get", index: 0 },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: bagOwnsIdx },
+    { op: "i32.eqz" },
+  ];
+
+  /**
+   * The shared `(receiver is a closure) && (key is "length") && (bag free)`
+   * guard, wrapping `then`. `anyLocal` receives `any.convert_extern(param0)`.
+   */
+  const closureLengthArm = (anyLocal: number, then: Instr[]): Instr[] => [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.set", index: anyLocal },
+    ...isClosure(anyLocal),
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...keyIsLength(), ...bagFree(), { op: "i32.and" }, { op: "if", blockType: { kind: "empty" }, then }],
+    },
+  ];
+
+  // ── generic arm: __builtinfn_get_meta(fn, "length") → box_number($arity) ──
+  // Registered locals: 2 = any, 3 = fkey, 4 = isName, 5 = isLen. Only 2 is
+  // touched here, and `fillBuiltinFnMeta`'s preamble re-sets it in front.
+  const getMetaFn = ctx.mod.functions.find((f) => f.name === "__builtinfn_get_meta");
+  if (getMetaFn) {
+    getMetaFn.body.splice(
+      0,
+      0,
+      ...closureLengthArm(2, [
+        { op: "local.get", index: 2 },
+        { op: "ref.cast", typeIdx: rootIdx },
+        { op: "struct.get", typeIdx: rootIdx, fieldIdx: CLOSURE_ARITY_FIELD_IDX },
+        { op: "f64.convert_i32_s" },
+        { op: "call", funcIdx: boxNumIdx },
+        { op: "return" },
+      ]),
+    );
+  }
+
+  // ── __builtinfn_gopd's get_meta→descriptor prologue, when #2896 won't ─────
+  //
+  // `__getOwnPropertyDescriptor` calls `__builtinfn_gopd`, whose body is
+  // otherwise filled ONLY by `fillBuiltinFnMeta` — and that fill returns early
+  // when the module materialized no builtin closure meta type at all
+  // (`metaMap.size === 0`). A program of nothing but user functions is exactly
+  // that case, so `__builtinfn_gopd` would keep its `ref.null.extern`
+  // placeholder and `gOPD(f, "length")` would answer `undefined` even though
+  // `hasOwnProperty` (which calls `get_meta` DIRECTLY, one level up) answers
+  // true. Measured: that split is precisely what the first cut of this module
+  // produced. Splicing here only when #2896 will not is what keeps the two
+  // surfaces consistent without emitting the prologue twice.
+  const metaMap = ctx.builtinFnMetaByTypeIdx;
+  const builtinFillWillRun = metaMap !== undefined && metaMap.size > 0;
+  const gopdFn = ctx.mod.functions.find((f) => f.name === "__builtinfn_gopd");
+  const getMetaFuncIdx = ctx.funcMap.get("__builtinfn_get_meta");
+  const createDescIdx = ctx.funcMap.get("__create_descriptor");
+  if (!builtinFillWillRun && gopdFn && getMetaFuncIdx !== undefined && createDescIdx !== undefined) {
+    gopdFn.body.splice(
+      0,
+      0,
+      { op: "local.get", index: 0 },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: getMetaFuncIdx },
+      { op: "local.tee", index: 2 },
+      { op: "ref.is_null" },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 2 },
+          { op: "i32.const", value: FLAG_CONFIGURABLE },
+          { op: "call", funcIdx: createDescIdx },
+          { op: "return" },
+        ],
+      },
+    );
+  }
+
+  // ── generic arm: __builtinfn_delete(fn, "length") → tombstone, 1 ──────────
+  const deleteFn = ctx.mod.functions.find((f) => f.name === "__builtinfn_delete");
+  if (deleteFn) {
+    deleteFn.body.splice(
+      0,
+      0,
+      ...closureLengthArm(2, [
+        { op: "local.get", index: 0 },
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: tombstoneIdx },
+        // A failed ensure (no bag substrate) must NOT report "handled", or
+        // `delete` would claim success while the property stays visible.
+        { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 1 }, { op: "return" }] },
+      ]),
+    );
+  }
+
+  // ── generic arm: __builtinfn_push_ownnames(fn, vec) → push "length" ───────
+  // `getOwnPropertyNames` only. for-in / `Object.keys` read `__obj_ordered`
+  // (enumerable-only) and never reach here, which is what keeps `length`
+  // correctly non-enumerable.
+  //
+  // Params are (0 = fn, 1 = vec) and the ONLY registered local is 2 — the vec
+  // parameter must not be clobbered, so the receiver is narrowed into 2.
+  //
+  // ⚠ This arm PUSHES AND FALLS THROUGH — it must NOT return 1. The caller in
+  // `object-runtime-descriptors.ts` reads the result as "this receiver's own
+  // names are COMPLETE" and returns the vector immediately, skipping the
+  // `bagKeysIf` carrier-bag key source directly below it. That is right for a
+  // builtin function value (`name`/`length` are all it has) and wrong for a user
+  // closure, which also carries #3468 expandos: returning 1 here dropped `p`
+  // from `Object.getOwnPropertyNames(f)` after `f.p = 12` (caught by
+  // `issue-4010.test.ts` "function: getOwnPropertyNames includes the expando").
+  // Falling through lets the bag arm append the expandos after `length`, which
+  // is also the correct §10.1.11 creation order.
+  const pushOwnFn = ctx.mod.functions.find((f) => f.name === "__builtinfn_push_ownnames");
+  if (pushOwnFn && objVecPushIdx !== undefined) {
+    pushOwnFn.body.splice(
+      0,
+      0,
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.set", index: 2 },
+      ...isClosure(2),
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          // Presence is asked with the SAME `"length"` key the arm would push.
+          { op: "local.get", index: 0 },
+          ...nativeStringLiteralInstrs(ctx, "length"),
+          { op: "extern.convert_any" },
+          { op: "call", funcIdx: bagOwnsIdx },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 1 }, // vec
+              ...nativeStringLiteralInstrs(ctx, "length"),
+              { op: "extern.convert_any" },
+              { op: "call", funcIdx: objVecPushIdx },
+            ],
+          },
+        ],
+      },
+    );
+  }
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -278,6 +278,7 @@ import { unshiftNativeProtoToPrimitiveArm } from "./native-proto-wrapper-primiti
 import { unshiftExternGetProtoMethodArm } from "./native-proto-instance-method-read.js"; // (#4248) inherited method value
 import { fillClosurePropHelpers } from "./closure-props.js"; // (#3468 C-core) closure-own-property side table
 import { fillInstanceTombstones } from "./instance-tombstones.js"; // (#4098 G1 s1) per-instance own-property deletability
+import { fillFunctionInstanceProps } from "./function-instance-props.js"; // (#4436) user-closure `length` own property
 import { fillInstanceProps } from "./instance-props.js"; // (#4194) instance expando bag substrate
 import { fillErrorPropHelpers } from "./error-props.js"; // (#4098) native Error `$props` shared MOP
 import { fillVecPropHelpers } from "./vec-props.js"; // (#3537) array ($Vec) expando side table
@@ -5408,6 +5409,13 @@ export function generateModule(
     // `hasOwnProperty` / `getOwnPropertyNames` reads over a builtin function
     // value resolve its spec `name`/`length` at runtime, host-free. No-op when
     // no builtin closure was materialized (standalone only).
+    // (#4436) The GENERIC user-closure `length` arm must be spliced FIRST: both
+    // fills splice at body index 0, so the builtin arms below land in front of
+    // it. That ordering is required — a #2896 meta struct is itself a
+    // funcref-wrapper-root descendant, and the builtin arms always `return`
+    // (including the deleted case), so this generic arm can never shadow a
+    // builtin's own metadata with a raw `$arity`.
+    fillFunctionInstanceProps(ctx);
     fillBuiltinFnMeta(ctx);
 
     // `$__ta_ctor` name/length arm for the same meta consult — a TypedArray

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -105,6 +105,7 @@ import {
   reserveInstanceProps,
 } from "./instance-props.js";
 import { buildErrorPropSetArm, reserveErrorPropHelpers } from "./error-props.js"; // (#4098) native Error `$props` MOP
+import { reserveFunctionInstanceProps } from "./function-instance-props.js"; // (#4436) `length` own-property on user closures
 import {
   INSTANCE_FIELD_DELETED,
   buildTombstoneScreen,
@@ -1044,6 +1045,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     reserveCarrierBagVisibility(ctx); // (#4010 S3) visibility over both bags — see that module
     reserveInstanceTombstones(ctx); // (#4098 G1 s1) per-instance delete over the SAME bag
     reserveInstanceProps(ctx); // (#4194) per-instance WRITE-through + expando over that bag
+    reserveFunctionInstanceProps(ctx); // (#4436) `length` own-property on a user function instance
     // (#4160) Prototype-index store — self-gated on `ctx.standalone &&
     // ctx.protoIndexDirty`, so a flag-clear module reserves NOTHING and every
     // consult site below resolves `funcMap.get("__protoidx_*") === undefined`,

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -33,6 +33,7 @@ import {
 } from "../checker/type-mapper.js";
 import { commonScalarFieldType, ensureScalarUnbox, symbolBrand } from "./symbol-field-carrier.js";
 import { emitDynGet, widenBooleanDynamicAccess } from "./dyn-read.js";
+import { expectedArgumentCountOfSignature } from "./function-expected-argument-count.js"; // (#4436) §15.1.5
 import { emitSymbolDescLoad, ensureNativeSymbolBoundaryBridge, usesNativeSymbolProvider } from "./symbol-native.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
 import { rollbackSpeculative, snapshotSpeculative } from "./context/speculative.js";
@@ -2430,15 +2431,14 @@ export function tryLengthAndNameReads(
         !fctx.localMap.has(rootNode.text) &&
         !(fctx.boxedCaptures?.has(rootNode.text) ?? false);
       if (!isLibrarySig || !rootIsReachableBuiltin) {
-        // ES spec: Function.length = number of required params before first
-        // optional/default/rest. TS forbids required-after-optional, so filtering
-        // out optional/default/rest is equivalent to iterating until the first one.
+        // (#4436) ES §15.1.5 ExpectedArgumentCount — a PREFIX count that stops
+        // at the first defaulted/optional/rest parameter, NOT a filter of them.
+        // The old `filter().length` justified itself with "TS forbids
+        // required-after-optional", which is false for the JS this compiler
+        // accepts: `function f(x = 42, y) {}` has `length === 0`, not 1. See
+        // function-expected-argument-count.ts for the measured divergence table.
         const sig = lengthSigs[0]!;
-        const paramCount = sig.parameters.filter((p: any) => {
-          const decl = p.valueDeclaration;
-          if (!decl || !ts.isParameter(decl)) return true;
-          return !decl.dotDotDotToken && !decl.questionToken && !decl.initializer;
-        }).length;
+        const paramCount = expectedArgumentCountOfSignature(sig);
         fctx.body.push({ op: "f64.const", value: paramCount });
         return { kind: "f64" };
       }

--- a/tests/issue-3468-closure-own-props.test.ts
+++ b/tests/issue-3468-closure-own-props.test.ts
@@ -131,9 +131,17 @@ describe("#3468 C-core — closure own-property side table (dynamic path, verifi
   });
 
   it("does not let a custom own property shadow the builtin metadata path", async () => {
-    // A user closure's `.length` is a pre-existing 0 via the any-path (its meta
-    // is not populated); the point here is that writing a custom prop must NOT
-    // change that — i.e. the side table doesn't shadow the builtin-meta arm.
+    // The invariant under test is unchanged: writing a custom own property must
+    // NOT disturb `.length` — the #3468 side table does not shadow the metadata
+    // arm.
+    //
+    // (#4436) The EXPECTED VALUE changed from 0 to 2. The 0 was never this
+    // test's subject; it was the flat `box_number(0)` the dyn-read closure arm
+    // returned for any closure the #2896 builtin-meta helper declined ("arity
+    // not statically tracked"). It IS tracked — the `$arity` header slot
+    // (#3673) — and the generic user-closure arm now reads it, so a
+    // two-parameter arrow correctly answers 2. Pinning 0 here would pin the
+    // defect, not the invariant.
     const { ret } = await runStandalone(`
       export function test(): number {
         let seed = 1;
@@ -143,7 +151,7 @@ describe("#3468 C-core — closure own-property side table (dynamic path, verifi
         return (g as any).length;
       }
     `);
-    expect(ret).toBe(0);
+    expect(ret).toBe(2);
   });
 
   it("includes shared noncapturing wrapper structs in the rollout (#3468 F1)", async () => {

--- a/tests/issue-4436.test.ts
+++ b/tests/issue-4436.test.ts
@@ -1,0 +1,219 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4436) `length` as a genuine OWN property of a user function instance, plus
+// §15.1.5 ExpectedArgumentCount for the static `<fn>.length` fold.
+//
+// Two independent defects, both measured on `main` 2026-08-15 (standalone):
+//
+//   1. REFLECTION. `f.length` folded to a constant for a typed receiver, but
+//      every reflective surface said the property did not exist —
+//      `hasOwnProperty` false, `getOwnPropertyDescriptor` undefined,
+//      `getOwnPropertyNames` without it, and the DYNAMIC `f["length"]` read
+//      answering a flat `0` regardless of arity. test262's `propertyHelper.js`
+//      uses exactly those surfaces (its receiver and key are runtime
+//      parameters), so a correct constant fold bought nothing.
+//
+//   2. ARITY. The fold counted parameters with a `filter()` that removed
+//      defaulted/optional/rest ones, justified by "TS forbids
+//      required-after-optional". That premise does not hold for the JS this
+//      compiler accepts: `function f(x = 42, y) {}` has `length === 0`, and the
+//      filter answered 1. §15.1.5 is a PREFIX count that stops at the first
+//      initializer, not a filter.
+//
+// The two are pinned together because they are one observable value: the
+// descriptor's `value`, the dynamic read and the static fold must all agree,
+// and the tests below assert them against each other, not just against a
+// literal.
+//
+// DELIBERATELY NOT PINNED AS PASSING (see the issue's residual section):
+// `name` is not an own property of a user closure, and the reflective `length`
+// VALUE is the declared formal count rather than ExpectedArgumentCount for a
+// function with a defaulted parameter. Both are asserted here in their CURRENT
+// shape so the residual is visible and a future fix has to update this file
+// rather than silently changing behaviour.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { expectedArgumentCountOfParams } from "../src/codegen/function-expected-argument-count.js";
+import { ts } from "../src/ts-api.js";
+
+/** Compile `body` as the `test()` export and run it host-free. */
+async function runStandalone(body: string): Promise<number> {
+  const source = `export function test(): number { ${body} }`;
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "issue-4436.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")).toBe(true);
+  // Host-free: a standalone module must instantiate against an empty import
+  // object. If this ever needs a host bridge, the arms leaked an import.
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+/** §15.1.5 over a parameter list parsed from `src`'s single function. */
+function expectedArgCountOf(src: string): number {
+  const file = ts.createSourceFile("t.js", src, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+  const fn = file.statements.find(ts.isFunctionDeclaration);
+  if (!fn) throw new Error("no function declaration in: " + src);
+  return expectedArgumentCountOfParams(fn.parameters);
+}
+
+describe("#4436 — §15.1.5 ExpectedArgumentCount", () => {
+  // The rows that distinguish a PREFIX count from a FILTER. Rows 3 and 5 are
+  // the ones the old `filter().length` got wrong; they are the `f2`/`f4` cases
+  // of language/{statements,expressions}/function/length-dflt.js.
+  it.each([
+    ["function f() {}", 0],
+    ["function f(x, y) {}", 2],
+    ["function f(x = 42) {}", 0],
+    ["function f(x = 42, y) {}", 0],
+    ["function f(x, y = 42) {}", 1],
+    ["function f(x, y = 42, z) {}", 1],
+    ["function f(...r) {}", 0],
+    ["function f(x, ...r) {}", 1],
+    ["function f(x, y = 1, z = 2) {}", 1],
+  ])("%s → %i", (src, want) => {
+    expect(expectedArgCountOf(src)).toBe(want);
+  });
+
+  it("a defaulted parameter truncates the count for REQUIRED parameters to its right", () => {
+    // The exact distinction the replaced `filter()` could not express: `y` and
+    // `z` are required, and still contribute nothing.
+    expect(expectedArgCountOf("function f(x = 42, y, z) {}")).toBe(0);
+    expect(expectedArgCountOf("function f(a, b, c = 1, d, e) {}")).toBe(2);
+  });
+
+  it("the STATIC fold reports ExpectedArgumentCount, not the formal count", async () => {
+    expect(await runStandalone(`function f(x = 42, y){} return f.length;`)).toBe(0);
+    expect(await runStandalone(`function f(x, y = 42, z){} return f.length;`)).toBe(1);
+    expect(await runStandalone(`function f(x, ...r){} return f.length;`)).toBe(1);
+  });
+});
+
+describe("#4436 — `length` is an own property of a function instance", () => {
+  it("hasOwnProperty sees it, through both spellings", async () => {
+    expect(await runStandalone(`function f(a,b){} return f.hasOwnProperty("length") ? 1 : 0;`)).toBe(1);
+    expect(
+      await runStandalone(`function f(a,b){} return Object.prototype.hasOwnProperty.call(f,"length") ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("getOwnPropertyDescriptor returns the §10.2.4 attribute set", async () => {
+    expect(
+      await runStandalone(`
+        function f(a,b){}
+        var d = Object.getOwnPropertyDescriptor(f, "length");
+        if (d === undefined) return 90;
+        if (d.value !== 2) return 91;
+        if (d.writable !== false) return 92;
+        if (d.enumerable !== false) return 93;
+        if (d.configurable !== true) return 94;
+        return 1;`),
+    ).toBe(1);
+  });
+
+  it("getOwnPropertyNames includes it", async () => {
+    expect(
+      await runStandalone(`
+        function f(a,b){}
+        var n = Object.getOwnPropertyNames(f);
+        for (var i = 0; i < n.length; i++) if (n[i] === "length") return 1;
+        return 0;`),
+    ).toBe(1);
+  });
+
+  it("the DYNAMIC read agrees with the static fold (it answered a flat 0 before)", async () => {
+    // Both spellings of the same property on the same object. `verifyProperty`
+    // compares exactly these two, so a disagreement is a guaranteed failure.
+    expect(
+      await runStandalone(`
+        function f(a,b,c){}
+        var k = "length";
+        return (f[k] === 3 && f.length === 3) ? 1 : 0;`),
+    ).toBe(1);
+    expect(await runStandalone(`function f(){} var k = "length"; return f[k] === 0 ? 1 : 0;`)).toBe(1);
+  });
+
+  it("is non-writable — a write is a silent no-op, not a change", async () => {
+    expect(await runStandalone(`function f(a,b){} f.length = 99; return f.length === 2 ? 1 : 0;`)).toBe(1);
+    expect(await runStandalone(`function f(a,b){} f.length = 99; var k="length"; return f[k] === 2 ? 1 : 0;`)).toBe(1);
+  });
+
+  it("is configurable — delete REMOVES it (propertyHelper's isConfigurable)", async () => {
+    // The #4010 ordering law: visibility without deletability fails every
+    // `verifyProperty` that names `configurable: true`.
+    expect(
+      await runStandalone(`
+        function f(a,b){}
+        if (!f.hasOwnProperty("length")) return 90;
+        delete f.length;
+        return f.hasOwnProperty("length") ? 0 : 1;`),
+    ).toBe(1);
+  });
+
+  it("a write AFTER delete resurrects it as an ordinary own property", async () => {
+    // The marker-inclusive presence check: once the bag owns the key, the
+    // generic `$arity` arm must stop answering or it would shadow the new value.
+    expect(
+      await runStandalone(`
+        function f(a,b){}
+        delete f.length;
+        f.length = 7;
+        var k = "length";
+        return (f.hasOwnProperty("length") && f[k] === 7) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("stays NON-ENUMERABLE — for-in must not list it", async () => {
+    expect(
+      await runStandalone(`
+        function f(a,b){}
+        for (var k in f) if (k === "length") return 0;
+        return 1;`),
+    ).toBe(1);
+  });
+
+  it("does not disturb a builtin function's own metadata (#2896 arms win)", async () => {
+    // The generic arm matches builtin meta structs too — they are
+    // funcref-wrapper-root descendants. The builtin arms are spliced in FRONT
+    // and always return, so `Array.isArray.length` stays its SPEC arity and is
+    // never overwritten by a raw `$arity`.
+    expect(
+      await runStandalone(`
+        var g = Array.isArray;
+        var k = "length";
+        return (g[k] === 1 && g.hasOwnProperty("length")) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("expando own properties on a function still work alongside it", async () => {
+    expect(
+      await runStandalone(`
+        function f(a){}
+        f.custom = 5;
+        return (f.hasOwnProperty("custom") && f.hasOwnProperty("length") && f.custom === 5) ? 1 : 0;`),
+    ).toBe(1);
+  });
+});
+
+describe("#4436 — measured residuals (pinned in their CURRENT shape)", () => {
+  it("`name` is NOT yet an own property of a user closure", async () => {
+    // Residual: `name` has no runtime carrier on a user closure. Adding one
+    // needs a per-function meta subtype (see the issue file). The static fold
+    // answers, the reflective surface does not — flip both together.
+    expect(await runStandalone(`function f(){} return f.name === "f" ? 1 : 0;`)).toBe(1);
+    expect(await runStandalone(`function f(){} return f.hasOwnProperty("name") ? 1 : 0;`)).toBe(0);
+  });
+
+  it("the reflective `length` VALUE is the formal count for a defaulted parameter", async () => {
+    // Residual: the runtime value reads the `$arity` header slot (declared
+    // formal count), which diverges from §15.1.5 only when a parameter is
+    // defaulted/optional. `$arity` cannot be re-pointed at the spec value —
+    // closure-exports.ts dispatches under-applied calls at `max(n, $arity)`.
+    // The STATIC fold is already correct, which is the divergence.
+    expect(await runStandalone(`function f(x = 42){} return f.length;`)).toBe(0); // static: correct
+    expect(await runStandalone(`function f(x = 42){} var k="length"; return f[k];`)).toBe(1); // dynamic: residual
+  });
+});


### PR DESCRIPTION
## Description

Wave 6a of the #4426 ES5-standalone campaign: the function-instance own-properties residual (#4436, filed with the measured corpus map — `length should be an own property` ×32, `name` ×74, `<other>` ×399 corpus-wide).

Two root causes, both probe-confirmed:
1. **Reflection**: `f.length` folded for typed receivers, but `hasOwnProperty`/gOPD/gOPN said absent and the dynamic `f["length"]` read returned a flat 0 — `dyn-read.ts` did that deliberately ("arity not statically tracked"), but the `$arity` closure-header slot (#3673) tracks it. New `src/codegen/function-instance-props.ts` wires the reflection arms to it.
2. **Arity**: the `<fn>.length` fold used `filter()` over defaulted/optional/rest params, justified by a TS rule ("no required-after-optional") that is false for the JS this compiler accepts — §15.1.5 is a *prefix* count. New `src/codegen/function-expected-argument-count.ts`.

Sample: `length should be an own property` **12 → 0**, passing 6 → 8, zero regressions across 122/122 control files (including 51 builtin-metadata files guarding against shadowing). 23-test pin. One existing expectation changed deliberately: `issue-3468`'s pin of `.length === 0` for a two-parameter arrow — the 0 was the defect, not the invariant (reasoning at the site). Pre-existing failures (`issue-3017` 4/16, one `descriptor-bags` case) A/B-confirmed byte-identical on base.

Residuals recorded in the issue file with owners — R1/R2 (`name` own-property + defaulted-param `length` value) are one unowned slice needing a per-function meta subtype; R3 (`new function f(){}` inline-fexpr construct trap) unowned; the rest routed to #3017/eval-lane.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_