### PR TITLE
feat(codegen): closure→prototype runtime edge — dynamic Get(F, "prototype") for standalone (#2660 M3)

### DIFF
--- a/plan/issues/2660-fnctor-instance-dynamic-use-escape-gate.md
+++ b/plan/issues/2660-fnctor-instance-dynamic-use-escape-gate.md
@@ -1,9 +1,10 @@
 ---
 id: 2660
 title: "Whole-program escape/dynamic-use gate for reconstructing `new F()` instances as `$Object` (value-rep infra)"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-06-25
+updated: 2026-08-15
 priority: medium
 feasibility: hard
 model: fable
@@ -13,7 +14,7 @@ area: codegen, value-rep, analysis
 language_feature: constructor functions, prototype chain, dynamic property access
 goal: test262-conformance
 related: [2580, 1888, 1712, 1100, 2009, 747, 4155, 4157, 3683]
-assignee: "ttraenkler/senior-dev-s3b"
+assignee: "ttraenkler/claude-es5-standalone"
 oracle-ratchet-allow:
   # (S3b, +1 ctx.checker in fnctor-typed-bindings.ts) The Slice-2 admission
   # needs the escape gate's write-once prototype-method resolution
@@ -25,6 +26,19 @@ oracle-ratchet-allow:
   # (use-site resolution, declaration identity) goes through `ctx.oracle`.
   - src/codegen/fnctor-typed-bindings.ts
 loc-budget-allow:
+  # (M3, +7) Two `fillClosurePrototypeEdge(ctx)` calls — one per pipeline
+  # (`generateModule`, `generateMultiModule`) — plus one import and a one-line
+  # ordering comment each. A finalize FILL can only be invoked from the
+  # finalize sequence; every line of decision and emission logic lives in the
+  # new subsystem module `src/codegen/closure-prototype-edge.ts`.
+  - src/codegen/index.ts
+  # (M3, +4) One `reserveClosurePrototypeEdge(ctx)` call plus its import and a
+  # two-line rationale, inside the existing `ctx.standalone || ctx.wasi`
+  # reserve block. The reservation must happen at exactly this point — BEFORE
+  # the `__extern_*` arms bake their `call <idx>` — which is the same
+  # constraint that pins `reserveClosurePropHelpers` / `reserveVecPropHelpers`
+  # / `reserveInstanceProps` to the same block.
+  - src/codegen/object-runtime.ts
   # (S3b, +18) The pinned member-SET path gains the same receiver-typed hook
   # the pinned GET already carries (#4155 Phase 2's own grant pattern): the
   # admission is on the receiver's COMPILED ValType, so the call must sit at
@@ -38,6 +52,14 @@ loc-budget-allow:
   # else. Decision logic is all in fnctor-typed-bindings.ts.
   - src/codegen/statements/variables.ts
 func-budget-allow:
+  # (M3, +3 each) The reserve/fill hooks land inside three already-oversized
+  # (#3399) driver functions because that is where the reserve-before-bake and
+  # fill-at-finalize orderings are defined. Splitting them is the #3399
+  # refactor and must not ride along with a behavioural slice — the same
+  # rationale S3b's grants below carry.
+  - src/codegen/index.ts::generateModule
+  - src/codegen/index.ts::generateMultiModule
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
   # (S3b, +7) The cascade-tail hook above lands inside this (already-oversized,
   # #3399) function because the slot-type cascade IS this function; splitting
   # it is the #3399 refactor and must not ride along with a flag-gated
@@ -851,3 +873,159 @@ under umbrella #4157 Workstream 1, flag-gated `JS2WASM_FNCTOR_TYPED_BINDINGS`
 
 Remaining #2660 scope (S3c ctor-body reconstruction, the floor-risk full
 merge_group slice) is untouched by this lap.
+
+## M3 — the closure → prototype runtime edge (2026-08-15, claude-es5-standalone, max reasoning)
+
+> Dispatched as the SOLE remaining dependency of #2916 (its "What is left to
+> close this issue" names exactly one thing: a runtime edge from a closure value
+> to its prototype object). New subsystem module
+> `src/codegen/closure-prototype-edge.ts`; consumers in
+> `native-dynamic-instanceof.ts` and `closure-props.ts`.
+
+### Verify-first — the problem was NOT where the issue text said it was
+
+The prior write-ups (#2916's residual, this file's S2 header) frame the gap as
+"`new F()` instances do not link to `F.prototype`". Measured on the branch base
+under `--target standalone`, that is **already fixed**:
+
+| probe (standalone, base) | before |
+| --- | --- |
+| `Object.getPrototypeOf(new F()) === F.prototype` | **true** |
+| `F.prototype={q:7}; (new F()).q` | **7** |
+| `var K:any = F; typeof K["prototype"]` | `"undefined"` |
+| `F.prototype={q:7}; var K:any=F; K["prototype"].q` | `undefined` — while the STATIC `F.prototype.q` reads **7** |
+| `var i = new F(); var K:any = F; i instanceof K` | **false** |
+
+So the instance→prototype link is live (S3a + #4172's work). What was missing is
+the **value→prototype** direction, and the concrete defect is a **SPLIT BRAIN**:
+one property, two disjoint stores.
+
+- `F.prototype` on an escape-gate-APPROVED fnctor is intercepted by S2 and lives
+  in the per-fnctor module global `__fnctor_proto_<name>`, keyed by the
+  COMPILE-TIME symbol name.
+- Every other `f.prototype` read/write goes through `__extern_get`/`__extern_set`
+  into the closure's own-property BAG (#3468), keyed by runtime identity.
+
+A dynamic consumer only ever reaches the second store, so it answered
+`undefined` for exactly the functions whose prototype the compiler knows best.
+
+### The fix — ONE identity-keyed edge, not a third store
+
+`src/codegen/closure-prototype-edge.ts` reserves and finalize-fills a native
+`__closure_proto_of(value: externref) -> externref`. It pairs two registries
+that already exist and are singletons by construction:
+
+| function kind | identity key | prototype object |
+| --- | --- | --- |
+| user fn declaration | `ctx.funcClosureGlobals` → `__fn_closure_<name>` (#1340; exists so `foo === foo` holds) | `ctx.fnctorPrototypeObject` (S2), lazily vivified with `__new_plain_object` exactly as `emitFnctorProtoGet` does |
+| class | `ctx.classObjectGlobals` → `__class_<Name>` (#1395) | `ctx.protoGlobals` — NOT vivified (that object is built by `class-proto-object.ts` with the methods installed; minting an empty one here would be a second, wrong identity) |
+
+The body is a `ref.eq` match against each singleton, guarded by `ref.test (ref
+eq)` so a host externref can never trap the cast. **A wrong `true` is
+structurally unreachable**: the lookup is exact object identity, and the value
+returned is the SAME object the `[[Prototype]]` seeding uses — so a consumer
+either gets the genuine `Get(C,"prototype")` or gets `null` and keeps its
+previous conservative answer. Functions with no singleton (a nested `function`
+memoized in a LOCAL, an arrow, a `Function(src)` value) are absent from the
+table by construction, not by an ad-hoc exclusion — which is why an arrow keeps
+answering `undefined` for `.prototype` (§15.3) with no special case.
+
+### Consumers
+
+1. **`native-dynamic-instanceof.ts`** (§7.3.20). Three changes:
+   - the `ref.test $Object` branch gained an **`else`**, so a callable that is
+     NOT an `$Object` — i.e. a closure carrier — also gets the own-`prototype`
+     read. `__hasOwnProperty`/`__extern_get` dispatch on receiver kind
+     themselves and route a closure into its #3468 bag, where `f.prototype = v`
+     actually lands, so that read is exactly as authoritative there as on a
+     branded `$Object` carrier;
+   - the hasOwn MISS now **falls through** instead of `return 0`, into the
+     identity-edge arm;
+   - the NOT-callable tail also consults the edge, because a CLASS value is
+     `typeof "object"` in this backend while being callable per spec.
+2. **`closure-props.ts` `__closure_prop_get`** — a `prototype`-keyed arm ahead
+   of the bag read. **Precedence is the spec's: an own bag entry always wins**,
+   tested with `__hasOwnProperty` rather than "did the bag read return
+   undefined", because `f.prototype = undefined` and an absent `prototype` are
+   indistinguishable by value and must behave oppositely (§7.3.20 step 5 ⇒
+   TypeError vs. nothing is known).
+
+Both arm builders return an EMPTY instruction list when the module has no edges,
+so `__closure_prop_get` keeps its previous body **and local list**.
+
+### Measured (all `--target standalone`, A/B through `.tmp/base-*.ts` revert copies)
+
+`language/expressions/instanceof`, all 43 files, `runTest262File`:
+
+| | base | branch |
+| --- | ---: | ---: |
+| pass | 24 | **26** |
+
+**+2, zero regressions** — `S15.3.5.3_A2_T2` and `_A2_T6` flip; every other row
+is byte-identical between the two runs. Three collateral directories are
+byte-identical run-to-run: `built-ins/Object/getPrototypeOf` 39/39,
+`built-ins/Object/prototype/isPrototypeOf` 6/10,
+`language/statements/function` 191/256.
+
+Behavioural probes, before → after:
+
+| probe | before | after |
+| --- | --- | --- |
+| `var K:any=F; K["prototype"]` (approved fnctor) | `undefined` | the prototype object |
+| `K["prototype"] === F.prototype` (identity) | n/a | **true** |
+| `new F() instanceof K`, `K` an `any` binding | `false` | **true** |
+| `({}) instanceof K` | `false` | `false` (unchanged — membership, not identity) |
+| `K.prototype = undefined; ({}) instanceof K` | `false` | **TypeError** |
+| `typeof (()=>1)["prototype"]` | `"undefined"` | `"undefined"` (unchanged) |
+
+**gc/host is BYTE-IDENTICAL** — sha256 of the compiled binary matched base on all
+6 probe programs (fnctor+prototype, class, dynamic instanceof, closure props,
+plain, arrow). Structural, not just sampled: the reservation is inside
+`ensureObjectRuntime`'s `ctx.standalone || ctx.wasi` block. A standalone/WASI
+module with no closures at all is byte-identical too (the reserved helper is
+dead-code-eliminated); one WITH closures but no user constructor carries ~27
+bytes of dead reserved helper, the same cost shape as the other six #3468
+reservations.
+
+### The five files the dispatch named — 2 flip, 3 have OTHER owners
+
+Measured with `runTest262File`, `--target standalone`, QuickJS runtime-eval
+engine linked (the adapter had to be built first — without it `Function(src)`
+files error out before reaching any assertion, which is what the first base run
+showed).
+
+| file | base | branch | blocker if still failing |
+| --- | --- | --- | --- |
+| `S15.3.5.3_A2_T2` | fail | **pass** | — |
+| `S15.3.5.3_A2_T6` | fail | **pass** | — |
+| `S15.3.5.3_A2_T5` | fail | fail | `new <Function(src) value>` evaluates to **null** (measured directly: `typeof` is `"object"`, the value is `null`). §7.3.20 step 3 then correctly returns `false` before the prototype read, so the TypeError cannot fire. Its CHECK#2 (`instance.constructor === FACTORY`) needs the same thing. Runtime-eval lane (#2928/#4242), not this edge. |
+| `S15.3.5.3_A3_T1` | fail | fail | same `new <runtime-eval callable>` → null, plus `FACTORY.prototype.type = 1` needs a vivified prototype on a value with no compile-time global. |
+| `S15.3.5.3_A3_T2` | fail | fail | `Object.prototype.isPrototypeOf({})` answers **false** on base AND branch — the plain-object `$proto` → `Object.prototype` link. #4172 slice 2 / #4160. |
+
+The own-`prototype` half of the arm was verified to work on a `Function(src)`
+callable in isolation (`hasOwnProperty(FF,"prototype")` is `true` after a write),
+so T5/A3_T1 are not blocked by anything in this module.
+
+### Deliberately NOT done
+
+- **No vivification for a closure with no compile-time prototype global.** It
+  would need a store, and the only one available is the #3468 bag — whose keys
+  are enumerable (`for (var k in f)` counts them), so every function would grow
+  a visible `prototype` own property, and an arrow would grow one it must not
+  have. The narrow, correct version of this is a `prototype` slot on the closure
+  carrier, which is a representation change, not this slice.
+- **`new F()` instance reconstruction (S3c)** and the `new F()`/`$proto` linking
+  work — the latter is #4172's live scope (`ttraenkler/W2-prototype-chain`) and
+  was deliberately not touched. This lap is the function-VALUE side only; the two
+  meet at the ONE prototype object, which is why the edge returns the registry's
+  object rather than minting its own.
+- **Class instances**: the edge answers `Get(C,"prototype")` for a class value
+  correctly, but `Object.getPrototypeOf(new C())` is not that object on current
+  main, so `new C() instanceof K` stays `false` (a missed conversion). Class-side
+  `$proto` seeding is #3976's surface.
+
+Files: `src/codegen/closure-prototype-edge.ts` (new),
+`src/codegen/native-dynamic-instanceof.ts`, `src/codegen/closure-props.ts`,
+`src/codegen/object-runtime.ts` (reserve hook), `src/codegen/index.ts` (two fill
+hooks), `tests/issue-2660-m3-closure-prototype-edge.test.ts` (11 cases; 6 of them
+fail on base, 5 are refusal/regression pins that must hold both ways).

--- a/plan/issues/2660-fnctor-instance-dynamic-use-escape-gate.md
+++ b/plan/issues/2660-fnctor-instance-dynamic-use-escape-gate.md
@@ -953,6 +953,18 @@ answering `undefined` for `.prototype` (§15.3) with no special case.
 Both arm builders return an EMPTY instruction list when the module has no edges,
 so `__closure_prop_get` keeps its previous body **and local list**.
 
+**Hot-path cost, stated because `__closure_prop_get` is the one hot native here**
+— #4241 measured 39,455 lookups per acorn self-parse. In a module WITH an edge, a
+read of any key other than `prototype` pays exactly four instructions
+(`local.get`, `any.convert_extern`, `ref.test $NativeString`, a not-taken `if`)
+before the arm is skipped; the bag lookup and the `__hasOwnProperty` call are
+inside the `prototype`-key branch. In a module with no edge the cost is zero
+instructions. The ordering — cheap interned-literal key test outermost — is
+deliberate and is the reason the arm could be placed BEFORE the bag read, which
+is where it has to be: the existing bag arm `return`s unconditionally once a bag
+exists, so anything placed after it is unreachable for a closure that carries any
+other own property.
+
 ### Measured (all `--target standalone`, A/B through `.tmp/base-*.ts` revert copies)
 
 `language/expressions/instanceof`, all 43 files, `runTest262File`:
@@ -1023,6 +1035,42 @@ so T5/A3_T1 are not blocked by anything in this module.
   correctly, but `Object.getPrototypeOf(new C())` is not that object on current
   main, so `new C() instanceof K` stays `false` (a missed conversion). Class-side
   `$proto` seeding is #3976's surface.
+
+### Gates, and the wrong-THROW check the class arm needed
+
+`typecheck` · `prettier` · `biome` · `check:loc-budget` · `check:func-budget`
+(both green after the allowances granted in this file's frontmatter;
+`ensureDynamicInstanceOfHelper` was kept UNDER the 300-LOC ceiling by moving its
+new rationale into the module header rather than by taking a grant) ·
+`check:oracle-ratchet` (0 new raw-checker queries — this module asks no type
+questions at all) · `check:coercion-sites` · `check:stack-balance` ·
+`check:pushraw` · `check:any-box-sites` · `check:host-import-policy` ·
+`check:codegen-fallbacks` · `check:ir-fallbacks` · `check:test-vacuity-shapes`
+— all green. `test:equivalence:gate`: **"No new equivalence regressions"**
+(24 failing / 1645 passing / 36 baseline; it also reports 12 stale baseline
+entries that now pass, none related to this change). `check:godfiles` fails
+IDENTICALLY on base (11 pre-existing entries, same list, `compileCallExpression`
+among them) — a stale baseline on `main`, not this change.
+
+Suites: the new 11 · `es5-standalone-instanceof` (20) ·
+`issue-3962-native-user-instanceof` · `issue-4276-instanceof-object-family` ·
+`issue-3468-closure-own-props` · `issue-2660-s2` · `issue-2660-s3` ·
+`issue-2994` — **135 passed**. `tests/instanceof.test.ts`'s 7 failures are the
+pre-existing `Import #0 module="string_constants"` host-harness artifact,
+A/B-verified identical on base.
+
+**The wrong-THROW risk the class arm introduced, and how it was closed.** The
+edge's class arm returns `ctx.protoGlobals[C]`, which is a `$ClassName` STRUCT
+rather than an `$Object` unless `class-proto-object.ts` converted it (it only
+converts a class with ≥1 installable instance method). The §7.3.20 tail throws
+`2` when the prototype is nullish or PROVABLY primitive, and the shared
+classifiers are known to mis-answer for unmodelled carriers — the
+`typeof Int8Array === "boolean"` hazard this module's header already records. A
+mis-answer there would be a wrong, catchable TypeError. Probed on the branch
+across ten shapes (class with a method / without / with only a field; a subclass
+and its parent as RHS; a fnctor whose prototype global is an empty vivified
+object; and number / string / null as LHS): **every one answers `0`, none
+throws.** Class `instanceof` remains a missed conversion, not a wrong answer.
 
 Files: `src/codegen/closure-prototype-edge.ts` (new),
 `src/codegen/native-dynamic-instanceof.ts`, `src/codegen/closure-props.ts`,

--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -935,6 +935,43 @@ edge from a closure value to its prototype object (#2660 M3). With it, the
 `ownedPrototypeOrdinaryHasInstance` arm applies unchanged to closures and the
 `S15.3.5.3_A2_*` / `_A3_*` family becomes answerable.
 
+> **UPDATE 2026-08-15 — #2660 M3 LANDED; this dependency is CLOSED. The
+> `S15.3.5.3` family is NOT, and the reason is three separate other defects.**
+>
+> `src/codegen/closure-prototype-edge.ts` supplies the edge
+> (`__closure_proto_of`, an identity-keyed match against the
+> `__fn_closure_<name>` / `__class_<Name>` singletons, answering the SAME
+> prototype object the `[[Prototype]]` seeding uses). This module's callable arm
+> now (a) does the own-`prototype` read for a NON-`$Object` callable — a closure,
+> whose own props live in the #3468 bag — and (b) falls through a hasOwn miss to
+> the edge instead of returning 0, and (c) consults the edge on the NOT-callable
+> tail too, because a class value is `typeof "object"` here.
+>
+> Measured, `--target standalone`, whole `language/expressions/instanceof`
+> directory A/B through file-copy reverts: **24 → 26 pass, zero regressions**,
+> every other row byte-identical.
+>
+> | file | result | if still failing, the blocker is |
+> | --- | --- | --- |
+> | `S15.3.5.3_A2_T2` | **fail → pass** | — |
+> | `S15.3.5.3_A2_T6` | **fail → pass** | — |
+> | `S15.3.5.3_A2_T5` | fail | `new <Function(src) value>` evaluates to **null**, so §7.3.20 step 3 returns `false` before the prototype read. Runtime-eval lane (#2928/#4242). |
+> | `S15.3.5.3_A3_T1` | fail | same, plus `FACTORY.prototype.type=1` on a value with no compile-time prototype global. |
+> | `S15.3.5.3_A3_T2` | fail | `Object.prototype.isPrototypeOf({})` is `false` on base AND branch — the plain-object `$proto` → `Object.prototype` link (#4172 slice 2 / #4160). |
+>
+> The own-`prototype` half was verified to work on a `Function(src)` callable in
+> isolation (`hasOwnProperty(FF,"prototype")` is `true` after a write), so the
+> three residual files are not blocked by anything in this module. The
+> "documented residual" paragraph above and in the module header — *a closure RHS
+> answers `false`* — no longer holds for a closure that owns a `prototype` or has
+> a compile-time prototype global; it does still hold for a runtime-eval callable
+> with neither.
+>
+> Full write-up, including the split-brain root cause (one property, two disjoint
+> stores) and the gc/host byte-identity evidence, in
+> `plan/issues/2660-fnctor-instance-dynamic-use-escape-gate.md` § "M3 — the
+> closure → prototype runtime edge".
+
 An earlier revision named the expression-statement elimination as a second
 blocker for that family. It is not — see the correction below.
 

--- a/src/codegen/closure-props.ts
+++ b/src/codegen/closure-props.ts
@@ -66,6 +66,7 @@
 import type { FieldDef, Instr, ValType, WasmFunction } from "../ir/types.js";
 import { undefinedExternInstrs } from "./any-helpers.js";
 import { collectClosureBaseWrapperTypeIdxs } from "./closure-classifier.js";
+import { closurePrototypeEdgeGetArm } from "./closure-prototype-edge.js"; // (#2660 M3)
 import type { CodegenContext } from "./context/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { nativeStringLiteralInstrs } from "./native-strings.js";
@@ -669,6 +670,9 @@ export function fillClosurePropHelpers(ctx: CodegenContext): void {
   // `undefined` unless the store was reserved, so a flag-clear module keeps
   // this body byte-identical.
   if (isClosureIdx !== undefined && bagLookupIdx !== undefined && externGetIdx !== undefined) {
+    // (#2660 M3) Empty for every module with no function-value → prototype edge,
+    // which keeps both the body AND the local list byte-identical there.
+    const protoEdgeArm = closurePrototypeEdgeGetArm(ctx, { recvSlot: 0, keySlot: 1, bagSlot: 2, protoSlot: 3 });
     const body: Instr[] = [
       { op: "local.get", index: 0 },
       { op: "call", funcIdx: isClosureIdx },
@@ -676,6 +680,14 @@ export function fillClosurePropHelpers(ctx: CodegenContext): void {
         op: "if",
         blockType: { kind: "empty" },
         then: [
+          // (#2660 M3) The function-value → prototype-object edge, consulted
+          // BEFORE the bag read but only for the key `prototype`, and only when
+          // the bag holds no OWN entry for it. Precedence is the spec's: an
+          // explicit `f.prototype = …` (which lands in the bag, including
+          // `= undefined`) always wins over the compile-time prototype object.
+          // Emits NOTHING when the module has no edges, so `__closure_prop_get`
+          // stays byte-identical for every module without a user constructor.
+          ...protoEdgeArm,
           { op: "local.get", index: 0 },
           { op: "call", funcIdx: bagLookupIdx },
           { op: "local.tee", index: 2 }, // bag
@@ -695,7 +707,16 @@ export function fillClosurePropHelpers(ctx: CodegenContext): void {
       },
       ...(protoIndexRecvGetMissInstrs(ctx, 0, 1) ?? getMiss()),
     ];
-    setBody(CLOSURE_PROP_GET, [{ name: "__bag", type: { kind: "externref" } }], body);
+    setBody(
+      CLOSURE_PROP_GET,
+      protoEdgeArm.length === 0
+        ? [{ name: "__bag", type: { kind: "externref" } }]
+        : [
+            { name: "__bag", type: { kind: "externref" } },
+            { name: "__protoEdge", type: { kind: "externref" } },
+          ],
+      body,
+    );
   } else {
     // Deps absent — keep a valid body: always return the undefined sentinel.
     setBody(CLOSURE_PROP_GET, [], [...getMiss()]);

--- a/src/codegen/closure-prototype-edge.ts
+++ b/src/codegen/closure-prototype-edge.ts
@@ -1,0 +1,383 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2660 M3) The runtime edge from a FUNCTION VALUE to its prototype object,
+ * under `--target standalone` / `--target wasi`.
+ *
+ * ## The gap this closes
+ *
+ * A user constructor's prototype object already exists in standalone, and the
+ * `[[Prototype]]` link from its instances already points at it — probe-verified
+ * on the base of this branch: `Object.getPrototypeOf(new F()) === F.prototype`
+ * is **true**, and `new F().q` reads through it. What is missing is the edge in
+ * the OTHER direction: from the function VALUE to that object.
+ *
+ * The reason is that the prototype object is keyed by a COMPILE-TIME name, in
+ * two disjoint registries:
+ *
+ *  - user function constructors — `ctx.fnctorPrototypeObject`, a per-fnctor
+ *    `mut externref` module global keyed by the fnctor's symbol name (#2660 S2,
+ *    `expressions/fnctor-prototype.ts`);
+ *  - classes — `ctx.protoGlobals`, keyed by class name (`class-proto-object.ts`).
+ *
+ * Both are reached only from a site where the compiler already knows WHICH
+ * function it is looking at (`F.prototype`, `new F()`). A value that arrives at
+ * runtime — an `any`-typed local, a parameter, a property read — carries no such
+ * name, so every dynamic consumer answered `undefined`. Measured on the base of
+ * this branch, `--target standalone`:
+ *
+ * | shape                                                     | before |
+ * | --------------------------------------------------------- | ------ |
+ * | `function F(){}; var K:any = F; typeof K["prototype"]`     | `"undefined"` |
+ * | `function F(){}; F.prototype={q:7}; K["prototype"].q`      | `undefined` (the STATIC read answers 7 — split brain) |
+ * | `var i = new F(); i instanceof K`                          | `false` (spec: `true`) |
+ *
+ * The third row is the one #2916 names as its single remaining dependency: the
+ * §7.3.20 `OrdinaryHasInstance` arm in `native-dynamic-instanceof.ts` cannot
+ * perform `Get(C, "prototype")` on a closure, so a closure RHS is answered with
+ * the conservative `false`.
+ *
+ * ## What this module adds
+ *
+ * ONE native `__closure_proto_of(target: externref) -> externref`, keyed by the
+ * VALUE's runtime IDENTITY rather than by a compile-time name. It answers the
+ * externref held in the compile-time registry when `target` is `ref.eq` to the
+ * canonical singleton for that function, and `null` otherwise.
+ *
+ * The identity handles already exist and are singletons by construction:
+ *
+ *  - `ctx.funcClosureGlobals` (#1340) — `__fn_closure_<name>`, the cached closure
+ *    struct for a top-level function declaration read as a value. It exists
+ *    precisely so `foo === foo` holds, which is what makes `ref.eq` a sound key.
+ *  - `ctx.classObjectGlobals` (#1395) — `__class_<Name>`, the class-object
+ *    singleton.
+ *
+ * ## Why this cannot answer a wrong `true`
+ *
+ * The lookup is an `ref.eq` IDENTITY match against a singleton the compiler
+ * minted, and the value it returns is the SAME object the `[[Prototype]]`
+ * seeding reads (`emitFnctorProtoGet` / `protoGlobals`). So a consumer either
+ * gets the genuine `Get(C, "prototype")` or gets `null` and keeps its existing
+ * conservative answer. There is no arm that infers membership from a type test,
+ * a name match, or a shape — the two failure modes #2916 forbids (a wrong `true`
+ * and a wrong throw) are structurally unreachable.
+ *
+ * Functions with no singleton global — a nested `function` memoized in a LOCAL
+ * (`funcref-as-closure.ts`), an arrow, a `Function(…)` value built at runtime —
+ * are simply absent from the table and answer `null`. That is a missed
+ * conversion, never a wrong one. In particular an ARROW keeps answering
+ * `undefined` for `.prototype`, which is what §15.3 requires and what this
+ * module must not break: it is not in the table because it never gets a
+ * per-fnctor prototype global, not because of an ad-hoc exclusion.
+ *
+ * ## Vivification, and why only on the fnctor arm
+ *
+ * A fnctor's prototype global is created lazily and starts `null`; `new F()` and
+ * a static `F.prototype` read both vivify it through
+ * `emitFnctorProtoGet` (`__new_plain_object` into the same global). This module
+ * vivifies identically, so whichever site runs first, all three agree on ONE
+ * object identity — the invariant the whole #2660 substrate rests on.
+ *
+ * The CLASS arm deliberately does NOT vivify. `ctx.protoGlobals` is populated by
+ * `class-proto-object.ts` / `emitLazyProtoGet`, which build a specific
+ * `$Object` with the class's methods installed at §17 attributes; minting an
+ * empty object here would be a SECOND, wrong prototype identity. A null class
+ * proto global answers `null` and the consumer keeps its conservative answer.
+ *
+ * ## Index-space discipline
+ *
+ * Reserve-then-fill, exactly like `closure-props.ts`: the helper is reserved at
+ * `ensureObjectRuntime` time (so any consumer can bake a stable `call <idx>`)
+ * with a `ref.null.extern` body, and filled at FINALIZE, once every fnctor
+ * global, class global and closure singleton has been registered. Nothing is
+ * MINTED at finalize (the #4221 hazard); the fill only swaps a body.
+ *
+ * Gated on `ctx.standalone || ctx.wasi`. In gc/host mode the host owns the
+ * dynamic-property and `instanceof` paths, nothing here is reserved, and the
+ * output is byte-identical.
+ */
+import type { Instr, ValType, WasmFunction } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { nativeStringLiteralInstrs } from "./native-strings.js";
+import { addFuncType } from "./registry/types.js";
+
+/** WasmGC `eq` abstract heap type — the key domain for the identity match. */
+const EQ_HEAP_TYPE = -19;
+
+/** `__closure_proto_of(value) -> externref` — null when the value has no edge. */
+export const CLOSURE_PROTO_OF = "__closure_proto_of";
+
+/** Param / local slots of the helper body. */
+const P_TARGET = 0;
+const L_TARGET_EQ = 1;
+const L_CAND = 2;
+
+/**
+ * One resolved edge: the module global holding the canonical function VALUE, and
+ * the module global holding that function's prototype object.
+ */
+interface PrototypeEdge {
+  /** `__fn_closure_<name>` / `__class_<Name>` — the identity key (externref). */
+  valueGlobalIdx: number;
+  /** `__fnctor_proto_<name>` / the class proto singleton (externref). */
+  protoGlobalIdx: number;
+  /** Vivify an empty `$Object` into the proto global when it is still null. */
+  vivify: boolean;
+  /** Diagnostic only — the compile-time name both registries agreed on. */
+  name: string;
+}
+
+/**
+ * The edges that exist in this module, in a deterministic order (fnctors by
+ * registration order, then classes). Both halves of every pair must be present:
+ * a function with a prototype global but no singleton VALUE global was never
+ * read as a value, so no runtime consumer can hold it.
+ */
+function collectPrototypeEdges(ctx: CodegenContext): PrototypeEdge[] {
+  const edges: PrototypeEdge[] = [];
+  for (const [name, protoGlobalIdx] of ctx.fnctorPrototypeObject) {
+    const valueGlobalIdx = ctx.funcClosureGlobals.get(name);
+    if (valueGlobalIdx === undefined) continue;
+    edges.push({ valueGlobalIdx, protoGlobalIdx, vivify: true, name });
+  }
+  for (const [name, valueGlobalIdx] of ctx.classObjectGlobals) {
+    const protoGlobalIdx = ctx.protoGlobals.get(name);
+    if (protoGlobalIdx === undefined) continue;
+    edges.push({ valueGlobalIdx, protoGlobalIdx, vivify: false, name });
+  }
+  return edges;
+}
+
+/**
+ * True when at least one function value in this module has a reachable
+ * prototype object. Consumers use it to keep their emission byte-identical for
+ * every module that has none.
+ */
+export function hasClosurePrototypeEdges(ctx: CodegenContext): boolean {
+  return collectPrototypeEdges(ctx).length > 0;
+}
+
+/** The reserved helper's stable funcIdx, or `undefined` when never reserved. */
+export function closureProtoOfFuncIdx(ctx: CodegenContext): number | undefined {
+  return ctx.funcMap.get(CLOSURE_PROTO_OF);
+}
+
+/**
+ * Reserve `__closure_proto_of` with a `ref.null.extern` body. Called from
+ * `ensureObjectRuntime` under `ctx.standalone || ctx.wasi`, BEFORE any consumer
+ * bakes its `call <idx>`. Idempotent.
+ *
+ * The placeholder is a VALID body for the declared result type, not an
+ * `unreachable` stub: a module whose fill finds no edges keeps this body, and
+ * every consumer's `proto == null ⇒ decline` arm then reproduces its exact
+ * previous answer.
+ */
+export function reserveClosurePrototypeEdge(ctx: CodegenContext): void {
+  if (ctx.funcMap.get(CLOSURE_PROTO_OF) !== undefined) return;
+  const externref: ValType = { kind: "externref" };
+  const typeIdx = addFuncType(ctx, [externref], [externref], `$${CLOSURE_PROTO_OF}_type`);
+  const funcIdx = mintDefinedFunc(ctx);
+  const placeholder: WasmFunction = {
+    name: CLOSURE_PROTO_OF,
+    typeIdx,
+    locals: [],
+    body: [{ op: "ref.null.extern" }],
+    exported: false,
+  };
+  pushDefinedFunc(ctx, funcIdx, placeholder);
+  ctx.funcMap.set(CLOSURE_PROTO_OF, funcIdx);
+}
+
+/**
+ * Fill the reserved body at FINALIZE, once every fnctor prototype global, class
+ * prototype global and function-value singleton is registered. No-op when the
+ * helper was never reserved (gc/host) or when the module has no edges — in the
+ * latter case the `ref.null.extern` placeholder is already the right answer.
+ */
+export function fillClosurePrototypeEdge(ctx: CodegenContext): void {
+  const funcIdx = ctx.funcMap.get(CLOSURE_PROTO_OF);
+  if (funcIdx === undefined) return;
+  const fn = definedFuncAt(ctx, funcIdx);
+  if (!fn) return;
+  const edges = collectPrototypeEdges(ctx);
+  if (edges.length === 0) return;
+
+  const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object");
+
+  /** Leave the edge's prototype object on the stack, vivifying if asked. */
+  const loadProto = (edge: PrototypeEdge): Instr[] => {
+    const out: Instr[] = [];
+    if (edge.vivify && newPlainObjectIdx !== undefined) {
+      out.push(
+        { op: "global.get", index: edge.protoGlobalIdx },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "call", funcIdx: newPlainObjectIdx },
+            { op: "global.set", index: edge.protoGlobalIdx },
+          ],
+        },
+      );
+    }
+    out.push({ op: "global.get", index: edge.protoGlobalIdx });
+    return out;
+  };
+
+  const body: Instr[] = [
+    // A null value has no identity to match.
+    { op: "local.get", index: P_TARGET },
+    { op: "ref.is_null" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+    // `ref.eq` needs an `eqref`. `ref.test (ref eq)` answers 0 for a host
+    // externref that is not a GC object, so the `ref.cast` below cannot trap.
+    { op: "local.get", index: P_TARGET },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: EQ_HEAP_TYPE },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+    { op: "local.get", index: P_TARGET },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: EQ_HEAP_TYPE },
+    { op: "local.set", index: L_TARGET_EQ },
+  ];
+
+  for (const edge of edges) {
+    body.push(
+      // A singleton global is `null` until the function is first read as a
+      // value; skip those rather than comparing against null.
+      { op: "global.get", index: edge.valueGlobalIdx },
+      { op: "ref.is_null" },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "global.get", index: edge.valueGlobalIdx },
+          { op: "any.convert_extern" },
+          { op: "local.tee", index: L_CAND },
+          { op: "ref.test", typeIdx: EQ_HEAP_TYPE },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: L_CAND },
+              { op: "ref.cast", typeIdx: EQ_HEAP_TYPE },
+              { op: "local.get", index: L_TARGET_EQ },
+              { op: "ref.eq" },
+              { op: "if", blockType: { kind: "empty" }, then: [...loadProto(edge), { op: "return" }] },
+            ],
+          },
+        ],
+      },
+    );
+  }
+
+  body.push({ op: "ref.null.extern" });
+
+  fn.locals = [
+    { name: "__targetEq", type: { kind: "eqref" } },
+    { name: "__cand", type: { kind: "anyref" } },
+  ];
+  fn.body = body;
+}
+
+/**
+ * (#2660 M3, half b) The `prototype` arm for `__closure_prop_get` — the dynamic
+ * MOP read of `f["prototype"]` / `f.prototype` on a FUNCTION VALUE.
+ *
+ * Returns an EMPTY array — and therefore leaves `__closure_prop_get`
+ * byte-identical, local list included — unless the module actually has an edge
+ * and every native this needs is registered.
+ *
+ * ## Precedence: an own bag entry always wins
+ *
+ * `f.prototype = v` lands in the closure's own-property bag (#3468), and that is
+ * the program's explicit state — including `f.prototype = undefined`, which
+ * §7.3.20 step 5 requires to be observable as a non-object (a TypeError for
+ * `instanceof`). Consulting the edge FIRST would silently replace it with the
+ * compile-time prototype object, i.e. would make a wrong answer out of a right
+ * one. So the arm asks `__hasOwnProperty` on the bag first and declines on a
+ * hit. That is also why the check is not "did the bag read return undefined":
+ * an own `prototype` explicitly set to `undefined` is indistinguishable from an
+ * absent one by value, and the two must behave oppositely.
+ *
+ * ## Cost
+ *
+ * Everything is behind an interned-literal `ref.eq` on the KEY, so a read of any
+ * other property pays one `ref.test` + `ref.cast` + `ref.eq`. A key that is not
+ * the interned literal (a rope, a runtime-built string) misses and keeps the
+ * pre-existing answer — the same deliberate limitation `fillClosureMethodCall`
+ * documents for its method-name matching.
+ */
+export function closurePrototypeEdgeGetArm(
+  ctx: CodegenContext,
+  slots: { recvSlot: number; keySlot: number; bagSlot: number; protoSlot: number },
+): Instr[] {
+  if (!hasClosurePrototypeEdges(ctx)) return [];
+  const protoOfIdx = ctx.funcMap.get(CLOSURE_PROTO_OF);
+  const bagLookupIdx = ctx.funcMap.get("__closure_bag_lookup");
+  const hasOwnIdx = ctx.funcMap.get("__hasOwnProperty");
+  const nativeStrTypeIdx = ctx.nativeStrTypeIdx;
+  if (protoOfIdx === undefined || bagLookupIdx === undefined || hasOwnIdx === undefined) return [];
+  if (!ctx.nativeStrings || nativeStrTypeIdx < 0) return [];
+
+  const { recvSlot, keySlot, bagSlot, protoSlot } = slots;
+
+  // A FACTORY, not a shared array: the same `Instr` object appearing at two
+  // points in one body is double-remapped by the finalize index walks
+  // (`reference_shared_instr_object_dce_double_remap`), which is how a correct
+  // instruction sequence turns into a call to the wrong function.
+  /** The edge consult itself — reached only when the bag holds no own entry. */
+  const consultEdge = (): Instr[] => [
+    { op: "local.get", index: recvSlot },
+    { op: "call", funcIdx: protoOfIdx },
+    { op: "local.tee", index: protoSlot },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: protoSlot }, { op: "return" }],
+    },
+  ];
+
+  /** `bag == null || !__hasOwnProperty(bag, "prototype")` ⇒ consult the edge. */
+  const whenNoOwnEntry: Instr[] = [
+    { op: "local.get", index: recvSlot },
+    { op: "call", funcIdx: bagLookupIdx },
+    { op: "local.tee", index: bagSlot },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: consultEdge(),
+      else: [
+        { op: "local.get", index: bagSlot },
+        { op: "local.get", index: keySlot },
+        { op: "call", funcIdx: hasOwnIdx },
+        { op: "i32.eqz" },
+        { op: "if", blockType: { kind: "empty" }, then: consultEdge() },
+      ],
+    },
+  ];
+
+  return [
+    { op: "local.get", index: keySlot },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: nativeStrTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: keySlot },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: nativeStrTypeIdx },
+        ...nativeStringLiteralInstrs(ctx, "prototype"),
+        { op: "ref.eq" },
+        { op: "if", blockType: { kind: "empty" }, then: whenNoOwnEntry },
+      ],
+    },
+  ];
+}

--- a/src/codegen/closure-prototype-edge.ts
+++ b/src/codegen/closure-prototype-edge.ts
@@ -157,11 +157,6 @@ export function hasClosurePrototypeEdges(ctx: CodegenContext): boolean {
   return collectPrototypeEdges(ctx).length > 0;
 }
 
-/** The reserved helper's stable funcIdx, or `undefined` when never reserved. */
-export function closureProtoOfFuncIdx(ctx: CodegenContext): number | undefined {
-  return ctx.funcMap.get(CLOSURE_PROTO_OF);
-}
-
 /**
  * Reserve `__closure_proto_of` with a `ref.null.extern` body. Called from
  * `ensureObjectRuntime` under `ctx.standalone || ctx.wasi`, BEFORE any consumer

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -277,6 +277,7 @@ import { unshiftNativeProtoHasOwnArms } from "./native-proto-own-props.js"; // (
 import { unshiftNativeProtoToPrimitiveArm } from "./native-proto-wrapper-primitive.js"; // (#4248) proto [[PrimitiveValue]]
 import { unshiftExternGetProtoMethodArm } from "./native-proto-instance-method-read.js"; // (#4248) inherited method value
 import { fillClosurePropHelpers } from "./closure-props.js"; // (#3468 C-core) closure-own-property side table
+import { fillClosurePrototypeEdge } from "./closure-prototype-edge.js"; // (#2660 M3) function-value → prototype-object edge
 import { fillInstanceTombstones } from "./instance-tombstones.js"; // (#4098 G1 s1) per-instance own-property deletability
 import { fillInstanceProps } from "./instance-props.js"; // (#4194) instance expando bag substrate
 import { fillErrorPropHelpers } from "./error-props.js"; // (#4098) native Error `$props` shared MOP
@@ -5204,6 +5205,9 @@ export function generateModule(
     // method-dispatch site reserved the bridge (`ctx.applyClosureReserved`).
     fillApplyClosure(ctx);
 
+    // (#2660 M3) FIRST — `fillClosurePropHelpers` reads the same edge table.
+    fillClosurePrototypeEdge(ctx);
+
     // (#3468) Fill after all closure types and object-runtime deps are known.
     fillClosurePropHelpers(ctx);
 
@@ -7637,6 +7641,9 @@ export function generateMultiModule(
     emitStructFieldBooleanMarkers(ctx);
     emitStructFieldPresenceGetters(ctx);
     emitStructFieldSetters(ctx);
+
+    // (#2660 M3) Same ordering as the single-source pipeline.
+    fillClosurePrototypeEdge(ctx);
 
     // (#3468) Multi-source compilation can reserve the closure own-property
     // side-table helpers too. Fill their placeholders only after every source

--- a/src/codegen/native-dynamic-instanceof.ts
+++ b/src/codegen/native-dynamic-instanceof.ts
@@ -40,13 +40,38 @@
  *    with `ref.eq` per level (object-runtime-prototype.ts). ONE walk, shared
  *    with #3962 and Slice C; no parallel `[[Prototype]]` mechanism.
  *
- * What it cannot decide is `Get(C, "prototype")` for a **closure**: a standalone
- * function value is a WasmGC closure-wrapper struct, and its prototype object
- * lives in a per-fnctor module GLOBAL keyed by the COMPILE-TIME symbol name
- * (`fnctor-prototype.ts`). There is no runtime edge from the closure value to
- * that global. Verified by probe on this branch: a dynamic `k["prototype"]` read
- * off a function value answers `undefined` for a `function` declaration, a
- * `var F = function(){}` and a `class` alike.
+ * ## The closure → prototype edge (#2660 M3) — what this module could NOT decide
+ *
+ * Until #2660 M3, `Get(C, "prototype")` was unanswerable for a **closure**: a
+ * standalone function value is a WasmGC closure-wrapper struct, and its
+ * prototype object lives in a module GLOBAL keyed by the COMPILE-TIME symbol
+ * name (`fnctor-prototype.ts`, and `ctx.protoGlobals` for classes), with no
+ * runtime edge from the value. So a closure RHS answered the conservative
+ * `false` and `S15.3.5.3_A2_T2/T6` / `_A3_T1/T2` kept failing.
+ *
+ * Two arms close it, in this precedence order:
+ *
+ * 1. **Own `prototype` on a NON-`$Object` callable.** The `ref.test $Object`
+ *    branch below gained an `else`. `__hasOwnProperty`/`__extern_get` dispatch
+ *    on the receiver kind themselves and route a closure into its own-property
+ *    bag (#3468), where `F.prototype = v` actually lands — so the read is
+ *    exactly as authoritative there as on a branded carrier. This is what lets
+ *    `FACTORY.prototype = undefined` / `= "error"` on a `new Function` value
+ *    reach the §7.3.20 step-5 TypeError (`S15.3.5.3_A2_T2` and `_A2_T6`,
+ *    measured fail→pass) instead of the conservative `false`.
+ * 2. **The identity edge**, `__closure_proto_of`
+ *    (`closure-prototype-edge.ts`), consulted when NO own `prototype` exists —
+ *    which is why the hasOwn miss now falls through instead of returning 0. It
+ *    matches the value against the canonical singleton global for each user
+ *    constructor / class by `ref.eq` and answers the SAME object the
+ *    `[[Prototype]]` seeding uses, so a hit is the genuine `Get(C,"prototype")`
+ *    and a miss is `null`. It is also consulted on the NOT-callable tail,
+ *    because a CLASS value is `typeof "object"` in this backend (reason 2
+ *    there) yet is callable per spec.
+ *
+ * Both arms emit NOTHING when the module has no edges, and neither can produce
+ * a wrong `true`: arm 2 is an exact identity match, and arm 1 reads a property
+ * the program itself wrote.
  *
  * ## The answers, and why each is the least-wrong one available
  *
@@ -118,6 +143,7 @@ import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import type { ts } from "../ts-api.js";
 import { OBJ_FLAG_CALLABLE } from "./builtin-callable-brand.js";
+import { CLOSURE_PROTO_OF } from "./closure-prototype-edge.js"; // (#2660 M3) closure → prototype identity edge
 import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { noJsHost } from "./js-errors.js";
@@ -165,6 +191,13 @@ function ensureDynamicInstanceOfHelper(ctx: CodegenContext): number | undefined 
   const primitiveIdxs = (["__typeof_number", "__typeof_string", "__typeof_boolean", "__typeof_bigint"] as const).map(
     (n) => ensureLateImport(ctx, n, [EXTERNREF], [I32]),
   );
+  // (#2660 M3) The function-value → prototype-object identity edge. It is a
+  // RESERVED defined function (`ensureObjectRuntime` above reserves it under
+  // `noJsHost`), so its funcIdx is stable here and its BODY is filled at
+  // finalize, once every fnctor/class prototype global exists. `undefined` only
+  // when the reservation did not happen, in which case every arm below that
+  // depends on it emits nothing and this helper keeps its previous answers.
+  const closureProtoOfIdx = ctx.funcMap.get(CLOSURE_PROTO_OF);
   flushLateImportShifts(ctx, null);
 
   const objectTypeIdx = ctx.objectRuntimeTypes?.objectTypeIdx;
@@ -242,16 +275,13 @@ function ensureDynamicInstanceOfHelper(ctx: CodegenContext): number | undefined 
   // A non-object P is likewise refused only when PROVABLY primitive, for the
   // same reason as `isProvenPrimitive`: an unrecognised P is simply not in V's
   // chain, and the walk already answers 0 for a non-`$Object`.
-  const ownedPrototypeOrdinaryHasInstance: Instr[] = [
-    { op: "local.get", index: P_TARGET },
-    ...stringConstantExternrefInstrs(ctx, "prototype"),
-    { op: "call", funcIdx: hasOwnIdx },
-    { op: "i32.eqz" },
-    { op: "if", blockType: { kind: "empty" }, then: returnConst(0) },
-    { op: "local.get", index: P_TARGET },
-    ...stringConstantExternrefInstrs(ctx, "prototype"),
-    { op: "call", funcIdx: externGetIdx },
-    { op: "local.set", index: L_PROTO },
+  //
+  // (#2660 M3) The next three are FACTORIES, not shared arrays: the tail is
+  // emitted at three points in one body, and a shared `Instr` object is
+  // double-remapped by the finalize index walks
+  // (`reference_shared_instr_object_dce_double_remap`).
+  /** §7.3.20 steps 5–7 for a `prototype` value already in `L_PROTO`. */
+  const ordinaryHasInstanceTail = (): Instr[] => [
     ...isNullish(L_PROTO),
     ...isProvenPrimitive(L_PROTO),
     { op: "i32.or" },
@@ -260,6 +290,53 @@ function ensureDynamicInstanceOfHelper(ctx: CodegenContext): number | undefined 
     { op: "local.get", index: P_VALUE },
     { op: "call", funcIdx: isProtoOfIdx },
     { op: "return" },
+  ];
+  /**
+   * §7.3.20 steps 4–7 for a target that OWNS a `prototype` property. (#2660 M3)
+   * A hasOwn MISS FALLS THROUGH to the identity-edge arm instead of `return 0`
+   * — see the module header's "the closure → prototype edge".
+   */
+  const ownedPrototypeOrdinaryHasInstance = (): Instr[] => [
+    { op: "local.get", index: P_TARGET },
+    ...stringConstantExternrefInstrs(ctx, "prototype"),
+    { op: "call", funcIdx: hasOwnIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: P_TARGET },
+        ...stringConstantExternrefInstrs(ctx, "prototype"),
+        { op: "call", funcIdx: externGetIdx },
+        { op: "local.set", index: L_PROTO },
+        ...ordinaryHasInstanceTail(),
+      ],
+    },
+  ];
+
+  /**
+   * (#2660 M3) `Get(C, "prototype")` through the function-value → prototype
+   * identity edge — see the module header. A miss answers `null` and this arm
+   * falls through, preserving the documented conservative `false`.
+   */
+  const prototypeEdgeArm = (): Instr[] => {
+    if (closureProtoOfIdx === undefined) return [];
+    return [
+      { op: "local.get", index: P_TARGET },
+      { op: "call", funcIdx: closureProtoOfIdx },
+      { op: "local.tee", index: L_PROTO },
+      { op: "ref.is_null" },
+      { op: "i32.eqz" },
+      { op: "if", blockType: { kind: "empty" }, then: ordinaryHasInstanceTail() },
+    ];
+  };
+
+  /** §7.3.20 step 3 — Type(V) is not Object ⇒ false, before any prototype read. */
+  const requireObjectValue = (): Instr[] => [
+    ...isNullish(P_VALUE),
+    { op: "if", blockType: { kind: "empty" }, then: returnConst(0) },
+    ...isObjectValue(P_VALUE),
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: returnConst(0) },
   ];
 
   const body: Instr[] = [
@@ -280,11 +357,7 @@ function ensureDynamicInstanceOfHelper(ctx: CodegenContext): number | undefined 
         // §7.3.20 step 3: Type(V) is not Object → false, BEFORE any prototype
         // read. Order matters: a primitive V must not fire a `prototype`
         // accessor nor throw on a non-object prototype (#2702).
-        ...isNullish(P_VALUE),
-        { op: "if", blockType: { kind: "empty" }, then: returnConst(0) },
-        ...isObjectValue(P_VALUE),
-        { op: "i32.eqz" },
-        { op: "if", blockType: { kind: "empty" }, then: returnConst(0) },
+        ...requireObjectValue(),
         // A #4120-branded builtin constructor carrier is a real `$Object`, so
         // its `prototype` own property is an authoritative read. Tested by
         // reading the brand bit DIRECTLY rather than through
@@ -300,21 +373,48 @@ function ensureDynamicInstanceOfHelper(ctx: CodegenContext): number | undefined 
         {
           op: "if",
           blockType: { kind: "empty" },
+          // (#2660 M3) The ELSE arm is new: a callable that is NOT an `$Object`
+          // is a WasmGC closure carrier, whose own `prototype` lives in the
+          // #3468 side bag — an equally authoritative read. Module header, "the
+          // closure → prototype edge", half 1.
+          else: ownedPrototypeOrdinaryHasInstance(),
           then: [
             { op: "local.get", index: L_TARGET_ANY },
             { op: "ref.cast", typeIdx: objectTypeIdx },
             { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
             { op: "i32.const", value: OBJ_FLAG_CALLABLE },
             { op: "i32.and" },
-            { op: "if", blockType: { kind: "empty" }, then: ownedPrototypeOrdinaryHasInstance },
+            { op: "if", blockType: { kind: "empty" }, then: ownedPrototypeOrdinaryHasInstance() },
           ],
         },
-        // Callable, but its `[[Prototype]]` source is a per-fnctor compile-time
-        // global with no runtime edge from the value — see the module header's
-        // "residual". Conservative `false`, never a wrong `true` or a wrong throw.
+        // (#2660 M3) No own `prototype` anywhere — try the identity edge to the
+        // compile-time prototype registry before giving up.
+        ...prototypeEdgeArm(),
+        // Callable, and its `[[Prototype]]` source is not reachable from the
+        // value — see the module header's "residual". Conservative `false`,
+        // never a wrong `true` or a wrong throw.
         ...returnConst(0),
       ],
     },
+
+    // (#2660 M3) NOT callable by `__typeof_function` — which in this backend
+    // includes every CLASS value (`typeof C === "object"`, reason 2 below). A
+    // class object IS callable per spec, so answering §7.3.20 for one through
+    // the `__class_<Name>` identity edge is a correction, not a widening.
+    ...(closureProtoOfIdx === undefined
+      ? []
+      : ([
+          { op: "local.get", index: P_TARGET },
+          { op: "call", funcIdx: closureProtoOfIdx },
+          { op: "local.tee", index: L_PROTO },
+          { op: "ref.is_null" },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [...requireObjectValue(), ...ordinaryHasInstanceTail()],
+          },
+        ] satisfies Instr[])),
 
     // NOT CALLABLE ⇒ conservative `false`. §13.10.2 steps 1/4 say TypeError, and
     // this arm deliberately does not emit one. Three independent reasons, each

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -95,6 +95,7 @@ import {
   reserveCarrierBagVisibility,
 } from "./carrier-bag-visibility.js";
 import { reserveClosurePropHelpers } from "./closure-props.js"; // (#3468 C-core) closure-own-property side table
+import { reserveClosurePrototypeEdge } from "./closure-prototype-edge.js"; // (#2660 M3) function-value → prototype-object edge
 // (#4230 L1) the #3251 overlay companion as a THIRD key source for the vec key walks
 import { buildOverlayPushKeys, buildVecOverlayHasArm, reserveVecOverlayPushKeys } from "./vec-overlay-keys.js";
 // (#4194) instance expando substrate — composes AROUND the #3537/#3468 arms and
@@ -1037,6 +1038,9 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   // these defined arms are not emitted, and nothing here is reserved.
   if (ctx.standalone || ctx.wasi) {
     reserveClosurePropHelpers(ctx);
+    // (#2660 M3) The function-value → prototype-object identity edge — same
+    // reserve-before-arms-bake discipline; see `closure-prototype-edge.ts`.
+    reserveClosurePrototypeEdge(ctx);
     // (#3537) reserve the array-expando side table right after — same
     // reserve-before-arms-bake discipline, appended indices only.
     reserveVecPropHelpers(ctx);

--- a/tests/issue-2660-m3-closure-prototype-edge.test.ts
+++ b/tests/issue-2660-m3-closure-prototype-edge.test.ts
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2660 M3) The runtime edge from a FUNCTION VALUE to its prototype object,
+ * under `--target standalone`.
+ *
+ * The prototype object of a user function constructor already exists, and
+ * `new F()` instances already link to it — what was missing was the edge from
+ * the function VALUE, because the object is keyed by a COMPILE-TIME name
+ * (`ctx.fnctorPrototypeObject` / `ctx.protoGlobals`). Every dynamic consumer —
+ * `k["prototype"]`, and §7.3.20 `Get(C, "prototype")` inside
+ * `__instanceof_dynamic` — therefore answered `undefined` / the conservative
+ * `false`. See `src/codegen/closure-prototype-edge.ts`.
+ *
+ * Every case asserts BOTH halves of the contract, the way
+ * `es5-standalone-instanceof.test.ts` does: the ANSWER, and a ZERO-import
+ * binary. A right answer that reintroduces a host import is still refused by
+ * the #2961 leak guard, so the import count is part of the contract.
+ *
+ * The three REFUSAL cases at the end are the load-bearing ones. This edge is
+ * identity-keyed precisely so it can never answer a wrong `true`, and an arrow
+ * function must keep answering `undefined` for `.prototype` (§15.3).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface Outcome {
+  result: number;
+  imports: string[];
+}
+
+/** Compile a standalone SCRIPT, run `__module_init`, read `result`. */
+async function run(body: string): Promise<Outcome> {
+  const source = `var result = -1;\n${body}\nexport function test(): number { return result as number; }\n`;
+  const compiled = await compile(source, {
+    allowJs: true,
+    fileName: "issue-2660-m3.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    deferTopLevelInit: true,
+    inferModuleStrictArguments: false,
+  });
+  expect(compiled.success, compiled.errors.map((e) => e.message).join("; ")).toBe(true);
+  const imports = (compiled.imports ?? []).map((i: unknown) =>
+    typeof i === "string" ? i : `${(i as { module: string }).module}::${(i as { name: string }).name}`,
+  );
+  const { instance } = await WebAssembly.instantiate(compiled.binary, {});
+  (instance.exports as Record<string, unknown> & { __module_init?: () => void }).__module_init?.();
+  const result = (instance.exports as Record<string, () => number>).test();
+  return { result, imports };
+}
+
+/**
+ * A fnctor the #2660 S1 escape gate approves, i.e. one whose `new F()` site is
+ * classified `reconstruct`. Without the dynamic instance read the gate answers
+ * `keep-static`, no per-fnctor prototype global is minted, and there is nothing
+ * for the edge to point at — so this prelude is not decoration, it is the
+ * precondition the whole substrate is gated on.
+ */
+const APPROVED_FNCTOR = `function F(){}\nF.prototype = {q:7};\nvar c:any = new F();\nvar dynRead:any = c["q"];\n`;
+
+describe("#2660 M3 — the closure → prototype runtime edge", () => {
+  it("answers a dynamic `f['prototype']` read with the prototype object", async () => {
+    // Measured before this change: `undefined`. The STATIC `F.prototype` read
+    // answered `{q:7}` at the same time — one property, two disjoint stores.
+    const o = await run(
+      `${APPROVED_FNCTOR}var K:any = F;\nvar p = K["prototype"];\nresult = (p && p.q === 7) ? 1 : 0;`,
+    );
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("the dynamic read and the static read are the SAME object", async () => {
+    // Identity, not just equality of contents. This is the invariant the whole
+    // #2660 substrate rests on: ONE prototype object per function, which is also
+    // the object `new F()` seeds into the instance's `$proto`.
+    const o = await run(
+      `function F(){}\nvar staticRead:any = (F as any).prototype;\nvar K:any = F;\nresult = (K["prototype"] === staticRead) ? 1 : 0;`,
+    );
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("`new F() instanceof K` is true for a variable RHS (§7.3.20 through the edge)", async () => {
+    // The residual #2916 names as its single remaining dependency. `K` is an
+    // `any`-typed binding, so every static instanceof rule declines and the
+    // fully-dynamic `__instanceof_dynamic` helper must do `Get(C, "prototype")`
+    // on a closure value. Measured before: `false`.
+    const o = await run(`${APPROVED_FNCTOR}var K:any = F;\nresult = (c instanceof K) ? 1 : 0;`);
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("`({}) instanceof K` stays FALSE — the edge answers membership, not identity", async () => {
+    // The wrong-`true` guard. A fresh object is not in F.prototype's chain, and
+    // the edge must not turn "I found the prototype" into "the value is an
+    // instance". Same program as the case above, different LHS.
+    const o = await run(`${APPROVED_FNCTOR}var K:any = F;\nresult = (({}) instanceof K) ? 1 : 0;`);
+    expect(o.result).toBe(0);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("an own `prototype` write WINS over the compile-time edge (§7.3.20 step 5)", async () => {
+    // `K.prototype = undefined` lands in the closure's own-property bag (#3468)
+    // and is the program's explicit state, so `instanceof` must throw a
+    // TypeError rather than fall back to the compile-time prototype object.
+    // Consulting the edge first would turn a right answer into a wrong one.
+    const o = await run(
+      `${APPROVED_FNCTOR}var K:any = F;\nK.prototype = undefined;\n` +
+        `try { ({}) instanceof K; result = 0; } catch (e) { result = (e instanceof TypeError) ? 1 : 5; }`,
+    );
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("a `new Function` value with `prototype = undefined` throws a catchable TypeError", async () => {
+    // `language/expressions/instanceof/S15.3.5.3_A2_T2` — measured fail→pass.
+    // The RHS is a runtime callable with no compile-time prototype global at
+    // all, so this is the OWN-BAG half of the arm, not the edge half.
+    const o = await run(
+      `var FACTORY:any = new Function;\nFACTORY.prototype = undefined;\nvar obj:any = {};\n` +
+        `try { obj instanceof FACTORY; result = 0; } catch (e) { result = (e instanceof TypeError) ? 1 : 5; }`,
+    );
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("a `new Function` value with a STRING `prototype` throws a catchable TypeError", async () => {
+    // `S15.3.5.3_A2_T6` — measured fail→pass. A present-but-non-object
+    // `prototype` is §7.3.20 step 5, distinct from an absent one; the arm's
+    // `__hasOwnProperty` gate is what separates the two.
+    const o = await run(
+      `var FACTORY:any = new Function;\nFACTORY.prototype = "error";\n` +
+        `try { (function(){}) instanceof FACTORY; result = 0; } catch (e) { result = (e instanceof TypeError) ? 1 : 5; }`,
+    );
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  // ── REFUSALS ────────────────────────────────────────────────────────────
+  // A missed conversion is a missed conversion; a wrong `true`, a wrong throw
+  // or a spurious `.prototype` is a correctness regression.
+
+  it("an ARROW function still has NO `prototype` (§15.3)", async () => {
+    // The edge is a table of singletons the compiler minted, not a rule about
+    // "callable values", so an arrow is absent from it by construction rather
+    // than by an ad-hoc exclusion. Compiled alongside an approved fnctor so the
+    // edge table is definitely non-empty and the arm is definitely emitted.
+    const o = await run(
+      `var a:any = () => 1;\n${APPROVED_FNCTOR}result = (typeof a["prototype"] === "undefined") ? 1 : 0;`,
+    );
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("an unrelated function value does NOT resolve another function's prototype", async () => {
+    // Two approved fnctors in one module: the `ref.eq` identity match must pick
+    // exactly one. A name-shaped or type-shaped lookup would confuse them.
+    const o = await run(
+      `function F(){}\nF.prototype = {q:7};\nfunction G(){}\nG.prototype = {q:9};\n` +
+        `var cf:any = new F();\nvar cg:any = new G();\nvar r1:any = cf["q"];\nvar r2:any = cg["q"];\n` +
+        `var KF:any = F;\nvar KG:any = G;\n` +
+        `result = (KF["prototype"].q === 7 && KG["prototype"].q === 9 && (cf instanceof KG) === false) ? 1 : 0;`,
+    );
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("a non-callable object RHS still throws, and a plain object still has no `prototype`", async () => {
+    // Regression pin for the two arms this change reorganised: the §7.3.20
+    // step-1 codegen throw (`es5-standalone-instanceof.test.ts` owns the full
+    // set) and the `$Object` receiver path, which must not acquire a
+    // `prototype` from the edge.
+    const o = await run(
+      `${APPROVED_FNCTOR}var o:any = {};\nvar threw = 0;\n` +
+        `try { ({}) instanceof o; } catch (e) { threw = (e instanceof TypeError) ? 1 : 0; }\n` +
+        `result = (threw === 1 && typeof o["prototype"] === "undefined") ? 1 : 0;`,
+    );
+    expect(o.result).toBe(1);
+    expect(o.imports).toEqual([]);
+  });
+
+  it("a module with no user constructor is unaffected", async () => {
+    // The arm builders return an empty instruction list when the edge table is
+    // empty, so `__closure_prop_get` keeps its exact previous body AND local
+    // list. Behavioural half of that claim; the byte-identity half is the
+    // gc/host compile-diff recorded in the issue file.
+    const o = await run(`function f(){}\n(f as any).x = 41;\nresult = ((f as any).x as number) + 1;`);
+    expect(o.result).toBe(42);
+    expect(o.imports).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

Wave 6b of the #4426 ES5-standalone campaign — the #2660 M3 slice, the dependency #2916 named as its sole remaining blocker.

The measured defect was not the one filed: `Object.getPrototypeOf(new F()) === F.prototype` already held on base. The real gap is a **split brain** over one property — `F.prototype` on an escape-gate-approved fnctor lives in a `__fnctor_proto_<name>` module global keyed by *compile-time symbol name* (#2660 S2), while every other `f.prototype` access goes to the #3468 own-property bag keyed by *runtime identity*. So a dynamic `K["prototype"]` read answered `undefined` while the static read answered the object, and `__instanceof_dynamic` could not perform `Get(C, "prototype")`.

New `src/codegen/closure-prototype-edge.ts`: a finalize-filled `__closure_proto_of(value) -> externref` pairing the closure/class-object globals (identity, `ref.eq`) with the registry's prototype objects — a wrong `true` is structurally unreachable (exact identity, same object the `[[Prototype]]` seeding uses); a miss returns null and consumers keep their prior conservative answers. Wired into `native-dynamic-instanceof.ts` and `__closure_prop_get`'s `prototype` arm (bag-own-entry-gated, so `f.prototype = undefined` still wins §7.3.20 step 5).

Measured (all A/B through first-edit revert copies): `S15.3.5.3_A2_T2`/`_T6` fail→**pass**; `language/expressions/instanceof` **24 → 26 of 43, zero regressions**, every other row byte-identical; gc/host byte-identical (6-probe sha256 + structural argument); equivalence gate clean; 135 tests green across the new suite and neighbors; 54/54 combined pins with #4436's just-merged function-props work on the integrated branch. Residuals with owners in the issue file: `new <runtime-eval callable>` → null (runtime-eval lane, blocks A2_T5/A3_T1), `isPrototypeOf` (#4172/#4160), class-instance `[[Prototype]]` seeding (#3976) — verified a missed conversion, never a wrong throw. Deliberately no vivification for closures without a compile-time global (the only store is the enumerable bag, which would grow visible `prototype` keys on arrows).

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_