### PR TITLE
fix(#2951): IR-claimed JS-host generators compile once

### DIFF
--- a/plan/issues/2951-ir-first-skip-set-generators-class-members.md
+++ b/plan/issues/2951-ir-first-skip-set-generators-class-members.md
@@ -565,5 +565,5 @@ confirms the other half:
 - `check:ir-only` single-host lane stays READY (async.ts entry contains
   generator-adjacent shapes — do not regress it).
 - `check:ir-fallbacks` no unintended/post-claim growth; `tsc --noEmit`
-  clean; scoped test262 generator sample (built-ins/GeneratorPrototype +
+  clean; scoped generator test262 sample (built-ins/GeneratorPrototype +
   language/generators strides) net-zero vs main.

--- a/plan/issues/2951-ir-first-skip-set-generators-class-members.md
+++ b/plan/issues/2951-ir-first-skip-set-generators-class-members.md
@@ -344,63 +344,6 @@ standalone with the skip forced, diff module sections), and only after the
 #3032 W6 buffer-model decision — this is explicitly NOT part of closing
 this issue.
 
-### Acceptance (updated for the redesign)
-
-- A claim-dense class corpus probe shows member keys in
-  `CompileResult.irFirstSkipped`; each skipped member's shipped body is the
-  IR body (byte-diff anti-vacuity, the established pattern).
-- Flag-off byte identity preserved (default CI path untouched — all of this
-  is dead unless `JS2WASM_IR_FIRST=1`).
-- `tests/issue-2138.test.ts` index-layout-invariance extended to a
-  class+method corpus; the Hazard-2 escalation test above.
-- Full `merge_group` net-zero with the flag on via the `ir_first`
-  measurement lane (same as the generator half).
-
-## Re-scope + Implementation Plan (fable, 2026-08-15 — IR-path-only migration session)
-
-Live measurement on main @ `7add6938` invalidates half this issue and
-confirms the other half:
-
-- **Class-member half: superseded by #3522** on the bounded corpus. The
-  `check:ir-only` single-host lane reports `class-member: 10` units, **0
-  legacy bodies** (37/37 IR overall) — prepared/compile-once class
-  transactions landed. First deliverable: a claim-dense class probe
-  confirming no member family still double-compiles; record the evidence
-  here and mark the class half done. Residual scope only if the probe finds
-  a double-compiled family.
-- **Generator half: LIVE.** Probe (2026-08-15): `export function*
-counter(n: number) { for (let i = 0; i < n; i++) yield i; return n; }`
-  compiles with `trackIrOutcomes` showing the generator unit at
-  `legacy: true, ir: true` — the generator body still compiles twice and
-  the legacy body is only later overwritten. `irFirstSkipped` is empty.
-
-### Plan (generator compile-once, host mode)
-
-1. **Measure the side-effect delta.** Compile a claimed generator with
-   legacy body emission forcibly skipped (patch or env probe in `.tmp/`);
-   diff module sections (imports, globals, funcs, elems) vs the normal
-   build. Enumerate exactly which auxiliary machinery legacy generator
-   compilation contributes that the IR path (`addGeneratorImports` and
-   friends) does not.
-2. **Route generators through the prepared/compile-once mechanism free
-   functions already use** (`src/codegen/ir-prepared-free-functions.ts`,
-   `computePreparedInheritedIrFirstSkipUnitIds`) once the IR path
-   registers everything the diff found missing. Prefer making the IR claim
-   register the missing pieces over keeping the double-compile.
-3. **Standalone generators stay out of scope** (gate-2 notes above stand:
-   #680 native lowering is a disjoint lane).
-
-### Acceptance
-
-- The probe generator's unit outcome flips to `legacy: false, ir: true`;
-  a for-of driver over it still runs correctly (issue-2035 + generator
-  suites green).
-- `check:ir-only` single-host lane stays READY (async.ts entry contains
-  generator-adjacent shapes — do not regress it).
-- `check:ir-fallbacks` no unintended/post-claim growth; `tsc --noEmit`
-  clean; scoped generator test262 sample (built-ins/GeneratorPrototype +
-  language/generators strides) net-zero vs main.
-
 ## Implementation Notes — generator compile-once (2026-08-15, fable, main @ 7add6938)
 
 ### Deliverable 1 — class half is DONE (superseded by #3522), verified
@@ -567,3 +510,60 @@ mistaken for unfinished #2951 work)
 2. Static accessors (`class-method`) + `static-class-initialization` module-init
    — same category.
 3. Standalone/WASI generators stay compile-twice by design (Phase 3, deferred).
+
+### Acceptance (updated for the redesign)
+
+- A claim-dense class corpus probe shows member keys in
+  `CompileResult.irFirstSkipped`; each skipped member's shipped body is the
+  IR body (byte-diff anti-vacuity, the established pattern).
+- Flag-off byte identity preserved (default CI path untouched — all of this
+  is dead unless `JS2WASM_IR_FIRST=1`).
+- `tests/issue-2138.test.ts` index-layout-invariance extended to a
+  class+method corpus; the Hazard-2 escalation test above.
+- Full `merge_group` net-zero with the flag on via the `ir_first`
+  measurement lane (same as the generator half).
+
+## Re-scope + Implementation Plan (fable, 2026-08-15 — IR-path-only migration session)
+
+Live measurement on main @ `7add6938` invalidates half this issue and
+confirms the other half:
+
+- **Class-member half: superseded by #3522** on the bounded corpus. The
+  `check:ir-only` single-host lane reports `class-member: 10` units, **0
+  legacy bodies** (37/37 IR overall) — prepared/compile-once class
+  transactions landed. First deliverable: a claim-dense class probe
+  confirming no member family still double-compiles; record the evidence
+  here and mark the class half done. Residual scope only if the probe finds
+  a double-compiled family.
+- **Generator half: LIVE.** Probe (2026-08-15): `export function*
+  counter(n: number) { for (let i = 0; i < n; i++) yield i; return n; }`
+  compiles with `trackIrOutcomes` showing the generator unit at
+  `legacy: true, ir: true` — the generator body still compiles twice and
+  the legacy body is only later overwritten. `irFirstSkipped` is empty.
+
+### Plan (generator compile-once, host mode)
+
+1. **Measure the side-effect delta.** Compile a claimed generator with
+   legacy body emission forcibly skipped (patch or env probe in `.tmp/`);
+   diff module sections (imports, globals, funcs, elems) vs the normal
+   build. Enumerate exactly which auxiliary machinery legacy generator
+   compilation contributes that the IR path (`addGeneratorImports` and
+   friends) does not.
+2. **Route generators through the prepared/compile-once mechanism free
+   functions already use** (`src/codegen/ir-prepared-free-functions.ts`,
+   `computePreparedInheritedIrFirstSkipUnitIds`) once the IR path
+   registers everything the diff found missing. Prefer making the IR claim
+   register the missing pieces over keeping the double-compile.
+3. **Standalone generators stay out of scope** (gate-2 notes above stand:
+   #680 native lowering is a disjoint lane).
+
+### Acceptance
+
+- The probe generator's unit outcome flips to `legacy: false, ir: true`;
+  a for-of driver over it still runs correctly (issue-2035 + generator
+  suites green).
+- `check:ir-only` single-host lane stays READY (async.ts entry contains
+  generator-adjacent shapes — do not regress it).
+- `check:ir-fallbacks` no unintended/post-claim growth; `tsc --noEmit`
+  clean; scoped test262 generator sample (built-ins/GeneratorPrototype +
+  language/generators strides) net-zero vs main.

--- a/plan/issues/2951-ir-first-skip-set-generators-class-members.md
+++ b/plan/issues/2951-ir-first-skip-set-generators-class-members.md
@@ -1,10 +1,10 @@
 ---
 id: 2951
 title: "IR-first skip set: include generators and class members (retire the two #2138 standing exclusions)"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-07-02
-updated: 2026-07-04
+updated: 2026-08-15
 priority: medium
 horizon: m
 feasibility: hard
@@ -18,6 +18,24 @@ model: fable
 fable_role: spec
 depends_on: [2138]
 related: [2950, 1370, 2864]
+# The new logic lives in `src/ir/generator-support.ts` (new module). What
+# remains in the four god-files is unavoidable in-place growth: the `gen.*`
+# provider fields on their node interfaces, the matching arms in the two
+# dependency-discovery switches, and the generator admission branch in the R2
+# selector — each must sit at the existing dispatch site.
+loc-budget-allow:
+  - src/ir/nodes.ts
+  - src/ir/integration.ts
+  - src/ir/prepared-component-dependencies.ts
+  - src/codegen/ir-prepared-free-functions.ts
+# Same reason at function granularity: the generator preparation step belongs in
+# `compileIrPathFunctions`' ordered pass pipeline (it must run right after
+# `addGeneratorImports` and before sealing), and the `gen.*` evidence arm belongs
+# in `collectFunctionEvidence`' instruction walk. Both bodies grew by the two
+# small blocks that call into `src/ir/generator-support.ts`.
+func-budget-allow:
+  - src/ir/integration.ts::compileIrPathFunctions
+  - src/ir/prepared-component-dependencies.ts::collectFunctionEvidence
 origin: "2026-07-02 July Fable audit §1 (#2138 impl-note deviations 3 and 4 had no tracking issue)"
 ---
 
@@ -337,3 +355,215 @@ this issue.
   class+method corpus; the Hazard-2 escalation test above.
 - Full `merge_group` net-zero with the flag on via the `ir_first`
   measurement lane (same as the generator half).
+
+## Re-scope + Implementation Plan (fable, 2026-08-15 — IR-path-only migration session)
+
+Live measurement on main @ `7add6938` invalidates half this issue and
+confirms the other half:
+
+- **Class-member half: superseded by #3522** on the bounded corpus. The
+  `check:ir-only` single-host lane reports `class-member: 10` units, **0
+  legacy bodies** (37/37 IR overall) — prepared/compile-once class
+  transactions landed. First deliverable: a claim-dense class probe
+  confirming no member family still double-compiles; record the evidence
+  here and mark the class half done. Residual scope only if the probe finds
+  a double-compiled family.
+- **Generator half: LIVE.** Probe (2026-08-15): `export function*
+counter(n: number) { for (let i = 0; i < n; i++) yield i; return n; }`
+  compiles with `trackIrOutcomes` showing the generator unit at
+  `legacy: true, ir: true` — the generator body still compiles twice and
+  the legacy body is only later overwritten. `irFirstSkipped` is empty.
+
+### Plan (generator compile-once, host mode)
+
+1. **Measure the side-effect delta.** Compile a claimed generator with
+   legacy body emission forcibly skipped (patch or env probe in `.tmp/`);
+   diff module sections (imports, globals, funcs, elems) vs the normal
+   build. Enumerate exactly which auxiliary machinery legacy generator
+   compilation contributes that the IR path (`addGeneratorImports` and
+   friends) does not.
+2. **Route generators through the prepared/compile-once mechanism free
+   functions already use** (`src/codegen/ir-prepared-free-functions.ts`,
+   `computePreparedInheritedIrFirstSkipUnitIds`) once the IR path
+   registers everything the diff found missing. Prefer making the IR claim
+   register the missing pieces over keeping the double-compile.
+3. **Standalone generators stay out of scope** (gate-2 notes above stand:
+   #680 native lowering is a disjoint lane).
+
+### Acceptance
+
+- The probe generator's unit outcome flips to `legacy: false, ir: true`;
+  a for-of driver over it still runs correctly (issue-2035 + generator
+  suites green).
+- `check:ir-only` single-host lane stays READY (async.ts entry contains
+  generator-adjacent shapes — do not regress it).
+- `check:ir-fallbacks` no unintended/post-claim growth; `tsc --noEmit`
+  clean; scoped generator test262 sample (built-ins/GeneratorPrototype +
+  language/generators strides) net-zero vs main.
+
+## Implementation Notes — generator compile-once (2026-08-15, fable, main @ 7add6938)
+
+### Deliverable 1 — class half is DONE (superseded by #3522), verified
+
+A claim-dense class probe (constructors, instance methods, static methods,
+instance accessors, static accessors, `extends` + override + `super()`,
+implicit constructor, field initializers, generator method) found **zero**
+double-compiled units — `TOTAL double-compiled units: 0`. Every IR-claimed
+member reports `legacy=false, ir=true`. `check:ir-only` agrees:
+`class-member: 10`, `legacy body emitted 0`.
+
+Two member families never IR-CLAIM at all and stay legacy-only. That is
+**compile-ONCE on the legacy side**, not the deviation-4 double-compile, so it
+is out of scope here — but recorded because it is the residual the widening
+track (#2855) still owns:
+
+| family              | outcome code                | note                              |
+| ------------------- | --------------------------- | --------------------------------- |
+| static get/set      | `class-method`              | plus `static-class-initialization` on the module-init unit |
+| generator method    | `class-member-unsupported`  | `*items()` inside a class; #3032 W4 territory |
+
+**Deviation 4 (class members "always legacy then overwrite") is closed.** No
+`irFirstSkipped` member-key work was needed: prepared/compile-once class
+transactions land the members before the direct emitter ever writes a body,
+which is a strictly better outcome than the skip-set widening the 2026-07-18
+plan designed (Hazards 1 and 2 in that plan are moot — there is no
+skipped-slot-with-no-body window to escalate).
+
+### Deliverable 2 — the generator side-effect delta
+
+The delta is **not** module state. Legacy generator compilation contributes
+**no import, global, type, elem or tag** that the IR claim fails to register —
+`addGeneratorImports` is driven by a *source-level* scan (`state.generatorFound`
+in `declarations.ts`) and again by the IR claim itself
+(`ir/integration.ts`), so the auxiliary machinery exists either way. Measured:
+the shipped module is **byte-identical** before and after this slice
+(`cmp` exit 0 on both probe programs, 1712 B and 413 B).
+
+What legacy compilation actually supplied was **dependency-discovery
+evidence**, and that is where the double-compile came from. Forcing the
+generator onto the prepared route produced this exact failure list:
+
+```
+prepared owner …top-level-function:0 has incomplete dependencies:
+  unplanned-abi-binding: external callable import|3:env|19:__gen_create_buffer
+    has no Program ABI identity
+  implicit-support-reference-unavailable: gen.push      resolves generator runtime callables without explicit symbolic refs
+  implicit-support-reference-unavailable: gen.setReturn resolves generator runtime callables without explicit symbolic refs
+  implicit-support-reference-unavailable: gen.epilogue  resolves generator runtime callables without explicit symbolic refs
+```
+
+Read this as the enumerated delta:
+
+1. `gen.push` / `gen.epilogue` / `gen.yieldStar` / `gen.setReturn` resolved
+   their host callables **by name inside `ir/lower.ts`**, so they were opaque
+   to `derivePreparedComponentDependencies` — the component could never be
+   dependency-complete and was peeled back to the direct route every time.
+2. `__gen_create_buffer` (already symbolic, an ordinary `call`) had no Program
+   ABI identity yet. That class of failure is retryable
+   (`planBlockingCallableImports`) — but the retry only fires when **every**
+   failure in the component is a plannable callable, so failure (1) suppressed
+   it.
+
+### The fix (why it is registration, not a wider skip predicate)
+
+- **`src/ir/generator-support.ts` (new) — `attachIrGeneratorSupport`.** Mirrors
+  `attachIrExternSupport`: after inference and middle-end transforms settle the
+  value types, attach the exact runtime callable to each `gen.*` instruction
+  (`__gen_push_f64|i32|ref`, `__create_generator`, `__gen_yield_star`,
+  `__gen_set_return`, plus `__box_number` as `gen.setReturn.boxProvider` when
+  the stashed value is `f64`/`i32`). Re-attachment is idempotent and rejects a
+  conflicting binding, so a component cannot seal against one callable and
+  lower through another.
+- **`observeAttachedGeneratorProviders` (`ir/integration.ts`).** The load-bearing
+  half, and the non-obvious one: **prepared-component sealing runs BEFORE the
+  bodies are lowered.** A `runtime`-bound provider is only observed by
+  `ProgramAbiCallableProviderRegistry` when `resolveAndObserveCallableProvider`
+  runs, i.e. during lowering — too late. Sealing therefore reported every
+  provider key as `unplanned-abi-binding` even after step 1, and
+  `importsForPreparedProviders` returned `undefined`. Observing them right after
+  `addGeneratorImports` (the same thing `prepareStrings` does for string
+  providers) is what actually makes the owner dependency-complete.
+- **`prepared-component-dependencies.ts`.** `implicitSupportRequirement` now
+  returns `null` for a `gen.*` carrying a provider, and the providers are
+  recorded as ordinary external callables. `gen.setReturn` fails closed when its
+  `boxProvider` disagrees with the stashed value type.
+- **`ir-prepared-free-functions.ts`.** `selectR2PreparedOwnerComponents` no
+  longer excludes `asteriskToken` outright; generators are admitted when
+  `generatorsPreparable(ctx)` (`!(standalone || wasi || strictNoHostImports)` —
+  the same condition gate 2 uses). A generator's source return contract is the
+  opaque generator object, a `val`-externref that the R2 signature vocabulary
+  did not admit, so `allowOpaqueExternrefValue` widens it **for generator claims
+  only**; `r2SignatureMatchesAllocatedSlot` still compares the projection
+  against the already-allocated slot, so admission stays fail-closed.
+- **`ir/lower.ts`** consumes `instr.provider ?? irRuntimeFuncRef(<name>)` so the
+  emitted call is exactly the sealed one; the by-name fallback keeps the
+  non-prepared route working unchanged.
+
+Standalone/WASI generators are untouched by design — the gate-2 reasoning still
+holds (legacy standalone generators are the #680 sequential-numeric-yield native
+carrier, a disjoint lane whose self-sufficiency is unproven). Phase 3 of the
+2026-07-18 plan stands.
+
+## Test Results — 2026-08-15 (fable)
+
+**Probe outcome flip** (`export function* counter(n: number) { for (let i = 0;
+i < n; i++) yield i; return n; }`, `trackIrOutcomes`):
+
+| | before (main @ 7add6938) | after |
+| --- | --- | --- |
+| `counter` unit | `legacy=true, ir=true` | **`legacy=false, ir=true`** |
+| `irFirstSkipped` (flag on) | `[]` | `["g"]` / owner listed |
+| for-of drain `counter(5)` | `[0,1,2,3,4]` | `[0,1,2,3,4]` |
+| terminal `next()` after 2 yields | `{done:true, value:2}` | `{done:true, value:2}` |
+| shipped module bytes | 1712 | **1712, byte-identical (`cmp` exit 0)** |
+
+**Class probe** (deliverable 1): 8 programs, 0 double-compiled units — evidence
+table above.
+
+**Gates**
+
+| gate | result |
+| --- | --- |
+| `tests/issue-2035.test.ts` | 11/11 pass |
+| `tests/issue-2951.test.ts` | 7/7 pass (2 stale compile-twice assertions updated to the compile-once contract, 3 new cases added) |
+| generator suites: `generators`, `generator-iife`, `generator-yield-contexts`, `generator-method-destructuring`, `for-of-string-generator` | 25/25 pass |
+| `issue-1665`, `issue-2079`, `issue-2157`, `issue-2169`×3, `issue-2172` (standalone / native carrier) | 56 pass, 1 todo |
+| `issue-2571`, `issue-2581`, `issue-2662`, `issue-2864`, `issue-3032`×2, `issue-4412`, `benchmark-module-size-generator` | 87/87 pass |
+| `issue-3143`, `issue-3519-ir-only-gate`, `issue-3519-ir-outcomes` | 26 + 38 pass |
+| `pnpm run check:ir-only` | **READY** — 5/5 entries, 37 units, `legacy body emitted 0`, 0 unsupported, 0 invariants |
+| `pnpm run check:ir-fallbacks` | **OK** — no unintended / post-claim / module-level increases |
+| `node scripts/equivalence-gate.mjs` shards 1/8…8/8 | **no new regressions** in any shard (several baseline entries report as newly-fixed; baseline deliberately NOT ratcheted here — unrelated to this slice) |
+| scoped test262 generator stride, 640 files (`language/{statements,expressions}/generators`, `built-ins/GeneratorPrototype`, `built-ins/GeneratorFunction`) | **0 divergences** base vs branch — `{ok: 522, ce: 118}` on both, compared per file |
+| `npx tsc --noEmit` | clean |
+
+Method note for the two A/B rows: measured by restoring the five touched `src/`
+files to `HEAD` (file-copy A/B, never `git stash` — shared stack) and re-running
+in the same worktree, so "base" is literally main @ `7add6938` with the same
+node/vitest.
+
+**Pre-existing RED, NOT this slice** (both re-verified by restoring the five
+touched `src/` files to `HEAD` and re-running — identical failure):
+
+- `tests/issue-2138.test.ts` → `stringy("x")` returns `"x"`, expected `"ax"`
+  (1 of 7).
+- `tests/issue-2138-multi-module-ir-overlay.test.ts` → V8 heap OOM in this
+  container (also OOMs at `--max-old-space-size=6144`).
+
+Not run per instruction: full test262.
+
+**Status call.** Both halves that this issue actually scopes — deviation 3
+(generators compile twice) and deviation 4 (class members compile twice) — are
+closed and measured. Left at `in-progress` rather than `done` only because this
+branch is handed to a merger, who should flip it at merge. Nothing below is a
+residual of #2951's own scope:
+
+**Residual scope after this slice** (tracked elsewhere, listed so it is not
+mistaken for unfinished #2951 work)
+
+1. Generator **methods** (`class Seq { *items() {} }`) and generator function
+   **expressions** still never IR-claim (`class-member-unsupported` /
+   `body-shape-rejected`), so they remain legacy-only — a claim-coverage
+   question owned by #3032 W4 / #2855, not a compile-once question.
+2. Static accessors (`class-method`) + `static-class-initialization` module-init
+   — same category.
+3. Standalone/WASI generators stay compile-twice by design (Phase 3, deferred).

--- a/src/codegen/ir-prepared-free-functions.ts
+++ b/src/codegen/ir-prepared-free-functions.ts
@@ -334,8 +334,17 @@ function bodyProjection(
   );
 }
 
-function r2StableSignatureType(type: IrType | null): boolean {
+function r2StableSignatureType(
+  type: IrType | null,
+  options?: { readonly allowOpaqueExternrefValue?: boolean },
+): boolean {
   if (type === null || type.kind === "string") return true;
+  // #2951 generator owners — the source return contract of a `function*` is the
+  // opaque generator object, which both front-ends project to the same physical
+  // `externref`. Only the generator admission path opts in; every other owner
+  // keeps the narrower vocabulary so an unproven reference contract cannot
+  // silently enter preparation.
+  if (options?.allowOpaqueExternrefValue === true && asVal(type)?.kind === "externref") return true;
   // #3522 returned-closure ownership — an exact callable source boundary is
   // the same canonical externref contract in both backends. Admit the owner to
   // prepare-before-emit so its inventoried lifted literal is allocated inside
@@ -626,8 +635,15 @@ function sameValType(left: ValType, right: ValType): boolean {
   return true;
 }
 
-function r2StableValType(ctx: CodegenContext, type: IrType): ValType | undefined {
+function r2StableValType(
+  ctx: CodegenContext,
+  type: IrType,
+  options?: { readonly allowOpaqueExternrefValue?: boolean },
+): ValType | undefined {
   if (type.kind === "extern" || type.kind === "callable") return { kind: "externref" };
+  if (options?.allowOpaqueExternrefValue === true && asVal(type)?.kind === "externref") {
+    return { kind: "externref" };
+  }
   if (type.kind === "string") {
     if (!ctx.nativeStrings) return { kind: "externref" };
     return ctx.anyStrTypeIdx >= 0 ? { kind: "ref", typeIdx: ctx.anyStrTypeIdx } : undefined;
@@ -643,6 +659,17 @@ function r2StableValType(ctx: CodegenContext, type: IrType): ValType | undefined
 }
 
 /**
+ * #2951 — IR-claimed generators compile once only in the JS-host lane. The
+ * standalone / WASI / no-host-import lanes lower generators through the
+ * disjoint #680 sequential-numeric-yield native carrier, whose self-sufficiency
+ * without the legacy body is unproven; keep them on the compile-twice route.
+ * Mirrors the `generatorsSkippable` condition of the inherited allowlist.
+ */
+function generatorsPreparable(ctx: CodegenContext): boolean {
+  return !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports);
+}
+
+/**
  * Preparation may replace an empty declaration slot before direct emission,
  * but it must not change that slot's already allocated callable ABI. The
  * Program ABI registry observes the allocation contract, and later direct
@@ -652,12 +679,13 @@ function r2SignatureMatchesAllocatedSlot(
   ctx: CodegenContext,
   unitId: IrUnitId,
   override: { readonly params: readonly IrType[]; readonly returnType: IrType | null },
+  options?: { readonly allowOpaqueExternrefValue?: boolean },
 ): boolean {
   const func = ctx.programAbiSourceCallables?.functionForUnit(unitId);
   const signature = func === undefined ? undefined : ctx.mod.types[func.typeIdx];
   if (!signature || signature.kind !== "func") return false;
-  const params = override.params.map((type) => r2StableValType(ctx, type));
-  const result = override.returnType === null ? null : r2StableValType(ctx, override.returnType);
+  const params = override.params.map((type) => r2StableValType(ctx, type, options));
+  const result = override.returnType === null ? null : r2StableValType(ctx, override.returnType, options);
   if (
     params.some((type) => type === undefined) ||
     result === undefined ||
@@ -1046,17 +1074,23 @@ export function selectR2PreparedOwnerComponents(input: {
       continue;
     }
     const isAsync = claim.declaration.modifiers?.some(({ kind }) => kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+    const isGenerator = claim.declaration.asteriskToken !== undefined;
+    // #2951 — a JS-host generator owner returns the opaque generator object.
+    // Admit that one reference contract for generators only; the standalone /
+    // WASI / no-host-import lanes keep the compile-twice route because their
+    // legacy lowering is the disjoint #680 native carrier.
+    const signatureOptions = isGenerator ? { allowOpaqueExternrefValue: true } : undefined;
     if (
       input.ctx.fast ||
       isAsync ||
-      claim.declaration.asteriskToken ||
+      (isGenerator && !generatorsPreparable(input.ctx)) ||
       containsUnplannedNestedExecutableSyntax(claim.declaration, unitId, claim.legacyName, input.hostVoidCallbacks) ||
       containsCurrentFunctionPoisonPillRead(input.ctx, claim.declaration) ||
       directCallerActivationTargets.has(unitId) ||
       containsTopLevelFunctionValueReference(input.ctx, claim.declaration, functionUnitsByName) ||
-      !override.params.every(r2StableSignatureType) ||
-      !r2StableSignatureType(override.returnType) ||
-      !r2SignatureMatchesAllocatedSlot(input.ctx, unitId, override)
+      !override.params.every((type) => r2StableSignatureType(type, signatureOptions)) ||
+      !r2StableSignatureType(override.returnType, signatureOptions) ||
+      !r2SignatureMatchesAllocatedSlot(input.ctx, unitId, override, signatureOptions)
     ) {
       continue;
     }

--- a/src/ir/generator-support.ts
+++ b/src/ir/generator-support.ts
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { irRuntimeFuncRef, sameIrCallableBinding } from "./callable-bindings.js";
+import {
+  asVal,
+  forEachInstrDeep,
+  mapNestedBuffers,
+  type IrFuncRef,
+  type IrFunction,
+  type IrInstr,
+  type IrType,
+  type IrValueId,
+} from "./nodes.js";
+
+function mapArray<T>(values: readonly T[], map: (value: T) => T): readonly T[] {
+  let changed = false;
+  const mapped = values.map((value) => {
+    const next = map(value);
+    changed ||= next !== value;
+    return next;
+  });
+  return changed ? mapped : values;
+}
+
+function valueTypesOf(fn: IrFunction): ReadonlyMap<IrValueId, IrType> {
+  const result = new Map<IrValueId, IrType>();
+  for (const param of fn.params) result.set(param.value, param.type);
+  for (const value of fn.asyncPlan?.values ?? []) result.set(value.value, value.type);
+  for (const block of fn.blocks) {
+    for (let index = 0; index < block.blockArgs.length; index++) {
+      const type = block.blockArgTypes[index];
+      if (type) result.set(block.blockArgs[index]!, type);
+    }
+    for (const root of block.instrs) {
+      forEachInstrDeep(root, (instr) => {
+        if (instr.result !== null && instr.resultType) result.set(instr.result, instr.resultType);
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * The exact typed `__gen_push_*` selection lowering performs.
+ *
+ * Keep this in lockstep with the `gen.push` arm of `src/ir/lower.ts`: sealing
+ * proves the callable named here, so a divergent spelling would seal against
+ * one import and emit another.
+ */
+export function irGeneratorPushProviderSymbol(valueType: IrType | undefined): string {
+  const val = valueType === undefined ? undefined : asVal(valueType);
+  if (val?.kind === "f64") return "__gen_push_f64";
+  if (val?.kind === "i32") return "__gen_push_i32";
+  return "__gen_push_ref";
+}
+
+/** True when a `gen.setReturn` value needs `__box_number` before the call. */
+export function irGeneratorSetReturnNeedsBoxing(valueType: IrType | undefined): boolean {
+  const val = valueType === undefined ? undefined : asVal(valueType);
+  return val?.kind === "f64" || val?.kind === "i32";
+}
+
+function requireSameProvider(kind: string, existing: IrFuncRef, next: IrFuncRef): void {
+  if (!sameIrCallableBinding(existing.binding, next.binding)) {
+    throw new Error(`IR ${kind} already carries a different prepared provider binding`);
+  }
+}
+
+/**
+ * Attach exact symbolic generator-runtime dependencies to final IR.
+ *
+ * #2951 — the `gen.*` instructions used to resolve their host callables by
+ * name inside the lowerer, which made them invisible to prepared-component
+ * dependency discovery: an IR-claimed generator always reported
+ * `implicit-support-reference-unavailable` and could never compile once.
+ * Selecting the provider here (after inference and middle-end transforms have
+ * settled the value types) lets sealing prove the same Program ABI callable
+ * lowering will consume. Repeated preparation is idempotent and rejects a
+ * stale or conflicting attachment, mirroring `attachIrExternSupport`.
+ */
+export function attachIrGeneratorSupport(fn: IrFunction): IrFunction {
+  if (fn.funcKind !== "generator") return fn;
+  const valueTypes = valueTypesOf(fn);
+  const mapBuffer = (buffer: readonly IrInstr[]): readonly IrInstr[] => mapArray(buffer, mapInstr);
+  const mapInstr = (instr: IrInstr): IrInstr => {
+    const nested = mapNestedBuffers(instr, mapBuffer);
+    switch (nested.kind) {
+      case "gen.push": {
+        const provider = irRuntimeFuncRef(irGeneratorPushProviderSymbol(valueTypes.get(nested.value)));
+        if (nested.provider) {
+          requireSameProvider(nested.kind, nested.provider, provider);
+          return nested;
+        }
+        return { ...nested, provider };
+      }
+      case "gen.epilogue": {
+        const provider = irRuntimeFuncRef("__create_generator");
+        if (nested.provider) {
+          requireSameProvider(nested.kind, nested.provider, provider);
+          return nested;
+        }
+        return { ...nested, provider };
+      }
+      case "gen.yieldStar": {
+        const provider = irRuntimeFuncRef("__gen_yield_star");
+        if (nested.provider) {
+          requireSameProvider(nested.kind, nested.provider, provider);
+          return nested;
+        }
+        return { ...nested, provider };
+      }
+      case "gen.setReturn": {
+        const provider = irRuntimeFuncRef("__gen_set_return");
+        const boxProvider = irGeneratorSetReturnNeedsBoxing(valueTypes.get(nested.value))
+          ? irRuntimeFuncRef("__box_number")
+          : undefined;
+        if (nested.provider) {
+          requireSameProvider(nested.kind, nested.provider, provider);
+          if ((nested.boxProvider === undefined) !== (boxProvider === undefined)) {
+            throw new Error("IR gen.setReturn already carries a different prepared boxing attachment");
+          }
+          if (nested.boxProvider && boxProvider) requireSameProvider(nested.kind, nested.boxProvider, boxProvider);
+          return nested;
+        }
+        return { ...nested, provider, ...(boxProvider ? { boxProvider } : {}) };
+      }
+      default:
+        return nested;
+    }
+  };
+
+  const blocks = mapArray(fn.blocks, (block) => {
+    const instrs = mapBuffer(block.instrs);
+    return instrs === block.instrs ? block : { ...block, instrs };
+  });
+  return blocks === fn.blocks ? fn : { ...fn, blocks };
+}
+
+/**
+ * Every generator-runtime callable the attached IR of `fns` will consume.
+ *
+ * The caller observes these against the Program ABI BEFORE prepared-component
+ * sealing. Sealing runs ahead of lowering, so a `runtime`-bound provider that
+ * is only resolved inside the lowerer has not crossed the observation boundary
+ * yet and the component is rejected with an `unplanned-abi-binding` for a
+ * callable that is in fact perfectly available.
+ */
+export function collectAttachedGeneratorProviders(fns: readonly IrFunction[]): readonly IrFuncRef[] {
+  const refs: IrFuncRef[] = [];
+  for (const fn of fns) {
+    if (fn.funcKind !== "generator") continue;
+    for (const block of fn.blocks) {
+      for (const root of block.instrs) {
+        forEachInstrDeep(root, (instr) => {
+          switch (instr.kind) {
+            case "gen.push":
+            case "gen.epilogue":
+            case "gen.yieldStar":
+              if (instr.provider) refs.push(instr.provider);
+              return;
+            case "gen.setReturn":
+              if (instr.provider) refs.push(instr.provider);
+              if (instr.boxProvider) refs.push(instr.boxProvider);
+              return;
+            default:
+              return;
+          }
+        });
+      }
+    }
+  }
+  return refs;
+}

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -270,6 +270,7 @@ import {
 import { verifyIrFunction } from "./verify.js";
 import { prepareIrRuntimeManifest, type PreparedIrRuntimeManifest } from "./intrinsic-support.js";
 import { attachIrExternSupport } from "./extern-support.js";
+import { attachIrGeneratorSupport, collectAttachedGeneratorProviders } from "./generator-support.js";
 import { isIntrinsicId, type IntrinsicId } from "./intrinsics.js";
 import { materializePreparedMathProviders, preparedMathProviderIndex } from "./math-runtime-providers.js";
 import { materializePreparedAsyncHostAdapters } from "../codegen/ir-async-runtime-adapters.js";
@@ -2513,7 +2514,21 @@ export function compileIrPathFunctions(
   if (healthyForLower.length === 0) return finishReport();
   if (
     !runGlobalPreparation(() => {
-      if (healthyForLower.some((entry) => entry.fn.funcKind === "generator")) addGeneratorImports(ctx);
+      if (!healthyForLower.some((entry) => entry.fn.funcKind === "generator")) return;
+      addGeneratorImports(ctx);
+      // #2951 — bind the `gen.*` runtime callables symbolically now that the
+      // imports exist, then OBSERVE them: prepared-component sealing runs
+      // before lowering, so an unobserved provider reads as an unplanned ABI
+      // binding and peels the generator back to the compile-twice route.
+      healthyForLower = healthyForLower.map((entry) => {
+        const fn = attachIrGeneratorSupport(entry.fn);
+        return fn === entry.fn ? entry : { ...entry, fn };
+      });
+      if (ctx.programAbiCallableProviders) {
+        for (const ref of collectAttachedGeneratorProviders(healthyForLower.map((entry) => entry.fn))) {
+          resolveAndObserveCallableProvider(ctx, ref);
+        }
+      }
     })
   ) {
     return finishReport();

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -2509,7 +2509,9 @@ export function lowerIrFunctionBody<S, Slot>(
           // `(externref, externref) → void`.
           importName = "__gen_push_ref";
         }
-        const fnIdx = resolver.resolveFunc(irRuntimeFuncRef(importName));
+        // #2951 — prefer the sealed provider so lowering consumes exactly the
+        // callable prepared-component dependency discovery proved.
+        const fnIdx = resolver.resolveFunc(instr.provider ?? irRuntimeFuncRef(importName));
         // Stack: buffer, value → (void); call __gen_push_*.
         emitter.pushRaw(out, {
           op: "local.get",
@@ -2527,7 +2529,7 @@ export function lowerIrFunctionBody<S, Slot>(
         if (func.generatorBufferSlot === undefined) {
           throw new Error(`ir/lower: gen.epilogue requires func.generatorBufferSlot (${func.name})`);
         }
-        const fnIdx = resolver.resolveFunc(irRuntimeFuncRef("__create_generator"));
+        const fnIdx = resolver.resolveFunc(instr.provider ?? irRuntimeFuncRef("__create_generator"));
         emitter.pushRaw(out, {
           op: "local.get",
           index: slotWasmIdx(func.generatorBufferSlot),
@@ -2547,7 +2549,7 @@ export function lowerIrFunctionBody<S, Slot>(
         if (func.generatorBufferSlot === undefined) {
           throw new Error(`ir/lower: gen.yieldStar requires func.generatorBufferSlot (${func.name})`);
         }
-        const fnIdx = resolver.resolveFunc(irRuntimeFuncRef("__gen_yield_star"));
+        const fnIdx = resolver.resolveFunc(instr.provider ?? irRuntimeFuncRef("__gen_yield_star"));
         emitter.pushRaw(out, {
           op: "local.get",
           index: slotWasmIdx(func.generatorBufferSlot),
@@ -2574,7 +2576,8 @@ export function lowerIrFunctionBody<S, Slot>(
         if (func.generatorBufferSlot === undefined) {
           throw new Error(`ir/lower: gen.setReturn requires func.generatorBufferSlot (${func.name})`);
         }
-        const setReturnIdx = resolver.resolveFunc(irRuntimeFuncRef("__gen_set_return"));
+        const setReturnIdx = resolver.resolveFunc(instr.provider ?? irRuntimeFuncRef("__gen_set_return"));
+        const boxRef = instr.boxProvider ?? irRuntimeFuncRef("__box_number");
         const valueT = asVal(typeOf(instr.value));
         // buffer (arg 0)
         emitter.pushRaw(out, {
@@ -2584,16 +2587,10 @@ export function lowerIrFunctionBody<S, Slot>(
         // value (arg 1), boxed to externref
         emitValue(instr.value, out);
         if (valueT?.kind === "f64") {
-          emitter.pushRaw(out, {
-            op: "call",
-            funcIdx: resolver.resolveFunc(irRuntimeFuncRef("__box_number")),
-          });
+          emitter.pushRaw(out, { op: "call", funcIdx: resolver.resolveFunc(boxRef) });
         } else if (valueT?.kind === "i32") {
           emitter.pushRaw(out, { op: "f64.convert_i32_s" });
-          emitter.pushRaw(out, {
-            op: "call",
-            funcIdx: resolver.resolveFunc(irRuntimeFuncRef("__box_number")),
-          });
+          emitter.pushRaw(out, { op: "call", funcIdx: resolver.resolveFunc(boxRef) });
         } else if (valueT?.kind === "ref" || valueT?.kind === "ref_null") {
           emitter.emitToExternref(out);
         }

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -1909,6 +1909,12 @@ export interface IrInstrCoerceToExternref extends IrInstrBase {
 export interface IrInstrGenPush extends IrInstrBase {
   readonly kind: "gen.push";
   readonly value: IrValueId;
+  /**
+   * #2951 — the exact typed `__gen_push_*` runtime callable, attached by
+   * `attachIrGeneratorSupport` once value types are final. Prepared-component
+   * sealing proves this same Program ABI callable that lowering consumes.
+   */
+  readonly provider?: IrFuncRef;
 }
 
 /**
@@ -2056,6 +2062,8 @@ export interface IrInstrForOfIter extends IrInstrBase {
  */
 export interface IrInstrGenEpilogue extends IrInstrBase {
   readonly kind: "gen.epilogue";
+  /** #2951 — exact `__create_generator` runtime callable (see `IrInstrGenPush.provider`). */
+  readonly provider?: IrFuncRef;
 }
 
 /**
@@ -2087,6 +2095,8 @@ export interface IrInstrGenEpilogue extends IrInstrBase {
 export interface IrInstrGenYieldStar extends IrInstrBase {
   readonly kind: "gen.yieldStar";
   readonly inner: IrValueId;
+  /** #2951 — exact `__gen_yield_star` runtime callable (see `IrInstrGenPush.provider`). */
+  readonly provider?: IrFuncRef;
 }
 
 /**
@@ -2115,6 +2125,14 @@ export interface IrInstrGenYieldStar extends IrInstrBase {
 export interface IrInstrGenSetReturn extends IrInstrBase {
   readonly kind: "gen.setReturn";
   readonly value: IrValueId;
+  /** #2951 — exact `__gen_set_return` runtime callable (see `IrInstrGenPush.provider`). */
+  readonly provider?: IrFuncRef;
+  /**
+   * #2951 — exact `__box_number` runtime callable, attached only when the
+   * stashed value is `f64`/`i32` and therefore needs boxing before the
+   * `(externref, externref)` call. Absent for already-externref values.
+   */
+  readonly boxProvider?: IrFuncRef;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ir/prepared-component-dependencies.ts
+++ b/src/ir/prepared-component-dependencies.ts
@@ -716,8 +716,21 @@ function implicitSupportRequirement(
     case "gen.push":
     case "gen.epilogue":
     case "gen.yieldStar":
-    case "gen.setReturn":
-      return `${instr.kind} resolves generator runtime callables without explicit symbolic refs`;
+      return instr.provider
+        ? null
+        : `${instr.kind} resolves generator runtime callables without explicit symbolic refs`;
+    case "gen.setReturn": {
+      if (!instr.provider) {
+        return `${instr.kind} resolves generator runtime callables without explicit symbolic refs`;
+      }
+      // The boxing helper is a second, type-dependent callable. Fail closed
+      // unless the attachment agrees with the value type lowering will see.
+      const val = valueTypes.get(instr.value);
+      const needsBoxing = val?.kind === "val" && (val.val.kind === "f64" || val.val.kind === "i32");
+      return needsBoxing === (instr.boxProvider !== undefined)
+        ? null
+        : `${instr.kind} boxing attachment disagrees with its stashed value type`;
+    }
     case "throw":
       return exceptionSupportPrepared
         ? null
@@ -1444,6 +1457,20 @@ function collectFunctionEvidence(
         nested.provider
       ) {
         recordExternalCallable(evidence, nested.provider, input.abi, ownership);
+      } else if (
+        (nested.kind === "gen.push" ||
+          nested.kind === "gen.epilogue" ||
+          nested.kind === "gen.yieldStar" ||
+          nested.kind === "gen.setReturn") &&
+        nested.provider
+      ) {
+        // #2951 — the generator runtime callables are ordinary external
+        // callables once they are symbolic. `gen.setReturn` may also pin the
+        // boxing helper for a numeric stashed value.
+        recordExternalCallable(evidence, nested.provider, input.abi, ownership);
+        if (nested.kind === "gen.setReturn" && nested.boxProvider) {
+          recordExternalCallable(evidence, nested.boxProvider, input.abi, ownership);
+        }
       } else if (nested.kind === "closure.new") {
         if (nested.liftedFunc.binding.kind === "unit") {
           recordUnitReference(

--- a/tests/issue-2951.test.ts
+++ b/tests/issue-2951.test.ts
@@ -53,12 +53,11 @@ describe("#2951 gate-2 — IR-first generator skip-set narrowing", () => {
   it("JS-host: a value-returning generator compiles+runs correctly under IR-first", async () => {
     const res = await compileWith(VALUE_RETURN_GEN, { fileName: "test.ts" }, /* irFirst */ true);
     expect(res.success).toBe(true);
-    // (#3143) The IR-first skip set is now an ALLOWLIST restricted to f64-numeric
-    // bodies, so a generator is NOT skipped — it stays COMPILE-TWICE (correct;
-    // the IR overlay still owns its body). The compile-once optimization for
-    // JS-host generators is DEFERRED to the allowlist-widening track
-    // (#2855/#2856); this test locks the CORRECTNESS that #2951 established.
-    expect(res.irFirstSkipped ?? []).not.toContain("g");
+    // (2026-08-15) The generator half of #2951 is now CLOSED: an IR-claimed
+    // JS-host generator enters the prepared/compile-once route, so the legacy
+    // body is never emitted and the owner IS listed in `irFirstSkipped`. This
+    // superseded the earlier "#3143 f64-only allowlist ⇒ compile-twice" note.
+    expect(res.irFirstSkipped ?? []).toContain("g");
     // no hard compile error and no post-claim demotion (self-sufficiency proof)
     expect((res.errors ?? []).filter((e) => e.severity === "error")).toHaveLength(0);
     expect(res.irPostClaimErrors ?? []).toHaveLength(0);
@@ -70,8 +69,9 @@ describe("#2951 gate-2 — IR-first generator skip-set narrowing", () => {
 
   it("JS-host: the terminal return value surfaces once with done:true", async () => {
     const res = await compileWith(VALUE_RETURN_GEN, { fileName: "test.ts" }, true);
-    // (#3143) compile-twice under the f64-only allowlist — correctness preserved.
-    expect(res.irFirstSkipped ?? []).not.toContain("g");
+    // Compile-once, and the shipped body is the IR body — anti-vacuity for the
+    // skip: a skipped slot with no IR body would trap instead of draining.
+    expect(res.irFirstSkipped ?? []).toContain("g");
     const got = await drain(res.binary!, res.imports, res.stringPool, (gen) => {
       gen.next();
       gen.next();
@@ -91,5 +91,81 @@ describe("#2951 gate-2 — IR-first generator skip-set narrowing", () => {
     const res = await compileWith(VALUE_RETURN_GEN, { fileName: "test.ts" }, /* irFirst */ false);
     expect(res.success).toBe(true);
     expect(res.irFirstSkipped).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2951 generator compile-once (2026-08-15) — the deviation-3 half, closed.
+// ---------------------------------------------------------------------------
+//
+// Before this slice an IR-claimed generator emitted BOTH bodies: the direct
+// emitter compiled the legacy body and the IR overlay overwrote the slot
+// afterwards. The blocker was not the skip predicate but DEPENDENCY DISCOVERY:
+// `gen.push` / `gen.epilogue` / `gen.yieldStar` / `gen.setReturn` resolved
+// their host callables by name inside the lowerer, so prepared-component
+// sealing reported `implicit-support-reference-unavailable` and peeled the
+// owner back to the direct route. `attachIrGeneratorSupport` makes those
+// callables symbolic and `observeAttachedGeneratorProviders` observes them
+// BEFORE sealing (sealing runs before lowering), after which the ordinary
+// prepared/compile-once machinery admits the generator.
+const FOROF_GEN = `export function* counter(n: number) { for (let i = 0; i < n; i++) yield i; return n; }`;
+
+describe("#2951 — IR-claimed JS-host generators compile once", () => {
+  it("emits only the IR body (legacy body skipped) and still drains correctly", async () => {
+    const res = await compileWith(FOROF_GEN, { fileName: "test.ts", trackIrOutcomes: true }, true);
+    expect(res.success).toBe(true);
+    const generatorUnit = (res.irOutcomes ?? []).find((outcome) => outcome.displayName === "counter");
+    expect(generatorUnit).toBeDefined();
+    // The regression this test exists for: `legacyBodyEmitted` used to be true.
+    expect(generatorUnit?.legacyBodyEmitted).toBe(false);
+    expect(generatorUnit?.irBodyEmitted).toBe(true);
+    expect((res.errors ?? []).filter((e) => e.severity === "error")).toHaveLength(0);
+    expect(res.irPostClaimErrors ?? []).toHaveLength(0);
+
+    // Anti-vacuity: a skipped slot without a shipped IR body traps on call.
+    const importObj = buildImports(res.imports as never, undefined, res.stringPool as never) as Record<string, unknown>;
+    const { instance } = await WebAssembly.instantiate(res.binary!, importObj as never);
+    if (typeof importObj.setExports === "function") {
+      (importObj.setExports as (e: unknown) => void)(instance.exports);
+    }
+    const exports = instance.exports as { counter: (n: number) => Iterable<number> & Iterator<number> };
+    expect([...exports.counter(5)]).toEqual([0, 1, 2, 3, 4]);
+    const gen = exports.counter(2);
+    gen.next();
+    gen.next();
+    expect(gen.next()).toMatchObject({ done: true, value: 2 });
+  });
+
+  it("standalone generators stay compile-twice (out of scope — #680 native carrier)", async () => {
+    const res = await compileWith(
+      FOROF_GEN,
+      { fileName: "test.ts", target: "standalone", trackIrOutcomes: true },
+      true,
+    );
+    expect(res.success).toBe(true);
+    const generatorUnit = (res.irOutcomes ?? []).find((outcome) => outcome.displayName === "counter");
+    expect(generatorUnit?.legacyBodyEmitted).toBe(true);
+    expect(res.irFirstSkipped ?? []).not.toContain("counter");
+  });
+
+  it("the IR-first escape hatch still runs the generator identically", async () => {
+    // The legacy generator body was pure waste: the IR overlay overwrote the
+    // slot anyway, so dropping it changes compile work, not observable
+    // behaviour. (Byte-identity of the SHIPPED module against pre-slice `main`
+    // was measured separately — see the issue's Test Results. Flag-on vs
+    // flag-off is NOT byte-comparable: `=0` disables the whole IR-first
+    // ordering, not just this skip.)
+    const withoutFlag = await compileWith(FOROF_GEN, { fileName: "test.ts" }, false);
+    expect(withoutFlag.success).toBe(true);
+    const importObj = buildImports(withoutFlag.imports as never, undefined, withoutFlag.stringPool as never) as Record<
+      string,
+      unknown
+    >;
+    const { instance } = await WebAssembly.instantiate(withoutFlag.binary!, importObj as never);
+    if (typeof importObj.setExports === "function") {
+      (importObj.setExports as (e: unknown) => void)(instance.exports);
+    }
+    const exports = instance.exports as { counter: (n: number) => Iterable<number> };
+    expect([...exports.counter(5)]).toEqual([0, 1, 2, 3, 4]);
   });
 });


### PR DESCRIPTION
Integration PR into the session branch (not main). New `src/ir/generator-support.ts` binds typed providers for the `gen.*` runtime callables before prepared-component sealing, so IR-claimed generators no longer double-compile (probe flips `legacy:true,ir:true` → `legacy:false,ir:true`). Class-member half verified already compile-once (0 double-compiled units across 8 probe programs).

Gates at head: issue-2035 11/11, issue-2951 7/7, 20 generator suites 168 pass, equivalence shards 1–8 no new regressions, test262 generator stride 640 files 0 divergences, check:ir-only READY (0 legacy bodies), check:ir-fallbacks OK, typecheck clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_