### PR TITLE
feat(#3518): standalone readiness lane + certify fully-annotated scalar ABI

### DIFF
--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -20,6 +20,19 @@ lane: ir-retirement
 model: gpt-5.6-sol
 related: [1373b, 2855, 2950, 3090, 3142, 3143, 3341, 3517, 3529, 3520, 3521, 3522, 3523, 3525, 3526, 3527, 3528, 3678, 3681, 4382]
 origin: "2026-07-21 explicit user directive: enable IR-only by default and retire the old direct codegen path"
+loc-budget-allow:
+  # +2: one import plus one call, wiring the new
+  # `src/codegen/ir-legacy-caller-abi.ts` predicate into the existing
+  # `legacyCallerAbiIsProjected` callback. All logic lives in that new module;
+  # this is the irreducible remainder, since the callback is constructed inside
+  # `planIrOverlay` and handed to the selector from there.
+  - src/codegen/index.ts
+func-budget-allow:
+  # +1: the single `hasFullyAnnotatedScalarAbi(declaration)` early-return added
+  # to the `legacyCallerAbiIsProjected` closure. That closure is built inside
+  # `planIrOverlay` because it captures `ctx`/`resolveImplicitParamType`; there
+  # is no seam that reaches the selector without passing through this function.
+  - src/codegen/index.ts::planIrOverlay
 ---
 # #3518 — IR-only default and direct front-end retirement
 
@@ -259,3 +272,219 @@ Verify-first re-audit on main @ `7652f0337` (full document:
   #1131, 12 by done issues, 3 untracked) — now tracked by new issue #3583.
 - R1 groundwork is confirmed landing on main (`4922ed58b`, `1a17b4458`);
   the R2–R8 `depends_on` frontmatter matches this epic's spine exactly.
+
+## Slice: standalone readiness lane + top blockers (fable, 2026-08-15)
+
+Live measurement on main @ `7add6938`: the `check:ir-only` gate has
+exactly ONE lane (single-host WasmGC over 5 playground entries, READY at
+37/37 IR bodies / 0 legacy). The SAME entries compiled with
+`target: "standalone"` collapse: `js/algorithms.ts` = **0 IR / 7 legacy
+bodies**, `js/classes.ts` = 10 IR / 1 legacy. The acceptance criteria
+require standalone/WASI/fast/multi-source matrices; none is measured
+today. This slice adds the standalone lane and attacks its top blockers.
+
+1. **Add a `standalone` lane to `scripts/check-ir-only.ts`**: same 5
+   entries, `target: "standalone"`, per-lane baseline in
+   `scripts/ir-only-baseline.json` per the existing #3519 schema. Baseline
+   HONESTLY at measured current truth (floors/ceilings) — the lane must
+   not be required to be READY to land; it must be required not to
+   regress.
+2. **Diagnose the algorithms.ts 0-IR collapse.** A file that is 100%
+   IR-owned on host emitting zero IR bodies standalone means a mode-gated
+   capability/seal/registration decision, not per-shape gaps — find the
+   single gate (selector capability rows, prepared-component sealing, or
+   resolver registration keyed on host mode) and record it here.
+3. **Fix the top blockers** to raise the standalone lane's IR-body floor;
+   ratchet the baseline with each fix. Known hazards: standalone number
+   boxing goes via `$AnyValue` not `__box_number` (#2955 notes),
+   standalone-floor CI guard (#1897/#2097) — net standalone test262 must
+   not go negative.
+4. **Fast-mode lane** (`fast: true`) same pattern, time permitting —
+   measure, baseline, do not block on READY.
+
+Acceptance: gate reports ≥ 2 lanes; single-host stays READY; standalone
+lane floors ≥ measured-at-landing values; `check:ir-fallbacks` no
+growth; equivalence suite + standalone probes green; `tsc --noEmit`
+clean.
+
+### Implementation Notes (fable, 2026-08-15)
+
+**Deliverable 1 — the lane landed.** `scripts/check-ir-only.ts` now observes
+two lanes. A generic `observeLane` helper backs both `observeSingleHostLane`
+(unchanged behaviour, unchanged name, still exported for the #3519 tests) and
+the new `observeStandaloneLane`, which compiles the SAME five entries with
+`target: "standalone"`.
+
+The lane carries a new `readiness: "ir-only" | "baseline"` field (absent ⇒
+`"ir-only"`, so every existing caller is untouched). Under `--policy=ir-only`
+a `"baseline"` lane withholds **exactly three** assertions — zero unsupported,
+zero legacy bodies, IR-body count equals terminal count. Everything else stays
+live for it: anti-vacuity (empty corpus / zero terminal units / zero emitted /
+duplicate keys / missing telemetry), the compile-result failures, the
+telemetry-consistency cross-checks against `irCompiledFuncs` /
+`irFirstSkipped` / `irPostClaimErrors`, the hard `invariants > 0` rule, and
+every baseline floor/ceiling. That is what keeps an honestly-red lane from
+becoming a blind spot (rule 5) rather than a lane that is merely "not checked".
+
+**Deliverable 2 — the diagnosis. It is NOT #4186.**
+
+The collapse is a **pre-claim selector rejection**, not the patch-time typeIdx
+parity demotion that #4186 owns. Every rejected `algorithms.ts` unit reports
+`stage: "select"`; there are **zero post-claim demotions** in the standalone
+lane (the `check:ir-fallbacks` post-claim bucket is empty, and the A/B below
+adds seven IR bodies with all seven landing at `stage: "patch"`). #4186's
+mechanism — lattice-typed implicit-any **object** params vs. legacy
+`lowerParamType` refusing `__anon_*` — cannot be it: `algorithms.ts` has no
+implicit-any object parameter at all; every parameter is explicitly annotated.
+Recording this explicitly because it is useful negative evidence for that lane.
+
+The single gate is the **caller-direction call-graph closure**, mode-keyed on
+host-ness in two mirrored places:
+
+- `src/ir/select.ts:950` — `const demoteOnLegacyCaller = options?.jsHostExterns !== true;`
+- `src/ir/select-identity.ts:971` — the same line on the production identity path.
+
+`jsHostExterns` is `irTargetProfile.allowHostImports`, so it is **false for
+standalone/WASI**. With it on, the Step-2 fixpoint deletes any claimed function
+that has an *unclaimed local caller*, not merely an unclaimed callee. In
+`algorithms.ts` the single unclaimed root is `main` — rejected
+`body-shape-rejected` because it drives `console.log` and string concat — and
+`main` calls **every other function in the file**. One root rejection therefore
+propagates to the whole file through the *caller* direction, which is precisely
+why a file that is 100% IR-owned on host emits zero IR bodies standalone. The
+same mechanism explains `calendar.ts` and `builtins.ts`; it is a whole-file
+amplifier, not a per-shape gap.
+
+The in-tree comment above that line (added by #2858) already predicted this and
+named `joinNums` in `algorithms.ts` under WASI as the motivating example. Its
+stated precondition for relaxing the demotion was that the offending callee
+bodies be "rejected up front by the body-shape work (#2856/#2857)" — which has
+since happened: `joinNums` is now cleanly rejected pre-claim with
+`primitive-method-unsupported`, and `fibMemo` with `body-shape-rejected`.
+
+**A/B sizing (probe, not a shipped change):** forcing
+`demoteOnLegacyCaller = false` in both files raises the standalone lane from
+**10 → 17** IR bodies (`algorithms.ts` 0 → 3) with 0 invariants, 0 post-claim
+demotions and `success: true` everywhere. That measures the blocker's full
+size. It was **not** shipped: the blanket flag also exempts families whose
+signature genuinely can diverge, which is the hazard the closure exists for.
+
+**Deliverable 3 — the fix shipped: prove the ABI instead of disabling the
+guard.** The closure already has a sanctioned escape hatch,
+`SelectionOptions.legacyCallerAbiIsProjected`, whose contract is "the direct
+callable and the IR overlay share one fully certified ABI, making a legacy
+caller's pre-emitted call safe". The pre-existing certifications only covered
+implicit/projected parameters plus one narrow reduce-fusion family. The new
+`src/codegen/ir-legacy-caller-abi.ts` adds `hasFullyAnnotatedScalarAbi`: a
+declaration qualifies when **every** parameter and the return type carry an
+explicit annotation from the fully-annotated scalar surface — `number`,
+`boolean`, one-level `number[]`/`boolean[]` params, and `number`/`boolean`/
+`void` returns.
+
+Why that is a proof and not optimism: the guard's stated hazard is *signature
+divergence* (IR replacing a legacy-allocated `typeIdx` after legacy already
+compiled the caller's body). For these annotations both front-ends read the
+same `ts.TypeNode` through the same mode-consistent mapping —
+`resolvePositionType` gives `number → f64`, `boolean → i32`, `void → no
+result`, and `T[] → irVec(...)`, which legacy `getOrRegisterVecType` interns as
+the identical `(ref_null $vec_<elem>)` struct. Body lowerability is a
+*separate* question and is still decided by the ordinary claim gates, which run
+first.
+
+Deliberately excluded, and each exclusion is load-bearing:
+
+- unannotated/implicit positions — that is the #4186 split-brain surface, and
+  this predicate must not pre-empt that lane's fix;
+- optional / rest / defaulted params — arity is part of the ABI;
+- generators and generics;
+- **string and object positions**, and non-scalar or nested array elements —
+  their carrier depends on `nativeStrings` / vec-element decisions this
+  predicate does not reproduce. This is why the shipped fix reaches 16 rather
+  than the A/B's 17: `calendar.ts::mname(m: number): string` returns a string
+  and is left uncertified on purpose.
+
+The predicate lives in its own module rather than in `src/codegen/index.ts`
+because the LOC-budget gate explicitly asks for that; the remaining +2 LOC /
++1 func-line in `index.ts` (one import, one early return) is irreducible —
+`legacyCallerAbiIsProjected` is a closure built inside `planIrOverlay` — and is
+granted in this file's `loc-budget-allow` / `func-budget-allow` frontmatter.
+
+**Standalone lane, before → after: 10 → 16 IR bodies** (`algorithms.ts` 0 → 3:
+`fibIter`, `binarySearch`, `quicksort`; `calendar.ts` 0 → 3: `dimOf`, `fdow`,
+`priceOf`). `select/call-graph-closure` fell 10 → 4. The baseline is ratcheted
+to the post-fix numbers. The single-host lane is unaffected (still 37/37,
+READY) — `jsHostExterns` is true there, so `demoteOnLegacyCaller` is false and
+the new predicate is never consulted.
+
+**Descoped, with reasons:**
+
+- **Fast-mode lane (plan item 4)** — not added. Adding a third lane is
+  mechanical now that `observeLane` is generic, but it needs its own honest
+  measurement pass and its own blocker triage, and the budget went to the
+  standalone blocker instead. Deliberately left rather than added unmeasured.
+- **The remaining 21 standalone unsupported units** are genuine per-shape gaps,
+  not this gate: 11 `body-shape-rejected` (`main`/`renderCal`/`el`/`fibMemo` —
+  console/DOM/`Map` bodies), 4 `async-function`, 4 residual
+  `call-graph-closure`, 1 `date-constructor-unsupported`, 1
+  `primitive-method-unsupported` (`joinNums`, f64 `.toString()`). Each needs
+  real standalone lowering; none is a mode-gating bug.
+- **String-return certification** (`mname`) — the one A/B-proven remaining unit
+  reachable via this gate. It needs a `nativeStrings`-aware carrier proof that
+  belongs with the string-ABI work, not here.
+- **The `legacyBodyEmitted` ceiling stays at 27.** The six newly-IR units are
+  IR-**emitted** (the overlay patches a legacy-created slot), not
+  **compile-once** — they still emit a legacy body first. Per this epic's own
+  Terms that is a real but lesser tier, and the baseline records it honestly
+  rather than implying compile-once ownership the lane does not have.
+
+### Test Results (fable, 2026-08-15)
+
+Measured in worktree `agent-a560da37ac458f0fa` on main @ `7add6938`.
+
+| Gate                                                | Result                                                                                                                                                                                                          |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm run typecheck` (ts7, the CI gate)              | **clean**                                                                                                                                                                                                       |
+| `npx tsc --noEmit` (legacy tsc)                     | environmental failure only — `@types/node` is unresolvable through this worktree's symlinked `node_modules`; every error is `Cannot find name 'process'/'require'/'__filename'` in files this change never touches |
+| `pnpm run check:ir-only`                            | **2 lanes reported**; single-host 37/37 IR, 0 legacy, **READY**; standalone 16 IR / 27 legacy / 21 unsupported / 0 invariants, ratcheted; verdict **READY**                                                    |
+| `pnpm run check:ir-fallbacks`                       | **OK** — unintended (none), post-claim demotions (none), module-level (none)                                                                                                                                    |
+| `npm run check:loc-budget`                          | OK — +2 in `src/codegen/index.ts`, granted by this file                                                                                                                                                         |
+| `npm run check:func-budget`                         | OK — +1 in `planIrOverlay`, granted by this file                                                                                                                                                                |
+| `npm run check:oracle-ratchet`                      | OK — `getTypeAtLocation +0`, `ctx.checker +0` (the new module makes no checker call)                                                                                                                            |
+| `biome lint` (changed files)                        | clean                                                                                                                                                                                                           |
+| `tests/issue-3519-ir-only-gate.test.ts`             | **14/14 pass**, including 5 new per-lane-readiness tests                                                                                                                                                        |
+| `scripts/equivalence-gate.mjs`, shards **1–8 of 8** | **no new equivalence regressions** in any shard                                                                                                                                                                 |
+
+Standalone runtime probes (`.tmp/`, gitignored):
+
+- `algorithms.ts` compiles standalone, and the binary **instantiates and
+  `main()` runs without trapping**.
+- A dedicated fixture exercising the three certified shapes (`fibIter`,
+  `binarySearch`, `quicksort`, plus a `boolean`-returning `isEven`) reached
+  from an intentionally **unclaimed** caller returns `55414`, matching the
+  hand-computed JS expectation — and returns the **identical** value on
+  unmodified main. The change moves work from the direct path to IR without
+  changing observable behaviour.
+
+**Every test failure encountered was A/B'd against unmodified `main` and is
+pre-existing.** Nothing in this change set regressed any of them:
+
+- `tests/es5-standalone*` (26 files): 5 failures — harness self-tests ×3,
+  descriptor bags, array-semantics dynamic HOF lane. Identical on baseline.
+- `issue-1712-standalone` (the acorn case #4186 documents as red on main),
+  `issue-3436-standalone-prelude-leak`, `issue-3673-standalone-gaps`,
+  `issue-4034-standalone-prelude-size`: 4 failures. Identical on baseline.
+- `issue-3520-ir-unit-identity`, `issue-3522-ir-class-compile-once` (×2,
+  including its standalone-lane case),
+  `issue-3522-ir-cross-owner-free-function`: 4 failures. Identical on baseline.
+- `issue-1654-wasi-dataview-arraybuffer`: 3 failures. Identical on baseline.
+
+The equivalence shards additionally reported **7 baseline failures that now
+PASS** (`coercion-arithmetic-add` ×3, `math-pow-test262-pattern`,
+`issue-1197`, `symbol-basic` ×2). These are **not** attributable to this
+change: `math-pow-test262-pattern`, `coercion-arithmetic-add` and `issue-1197`
+were each re-run on unmodified `main` and pass there too. The equivalence
+baseline is simply stale; ratcheting it is out of scope here.
+
+Full test262 was **not** run (per instruction). The standalone-floor / net
+guards (#1897/#2097) run in the `merge_group` and remain the authoritative
+check on this change's standalone conformance effect.

--- a/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
+++ b/plan/issues/3518-ir-only-default-and-direct-frontend-retirement.md
@@ -140,19 +140,19 @@ child issues; R9–R10 receive child issue IDs before dispatch. This epic owns
 their order and acceptance boundaries.
 
 | Slice                        | Outcome                                                                                               | Depends on                            | Exit evidence                                                                                                                                                   |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **R0a — #3529 (done)**       | Restore typed-producer equivalence parity without weakening unknown-throw-to-Invariant classification | #3143; exposed by #3519               | 154 new compile failures return to the committed baseline through preclaim/typed Unsupported or true invariant fixes; no baseline expansion                     |
 | **R0b — #3519 (done)**       | Typed `Prepared` / `Unsupported` / `Invariant` outcomes plus an honest `check:ir-only` readiness gate | #3143, #3529; informed by #2855/#3341 | No TypeMap or compile failures are skipped; `result.errors` and every unit outcome are accounted for; hybrid vs IR-only policy is tested                        |
 | **R1 — #3520 (in progress)** | Source-qualified `IrUnitId` and a whole-program `ProgramAbiMap`                                       | R0                                    | Same-named units across files/classes cannot collide; signatures, globals, imports, types, exports, and synthetic units are planned once                        |
 | **R2 — #3521 (in progress)** | `PreparedIrProgram` and prepare-before-emit compile-once pipeline                                     | #3520                                 | Prepared free functions never call legacy body compilation; the versioned validated program round-trips losslessly; unsupported units are decided before emission |
 | **R3 — #3522 (in progress)** | Classes and class members are Prepared/compile-once                                                   | #3521                                 | Constructors, instance/static methods, fields, inheritance, wrappers, and type indices no longer depend on legacy body compilation                              |
 | **R4 — #3523 (in progress)** | Module init is Prepared/compile-once                                                                  | #3521, #3522                          | One program-owned module-init unit replaces the compile-first/patch-later `__module_init` overlay, including top-level binding/TDZ/export effects               |
-| **R5 — #3525 (blocked)**     | Whole-program single- and multi-source Prepared ownership                                             | #3520–#3523                           | Cross-file calls/imports, fast mode, collisions, module init, and class members use one `PreparedIrProgram`; no per-source overlay loop remains                 |
+| **R5 — #3525 (blocked)**     | Whole-program single- and multi-source Prepared ownership                                             | #3520–#3523                          | Cross-file calls/imports, fast mode, collisions, module init, and class members use one `PreparedIrProgram`; no per-source overlay loop remains                 |
 | **R6 — #3526 (blocked)**     | Typed semantic intrinsic/runtime-feature/host-capability contract                                     | #3521                                 | The ~47K runtime/builtin emission lines are reached from a frozen semantic manifest, never AST dispatch; families land in measured sub-slices                   |
 | **R7 — #3527 (blocked)**     | AST-free async suspension plans and canonical Promise ABI                                             | #3522, #3525, #3526                   | Every supported async container uses one verified `IrAsyncPlan` and the existing frame engine; no AST callback/direct async route remains                       |
-| **R8 — #3528 (blocked)**     | Linear consumes the shared Prepared program                                                           | #3525–#3527                           | WasmGC and linear receive the exact same program/ABI/runtime/async plans; `src/codegen-linear/` has no source-AST lowering path                                 |
-| **R9**                       | Fail-closed IR-only default; remove escape hatches                                                    | R3–R8; #2949, #2952, #1373b, #3583    | Default policy is IR-only; hybrid demotion, `experimentalIR: false`, `JS2WASM_IR_FIRST`, `disableIrFirst`, skip allowlists, and compile-twice switches are gone |
-| **R10**                      | Reachability-proven direct-front-end deletion                                                         | R9                                    | Re-run #3090 audit; delete the ~59,676 frontend-only fn-lines and dispatch roots; zero direct AST→Wasm reachability remains                                     |
+| **R8 — #3528 (blocked)**     | Linear consumes the shared Prepared program                                                           | #3525–#3527                          | WasmGC and linear receive the exact same program/ABI/runtime/async plans; `src/codegen-linear/` has no source-AST lowering path                                 |
+| **R9**                       | Fail-closed IR-only default; remove escape hatches                                                    | R3–R8; #2949, #2952, #1373b, #3583   | Default policy is IR-only; hybrid demotion, `experimentalIR: false`, `JS2WASM_IR_FIRST`, `disableIrFirst`, skip allowlists, and compile-twice switches are gone |
+| **R10**                      | Reachability-proven direct-front-end deletion                                                         | R9                                    | Re-run #3090 audit; delete the ~59,676 frontend-only fn-lines and dispatch roots; zero direct AST→Wasm reachability remains                                    |
 
 R0a and R0b completed on 2026-07-21. R1 remains active while R2 production
 preparation and the first R3 static-method transaction are now in progress.
@@ -243,71 +243,7 @@ above.
   through legacy dispatch. R6 must first provide IR-owned semantic entry points.
 - Adding new language behavior to the direct front-end during migration.
 
-## Review (Fable, 2026-07-24)
-
-Verify-first re-audit on main @ `7652f0337` (full document:
-`plan/agent-context/fable-ir-review-2026-07-24.md`).
-
-- **The "Current truth" table still holds.** Re-ran `check:ir-fallbacks`
-  (all unintended buckets 0; module-level 0) and `check:ir-only` (5/5
-  entries, 37 units, 31 IR-emitted, 6 typed Unsupported, 0 Invariants,
-  37/37 legacy bodies, NOT READY) — identical to the 2026-07-21 audit.
-  Adoption matrix: 18 ir-owned confirmed; denominator is now 58 kind rows
-  (prose says 56). Compile-once ceiling and fn-line reachability were not
-  re-measured; no allowlist-widening landed since 2026-07-21, so ≈28.1%
-  plausibly holds.
-- **Ladder gap — R9 needs an explicit coverage-closure dependency.** R9
-  depends on R3–R8 only, but a fail-closed flip with `SwitchStatement` /
-  `LabeledStatement` / `ForInStatement` still direct-only (#2952 `ready`,
-  unstarted) and `%`/`**`/`in`/`instanceof` unlowered would hard-fail
-  ordinary core-JS programs. The acceptance gate only catches this if the
-  authoritative matrices contain such syntax — the playground corpus barely
-  does. Recommend: (a) add "#2952 + #2949 + #1373b + #3583 coverage closure"
-  to R9's Depends-on cell, and (b) grow the `check:ir-only` corpus beyond
-  the playground before R9 readiness is claimed.
-- **#2952 can and should start now** — its structural work (br_table +
-  labeled nested-buffer exits) depends on neither R1 nor R2 and is the
-  longest-lead item on the R9 critical path.
-- **28 adoption-matrix rows had no live owner** (13 tracked by wont-fix
-  #1131, 12 by done issues, 3 untracked) — now tracked by new issue #3583.
-- R1 groundwork is confirmed landing on main (`4922ed58b`, `1a17b4458`);
-  the R2–R8 `depends_on` frontmatter matches this epic's spine exactly.
-
-## Slice: standalone readiness lane + top blockers (fable, 2026-08-15)
-
-Live measurement on main @ `7add6938`: the `check:ir-only` gate has
-exactly ONE lane (single-host WasmGC over 5 playground entries, READY at
-37/37 IR bodies / 0 legacy). The SAME entries compiled with
-`target: "standalone"` collapse: `js/algorithms.ts` = **0 IR / 7 legacy
-bodies**, `js/classes.ts` = 10 IR / 1 legacy. The acceptance criteria
-require standalone/WASI/fast/multi-source matrices; none is measured
-today. This slice adds the standalone lane and attacks its top blockers.
-
-1. **Add a `standalone` lane to `scripts/check-ir-only.ts`**: same 5
-   entries, `target: "standalone"`, per-lane baseline in
-   `scripts/ir-only-baseline.json` per the existing #3519 schema. Baseline
-   HONESTLY at measured current truth (floors/ceilings) — the lane must
-   not be required to be READY to land; it must be required not to
-   regress.
-2. **Diagnose the algorithms.ts 0-IR collapse.** A file that is 100%
-   IR-owned on host emitting zero IR bodies standalone means a mode-gated
-   capability/seal/registration decision, not per-shape gaps — find the
-   single gate (selector capability rows, prepared-component sealing, or
-   resolver registration keyed on host mode) and record it here.
-3. **Fix the top blockers** to raise the standalone lane's IR-body floor;
-   ratchet the baseline with each fix. Known hazards: standalone number
-   boxing goes via `$AnyValue` not `__box_number` (#2955 notes),
-   standalone-floor CI guard (#1897/#2097) — net standalone test262 must
-   not go negative.
-4. **Fast-mode lane** (`fast: true`) same pattern, time permitting —
-   measure, baseline, do not block on READY.
-
-Acceptance: gate reports ≥ 2 lanes; single-host stays READY; standalone
-lane floors ≥ measured-at-landing values; `check:ir-fallbacks` no
-growth; equivalence suite + standalone probes green; `tsc --noEmit`
-clean.
-
-### Implementation Notes (fable, 2026-08-15)
+## Standalone-lane Implementation Notes (fable, 2026-08-15)
 
 **Deliverable 1 — the lane landed.** `scripts/check-ir-only.ts` now observes
 two lanes. A generic `observeLane` helper backs both `observeSingleHostLane`
@@ -437,12 +373,12 @@ the new predicate is never consulted.
   Terms that is a real but lesser tier, and the baseline records it honestly
   rather than implying compile-once ownership the lane does not have.
 
-### Test Results (fable, 2026-08-15)
+## Standalone-lane Test Results (fable, 2026-08-15)
 
 Measured in worktree `agent-a560da37ac458f0fa` on main @ `7add6938`.
 
 | Gate                                                | Result                                                                                                                                                                                                          |
-| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `npm run typecheck` (ts7, the CI gate)              | **clean**                                                                                                                                                                                                       |
 | `npx tsc --noEmit` (legacy tsc)                     | environmental failure only — `@types/node` is unresolvable through this worktree's symlinked `node_modules`; every error is `Cannot find name 'process'/'require'/'__filename'` in files this change never touches |
 | `pnpm run check:ir-only`                            | **2 lanes reported**; single-host 37/37 IR, 0 legacy, **READY**; standalone 16 IR / 27 legacy / 21 unsupported / 0 invariants, ratcheted; verdict **READY**                                                    |
@@ -488,3 +424,67 @@ baseline is simply stale; ratcheting it is out of scope here.
 Full test262 was **not** run (per instruction). The standalone-floor / net
 guards (#1897/#2097) run in the `merge_group` and remain the authoritative
 check on this change's standalone conformance effect.
+
+## Review (Fable, 2026-07-24)
+
+Verify-first re-audit on main @ `7652f0337` (full document:
+`plan/agent-context/fable-ir-review-2026-07-24.md`).
+
+- **The "Current truth" table still holds.** Re-ran `check:ir-fallbacks`
+  (all unintended buckets 0; module-level 0) and `check:ir-only` (5/5
+  entries, 37 units, 31 IR-emitted, 6 typed Unsupported, 0 Invariants,
+  37/37 legacy bodies, NOT READY) — identical to the 2026-07-21 audit.
+  Adoption matrix: 18 ir-owned confirmed; denominator is now 58 kind rows
+  (prose says 56). Compile-once ceiling and fn-line reachability were not
+  re-measured; no allowlist-widening landed since 2026-07-21, so ≈28.1%
+  plausibly holds.
+- **Ladder gap — R9 needs an explicit coverage-closure dependency.** R9
+  depends on R3–R8 only, but a fail-closed flip with `SwitchStatement` /
+  `LabeledStatement` / `ForInStatement` still direct-only (#2952 `ready`,
+  unstarted) and `%`/`**`/`in`/`instanceof` unlowered would hard-fail
+  ordinary core-JS programs. The acceptance gate only catches this if the
+  authoritative matrices contain such syntax — the playground corpus barely
+  does. Recommend: (a) add "#2952 + #2949 + #1373b + #3583 coverage closure"
+  to R9's Depends-on cell, and (b) grow the `check:ir-only` corpus beyond
+  the playground before R9 readiness is claimed.
+- **#2952 can and should start now** — its structural work (br_table +
+  labeled nested-buffer exits) depends on neither R1 nor R2 and is the
+  longest-lead item on the R9 critical path.
+- **28 adoption-matrix rows had no live owner** (13 tracked by wont-fix
+  #1131, 12 by done issues, 3 untracked) — now tracked by new issue #3583.
+- R1 groundwork is confirmed landing on main (`4922ed58b`, `1a17b4458`);
+  the R2–R8 `depends_on` frontmatter matches this epic's spine exactly.
+
+## Slice: standalone readiness lane + top blockers (fable, 2026-08-15)
+
+Live measurement on main @ `7add6938`: the `check:ir-only` gate has
+exactly ONE lane (single-host WasmGC over 5 playground entries, READY at
+37/37 IR bodies / 0 legacy). The SAME entries compiled with
+`target: "standalone"` collapse: `js/algorithms.ts` = **0 IR / 7 legacy
+bodies**, `js/classes.ts` = 10 IR / 1 legacy. The acceptance criteria
+require standalone/WASI/fast/multi-source matrices; none is measured
+today. This slice adds the standalone lane and attacks its top blockers.
+
+1. **Add a `standalone` lane to `scripts/check-ir-only.ts`**: same 5
+   entries, `target: "standalone"`, per-lane baseline in
+   `scripts/ir-only-baseline.json` per the existing #3519 schema. Baseline
+   HONESTLY at measured current truth (floors/ceilings) — the lane must
+   not be required to be READY to land; it must be required not to
+   regress.
+2. **Diagnose the algorithms.ts 0-IR collapse.** A file that is 100%
+   IR-owned on host emitting zero IR bodies standalone means a mode-gated
+   capability/seal/registration decision, not per-shape gaps — find the
+   single gate (selector capability rows, prepared-component sealing, or
+   resolver registration keyed on host mode) and record it here.
+3. **Fix the top blockers** to raise the standalone lane's IR-body floor;
+   ratchet the baseline with each fix. Known hazards: standalone number
+   boxing goes via `$AnyValue` not `__box_number` (#2955 notes),
+   standalone-floor CI guard (#1897/#2097) — net standalone test262 must
+   not go negative.
+4. **Fast-mode lane** (`fast: true`) same pattern, time permitting —
+   measure, baseline, do not block on READY.
+
+Acceptance: gate reports ≥ 2 lanes; single-host stays READY; standalone
+lane floors ≥ measured-at-landing values; `check:ir-fallbacks` no
+growth; equivalence suite + standalone probes green; `tsc --noEmit`
+clean.

--- a/scripts/check-ir-only.ts
+++ b/scripts/check-ir-only.ts
@@ -18,6 +18,17 @@ export const SINGLE_HOST_ENTRIES = [
   "website/playground/examples/js/classes.ts",
 ] as const;
 
+/**
+ * #3518 standalone lane — the SAME five terminals compiled with
+ * `target: "standalone"` (no JS host imports). This lane is deliberately NOT
+ * required to reach IR-only readiness: standalone IR coverage is still partial,
+ * so the lane is a **regression ratchet** over honestly measured floors, per
+ * the epic's rule 5 ("no corpus-zero shortcuts"). Its readiness mode is
+ * `"baseline"`, which keeps `--policy=ir-only` from asserting compile-once on a
+ * population that provably is not there yet.
+ */
+export const STANDALONE_ENTRIES = SINGLE_HOST_ENTRIES;
+
 export type IrOnlyEntryFailureCode = "compile-threw" | "compile-failed" | "fatal-diagnostic" | "missing-telemetry";
 
 export interface IrOnlyEntryFailure {
@@ -36,10 +47,24 @@ export interface IrOnlyEntryObservation {
   readonly failures: readonly IrOnlyEntryFailure[];
 }
 
+/**
+ * How a lane participates in the `--policy=ir-only` verdict.
+ *
+ * - `"ir-only"` (default): the lane must be compile-once — zero unsupported
+ *   units, zero legacy bodies, one IR body per terminal.
+ * - `"baseline"`: the lane is measured and ratcheted against its committed
+ *   floors/ceilings, but is not asserted to be IR-only. Every anti-vacuity,
+ *   telemetry-consistency, invariant, and baseline check still applies; only
+ *   the compile-once assertions are withheld.
+ */
+export type IrOnlyLaneReadiness = "ir-only" | "baseline";
+
 export interface IrOnlyLaneObservation {
   readonly name: string;
   readonly expectedEntries: number;
   readonly entries: readonly IrOnlyEntryObservation[];
+  /** Defaults to `"ir-only"` when absent. */
+  readonly readiness?: IrOnlyLaneReadiness;
 }
 
 export interface IrOnlyBaselineLane {
@@ -61,6 +86,7 @@ export interface IrOnlyBaseline {
 
 export interface IrOnlyLaneSummary {
   readonly name: string;
+  readonly readiness: IrOnlyLaneReadiness;
   readonly entries: number;
   readonly expectedEntries: number;
   readonly terminalUnits: number;
@@ -87,9 +113,15 @@ export type CompileSeedEntry = (source: string, entry: string) => Promise<Compil
 const defaultCompileSeedEntry: CompileSeedEntry = (source, entry) =>
   compile(source, { fileName: entry, trackIrOutcomes: true });
 
-export async function observeSingleHostLane(
-  entries: readonly string[] = SINGLE_HOST_ENTRIES,
-  compileEntry: CompileSeedEntry = defaultCompileSeedEntry,
+const standaloneCompileSeedEntry: CompileSeedEntry = (source, entry) =>
+  compile(source, { fileName: entry, trackIrOutcomes: true, target: "standalone" });
+
+async function observeLane(
+  name: string,
+  entries: readonly string[],
+  compileEntry: CompileSeedEntry,
+  readiness: IrOnlyLaneReadiness,
+  expectedEntries: number,
 ): Promise<IrOnlyLaneObservation> {
   const observations: IrOnlyEntryObservation[] = [];
   for (const entry of entries) {
@@ -132,7 +164,21 @@ export async function observeSingleHostLane(
       failures,
     });
   }
-  return { name: "single-host", expectedEntries: SINGLE_HOST_ENTRIES.length, entries: observations };
+  return { name, expectedEntries, entries: observations, readiness };
+}
+
+export async function observeSingleHostLane(
+  entries: readonly string[] = SINGLE_HOST_ENTRIES,
+  compileEntry: CompileSeedEntry = defaultCompileSeedEntry,
+): Promise<IrOnlyLaneObservation> {
+  return observeLane("single-host", entries, compileEntry, "ir-only", SINGLE_HOST_ENTRIES.length);
+}
+
+export async function observeStandaloneLane(
+  entries: readonly string[] = STANDALONE_ENTRIES,
+  compileEntry: CompileSeedEntry = standaloneCompileSeedEntry,
+): Promise<IrOnlyLaneObservation> {
+  return observeLane("standalone", entries, compileEntry, "baseline", STANDALONE_ENTRIES.length);
 }
 
 function bump(target: Record<string, number>, key: string): void {
@@ -168,6 +214,7 @@ function summarizeLane(lane: IrOnlyLaneObservation): IrOnlyLaneSummary {
   }
   return {
     name: lane.name,
+    readiness: lane.readiness ?? "ir-only",
     entries: lane.entries.length,
     expectedEntries: lane.expectedEntries,
     terminalUnits: allOutcomes.length,
@@ -314,7 +361,11 @@ export function evaluateIrOnlyReport(
       }
     }
 
-    if (policy === "ir-only") {
+    // A `"baseline"` lane is measured and ratcheted but never asserted to be
+    // compile-once. Withholding only these three assertions keeps every
+    // anti-vacuity/telemetry/baseline check above live for the lane, so an
+    // honestly-red lane cannot become a blind spot (#3518 rule 5).
+    if (policy === "ir-only" && summary.readiness === "ir-only") {
       if (summary.unsupported > 0) failures.push(`${lane.name}: ${summary.unsupported} unsupported unit(s)`);
       if (summary.legacyBodyEmitted > 0) {
         failures.push(`${lane.name}: ${summary.legacyBodyEmitted} unit(s) still emitted a legacy body`);
@@ -363,7 +414,7 @@ function loadBaseline(): IrOnlyBaseline {
 
 function printHuman(verdict: IrOnlyGateVerdict): void {
   for (const lane of verdict.lanes) {
-    process.stdout.write(`\nIR-only readiness lane: ${lane.name}\n`);
+    process.stdout.write(`\nIR-only readiness lane: ${lane.name} (${lane.readiness})\n`);
     process.stdout.write(`  entries             ${lane.entries}/${lane.expectedEntries}\n`);
     process.stdout.write(`  terminal units      ${lane.terminalUnits}\n`);
     process.stdout.write(`  emitted             ${lane.emitted}\n`);
@@ -392,7 +443,7 @@ async function main(): Promise<void> {
   const update = args.includes("--update");
   if (update && policy !== "hybrid") throw new Error("--update requires --policy=hybrid");
 
-  const lanes = [await observeSingleHostLane()];
+  const lanes = [await observeSingleHostLane(), await observeStandaloneLane()];
   const activeBaseline = update ? baselineFrom(lanes) : loadBaseline();
   const verdict = evaluateIrOnlyReport(lanes, activeBaseline, policy);
   if (update && verdict.ready) {

--- a/scripts/ir-only-baseline.json
+++ b/scripts/ir-only-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generated": "2026-08-09",
+  "generated": "2026-08-15",
   "lanes": {
     "single-host": {
       "entryFloor": 5,
@@ -10,6 +10,22 @@
       "legacyBodyEmittedCeiling": 10,
       "unsupportedCeiling": 0,
       "unsupportedByCode": {},
+      "invariantCeiling": 0
+    },
+    "standalone": {
+      "entryFloor": 5,
+      "terminalUnitFloor": 37,
+      "emittedFloor": 16,
+      "irBodyEmittedFloor": 16,
+      "legacyBodyEmittedCeiling": 27,
+      "unsupportedCeiling": 21,
+      "unsupportedByCode": {
+        "select/body-shape-rejected": 11,
+        "select/call-graph-closure": 4,
+        "select/date-constructor-unsupported": 1,
+        "select/primitive-method-unsupported": 1,
+        "select/async-function": 4
+      },
       "invariantCeiling": 0
     }
   }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -133,6 +133,7 @@ import { emitDataStructHostBridgeManifest } from "./data-struct-host-bridge.js";
 import { planProgramAbiFunctionValue, planProgramAbiGlobal, PROGRAM_ABI_GLOBAL_ROLE } from "./program-abi-planning.js";
 import { collectLocalCallEdgesByIdentity } from "./ir-first-gate.js";
 import { planIrImportedCalls, recordIrOverlayPreparationFailure } from "./ir-imported-call-planning.js";
+import { hasFullyAnnotatedScalarAbi } from "./ir-legacy-caller-abi.js";
 import {
   canPrepareHostDateSnapshotLoweringByIdentity,
   closeIrBlockedComponentByIdentity,
@@ -2446,6 +2447,7 @@ function planIrOverlay(
     return ctx.typeIdxToStructName.get(valueType.typeIdx) === "__vec_f64";
   };
   const legacyCallerAbiIsProjected = (declaration: ts.FunctionDeclaration): boolean => {
+    if (hasFullyAnnotatedScalarAbi(declaration)) return true;
     const onlyStatement = declaration.body?.statements.length === 1 ? declaration.body.statements[0] : undefined;
     const returned = onlyStatement && ts.isReturnStatement(onlyStatement) ? onlyStatement.expression : undefined;
     if (

--- a/src/codegen/ir-legacy-caller-abi.ts
+++ b/src/codegen/ir-legacy-caller-abi.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3518 (standalone lane) — exact direct/IR signature certification used by the
+ * standalone/WASI caller-direction call-graph closure in `src/ir/select.ts`.
+ *
+ * Outside JS-host mode the selector demotes any claimed function that has an
+ * unclaimed LOCAL caller, because the IR overlay may replace the function's
+ * legacy-allocated `typeIdx` after legacy already compiled that caller's body —
+ * a cross-signature `call`. `planIrOverlay` may exempt a callee when it can
+ * prove the two front-ends derive the SAME signature; this module owns one such
+ * proof.
+ */
+import { ts } from "../ts-api.js";
+
+import { effectiveIrParamTypeNode, effectiveIrReturnTypeNode } from "../ir/select.js";
+
+function isScalarAbiKeyword(kind: ts.SyntaxKind): boolean {
+  return kind === ts.SyntaxKind.NumberKeyword || kind === ts.SyntaxKind.BooleanKeyword;
+}
+
+/**
+ * Is this declaration's wasm signature identical in the direct and IR
+ * front-ends *by construction*?
+ *
+ * True when every parameter and the return type carry an explicit annotation
+ * drawn from the fully-annotated scalar surface. Both front-ends then resolve
+ * the same `ts.TypeNode` through the same mode-consistent mapping — number →
+ * f64, boolean → i32, void → no result, and `T[]` → the interned
+ * `(ref_null $vec_<elem>)` struct that `resolvePositionType` and legacy
+ * `getOrRegisterVecType` agree on. Signature divergence, NOT body lowerability,
+ * is what the caller-direction closure guards against, so certifying this
+ * family is a proof rather than an optimism.
+ *
+ * Deliberately excluded:
+ * - unannotated / implicit positions — the implicit-param resolver owns those,
+ *   and they are the #4186 signature split-brain surface (lattice shape structs
+ *   vs. legacy `lowerParamType`), which this predicate must not pre-empt;
+ * - optional / rest / defaulted parameters — arity is part of the ABI;
+ * - generators and generics;
+ * - string and object positions, plus non-scalar or nested array elements —
+ *   their carrier depends on `nativeStrings` / vec-element decisions this
+ *   predicate does not reproduce.
+ */
+export function hasFullyAnnotatedScalarAbi(declaration: ts.FunctionDeclaration): boolean {
+  if (declaration.typeParameters && declaration.typeParameters.length > 0) return false;
+  if (declaration.asteriskToken) return false;
+  for (const parameter of declaration.parameters) {
+    if (parameter.dotDotDotToken || parameter.questionToken || parameter.initializer) return false;
+    const explicitType = effectiveIrParamTypeNode(parameter);
+    if (!explicitType) return false;
+    const isScalarArray = ts.isArrayTypeNode(explicitType) && isScalarAbiKeyword(explicitType.elementType.kind);
+    if (!isScalarAbiKeyword(explicitType.kind) && !isScalarArray) return false;
+  }
+  const returnType = effectiveIrReturnTypeNode(declaration);
+  if (!returnType) return false;
+  return isScalarAbiKeyword(returnType.kind) || returnType.kind === ts.SyntaxKind.VoidKeyword;
+}

--- a/tests/issue-3519-ir-only-gate.test.ts
+++ b/tests/issue-3519-ir-only-gate.test.ts
@@ -318,4 +318,105 @@ describe("#3519 honest IR-only gate", () => {
       ]),
     );
   });
+
+  // #3518 — the standalone lane is measured but not asserted to be compile-once.
+  describe("per-lane readiness (#3518 standalone lane)", () => {
+    const twoLaneBaseline = (standalone: Partial<IrOnlyBaseline["lanes"][string]> = {}): IrOnlyBaseline => ({
+      ...baseline(),
+      lanes: {
+        ...baseline().lanes,
+        standalone: {
+          entryFloor: 1,
+          terminalUnitFloor: 2,
+          emittedFloor: 1,
+          irBodyEmittedFloor: 1,
+          legacyBodyEmittedCeiling: 2,
+          unsupportedCeiling: 1,
+          unsupportedByCode: { "select/async-function": 1 },
+          invariantCeiling: 0,
+          ...standalone,
+        },
+      },
+    });
+    const baselineLane = (entries: readonly IrOnlyEntryObservation[]): IrOnlyLaneObservation => ({
+      name: "standalone",
+      expectedEntries: entries.length,
+      entries,
+      readiness: "baseline",
+    });
+    const mixed = () => entry([emitted("kept", true), unsupported("deferred")]);
+
+    it("does not fail --policy=ir-only for a lane whose readiness is 'baseline'", () => {
+      const verdict = evaluateIrOnlyReport(
+        [lane([entry([emitted("a")])]), baselineLane([mixed()])],
+        twoLaneBaseline(),
+        "ir-only",
+      );
+      expect(verdict.failures).toEqual([]);
+      expect(verdict.ready).toBe(true);
+      expect(verdict.lanes.find((l) => l.name === "standalone")?.readiness).toBe("baseline");
+      // The default (absent field) stays strict, so existing lanes are unchanged.
+      expect(verdict.lanes.find((l) => l.name === "single-host")?.readiness).toBe("ir-only");
+    });
+
+    it("still fails --policy=ir-only when the SAME population sits in a strict lane", () => {
+      const strict: IrOnlyLaneObservation = { ...baselineLane([mixed()]), readiness: "ir-only" };
+      const verdict = evaluateIrOnlyReport([lane([entry([emitted("a")])]), strict], twoLaneBaseline(), "ir-only");
+      expect(verdict.ready).toBe(false);
+      expect(verdict.failures).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("standalone: 1 unsupported unit(s)"),
+          expect.stringContaining("standalone: 2 unit(s) still emitted a legacy body"),
+        ]),
+      );
+    });
+
+    it("ratchets a 'baseline' lane against its floors and per-code ceilings", () => {
+      const regressed = evaluateIrOnlyReport(
+        [lane([entry([emitted("a")])]), baselineLane([mixed()])],
+        twoLaneBaseline({ irBodyEmittedFloor: 2, emittedFloor: 2 }),
+        "ir-only",
+      );
+      expect(regressed.ready).toBe(false);
+      expect(regressed.failures).toEqual(
+        expect.arrayContaining([expect.stringContaining("IR-body-emitted floor regressed 1 < 2")]),
+      );
+
+      const grown = evaluateIrOnlyReport(
+        [lane([entry([emitted("a")])]), baselineLane([mixed()])],
+        twoLaneBaseline({ unsupportedByCode: {} }),
+        "ir-only",
+      );
+      expect(grown.failures).toEqual(
+        expect.arrayContaining([expect.stringContaining("unsupported select/async-function grew 1 > 0")]),
+      );
+    });
+
+    it("keeps anti-vacuity and invariant checks live on a 'baseline' lane", () => {
+      const vacuous = evaluateIrOnlyReport(
+        [lane([entry([emitted("a")])]), baselineLane([entry([])])],
+        twoLaneBaseline(),
+        "ir-only",
+      );
+      expect(vacuous.ready).toBe(false);
+      expect(vacuous.failures).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("standalone: zero emitted units"),
+          expect.stringContaining("missing terminal telemetry"),
+        ]),
+      );
+    });
+
+    it("regenerates a committed baseline for every lane, keyed by name", () => {
+      const regenerated = baselineFrom([lane([entry([emitted("a")])]), baselineLane([mixed()])]);
+      expect(Object.keys(regenerated.lanes).sort()).toEqual(["single-host", "standalone"]);
+      expect(regenerated.lanes.standalone).toMatchObject({
+        emittedFloor: 1,
+        irBodyEmittedFloor: 1,
+        legacyBodyEmittedCeiling: 2,
+        unsupportedCeiling: 1,
+        unsupportedByCode: { "select/async-function": 1 },
+      });
+    });
+  });
 });


### PR DESCRIPTION
Integration PR into the session branch (not main). Adds a `standalone` lane to `check:ir-only` (honest per-lane baseline). Root cause of the algorithms.ts 0-IR standalone collapse: the caller-direction call-graph closure keyed on `jsHostExterns` at `select.ts:950` (NOT #4186). Fix: `hasFullyAnnotatedScalarAbi` certification feeding the existing `legacyCallerAbiIsProjected` escape hatch — standalone lane 10→16 IR bodies, algorithms.ts 0→3.

Gates at head: typecheck (ts7) clean, check:ir-only 2 lanes (single-host READY, standalone baselined), check:ir-fallbacks OK, issue-3519 gate tests 14/14, equivalence shards 1–8 no new regressions; all observed failures A/B-verified pre-existing on unmodified main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_