### PR TITLE
feat(codegen): per-function meta — name as an own property + §15.1.5 prefix length (#4437)

### DIFF
--- a/plan/issues/4437-per-function-meta-name-and-prefix-length.md
+++ b/plan/issues/4437-per-function-meta-name-and-prefix-length.md
@@ -1,0 +1,214 @@
+---
+id: 4437
+title: "ES5 standalone: per-function meta carrier — `name` as an own property + §15.1.5 `length` VALUE"
+status: in-progress
+assignee: ttraenkler/claude-es5-standalone
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: l
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: function-objects, property-descriptors, own-properties
+goal: standalone-gap
+related: [2896, 3468, 4010, 4098, 4194, 4241, 4390, 4436]
+umbrella: 2860
+loc-budget-allow:
+  # The minimal wiring a new subsystem module needs. All new logic is in the two
+  # new modules (`function-instance-meta.ts`, `function-instance-meta-arms.ts`);
+  # what lands in these three is 25 lines of frontmatter-style field docs, 8
+  # lines of two extra native locals, and 2 lines threading one argument.
+  - src/codegen/context/types.ts
+  - src/codegen/object-runtime.ts
+  - src/codegen/closures.ts
+func-budget-allow:
+  # +8 lines: two extra `registerNative` locals (`fnmeta` on `__builtinfn_get_meta`
+  # / `__builtinfn_delete`, and on `__builtinfn_push_ownnames`). Appended LAST so
+  # `fillBuiltinFnMeta`'s by-index reads of locals 2..5 are untouched. A local has
+  # to be declared where the native is registered; there is no other site.
+  - src/codegen/object-runtime.ts::ensureObjectRuntime
+---
+
+# #4437 — Per-function metadata carrier (`name` + §15.1.5 `length`)
+
+The R1/R2 slice `plan/issues/4436-function-instance-own-properties-residual.md`
+left unowned. #4436 made `length` a genuine own property of a user function
+instance by answering every reflective surface from the `$arity` closure-header
+slot; this closes the two residuals it recorded as **one** slice, because they
+need the same substrate.
+
+## Before-state (measured on this branch's base `f5e2fa6`, `--target standalone`)
+
+Not inherited from the baseline artifact — every figure below is from a run of
+`.tmp/run-one.mts` (the real `runTest262File`) on `f5e2fa6` sources, restored
+from the `.tmp/base/*` copies captured at the first edit.
+
+| read on `function f(a,b){}` / `function g(x=42,y){}` | base   | spec  |
+| ---------------------------------------------------- | ------ | ----- |
+| `f.name` (STATIC fold, typed receiver)               | `"f"`  | `"f"` |
+| `f["name"]` (DYNAMIC key — what `verifyProperty` uses) | absent | `"f"` |
+| `f.hasOwnProperty("name")`                           | false  | true  |
+| `Object.getOwnPropertyDescriptor(f, "name")`         | undef  | desc  |
+| `Object.getOwnPropertyNames(f)` ∋ `"name"`           | false  | true  |
+| `g["length"]` (reflective)                           | **2**  | **0** |
+
+`g`'s `length` is the R2 row: `$arity` is the DECLARED FORMAL COUNT (2), while
+§15.1.5 ExpectedArgumentCount is a PREFIX count that stops at the first
+defaulted/optional parameter (0). The static fold was already correct — the
+divergence was that the reflective read answered `$arity`.
+
+## Root cause
+
+One cause, two symptoms: **a user closure has no per-DECLARATION data slot.**
+
+`$arity` is per-instance and holds one number, and that number is already spoken
+for — `closure-exports.ts` widens an under-applied dispatch to
+`max(n, $arity)`, so lowering it to the §15.1.5 value would stop padding omitted
+arguments (pinned: `issue-4437.test.ts` "keeps `$arity` as the DISPATCH arity").
+`name` has no slot at all. So R1 and R2 are the same missing thing: a second,
+independent carrier for the two values a function object must *reflect*, as
+distinct from the one value it *dispatches* on.
+
+## What shipped
+
+Two new modules, split along the compile-time / runtime seam:
+
+- **`src/codegen/function-instance-meta.ts`** — the WRITE side. Mints the nominal
+  `$__fn_instance_meta { externref name; i32 length }` struct, grows a `$fnmeta`
+  slot on closure structs, interns one lazily-initialized module global per
+  distinct `{name, length}`, and resolves §10.2.9 `name` (including
+  NamedEvaluation) + §15.1.5 `length` from the declaration.
+- **`src/codegen/function-instance-meta-arms.ts`** — the READ side. The
+  `__fninst_meta(fn) -> externref` resolver body (one `ref.test` arm per
+  registered family) and the three instruction shapes the reflective arms use.
+- **`src/codegen/function-instance-props.ts`** (#4436's module) — extended, not
+  duplicated. `length` now consults `$fnmeta` FIRST and falls back to `$arity`;
+  `name` is a new arm on the same `closureKeyArm` guard, so it moves in lockstep
+  with `hasOwnProperty` / `gOPD` / `getOwnPropertyNames` / `delete` / the
+  `__extern_set` refusal, exactly as `length` already did.
+
+Mint sites wired: `method-trampolines.ts::ensureFuncClosureSingleton` (the
+canonical cached value of a top-level function declaration),
+`funcref-as-closure.ts` (both the capture-carrying and the plain path), and
+`arrow-phases.ts::mintClosureStructTypes` (arrows + function expressions).
+
+### Four things that were load-bearing and are easy to get wrong
+
+1. **A bare `i32` id is NOT a sound discriminator, and neither is
+   `[externref, i32]`.** WasmGC canonicalizes structurally — field names are ours
+   alone and never reach the binary — so `ref.test <family>` also matches any
+   unrelated struct with the same shape and supertype. A trailing `i32` collides
+   with the constructible wrapper's `__constructible` (a `function f(){}` value
+   would read `1` as a metadata id and answer some other function's `name`);
+   `[externref, i32]` collides with a closure capturing one reference and one
+   number. The slot therefore holds a `(ref null $__fn_instance_meta)`: a
+   nominal type user source can never produce, so the family test is sound by
+   construction rather than by a layout argument. This is the same problem
+   #2896's `bfnid` solves, one level up.
+2. **The metadata struct references NO other type.** `computeRecGroups`
+   (emit/binary.ts) merges every type between a definition and its
+   forward-referenced target into one rec group, which would perturb the #2514
+   canonical runtime rec-group boundary. `name` is an `externref` rather than a
+   `(ref $anystr)` for exactly that reason — and it is also precisely what
+   `__builtinfn_get_meta` returns, so the read is a bare `struct.get`.
+3. **Allocate DERIVED, report the BASE.** Where the base struct is shared across
+   functions (the per-signature wrapper), the slot needs a subtype — but the
+   value's reported static type stays the base. `emitCachedFuncClosureExternref`
+   documents why: a `ref.cast` to a MORE derived type TRAPS on a value stored as
+   the base, and two callers routinely disagree about the `constructible` flag
+   over one cache global. Widening is safe; narrowing is a live `illegal cast`.
+   A capture-carrying struct is already per-closure, so it grows the slot in
+   place and no type identity changes at all.
+4. **`length` falls back, `name` does not.** A closure whose mint site is not yet
+   wired keeps #4436's `$arity` answer for `length` (never loses the property)
+   and declines for `name` (absent — never a *wrong* name). That asymmetry is
+   what makes the remaining residuals safe to leave: class/object methods report
+   no `name` rather than a guessed one.
+
+### One leak this found and fixed
+
+Publishing `decl.name.text` made `built-ins/Function/instance-name.js` report
+`"__new_function_474"` — `eval-inline.ts` splices `new Function(…)` in as a real
+parsed declaration under a generated name. §20.2.1.1.1 says the answer is
+`"anonymous"`; detecting it by SOURCE FILE (`EVAL_SOURCE_FILENAME`) rather than
+by name text avoids coupling to a template literal in another module. That file
+now passes.
+
+## Verification
+
+### Target population — the FULL bucket, before and after, both runs my own
+
+90 files: every corpus entry failing `"name should be an own property"` (74) ∪
+every `*length-dflt.js` (16). Run with the real `runTest262File`,
+`--target standalone`, on base `f5e2fa6` and on this branch.
+
+| | before | after |
+| --- | ---: | ---: |
+| pass | **0** | **42** |
+| fail | 90 | 48 |
+
+**42 flips, 0 regressions.** Flipped: `language/{statements,expressions}/{function,generators}/{name,length-dflt}.js`,
+`arrow-function/{name,length-dflt}.js`, `async-{function,arrow-function,generator}/name.js`,
+`built-ins/{AsyncFunction/instance-has-name,Function/instance-name}.js`, and the
+whole `fn-name-{fn,arrow,gen,cover,lhs-cover,lhs-member}` family across
+`statements/{const,let,variable}`, `expressions/assignment` (incl. `dstr/`) and
+`statements/for-of/dstr/`.
+
+### Remaining failure buckets in that population (all outside this slice)
+
+| count | bucket | why not here |
+| ----: | ------ | ------------ |
+| 22 | `name should be an own property` | class values, class/object METHODS, and builtin function objects (`eval`, `Proxy.revocable`, `Promise` resolve/reject functions, `Iterator.zipKeyed`, `TypedArray`) — different mint sites, see residuals |
+| 8 | `length descriptor value should be 0` | all eight are class/object METHODS + setters (`{statements,expressions}/class/{,gen-,static-}method-length-dflt.js`, `object/method-definition/*`, `object/setter-length-dflt.js`) |
+| 9 | wrong `name` VALUE (`[test262]`, `id`, `[method]`, …) | computed / symbol-keyed NamedEvaluation — a runtime key, not resolvable at the mint site |
+| 3 | `Cannot convert undefined or null to object` | unrelated pre-existing defects in those files |
+
+### Controls — 140 currently-PASSING files, sampled by stride
+
+Pool 11,029 passing standalone entries under
+`language/{statements,expressions}/{function,arrow-function,generators,object,class}`
+∪ `built-ins/{Function,Object/{getOwnPropertyNames,getOwnPropertyDescriptor,keys,defineProperty},Array/prototype/{map,filter},Reflect}`
+∪ `language/statements/for-of`; every 78th taken.
+
+**138/140 pass.** The two failures
+(`arrow-function/syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js`,
+`object/method-definition/generator-param-redecl-const.js`) were A/B'd against
+the pristine base copies and fail IDENTICALLY there — stale baseline entries,
+not regressions.
+
+### Vitest
+
+- `tests/issue-4437.test.ts` — new, 19 tests.
+- `tests/issue-4436.test.ts` — its two DELIBERATELY-PINNED residual assertions
+  are flipped to the spec answer, in place, with the reasoning at the site.
+  #4436 pinned them precisely so this change could not happen silently.
+- Green: `issue-2896`, `issue-3468-closure-own-props`, `issue-4010`,
+  `issue-4194-instance-expando`, `issue-4241-carrier-bag-slot`,
+  `issue-4098-error-expando`, `es5-standalone-function-semantics` — 145/145.
+- `tests/equivalence/**` (host lane) — everything here is `ctx.standalone`-gated,
+  so host output is unchanged by construction; run to confirm.
+
+### Gates
+
+`typecheck`, `check:oracle-ratchet` (+0/+0), `check:stack-balance`,
+`check:ir-fallbacks`, `check:func-budget` all OK. `check:loc-budget` needs the
+three allowances in this file's frontmatter (see the comment there).
+`check:godfiles` fails with **11 regressions on the pristine base too** —
+identical list, A/B-verified; pre-existing drift, not this change.
+
+## Residuals, with owners
+
+| id | residual | why it is not fixed here | owner |
+| -- | -------- | ------------------------ | ----- |
+| **R1** | Class and object-literal **METHODS** carry no `$fnmeta` — 8 `*-method-length-dflt.js` + several `name` files. | `ensureMethodClosureSingleton` / `emitObjectMethodAsClosure` take a method NAME and funcIdx, not a declaration node, so the §15.1.5 walk has nothing to read; and method `name` has spec subtleties this slice does not measure (`get `/`set ` prefixes §10.2.9, symbol keys `[Symbol.iterator]` → `"[Symbol.iterator]"`, class-field vs method). Because `name` declines rather than guessing, leaving it is SAFE — those files report no `name` instead of a wrong one. | **unowned — next slice of #2860** |
+| **R2** | Computed / symbol-keyed NamedEvaluation: `({ [test262]: function(){} })` should name the function from the runtime key. 9 files. | The key is a runtime value; the mint site has only the AST. Needs a runtime `SetFunctionName` on the closure's `$fnmeta` (a mutable slot, or a bag write) rather than a compile-time constant. | **unowned** |
+| **R3** | A CLASS value's `name` (`language/{statements,expressions}/class/name.js`). | A class value is not a funcref-wrapper closure; different carrier entirely. #4436's bucket map already calls the class own-property stratum separate. | **unowned** |
+| **R4** | Builtin function objects still missing `name`: `eval`, `Proxy.revocable`'s revoker, `Promise` resolve/reject functions, `Iterator.zip*`, `TypedArray`. | These are #2896's substrate (`ensureBuiltinFnMetaType`), not a user closure — each needs its own meta type registered at its own materialization site. | **unowned** |
+| **R5** | `f.hasOwnProperty("prototype")` is still false; `propertyIsEnumerable` on a closure expando returns false. | Adjacent own-property surfaces on function instances; inherited unchanged from #4436's R5. | **unowned** |
+| **R6** | `new function f(){ this.p = 1; }` (INLINE function expression as the `new` callee) traps. | #4436's R3, a construct-path defect unrelated to own properties. | **unowned** |
+| **R7** | The STATIC `<fn>.name` / `<fn>.length` fold does not observe a runtime `delete`+rewrite: after `delete f.length; f.length = 5`, the fold answers `2` while the dynamic read answers `5`. | Pre-existing and NOT caused here — **A/B'd against the pristine base copies: identical numbers (fold 2, dynamic 5) on `f5e2fa6`.** The fold is a compile-time answer for a typed receiver; making it defer would need a "this receiver may have been mutated" analysis. Found while writing this issue's tests, which is why the write-refusal test asserts the DYNAMIC read (the surface `verifyProperty` uses). | **unowned** |
+| **R8** | Two same-named nested function declarations in DIFFERENT enclosing scopes alias to one closure value: `outer(){function f(){return 1}}` / `outer2(){function f(){return 2}}` yields `p === q` and `q() === 1`. | Pre-existing and NOT caused here — **A/B'd: identical on `f5e2fa6`.** `nestedFnClosureArtifacts` / the `__fn_closure_<key>` cache key off the bare source NAME; `ensureFuncClosureSingleton` has a `$n` disambiguator (#4133) for the top-level case but the nested path does not. A correctness bug well beyond own properties — surfaced by a metadata test, worth its own issue. | **unowned — file separately** |

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -3017,6 +3017,7 @@ export function compileArrowAsClosure(
     closureResults,
     closureName,
     isNamedFuncExpr: !!isNamedFuncExpr,
+    decl: arrow, // (#4437) the `$fnmeta` slot's source of `name` + §15.1.5 `length`
     constructible:
       (noJsHost(ctx) || ctx.targetProfile.semanticProviders === "native-first") &&
       ts.isFunctionExpression(arrow) &&
@@ -3213,6 +3214,7 @@ export function compileArrowAsClosure(
     liftedFuncIdx,
     structTypeIdx,
     hasRestParam ? Math.max(0, arrowParams.length - 1) : arrowParams.length,
+    mintedTypes.meta, // (#4437)
   );
   if (directGenericGlobalIdx !== undefined) {
     // Keep one typed handle to the exact closure instance installed on the

--- a/src/codegen/closures/arrow-phases.ts
+++ b/src/codegen/closures/arrow-phases.ts
@@ -37,6 +37,8 @@ import { closureObservesBindingValue, collectTransitiveCaptureNames } from "../f
 import { emitBoundsCheckedArrayGet, valTypesMatch } from "../shared.js";
 import { spliceNullGuarded } from "./param-emit-helpers.js";
 import { materializeHoistedFunctionValueBinding } from "./funcref-as-closure.js";
+// (#4437) per-declaration `name` / §15.1.5 `length` carrier
+import { ensureFnMetaSubtype, fnMetaSlot, registerFnMetaFamily } from "../function-instance-meta.js";
 import {
   arrowOwnLocals,
   buildCaptureFieldDef,
@@ -691,9 +693,30 @@ export function mintClosureStructTypes(
     closureName: string;
     isNamedFuncExpr: boolean;
     constructible: boolean;
+    /** (#4437) The arrow / function expression itself, for the `$fnmeta` slot. */
+    decl?: ts.Node;
   },
-): { structTypeIdx: number; liftedFuncTypeIdx: number; liftedSelfTypeIdx: number; liftedParams: ValType[] } {
+): {
+  structTypeIdx: number;
+  liftedFuncTypeIdx: number;
+  liftedSelfTypeIdx: number;
+  liftedParams: ValType[];
+  /**
+   * (#4437) The type to `struct.new` and the `$fnmeta` operand, when this
+   * closure carries metadata.
+   *
+   * For a CAPTURE-carrying closure this equals `structTypeIdx` — that struct is
+   * already per-closure, so the slot grows in place and no type identity
+   * changes. For a capture-free closure the wrapper is SHARED across every
+   * closure of the signature, so the slot needs a per-base subtype; the
+   * reported `structTypeIdx` deliberately stays the BASE, because that is the
+   * type every other site casts to and a cast to a MORE derived type traps on a
+   * value stored as the base (see `emitCachedFuncClosureExternref`'s note).
+   */
+  meta?: { allocTypeIdx: number; init: Instr[] };
+} {
   const { captures, arrowParams, closureResults, closureName, isNamedFuncExpr, constructible } = opts;
+  const metaSlot = fnMetaSlot(ctx, opts.decl);
   let structTypeIdx: number;
   let liftedFuncTypeIdx: number;
   let liftedSelfTypeIdx: number;
@@ -707,6 +730,17 @@ export function mintClosureStructTypes(
       liftedFuncTypeIdx = wrapperTypes.liftedFuncTypeIdx;
       liftedSelfTypeIdx = wrapperTypes.liftedSelfTypeIdx;
       liftedParams = [{ kind: "ref", typeIdx: liftedSelfTypeIdx }, ...arrowParams];
+      // (#4437) Shared wrapper ⇒ the metadata slot needs a per-base subtype.
+      const allocTypeIdx = metaSlot ? ensureFnMetaSubtype(ctx, structTypeIdx) : undefined;
+      if (metaSlot && allocTypeIdx !== undefined) {
+        return {
+          structTypeIdx,
+          liftedFuncTypeIdx,
+          liftedSelfTypeIdx,
+          liftedParams,
+          meta: { allocTypeIdx, init: metaSlot.init },
+        };
+      }
     } else {
       // Fallback: create a unique struct type
       const structFields = [
@@ -750,6 +784,10 @@ export function mintClosureStructTypes(
     if (constructible) {
       structFields.push({ name: "__constructible", type: { kind: "i32" as const }, mutable: false });
     }
+    // (#4437) A capture-carrying closure's struct is ALREADY per-closure, so
+    // the slot is appended in place — last, after `__constructible`, matching
+    // the operand order `emitClosureConstruction` pushes.
+    if (metaSlot) structFields.push(metaSlot.field);
 
     // For closures with captures, make the struct a subtype of the shared
     // wrapper struct so ref.cast at call sites succeeds. Named func exprs need
@@ -805,6 +843,22 @@ export function mintClosureStructTypes(
       liftedSelfTypeIdx = structTypeIdx;
       liftedParams = [{ kind: "ref_null", typeIdx: liftedSelfTypeIdx }, ...arrowParams];
       liftedFuncTypeIdx = addFuncType(ctx, liftedParams, closureResults, `${closureName}_type`);
+    }
+  }
+  if (metaSlot) {
+    // Registered here rather than at each mint branch so every path that grew
+    // the field also gets its family arm — the slot is always LAST, so its
+    // index is the struct's field count minus one.
+    const fields = ctx.mod.types[structTypeIdx];
+    if (fields?.kind === "struct" && fields.fields[fields.fields.length - 1]?.name === metaSlot.field.name) {
+      registerFnMetaFamily(ctx, structTypeIdx, fields.fields.length - 1);
+      return {
+        structTypeIdx,
+        liftedFuncTypeIdx,
+        liftedSelfTypeIdx,
+        liftedParams,
+        meta: { allocTypeIdx: structTypeIdx, init: metaSlot.init },
+      };
     }
   }
   return { structTypeIdx, liftedFuncTypeIdx, liftedSelfTypeIdx, liftedParams };
@@ -1121,6 +1175,8 @@ export function emitClosureConstruction(
   liftedFuncIdx: number,
   structTypeIdx: number,
   arity: number,
+  /** (#4437) The `$fnmeta` operand + the type to allocate, from `mintClosureStructTypes`. */
+  meta?: { allocTypeIdx: number; init: Instr[] },
 ): void {
   // A construction site in a conditional arm cannot own the canonical box for
   // a captured parameter: compilation re-aims all later reads to that box even
@@ -1225,7 +1281,8 @@ export function emitClosureConstruction(
     fctx.body.push({ op: "i32.const", value: 1 });
   }
 
-  fctx.body.push({ op: "struct.new", typeIdx: structTypeIdx });
+  if (meta) for (const instr of meta.init) fctx.body.push(instr);
+  fctx.body.push({ op: "struct.new", typeIdx: meta ? meta.allocTypeIdx : structTypeIdx });
 }
 
 /**

--- a/src/codegen/closures/funcref-as-closure.ts
+++ b/src/codegen/closures/funcref-as-closure.ts
@@ -20,6 +20,8 @@ import { mintDefinedFunc, pushDefinedFunc } from "../func-space.js";
 import { observeProgramAbiFunctionValue } from "../program-abi-source-callable-planning.js";
 import { noJsHost } from "../js-errors.js";
 import { emitCachedFuncClosureAccess } from "./method-trampolines.js";
+// (#4437) per-declaration `name` / §15.1.5 `length` carrier
+import { ensureFnMetaSubtype, fnMetaSlot, registerFnMetaFamily } from "../function-instance-meta.js";
 import {
   CLOSURE_CAPTURE_FIELD_BASE,
   closureArityField,
@@ -71,6 +73,12 @@ function emitMemoizedNestedFnClosure(
   tdzFlaggedNested: NonNullable<ReturnType<CodegenContext["nestedFuncCaptures"]["get"]>>,
   constructible: boolean,
   arity: number,
+  /**
+   * (#4437) The `$fnmeta` operand, when this closure's struct carries the slot.
+   * Pushed LAST — the field is appended after `__constructible`, so the
+   * `struct.new` operand order has to match or the emitter rejects it.
+   */
+  metaInit?: Instr[],
 ): void {
   const numCaptures = nestedCaptures.length;
   const numTdzFlags = tdzFlaggedNested.length;
@@ -291,6 +299,7 @@ function emitMemoizedNestedFnClosure(
     }
   }
   if (constructible) fctx.body.push({ op: "i32.const", value: 1 });
+  if (metaInit) for (const instr of metaInit) fctx.body.push(instr);
   fctx.body.push({ op: "struct.new", typeIdx: structTypeIdx });
   fctx.body.push({ op: "local.set", index: memoLocal });
 
@@ -317,6 +326,13 @@ export function emitFuncRefAsClosure(
 ): ValType | null {
   const sig = getFuncSignature(ctx, funcIdx);
   if (!sig) return null;
+
+  // (#4437) The declaration behind `funcName`, for the `$fnmeta` slot. Resolved
+  // ONCE here (both paths below need it) but materialized lazily — `fnMetaSlot`
+  // mints an interned string global, and a path that ends up not carrying the
+  // slot should not leave one behind.
+  const metaDecl = ctx.funcMapOwnerDecl.get(funcName) ?? ctx.topLevelFunctionDeclarations.get(funcName);
+  const metaSlotOf = (): ReturnType<typeof fnMetaSlot> => fnMetaSlot(ctx, metaDecl);
 
   const nestedCaptures = ctx.nestedFuncCaptures.get(funcName);
   if (nestedCaptures && nestedCaptures.length > 0) {
@@ -361,6 +377,12 @@ export function emitFuncRefAsClosure(
           tdzFlaggedNested,
           constructible,
           userParams.length,
+          // Re-derived rather than cached alongside the struct type: the
+          // metadata is a pure function of `metaDecl`, and the global it reads
+          // is interned by key, so this yields the same instrs the mint site
+          // emitted. A cached Instr[] would be ALIASED into two bodies, which
+          // double-remaps on a late-import shift.
+          metaSlotOf()?.init,
         );
         return { kind: "ref", typeIdx: cachedArtifacts.structTypeIdx };
       }
@@ -388,6 +410,10 @@ export function emitFuncRefAsClosure(
     if (constructible) {
       captureFields.push({ name: "__constructible", type: { kind: "i32" }, mutable: false });
     }
+    // (#4437) This struct is ALREADY per-function, so the `$fnmeta` slot is
+    // appended in place — no extra subtype. Last, after `__constructible`.
+    const metaSlot = metaSlotOf();
+    if (metaSlot) captureFields.push(metaSlot.field);
     const closureName = `__fn_cap_${funcName}_${ctx.closureCounter++}`;
     const structTypeIdx = ctx.mod.types.length;
     ctx.mod.types.push({
@@ -402,6 +428,9 @@ export function emitFuncRefAsClosure(
       superTypeIdx: wrapperTypes.structTypeIdx,
     });
     if (constructible) ctx.constructibleClosureTypeIdxs.add(structTypeIdx);
+    if (metaSlot) {
+      registerFnMetaFamily(ctx, structTypeIdx, CLOSURE_CAPTURE_FIELD_BASE + captureFields.length - 1);
+    }
 
     // Use the base wrapper's func type so call_ref works via subtype cast
     const liftedFuncTypeIdx = wrapperTypes.liftedFuncTypeIdx;
@@ -488,6 +517,7 @@ export function emitFuncRefAsClosure(
       tdzFlaggedNested,
       constructible,
       userParams.length,
+      metaSlot?.init,
     );
     return { kind: "ref", typeIdx: structTypeIdx };
   }
@@ -522,14 +552,23 @@ export function emitFuncRefAsClosure(
   });
   ctx.funcMap.set(trampolineName, trampolineFuncIdx);
 
+  // (#4437) `structTypeIdx` here is the SHARED per-signature wrapper, so the
+  // metadata slot needs a per-base subtype. Falling back to the bare wrapper
+  // when the subtype cannot be minted keeps this path's previous behaviour
+  // (reflective `length` from `$arity`, no `name`) rather than failing.
+  const metaSlot = metaSlotOf();
+  const metaTypeIdx = metaSlot ? ensureFnMetaSubtype(ctx, structTypeIdx) : undefined;
+  const allocTypeIdx = metaTypeIdx ?? structTypeIdx;
+
   // Emit: ref.func $trampoline, (#3673) $arity, (#4241) $bag, struct.new $closure_struct
   fctx.body.push({ op: "ref.func", funcIdx: trampolineFuncIdx });
   fctx.body.push({ op: "i32.const", value: userParams.length });
   fctx.body.push(closureBagInitInstr());
   if (constructible) fctx.body.push({ op: "i32.const", value: 1 });
-  fctx.body.push({ op: "struct.new", typeIdx: structTypeIdx });
+  if (metaTypeIdx !== undefined && metaSlot) for (const instr of metaSlot.init) fctx.body.push(instr);
+  fctx.body.push({ op: "struct.new", typeIdx: allocTypeIdx });
 
-  return { kind: "ref", typeIdx: structTypeIdx };
+  return { kind: "ref", typeIdx: allocTypeIdx };
 }
 
 /**

--- a/src/codegen/closures/method-trampolines.ts
+++ b/src/codegen/closures/method-trampolines.ts
@@ -33,6 +33,8 @@ import {
 } from "./funcref-wrapper-types.js";
 import { emitFuncRefAsClosure } from "./funcref-as-closure.js";
 import { observeProgramAbiFunctionValue } from "../program-abi-source-callable-planning.js";
+// (#4437) per-declaration `name` / §15.1.5 `length` carrier
+import { ensureFnMetaSubtype, fnMetaSlot } from "../function-instance-meta.js";
 
 /**
  * (#2015) Build the `this`-slot prologue for an object-method trampoline.
@@ -543,6 +545,13 @@ export function finalizeMethodTrampolines(ctx: CodegenContext): void {
  * The func-decl caller appends its own `any.convert_extern` + `ref.cast`
  * recovery after this returns.
  */
+/** (#4437) Narrow a singleton's optional metadata pair into the emit argument. */
+function fnMetaAllocOf(singleton: FuncClosureSingleton): { allocStructTypeIdx: number; metaInit: Instr[] } | undefined {
+  return singleton.allocStructTypeIdx !== undefined && singleton.metaInit !== undefined
+    ? { allocStructTypeIdx: singleton.allocStructTypeIdx, metaInit: singleton.metaInit }
+    : undefined;
+}
+
 function emitLazyClosureCacheAccess(
   fctx: FunctionContext,
   cacheGlobalIdx: number,
@@ -550,13 +559,16 @@ function emitLazyClosureCacheAccess(
   structTypeIdx: number,
   arity: number,
   constructible = false,
+  /** (#4437) `$fnmeta` operand + the SUBTYPE to allocate, when the slot exists. */
+  meta?: { allocStructTypeIdx: number; metaInit: Instr[] },
 ): void {
   const initBody: Instr[] = [
     { op: "ref.func", funcIdx: trampolineFuncIdx },
     { op: "i32.const", value: arity }, // (#3673) $arity
     closureBagInitInstr(), // (#4241) $bag
     ...(constructible ? ([{ op: "i32.const", value: 1 }] satisfies Instr[]) : []),
-    { op: "struct.new", typeIdx: structTypeIdx },
+    ...(meta ? meta.metaInit : []),
+    { op: "struct.new", typeIdx: meta ? meta.allocStructTypeIdx : structTypeIdx },
     { op: "extern.convert_any" },
     { op: "global.set", index: cacheGlobalIdx },
   ];
@@ -745,6 +757,19 @@ export interface FuncClosureSingleton {
   readonly cacheGlobalIdx: number;
   readonly trampolineFuncIdx: number;
   readonly closureStructTypeIdx: number;
+  /**
+   * (#4437) The type to `struct.new`, when the closure carries a `$fnmeta`
+   * slot — a per-base SUBTYPE of `closureStructTypeIdx`.
+   *
+   * Deliberately SEPARATE from `closureStructTypeIdx`, which stays the base:
+   * the read path casts the cached externref back with `ref.cast`, and this
+   * helper's own doc records that casting to a MORE derived type traps on a
+   * value stored as the base. Allocating derived and casting to the base is the
+   * safe direction; the reverse is the live `illegal cast` hazard.
+   */
+  readonly allocStructTypeIdx?: number;
+  /** (#4437) The `$fnmeta` operand for `allocStructTypeIdx`, pushed last. */
+  readonly metaInit?: Instr[];
 }
 
 /**
@@ -883,7 +908,22 @@ export function ensureFuncClosureSingleton(
   }
 
   observeProgramAbiFunctionValue(ctx, funcIdx, trampolineFuncIdx, cacheGlobalIdx);
-  return { cacheGlobalIdx, trampolineFuncIdx, closureStructTypeIdx: structTypeIdx };
+
+  // (#4437) The cached singleton is the canonical value of a top-level function
+  // DECLARATION — the receiver every `verifyProperty(f, "name", …)` sees. It is
+  // built exactly once into the cache global, so the metadata operand costs one
+  // push per module, not per reference.
+  const metaSlot = fnMetaSlot(
+    ctx,
+    ctx.funcMapOwnerDecl.get(funcName) ?? ctx.topLevelFunctionDeclarations.get(funcName),
+  );
+  const allocStructTypeIdx = metaSlot ? ensureFnMetaSubtype(ctx, structTypeIdx) : undefined;
+  return {
+    cacheGlobalIdx,
+    trampolineFuncIdx,
+    closureStructTypeIdx: structTypeIdx,
+    ...(allocStructTypeIdx !== undefined && metaSlot ? { allocStructTypeIdx, metaInit: metaSlot.init } : {}),
+  };
 }
 
 /**
@@ -928,6 +968,7 @@ export function emitCachedFuncClosureExternref(
     closureStructTypeIdx,
     ctx.closureInfoByTypeIdx.get(closureStructTypeIdx)?.paramTypes.length ?? 0,
     constructible,
+    fnMetaAllocOf(singleton),
   );
   return true;
 }
@@ -971,6 +1012,7 @@ export function emitCachedFuncClosureAccess(
     structTypeIdx,
     ctx.closureInfoByTypeIdx.get(structTypeIdx)?.paramTypes.length ?? 0,
     constructible,
+    fnMetaAllocOf(singleton),
   );
   fctx.body.push({ op: "any.convert_extern" });
   fctx.body.push({ op: "ref.cast", typeIdx: structTypeIdx });

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -3390,6 +3390,31 @@ export interface CodegenContext {
    *  `struct.new` in a shift-covered function body — NOT a const-init, whose
    *  embedded `ref.func` the late-import funcidx shifter does not walk). */
   builtinFnSingletonGlobalByTypeIdx?: Map<number, number>;
+  /** (#4437) Type index of `$__fn_instance_meta` — `{externref name, i32 length}`,
+   *  the nominal per-DECLARATION metadata struct a user closure's `$fnmeta` slot
+   *  points at. Minted lazily by `ensureFnInstanceMetaStructType`
+   *  (function-instance-meta.ts) at the first closure that carries the slot, so
+   *  its index is always LOWER than every referring closure struct — a backward
+   *  reference, which keeps it a singleton rec group (`computeRecGroups` would
+   *  otherwise merge everything in between, perturbing the #2514 canonical
+   *  runtime rec-group boundary). */
+  fnInstanceMetaStructTypeIdx?: number;
+  /** (#4437) `"<length>:<name>"` → index of the mutable `(ref null
+   *  $__fn_instance_meta)` global holding that entry's ONE instance. Two
+   *  declarations with the same name and expected-argument-count share it: the
+   *  struct is immutable, so sharing is unobservable. */
+  fnInstanceMetaGlobalByKey?: Map<string, number>;
+  /** (#4437) Closure struct-type index → the field index of its `$fnmeta` slot.
+   *  One `ref.test` arm per entry is emitted into `__fninst_meta` at finalize
+   *  (function-instance-props.ts). The slot always sits LAST, so the index
+   *  differs per family — the shared wrapper has 3 own fields, the constructible
+   *  wrapper 4, and a capture subtype 3+N. */
+  fnInstanceMetaFamilies?: Map<number, number>;
+  /** (#4437) Base closure struct-type index → the `$fnmeta`-carrying SUBTYPE
+   *  minted over it. Needed only where the base is SHARED across functions (the
+   *  per-signature wrapper and its constructible variant); a capture subtype is
+   *  already per-function and grows the slot in place. */
+  fnInstanceMetaSubtypeByBase?: Map<number, number>;
   /** (#2193 PR-B) Struct-type indices of `$NativeProto` member closures whose
    *  FIRST user param is the receiver (`this`) — e.g. `Array.prototype.slice`'s
    *  `(self, this, start, end)` closure. Unlike a plain user function (which

--- a/src/codegen/function-instance-meta-arms.ts
+++ b/src/codegen/function-instance-meta-arms.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4437) The RUNTIME half of the per-function metadata carrier: the
+ * `__fninst_meta` resolver body, and the three small instruction shapes the
+ * reflective arms in `function-instance-props.ts` splice around it.
+ *
+ * `function-instance-meta.ts` owns the COMPILE-time half (minting the
+ * `$__fn_instance_meta` struct, growing the `$fnmeta` slot, registering
+ * families). This module owns the read side. They are split so neither the
+ * closure-mint sites nor the reflective fill has to import the other's
+ * concerns, and so `fillFunctionInstanceProps` stays a sequence of splices
+ * rather than absorbing a second subsystem.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { FN_META_LENGTH_FIELD_IDX, FN_META_NAME_FIELD_IDX } from "./function-instance-meta.js";
+import { FNINST_META } from "./function-instance-props.js";
+
+/** How `fillFunctionInstanceProps` installs a reserved native's body. */
+export type SetNativeBody = (name: string, locals: { name: string; type: ValType }[], body: Instr[]) => void;
+
+export interface FnMetaArms {
+  /**
+   * Is there anything to read? False when the module minted no `$fnmeta` slot
+   * (no user closure, or a non-standalone target), in which case every consumer
+   * emits its pre-#4437 instructions and the reserved resolver keeps its
+   * `ref.null.extern` placeholder.
+   */
+  readonly available: boolean;
+  /**
+   * `i32` — 1 iff the receiver (param 0) carries metadata. Leaves the metadata
+   * externref in `metaLocal` so {@link name} / {@link boxedLength} can read it
+   * without asking twice.
+   */
+  present(metaLocal: number): Instr[];
+  /** `metaLocal` (known non-null) → its §10.2.9 `name`, already an externref. */
+  name(metaLocal: number): Instr[];
+  /** `metaLocal` (known non-null) → its §15.1.5 `length`, as a boxed number. */
+  boxedLength(metaLocal: number, boxNumIdx: number): Instr[];
+  /** Install the `__fninst_meta` body. No-op when {@link available} is false. */
+  fillResolver(setFn: SetNativeBody): void;
+}
+
+/**
+ * Bind the metadata read surface for this module.
+ *
+ * Every field index and type index is resolved ONCE here, so a consumer cannot
+ * accidentally read `length` out of the `name` slot — the two are only ever
+ * named through {@link FnMetaArms.name} / {@link FnMetaArms.boxedLength}.
+ */
+export function fnMetaArms(ctx: CodegenContext): FnMetaArms {
+  const structTypeIdx = ctx.fnInstanceMetaStructTypeIdx;
+  const families = ctx.fnInstanceMetaFamilies;
+  const metaIdx = ctx.funcMap.get(FNINST_META);
+  const available = structTypeIdx !== undefined && families !== undefined && families.size > 0 && metaIdx !== undefined;
+
+  const field = (metaLocal: number, fieldIdx: number): Instr[] => [
+    { op: "local.get", index: metaLocal },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: structTypeIdx! },
+    { op: "struct.get", typeIdx: structTypeIdx!, fieldIdx },
+  ];
+
+  return {
+    available,
+    present: (metaLocal) => [
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: metaIdx! },
+      { op: "local.tee", index: metaLocal },
+      { op: "ref.is_null" },
+      { op: "i32.eqz" },
+    ],
+    name: (metaLocal) => field(metaLocal, FN_META_NAME_FIELD_IDX),
+    boxedLength: (metaLocal, boxNumIdx) => [
+      ...field(metaLocal, FN_META_LENGTH_FIELD_IDX),
+      { op: "f64.convert_i32_s" },
+      { op: "call", funcIdx: boxNumIdx },
+    ],
+    fillResolver: (setFn) => {
+      if (!available) return;
+      // One `ref.test` arm per registered family. Families are SIBLINGS, never
+      // subtypes of one another (each is `<some closure struct> + $fnmeta`), so
+      // arm order is immaterial and at most one can match. The `$fnmeta` type
+      // is nominal and unreachable from user source, so a family `ref.test`
+      // cannot be satisfied by a structurally-similar non-metadata closure —
+      // see function-instance-meta.ts on why a bare `i32` id could.
+      const body: Instr[] = [];
+      for (const [famTypeIdx, fieldIdx] of families!) {
+        body.push(
+          { op: "local.get", index: 0 },
+          { op: "any.convert_extern" },
+          { op: "ref.test", typeIdx: famTypeIdx },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 0 },
+              { op: "any.convert_extern" },
+              { op: "ref.cast", typeIdx: famTypeIdx },
+              { op: "struct.get", typeIdx: famTypeIdx, fieldIdx },
+              { op: "local.tee", index: 1 },
+              { op: "ref.is_null" },
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: 1 },
+                  { op: "ref.as_non_null" },
+                  { op: "extern.convert_any" },
+                  { op: "return" },
+                ],
+              },
+            ],
+          },
+        );
+      }
+      body.push({ op: "ref.null.extern" });
+      setFn(FNINST_META, [{ name: "__m", type: { kind: "ref_null", typeIdx: structTypeIdx! } }], body);
+    },
+  };
+}

--- a/src/codegen/function-instance-meta.ts
+++ b/src/codegen/function-instance-meta.ts
@@ -1,0 +1,359 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4437) A per-function metadata CARRIER on a user closure instance — the
+ * runtime substrate for `name` and for an exact §15.1.5 `length`.
+ *
+ * ## The two residuals this exists for (#4436 R1/R2)
+ * #4436 made `length` a genuine own property of a user function instance by
+ * answering every reflective surface from the `$arity` header slot. That left
+ * two measured gaps, both recorded on its issue as ONE slice:
+ *
+ * | read on `function f(a,b){}` / `function g(x=42,y){}` | #4436 | spec |
+ * | ---------------------------------------------------- | ----- | ---- |
+ * | `f["name"]`, `hasOwnProperty("name")`, `gOPD`, `gOPN` | absent | `"f"` |
+ * | `g["length"]` (reflective)                            | 2     | 0    |
+ *
+ * `$arity` cannot be re-pointed at the spec value to close the second one:
+ * `closure-exports.ts` widens an under-applied dispatch to `max(n, $arity)`, so
+ * lowering it to 0 for `g` would stop padding the omitted `y`. The two answers
+ * are genuinely different numbers with different jobs, and `name` has no runtime
+ * carrier at all — hence a second slot.
+ *
+ * ## Mechanism — one nominal metadata struct, referenced from a `$fnmeta` slot
+ *
+ * ```
+ *   $__fn_instance_meta { name externref;  length i32 }        (this module)
+ *   <closure struct>     [ func, $arity, $bag, …own…, $fnmeta ] <- (ref null $__fn_instance_meta)
+ * ```
+ *
+ * The metadata is per-DECLARATION and constant, so each entry is materialized
+ * ONCE into a lazily-filled module global (the `pushBuiltinFnSingletonValueInstrs`
+ * pattern) and every instance of that declaration stores the same reference.
+ * Closure creation therefore costs one extra `global.get`-guarded push, not an
+ * allocation per closure.
+ *
+ * ### Why the slot holds a REF to a nominal struct, not two plain fields
+ * WasmGC canonicalizes structurally: a type's identity is (fields, supertype,
+ * finality) — field NAMES are ours alone and are not in the binary. So
+ * `ref.test` against a family type also matches any UNRELATED struct that
+ * happens to share the shape. Two tempting cheaper layouts are both unsafe:
+ *
+ * - a bare trailing `i32` id collides with the constructible wrapper's
+ *   `__constructible` field (same supertype, same shape) — a `function f(){}`
+ *   value would read `1` as a metadata id and answer another function's `name`;
+ * - `[externref, i32]` appended directly collides with a closure that captures
+ *   one reference and one `i32` (`function outer(o, n) { return function () {
+ *   return o; }; }` shapes exactly that way).
+ *
+ * A `(ref null $__fn_instance_meta)` cannot collide with anything: the type is
+ * never produced by user source, so no capture can ever hold it. That makes the
+ * family `ref.test` a sound discriminator by construction rather than by a
+ * probabilistic argument about field layouts.
+ *
+ * ### Why `name` is an `externref`, not a `(ref $anystr)`
+ * Type-section rec groups are computed from forward references
+ * (`computeRecGroups` in emit/binary.ts): a type that references a
+ * HIGHER-indexed type drags every type in between into one rec group, which
+ * would perturb the canonical runtime rec-group boundary (#2514). This struct
+ * therefore references NO other type, so it is always a singleton group
+ * wherever it is minted. `externref` is also exactly what
+ * `__builtinfn_get_meta` returns, so the reflective read is a bare
+ * `struct.get` with no conversion.
+ *
+ * ## Scope
+ * Standalone only. In gc/host mode the `env::__extern_*` imports own the
+ * reflective property path, so the extra field would be pure cost; every entry
+ * point here is a no-op unless `ctx.standalone`.
+ */
+import type { FieldDef, Instr, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { ts } from "../ts-api.js";
+import { expectedArgumentCountOfParams } from "./function-expected-argument-count.js";
+import { nativeStringLiteralInstrs } from "./native-string-literals.js";
+import { EVAL_SOURCE_FILENAME } from "./expressions/eval-source.js";
+
+/** The closure-struct slot name. `$`-prefixed to stay out of name enumeration. */
+export const FN_META_FIELD = "$fnmeta";
+
+/** Field 0 of `$__fn_instance_meta` — §10.2.9 `name`, already an `externref`. */
+export const FN_META_NAME_FIELD_IDX = 0;
+/** Field 1 of `$__fn_instance_meta` — §15.1.5 ExpectedArgumentCount. */
+export const FN_META_LENGTH_FIELD_IDX = 1;
+
+/** §10.2.9 `name` + §15.1.5 `length` for one function DECLARATION. */
+export interface FnInstanceMeta {
+  readonly name: string;
+  readonly length: number;
+}
+
+/**
+ * Mint (idempotently) `$__fn_instance_meta`. Referenced by every `$fnmeta`
+ * slot, so it must exist BEFORE the first closure struct that carries one —
+ * which it does by construction: the only callers are the slot factories below,
+ * and they run while the closure struct's field list is still being built.
+ */
+export function ensureFnInstanceMetaStructType(ctx: CodegenContext): number {
+  const existing = ctx.fnInstanceMetaStructTypeIdx;
+  if (existing !== undefined) return existing;
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "__fn_instance_meta_struct",
+    fields: [
+      // §10.2.9 `name`, already in the representation `__builtinfn_get_meta`
+      // hands back — no conversion at the read.
+      { name: "name", type: { kind: "externref" }, mutable: false },
+      // §15.1.5 ExpectedArgumentCount. Deliberately NOT `$arity`: that slot is
+      // the dispatch arity `closure-exports.ts` pads under-applied calls to.
+      { name: "length", type: { kind: "i32" }, mutable: false },
+    ],
+  });
+  ctx.fnInstanceMetaStructTypeIdx = typeIdx;
+  return typeIdx;
+}
+
+/** The `$fnmeta` field definition. Nullable so a fill failure degrades to "no metadata". */
+export function fnMetaField(ctx: CodegenContext): FieldDef {
+  return {
+    name: FN_META_FIELD,
+    type: {
+      kind: "ref_null",
+      typeIdx: ensureFnInstanceMetaStructType(ctx),
+    } as ValType,
+    mutable: false,
+  };
+}
+
+/**
+ * The lazily-initialized module global holding the ONE metadata instance for
+ * `meta`, and the instruction sequence that yields it.
+ *
+ * The null-guard lives in a FUNCTION BODY rather than the global's initializer
+ * for the reason `pushBuiltinFnSingletonValueInstrs` documents: a native string
+ * literal materializes as `global.get <interned>` today but as `call <helper>`
+ * once it exceeds `array.new_fixed`'s limit, and the late-import shifters walk
+ * function bodies, never `ctx.mod.globals[].init`. Keeping the sequence in a
+ * shift-covered array makes the choice of materialization irrelevant here.
+ */
+function pushFnInstanceMetaValueInstrs(ctx: CodegenContext, meta: FnInstanceMeta): Instr[] {
+  const structTypeIdx = ensureFnInstanceMetaStructType(ctx);
+  // `<length>:<name>` — unambiguous for ANY name, because `length` is
+  // digits-only, so the first `:` is always the separator even when the name
+  // itself contains one (a computed key like `{ "a:b": function () {} }`).
+  const key = `${meta.length}:${meta.name}`;
+  const cache = (ctx.fnInstanceMetaGlobalByKey ??= new Map<string, number>());
+  let globalIdx = cache.get(key);
+  if (globalIdx === undefined) {
+    globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: `__fn_instance_meta_${cache.size}`,
+      type: { kind: "ref_null", typeIdx: structTypeIdx },
+      mutable: true,
+      init: [{ op: "ref.null", typeIdx: structTypeIdx }],
+    });
+    cache.set(key, globalIdx);
+  }
+  return [
+    { op: "global.get", index: globalIdx },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...nativeStringLiteralInstrs(ctx, meta.name),
+        { op: "extern.convert_any" },
+        { op: "i32.const", value: meta.length },
+        { op: "struct.new", typeIdx: structTypeIdx },
+        { op: "global.set", index: globalIdx },
+      ],
+    },
+    { op: "global.get", index: globalIdx },
+  ];
+}
+
+/**
+ * Register `typeIdx` as a metadata FAMILY: a closure struct type whose field
+ * `fieldIdx` is a `$fnmeta` slot. `fillFunctionInstanceProps` emits one
+ * `ref.test` arm per registered family, so every family must be registered
+ * before finalize (they all are — minting happens during expression codegen).
+ */
+export function registerFnMetaFamily(ctx: CodegenContext, typeIdx: number, fieldIdx: number): void {
+  (ctx.fnInstanceMetaFamilies ??= new Map<number, number>()).set(typeIdx, fieldIdx);
+}
+
+/**
+ * The `$fnmeta`-carrying SUBTYPE of a SHARED closure struct, minted once per
+ * base and cached.
+ *
+ * Only needed where the base is shared across functions — the per-signature
+ * funcref wrapper and its constructible variant. A capture subtype is already
+ * per-function (`__fn_cap_<name>_<n>`), so it grows the slot in its own field
+ * list instead and never comes here.
+ *
+ * The subtype redeclares the base's fields verbatim, so every existing
+ * `struct.get` by index (captures, `__constructible`, the closure header) is
+ * unchanged, and every `ref.cast` to the base still succeeds. `closureInfo` is
+ * re-registered under the new index so the static closure-call path and
+ * reflective `.call` recovery resolve it exactly like the base.
+ */
+export function ensureFnMetaSubtype(ctx: CodegenContext, baseTypeIdx: number): number | undefined {
+  if (!ctx.standalone) return undefined;
+  const cache = (ctx.fnInstanceMetaSubtypeByBase ??= new Map<number, number>());
+  const existing = cache.get(baseTypeIdx);
+  if (existing !== undefined) return existing;
+
+  const base = ctx.mod.types[baseTypeIdx];
+  if (base === undefined || base.kind !== "struct") return undefined;
+  // Mint the metadata struct BEFORE the subtype so the `$fnmeta` field's type
+  // index is a backward reference (see the module header on rec groups).
+  const field = fnMetaField(ctx);
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: `${base.name}__fnmeta`,
+    fields: [...base.fields, field],
+    superTypeIdx: baseTypeIdx,
+  });
+
+  const baseInfo = ctx.closureInfoByTypeIdx.get(baseTypeIdx);
+  if (baseInfo)
+    ctx.closureInfoByTypeIdx.set(typeIdx, {
+      ...baseInfo,
+      structTypeIdx: typeIdx,
+    });
+  // IsConstructor is a `ref.test` over the registered constructible types; the
+  // subtype passes the base's test, but reflect-construct-native.ts enumerates
+  // the set by index, so record it there too when the base is constructible.
+  if (ctx.constructibleClosureTypeIdxs.has(baseTypeIdx)) ctx.constructibleClosureTypeIdxs.add(typeIdx);
+  registerFnMetaFamily(ctx, typeIdx, base.fields.length);
+  cache.set(baseTypeIdx, typeIdx);
+  return typeIdx;
+}
+
+/**
+ * Is `decl` the synthesized declaration `eval-inline.ts` parses for a
+ * `new Function(…)` / `eval(…)` splice? Detected by the SOURCE FILE the node
+ * came from rather than by its name text: the name is a generated
+ * `__new_function_<n>`, and matching that string would couple this module to a
+ * template literal in another file.
+ */
+function isSynthesizedEvalDeclaration(decl: ts.Node): boolean {
+  const file = decl.getSourceFile?.();
+  return file !== undefined && file.fileName === EVAL_SOURCE_FILENAME;
+}
+
+/**
+ * §10.2.9 SetFunctionName for a function-like declaration, as far as it is
+ * statically decidable at the closure's mint site.
+ *
+ * A named declaration/expression uses its own name. An ANONYMOUS function or
+ * arrow inherits the binding it is being defined into (NamedEvaluation) — the
+ * variable, property, binding element or simple assignment target. Anything
+ * else answers `""`, which is also the spec answer for a genuinely anonymous
+ * function value, so a miss here is a correct-but-imprecise `""` rather than a
+ * wrong name.
+ */
+export function fnInstanceNameOf(decl: ts.Node): string {
+  if (
+    (ts.isFunctionDeclaration(decl) || ts.isFunctionExpression(decl) || ts.isClassDeclaration(decl)) &&
+    decl.name !== undefined
+  ) {
+    // §20.2.1.1.1: a function built by `new Function(…)` is named `"anonymous"`.
+    // `eval-inline.ts` splices one in as a real parsed declaration under a
+    // SYNTHESIZED name (`__new_function_<n>`, unique per site), so reading
+    // `decl.name.text` here would publish a compiler-internal identifier as an
+    // observable property value — measured on `built-ins/Function/instance-name.js`,
+    // which went from reporting `undefined` to reporting `__new_function_474`.
+    if (isSynthesizedEvalDeclaration(decl)) return "anonymous";
+    return decl.name.text;
+  }
+  if (ts.isClassExpression(decl) && decl.name !== undefined) return decl.name.text;
+
+  // NamedEvaluation: the anonymous definition takes the name of what it is
+  // being bound to. Only the syntactic forms that carry an identifier/literal
+  // key are resolvable here; computed keys are runtime values.
+  //
+  // Parentheses are TRANSPARENT to NamedEvaluation — the CoverParenthesized
+  // production keeps `var cover = (function () {});` anonymous, so the binding
+  // name still applies (`language/*/fn-name-cover.js`). A COMMA expression is
+  // not: `var xCover = (0, function () {});` is not an anonymous function
+  // DEFINITION, and those files assert the name is NOT taken. Walking only
+  // through `ParenthesizedExpression` keeps the two apart.
+  let node: ts.Node = decl;
+  while (node.parent !== undefined && ts.isParenthesizedExpression(node.parent)) node = node.parent;
+  const parent = node.parent as ts.Node | undefined;
+  if (parent === undefined) return "";
+  if ((ts.isVariableDeclaration(parent) || ts.isBindingElement(parent)) && parent.initializer === node) {
+    return ts.isIdentifier(parent.name) ? parent.name.text : "";
+  }
+  if (ts.isPropertyAssignment(parent) && parent.initializer === node) {
+    const key = parent.name;
+    if (ts.isIdentifier(key) || ts.isStringLiteral(key) || ts.isNumericLiteral(key)) return key.text;
+    return "";
+  }
+  if (ts.isPropertyDeclaration(parent) && parent.initializer === node) {
+    const key = parent.name;
+    return ts.isIdentifier(key) || ts.isStringLiteral(key) ? key.text : "";
+  }
+  if (
+    ts.isBinaryExpression(parent) &&
+    parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    parent.right === node &&
+    ts.isIdentifier(parent.left)
+  ) {
+    return parent.left.text;
+  }
+  return "";
+}
+
+/**
+ * The metadata a function-like declaration must reflect, or `undefined` when
+ * this module has nothing to add (not standalone, or `decl` is not a function
+ * with a parameter list).
+ *
+ * `length` comes from the SAME §15.1.5 walk the static `<fn>.length` fold uses
+ * (#4436's `function-expected-argument-count.ts`) — one statement of one
+ * observable value, so the fold and the descriptor cannot disagree.
+ */
+export function fnInstanceMetaOf(ctx: CodegenContext, decl: ts.Node | undefined): FnInstanceMeta | undefined {
+  if (!ctx.standalone || decl === undefined) return undefined;
+  if (!ts.isFunctionLike(decl)) return undefined;
+  // A method/accessor's own `name` has spec subtleties (`get `/`set ` prefixes,
+  // symbol keys) that this slice does not measure; declarations, function
+  // expressions and arrows are the buckets #4436 left open.
+  if (
+    !ts.isFunctionDeclaration(decl) &&
+    !ts.isFunctionExpression(decl) &&
+    !ts.isArrowFunction(decl) &&
+    !ts.isMethodDeclaration(decl)
+  ) {
+    return undefined;
+  }
+  return {
+    name: fnInstanceNameOf(decl),
+    length: expectedArgumentCountOfParams(decl.parameters),
+  };
+}
+
+/**
+ * The `$fnmeta` field + its `struct.new` operand for `decl`, or `undefined`
+ * when the declaration carries no resolvable metadata.
+ *
+ * The two halves are returned TOGETHER on purpose: a field added without its
+ * operand (or the reverse) is a `struct.new` arity mismatch, which the emitter
+ * rejects loudly — but only if both live at one call site. Splitting them
+ * across two helpers is how a missed allocation site becomes a silent
+ * mis-typed push.
+ */
+export function fnMetaSlot(
+  ctx: CodegenContext,
+  decl: ts.Node | undefined,
+): { field: FieldDef; init: Instr[]; meta: FnInstanceMeta } | undefined {
+  const meta = fnInstanceMetaOf(ctx, decl);
+  if (meta === undefined) return undefined;
+  return {
+    field: fnMetaField(ctx),
+    init: pushFnInstanceMetaValueInstrs(ctx, meta),
+    meta,
+  };
+}

--- a/src/codegen/function-instance-props.ts
+++ b/src/codegen/function-instance-props.ts
@@ -84,23 +84,22 @@
  * Filtering the marker here would make the first case answer `$arity` again and
  * silently un-delete the property.
  *
- * ## Scope — `length` only, and why `name` is NOT here
- * `$arity` is a per-INSTANCE field, so `length` needs no per-function type.
- * `name` has no runtime carrier on a user closure and cannot be added without
- * either a new header field (which changes gc-mode bytes — #2896's standing
- * constraint) or a per-function meta subtype. Left as a measured residual on
- * the issue rather than half-answered here.
+ * ## Scope — `name` and the exact `length` arrived in #4437
+ * #4436 shipped `length` only, answered from `$arity`, and left two measured
+ * residuals: `name` had no runtime carrier at all, and `$arity` is the DECLARED
+ * FORMAL COUNT, which diverges from §15.1.5 whenever a parameter is defaulted or
+ * optional (`function f(x = 42) {}` — `$arity` 1, spec `length` 0). `$arity`
+ * could not simply be re-pointed at the spec value: `closure-exports.ts`'s
+ * under-application widening dispatches at `max(n, $arity)` and would stop
+ * padding omitted arguments.
  *
- * ## Known value divergence (documented, not hidden)
- * `$arity` is the **declared formal count**, which equals §15.1.5
- * ExpectedArgumentCount for every parameter list without a defaulted or
- * optional parameter (rest is already excluded at the allocation site, which
- * pushes `max(0, params - 1)`). For `function f(x = 42) {}` the spec `length`
- * is 0 while `$arity` is 1. `$arity` cannot simply be re-pointed at the spec
- * value: `closure-exports.ts`'s under-application widening dispatches at
- * `max(n, $arity)` and would stop padding omitted arguments. The exact-value
- * fix needs the per-function meta subtype above; it is tracked as this issue's
- * residual.
+ * #4437 closes both with a second, independent carrier — a `$fnmeta` slot on
+ * the closure struct pointing at a per-DECLARATION `{name, length}` struct
+ * (`function-instance-meta.ts` mints it, `function-instance-meta-arms.ts` reads
+ * it). The arms below consult it FIRST and fall back to `$arity` for `length`,
+ * so a closure whose mint site does not carry the slot keeps exactly #4436's
+ * answer rather than losing the property. `name` has no fallback: without the
+ * slot it declines, which is "the property is absent" — never a wrong name.
  */
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
@@ -108,11 +107,24 @@ import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js
 import { addFuncType } from "./registry/types.js";
 import { CLOSURE_ARITY_FIELD_IDX, getFuncRefWrapperRootTypeIdx } from "./closures/funcref-wrapper-types.js";
 import { nativeStringLiteralInstrs } from "./native-string-literals.js";
+// (#4437) the per-declaration `name` / §15.1.5 `length` carrier — read surface
+import { fnMetaArms, type FnMetaArms } from "./function-instance-meta-arms.js";
 
 /** `(externref fn, externref key) -> i32` — 1 iff fn's bag holds ANY entry for key. */
 export const FNINST_BAG_OWNS = "__fninst_bag_owns";
 /** `(externref fn, externref key) -> i32` — 1 iff the #4098 marker was written. */
 export const FNINST_TOMBSTONE = "__fninst_tombstone";
+/**
+ * (#4437) `(externref fn) -> externref` — fn's `$__fn_instance_meta` struct as
+ * an externref, or null when fn carries no `$fnmeta` slot.
+ *
+ * Reserved with an `externref` result rather than `(ref null
+ * $__fn_instance_meta)` on purpose: the metadata struct type is minted lazily at
+ * the first closure that carries the slot, which is long after this reservation,
+ * and a reserved func type cannot name a type that does not exist yet. The two
+ * consumers cast back — one `any.convert_extern` + `ref.cast` each.
+ */
+export const FNINST_META = "__fninst_meta";
 
 const CLOSURE_BAG_LOOKUP = "__closure_bag_lookup";
 const CLOSURE_BAG_ENSURE = "__closure_bag_ensure";
@@ -155,6 +167,20 @@ export function reserveFunctionInstanceProps(ctx: CodegenContext): void {
 
   reserve(FNINST_BAG_OWNS);
   reserve(FNINST_TOMBSTONE);
+
+  // (#4437) The per-declaration metadata resolver — one param, externref result.
+  {
+    const typeIdx = addFuncType(ctx, [EXT], [EXT], `$${FNINST_META}_type`);
+    const funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, {
+      name: FNINST_META,
+      typeIdx,
+      locals: [],
+      body: [{ op: "ref.null.extern" }],
+      exported: false,
+    });
+    ctx.funcMap.set(FNINST_META, funcIdx);
+  }
 }
 
 /**
@@ -220,7 +246,11 @@ export function fillFunctionInstanceProps(ctx: CodegenContext): void {
       { op: "call", funcIdx: lookupIdx },
       { op: "local.tee", index: 2 },
       { op: "ref.is_null" },
-      { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
       // The bag is a `__new_plain_object` product; screen before the cast so a
       // future substrate change can never trap inside a helper that must not
       // throw (#3468 S1 discipline).
@@ -228,7 +258,11 @@ export function fillFunctionInstanceProps(ctx: CodegenContext): void {
       { op: "any.convert_extern" },
       { op: "ref.test", typeIdx: objectTypeIdx },
       { op: "i32.eqz" },
-      { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
       { op: "local.get", index: 2 },
       { op: "any.convert_extern" },
       { op: "ref.cast", typeIdx: objectTypeIdx },
@@ -251,7 +285,11 @@ export function fillFunctionInstanceProps(ctx: CodegenContext): void {
       { op: "call", funcIdx: ensureIdx },
       { op: "local.tee", index: 2 },
       { op: "ref.is_null" },
-      { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      },
       { op: "local.get", index: 2 }, // receiver = the bag
       { op: "local.get", index: 1 }, // key
       { op: "local.get", index: 2 }, // value = the bag  ← the marker
@@ -271,14 +309,14 @@ export function fillFunctionInstanceProps(ctx: CodegenContext): void {
   ];
 
   /**
-   * `i32`: is param 1 the string `"length"`?
+   * `i32`: is param 1 the string `key`?
    *
    * Classified HERE rather than read from `fillBuiltinFnMeta`'s shared
    * `isLen` local (5): that preamble returns early when the module
    * materialized no builtin closure at all (`metaMap.size === 0`), which would
    * leave local 5 unset and silently disable this arm for exactly the programs
-   * that have only user functions. A non-string key can never be `"length"`,
-   * so the `ref.test` guard also keeps the flatten/compare off every
+   * that have only user functions. A non-string key can never be `"length"` or
+   * `"name"`, so the `ref.test` guard also keeps the flatten/compare off every
    * numeric-key read.
    *
    * A FACTORY (fresh `Instr` objects per call): the same shape goes into two
@@ -286,7 +324,7 @@ export function fillFunctionInstanceProps(ctx: CodegenContext): void {
    * double-remap on a later import shift (see
    * `reference_shared_instr_object_dce_double_remap`).
    */
-  const keyIsLength = (): Instr[] => [
+  const keyIs = (key: string): Instr[] => [
     { op: "local.get", index: 1 },
     { op: "any.convert_extern" },
     { op: "ref.test", typeIdx: anyStrTypeIdx },
@@ -299,12 +337,13 @@ export function fillFunctionInstanceProps(ctx: CodegenContext): void {
         { op: "ref.cast", typeIdx: anyStrTypeIdx },
         { op: "call", funcIdx: strFlattenIdx },
         { op: "ref.as_non_null" },
-        ...nativeStringLiteralInstrs(ctx, "length"),
+        ...nativeStringLiteralInstrs(ctx, key),
         { op: "call", funcIdx: strEqualsIdx },
       ],
       else: [{ op: "i32.const", value: 0 }],
     },
   ];
+  const keyIsLength = (): Instr[] => keyIs("length");
 
   /** `!__fninst_bag_owns(param0, param1)` — the bag has not taken the key over. */
   const bagFree = (): Instr[] => [
@@ -315,10 +354,10 @@ export function fillFunctionInstanceProps(ctx: CodegenContext): void {
   ];
 
   /**
-   * The shared `(receiver is a closure) && (key is "length") && (bag free)`
+   * The shared `(receiver is a closure) && (key is `key`) && (bag free)`
    * guard, wrapping `then`. `anyLocal` receives `any.convert_extern(param0)`.
    */
-  const closureLengthArm = (anyLocal: number, then: Instr[]): Instr[] => [
+  const closureKeyArm = (anyLocal: number, key: string, then: Instr[]): Instr[] => [
     { op: "local.get", index: 0 },
     { op: "any.convert_extern" },
     { op: "local.set", index: anyLocal },
@@ -326,27 +365,68 @@ export function fillFunctionInstanceProps(ctx: CodegenContext): void {
     {
       op: "if",
       blockType: { kind: "empty" },
-      then: [...keyIsLength(), ...bagFree(), { op: "i32.and" }, { op: "if", blockType: { kind: "empty" }, then }],
+      then: [...keyIs(key), ...bagFree(), { op: "i32.and" }, { op: "if", blockType: { kind: "empty" }, then }],
     },
   ];
+  const closureLengthArm = (anyLocal: number, then: Instr[]): Instr[] => closureKeyArm(anyLocal, "length", then);
 
-  // ── generic arm: __builtinfn_get_meta(fn, "length") → box_number($arity) ──
-  // Registered locals: 2 = any, 3 = fkey, 4 = isName, 5 = isLen. Only 2 is
-  // touched here, and `fillBuiltinFnMeta`'s preamble re-sets it in front.
+  // (#4437) `meta.present(L)` leaves `__fninst_meta(fn)` in local L and yields
+  // the i32 "is present" flag, so the `name` arm and the exact-`length` arm ask
+  // the same question once. Read surface: function-instance-meta-arms.ts.
+  const meta = fnMetaArms(ctx);
+  meta.fillResolver(setFn);
+
+  // ── generic arm: __builtinfn_get_meta(fn, "length"|"name") ───────────────
+  // Registered locals: 2 = any, 3 = fkey, 4 = isName, 5 = isLen, 6 = fnmeta
+  // (#4437). Only 2 and 6 are touched here; `fillBuiltinFnMeta`'s preamble
+  // re-sets 2 in front. `length` prefers the `$fnmeta` §15.1.5 value and falls
+  // back to `$arity` (see the module header for why they are two numbers);
+  // `name` has NO fallback, so a slot-less closure declines — "absent", never a
+  // wrong name. Answering `name` here also makes the write REFUSAL correct for
+  // free: `buildBuiltinFnSetRefusalArm` refuses any `__extern_set` whose key
+  // `get_meta` claims, which is §10.2.8's `writable: false`.
   const getMetaFn = ctx.mod.functions.find((f) => f.name === "__builtinfn_get_meta");
   if (getMetaFn) {
     getMetaFn.body.splice(
       0,
       0,
       ...closureLengthArm(2, [
+        ...(meta.available
+          ? ([
+              ...meta.present(6),
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [...meta.boxedLength(6, boxNumIdx), { op: "return" }],
+              },
+            ] satisfies Instr[])
+          : []),
         { op: "local.get", index: 2 },
         { op: "ref.cast", typeIdx: rootIdx },
-        { op: "struct.get", typeIdx: rootIdx, fieldIdx: CLOSURE_ARITY_FIELD_IDX },
+        {
+          op: "struct.get",
+          typeIdx: rootIdx,
+          fieldIdx: CLOSURE_ARITY_FIELD_IDX,
+        },
         { op: "f64.convert_i32_s" },
         { op: "call", funcIdx: boxNumIdx },
         { op: "return" },
       ]),
     );
+    if (meta.available) {
+      getMetaFn.body.splice(
+        0,
+        0,
+        ...closureKeyArm(2, "name", [
+          ...meta.present(6),
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [...meta.name(6), { op: "return" }],
+          },
+        ]),
+      );
+    }
   }
 
   // ── __builtinfn_gopd's get_meta→descriptor prologue, when #2896 won't ─────
@@ -361,100 +441,172 @@ export function fillFunctionInstanceProps(ctx: CodegenContext): void {
   // true. Measured: that split is precisely what the first cut of this module
   // produced. Splicing here only when #2896 will not is what keeps the two
   // surfaces consistent without emitting the prologue twice.
+  spliceGopdPrologue(ctx);
+
+  // ── generic arm: __builtinfn_delete(fn, "length"|"name") → tombstone, 1 ──
+  //
+  // Deletability ships with visibility (#4010's ordering law): `propertyHelper`'s
+  // `isConfigurable` is `delete obj[k]; return !hasOwnProperty(obj, k)`, so a
+  // visible-but-undeletable property fails every `verifyProperty` naming
+  // `configurable: true` — which is all of them. `name` is added here in the
+  // same change that makes it visible, for exactly that reason.
+  const tombstoneArm = (): Instr[] => [
+    { op: "local.get", index: 0 },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: tombstoneIdx },
+    // A failed ensure (no bag substrate) must NOT report "handled", or
+    // `delete` would claim success while the property stays visible.
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+    },
+  ];
+  const deleteFn = ctx.mod.functions.find((f) => f.name === "__builtinfn_delete");
+  if (deleteFn) {
+    deleteFn.body.splice(0, 0, ...closureLengthArm(2, tombstoneArm()));
+    if (meta.available) {
+      // Gated on the receiver actually HAVING metadata: a closure with no
+      // `$fnmeta` slot has no `name` own property, and tombstoning a key that
+      // was never visible would take the bag's `name` slot away from a later
+      // `f.name = "x"` expando.
+      deleteFn.body.splice(
+        0,
+        0,
+        ...closureKeyArm(2, "name", [
+          ...meta.present(6),
+          { op: "if", blockType: { kind: "empty" }, then: tombstoneArm() },
+        ]),
+      );
+    }
+  }
+
+  spliceOwnNamesArm(ctx, { meta, isClosure, bagOwnsIdx, objVecPushIdx });
+}
+
+/**
+ * `__builtinfn_gopd`'s `get_meta` → descriptor prologue, spliced only when
+ * `fillBuiltinFnMeta` will NOT run.
+ *
+ * `__getOwnPropertyDescriptor` calls `__builtinfn_gopd`, whose body is otherwise
+ * filled ONLY by `fillBuiltinFnMeta` — and that fill returns early when the
+ * module materialized no builtin closure meta type at all (`metaMap.size === 0`).
+ * A program of nothing but user functions is exactly that case, so
+ * `__builtinfn_gopd` would keep its `ref.null.extern` placeholder and
+ * `gOPD(f, "length")` would answer `undefined` even though `hasOwnProperty`
+ * (which calls `get_meta` DIRECTLY, one level up) answers true. Measured: that
+ * split is precisely what the first cut of #4436 produced. Splicing here only
+ * when #2896 will not is what keeps the two surfaces consistent without emitting
+ * the prologue twice.
+ */
+function spliceGopdPrologue(ctx: CodegenContext): void {
   const metaMap = ctx.builtinFnMetaByTypeIdx;
   const builtinFillWillRun = metaMap !== undefined && metaMap.size > 0;
   const gopdFn = ctx.mod.functions.find((f) => f.name === "__builtinfn_gopd");
   const getMetaFuncIdx = ctx.funcMap.get("__builtinfn_get_meta");
   const createDescIdx = ctx.funcMap.get("__create_descriptor");
-  if (!builtinFillWillRun && gopdFn && getMetaFuncIdx !== undefined && createDescIdx !== undefined) {
-    gopdFn.body.splice(
-      0,
-      0,
-      { op: "local.get", index: 0 },
-      { op: "local.get", index: 1 },
-      { op: "call", funcIdx: getMetaFuncIdx },
-      { op: "local.tee", index: 2 },
-      { op: "ref.is_null" },
-      { op: "i32.eqz" },
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [
-          { op: "local.get", index: 2 },
-          { op: "i32.const", value: FLAG_CONFIGURABLE },
-          { op: "call", funcIdx: createDescIdx },
-          { op: "return" },
-        ],
-      },
-    );
-  }
+  if (builtinFillWillRun || !gopdFn || getMetaFuncIdx === undefined || createDescIdx === undefined) return;
+  gopdFn.body.splice(
+    0,
+    0,
+    { op: "local.get", index: 0 },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: getMetaFuncIdx },
+    { op: "local.tee", index: 2 },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 2 },
+        { op: "i32.const", value: FLAG_CONFIGURABLE },
+        { op: "call", funcIdx: createDescIdx },
+        { op: "return" },
+      ],
+    },
+  );
+}
 
-  // ── generic arm: __builtinfn_delete(fn, "length") → tombstone, 1 ──────────
-  const deleteFn = ctx.mod.functions.find((f) => f.name === "__builtinfn_delete");
-  if (deleteFn) {
-    deleteFn.body.splice(
-      0,
-      0,
-      ...closureLengthArm(2, [
-        { op: "local.get", index: 0 },
-        { op: "local.get", index: 1 },
-        { op: "call", funcIdx: tombstoneIdx },
-        // A failed ensure (no bag substrate) must NOT report "handled", or
-        // `delete` would claim success while the property stays visible.
-        { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 1 }, { op: "return" }] },
-      ]),
-    );
-  }
-
-  // ── generic arm: __builtinfn_push_ownnames(fn, vec) → push "length" ───────
-  // `getOwnPropertyNames` only. for-in / `Object.keys` read `__obj_ordered`
-  // (enumerable-only) and never reach here, which is what keeps `length`
-  // correctly non-enumerable.
-  //
-  // Params are (0 = fn, 1 = vec) and the ONLY registered local is 2 — the vec
-  // parameter must not be clobbered, so the receiver is narrowed into 2.
-  //
-  // ⚠ This arm PUSHES AND FALLS THROUGH — it must NOT return 1. The caller in
-  // `object-runtime-descriptors.ts` reads the result as "this receiver's own
-  // names are COMPLETE" and returns the vector immediately, skipping the
-  // `bagKeysIf` carrier-bag key source directly below it. That is right for a
-  // builtin function value (`name`/`length` are all it has) and wrong for a user
-  // closure, which also carries #3468 expandos: returning 1 here dropped `p`
-  // from `Object.getOwnPropertyNames(f)` after `f.p = 12` (caught by
-  // `issue-4010.test.ts` "function: getOwnPropertyNames includes the expando").
-  // Falling through lets the bag arm append the expandos after `length`, which
-  // is also the correct §10.1.11 creation order.
+/**
+ * `__builtinfn_push_ownnames(fn, vec)` → push `"length"`, then `"name"` when the
+ * receiver carries #4437 metadata.
+ *
+ * `getOwnPropertyNames` only. for-in / `Object.keys` read `__obj_ordered`
+ * (enumerable-only) and never reach here, which is what keeps both properties
+ * correctly non-enumerable. §10.2.x creation order is `length` then `name`, and
+ * the `name` push is gated on the SAME `__fninst_meta` consult `get_meta` uses,
+ * so enumeration and the descriptor cannot disagree about existence.
+ *
+ * Params are (0 = fn, 1 = vec); registered locals are 2 (receiver, narrowed —
+ * the vec parameter must not be clobbered) and 3 (#4437 metadata).
+ *
+ * ⚠ This arm PUSHES AND FALLS THROUGH — it must NOT return 1. The caller in
+ * `object-runtime-descriptors.ts` reads the result as "this receiver's own names
+ * are COMPLETE" and returns the vector immediately, skipping the `bagKeysIf`
+ * carrier-bag key source directly below it. That is right for a builtin function
+ * value (`name`/`length` are all it has) and wrong for a user closure, which also
+ * carries #3468 expandos: returning 1 here dropped `p` from
+ * `Object.getOwnPropertyNames(f)` after `f.p = 12` (caught by
+ * `issue-4010.test.ts` "function: getOwnPropertyNames includes the expando").
+ * Falling through lets the bag arm append the expandos after `length`, which is
+ * also the correct §10.1.11 creation order.
+ */
+function spliceOwnNamesArm(
+  ctx: CodegenContext,
+  deps: {
+    meta: FnMetaArms;
+    isClosure: (anyLocal: number) => Instr[];
+    bagOwnsIdx: number;
+    objVecPushIdx: number | undefined;
+  },
+): void {
+  const { meta, isClosure, bagOwnsIdx, objVecPushIdx } = deps;
   const pushOwnFn = ctx.mod.functions.find((f) => f.name === "__builtinfn_push_ownnames");
-  if (pushOwnFn && objVecPushIdx !== undefined) {
-    pushOwnFn.body.splice(
-      0,
-      0,
-      { op: "local.get", index: 0 },
-      { op: "any.convert_extern" },
-      { op: "local.set", index: 2 },
-      ...isClosure(2),
-      {
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [
-          // Presence is asked with the SAME `"length"` key the arm would push.
-          { op: "local.get", index: 0 },
-          ...nativeStringLiteralInstrs(ctx, "length"),
-          { op: "extern.convert_any" },
-          { op: "call", funcIdx: bagOwnsIdx },
-          { op: "i32.eqz" },
-          {
-            op: "if",
-            blockType: { kind: "empty" },
-            then: [
-              { op: "local.get", index: 1 }, // vec
-              ...nativeStringLiteralInstrs(ctx, "length"),
-              { op: "extern.convert_any" },
-              { op: "call", funcIdx: objVecPushIdx },
-            ],
-          },
-        ],
-      },
-    );
-  }
+  if (!pushOwnFn || objVecPushIdx === undefined) return;
+
+  /** Push `key` into the vec unless the receiver's bag has taken it over. */
+  const pushIfLive = (key: string): Instr[] => [
+    // Presence is asked with the SAME key the arm would push.
+    { op: "local.get", index: 0 },
+    ...nativeStringLiteralInstrs(ctx, key),
+    { op: "extern.convert_any" },
+    { op: "call", funcIdx: bagOwnsIdx },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 1 }, // vec
+        ...nativeStringLiteralInstrs(ctx, key),
+        { op: "extern.convert_any" },
+        { op: "call", funcIdx: objVecPushIdx },
+      ],
+    },
+  ];
+  pushOwnFn.body.splice(
+    0,
+    0,
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.set", index: 2 },
+    ...isClosure(2),
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...pushIfLive("length"),
+        ...(meta.available
+          ? ([
+              ...meta.present(3),
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: pushIfLive("name"),
+              },
+            ] satisfies Instr[])
+          : []),
+      ],
+    },
+  );
 }

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1110,6 +1110,10 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     { name: "fkey", type: { kind: "ref_null", typeIdx: nativeStrTypeIdx } as ValType },
     { name: "isName", type: { kind: "i32" } as ValType },
     { name: "isLen", type: { kind: "i32" } as ValType },
+    // (#4437) local 6 — the `$fnmeta` struct of a user closure, as an externref.
+    // Appended LAST so `fillBuiltinFnMeta`'s by-index reads of 2..5 are
+    // untouched; `fillFunctionInstanceProps` is the only writer.
+    { name: "fnmeta", type: { kind: "externref" } as ValType },
   ];
   if (ctx.standalone) {
     registerNative(
@@ -1137,7 +1141,11 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       "__builtinfn_push_ownnames",
       [{ kind: "externref" }, { kind: "externref" }],
       [{ kind: "i32" }],
-      [{ name: "any", type: { kind: "anyref" } as ValType }],
+      [
+        { name: "any", type: { kind: "anyref" } as ValType },
+        // (#4437) local 3 — the `$fnmeta` struct, gating the `"name"` push.
+        { name: "fnmeta", type: { kind: "externref" } as ValType },
+      ],
       [{ op: "i32.const", value: 0 }],
     );
   }

--- a/tests/issue-4436.test.ts
+++ b/tests/issue-4436.test.ts
@@ -198,22 +198,26 @@ describe("#4436 — `length` is an own property of a function instance", () => {
   });
 });
 
-describe("#4436 — measured residuals (pinned in their CURRENT shape)", () => {
-  it("`name` is NOT yet an own property of a user closure", async () => {
-    // Residual: `name` has no runtime carrier on a user closure. Adding one
-    // needs a per-function meta subtype (see the issue file). The static fold
-    // answers, the reflective surface does not — flip both together.
+// (#4437) These two `it`s were #4436's pinned RESIDUALS — asserted in their
+// then-current (wrong) shape precisely so a future fix would have to come here
+// and change them rather than silently alter behaviour. #4437 is that fix: it
+// gives a user closure a `$fnmeta` slot pointing at a per-declaration
+// `{name, length}` struct, so both now assert the SPEC answer. The full
+// assertions live in `issue-4437.test.ts`; what stays here is the exact pair
+// #4436 pinned, flipped, so the residual's closure is visible from the issue
+// that recorded it.
+describe("#4436 residuals — closed by #4437", () => {
+  it("`name` IS an own property of a user closure (was: absent)", async () => {
     expect(await runStandalone(`function f(){} return f.name === "f" ? 1 : 0;`)).toBe(1);
-    expect(await runStandalone(`function f(){} return f.hasOwnProperty("name") ? 1 : 0;`)).toBe(0);
+    expect(await runStandalone(`function f(){} return f.hasOwnProperty("name") ? 1 : 0;`)).toBe(1);
   });
 
-  it("the reflective `length` VALUE is the formal count for a defaulted parameter", async () => {
-    // Residual: the runtime value reads the `$arity` header slot (declared
-    // formal count), which diverges from §15.1.5 only when a parameter is
-    // defaulted/optional. `$arity` cannot be re-pointed at the spec value —
-    // closure-exports.ts dispatches under-applied calls at `max(n, $arity)`.
-    // The STATIC fold is already correct, which is the divergence.
-    expect(await runStandalone(`function f(x = 42){} return f.length;`)).toBe(0); // static: correct
-    expect(await runStandalone(`function f(x = 42){} var k="length"; return f[k];`)).toBe(1); // dynamic: residual
+  it("the reflective `length` VALUE is §15.1.5, not the formal count (was: `$arity`)", async () => {
+    // The static fold was already correct; the divergence was that the runtime
+    // read answered the `$arity` header slot. `$arity` still holds the DISPATCH
+    // arity — closure-exports.ts pads under-applied calls to `max(n, $arity)` —
+    // so the two values are carried separately rather than one re-pointed.
+    expect(await runStandalone(`function f(x = 42){} return f.length;`)).toBe(0); // static
+    expect(await runStandalone(`function f(x = 42){} var k="length"; return f[k];`)).toBe(0); // dynamic
   });
 });

--- a/tests/issue-4437.test.ts
+++ b/tests/issue-4437.test.ts
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4437) `name` as an own property of a user function instance, and the
+// reflective `length` VALUE as §15.1.5 ExpectedArgumentCount.
+//
+// These are #4436's two measured residuals (R1/R2), which it recorded as ONE
+// slice because they need the SAME substrate. Measured on this branch's base
+// `f5e2fa6` with `--target standalone`:
+//
+//   | read on `function f(a,b){}` / `function g(x=42,y){}` | base | spec |
+//   | ---------------------------------------------------- | ---- | ---- |
+//   | `f["name"]` (dynamic key — what verifyProperty uses)  | undef| "f"  |
+//   | `f.hasOwnProperty("name")`                            | false| true |
+//   | `Object.getOwnPropertyDescriptor(f, "name")`          | undef| desc |
+//   | `Object.getOwnPropertyNames(f)` ∋ "name"              | false| true |
+//   | `g["length"]` (reflective)                            | 2    | 0    |
+//
+// The `length` row is the interesting one: `$arity` (the #3673 closure-header
+// slot #4436 answered from) is the DECLARED FORMAL COUNT, and §15.1.5 is a
+// PREFIX count that stops at the first defaulted/optional parameter. The two are
+// different numbers with different jobs — `closure-exports.ts` widens an
+// under-applied dispatch to `max(n, $arity)`, so lowering `$arity` to the spec
+// value would stop padding omitted arguments. Hence a SECOND carrier rather than
+// a re-pointing, which is why R1 and R2 are one change: the `$fnmeta` slot that
+// gives `name` a home is the same slot that gives `length` an exact value.
+//
+// The tests below assert the surfaces AGAINST EACH OTHER (descriptor value ==
+// dynamic read == static fold), not just against literals — that agreement is
+// the actual invariant, and it is what test262's `propertyHelper.js` checks.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { expectedArgumentCountOfParams } from "../src/codegen/function-expected-argument-count.js";
+import { ts } from "../src/ts-api.js";
+
+/** Compile `body` as the `test()` export and run it host-free. */
+async function runStandalone(body: string): Promise<number> {
+  const source = `export function test(): number { ${body} }`;
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "issue-4437.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")).toBe(true);
+  // Host-free: a standalone module must instantiate against an empty import
+  // object. If this ever needs a host bridge, the arms leaked an import.
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#4437 — `name` is an own property of a user function instance", () => {
+  it("answers the dynamic (runtime-key) read, not just the static fold", async () => {
+    // The static fold already worked on `main`; the reflective read is what
+    // `verifyProperty` uses, because its receiver AND key are parameters.
+    expect(await runStandalone(`function f(a,b){} var k = "name"; return f[k] === "f" ? 1 : 0;`)).toBe(1);
+  });
+
+  it("agrees across hasOwnProperty / gOPD / getOwnPropertyNames / dynamic read", async () => {
+    // One property, five surfaces. Asserted together because the failure mode
+    // #4436 hit was a SPLIT (hasOwnProperty true, gOPD undefined), not an
+    // absence — a single surface passing proves nothing about the others.
+    expect(
+      await runStandalone(`
+        function f(a,b){}
+        var k = "name";
+        var d = Object.getOwnPropertyDescriptor(f, "name");
+        var names = Object.getOwnPropertyNames(f);
+        var inNames = 0;
+        for (var i = 0; i < names.length; i++) { if (names[i] === "name") inNames = 1; }
+        return (f.hasOwnProperty("name") && d !== undefined && d.value === "f" && f[k] === "f" && inNames) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("carries §10.2.8 attributes: non-writable, non-enumerable, configurable", async () => {
+    expect(
+      await runStandalone(`
+        function f(){}
+        var d = Object.getOwnPropertyDescriptor(f, "name");
+        return (d.writable === false && d.enumerable === false && d.configurable === true) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("is DELETABLE, and the delete is observable through hasOwnProperty", async () => {
+    // #4010's ordering law: `propertyHelper`'s `isConfigurable` is
+    // `delete obj[k]; return !hasOwnProperty(obj, k)`. A visible-but-undeletable
+    // property fails every `verifyProperty` naming `configurable: true` — which
+    // is all of them. #4055 v1 shipped visibility without delete and the merge
+    // queue parked it at -684.
+    expect(
+      await runStandalone(`
+        function f(){}
+        delete f.name;
+        return f.hasOwnProperty("name") ? 0 : 1;`),
+    ).toBe(1);
+  });
+
+  it("refuses a write while live (writable:false), and accepts one after delete", async () => {
+    // The refusal is not spelled separately: `buildBuiltinFnSetRefusalArm`
+    // refuses any `__extern_set` whose key `__builtinfn_get_meta` claims, so
+    // making `name` visible made the write non-writable in the same stroke —
+    // and made it writable again after the delete, for free.
+    expect(
+      await runStandalone(`
+        function f(){}
+        f.name = "other";
+        return f.name === "f" ? 1 : 0;`),
+    ).toBe(1);
+    expect(
+      await runStandalone(`
+        function f(){}
+        delete f.name;
+        f.name = "other";
+        var k = "name";
+        return f[k] === "other" ? 1 : 0;`),
+    ).toBe(1);
+    // The DYNAMIC read is deliberate. The static `f.name` fold answers from the
+    // type, not the runtime, so it still says "f" after a delete+rewrite —
+    // measured IDENTICALLY on base for `length` (fold 2, dynamic 5), i.e. a
+    // pre-existing fold-aggressiveness divergence #4436 already had and this
+    // change neither causes nor fixes. Recorded as a residual on the issue.
+  });
+
+  it("does not disturb #3468 expandos on the same function", async () => {
+    expect(
+      await runStandalone(`
+        function f(a){}
+        f.custom = 5;
+        return (f.hasOwnProperty("custom") && f.hasOwnProperty("name") && f.hasOwnProperty("length")
+                && f.custom === 5) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("covers function expressions and arrows via NamedEvaluation", async () => {
+    expect(await runStandalone(`var b = function(){}; var k="name"; return b[k] === "b" ? 1 : 0;`)).toBe(1);
+    expect(await runStandalone(`var a = (p) => p; var k="name"; return a[k] === "a" ? 1 : 0;`)).toBe(1);
+    // A NAMED function expression keeps its own name; the binding is ignored.
+    expect(await runStandalone(`var c = function inner(){}; var k="name"; return c[k] === "inner" ? 1 : 0;`)).toBe(1);
+  });
+
+  it("treats parentheses as transparent but a comma expression as opaque", async () => {
+    // `language/*/fn-name-cover.js`. `(function(){})` is still an anonymous
+    // function DEFINITION so NamedEvaluation applies; `(0, function(){})` is
+    // not, and those files assert the binding name is NOT taken.
+    expect(await runStandalone(`var cover = (function(){}); var k="name"; return cover[k] === "cover" ? 1 : 0;`)).toBe(
+      1,
+    );
+    // A genuinely anonymous function's `name` is `""` — present, but empty; what
+    // the file asserts is that the BINDING name was not taken.
+    expect(
+      await runStandalone(`var xCover = (0, function(){}); var k="name"; return xCover[k] === "xCover" ? 0 : 1;`),
+    ).toBe(1);
+  });
+
+  it("does not leak the compiler's synthesized `new Function` identifier", async () => {
+    // `eval-inline.ts` splices a real parsed declaration named
+    // `__new_function_<n>`. Reading that as the observable `name` published a
+    // compiler-internal identifier: `built-ins/Function/instance-name.js` went
+    // from reporting `undefined` to reporting `__new_function_474`. §20.2.1.1.1
+    // says the answer is `"anonymous"`.
+    expect(await runStandalone(`var k="name"; return (Function())[k] === "anonymous" ? 1 : 0;`)).toBe(1);
+  });
+
+  it("does not shadow a BUILTIN function value's own metadata", async () => {
+    // A #2896 meta struct is itself a funcref-wrapper-root descendant, so the
+    // generic arms `ref.test`-match it too. The builtin arms are spliced in
+    // FRONT and always return, which is what keeps `Array.isArray.name` its own
+    // spec answer rather than a user closure's.
+    expect(
+      await runStandalone(`
+        var g = Array.isArray;
+        var k = "name";
+        return (g[k] === "isArray" && g.hasOwnProperty("name")) ? 1 : 0;`),
+    ).toBe(1);
+  });
+});
+
+describe("#4437 — the reflective `length` is §15.1.5, not the formal count", () => {
+  it("stops at the first defaulted parameter, including for required ones to its right", async () => {
+    // The §15.1.5 prefix rule, on the reflective surface this time. `$arity` for
+    // `g` is 2 (two declared formals) and the spec `length` is 0.
+    expect(await runStandalone(`function g(x = 42, y){} var k="length"; return g[k];`)).toBe(0);
+    expect(await runStandalone(`function g(x, y = 4, z){} var k="length"; return g[k];`)).toBe(1);
+    expect(await runStandalone(`function g(a, b){} var k="length"; return g[k];`)).toBe(2);
+  });
+
+  it("makes the descriptor value, the dynamic read and the static fold agree", async () => {
+    // The three used to disagree: the fold was already §15.1.5 while the
+    // reflective read answered `$arity`. Asserting them against EACH OTHER is
+    // the invariant; asserting each against `0` separately would not catch a
+    // future change that moved all three together but wrongly.
+    expect(
+      await runStandalone(`
+        function g(x = 42, y){}
+        var k = "length";
+        var d = Object.getOwnPropertyDescriptor(g, "length");
+        return (d.value === g.length && g[k] === g.length && g.length === 0) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("keeps `$arity` as the DISPATCH arity — omitted arguments are still padded", async () => {
+    // The reason `$arity` was not simply re-pointed. `closure-exports.ts` widens
+    // an under-applied call to `max(n, $arity)`; if the spec `length` had taken
+    // that slot, `y` would stop being padded and the call would trap or read
+    // garbage. Calling `g(1)` through a dynamic (non-folded) receiver exercises
+    // exactly that path.
+    expect(
+      await runStandalone(`
+        function g(x = 42, y) { return y === undefined ? 7 : 9; }
+        var h = g;
+        return h(1);`),
+    ).toBe(7);
+  });
+
+  it("rest parameters contribute nothing", async () => {
+    expect(await runStandalone(`function r(a, ...rest){} var k="length"; return r[k];`)).toBe(1);
+  });
+
+  it("§15.1.5 is stated ONCE — the walk the fold uses is the walk the slot stores", async () => {
+    // Unit-level companion: both the static fold and the `$fnmeta` slot call
+    // `expectedArgumentCountOfParams`. If a future change gives either its own
+    // copy, this and the agreement test above are what fail.
+    const countOf = (src: string): number => {
+      const file = ts.createSourceFile("t.js", src, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+      const fn = file.statements.find(ts.isFunctionDeclaration);
+      if (!fn) throw new Error("no function declaration in: " + src);
+      return expectedArgumentCountOfParams(fn.parameters);
+    };
+    expect(countOf("function f(x = 42, y) {}")).toBe(0);
+    expect(countOf("function f(x, y = 4, z) {}")).toBe(1);
+    expect(countOf("function f(a, ...rest) {}")).toBe(1);
+  });
+});
+
+describe("#4437 — the carrier itself", () => {
+  it("keeps `name` ABSENT rather than wrong where no slot was minted", async () => {
+    // The `name` arm has no fallback by design: a closure whose mint site does
+    // not carry a `$fnmeta` slot declines, which reads as "the property is
+    // absent" — never a wrong name. `length` DOES fall back to `$arity`, so it
+    // never loses the property #4436 added. Class methods are the live example
+    // of a mint site still outside this slice (see the issue's residuals).
+    expect(
+      await runStandalone(`
+        class C { m(x = 1) {} }
+        var p = C.prototype;
+        return p.m.hasOwnProperty("length") ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("closure identity is preserved — the slot did not fork the value", async () => {
+    // The metadata operand is pushed into the SAME cached singleton the
+    // identity protocol already builds, so `f === f` and sidecar writes still
+    // land on one object. A per-reference `struct.new` would break both.
+    expect(
+      await runStandalone(`
+        function f(){}
+        f.sidecar = 3;
+        var g = f;
+        return (g === f && g.sidecar === 3) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("distinct declarations of the same arity get distinct metadata", async () => {
+    // The metadata GLOBAL is interned by `"<length> <name>"`. Same arity must
+    // therefore NOT be enough to share an entry — only same arity AND same name,
+    // where sharing is unobservable because the struct is immutable.
+    expect(
+      await runStandalone(`
+        function a1(x){} function b1(y){}
+        var k = "name";
+        return (a1[k] === "a1" && b1[k] === "b1" && a1[k] !== b1[k]) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("a function that also has `length` reflects BOTH, from one carrier", async () => {
+    // Both values come out of the same `$fnmeta` struct, so a bug that dropped
+    // the slot would take both down together — asserting them jointly is what
+    // makes that visible.
+    expect(
+      await runStandalone(`
+        function g(x = 42, y){}
+        var kn = "name", kl = "length";
+        return (g[kn] === "g" && g[kl] === 0) ? 1 : 0;`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

Wave 7a of the #4426 ES5-standalone campaign — the R1/R2 slice #4436 left unowned. Full target population (74 corpus `"name should be an own property"` files ∪ 16 `*length-dflt.js`): **0 → 42 pass, zero regressions**; 138/140 closure-heavy controls (both failures identical on base); host/gc lane byte-identical (10-program sha256); 164/164 vitest incl. the new 19-test pin.

Since `$arity` cannot be re-pointed (`closure-exports.ts` widens under-applied dispatch to `max(n, $arity)`), this adds a second carrier: a `$fnmeta` slot referencing a **nominal** `$__fn_instance_meta {externref name; i32 length}` struct, interned per `{name, length}`. The nominal struct is load-bearing: a bare trailing `i32` id canonicalizes to the same WasmGC type as the constructible wrapper (`[func, $arity, $bag, i32]`), so `ref.test` would read `__constructible == 1` as a metadata id — field names don't discriminate, a nominal ref does. New `function-instance-meta.ts` (write side) + `function-instance-meta-arms.ts` (read side); `function-instance-props.ts` extended.

Also fixes a synthesized-identifier leak this surfaced: `Function(src)` values reported `__new_function_<n>` as their name — §20.2.1.1.1 requires `"anonymous"` (detected by source file, not name text).

Residuals R1–R8 recorded with owners in the issue file; R8 (same-named nested function declarations in different scopes alias to one closure value) is flagged as a real correctness bug deserving its own issue.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_