### PR TITLE
feat(codegen): §10.2.2 [[Construct]] through a runtime-eval callable (#4438)

### DIFF
--- a/plan/issues/4438-runtime-eval-callable-construction.md
+++ b/plan/issues/4438-runtime-eval-callable-construction.md
@@ -1,0 +1,317 @@
+---
+id: 4438
+title: "`new <runtime-eval callable>` evaluates to null in standalone — §10.2.2 [[Construct]] through a `Function(src)` value"
+status: done
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+completed: 2026-08-15
+priority: medium
+horizon: m
+feasibility: hard
+model: opus
+reasoning_effort: max
+task_type: defect
+area: runtime-eval
+language_feature: eval
+goal: runtime-eval
+related: [2660, 2916, 2928, 3468, 4172, 4196, 4242, 4307, 4308]
+blocked_by: []
+assignee: ttraenkler/claude-es5-standalone
+# (#4438) The wiring is three call sites (two imports + a fill hook + one retry
+# line + the prototype-seed line); ALL of the logic lives in the new subsystem
+# module `src/codegen/runtime-eval-construct.ts`, which is what the
+# consolidation plan asks for. The +20 lines below are the unavoidable cost of
+# reaching that module from the three places that own the emission points.
+loc-budget-allow:
+  - src/codegen/expressions/eval-inline.ts
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/index.ts
+func-budget-allow:
+  - src/codegen/expressions/new-super.ts::compileNewExpression
+  - src/codegen/index.ts::generateModule
+  - src/codegen/index.ts::generateMultiModule
+---
+
+# #4438 — `new <runtime-eval callable>` evaluated to **null**
+
+Measured during #2660 M3 and recorded there as a blocker with a different
+owner: "`new <Function(src) value>` evaluates to **null** (measured directly:
+`typeof` is `"object"`, the value is `null`)".
+
+## Before-state, measured on this branch's base (`origin/main` f5e2fa6)
+
+`--target standalone`, QuickJS provider linked (`.tmp/p1.mts`, `.tmp/p2.mts` —
+each probe is a test262-shaped file run through `runTest262File`):
+
+| probe | base | branch |
+| --- | --- | --- |
+| `var F = Function("this.prop=1;"); typeof new F()` is `"object"` **and not null** | **FAIL** (null) | **PASS** |
+| `(new F()).prop === 1` | **FAIL** (TypeError on null) | **PASS** |
+| `typeof F.prototype === "object"` | **FAIL** (`undefined`) | **PASS** |
+| `F.prototype.name = "fairy"; F.prototype.name` | **FAIL** (`undefined`) | **PASS** |
+| `F.prototype = {q:5}; var i = new F(); i.q` | **FAIL** (null) | **PASS** |
+| `Object.getPrototypeOf(new F()) === F.prototype` | FAIL (null) | **PASS** |
+| `F.prototype.name="fairy"; (new F()).name` | FAIL (null) | **PASS** |
+| `(new F()).constructor === F` | FAIL (null) | **PASS** |
+| `typeof F === "function"` | PASS | PASS (unchanged) |
+| `F()` returns its value | PASS | PASS (unchanged) |
+| `var o={}; F.call(o); o.prop` | PASS | PASS (unchanged) |
+
+Two independent defects, not one. The second was not in the dispatch and was
+found by measuring the before-state rather than inheriting #2660 M3's note,
+which had verified only the post-WRITE half of `F.prototype`:
+
+1. **`new F()` had no lowering** — it reached the terminal dynamic-`new`
+   fallthrough and emitted `ref.null.extern`.
+2. **`F.prototype` read `undefined`** — a runtime-eval callable had no
+   prototype object at all, so even a correct construct path had nothing to
+   build an instance from.
+
+## Root cause
+
+### Why `new` produced null
+
+`Function(src)` lowers through `emitStandaloneDynamicFunctionRuntime`
+(`eval-inline.ts`) to the provider import `__runtime_new_function`, and the
+result is wrapped in the #4307 AOT-callable **carrier**. At a `new` site the
+callee is an `any`/`Function`-typed binding, so it lands in `new-super.ts`'s
+`resolvesToDynamicAnyCtorValue` arm — the `$__ta_ctor` runtime kind-switch —
+which yields `ref.null.extern` for a value that is not a TypedArray
+constructor. #4196 added a bound-function retry on that null; nothing handled a
+runtime-eval carrier, so it kept the null.
+
+### Why `F.prototype` was `undefined`
+
+Structural, in the provider. `qjsPublish` exposes a QuickJS function as the
+branded `$RuntimeEvalInterpretedCallback` marker whose `target` is an **empty
+`$Object`** created only to carry the box row — and that row is registered
+`qjsPushBoxRow(retained, carrierTarget, exposed, 0)`, mirror flag **0**,
+deliberately unmirrored. QuickJS's real `.prototype` therefore never crosses
+the seam, and the caller-side property-get trampoline
+(`__runtime_eval_get_aot_property`) has arms for `name` / `length` /
+`constructor` only, falling through to a raw `__extern_get` on a foreign
+nominal struct that answers nothing.
+
+## Can the seam express construction? YES — verified, not assumed
+
+The `js2wasm:runtime-eval` ABI has exactly four entries
+(`__runtime_direct_eval`, `__runtime_indirect_eval`, `__runtime_new_function`,
+`__runtime_apply_interpreted`) and **no construct entry**. It does not need
+one. The fourth takes a `thisArg`, and the #4245 inward membrane makes a
+compiled `$Object` receiver writable from inside evaluated code. Probed on the
+BASE, before any code was written:
+
+```js
+var F = Function("this.prop=1; return 9;");
+var o = {}; F.call(o);     // → 9, and o.prop === 1   ✓ PASSES on base
+```
+
+So §10.2.2 decomposes into operations that already work:
+`OrdinaryCreateFromConstructor` (caller-side `__object_create`) + an ordinary
+`[[Call]]` with the fresh object as receiver + the step-13 result rule. **No
+ABI extension, no provider change, no QuickJS artifact rebuild.** The
+analysis-only stop the dispatch allowed for was therefore not taken.
+
+## The fix
+
+New subsystem module `src/codegen/runtime-eval-construct.ts`; three wiring
+sites. The module header carries the full rationale — the load-bearing parts:
+
+### 1. The prototype is minted at the `Function(...)` site, not in the trampoline
+
+§20.2.1.1 always creates an ordinary **constructable** function with a fresh
+`prototype` whose `constructor` is the function, so seeding it at
+`emitStandaloneDynamicFunctionRuntime` is spec-mandated rather than a guess —
+and that site knows it from the SOURCE.
+
+The obvious alternative — vivify `prototype` inside the shared carrier
+property-get trampoline on a key miss — was designed and **rejected**. That
+trampoline also serves carriers wrapping arrows, prototype methods and AOT
+declarations. An arrow must NOT have a `prototype` (§15.3), and an AOT
+declaration already has one (its fnctor global), so a trampoline-side vivify
+would both invent a property that must not exist and mint a SECOND, rival
+prototype object for one that does — the exact split-brain #2660 M3 spent its
+lap removing. Telling the cases apart at runtime needs an `IsConstructor` bit
+on the cross-module marker struct, i.e. an ABI widening. Minting at the
+source-known site costs nothing and is exactly as narrow.
+
+The store is the carrier's own #3468 property **bag** — the same table
+`F.zz = 7` and `F.prototype = {…}` already round-trip through (both verified
+PASSING on base). It is written with `__defineProperty_value`, not
+`__extern_set`, so the attributes are the spec's: `prototype` is
+`{writable:true, enumerable:false, configurable:false}` (§20.2.3.2) and
+`constructor` is `{writable:true, enumerable:false, configurable:true}`
+(§10.2.5). **Enumerability is load-bearing, not decoration** — a bag entry
+written by assignment is enumerable, and `for (var k in F)` would then report
+`prototype`, which `13.2-15-s` enumerates over.
+
+### 2. The driver — `__construct_runtime_eval`, mirroring #4196's `__construct_bound`
+
+```
+__construct_runtime_eval(callee, args) -> externref
+  if callee is not a BRANDED runtime-eval carrier: return null
+  proto = __extern_get(callee, "prototype")        ;; §10.2.2 step 3
+  if proto is not an Object:                 return null
+  self   = __object_create(proto)
+  result = __apply_closure(callee, self, args)     ;; [[Call]] with this=self
+  return IsObject(result) ? result : self          ;; §10.2.2 step 13
+```
+
+**The `proto is not an Object → null` clause is the safety property of the
+whole change, not an oversight.** It is what stops the driver turning a carrier
+around an arrow — or any callable that legitimately has no `prototype` — into a
+silently-wrong constructed object: such a value reads `undefined` there and
+keeps the site's pre-#4438 null, byte-for-byte the same observable outcome as
+today. Only a callable that ACTUALLY has a prototype object constructs, which
+after the seeding above is precisely the `Function(src)` population (plus any
+carrier the user explicitly assigned a `prototype` to, where constructing is
+also correct).
+
+Two traps inherited verbatim from #4196, both re-checked here: the null test in
+the step-13 probe is **separate and first** (`__typeof_object(null)` is 1 by
+design, so folding them would return null from `new` and reinstate this very
+bug); and the fill **declines** unless a `__call_fn_method_<N>` receiver
+dispatcher exists, because without one `__apply_closure` returns its undefined
+sentinel and the driver would hand back an EMPTY instance — worse than the null.
+
+### 3. Reserve-then-fill + byte-neutrality gate
+
+The driver calls `__apply_closure` (filled at finalize) and needs
+`ctx.runtimeEvalAotCallableCarrier` (a `new` site can compile before any
+carrier is minted), so the site reserves an `unreachable` stub and
+`fillRuntimeEvalConstructDriver` supplies the body at finalize — degrading to
+`ref.null.extern`, never a trap, when the module minted no carrier. The retry
+is emitted only in a file that syntactically mentions `eval` or `Function`
+(memoized AST walk, same discipline and the same synthesized-node guard as
+`nodeCanMintBoundFn`), so every other module is untouched.
+
+## Measured after-state
+
+### test262, `--target standalone`, QuickJS engine — the attribution matrix
+
+`language/expressions/instanceof`, all 43 files, `runTest262File`. Four
+configurations, each a full rebuild (compiler bundle + runtime bundle + QuickJS
+adapter) from `.tmp/base/` ↔ `.tmp/new/` file copies:
+
+| configuration | dir | `S15.3.5.3_A2_T5` | `S15.3.5.3_A3_T1` |
+| --- | ---: | --- | --- |
+| base (`origin/main` f5e2fa6) | 24/43 | fail | fail |
+| base **+ #4438 (this change)** | 24/43 | fail | fail |
+| base **+ #4538's M3 instanceof arm alone** | 26/43 | fail | fail |
+| base **+ #4538 + #4438** | **28/43** | **pass** | **pass** |
+
+**Neither change alone flips either target file; together they flip both.**
+That is the honest headline and it is stated first deliberately: measured in
+isolation, this change moves **zero** test262 rows in the two directories the
+dispatch named. It supplies the half #2660 M3's own write-up identified as its
+blocker ("`new <runtime-eval callable>` → null, plus `FACTORY.prototype.type =
+1` needs a vivified prototype on a value with no compile-time global"); #4538
+supplies the other half (the `else` arm in `native-dynamic-instanceof.ts` that
+lets a non-`$Object` callable carrier reach the own-`prototype` read).
+
+The third row is a **counterfactual run**, not an inference: #4538's arm was
+reproduced locally on the base, measured, and reverted (`.tmp/base/
+native-dynamic-instanceof.ts`). `native-dynamic-instanceof.ts` is **not touched
+by this branch** — that file is #4538's live scope and duplicating it would
+merge-conflict.
+
+### Zero regressions
+
+Both named directories are **line-for-line identical** between base and branch
+(`diff` of the per-file status sweeps; the only differing line is the runner's
+adapter-key banner):
+
+| directory | base | branch |
+| --- | ---: | ---: |
+| `language/expressions/instanceof` (43) | 24 | 24 |
+| `language/statements/function` `13.2-*` (33) | 23 | 23 |
+
+The ten still-failing `13.2-*` files were read: `13.2-5-s`, `13.2-6-s`,
+`13.2-13-s`, `13.2-14-s`, `13.2-17-*`, `13.2-18-*` are the **strict-poison**
+family (`foo.caller` / `foo.arguments` must throw TypeError) — a different
+defect with a different owner, not construction.
+
+### Suites
+
+`issue-1164-es5-eval-slice` + `es5-standalone-instanceof`: **49 passed**.
+`issue-2928` · `issue-4307-closure-carrier-wrap` · `issue-4196` ·
+`issue-3981-standalone-construct-function-value` · `issue-3468-closure-own-props`
+· `fn-constructor` · `new-function-noop` · `es5-standalone-this-and-construct`:
+green. `tests/new-non-constructor.test.ts` fails IDENTICALLY on base — a broken
+import path (`Cannot find module '../../src/index.js'`), pre-existing on main
+and unrelated. New: `tests/issue-4438-runtime-eval-construct.test.ts` (5 cases,
+3 of them refusal pins that must hold in both directions).
+
+`tests/issue-2660-m3-closure-prototype-edge.test.ts` — named in the dispatch —
+does not exist on this base; it arrives with #4538.
+
+## The one place the fix is INCOMPLETE, found by probing past the target files
+
+Making construction work at all exposed a second question the null was hiding:
+**which prototype objects the instance can actually inherit through.** Measured
+(`.tmp/p4.mts`, `.tmp/p5.mts`, `.tmp/p6.mts`):
+
+| how `F.prototype` got its value | `(new F()).k` |
+| --- | --- |
+| the #4438 seeded object, written via `F.prototype.k = v` | **5** ✓ |
+| `F.prototype = {}` then `F.prototype.k = v` | **5** ✓ |
+| `F.prototype = { k: v }` (literal WITH inline properties) | `undefined` ✗ |
+| `var p = { k: v }; F.prototype = p` | `undefined` ✗ |
+
+The first hypothesis — "an object literal with inline properties is a closed
+typed struct the dynamic `$proto` walk cannot read" — was **tested and is
+WRONG**. With no eval anywhere, `var p = {q:5}; var k = "q"; p[k]`,
+`Object.create(p)[k]` and `G.prototype = {q:5}; (new G()).q` on an AOT fnctor
+all answer **5**. So the literal is readable dynamically AND usable as an
+`Object.create` prototype; what fails is specifically that object arriving at
+`__object_create` through the CARRIER BAG round-trip. The mechanism is not
+identified and is deliberately not guessed at here.
+
+**This is not a regression, and the direction is worth naming:** on base every
+one of those four programs produced `null` and a hard null-access TypeError on
+the read. Two of the four now work; the other two answer `undefined` instead of
+throwing — quieter, but strictly closer to spec than a null `new`.
+
+## Residuals, with owners
+
+- **`instance instanceof FACTORY` / the `F.prototype = void 0` TypeError** —
+  needs #4538 (#2660 M3). Measured above; not this branch's file.
+- **The `13.2-*` strict-poison family** (`foo.caller` / `foo.arguments` must
+  throw) — unrelated defect, unowned here.
+- **Caller-side and QuickJS-side `F.prototype` are DIFFERENT objects.** Inside
+  evaluated code `F.prototype` is QuickJS's own; the compiled side sees the
+  seeded one. The caller-side view is self-consistent (identity, inherited
+  reads, `getPrototypeOf`, `constructor` all hold), which is what the ES5
+  population exercises, but a program that sets `F.prototype.x` from compiled
+  code and reads it from inside a later `eval` will not see it. Closing that
+  means publishing QuickJS's real prototype as a mirrored box, which trades the
+  split for a carrier-vs-marker identity break on `instance.constructor === F`
+  — strictly worse for this population. Owner: the runtime-eval seam (#4245).
+- **Only the bare-identifier dynamic-`new` site is wired.**
+  `new (Function("…"))()` and `new obj.f()` reach different dispatch arms and
+  keep their existing behaviour.
+- **`hasOwnProperty(F, "prototype")`** answered `false` on base; it is `true` on
+  the branch as a side effect of the bag write (re-measured, not assumed).
+  Correct, and noted because #2660 M3's write-up cited the post-write behaviour
+  of this same probe.
+- **The bag-round-tripped prototype object** above — inherited reads miss when
+  `F.prototype` is REPLACED by an object that already carries properties. Owner:
+  unassigned; it is a `$proto`-linkage question (#4172 / #2660 territory), not a
+  construct-lowering one, and the driver is doing exactly what
+  `__construct_bound` (#4196) does at the same step.
+
+## Gates
+
+`typecheck` green. `check:loc-budget` / `check:func-budget` require the
+allowances granted in this file's frontmatter — three wiring files, +20 lines
+total, all of the logic in the new subsystem module. `check:oracle-ratchet`: the
+new module asks no type questions at all (zero raw-checker queries).
+
+## Files
+
+- `src/codegen/runtime-eval-construct.ts` (new)
+- `src/codegen/expressions/eval-inline.ts` — §20.2.1.1 prototype seed
+- `src/codegen/expressions/new-super.ts` — the null retry, chained after #4196's
+- `src/codegen/index.ts` — two fill hooks (single-module + multi-module finalize)
+- `tests/issue-4438-runtime-eval-construct.test.ts` (new)

--- a/plan/issues/4439-reflective-string-match-search-dynamic-regexp.md
+++ b/plan/issues/4439-reflective-string-match-search-dynamic-regexp.md
@@ -1,0 +1,75 @@
+---
+id: 4439
+title: "Reflective String.prototype.match/search + dynamic-pattern residual — borrowed-method and runtime-pattern regexp shapes in standalone"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: regexp-string-methods
+goal: standalone-gap
+related: [4426, 4220, 4232, 2928, 1539]
+origin: "2026-08-15 ES5-standalone campaign wave 8 — from the fresh baseline cluster map (built-ins/String/prototype 41 ES<=5 non-pass; 'Unsupported dynamic regular expression pattern' x8)."
+---
+
+# #4439 — reflective `String.prototype.match`/`search` + dynamic-pattern residual
+
+## Problem
+
+Three related ES≤5 standalone clusters (fresh baseline 2026-08-15, es5id scope):
+
+1. **Borrowed `match`/`search` throw the refusal** `String.prototype.<m> is
+   not yet implemented in --target standalone` — e.g.
+   `test/built-ins/String/prototype/search/S15.5.4.12_A1_T1.js`
+   (`new Object(true)` receiver, `search(true)` — a LITERAL pattern after
+   ToString), `match/S15.5.4.10_A2_T17/T18`, `A1_T3` (`match` bound to the
+   global object). The DIRECT lanes (`"abc".match(/b/)`, `.search(/b/)`)
+   already work.
+2. **`Cache_match` host-import leak** on `match/this-val-obj.js`,
+   `this-val-bool.js` (#2961 refusal).
+3. **`Unsupported dynamic regular expression pattern`** ×8 (e.g.
+   `built-ins/RegExp/S15.10.4.1_A8_T4.js`) — patterns outside
+   `__regex_compile_dynamic_simple`'s literal/alternation subset.
+
+## Implementation Plan
+
+1. Follow the established reflective-body pattern (`string-proto-split.ts` —
+   the closest sibling: it already returns a non-string result and handles a
+   TWO-lane arg: static RegExp vs ToString'd separator). Wire `match` and
+   `search` in `emitStringProtoMemberBody`
+   (`src/codegen/array-object-proto.ts`) to new bodies in a NEW module
+   (`string-proto-match-search.ts`), refusal fallback preserved.
+2. The arg dispatch at runtime: `ref.test` the native `$NativeRegExp` struct
+   (`ensureStandaloneRegExpStruct`, `regexp-standalone.ts`) → use its
+   prog/classTable/nGroups fields; otherwise ToString(arg) →
+   `ensureDynamicStandaloneRegExpCompiler` (`__regex_compile_dynamic_simple`,
+   regexp-standalone.ts ~1023) with empty flags.
+3. `search` semantics: `__regex_search`-based sequence
+   (`emitRegexSearchCallSequence` ~2189 — used by `.test`; returns match
+   start or -1) → box as Number. `match` (non-global): the `exec` result
+   shape — `__regex_capture_array` → `$__regexp_match_vec` (~2397) → null on
+   miss. Reuse the ensure* helpers; do NOT hand-roll a matcher.
+4. The `Cache_match` leak: locate the emit site (grep `Cache_match`), gate it
+   on the host lane, route standalone to the same new body.
+5. Dynamic-pattern residual: measure which of the 8 files' patterns fall
+   inside a MODEST extension of the runtime subset (character classes,
+   quantifiers on literals?) — extend only what the corpus needs, keep the
+   catchable-TypeError refusal for the rest (never manufacture an empty
+   program — the ~1030 comment explains the OOB hazard).
+6. Verify per-file with the single-test driver; scoped standalone run over
+   `built-ins/String/prototype/match|built-ins/String/prototype/search|built-ins/RegExp`
+   for collateral; the regexp unit suites (`es5-standalone-regexp*`,
+   `issue-1539*`) stay green.
+
+## Acceptance criteria
+
+- S15.5.4.12_A1_T1/T2 and the S15.5.4.10 borrowed-match family flip, or each
+  non-flip is root-caused in this file with an owner.
+- Zero regressions in the scoped regexp/string sweep; gc/host byte-identical.

--- a/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
+++ b/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
@@ -1,0 +1,64 @@
+---
+id: 4440
+title: "Function meta R1/R-attr slice — method name/length + own-property descriptor attributes (writable/enumerable/configurable)"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: function-properties
+goal: standalone-gap
+related: [4437, 4436, 2896]
+origin: "2026-08-15 ES5-standalone campaign wave 8 — #4437's R1 residual (class/object METHODS decline the meta) plus the descriptor-attribute family ('Expected obj[length] NOT to be writable' x4, Function/length 6 ES<=5 non-pass)."
+---
+
+# #4440 — function meta for METHODS + own-property descriptor attributes
+
+## Problem
+
+Two adjacent residuals #4437 left with owners-unassigned:
+
+1. **R1 — methods decline the meta.** `ensureMethodClosureSingleton` receives
+   a name + funcIdx, not a declaration node, so class/object-literal methods
+   have no `$fnmeta` and `name`/`length` reflection declines. All 8 remaining
+   `*length-dflt.js` files sit here. Method `name` needs the `get `/`set `
+   prefix rule and symbol-key handling (§10.2.9 SetFunctionName).
+2. **Descriptor attributes.** `length`/`name` are now own DATA properties on
+   plain functions (#4437), but their gOPD attributes must be
+   `{ writable:false, enumerable:false, configurable:true }` per ES2015+/
+   §15.1.5 ES5 (non-configurable in ES5 — test262 tests the MODERN attributes;
+   follow what the failing files assert). Fresh-baseline signatures:
+   `Expected obj[length] NOT to be writable, but was.` ×4;
+   `built-ins/Function/length` 6 non-pass (S15.3.5.1_A2_T*/A3_T* —
+   DontDelete/ReadOnly probes via assignment and delete).
+
+## Implementation Plan
+
+1. Base on #4437's modules: `function-instance-meta.ts` (write side),
+   `function-instance-meta-arms.ts` (read side), `function-instance-props.ts`.
+   Read #4437's issue file first — the nominal-struct discriminator rationale
+   and the `$arity` no-repoint constraint both bind here.
+2. R1: thread the declaration (or at minimum `{name, prefix-length}`) into
+   `ensureMethodClosureSingleton`'s callers so methods intern a meta too.
+   Where the declaration is genuinely unavailable, keep the decline.
+3. Attributes: the reflection arms (`hasOwnProperty`/gOPD/`__extern_get`)
+   answer for `length`/`name`; extend the gOPD synthesis to report the spec
+   attribute triple, and make WRITES respect writable:false (sloppy silent
+   no-op, strict TypeError — check what `__extern_set_strict` needs) and
+   `delete` respect configurable per the asserted edition semantics.
+4. Verify: the 8 `*length-dflt.js` files; `built-ins/Function/length/*`
+   (6 non-pass; S15.3.5.1_A2_T1-3, A3_T1-3); the `Expected obj[length] NOT
+   to be writable` ×4; #4437's 19-test pin + #4436's 23-test pin stay green;
+   140-file closure-heavy control from #4437's methodology.
+
+## Acceptance criteria
+
+- ≥6 of the named files flip; zero regressions in the control set; gc/host
+  byte-identical; non-flips root-caused here with owners.

--- a/src/codegen/expressions/eval-inline.ts
+++ b/src/codegen/expressions/eval-inline.ts
@@ -45,6 +45,7 @@ import {
 } from "./runtime-eval-provider.js";
 import { emitRuntimeEvalInterpretedCallableAdapter } from "../runtime-eval-callable.js";
 import { ensureRuntimeEvalInterpretedCallbackType } from "../runtime-eval-boundary.js";
+import { emitRuntimeEvalFunctionPrototypeSeed } from "../runtime-eval-construct.js"; // (#4438) §20.2.1.1
 import { currentDirectEvalLexicalBindingNames, reifyCurrentDirectEvalBindings } from "../direct-eval-environment.js";
 export { emitStandaloneDirectEvalRuntime } from "./runtime-eval-provider.js";
 
@@ -2020,7 +2021,17 @@ export function emitStandaloneDynamicFunctionRuntime(
   const liveIdx = ctx.funcMap.get("__runtime_new_function") ?? newFnIdx;
   fctx.body.push({ op: "call", funcIdx: liveIdx });
   emitRuntimeEvalResultUnwrap(ctx, fctx);
-  return emitRuntimeEvalInterpretedCallableAdapter(ctx, fctx);
+  const carrierType = emitRuntimeEvalInterpretedCallableAdapter(ctx, fctx);
+  // (#4438) §20.2.1.1 always creates an ordinary CONSTRUCTABLE function with a
+  // fresh `prototype` object whose `constructor` is the function. QuickJS's own
+  // `.prototype` does not cross the seam (the marker's `target` is an empty,
+  // deliberately unmirrored box), so `F.prototype` read `undefined` and
+  // `new F()` had no prototype to build an instance from. This is the ONE site
+  // that knows from the SOURCE that the value is constructable — see
+  // runtime-eval-construct.ts for why the shared carrier trampoline is the
+  // wrong place for it.
+  emitRuntimeEvalFunctionPrototypeSeed(ctx, fctx);
+  return carrierType;
 }
 
 /**

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -63,6 +63,7 @@ import { compileObjectLiteralAsExternref, resolveComputedKeyExpression } from ".
 import { stringConstantExternrefInstrs, ensureAnyToStringHelper } from "../native-strings.js";
 import { MAX_NATIVE_CONSTRUCT_ARITY, reserveNativeConstructDriver } from "../native-construct.js"; // (#3981)
 import { emitBoundConstructOnNull } from "../construct-bound.js"; // (#4196) §10.4.1.2
+import { emitRuntimeEvalConstructOnNull } from "../runtime-eval-construct.js"; // (#4438) §10.2.2
 import { emitNativeNumberFormat } from "../number-format-native.js";
 import {
   compileStandaloneRegExpConstructor,
@@ -4350,6 +4351,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
           // (#4196) A `$__bound_fn` is not a `$__ta_ctor`, so the arm above
           // yields null for it. Retry as §10.4.1.2 [[Construct]] on null.
           emitBoundConstructOnNull(ctx, fctx, expr, taDescLocal, taArgLocals);
+          // (#4438) …and a runtime-eval callable (a `Function(src)` value) is
+          // neither, so it lands in the null too. Retry as §10.2.2
+          // [[Construct]]. Each retry declines for the other's carrier shape,
+          // so the chain has no ordering hazard.
+          emitRuntimeEvalConstructOnNull(ctx, fctx, expr, taDescLocal, taArgLocals);
           return { kind: "externref" };
         }
       }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -17,6 +17,7 @@ import { definedFuncAt, isImportFuncIdx, mintDefinedFunc, pushDefinedFunc } from
 import { fillHostFnctorMethodDrivers, maxHostFnctorMethodArity } from "./host-fnctor-method-driver.js";
 import { fillNativeConstructDrivers, maxReservedNativeConstructArity } from "./native-construct.js";
 import { fillConstructBoundDriver } from "./construct-bound.js"; // (#4196)
+import { fillRuntimeEvalConstructDriver } from "./runtime-eval-construct.js"; // (#4438)
 import { emitVecDefineWritebackExports } from "./vec-define-writeback.js"; // (#3116)
 import { detectArrayReduceFusion } from "./array-reduce-fusion.js";
 import { finalizeModuleValueCaches } from "./module-value-caches.js"; // (#4150/#4157)
@@ -5178,6 +5179,7 @@ export function generateModule(
     fillNativeConstructDrivers(ctx);
 
     fillConstructBoundDriver(ctx); // (#4196) §10.4.1.2 [[Construct]] through $__bound_fn
+    fillRuntimeEvalConstructDriver(ctx); // (#4438) §10.2.2 [[Construct]] through an eval-lane callable
 
     // (#1719 CPR read-drive) Fill the reserved `__drive_proto_iterator` driver
     // body now that `__call_fn_method_0` is registered. No-op when no read-drive
@@ -7869,6 +7871,7 @@ export function generateMultiModule(
     // multi-file module without such a site stays byte-identical.
     fillNativeConstructDrivers(ctx);
     fillConstructBoundDriver(ctx); // (#4196) same stub hazard; degrades to null
+    fillRuntimeEvalConstructDriver(ctx); // (#4438) same stub hazard; degrades to null
     // Native Proxy trap drivers use the same finalize-only closure bridge in
     // project compilation as in the single-source pipeline.
     fillProxyDispatch(ctx);

--- a/src/codegen/runtime-eval-construct.ts
+++ b/src/codegen/runtime-eval-construct.ts
@@ -1,0 +1,484 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4438) `[[Construct]]` through a RUNTIME-EVAL callable in `--target
+ * standalone` (ECMA-262 §10.2.2 OrdinaryCallEvaluateBody / §13.3.5.1).
+ *
+ * ## The gap
+ * `var F = Function("this.p = 1"); new F()` evaluated to **null**. Measured on
+ * the branch base (`--target standalone`, QuickJS provider linked): `typeof
+ * (new F())` is `"object"` and the value is `null`, with no trap and no
+ * diagnostic. That is `S15.3.5.3_A2_T5` (its CHECK#2), `S15.3.5.3_A3_T1`, and
+ * the constructor-shaped part of the `language/statements/function/13.2-*`
+ * family — every ES5 file that constructs through an eval-lane function value.
+ *
+ * ## Why the seam CAN express construction (this was verified, not assumed)
+ * The `js2wasm:runtime-eval` ABI has exactly four entries
+ * (`__runtime_direct_eval`, `__runtime_indirect_eval`, `__runtime_new_function`,
+ * `__runtime_apply_interpreted`) and **no construct entry**. It does not need
+ * one: the fourth takes a `thisArg`, and the provider's inward membrane makes a
+ * compiled `$Object` receiver writable from inside the evaluated code. Probed on
+ * the base before any of this was written:
+ *
+ *     var F = Function("this.prop=1; return 9;");
+ *     var o = {}; F.call(o);        // → 9, and o.prop === 1   ✓ PASSES on base
+ *
+ * So `[[Construct]]` decomposes into operations that already work:
+ * `OrdinaryCreateFromConstructor` (caller-side `__object_create`) + an ordinary
+ * `[[Call]]` with the fresh object as receiver + the §10.2.2 step-13 result
+ * rule. No ABI extension, no provider change, no artifact rebuild.
+ *
+ * ## The other half: a runtime-eval function had no `prototype` AT ALL
+ * The construct path is worth nothing without a prototype object, and
+ * `F.prototype` read `undefined` on base — measured, and contrary to the note in
+ * #2660's M3 write-up, which had verified only the post-WRITE half. The reason
+ * is structural: `qjsPublish` exposes a QuickJS function as the branded
+ * `$RuntimeEvalInterpretedCallback` marker whose `target` is an EMPTY `$Object`
+ * created solely to carry the box row (`qjsPushBoxRow(..., 0)` — deliberately
+ * NOT mirrored). QuickJS's real `.prototype` never crosses, and the caller's
+ * property-get trampoline has arms for `name`/`length`/`constructor` only.
+ *
+ * ### Where the prototype is minted, and why THERE
+ * At the ONE emission site that knows, from the SOURCE, that the value is an
+ * ordinary constructable function: `emitStandaloneDynamicFunctionRuntime`, the
+ * `Function(...)` / `new Function(...)` lowering. §20.2.1.1 always creates a
+ * function with a fresh `prototype` object whose `constructor` is the function,
+ * so seeding it there is spec-mandated rather than a guess.
+ *
+ * The alternative — vivifying `prototype` inside the shared carrier
+ * property-get trampoline whenever the key misses — was designed and REJECTED:
+ * that trampoline also serves carriers wrapping arrows, prototype methods and
+ * AOT declarations. An arrow must NOT have a `prototype` (§15.3), and an AOT
+ * declaration already has one (its fnctor global), so a trampoline-side vivify
+ * would both invent a property that must not exist and mint a SECOND, rival
+ * prototype object for one that does — the exact split-brain #2660 M3 spent its
+ * lap removing. Distinguishing the cases at runtime would need an
+ * `IsConstructor` bit on the cross-module marker struct, i.e. an ABI widening.
+ * Minting at the source-known site costs nothing and is exactly as narrow.
+ *
+ * The store is the carrier's own #3468 property BAG — the same table
+ * `F.zz = 7` / `F.prototype = {…}` already round-trip through (both verified
+ * working on base). It is written with `__defineProperty_value`, not
+ * `__extern_set`, so the attributes are the spec's: `prototype` is
+ * `{writable:true, enumerable:false, configurable:false}` (§20.2.3.2) and
+ * `constructor` is `{writable:true, enumerable:false, configurable:true}`
+ * (§10.2.5). Enumerability is load-bearing, not decoration — a bag entry
+ * written by assignment is enumerable, and `for (var k in F)` would then report
+ * `prototype`.
+ *
+ * ## The driver (§10.2.2, mirroring #4196's `__construct_bound`)
+ *
+ *     __construct_runtime_eval(callee, args) -> externref
+ *       if callee is not a branded runtime-eval carrier: return null
+ *       proto = __extern_get(callee, "prototype")        ;; §10.2.2 step 3
+ *       if proto is not an Object:                 return null
+ *       self   = __object_create(proto)                  ;; OrdinaryObjectCreate
+ *       result = __apply_closure(callee, self, args)     ;; [[Call]] with this=self
+ *       return IsObject(result) ? result : self          ;; §10.2.2 step 13
+ *
+ * **The `proto is not an Object → null` clause is the safety property of this
+ * whole change, not an oversight.** It is what keeps the driver from turning a
+ * carrier around an arrow — or around any callable that legitimately has no
+ * `prototype` — into a silently-wrong constructed object: such a value reads
+ * `undefined` there and keeps the site's pre-#4438 null, byte-for-byte the same
+ * observable outcome as today. Only a callable that ACTUALLY has a prototype
+ * object constructs, which after the seeding above is precisely the
+ * `Function(src)` population this issue is about (plus any carrier the user
+ * explicitly assigned a `prototype` to, where constructing is also correct).
+ *
+ * A returned FUNCTION is an Object per spec, hence the second arm of the
+ * step-13 probe; and the null test is separate and FIRST, because
+ * `__typeof_object(null)` is 1 by design (`typeof null === "object"`) and
+ * folding the two would return null from `new`, reinstating the very bug this
+ * fixes. Same trap #4196 documents.
+ *
+ * ## Why reserve-then-fill
+ * The driver calls `__apply_closure`, whose body is filled at FINALIZE over the
+ * complete closure-shape table, and it needs
+ * `ctx.runtimeEvalAotCallableCarrier`, which a `new` site may compile BEFORE any
+ * carrier is minted. So the call site reserves a stable funcIdx with an
+ * `unreachable` stub and bakes `call <idx>`; {@link fillRuntimeEvalConstructDriver}
+ * supplies the body at finalize. Same discipline as `construct-bound.ts`
+ * (#4196), `native-construct.ts` (#3981) and `accessor-driver.ts` (#1888), and
+ * it keeps the late-import index shifter (#329/#1899) authoritative via
+ * `funcMap`.
+ *
+ * ## Degradation and byte-neutrality
+ * A module whose source cannot reach the runtime-eval lane at all never
+ * reserves the driver and never emits the retry, so its output is
+ * byte-identical (gc/host included — every entry point is gated on
+ * `ctx.standalone`). When the driver IS reserved but the module minted no
+ * carrier, or an object-model helper is missing, the fill emits
+ * `ref.null.extern` — the exact pre-#4438 outcome for that site, never a trap.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { ensureObjectRuntime, ensureObjVecBuilders, reserveApplyClosure } from "./object-runtime.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { addFuncType } from "./registry/types.js";
+import { RUNTIME_EVAL_AOT_CALLABLE_BRAND_A, RUNTIME_EVAL_AOT_CALLABLE_BRAND_B } from "./runtime-eval-boundary.js";
+import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+
+const EXTERNREF: ValType = { kind: "externref" };
+const DRIVER_NAME = "__construct_runtime_eval";
+
+/**
+ * §20.2.3.2 — a function created by the `Function` constructor has
+ * `prototype` as `{writable: true, enumerable: false, configurable: false}`.
+ * Bit layout is `__defineProperty_value`'s HOST encoding: 1 writable,
+ * 2 enumerable, 4 configurable.
+ */
+const FUNCTION_PROTOTYPE_FLAGS = 0x01;
+
+/** §10.2.5 — `constructor` on a function's prototype object is
+ *  `{writable: true, enumerable: false, configurable: true}`. */
+const PROTOTYPE_CONSTRUCTOR_FLAGS = 0x01 | 0x04;
+
+/**
+ * Reserve-time `"prototype"` key push, replayed into the driver body at
+ * finalize. Held per-context in a `WeakMap` rather than as a `CodegenContext`
+ * field, for the reason `construct-bound.ts` states: the context type is a
+ * god-file under the #3102 LOC gate and one optional per-compile value has no
+ * business widening it.
+ */
+const PROTO_KEY_BY_CTX = new WeakMap<CodegenContext, Instr[]>();
+
+/** Memo for {@link nodeCanSeeRuntimeEvalCallable} — one AST walk per file. */
+const MENTIONS_EVAL_LANE_BY_FILE = new WeakMap<ts.SourceFile, boolean>();
+
+/**
+ * Could this source file ever hold a runtime-eval callable?
+ *
+ * BYTE-NEUTRALITY GATE, same role as `nodeCanMintBoundFn` in
+ * `construct-bound.ts`. Every runtime-eval carrier originates from a source
+ * mention of `eval` or `Function` — the `Function(...)` lowering, the
+ * direct/indirect eval routes, or the global-binding seed those routes install.
+ * A file that names neither can never produce one, so emitting the retry at its
+ * `new` sites would move the module's bytes for a branch provably never taken.
+ *
+ * Deliberately syntactic and deliberately over-approximate: a false positive
+ * costs a not-taken branch, a false negative costs the fix. Matching a bare
+ * NAME (identifier, property name, or string literal) rather than a resolved
+ * symbol is part of that — a local shadow named `Function` is a miss in the
+ * harmless direction.
+ *
+ * A **SYNTHESIZED** node — one a codegen desugaring built, with no parent chain
+ * — has no source file, and `getSourceFile()` returns `undefined` rather than
+ * throwing. Feeding that to the memo `WeakMap` is a hard
+ * `Invalid value used as weak map key` crash that takes the whole compile down
+ * (it cost #4196 seven passing files before its control sweep caught it), so
+ * unknown provenance is treated as "cannot see one" — the fail-safe direction.
+ */
+function nodeCanSeeRuntimeEvalCallable(site: ts.Node): boolean {
+  const file = typeof site.getSourceFile === "function" ? site.getSourceFile() : undefined;
+  if (file === undefined || file === null || typeof file !== "object") return false;
+  const memo = MENTIONS_EVAL_LANE_BY_FILE.get(file);
+  if (memo !== undefined) return memo;
+  let found = false;
+  const names = new Set(["eval", "Function"]);
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isIdentifier(node) && names.has(node.text)) {
+      found = true;
+      return;
+    }
+    if (ts.isStringLiteralLike(node) && names.has(node.text)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(file, visit);
+  MENTIONS_EVAL_LANE_BY_FILE.set(file, found);
+  return found;
+}
+
+/**
+ * (#4438) Seed the §20.2.1.1 `prototype` / `constructor` pair onto a freshly
+ * minted runtime-eval callable.
+ *
+ * Consumes the carrier externref on the stack and leaves the SAME reference —
+ * this is a decoration, never a replacement, so every identity the caller
+ * already established (`F === F`, the memoized carrier) is untouched.
+ *
+ * Emits nothing at all (leaving the site byte-identical) when the object
+ * runtime cannot supply `__new_plain_object` / `__defineProperty_value`.
+ */
+export function emitRuntimeEvalFunctionPrototypeSeed(ctx: CodegenContext, fctx: FunctionContext): void {
+  if (!ctx.standalone) return;
+  ensureObjectRuntime(ctx);
+  const newObjIdx = ensureLateImport(ctx, "__new_plain_object", [], [EXTERNREF]);
+  const defineIdx = ensureLateImport(
+    ctx,
+    "__defineProperty_value",
+    [EXTERNREF, EXTERNREF, EXTERNREF, { kind: "f64" }],
+    [EXTERNREF],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (newObjIdx === undefined || defineIdx === undefined) return;
+  const liveNewObjIdx = ctx.funcMap.get("__new_plain_object") ?? newObjIdx;
+  const liveDefineIdx = ctx.funcMap.get("__defineProperty_value") ?? defineIdx;
+
+  addStringConstantGlobal(ctx, "prototype");
+  addStringConstantGlobal(ctx, "constructor");
+
+  const carrierLocal = allocLocal(fctx, `__rec_fn_${fctx.locals.length}`, EXTERNREF);
+  const protoLocal = allocLocal(fctx, `__rec_proto_${fctx.locals.length}`, EXTERNREF);
+  fctx.body.push(
+    { op: "local.set", index: carrierLocal },
+    { op: "call", funcIdx: liveNewObjIdx },
+    { op: "local.set", index: protoLocal },
+    // proto.constructor = F
+    { op: "local.get", index: protoLocal },
+    ...stringConstantExternrefInstrs(ctx, "constructor"),
+    { op: "local.get", index: carrierLocal },
+    { op: "f64.const", value: PROTOTYPE_CONSTRUCTOR_FLAGS },
+    { op: "call", funcIdx: liveDefineIdx },
+    { op: "drop" },
+    // F.prototype = proto
+    { op: "local.get", index: carrierLocal },
+    ...stringConstantExternrefInstrs(ctx, "prototype"),
+    { op: "local.get", index: protoLocal },
+    { op: "f64.const", value: FUNCTION_PROTOTYPE_FLAGS },
+    { op: "call", funcIdx: liveDefineIdx },
+    { op: "drop" },
+    { op: "local.get", index: carrierLocal },
+  );
+}
+
+/**
+ * Reserve `__construct_runtime_eval(callee, args) -> externref`.
+ *
+ * `protoKeyInstrs` pushes the `"prototype"` property key as an externref. The
+ * caller builds it at RESERVE time (while the string-constant machinery is in
+ * its normal mid-compile state) and it is replayed verbatim into the filled
+ * body; string-constant globals are append-only and index-stable, so the baked
+ * instructions stay valid across the intervening compilation.
+ */
+function reserveRuntimeEvalConstructDriver(ctx: CodegenContext, protoKeyInstrs: Instr[]): number {
+  const existing = ctx.funcMap.get(DRIVER_NAME);
+  if (existing !== undefined) return existing;
+  const typeIdx = addFuncType(ctx, [EXTERNREF, EXTERNREF], [EXTERNREF], `$${DRIVER_NAME}_type`);
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: DRIVER_NAME,
+    typeIdx,
+    locals: [],
+    body: [{ op: "unreachable" }],
+    exported: false,
+  });
+  ctx.funcMap.set(DRIVER_NAME, funcIdx);
+  PROTO_KEY_BY_CTX.set(ctx, protoKeyInstrs);
+  return funcIdx;
+}
+
+/**
+ * Retry an already-emitted host-free `new` as §10.2.2 [[Construct]] on a
+ * runtime-eval callable when the value on the stack is null.
+ *
+ * Consumes the externref currently on the stack and leaves an externref. Both
+ * the callee (as an `anyref` local, the form the caller already has) and the
+ * arguments are read from LOCALS the caller evaluated — nothing is re-compiled,
+ * so no argument side effect runs twice.
+ *
+ * Chains AFTER `emitBoundConstructOnNull`: a `$__bound_fn` is not a
+ * runtime-eval carrier and vice versa, so each retry declines (returning null)
+ * for the other's shape and the two compose without ordering hazard.
+ */
+export function emitRuntimeEvalConstructOnNull(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  site: ts.Node,
+  calleeAnyLocal: number,
+  argLocals: readonly number[],
+): void {
+  if (!ctx.standalone) return;
+  if (!nodeCanSeeRuntimeEvalCallable(site)) return;
+  ensureObjectRuntime(ctx);
+  ensureObjVecBuilders(ctx);
+  reserveApplyClosure(ctx);
+  ensureLateImport(ctx, "__extern_get", [EXTERNREF, EXTERNREF], [EXTERNREF]);
+  ensureLateImport(ctx, "__object_create", [EXTERNREF], [EXTERNREF]);
+  flushLateImportShifts(ctx, fctx);
+  const objVecNewIdx = ctx.funcMap.get("__objvec_new");
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push");
+  if (objVecNewIdx === undefined || objVecPushIdx === undefined) return;
+
+  addStringConstantGlobal(ctx, "prototype");
+  const driverIdx = reserveRuntimeEvalConstructDriver(ctx, stringConstantExternrefInstrs(ctx, "prototype"));
+
+  const priorLocal = allocLocal(fctx, `__rec_prior_${fctx.locals.length}`, EXTERNREF);
+  const argvLocal = allocLocal(fctx, `__rec_argv_${fctx.locals.length}`, EXTERNREF);
+  const arm: Instr[] = [
+    { op: "call", funcIdx: objVecNewIdx },
+    { op: "local.set", index: argvLocal },
+  ];
+  for (const argLocal of argLocals) {
+    arm.push(
+      { op: "local.get", index: argvLocal },
+      { op: "local.get", index: argLocal },
+      { op: "call", funcIdx: objVecPushIdx },
+    );
+  }
+  arm.push(
+    { op: "local.get", index: calleeAnyLocal },
+    { op: "extern.convert_any" },
+    { op: "local.get", index: argvLocal },
+    { op: "call", funcIdx: ctx.funcMap.get(DRIVER_NAME) ?? driverIdx },
+  );
+
+  fctx.body.push(
+    { op: "local.tee", index: priorLocal },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: EXTERNREF },
+      then: arm,
+      else: [{ op: "local.get", index: priorLocal }],
+    },
+  );
+}
+
+/**
+ * Fill the reserved driver once `__apply_closure`, the carrier types and the
+ * object-model helpers are registered. No-op when no site reserved one.
+ */
+export function fillRuntimeEvalConstructDriver(ctx: CodegenContext): void {
+  const driverIdx = ctx.funcMap.get(DRIVER_NAME);
+  if (driverIdx === undefined) return;
+  const driver = definedFuncAt(ctx, driverIdx);
+  if (!driver) return;
+
+  const carrier = ctx.runtimeEvalAotCallableCarrier;
+  const externGetIdx = ctx.funcMap.get("__extern_get");
+  const objectCreateIdx = ctx.funcMap.get("__object_create");
+  const applyClosureIdx = ctx.funcMap.get("__apply_closure");
+  const typeofObjectIdx = ctx.funcMap.get("__typeof_object");
+  const typeofFunctionIdx = ctx.funcMap.get("__typeof_function");
+  const protoKeyInstrs = PROTO_KEY_BY_CTX.get(ctx);
+  // `__apply_closure` can only invoke a callee with an explicit receiver via a
+  // `__call_fn_method_<N>` dispatcher. The multi-file finalize path emits only
+  // `__call_fn_0`/`__call_fn_1`, so without one of these the bridge returns its
+  // undefined sentinel and the driver would hand back an EMPTY instance instead
+  // of the pre-#4438 null. Decline rather than invent one. (#4196's fill states
+  // the same constraint for the same reason.)
+  const hasReceiverDispatcher = [0, 1, 2, 3, 4, 5, 6, 7, 8].some(
+    (n) => ctx.funcMap.get(`__call_fn_method_${n}`) !== undefined,
+  );
+
+  if (
+    carrier === undefined ||
+    !hasReceiverDispatcher ||
+    externGetIdx === undefined ||
+    objectCreateIdx === undefined ||
+    applyClosureIdx === undefined ||
+    typeofObjectIdx === undefined ||
+    protoKeyInstrs === undefined
+  ) {
+    // Missing machinery (most commonly: the module never minted a runtime-eval
+    // carrier). Degrade to the pre-#4438 value for this site rather than
+    // trapping.
+    driver.body = [{ op: "ref.null.extern" }];
+    driver.locals = [];
+    return;
+  }
+
+  // 0 = callee, 1 = call-site args ($ObjVec externref)
+  const protoLocal = 2;
+  const selfLocal = 3;
+  const resultLocal = 4;
+
+  const castCarrier: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: carrier.structTypeIdx },
+  ];
+  const brandEq = (fieldIdx: number, brand: number): Instr[] => [
+    ...castCarrier,
+    { op: "struct.get", typeIdx: carrier.structTypeIdx, fieldIdx },
+    { op: "i32.const", value: brand },
+    { op: "i32.eq" },
+  ];
+
+  // §10.2.2 step 13, and the null-first ordering the header explains.
+  const isObjectProbe: Instr[] = [
+    { op: "local.get", index: resultLocal },
+    { op: "call", funcIdx: typeofObjectIdx },
+  ];
+  if (typeofFunctionIdx !== undefined) {
+    isObjectProbe.push(
+      { op: "local.get", index: resultLocal },
+      { op: "call", funcIdx: typeofFunctionIdx },
+      { op: "i32.or" },
+    );
+  }
+
+  driver.body = [
+    // Not a branded runtime-eval carrier → the site's pre-#4438 value. Keeps
+    // this driver a pure ADDITION for every other dynamic-`new` callee.
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: carrier.structTypeIdx },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+    ...brandEq(3, RUNTIME_EVAL_AOT_CALLABLE_BRAND_A),
+    ...brandEq(4, RUNTIME_EVAL_AOT_CALLABLE_BRAND_B),
+    { op: "i32.and" },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+
+    // proto = Get(F, "prototype") — §10.2.2 step 3.
+    { op: "local.get", index: 0 },
+    ...protoKeyInstrs,
+    { op: "call", funcIdx: externGetIdx },
+    { op: "local.set", index: protoLocal },
+    // NOT an Object ⇒ keep the pre-#4438 null. This is the clause that makes a
+    // callable with no prototype (an arrow, a method) construct nothing rather
+    // than something wrong — see the header.
+    { op: "local.get", index: protoLocal },
+    { op: "ref.is_null" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+    { op: "local.get", index: protoLocal },
+    { op: "call", funcIdx: typeofObjectIdx },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: [{ op: "ref.null.extern" }, { op: "return" }] },
+
+    // self = OrdinaryObjectCreate(proto)
+    { op: "local.get", index: protoLocal },
+    { op: "call", funcIdx: objectCreateIdx },
+    { op: "local.set", index: selfLocal },
+
+    // result = F.[[Call]](self, args)
+    { op: "local.get", index: 0 },
+    { op: "local.get", index: selfLocal },
+    { op: "local.get", index: 1 },
+    { op: "call", funcIdx: applyClosureIdx },
+    { op: "local.set", index: resultLocal },
+
+    { op: "local.get", index: resultLocal },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: EXTERNREF },
+      then: [{ op: "local.get", index: selfLocal }],
+      else: [
+        ...isObjectProbe,
+        {
+          op: "if",
+          blockType: { kind: "val", type: EXTERNREF },
+          then: [{ op: "local.get", index: resultLocal }],
+          else: [{ op: "local.get", index: selfLocal }],
+        },
+      ],
+    },
+  ];
+
+  driver.locals = [
+    { name: "__rec_proto", type: EXTERNREF },
+    { name: "__rec_self", type: EXTERNREF },
+    { name: "__rec_result", type: EXTERNREF },
+  ];
+}

--- a/tests/issue-4438-runtime-eval-construct.test.ts
+++ b/tests/issue-4438-runtime-eval-construct.test.ts
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4438) `new <runtime-eval callable>` in `--target standalone`.
+ *
+ * The behavioural half of this issue can only be observed with the QuickJS
+ * provider linked, which is a test262-runner-scale fixture rather than a unit
+ * test (the measured before/after probes live in the issue file). What IS
+ * unit-checkable — and is what actually broke in every prior reserve/fill
+ * driver (#4196, #3981, #1888) — is the STRUCTURAL contract:
+ *
+ *  1. the driver is reserved AND filled (an `unreachable` stub reaching the
+ *     binary is strictly worse than the null it replaces: an uncatchable trap);
+ *  2. the §20.2.1.1 `prototype`/`constructor` seed is emitted at the
+ *     `Function(...)` site;
+ *  3. every module that cannot reach the runtime-eval lane stays untouched —
+ *     the byte-neutrality gate. These are refusal pins: they must hold in BOTH
+ *     directions, so they fail if the gate is ever widened by accident.
+ */
+import { describe, expect, it } from "vitest";
+import { compile, type CompileResult } from "../src/index.js";
+
+const DRIVER = "__construct_runtime_eval";
+
+async function compileWat(source: string, target?: "standalone"): Promise<CompileResult> {
+  const result = await compile(source, {
+    fileName: "issue-4438-runtime-eval-construct.ts",
+    skipSemanticDiagnostics: true,
+    allowJs: true,
+    emitWat: true,
+    inferModuleStrictArguments: false,
+    ...(target ? { target } : {}),
+  });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  return result;
+}
+
+/**
+ * The driver's own `(func $__construct_runtime_eval …)` body text.
+ *
+ * Sliced to the NEXT `(func $` rather than by paren balance: the WAT printer's
+ * indentation is not part of the contract, and an over-wide slice silently
+ * imports the next function's opcodes into every assertion (which is exactly
+ * how the first cut of this file "found" an `unreachable` that belonged to an
+ * unrelated helper).
+ */
+function driverBody(wat: string): string | undefined {
+  const start = wat.indexOf(`(func $${DRIVER}`);
+  if (start < 0) return undefined;
+  const next = wat.indexOf("(func $", start + 1);
+  return wat.slice(start, next < 0 ? undefined : next);
+}
+
+describe("#4438 — [[Construct]] through a runtime-eval callable", () => {
+  it("reserves AND fills the construct driver for `new <Function(src) value>`", async () => {
+    const { wat } = await compileWat(
+      `var F = Function("this.p = 1;");
+       var i = new F();
+       export function probe(): number { return 0; }`,
+      "standalone",
+    );
+    const body = driverBody(wat);
+    expect(body, "driver must be reserved at the `new` site").toBeDefined();
+    // The whole point of the reserve/fill discipline: a surviving stub traps,
+    // which is strictly worse than the null it replaces.
+    expect(body).not.toContain("unreachable");
+    // The brand pair is the driver's identity gate — without it the driver
+    // would construct through ANY carrier-shaped value.
+    expect(body).toContain(`i32.const ${0x2928}`);
+    expect(body).toContain(`i32.const ${0x414f5443}`);
+    // §10.2.2: at least the `prototype` read, `__object_create` and
+    // `__apply_closure`. Callee indices are numeric in the WAT, so assert the
+    // COUNT — a body that lost one of the three would drop below it.
+    expect((body!.match(/^\s*call \d+$/gm) ?? []).length).toBeGreaterThanOrEqual(3);
+    // Both refusal arms (not a carrier / prototype is not an Object) must keep
+    // the site's pre-#4438 null rather than fall through to a constructed value.
+    expect((body!.match(/ref\.null extern/g) ?? []).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("seeds `prototype` and `constructor` at the `Function(...)` site", async () => {
+    const result = await compileWat(
+      `var F = Function("this.p = 1;");
+       export function probe(): number { return 0; }`,
+      "standalone",
+    );
+    const pool = JSON.stringify(result.stringPool);
+    // Both keys must be interned; without them the bag write has no key.
+    expect(pool).toContain('"prototype"');
+    expect(pool).toContain('"constructor"');
+    // The seed needs both helpers materialized in a module that only creates a
+    // function value — it never constructs one, so nothing else pulls them in.
+    expect(result.wat).toContain("(func $__new_plain_object");
+    expect(result.wat).toContain("(func $__defineProperty_value");
+    // The provider entry the seeded value comes from.
+    expect(result.wat).toContain("__runtime_new_function");
+    // …and the driver is NOT reserved, because there is no `new` site. Reserving
+    // it here would mean the gate keys off the wrong thing.
+    expect(driverBody(result.wat)).toBeUndefined();
+  });
+
+  it("REFUSES to touch a standalone module that cannot reach the eval lane", async () => {
+    const { wat } = await compileWat(
+      `function G() { this.p = 1; }
+       var k: any = G;
+       var i = new k();
+       export function probe(): number { return 0; }`,
+      "standalone",
+    );
+    expect(driverBody(wat)).toBeUndefined();
+  });
+
+  it("REFUSES in the JS-host lane, where the host construct bridge owns `new`", async () => {
+    const { wat } = await compileWat(
+      `var F = Function("this.p = 1;");
+       var i = new F();
+       export function probe(): number { return 0; }`,
+    );
+    expect(driverBody(wat)).toBeUndefined();
+    expect(wat).not.toContain("__runtime_new_function");
+  });
+
+  it("does not add a host import — the standalone lane stays host-free", async () => {
+    const result = await compileWat(
+      `var F = Function("this.p = 1;");
+       var i = new F();
+       export function probe(): number { return 0; }`,
+      "standalone",
+    );
+    const imports = WebAssembly.Module.imports(new WebAssembly.Module(result.binary));
+    // The runtime-eval provider is the ONLY permitted import module here; a new
+    // `env::` entry would make the binary un-instantiable host-free (#2961).
+    expect(imports.filter((entry) => entry.module === "env")).toEqual([]);
+    expect(imports.some((entry) => entry.module === "js2wasm:runtime-eval")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Wave 7b of the #4426 ES5-standalone campaign — the runtime-eval construction residual #2660 M3 named as the blocker for `S15.3.5.3_A2_T5`/`_A3_T1`: `new <Function(src) value>` evaluated to null, so §7.3.20 step 3 answered `false` before the prototype read could happen. New `src/codegen/runtime-eval-construct.ts` implements [[Construct]] through a runtime-eval callable.

Provenance note: the implementing agent committed this work and then was lost to a container restart before reporting, so the verification here is the orchestrator's own, run on the integrated branch: the new pin suite plus the instanceof and closure-prototype-edge suites are **36/36**, and both named target files flip fail→**pass** (runner-verified, `--target standalone`). Also carries the #4439/#4440 wave-8 issue files with their implementation plans.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_