### PR TITLE
ci(#4441): rebalance merge_group test262 shards 58/44 → 52/50 — fourth ratio drift, measured

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1012,10 +1012,13 @@ jobs:
     # one merge-group entry at a time (`max_entries_to_build=1`).
     #
     # With the queue serialized, the matrix instead uses 102 of the 120
-    # four-core runners: js-host=66 and standalone=36, based on the 1.835:1
-    # measured work ratio from run 30631849709 (#3914 — re-derived; the
-    # previous 72/34 came from a 2.13:1 ratio measured at run 29807524490 and
-    # had drifted, leaving standalone the long pole again). The remaining 18
+    # four-core runners, split by the MEASURED per-lane work ratio — currently
+    # js-host=52 and standalone=50 at a 1.03:1 ratio (#4441, re-derived from
+    # merge_group runs 31870031833/31872537807/31873778381 on 2026-08-15).
+    # That ratio has drifted at every measurement (2.13 -> 1.835 -> 1.31 ->
+    # 1.03), each time leaving one lane the long pole, so the live numbers and
+    # the re-derivation procedure live in scripts/gen-test262-mg-matrix.mjs,
+    # which is the single source of truth for the split. The remaining 18
     # runners cover the overlapping CI/equivalence/differential/gate jobs —
     # raised from 14 because run 30631849709 showed 5 shard jobs starting
     # 90-184 s late, i.e. 106 was genuinely over the ceiling. pull_request,

--- a/plan/issues/4441-mg-shard-rebalance-fourth-drift.md
+++ b/plan/issues/4441-mg-shard-rebalance-fourth-drift.md
@@ -1,10 +1,11 @@
 ---
 id: 4441
 title: "merge_group shard split — FOURTH ratio re-derivation: 58/44 estimate overshot, measured 1.03 → 52/50"
-status: ready
+status: done
 sprint: current
 created: 2026-08-15
 updated: 2026-08-15
+completed: 2026-08-15
 priority: medium
 horizon: s
 feasibility: easy
@@ -81,3 +82,37 @@ own re-derivation procedure)
 1. Generator emits 52 js-host + 50 standalone entries; shape test green.
 2. Comment block documents the fourth derivation with the run ids + numbers.
 3. Typecheck + quality gates green. No other workflow behavior changed.
+
+## Results (2026-08-15)
+
+- `scripts/gen-test262-mg-matrix.mjs`: `JS_HOST_CHUNKS` 58 -> **52**,
+  `STANDALONE_CHUNKS` 44 -> **50** (total unchanged at 102 =
+  `MERGE_GROUP_RUNNER_CAPACITY` 120 - `MERGE_GROUP_RESERVED_RUNNERS` 18).
+  Added the "FOURTH ratio drift (2026-08-15)" block with the three run ids,
+  per-lane totals/means/maxes, the measured 1.02-1.05 ratio, and the note that
+  the THIRD split was an estimate (x1.4) that overshot while js-host itself
+  fell 29,353 -> ~22.5k rs. Updated the RE-DERIVING paragraph's drift count
+  (twice -> four times, 2.13 -> 1.835 -> 1.31 -> 1.03).
+- Dry run, `node scripts/gen-test262-mg-matrix.mjs --github-output`: 102
+  entries total — **52 js-host + 50 standalone**, single-line `matrix=` output
+  intact. Lane-drop runs unchanged in behavior: host-only 52, standalone-only
+  50, each keeping its own `chunk_total`.
+- `tests/issue-3431-mg-matrix.test.ts`: the only assertion pinning the old
+  numbers was `toBeCloseTo(58 / 44, 2)` -> `toBeCloseTo(52 / 50, 2)`; drift-
+  history comment extended. The `toHaveLength(102)` /
+  `CAPACITY - RESERVED` assertions needed no change. **12/12 tests pass.**
+- `.github/workflows/test262-sharded.yml`: the `test262-shard-mg` header
+  comment still claimed "js-host=66 and standalone=36 ... 1.835:1" (stale since
+  the THIRD drift). Rewritten to cite 52/50 at 1.03:1 and to point at the
+  generator as the single source of truth, so it stops re-staling. Comment
+  only — no workflow behavior touched.
+- Grep found no other consumer of `JS_HOST_CHUNKS`/`STANDALONE_CHUNKS` or of
+  the 58/44 pair; other `102` references (`scripts/set-merge-queue-config.sh`,
+  `docs/ci-policy.md`) are about the unchanged total.
+- Gates: `pnpm run typecheck` clean; `npm run lint` (biome src/tests/scripts)
+  exit 0; `npx prettier --check` clean on all three changed files.
+  `buildMergeGroupMatrix`'s lane-drop behavior untouched.
+- **Follow-up (recurring, not one-off):** spot-check the next few merge_group
+  runs' per-lane `Run shard` means — both should converge on ~430-440 s. The
+  ratio has now drifted four times; re-derive again if one lane's max is
+  consistently >~1 min past the other's.

--- a/plan/issues/4441-mg-shard-rebalance-fourth-drift.md
+++ b/plan/issues/4441-mg-shard-rebalance-fourth-drift.md
@@ -1,0 +1,83 @@
+---
+id: 4441
+title: "merge_group shard split — FOURTH ratio re-derivation: 58/44 estimate overshot, measured 1.03 → 52/50"
+status: ready
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: ci
+area: infra
+goal: velocity
+---
+
+# #4441 — merge_group shard split: measured re-derivation to 52/50
+
+The `JS_HOST_CHUNKS`/`STANDALONE_CHUNKS` split in
+`scripts/gen-test262-mg-matrix.mjs` was rebalanced to 58/44 on 2026-08-14
+(the "THIRD ratio drift" note) using an **estimated** ×1.4 standalone growth
+(ratio 1.31). Measurement across three green merge_group runs on 2026-08-15
+shows the estimate overshot: the standalone lane is still the wall-clock tail
+of every run, and the js-host lane's cost has dropped substantially since the
+2026-07-31 numbers (compile-speedup lane #4425/#4431/#4432 among others).
+
+## Measurements (2026-08-15, `Run shard` step durations per the generator's
+own re-derivation procedure)
+
+| run | js-host (58 shards) | standalone (44 shards) | ratio |
+| --- | --- | --- | --- |
+| 31870031833 (pr-4536) | 22,923 rs, mean 395 s, max 536 s | 21,769 rs, mean 495 s, max 568 s | 1.053 |
+| 31872537807 (pr-4537) | 22,452 rs, mean 387 s, max 445 s | 21,384 rs, mean 486 s, max 576 s | 1.050 |
+| 31873778381 (pr-4538) | 22,261 rs, mean 384 s, max 431 s | 21,730 rs, mean 494 s, max 560 s | 1.024 |
+
+- True host/standalone work ratio: **1.02–1.05** (assumed: 1.31).
+- Per-shard imbalance today: standalone ~490 s vs js-host ~385 s — ~105 s of
+  avoidable tail on every merge_group run (the last finisher is always a
+  standalone shard; verified again on run 31873778381).
+- Balanced split of the same 102-shard budget: **52 js-host / 50 standalone**
+  → both lanes land at ~428–441 s mean. Same total runner budget; no change
+  to `MERGE_GROUP_RUNNER_CAPACITY` (120) or `MERGE_GROUP_RESERVED_RUNNERS`
+  (18).
+- Also serves the 2026-08-14 note's wave-survival concern: standalone shards
+  get SHORTER (~495 → ~435 s), reducing exposure to hosted-runner shutdown
+  waves.
+
+## Implementation Plan (Fable, 2026-08-15)
+
+1. In `scripts/gen-test262-mg-matrix.mjs`:
+   - `JS_HOST_CHUNKS = 58` → `52`; `STANDALONE_CHUNKS = 44` → `50`.
+   - Add a "FOURTH ratio drift (2026-08-15)" comment block above the
+     constants, following the established style: cite the three run ids and
+     the measured totals/means from the table above, state ratio 1.03 →
+     52/50, note that the THIRD derivation was an estimate (×1.4) that
+     overshot, and note the js-host total's drop (29,353 → ~22.5k rs) so the
+     next re-deriver knows both lanes moved. Keep the existing "RE-DERIVING
+     THIS" paragraph — it is the procedure that was used.
+2. Check `tests/issue-3431-mg-matrix.test.ts` (and grep for other consumers
+   of `JS_HOST_CHUNKS`/`STANDALONE_CHUNKS` or hard-coded 58/44/102): update
+   any count assertions to the new constants — prefer asserting
+   `JS_HOST_CHUNKS + STANDALONE_CHUNKS === 102` and importing the constants
+   over re-hard-coding numbers, but follow the test's existing style.
+3. Do NOT touch `buildMergeGroupMatrix`'s lane-drop behavior (single-lane
+   runs keep their own chunk_total — that invariant is load-bearing for
+   baseline comparability, see the comment in the function).
+4. Partition safety is already guaranteed (`assignBalancedChunk` is a pure
+   function of (chunkIndex, totalChunks) — any total is a full, disjoint
+   partition), so no test-coverage risk from changing counts; say so in the
+   PR body rather than re-proving it.
+5. Validation: `pnpm run typecheck`; run the matrix shape test file; run the
+   generator locally (`node scripts/gen-test262-mg-matrix.mjs --lanes
+   "host standalone"` or per its CLI, check it emits 52+50 entries).
+6. The real proof is the next merge_group runs' lane means converging
+   (~430–440 s both lanes); note in the issue that this should be spot-checked
+   after a few queue merges and the ratio re-derived again if drift recurs —
+   it has now drifted four times, it is a recurring check, not a constant.
+
+## Acceptance criteria
+
+1. Generator emits 52 js-host + 50 standalone entries; shape test green.
+2. Comment block documents the fourth derivation with the run ids + numbers.
+3. Typecheck + quality gates green. No other workflow behavior changed.

--- a/scripts/gen-test262-mg-matrix.mjs
+++ b/scripts/gen-test262-mg-matrix.mjs
@@ -59,8 +59,8 @@
 // merge_group run, sum them per lane, and split the shard budget by the two
 // sums. If one lane's max job is consistently more than ~1 min past the
 // other's, the ratio has drifted again — that is the signal to redo it, and
-// it has now drifted twice (2.13 -> 1.835), so treat it as a recurring check
-// rather than a constant.
+// it has now drifted four times (2.13 -> 1.835 -> 1.31 -> 1.03), so treat it
+// as a recurring check rather than a constant.
 //
 // The underlying partition (assignBalancedChunk, test262-shared.ts) is a
 // pure function of (chunkIndex, totalChunks): it re-derives the FULL test262
@@ -86,8 +86,29 @@ export const MERGE_GROUP_RESERVED_RUNNERS = 18;
 // post-flip 36-way standalone shards ran 20-36+ min — 2-4x the exposure of
 // every PR that merged through the same windows. 44-way puts standalone jobs
 // back at the ~15-min profile that demonstrably survives.
-export const JS_HOST_CHUNKS = 58;
-export const STANDALONE_CHUNKS = 44;
+// FOURTH ratio drift (2026-08-15): the THIRD split above was an ESTIMATE
+// (standalone 16,000 rs x 1.4 for the tuned-emission flip) and it overshot.
+// Measured `Run shard` totals across three green merge_group runs at 58/44:
+//   run 31870031833 (pr-4536): js-host 22,923 rs, mean 395 s, max 536 s
+//                              standalone 21,769 rs, mean 495 s, max 568 s
+//   run 31872537807 (pr-4537): js-host 22,452 rs, mean 387 s, max 445 s
+//                              standalone 21,384 rs, mean 486 s, max 576 s
+//   run 31873778381 (pr-4538): js-host 22,261 rs, mean 384 s, max 431 s
+//                              standalone 21,730 rs, mean 494 s, max 560 s
+// True work ratio is **1.02-1.05** (call it 1.03), not the assumed 1.31.
+// BOTH lanes moved, which is why the estimate missed: standalone grew roughly
+// as predicted (16,000 -> ~21.6k rs) but js-host also FELL hard (29,353 ->
+// ~22.5k rs) as the compile-speedup work landed (#4425/#4431/#4432 among
+// others), so scaling only the standalone side could not land on the right
+// ratio. At 58/44 standalone is therefore still the tail of every run (~490 s
+// vs ~385 s per shard, i.e. ~105 s of avoidable tail; the last finisher was a
+// standalone shard on all three runs). 52/50 of the same 102-shard budget puts
+// both lanes at ~428-441 s mean. Unchanged: MERGE_GROUP_RUNNER_CAPACITY (120)
+// and MERGE_GROUP_RESERVED_RUNNERS (18). Shorter standalone shards also cut
+// exposure to the hosted-runner shutdown waves the THIRD note was worried
+// about (~495 -> ~435 s).
+export const JS_HOST_CHUNKS = 52;
+export const STANDALONE_CHUNKS = 50;
 
 /**
  * @param {string} targetName matrix job-name suffix, e.g. "js-host"

--- a/tests/issue-3431-mg-matrix.test.ts
+++ b/tests/issue-3431-mg-matrix.test.ts
@@ -75,15 +75,17 @@ describe("#3431 gen-test262-mg-matrix", () => {
     expect(matrix).toHaveLength(102);
     expect(matrix.length).toBe(MERGE_GROUP_RUNNER_CAPACITY - MERGE_GROUP_RESERVED_RUNNERS);
     // #3914 — the lane split tracks the MEASURED per-lane `Run shard` work
-    // ratio, which is 1.835 as of merge_group run 30631849709 (2026-07-31).
-    // It has already drifted once (2.13 at run 29807524490), so this asserts
-    // the constants stay mutually consistent rather than pinning a number
-    // forever: whoever re-derives the ratio updates both sides together.
+    // ratio, which is 1.03 as of merge_group runs 31870031833 / 31872537807 /
+    // 31873778381 (2026-08-15). It has drifted at every measurement, so this
+    // asserts the constants stay mutually consistent rather than pinning a
+    // number forever: whoever re-derives the ratio updates both sides together.
     // Drift history: 2.13 (run 29807524490) -> 1.835 (run 30631849709,
     // 2026-07-31) -> 1.318 (2026-08-14, the #4157 tuned-defaults flip grew
-    // standalone work ~40 % while js-host stayed flat — see the derivation in
+    // standalone work ~40 % while js-host stayed flat — an ESTIMATE) -> 1.03
+    // (#4441, 2026-08-15, measured: that estimate overshot, and js-host had
+    // itself gotten cheaper — see the derivation in
     // scripts/gen-test262-mg-matrix.mjs).
-    expect(JS_HOST_CHUNKS / STANDALONE_CHUNKS).toBeCloseTo(58 / 44, 2);
+    expect(JS_HOST_CHUNKS / STANDALONE_CHUNKS).toBeCloseTo(52 / 50, 2);
   });
 });
 


### PR DESCRIPTION
## Description

Re-derives the merge_group test262 shard split from measured data (issue #4441; plan by the Fable lane, implementation by an Opus subagent per the plan/implement split).

**Why**: the THIRD derivation (2026-08-14) set 58/44 from an *estimated* ×1.4 standalone growth (ratio 1.31). Measured `Run shard` step totals across three green merge_group runs on 2026-08-15 (31870031833, 31872537807, 31873778381) show the true host/standalone work ratio is **1.02–1.05** — standalone shards carry ~490 s each vs js-host's ~385 s, and the last finisher of every run is a standalone shard. Two things moved under the estimate: standalone grew less than assumed, and js-host itself fell 29,353 → ~22.5k runner-seconds (the #4425/#4431/#4432 compile-speedup lane among others).

**Change**: `JS_HOST_CHUNKS` 58 → **52**, `STANDALONE_CHUNKS` 44 → **50** (same 102-shard budget; `MERGE_GROUP_RUNNER_CAPACITY`/`MERGE_GROUP_RESERVED_RUNNERS` untouched). Both lanes land at ~428–441 s mean — ~1–2 min off every merge_group run's critical path, and shorter standalone jobs also reduce exposure to hosted-runner shutdown waves (the THIRD note's concern). Partition safety is structural: `assignBalancedChunk` is a pure function of (chunkIndex, totalChunks), so any total yields a full, disjoint partition — no tests dropped or duplicated by changing counts.

- `scripts/gen-test262-mg-matrix.mjs`: constants + "FOURTH ratio drift (2026-08-15)" derivation block (run ids, per-lane totals/means/maxes); RE-DERIVING paragraph's drift history updated (2.13 → 1.835 → 1.31 → 1.03 — treat as a recurring check).
- `tests/issue-3431-mg-matrix.test.ts`: ratio assertion 58/44 → 52/50; 12/12 pass.
- `.github/workflows/test262-sharded.yml`: comment-only — the `test262-shard-mg` header still cited the 66/36 split (stale since the THIRD drift); now points at the generator as single source of truth.
- `buildMergeGroupMatrix` lane-drop behavior deliberately untouched (single-lane runs keep their own `chunk_total` for baseline comparability).

## Validation

- Dry run `node scripts/gen-test262-mg-matrix.mjs --github-output`: 102 entries, **52 js-host + 50 standalone**; lane-drop runs unchanged (host-only 52, standalone-only 50).
- `pnpm run typecheck` clean; biome + prettier clean; full pre-commit chain run (no skip).
- Post-merge follow-up recorded in the issue: spot-check the next few merge_group runs' per-lane means converge on ~430–440 s; re-derive if one lane's max drifts >~1 min past the other again.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm)_