### PR TITLE
fix(codegen): vec named-key presence — widen the compile-time false fold to runtime (#4062)

### DIFF
--- a/plan/issues/4062-standalone-array-length-absent-from-descriptor-reflection.md
+++ b/plan/issues/4062-standalone-array-length-absent-from-descriptor-reflection.md
@@ -1,24 +1,229 @@
 ---
 id: 4062
-title: "D3 — array `length` absent from descriptor reflection in standalone (gOPD undefined, gOPN omits it) while hasOwnProperty says true"
-status: ready
+title: "D3 — named-key presence on an ARRAY receiver disagrees with the read path in standalone (`a.foo === 7` but `a.hasOwnProperty(\"foo\") === false`)"
+status: done
+completed: 2026-08-15
 sprint: current
 created: 2026-08-02
-updated: 2026-08-02
+updated: 2026-08-15
 priority: high
 horizon: s
 feasibility: medium
 reasoning_effort: high
 task_type: bug
-area: standalone
-language_feature: n/a
+area: standalone, codegen
+language_feature: arrays, property-descriptors
 goal: standalone-mode
+related: [4434, 3537, 3251, 4010, 3984, 4227, 4176]
+# (#3102 LOC ratchet / #3400 R-FUNC) The substance of this change-set is the NEW
+# subsystem module `src/codegen/vec-named-key-presence.ts` — the routing
+# predicate and the whole safety argument for it. What lands in the two god-file
+# fold sites is the DECISION, and it cannot move out of them: the predicate's
+# eligibility input is the fold's own answer (`result` in
+# `compilePropertyIntrospection`, `has` in `compileInOperator`), which exists
+# only at those two points and is the reason the change can widen a `false`
+# without touching a single affirmative answer. `object-ops.ts` was sitting
+# EXACTLY at its LOC budget (4847), so any addition at all faults the gate.
+loc-budget-allow:
+  - src/codegen/object-ops.ts
+func-budget-allow:
+  - src/codegen/object-ops.ts::compilePropertyIntrospection
+  - src/codegen/binary-ops-in.ts::compileInOperator
 ---
-# D3 — array `length` absent from descriptor reflection in standalone (gOPD undefined, gOPN omits it) while hasOwnProperty says true
 
-> Filed 2026-08-02 from a TaskList entry that had been carrying the full
-> analysis but no issue file. The body below is the original measurement
-> report, verbatim — it was written by the agent that did the measuring.
+# D3 — named-key presence on an array receiver, standalone
+
+> The original filing (verbatim below, under "Original report") was about
+> `length` and descriptor reflection. **That cell was fixed by #3984/#4227 and
+> #4434** — verified on this tree before any edit: `arr.hasOwnProperty("length")`
+> is `true`, `Object.getOwnPropertyDescriptor(arr,"length")` is a descriptor, and
+> `Object.getOwnPropertyNames(arr)` lists it. #4434's residual #2 routed the
+> REMAINING cell of the same reflection surface here, and that is what this issue
+> now closes: an ordinary **named expando** (`a.foo = 7`) is invisible to
+> `hasOwnProperty` / `propertyIsEnumerable` / `in` while the read path answers
+> correctly.
+
+## Root cause — a compile-time FOLD, not a runtime gap
+
+The runtime chokepoints were already right. `__hasOwnProperty` / `__object_hasOwn`
+carry the vec arm that consults the #3251 overlay and then falls through to the
+#3537 expando bag (`vec-bag-seed.ts:fillVecHasOwnHelpers` + `carrier-bag-visibility.ts`),
+and `__extern_has` reaches the same bag. Measured on this tree, `--target standalone`,
+with a receiver the compiler CANNOT see as an array (`const a: any = []`): every
+cell already answered `true`.
+
+The two wrong cells never reached a helper. When the receiver's resolved Wasm
+type is a `__vec_<k>` struct **and** the key resolves at compile time, both sites
+answer from the static shape:
+
+| site | folds from |
+| --- | --- |
+| `compilePropertyIntrospection` (`object-ops.ts`) | `structFieldNames ∪ receiverType.getProperties()` |
+| `compileInOperator` (`binary-ops-in.ts`) | `structFieldNames ∪ tsTypeHasProperty` |
+
+A vec's field list is `["length", "data"]` and `any[]`'s checker properties are
+its prototype methods, so an expando the program wrote one line earlier is in
+neither — the fold emits `i32.const 0`. The `--target standalone` harness shape
+(`var a = []`) always produces that statically-typed receiver, which is why the
+defect looked lane-specific and why an `any`-typed probe could not reproduce it.
+
+This is #4010 S3 one lane further out: there the vec arm `return`ed the overlay
+answer unconditionally and never reached the bag; here the query never reaches
+the arm.
+
+## The fix
+
+`src/codegen/vec-named-key-presence.ts` (NEW) owns the predicate
+`vecNamedKeyNeedsRuntime(ctx, recvWasm, staticKey, foldedAnswer)` — true only
+when the receiver is a `__vec_<k>` struct, the module is `--target standalone`,
+the key is NOT a canonical array index, **and the fold's own answer would be
+`0`**. The two fold sites then route to the runtime predicate they were bypassing
+(`__hasOwnProperty` / `__propertyIsEnumerable`, and `__extern_has`).
+
+**Only a folded FALSE is widened. That is the entire safety argument**, and it is
+the property #4055 v1 lacked when it widened `hasOwnProperty` over a bag a refused
+write had polluted and the merge queue measured **−684**. Affirmative folds
+(`"length"`, a checker-named inherited method, `propertyIsEnumerable`'s
+non-enumerable `0`) are emitted byte-for-byte as before.
+
+| file | what |
+| --- | --- |
+| `src/codegen/vec-named-key-presence.ts` (NEW) | the routing predicate, the canonical-index screen, the measured before/after matrix and the widen-only-a-false argument |
+| `src/codegen/object-ops.ts` | `compilePropertyIntrospection`: route a folded `0` on a vec receiver to `emitRuntimePropertyIntrospection` |
+| `src/codegen/binary-ops-in.ts` | `compileInOperator`: admit a vec receiver to the existing `__extern_has` arm (§13.10.1 key-then-object order unchanged) |
+
+## Measurement
+
+Every figure below was produced on this tree by the agent that wrote it, paired
+by file-copy revert (`.tmp/base-object-ops.ts`, `.tmp/base-binary-ops-in.ts`),
+same process, same instrument (the real test262 harness via `runTest262File`,
+`lane=standalone`). Corpus baseline used only to SELECT the population:
+`.test262-cache/test262-standalone-current.jsonl`, generated 2026-08-15 09:41.
+
+### The defect, under the harness (`var a = []; a.foo = 7`)
+
+| query | base | after | Node |
+| --- | --- | --- | --- |
+| `a.foo` | `7` | `7` | `7` |
+| `Object.getOwnPropertyDescriptor(a,"foo").value` | `7` | `7` | `7` |
+| `Object.getOwnPropertyNames(a)` / `Object.keys(a)` | includes `"foo"` | unchanged | includes `"foo"` |
+| `a.hasOwnProperty("foo")` | **`false`** | `true` | `true` |
+| `a.propertyIsEnumerable("foo")` | **`false`** | `true` | `true` |
+| `"foo" in a` | **`false`** | `true` | `true` |
+| `for (k in a)` | **omits `"foo"`** | **still omits** | includes `"foo"` |
+
+The for-in cell is a different root cause and is left open — residual 1.
+
+### Population
+
+Selected from the corpus baseline by SOURCE shape (a statically-array-bound
+receiver + a presence query with a static, non-index, non-`length` key — exactly
+the cell the fold answers), then re-verified on the base:
+
+| set | base | after |
+| --- | --- | --- |
+| the 3 files that gate directly on this cell | 0 / 3 | **2 / 3 (+2, −0)** |
+| the wider 22-file array-receiver presence/reflection candidate set | 0 / 22 | **2 / 22 (+2, −0)** |
+
+Flipped: `built-ins/Object/defineProperty/15.2.3.6-4-403.js` (`arrObj.prop = 1002;
+arrObj.hasOwnProperty("prop")` with an inherited `Array.prototype.prop`),
+`built-ins/Object/defineProperty/15.2.3.6-4-339-3.js` (`defineProperty(arr,"prop",…)`
+then `arr.hasOwnProperty("prop")`, plus its two descriptor asserts).
+
+The third, `15.2.3.6-4-579.js`, does NOT flip and its failure moved EARLIER — see
+residual 2. It is the honest cost of this widening and is recorded as such rather
+than netted out.
+
+### Controls (currently-PASSING standalone tests, run on the fixed tree)
+
+| control | selection | result |
+| --- | --- | --- |
+| A — 197 files | every passing file where the route can FIRE (4 with a static named-key query on an array) + all 53 with an `Array.prototype` install *and* a named write (the bag-pollution shape) + a 140-file stride sample of the remaining 1,844 array+presence passers | **194 pass / 0 fail / 3 Temporal skips** |
+| B — 163 files | deterministic stride sample of the passing `built-ins/Array`, `built-ins/Object`, `language/statements/for-in`, `language/expressions/in` families | **163 / 163** |
+
+Zero failures on the after-run, so no base run can attribute a loss to this
+change in either set.
+
+### Byte-neutrality
+
+`compile()` binary sha over 6 fixed sources (array expando + `in` expando +
+array index + plain-object hasOwn + a plain indexed loop + for-in over an array):
+
+- **host lane: byte-identical on all 6** — the predicate is gated on `ctx.standalone`.
+- standalone: identical on 4; the two expando sources differ, as intended.
+
+### Suites
+
+`tests/issue-4062.test.ts` (NEW) 27/27. `issue-3251`, `issue-3251-s2`,
+`issue-3251-s3`, `issue-4159`, `issue-4434-vec-index-domain-sparse-tail`: all
+pass. `issue-3537` fails 1 of 11 — `"a computed 'length' key write cannot shadow
+the real length via the bag"` — **verified failing identically on the base**
+(residual 3).
+
+## Residuals (measured, each with an owner)
+
+1. **`for (k in arr)` on a STATICALLY-TYPED array does not enumerate named
+   expandos (standalone).** Not a presence chokepoint at all: `emitArrayForIn`
+   (`statements/loops.ts`) builds its own key SOURCE — the integer range
+   `0..length-1` — and only the host lane materialises the full key list
+   (`__array_forin_keys`, #3323). The dynamic lane is already correct, and the
+   route is available: probed here, a receiver the compiler cannot type as a vec
+   enumerates `0|1|foo` through `__object_keys_forin` + `__extern_length` /
+   `__extern_get_idx` (the same helpers `compileForInStatement` uses for a
+   dynamic receiver in standalone), with no method leakage from the prototype.
+   **Deliberately not attempted here**: it changes the key source of *every*
+   standalone array for-in, and the measured test262 gain is **zero** — the one
+   population file that queries it,
+   `language/statements/for-in/order-after-define-property.js`, fails first on
+   its PLAIN-OBJECT half. Wants its own slice; nearest owner **#4222 / #2001**
+   (array-hole + enumeration semantics), or a new `emitArrayForIn` slice.
+2. **An inherited `Array.prototype` ACCESSOR does not consume a named write —
+   the write lands in the #3537 bag.** `15.2.3.6-4-579.js` installs a
+   get/set `prop` on `Array.prototype`, then `arrObj.prop = "myOwnProperty"`
+   must run the inherited SETTER (leaving `hasOwnProperty("prop") === false`).
+   The write goes to the bag instead, so this fix — correctly reporting what the
+   bag holds — turns the file's first failure from `data !== "myOwnProperty"`
+   into `hasOwnProperty("prop")` answering `true`. Fail either way, no pass lost,
+   but it is the pollution direction #4010 warned about and it will cap this
+   family until the write path consults inherited accessors. Nearest owner:
+   **#4176** (proto-property companions / `protoIndexRecvGetMissInstrs`) — the
+   read side of that store already exists; the SET side does not.
+3. **`tests/issue-3537.test.ts` "a computed 'length' key write cannot shadow the
+   real length via the bag" fails on current main** (base-verified, unrelated to
+   this change): `var k = "length"; g[k] = 55` reaches a lane that does not apply
+   `__vec_prop_set`'s `"length"` refusal. Owner: **#3537**.
+4. **`arr.hasOwnProperty("data")` answers `true`.** `"data"` is the vec struct's
+   second physical field, so the fold reports it as an own property. Pre-existing
+   and deliberately untouched: this change widens only a folded `false`, and
+   demoting a folded `true` is a different (and riskier) edit. Owner: **#3920 /
+   #4225** (the closed-struct presence family, which owns unsound folded
+   constants) or a `publicPhysicalFieldNames`-style screen at the vec fold site.
+5. **Host lane: an array expando is invisible to `hasOwnProperty` / `in`, and so
+   is a PLAIN-OBJECT expando** (`const o: any = {}; o.foo = 7;
+   o.hasOwnProperty("foo")` → `false`). Base-verified, unchanged here, and
+   asserted in `tests/issue-4062.test.ts` so it stays visible. Owner: **#3116** /
+   the host descriptor sidecar.
+6. **The STATIC `compileObjectDefineProperty` lane** (#4434 residual 1) and the
+   **2^31−1 length ceiling** (#4434 residual 3) still gate the rest of the
+   `15.2.3.6-4-*` family. Untouched, owners unchanged (#3251, and a new issue
+   respectively).
+
+## Acceptance criteria
+
+- [x] `arr.hasOwnProperty("foo")`, `arr.propertyIsEnumerable("foo")`,
+      `Object.hasOwn(arr,"foo")` and `"foo" in arr` agree with the read path for a
+      named expando on a statically-typed array receiver (standalone).
+- [x] gOPD / gOPN / `Object.keys` answers unchanged (they already agreed).
+- [x] No affirmative answer changes: `length`, canonical indices, inherited
+      methods and out-of-range indices are byte-identical.
+- [x] Host lane byte-identical.
+- [x] Zero losses across 360 currently-passing standalone control files.
+- [x] `length` arms (#4434) and the static defineProperty lane (#3251) untouched.
+- [ ] for-in agreement — **not done**, residual 1, routed with a measured plan.
+
+---
+
+## Original report (2026-08-02, verbatim)
 
 Found by g-arraylen 2026-08-01 alongside D2 (task #49). Standalone-lane only. NOT fixed by #3984.
 
@@ -46,5 +251,10 @@ Together with D2 this gates most of the 69 files #3984's fix did not flip.
   not the pass count.
 
 Context: /workspace/plan/log/analysis-2026-08-01-descriptor-dedup-map.md, PR #3973.
-No issue id allocated yet — allocate at pickup. Do NOT reserve an id you may not use
-(#3890/#3891 became permanent holes exactly that way).
+
+> **Status of the original cell, re-measured 2026-08-15 on BOTH trees** (base by
+> file-copy revert, and with this fix applied — it passes on both, so the closure
+> is not this change's): `var a = [1,2]` under the standalone harness —
+> `a.hasOwnProperty("length")` `true`, `Object.getOwnPropertyDescriptor(a,"length")`
+> a descriptor with `value === 2`, `Object.getOwnPropertyNames(a)` includes
+> `"length"`. Closed by #3984 / #4227 / #4434.

--- a/src/codegen/binary-ops-in.ts
+++ b/src/codegen/binary-ops-in.ts
@@ -28,6 +28,7 @@ import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, flushLateImportShifts } from "./shared.js";
 import { inRhsIsExclusivelyPrimitive } from "./binary-ops.js";
 import { overlayRouteActive } from "./typed-lane-overlay-route.js"; // (#4222) overlay-aware index presence
+import { vecNamedKeyNeedsRuntime } from "./vec-named-key-presence.js"; // (#4062) array expando presence
 
 /**
  * (#3714) `emitThrowTypeError` pushes directly onto `fctx.body`; to nest its
@@ -382,7 +383,15 @@ export function compileInOperator(ctx: CodegenContext, fctx: FunctionContext, ex
     // — the host object may carry dynamic keys (e.g. regex `result.groups`).
     // Route through `__extern_has` for the real `in` check instead of
     // emitting an unconditional `false`.
-    if (!has && (rightWasm.kind === "externref" || rightWasm.kind === "anyref")) {
+    //
+    // (#4062) The same reasoning reaches one receiver further: a STATICALLY-TYPED
+    // array carrying a named expando (`a.foo = 7`) answers `7` on the read and
+    // folded `false` here, because a vec's field list is `["length","data"]` and
+    // the bag is invisible to both. `__extern_has`'s vec arm consults the #3251
+    // overlay and the #3537 bag, so routing makes `in` agree with the read — and
+    // only a folded `false` is routed, so no affirmative answer moves.
+    const vecNamedKeyRoute = !has && vecNamedKeyNeedsRuntime(ctx, rightWasm, staticKey, 0);
+    if (!has && (rightWasm.kind === "externref" || rightWasm.kind === "anyref" || vecNamedKeyRoute)) {
       const hasIdx = ensureLateImport(
         ctx,
         "__extern_has",

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -47,6 +47,7 @@ import {
   tryEmitVecLengthDefineForDefineProperties,
 } from "./array-length-define.js";
 import { emitHasOwnPresence } from "./closed-struct-presence.js"; // (#3920) per-instance own-presence
+import { vecNamedKeyNeedsRuntime } from "./vec-named-key-presence.js"; // (#4062) array expando presence
 import { isStaticDescWellFormed, isStaticallyNonObjectDescExpr } from "./descriptor-shape.js";
 import { isDescriptorTranscribableStruct } from "./property-descriptor-shape.js"; // (#4180) #2372 transcription gate
 import {
@@ -4756,6 +4757,16 @@ export function compilePropertyIntrospection(
     // (#3920/#4225) Replace an unsound folded constant — see closed-struct-presence.ts.
     if (emitHasOwnPresence(ctx, fctx, receiverWasm, structFieldNames, staticKey, propAccess, arg, result)) {
       return { kind: "i32", boolean: true };
+    }
+
+    // (#4062) A named expando on an ARRAY receiver lives in the #3537 bag, which
+    // no part of the fold above can see — the vec's field list is
+    // `["length","data"]`. Only a folded `0` is routed, so every affirmative
+    // answer stays byte-identical. See vec-named-key-presence.ts.
+    if (vecNamedKeyNeedsRuntime(ctx, receiverWasm, staticKey, result)) {
+      if (emitRuntimePropertyIntrospection(ctx, fctx, propAccess.expression, arg, isPropertyIsEnumerable)) {
+        return { kind: "i32", boolean: true };
+      }
     }
 
     // Compile receiver and argument for side effects, then drop

--- a/src/codegen/vec-named-key-presence.ts
+++ b/src/codegen/vec-named-key-presence.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4062) The STATICALLY-TYPED array receiver's answer to a NAMED-key presence
+ * question — `arr.hasOwnProperty("foo")`, `arr.propertyIsEnumerable("foo")`,
+ * `"foo" in arr` — routed to the same runtime chokepoint the value read uses.
+ *
+ * ## The defect
+ * `a.foo = 7` on an array stores into the #3537 expando bag (`__vec_prop_set`),
+ * and every DYNAMIC surface already sees it: `__hasOwnProperty` / `__extern_has`
+ * carry the vec arm that consults the #3251 overlay and then the bag
+ * (`vec-bag-seed.ts`, `carrier-bag-visibility.ts`), and `Object.keys` / gOPD /
+ * gOPN answer through the same natives. Measured on this tree, under the real
+ * test262 harness (`var a = []; a.foo = 7`), `--target standalone`:
+ *
+ * | query | before | Node |
+ * | --- | --- | --- |
+ * | `a.foo` | `7` | `7` |
+ * | `Object.getOwnPropertyDescriptor(a, "foo").value` | `7` | `7` |
+ * | `Object.getOwnPropertyNames(a)` | includes `"foo"` | includes `"foo"` |
+ * | `Object.keys(a)` | includes `"foo"` | includes `"foo"` |
+ * | `a.hasOwnProperty("foo")` | **`false`** | `true` |
+ * | `"foo" in a` | **`false`** | `true` |
+ *
+ * The two wrong cells are the two that never reach a runtime helper. With a
+ * receiver the compiler sees as a `__vec_<k>` struct and a key it can resolve at
+ * compile time, both sites answer from the STATIC shape:
+ * `compilePropertyIntrospection` (object-ops.ts) folds
+ * `structFieldNames ∪ checker properties`, and `compileInExpression`
+ * (binary-ops-in.ts) folds `structFieldNames ∪ tsTypeHasProperty`. A vec's field
+ * list is `["length", "data"]` and `any[]`'s checker properties are its
+ * prototype methods, so an expando the program itself wrote a line earlier is
+ * absent from both — the fold emits `i32.const 0`.
+ *
+ * This is the same shape as #4010 S3, one lane further out: there the vec arm
+ * `return`ed the overlay answer unconditionally and never reached the bag; here
+ * the query never reaches the arm at all.
+ *
+ * ## Why this widens only a FALSE, and why that is the whole safety argument
+ * The routing predicate fires only where the fold's answer would be `0`. A fold
+ * that answers `1` (`"length"`, an inherited method named by the checker, a
+ * `propertyIsEnumerable` non-enumerable `0` — see below) is emitted exactly as
+ * before, so no receiver/key pair that answers affirmatively today changes.
+ * That is the property #4055 v1 did not have: it widened `hasOwnProperty` over a
+ * bag that a REFUSED write had polluted, and the merge queue measured **-684**.
+ * The refusal (`buildBuiltinFnSetRefusalArm`) is at the write source now, and the
+ * vec arm's own consult order (overlay affirmative → bag) is what this route
+ * inherits — it adds no new visibility of its own.
+ *
+ * ## Scope, deliberately narrow
+ * - **Standalone only.** In host mode `env::__hasOwnProperty` / `__extern_has`
+ *   own the dynamic path over a JS sidecar with different (and, measured here,
+ *   worse) answers for an array expando; gc/host output stays byte-identical.
+ * - **Named keys only.** A canonical array index is the vec's ELEMENT domain —
+ *   #3251/#4434 own it, and the two fold sites have their own index arms above
+ *   this one. `"length"` is excluded by construction: its fold answers `1`.
+ * - **Nothing about `length`, and nothing about the static defineProperty
+ *   lane.** #4434 landed the length arms; #3251 owns the inline define.
+ */
+import type { ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+
+/** A canonical array index string (`"0"`, `"7"`, …) — never `"01"` / `"-1"` / `"1e3"`. */
+function isCanonicalIndexKey(key: string): boolean {
+  if (key.length === 0 || key.length > 10) return false;
+  for (let i = 0; i < key.length; i++) {
+    const c = key.charCodeAt(i);
+    if (c < 48 || c > 57) return false;
+  }
+  if (key.length > 1 && key.charCodeAt(0) === 48) return false;
+  return true;
+}
+
+/** Is `recvWasm` a reference to a `__vec_<kind>` array struct? */
+function isVecStructType(ctx: CodegenContext, recvWasm: ValType | undefined): boolean {
+  if (!recvWasm) return false;
+  if (recvWasm.kind !== "ref" && recvWasm.kind !== "ref_null") return false;
+  const structDef = ctx.mod.types[(recvWasm as { typeIdx: number }).typeIdx];
+  return structDef?.kind === "struct" && (structDef.name?.startsWith("__vec_") ?? false);
+}
+
+/**
+ * Should a presence question about `staticKey` on this receiver be answered by
+ * the runtime chokepoint instead of the compile-time fold?
+ *
+ * `foldedAnswer` is what the call site would otherwise emit. Only a `0` is
+ * eligible — see the module header: the affirmative answers are unchanged, which
+ * is what keeps this from re-opening the #4055 v1 regression.
+ */
+export function vecNamedKeyNeedsRuntime(
+  ctx: CodegenContext,
+  recvWasm: ValType | undefined,
+  staticKey: string,
+  foldedAnswer: number,
+): boolean {
+  if (foldedAnswer !== 0) return false;
+  if (!ctx.standalone) return false;
+  if (isCanonicalIndexKey(staticKey)) return false;
+  return isVecStructType(ctx, recvWasm);
+}

--- a/tests/issue-4062.test.ts
+++ b/tests/issue-4062.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4062) A named expando on a STATICALLY-TYPED array receiver is visible to the
+// read path and to gOPD / gOPN / Object.keys, but `hasOwnProperty`,
+// `propertyIsEnumerable` and `in` answered a compile-time constant `false`: with
+// a receiver the compiler sees as a `__vec_<k>` struct and a key it resolves
+// statically, both fold sites answer from the vec's field list (`length`,
+// `data`) plus the checker's properties, neither of which can see the #3537
+// expando bag.
+//
+// Every expectation below is Node's answer for the same program. The host lane
+// is asserted for the cells where it already agrees; the two presence cells are
+// standalone-only (host's `env::__hasOwnProperty` sidecar answers `false` for an
+// array expando — a separate, pre-existing host defect, see the issue file).
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+type Lane = "host" | "standalone";
+
+async function run(source: string, lane: Lane): Promise<number> {
+  const result = await compile(source, lane === "standalone" ? { target: "standalone" } : {});
+  expect(
+    result.success,
+    `compile failed (${lane}):\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+  return (instance.exports as Record<string, () => number>).t!();
+}
+
+const fn = (body: string): string => `export function t(): number {\n${body}\n}`;
+
+// Each case is its own module: a module that ALSO performs an indexed define
+// arms the #3673 numeric-companion flag and later queries then work for the
+// wrong reason (#4434's instrument warning applies to this family too).
+describe("#4062 named-key presence on a statically-typed array receiver", () => {
+  const PRESENT: Array<[string, string]> = [
+    ["hasOwnProperty", `const a: any[] = []; (a as any).foo = 7; return a.hasOwnProperty("foo") ? 1 : 0;`],
+    [
+      "hasOwnProperty, non-empty",
+      `const a: any[] = [1, 2]; (a as any).foo = 7; return a.hasOwnProperty("foo") ? 1 : 0;`,
+    ],
+    ["hasOwnProperty, f64 vec", `const a: number[] = [1]; (a as any).foo = 7; return a.hasOwnProperty("foo") ? 1 : 0;`],
+    ["propertyIsEnumerable", `const a: any[] = []; (a as any).foo = 7; return a.propertyIsEnumerable("foo") ? 1 : 0;`],
+    ["in", `const a: any[] = []; (a as any).foo = 7; return ("foo" in (a as any[])) ? 1 : 0;`],
+    ["Object.hasOwn", `const a: any[] = []; (a as any).foo = 7; return (Object as any).hasOwn(a, "foo") ? 1 : 0;`],
+  ];
+  for (const [name, body] of PRESENT) {
+    it(`standalone: ${name} sees the expando`, async () => {
+      expect(await run(fn(body), "standalone")).toBe(1);
+    });
+  }
+
+  // The read path already agreed — asserted alongside so a future change cannot
+  // fix presence by breaking the read.
+  it("standalone: the read still answers the stored value", async () => {
+    expect(
+      await run(fn(`const a: any[] = []; (a as any).foo = 7; return (a as any).foo === 7 ? 1 : 0;`), "standalone"),
+    ).toBe(1);
+  });
+
+  it("standalone: gOPD still describes the expando", async () => {
+    const body = `const a: any[] = []; (a as any).foo = 7;
+      const d = Object.getOwnPropertyDescriptor(a, "foo");
+      return d !== undefined && (d as any).value === 7 ? 1 : 0;`;
+    expect(await run(fn(body), "standalone")).toBe(1);
+  });
+
+  // Only a folded FALSE is routed to the runtime; every affirmative answer and
+  // every index answer is unchanged. These are the guards on that claim.
+  const UNCHANGED: Array<[string, string, number]> = [
+    ["absent named key stays absent", `const a: any[] = [1, 2]; return a.hasOwnProperty("nope") ? 1 : 0;`, 0],
+    ["length is own", `const a: any[] = [1, 2]; return a.hasOwnProperty("length") ? 1 : 0;`, 1],
+    ["index 0 is own", `const a: any[] = [1, 2]; return a.hasOwnProperty("0") ? 1 : 0;`, 1],
+    ["index out of range is not own", `const a: any[] = [1, 2]; return a.hasOwnProperty("5") ? 1 : 0;`, 0],
+    ["'0' in arr", `const a: any[] = [1, 2]; return ("0" in (a as any[])) ? 1 : 0;`, 1],
+    ["'length' in arr", `const a: any[] = [1, 2]; return ("length" in (a as any[])) ? 1 : 0;`, 1],
+    // an inherited method is named by the checker, so the fold answers 1 for
+    // `in` (correct: HasProperty walks the prototype chain) and the routing
+    // predicate never sees it.
+    ["'concat' in arr", `const a: any[] = [1]; return ("concat" in (a as any[])) ? 1 : 0;`, 1],
+    // …but it is NOT an own property.
+    ["concat is not own", `const a: any[] = [1]; return a.hasOwnProperty("concat") ? 1 : 0;`, 0],
+  ];
+  for (const [name, body, want] of UNCHANGED) {
+    it(`standalone: ${name}`, async () => {
+      expect(await run(fn(body), "standalone")).toBe(want);
+    });
+    it(`host: ${name}`, async () => {
+      expect(await run(fn(body), "host")).toBe(want);
+    });
+  }
+
+  // The plain-object control: standalone is the spec answer, host is NOT — and
+  // was not before this change either (verified by file-copy revert on the same
+  // instrument). Asserted in both directions so the host gap stays visible and
+  // this fix cannot be blamed for it.
+  const PLAIN_OBJ = fn(`const o: any = {}; o.foo = 7; return o.hasOwnProperty("foo") ? 1 : 0;`);
+  it("standalone: plain object receiver (control) is own", async () => {
+    expect(await run(PLAIN_OBJ, "standalone")).toBe(1);
+  });
+  it("host: plain object receiver answers false (PRE-EXISTING host gap, base-verified)", async () => {
+    expect(await run(PLAIN_OBJ, "host")).toBe(0);
+  });
+
+  // The host lane is gated OUT of the route entirely (`ctx.standalone`), so its
+  // answers — including the ones it gets wrong — are unchanged by this fix.
+  it("host: array expando presence is unchanged (pre-existing host gap)", async () => {
+    expect(
+      await run(fn(`const a: any[] = []; (a as any).foo = 7; return a.hasOwnProperty("foo") ? 1 : 0;`), "host"),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

Wave 8a of the #4426 ES5-standalone campaign. The runtime presence chokepoints (`__hasOwnProperty`/`__object_hasOwn`/`__extern_has` with the #3251 overlay + #3537 bag arms) were already correct — the wrong answers never reached them. When the receiver&#39;s resolved Wasm type is a `__vec_` struct and the key is static, `compilePropertyIntrospection` (object-ops.ts) and `compileInOperator` (binary-ops-in.ts) fold from `structFieldNames ∪ checker properties` — a vec&#39;s field list is `[&#34;length&#34;,&#34;data&#34;]`, so a named expando written one line earlier folded to `i32.const 0`. The harness&#39;s `var a = []` shape always produces that statically-typed receiver, which is why `any`-typed probes could not reproduce it.

New `src/codegen/vec-named-key-presence.ts`: `vecNamedKeyNeedsRuntime` — standalone + vec receiver + non-index static key + **the fold&#39;s own answer would be `0`**. Widening only a `false` answer is the entire safety argument. Measured (paired file-copy revert, real harness): direct-gating set 0/3 → **2/3**; 197-file and 163-file control sets fully clean; host lane byte-identical on all probe binaries; 27-test pin. Verified on the integrated branch: 44/44 with the #4434 pins.

Residuals with owners in the issue file: typed-lane for-in named-key enumeration (#4222/#2001 — measured route documented, zero test262 gain today), inherited-accessor write consumption (#4176), the folded-`true` `&#34;data&#34;`/`&#34;length&#34;` physical-field cells (#3920/#4225 — demoting a `true` is the riskier direction, deliberately untouched), host-lane expando presence (#3116).

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_