### PR TITLE
fix(pages): copy standalone-editions-index.json into the pages dist

### DIFF
--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -408,6 +408,14 @@ const test262RunsStandaloneIndexSource = resolvePreferredFileOrNull(
   join(BENCHMARKS_RESULTS_DIR, "runs", "standalone-index.json"),
   join(PUBLIC_BENCH, "runs", "standalone-index.json"),
 );
+// Host-free per-edition twin (#4362) — consumed by the landing page's
+// edition-scope trend in standalone mode and report.html. Without this copy
+// the deployed site 404s the file and the standalone edition trend never
+// renders, even though promote-baseline appends it every run.
+const test262RunsStandaloneEditionsIndexSource = resolvePreferredFileOrNull(
+  join(BENCHMARKS_RESULTS_DIR, "runs", "standalone-editions-index.json"),
+  join(PUBLIC_BENCH, "runs", "standalone-editions-index.json"),
+);
 copyFile(test262ReportSource, join(PAGES_DIST, "benchmarks", "results", "test262-report.json"));
 if (test262StandaloneReportSource) {
   copyFile(test262StandaloneReportSource, join(PAGES_DIST, "benchmarks", "results", "test262-standalone-report.json"));
@@ -425,6 +433,12 @@ if (test262RunsStandaloneIndexSource) {
   copyFile(
     test262RunsStandaloneIndexSource,
     join(PAGES_DIST, "benchmarks", "results", "runs", "standalone-index.json"),
+  );
+}
+if (test262RunsStandaloneEditionsIndexSource) {
+  copyFile(
+    test262RunsStandaloneEditionsIndexSource,
+    join(PAGES_DIST, "benchmarks", "results", "runs", "standalone-editions-index.json"),
   );
 }
 


### PR DESCRIPTION
## Description

The standalone per-edition trend history (#4362) is collected on every promote — `append-run-history.mjs` appends to `runs/standalone-editions-index.json` in the baselines repo, and `deploy-pages.yml` fetches it into `benchmarks/results/runs/` — but `scripts/build-pages.js` never copied it into the pages dist. It only handled `index.json`, `editions-index.json`, and `standalone-index.json`, so the deployed site 404'd the standalone editions file and both consumers (`website/components/t262-conformance-trend.js` and `report.html`) got no series: the edition-scope trend in standalone mode stayed below the chart's 2-point render floor and never updated.

This adds the missing resolve+copy block, mirroring the adjacent `standalone-index.json` handling.

Verified locally: with a seeded `benchmarks/results/runs/standalone-editions-index.json`, `node scripts/build-pages.js` now emits `dist/pages/benchmarks/results/runs/standalone-editions-index.json` alongside the other three trend indexes.

## CLA

- [x] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQvctxnU19HU3JHrEp9M2u)_