### PR TITLE
feat(codegen): reflective String.prototype.match/search + dynamic-pattern deferred refusal (#4439)

### DIFF
--- a/plan/issues/4439-reflective-string-match-search-dynamic-regexp.md
+++ b/plan/issues/4439-reflective-string-match-search-dynamic-regexp.md
@@ -1,7 +1,7 @@
 ---
 id: 4439
 title: "Reflective String.prototype.match/search + dynamic-pattern residual — borrowed-method and runtime-pattern regexp shapes in standalone"
-status: in-progress
+status: in-review
 sprint: current
 assignee: ttraenkler/claude-es5-standalone
 created: 2026-08-15
@@ -17,6 +17,33 @@ language_feature: regexp-string-methods
 goal: standalone-gap
 related: [4426, 4220, 4232, 2928, 1539]
 origin: "2026-08-15 ES5-standalone campaign wave 8 — from the fresh baseline cluster map (built-ins/String/prototype 41 ES<=5 non-pass; 'Unsupported dynamic regular expression pattern' x8)."
+# The IMPLEMENTATION lives in the new subsystem module
+# `src/codegen/string-proto-match-search.ts` — these four are the unavoidable
+# seams it plugs into, and every one of them is a small, local edit:
+#   regexp-standalone.ts  the poison struct (replacing an in-place throw) +
+#                         nullable operand nodes for the reflective lane
+#   native-regex.ts       the `__regex_search` poison guard + its throw builder
+#   array-object-proto.ts the two dispatcher arms (the file IS the dispatcher)
+#   calls-closures.ts     one `noJsHost` argument on an existing refusal call
+# The majority of each delta is the explanatory comment the seam needs.
+loc-budget-allow:
+  - src/codegen/regexp-standalone.ts
+  - src/codegen/native-regex.ts
+  - src/codegen/array-object-proto.ts
+  - src/codegen/expressions/calls-closures.ts
+# All three are single-emitter functions whose body IS one contiguous Wasm
+# instruction list — splitting them would move instructions away from the
+# ordering contracts documented in-place, not reduce complexity:
+#   ensureDynamicStandaloneRegExpCompiler  one arm swapped from `throw` to a
+#     struct + `return`; the added lines are the struct's 12 operands and the
+#     note on why it is not the ~1030 empty-program hazard
+#   ensureRegexSearch  a 3-instruction guard at the head + its comment
+#   tryExternClassMethodOnAny  one argument added to an existing call; it
+#     crosses 300 only because it is already a long ladder of refusals
+func-budget-allow:
+  - src/codegen/regexp-standalone.ts::ensureDynamicStandaloneRegExpCompiler
+  - src/codegen/native-regex.ts::ensureRegexSearch
+  - src/codegen/expressions/calls-closures.ts::tryExternClassMethodOnAny
 ---
 
 # #4439 — reflective `String.prototype.match`/`search` + dynamic-pattern residual
@@ -73,3 +100,246 @@ Three related ES≤5 standalone clusters (fresh baseline 2026-08-15, es5id scope
 - S15.5.4.12_A1_T1/T2 and the S15.5.4.10 borrowed-match family flip, or each
   non-flip is root-caused in this file with an owner.
 - Zero regressions in the scoped regexp/string sweep; gc/host byte-identical.
+
+---
+
+## Implementation notes (2026-08-15)
+
+Three clusters, three DIFFERENT root causes. Only the first was the one the
+plan predicted; the other two were mis-attributed in the problem statement and
+are worth reading before touching this area again.
+
+### 1. Borrowed `match` / `search` — the predicted cause, confirmed
+
+`emitStringProtoMemberBody` (`src/codegen/array-object-proto.ts`) had no
+`match`/`search` arm, so the reflective closure body fell through to
+`emitProtoMemberBodyRefusal`. New module
+`src/codegen/string-proto-match-search.ts` supplies both.
+
+**The one design decision worth recording.** `string-proto-split.ts` documents
+a carve-out saying a reflective closure "receives its separator as a runtime
+`externref`, so there is no static pattern to compile and no runtime
+interpreter to fall back on." That reasoning does **not** transfer, and taking
+it at face value would have produced a ToString-only body that silently
+mismatches every borrowed `s.match(/re/)`:
+
+1. a backend-created RegExp **is** recoverable from an opaque `externref` —
+   `ref.test $NativeRegExp`, the same recovery `recoverRegExpStructFromExternref`
+   already does for `RegExp.prototype.test.call`; and
+2. there **is** a runtime compiler for everything else,
+   `__regex_compile_dynamic_simple` (#2161), which the direct path's
+   `RegExpCreate(ToString(v), "")` arm (`string-search-value.ts`) already calls.
+
+So the argument dispatch is a RUNTIME two-lane branch, not a compile-time
+decision. `split` legitimately stops at ToString because §22.1.3.23 has no
+RegExpCreate step; `match`/`search` have one, which is what makes the second
+lane spec-correct rather than a widening.
+
+The `g` flag is likewise only known at runtime here, so `match` picks between
+`__regex_match_all` and the `exec` path with a runtime test on the struct's
+flags field (both arms yield `ref null $__regexp_match_vec`, so they share one
+block type). Emitting only the `exec` arm would have been a silent wrong
+answer for a borrowed `match` with a `/…/g` argument.
+
+`emitRegexSearchCall` / `emitRegexExecArrayCall` now accept `ts.Expression |
+null` for their two operand nodes: a reflective closure has no operand AST at
+all. Null is only reachable together with the matching override.
+
+### 2. `Cache_match` — NOT a String.prototype problem
+
+The plan called this a "`Cache_match` host-import leak" to be gated on the host
+lane. It is not in the String-proto lane at all. `o.match = String.prototype.match;
+o.match(true)` reaches the `any`-receiver **extern-class first-match loop**
+(`compileExternClassMethodCallAny`, `src/codegen/expressions/calls-closures.ts`
+~L1838), which binds the FIRST registered extern class declaring `match` — the
+DOM `Cache` interface — and emits `env::Cache_match`.
+
+That loop already has the correct refusal (#3033: "if the program's OWN code
+defines a function-valued member of this name, the receiver is far more
+plausibly a user object"). It missed this shape for one reason:
+`sourceAssignsAliasedFunctionMember` required the assignment's RHS to be an
+**identifier**, and the ES5-sputnik spelling is a **property access**
+(`String.prototype.match`). Widened, keyed by RHS shape so the identifier-only
+answer is bit-for-bit what it was, and **opted into only under `noJsHost`** —
+host-side the import is satisfiable, so widening there would change host output
+for no host benefit (the gc/host byte-identity requirement).
+
+The refusal stays receiver-scoped: only the identifier this file assigned the
+member to declines the extern binding.
+
+### 3. Dynamic-pattern residual — deferred, not extended
+
+The plan asked for "a MODEST extension of the runtime subset (character
+classes, quantifiers on literals?)". Measured against the corpus, that is the
+wrong lever. The patterns are `[z-z]`, `[0-9]`, `a|b|[]`, `abc{1}` — character
+classes and counted quantifiers, i.e. genuine engine features (a runtime class
+table plus new bytecode), not tokenizer additions.
+
+But the tests do not need them. Every one of the affected S15.10.4.1_A8 files
+**constructs the RegExp and then reads only `.ignoreCase` / `.multiline` /
+`.global` / `.lastIndex` / `.source`** — none of them ever matches with the
+value. §22.2.3.1 RegExpInitialize does not fail for those patterns either;
+only *this compiler* cannot run them. So the defect was the *timing* of the
+refusal, not its absence.
+
+`__regex_compile_dynamic_simple` now returns a **poisoned** `$NativeRegExp`
+(`nGroups = 0`, `nScratch = 0`, zero-length `prog`, real flags + real `source`)
+instead of throwing, and `__regex_search` throws the identical catchable
+TypeError on first use. `nSlots = 2*nGroups + nScratch == 0` is unrepresentable
+for a compiled program (group 0 alone makes it ≥ 2), so the marker is
+unambiguous.
+
+**This is not the hazard the `~1030` comment warns about.** That warning is
+about manufacturing an empty *executable* program: the VM then ran it and read
+past its bounds, an **uncatchable** Wasm trap. Here the guard is the first
+thing in `__regex_search` and throws before the VM touches `prog` or `caps`.
+`__regex_search` is the single VM entry — `test` / `exec` / `search` / `match` /
+`matchAll` / `split` / `replace` and `__regex_run` are all reached through it —
+so the guard has complete coverage. A per-call-site guard was rejected for
+exactly that reason: partial coverage would resurrect the uncatchable trap.
+
+## Measurements
+
+Base = this branch's merge base (`origin/main` 09ecad8 + the wave-8 plan commit
+3a2189b), compiled and run by me on 2026-08-15 with the single-test /
+scoped-sweep drivers in `.tmp/`, `--target standalone`. Every "before" figure
+below is from a base run I executed, not from a baseline artifact.
+
+**Scoped sweep — `built-ins/String/prototype/{match,search,matchAll}` (119 files):**
+
+| | pass | fail | compile_error |
+| --- | --- | --- | --- |
+| base | 74 | 33 | 12 |
+| after | **78** | 29 | 12 |
+
+`gained=4 lost=0` — no status change anywhere else in the scope.
+
+**Per target file:**
+
+| file | before | after |
+| --- | --- | --- |
+| `String/prototype/search/S15.5.4.12_A1_T1.js` | FAIL `String.prototype.search is not yet implemented` | **PASS** |
+| `String/prototype/search/S15.5.4.12_A1_T2.js` | FAIL (same refusal) | **PASS** |
+| `String/prototype/match/this-val-obj.js` | FAIL `[0] === undefined` (`env::Cache_match`) | **PASS** |
+| `String/prototype/match/this-val-bool.js` | FAIL (same) | **PASS** |
+| `String/prototype/match/S15.5.4.10_A2_T17.js` | FAIL `match is not yet implemented` | FAIL `[0] === undefined` — see residual R1 |
+| `String/prototype/match/S15.5.4.10_A2_T18.js` | FAIL (same refusal) | FAIL — R1 |
+| `String/prototype/match/S15.5.4.10_A1_T3.js` | FAIL (same refusal) | FAIL — R1 |
+| `RegExp/S15.10.4.1_A8_T4.js` (`[z-z]`) | FAIL `Unsupported dynamic regular expression pattern` | **PASS** |
+| `RegExp/S15.10.4.1_A8_T5.js` (`abc{1}`) | FAIL (same) | **PASS** |
+| `RegExp/S15.10.4.1_A8_T3.js` (`a\|b\|[]`) | FAIL (same) | **PASS** |
+| `RegExp/S15.10.4.1_A8_T2.js` | FAIL (same) | **PASS** |
+| `RegExp/S15.10.3.1_A3_T2.js` | FAIL (same) | **PASS** |
+
+(`S15.10.4.1_A8_T7`, the `[0-9]`+"m" case, passed on base already — its flags
+operand is static enough for the other arm. It is listed in the plan's cluster
+but is not a gain; the A/B below is what settled that, a per-file check on the
+new tree alone would have mis-credited it.)
+
+The three A2_T17/T18/A1_T3 non-flips are root-caused below; the reflective body
+itself is correct for them (verified: `.length`, `.index`, `.input` and the
+STRING-key element read `m["0"]` are all right — only the NUMERIC index read is
+lost).
+
+**Collateral sweeps (both arms run by me, same box, same list, file-copy A/B):**
+
+| scope | files | base | after | delta |
+| --- | --- | --- | --- | --- |
+| `String/prototype/{match,search,matchAll}` | 119 | 74 / 33 / 12 | **78** / 29 / 12 | `gained=4 lost=0` |
+| `RegExp/S15.10.4.1_*` + `S15.10.3.1_*` | 52 | 46 / 6 | **51** / 1 | `gained=5 lost=0` |
+| `RegExp/prototype/{exec,test}` | 124 | 102 / 19 / 3 | 102 / 19 / 3 | `gained=0 lost=0` |
+
+(pass / fail / compile_error). The constructor-family scope is the population
+the deferral targets; the `exec`+`test` scope is its collateral check — the
+`__regex_search` poison guard sits on the single VM entry every regexp
+operation funnels through, and it does not move a single verdict there.
+
+**Net across the three measured scopes: +9 pass, 0 regressions.**
+
+**gc/host byte-identity: sha256-IDENTICAL on all 13 corpus programs**, compiled
+with no `target` (the default gc/host lane): the 11 `website/playground/examples`
+sources plus two written for this issue that exercise borrowed `match`/`search`
+and dynamic `RegExp` construction directly. That identity is what the two
+`noJsHost` gates buy — see the notes on the alias widening and on the
+poison/guard pair.
+
+**Unit suites:** `tests/issue-4439.test.ts` (new, 18 cases) passes; so do
+`es5-standalone-regexp`, `issue-1539-standalone-regex{,-replace}`,
+`issue-1539-standalone-array-coercion`, `regexp`, `issue-4016-…`,
+`issue-4220-…`, `issue-2161-{regex-symbol-protocol,matchall,regex-string-
+coercion,regex-const-ctor}`, `issue-4089-…`, `issue-3724-…`, `issue-4164`,
+`issue-682-regexp-standalone-abi` — 350 cases, 0 new failures.
+`issue-2875-slice3-search.test.ts` has **5 failures that reproduce identically
+on base** (the `includes`/`startsWith`/`endsWith` arm); A/B'd, not mine.
+
+## Residuals
+
+### R1 — `__extern_get_idx` answers `undefined` for a `$__regexp_match_vec` in a builtin-proto-dirty module — PRE-EXISTING, blocks 3 files
+
+**Not caused by this work, and not fixable inside it.** Minimal repro with zero
+#4439 code involved (`.tmp/t7.js`):
+
+```js
+Number.prototype.foo = 1;                              // ANY builtin-proto write
+var m = "10203040506070809000".match(/0./);            // the DIRECT path
+var box = {}; box.v = m; var w = box.v;                // force the externref lane
+w[0];        // undefined   ← wrong, should be "02"
+w.length;    // 1           ← right
+w["0"];      // "02"        ← right (string-key lane works)
+```
+
+Remove the `Number.prototype.foo = 1` line and `w[0]` is `"02"`. Replace it
+with a plain-object write (`var q = {}; q.foo = 1;`) and `w[0]` is `"02"`. A
+plain array in the same dirty module reads fine (`["a","b"]` → `w[0] === "a"`),
+so it is specific to the match-vec.
+
+Narrowed to `__extern_get_idx`'s arm ladder: under a builtin-proto write the
+finalize fills splice an extra arm ahead of the `$__vec_base`/nstr-vec arm, and
+control never reaches the arm that would read `vec.data[i]` — the receiver is
+answered with the Array-prototype consult (`protoIndexGetIdxMissInstrs(...,
+consultArray = 1)`, the `i32.const 18` = `ARR_OFF` delegate), i.e. every index
+is treated as a miss. WAT evidence: in the clean module the ladder is
+`[2, 4, 42, 84, 86]`; in the dirty module it is a spliced `[58]` followed by
+`[2, 4, 42]`, and the spliced arm returns the consult unconditionally.
+
+This blocks `S15.5.4.10_A2_T17/T18` and `A1_T3` — all three write
+`Number.prototype.match = String.prototype.match` and then read `[0]`.
+
+**Owner: the vec-overlay / proto-index lane (#4160 / #3673 / #4434 authors).**
+It is a general defect — it costs the DIRECT `s.match(re)[0]` path in every
+module that touches a builtin prototype — and it wants a fix in
+`object-runtime.ts` / `vec-overlay.ts`, not in the String-proto subsystem. It
+should be filed with its own id (`claim-issue.mjs --allocate`); this session
+was instructed not to push, so no id was reserved rather than burning one.
+
+### R2 — explicit `null` argument is treated as absent
+
+`s.match(null)` / `s.search(null)` build the EMPTY pattern rather than
+`ToString(null) === "null"`. The reflective ABI pads an omitted trailing
+argument with `ref.null.extern` and the #2106 regime's `__extern_is_undefined`
+answers true for both spellings, so the two are indistinguishable inside the
+closure. `string-proto-split.ts` carries the identical conflation; fixing it
+needs a distinct absent-argument marker in the closure ABI. Owner: whoever
+takes the reflective-ABI arity work.
+
+### R3 — `@@match` / `@@search` protocol objects
+
+An arbitrary object carrying a custom `@@match`/`@@search` is `ToString`'d
+rather than dispatched to that method (§22.1.3.14/.17 step 2). Visible as the
+still-failing `cstm-matcher-invocation` / `cstm-search-invocation` /
+`cstm-*-is-null` files, which now reach the poisoned-pattern TypeError instead
+of the construction one — same verdict, different message. Shared by the whole
+reflective String family; out of scope here.
+
+### Status note
+
+Left at **`in-review`**, not `done`: this session was instructed not to push or
+open a PR, so the author is not the merger — the handoff case the lifecycle
+reserves `in-review` for. Whoever lands the branch flips it to `done`.
+
+### R4 — the dynamic pattern subset itself
+
+Character classes and counted quantifiers are still uncompilable at runtime;
+they now fail at first MATCH instead of at construction. Extending the subset
+is real engine work (runtime class table + bytecode) and is deliberately not
+attempted here — see "Implementation notes §3".

--- a/plan/issues/4439-reflective-string-match-search-dynamic-regexp.md
+++ b/plan/issues/4439-reflective-string-match-search-dynamic-regexp.md
@@ -1,0 +1,75 @@
+---
+id: 4439
+title: "Reflective String.prototype.match/search + dynamic-pattern residual — borrowed-method and runtime-pattern regexp shapes in standalone"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: regexp-string-methods
+goal: standalone-gap
+related: [4426, 4220, 4232, 2928, 1539]
+origin: "2026-08-15 ES5-standalone campaign wave 8 — from the fresh baseline cluster map (built-ins/String/prototype 41 ES<=5 non-pass; 'Unsupported dynamic regular expression pattern' x8)."
+---
+
+# #4439 — reflective `String.prototype.match`/`search` + dynamic-pattern residual
+
+## Problem
+
+Three related ES≤5 standalone clusters (fresh baseline 2026-08-15, es5id scope):
+
+1. **Borrowed `match`/`search` throw the refusal** `String.prototype.<m> is
+   not yet implemented in --target standalone` — e.g.
+   `test/built-ins/String/prototype/search/S15.5.4.12_A1_T1.js`
+   (`new Object(true)` receiver, `search(true)` — a LITERAL pattern after
+   ToString), `match/S15.5.4.10_A2_T17/T18`, `A1_T3` (`match` bound to the
+   global object). The DIRECT lanes (`"abc".match(/b/)`, `.search(/b/)`)
+   already work.
+2. **`Cache_match` host-import leak** on `match/this-val-obj.js`,
+   `this-val-bool.js` (#2961 refusal).
+3. **`Unsupported dynamic regular expression pattern`** ×8 (e.g.
+   `built-ins/RegExp/S15.10.4.1_A8_T4.js`) — patterns outside
+   `__regex_compile_dynamic_simple`'s literal/alternation subset.
+
+## Implementation Plan
+
+1. Follow the established reflective-body pattern (`string-proto-split.ts` —
+   the closest sibling: it already returns a non-string result and handles a
+   TWO-lane arg: static RegExp vs ToString'd separator). Wire `match` and
+   `search` in `emitStringProtoMemberBody`
+   (`src/codegen/array-object-proto.ts`) to new bodies in a NEW module
+   (`string-proto-match-search.ts`), refusal fallback preserved.
+2. The arg dispatch at runtime: `ref.test` the native `$NativeRegExp` struct
+   (`ensureStandaloneRegExpStruct`, `regexp-standalone.ts`) → use its
+   prog/classTable/nGroups fields; otherwise ToString(arg) →
+   `ensureDynamicStandaloneRegExpCompiler` (`__regex_compile_dynamic_simple`,
+   regexp-standalone.ts ~1023) with empty flags.
+3. `search` semantics: `__regex_search`-based sequence
+   (`emitRegexSearchCallSequence` ~2189 — used by `.test`; returns match
+   start or -1) → box as Number. `match` (non-global): the `exec` result
+   shape — `__regex_capture_array` → `$__regexp_match_vec` (~2397) → null on
+   miss. Reuse the ensure* helpers; do NOT hand-roll a matcher.
+4. The `Cache_match` leak: locate the emit site (grep `Cache_match`), gate it
+   on the host lane, route standalone to the same new body.
+5. Dynamic-pattern residual: measure which of the 8 files' patterns fall
+   inside a MODEST extension of the runtime subset (character classes,
+   quantifiers on literals?) — extend only what the corpus needs, keep the
+   catchable-TypeError refusal for the rest (never manufacture an empty
+   program — the ~1030 comment explains the OOB hazard).
+6. Verify per-file with the single-test driver; scoped standalone run over
+   `built-ins/String/prototype/match|built-ins/String/prototype/search|built-ins/RegExp`
+   for collateral; the regexp unit suites (`es5-standalone-regexp*`,
+   `issue-1539*`) stay green.
+
+## Acceptance criteria
+
+- S15.5.4.12_A1_T1/T2 and the S15.5.4.10 borrowed-match family flip, or each
+  non-flip is root-caused in this file with an owner.
+- Zero regressions in the scoped regexp/string sweep; gc/host byte-identical.

--- a/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
+++ b/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
@@ -1,0 +1,64 @@
+---
+id: 4440
+title: "Function meta R1/R-attr slice — method name/length + own-property descriptor attributes (writable/enumerable/configurable)"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: function-properties
+goal: standalone-gap
+related: [4437, 4436, 2896]
+origin: "2026-08-15 ES5-standalone campaign wave 8 — #4437's R1 residual (class/object METHODS decline the meta) plus the descriptor-attribute family ('Expected obj[length] NOT to be writable' x4, Function/length 6 ES<=5 non-pass)."
+---
+
+# #4440 — function meta for METHODS + own-property descriptor attributes
+
+## Problem
+
+Two adjacent residuals #4437 left with owners-unassigned:
+
+1. **R1 — methods decline the meta.** `ensureMethodClosureSingleton` receives
+   a name + funcIdx, not a declaration node, so class/object-literal methods
+   have no `$fnmeta` and `name`/`length` reflection declines. All 8 remaining
+   `*length-dflt.js` files sit here. Method `name` needs the `get `/`set `
+   prefix rule and symbol-key handling (§10.2.9 SetFunctionName).
+2. **Descriptor attributes.** `length`/`name` are now own DATA properties on
+   plain functions (#4437), but their gOPD attributes must be
+   `{ writable:false, enumerable:false, configurable:true }` per ES2015+/
+   §15.1.5 ES5 (non-configurable in ES5 — test262 tests the MODERN attributes;
+   follow what the failing files assert). Fresh-baseline signatures:
+   `Expected obj[length] NOT to be writable, but was.` ×4;
+   `built-ins/Function/length` 6 non-pass (S15.3.5.1_A2_T*/A3_T* —
+   DontDelete/ReadOnly probes via assignment and delete).
+
+## Implementation Plan
+
+1. Base on #4437's modules: `function-instance-meta.ts` (write side),
+   `function-instance-meta-arms.ts` (read side), `function-instance-props.ts`.
+   Read #4437's issue file first — the nominal-struct discriminator rationale
+   and the `$arity` no-repoint constraint both bind here.
+2. R1: thread the declaration (or at minimum `{name, prefix-length}`) into
+   `ensureMethodClosureSingleton`'s callers so methods intern a meta too.
+   Where the declaration is genuinely unavailable, keep the decline.
+3. Attributes: the reflection arms (`hasOwnProperty`/gOPD/`__extern_get`)
+   answer for `length`/`name`; extend the gOPD synthesis to report the spec
+   attribute triple, and make WRITES respect writable:false (sloppy silent
+   no-op, strict TypeError — check what `__extern_set_strict` needs) and
+   `delete` respect configurable per the asserted edition semantics.
+4. Verify: the 8 `*length-dflt.js` files; `built-ins/Function/length/*`
+   (6 non-pass; S15.3.5.1_A2_T1-3, A3_T1-3); the `Expected obj[length] NOT
+   to be writable` ×4; #4437's 19-test pin + #4436's 23-test pin stay green;
+   140-file closure-heavy control from #4437's methodology.
+
+## Acceptance criteria
+
+- ≥6 of the named files flip; zero regressions in the control set; gc/host
+  byte-identical; non-flips root-caused here with owners.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -66,6 +66,7 @@ import { emitObjectProtoOrRefusal as emitProtoMemberBodyRefusal } from "./object
 import { emitStringConcatMemberBody } from "./string-proto-concat.js";
 import { emitStringSubstringMemberBody } from "./string-proto-substring.js";
 import { emitStringSplitMemberBody } from "./string-proto-split.js"; // (#4220) reflective String.prototype.split
+import { emitStringMatchSearchMemberBody } from "./string-proto-match-search.js"; // (#4439) reflective match/search
 import { emitStringReplaceMemberBody } from "./string-proto-replace-transfer.js"; // (#4232) reflective String.prototype.replace
 import { NO_ARG_STRING_MEMBER_HELPER, emitStringProtoToStringFlat } from "./string-proto-tostring.js"; // (#3992)
 import { standaloneGlobalFunctionSeedInstrs } from "./standalone-global-functions.js";
@@ -899,6 +900,16 @@ function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, m
   // undefined discipline. Same refusal fallback as its siblings.
   if (member === "concat")
     return emitStringConcatMemberBody(ctx, fctx) ?? emitProtoMemberBodyRefusal(ctx, fctx, "String", member);
+  // (#4439) `match` / `search` (§22.1.3.14 / §22.1.3.17) — the two members that
+  // build a RegExp from their argument. Unlike `split`'s ToString-only arm they
+  // reach the standalone regex engine, via a RUNTIME two-lane argument dispatch
+  // (`ref.test $NativeRegExp` vs `__regex_compile_dynamic_simple`); see
+  // string-proto-match-search.ts. Same refusal fallback as the siblings, which
+  // is also what keeps the host lane byte-identical (the body declines there).
+  if (member === "match" || member === "search")
+    return (
+      emitStringMatchSearchMemberBody(ctx, fctx, member) ?? emitProtoMemberBodyRefusal(ctx, fctx, "String", member)
+    );
   // (#4232) `replace` (§22.1.3.19) is `split`'s sibling in every structural
   // respect — reflective closure ABI, string-returning, ToString-everything —
   // and was the arm #4224 named as its leftover. Same refusal fallback.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -1782,7 +1782,11 @@ export function tryExternClassMethodOnAny(
   // handles genuine extern receivers correctly host-side.
   if (
     sourceDefinesFunctionMember(expr.getSourceFile(), methodName) ||
-    sourceAssignsAliasedFunctionMember(expr.getSourceFile(), propAccess.expression, methodName)
+    // (#4439) `noJsHost` widens the alias shape to a borrowed BUILTIN method
+    // (`o.match = String.prototype.match`), which otherwise first-matched the
+    // DOM `Cache.match` extern class and leaked `env::Cache_match` host-free.
+    // Host lane keeps the identifier-only answer, byte-identical.
+    sourceAssignsAliasedFunctionMember(expr.getSourceFile(), propAccess.expression, methodName, noJsHost(ctx))
   ) {
     return null;
   }

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -42,6 +42,38 @@ export const REGEX_ANCHORED_LITERAL_ALTS_MARKER = -0x40000000;
 const REGEX_CAP_MESSAGE = "RangeError: regular expression step limit exceeded";
 
 /**
+ * (#4439) The refusal a POISONED `$NativeRegExp` raises on first use.
+ *
+ * `__regex_compile_dynamic_simple` builds a poisoned value — `nGroups = 0`,
+ * `nScratch = 0`, zero-length `prog` — for a pattern outside its runtime
+ * grammar, instead of throwing at construction (§22.2.3.1 does not fail for
+ * `[z-z]` / `[0-9]` / `abc{1}`; only THIS compiler cannot run them). The
+ * message is shared with the constructor so the observable text is unchanged
+ * from the pre-#4439 construction-time throw.
+ */
+export const REGEX_UNSUPPORTED_DYNAMIC_PATTERN = "Unsupported dynamic regular expression pattern";
+
+/**
+ * (#4439) Build the throw sequence for a poisoned pattern — a catchable
+ * `TypeError` through the shared `$exc` tag, never a Wasm trap.
+ *
+ * Same ordering contract as {@link regexCapExhaustionThrow}: call it at the TOP
+ * of the helper that embeds it, BEFORE any funcIdx is captured, because
+ * `ensureLateImport("__new_TypeError")` can register a host import and shift
+ * every defined-function index.
+ */
+function regexUnsupportedPatternThrow(ctx: CodegenContext): Instr[] {
+  if (noJsHost(ctx)) emitWasiErrorConstructor(ctx, "TypeError", 1);
+  addStringConstantGlobal(ctx, REGEX_UNSUPPORTED_DYNAMIC_PATTERN);
+  const ctorIdx = ensureLateImport(ctx, "__new_TypeError", [{ kind: "externref" }], [{ kind: "externref" }]);
+  const tagIdx = ensureExnTag(ctx);
+  const instrs: Instr[] = [...stringConstantExternrefInstrs(ctx, REGEX_UNSUPPORTED_DYNAMIC_PATTERN)];
+  if (ctorIdx !== undefined) instrs.push({ op: "call", funcIdx: ctorIdx });
+  instrs.push({ op: "throw", tagIdx });
+  return instrs;
+}
+
+/**
  * (#2091) Build the instruction sequence for a regex VM step-cap-exhaustion
  * throw — a catchable `RangeError` instance (via the shared `$exc` tag), NOT a
  * silent `return 0` (which is indistinguishable from a genuine no-match).
@@ -1671,6 +1703,18 @@ export function ensureRegexRun(ctx: CodegenContext): number {
 export function ensureRegexSearch(ctx: CodegenContext): number {
   const existing = ctx.nativeRegexHelpers.get("__regex_search");
   if (existing !== undefined) return existing;
+  // (#4439) FIRST — before `ensureRegexRun` and before any funcIdx capture, per
+  // the `regexCapExhaustionThrow` ordering contract.
+  //
+  // HOST-LANE GATE, and it is load-bearing rather than an optimisation: a
+  // poisoned value can only be produced by `__regex_compile_dynamic_simple`,
+  // which is part of the STANDALONE regexp backend (host-side a dynamic RegExp
+  // goes to the host bridge). Building the throw unconditionally would call
+  // `ensureLateImport("__new_TypeError")`, which host-side registers a HOST
+  // IMPORT — adding one import to every gc/host module that uses a RegExp and
+  // shifting its function indices. That breaks the gc/host byte-identity this
+  // change is required to preserve, for a guard that can never fire there.
+  const poisonThrow = noJsHost(ctx) ? regexUnsupportedPatternThrow(ctx) : null;
   const runIdx = ensureRegexRun(ctx);
   const i32Arr = regexI32ArrayType(ctx);
   const strDataIdx = ctx.nativeStrDataTypeIdx;
@@ -1711,6 +1755,19 @@ export function ensureRegexSearch(ctx: CodegenContext): number {
     ALT_BODY_LEN = 15;
   const indexedLiteralAlt = buildIndexedAnchoredLiteralAltSearch(i32Arr, strDataIdx);
   const body: Instr[] = [
+    // (#4439) POISON GUARD — must precede every read of `prog` / `caps`.
+    // `nSlots == 0` is unrepresentable for a compiled program (group 0 alone
+    // makes it ≥ 2), so it means `__regex_compile_dynamic_simple` deferred an
+    // out-of-subset pattern to here. Throw the catchable TypeError now, before
+    // the VM can index a zero-length program or capture array — that OOB trap
+    // is uncatchable and is exactly what the deferral must not resurrect.
+    ...(poisonThrow === null
+      ? []
+      : ([
+          { op: "local.get", index: NSLOTS },
+          { op: "i32.eqz" },
+          { op: "if", blockType: { kind: "empty" }, then: poisonThrow },
+        ] satisfies Instr[])),
     ...indexedLiteralAlt.body,
     // Runtime-compiled `^(?:literal|literal|...)$` with no flags. Acorn builds
     // its keyword/reserved-word predicates in this exact generic form. Compare

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -49,6 +49,7 @@ import {
   MATCH_VEC_FIELD_INPUT,
   MATCH_VEC_FIELD_GROUPS,
   REGEX_ANCHORED_LITERAL_ALTS_MARKER,
+  REGEX_UNSUPPORTED_DYNAMIC_PATTERN,
   REGEXP_MATCH_VEC_STRUCT,
   regexI32ArrayType,
 } from "./native-regex.js";
@@ -78,6 +79,7 @@ import {
 import { emitReceiverBrandCheck } from "./receiver-brand.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression } from "./shared.js";
+import { noJsHost } from "./js-errors.js"; // (#4439) pairs the poison with its guard
 import { compileStringLiteral } from "./string-ops.js";
 import { tryCompileCoercedStringMatch, tryCompileCoercedStringSearch } from "./string-search-value.js";
 import { isPlainToStringReplacement } from "./string-proto-replace.js";
@@ -805,13 +807,16 @@ export function staticRegExpGroupMeta(
  * (#682's struct dodged this by having `flags:i32` at field[1]); putting the
  * i32 scalars first keeps the struct off that heuristic.
  */
-const RE_FIELD_FLAGS = 0;
+export const RE_FIELD_FLAGS = 0;
 export const RE_FIELD_NGROUPS = 1;
 export const RE_FIELD_PROG = 2;
 export const RE_FIELD_CLASS_TABLE = 3;
 const RE_FIELD_SOURCE = 4;
 export const RE_FIELD_NSCRATCH = 5; // #1959 — scratch slots for PROGRESS guards
-const RE_FIELD_LASTINDEX = 6;
+// (#4439) Exported for the reflective `String.prototype.match` body, which must
+// resolve the `g` flag and reset `lastIndex` at RUNTIME — the borrowed form has
+// no regex EXPRESSION for `staticRegExpFlags` to read.
+export const RE_FIELD_LASTINDEX = 6;
 
 /**
  * Push `2 * nGroups + nScratch` (the VM caps-array length) onto the stack,
@@ -1035,13 +1040,16 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
   const i32ArrIdx = regexI32ArrayType(ctx);
   const i32ArrRef: ValType = { kind: "ref", typeIdx: i32ArrIdx };
   const invalidMessage = "Invalid regular expression";
-  const unsupportedMessage = "Unsupported dynamic regular expression pattern";
   emitWasiErrorConstructor(ctx, "SyntaxError", 1);
+  // (#4439) The out-of-subset pattern no longer throws HERE — it returns a
+  // poisoned struct and `__regex_search` raises the TypeError on first use. The
+  // native TypeError ctor and the message constant are still registered from
+  // this site so the ordering contract is unchanged for callers that reach the
+  // dynamic compiler before any `__regex_search` is minted.
   emitWasiErrorConstructor(ctx, "TypeError", 1);
   addStringConstantGlobal(ctx, invalidMessage);
-  addStringConstantGlobal(ctx, unsupportedMessage);
+  addStringConstantGlobal(ctx, REGEX_UNSUPPORTED_DYNAMIC_PATTERN);
   const syntaxCtorIdx = ctx.funcMap.get("__new_SyntaxError")!;
-  const typeCtorIdx = ctx.funcMap.get("__new_TypeError")!;
   const exnTagIdx = ensureExnTag(ctx);
   const typeIdx = addFuncType(ctx, [strRef, strRef], [{ kind: "ref", typeIdx: structTypeIdx }]);
   const funcIdx = mintDefinedFunc(ctx);
@@ -1440,7 +1448,63 @@ export function ensureDynamicStandaloneRegExpCompiler(ctx: CodegenContext): numb
           op: "if",
           blockType: { kind: "empty" },
           then: throwConstructed(syntaxCtorIdx, invalidMessage),
-          else: throwConstructed(typeCtorIdx, unsupportedMessage),
+          // (#4439) OUT-OF-SUBSET PATTERN: build a POISONED regexp and return
+          // it, instead of throwing here.
+          //
+          // §22.2.3.1 RegExpInitialize does not fail for `[z-z]`, `[0-9]` or
+          // `abc{1}` — those are perfectly valid patterns this runtime grammar
+          // simply cannot compile. Throwing at CONSTRUCTION therefore failed
+          // tests that never match with the value at all: the whole
+          // S15.10.4.1_A8 family reads only `.ignoreCase`/`.multiline`/
+          // `.global`/`.lastIndex`/`.source` off the constructed RegExp
+          // (measured: A8_T4 `[z-z]`+"mig", A8_T5 `abc{1}`, A8_T7 `[0-9]`+"m").
+          // Deferring the refusal to first USE makes those observables correct
+          // while keeping the limitation loud for anything that actually
+          // matches.
+          //
+          // The poison is `nGroups = 0` (+ `nScratch = 0`), which is
+          // unrepresentable for a real program — every compiled pattern has at
+          // least group 0 — so `nSlots = 2*nGroups + nScratch` is 0 exactly for
+          // a poisoned value. `__regex_search` (the SINGLE VM entry: `test`,
+          // `exec`, `search`, `match`, `matchAll`, `split`, `replace` all reach
+          // the VM through it) rejects that with a catchable TypeError carrying
+          // this same message.
+          //
+          // This is NOT "manufacture an empty executable program" — the hazard
+          // the ~1030 note warns about. That failed because an empty program
+          // was RUN and the VM read past its bounds, an UNCATCHABLE Wasm trap.
+          // Here the zero-length program is never reached: the guard throws
+          // before the VM touches `prog` or `caps`.
+          //
+          // Paired with the `__regex_search` guard by the SAME `noJsHost`
+          // condition: the poison is only ever produced where the guard that
+          // catches it is emitted. Never let those two drift apart — an
+          // unguarded poison would run a zero-length program and trap
+          // uncatchably, the exact failure the deferral exists to avoid.
+          else: !noJsHost(ctx)
+            ? throwConstructed(ctx.funcMap.get("__new_TypeError")!, REGEX_UNSUPPORTED_DYNAMIC_PATTERN)
+            : [
+                { op: "local.get", index: FBITS },
+                { op: "i32.const", value: 0 }, // nGroups = 0 → POISON
+                { op: "i32.const", value: 0 },
+                { op: "array.new_default", typeIdx: i32ArrIdx }, // prog (never run)
+                { op: "i32.const", value: 0 },
+                { op: "array.new_default", typeIdx: i32ArrIdx }, // classTable
+                // `source` keeps the ordinary normalization so `.source` reads and
+                // `toString()` are unaffected by the poison.
+                { op: "local.get", index: PLEN },
+                { op: "i32.eqz" },
+                {
+                  op: "if",
+                  blockType: { kind: "val", type: strRef },
+                  then: nativeStringLiteralInstrs(ctx, "(?:)"),
+                  else: [{ op: "local.get", index: PATTERN }],
+                },
+                { op: "i32.const", value: 0 }, // nScratch
+                { op: "f64.const", value: 0 }, // lastIndex
+                { op: "struct.new", typeIdx: structTypeIdx },
+                { op: "return" },
+              ],
         },
       ],
     },
@@ -2195,12 +2259,19 @@ export function recoverRegExpStructFromExternref(
  * match flag (1/0) is left on the stack and the populated caps array is
  * available via the returned `capsLocal`. Returns `null` after reporting a
  * narrowed refusal if the regex value was not backend-created.
+ *
+ * (#4439) Both expressions may be `null` — but ONLY when the corresponding
+ * override is supplied, which is the reflective-closure case: a borrowed
+ * `String.prototype.match`/`search` body has no operand AST at all (its
+ * receiver and argument are closure params). The two nodes are used for
+ * exactly three things — `loadStandaloneRegExpStruct`, `compileExpression`, and
+ * a `reportError` location — and the overrides replace the first two.
  */
 export function emitRegexSearchCall(
   ctx: CodegenContext,
   fctx: FunctionContext,
-  regexpExpr: ts.Expression,
-  inputExpr: ts.Expression,
+  regexpExpr: ts.Expression | null,
+  inputExpr: ts.Expression | null,
   options?: {
     /**
      * §22.2.7.2 RegExpBuiltinExec [[LastIndex]] semantics for g/y regexps
@@ -2221,7 +2292,9 @@ export function emitRegexSearchCall(
   ensureNativeStringHelpers(ctx);
   const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
   if (flattenIdx === undefined) {
-    reportError(ctx, regexpExpr, "Codegen error: standalone RegExp backend missing native string helpers (#682).");
+    if (regexpExpr !== null) {
+      reportError(ctx, regexpExpr, "Codegen error: standalone RegExp backend missing native string helpers (#682).");
+    }
     return null;
   }
   const searchIdx = ensureRegexSearch(ctx);
@@ -2229,7 +2302,10 @@ export function emitRegexSearchCall(
   const strTypeIdx = ctx.nativeStrTypeIdx;
 
   // --- the compiled $NativeRegExp struct ---
-  const loaded = options?.regexpOverride ?? loadStandaloneRegExpStruct(ctx, fctx, regexpExpr);
+  // (#4439) A null `regexpExpr` is only reachable WITH `regexpOverride` (the
+  // reflective closure lane), so the `??` never falls through to a null node.
+  const loaded =
+    options?.regexpOverride ?? (regexpExpr === null ? null : loadStandaloneRegExpStruct(ctx, fctx, regexpExpr));
   if (loaded === null) return null;
   const { regexpLocal, structTypeIdx } = loaded;
 
@@ -2243,6 +2319,8 @@ export function emitRegexSearchCall(
   let normalizedOrdinaryInput = false;
   if (options?.inputOverride) {
     inputType = options.inputOverride();
+  } else if (inputExpr === null) {
+    return null; // (#4439) unreachable: a null node always comes with an override
   } else {
     inputType = compileExpression(ctx, fctx, inputExpr, { kind: "externref" });
     if (inputType !== null && inputType.kind !== "externref") {
@@ -2821,8 +2899,10 @@ function buildIndexPairExternref(
 export function emitRegexExecArrayCall(
   ctx: CodegenContext,
   fctx: FunctionContext,
-  regexpExpr: ts.Expression,
-  inputExpr: ts.Expression,
+  // (#4439) Both may be null in the reflective-closure lane — see
+  // `emitRegexSearchCall`, which this delegates to.
+  regexpExpr: ts.Expression | null,
+  inputExpr: ts.Expression | null,
   options?: {
     gyLastIndex?: boolean | "runtime";
     inputOverride?: () => ValType | null;
@@ -2858,7 +2938,7 @@ export function emitRegexExecArrayCall(
   let nGroups = 0;
   // (#4016) An overridden regex was built at RUNTIME, so `regexpExpr` is the
   // search-value argument, not a regex source — skip static recovery outright.
-  const meta = options?.regexpOverride ? null : staticRegExpGroupMeta(ctx, regexpExpr);
+  const meta = options?.regexpOverride || regexpExpr === null ? null : staticRegExpGroupMeta(ctx, regexpExpr);
   if (meta !== null) {
     groupNames = meta.groupNames;
     hasD = (meta.flags & RE_FLAG_D) !== 0;

--- a/src/codegen/source-function-members.ts
+++ b/src/codegen/source-function-members.ts
@@ -40,10 +40,35 @@ export function sourceDefinesFunctionMember(sourceFile: ts.SourceFile, name: str
   return names.has(name);
 }
 
+/**
+ * Does this file assign `<receiver>.<name> = <alias>` somewhere?
+ *
+ * `alias` is an identifier by default. `includeMemberAliases` additionally
+ * admits a PROPERTY-ACCESS right-hand side — `o.match = String.prototype.match`
+ * (#4439), the dominant ES5-sputnik spelling of borrowing a builtin method.
+ *
+ * Why that spelling had to be admitted, and why it is opt-in:
+ *
+ * - **The miss is not cosmetic.** With the property-access RHS unrecognized,
+ *   `o.match(v)` fell through to the extern-class first-match loop, which binds
+ *   the FIRST registered extern class declaring `match` — the DOM `Cache`
+ *   interface — and emitted `env::Cache_match`. That is a host import the
+ *   standalone runtime cannot satisfy (measured on
+ *   `built-ins/String/prototype/match/this-val-obj.js` and `this-val-bool.js`,
+ *   which the compiler's own host-import-leak diagnostic named).
+ * - **It stays RECEIVER-SCOPED.** The answer is `members[name] ∋ receiver.text`,
+ *   so only the very identifier this file assigned the member to declines the
+ *   extern binding; every other receiver keeps it.
+ * - **It is opt-in because the JS-HOST lane must stay byte-identical.** There
+ *   the `Cache_match` import is satisfiable, so widening the refusal would
+ *   change host-lane output for no host-lane benefit. The caller gates on
+ *   `noJsHost`.
+ */
 export function sourceAssignsAliasedFunctionMember(
   sourceFile: ts.SourceFile,
   receiver: ts.Expression,
   name: string,
+  includeMemberAliases = false,
 ): boolean {
   if (!ts.isIdentifier(receiver)) return false;
   let members = aliasedFunctionMembers.get(sourceFile);
@@ -55,16 +80,20 @@ export function sourceAssignsAliasedFunctionMember(
         node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         ts.isPropertyAccessExpression(node.left) &&
         ts.isIdentifier(node.left.expression) &&
-        ts.isIdentifier(node.right)
+        (ts.isIdentifier(node.right) || ts.isPropertyAccessExpression(node.right))
       ) {
-        const receivers = members!.get(node.left.name.text) ?? new Set<string>();
+        // Key by RHS shape so the identifier-only answer stays exactly what it
+        // was; the widened answer is a superset the caller opts into.
+        const key = ts.isIdentifier(node.right) ? node.left.name.text : `member:${node.left.name.text}`;
+        const receivers = members!.get(key) ?? new Set<string>();
         receivers.add(node.left.expression.text);
-        members!.set(node.left.name.text, receivers);
+        members!.set(key, receivers);
       }
       ts.forEachChild(node, visit);
     };
     visit(sourceFile);
     aliasedFunctionMembers.set(sourceFile, members);
   }
-  return members.get(name)?.has(receiver.text) === true;
+  if (members.get(name)?.has(receiver.text) === true) return true;
+  return includeMemberAliases && members.get(`member:${name}`)?.has(receiver.text) === true;
 }

--- a/src/codegen/string-proto-match-search.ts
+++ b/src/codegen/string-proto-match-search.ts
@@ -1,0 +1,404 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4439) Native bodies for the reflective `String.prototype.match` /
+ * `String.prototype.search` closures in `--target standalone`.
+ *
+ * The DIRECT call path (`"abc".match(/b/)`, `"abc".search(/b/)`) has been
+ * native since #1539/#4016. What was missing is the **borrowed / transferred**
+ * form the ES5 sputnik battery uses almost exclusively:
+ *
+ * ```js
+ * var o = new Object(true);
+ * o.search = String.prototype.search;
+ * o.search(true);                      // → 0  ("true".search(/true/))
+ *
+ * Number.prototype.match = String.prototype.match;
+ * (10203040506070809000).match(/0./)[0];   // → "02"
+ * ```
+ *
+ * Those reach the `native-proto.ts` closure factory, whose String glue
+ * (`array-object-proto.ts`) had no `match`/`search` arm — so the member fell
+ * through to `emitProtoMemberBodyRefusal` and threw
+ * `String.prototype.<m> is not yet implemented in --target standalone`.
+ *
+ * This module supplies the missing arms. It is `string-proto-split.ts`'s
+ * sibling in every structural respect (reflective closure ABI, its own module
+ * so the dispatcher stays a dispatcher and the LOC/function budget gates keep
+ * growth cohesive) and differs in exactly one place: **it does NOT stop at
+ * `ToString(searchValue)`.**
+ *
+ * ## Why the RegExp lane is reachable here and was not for `split`
+ *
+ * `string-proto-split.ts` documents a deliberate carve-out: a reflective
+ * closure receives its separator as a runtime `externref`, "so there is no
+ * static pattern to compile and no runtime interpreter to fall back on."
+ * That is only half true, and the other half is what this module uses:
+ *
+ *   1. A backend-created RegExp **is** a runtime value with a concrete WasmGC
+ *      shape — the `$NativeRegExp` struct. `ref.test` recovers it from the
+ *      opaque `externref` with no static provenance at all (the same recovery
+ *      `recoverRegExpStructFromExternref` does for `RegExp.prototype.test.call`).
+ *   2. For everything else there **is** a runtime compiler:
+ *      `__regex_compile_dynamic_simple` (#2161), which is exactly what the
+ *      direct-path `RegExpCreate(ToString(v), "")` arm of `string-search-value.ts`
+ *      already calls.
+ *
+ * So the argument dispatch is a two-lane runtime branch, not a compile-time
+ * decision — that is the whole design of this module:
+ *
+ * ```
+ * ref.test $NativeRegExp(arg) ? arg                       // a real RegExp
+ *                             : __regex_compile_dynamic_simple(P, "")
+ *                                 where P = undefined(arg) ? "" : ToString(arg)
+ * ```
+ *
+ * `split` keeps its ToString-only behaviour because §22.1.3.23 has no
+ * RegExpCreate step; `match`/`search` have one (§22.1.3.14 step 3 /
+ * §22.1.3.17 step 3), which is what makes the second lane spec-correct rather
+ * than a widening.
+ *
+ * ## Result shapes
+ *
+ * `search` → the match index or `-1`, boxed as a Number (`__box_number`), via
+ * the shared `__regex_search` sequence (`emitRegexSearchCall`) — the same
+ * helper `.test` and the direct `search` use.
+ *
+ * `match` → `null` on a miss, else the `exec`-shaped `$__regexp_match_vec`
+ * (element 0 + captures, with the `index`/`input`/`groups` own properties
+ * `emitRegexExecArrayCall` defines on it), boxed to `externref`. The `g` flag
+ * is only known at RUNTIME here, so the global all-matches walk
+ * (`__regex_match_all`) is selected by a runtime test on the struct's flags
+ * field rather than the static `staticRegExpFlags` the direct path uses. Both
+ * arms yield `ref null $__regexp_match_vec`, so they share one block type.
+ * Emitting only the exec arm would have been a SILENT WRONG ANSWER for a
+ * borrowed `match` with a `/…/g` argument, which this project rates worse than
+ * a refusal.
+ *
+ * ## Known deviations (shared with the sibling reflective bodies)
+ *
+ * - An explicit `null` argument is treated as an ABSENT one (empty pattern),
+ *   not as `ToString(null) === "null"`. The reflective closure ABI pads an
+ *   omitted trailing argument with `ref.null.extern`, and the #2106 regime's
+ *   `__extern_is_undefined` answers true for both spellings, so the two are
+ *   indistinguishable inside the closure. `string-proto-split.ts` carries the
+ *   identical conflation.
+ * - An arbitrary object carrying a custom `@@match`/`@@search` method is
+ *   `ToString`'d rather than dispatched to that method (§22.1.3.14/.17 step 2).
+ *   Same gap the whole reflective String family has.
+ */
+
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { allocLocal } from "./context/locals.js";
+import { undefinedSingletonActive } from "./any-helpers.js";
+import { emitBrandCheckTypeError } from "./native-proto.js";
+import {
+  ensureAnyToStringHelper,
+  ensureNativeStringHelpers,
+  flatStringType,
+  nativeStringLiteralInstrs,
+} from "./native-strings.js";
+import { ensureRegexMatchAll, ensureRegexMatchVecType, regexI32ArrayType } from "./native-regex.js";
+import { ensureObjectRuntime } from "./object-runtime.js";
+import { RE_FLAG_G } from "./regex/bytecode.js";
+import {
+  RE_FIELD_CLASS_TABLE,
+  RE_FIELD_FLAGS,
+  RE_FIELD_LASTINDEX,
+  RE_FIELD_NGROUPS,
+  RE_FIELD_NSCRATCH,
+  RE_FIELD_PROG,
+  emitRegexExecArrayCall,
+  emitRegexSearchCall,
+  ensureDynamicStandaloneRegExpCompiler,
+  ensureStandaloneRegExpStruct,
+  usesNativeRegExpProvider,
+} from "./regexp-standalone.js";
+import { ensureLateImport } from "./expressions/late-imports.js";
+import { flushLateImportShifts } from "./shared.js";
+import { emitStringProtoToStringFlat } from "./string-proto-tostring.js";
+import { ensureVecConstructorCarrier } from "./vec-constructor-carrier.js";
+
+/**
+ * Push `1` when the closure param at `paramIdx` holds `undefined`.
+ *
+ * Mirrors `string-proto-split.ts`'s private helper: the reflective ABI pads an
+ * omitted trailing argument with `ref.null.extern`, while the #2106 standalone
+ * regime represents a written `undefined` as a DISTINCT non-null sentinel
+ * externref, so both spellings must be recognized or `s.match()` would compile
+ * the pattern `"undefined"` instead of the empty one.
+ */
+function pushIsUndefined(ctx: CodegenContext, sink: Instr[], paramIdx: number): void {
+  sink.push({ op: "local.get", index: paramIdx }, { op: "ref.is_null" });
+  const isUndefIdx = undefinedSingletonActive(ctx) ? ctx.funcMap.get("__extern_is_undefined") : undefined;
+  if (isUndefIdx !== undefined) {
+    sink.push({ op: "local.get", index: paramIdx }, { op: "call", funcIdx: isUndefIdx }, { op: "i32.or" });
+  }
+}
+
+/**
+ * §22.1.3.14 / §22.1.3.17 step 1 — `? RequireObjectCoercible(this)`: throw a
+ * *catchable* TypeError (never a `ref.cast` trap) when `this` is null or
+ * undefined.
+ */
+function emitRequireObjectCoercible(ctx: CodegenContext, fctx: FunctionContext, member: string): void {
+  const rocThrow: Instr[] = [];
+  emitBrandCheckTypeError(ctx, rocThrow, `String.prototype.${member} called on null or undefined`);
+  pushIsUndefined(ctx, fctx.body, 1);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rocThrow });
+}
+
+/**
+ * Leave a non-null `$NativeRegExp` on the stack for the closure's argument slot
+ * (param 2), choosing between the two lanes at RUNTIME — see the module header.
+ *
+ * Every temporary instruction buffer is registered in `fctx.savedBodies` before
+ * anything is emitted into it. That is load-bearing, not tidiness: an
+ * `ensureLateImport` flush occurring while `fctx.body` points at one buffer
+ * walks `fctx.body` + `fctx.savedBodies`, and a buffer reachable from neither
+ * would keep pre-shift `funcIdx`s and call the wrong function.
+ */
+function emitRegExpOperand(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  structTypeIdx: number,
+  dynCompilerIdx: number,
+  anyToStrIdx: number,
+  flattenIdx: number,
+): void {
+  const outer = fctx.body;
+  fctx.savedBodies.push(outer);
+
+  // Lane A — the argument already IS a backend-created RegExp.
+  const regexpArm: Instr[] = [
+    { op: "local.get", index: 2 },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: structTypeIdx },
+  ];
+  fctx.savedBodies.push(regexpArm);
+
+  // Lane B — RegExpCreate(P, "") where P is "" for an absent/undefined
+  // argument (RegExpInitialize step 1) and `ToString(arg)` otherwise.
+  const createArm: Instr[] = [];
+  const toStringArm: Instr[] = [];
+  fctx.savedBodies.push(createArm, toStringArm);
+
+  fctx.body = toStringArm;
+  emitStringProtoToStringFlat(ctx, fctx, 2, anyToStrIdx, flattenIdx);
+
+  fctx.body = createArm;
+  pushIsUndefined(ctx, fctx.body, 2);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: flatStringType(ctx) },
+    then: [...nativeStringLiteralInstrs(ctx, "")],
+    else: toStringArm,
+  });
+  for (const instr of nativeStringLiteralInstrs(ctx, "")) fctx.body.push(instr); // flags
+  fctx.body.push({ op: "call", funcIdx: dynCompilerIdx });
+
+  fctx.body = outer;
+  fctx.body.push(
+    { op: "local.get", index: 2 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: structTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "ref", typeIdx: structTypeIdx } },
+      then: regexpArm,
+      else: createArm,
+    },
+  );
+}
+
+/**
+ * Native body for a reflective `String.prototype.match(regexp)` /
+ * `String.prototype.search(regexp)` closure. Closure ABI: `this` = param 1,
+ * the search value = param 2 (both spec arity 1, so one arg slot).
+ *
+ * Spec order (observable — the receiver's `toString` runs before the
+ * argument's, and the sputnik battery's boxed-primitive receivers exercise
+ * exactly that):
+ *
+ *   1. `? RequireObjectCoercible(this)`
+ *   3. `S = ? ToString(this)`
+ *   4. `rx = ? RegExpCreate(searchValue, undefined)` — or the value itself
+ *      when it already carries the native RegExp brand
+ *   5. the `@@search` / `@@match` core
+ *
+ * Returns `externref` (the uniform closure result). `null` here means "no
+ * native body" and the caller falls through to its refusal, exactly as for the
+ * `split` / `concat` / `replace` siblings.
+ */
+export function emitStringMatchSearchMemberBody(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  member: "match" | "search",
+): ValType | null {
+  // Host lane and any build without the standalone engine keep the refusal:
+  // there `String.prototype.match` is served by the host bridge.
+  if (!usesNativeRegExpProvider(ctx) || !ctx.nativeStrings || ctx.anyStrTypeIdx < 0) return null;
+
+  // (1) Every late-import / type / helper registration happens FIRST and is
+  // settled by ONE flush, so each funcIdx fetched BY NAME below is
+  // post-shift-correct. This is the discipline every sibling reflective body
+  // follows (see `emitStringSplitMemberBody`).
+  ensureNativeStringHelpers(ctx);
+  ensureObjectRuntime(ctx); // registers `__extern_is_undefined`
+  // The result of `match` reaches the caller as an `externref`, so every
+  // property read on it goes through the dynamic `__extern_get` native. Demand
+  // the runtime `.constructor` carrier for the same reason `split` does.
+  if (member === "match") {
+    ensureVecConstructorCarrier(ctx);
+    ensureRegexMatchVecType(ctx);
+    ensureRegexMatchAll(ctx);
+  }
+  const structTypeIdx = ensureStandaloneRegExpStruct(ctx);
+  const dynCompilerMinted = ensureDynamicStandaloneRegExpCompiler(ctx);
+  flushLateImportShifts(ctx, fctx);
+
+  // (2) Helper funcIdxs, after the shifts.
+  const anyToStrIdx = ensureAnyToStringHelper(ctx);
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  const dynCompilerIdx = ctx.nativeRegexHelpers.get("__regex_compile_dynamic_simple") ?? dynCompilerMinted;
+  if (flattenIdx === undefined) return null; // caller falls through to its refusal
+
+  // Step 1.
+  emitRequireObjectCoercible(ctx, fctx, member);
+
+  // Step 3: S = ? ToString(this), flattened. Kept as the FLAT struct so the
+  // global-match arm can read data/off/len directly; `emitRegexSearchCall`
+  // re-flattens (a no-op on an already-flat string) through its input override.
+  emitStringProtoToStringFlat(ctx, fctx, 1, anyToStrIdx, flattenIdx);
+  const subjLocal = allocLocal(fctx, `__ms_subj_${fctx.locals.length}`, flatStringType(ctx));
+  fctx.body.push({ op: "local.set", index: subjLocal });
+  const inputOverride = (): ValType => {
+    fctx.body.push({ op: "local.get", index: subjLocal });
+    return flatStringType(ctx);
+  };
+
+  // Step 4: rx.
+  emitRegExpOperand(ctx, fctx, structTypeIdx, dynCompilerIdx, anyToStrIdx, flattenIdx);
+  const reLocal = allocLocal(fctx, `__ms_re_${fctx.locals.length}`, { kind: "ref", typeIdx: structTypeIdx });
+  fctx.body.push({ op: "local.set", index: reLocal });
+  const regexpOverride = { regexpLocal: reLocal, structTypeIdx };
+
+  if (member === "search") return emitSearchResult(ctx, fctx, regexpOverride, inputOverride);
+  return emitMatchResult(ctx, fctx, subjLocal, regexpOverride, inputOverride);
+}
+
+/**
+ * §22.2.6.13 `RegExp.prototype[@@search]` — the match start or `-1`, boxed as a
+ * Number. `search` ignores the `g` flag and never advances `lastIndex`, so the
+ * shared `__regex_search` sequence is used with its default start-at-0.
+ *
+ * `__box_number` is resolved AFTER the search sequence: that sequence may add
+ * its own late imports, and in the standalone regime `__box_number` can be a
+ * DEFINED function (`addUnionImportsAsNativeFuncs`) whose index moves with an
+ * import batch — so a funcIdx captured before it would be stale.
+ */
+function emitSearchResult(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  regexpOverride: { regexpLocal: number; structTypeIdx: number },
+  inputOverride: () => ValType,
+): ValType | null {
+  const emitted = emitRegexSearchCall(ctx, fctx, null, null, { regexpOverride, inputOverride });
+  if (emitted === null) return null;
+  const i32Arr = regexI32ArrayType(ctx);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "f64" } },
+    then: [
+      { op: "local.get", index: emitted.capsLocal },
+      { op: "i32.const", value: 0 },
+      { op: "array.get", typeIdx: i32Arr },
+      { op: "f64.convert_i32_s" },
+    ],
+    else: [{ op: "f64.const", value: -1 }],
+  });
+  const idxLocal = allocLocal(fctx, `__ms_idx_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "local.set", index: idxLocal });
+
+  const minted = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  const boxIdx = ctx.funcMap.get("__box_number") ?? minted;
+  if (boxIdx === undefined) return null;
+  fctx.body.push({ op: "local.get", index: idxLocal }, { op: "call", funcIdx: boxIdx });
+  return { kind: "externref" };
+}
+
+/**
+ * §22.2.6.8 `RegExp.prototype[@@match]` with the `g` flag resolved at RUNTIME.
+ *
+ * Global: `__regex_match_all` collects every `[0]` substring and `lastIndex`
+ * ends at 0 (the net spec effect of the exec loop). Non-global (incl. sticky):
+ * the shared `exec` path. Both arms produce `ref null $__regexp_match_vec`, so
+ * one `extern.convert_any` boxes either — and a miss (`ref.null`) becomes a
+ * null externref, which the standalone value model reads as `null`.
+ */
+function emitMatchResult(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  subjLocal: number,
+  regexpOverride: { regexpLocal: number; structTypeIdx: number },
+  inputOverride: () => ValType,
+): ValType | null {
+  const { regexpLocal, structTypeIdx } = regexpOverride;
+  const matchVecTypeIdx = ensureRegexMatchVecType(ctx);
+  const matchAllIdx = ensureRegexMatchAll(ctx);
+  const strTypeIdx = ctx.nativeStrTypeIdx;
+  const resultType: ValType = { kind: "ref_null", typeIdx: matchVecTypeIdx };
+
+  const outer = fctx.body;
+  fctx.savedBodies.push(outer);
+  const globalArm: Instr[] = [];
+  const execArm: Instr[] = [];
+  fctx.savedBodies.push(globalArm, execArm);
+
+  fctx.body = globalArm;
+  const allLocal = allocLocal(fctx, `__ms_all_${fctx.locals.length}`, resultType);
+  fctx.body.push(
+    { op: "local.get", index: regexpLocal },
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_PROG },
+    { op: "local.get", index: regexpLocal },
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_CLASS_TABLE },
+    { op: "local.get", index: regexpLocal },
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NGROUPS },
+    { op: "local.get", index: subjLocal },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // data
+    { op: "local.get", index: subjLocal },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // off
+    { op: "local.get", index: subjLocal },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }, // len
+    { op: "local.get", index: subjLocal },
+    { op: "local.get", index: regexpLocal },
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_NSCRATCH },
+    { op: "call", funcIdx: matchAllIdx },
+    { op: "local.set", index: allLocal },
+    // lastIndex = 0 — the net effect of the spec's exec loop on a global regex.
+    { op: "local.get", index: regexpLocal },
+    { op: "f64.const", value: 0 },
+    { op: "struct.set", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_LASTINDEX },
+    { op: "local.get", index: allLocal },
+  );
+
+  fctx.body = execArm;
+  const exec = emitRegexExecArrayCall(ctx, fctx, null, null, {
+    gyLastIndex: "runtime",
+    regexpOverride,
+    inputOverride,
+  });
+
+  fctx.body = outer;
+  if (exec === null) return null;
+  fctx.body.push(
+    { op: "local.get", index: regexpLocal },
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_FLAGS },
+    { op: "i32.const", value: RE_FLAG_G },
+    { op: "i32.and" },
+    { op: "if", blockType: { kind: "val", type: resultType }, then: globalArm, else: execArm },
+    { op: "extern.convert_any" },
+  );
+  return { kind: "externref" };
+}

--- a/tests/issue-4439.test.ts
+++ b/tests/issue-4439.test.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4439 — reflective `String.prototype.match` / `search` in `--target
+ * standalone`, plus the dynamic-pattern refusal's move from CONSTRUCTION to
+ * first USE.
+ *
+ * Three defects, three groups below:
+ *
+ *  1. **A borrowed `match`/`search` runs natively.** `o.search = String.
+ *     prototype.search; o.search(v)` reaches the `native-proto.ts` closure
+ *     factory, whose String glue had no arm for these two members — so the
+ *     call threw `String.prototype.search is not yet implemented in --target
+ *     standalone`. The argument is dispatched at RUNTIME: `ref.test
+ *     $NativeRegExp` for a real RegExp, `__regex_compile_dynamic_simple` on
+ *     `ToString(arg)` otherwise.
+ *  2. **No host import leaks.** `runStandalone` asserts the module imports
+ *     NOTHING. That is the regression guard for the second defect, which was
+ *     not in the String lane at all: the `any`-receiver extern-class
+ *     first-match loop bound `o.match(v)` to `env::Cache_match` (the DOM
+ *     `Cache` interface declares `match`), unsatisfiable host-free.
+ *  3. **An out-of-subset dynamic pattern constructs.** `new RegExp(objWith-
+ *     ToString("[0-9]"), "gim")` is a valid pattern this runtime grammar
+ *     cannot compile; §22.2.3.1 does not fail for it, so construction must
+ *     succeed and expose the flags/source. The refusal fires — still a
+ *     catchable TypeError, never a Wasm trap — only when the value is used.
+ *
+ * Two harness constraints, both learned by getting them wrong first:
+ *
+ *  - **Compile as JAVASCRIPT** (`allowJs` + a `.js` fileName), which is what
+ *    test262 does. The borrowed-method shapes are lowered differently in the
+ *    TypeScript lane — `o.search(v)` on a `const o: any` never reaches the
+ *    reflective closure there — so a TS-worded version of these cases would
+ *    assert nothing about this code.
+ *  - **Compare, don't coerce.** A reflective closure returns a BOXED number
+ *    externref; `(v as number)` in arithmetic reads NaN. `v === 2` is the
+ *    idiom every sibling reflective-closure suite uses (see
+ *    `issue-2875-slice3-search.test.ts`).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string, fn = "f"): Promise<unknown> {
+  const r = await compile(src, {
+    target: "standalone",
+    allowJs: true,
+    fileName: "issue-4439.js",
+    skipSemanticDiagnostics: true,
+  });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const mod = await WebAssembly.compile(r.binary as BufferSource);
+  // The whole point of the standalone lane — and the `Cache_match` guard.
+  expect(WebAssembly.Module.imports(mod)).toEqual([]);
+  const { exports } = await WebAssembly.instantiate(mod, {});
+  return (exports as Record<string, () => unknown>)[fn]!();
+}
+
+/** `new Object(true)` → the boxed-primitive receiver the sputnik battery uses. */
+const BORROWED = `var o = new Object(true);
+  o.search = String.prototype.search;
+  o.match = String.prototype.match;`;
+
+describe("#4439 — borrowed String.prototype.search", () => {
+  it.each([
+    // Lane A — the argument already carries the native RegExp brand.
+    ["RegExp argument", `o.search(/ue/) === 2`],
+    // Lane B — ToString(arg) → the runtime pattern compiler.
+    ["boolean argument", `o.search(true) === 0`],
+    ["string argument", `o.search("ue") === 2`],
+    ["no match", `o.search("zz") === -1`],
+    // RegExpCreate(undefined) is the EMPTY pattern, so this is 0, not -1.
+    ["absent argument", `o.search() === 0`],
+  ])("%s", async (_label, test) => {
+    expect(await runStandalone(`export function f() { ${BORROWED} return (${test}) ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("throws a catchable TypeError on a null receiver", async () => {
+    const src = `export function f() {
+      try { String.prototype.search.call(null, "a"); return 0; }
+      catch (e) { return (e instanceof TypeError) ? 1 : 2; }
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+});
+
+describe("#4439 — borrowed String.prototype.match", () => {
+  it.each([
+    ["exec-shaped element 0", `m !== null && m[0] === "true"`],
+    ["spec `index` own property", `m !== null && m.index === 0`],
+    ["null on a miss", `o.match("zz") === null`],
+  ])("%s", async (_label, test) => {
+    const src = `export function f() { ${BORROWED} var m = o.match(true); return (${test}) ? 1 : 0; }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("takes the all-matches walk for a GLOBAL RegExp, resolved at runtime", async () => {
+    // The reflective body has no regex EXPRESSION, so `g` is read off the
+    // struct's flags field at RUNTIME. Emitting only the exec arm would answer
+    // 1 here instead of 3 — a silent wrong answer, which is why the runtime
+    // branch exists.
+    const src = `export function f() {
+      var n = new Object(1011);
+      n.match = String.prototype.match;
+      var g = n.match(/1/g);
+      return (g !== null && g.length === 3) ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("keeps the exec shape for a NON-global RegExp on the same receiver", async () => {
+    const src = `export function f() {
+      var n = new Object(1011);
+      n.match = String.prototype.match;
+      var e = n.match(/1/);
+      return (e !== null && e.length === 1 && e.index === 0) ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+});
+
+describe("#4439 — an out-of-subset dynamic pattern constructs, then refuses on use", () => {
+  // A DYNAMIC pattern is required: `new RegExp("[0-9]", "g")` with both
+  // operands static is compiled by the STATIC path, which supports classes.
+  const DYNAMIC = `new RegExp({ toString: function () { return "[0-9]"; } }, (function () { return "gim"; })())`;
+
+  it.each([
+    ["global flag", `re.global === true`],
+    ["ignoreCase flag", `re.ignoreCase === true`],
+    ["multiline flag", `re.multiline === true`],
+    ["lastIndex", `re.lastIndex === 0`],
+    ["source is defined", `typeof re.source !== "undefined"`],
+  ])("exposes the %s of a pattern the runtime grammar cannot compile", async (_label, test) => {
+    expect(await runStandalone(`export function f() { var re = ${DYNAMIC}; return (${test}) ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("raises a CATCHABLE TypeError on first use, never a trap", async () => {
+    const src = `export function f() {
+      var re = ${DYNAMIC};
+      try { re.test("a1b"); return 0; }
+      catch (e) { return (e instanceof TypeError) ? 1 : 2; }
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("still throws SyntaxError at construction for genuinely invalid syntax", async () => {
+    // The lone-`[` shape keeps the spec error FAMILY — only the
+    // valid-but-uncompilable patterns were deferred.
+    const src = `export function f() {
+      try { var bad = new RegExp((function () { return "["; })(), ""); return bad ? 0 : 0; }
+      catch (e) { return (e instanceof SyntaxError) ? 1 : 2; }
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

Wave 8b of the #4426 ES5-standalone campaign. Three root causes, only the first the predicted one (full writeup in the issue file):

1. **No `match`/`search` reflective arms** — new `string-proto-match-search.ts` with a runtime two-lane argument dispatch: `ref.test $NativeRegExp` recovers a real RegExp from the opaque externref; anything else goes ToString → `__regex_compile_dynamic_simple`. The `g` flag is likewise runtime-resolved.
2. **`Cache_match` was not a String-lane leak** — it's the `any`-receiver extern-class first-match loop binding `o.match(v)` to the DOM `Cache` interface (the #3033 refusal missed property-access RHS). Fixed at the binding site.
3. **The dynamic-pattern lever was timing, not subset size** — the corpus's `[z-z]`/`[0-9]`/`abc{1}` patterns are never *matched* by the tests; §22.2.3.1 must not throw at construction. Refusal now defers to first use via a poisoned struct + a guard on the single VM entry.

Measured (file-copy A/B, both arms executed): **net +9 pass, 0 regressions** — `String/prototype/{match,search,matchAll}` 74→78 of 119, `RegExp/S15.10.4.1_*`+`S15.10.3.1_*` 46→51 of 52, exec/test 124-file control unchanged. gc/host sha256-identical on 13 corpus programs; 350 unit cases green; 18-test pin. Verified on the integrated branch: 18/18 + 45/45 with the wave-8a pins.

Residuals with owners in the issue file — R1 (`__extern_get_idx` on a `$__regexp_match_vec` receiver in builtin-prototype-writing modules, pre-existing, blocks the 3 remaining match files; vec-overlay lane) is the notable one.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_