### PR TITLE
fix(#4097): class-throw struct identity — harness renderer arm for user error classes, IR claims class throws

### DIFF
--- a/plan/issues/4097-ir-class-throw-struct-identity-unification.md
+++ b/plan/issues/4097-ir-class-throw-struct-identity-unification.md
@@ -1,10 +1,17 @@
 ---
 id: 4097
 title: "Lift the IR class-instance-throw demote: unify IR class-allocation struct identity with legacy collectClassDeclaration"
-status: ready
+status: done
+completed: 2026-08-15
 sprint: current
 created: 2026-08-02
-updated: 2026-08-02
+updated: 2026-08-15
+loc-budget-allow:
+  # +26 lines: the user-class render arm must be built in the SAME
+  # index-shift-safe window as the #4394 fnctor arms it mirrors (every helper
+  # index and literal global is resolved before either body is built), so it
+  # cannot move out of this emitter.
+  - src/codegen/native-strings.ts
 priority: medium
 horizon: m
 feasibility: medium
@@ -82,20 +89,131 @@ harness can *report*. Size it first (count standalone entries whose recorded
 error is the opaque label), then decide priority. Do not quote a conformance
 delta that has not been measured.
 
+# Root cause — MEASURED 2026-08-15 (the hypothesis above is REFUTED)
+
+Struct identity is **not** the mechanism. Dumping `ctx.typeIdxToStructName` +
+`ctx.structFields` at `emitExceptionRenderExports` for the exact repro, on both
+paths (`--target standalone`, `hostBridge: always`):
+
+| path | registered class struct | `$Error_struct` | `irCompiledFuncs` | render |
+| --- | --- | --- | --- | --- |
+| legacy | typeIdx **45** `Test262Error` (`__tag:i32, message:ref_null`) | 49 | `undefined` | `"Test262Error: Expected a to equal b"` |
+| IR (decline lifted) | typeIdx **45** `Test262Error` (identical fields) | 77 | `["test","Test262Error_new"]` | `"[object Object]"` |
+
+Same typeIdx, same name, same fields, and the IR-allocated struct IS in
+`typeIdxToStructName` — so the render-side lookup does not "miss". The real
+divergence is **which value the `new` site allocates**:
+
+- `tryCompileBuiltinGlobalNew` (`src/codegen/expressions/new-builtin-globals.ts:378`)
+  claims `new Test262Error(...)` **by name**. Its shadow guard is
+  `errorCtorNameIsUserFunctionShadowed`, which matches only a `function`
+  declaration (#4394, deliberately narrow) — so a **`class Test262Error`**
+  does not decline it. Legacy therefore throws a native `$Error_struct`, which
+  `__any_to_string` renders through §20.5.3.4 `__error_to_string`.
+- `lowerNewExpression` → `emitClassNew` has no such interception, so the IR
+  throws the genuine user-class struct, for which `__exn_render_prepare` had no
+  arm → the generic `"[object Object]"` terminal (which is what §7.1.17 says
+  for a class with no `toString`, so the compile was not "wrong" — it lost the
+  harness signal legacy synthesises).
+
+# Fix
+
+1. `emitExceptionRenderExports` (`src/codegen/native-strings.ts`) gains a
+   user-class arm alongside the #4394 declined-fnctor arms: for every struct in
+   `ctx.typeIdxToStructName` that is a **local class** (`ctx.classSet`), is not
+   `$Error_struct`, and carries a `message` field, render `"<ClassName>: " +
+   ToString(message)`. The arm lives in the harness renderer, **not** in
+   `__any_to_string`, so in-module `String(obj)` keeps its §7.1.17 behaviour.
+2. The `valueType.kind === "class"` arm of the `throw-value-unsupported`
+   decline in `lowerThrowStatement` (`src/ir/from-ast.ts`) is removed. The
+   numeric arm (`throw 42`) stays deferred — still needs a box helper.
+
+Because the arm is keyed on the struct, it is **path-independent**: legacy and
+IR render identically for every user-class payload. Deliberate, symmetric
+consequence — a thrown `class MyErr { message }` now renders `"MyErr: boom"` on
+**both** paths where both previously rendered `"[object Object]"`. That is a
+triage-signal improvement in the same direction as #4394, not an IR-only
+behaviour.
+
+# Measured behaviour after the fix (same probe matrix)
+
+| source | legacy | IR |
+| --- | --- | --- |
+| `class Test262Error { message }` | `Test262Error: Expected a to equal b` | same, `irCompiledFuncs` ⊇ `["test"]` |
+| `class MyErr { message }` | `MyErr: boom` | same, `test` IR-compiled |
+| `class MyErr { message; toString() }` | `MyErr: boom` | same |
+| `class Test262Error extends Error` | `Test262Error: wrapped` | same (IR claims nothing) |
+| `function Test262Error` (sta.js shape) | `[object Object]` | same (unchanged) |
+| `throw new TypeError("boom")` | `TypeError: boom` | same |
+| `class Pt { x }` (no `message`) | `[object Object]` | same |
+
+# Sizing the opaque-render population (acceptance 5)
+
+Measured against `test262-standalone-current.jsonl` (the **standalone** lane's
+per-test corpus in `loopdive/js2wasm-baselines`, downloaded 2026-08-15, 48,735
+entries — the host-lane `test262-current.jsonl` is the wrong artifact here: the
+render path exists only under standalone/WASI):
+
+| population | count |
+| --- | --- |
+| entries whose recorded error contains `[object Object]` (all `fail`) | 1,212 |
+| …of which the render **is** the whole error (the uncaught-throw shape this arm changes) | **2** |
+| …`Test262:AsyncTestFailure:Test262Error: [object Object]` (async rejection-reason ToString) | 551 |
+| …in-test assertion text (`String(obj)` inside the test — §7.1.17-correct) | 659 |
+| entries already carrying a real `Test262Error: <msg>` signature | 7,741 |
+| entries carrying the #2870 opaque label | 0 |
+
+Reading: the harness signal is **already intact** today (7,741 rows), because
+legacy's name interception synthesises it — which is exactly why #4035's
+decline was the right call and why this issue is about lifting it safely, not
+about recovering a lost population. The directly-addressed population is small
+(2 rows). The 551 async rows are a **different render site** (in-module
+`String(reason)` via `__any_to_string`, not `__exn_render_prepare`) and are
+deliberately untouched here: changing them means changing spec-correct
+`String(obj)` behaviour, which needs its own issue.
+
+So the payoff claim for this issue is coverage, not conformance: `throw <class
+instance>` returns to the IR path with the render pinned by value.
+
 # Acceptance
 
-- [ ] The struct-identity mechanism is confirmed (or corrected) by direct
+- [x] The struct-identity mechanism is confirmed (or corrected) by direct
       measurement of the emitted type indices, and written down here.
-- [ ] IR-lowered `throw <class instance>` renders identically to the legacy
+      **CORRECTED** — identical type indices on both paths; see "Root cause".
+- [x] IR-lowered `throw <class instance>` renders identically to the legacy
       path — verified **by value**, not by absence of a diagnostic.
-- [ ] The `throw-value-unsupported` decline for `valueType.kind === "class"`
+      (`tests/issue-4097.test.ts`, 7-row probe matrix above.)
+- [x] The `throw-value-unsupported` decline for `valueType.kind === "class"`
       in `lowerThrowStatement` is removed, and `irCompiledFuncs` again contains
       the throwing function (proving the IR body is really in use, not that the
-      test merely passes).
-- [ ] `tests/issue-2877.test.ts` stays **7/7**, and the case above is covered
+      test merely passes). Pinned by an explicit `toContain("test")`.
+- [x] `tests/issue-2877.test.ts` stays **7/7**, and the case above is covered
       by a test that would fail if the render regressed to `"[object Object]"`.
-- [ ] The opaque-render population is sized and recorded, so the payoff claim
-      is a measurement rather than an assumption.
+- [~] The opaque-render population is sized and recorded — sized as far as the
+      published artifacts allow, and the limit stated rather than estimated
+      past (see "Sizing the opaque-render population").
+
+# Test Results (2026-08-15)
+
+- `npx vitest run tests/issue-4097.test.ts` — **5/5 pass** (new).
+- `npx vitest run tests/issue-2877.test.ts` — **7/7 pass**.
+- `npx vitest run tests/issue-2962.test.ts tests/issue-2969.test.ts` — 22/22 pass.
+- `npx vitest run tests/issue-4394-test262-error-ctor-identity.test.ts
+  tests/issue-4394-test262-error-instanceof.test.ts
+  tests/issue-4394-shadowed-error-ctor.test.ts` — 13/13 pass.
+- `npx vitest run tests/issue-3613-render-parity.test.ts` — 2 failures, **pre-existing
+  on `origin/main`**: verified by an A/B file-copy revert of both changed sources
+  (same 2 failures at base; `tryNativeExnRender` returns null in this container).
+- `npm run typecheck`, `npx biome lint` (changed files), `prettier --check`,
+  `node scripts/check-func-budget.mjs` — clean. `check-loc-budget` passes via the
+  `loc-budget-allow` grant above.
+
+Residual risk, stated plainly: lifting the decline means a function that throws
+a class instance is now IR-compiled, so in standalone test262 the thrown
+`Test262Error` becomes a real class instance instead of legacy's `$Error_struct`
+at those sites. Catch-side field reads (`e.message`, `e.name`) still work for the
+runner's harness class (it declares both), and `instanceof` gets *more* correct,
+but the merge-queue test262 shards are the gate that arbitrates this.
 
 # Notes
 

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -2019,6 +2019,32 @@ export function emitExceptionRenderExports(ctx: CodegenContext): void {
       prefixInstrs: nativeStringLiteralInstrs(ctx, `${name}: `),
     });
   }
+  // (#4097) Same arm shape for a thrown USER-CLASS error instance. Legacy
+  // throws such a struct only for a class the builtin-error interception does
+  // NOT claim; the IR throws it for `class Test262Error` too (measured: both
+  // paths register the IDENTICAL struct — same typeIdx, name and fields — so
+  // the divergence is which VALUE the `new` site allocates, not struct
+  // identity, and #4035 declined the throw over the resulting
+  // "[object Object]"). Arms key on the struct's own registered name and are
+  // PATH-INDEPENDENT, so IR and legacy render alike. Gated on `ctx.classSet`
+  // (local class declarations only) plus a `message` field, so a plain data
+  // class keeps the canonical "[object Object]"; `$Error_struct` is skipped —
+  // `__any_to_string` already routes it through §20.5.3.4.
+  for (const [structTypeIdx, structName] of ctx.typeIdxToStructName) {
+    if (structTypeIdx === ctx.errorStructTypeIdx) continue;
+    if (!ctx.classSet.has(structName)) continue;
+    const fields = ctx.structFields.get(structName);
+    const fieldIdx = fields === undefined ? -1 : fields.findIndex((f) => f.name === "message");
+    if (fields === undefined || fieldIdx < 0) continue;
+    const ft = fields[fieldIdx].type;
+    if (ft.kind !== "externref" && ft.kind !== "anyref" && ft.kind !== "ref" && ft.kind !== "ref_null") continue;
+    fnctorArms.push({
+      typeIdx: structTypeIdx,
+      fieldIdx,
+      fieldIsExtern: ft.kind === "externref",
+      prefixInstrs: nativeStringLiteralInstrs(ctx, `${structName}: `),
+    });
+  }
   const fnctorConcatIdx = fnctorArms.length === 0 ? undefined : ctx.nativeStrHelpers.get("__str_concat");
   const anyStrTypeIdx = ctx.anyStrTypeIdx;
 

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -12027,10 +12027,10 @@ function lowerThrowStatement(stmt: ts.ThrowStatement, cx: LowerCtx): void {
   const value = lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
   const valueType = cx.builder.typeOf(value);
   const valTy = asVal(valueType);
-  if (valTy?.kind === "f64" || valTy?.kind === "i32" || valueType.kind === "class") {
-    // Slice 9 defers numerics (need a box helper) and class instances (#4035:
-    // `extern.convert_any` on an IR class struct renders as "[object Object]"
-    // not "Cls: msg" — a SILENT wrong answer, so IR declines). Legacy takes over.
+  if (valTy?.kind === "f64" || valTy?.kind === "i32") {
+    // Slice 9 still defers numerics (they need a box helper). Class instances
+    // are lowered again (#4097): #4035 declined them for a render gap that the
+    // `__exn_render_prepare` user-class arm now closes on BOTH paths.
     demoteToLegacy("throw-value-unsupported", `ir/from-ast: throw ${valueType.kind} not in slice 9 (${cx.funcName})`);
   }
   // Reference-shaped — coerce to externref. The helper is a no-op

--- a/tests/issue-4097.test.ts
+++ b/tests/issue-4097.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4097) IR-lowered `throw <class instance>` renders like the legacy path.
+//
+// #4035 made the IR DECLINE `throw <class instance>` because an IR-lowered
+// `throw new Test262Error(msg)` rendered "[object Object]" where legacy rendered
+// "Test262Error: msg" — a silent wrong answer. The measured mechanism was NOT a
+// struct-identity mismatch (both paths register the identical struct: same
+// typeIdx, same name, same fields): legacy's `tryCompileBuiltinGlobalNew`
+// INTERCEPTS `new Test262Error(...)` by name — a `class` declaration does not
+// shadow-guard it, only a `function` one does — and allocates a native
+// `$Error_struct`, which `__any_to_string` renders through §20.5.3.4
+// `__error_to_string`. The IR allocates the real user-class struct, for which
+// the renderer had no arm.
+//
+// The fix adds a path-INDEPENDENT arm to `__exn_render_prepare` for a thrown
+// user-class instance carrying a `message` field, so both paths render the same
+// text, and lifts the decline.
+//
+// Every assertion here is by VALUE, plus a non-vacuity check: the throwing
+// function must appear in `irCompiledFuncs`, or the test would pass simply
+// because the IR declined again.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { extractWasmExceptionMessage } from "./test262-runner.js";
+
+interface Rendered {
+  readonly message: string;
+  readonly irCompiledFuncs: readonly string[];
+}
+
+async function throwAndExtract(src: string, experimentalIR: boolean): Promise<Rendered> {
+  const r = await compile(src, {
+    fileName: "t.ts",
+    target: "standalone" as never,
+    hostBridge: "always",
+    experimentalIR,
+  });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  try {
+    (instance.exports as Record<string, () => unknown>).test();
+    throw new Error("expected the module to throw");
+  } catch (err) {
+    return { message: extractWasmExceptionMessage(err, instance), irCompiledFuncs: r.irCompiledFuncs ?? [] };
+  }
+}
+
+const TEST262_ERROR_SHAPE = `
+class Test262Error {
+  message: string;
+  constructor(message: string) { this.message = message; }
+}
+export function test(): number { throw new Test262Error("Expected a to equal b"); }
+`;
+
+const USER_ERROR_CLASS = `
+class MyErr {
+  message: string;
+  constructor(message: string) { this.message = message; }
+}
+export function test(): number { throw new MyErr("boom"); }
+`;
+
+const PLAIN_DATA_CLASS = `
+class Pt {
+  x: number;
+  constructor(x: number) { this.x = x; }
+}
+export function test(): number { throw new Pt(1); }
+`;
+
+describe("#4097 — IR-lowered throw of a class instance renders like legacy", () => {
+  it("renders the Test262Error assertion message (the shape #4035 declined)", async () => {
+    const ir = await throwAndExtract(TEST262_ERROR_SHAPE, true);
+    expect(ir.message).toBe("Test262Error: Expected a to equal b");
+    // NON-VACUITY: the IR body is really in use — this is what #4035 gave up.
+    expect(ir.irCompiledFuncs).toContain("test");
+  });
+
+  it("agrees with the legacy path by value on the same source", async () => {
+    const legacy = await throwAndExtract(TEST262_ERROR_SHAPE, false);
+    const ir = await throwAndExtract(TEST262_ERROR_SHAPE, true);
+    expect(ir.message).toBe(legacy.message);
+    expect(ir.message).not.toBe("[object Object]");
+  });
+
+  it("agrees on an ordinary user error class, with the IR body in use", async () => {
+    const legacy = await throwAndExtract(USER_ERROR_CLASS, false);
+    const ir = await throwAndExtract(USER_ERROR_CLASS, true);
+    expect(ir.message).toBe(legacy.message);
+    expect(ir.message).toBe("MyErr: boom");
+    expect(ir.irCompiledFuncs).toContain("test");
+  });
+
+  it("leaves a class with no `message` field on the canonical opaque label", async () => {
+    // The arm is gated on a `message` field, so a plain data class keeps the
+    // §7.1.17 "[object Object]" text on BOTH paths — the gate that stops this
+    // from becoming a blanket rename of every thrown struct.
+    const legacy = await throwAndExtract(PLAIN_DATA_CLASS, false);
+    const ir = await throwAndExtract(PLAIN_DATA_CLASS, true);
+    expect(legacy.message).toBe("[object Object]");
+    expect(ir.message).toBe(legacy.message);
+  });
+
+  it("control: the intrinsic Error family is unchanged", async () => {
+    const src = `export function test(): number { throw new TypeError("boom"); }`;
+    expect((await throwAndExtract(src, false)).message).toBe("TypeError: boom");
+    expect((await throwAndExtract(src, true)).message).toBe("TypeError: boom");
+  });
+});


### PR DESCRIPTION
## Description

Implements #4097 (IR-migration backfill queue). The issue's original hypothesis was corrected by measurement before implementation — the root-cause analysis is recorded in the issue file.

**Measured mechanism** (not the hypothesized registration miss): `tryCompileBuiltinGlobalNew` (`src/codegen/expressions/new-builtin-globals.ts:378`) claims `new Test262Error(...)` by name, and its #4394 shadow guard only matches a `function` declaration — so a `class Test262Error` doesn't decline it. Legacy then throws a native `$Error_struct` (rendered per §20.5.3.4) while the IR's `emitClassNew` throws the genuine class struct, which `__exn_render_prepare` had no arm for.

**Changes:**
- `src/codegen/native-strings.ts` — `emitExceptionRenderExports` gains a user-class arm beside the #4394 fnctor arms: any struct in `ctx.classSet` (excluding `$Error_struct`) with a `message` field renders `"<ClassName>: " + ToString(message)`. Harness renderer only — in-module `String(obj)` keeps §7.1.17 behaviour. Keyed on the struct, so it's path-independent.
- `src/ir/from-ast.ts` — the `valueType.kind === "class"` arm of the `throw-value-unsupported` decline removed (net 0 LOC; numeric `throw 42` stays deferred per the issue).
- `tests/issue-4097.test.ts` — 5 new tests incl. a non-vacuity `irCompiledFuncs` assertion.
- Issue file: `status: done`, root-cause correction, before/after matrices, `loc-budget-allow` for native-strings (+26, justified).

**Validation:** 5/5 new tests; #2877 7/7; #2962/#2969 22/22; all #4394 pins 13/13; 45/45 across 7 exception/class equivalence files; typecheck, biome, prettier, LOC/function budgets, `check:ir-fallbacks`, issue-id and done-status integrity all clean. `issue-3613-render-parity` has 2 failures proven pre-existing by file-copy A/B revert at base. Sizing measured against the standalone test262 corpus: the payoff is IR coverage (class-throwing functions now IR-compile), not a conformance delta — only 2 of 1,212 `[object Object]` fail rows are the shape this changes.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_