### PR TITLE
feat(codegen): method meta (name/length) + Function length descriptors + new Function(len) fold (#4440)

### DIFF
--- a/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
+++ b/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
@@ -95,3 +95,283 @@ Two adjacent residuals #4437 left with owners-unassigned:
 
 - ≥6 of the named files flip; zero regressions in the control set; gc/host
   byte-identical; non-flips root-caused here with owners.
+
+**Met, with one declared exception.** 14 named files flip (8 method
+`*length-dflt.js` + 6 `built-ins/Function/length/S15.3.5.1_A2/_A3`); the two
+control sets are clean (128-file stride sample byte-identical, 114-file
+neighborhood +8/−0); gc/host is sha256-identical across 27 files. The exception
+is **one** regression, `built-ins/Function/S15.3.2.1_A1_T10`, root-caused below,
+pinned in the test file, and filed as R6 — it is the price of the `null`-body
+fold that buys the six `A2`/`A3` files, so the directory is net +5.
+
+---
+
+## Root cause
+
+**Two causes, not one.** The issue bundled them because the two failure
+signatures look adjacent, but they are unrelated mechanisms and needed separate
+fixes.
+
+### R1 — a method mint site has a NAME, not a node
+
+`ensureMethodClosureSingleton`, `emitObjectMethodAsClosure` and
+`emitFuncRefAsClosure` (the static-method path) all receive
+`(methodName, methodFuncIdx, objStructTypeIdx)`. #4437's `fnMetaSlot` resolves
+§15.1.5 / §10.2.9 **from a declaration node**, so every one of them declined and
+`length` kept #4436's `$arity` fallback — the DECLARED FORMAL COUNT, which
+diverges from §15.1.5 for exactly the defaulted-parameter shapes the
+`*length-dflt.js` files test.
+
+What the three sites *do* share is the physical name they key everything else
+by (`ClassName_m`, `ClassName_get_p`, `ClassName_set_p`,
+`LiteralType_field`). `class-bodies.ts` records the member declaration under
+that key at the same moment it writes `ctx.funcMap`; the mint sites look it up.
+Keyed by NAME rather than funcIdx because funcIdx is shift-sensitive and the
+name is what those sites already re-resolve by at fill time.
+
+### R-attr — the six `Function/length` files never reached the enforcement
+
+The attributes were **already right** for an ordinary user closure before this
+change: `__builtinfn_gopd` derives the descriptor from `get_meta` with
+`FLAG_CONFIGURABLE` (= `{writable:false, enumerable:false, configurable:true}`),
+`buildBuiltinFnSetRefusalArm` refuses the write, and #4436's tombstone arm
+implements `delete`. Measured on this branch's base:
+
+```
+function g(a,b,c){}                    delete → removed;  g.length = 99 → refused (3)
+new Function("a,b,c", null)            delete → NO-OP;    f.length = 99 → accepted (99)
+```
+
+The receiver was the whole difference. §20.2.1.1.1 `ToString`s every argument,
+so a `null` body IS a constant body — but `resolveConstantString` returns
+`null` for a non-string literal, so `synthesizeStaticNewFunction` declined and
+the call routed to the **runtime-eval (QuickJS) tier**, whose function object is
+not a Wasm closure at all: no `$bag`, no `$fnmeta`, none of the #4436/#4437
+arms. Measured through a fully opaque receiver (passed as a function parameter,
+so no static fold can answer):
+
+| on `f`, opaque receiver | `new Function("a,b,c", null)` | `new Function("a,b,c", "return 1;")` |
+| ----------------------- | ----------------------------: | -----------------------------------: |
+| `x[k]`, `hasOwnProperty("length")` | 3, true (the eval tier answers) | 3, true |
+| `Object.getOwnPropertyNames(x).length` | **0** | 2 |
+| `delete x.length`, then `hasOwnProperty` | **still true** | false |
+| `x.length = 99`, then read | **99** | 3 (refused) |
+
+Every one of the six files passes `null` as the body; that is their only unusual
+ingredient. No new enforcement code was needed — folding the three KEYWORD
+literals (`null` / `true` / `false`) puts the call back on the AOT closure path,
+where the enforcement already lives.
+
+This is why the first two `hasOwnProperty`/dynamic-read rows agreeing was
+misleading for a while: those surfaces were answered by the eval tier, so the
+receiver looked healthy while four other surfaces on the same value did not
+exist.
+
+## What shipped
+
+- **`src/codegen/function-instance-meta-methods.ts`** (new) — the physical-name
+  side table, §10.2.9 for a member (`get `/`set ` prefixes, literal keys only),
+  and §15.1.5 over the member's own parameter list. Reuses #4437's interning
+  global and field definition through the new `fnMetaSlotOfMeta` export, so a
+  method's `{name, length}` lands in the same per-`<length>:<name>` global as an
+  identically-shaped function's and the two cannot disagree about layout.
+- Mint sites wired: `ensureMethodClosureSingleton` (typed `C.prototype.m`), the
+  `member-get-dispatch` fill arm (dynamic `c.m`), `emitObjectMethodAsClosure`
+  (`{ m() {} }.m`), `emitFuncRefAsClosure` (STATIC `C.m`),
+  `mintClosureStructTypes` (object-literal get/set accessors).
+- `eval-inline.ts` — `keywordLiteralToString`, standalone-gated.
+
+### Three things that were load-bearing
+
+1. **The dynamic read builds the singleton INDEPENDENTLY.**
+   `member-get-dispatch.ts`'s fill arm has its own `ref.is_null`-guarded lazy
+   init writing the SAME cache global as `emitCachedMethodClosureAccess`.
+   Whichever executes first wins. If only one pushed the `$fnmeta` operand,
+   `C.prototype.m.name` would depend on whether the typed or the dynamic read
+   ran first in the program. Both push it; the operand is recorded on the arm at
+   RESERVE time (the fill must not mint types, globals or string literals) and
+   **deep-cloned per splice**, because one arm feeds both the externref and the
+   typed-f64 dispatcher and a shared `Instr` object double-remaps on a
+   late-import shift.
+2. **Declining beats guessing, and it costs nothing.** A computed or `#private`
+   key records nothing, so `length` keeps #4436's `$arity` answer (the property
+   never disappears) and `name` stays absent (never *wrong*). Pinned:
+   `class C { [Symbol.iterator]() {} }` reports no `name` rather than `""`.
+3. **The keyword fold is deliberately three tokens wide.** `undefined` is an
+   ordinary, shadowable identifier; a numeric literal's ToString is
+   Number::toString (`1e21` → `"1e+21"`, `0x10` → `"16"`). Getting either wrong
+   publishes a wrong function BODY, which is far worse than declining. Pinned by
+   asserting the IMPORT SECTION: a folded call links no `js2wasm:runtime-eval`,
+   a declined one still does.
+
+## Test Results
+
+All figures below are from runs of `.tmp/run-one.mts` / `.tmp/run-list.mts` (the
+real `runTest262File`, `--target standalone`) on **this branch's base** — the
+merge of `claude/es5-standalone-pass-rate-6tk9rb` (#4437) — and on the change,
+both mine. Nothing is inherited from `.test262-cache/test262-standalone-current.jsonl`,
+which predates #4437 (it still records `language/statements/function/name.js`
+as `fail`) and is therefore unusable as a before-state here.
+
+### Target family 1 — the `*length-dflt.js` methods (all 11 method/setter files)
+
+| | base | after |
+| --- | ---: | ---: |
+| pass | **0** | **8** |
+| fail | 11 | 3 |
+
+Flipped: `{statements,expressions}/class/{method,gen-method}-length-dflt.js`,
+`statements/class/static-method-length-dflt.js`,
+`expressions/object/method-definition/{generator,name}-length-dflt.js`,
+`expressions/object/setter-length-dflt.js`.
+
+The 3 non-flips fail with `TypeError: Cannot convert undefined or null to
+object` — **identical on base**, a `gOPD` gap on the class prototype that has
+nothing to do with `length` (it is #4437's already-recorded 3-file bucket). See
+residual R1 below.
+
+### Target family 2 — `built-ins/Function/length/` (the whole directory)
+
+| | base | after |
+| --- | ---: | ---: |
+| pass | **7** | **13** |
+| fail | 6 | 0 |
+
+Flipped: `S15.3.5.1_A2_T1-T3` (DontDelete) and `S15.3.5.1_A3_T1-T3` (ReadOnly).
+The other 7 (`A1_T*`, `A4_T*`, `15.3.3.2-1`) passed on base and still pass.
+
+**Whole `built-ins/Function` directory, 509 files, A/B both mine: 346 → 351.**
+The diff is exactly those 6 FAIL→PASS plus ONE PASS→FAIL,
+`S15.3.2.1_A1_T10` — analysed in full below. Net **+5** in the directory the
+fold touches most.
+
+### The `f.constructor` family — a mis-attributed regression, and one real cost
+
+Mid-slice this lane was asked to fix a reported **17-file ES≤5 regression**
+(`The value of f.constructor is expected to equal the value of Function`, on
+`built-ins/Function/S15.3.2.1_A1_T2..T12` / `_A3_T2..T14`) attributed to #4437,
+since it sits in the modules reworked here.
+
+**It is not a #4437 regression.** A/B'd across three trees, 28 files
+(`S15.3.2.1_A{1,3}_T*`), all runs mine:
+
+| tree | pass | failing |
+| ---- | ---: | ------- |
+| pre-#4437 (`09ecad8`, `src/` checked out wholesale) | 25/28 | A1_T6, A3_T3, A3_T15 |
+| this branch's base (`09ecad8` + #4437) | 25/28 | **identical list** (`diff` empty) |
+
+#4437 moves this family by **0**. A1_T6 and A3_T15 carry the reported signature
+and fail the same way *before* #4437 exists.
+
+**The real cause** is that there is no `.constructor` arm for a function-valued
+receiver at all, so an AOT-compiled closure answers `undefined`. A NON-constant
+`Function(…)` body routes to the runtime-eval tier, which *does* answer
+correctly — which is exactly why the object/dynamic-body files (A1_T2..T5,
+T7..T9, T11..T13) pass and the constant-body ones do not. Nothing to do with the
+`$fnmeta` slot, the `spliceGopdPrologue` guard, or the `"anonymous"` change.
+
+**On the CI figure itself** (load-bearing for anyone reading the baseline
+trend): a per-run ES≤5 delta of this shape can be ENVIRONMENT, not code. The
+whole family is served by the runtime-eval tier, and when that tier is
+unavailable the entire family fails at once with one signature — reproduced
+here: with `JS2WASM_EVAL_ENGINE=interpreter` (provider not prebuilt in this
+container) the same 28 files go **0/28**. Before blaming a compiler commit for a
+promote-to-promote delta in this family, check the eval-provider artifact of the
+two runs.
+
+**The one real cost this slice does incur** is `S15.3.2.1_A1_T10`
+(`new Function(null)`): the fold moves it off the runtime-eval tier and onto the
+AOT path, where `.constructor` is unimplemented. That is a 1-file regression
+bought for the 6 `S15.3.5.1_A2/_A3` files, and it is pinned in
+`tests/issue-4440.test.ts` so it cannot be forgotten.
+
+**A fix was implemented, measured, and deliberately NOT shipped.** Both routes
+were built:
+
+1. **`__builtin_ctor_Function` carrier** (adding `"Function"` to
+   `BUILTIN_CONSTRUCTOR_IDENTITY_NAMES`, the #3006 route used for
+   `Set`/`Map`/`Number`/…). Produced a genuine identity-stable object — and
+   `f.constructor === Function` was **still false**, because the bare `Function`
+   identifier read does not resolve through `emitBuiltinConstructorIdentity`.
+   Two self-consistent objects that are not each other.
+2. **Synthetic bare-`Function` identifier read** (the trick the
+   `arguments.constructor` → `%Object%` arm already uses), gated on a callable
+   receiver / the ambient `Function` interface. This WORKED — measured on the
+   full 509-file `built-ins/Function` directory: **346 → 354, +9 / −1**, with
+   `S15.3.2.1_A1_T6`, `S15.3.2_A1` and
+   `Function/prototype/constructor/S15.3.4.1_A1_T1` flipping to pass.
+
+It was dropped anyway, on a measurement the flip count hides: **the bare
+`Function` value read pulls in the `js2wasm:runtime-eval` import**, so with the
+arm in place ANY standalone module that reads `<fn>.constructor` stops being
+host-free. Caught by `tests/issue-4440.test.ts`, which instantiates against an
+empty import object and failed with
+`Import #0 module="js2wasm:runtime-eval": module is not an object or function`
+for a program containing nothing but `function g(a,b){}`. No gate measures
+standalone-ness, so this would have shipped silently against the whole point of
+the `standalone-gap` goal (#2860). +3 files is not worth that trade; the
+prerequisite is a real self-contained `%Function%` carrier. Recorded as R6.
+
+One further narrowing for whoever takes R6: with the arm in, the arm **fires**
+for `A1_T10` (verified with a temporary `FIRE` trace) and the read still answers
+`undefined`, while the identical arm in `A1_T6`'s module answers correctly. Both
+compile the same synthetic `Function` identifier, so **two reads of the same
+identifier in one program do not agree** — the divergence is inside
+`compileIdentifier`'s bare-`Function` resolution
+(`src/codegen/expressions/identifiers.ts`), not in the property-access arm, and
+it is sensitive to the synthetic node's parent/text-range context. Start there.
+
+### Target family 3 — `Expected obj[length] NOT to be writable` ×4
+
+Three of the four are `S15.3.5.1_A3_T1-T3`, above. The fourth,
+`built-ins/String/S15.5.5.1_A4_T2.js`, is `new String("…").length` — a String
+exotic object, a different substrate entirely. Confirmed still failing on the
+change with the same message; recorded as R3.
+
+### Controls
+
+- **Neighborhood A/B, 114 files** — every `name.js` / `*length*.js` /
+  `fn-name-*.js` / `instance-name.js` / `prop-desc.js` under
+  `language/{statements,expressions}` ∪ `built-ins/Function`. Base **54 pass**,
+  after **62 pass**; the diff is exactly 8 FAIL→PASS lines and **zero
+  PASS→FAIL**.
+- **Stride sample, 128 files** — pool 13,417 files across
+  `language/{statements,expressions}/{class,object,function,arrow-function,generators}`
+  ∪ `built-ins/{Function,Object/{getOwnPropertyNames,getOwnPropertyDescriptor,defineProperty,keys},Reflect}`,
+  every 105th taken. **108 pass on base, 108 after, status lines byte-identical**
+  (`diff` empty).
+- **gc/host byte-identity (sha256 A/B, both runs mine)** — 23 files
+  (`website/playground/examples` ∪ `examples`) plus a 4-file corpus written for
+  this change (class methods + static + accessors, object-literal
+  methods/accessors, `new Function` with `null`/`true`/string bodies, a
+  capture-carrying closure). **All 27 sha256s identical**; the diff is empty.
+  Expected by construction — every entry point added here returns early unless
+  `ctx.standalone` — and measured rather than asserted.
+
+### Vitest
+
+- `tests/issue-4440.test.ts` — new, **14 tests** (one of them PINS the A1_T10
+  cost: `g.constructor === undefined`, with the flip-to-`Function` instruction
+  written at the site for whoever lands R6).
+- Controls, all green: `issue-4437` (19), `issue-4436` (23), `issue-2896`,
+  `issue-4010`, `issue-4194-instance-expando`, `issue-4241-carrier-bag-slot`,
+  `issue-4098-error-expando`, `issue-3468-closure-own-props`,
+  `es5-standalone-function-semantics` — **164/164**.
+
+### Gates
+
+`typecheck`, `check:stack-balance`, `check:ir-fallbacks`,
+`check:oracle-ratchet` (+0/+0), `biome lint` — all OK.
+`check:loc-budget` and `check:func-budget` need the allowances in this file's
+frontmatter (rationale in the comments there); with them, both OK.
+
+## Residuals, with owners
+
+| id | residual | why it is not fixed here | owner |
+| -- | -------- | ------------------------ | ----- |
+| **R1** | `{statements,expressions}/class/setter-length-dflt.js` and `expressions/class/static-method-length-dflt.js` throw `TypeError: Cannot convert undefined or null to object`. | Not a metadata defect — **identical on base**. These read `Object.getOwnPropertyDescriptor(C.prototype, "m").set`, and `gOPD` over a CLASS PROTOTYPE object returns `undefined` for an accessor member, so the test dereferences `undefined`. A class-prototype accessor-descriptor gap, adjacent to #4436's "class own-property stratum". The metadata half is already in place: an object-literal setter with the same shape now passes. | **unowned — next slice of #2860** |
+| **R2** | Computed / symbol-keyed members decline the meta entirely (`[Symbol.iterator]() {}` reports no `name`, and `length` falls back to `$arity`). | The key is a runtime value at the mint site. §10.2.9 wants `"[Symbol.iterator]"`, which needs the well-known-symbol description at compile time or a runtime `SetFunctionName` on a MUTABLE `$fnmeta` slot. Declining is the safe state (absent, never wrong) and is pinned as such. Same root as #4437's R2. | **unowned** |
+| **R3** | `built-ins/String/S15.5.5.1_A4_T2.js` — `new String("globglob").length` is writable. | A String exotic object, not a function object; §10.4.3 `length` lives on a different substrate with different attributes (`configurable: false`). Nothing in this slice touches it. | **unowned** |
+| **R4** | `new Function` still declines the fold for a numeric or `undefined` body, so those calls keep the runtime-eval receiver and its missing gOPD/gOPN/delete/writable surfaces. | Deliberate: Number::toString is not trivially reproducible at compile time and `undefined` is shadowable (see "Three things that were load-bearing" #3). The **general** fix is to give the runtime-eval function object the own-property surfaces, not to widen the fold — that is a runtime-eval-boundary slice (Lane A), not a function-metadata one. | **unowned — runtime-eval boundary (Lane A)** |
+| **R6** | `<function value>.constructor` answers `undefined` instead of `%Function%` (§20.2.3.1). Costs `built-ins/Function/S15.3.2.1_{A1_T6,A1_T10,A3_T15}`, `S15.3.2_A1`, `Function/prototype/constructor/S15.3.4.1_A1_T1` — 5 files, of which A1_T10 is this slice's one regression. | Pre-existing (A/B'd on the pre-#4437 tree). Both fixes were BUILT and measured here; see the `f.constructor` section above for why each was rejected. The blocker is that the bare `Function` value read has no self-contained carrier and pulls `js2wasm:runtime-eval`, so the working fix (+9/−1 over 509 files) would make every `.constructor`-reading standalone module non-host-free. Prerequisite: a real `%Function%` carrier that the BARE identifier read resolves to. Narrowed to `compileIdentifier`'s `Function` resolution in `src/codegen/expressions/identifiers.ts`. | **unowned — needs a `%Function%` carrier first** |
+| **R5** | Class VALUES, builtin function objects (`eval`, `Proxy.revocable`'s revoker, Promise resolve/reject), `f.hasOwnProperty("prototype")`, and the static-fold/runtime-delete divergence. | Inherited unchanged from #4437's R3/R4/R5/R7 — different carriers, none touched here. | **unowned** |

--- a/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
+++ b/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
@@ -1,7 +1,8 @@
 ---
 id: 4440
 title: "Function meta R1/R-attr slice — method name/length + own-property descriptor attributes (writable/enumerable/configurable)"
-status: in-progress
+status: done
+completed: 2026-08-15
 sprint: current
 assignee: ttraenkler/claude-es5-standalone
 created: 2026-08-15

--- a/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
+++ b/plan/issues/4440-function-meta-methods-and-descriptor-attributes.md
@@ -17,6 +17,39 @@ language_feature: function-properties
 goal: standalone-gap
 related: [4437, 4436, 2896]
 origin: "2026-08-15 ES5-standalone campaign wave 8 — #4437's R1 residual (class/object METHODS decline the meta) plus the descriptor-attribute family ('Expected obj[length] NOT to be writable' x4, Function/length 6 ES<=5 non-pass)."
+loc-budget-allow:
+  # All new LOGIC is in the new module `function-instance-meta-methods.ts`
+  # (157 lines). What lands in these four is wiring and its rationale:
+  #  - eval-inline.ts       +50: ONE 6-line predicate plus the measurement table
+  #                              that justifies why a `null` body argument is a
+  #                              constant, not a dynamic body (the whole reason
+  #                              the six Function/length files were unreachable).
+  #  - context/types.ts     +11: one optional Map field + its field doc. A
+  #                              per-compile side table has to live on the
+  #                              context; there is no other home.
+  #  - literals.ts           +9: one extra argument threaded to
+  #                              `emitObjectMethodAsClosure`, reformatted by
+  #                              prettier onto its own lines.
+  #  - class-bodies.ts       +6: three `recordFnMetaMemberDeclaration` calls at
+  #                              the three registration sites (method / getter /
+  #                              setter) plus the import. The declaration is only
+  #                              in scope here.
+  - src/codegen/expressions/eval-inline.ts
+  - src/codegen/context/types.ts
+  - src/codegen/literals.ts
+  - src/codegen/class-bodies.ts
+func-budget-allow:
+  # The same three wiring edits, seen per-function. Each is a call/argument at
+  # the ONE site where the needed value is in scope; none adds a branch.
+  #  - compileObjectLiteralForStruct +9: the extra `emitObjectMethodAsClosure`
+  #    argument, wrapped by prettier.
+  #  - fillMemberGetDispatch        +7: the `$fnmeta` operand + derived type in
+  #    the dynamic-read lazy init, so it cannot disagree with the typed read.
+  #  - collectClassDeclaration      +5: three one-line registry writes next to
+  #    the three existing `ctx.funcMap.set` calls.
+  - src/codegen/literals.ts::compileObjectLiteralForStruct
+  - src/codegen/member-get-dispatch.ts::fillMemberGetDispatch
+  - src/codegen/class-bodies.ts::collectClassDeclaration
 ---
 
 # #4440 — function meta for METHODS + own-property descriptor attributes

--- a/plan/issues/4442-function-intrinsic-carrier-constructor-arm.md
+++ b/plan/issues/4442-function-intrinsic-carrier-constructor-arm.md
@@ -1,0 +1,58 @@
+---
+id: 4442
+title: "Self-contained %Function% carrier + the <fn>.constructor arm (R6 of #4440)"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: function-properties
+goal: standalone-gap
+related: [4440, 4437, 2860, 2660]
+origin: "2026-08-15 wave 9 — #4440's R6 residual, with its measurement and narrowing."
+---
+
+# #4442 — self-contained `%Function%` carrier + `<fn>.constructor`
+
+## Problem & prior evidence (READ #4440's issue file R6 + finding 2 FIRST)
+
+`<function value>.constructor` answers `undefined` for every AOT-compiled
+closure (never implemented); runtime-eval-tier callables answer correctly.
+#4440 built the arm two ways and measured **+9/−1 over the 509-file
+`built-ins/Function` directory** — but did NOT ship it, because the working
+route (a synthetic bare `Function` identifier read) resolves through
+`js2wasm:runtime-eval`, silently ending host-freeness for every
+`.constructor`-reading module (#2860; no gate measures this). The narrowing:
+`compileIdentifier`'s `Function` resolution in
+`src/codegen/expressions/identifiers.ts` (`emitStandaloneIntrinsicFunctionValue`).
+
+## Implementation Plan
+
+1. Build a SELF-CONTAINED `%Function%` carrier: a realm-stable native object
+   (the `emitBuiltinNamespaceObject` / lazy-singleton pattern used for
+   Array/Object namespace values) that is identity-stable with what
+   `f.constructor` must return AND with what a bare `Function` identifier
+   read yields in a module WITHOUT the runtime-eval provider linked. In a
+   module WITH the provider, identity must match the provider's intrinsic
+   (that equality is what #4440's `__builtin_ctor_Function` attempt failed —
+   measure it explicitly this time, both provider-linked and provider-free).
+2. Re-add the `.constructor` arm on function-valued receivers reading that
+   carrier; A/B the 509-file directory (target ≥ #4440's +9/−1, ideally
+   fixing the −1: `S15.3.2.1_A1_T10`) and a provider-free probe asserting the
+   module emits NO `js2wasm:runtime-eval` import for a plain
+   `f.constructor` read.
+3. Controls per the campaign methodology: base copies at first edit; both
+   arms yours; gc/host byte-identity; #4436/#4437/#4440 pins green.
+
+## Acceptance criteria
+
+- `f.constructor === Function` for AOT closures in both provider-linked and
+  provider-free modules, with NO runtime-eval import added to provider-free
+  modules; ≥ +9/0 on the 509-file A/B; zero control regressions.

--- a/plan/issues/4443-match-vec-proto-index-read.md
+++ b/plan/issues/4443-match-vec-proto-index-read.md
@@ -1,0 +1,57 @@
+---
+id: 4443
+title: "__extern_get_idx answers undefined for a $__regexp_match_vec receiver in builtin-prototype-writing modules (R1 of #4439)"
+status: in-progress
+sprint: current
+assignee: ttraenkler/claude-es5-standalone
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 5
+language_feature: regexp-string-methods
+goal: standalone-gap
+related: [4439, 4160, 3673, 4434]
+origin: "2026-08-15 wave 9 — #4439's R1 residual, pre-existing, with its repro and narrowing."
+---
+
+# #4443 — match-vec indexed read vs the builtin-prototype consult arm
+
+## Problem & prior narrowing (READ #4439's issue file R1 FIRST)
+
+Pre-existing, blocks the 3 remaining borrowed-match files
+(`match/S15.5.4.10_A2_T17/T18`, `A1_T3`). Repro uses only the DIRECT path:
+
+```js
+Number.prototype.foo = 1;                    // any builtin-prototype write
+var m = "10203040506070809000".match(/0./);
+box.v = m; box.v[0]                          // → undefined
+```
+
+while `.length`, `.index`, and `m["0"]` are all correct, and a plain array
+receiver is unaffected. #4439 narrowed it to a spliced arm AHEAD of the
+base-vec arm in `__extern_get_idx` returning the Array-prototype consult
+(`consultArray=1`) for the `$__regexp_match_vec` receiver.
+
+## Implementation Plan
+
+1. Reproduce with the one-define-per-module discipline (#4434's confound
+   warning applies). Read the `__extern_get_idx` arm ordering
+   (vec-overlay.ts / dyn-read.ts fills) and find why the match-vec receiver
+   takes the proto-consult arm instead of its own indexed read.
+2. Fix by ordering/gating the match-vec arm correctly; the match-vec struct
+   is `$__regexp_match_vec` (native-regex.ts, REGEXP_MATCH_VEC_STRUCT) — a
+   subtype of `$__vec_base`, so a base-vec-typed arm placed first should
+   already serve it; find why it doesn't.
+3. Verify: the repro; the 3 borrowed-match files; #4439's 18-test pin and
+   the match/search collateral scope (119 files) with zero regressions;
+   gc/host byte-identity.
+
+## Acceptance criteria
+
+- The repro reads "02"; ≥2 of the 3 blocked files flip; zero regressions in
+  the #4439 collateral scope.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -19,6 +19,7 @@ import { isStandalonePromiseActive } from "./async-scheduler.js"; // (#2637 B2) 
 import { emitAsyncGenerator, isAsyncGenDriveCandidate } from "./async-frame.js";
 import { genBodyReferencesThis, genBodyReferencesSuper, emitCachedFuncClosureAccess } from "./closures.js"; // (#3132 / #3123 fnctor parent closure)
 import { classMemberFuncKey, fnctorAncestorOfClass } from "./class-member-keys.js"; // (#1983 / #3123)
+import { recordFnMetaMemberDeclaration } from "./function-instance-meta-methods.js"; // (#4440)
 import { exactClassExpressionTypeName } from "./class-expression-identity.js";
 import { installAstFreeClassConstructorNewWrapper } from "./class-constructor-wrapper.js";
 import { commitClassStructLayout } from "./class-layout-registration.js";
@@ -1250,6 +1251,9 @@ export function collectClassDeclaration(
       // display name) does not collide with a user `function ClassName_m()`.
       const methodKey = classMemberFuncKey(ctx, fullName);
       ctx.funcMap.set(methodKey, methodFuncIdx);
+      // (#4440) The method mint sites key everything by `fullName`; record the
+      // node under the same key so they can read §15.1.5 / §10.2.9 from it.
+      recordFnMetaMemberDeclaration(ctx, fullName, member);
 
       pushProgramAbiClassCallable(ctx, member, "unit", methodFuncIdx, {
         name: methodKey,
@@ -1305,6 +1309,7 @@ export function collectClassDeclaration(
       const getterFuncIdx = mintDefinedFunc(ctx);
       const getterKey = classMemberFuncKey(ctx, getterName); // (#1983) key + display name
       ctx.funcMap.set(getterKey, getterFuncIdx);
+      recordFnMetaMemberDeclaration(ctx, getterName, member); // (#4440) `get p`
 
       pushProgramAbiClassCallable(ctx, member, "unit", getterFuncIdx, {
         name: getterKey,
@@ -1338,6 +1343,7 @@ export function collectClassDeclaration(
       const setterFuncIdx = mintDefinedFunc(ctx);
       const setterKey = classMemberFuncKey(ctx, setterName); // (#1983) key + display name
       ctx.funcMap.set(setterKey, setterFuncIdx);
+      recordFnMetaMemberDeclaration(ctx, setterName, member); // (#4440) `set p`
 
       pushProgramAbiClassCallable(ctx, member, "unit", setterFuncIdx, {
         name: setterKey,

--- a/src/codegen/closures/arrow-phases.ts
+++ b/src/codegen/closures/arrow-phases.ts
@@ -39,6 +39,8 @@ import { spliceNullGuarded } from "./param-emit-helpers.js";
 import { materializeHoistedFunctionValueBinding } from "./funcref-as-closure.js";
 // (#4437) per-declaration `name` / §15.1.5 `length` carrier
 import { ensureFnMetaSubtype, fnMetaSlot, registerFnMetaFamily } from "../function-instance-meta.js";
+// (#4440) object-literal accessors / methods — §10.2.9 comes from the property key
+import { fnMetaSlotForMemberDecl } from "../function-instance-meta-methods.js";
 import {
   arrowOwnLocals,
   buildCaptureFieldDef,
@@ -716,7 +718,12 @@ export function mintClosureStructTypes(
   meta?: { allocTypeIdx: number; init: Instr[] };
 } {
   const { captures, arrowParams, closureResults, closureName, isNamedFuncExpr, constructible } = opts;
-  const metaSlot = fnMetaSlot(ctx, opts.decl);
+  // (#4440) An object-literal accessor/method reaches this mint site as its
+  // OWN declaration node (`literals.ts` casts a `Get/SetAccessorDeclaration` to
+  // `FunctionExpression` for the closure compile). `fnMetaSlot` declines those —
+  // §10.2.9 for an accessor is `"get p"` / `"set p"`, which comes from the
+  // property KEY, not from a function name. The member walk answers it.
+  const metaSlot = fnMetaSlot(ctx, opts.decl) ?? fnMetaSlotForMemberDecl(ctx, opts.decl);
   let structTypeIdx: number;
   let liftedFuncTypeIdx: number;
   let liftedSelfTypeIdx: number;

--- a/src/codegen/closures/funcref-as-closure.ts
+++ b/src/codegen/closures/funcref-as-closure.ts
@@ -22,6 +22,7 @@ import { noJsHost } from "../js-errors.js";
 import { emitCachedFuncClosureAccess } from "./method-trampolines.js";
 // (#4437) per-declaration `name` / §15.1.5 `length` carrier
 import { ensureFnMetaSubtype, fnMetaSlot, registerFnMetaFamily } from "../function-instance-meta.js";
+import { fnMetaSlotForMemberName } from "../function-instance-meta-methods.js"; // (#4440) static methods
 import {
   CLOSURE_CAPTURE_FIELD_BASE,
   closureArityField,
@@ -332,7 +333,13 @@ export function emitFuncRefAsClosure(
   // mints an interned string global, and a path that ends up not carrying the
   // slot should not leave one behind.
   const metaDecl = ctx.funcMapOwnerDecl.get(funcName) ?? ctx.topLevelFunctionDeclarations.get(funcName);
-  const metaSlotOf = (): ReturnType<typeof fnMetaSlot> => fnMetaSlot(ctx, metaDecl);
+  // (#4440) A STATIC class method reaches this helper (not the cached-singleton
+  // one — `property-access-dispatch.ts` reads `C.m` through `emitFuncRefAsClosure`),
+  // and its `funcName` is the physical `ClassName_m`, which neither map above
+  // holds. The member side table does; consulting it second keeps a real
+  // function declaration's own metadata winning wherever both could answer.
+  const metaSlotOf = (): ReturnType<typeof fnMetaSlot> =>
+    fnMetaSlot(ctx, metaDecl) ?? fnMetaSlotForMemberName(ctx, funcName);
 
   const nestedCaptures = ctx.nestedFuncCaptures.get(funcName);
   if (nestedCaptures && nestedCaptures.length > 0) {

--- a/src/codegen/closures/method-trampolines.ts
+++ b/src/codegen/closures/method-trampolines.ts
@@ -35,6 +35,8 @@ import { emitFuncRefAsClosure } from "./funcref-as-closure.js";
 import { observeProgramAbiFunctionValue } from "../program-abi-source-callable-planning.js";
 // (#4437) per-declaration `name` / §15.1.5 `length` carrier
 import { ensureFnMetaSubtype, fnMetaSlot } from "../function-instance-meta.js";
+// (#4440) the METHOD half of the same carrier — class/object-literal members
+import { fnMetaSlotForMemberDecl, fnMetaSlotForMemberName } from "../function-instance-meta-methods.js";
 
 /**
  * (#2015) Build the `this`-slot prologue for an object-method trampoline.
@@ -214,6 +216,12 @@ export function emitObjectMethodAsClosure(
   methodName: string,
   methodFuncIdx: number,
   objStructTypeIdx: number,
+  /**
+   * (#4440) The object-literal member this closure is the value of, when the
+   * caller has it. Unlike the class path there is no side table to consult —
+   * `literals.ts` holds the node right at the call — so it is passed directly.
+   */
+  memberDecl?: ts.Node,
 ): ValType | null {
   const sig = getFuncSignature(ctx, methodFuncIdx);
   if (!sig) return null;
@@ -292,10 +300,19 @@ export function emitObjectMethodAsClosure(
   });
 
   // Emit: ref.func $trampoline, (#3673) $arity, (#4241) $bag, struct.new $closure_struct
+  //
+  // (#4440) …plus the `$fnmeta` operand when the member carries resolvable
+  // metadata. The base wrapper struct is SHARED across every function of this
+  // signature, so the slot lives on a per-base SUBTYPE — allocate the derived
+  // type and report the BASE (#4437's note 3: a `ref.cast` to a MORE derived
+  // type traps on a value stored as the base; widening is the safe direction).
+  const metaSlot = fnMetaSlotForMemberDecl(ctx, memberDecl);
+  const allocTypeIdx = metaSlot ? ensureFnMetaSubtype(ctx, structTypeIdx) : undefined;
   fctx.body.push({ op: "ref.func", funcIdx: trampolineFuncIdx });
   fctx.body.push({ op: "i32.const", value: userParams.length });
   fctx.body.push(closureBagInitInstr());
-  fctx.body.push({ op: "struct.new", typeIdx: structTypeIdx });
+  if (metaSlot && allocTypeIdx !== undefined) for (const instr of metaSlot.init) fctx.body.push(instr);
+  fctx.body.push({ op: "struct.new", typeIdx: allocTypeIdx !== undefined && metaSlot ? allocTypeIdx : structTypeIdx });
 
   return { kind: "ref", typeIdx: structTypeIdx };
 }
@@ -605,6 +622,8 @@ export function emitCachedMethodClosureAccess(
     trampolineFuncIdx,
     closureStructTypeIdx,
     ctx.closureInfoByTypeIdx.get(closureStructTypeIdx)?.paramTypes.length ?? 0,
+    /* constructible */ false,
+    fnMetaAllocOf(singleton), // (#4440)
   );
   return true;
 }
@@ -631,7 +650,7 @@ export function ensureMethodClosureSingleton(
   methodName: string,
   methodFuncIdx: number,
   objStructTypeIdx: number,
-): { cacheGlobalIdx: number; trampolineFuncIdx: number; closureStructTypeIdx: number } | null {
+): FuncClosureSingleton | null {
   // Resolve the user-visible signature so we know the wrapper struct's
   // funcref shape. Method signature is [(ref null objStruct), ...userParams]
   // → results; strip the leading `this` to derive the closure-callable
@@ -726,7 +745,20 @@ export function ensureMethodClosureSingleton(
     ctx.methodClosureGlobals.set(methodName, cacheGlobalIdx);
   }
 
-  return { cacheGlobalIdx, trampolineFuncIdx, closureStructTypeIdx: structTypeIdx };
+  // (#4440) A class / object-literal method is #4437's R1 residual: this site
+  // has only `methodName`, so the §15.1.5 walk had nothing to read and `length`
+  // fell back to `$arity` (the DECLARED FORMAL COUNT — 1 for `m(x = 42)`, spec
+  // 0). `class-bodies.ts` records the declaration under exactly this physical
+  // name; a member whose key is computed/private records nothing and keeps the
+  // pre-#4440 answers, which is the safe direction (see the methods module).
+  const metaSlot = fnMetaSlotForMemberName(ctx, methodName);
+  const allocStructTypeIdx = metaSlot ? ensureFnMetaSubtype(ctx, structTypeIdx) : undefined;
+  return {
+    cacheGlobalIdx,
+    trampolineFuncIdx,
+    closureStructTypeIdx: structTypeIdx,
+    ...(allocStructTypeIdx !== undefined && metaSlot ? { allocStructTypeIdx, metaInit: metaSlot.init } : {}),
+  };
 }
 
 /**

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -3415,6 +3415,17 @@ export interface CodegenContext {
    *  per-signature wrapper and its constructible variant); a capture subtype is
    *  already per-function and grows the slot in place. */
   fnInstanceMetaSubtypeByBase?: Map<number, number>;
+  /** (#4440) Physical function name (`ClassName_m`, `ClassName_get_p`,
+   *  `ClassName_set_p`, `LiteralType_field`) → the member DECLARATION behind it.
+   *  The method mint sites take a name + funcIdx, never a node, so this is how
+   *  `function-instance-meta-methods.ts` recovers the parameter list for §15.1.5
+   *  and the property key for §10.2.9. Keyed by NAME rather than funcIdx because
+   *  funcIdx is shift-sensitive and the name is what those sites already
+   *  re-resolve by. Written by `class-bodies.ts` at registration time. */
+  fnMetaMemberDecls?: Map<
+    string,
+    ts.MethodDeclaration | ts.GetAccessorDeclaration | ts.SetAccessorDeclaration | ts.PropertyAssignment
+  >;
   /** (#2193 PR-B) Struct-type indices of `$NativeProto` member closures whose
    *  FIRST user param is the receiver (`this`) — e.g. `Array.prototype.slice`'s
    *  `(self, this, start, end)` closure. Unlike a plain user function (which

--- a/src/codegen/expressions/eval-inline.ts
+++ b/src/codegen/expressions/eval-inline.ts
@@ -72,6 +72,55 @@ export function resolveConstantString(expr: ts.Expression, checker?: ts.TypeChec
   return resolveConstantStringDepth(expr, checker, 0);
 }
 
+/**
+ * (#4440) §20.2.1.1.1 step 8/11: CreateDynamicFunction `ToString`s EVERY
+ * argument, so a non-string one is not a "dynamic body" — it is a *constant*
+ * body the fold declined to see. `new Function("a,b,c", null)` is
+ * `function anonymous(a,b,c) { null }`, not an opaque runtime construction.
+ *
+ * ## Why this belongs to a descriptor-attributes slice
+ * Declining sent those calls to the runtime-eval (QuickJS) tier, whose function
+ * object is NOT a Wasm closure — so it carries no `$bag`, no `$fnmeta`, and
+ * none of the #4436/#4437/#4440 reflective arms apply to it. Measured on this
+ * branch's base, `--target standalone`, with a fully opaque receiver (passed
+ * through a function parameter so no static fold can answer):
+ *
+ * | on `f` from …                    | `new Function("a,b,c", null)` | `…, "return 1;")` |
+ * | -------------------------------- | ----------------------------- | ----------------- |
+ * | `x[k]`, `hasOwnProperty("length")`| 3, true (via the eval tier)  | 3, true           |
+ * | `getOwnPropertyNames(x).length`   | **0**                        | 2                 |
+ * | `delete x.length` then hasOwn     | **still true**               | false             |
+ * | `x.length = 99` then read         | **99**                       | 3 (refused)       |
+ *
+ * That is exactly the `built-ins/Function/length/S15.3.5.1_A2_T*` (DontDelete)
+ * and `_A3_T*` (ReadOnly) signature — six files whose ONLY unusual ingredient
+ * is a `null` body argument. Routing them back onto the AOT closure path is
+ * what makes the attribute enforcement reach them; no new enforcement code is
+ * needed, because the closure path already has it.
+ *
+ * ## Scope — the three keyword literals only, and standalone only
+ * `null` / `true` / `false` are KEYWORD tokens: their `ToString` is fixed by
+ * the grammar, unshadowable, and needs no numeric formatting. `undefined` is
+ * deliberately excluded — it is an ordinary identifier that sloppy code may
+ * shadow — and so are numeric literals, whose `ToString` is Number::toString
+ * (`1e21` → `"1e+21"`, `0x10` → `"16"`); getting that subtly wrong would
+ * publish a wrong function BODY, which is far worse than declining.
+ *
+ * Standalone-gated because the JS-host lane has no gap to close here: a
+ * non-constant `Function(…)` there already routes to the working
+ * `__extern_eval` shim, and widening the fold would change host output for no
+ * behavioural gain.
+ */
+function keywordLiteralToString(ctx: CodegenContext, expr: ts.Expression): string | null {
+  if (!ctx.standalone) return null;
+  let e: ts.Expression = expr;
+  while (ts.isParenthesizedExpression(e) || ts.isAsExpression(e) || ts.isNonNullExpression(e)) e = e.expression;
+  if (e.kind === ts.SyntaxKind.NullKeyword) return "null";
+  if (e.kind === ts.SyntaxKind.TrueKeyword) return "true";
+  if (e.kind === ts.SyntaxKind.FalseKeyword) return "false";
+  return null;
+}
+
 /** Defensive recursion cap for pathological const-reference chains. */
 const CONST_STRING_MAX_DEPTH = 16;
 
@@ -1548,6 +1597,7 @@ function synthesizeStaticNewFunction(
     let s = resolveConstantString(a);
     if (s === null) {
       s = resolveConstantString(a, ctx.checker);
+      if (s === null) s = keywordLiteralToString(ctx, a);
       if (s === null) return undefined;
       widened = true;
     }

--- a/src/codegen/function-instance-meta-methods.ts
+++ b/src/codegen/function-instance-meta-methods.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4440) The METHOD half of #4437's per-function metadata carrier: class and
+ * object-literal methods/accessors get a `$fnmeta` slot too, so their `name`
+ * and their §15.1.5 `length` reflect like a plain function declaration's.
+ *
+ * ## The residual this closes (#4437 R1)
+ * #4437 gave `name` a runtime home and made the reflective `length` exact, but
+ * only for mint sites that hold a DECLARATION: `ensureFuncClosureSingleton`,
+ * `funcref-as-closure.ts`, `arrow-phases.ts`. The method mint sites
+ * (`ensureMethodClosureSingleton`, `emitObjectMethodAsClosure`) take a method
+ * NAME and a funcIdx — no node — so the §15.1.5 walk had nothing to read and
+ * `length` fell back to `$arity`, the DECLARED FORMAL COUNT. Measured on this
+ * branch's base (`--target standalone`, `.tmp/run-one.mts`):
+ *
+ * | `class C { m(x = 42) {} }` — read on `C.prototype.m` | base | spec |
+ * | ---------------------------------------------------- | ---- | ---- |
+ * | `m["length"]` (reflective)                           | 1    | 0    |
+ * | `m["name"]`                                          | absent | "m" |
+ *
+ * All eight remaining `*-method-length-dflt.js` / `*-setter-length-dflt.js`
+ * files sit on that first row.
+ *
+ * ## Mechanism — a physical-name → declaration side table
+ * The two method mint sites are reached from very different places (a class
+ * prototype object build, a member-get dispatcher fill, an object literal), and
+ * threading a node through all of them would touch five files. What they DO
+ * share is the physical name they key everything else by:
+ * `${className}_${member}` for a class method, `${className}_get_<p>` /
+ * `${className}_set_<p>` for an accessor, `${literalType}_${field}` for an
+ * object-literal method. `class-bodies.ts` records the declaration under that
+ * exact key at the same moment it registers the funcMap entry; the mint sites
+ * look it up.
+ *
+ * Keying by NAME rather than by funcIdx is deliberate: funcIdx is shift-
+ * sensitive (late imports renumber every defined function), and the physical
+ * name is precisely what `ensureMethodClosureSingleton` /
+ * `member-get-dispatch.ts` already re-resolve by at fill time.
+ *
+ * ## §10.2.9 SetFunctionName for a method — what is and is NOT resolvable
+ * A method's `name` carries a prefix for accessors (`get m` / `set m`) and, for
+ * a symbol key, the description in brackets (`[Symbol.iterator]`). Only the
+ * syntactic forms that carry a literal key are decidable at the mint site, so
+ * this module **declines the whole slot** when the key is computed or private,
+ * rather than publishing a guess.
+ *
+ * Declining is the safe direction and costs nothing that was already there:
+ * with no slot, `length` keeps #4436's `$arity` answer (the property never
+ * disappears) and `name` stays absent (never *wrong*). That asymmetry is
+ * #4437's design and this module preserves it verbatim — a wrong `name` on
+ * `[Symbol.iterator]` would be a new defect, whereas a missing one is the
+ * status quo.
+ */
+import type { Instr, FieldDef } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { ts } from "../ts-api.js";
+import { expectedArgumentCountOfParams } from "./function-expected-argument-count.js";
+import { fnMetaSlotOfMeta, type FnInstanceMeta } from "./function-instance-meta.js";
+
+/** A member declaration that can carry `name` / `length` metadata. */
+type MetaBearingMember =
+  | ts.MethodDeclaration
+  | ts.GetAccessorDeclaration
+  | ts.SetAccessorDeclaration
+  | ts.PropertyAssignment;
+
+/** The side table, created lazily so an unrelated compile pays nothing. */
+function registry(ctx: CodegenContext): Map<string, MetaBearingMember> {
+  return (ctx.fnMetaMemberDecls ??= new Map<string, MetaBearingMember>());
+}
+
+/**
+ * Record `decl` as the declaration behind the physical function name
+ * `physicalName` (`ClassName_m`, `ClassName_get_p`, `ClassName_set_p`, or an
+ * object literal's `TypeName_field`).
+ *
+ * Idempotent by first-writer-wins: `class-bodies.ts` skips re-registering a
+ * name that is already in `funcMap`, and the same guard applies here so a
+ * second class reusing a physical name cannot silently repoint an existing
+ * entry at its own parameter list.
+ */
+export function recordFnMetaMemberDeclaration(ctx: CodegenContext, physicalName: string, decl: ts.Node): void {
+  if (!ctx.standalone) return;
+  if (!isMetaBearingMember(decl)) return;
+  const map = registry(ctx);
+  if (map.has(physicalName)) return;
+  map.set(physicalName, decl);
+}
+
+function isMetaBearingMember(decl: ts.Node): decl is MetaBearingMember {
+  return (
+    ts.isMethodDeclaration(decl) ||
+    ts.isGetAccessorDeclaration(decl) ||
+    ts.isSetAccessorDeclaration(decl) ||
+    ts.isPropertyAssignment(decl)
+  );
+}
+
+/**
+ * §10.2.9 `name` for a member, or `undefined` when the key is not statically
+ * decidable (a computed key is a runtime value; a `#private` name is not an
+ * observable property key at all).
+ *
+ * The `get `/`set ` prefixes are part of the spec answer, not decoration:
+ * `Object.getOwnPropertyDescriptor({ get m() {} }, "m").get.name` is `"get m"`.
+ */
+function memberNameOf(decl: MetaBearingMember): string | undefined {
+  const key = decl.name;
+  let base: string | undefined;
+  if (ts.isIdentifier(key) || ts.isStringLiteral(key) || ts.isNumericLiteral(key)) base = key.text;
+  if (base === undefined) return undefined;
+  if (ts.isGetAccessorDeclaration(decl)) return `get ${base}`;
+  if (ts.isSetAccessorDeclaration(decl)) return `set ${base}`;
+  return base;
+}
+
+/**
+ * The §15.1.5 / §10.2.9 metadata for a member declaration, or `undefined` when
+ * the member carries no resolvable key (see the module header on why declining
+ * beats guessing).
+ *
+ * A `PropertyAssignment` is included because an object literal's
+ * `{ m: function () {} }` reaches the same mint site as `{ m() {} }`; its
+ * metadata comes from the INITIALIZER's parameter list, and NamedEvaluation
+ * already gives that function the property name, so the two spellings agree.
+ */
+export function fnMetaOfMember(decl: MetaBearingMember): FnInstanceMeta | undefined {
+  const name = memberNameOf(decl);
+  if (name === undefined) return undefined;
+  const fnLike: ts.Node | undefined = ts.isPropertyAssignment(decl) ? decl.initializer : decl;
+  if (fnLike === undefined || !ts.isFunctionLike(fnLike)) return undefined;
+  return { name, length: expectedArgumentCountOfParams(fnLike.parameters) };
+}
+
+/** The `$fnmeta` field + `struct.new` operand for a member declaration. */
+export function fnMetaSlotForMemberDecl(
+  ctx: CodegenContext,
+  decl: ts.Node | undefined,
+): { field: FieldDef; init: Instr[]; meta: FnInstanceMeta } | undefined {
+  if (!ctx.standalone || decl === undefined || !isMetaBearingMember(decl)) return undefined;
+  const meta = fnMetaOfMember(decl);
+  return meta === undefined ? undefined : fnMetaSlotOfMeta(ctx, meta);
+}
+
+/**
+ * The `$fnmeta` field + `struct.new` operand for the member registered under
+ * `physicalName`, or `undefined` when nothing was recorded (an object-literal
+ * method reached through a path `class-bodies.ts` never sees, a computed key,
+ * or a non-standalone target).
+ */
+export function fnMetaSlotForMemberName(
+  ctx: CodegenContext,
+  physicalName: string,
+): { field: FieldDef; init: Instr[]; meta: FnInstanceMeta } | undefined {
+  if (!ctx.standalone) return undefined;
+  return fnMetaSlotForMemberDecl(ctx, ctx.fnMetaMemberDecls?.get(physicalName));
+}

--- a/src/codegen/function-instance-meta.ts
+++ b/src/codegen/function-instance-meta.ts
@@ -351,6 +351,25 @@ export function fnMetaSlot(
 ): { field: FieldDef; init: Instr[]; meta: FnInstanceMeta } | undefined {
   const meta = fnInstanceMetaOf(ctx, decl);
   if (meta === undefined) return undefined;
+  return fnMetaSlotOfMeta(ctx, meta);
+}
+
+/**
+ * (#4440) The same pair for a metadata value the caller resolved itself.
+ *
+ * `fnMetaSlot` reads §10.2.9 off the declaration, which is the right answer for
+ * a function declaration/expression/arrow but NOT for a method: a method's name
+ * carries the `get `/`set ` prefix and comes from a property KEY, and the walk
+ * that decides it lives in `function-instance-meta-methods.ts`. Exposing the
+ * materialization half separately lets that module reuse the interning global
+ * and the field definition verbatim instead of duplicating them — so a method's
+ * `{name, length}` lands in the SAME per-`<length>:<name>` module global as an
+ * identically-shaped function's, and the two can never disagree about layout.
+ */
+export function fnMetaSlotOfMeta(
+  ctx: CodegenContext,
+  meta: FnInstanceMeta,
+): { field: FieldDef; init: Instr[]; meta: FnInstanceMeta } {
   return {
     field: fnMetaField(ctx),
     init: pushFnInstanceMetaValueInstrs(ctx, meta),

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -2777,7 +2777,16 @@ export function compileObjectLiteralForStruct(
       // actually be compiled for THIS literal, not a sibling literal's body.
       const methodFuncIdx = literalMethodFuncIdx.get(field.name) ?? ctx.funcMap.get(methodFullName);
       if (methodFuncIdx !== undefined) {
-        const closureType = emitObjectMethodAsClosure(ctx, fctx, methodFullName, methodFuncIdx, structTypeIdx);
+        // (#4440) `methodProp` is the object-literal member itself — pass it so
+        // the closure carries §15.1.5 `length` / §10.2.9 `name` metadata.
+        const closureType = emitObjectMethodAsClosure(
+          ctx,
+          fctx,
+          methodFullName,
+          methodFuncIdx,
+          structTypeIdx,
+          methodProp,
+        );
         if (closureType) {
           // (#1989) Method-shorthand `valueOf`/`toString` now store a
           // per-instance closure in the eqref field (each literal owns a

--- a/src/codegen/member-get-dispatch.ts
+++ b/src/codegen/member-get-dispatch.ts
@@ -98,6 +98,19 @@ export interface MemberGetMethodArm {
   methodFullName: string;
   /** The funcref-wrapper closure struct the lazy init `struct.new`s. */
   closureStructTypeIdx: number;
+  /**
+   * (#4440) The `$fnmeta`-carrying SUBTYPE to `struct.new` instead, and the
+   * operand to push last, when the method has resolvable metadata.
+   *
+   * This arm builds the singleton INDEPENDENTLY of
+   * `emitCachedMethodClosureAccess` — both lazy-inits write the same cache
+   * global, and whichever runs first in program order wins. If only one of them
+   * carried the metadata, `C.prototype.m.name` would depend on whether the
+   * typed read or the dynamic read happened to execute first. Recorded here at
+   * RESERVE time (the fill must not mint types, globals or string literals).
+   */
+  metaAllocStructTypeIdx?: number;
+  metaInit?: Instr[];
   /** Inheritance depth of the RECEIVER class — children sort first so an
    * override's arm shadows the superclass arm under WasmGC subtyping. */
   depth: number;
@@ -280,6 +293,10 @@ export function ensureMethodArmsForProp(ctx: CodegenContext, propName: string, f
       receiverStructTypeIdx: cand.receiverStructTypeIdx,
       methodFullName: cand.methodFullName,
       closureStructTypeIdx: singleton.closureStructTypeIdx,
+      // (#4440) mirror the metadata the typed read's lazy init pushes
+      ...(singleton.allocStructTypeIdx !== undefined && singleton.metaInit !== undefined
+        ? { metaAllocStructTypeIdx: singleton.allocStructTypeIdx, metaInit: singleton.metaInit }
+        : {}),
       depth: cand.depth,
     });
     ensured = true;
@@ -491,7 +508,14 @@ export function fillMemberGetDispatch(ctx: CodegenContext): void {
                   value: ctx.closureInfoByTypeIdx.get(arm.closureStructTypeIdx)?.paramTypes.length ?? 0,
                 },
                 closureBagInitInstr(), // (#4241) $bag
-                { op: "struct.new", typeIdx: arm.closureStructTypeIdx },
+                // (#4440) `$fnmeta`, and the derived type that carries it. Deep-
+                // cloned per splice: this chain is built once per dispatcher and
+                // the SAME arm feeds both the externref and the typed-f64
+                // dispatcher, so sharing one `Instr` object across two bodies
+                // would double-remap it on a late-import shift
+                // (`reference_shared_instr_object_dce_double_remap`).
+                ...(arm.metaInit !== undefined ? (structuredClone(arm.metaInit) as Instr[]) : []),
+                { op: "struct.new", typeIdx: arm.metaAllocStructTypeIdx ?? arm.closureStructTypeIdx },
                 { op: "extern.convert_any" },
                 { op: "global.set", index: arm.cacheGlobalIdx },
               ],

--- a/tests/issue-4440.test.ts
+++ b/tests/issue-4440.test.ts
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4440) The METHOD half of #4437's per-function metadata carrier, and the
+// descriptor-attribute enforcement reaching `new Function(…, null)`.
+//
+// #4437 gave a function DECLARATION / expression / arrow an exact §15.1.5
+// `length` and a §10.2.9 `name`; the method mint sites take a NAME and a
+// funcIdx, never a node, so class and object-literal members declined. Measured
+// on this branch's base with `--target standalone` (`.tmp/run-one.mts`, the real
+// `runTest262File`), before this change:
+//
+//   | `class C { m(x = 42) {} }` — on `C.prototype.m` | base | spec |
+//   | ----------------------------------------------- | ---- | ---- |
+//   | `m["length"]` (reflective)                      | 1    | 0    |
+//   | `m["name"]`                                     | absent | "m" |
+//
+// The `1` is `$arity`, the DECLARED FORMAL COUNT #4436 answers from — right for
+// dispatch (`closure-exports.ts` pads an under-applied call to `max(n,$arity)`),
+// wrong for the property. All eight remaining `*length-dflt.js` files sat there.
+//
+// The tests below assert the surfaces AGAINST EACH OTHER (descriptor value ==
+// dynamic read == typed read) wherever there is more than one, because the
+// failure mode this family produces is a SPLIT, not an absence — and a split is
+// exactly what test262's `propertyHelper.js` catches and a single-surface
+// assertion does not.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile `body` as the `test()` export and run it host-free. */
+async function runStandalone(body: string): Promise<number> {
+  const source = `export function test(): number { ${body} }`;
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "issue-4440.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")).toBe(true);
+  // Host-free: a standalone module must instantiate against an empty import
+  // object. If this ever needs a host bridge, the arms leaked an import.
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+/**
+ * Does the standalone module compiled from `body` still link the runtime-eval
+ * tier? That import is the exact observable of "the `Function(…)` fold
+ * declined" — a folded call is an AOT closure and needs no host at all.
+ */
+async function linksRuntimeEval(body: string): Promise<boolean> {
+  const result = await compile(`export function test(): number { ${body} }`, {
+    allowJs: true,
+    fileName: "issue-4440.ts",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(result.success, result.errors.map((error) => `L${error.line}: ${error.message}`).join("\n")).toBe(true);
+  return WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).some(
+    (imp) => imp.module === "js2wasm:runtime-eval",
+  );
+}
+
+describe("#4440 — class and object-literal METHODS carry the metadata", () => {
+  it("gives an instance method the §15.1.5 `length` and the §10.2.9 `name`", async () => {
+    // `m(x = 42, y)` — `$arity` is 2, the §15.1.5 prefix count is 0 (the walk
+    // STOPS at the first defaulted parameter, including for required ones to
+    // its right).
+    expect(
+      await runStandalone(`
+        class C { m(x = 42, y) {} }
+        var k = "name", kl = "length";
+        var p = C.prototype.m;
+        return (p[k] === "m" && p[kl] === 0) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("keeps the DYNAMIC `c.m` read and the typed `C.prototype.m` read identical", async () => {
+    // The two reads build the SAME cache global through INDEPENDENT lazy inits
+    // (`emitCachedMethodClosureAccess` and the `member-get-dispatch` fill arm).
+    // If only one pushed the `$fnmeta` operand, the answer would depend on which
+    // one happened to execute first — asserting identity AND the value together
+    // is what makes that visible.
+    expect(
+      await runStandalone(`
+        class C { m(x = 42) {} }
+        var c = new C();
+        var t = C.prototype.m;
+        var k = "length";
+        return (c.m === t && c.m[k] === 0) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("does not collapse two classes that share a method NAME onto one entry", async () => {
+    // The metadata global is interned by `"<length>:<name>"`, and the method
+    // singleton is keyed by `<Class>_<method>` — both halves have to be
+    // class-qualified or `C1.prototype.m` and `C2.prototype.m` would report the
+    // same number. 0 and 1 here, i.e. `0*10 + 1`.
+    expect(
+      await runStandalone(`
+        class C1 { m(x = 42, y) {} }
+        class C2 { m(a, b = 1) {} }
+        var k = "length";
+        return C1.prototype.m[k] * 10 + C2.prototype.m[k];`),
+    ).toBe(1);
+  });
+
+  it("covers STATIC methods, which reach a different mint site", async () => {
+    // `C.m` is read through `emitFuncRefAsClosure`, not the cached method
+    // singleton — a separate wiring that the `*static-method-length-dflt.js`
+    // files exercise and the instance-method one does not.
+    expect(
+      await runStandalone(`
+        class C { static s(p = 1, q) {} }
+        var k = "name", kl = "length";
+        return (C.s[k] === "s" && C.s[kl] === 0) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("covers object-literal methods", async () => {
+    expect(
+      await runStandalone(`
+        var o = { m(x = 42, y) {} };
+        var k = "name", kl = "length";
+        return (o.m[k] === "m" && o.m[kl] === 0) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("applies §10.2.9's `get `/`set ` prefix to accessor functions", async () => {
+    // The prefix is part of the spec answer, not decoration, and it is the
+    // reason a method's `name` cannot come from `fnMetaSlot`'s declaration walk:
+    // it is derived from the property KEY plus the accessor kind.
+    expect(
+      await runStandalone(`
+        var o = { set m(x = 42) {} };
+        var s = Object.getOwnPropertyDescriptor(o, "m").set;
+        var k = "name", kl = "length";
+        return (s[k] === "set m" && s[kl] === 0) ? 1 : 0;`),
+    ).toBe(1);
+    expect(
+      await runStandalone(`
+        var o = { get p() { return 1; } };
+        var g = Object.getOwnPropertyDescriptor(o, "p").get;
+        var k = "name", kl = "length";
+        return (g[k] === "get p" && g[kl] === 0) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("DECLINES a computed/symbol key rather than publishing a guess", async () => {
+    // §10.2.9 for `[Symbol.iterator]() {}` is `"[Symbol.iterator]"`, which this
+    // slice does not resolve. Declining leaves `name` ABSENT — the pre-#4440
+    // state — where guessing would publish a WRONG name. That asymmetry is
+    // #4437's design and the reason the remaining residuals are safe to leave.
+    expect(
+      await runStandalone(`
+        class C { [Symbol.iterator]() {} }
+        var p = C.prototype[Symbol.iterator];
+        var k = "name";
+        return p[k] === undefined ? 1 : 0;`),
+    ).toBe(1);
+  });
+});
+
+describe("#4440 — a method's `length` carries the §10.2.4 attributes", () => {
+  it("reports {writable:false, enumerable:false, configurable:true} with the right value", async () => {
+    expect(
+      await runStandalone(`
+        class C { m(x = 42) {} }
+        var d = Object.getOwnPropertyDescriptor(C.prototype.m, "length");
+        return (d.value === 0 && d.writable === false && d.enumerable === false && d.configurable === true) ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("is deletable (configurable:true) and refuses a write while live", async () => {
+    // #4010's ordering law: `propertyHelper`'s `isConfigurable` is
+    // `delete obj[k]; return !hasOwnProperty(obj, k)`, so a visible-but-
+    // undeletable property fails every `verifyProperty` naming
+    // `configurable: true` — which is every one of the target files.
+    expect(
+      await runStandalone(`
+        class C { m(x = 42) {} }
+        var p = C.prototype.m;
+        delete p.length;
+        return p.hasOwnProperty("length") ? 0 : 1;`),
+    ).toBe(1);
+    expect(
+      await runStandalone(`
+        class C { m(x = 42) {} }
+        var p = C.prototype.m;
+        p.length = 9;
+        var k = "length";
+        return p[k];`),
+    ).toBe(0);
+  });
+});
+
+describe("#4440 — `new Function` with a non-string argument", () => {
+  it("treats a `null` body as the constant body it is, not a dynamic one", async () => {
+    // §20.2.1.1.1 `ToString`s every argument, so `new Function("a,b,c", null)`
+    // is `function anonymous(a,b,c) { null }`. Declining sent it to the
+    // runtime-eval tier, whose function object is not a Wasm closure and so
+    // carries no `$bag`, no `$fnmeta` and none of the reflective arms —
+    // measured on base through an opaque receiver: `getOwnPropertyNames` 0
+    // (vs 2), `delete x.length` a no-op, `x.length = 99` accepted.
+    //
+    // 11 = `length` (1) + `name` (10), i.e. BOTH own properties are enumerated.
+    expect(
+      await runStandalone(`
+        var f = new Function("a,b,c", null);
+        var n = Object.getOwnPropertyNames(f);
+        var s = 0;
+        for (var i = 0; i < n.length; i++) { if (n[i] === "length") s += 1; if (n[i] === "name") s += 10; }
+        return s;`),
+    ).toBe(11);
+  });
+
+  it("makes DontDelete and ReadOnly reach it (S15.3.5.1_A2 / _A3)", async () => {
+    expect(
+      await runStandalone(`
+        var f = new Function("arg1,arg2,arg3", null);
+        var deleted = delete f.length;
+        return (deleted && !f.hasOwnProperty("length")) ? 1 : 0;`),
+    ).toBe(1);
+    expect(
+      await runStandalone(`
+        var f = new Function("arg1,arg2,arg3", "arg4,arg5", null);
+        f.length = 99;
+        var k = "length";
+        return f[k];`),
+    ).toBe(5);
+  });
+
+  it("PINS the known cost of the fold: `f.constructor` is still unimplemented", async () => {
+    // The fold's one measured regression, pinned deliberately so it cannot be
+    // "fixed" silently or forgotten. §20.2.3.1 says every function object's
+    // `constructor` is `%Function%`; this compiler has no `.constructor` arm for
+    // a function-valued receiver at all, so an AOT-compiled closure answers
+    // `undefined`. That gap is PRE-EXISTING — A/B'd identical on the pre-#4437
+    // tree (`09ecad8`), where `built-ins/Function/S15.3.2.1_A1_T6` and `_A3_T15`
+    // already fail with the same message — but the `null`-body fold moves
+    // `S15.3.2.1_A1_T10` off the runtime-eval tier (which DOES answer
+    // `constructor`) and onto the AOT path, so that one file regresses in
+    // exchange for the six `S15.3.5.1_A2/_A3` files.
+    //
+    // When the `%Function%` carrier lands (see R6 on the issue), this assertion
+    // flips to `=== Function` and A1_T10 comes back.
+    expect(
+      await runStandalone(`
+        function g(a, b) {}
+        return g.constructor === undefined ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("folds the other two KEYWORD literals", async () => {
+    // `true`/`false` are keyword TOKENS: their ToString is fixed by the grammar
+    // and unshadowable, so `new Function("a", true)` is
+    // `function anonymous(a) { true }` — arity 1.
+    expect(await runStandalone(`var f = new Function("a", true); var k = "length"; return f[k];`)).toBe(1);
+  });
+
+  it("still DECLINES anything whose ToString is not fixed by the grammar", async () => {
+    // `undefined` is an ordinary, shadowable identifier; a numeric literal's
+    // ToString is Number::toString (`1e21` → `"1e+21"`, `0x10` → `"16"`).
+    // Publishing a wrong function BODY is far worse than declining to fold, so
+    // both keep routing to the runtime-eval tier.
+    //
+    // Asserted through the IMPORT SECTION rather than by running the module:
+    // "did the fold fire?" IS "is `js2wasm:runtime-eval` linked?", and a
+    // declined fold cannot instantiate host-free at all — which is the whole
+    // reason the six `Function/length` files were unreachable.
+    expect(await linksRuntimeEval(`var f = new Function("a", 1e21); return 0;`)).toBe(true);
+    expect(await linksRuntimeEval(`var f = new Function("a", undefined); return 0;`)).toBe(true);
+    // …while the three keyword literals do not need it.
+    expect(await linksRuntimeEval(`var f = new Function("a", null); return 0;`)).toBe(false);
+    expect(await linksRuntimeEval(`var f = new Function("a", false); return 0;`)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Wave 8c of the #4426 ES5-standalone campaign — the #4437 R1 residual (methods decline the meta) plus the Function-length descriptor family. New `function-instance-meta-methods.ts`; measured on the integrated branch (all A/Bs run by the implementing agent, both arms, nothing read from stale baseline artifacts):

- Method `*length-dflt.js`: 0 → **8** of 11
- `built-ins/Function/length/`: 7 → **13** of 13
- `built-ins/Function` whole directory (509 files): 346 → **351**
- `Expected obj[length] NOT to be writable`: 0 → 3 of 4 (the 4th is a String exotic, different substrate)
- Controls: 128-file stride sample byte-identical; gc/host sha256-identical on 27 files; 178/178 vitest (14-test pin + the #4436/#4437 pins). Verified post-merge here: 56/56.

Two findings recorded in the issue file that change what a reader should do:
1. **The &#34;17-file `f.constructor` regression from #4437&#34; was a mis-attribution** — three-tree A/B shows the S15.3.2.1 family at 25/28 on both sides of #4437 with byte-identical failure lists. The real gap is that no `.constructor` arm exists for function-valued receivers (AOT closures answer `undefined`; runtime-eval-tier callables answer correctly), and a promote-to-promote flip of that shape can be pure environment (with the eval provider unavailable the family drops 0/28 in one stroke).
2. **One declared regression (`S15.3.2.1_A1_T10`, the price of six A2/A3 conversions) and a fix built but deliberately NOT shipped**: the synthetic-`Function`-identifier `.constructor` arm measured +9/−1 over 509 files, but it pulls `js2wasm:runtime-eval` into every `.constructor`-reading module — silently ending host-freeness, which no gate measures. Filed as R6 with the narrowing (`compileIdentifier`&#39;s `Function` resolution); needs a self-contained `%Function%` carrier first.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_