### PR TITLE
fix(#4420): gate compiles on WebAssembly.compile + fix the encodeInstr miscompile it exposed

### DIFF
--- a/plan/issues/4420-gate-selfhost-on-webassembly-compile.md
+++ b/plan/issues/4420-gate-selfhost-on-webassembly-compile.md
@@ -1,10 +1,11 @@
 ---
 id: 4420
 title: "A compile can report success:true and emit a module the engine rejects — gate on WebAssembly.compile"
-status: in-progress
+status: done
+completed: 2026-08-15
 sprint: current
 created: 2026-08-14
-updated: 2026-08-14
+updated: 2026-08-15
 priority: high
 horizon: m
 feasibility: medium
@@ -12,6 +13,15 @@ reasoning_effort: medium
 task_type: bug
 area: codegen
 goal: correctness
+# Both grants are comment-dominated: the two edits add 3 and 1 statement lines
+# respectively; the rest is the rationale for a one-condition change whose
+# absence produced an engine-invalid module while the compiler reported success.
+loc-budget-allow:
+  - src/compiler.ts
+  - src/codegen/property-access-dispatch.ts
+func-budget-allow:
+  - src/compiler.ts::runPipeline
+  - src/codegen/property-access-dispatch.ts::finalizeStructAndDynamicMemberGet
 ---
 
 ## Problem
@@ -48,11 +58,11 @@ broken".
 
 ## Acceptance criteria
 
-- [ ] A validation step exists that callers can opt into, and every
+- [x] A validation step exists that callers can opt into, and every
       self-host / dogfood / compat scoreboard uses it.
-- [ ] A regression test compiles `src/emit/binary.ts` and asserts
+- [x] A regression test compiles `src/emit/binary.ts` and asserts
       `WebAssembly.compile` resolves — currently failing, which is the point.
-- [ ] The `encodeInstr` type mismatch is root-caused and fixed.
+- [x] The `encodeInstr` type mismatch is root-caused and fixed.
 
 ## Notes
 
@@ -145,3 +155,168 @@ planner after this lands; results recorded here.
 ### Acceptance criteria (restated, unchanged from above)
 
 The three checkboxes in this issue; the regression test is (b) in Part 2.
+
+## Results (2026-08-15)
+
+### Root cause of the `encodeInstr` miscompile
+
+**Construct** — `src/emit/binary.ts:1008`, inside `case "if":` of `encodeInstr`:
+
+```ts
+const hasElse = instr.else && instr.else.length > 0;
+```
+
+**Why the read went dynamic.** `Instr` (`src/ir/types.ts:343`) is not a plain
+union — it is an **intersection**, `(…~200 variants…) & { sourcePos?: SourcePos }`.
+An intersection carries `ts.TypeFlags.Intersection`, not `Object`, so
+`ensureStructForType` returns at its first guard and the narrowed `if`-variant
+never becomes a WasmGC struct. `resolveWasmType` therefore answers `externref`
+for the receiver and the read is serviced by the dynamic property dispatch in
+`finalizeStructAndDynamicMemberGet` (`src/codegen/property-access-dispatch.ts`).
+Confirmed by instrumentation: `objType = { op: "if"; blockType: BlockType;
+then: Instr[]; else?: Instr[] } & { sourcePos?: SourcePos }`, `objWasm =
+externref`.
+
+**The faulty type decision.** In that dispatch, the Phase-3 (#1269)
+consumer-side specialization narrows the dispatch RESULT to a primitive when
+every struct in the module carrying a field of the same NAME agrees on its
+kind. Its guard read:
+
+```ts
+let resultWasm = accessWasm.kind === "f64" || accessWasm.kind === "i32" ? accessWasm : { kind: "externref" };
+if (resultWasm.kind === "externref" && !preserveDynamicResultCarrier) { …vote… }
+```
+
+`resultWasm` is set to `externref` for **every** non-f64/i32 `accessWasm`, so
+the vote was also eligible for reads whose static type is a concrete
+`ref`/`ref_null`. Here `accessWasm` for `instr.else` is
+`{kind:"ref_null", typeIdx: 2}` — `$__vec_externref`, i.e. `Instr[]`. The only
+struct in the whole module carrying a field named `else` is the `OP` opcode
+table (`$__anon_5`, ~150 all-f64 fields, `else: 0x05`). A single-candidate,
+unanimous vote therefore collapsed the read of an **array** to **f64**, while
+the enclosing `.length` still emitted the typed `struct.get $__vec_externref 0`:
+
+```wat
+call 16                 ;; dispatch result
+local.tee 295           ;; $__sd_res_293, declared f64
+struct.get 2 0          ;; .length off a $__vec_externref
+```
+
+→ `Compiling function #103:"encodeInstr" failed: struct.get[0] expected type
+(ref null 2), found local.tee of type f64 @+128058`.
+
+The vote is a NAME-keyed heuristic; a concrete `ref`/`ref_null` access type is
+a statement about the value's representation and may not be overruled by it.
+
+### Fix
+
+`src/codegen/property-access-dispatch.ts`, in `finalizeStructAndDynamicMemberGet`
+— the Phase-3 vote is now admissible only when the access is statically dynamic:
+
+```ts
+if (resultWasm.kind === "externref" && accessWasm.kind === "externref" && !preserveDynamicResultCarrier) {
+```
+
+That is the condition the surrounding #1269 comment always described
+("when `accessWasm` is externref (TS `any`-typed receiver)"); the guard tested
+the wrong variable. Reads with a concrete access type keep the honest externref
+dispatch result and are re-narrowed by the caller's own coercion. No cast at the
+emission site, no raw `checker.*` call (`check:oracle-ratchet` reports
+`getTypeAtLocation +0, ctx.checker +0`).
+
+### Part 1 — the validate gate as implemented
+
+- **`validateEmittedBinary(binary): { valid, detail? }`** — new export in
+  `src/optimize.ts`, re-exported from `src/index.ts`. It owns the
+  validate-then-reconstruct-a-`Module`-to-recover-the-engine-detail idiom
+  (including the TS 5.7+ `BufferSource` cast). Returns `valid: true` when no
+  `WebAssembly` global exists, preserving the pre-existing optimizer behavior.
+- **`CompileOptions.validate?: boolean`** (`src/index.ts`) — opt-in. When set
+  and a binary was produced, an engine rejection flips `success` to `false` and
+  pushes a source-anchored **error**-severity `CompileError` carrying the engine
+  detail. The binary is still returned so the caller can dump or diff it.
+- **Wired at the single common exit**: the tail of `runPipeline`
+  (`src/compiler.ts`), which every driver funnels through — `compileSourceSync`,
+  `compileSource`, `compileMultiSource` and `compileFilesSource` all return its
+  result. Not per-caller, so no driver can be gated while another is not. It
+  runs before the async wasm-opt pass, which validates its own output already
+  (#1941), so the gate answers for what CODEGEN produced.
+- **No duplication and no double-reporting**: `optimizedBinaryValidates`
+  (#1941) now delegates to the helper; the CLI's refuse-to-publish check
+  (#3338, `src/cli.ts`) calls it instead of its inline copy and keeps its own
+  post-optimize placement, so the CLI does not pass `validate: true`.
+
+### Consumers updated
+
+- `tests/helpers/compile-project-probe.ts` — the shared probe behind the
+  package-entry dogfood harness (and thus the npm-compat `compile`/`validation`
+  fields) held a **third** copy of the idiom; it now calls the helper.
+- `scripts/generate-npm-compat-report.mjs` — `correctnessVerdict(...,
+  { compiles: report?.compile?.success !== false })` treated `success` as
+  "compiled". It now also requires `report?.validation?.validates !== false`.
+- **Audited, no change needed**: every `tests/dogfood/*.mjs` harness that
+  compiles already runs `WebAssembly.compile`/`validate`/`instantiate` on the
+  result (verified mechanically over all of them), and their reports already
+  carry `compile.success` and `validation.validates` as separate axes. Passing
+  `validate: true` there would have merged two axes their reporting formats
+  deliberately keep apart.
+
+### Measured outcome
+
+| Probe | Before | After |
+| --- | --- | --- |
+| `compileFiles("src/emit/binary.ts")` | `success: true`, 269,241 B, **`WebAssembly.validate: false`** | `success: true`, 269,259 B, **`WebAssembly.validate: true`** |
+| minimized construct (13 lines) | `success: true`, **invalid** — same engine message | `success: true`, **valid**, `main()` returns the correct `54` |
+
+`npx tsx .tmp/selfhost-repro.mts src/emit/binary.ts` → `success: true` and
+`WebAssembly.validate: true`. (The 5 remaining diagnostics are pre-existing
+warning-severity IR-fallback / `rootDir` notes, unrelated.)
+
+### Tests
+
+`tests/issue-4420-emitted-binary-validation.test.ts` (5 tests, all pass):
+
+1. minimized construct emits a module the engine accepts;
+2. minimized construct computes the right answer through the dynamic read (54);
+3. `validateEmittedBinary` returns `valid: false` **with** an engine detail for
+   rejected bytes;
+4. `validate: true` accepts a valid module and does not perturb the emitted bytes;
+5. **AC** — `compileFiles("src/emit/binary.ts", { validate: true })` reports
+   success and `WebAssembly.compile` resolves.
+
+Cost note on (5): **~13.9 s**. It runs OUT OF PROCESS via the new
+`tests/helpers/compile-files-validate-probe.ts` (spawned with
+`--max-old-space-size=2048`, same pattern as `compile-project-probe.ts`): the
+vitest fork pool caps a worker at 512 MB and this graph exhausts that heap, which
+surfaces as a worker crash rather than a verdict. The probe also passes
+`emitWat: false` — the full-module WAT is a ~2 MB string nothing here reads.
+
+Regression sweep: `issue-1269`, `issue-2938`, `issue-2785`, `issue-2674`,
+`issue-2664`, `issue-1712-dynamic-dispatch`, `issue-1712-capture-closure-dispatch`,
+`issue-3037`, `issue-3053-u0`, `issue-3431-mg-matrix` → **105 passed, 6 failed**,
+and the *identical* 6 fail on the pre-fix codegen (A/B'd by swapping the single
+changed file), so they are pre-existing, not caused here. `pnpm run typecheck`
+exit 0; biome `--diagnostic-level=error` clean; prettier clean.
+`check:oracle-ratchet`, `check:pushraw`, `check:coercion-sites`,
+`check:any-box-sites` all green. `check:loc-budget` / `check:func-budget` growth
+is granted in this file's frontmatter (comment-dominated).
+
+### Open finding — a SIBLING invalid-module bug, NOT fixed here
+
+`compileFiles("src/boundary-policy.ts")` still returns `success: true` with
+60,352 bytes that the engine rejects, **after** this fix:
+
+```
+Compiling function #47:"__cb_0" failed:
+  struct.new[1] expected type (ref null 26), found if of type f64 @+28816
+```
+
+Re-verified against the fixed compiler, so it is a different defect in the same
+family (a value the checker types as a struct ref lowered as f64), not a second
+symptom of the Phase-3 vote. WAT localization points at a generated callback
+wrapper `$__cb_0` building a `$__tuple_0 (struct (field $_0 externref) (field
+$_1 (ref null $StructTypeDef)))`, whose second element is a bounds-guarded array
+read lowered as `(if (result f64) … (else NaN))` — i.e. the element type was
+decided f64 while the tuple slot is a struct ref. Left for a follow-up issue per
+the parent lane's instruction; recorded here so the repro is not lost:
+`npx tsx .tmp/selfhost-repro.mts src/boundary-policy.ts`.

--- a/plan/issues/4420-gate-selfhost-on-webassembly-compile.md
+++ b/plan/issues/4420-gate-selfhost-on-webassembly-compile.md
@@ -1,7 +1,7 @@
 ---
 id: 4420
 title: "A compile can report success:true and emit a module the engine rejects — gate on WebAssembly.compile"
-status: ready
+status: in-progress
 sprint: current
 created: 2026-08-14
 updated: 2026-08-14
@@ -63,3 +63,85 @@ Worth checking whether the existing `validate` paths (`src/emit/`,
 
 Found by the self-hosting investigation. Repro: `compileFiles` on
 `src/emit/binary.ts`, then `WebAssembly.compile(result.binary)`.
+
+## Implementation Plan (Fable, 2026-08-15)
+
+Reproduced on current main (worktree
+`/home/user/js2wasm/.claude/worktrees/compiler-speedup`, harness
+`.tmp/selfhost-repro.mts` — note it must shim `globalThis.require` via
+`createRequire` because `analyzeFiles` calls bare `require()`, and must not
+use top-level await alongside it): `success: true`, `errors` length 5
+(warning-severity IR-fallback diagnostics), 269,241 bytes,
+`WebAssembly.validate` false, engine error
+`function #103:"encodeInstr": struct.get[0] expected (ref null 2), found
+local.tee of type f64 @+128058`.
+
+### Part 1 — the validate gate (do this first; it is the durable half)
+
+The CLI is already honest: `src/cli.ts:503` validates before writing and
+exits 1, constructing a `WebAssembly.Module` to surface the engine's detail
+string. The programmatic API (`compileFiles`/`compile` → `CompileResult`) is
+what lies. Plan:
+
+1. Extract the CLI's validate-with-detail idiom into a small exported helper
+   (suggest `validateEmittedBinary(binary): { valid: boolean; detail?: string }`
+   in `src/optimize.ts` next to `optimizedBinaryValidates`, which already has
+   the `BufferSource` cast pattern — check both call sites and reuse, don't
+   duplicate a third copy).
+2. Add opt-in `validate?: boolean` to `CompileOptions`. When set and a binary
+   was produced: run the helper; on failure flip `success: false` and push a
+   `CompileError` (`severity: "error"`, message carrying the engine detail).
+   Wire it in `compileFilesSource` (src/compiler.ts:1806) AND the single-file
+   `compile`/`compileSource` path — grep for where `success: true` results
+   are assembled (src/compiler.ts:1232 area) and apply at the common exit
+   point, not per-caller. CLI keeps its own existing check (it runs post-
+   optimize; do not double-report).
+3. Point the scoreboard consumers at it: `tests/dogfood/*.mjs` harnesses and
+   `scripts/generate-npm-compat-report.mjs` — wherever they treat
+   `success`/compile-OK as "compiled", pass `validate: true` or call the
+   helper on the binary. Do not rewrite their reporting formats; just make
+   "compiled OK" mean "engine-valid".
+
+### Part 2 — the encodeInstr miscompile (root-cause with a procedure)
+
+The failing construct is in `encodeInstr` (`src/emit/binary.ts`): codegen
+emits `(struct.get $T 0 (local.tee $t <f64 value>))` — a member read off a
+value it typed as a struct ref while the local it allocated is f64. Suspect
+class: a checker/oracle type says "object" while the ValType map says f64
+(or a union collapse), likely from an expression of the form
+`(x = <numeric expr>).<member>` / compound assignment feeding a member
+access, or a vec `.length` read (field 0) off a numeric local.
+
+Procedure (do not skip to guessing):
+
+1. Localize: compile `src/emit/binary.ts` with the WAT emitter (CLI `--wat`
+   or the analyze-wat script path) and find in `encodeInstr`'s body the
+   `struct.get` whose operand is a `local.tee` of an f64 local. The WAT names
+   give you the source construct.
+2. Minimize into a standalone repro file in `.tmp/` (extract the construct
+   with only the types it needs) and confirm it still emits invalid Wasm via
+   the Part-1 helper. THEN reduce to the smallest program that flips
+   valid/invalid.
+3. Fix at the type-decision site, not by casting at the emission site —
+   follow where the ValType for that local was chosen (likely
+   `src/codegen/expressions/*` assignment/member paths; check `ctx.oracle`
+   usage rules in CLAUDE.md — do NOT reach for raw `checker.*`, the
+   oracle-ratchet gate blocks it).
+4. Regression tests: (a) the minimized construct as a normal
+   `tests/issue-4420*.test.ts` equivalence-style test (compile + validate +
+   run, assert correct value); (b) the AC test — compile
+   `src/emit/binary.ts` via `compileFiles` with `validate: true` and assert
+   `success === true` and `WebAssembly.compile` resolves. Both must pass at
+   PR time, so Part 2's fix lands in the same PR as Part 1.
+   ⚠ Test (b) compiles a real compiler source file inside vitest — check its
+   runtime cost; if it exceeds ~60 s in the suite, scope it to the file-level
+   test timeout and note the cost in the test header.
+
+### Out of scope (stays with the parent lane)
+
+The full `src/**/*.ts` self-compile sweep/scoreboard — run separately by the
+planner after this lands; results recorded here.
+
+### Acceptance criteria (restated, unchanged from above)
+
+The three checkboxes in this issue; the regression test is (b) in Part 2.

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -1499,7 +1499,15 @@ async function buildPackageEntry({ name, version, issue, entryFile, shape, repor
     // package that compiles to a valid module but computes the WRONG ANSWER
     // cannot read as green. `unverified` means nothing is known — it is never
     // a synonym for "fine".
-    correctness: correctnessVerdict(tests, { compiles: report?.compile?.success !== false }),
+    // (#4420) "compiles" must mean the ENGINE accepted the module, not that
+    // `compile()` returned `success: true` — codegen can finish and still emit
+    // bytes `WebAssembly.compile` rejects, which would let a package read as
+    // compiling when nothing it produced can run. Every harness feeding this
+    // report already records `validation.validates` from the engine; consult it.
+    // `!== false` on both axes keeps "unknown" out of the failure bucket.
+    correctness: correctnessVerdict(tests, {
+      compiles: report?.compile?.success !== false && report?.validation?.validates !== false,
+    }),
     perf,
     knownBugs: knownBugsFor(name),
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,8 @@ if (args.includes("--ts7")) {
   process.env.JS2WASM_TS7 = "1";
 }
 
-const { compile, compileProject, entryHasRelativeImports, formatCompileExplanation } = await import("./index.js");
+const { compile, compileProject, entryHasRelativeImports, formatCompileExplanation, validateEmittedBinary } =
+  await import("./index.js");
 const { buildDefaultDefines } = await import("./compiler/define-substitution.js");
 
 if (args.includes("--version") || args.includes("-v")) {
@@ -495,22 +496,14 @@ if (suppressedAllowlist > 0) {
 // output file is written — so a malformed artifact never escapes with a
 // success exit code. Optimizer-availability warnings stay nonfatal because the
 // preserved binary they fall back to still reaches this check and validates.
-// Cast to BufferSource: under TS 5.7+ the typed-array generic types this as
-// `Uint8Array<ArrayBufferLike>`, which the lib `validate`/`Module` overloads
-// (param: BufferSource) don't structurally accept without the widening — the
-// same cast `optimizedBinaryValidates` uses in src/optimize.ts.
-const binaryForValidation = result.binary as unknown as BufferSource;
-if (!WebAssembly.validate(binaryForValidation)) {
-  let detail = "";
-  try {
-    // Constructing a Module surfaces the first engine validation detail that
-    // `WebAssembly.validate` (a bare boolean) does not expose.
-    new WebAssembly.Module(binaryForValidation);
-  } catch (err) {
-    detail = err instanceof Error ? err.message : String(err);
-  }
+// (#4420) Shared with the compiler's opt-in `validate` gate and the optimizer's
+// own output check — `validateEmittedBinary` owns the validate-then-recover-the-
+// engine-detail idiom (including the BufferSource cast TS 5.7+ requires).
+const cliValidation = validateEmittedBinary(result.binary);
+if (!cliValidation.valid) {
   console.error(
-    `${absInput}: error: emitted WebAssembly failed validation and was not written` + (detail ? ` — ${detail}` : ""),
+    `${absInput}: error: emitted WebAssembly failed validation and was not written` +
+      (cliValidation.detail ? ` — ${cliValidation.detail}` : ""),
   );
   process.exit(1);
 }

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -3864,7 +3864,24 @@ export function finalizeStructAndDynamicMemberGet(
           // taught the consumer-side dispatch to use the typed read.
           let resultWasm: ValType =
             accessWasm.kind === "f64" || accessWasm.kind === "i32" ? accessWasm : ({ kind: "externref" } as const);
-          if (resultWasm.kind === "externref" && !preserveDynamicResultCarrier) {
+          // (#4420) The vote is only admissible when the ACCESS ITSELF is
+          // statically dynamic — `accessWasm.kind === "externref"`. The old
+          // guard tested `resultWasm`, which is set to externref for EVERY
+          // non-f64/i32 `accessWasm`, so a read whose static type is a concrete
+          // `ref`/`ref_null` (an array, a struct) was eligible too and could be
+          // collapsed to f64/i32 by an unrelated struct that merely shares the
+          // property NAME. Self-compiling `src/emit/binary.ts` hit exactly that:
+          // `instr.else` is `Instr[]` (`ref null $__vec_externref`), the only
+          // struct in the module carrying an `else` field is the `OP` opcode
+          // table (all-f64), so the single-candidate vote narrowed the read to
+          // f64 while the enclosing `.length` still emitted the typed
+          // `struct.get $__vec_externref 0` — `struct.get[0] expected (ref null
+          // 2), found local.tee of type f64`, a module the engine rejects while
+          // the compiler reported success. A concrete `ref`/`ref_null` access
+          // type is a STATEMENT about the value's representation; a name-keyed
+          // field vote may not overrule it. Such reads keep the honest
+          // externref result and are re-narrowed by the caller's own coercion.
+          if (resultWasm.kind === "externref" && accessWasm.kind === "externref" && !preserveDynamicResultCarrier) {
             const fieldKinds = new Set(structCandidates.map((c) => c.fieldType.kind));
             // (#3927) A hot/cold-split fnctor carries `propName` in its
             // lazily-allocated tail, and `findAlternateStructsForField`

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -65,7 +65,7 @@ import { normalizeScriptHtmlLikeComments } from "./compiler/html-like-comments.j
 import * as irIds from "./compiler/ir-outcome-inventory.js";
 import { buildLinearOptions } from "./compiler/linear-options.js";
 import type { CompileError, CompileOptions, CompileResult } from "./index.js";
-import { optimizeBinaryAsync } from "./optimize.js";
+import { optimizeBinaryAsync, validateEmittedBinary } from "./optimize.js";
 import { generateWit } from "./wit-generator.js";
 import {
   foldGroundCallsInMultiFilesForCompile as foldGroundCallsInMulti,
@@ -1224,12 +1224,39 @@ function runPipeline(input: PipelineInput): CompileResult {
   // API callers. The serialized helper therefore cannot silently recover the
   // low-level buildImports compatibility defaults.
   const importsHelper = generateImportsHelper(adapterManifest);
+
+  // Step 8 (#4420): opt-in engine validation. `success: true` above only says
+  // codegen finished — it is NOT a claim that the bytes form a module, and a
+  // miscompile therefore escaped as a green result (`compileFiles` on
+  // `src/emit/binary.ts` returned success with 268 KB the engine rejected).
+  // Wired HERE, at the one exit every driver funnels through (compileSourceSync
+  // / compileSource / compileMultiSource / compileFilesSource all return
+  // runPipeline's result), so no caller can be validated while another is not.
+  // Runs BEFORE the async wasm-opt pass, which is deliberate: the optimizer
+  // validates its own output already (#1941, and it refuses to ship bytes it
+  // broke), so this gate answers for what CODEGEN produced. The binary is
+  // still returned on failure — a caller that just learned its module is
+  // invalid needs the bytes to dump or diff.
+  let emittedBinaryAccepted = true;
+  if (options.validate === true && binary.length > 0) {
+    const validation = validateEmittedBinary(binary);
+    if (!validation.valid) {
+      emittedBinaryAccepted = false;
+      pushSourceAnchoredDiagnostic(
+        errors,
+        diagnosticAnchor,
+        `emitted WebAssembly failed validation${validation.detail ? ` — ${validation.detail}` : ""}`,
+        "error",
+      );
+    }
+  }
+
   return {
     binary,
     wat,
     dts,
     importsHelper,
-    success: true,
+    success: emittedBinaryAccepted,
     errors,
     stringPool: mod.stringPool,
     sourceMap: sourceMapJson,

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,6 +383,27 @@ export interface CompileOptions {
   /** Emit WAT debug output (default: true) */
   emitWat?: boolean;
   /**
+   * (#4420) Gate the result on the host WebAssembly engine.
+   *
+   * `success` alone means "codegen ran to completion", NOT "the bytes are a
+   * module". Self-compiling `src/emit/binary.ts` returned `success: true` with
+   * 268 KB of Wasm the engine then rejected — so any scoreboard built on the
+   * flag (self-hosting progress, npm-compat matrix, conformance counts) could
+   * report progress that does not exist.
+   *
+   * With `validate: true` the emitted binary is run through
+   * `validateEmittedBinary`; if the engine rejects it, `success` flips to
+   * `false` and an error-severity {@link CompileError} carrying the engine's
+   * detail string is pushed onto `errors`. The binary is still returned so the
+   * caller can dump/diff it.
+   *
+   * Opt-in: validation costs a full engine decode of the module, and existing
+   * callers that deliberately inspect invalid output (WAT dumps, minimizers)
+   * must keep getting it. The CLI runs its own post-optimize check (#3338) and
+   * therefore does NOT set this — it would double-report.
+   */
+  validate?: boolean;
+  /**
    * Debug-only: when set, WAT emission only formats functions whose Wasm
    * name is in this set (plus types/imports/globals for context), skipping
    * the rest. Full-module `emitWat` can throw "Invalid string length" on
@@ -1155,6 +1176,11 @@ export { preloadLibFiles } from "./checker/index.js";
 export { getEntryExportNames, treeshake } from "./treeshake.js";
 export { generateWit } from "./wit-generator.js";
 export type { WitGeneratorOptions } from "./wit-generator.js";
+// (#4420) The single engine-validation primitive. Exported so scoreboards
+// (dogfood harnesses, npm-compat, self-host probes) can ask "is this a module
+// the engine accepts?" without growing another private copy of the idiom.
+export { validateEmittedBinary } from "./optimize.js";
+export type { EmittedBinaryValidation } from "./optimize.js";
 
 // #2527 / #2514 — canonical runtime-type rec-group identity primitive for
 // core-wasm module linking (shared store). Pure analysis over a WasmModule's

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -146,6 +146,68 @@ function isBrowserLikeRuntime(): boolean {
   return typeof window !== "undefined" || typeof (globalThis as any).WorkerGlobalScope !== "undefined";
 }
 
+/** Outcome of {@link validateEmittedBinary}. */
+export interface EmittedBinaryValidation {
+  /** `false` only when the engine actively REJECTED the bytes. */
+  valid: boolean;
+  /** The engine's first validation message, when one could be obtained. */
+  detail?: string;
+}
+
+/**
+ * Ask the host engine whether a Wasm binary is a valid module (#4420).
+ *
+ * This is the ONE place the "validate, then re-run through `new
+ * WebAssembly.Module` to recover the engine's detail string" idiom lives.
+ * `WebAssembly.validate` answers a bare boolean; constructing a `Module` is
+ * what surfaces the actual complaint (`Compiling function #103:"encodeInstr"
+ * failed: struct.get[0] expected type (ref null 2), found local.tee of type
+ * f64`) that makes a miscompile diagnosable. Callers: the compiler's opt-in
+ * `validate` gate (src/compiler.ts), the CLI's refuse-to-publish check
+ * (src/cli.ts, #3338), {@link optimizedBinaryValidates} (#1941), and the
+ * dogfood/npm-compat compile probe.
+ *
+ * Reports `valid: true` when validation cannot be performed at all (no
+ * `WebAssembly` global — an exotic embedding). That is deliberate and matches
+ * the pre-existing optimizer behavior: an environment that cannot validate
+ * must not have every compile fail, and it cannot run the module either.
+ */
+export function validateEmittedBinary(binary: Uint8Array): EmittedBinaryValidation {
+  const WA = (
+    globalThis as {
+      WebAssembly?: {
+        validate?: (b: BufferSource) => boolean;
+        Module?: new (b: BufferSource) => unknown;
+      };
+    }
+  ).WebAssembly;
+  if (!WA || typeof WA.validate !== "function") return { valid: true };
+  // Cast to BufferSource: under TS 5.7+ the typed-array generic types this as
+  // `Uint8Array<ArrayBufferLike>`, which the lib `validate`/`Module` overloads
+  // (param: BufferSource) don't structurally accept without the widening.
+  const bytes = binary as unknown as BufferSource;
+  let ok = false;
+  try {
+    ok = WA.validate(bytes);
+  } catch {
+    // A throw from validate means the bytes are structurally broken — treat
+    // as invalid rather than letting a malformed binary through.
+    ok = false;
+  }
+  if (ok) return { valid: true };
+  let detail: string | undefined;
+  if (typeof WA.Module === "function") {
+    try {
+      new WA.Module(bytes);
+      // Module construction accepting bytes `validate` rejected would be an
+      // engine inconsistency; trust the stricter answer and stay invalid.
+    } catch (err) {
+      detail = err instanceof Error ? err.message : String(err);
+    }
+  }
+  return detail === undefined ? { valid: false } : { valid: false, detail };
+}
+
 /**
  * Validate optimizer output before trusting it (#1941).
  *
@@ -159,18 +221,7 @@ function isBrowserLikeRuntime(): boolean {
  * worse than the status quo.
  */
 function optimizedBinaryValidates(binary: Uint8Array): boolean {
-  const WA = (globalThis as { WebAssembly?: { validate?: (b: BufferSource) => boolean } }).WebAssembly;
-  if (!WA || typeof WA.validate !== "function") return true;
-  try {
-    // Cast to BufferSource: under TS 5.7+ the typed-array generic types this
-    // as `Uint8Array<ArrayBufferLike>`, which the lib.dom `validate` overload
-    // (param: BufferSource) doesn't structurally accept without the widening.
-    return WA.validate(binary as unknown as BufferSource);
-  } catch {
-    // A throw from validate means the bytes are structurally broken — treat
-    // as invalid rather than letting a malformed binary through.
-    return false;
-  }
+  return validateEmittedBinary(binary).valid;
 }
 
 /**

--- a/tests/helpers/compile-files-validate-probe.ts
+++ b/tests/helpers/compile-files-validate-probe.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4420) Run `compileFiles` with the engine-validation gate outside Vitest's
+// worker process. Same reason as `compile-project-probe.ts`: a real source
+// graph (the compiler's own `src/emit/binary.ts` pulls in ~270 KB of Wasm)
+// needs more heap than the 512 MB the fork pool gives a worker, and a
+// heap-exhausted worker reads as an infrastructure failure rather than a
+// verdict.
+//
+// Prints one marker line with the verdict: whether `compileFiles` reported
+// success under `validate: true`, and — independently — whether the host
+// engine actually accepts the emitted bytes.
+
+import { createRequire } from "node:module";
+
+// `analyzeFiles` (src/checker/index.ts) reaches for a bare `require("node:path")`.
+// Under an ESM entry that binding does not exist, and Node reports it as
+// ERR_AMBIGUOUS_MODULE_SYNTAX rather than a missing global. Provide it before
+// the compiler is loaded.
+(globalThis as unknown as { require?: NodeRequire }).require ??= createRequire(import.meta.url);
+
+const { compileFiles } = await import("../../src/index.js");
+
+export const COMPILE_FILES_VALIDATE_PROBE_MARKER = "__JS2_COMPILE_FILES_VALIDATE_PROBE__";
+
+const [entry] = process.argv.slice(2);
+if (!entry) {
+  throw new Error("usage: compile-files-validate-probe.ts <entry>");
+}
+
+// `emitWat: false`: the full-module WAT for a graph this size is a multi-MB
+// string built from millions of fragments, and nothing here reads it.
+const result = await compileFiles(entry, { validate: true, emitWat: false });
+
+let engineAccepts = false;
+let engineError: string | null = null;
+try {
+  await WebAssembly.compile(result.binary as unknown as BufferSource);
+  engineAccepts = true;
+} catch (error) {
+  engineError = error instanceof Error ? error.message : String(error);
+}
+
+const report = {
+  success: result.success,
+  binaryByteLength: result.binary.byteLength,
+  engineAccepts,
+  engineError,
+  errors: result.errors
+    .filter((error) => error.severity !== "warning")
+    .map((error) => ({
+      message: error.message,
+      line: error.line,
+      column: error.column,
+    })),
+};
+
+process.stdout.write(`${COMPILE_FILES_VALIDATE_PROBE_MARKER}${JSON.stringify(report)}\n`);

--- a/tests/helpers/compile-project-probe.ts
+++ b/tests/helpers/compile-project-probe.ts
@@ -4,7 +4,7 @@
 // graphs can synchronously occupy the compiler for longer than Vitest's worker
 // heartbeat, producing a false infrastructure failure after valid assertions.
 
-import { compileProject, type CompileOptions } from "../../src/index.js";
+import { compileProject, validateEmittedBinary, type CompileOptions } from "../../src/index.js";
 
 export const COMPILE_PROJECT_PROBE_MARKER = "__JS2_COMPILE_PROJECT_PROBE__";
 
@@ -15,15 +15,16 @@ if (!entry || !rawOptions) {
 
 const options = JSON.parse(rawOptions) as CompileOptions;
 const result = await compileProject(entry, options);
+// (#4420) `success` means codegen finished, not that the engine accepts the
+// bytes — the package-entry harness reports "compiled" off this probe, so the
+// verdict has to come from the shared engine gate rather than a local copy of
+// the validate-then-recover-the-detail idiom.
 let valid = false;
 let validationError: string | null = null;
 if (result.success) {
-  try {
-    new WebAssembly.Module(result.binary);
-    valid = true;
-  } catch (error) {
-    validationError = error instanceof Error ? error.message : String(error);
-  }
+  const validation = validateEmittedBinary(result.binary);
+  valid = validation.valid;
+  validationError = valid ? null : (validation.detail ?? "emitted binary failed WebAssembly validation");
 }
 const report = {
   success: result.success,

--- a/tests/issue-4420-emitted-binary-validation.test.ts
+++ b/tests/issue-4420-emitted-binary-validation.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { compile, validateEmittedBinary } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+// Re-declared, not imported: the probe module runs its compile on import.
+// Same convention as `eslint-graph-probe.ts` vs `compile-project-probe.ts`.
+const COMPILE_FILES_VALIDATE_PROBE_MARKER = "__JS2_COMPILE_FILES_VALIDATE_PROBE__";
+
+/**
+ * #4420 — a compile could report `success: true` and hand back a module the
+ * engine rejects. Two halves, both pinned here.
+ *
+ * PART 1 — the gate. `success` only ever meant "codegen finished". The opt-in
+ * `validate: true` option makes it mean "the engine accepts these bytes":
+ * `validateEmittedBinary` (src/optimize.ts) is the single implementation of the
+ * validate-then-recover-the-engine-detail idiom, shared by the CLI's
+ * refuse-to-publish check (#3338), the optimizer's own output check (#1941) and
+ * this option.
+ *
+ * PART 2 — the miscompile the gate exposed. Compiling the compiler's own
+ * `src/emit/binary.ts` produced
+ *   `Compiling function #103:"encodeInstr" failed: struct.get[0] expected type
+ *    (ref null 2), found local.tee of type f64`
+ * from `const hasElse = instr.else && instr.else.length > 0;`. `Instr` is an
+ * INTERSECTION (`(…variants…) & { sourcePos?: SourcePos }`), so its narrowed
+ * receiver never registers a WasmGC struct and the read goes through the
+ * dynamic property dispatch. There the Phase-3 (#1269) result narrowing voted
+ * on every struct in the module carrying a field NAMED `else` — the only one
+ * being the all-f64 `OP` opcode table — and collapsed the read of an `Instr[]`
+ * to f64, while the enclosing `.length` still emitted the typed
+ * `struct.get $__vec_externref 0`. The vote is now admissible only when the
+ * access's own static type is externref (genuinely dynamic); a concrete
+ * `ref`/`ref_null` access type may not be overruled by a name collision.
+ */
+
+// The minimized construct, reduced from `encodeInstr`. Every ingredient is
+// load-bearing: the union must be INTERSECTED (otherwise the narrowed receiver
+// registers an anon struct that also carries `else`, the field-kind vote then
+// disagrees, and the defect hides), the numeric table must collide on the
+// property NAME, and the read must be an array whose `.length` is taken.
+const MINIMIZED = `
+  type Pos = { line: number };
+
+  type Node = ({ op: "block"; body: Node[] } | { op: "if"; then: Node[]; else?: Node[] }) & { pos?: Pos };
+
+  const OP = { block: 2, if: 4, else: 5 };
+
+  function encode(n: Node): number {
+    if (n.op === "if") {
+      const hasElse = n.else && n.else.length > 0;
+      return hasElse ? OP.else : OP.if;
+    }
+    return OP.block;
+  }
+
+  export function main(): number {
+    const withElse: Node = { op: "if", then: [], else: [{ op: "block", body: [] }] };
+    const without: Node = { op: "if", then: [] };
+    return encode(withElse) * 10 + encode(without);
+  }
+`;
+
+describe("#4420 Part 2 — dynamic-dispatch result narrowing vs. a typed access", () => {
+  it("emits a module the engine accepts", async () => {
+    const result = await compile(MINIMIZED, {});
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    // Before the fix: `struct.get[0] expected type (ref null 2), found
+    // local.tee of type f64` — reported by the engine, not by the compiler.
+    expect(validateEmittedBinary(result.binary).detail ?? "").toBe("");
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+
+  it("computes the right answer through the dynamic read", async () => {
+    const result = await compile(MINIMIZED, {});
+    expect(result.success).toBe(true);
+    const instance = await instantiateWithRuntime(result);
+    // `else` present → OP.else (5); absent → OP.if (4).
+    expect((instance.exports.main as () => number)()).toBe(54);
+  });
+});
+
+describe("#4420 Part 1 — the opt-in validate gate", () => {
+  it("validateEmittedBinary reports the engine's detail for rejected bytes", () => {
+    // A well-formed header followed by a garbage section: `validate` says no,
+    // and the detail string is what makes such a failure diagnosable at all.
+    const bogus = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0xff, 0x7f, 0x7f, 0x7f]);
+    const verdict = validateEmittedBinary(bogus);
+    expect(verdict.valid).toBe(false);
+    expect(verdict.detail !== undefined && verdict.detail.length > 0).toBe(true);
+  });
+
+  it("accepts a valid module and leaves the emitted bytes untouched", async () => {
+    const source = `export function add(a: number, b: number): number { return a + b; }`;
+    const gated = await compile(source, { validate: true });
+    expect(gated.success).toBe(true);
+    expect(gated.errors.filter((e) => e.severity === "error")).toEqual([]);
+    const ungated = await compile(source, {});
+    expect(gated.binary.length).toBe(ungated.binary.length);
+  });
+});
+
+describe("#4420 acceptance — self-compiling src/emit/binary.ts", () => {
+  // Cost note: ~14 s wall on an 8-core container (a real compiler source file
+  // plus its whole import graph, ~270 KB of Wasm), so the test carries an
+  // explicit timeout well past vitest's 5 s default.
+  //
+  // Run OUT OF PROCESS, like `compile-project-probe.ts`: the fork pool caps a
+  // worker at 512 MB (`VITEST_FORK_MAX_OLD_SPACE_SIZE`) and this graph exhausts
+  // that heap, which surfaces as a worker crash — an infrastructure failure,
+  // not a verdict — rather than as a test result.
+  it("returns success under the validate gate and yields a module WebAssembly.compile accepts", () => {
+    const probe = fileURLToPath(new URL("./helpers/compile-files-validate-probe.ts", import.meta.url));
+    const child = spawnSync(
+      process.execPath,
+      ["--max-old-space-size=2048", "--import", "tsx", probe, "src/emit/binary.ts"],
+      {
+        cwd: fileURLToPath(new URL("..", import.meta.url)),
+        encoding: "utf-8",
+        maxBuffer: 64 * 1024 * 1024,
+        timeout: 240_000,
+      },
+    );
+    const marked = (child.stdout ?? "")
+      .split("\n")
+      .find((line) => line.startsWith(COMPILE_FILES_VALIDATE_PROBE_MARKER));
+    expect(marked, `probe produced no verdict:\n${child.stderr ?? ""}`).toBeDefined();
+    const report = JSON.parse(marked!.slice(COMPILE_FILES_VALIDATE_PROBE_MARKER.length)) as {
+      success: boolean;
+      binaryByteLength: number;
+      engineAccepts: boolean;
+      engineError: string | null;
+      errors: { message: string }[];
+    };
+    // The two axes, asserted separately and in this order: the engine's
+    // verdict is the ground truth, and `success` is only trustworthy because
+    // the gate now derives it from that verdict.
+    expect(report.engineError ?? "").toBe("");
+    expect(report.engineAccepts).toBe(true);
+    expect(report.success, report.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(report.binaryByteLength).toBeGreaterThan(0);
+  }, 300_000);
+});


### PR DESCRIPTION
## Description

Issue #4420 (plan by the Fable lane, implementation by an Opus subagent). Two halves, landed together so the AC test passes at PR time:

**The gate (durable half).** `compileFiles("src/emit/binary.ts")` returned `success: true` with a 269KB module the engine rejects — `success` said nothing about module validity. Now: `validateEmittedBinary(binary) → { valid, detail? }` (new export in `src/optimize.ts`, owns the validate-then-`Module`-for-detail idiom), opt-in `CompileOptions.validate` that flips `success: false` with an error-severity `CompileError` carrying the engine detail, wired once at the tail of `runPipeline` so every driver is covered. `optimizedBinaryValidates` and the CLI's refuse-to-publish check now delegate to the helper (three inline copies → one). npm-compat's `correctnessVerdict` additionally requires `validation.validates !== false`; the dogfood harnesses were audited and already validate independently (left unchanged deliberately — their reports keep compile/validation as separate axes).

**The miscompile it exposed.** Root cause in `finalizeStructAndDynamicMemberGet` (`src/codegen/property-access-dispatch.ts`): the Phase-3 (#1269) name-keyed field-kind vote was admissible for ANY non-f64/i32 access type, so a read of `instr.else` (`Instr[]`, concrete `ref_null $__vec_externref`) got collapsed to f64 because the only struct in the module with a field named `else` was the all-f64 opcode table. (`Instr` being an intersection type kept the receiver off the struct path and routed it into dynamic dispatch in the first place.) Fix is one condition: the vote now also requires `accessWasm.kind === "externref"` — the condition the surrounding #1269 comment always described. No emission-site cast, oracle-ratchet clean.

## Validation

- `compileFiles("src/emit/binary.ts")`: was `success: true` + `validate: false`; now `success: true` + **`WebAssembly.validate: true`**.
- `tests/issue-4420-emitted-binary-validation.test.ts` 5/5 — minimized construct validates AND computes the right value (54); helper surfaces engine detail; `validate: true` doesn't perturb valid output; AC test compiles `src/emit/binary.ts` itself with `validate: true` (~13.9s, run out-of-process via a probe helper because the vitest fork pool's 512MB worker cap OOMs on this graph in-worker).
- Regression sweep over the dispatch-adjacent suites: 105 pass / 6 fail, the identical 6 fail on pre-fix codegen (A/B'd) — pre-existing.
- Typecheck/biome/prettier clean; oracle-ratchet, pushraw, coercion-sites, any-box-sites gates green; LOC/func budget growth granted in the issue frontmatter (comment-dominated).

**Recorded open finding** (issue Results): `src/boundary-policy.ts` is a *sibling* invalid-module bug, still reproducing after this fix (`__cb_0`: `struct.new[1] expected (ref null 26), found if of type f64` — a tuple slot vs bounds-guarded array read). Follow-up issue being filed with its own plan.

Issue #4420 → done in this PR (self-merge path), with full root-cause writeup in the issue file.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm)_