### PR TITLE
fix(early-errors): nested-block shadowing is not a TDZ violation (#4453)

### DIFF
--- a/plan/issues/4453-tdz-shadowed-block-false-positive.md
+++ b/plan/issues/4453-tdz-shadowed-block-false-positive.md
@@ -1,0 +1,95 @@
+---
+id: 4453
+title: "TDZ early-error false positive: nested-block shadowing — 'Cannot access X before initialization' on correct code"
+status: in-progress
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: correctness
+---
+
+# #4453 — TDZ checker reports shadowed nested-block consts as TDZ violations
+
+Found by the #4420 self-hosting baseline sweep: compiling the compiler's own
+`src/import-resolver.ts` fails with `Cannot access 'replacementText' before
+initialization` and `src/cjs-rewrite.ts` with `Cannot access 'imports' before
+initialization` — both files are correct TypeScript that executes fine.
+
+## Suspected mechanism (verify first — this is a hypothesis with a specific
+predicted repro, not a confirmed diagnosis)
+
+`checkTDZInStatements` (`src/compiler/early-errors/tdz.ts`) collects the
+let/const declarations of ONE statement list, then scans earlier statements
+for references to not-yet-declared names via a traversal that stops at
+function/class boundaries but **descends into nested Blocks without tracking
+shadowing**. So:
+
+```ts
+if (cond) {
+  const x = 1;      // inner block's OWN x
+  use(x);           // ← reported: "Cannot access 'x' before initialization"
+}
+const x = 2;        // outer list declares x AFTER the if-statement
+```
+
+The outer list's scan sees the identifier `x` inside the `if` block before the
+outer `const x` and cannot tell it refers to the inner binding.
+`src/import-resolver.ts` declares `const replacementText` twice in sibling
+scopes (lines ~1313 and ~1396), matching this shape.
+
+## Implementation Plan (Fable, 2026-08-15)
+
+1. **Confirm the mechanism**: run the predicted repro above through
+   `detectEarlyErrors` (see `.tmp/ee-diff.mts` in the `compiler-speedup`
+   worktree for the parse+detect harness shape). If it does NOT reproduce,
+   STOP and diagnose from the real files instead (binary-search
+   `import-resolver.ts` down to the triggering construct) before changing
+   anything — then update this section with the real mechanism.
+2. **Fix in the collector, minimally**: in the TDZ reference scan
+   (`collectTDZRefs` / `checkForTDZRef` — note #4432 restructured this file;
+   read the current shape first), when descending into a nested **Block /
+   CaseClause-like scope** whose own `LexicallyDeclaredNames` include the
+   pending name, do not report references to that name inside it (the inner
+   binding shadows the outer). Implementation sketch: at each Block boundary
+   during the scan, compute the block's own let/const/class/function lexical
+   names (reuse the existing collection helpers in `duplicates.ts` if their
+   semantics fit — check before reusing) and subtract them from the pending
+   set for that subtree. Same rule for `for`-statement heads if the scan
+   descends into them.
+3. **Scope discipline**: this changes emitted diagnostics (removes false
+   positives) — it is NOT differential-neutral, so the #4425-style
+   byte-identical gate does not apply. The guard is tests + the merge_group
+   conformance diff: removing a false TDZ *warning* may flip test262
+   runtime-negative tests that relied on the warning channel — check the
+   test262 TDZ-adjacent suites locally if feasible (grep the baseline for
+   tests whose expected error is `Cannot access`), and state in the PR that
+   the merge queue's regression diff is the authority.
+4. **Tests** (`tests/issue-4453*.test.ts`): (a) the shadowed-nested-block
+   shape produces NO TDZ diagnostic; (b) a genuine TDZ violation
+   (`use(x); const x = 1;` same list) still produces one — pin both
+   directions; (c) `compileFiles` on a reduced fixture mirroring
+   import-resolver's shape reports no `Cannot access` error. Optionally (d):
+   the real files — `compileFiles("src/import-resolver.ts")` no longer
+   emits the false positive (cheap: 5.6 s graph; assert on error text, not
+   success, since other gaps may remain).
+5. **Perf note**: the per-block lexical-name computation runs only while a
+   pending name exists and only on nested blocks in its subtree — keep it
+   lazy so #4432's single-traversal win is not eroded; if you add
+   allocations on the hot path, re-run `.tmp/ee-time.mts` (compiler-speedup
+   worktree) and report the delta.
+
+## Acceptance criteria
+
+- [ ] Mechanism confirmed (or corrected) and documented in Results.
+- [ ] Shadowed nested-block shape emits no TDZ diagnostic; genuine TDZ still
+      caught (both pinned by tests).
+- [ ] `src/import-resolver.ts` / `src/cjs-rewrite.ts` no longer emit the
+      false 'Cannot access' errors.
+- [ ] Typecheck + gates green; detect-time delta reported if the hot path
+      changed.

--- a/plan/issues/4453-tdz-shadowed-block-false-positive.md
+++ b/plan/issues/4453-tdz-shadowed-block-false-positive.md
@@ -1,10 +1,11 @@
 ---
 id: 4453
 title: "TDZ early-error false positive: nested-block shadowing — 'Cannot access X before initialization' on correct code"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-15
 updated: 2026-08-15
+completed: 2026-08-15
 priority: medium
 horizon: s
 feasibility: medium
@@ -86,10 +87,127 @@ scopes (lines ~1313 and ~1396), matching this shape.
 
 ## Acceptance criteria
 
-- [ ] Mechanism confirmed (or corrected) and documented in Results.
-- [ ] Shadowed nested-block shape emits no TDZ diagnostic; genuine TDZ still
+- [x] Mechanism confirmed (or corrected) and documented in Results.
+- [x] Shadowed nested-block shape emits no TDZ diagnostic; genuine TDZ still
       caught (both pinned by tests).
-- [ ] `src/import-resolver.ts` / `src/cjs-rewrite.ts` no longer emit the
+- [x] `src/import-resolver.ts` / `src/cjs-rewrite.ts` no longer emit the
       false 'Cannot access' errors.
-- [ ] Typecheck + gates green; detect-time delta reported if the hot path
+- [x] Typecheck + gates green; detect-time delta reported if the hot path
       changed.
+
+## Results (2026-08-15)
+
+### Mechanism — CONFIRMED exactly as hypothesized, no correction needed
+
+The predicted repro reproduced on the first run, before any change:
+
+```
+=== shadowed nested block (predicted repro)
+   [warning] 4:11 Cannot access 'x' before initialization   ← the INNER `const x = 1` itself
+   [warning] 5:9  Cannot access 'x' before initialization   ← `use(x)`
+```
+
+Note the first row: the scan flagged the inner declaration's **own name
+identifier**, which is the giveaway that it was descending into the block with
+no notion of the scope it had entered.
+
+Both real files reproduced at the `detectEarlyErrors` level too —
+`src/import-resolver.ts` 3 diagnostics (lines 1313/1317/1318),
+`src/cjs-rewrite.ts` 4 (lines 179/184/186/190) — and the source confirms the
+shape in both: `cjs-rewrite.ts` declares `const imports` at line 179 inside
+`if (!isConst) { … }` and again at line 194 in the enclosing function body;
+`import-resolver.ts` declares `const replacementText` at 1313 inside a nested
+`if` and at 1396 in the enclosing for-body statement list.
+
+### Fix
+
+`src/compiler/early-errors/tdz.ts` only. `collectTDZRefs` now subtracts a
+nested scope's own lexically-declared names from the pending set **for that
+subtree**, via `shadowedNames(node, names)`:
+
+- Boundaries handled: `Block` (let/const incl. destructuring patterns, plus
+  function and class declarations), `CaseBlock` (one scope across all clauses),
+  `for`/`for-in`/`for-of` heads with a let/const initializer, and `CatchClause`
+  (the catch parameter). Function/class scopes are unaffected — the scan
+  already stops there.
+- **Lazy, per #4432's constraint**: `shadowedNames` returns `undefined` both
+  for a non-boundary node and for a boundary that shadows nothing, so the
+  common case allocates nothing and the traversal continues unchanged. A
+  narrowed `Set` is built only when a scope actually re-declares a pending
+  name. When *every* pending name is shadowed the subtree is skipped outright,
+  which is strictly less work than before.
+- **Emission order is preserved by construction**: the change only removes
+  candidate matches; the grouped-by-declaration-map-order-then-encounter-order
+  emission in `checkTDZInStatements` is untouched.
+  `tests/issue-4432-scope-collectors.test.ts` stays green (8/8).
+- `checkForTDZRef` (the initializer self-reference path) gets the same rule,
+  guarded by a cheap kind test so it allocates only at an actual boundary.
+
+### Measurements (all A/B'd against the unmodified file kept at `.tmp/tdz-base.ts`)
+
+**Diagnostic delta** — `ee-diff.mts` over test262 `language` + `annexB` + `src/**/*.ts`
+(25,878 files):
+
+| | base | fixed |
+| --- | --- | --- |
+| diagnostics | 23,988 | 22,421 |
+
+**1,567 removed, 0 added.** Every removal is `Cannot access 'X' before
+initialization`. 1,566 of them are in `src/**` — 95 distinct compiler source
+files, **76 of which drop to zero early-error diagnostics**, so this was
+blocking self-hosting far more broadly than the two files in the report.
+
+Exactly **one** removal lands in the whole test262 corpus scanned:
+`language/statements/block/scope-lex-close.js` — a **positive** test
+(`assert.sameValue(x, 'outside')`) that was being handed a spurious warning on
+its `let x = 'inside'`. Removing it can only help that test. The merge queue's
+regression diff remains the authority on conformance.
+
+**Detect time** — `ee-time.mts`, same corpus at `sampleEvery=3` (8,626 files),
+steady-state (iter2), two independent rounds each:
+
+| | round 1 | round 2 |
+| --- | --- | --- |
+| base | 2.56 s wall / 2.62 s cpu | 2.63 s / 2.71 s |
+| fixed | 2.46 s / 2.52 s | 2.80 s / 2.85 s |
+
+The sign flips between rounds, so **no measurable delta** — the round-to-round
+spread (~0.2 s) exceeds the base-vs-fixed spread. #4432's single-traversal
+structure is intact.
+
+**Whole-program `compileFiles`** (tsx, outside vitest):
+
+| entry | base | fixed |
+| --- | --- | --- |
+| `src/import-resolver.ts` | 8 errors, 3 TDZ | 5 errors, **0 TDZ** |
+| `src/cjs-rewrite.ts` | 9 errors, 4 TDZ | 5 errors, **0 TDZ** |
+
+The 5 residual errors in each are unrelated self-hosting gaps (a `typescript`
+module-resolution error and `Missing __make_getter_callback import`), which is
+why the tests assert on the diagnostic text rather than on `success`.
+
+### Tests
+
+`tests/issue-4453-tdz-shadowed-block.test.ts` (16 tests, all green; **11 of the
+16 fail on the unmodified file**, verified by reverting):
+
+- 7 shadowing shapes emit nothing: if-block, bare top-level block, for-head,
+  switch `CaseBlock`, catch parameter, destructuring pattern, block-scoped
+  class/function.
+- 6 genuine-TDZ pins still fire at the exact same position, including
+  `{ use(x); const x = 1; } const x = 2;` — which is both a shadowing block AND
+  its own TDZ violation, and now reports **once** instead of three times.
+- `compileFiles` on `tests/fixtures/issue-4453-shadowed-block.ts` (reduced
+  import-resolver shape) reports no `Cannot access`.
+- The two real files are asserted via `detectEarlyErrors` on their own source
+  rather than `compileFiles`: a whole-program compile of either pulls the
+  ~700-file compiler graph and peaks at 0.7–0.9 GB RSS, which **OOMs a vitest
+  worker** (measured — the worker died at a ~510 MB heap limit). The false
+  positive is produced by the early-error gate on the single file, so this
+  asserts the same thing without the graph.
+
+Other suites: `issue-4432` 8/8, `issue-1931` 20/20, `issue-4417` 13/13,
+`issue-2929` (4 files) 35 passed / 12 skipped — all green. `issue-790` has 4
+failures that are **pre-existing**: identical on the unmodified file.
+
+`pnpm run typecheck` exit 0; biome and prettier clean on all touched files.

--- a/src/compiler/early-errors/tdz.ts
+++ b/src/compiler/early-errors/tdz.ts
@@ -102,6 +102,18 @@ export function checkTDZInStatements(ctx: EarlyErrorContext, stmts: ts.NodeArray
  * five nested-scope descent boundaries are ported verbatim from
  * `checkForTDZRef`; only emission is deferred to the caller so that the
  * original grouped-by-name ordering is preserved.
+ *
+ * #4453: a nested block scope that re-declares a pending name shadows the outer
+ * binding throughout its subtree, so a reference there is to the INNER binding
+ * and is not a TDZ violation of the outer declaration:
+ *
+ *     if (c) { const x = 1; use(x); }   // ← both were flagged before #4453
+ *     const x = 2;
+ *
+ * The shadowed names are subtracted from `names` for that subtree only, which
+ * narrows what the single traversal matches without adding a traversal — the
+ * #4432 structure and its emission order are unchanged (removing matches cannot
+ * reorder the ones that remain).
  */
 function collectTDZRefs(node: ts.Node, names: Set<string>, matches: Map<string, ts.Node[]>): void {
   if (ts.isIdentifier(node)) {
@@ -133,7 +145,128 @@ function collectTDZRefs(node: ts.Node, names: Set<string>, matches: Map<string, 
   ) {
     return;
   }
+  const inner = shadowedNames(node, names);
+  if (inner !== undefined) {
+    // Every pending name is shadowed here — nothing in this subtree can name an
+    // outer binding, so the whole subtree is skipped.
+    if (inner.size === 0) return;
+    forEachChild(node, (child: ts.Node) => collectTDZRefs(child, inner, matches));
+    return;
+  }
   forEachChild(node, (child: ts.Node) => collectTDZRefs(child, names, matches));
+}
+
+/**
+ * The scopes a TDZ reference scan can descend into that introduce lexical
+ * bindings of their own (#4453). Function and class scopes are NOT here: the
+ * scan stops at those outright, before this is consulted.
+ */
+function isNestedLexicalScope(node: ts.Node): boolean {
+  return (
+    ts.isBlock(node) ||
+    ts.isCaseBlock(node) ||
+    ts.isForStatement(node) ||
+    ts.isForInStatement(node) ||
+    ts.isForOfStatement(node) ||
+    ts.isCatchClause(node)
+  );
+}
+
+/**
+ * `names` minus the lexical names `node` introduces, or `undefined` when `node`
+ * is not a nested lexical scope OR declares none of `names` (#4453).
+ *
+ * `undefined` deliberately covers both cases: both mean *keep traversing with
+ * the caller's set*, and collapsing them keeps the check allocation-free on the
+ * hot path — a narrowed Set is built only for a scope that actually re-declares
+ * a pending name, which is rare.
+ *
+ * What each boundary contributes:
+ * - `Block` — its LexicallyDeclaredNames: let/const (including destructuring
+ *   patterns), plus function and class declarations.
+ * - `CaseBlock` — one shared scope across every clause (ES §14.12.2).
+ * - `for` / `for-in` / `for-of` — a let/const head binding scopes over the
+ *   whole statement, head and body alike.
+ * - `CatchClause` — the catch parameter binding.
+ */
+function shadowedNames(node: ts.Node, names: Set<string>): Set<string> | undefined {
+  if (ts.isBlock(node)) {
+    return shadowStatementList(node.statements, names, undefined);
+  }
+  if (ts.isCaseBlock(node)) {
+    let out: Set<string> | undefined;
+    for (const clause of node.clauses) {
+      out = shadowStatementList(clause.statements, names, out);
+    }
+    return out;
+  }
+  if (ts.isForStatement(node) || ts.isForInStatement(node) || ts.isForOfStatement(node)) {
+    const init = node.initializer;
+    if (init === undefined || !ts.isVariableDeclarationList(init)) return undefined;
+    const flags = init.flags;
+    if ((flags & ts.NodeFlags.Let) === 0 && (flags & ts.NodeFlags.Const) === 0) return undefined;
+    let out: Set<string> | undefined;
+    for (const decl of init.declarations) {
+      out = shadowBinding(decl.name, names, out);
+    }
+    return out;
+  }
+  if (ts.isCatchClause(node)) {
+    if (node.variableDeclaration === undefined) return undefined;
+    return shadowBinding(node.variableDeclaration.name, names, undefined);
+  }
+  return undefined;
+}
+
+/** Subtract a statement list's lexically-declared names from `names` (#4453). */
+function shadowStatementList(
+  stmts: readonly ts.Statement[],
+  names: Set<string>,
+  out: Set<string> | undefined,
+): Set<string> | undefined {
+  for (const stmt of stmts) {
+    if (ts.isVariableStatement(stmt)) {
+      const flags = stmt.declarationList.flags;
+      if ((flags & ts.NodeFlags.Let) !== 0 || (flags & ts.NodeFlags.Const) !== 0) {
+        for (const decl of stmt.declarationList.declarations) {
+          out = shadowBinding(decl.name, names, out);
+        }
+      }
+    } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+      out = shadowName(stmt.name.text, names, out);
+    } else if (ts.isClassDeclaration(stmt) && stmt.name) {
+      out = shadowName(stmt.name.text, names, out);
+    }
+  }
+  return out;
+}
+
+/** Subtract every identifier bound by a (possibly destructuring) binding name. */
+function shadowBinding(
+  name: ts.BindingName,
+  names: Set<string>,
+  out: Set<string> | undefined,
+): Set<string> | undefined {
+  if (ts.isIdentifier(name)) return shadowName(name.text, names, out);
+  for (const el of name.elements) {
+    if (ts.isBindingElement(el)) out = shadowBinding(el.name, names, out);
+  }
+  return out;
+}
+
+/**
+ * Subtract one name, materializing the narrowed set only on a real hit. `out`
+ * is always a subset of `names`, so once it exists the delete is unconditional.
+ */
+function shadowName(text: string, names: Set<string>, out: Set<string> | undefined): Set<string> | undefined {
+  if (out !== undefined) {
+    out.delete(text);
+    return out;
+  }
+  if (!names.has(text)) return undefined;
+  const narrowed = new Set(names);
+  narrowed.delete(text);
+  return narrowed;
 }
 
 /**
@@ -170,5 +303,11 @@ export function checkForTDZRef(ctx: EarlyErrorContext, node: ts.Node, name: stri
   ) {
     return;
   }
+  // #4453: same shadowing rule as `collectTDZRefs`. This path scans a single
+  // declaration's initializer, where a nested lexical scope is reachable only
+  // through a node that is not one of the function-like boundaries above (an
+  // object-literal method body, say) — rare enough that the probe Set is built
+  // only once the kind test has already matched.
+  if (isNestedLexicalScope(node) && shadowedNames(node, new Set([name])) !== undefined) return;
   forEachChild(node, (child: ts.Node) => checkForTDZRef(ctx, child, name));
 }

--- a/tests/fixtures/issue-4453-shadowed-block.ts
+++ b/tests/fixtures/issue-4453-shadowed-block.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Fixture for #4453: the shape of src/import-resolver.ts' two sibling
+// `const replacementText` declarations — the first inside a nested if-block,
+// the second in the enclosing statement list. Correct code; the TDZ scan used
+// to report the inner block's mentions as uses of the outer binding.
+export function reduce(kind: number, lines: string[]): string {
+  if (kind === 0) {
+    const replacementText = lines.length > 0 ? lines[0] : "";
+    return replacementText + replacementText;
+  }
+
+  const replacementText = lines.length > 0 ? lines[0] : "none";
+  return replacementText;
+}

--- a/tests/issue-4453-tdz-shadowed-block.test.ts
+++ b/tests/issue-4453-tdz-shadowed-block.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4453 — the TDZ early-error scan reported a nested block's OWN lexical
+// declarations as TDZ violations of a same-named outer binding declared later
+// in the enclosing statement list:
+//
+//     if (cond) { const x = 1; use(x); }   // ← both flagged
+//     const x = 2;
+//
+// The scan descended into nested blocks without tracking shadowing, so every
+// mention of `x` inside the `if` looked like a use-before-declaration of the
+// outer `const x`. This is correct code — `src/import-resolver.ts` (two sibling
+// `const replacementText`) and `src/cjs-rewrite.ts` (two sibling `const
+// imports`) both hit it, and it blocked compiling the compiler with itself.
+//
+// Every test pins BOTH directions: the shadowed shape must be silent, and the
+// genuine TDZ it resembles must still be reported at the same position. A fix
+// that only removes the false positive, at the cost of missing the real
+// violation, is not a fix.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { ts } from "../src/ts-api.js";
+import { detectEarlyErrors } from "../src/compiler/early-errors/index.js";
+import { compileFiles } from "../src/index.js";
+
+/** Every early-error diagnostic for `src`, as `message@line:column`. */
+function diagnostics(src: string): string[] {
+  const sf = ts.createSourceFile("t.ts", src, ts.ScriptTarget.Latest, /*setParentNodes*/ true, ts.ScriptKind.TS);
+  return detectEarlyErrors(sf, { moduleGoal: true }).map((e) => `${e.message}@${e.line}:${e.column}`);
+}
+
+/** Just the TDZ diagnostics, so an unrelated rule firing can't mask the result. */
+function tdz(src: string): string[] {
+  return diagnostics(src).filter((m) => m.startsWith("Cannot access "));
+}
+
+describe("#4453 nested-block shadowing is not a TDZ violation", () => {
+  it("an if-block's own const is not a use of the same-named outer const", () => {
+    expect(
+      tdz("function f(cond, use) {\n  if (cond) {\n    const x = 1;\n    use(x);\n  }\n  const x = 2;\n}"),
+    ).toEqual([]);
+  });
+
+  it("a bare block at module top level shadows the same way", () => {
+    expect(tdz("{\n  const y = 1;\n  use(y);\n}\nconst y = 2;")).toEqual([]);
+  });
+
+  it("a let/const for-head binding shadows over the whole loop", () => {
+    expect(tdz("for (let i = 0; i < 3; i++) { use(i); }\nconst i = 9;")).toEqual([]);
+  });
+
+  it("a switch CaseBlock's lexical names shadow across its clauses", () => {
+    expect(tdz("switch (v) { case 1: const s = 1; use(s); }\nconst s = 2;")).toEqual([]);
+  });
+
+  it("a catch parameter shadows", () => {
+    expect(tdz("try { g(); } catch (e) { use(e); }\nconst e = 2;")).toEqual([]);
+  });
+
+  it("a destructuring pattern shadows every name it binds", () => {
+    expect(tdz("{ const { p, q } = o; use(p, q); }\nconst p = 1;\nconst q = 2;")).toEqual([]);
+  });
+
+  it("block-scoped class and function declarations shadow too", () => {
+    expect(tdz("{ class C {} use(C); }\nconst C = 1;")).toEqual([]);
+    expect(tdz("{ function fn() {} use(fn); }\nconst fn = 1;")).toEqual([]);
+  });
+});
+
+describe("#4453 genuine TDZ violations are still reported", () => {
+  it("a use before the declaration in the same statement list", () => {
+    expect(tdz("function g(use) {\n  use(x);\n  const x = 1;\n}")).toEqual([
+      "Cannot access 'x' before initialization@2:7",
+    ]);
+  });
+
+  it("a use inside a nested block that does NOT re-declare the name", () => {
+    expect(tdz("{ use(x); }\nconst x = 2;")).toEqual(["Cannot access 'x' before initialization@1:7"]);
+  });
+
+  it("a nested block that declares only OTHER names still exposes the outer use", () => {
+    expect(tdz("{ const y = 0; use(x); }\nconst x = 2;")).toEqual(["Cannot access 'x' before initialization@1:20"]);
+  });
+
+  it("a use before the declaration INSIDE the shadowing block — reported exactly once", () => {
+    // The inner block both shadows the outer `x` and violates its own TDZ. The
+    // outer scan must stay silent; the inner scan must report the one real
+    // violation. Before #4453 this emitted three diagnostics for one bug.
+    expect(tdz("{ use(x); const x = 1; }\nconst x = 2;")).toEqual(["Cannot access 'x' before initialization@1:7"]);
+  });
+
+  it("a for-head binding does not shadow a different pending name", () => {
+    expect(tdz("for (let i = 0; i < n; i++) {}\nconst n = 9;")).toEqual([
+      "Cannot access 'n' before initialization@1:21",
+    ]);
+  });
+
+  it("a self-reference in the declaration's own initializer", () => {
+    expect(tdz("let a = a + 1;")).toEqual(["Cannot access 'a' before initialization@1:9"]);
+  });
+});
+
+describe("#4453 compileFiles no longer reports the false positive", () => {
+  /** The `Cannot access` messages a whole-program compile of `entry` produces. */
+  async function tdzErrorsOf(entry: string): Promise<string[]> {
+    const r = (await compileFiles(entry, {})) as { errors?: { message: string }[] };
+    return (r.errors ?? []).map((e) => e.message).filter((m) => m.startsWith("Cannot access "));
+  }
+
+  it("compiles a reduced fixture with import-resolver's shape", async () => {
+    // Two sibling `const replacementText`, the first inside a nested if-block —
+    // src/import-resolver.ts lines ~1313 and ~1396, minimized.
+    const fixture = fileURLToPath(new URL("./fixtures/issue-4453-shadowed-block.ts", import.meta.url));
+    expect(await tdzErrorsOf(fixture)).toEqual([]);
+  }, 60_000);
+});
+
+describe("#4453 the reporting files are clean", () => {
+  // The two real files the sweep found. Asserted on the DIAGNOSTIC, not on a
+  // whole-program compile: `compileFiles` on either pulls the compiler's full
+  // ~700-file graph and peaks at 0.7–0.9 GB RSS, which OOMs a vitest worker
+  // (measured 2026-08-15) — while the false positive is produced by the
+  // early-error gate on the single file, which is exactly what this asserts.
+  // Before the fix: 3 diagnostics for import-resolver, 4 for cjs-rewrite.
+  function tdzOfFile(rel: string): string[] {
+    const path = fileURLToPath(new URL(rel, import.meta.url));
+    const sf = ts.createSourceFile(
+      path,
+      readFileSync(path, "utf8"),
+      ts.ScriptTarget.Latest,
+      /*setParentNodes*/ true,
+      ts.ScriptKind.TS,
+    );
+    return detectEarlyErrors(sf, { moduleGoal: true })
+      .map((e) => `${e.message}@${e.line}`)
+      .filter((m) => m.startsWith("Cannot access "));
+  }
+
+  it("src/import-resolver.ts — no 'Cannot access replacementText'", () => {
+    expect(tdzOfFile("../src/import-resolver.ts")).toEqual([]);
+  });
+
+  it("src/cjs-rewrite.ts — no 'Cannot access imports'", () => {
+    expect(tdzOfFile("../src/cjs-rewrite.ts")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

Issue #4453 (plan by the Fable lane, implementation by an Opus subagent) — one of four fan-out fixes from the #4420 self-hosting baseline sweep.

The TDZ early-error scan descended into nested blocks with no notion of the scope it entered: a `const x` inside a nested block, with another `const x` later in the enclosing statement list, produced `Cannot access 'x' before initialization` on correct code — it even flagged the inner declaration's own name identifier. The predicted minimal repro confirmed the mechanism on first run.

**Fix** (`src/compiler/early-errors/tdz.ts` only): `collectTDZRefs` subtracts a nested scope's own lexically-declared names from the pending set for that subtree (`Block`, `CaseBlock`, let/const `for`/`for-in`/`for-of` heads, `CatchClause`). Lazy per #4432's single-traversal constraint — the common path allocates nothing, a fully-shadowed subtree is skipped outright — and emission order is preserved by construction (matches are only removed, never reordered; the #4432 order-pinning tests stay green).

**This deliberately changes diagnostics** — the #4425/#4432 byte-identical differential gate does not apply. Measured delta over the 25,878-file corpus: **23,988 → 22,421 diagnostics; 1,567 removed, 0 added**, every removal a `Cannot access` false positive. 1,566 of them in the compiler's own `src/**` (95 files, 76 dropping to zero early-error diagnostics); exactly 1 in test262 — `language/statements/block/scope-lex-close.js`, a positive test that was being handed a spurious warning. The merge queue's regression diff is the authority for conformance movement.

## Validation

- `tests/issue-4453-tdz-shadowed-block.test.ts`: 16 tests green, 11 of which fail on the unmodified file (verified by revert) — 7 shadowing shapes now silent, 6 genuine-TDZ pins unchanged.
- Real files: `compileFiles` on `src/import-resolver.ts` 3 → 0 TDZ errors, `src/cjs-rewrite.ts` 4 → 0 (residual errors are unrelated self-hosting gaps, tracked in #4452/#4454). The in-suite assertions use `detectEarlyErrors` on the file's own source because a whole-graph `compileFiles` OOMs a 512MB vitest worker; the full-compile results are recorded in the issue file.
- Detect-time A/B: no measurable delta (sign flips between rounds, spread exceeds version difference).
- `issue-4432` 8/8, `issue-1931` 20/20, `issue-4417` 13/13, `issue-2929` green; `issue-790`'s 4 failures reproduce identically on unmodified HEAD (pre-existing). Typecheck/biome/prettier clean, full pre-commit chain run.

Issue #4453 → done in this PR (self-merge path), with the confirmed mechanism and full measurements in the issue file.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm)_