### PR TITLE
fix(#4454): register __make_getter_callback for spread+method object literals on the host plain-object path

### DIFF
--- a/plan/issues/4454-missing-make-getter-callback-import.md
+++ b/plan/issues/4454-missing-make-getter-callback-import.md
@@ -1,0 +1,204 @@
+---
+id: 4454
+title: "compileFiles fails with 'Missing __make_getter_callback import' on src/shape-inference.ts — late import registration gap"
+status: done
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+completed: 2026-08-15
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+goal: correctness
+# The new bridge-registration arm belongs next to its three sibling arms
+# (#1239 accessors, #1433 dispose, #3048 computed keys) in the collector's
+# object-literal branch; splitting one of four siblings into its own module
+# would cost more clarity than the 32 lines are worth.
+loc-budget-allow:
+  - src/codegen/declarations/import-collector.ts
+# The predicate itself is extracted to a module-level helper, so the visitor
+# grows by only the 3-line dispatch that every sibling arm also costs.
+func-budget-allow:
+  - src/codegen/declarations/import-collector.ts::unifiedVisitNode
+---
+
+# #4454 — `Missing __make_getter_callback import`
+
+Found by the #4420 self-hosting baseline sweep:
+`compileFiles("src/shape-inference.ts")` fails (5 errors) including
+`Missing __make_getter_callback import` — a compiler-internal error, not a
+user-source diagnostic. The compiler decided it needed the getter-callback
+host machinery but the import was never registered for this compilation
+shape.
+
+## Implementation Plan (Fable, 2026-08-15)
+
+1. **Locate the error**: grep `Missing __make_getter_callback` in `src/` —
+   find the emit site that throws/pushes it. `__make_getter_callback` is
+   referenced from `src/codegen/expressions/eval-inline.ts`,
+   `src/codegen/object-runtime.ts`, `src/codegen/literals.ts`,
+   `src/codegen/object-ops.ts` — one of these requests the import index and
+   fails because registration didn't happen.
+2. **Reproduce + minimize**: `compileFiles("src/shape-inference.ts")` (fast,
+   ~3.6 s graph) reproduces. Minimize to the construct that triggers the
+   getter-callback path (likely an object literal with a getter, or a class
+   accessor, reached via a multi-file/module-graph path where import
+   registration runs in a different order than the single-file path).
+3. **Root-cause against the known pattern**: CLAUDE.md documents the
+   `addUnionImports` hazard — late import addition shifts function indices
+   and must also shift `ctx.currentFunc.body`. Check whether
+   `__make_getter_callback` uses the same late-registration mechanism and
+   whether the multi-module path (`compileMultiSource` /
+   `generateMultiModule`) registers it per-module vs per-program. The bug
+   class is likely "import registered in single-file mode but not in the
+   files/multi-module pipeline" or "registered after the point where the
+   import table was frozen".
+4. **Fix at the registration site** so the import exists whenever the
+   emitting path can be reached; do not paper over by emitting a different
+   call. Standalone-mode rule applies (CLAUDE.md dual-mode): if this import
+   is host-only, confirm what standalone mode does on the same construct and
+   keep that behavior consistent — if standalone has its own lowering, the
+   fix must not accidentally route standalone through the host import.
+5. **Tests** (`tests/issue-4454*.test.ts`): (a) minimized construct compiles
+   with `validate: true`-style honesty if available on this branch (this
+   branch is based on origin/main which may not yet have #4420's option —
+   use `WebAssembly.validate` directly on the binary in that case) and runs
+   correctly in JS-host mode; (b)
+   `compileFiles("src/shape-inference.ts")` no longer reports the missing-
+   import error (assert on error text; other failures in that file may
+   remain — do not assert overall success unless it actually holds).
+6. **Collateral**: run the object/getter-adjacent suites (grep tests/ for
+   getter/accessor issue tests) — import-table changes are the classic
+   index-shift regression source.
+
+## Acceptance criteria
+
+- [x] Emit site + registration gap documented in Results (which pipeline
+      path skips registration and why).
+- [x] Minimized getter construct compiles to an engine-valid module and runs.
+- [x] `src/shape-inference.ts` no longer reports the missing-import error.
+- [x] Object/getter suites green; typecheck + gates green.
+
+## Results (2026-08-15)
+
+### It is NOT a pipeline / late-import-ordering bug
+
+The plan's hypothesis (single-file vs `compileFiles` multi-module registration
+order) does not hold. The construct is shape-triggered, not pipeline-triggered:
+the same literal fails in a plain single-file `compile()`. `compileFiles` was
+only how it surfaced — the offending literal lives in `src/ts-api.ts`, which
+`src/shape-inference.ts` pulls in transitively, so a single-file compile of the
+entry file never reached it. No late-import / index-shift mechanism is involved
+in the fix; the import is registered in the ordinary up-front pre-pass.
+
+### Emit site
+
+`src/codegen/closures.ts:3824` — `compileArrowAsCallback` resolves the maker
+name via `resolveCallbackMakerName` (`__make_getter_callback` when
+`needsThis`), looks it up in `ctx.funcMap`, and on a miss does
+`reportError(ctx, arrow, \`Missing ${makeCallbackName} import\`)`.
+(Standalone/WASI never reaches the error — it degrades to
+`compileArrowAsClosure` one branch earlier, #3235.)
+
+Reached from `emitObjectLiteralMethodFn` (`src/codegen/literals.ts:1168`), the
+MethodDeclaration arms of the host plain-object literal paths
+(`compileObjectLiteralAsExternref` ~L532, `compileObjectLiteralWithAccessors`
+~L1049).
+
+### Registration gap
+
+`unifiedVisitNode` in `src/codegen/declarations/import-collector.ts` sets
+`state.getterCallbackFound` (which materializes the `env::__make_getter_callback`
+import in the finalizer, ~L1917) for an object literal only when it carries:
+
+- a `get`/`set` accessor (#1239), or
+- a computed method key — `Symbol.dispose`/`asyncDispose` (#1433) or any
+  non-plain-literal computed key (#3048).
+
+A **plain-named method shorthand** (`m() {}`, `"m"() {}`, `0() {}`) was not
+covered, because in the ordinary case such a literal lowers to a struct with a
+compile-time method table and never touches the bridge. But a literal that also
+contains a **spread** and has no concrete contextual type is diverted to the
+host plain-object path by `objectLiteralSpreadTakesHostPath` (#2804), and that
+path installs each method as a real runtime own property through
+`emitObjectLiteralMethodFn` → the bridge. Pre-pass and emitter therefore
+disagreed, and the emit site found an empty `funcMap`.
+
+`src/ts-api.ts` hits it three times:
+
+```ts
+const synthesized: Record<string, unknown> = {
+  ...astMod,
+  ...isMod,
+  factory: factoryMod,
+  __js2wasmTs7: true,
+  createProgram() { … },
+  createSourceFile() { … },
+  createCompilerHost() { … },
+};
+```
+
+`Record<string, unknown>` has zero properties, so
+`objectLiteralSpreadTakesHostPath` answers true → host path → three CEs.
+
+Minimized (single-file `compile()`, JS-host mode):
+
+| literal                                                          | before |
+| ---------------------------------------------------------------- | ------ |
+| `const o: any = { m() {} }`                                       | ok     |
+| `const o = { ...s, m() {} }` (no annotation)                      | **CE** |
+| `const o: any = { ...s, m() {} }`                                 | **CE** |
+| `const o: Record<string, unknown> = { ...s, m() {} }`             | **CE** |
+| `const o: any = { ...s, "m"() {} }`                               | **CE** |
+| `const o: { a: number; m(): number } = { ...s, m() {} }` (concrete) | ok   |
+| `const o: any = { ...s, m: function () {} }` (property, not shorthand) | ok |
+
+### Fix
+
+`src/codegen/declarations/import-collector.ts` — a new module-level predicate
+`objectLiteralMethodNeedsGetterBridge(ctx, node)` (true when the literal has a
+spread **and** a plain-named method **and** `objectLiteralSpreadTakesHostPath`
+answers true), dispatched from one extra 3-line arm in the object-literal branch
+of `unifiedVisitNode`. Gating on the emitter's own predicate (rather than on
+"has a spread") keeps pre-pass and emit site in lockstep, so the
+concretely-annotated struct-path case does not pull in an unused import. The
+predicate lives outside the visitor so the already-oversized `unifiedVisitNode`
+grows only by the dispatch (#3400 func budget); both budget gates are granted
+for this change-set in the frontmatter above.
+
+Dual-mode: gated `!(ctx.standalone || targetProfile.semanticProviders ===
+"native-first")`, mirroring `emitObjectLiteralMethodFn`'s own branch —
+standalone lowers the method to a host-free closure (#2194) and must not
+declare the unsatisfiable `env::` import. Verified: the standalone build of the
+failing literal imports no `__make_getter_callback`.
+
+### Validation
+
+- `compileFiles("src/shape-inference.ts")`: was `success: false, 5 errors`
+  incl. 3 × `Missing __make_getter_callback import` (at `src/ts-api.ts:194`,
+  `:200`, `:206`), 0 binary bytes → now `success: true, 0 missing-import
+  errors, 25,939 binary bytes`. The two remaining diagnostics are unrelated
+  and pre-existing (a TS1259 `allowSyntheticDefaultImports` diagnostic and an
+  IR-path warning).
+- `tests/issue-4454-spread-method-getter-callback.test.ts` — 6 tests, all
+  pass: JS-host run (`{ ...src, m() { return this.a + 2 } }` → 42), the
+  three-method `src/ts-api.ts` shape, four spread+method variants asserted
+  `WebAssembly.validate`-valid, standalone host-free, concrete-annotation
+  control, and a `compileMulti` two-file graph reproducing the cross-module
+  original. The real-file `compileFiles` run is NOT in the suite: compiling
+  the compiler's own module graph exceeds vitest's 512 MB per-fork heap
+  (`VITEST_FORK_MAX_OLD_SPACE_SIZE`) and OOM-killed the worker.
+- Collateral, A/B'd against the unpatched file (file-copy revert, same
+  command both runs): 18 object/getter/accessor/spread/callback suites —
+  identical failure sets before and after — 20 pre-existing failures in the
+  spread/object batch (`spread-rest` 13, `getters-setters` 6,
+  `issue-2151-mixed-spread` 1) and 8 in the defineProperty/accessor batch
+  (`issue-2992-accessor-merge` 5, `issue-2992-accessor-widening` 1,
+  `issue-2580-m3-bacc-defineproperty-accessor` 1, `issue-3214-void-host-callback`
+  1), byte-identical lists in both directions; 15 `tests/equivalence/*`
+  object/spread suites all green.
+- `pnpm run typecheck` 0 · `pnpm run lint` 0 · prettier clean ·
+  `check:oracle-ratchet` OK (checker usage +0) · `check:ir-fallbacks` OK.

--- a/src/codegen/declarations/import-collector.ts
+++ b/src/codegen/declarations/import-collector.ts
@@ -45,6 +45,7 @@ import {
   hasDeclareModifier,
   parseRegExpLiteral,
 } from "../index.js";
+import { isPlainNamedMethodDeclaration, objectLiteralSpreadTakesHostPath } from "../literals.js";
 import { ensureNativeStringHelpers } from "../native-strings.js";
 import { emitNativeNumberFormat, usesNativeNumberFormat } from "../number-format-native.js";
 import { emitNativeBigIntFormat } from "../bigint-format-native.js";
@@ -284,6 +285,41 @@ function needsHostIndirectEvalImport(ctx: CodegenContext, node: ts.Node): boolea
   return (
     !!shape && collectorSeesAmbientEval(ctx, shape.evalIdentifier) && collectorProvesHostEvalString(ctx, shape.source)
   );
+}
+
+/**
+ * (#4454) True when this object literal will install a PLAIN-NAMED method
+ * shorthand (`m() {}`, `"m"() {}`, `0() {}`) through the
+ * `this`-forwarding `env::__make_getter_callback` bridge, so the collector must
+ * pre-register that import.
+ *
+ * A SPREAD-bearing literal with no concrete contextual type is diverted to the
+ * host plain-object path by `objectLiteralSpreadTakesHostPath` (#2804), whose
+ * MethodDeclaration arm materializes each method as a real runtime own property
+ * via `emitObjectLiteralMethodFn` → `compileArrowAsCallback({needsThis:true})` →
+ * the bridge. The collector previously registered it only for get/set accessors
+ * (#1239) and computed method keys (#1433/#3048), so `{ ...src, m() {…} }`
+ * reached the emit site with an empty `funcMap` and hard-CE'd with
+ * "Missing __make_getter_callback import" — found by the #4420 self-hosting
+ * sweep, where `src/ts-api.ts` synthesizes its TS7 shim as
+ * `{ ...astMod, ...isMod, createProgram() {…}, … }` typed `Record<string, unknown>`.
+ *
+ * Gating on the EMITTER'S OWN predicate rather than on "has a spread" keeps
+ * pre-pass and emit site in lockstep — the discipline that avoids re-introducing
+ * the late-import index-shift hazard (#1384) — and leaves a concretely-annotated
+ * target (`const o: { a: number; m(): number } = { ...s, m() {…} }`) on the
+ * struct path with no unused import.
+ *
+ * Host/GC only, mirroring `emitObjectLiteralMethodFn`'s own branch: standalone /
+ * native-first lowers the method to a host-free closure (#2194) and must not
+ * declare the unsatisfiable `env::` import.
+ */
+function objectLiteralMethodNeedsGetterBridge(ctx: CodegenContext, node: ts.Node): boolean {
+  if (!ts.isObjectLiteralExpression(node)) return false;
+  if (ctx.standalone || ctx.targetProfile.semanticProviders === "native-first") return false;
+  if (!node.properties.some((p) => ts.isSpreadAssignment(p))) return false;
+  if (!node.properties.some((p) => isPlainNamedMethodDeclaration(p))) return false;
+  return objectLiteralSpreadTakesHostPath(ctx, node);
 }
 
 /** Single-pass visitor called on every AST node */
@@ -993,6 +1029,9 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
           break;
         }
       }
+    }
+    if (!state.getterCallbackFound && objectLiteralMethodNeedsGetterBridge(ctx, node)) {
+      state.getterCallbackFound = true;
     }
   }
   // ── getterCallbackFound: Object.defineProperty / Reflect.defineProperty with accessor descriptor (#929) ──

--- a/tests/issue-4454-spread-method-getter-callback.test.ts
+++ b/tests/issue-4454-spread-method-getter-callback.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile, compileMulti } from "../src/index.js";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #4454 — `Missing __make_getter_callback import` on a spread-bearing object
+// literal that also carries a plain-named method shorthand.
+//
+// `objectLiteralSpreadTakesHostPath` (literals.ts) diverts such a literal to the
+// host plain-object path, whose MethodDeclaration arm installs the method as a
+// real runtime own property via `emitObjectLiteralMethodFn` → JS-host/GC routes
+// that through the `this`-forwarding `__make_getter_callback` bridge. The
+// single-pass import collector only pre-registered that bridge for get/set
+// accessors and computed method keys, so the emit site found no import in
+// `ctx.funcMap` and hard-CE'd (closures.ts `Missing ${makeCallbackName} import`).
+//
+// Found by the #4420 self-hosting sweep: `compileFiles("src/shape-inference.ts")`
+// pulls in `src/ts-api.ts`, which synthesizes its TS7 shim as
+// `{ ...astMod, ...isMod, factory, createProgram() {…}, createSourceFile() {…},
+// createCompilerHost() {…} }` — three methods, three CEs.
+
+describe("#4454 spread + method-shorthand object literal registers the getter-callback bridge", () => {
+  it("compiles to an engine-valid module and runs in JS-host mode", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        const src: any = { a: 40 };
+        const o: any = { ...src, m() { return this.a + 2; } };
+        return o.m();
+      }
+    `);
+    expect(exports.test()).toBe(42);
+  });
+
+  it("handles the multi-method / no-annotation shape from src/ts-api.ts", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        const astMod: any = { a: 1 };
+        const isMod: any = { b: 2 };
+        const o = {
+          ...astMod,
+          ...isMod,
+          tag: 4,
+          first() { return 10; },
+          second() { return 20; },
+          third() { return 30; },
+        };
+        return o.first() + o.second() + o.third() + o.tag;
+      }
+    `);
+    expect(exports.test()).toBe(64);
+  });
+
+  it("no longer emits the missing-import error for any spread+method shape", async () => {
+    const sources = [
+      // no contextual type
+      `const s: any = { a: 1 };\nconst o = { ...s, m() { return 1; } };\nexport function test(): number { return o.m(); }`,
+      // `any` contextual type
+      `const s: any = { a: 1 };\nconst o: any = { ...s, m() { return 1; } };\nexport function test(): number { return o.m(); }`,
+      // index-signature contextual type (the src/ts-api.ts shape)
+      `const s: Record<string, unknown> = { a: 1 };\nconst o: Record<string, unknown> = { ...s, m() { return 1; } };\nexport function test(): number { return 0; }`,
+      // string-literal method key
+      `const s: any = { a: 1 };\nconst o: any = { ...s, "m"() { return 1; } };\nexport function test(): number { return 0; }`,
+    ];
+    for (const src of sources) {
+      const r = await compile(src, {});
+      const missing = r.errors.filter((e) => e.message.includes("Missing __make_getter_callback import"));
+      expect(
+        missing.map((e) => e.message),
+        src,
+      ).toEqual([]);
+      expect(r.success, `${src}\n${r.errors.map((e) => e.message).join("\n")}`).toBe(true);
+      expect(WebAssembly.validate(r.binary), src).toBe(true);
+    }
+  });
+
+  it("standalone keeps the method host-free (no env:: bridge import leaked)", async () => {
+    const r = await compile(
+      `const s: any = { a: 1 };\nconst o: any = { ...s, m() { return 1; } };\nexport function test(): number { return 0; }`,
+      { target: "standalone" },
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const mod = await WebAssembly.compile(r.binary);
+    const bridge = WebAssembly.Module.imports(mod).filter((i) => i.name === "__make_getter_callback");
+    expect(bridge).toHaveLength(0);
+  });
+
+  it("a concretely-annotated spread target still takes the struct path (no unused import)", async () => {
+    const r = await compile(
+      `const s = { a: 1 };\nconst o: { a: number; m(): number } = { ...s, m() { return 2; } };\nexport function test(): number { return o.m(); }`,
+      {},
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const mod = await WebAssembly.compile(r.binary);
+    const bridge = WebAssembly.Module.imports(mod).filter((i) => i.name === "__make_getter_callback");
+    expect(bridge).toHaveLength(0);
+  });
+
+  // The original repro is `compileFiles("src/shape-inference.ts")` — the failing
+  // literal lives in the imported `src/ts-api.ts`, not in the entry file, so the
+  // bug only surfaces through a multi-module graph. Compiling the compiler's own
+  // graph needs far more than the 512 MB per-fork heap vitest allots, so the
+  // regression test reproduces the same cross-module shape with `compileMulti`;
+  // the real-file run is recorded in the issue's Results section.
+  it("multi-module: the failing literal in an IMPORTED module compiles", async () => {
+    const files = {
+      "./ts-api.ts": `
+        export function makeShim(): any {
+          const astMod: any = { a: 1 };
+          const isMod: any = { b: 2 };
+          return {
+            ...astMod,
+            ...isMod,
+            createProgram() { return 7; },
+            createSourceFile() { return 8; },
+            createCompilerHost() { return 9; },
+          };
+        }
+      `,
+      "./entry.ts": `
+        import { makeShim } from "./ts-api";
+        export function test(): number {
+          const shim: any = makeShim();
+          return shim.createProgram() + shim.createSourceFile() + shim.createCompilerHost();
+        }
+      `,
+    };
+    const r = await compileMulti(files, "./entry.ts");
+    const missing = r.errors.filter((e) => e.message.includes("Missing __make_getter_callback import"));
+    expect(missing.map((e) => e.message)).toEqual([]);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Issue #4454 (plan by the Fable lane, implementation by an Opus subagent) — the `Missing __make_getter_callback import` internal error from the #4420 self-hosting baseline sweep.

**Root cause** (the plan's pipeline-ordering hypothesis did not hold; corrected in the issue): the gap is shape-triggered, not pipeline-triggered. The import pre-pass (`unifiedVisitNode` in `src/codegen/declarations/import-collector.ts`) materializes `env::__make_getter_callback` for object literals with accessors or computed method keys — but not for a **plain-named method shorthand**. Normally fine (such literals lower to a struct with a compile-time method table), but a literal that also contains a **spread** and has no concrete contextual type is diverted to the host plain-object path (`objectLiteralSpreadTakesHostPath`, #2804), which installs each method as a runtime own property through the bridge. Pre-pass and emitter disagreed; the emit site (`compileArrowAsCallback`, `src/codegen/closures.ts`) found an empty `funcMap`. The trigger in the wild: the `{ ...astMod, ...isMod, createProgram() {…}, … }` literal in `src/ts-api.ts` (typed `Record<string, unknown>` — zero concrete properties), reached transitively from `src/shape-inference.ts`.

**Fix**: one extra arm in the pre-pass, gated on **the emitter's own predicate** (`objectLiteralSpreadTakesHostPath`) so pre-pass and emit site stay in lockstep — a concretely-annotated struct-path literal doesn't pull in an unused import. Dual-mode respected: gated off for standalone/native-first, mirroring the emitter's branch (standalone lowers the method to a host-free closure, #2194); verified the standalone build of the failing literal imports no `__make_getter_callback`.

## Validation

- `compileFiles("src/shape-inference.ts")`: was `success: false` with 3 × missing-import errors and 0 bytes → now `success: true`, 25,939 bytes (remaining diagnostics pre-existing and unrelated).
- `tests/issue-4454-spread-method-getter-callback.test.ts` 6/6: JS-host runtime value through the bridge (42), the real three-method `ts-api.ts` shape, four spread+method variants engine-valid, standalone host-free, concrete-annotation control, and a two-file `compileMulti` graph reproducing the cross-module original. (The real-file compile is asserted out-of-suite — the compiler's own graph OOMs a 512MB vitest fork.)
- Collateral A/B'd against the unpatched file: 18 object/getter/accessor/spread/callback suites with identical failure sets before/after (all pre-existing); 15 equivalence object/spread suites green.
- Typecheck 0, lint 0, prettier clean, `check:oracle-ratchet` +0, `check:ir-fallbacks` OK.

Issue #4454 → done in this PR (self-merge path), with the corrected root cause and the minimization table in the issue file.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhCthcoeCGK29GwmdyiqGm)_