### PR TITLE
fix(codegen): match-vec structurally excluded from closed-struct array-like arms (#4443)

### DIFF
--- a/plan/issues/4443-match-vec-proto-index-read.md
+++ b/plan/issues/4443-match-vec-proto-index-read.md
@@ -1,7 +1,8 @@
 ---
 id: 4443
 title: "__extern_get_idx answers undefined for a $__regexp_match_vec receiver in builtin-prototype-writing modules (R1 of #4439)"
-status: in-progress
+status: done
+completed: 2026-08-15
 sprint: current
 assignee: ttraenkler/claude-es5-standalone
 created: 2026-08-15
@@ -17,6 +18,23 @@ language_feature: regexp-string-methods
 goal: standalone-gap
 related: [4439, 4160, 3673, 4434]
 origin: "2026-08-15 wave 9 — #4439's R1 residual, pre-existing, with its repro and narrowing."
+# The fix's LOGIC lives in `registry/types.ts` (`isVecBaseSubtype`, a query
+# about vec types, next to `getOrRegisterVecBaseType` — not a god-file). What
+# remains in `object-runtime.ts` is 3 lines of wiring plus a 12-line note at
+# the call site recording WHY the name-based filter was wrong and what the
+# mis-minted arm cost. That note is the load-bearing part: the defect is
+# invisible without a proto-index store, so a future reader has no way to
+# rediscover it from the code. +16 lines against a 9928 baseline.
+loc-budget-allow:
+  - src/codegen/object-runtime.ts
+# Same 12-line note, counted again by the function gate: the call site is
+# inside `fillExternArrayLikeStructArms`, which was ALREADY 310 lines before
+# this change. Splitting a 310-line function is real work with a real
+# regression surface and is not something an S-horizon bug fix should do
+# opportunistically — flagged as a residual for the consolidation lane (#3399)
+# rather than half-done here. +15.
+func-budget-allow:
+  - src/codegen/object-runtime.ts::fillExternArrayLikeStructArms
 ---
 
 # #4443 — match-vec indexed read vs the builtin-prototype consult arm
@@ -29,7 +47,7 @@ Pre-existing, blocks the 3 remaining borrowed-match files
 ```js
 Number.prototype.foo = 1;                    // any builtin-prototype write
 var m = "10203040506070809000".match(/0./);
-box.v = m; box.v[0]                          // → undefined
+box.v = m; box.v[0]                          // → undefined; must be "02"
 ```
 
 while `.length`, `.index`, and `m["0"]` are all correct, and a plain array
@@ -55,3 +73,178 @@ base-vec arm in `__extern_get_idx` returning the Array-prototype consult
 
 - The repro reads "02"; ≥2 of the 3 blocked files flip; zero regressions in
   the #4439 collateral scope.
+
+## Root cause
+
+Not the vec-overlay fills and not an ordering accident — a **candidate-set**
+defect in `fillExternArrayLikeStructArms` (`src/codegen/object-runtime.ts`).
+
+That fill mints closed-struct array-like arms into `__extern_length` /
+`__extern_get_idx` / `__extern_has_idx` for every struct in
+`ctx.structFields` that carries a numeric-able `length` field, minus a
+**name-based** skip list: `Wrapper*`, `$AnyValue`, `__vec_*`, `__arr_*`,
+`__subview_*`, `$*`. Its own comment states the intent correctly — typed-array
+view carriers "carry a `length` field but are NOT generic array-likes" — but
+spells it as names.
+
+`$__regexp_match_vec` is exactly such a carrier (a `$__vec_base` subtype whose
+elements live in `data`), and its name matches none of the six patterns. So it
+was admitted as a "closed struct". It declares `length`, `index`, `input`,
+`groups`, `indices` — and **no canonical integer-named fields** — so
+`numericFields` is empty and its `__extern_get_idx` arm degenerates to:
+
+```
+local.get 2 ; ref.test $__regexp_match_vec
+if → <prototype-index consult> ; return
+```
+
+i.e. **every index is answered as a chain miss, unconditionally**.
+
+Two conditions hide this in the ordinary module and expose it in the reported
+one:
+
+- **Why only under a builtin-prototype write.** The arm is guarded by
+  `if (fieldChecks.length === 0 && protoGlobalIdx === undefined &&
+  protoGetMiss() === undefined) continue;`. With no proto-index store
+  `protoGetMiss()` is `undefined`, all three clauses hold, and the arm is
+  never minted. Any builtin-prototype write creates the store, so
+  `protoGetMiss()` is defined, the guard falls through, and the fieldless arm
+  is emitted.
+- **Why it wins over the real element read.** Both fills splice at body index
+  3, and `fillExternArrayLikeStructArms` runs *after* `fillExternGetIdxVecArms`
+  (index.ts finalize order) — so the later splice lands **ahead** of the vec
+  element arms. Control returns before reaching `vec.data[i]`. This is the
+  `[58]`-then-`[2, 4, 42]` ladder #4439 saw in the WAT.
+
+Measured candidate set for the repro module (instrumented finalize, both
+lanes): `__regexp_match_vec#126[n=0]` — the sole candidate, zero numeric
+fields. In the clean module it is the same sole candidate and no arm is minted.
+
+Consistent with every symptom in #4439's narrowing: `.length` is right (the
+array-like `__extern_length` arm reads the real `length` field, and the
+`$__vec_base` arm answers it once the candidate is dropped); `m["0"]` is right
+(string keys route through `__extern_get`, a different helper, whose overlay
+prologue is untouched); a plain array is right (`__vec_*` is name-excluded);
+and the direct `m[0]` on a statically-typed match-vec is right (it lowers to
+`array.get`, never consulting the helper at all).
+
+## Fix
+
+`isVecBaseSubtype(ctx, typeIdx)` — new, in `src/codegen/registry/types.ts`
+next to `getOrRegisterVecBaseType`, a bounded walk over
+`ctx.mod.types[].superTypeIdx` so a malformed or cyclic chain cannot hang
+finalize. `fillExternArrayLikeStructArms` keeps the existing name filter and
+adds the **structural** form of the same rule: skip any candidate whose
+supertype chain reaches `$__vec_base`.
+
+A `$__vec_base` subtype is an indexable carrier, never a closed-struct
+array-like, whatever it is called. All three helpers already serve it through
+their own arms — `__extern_length`'s #2186 base-vec arm, `__extern_get_idx`'s
+#2190/#3183 vec arms, `__extern_has_idx`'s vec generalisation — which is
+precisely what the name-based exclusions for `__vec_*`/`__subview_*` were
+already relying on.
+
+The structural rule also covers the carriers minted since the name list was
+written and never matched by it: `__template_vec_externref`, `__ta_view_<K>`,
+`__ta_dyn_view`. Those were **not** observed to misbehave here — none entered
+the candidate set in any module measured for this issue — so they are stated
+as scope the rule now closes, not as bugs fixed.
+
+## Test Results
+
+All figures below are base runs executed in this worktree via the file-copy
+A/B (`.tmp/base-object-runtime.ts` captured at the first edit), same box, same
+file lists, `--target standalone` through `tests/test262-runner.ts`.
+
+**The 3 blocked files — 3/3 flip:**
+
+| file | base | after |
+| --- | --- | --- |
+| `String/prototype/match/S15.5.4.10_A2_T17.js` | FAIL `[0]=== "02". Actual: undefined` | **PASS** |
+| `String/prototype/match/S15.5.4.10_A2_T18.js` | FAIL (same) | **PASS** |
+| `String/prototype/match/S15.5.4.10_A1_T3.js` | FAIL (same, via `bind` + `eval`) | **PASS** |
+
+**Collateral sweeps (both arms run by me, file-copy A/B):**
+
+| scope | files | base pass/fail/CE | after pass/fail/CE | delta |
+| --- | --- | --- | --- | --- |
+| `String/prototype/{match,search,matchAll}` | 119 | 78 / 29 / 12 | **85** / 22 / 12 | `gained=7 lost=0` |
+| `RegExp/prototype/{exec,test,Symbol.match}` | 177 | 117 / 54 / 6 | 117 / 54 / 6 | `gained=0 lost=0` |
+| `Array/prototype/{reduce,indexOf,includes,every}` array-like receivers | 275 | 176 / 99 / 0 | 176 / 99 / 0 | `gained=0 lost=0` |
+
+**Net across 571 files: +7 pass, 0 regressions.**
+
+The four gains beyond the three targeted files are the
+`match/cstm-matcher-on-{bigint,boolean,number,string}-primitive` family — the
+same borrowed-`match`-then-index shape. The `exec`/`test` scope is the
+collateral check for the carrier itself; the Array-prototype scope is the
+collateral check for the population `fillExternArrayLikeStructArms` exists to
+serve (a closed `{0:…, length:n}` struct is not a vec subtype, so the filter
+must not touch it — and does not).
+
+**gc/host byte-identity: sha256-IDENTICAL on all 17 corpus programs** compiled
+with no `target` (the default gc/host lane) — the 13 `website/playground/
+examples` sources plus four written for this issue that exercise a dirty
+builtin prototype with match-vec indexed reads, a closed-struct array-like, a
+typed array and a template literal. Expected: the whole fill is gated on
+`ctx.externGetIdxReserved` (standalone-only), and this is the measurement that
+confirms it.
+
+**Unit suites:** `tests/issue-4443.test.ts` (new, 12 cases) passes and **fails
+2/12 on base** — the externref-round-trip and borrowed-match cases, the two
+that actually reach `__extern_get_idx`. Also green: `issue-4439` (18),
+`es5-standalone-regexp`, `regexp`, `issue-1539-standalone-regex{,-replace}`,
+`issue-1539-standalone-array-coercion`, `issue-2161-matchall`, `issue-3169`,
+`issue-1461-standalone-{reduce,search}-arraylike`,
+`issue-3643-array-from-arraylike`, `issue-4159-4160-prescan-flags`,
+`issue-4160-{proto-index-store,filter-live-prototype-index}`,
+`issue-4434-vec-index-domain-sparse-tail` — 0 new failures.
+
+**Equivalence gate** (`node scripts/equivalence-gate.mjs`, full suite): 24
+failing / 1645 passing / 36 known-failures — **no new regressions**, exit 0.
+It also reports 12 baseline failures now passing; those arrive with the
+merged #4439 work, not with this change, and the baseline is deliberately not
+ratcheted here.
+
+**Two-stage measurement note.** The sweeps above were run against the first
+cut, which inlined the predicate in `object-runtime.ts`; it was then moved to
+`registry/types.ts` to keep the god-file growth to the wiring plus its
+call-site note. The 119-file scope and the 17-program sha corpus were **re-run
+on the moved version** and are verdict-identical to the inlined one
+(`gained=0 lost=0` diffing the two after-states, sha256 unchanged), so the
+figures describe the code that is committed.
+
+**Pre-existing failures, A/B'd identical on base, NOT mine:**
+`issue-2773-arraylike-call-thisarg` (9/9), `issue-2640-arraylike-call-
+receiver-arg` (6/9), `issue-2580-m22b-map-arraylike` (1/5),
+`issue-3673-standalone-gaps` (1/20, "single-call-site fnctor prototype method
+still loses to the string sentinel").
+
+## Residuals
+
+### R1 — `0 in m` is false for an externref-held match-vec, in BOTH lanes
+
+`var box = {}; box.v = "1020".match(/0./); 0 in box.v` answers `false` while
+`box.v[0]` answers `"02"`. Measured identical on base and after, and identical
+in the clean and dirty module, so it is neither caused nor repaired here: the
+`__extern_has_idx` vec coverage does not reach `$__regexp_match_vec`. Get and
+HasProperty therefore disagree on the same index. `tests/issue-4443.test.ts`
+pins the honest invariant (dirty === clean) rather than asserting the correct
+answer, deliberately — asserting `1` there would be asserting someone else's
+fix. Owner: the vec-overlay presence lane (`vec-overlay-presence.ts`, #4222).
+
+### R2 — `fillExternArrayLikeStructArms` is 325 lines
+
+It was 310 before this change and is now over the function budget by the size
+of the call-site note, granted as an allowance above. The function is genuinely
+too big and wants splitting (the three helper arms — `__extern_length`,
+`__extern_get_idx`, `__extern_has_idx` — are three independent loops over one
+shared candidate list, so the seam is obvious). Not done here: that is a
+refactor with its own regression surface, and doing it inside a bug fix would
+make the fix unreviewable. Owner: the consolidation lane (#3399).
+
+### R3 / R4 — inherited from #4439, untouched
+
+`s.match(null)` treated as an absent argument, and `@@match`/`@@search`
+protocol objects `ToString`'d rather than dispatched. Both are in #4439's
+issue file with owners; neither is in this issue's surface.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -80,6 +80,7 @@ import {
   getOrRegisterBoundFnType,
   getOrRegisterVecBaseType,
   getOrRegisterVecType,
+  isVecBaseSubtype,
 } from "./registry/types.js";
 import { buildClosureRefTestArms } from "./closure-classifier.js"; // (#3140) __bind_dyn callable gate
 import { builtinCtorCallableArmInstrs } from "./builtin-ctor-callable.js"; // (#4394) wrapper-ctor [[Call]] arm
@@ -9176,6 +9177,19 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
   // their element reads go through the dedicated typed-array paths, and
   // widening their `.length` here would change established fall-through
   // behaviour).
+  //
+  // (#4443) The name list states the right rule the wrong way; `isVecBase-
+  // Subtype` (registry/types.ts) is its structural form — see there for the
+  // carriers the names miss. What one costs when it slips through: it declares
+  // `length` but no integer-named FIELDS, so `numericFields` is empty and its
+  // `__extern_get_idx` arm degenerates to "`ref.test` the carrier → answer the
+  // prototype-index consult, unconditionally". The arm is skipped while
+  // `protoGetMiss()` is undefined, so an ordinary module never shows it; ANY
+  // builtin-prototype write mints it, and since these arms splice at body
+  // index 3 AFTER `fillExternGetIdxVecArms` put the real element arms there,
+  // it lands AHEAD of the `vec.data[i]` read. Measured on
+  // `$__regexp_match_vec`: `Number.prototype.foo = 1; "1020".match(/0./)[0]`
+  // read `undefined` while `.length` / `.index` / `m["0"]` stayed correct.
   type ArrayLikeCand = {
     typeIdx: number;
     lengthFieldIdx: number;
@@ -9197,6 +9211,8 @@ export function fillExternArrayLikeStructArms(ctx: CodegenContext): void {
       structName.startsWith("$")
     )
       continue;
+    // (#4443) …and the structural form of that same rule — see the note above.
+    if (isVecBaseSubtype(ctx, typeIdx)) continue;
     const lengthFieldIdx = fields.findIndex(
       (f) =>
         f.name === "length" &&

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -139,6 +139,38 @@ export function getOrRegisterVecBaseType(ctx: CodegenContext): number {
 }
 
 /**
+ * (#4443) Is `typeIdx` an INDEXABLE CARRIER — `$__vec_base` itself or any
+ * (transitive) subtype of it?
+ *
+ * Every concrete vec, subview, TypedArray view and the regexp match-result
+ * struct subtypes `$__vec_base`, so this is the one reliable way to ask "does
+ * this struct's element data live in a `data`/`buf` array, read by the
+ * dedicated vec / typed-array arms?". Callers that answer that question by
+ * NAME instead go stale the moment a new carrier is minted: the array-like
+ * fill in `object-runtime.ts` listed `__vec_*` / `__arr_*` / `__subview_*` and
+ * so silently admitted `__regexp_match_vec`, `__template_vec_externref`,
+ * `__ta_view_<K>` and `__ta_dyn_view` as ordinary closed structs (#4443).
+ *
+ * The walk is bounded by the type-table size so a malformed or cyclic
+ * supertype chain cannot hang finalize. Returns false when no `$__vec_base`
+ * has been registered — a module with no vecs has no carriers either.
+ */
+export function isVecBaseSubtype(ctx: CodegenContext, typeIdx: number): boolean {
+  const vecBaseTypeIdx = ctx.vecBaseTypeIdx;
+  if (vecBaseTypeIdx < 0) return false;
+  if (typeIdx === vecBaseTypeIdx) return true;
+  for (let cur = typeIdx, hops = 0; hops < ctx.mod.types.length; hops++) {
+    const def = ctx.mod.types[cur];
+    if (!def || def.kind !== "struct") return false;
+    const sup = def.superTypeIdx;
+    if (sup === undefined || sup < 0) return false;
+    if (sup === vecBaseTypeIdx) return true;
+    cur = sup;
+  }
+  return false;
+}
+
+/**
  * (#4034) Run `fn` with `usesVecValue` pinned to its current value, so vec
  * types registered by COMPILER-INTERNAL emission (runtime preludes, reflective
  * accessors, type-index-stability stubs) do not read as user array usage.

--- a/tests/issue-4443.test.ts
+++ b/tests/issue-4443.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4443 — `__extern_get_idx` answered `undefined` for a `$__regexp_match_vec`
+ * receiver in any `--target standalone` module that writes a builtin prototype.
+ *
+ * `fillExternArrayLikeStructArms` (object-runtime.ts) mints closed-struct
+ * array-like arms for every struct in `ctx.structFields` carrying a
+ * numeric-able `length`, minus a NAME-based skip list (`__vec_*`, `__arr_*`,
+ * `__subview_*`, `$*`, `Wrapper*`). `$__regexp_match_vec` is an indexable vec
+ * carrier — a `$__vec_base` subtype whose elements live in `data` — but its
+ * name matches none of those, so it was admitted as a "closed struct". It
+ * declares no canonical integer-named FIELDS, so its `__extern_get_idx` arm
+ * degenerated to "`ref.test` the match-vec → answer the prototype-index
+ * consult, unconditionally".
+ *
+ * That arm is only minted when the module HAS a proto-index store, i.e. when
+ * something writes a builtin prototype — otherwise `protoGetMiss()` is
+ * undefined and the guard skips it. And because these arms splice at body
+ * index 3 AFTER `fillExternGetIdxVecArms` put the real element arms there, the
+ * bogus arm landed AHEAD of them: control never reached the `vec.data[i]`
+ * read.
+ *
+ * Hence the signature: with ANY builtin-prototype write in the module,
+ * `"…".match(re)[0]` was `undefined` while `.length`, `.index` and the
+ * STRING-key `m["0"]` were all correct (that key routes through
+ * `__extern_get`, a different helper), and a plain array receiver in the same
+ * dirty module read fine. Remove the prototype write and the same read is
+ * correct — which is what makes the two-module A/B in every case below the
+ * actual assertion.
+ *
+ * Fix: filter STRUCTURALLY on the supertype chain — a `$__vec_base` subtype is
+ * never a closed-struct array-like, whatever it is called. Its three helpers
+ * are already served by their own arms (`__extern_length`'s #2186 base-vec
+ * arm, `__extern_get_idx`'s #2190/#3183 vec arms, `__extern_has_idx`'s vec
+ * generalisation), which is exactly what the name-based exclusions relied on.
+ *
+ * Harness notes (inherited from `issue-4439.test.ts`, same reasons):
+ *  - compile as JAVASCRIPT (`allowJs` + a `.js` fileName) — test262's lane;
+ *  - compare INSIDE wasm and return an i32. A standalone string is a
+ *    `$__nstr` struct; returning it to the host reads as `null` regardless of
+ *    correctness, so a host-side `expect(result).toBe("02")` would pass on the
+ *    broken compiler too.
+ *  - ONE builtin-prototype define per module (#4434's numeric-companion
+ *    confound): a second define can move the companion table and mask which
+ *    arm answered.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string, fn = "f"): Promise<unknown> {
+  const r = await compile(src, {
+    target: "standalone",
+    allowJs: true,
+    fileName: "issue-4443.js",
+    skipSemanticDiagnostics: true,
+  });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const mod = await WebAssembly.compile(r.binary as BufferSource);
+  expect(WebAssembly.Module.imports(mod)).toEqual([]);
+  const { exports } = await WebAssembly.instantiate(mod, {});
+  return (exports as Record<string, () => unknown>)[fn]!();
+}
+
+/** The `Number.prototype.match = String.prototype.match` shape of A2_T17/T18. */
+const DIRTY = `Number.prototype.foo = 1;\n`;
+
+/**
+ * Run `body` twice — once in a module that writes a builtin prototype and once
+ * in an otherwise identical clean module — and require the SAME answer. The
+ * clean run is the control: it is what the dirty run regressed away from, and
+ * it keeps a future "fix" that breaks both lanes equally from passing.
+ */
+async function bothLanes(body: string): Promise<{ dirty: unknown; clean: unknown }> {
+  const wrap = (prefix: string) => `${prefix}export function f() {\n${body}\n}`;
+  return {
+    dirty: await runStandalone(wrap(DIRTY)),
+    clean: await runStandalone(wrap("")),
+  };
+}
+
+describe("#4443 — indexed read of a match-vec under a dirty builtin prototype", () => {
+  // Of the six below, exactly TWO fail on base (measured: revert
+  // `object-runtime.ts`, 2 failed / 10 passed) — "through an externref
+  // round-trip" and "a borrowed match, the A2_T17 shape". Those are the two
+  // that actually reach `__extern_get_idx`. The other four keep the match-vec
+  // in its STATIC type, so the element read lowers to a direct `array.get`
+  // that never consults the helper's arm ladder. They are non-regression pins,
+  // not reproductions, and are listed together deliberately: the defect's
+  // whole signature is that the same source reads correctly or not depending
+  // on whether the receiver survives as a typed vec, so the passing four are
+  // what make the failing two legible.
+  it.each([
+    [
+      "m[0] with a constant index",
+      `var m = "10203040506070809000".match(/0./);
+       return m[0] === "02" ? 1 : (m[0] === undefined ? -1 : 0);`,
+    ],
+    [
+      "m[i] with a variable index",
+      `var m = "10203040506070809000".match(/0./);
+       var i = 0;
+       return m[i] === "02" ? 1 : (m[i] === undefined ? -1 : 0);`,
+    ],
+    [
+      "through an externref round-trip (the any-typed lane)",
+      `var m = "10203040506070809000".match(/0./);
+       var box = {}; box.v = m; var w = box.v;
+       return w[0] === "02" ? 1 : (w[0] === undefined ? -1 : 0);`,
+    ],
+    [
+      "a capture group at index 1",
+      `var m = "abc".match(/a(b)c/);
+       return m[1] === "b" ? 1 : (m[1] === undefined ? -1 : 0);`,
+    ],
+    [
+      "exec() result, same carrier",
+      `var m = /0./.exec("10203040506070809000");
+       return m[0] === "02" ? 1 : (m[0] === undefined ? -1 : 0);`,
+    ],
+    [
+      "a borrowed match, the A2_T17 shape",
+      `Number.prototype.match = String.prototype.match;
+       var m = (10203040506070809000).match(/0./);
+       return m[0] === "02" ? 1 : (m[0] === undefined ? -1 : 0);`,
+    ],
+  ])("%s reads the element, not the prototype consult", async (_label, body) => {
+    const { dirty, clean } = await bothLanes(body);
+    expect(clean).toBe(1);
+    expect(dirty).toBe(1);
+  });
+
+  it.each([
+    // These three were already correct on the broken compiler — they are the
+    // narrowing that located the defect, so they are pinned as non-regressions.
+    ["length", `var m = "10203040506070809000".match(/0./); return m.length;`, 1],
+    ["index", `var m = "10203040506070809000".match(/0./); return m.index;`, 1],
+    [
+      "string-key element read",
+      `var m = "10203040506070809000".match(/0./);
+       return m["0"] === "02" ? 1 : (m["0"] === undefined ? -1 : 0);`,
+      1,
+    ],
+  ])("keeps %s correct", async (_label, body, want) => {
+    const { dirty, clean } = await bothLanes(body);
+    expect(clean).toBe(want);
+    expect(dirty).toBe(want);
+  });
+
+  it("does not let the dirty lane diverge from the clean one on `0 in m`", async () => {
+    // The same fill mints an `__extern_has_idx` arm from the same candidate
+    // list, so the bogus arm could have made `0 in m` diverge between lanes.
+    //
+    // It does not, and the honest pin is EQUALITY, not 1: `0 in m` on an
+    // externref-held match-vec answers **0 in BOTH lanes, before and after
+    // this fix** (measured on base 2026-08-15 — see residual R1 in the issue
+    // file). That is a separate pre-existing gap in the `__extern_has_idx` vec
+    // coverage for `$__regexp_match_vec`, not something #4443 caused or
+    // repairs, and asserting 1 here would be asserting someone else's fix.
+    const body = `var m = "10203040506070809000".match(/0./);
+       var box = {}; box.v = m; var w = box.v;
+       return (0 in w) ? 1 : 0;`;
+    const { dirty, clean } = await bothLanes(body);
+    expect(dirty).toBe(clean);
+  });
+
+  it("leaves a genuine closed-struct array-like on its own arm", async () => {
+    // The population `fillExternArrayLikeStructArms` exists for. `{0:…,
+    // length:…}` is NOT a vec carrier, so the structural filter must not touch
+    // it — including under a dirty prototype, where its arm IS minted.
+    const body = `var obj = { 0: 11, 1: 12, length: 2 };
+       var s = Array.prototype.reduce.call(obj, function (a, b) { return a + b; }, 0);
+       return s * 10 + Array.prototype.indexOf.call(obj, 12);`;
+    const { dirty, clean } = await bothLanes(body);
+    // reduce → 23, indexOf(12) → 1.
+    expect(clean).toBe(231);
+    expect(dirty).toBe(231);
+  });
+
+  it("leaves a plain array receiver unaffected in a dirty module", async () => {
+    const body = `var a = ["a", "b"];
+       var box = {}; box.v = a; var w = box.v;
+       return w[1] === "b" ? 1 : (w[1] === undefined ? -1 : 0);`;
+    const { dirty, clean } = await bothLanes(body);
+    expect(clean).toBe(1);
+    expect(dirty).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

Wave 9b of the #4426 ES5-standalone campaign — #4439's R1 residual. Root cause was not arm ordering but the candidate set: `fillExternArrayLikeStructArms` admits any struct with a numeric-able `length` as a closed-struct array-like, excluded only by a **name**-based skip list, so `$__regexp_match_vec` was admitted with zero numeric fields. The degenerate arm (`ref.test → proto-index consult; return`) only materializes when a builtin-prototype write creates the proto-index store, and its splice lands ahead of the real element arms — explaining every asymmetry in the original narrowing (`.length`/`m["0"]`/static `m[0]` all correct, only the dynamic indexed read wrong).

Fix: new structural predicate `isVecBaseSubtype` (registry/types.ts) — a `$__vec_base` subtype is never a closed-struct array-like; the name filter stays, and the same rule covers carriers the names never matched (template vec, TA views), stated as scope rather than measured bugs.

Measured (file-copy A/B, base runs executed by the agent): repro `undefined` → `"02"`; the 3 blocked borrowed-match files 0/3 → **3/3**; `String/prototype/{match,search,matchAll}` 78 → **85** of 119; exec/test/array-like controls (452 files) zero moved — **net +7, 0 regressions over 571 files**; gc/host sha256-identical on all 17 corpus programs; equivalence gate clean; 12-test pin (2/12 fail on base). Verified post-merge here: 30/30 with the #4439 pins. Residuals with owners in the issue file (notably `0 in m` presence disagreement, both lanes, pre-existing — vec-overlay presence lane #4222).

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate is skipped automatically. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdMAVayXGLs5Syf9GaQzT7)_