### PR TITLE
ci(#3914): merge-queue floor 2 measured a no-op — revert canonical floor to 1, correct the batching model

### DIFF
--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -186,9 +186,9 @@ Two test262 workflows currently run on PRs:
     #1081 runs/<merge-base> cache, then latest-main baseline — i.e. exactly
     the pre-#1956 behavior.
   - **Canonical queue configuration: `max_entries_to_build: 1` (no
-    speculation), `max_entries_to_merge: 5` (BATCH UP TO 5 PRs PER GROUP),
-    `min_entries_to_merge: 2` with a 5-minute wait timer (#3914 Step 2, live
-    since 2026-08-14 — see the floor note below).** These live in the repo
+    speculation), `max_entries_to_merge: 5`, `min_entries_to_merge: 1`
+    (#3914 Step 2 was tried at floor 2 on 2026-08-14 and measured a NO-OP on
+    2026-08-15 — reverted; see the floor note below).** These live in the repo
     ruleset, not in any workflow file, so they are applied and read back with
     **`scripts/set-merge-queue-config.sh`** (`--show` to read, `--check` to
     diff, no flag to apply; needs repo-admin `gh`). Before that script existed
@@ -196,15 +196,18 @@ Two test262 workflows currently run on PRs:
     six weeks stale — it still said `max_entries_to_build: 5` long after the
     2026-06-20 wedge reverted it. Treat the script's `--show` output as
     authoritative and this paragraph as the intent.
-  - **The two knobs are not the same thing, and only one of them is safe.**
-    - `max_entries_to_merge` (**the batch cap, 5**) puts up to five queued PRs
-      into **one** merge group validated by **one** shard-matrix run. Runner
-      pressure is unchanged and the fixed ~170 s per-run overhead is divided
-      across the batch. It costs the batched PRs no latency: the queue is
-      serial, so they were already waiting for that run. Measured 2026-07-31:
-      the median PR waited 23.6 min for a 13.3 min run and 13 of 20 groups had
-      another PR already waiting when they were dispatched — all of which still
-      went out as size-1 groups.
+  - **The two knobs are not the same thing — and NEITHER of them batches CI
+    runs.** (Corrected 2026-08-15; the previous version of this bullet claimed
+    the cap gives "one run for N PRs", which is not what GitHub's product does.)
+    - `max_entries_to_merge` / `min_entries_to_merge` (**merge limits**) only
+      group the final fast-forward to `main` of queue entries that have EACH
+      already passed **their own** `merge_group` run. GitHub's docs describe
+      them as "the number of pull requests to merge into the base branch at the
+      same time", and merge limits explicitly do **not** combine `merge_group`
+      builds (GitHub community discussion #58523). Every queued PR always gets
+      its own temporary branch and its own full shard-matrix run — the native
+      merge queue has **no fewer-runs-than-PRs mode**. The fixed per-run
+      overhead can never be amortised across PRs with these knobs.
     - `max_entries_to_build` (**speculation depth, 1**) builds up to N
       _separate_ groups concurrently, each with its own full run. It is capped
       at a ~1.25× theoretical win, it puts 5 × ~102 shard jobs on a
@@ -235,22 +238,30 @@ Two test262 workflows currently run on PRs:
     optimistic-batch/split-on-failure: re-enqueue the members singly to
     attribute. Cost is one wasted run, which is the `e`-weighted term in
     #3914's sizing.
-  - **`min_entries_to_merge` is now 2 — #3914 Step 2 fired.** Its precondition
-    was "raise the floor only if groups are observed to stay size-1 at cap 5,
-    i.e. only if GitHub's formation is eager-with-minimum rather than
-    `min(available, cap)`". Measured 2026-08-14 and met: **all 30 merge groups
-    dispatched that day went out at size 1**, reconstructed by walking each
-    group's `base_sha` forward on `main` and counting the merge commits it
-    produced. That included a ~2h window (15:41–17:40Z) in which 2-3 green PRs
-    sat queued behind a head that could not go green, and they still merged one
-    at a time afterwards. Cap 5 alone never batches; the floor is what forms
-    groups.
-    The cost is unchanged and was always the point of the trigger: raising the
-    cap is free, raising the floor is not — a genuinely solo PR pays the wait
-    timer as pure added latency (~1/3 of measured dispatches had no peer
-    waiting). The live timer is **5 minutes**, not the 2 minutes this section
-    originally prescribed; that is the knob to revisit first if solo-PR latency
-    is felt, since it bounds the added wait directly.
+  - **`min_entries_to_merge` is back to 1 — #3914 Step 2 was tried and
+    measured a NO-OP.** The floor was raised to 2 (5-min timer) on
+    2026-08-14T18:16Z on the "the floor is what forms groups" hypothesis.
+    Measured across all of 2026-08-15 up to 13:34Z: **29/29 successful merge
+    groups still carried exactly one PR**, one full run each, merging ~15 min
+    apart — including a window where entries for #4557/#4558/#4559 were
+    stacked in the queue simultaneously (their queue merge commits are all
+    dated 12:39–12:44Z) and still consumed three full runs. The floor cannot
+    bind on this queue, for two structural reasons:
+    1. the wait timer counts from queue entry and, per GitHub's docs, the
+       queue then "stop[s] waiting for more entries and merge[s] with fewer
+       than the minimum" — under load the head's queue wait (≥ one ~15-min
+       run) always exceeds the timer, so the floor is waived at every merge
+       decision;
+    2. merging ≥2 entries together requires ≥2 entries green simultaneously,
+       which `max_entries_to_build: 1` makes impossible — the next entry's
+       run is only dispatched **after** the head merges (observed +2 s).
+    Its only observable effect is added latency on quiet-queue fast merges
+    (docs-only runs go green in ~2-3 min, inside the timer). Conclusion for
+    future readers: **no ruleset setting batches N PRs into one CI run** —
+    that mode does not exist in GitHub's native merge queue. Genuine per-run
+    amortisation requires a queue product that builds batches (e.g.
+    Mergify-style) or a bot-maintained train PR — a project-lead decision,
+    not a ruleset flip.
   - **Intra-group masking is narrower than this doc used to claim.** It applies
     only to the test262 _delta_ gate, not to `quality` / `cheap gate` /
     `equivalence-*` (pass/fail), nor to the catastrophic guard (#1668) or the

--- a/plan/issues/3914-ci-throughput-merge-queue-batching.md
+++ b/plan/issues/3914-ci-throughput-merge-queue-batching.md
@@ -485,15 +485,65 @@ that converts directly into queue throughput.
       the speculation guard and `tests/issue-3914-merge-queue-config.test.ts`.
       `docs/ci-policy.md` §3 records the canonical values, why the two knobs
       differ, and why a tail append never ejects a running group.
-- [ ] **Follow-up (needs an admin-scoped `gh` — the only remaining step):**
-      run `./scripts/set-merge-queue-config.sh` (cap 5, floor 1, build 1) and
-      observe one backed-up window. Only if groups stay size-1, Step 2:
-      `MIN_ENTRIES_TO_MERGE=2` with a 2-minute wait timer. Rollback is
-      `MAX_ENTRIES_TO_MERGE=1 ./scripts/set-merge-queue-config.sh`; no code
-      revert, since every code change here is a no-op at batch size 1.
+- [x] **Follow-up — DONE, with a negative result (see "Step 1+2 result"
+      below):** Step 1 (cap 5) applied, groups stayed size 1; Step 2 (floor 2,
+      5-min timer) applied 2026-08-14T18:16Z, groups **still** stayed size 1
+      (29/29 on 2026-08-15). Root cause: GitHub merge limits do not combine
+      `merge_group` builds at all — the premise of Part 2 was wrong.
+- [ ] **Revert the floor to 1** (`MIN_ENTRIES_TO_MERGE=1
+      ./scripts/set-merge-queue-config.sh`, needs repo-admin `gh`/PAT — the
+      script's default is 1 again, so a bare run applies it). The floor-2
+      config batches nothing and taxes quiet-queue docs-only merges with up
+      to ~3 min of wait-timer latency.
 - [ ] **Verify after merge:** on the first post-merge `merge_group` run, confirm
       (a) max shard start < 60 s, (b) both lanes' max job within ~1 min,
       (c) `changes` job < 20 s, (d) total run wall ≈ 11 min.
+
+## Step 1+2 result (2026-08-15) — the floor is a no-op; Part 2's premise was wrong
+
+Step 2 went live 2026-08-14T18:16Z (ruleset 16700772: `min_entries_to_merge: 2`,
+`min_entries_to_merge_wait_minutes: 5`, cap 5, build 1, HEADGREEN). Measured the
+next day, 03:23–13:34Z: **29/29 successful `merge_group` runs carried exactly
+one PR** (counted as merge commits in each queue ref's `base..head`), one full
+shard-matrix run each, PRs merging one at a time ~15 min apart. Decisive
+counterexample: entries for #4557/#4558/#4559 were all stacked in the queue by
+12:44Z (their queue merge commits are dated 12:39:40/12:44:21/12:44:42Z) and
+still consumed three separate full runs, merging at 13:18/13:34/13:49Z.
+
+Why, in two layers:
+
+1. **The wait timer can never survive a busy queue.** It counts from queue
+   entry, and GitHub's documented behavior is that after it elapses the queue
+   "stop[s] waiting for more entries and merge[s] with fewer than the minimum".
+   The head's queue wait under load is ≥ one ~15-min run, so a 5-min timer is
+   always expired by merge-decision time and the floor is permanently waived.
+2. **The deeper one: GitHub merge limits do not combine `merge_group` builds —
+   period.** Every queued PR always gets its own temporary branch and its own
+   full CI run; `min`/`max_entries_to_merge` only group the final fast-forward
+   of entries that have each already passed their own run (GitHub community
+   discussion #58523 confirms; today's runs demonstrate). "N PRs validated by
+   one 102-job run" — the whole Part 2 design goal — **does not exist as a mode
+   of GitHub's native merge queue.** Even with a timer long enough to bind, a
+   ≥2 merge needs ≥2 simultaneously-green entries, which `max_entries_to_build:
+   1` precludes: the next entry's run is dispatched ~2 s *after* the head
+   merges (observed on every pair today).
+
+Consequences:
+
+- Floor reverted to 1 (it batches nothing and adds up to timer-minutes of
+  latency to quiet-queue docs-only merges, which go green inside the timer).
+  Cap 5 / build 1 unchanged. `docs/ci-policy.md` §3 and
+  `set-merge-queue-config.sh` corrected — the script's refusal message itself
+  repeated the "one group, one run" claim.
+- The P1/P2/P3 multi-member-group hardening stays: multi-PR groups can still
+  occur as merged *prefixes* (e.g. if speculation were ever re-enabled) and the
+  fixes are no-ops at size 1.
+- Real per-run amortisation, if ever wanted, means leaving the native queue:
+  a batch-building queue product (Mergify-style) or a bot-maintained train PR
+  (combine N green PRs into one PR, enqueue that). Both are project-lead
+  decisions with their own failure modes; neither is a ruleset flip. The
+  cheaper lever that remains inside this repo is cutting per-run cost (Part 3
+  landed −17 %; L3/L4 in `plan/ci-acceleration-review.md` remain the big one).
 
 ## Notes / non-goals
 

--- a/scripts/set-merge-queue-config.sh
+++ b/scripts/set-merge-queue-config.sh
@@ -44,35 +44,40 @@ RULESET_ID="${RULESET_ID:-16700772}"
 # CANONICAL VALUES — keep in sync with `docs/ci-policy.md` §3 and #3914.
 # -----------------------------------------------------------------------------
 #
-# MAX_ENTRIES_TO_MERGE — the BATCH CAP: how many queued PRs a single merge
-#   group may swallow, validated by ONE shard-matrix run. This is the knob that
-#   actually buys throughput here. Because the queue is serial, PRs pile up
-#   while a group is in flight *for free*, so batching them costs those PRs no
-#   latency — they were waiting for that run either way.
+# MAX_ENTRIES_TO_MERGE — the merge-grouping cap: how many consecutive GREEN
+#   queue entries GitHub may fast-forward into `main` in one operation.
 #
-#   5 is the project-lead's chosen cap. #3914's expected-runtime-per-merged-PR
-#   model puts the optimum at 4–5 for the observed merge_group failure rate
-#   (e ≈ 0.05–0.10): at e=0.05 N=5 is the best value in the table (0.426W vs
-#   0.435W for N=4); at e=0.10 N=4 edges it (0.594W vs 0.610W). The two are
-#   within noise of each other and both are ~1.85× better than serial. What
-#   matters is that the curve is a BOWL that turns back up — by N=12 you are
-#   back near the N=2 result — so this is a cap to hold, not a floor to raise.
+#   ⚠ #3914's original premise for this knob — "one group, one run, N PRs" —
+#   is NOT what GitHub's product does. Merge limits do NOT combine
+#   `merge_group` builds: every queued PR always gets its own temporary
+#   branch and its own full CI run, and min/max_entries_to_merge only group
+#   the final fast-forward of entries that have EACH already passed their own
+#   run (GitHub community discussion #58523; measured here 2026-08-15, see
+#   "Step 1+2 result" in the issue file). Native GitHub merge queue has no
+#   fewer-runs-than-PRs mode. The cap is therefore harmless but buys no CI
+#   throughput; 5 is kept because a bigger mergeable prefix is free on the
+#   rare occasion it can form.
 MAX_ENTRIES_TO_MERGE="${MAX_ENTRIES_TO_MERGE:-5}"
 #
-# MIN_ENTRIES_TO_MERGE — the quorum FLOOR. Now 2: #3914 Step 2 is LIVE.
-#   Step 2's precondition was "raise to 2 ONLY if Step 1 (cap 5) leaves groups
-#   at size 1", i.e. only if GitHub's formation is eager-with-minimum rather
-#   than min(available, cap). That precondition was measured and met on
-#   2026-08-14: all 30 merge groups dispatched that day went out at size 1
-#   under cap 5, including during a ~2h window where 2-3 green PRs sat queued
-#   behind a wedged head. Formation is eager; the cap alone never batches.
-#   The cost is unchanged and real — a genuinely solo PR pays the wait timer as
-#   pure added latency (~1/3 of dispatches on the measured day had no peer
-#   waiting), which is why the floor is the knob that needs a trigger and the
-#   cap does not.
+# MIN_ENTRIES_TO_MERGE — the quorum FLOOR. Back to 1: #3914 Step 2 was tried
+#   (floor 2, 5-min timer, live 2026-08-14T18:16Z) and MEASURED A NO-OP on
+#   2026-08-15: 29/29 successful merge groups still carried exactly one PR,
+#   including a window where entries for three PRs (#4557/#4558/#4559) sat
+#   stacked in the queue simultaneously and still consumed three full runs,
+#   merging one at a time ~15 min apart. Two reasons, both structural:
+#   1. The wait timer counts from queue entry, and GitHub "merges with fewer
+#      than the minimum" once it expires. Under load the head's queue wait
+#      (>= one ~15-min run) always exceeds any sane timer, so the floor is
+#      permanently waived by the time a merge decision is made.
+#   2. Even if it bound, merging >=2 entries together needs >=2 entries green
+#      at once, which max_entries_to_build=1 makes impossible — the next
+#      entry's run is only dispatched after the head merges (observed: +2 s).
+#   So a floor > 1 can never batch on this queue; its only observable effect
+#   is up to timer-minutes of added latency on quiet-queue fast merges
+#   (docs-only runs go green in ~2-3 min, inside the timer). Keep 1.
 #   This default MUST track the live ruleset. Apply is this script's DEFAULT
-#   mode, so a stale 1 here silently reverts the floor on the next bare run.
-MIN_ENTRIES_TO_MERGE="${MIN_ENTRIES_TO_MERGE:-2}"
+#   mode, so a stale value here silently rewrites the floor on the next bare run.
+MIN_ENTRIES_TO_MERGE="${MIN_ENTRIES_TO_MERGE:-1}"
 #
 # MAX_ENTRIES_TO_BUILD — SPECULATION DEPTH. Stays 1. This is NOT the batching
 #   knob and raising it is the thing that must not happen a third time.
@@ -131,8 +136,10 @@ shard jobs on a ~120-runner pool, which starves the one group that can merge
 in order to precompute results that are usually discarded. It is also the only
 setting that makes queue changes EJECT other PRs' in-flight runs.
 
-Want more PRs per run? Raise MAX_ENTRIES_TO_MERGE (the batch cap) instead —
-one group, one run, N PRs, no extra runner pressure.
+Note there is NO ruleset setting that batches N PRs into one CI run:
+MAX_ENTRIES_TO_MERGE / MIN_ENTRIES_TO_MERGE only group the final fast-forward
+of entries that each already passed their own run (measured 2026-08-15; GitHub
+community discussion #58523). Every queued PR always costs one full run.
 
 Full post-mortem + arithmetic: plan/issues/3914-ci-throughput-merge-queue-batching.md
 Prerequisite if you really mean it: shrink the merge_group shard matrix first


### PR DESCRIPTION
## Description

Answers "is merge-queue batching working?" — **no**, and it cannot work via the ruleset.

**Measured (2026-08-15, 03:23–13:34Z, all under the floor-2 config live since 2026-08-14T18:16Z):** 29/29 successful `merge_group` runs carried exactly one PR (merge commits counted in each queue ref's `base..head`), one full shard-matrix run each, merging one PR every ~15 min. Decisive counterexample: entries for #4557/#4558/#4559 were stacked in the queue simultaneously by 12:44Z (queue merge commits dated 12:39:40/12:44:21/12:44:42Z) and still consumed three separate full runs.

**Why the floor can never batch here:**
1. The wait timer counts from queue entry, and GitHub then "stop[s] waiting for more entries and merge[s] with fewer than the minimum" — under load the head's queue wait (≥ one ~15-min run) always exceeds the 5-min timer, so the floor is waived at every merge decision.
2. GitHub merge limits do not combine `merge_group` builds at all: every queued PR always gets its own branch and its own full CI run; `min`/`max_entries_to_merge` only group the final fast-forward of entries that each already passed their own run (GitHub community discussion #58523). "N PRs, one run" is not a mode of the native merge queue.
3. Even if the timer bound, a ≥2 merge needs ≥2 simultaneously-green entries, which `max_entries_to_build: 1` precludes — the next entry's run is dispatched ~2 s *after* the head merges (observed on every consecutive pair today).

**Changes:**
- `scripts/set-merge-queue-config.sh`: canonical floor back to 1; rationale comments and the refusal message rewritten (both repeated the falsified "one group, one run, N PRs" model). Re-aligns `tests/issue-3914-merge-queue-config.test.ts`, which still pins floor 1 and was left inconsistent with the script by the 2026-08-14 default flip (verified: 7/7 pass).
- `docs/ci-policy.md` §3: canonical config corrected; knob semantics rewritten with the measurement.
- `plan/issues/3914-…`: "Step 1+2 result" section with the evidence; remaining admin step recorded.

**Remaining operational step (repo admin):** apply the revert to ruleset 16700772 — `./scripts/set-merge-queue-config.sh` (bare run now applies floor 1; verified `--check` shows exactly the one-line `min_entries_to_merge: 2 → 1` diff). This session's token was not permitted to write the ruleset.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsvJB3Wwr8KZ5WvVECgjvi

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsvJB3Wwr8KZ5WvVECgjvi)_