### PR TITLE
ES6 standalone close-out wave 1: #4445 annexB HTML wrappers, #4446 native concat fallback, #4447 for-of destructuring (+ #4444 umbrella, #4449/#4450 triage issues)

### DIFF
--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -64,7 +64,8 @@ generator row).
 ## Session results (2026-08-15, wave 1)
 
 - **#4445 landed** (`5b715e1`): annexB String filter 17→95/111 standalone, 13
-  HTML dirs 4/82→82/82, gc byte-identical. Free follow-up found:
+  HTML dirs 4/82→82/82, gc unchanged (108/111 before/after, official wrapper —
+  an earlier 92/111 figure was a fast-driver artifact). Free follow-up found:
   `trimLeft`/`trimRight` miss the same `STRING_PROTO_METHODS` CSV (6 tests;
   `reference-*` also needs alias identity `trimLeft === trimStart`).
 - **#4447 slice 1 landed** (`8dcbc88`): standalone for-of/dstr 342→400/569,

--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -41,9 +41,9 @@ generator row).
 | 3 | **Built-in method reflection** — `length.js`/`name.js`/`prop-desc.js`/`not-a-constructor.js`/`invoked-as-func.js` across every built-in: methods are not reified function objects (`Object.getOwnPropertyDescriptor` → "Cannot convert undefined or null to object", `typeof m === "undefined"`) | ~324 | #2175 (ready, arch spec written), #2158, #2159; sibling lane PR #4553 (method name/length meta) is in flight | tracked — architectural |
 | 4 | **TypedArray.prototype semantics** — species-constructor protocol (`speciesctor-*`, 55), custom-ctor paths, detached-buffer TypeErrors (~41), coercion/validation order. Excludes row-3 reflection files | ~556 | **#4449** (filed this session, triage-first; reflection part stays #2159) | tracked |
 | 5 | **RegExp `@@replace`/`@@match`/`@@split`/`@@search`** — function replacer refusal (CE, "#1913 follow-up"), coercion order, `lastIndex` protocol | ~161 | #2161 (blocked on #2175), F7 dynamic-receiver arch spec pending | tracked/blocked |
-| 6 | **for-of destructuring residual** — iterator close/return/throw propagation, trailing-iterator state (`trlg-iter`, 23), nested patterns, fn-name inference, TDZ | ~200 (non-generator) | **#4447 (this session)** | dispatched |
+| 6 | **for-of destructuring residual** — iterator close/return/throw propagation, trailing-iterator state (`trlg-iter`, 23), nested patterns, fn-name inference, TDZ | ~200 (non-generator) | **#4447 — slice 1 LANDED** (standalone dstr 342→400/569, gc +51, assignment/dstr +6, 0 lost; binding form + eval-order deferred, see issue) | landed |
 | 7 | **Class semantics residual** — `class/dstr` method-param destructuring dominates (112, shares #4447's machinery), subclass (46), definition (36), NamedEvaluation `NaN vs undefined` | ~321 (non-generator) | **#4450** (filed this session; re-measure after #4447 lands; overlaps #2158/#2175) | tracked |
-| 8 | **annexB String HTML methods** — `anchor`/`big`/…/`sup` (13 methods) return `undefined`; CreateHTML not implemented | 79 (≈26 functional + 53 reflection→row 3) | **#4445 (this session)** | dispatched |
+| 8 | **annexB String HTML methods** — the direct-call lowering existed (#3069); the gap was the value-erased proto-closure shape | 79 | **#4445 — DONE** (filter 17→95/111 standalone, 13 HTML dirs 82/82, gc identical; reflection files flipped free via method-meta) | done |
 | 9 | **Array.prototype extern fallback leak** — `compileArrayConcatExtern` emits `__array_concat_any`/`__js_array_new`/`__js_array_push` → standalone leak-guard CE | ~30 | **#4446 (this session)** | dispatched |
 | 10 | Long tail — `Object.prototype` (38), `Function.prototype` (35), `let`/TDZ (26), `arrow-function` (25), `switch` (23), DataView (45), Iterator.prototype (55) | ~250 | untracked — file per-cluster on pickup | open |
 
@@ -60,6 +60,19 @@ generator row).
 3. **Next-wave triage issues filed**: #4449 (row 4, TypedArray) and #4450
    (row 7, class residual). Row 10's long tail gets per-cluster issues as the
    dispatched wave lands, so counts stay attributable.
+
+## Session results (2026-08-15, wave 1)
+
+- **#4445 landed** (`5b715e1`): annexB String filter 17→95/111 standalone, 13
+  HTML dirs 4/82→82/82, gc byte-identical. Free follow-up found:
+  `trimLeft`/`trimRight` miss the same `STRING_PROTO_METHODS` CSV (6 tests;
+  `reference-*` also needs alias identity `trimLeft === trimStart`).
+- **#4447 slice 1 landed** (`8dcbc88`): standalone for-of/dstr 342→400/569,
+  gc 344→395 (+51 — three of four fixes are lane-independent), standalone
+  assignment/dstr 240→246, 0 lost anywhere. Deferred: eval-order interleaving,
+  §7.4.9 refinements, fn.name, binding form (~30 tests,
+  `destructureParamArray`).
+- **#4446**: in flight (interim: concat 13→23 pass, 29→1 CE, 0 lost).
 
 ## Acceptance
 

--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -1,0 +1,68 @@
+---
+id: 4444
+title: "UMBRELLA: ES6 (ES2015) standalone edition close-out — 7,695/11,704 (66%) → 100%"
+status: in-progress
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+assignee: claude/es6-standalone-session
+priority: high
+horizon: xl
+feasibility: hard
+task_type: conformance
+area: codegen, conformance
+es_edition: es6
+goal: standalone-mode
+related: [2860, 2864, 2865, 2867, 2906, 3032, 3178, 2161, 2175, 2158, 2159, 4445, 4446, 4447]
+---
+
+# #4444 — UMBRELLA: ES6 (ES2015) standalone edition close-out
+
+## Measurement (2026-08-15, this session)
+
+Source: fresh `test262-standalone-current.jsonl` (baselines repo, fetched
+`--force`, 48,735 entries, baseline_sha `734fab88`), classified per-test with
+`scripts/generate-editions.ts` `classifyEdition` (host-free pass definition,
+`host_import_leak_class` excluded). Reproduction: `.tmp/es6-standalone-clusters.ts`.
+
+**ES2015 standalone: 7,695 pass / 11,704 total (66%) — 3,401 fail, 607
+compile_error, 1 skip = 4,009 non-passing.**
+
+## Cluster map → owning issues
+
+Counts are non-passing ES2015-classified tests in the standalone lane; clusters
+overlap paths (a generator test under `language/statements/class` counts in the
+generator row).
+
+| # | Cluster (root cause) | ~Tests | Owning issue(s) | State |
+|---|---|---|---|---|
+| 1 | **Native generator carrier** — standalone lowering only supports "sequential numeric yields"; everything else leaks `__create_generator`/`__gen_*` host imports (CE) or mis-executes. Spread across `language/{expressions,statements}/generators`, `yield`, `class` (gen methods), `object` (gen shorthand), for-of/dstr | ~500 | #2864 (in-progress), #2906 (in-progress), #3032, #680; umbrella #3178 | tracked — do NOT duplicate |
+| 2 | **Promise/microtask carrier** — `Promise.all/race` leak `Promise_all`/`Promise_race`/`__js_array_new` (CE); `Promise.resolve` "not yet implemented"; `illegal cast [__then_fulfill_N]` in the async drive layer | ~233 | #2867 (ready), #2906, umbrella #3178 | tracked |
+| 3 | **Built-in method reflection** — `length.js`/`name.js`/`prop-desc.js`/`not-a-constructor.js`/`invoked-as-func.js` across every built-in: methods are not reified function objects (`Object.getOwnPropertyDescriptor` → "Cannot convert undefined or null to object", `typeof m === "undefined"`) | ~324 | #2175 (ready, arch spec written), #2158, #2159; sibling lane PR #4553 (method name/length meta) is in flight | tracked — architectural |
+| 4 | **TypedArray.prototype semantics** — species-constructor protocol (`speciesctor-*`, 55), custom-ctor paths, detached-buffer TypeErrors (~42), coercion/validation order. Excludes row-3 reflection files | ~330 net | #2159 lane (reflection part); species/detached part **untracked** — file on pickup, depends on #2175 for reflective receivers | partially tracked |
+| 5 | **RegExp `@@replace`/`@@match`/`@@split`/`@@search`** — function replacer refusal (CE, "#1913 follow-up"), coercion order, `lastIndex` protocol | ~161 | #2161 (blocked on #2175), F7 dynamic-receiver arch spec pending | tracked/blocked |
+| 6 | **for-of destructuring residual** — iterator close/return/throw propagation, trailing-iterator state (`trlg-iter`, 23), nested patterns, fn-name inference, TDZ | ~200 (non-generator) | **#4447 (this session)** | dispatched |
+| 7 | **Class semantics residual** — missing TypeErrors, field-init `NaN vs undefined`, destructured params, `message should be an own property` | ~330 (non-generator) | partially #2158/#2175; residual untracked — needs triage slice after row 3 lands | partially tracked |
+| 8 | **annexB String HTML methods** — `anchor`/`big`/…/`sup` (13 methods) return `undefined`; CreateHTML not implemented | 79 (≈26 functional + 53 reflection→row 3) | **#4445 (this session)** | dispatched |
+| 9 | **Array.prototype extern fallback leak** — `compileArrayConcatExtern` emits `__array_concat_any`/`__js_array_new`/`__js_array_push` → standalone leak-guard CE | ~30 | **#4446 (this session)** | dispatched |
+| 10 | Long tail — `Object.prototype` (38), `Function.prototype` (35), `let`/TDZ (26), `arrow-function` (25), `switch` (23), DataView (45), Iterator.prototype (55) | ~250 | untracked — file per-cluster on pickup | open |
+
+## Strategy
+
+1. **The two umbrella dependencies dominate**: rows 1–2 (generator + promise
+   carriers, ~733 tests) are owned by the in-flight #3178 machinery retirement
+   lane; row 3 (#2175 reflection, ~324 direct + unlocks rows 4/5/7 residuals)
+   has an architect spec and sibling-lane momentum (PR #4553). This umbrella
+   does not re-dispatch them.
+2. **This session dispatches the unowned, bounded clusters** — #4445, #4446,
+   #4447 — to Opus implementation agents in parallel worktrees (plans in the
+   issue files).
+3. **Remaining untracked residuals** (rows 4, 7, 10) get triage slices filed as
+   the dispatched wave lands, so counts stay attributable.
+
+## Acceptance
+
+- ES2015 standalone (host-free) reaches 100% of its 11,704-test bucket.
+- Interim checkpoints: each cluster row either has an owning issue with a plan
+  or a landed fix; the edition table in this file is refreshed per measurement
+  (name the artifact + date per project measurement discipline).

--- a/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
+++ b/plan/issues/4444-es6-standalone-edition-closeout-umbrella.md
@@ -13,7 +13,7 @@ task_type: conformance
 area: codegen, conformance
 es_edition: es6
 goal: standalone-mode
-related: [2860, 2864, 2865, 2867, 2906, 3032, 3178, 2161, 2175, 2158, 2159, 4445, 4446, 4447]
+related: [2860, 2864, 2865, 2867, 2906, 3032, 3178, 2161, 2175, 2158, 2159, 4445, 4446, 4447, 4449, 4450]
 ---
 
 # #4444 — UMBRELLA: ES6 (ES2015) standalone edition close-out
@@ -39,10 +39,10 @@ generator row).
 | 1 | **Native generator carrier** — standalone lowering only supports "sequential numeric yields"; everything else leaks `__create_generator`/`__gen_*` host imports (CE) or mis-executes. Spread across `language/{expressions,statements}/generators`, `yield`, `class` (gen methods), `object` (gen shorthand), for-of/dstr | ~500 | #2864 (in-progress), #2906 (in-progress), #3032, #680; umbrella #3178 | tracked — do NOT duplicate |
 | 2 | **Promise/microtask carrier** — `Promise.all/race` leak `Promise_all`/`Promise_race`/`__js_array_new` (CE); `Promise.resolve` "not yet implemented"; `illegal cast [__then_fulfill_N]` in the async drive layer | ~233 | #2867 (ready), #2906, umbrella #3178 | tracked |
 | 3 | **Built-in method reflection** — `length.js`/`name.js`/`prop-desc.js`/`not-a-constructor.js`/`invoked-as-func.js` across every built-in: methods are not reified function objects (`Object.getOwnPropertyDescriptor` → "Cannot convert undefined or null to object", `typeof m === "undefined"`) | ~324 | #2175 (ready, arch spec written), #2158, #2159; sibling lane PR #4553 (method name/length meta) is in flight | tracked — architectural |
-| 4 | **TypedArray.prototype semantics** — species-constructor protocol (`speciesctor-*`, 55), custom-ctor paths, detached-buffer TypeErrors (~42), coercion/validation order. Excludes row-3 reflection files | ~330 net | #2159 lane (reflection part); species/detached part **untracked** — file on pickup, depends on #2175 for reflective receivers | partially tracked |
+| 4 | **TypedArray.prototype semantics** — species-constructor protocol (`speciesctor-*`, 55), custom-ctor paths, detached-buffer TypeErrors (~41), coercion/validation order. Excludes row-3 reflection files | ~556 | **#4449** (filed this session, triage-first; reflection part stays #2159) | tracked |
 | 5 | **RegExp `@@replace`/`@@match`/`@@split`/`@@search`** — function replacer refusal (CE, "#1913 follow-up"), coercion order, `lastIndex` protocol | ~161 | #2161 (blocked on #2175), F7 dynamic-receiver arch spec pending | tracked/blocked |
 | 6 | **for-of destructuring residual** — iterator close/return/throw propagation, trailing-iterator state (`trlg-iter`, 23), nested patterns, fn-name inference, TDZ | ~200 (non-generator) | **#4447 (this session)** | dispatched |
-| 7 | **Class semantics residual** — missing TypeErrors, field-init `NaN vs undefined`, destructured params, `message should be an own property` | ~330 (non-generator) | partially #2158/#2175; residual untracked — needs triage slice after row 3 lands | partially tracked |
+| 7 | **Class semantics residual** — `class/dstr` method-param destructuring dominates (112, shares #4447's machinery), subclass (46), definition (36), NamedEvaluation `NaN vs undefined` | ~321 (non-generator) | **#4450** (filed this session; re-measure after #4447 lands; overlaps #2158/#2175) | tracked |
 | 8 | **annexB String HTML methods** — `anchor`/`big`/…/`sup` (13 methods) return `undefined`; CreateHTML not implemented | 79 (≈26 functional + 53 reflection→row 3) | **#4445 (this session)** | dispatched |
 | 9 | **Array.prototype extern fallback leak** — `compileArrayConcatExtern` emits `__array_concat_any`/`__js_array_new`/`__js_array_push` → standalone leak-guard CE | ~30 | **#4446 (this session)** | dispatched |
 | 10 | Long tail — `Object.prototype` (38), `Function.prototype` (35), `let`/TDZ (26), `arrow-function` (25), `switch` (23), DataView (45), Iterator.prototype (55) | ~250 | untracked — file per-cluster on pickup | open |
@@ -57,8 +57,9 @@ generator row).
 2. **This session dispatches the unowned, bounded clusters** — #4445, #4446,
    #4447 — to Opus implementation agents in parallel worktrees (plans in the
    issue files).
-3. **Remaining untracked residuals** (rows 4, 7, 10) get triage slices filed as
-   the dispatched wave lands, so counts stay attributable.
+3. **Next-wave triage issues filed**: #4449 (row 4, TypedArray) and #4450
+   (row 7, class residual). Row 10's long tail gets per-cluster issues as the
+   dispatched wave lands, so counts stay attributable.
 
 ## Acceptance
 

--- a/plan/issues/4445-annexb-string-html-methods-standalone.md
+++ b/plan/issues/4445-annexb-string-html-methods-standalone.md
@@ -1,0 +1,90 @@
+---
+id: 4445
+title: "annexB String.prototype HTML methods (anchor/big/…/sup) return undefined in standalone — implement CreateHTML natively"
+status: in-progress
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+assignee: claude/es6-standalone-session
+priority: high
+horizon: s
+feasibility: medium
+task_type: conformance
+area: codegen
+es_edition: es6
+goal: standalone-mode
+related: [4444, 3256, 2175]
+---
+
+# #4445 — annexB String HTML methods: implement CreateHTML in standalone
+
+## Problem
+
+All 13 annexB §B.2.3 String.prototype HTML wrapper methods — `anchor`, `big`,
+`blink`, `bold`, `fixed`, `fontcolor`, `fontsize`, `italics`, `link`, `small`,
+`strike`, `sub`, `sup` — are unimplemented in the standalone lane. Method calls
+compile but produce `undefined`.
+
+**79 non-passing ES2015 tests** under `annexB/built-ins/String/prototype/*`
+(6-7 per method). Per-method breakdown of the 6 failures:
+
+- `B.2.3.N.js` (functional: `"42".anchor(42) === '<a name="42">42</a>'`) — fixed here
+- `this-val-tostring-err.js` (RequireObjectCoercible + ToString(this) abrupt) — fixed here
+- `length.js`, `name.js`, `prop-desc.js`, `not-a-constructor.js` — method
+  reflection, owned by #2175/PR #4553 machinery; NOT this issue's scope. If the
+  method-meta machinery on main covers self-hosted string helpers, wire it; do
+  not build new reflection machinery here.
+
+Spec (B.2.3.2.1 CreateHTML): `ToString(RequireObjectCoercible(this))`, then
+`"<" + tag + (attr ? " " + attr + '="' + ToString(value).replaceAll('"', "&quot;") + '"' : "") + ">" + S + "</" + tag + ">"`.
+
+## Implementation Plan (fable, 2026-08-15)
+
+The string family has a **self-hosted stdlib mechanism** (#3256): TS source in
+`src/stdlib/strings.ts` (`SELF_HOSTED_STRING_HELPERS`, ~L276-346) is compiled
+through the compiler's own IR pipeline by
+`src/codegen/native-strings-selfhost.ts` (`emitSelfHostedStringHelpers`), which
+registers each unit in `ctx.nativeStrHelpers` under its `canonicalName`.
+`repeat`/`padStart`/`padEnd` are the model.
+
+1. **Stdlib unit** — add to `src/stdlib/strings.ts` one generic helper:
+   `__sh_str_createHTML(s: str, tag: str, attr: str, value: str, hasAttr: i32) -> str`
+   (or a `str`-only ABI using an empty-attr sentinel if the i32 param needs a
+   thunk — follow the existing `thunk` pattern at ~L329). Body: pure string
+   concat + a quote-escape loop (`replaceAll('"', "&quot;")` — check what
+   self-hosted units may call; if `replaceAll` isn't available in the
+   self-hosted subset, write the scan/concat loop manually like the pad family).
+   Register `canonicalName: "__str_createHTML"`.
+2. **Dispatch** — `src/codegen/string-ops.ts` has the per-method call-site
+   dispatch (`if (method === "startsWith") { … ctx.nativeStrHelpers.get(...) }`,
+   ~L3032). Add one arm for the 13 method names via a small
+   `HTML_METHODS: Record<name, {tag, attr}>` table (per B.2.3.2-15:
+   anchor→a/name, link→a/href, fontcolor→font/color, fontsize→font/size, the
+   other 9 have no attribute). Compile receiver with the existing
+   `compileReceiverToLocal` (this already carries the
+   RequireObjectCoercible/ToString semantics the other methods use — verify
+   with `this-val-tostring-err.js`, which requires the abrupt completion from
+   `ToString(this)` to propagate), the attr value with
+   `compileStringValueToLocal(expr.arguments[0], "undefined", …)` (note: spec
+   passes the value through ToString, so `undefined` → the literal string
+   `"undefined"` — same as the search-family default), then
+   `call __str_createHTML`.
+3. **Method-name lists** — add the 13 names wherever string proto method names
+   are enumerated so the dispatch is reachable: check
+   `src/codegen/array-object-proto.ts` ~L210 region ("repeat" appears in a
+   method-name list) and `numeric-property-analysis.ts` ~L249; grep for an
+   existing `"repeat"` entry and mirror it.
+4. **gc lane** — the JS-host lane already passes these via host strings; make
+   the new arm either standalone-only (`ctx.nativeStrings`) or verify it is
+   semantically identical in both lanes (preferred if cheap). Do not regress
+   the gc baseline.
+
+## Validation
+
+- Scoped run (~2 min): `TEST262_TARGET=standalone TEST262_PATH_FILTER="annexB/built-ins/String/prototype" pnpm run test:262`
+  Expect: the 13 `B.2.3.*.js` + 13 `this-val-tostring-err.js` flip to pass
+  (26); reflection files stay failing unless method-meta already covers them.
+- Unit test: `tests/issue-4445-annexb-html-methods.test.ts` compiling
+  `"_".anchor('"x"')` (quote escaping), `"".link(undefined)`, and an abrupt
+  `{toString(){throw …}}` receiver, both targets.
+- Equivalence guard: `npm test -- tests/equivalence.test.ts` unaffected.

--- a/plan/issues/4445-annexb-string-html-methods-standalone.md
+++ b/plan/issues/4445-annexb-string-html-methods-standalone.md
@@ -97,9 +97,14 @@ registers each unit in `ctx.nativeStrHelpers` under its `canonicalName`.
 ## Result (2026-08-15, Opus implementation — dev-4445-html)
 
 **Standalone 17/111 → 95/111 (+78) on the issue filter; the 13 HTML method
-dirs went 4/82 → 82/82. gc lane byte-identical (92/111 before and after).**
-A/B-measured against reverted HEAD copies, not inherited from an artifact;
-official scoped runner run agrees exactly with the direct-driver figures.
+dirs went 4/82 → 82/82. gc lane unchanged: 108/111 before and after, same 3
+failures file-for-file (official wrapper, all four arms).**
+A/B-measured against reverted HEAD copies, not inherited from an artifact.
+Correction (agent's own late re-measure): an earlier draft quoted gc as
+92/111 from a fast in-process driver; the 16-row gap was `strict rerun` rows
+the sharded path builds from a harness assembly the driver doesn't use. The
+official-wrapper figures above supersede it; the "gc unchanged" conclusion is
+unaffected.
 
 The plan's premise was stale: #3069 had already landed the native direct-call
 CreateHTML lowering. The actual gap was the VALUE-ERASED shape —

--- a/plan/issues/4445-annexb-string-html-methods-standalone.md
+++ b/plan/issues/4445-annexb-string-html-methods-standalone.md
@@ -1,7 +1,8 @@
 ---
 id: 4445
 title: "annexB String.prototype HTML methods (anchor/big/…/sup) return undefined in standalone — implement CreateHTML natively"
-status: in-progress
+status: done
+completed: 2026-08-15
 sprint: current
 created: 2026-08-15
 updated: 2026-08-15
@@ -14,6 +15,10 @@ area: codegen
 es_edition: es6
 goal: standalone-mode
 related: [4444, 3256, 2175]
+loc-budget-allow:
+  - src/codegen/array-object-proto.ts
+func-budget-allow:
+  - src/codegen/array-object-proto.ts::emitStringProtoMemberBody
 ---
 
 # #4445 — annexB String HTML methods: implement CreateHTML in standalone
@@ -88,3 +93,32 @@ registers each unit in `ctx.nativeStrHelpers` under its `canonicalName`.
   `"_".anchor('"x"')` (quote escaping), `"".link(undefined)`, and an abrupt
   `{toString(){throw …}}` receiver, both targets.
 - Equivalence guard: `npm test -- tests/equivalence.test.ts` unaffected.
+
+## Result (2026-08-15, Opus implementation — dev-4445-html)
+
+**Standalone 17/111 → 95/111 (+78) on the issue filter; the 13 HTML method
+dirs went 4/82 → 82/82. gc lane byte-identical (92/111 before and after).**
+A/B-measured against reverted HEAD copies, not inherited from an artifact;
+official scoped runner run agrees exactly with the direct-driver figures.
+
+The plan's premise was stale: #3069 had already landed the native direct-call
+CreateHTML lowering. The actual gap was the VALUE-ERASED shape —
+`String.prototype.anchor.call(x, v)` — because the 13 names were missing from
+`STRING_PROTO_METHODS` in `src/codegen/array-object-proto.ts`. Fix: 13 names
+into that CSV + 9 zero-arities into `PROTO_METHOD_LENGTH` + a reflective
+CreateHTML closure body (`src/codegen/string-proto-html.ts`, spec-order
+RequireObjectCoercible → ToString(this) → ToString(value)+quote-escape) reusing
+the #3069 tag table (moved to `html-wrapper-native.ts` behind an own-property
+accessor `htmlWrapperFor`). The reflection files (length/name/prop-desc/
+not-a-constructor) flipped for free via the existing method-meta machinery —
+no new reflection machinery was built. Also fixed a latent hazard: bare
+`HTML_WRAPPER_TAGS[member]` answered inherited `Object.prototype.toString` for
+`member === "toString"`, which would have compiled
+`String.prototype.toString.call(x)` to `"<undefined>x</undefined>"`.
+
+**Follow-up worth its own issue**: `trimLeft`/`trimRight` have the identical
+CSV defect (6 tests) — 4 flip by adding the names; `reference-trimStart/End`
+additionally need alias identity (`trimLeft === trimStart`), which the CSV
+mechanism cannot express. Residual annexB String failures (16) are all
+non-HTML members: #1474 dynamic-regexp refusals, `substr` coercion, the trim
+aliases.

--- a/plan/issues/4446-standalone-native-array-concat-fallback.md
+++ b/plan/issues/4446-standalone-native-array-concat-fallback.md
@@ -1,10 +1,11 @@
 ---
 id: 4446
 title: "standalone: Array.prototype.concat extern fallback leaks __array_concat_any/__js_array_new/__js_array_push — lower natively"
-status: in-progress
+status: done
 sprint: current
 created: 2026-08-15
 updated: 2026-08-15
+completed: 2026-08-15
 assignee: claude/es6-standalone-session
 priority: high
 horizon: m
@@ -14,6 +15,8 @@ area: codegen
 es_edition: es6
 goal: standalone-mode
 related: [4444, 2961, 1359, 2860]
+coercion-sites-allow:
+  - src/codegen/array-concat-spec.ts
 ---
 
 # #4446 — standalone native Array.prototype.concat fallback
@@ -82,3 +85,134 @@ HasProperty/Get; else append E itself. Final `Set(result, "length")`.
   array-like, length-getter-throws abrupt — assert no `env::` imports in the
   emitted module (mirror an existing strict-leak assertion from #2961 tests).
 - gc-lane equivalence: `npm test -- tests/equivalence.test.ts`.
+
+## Implementation (2026-08-15)
+
+Three files. The bulk lands in a NEW subsystem module rather than in
+`array-methods.ts`, which is a tracked god-file — `check:loc-budget` and
+`check:godfiles` both refuse a 270-line addition there, and their own advice is
+"add code to the subsystem module, not the barrel/driver". After the split
+`array-methods.ts` is 8881 lines (**below** its 8909 cap) and
+`profile-godfiles.mjs --check` output is byte-identical to the base.
+
+- **`src/codegen/array-concat-spec.ts`** (new) — the native lowering.
+- **`src/codegen/array-method-host.ts`** — gains the JS-host bridge, moved
+  verbatim from `array-methods.ts`.
+- **`src/codegen/array-methods.ts`** — keeps only the two dispatch decisions.
+
+- **`compileArrayConcatNativeSpec`** (new) — the §23.1.3.1 loop over dynamic
+  operands, emitted inline (the operand count is static, so no args vec and no
+  new module-level helper function is needed). Per operand E:
+  `IsConcatSpreadable(E)` = `__extern_get(E, __box_symbol(6))` → null/undefined
+  ⇒ `__extern_is_array(E)`, else `ToBoolean` via the shared `emitToBoolean`
+  (`__is_truthy`); spreadable ⇒ `__extern_length(E)` (which already performs
+  `Get` + ToLength §7.1.20 including the observable ToPrimitive walk) then
+  `__extern_get_idx` per index into `__objvec_push`; non-spreadable ⇒ push E.
+  A running f64 total enforces the step-5.c.iii `n + len > 2^53-1` TypeError —
+  load-bearing beyond conformance, since it is what stops
+  `length = Number.MAX_SAFE_INTEGER` from entering a 2^31-iteration loop after
+  the i32 truncation.
+- **`compileArrayConcatExtern`** now switches per target: `native-first`
+  (standalone / wasi / explicit `semanticProviders`) → the native lowering;
+  everything else → `compileArrayConcatExternHost`, the untouched
+  `__array_concat_any` bridge.
+- **`compileArrayConcatNativeDynamic`** (the pre-existing all-operands-are-arrays
+  shortcut) now delegates to the same spec loop, keeping its unconditional walk
+  only as the substrate-unavailable fallback. The shortcut spread every operand
+  unconditionally, which is wrong for an array carrying a falsy
+  `@@isConcatSpreadable`.
+
+Deliberate under-approximations (both pre-existing, neither a regression):
+
+- **ArraySpeciesCreate** is a plain `$ObjVec`, not a species-derived construct.
+- **Holes are not preserved** — `$ObjVec` has no hole slot. The VALUES are
+  spec-correct (`Get` of an absent index is `undefined`, exactly what
+  `__extern_get_idx` answers), so `compareArray` tests pass; only a
+  `hasOwnProperty` probe on the result could tell. This is also why the loop
+  does NOT gate on `__extern_has_idx`: the gate would buy nothing and would
+  actively drop legitimately-present `null` elements (`__extern_has_idx`
+  answers 0 for a field holding the externref null — the #1382 note in
+  `array-prototype-borrow.ts`).
+
+## Test Results
+
+Scoped `TEST262_PATH_FILTER="built-ins/Array/prototype/concat"` (69 files),
+measured in this worktree on 2026-08-15:
+
+| target | before | after |
+| ------ | ------ | ----- |
+| `standalone` | **13 pass** / 27 fail / 29 compile_error | **23 pass** / 45 fail / 1 compile_error |
+| `gc` | (binaries byte-identical to after — see below) | **24 pass** / 45 fail / 0 compile_error |
+
+`+10 standalone passes; 28 of the 29 compile_errors cleared` (the survivor is
+`concat_non-array.js`, a `__get_builtin` refusal unrelated to concat). **Zero
+pass → non-pass transitions**: all 13 baseline standalone passes are retained.
+
+The gc lane is proved unchanged by something stronger than a conformance run:
+compiling all **69** concat test262 files for gc against the working tree and
+against `git show HEAD:` (restored `array-methods.ts` + `array-method-host.ts`,
+`array-concat-spec.ts` removed) yields **byte-identical `result.binary` for
+every file** — 69/69 sha256 match. `gc` never reaches the new branch
+(`semanticProviders` is `host-assisted` there), and the host bridge was moved
+verbatim.
+
+Re-measured after the module extraction: the standalone per-test result set is
+identical to the pre-extraction measurement (`diff` of both result summaries is
+empty), i.e. the extraction is a pure move.
+
+Unit test `tests/issue-4446-concat-dyn-standalone.test.ts` — 13 assertions,
+all green: zero `env::` imports for each of the four Validation fixtures, the
+three retired imports absent by name, the §23.1.3.1 behaviours, the pinned
+residual, and the gc lane still routing through `env::__array_concat_any`.
+
+## Residual non-passes (46 of 69), by cause
+
+None of these is in the concat loop itself; each names the substrate that owns it.
+
+1. **ArraySpeciesCreate not implemented (12)** — `create-ctor-non-object`,
+   `create-ctor-poisoned`, `create-species-abrupt`, `create-species-non-ctor`,
+   `create-species-non-extensible{,-spreadable}`,
+   `create-species-with-non-configurable-property{,-spreadable}`,
+   `create-species`, `create-proto-from-ctor-realm-non-array`, `create-proxy`,
+   `is-concat-spreadable-get-order` (needs the observable `constructor` read).
+   The result is a plain `$ObjVec`; species needs the native constructor channel.
+2. **`Array.prototype.concat` not callable as a VALUE standalone (5)** —
+   `15.4.4.4-5-c-i-1`, `concat_array-like-string-length`, `concat_array-like`,
+   `call-with-boolean`, `create-non-array`. A `#1888`-class builtin-method-as-value
+   gap that fails before concat is ever entered.
+3. **Symbol keys on a VEC receiver (2)** — `is-concat-spreadable-val-falsey`,
+   `-val-undefined`. `item[Symbol.isConcatSpreadable] = v` on an array lands on
+   numeric index 6 (so `item.length` becomes 7) instead of the symbol-key
+   channel `__extern_get` reads, so IsConcatSpreadable falls through to IsArray.
+   `Object.defineProperty(arr, Symbol.…)` does not corrupt length but is still
+   invisible to `__extern_get`. **Reproduces identically on the untouched gc
+   lane** (`item.length === 7` there too) ⇒ it is the #2866-adjacent symbol/vec
+   property channel, not this issue. The object-receiver form works
+   (`is-concat-spreadable-val-truthy` now passes).
+4. **Symbol-keyed ACCESSORS not invoked (3)** — `is-concat-spreadable-get-err`,
+   `concat_spreadable-getter-throws`, `concat_length-throws`. A throwing
+   `@@isConcatSpreadable` / `length` getter installed via `defineProperty` is
+   not run by the reflective read, so the abrupt completion never propagates.
+5. **Proxy (3)** — `is-concat-spreadable-is-array-proxy-revoked`,
+   `is-concat-spreadable-proxy-revoked` (illegal cast),
+   `arg-length-exceeding-integer-limit` (its Proxy half; the non-Proxy half now
+   throws the correct TypeError).
+6. **Boxed-primitive / exotic operands (5)** — `spreadable-boolean-wrapper`,
+   `spreadable-number-wrapper`, `spreadable-string-wrapper`,
+   `spreadable-reg-exp`, `spreadable-function`. `new Boolean(true)` &c. as a
+   concat operand do not round-trip through the reflective element channel.
+7. **TypedArray operands (2)** — `concat_large-typed-array`,
+   `concat_small-typed-array`: `__extern_get_idx` over a TypedArray answers
+   0/NaN rather than the element.
+8. **`arguments` object absent indices read back as `null`, not `undefined` (3)**
+   — `concat_sloppy-arguments`, `-with-dupes`, `concat_strict-arguments`.
+   Verified NOT general: an array-like `$Object`, an array hole and a stored
+   `undefined` all read back as `undefined` from this same loop; only the
+   arguments carrier answers null.
+9. **`__extern_length` ToPrimitive gap (1)** — `concat_array-like-length-to-string-throws`:
+   `illegal cast [in __call_valueOf() ← __to_primitive ← __extern_length]`.
+10. **`concat_spreadable-sparse-object` (1)** — uncaught Wasm-GC exception.
+11. **Pre-existing, not on the dynamic fallback at all (8)** —
+    `S15.4.4.4_A1_T2`, `_A1_T4`, `_A2_T1`, `_A2_T2`, `_A3_T1`, `_A3_T2`,
+    `_A3_T3` (typed vec path / null receiver), and the one surviving
+    compile_error `concat_non-array.js` (`__get_builtin`, #1472).

--- a/plan/issues/4446-standalone-native-array-concat-fallback.md
+++ b/plan/issues/4446-standalone-native-array-concat-fallback.md
@@ -1,0 +1,84 @@
+---
+id: 4446
+title: "standalone: Array.prototype.concat extern fallback leaks __array_concat_any/__js_array_new/__js_array_push — lower natively"
+status: in-progress
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+assignee: claude/es6-standalone-session
+priority: high
+horizon: m
+feasibility: medium
+task_type: conformance
+area: codegen
+es_edition: es6
+goal: standalone-mode
+related: [4444, 2961, 1359, 2860]
+---
+
+# #4446 — standalone native Array.prototype.concat fallback
+
+## Problem
+
+`compileArrayConcatExtern` (`src/codegen/array-methods.ts` ~L4113-4175) is the
+fallback when any concat operand is not a statically-known WasmGC array (any-
+typed receiver, `Symbol.isConcatSpreadable` objects, array-likes). It emits the
+host imports `__array_concat_any` + `__js_array_new` + `__js_array_push`; in
+the standalone lane the strict leak guard (#2961) turns that into a
+compile_error: `standalone target emitted host imports: env::__array_concat_any…`.
+
+**~30 non-passing ES2015 tests** under `built-ins/Array/prototype/concat/*`
+(all CE), including every `isConcatSpreadable` protocol test. The same leaked
+pair `__js_array_new`/`__js_array_push` also appears in Promise-combinator CEs
+(owned by #2867 — out of scope here).
+
+The native fast path directly above it (~L4090, WasmGC vec `array.copy` with
+`emitBackingClampedArrayCopy`) already handles statically-typed array operands
+— this issue is only the dynamic fallback.
+
+## Implementation Plan (fable, 2026-08-15)
+
+Spec (§23.1.3.1): result = ArraySpeciesCreate(O, 0); for O then each arg E:
+if `IsConcatSpreadable(E)` (Object + `@@isConcatSpreadable` coerced via
+ToBoolean, default IsArray(E)) append E's `0..ToLength(E.length)` elements via
+HasProperty/Get; else append E itself. Final `Set(result, "length")`.
+
+1. **Investigate the dynamic-object substrate first.** Standalone has a dynamic
+   object runtime (`src/stdlib/object-runtime.ts`, `src/codegen/dyn-read.ts`)
+   with property get/has and array-ness answers. Find the existing helpers for
+   "is this dyn value an array", "get length", "indexed get", "indexed set /
+   push" — the ES5 standalone lane already passes generic
+   `Array.prototype.*` tests (#1461 array-like receivers is `done`), so
+   these primitives exist. Reuse them; do NOT invent a second dyn-array ABI.
+2. **Self-hosted or hand-emitted `__arr_concat_dyn`** taking the receiver and
+   an args vec, implementing the spec loop over dyn values:
+   spreadable-check (`@@isConcatSpreadable` read → ToBoolean, falling back to
+   IsArray), ToLength on `length` (handles the
+   `arg-length-exceeding-integer-limit.js` / `length-to-string-throws` abrupt
+   cases), hole semantics via HasProperty (`concat` skips holes but counts
+   them in length). Check how the standalone `slice`/`splice` generic paths
+   (#1359, done) solved species + holes and mirror their approach; if a
+   shared `ArraySpeciesCreate` helper exists, use it, else default-Array
+   creation is acceptable for a first slice (species tests are a minority of
+   the bucket — measure and say which remain).
+3. **Rewire** `compileArrayConcatExtern` behind a target switch: standalone →
+   the native lowering; JS-host (gc) → keep the existing host-import path
+   unchanged (it is faster and complete there).
+4. **Symbol plumbing**: `@@isConcatSpreadable` needs a well-known-symbol
+   property read on a dyn object in standalone. Check how existing well-known
+   symbol reads (`Symbol.iterator` in for-of dyn paths, `@@toStringTag`) are
+   keyed in the object runtime and use the same keying. If Symbol keying is
+   genuinely blocked on #2866 (Symbol carrier), implement the default
+   IsArray(E) branch now, leave the @@isConcatSpreadable override subset
+   failing, and record the residual count here.
+
+## Validation
+
+- Scoped run: `TEST262_TARGET=standalone TEST262_PATH_FILTER="built-ins/Array/prototype/concat" pnpm run test:262`
+  Baseline: ~30 CE. Target: majority flip to pass; every remaining non-pass
+  named in this file with its reason.
+- Unit test `tests/issue-4446-concat-dyn-standalone.test.ts`: any-typed
+  receiver concat, isConcatSpreadable=false array, spreadable object
+  array-like, length-getter-throws abrupt — assert no `env::` imports in the
+  emitted module (mirror an existing strict-leak assertion from #2961 tests).
+- gc-lane equivalence: `npm test -- tests/equivalence.test.ts`.

--- a/plan/issues/4447-forof-destructuring-standalone-residual.md
+++ b/plan/issues/4447-forof-destructuring-standalone-residual.md
@@ -14,6 +14,15 @@ area: codegen
 es_edition: es6
 goal: standalone-mode
 related: [4444, 2566, 1219, 999]
+loc-budget-allow:
+  - src/codegen/statements/for-of-destructuring.ts
+  - src/codegen/iterator-native.ts
+func-budget-allow:
+  - src/codegen/statements/for-of-destructuring.ts::compileForOfIteratorAssignDestructuring
+  - src/codegen/statements/for-of-destructuring.ts::compileForOfAssignDestructuringExternref
+  - src/codegen/statements/for-of-destructuring.ts::compileForOfAssignDestructuring
+  - src/codegen/iterator-native.ts::buildIteratorNextBody
+  - src/codegen/iterator-native.ts::fillNativeIteratorLateArms
 ---
 
 # #4447 — for-of destructuring standalone residual
@@ -87,3 +96,38 @@ sub-bucket, each with its own commit:
 - gc lane must not regress: the same lowering runs in both lanes — run the
   same filter with `TEST262_TARGET=gc` before finishing.
 - Equivalence guard: `npm test -- tests/equivalence.test.ts`.
+
+## Result — slice 1 (2026-08-15, Opus implementation — dev-4447-dstr)
+
+**standalone for-of/dstr 342→400/569 (+58, 0 lost); gc 344→395/569 (+51, 0
+lost); standalone assignment/dstr cross-check 240→246/370 (+6, 0 lost).**
+File-copy A/B against HEAD; measured on a quiescent tree. 19 new unit tests
+(`tests/issue-4447-forof-dstr-standalone.test.ts`) + 13-file regression sweep.
+
+Four root causes, all in the ASSIGNMENT form of for-of heads (the binding form
+routes through `destructureParamArray` and was already correct):
+
+1. §13.15.5.2 GetIterator was never performed — elements were read via
+   `__extern_get(elem, i)`, so user iterables saw zero `next()`/`return()`.
+2. `__iterator_next`'s closed-struct read required BOTH `__sget_done` AND
+   `__sget_value`, so a conformant `{done}`-only IteratorResult degraded to
+   "exhausted on step 1" and suppressed IteratorClose.
+3. Object assignment patterns dropped defaults and wrote the KEY name instead
+   of the target (`{k: t = d}` wrote `k`, ignored `d`).
+4. Nested patterns in value/element/rest position were silently dropped
+   (isIdentifier bail) instead of recursing + throwing TypeError on
+   null/undefined.
+
+Secondary fixes: `emitGlobalSyncWritebackByName` (stale module-global index
+after `addStringConstantGlobal` import-global remap → "immutable global #3
+cannot be assigned"); `__sget_done` result-type following the field type (f64
+fed `__is_truthy`) — additive gate, pre-existing path untouched.
+
+**Deferred (named in worktree RESULT-4447.md with reasons)**: assignment-target
+evaluation ORDER (needs interleaved stepping — rewrite of shared lowering);
+§7.4.9 IteratorClose refinements (throwing/non-Object `return()` — needs a
+native throw path, #2038 note); NamedEvaluation/fn.name (6); nested obj pattern
+over rest slice (string-keyed `__extern_get` misses `$Vec`, #3100);
+generator-carrier (27, #2864). **Natural follow-up: the BINDING form**
+(`destructureParamArray`, `src/codegen/destructuring-params.ts`, ~30 residual
+tests).

--- a/plan/issues/4447-forof-destructuring-standalone-residual.md
+++ b/plan/issues/4447-forof-destructuring-standalone-residual.md
@@ -1,0 +1,89 @@
+---
+id: 4447
+title: "standalone: for-of destructuring residual (~200 non-generator tests) — iterator close/abrupt-completion + trailing-iterator state + nested patterns"
+status: in-progress
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+assignee: claude/es6-standalone-session
+priority: high
+horizon: m
+feasibility: medium
+task_type: conformance
+area: codegen
+es_edition: es6
+goal: standalone-mode
+related: [4444, 2566, 1219, 999]
+---
+
+# #4447 — for-of destructuring standalone residual
+
+## Problem
+
+201 non-passing ES2015 tests under `language/statements/for-of/dstr/*` in the
+standalone lane are NOT generator-carrier failures (those are #2864's; ~15 of
+the 216 total are and stay out of scope — skip any test whose failure mentions
+`__gen_`/`__create_generator`). Top sub-buckets by test-name pattern
+(measured 2026-08-15 from the fresh standalone baseline via
+`.tmp/es6-standalone-clusters.ts`):
+
+| ~Tests | Pattern | Symptom |
+|---|---|---|
+| 23 | `array-elem-trlg-iter-*` | trailing-element iterator state: elision/rest after a completed or abrupt iterator |
+| 14 | `obj-prop-elem-init-*` | object-pattern property element with initializer (incl. fn-name inference `NaN vs undefined`) |
+| 27 | `{const,var,let}-ary-ptrn-*` | array-pattern binding forms |
+| ~25 | `*-nested-obj-*` / `*-nested-array-*` | nested pattern recursion (null/undefined → "Expected a TypeError but none thrown") |
+| ~12 | `*-iter-{rtrn,thrw,close}*` | IteratorClose on abrupt completion; `return`/`throw` propagation |
+| rest | put-prop / put-unresolvable / init-fn-name / elision | assignment-target evaluation order, strict unresolvable ReferenceError, fn `name` |
+
+Error mix: "Expected a TypeError/Test262Error/ReferenceError but none thrown"
+(~62), SameValue mismatches (value semantics, ~35), "Cannot convert undefined
+or null to object" (~10).
+
+## Implementation Plan (fable, 2026-08-15) — triage-first
+
+This bucket is diverse; do NOT attempt one mega-fix. Work top-down by
+sub-bucket, each with its own commit:
+
+1. **Reproduce cheaply.** Compile single tests with the CLI
+   (`npx tsx src/cli.ts <file> --nativeStrings` per its `--help`) or run the
+   scoped suite (see Validation). Pick ONE representative per sub-bucket and
+   diff actual-vs-expected before touching code.
+2. **Locate the lowering.** Destructuring lowering lives in the codegen
+   statements/expressions path (grep `dstr`, `ArrayBindingPattern`,
+   `ObjectBindingPattern` under `src/codegen/` and `src/ir/`; #1219/#2566 name
+   the iterator-destructuring machinery — read their issue files first for
+   known constraints, esp. #2566's eager-buffer over-consumption note: the
+   standalone iterator protocol for array patterns may be eager-buffered,
+   which is likely the root of the `trlg-iter` bucket).
+3. **Expected order of attack** (largest bounded first):
+   a. `trlg-iter` (23): trailing elision/rest must NOT call `next()` after
+      `done:true`, and elision still advances the iterator — check where the
+      pattern consumes the iterator record and thread the `done` flag.
+   b. Nested-pattern TypeErrors (~25): destructuring `undefined`/`null` at a
+      nested level must throw TypeError (RequireObjectCoercible /
+      GetIterator on the nested value). Likely a missing coercible check in
+      the recursive pattern-lowering entry.
+   c. IteratorClose family (~12): abrupt completion inside the pattern body
+      must call `return()` on the iterator when `done` is false.
+   d. `obj-prop-elem-init` + fn-name (~14): default-initializer evaluation
+      (only when value is undefined) + NamedEvaluation for anonymous
+      fn/class/arrow initializers (`NaN vs undefined` on `.name` reads).
+   e. Binding-form residual (`const/let/var-ary-ptrn`): re-measure after
+      a-d — many are the same defects surfacing through different binding
+      forms; fix what remains.
+4. **Shared machinery caution**: destructuring lowering is shared with plain
+   assignment/declaration destructuring (`language/expressions/assignment/dstr`
+   has ~89 similar failures — same fixes likely flip those too; measure and
+   report the cross-bucket delta, don't scope-creep into new machinery for
+   them).
+
+## Validation
+
+- Scoped run: `TEST262_TARGET=standalone TEST262_PATH_FILTER="language/statements/for-of/dstr" pnpm run test:262`
+  Baseline: 201 non-pass (of ~700 total dstr files). Report per-sub-bucket
+  flips; also run `language/expressions/assignment/dstr` once at the end for
+  the cross-bucket delta.
+- gc lane must not regress: the same lowering runs in both lanes — run the
+  same filter with `TEST262_TARGET=gc` before finishing.
+- Equivalence guard: `npm test -- tests/equivalence.test.ts`.

--- a/plan/issues/4449-typedarray-standalone-semantics-residual.md
+++ b/plan/issues/4449-typedarray-standalone-semantics-residual.md
@@ -1,0 +1,56 @@
+---
+id: 4449
+title: "standalone: TypedArray.prototype ES6 semantics residual (~556 non-reflection tests) — species protocol, detached-buffer checks, custom-ctor paths"
+status: ready
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: l
+feasibility: hard
+task_type: conformance
+area: codegen, conformance
+es_edition: es6
+goal: standalone-mode
+related: [4444, 2159, 2175]
+---
+
+# #4449 — TypedArray.prototype standalone semantics residual
+
+## Problem
+
+556 non-passing ES2015-classified standalone tests under `built-ins/TypedArray*`
+remain after excluding the reflection files (`length.js`/`name.js`/
+`prop-desc.js`/`not-a-constructor.js`/`invoked-as-func.js` — those are
+#2159/#2175's lane). Measured 2026-08-15 (`.tmp/es6-standalone-clusters.ts`,
+baseline_sha `734fab88`):
+
+| ~Tests | Sub-bucket | Symptom |
+|---|---|---|
+| 55 | `speciesctor-*` | `@@species` / custom-constructor protocol not consulted (`Expected a TypeError…`, `same constructor Expected SameValue(«undefined», «true»)`) |
+| 41 | detached-buffer | operations must throw TypeError on a detached ArrayBuffer; no exception thrown |
+| 22 | `custom-ctor` | result-constructor selection on map/slice/filter/subarray |
+| 438 | other | per-method semantics under "Testing with FloatNArray and makeArray" — validation order, `ToInteger` coercion, callbackfn protocol observability, `arraylength-internal` |
+
+Heaviest methods: `set` (37), `map` (35), `slice` (34), `filter` (32),
+`subarray` (31), `copyWithin` (27), `fill` (20), `reduce`/`reduceRight` (38).
+
+## Direction (not yet a full plan)
+
+- **Triage-first slice** like #4447: pick one representative per sub-bucket,
+  identify where the standalone TypedArray methods live (grep TypedArray under
+  `src/codegen/`), and confirm which failures are (a) missing protocol steps in
+  otherwise-working methods vs (b) blocked on #2175 reflective receivers.
+- The `speciesctor`/`custom-ctor` buckets need a SpeciesConstructor lookup on a
+  runtime receiver — check whether that genuinely requires #2175's prototype
+  objects or can key off the receiver's brand struct.
+- Detached-buffer checks are likely a bounded, high-yield first slice: one
+  `IsDetachedBuffer` guard emitted at each method entry.
+- Write the full `## Implementation Plan` (fable lane) before dispatching an
+  implementation agent, per the plan/implement split.
+
+## Acceptance
+
+- Sub-bucket counts above driven to zero (or re-attributed to #2175 with
+  evidence) with scoped-run measurements
+  (`TEST262_TARGET=standalone TEST262_PATH_FILTER="built-ins/TypedArray"`).

--- a/plan/issues/4450-class-es6-standalone-residual.md
+++ b/plan/issues/4450-class-es6-standalone-residual.md
@@ -1,0 +1,54 @@
+---
+id: 4450
+title: "standalone: class ES6 semantics residual (~321 non-generator tests) — dstr params dominate (112), subclass (46), definition (36)"
+status: ready
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: l
+feasibility: hard
+task_type: conformance
+area: codegen, conformance
+es_edition: es6
+goal: standalone-mode
+related: [4444, 4447, 2158, 2175]
+---
+
+# #4450 — class ES6 standalone residual
+
+## Problem
+
+321 non-generator non-passing ES2015 standalone tests under
+`language/statements/class` + `language/expressions/class`. Measured 2026-08-15
+(`.tmp/es6-standalone-clusters.ts`, baseline_sha `734fab88`):
+
+| ~Tests | Sub-bucket | Note |
+|---|---|---|
+| 112 | `class/dstr/*` | destructuring in class METHOD PARAMETERS — same lowering machinery as #4447 (for-of dstr). **Re-measure after #4447 lands before dispatching**; a large fraction should flip for free |
+| 46 | `class/subclass/*` | builtin subclassing (`extends Array/Error/…`), super-construct semantics |
+| 36 | `class/definition/*` | method/accessor definition semantics, `message should be an own property`, missing TypeErrors |
+| 10+18 | `gen-method(-static)` + misc | generator methods — #2864's lane, skip |
+| ~99 | elements / accessor-name / method(-static) / name-binding / restricted-properties | field-init `NaN vs undefined` (fn-name/NamedEvaluation family), computed accessor names, name binding TDZ |
+
+Top error shapes: "Expected a TypeError but none thrown" (24+11),
+`SameValue(«NaN», «undefined»)` (36 across both dirs — NamedEvaluation /
+field-value reads), "Cannot destructure 'null' or 'undefined'" thrown when it
+should be TypeError-with-different-message-shape or vice-versa (8).
+
+## Direction (not yet a full plan)
+
+1. **Wait for #4447's landing, re-measure `class/dstr`** — do not double-fix
+   shared destructuring machinery.
+2. Triage `subclass` (46): how much is blocked on #2158 ($ClassMeta prototype
+   scaffolding) vs bounded super-construct fixes.
+3. `definition` + NamedEvaluation buckets are likely bounded codegen fixes —
+   slice them after triage.
+4. Write the full `## Implementation Plan` (fable lane) before dispatching, per
+   the plan/implement split.
+
+## Acceptance
+
+- Post-#4447 re-measurement recorded here; remaining sub-buckets fixed or
+  re-attributed to #2158/#2864 with evidence, scoped-run measured
+  (`TEST262_TARGET=standalone TEST262_PATH_FILTER="language/statements/class|language/expressions/class"`).

--- a/src/codegen/array-concat-spec.ts
+++ b/src/codegen/array-concat-spec.ts
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4446) Wasm-native `Array.prototype.concat` for DYNAMIC operands — the
+ * ECMA-262 §23.1.3.1 spec loop used by every target whose semantic provider is
+ * `native-first` (`--target standalone` / `--target wasi` / an explicit
+ * `semanticProviders: "native-first"` gc build).
+ *
+ * Extracted into its own module rather than added to `array-methods.ts`: that
+ * file is a tracked god-file (`check:loc-budget` / `check:godfiles`), and the
+ * gate's own advice is to put new code in a subsystem module. `array-methods.ts`
+ * keeps only the two dispatch decisions that choose between this lowering and
+ * the JS-host `__array_concat_any` bridge.
+ *
+ * `compileExpression` is imported from `./shared.js`, NOT `./expressions.js`,
+ * for the same circular-dependency reason `array-methods.ts` documents.
+ */
+import type { ts } from "../ts-api.js";
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { allocLocal } from "./context/locals.js";
+import { buildThrowJsErrorInstrs } from "./js-errors.js";
+import { emitToBoolean } from "./coercion-engine.js";
+import { ensureObjVecBuilders } from "./object-runtime.js";
+import { compileExpression, ensureLateImport, flushLateImportShifts } from "./shared.js";
+import { coerceType } from "./type-coercion.js";
+
+/**
+ * (#4446) Well-known `@@isConcatSpreadable` symbol handle — the id the object
+ * runtime's native `$Symbol` carrier interns for `Symbol.isConcatSpreadable`
+ * (mirrors `WELL_KNOWN_SYMBOLS` in literals.ts / builtin-value-read.ts).
+ */
+const SYMBOL_IS_CONCAT_SPREADABLE_ID = 6;
+
+/** §23.1.3.1 step 5.c.iii — the 2^53-1 result-length ceiling. */
+const MAX_SAFE_LENGTH = 9007199254740991;
+
+/**
+ * (#4446) Native, host-free `Array.prototype.concat` — the §23.1.3.1 spec loop
+ * over DYNAMIC operands, for every target whose semantic provider is
+ * `native-first` (`--target standalone` / `--target wasi` / an explicit
+ * `semanticProviders: "native-first"` gc build).
+ *
+ * The JS-host fallback (`compileArrayConcatExternHost` in array-methods.ts)
+ * delegates the
+ * whole operation to `env::__array_concat_any` (plus `env::__js_array_new` /
+ * `env::__js_array_push` for the argument list). Those are unsatisfiable
+ * `env::*` imports host-free, so the #2961 strict leak guard turned every
+ * dynamic-operand concat into a standalone compile error — ~28 of the 69
+ * `built-ins/Array/prototype/concat` test262 files.
+ *
+ * This lowering walks the spec loop directly over the dynamic-object substrate
+ * that the generic `Array.prototype.*` array-like paths (#1359/#1461) already
+ * use, so no second dyn-array ABI is introduced:
+ *
+ * ```
+ *   out = __objvec_new()                       // ArraySpeciesCreate(O, 0) — see below
+ *   n   = 0
+ *   for E in [receiver, ...args]:
+ *     spreadable = IsConcatSpreadable(E):
+ *       v = __extern_get(E, __box_symbol(@@isConcatSpreadable))
+ *       v is null/undefined ? __extern_is_array(E) : ToBoolean(v)   // __is_truthy
+ *     if spreadable:
+ *       len = __extern_length(E)               // Get(E,"length") + ToLength (§7.1.20),
+ *                                              // incl. the observable valueOf/toString
+ *                                              // walk and its abrupt propagation
+ *       if n + len > 2^53-1: throw TypeError   // step 5.c.iii
+ *       for i in 0 .. len: __objvec_push(out, __extern_get_idx(E, i))
+ *       n += len
+ *     else:
+ *       __objvec_push(out, E); n += 1
+ *   return out                                  // a Wasm-owned $ObjVec — a real Array
+ * ```
+ *
+ * Two deliberate under-approximations, both measured and recorded on #4446:
+ *
+ * - **ArraySpeciesCreate** is a plain `$ObjVec`, not a species-derived
+ *   constructor call. The `create-species-*` bucket is a separate (already
+ *   failing, not regressed) concern that needs the species protocol on the
+ *   native constructor channel.
+ * - **Holes are not preserved.** `$ObjVec` has no hole representation, so a
+ *   skipped index materialises as `undefined` rather than an absent property.
+ *   The VALUES are spec-correct (`Get` of an absent index is `undefined`, which
+ *   is exactly what `__extern_get_idx` answers), so `compareArray`-style tests
+ *   pass; only a `hasOwnProperty` probe on the result could tell the difference.
+ *   That is why the loop does NOT gate on `__extern_has_idx`: the gate would buy
+ *   nothing here and would actively DROP legitimately-present `null` elements
+ *   (`__extern_has_idx` answers 0 for a field holding the externref null —
+ *   see the #1382 note in array-prototype-borrow.ts).
+ *
+ * Returns `undefined` (nothing emitted) when the substrate is unavailable, so
+ * the caller falls back to the host bridge unchanged.
+ */
+export function compileArrayConcatNativeSpec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+): ValType | null | undefined {
+  const externref: ValType = { kind: "externref" };
+  const i32: ValType = { kind: "i32" };
+  const f64: ValType = { kind: "f64" };
+
+  const builders = ensureObjVecBuilders(ctx);
+  // Register every helper BEFORE resolving any index; each of these is a
+  // DEFINED native under the native-first provider, so a later registration
+  // shifts the ones already resolved (the #2043 late-shift class). Every
+  // per-operand emission below re-resolves by NAME after its own
+  // `compileExpression`, which is the only other shift source in this body.
+  ensureLateImport(ctx, "__extern_length", [externref], [f64]);
+  ensureLateImport(ctx, "__extern_get_idx", [externref, f64], [externref]);
+  ensureLateImport(ctx, "__extern_get", [externref, externref], [externref]);
+  ensureLateImport(ctx, "__extern_is_array", [externref], [i32]);
+  ensureLateImport(ctx, "__extern_is_undefined", [externref], [i32]);
+  ensureLateImport(ctx, "__box_symbol", [i32], [externref]);
+  ensureLateImport(ctx, "__is_truthy", [externref], [i32]);
+  flushLateImportShifts(ctx, fctx);
+
+  const required = [
+    "__extern_length",
+    "__extern_get_idx",
+    "__extern_get",
+    "__extern_is_array",
+    "__extern_is_undefined",
+    "__box_symbol",
+    "__is_truthy",
+  ];
+  if (required.some((name) => ctx.funcMap.get(name) === undefined)) return undefined;
+
+  const out = allocLocal(fctx, `__cat_spec_out_${fctx.locals.length}`, externref);
+  const src = allocLocal(fctx, `__cat_spec_src_${fctx.locals.length}`, externref);
+  const spv = allocLocal(fctx, `__cat_spec_spv_${fctx.locals.length}`, externref);
+  const flag = allocLocal(fctx, `__cat_spec_flag_${fctx.locals.length}`, i32);
+  const lenF = allocLocal(fctx, `__cat_spec_lenf_${fctx.locals.length}`, f64);
+  const len = allocLocal(fctx, `__cat_spec_len_${fctx.locals.length}`, i32);
+  const idx = allocLocal(fctx, `__cat_spec_i_${fctx.locals.length}`, i32);
+  const total = allocLocal(fctx, `__cat_spec_n_${fctx.locals.length}`, f64);
+
+  // out = ArraySpeciesCreate(O, 0) ≈ a fresh $ObjVec ; n = 0
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__objvec_new") ?? builders.newIdx });
+  fctx.body.push({ op: "local.set", index: out });
+  fctx.body.push({ op: "f64.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: total });
+
+  for (const sourceExpr of [propAccess.expression, ...callExpr.arguments]) {
+    const sourceType = compileExpression(ctx, fctx, sourceExpr, externref);
+    if (sourceType === null) fctx.body.push({ op: "ref.null.extern" });
+    else if (sourceType.kind !== "externref") coerceType(ctx, fctx, sourceType, externref);
+    fctx.body.push({ op: "local.set", index: src });
+
+    // Build the overflow throw BEFORE resolving the helper indices: it can add
+    // the `__new_TypeError` late import and a string-constant global, and it
+    // flushes against `fctx.body` itself. Everything resolved after this point
+    // is therefore stable for the rest of this operand's emission.
+    const overflowThrow = buildThrowJsErrorInstrs(
+      ctx,
+      "TypeError",
+      "Array.prototype.concat: resulting array length exceeds 2^53-1",
+      { flush: fctx },
+    );
+
+    const pushIdx = ctx.funcMap.get("__objvec_push") ?? builders.pushIdx;
+    const externLenIdx = ctx.funcMap.get("__extern_length")!;
+    const getIdxIdx = ctx.funcMap.get("__extern_get_idx")!;
+    const externGetIdx = ctx.funcMap.get("__extern_get")!;
+    const isArrayIdx = ctx.funcMap.get("__extern_is_array")!;
+    const isUndefinedIdx = ctx.funcMap.get("__extern_is_undefined")!;
+    const boxSymbolIdx = ctx.funcMap.get("__box_symbol")!;
+
+    // ── IsConcatSpreadable(E) (§23.1.3.1.1) ──────────────────────────────
+    // spv = Get(E, @@isConcatSpreadable); a null/undefined answer (which also
+    // covers every non-Object E, whose reflective read misses) falls back to
+    // IsArray(E), otherwise ToBoolean(spv).
+    fctx.body.push({ op: "local.get", index: src });
+    fctx.body.push({ op: "i32.const", value: SYMBOL_IS_CONCAT_SPREADABLE_ID });
+    fctx.body.push({ op: "call", funcIdx: boxSymbolIdx });
+    fctx.body.push({ op: "call", funcIdx: externGetIdx });
+    fctx.body.push({ op: "local.tee", index: spv });
+    fctx.body.push({ op: "ref.is_null" });
+    fctx.body.push({ op: "local.get", index: spv });
+    fctx.body.push({ op: "call", funcIdx: isUndefinedIdx });
+    fctx.body.push({ op: "i32.or" });
+    const toBool: Instr[] = [{ op: "local.get", index: spv }];
+    emitToBoolean(ctx, externref, toBool);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: i32 },
+      then: [
+        { op: "local.get", index: src },
+        { op: "call", funcIdx: isArrayIdx },
+      ],
+      else: toBool,
+    });
+    fctx.body.push({ op: "local.set", index: flag });
+
+    // ── Spreadable arm: append E's 0..ToLength(E.length) elements ─────────
+    const spreadArm: Instr[] = [
+      { op: "local.get", index: src },
+      { op: "call", funcIdx: externLenIdx },
+      { op: "local.set", index: lenF },
+      // step 5.c.iii — n + len > 2^53-1 ⇒ TypeError. Load-bearing beyond
+      // conformance: it is what keeps `length = Number.MAX_SAFE_INTEGER`
+      // (arg-length-exceeding-integer-limit.js) from entering a 2^31-iteration
+      // copy loop after the i32 truncation below.
+      { op: "local.get", index: total },
+      { op: "local.get", index: lenF },
+      { op: "f64.add" },
+      { op: "f64.const", value: MAX_SAFE_LENGTH },
+      { op: "f64.gt" },
+      { op: "if", blockType: { kind: "empty" }, then: overflowThrow },
+      { op: "local.get", index: total },
+      { op: "local.get", index: lenF },
+      { op: "f64.add" },
+      { op: "local.set", index: total },
+      { op: "local.get", index: lenF },
+      { op: "i32.trunc_sat_f64_s" },
+      { op: "local.set", index: len },
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: idx },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: idx },
+              { op: "local.get", index: len },
+              { op: "i32.ge_s" },
+              { op: "br_if", depth: 1 },
+              { op: "local.get", index: out },
+              { op: "local.get", index: src },
+              { op: "local.get", index: idx },
+              { op: "f64.convert_i32_s" },
+              { op: "call", funcIdx: getIdxIdx },
+              { op: "call", funcIdx: pushIdx },
+              { op: "local.get", index: idx },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: idx },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+    ];
+
+    // ── Non-spreadable arm: append E itself ──────────────────────────────
+    const singleArm: Instr[] = [
+      { op: "local.get", index: out },
+      { op: "local.get", index: src },
+      { op: "call", funcIdx: pushIdx },
+      { op: "local.get", index: total },
+      { op: "f64.const", value: 1 },
+      { op: "f64.add" },
+      { op: "local.set", index: total },
+    ];
+
+    fctx.body.push({ op: "local.get", index: flag });
+    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: spreadArm, else: singleArm });
+  }
+
+  fctx.body.push({ op: "local.get", index: out });
+  return { kind: "externref" };
+}

--- a/src/codegen/array-method-host.ts
+++ b/src/codegen/array-method-host.ts
@@ -49,3 +49,73 @@ export function compileArrayMethodExtern(
   );
   return externref;
 }
+
+/**
+ * The JS-host `arr.concat(arg…)` bridge for operands that are not statically
+ * known WasmGC arrays. Uses `__array_concat_any(receiver_ext, args_js_array)`,
+ * which:
+ * 1. Converts the WasmGC receiver to a real JS array via `__vec_len`/`__vec_get`
+ *    exports;
+ * 2. Calls `Array.prototype.concat` with all arguments (so the host owns
+ *    `Symbol.isConcatSpreadable`, species and hole semantics);
+ * 3. Returns the result as externref (a new JS Array).
+ *
+ * (#4446) Moved here from `array-methods.ts` UNCHANGED when the dynamic concat
+ * fallback became a per-target switch — this is the JS-host half; the host-free
+ * half is `array-concat-spec.ts` and `array-methods.ts` keeps only the dispatch.
+ * That the move is behaviour-neutral was measured, not assumed: compiling all
+ * 69 `built-ins/Array/prototype/concat` test262 files for the gc lane before
+ * and after yields byte-identical binaries (sha256 of `result.binary`, 69/69).
+ */
+export function compileArrayConcatExternHost(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+): ValType | null {
+  const arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+  const arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
+  // __array_concat_any(receiver: externref, args: externref) -> externref
+  // Converts WasmGC receiver to JS array, then calls .concat(...args)
+  const concatAnyIdx = ensureLateImport(
+    ctx,
+    "__array_concat_any",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+
+  if (arrNewIdx === undefined || arrPushIdx === undefined || concatAnyIdx === undefined) {
+    return null;
+  }
+
+  // Compile receiver as externref (WasmGC vec struct → extern ref), save to local
+  const recvLocal = allocLocal(fctx, `__cat_ext_recv_${fctx.locals.length}`, { kind: "externref" });
+  const recvType = compileExpression(ctx, fctx, propAccess.expression);
+  if (recvType && recvType.kind !== "externref") {
+    fctx.body.push({ op: "extern.convert_any" });
+  }
+  fctx.body.push({ op: "local.set", index: recvLocal });
+
+  // Build JS args array from all concat arguments
+  fctx.body.push({ op: "call", funcIdx: arrNewIdx });
+  const argsLocal = allocLocal(fctx, `__cat_ext_args_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: argsLocal });
+
+  for (const arg of callExpr.arguments) {
+    fctx.body.push({ op: "local.get", index: argsLocal });
+    const argType = compileExpression(ctx, fctx, arg, { kind: "externref" });
+    if (argType === null) {
+      fctx.body.push({ op: "ref.null.extern" });
+    } else if (argType.kind !== "externref") {
+      fctx.body.push({ op: "extern.convert_any" });
+    }
+    fctx.body.push({ op: "call", funcIdx: arrPushIdx });
+  }
+
+  // Call __array_concat_any(receiver_ext, args_array) -> externref JS array
+  fctx.body.push({ op: "local.get", index: recvLocal });
+  fctx.body.push({ op: "local.get", index: argsLocal });
+  fctx.body.push({ op: "call", funcIdx: concatAnyIdx });
+  return { kind: "externref" };
+}

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -75,7 +75,9 @@ import {
 import { staticIntegerRange } from "./analysis/static-numeric-range.js";
 import { tryEmitStaticI32Expression } from "./i32-static-range-expr.js";
 import { countedPushIndexOfUnroll, emitArrayIndexOfScan } from "./array-indexof-scan.js";
-import { compileArrayMethodExtern } from "./array-method-host.js";
+import { compileArrayConcatExternHost, compileArrayMethodExtern } from "./array-method-host.js";
+// (#4446) The §23.1.3.1 host-free concat loop for dynamic operands.
+import { compileArrayConcatNativeSpec } from "./array-concat-spec.js";
 import { emitFuncRefAsClosure } from "./closures/funcref-as-closure.js";
 
 // (#3264) Array.prototype-borrow subsystem extracted to array-prototype-borrow.ts;
@@ -3909,6 +3911,14 @@ function compileArrayConcatNativeDynamic(
   propAccess: ts.PropertyAccessExpression,
   callExpr: ts.CallExpression,
 ): ValType | null {
+  // (#4446) The spec loop subsumes this all-array-operands shortcut and is
+  // strictly more correct on it: the shortcut spreads EVERY operand
+  // unconditionally, which is wrong for an array carrying a falsy
+  // `@@isConcatSpreadable` (is-concat-spreadable-val-falsey/-val-undefined).
+  // Keep the original unconditional walk as the substrate-unavailable fallback.
+  const spec = compileArrayConcatNativeSpec(ctx, fctx, propAccess, callExpr);
+  if (spec !== undefined) return spec;
+
   const builders = ensureObjVecBuilders(ctx);
   const externLenIdx = ctx.funcMap.get("__extern_length");
   const externGetIdx = ctx.funcMap.get("__extern_get_idx");
@@ -4115,10 +4125,12 @@ function compileArrayConcat(
  * Fallback for arr.concat(arg...) when any arg is not a known WasmGC array type
  * (e.g. `any`, array-like with Symbol.isConcatSpreadable, or plain objects).
  *
- * Uses __array_concat_any(receiver_ext, args_js_array) host import, which:
- * 1. Converts the WasmGC receiver to a real JS array via __vec_len/__vec_get exports
- * 2. Calls Array.prototype.concat with all arguments (supports isConcatSpreadable)
- * 3. Returns the result as externref (a new JS Array)
+ * (#4446) Per-target switch. `native-first` (`--target standalone` /
+ * `--target wasi`) takes the Wasm-native §23.1.3.1 loop
+ * ({@link compileArrayConcatNativeSpec}); everything else keeps the unchanged
+ * `env::__array_concat_any` host bridge (`compileArrayConcatExternHost` in
+ * array-method-host.ts), whose `env::*` imports the #2961 leak guard rejects
+ * host-free.
  */
 function compileArrayConcatExtern(
   ctx: CodegenContext,
@@ -4126,51 +4138,11 @@ function compileArrayConcatExtern(
   propAccess: ts.PropertyAccessExpression,
   callExpr: ts.CallExpression,
 ): ValType | null {
-  const arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
-  const arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
-  // __array_concat_any(receiver: externref, args: externref) -> externref
-  // Converts WasmGC receiver to JS array, then calls .concat(...args)
-  const concatAnyIdx = ensureLateImport(
-    ctx,
-    "__array_concat_any",
-    [{ kind: "externref" }, { kind: "externref" }],
-    [{ kind: "externref" }],
-  );
-  flushLateImportShifts(ctx, fctx);
-
-  if (arrNewIdx === undefined || arrPushIdx === undefined || concatAnyIdx === undefined) {
-    return null;
+  if (ctx.targetProfile.semanticProviders === "native-first") {
+    const native = compileArrayConcatNativeSpec(ctx, fctx, propAccess, callExpr);
+    if (native !== undefined) return native;
   }
-
-  // Compile receiver as externref (WasmGC vec struct → extern ref), save to local
-  const recvLocal = allocLocal(fctx, `__cat_ext_recv_${fctx.locals.length}`, { kind: "externref" });
-  const recvType = compileExpression(ctx, fctx, propAccess.expression);
-  if (recvType && recvType.kind !== "externref") {
-    fctx.body.push({ op: "extern.convert_any" });
-  }
-  fctx.body.push({ op: "local.set", index: recvLocal });
-
-  // Build JS args array from all concat arguments
-  fctx.body.push({ op: "call", funcIdx: arrNewIdx });
-  const argsLocal = allocLocal(fctx, `__cat_ext_args_${fctx.locals.length}`, { kind: "externref" });
-  fctx.body.push({ op: "local.set", index: argsLocal });
-
-  for (const arg of callExpr.arguments) {
-    fctx.body.push({ op: "local.get", index: argsLocal });
-    const argType = compileExpression(ctx, fctx, arg, { kind: "externref" });
-    if (argType === null) {
-      fctx.body.push({ op: "ref.null.extern" });
-    } else if (argType.kind !== "externref") {
-      fctx.body.push({ op: "extern.convert_any" });
-    }
-    fctx.body.push({ op: "call", funcIdx: arrPushIdx });
-  }
-
-  // Call __array_concat_any(receiver_ext, args_array) -> externref JS array
-  fctx.body.push({ op: "local.get", index: recvLocal });
-  fctx.body.push({ op: "local.get", index: argsLocal });
-  fctx.body.push({ op: "call", funcIdx: concatAnyIdx });
-  return { kind: "externref" };
+  return compileArrayConcatExternHost(ctx, fctx, propAccess, callExpr);
 }
 
 /**

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -66,6 +66,8 @@ import { emitObjectProtoOrRefusal as emitProtoMemberBodyRefusal } from "./object
 import { emitStringConcatMemberBody } from "./string-proto-concat.js";
 import { emitStringSubstringMemberBody } from "./string-proto-substring.js";
 import { emitStringSplitMemberBody } from "./string-proto-split.js"; // (#4220) reflective String.prototype.split
+import { htmlWrapperFor } from "./html-wrapper-native.js"; // (#4445) Annex B §B.2.3 tag table
+import { emitStringHtmlWrapperMemberBody } from "./string-proto-html.js"; // (#4445) reflective HTML wrappers
 import { emitStringMatchSearchMemberBody } from "./string-proto-match-search.js"; // (#4439) reflective match/search
 import { emitStringReplaceMemberBody } from "./string-proto-replace-transfer.js"; // (#4232) reflective String.prototype.replace
 import { NO_ARG_STRING_MEMBER_HELPER, emitStringProtoToStringFlat } from "./string-proto-tostring.js"; // (#3992)
@@ -187,20 +189,30 @@ const DATE_PROTO_METHODS = [
  * `String.prototype`'s own method names (ES2024 §22.1.3). `@@iterator` is a
  * well-known-symbol member resolved via the computed-access path, so only the
  * string members go in the CSV (same convention as `ARRAY_PROTO_METHODS`).
- * Annex-B (`substr`, `anchor`, `big`, …) is included so a bare
- * `String.prototype.substr` value read resolves host-free.
+ * Annex-B (`substr`, and since #4445 the 13 §B.2.3 HTML wrappers) is included so
+ * a bare `String.prototype.substr` / `String.prototype.anchor` value read
+ * resolves host-free.
  */
 const STRING_PROTO_METHODS = [
+  "anchor",
   "at",
+  "big",
+  "blink",
+  "bold",
   "charAt",
   "charCodeAt",
   "codePointAt",
   "concat",
   "endsWith",
+  "fixed",
+  "fontcolor",
+  "fontsize",
   "includes",
   "indexOf",
   "isWellFormed",
+  "italics",
   "lastIndexOf",
+  "link",
   "localeCompare",
   "match",
   "matchAll",
@@ -212,10 +224,14 @@ const STRING_PROTO_METHODS = [
   "replaceAll",
   "search",
   "slice",
+  "small",
   "split",
   "startsWith",
+  "strike",
+  "sub",
   "substr",
   "substring",
+  "sup",
   "toLocaleLowerCase",
   "toLocaleUpperCase",
   "toLowerCase",
@@ -503,6 +519,20 @@ const PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = Object.assign(
     trimStart: 0,
     isWellFormed: 0,
     toWellFormed: 0,
+    // (#4445) Annex B §B.2.3 HTML wrappers. `fn.length` is 1 for the four that
+    // take an attribute value (anchor/link/fontcolor/fontsize — the shared
+    // default already), 0 for the nine tag-only ones; the 0s are load-bearing,
+    // since the arity also sizes the closure's param slots and a spurious slot
+    // would make the body read an arg that was never declared.
+    big: 0,
+    blink: 0,
+    bold: 0,
+    fixed: 0,
+    italics: 0,
+    small: 0,
+    strike: 0,
+    sub: 0,
+    sup: 0,
     // Date.prototype set* arities (ES2024 §21.4.4) that differ from the default 1.
     setFullYear: 3,
     setUTCFullYear: 3,
@@ -939,6 +969,18 @@ function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, m
   // shape, so it shares this body rather than getting a fourth per-member
   // clone — see NO_ARG_STRING_MEMBER_HELPER in string-proto-tostring.ts.
   if (NO_ARG_STRING_MEMBER_HELPER[member] !== undefined) return emitStringTrimMemberBody(ctx, fctx, member);
+  // (#4445) The 13 Annex B §B.2.3 HTML wrappers. Their DIRECT call sites were
+  // already native since #3069; this is the value-erased shape
+  // (`String.prototype.anchor.call(x, v)`) that reached the refusal instead.
+  // Routed after the trim family because the nine tag-only members share its
+  // arity-0 closure shape but not its single-helper body.
+  if (htmlWrapperFor(member) !== undefined) {
+    ensureStringRocUndefinedNative(ctx, fctx); // register the undefined-sentinel predicate first
+    return (
+      emitStringHtmlWrapperMemberBody(ctx, fctx, member, () => emitStringRequireObjectCoercible(ctx, fctx, member)) ??
+      emitProtoMemberBodyRefusal(ctx, fctx, "String", member)
+    );
+  }
   if (member === "charAt") {
     return emitTransferredCharAtProtoMemberBody(
       ctx,

--- a/src/codegen/html-wrapper-native.ts
+++ b/src/codegen/html-wrapper-native.ts
@@ -26,6 +26,47 @@ import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3
 const i32: ValType = { kind: "i32" };
 
 /**
+ * (#3069) Annex B §B.2.3 legacy HTML string-wrapper method → HTML tag +
+ * optional attribute name (ECMA-262 §B.2.3.2..§B.2.3.14). `String.prototype`
+ * `bold`→`<b>`, `italics`→`<i>`, `anchor(name)`→`<a name="…">`,
+ * `link(url)`→`<a href="…">`, `fontcolor(c)`/`fontsize(s)`→`<font color/size="…">`,
+ * etc. Methods with an `attribute` take one argument (the attribute VALUE,
+ * `"`→`&quot;` escaped); the rest take none — which is also their spec
+ * `fn.length` (§B.2.3.2.1 CreateHTML's `attribute` operand).
+ *
+ * Two consumers, one table (#4445): the DIRECT call-site arm in
+ * `compileNativeStringMethodCall` (string-ops.ts) and the REFLECTIVE closure
+ * body in `string-proto-html.ts`.
+ */
+const HTML_WRAPPER_TAGS: Readonly<Record<string, { tag: string; attribute?: string }>> = {
+  anchor: { tag: "a", attribute: "name" },
+  big: { tag: "big" },
+  blink: { tag: "blink" },
+  bold: { tag: "b" },
+  fixed: { tag: "tt" },
+  fontcolor: { tag: "font", attribute: "color" },
+  fontsize: { tag: "font", attribute: "size" },
+  italics: { tag: "i" },
+  link: { tag: "a", attribute: "href" },
+  small: { tag: "small" },
+  strike: { tag: "strike" },
+  sub: { tag: "sub" },
+  sup: { tag: "sup" },
+};
+
+/**
+ * The §B.2.3 descriptor for `method`, or `undefined` when it is not one of the
+ * 13. The OWN-property check is load-bearing, not defensive style: both callers
+ * dispatch on arbitrary `String.prototype` member names, and a bare
+ * `HTML_WRAPPER_TAGS[member]` answers `Object.prototype.toString` (a truthy
+ * function) for `member === "toString"` — which would destructure to
+ * `tag === undefined` and emit a silently wrong `<undefined>x</undefined>`.
+ */
+export function htmlWrapperFor(method: string): { tag: string; attribute?: string } | undefined {
+  return Object.prototype.hasOwnProperty.call(HTML_WRAPPER_TAGS, method) ? HTML_WRAPPER_TAGS[method] : undefined;
+}
+
+/**
  * Ensure `__str_html_escape_quot(s: ref $AnyString) -> ref $NativeString` is
  * emitted (idempotent). It returns a copy of `s` with every `"` (U+0022) code
  * unit replaced by the six code units `&quot;` — the exact CreateHTML step-4.b

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -292,6 +292,14 @@ interface UserCarrierDeps {
   sgetValueIdx?: number;
   /** `__sget_done(externref) -> externref` (emitStructFieldGetters). Optional — see sgetValueIdx. */
   sgetDoneIdx?: number;
+  /**
+   * (#4447) True when `__sget_done` really has the extern signature
+   * `(externref) -> externref`. A getter's RESULT type follows the FIELD type,
+   * so a module whose `done` field is numeric emits `(externref) -> f64`,
+   * which cannot feed `__is_truthy`. Only a `true` here licenses reading
+   * `done` WITHOUT `__sget_value` (the `{ done: … }`-only IteratorResult arm).
+   */
+  sgetDoneIsExtern?: boolean;
   /** `__is_truthy(externref) -> i32` (ToBoolean on the boxed `done` flag). */
   isTruthyIdx: number;
   /**
@@ -330,6 +338,9 @@ interface ObjCarrierDeps {
   sgetValueIdx?: number;
   /** `__sget_done(externref) -> externref` — see `sgetValueIdx`. */
   sgetDoneIdx?: number;
+  /** (#4447) `__sget_done` really is `(externref) -> externref` — see the twin
+   *  field on `UserCarrierDeps`. */
+  sgetDoneIsExtern?: boolean;
   /** `__sget_next(externref) -> externref` — the ITERATOR OBJECT itself often
    *  pre-shapes into a closed struct (`{ next: function () {…} }` literal with
    *  a field-stored closure, #3117), so the `next` read needs the field getter
@@ -1141,6 +1152,37 @@ export function ensureNativeExternSlice(ctx: CodegenContext): number | undefined
 }
 
 /**
+ * (#4447) Resolve a `__sget_<field>` getter ONLY when it actually has the
+ * extern signature `(externref) -> externref`.
+ *
+ * A field getter's RESULT type follows the FIELD's type, so a module whose
+ * `done` field is numeric emits `__sget_done : (externref) -> f64`. The
+ * iterator-result arms feed that value straight into `__is_truthy`
+ * (`(externref) -> i32`), which is invalid Wasm. Before #4447 the mismatch was
+ * masked: the arm was emitted only when `__sget_value` ALSO existed, and those
+ * modules happened to have an externref `done`. Making the two getters
+ * independent (so a conformant `{ done: … }`-only IteratorResult reports its
+ * real `done`) exposed it — `Iterator.from([1,2,3])` produced
+ * "call[0] expected type externref, found block of type f64" in
+ * `__iterator_next`. A non-extern getter answers `undefined` here, which keeps
+ * the new done-only arm off and leaves the existing degrade in place.
+ *
+ * This gate is ADDITIVE: the pre-existing both-getters-present path is not
+ * routed through it, so modules that compiled before are byte-identical.
+ */
+function externSgetIdx(ctx: CodegenContext, name: string): number | undefined {
+  const idx = ctx.funcMap.get(name);
+  if (idx === undefined) return undefined;
+  const fn = definedFuncAt(ctx, idx);
+  if (!fn) return undefined;
+  const t = ctx.mod.types[fn.typeIdx];
+  if (!t || t.kind !== "func") return undefined;
+  if (t.params.length !== 1 || t.params[0]?.kind !== "externref") return undefined;
+  if (t.results.length !== 1 || t.results[0]?.kind !== "externref") return undefined;
+  return idx;
+}
+
+/**
  * (#2038 / #3100, reserve-then-fill #1719) Rebuild the `__iterator` (and, with
  * USER deps, `__iterator_next`) bodies with the LATE ladder arms at finalize:
  *
@@ -1173,6 +1215,9 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
   const callNextIdx = ctx.funcMap.get("__call_next");
   const sgetValueIdx = ctx.funcMap.get("__sget_value");
   const sgetDoneIdx = ctx.funcMap.get("__sget_done");
+  // (#4447) Only gates the NEW `{ done }`-only arm; the pre-existing
+  // both-getters-present path is untouched (byte-identical).
+  const sgetDoneIsExtern = externSgetIdx(ctx, "__sget_done") !== undefined;
   const isTruthyIdx = ctx.funcMap.get("__is_truthy");
   const deps: UserCarrierDeps | undefined =
     callNextIdx === undefined || isTruthyIdx === undefined
@@ -1189,6 +1234,7 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
           callNextIdx,
           sgetValueIdx,
           sgetDoneIdx,
+          sgetDoneIsExtern,
           isTruthyIdx,
           // (#3100 S5) optional — only when some struct has a `return` method.
           callReturnIdx: ctx.funcMap.get("__call_return"),
@@ -1224,6 +1270,7 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
         applyClosureIdx: reserveApplyClosure(ctx),
         sgetValueIdx: ctx.funcMap.get("__sget_value"),
         sgetDoneIdx: ctx.funcMap.get("__sget_done"),
+        sgetDoneIsExtern,
         sgetNextIdx: ctx.funcMap.get("__sget_next"),
         sgetReturnIdx: ctx.funcMap.get("__sget_return"),
         keyInstrs: (name: string) => [...nativeStringLiteralInstrs(ctx, name), { op: "extern.convert_any" }],
@@ -2414,10 +2461,21 @@ function buildIteratorNextBody(
           { op: "local.set", index: 5 },
         ];
         // res is a closed struct (`{value, done}` literal pre-shape) → the
-        // #2038 field getters. Without them a non-`$Object` res is unreadable:
-        // report done (terminate) rather than spin.
+        // #2038 field getters. Without `__sget_done` a non-`$Object` res is
+        // unreadable: report done (terminate) rather than spin.
+        //
+        // (#4447) `__sget_value` is read INDEPENDENTLY of `__sget_done`. A
+        // conformant iterator may return `{ done: … }` with no `value` property
+        // at all (§7.4.4 IteratorValue then answers `undefined`) — test262's
+        // `for-of/dstr/array-elem-trlg-iter-*` iterators do exactly that. No
+        // struct in such a module carries a `value` field, so `__sget_value`
+        // is never emitted; the old conjunction then fell to the
+        // `done := 1` degrade and reported the iterator EXHAUSTED on its first
+        // step. That silently skipped IteratorClose (the drain breaks on the
+        // done-branch, §7.4.9 closes only on a non-done stop) and made
+        // `nextCount`/`returnCount` observably wrong.
         const readStructArm: Instr[] =
-          od.sgetDoneIdx !== undefined && od.sgetValueIdx !== undefined
+          od.sgetDoneIdx !== undefined && (od.sgetValueIdx !== undefined || od.sgetDoneIsExtern === true)
             ? [
                 { op: "local.get", index: 6 },
                 { op: "call", funcIdx: od.sgetDoneIdx },
@@ -2428,10 +2486,13 @@ function buildIteratorNextBody(
                   op: "if",
                   blockType: { kind: "val", type: { kind: "externref" } },
                   then: od.missInstrs(),
-                  else: [
-                    { op: "local.get", index: 6 },
-                    { op: "call", funcIdx: od.sgetValueIdx },
-                  ],
+                  else:
+                    od.sgetValueIdx !== undefined
+                      ? [
+                          { op: "local.get", index: 6 },
+                          { op: "call", funcIdx: od.sgetValueIdx },
+                        ]
+                      : od.missInstrs(),
                 },
                 { op: "local.set", index: 5 },
               ]
@@ -2744,8 +2805,13 @@ function buildIteratorNextBody(
   // NO `{value, done}`-shaped closed struct at all, `__sget_value`/`__sget_done`
   // were never emitted (now optional in the deps) — a closed result then
   // reports done=1 rather than spinning, mirroring the OBJ arm's fallback.
+  // (#4447) `__sget_value` is read INDEPENDENTLY of `__sget_done` — see the
+  // twin note on the OBJ arm's `readStructArm`. A `{ done: … }`-only result
+  // (no `value` property anywhere in the module ⇒ no `__sget_value`) must
+  // report the REAL `done`, not the done=1 degrade, or the drain terminates
+  // on step 1 and skips IteratorClose.
   const userReadStructArm: Instr[] =
-    deps.sgetDoneIdx !== undefined && deps.sgetValueIdx !== undefined
+    deps.sgetDoneIdx !== undefined && (deps.sgetValueIdx !== undefined || deps.sgetDoneIsExtern === true)
       ? [
           { op: "local.get", index: 6 },
           { op: "call", funcIdx: deps.sgetDoneIdx },
@@ -2756,10 +2822,13 @@ function buildIteratorNextBody(
             op: "if",
             blockType: { kind: "val", type: { kind: "externref" } },
             then: [{ op: "ref.null.extern" }],
-            else: [
-              { op: "local.get", index: 6 },
-              { op: "call", funcIdx: deps.sgetValueIdx },
-            ],
+            else:
+              deps.sgetValueIdx !== undefined
+                ? [
+                    { op: "local.get", index: 6 },
+                    { op: "call", funcIdx: deps.sgetValueIdx },
+                  ]
+                : [{ op: "ref.null.extern" }],
           },
           { op: "local.set", index: 5 },
         ]

--- a/src/codegen/statements/for-of-destructuring.ts
+++ b/src/codegen/statements/for-of-destructuring.ts
@@ -20,6 +20,7 @@ import {
   emitExternrefDestructureGuard,
   emitNativeObjectRest,
   emitObjectPatternRestFromVec,
+  patternIteratorStepCount,
 } from "../destructuring-params.js";
 import { emitAssignToTarget, isStrictContext } from "../expressions/assignment.js";
 import { findUnresolvableInArrayPattern, findUnresolvableInObjectPattern } from "../expressions/unresolvable-assign.js";
@@ -83,6 +84,34 @@ function emitGlobalSyncWriteback(
     }
     fctx.body.push({ op: "global.set", index: syncGlobalIdx });
   }
+}
+
+/**
+ * (#4447) Re-resolve a module global's ABSOLUTE index at write time, then emit
+ * the sync writeback.
+ *
+ * A module global's absolute index shifts every time a string-constant IMPORT
+ * global is added (`addStringConstantGlobal` → `fixupModuleGlobalIndices`,
+ * which re-maps `ctx.moduleGlobals` and every already-emitted `global.get/set`
+ * — but obviously not an index a caller stashed in a local variable). Between
+ * resolving the target and emitting its writeback these paths now register a
+ * property-name constant and/or compile a default initializer, either of which
+ * can import a string constant. A stale index then lands in the IMPORT range:
+ * "immutable global #N cannot be assigned" (reproduced on
+ * `for ({ x: a = 11 } of [{}])` in the JS-host lane).
+ *
+ * `hadGlobal` preserves the caller's decision that this target IS a module
+ * global (a name absent from `ctx.moduleGlobals` must stay unsynced).
+ */
+function emitGlobalSyncWritebackByName(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  targetLocal: number,
+  targetName: string,
+  hadGlobal: boolean,
+): void {
+  if (!hadGlobal) return;
+  emitGlobalSyncWriteback(ctx, fctx, targetLocal, ctx.moduleGlobals.get(targetName));
 }
 
 export function compileForOfDestructuring(
@@ -739,6 +768,39 @@ function emitBoxedForOfAssignStore(
   fctx.body.push({ op: "struct.set", typeIdx: boxedCap.refCellTypeIdx, fieldIdx: 0 });
 }
 
+/** True when an assignment pattern binds at least one target. */
+function assignPatternIsNonEmpty(pattern: ts.ObjectLiteralExpression | ts.ArrayLiteralExpression): boolean {
+  return ts.isObjectLiteralExpression(pattern) ? pattern.properties.length > 0 : pattern.elements.length > 0;
+}
+
+/**
+ * (#4447) Destructure a NESTED assignment pattern out of an externref value
+ * already sitting in `valueLocal`.
+ *
+ * §13.15.5.4/§13.15.5.5 recurse into a nested pattern through the same
+ * DestructuringAssignmentEvaluation as the top level, so the nested value gets
+ * its own RequireObjectCoercible/GetIterator — `for ({ x: { y } } of [{}])`
+ * must throw TypeError, not silently bind `undefined`. Array patterns route to
+ * the externref array path (which performs the #4447 GetIterator
+ * materialisation); object patterns route to the extern-get property path.
+ */
+function destructureNestedExternrefPattern(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  pattern: ts.ObjectLiteralExpression | ts.ArrayLiteralExpression,
+  valueLocal: number,
+  stmt: ts.ForOfStatement,
+): void {
+  if (assignPatternIsNonEmpty(pattern)) {
+    emitExternrefDestructureGuard(ctx, fctx, valueLocal);
+  }
+  if (ts.isArrayLiteralExpression(pattern)) {
+    compileForOfAssignDestructuringExternref(ctx, fctx, pattern, valueLocal, stmt);
+  } else {
+    compileForOfIteratorAssignDestructuring(ctx, fctx, pattern, valueLocal, stmt);
+  }
+}
+
 export function compileForOfAssignDestructuring(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -769,6 +831,16 @@ export function compileForOfAssignDestructuring(
       // through a non-empty object pattern must throw TypeError (#1225).
       if (elemType.kind === "externref" && expr.properties.length > 0) {
         emitExternrefDestructureGuard(ctx, fctx, elemLocal);
+        // (#4447) An externref element is a REAL object at runtime — an empty
+        // object literal `[{}]`, an `any`-typed source, a boxed value. The
+        // default-only loop below never READ a property, so
+        // `for ({ x: t = d } of [{}])` dropped the write entirely (the target
+        // resolved to the KEY name, and only shorthand defaults were seen), and
+        // a shorthand default fired UNCONDITIONALLY even when the property was
+        // present. Route to the extern-get path, which does the real
+        // `__extern_get` read plus §13.15.5.4 undefined-only defaulting.
+        compileForOfIteratorAssignDestructuring(ctx, fctx, expr, elemLocal, stmt);
+        return;
       }
       // Primitives (bool, number, string) are object-coercible in JS.
       // Empty destructuring `for ({} of [val])` is a no-op — just iterate.
@@ -830,15 +902,111 @@ export function compileForOfAssignDestructuring(
         propName = resolveComputedKeyExpression(ctx, prop.name.expression);
       }
       if (!propName) continue; // skip truly unresolvable computed property names
-      const targetName = ts.isShorthandPropertyAssignment(prop)
-        ? prop.name.text
-        : ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.initializer)
-          ? prop.initializer.text
-          : propName;
+
+      // (#4447) Split the property's VALUE position into (target, default).
+      // §13.15.5.4 ObjectAssignmentPattern: `{ k: t = d }` parses as a
+      // PropertyAssignment whose initializer is the AssignmentExpression
+      // `t = d`, and `{ k = d }` as a ShorthandPropertyAssignment carrying an
+      // `objectAssignmentInitializer`. Before this, neither shape was
+      // recognised here: `targetName` fell through to `propName` (so
+      // `for ({y: b = 22} of [{y: 5}])` wrote a variable named `y`, not `b`)
+      // and the default was dropped entirely.
+      const targetExpr: ts.Expression = ts.isShorthandPropertyAssignment(prop)
+        ? prop.name
+        : ts.isBinaryExpression(prop.initializer) && prop.initializer.operatorToken.kind === ts.SyntaxKind.EqualsToken
+          ? prop.initializer.left
+          : prop.initializer;
+      const defaultInit: ts.Expression | undefined = ts.isShorthandPropertyAssignment(prop)
+        ? prop.objectAssignmentInitializer
+        : ts.isBinaryExpression(prop.initializer) && prop.initializer.operatorToken.kind === ts.SyntaxKind.EqualsToken
+          ? prop.initializer.right
+          : undefined;
+      const targetName = ts.isIdentifier(targetExpr) ? targetExpr.text : propName;
 
       const fieldIdx = fields.findIndex((f) => f.name === propName);
+      const isMemberTarget = ts.isPropertyAccessExpression(targetExpr) || ts.isElementAccessExpression(targetExpr);
+      const isNestedPattern = ts.isObjectLiteralExpression(targetExpr) || ts.isArrayLiteralExpression(targetExpr);
       if (fieldIdx === -1) {
+        // (#4447) The property is ABSENT ⇒ the read is `undefined`. A nested
+        // pattern must then RequireObjectCoercible/GetIterator on `undefined`
+        // and throw TypeError (§13.15.5.4 step 3 → §13.15.5.2) — that is the
+        // `obj-prop-nested-{obj,array}-undefined` family, which previously
+        // bound nothing and threw nothing. A default initializer, if present,
+        // fires first and the nested pattern destructures ITS value instead.
+        if (isNestedPattern) {
+          const nestedLocal = allocLocal(fctx, `__forof_objnestmiss_${fctx.locals.length}`, { kind: "externref" });
+          if (defaultInit) {
+            const instrs = collectInstrs(fctx, () => {
+              const dt = compileExpression(ctx, fctx, defaultInit, { kind: "externref" });
+              if (dt && dt.kind !== "externref") coerceType(ctx, fctx, dt, { kind: "externref" });
+              fctx.body.push({ op: "local.set", index: nestedLocal });
+            });
+            fctx.body.push(...instrs);
+          } else {
+            fctx.body.push({ op: "ref.null.extern" });
+            fctx.body.push({ op: "local.set", index: nestedLocal });
+          }
+          destructureNestedExternrefPattern(ctx, fctx, targetExpr, nestedLocal, stmt);
+          continue;
+        }
+        // The read is `undefined` ⇒ a default initializer, if any, MUST fire
+        // (§13.15.5.4 KeyedDestructuringAssignmentEvaluation step 4). Only a
+        // default-less miss is a genuine silent drop.
+        if (defaultInit && !isMemberTarget) {
+          let missLocal = fctx.localMap.get(targetName);
+          let missSyncGlobalIdx: number | undefined;
+          if (missLocal === undefined) {
+            const globalIdx = ctx.moduleGlobals.get(targetName);
+            if (globalIdx !== undefined) {
+              const globalDef = ctx.mod.globals[localGlobalIdx(ctx, globalIdx)];
+              const globalType = globalDef?.type ?? { kind: "externref" as const };
+              missLocal = allocLocal(fctx, targetName, globalType);
+              missSyncGlobalIdx = globalIdx;
+            }
+          }
+          if (missLocal !== undefined) {
+            const boxedCapMiss = fctx.boxedCaptures?.get(targetName);
+            const missType = boxedCapMiss ? boxedCapMiss.valType : (getLocalType(fctx, missLocal) ?? undefined);
+            const instrs = collectInstrs(fctx, () => {
+              const dfltType = compileExpression(ctx, fctx, defaultInit, missType ?? { kind: "externref" });
+              if (boxedCapMiss) {
+                emitBoxedForOfAssignStore(ctx, fctx, missLocal!, dfltType ?? boxedCapMiss.valType, boxedCapMiss);
+              } else {
+                if (dfltType && missType && !valTypesMatch(dfltType, missType)) {
+                  coerceType(ctx, fctx, dfltType, missType);
+                }
+                fctx.body.push({ op: "local.set", index: missLocal! });
+              }
+            });
+            fctx.body.push(...instrs);
+            if (!boxedCapMiss) {
+              emitGlobalSyncWritebackByName(ctx, fctx, missLocal, targetName, missSyncGlobalIdx !== undefined);
+            }
+            continue;
+          }
+        }
         reportSilentFallback(ctx, "lookup-miss-skip", "loops:forof-assign-destructure-field-miss", prop);
+        continue;
+      }
+
+      // (#4447) Nested pattern in the value position — `for ({ x: { y } } of …)`
+      // / `for ({ x: [y] } of …)`. Extract the field (applying any default),
+      // then recurse through the top-level dispatcher so the nested value gets
+      // its own RequireObjectCoercible / GetIterator. Previously `targetName`
+      // degraded to the KEY and the nested targets were never written.
+      if (isNestedPattern) {
+        const fieldEntryN = fields[fieldIdx];
+        if (!fieldEntryN) continue;
+        const fieldTypeN = fieldEntryN.type;
+        const nestedLocal = allocLocal(fctx, `__forof_objnested_${fctx.locals.length}`, fieldTypeN);
+        fctx.body.push({ op: "local.get", index: elemLocal });
+        fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx });
+        if (defaultInit) {
+          emitDefaultValueCheck(ctx, fctx, fieldTypeN, nestedLocal, defaultInit, fieldTypeN, true);
+        } else {
+          fctx.body.push({ op: "local.set", index: nestedLocal });
+        }
+        compileForOfAssignDestructuring(ctx, fctx, targetExpr, nestedLocal, fieldTypeN, vecTypeIdx, arrTypeIdx, stmt);
         continue;
       }
 
@@ -848,18 +1016,19 @@ export function compileForOfAssignDestructuring(
       // route through emitAssignToTarget → the #2664 member-set dispatcher. This
       // emits into the LIVE loop body, so there is no detached-buffer funcIdx
       // repoint hazard (unlike the assignment-expression path).
-      if (
-        ts.isPropertyAssignment(prop) &&
-        (ts.isPropertyAccessExpression(prop.initializer) || ts.isElementAccessExpression(prop.initializer))
-      ) {
+      if (isMemberTarget) {
         const fieldEntryM = fields[fieldIdx];
         if (!fieldEntryM) continue;
         const fieldTypeM = fieldEntryM.type;
         const tmpV = allocLocal(fctx, `__forof_objmemtgt_${fctx.locals.length}`, fieldTypeM);
         fctx.body.push({ op: "local.get", index: elemLocal });
         fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx });
-        fctx.body.push({ op: "local.set", index: tmpV });
-        emitAssignToTarget(ctx, fctx, prop.initializer, tmpV, fieldTypeM);
+        if (defaultInit) {
+          emitDefaultValueCheck(ctx, fctx, fieldTypeM, tmpV, defaultInit, fieldTypeM, true);
+        } else {
+          fctx.body.push({ op: "local.set", index: tmpV });
+        }
+        emitAssignToTarget(ctx, fctx, targetExpr, tmpV, fieldTypeM);
         continue;
       }
 
@@ -877,6 +1046,28 @@ export function compileForOfAssignDestructuring(
       const fieldEntry2 = fields[fieldIdx];
       if (!fieldEntry2) continue;
       const fieldType = fieldEntry2.type;
+
+      // (#4447) Present field WITH a default: fire the initializer only when
+      // the read is `undefined` (object-property semantics — a genuine `null`
+      // does NOT trigger it, §13.15.5.4 / #1550).
+      if (defaultInit) {
+        const boxedCapDflt = fctx.boxedCaptures?.get(targetName);
+        if (boxedCapDflt) {
+          const dfltTmp = allocLocal(fctx, `__forof_objdflt_${fctx.locals.length}`, fieldType);
+          fctx.body.push({ op: "local.get", index: elemLocal });
+          fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx });
+          emitDefaultValueCheck(ctx, fctx, fieldType, dfltTmp, defaultInit, fieldType, true);
+          fctx.body.push({ op: "local.get", index: dfltTmp });
+          emitBoxedForOfAssignStore(ctx, fctx, targetLocal, fieldType, boxedCapDflt);
+          continue;
+        }
+        const targetTypeD = getLocalType(fctx, targetLocal);
+        fctx.body.push({ op: "local.get", index: elemLocal });
+        fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx });
+        emitDefaultValueCheck(ctx, fctx, fieldType, targetLocal, defaultInit, targetTypeD ?? undefined, true);
+        emitGlobalSyncWritebackByName(ctx, fctx, targetLocal, targetName, targetSyncGlobalIdx !== undefined);
+        continue;
+      }
       // (#2692) Box-aware write: when `targetName` is a closure-captured-mutable
       // var, `targetLocal` is the ref-cell-ref local (now the common case since
       // #2692 boxes such vars eagerly at function-top). A plain
@@ -917,7 +1108,7 @@ export function compileForOfAssignDestructuring(
         if (expr.elements.length > 0) {
           emitExternrefDestructureGuard(ctx, fctx, elemLocal);
         }
-        compileForOfAssignDestructuringExternref(ctx, fctx, expr, elemLocal);
+        compileForOfAssignDestructuringExternref(ctx, fctx, expr, elemLocal, stmt);
       }
       return;
     }
@@ -984,7 +1175,7 @@ export function compileForOfAssignDestructuring(
           // slice (a JS array host / native array standalone), then PutValue it.
           fctx.body.push({ op: "local.get", index: elemLocal });
           fctx.body.push({ op: "extern.convert_any" });
-          emitForOfRestAssignment(ctx, fctx, el, i, (name) => ctx.moduleGlobals.get(name));
+          emitForOfRestAssignment(ctx, fctx, el, i, (name) => ctx.moduleGlobals.get(name), stmt);
           continue;
         }
 
@@ -1393,8 +1584,38 @@ function emitForOfRestAssignment(
   spread: ts.SpreadElement,
   restStartIndex: number,
   syncGlobalForName: (name: string) => number | undefined,
+  /** (#4447) Enclosing for-of — needed to recurse into a nested rest target. */
+  stmtForNested?: ts.ForOfStatement,
 ): boolean {
   const restTarget = spread.expression;
+
+  // (#4447) NESTED rest target — `for ([...{ 1: x }] of …)` / `for ([...[y]] of …)`.
+  // §13.15.5.5 AssignmentRestElement PutValue's the remainder into an
+  // AssignmentPattern just like any other target, so slice first and then
+  // destructure the slice. Previously any non-identifier rest target dropped
+  // the source and bound nothing.
+  if (
+    stmtForNested !== undefined &&
+    (ts.isObjectLiteralExpression(restTarget) || ts.isArrayLiteralExpression(restTarget))
+  ) {
+    let nestedSliceIdx = ctx.funcMap.get("__extern_slice");
+    if (nestedSliceIdx === undefined) {
+      ensureLateImport(ctx, "__extern_slice", [{ kind: "externref" }, { kind: "f64" }], [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, fctx);
+      nestedSliceIdx = ctx.funcMap.get("__extern_slice");
+    }
+    if (nestedSliceIdx === undefined) {
+      fctx.body.push({ op: "drop" });
+      return true;
+    }
+    const nestedRestLocal = allocLocal(fctx, `__forof_restnested_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "f64.const", value: restStartIndex });
+    fctx.body.push({ op: "call", funcIdx: nestedSliceIdx });
+    fctx.body.push({ op: "local.set", index: nestedRestLocal });
+    destructureNestedExternrefPattern(ctx, fctx, restTarget, nestedRestLocal, stmtForNested);
+    return true;
+  }
+
   // Pop the source externref the caller pushed — we only need it when the target
   // resolves; for an unhandled target shape, drop it to keep the stack balanced.
   if (!ts.isIdentifier(restTarget)) {
@@ -1576,32 +1797,88 @@ function emitVecRestAssignment(
 /**
  * Handle assignment destructuring of externref arrays in for-of.
  * Uses __extern_get(elem, box(i)) for each element, with default value support.
+ *
+ * (#4447) The element is first normalised through `__array_from_iter_n` —
+ * §13.15.5.2 ArrayAssignmentPattern performs GetIterator(value) and steps the
+ * iterator once per element, then IteratorCloses when the pattern did not
+ * exhaust it. Reading `elem[i]` directly (what this did before) never touches
+ * `@@iterator`/`next`/`return`, so a for-of head assigning FROM a user iterable
+ * (`for ([x,] of [iterable])`) observed zero `next()` calls and zero
+ * `return()` calls. This mirrors the plain assignment-destructuring path in
+ * `expressions/assignment.ts` (#1454/#1592/#3100 S4) exactly: bounded step
+ * count from the pattern, `-1` (unbounded drain) when a rest element is
+ * present, and carrier-aware `__extern_get_idx` reads on standalone/WASI.
+ * Plain arrays with the default `@@iterator` keep the indexed fast path inside
+ * the helper, so array sources stay byte-equivalent.
  */
 function compileForOfAssignDestructuringExternref(
   ctx: CodegenContext,
   fctx: FunctionContext,
   expr: ts.ArrayLiteralExpression,
   elemLocal: number,
+  /** (#4447) Enclosing for-of — needed to recurse into nested patterns. */
+  stmtForNested: ts.ForOfStatement,
 ): void {
-  // Ensure __extern_get is available (#1866: ensureLateImport routes to the
+  // (#4447) GetIterator materialisation — must run BEFORE the readers are
+  // resolved, since `ensureLateImport` can shift function indices.
+  let srcLocal = elemLocal;
+  if (expr.elements.length > 0) {
+    const matStepCount = patternIteratorStepCount(expr.elements);
+    const matIterIdx = ensureLateImport(
+      ctx,
+      "__array_from_iter_n",
+      [{ kind: "externref" }, { kind: "f64" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    if (matIterIdx !== undefined) {
+      const matLocal = allocLocal(fctx, `__forof_dstr_mat_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.get", index: elemLocal });
+      fctx.body.push({ op: "f64.const", value: matStepCount });
+      fctx.body.push({ op: "call", funcIdx: matIterIdx });
+      fctx.body.push({ op: "local.set", index: matLocal });
+      srcLocal = matLocal;
+    }
+  }
+
+  // (#3100 S4) Standalone/WASI element reads use the carrier-aware native
+  // `__extern_get_idx(src, f64 i)` — the native `__extern_get` is string-keyed
+  // and misses the `$Vec` carrier `__array_from_iter_n` produces. Host mode
+  // keeps `__extern_get` + `__box_number` (byte-identical to pre-#4447).
+  const useIdxReads = ctx.standalone || ctx.wasi;
+  const readName = useIdxReads ? "__extern_get_idx" : "__extern_get";
+  const readKeyType: ValType = useIdxReads ? { kind: "f64" } : { kind: "externref" };
+  // Ensure the reader is available (#1866: ensureLateImport routes to the
   // native object-runtime impl under --target standalone — no leaked
   // `env::__extern_get` host import — and to the host import in JS-host mode).
-  ensureLateImport(ctx, "__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  ensureLateImport(ctx, readName, [{ kind: "externref" }, readKeyType], [{ kind: "externref" }]);
   flushLateImportShifts(ctx, fctx);
-  let getIdx = ctx.funcMap.get("__extern_get");
+  let getIdx = ctx.funcMap.get(readName);
   if (getIdx === undefined) return;
 
-  // Ensure __box_number is available
+  // Ensure __box_number is available (host mode only — it boxes the index key).
   let boxIdx = ctx.funcMap.get("__box_number");
-  if (boxIdx === undefined) {
+  if (!useIdxReads && boxIdx === undefined) {
     const importsBefore = ctx.numImportFuncs;
     const boxType = addFuncType(ctx, [{ kind: "f64" }], [{ kind: "externref" }]);
     addImport(ctx, "env", "__box_number", { kind: "func", typeIdx: boxType });
     shiftLateImportIndices(ctx, fctx, importsBefore, ctx.numImportFuncs - importsBefore);
     boxIdx = ctx.funcMap.get("__box_number");
-    getIdx = ctx.funcMap.get("__extern_get");
+    getIdx = ctx.funcMap.get(readName);
   }
-  if (boxIdx === undefined || getIdx === undefined) return;
+  if ((!useIdxReads && boxIdx === undefined) || getIdx === undefined) return;
+
+  /**
+   * Push `src[i]` as an externref — the single read shape this function used to
+   * inline five times. Host: `__extern_get(src, __box_number(i))`; standalone:
+   * `__extern_get_idx(src, i)`.
+   */
+  const pushElemRead = (i: number): void => {
+    fctx.body.push({ op: "local.get", index: srcLocal });
+    fctx.body.push({ op: "f64.const", value: i });
+    if (!useIdxReads) fctx.body.push({ op: "call", funcIdx: boxIdx! });
+    fctx.body.push({ op: "call", funcIdx: getIdx! });
+  };
 
   // Lazily register __extern_set for property/element-access destructuring
   // targets. We only register if/when we actually need it; that keeps the
@@ -1625,9 +1902,11 @@ function compileForOfAssignDestructuringExternref(
     if (ts.isOmittedExpression(el)) continue;
     if (ts.isSpreadElement(el)) {
       // (#2602) Rest element `...y`: PutValue the slice from index `i` onward.
-      // The element local is already an externref source — push it directly.
-      fctx.body.push({ op: "local.get", index: elemLocal });
-      emitForOfRestAssignment(ctx, fctx, el, i, (name) => ctx.moduleGlobals.get(name));
+      // (#4447) Slice the MATERIALISED source — a rest element passes -1 to
+      // `__array_from_iter_n`, i.e. an unbounded drain, so `srcLocal` already
+      // holds every value the iterator produced.
+      fctx.body.push({ op: "local.get", index: srcLocal });
+      emitForOfRestAssignment(ctx, fctx, el, i, (name) => ctx.moduleGlobals.get(name), stmtForNested);
       continue;
     }
 
@@ -1637,6 +1916,23 @@ function compileForOfAssignDestructuringExternref(
     if (ts.isBinaryExpression(el) && el.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
       targetEl = el.left;
       defaultInit = el.right;
+    }
+
+    // (#4447) Nested pattern element — `for ([[x]] of …)` / `for ([{x}] of …)`.
+    // Read the slot, apply any default, then recurse so the nested value runs
+    // its own RequireObjectCoercible / GetIterator. Previously a non-identifier,
+    // non-member target fell through to the `isIdentifier` bail below and the
+    // whole nested pattern was silently dropped.
+    if (ts.isObjectLiteralExpression(targetEl) || ts.isArrayLiteralExpression(targetEl)) {
+      const nestedLocal = allocLocal(fctx, `__forof_extnested_${fctx.locals.length}`, { kind: "externref" });
+      pushElemRead(i);
+      if (defaultInit) {
+        emitDefaultValueCheck(ctx, fctx, { kind: "externref" }, nestedLocal, defaultInit, { kind: "externref" });
+      } else {
+        fctx.body.push({ op: "local.set", index: nestedLocal });
+      }
+      destructureNestedExternrefPattern(ctx, fctx, targetEl, nestedLocal, stmtForNested);
+      continue;
     }
 
     // #1258 — destructure-assignment target may be a property access
@@ -1675,11 +1971,8 @@ function compileForOfAssignDestructuringExternref(
           fctx.body.push({ op: "ref.null.extern" });
         }
       }
-      // Push value: __extern_get(elem, box(i))
-      fctx.body.push({ op: "local.get", index: elemLocal });
-      fctx.body.push({ op: "f64.const", value: i });
-      fctx.body.push({ op: "call", funcIdx: boxIdx });
-      fctx.body.push({ op: "call", funcIdx: getIdx! });
+      // Push value: src[i]
+      pushElemRead(i);
       // Defaults on property targets: if the read is undefined, fall back to default.
       // Spec applies to ALL destructure targets identically, but the existing emit
       // path uses `emitDefaultValueCheck` against a local. For property targets
@@ -1722,11 +2015,8 @@ function compileForOfAssignDestructuringExternref(
     if (boxedCap && !defaultInit) {
       // Boxed-capture path: <local.get cell-ref> <value> <struct.set 0>
       fctx.body.push({ op: "local.get", index: targetLocal });
-      // Push value: __extern_get(elem, box(i))
-      fctx.body.push({ op: "local.get", index: elemLocal });
-      fctx.body.push({ op: "f64.const", value: i });
-      fctx.body.push({ op: "call", funcIdx: boxIdx });
-      fctx.body.push({ op: "call", funcIdx: getIdx! });
+      // Push value: src[i]
+      pushElemRead(i);
       // Coerce value to the cell's inner type if needed (refCell stores valType)
       if (boxedCap.valType.kind !== "externref") {
         coerceType(ctx, fctx, { kind: "externref" }, boxedCap.valType);
@@ -1766,11 +2056,8 @@ function compileForOfAssignDestructuringExternref(
       const undefIdx = ensureExternIsUndefined(ctx, fctx);
       // Push the box-ref for the eventual struct.set.
       fctx.body.push({ op: "local.get", index: targetLocal });
-      // Get the extracted value: __extern_get(elem, box(i)) -> externref
-      fctx.body.push({ op: "local.get", index: elemLocal });
-      fctx.body.push({ op: "f64.const", value: i });
-      fctx.body.push({ op: "call", funcIdx: boxIdx! });
-      fctx.body.push({ op: "call", funcIdx: getIdx! });
+      // Get the extracted value: src[i] -> externref
+      pushElemRead(i);
       // Tee into a temp so we can both test-undefined and reuse on else.
       const tmpExt = allocLocal(fctx, `__forof_dflt_ext_${fctx.locals.length}`, { kind: "externref" });
       fctx.body.push({ op: "local.tee", index: tmpExt });
@@ -1819,11 +2106,8 @@ function compileForOfAssignDestructuringExternref(
       continue;
     }
 
-    // Emit: __extern_get(elem, box(i)) -> externref
-    fctx.body.push({ op: "local.get", index: elemLocal });
-    fctx.body.push({ op: "f64.const", value: i });
-    fctx.body.push({ op: "call", funcIdx: boxIdx });
-    fctx.body.push({ op: "call", funcIdx: getIdx! });
+    // Emit: src[i] -> externref
+    pushElemRead(i);
 
     if (defaultInit) {
       const targetType = getLocalType(fctx, targetLocal);
@@ -1862,20 +2146,90 @@ export function compileForOfIteratorAssignDestructuring(
       if (ts.isSpreadAssignment(prop)) continue;
       if (!ts.isShorthandPropertyAssignment(prop) && !ts.isPropertyAssignment(prop)) continue;
 
+      // (#4447) Numeric-literal keys count: `for ([...{ 1: x }] of [[1,2,3]])`
+      // reads index 1 of the rest slice. §13.2.5.5 canonicalises a numeric
+      // PropertyName to its string form, which `prop.name.text` already is.
       const propName = ts.isShorthandPropertyAssignment(prop)
         ? prop.name.text
         : ts.isIdentifier(prop.name)
           ? prop.name.text
-          : ts.isStringLiteral(prop.name)
+          : ts.isStringLiteral(prop.name) || ts.isNumericLiteral(prop.name)
             ? prop.name.text
             : undefined;
       if (!propName) continue;
 
-      const targetName = ts.isShorthandPropertyAssignment(prop)
-        ? prop.name.text
-        : ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.initializer)
-          ? prop.initializer.text
-          : propName;
+      // (#4447) Same (target, default) split as the struct path — `{ k: t = d }`
+      // is a PropertyAssignment over the AssignmentExpression `t = d`, and
+      // `{ k = d }` a ShorthandPropertyAssignment with an
+      // `objectAssignmentInitializer`. Neither was recognised here: the target
+      // fell back to the KEY name and the default was dropped.
+      const targetExpr: ts.Expression = ts.isShorthandPropertyAssignment(prop)
+        ? prop.name
+        : ts.isBinaryExpression(prop.initializer) && prop.initializer.operatorToken.kind === ts.SyntaxKind.EqualsToken
+          ? prop.initializer.left
+          : prop.initializer;
+      const defaultInit: ts.Expression | undefined = ts.isShorthandPropertyAssignment(prop)
+        ? prop.objectAssignmentInitializer
+        : ts.isBinaryExpression(prop.initializer) && prop.initializer.operatorToken.kind === ts.SyntaxKind.EqualsToken
+          ? prop.initializer.right
+          : undefined;
+      const isMemberTarget = ts.isPropertyAccessExpression(targetExpr) || ts.isElementAccessExpression(targetExpr);
+      const targetName = ts.isIdentifier(targetExpr) ? targetExpr.text : propName;
+
+      /** Push `__extern_get(elem, "propName")` — the read shared by every arm. */
+      const pushPropRead = (): boolean => {
+        // Register string constant for property name.
+        addStringConstantGlobal(ctx, propName);
+        // Refresh getIdx in case addStringConstantGlobal shifted indices.
+        getIdx = ctx.funcMap.get("__extern_get");
+        if (getIdx === undefined) return false;
+        // (#51) Materialize the key via the dual-mode helper — nativeStrings
+        // stores a `-1` sentinel global so a bare `global.get` would crash
+        // binary emit.
+        fctx.body.push({ op: "local.get", index: elemLocal });
+        for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
+        fctx.body.push({ op: "call", funcIdx: getIdx });
+        return true;
+      };
+
+      // (#4447) Nested pattern in the value position — `for ({ x: { y } } of …)`.
+      // Read the property, apply any default, then recurse so the nested value
+      // performs its own RequireObjectCoercible / GetIterator (an absent or
+      // `undefined`/`null` property must throw TypeError, not bind silently).
+      if (ts.isObjectLiteralExpression(targetExpr) || ts.isArrayLiteralExpression(targetExpr)) {
+        const nestedLocal = allocLocal(fctx, `__forof_iternested_${fctx.locals.length}`, { kind: "externref" });
+        if (!pushPropRead()) continue;
+        if (defaultInit) {
+          emitDefaultValueCheck(
+            ctx,
+            fctx,
+            { kind: "externref" },
+            nestedLocal,
+            defaultInit,
+            { kind: "externref" },
+            true,
+          );
+        } else {
+          fctx.body.push({ op: "local.set", index: nestedLocal });
+        }
+        destructureNestedExternrefPattern(ctx, fctx, targetExpr, nestedLocal, stmt);
+        continue;
+      }
+
+      // (#4447) Member-expression target — `for ({k: obj.y} of iterable)`.
+      // Route through the #2664 member-set dispatcher via a temp, mirroring
+      // the struct path's #2869 arm.
+      if (isMemberTarget) {
+        const tmpM = allocLocal(fctx, `__forof_itermemtgt_${fctx.locals.length}`, { kind: "externref" });
+        if (!pushPropRead()) continue;
+        if (defaultInit) {
+          emitDefaultValueCheck(ctx, fctx, { kind: "externref" }, tmpM, defaultInit, { kind: "externref" }, true);
+        } else {
+          fctx.body.push({ op: "local.set", index: tmpM });
+        }
+        emitAssignToTarget(ctx, fctx, targetExpr, tmpM, { kind: "externref" });
+        continue;
+      }
 
       let targetLocal = fctx.localMap.get(targetName);
       let iterObjSyncGlobalIdx: number | undefined;
@@ -1888,24 +2242,42 @@ export function compileForOfIteratorAssignDestructuring(
         iterObjSyncGlobalIdx = globalIdx;
       }
 
-      // Register string constant for property name
-      addStringConstantGlobal(ctx, propName);
+      // (#4447) Boxed-capture target: write THROUGH the ref cell.
+      const boxedCapIter = fctx.boxedCaptures?.get(targetName);
+      if (boxedCapIter) {
+        const tmpB = allocLocal(fctx, `__forof_iterdflt_${fctx.locals.length}`, { kind: "externref" });
+        if (!pushPropRead()) continue;
+        if (defaultInit) {
+          emitDefaultValueCheck(ctx, fctx, { kind: "externref" }, tmpB, defaultInit, { kind: "externref" }, true);
+        } else {
+          fctx.body.push({ op: "local.set", index: tmpB });
+        }
+        fctx.body.push({ op: "local.get", index: tmpB });
+        emitBoxedForOfAssignStore(ctx, fctx, targetLocal, { kind: "externref" }, boxedCapIter);
+        continue;
+      }
 
-      // Refresh getIdx in case addStringConstantGlobal shifted indices
-      getIdx = ctx.funcMap.get("__extern_get");
-      if (getIdx === undefined) continue;
+      if (!pushPropRead()) continue;
 
-      // Emit: __extern_get(elem, "propName") -> externref. (#51) Materialize the
-      // key via the dual-mode helper — nativeStrings stores a `-1` sentinel global
-      // so a bare `global.get` would crash binary emit.
-      fctx.body.push({ op: "local.get", index: elemLocal });
-      for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
-      fctx.body.push({ op: "call", funcIdx: getIdx });
+      if (defaultInit) {
+        // §13.15.5.4 step 4: the initializer fires only when the read is
+        // `undefined` — object-property semantics, so a genuine `null` keeps.
+        const targetTypeI = getLocalType(fctx, targetLocal);
+        emitDefaultValueCheck(
+          ctx,
+          fctx,
+          { kind: "externref" },
+          targetLocal,
+          defaultInit,
+          targetTypeI ?? undefined,
+          true,
+        );
+      } else {
+        // Coerce externref to target local's type and set
+        emitCoercedLocalSet(ctx, fctx, targetLocal, { kind: "externref" });
+      }
 
-      // Coerce externref to target local's type and set
-      emitCoercedLocalSet(ctx, fctx, targetLocal, { kind: "externref" });
-
-      emitGlobalSyncWriteback(ctx, fctx, targetLocal, iterObjSyncGlobalIdx);
+      emitGlobalSyncWritebackByName(ctx, fctx, targetLocal, targetName, iterObjSyncGlobalIdx !== undefined);
     }
   } else if (ts.isArrayLiteralExpression(expr)) {
     // for ([x, y] of iterable) — use __extern_get(elem, box(i)) for each element
@@ -1955,7 +2327,7 @@ export function compileForOfIteratorAssignDestructuring(
         // / generator source, incl. for-await). The element local is externref —
         // push it directly and slice from index `i`.
         fctx.body.push({ op: "local.get", index: elemLocal });
-        emitForOfRestAssignment(ctx, fctx, el, i, (name) => ctx.moduleGlobals.get(name));
+        emitForOfRestAssignment(ctx, fctx, el, i, (name) => ctx.moduleGlobals.get(name), stmt);
         continue;
       }
 

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -31,6 +31,7 @@ import {
   tryCompileNativeVecConcatOperand,
 } from "./native-strings.js";
 import { emitBrandCheckTypeError } from "./native-proto.js";
+import { htmlWrapperFor } from "./html-wrapper-native.js"; // (#4445) shared with the reflective body
 import { emitFlattenWithInlineFlatFastPath } from "./string-materialize.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
 import { collectConcatOperands, ensureNativeBatchedConcat } from "./native-batched-concat.js";
@@ -231,31 +232,6 @@ export function emitHostExternrefToNativeString(ctx: CodegenContext, fctx: Funct
   fctx.body.push({ op: "call", funcIdx: fromExternIdx });
   return nativeStringType(ctx);
 }
-
-/**
- * (#3069) Annex B §B.2.2 legacy HTML string-wrapper method → HTML tag +
- * optional attribute name (ECMA-262 §B.2.2.2..§B.2.2.14). `String.prototype`
- * `bold`→`<b>`, `italics`→`<i>`, `anchor(name)`→`<a name="…">`,
- * `link(url)`→`<a href="…">`, `fontcolor(c)`/`fontsize(s)`→`<font color/size="…">`,
- * etc. Methods with an `attribute` take one argument (the attribute VALUE,
- * `"`→`&quot;` escaped); the rest take none. Consumed by
- * `compileNativeStringMethodCall`'s standalone/WASI native arm.
- */
-const HTML_WRAPPER_TAGS: Readonly<Record<string, { tag: string; attribute?: string }>> = {
-  anchor: { tag: "a", attribute: "name" },
-  big: { tag: "big" },
-  blink: { tag: "blink" },
-  bold: { tag: "b" },
-  fixed: { tag: "tt" },
-  fontcolor: { tag: "font", attribute: "color" },
-  fontsize: { tag: "font", attribute: "size" },
-  italics: { tag: "i" },
-  link: { tag: "a", attribute: "href" },
-  small: { tag: "small" },
-  strike: { tag: "strike" },
-  sub: { tag: "sub" },
-  sup: { tag: "sup" },
-};
 
 /**
  * #1470 — Compile a `+`-concat operand and coerce its result to a native
@@ -2852,7 +2828,7 @@ export function compileNativeStringMethodCall(
   // step-4.b `"`→`&quot;` escaping). Do NOT add these to STRING_METHODS — that
   // would register a host `string_<m>` import and regress host-mode boxing.
   {
-    const htmlWrapper = HTML_WRAPPER_TAGS[method];
+    const htmlWrapper = htmlWrapperFor(method);
     if (htmlWrapper) {
       const concatIdx = ctx.nativeStrHelpers.get("__str_concat")!;
       const { tag, attribute } = htmlWrapper;

--- a/src/codegen/string-proto-html.ts
+++ b/src/codegen/string-proto-html.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#4445) Native body for a reflective `String.prototype.<html-wrapper>` closure
+ * — the 13 Annex B §B.2.3 methods (`anchor`, `big`, `blink`, `bold`, `fixed`,
+ * `fontcolor`, `fontsize`, `italics`, `link`, `small`, `strike`, `sub`, `sup`).
+ *
+ * The DIRECT `"x".anchor(n)` call never reaches here: #3069 already lowers it in
+ * `string-ops.ts` from the same {@link htmlWrapperFor} table. What was missing
+ * is the VALUE-ERASED shape — `String.prototype.anchor.call(thisArg, v)` and
+ * `obj.anchor = String.prototype.anchor; obj.anchor(v)` — which resolves through
+ * the reflective proto-closure path and hit `emitProtoMemberBodyRefusal`, so
+ * every `B.2.3.N.js` (whose last assertions are `.call` forms) and every
+ * `this-val-tostring-err.js` failed while the direct assertions in the same file
+ * passed.
+ *
+ * Closure ABI: `this` = param 1 (externref); the attribute VALUE = param 2, and
+ * ONLY for the four methods that carry an attribute (the other nine are arity 0,
+ * so their closure has no param-2 slot — reading it would emit invalid Wasm).
+ *
+ * §B.2.3.2.1 CreateHTML, in order:
+ *   1. `? RequireObjectCoercible(string)`
+ *   2. `S = ? ToString(str)`                       ← before the value coercion
+ *   4.b `V = ? ToString(value)`, `"` → `&quot;`    ← `__str_html_escape_quot`
+ *   5-9 `"<" tag [" " attr '="' V '"'] ">" S "</" tag ">"`
+ * The step-2-before-step-4.b order is observable and is what
+ * `this-val-tostring-err.js` (abrupt receiver `toString`) pins down.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { htmlWrapperFor } from "./html-wrapper-native.js";
+import { nativeStringLiteralInstrs } from "./native-string-literals.js";
+import { ensureAnyToStringHelper, ensureNativeStringHelpers, nativeStringType } from "./native-strings.js";
+import { emitStringProtoToStringFlat } from "./string-proto-tostring.js";
+
+export function emitStringHtmlWrapperMemberBody(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  member: string,
+  emitRequireObjectCoercible: () => void,
+): ValType | null {
+  const wrapper = htmlWrapperFor(member);
+  if (wrapper === undefined) return null;
+
+  // This body adds NO late imports of its own (no numeric box/unbox — every
+  // operand and the result are strings), so there is nothing to over-shift; the
+  // helper funcIdxs are fetched by NAME after `ensureNativeStringHelpers`, which
+  // flushes any pending import batch on entry. Same discipline as the trim body.
+  ensureNativeStringHelpers(ctx);
+  const anyToStrIdx = ensureAnyToStringHelper(ctx);
+  const concatIdx = ctx.nativeStrHelpers.get("__str_concat");
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  const escapeIdx = ctx.nativeStrHelpers.get("__str_html_escape_quot");
+  if (concatIdx === undefined || flattenIdx === undefined || escapeIdx === undefined || ctx.anyStrTypeIdx < 0) {
+    return null; // host/gc lowering — the caller falls back to its refusal
+  }
+
+  const { tag, attribute } = wrapper;
+  // The glue sizes the four attribute methods to arity 1, so param 2 exists for
+  // exactly those (`fctx.params` is `[self, this, …args]`). The tag SHAPE is
+  // decided by `attribute` alone, never by the slot count — a missing slot means
+  // "the value is undefined", not "drop the attribute".
+  const hasAttrSlot = fctx.params.length > 2;
+
+  // (1) ? RequireObjectCoercible(this).
+  emitRequireObjectCoercible();
+
+  // (2) S = ? ToString(this) — emitted BEFORE the value coercion below so an
+  // abrupt receiver `toString` wins over an abrupt attribute `toString`.
+  const strTy = nativeStringType(ctx);
+  emitStringProtoToStringFlat(ctx, fctx, 1, anyToStrIdx, flattenIdx);
+  const sLocal = allocLocal(fctx, `__str_html_s_${fctx.locals.length}`, strTy);
+  fctx.body.push({ op: "local.set", index: sLocal });
+
+  // (3) prefix = `<tag>` or `<tag attribute="` + escapeQuot(? ToString(value)) + `">`.
+  if (attribute === undefined) {
+    fctx.body.push(...nativeStringLiteralInstrs(ctx, `<${tag}>`));
+  } else {
+    const vLocal = allocLocal(fctx, `__str_html_v_${fctx.locals.length}`, strTy);
+    if (hasAttrSlot) {
+      // An ABSENT arg arrives as a null pad. Unlike `concat`'s step-3 skip,
+      // CreateHTML step 4.b coerces the (undefined) value regardless, so the pad
+      // must stringify to "undefined" rather than reach `$__any_to_string`.
+      const coerced: Instr[] = [];
+      const saved = fctx.body;
+      fctx.body = coerced;
+      emitStringProtoToStringFlat(ctx, fctx, 2, anyToStrIdx, flattenIdx);
+      fctx.body = saved;
+      coerced.push({ op: "local.set", index: vLocal });
+      fctx.body.push(
+        { op: "local.get", index: 2 },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [...nativeStringLiteralInstrs(ctx, "undefined"), { op: "local.set", index: vLocal }],
+          else: coerced,
+        },
+      );
+    } else {
+      fctx.body.push(...nativeStringLiteralInstrs(ctx, "undefined"), { op: "local.set", index: vLocal });
+    }
+    fctx.body.push(...nativeStringLiteralInstrs(ctx, `<${tag} ${attribute}="`));
+    fctx.body.push({ op: "local.get", index: vLocal });
+    fctx.body.push({ op: "call", funcIdx: escapeIdx });
+    fctx.body.push({ op: "call", funcIdx: concatIdx });
+    fctx.body.push(...nativeStringLiteralInstrs(ctx, `">`));
+    fctx.body.push({ op: "call", funcIdx: concatIdx });
+  }
+
+  // (4) prefix + S + `</tag>` → externref (the uniform closure result type).
+  fctx.body.push({ op: "local.get", index: sLocal });
+  fctx.body.push({ op: "call", funcIdx: concatIdx });
+  fctx.body.push(...nativeStringLiteralInstrs(ctx, `</${tag}>`));
+  fctx.body.push({ op: "call", funcIdx: concatIdx });
+  fctx.body.push({ op: "extern.convert_any" });
+  return { kind: "externref" };
+}

--- a/tests/issue-4445-annexb-html-methods.test.ts
+++ b/tests/issue-4445-annexb-html-methods.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4445 — the 13 Annex B §B.2.3 HTML string-wrapper methods through the
+// VALUE-ERASED shape.
+//
+// #3069 already lowered the DIRECT `"x".anchor(v)` call natively, and
+// tests/issue-3069-annexb-html-wrappers-standalone.test.ts pins that. What was
+// missing is `String.prototype.anchor.call(thisArg, v)` (and the transferred
+// `obj.anchor = String.prototype.anchor` form): `anchor`…`sup` were absent from
+// the `String.prototype` glue's member set, so the reflective proto-closure
+// path never resolved them and the call answered `undefined`. That is exactly
+// the tail of every test262 `annexB/.../B.2.3.N.js` file — its first assertions
+// (direct calls) passed while the `String.prototype.<m>.call(…)` ones did not —
+// and the whole of every `this-val-tostring-err.js`, where the abrupt
+// `ToString(this)` of CreateHTML step 2 must propagate.
+//
+// Deliberate choices:
+//  1. Assertions are made INSIDE the module and reported as a number — a
+//     `string` returned from an exported standalone function does not marshal
+//     back across the JS boundary.
+//  2. Both lanes run the SAME source: the standalone lane is the one this issue
+//     fixes, the gc/JS-host lane is the no-regression control.
+//  3. Every expectation is the value Node produces for the same source, so a
+//     failure means a compiler defect rather than a wrong assertion.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/** Compile + run `test()` on the host-free standalone lane (no imports at all). */
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+/** Compile + run `test()` on the default JS-host (gc) lane. */
+async function runHost(src: string): Promise<number> {
+  const r = await compile(src);
+  expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => number }).test();
+}
+
+/** Run the same source on both lanes and assert both answer `want`. */
+async function bothLanes(src: string, want: number): Promise<void> {
+  expect(await runStandalone(src), "standalone").toBe(want);
+  expect(await runHost(src), "gc/JS-host").toBe(want);
+}
+
+describe("#4445 reflective String.prototype HTML wrappers (§B.2.3)", () => {
+  it("returns the CreateHTML string through String.prototype.<m>.call", async () => {
+    // One tag-only method (arity 0 — its closure has no argument slot) and one
+    // attribute method (arity 1) per shape.
+    await bothLanes(
+      `export function test(): number {
+         if (String.prototype.bold.call("x") !== "<b>x</b>") return 1;
+         if (String.prototype.sup.call("x") !== "<sup>x</sup>") return 2;
+         if (String.prototype.anchor.call("_", "b") !== '<a name="b">_</a>') return 3;
+         if (String.prototype.link.call("_", "u") !== '<a href="u">_</a>') return 4;
+         if (String.prototype.fontcolor.call("_", "red") !== '<font color="red">_</font>') return 5;
+         if (String.prototype.fontsize.call("_", "3") !== '<font size="3">_</font>') return 6;
+         return 0;
+       }`,
+      0,
+    );
+  });
+
+  it("escapes each '\"' in the attribute value (CreateHTML step 4.b)", async () => {
+    await bothLanes(
+      `export function test(): number {
+         return String.prototype.anchor.call("_", '"x"') === '<a name="&quot;x&quot;">_</a>' ? 0 : 1;
+       }`,
+      0,
+    );
+  });
+
+  it('stringifies an absent/undefined attribute argument as "undefined"', async () => {
+    // §B.2.3.2.1 step 4.b coerces the value even when it is `undefined` — unlike
+    // `concat`'s step-3 skip, so the closure's null arg pad must NOT be dropped.
+    await bothLanes(
+      `export function test(): number {
+         if ("".link(undefined as unknown as string) !== '<a href="undefined"></a>') return 1;
+         if (String.prototype.anchor.call("_") !== '<a name="undefined">_</a>') return 2;
+         return 0;
+       }`,
+      0,
+    );
+  });
+
+  it("coerces a non-string receiver via ToString (CreateHTML step 2)", async () => {
+    await bothLanes(
+      `export function test(): number {
+         return String.prototype.big.call(42 as unknown as string) === "<big>42</big>" ? 0 : 1;
+       }`,
+      0,
+    );
+  });
+
+  it("propagates an abrupt ToString(this) from CreateHTML step 2", async () => {
+    // The receiver coercion happens BEFORE the attribute coercion, so this
+    // receiver's throw is what escapes even though an argument is supplied.
+    await bothLanes(
+      `export function test(): number {
+         const thisVal = { toString: function(): string { throw new Error("boom"); } };
+         try {
+           String.prototype.anchor.call(thisVal as unknown as string, "b");
+         } catch (e) {
+           return 0;
+         }
+         return 1;
+       }`,
+      0,
+    );
+  });
+
+  it("throws TypeError for a null or undefined receiver (RequireObjectCoercible)", async () => {
+    await bothLanes(
+      `export function test(): number {
+         let threwUndefined = 0;
+         let threwNull = 0;
+         try { String.prototype.anchor.call(undefined as unknown as string); } catch (e) { threwUndefined = 1; }
+         try { String.prototype.bold.call(null as unknown as string); } catch (e) { threwNull = 1; }
+         return threwUndefined === 1 && threwNull === 1 ? 0 : 1;
+       }`,
+      0,
+    );
+  });
+});
+
+describe("#4445 reflective HTML wrappers stay host-free in standalone", () => {
+  it("emits no env import", async () => {
+    const r = await compile(`export function test(): string { return String.prototype.anchor.call("x", '"y"'); }`, {
+      target: "standalone",
+    });
+    expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+    const envImports = (r.imports ?? []).filter((i: { module?: string }) => i.module === "env");
+    expect(envImports).toEqual([]);
+  });
+});

--- a/tests/issue-4446-concat-dyn-standalone.test.ts
+++ b/tests/issue-4446-concat-dyn-standalone.test.ts
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#4446) `Array.prototype.concat` with a DYNAMIC operand must lower natively
+// under `--target standalone`.
+//
+// `compileArrayConcatExtern` — the fallback taken whenever an operand is not a
+// statically-known WasmGC array (an `any`-typed receiver, an array-like, an
+// object carrying `Symbol.isConcatSpreadable`) — delegated the whole operation
+// to the JS host via `env::__array_concat_any` plus `env::__js_array_new` /
+// `env::__js_array_push`. Host-free those are unsatisfiable imports, so the
+// #2961 strict leak guard turned every such call into a standalone
+// compile_error: 28 of the 69 `built-ins/Array/prototype/concat` test262 files
+// reported `standalone target emitted host imports: env::__array_concat_any…`.
+//
+// The replacement (`compileArrayConcatNativeSpec`) walks §23.1.3.1 directly
+// over the dynamic-object substrate — `__extern_get` + `__box_symbol` for the
+// `@@isConcatSpreadable` read, `__extern_is_array` for the IsArray default,
+// `__extern_length` for `Get(E,"length")` + ToLength (§7.1.20, including the
+// observable valueOf/toString walk and its abrupt propagation),
+// `__extern_get_idx` per element, and the `$ObjVec` builders for the result.
+//
+// The load-bearing assertion in every case below is the LEAK one: the emitted
+// standalone module must carry ZERO `env::` imports (mirrors the
+// `envImportNames` WAT scan in tests/issue-2961.test.ts). A behavioural
+// assertion alone would not catch a regression that silently re-routes the
+// call back to the host bridge, because the host bridge is *also* correct —
+// it just cannot be instantiated standalone.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/** Extract `env` import names from WAT (same scan as tests/issue-2961.test.ts). */
+function envImportNames(wat: string): string[] {
+  const out: string[] = [];
+  const re = /\(import\s+"env"\s+"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(wat)) !== null) out.push(m[1]!);
+  return out;
+}
+
+async function compileJs(src: string, target: "standalone" | "gc") {
+  const r = await compile(src, {
+    fileName: "test.js",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    ...(target === "standalone" ? { target: "standalone" as const } : {}),
+  });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
+  return r;
+}
+
+async function run(src: string, target: "standalone" | "gc"): Promise<unknown> {
+  const r = await compileJs(src, target);
+  const imports = target === "standalone" ? {} : buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+/** Compile standalone and return the leaked `env::` import names (expected: none). */
+async function standaloneEnvImports(src: string): Promise<string[]> {
+  const r = await compileJs(src, "standalone");
+  return envImportNames(r.wat);
+}
+
+// ── The four fixtures from the #4446 Validation section ────────────────────
+
+/** `any`-typed receiver: `Array.prototype.concat.call(arrayLike, …)`-shaped. */
+const ANY_RECEIVER = `
+var recv = [1, 2];
+var arg = {};
+export function test() {
+  var out = recv.concat(arg);
+  return out.length;
+}`;
+
+/**
+ * An ARRAY with a falsy `@@isConcatSpreadable`. Carried for the LEAK assertion
+ * only — see the `RESIDUAL` note on the semantics block below: a vec-backed
+ * receiver does not expose symbol-keyed own properties through `__extern_get`,
+ * so the IsArray default wins and this operand is still spread. That gap is in
+ * the symbol/vec property channel (#2866-adjacent), not in the concat loop, and
+ * it reproduces identically on the untouched gc lane.
+ */
+const SPREADABLE_FALSE_ARRAY = `
+var item = [1, 2, 3];
+item[Symbol.isConcatSpreadable] = false;
+export function test() {
+  var out = [].concat(item);
+  return out.length;
+}`;
+
+/** A non-array array-like with a FALSY `@@isConcatSpreadable` is appended whole. */
+const SPREADABLE_FALSE_OBJECT = `
+var item = { length: 3, 0: 1, 1: 2, 2: 3 };
+item[Symbol.isConcatSpreadable] = false;
+export function test() {
+  var out = [].concat(item);
+  return out.length;
+}`;
+
+/** A non-array array-like with a truthy `@@isConcatSpreadable` IS spread. */
+const SPREADABLE_ARRAY_LIKE = `
+var obj = { length: 3, 0: "a", 1: "b", 2: "c" };
+obj[Symbol.isConcatSpreadable] = true;
+export function test() {
+  var out = [9].concat(obj);
+  return out.length;
+}`;
+
+/** A throwing `length` getter propagates out of ToLength (§7.1.20 abrupt). */
+const LENGTH_GETTER_THROWS = `
+var obj = {};
+obj[Symbol.isConcatSpreadable] = true;
+Object.defineProperty(obj, "length", {
+  get: function () { throw new TypeError("boom"); },
+});
+export function test() {
+  try {
+    [].concat(obj);
+  } catch (e) {
+    return 42;
+  }
+  return 0;
+}`;
+
+const FIXTURES: [string, string][] = [
+  ["any-typed receiver + object argument", ANY_RECEIVER],
+  ["array with isConcatSpreadable=false", SPREADABLE_FALSE_ARRAY],
+  ["object with isConcatSpreadable=false", SPREADABLE_FALSE_OBJECT],
+  ["spreadable array-like object", SPREADABLE_ARRAY_LIKE],
+  ["throwing length getter", LENGTH_GETTER_THROWS],
+];
+
+describe("#4446 — dynamic Array.prototype.concat lowers host-free under --target standalone", () => {
+  describe("no host-import leak (the #2961 guard)", () => {
+    for (const [name, src] of FIXTURES) {
+      it(`${name} emits zero env:: imports`, async () => {
+        const leaked = await standaloneEnvImports(src);
+        expect(leaked, `leaked host imports: ${leaked.join(", ")}`).toEqual([]);
+      });
+    }
+
+    it("specifically none of the three retired concat host imports appears", async () => {
+      // The exact trio the issue names. Pinned separately from the blanket
+      // "zero imports" assertion so a future, deliberately-allowlisted import
+      // elsewhere in the module cannot mask a concat regression.
+      const retired = ["__array_concat_any", "__js_array_new", "__js_array_push"];
+      for (const [, src] of FIXTURES) {
+        const leaked = await standaloneEnvImports(src);
+        for (const name of retired) expect(leaked).not.toContain(name);
+      }
+    });
+  });
+
+  describe("§23.1.3.1 semantics", () => {
+    it("a non-spreadable object argument is appended as one element", async () => {
+      // IsConcatSpreadable({}) → Get(@@isConcatSpreadable) is undefined →
+      // IsArray({}) is false → the object itself is element 2.
+      expect(await run(ANY_RECEIVER, "standalone")).toBe(3);
+    });
+
+    it("an OBJECT with a falsy @@isConcatSpreadable is NOT spread", async () => {
+      // The pre-#4446 native shortcut spread every operand it took
+      // unconditionally — the is-concat-spreadable-val-falsey signature.
+      expect(await run(SPREADABLE_FALSE_OBJECT, "standalone")).toBe(1);
+    });
+
+    it("RESIDUAL: a vec-backed ARRAY still ignores its @@isConcatSpreadable", async () => {
+      // Pins the KNOWN GAP so it cannot regress silently in either direction.
+      // `item[Symbol.isConcatSpreadable] = false` on a vec receiver does not
+      // reach the symbol-key channel that `__extern_get` reads, so
+      // IsConcatSpreadable falls through to IsArray → true → spread. The set
+      // currently lands on numeric index 6 instead, which is why `item.length`
+      // is 7 and the concat result has 7 elements. Measured identically on the
+      // untouched gc lane (`item.length === 7` there too), so this is the
+      // symbol/vec property channel, NOT the #4446 concat loop.
+      expect(await run(SPREADABLE_FALSE_ARRAY, "standalone")).toBe(7);
+      expect(
+        await run(
+          `var item=[1,2,3]; item[Symbol.isConcatSpreadable]=false;
+        export function test(){ return item.length; }`,
+          "gc",
+        ),
+      ).toBe(7);
+    });
+
+    it("an array-like with a truthy @@isConcatSpreadable IS spread", async () => {
+      expect(await run(SPREADABLE_ARRAY_LIKE, "standalone")).toBe(4);
+    });
+
+    it("a throwing length getter propagates (ToLength is observable)", async () => {
+      expect(await run(LENGTH_GETTER_THROWS, "standalone")).toBe(42);
+    });
+  });
+
+  describe("the JS-host (gc) lane keeps its host bridge", () => {
+    it("gc still routes the dynamic fallback through env::__array_concat_any", async () => {
+      // #4446 switches the fallback PER TARGET; the gc path is deliberately
+      // unchanged (it is faster and complete there). This pins that the switch
+      // did not leak into the host lane.
+      const r = await compileJs(ANY_RECEIVER, "gc");
+      expect(envImportNames(r.wat)).toContain("__array_concat_any");
+    });
+
+    it("gc's own answer for this shape is byte-for-byte what it was", async () => {
+      // Deliberately NOT `toBe(3)`. The gc host bridge already answered 1 for
+      // this program before #4446 (its `.length` read of the returned host
+      // Array is a separate, pre-existing defect), and an A/B against
+      // `git show HEAD:src/codegen/array-methods.ts` reproduced 1 on both
+      // sides. Pinning the OBSERVED value is what proves the per-target switch
+      // left the host lane untouched; pinning the SPEC value here would just
+      // be a red test about someone else's bug.
+      expect(await run(ANY_RECEIVER, "gc")).toBe(1);
+    });
+  });
+});

--- a/tests/issue-4447-forof-dstr-standalone.test.ts
+++ b/tests/issue-4447-forof-dstr-standalone.test.ts
@@ -1,0 +1,356 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4447 — for-of ASSIGNMENT-destructuring residual on the standalone lane.
+//
+// Four independent defects, all in the ASSIGNMENT form of a for-of head
+// (`for ([x] of …)` / `for ({k: t} of …)`). The BINDING form
+// (`for (const [x] of …)`) already routed through `destructureParamArray` and
+// was correct — that asymmetry is what hid these:
+//
+//  1. §13.15.5.2 GetIterator was never performed for an array assignment
+//     pattern in a for-of head: the element was read as `elem[i]` via
+//     `__extern_get`, so a user iterable observed ZERO `next()` and ZERO
+//     `return()` calls (test262 `for-of/dstr/array-elem-trlg-iter-*`, 0/23).
+//  2. `__iterator_next`'s closed-struct result read required BOTH
+//     `__sget_done` and `__sget_value`. A conformant `{ done: … }`-only
+//     IteratorResult leaves a module with no `value` field anywhere ⇒ no
+//     `__sget_value` is emitted ⇒ the read fell to the `done := 1` degrade and
+//     reported the iterator exhausted on step 1, which ALSO suppressed
+//     IteratorClose (§7.4.9 closes only on a non-done stop).
+//  3. Object assignment patterns dropped their DEFAULTS and mis-resolved their
+//     TARGET: `{ k: t = d }` parses as a PropertyAssignment over the
+//     AssignmentExpression `t = d`, which the lowering never destructured, so
+//     it wrote a variable named `k` and ignored `d`.
+//  4. Nested patterns in the value/element/rest position (`{ x: { y } }`,
+//     `[[y]]`, `[...{ 1: x }]`) were silently dropped instead of recursing —
+//     and an absent/`undefined` nested source must throw TypeError.
+//
+// LANE SCOPE. The lowering is shared with the JS-host (`gc`) lane, so every
+// case is exercised there too — but several of these shapes have a SEPARATE,
+// pre-existing gc-lane gap that #4447 does not address: the host
+// `__array_from_iter_n` / `__extern_get` helpers cannot drive a COMPILED
+// closed-struct iterator or read a compiled object's properties, so the
+// iterator-protocol cases answer 0 on gc both before and after this change
+// (measured: `for-of/dstr/array-elem-trlg-iter-*` is 0/23 on gc at HEAD).
+// Those cases therefore assert the standalone value and only require that the
+// gc module still COMPILES and VALIDATES — locking in "no gc crash/regression"
+// without freezing a wrong gc value.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string, target: "standalone" | "gc"): Promise<unknown> {
+  const opts = target === "standalone" ? { target: "standalone" as const } : {};
+  const r = await compile(src, opts);
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), `${target}: module failed WebAssembly.validate`).toBe(true);
+  const imports = target === "standalone" ? {} : buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+/** Compile + validate on `gc` without asserting the (pre-existing-gap) value. */
+async function gcCompilesAndValidates(src: string): Promise<void> {
+  const r = await compile(src, {});
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "gc: module failed WebAssembly.validate").toBe(true);
+}
+
+/** Standalone is the lane under test; gc must merely stay compilable. */
+async function standaloneOnly(src: string, expected: unknown): Promise<void> {
+  expect(await run(src, "standalone"), "standalone").toStrictEqual(expected);
+  await gcCompilesAndValidates(src);
+}
+
+/** Both lowering lanes agree on this shape — assert both. */
+async function bothLanes(src: string, expected: unknown): Promise<void> {
+  expect(await run(src, "standalone"), "standalone").toStrictEqual(expected);
+  expect(await run(src, "gc"), "gc").toStrictEqual(expected);
+}
+
+/**
+ * A user iterable whose `next()` returns a `{ done }`-only IteratorResult —
+ * exactly test262's `array-elem-trlg-iter-*` shape, and the one that tripped
+ * the `__sget_value` conjunction. `n`/`r` count `next`/`return` calls.
+ */
+const ITERABLE_PRELUDE = `
+var n = 0;
+var r = 0;
+var iterator: any = {
+  next: function () { n += 1; return { done: n > 10 }; },
+  return: function () { r += 1; return {}; },
+};
+var iterable: any = {};
+iterable[Symbol.iterator] = function () { return iterator; };
+`;
+
+describe("#4447 §13.15.5.2 — for-of array assignment pattern performs GetIterator", () => {
+  it("steps the iterator once per element and IteratorCloses a non-exhausted iterator", async () => {
+    // §8.5.3: one IteratorStep per element; the pattern does not exhaust the
+    // iterator (`done` stays false), so §7.4.9 IteratorClose calls `return()`.
+    // Before: n === 0, r === 0 — the iterator was never touched at all.
+    await standaloneOnly(
+      `${ITERABLE_PRELUDE}
+      var x: any;
+      export function test(): number {
+        for ([x] of [iterable]) { break; }
+        return n * 10 + r;
+      }`,
+      11,
+    );
+  });
+
+  it("does NOT close an iterator that reported done (§7.4.9 closes only a non-done stop)", async () => {
+    await standaloneOnly(
+      `var n = 0;
+      var r = 0;
+      var iterator: any = {
+        next: function () { n += 1; return { done: true }; },
+        return: function () { r += 1; return {}; },
+      };
+      var iterable: any = {};
+      iterable[Symbol.iterator] = function () { return iterator; };
+      var x: any;
+      export function test(): number {
+        for ([x] of [iterable]) { break; }
+        return n * 10 + r;
+      }`,
+      10,
+    );
+  });
+
+  it("an elision still costs one IteratorStep", async () => {
+    // §8.5.3 step 2: an Elision consumes an iterator step exactly like a
+    // binding element, so `[, y]` takes two and then closes.
+    await standaloneOnly(
+      `${ITERABLE_PRELUDE}
+      var y: any;
+      export function test(): number {
+        for ([, y] of [iterable]) { break; }
+        return n * 10 + r;
+      }`,
+      21,
+    );
+  });
+
+  it("a rest element drains to exhaustion and does NOT close", async () => {
+    // A rest element passes -1 (unbounded) to `__array_from_iter_n`, so the
+    // iterator runs to its natural `done` — no IteratorClose (§7.4.9).
+    await standaloneOnly(
+      `var n = 0;
+      var r = 0;
+      var iterator: any = {
+        next: function () { n += 1; return { done: n > 3, value: n }; },
+        return: function () { r += 1; return {}; },
+      };
+      var iterable: any = {};
+      iterable[Symbol.iterator] = function () { return iterator; };
+      var rest: any;
+      export function test(): number {
+        for ([...rest] of [iterable]) { break; }
+        return n * 10 + r;
+      }`,
+      40,
+    );
+  });
+
+  it("a plain array literal source still destructures by value (unchanged fast path)", async () => {
+    // Plain arrays with the default @@iterator keep the indexed fast path
+    // inside `__array_from_iter_n`, so this shape is byte-equivalent.
+    await bothLanes(
+      `var a: any, b: any;
+      export function test(): number {
+        for ([a, b] of [[7, 9]]) { }
+        return a * 10 + b;
+      }`,
+      79,
+    );
+  });
+
+  it("an `any`-typed array source now destructures by index (was NaN on both lanes)", async () => {
+    await standaloneOnly(
+      `var src: any = [4, 5];
+      var p: any, q: any;
+      export function test(): number {
+        for ([p, q] of [src]) { }
+        return p * 10 + q;
+      }`,
+      45,
+    );
+  });
+});
+
+describe("#4447 §7.4.4 — a `{ done }`-only IteratorResult reports the real done flag", () => {
+  it("reads `done` through __sget_done even when the module emits no __sget_value", async () => {
+    // The module below contains NO struct carrying a `value` field, so
+    // `__sget_value` is never emitted. Before, that forced `done := 1` on the
+    // first step, so the drain stopped at n === 1.
+    await standaloneOnly(
+      `var n = 0;
+      var iterator: any = { next: function () { n += 1; return { done: n >= 3 }; } };
+      var iterable: any = {};
+      iterable[Symbol.iterator] = function () { return iterator; };
+      var out: any;
+      export function test(): number {
+        for ([...out] of [iterable]) { break; }
+        return n;
+      }`,
+      3,
+    );
+  });
+});
+
+describe("#4447 §13.15.5.4 — object assignment pattern targets and defaults", () => {
+  it("`{ k: t = d }` writes `t`, not `k`, when the property is present", async () => {
+    await bothLanes(
+      `var b: any;
+      export function test(): number {
+        for ({ y: b = 22 } of [{ y: 5 }]) { }
+        return b;
+      }`,
+      5,
+    );
+  });
+
+  it("`{ k: t = d }` fires the default when the property is ABSENT", async () => {
+    await bothLanes(
+      `var a: any;
+      export function test(): number {
+        for ({ x: a = 11 } of [{ q: 1 }]) { }
+        return a;
+      }`,
+      11,
+    );
+  });
+
+  it("`{ k = d }` shorthand default fires only when the property is absent", async () => {
+    await bothLanes(
+      `var z: any, w: any;
+      export function test(): number {
+        for ({ z = 33 } of [{ q: 1 }]) { }
+        for ({ w = 44 } of [{ w: 7 }]) { }
+        return z * 10 + w;
+      }`,
+      337,
+    );
+  });
+
+  it("an empty-object source ({} → externref element) reads properties and defaults", async () => {
+    // `[{}]` lowers the element to an externref, which took a branch that never
+    // READ a property: the target degraded to the key name and only shorthand
+    // defaults were seen (and those fired unconditionally). This shape also
+    // exercises the #4447 module-global re-resolution — registering the
+    // property-name string constant shifts every module global's absolute
+    // index, and the stale one landed in the immutable IMPORT range
+    // ("immutable global #3 cannot be assigned") on the gc lane.
+    await bothLanes(
+      `var a: any, z: any;
+      export function test(): number {
+        for ({ x: a = 11 } of [{}]) { }
+        for ({ z = 33 } of [{}]) { }
+        return a * 100 + z;
+      }`,
+      1133,
+    );
+  });
+
+  it("an externref source with the property PRESENT does not fire the default", async () => {
+    await standaloneOnly(
+      `var src: any = { w: 7 };
+      var w: any;
+      export function test(): number {
+        for ({ w = 44 } of [src]) { }
+        return w;
+      }`,
+      7,
+    );
+  });
+
+  it("`null` does NOT fire a default — only `undefined` does (§13.15.5.4 / #1550)", async () => {
+    await bothLanes(
+      `var v: any;
+      export function test(): number {
+        for ({ k: v = 9 } of [{ k: null }]) { }
+        return v === null ? 1 : 0;
+      }`,
+      1,
+    );
+  });
+});
+
+describe("#4447 §13.15.5.4/5 — nested assignment patterns recurse", () => {
+  it("nested object pattern in the value position binds its targets", async () => {
+    await bothLanes(
+      `var y: any;
+      export function test(): number {
+        for ({ x: { y } } of [{ x: { y: 2 } }]) { }
+        return y;
+      }`,
+      2,
+    );
+  });
+
+  it("nested array pattern in the value position binds its targets", async () => {
+    await bothLanes(
+      `var y: any;
+      export function test(): number {
+        for ({ x: [y] } of [{ x: [321] }]) { }
+        return y;
+      }`,
+      321,
+    );
+  });
+
+  it("destructuring an ABSENT property through a nested pattern throws", async () => {
+    // §13.15.5.4 step 3 → §13.15.5.2 RequireObjectCoercible / GetIterator on
+    // `undefined`. Before: bound nothing and threw nothing. The thrown carrier
+    // is the module's native TypeError throw (an `$exc` tag payload, not a JS
+    // `TypeError` instance in the standalone lane), so this asserts THAT it
+    // throws — which is exactly what test262's `assert.throws(TypeError, …)`
+    // observes through the runner's harness transform.
+    const src = `export function test(): number {
+      for ({ x: { y } } of [{}]) { }
+      return 0;
+    }`;
+    await expect(run(src, "standalone")).rejects.toThrow();
+    await gcCompilesAndValidates(src);
+  });
+
+  it("a nested default fires before the nested pattern destructures it", async () => {
+    await standaloneOnly(
+      `var y: any;
+      export function test(): number {
+        for ({ x: { y } = { y: 8 } } of [{}]) { }
+        return y;
+      }`,
+      8,
+    );
+  });
+
+  it("a nested pattern as an ARRAY element binds its targets", async () => {
+    await standaloneOnly(
+      `var src: any = [[4, 5]];
+      var p: any, q: any;
+      export function test(): number {
+        for ([[p, q]] of [src]) { }
+        return p * 10 + q;
+      }`,
+      45,
+    );
+  });
+
+  it("a nested pattern as the REST target destructures the slice", async () => {
+    // `for ([...{ 1: x }] of …)` — §13.15.5.5 AssignmentRestElement PutValue's
+    // the remainder into an AssignmentPattern like any other target. Numeric
+    // PropertyNames count (`{ 1: x }`), which the key resolution also missed.
+    await standaloneOnly(
+      `var src: any = [[1, 2, 3]];
+      var a: any, b: any;
+      export function test(): number {
+        for ([...[a, b]] of src) { }
+        return a * 10 + b;
+      }`,
+      12,
+    );
+  });
+});


### PR DESCRIPTION
## Description

First implementation wave of the **#4444 ES6 (ES2015) standalone edition close-out** umbrella. ES2015 standalone measured at 7,695/11,704 (66%) host-free from the 2026-08-15 baseline (sha `734fab88`); the umbrella maps all ten failure clusters to owning issues, avoiding the lanes already in flight (generators #2864/#2906, Promise carrier #2867/#3178, method reflection #2175). Three unowned bounded clusters were planned (Fable lane) and implemented by Opus subagents in parallel worktrees, each validated with scoped A/B test262 runs before integration:

- **#4445 — annexB String HTML wrappers** (`5b715e1`): the 13 §B.2.3 methods added to `STRING_PROTO_METHODS` + a reflective CreateHTML closure body (`string-proto-html.ts`); tag table unified behind an own-property accessor, closing a latent `String.prototype.toString.call` mis-lowering. Scoped `annexB/built-ins/String/prototype`: **standalone 17 → 95/111** (13 HTML dirs 4/82 → 82/82), gc lane result set diff-identical.
- **#4447 — for-of head destructuring, slice 1** (`8dcbc88`): four root causes in the assignment form (missing GetIterator, `{done}`-only IteratorResult mis-read, object-pattern default/target resolution, dropped nested patterns) + two secondary fixes. Scoped `language/statements/for-of/dstr`: **standalone 342 → 400/569, gc 344 → 395**, assignment/dstr +6, **zero losses on all three buckets**. 19 new unit tests + 13-file regression sweep.
- **#4446 — native standalone `Array.prototype.concat` dynamic fallback** (`1881dba`): per-target switch — native §23.1.3.1 loop (`array-concat-spec.ts`) for native-first targets, host bridge moved verbatim to `array-method-host.ts` for gc. Scoped `built-ins/Array/prototype/concat`: **standalone 13 → 23/69, compile_error 29 → 1**, zero pass→non-pass; gc lane proven unchanged (all 69 emitted binaries sha256-identical to HEAD).

Docs commits carry the umbrella (#4444) with the full cluster→issue map and measured results, and the next-wave triage issues **#4449** (TypedArray residual, ~556 tests) and **#4450** (class residual, ~321 tests, with the 112-test `class/dstr` overlap flagged for post-#4447 re-measurement). Issue ids #4444–#4450 reserved on `origin/issue-assignments`; budget-gate allowances (`loc`/`func`/`coercion-sites`) are granted in the respective issue files' frontmatter.

Residuals deliberately deferred (named with reasons in each issue's Result section): assignment-target evaluation order, §7.4.9 IteratorClose refinements, NamedEvaluation/`fn.name`, the binding-form destructuring follow-up, ArraySpeciesCreate, vec-receiver symbol keys (#2866-adjacent), and the `trimLeft`/`trimRight` CSV follow-up.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016m4RbzgJe7infHw27fwU6L

---
_Generated by [Claude Code](https://claude.ai/code/session_016m4RbzgJe7infHw27fwU6L)_