### PR TITLE
fix(website): keep skipped stat clear of CTA

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -415,6 +415,13 @@
         overflow: visible;
       }
 
+      /* The donut's desktop orbit keeps its top stat and glow visible outside
+         the chart host. Reserve that overhang so the skipped count cannot
+         overlap the CTA row above it. */
+      #conformance-donut-slot {
+        padding-top: 72px;
+      }
+
       .bench-test-group {
         grid-column: 1 / -1;
         margin: 0 0 40px;
@@ -581,6 +588,12 @@
       @media (max-width: 720px) {
         .diagram-panel {
           padding: 0;
+        }
+      }
+
+      @media (max-width: 440px) {
+        #conformance-donut-slot {
+          padding-top: 0;
         }
       }
 


### PR DESCRIPTION
## Summary

- Reserve the desktop donut orbit's top overhang so the skipped count and glow stay clear of the CTA row.
- Restore the compact spacing on mobile, where orbit stats are hidden.

Follow-up to #4569.

## Validation

- `node --check website/components/t262-charts.js`
- `pnpm exec prettier --check website/index.html website/components/t262-charts.js`
- `git diff --check`
- `pnpm exec vitest run tests/issue-1777.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism --reporter=dot` (6/6)
