### PR TITLE
fix(#4458): legacy codegen mis-compiles `<T>x` and `x satisfies T` to 0

### DIFF
--- a/plan/issues/4458-legacy-type-assertion-miscompile.md
+++ b/plan/issues/4458-legacy-type-assertion-miscompile.md
@@ -1,0 +1,193 @@
+---
+id: 4458
+title: "Legacy direct-codegen mis-compiles <T>x and x satisfies T to 0"
+status: done
+completed: 2026-08-15
+priority: high
+task_type: bug
+area: codegen
+sprint: current
+horizon: s
+model: opus
+assignee: ttraenkler/opus-4458
+related: [3583]
+loc-budget-allow:
+  - src/codegen/expressions.ts
+func-budget-allow:
+  - src/codegen/expressions.ts::compileExpressionInner
+---
+
+# #4458 — legacy direct-codegen mis-compiles type-erased wrapper expressions
+
+## Problem
+
+The **legacy** direct AST→Wasm front-end silently mis-compiled two of the three
+type-erased wrapper expressions:
+
+| form | legacy path (before) | IR path |
+| --- | --- | --- |
+| `x as T` (`AsExpression`) | correct | correct |
+| `<T>x` (`TypeAssertionExpression`) | **evaluates to `0`** | correct |
+| `x satisfies T` (`SatisfiesExpression`) | **evaluates to `0`** | correct |
+
+`x as T` was **not** affected — the legacy dispatcher already had that arm. The
+task brief flagged all three as suspect; measurement narrowed it to two.
+
+The failure was **silent**: `compile()` returned `success: true` with an empty
+`errors` array. There was no compile error and no warning — just a wrong value.
+
+Discovered during #3583 (2026-08-15). The IR front-end grew unwrap arms for all
+three forms in `isPhase1Expr`/`lowerExpr`, so only functions the **IR selector
+rejects** (fallback bodies, non-claimed shapes) kept the wrong behaviour. That
+made the bug invisible to any test whose body the IR path happens to claim.
+
+## Reproduction
+
+`2 ** 1` is used as a deliberate IR-selector rejector to force the legacy
+fallback. It is empirically load-bearing: with it the wrapper yields `0`,
+without it the IR path yields the operand. (The exact IR rejection *reason*
+string was not extracted — the behavioural flip is the evidence.)
+
+```ts
+export function test(): number {
+  const x: number = 7;
+  const y = <number>x;
+  return y + 2 ** 1;   // expected 9, got 2  →  y evaluated to 0
+}
+```
+
+Measured on `92f78620` (probe over all three forms × legacy/IR-claimed):
+
+```
+PASS as (legacy via **):        ret=9  (expected 9)
+FAIL angle (legacy via **):     ret=2  (expected 9)
+FAIL satisfies (legacy via **): ret=2  (expected 9)
+PASS as (plain):                ret=9
+PASS angle (plain):             ret=9
+PASS satisfies (plain):         ret=9
+```
+
+The emitted WAT for the failing case shows the operand replaced by a constant,
+with **no diagnostic**:
+
+```wat
+(func $test (result f64)
+  (local $x i32)
+  (local $y i32)
+  i32.const 7
+  local.set 0
+  i32.const 0      ;; <-- `<number>x` became 0
+  local.tee 1
+  f64.convert_i32_s
+  f64.const 2
+  f64.add
+  return)
+```
+
+## Root cause
+
+Two missing arms in the legacy expression dispatcher
+`compileExpressionInner` (`src/codegen/expressions.ts`). It handled
+`AsExpression` and `NonNullExpression` but had **no** `TypeAssertionExpression`
+or `SatisfiesExpression` case, so both fell all the way through to the tail:
+
+```ts
+reportError(ctx, expr, `Unsupported expression: ${ts.SyntaxKind[expr.kind]}`);
+return null;
+```
+
+The silence is the second half of the root cause, and it is what let this
+survive: the caller `compileExpressionBody` wraps the inner compile in the
+**#1919 speculative transaction**. On a `null` result it runs
+`rollbackSpeculative(ctx, fctx, snap)`, which discards the partial body **and
+the errors the inner compile leaked**, then calls `pushDefaultValue` — emitting
+`i32.const 0` / `f64.const 0`. So the `Unsupported expression` diagnostic was
+raised and then thrown away, converting a would-be compile error into a wrong
+answer. Verified: on base, `<T>x` in const-init, return, and call-argument
+position all compile with `success=true, errors=[]`.
+
+Notably the file already unwrapped `TypeAssertionExpression` in three *other*
+places (the null/undefined numeric fast-path at ~L723/L786/L812) — so the node
+kind was known to the module; only the value-producing dispatcher missed it.
+`SatisfiesExpression` was absent from `src/codegen/expressions.ts` entirely,
+although ~15 other `src/codegen/**` modules already unwrap it.
+
+## Fix
+
+`src/codegen/expressions.ts`, in `compileExpressionInner`. Rather than adding
+two more parallel arms beside `isAsExpression`, the existing `as` arm is widened
+to cover all three erased forms — they have identical lowering, and one arm
+makes that explicit (and costs 8 fewer lines in a god-file):
+
+```ts
+if (ts.isAsExpression(expr) || ts.isTypeAssertionExpression(expr) || ts.isSatisfiesExpression(expr)) {
+  return compileExpressionInner(ctx, fctx, expr.expression, expectedType);
+}
+```
+
+Forwarding `expectedType` unchanged is what makes this a pure unwrap: the
+operand is compiled into exactly the context the wrapper occupied, so the
+wrapper is erased rather than re-typed.
+
+### Budget allowances (LOC + function)
+
+The same +8 lines trip two gates, both granted in the frontmatter above:
+
+- **LOC** — `src/codegen/expressions.ts` is a gated god-file (cap 1670) → 1678.
+- **Function** — `compileExpressionInner` (cap 660) → 668.
+
+Justification for both:
+
+- A dispatcher arm has exactly one correct home — the dispatcher. The gate's
+  standard remedy ("add to the subsystem module, not the barrel/driver") does
+  not apply: relocating the erased-wrapper case would split it from the
+  `AsExpression` arm it is definitionally identical to, in a different file.
+- The change was already minimised. The first cut added two separate arms
+  (+18); folding all three into one condition cut that to +8, of which **6 are
+  the comment** and 2 are code. The net *executable* growth is two `||` clauses.
+- It is a correctness fix for a silent miscompile, not a feature.
+
+## Test Results
+
+`tests/equivalence/issue-4458-type-assertions.test.ts` — 16 cases covering
+`<T>x`, `x satisfies T` and `x as T` (control) across const-initializer, return,
+call-argument and nested-wrapper positions, over number/string/boolean/array
+operands, plus two side-effect cases asserting the wrapper does not swallow a
+call in its operand. Each legacy case is paired with an IR-claimed twin so the
+two front-ends are pinned to the same answer.
+
+| | fix | base (`92f78620`) |
+| --- | --- | --- |
+| `issue-4458-type-assertions.test.ts` | 16 / 16 pass | **12 fail**, 4 pass |
+
+The 4 that pass on base are exactly the intended controls: both `x as T` cases
+and the two IR-claimed variants. This confirms the suite guards the real defect
+rather than passing vacuously.
+
+Other gates:
+
+- `pnpm run check:ir-fallbacks` — **OK**, no unintended / post-claim /
+  module-level increases vs. baseline.
+- Scoped equivalence run (`gradual-typing`, `destructuring-type-coercion`,
+  `iife-and-call-expressions`, `compound-assignment-nonref-element`,
+  `illegal-cast-assert-throws`) — 118 / 118 pass.
+- `tests/equivalence/yield-as-expression.test.ts` has **1 pre-existing failure**
+  ("yield without value used as IIFE argument"). Verified identical on base
+  (1 failed / 3 passed both with and without the fix) — unrelated to #4458, not
+  introduced here, and left untouched.
+
+Budget gate: `budget-status --pick` reported 100% remaining, per-agent share
+100%, horizon ≤ XL. This is an `S`-horizon task, well inside the allowance — no
+allowance exception needed.
+
+## Notes / follow-up
+
+The #1919 speculative rollback swallowing a `reportError` is the reason a
+missing dispatcher arm degrades to a **wrong value** instead of a compile error.
+That is a general hazard, not specific to these two node kinds: any future
+unhandled expression kind on the legacy path will fail the same silent way.
+Worth a separate issue — e.g. let `reportError` mark `Unsupported expression`
+`sticky` (the mechanism already exists, #3725, and is honoured by the same
+rollback) so the diagnostic survives the unwind. Deliberately **not** changed
+here: it would alter behaviour for every other unhandled kind at once and needs
+its own conformance measurement.

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -1499,7 +1499,15 @@ function compileExpressionInner(
     return compileArrayLiteral(ctx, fctx, expr);
   }
 
-  if (ts.isAsExpression(expr)) {
+  // (#4458) All three type-erased wrappers — the operand IS the value, so
+  // forward `expectedType` unchanged and let the operand compile into exactly
+  // the context the wrapper occupied. `<T>x` and `x satisfies T` used to have no
+  // arm here and fell through to the `Unsupported expression` reporter; the
+  // #1919 speculative rollback in `compileExpressionBody` then discarded that
+  // diagnostic along with the partial body and pushed a default instead, so both
+  // silently compiled to 0 rather than erroring. IR unwraps all three (#3583),
+  // so only bodies the IR selector rejects were affected.
+  if (ts.isAsExpression(expr) || ts.isTypeAssertionExpression(expr) || ts.isSatisfiesExpression(expr)) {
     return compileExpressionInner(ctx, fctx, expr.expression, expectedType);
   }
 

--- a/tests/equivalence/issue-4458-type-assertions.test.ts
+++ b/tests/equivalence/issue-4458-type-assertions.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./helpers.js";
+
+/**
+ * #4458 — the LEGACY direct front-end mis-compiled type-erased wrapper
+ * expressions.
+ *
+ * `compileExpressionInner` (src/codegen/expressions.ts) had arms for
+ * `AsExpression` and `NonNullExpression` but none for `TypeAssertionExpression`
+ * (`<T>x`) or `SatisfiesExpression` (`x satisfies T`). Both fell through to the
+ * `Unsupported expression` reporter and returned `null`; the #1919 speculative
+ * rollback in `compileExpressionBody` then discarded that diagnostic together
+ * with the partial body and substituted a default value — so the wrapper
+ * evaluated to **0** with a fully successful compile and no diagnostic.
+ *
+ * The IR front-end already unwraps all three forms (#3583), so only bodies the
+ * IR selector REJECTS were affected. Every `legacy` case below therefore
+ * contains a deliberate IR rejector (`**`) to force the fallback; the matching
+ * `IR-claimed` case omits it, so the pair also pins the two front-ends to the
+ * same answer.
+ */
+describe("#4458 type-erased wrapper expressions on the legacy path", () => {
+  describe("angle-bracket assertion <T>x", () => {
+    it("legacy path (IR-rejected body): const initializer", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const x: number = 7;
+          const y = <number>x;
+          return y + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("IR-claimed body: const initializer", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const x: number = 7;
+          const y = <number>x;
+          return y + 2;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("legacy path: return position", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const x: number = 7;
+          return (<number>x) + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("legacy path: call argument", async () => {
+      const exports = await compileToWasm(`
+        function id(n: number): number {
+          return n;
+        }
+        export function test(): number {
+          const x: number = 7;
+          return id(<number>x) + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("legacy path: nested wrappers unwrap to the operand", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const x: number = 7;
+          const y = <number>(<number>x);
+          return y + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+  });
+
+  describe("satisfies operator x satisfies T", () => {
+    it("legacy path (IR-rejected body): const initializer", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const x: number = 7;
+          const y = x satisfies number;
+          return y + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("IR-claimed body: const initializer", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const x: number = 7;
+          const y = x satisfies number;
+          return y + 2;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("legacy path: return position", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const x: number = 7;
+          return (x satisfies number) + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("legacy path: call argument", async () => {
+      const exports = await compileToWasm(`
+        function id(n: number): number {
+          return n;
+        }
+        export function test(): number {
+          const x: number = 7;
+          return id(x satisfies number) + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+  });
+
+  describe("as expression x as T (control — was already correct)", () => {
+    it("legacy path (IR-rejected body): const initializer", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const x: number = 7;
+          const y = x as number;
+          return y + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("IR-claimed body: const initializer", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const x: number = 7;
+          const y = x as number;
+          return y + 2;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+  });
+
+  describe("non-number operands survive the unwrap", () => {
+    it("legacy path: <T>x over a string", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const s: string = "abcd";
+          const t = <string>s;
+          return t.length + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(6);
+    });
+
+    it("legacy path: satisfies over a boolean", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const b: boolean = true;
+          const c = b satisfies boolean;
+          return (c ? 7 : 3) + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("legacy path: <T>x over an array element read", async () => {
+      const exports = await compileToWasm(`
+        export function test(): number {
+          const arr: number[] = [1, 2, 7];
+          const v = <number>arr[2];
+          return v + 2 ** 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+  });
+
+  describe("the wrapper does not swallow operand side effects", () => {
+    it("legacy path: <T>f() still calls f", async () => {
+      const exports = await compileToWasm(`
+        let calls: number = 0;
+        function bump(): number {
+          calls = calls + 1;
+          return 7;
+        }
+        export function test(): number {
+          const y = <number>bump();
+          return y + calls + 2 ** 1 - 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+
+    it("legacy path: (f() satisfies T) still calls f", async () => {
+      const exports = await compileToWasm(`
+        let calls: number = 0;
+        function bump(): number {
+          calls = calls + 1;
+          return 7;
+        }
+        export function test(): number {
+          const y = bump() satisfies number;
+          return y + calls + 2 ** 1 - 1;
+        }
+      `);
+      expect(exports.test()).toBe(9);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Implements #4458 (correctness bug found during #3583's measurement, now with its own issue file in this PR). Opus-implemented; the authoring agent was killed by a container restart after pushing — work verified complete from the branch.

**Reproduced:** on the legacy direct path, `<T>x` (angle-bracket TypeAssertion) and `x satisfies T` both evaluated the operand as **0** (probe: ret=2 vs expected 9); `x as T` was already correct (it has a dispatcher arm), and the IR path handles all three correctly. **Root cause:** `compileExpressionInner` (`src/codegen/expressions.ts`) had arms for `AsExpression` + `NonNullExpression` but none for `TypeAssertionExpression`/`SatisfiesExpression` — the missing arms fell through to the zero default. **Fix:** mirror the `AsExpression` pass-through for both kinds.

Matters wherever legacy still compiles a body (IR-rejected shapes, fallback bodies). Equivalence tests cover all three wrapper forms on legacy-forced and IR-claimed variants.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_