### PR TITLE
fix(#4466): repair the 7 test262 regressions #4507 landed on main

### DIFF
--- a/plan/issues/4466-4507-landed-seven-test262-regressions-on-main.md
+++ b/plan/issues/4466-4507-landed-seven-test262-regressions-on-main.md
@@ -1,0 +1,173 @@
+---
+id: 4466
+title: "#4507 landed 7 test262 regressions on main — three independent codegen defects the queue let through"
+status: done
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+completed: 2026-08-15
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+goal: spec-completeness
+# The growth in both files is comment, not logic: each fix records WHY the
+# constraint it restores is load-bearing, so the next change does not remove it
+# again the way #4507 did. Net logic is roughly flat — the gate in
+# closed-method-dispatch.ts trades an inline `.some(...)` for a named predicate,
+# and literals.ts only re-adds one condition.
+loc-budget-allow:
+  - src/codegen/closed-method-dispatch.ts
+  - src/codegen/literals.ts
+# Same reason, function scope: the whole +11 here is the comment explaining why
+# the `native-first` gate must stay. Splitting the function to make room for a
+# comment would be the wrong response to a regression fix.
+func-budget-allow:
+  - src/codegen/literals.ts::compileObjectLiteralWithAccessors
+---
+
+# #4466 — #4507 landed 7 test262 regressions on main
+
+## Problem
+
+PR #4507 ("fix(marked): bound upstream compilation and preserve class object
+shapes", merged as `6756ed8c2`) turned 7 test262 tests from `pass` to `fail` on
+`main`. They are real and deterministic, not flake — reproduced three times on
+`976e0f886` through the same execution function CI's js-host shard uses, with
+identical error text every run.
+
+| test262 file | error |
+| --- | --- |
+| `language/expressions/object/dstr/meth-dflt-obj-ptrn-empty.js` | `Cannot destructure 'null' or 'undefined' [in __anon_5_method()]` |
+| `language/expressions/object/dstr/gen-meth-dflt-obj-ptrn-empty.js` | same |
+| `language/expressions/object/dstr/async-gen-meth-dflt-obj-ptrn-empty.js` | same |
+| `language/expressions/array/spread-obj-manipulate-outter-obj-in-getter.js` | `Expected SameValue(«true», «false»)` |
+| `language/expressions/new/spread-obj-manipulate-outter-obj-in-getter.js` | same |
+| `language/expressions/super/call-spread-obj-manipulate-outter-obj-in-getter.js` | same |
+| `language/statements/class/elements/super-access-inside-a-private-method.js` | `dereferencing a null pointer [in __obj_meth_tramp_C___priv_m_cached()]` |
+
+### How it reached main despite the gate catching it
+
+The queue did its job and was overruled by its own baseline moving:
+
+- #4507's `merge_group` run reported exactly these 7 as regressions and failed.
+- #4567's `merge_group` run (a completely unrelated PR, whose group sat on top
+  of #4507) reported the **identical** 7 and failed —
+  [run 31892848578](https://github.com/loopdive/js2wasm/actions/runs/31892848578).
+- The next group, #4566's, was built speculatively **on top of #4567** —
+  therefore containing both PRs' code — and reported **0 regressions** against
+  the *same* baseline sha (`e07c1a6`). That group passed and merged, and
+  speculative batching carried #4507 and #4567 in with it.
+
+So an identical failure signature on two unrelated PRs read as the drift
+signature the gate itself documents ("overlapping clusters across unrelated PRs
+are drift"), while the 0-regression neighbour looked like exoneration. Both
+readings were wrong: the cluster was one PR's real defect, seen by every group
+that contained it.
+
+**Baseline consequence, worth knowing:** the promoted baseline now banks three
+of the seven (`*-dflt-obj-ptrn-empty`) as `fail`. A gate cannot flag what it
+already records as failing, so those three were unprotected until this fix
+lands and the next promote restores them to `pass`.
+
+## Attribution
+
+Adjacent-commit A/B (`c3ff8a1fa` = `6756ed8c2^1`), then per-file revert from
+`6756ed8c2`, then per-hunk. All 7 pass at `c3ff8a1fa`; all 7 fail at
+`6756ed8c2`. Three independent defects, one per failure family:
+
+| file | failures | mechanism |
+| --- | --- | --- |
+| `src/codegen/closed-method-dispatch.ts` | the 3 `*-dflt-obj-ptrn-empty` | relaxed arity gate admits under-application the arm cannot express |
+| `src/codegen/literals.ts` | the 3 spread-getter | dropped `native-first` gate puts the host lane on eager materialization |
+| `src/codegen/closures/method-trampolines.ts` | the private-method one | receiver re-coerced on the finalize REBUILD path |
+
+### (1) The under-application gate admits more than the arm can express
+
+#4507 relaxed `collectMethodEntries`' arity check from "exactly `1 + exactArity`
+params" to "under-application is fine when every omitted formal is optional",
+and taught `buildEntryArm` to synthesize a value for each omitted formal. Those
+are two different questions, and merging them is the bug.
+
+`buildEntryArm` can only faithfully stand in for an omitted formal whose default
+is a **compile-time constant** (it materializes the constant) or whose type is
+**f64** (it pushes the `0x7ff00000deadc0de` NaN sentinel the callee's prologue
+recognizes). For every other lane it pushes a typed zero/null — which the callee
+cannot distinguish from an explicitly passed argument. So `method({} = obj)`
+called with no arguments never runs `= obj` and destructures a null.
+
+Setting `$__argc` in the arm (mirroring `maybeSetArgcForKnownCall`) was tried
+and does **not** fix it — the callee still destructures null — and pushing the
+argc restore *after* the call breaks Wasm validation outright
+(`f64.convert_i32_s expected type i32, found call of type externref`), because a
+later fixup pass depends on the call being the last instruction before result
+coercion. **Fix:** admit only what the arm can express; everything else falls
+back to the host path exactly as before #4507.
+
+Cost: #4507's cited marked case (`inline(text)` with `tokens = []`, an
+expression default on a ref-typed formal) goes back to the host fallback. That
+is the correct trade — a conformance gain bought with a silently wrong value is
+negative value — but it is a real partial revert of #4507's intent, and a
+follow-up that gives ref-typed expression defaults a genuine absence signal
+would recover it.
+
+### (2) The `native-first` gate on spread materialization is load-bearing
+
+#4507 removed `ctx.targetProfile.semanticProviders === "native-first"` from the
+closed-struct spread-source materialization, so the **JS-host** lane also
+materializes the struct into an open `$Object` before `__object_assign`. The
+host lane already reads closed structs through host reflection and needs no
+materialization — and materializing changes observable behaviour: the eager
+field walk snapshots the source *before* `__object_assign` runs, so a getter
+that mutates the other spread source mid-spread no longer sees spec
+CopyDataProperties ordering. **Fix:** restore the gate.
+
+### (3) Don't re-coerce the receiver on the finalize rebuild
+
+#4507 added `coerceTrampolineThisSlot` at three sites. The two emit-time sites
+are fine. The third, in `finalizeMethodTrampolines`, runs on the rebuild path
+and aliases `tFctx.body = newBody` so the coercion can append there — which is
+independently against the rule in `CLAUDE.md` ("`body: []` in FunctionContext,
+NOT `body: func.body` — shared references break the savedBody/swap pattern").
+Removing that hunk fixes the private-method trampoline; the other two sites stay.
+
+## Fix
+
+- `closed-method-dispatch.ts` — `canSynthesizeOmitted` gate: constant default,
+  or `?` with no initializer, or an f64 expression default. Nothing else.
+- `literals.ts` — restore the `native-first` gate, with a comment recording why
+  removing it is not a safe trade.
+- `closures/method-trampolines.ts` — drop the finalize-path re-coercion and its
+  `tFctx.body` aliasing.
+
+## Verification
+
+All 7 test262 files, js-host lane, run through `runTest262Chunk` (the same
+function `tests/test262-chunk*.test.ts` call) scoped by `TEST262_PATH_FILTER`:
+
+| state | result |
+| --- | --- |
+| `c3ff8a1fa` (before #4507) | 7 pass |
+| `main` `9e17d34f3` | **0 pass, 7 fail** |
+| main + this fix | **7 pass** |
+
+`tests/multi-file.test.ts` (touched by #4507) passes. TS5 typecheck clean.
+
+`tests/issue-4466-4507-conformance-regression.test.ts` pins root cause (3) and
+is verified non-vacuous — it fails against the unfixed compiler. Root causes (1)
+and (2) have **no** unit test on purpose: every reduced source tried for them
+either failed for an unrelated reason or passed pre-fix, i.e. never reached the
+path that broke. Their coverage is the six test262 files, named in that test
+file's header. See also `plan/issues/1363-spec-gap-class-dstr-runtime-cannot-destructure-null.md`,
+which fixed this same "Cannot destructure" family in Sprint 51.
+
+## Follow-ups (not in this PR)
+
+- Give ref-typed expression defaults a real absence signal so the under-applied
+  closed-method arm can serve marked's `inline(text)` case again.
+- The queue hole this exposed: a group that contains a failing predecessor can
+  report 0 regressions because the baseline it diffs against has moved, and
+  speculative batching then merges the predecessor. Worth a separate issue
+  against the merge-group regression gate.

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -464,13 +464,25 @@ function collectMethodEntries(ctx: CodegenContext, methodName: string, exactArit
     const paramTypes = funcType.params.slice(1);
     const optionalParams = ctx.funcOptionalParams.get(fullName) ?? [];
     // A fixed-arity call may under-apply a method only when every omitted
-    // formal has a default/optional marker.  The callee's normal parameter
-    // prologue recognizes the same sentinels as identifier calls; rejecting
-    // this case sends valid calls (e.g. marked's `inline(text)` where the
-    // second parameter defaults to `[]`) to the host fallback instead.
+    // formal has a default/optional marker AND `buildEntryArm` can faithfully
+    // stand in for it. Those are two different questions, and (#4466) treating
+    // them as one is what broke `({ m({} = {}) {} }).m()`: an omitted formal
+    // whose default is a non-constant EXPRESSION has to be evaluated by the
+    // callee, which needs to know the argument was absent. Only the f64 lane
+    // carries a sentinel the prologue recognizes; for every other lane the arm
+    // can push nothing better than a typed zero/null, which the callee cannot
+    // tell apart from an explicitly passed value — so it destructures a null
+    // instead of running `= {}`. Admit only what the arm can express; the rest
+    // falls back to the host path exactly as it did before.
+    const canSynthesizeOmitted = (index: number, type: ValType | undefined): boolean => {
+      const opt = optionalParams.find((o) => o.index === index);
+      if (!opt) return false;
+      if (!opt.hasExpressionDefault) return true; // constant default, or `?` with none
+      return type?.kind === "f64"; // the one lane with an absence sentinel
+    };
     if (exactArity !== null) {
       if (paramTypes.length < exactArity) continue;
-      if (paramTypes.slice(exactArity).some((_type, i) => !optionalParams.some((o) => o.index === exactArity + i))) {
+      if (paramTypes.slice(exactArity).some((type, i) => !canSynthesizeOmitted(exactArity + i, type))) {
         continue;
       }
     }

--- a/src/codegen/closures/method-trampolines.ts
+++ b/src/codegen/closures/method-trampolines.ts
@@ -475,8 +475,16 @@ export function finalizeMethodTrampolines(ctx: CodegenContext): void {
       // scan only when it wasn't recorded.
       const usesThis = t.methodUsesThis ?? methodBodyReadsThis(ctx, t.methodFuncIdx);
       newBody = buildTrampolineThisSlot(ctx, t.objStructTypeIdx, anyTempLocalIdx, usesThis);
-      tFctx.body = newBody;
-      coerceTrampolineThisSlot(ctx, newBody, t.objStructTypeIdx, sig.params[0], usesThis, tFctx);
+      // (#4466) Do NOT re-coerce the receiver here, and do NOT alias
+      // `tFctx.body` to `newBody` to make that possible. The emit-time call
+      // sites (`emitObjectMethodAsClosure`, `ensureMethodClosureSingleton`)
+      // already reconcile the receiver; repeating it on the finalize REBUILD
+      // path corrupted the private-method trampoline
+      // (`class/elements/super-access-inside-a-private-method.js` →
+      // "dereferencing a null pointer" in `__obj_meth_tramp_*_cached`). The
+      // aliasing is independently against the rule in CLAUDE.md — a
+      // FunctionContext must own `body: []`, never a shared reference, or the
+      // savedBody/swap pattern writes through into someone else's buffer.
     }
     for (let i = 0; i < methodUserParams.length; i++) {
       newBody.push({ op: "local.get", index: i + 1 });

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -811,14 +811,25 @@ function compileObjectLiteralWithAccessors(
       // Compile spread source and call __object_assign(target, [source])
       const srcType = compileExpression(ctx, fctx, prop.expression);
       if (srcType) {
-        // A spread source whose STATIC type is a closed-shape struct
-        // (`{...typedObj}`) must be materialized into a real open `$Object`
-        // before `__object_assign`.  Reinterpreting the struct with
-        // `extern.convert_any` leaves its GC fields invisible to the dynamic
-        // own-key walk, so inherited fields (notably Marked's rule tables) are
-        // silently lost.  This applies to the JS-host and native providers;
-        // both consume the same open-object representation here.
+        // (#3222 C1) In standalone/WASI, a spread source whose STATIC type is a
+        // closed-shape struct (`{...typedObj}`) would otherwise be reinterpreted
+        // as an externref via `coerceType` and handed to `__object_assign`, whose
+        // native enumeration walks only the open-`$Object` hash — so it copies
+        // NOTHING (the struct fields are invisible to `__object_keys`). Instead
+        // materialize the struct into a real open `$Object` first (own-enumerable
+        // fields only) so `__object_assign` enumerates and copies them correctly.
+        //
+        // (#4466) The `native-first` gate is load-bearing, not a leftover. The
+        // host lane reads closed structs through host reflection already, so it
+        // needs no materialization — and materializing there CHANGES OBSERVABLE
+        // SPEC BEHAVIOUR: the eager field walk snapshots the source before
+        // `__object_assign` runs, so a getter that mutates the outer object
+        // mid-spread no longer sees the spec's CopyDataProperties ordering
+        // (`language/expressions/{array,new,super}/spread-obj-manipulate-outter-
+        // obj-in-getter.js` all flip pass→fail). Dropping the gate to reach a
+        // dogfood case in the host lane is not a safe trade.
         const spreadStructIdx =
+          ctx.targetProfile.semanticProviders === "native-first" &&
           (srcType.kind === "ref" || srcType.kind === "ref_null") &&
           typeof (srcType as { typeIdx?: number }).typeIdx === "number" &&
           ctx.typeIdxToStructName.has((srcType as { typeIdx: number }).typeIdx)

--- a/tests/issue-4466-4507-conformance-regression.test.ts
+++ b/tests/issue-4466-4507-conformance-regression.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4466 — the three independent codegen defects #4507 landed on `main`, each
+// pinned by the SHAPE of the test262 file it broke.
+//
+// #4507 ("bound upstream compilation and preserve class object shapes") went
+// through the merge queue while its own `merge_group` run was reporting these
+// as pass→fail. It merged anyway because the NEXT queue group — which already
+// contained it — diffed against a baseline that had moved, and so read 0
+// regressions. The failures were real and deterministic on `main`.
+//
+// SHAPE IS LOAD-BEARING HERE. A first cut of this file used the obvious
+// simplification of each case (`const o = { m({} = {}) {} }; o.m()`, a direct
+// `this.#priv()`, a spread of a plain literal) and every assertion PASSED
+// against the unfixed compiler — the simplified sources never reach the paths
+// that break. Only root cause (3) reduces to a source that genuinely
+// reproduces; see the note below the helper for why (1) and (2) are covered by
+// their test262 files instead. Before changing the source below, re-run it
+// against the pre-fix compiler and confirm it still fails.
+//
+// The three root causes share nothing but their author:
+//
+//  1. `closed-method-dispatch.ts` relaxed the closed-method arity gate to admit
+//     under-applied calls, but the arm it builds can only stand in for an
+//     omitted formal whose default is a CONSTANT (or an f64, which has an
+//     absence sentinel the callee's prologue recognizes). For any other lane it
+//     pushes a typed zero/null the callee cannot tell from a real argument, so
+//     the default never runs and the callee destructures a null.
+//     → `language/expressions/object/dstr/{,gen-,async-gen-}meth-dflt-obj-ptrn-empty.js`
+//  2. `literals.ts` dropped the `native-first` gate on spread-source
+//     materialization, putting the JS-host lane on an eager field walk that
+//     snapshots the source before `__object_assign` — changing what a getter
+//     that mutates the outer object mid-spread observes.
+//     → `language/expressions/{array,new,super}/spread-obj-manipulate-outter-obj-in-getter.js`
+//  3. `method-trampolines.ts` re-coerced the receiver on the finalize REBUILD
+//     path (aliasing `tFctx.body` to the trampoline body to do it), corrupting
+//     the cached private-method trampoline.
+//     → `language/statements/class/elements/super-access-inside-a-private-method.js`
+//
+// Assertions are made INSIDE the module and reported as a number, so nothing
+// depends on marshalling a string or object back across the JS boundary.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/** Compile + run `test()` on the default JS-host (gc) lane — CI's js-host shard. */
+async function runHost(src: string): Promise<number> {
+  const r = await compile(src);
+  expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => number }).test();
+}
+
+// NOTE — root causes (1) and (2) have NO unit test here, deliberately.
+//
+// Every reduced TypeScript source tried for them either failed for an
+// unrelated reason (`delete` on a typed record) or PASSED against the UNFIXED
+// compiler — i.e. it never reached the path that broke. For (1) that is the
+// closed-method dispatcher (`__call_m_<name>_<arity>`), which a reduced source
+// does not engage: shape-erased receivers, two same-named methods on
+// differently-shaped literals, and generator methods were all tried and all
+// passed pre-fix. Shipping those would have banked a test that proves nothing
+// and reads as armor.
+//
+// The coverage for (1) and (2) is the test262 files themselves, which CI's
+// js-host shard runs on every merge_group. Each was verified locally
+// pass (pre-#4507) → fail (on main) → pass (with this fix):
+//   test262/test/language/expressions/object/dstr/meth-dflt-obj-ptrn-empty.js
+//   test262/test/language/expressions/object/dstr/gen-meth-dflt-obj-ptrn-empty.js
+//   test262/test/language/expressions/object/dstr/async-gen-meth-dflt-obj-ptrn-empty.js
+//   test262/test/language/expressions/array/spread-obj-manipulate-outter-obj-in-getter.js
+//   test262/test/language/expressions/new/spread-obj-manipulate-outter-obj-in-getter.js
+//   test262/test/language/expressions/super/call-spread-obj-manipulate-outter-obj-in-getter.js
+//
+// Their protection is restored once this lands: three of them are currently
+// banked as `fail` in the promoted baseline (the regression gate cannot flag
+// what it already records as failing), and the next promote after this merge
+// puts them back to `pass`.
+
+// NOTE — root cause (2) has NO unit test here, deliberately. Every reduced
+// TypeScript source I could write either failed for an unrelated reason
+// (`delete` on a typed record) or passed against the UNFIXED compiler, i.e. it
+// did not reach the path that broke. Rather than ship a test that proves
+// nothing, the coverage for (2) is the three test262 files themselves, which
+// CI's js-host shard runs on every merge_group:
+//   test262/test/language/expressions/array/spread-obj-manipulate-outter-obj-in-getter.js
+//   test262/test/language/expressions/new/spread-obj-manipulate-outter-obj-in-getter.js
+//   test262/test/language/expressions/super/call-spread-obj-manipulate-outter-obj-in-getter.js
+// All three were verified pass→fail→pass across the fix locally.
+
+describe("#4466 (3) cached private-method trampoline keeps a live receiver", () => {
+  it("calls an EXTRACTED private method that reads super", async () => {
+    // `super-access-inside-a-private-method.js`: the private method is reached
+    // as a VALUE through `.call(o)`, which routes via the cached trampoline and
+    // `__call_fn_method_0`. Pre-fix this gave "dereferencing a null pointer" in
+    // `__obj_meth_tramp_*_cached`. A direct `this.#m()` does NOT reproduce it.
+    expect(
+      await runHost(
+        `class A {
+           method(): string {
+             return "Test262";
+           }
+         }
+         class C extends A {
+           #m(): string {
+             return super.method();
+           }
+           access(o: unknown): string {
+             return this.#m.call(o as C);
+           }
+         }
+         export function test(): number {
+           const c = new C();
+           if (c.access(c) !== "Test262") return 1;
+           if (c.access({}) !== "Test262") return 2;
+           return 0;
+         }`,
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

#4507 turned **7 test262 tests from pass to fail on `main`**. This restores all 7.

They are real and deterministic, not flake — reproduced three times on `976e0f886`, with identical error text each run, through the same execution function CI's js-host shard uses.

## Why it got in

The queue caught it and was overruled by its own baseline moving:

- #4507's `merge_group` run reported exactly these 7 and failed.
- #4567's run (unrelated PR, group stacked on #4507) reported the **identical** 7 and failed — [run 31892848578](https://github.com/loopdive/js2wasm/actions/runs/31892848578).
- #4566's group was built speculatively **on top of #4567**, so it contained both — and reported **0 regressions** against the *same* baseline sha (`e07c1a6`). It passed, and speculative batching carried #4507 and #4567 in with it.

An identical signature on two unrelated PRs looks exactly like the drift signature the gate documents, and the 0-regression neighbour looks like exoneration. Both readings were wrong.

## Attribution

Adjacent-commit A/B (`c3ff8a1fa` = `6756ed8c2^1`), then per-file, then per-hunk. Three independent defects, one per failure family:

| file | failures | mechanism |
| --- | --- | --- |
| `closed-method-dispatch.ts` | 3× `*-dflt-obj-ptrn-empty` | relaxed arity gate admits under-application the arm cannot express |
| `literals.ts` | 3× spread-getter | dropped `native-first` gate puts the host lane on eager materialization |
| `closures/method-trampolines.ts` | private-method null deref | receiver re-coerced on the finalize REBUILD path |

**(1)** `buildEntryArm` can only stand in for an omitted formal whose default is a **constant**, or whose type is **f64** (the one lane with an absence sentinel the callee's prologue recognizes). Elsewhere it pushes a typed zero/null the callee cannot distinguish from a real argument, so `method({} = obj)` never runs its default and destructures a null. The gate now admits only what the arm can express. Setting `$__argc` instead was tried and does **not** fix it; restoring argc *after* the call breaks Wasm validation outright, because a later fixup pass needs the call to be the last instruction before result coercion.

**(2)** The host lane already reads closed structs via host reflection. Materializing there snapshots the source *before* `__object_assign`, so a getter mutating the other spread source mid-spread no longer sees CopyDataProperties ordering. Gate restored, with the reason recorded in-place so it isn't removed again.

**(3)** The finalize rebuild aliased `tFctx.body` to the trampoline body to re-coerce the receiver — independently against the `body: []` FunctionContext rule in `CLAUDE.md`. Dropped; the two emit-time coercion sites stay.

## Verification

| state | 7 test262 files (js-host) |
| --- | --- |
| `c3ff8a1fa` (before #4507) | 7 pass |
| `main` `9e17d34f3` | **0 pass, 7 fail** |
| main + this fix | **7 pass** |

`tests/multi-file.test.ts` (touched by #4507) passes. TS5 typecheck clean.

The new test pins root cause (3) and is **verified non-vacuous** — it fails against the unfixed compiler. Root causes (1) and (2) get no unit test on purpose: every reduced source tried for them either failed for an unrelated reason or passed pre-fix, i.e. never reached the broken path. Their coverage is the six test262 files, named in the test file's header. Shipping a green-but-vacuous test would have read as armor while proving nothing.

Note: three of the seven are currently banked as `fail` in the promoted baseline, so the gate could not have flagged them again. The next promote after this merges restores them to `pass`.

## Known cost

#4507's cited marked case (`inline(text)` with `tokens = []` — an expression default on a ref-typed formal) returns to the host fallback. That is the right trade here, but it is a partial revert of #4507's intent; a follow-up giving ref-typed expression defaults a real absence signal would recover it. Listed with the other follow-up (the queue hole above) in `plan/issues/4466-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)