### PR TITLE
fix(#4469): private-method super/HomeObject regression — trampoline `this` bridge fired on nullability-only mismatch

### DIFF
--- a/plan/issues/4469-private-method-homeobject-call-regression.md
+++ b/plan/issues/4469-private-method-homeobject-call-regression.md
@@ -1,0 +1,151 @@
+---
+id: 4469
+title: "Private method + super HomeObject traps when .call()ed with a foreign receiver"
+status: done
+sprint: current
+created: 2026-08-15
+completed: 2026-08-15
+priority: high
+horizon: s
+feasibility: medium
+task_type: bug
+area: codegen
+related: [4507, 4578]
+---
+
+# #4469 — private-method HomeObject dispatch regressed to an uncatchable trap
+
+## Symptom
+
+Every PR in the merge queue failed the uncatchable-trap ratchet (#3189):
+`null_deref` **140 → 142**.
+
+Two test262 files flipped to `null_deref`:
+
+| File | Baseline | After #4507 |
+| --- | --- | --- |
+| `test/language/statements/class/elements/super-access-inside-a-private-method.js` | **pass** | `null_deref` |
+| `test/language/statements/class/elements/private-method-get-and-call.js` | fail (catchable) | `null_deref` |
+
+The first is the genuine conformance regression; the second was already
+failing, but a *catchable* failure became an *uncatchable* trap, which is what
+the ratchet counts.
+
+## Bisect
+
+First-parent probes on `main` (2026-08-15), run by the tech lead:
+
+| Commit | Time | Result |
+| --- | --- | --- |
+| `0b50dada` | — | PASS |
+| `d1cc32ef` | — | PASS |
+| `92f78620` | — | PASS |
+| `602aee7c` | — | PASS |
+| `63247601` (GVN, flag OFF) | — | untested, inert |
+| `c3ff8a1f` | 14:21 | **PASS** |
+| `6756ed8c` (PR #4507) | 14:58 | **TRAP** |
+
+Narrowed within #4507's diff by file-copy A/B (`git show c3ff8a1f:<file>` swapped
+in, one file at a time): reverting **only**
+`src/codegen/closures/method-trampolines.ts` to its `c3ff8a1f` content removes
+the trap. Every other file in the diff is innocent.
+
+## Repro
+
+```ts
+class A {
+  method(): string { return "Test262"; }
+}
+class C extends A {
+  #m(): string { return super.method(); }
+  access(o: any): string { return (this as any).#m.call(o); }
+}
+const c = new C();
+c.access(c);   // "Test262"
+c.access({});  // "Test262" — HomeObject is independent of the receiver
+```
+
+`null_deref` on **both** front-ends (`experimentalIR` true and false) and in
+both `target: "gc"` and `target: "standalone"` + `hostBridge: "always"`, which
+is what identified the break as shared class/closure plumbing rather than
+front-end selection.
+
+## Root cause
+
+`coerceTrampolineThisSlot` in `src/codegen/closures/method-trampolines.ts`
+(added by #4507, refined by `9b8f6f82`).
+
+`buildTrampolineThisSlot` produces the trampoline's receiver as a **nullable**
+`ref_null $S`, and that nullability is load-bearing: the #2025 passthrough
+hands the method `ref.null` whenever the resolved `this` is non-null but does
+not `ref.test` as this exact struct — i.e. exactly the foreign-receiver case
+`this.#m.call({})`.
+
+`coerceTrampolineThisSlot` then reconciled that slot with the method's hidden
+`this` parameter whenever the two `ValType.kind`s differed:
+
+```ts
+if (source.kind === methodThisType.kind) return;
+body.push(...coercionInstrs(ctx, source, methodThisType, fctx));
+```
+
+A class instance method's hidden `this` is a **non-null** `ref $S`
+(`class-bodies.ts`: `methodParams = [{ kind: "ref", typeIdx: structTypeIdx }]`),
+so `"ref_null" !== "ref"` and the bridge fired. Instrumented on the repro:
+
+```
+[tramp] src= {"kind":"ref_null","typeIdx":49} -> this= {"kind":"ref","typeIdx":49}  usesThis=true
+```
+
+Same struct — the mismatch is **nullability only**. `coercionInstrs`
+(`type-coercion.ts:4187`) answers `ref_null → ref` with
+`[{ op: "ref.as_non_null" }]`, so the designed null passthrough became an
+uncatchable trap at the ABI boundary, **before** the method body ran. `#m()`
+here only needs its HomeObject (`super.method()`) and never reads `this`, so the
+body would have returned `"Test262"` regardless of the receiver.
+
+The `methodUsesThis` guard added in `9b8f6f82` ("preserve nullable receivers for
+this-free methods") already patched the same class of bug for methods that never
+read `this`. `#m() { return super.method(); }` *does* read `this` in the emitted
+code — `super.method()` lowers to a direct call passing `this` on as the callee's
+receiver — so it fell through that guard into the trapping path.
+
+## Fix
+
+Limit the reconciliation to a genuine **cross-carrier** mismatch. `ref` and
+`ref_null` are one carrier family differing only in nullability; nullability is
+settled by the callee's own signature, never by a cast at the trampoline. The
+externref / anyref case that #4507 added the bridge for is untouched.
+
+```ts
+if (isStructRefCarrier(source) && isStructRefCarrier(methodThisType)) return;
+```
+
+`ref.as_non_null` never fixed a *typeIdx* mismatch anyway (it preserves the heap
+type), so the narrowing removes no capability: the only thing the ref→ref branch
+ever did was strip nullability, which is precisely the harmful part.
+
+## Test Results
+
+Behaviour is now **byte-for-byte parity with pre-#4507 `c3ff8a1f`** on both
+shapes, both front-ends, both targets:
+
+| Shape | pre-#4507 base | `main` (regressed) | with fix |
+| --- | --- | --- | --- |
+| `super-access-inside-a-private-method` | PASS | `null_deref` | **PASS** |
+| `private-method-get-and-call` | catchable throw / `NaN` | `null_deref` | **catchable throw / `NaN`** |
+
+`private-method-get-and-call` reading the foreign receiver's own `_v` is a
+separate, still-open gap (the #2025 passthrough gives the body a null receiver);
+this issue only restores it from uncatchable to catchable, which is what the
+ratchet measures.
+
+Pinned by `tests/issue-4469.test.ts` (both front-ends, module instantiated and
+run, direct and `.call(o)` invocations).
+
+## Non-goals
+
+Undoing #4507's Marked win. Its class-method identity / ABI-key /
+closed-dispatch changes (`class-member-keys.ts`, `closed-method-dispatch.ts`,
+`class-bodies.ts`, …) are untouched — only the trampoline receiver bridge is
+narrowed.

--- a/plan/issues/4469-private-method-homeobject-call-regression.md
+++ b/plan/issues/4469-private-method-homeobject-call-regression.md
@@ -141,7 +141,40 @@ this issue only restores it from uncatchable to catchable, which is what the
 ratchet measures.
 
 Pinned by `tests/issue-4469.test.ts` (both front-ends, module instantiated and
-run, direct and `.call(o)` invocations).
+run, direct and `.call(o)` invocations) — 4/4 green.
+
+Suite results, all run in this worktree on 2026-08-15:
+
+| Suite | With fix |
+| --- | --- |
+| `tests/issue-4469.test.ts` | 4/4 ✓ |
+| `tests/multi-file.test.ts` (the pin #4507 added) | 11/11 ✓ |
+| `tests/private-class-members.test.ts` | 5/5 ✓ |
+| `tests/class-static-private-this.test.ts` | 3/3 ✓ |
+| `tests/issue-4301-class-expression-private-receiver.test.ts` | 5/5 ✓ |
+
+Six further class/method files fail — **all of them fail identically on
+unmodified `main`**, so none is caused by this change. Measured by swapping
+`.tmp/mt-new.ts` (main's `method-trampolines.ts`) back in and re-running the
+same six files:
+
+| Suite | main | with fix |
+| --- | --- | --- |
+| `class-methods.test.ts` | 17 failed | 17 failed |
+| `class-method-calls.test.ts` | 3 failed | 3 failed |
+| `issue-1672-async-gen-method-trampoline.test.ts` | 5 failed | 5 failed |
+| `issue-4154-private-brand-check-typeerror.test.ts` | 2 failed | 2 failed |
+| `issue-3520-class-method-alias-abi.test.ts` | 1 failed | 1 failed |
+| `issue-4295-runtime-user-class-method-dispatch.test.ts` | 1 failed | 1 failed |
+| **total** | **29 failed** | **29 failed** |
+
+Two distinct pre-existing causes, neither related to the trampoline receiver:
+`class-methods` / `class-method-calls` instantiate with a bare
+`WebAssembly.instantiate(binary, { env: {} })` and fail on the missing
+`string_constants` module; the `... is not a function` failures in `4295`/`4154`
+point at #4507's static-vs-instance ABI-key split. **Zero** Wasm *validation*
+errors appear in either run, which is the specific risk of narrowing an ABI
+coercion.
 
 ## Non-goals
 

--- a/src/codegen/closures/method-trampolines.ts
+++ b/src/codegen/closures/method-trampolines.ts
@@ -190,10 +190,23 @@ function buildTrampolineThisSlot(
  * Reconcile the receiver produced by {@link buildTrampolineThisSlot} with the
  * actual first parameter of the method.  The trampoline's receiver is always
  * the nullable object-struct reference used by the closure ABI, but late type
- * resolution can leave a method's hidden `this` parameter as `externref` (or a
- * different reference carrier).  Passing the struct reference directly in
- * that case makes the generated `call` fail Wasm validation.  Keep this at the
- * ABI boundary instead of weakening validation or relying on stack fixups.
+ * resolution can leave a method's hidden `this` parameter on a DIFFERENT
+ * reference carrier (`externref`/`anyref`).  Passing the struct reference
+ * directly in that case makes the generated `call` fail Wasm validation.  Keep
+ * this at the ABI boundary instead of weakening validation or relying on stack
+ * fixups.
+ *
+ * (#4469) The reconciliation is deliberately limited to a CROSS-CARRIER
+ * mismatch.  `ref`/`ref_null` are the same carrier family and differ only in
+ * nullability, and {@link buildTrampolineThisSlot} emits a null receiver ON
+ * PURPOSE: the #2025 passthrough hands `ref.null` to the method whenever the
+ * resolved `this` is non-null but does not `ref.test` as this exact struct
+ * (a foreign receiver, e.g. `this.#m.call({})`).  Bridging `ref_null $S` to
+ * `ref $S` there means `ref.as_non_null`, which turns that designed
+ * passthrough into an UNCATCHABLE `null_deref` trap at the ABI boundary —
+ * before the method body (which may never touch `this` at all, as in
+ * `#m() { return super.method(); }`) gets to run.  Nullability is therefore
+ * settled by the callee's own signature, never by a cast here.
  */
 function coerceTrampolineThisSlot(
   ctx: CodegenContext,
@@ -209,14 +222,20 @@ function coerceTrampolineThisSlot(
   // provisional signature before the method body pass settles its ABI.
   if (!methodUsesThis) return;
   const source: ValType = { kind: "ref_null", typeIdx: objStructTypeIdx };
-  if (source.kind === methodThisType.kind) {
-    // Same-kind references are already compatible when they name the same
-    // struct.  A distinct type index is handled by the existing method-arg
-    // reconciliation path; the receiver path should not add an unsafe cast
-    // for an unrelated object shape.
+  if (isStructRefCarrier(source) && isStructRefCarrier(methodThisType)) {
+    // Same carrier family.  Same struct ⇒ already compatible up to
+    // nullability, which must stay nullable (see the #4469 note above).  A
+    // distinct type index is handled by the existing method-arg reconciliation
+    // path; the receiver path should not add an unsafe cast for an unrelated
+    // object shape.
     return;
   }
   body.push(...coercionInstrs(ctx, source, methodThisType, fctx));
+}
+
+/** `ref` and `ref_null` are one carrier family — they differ only in nullability. */
+function isStructRefCarrier(type: ValType): boolean {
+  return type.kind === "ref" || type.kind === "ref_null";
 }
 
 /**

--- a/tests/issue-4469.test.ts
+++ b/tests/issue-4469.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+/**
+ * #4469 — a private method extracted as a value and invoked with a FOREIGN
+ * receiver (`this.#m.call(o)`) must not trap at the closure/method ABI
+ * boundary.
+ *
+ * `buildTrampolineThisSlot` deliberately hands the method a `ref.null`
+ * receiver when the resolved `this` does not `ref.test` as the method's exact
+ * struct (#2025 passthrough). #4507's `coerceTrampolineThisSlot` bridged that
+ * nullable slot onto the method's hidden `this` parameter — and because a
+ * class instance method's `this` is a NON-null `ref $S`, the bridge emitted
+ * `ref.as_non_null`, converting the designed passthrough into an uncatchable
+ * `null_deref` trap before the body ever ran.
+ *
+ * The shape that broke is test262's
+ * `language/statements/class/elements/super-access-inside-a-private-method.js`:
+ * `#m()` only needs its HomeObject (`super.method()`), never `this`, so the
+ * foreign receiver is irrelevant to its result.
+ *
+ * Both front-ends are pinned: the trap fired on the direct AST path AND the IR
+ * path, so this is shared class/closure plumbing, not front-end selection.
+ */
+async function run(source: string, experimentalIR: boolean): Promise<number> {
+  const result = await compile(source, {
+    allowJs: true,
+    experimentalIR,
+    fileName: "issue-4469.ts",
+    platform: "node",
+    skipSemanticDiagnostics: true,
+    target: "gc",
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    result.binary,
+    imports.env,
+    imports.string_constants,
+    imports.string_constants16,
+  );
+  imports.setInstance?.(instance);
+  return (instance.exports.runCase as () => number)();
+}
+
+const SUPER_ACCESS_INSIDE_PRIVATE_METHOD = `
+  class A {
+    method(): string { return "Test262"; }
+  }
+  class C extends A {
+    #m(): string { return super.method(); }
+    access(o: any): string { return (this as any).#m.call(o); }
+  }
+  export function runCase(): number {
+    const c = new C();
+    const direct = c.access(c);
+    const foreign = c.access({} as any);
+    return (direct === "Test262" ? 1 : 0) + (foreign === "Test262" ? 2 : 0);
+  }
+`;
+
+const PRIVATE_METHOD_GET_AND_CALL = `
+  class C {
+    #m(): number { return (this as any)._v; }
+    getPrivateMethod(): any { return (this as any).#m; }
+  }
+  export function runCase(): number {
+    const c = new C();
+    return c.getPrivateMethod().call({ _v: 7 } as any);
+  }
+`;
+
+describe("#4469 private-method HomeObject dispatch with a foreign receiver", () => {
+  for (const experimentalIR of [false, true]) {
+    const label = experimentalIR ? "IR" : "direct";
+
+    it(`resolves super.method() from a private method invoked via .call(o) [${label}]`, async () => {
+      // 1 = `c.access(c)` (native receiver), 2 = `c.access({})` (foreign
+      // receiver — the case that regressed). 3 = both correct.
+      expect(await run(SUPER_ACCESS_INSIDE_PRIVATE_METHOD, experimentalIR)).toBe(3);
+    });
+
+    it(`does not trap when an extracted private method is .call()ed with a foreign receiver [${label}]`, async () => {
+      // This pins the ABSENCE of an uncatchable `null_deref` trap at the
+      // trampoline boundary — before the fix the module aborted here instead
+      // of running the body. Reading the foreign receiver's own `_v` (spec
+      // answer: 7) is a SEPARATE, still-open gap: the #2025 passthrough hands
+      // the body a null receiver, so the property read yields NaN. Assert only
+      // that a value comes back, so closing that gap does not need a test edit.
+      await expect(run(PRIVATE_METHOD_GET_AND_CALL, experimentalIR)).resolves.toEqual(expect.any(Number));
+    });
+  }
+});


### PR DESCRIPTION
## Description

Fixes the queue-poisoning regression bisected to #4507's merge (`6756ed8c`): `test262/language/statements/class/elements/super-access-inside-a-private-method.js` went baseline-pass → uncatchable `null_deref` on BOTH front-ends, growing the #3189 trap ratchet 140→142 and auto-parking queue entries (first casualty #4578) until baseline promotion baked it in. Issue #4469 carries the bisect table and probe; the owning lane was notified on #4507.

**Root cause** (`src/codegen/closures/method-trampolines.ts`, added by #4507): `coerceTrampolineThisSlot()` bridged the trampoline receiver onto the method's hidden `this` whenever the `ValType.kind`s differed — but a class instance method's `this` is non-null `ref $S` while the trampoline slot is `ref_null $S`, same typeIdx. Instrumented: `src=ref_null 49 → this=ref 49`. `coercionInstrs` answers that with `ref.as_non_null`, turning `buildTrampolineThisSlot`'s deliberate #2025 null passthrough for foreign receivers (`this.#m.call(o)`) into a trap at the ABI boundary, before the body runs.

**Fix:** restrict the bridge to genuine cross-carrier (externref) mismatches — `ref`/`ref_null` are one family, and `ref.as_non_null` never fixed a typeIdx mismatch anyway; stripping nullability was the only thing that branch did. The externref case #4507 added it for is untouched; no capability removed.

**Verification:** probe passes both front-ends and both targets; **byte-parity with pre-#4507 `c3ff8a1f`** on both affected test262 files (file-copy A/B); `tests/issue-4469.test.ts` 4/4; #4507's actual pin `tests/multi-file.test.ts` 11/11; private-class-members 5/5, class-static-private-this 3/3, issue-4301 5/5; six other class/method test files fail **identically on unmodified main** (29=29 per file — two pre-existing causes documented, incl. #4507's static-vs-instance ABI-key split, which deserves its own issue); zero Wasm validation errors; `check:ir-fallbacks` no growth.

After this merges, the next baseline promotion returns `null_deref` to 140.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_