### PR TITLE
docs: #4467 shard-attribution addendum + file #4486 (nested-vec for-of invariant bug)

### DIFF
--- a/plan/issues/4467-ir-template-numeric-substitutions.md
+++ b/plan/issues/4467-ir-template-numeric-substitutions.md
@@ -187,7 +187,20 @@ handles it correctly.
   to the same command on base `9e17d34f`; none in a file this change touches.
 - `node scripts/check-oracle-ratchet.mjs`, `check-issue-ids.mjs
   --against-main`, `prettier --check`, `biome lint` — all clean.
-- `scripts/equivalence-gate.mjs`, all 8 shards — no new regressions. (Shard 2
-  additionally reports one baseline known-failure as `fixed`:
-  `coercion/arithmetic-add standalone-O any string + any string concatenates`.
-  Not attributed to this change — the shape has no template literal in it.)
+- `scripts/equivalence-gate.mjs`, **all 8 shards — no new regressions.**
+  Several shards additionally report baseline known-failures as `fixed`
+  (`coercion/arithmetic-add`, `symbol-basic`, `Math.pow`, the #1197 i32
+  peephole). **These are NOT this change's doing, and that is measured, not
+  assumed**: running shard 2 in a worktree at base `9e17d34f` reports SIX
+  `fixed` entries in that shard alone — including the exact
+  `coercion/arithmetic-add standalone-O any string + any string concatenates`
+  the branch reported — against the branch's one. The baseline is simply stale
+  (and partly nondeterministic) relative to main; the gate does not fail on it.
+
+  **Methodology note, worth keeping:** `equivalence-gate.mjs` calls
+  `process.exit()`, which TRUNCATES pending stdout writes when stdout is a
+  PIPE. `node scripts/equivalence-gate.mjs 2>&1 | tail -N` therefore showed
+  only the stderr `JSON report written …` line for shards 4 and 8, which reads
+  exactly like a crashed/failing shard. Both were clean on re-run with a file
+  REDIRECT (`> file 2>&1`), which is synchronous and loses nothing. Redirect,
+  don't pipe, when you need this script's verdict.

--- a/plan/issues/4486-nested-vec-forof-invariant-hard-error.md
+++ b/plan/issues/4486-nested-vec-forof-invariant-hard-error.md
@@ -1,0 +1,64 @@
+---
+id: 4486
+title: "Identifier-head for-of over string[][] hard-fails: prepared-vector registry answers invariant instead of unsupported"
+status: ready
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ir
+language_feature: statements
+goal: ir-full-coverage
+related: [4470, 3583]
+origin: "2026-08-15 #4470 measurement (dev-4470) — found on unmodified main while probing for-of head shapes"
+---
+
+# #4486 — nested-vec for-of: claimed unit hard-fails instead of demoting
+
+## Problem
+
+On unmodified main (`3faec1ae`-era), with zero changes applied:
+
+```ts
+function f(rows: string[][]): number {
+  let n = 0;
+  for (const r of rows) { n = n + 1; }
+  return n;
+}
+```
+
+does not compile (`success: false`). The unit is CLAIMED by the selector,
+then the prepared-vector registry refuses the `vec<vec<externref>>` element
+as an **`invariant`** (`prepared vec element vec<externref> is not
+supported`, `invariant@resolve`) rather than an `unsupported` — so the
+function hard-fails instead of demoting to the perfectly good legacy body.
+Same shape as the adjacent `.length`-on-externref hard error.
+
+By contrast `number[][]` / `Array<Array<number>>` / tuple-typed nestings
+take the soft `unsupported@resolve` path and demote cleanly — the
+inconsistency is specific to the `vec<externref>` element arm in
+`src/ir/prepared-vector-support.ts` (~L70) / `resolvePositionType`
+(`src/codegen/index.ts` ~L989).
+
+Pinned as a KNOWN DEFECT in `tests/issue-4470.test.ts` section C (landed
+via PR #4590), so the repro cannot go stale.
+
+## Acceptance criteria
+
+1. The repro compiles again: the registry's `vec<externref>`-element
+   refusal becomes a typed `unsupported` demote (matching the sibling
+   nestings), NOT an invariant — a capability gap by construction, never a
+   producer-promise violation (same reasoning as the #4578 string-arm fix).
+2. The #4470 section-C pin flips from KNOWN-DEFECT to positive.
+3. `check:ir-fallbacks` no growth beyond the (typed) bucket this moves
+   into; host lane 37/37 unchanged.
+
+## Note
+
+This is the demote-vs-invariant classification bug only. Actually ADOPTING
+nested-vec carriers (so these claims lower instead of demoting) is #4470's
+blocked scope — carrier first, head second, per the unblock spec there.


### PR DESCRIPTION
## Description

Docs-only bundle:

1. **#4467 addendum** (byte-exact from the authoring agent's commit, stranded when its branch was queue-locked): all 8 equivalence shards clean, with the "fixed" baseline entries attributed by measurement — a base-tree worktree reports six of them in shard 2 alone, so none were the change's doing. Includes the methodology note that `equivalence-gate.mjs`'s `process.exit()` truncates stdout on a pipe (redirect to a file for its verdict).
2. **Files issue #4486** (id via `--allocate --allow-unscanned`, `pr_scan=degraded`; the CI id gate backstops): identifier-head `for..of` over `string[][]` hard-fails on main because the prepared-vector registry classifies the `vec<externref>` element as an `invariant` instead of a typed `unsupported` demote — found during #4470's measurement, repro pinned in `tests/issue-4470.test.ts` section C (PR #4590).

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_