### PR TITLE
fix(#4488): native-Map capability query emitted the collection runtime into every constructing module

### DIFF
--- a/plan/issues/4488-native-map-query-emits-collection-runtime.md
+++ b/plan/issues/4488-native-map-query-emits-collection-runtime.md
@@ -1,0 +1,137 @@
+---
+id: 4488
+title: "#4461's native-map capability QUERY emits the $Map runtime, putting it in every module with a `new`"
+status: in-review
+sprint: current
+created: 2026-08-15
+assignee: ttraenkler/opus-4462
+priority: high
+horizon: s
+feasibility: easy
+task_type: fix
+area: ir
+goal: ir-full-coverage
+related: [4461, 4583, 1103, 2955]
+loc-budget-allow:
+  # +37: the split of one resolver capability into a pure query and an explicit
+  # materializer, plus the doc block that records WHY (a query that emits cost
+  # 508 wasm-hash changes). The arms must stay beside the call sites they gate.
+  - src/ir/from-ast.ts
+  # +12: the same split on the resolver side, in the object that holds every
+  # other capability method.
+  - src/ir/integration.ts
+func-budget-allow:
+  # +12: one capability method became two (pure query + explicit materializer),
+  # in the object that already holds every other resolver capability.
+  - src/ir/integration.ts::makeFromAstResolver
+---
+
+# #4488 — a capability query with an emission side effect
+
+#4583 (#4461, native `$Map` module-binding storage) merged as `60d1db4f` and put a
+real regression on `main`: the `merge_group` run measured **net −475**
+(33 improvements / 508 regressions), **297** of them in
+`test/language/expressions/class/elements`, **all 508 with wasm-hash changes**,
+plus a failing standalone high-water floor. The PR was auto-parked; the park did
+not hold and it landed anyway.
+
+## Root cause
+
+`makeFromAstResolver.nativeMapStorageType()` (`src/ir/integration.ts`) called
+`ensureMapHelpers(ctx)` — which **emits the entire twelve-function `$Map`
+runtime plus its struct types**. It is a *capability query*, and both from-ast
+callers asked it **before** they knew they were looking at a `Map`:
+
+- `lowerNewExpression` asked on **every `new` expression**;
+- `nativeMapModuleBinding` asked on **every method-call receiver**.
+
+So in any lane where `ctx.nativeStrings` is true (native strings, standalone,
+WASI), **every module containing a `new` expression received the whole
+collection runtime**, whether or not it ever mentions `Map`. Class-element tests
+all construct (`new C()`), which is exactly the 297-file bucket; the size blowup
+is what failed the standalone floor.
+
+The host `gc` lane was untouched because the query early-returns on
+`!ctx.nativeStrings` — which is why the damage looked selective.
+
+## Measured evidence
+
+Two-class module, **no `Map` anywhere**, native-strings lane, pre-#4583 main
+(`793b5c0e`) vs `main` at `60d1db4f`:
+
+| | pre-#4583 | with #4583 | delta |
+|---|---|---|---|
+| binary | 22,214 B | 23,588 B | **+1,374 B** |
+| functions | 59 | 71 | **+12** |
+| type section | 348 B | 484 B | +136 B |
+
+The 12 added functions are exactly the `$Map` runtime: `__map_new`, `__map_get`,
+`__map_set`, `__map_has`, `__map_delete`, `__map_clear`, `__map_size`,
+`__map_iter_new`, `__map_iter_next`, `__map_lookup_idx`, `__hash_anyref`,
+`__same_value_zero`.
+
+**The three `__ir_map_*` adapters were ABSENT from that list.** That is the
+decisive datum: it proves `addAdapter` never ran, so the originally-suspected
+`ir-native-map.ts` late-minting / function-index-shift hypothesis (the
+documented `addUnionImports` hazard class) is **not** the cause here.
+`ensureIrNativeMapAdapters` is correctly gated on `usesNativeMapAdapters` and
+correctly placed before Phase 3; the leak is upstream of it, in the resolver.
+
+## Fix
+
+Split the one method into a pure query and an explicit materializer, and make
+each call site use the right one:
+
+1. `nativeMapStorageType()` is now **PURE** — returns `undefined` while
+   `ctx.mapTypeIdx < 0` and never registers anything.
+2. New `ensureNativeMapStorageType()` keeps the materializing body. Its only
+   caller is `tryLowerNativeMapConstruction`, **after** that function has
+   syntactically proven an ambient zero-arg `new Map()`.
+3. `nativeMapModuleBinding` resolves the module binding **first** — the cheap
+   discriminator, and for a genuinely native-map binding that resolution is
+   itself what registers `$Map` (`resolveModuleBindingGlobal`'s `native-map`
+   arm) — then consults the pure query.
+
+No change to what the Map feature lowers; only *when* the runtime is
+materialized.
+
+## Verification
+
+**Hard invariant — a no-Map module must be byte-identical to pre-#4583 main.**
+Compiled on the fix branch and on `793b5c0e`, sha256 of the binary:
+
+| case | lane | pre-#4583 main | fix branch | |
+|---|---|---|---|---|
+| `plain-class` | native | `2ddb2df6f6a00df9` | `2ddb2df6f6a00df9` | identical |
+| `private-method` | native | `3c93ee509b6a87ef` | `3c93ee509b6a87ef` | identical |
+| `plain-arith` | native | `fe43ab03f38e48f8` | `fe43ab03f38e48f8` | identical |
+| `plain-class` | standalone | `9a01fc5d4b279c0b` | `9a01fc5d4b279c0b` | identical |
+| `private-method` | standalone | `bfdf3ce748f8d3aa` | `bfdf3ce748f8d3aa` | identical |
+| `plain-arith` | standalone | `6503d0643ab23fca` | `6503d0643ab23fca` | identical |
+| `with-map` | native | `8f2cb840d92aebd4` | `d08dda763ae74dc6` | **differs — the feature** |
+| `with-map` | standalone | `af225a9fa998d49d` | `a0bc1a44940559ab` | **differs — the feature** |
+
+All four cases in the host `gc` lane are identical across all trees.
+
+`tests/issue-4461.test.ts`: **5/5 pass** on the fix branch — the Map adoption
+survives; only the collateral damage is removed.
+
+### Stated honestly: what I did NOT verify
+
+I could **not** reproduce the two named test262 files
+(`new-no-sc-line-method-private-names.js`,
+`after-same-line-method-rs-private-method.js`) trapping locally. Compiled raw,
+they hash **identically** on pre-#4583 main, on damaged main, and on the fix
+branch, and my hand-assembled harness bundle CEs identically on all three — so
+my probe does not reproduce the runner's harness assembly and is not a
+discriminating test. The synthetic two-class repro above *is* discriminating and
+is what localises the defect; CI's `merge_group` re-run is the authority on the
+508 files.
+
+## Follow-up worth having
+
+A resolver capability query that emits is a repeatable trap — this is the same
+shape as the `addUnionImports` hazard, one layer up. Consider a naming rule
+(`ensure*` may materialize, everything else must be pure) and, if cheap, a
+debug-mode assertion that non-`ensure*` resolver methods do not grow
+`ctx.mod.functions`.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -533,8 +533,36 @@ export interface IrFromAstResolver extends PreparedAsyncFromAstResolver {
    * This is the SINGLE predicate that decides the native-map lowering arms, so
    * it is also what the selector's `allowNativeMapStorage` option must agree
    * with — one fact, two readers, no independent mode reads.
+   *
+   * PURE — it never materializes anything. It answers `undefined` until the
+   * `$Map` struct actually exists in this module, which is what makes it safe
+   * to call from a hot path. Use {@link ensureNativeMapStorageType} at the one
+   * site that is genuinely constructing a Map; see that method for why.
    */
   nativeMapStorageType?(): IrType | undefined;
+  /**
+   * The MATERIALIZING twin of {@link nativeMapStorageType}: registers the
+   * `$Map` struct + its runtime helpers if absent, then reports the storage
+   * type.
+   *
+   * The split is load-bearing, not stylistic. #4461 shipped ONE method that
+   * always materialized, and both from-ast call sites asked it BEFORE they knew
+   * they were looking at a Map — `lowerNewExpression` asked on every `new`, and
+   * the module-binding probe on every method receiver. In a native-string or
+   * standalone lane that emitted the entire twelve-function `$Map` runtime
+   * (`__map_new`, `__map_get`, `__map_set`, `__map_has`, `__map_delete`,
+   * `__map_clear`, `__map_size`, the two iterator helpers, `__map_lookup_idx`,
+   * `__hash_anyref`, `__same_value_zero`) plus its struct types into every
+   * module containing a `new` expression. Measured on a two-class module with
+   * no `Map` anywhere: +1,374 bytes, 59 → 71 functions. That is what changed
+   * the wasm hash of 508 test262 files, regressed 297 in
+   * `language/expressions/class/elements`, and failed the standalone
+   * high-water floor.
+   *
+   * So: a QUERY must not emit. Only call this once the construct is PROVEN to
+   * be a `Map`.
+   */
+  ensureNativeMapStorageType?(): IrType | undefined;
   /**
    * (#4461) True when `undefined`-ness of an externref-shaped value is tested
    * by a NATIVE `__extern_is_undefined` function rather than the `env` host
@@ -5999,11 +6027,10 @@ function lowerNewExpression(expr: ts.NewExpression, cx: LowerCtx): IrValueId {
   // struct. Intercepted before the extern-class registry, which has no `Map`
   // entry at all in host-free mode — the pre-#4461 behaviour was the
   // `unknown-class-construction` demote at the bottom of this function.
-  const nativeMapStorage = cx.resolver?.nativeMapStorageType?.();
-  if (nativeMapStorage) {
-    const nativeMap = tryLowerNativeMapConstruction(expr, nativeMapStorage, cx);
-    if (nativeMap !== null) return nativeMap;
-  }
+  // The storage type is obtained INSIDE, after the `new Map()` shape is proven
+  // — asking first materialized the whole `$Map` runtime on every `new`.
+  const nativeMap = tryLowerNativeMapConstruction(expr, cx);
+  if (nativeMap !== null) return nativeMap;
   if (!ts.isIdentifier(expr.expression)) {
     throw new Error(`ir/from-ast: only direct constructor names supported in slice 4 (${cx.funcName})`);
   }
@@ -6427,10 +6454,15 @@ function nativeMapModuleBinding(
   cx: LowerCtx,
 ): { readonly binding: ModuleBindingGlobal; readonly name: string } | null {
   if (receiver === undefined) return null;
-  const storageType = cx.resolver?.nativeMapStorageType?.();
-  if (!storageType) return null;
+  // Resolve the binding FIRST: it is the cheap discriminator, and resolving a
+  // genuinely native-map binding is itself what registers the `$Map` struct
+  // (`resolveModuleBindingGlobal`'s `native-map` arm). So by the time the PURE
+  // storage-type query below runs, the struct exists exactly when it should —
+  // and for every other receiver we have emitted nothing at all.
   const binding = cx.resolver?.resolveModuleBinding?.(receiver);
-  if (!binding || !irTypeEquals(binding.type, storageType)) return null;
+  if (!binding) return null;
+  const storageType = cx.resolver?.nativeMapStorageType?.();
+  if (!storageType || !irTypeEquals(binding.type, storageType)) return null;
   return { binding, name: receiver.text };
 }
 
@@ -6499,10 +6531,15 @@ function tryLowerNativeMapMethodCall(
  * the native-map `writeValueMatches` arm), so anything else that reaches here
  * is drift rather than an unsupported source.
  */
-function tryLowerNativeMapConstruction(expr: ts.NewExpression, storageType: IrType, cx: LowerCtx): IrValueId | null {
+function tryLowerNativeMapConstruction(expr: ts.NewExpression, cx: LowerCtx): IrValueId | null {
+  // Every cheap, PURE rejection first. Only a proven ambient `new Map()` may
+  // reach the materializing resolver call below — see
+  // `ensureNativeMapStorageType` for what asking too early cost.
   if (!ts.isIdentifier(expr.expression) || expr.expression.text !== "Map") return null;
   if ((expr.arguments?.length ?? 0) !== 0) return null;
   if (cx.resolver?.isAmbientBinding?.(expr.expression) === false) return null;
+  const storageType = cx.resolver?.ensureNativeMapStorageType?.();
+  if (!storageType) return null;
   const result = cx.builder.emitCall(irRuntimeFuncRef(IR_NATIVE_MAP_NEW_FN), [], storageType);
   if (result === null) throw new Error(`ir/from-ast: native Map allocator returned void (${cx.funcName})`);
   return result;

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -4445,7 +4445,19 @@ function makeFromAstResolver(
     // (#4461) The three host-free capabilities the native-`$Map` arms consult.
     // They live here, on the lower/integration side, for the same #2955 reason
     // the box/unbox predicates do: from-ast reads no mode flags of its own.
+    // PURE. Reports the storage type only if the `$Map` struct already exists;
+    // it never registers one. The hot-path callers (every method receiver,
+    // every `new`) use this one. See `ensureNativeMapStorageType` for the twin
+    // and for the 508-file regression that made the split necessary.
     nativeMapStorageType(): IrType | undefined {
+      if (!ctx.nativeStrings || ctx.mapTypeIdx < 0) return undefined;
+      return { kind: "val", val: { kind: "ref_null", typeIdx: ctx.mapTypeIdx } };
+    },
+    // MATERIALIZING. Only for a call site that has already PROVEN it is looking
+    // at a `Map`: `ensureMapHelpers` emits twelve functions and the struct
+    // types, so reaching it speculatively puts the whole collection runtime
+    // into modules that never mention `Map`.
+    ensureNativeMapStorageType(): IrType | undefined {
       if (!ctx.nativeStrings) return undefined;
       ensureMapHelpers(ctx);
       if (ctx.mapTypeIdx < 0) return undefined;


### PR DESCRIPTION
## Description

URGENT fix-forward for the #4583 merged-state regression (its merge-group park showed −475 net with 297 regressions in `language/expressions/class/elements` and a standalone size-floor failure; the park's hold did not prevent the merge). Issue #4488 carries the full evidence.

**Root cause — a capability QUERY with an emission side effect.** `makeFromAstResolver.nativeMapStorageType()` (from #4583/#4461) called `ensureMapHelpers`, which emits the entire 12-function `$Map` runtime + struct types. Both from-ast callers asked before knowing they had a Map: `lowerNewExpression` on **every `new` expression**, `nativeMapModuleBinding` on **every method receiver**. Every module with a `new` in the nativeStrings/standalone/WASI lanes got the whole collection runtime — measured on a no-Map two-class module: **+1,374 B, 59→71 functions, +136 B types**. Class-element tests all construct → the 297-file bucket. The host `gc` lane was spared (query early-returns on `!nativeStrings`), matching the park signature. The initially suspected `addAdapter` index shift was disproven: the adapters are absent from damaged modules.

**Fix (3 edits, 2 files, feature unchanged):** the query is now pure (`ctx.mapTypeIdx < 0` → undefined, never materializes); a new `ensureNativeMapStorageType()` keeps the emitting body, called only from `tryLowerNativeMapConstruction` after proving an ambient zero-arg `new Map()`; `nativeMapModuleBinding` resolves the binding first (which itself registers `$Map` for genuine native-map bindings) then uses the pure query.

**Verified:** no-Map modules are **byte-identical (sha256) to pre-#4583 main (`793b5c0e`)** in both native and standalone lanes (`plain-class`, `private-method`, `plain-arith`; table in the issue file); `with-map` still differs (the feature is intact); gc lane identical throughout; `tests/issue-4461.test.ts` 5/5 — the Map adoption survives. Honest caveat recorded in the issue: the two individually named test262 files from the park run don't discriminate locally (raw compiles hash identically across all three trees); the synthetic repro localizes the defect and this PR's own merge_group re-run is the authority on the 508.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_