### PR TITLE
test(#3583): tripwire fired as designed — retire wrong-answer pins to parity

### DIFF
--- a/tests/issue-3583.test.ts
+++ b/tests/issue-3583.test.ts
@@ -144,25 +144,25 @@ describe("#3583 — type-erased assertion wrappers are IR-claimed and lowered", 
   // zero value instead of erroring. `as` / `!` are unaffected (legacy handles
   // those), which is exactly why only these two forms diverge.
   //
-  // These two cases therefore deliberately do NOT assert IR/legacy parity —
-  // asserting it would pin the WRONG answer. They assert the spec answer from
-  // the IR path and pin legacy's wrong answer, so that fixing legacy (tracked
-  // in the #3583 "TODO — next allocation window" list) fails this test loudly
-  // rather than passing silently.
-  it("`<T>x` — IR is spec-correct; legacy is a known-wrong pre-existing bug", async () => {
+  // UPDATE 2026-08-15 (#4458/#4578): the legacy bug was FIXED — the missing
+  // `TypeAssertionExpression`/`SatisfiesExpression` dispatcher arms were added,
+  // mirroring `AsExpression`. The tripwire below fired exactly as designed
+  // (the wrong-answer pins failed loudly when the fix landed), so both cases
+  // now assert full IR/legacy PARITY on the spec answer.
+  it("`<T>x` — IR and legacy agree on the spec answer (legacy fixed by #4458)", async () => {
     const src = `export function f(x: number): number { return (<number>x) + 1; }`;
     expect(claims(src, "f")).toBe(true);
     expect(await irEmitted(src, "f")).toBe(true);
     expect(((await instantiate(src, true)).f as (n: number) => number)(41)).toBe(42);
-    expect(((await instantiate(src, false)).f as (n: number) => number)(41)).toBe(1);
+    expect(((await instantiate(src, false)).f as (n: number) => number)(41)).toBe(42);
   });
 
-  it("`x satisfies T` — IR is spec-correct; legacy is a known-wrong pre-existing bug", async () => {
+  it("`x satisfies T` — IR and legacy agree on the spec answer (legacy fixed by #4458)", async () => {
     const src = `export function f(x: number): number { return (x satisfies number) + 1; }`;
     expect(claims(src, "f")).toBe(true);
     expect(await irEmitted(src, "f")).toBe(true);
     expect(((await instantiate(src, true)).f as (n: number) => number)(41)).toBe(42);
-    expect(((await instantiate(src, false)).f as (n: number) => number)(41)).toBe(1);
+    expect(((await instantiate(src, false)).f as (n: number) => number)(41)).toBe(42);
   });
 
   it("non-null assertion `x!`", async () => {


### PR DESCRIPTION
## Description

#3583's two assertion-wrapper tests deliberately pinned legacy's known-wrong answer (`<T>x`/`satisfies` operand evaluated as 0) so that fixing legacy would fail loudly instead of passing silently. #4458 (PR #4578) fixed legacy today, the tripwire fired exactly as designed (spotted red by the #4471 agent's sweep), and this retires the pins: both cases now assert full IR↔legacy parity on the spec answer (42), with the comment block updated to record the fix lineage. 16/16 on the file.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_