### PR TITLE
test(#4507): class-family suites instantiate via importObject — 84 tests un-redded, zero codegen bugs beneath

### DIFF
--- a/plan/issues/4507-class-suite-string-constants-instantiation.md
+++ b/plan/issues/4507-class-suite-string-constants-instantiation.md
@@ -1,0 +1,151 @@
+---
+id: 4507
+title: "tests: class-family suites instantiate without `string_constants` — 84 tests dead at instantiation"
+status: done
+sprint: current
+created: 2026-08-15
+updated: 2026-08-15
+completed: 2026-08-15
+assignee: ttraenkler/opus-4507h
+priority: medium
+horizon: s
+feasibility: easy
+task_type: chore
+area: tests
+related: [4494, 4469]
+origin: "2026-08-15 IR-migration session — surfaced while investigating #4494 (IR claim/preparability parity) and independently by the #4469 agent: the class-family dev suites were red on clean main for days, with no CI signal."
+---
+
+## Problem
+
+Thirteen class-family test files instantiate their compiled modules with a
+hand-rolled import object that omits the `string_constants` namespace:
+
+```ts
+const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+```
+
+Any module that declares imported string-constant globals — which a class
+declaration does, via its field/method name pool — then dies at **instantiation**:
+
+```
+TypeError: WebAssembly.instantiate(): Import #0 module="string_constants":
+module is not an object or function
+```
+
+The failure happens **before any assertion runs**, so every test in the affected
+files was dead weight: it could neither pass nor detect a regression. Measured on
+clean `main` (`b7da49d1`), **84 tests across 13 files** were failing this way.
+
+This is the same defect #4029 fixed for `tests/multi-file.test.ts` (a module with
+**zero function imports** can still declare string-constant globals, so the
+`importObject` short-circuit had to require both `imports` and `stringPool` to be
+empty). These 13 files never adopted the `result.importObject` convenience path
+(#1667) at all.
+
+### Why it stayed invisible
+
+These are dev-suite files, not part of a required CI gate. They are now
+**partially** covered by the changed-files issue-tests lane, which made them
+land-mines: the next person to touch any of these files would inherit a wall of
+pre-existing red that has nothing to do with their change.
+
+## Fix
+
+Route every affected site through the compiler's own import object (#1667),
+which is the canonical documented pattern in `src/index.ts`:
+
+```ts
+const imports = result.importObject ?? { env: {} };
+const { instance } = await WebAssembly.instantiate(result.binary, imports);
+(imports as WebAssembly.Imports & { __setInstance?: (i: WebAssembly.Instance) => void }).__setInstance?.(instance);
+```
+
+The `__setInstance` call is part of the contract (#1712): without it the host
+runtime's `getExports()` stays undefined, silently disabling closure wrapping
+and `__sget_*` struct-field reads. `tests/class-expressions.test.ts` (plural —
+already correct) was the in-repo reference.
+
+**Assertions were not touched.** The change is purely the instantiation line.
+`tests/class-expression.test.ts` (singular) had 8 identical inline instantiation
+blocks carrying `console_log_number` / `console_log_bool` stubs; those were
+folded into one local `instantiate()` helper that keeps the stubs as a
+*fallback* overlay (the real host `env` is spread last, so it wins wherever it
+provides a binding).
+
+**No `src/` changes at all** — this is a harness fix, not a codegen fix.
+
+## Test Results
+
+Measured on `main` @ `b7da49d1` (before) and on this branch (after). Counts are
+`pass / fail`.
+
+### Group A — files named in the #4494 / #4469 evidence
+
+| File                                    | Before  | After  |
+| --------------------------------------- | ------- | ------ |
+| `tests/classes.test.ts`                 | 0 / 7   | 7 / 0  |
+| `tests/class-methods.test.ts`           | 0 / 17  | 17 / 0 |
+| `tests/class-method-calls.test.ts`      | 2 / 3   | 5 / 0  |
+| `tests/class-method-struct-new.test.ts` | 0 / 4   | 4 / 0  |
+| `tests/abstract-classes.test.ts`        | 0 / 6   | 6 / 0  |
+| `tests/class-expression.test.ts`        | 0 / 8   | 8 / 0  |
+| **Group A total**                       | **2 / 45** | **47 / 0** |
+
+The 45 matches the "~45 class-family tests" in the original evidence exactly.
+
+### Group B — same defect, found by sweeping the rest of the class family
+
+The evidence said "and possibly others". It was right: seven more files carry
+the byte-identical helper and were equally dead.
+
+| File                                | Before | After |
+| ----------------------------------- | ------ | ----- |
+| `tests/static-members.test.ts`      | 0 / 8  | 8 / 0 |
+| `tests/inheritance.test.ts`         | 0 / 7  | 7 / 0 |
+| `tests/instanceof.test.ts`          | 0 / 7  | 7 / 0 |
+| `tests/class-elements-619.test.ts`  | 0 / 6  | 6 / 0 |
+| `tests/getters-setters.test.ts`     | 0 / 6  | 6 / 0 |
+| `tests/null-deref-class.test.ts`    | 0 / 4  | 4 / 0 |
+| `tests/constructor-arity.test.ts`   | 0 / 1  | 1 / 0 |
+| **Group B total**                   | **0 / 39** | **39 / 0** |
+
+### Grand total
+
+**2 / 84 → 86 / 0.** All 13 files green.
+
+## Genuine pre-existing codegen failures: NONE
+
+The task anticipated that some of the 84 would survive the harness fix as real
+codegen bugs — in particular that some might be the static-vs-instance ABI-key
+split another lane is working on. **They did not.** Every one of the 84 failures
+was purely the instantiation artifact; once the import object was supplied, all
+84 passed on the first run with their original assertions intact.
+
+So there is **no follow-up codegen evidence to hand off** from this issue. That
+is a genuine (and slightly surprising) finding, not an omission: the class
+family's runtime behaviour on these paths is correct on current `main`, and the
+suites had simply been blind to it.
+
+## Residual risk / follow-up
+
+The bare `{ env: {} }` pattern still exists in roughly two dozen **non**-class
+test files (e.g. `tests/drop-validation.test.ts`,
+`tests/export-declarations.test.ts`, `tests/tail-call-optimization.test.ts`,
+`tests/react-fiber-test.test.ts`). Those were **out of scope here** and were not
+measured — a module only trips this when it declares string-constant globals, so
+some of them are fine and some are probably dead the same way. A follow-up sweep
+should measure them before converting; do not assume the count.
+
+The durable fix for the class is a lint rule or a shared test helper that makes
+`WebAssembly.instantiate(result.binary, <hand-rolled literal>)` hard to write,
+rather than fixing files one family at a time.
+
+## Validation
+
+- 13 converted suites: 86 passed / 0 failed (two runs, Group A and Group B).
+- `npm run typecheck` — exit 0.
+- `npm run lint` — exit 0.
+- `git diff --name-only -- src/ scripts/ .github/` — empty. No compiler change,
+  so `check:ir-fallbacks` and every conformance gate are untouched by
+  construction.

--- a/tests/abstract-classes.test.ts
+++ b/tests/abstract-classes.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/class-elements-619.test.ts
+++ b/tests/class-elements-619.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/class-expression.test.ts
+++ b/tests/class-expression.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
+import type { CompileResult } from "../src/index.js";
+
+/**
+ * (#4507) Instantiate through the compiler's own import object (#1667).
+ *
+ * Each site here previously passed a hand-rolled `{ env: { console_log_* } }`,
+ * which omits the `string_constants` namespace, so every test in this file died
+ * at INSTANTIATION with
+ *   Import #0 module="string_constants": module is not an object or function
+ * before any assertion ran. The console stubs are kept as a *fallback* overlay:
+ * the real host runtime's `env` is spread last so it wins wherever it provides
+ * a binding.
+ */
+async function instantiate(result: CompileResult): Promise<WebAssembly.Instance> {
+  const imports = (result.importObject ?? {}) as WebAssembly.Imports & {
+    __setInstance?: (instance: WebAssembly.Instance) => void;
+  };
+  imports.env = {
+    console_log_number: () => {},
+    console_log_bool: () => {},
+    ...((imports.env ?? {}) as Record<string, unknown>),
+  } as unknown as WebAssembly.ModuleImports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.__setInstance?.(instance);
+  return instance;
+}
 
 describe("ClassExpression in various positions (#330)", () => {
   it("class expression in variable initializer with new", async () => {
@@ -22,12 +48,7 @@ describe("ClassExpression in various positions (#330)", () => {
       true,
     );
 
-    const { instance } = await WebAssembly.instantiate(result.binary, {
-      env: {
-        console_log_number: () => {},
-        console_log_bool: () => {},
-      },
-    });
+    const instance = await instantiate(result);
     const exports = instance.exports as any;
     expect(exports.test()).toBe(42);
   });
@@ -52,12 +73,7 @@ describe("ClassExpression in various positions (#330)", () => {
       true,
     );
 
-    const { instance } = await WebAssembly.instantiate(result.binary, {
-      env: {
-        console_log_number: () => {},
-        console_log_bool: () => {},
-      },
-    });
+    const instance = await instantiate(result);
     const exports = instance.exports as any;
     expect(exports.test()).toBe(10);
   });
@@ -92,12 +108,7 @@ describe("ClassExpression in various positions (#330)", () => {
       true,
     );
 
-    const { instance } = await WebAssembly.instantiate(result.binary, {
-      env: {
-        console_log_number: () => {},
-        console_log_bool: () => {},
-      },
-    });
+    const instance = await instantiate(result);
     const exports = instance.exports as any;
     expect(exports.test()).toBe(7);
   });
@@ -122,12 +133,7 @@ describe("ClassExpression in various positions (#330)", () => {
       true,
     );
 
-    const { instance } = await WebAssembly.instantiate(result.binary, {
-      env: {
-        console_log_number: () => {},
-        console_log_bool: () => {},
-      },
-    });
+    const instance = await instantiate(result);
     const exports = instance.exports as any;
     expect(exports.test()).toBe(55);
   });
@@ -151,12 +157,7 @@ describe("ClassExpression in various positions (#330)", () => {
       true,
     );
 
-    const { instance } = await WebAssembly.instantiate(result.binary, {
-      env: {
-        console_log_number: () => {},
-        console_log_bool: () => {},
-      },
-    });
+    const instance = await instantiate(result);
     const exports = instance.exports as any;
     expect(exports.test()).toBe(100);
   });
@@ -184,12 +185,7 @@ describe("ClassExpression in various positions (#330)", () => {
       true,
     );
 
-    const { instance } = await WebAssembly.instantiate(result.binary, {
-      env: {
-        console_log_number: () => {},
-        console_log_bool: () => {},
-      },
-    });
+    const instance = await instantiate(result);
     const exports = instance.exports as any;
     expect(exports.test()).toBe(33);
   });
@@ -211,12 +207,7 @@ describe("ClassExpression in various positions (#330)", () => {
       true,
     );
 
-    const { instance } = await WebAssembly.instantiate(result.binary, {
-      env: {
-        console_log_number: () => {},
-        console_log_bool: () => {},
-      },
-    });
+    const instance = await instantiate(result);
     const exports = instance.exports as any;
     expect(exports.test()).toBe(5);
   });
@@ -247,12 +238,7 @@ describe("ClassExpression in various positions (#330)", () => {
       true,
     );
 
-    const { instance } = await WebAssembly.instantiate(result.binary, {
-      env: {
-        console_log_number: () => {},
-        console_log_bool: () => {},
-      },
-    });
+    const instance = await instantiate(result);
     const exports = instance.exports as any;
     expect(exports.test()).toBe(42);
   });

--- a/tests/class-method-calls.test.ts
+++ b/tests/class-method-calls.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/class-method-struct-new.test.ts
+++ b/tests/class-method-struct-new.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/class-methods.test.ts
+++ b/tests/class-methods.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string = "test", args: unknown[] = []): P
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/classes.test.ts
+++ b/tests/classes.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/constructor-arity.test.ts
+++ b/tests/constructor-arity.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/getters-setters.test.ts
+++ b/tests/getters-setters.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/inheritance.test.ts
+++ b/tests/inheritance.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/instanceof.test.ts
+++ b/tests/instanceof.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/null-deref-class.test.ts
+++ b/tests/null-deref-class.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 

--- a/tests/static-members.test.ts
+++ b/tests/static-members.test.ts
@@ -8,7 +8,16 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  // (#4507) Instantiate through the compiler's own import object (#1667).
+  // A bare `{ env: {} }` omits the `string_constants` namespace, so every test
+  // in this file died at INSTANTIATION with
+  //   Import #0 module="string_constants": module is not an object or function
+  // before any assertion ran.
+  const imports = result.importObject ?? { env: {} };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as WebAssembly.Imports & { __setInstance?: (instance: WebAssembly.Instance) => void }).__setInstance?.(
+    instance,
+  );
   return (instance.exports as any)[fn](...args);
 }
 


### PR DESCRIPTION
## Description

Implements issue #4507 (an issue id, unrelated to the merged PR #4507; issue file in this PR). Thirteen class-family test suites instantiated compiled modules with a hand-rolled `{ env: {} }`, omitting the `string_constants` namespace — every class declaration's name pool imports string-constant globals, so the modules died at **instantiation** before any assertion ran. Red for days, invisible because these files aren't CI-gated. Fix: the canonical `result.importObject` path (#1667) plus `__setInstance` wiring (#1712, else closure wrapping / `__sget_*` reads silently disable) — the same fix #4029 applied to `multi-file.test.ts` that this family never adopted. **Zero src changes** (`git diff -- src/ scripts/ .github/` empty).

**Before → after: 2/84 → 86/0** across the 6 files named in the #4494/#4469 evidence (exactly the reported ~45) plus 7 more found carrying the byte-identical helper (`static-members`, `inheritance`, `instanceof`, `class-elements-619`, `getters-setters`, `null-deref-class`, `constructor-arity`).

**The finding that contradicts expectations:** all 84 passed with original assertions on the first post-fix run — none were the suspected static-vs-instance ABI-key split, and no genuine codegen failure hid underneath. The class family's runtime behavior on these paths is correct on current main; the suites were blind to it.

Residual recorded in the issue (not done, deliberately): ~two dozen non-class files still carry the bare `{ env: {} }` pattern — unmeasured, so unclaimed either way; the durable fix is a lint rule against hand-rolled import literals.

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_