### PR TITLE
feat(#4511): session-start usage-limit monitor — 5h-window cache, suspend sentinel, agent-spawn deny hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,11 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PROJECT_DIR:-/workspace}\"/.claude/hooks/ensure-sshd.sh 2>/dev/null || true",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-/workspace}\"/scripts/usage-limit-monitor.sh 2>/dev/null || true",
+            "timeout": 10
           }
         ]
       }
@@ -180,6 +185,16 @@
             "type": "command",
             "command": "\"${CLAUDE_PROJECT_DIR:-/workspace}\"/.claude/hooks/pre-agent-spawn.sh",
             "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "S=\"${CLAUDE_HOME:-$HOME/.claude}/usage-limit-suspend.json\"; if [ -f \"$S\" ]; then R=$(jq -r '.resets_at // 0' \"$S\" 2>/dev/null || echo 0); N=$(date +%s); if [ \"${R%.*}\" -gt \"$N\" ] 2>/dev/null; then W=$(jq -r '.window // \"unknown\"' \"$S\"); P=$(jq -r '.used_pct // \"?\"' \"$S\"); T=$(date -u -d @\"${R%.*}\" +%H:%MZ 2>/dev/null || echo soon); jq -cn --arg m \"usage-limit-monitor: $W window at $P% \u2014 SUSPEND the team now (push-safe checkpoints, no new spawns) and schedule ONE wakeup at $T, per feedback_5h_window_pause_resume\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:$m}}'; fi; fi; exit 0",
+            "timeout": 10
           }
         ]
       }

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -137,14 +137,16 @@ if [ -n "$resets_at" ]; then
   fi
 fi
 
-# Budget cache for budget-aware sprint scheduling (#2751): standalone scripts
-# (budget-status.mjs / freeze-sprint.mjs) can't see this stdin JSON, so expose the
-# weekly (seven_day) usage% + reset timestamp to them via a small cache file the
-# statusline keeps fresh on every render.
-if [ -n "$weekly" ] || [ -n "$resets_at" ]; then
+# Budget cache for budget-aware sprint scheduling (#2751) and the usage-limit
+# monitor (#4511): standalone scripts (budget-status.mjs / freeze-sprint.mjs /
+# usage-limit-monitor.sh) can't see this stdin JSON, so expose the weekly
+# (seven_day) AND 5-hour usage% + reset timestamps to them via a small cache
+# file the statusline keeps fresh on every render.
+if [ -n "$weekly" ] || [ -n "$resets_at" ] || [ -n "$five_hour" ]; then
   _budget_dir="${CLAUDE_HOME:-$HOME/.claude}"
-  printf '{"seven_day_used_pct":%s,"resets_at":%s,"written_at":%s}\n' \
-    "${weekly:-null}" "${resets_at:-null}" "$(date +%s)" \
+  _five_hour_resets=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+  printf '{"seven_day_used_pct":%s,"resets_at":%s,"five_hour_used_pct":%s,"five_hour_resets_at":%s,"written_at":%s}\n' \
+    "${weekly:-null}" "${resets_at:-null}" "${five_hour:-null}" "${_five_hour_resets:-null}" "$(date +%s)" \
     > "$_budget_dir/js2wasm-budget.json" 2>/dev/null || true
 fi
 

--- a/plan/issues/4509-test262-print-shim-couples-console-claim-surface.md
+++ b/plan/issues/4509-test262-print-shim-couples-console-claim-surface.md
@@ -1,0 +1,45 @@
+---
+id: 4509
+title: "test262 print shim is a statement-position console.log — couples #4462's console claim surface to every suite compile once param types resolve"
+status: ready
+sprint: Backlog
+created: 2026-08-16
+priority: medium
+horizon: s
+feasibility: medium
+task_type: hardening
+area: ir, test262
+goal: ir-full-coverage
+related: [4462, 4605]
+origin: "dev-4605-park diagnosis 2026-08-16 — found while refuting the #4605 park (which was stale-base collateral, not a real regression)"
+---
+
+# #4509 — test262 `print` shim exactly matches the console claim surface
+
+## Finding (measured 2026-08-16)
+
+`scripts/test262-fyi-runtime.js` is prepended verbatim to every non-raw
+test262 test and contains:
+
+```js
+var print = function (value) { console.log(value); };
+```
+
+— a statement-position, single-argument `console.log` that matches
+`isHostFreeConsoleCallReceiver` (#4462) **exactly**. Today it is inert: the
+untyped `value` parameter keeps the unit out of IR claiming (byte-identity
+measured 440/440 across the class-elements family on main vs the #4605
+branch, with a live positive control). But any future widening of param-type
+resolution makes the console claim surface live across the ENTIRE test262
+suite in one step — a maximal-blast-radius coupling that would surface as a
+suite-wide diff attributed to whatever innocent PR lands the widening.
+
+## Acceptance criteria
+
+1. A test pins the current inertness: compile the shim shape
+   (`var print = function (value) { console.log(value); };` at top level with
+   an untyped param) and assert byte-identity IR-on vs IR-off, so the day it
+   goes live is a deliberate test flip, not a surprise.
+2. A decision is recorded (in this issue) whether the console surface should
+   claim an untyped-param forwarder at all, or demote it by policy until
+   #2949's union/dynamic value work lands.

--- a/plan/issues/4510-ir-only-baseline-preclaim-to-postclaim-drift.md
+++ b/plan/issues/4510-ir-only-baseline-preclaim-to-postclaim-drift.md
@@ -1,0 +1,44 @@
+---
+id: 4510
+title: "#4605 baseline traded a pre-claim rejection for 2 post-claim resolve-stage demotes — the drift #4462's design notes set out to avoid"
+status: ready
+sprint: Backlog
+created: 2026-08-16
+priority: low
+horizon: s
+feasibility: medium
+task_type: hardening
+area: ir
+goal: ir-full-coverage
+related: [4462, 4605, 4494]
+origin: "dev-4605-park diagnosis 2026-08-16"
+---
+
+# #4510 — pre-claim → post-claim demote drift in the standalone reference corpus
+
+## Finding (measured 2026-08-16)
+
+The #4605 (`#4462`) branch's `scripts/ir-only-baseline.json` trades
+`select/primitive-method-unsupported: 1` for
+`resolve/late-preparation-unsupported: 2` in the standalone corpus — i.e. two
+reference-corpus units moved from a **pre-claim** rejection (selector says no
+before committing) to a **post-claim resolve-stage** demote (selector claims,
+then the build backs out). This is exactly the selector↔capability-table
+drift #4462's own design notes set out to make structurally impossible, now
+merged. It is NOT a regression (both are demotes, the units still compile via
+legacy) but it weakens the claim ⇔ preparability parity story #4494
+established, and post-claim demotes are the bucket `check:ir-fallbacks`
+watches most closely.
+
+Note: #4611 (#4508) landed immediately after and reworked the same baseline
+region (`late-preparation-unsupported` → 0 in standalone) — re-measure on
+current main before doing anything; the residue may already be gone.
+
+## Acceptance criteria
+
+1. Re-measure on current main: `pnpm run check:ir-only` standalone lane —
+   list any unit whose rejection is post-claim (`resolve/`-stage) where a
+   pre-claim (`select/`-stage) verdict is derivable from the same facts.
+2. For each, either move the verdict pre-claim (selector consults the same
+   predicate the resolver uses) or record in this issue why the facts are
+   genuinely only known at resolve time.

--- a/plan/issues/4511-session-usage-limit-monitor-hook.md
+++ b/plan/issues/4511-session-usage-limit-monitor-hook.md
@@ -1,0 +1,78 @@
+---
+id: 4511
+title: "Session-start usage-limit monitor: per-minute window check, suspend sentinel at ≥99%, agent-spawn deny hook"
+status: done
+completed: 2026-08-16
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+assignee: ttraenkler/fable-lead
+priority: high
+horizon: s
+feasibility: medium
+task_type: infra
+area: ci, process
+goal: ir-full-coverage
+origin: "user directive 2026-08-16 — 'at the beginning of every session a background job should be scheduled that every minute reads the usage limits and if one is close should suspend work for itself and the whole team … ideally set up as a hook when the session starts'"
+related: []
+---
+
+# #4511 — Session-start usage-limit monitor (hook + daemon + sentinel)
+
+## Problem
+
+The suspend-at-99% rule (`feedback_5h_window_pause_resume`,
+`feedback_5h_window_99pct_schedule_wakeup`) had no automated detector: the
+5-hour window percentage was in the statusline's stdin payload but was never
+persisted, so the fleet only learned the window was exhausted when agents
+died mid-turn with limit errors (it happened twice on 2026-08-15/16 — both
+recoveries were clean only because of push-early discipline).
+
+## What landed
+
+1. **`.claude/statusline-command.sh`** — the budget cache
+   (`~/.claude/js2wasm-budget.json`) now also persists
+   `five_hour_used_pct` + `five_hour_resets_at` (it previously kept only the
+   weekly figures).
+2. **`scripts/usage-limit-monitor.sh`** (new) — singleton daemon, 60s loop:
+   reads the cache; at ≥99% (env-overridable `USAGE_LIMIT_SUSPEND_PCT`) on the
+   5h (or weekly) window it raises `~/.claude/usage-limit-suspend.json`
+   carrying the window name, percentage and reset timestamp; clears it when
+   usage drops (new window). `--once` mode for tests.
+3. **`.claude/settings.json`** — two hook wirings:
+   - `SessionStart` launches the daemon (no-op if already running).
+   - `PreToolUse` on `Agent` DENIES new agent spawns while the sentinel is
+     live and unexpired, with a reason that carries the suspend order and the
+     reset time, so the lead is instructed in-band to suspend the team and
+     schedule exactly one wakeup.
+
+## Honesty constraint (load-bearing)
+
+The cache is written only when the statusline renders — i.e. interactive
+sessions. **Headless/remote sessions never refresh it**, so the monitor
+degrades to an explicit `NO-SIGNAL` log state there and never fabricates a
+percentage (a detector must be able to say "I don't know"). In no-signal
+sessions the fallback remains the documented limit-error handling: on the
+first "hit your limit · resets HH:MM" error, suspend everything and arm one
+wakeup at the stated reset.
+
+## Test evidence (2026-08-16, `--once` mode against a synthetic cache)
+
+| scenario | result |
+| --- | --- |
+| cache with `five_hour_used_pct: 99.5` | sentinel raised with `resets_at` |
+| deny-hook command with live sentinel | emits `permissionDecision: "deny"` naming window, %, reset time |
+| cache back to 12% | sentinel cleared, transition logged |
+| cache absent | `NO-SIGNAL` logged once, no sentinel |
+
+Settings JSON validated with `jq -e` for both hook entries after the merge
+(existing hook arrays preserved).
+
+## Residual
+
+- The deny hook gates `Agent` spawns only; the lead's own long turns are not
+  interrupted mid-flight (deliberate — the suspend itself costs tokens and
+  must run to completion).
+- Wakeup scheduling stays with the lead (send_later/one-shot cron) because
+  hook scripts cannot reach the scheduling tools; the deny reason tells the
+  lead the exact reset time to use.

--- a/scripts/usage-limit-monitor.sh
+++ b/scripts/usage-limit-monitor.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# usage-limit-monitor.sh — per-minute usage-window watchdog (#4511)
+#
+# Reads the statusline budget cache (~/.claude/js2wasm-budget.json) every
+# minute. When any rate-limit window reaches the suspend threshold (default
+# 99%), it raises a suspend sentinel (~/.claude/usage-limit-suspend.json)
+# carrying the window's reset timestamp; when usage drops (new window), it
+# clears the sentinel. The PreToolUse hook in .claude/settings.json denies
+# new Agent spawns while the sentinel is live, which surfaces the suspend
+# order — "suspend the team, schedule ONE wakeup at the reset" — to the lead
+# in-band (feedback_5h_window_pause_resume).
+#
+# HONESTY CONSTRAINT: the cache is written only when the statusline renders
+# (interactive sessions). Headless sessions never refresh it, so this monitor
+# DEGRADES TO NO-SIGNAL there — it logs that state explicitly and never
+# fabricates a percentage. A detector must be able to say "I don't know";
+# the fallback in no-signal sessions remains the documented limit-error
+# handling (agents dying with "hit your limit · resets HH:MM").
+#
+# Usage:
+#   usage-limit-monitor.sh            # launch singleton daemon (no-op if running)
+#   usage-limit-monitor.sh --once     # single evaluation, for tests/hooks
+#   usage-limit-monitor.sh --daemon   # internal: the loop itself
+set -u
+
+CLAUDE_HOME="${CLAUDE_HOME:-$HOME/.claude}"
+CACHE="$CLAUDE_HOME/js2wasm-budget.json"
+SENTINEL="$CLAUDE_HOME/usage-limit-suspend.json"
+PIDFILE="$CLAUDE_HOME/usage-limit-monitor.pid"
+LOG="$CLAUDE_HOME/usage-limit-monitor.log"
+THRESHOLD="${USAGE_LIMIT_SUSPEND_PCT:-99}"
+INTERVAL="${USAGE_LIMIT_POLL_SEC:-60}"
+MAX_CACHE_AGE="${USAGE_LIMIT_MAX_CACHE_AGE_SEC:-600}"
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$1" >>"$LOG"; }
+
+evaluate_once() {
+  local now pct window resets written age state_file="$CLAUDE_HOME/.usage-limit-monitor.state"
+  local prev="" state=""
+  [ -f "$state_file" ] && prev=$(cat "$state_file" 2>/dev/null)
+  now=$(date +%s)
+
+  if [ ! -f "$CACHE" ]; then
+    state="nosignal-absent"
+    [ "$prev" != "$state" ] && log "NO-SIGNAL: cache absent ($CACHE) — statusline not rendering in this session; detection degraded to limit-error signals"
+  else
+    written=$(jq -r '.written_at // 0' "$CACHE" 2>/dev/null || echo 0)
+    age=$((now - ${written%.*}))
+    if [ "$age" -gt "$MAX_CACHE_AGE" ]; then
+      state="nosignal-stale"
+      [ "$prev" != "$state" ] && log "NO-SIGNAL: cache is ${age}s old (> ${MAX_CACHE_AGE}s) — treating as unknown, not as healthy"
+    else
+      # Prefer the tighter 5h window; fall back to weekly.
+      pct=$(jq -r '.five_hour_used_pct // empty' "$CACHE" 2>/dev/null)
+      window="five_hour"
+      resets=$(jq -r '.five_hour_resets_at // empty' "$CACHE" 2>/dev/null)
+      wk=$(jq -r '.seven_day_used_pct // empty' "$CACHE" 2>/dev/null)
+      if [ -n "$wk" ] && { [ -z "$pct" ] || awk -v a="$wk" -v b="${pct:-0}" 'BEGIN{exit !(a>b)}'; }; then
+        if awk -v a="$wk" -v t="$THRESHOLD" 'BEGIN{exit !(a>=t)}'; then
+          pct="$wk"; window="seven_day"
+          resets=$(jq -r '.resets_at // empty' "$CACHE" 2>/dev/null)
+        fi
+      fi
+      if [ -n "${pct:-}" ] && awk -v a="$pct" -v t="$THRESHOLD" 'BEGIN{exit !(a>=t)}'; then
+        state="suspend"
+        if [ "$prev" != "$state" ]; then
+          printf '{"window":"%s","used_pct":%s,"resets_at":%s,"written_at":%s}\n' \
+            "$window" "$pct" "${resets:-null}" "$now" >"$SENTINEL"
+          log "SUSPEND: $window at ${pct}% >= ${THRESHOLD}% — sentinel raised (resets_at=${resets:-unknown})"
+        fi
+      else
+        state="clear"
+        if [ -f "$SENTINEL" ]; then
+          rm -f "$SENTINEL"
+          log "CLEAR: usage below threshold (five_hour=${pct:-n/a}) — sentinel removed"
+        fi
+      fi
+    fi
+  fi
+  printf '%s' "$state" >"$state_file"
+}
+
+case "${1:-}" in
+  --daemon)
+    log "monitor daemon started (pid $$, threshold ${THRESHOLD}%, interval ${INTERVAL}s)"
+    while true; do
+      evaluate_once
+      sleep "$INTERVAL"
+    done
+    ;;
+  --once)
+    evaluate_once
+    ;;
+  *)
+    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+      exit 0
+    fi
+    nohup bash "$0" --daemon >/dev/null 2>&1 &
+    echo $! >"$PIDFILE"
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
## Description

Implements #4511 (issue file in this PR; user directive 2026-08-16): the suspend-at-99% rule (`feedback_5h_window_pause_resume`) becomes automation instead of a convention the lead must remember under pressure.

- **`.claude/statusline-command.sh`** — the budget cache (`~/.claude/js2wasm-budget.json`) now persists the **five_hour** window (`used_percentage` + `resets_at`) alongside the weekly figures it already kept. The payload field was always there; only the cache write dropped it.
- **`scripts/usage-limit-monitor.sh`** (new) — singleton daemon, 60s poll: at ≥99% on the 5h (or weekly) window it raises `~/.claude/usage-limit-suspend.json` with the window, percentage, and reset timestamp; clears it when a new window starts. `--once` mode for tests.
- **`.claude/settings.json`** — `SessionStart` launches the daemon (idempotent); `PreToolUse` on `Agent` **denies new agent spawns** while the sentinel is live and unexpired, with a reason carrying the suspend order and the exact reset time, so the lead is told in-band to suspend the team and schedule exactly one wakeup.

**Honesty constraint:** the cache refreshes only when the statusline renders (interactive sessions). Headless sessions degrade to an explicit `NO-SIGNAL` log state — the monitor never fabricates a percentage; the limit-error fallback stands there. Verified live: the daemon in the authoring (headless) session logs exactly that.

Pipe-tested all four paths with a synthetic cache (raise → sentinel with reset ts; deny hook emits `permissionDecision:"deny"` naming window/%/reset; healthy cache clears; absent cache logs NO-SIGNAL once). Settings merged additively — both existing hook arrays preserved, validated with `jq -e`.

Also files two findings from the dev-4605-park diagnosis (which refuted the stale-base park with 440/440 byte-identity): **#4509** — the test262 `print` shim is a statement-position `console.log(value)` matching #4462's console claim surface exactly, inert today only because the param is untyped; **#4510** — the #4605 baseline traded a pre-claim rejection for 2 post-claim resolve-stage demotes (re-measure post-#4611 before acting).

## CLA

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8EzRKZovuUremQM9dfJAC)_