### PR TITLE
fix(website): collapse JS host source cards

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -504,6 +504,62 @@
         line-height: 1.72;
         color: var(--fg-faint);
       }
+      .host-bench-sources-footnote {
+        grid-column: 1 / -1;
+        margin-top: -8px;
+        padding-top: 8px;
+        border-top: 1px solid var(--fg-faintest, rgba(255, 255, 255, 0.08));
+      }
+      .host-bench-sources-footnote > summary {
+        cursor: pointer;
+        list-style: none;
+        color: var(--fg-faint, rgba(255, 255, 255, 0.55));
+        font-family: var(--mono, ui-monospace, monospace);
+        font-size: 11px;
+        letter-spacing: 0.05em;
+        padding: 4px 0;
+      }
+      .host-bench-sources-footnote > summary::-webkit-details-marker {
+        display: none;
+      }
+      .host-bench-sources-footnote > summary::before {
+        content: "+ ";
+        color: var(--fg-soft, rgba(255, 255, 255, 0.75));
+      }
+      .host-bench-sources-footnote[open] > summary::before {
+        content: "− ";
+      }
+      .host-bench-sources-footnote > summary:hover {
+        color: var(--fg);
+      }
+      .host-bench-sources-footnote .host-bench-section-desc {
+        max-width: 780px;
+        margin: 8px 0 16px;
+        font-size: 13px;
+        line-height: 1.5;
+      }
+      .host-bench-source-list {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 12px;
+      }
+      .host-bench-source-list .bench-test-group {
+        grid-column: auto;
+        margin: 0;
+        padding: 12px;
+      }
+      .host-bench-source-list .bench-test-title {
+        font-size: 11px;
+        line-height: 1.35;
+      }
+      .host-bench-source-list .bench-test-desc {
+        margin-bottom: 8px;
+        font-size: 12px;
+        line-height: 1.4;
+      }
+      .host-bench-source-list .bench-test-source summary {
+        font-size: 10px;
+      }
 
       .diagram-title {
         font-family: var(--mono);
@@ -583,6 +639,9 @@
         .edition-chart {
           grid-column: span 1;
         }
+        .host-bench-source-list {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
       }
 
       @media (max-width: 720px) {
@@ -594,6 +653,9 @@
       @media (max-width: 440px) {
         #conformance-donut-slot {
           padding-top: 0;
+        }
+        .host-bench-source-list {
+          grid-template-columns: 1fr;
         }
       }
 
@@ -3588,9 +3650,8 @@ match (value) {
             extending past the JS baseline mean Wasm is faster. The left chart pins both runtimes to their baseline
             tier, the no-optimizing-JIT path that matters for cold starts and multi-tenant edge runtimes; the right
             chart is the production setup with both full optimizing pipelines. These benchmarks run in a JS host
-            (Wasmtime/WASI figures are in the section below). Source for each program is shown inline below the charts.
-            Use &ldquo;Run Browser Benchmark&rdquo; to measure live in your browser, including additional DOM
-            benchmarks.
+            (Wasmtime/WASI figures are in the section below). Source footnotes are available below the charts. Use
+            &ldquo;Run Browser Benchmark&rdquo; to measure live in your browser, including additional DOM benchmarks.
           </p>
           <div class="conformance-diagrams">
             <div class="diagram-panel">
@@ -3613,22 +3674,22 @@ match (value) {
                 legend="Production tiers enabled — V8 TurboFan for JS, Liftoff→TurboFan for Wasm. Bars show speedup over the warm/hot JS runtime."
               ></perf-benchmark-chart>
             </div>
-            <h4 class="host-bench-section-title">Sources</h4>
-            <p class="host-bench-section-desc">
-              One bar per program above. Each block below is the measured kernel — the single exported function the
-              harness times, taken verbatim from
-              <code>website/playground/examples/benchmarks/</code>
-              . Each file also exports a
-              <code>main()</code>
-              that draws the playground's DOM card; that scaffolding is compiled but never timed, so it is not shown
-              here.
-            </p>
-            <div class="bench-test-group" data-test="fib">
-              <h4 class="bench-test-title">fib — fib(30)</h4>
-              <p class="bench-test-desc">Recursive — pure i32/f64 math, no host calls.</p>
-              <details class="bench-test-source">
-                <summary>Show source</summary>
-                <pre class="how-code js">
+            <details class="host-bench-sources-footnote">
+              <summary>Source footnotes · fib · loop · string · array</summary>
+              <p class="host-bench-section-desc">
+                Each source is the measured kernel taken verbatim from
+                <code>website/playground/examples/benchmarks/</code>
+                . The files also export a
+                <code>main()</code>
+                for the playground card; that scaffolding is compiled but not timed.
+              </p>
+              <div class="host-bench-source-list">
+                <div class="bench-test-group" data-test="fib">
+                  <h4 class="bench-test-title">fib — fib(30)</h4>
+                  <p class="bench-test-desc">Recursive — pure i32/f64 math, no host calls.</p>
+                  <details class="bench-test-source">
+                    <summary>Show source</summary>
+                    <pre class="how-code js">
 export function fib(n: number): number {
   if (n &lt;= 1) return n;
   return fib(n - 1) + fib(n - 2);
@@ -3637,43 +3698,43 @@ export function fib(n: number): number {
 export function bench_fib(): number {
   return fib(30);
 }</pre
-                >
-              </details>
-            </div>
-            <div class="bench-test-group" data-test="loop">
-              <h4 class="bench-test-title">loop — 1M Int32 sum</h4>
-              <p class="bench-test-desc">Tight i32 loop with explicit | 0 wrap, no allocations.</p>
-              <details class="bench-test-source">
-                <summary>Show source</summary>
-                <pre class="how-code js">
+                    >
+                  </details>
+                </div>
+                <div class="bench-test-group" data-test="loop">
+                  <h4 class="bench-test-title">loop — 1M Int32 sum</h4>
+                  <p class="bench-test-desc">Tight i32 loop with explicit | 0 wrap, no allocations.</p>
+                  <details class="bench-test-source">
+                    <summary>Show source</summary>
+                    <pre class="how-code js">
 export function bench_loop(): number {
   let s = 0;
   for (let i = 0; i &lt; 1000000; i++) s = (s + i) | 0;
   return s;
 }</pre
-                >
-              </details>
-            </div>
-            <div class="bench-test-group" data-test="string">
-              <h4 class="bench-test-title">string — concat 1k</h4>
-              <p class="bench-test-desc">wasm:js-string concat per iteration.</p>
-              <details class="bench-test-source">
-                <summary>Show source</summary>
-                <pre class="how-code js">
+                    >
+                  </details>
+                </div>
+                <div class="bench-test-group" data-test="string">
+                  <h4 class="bench-test-title">string — concat 1k</h4>
+                  <p class="bench-test-desc">wasm:js-string concat per iteration.</p>
+                  <details class="bench-test-source">
+                    <summary>Show source</summary>
+                    <pre class="how-code js">
 export function bench_string(): number {
   let str = "";
   for (let i = 0; i &lt; 1000; i++) str = str + "abcde";
   return str.length;
 }</pre
-                >
-              </details>
-            </div>
-            <div class="bench-test-group" data-test="array">
-              <h4 class="bench-test-title">array — fill+sum 10k</h4>
-              <p class="bench-test-desc">Wasm GC array — push / get loop.</p>
-              <details class="bench-test-source">
-                <summary>Show source</summary>
-                <pre class="how-code js">
+                    >
+                  </details>
+                </div>
+                <div class="bench-test-group" data-test="array">
+                  <h4 class="bench-test-title">array — fill+sum 10k</h4>
+                  <p class="bench-test-desc">Wasm GC array — push / get loop.</p>
+                  <details class="bench-test-source">
+                    <summary>Show source</summary>
+                    <pre class="how-code js">
 export function bench_array(): number {
   const arr: number[] = [];
   for (let i = 0; i &lt; 10000; i++) arr.push(i);
@@ -3681,9 +3742,11 @@ export function bench_array(): number {
   for (let i = 0; i &lt; arr.length; i++) total = total + arr[i];
   return total;
 }</pre
-                >
-              </details>
-            </div>
+                    >
+                  </details>
+                </div>
+              </div>
+            </details>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- collapse the JavaScript-host benchmark source cards into one compact expandable footnote
- keep individual source snippets available on demand
- keep the expanded source list responsive across desktop and mobile widths

## Validation
- Checking formatting...
All matched files use Prettier code style!
- 
 RUN  v3.2.4 /private/tmp/js2wasm-source-footnote

········

 Test Files  2 passed (2)
      Tests  8 passed (8)
   Start at  08:15:36
   Duration  1.00s (transform 49ms, setup 0ms, collect 728ms, tests 72ms, environment 0ms, prepare 42ms) (8 tests passed)
- 
- commit hooks passed: LOC/function budgets, changed-root test selection, and oracle-ratchet