### PR TITLE
docs(ir): file #4520–#4523 — IR design-review hardening issues

### DIFF
--- a/plan/issues/4520-ir-abi-carrier-differential-gate.md
+++ b/plan/issues/4520-ir-abi-carrier-differential-gate.md
@@ -1,0 +1,64 @@
+---
+id: 4520
+title: "Differential gate for three-way ABI carrier agreement: r2StableSignatureType / hasFullyAnnotatedScalarAbi / legacy resolveWasmType agree only by argument, not by test"
+status: ready
+sprint: current
+created: 2026-08-16
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: hardening
+area: ir, codegen
+language_feature: compiler-internals
+goal: ir-full-coverage
+parent: 3518
+related: [4514, 4508, 4186, 3518]
+origin: "tech-lead IR design review 2026-08-16"
+files:
+  - src/codegen/ir-legacy-caller-abi.ts
+  - src/codegen/ir-prepared-free-functions.ts
+  - src/ir/program-abi.ts
+---
+
+# #4520 — differential test for the three ABI carrier oracles
+
+## Problem
+
+Three independent predicates must answer "what wasm carrier does this
+annotated position get" identically:
+
+1. `r2StableSignatureType` (prepared-component admission,
+   `src/codegen/ir-prepared-free-functions.ts`),
+2. `hasFullyAnnotatedScalarAbi` (select-stage caller-closure certification,
+   `src/codegen/ir-legacy-caller-abi.ts`),
+3. legacy `resolveWasmType` / `getOrRegisterVecType` (the slot ABI a legacy
+   caller's pre-emitted `call` actually targets).
+
+Their agreement is currently argued in comments ("both read the same
+`ts.TypeNode` through the same mode-consistent mapping") — not asserted by
+any test. The `mname` episode (#3518 notes, 2026-08-15) proved these
+arguments go wrong in BOTH directions: `string` positions were excluded from
+certification on the claim that "their carrier depends on `nativeStrings`",
+which was FALSE (both sides pick from the same
+`ctx.nativeStrings && ctx.anyStrTypeIdx >= 0` pair, including the corner). A
+wrong argument in the other direction (certifying a position the carriers
+disagree on) would be a silent ABI mismatch — the exact hazard class of
+#4186 and the late-import index-shift family.
+
+## Acceptance criteria
+
+- [ ] A test enumerates the annotated-type surface (scalars, `void`,
+      one-level arrays, `string`, and the excluded families: optional/rest/
+      default params, generators, object positions) × modes
+      (host/standalone/wasi × nativeStrings on/off) and asserts, for every
+      cell: certification granted ⇒ IR carrier === legacy carrier
+      (structurally, e.g. both `(ref_null $vec_f64)`).
+- [ ] Cells where certification is DENIED assert why: either the carriers
+      genuinely diverge (documented) or the denial is conservative-but-sound
+      (candidate for a follow-up widening, listed in the test as such —
+      `mname`-style false exclusions become visible instead of latent).
+- [ ] The test fails if a new `IrType` family or a carrier-affecting ctx flag
+      is added without a row (exhaustiveness over the certified surface).
+- [ ] No behavior change in this PR — a discovered disagreement is its own
+      bug to file, not to quietly fix here.

--- a/plan/issues/4521-dedupe-demote-on-legacy-caller-policy.md
+++ b/plan/issues/4521-dedupe-demote-on-legacy-caller-policy.md
@@ -1,0 +1,49 @@
+---
+id: 4521
+title: "demoteOnLegacyCaller mode policy is duplicated in select.ts and select-identity.ts — hoist to one shared module"
+status: ready
+sprint: current
+created: 2026-08-16
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: refactor
+area: ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+parent: 3518
+related: [3518, 4514]
+origin: "tech-lead IR design review 2026-08-16"
+files:
+  - src/ir/select.ts
+  - src/ir/select-identity.ts
+---
+
+# #4521 — one definition for the caller-direction demotion policy
+
+## Problem
+
+`const demoteOnLegacyCaller = options.jsHostExterns !== true;` is computed
+independently in `src/ir/select.ts` (~line 1014) and
+`src/ir/select-identity.ts` (~line 982), with mirrored consult sites in each.
+The predicate machinery is properly shared (select-identity imports
+`configureIrStructuralSelectorPredicates` etc. from select.ts), but the
+mode-keyed POLICY line and its guard sites are copy-pairs. #3518's 2026-08-15
+work had to patch both files in lockstep, and its notes call them out as "two
+mirrored places". A future edit that touches only one silently forks
+selection behavior between the structural and identity paths — a class of
+drift no current gate detects (the two paths are never diffed against each
+other).
+
+## Acceptance criteria
+
+- [ ] The policy (`jsHostExterns !== true`, plus the
+      `legacyCallerAbiIsProjected` consult contract around it) lives in ONE
+      exported helper; both select.ts and select-identity.ts call it. Grep
+      for `jsHostExterns !== true` finds exactly one hit under `src/ir/`.
+- [ ] Pure refactor: `check:ir-only` (both lanes), `check:ir-fallbacks`, and
+      the equivalence gate are byte-for-byte unchanged.
+- [ ] Bonus if cheap: a comment or micro-test asserting the structural and
+      identity paths consult the same policy object, so the next mirrored
+      policy addition has an obvious home.

--- a/plan/issues/4522-ir-kill-switch-inventory-r9.md
+++ b/plan/issues/4522-ir-kill-switch-inventory-r9.md
@@ -1,0 +1,54 @@
+---
+id: 4522
+title: "Inventory and retirement plan for the 13 JS2WASM_IR_* env kill-switches — R9 requires them gone, nobody owns the list"
+status: ready
+sprint: current
+created: 2026-08-16
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: hardening
+area: ir, tooling
+language_feature: compiler-internals
+goal: ir-full-coverage
+parent: 3518
+related: [3518, 3792]
+origin: "tech-lead IR design review 2026-08-16"
+---
+
+# #4522 — kill-switch inventory for the R9 flip
+
+## Problem
+
+R9 of #3518 requires all IR/legacy escape hatches and compile-twice switches
+removed "from public options, env handling, tests, scripts, and
+documentation". Measured 2026-08-16: **13 distinct `JS2WASM_IR_*` env vars**
+(~57 references) exist under `src/`:
+
+`JS2WASM_IR_INLINE` (15) · `JS2WASM_IR_FIRST` (10) · `JS2WASM_IR_SHAPE_DIAG`
+(7) · `JS2WASM_IR_I…` (4) · `JS2WASM_IR_POSTCLAIM_LOG` (3) ·
+`JS2WASM_IR_OWNERSHIP` (3) · `JS2WASM_IR_OBJECT_SHAPES` (3) ·
+`JS2WASM_IR_GVN` (3) · `JS2WASM_IR_ESCAPE` (3) · `JS2WASM_IR_ASYNC` (3) ·
+`JS2WASM_IR_VERIFY_DOMINANCE_NAIVE` (2) · `JS2WASM_IR_STRING_BUILDER` (2) ·
+`JS2WASM_IR_GVN_DEBUG` (1)
+
+These are not one category, and R9 must not delete them uniformly:
+diagnostics (`*_DIAG`, `*_LOG`, `*_DEBUG`) and self-checks
+(`VERIFY_DOMINANCE_NAIVE` cross-checks the fast dominance algorithm against
+the naive one) are healthy and should SURVIVE; feature kill-switches
+(`IR_FIRST`, `IR_STRING_BUILDER`, pass toggles) are the R9 debt. Nobody owns
+the classification today, and rediscovering it at flip time is exactly the
+kind of last-minute audit R9 should not depend on.
+
+## Acceptance criteria
+
+- [ ] A table in this issue (or `plan/log/ir-adoption.md`) classifying every
+      `JS2WASM_IR_*` var: keep-as-diagnostic / keep-as-self-check /
+      retire-at-R9 (with the retiring issue or R-slice named) /
+      retire-now-already-dead.
+- [ ] Any var classified retire-now is actually removed in the same PR, with
+      grep-zero evidence.
+- [ ] A one-line guard is added to the R9 acceptance checklist in #3518
+      pointing at this inventory, so the flip consumes it rather than
+      re-auditing.

--- a/plan/issues/4523-verify-checkinstr-coverage-roadmap.md
+++ b/plan/issues/4523-verify-checkinstr-coverage-roadmap.md
@@ -1,0 +1,50 @@
+---
+id: 4523
+title: "checkInstr type rules cover 16/78 IR kinds by construction — decide the opt-in→opt-out question and own the roadmap"
+status: ready
+sprint: current
+created: 2026-08-16
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: hardening
+area: ir
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+related: [4070, 3518]
+origin: "opus-ir-1's #4070 writeup + tech-lead IR review, 2026-08-16"
+files:
+  - src/ir/verify.ts
+  - plan/agent-context/opus-ir-1.md
+---
+
+# #4523 — per-instruction type-rule coverage is an undecided policy, not a hole
+
+## Problem
+
+The #4070 sweep (PR #4623) hardened every IR-union switch that could fail
+silently, but deliberately left `checkInstr` in `src/ir/verify.ts` unguarded:
+it implements type rules for **16 of 78** IR kinds and is partial BY
+CONSTRUCTION — an opt-in policy where a kind without a rule is simply not
+type-checked. Adding a `never` guard there would mean 62 empty cases and
+would flip the policy to opt-out. That is a design decision, and the #4070
+dev correctly wrote it up (`plan/agent-context/opus-ir-1.md`) rather than
+deciding it unilaterally. Undecided, it has a real cost: a new IR kind gets
+NO type verification and nothing reminds its author that the omission was a
+choice. Meanwhile the rest of verify.ts (def-use, dominance, branch arity/
+types) IS total, so the partial region is easy to mistake for covered.
+
+## Acceptance criteria
+
+- [ ] A decision, recorded in this file: (a) opt-out — every kind needs a
+      rule or an explicit `case: skip` with a reason, enforced by the switch;
+      or (b) opt-in stays — but a generated coverage table (kinds with/
+      without rules) is emitted and ratcheted so coverage can only grow; or
+      (c) a hybrid (e.g. new kinds require a rule; the 62 legacy kinds are a
+      grandfathered baseline that ratchets down).
+- [ ] The chosen mechanism implemented; deliberately removing one existing
+      rule must fail loudly (prove the gate fires, per the #4070 method).
+- [ ] The 62 uncovered kinds triaged at least into "type rule meaningful" vs
+      "nothing to check" (e.g. kinds whose operands are untyped by design),
+      so the roadmap has a real denominator.


### PR DESCRIPTION
Four issues from the 2026-08-16 tech-lead IR state review (consistency / correctness / design), all groomed with acceptance criteria:

- **#4520** — differential test gate for the three-way ABI carrier agreement (`r2StableSignatureType` / `hasFullyAnnotatedScalarAbi` / legacy `resolveWasmType`) — agreement is currently argued in comments only, and the `mname` episode showed those arguments fail in both directions.
- **#4521** — `demoteOnLegacyCaller` mode policy is computed independently in `select.ts` and `select-identity.ts` (lockstep-edit hazard, confirmed by #3518's own notes) — hoist to one shared helper.
- **#4522** — inventory + classification of the 13 `JS2WASM_IR_*` env kill-switches (~57 refs) so the R9 flip consumes a decided list instead of a last-minute audit.
- **#4523** — `checkInstr` type rules cover 16/78 IR kinds by construction; decide the opt-in→opt-out question (from the #4070 dev's writeup) and ratchet coverage.

Docs-only: touches `plan/issues/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCc9pPr4zkApPrpHwNyV1f