### PR TITLE
docs(npm-compat): triage curated-package upstream failures — file #4525–#4536 with implementation plans

### DIFF
--- a/plan/issues/4383-uuid-original-suite-runtime-and-callref-gaps.md
+++ b/plan/issues/4383-uuid-original-suite-runtime-and-callref-gaps.md
@@ -134,6 +134,25 @@ broad vector, crypto, digest, exception, and dynamic-state failures: **65/75**
 upstream callbacks still fail and remain follow-up work for the final 75/75
 acceptance target.
 
+## 2026-08-16 re-measure (main `a9b20d4c`, curated-suite triage)
+
+Still **10/75 Wasm, 75/75 Node**, all ten modules validate — unchanged from
+the 2026-08-12 checkpoint; the 65 remaining failures bucket as:
+
+| bucket | count | note |
+| --- | --- | --- |
+| `[object WebAssembly.Exception]` (uncaught wasm exception) | 24 | v35 digest paths + v1/v6/v7 option/state paths |
+| `RuntimeError: illegal cast` | 21 | v1/v6/v7 dynamic-state clusters |
+| assertion: `Invalid UUID` / stringify invalid | 7 | byte-vector parse/stringify round-trips |
+| `crypto.getRandomValues: argument is not a typed-array (Uint8Array required)` | 6 | compiled Uint8Array loses host typed-array identity (see `tests/issue-4383-uuid-typed-array-identity.test.ts`) |
+| `crypto is not defined` | 3 | v4 native-random probes |
+| validate/version null-result table cases | 4 | helpers return null/undefined |
+
+Per-file: `v35` 0/21 · `v7` 0/14 · `v1` 0/10 · `v6` 0/8 · `v4` 6/10 ·
+`parse` 1/5 · `stringify` 3/4 · `rng` 0/1 · `validate` 0/1 · `version` 0/1.
+The open acceptance boxes above are all still open; no drift, no progress
+since the checkpoint.
+
 ## Reproduction
 
 ```bash

--- a/plan/issues/4525-moment-closure-capture-i32-ref-validation.md
+++ b/plan/issues/4525-moment-closure-capture-i32-ref-validation.md
@@ -1,0 +1,103 @@
+---
+id: 4525
+title: "Moment: every generated upstream module fails validation — closure struct.new receives i32 where a ref-typed capture field is expected"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: closures
+goal: npm-library-support
+related: [4384, 3996, 3995]
+files:
+  - src/codegen/closures.ts
+  - src/codegen/closures/arrow-phases.ts
+  - tests/dogfood/moment-upstream-suite.mjs
+---
+
+# Moment: closure capture field typed `(ref null N)` receives an i32 at `struct.new`
+
+## Problem
+
+The pinned Moment 2.30.1 upstream slice (6 selected test files, 10 callbacks)
+is **0/10 in Wasm on current main** because **all six generated modules fail
+`WebAssembly.compile()` validation** with one consistent defect — a closure
+allocation passes an `i32` where the capture struct's field is a reference:
+
+```text
+CompileError: WebAssembly.compile(): Compiling function #1115:"__closure_296"
+failed: struct.new[5] expected type (ref null 72), found local.get of type i32
+```
+
+Measured 2026-08-16 on `a9b20d4c` (local run reproduces the npm-compat CI card
+bit-for-bit: 0/10). Per-module: `days_in_year` (`__closure_296`), `is_date`
+(`__closure_298`), `is_moment` (`__closure_301`), `min_max` (`__closure_297`),
+`mutable` (`__closure_297`), `normalize_units` (`__closure_296`) — always
+capture field **[5]**, always `(ref null 72)` vs `i32`, in a `__closure_*`
+allocation. All six modules *emit* successfully (`success: true`,
+~630–660 KB); only validation fails, so no callback ever runs.
+
+## Relationship to #4384
+
+#4384's 2026-08-13 checkpoint measured **6/6 modules compile AND validate,
+10/10 Node, 10/10 Wasm** — on its remediation branch. That work has not merged
+(`git log origin/main --grep="#4384"` is empty). Current main fails earlier
+than #4384's resolver problem: the module never instantiates, so the
+declaration-pairing defect #4384 describes is masked. Whoever picks this up
+should first check whether the #4384 branch already fixes the capture typing
+(its final remediation touched exactly this area: "async resume frames …
+name-remapped capture sources", "captures written after a declaration use a
+live cell").
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/moment-upstream-suite.mjs --json
+# compile.details[*].validationError — all six modules
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Reduce first.** Extract the smallest of the six modules
+   (`.moment-upstream-suite*/generated/src/test/moment/days_in_year.*`) and
+   bisect the source by halving until the `struct.new[5]` mismatch reproduces
+   in a standalone `.tmp/` file. The suspect shape, given field index 5 and
+   one consistent closure per module, is a lifted closure capturing a mix of
+   scalar (i32-storage) and reference locals where the capture *plan* and the
+   capture *emission* disagree on one slot's storage class — i.e. the plan
+   said "boxed/ref cell" (field type `(ref null 72)`) but the allocation site
+   pushes the raw i32 storage value.
+2. **Locate the disagreement**: `planClosureCaptures`
+   (src/codegen/closures/arrow-phases.ts) decides field types;
+   `compileLiftedClosureBody` / the `struct.new` emission in
+   src/codegen/closures.ts pushes capture values. Compare the code paths for a
+   capture that is (a) written after declaration (live-cell rule from #4384's
+   notes) or (b) an i32-storage boolean/int local captured into a ref-cell
+   field. The fix belongs at the emission site: coerce/box the pushed value to
+   the planned field type, or make the plan record the raw storage class it
+   will actually push — whichever direction the existing invariants support.
+   Do NOT special-case Moment.
+3. **Bisect main if the reduction stalls**: #4384's checkpoint proves a
+   branch existed where all six validated. `git bisect` between that
+   checkpoint's merge-base and current main with
+   `node --import tsx tests/dogfood/moment-upstream-suite.mjs --json | jq .compile.validated`
+   (expect 6 → 0 flip) pins the regressing merge; /bisect-regression has the
+   protocol.
+4. **Validation gates**: (a) reduction compiles+validates and runs correct in
+   `.tmp/` probe; (b) moment harness reports 6/6 validated (pass count may
+   still be limited by #4384's resolver issue — record whatever it is, do not
+   claim 10/10 unless measured); (c) equivalence tests + scoped closure tests
+   (`npm test -- tests/issue-4384-merge-group-regressions.test.ts` and the
+   closure suites); (d) `pnpm run check:ir-fallbacks` no unintended growth.
+
+## Acceptance criteria
+
+- [ ] All six generated Moment modules validate on main.
+- [ ] The reduced closure-capture shape is a committed regression test.
+- [ ] Moment upstream slice pass count recorded in this file (Node 10/10 must
+      hold; Wasm count depends on #4384's unmerged resolver fix).

--- a/plan/issues/4526-redux-runtime-null-deref-illegal-cast-clusters.md
+++ b/plan/issues/4526-redux-runtime-null-deref-illegal-cast-clusters.md
@@ -1,0 +1,128 @@
+---
+id: 4526
+title: "Redux: 3/78 — combineReducers null-deref (40 tests), dynamic-dispatch illegal cast (16), createStore dispatch illegal cast (7)"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: codegen, runtime
+language_feature: closures, objects
+goal: npm-library-support
+related: [3996, 3995, 4370]
+files:
+  - tests/dogfood/redux-upstream-suite.mjs
+  - src/codegen/closures.ts
+  - src/runtime.ts
+---
+
+# Redux: three runtime clusters keep the pinned suite at 3/78
+
+## Problem
+
+The pinned Redux 5.0.1 upstream suite compiles and validates **all 9 modules**
+(the #3996 `local index out of range` emit failures are gone), but only
+**3/78** admitted tests pass in Wasm (78/78 in Node; 4 harness-incompatible).
+Measured 2026-08-16 on `a9b20d4c`, reproducing the npm-compat card exactly.
+
+Per-file: `createStore.spec` 0/40 · `combineReducers.spec` 0/16 ·
+`bindActionCreators.spec` 0/7 · `compose.spec` 1/6 · `applyMiddleware.spec`
+1/3 · `utils/*` 1/6.
+
+## Measured failure buckets
+
+1. **40× `RuntimeError: dereferencing a null pointer`** — one stack shape
+   dominates `createStore.spec` and `combineReducers.spec`:
+
+   ```text
+   at __closure_171
+   at combineReducers
+   at __closure_411 / __closure_354
+   at __call_fn_method_1 → wasmClosureDynamicDispatch
+   ```
+
+   A closure invoked *inside* `combineReducers` reads a null capture/field.
+   Redux's `combineReducers` iterates `Object.keys(reducers)` and calls each
+   reducer through a captured object — consistent with a capture or
+   object-field slot that was never populated for values that crossed the
+   host bridge (`assertReducerShape` calls every reducer with
+   `{type: ActionTypes.INIT}`).
+
+2. **16× `RuntimeError: illegal cast at __call_fn_2`** (combineReducers.spec,
+   utils specs) — the dynamic call trampoline
+   (`wasmClosureDynamicDispatch` → `__call_fn_2`, src/runtime.ts:1924) casts
+   the callee's argument/closure struct to a shape it does not have.
+
+3. **7× `RuntimeError: illegal cast at dispatch`** (bindActionCreators.spec):
+
+   ```text
+   at dispatch (wasm-function[228])
+   at createStore (wasm-function[100])
+   at __closure_157 → __call_fn_method_0
+   ```
+
+   `createStore`'s internal `dispatch({type: ActionTypes.INIT})` traps when
+   the store was created through the re-exported `legacy_createStore` /
+   bound-creator path — the action object literal fails a struct cast inside
+   `dispatch` (`isPlainObject(action)` / property reads on a
+   differently-shaped action struct).
+
+4. Remainder: 12 ordinary assertion failures (`toBe: object:null != …` — 
+   functions returning null through the bridge), 2 `global is not defined`
+   (harness env gap, `warning.spec` writes `global.console`).
+
+#3996's 2026-08-09 decomposition (frame-selection defects in
+`observeState`/`bindActionCreator`, invalid binary in `combination`) predates
+these measurements; the emit-stage failures it lists are fixed, and these are
+the runtime successors.
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/redux-upstream-suite.mjs --json
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+Work the buckets in order — bucket 1 is half the suite and blocks reading
+later failures behind it.
+
+1. **Reduce bucket 1**: `createStore.spec` "exposes the public API" is the
+   smallest carrier (it only creates a store with `combineReducers({...})`
+   and reads keys). Reduce in `.tmp/`: a function that takes an object of
+   function-valued fields, iterates its keys, and calls each value through a
+   local alias (`const reducer = reducers[key]; reducer(...)`). Suspect: the
+   heterogeneous object-literal-of-closures carrier — each spec file defines
+   reducers of different shapes, and `__closure_171`'s null read is the
+   capture cell for the object field. Cross-check #4370 (externref-array
+   receivers for map) and #3749/#3750 (heterogeneous object shapes) — the
+   object-of-functions shape here may be the same carrier defect.
+2. **Bucket 2/3 likely share a root**: both are casts of an action/argument
+   struct at a dynamic call boundary. After bucket 1's fix, re-run the suite
+   before investing in these — the counts may collapse (combineReducers
+   feeds createStore in most fixtures). If they persist, reduce
+   `bindActionCreators.spec` "wraps the action creators with the dispatch
+   function": `bindActionCreator` returns
+   `function() { return dispatch(actionCreator.apply(this, arguments)) }` —
+   an `arguments`-forwarding closure whose return value (an object literal
+   from a *different* module scope) crosses into `dispatch`'s cast.
+3. **Harness env (bucket 4, cheap)**: define `global` (alias of
+   `globalThis`) in the redux harness shim so `warning.spec` scores the real
+   behavior — 3 tests. Do this in tests/dogfood/redux-upstream-suite.mjs, not
+   the compiler.
+4. **Validation gates**: scoped `.tmp/` reductions; redux harness pass-count
+   strictly increasing with each landed fix (record per-bucket deltas here);
+   equivalence tests; `tests/issue-3996-redux-runtime.test.ts` stays green.
+
+## Acceptance criteria
+
+- [ ] `createStore.spec` + `combineReducers.spec` null-deref cluster fixed via
+      a general carrier/capture fix (no Redux-specific rewriting), with a
+      committed reduction test.
+- [ ] Illegal-cast clusters at `__call_fn_2` and `dispatch` fixed or reduced
+      to a named, filed residual.
+- [ ] Redux pinned suite ≥ 60/78 Wasm with 78/78 Node unchanged.

--- a/plan/issues/4527-axios-class-call-concat-vararg-invalid-module.md
+++ b/plan/issues/4527-axios-class-call-concat-vararg-invalid-module.md
@@ -1,0 +1,87 @@
+---
+id: 4527
+title: "axios: __class_call_concat_vararg dispatch bridge emits invalid Wasm — 7 modules fail validation, ~101 tests blocked"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: classes, rest-parameters
+goal: npm-library-support
+related: [3995, 4302]
+files:
+  - src/codegen/index.ts
+  - tests/dogfood/axios-upstream-suite.mjs
+---
+
+# axios: the vararg class-method dispatch bridge for `concat` is mistyped
+
+## Problem
+
+7 of axios's 25 generated upstream test modules **emit but fail
+`WebAssembly.compile()` validation** in the same synthetic function:
+
+```text
+Compiling function #1781:"__class_call_concat_vararg" failed:
+local.set[0] expected type (ref null 40), found ref.cast null of type (ref null 2)
+```
+
+(`settle.test.js` shows the `call[0]`-position variant of the same mismatch.)
+Affected: `isCancel` (2 tests), `mergeConfig` (57), `settle` (12),
+`transformData` (4), `buildURL` (20), `isAxiosError` (4), `validator` (2) —
+**~101 of the 154 failing axios tests**, all blocked before execution.
+Measured 2026-08-16 on `a9b20d4c`; matches the npm-compat card (16/170).
+
+## Mechanism
+
+`__class_call_concat_vararg` is the host dispatch bridge emitted per method
+key for classes whose method has rest params — src/codegen/index.ts:6624
+(`emitMethodDispatch(key, exportName, true, -1)`). axios defines `concat` on
+**more than one class** (`AxiosHeaders.concat(...targets)` and the internal
+config/header merge helpers), so the bridge's per-struct `ref.test` cascade
+covers several receiver struct types. The validation error says the cascade
+stores a `ref.cast null <structA>` result into a local declared as
+`<structB>`: one shared receiver local typed for the *first* struct arm is
+reused across arms of different types. Any package with a same-named
+rest-param method on two classes should reproduce.
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/axios-upstream-suite.mjs --json
+# compile.details[*].validationError on the 7 files above
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Reduce**: two classes, each with `concat(...xs: any[])` of different
+   field shapes, both dynamically called through the host bridge (export the
+   instances). Compile with the same options the harness uses; expect the
+   identical `local.set` type error. Commit the reduction as
+   `tests/issue-4527.test.ts` asserting `WebAssembly.validate` on the binary.
+2. **Fix in `emitMethodDispatch`** (src/codegen/index.ts, vararg arm,
+   `arity === -1`): the receiver local that holds the `ref.cast` result must
+   be per-arm (declare one local per struct type in the cascade) or the cast
+   result must stay on the stack for the immediate `call` instead of a
+   `local.set`. Follow whichever pattern the fixed-arity arm already uses —
+   the error appearing only in the `_vararg` bridge says the fixed-arity
+   cascade handles this correctly; mirror it.
+3. **Check the `settle` variant** (`call[0] expected (ref null 35)`): same
+   cascade, mismatch surfaces at the call instead of the local store — one
+   fix should cover both; assert both files validate.
+4. **Validation gates**: (a) new reduction test; (b) axios harness:
+   `compile.validated` 16 → 23 and pass count re-measured (record here —
+   the 101 blocked tests will surface their true runtime state, do not
+   assume they pass); (c) equivalence + `npm test -- tests/issue-4373`
+   (host bridge arity family) stay green.
+
+## Acceptance criteria
+
+- [ ] All 25 axios test modules validate.
+- [ ] Reduction test committed; general fix, no axios-specific casing.
+- [ ] Fresh axios pass/total recorded in this file after the fix.

--- a/plan/issues/4528-axios-module-init-symbol-tonumber.md
+++ b/plan/issues/4528-axios-module-init-symbol-tonumber.md
@@ -1,0 +1,89 @@
+---
+id: 4528
+title: "axios: module init crashes with 'Cannot convert a Symbol value to a number' — 49 tests in 10 utils modules never run"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: symbols, coercion
+goal: npm-library-support
+related: [3995, 1434, 3511, 3676]
+files:
+  - src/runtime.ts
+  - tests/dogfood/axios-upstream-suite.mjs
+---
+
+# axios: compiled module init routes a Symbol through ToNumber
+
+## Problem
+
+10 axios test modules (all the `tests/unit/utils/*` and several `helpers/*`
+files) compile, validate, and then **crash during `__module_init`**:
+
+```text
+module init: TypeError: Cannot convert a Symbol value to a number
+    at Number (<anonymous>)
+    at src/runtime.ts:15866 (any_to_number / __unbox_number)
+    at __module_init (wasm-function[454])
+```
+
+49 tests never execute. Measured 2026-08-16 on `a9b20d4c`; matches the
+npm-compat card. Files: `formDataToJSON` (8), `parseHeaders` (3),
+`progressEventReducer` (2), `endsWith` (1), `extend` (3), `forEach` (5),
+`isX` (14), `kindOf` (1), `kindOfTest` (1), `merge` (9), `trim` (2).
+
+The throwing site is the **correct** #1434 behavior (`Number(Symbol)` must
+throw). The defect is upstream of it: axios's `utils.js` module scope never
+calls `Number()` on a Symbol natively (75/75 of these callbacks pass in
+Node), so the **compiler inserted a numeric coercion on a Symbol-valued
+expression** during module init. axios's `utils.js` top level builds
+`kindOfTest` tables and touches `Symbol.iterator` / `Symbol.toStringTag` /
+`Symbol.asyncIterator` — a Symbol read is flowing into an `any_to_number`
+unbox that the source never requests.
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/axios-upstream-suite.mjs --json
+# results.tests[*].wasmError startsWith "module init:" on the files above
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Get the exact expression**: instrument locally — wrap the
+   `any_to_number` closure in src/runtime.ts (~15840) to print a stack and
+   the wasm frame on Symbol input, run the smallest affected module
+   (`endsWith.test.js`, 1 test). The wasm-side frame index identifies the
+   emitting site; correlate with the generated `.axios-upstream-suite*`
+   module's WAT (`--wit`-free `emitWat` compile of the same generated file,
+   grep the caller of the unbox import around the reported function index).
+2. **Expected shapes to check** (axios `utils.js` top level):
+   - `const iterator = obj && obj[Symbol.iterator]` guarded reads where the
+     compiler's dynamic-index probe ToNumber-probes the key — #3511 fixed
+     this for element access; verify the *property-read-by-known-Symbol*
+     path (`obj[Symbol.iterator]`) and the `typeof thing[Symbol.x]` shapes
+     also use the Symbol-safe probe rather than `__unbox_number`.
+   - comparison/arithmetic on `.length`-like fields whose inferred type
+     collapsed to `any` and whose runtime value is a Symbol-keyed method.
+3. **Fix at the emitting site**, not in the runtime: whatever coercion path
+   sends a possibly-Symbol `any` into `any_to_number` for a *probe* (not a
+   user-visible ToNumber) must use the Symbol-safe variant (`any_to_index`
+   family, #3511) or a `ref.test`/typeof guard first. User-visible ToNumber
+   on Symbol must keep throwing (#1434 tests pin this).
+4. **Validation gates**: (a) reduction in `.tmp/` compiled+run (module init
+   completes; Symbol-keyed reads return the method); (b) axios harness:
+   the 10 modules initialize, 49 blocked tests surface their real results —
+   record the new pass/total here; (c) `npm test -- tests/issue-3511` and
+   the #1434 coercion tests stay green (both directions protected).
+
+## Acceptance criteria
+
+- [ ] All 10 affected modules complete `__module_init`.
+- [ ] Committed reduction covering the identified Symbol-into-ToNumber shape.
+- [ ] `Number(Symbol())` still throws (no regression on #1434).

--- a/plan/issues/4529-jest-get-type-typeof-boxed-any-classification.md
+++ b/plan/issues/4529-jest-get-type-typeof-boxed-any-classification.md
@@ -1,0 +1,82 @@
+---
+id: 4529
+title: "jest-get-type: typeof/classification on boxed any returns 'object' for every primitive — 16/32 upstream tests fail"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: typeof
+goal: npm-library-support
+related: [3995, 4367]
+files:
+  - src/codegen/typeof-delete.ts
+  - tests/dogfood/jest-upstream-suite.mjs
+---
+
+# jest-get-type: compiled `getType()` classifies every value as "object"
+
+## Problem
+
+Jest's pinned upstream slice runs `jest-get-type` (`getType.test.ts` +
+`isPrimitive.test.ts`): **16/32 in Wasm** (32/32 Node), measured 2026-08-16
+on `a9b20d4c`, matching the npm-compat card.
+
+Every failure is one defect observed twice:
+
+- `getType(value)` returns `"object"` for number, string, function, boolean,
+  symbol, date, bigint inputs (7 failures:
+  `toBe: string:object != string:number` …);
+- `isPrimitive(value)` returns `false` for null, undefined, numbers, strings,
+  booleans, symbols (9 failures: `toBe: boolean:false != boolean:true`).
+
+Upstream `getType` is a chain of `typeof value === '…'` /
+`value === null` / `Array.isArray` / `constructor` checks on an untyped
+parameter. The test callbacks pass primitives in from the shim through the
+dynamic-call ABI, so the parameter arrives as a boxed `any`/externref. Inside
+the compiled function, `typeof` on that boxed value answers `"object"`
+regardless of what the box holds — the typeof lowering is reading the box,
+not the boxed value.
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/jest-upstream-suite.mjs --json
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Reduce**: `export function getType(v) { if (typeof v === 'number') return 'number'; … return 'object'; }`
+   called dynamically with primitive arguments through the host bridge
+   (mirror the harness's `wrapExports` call path — the static-call path is
+   probably fine; the defect is the dynamic-arg boxing). Assert each
+   primitive classifies correctly. `.tmp/` first, then commit as
+   `tests/issue-4529.test.ts`.
+2. **Fix in `compileTypeofExpression` / `compileTypeofComparison`**
+   (src/codegen/typeof-delete.ts): when the operand is a boxed-any carrier,
+   the lowering must dispatch on the *runtime* box kind (number box, string,
+   bool, symbol — the runtime already distinguishes these for `any_to_*`
+   unboxing; see src/codegen/any-boxing-helpers.ts and the `__extern_typeof`
+   host import if present) instead of statically answering `"object"`.
+   Check what the host lane does for an `externref` operand today — there is
+   likely an existing `typeof` host helper that this operand shape simply
+   fails to route into.
+3. **Note the date/bigint arms**: `getType` distinguishes `date` via
+   `constructor` checks upstream — those may fail for a second reason
+   (constructor identity through the bridge). Fix typeof first, re-measure,
+   and record what remains rather than chasing both blind.
+4. **Validation gates**: reduction test; jest harness re-measured (target:
+   the 9 isPrimitive + the 5 pure-typeof getType failures flip; record the
+   final number here); test262 typeof family + equivalence green.
+
+## Acceptance criteria
+
+- [ ] `typeof` on a dynamically-passed primitive answers its real tag in
+      compiled code.
+- [ ] jest-get-type slice ≥ 28/32 Wasm, with the residual (if any) named.
+- [ ] Committed reduction test.

--- a/plan/issues/4530-clsx-variadic-argument-classification.md
+++ b/plan/issues/4530-clsx-variadic-argument-classification.md
@@ -1,0 +1,80 @@
+---
+id: 4530
+title: "clsx: variadic argument classification broken — strings iterate per-character ('f o o'), numbers and object keys drop; 12/32 upstream tests fail"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: typeof, arguments, for-in
+goal: npm-library-support
+related: [3995, 4529, 3750]
+files:
+  - tests/dogfood/clsx-upstream-suite.mjs
+---
+
+# clsx: `toVal`'s typeof/iteration classification misfires on variadic args
+
+## Problem
+
+clsx's pinned upstream suite: **20/32 Wasm** (32/32 Node), measured
+2026-08-16 on `a9b20d4c`, matching the npm-compat card. The 12 failures are
+classification errors inside clsx's tiny `toVal`/loop core:
+
+| upstream test | got | expected | reading |
+| --- | --- | --- | --- |
+| `strings` | `f o o` | `foo` | a **string** arg was iterated element-wise like an array |
+| `strings (variadic)` | `f o o bar` | `foo bar` | same, mixed with a later arg that worked |
+| `numbers` | `` (empty) | `1` | a **number** arg was dropped (typeof gate missed) |
+| `numbers (variadic)` | `2` | `1 2` | first number dropped |
+| `objects` | `` | `foo` | object key iteration produced nothing |
+| `objects (variadic)` | `bar` | `foo bar` | first object's keys dropped |
+| `arrays (no push escape)` | `` | `push` | array-like branch misrouted |
+| `functions` | `hello w o r l d` | `hello world` | string after function arg re-hit the char-split |
+| `exports` (×2, index+lite) | function !== function | — | default vs named export not identical |
+| lite `strings` ×2 | ``/`bar` | `foo`/`foo bar` | lite's `typeof x === 'string'` gate failed |
+
+Upstream `toVal` is: `typeof mix === 'string' || typeof mix === 'number'` →
+append; else if object → `Array.isArray` ? recurse : `for (k in mix)`. The
+observed set (string treated as iterable object, number failing the typeof
+gate, `for..in` over an object yielding nothing) says variadic/boxed args are
+misclassified — the same family as #4529's typeof-on-boxed-any, plus the
+`for..in`-over-boxed-object and `Array.isArray`-on-boxed gates. The
+`exports` failures are separate: `clsx` default and named export are not the
+same function object after compilation.
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/clsx-upstream-suite.mjs --json
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Land #4529 first** (typeof on boxed any) and re-run this suite — the
+   string/number rows likely flip with it; this issue then owns what
+   remains. Do not duplicate the typeof fix here.
+2. **Reduce the `for..in` row independently**: a function receiving a boxed
+   object arg (via rest/`arguments`) whose `for (k in obj)` yields no keys.
+   Cross-check #3750 (dynamic property writes dropped) and the
+   `Object.keys`-on-dynamic issues (#4298) — pick the existing issue if the
+   reduction matches; otherwise this issue carries it.
+3. **Reduce the export-identity row**: `export default clsx; export { clsx }` —
+   both bindings must resolve to one function object through the host
+   bridge. Suspect: each export path mints its own wrapper closure. Fix in
+   the export emission (one canonical function value per declaration),
+   not in the harness.
+4. **Validation gates**: clsx harness 20 → ≥30 (record exact); committed
+   reductions for each fixed row; equivalence green.
+
+## Acceptance criteria
+
+- [ ] `clsx('foo')` compiles to `"foo"`, `clsx(1,2)` to `"1 2"`,
+      `clsx({foo:true})` to `"foo"` through the dynamic-arg path.
+- [ ] Default and named export are identical function values.
+- [ ] clsx upstream ≥ 30/32 with any residual named in this file.

--- a/plan/issues/4531-prettier-astpath-heterogeneous-stack-illegal-cast.md
+++ b/plan/issues/4531-prettier-astpath-heterogeneous-stack-illegal-cast.md
@@ -1,0 +1,74 @@
+---
+id: 4531
+title: "prettier: AstPath.getValue traps 'illegal cast' on the heterogeneous stack array — 4 of 7 upstream failures"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: arrays, classes
+goal: npm-library-support
+related: [3995, 4289, 3979]
+files:
+  - tests/dogfood/prettier-upstream-suite.mjs
+---
+
+# prettier: mixed string/number/object `stack` array element reads trap
+
+## Problem
+
+Prettier's pinned upstream slice: **1/8 Wasm** (8/8 Node), 2026-08-16 on
+`a9b20d4c`, matching the npm-compat card. Four failures are one trap:
+
+```text
+RuntimeError: illegal cast
+    at AstPath_getValue (wasm-function[68])
+```
+
+in `AstPath#call() / #callParent() / #each() / #map()`. Upstream `AstPath`
+keeps `this.stack = [node, key1, child1, key2, child2, …]` — an array
+interleaving **objects, strings, and numbers** — and `getValue()` reads
+`this.stack[this.stack.length - 1]`. The compiled element read casts to one
+element shape and traps on the mixed carrier. This is the class-field
+variant of the mixed-array-literal family (#3979 mixed array literal calls,
+#4289 heterogeneous object-array carrier): here the array is a **class
+field** mutated by `push`/`splice` across element types.
+
+The other three failures are Error-subclass `.name` (#4532).
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/prettier-upstream-suite.mjs --json
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Reduce**: class with `stack: any[]` field seeded `[obj]`, methods that
+   `push(str, num, obj)` and read `this.stack[i]` returning it through the
+   host bridge. Expect the illegal cast at the read. `.tmp/`, then
+   `tests/issue-4531.test.ts`.
+2. **Root cause**: the field's array carrier was specialized (probably to the
+   seed element's struct type) while writes admit any element. Either the
+   declaration-site inference must widen a class-field array that receives
+   heterogeneous `push` args (preferred — matches how #4289 handled the
+   literal case; check `src/codegen/declarations/object-shape-widening.ts`
+   and the array-element-typing pass `src/codegen/array-element-typing.ts`),
+   or the element read must cast through the generic any-carrier when the
+   element type is not provable.
+3. **Check overlap before implementing**: #4289 / #4290 landed carriers for
+   heterogeneous arrays in object/class contexts — read their tests first;
+   this may be a small extension of an existing pass, not a new one.
+4. **Validation gates**: reduction test; prettier harness 1 → ≥5 (the 4
+   AstPath tests; record exact); equivalence + #4289/#3979 tests green.
+
+## Acceptance criteria
+
+- [ ] `AstPath` reduction passes: mixed push + indexed read round-trips all
+      three element kinds.
+- [ ] Prettier upstream ≥ 5/8 (remaining 3 tracked by #4532).

--- a/plan/issues/4532-error-subclass-constructor-name.md
+++ b/plan/issues/4532-error-subclass-constructor-name.md
@@ -1,0 +1,77 @@
+---
+id: 4532
+title: "Error subclasses report name 'Error' — prettier ConfigError/UndefinedParserError/ArgExpansionBailout tests fail"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen, runtime
+language_feature: classes, errors
+goal: npm-library-support
+related: [3959, 3995, 1378]
+files:
+  - tests/dogfood/prettier-upstream-suite.mjs
+---
+
+# `class X extends Error` instances answer `name === "Error"`
+
+## Problem
+
+Prettier's `tests/unit/errors.js` fails all three cases, 2026-08-16 on
+`a9b20d4c`:
+
+```text
+ConfigError            → toBe: string:Error != string:ConfigError
+UndefinedParserError   → toBe: string:Error != string:UndefinedParserError
+ArgExpansionBailout    → toBe: string:Error != string:ArgExpansionBailout
+```
+
+Upstream defines `class ConfigError extends Error { name = "ConfigError" }`
+(prettier's src/common/errors.js uses class-field `name` assignments; the
+exact upstream shape uses either a field or `this.name = …` in the ctor).
+The compiled instance's `.name` read yields the base `"Error"` — the
+subclass's own `name` (class field or ctor assignment) does not shadow the
+builtin Error brand's name through the property-read path used after the
+value crosses the throw/bridge boundary.
+
+Generic defect: any package that brands errors by subclass name and
+dispatches on `err.name` misbehaves (axios `CanceledError`/`AxiosError`,
+webpack `WebpackError` family — same pattern).
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/prettier-upstream-suite.mjs --json
+# tests/unit/errors.js rows
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Reduce along both axes** in `.tmp/`:
+   (a) `class E extends Error { name = "E" }; new E("m").name`
+   (b) `class E extends Error { constructor(m){ super(m); this.name = "E"; } }`
+   (c) read `.name` after the instance crosses a throw/catch and after a
+   host-bridge round-trip. Identify which axis loses the write: the class
+   field initializer ordering vs `super()` (field must apply after super
+   returns), or the `.name` read resolving to the builtin brand instead of
+   the instance property.
+2. **Likely site**: the builtin-Error heritage path (#3959 fixed
+   Error-without-new null; the brand/prototype plumbing it touched is where
+   `name` resolution lives). Check how a property read on an
+   Error-branded struct resolves `name` — if the read short-circuits to the
+   brand's static name before consulting instance fields, invert that order.
+3. **Validation gates**: reduction test committed
+   (`tests/issue-4532.test.ts`); prettier `errors.js` 0/3 → 3/3; test262
+   Error-family (`built-ins/Error`, `NativeErrors`) no regressions;
+   equivalence green.
+
+## Acceptance criteria
+
+- [ ] Subclass `name` (field and ctor-assignment forms) observable on
+      instances, including through throw/catch and the host bridge.
+- [ ] Prettier upstream errors.js 3/3.

--- a/plan/issues/4533-lodash-module-init-null-call-and-es-lane-report.md
+++ b/plan/issues/4533-lodash-module-init-null-call-and-es-lane-report.md
@@ -1,0 +1,92 @@
+---
+id: 4533
+title: "lodash: module init calls a null host function (0/11); lodash-es lane fails compile silently with a recursive report"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen, runtime, testing
+language_feature: modules
+goal: npm-library-support
+related: [3996, 3995]
+files:
+  - tests/dogfood/lodash-upstream-suite.mjs
+  - src/runtime/host-call-abi.ts
+---
+
+# lodash 0/11: `__module_init` invokes null; lodash-es lane can't say why it fails
+
+## Problem (a) — lodash
+
+The pinned lodash suite's single test module compiles **and validates**, then
+every test is blocked by one init crash (2026-08-16, `a9b20d4c`, matches the
+npm-compat card 0/11):
+
+```text
+module init: TypeError: null is not a function
+    at invoke (src/runtime/host-call-abi.ts:24)
+    at __module_init (wasm-function[286])
+```
+
+The #3996-era emit failure (`local index out of range` at `__cb_6`) is gone;
+this is its runtime successor: during module init a host-call slot is
+invoked before it is populated (or was never populated). lodash's UMD entry
+runs a large IIFE at module scope — the first dynamic callable it reaches
+through the host-call ABI is null.
+
+## Problem (b) — lodash-es lane
+
+The lodash-es variant reports 0 succeeded / 0 validated / `binaryBytes: 0`
+with an **empty error string**, and the written report nests
+`compile.details` recursively (details[0].details[0]… same object shape,
+many levels deep). Two harness defects in
+`tests/dogfood/lodash-upstream-suite.mjs` when `packageName: "lodash-es"`:
+the compile failure text is dropped, and the report builder feeds its own
+output back into itself. The dashboard card shows 0/11 with no diagnosable
+cause — indistinguishable from problem (a) when it is actually a different,
+unnamed failure.
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/lodash-upstream-suite.mjs --json          # (a)
+node --import tsx --input-type=module -e "
+import { runHarness } from './tests/dogfood/lodash-upstream-suite.mjs';
+console.log(JSON.stringify(await runHarness({ quiet: true, packageName: 'lodash-es' })).length;" # (b)
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **(b) first — it is cheap and unblocks diagnosis**: in the lodash harness,
+   fix the lodash-es report assembly (stop nesting `details` into itself;
+   surface the compile error/stderr string). Re-run; record lodash-es's real
+   failure in this file. It may be identical to (a) or a distinct compile
+   error — do not assume.
+2. **(a)**: identify the null slot — wrap `invoke` in
+   src/runtime/host-call-abi.ts locally to log the slot index/name on null,
+   run the harness, correlate with the generated module's import/export
+   tables. Suspect family: a callable reached through
+   `wasmClosureDynamicDispatch` whose function-table entry is only installed
+   by a later `setExports` phase — an init-ordering defect (module init
+   running before the host finished wiring bridge exports), or a callable
+   the dead-import eliminator dropped while the init path still references
+   its slot (#4435 saw the same "empty marshaled status" family in marked).
+3. **Reduce** whatever step 2 names into a `.tmp/` probe (module-scope IIFE
+   that calls a function value defined later / via `Function('return this')`
+   — lodash's root detection — are prime candidates).
+4. **Validation gates**: lodash harness init completes and the 11 tests
+   report real statuses (record the number here — passing is not implied);
+   lodash-es lane reports a non-empty, single-level compile record;
+   equivalence green.
+
+## Acceptance criteria
+
+- [ ] lodash `__module_init` completes; per-test results recorded.
+- [ ] lodash-es lane surfaces its real compile error (no recursive report,
+      no empty error string).
+- [ ] Reduction test for the null-slot init shape.

--- a/plan/issues/4534-jsdom-virtualconsole-eventemitter-inheritance.md
+++ b/plan/issues/4534-jsdom-virtualconsole-eventemitter-inheritance.md
@@ -1,0 +1,81 @@
+---
+id: 4534
+title: "jsdom: VirtualConsole loses inherited EventEmitter methods — 'on is not a function', 5 of 6 upstream tests fail"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: classes, inheritance
+goal: npm-library-support
+related: [4299, 3995, 1533]
+files:
+  - tests/dogfood/jsdom-upstream-suite.mjs
+---
+
+# jsdom: `class VirtualConsole extends EventEmitter` has no `on`
+
+## Problem
+
+The jsdom pinned slice (`test/api/virtual-console.js`, 6 tests): **1/6 Wasm**
+(6/6 Node), 2026-08-16 on `a9b20d4c`, matching the npm-compat card. All five
+failures are the same message:
+
+```text
+on is not a function
+```
+
+`VirtualConsole extends EventEmitter` (node:events, supplied by the
+harness's shim/host environment). Methods inherited from a base class whose
+implementation lives **outside the compiled module** (host-provided or
+shim-declared) are not reachable on the compiled subclass instance:
+`vc.on(...)`, inherited from the extern base, resolves to nothing.
+
+This is the narrow, measured slice of what #4299 (full jsdom API suite)
+will hit everywhere; fixing it is prerequisite work for that issue and for
+any package subclassing node builtins (#1533's host-import family).
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/jsdom-upstream-suite.mjs --json
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Establish the intended semantics first**: check how the harness
+   provides `EventEmitter` (grep tests/dogfood/jsdom-upstream-suite.mjs for
+   the events shim). Two legitimate designs: (a) EventEmitter is a
+   *compiled* shim class → then `extends` over a same-module class losing
+   methods is an ordinary heritage bug; (b) EventEmitter is a *host*
+   constructor → then this needs the extern-heritage path (subclass whose
+   proto chain hangs off a host object). Read the generated module to see
+   which one the compiler actually saw.
+2. **For (a)**: reduce to two compiled classes, `class A { on(){…} }`,
+   `class B extends A {}`, instance created via `new B()` crossing the host
+   bridge, then `b.on(...)` called dynamically. Compare with #4291 (imported
+   class alias heritage) and #4288 (imported anonymous class constructor
+   identity) — the fix likely lives in the same heritage/member-dispatch
+   plumbing; extend whichever pass those landed.
+3. **For (b)**: route the subclass's method lookup through the host bridge
+   when the member is not found on compiled structs (the
+   `__member_kind_<key>` discriminator path in src/codegen/index.ts already
+   cascades struct types; it needs a host-proto fallback arm) — and state
+   explicitly in the PR if this is host-lane-only, per the dual-mode rule
+   (standalone needs at least an honest "unsupported" diagnostic, not a
+   silent miss).
+4. **Validation gates**: reduction test; jsdom slice 1/6 → ≥5/6 (the
+   remaining test may hit the next missing emitter feature — record it);
+   hono/react suites (heavy class users) unchanged.
+
+## Acceptance criteria
+
+- [ ] Inherited methods callable on compiled subclass instances for the
+      pattern jsdom uses.
+- [ ] jsdom pinned slice ≥ 5/6, residual named.
+- [ ] Reduction test committed.

--- a/plan/issues/4535-three-mathutils-silent-wasm-failures.md
+++ b/plan/issues/4535-three-mathutils-silent-wasm-failures.md
@@ -1,0 +1,72 @@
+---
+id: 4535
+title: "three.js: MathUtils module validates but 0/18 tests pass in Wasm, all silently — including trivial clamp/euclideanModulo"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen, testing
+language_feature: modules
+goal: npm-library-support
+related: [3995]
+files:
+  - tests/dogfood/three-upstream-suite.mjs
+  - tests/dogfood/upstream-suite-runner.mjs
+---
+
+# three.js MathUtils: one validated module, 18 uniform silent failures
+
+## Problem
+
+The three.js pinned slice (`test/unit/src/math/MathUtils.tests.js`, 18 QUnit
+tests): the single generated module **compiles and validates** (138 KB), all
+18 pass natively, and **0/18 pass in Wasm** — with `wasmError: null` on
+every row (2026-08-16, `a9b20d4c`, matches the npm-compat card).
+
+Two observations that shape the diagnosis:
+
+1. **`clamp` and `euclideanModulo` fail too.** Those bodies are 1–2 lines of
+   pure `Math.min/max` arithmetic. 18/18 uniform failure across trivial and
+   non-trivial bodies points at a *shared* defect — the QUnit
+   assert-adapter, the `runUpstreamTests` export path, or the module's
+   shared prelude — not 18 independent math bugs.
+2. **No error text.** The generic runner's status array comes back all-zero
+   with empty error strings. The in-flight PR #4619 rewrites
+   `upstream-suite-compile-worker.mjs` / `upstream-suite-runner.mjs` to a
+   per-test entry point (`runUpstreamTest(index)`) with real error capture —
+   after it lands, this suite should produce per-test messages for free.
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/three-upstream-suite.mjs --json
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Wait for / rebase on PR #4619** (upstream-suite runner error capture),
+   then re-run — with real error text this issue may reduce to an existing
+   bucket (typeof-on-boxed #4529, assert-shim mismatch, etc.). Do not
+   hand-roll a parallel error-capture mechanism; #4619 already does it.
+2. If #4619's text shows a shared prelude/adapter failure: reduce the QUnit
+   `assert` object flow — the shim passes an `assert` object into each
+   callback (`__upstreamTests[i].body(__qunitAssert)`); a single defect in
+   calling method-on-parameter-object (`assert.ok(...)` where `assert` is a
+   boxed parameter) would fail all 18 uniformly. Cross-check #4123
+   (prototype method on parameter receiver returns null).
+3. Reduce to `.tmp/` probe, fix at the identified compiler site, commit the
+   reduction as `tests/issue-4535.test.ts`.
+4. **Validation gates**: three slice 0/18 → ≥16/18 (record exact); the two
+   sibling QUnit-style suites (webpack, stylelint — same generic runner)
+   re-measured for collateral movement; equivalence green.
+
+## Acceptance criteria
+
+- [ ] Root cause named with per-test error evidence (post-#4619).
+- [ ] three MathUtils slice ≥ 16/18, residual named.
+- [ ] Reduction test committed.

--- a/plan/issues/4536-stylelint-webpack-residual-illegal-casts.md
+++ b/plan/issues/4536-stylelint-webpack-residual-illegal-casts.md
@@ -1,0 +1,81 @@
+---
+id: 4536
+title: "stylelint arrayEqual + webpack groupBy/formatSize residuals: illegal casts on mixed-element compares and NaN branch — 5 tests"
+status: ready
+sprint: current
+created: 2026-08-16
+updated: 2026-08-16
+priority: low
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: arrays, closures
+goal: npm-library-support
+related: [3995, 4531, 4303]
+files:
+  - tests/dogfood/stylelint-upstream-suite.mjs
+  - tests/dogfood/webpack-upstream-suite.mjs
+---
+
+# Last-mile residuals in the stylelint (7/9) and webpack (13/16) suites
+
+## Problem
+
+Measured 2026-08-16 on `a9b20d4c`, both matching their npm-compat cards.
+
+**stylelint — 2 failures**, both:
+
+```text
+RuntimeError: illegal cast
+    at arrayEqual (wasm-function[56])
+```
+
+Upstream `arrayEqual(a, b)` is `a.every((item, i) => item === b[i])` over
+arrays that mix strings/numbers in the test fixtures — an element read/compare
+on a mixed carrier traps. Same family as #4531 (prettier AstPath); reduce
+against that issue's fix first, this may be free collateral.
+
+**webpack — 3 failures**:
+
+- 2× `RuntimeError: illegal cast at __call_fn_method_2` in `ArrayHelpers`
+  `groupBy` ("partition into two arrays", "works with empty array"):
+  `groupBy(arr, fn)` returns `[arr.filter(fn), arr.filter(x => !fn(x))]` —
+  the user callback passed through `wasmClosureDynamicDispatch` traps on its
+  argument cast (boolean-returning predicate over number elements).
+- 1× `formatSize` NaN branch: `formatSize(NaN)` returns `"0 bytes"` instead
+  of `"unknown size"` — upstream gates on `Number.isNaN(size)` (or
+  `typeof size !== 'number'`); the compiled NaN test answers false, so NaN
+  falls through to the numeric formatting path.
+
+## Reproduction
+
+```bash
+node --import tsx tests/dogfood/stylelint-upstream-suite.mjs --json
+node --import tsx tests/dogfood/webpack-upstream-suite.mjs --json
+```
+
+## Implementation Plan (Fable; implement per the plan/implement split)
+
+1. **Order behind the bigger issues**: re-run both suites after #4531
+   (mixed-carrier element reads) and #4529 (boxed-any classification) land;
+   strike out whatever they fix and keep only the true residual here.
+2. **groupBy cast (if it survives)**: reduce
+   `arr.filter(predicate)` where `predicate` arrives as a function parameter
+   and `arr` is `number[]` — the `__call_fn_method_2` cast suggests the
+   dispatch trampoline casts the predicate's closure struct to the wrong
+   shape when the same callback flows through two `filter` sites with
+   different inferred element types.
+3. **formatSize NaN (independent, small)**: reduce
+   `Number.isNaN(x)` / `x !== x` on a boxed-any parameter; the NaN test on
+   an unboxed-from-any f64 must survive the round-trip. Likely a one-site
+   fix in the isNaN builtin lowering for any-typed operands.
+4. **Validation gates**: stylelint 9/9, webpack 16/16 (or residuals named
+   with fresh evidence); committed reductions; equivalence green.
+
+## Acceptance criteria
+
+- [ ] stylelint pinned suite 9/9.
+- [ ] webpack pinned suite 16/16.
+- [ ] Each fix carried by a general reduction, no package-specific casing.

--- a/plan/log/npm-compat-triage-2026-08-16.md
+++ b/plan/log/npm-compat-triage-2026-08-16.md
@@ -1,0 +1,50 @@
+# Curated npm-package upstream-suite triage — 2026-08-16
+
+Every failing curated package's pinned upstream suite was re-run locally on
+main `a9b20d4c` (`node --import tsx tests/dogfood/<pkg>-upstream-suite.mjs
+--json`). **Every local result reproduced the npm-compat dashboard card
+exactly**, so the buckets below are current-main facts, not artifact drift.
+(lit is the one exception: the local run died at exit 137/OOM on this 4-core
+box; its 12/16 figure is the CI card's, tracked by #3977.)
+
+## Result → issue map
+
+| package | Wasm/total | dominant failure | issue |
+| --- | --- | --- | --- |
+| moment | 0/10 | all 6 modules fail validation: closure `struct.new[5]` gets i32, wants `(ref null 72)` | **#4525** (new) |
+| redux | 3/78 | 40× null-deref in `combineReducers` closures; 23× illegal cast at dynamic dispatch/`dispatch` | **#4526** (new) |
+| axios | 16/170 | 7 modules invalid (`__class_call_concat_vararg` local type clash) ≈101 tests; 10 modules crash init on Symbol→ToNumber ≈49 tests | **#4527**, **#4528** (new) |
+| jest | 16/32 | `typeof` on boxed any answers "object" for every primitive (jest-get-type) | **#4529** (new) |
+| clsx | 20/32 | variadic arg classification: strings split per char, numbers/object-keys dropped; export identity | **#4530** (new) |
+| prettier | 1/8 | 4× illegal cast on heterogeneous `AstPath.stack` reads; 3× Error-subclass `.name` = "Error" | **#4531**, **#4532** (new) |
+| lodash / lodash-es | 0/11 ×2 | module init invokes null host slot; lodash-es lane hides its compile error behind a recursive report | **#4533** (new) |
+| jsdom | 1/6 | `VirtualConsole extends EventEmitter` loses inherited `on` | **#4534** (new) |
+| three | 0/18 | uniform silent failure incl. trivial `clamp` — shared adapter/ABI defect; error text needs PR #4619 | **#4535** (new) |
+| stylelint | 7/9 | `arrayEqual` illegal cast (mixed elements) | **#4536** (new) |
+| webpack | 13/16 | `groupBy` callback cast, `formatSize(NaN)` branch | **#4536** (new) |
+| uuid | 10/75 | unchanged buckets, re-measured table added | #4383 (updated) |
+| marked | 0/15 | `br is not a function` — matches the open measurement exactly | #4435 (in-review, no change) |
+| tailwindcss / eslint / react / hono / styled-components / cookie | all tests pass | entry-compile budget issues only | #4287 / #4293 |
+| react-dom | 0 run | suite not yet wired | #3982 (in-progress) |
+| typescript | 1/1 | entry compile exceeds 600 s budget | #1058 / #1579 |
+
+## Cross-package roots (fix-ordering signal)
+
+1. **Boxed-`any` classification** (`typeof`, `Number.isNaN`, `for..in`,
+   `Array.isArray` on dynamically passed values) — #4529 is the cleanest
+   carrier; clsx (#4530) and webpack's formatSize (#4536) expect collateral.
+2. **Heterogeneous array carriers** — prettier AstPath (#4531) is the
+   carrier; stylelint arrayEqual (#4536) expects collateral.
+3. **Dynamic-dispatch struct casts** (`__call_fn_*`, `__class_call_*`) —
+   axios's invalid vararg bridge (#4527) is a hard validation error with a
+   precise mechanism; redux's runtime casts (#4526) are the same boundary at
+   runtime.
+4. **Module-init ordering / null host slots** — lodash (#4533) and axios's
+   Symbol crash (#4528) both kill whole modules before any test runs;
+   per-test fixes are invisible until these land.
+
+Biggest single-fix unlocks by blocked-test count: #4527 (~101), #4528 (49),
+#4526 (~63), #4525 (10 + unmasks #4384's resolver work).
+
+All twelve new issues carry `## Implementation Plan` sections written per the
+plan/implement split (Fable plans, Opus implements).


### PR DESCRIPTION
## Description

Re-ran every failing curated package's pinned upstream suite locally on main `a9b20d4c` (`node --import tsx tests/dogfood/<pkg>-upstream-suite.mjs --json`). **Every local result reproduced the npm-compat dashboard card exactly** (uuid 10/75, redux 3/78, axios 16/170, jest 16/32, clsx 20/32, prettier 1/8, moment 0/10, lodash/lodash-es 0/11, marked 0/15, three 0/18, jsdom 1/6, stylelint 7/9, webpack 13/16), so the buckets are current-main facts.

This PR is docs-only: 12 new issue files (ids reserved via `claim-issue.mjs --allocate`; the open-PR id scan was degraded because `gh` is unavailable in this environment, so open PRs were scanned by hand via the GitHub API — none introduces an id ≥ 4525), each carrying a Fable-lane `## Implementation Plan` per the plan/implement split, plus a fresh re-measure section in [#4383](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4383-uuid-original-suite-runtime-and-callref-gaps) and a summary map at `plan/log/npm-compat-triage-2026-08-16.md`.

New issues:

- [#4525](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4525-moment-closure-capture-i32-ref-validation) — moment: all 6 modules fail validation, closure `struct.new[5]` gets i32 where `(ref null 72)` is expected (masks the unmerged #4384 resolver work)
- [#4526](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4526-redux-runtime-null-deref-illegal-cast-clusters) — redux: 40× combineReducers null-deref + 23× dynamic-dispatch illegal casts keep the suite at 3/78
- [#4527](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4527-axios-class-call-concat-vararg-invalid-module) — axios: `__class_call_concat_vararg` bridge mistypes its receiver local, 7 modules invalid, ~101 tests blocked
- [#4528](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4528-axios-module-init-symbol-tonumber) — axios: module init routes a Symbol into ToNumber, 10 modules / 49 tests blocked
- [#4529](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4529-jest-get-type-typeof-boxed-any-classification) — jest-get-type: `typeof` on boxed any answers "object" for every primitive
- [#4530](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4530-clsx-variadic-argument-classification) — clsx: strings iterate per-character, numbers/object keys dropped, export identity
- [#4531](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4531-prettier-astpath-heterogeneous-stack-illegal-cast) — prettier: heterogeneous `AstPath.stack` element reads trap
- [#4532](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4532-error-subclass-constructor-name) — `class X extends Error` instances answer `name === "Error"`
- [#4533](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4533-lodash-module-init-null-call-and-es-lane-report) — lodash: init invokes a null host slot; lodash-es lane hides its compile error behind a recursive report
- [#4534](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4534-jsdom-virtualconsole-eventemitter-inheritance) — jsdom: `VirtualConsole extends EventEmitter` loses inherited `on`
- [#4535](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4535-three-mathutils-silent-wasm-failures) — three: 0/18 uniform silent failures incl. trivial `clamp`; per-test error text arrives with PR #4619
- [#4536](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4536-stylelint-webpack-residual-illegal-casts) — stylelint/webpack last-mile residuals

Fix-ordering signal (from the cross-package roots in the triage doc): #4527 unlocks ~101 blocked tests, #4528 49, #4526 ~63; #4529's typeof fix should carry clsx and webpack collateral.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [x] I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmkUfjm8nvMDJTjURiPRYZ)_