### PR TITLE
fix(ci): import missing setupMarked in npm-compat report generator

### DIFF
--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -75,6 +75,7 @@ import { setupAcorn } from "../tests/dogfood/setup-acorn.mjs";
 import { setupClsx } from "../tests/dogfood/setup-clsx.mjs";
 import { setupCookie } from "../tests/dogfood/setup-cookie.mjs";
 import { setupEslint } from "../tests/dogfood/setup-eslint.mjs";
+import { setupMarked } from "../tests/dogfood/setup-marked.mjs";
 import { setupPrettier } from "../tests/dogfood/setup-prettier.mjs";
 import { setupReact } from "../tests/dogfood/setup-react.mjs";
 import { CLSX_OPS } from "../tests/dogfood/clsx-ops.mjs";


### PR DESCRIPTION
## Description

Fixes the `refresh` job in `Refresh npm-compat` (`npm-compat-refresh.yml`), which has been failing on every push to `main` with:

```
ReferenceError: setupMarked is not defined
    at scripts/generate-npm-compat-report.mjs:2060:23
```

`scripts/generate-npm-compat-report.mjs` uses `setupMarked` as a `setupFactory` in two places (lines 1957 and 2060) but never imports it — every other package's setup function (`setupAcorn`, `setupClsx`, `setupCookie`, `setupEslint`, `setupPrettier`, `setupReact`) has a matching import, `setupMarked` was simply missing despite `tests/dogfood/setup-marked.mjs` already exporting it. Added the missing import.

Reference: https://github.com/loopdive/js2wasm/actions/runs/31985656798/job/95260126510

## Validation

- `node --check scripts/generate-npm-compat-report.mjs` — syntax OK
- `pnpm run lint` / `pnpm run format:check` — pass
- `node --import tsx scripts/generate-npm-compat-report.mjs --only marked` — runs to completion (previously crashed with the `ReferenceError` above)

## CLA

Internal maintenance fix by a repo-owner-authorized session; the `cla-check` gate auto-skips for internal/org-member PRs per this template's note.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UvD69Fikp4R9x6aXAbd1rb)_