### PR TITLE
docs(issues): #4549 inter-procedural summary framework + context-as-region note on #4541

### DIFF
--- a/plan/issues/4541-linear-jsvalue-boxed-tier-representation.md
+++ b/plan/issues/4541-linear-jsvalue-boxed-tier-representation.md
@@ -59,6 +59,40 @@ entirely (`layout.ts` is a static fat-slot model over planned records).
   precisely, implement the weak-wrapper mitigation, and record what remains
   accepted rather than leaving it as a footnote.
 
+## A context is already a region — bound the leak class with scope, not analysis
+
+The engine gives us grouped deallocation natively: **a `JSContext` /
+`JSRuntime` is a region**, and `JS_FreeRuntime` releases everything in it at
+once. For a *scoped* use — evaluate a snippet, extract a value, discard — a
+per-eval context makes the whole group's teardown O(1) and requires **no
+lifetime analysis at all**, only that the result is copied or upgraded out
+first.
+
+That matters directly for the leak class above: **a cross-heap cycle that
+cannot be collected is still reclaimed when its context is torn down.** So the
+residual leak this slice must document is bounded by context lifetime, not by
+process lifetime — state it that way, because "leaks forever" and "leaks until
+this eval scope ends" are different severities and only the second is
+acceptable.
+
+Two limits decide how far the idea scales down, and both should be recorded so
+a later reader does not try to push it further:
+
+- **The allocator hook cannot segregate by purpose.** `JSMallocFunctions`
+  (see #4540) sees one undifferentiated stream: transient object allocations
+  interleaved with interned atoms, shapes and bytecode that have *runtime*
+  lifetime. So a region rewind cannot be nested *inside* a live runtime — it
+  would take the atom table with it. Grouping is available at context/runtime
+  granularity, not below.
+- **Rewinding under live engine references is a use-after-free inside the
+  engine** — worse than one in our own code, because it corrupts a component we
+  do not debug. A rewind point must be provable; at context granularity the
+  proof is trivial (tear down, having extracted the result), which is exactly
+  why that is the granularity to use.
+
+Long-lived shared state within one runtime stays refcounted. This is a
+complement to the mechanism, not a replacement for it.
+
 ## Amendments this slice must record
 
 - **#1852 §1** fixes the linear lane's dynamic residue as a parallel
@@ -107,6 +141,9 @@ still-unowned "version pin + upgrade policy" box lands here.
 - [ ] The string decision is recorded **with the measurement that decided it**.
 - [ ] The residual cycle-leak class is documented and covered by a test that
       demonstrates the mitigation working on the solvable cases.
+- [ ] The documented leak class states its **bound** — reclaimed at context
+      teardown, not process exit — and a test tears down a context holding an
+      uncollectable cross-heap cycle and asserts the memory is returned.
 
 ## Validation
 

--- a/plan/issues/4549-interprocedural-summary-framework.md
+++ b/plan/issues/4549-interprocedural-summary-framework.md
@@ -1,0 +1,124 @@
+---
+id: 4549
+title: "Shared inter-procedural summary framework: one call graph + summary fixpoint serving lifetime, escape, type-flow and foreign-function analyses"
+status: ready
+sprint: Backlog
+created: 2026-08-17
+updated: 2026-08-17
+priority: high
+horizon: xl
+feasibility: hard
+model: fable
+reasoning_effort: max
+task_type: feature
+area: ir
+language_feature: compiler-internals
+goal: compiler-architecture
+related: [652, 685, 1166, 1587, 3756, 4538, 4542, 4543]
+# id 4549 reserved via claim-issue.mjs --allocate --allow-unscanned on
+# 2026-08-17 (gh CLI offline in this container; pr_scan=degraded). Equivalent
+# open-PR scan via the GitHub MCP at reservation time: sole open PR was 4639
+# (ci/npm-compat-refresh, artifact-only), which adds no issue file.
+---
+
+# #4549 — One inter-procedural summary framework, several consumers
+
+## Problem
+
+Several tracked workstreams independently need the same three things: a
+**whole-program call graph**, **compact per-function summaries**, and a
+**monotone fixpoint** over that graph. None of them has it, and each is
+positioned to build its own.
+
+What exists today is one axis half-built and the other missing:
+
+- **#685 — "Interprocedural type flow: track return types across call sites"**
+  (`done`) — return types already flow across call sites. Partial, and
+  type-specific.
+- **#1587 — "Static analysis pass: ownership and access semantics on IR
+  values"** (`done`) — but Phase 1 only. Its own source states: *"Phase 1 is
+  intra-procedural: unknown callees are treated as fully escaping.
+  Inter-procedural summaries are Phase 2."*
+
+Measured consequence of that gap (2026-08-17, recorded in **#652 —
+"Compile-time ARC: static lifetime analysis for linear memory mode"**): in a
+ten-pattern probe, *"object passed to a local callee"* was **rejected at IR
+build** — not analysed conservatively, not analysed at all. Passing an object
+to a function is not an exotic shape.
+
+## Consumers (all currently blocked on the same missing layer)
+
+| consumer | needs |
+| --- | --- |
+| #1587 Phase 2 | escape/ownership across calls — today unknown callee ⇒ fully escaping |
+| #652 | lifetime placement; region assignment needs region-polymorphic callees |
+| **#1166 — "Closed-world integer specialization from literal call sites"** (`ready`) | call-site → callee value/type flow |
+| #4542 (refcount discipline) | foreign summaries: per-import consumes/borrows/retains for the engine C API |
+| #4543 (object frontier) | inter-procedural taint: which allocation sites can reach dynamic code |
+| `param-type-not-resolvable`, `return-type-not-resolvable`, `type-resolution-failure` | CLAUDE.md names the fix as "better TypeMap propagation" — all three are **unintended** buckets in the #1376 ratchet |
+
+**Foreign functions are summaries too.** #4542's requirement that every declared
+engine import carry an ownership annotation is exactly a hand-written summary
+for code the analysis cannot see. It should use this framework's summary type,
+not a parallel mechanism.
+
+## What is shared, and what is emphatically not
+
+**Shared:** call-graph construction, summary representation and propagation,
+the worklist/fixpoint driver, convergence and cycle handling (recursion,
+mutual recursion), caching and invalidation. The lattice machinery is already
+factored out in `src/ir/analysis/lattice.ts`.
+
+**Not shared:** the lattices and transfer functions. Conflating them would be a
+serious mistake, because the *soundness directions differ*: a wrong type is a
+miscompilation, a wrong lifetime is a use-after-free. Different tops, different
+joins, different notions of "safe when uncertain". The framework must let each
+analysis define its own lattice and its own conservative element, and must
+never supply a default.
+
+## The two properties that decide whether this is worth having
+
+**1. It must be able to say "I don't know", and that must be the safe answer.**
+Every consumer has an unanalyzable boundary — `eval`'d source, host imports,
+callbacks from dynamic code, function-valued parameters. A framework that
+silently treats an unresolved callee as benign is unsound for every consumer at
+once, which is strictly worse than the per-analysis conservatism it replaces.
+Per `.claude/memory/MEMORY.md`: *what does it do when it CANNOT SEE?* Going to
+top must be explicit, attributable to a named cause, and countable.
+
+**2. Compile time is the real risk.** A whole-program fixpoint scales with
+program size, and this repo already has superlinear-scaling pain on
+acorn-sized input (**#3756 — "acorn parse superlinear scaling"**). Summaries
+must be compact — bounded size per function, independent of callee count — or
+the analysis becomes the bottleneck it was built to remove. Budget this
+up front rather than discovering it on a large package.
+
+## Acceptance criteria
+
+- [ ] A framework with: call-graph construction over the IR, a summary
+      interface parameterised by a consumer-supplied lattice, and a fixpoint
+      driver that terminates on recursive and mutually-recursive call graphs.
+- [ ] **Two** consumers ported onto it — one lifetime-shaped (#1587 Phase 2)
+      and one type-shaped — so the abstraction is proven against the two
+      soundness directions rather than fitted to one. (ADR-0014's "one
+      demonstration consumer" rule is the floor; two is the requirement here
+      precisely because the risk is over-fitting to a single lattice.)
+- [ ] Unresolved callees are recorded with a **reason** and **counted**, not
+      silently widened; the count is reportable per compilation.
+- [ ] A compile-time budget is measured and committed as a baseline on a large
+      real package, with the framework enabled and disabled.
+- [ ] Foreign-function summaries (#4542's engine-import annotations) use the
+      same summary type as inferred ones.
+- [ ] Removing the framework cannot change emitted Wasm while consumers are in
+      annotation-only mode — the ADR-0014 inertness property #1587 already
+      holds.
+
+## Non-goals
+
+- Any specific optimisation. This issue delivers the substrate; #652, #1166 and
+  #1587 Phase 2 deliver the wins.
+- Whole-program analysis across the dynamic-tier frontier. Analysis is only as
+  whole-program as the typed tier is closed; the frontier is where summaries go
+  to top by construction (see ADR-0020 and #4543).
+- Separate compilation. We compile whole-program; if that ever changes, summary
+  serialisation becomes a new requirement, not a retrofit.


### PR DESCRIPTION
## Description

Docs-only follow-up to #4640. Two issue files; no `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` changes.

### [#4549](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4549-interprocedural-summary-framework) — shared inter-procedural summary framework

Several workstreams independently need the same substrate: a whole-program call graph, compact per-function summaries, and a monotone fixpoint over that graph. Today one axis is half-built and the other is missing — [#685](https://js2wasm.loopdive.com/dashboard/issue.html?slug=685-interprocedural-type-flow-track-return) (`done`) flows return types across call sites, while [#1587](https://js2wasm.loopdive.com/dashboard/issue.html?slug=1587-ownership-and-access-semantics-analysis) is Phase 1 only and says so in its own source: *"Phase 1 is intra-procedural: unknown callees are treated as fully escaping."*

The measured consequence is already recorded in [#652](https://js2wasm.loopdive.com/dashboard/issue.html?slug=652-compile-time-arc-static-lifetime): in a ten-pattern probe, *object passed to a local callee* was **rejected at IR build** — not analysed conservatively, not analysed at all.

Named consumers: #1587 Phase 2, #652&#39;s lifetime placement, [#1166](https://js2wasm.loopdive.com/dashboard/issue.html?slug=1166-closed-world-integer-specialization-from) (`ready`), [#4542](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4542-linear-refcount-handle-scope-pass)&#39;s foreign-function summaries, [#4543](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4543-object-frontier-tainted-alloc-vs-wrappers)&#39;s frontier taint, and the three type-resolution buckets CLAUDE.md says reduce with "better TypeMap propagation" — all **unintended** buckets in the #1376 ratchet.

Two design constraints the issue makes load-bearing:

- **What is shared vs what is not.** Call graph, summary propagation and the fixpoint driver are shared; **lattices and transfer functions are not**. A wrong type is a miscompilation, a wrong lifetime is a use-after-free — different tops, different joins. The framework must never supply a default conservative element. It therefore requires **two** consumers ported, one lifetime-shaped and one type-shaped, so the abstraction is proven against both soundness directions rather than fitted to one.
- **It must be able to say "I don&#39;t know", safely.** Unresolved callees must be recorded with a reason and counted, never silently widened — a framework that treats an unresolved callee as benign is unsound for every consumer at once, which is worse than the per-analysis conservatism it replaces.

Compile time is flagged as the real risk, citing [#3756](https://js2wasm.loopdive.com/dashboard/issue.html?slug=3756-acorn-parse-superlinear-scaling): summaries must be bounded in size per function or the analysis becomes the bottleneck it was built to remove.

### [#4541](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4541-linear-jsvalue-boxed-tier-representation) — a context is already a region

Records that the engine provides grouped deallocation natively: a `JSContext` / `JSRuntime` **is** a region, and `JS_FreeRuntime` releases it in O(1). For a scoped eval — evaluate, extract, discard — a per-eval context gives grouped teardown across the frontier with **no lifetime analysis at all**.

This **bounds the cross-heap cycle leak class that slice already owns**: an uncollectable cycle is still reclaimed at context teardown, so the documented severity is "leaks until this scope ends", not "leaks forever". Those are different severities and only the second is unacceptable — a new acceptance criterion asserts it with a teardown test.

Two limits recorded so the idea is not pushed further than it goes: `JSMallocFunctions` sees one undifferentiated stream and cannot separate transient objects from runtime-lifetime atoms, shapes and bytecode, so grouping is available at context granularity and **not below**; and rewinding under live engine references is a use-after-free *inside the engine*, which is worse than one in our own code.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: an agent should not attest to a legal agreement on the author's behalf. cla-check passes automatically for internal PRs per the template note. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6CYp7YeqqhKf8sgFsDMKq)_