### PR TITLE
docs(issues): #4550 measured IR coverage gap + scope fixes to #4541 and #4544

### DIFF
--- a/plan/issues/4541-linear-jsvalue-boxed-tier-representation.md
+++ b/plan/issues/4541-linear-jsvalue-boxed-tier-representation.md
@@ -28,6 +28,23 @@ related: [1852, 4236, 4245]
 Slice 3 of #4538. Lands the core of
 [ADR-0020](../../docs/adr/0020-linear-dynamic-tier-quickjs-jsvalue.md).
 
+## This lands behind the `BackendEmitter` trait — not in direct `codegen-linear`
+
+**Load-bearing constraint, not a style preference.** The boxed tier is a
+backend lowering of an IR-level concept, so it belongs behind the emitter seam:
+**#1713 — "IR backend-trait: audit WasmGC bias in lower.ts + define
+BackendEmitter seam"** and **#1714 — "Lower one IR node kind through the
+BackendEmitter trait to BOTH WasmGC and linear"** are both `done`, and
+**#1852 — "Make dynamic-value representation explicitly per-backend…"** already
+specifies this work as its slice G4 (`emitBox` / `emitUnbox` / `emitTagLoad` /
+`emitTagTest` implemented in `LinearEmitter`).
+
+Writing it as a direct AST→Wasm path in `src/codegen-linear/` because it is
+urgent would grow exactly the legacy front-end the IR migration is retiring —
+the "wrong answer" `docs/architecture/codegen-axes.md` names explicitly. ADR-0020
+supersedes #1852's *representation* for this target; it does **not** supersede
+#1852's *mechanism*, and the two must not be conflated.
+
 ## Scope
 
 Give the linear lane a dynamic value representation, which it currently lacks
@@ -139,6 +156,9 @@ still-unowned "version pin + upgrade policy" box lands here.
 - [ ] Number box/unbox uses extracted tag constants; a test fails if the
       constants are hardcoded rather than read from the pinned build.
 - [ ] The string decision is recorded **with the measurement that decided it**.
+- [ ] Box / unbox / tag-test are emitted through `BackendEmitter` primitives
+      implemented in `LinearEmitter` — **not** via a direct `codegen-linear`
+      path. A `pushRaw`-style inline emission of these ops fails review.
 - [ ] The residual cycle-leak class is documented and covered by a test that
       demonstrates the mitigation working on the solvable cases.
 - [ ] The documented leak class states its **bound** — reclaimed at context

--- a/plan/issues/4544-native-binary-emission-and-tier-elision.md
+++ b/plan/issues/4544-native-binary-emission-and-tier-elision.md
@@ -15,8 +15,12 @@ area: codegen-linear
 language_feature: compiler-internals
 goal: standalone-mode
 parent: 4538
-depends_on: [4541]
-related: [2776, 4236]
+# Part B (tier elision) depends on 4541; Part A (AOT an existing linear module
+# and record size/startup) depends on NOTHING and is the evidence gate for
+# ADR-0021. The blanket depends_on was wrong and would have parked the one
+# measurement that should run first — corrected 2026-08-17.
+depends_on: []
+related: [2776, 4236, 4541]
 # id 4544 reserved via claim-issue.mjs --allocate --allow-unscanned on
 # 2026-08-17 (gh CLI offline in this container; pr_scan=degraded). Equivalent
 # open-PR scan via the GitHub MCP at reservation time: the sole open PR was
@@ -27,6 +31,15 @@ related: [2776, 4236]
 
 Slice 6 of #4538. Delivers the actual goal — a binary — and the property that
 keeps the tier from taxing programs that never touch it.
+
+## Sequencing — Part A is unblocked, Part B is not
+
+**Part A can start today.** AOT-compiling an existing linear-target module and
+recording size/startup depends on no other slice, and it is the evidence gate
+for [ADR-0021](../../docs/adr/0021-native-backend-targets-c.md): if these
+numbers are adequate, the direct C backend stays deferred indefinitely, which
+is worth learning before anyone invests in it. Part B (tier elision) genuinely
+needs #4541.
 
 ## Part A — native binary emission
 

--- a/plan/issues/4550-ir-ratchet-corpus-unrepresentative.md
+++ b/plan/issues/4550-ir-ratchet-corpus-unrepresentative.md
@@ -1,0 +1,137 @@
+---
+id: 4550
+title: "The IR ratchet corpus is 13 files and unrepresentative: measured 0 % linear-lane claim rate on 5 real npm entry modules, with body-shape-rejected dominant despite its bucket reading zero"
+status: ready
+sprint: Backlog
+created: 2026-08-17
+updated: 2026-08-17
+priority: high
+horizon: l
+feasibility: medium
+model: fable
+reasoning_effort: high
+task_type: analysis
+area: ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+related: [652, 1376, 2855, 2856, 2859, 3341, 4538, 4539, 4541, 4549]
+# id 4550 reserved via claim-issue.mjs --allocate --allow-unscanned on
+# 2026-08-17 (gh CLI offline in this container; pr_scan=degraded). Equivalent
+# open-PR scan via the GitHub MCP at reservation time: sole open PR was 4639
+# (ci/npm-compat-refresh, artifact-only), which adds no issue file.
+---
+
+# #4550 — The ratchet's zero is corpus-specific, and now measured
+
+## What was measured (2026-08-17)
+
+The #1376 ratchet reports its unintended buckets at zero, and the bucket work
+is `done`: **#2856 — "IR: drive body-shape-rejected fallback bucket to zero
+(dominant unintended bucket)"** and **#2859 — "IR: drive
+param-type-not-resolvable fallback bucket to zero (TypeMap propagation)"**,
+under **#2855 — "IR fallback-corpus ratchet: drive unintended function buckets
+to zero"**.
+
+Its corpus is **13 files** under `website/playground/examples`.
+
+Compiling five real npm entry modules through `--target linear` and reading
+`getLastLinearIrReport()`:
+
+| module | claimed | rejected | claim rate |
+| --- | ---: | ---: | ---: |
+| `playground/benchmarks.ts` | 3 | 5 | 37.5 % |
+| `cookie@2.0.1` | **0** | 9 | **0 %** |
+| `clsx@2.1.1` | **0** | 2 | **0 %** |
+| `redux@5.0.1` | **0** | 2 | **0 %** |
+| `marked@18.0.2` | **0** | 2 | **0 %** |
+| `moment@2.30.1` | **0** | 2 | **0 %** |
+| **total** | **3** | **22** | **12 %** |
+
+Rejection reasons across all files:
+
+| reason | count |
+| --- | ---: |
+| `select:body-shape-rejected` | **10** |
+| `select:recursive-type-evidence` | 4 |
+| `select:logical-value-unsupported` | 3 |
+| `select:param-type-not-resolvable` | 2 |
+| `select:string-builder-candidate` | 1 |
+| `illegal:instr-vec.set_length` | 1 |
+| `select:constructor-resolution-unsupported` | 1 |
+
+**`body-shape-rejected` is the single most common rejection — the same bucket
+the ratchet reads as zero.** `param-type-not-resolvable` appears too. This is
+not a ratchet defect; CLAUDE.md already states the hazard (#3341): a bucket
+absent from the baseline means *the corpus does not trigger it*, never *the
+reason is unreachable*. What is new is that the claim is now measured rather
+than cautioned about.
+
+**Validity.** A positive control (a known-claimable non-escaping-object
+function) was claimed in the same run, so a 0 % rate means "not claimed", not
+"the probe cannot see". A first version of this probe lacked that control and
+its output would have been indistinguishable from a broken harness.
+
+## The denominators are truncated — do not quote 12 % as coverage
+
+`moment@2.30.1` is 176 KB and reports **2** functions; `marked@18.0.2` is 42 KB
+and reports **2**. Those packages contain hundreds. So the linear IR path is
+reporting only a small prefix of each module — plausibly bailing at a
+module-level gate (`select:recursive-type-evidence` appears exactly once per
+large package) before enumerating the rest.
+
+That means the numbers above **understate the population, not the coverage**:
+the true claim rate is no better than 12 % and probably worse, but the honest
+statement is that we cannot yet count the denominator. Establishing it is the
+first deliverable below.
+
+## Why this matters beyond the ratchet
+
+Every downstream measurement in the current program is gated on this, and each
+one hit the same wall this session (recorded in **#652 — "Compile-time ARC:
+static lifetime analysis for linear memory mode"**):
+
+- the stack-allocation census returned **0/0** — no allocation sites in claimed
+  functions, so no denominator;
+- `cookie` yielded no analysable function at all;
+- ordinary shapes — *object returned*, *object passed to a local callee*,
+  *closure capturing a local* — are rejected outright.
+
+**#4549 — "Shared inter-procedural summary framework…"**, #652's region work,
+and #4541's representation slice all consume IR that mostly does not exist for
+real code today.
+
+## Deliverables
+
+- [ ] **Establish the real denominator.** Determine why large modules report a
+      handful of functions, and report claim rate over *all* functions in a
+      module, not the reported prefix. Until this lands, no coverage percentage
+      should be quoted.
+- [ ] **Widen the measured corpus** beyond the 13 playground files — the
+      `tests/dogfood/fixtures/*.tgz` pinned tarballs are already in-tree and
+      need no network.
+- [ ] **Decide the corpus's relationship to the gate.** Widening the *gating*
+      ratchet corpus would fail CI immediately, so this is deliberately two
+      decisions: a **reported** wide corpus (informational, tracked over time)
+      and, separately, whether/when any of it becomes gating. Do not silently
+      widen the gate.
+- [ ] **Re-rank the buckets by the wide corpus.** `body-shape-rejected` at 10/22
+      suggests the retired bucket work was corpus-fitted; the next bucket
+      campaign should be prioritised by real-code frequency.
+- [ ] Publish the reasons histogram per corpus so a future reader can see which
+      corpus a "zero" refers to.
+
+## Non-goals
+
+- Fixing any individual rejection reason. This issue establishes the honest
+  measurement; the bucket campaigns act on it.
+- Changing the existing gate's pass/fail behaviour. The 13-file ratchet keeps
+  doing its job; it simply must not be read as a coverage statement.
+
+## Repro
+
+Probe used: `.tmp/coverage-census.ts` (gitignored — restated here so it does
+not die with the container). For each module: `compile(src, { target: "linear",
+allocator: "analysis-stack" })`, then read `getLastLinearIrReport()`'s
+`compiled` / `rejected` arrays and histogram `rejected[].reason`. Fixtures
+extracted from `tests/dogfood/fixtures/<pkg>-<ver>.tgz`; entry modules taken
+from `tests/dogfood/<pkg>-pin.json`'s `entryModule`.


### PR DESCRIPTION
## Description

Docs-only. One new issue recording a measurement, plus two scope corrections to issues filed earlier today. No `src/`, `tests/`, `scripts/`, `.github/` or `benchmarks/` changes.

### [#4550](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4550-ir-ratchet-corpus-unrepresentative) — the ratchet&#39;s zero is corpus-specific, now measured

The #1376 ratchet reports its unintended buckets at zero and the bucket work is `done` ([#2856](https://js2wasm.loopdive.com/dashboard/issue.html?slug=2856-ir-body-shape-rejected-bucket-zero), [#2859](https://js2wasm.loopdive.com/dashboard/issue.html?slug=2859-ir-param-type-not-resolvable-bucket-zero)). Its corpus is **13 files**.

Compiling five real npm entry modules through `--target linear`:

| module | claimed | rejected |
| --- | ---: | ---: |
| `playground/benchmarks.ts` | 3 | 5 |
| `cookie@2.0.1` | **0** | 9 |
| `clsx@2.1.1` | **0** | 2 |
| `redux@5.0.1` | **0** | 2 |
| `marked@18.0.2` | **0** | 2 |
| `moment@2.30.1` | **0** | 2 |

`select:body-shape-rejected` is the **most common rejection (10 of 22)** — the same bucket the ratchet reads as zero — with `select:param-type-not-resolvable` also present.

This is **not a ratchet defect**. CLAUDE.md already states the hazard (#3341): a bucket absent from the baseline means *the corpus does not trigger it*, never *the reason is unreachable*. What is new is that the claim is measured rather than cautioned about.

Two honesty constraints written into the issue:

- **A positive control was claimed in the same run**, so 0 % means "not claimed", not "the probe cannot see". An earlier version of this probe lacked that control and its output would have been indistinguishable from a broken harness.
- **The 12 % overall figure is explicitly not quotable as coverage.** `moment@2.30.1` is 176 KB and reports **2** functions, so the reported denominators are truncated. Establishing the real denominator is the first deliverable; until then no percentage should be cited.

It also separates the two decisions that could otherwise get conflated: a **reported** wide corpus (informational) versus whether any of it becomes **gating**. Silently widening the gate would fail CI immediately.

### Scope fixes

**[#4541](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4541-linear-jsvalue-boxed-tier-representation)** — records that the boxed tier **must land behind the `BackendEmitter` trait**, not as a direct `codegen-linear` path. [#1713](https://js2wasm.loopdive.com/dashboard/issue.html?slug=1713-ir-backend-trait-audit-wasmgc-bias) and [#1714](https://js2wasm.loopdive.com/dashboard/issue.html?slug=1714-lower-one-ir-node-kind-through) are both `done`, and [#1852](https://js2wasm.loopdive.com/dashboard/issue.html?slug=1852-per-backend-value-representation)&#39;s slice G4 already specifies this as `LinearEmitter` work. ADR-0020 supersedes #1852&#39;s *representation* for this target but **not** its *mechanism* — conflating the two would grow the legacy front-end the IR migration is retiring, which is the "wrong answer" `codegen-axes.md` names explicitly. New acceptance criterion: inline `pushRaw`-style emission of box/unbox/tag-test fails review.

**[#4544](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4544-native-binary-emission-and-tier-elision)** — corrected `depends_on`. Part A (AOT an existing linear module, record size/startup) depends on nothing and is the evidence gate for ADR-0021; only Part B (tier elision) needs #4541. The blanket dependency would have parked the one measurement that should run first.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: an agent should not attest to a legal agreement on the author's behalf. cla-check passes automatically for internal PRs per the template note. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6CYp7YeqqhKf8sgFsDMKq)_