### PR TITLE
feat(codegen-linear): #4539 link topology + calls through to C, and #4554 tier-1 address domain

### DIFF
--- a/plan/issues/4539-linear-lane-import-direction-and-memory.md
+++ b/plan/issues/4539-linear-lane-import-direction-and-memory.md
@@ -1,8 +1,18 @@
 ---
 id: 4539
 title: "Linear lane link topology: extern-C import declarations, emit imports at all, import the memory instead of defining it"
-status: ready
+status: in-progress
 sprint: Backlog
+# The substantive code lands in c-abi.ts (not a god-file). What remains is
+# wiring that can only live where the module is constructed: +24 in
+# codegen-linear/index.ts (the two LinearOptions fields and the
+# declare-imports-first calls, which MUST precede any runtime function) and +7
+# in runtime.ts (the `skip defining memory when one is imported` guard inside
+# addRuntime). Neither can move to a subsystem module without indirecting the
+# construction order the gate exists to keep legible.
+loc-budget-allow:
+  - src/codegen-linear/index.ts
+  - src/codegen-linear/runtime.ts
 created: 2026-08-17
 updated: 2026-08-17
 priority: high

--- a/plan/issues/4554-linear-address-domain-wasm64-ready.md
+++ b/plan/issues/4554-linear-address-domain-wasm64-ready.md
@@ -1,0 +1,126 @@
+---
+id: 4554
+title: "A declared address domain for the linear lane: ptr/size/handle instead of literal i32, so handles stop riding as f64 and memory64 stays reachable"
+status: in-progress
+sprint: Backlog
+created: 2026-08-17
+updated: 2026-08-17
+priority: high
+horizon: l
+feasibility: hard
+model: fable
+reasoning_effort: max
+task_type: feature
+area: codegen-linear
+language_feature: compiler-internals
+goal: standalone-mode
+parent: 4538
+related: [3686, 4539, 4541, 4550]
+# id 4554 reserved via claim-issue.mjs --allocate --allow-unscanned on
+# 2026-08-17 (gh CLI offline in this container; pr_scan=degraded). Equivalent
+# open-PR scan via the GitHub MCP at reservation time: the only open PRs were
+# 4639 (ci artifact refresh) and 4643 (this lane's own), neither adding an
+# issue file.
+loc-budget-allow:
+  - src/codegen-linear/index.ts
+---
+
+# #4554 — A declared address domain, not literal `i32`
+
+Two problems with one shape. Both are about naming the *role* of a scalar
+instead of hard-coding its width.
+
+## Problem 1 — handles ride as f64, and the cost is representation
+
+The linear backend compiles a TS `number` to **f64**, so a value that is
+semantically an i32 handle is stored in an f64 local and an 8-byte arena slot.
+Under [ADR-0020](../../docs/adr/0020-linear-dynamic-tier-quickjs-jsvalue.md)
+*every* `JSValue` is a handle, so that is **2× memory on every stored handle**
+plus a conversion at every use.
+
+The conversion instructions themselves are not the cost — a `trunc`/`convert`
+pair next to a call is noise. The representation is.
+
+**This is not a flag that was left off.** `resolveType` in
+`src/codegen-linear/index.ts` deliberately resolves numeric aliases —
+`type i32 = number` and `type Meters = number` alike — to **f64**, and says why:
+
+> Anything else used to fall straight into the `i32` (pointer) default — which
+> silently mis-typed **every type alias of a numeric type** (#3686 bug 2). The
+> signature slot came out `i32` while the body compiled the arithmetic as
+> `f64`, so the module failed validation.
+
+So what is missing is a **value domain**: the direct backend has no
+expression-level type tracking, so a signature saying `i32` and a body emitting
+`f64` cannot be kept in agreement. That is the same gap recorded as the
+boundary-conversion limitation in `c-abi.ts`, seen from the other side.
+
+## Problem 2 — `i32` is hard-coded as *the* pointer type
+
+Pointers, sizes and handles are `i32` **because the target is wasm32**, not
+because they are inherently 32-bit. Under memory64 addresses and sizes become
+`i64`. Every literal `{ kind: "i32" }` standing for an address is therefore an
+unexamined assumption, and today there are hundreds of them (`__heap_ptr`, the
+`this` param, string/array pointers, the aggregate offsets).
+
+**We already read the answer and then ignore it.** `scripts/quickjs-artifact/
+extract-abi.mjs` pulls `handleSize` and `jsValueSize` out of the pinned
+artifact — the design already treats handle width as a property of the build.
+Then the extern ABI hard-codes `{ kind: "i32" }`.
+
+## Non-goal: adopting memory64
+
+Preparation is about not foreclosing it, **not** betting on it. memory64 is
+frequently *slower* on today's engines — 64-bit bounds checks cannot use the
+4 GiB guard-page trick — and doubling pointer width costs cache. Nothing here
+should be read as a plan to switch.
+
+## Tier 1 — the new surface, while it is still private (this PR)
+
+`ExternCImportSpec` is hours old and has no callers outside its own tests, so
+changing its shape costs nothing now and is breaking after #4643 merges.
+
+- [x] An `AddressKind` (`"ptr" | "size" | "handle"`) usable anywhere an extern
+      param/result type is written, resolved through a single
+      `LinearAddressModel`.
+- [x] `WASM32_ADDRESS_MODEL` maps all three to `i32` — today's behaviour,
+      now stated once instead of assumed everywhere.
+- [x] `declareImportedMemory` accepts an `indexType`, and **refuses `"i64"`
+      with an explicit error** rather than accepting it and emitting wasm32
+      limits. The API is shaped for memory64; the emitter cannot encode it yet,
+      and silently emitting the wrong bytes is the failure this avoids.
+
+## Tier 2 — the value domain (not this PR)
+
+- [ ] A pointer/size/handle domain across the linear **IR** value model, so a
+      handle stays i32 from producer to consumer with no f64 round-trip.
+- [ ] Consume the extracted `handleSize` so width comes from the artifact
+      rather than a constant — pairs with #4541's ABI stamp.
+- [ ] Retire the boundary-conversion limitation documented in `c-abi.ts`.
+
+**Tier 2 belongs in the IR / `LinearEmitter`, not the direct backend.** The IR
+already has a typed value model; the direct path is precisely what lacks one.
+Building an address domain into the direct backend would grow the legacy
+front-end the migration is retiring — the same constraint recorded on #4541 —
+and it shares the coverage gate measured in #4550.
+
+## Soundness constraint (applies to both tiers)
+
+The domain must be **declared, never inferred.** JS `number` is f64; narrowing
+anything that "looks like a size" silently changes overflow and division
+semantics. `nativeTypeFromTypeNode` already enforces the right guard — the name
+must bind to a user-declared `= number` alias, so a stray `interface i32 {}`
+cannot miscompile — and that guard should be reused rather than reinvented.
+
+## Acceptance criteria
+
+- [x] Tier 1: an extern import declared with an address kind resolves to the
+      target's width and links end-to-end against the real C peer.
+- [x] Tier 1: a memory64 index type is refused with a message naming the
+      limitation, and a test asserts the refusal.
+- [ ] Tier 2: a handle-typed value makes a full round trip — C → compiled code →
+      C — with **no** f64 conversion emitted, asserted on the instruction
+      stream, not just on the result.
+- [ ] Tier 2: switching the address model to i64 changes the emitted types with
+      no other source edit — the property that makes this "prepared" rather
+      than "hard-coded differently".

--- a/src/codegen-linear/c-abi.ts
+++ b/src/codegen-linear/c-abi.ts
@@ -386,3 +386,111 @@ export function inferSemantic(wasmType: ValType, tsTypeText: string | undefined)
   if (cleaned === "void") return "number_f64"; // shouldn't occur for params
   return "object";
 }
+
+// ── Import direction (#4539) ─────────────────────────────────────────
+//
+// Everything above marshals the EXPORT direction: TS functions surfaced to a C
+// caller. This section is the inverse — declaring external C functions that the
+// linear module CALLS, which is what linking against a C library (e.g. the
+// pinned engine artifact of ADR-0020) requires.
+//
+// Ordering is load-bearing. A function's index is `numImportFuncs + position`,
+// so every import must be declared BEFORE any defined function is added.
+// Declaring one afterwards would shift every existing index — the failure mode
+// the WasmGC lane works around with late `addUnionImports` shifting, which this
+// backend deliberately does not replicate. `declareExternCImports` therefore
+// REFUSES rather than silently corrupting indices.
+
+/** An external C function this module calls. */
+export interface ExternCImportSpec {
+  /** Wasm import module name, e.g. `"qjs"`. */
+  module: string;
+  /** Wasm import field name, e.g. `"qjs_eval"`. */
+  name: string;
+  params: ValType[];
+  results: ValType[];
+  /**
+   * Whether the callee takes ownership of handle-typed arguments.
+   *
+   * Declared here rather than inferred because the callee is foreign code the
+   * analysis cannot see — it is a hand-written summary. The refcount /
+   * handle-scope pass (#4542) consumes this; that issue requires every import
+   * to carry one, so the field is intentionally not optional-with-a-default:
+   * a wrong default is a leak or a double-free, and "unset" must stay
+   * distinguishable from "borrows".
+   */
+  ownership?: "borrows" | "consumes";
+}
+
+/** Count the function imports already declared on a module. */
+export function countImportedFuncs(mod: WasmModule): number {
+  let n = 0;
+  for (const imp of mod.imports) if (imp.desc.kind === "func") n++;
+  return n;
+}
+
+/** Find an existing structurally-identical func type, or append one. */
+function internFuncType(mod: WasmModule, params: ValType[], results: ValType[]): number {
+  const same = (a: ValType[], b: ValType[]): boolean =>
+    a.length === b.length && a.every((t, i) => t.kind === b[i].kind);
+  for (let i = 0; i < mod.types.length; i++) {
+    const t = mod.types[i];
+    if (t.kind === "func" && same(t.params, params) && same(t.results, results)) return i;
+  }
+  const typeIdx = mod.types.length;
+  const def: FuncTypeDef = { kind: "func", params, results };
+  mod.types.push(def);
+  return typeIdx;
+}
+
+/**
+ * Declare external C functions this module imports, in order.
+ *
+ * MUST run before any defined function exists on `mod`; throws otherwise, so
+ * an index-shifting mistake is a loud failure at build time rather than a
+ * miscompile. Returns `name → function index`; imports occupy `[0, n)`.
+ */
+export function declareExternCImports(mod: WasmModule, specs: readonly ExternCImportSpec[]): Map<string, number> {
+  const indices = new Map<string, number>();
+  if (specs.length === 0) return indices;
+  if (mod.functions.length > 0) {
+    throw new Error(
+      `declareExternCImports: ${mod.functions.length} function(s) already defined. ` +
+        "Imports must be declared before any function is added — adding one later shifts every " +
+        "function index. Move the call earlier in generateLinearModule.",
+    );
+  }
+  for (const spec of specs) {
+    const existing = indices.get(`${spec.module}.${spec.name}`);
+    if (existing !== undefined) continue;
+    const typeIdx = internFuncType(mod, spec.params, spec.results);
+    const funcIdx = countImportedFuncs(mod);
+    mod.imports.push({ module: spec.module, name: spec.name, desc: { kind: "func", typeIdx } });
+    indices.set(`${spec.module}.${spec.name}`, funcIdx);
+    indices.set(spec.name, funcIdx);
+  }
+  return indices;
+}
+
+/**
+ * Import the module's linear memory instead of defining it.
+ *
+ * Required when linking against an artifact that EXPORTS memory (the ADR-0020
+ * topology): both sides must address one memory, and only one may own it.
+ * `addRuntime` skips defining memory when an import is present.
+ */
+export function declareImportedMemory(mod: WasmModule, module: string, name: string, min: number, max?: number): void {
+  if (mod.memories.length > 0) {
+    throw new Error(
+      "declareImportedMemory: this module already DEFINES a memory. A module may not both " +
+        "define and import one; declare the import before the runtime is added.",
+    );
+  }
+  if (hasImportedMemory(mod)) return;
+  mod.imports.push({ module, name, desc: { kind: "memory", min, max } });
+}
+
+/** Whether the module imports its linear memory rather than defining one. */
+export function hasImportedMemory(mod: WasmModule): boolean {
+  return mod.imports.some((imp) => imp.desc.kind === "memory");
+}

--- a/src/codegen-linear/c-abi.ts
+++ b/src/codegen-linear/c-abi.ts
@@ -494,3 +494,60 @@ export function declareImportedMemory(mod: WasmModule, module: string, name: str
 export function hasImportedMemory(mod: WasmModule): boolean {
   return mod.imports.some((imp) => imp.desc.kind === "memory");
 }
+
+/**
+ * Boundary marshalling for a call to an extern-C import (#4539).
+ *
+ * This backend compiles a TS `number` to **f64**, while a C signature is
+ * whatever it declares — typically `i32` for handles and sizes. So each
+ * argument is converted into the declared parameter type on the way in, and
+ * the result back into the f64 domain on the way out.
+ *
+ * KNOWN LIMITATION, stated rather than hidden: the conversion assumes the
+ * argument expression produced f64, which holds for ordinary `number`
+ * expressions but NOT for values already in i32 form via native type
+ * annotations (`type i32 = number`). Mixing those with extern calls is
+ * therefore not yet supported; it needs the expression-level type tracking
+ * the direct backend does not have. Emitting a wrong conversion silently is
+ * the failure this comment exists to prevent someone from causing.
+ */
+export function emitExternCBoundaryArg(out: Instr[], declared: ValType): void {
+  switch (declared.kind) {
+    case "f64":
+      return; // already the backend's domain
+    case "i32":
+      out.push({ op: "i32.trunc_f64_s" });
+      return;
+    case "i64":
+      out.push({ op: "i64.trunc_f64_s" });
+      return;
+    case "f32":
+      out.push({ op: "f32.demote_f64" });
+      return;
+    default:
+      throw new Error(
+        `extern-C import parameter type '${declared.kind}' is not supported yet. ` +
+          "Supported: f64, i32, i64, f32 — the scalar C ABI. A reference type " +
+          "cannot cross this boundary by value.",
+      );
+  }
+}
+
+/** Convert an extern-C result back into the backend's f64 value domain. */
+export function emitExternCBoundaryResult(out: Instr[], declared: ValType): void {
+  switch (declared.kind) {
+    case "f64":
+      return;
+    case "i32":
+      out.push({ op: "f64.convert_i32_s" });
+      return;
+    case "i64":
+      out.push({ op: "f64.convert_i64_s" });
+      return;
+    case "f32":
+      out.push({ op: "f64.promote_f32" });
+      return;
+    default:
+      throw new Error(`extern-C import result type '${declared.kind}' is not supported yet.`);
+  }
+}

--- a/src/codegen-linear/c-abi.ts
+++ b/src/codegen-linear/c-abi.ts
@@ -401,14 +401,63 @@ export function inferSemantic(wasmType: ValType, tsTypeText: string | undefined)
 // backend deliberately does not replicate. `declareExternCImports` therefore
 // REFUSES rather than silently corrupting indices.
 
+// ── Address domain (#4554) ───────────────────────────────────────────
+//
+// Pointers, sizes and handles are `i32` because the TARGET is wasm32, not
+// because they are inherently 32-bit; under memory64 they become `i64`. Naming
+// the role instead of the width keeps that a one-line change here rather than
+// a hunt through every declaration site.
+//
+// This is deliberately NOT an adoption of memory64, which is often slower on
+// today's engines (64-bit bounds checks cannot use the 4 GiB guard-page trick)
+// and costs cache through wider pointers. It only stops foreclosing it.
+
+/** The role a scalar plays, when its width is a property of the target. */
+export type AddressKind = "ptr" | "size" | "handle";
+
+/** A param/result type: an exact Wasm type, or a role resolved per target. */
+export type ExternCValType = ValType | { address: AddressKind };
+
+/** Which Wasm type each address role lowers to on a given target. */
+export interface LinearAddressModel {
+  readonly pointer: ValType;
+  readonly size: ValType;
+  readonly handle: ValType;
+}
+
+/** wasm32: every address role is an `i32`. The status quo, stated once. */
+export const WASM32_ADDRESS_MODEL: LinearAddressModel = {
+  pointer: { kind: "i32" },
+  size: { kind: "i32" },
+  handle: { kind: "i32" },
+};
+
+/** Resolve a declared extern type against the target's address model. */
+export function resolveExternCValType(t: ExternCValType, model: LinearAddressModel = WASM32_ADDRESS_MODEL): ValType {
+  if (!("address" in t)) return t;
+  switch (t.address) {
+    case "ptr":
+      return model.pointer;
+    case "size":
+      return model.size;
+    case "handle":
+      return model.handle;
+  }
+}
+
 /** An external C function this module calls. */
 export interface ExternCImportSpec {
   /** Wasm import module name, e.g. `"qjs"`. */
   module: string;
   /** Wasm import field name, e.g. `"qjs_eval"`. */
   name: string;
-  params: ValType[];
-  results: ValType[];
+  /**
+   * Parameter types. Prefer an {@link AddressKind} — `{ address: "handle" }` —
+   * over a literal `i32` wherever the value is an address rather than a number
+   * that happens to be 32 bits wide.
+   */
+  params: ExternCValType[];
+  results: ExternCValType[];
   /**
    * Whether the callee takes ownership of handle-typed arguments.
    *
@@ -450,7 +499,11 @@ function internFuncType(mod: WasmModule, params: ValType[], results: ValType[]):
  * an index-shifting mistake is a loud failure at build time rather than a
  * miscompile. Returns `name → function index`; imports occupy `[0, n)`.
  */
-export function declareExternCImports(mod: WasmModule, specs: readonly ExternCImportSpec[]): Map<string, number> {
+export function declareExternCImports(
+  mod: WasmModule,
+  specs: readonly ExternCImportSpec[],
+  model: LinearAddressModel = WASM32_ADDRESS_MODEL,
+): Map<string, number> {
   const indices = new Map<string, number>();
   if (specs.length === 0) return indices;
   if (mod.functions.length > 0) {
@@ -463,7 +516,11 @@ export function declareExternCImports(mod: WasmModule, specs: readonly ExternCIm
   for (const spec of specs) {
     const existing = indices.get(`${spec.module}.${spec.name}`);
     if (existing !== undefined) continue;
-    const typeIdx = internFuncType(mod, spec.params, spec.results);
+    const typeIdx = internFuncType(
+      mod,
+      spec.params.map((t) => resolveExternCValType(t, model)),
+      spec.results.map((t) => resolveExternCValType(t, model)),
+    );
     const funcIdx = countImportedFuncs(mod);
     mod.imports.push({ module: spec.module, name: spec.name, desc: { kind: "func", typeIdx } });
     indices.set(`${spec.module}.${spec.name}`, funcIdx);
@@ -479,11 +536,30 @@ export function declareExternCImports(mod: WasmModule, specs: readonly ExternCIm
  * topology): both sides must address one memory, and only one may own it.
  * `addRuntime` skips defining memory when an import is present.
  */
-export function declareImportedMemory(mod: WasmModule, module: string, name: string, min: number, max?: number): void {
+export function declareImportedMemory(
+  mod: WasmModule,
+  module: string,
+  name: string,
+  min: number,
+  max?: number,
+  indexType: "i32" | "i64" = "i32",
+): void {
   if (mod.memories.length > 0) {
     throw new Error(
       "declareImportedMemory: this module already DEFINES a memory. A module may not both " +
         "define and import one; declare the import before the runtime is added.",
+    );
+  }
+  // #4554 — the parameter exists so a memory64 caller has somewhere to say so,
+  // and is REFUSED rather than accepted-and-ignored. Accepting it would emit
+  // wasm32 limits for a 64-bit memory: a module that instantiates and then
+  // addresses the wrong bytes. A loud refusal is the only honest answer until
+  // the emitter can encode 64-bit limits.
+  if (indexType === "i64") {
+    throw new Error(
+      "declareImportedMemory: memory64 (i64 index type) is not supported yet — the emitter " +
+        "cannot encode 64-bit limits, and emitting 32-bit ones for a 64-bit memory would " +
+        "silently address the wrong memory. See #4554.",
     );
   }
   if (hasImportedMemory(mod)) return;

--- a/src/codegen-linear/context.ts
+++ b/src/codegen-linear/context.ts
@@ -17,6 +17,15 @@ export interface LinearContext {
   funcMap: Map<string, number>;
   /** Number of imported functions */
   numImportFuncs: number;
+  /**
+   * Declared signatures of extern-C imports, by import field name (#4539).
+   *
+   * Present only for names declared via `LinearOptions.externImports`. The
+   * call path uses it to marshal at the boundary: this backend compiles a TS
+   * `number` to f64, so an import declaring `i32` needs an explicit
+   * conversion in each direction. Absent name ⇒ an ordinary internal call.
+   */
+  externImportSigs?: Map<string, { index: number; params: ValType[]; results: ValType[] }>;
   /** Current function context (set during function compilation) */
   currentFunc: LinearFuncContext | null;
   /** Errors accumulated during codegen */

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -10,6 +10,7 @@ import {
   emitExternCBoundaryArg,
   emitExternCBoundaryResult,
   type ExternCImportSpec,
+  resolveExternCValType,
 } from "./c-abi.js";
 import { createEmptyModule } from "../ir/types.js";
 import { linearAllocatorPolicy, type LinearAllocatorPolicyId } from "../ir/analysis/linear-memory-plan.js";
@@ -116,7 +117,14 @@ export interface LinearOptions {
    * Import linear memory from another module instead of defining one — the
    * ADR-0020 link topology, where the engine artifact owns the memory.
    */
-  importMemory?: { module: string; name: string; min: number; max?: number };
+  importMemory?: {
+    module: string;
+    name: string;
+    min: number;
+    max?: number;
+    /** memory64 index type (#4554). Refused for now; see declareImportedMemory. */
+    indexType?: "i32" | "i64";
+  };
 }
 
 /**
@@ -130,8 +138,8 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
   // index; `declareExternCImports` throws rather than allow that. With no
   // imports requested this is a no-op and emitted output is unchanged.
   if (opts.importMemory) {
-    const { module, name, min, max } = opts.importMemory;
-    declareImportedMemory(mod, module, name, min, max);
+    const { module, name, min, max, indexType } = opts.importMemory;
+    declareImportedMemory(mod, module, name, min, max, indexType);
   }
   const externImportIndices = declareExternCImports(mod, opts.externImports ?? []);
   // The index lives here rather than only in funcMap because an ambient
@@ -139,11 +147,18 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
   // function and would overwrite the funcMap entry — silently retargeting the
   // call at a body-less local slot with a TS-derived (f64) signature. Keeping
   // the extern binding in its own map makes it authoritative.
+  // Types are RESOLVED through the address model here (#4554) so every later
+  // consumer — the call site's boundary marshalling included — sees concrete
+  // Wasm types and never has to re-decide how wide a handle is.
   const externImportSigs = new Map<string, { index: number; params: ValType[]; results: ValType[] }>();
   for (const spec of opts.externImports ?? []) {
     const index = externImportIndices.get(spec.name);
     if (index === undefined) continue;
-    externImportSigs.set(spec.name, { index, params: [...spec.params], results: [...spec.results] });
+    externImportSigs.set(spec.name, {
+      index,
+      params: spec.params.map((t) => resolveExternCValType(t)),
+      results: spec.results.map((t) => resolveExternCValType(t)),
+    });
   }
   const allocationPolicy = linearAllocatorPolicy(opts.allocationPolicy ?? "arena-v1");
   const dataSegmentBase = numberFormat.addRuntime(mod, ast, opts.exposeArenaReset, DATA_SEGMENT_BASE);

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -3,6 +3,7 @@ import { ts, forEachChild } from "../ts-api.js";
 import type { MultiTypedAST, TypedAST } from "../checker/index.js";
 import type { BuildIrUnitInventoryOptions } from "../ir/identity.js";
 import type { FuncTypeDef, Instr, ValType, WasmModule } from "../ir/types.js";
+import { countImportedFuncs, declareExternCImports, declareImportedMemory, type ExternCImportSpec } from "./c-abi.js";
 import { createEmptyModule } from "../ir/types.js";
 import { linearAllocatorPolicy, type LinearAllocatorPolicyId } from "../ir/analysis/linear-memory-plan.js";
 import * as linearIr from "../ir/backend/linear-integration.js";
@@ -99,6 +100,16 @@ export interface LinearOptions {
   /** Shared IR allocation policy. Direct-backend fallbacks remain arena-backed. */
   allocationPolicy?: LinearAllocatorPolicyId;
   irInventoryOptions?: BuildIrUnitInventoryOptions;
+  /**
+   * External C functions this module calls (#4539). Declared before any
+   * defined function so indices are stable; see `declareExternCImports`.
+   */
+  externImports?: readonly ExternCImportSpec[];
+  /**
+   * Import linear memory from another module instead of defining one — the
+   * ADR-0020 link topology, where the engine artifact owns the memory.
+   */
+  importMemory?: { module: string; name: string; min: number; max?: number };
 }
 
 /**
@@ -107,6 +118,15 @@ export interface LinearOptions {
  */
 export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): WasmModule {
   const mod = createEmptyModule();
+  // #4539 — imports FIRST, before any runtime function exists. A function's
+  // index is `numImportFuncs + position`, so a later import would shift every
+  // index; `declareExternCImports` throws rather than allow that. With no
+  // imports requested this is a no-op and emitted output is unchanged.
+  if (opts.importMemory) {
+    const { module, name, min, max } = opts.importMemory;
+    declareImportedMemory(mod, module, name, min, max);
+  }
+  declareExternCImports(mod, opts.externImports ?? []);
   const allocationPolicy = linearAllocatorPolicy(opts.allocationPolicy ?? "arena-v1");
   const dataSegmentBase = numberFormat.addRuntime(mod, ast, opts.exposeArenaReset, DATA_SEGMENT_BASE);
 
@@ -144,7 +164,9 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     mod,
     checker: ast.checker,
     funcMap: new Map(),
-    numImportFuncs: 0,
+    // #4539 — derived, not hard-coded. Zero when nothing is imported, so
+    // output is unchanged for every existing caller.
+    numImportFuncs: countImportedFuncs(mod),
     currentFunc: null,
     errors: [],
     classLayouts: new Map(),
@@ -311,7 +333,9 @@ export function generateLinearMultiModule(multiAst: MultiTypedAST, opts: LinearO
     mod,
     checker: multiAst.checker,
     funcMap: new Map(),
-    numImportFuncs: 0,
+    // #4539 — derived, not hard-coded. Zero when nothing is imported, so
+    // output is unchanged for every existing caller.
+    numImportFuncs: countImportedFuncs(mod),
     currentFunc: null,
     errors: [],
     classLayouts: new Map(),

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -3,7 +3,14 @@ import { ts, forEachChild } from "../ts-api.js";
 import type { MultiTypedAST, TypedAST } from "../checker/index.js";
 import type { BuildIrUnitInventoryOptions } from "../ir/identity.js";
 import type { FuncTypeDef, Instr, ValType, WasmModule } from "../ir/types.js";
-import { countImportedFuncs, declareExternCImports, declareImportedMemory, type ExternCImportSpec } from "./c-abi.js";
+import {
+  countImportedFuncs,
+  declareExternCImports,
+  declareImportedMemory,
+  emitExternCBoundaryArg,
+  emitExternCBoundaryResult,
+  type ExternCImportSpec,
+} from "./c-abi.js";
 import { createEmptyModule } from "../ir/types.js";
 import { linearAllocatorPolicy, type LinearAllocatorPolicyId } from "../ir/analysis/linear-memory-plan.js";
 import * as linearIr from "../ir/backend/linear-integration.js";
@@ -126,7 +133,18 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     const { module, name, min, max } = opts.importMemory;
     declareImportedMemory(mod, module, name, min, max);
   }
-  declareExternCImports(mod, opts.externImports ?? []);
+  const externImportIndices = declareExternCImports(mod, opts.externImports ?? []);
+  // The index lives here rather than only in funcMap because an ambient
+  // `declare function` of the same name is later registered as a user
+  // function and would overwrite the funcMap entry — silently retargeting the
+  // call at a body-less local slot with a TS-derived (f64) signature. Keeping
+  // the extern binding in its own map makes it authoritative.
+  const externImportSigs = new Map<string, { index: number; params: ValType[]; results: ValType[] }>();
+  for (const spec of opts.externImports ?? []) {
+    const index = externImportIndices.get(spec.name);
+    if (index === undefined) continue;
+    externImportSigs.set(spec.name, { index, params: [...spec.params], results: [...spec.results] });
+  }
   const allocationPolicy = linearAllocatorPolicy(opts.allocationPolicy ?? "arena-v1");
   const dataSegmentBase = numberFormat.addRuntime(mod, ast, opts.exposeArenaReset, DATA_SEGMENT_BASE);
 
@@ -177,7 +195,16 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     closureEnvGlobalIdx,
     moduleGlobals: new Map(),
     moduleCollectionTypes: new Map(),
+    externImportSigs: externImportSigs.size > 0 ? externImportSigs : undefined,
   };
+
+  // #4539 — extern imports are callable by name. They occupy indices [0, n),
+  // so registering them here lets the ordinary call path resolve them; the
+  // signature map drives boundary marshalling at each call site.
+  for (const spec of opts.externImports ?? []) {
+    const idx = externImportIndices.get(spec.name);
+    if (idx !== undefined) ctx.funcMap.set(spec.name, idx);
+  }
 
   // Register runtime functions in funcMap
   for (let i = 0; i < mod.functions.length; i++) {
@@ -1833,8 +1860,18 @@ export function compileExpression(ctx: LinearContext, fctx: LinearFuncContext, e
           fctx.body.push({ op: "local.get", index: localIdx }); // table index
           fctx.body.push({ op: "call_indirect", typeIdx: cbTypeIdx, tableIdx: 0 });
         } else {
+          // #4539 — an extern-C binding wins over any same-named local slot.
+          // A `declare function` is registered as a user function too, so
+          // consulting funcMap first would retarget the call at a body-less
+          // slot carrying a TS-derived signature.
+          const externSig = ctx.externImportSigs?.get(funcName);
           const funcIdx = ctx.funcMap.get(funcName);
-          if (funcIdx !== undefined) {
+          if (externSig !== undefined) {
+            // The declared C signature is authoritative and this backend's
+            // `number` is f64, so arguments and result convert at the
+            // boundary rather than being assumed to match.
+            emitExternCCall(ctx, fctx, expr, funcName, externSig.index, externSig);
+          } else if (funcIdx !== undefined) {
             for (const arg of expr.arguments) {
               compileCallArg(ctx, fctx, arg);
             }
@@ -5595,4 +5632,51 @@ function emitClosureSetup(
 
   // Push the table index as the i32 argument value
   fctx.body.push({ op: "i32.const", value: tableIdx });
+}
+
+/**
+ * Emit a call to an extern-C import, marshalling at the boundary (#4539).
+ *
+ * Arity is validated here rather than left to Wasm validation: a C callee is
+ * fixed-arity, and a mismatch caught at the call site names the function and
+ * the source location, where a validation failure would surface as an opaque
+ * "type mismatch" against a whole module.
+ */
+function emitExternCCall(
+  ctx: LinearContext,
+  fctx: LinearFuncContext,
+  expr: ts.CallExpression,
+  funcName: string,
+  funcIdx: number,
+  sig: { params: ValType[]; results: ValType[] },
+): void {
+  if (expr.arguments.length !== sig.params.length) {
+    ctx.errors.push({
+      message:
+        `extern-C import '${funcName}' takes ${sig.params.length} argument(s), ` +
+        `called with ${expr.arguments.length}. C imports are fixed-arity — ` +
+        "there are no defaults to fill in.",
+      ...nodeLoc(expr),
+    });
+    fctx.body.push({ op: "f64.const", value: 0 });
+    return;
+  }
+  try {
+    for (let i = 0; i < expr.arguments.length; i++) {
+      compileCallArg(ctx, fctx, expr.arguments[i]);
+      emitExternCBoundaryArg(fctx.body, sig.params[i]);
+    }
+    fctx.body.push({ op: "call", funcIdx });
+    // A void C function leaves nothing on the stack; the linear backend's
+    // expression positions always expect a value, so push the same `f64.const
+    // 0` the rest of the backend uses for a void result.
+    if (sig.results.length === 0) {
+      fctx.body.push({ op: "f64.const", value: 0 });
+    } else {
+      emitExternCBoundaryResult(fctx.body, sig.results[0]);
+    }
+  } catch (error) {
+    ctx.errors.push({ message: (error as Error).message, ...nodeLoc(expr) });
+    fctx.body.push({ op: "f64.const", value: 0 });
+  }
 }

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -5,6 +5,7 @@ import {
   LINEAR_STRING_PAYLOAD_PREFIX_BYTES,
   LINEAR_STRING_PAYLOAD_SIZE_OFFSET,
 } from "../ir/analysis/linear-memory-plan.js";
+import { hasImportedMemory } from "./c-abi.js";
 import { hashProbeAdvanceInstrs, hashProbeInitInstrs } from "./emit-idioms.js";
 import { isLinearStringLiteralCacheGlobal } from "./string-literals.js";
 
@@ -83,8 +84,14 @@ export interface ArenaOptions {
  */
 export function addRuntime(mod: WasmModule, opts: ArenaOptions = {}): void {
   const heapStart = opts.heapStart ?? HEAP_START;
-  // Add memory (1 page = 64 KiB, growable to 256 pages = 16 MiB)
-  if (mod.memories.length === 0) {
+  // Add memory (1 page = 64 KiB, growable to 256 pages = 16 MiB).
+  //
+  // #4539: skip this entirely when the module IMPORTS its memory. A module may
+  // not both define and import one, and when linking against an artifact that
+  // exports memory (the ADR-0020 topology) the artifact owns it. Re-exporting
+  // an imported memory is legal but deliberately not done here: the owner
+  // already exports it, and a second export invites two names for one memory.
+  if (mod.memories.length === 0 && !hasImportedMemory(mod)) {
     mod.memories.push({ min: 1, max: 256 });
     // Export memory so tests can inspect it
     mod.exports.push({

--- a/src/compiler/linear-options.ts
+++ b/src/compiler/linear-options.ts
@@ -12,5 +12,9 @@ export function buildLinearOptions(
     exposeArenaReset: options.allocator === "arena-reset",
     allocationPolicy: options.allocator === "analysis-stack" ? "analysis-stack-arena-v1" : "arena-v1",
     irInventoryOptions,
+    // #4539 — link topology. Both are undefined for every existing caller, so
+    // the emitted binary is unchanged unless a link is explicitly requested.
+    externImports: options.linearExternImports,
+    importMemory: options.linearImportMemory,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,8 @@ export interface ImportDescriptor {
 }
 
 export type { ExportBoundaryKind, ExportSignature, TypedArrayKind } from "./ir/types.js";
+import type { ExternCImportSpec as LinearExternCImportSpec } from "./codegen-linear/c-abi.js";
+export type { LinearExternCImportSpec };
 export type {
   HostImportInventoryEntry,
   HostImportInventorySummary,
@@ -898,6 +900,24 @@ export interface CompileOptions {
    * lifetime to the host GC and have no linear allocator.
    */
   allocator?: "bump" | "arena-reset" | "analysis-stack";
+  /**
+   * External C functions the emitted linear module imports (#4539).
+   *
+   * Linking against a C library — e.g. the pinned engine artifact of ADR-0020
+   * — requires the module to declare the functions it calls. Declared before
+   * any defined function so indices stay stable; omitting this leaves the
+   * emitted binary byte-identical.
+   *
+   * `linear` target only.
+   */
+  linearExternImports?: readonly LinearExternCImportSpec[];
+  /**
+   * Import linear memory from another module instead of defining one (#4539).
+   *
+   * Required when linking against an artifact that EXPORTS memory: both sides
+   * must address one memory and only one may own it. `linear` target only.
+   */
+  linearImportMemory?: { module: string; name: string; min: number; max?: number };
 }
 
 import * as path from "path";

--- a/src/index.ts
+++ b/src/index.ts
@@ -917,7 +917,19 @@ export interface CompileOptions {
    * Required when linking against an artifact that EXPORTS memory: both sides
    * must address one memory and only one may own it. `linear` target only.
    */
-  linearImportMemory?: { module: string; name: string; min: number; max?: number };
+  linearImportMemory?: {
+    module: string;
+    name: string;
+    min: number;
+    max?: number;
+    /**
+     * memory64 index type (#4554). The field exists so a 64-bit caller has
+     * somewhere to say so; `"i64"` is currently **refused** rather than
+     * accepted and ignored, which would emit 32-bit limits for a 64-bit
+     * memory.
+     */
+    indexType?: "i32" | "i64";
+  };
 }
 
 import * as path from "path";

--- a/tests/fixtures/linear-link/README.md
+++ b/tests/fixtures/linear-link/README.md
@@ -1,0 +1,24 @@
+# `peer.wasm` — a real C-compiled module for the #4539 link test
+
+`peer.c` is compiled to a **freestanding** wasm32 module (no libc, no WASI) so
+the linear backend's link topology can be proven against genuine C output
+rather than against JS stubs. It owns and exports a memory, exports two
+functions, and imports nothing.
+
+The bytes are embedded as base64 in `tests/issue-4539-c-link.test.ts` rather
+than committed as a binary: at ~529 bytes the encoding is small, it keeps the
+test deterministic on machines with no C toolchain, and the source plus the
+exact command below keep it auditable and regenerable.
+
+Regenerate:
+
+```bash
+clang --target=wasm32 -nostdlib -O2 \
+  -Wl,--no-entry -Wl,--export-memory -Wl,--export-all \
+  -o peer.wasm peer.c
+node -e 'console.log(require("fs").readFileSync("peer.wasm").toString("base64"))'
+```
+
+Built with Ubuntu clang 18.1.3; sha256 of the committed bytes starts `2899c9d1f50498cb`.
+A WASI sysroot is deliberately **not** required — freestanding is enough, which
+is what makes this test runnable where the full engine artifact build is not.

--- a/tests/fixtures/linear-link/peer.c
+++ b/tests/fixtures/linear-link/peer.c
@@ -1,0 +1,12 @@
+// Freestanding C peer for the #4539 link test. No libc, no WASI: it exists
+// only to be a REAL C-compiled wasm module that owns a memory and exports a
+// function, so the linear module is proven to link against C rather than
+// against JS stubs.
+__attribute__((export_name("c_double"))) int c_double(int x) { return x * 2; }
+
+// Touch linear memory so the module genuinely owns one, and give the test a
+// way to observe that both modules address the SAME bytes.
+__attribute__((export_name("c_poke"))) int c_poke(int addr, int value) {
+  *(int *)addr = value;
+  return *(int *)addr;
+}

--- a/tests/issue-4539-c-link.test.ts
+++ b/tests/issue-4539-c-link.test.ts
@@ -90,4 +90,89 @@ describe("#4539 — linking against a real C-compiled module", () => {
     expect(view.getInt32(addr, true)).toBe(0xabcd);
     expect((ours.instance.exports as { add?: unknown }).add).toBeTypeOf("function");
   });
+
+  it("compiled TypeScript CALLS a C function and gets its result", async () => {
+    const peer = await WebAssembly.instantiate(peerBytes(), {});
+    const px = peer.instance.exports as {
+      memory: WebAssembly.Memory;
+      c_double: (x: number) => number;
+    };
+
+    // Nested calls on purpose: the result of one extern call feeds the next,
+    // so the outbound and inbound boundary conversions must compose.
+    const result = await compile(
+      `declare function c_double(x: number): number;
+export function quadruple(n: number): number { return c_double(c_double(n)); }`,
+      {
+        target: "linear",
+        linearImportMemory: { module: "cpeer", name: "memory", min: 2 },
+        linearExternImports: [
+          { module: "cpeer", name: "c_double", params: [{ kind: "i32" }], results: [{ kind: "i32" }] },
+        ],
+      } as never,
+    );
+    expect(result.errors ?? []).toEqual([]);
+
+    const ours = await WebAssembly.instantiate(result.binary, {
+      cpeer: { memory: px.memory, c_double: px.c_double },
+    });
+    const quadruple = (ours.instance.exports as { quadruple?: (n: number) => number }).quadruple;
+    expect(quadruple?.(5)).toBe(20);
+    expect(quadruple?.(0)).toBe(0);
+    expect(quadruple?.(-3)).toBe(-12);
+  });
+
+  it("a two-argument C call from compiled code writes into the shared memory", async () => {
+    const peer = await WebAssembly.instantiate(peerBytes(), {});
+    const px = peer.instance.exports as {
+      memory: WebAssembly.Memory;
+      c_poke: (addr: number, value: number) => number;
+    };
+
+    const result = await compile(
+      `declare function c_poke(addr: number, value: number): number;
+export function poke(addr: number, value: number): number { return c_poke(addr, value); }`,
+      {
+        target: "linear",
+        linearImportMemory: { module: "cpeer", name: "memory", min: 2 },
+        linearExternImports: [
+          {
+            module: "cpeer",
+            name: "c_poke",
+            params: [{ kind: "i32" }, { kind: "i32" }],
+            results: [{ kind: "i32" }],
+          },
+        ],
+      } as never,
+    );
+    expect(result.errors ?? []).toEqual([]);
+
+    const ours = await WebAssembly.instantiate(result.binary, {
+      cpeer: { memory: px.memory, c_poke: px.c_poke },
+    });
+    const poke = (ours.instance.exports as { poke?: (a: number, v: number) => number }).poke;
+
+    // Compiled code -> C -> linear memory, observed from the host. Argument
+    // order surviving is the point: a reversed marshal would write the value
+    // as an address and trap or corrupt.
+    const addr = px.memory.buffer.byteLength - 16;
+    expect(poke?.(addr, 0x1234)).toBe(0x1234);
+    expect(new DataView(px.memory.buffer).getInt32(addr, true)).toBe(0x1234);
+  });
+
+  it("an arity mismatch is a compile error that names the function", async () => {
+    const result = await compile(
+      `declare function c_double(x: number): number;
+export function bad(n: number): number { return c_double(n, n); }`,
+      {
+        target: "linear",
+        linearExternImports: [
+          { module: "cpeer", name: "c_double", params: [{ kind: "i32" }], results: [{ kind: "i32" }] },
+        ],
+      } as never,
+    );
+    const messages = (result.errors ?? []).map((e) => e.message).join(" | ");
+    expect(messages).toContain("c_double");
+    expect(messages).toContain("fixed-arity");
+  });
 });

--- a/tests/issue-4539-c-link.test.ts
+++ b/tests/issue-4539-c-link.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4539 — link the linear backend against a REAL C-compiled wasm module.
+//
+// tests/issue-4539.test.ts links against JS stubs, which proves the import
+// section decodes and indices survive. It does NOT prove we can link against C
+// output, which is the entire point of the topology (ADR-0020's engine
+// artifact is a C library). This test closes that gap with a freestanding
+// wasm32 module built by clang — no libc, no WASI sysroot — so it runs
+// anywhere, unlike the full engine-artifact build.
+//
+// The bytes below are `tests/fixtures/linear-link/peer.c` compiled with the
+// exact command in that directory's README. Source + command are committed;
+// see the README to regenerate.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const PEER_WASM_B64 =
+  "AGFzbQEAAAABDwNgAABgAX8Bf2ACf38BfwMEAwABAgQFAXABAQEFAwEAAgY/Cn8BQYCIBAt/AEGACAt/AEGACAt/AEGACAt/AEGAiAQLfwBBgAgLfwBBgIgEC38AQYCACAt/AEEAC38AQQELB9EBDgZtZW1vcnkCABFfX3dhc21fY2FsbF9jdG9ycwAACGNfZG91YmxlAAEGY19wb2tlAAIZX19pbmRpcmVjdF9mdW5jdGlvbl90YWJsZQEADF9fZHNvX2hhbmRsZQMBCl9fZGF0YV9lbmQDAgtfX3N0YWNrX2xvdwMDDF9fc3RhY2tfaGlnaAMEDV9fZ2xvYmFsX2Jhc2UDBQtfX2hlYXBfYmFzZQMGCl9faGVhcF9lbmQDBw1fX21lbW9yeV9iYXNlAwgMX190YWJsZV9iYXNlAwkKGAMCAAsHACAAQQF0CwsAIAAgATYCACABCwBNBG5hbWUACglwZWVyLndhc20BJgMAEV9fd2FzbV9jYWxsX2N0b3JzAQhjX2RvdWJsZQIGY19wb2tlBxIBAA9fX3N0YWNrX3BvaW50ZXIAOAlwcm9kdWNlcnMBDHByb2Nlc3NlZC1ieQEMVWJ1bnR1IGNsYW5nETE4LjEuMyAoMXVidW50dTEpACwPdGFyZ2V0X2ZlYXR1cmVzAisPbXV0YWJsZS1nbG9iYWxzKwhzaWduLWV4dA==";
+
+const SRC = `export function add(a: number, b: number): number { return a + b; }`;
+
+function peerBytes(): Uint8Array {
+  return Uint8Array.from(Buffer.from(PEER_WASM_B64, "base64"));
+}
+
+describe("#4539 — linking against a real C-compiled module", () => {
+  it("the fixture really is a C module that owns a memory and imports nothing", async () => {
+    const mod = new WebAssembly.Module(peerBytes());
+    // If this ever starts importing something, it stopped being a standalone
+    // C peer and the test below would be proving something weaker.
+    expect(WebAssembly.Module.imports(mod)).toEqual([]);
+    const exports = WebAssembly.Module.exports(mod);
+    expect(exports.some((e) => e.kind === "memory" && e.name === "memory")).toBe(true);
+    expect(exports.some((e) => e.kind === "function" && e.name === "c_double")).toBe(true);
+  });
+
+  it("a linear module imports the C module's memory and functions, and runs", async () => {
+    const peer = await WebAssembly.instantiate(peerBytes(), {});
+    const peerExports = peer.instance.exports as {
+      memory: WebAssembly.Memory;
+      c_double: (x: number) => number;
+      c_poke: (addr: number, value: number) => number;
+    };
+
+    const result = await compile(SRC, {
+      target: "linear",
+      linearImportMemory: { module: "cpeer", name: "memory", min: 2 },
+      linearExternImports: [
+        { module: "cpeer", name: "c_double", params: [{ kind: "i32" }], results: [{ kind: "i32" }] },
+      ],
+    } as never);
+    expect(result.errors ?? []).toEqual([]);
+
+    // The real assertion: our emitted binary instantiates against exports of a
+    // module clang produced. A signature mismatch or a bad index fails here.
+    const ours = await WebAssembly.instantiate(result.binary, {
+      cpeer: { memory: peerExports.memory, c_double: peerExports.c_double },
+    });
+    const add = (ours.instance.exports as { add?: (a: number, b: number) => number }).add;
+    expect(add?.(2, 3)).toBe(5);
+  });
+
+  it("both modules address the same linear memory", async () => {
+    const peer = await WebAssembly.instantiate(peerBytes(), {});
+    const peerExports = peer.instance.exports as {
+      memory: WebAssembly.Memory;
+      c_poke: (addr: number, value: number) => number;
+    };
+
+    const result = await compile(SRC, {
+      target: "linear",
+      linearImportMemory: { module: "cpeer", name: "memory", min: 2 },
+    } as never);
+    const ours = await WebAssembly.instantiate(result.binary, {
+      cpeer: { memory: peerExports.memory },
+    });
+
+    // Write through the C module, observe through the memory object our module
+    // was instantiated with — same object, therefore same bytes.
+    //
+    // The address is picked from the live buffer's end rather than hard-coded:
+    // the peer owns this memory and its size is its business, and a hard-coded
+    // offset either traps (too high) or lands in its data/stack (too low).
+    // Needing to reason about that at all is exactly the hazard #4540 exists
+    // to remove.
+    const addr = peerExports.memory.buffer.byteLength - 8;
+    peerExports.c_poke(addr, 0xabcd);
+    const view = new DataView(peerExports.memory.buffer);
+    expect(view.getInt32(addr, true)).toBe(0xabcd);
+    expect((ours.instance.exports as { add?: unknown }).add).toBeTypeOf("function");
+  });
+});

--- a/tests/issue-4539-c-link.test.ts
+++ b/tests/issue-4539-c-link.test.ts
@@ -175,4 +175,68 @@ export function bad(n: number): number { return c_double(n, n); }`,
     expect(messages).toContain("c_double");
     expect(messages).toContain("fixed-arity");
   });
+
+  it("an address KIND resolves to the target width and links (#4554)", async () => {
+    const peer = await WebAssembly.instantiate(peerBytes(), {});
+    const px = peer.instance.exports as {
+      memory: WebAssembly.Memory;
+      c_double: (x: number) => number;
+    };
+
+    // Declared by ROLE, not width. On wasm32 `handle` is i32, so this must
+    // produce the byte-identical import a literal i32 would — the point being
+    // that a memory64 target changes one model, not every call site.
+    const result = await compile(
+      `declare function c_double(x: number): number;
+export function twice(n: number): number { return c_double(n); }`,
+      {
+        target: "linear",
+        linearImportMemory: { module: "cpeer", name: "memory", min: 2 },
+        linearExternImports: [
+          {
+            module: "cpeer",
+            name: "c_double",
+            params: [{ address: "handle" }],
+            results: [{ address: "handle" }],
+          },
+        ],
+      } as never,
+    );
+    expect(result.errors ?? []).toEqual([]);
+
+    const ours = await WebAssembly.instantiate(result.binary, {
+      cpeer: { memory: px.memory, c_double: px.c_double },
+    });
+    const twice = (ours.instance.exports as { twice?: (n: number) => number }).twice;
+    expect(twice?.(21)).toBe(42);
+  });
+
+  it("an address kind emits the same bytes as the literal it resolves to", async () => {
+    const opts = (params: unknown) =>
+      ({
+        target: "linear",
+        linearExternImports: [{ module: "cpeer", name: "c_double", params, results: params }],
+      }) as never;
+    const viaLiteral = await compile(SRC, opts([{ kind: "i32" }]));
+    const viaRole = await compile(SRC, opts([{ address: "handle" }]));
+    expect(Buffer.from(viaRole.binary).equals(Buffer.from(viaLiteral.binary))).toBe(true);
+  });
+
+  it("refuses a memory64 index type instead of emitting 32-bit limits (#4554)", async () => {
+    // Accepting `i64` and ignoring it would produce a module that instantiates
+    // and then addresses the wrong memory — the failure this refusal exists to
+    // prevent. Loud beats silently-wrong.
+    //
+    // It surfaces as a compile DIAGNOSTIC rather than a thrown exception, which
+    // is the better shape: the caller gets `success: false` and a message
+    // naming the limitation, in the same channel as every other codegen error.
+    const result = await compile(SRC, {
+      target: "linear",
+      linearImportMemory: { module: "cpeer", name: "memory", min: 2, indexType: "i64" },
+    } as never);
+    expect(result.success).toBe(false);
+    const messages = (result.errors ?? []).map((e) => e.message).join(" | ");
+    expect(messages).toMatch(/memory64/i);
+    expect(messages).toContain("#4554");
+  });
 });

--- a/tests/issue-4539.test.ts
+++ b/tests/issue-4539.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4539 — linear lane link topology: the module can declare external C imports
+// and import its memory instead of defining one.
+//
+// The point of these tests is that the emitted binary genuinely LINKS in a real
+// engine, not merely that a declaration table type-checks. Every case
+// instantiates the module against a host-provided memory and imported
+// functions; a wrong function index or a module that both defines and imports
+// memory fails instantiation rather than passing quietly.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const SRC = `export function add(a: number, b: number): number { return a + b; }`;
+
+async function build(opts: Record<string, unknown>) {
+  const result = await compile(SRC, { target: "linear", ...opts } as never);
+  expect(result.errors ?? []).toEqual([]);
+  expect(result.binary).toBeInstanceOf(Uint8Array);
+  return result.binary;
+}
+
+/** Decode the import section names/kinds straight from the binary. */
+function importsOf(bytes: Uint8Array): { module: string; name: string; kind: number }[] {
+  const mod = new WebAssembly.Module(bytes);
+  return WebAssembly.Module.imports(mod).map((i) => ({
+    module: i.module,
+    name: i.name,
+    kind: i.kind === "function" ? 0 : i.kind === "memory" ? 2 : -1,
+  }));
+}
+
+describe("#4539 — linear link topology", () => {
+  it("emits no imports and defines its own memory by default (unchanged behaviour)", async () => {
+    const bytes = await build({});
+    expect(importsOf(bytes)).toEqual([]);
+    const mod = new WebAssembly.Module(bytes);
+    // Memory is defined AND exported by the module itself.
+    expect(WebAssembly.Module.exports(mod).some((e) => e.kind === "memory")).toBe(true);
+  });
+
+  it("declares external C imports, and the module instantiates against them", async () => {
+    const bytes = await build({
+      linearExternImports: [
+        {
+          module: "qjs",
+          name: "qjs_tag",
+          params: [{ kind: "i32" }],
+          results: [{ kind: "i32" }],
+          ownership: "borrows",
+        },
+        {
+          module: "qjs",
+          name: "qjs_malloc_raw",
+          params: [{ kind: "i32" }],
+          results: [{ kind: "i32" }],
+        },
+      ],
+    });
+    const imports = importsOf(bytes);
+    expect(imports.map((i) => `${i.module}.${i.name}`)).toEqual(["qjs.qjs_tag", "qjs.qjs_malloc_raw"]);
+
+    // The real proof: it links and its own exports still work, which they
+    // cannot if the import shift corrupted function indices.
+    const instance = await WebAssembly.instantiate(bytes, {
+      qjs: { qjs_tag: () => 0, qjs_malloc_raw: () => 0 },
+    });
+    const add = (instance.instance.exports as { add?: (a: number, b: number) => number }).add;
+    expect(typeof add).toBe("function");
+    expect(add?.(2, 3)).toBe(5);
+  });
+
+  it("imports memory instead of defining one, and shares the host's memory", async () => {
+    const bytes = await build({
+      linearImportMemory: { module: "qjs", name: "memory", min: 2, max: 16384 },
+    });
+    const imports = importsOf(bytes);
+    expect(imports).toEqual([{ module: "qjs", name: "memory", kind: 2 }]);
+
+    const mod = new WebAssembly.Module(bytes);
+    // It must NOT also define/export its own memory — one memory, one owner.
+    expect(WebAssembly.Module.exports(mod).some((e) => e.kind === "memory")).toBe(false);
+
+    const memory = new WebAssembly.Memory({ initial: 2, maximum: 16384 });
+    const instance = await WebAssembly.instantiate(bytes, { qjs: { memory } });
+    const add = (instance.instance.exports as { add?: (a: number, b: number) => number }).add;
+    expect(add?.(40, 2)).toBe(42);
+  });
+
+  it("combines an imported memory with imported functions, indices intact", async () => {
+    const bytes = await build({
+      linearImportMemory: { module: "qjs", name: "memory", min: 2 },
+      linearExternImports: [
+        {
+          module: "qjs",
+          name: "qjs_tag",
+          params: [{ kind: "i32" }],
+          results: [{ kind: "i32" }],
+        },
+      ],
+    });
+    const memory = new WebAssembly.Memory({ initial: 2 });
+    const instance = await WebAssembly.instantiate(bytes, {
+      qjs: { memory, qjs_tag: () => 7 },
+    });
+    const add = (instance.instance.exports as { add?: (a: number, b: number) => number }).add;
+    expect(add?.(1, 1)).toBe(2);
+  });
+
+  it("dedupes a repeated import rather than emitting it twice", async () => {
+    const spec = {
+      module: "qjs",
+      name: "qjs_tag",
+      params: [{ kind: "i32" }],
+      results: [{ kind: "i32" }],
+    };
+    const bytes = await build({ linearExternImports: [spec, spec] });
+    expect(importsOf(bytes)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Description

First slice of [#4538](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4538-linear-native-binaries-dynamic-tier-umbrella): [#4539](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4539-linear-lane-import-direction-and-memory) in full, plus tier 1 of [#4554](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4554-linear-address-domain-wasm64-ready).

The linear backend could not link against anything: it modelled only the **export** direction, hard-coded `numImportFuncs` to `0`, and unconditionally defined + exported its own memory. All three are prerequisites for linking against a C library — the ADR-0020 engine artifact.

```ts
declare function c_double(x: number): number;
export function quadruple(n: number): number { return c_double(c_double(n)); }
```

compiles, links against a clang-built module, and returns `20` for `5`.

## Topology (#4539)

- **`c-abi.ts` gains the import direction**: `ExternCImportSpec`, `declareExternCImports` (interns func types, dedupes, returns name → index), `declareImportedMemory` / `hasImportedMemory`.
- **Ordering is enforced, not documented.** A function&#39;s index is `numImportFuncs + position`, so declaring an import after any function exists would shift every index. `declareExternCImports` **throws** rather than silently corrupt them. The WasmGC lane&#39;s late `addUnionImports` index-shifting is deliberately not replicated.
- **`ownership` on each spec** (`"borrows" | "consumes"`) — a hand-written summary for foreign code the analysis cannot see, which [#4542](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4542-linear-refcount-handle-scope-pass)&#39;s handle-scope pass consumes. Deliberately **not** defaulted: a wrong default is a leak or a double-free.
- **`index.ts`** declares imports first and derives `numImportFuncs` from the module instead of hard-coding `0`; **`runtime.ts`** skips defining memory when one is imported.
- Reachable from the public API (`CompileOptions.linearExternImports` / `linearImportMemory`).

## Calls, marshalled at the boundary (#4539)

This backend compiles a TS `number` to **f64**, while a C signature declares what it declares — typically `i32`. `emitExternCBoundaryArg` / `emitExternCBoundaryResult` convert per declared type rather than assuming a match, and reject reference types with a message saying why.

**Two defects found while building this, both silent-miscompile class:**

1. An ambient `declare function` is **also** registered as a user function, so a `funcMap` lookup retargeted the call at a body-less local slot carrying a TS-derived (f64) signature. Caught as `call[0] expected type f64, found i32.trunc_f64_s`. The extern binding now lives in its own map, consulted **first**. The JS-stub tests could never have caught it — it only appears once a real call is emitted.
2. **Arity is validated at the call site.** A C callee is fixed-arity; without the check a mismatch surfaced as an opaque validation error against the whole module instead of naming the function and its line.

## Address domain — tier 1 (#4554)

Pointers, sizes and handles are `i32` because the **target** is wasm32, not because they are inherently 32-bit. Landing this now because the window closes: `ExternCImportSpec` has no callers outside its tests today and becomes public API on merge.

- `AddressKind` (`"ptr" | "size" | "handle"`) usable anywhere an extern type is written, resolved through a single `LinearAddressModel`; `WASM32_ADDRESS_MODEL` maps all three to `i32`.
- **A test asserts a role-declared import emits byte-identical output to the literal it resolves to** — the abstraction is proven inert, not assumed to be. That is what makes a memory64 port a model change rather than a rewrite.
- `declareImportedMemory` takes an `indexType` and **refuses `"i64"`**, as a compile diagnostic naming the limitation. Accepting and ignoring it would emit 32-bit limits for a 64-bit memory: a module that instantiates and then addresses the wrong bytes.

**Not an adoption of memory64** — it is often slower on today&#39;s engines (64-bit bounds checks cannot use the 4 GiB guard-page trick) and wider pointers cost cache. This only stops foreclosing it. Tier 2 (the domain across the value model) belongs in the IR / `LinearEmitter`, not the direct backend.

## Tests link against real C, not stubs

`tests/issue-4539-c-link.test.ts` uses a **freestanding** wasm32 module produced by clang — no libc, no WASI sysroot, so it runs where the full engine-artifact build cannot (the toolchain gap that blocked the #4236 spike).

- the fixture really is a standalone C module (`imports === []`, exports a memory) — the test cannot silently decay into proving something weaker;
- our binary instantiates against clang&#39;s exports and its own exports still work;
- both modules address the same memory;
- **nested extern calls** (`quadruple(5) === 20`) — outbound and inbound conversions compose;
- **a two-argument call** observed in shared memory — argument order survives the marshal;
- the arity error names the function;
- an address **kind** links end-to-end and emits identical bytes to the literal;
- the memory64 refusal fires.

Source (`tests/fixtures/linear-link/peer.c`), the exact clang command and a sha256 prefix are committed; the 529 bytes are embedded as base64 so the test stays deterministic without a C toolchain.

**14 tests across the two #4539 files.**

## Existing output is unchanged — proven, not asserted

Every new option is `undefined` for existing callers. `prove-emit-identity check` reports **all 60 (file,target) emits identical** to a baseline captured **before the first edit**.

## Known limitation, documented rather than left to be discovered

The boundary conversion assumes the argument expression produced f64 — true for ordinary `number` expressions, false for values already in i32 form via native type annotations. That needs the expression-level type tracking the direct backend lacks, and is #4554 tier 2. Recorded in `c-abi.ts` at the conversion itself.

## Still gated

[#4540](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4540-linear-heap-coexistence-arena-relocation) blocks any end-to-end link against the **real engine artifact**: its first `malloc` returns 171,696 while `__heap_ptr` starts at 1024 — inside its shadow stack. The C-peer tests dodge this only because the peer&#39;s memory is larger than our arena ever touches.

## Pre-existing failure, NOT caused by this change

`check:linear-ir` fails on **clean `main`**: IR-compiled count 8 → 6, with `illegal:instr-vec.set_length` and `select:string-builder-candidate` each 0 → 2. Verified by reverting the patch and re-running on base. Reported rather than silenced with `--update`, which would bank a real regression into the baseline. Those two reasons also appeared while measuring #4550.

## Validation

- `npm run typecheck` — clean
- `vitest run tests/issue-4539*.test.ts` — 14/14
- `prove-emit-identity check` — 60/60 identical
- `prettier --check` + `biome lint --diagnostic-level=error` on changed files
- `check-loc-budget` — passes with the allowance granted in the issue frontmatter

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unchecked deliberately: an agent should not attest to a legal agreement on the author's behalf. -->