### PR TITLE
fix(ci): retry transient API failures in cla-check; docs: #4540 two-memory alternative

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -115,6 +115,16 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           github-token: ${{ github.token }}
+          # Retry transient GitHub API failures. Without this, github-script
+          # defaults to `retries: 0`, so ONE 503 on the commit-status POST fails
+          # this REQUIRED check even though the CLA decision itself succeeded.
+          # Observed twice on PR #4645 (2026-08-17, edge regions `sea` then
+          # `westus3`): the log shows the gate resolving "Author … is exempt
+          # (allowlist); CLA not required." and then dying on
+          # `POST /repos/…/statuses/…` with 503 — the verdict was computed and
+          # only the write failed. 503 is not in `retry-exempt-status-codes`
+          # (400,401,403,404,422), so it is retried by this setting.
+          retries: 3
           script: |
             const gate = await import(`${process.env.GITHUB_WORKSPACE}/.github/cla/cla-gate.mjs`);
             const fs = require("node:fs");

--- a/plan/issues/4540-linear-heap-coexistence-arena-relocation.md
+++ b/plan/issues/4540-linear-heap-coexistence-arena-relocation.md
@@ -103,6 +103,81 @@ straight at the engine's `malloc` (simplest, one allocator, but typed data
 loses the bump path and pays dlmalloc per allocation — which is exactly what
 ADR-0017 chose the arena to avoid).
 
+## The alternative this slice does not currently consider: two memories
+
+Everything above assumes **one** linear memory and then works to make two
+allocators coexist inside it. Multi-memory removes that problem rather than
+solving it: the engine keeps memory 0, our arena moves to memory 1, and there
+are two address spaces, so a collision cannot occur by construction and the
+arena keeps ADR-0017's zero-metadata bump path untouched.
+
+This is worth costing before the single-memory design is built, because the two
+options trade opposite things.
+
+**Why it fits this codebase better than it looks.** ADR-0020 already requires
+that `JSValue` be **opaque** and that all manipulation go through the C API.
+That *is* the accessor discipline — we never dereference engine memory
+directly, so almost nothing we do needs to see memory 0. And the arena is
+precisely the data that never needs to be visible to the engine: it holds our
+compiled program's typed, statically-planned values.
+
+**What it costs.** Payloads that genuinely cross — a string handed to
+`JS_NewStringLen`, an array we ask the engine to wrap — must live in the memory
+the engine can read. Under one memory we can build them in the arena and pass
+the pointer; under two we must allocate from the engine's `malloc` and copy
+into it. So multi-memory removes the coexistence hazard and reintroduces a copy
+at exactly the boundary where data crosses. The single-memory design has the
+mirror-image tradeoff. Neither is free, and which is cheaper is an empirical
+question about how much data actually crosses the seam in real workloads.
+
+**The security argument, which this issue does not currently weigh.** One
+shared memory means the engine can read and write our arena, and vice versa.
+That matters more here than in a generic two-module link, because the engine's
+whole purpose in ADR-0020 is to execute **`eval`** — attacker-controlled input
+by design. Under one memory, an exploited engine bug reaches our compiled
+program's data; under two, it does not. #4539's `declareImportedMemory` gives
+up the inter-module sandbox deliberately, and that is a defensible trade for a
+trusted peer — it is a different trade when the peer is running untrusted
+source.
+
+**Prior art, with the discussion.** This is the design in
+[WebAssembly/component-model#626](https://github.com/WebAssembly/component-model/issues/626)
+("intra-module sandboxing"): after a multi-memory merge, an accessor exported
+by one module carries the other's memory index as a **static immediate**, so
+post-merge inlining reduces it to a direct load — the boundary is enforced
+pre-merge and erased by inlining, at no runtime cost. Two findings from that
+thread bear directly on this slice:
+
+- **Bounds checking is not optional.** lukewagner's objection: an accessor
+  taking a raw `i32` and loading indiscriminately lets the caller read anywhere
+  in the callee's memory, which is "roughly equivalent to importing its linear
+  memory" — the sandbox is nominal. A region must carry its length and the
+  accessor must check, statically for fixed-size regions and dynamically
+  otherwise. He argues handles-plus-call-scoped-lifetimes converges on lazy
+  lowering; cfallin (Cranelift) disagrees explicitly, holding that an
+  unforgeable resource handle with primitive-wise accessors is "not covered by
+  lazy lowering" and fills a niche no other zero-copy mechanism does — the same
+  shape Wasmtime's compile-time builtins target. That disagreement is unresolved
+  upstream; we do not need to resolve it, but we should not assume either
+  answer.
+- **The bulk-data gap is the known weak point**, and it is the same one we hit
+  above: per-element accessors lose to a single `memory.copy`. The upstream
+  answers are explicit bulk methods, region borrows
+  ([#568](https://github.com/WebAssembly/component-model/issues/568)'s
+  `mappableref`, [#383](https://github.com/WebAssembly/component-model/issues/383)
+  lazy lowering), or optimizer recovery of sequential accessor loops.
+
+**What would need building here**: multi-memory emission in
+`src/codegen-linear/` (today `declareImportedMemory` asserts the module defines
+no memory, and the emitter assumes a single one), memory-index immediates in
+our own arena accesses, and a measured comparison of the cross-boundary copy
+against the single-memory design. Engine/runtime multi-memory support on our
+target matrix needs verifying rather than assuming.
+
+**This is recorded as an option, not a recommendation.** The single-memory
+allocator-unification design above may well still win on the numbers. What it
+should not do is win by default because the alternative was never written down.
+
 ## Acceptance criteria
 
 - [ ] A linked module allocates, writes, and reads without touching any byte it
@@ -123,6 +198,11 @@ ADR-0017 chose the arena to avoid).
       allocation directly at the engine's `malloc`, and the choice is recorded
       with both numbers — ADR-0017's zero-metadata bump path is the thing
       being traded, so the trade needs a figure.
+- [ ] The **two-memory** alternative is explicitly decided, not defaulted past:
+      record whether it was rejected on the cross-boundary copy cost, on
+      toolchain/runtime support, or on measurement — and state the security
+      consequence accepted by staying on one memory, given the engine executes
+      `eval` input.
 
 ## Validation
 


### PR DESCRIPTION
## Description

Two independent changes. The CI fix was forced by this PR's own CI failing twice.

### 1. `fix(ci)` — one transient 503 currently reds a required check

`cla-check` failed twice on this PR **with the CLA decision already made**. Both job logs show the same shape:

```
PR #4645 author=ttraenkler cla_version=sha256:acaf2182ce49
Author ttraenkler is exempt (allowlist); CLA not required.
RequestError [HttpError]: No server is currently available ... status: 503
POST https://api.github.com/repos/loopdive/js2wasm/statuses/0b075e3a6
body: {"state":"success","context":"cla-check","description":"CLA not required (allowlist)."}
```

The gate computed the right answer and died writing it. Two different edge regions (`sea`, then `westus3`), so GitHub's status API was having a bad patch — **but the reason a transient 503 becomes a red required check is ours**: `actions/github-script` defaults to `retries: 0` (visible in the job log's own input dump) and nothing in this repo sets it. `cla-check.yml` is the only workflow using github-script, so that's the whole exposure — but it applies to every PR in the repo: any of them is one transient 503 away from a required check clearable only by a manual re-run.

`retries: 3` is github-script's own mechanism, and 503 is not in `retry-exempt-status-codes` (`400,401,403,404,422`), so it's covered. The CLA decision logic is untouched; a genuine failure after retries still fails the job.

Re-running was the right *first* response — the check body had run and passed, only the publish failed. A second identical failure makes it a configuration defect rather than flake, so it gets fixed instead of re-run again.

Verified: YAML parses, step resolves to `actions/github-script@v8` with `retries: 3`.

### 2. `docs` — record the two-memory alternative in #4540

Adds a section to [#4540](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4540-linear-heap-coexistence-arena-relocation), which assumes **one** linear memory and then works to make two allocators coexist inside it. Multi-memory dissolves that problem rather than solving it: engine keeps memory 0, arena moves to memory 1, collision impossible by construction, ADR-0017's bump path untouched.

- **Fits better than it looks** — ADR-0020 already requires `JSValue` to be opaque with all manipulation through the C API. That *is* the accessor discipline, and the arena is exactly the data the engine never needs to see.
- **Costs a copy** for payloads that genuinely cross (a string handed to `JS_NewStringLen`). Mirror-image tradeoff; which is cheaper is empirical.
- **The security argument #4540 doesn't weigh** — the engine's purpose under ADR-0020 is to execute `eval`, i.e. attacker-controlled input. #4539's `declareImportedMemory` gives up the inter-module sandbox deliberately; that's defensible for a trusted peer and a different trade when the peer runs untrusted source.

Prior art recorded with its discussion ([component-model#626](https://github.com/WebAssembly/component-model/issues/626)), including that an unchecked accessor is "roughly equivalent to importing its linear memory" (lukewagner), that he and cfallin **disagree** on whether handles + accessors reduce to lazy lowering, and that the bulk-data gap is the known weak point ([#568](https://github.com/WebAssembly/component-model/issues/568) `mappableref`, [#383](https://github.com/WebAssembly/component-model/issues/383)).

Recorded as an option, not a recommendation, plus an acceptance criterion so it's explicitly **decided** rather than defaulted past.

## CLA

- [x] I have read and agree to the CLA