### PR TITLE
release: v0.70.0

### DIFF
--- a/docs/release-notes/v0.70.0.md
+++ b/docs/release-notes/v0.70.0.md
@@ -1,0 +1,57 @@
+# v0.70.0
+
+Lockstep release of `@loopdive/js2` and the `js2wasm` proxy: 0.69.0 → 0.70.0.
+
+A minor bump: **153 features and 281 fixes** land here, with **no breaking
+changes** — neither a `!:` subject nor a `BREAKING CHANGE` trailer appears in the
+range.
+
+## Conformance
+
+test262 moves **31,651 → 32,615 passing (+964)**.
+
+Read the percentage carefully: **72.8% → 74.8%**, but the denominator moved too,
+from 43,505 to 43,621 tests. The suite itself grew by 116 cases over the range,
+so the two percentages are not measured against the same corpus. The pass-count
+delta is the like-for-like figure.
+
+Both endpoints come from `benchmarks/results/test262-current.json`, read at the
+`v0.69.0` tag and at this release commit.
+
+## Highlights
+
+**IR front-end (68 changes)** — the largest single area. Work continued toward
+making the typed IR the only path for the node kinds it covers, including the
+dialect split that separates the JS dialect from the shared core, and feeding
+module-binding storage edges into the prepared-owner fixpoint.
+
+**Linear backend** — the linear-memory lowering gained a real link topology:
+extern-C imports and imported memory, calls marshalled at the boundary, and
+addresses declared by role rather than by width.
+
+**ES5 semantics and the property MOP** — a long run of descriptor, coercion and
+enumeration fixes: own-property views consulting the NativeProto companion via
+receiver substitution, inherited-accessor `[[Set]]` chain walks, and
+`this.p` ⇄ module-global routing unified across all three read/write paths.
+
+**npm package compatibility** — dogfooding real packages (25 changes) plus
+per-package compile/validate/test/perf reporting, now benchmarking every curated
+package.
+
+## Detail
+
+The full log is 945 human-authored commits across 100+ scopes, most active:
+`ir` (68), `ci` (49), `codegen` (46), `dogfood` (25), `issues` (21),
+`npm-compat` (17), `es5` (16). 191 issues are referenced. A further 412
+automated baseline and artifact-refresh commits are excluded from these counts.
+
+For the complete list, see the compare view:
+<https://github.com/loopdive/js2wasm/compare/v0.69.0...v0.70.0>
+
+## Install
+
+```bash
+npm install @loopdive/js2@0.70.0
+# or the unscoped proxy
+npm install js2wasm@0.70.0
+```

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.69.0"
+    "@loopdive/js2": "0.70.0"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
## Description

Lockstep version bump 0.69.0 → **0.70.0** across `@loopdive/js2`, the `js2wasm` proxy (and its `@loopdive/js2` dependency pin), and `jsr.json`, plus the curated release notes. Cut with `node scripts/release.mjs 0.70.0` from a clean tree at `origin/main` — no hand-written tag.

The `v0.70.0` tag exists **locally only** and is deliberately not pushed: `publish-npm.yml` fires on any `v*` tag push, so pushing before this merges would publish un-reviewed code.

### Why minor

153 features and 281 fixes since `v0.69.0`, and **no breaking changes** — no `!:` subject and no `BREAKING CHANGE` trailer anywhere in the 1,676-commit range.

### Conformance

test262 **31,651 → 32,615 passing (+964)**, both endpoints read from `benchmarks/results/test262-current.json` at the `v0.69.0` tag and at this release commit.

The percentage moves 72.8% → 74.8%, but the **denominator moved too** (43,505 → 43,621; the suite grew by 116 cases), so those two percentages are not measured against the same corpus. The pass-count delta is the like-for-like figure. The release notes say this explicitly rather than quoting the percentage alone.

### What's in the diff

| file | change |
| --- | --- |
| `package.json` | 0.69.0 → 0.70.0 |
| `packages/js2wasm/package.json` | version **and** the `@loopdive/js2` dependency pin |
| `jsr.json` | 0.70.0 (its own version field, published to JSR) |
| `docs/release-notes/v0.70.0.md` | curated notes |

All four are what `release.mjs` stages. `verify-version` checks the first three against the tag; replicated locally, it would pass.

The generated notes were a 1,371-line dump of every commit subject in the range. They've been rewritten to 57 lines — conformance with its caveat, the four substantial areas (IR front-end, linear backend, ES5/property MOP, npm compatibility), and a compare link for the full log.

## Merging and publishing

This PR only lands the bump. Publishing is a separate, deliberate step afterwards:

1. Merge this PR.
2. Verify the tagged commit is reachable from `main` (`git merge-base --is-ancestor v0.70.0^{commit} origin/main`) — the tag is on a branch commit and stays valid only because the queue uses merge commits.
3. `git push origin refs/tags/v0.70.0:refs/tags/v0.70.0`, then confirm with `git ls-remote --tags`.

**Step 3 could not be done from the session that prepared this.** Tag pushes there are rejected `HTTP 403` while branch pushes succeed — not the egress proxy (its status endpoint reported `recentRelayFailures: []`), so the credentials permit branch writes only. **The tag push needs someone with tag permission**; until then 0.70.0 is prepared but unpublished.

## CLA

Please read the [Contributor License Agreement](../blob/main/CLA.md) and check the box:

- [ ] I have read and agree to the CLA

<!-- Left unticked deliberately: the CLA is a personal legal affirmation, not mine to make on the author's behalf. Per the template, internal/org-member PRs skip this check automatically. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7E9AncSjXyDuCURcewmTP)_