### PR TITLE
fix: follow the loopdive/js2wasm → loopdive/js2 rename (npm publish + Pages deploy)

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   measure-and-gate:
-    if: github.repository == 'loopdive/js2wasm' && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
+    if: github.repository == 'loopdive/js2' && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     outputs:
@@ -376,7 +376,7 @@ jobs:
     if: |
       needs.measure-and-gate.result == 'success' &&
       github.event_name != 'pull_request' &&
-      github.repository == 'loopdive/js2wasm' &&
+      github.repository == 'loopdive/js2' &&
       github.actor != 'github-actions[bot]'
     needs: measure-and-gate
     runs-on: ubuntu-24.04

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,7 +37,7 @@ jobs:
     # A failed/cancelled Refresh Benchmarks run has nothing new to publish, and
     # redeploying on it would just burn a build — only follow through on success.
     if: |
-      github.repository == 'loopdive/js2wasm' &&
+      github.repository == 'loopdive/js2' &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
@@ -207,7 +207,7 @@ jobs:
           path: dist/pages
 
   deploy:
-    if: github.repository == 'loopdive/js2wasm'
+    if: github.repository == 'loopdive/js2'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/npm-compat-refresh.yml
+++ b/.github/workflows/npm-compat-refresh.yml
@@ -110,7 +110,7 @@ jobs:
     # The `paths-ignore` filter above is what actually breaks the trigger loop
     # now (this job's own landing changes only artifact paths). The actor guard
     # is kept as a second, cheaper line against any OTHER bot push to main.
-    if: github.repository == 'loopdive/js2wasm' && github.actor != 'github-actions[bot]'
+    if: github.repository == 'loopdive/js2' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     environment: baseline-promote

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://js2wasm.loopdive.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/loopdive/js2wasm.git"
+    "url": "git+https://github.com/loopdive/js2.git"
   },
   "bugs": {
     "url": "https://github.com/loopdive/js2wasm/issues"

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://js2wasm.loopdive.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/loopdive/js2wasm.git",
+    "url": "git+https://github.com/loopdive/js2.git",
     "directory": "packages/js2wasm"
   },
   "bugs": {

--- a/website/CNAME
+++ b/website/CNAME
@@ -1,1 +1,1 @@
-js2wasm.loopdive.com
+js2.loopdive.com


### PR DESCRIPTION
The repo rename broke two things silently. GitHub redirects renamed repos for git and the API, so everything kept *appearing* to work.

## 1 — npm publish rejects v0.70.0

OIDC tokens carry the **current** repo name, so the provenance attestation says `loopdive/js2` while both manifests still said `loopdive/js2wasm`. npm validates that they match:

```
npm error code E422
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/loopdive/js2wasm.git",
expected to match "https://github.com/loopdive/js2" from provenance
```

The first attempt failed `E404` instead — the npm trusted publisher was still registered against the old name (fixed separately on npmjs.com). The **E404 → E422 move is the evidence** that the auth half is resolved and only the manifest URL remains.

## 2 — Workflow identity guards silently skip whole jobs

Five `github.repository == 'loopdive/js2wasm'` conditions now evaluate **false**. They gate entire jobs, and a skipped job reports the workflow **green** — so Pages, benchmark-refresh and npm-compat-refresh would each stop publishing with CI showing all-clear. No `deploy-pages` run has happened since the rename; the next one would have been the first silent skip.

| workflow | guards |
| --- | --- |
| `deploy-pages.yml` | 2 (the `build` and `deploy` jobs) |
| `benchmark-refresh.yml` | 2 |
| `npm-compat-refresh.yml` | 1 |

## 3 — Site moves to js2.loopdive.com

DNS now points `js2.loopdive.com` at `loopdive.github.io`, and Cloudflare 301s the old `js2wasm.loopdive.com` to it. The Pages custom domain is updated via the API; `website/CNAME` has to match or the next deploy reverts it, since Pages honours the CNAME in the **deployed artifact**.

`js2.loopdive.com` currently serves GitHub's "Site not found" — the live artifact still carries the old CNAME, and republishing depends on the guard fix above. **This PR merging is what makes the site reachable.**

## Deliberately not changed

- `loopdive/js2wasm-baselines` and `loopdive/js2wasm-labs` are **separate repos** that were not renamed.
- ~500 stale URLs under `.claude/ci-status/` are the retired PR-status feed.
- Plain URL references elsewhere still resolve through GitHub's redirect. Only **identity comparisons** and the **provenance-validated manifest URLs** actually break.

## CLA

- [ ] I have read and agree to the CLA

---
_Generated by [Claude Code](https://claude.ai/code)_