### PR TITLE
feat: QuickJS allocates through our allocator (4557); native AOT baseline closes the ADR-0021 gate (4544 Part A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ benchmarks/results/*.json
 !benchmarks/results/npm-compat.json
 !benchmarks/results/npm-compat-perf.json
 !benchmarks/results/npm-compat-history.json
+# #4544 Part A — the native-binary size/startup baseline that gates ADR-0021.
+# Hand-refreshed by `node scripts/benchmark-native-aot.mjs`; no CI job promotes
+# it, because it needs a toolchain (wasmtime, wamrc, a native wabt) that the
+# runners do not carry.
+!benchmarks/results/native-aot-baseline.json
 benchmarks/results/*.md
 benchmarks/results/*.txt
 # #1528 — the ~15 MB test262 baseline JSONL lives in loopdive/js2wasm-baselines.

--- a/benchmarks/results/native-aot-baseline.json
+++ b/benchmarks/results/native-aot-baseline.json
@@ -1,0 +1,852 @@
+{
+  "issue": 4544,
+  "part": "A",
+  "title": "Native binary emission: size/startup baseline",
+  "generatedAt": "2026-08-19T04:01:36.826Z",
+  "generatedBy": "scripts/benchmark-native-aot.mjs",
+  "gates": "docs/adr/0021-native-backend-targets-c.md",
+  "container": {
+    "arch": "x64",
+    "platform": "linux",
+    "cpus": "4",
+    "kernel": "6.18.5-fc-v20",
+    "node": "v22.22.2",
+    "note": "Shared 4-core container; startup numbers carry scheduler noise, which is why the distribution is reported rather than a single sample."
+  },
+  "methodology": {
+    "backend": "--target linear (linear memory). The linear backend is the only one all three AOT routes can consume: wasm2c and WAMR have no WasmGC support, so the WasmGC `wasi` target is AOT-able by at most one of the three.",
+    "startup": "Whole-process wall clock (exec to exit), argument chosen so the program's loop body runs ZERO times, one discarded warmup then N timed rounds, filesystem cache WARM. Lanes are interleaved in a rotating order within each round, and each round also times an exec-floor binary; QUOTE `aboveFloorMs` (median of per-round differences), not `p50Ms` — the absolute figures include ~1 ms of this harness's own spawnSync cost. Resolution is about +/-0.5 ms, so an aboveFloorMs under ~1 ms means indistinguishable from bare process creation.",
+    "size": "Raw and gzip -9. The honest size for a lane is artifact + whatever must ship with it: see denominators.runtimeSizes. wasm2c-native ships nothing else, so its binary IS its shipped size.",
+    "correctness": "Every lane is re-run on a REAL argument and all four lane outputs must agree with each other AND with Node before any timing is recorded. Agreement is checked at 6 significant digits because iwasm's `-f` printer is lossy; raw per-lane outputs are kept in each program's `outputs`.",
+    "dynamicTier": "Measured separately. No corpus program links QuickJS (all are typed and eval-free), so the corpus numbers are what a normal program pays."
+  },
+  "toolchain": {
+    "wasmtime": "wasmtime 27.0.0 (8eefa236f 2024-11-20)",
+    "wamrc": "wamrc 2.2.0",
+    "iwasm": "iwasm 2.2.0",
+    "wasm2c": "1.0.39 (native build at .tmp/toolchain/wabt-build/wasm2c)",
+    "cc": "Ubuntu clang version 18.1.3 (1ubuntu1)",
+    "wasmRtSource": "wabt 1.0.39 wasm2c/ (fetched at the matching tag; see script header)"
+  },
+  "commands": {
+    "wasm-jit": "wasmtime run --invoke run <prog>.wasm <arg>",
+    "wasmtime-aot": "wasmtime compile <prog>.wasm -o <prog>.cwasm && wasmtime run --allow-precompiled --invoke run <prog>.cwasm <arg>",
+    "wamr-aot": "wamrc -o <prog>.aot <prog>.wasm && iwasm -f run <prog>.aot <arg>",
+    "wasm2c-native": "wasm2c <prog>.wasm -o <prog>.c && clang -O2 -fwrapv -o <prog> scripts/native-aot-corpus/driver.c <prog>.c wasm-rt-impl.c wasm-rt-mem-impl.c -lm && ./<prog> <arg>",
+    "c-floor": "clang -O2 -fwrapv -o fib-c-floor scripts/native-aot-corpus/fib-floor.c && ./fib-c-floor <arg>"
+  },
+  "runs": 201,
+  "programs": [
+    {
+      "id": "noop",
+      "label": "Empty (startup isolation)",
+      "source": "scripts/native-aot-corpus/noop.ts",
+      "value": 7,
+      "checkArg": 7,
+      "outputs": {
+        "wasm-jit": "7",
+        "wasmtime-aot": "7",
+        "wamr-aot": "7",
+        "wasm2c-native": "7",
+        "node": "7"
+      },
+      "imports": [],
+      "size": {
+        "wasm-jit": {
+          "raw": 4986,
+          "gzip": 1942
+        },
+        "wasmtime-aot": {
+          "raw": 35288,
+          "gzip": 12812
+        },
+        "wamr-aot": {
+          "raw": 15828,
+          "gzip": 6048
+        },
+        "wasm2c-native": {
+          "raw": 26944,
+          "gzip": 8681
+        },
+        "wasm2c-native-stripped": {
+          "raw": 22944,
+          "gzip": 7486
+        },
+        "generatedCBytes": 104402
+      },
+      "startup": {
+        "runs": 201,
+        "execFloor": {
+          "minMs": 3.187,
+          "p50Ms": 3.662,
+          "p90Ms": 4.178,
+          "maxMs": 5.023
+        },
+        "wasm-jit": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/wasm/noop.wasm",
+            "0"
+          ],
+          "minMs": 7.437,
+          "p50Ms": 8.426,
+          "p90Ms": 9.131,
+          "maxMs": 12.396,
+          "aboveFloorMs": 4.719,
+          "stdout": "0"
+        },
+        "wasmtime-aot": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--allow-precompiled",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/cwasm/noop.cwasm",
+            "0"
+          ],
+          "minMs": 7.37,
+          "p50Ms": 8.05,
+          "p90Ms": 8.653,
+          "maxMs": 11.343,
+          "aboveFloorMs": 4.38,
+          "stdout": "0"
+        },
+        "wamr-aot": {
+          "argv": [
+            ".tmp/toolchain/wamr-min/iwasm",
+            "-f",
+            "run",
+            ".tmp/native-aot/aot/noop.aot",
+            "0"
+          ],
+          "minMs": 7.628,
+          "p50Ms": 8.412,
+          "p90Ms": 9.096,
+          "maxMs": 11.631,
+          "aboveFloorMs": 4.679,
+          "stdout": "0:f64"
+        },
+        "wasm2c-native": {
+          "argv": [
+            ".tmp/native-aot/bin/noop",
+            "0"
+          ],
+          "minMs": 3.376,
+          "p50Ms": 3.904,
+          "p90Ms": 4.409,
+          "maxMs": 6.12,
+          "aboveFloorMs": 0.196,
+          "stdout": "0"
+        }
+      }
+    },
+    {
+      "id": "fib",
+      "label": "Fibonacci loop",
+      "source": "website/public/benchmarks/competitive/programs/fib.js",
+      "value": 832040,
+      "checkArg": 30,
+      "outputs": {
+        "wasm-jit": "832040",
+        "wasmtime-aot": "832040",
+        "wamr-aot": "832040",
+        "wasm2c-native": "832040",
+        "node": "832040"
+      },
+      "imports": [],
+      "size": {
+        "wasm-jit": {
+          "raw": 4943,
+          "gzip": 1882
+        },
+        "wasmtime-aot": {
+          "raw": 35296,
+          "gzip": 12639
+        },
+        "wamr-aot": {
+          "raw": 15796,
+          "gzip": 5996
+        },
+        "wasm2c-native": {
+          "raw": 26936,
+          "gzip": 8640
+        },
+        "wasm2c-native-stripped": {
+          "raw": 22944,
+          "gzip": 7448
+        },
+        "generatedCBytes": 103476
+      },
+      "startup": {
+        "runs": 201,
+        "execFloor": {
+          "minMs": 3.354,
+          "p50Ms": 3.956,
+          "p90Ms": 4.584,
+          "maxMs": 5.848
+        },
+        "wasm-jit": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/wasm/fib.wasm",
+            "0"
+          ],
+          "minMs": 7.915,
+          "p50Ms": 8.851,
+          "p90Ms": 10.009,
+          "maxMs": 12.926,
+          "aboveFloorMs": 4.805,
+          "stdout": "0"
+        },
+        "wasmtime-aot": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--allow-precompiled",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/cwasm/fib.cwasm",
+            "0"
+          ],
+          "minMs": 7.735,
+          "p50Ms": 8.453,
+          "p90Ms": 9.428,
+          "maxMs": 22.987,
+          "aboveFloorMs": 4.532,
+          "stdout": "0"
+        },
+        "wamr-aot": {
+          "argv": [
+            ".tmp/toolchain/wamr-min/iwasm",
+            "-f",
+            "run",
+            ".tmp/native-aot/aot/fib.aot",
+            "0"
+          ],
+          "minMs": 7.964,
+          "p50Ms": 8.785,
+          "p90Ms": 9.653,
+          "maxMs": 18.407,
+          "aboveFloorMs": 4.766,
+          "stdout": "0:f64"
+        },
+        "wasm2c-native": {
+          "argv": [
+            ".tmp/native-aot/bin/fib",
+            "0"
+          ],
+          "minMs": 3.651,
+          "p50Ms": 4.11,
+          "p90Ms": 4.655,
+          "maxMs": 19.375,
+          "aboveFloorMs": 0.142,
+          "stdout": "0"
+        }
+      }
+    },
+    {
+      "id": "fib-recursive",
+      "label": "Fibonacci recursion",
+      "source": "website/public/benchmarks/competitive/programs/fib-recursive.js",
+      "value": 832040,
+      "checkArg": 30,
+      "outputs": {
+        "wasm-jit": "832040",
+        "wasmtime-aot": "832040",
+        "wamr-aot": "832040",
+        "wasm2c-native": "832040",
+        "node": "832040"
+      },
+      "imports": [],
+      "size": {
+        "wasm-jit": {
+          "raw": 4948,
+          "gzip": 1884
+        },
+        "wasmtime-aot": {
+          "raw": 35360,
+          "gzip": 12754
+        },
+        "wamr-aot": {
+          "raw": 16036,
+          "gzip": 6067
+        },
+        "wasm2c-native": {
+          "raw": 27040,
+          "gzip": 8706
+        },
+        "wasm2c-native-stripped": {
+          "raw": 22944,
+          "gzip": 7502
+        },
+        "generatedCBytes": 106422
+      },
+      "startup": {
+        "runs": 201,
+        "execFloor": {
+          "minMs": 3.383,
+          "p50Ms": 3.903,
+          "p90Ms": 4.39,
+          "maxMs": 6.175
+        },
+        "wasm-jit": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/wasm/fib-recursive.wasm",
+            "0"
+          ],
+          "minMs": 7.797,
+          "p50Ms": 8.613,
+          "p90Ms": 9.371,
+          "maxMs": 10.688,
+          "aboveFloorMs": 4.718,
+          "stdout": "0"
+        },
+        "wasmtime-aot": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--allow-precompiled",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/cwasm/fib-recursive.cwasm",
+            "0"
+          ],
+          "minMs": 7.398,
+          "p50Ms": 8.296,
+          "p90Ms": 9.004,
+          "maxMs": 12.057,
+          "aboveFloorMs": 4.373,
+          "stdout": "0"
+        },
+        "wamr-aot": {
+          "argv": [
+            ".tmp/toolchain/wamr-min/iwasm",
+            "-f",
+            "run",
+            ".tmp/native-aot/aot/fib-recursive.aot",
+            "0"
+          ],
+          "minMs": 7.948,
+          "p50Ms": 8.709,
+          "p90Ms": 9.406,
+          "maxMs": 12.49,
+          "aboveFloorMs": 4.761,
+          "stdout": "0:f64"
+        },
+        "wasm2c-native": {
+          "argv": [
+            ".tmp/native-aot/bin/fib-recursive",
+            "0"
+          ],
+          "minMs": 3.564,
+          "p50Ms": 4.057,
+          "p90Ms": 4.52,
+          "maxMs": 5.38,
+          "aboveFloorMs": 0.151,
+          "stdout": "0"
+        }
+      }
+    },
+    {
+      "id": "string-hash",
+      "label": "String build + hash",
+      "source": "website/public/benchmarks/competitive/programs/string-hash.js",
+      "value": 36729900,
+      "checkArg": 100,
+      "outputs": {
+        "wasm-jit": "36729899",
+        "wasmtime-aot": "36729899",
+        "wamr-aot": "3.67299e+07",
+        "wasm2c-native": "36729899",
+        "node": "36729899"
+      },
+      "imports": [],
+      "size": {
+        "wasm-jit": {
+          "raw": 6040,
+          "gzip": 2427
+        },
+        "wasmtime-aot": {
+          "raw": 43864,
+          "gzip": 15169
+        },
+        "wamr-aot": {
+          "raw": 19496,
+          "gzip": 7697
+        },
+        "wasm2c-native": {
+          "raw": 35368,
+          "gzip": 10380
+        },
+        "wasm2c-native-stripped": {
+          "raw": 31136,
+          "gzip": 9092
+        },
+        "generatedCBytes": 121542
+      },
+      "startup": {
+        "runs": 201,
+        "execFloor": {
+          "minMs": 3.447,
+          "p50Ms": 3.997,
+          "p90Ms": 4.542,
+          "maxMs": 5.176
+        },
+        "wasm-jit": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/wasm/string-hash.wasm",
+            "0"
+          ],
+          "minMs": 8.157,
+          "p50Ms": 9.039,
+          "p90Ms": 9.79,
+          "maxMs": 39.169,
+          "aboveFloorMs": 5.023,
+          "stdout": "0"
+        },
+        "wasmtime-aot": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--allow-precompiled",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/cwasm/string-hash.cwasm",
+            "0"
+          ],
+          "minMs": 7.73,
+          "p50Ms": 8.693,
+          "p90Ms": 9.411,
+          "maxMs": 40.988,
+          "aboveFloorMs": 4.681,
+          "stdout": "0"
+        },
+        "wamr-aot": {
+          "argv": [
+            ".tmp/toolchain/wamr-min/iwasm",
+            "-f",
+            "run",
+            ".tmp/native-aot/aot/string-hash.aot",
+            "0"
+          ],
+          "minMs": 8.259,
+          "p50Ms": 8.968,
+          "p90Ms": 9.766,
+          "maxMs": 28.661,
+          "aboveFloorMs": 4.932,
+          "stdout": "0:f64"
+        },
+        "wasm2c-native": {
+          "argv": [
+            ".tmp/native-aot/bin/string-hash",
+            "0"
+          ],
+          "minMs": 3.647,
+          "p50Ms": 4.206,
+          "p90Ms": 4.953,
+          "maxMs": 6.033,
+          "aboveFloorMs": 0.204,
+          "stdout": "0"
+        }
+      }
+    },
+    {
+      "id": "object-ops",
+      "label": "Object property ops",
+      "source": "website/public/benchmarks/competitive/programs/object-ops.js",
+      "value": -2174880,
+      "checkArg": 100,
+      "outputs": {
+        "wasm-jit": "-2174878",
+        "wasmtime-aot": "-2174878",
+        "wamr-aot": "-2174878",
+        "wasm2c-native": "-2174878",
+        "node": "-2174878"
+      },
+      "imports": [],
+      "size": {
+        "wasm-jit": {
+          "raw": 5190,
+          "gzip": 2073
+        },
+        "wasmtime-aot": {
+          "raw": 35496,
+          "gzip": 13331
+        },
+        "wamr-aot": {
+          "raw": 16512,
+          "gzip": 6342
+        },
+        "wasm2c-native": {
+          "raw": 31072,
+          "gzip": 9147
+        },
+        "wasm2c-native-stripped": {
+          "raw": 27040,
+          "gzip": 7957
+        },
+        "generatedCBytes": 109217
+      },
+      "startup": {
+        "runs": 201,
+        "execFloor": {
+          "minMs": 3.637,
+          "p50Ms": 4.154,
+          "p90Ms": 4.696,
+          "maxMs": 6.938
+        },
+        "wasm-jit": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/wasm/object-ops.wasm",
+            "0"
+          ],
+          "minMs": 8.074,
+          "p50Ms": 9.069,
+          "p90Ms": 9.712,
+          "maxMs": 13.548,
+          "aboveFloorMs": 4.88,
+          "stdout": "0"
+        },
+        "wasmtime-aot": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--allow-precompiled",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/cwasm/object-ops.cwasm",
+            "0"
+          ],
+          "minMs": 7.922,
+          "p50Ms": 8.701,
+          "p90Ms": 9.532,
+          "maxMs": 38.814,
+          "aboveFloorMs": 4.513,
+          "stdout": "0"
+        },
+        "wamr-aot": {
+          "argv": [
+            ".tmp/toolchain/wamr-min/iwasm",
+            "-f",
+            "run",
+            ".tmp/native-aot/aot/object-ops.aot",
+            "0"
+          ],
+          "minMs": 8.218,
+          "p50Ms": 9.004,
+          "p90Ms": 9.707,
+          "maxMs": 11.64,
+          "aboveFloorMs": 4.824,
+          "stdout": "0:f64"
+        },
+        "wasm2c-native": {
+          "argv": [
+            ".tmp/native-aot/bin/object-ops",
+            "0"
+          ],
+          "minMs": 3.84,
+          "p50Ms": 4.325,
+          "p90Ms": 4.913,
+          "maxMs": 44.125,
+          "aboveFloorMs": 0.153,
+          "stdout": "0"
+        }
+      }
+    },
+    {
+      "id": "collections",
+      "label": "Map/Set hash-table runtime",
+      "source": "scripts/emit-identity-corpus/collections.ts",
+      "value": 232,
+      "checkArg": null,
+      "outputs": {
+        "wasm-jit": "232",
+        "wasmtime-aot": "232",
+        "wamr-aot": "232",
+        "wasm2c-native": "232",
+        "node": "232"
+      },
+      "imports": [],
+      "size": {
+        "wasm-jit": {
+          "raw": 6488,
+          "gzip": 2395
+        },
+        "wasmtime-aot": {
+          "raw": 47960,
+          "gzip": 16123
+        },
+        "wamr-aot": {
+          "raw": 25420,
+          "gzip": 8687
+        },
+        "wasm2c-native": {
+          "raw": 39504,
+          "gzip": 10633
+        },
+        "wasm2c-native-stripped": {
+          "raw": 35224,
+          "gzip": 9264
+        },
+        "generatedCBytes": 125290
+      },
+      "startup": {
+        "runs": 201,
+        "execFloor": {
+          "minMs": 3.645,
+          "p50Ms": 4.122,
+          "p90Ms": 4.67,
+          "maxMs": 6.695
+        },
+        "wasm-jit": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/wasm/collections.wasm"
+          ],
+          "minMs": 8.418,
+          "p50Ms": 9.13,
+          "p90Ms": 9.813,
+          "maxMs": 15.544,
+          "aboveFloorMs": 4.968,
+          "stdout": "232"
+        },
+        "wasmtime-aot": {
+          "argv": [
+            ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+            "run",
+            "--allow-precompiled",
+            "--invoke",
+            "run",
+            ".tmp/native-aot/cwasm/collections.cwasm"
+          ],
+          "minMs": 7.877,
+          "p50Ms": 8.676,
+          "p90Ms": 9.458,
+          "maxMs": 26.96,
+          "aboveFloorMs": 4.51,
+          "stdout": "232"
+        },
+        "wamr-aot": {
+          "argv": [
+            ".tmp/toolchain/wamr-min/iwasm",
+            "-f",
+            "run",
+            ".tmp/native-aot/aot/collections.aot"
+          ],
+          "minMs": 8.213,
+          "p50Ms": 9.064,
+          "p90Ms": 10.11,
+          "maxMs": 49.269,
+          "aboveFloorMs": 4.899,
+          "stdout": "232:f64"
+        },
+        "wasm2c-native": {
+          "argv": [
+            ".tmp/native-aot/bin/collections"
+          ],
+          "minMs": 3.868,
+          "p50Ms": 4.349,
+          "p90Ms": 4.797,
+          "maxMs": 6.115,
+          "aboveFloorMs": 0.179,
+          "stdout": "232"
+        }
+      }
+    }
+  ],
+  "denominators": {
+    "cFloor": {
+      "note": "fib(n) hand-written in C, same clang -O2 -fwrapv, stripped. The floor: what a native binary costs in size and startup when no Wasm was ever involved. `wasm2c-native-fib` is re-timed alongside it so the two are directly comparable.",
+      "size": {
+        "raw": 14528,
+        "gzip": 1806
+      },
+      "startup": {
+        "argv": [
+          ".tmp/native-aot/bin/fib-c-floor",
+          "0"
+        ],
+        "minMs": 3.592,
+        "p50Ms": 4.15,
+        "p90Ms": 4.728,
+        "maxMs": 5.806,
+        "aboveFloorMs": 0.011,
+        "stdout": "0"
+      },
+      "wasm2cNativeSameRound": {
+        "argv": [
+          ".tmp/native-aot/bin/fib",
+          "0"
+        ],
+        "minMs": 3.661,
+        "p50Ms": 4.215,
+        "p90Ms": 4.749,
+        "maxMs": 5.773,
+        "aboveFloorMs": 0.061,
+        "stdout": "0"
+      }
+    },
+    "execFloor": {
+      "note": "scripts/native-aot-corpus/exec-floor.c — `int main(void){return 0;}`, same clang, stripped. The process exec + dynamic-loader + libc-start floor that EVERY lane pays, plus this harness's own ~1 ms spawnSync overhead. No process-based route can start faster. It is what `aboveFloorMs` subtracts. NOT /bin/true: coreutils does locale setup worth ~0.5 ms, which showed up as impossible negative excesses on the floor-speed lanes.",
+      "binary": {
+        "raw": 14440,
+        "gzip": 1610
+      },
+      "startup": {
+        "minMs": 3.646,
+        "p50Ms": 4.155,
+        "p90Ms": 4.635,
+        "maxMs": 5.557
+      }
+    },
+    "nodeFloor": {
+      "note": "node instantiating the same fib .wasm. Context for startup only; Node's own boot dominates and nobody would ship this as a native binary.",
+      "startup": {
+        "argv": [
+          "/opt/node22/bin/node",
+          "scripts/native-aot-corpus/node-runner.mjs",
+          ".tmp/native-aot/wasm/fib.wasm",
+          "0"
+        ],
+        "minMs": 42.808,
+        "p50Ms": 47.889,
+        "p90Ms": 51.227,
+        "maxMs": 87.976,
+        "aboveFloorMs": 42.63,
+        "stdout": "0"
+      }
+    },
+    "runtimeSizes": {
+      "wasmtime": {
+        "path": ".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime",
+        "raw": 42240592,
+        "gzip": 12137059,
+        "note": "wasmtime 27.0.0 official release CLI. Required at run time by the wasm-jit and wasmtime-aot lanes."
+      },
+      "iwasm": {
+        "path": ".tmp/toolchain/wamr-min/iwasm",
+        "raw": 305776,
+        "gzip": 117950,
+        "note": "iwasm 2.2.0 built AOT-ONLY from source (interpreter/JIT/SIMD off) — what an embedder would actually ship. Required at run time by the wamr-aot lane."
+      },
+      "iwasmRelease": {
+        "path": ".tmp/toolchain/iwasm/iwasm",
+        "raw": 52153728,
+        "gzip": 20936563,
+        "startup": {
+          "argv": [
+            ".tmp/toolchain/iwasm/iwasm",
+            "-f",
+            "run",
+            ".tmp/native-aot/aot/fib.aot",
+            "0"
+          ],
+          "minMs": 15.228,
+          "p50Ms": 17.527,
+          "p90Ms": 19.017,
+          "maxMs": 62.846,
+          "aboveFloorMs": 12.245,
+          "stdout": "0:f64"
+        },
+        "note": "The PREBUILT iwasm 2.2.0 release, for contrast only. A full developer build (interpreter + AOT + JIT + debug). Recorded because reaching for the convenient prebuilt is the obvious mistake here and it misstates WAMR badly on both axes — compare its bytes and its aboveFloorMs against the minimal build above."
+      },
+      "wasm2c-native": {
+        "path": null,
+        "raw": 0,
+        "gzip": 0,
+        "note": "Nothing. The wasm2c lane's binary IS the whole deliverable — wabt's wasm-rt is statically linked into it and is already counted in each program's wasm2c-native size."
+      }
+    }
+  },
+  "dynamicTier": {
+    "note": "The QuickJS boxed-tier artifact (#4236), built by scripts/quickjs-artifact/build.sh at -O2. Reported SEPARATELY and never blended with the corpus: no corpus program links it (all are typed and eval-free). This is what a program WITH a dynamic residue would additionally pay.",
+    "source": ".tmp/quickjs-artifact/libquickjs.wasm",
+    "buildInfo": {
+      "quickjs_ng_ref": "954dc53628e36891f93c359aa60895c2ae3dac6b",
+      "wasi_libc_ref": "8d8348ec24253d0638a693b8af82445c13d92d32",
+      "builtins_url": "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-34-rc.1/libclang_rt-34.0-rc.1.tar.gz",
+      "target_triple": "wasm32-wasip1",
+      "compiler": "Ubuntu clang version 18.1.3 (1ubuntu1)",
+      "raw_bytes": 1016254,
+      "gzip_bytes": 349808,
+      "sha256": "b0662069c241d0430d91c53a3b0e2d1281fd9eb78dd1c93490b0a9dfa70eec5b"
+    },
+    "size": {
+      "wasm-jit": {
+        "raw": 1016254,
+        "gzip": 352007
+      },
+      "wasmtime-aot": {
+        "raw": 3917128,
+        "gzip": 1908082
+      },
+      "wamr-aot": {
+        "raw": 1888868,
+        "gzip": 747411
+      }
+    },
+    "wasm2cNative": {
+      "status": "ok",
+      "note": "The whole engine linked into ONE self-contained native executable via the recommended route, evaluating real JavaScript. Nothing else ships alongside it. Startup includes instantiating a QuickJS runtime + context and evaluating `1+1`. The five wasi_snapshot_preview1 imports are implemented in scripts/native-aot-corpus/qjs-driver.c — about forty lines, no uvwasi, no WASI SDK at run time.",
+      "generatedCBytes": 12679743,
+      "size": {
+        "raw": 1595952,
+        "gzip": 703681
+      },
+      "evalResults": [
+        {
+          "src": "1+1",
+          "got": "2"
+        },
+        {
+          "src": "[1,2,3].map(x=>x*7).join(\"-\")",
+          "got": "7-14-21"
+        },
+        {
+          "src": "JSON.stringify({a:1,b:[2,3]})",
+          "got": "{\"a\":1,\"b\":[2,3]}"
+        }
+      ],
+      "startup": {
+        "argv": [
+          ".tmp/native-aot/bin/qjs-native",
+          "1+1"
+        ],
+        "minMs": 4.441,
+        "p50Ms": 4.872,
+        "p90Ms": 5.691,
+        "maxMs": 11.111,
+        "aboveFloorMs": 0.644,
+        "stdout": "2"
+      },
+      "execFloor": {
+        "minMs": 3.803,
+        "p50Ms": 4.311,
+        "p90Ms": 5.048,
+        "maxMs": 6.002
+      }
+    }
+  }
+}

--- a/docs/adr/0020-linear-dynamic-tier-quickjs-jsvalue.md
+++ b/docs/adr/0020-linear-dynamic-tier-quickjs-jsvalue.md
@@ -78,6 +78,31 @@ per cross-module call.
    decision is a target, with that fallback working in the meantime. #4540
    carries the cost analysis.
 
+   **Status 2026-08-19 — the allocator half is BUILT (#4557); the memory half
+   is not.** The linear lane now has a real
+   `malloc`/`calloc`/`free`/`realloc`/`usable_size`, and QuickJS allocates
+   through it via `JS_NewRuntime2`, proven by call counters read out of our own
+   module. It is **opt-in** (`linearHeapAllocator: "malloc-v1"`); #4540's
+   carve-from-the-engine arena remains the default, because the measured
+   end-to-end cost is 1.025× and the reclamation benefit does not yet justify
+   flipping a new allocator under foreign code by default.
+
+   Two things recorded above turn out to be wrong, and both are worth carrying
+   forward rather than quietly fixing:
+
+   - **The members are installed as table callbacks, not wasm imports.** Five
+     unconditional imports would make the artifact un-instantiable without a
+     peer that supplies an allocator — which `extract-abi.mjs` (it instantiates
+     the artifact alone to read these very constants out of it) and the
+     runtime-eval tier both do. The #4245 membrane already solved this shape.
+     A consequence: memory ownership is *not* required for the allocator,
+     though it WOULD have been under imports, because engine-imports-allocator
+     plus we-import-memory is an instantiation cycle.
+   - **"Dropping dlmalloc may shrink the artifact" did not happen.** dlmalloc is
+     still linked and still provides the regions our allocator sub-allocates
+     from, so the artifact grew by 6,735 bytes. Exactly one component still
+     grows the memory, and it is still the engine.
+
 ## Scope
 
 - **The WasmGC backend is unaffected.** `JSValue` cannot hold WasmGC

--- a/docs/adr/0021-native-backend-targets-c.md
+++ b/docs/adr/0021-native-backend-targets-c.md
@@ -5,6 +5,25 @@ to build a direct native backend at all is gated on evidence from #4544; this
 record fixes what it emits *if* that gate opens, so the question is not
 re-litigated each time it resurfaces.
 
+> **Gate result 2026-08-19: CLOSED — the direct backend is not justified.**
+> #4544 Part A measured the AOT route and it is not inadequate on either axis:
+> a real program becomes a **22.9 KB self-contained native binary** starting
+> **0.14–0.20 ms above bare process creation** (1.58x the size of the same
+> program hand-written in C, and indistinguishable from it on startup), via
+> `wasm2c` + clang. Even the whole QuickJS tier links into one 1.60 MB binary
+> that evaluates JavaScript in 0.64 ms. This ADR therefore stays Accepted as a
+> **target choice** and stays unscheduled — including its stated prerequisite of
+> finishing `ir-full-coverage` (#2855) first, which does not have to be paid for
+> this reason.
+>
+> **Still open:** the Wasm→C **throughput** objection under "Alternatives
+> rejected" was NOT tested — Part A measured size and startup only. Note it is
+> an argument about the *engine*, and the engine is already C, so a native build
+> can link `libquickjs` compiled directly by clang and route only generated code
+> through `wasm2c`. Evidence:
+> [`benchmarks/results/native-aot-baseline.json`](../../benchmarks/results/native-aot-baseline.json),
+> generator `scripts/benchmark-native-aot.mjs`.
+
 ## Context
 
 The goal behind #4538 is standalone **native binaries**. The near-term route is

--- a/plan/issues/4540-linear-heap-coexistence-arena-relocation.md
+++ b/plan/issues/4540-linear-heap-coexistence-arena-relocation.md
@@ -249,11 +249,28 @@ one grower, but it is the engine's. Keep it as the working fallback; it is not
 the end state. The costs recorded in the Decision above are unchanged by this —
 they are the price of the intended direction, not of the fallback.
 
-**Status 2026-08-19: NOT implemented.** See "Implementation status" below —
-this slice shipped the recorded fallback (carve from the engine's `malloc`),
-which closes the corruption class on its own. The own-allocator decision stands
-and is unstarted; `scripts/quickjs-artifact/qjs_shim.c` still calls plain
-`JS_NewRuntime()`.
+**Status 2026-08-19: NOT implemented in THIS slice; implemented in #4557.** See
+"Implementation status" below — this slice shipped the recorded fallback (carve
+from the engine's `malloc`), which closes the corruption class on its own.
+The own allocator was then built in
+[#4557](./4557-linear-own-allocator-engine-allocates-through-us.md): a real
+`malloc`/`calloc`/`free`/`realloc`/`usable_size` in the linear lane, installed
+through `qjs_new_runtime2` → `JS_NewRuntime2`. Three of that work's findings
+correct assumptions recorded on THIS page:
+
+- The `JSMallocFunctions` members are wired as **`__indirect_function_table`
+  callbacks, not wasm imports** — five unconditional imports would make the
+  artifact un-instantiable without a peer allocator, which `extract-abi.mjs`
+  and the runtime-eval tier both require.
+- The "many small, short-lived objects" premise this page uses to argue
+  dlmalloc's tuning advantage is **false for quickjs-ng v0.16.1**: it has its
+  own 4 KiB size-class arena in front of the embedder allocator, so an eval
+  creating 120,000 objects makes **10** calls to the embedder allocator.
+- Dropping dlmalloc did **not** shrink the artifact (it is still linked);
+  it grew by 6,735 bytes.
+
+**The fallback on this page stays the DEFAULT.** `linearHeapAllocator` is
+opt-in; the measured end-to-end cost of the own allocator is 1.025×.
 
 ## The alternative this slice does not currently consider: two memories
 

--- a/plan/issues/4544-native-binary-emission-and-tier-elision.md
+++ b/plan/issues/4544-native-binary-emission-and-tier-elision.md
@@ -1,10 +1,10 @@
 ---
 id: 4544
 title: "Native binary emission: size/startup baseline, and pay-for-what-you-use elision of the dynamic tier"
-status: ready
+status: in-progress
 sprint: Backlog
 created: 2026-08-17
-updated: 2026-08-17
+updated: 2026-08-19
 priority: high
 horizon: l
 feasibility: medium
@@ -34,12 +34,13 @@ keeps the tier from taxing programs that never touch it.
 
 ## Sequencing — Part A is unblocked, Part B is not
 
-**Part A can start today.** AOT-compiling an existing linear-target module and
-recording size/startup depends on no other slice, and it is the evidence gate
-for [ADR-0021](../../docs/adr/0021-native-backend-targets-c.md): if these
-numbers are adequate, the direct C backend stays deferred indefinitely, which
-is worth learning before anyone invests in it. Part B (tier elision) genuinely
-needs #4541.
+**Part A is DONE (2026-08-19) — see [Part A — results](#part-a--results-measured-2026-08-19).**
+AOT-compiling an existing linear-target module and recording size/startup
+depended on no other slice, and it was the evidence gate for
+[ADR-0021](../../docs/adr/0021-native-backend-targets-c.md). The numbers are
+adequate, so the direct C backend stays deferred indefinitely — now on evidence
+rather than on absence of it. Part B (tier elision) genuinely needs #4541 and
+remains open; this issue stays open for it.
 
 ## Part A — native binary emission
 
@@ -93,6 +94,257 @@ consequences worth designing for, not discovering:
   before the first edit.
 - Startup measured as a distribution over repeated runs, not a single sample.
 - The binary runs the differential fixture set with output matching Node.
+
+## Part A — results (measured 2026-08-19)
+
+**The AOT route is adequate, and the gate on ADR-0021 closes on size and
+startup.** A real program compiles to a **22.9 KB self-contained native
+executable** that starts **0.14–0.20 ms above bare process creation** — within
+noise of a hand-written C binary doing the same arithmetic. Even the whole
+QuickJS dynamic tier links into **one 1.60 MB binary that evaluates JavaScript
+in 0.64 ms**. Nothing here is inadequate, so nothing here justifies building a
+second lowering path.
+
+Artifact: [`benchmarks/results/native-aot-baseline.json`](../../benchmarks/results/native-aot-baseline.json)
+· generator: `scripts/benchmark-native-aot.mjs` · 201 rounds/lane ·
+`generatedAt` 2026-08-19T04:01:36Z · 4-core x86_64 container, kernel 6.18.5,
+clang 18.1.3, Node v22.22.2, other agents active.
+
+```bash
+pnpm run build:compiler-bundle
+node scripts/benchmark-native-aot.mjs --runs 201
+```
+
+### The corpus, and why these programs
+
+Six programs, all compiled `--target linear`. Four are the landing benchmark
+corpus (`fib`, `fib-recursive`, `string-hash`, `object-ops` — the same source
+bytes the competitive benchmarks consume), one is the emit-identity corpus
+(`collections`, the only curated program that pulls in the linear backend's
+Map/Set open-addressing runtime), and one is a purpose-written `noop` for
+startup isolation. A hello-world alone would have flattered AOT on both axes.
+
+**The backend choice is forced, not preferred.** `wasm2c` and WAMR have no
+WasmGC support, so only the **linear** backend's output can feed all three
+routes; the WasmGC `wasi` target is AOT-able by at most one of them. This
+baseline is therefore inherently about the linear lane — which is where #4538
+lives anyway.
+
+All six link **zero imports** (verified in the artifact's per-program
+`imports: []`), so none of them pays for the dynamic tier.
+
+### Size — raw bytes / gzip -9
+
+| program | `.wasm` (today) | wasmtime `.cwasm` | WAMR `.aot` | **wasm2c native** (stripped) |
+| --- | --- | --- | --- | --- |
+| noop | 4,986 / 1,942 | 35,288 / 12,812 | 15,828 / 6,048 | 22,944 / 7,486 |
+| fib | 4,943 / 1,882 | 35,296 / 12,639 | 15,796 / 5,996 | 22,944 / 7,448 |
+| fib-recursive | 4,948 / 1,884 | 35,360 / 12,754 | 16,036 / 6,067 | 22,944 / 7,502 |
+| string-hash | 6,040 / 2,427 | 43,864 / 15,169 | 19,496 / 7,697 | 31,136 / 9,092 |
+| object-ops | 5,190 / 2,073 | 35,496 / 13,331 | 16,512 / 6,342 | 27,040 / 7,957 |
+| collections | 6,488 / 2,395 | 47,960 / 16,123 | 25,420 / 8,687 | 35,224 / 9,264 |
+
+**The artifact column is the misleading one.** Two of the three routes produce a
+module that still needs its engine at run time:
+
+| must also ship | raw | gzip |
+| --- | --- | --- |
+| wasmtime 27.0.0 CLI | 42,240,592 | 12,137,059 |
+| iwasm 2.2.0, **built AOT-only from source** | 305,776 | 117,950 |
+| iwasm 2.2.0, prebuilt release | 52,153,728 | — |
+| wasm2c native | **nothing** | — |
+
+So the honest shipped size for one program (`fib`):
+
+| route | shipped bytes | vs wasm2c |
+| --- | --- | --- |
+| **wasm2c native** | **22,944** | 1x |
+| WAMR AOT + minimal iwasm | 321,572 | 14.0x |
+| wasmtime AOT + wasmtime CLI | 42,275,888 | 1,843x |
+
+Against the floor: a hand-written C `fib` at the same `clang -O2 -fwrapv` is
+**14,528 bytes**, and an empty `int main(void){return 0;}` is **14,440**. So
+wasm2c's whole cost — the translated module plus wabt's `wasm-rt` — is **8,504
+bytes over an empty C binary**, and the finished thing is **1.58x** a
+hand-written C program.
+
+### Startup — ms above the process-exec floor
+
+Every program is invoked at the argument where its loop body runs **zero
+times**, so this times instantiation, not work. Lanes are interleaved in a
+rotating order and each round also times an exec-floor binary; the figure is the
+median of the **per-round paired differences** over 201 rounds. Filesystem cache
+warm. Resolution is about ±0.5 ms, so anything under ~1 ms means
+"indistinguishable from bare process creation".
+
+| program | wasm-jit | wasmtime AOT | WAMR AOT | **wasm2c native** |
+| --- | --- | --- | --- | --- |
+| noop | 4.719 | 4.380 | 4.679 | **0.196** |
+| fib | 4.805 | 4.532 | 4.766 | **0.142** |
+| fib-recursive | 4.718 | 4.373 | 4.761 | **0.151** |
+| string-hash | 5.023 | 4.681 | 4.932 | **0.204** |
+| object-ops | 4.880 | 4.513 | 4.824 | **0.153** |
+| collections | 4.968 | 4.510 | 4.899 | **0.179** |
+
+Denominators, same units, same harness:
+
+| lane | above floor |
+| --- | --- |
+| hand-written C `fib`, clang -O2 | 0.011 |
+| wasm2c native `fib` (re-timed beside it) | 0.061 |
+| Node instantiating the same `.wasm` | 42.63 |
+| WAMR AOT under the **prebuilt** 52 MB iwasm | 12.245 |
+
+Exec floor itself: 4.155 ms p50 — which includes roughly 1 ms of the harness's
+own `spawnSync` cost (cross-checked against a Python `subprocess` timer). That
+is exactly why the tables quote `aboveFloorMs` and not the absolute p50.
+
+**Two findings that change what you would do:**
+
+1. **AOT buys almost nothing for startup.** wasmtime JIT → wasmtime AOT is
+   4.81 → 4.53 ms, about **6 %**. The ~4.5 ms is engine and CLI initialisation,
+   not compilation — Cranelift compiling a 5 KB module was never the cost. So
+   "AOT-compile the Wasm" is not, by itself, a startup answer. The win comes
+   from **removing the engine**, which only the wasm2c route does: ~**30x** less
+   startup than any engine-hosted lane.
+2. **Which iwasm you build decides whether WAMR looks good or bad.** The
+   prebuilt release is a 52 MB developer build (interpreter + AOT + JIT +
+   debug); merely loading it costs 12.2 ms. Built AOT-only from source it is
+   305 KB and 4.8 ms — 170x smaller and 2.5x faster on the *same* `.aot` file.
+   Recording the prebuilt as "WAMR" would have libelled the route.
+
+### The dynamic tier, measured separately and never blended
+
+None of the corpus programs link QuickJS, so the tables above are what a normal
+typed program pays. The engine, reproduced from
+`scripts/quickjs-artifact/build.sh` at `-O2` (1,016,254 raw / 352,007 gzip —
+matching #4236's recorded 1,011,134 / 350,017 to within toolchain drift):
+
+| form | raw | gzip |
+| --- | --- | --- |
+| `libquickjs.wasm` | 1,016,254 | 352,007 |
+| wasmtime `.cwasm` | 3,917,128 | 1,908,082 |
+| WAMR `.aot` | 1,888,868 | 747,411 |
+| **wasm2c native, self-contained, evaluates JS** | **1,595,952** | **703,681** |
+
+That binary is the recommended route exercised on the hardest input the project
+has. It links the entire engine plus a ~40-line implementation of the five
+`wasi_snapshot_preview1` imports (`scripts/native-aot-corpus/qjs-driver.c` — no
+uvwasi, no WASI SDK at run time), and it answers:
+
+```
+$ qjs-native '1+1'                            -> 2
+$ qjs-native '[1,2,3].map(x=>x*7).join("-")'  -> 7-14-21
+$ qjs-native 'JSON.stringify({a:1,b:[2,3]})'  -> {"a":1,"b":[2,3]}
+```
+
+Startup **0.644 ms above the exec floor**, including creating a QuickJS runtime
+and context and evaluating `1+1` — still less than any engine-hosted lane needs
+to instantiate a 5 KB module containing no engine at all.
+
+So the with-tier / without-tier size delta is roughly **1.60 MB vs 22.9 KB**, a
+70x step. That is the number that makes Part B's elision worth building; it is
+not an argument against the AOT route, which handles both ends.
+
+### Route evaluation
+
+| route | verdict | evidence |
+| --- | --- | --- |
+| **wasm2c + C compiler** | **supported default** | smallest deliverable (22.9 KB, 1.58x the hand-written-C floor), startup at the process floor, no runtime to ship, and it survives the 1 MB engine |
+| WAMR AOT (`wamrc` + minimal `iwasm`) | keep as the sandboxed alternative | 321 KB shipped, 4.8 ms. 14x the size and ~30x the startup, but you retain a real Wasm sandbox and a stable embedding API — the right pick when isolation matters more than bytes |
+| wasmtime AOT (`wasmtime compile`) | not a shipping route | 42 MB shipped. Its AOT mode buys 0.38 ms over its own JIT. Excellent as a development/host runtime, which is what it already is here |
+
+**One provisioning caveat that is load-bearing for the recommendation:** the
+vendored `wasm2c` is `wabt.js` — wabt itself compiled to Wasm — and it runs out
+of linear memory on large inputs. It trapped with `RuntimeError: memory access
+out of bounds` on the QuickJS artifact after emitting a truncated 2 MB `.c`
+file. A **natively built** wabt translates the same module fine (12.7 MB of C).
+The npm build is adequate for corpus-sized programs and is kept as the
+zero-install fallback, but anything engine-sized needs the native one. The
+generator prefers a native build when present and records which one it used.
+
+### What this means for ADR-0021 — the gate CLOSES
+
+[ADR-0021](../../docs/adr/0021-native-backend-targets-c.md) fixes C as the
+target *if* a direct native backend is ever built, and makes building one
+conditional: *"If those numbers prove inadequate on size or startup, the
+alternative is a direct native backend."*
+
+**They are not inadequate.** On the condition the ADR actually names, this
+measurement closes the gate:
+
+- **Size** — 22.9 KB self-contained for a real program, 1.58x a hand-written C
+  binary. A direct backend cannot beat that by enough to matter; the 8.5 KB of
+  daylight between wasm2c and hand-written C is the entire prize.
+- **Startup** — 0.14–0.20 ms above bare process creation, statistically
+  indistinguishable from hand-written C at this harness's resolution. There is
+  nothing left to win.
+
+The ADR should stay **Accepted as a target choice** and its schedule should stay
+deferred — now on evidence rather than on absence of it. Concretely: the honest
+price the ADR names for the backend ("finishing `ir-full-coverage` first") does
+not have to be paid, and #2855's sequencing is unaffected.
+
+**One thing this does NOT settle, stated plainly.** ADR-0021 rejects Wasm→C on a
+**throughput** argument — that `quickjs.c → Wasm → C → clang` destroys the
+aliasing and control-flow structure the C optimiser needs, so the engine runs
+measurably slower than compiling it directly. This slice measured size and
+startup only, so that objection is **untested here and remains open**. Two
+things bound it, though:
+
+- It is an argument about the **engine**, and no typed program links the engine.
+  For the corpus — the case a normal program is in — it does not arise.
+- Where it does arise there is an obvious escape the ADR does not need a new
+  backend for: **the engine is already C**, so a native build can link
+  `libquickjs` compiled directly by clang and send only *our* generated code
+  through wasm2c. That removes the intermediate Wasm from exactly the code the
+  objection is about. That is a design note, not a measurement — it is the
+  natural follow-up if throughput ever becomes the binding constraint.
+
+Filing a throughput follow-up is the right next step **only if** something
+actually demands it; on size and startup, the question is answered.
+
+### What was not measured
+
+- **Throughput.** Size and startup only. See above.
+- **Non-linear-backend programs.** The linear backend compiles a typed subset,
+  so this measures the subset that exists today. `array-sum` from the landing
+  corpus does not compile under it (`Type 'number' is not assignable to type
+  'never'`) and was excluded rather than quietly dropped.
+- **Cross-platform.** One x86_64 Linux container. No macOS/ARM figures.
+- **Cold filesystem cache.** Deliberately warm, and stated as such.
+
+### One measurement bug worth recording
+
+The first version of the harness closed over the wrong argument, so the two
+wasmtime lanes were timed with the **correctness** argument while WAMR and
+wasm2c were timed with the **startup** argument. Every program hid it except
+`fib-recursive`, where arg 30 is 1.3M recursive calls — a stable, reproducible
++5.7 ms that read exactly like a real wasmtime weakness on recursion, and
+survived two full 201-round runs looking like signal. It was caught only by
+re-running one lane standalone and failing to reproduce it. The generator now
+records each timed lane's exact `argv` in the artifact so the same class of
+error is visible rather than lucky to find. Two related corrections in the same
+pass: `/bin/true` is coreutils and does locale setup, which made two lanes come
+out with impossible *negative* excess until it was replaced with a real empty
+binary; and interleaving a 48 ms Node lane against 1 ms native lanes injected
+the same distortion until the denominators were split by magnitude.
+
+### Acceptance criteria — Part A
+
+- [x] A native binary is produced from a linear-target program and runs, with
+      the exact command recorded (`commands` in the artifact; per-lane `argv`
+      per program).
+- [x] Size and startup recorded as a committed baseline artifact with
+      measurement command and container shape named.
+- [x] The AOT route chosen is justified against alternatives with both sets of
+      numbers — against **two**, plus a hand-written-C floor and an exec floor.
+- [~] "A typed-only program links **none** of the engine": confirmed as far as
+      today's code allows — all six corpus programs emit `imports: []` and
+      4.9–6.5 KB, linking no engine. The *byte-identity* half of that criterion
+      needs elision code to compare against and belongs to Part B.
+- [ ] "A program with a residue links the tier automatically" — **Part B**,
+      depends on #4541, out of scope for this slice.
 
 ## Non-goals
 

--- a/plan/issues/4557-linear-own-allocator-engine-allocates-through-us.md
+++ b/plan/issues/4557-linear-own-allocator-engine-allocates-through-us.md
@@ -1,10 +1,13 @@
 ---
 id: 4557
 title: "Invert allocator ownership: a real linear-lane allocator, installed via JS_NewRuntime2 so QuickJS allocates through us"
-status: in-progress
+status: in-review
 sprint: current
 created: 2026-08-19
 updated: 2026-08-19
+# Implementation complete and all acceptance criteria exercised (see
+# "Implementation notes"). `in-review` rather than `done` because this lane does
+# not merge: the project lead consolidates. Flip to `done` on merge.
 priority: high
 horizon: l
 feasibility: hard
@@ -15,6 +18,17 @@ goal: standalone-mode
 parent: 4538
 depends_on: [4540]
 related: [652, 1856, 4236, 4539]
+assignee: ttraenkler/senior-dev
+# Growth on top of #4540's grants: the allocator is a NEW module
+# (src/codegen-linear/heap-allocator.ts), so what these cover is only the
+# wiring that could not live anywhere else — the `heapAllocator` option next to
+# the option it configures, and two opcode cases in the one opcode switch.
+loc-budget-allow:
+  - src/codegen-linear/runtime.ts
+  - src/codegen-linear/index.ts
+  - src/emit/binary.ts
+func-budget-allow:
+  - src/emit/binary.ts::encodeInstr
 # id 4557 reserved via claim-issue.mjs --allocate --allow-unscanned on
 # 2026-08-19 (gh CLI offline in this container; pr_scan=degraded). Equivalent
 # open-PR scan via the GitHub MCP at reservation time: open PRs were 4646,
@@ -80,22 +94,196 @@ inversion is gated on writing an allocator, not on wiring.
 
 ## Acceptance criteria
 
-- [ ] The engine reaches our allocator, **proven by counting calls**, not
-      inferred from the wiring.
-- [ ] `malloc_usable_size` reports true reserved size across a spread of sizes.
-- [ ] An `eval`-in-a-loop fixture against the real artifact shows a **bounded**
-      heap — the property the bump arena cannot provide.
-- [ ] Allocator measured against the artifact's dlmalloc on an
-      engine-realistic pattern; **both numbers recorded**. A material
-      regression keeps the #4540 fallback as default, and that is an
-      acceptable outcome of this issue.
-- [ ] Whether exactly one component grows the memory is **answered explicitly**,
-      including what wasi-libc still does.
-- [ ] Standalone (unlinked) emit identity unchanged — 60/60 records.
+Ticked only where the criterion was **exercised**. Evidence is in
+`tests/issue-4557-own-allocator.test.ts` unless another source is named.
+
+- [x] The engine reaches our allocator, **proven by counting calls**, not
+      inferred from the wiring. Four call counters live in the emitted module
+      (`__heap_stats(4..7)`) and are read back from OUR side, so no JS closure
+      sits on the allocation path distorting what is measured. Creating the
+      runtime + context alone is 58 allocations; an eval adds more.
+- [x] `malloc_usable_size` reports true reserved size across a spread of sizes.
+      Measured, and it is **not** the request: `malloc(1)→12`, `13→20`,
+      `31→36`, `100→100`, `1000→1004`. The test also WRITES the full reported
+      reservation, so an over-report would trap rather than pass.
+- [x] An `eval`-in-a-loop fixture against the real artifact shows a **bounded**
+      heap. 12 rounds: region bytes flat at 196,608 from round 3 onward,
+      QuickJS's own `malloc_size` flat at 68,304, memory flat at 256 pages.
+- [x] Allocator measured against the artifact's dlmalloc; **both numbers
+      recorded** — see "Measurements" below.
+- [x] Whether exactly one component grows the memory is **answered explicitly**
+      — see "Who grows the memory" below.
+- [x] Standalone (unlinked) emit identity unchanged — 60/60 records identical
+      to a baseline captured before the first edit (`prove-emit-identity`).
 
 ## Non-goals
 
 - **Memory ownership** (our module exporting the memory, the engine importing
   it via `-Wl,--import-memory`) — the other half of ADR-0020 Decision 6, only
   in scope here if it proves *required* to make the allocator work.
+  **NOT required, and the reason is worth recording**: it would have been
+  required under the *import-based* wiring this issue originally specified,
+  because that creates an instantiation CYCLE (the engine imports the allocator
+  from us; we import the memory from the engine, and neither can instantiate
+  first). The table-callback wiring actually used has no cycle, so memory
+  ownership stays untouched. See "Wiring" below.
 - Refcount discipline (#4542) and value representation (#4541).
+
+---
+
+## Implementation notes (2026-08-19)
+
+### What was built
+
+| Area | Change |
+| --- | --- |
+| `src/codegen-linear/heap-allocator.ts` (new) | The allocator. 4-byte block header, boundary tags with a footer in free blocks only, `PINUSE`/`INUSE` flag bits, 32 exact-size small bins (16…264 B) + 16 power-of-two large bins, both-direction coalescing, `realloc` in place in both directions, honest `usable_size`, overflow-checked `calloc`. Control block carved from the FIRST region (no link-time address exists in linked mode — ADR-0022), pointed at by one global `__heap_ctl`. |
+| `src/codegen-linear/runtime.ts` | `ArenaOptions.heapAllocator: "bump" \| "malloc-v1"`. Under `malloc-v1` the allocator is emitted first and `__malloc` becomes the SAME chunked bump prologue #4540 already ships — only the chunk source moves, from the engine's `malloc` to our `__heap_alloc`. ADR-0017's zero-metadata typed path is kept, now over our own heap. |
+| `src/codegen-linear/linked-arena.ts` | Split `isLinkedArena` (imports its memory) from `hasChunkedArena` (`__arena_limit` exists). They were the same question only while a chunked arena implied linked mode; `malloc-v1` gives a STANDALONE module a chunked arena too, and left merged it would have emitted a passive Ryū segment with nothing to copy it in. |
+| `src/emit/{binary.ts}`, `src/ir/types.ts` | `memory.copy` / `memory.fill` (`0xFC 10/11`). `calloc` must zero and `realloc` must relocate; a hand-written byte loop for either puts an interpreter loop on the allocator's path. Neither needs the data-count section. |
+| `scripts/quickjs-artifact/qjs_shim.c` | `qjs_set_allocator(5 table slots)` + `qjs_new_runtime2()` → `JS_NewRuntime2(&mf, NULL)`. Every scratch allocation in the shim also follows the peer allocator, and `qjs_libc_alloc_count()` reports how many did not. `qjs_malloc_size`/`qjs_malloc_count` expose QuickJS's own accounting so a wrong `usable_size` shows up as a number. |
+
+### Wiring: table callbacks, not imports — and why the issue's instruction could not be followed
+
+The issue (scope item 3) specifies
+`__attribute__((import_module("js2wasm"), import_name(...)))`. **That encoding
+cannot be used, and the reason only shows up downstream.** A wasm import must be
+satisfied at INSTANTIATION, so five unconditional imports make the artifact
+un-instantiable without a peer that supplies an allocator. Two shipped
+configurations do exactly that:
+
+- `scripts/quickjs-artifact/extract-abi.mjs` instantiates the artifact ALONE to
+  read the ABI constants out of it — that is how the build produces
+  `qjs-abi.json`;
+- the runtime-eval tier instantiates it beside an adapter that imports FROM it
+  and exports no allocator.
+
+Both would have to hand it JS closures, which is what
+`assertQuickjsArtifactStandalone` exists to forbid ("wasi-stub.mjs is the ONLY
+JavaScript allowed behind the seam"). So this mirrors the **#4245 membrane**,
+which solved the identical problem in the same file: the peer's functions go
+into the artifact's exported, growable `__indirect_function_table` and are
+called through it. The edge stays wasm→wasm, and the artifact **still imports
+only `wasi_snapshot_preview1`** — asserted in the test. Cost: one indirect call
+per allocation instead of a direct one.
+
+`qjs_set_allocator` REFUSES once the shim has already served a libc allocation,
+so a pointer minted by dlmalloc can never be freed through the peer.
+
+### Correction to this issue: the "many small, short-lived objects" premise is FALSE for this engine
+
+The issue and ADR-0020 both reason from "a JS engine allocates many small,
+short-lived objects; dlmalloc is tuned for exactly that; a first-cut allocator
+can lose materially". **Measured against the pinned artifact, quickjs-ng
+v0.16.1 does not hand that pattern to `JSMallocFunctions` at all.** It has its
+own size-class arena (`JSArenaState`, `JS_ARENA_SIZE = 4096`,
+`JS_ARENA_BLOCK_SIZE_COUNT = 31`, `quickjs.c:266`) between the interpreter and
+the embedder allocator.
+
+Request-size histogram for an eval that creates **120,000 objects**, read out of
+our own allocator (`__heap_stats(16..31)`):
+
+| bucket | calls |
+| --- | --- |
+| 8–15 B | 1 |
+| 128–255 B | 1 |
+| 512–1023 B | 2 |
+| 2048–4095 B | 6 |
+| **total** | **10** |
+
+Ten calls, not 120,000. The distribution that reaches us is a handful of ~4 KiB
+arenas plus occasional large blocks. Any benchmark run on a synthetic
+many-tiny-allocations pattern is measuring something this engine never asks for.
+
+### Measurements (2026-08-19, this container, artifact rebuilt from the current shim)
+
+Artifact: quickjs-ng `954dc53` / wasi-libc `8d8348e`, clang 18.1.3, `-O2`.
+`.tmp/qjs-alloc-bench.mjs`, medians of 7.
+
+**End-to-end engine workload** (120,000 objects + arrays + string keys, evaluated
+by the engine, identical source both sides):
+
+| allocator | median |
+| --- | --- |
+| dlmalloc (`JS_NewRuntime`) | 73.13 ms |
+| ours (`JS_NewRuntime2`) | 74.98 ms |
+| **ratio** | **1.025×** |
+
+**Allocator microbenchmarks**, driven from JS against the same shared memory,
+with the JS→wasm call floor measured (`qjs_noop`, 0.62 ms / 200k calls) and
+subtracted:
+
+| pattern | dlmalloc | ours | ratio (floor-subtracted) |
+| --- | --- | --- | --- |
+| engine-shaped (4 KiB arenas + large) | 3.26 ms | 3.51 ms | **1.076×** |
+| many small short-lived (8–256 B) | 3.04 ms | 6.29 ms | **2.068×** |
+
+The 2× on the small pattern is real and it is **not** instrumentation: an A/B
+with the counters and histogram removed measured 6.93 ms vs 6.91 ms — within
+noise. The cause is that `__heap_alloc` makes four to five non-inlined wasm
+calls per allocation (`__heap_find`, `__heap_unlink`, `__heap_insert`, and
+`__heap_bin` three times) where dlmalloc inlines its whole fast path. It does
+not bind on the engine workload, because that pattern does not reach us.
+
+**Artifact size**: 1,016,254 → 1,022,989 bytes raw (349,808 → 352,305 gzipped),
+**+6,735 / +2,497**. ADR-0020 speculated that dropping dlmalloc might shrink the
+artifact; it did not, because dlmalloc is still linked — see below.
+
+### Who grows the memory — answered explicitly
+
+**Exactly one component grows it: the engine's dlmalloc. That is unchanged by
+this work, and dlmalloc is NOT eliminated.**
+
+- Our emitted module contains **no `memory.grow` instruction at all** in linked
+  mode — asserted on the WAT, with #4540's discriminating counter-assertion
+  that the standalone module does contain one. Installing our allocator does
+  not change this: our allocator takes whole REGIONS from the engine's `malloc`
+  and sub-allocates inside them.
+- Measured: six evals of the workload with our allocator installed leave the
+  memory at 256 pages.
+- **What still allocates outside `JSMallocFunctions`:** the shim's own scratch
+  allocations would, and they were rerouted — `qjs_libc_alloc_count()` reads
+  **0** after a full workload. What remains outside is (a) our own region
+  requests, which go to the engine's `malloc` by design, and (b) anything
+  wasi-libc allocates for itself. On this artifact (b) is not exercised by the
+  eval path — the artifact imports only five WASI functions and the build has
+  no stdio in the hot path — but it is **not** zero by construction, and
+  dlmalloc remains linked, which is why the artifact did not shrink.
+- So the honest statement is: **QuickJS's heap is ours; the address space is
+  still the engine's.** Flipping that is the memory-ownership half of Decision
+  6, which is out of scope here.
+
+### Recommendation
+
+**Keep `bump` (the #4540 fallback) as the DEFAULT; ship `malloc-v1` opt-in**,
+which is what this change does — `linearHeapAllocator` is undefined for every
+existing caller and standalone emit is byte-identical.
+
+The measured case for adopting it in the linked/dynamic tier is good and the
+decision is the project lead's: it costs **2.5% end-to-end** and buys real
+reclamation, which the linked chunked arena does not have at all (its chunks are
+never returned). The case against flipping the default *today* is that the
+allocator is new and a bug in it corrupts the engine's heap, where the failure
+surfaces inside foreign code. Suggested order: enable for the dynamic tier
+first, leave standalone on the bump arena.
+
+### Follow-ups (not done)
+
+1. **Small-allocation fast path.** Inline `__heap_bin` and stop recomputing the
+   bin index in `__heap_unlink`/`__heap_insert`; that is most of the 2× above.
+   Only worth it if a future engine version stops arena-ing small allocations.
+2. **`exposeArenaReset`** is still refused with a chunked arena (unchanged from
+   #4540) — now for both chunk sources. Freeing the chunk chain needs a chunk
+   list.
+3. **Region source in linked mode** is fixed to the host `malloc`. Letting it be
+   `memory.grow` would drop dlmalloc from the region path but give up #4540's
+   by-construction one-grower proof. Not attempted.
+
+### Pre-existing failures observed, NOT caused by this work
+
+- `pnpm run check:godfiles` — 14 regressions, all in `src/codegen/`
+  (`index.ts`, `object-runtime.ts`, `array-methods.ts`, `native-strings.ts`,
+  `expressions/calls.ts`). This change touches none of those files; the
+  flagged-file set and the changed-file set do not intersect.
+- `pnpm run check:linear-ir` and `tests/emit-encodeinstr-failloud.test.ts` were
+  already recorded as red on this branch by #4540.

--- a/scripts/benchmark-native-aot.mjs
+++ b/scripts/benchmark-native-aot.mjs
@@ -1,0 +1,769 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/**
+ * scripts/benchmark-native-aot.mjs — #4544 Part A: the native-binary
+ * size/startup baseline that gates ADR-0021.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * ADR-0021 records that a *direct* native backend would emit C — but explicitly
+ * "as a target choice, not a schedule". Whether that backend gets built at all
+ * is gated on this measurement: if ahead-of-time-compiling the Wasm we ALREADY
+ * emit is adequate on size and startup, the second lowering path stays deferred
+ * indefinitely. A result showing AOT is adequate closes the gate, and that is a
+ * useful outcome, not a disappointing one. So this script is deliberately
+ * neutral: it measures every route the issue names and reports ratios with both
+ * sides identified.
+ *
+ * WHAT IT MEASURES
+ * ----------------
+ * Four lanes over one corpus, all from the SAME emitted `.wasm`:
+ *
+ *   | lane            | artifact              | needs at run time        |
+ *   | --------------- | --------------------- | ------------------------ |
+ *   | `wasm-jit`      | `.wasm`               | wasmtime (compiles cold) |
+ *   | `wasmtime-aot`  | `.cwasm`              | wasmtime                 |
+ *   | `wamr-aot`      | `.aot`                | iwasm                    |
+ *   | `wasm2c-native` | a native ELF          | nothing                  |
+ *
+ * `wasm-jit` is the BASELINE the other three are ratios against — it is the
+ * standalone path we ship today. `wasm2c-native` is the only lane that yields a
+ * self-contained executable; the other two AOT lanes produce a module that
+ * still needs its runtime, which is why `shippedBytes` is reported next to
+ * `artifactBytes` and is the honest size number for them.
+ *
+ * Two further denominators, because a ratio needs both sides named:
+ *   - `c-native`: the same algorithm hand-written in C at -O2. The floor —
+ *     what a native binary "should" cost when no Wasm was ever involved.
+ *   - `node`: Node instantiating the same `.wasm`. Context for startup only.
+ *
+ * NOT FOOLING OURSELVES ABOUT STARTUP
+ * -----------------------------------
+ *   - Every program is invoked with the argument that makes its workload
+ *     ~empty (`arg 0`: zero loop trips), plus a dedicated `noop` program. So
+ *     these are instantiation timings, not workload timings.
+ *   - Wall clock is measured around the whole PROCESS (exec -> exit), because
+ *     that is what a CLI user actually waits for.
+ *   - Reported as a DISTRIBUTION (min / p50 / p90 / max) over N runs, never a
+ *     single sample, after a discarded warmup round. The filesystem cache is
+ *     therefore WARM; that is stated in the artifact rather than left implied.
+ *
+ * TOOLCHAIN — none of this ships in the container. Exact provisioning:
+ *
+ *   # wasmtime 27.0.0 (Cranelift AOT)
+ *   curl -sSL -o wasmtime.tar.xz \
+ *     https://github.com/bytecodealliance/wasmtime/releases/download/v27.0.0/wasmtime-v27.0.0-x86_64-linux.tar.xz
+ *   tar xf wasmtime.tar.xz   # -> wasmtime-v27.0.0-x86_64-linux/wasmtime
+ *
+ *   # WAMR 2.2.0 (wamrc compiler + iwasm runtime), prebuilt releases
+ *   curl -sSL -o wamrc.tar.gz \
+ *     https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-2.2.0/wamrc-2.2.0-x86_64-ubuntu-22.04.tar.gz
+ *   curl -sSL -o iwasm.tar.gz \
+ *     https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-2.2.0/iwasm-2.2.0-x86_64-ubuntu-22.04.tar.gz
+ *
+ *   # wasm2c ships in the repo already, via the `wabt` npm package:
+ *   #   node_modules/.bin/wasm2c   (wabt 1.0.39)
+ *   # its C runtime is NOT in that package and is fetched from the matching tag:
+ *   curl -sSL --remote-name-all \
+ *     https://raw.githubusercontent.com/WebAssembly/wabt/1.0.39/wasm2c/{wasm-rt.h,wasm-rt-impl.h,wasm-rt-impl.c,wasm-rt-mem-impl.c,wasm-rt-impl-tableops.inc,wasm-rt-mem-impl-helper.inc}
+ *
+ * USAGE
+ *   pnpm run build:compiler-bundle
+ *   node scripts/benchmark-native-aot.mjs [--runs N] [--out PATH]
+ *
+ * Tool locations are discovered on PATH and under `.tmp/toolchain/`; override
+ * with WASMTIME / WAMRC / IWASM / WASM2C / CC. Every produced binary lands in
+ * `.tmp/` — only the MEASUREMENTS are committed.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { gzipSync } from "node:zlib";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { compile } from "./compiler-bundle.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const WORK = join(REPO_ROOT, ".tmp", "native-aot");
+const DEFAULT_OUT = join(REPO_ROOT, "benchmarks", "results", "native-aot-baseline.json");
+
+// ---------------------------------------------------------------- corpus --
+
+/**
+ * Real programs, not a hello-world — a trivial program flatters AOT on both
+ * axes. Four come from the landing benchmark corpus (the same source bytes the
+ * competitive benchmarks consume) and one from the emit-identity corpus, which
+ * is the only curated program that pulls in the linear backend's Map/Set
+ * open-addressing runtime.
+ *
+ * `arg` is the startup-isolation argument: the value at which the program's
+ * loop body executes zero times, so a wall-clock run is dominated by process
+ * exec + instantiation. `checkArg`/`expect` are the correctness check that the
+ * native binary really ran the program.
+ */
+const CORPUS = [
+  {
+    id: "noop",
+    label: "Empty (startup isolation)",
+    source: "scripts/native-aot-corpus/noop.ts",
+    arity: 1,
+    arg: 0,
+    checkArg: 7,
+    expect: 7,
+  },
+  {
+    id: "fib",
+    label: "Fibonacci loop",
+    source: "website/public/benchmarks/competitive/programs/fib.js",
+    arity: 1,
+    arg: 0,
+    checkArg: 30,
+    expect: 832040,
+  },
+  {
+    id: "fib-recursive",
+    label: "Fibonacci recursion",
+    source: "website/public/benchmarks/competitive/programs/fib-recursive.js",
+    arity: 1,
+    arg: 0,
+    checkArg: 30,
+    expect: 832040,
+  },
+  {
+    id: "string-hash",
+    label: "String build + hash",
+    source: "website/public/benchmarks/competitive/programs/string-hash.js",
+    arity: 1,
+    arg: 0,
+    checkArg: 100,
+    expect: null, // filled from the wasm-jit lane, then required to agree
+  },
+  {
+    id: "object-ops",
+    label: "Object property ops",
+    source: "website/public/benchmarks/competitive/programs/object-ops.js",
+    arity: 1,
+    arg: 0,
+    checkArg: 100,
+    expect: null,
+  },
+  {
+    id: "collections",
+    label: "Map/Set hash-table runtime",
+    source: "scripts/emit-identity-corpus/collections.ts",
+    arity: 0,
+    arg: null,
+    checkArg: null,
+    expect: 232,
+  },
+];
+
+// ------------------------------------------------------------ tool lookup --
+
+function findTool(envVar, candidates) {
+  const fromEnv = process.env[envVar];
+  if (fromEnv) return fromEnv;
+  for (const c of candidates) {
+    const p = c.startsWith("/") ? c : join(REPO_ROOT, c);
+    if (existsSync(p)) return p;
+  }
+  const which = spawnSync("sh", ["-c", `command -v ${envVar.toLowerCase()}`], {
+    encoding: "utf-8",
+  });
+  if (which.status === 0 && which.stdout.trim()) return which.stdout.trim();
+  return null;
+}
+
+const TOOLS = {
+  wasmtime: findTool("WASMTIME", [".tmp/toolchain/wasmtime-v27.0.0-x86_64-linux/wasmtime"]),
+  wamrc: findTool("WAMRC", [".tmp/toolchain/wamr/wamrc"]),
+  // The MINIMAL, AOT-only iwasm built from WAMR source — not the prebuilt
+  // release. This is not a detail: the release `iwasm` is a 52 MB
+  // developer build (interpreter + AOT + JIT + debug) and merely loading it
+  // costs ~7 ms, which would have been recorded as WAMR's startup and
+  // misrepresented the route by ~170x on size and ~2.4x on time. The minimal
+  // build is what an embedder would actually ship. Built with:
+  //   cmake -S wasm-micro-runtime/product-mini/platforms/linux -B build \
+  //     -DWAMR_BUILD_AOT=1 -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_JIT=0 \
+  //     -DWAMR_BUILD_FAST_JIT=0 -DWAMR_BUILD_LIBC_WASI=1 \
+  //     -DWAMR_BUILD_LIBC_BUILTIN=1 -DWAMR_BUILD_SIMD=0 -DCMAKE_BUILD_TYPE=Release
+  //   cmake --build build -j"$(nproc)"
+  iwasm: findTool("IWASM", [".tmp/toolchain/wamr-min/iwasm", ".tmp/toolchain/iwasm/iwasm"]),
+  // Kept only so the size table can name what the convenient prebuilt costs.
+  iwasmRelease: findTool("IWASM_RELEASE", [".tmp/toolchain/iwasm/iwasm"]),
+  // Prefer a NATIVE wabt build over the vendored npm one. The `wabt` npm
+  // package is wabt.js — wabt itself compiled to Wasm — and it runs out of
+  // linear memory on large inputs: it traps with `RuntimeError: memory access
+  // out of bounds` on the 1 MB QuickJS artifact after emitting a truncated
+  // 2 MB .c file. The native build translates the same module fine (12.7 MB of
+  // C). The npm build is adequate for the corpus programs and is kept as the
+  // zero-install fallback, but anything engine-sized needs the native one:
+  //   git clone --depth 1 -b 1.0.39 --recursive https://github.com/WebAssembly/wabt.git
+  //   cmake -S wabt -B wabt-build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF
+  //   cmake --build wabt-build -j"$(nproc)" --target wasm2c
+  wasm2c: findTool("WASM2C", [".tmp/toolchain/wabt-build/wasm2c", "node_modules/.bin/wasm2c"]),
+  cc: process.env.CC || "clang",
+  wasmRt: join(REPO_ROOT, ".tmp", "toolchain", "wasm-rt"),
+};
+
+function toolVersion(bin, args = ["--version"]) {
+  if (!bin) return null;
+  const r = spawnSync(bin, args, { encoding: "utf-8" });
+  return `${r.stdout ?? ""}${r.stderr ?? ""}`.trim().split("\n")[0] || null;
+}
+
+// ------------------------------------------------------------- measurement --
+
+function sizes(path) {
+  const buf = readFileSync(path);
+  return { raw: buf.length, gzip: gzipSync(buf, { level: 9 }).length };
+}
+
+const EXEC_FLOOR_LANE = "__exec-floor";
+
+/**
+ * Time several lanes INTERLEAVED, plus an exec-floor lane, and report both the
+ * raw distribution and a PAIRED excess over the floor.
+ *
+ * Three things this shape is deliberately buying:
+ *
+ * 1. **Interleaving.** Running 30 samples of lane A then 30 of lane B lets
+ *    container load drift between the blocks and land entirely on one lane. One
+ *    round = one sample of every lane, in a fixed order, so a load spike is
+ *    charged to all lanes at once. (Measured while building this: `/bin/true`
+ *    read 3.9 ms during a busy pass and 2.3 ms during a quiet one — a 1.6 ms
+ *    swing, which is larger than the difference this whole issue is about.)
+ *
+ * 2. **A paired floor, in a rotating order.** Every round also times
+ *    `/bin/true`. The reported `aboveFloorMs` is the median of the PER-ROUND
+ *    differences, so the constant cost of process creation — and of this
+ *    harness's own spawn overhead — cancels instead of being subtracted from
+ *    two separately-drifting medians. The lane order rotates each round so no
+ *    lane is systematically first (see the comment on `order` below).
+ *
+ *    RESOLUTION: residual position/scheduling effects are worth roughly
+ *    ±0.5 ms on this container. An `aboveFloorMs` under about 1 ms means
+ *    "indistinguishable from bare process creation", not "exactly this much".
+ *
+ * 3. **Reporting the harness's own cost.** Node's `spawnSync` is not free:
+ *    cross-checked against a Python `subprocess` timer on the same binaries,
+ *    it adds roughly 1 ms per spawn. That inflates every ABSOLUTE number here
+ *    by a constant. It is recorded rather than hidden, and it is exactly what
+ *    `aboveFloorMs` removes — which is why `aboveFloorMs`, not `p50Ms`, is the
+ *    number to quote.
+ */
+/** Path to the compiled exec-floor binary; set once by `main`. */
+let EXEC_FLOOR_BIN = "/bin/true";
+
+function timeLanes(lanes, runs) {
+  const names = Object.keys(lanes);
+  const samples = Object.fromEntries([...names, EXEC_FLOOR_LANE].map((n) => [n, []]));
+  const stdouts = {};
+  const errors = {};
+
+  const once = (bin, args) => {
+    const t0 = process.hrtime.bigint();
+    const r = spawnSync(bin, args, { encoding: "utf-8" });
+    const t1 = process.hrtime.bigint();
+    return { ms: Number(t1 - t0) / 1e6, r };
+  };
+
+  // The floor is just another lane in the rotation, not a privileged first
+  // measurement. Keeping it permanently first gave it a systematic ordering
+  // penalty: in a block whose other lanes included a ~48 ms Node start, the
+  // floor read ~0.8 ms HIGH and two lanes came out with NEGATIVE excess — an
+  // impossible result that is a giveaway for exactly this bias. Rotating the
+  // start index each round spreads any position effect evenly across lanes.
+  const order = [EXEC_FLOOR_LANE, ...names];
+  const binOf = (n) => (n === EXEC_FLOOR_LANE ? EXEC_FLOOR_BIN : lanes[n].bin);
+  const argsOf = (n) => (n === EXEC_FLOOR_LANE ? [] : lanes[n].args);
+
+  // Warmup round, discarded: the filesystem cache is WARM for every timed run.
+  for (const n of order) once(binOf(n), argsOf(n));
+
+  for (let i = 0; i < runs; i++) {
+    for (let j = 0; j < order.length; j++) {
+      const n = order[(i + j) % order.length];
+      const { ms, r } = once(binOf(n), argsOf(n));
+      if (n !== EXEC_FLOOR_LANE) {
+        if (r.status !== 0) errors[n] = `exit ${r.status}: ${(r.stderr ?? "").slice(0, 200)}`;
+        stdouts[n] = (r.stdout ?? "").trim().split("\n").pop() ?? "";
+      }
+      samples[n].push(ms);
+    }
+  }
+
+  const stats = (arr) => {
+    const s = [...arr].sort((a, b) => a - b);
+    const q = (p) => s[Math.min(s.length - 1, Math.floor(p * s.length))];
+    return { minMs: round3(s[0]), p50Ms: round3(q(0.5)), p90Ms: round3(q(0.9)), maxMs: round3(s[s.length - 1]) };
+  };
+  const median = (arr) => {
+    const s = [...arr].sort((a, b) => a - b);
+    return s[Math.floor(s.length / 2)];
+  };
+
+  const out = { runs, execFloor: stats(samples[EXEC_FLOOR_LANE]) };
+  for (const n of names) {
+    const paired = samples[n].map((v, i) => v - samples[EXEC_FLOOR_LANE][i]);
+    out[n] = {
+      // The EXACT argv that was timed. Recorded because the acceptance criteria
+      // ask for reproducibility, and because the one real bug found while
+      // building this harness was a lane being timed with the wrong argument —
+      // invisible in a summary, obvious the moment the argv is written down.
+      argv: relArgv([lanes[n].bin, ...lanes[n].args]),
+      ...stats(samples[n]),
+      // The headline: cost above bare process creation, paired per round.
+      aboveFloorMs: round3(median(paired)),
+      stdout: stdouts[n],
+      ...(errors[n] ? { error: errors[n] } : {}),
+    };
+  }
+  return out;
+}
+
+const round3 = (n) => Math.round(n * 1000) / 1000;
+
+/**
+ * Strip the absolute repo/worktree prefix out of anything that goes into the
+ * committed artifact. Without this every path is `/home/<user>/.../worktrees/
+ * agent-<hash>/...`, which is noise in a file meant to be read and diffed on
+ * another machine.
+ */
+const relPath = (s) => String(s).split(`${REPO_ROOT}/`).join("");
+const relArgv = (argv) => argv.map(relPath);
+
+// ----------------------------------------------------------------- build --
+
+function sh(cmd, args, label) {
+  const r = spawnSync(cmd, args, { encoding: "utf-8" });
+  if (r.status !== 0) {
+    throw new Error(`${label} failed (exit ${r.status}):\n${r.stderr ?? r.stdout}`);
+  }
+  return r;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const runs = Number(argv[argv.indexOf("--runs") + 1]) || 30;
+  const outPath = argv.includes("--out") ? argv[argv.indexOf("--out") + 1] : DEFAULT_OUT;
+
+  // `iwasmRelease` is optional — it only enriches the size table.
+  for (const k of ["wasmtime", "wamrc", "iwasm", "wasm2c", "cc"]) {
+    if (TOOLS[k] === null) {
+      console.error(`missing tool: ${k}. See the provisioning commands in this script's header.`);
+      process.exit(1);
+    }
+  }
+  if (!existsSync(join(TOOLS.wasmRt, "wasm-rt-impl.c"))) {
+    console.error(`missing wasm2c runtime sources under ${TOOLS.wasmRt} — see header.`);
+    process.exit(1);
+  }
+
+  rmSync(WORK, { recursive: true, force: true });
+  for (const d of ["wasm", "cwasm", "aot", "c", "bin"]) {
+    mkdirSync(join(WORK, d), { recursive: true });
+  }
+
+  // Built before any timing: every lane is paired against it.
+  EXEC_FLOOR_BIN = join(WORK, "bin", "exec-floor");
+  sh(
+    TOOLS.cc,
+    ["-O2", "-o", EXEC_FLOOR_BIN, join(REPO_ROOT, "scripts", "native-aot-corpus", "exec-floor.c")],
+    "cc (exec floor)",
+  );
+  spawnSync("strip", [EXEC_FLOOR_BIN]);
+
+  const programs = [];
+
+  for (const p of CORPUS) {
+    process.stdout.write(`\n=== ${p.id}\n`);
+
+    // 1. Emit the linear-backend module. The linear backend is the ONLY one
+    //    all three AOT routes can consume: wasm2c and WAMR have no WasmGC, so
+    //    `--target wasi` (WasmGC + WASI) is not AOT-able by two of the three.
+    const src = readFileSync(join(REPO_ROOT, p.source), "utf-8");
+    const res = await compile(src, { target: "linear" });
+    if (!res.success || !res.binary) {
+      throw new Error(`${p.id}: compile failed: ${res.errors?.[0]?.message}`);
+    }
+    const wasmPath = join(WORK, "wasm", `${p.id}.wasm`);
+    writeFileSync(wasmPath, res.binary);
+
+    const mod = await WebAssembly.compile(res.binary);
+    const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}.${i.name}`);
+
+    const runArgs = p.arity === 0 ? [] : [String(p.arg)];
+    const checkArgs = p.arity === 0 ? [] : [String(p.checkArg)];
+
+    // 2. wasmtime AOT
+    const cwasmPath = join(WORK, "cwasm", `${p.id}.cwasm`);
+    sh(TOOLS.wasmtime, ["compile", wasmPath, "-o", cwasmPath], "wasmtime compile");
+
+    // 3. WAMR AOT
+    const aotPath = join(WORK, "aot", `${p.id}.aot`);
+    sh(TOOLS.wamrc, ["-o", aotPath, wasmPath], "wamrc");
+
+    // 4. wasm2c -> native ELF
+    const cDir = join(WORK, "c");
+    // Alphanumeric only. wasm2c escapes every non-alphanumeric character in the
+    // module name when it builds C symbols — `-` becomes `0x2D` and even `_`
+    // becomes `__` — so any separator here desynchronises the driver's macros
+    // from the generated header.
+    const modName = p.id.replace(/[^a-z0-9]/gi, "");
+    const cPath = join(cDir, `${modName}.c`);
+    // `-n` is required, not cosmetic: without it wasm2c derives the C symbol
+    // prefix from the embedded module name and hex-escapes anything not
+    // C-identifier-safe (`fib-recursive` -> `w2c_fib0x2Drecursive_run`), which
+    // no fixed driver template can name.
+    sh(TOOLS.wasm2c, [wasmPath, "-n", modName, "-o", cPath], "wasm2c");
+    const binPath = join(WORK, "bin", `${p.id}`);
+    // -fwrapv: ADR-0021 names signed-overflow wrap as a semantic requirement of
+    // any C target. wasm2c already emits wrapping idioms, but pinning it here
+    // makes the build match the ADR's stated constraint rather than rely on it.
+    sh(
+      TOOLS.cc,
+      [
+        "-O2",
+        "-fwrapv",
+        "-o",
+        binPath,
+        `-I${TOOLS.wasmRt}`,
+        `-I${cDir}`,
+        `-DMOD_NAME=${modName}`,
+        `-DMOD_HEADER="${modName}.h"`,
+        ...(p.arity === 0 ? ["-DARITY0"] : []),
+        join(REPO_ROOT, "scripts", "native-aot-corpus", "driver.c"),
+        cPath,
+        join(TOOLS.wasmRt, "wasm-rt-impl.c"),
+        join(TOOLS.wasmRt, "wasm-rt-mem-impl.c"),
+        "-lm",
+      ],
+      "cc (wasm2c native)",
+    );
+    const strippedPath = `${binPath}-stripped`;
+    sh("cp", [binPath, strippedPath], "cp");
+    spawnSync("strip", [strippedPath]);
+
+    // ---- correctness: every lane must agree, on a REAL argument ----
+    // `progArgs` is a REQUIRED parameter, not a closed-over default. It was
+    // originally closed over `checkArgs`, which silently timed the two wasmtime
+    // lanes with the correctness argument while WAMR and wasm2c were timed with
+    // the startup argument. Every program hid it except `fib-recursive`, where
+    // arg 30 is 1.3M recursive calls — a reproducible +5.7 ms that looked
+    // exactly like a real wasmtime weakness on recursion. Timing the WORKLOAD
+    // when you meant to time STARTUP is the trap this whole measurement is
+    // supposed to avoid; keep the argument explicit at every call site.
+    const wasmtimeInvoke = (art, extra, progArgs) => ["run", ...extra, "--invoke", "run", art, ...progArgs];
+    const outputs = {
+      "wasm-jit": sh(TOOLS.wasmtime, wasmtimeInvoke(wasmPath, [], checkArgs), "check jit").stdout.trim(),
+      "wasmtime-aot": sh(
+        TOOLS.wasmtime,
+        wasmtimeInvoke(cwasmPath, ["--allow-precompiled"], checkArgs),
+        "check cwasm",
+      ).stdout.trim(),
+      "wamr-aot": sh(TOOLS.iwasm, ["-f", "run", aotPath, ...checkArgs], "check aot")
+        .stdout.trim()
+        .replace(/:f64$/, ""),
+      "wasm2c-native": sh(binPath, checkArgs, "check native").stdout.trim(),
+    };
+    // Node is the oracle — the acceptance criteria ask for output matching Node,
+    // not merely for the four Wasm lanes agreeing with each other.
+    outputs.node = sh(
+      process.execPath,
+      [join(REPO_ROOT, "scripts", "native-aot-corpus", "node-runner.mjs"), wasmPath, ...checkArgs],
+      "check node",
+    ).stdout.trim();
+
+    // iwasm's `-f` printer emits 6 significant digits (`3.67299e+07`), so an
+    // exact string compare would flag a PRINTER artifact as a computation
+    // difference. Comparing at the weakest printer's precision is the honest
+    // resolution of the measurement, and it is recorded as such rather than
+    // silently widened.
+    const sig6 = (v) => Number(Number(v).toPrecision(6));
+    const distinct = [...new Set(Object.values(outputs).map(sig6))];
+    if (distinct.length !== 1) {
+      throw new Error(`${p.id}: lanes disagree: ${JSON.stringify(outputs)}`);
+    }
+    if (p.expect !== null && sig6(p.expect) !== distinct[0]) {
+      throw new Error(`${p.id}: expected ${p.expect}, lanes produced ${distinct[0]}`);
+    }
+
+    // ---- startup: workload ~empty, interleaved, paired against the exec floor ----
+    const startup = timeLanes(
+      {
+        "wasm-jit": { bin: TOOLS.wasmtime, args: wasmtimeInvoke(wasmPath, [], runArgs) },
+        "wasmtime-aot": {
+          bin: TOOLS.wasmtime,
+          args: wasmtimeInvoke(cwasmPath, ["--allow-precompiled"], runArgs),
+        },
+        "wamr-aot": { bin: TOOLS.iwasm, args: ["-f", "run", aotPath, ...runArgs] },
+        "wasm2c-native": { bin: binPath, args: runArgs },
+      },
+      runs,
+    );
+
+    programs.push({
+      id: p.id,
+      label: p.label,
+      source: p.source,
+      value: distinct[0],
+      checkArg: p.checkArg,
+      // Kept verbatim, including iwasm's lossy printer, so the agreement claim
+      // above can be re-checked from the artifact rather than trusted.
+      outputs,
+      imports,
+      size: {
+        "wasm-jit": sizes(wasmPath),
+        "wasmtime-aot": sizes(cwasmPath),
+        "wamr-aot": sizes(aotPath),
+        "wasm2c-native": sizes(binPath),
+        "wasm2c-native-stripped": sizes(strippedPath),
+        generatedCBytes: statSync(cPath).size,
+      },
+      startup,
+    });
+    console.log(
+      `  wasm ${sizes(wasmPath).raw}B  cwasm ${sizes(cwasmPath).raw}B  aot ${sizes(aotPath).raw}B  native ${sizes(strippedPath).raw}B(stripped)`,
+    );
+    console.log(
+      `  startup above exec floor: jit ${startup["wasm-jit"].aboveFloorMs}ms  wasmtime-aot ${startup["wasmtime-aot"].aboveFloorMs}ms  wamr-aot ${startup["wamr-aot"].aboveFloorMs}ms  native ${startup["wasm2c-native"].aboveFloorMs}ms`,
+    );
+  }
+
+  // ------------------------------------------------- denominators --------
+  // A ratio needs both sides named. `c-native` is the floor: the same loop in
+  // C, compiled by the same clang, never having been Wasm.
+  process.stdout.write("\n=== denominators\n");
+  const cFloorSrc = join(REPO_ROOT, "scripts", "native-aot-corpus", "fib-floor.c");
+  const cFloorBin = join(WORK, "bin", "fib-c-floor");
+  sh(TOOLS.cc, ["-O2", "-fwrapv", "-o", cFloorBin, cFloorSrc], "cc (c floor)");
+  spawnSync("strip", [cFloorBin]);
+  const cFloorCheck = sh(cFloorBin, ["30"], "c floor check").stdout.trim();
+  if (Number(cFloorCheck) !== 832040) {
+    throw new Error(`c floor produced ${cFloorCheck}, expected 832040`);
+  }
+  // TWO blocks, not one. Interleaving only cancels drift between lanes of
+  // COMPARABLE cost: putting Node's ~48 ms start in the same rounds as two
+  // ~1 ms native binaries let the expensive lane disturb whichever lane
+  // followed it, and the paired medians came out NEGATIVE for the two
+  // floor-speed lanes. Grouping by magnitude fixes it. (The per-program blocks
+  // above are already homogeneous — every lane there is 4–10 ms.)
+  const denomFast = timeLanes(
+    {
+      "c-native": { bin: cFloorBin, args: ["0"] },
+      "wasm2c-native-fib": { bin: join(WORK, "bin", "fib"), args: ["0"] },
+    },
+    runs,
+  );
+  const denomSlow = timeLanes(
+    {
+      node: {
+        bin: process.execPath,
+        args: [join(REPO_ROOT, "scripts", "native-aot-corpus", "node-runner.mjs"), join(WORK, "wasm", "fib.wasm"), "0"],
+      },
+      ...(TOOLS.iwasmRelease && TOOLS.iwasmRelease !== TOOLS.iwasm
+        ? {
+            "wamr-aot-release-iwasm": {
+              bin: TOOLS.iwasmRelease,
+              args: ["-f", "run", join(WORK, "aot", "fib.aot"), "0"],
+            },
+          }
+        : {}),
+    },
+    runs,
+  );
+  const denomStartup = { ...denomFast, ...denomSlow, execFloor: denomFast.execFloor };
+
+  const cFloor = {
+    note: "fib(n) hand-written in C, same clang -O2 -fwrapv, stripped. The floor: what a native binary costs in size and startup when no Wasm was ever involved. `wasm2c-native-fib` is re-timed alongside it so the two are directly comparable.",
+    size: sizes(cFloorBin),
+    startup: denomStartup["c-native"],
+    wasm2cNativeSameRound: denomStartup["wasm2c-native-fib"],
+  };
+
+  const execFloor = {
+    note: "scripts/native-aot-corpus/exec-floor.c — `int main(void){return 0;}`, same clang, stripped. The process exec + dynamic-loader + libc-start floor that EVERY lane pays, plus this harness's own ~1 ms spawnSync overhead. No process-based route can start faster. It is what `aboveFloorMs` subtracts. NOT /bin/true: coreutils does locale setup worth ~0.5 ms, which showed up as impossible negative excesses on the floor-speed lanes.",
+    binary: sizes(EXEC_FLOOR_BIN),
+    startup: denomStartup.execFloor,
+  };
+
+  const nodeFloor = {
+    note: "node instantiating the same fib .wasm. Context for startup only; Node's own boot dominates and nobody would ship this as a native binary.",
+    startup: denomStartup.node,
+  };
+
+  const wamrReleaseLane = denomStartup["wamr-aot-release-iwasm"] ?? null;
+
+  // What you actually SHIP for the two lanes that keep a runtime.
+  const runtimeSizes = {
+    wasmtime: {
+      path: relPath(TOOLS.wasmtime),
+      ...sizes(TOOLS.wasmtime),
+      note: "wasmtime 27.0.0 official release CLI. Required at run time by the wasm-jit and wasmtime-aot lanes.",
+    },
+    iwasm: {
+      path: relPath(TOOLS.iwasm),
+      ...sizes(TOOLS.iwasm),
+      note: "iwasm 2.2.0 built AOT-ONLY from source (interpreter/JIT/SIMD off) — what an embedder would actually ship. Required at run time by the wamr-aot lane.",
+    },
+    iwasmRelease:
+      TOOLS.iwasmRelease && TOOLS.iwasmRelease !== TOOLS.iwasm
+        ? {
+            path: relPath(TOOLS.iwasmRelease),
+            ...sizes(TOOLS.iwasmRelease),
+            startup: wamrReleaseLane,
+            note: "The PREBUILT iwasm 2.2.0 release, for contrast only. A full developer build (interpreter + AOT + JIT + debug). Recorded because reaching for the convenient prebuilt is the obvious mistake here and it misstates WAMR badly on both axes — compare its bytes and its aboveFloorMs against the minimal build above.",
+          }
+        : null,
+    "wasm2c-native": {
+      path: null,
+      raw: 0,
+      gzip: 0,
+      note: "Nothing. The wasm2c lane's binary IS the whole deliverable — wabt's wasm-rt is statically linked into it and is already counted in each program's wasm2c-native size.",
+    },
+  };
+
+  // The dynamic tier, measured separately and NEVER blended into the numbers
+  // above: none of the corpus programs link it (they are typed, eval-free).
+  const qjs = join(REPO_ROOT, ".tmp", "quickjs-artifact", "libquickjs.wasm");
+  let dynamicTier = null;
+  if (existsSync(qjs)) {
+    const cw = join(WORK, "cwasm", "libquickjs.cwasm");
+    const ao = join(WORK, "aot", "libquickjs.aot");
+    sh(TOOLS.wasmtime, ["compile", qjs, "-o", cw], "wasmtime compile quickjs");
+    sh(TOOLS.wamrc, ["-o", ao, qjs], "wamrc quickjs");
+    dynamicTier = {
+      note: "The QuickJS boxed-tier artifact (#4236), built by scripts/quickjs-artifact/build.sh at -O2. Reported SEPARATELY and never blended with the corpus: no corpus program links it (all are typed and eval-free). This is what a program WITH a dynamic residue would additionally pay.",
+      source: ".tmp/quickjs-artifact/libquickjs.wasm",
+      buildInfo: JSON.parse(readFileSync(join(REPO_ROOT, ".tmp", "quickjs-artifact", "build-info.json"), "utf-8")),
+      size: {
+        "wasm-jit": sizes(qjs),
+        "wasmtime-aot": sizes(cw),
+        "wamr-aot": sizes(ao),
+      },
+    };
+
+    // The recommended route, exercised on the hardest input the project has.
+    // A recommendation that only survives 5 KB corpus programs would be worth
+    // very little: this links the WHOLE engine into one native executable and
+    // evaluates JavaScript in it. Needs a native wasm2c (see the TOOLS note).
+    const qjsC = join(WORK, "c", "qjs.c");
+    const w2c = spawnSync(TOOLS.wasm2c, [qjs, "-n", "qjs", "-o", qjsC], { encoding: "utf-8" });
+    if (w2c.status !== 0) {
+      dynamicTier.wasm2cNative = {
+        status: "FAILED",
+        detail: `${TOOLS.wasm2c} could not translate the engine: ${(w2c.stderr ?? "").split("\n")[0].slice(0, 200)}`,
+        note: "Recorded as a failure rather than dropped. If this is the npm `wabt` build, it is the known heap limit — build wabt natively.",
+      };
+    } else {
+      const qjsBin = join(WORK, "bin", "qjs-native");
+      sh(
+        TOOLS.cc,
+        [
+          "-O2",
+          "-fwrapv",
+          "-o",
+          qjsBin,
+          `-I${TOOLS.wasmRt}`,
+          `-I${join(WORK, "c")}`,
+          join(REPO_ROOT, "scripts", "native-aot-corpus", "qjs-driver.c"),
+          qjsC,
+          join(TOOLS.wasmRt, "wasm-rt-impl.c"),
+          join(TOOLS.wasmRt, "wasm-rt-mem-impl.c"),
+          "-lm",
+        ],
+        "cc (quickjs native)",
+      );
+      spawnSync("strip", [qjsBin]);
+      // Correctness first: it must actually evaluate JavaScript, not merely link.
+      const evalChecks = [
+        ["1+1", "2"],
+        ['[1,2,3].map(x=>x*7).join("-")', "7-14-21"],
+        ["JSON.stringify({a:1,b:[2,3]})", '{"a":1,"b":[2,3]}'],
+      ];
+      const evalResults = evalChecks.map(([src, want]) => {
+        const got = sh(qjsBin, [src], "quickjs native eval").stdout.trim();
+        if (got !== want) throw new Error(`quickjs native: ${src} -> ${got}, expected ${want}`);
+        return { src, got };
+      });
+      const qjsStartup = timeLanes({ "quickjs-native": { bin: qjsBin, args: ["1+1"] } }, runs);
+      dynamicTier.wasm2cNative = {
+        status: "ok",
+        note: "The whole engine linked into ONE self-contained native executable via the recommended route, evaluating real JavaScript. Nothing else ships alongside it. Startup includes instantiating a QuickJS runtime + context and evaluating `1+1`. The five wasi_snapshot_preview1 imports are implemented in scripts/native-aot-corpus/qjs-driver.c — about forty lines, no uvwasi, no WASI SDK at run time.",
+        generatedCBytes: statSync(qjsC).size,
+        size: sizes(qjsBin),
+        evalResults,
+        startup: qjsStartup["quickjs-native"],
+        execFloor: qjsStartup.execFloor,
+      };
+    }
+  }
+
+  const artifact = {
+    issue: 4544,
+    part: "A",
+    title: "Native binary emission: size/startup baseline",
+    generatedAt: new Date().toISOString(),
+    generatedBy: "scripts/benchmark-native-aot.mjs",
+    gates: "docs/adr/0021-native-backend-targets-c.md",
+    container: {
+      arch: process.arch,
+      platform: process.platform,
+      cpus: (() => {
+        try {
+          return execFileSync("nproc", { encoding: "utf-8" }).trim();
+        } catch {
+          return null;
+        }
+      })(),
+      kernel: execFileSync("uname", ["-r"], { encoding: "utf-8" }).trim(),
+      node: process.version,
+      note: "Shared 4-core container; startup numbers carry scheduler noise, which is why the distribution is reported rather than a single sample.",
+    },
+    methodology: {
+      backend:
+        "--target linear (linear memory). The linear backend is the only one all three AOT routes can consume: wasm2c and WAMR have no WasmGC support, so the WasmGC `wasi` target is AOT-able by at most one of the three.",
+      startup:
+        "Whole-process wall clock (exec to exit), argument chosen so the program's loop body runs ZERO times, one discarded warmup then N timed rounds, filesystem cache WARM. Lanes are interleaved in a rotating order within each round, and each round also times an exec-floor binary; QUOTE `aboveFloorMs` (median of per-round differences), not `p50Ms` — the absolute figures include ~1 ms of this harness's own spawnSync cost. Resolution is about +/-0.5 ms, so an aboveFloorMs under ~1 ms means indistinguishable from bare process creation.",
+      size: "Raw and gzip -9. The honest size for a lane is artifact + whatever must ship with it: see denominators.runtimeSizes. wasm2c-native ships nothing else, so its binary IS its shipped size.",
+      correctness:
+        "Every lane is re-run on a REAL argument and all four lane outputs must agree with each other AND with Node before any timing is recorded. Agreement is checked at 6 significant digits because iwasm's `-f` printer is lossy; raw per-lane outputs are kept in each program's `outputs`.",
+      dynamicTier:
+        "Measured separately. No corpus program links QuickJS (all are typed and eval-free), so the corpus numbers are what a normal program pays.",
+    },
+    toolchain: {
+      wasmtime: toolVersion(TOOLS.wasmtime),
+      wamrc: toolVersion(TOOLS.wamrc),
+      iwasm: toolVersion(TOOLS.iwasm, ["--version"]),
+      // Path as well as version: the npm and native builds report the SAME
+      // version string (1.0.39) but do not have the same capability — only the
+      // native one can translate the engine.
+      wasm2c: `${toolVersion(TOOLS.wasm2c)} (${TOOLS.wasm2c.includes("node_modules") ? "npm wabt.js build" : "native build"} at ${relPath(TOOLS.wasm2c)})`,
+      cc: toolVersion(TOOLS.cc),
+      wasmRtSource: "wabt 1.0.39 wasm2c/ (fetched at the matching tag; see script header)",
+    },
+    commands: {
+      "wasm-jit": "wasmtime run --invoke run <prog>.wasm <arg>",
+      "wasmtime-aot":
+        "wasmtime compile <prog>.wasm -o <prog>.cwasm && wasmtime run --allow-precompiled --invoke run <prog>.cwasm <arg>",
+      "wamr-aot": "wamrc -o <prog>.aot <prog>.wasm && iwasm -f run <prog>.aot <arg>",
+      "wasm2c-native":
+        "wasm2c <prog>.wasm -o <prog>.c && clang -O2 -fwrapv -o <prog> scripts/native-aot-corpus/driver.c <prog>.c wasm-rt-impl.c wasm-rt-mem-impl.c -lm && ./<prog> <arg>",
+      "c-floor": "clang -O2 -fwrapv -o fib-c-floor scripts/native-aot-corpus/fib-floor.c && ./fib-c-floor <arg>",
+    },
+    runs,
+    programs,
+    denominators: { cFloor, execFloor, nodeFloor, runtimeSizes },
+    dynamicTier,
+  };
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  console.log(`\nwrote ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/native-aot-corpus/driver.c
+++ b/scripts/native-aot-corpus/driver.c
@@ -1,0 +1,48 @@
+/* #4544 Part A — native driver for the wasm2c route.
+ *
+ * wasm2c emits a translation unit per module plus a header declaring the
+ * instance struct and the exports; it does NOT emit a `main`. This is that
+ * `main`: instantiate, call the exported `run`, print, free.
+ *
+ * One template serves every corpus program — the build script passes MOD_NAME
+ * (the wasm2c module prefix, derived from the output filename) and MOD_HEADER,
+ * and defines ARITY0 for the one program whose `run` takes no argument.
+ *
+ * Note what is NOT here: no WASI shim, no host imports, no runtime lookup. The
+ * linear backend's modules import nothing, so the whole native binary is this
+ * file plus the translated module plus wabt's ~15 KB wasm-rt.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "wasm-rt.h"
+
+#include MOD_HEADER
+
+#define CAT_(a, b) a##b
+#define CAT(a, b) CAT_(a, b)
+#define INSTANTIATE CAT(CAT(wasm2c_, MOD_NAME), _instantiate)
+#define FREEFN CAT(CAT(wasm2c_, MOD_NAME), _free)
+#define RUNFN CAT(CAT(w2c_, MOD_NAME), _run)
+#define INSTTYPE CAT(w2c_, MOD_NAME)
+
+int main(int argc, char **argv) {
+  double arg = argc > 1 ? atof(argv[1]) : 0.0;
+  (void)arg;
+
+  wasm_rt_init();
+  struct INSTTYPE inst;
+  INSTANTIATE(&inst);
+
+#ifdef ARITY0
+  double r = RUNFN(&inst);
+#else
+  double r = RUNFN(&inst, arg);
+#endif
+
+  printf("%.0f\n", r);
+
+  FREEFN(&inst);
+  wasm_rt_free();
+  return 0;
+}

--- a/scripts/native-aot-corpus/exec-floor.c
+++ b/scripts/native-aot-corpus/exec-floor.c
@@ -1,0 +1,13 @@
+/* #4544 Part A — the exec floor.
+ *
+ * The cheapest possible process: fork/exec, dynamic loader, libc start, exit.
+ * Every lane in this benchmark pays this, plus the harness's own spawn cost,
+ * so it is what `aboveFloorMs` subtracts.
+ *
+ * WHY NOT `/bin/true`: that was the first choice and it was wrong. GNU
+ * coreutils binaries do real startup work — `set_program_name`, `setlocale`,
+ * `bindtextdomain` — worth a consistent ~0.5 ms here. Using it as the floor
+ * made the two genuinely-floor-speed lanes come out with NEGATIVE excess, which
+ * is impossible and is the tell that the floor itself was too expensive.
+ */
+int main(void) { return 0; }

--- a/scripts/native-aot-corpus/fib-floor.c
+++ b/scripts/native-aot-corpus/fib-floor.c
@@ -1,0 +1,29 @@
+/* #4544 Part A — the native floor denominator.
+ *
+ * The same loop as website/public/benchmarks/competitive/programs/fib.js,
+ * hand-written in C and compiled by the same clang at the same -O2 -fwrapv.
+ * This is the number the AOT routes are measured AGAINST: what a native binary
+ * costs in size and startup when no Wasm was ever in the picture.
+ *
+ * -fwrapv is not decoration: JS `|0` wraps and signed overflow in C is
+ * undefined, which ADR-0021 lists as a semantic requirement of any C target.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+static int run(int n) {
+  int a = 0;
+  int b = 1;
+  for (int i = 0; i < n; i++) {
+    int next = a + b;
+    a = b;
+    b = next;
+  }
+  return a;
+}
+
+int main(int argc, char **argv) {
+  int n = argc > 1 ? atoi(argv[1]) : 0;
+  printf("%d\n", run(n));
+  return 0;
+}

--- a/scripts/native-aot-corpus/node-runner.mjs
+++ b/scripts/native-aot-corpus/node-runner.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4544 Part A — the Node startup denominator.
+//
+// Instantiates the same emitted `.wasm` under Node and calls `run`. This exists
+// only as CONTEXT for the startup numbers: Node's own boot dominates, so this
+// is not a lane anyone would ship a native binary as — it is the "what does the
+// JS host cost" side of the ratio.
+import { readFileSync } from "node:fs";
+
+const [, , wasmPath, argText] = process.argv;
+const mod = new WebAssembly.Module(readFileSync(wasmPath));
+const inst = new WebAssembly.Instance(mod, {});
+process.stdout.write(`${inst.exports.run(Number(argText ?? 0))}\n`);

--- a/scripts/native-aot-corpus/noop.ts
+++ b/scripts/native-aot-corpus/noop.ts
@@ -1,0 +1,12 @@
+// #4544 Part A — startup-isolation program.
+//
+// Does approximately nothing, so a wall-clock run of the compiled artifact is
+// dominated by process exec + module instantiation rather than by any workload.
+// `n` is threaded through and returned so the call cannot be folded away.
+//
+// This exists because the other corpus programs, even at their zero argument,
+// still carry their own runtime scaffolds; this one isolates the floor that
+// EVERY linear-backend module pays.
+export function run(n: number): number {
+  return n | 0;
+}

--- a/scripts/native-aot-corpus/qjs-driver.c
+++ b/scripts/native-aot-corpus/qjs-driver.c
@@ -1,0 +1,126 @@
+/* #4544 Part A — native driver for the DYNAMIC-TIER binary.
+ *
+ * This is the hard case for the recommended route. The corpus programs link no
+ * engine at all; this one links the whole QuickJS boxed tier (#4236) — a 1 MB
+ * wasm32-wasip1 module — through wasm2c into a single native executable, and
+ * evaluates JavaScript in it. It exists to answer two questions the corpus
+ * cannot:
+ *
+ *   1. Does the wasm2c route survive a real, large, C-derived module at all?
+ *   2. What does a program WITH a dynamic residue weigh natively?
+ *
+ * The five `wasi_snapshot_preview1` imports are implemented right here, in
+ * about forty lines, because that is the whole host surface the artifact needs
+ * — no uvwasi, no WASI SDK at run time. `fd_write` is the only one that does
+ * real work; the rest are the stubs a reactor module touches on paths QuickJS
+ * does not take.
+ *
+ * NOTE ON THE ABI: under wasm2c a wasm pointer is a u32 offset into the
+ * module's linear memory, NOT a C pointer. Every string handed to or taken from
+ * QuickJS has to be moved through `qjs_malloc_raw` + the memory base, which is
+ * exactly the discipline scripts/quickjs-artifact/README.md describes for the
+ * peer module.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "wasm-rt.h"
+
+#include "qjs.h"
+
+/* ------------------------------------------------------- the five imports -- */
+/* wasm2c routes host imports through an opaque instance pointer; this module
+ * needs no host state, so the struct is empty and the pointer is a token. */
+struct w2c_wasi__snapshot__preview1 {
+  w2c_qjs *mod;
+};
+
+static uint8_t *mem_base(struct w2c_wasi__snapshot__preview1 *w) {
+  return w2c_qjs_memory(w->mod)->data;
+}
+
+static u32 ld32(struct w2c_wasi__snapshot__preview1 *w, u32 addr) {
+  u32 v;
+  memcpy(&v, mem_base(w) + addr, 4);
+  return v;
+}
+
+static void st32(struct w2c_wasi__snapshot__preview1 *w, u32 addr, u32 v) {
+  memcpy(mem_base(w) + addr, &v, 4);
+}
+
+/* The only import that does real work: gather the iovecs and write them out. */
+u32 w2c_wasi__snapshot__preview1_fd_write(struct w2c_wasi__snapshot__preview1 *w, u32 fd, u32 iovs,
+                                          u32 iovs_len, u32 nwritten) {
+  u32 total = 0;
+  FILE *out = fd == 2 ? stderr : stdout;
+  for (u32 i = 0; i < iovs_len; i++) {
+    u32 buf = ld32(w, iovs + i * 8);
+    u32 len = ld32(w, iovs + i * 8 + 4);
+    if (len) total += (u32)fwrite(mem_base(w) + buf, 1, len, out);
+  }
+  st32(w, nwritten, total);
+  return 0;
+}
+
+u32 w2c_wasi__snapshot__preview1_clock_time_get(struct w2c_wasi__snapshot__preview1 *w, u32 id,
+                                                u64 precision, u32 out) {
+  (void)id;
+  (void)precision;
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  u64 ns = (u64)ts.tv_sec * 1000000000ull + (u64)ts.tv_nsec;
+  memcpy(mem_base(w) + out, &ns, 8);
+  return 0;
+}
+
+u32 w2c_wasi__snapshot__preview1_fd_close(struct w2c_wasi__snapshot__preview1 *w, u32 fd) {
+  (void)w;
+  (void)fd;
+  return 0;
+}
+
+u32 w2c_wasi__snapshot__preview1_fd_fdstat_get(struct w2c_wasi__snapshot__preview1 *w, u32 fd,
+                                                u32 out) {
+  (void)fd;
+  memset(mem_base(w) + out, 0, 24);
+  return 0;
+}
+
+u32 w2c_wasi__snapshot__preview1_fd_seek(struct w2c_wasi__snapshot__preview1 *w, u32 fd, u64 off,
+                                          u32 whence, u32 out) {
+  (void)fd;
+  (void)off;
+  (void)whence;
+  memset(mem_base(w) + out, 0, 8);
+  return 0;
+}
+
+/* --------------------------------------------------------------- the run -- */
+
+int main(int argc, char **argv) {
+  const char *src = argc > 1 ? argv[1] : "1+1";
+  const u32 len = (u32)strlen(src);
+
+  wasm_rt_init();
+  static w2c_qjs mod;
+  struct w2c_wasi__snapshot__preview1 wasi = {&mod};
+  wasm2c_qjs_instantiate(&mod, &wasi);
+  w2c_qjs_0x5Finitialize(&mod); /* reactor init */
+
+  u32 rt = w2c_qjs_qjs_new_runtime(&mod);
+  u32 ctx = w2c_qjs_qjs_new_context(&mod, rt);
+
+  /* Move the source into the module's heap — a wasm "pointer" is an offset. */
+  u32 buf = w2c_qjs_qjs_malloc_raw(&mod, len + 1);
+  memcpy(w2c_qjs_memory(&mod)->data + buf, src, len + 1);
+
+  u32 val = w2c_qjs_qjs_eval(&mod, ctx, buf, len);
+  u32 cstr = w2c_qjs_qjs_to_cstring(&mod, ctx, val);
+  printf("%s\n", cstr ? (char *)(w2c_qjs_memory(&mod)->data + cstr) : "(null)");
+
+  wasm_rt_free();
+  return 0;
+}

--- a/scripts/quickjs-artifact/qjs_shim.c
+++ b/scripts/quickjs-artifact/qjs_shim.c
@@ -52,6 +52,12 @@
  *    exported.  js2wasm's own bump arena must live ABOVE this module's heap or
  *    be made dynamic — two independent growers over one memory corrupt it
  *    (#4236 R5 gap 4).
+ *
+ *    SUPERSEDED IN PART by #4557: the peer may now install ITS allocator here
+ *    (`qjs_set_allocator` + `qjs_new_runtime2`), so the direction inverts and
+ *    QuickJS's whole heap comes from the peer.  What survives unchanged is the
+ *    one-address-space rule: whoever allocates, everyone takes addresses from
+ *    that one allocator rather than naming them.
  */
 
 #include <stddef.h>
@@ -66,8 +72,16 @@
 /* A handle is a JSValue* in the shared linear memory. */
 typedef uint32_t qjs_handle;
 
+/* #4557 — every scratch allocation in this file goes through these, so that
+ * installing the peer's allocator moves the WHOLE artifact onto it rather than
+ * leaving a second live heap behind. Defined under "peer allocator" below;
+ * declared here because `box` is the first user. */
+static void *qjs_shim_malloc(size_t n);
+static void qjs_shim_free(void *p);
+static void *qjs_shim_realloc(void *p, size_t n);
+
 static qjs_handle box(JSValue v) {
-  JSValue *p = (JSValue *)malloc(sizeof(JSValue));
+  JSValue *p = (JSValue *)qjs_shim_malloc(sizeof(JSValue));
   if (!p) return 0;
   *p = v;
   return (qjs_handle)(uintptr_t)p;
@@ -80,9 +94,170 @@ static JSValue unbox(qjs_handle h) {
   return *(JSValue *)(uintptr_t)h;
 }
 
+/* ------------------------------------------ peer allocator (#4557) --------
+ *
+ * ADR-0020 Decision 6, allocator half: the PEER's allocator becomes QuickJS's
+ * allocator, via `JS_NewRuntime2(&mf, opaque)`.  Everything the engine
+ * allocates — objects, shapes, atoms, bytecode, string data — then comes out of
+ * the peer's heap, and `JS_SetMemoryLimit` / `JS_SetGCThreshold` account
+ * against numbers the peer controls.
+ *
+ * ### Why these arrive as TABLE INDICES and not as wasm imports
+ *
+ * The obvious encoding is `__attribute__((import_module("js2wasm"),
+ * import_name("js2wasm_malloc")))`, and that is what #4557 originally
+ * specified.  It cannot be used, for a reason that only shows up downstream:
+ * a wasm import must be SATISFIED AT INSTANTIATION, so five unconditional
+ * imports would make this artifact un-instantiable without a peer that
+ * provides an allocator.  Two shipped configurations do exactly that —
+ * `extract-abi.mjs` instantiates the artifact alone to read the ABI constants
+ * out of it, and the runtime-eval tier instantiates it beside an adapter that
+ * imports FROM it and exports no allocator.  Both would have to hand it JS
+ * closures, which is precisely what `assertQuickjsArtifactStandalone` exists to
+ * forbid ("wasi-stub.mjs is the ONLY JavaScript allowed behind the seam").
+ *
+ * So this mirrors the #4245 membrane instead, which solved the identical
+ * problem: the peer's functions are stored into THIS module's
+ * `__indirect_function_table` (exported and growable at link time) and called
+ * through it.  On wasm32 a function pointer IS a table index, so each call
+ * below lowers to a `call_indirect` whose signature the engine typechecks, the
+ * edge stays wasm→wasm with no JS in it, and the artifact still imports ONLY
+ * `wasi_snapshot_preview1`.  The cost is one indirect call per allocation
+ * instead of a direct one.
+ *
+ * ### Ordering constraint, enforced rather than documented
+ *
+ * `qjs_set_allocator` REFUSES (returns 0) once this file has already handed out
+ * a libc allocation, because from that point on a pointer minted by dlmalloc
+ * could be freed through the peer.  Install first, then create the runtime.
+ */
+
+typedef void *(*qjs_alloc_fn)(uint32_t size);
+typedef void *(*qjs_calloc_fn)(uint32_t count, uint32_t size);
+typedef void (*qjs_free_fn)(void *ptr);
+typedef void *(*qjs_realloc_fn)(void *ptr, uint32_t size);
+typedef uint32_t (*qjs_usable_fn)(const void *ptr);
+
+static qjs_alloc_fn qjs_peer_malloc;
+static qjs_calloc_fn qjs_peer_calloc;
+static qjs_free_fn qjs_peer_free;
+static qjs_realloc_fn qjs_peer_realloc;
+static qjs_usable_fn qjs_peer_usable;
+
+/* Counts allocations this file served from libc (i.e. dlmalloc) rather than
+ * from the peer.  Exported because "does anything still allocate outside
+ * JSMallocFunctions" is a question #4557 requires answering with a measurement
+ * rather than with an argument. */
+static uint32_t qjs_libc_allocs;
+
+/* The shim's own scratch allocations (handle cells, eval buffers, argv arrays,
+ * rendered strings). They follow the peer allocator once it is installed, so
+ * the artifact does not keep a second live heap alongside it. */
+static void *qjs_shim_malloc(size_t n) {
+  if (qjs_peer_malloc) return qjs_peer_malloc((uint32_t)n);
+  qjs_libc_allocs++;
+  return malloc(n);
+}
+
+static void qjs_shim_free(void *p) {
+  if (qjs_peer_free) {
+    qjs_peer_free(p);
+    return;
+  }
+  free(p);
+}
+
+static void *qjs_shim_realloc(void *p, size_t n) {
+  if (qjs_peer_realloc) return qjs_peer_realloc(p, (uint32_t)n);
+  qjs_libc_allocs++;
+  return realloc(p, n);
+}
+
+static void *qjs_mf_calloc(void *opaque, size_t count, size_t size) {
+  (void)opaque;
+  return qjs_peer_calloc((uint32_t)count, (uint32_t)size);
+}
+static void *qjs_mf_malloc(void *opaque, size_t size) {
+  (void)opaque;
+  return qjs_peer_malloc((uint32_t)size);
+}
+static void qjs_mf_free(void *opaque, void *ptr) {
+  (void)opaque;
+  qjs_peer_free(ptr);
+}
+static void *qjs_mf_realloc(void *opaque, void *ptr, size_t size) {
+  (void)opaque;
+  return qjs_peer_realloc(ptr, (uint32_t)size);
+}
+static size_t qjs_mf_usable_size(const void *ptr) {
+  return (size_t)qjs_peer_usable(ptr);
+}
+
+static const JSMallocFunctions qjs_peer_mf = {
+    .js_calloc = qjs_mf_calloc,
+    .js_malloc = qjs_mf_malloc,
+    .js_free = qjs_mf_free,
+    .js_realloc = qjs_mf_realloc,
+    .js_malloc_usable_size = qjs_mf_usable_size,
+};
+
+/**
+ * Install the peer's allocator. Arguments are `__indirect_function_table` slot
+ * indices, in the order malloc / calloc / free / realloc / usable_size.
+ * Returns 1 on success, 0 if refused (already installed, an argument is 0, or a
+ * libc allocation has already been handed out by this file).
+ */
+int QJS_EXPORT(qjs_set_allocator)(uint32_t malloc_idx, uint32_t calloc_idx,
+                                  uint32_t free_idx, uint32_t realloc_idx,
+                                  uint32_t usable_idx) {
+  if (qjs_peer_malloc) return 0;
+  if (!malloc_idx || !calloc_idx || !free_idx || !realloc_idx || !usable_idx) {
+    return 0;
+  }
+  if (qjs_libc_allocs) return 0;
+  qjs_peer_malloc = (qjs_alloc_fn)(uintptr_t)malloc_idx;
+  qjs_peer_calloc = (qjs_calloc_fn)(uintptr_t)calloc_idx;
+  qjs_peer_free = (qjs_free_fn)(uintptr_t)free_idx;
+  qjs_peer_realloc = (qjs_realloc_fn)(uintptr_t)realloc_idx;
+  qjs_peer_usable = (qjs_usable_fn)(uintptr_t)usable_idx;
+  return 1;
+}
+
+/** How many allocations this file served from libc rather than from the peer. */
+uint32_t QJS_EXPORT(qjs_libc_alloc_count)(void) { return qjs_libc_allocs; }
+
 /* ---------------------------------------------------------------- lifecycle */
 
 JSRuntime *QJS_EXPORT(qjs_new_runtime)(void) { return JS_NewRuntime(); }
+
+/**
+ * A runtime whose whole heap comes from the peer's allocator (#4557).
+ * Returns NULL when no allocator has been installed — a null runtime is a
+ * diagnosable failure, whereas silently falling back to `JS_NewRuntime()` would
+ * make "the engine allocates through us" quietly untrue.
+ */
+JSRuntime *QJS_EXPORT(qjs_new_runtime2)(void) {
+  if (!qjs_peer_malloc) return NULL;
+  return JS_NewRuntime2(&qjs_peer_mf, NULL);
+}
+
+/** Bytes QuickJS believes it has allocated — its own accounting, which is
+ * driven by `js_malloc_usable_size`. Reported so a wrong `usable_size` shows up
+ * as a number rather than as a GC-timing mystery. */
+double QJS_EXPORT(qjs_malloc_size)(JSRuntime *rt) {
+  JSMemoryUsage u;
+  if (!rt) return 0;
+  JS_ComputeMemoryUsage(rt, &u);
+  return (double)u.malloc_size;
+}
+
+/** Live allocation count according to QuickJS's own accounting. */
+double QJS_EXPORT(qjs_malloc_count)(JSRuntime *rt) {
+  JSMemoryUsage u;
+  if (!rt) return 0;
+  JS_ComputeMemoryUsage(rt, &u);
+  return (double)u.malloc_count;
+}
 
 void QJS_EXPORT(qjs_free_runtime)(JSRuntime *rt) {
   if (rt) JS_FreeRuntime(rt);
@@ -109,7 +284,7 @@ void QJS_EXPORT(qjs_free_value)(JSContext *ctx, qjs_handle h) {
   if (!h) return;
   JSValue *p = (JSValue *)(uintptr_t)h;
   JS_FreeValue(ctx, *p);
-  free(p);
+  qjs_shim_free(p);
 }
 
 qjs_handle QJS_EXPORT(qjs_dup)(JSContext *ctx, qjs_handle h) {
@@ -208,12 +383,12 @@ int QJS_EXPORT(qjs_is_equal)(JSContext *ctx, qjs_handle a, qjs_handle b,
 /* `src` need not be NUL-terminated by the caller; we copy and terminate, which
  * is what JS_Eval requires. Returns an owned handle (possibly an exception). */
 qjs_handle QJS_EXPORT(qjs_eval)(JSContext *ctx, const char *src, uint32_t len) {
-  char *buf = (char *)malloc((size_t)len + 1);
+  char *buf = (char *)qjs_shim_malloc((size_t)len + 1);
   if (!buf) return 0;
   memcpy(buf, src, len);
   buf[len] = '\0';
   JSValue v = JS_Eval(ctx, buf, len, "<qjs_eval>", JS_EVAL_TYPE_GLOBAL);
-  free(buf);
+  qjs_shim_free(buf);
   return box(v);
 }
 
@@ -228,12 +403,12 @@ qjs_handle QJS_EXPORT(qjs_call)(JSContext *ctx, qjs_handle fn,
   JSValue *args = NULL;
   if (argc > 0) {
     if (!argv) return 0;
-    args = (JSValue *)malloc(sizeof(JSValue) * (size_t)argc);
+    args = (JSValue *)qjs_shim_malloc(sizeof(JSValue) * (size_t)argc);
     if (!args) return 0;
     for (uint32_t i = 0; i < argc; i++) args[i] = unbox(argv[i]);
   }
   JSValue r = JS_Call(ctx, unbox(fn), unbox(this_val), (int)argc, args);
-  free(args);
+  qjs_shim_free(args);
   return box(r);
 }
 
@@ -251,7 +426,7 @@ char *QJS_EXPORT(qjs_to_cstring)(JSContext *ctx, qjs_handle h) {
     return NULL;
   }
   size_t n = strlen(s);
-  char *out = (char *)malloc(n + 1);
+  char *out = (char *)qjs_shim_malloc(n + 1);
   if (out) memcpy(out, s, n + 1);
   JS_FreeCString(ctx, s);
   return out;
@@ -271,7 +446,7 @@ char *QJS_EXPORT(qjs_to_cstring_len)(JSContext *ctx, qjs_handle h,
     if (len_out) *len_out = 0;
     return NULL;
   }
-  char *out = (char *)malloc(n + 1);
+  char *out = (char *)qjs_shim_malloc(n + 1);
   if (out) {
     memcpy(out, s, n);
     out[n] = '\0';
@@ -350,7 +525,7 @@ static JSValue qjs_take(qjs_handle h) {
   if (!h) return JS_UNDEFINED;
   JSValue *p = (JSValue *)(uintptr_t)h;
   JSValue v = *p;
-  free(p);
+  qjs_shim_free(p);
   return v;
 }
 
@@ -531,7 +706,7 @@ static JSValue qjs_mb_exotic_call(JSContext *ctx, JSValueConst func_obj,
     return JS_ThrowTypeError(ctx, "not a compiled callable (#4245)");
   }
   if (argc > 0) {
-    cells = (qjs_handle *)malloc(sizeof(qjs_handle) * (size_t)argc);
+    cells = (qjs_handle *)qjs_shim_malloc(sizeof(qjs_handle) * (size_t)argc);
     if (!cells) return JS_ThrowTypeError(ctx, "out of memory (#4245)");
     for (i = 0; i < argc; i++) cells[i] = box(JS_DupValue(ctx, argv[i]));
   }
@@ -540,7 +715,7 @@ static JSValue qjs_mb_exotic_call(JSContext *ctx, JSValueConst func_obj,
   /* Every handle passed IN is released here (borrow-in), on both paths. */
   qjs_free_value(ctx, this_h);
   for (i = 0; i < argc; i++) qjs_free_value(ctx, cells[i]);
-  free(cells);
+  qjs_shim_free(cells);
   if (!r) {
     return JS_ThrowTypeError(
         ctx, "a compiled function could not be called from evaluated code "
@@ -599,9 +774,9 @@ static int qjs_wrap_reserve(uint32_t gc_id) {
   if (gc_id < qjs_wrap_slots_len) return 1;
   want = qjs_wrap_slots_len ? qjs_wrap_slots_len : 16;
   while (want <= gc_id) want *= 2;
-  slots = (JSValue *)realloc(qjs_wrap_slots, sizeof(JSValue) * (size_t)want);
+  slots = (JSValue *)qjs_shim_realloc(qjs_wrap_slots, sizeof(JSValue) * (size_t)want);
   if (!slots) return 0;
-  live = (uint8_t *)realloc(qjs_wrap_live, (size_t)want);
+  live = (uint8_t *)qjs_shim_realloc(qjs_wrap_live, (size_t)want);
   if (!live) {
     qjs_wrap_slots = slots;
     return 0;

--- a/src/codegen-linear/heap-allocator.ts
+++ b/src/codegen-linear/heap-allocator.ts
@@ -1,0 +1,1360 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * A real allocator for the linear lane — `malloc`, `calloc`, `free`, `realloc`,
+ * `malloc_usable_size` — so that the QuickJS artifact can allocate through US
+ * (#4557, ADR-0020 Decision 6, allocator half).
+ *
+ * ### Why this exists at all
+ *
+ * ADR-0017 chose a bump arena and deferred reclamation, while explicitly
+ * reserving "one fixed strategy, chosen and recorded then, not abstracted now".
+ * This is that choice arriving, and the trigger is concrete: QuickJS's
+ * `JS_NewRuntime2` takes a `JSMallocFunctions` whose members include a real
+ * `free`, `realloc` and `usable_size`. A bump arena has no honest
+ * implementation of any of the three, so the ownership inversion is gated on
+ * writing an allocator rather than on wiring one up. #4540 shipped the mirror
+ * image — our arena carved from the ENGINE's `malloc` — and kept it as the
+ * documented fallback; this module is the other direction.
+ *
+ * ### Layout — boundary tags, the classic Knuth/dlmalloc shape
+ *
+ * Every block carries a 4-byte header at its base; the payload starts at
+ * `base + 4`. Block bases are therefore ≡ 4 (mod 8) and payloads ≡ 0 (mod 8),
+ * which is the 8-byte alignment the rest of the linear backend already assumes.
+ *
+ * ```text
+ *   allocated:  [ size | PINUSE | INUSE ][ payload … ]
+ *   free:       [ size | PINUSE         ][ next ][ prev ][ … ][ size (footer) ]
+ * ```
+ *
+ * `size` is the WHOLE block including the header and is always a multiple of 8,
+ * so the low three bits are free for flags. The footer exists only in free
+ * blocks, which is what lets `free()` coalesce BACKWARD: a block whose PINUSE
+ * bit is clear knows its predecessor is free and can read that predecessor's
+ * size out of the 4 bytes immediately below its own header. Forward coalescing
+ * needs no footer — the next header is at `base + size`.
+ *
+ * Each region ends with an **epilogue**: a 4-byte header with size 0 and INUSE
+ * set. It is never allocatable (size 0 fails every fit test) and it makes
+ * "walk forward and coalesce" terminate without a bounds check on the hot path.
+ *
+ * ### Where the metadata lives (this is the part that is NOT textbook)
+ *
+ * A textbook allocator puts its bin array at a link-time address. This backend
+ * may not name an address at all in linked mode — see ADR-0022 — so the control
+ * block is carved out of the FIRST region the allocator acquires, and one
+ * mutable global (`__heap_ctl`) points at it. Everything else is reached
+ * through that pointer.
+ *
+ * ### Where the memory comes from
+ *
+ * Region acquisition is a parameter, not a decision baked in here:
+ *
+ * - **linked mode** — regions come from the imported host `malloc`. The module
+ *   still contains no `memory.grow`, so #4540's "the memory's owner is the only
+ *   grower" property is preserved by construction rather than traded away for
+ *   reclamation.
+ * - **standalone** — regions come from `memory.grow`, and the allocator uses
+ *   ONLY pages it grew itself. That is the substantive difference from the
+ *   pre-#4540 arena, which claimed everything from its bump pointer to the end
+ *   of memory whether or not it had obtained it.
+ *
+ * ### Bins
+ *
+ * 32 exact-size small bins (16, 24, … 264 bytes) give O(1) allocation for the
+ * sizes a JS engine actually allocates, then 16 power-of-two large bins that
+ * are scanned for the first fit. dlmalloc is tuned for precisely this
+ * workload; see #4557 for the measured comparison, which is the number that
+ * decides whether this path or the #4540 fallback is the default.
+ */
+import type { FuncTypeDef, Instr, ValType, WasmModule } from "../ir/types.js";
+
+/** Wasm page size in bytes — the unit `memory.grow` operates on. */
+const WASM_PAGE_SIZE = 65536;
+
+/** Bytes of block header. The payload begins immediately after it. */
+const HDR = 4;
+/** Smallest block: header + next + prev + footer. Nothing smaller can be free. */
+const MIN_BLOCK = 16;
+/** Header bit 0 — this block is allocated. */
+const INUSE = 1;
+/** Header bit 1 — the PHYSICALLY PRECEDING block is allocated. */
+const PINUSE = 2;
+/** `hdr & SIZE_MASK` is the block size; sizes are always multiples of 8. */
+const SIZE_MASK = -8;
+
+/** Exact-size bins, covering 16, 24, … 264 bytes. */
+const NSMALL = 32;
+/** Power-of-two bins above that, the last one unbounded. */
+const NLARGE = 16;
+const NBINS = NSMALL + NLARGE;
+/** Largest size served by an exact-size bin. */
+const SMALL_MAX = MIN_BLOCK + 8 * (NSMALL - 1); // 264
+
+/** Control-block field offsets, in bytes from `__heap_ctl`. */
+const CTL_BINS = 0;
+const CTL_NEXT_REGION = CTL_BINS + NBINS * 4; // 192
+const CTL_TOTAL_BYTES = CTL_NEXT_REGION + 4; // 196
+const CTL_REGION_COUNT = CTL_TOTAL_BYTES + 4; // 200
+/**
+ * Request-size histogram, 16 log2 buckets: bucket `b` counts requests in
+ * `[2^(b+3), 2^(b+4))`, with `b = 0` catching everything below 16 bytes and
+ * `b = 15` everything from 256 KiB up.
+ *
+ * Not decoration. #4557 assumed the engine would hand this allocator "many
+ * small, short-lived objects" — the pattern dlmalloc is tuned for and the
+ * stated risk of losing on. Measured, quickjs-ng v0.16.1 does NOT: it has its
+ * own 4 KiB size-class arena (`JSArenaState`) between the interpreter and
+ * `JSMallocFunctions`, so what reaches us is a few hundred mid-sized blocks,
+ * not tens of thousands of tiny ones. A benchmark is only honest if it is run
+ * on the distribution that actually arrives, so the distribution is measurable.
+ */
+const CTL_HIST = 208;
+const HIST_BUCKETS = 16;
+const CTL_BYTES = CTL_HIST + HIST_BUCKETS * 4; // 272
+
+/** Region size cap — beyond this, asking for more just fragments harder. */
+const MAX_REGION_BYTES = 8 * 1024 * 1024;
+
+/** Global holding the control-block address; 0 until the first allocation. */
+export const HEAP_CTL_GLOBAL = "__heap_ctl";
+
+/**
+ * Per-entry-point call counters, read back through `__heap_stats(4..7)`.
+ *
+ * They exist because #4557's acceptance criterion is that the engine reaches
+ * this allocator **proven by counting calls, not inferred from the wiring**.
+ * Counting on the JS side would mean putting a JS closure on the allocation
+ * path, which both changes what is being measured and violates the artifact's
+ * no-JS-behind-the-seam rule; counting here counts the calls that actually
+ * happened, in the module that served them.
+ */
+const COUNTER_GLOBALS = ["__heap_n_alloc", "__heap_n_free", "__heap_n_realloc", "__heap_n_calloc"] as const;
+
+/**
+ * Export names the QuickJS artifact installs as its `JSMallocFunctions`.
+ *
+ * They are **exports, not the far side of imports**: the artifact must stay
+ * instantiable with no peer at all (`extract-abi.mjs` instantiates it alone),
+ * so `qjs_set_allocator` takes `__indirect_function_table` slot indices the way
+ * the #4245 membrane does, and a harness stores these functions into that
+ * table. The ORDER in `qjs_set_allocator`'s signature is part of the ABI.
+ */
+export const ENGINE_ALLOC_EXPORTS = {
+  malloc: "js2wasm_malloc",
+  calloc: "js2wasm_calloc",
+  free: "js2wasm_free",
+  realloc: "js2wasm_realloc",
+  usableSize: "js2wasm_usable_size",
+} as const;
+
+/** Options for {@link addHeapAllocatorRuntime}. */
+export interface HeapAllocatorOptions {
+  /**
+   * Function index of the region source, signature `(i32 bytes) -> i32 ptr`,
+   * returning 0 on failure. When omitted the allocator grows the memory itself
+   * (`memory.grow`) and uses only the pages it obtained that way.
+   *
+   * In the ADR-0020 link topology this is the ENGINE's `malloc`, which keeps
+   * "the memory's owner is its only grower" true while still giving us a real
+   * allocator on top.
+   */
+  regionSourceFuncIdx?: number;
+  /** Bytes in the first region, and the floor for every later one. */
+  regionBytes?: number;
+  /** Export the five engine-facing entry points (default true). */
+  exportForEngine?: boolean;
+}
+
+/** Default first-region size: one Wasm page. */
+export const HEAP_DEFAULT_REGION_BYTES = WASM_PAGE_SIZE;
+
+// ─────────────────────────── instruction shorthands ──────────────────────────
+// The bodies below are long enough that spelled-out object literals bury the
+// algorithm. These are the same literals, named.
+
+const i32c = (value: number): Instr => ({ op: "i32.const", value });
+const get = (index: number): Instr => ({ op: "local.get", index });
+const set = (index: number): Instr => ({ op: "local.set", index });
+const tee = (index: number): Instr => ({ op: "local.tee", index });
+const gget = (index: number): Instr => ({ op: "global.get", index });
+const gset = (index: number): Instr => ({ op: "global.set", index });
+const load = (offset = 0): Instr => ({ op: "i32.load", align: 2, offset });
+const store = (offset = 0): Instr => ({ op: "i32.store", align: 2, offset });
+const call = (funcIdx: number): Instr => ({ op: "call", funcIdx });
+const add: Instr = { op: "i32.add" };
+const sub: Instr = { op: "i32.sub" };
+const mul: Instr = { op: "i32.mul" };
+const and: Instr = { op: "i32.and" };
+const or: Instr = { op: "i32.or" };
+const shl: Instr = { op: "i32.shl" };
+const shrU: Instr = { op: "i32.shr_u" };
+const eqz: Instr = { op: "i32.eqz" };
+const eq: Instr = { op: "i32.eq" };
+const ne: Instr = { op: "i32.ne" };
+const ltU: Instr = { op: "i32.lt_u" };
+const leU: Instr = { op: "i32.le_u" };
+const gtU: Instr = { op: "i32.gt_u" };
+const geU: Instr = { op: "i32.ge_u" };
+const gtS: Instr = { op: "i32.gt_s" };
+const clz: Instr = { op: "i32.clz" };
+const ret: Instr = { op: "return" };
+const EMPTY = { kind: "empty" } as const;
+const I32 = { kind: "val", type: { kind: "i32" } } as const;
+
+const iff = (then: Instr[], els: Instr[] = []): Instr => ({ op: "if", blockType: EMPTY, then, else: els });
+const iffI32 = (then: Instr[], els: Instr[]): Instr => ({ op: "if", blockType: I32, then, else: els });
+
+/** `hdr(b) & SIZE_MASK` — the block size behind an address already on the stack. */
+const sizeOfLoaded: Instr[] = [load(0), i32c(SIZE_MASK), and];
+
+// ─────────────────────────────── module builder ──────────────────────────────
+
+interface Ctx {
+  mod: WasmModule;
+  ctlGlobalIdx: number;
+  /** Index of the first counter global; the four are consecutive. */
+  counterBaseIdx: number;
+  regionSourceFuncIdx?: number;
+  regionBytes: number;
+  /** Resolved indices of the functions emitted so far. */
+  idx: Map<string, number>;
+}
+
+/** `++counter[n]`, four instructions on the entry point's hot path. */
+const bump = (ctx: Ctx, n: number): Instr[] => [
+  gget(ctx.counterBaseIdx + n),
+  i32c(1),
+  add,
+  gset(ctx.counterBaseIdx + n),
+];
+
+function emit(
+  ctx: Ctx,
+  name: string,
+  params: ValType[],
+  results: ValType[],
+  extraLocals: number,
+  body: (l: (n: number) => number) => Instr[],
+): void {
+  const typeIdx = ctx.mod.types.length;
+  const type: FuncTypeDef = { kind: "func", name: `$type_${name}`, params, results };
+  ctx.mod.types.push(type);
+  const locals = [];
+  for (let i = 0; i < extraLocals; i++) locals.push({ name: `${name}_l${i}`, type: { kind: "i32" as const } });
+  const first = params.length;
+  const position = ctx.mod.functions.length;
+  ctx.mod.functions.push({
+    name,
+    typeIdx,
+    locals,
+    body: body((n) => first + n),
+    exported: false,
+  });
+  const numImportFuncs = ctx.mod.imports.filter((imp) => imp.desc.kind === "func").length;
+  ctx.idx.set(name, numImportFuncs + position);
+}
+
+const fn = (ctx: Ctx, name: string): number => {
+  const found = ctx.idx.get(name);
+  if (found === undefined) throw new Error(`heap allocator: ${name} referenced before it was emitted`);
+  return found;
+};
+
+/**
+ * Add the linear-lane allocator (#4557).
+ *
+ * Emits, in dependency order so every index is resolved by the time it is
+ * referenced: `__heap_bin`, `__heap_insert`, `__heap_unlink`, `__heap_install`,
+ * `__heap_init`, `__heap_more`, `__heap_find`, `__heap_alloc`, `__heap_free`,
+ * `__heap_usable`, `__heap_calloc`, `__heap_realloc`, `__heap_stats`.
+ *
+ * Must be called BEFORE `__malloc` is created: in this mode `__malloc` becomes
+ * a bump arena carved from `__heap_alloc`, so it needs this allocator's index.
+ */
+export function addHeapAllocatorRuntime(mod: WasmModule, opts: HeapAllocatorOptions = {}): void {
+  if (mod.globals.some((g) => g.name === HEAP_CTL_GLOBAL)) {
+    throw new Error("heap allocator: already installed on this module (#4557)");
+  }
+  const ctlGlobalIdx = mod.globals.length;
+  mod.globals.push({
+    name: HEAP_CTL_GLOBAL,
+    type: { kind: "i32" },
+    mutable: true,
+    init: [i32c(0)],
+  });
+  const counterBaseIdx = mod.globals.length;
+  for (const name of COUNTER_GLOBALS) {
+    mod.globals.push({ name, type: { kind: "i32" }, mutable: true, init: [i32c(0)] });
+  }
+  const ctx: Ctx = {
+    mod,
+    ctlGlobalIdx,
+    counterBaseIdx,
+    regionSourceFuncIdx: opts.regionSourceFuncIdx,
+    regionBytes: opts.regionBytes ?? HEAP_DEFAULT_REGION_BYTES,
+    idx: new Map(),
+  };
+
+  emitBin(ctx);
+  emitInsert(ctx);
+  emitUnlink(ctx);
+  emitInstall(ctx);
+  emitAcquire(ctx);
+  emitInit(ctx);
+  emitMore(ctx);
+  emitFind(ctx);
+  emitAlloc(ctx);
+  emitFree(ctx);
+  emitUsable(ctx);
+  emitCalloc(ctx);
+  emitRealloc(ctx);
+  emitStats(ctx);
+
+  if (opts.exportForEngine !== false) {
+    const exportPairs: [string, string][] = [
+      [ENGINE_ALLOC_EXPORTS.malloc, "__heap_alloc"],
+      [ENGINE_ALLOC_EXPORTS.calloc, "__heap_calloc"],
+      [ENGINE_ALLOC_EXPORTS.free, "__heap_free"],
+      [ENGINE_ALLOC_EXPORTS.realloc, "__heap_realloc"],
+      [ENGINE_ALLOC_EXPORTS.usableSize, "__heap_usable"],
+    ];
+    for (const [exportName, funcName] of exportPairs) {
+      mod.exports.push({ name: exportName, desc: { kind: "func", index: fn(ctx, funcName) } });
+    }
+    // Not part of the engine ABI; exported so a test can assert the heap is
+    // BOUNDED rather than infer it from the absence of a crash.
+    mod.exports.push({ name: "__heap_stats", desc: { kind: "func", index: fn(ctx, "__heap_stats") } });
+  }
+}
+
+/** Index of the raw allocator entry point, for the bump arena to carve from. */
+export function heapAllocFuncIndex(mod: WasmModule): number {
+  const numImportFuncs = mod.imports.filter((imp) => imp.desc.kind === "func").length;
+  const position = mod.functions.findIndex((f) => f.name === "__heap_alloc");
+  if (position < 0) throw new Error("heap allocator: __heap_alloc not found (#4557)");
+  return numImportFuncs + position;
+}
+
+// ───────────────────────────────── the bodies ────────────────────────────────
+
+/**
+ * `__heap_bin(size) -> bin` — the free list a block of `size` belongs in.
+ *
+ * Small sizes get an EXACT bin, which is what makes allocation O(1) for the
+ * many-small-objects pattern a JS engine actually produces: any non-empty bin
+ * at or above the requested index is guaranteed to fit, with no list walk.
+ * Above `SMALL_MAX` the bins are power-of-two ranges and the caller must check
+ * each candidate's size.
+ */
+function emitBin(ctx: Ctx): void {
+  emit(ctx, "__heap_bin", [{ kind: "i32" }], [{ kind: "i32" }], 1, (l) => {
+    const t = l(0);
+    return [
+      get(0),
+      i32c(SMALL_MAX),
+      leU,
+      iffI32(
+        [get(0), i32c(3), shrU, i32c(MIN_BLOCK / 8), sub],
+        [
+          // floor(log2(size)) - 8, clamped into the large-bin range.
+          i32c(31),
+          get(0),
+          clz,
+          sub,
+          i32c(8),
+          sub,
+          set(t),
+          i32c(NLARGE - 1),
+          get(t),
+          get(t),
+          i32c(NLARGE - 1),
+          gtS,
+          { op: "select" },
+          i32c(NSMALL),
+          add,
+        ],
+      ),
+    ];
+  });
+}
+
+/** `__heap_insert(b, size)` — push a free block onto the head of its bin. */
+function emitInsert(ctx: Ctx): void {
+  const binIdx = fn(ctx, "__heap_bin");
+  emit(ctx, "__heap_insert", [{ kind: "i32" }, { kind: "i32" }], [], 2, (l) => {
+    const slot = l(0);
+    const head = l(1);
+    return [
+      // slot = ctl + bin(size) * 4
+      gget(ctx.ctlGlobalIdx),
+      get(1),
+      call(binIdx),
+      i32c(4),
+      mul,
+      add,
+      tee(slot),
+      load(CTL_BINS),
+      set(head),
+      get(0),
+      get(head),
+      store(4), // b.next = head
+      get(0),
+      i32c(0),
+      store(8), // b.prev = 0
+      get(head),
+      iff([get(head), get(0), store(8)]), // head.prev = b
+      get(slot),
+      get(0),
+      store(CTL_BINS), // bin head = b
+    ];
+  });
+}
+
+/** `__heap_unlink(b)` — remove a free block from whichever bin holds it. */
+function emitUnlink(ctx: Ctx): void {
+  const binIdx = fn(ctx, "__heap_bin");
+  emit(ctx, "__heap_unlink", [{ kind: "i32" }], [], 2, (l) => {
+    const nxt = l(0);
+    const prv = l(1);
+    return [
+      get(0),
+      load(4),
+      set(nxt),
+      get(0),
+      load(8),
+      set(prv),
+      get(prv),
+      iff(
+        [get(prv), get(nxt), store(4)],
+        // No predecessor: this block IS the bin head, so the bin slot moves.
+        [gget(ctx.ctlGlobalIdx), get(0), ...sizeOfLoaded, call(binIdx), i32c(4), mul, add, get(nxt), store(CTL_BINS)],
+      ),
+      get(nxt),
+      iff([get(nxt), get(prv), store(8)]),
+    ];
+  });
+}
+
+/**
+ * `__heap_install(p, n) -> ok` — turn a raw `[p, p+n)` region into one free
+ * block plus its epilogue, and file it.
+ *
+ * The arithmetic exists to keep block bases ≡ 4 (mod 8), so that payloads come
+ * out 8-aligned: `base` is the first such address at or above `p`, and the
+ * epilogue sits at the last such address whose 4 header bytes still fit.
+ */
+function emitInstall(ctx: Ctx): void {
+  const insertIdx = fn(ctx, "__heap_insert");
+  emit(ctx, "__heap_install", [{ kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }], 3, (l) => {
+    const base = l(0);
+    const epi = l(1);
+    const size = l(2);
+    return [
+      get(1),
+      i32c(MIN_BLOCK + 16),
+      ltU,
+      iff([i32c(0), ret]),
+      // base = align8(p) + 4
+      get(0),
+      i32c(7),
+      add,
+      i32c(-8),
+      and,
+      i32c(HDR),
+      add,
+      set(base),
+      // epi = align8down(p + n - 8) + 4  (so epi + 4 <= p + n, epi ≡ 4 mod 8)
+      get(0),
+      get(1),
+      add,
+      i32c(8),
+      sub,
+      i32c(-8),
+      and,
+      i32c(HDR),
+      add,
+      set(epi),
+      get(epi),
+      get(base),
+      leU,
+      iff([i32c(0), ret]),
+      get(epi),
+      get(base),
+      sub,
+      tee(size),
+      i32c(MIN_BLOCK),
+      ltU,
+      iff([i32c(0), ret]),
+      // The sole free block: PINUSE set so backward coalescing stops here.
+      get(base),
+      get(size),
+      i32c(PINUSE),
+      or,
+      store(0),
+      get(base),
+      get(size),
+      add,
+      i32c(HDR),
+      sub,
+      get(size),
+      store(0), // footer at base + size - 4
+      // Epilogue: size 0, allocated, preceded by a free block.
+      get(epi),
+      i32c(INUSE),
+      store(0),
+      get(base),
+      get(size),
+      call(insertIdx),
+      i32c(1),
+    ];
+  });
+}
+
+/**
+ * `__heap_acquire(bytes) -> ptr` — one region from the configured source.
+ *
+ * Standalone grows the memory and hands back the pages it just obtained, which
+ * is the whole difference from the pre-#4540 arena: those pages are ours
+ * because we asked for them, not because they were above a bump pointer.
+ */
+function emitAcquire(ctx: Ctx): void {
+  const source = ctx.regionSourceFuncIdx;
+  emit(ctx, "__heap_acquire", [{ kind: "i32" }], [{ kind: "i32" }], 1, (l) => {
+    if (source !== undefined) return [get(0), call(source)];
+    const prev = l(0);
+    return [
+      // pages = ceil(bytes / 65536)
+      get(0),
+      i32c(WASM_PAGE_SIZE - 1),
+      add,
+      i32c(16),
+      shrU,
+      { op: "memory.grow" },
+      tee(prev),
+      i32c(-1),
+      eq,
+      iff([i32c(0), ret]),
+      get(prev),
+      i32c(16),
+      shl,
+    ];
+  });
+}
+
+/**
+ * `__heap_init() -> ok` — acquire the first region and carve the control block
+ * out of its head.
+ *
+ * The control block cannot live at a link-time address (ADR-0022: in linked
+ * mode this module may not name one), so it is the first thing allocated and
+ * `__heap_ctl` is the only fixed thing about the heap.
+ */
+function emitInit(ctx: Ctx): void {
+  const acquireIdx = fn(ctx, "__heap_acquire");
+  const installIdx = fn(ctx, "__heap_install");
+  const first = Math.max(ctx.regionBytes, CTL_BYTES + MIN_BLOCK + 32);
+  emit(ctx, "__heap_init", [], [{ kind: "i32" }], 2, (l) => {
+    const p = l(0);
+    const ctl = l(1);
+    return [
+      gget(ctx.ctlGlobalIdx),
+      iff([i32c(1), ret]),
+      i32c(first),
+      call(acquireIdx),
+      tee(p),
+      eqz,
+      iff([i32c(0), ret]),
+      get(p),
+      i32c(7),
+      add,
+      i32c(-8),
+      and,
+      tee(ctl),
+      i32c(0),
+      i32c(CTL_BYTES),
+      { op: "memory.fill" },
+      get(ctl),
+      gset(ctx.ctlGlobalIdx),
+      get(ctl),
+      i32c(Math.min(first * 2, MAX_REGION_BYTES)),
+      store(CTL_NEXT_REGION),
+      get(ctl),
+      i32c(first),
+      store(CTL_TOTAL_BYTES),
+      get(ctl),
+      i32c(1),
+      store(CTL_REGION_COUNT),
+      // Whatever is left of the first region after the control block is heap.
+      get(ctl),
+      i32c(CTL_BYTES),
+      add,
+      get(p),
+      i32c(first),
+      add,
+      get(ctl),
+      sub,
+      i32c(CTL_BYTES),
+      sub,
+      call(installIdx),
+    ];
+  });
+}
+
+/**
+ * `__heap_more(need) -> ok` — acquire another region big enough for a `need`
+ * byte block.
+ *
+ * The region size grows geometrically so a long-running workload does not pay
+ * a host-allocator call per page, and is capped so a single huge region cannot
+ * strand most of itself. On failure it retries once at the minimum size: under
+ * memory pressure the difference between "the heap is full" and "the
+ * geometric next step was too greedy" is worth one extra call.
+ */
+function emitMore(ctx: Ctx): void {
+  const acquireIdx = fn(ctx, "__heap_acquire");
+  const installIdx = fn(ctx, "__heap_install");
+  emit(ctx, "__heap_more", [{ kind: "i32" }], [{ kind: "i32" }], 3, (l) => {
+    const want = l(0);
+    const p = l(1);
+    const floor = l(2);
+    return [
+      gget(ctx.ctlGlobalIdx),
+      load(CTL_NEXT_REGION),
+      set(want),
+      get(0),
+      i32c(CTL_BYTES),
+      add,
+      tee(floor),
+      get(want),
+      gtU,
+      iff([get(floor), set(want)]),
+      get(want),
+      call(acquireIdx),
+      set(p),
+      get(p),
+      eqz,
+      iff([
+        get(want),
+        get(floor),
+        gtU,
+        iff([get(floor), tee(want), call(acquireIdx), set(p)]),
+        get(p),
+        eqz,
+        iff([i32c(0), ret]),
+      ]),
+      get(p),
+      get(want),
+      call(installIdx),
+      eqz,
+      iff([i32c(0), ret]),
+      gget(ctx.ctlGlobalIdx),
+      gget(ctx.ctlGlobalIdx),
+      load(CTL_TOTAL_BYTES),
+      get(want),
+      add,
+      store(CTL_TOTAL_BYTES),
+      gget(ctx.ctlGlobalIdx),
+      gget(ctx.ctlGlobalIdx),
+      load(CTL_REGION_COUNT),
+      i32c(1),
+      add,
+      store(CTL_REGION_COUNT),
+      // Next region is twice this one, capped.
+      gget(ctx.ctlGlobalIdx),
+      i32c(MAX_REGION_BYTES),
+      get(want),
+      i32c(1),
+      shl,
+      get(want),
+      i32c(1),
+      shl,
+      i32c(MAX_REGION_BYTES),
+      gtU,
+      { op: "select" },
+      store(CTL_NEXT_REGION),
+      i32c(1),
+    ];
+  });
+}
+
+/**
+ * `__heap_find(blk) -> b` — first free block of at least `blk` bytes, or 0.
+ *
+ * Small bins are exact-size, so the first non-empty bin at or above the
+ * requested index fits without inspection. Large bins hold a range, so their
+ * lists are walked. Both are first-fit; best-fit was not chosen because the
+ * exact-size small bins already make the common case exact.
+ */
+function emitFind(ctx: Ctx): void {
+  const binIdx = fn(ctx, "__heap_bin");
+  emit(ctx, "__heap_find", [{ kind: "i32" }], [{ kind: "i32" }], 2, (l) => {
+    const i = l(0);
+    const b = l(1);
+    return [
+      get(0),
+      call(binIdx),
+      set(i),
+      {
+        op: "block",
+        blockType: EMPTY,
+        body: [
+          {
+            op: "loop",
+            blockType: EMPTY,
+            body: [
+              get(i),
+              i32c(NBINS),
+              geU,
+              { op: "br_if", depth: 1 },
+              gget(ctx.ctlGlobalIdx),
+              get(i),
+              i32c(4),
+              mul,
+              add,
+              load(CTL_BINS),
+              set(b),
+              get(i),
+              i32c(NSMALL),
+              ltU,
+              iff(
+                // Exact-size bin: non-empty means it fits.
+                [get(b), iff([get(b), ret])],
+                // Range bin: walk for the first that fits.
+                [
+                  {
+                    op: "block",
+                    blockType: EMPTY,
+                    body: [
+                      {
+                        op: "loop",
+                        blockType: EMPTY,
+                        body: [
+                          get(b),
+                          eqz,
+                          { op: "br_if", depth: 1 },
+                          get(b),
+                          ...sizeOfLoaded,
+                          get(0),
+                          geU,
+                          iff([get(b), ret]),
+                          get(b),
+                          load(4),
+                          set(b),
+                          { op: "br", depth: 0 },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ),
+              get(i),
+              i32c(1),
+              add,
+              set(i),
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      i32c(0),
+    ];
+  });
+}
+
+/**
+ * `__heap_alloc(size) -> payload` — the allocator proper. Returns 0 on failure
+ * rather than trapping, because that is what `JSMallocFunctions` expects: the
+ * engine turns a NULL into a JS out-of-memory error, which is a far better
+ * outcome than a trap inside foreign code.
+ */
+function emitAlloc(ctx: Ctx): void {
+  const initIdx = fn(ctx, "__heap_init");
+  const moreIdx = fn(ctx, "__heap_more");
+  const findIdx = fn(ctx, "__heap_find");
+  const unlinkIdx = fn(ctx, "__heap_unlink");
+  const insertIdx = fn(ctx, "__heap_insert");
+  emit(ctx, "__heap_alloc", [{ kind: "i32" }], [{ kind: "i32" }], 5, (l) => {
+    const blk = l(0);
+    const b = l(1);
+    const s = l(2);
+    const rem = l(3);
+    const bucket = l(4);
+    /** `++hist[clamp(floor(log2(size)) - 3, 0, 15)]`, after ctl exists. */
+    const recordSize: Instr[] = [
+      i32c(31),
+      get(0),
+      i32c(1),
+      or,
+      clz,
+      sub,
+      i32c(3),
+      sub,
+      tee(bucket),
+      i32c(0),
+      gtS,
+      iff([], [i32c(0), set(bucket)]),
+      get(bucket),
+      i32c(HIST_BUCKETS - 1),
+      gtS,
+      iff([i32c(HIST_BUCKETS - 1), set(bucket)]),
+      gget(ctx.ctlGlobalIdx),
+      get(bucket),
+      i32c(4),
+      mul,
+      add,
+      gget(ctx.ctlGlobalIdx),
+      get(bucket),
+      i32c(4),
+      mul,
+      add,
+      load(CTL_HIST),
+      i32c(1),
+      add,
+      store(CTL_HIST),
+    ];
+    return [
+      ...bump(ctx, 0),
+      // A request that overflows the block-size arithmetic is a failure, not a
+      // wrap-around into a tiny allocation.
+      get(0),
+      i32c(0x7ffffff0),
+      gtU,
+      iff([i32c(0), ret]),
+      get(0),
+      i32c(HDR + 7),
+      add,
+      i32c(-8),
+      and,
+      tee(blk),
+      i32c(MIN_BLOCK),
+      ltU,
+      iff([i32c(MIN_BLOCK), set(blk)]),
+      gget(ctx.ctlGlobalIdx),
+      eqz,
+      iff([call(initIdx), eqz, iff([i32c(0), ret])]),
+      ...recordSize,
+      get(blk),
+      call(findIdx),
+      tee(b),
+      eqz,
+      iff([
+        get(blk),
+        call(moreIdx),
+        eqz,
+        iff([i32c(0), ret]),
+        get(blk),
+        call(findIdx),
+        tee(b),
+        eqz,
+        iff([i32c(0), ret]),
+      ]),
+      get(b),
+      ...sizeOfLoaded,
+      set(s),
+      get(b),
+      call(unlinkIdx),
+      get(s),
+      get(blk),
+      sub,
+      tee(rem),
+      i32c(MIN_BLOCK),
+      geU,
+      iff(
+        [
+          // Split. The remainder's PINUSE is set (we are allocated); the block
+          // after the remainder already has PINUSE clear, because the block we
+          // just split was free.
+          get(b),
+          get(blk),
+          get(b),
+          load(0),
+          i32c(PINUSE),
+          and,
+          or,
+          i32c(INUSE),
+          or,
+          store(0),
+          get(b),
+          get(blk),
+          add,
+          get(rem),
+          i32c(PINUSE),
+          or,
+          store(0),
+          get(b),
+          get(s),
+          add,
+          i32c(HDR),
+          sub,
+          get(rem),
+          store(0), // remainder footer at b + s - 4
+          get(b),
+          get(blk),
+          add,
+          get(rem),
+          call(insertIdx),
+        ],
+        [
+          // Too small to split: hand out the whole block and tell the physical
+          // successor that its predecessor is now in use.
+          get(b),
+          get(s),
+          get(b),
+          load(0),
+          i32c(PINUSE),
+          and,
+          or,
+          i32c(INUSE),
+          or,
+          store(0),
+          get(b),
+          get(s),
+          add,
+          get(b),
+          get(s),
+          add,
+          load(0),
+          i32c(PINUSE),
+          or,
+          store(0),
+        ],
+      ),
+      get(b),
+      i32c(HDR),
+      add,
+    ];
+  });
+}
+
+/**
+ * `__heap_free(payload)` — coalesce both ways and file the result.
+ *
+ * Freeing something this allocator did not hand out TRAPS rather than
+ * corrupting the heap. The alternative — silently ignoring it — would turn a
+ * caller bug into a leak plus a later mystery, and this allocator's callers
+ * include an engine whose heap we would be corrupting.
+ */
+function emitFree(ctx: Ctx): void {
+  const unlinkIdx = fn(ctx, "__heap_unlink");
+  const insertIdx = fn(ctx, "__heap_insert");
+  emit(ctx, "__heap_free", [{ kind: "i32" }], [], 3, (l) => {
+    const b = l(0);
+    const s = l(1);
+    const nb = l(2);
+    return [
+      ...bump(ctx, 1),
+      get(0),
+      eqz,
+      iff([ret]),
+      get(0),
+      i32c(HDR),
+      sub,
+      set(b),
+      // Not an allocated block of ours: fail loudly.
+      get(b),
+      load(0),
+      i32c(INUSE),
+      and,
+      eqz,
+      iff([{ op: "unreachable" }]),
+      get(b),
+      ...sizeOfLoaded,
+      tee(s),
+      i32c(MIN_BLOCK),
+      ltU,
+      iff([{ op: "unreachable" }]),
+      // Forward coalesce.
+      get(b),
+      get(s),
+      add,
+      tee(nb),
+      load(0),
+      i32c(INUSE),
+      and,
+      eqz,
+      iff([get(nb), call(unlinkIdx), get(s), get(nb), ...sizeOfLoaded, add, set(s)]),
+      // Backward coalesce, through the predecessor's footer.
+      get(b),
+      load(0),
+      i32c(PINUSE),
+      and,
+      eqz,
+      iff([
+        get(s),
+        get(b),
+        i32c(HDR),
+        sub,
+        load(0),
+        add,
+        set(s),
+        get(b),
+        get(b),
+        i32c(HDR),
+        sub,
+        load(0),
+        sub,
+        tee(b),
+        call(unlinkIdx),
+      ]),
+      get(b),
+      get(s),
+      get(b),
+      load(0),
+      i32c(PINUSE),
+      and,
+      or,
+      store(0),
+      get(b),
+      get(s),
+      add,
+      i32c(HDR),
+      sub,
+      get(s),
+      store(0), // footer at b + s - 4
+      // Tell the physical successor its predecessor is free.
+      get(b),
+      get(s),
+      add,
+      get(b),
+      get(s),
+      add,
+      load(0),
+      i32c(-3),
+      and,
+      store(0),
+      get(b),
+      get(s),
+      call(insertIdx),
+    ];
+  });
+}
+
+/**
+ * `__heap_usable(payload) -> bytes` — the TRUE reserved payload size.
+ *
+ * This is deliberately not "what the caller asked for". QuickJS drives
+ * `JS_SetMemoryLimit` and `JS_SetGCThreshold` off this number, so reporting the
+ * request rather than the reservation would under-count the heap and delay
+ * collection — a footprint mystery with no visible connection to its cause. A
+ * block that was too small to split carries its whole remainder here.
+ */
+function emitUsable(ctx: Ctx): void {
+  emit(ctx, "__heap_usable", [{ kind: "i32" }], [{ kind: "i32" }], 0, () => [
+    get(0),
+    eqz,
+    iff([i32c(0), ret]),
+    get(0),
+    i32c(HDR),
+    sub,
+    ...sizeOfLoaded,
+    i32c(HDR),
+    sub,
+  ]);
+}
+
+/** `__heap_calloc(count, size) -> payload`, with an overflow-safe product. */
+function emitCalloc(ctx: Ctx): void {
+  const allocIdx = fn(ctx, "__heap_alloc");
+  emit(ctx, "__heap_calloc", [{ kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }], 2, (l) => {
+    const total = l(0);
+    const p = l(1);
+    return [
+      ...bump(ctx, 3),
+      get(0),
+      eqz,
+      iff(
+        [i32c(0), set(total)],
+        [get(0), get(1), mul, tee(total), get(0), { op: "i32.div_u" }, get(1), ne, iff([i32c(0), ret])],
+      ),
+      get(total),
+      call(allocIdx),
+      tee(p),
+      eqz,
+      iff([i32c(0), ret]),
+      get(total),
+      iff([get(p), i32c(0), get(total), { op: "memory.fill" }]),
+      get(p),
+    ];
+  });
+}
+
+/**
+ * `__heap_realloc(payload, size) -> payload`.
+ *
+ * In-place first, in both directions: shrinking splits and frees the tail,
+ * growing absorbs the physically-next block when it is free and big enough.
+ * Only when neither works does it allocate-copy-free. Growing a buffer by
+ * repeated append — which is what a JS engine's arrays and string builders do —
+ * therefore usually costs no copy at all.
+ */
+function emitRealloc(ctx: Ctx): void {
+  const allocIdx = fn(ctx, "__heap_alloc");
+  const freeIdx = fn(ctx, "__heap_free");
+  const unlinkIdx = fn(ctx, "__heap_unlink");
+  emit(ctx, "__heap_realloc", [{ kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }], 5, (l) => {
+    const b = l(0);
+    const s = l(1);
+    const blk = l(2);
+    const nb = l(3);
+    const q = l(4);
+    /** Split `b` (size `s`) down to `blk` and release the tail. */
+    const shrinkTail: Instr[] = [
+      get(s),
+      get(blk),
+      sub,
+      i32c(MIN_BLOCK),
+      geU,
+      iff([
+        get(b),
+        get(blk),
+        get(b),
+        load(0),
+        i32c(PINUSE),
+        and,
+        or,
+        i32c(INUSE),
+        or,
+        store(0),
+        // Mark the tail allocated, then free it: that reuses the coalescing and
+        // bookkeeping in __heap_free instead of restating it here.
+        get(b),
+        get(blk),
+        add,
+        get(s),
+        get(blk),
+        sub,
+        i32c(PINUSE | INUSE),
+        or,
+        store(0),
+        get(b),
+        get(blk),
+        add,
+        i32c(HDR),
+        add,
+        call(freeIdx),
+      ]),
+    ];
+    return [
+      ...bump(ctx, 2),
+      get(0),
+      eqz,
+      iff([get(1), call(allocIdx), ret]),
+      get(1),
+      eqz,
+      iff([get(0), call(freeIdx), i32c(0), ret]),
+      get(1),
+      i32c(0x7ffffff0),
+      gtU,
+      iff([i32c(0), ret]),
+      get(0),
+      i32c(HDR),
+      sub,
+      set(b),
+      get(b),
+      ...sizeOfLoaded,
+      set(s),
+      get(1),
+      i32c(HDR + 7),
+      add,
+      i32c(-8),
+      and,
+      tee(blk),
+      i32c(MIN_BLOCK),
+      ltU,
+      iff([i32c(MIN_BLOCK), set(blk)]),
+      get(blk),
+      get(s),
+      leU,
+      iff([...shrinkTail, get(0), ret]),
+      // Grow in place by absorbing a free physical successor.
+      get(b),
+      get(s),
+      add,
+      tee(nb),
+      load(0),
+      i32c(INUSE),
+      and,
+      eqz,
+      iff([
+        get(s),
+        get(nb),
+        ...sizeOfLoaded,
+        add,
+        get(blk),
+        geU,
+        iff([
+          get(nb),
+          call(unlinkIdx),
+          get(s),
+          get(nb),
+          ...sizeOfLoaded,
+          add,
+          set(s),
+          get(b),
+          get(s),
+          get(b),
+          load(0),
+          i32c(PINUSE),
+          and,
+          or,
+          i32c(INUSE),
+          or,
+          store(0),
+          get(b),
+          get(s),
+          add,
+          get(b),
+          get(s),
+          add,
+          load(0),
+          i32c(PINUSE),
+          or,
+          store(0),
+          ...shrinkTail,
+          get(0),
+          ret,
+        ]),
+      ]),
+      get(1),
+      call(allocIdx),
+      tee(q),
+      eqz,
+      iff([i32c(0), ret]),
+      get(q),
+      get(0),
+      get(s),
+      i32c(HDR),
+      sub,
+      { op: "memory.copy" },
+      get(0),
+      call(freeIdx),
+      get(q),
+    ];
+  });
+}
+
+/**
+ * `__heap_stats(which) -> i32` — 0 total region bytes, 1 region count, 2 bytes
+ * currently on the free lists, 3 the control-block address.
+ *
+ * Exported so a bounded-heap claim can be MEASURED. "It did not crash" is not
+ * evidence that a free/realloc loop reclaims; total region bytes staying flat
+ * across a million allocations is.
+ */
+function emitStats(ctx: Ctx): void {
+  emit(ctx, "__heap_stats", [{ kind: "i32" }], [{ kind: "i32" }], 3, (l) => {
+    const i = l(0);
+    const b = l(1);
+    const acc = l(2);
+    return [
+      // The call counters answer "did the engine reach us" and must therefore
+      // be readable BEFORE any allocation has happened — otherwise a zero could
+      // mean either "never called" or "heap not initialised", which is exactly
+      // the ambiguity the criterion exists to remove.
+      get(0),
+      i32c(4),
+      geU,
+      get(0),
+      i32c(8),
+      ltU,
+      and,
+      iff([
+        get(0),
+        i32c(4),
+        eq,
+        iff([gget(ctx.counterBaseIdx), ret]),
+        get(0),
+        i32c(5),
+        eq,
+        iff([gget(ctx.counterBaseIdx + 1), ret]),
+        get(0),
+        i32c(6),
+        eq,
+        iff([gget(ctx.counterBaseIdx + 2), ret]),
+        gget(ctx.counterBaseIdx + 3),
+        ret,
+      ]),
+      gget(ctx.ctlGlobalIdx),
+      eqz,
+      iff([i32c(0), ret]),
+      // 16..31 — the request-size histogram.
+      get(0),
+      i32c(16),
+      geU,
+      get(0),
+      i32c(16 + HIST_BUCKETS),
+      ltU,
+      and,
+      iff([gget(ctx.ctlGlobalIdx), get(0), i32c(16), sub, i32c(4), mul, add, load(CTL_HIST), ret]),
+      get(0),
+      i32c(3),
+      eq,
+      iff([gget(ctx.ctlGlobalIdx), ret]),
+      get(0),
+      eqz,
+      iff([gget(ctx.ctlGlobalIdx), load(CTL_TOTAL_BYTES), ret]),
+      get(0),
+      i32c(1),
+      eq,
+      iff([gget(ctx.ctlGlobalIdx), load(CTL_REGION_COUNT), ret]),
+      get(0),
+      i32c(2),
+      ne,
+      iff([i32c(0), ret]),
+      {
+        op: "block",
+        blockType: EMPTY,
+        body: [
+          {
+            op: "loop",
+            blockType: EMPTY,
+            body: [
+              get(i),
+              i32c(NBINS),
+              geU,
+              { op: "br_if", depth: 1 },
+              gget(ctx.ctlGlobalIdx),
+              get(i),
+              i32c(4),
+              mul,
+              add,
+              load(CTL_BINS),
+              set(b),
+              {
+                op: "block",
+                blockType: EMPTY,
+                body: [
+                  {
+                    op: "loop",
+                    blockType: EMPTY,
+                    body: [
+                      get(b),
+                      eqz,
+                      { op: "br_if", depth: 1 },
+                      get(acc),
+                      get(b),
+                      ...sizeOfLoaded,
+                      add,
+                      set(acc),
+                      get(b),
+                      load(4),
+                      set(b),
+                      { op: "br", depth: 0 },
+                    ],
+                  },
+                ],
+              },
+              get(i),
+              i32c(1),
+              add,
+              set(i),
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      get(acc),
+    ];
+  });
+}

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -159,6 +159,21 @@ export interface LinearOptions {
     /** Bytes per carved chunk (default: one Wasm page). */
     chunkBytes?: number;
   };
+  /**
+   * Which allocator backs the heap (#4557).
+   *
+   * `"malloc-v1"` emits the real allocator — free lists, boundary tags,
+   * coalescing, in-place `realloc` — and exports `js2wasm_malloc` /
+   * `js2wasm_calloc` / `js2wasm_free` / `js2wasm_realloc` /
+   * `js2wasm_usable_size` so the QuickJS artifact can install them through
+   * `JS_NewRuntime2`. `__malloc` keeps its bump fast path; only the source of
+   * its chunks moves, from the engine's heap to ours.
+   *
+   * Defaults to `"bump"`, which is #4540's shipped fallback and the reason it
+   * was kept: if the measured comparison against the artifact's dlmalloc does
+   * not hold, this option is simply not set.
+   */
+  heapAllocator?: "bump" | "malloc-v1";
 }
 
 /**
@@ -235,7 +250,14 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
   }
   const allocationPolicy = linearAllocatorPolicy(opts.allocationPolicy ?? "arena-v1");
   const linkedHeap = resolveLinkedHeap(opts, externImportIndices);
-  const dataSegmentBase = numberFormat.addRuntime(mod, ast, opts.exposeArenaReset, DATA_SEGMENT_BASE, linkedHeap);
+  const dataSegmentBase = numberFormat.addRuntime(
+    mod,
+    ast,
+    opts.exposeArenaReset,
+    DATA_SEGMENT_BASE,
+    linkedHeap,
+    opts.heapAllocator,
+  );
 
   // Add memory and runtime functions first
   if (allocationPolicy.id === "analysis-stack-arena-v1") addLinearStackArenaRuntime(mod);

--- a/src/codegen-linear/linked-arena.ts
+++ b/src/codegen-linear/linked-arena.ts
@@ -80,12 +80,34 @@ export const ARENA_LIMIT_GLOBAL = "__arena_limit";
 export const RODATA_BIAS_GLOBAL = "__rodata_bias";
 
 /**
- * Whether this module's arena is carved from a host allocator.
+ * Whether this module is in LINKED mode — it imports its memory, so it does not
+ * own the address space and may not name an address.
  *
  * Derived from the emitted module rather than threaded through as a flag so
  * every downstream pass agrees with the bytes it will actually serialize.
+ *
+ * **Not the same question as {@link hasChunkedArena}, and #4557 is what split
+ * them.** Until then this predicate read `__arena_limit`, which was an exact
+ * proxy only while the chunked arena existed *only* in linked mode. The own
+ * allocator (#4557) gives a STANDALONE module a chunked arena too — carved from
+ * our own heap — and a standalone module still owns its address space, still
+ * emits ACTIVE data segments, and still needs `memory.min` to cover them. Left
+ * merged, the two questions would have emitted a passive Ryū table with nothing
+ * to copy it in.
  */
 export function isLinkedArena(mod: WasmModule): boolean {
+  return mod.imports.some((imp) => imp.desc.kind === "memory");
+}
+
+/**
+ * Whether `__malloc` is a CHUNKED bump arena (carving from some allocator)
+ * rather than the monotonic one that owns everything above its pointer.
+ *
+ * True in linked mode (chunks from the engine, #4540) and under the own
+ * allocator (chunks from `__heap_alloc`, #4557). What it buys either way is
+ * that no absolute heap floor exists to be lifted.
+ */
+export function hasChunkedArena(mod: WasmModule): boolean {
   return mod.globals.some((global) => global.name === ARENA_LIMIT_GLOBAL);
 }
 

--- a/src/codegen-linear/number-format.ts
+++ b/src/codegen-linear/number-format.ts
@@ -88,6 +88,7 @@ export function addRuntime(
   exposeArenaReset: boolean | undefined,
   defaultDataSegmentBase: number,
   linkedHeap?: LinkedHeapOptions,
+  heapAllocator?: "bump" | "malloc-v1",
 ): number {
   const enabled = sourceMayUseLinearNumberToString(ast);
   if (enabled && linkedHeap !== undefined) {
@@ -109,6 +110,7 @@ export function addRuntime(
     exposeArenaReset,
     ...(enabled ? { heapStart: LINEAR_NUMBER_FORMAT_HEAP_START } : {}),
     ...(linkedHeap !== undefined ? { linkedHeap } : {}),
+    ...(heapAllocator !== undefined ? { heapAllocator } : {}),
   });
   if (enabled) addLinearNumberToStringRuntime(mod);
   return enabled ? LINEAR_NUMBER_FORMAT_DATA_BASE : defaultDataSegmentBase;

--- a/src/codegen-linear/refcount/pinned-shim.ts
+++ b/src/codegen-linear/refcount/pinned-shim.ts
@@ -108,6 +108,23 @@ const HANDLE_FREE_EXPORTS: ExternCImportSpec[] = [
     results: [],
   },
   { module: "", name: "qjs_noop", params: [], results: [I32] },
+  // #4557 — the peer allocator. `qjs_set_allocator` takes five
+  // `__indirect_function_table` slot indices, positionally, in the order
+  // malloc / calloc / free / realloc / usable_size; the rest report on the
+  // installation. None of them touches a JSValue, so none carries ownership.
+  {
+    module: "",
+    name: "qjs_set_allocator",
+    params: [I32, I32, I32, I32, I32],
+    results: [I32],
+  },
+  { module: "", name: "qjs_new_runtime2", params: [], results: [PTR] },
+  { module: "", name: "qjs_libc_alloc_count", params: [], results: [I32] },
+  // f64 because QuickJS's accounting is int64 and an i64 crossing this boundary
+  // would be a BigInt at any JS edge; these are diagnostics, so the double's
+  // 53-bit exact range is ample.
+  { module: "", name: "qjs_malloc_size", params: [PTR], results: [F64] },
+  { module: "", name: "qjs_malloc_count", params: [PTR], results: [F64] },
 ];
 
 const HANDLE_EXPORTS: ExternCImportSpec[] = [

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -7,9 +7,10 @@ import {
 } from "../ir/analysis/linear-memory-plan.js";
 import { hasImportedMemory } from "./c-abi.js";
 import { hashProbeAdvanceInstrs, hashProbeInitInstrs } from "./emit-idioms.js";
+import { addHeapAllocatorRuntime, heapAllocFuncIndex } from "./heap-allocator.js";
 import {
   ARENA_LIMIT_GLOBAL,
-  isLinkedArena,
+  hasChunkedArena,
   LINKED_ARENA_DEFAULT_CHUNK_BYTES,
   type LinkedHeapOptions,
   linkedMallocPrologue,
@@ -94,6 +95,21 @@ export interface ArenaOptions {
    * owning the address space. See {@link LinkedHeapOptions}.
    */
   linkedHeap?: LinkedHeapOptions;
+  /**
+   * Which allocator backs `__malloc` (#4557).
+   *
+   * - `"bump"` (default) — ADR-0017's monotonic arena. Nothing is ever freed.
+   * - `"malloc-v1"` — the real allocator in `heap-allocator.ts`: free lists,
+   *   boundary tags, coalescing, `realloc` in place. `__malloc` stays a bump
+   *   arena, but its chunks are now carved from OUR heap instead of the
+   *   engine's, so ADR-0017's zero-metadata typed path survives while
+   *   `free`/`realloc`/`usable_size` become implementable — which is what
+   *   `JS_NewRuntime2` requires before QuickJS can allocate through us.
+   *
+   * Default-off: the standalone lane's emitted bytes must not move (#4557
+   * acceptance criterion, `prove-emit-identity`).
+   */
+  heapAllocator?: "bump" | "malloc-v1";
 }
 
 /**
@@ -111,18 +127,38 @@ export interface ArenaOptions {
  * ADR-0017.
  */
 export function addRuntime(mod: WasmModule, opts: ArenaOptions = {}): void {
-  const linked = opts.linkedHeap;
-  // Linked mode has no address space of its own, so the baked-in floor is
-  // meaningless there: the bump pointer starts at 0 ("no chunk carved yet")
-  // and every real address comes from the host allocator.
-  const heapStart = linked !== undefined ? 0 : (opts.heapStart ?? HEAP_START);
-  if (linked !== undefined && !hasImportedMemory(mod)) {
+  const ownAllocator = opts.heapAllocator === "malloc-v1";
+  if (opts.linkedHeap !== undefined && !hasImportedMemory(mod)) {
     throw new Error(
       "linear runtime: linkedHeap was requested but the module does not import its memory. " +
         "Carving from a host allocator only makes sense when another module owns the address " +
         "space; a module that defines its own memory must use the standalone arena (#4540).",
     );
   }
+  // #4557 — the own-allocator inversion. `__malloc` keeps its bump fast path;
+  // what changes is WHERE the chunks come from. With `malloc-v1` the real
+  // allocator is emitted first and the arena carves from OUR `__heap_alloc`,
+  // which in turn takes regions from the host allocator (linked) or from
+  // `memory.grow` (standalone). Two consequences worth being explicit about:
+  //   - linked mode still emits NO `memory.grow`, so #4540's "the memory's
+  //     owner is its only grower" survives the inversion by construction;
+  //   - `free`/`realloc`/`usable_size` become implementable, which is the
+  //     precondition for `JS_NewRuntime2` and the whole point of the issue.
+  let linked: LinkedHeapOptions | undefined = opts.linkedHeap;
+  if (ownAllocator) {
+    addHeapAllocatorRuntime(mod, {
+      regionSourceFuncIdx: opts.linkedHeap?.mallocFuncIdx,
+      regionBytes: opts.linkedHeap?.chunkBytes,
+    });
+    linked = {
+      mallocFuncIdx: heapAllocFuncIndex(mod),
+      chunkBytes: opts.linkedHeap?.chunkBytes ?? LINKED_ARENA_DEFAULT_CHUNK_BYTES,
+    };
+  }
+  // Linked mode has no address space of its own, so the baked-in floor is
+  // meaningless there: the bump pointer starts at 0 ("no chunk carved yet")
+  // and every real address comes from the host allocator.
+  const heapStart = linked !== undefined ? 0 : (opts.heapStart ?? HEAP_START);
   if (linked !== undefined && opts.exposeArenaReset) {
     // `__arena_reset` rewinds one bump pointer to a fixed floor. In linked mode
     // the arena is a CHAIN of host-allocated chunks, so rewinding would (a)
@@ -132,9 +168,9 @@ export function addRuntime(mod: WasmModule, opts: ArenaOptions = {}): void {
     // a reset that silently means something else. Freeing the chain needs a
     // chunk list; that is follow-up work, not a default.
     throw new Error(
-      "linear runtime: exposeArenaReset is not supported in linked mode. The linked arena is a " +
-        "chain of host-allocated chunks; an O(1) rewind would leak every chunk but the last. " +
-        "See #4540.",
+      "linear runtime: exposeArenaReset is not supported with a chunked arena. The arena is a " +
+        "chain of allocated chunks; an O(1) rewind would leak every chunk but the last. " +
+        "See #4540 (linked mode) and #4557 (own allocator).",
     );
   }
   // Add memory (1 page = 64 KiB, growable to 256 pages = 16 MiB).
@@ -346,7 +382,6 @@ export function finalizeLinearHeapLayout(mod: WasmModule): void {
   // allocated, so "the heap must sit above the data segments" is not a
   // relationship that exists. Lifting it here would bake an absolute constant
   // back into the exact mode this slice removes them from.
-  if (isLinkedArena(mod)) return;
   let dataEnd = 0;
   for (const seg of mod.dataSegments ?? []) {
     // A passive segment has no address, so it cannot constrain the heap floor.
@@ -354,6 +389,24 @@ export function finalizeLinearHeapLayout(mod: WasmModule): void {
     dataEnd = Math.max(dataEnd, seg.offset + seg.bytes.length);
   }
   if (dataEnd === 0) return;
+
+  // Data segments are initialised before any code runs, so the *declared*
+  // minimum has to cover them — this is true in every mode, including the
+  // #4557 own-allocator one where there is no floor to lift but the module
+  // still defines its own memory and still emits active segments.
+  const memoryForSegments = mod.memories[0];
+  if (memoryForSegments !== undefined) {
+    const neededPages = Math.ceil(dataEnd / WASM_PAGE_SIZE);
+    if (neededPages > memoryForSegments.min) memoryForSegments.min = neededPages;
+    if (memoryForSegments.max !== undefined && memoryForSegments.max < memoryForSegments.min) {
+      memoryForSegments.max = memoryForSegments.min;
+    }
+  }
+
+  // A chunked arena has no absolute floor to lift: its bump pointer starts at 0
+  // ("no chunk carved yet") and every address comes from an allocator. Lifting
+  // one here would bake back the absolute constant this design removed.
+  if (hasChunkedArena(mod)) return;
 
   const heapPtr = mod.globals.find((g) => g.name === "__heap_ptr");
   if (heapPtr === undefined) return;
@@ -374,14 +427,8 @@ export function finalizeLinearHeapLayout(mod: WasmModule): void {
     }
   }
 
-  // Data segments are initialised before any code runs, so the *declared*
-  // minimum has to cover them (memory.grow in __malloc is too late).
-  const memory = mod.memories[0];
-  if (memory !== undefined) {
-    const neededPages = Math.ceil(dataEnd / WASM_PAGE_SIZE);
-    if (neededPages > memory.min) memory.min = neededPages;
-    if (memory.max !== undefined && memory.max < memory.min) memory.max = memory.min;
-  }
+  // (`memory.min` was raised above, before the chunked-arena early return —
+  // active segments must be in bounds whichever allocator is in use.)
 
   if (newHeapStart === oldHeapStart) return;
   init.value = newHeapStart;

--- a/src/compiler/linear-options.ts
+++ b/src/compiler/linear-options.ts
@@ -19,5 +19,8 @@ export function buildLinearOptions(
     // #4540 — heap ownership in linked mode. Undefined unless a link is
     // requested, so standalone emission is untouched.
     linkedHeap: options.linearLinkedHeap,
+    // #4557 — own allocator. Undefined for every existing caller, so the bump
+    // arena and its emitted bytes are untouched unless it is asked for.
+    heapAllocator: options.linearHeapAllocator,
   };
 }

--- a/src/emit/binary.ts
+++ b/src/emit/binary.ts
@@ -1550,6 +1550,20 @@ export function encodeInstr(instr: Instr, enc: WasmEncoder): void {
       enc.u32(0x09);
       enc.u32(instr.dataIdx);
       break;
+    // `memory.copy` carries TWO memory indices (dst then src) and `memory.fill`
+    // one. Neither needs the data-count section — that requirement is specific
+    // to the two opcodes above, which name a data segment.
+    case "memory.copy":
+      enc.byte(OP.misc_prefix);
+      enc.u32(0x0a);
+      enc.byte(0x00);
+      enc.byte(0x00);
+      break;
+    case "memory.fill":
+      enc.byte(OP.misc_prefix);
+      enc.u32(0x0b);
+      enc.byte(0x00);
+      break;
     case "throw":
       if (valCtx) vIdx("exception tag", instr.tagIdx, valCtx.numTags);
       enc.byte(OP.throw);

--- a/src/index.ts
+++ b/src/index.ts
@@ -945,6 +945,16 @@ export interface CompileOptions {
     mallocImport: string;
     chunkBytes?: number;
   };
+  /**
+   * Which allocator backs the linear heap (#4557).
+   *
+   * `"malloc-v1"` emits a real allocator (free lists, coalescing, in-place
+   * `realloc`) and exports the five entry points the QuickJS artifact imports
+   * for `JS_NewRuntime2`, so the engine allocates through us instead of its own
+   * dlmalloc. Defaults to `"bump"` — ADR-0017's monotonic arena, and #4540's
+   * shipped fallback.
+   */
+  linearHeapAllocator?: "bump" | "malloc-v1";
 }
 
 import * as path from "path";

--- a/src/ir/types.ts
+++ b/src/ir/types.ts
@@ -415,6 +415,14 @@ type InstrBase =
   // Stack: [dest:i32, src_offset:i32, len:i32] -> []
   | { op: "memory.init"; dataIdx: number }
   | { op: "data.drop"; dataIdx: number }
+  // Bulk memory, the other half (#4540 own-allocator slice). A real `calloc`
+  // must zero and a real `realloc` must relocate; hand-written byte loops for
+  // either put an interpreter loop on the allocator's hot path. Neither of
+  // these names a data segment, so neither needs the data-count section.
+  // Stack: memory.copy [dest:i32, src:i32, len:i32] -> []
+  //        memory.fill [dest:i32, byte:i32, len:i32] -> []
+  | { op: "memory.copy" }
+  | { op: "memory.fill" }
   | { op: "try"; blockType: BlockType; body: Instr[]; catches: CatchClause[]; catchAll?: Instr[] }
   | { op: "throw"; tagIdx: number }
   | { op: "rethrow"; depth: number }

--- a/tests/issue-4557-own-allocator.test.ts
+++ b/tests/issue-4557-own-allocator.test.ts
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4557 — the ownership inversion: QuickJS allocates through OUR allocator.
+//
+// #4540 shipped the mirror image (our bump arena carved from the ENGINE's
+// `malloc`) and kept it as the documented fallback, because a bump arena has no
+// honest `free`, `realloc` or `usable_size` and `JS_NewRuntime2` needs all
+// three. This file covers the allocator that makes the inversion possible and
+// the wiring that installs it.
+//
+// The structural and standalone tests run everywhere. The artifact tests need
+// a libquickjs.wasm built from the CURRENT `qjs_shim.c` — one that predates
+// this issue has no `qjs_set_allocator`, and is skipped with a message rather
+// than failing as a bare `undefined is not a function`.
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const ARTIFACT_CANDIDATES = [
+  process.env.JS2WASM_QUICKJS_ARTIFACT,
+  new URL("../.tmp/quickjs-artifact/libquickjs.wasm", import.meta.url).pathname,
+  "/home/user/js2wasm/.tmp/quickjs-artifact/libquickjs.wasm",
+].filter((p): p is string => typeof p === "string" && p.length > 0);
+const ARTIFACT = ARTIFACT_CANDIDATES.find((p) => existsSync(p));
+
+/** Present only in an artifact built from the current shim. */
+const ARTIFACT_HAS_ALLOCATOR_HOOK =
+  ARTIFACT !== undefined &&
+  WebAssembly.Module.exports(new WebAssembly.Module(new Uint8Array(readFileSync(ARTIFACT)))).some(
+    (e) => e.name === "qjs_set_allocator",
+  );
+
+const MALLOC_SPEC = {
+  module: "qjs",
+  name: "malloc",
+  params: [{ kind: "i32" }],
+  results: [{ kind: "i32" }],
+} as const;
+
+/** `__heap_stats` selectors — see `heap-allocator.ts`. */
+const STAT_REGION_BYTES = 0;
+const STAT_REGION_COUNT = 1;
+const STAT_FREE_BYTES = 2;
+const STAT_N_ALLOC = 4;
+const STAT_N_FREE = 5;
+
+interface HeapExports {
+  memory: WebAssembly.Memory;
+  js2wasm_malloc: (n: number) => number;
+  js2wasm_calloc: (count: number, size: number) => number;
+  js2wasm_free: (p: number) => void;
+  js2wasm_realloc: (p: number, n: number) => number;
+  js2wasm_usable_size: (p: number) => number;
+  __heap_stats: (which: number) => number;
+}
+
+/** A STANDALONE module with the real allocator — regions come from memory.grow. */
+async function standaloneHeap(): Promise<HeapExports> {
+  const result = await compile(`export function ping(n: number): number { return n + 1; }`, {
+    target: "linear",
+    linearHeapAllocator: "malloc-v1",
+  } as never);
+  expect(result.errors ?? []).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return instance.exports as unknown as HeapExports;
+}
+
+describe("#4557 — the linear-lane allocator, standalone", () => {
+  it("exports the five entry points JSMallocFunctions needs", async () => {
+    const heap = await standaloneHeap();
+    for (const name of [
+      "js2wasm_malloc",
+      "js2wasm_calloc",
+      "js2wasm_free",
+      "js2wasm_realloc",
+      "js2wasm_usable_size",
+    ] as const) {
+      expect(typeof heap[name], name).toBe("function");
+    }
+  });
+
+  it("reports the TRUE reserved size, which is not the request", async () => {
+    // The acceptance criterion is specifically that this is asserted across a
+    // spread rather than assumed to equal the request: QuickJS drives
+    // JS_SetMemoryLimit / JS_SetGCThreshold off it, so a size that merely
+    // echoes the argument under-counts the heap and delays collection.
+    const heap = await standaloneHeap();
+    const seenLarger: number[] = [];
+    for (const n of [0, 1, 4, 8, 12, 13, 16, 17, 24, 31, 32, 100, 1000, 4096, 65536]) {
+      const p = heap.js2wasm_malloc(n);
+      expect(p, `malloc(${n})`).toBeGreaterThan(0);
+      const usable = heap.js2wasm_usable_size(p);
+      expect(usable, `usable(${n})`).toBeGreaterThanOrEqual(n);
+      // The whole reservation must be writable, or the number is a lie in the
+      // direction that corrupts rather than the direction that over-reports.
+      new Uint8Array(heap.memory.buffer).fill(0xa5, p, p + usable);
+      if (usable > n) seenLarger.push(n);
+      heap.js2wasm_free(p);
+    }
+    expect(seenLarger.length, "usable_size never exceeded the request — suspiciously echo-like").toBeGreaterThan(0);
+    expect(heap.js2wasm_usable_size(0)).toBe(0);
+  });
+
+  it("hands out non-overlapping blocks and keeps their contents", async () => {
+    const heap = await standaloneHeap();
+    const live: [number, number, number][] = [];
+    for (let i = 0; i < 500; i++) {
+      const n = 1 + ((i * 37) % 300);
+      const p = heap.js2wasm_malloc(n);
+      expect(p).toBeGreaterThan(0);
+      new Uint8Array(heap.memory.buffer).fill((i % 251) + 1, p, p + n);
+      live.push([p, n, (i % 251) + 1]);
+    }
+    const mem = new Uint8Array(heap.memory.buffer);
+    for (const [p, n, v] of live) {
+      for (let a = p; a < p + n; a++) {
+        if (mem[a] !== v) throw new Error(`block at ${p} clobbered at ${a}: ${mem[a]} != ${v}`);
+      }
+    }
+  });
+
+  it("keeps the heap BOUNDED under alloc/free churn — the property the bump arena cannot have", async () => {
+    const heap = await standaloneHeap();
+    const live = new Int32Array(64);
+    for (let i = 0; i < 2000; i++) {
+      const slot = i % 64;
+      if (live[slot]) heap.js2wasm_free(live[slot]!);
+      live[slot] = heap.js2wasm_malloc(1 + ((i * 13) % 200));
+    }
+    const settled = heap.__heap_stats(STAT_REGION_BYTES);
+    for (let i = 0; i < 200_000; i++) {
+      const slot = i % 64;
+      if (live[slot]) heap.js2wasm_free(live[slot]!);
+      live[slot] = heap.js2wasm_malloc(1 + ((i * 13) % 200));
+    }
+    // 200k more allocations after the working set settled must not grow it.
+    expect(heap.__heap_stats(STAT_REGION_BYTES)).toBe(settled);
+    expect(heap.__heap_stats(STAT_N_ALLOC)).toBeGreaterThan(200_000);
+    expect(heap.__heap_stats(STAT_N_FREE)).toBeGreaterThan(200_000);
+  });
+
+  it("coalesces: many freed neighbours become one block bigger than any of them", async () => {
+    // Without coalescing this fails — the free lists would hold 64 separate
+    // 1 KiB blocks and a 60 KiB request would have to take a fresh region.
+    const heap = await standaloneHeap();
+    const ptrs: number[] = [];
+    for (let i = 0; i < 64; i++) ptrs.push(heap.js2wasm_malloc(1024));
+    const regionsBefore = heap.__heap_stats(STAT_REGION_COUNT);
+    for (const p of ptrs) heap.js2wasm_free(p);
+    const big = heap.js2wasm_malloc(60 * 1024);
+    expect(big).toBeGreaterThan(0);
+    expect(heap.__heap_stats(STAT_REGION_COUNT)).toBe(regionsBefore);
+  });
+
+  it("reallocs in place when it can, and preserves contents when it cannot", async () => {
+    const heap = await standaloneHeap();
+    let p = heap.js2wasm_malloc(16);
+    new Uint8Array(heap.memory.buffer).fill(0xab, p, p + 16);
+    for (let n = 32; n <= 8192; n *= 2) {
+      const q = heap.js2wasm_realloc(p, n);
+      expect(q, `realloc to ${n}`).toBeGreaterThan(0);
+      expect(heap.js2wasm_usable_size(q)).toBeGreaterThanOrEqual(n);
+      const mem = new Uint8Array(heap.memory.buffer);
+      for (let a = q; a < q + 16; a++) expect(mem[a], `byte ${a - q} after realloc to ${n}`).toBe(0xab);
+      p = q;
+    }
+    // Shrinking releases the tail rather than sitting on it.
+    const freeBefore = heap.__heap_stats(STAT_FREE_BYTES);
+    p = heap.js2wasm_realloc(p, 32);
+    expect(heap.__heap_stats(STAT_FREE_BYTES)).toBeGreaterThan(freeBefore);
+    // realloc(p, 0) frees and yields the null pointer, per js_realloc's contract.
+    expect(heap.js2wasm_realloc(p, 0)).toBe(0);
+  });
+
+  it("calloc zeroes recycled memory and refuses an overflowing product", async () => {
+    const heap = await standaloneHeap();
+    const dirty = heap.js2wasm_malloc(256);
+    new Uint8Array(heap.memory.buffer).fill(0xff, dirty, dirty + 256);
+    heap.js2wasm_free(dirty);
+    const p = heap.js2wasm_calloc(16, 16);
+    const mem = new Uint8Array(heap.memory.buffer);
+    for (let a = p; a < p + 256; a++) expect(mem[a], `calloc byte ${a - p}`).toBe(0);
+    // 0x10000 * 0x10000 wraps to 0 in i32; a wrapped product would hand back a
+    // tiny block for a huge request, which is a heap overflow waiting to happen.
+    expect(heap.js2wasm_calloc(0x10000, 0x10000)).toBe(0);
+  });
+
+  it("standalone emission is untouched unless the allocator is asked for", async () => {
+    const src = `export function f(n: number): number { const a: number[] = []; for (let i = 0; i < n; i = i + 1) { a.push(i); } return a.length; }`;
+    const plain = await compile(src, { target: "linear" } as never);
+    const own = await compile(src, { target: "linear", linearHeapAllocator: "malloc-v1" } as never);
+    expect(plain.wat).not.toContain("__heap_ctl");
+    expect(own.wat).toContain("__heap_ctl");
+    // The bump arena is the default, and it still owns the address space.
+    expect(plain.wat).toContain("memory.grow");
+  });
+});
+
+describe("#4557 — linked mode keeps #4540's one-grower property", () => {
+  it("emits no memory.grow: with the allocator installed the ENGINE still owns growth", async () => {
+    // The inversion moves WHO ALLOCATES, not who grows. Our allocator takes
+    // whole regions from the engine's `malloc`; it never grows the memory
+    // itself, so the #4540 construction proof survives unchanged.
+    const result = await compile(`export function f(n: number): number { return n + 1; }`, {
+      target: "linear",
+      linearImportMemory: { module: "qjs", name: "memory", min: 256, max: 16384 },
+      linearExternImports: [MALLOC_SPEC],
+      linearLinkedHeap: { mallocImport: "malloc" },
+      linearHeapAllocator: "malloc-v1",
+    } as never);
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.wat).not.toContain("memory.grow");
+    expect(result.wat).toContain("__heap_ctl");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.skipIf(!ARTIFACT_HAS_ALLOCATOR_HOOK)("#4557 — against the real pinned artifact", () => {
+  const bytes = (): Uint8Array => new Uint8Array(readFileSync(ARTIFACT!));
+
+  type Engine = {
+    memory: WebAssembly.Memory;
+    malloc: (n: number) => number;
+    free: (p: number) => void;
+    __indirect_function_table: WebAssembly.Table;
+    _initialize?: () => void;
+    qjs_set_allocator: (m: number, c: number, f: number, r: number, u: number) => number;
+    qjs_new_runtime: () => number;
+    qjs_new_runtime2: () => number;
+    qjs_new_context: (rt: number) => number;
+    qjs_eval: (ctx: number, src: number, len: number) => number;
+    qjs_to_f64: (ctx: number, h: number) => number;
+    qjs_free_value: (ctx: number, h: number) => void;
+    qjs_libc_alloc_count: () => number;
+    qjs_malloc_size: (rt: number) => number;
+  };
+
+  /** Order IS the ABI — `qjs_set_allocator` takes the slots positionally. */
+  const PEER_ALLOC_ORDER = [
+    "js2wasm_malloc",
+    "js2wasm_calloc",
+    "js2wasm_free",
+    "js2wasm_realloc",
+    "js2wasm_usable_size",
+  ] as const;
+
+  async function newEngine(): Promise<Engine> {
+    const held: { instance?: WebAssembly.Instance } = {};
+    const mem = (): WebAssembly.Memory => held.instance!.exports.memory as WebAssembly.Memory;
+    const dv = (): DataView => new DataView(mem().buffer);
+    const wasi_snapshot_preview1 = {
+      clock_time_get: (_a: number, _b: bigint, out: number) => {
+        dv().setBigUint64(out, 0n, true);
+        return 0;
+      },
+      fd_write: (_fd: number, iovs: number, len: number, nwritten: number) => {
+        const view = dv();
+        let total = 0;
+        for (let i = 0; i < len; i++) total += view.getUint32(iovs + i * 8 + 4, true);
+        view.setUint32(nwritten, total, true);
+        return 0;
+      },
+      fd_close: () => 0,
+      fd_seek: (_fd: number, _o: bigint, _w: number, out: number) => {
+        dv().setBigUint64(out, 0n, true);
+        return 0;
+      },
+      fd_fdstat_get: (_fd: number, stat: number) => {
+        new Uint8Array(mem().buffer).fill(0, stat, stat + 24);
+        return 0;
+      },
+    };
+    const result = await WebAssembly.instantiate(bytes(), { wasi_snapshot_preview1 });
+    held.instance = result.instance;
+    (held.instance.exports as { _initialize?: () => void })._initialize?.();
+    return held.instance.exports as unknown as Engine;
+  }
+
+  async function linkedPair(install: boolean): Promise<{ engine: Engine; peer: HeapExports; rt: number; ctx: number }> {
+    const engine = await newEngine();
+    const built = await compile(`export function ping(n: number): number { return n + 1; }`, {
+      target: "linear",
+      linearImportMemory: { module: "qjs", name: "memory", min: 256, max: 16384 },
+      linearExternImports: [MALLOC_SPEC],
+      linearLinkedHeap: { mallocImport: "malloc", chunkBytes: 65536 },
+      linearHeapAllocator: "malloc-v1",
+    } as never);
+    expect(built.errors ?? []).toEqual([]);
+    const peer = (
+      await WebAssembly.instantiate(built.binary, { qjs: { memory: engine.memory, malloc: engine.malloc } })
+    ).instance.exports as unknown as HeapExports;
+    if (install) {
+      const table = engine.__indirect_function_table;
+      const base = table.grow(PEER_ALLOC_ORDER.length);
+      PEER_ALLOC_ORDER.forEach((name, i) => table.set(base + i, (peer as unknown as Record<string, unknown>)[name]));
+      expect(engine.qjs_set_allocator(base, base + 1, base + 2, base + 3, base + 4)).toBe(1);
+    }
+    const rt = install ? engine.qjs_new_runtime2() : engine.qjs_new_runtime();
+    return { engine, peer, rt, ctx: engine.qjs_new_context(rt) };
+  }
+
+  function evalJs(engine: Engine, ctx: number, src: string): number {
+    const p = engine.malloc(src.length + 1);
+    new Uint8Array(engine.memory.buffer).set(new TextEncoder().encode(src), p);
+    const h = engine.qjs_eval(ctx, p, src.length);
+    engine.free(p);
+    return h;
+  }
+
+  // The IIFE is load-bearing: JS_EVAL_TYPE_GLOBAL shares one lexical scope, so a
+  // top-level `let` makes every eval after the first throw a redeclaration
+  // SyntaxError — which looks exactly like an extremely fast allocator.
+  const WORKLOAD = `(function () {
+    let acc = 0;
+    for (let i = 0; i < 20000; i++) {
+      const o = { a: i, b: i + 1, s: "k" + (i & 255) };
+      acc += o.a + o.b + o.s.length;
+    }
+    return acc;
+  })()`;
+  // Cross-checked against Node evaluating the same source, not taken from the
+  // engine under test — a self-reported constant would make the assertion vacuous.
+  const WORKLOAD_EXPECT = 400_071_378;
+
+  it("still imports ONLY wasi_snapshot_preview1 — the allocator arrives via the table, not as imports", () => {
+    // Five unconditional wasm imports would make the artifact un-instantiable
+    // without a peer that supplies an allocator, which `extract-abi.mjs` and the
+    // runtime-eval tier both do. See the peer-allocator note in qjs_shim.c.
+    const modules = new Set(WebAssembly.Module.imports(new WebAssembly.Module(bytes())).map((i) => i.module));
+    expect([...modules]).toEqual(["wasi_snapshot_preview1"]);
+  });
+
+  it("refuses to build a runtime when no allocator was installed", async () => {
+    const engine = await newEngine();
+    expect(engine.qjs_new_runtime2()).toBe(0);
+    // …and the legacy constructor still works, so the fallback stays reachable.
+    expect(engine.qjs_new_runtime()).toBeGreaterThan(0);
+  });
+
+  it("the ENGINE reaches our allocator — proven by counting calls, not by the wiring", async () => {
+    const { engine, peer, rt, ctx } = await linkedPair(true);
+    expect(rt).toBeGreaterThan(0);
+    const before = peer.__heap_stats(STAT_N_ALLOC);
+    // Creating the runtime and context alone must already have gone through us.
+    expect(before).toBeGreaterThan(0);
+    const handle = evalJs(engine, ctx, WORKLOAD);
+    expect(engine.qjs_to_f64(ctx, handle)).toBe(WORKLOAD_EXPECT);
+    expect(peer.__heap_stats(STAT_N_ALLOC)).toBeGreaterThan(before);
+    // Every byte QuickJS thinks it owns came from a block we handed out, so its
+    // accounting cannot exceed the memory we actually reserved.
+    expect(engine.qjs_malloc_size(rt)).toBeGreaterThan(0);
+    expect(engine.qjs_malloc_size(rt)).toBeLessThanOrEqual(peer.__heap_stats(STAT_REGION_BYTES));
+    // Nothing in the shim fell back to dlmalloc behind our back.
+    expect(engine.qjs_libc_alloc_count()).toBe(0);
+  });
+
+  it("eval in a loop leaves the heap bounded", async () => {
+    const { engine, peer, rt, ctx } = await linkedPair(true);
+    let settled = 0;
+    for (let round = 0; round < 12; round++) {
+      const handle = evalJs(engine, ctx, WORKLOAD);
+      expect(engine.qjs_to_f64(ctx, handle), `round ${round}`).toBe(WORKLOAD_EXPECT);
+      engine.qjs_free_value(ctx, handle);
+      if (round === 2) settled = peer.__heap_stats(STAT_REGION_BYTES);
+    }
+    expect(settled).toBeGreaterThan(0);
+    // Nine more evals after the working set settled reserve nothing further,
+    // and QuickJS's own accounting agrees the heap is not creeping.
+    expect(peer.__heap_stats(STAT_REGION_BYTES)).toBe(settled);
+    expect(engine.qjs_malloc_size(rt)).toBeLessThan(settled);
+  });
+
+  it("the memory does NOT grow while the engine allocates through us", async () => {
+    // Who grows: still the engine. Our regions come from its `malloc`, and our
+    // module contains no `memory.grow` instruction at all.
+    const { engine, ctx } = await linkedPair(true);
+    const pagesBefore = engine.memory.buffer.byteLength / 65536;
+    for (let i = 0; i < 6; i++) engine.qjs_free_value(ctx, evalJs(engine, ctx, WORKLOAD));
+    expect(engine.memory.buffer.byteLength / 65536).toBe(pagesBefore);
+  });
+});


### PR DESCRIPTION
## Description

Two independent slices. 26 files, ~4,500 insertions.

### [#4557](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4557-linear-own-allocator-engine-allocates-through-us) — QuickJS allocates through our allocator

New `src/codegen-linear/heap-allocator.ts` (a real `malloc`/`calloc`/`free`/`realloc`/`usable_size`), `qjs_shim.c` builds `JSMallocFunctions` from imported functions and calls `JS_NewRuntime2`. All six acceptance criteria met, each exercised rather than asserted.

**Two findings that go against the plan of record, both measured:**

| | dlmalloc | ours | ratio |
|---|---|---|---|
| End-to-end engine workload (120k objects/arrays/string keys) | 73.13 ms | 74.98 ms | 1.025× |
| Engine-shaped alloc (4 KiB arenas + large) | 3.26 ms | 3.51 ms | 1.076× |
| Many small short-lived (8–256 B) | 3.04 ms | 6.29 ms | **2.068×** |

The 2× is real, not instrumentation — an A/B with counters and histogram removed measured 6.93 vs 6.91 ms, within noise. Cause: `__heap_alloc` makes four to five non-inlined wasm calls per allocation where dlmalloc inlines its whole fast path. It does not bind end-to-end because the engine's own pattern does not reach that path.

**"One grower" is NOT achieved, and that answer is explicit rather than glossed.** The engine's dlmalloc still grows the memory and is still linked. Our emitted module contains no `memory.grow` at all in linked mode (asserted on the WAT, with #4540's discriminating counter-assertion that the standalone module does contain one). ADR-0020 speculated that dropping dlmalloc might shrink the artifact; it did not — **1,016,254 → 1,022,989 bytes raw** (+6,735), because dlmalloc is still there.

### [#4544](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4544-native-binary-emission-and-tier-elision) Part A — native binary baseline

**The ADR-0021 gate CLOSES: a direct native backend is not justified.**

A real program becomes a **22.9 KB self-contained native binary** starting **0.14–0.20 ms above bare process creation** — 1.58× the size of the same program hand-written in C, and indistinguishable from it on startup — via `wasm2c` + clang. Even linking the whole QuickJS tier yields one 1.60 MB binary that evaluates JavaScript in 0.64 ms.

All four routes were installed and measured (wasmtime 27.0.0 AOT, WAMR 2.2.0 AOT, `wasm2c` 1.0.39 + clang 18.1.3, and the JIT baseline), with outputs verified per route so the binaries demonstrably *run*, not merely build. Startup is 201 runs per configuration against a measured `execFloor` for bare process creation, reported as min/p50/p90/max.

So ADR-0021 stays Accepted as a *target choice* and stays unscheduled — including its stated prerequisite of finishing `ir-full-coverage` (#2855), which does not have to be paid for this reason.

**Still open, stated rather than implied:** the Wasm→C *throughput* objection was not tested — Part A measured size and startup only.

## Validation

| Gate | Result |
|---|---|
| Targeted tests (4 files) | 65 pass, 5 skipped |
| `biome lint --diagnostic-level=error` | clean |
| Standalone emit identity | 60/60 records identical |

`check:linear-ir` is red, byte-identical on clean `main` — pre-existing and unowned, filed as [#4558](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4558-linear-ir-ratchet-red-on-main).

## CLA

- [ ] I have read and agree to the CLA

Left unticked deliberately: org-member PRs skip `cla-check` automatically per the template, and affirming the agreement is the author's to make.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6CYp7YeqqhKf8sgFsDMKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6CYp7YeqqhKf8sgFsDMKq)_