### PR TITLE
chore(issues): 4539 and 4557 done post-merge, with evidence for the last criterion

### DIFF
--- a/plan/issues/4539-linear-lane-import-direction-and-memory.md
+++ b/plan/issues/4539-linear-lane-import-direction-and-memory.md
@@ -1,7 +1,7 @@
 ---
 id: 4539
 title: "Linear lane link topology: extern-C import declarations, emit imports at all, import the memory instead of defining it"
-status: in-progress
+status: done
 sprint: Backlog
 # The substantive code lands in c-abi.ts (not a god-file). What remains is
 # wiring that can only live where the module is constructed: +24 in
@@ -15,6 +15,7 @@ loc-budget-allow:
   - src/codegen-linear/runtime.ts
 created: 2026-08-17
 updated: 2026-08-17
+completed: 2026-08-19
 priority: high
 horizon: l
 feasibility: medium
@@ -75,15 +76,28 @@ drift):
 
 ## Acceptance criteria
 
-- [ ] A linear-target module can declare and call an imported C function, with
+- [x] A linear-target module can declare and call an imported C function, with
       correct function indices, verified by a decoded-module assertion.
-- [ ] A linear-target module can be emitted in import-memory mode and
+- [x] A linear-target module can be emitted in import-memory mode and
       instantiate successfully against the pinned engine artifact.
-- [ ] Existing standalone output is **unchanged** when neither mode is
+- [x] Existing standalone output is **unchanged** when neither mode is
       requested — verified by `scripts/prove-emit-identity.mjs` against a
       pre-change baseline captured at the first edit.
-- [ ] The import path is exercised by a test that links the two modules and
+- [x] The import path is exercised by a test that links the two modules and
       calls through, not merely by a unit test of the declaration table.
+
+**All four criteria met (recorded 2026-08-19, post-merge).** Where each is
+demonstrated, since three landed with this issue and the fourth arrived later:
+
+- Declare + call an imported C function with correct indices, and the
+  link-and-call-through test: `tests/issue-4539.test.ts` and
+  `tests/issue-4539-c-link.test.ts` (the latter builds a real clang module).
+- Standalone output unchanged: `prove-emit-identity`, 60/60 records identical.
+- **Instantiate against the pinned engine artifact** — this one was NOT met when
+  the rest landed, because no artifact existed here. It is met now via #4557,
+  whose tests instantiate our module alongside the real `libquickjs.wasm`
+  sharing one memory and run `eval` workloads through it. Ticked on that
+  evidence rather than on this issue's own tests.
 
 ## Validation
 

--- a/plan/issues/4557-linear-own-allocator-engine-allocates-through-us.md
+++ b/plan/issues/4557-linear-own-allocator-engine-allocates-through-us.md
@@ -1,10 +1,11 @@
 ---
 id: 4557
 title: "Invert allocator ownership: a real linear-lane allocator, installed via JS_NewRuntime2 so QuickJS allocates through us"
-status: in-review
+status: done
 sprint: current
 created: 2026-08-19
 updated: 2026-08-19
+completed: 2026-08-19
 # Implementation complete and all acceptance criteria exercised (see
 # "Implementation notes"). `in-review` rather than `done` because this lane does
 # not merge: the project lead consolidates. Flip to `done` on merge.


### PR DESCRIPTION
## Description

Post-merge issue reconciliation after #4656 landed. Two plan files, +21 / −6. No source change.

### [#4557](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4557-linear-own-allocator-engine-allocates-through-us) → done

Left at `in-review` with all six criteria met and its PR merged. A merged PR means done — an issue stranded at `in-review` has no observer left to move it, which is exactly the failure the lifecycle rule names.

### [#4539](https://js2wasm.loopdive.com/dashboard/issue.html?slug=4539-linear-lane-import-direction-and-memory) → done

All four criteria were unticked although every one is now satisfied. Ticked with a note recording **where each is demonstrated**, rather than silently:

- declare and call an imported C function with correct indices, plus the link-and-call-through test — `tests/issue-4539.test.ts` and `tests/issue-4539-c-link.test.ts` (the latter builds a real clang module);
- standalone output unchanged — `prove-emit-identity`, 60/60 records identical;
- **instantiate against the pinned engine artifact** — this one was *not* met when the rest landed, because no artifact existed in the container. It is met now via #4557, whose tests instantiate our module alongside the real `libquickjs.wasm` sharing one memory and run `eval` workloads through it.

That last point is why this is a commit rather than a quiet edit: #4539 was reported as complete earlier while its second criterion was unmet. Satisfying it took building the artifact and landing #4557.

### Left in-progress, with genuinely open items

| Issue | Outstanding |
|---|---|
| #4540 | carve-from-`malloc` vs direct comparison arm; two-memory decision (deliberately a project-lead call — one shared memory means an exploited `eval` reaches our arena) |
| #4542 | heap-growth fixtures still artifact-gated |
| #4544 | Part B depends on #4541 |
| #4554 | tier 1 only |
| #4558 | `ready`, unowned |

## CLA

- [ ] I have read and agree to the CLA

Left unticked deliberately: org-member PRs skip `cla-check` automatically per the template, and affirming the agreement is the author's to make.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6CYp7YeqqhKf8sgFsDMKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6CYp7YeqqhKf8sgFsDMKq)_