### PR TITLE
docs(plan): add Node API compatibility roadmap

### DIFF
--- a/plan/issues/2512-node-host-apis-as-separate-linkable-wasm-modules.md
+++ b/plan/issues/2512-node-host-apis-as-separate-linkable-wasm-modules.md
@@ -4,23 +4,24 @@ title: "Node.js host APIs as separate, link-on-demand Wasm modules (process, fs,
 status: backlog
 sprint: Backlog
 created: 2026-06-19
-updated: 2026-06-19
-priority: medium
+updated: 2026-08-20
+priority: high
 feasibility: hard
 reasoning_effort: high
 task_type: architecture
 area: codegen
 language_feature: node-host-apis
 goal: architecture
-related: [1044, 1046, 2514]
+related: [1044, 1046, 2514, 4382, 4567, 4568, 4570, 4571]
 ---
 
-> **Linking mechanism (decided):** **core-wasm module linking** (per-host shim
-> modules: `node-shim.wasm` over WASI, `deno-shim.wasm`, … sharing a store with
-> the user module) — see **#2524** (chosen, implement first). The Component Model
-> + WIT alternative — a `node:io/process` WIT world embedded in the component as
-> the declared dependency, composed against a shim component — is **#2525**
-> (deferred; clean fit for this byte/scalar boundary but lower priority).
+> **Interface and linking mechanism (decided):** the compiled user module
+> declares the standard interface it needs, such as import module `node:fs`
+> with member `readSync`. Core-Wasm module linking selects a provider over WASI,
+> a JS host, or another explicit target adapter. The provider implementation's
+> name is not part of the user's declared dependency. “Phase 1: process IO via
+> linkable js2wasm:node-io shim” (#2524) owns the current linking substrate;
+> “Component Model + WIT for host-API shims” (#2525) remains deferred.
 
 ## Problem / proposal
 
@@ -31,11 +32,13 @@ is currently lowered as **inline glue** baked into each compiled module:
 reusable Wasm module that implements the Node API surface and gets **linked when
 required**.
 
-Proposal: factor each Node host-API surface into its own linkable Wasm module
-(or host-import interface) that user modules import on demand, instead of
-re-emitting the glue per module. This keeps the user's binary focused on user
-code, lets the host-API implementations version independently, and gives a clean
-seam for the dual-mode story (WASI syscalls vs JS host).
+Proposal: factor each Node host-API surface into its own linkable provider that
+user modules import on demand, instead of re-emitting the glue per module. The
+user artifact names the standard `node:<module>` interface and real member;
+provider selection and composition happen after the compiler has frozen the
+program's required-member set. This keeps the user's binary focused on user
+code, lets implementations version independently, and gives a clean seam for
+the dual-mode story (WASI syscalls vs JS host).
 
 ## Why this surface is the tractable half
 
@@ -54,24 +57,50 @@ extract behind a stable interface.
 
 ## Scope
 
-- Define a stable host-API interface (Wasm imports / a `node:` runtime module)
-  per supported Node surface, starting with `process`.
-- Emit an *import of* that interface from the user module instead of inline glue,
-  gated on actual usage (preserve current DCE behavior).
+- Define a stable Wasm import interface named after each standard Node module,
+  starting with byte/scalar members of `node:process` and `node:fs`.
+- Emit only the real members proven used by prepared IR. Namespace recognition
+  alone must not link a provider family.
+- Select and link the provider from the frozen runtime-feature/capability plan;
+  backend emission must not rescan source or infer use from stringly import
+  names.
 - Keep the dual-mode contract: WASI syscall backing in standalone, JS host
   backing when a JS runtime is present (cf. #1044 Node-builtins-as-host-imports).
+- Prove with negative fixtures that unused Node modules, members, provider code,
+  and transitive WASI imports are absent from the artifact.
 - Out of scope: GC-typed runtime helpers (number_toString, string/array helpers)
   — tracked separately in #2514, blocked on the cross-module GC type-identity
   problem.
 
-## Open questions (route to architect)
+## Resolved constraints and remaining design work
 
-- Module-linking vs Component Model vs plain shared host-import namespace — which
-  seam, and how does it interact with `--target wasi` vs JS-host?
-- Relationship to #1044 (Node builtins as host imports) and #1046 (separate
-  ES-module compilation + consumer-driven linking) — is this a generalization of
-  #1044, or a distinct runtime-module layer?
-- Versioning / ABI stability of the interface across compiler versions.
+- The public import namespace is `node:<module>`, never an
+  implementation-specific shim name. The module declares what it needs, not
+  how it is satisfied.
+- Core-Wasm linking is the current composition mechanism. A real Node host may
+  satisfy the same interface directly where ABI adaptation permits it.
+- The first tractable tranche is byte/scalar IO. GC string/object APIs require
+  an explicit cross-module representation/versioning decision; they must not be
+  smuggled through ambient externrefs.
+- ABI versioning, provider compatibility checks, and diagnostics for a missing
+  or incompatible provider remain implementation work for this issue.
+
+## Acceptance criteria
+
+- [ ] A compiled member call declares `node:<module>` plus the real Node member
+      name and never exposes an implementation-specific provider namespace.
+- [ ] Prepared IR records the exact used-member set and provider requirements
+      before emission; linking consumes that frozen record.
+- [ ] JS-host and WASI providers can satisfy the same declared interface without
+      source changes or compiler-special syscall lowering.
+- [ ] ABI version/capability mismatches fail with stable diagnostics before a
+      provider can return an empty or placeholder value.
+- [ ] Positive fixtures execute one selected member per initial provider;
+      negative fixtures prove unused members, modules, code, and transitive host
+      imports are absent.
+- [ ] “Compiler-derived capability manifest and per-program explain workflow”
+      (#4382) explains the interface, selected provider, and transitive
+      requirements from the same decision record.
 
 ## Notes
 

--- a/plan/issues/3681-differential-whole-program-corpus-testing.md
+++ b/plan/issues/3681-differential-whole-program-corpus-testing.md
@@ -4,7 +4,7 @@ title: "Differential whole-program target matrix — Node oracle vs JS-host, sta
 status: backlog
 sprint: Backlog
 created: 2026-07-26
-updated: 2026-08-12
+updated: 2026-08-20
 priority: high
 horizon: m
 feasibility: medium
@@ -14,7 +14,7 @@ area: testing, compiler, codegen-linear
 language_feature: whole-program-semantics
 es_edition: multi
 goal: test-infrastructure
-related: [1203, 1854, 1941, 2711, 3518, 3781]
+related: [1203, 1854, 1941, 2711, 3518, 3781, 4567, 4568, 4569, 4570, 4572]
 ---
 
 # #3681 — Differential whole-program target matrix
@@ -90,6 +90,26 @@ behavioral interaction they protect. Test262 remains authoritative for
 language conformance, and its license/metadata rules are preserved when a
 minimized case is derived from it.
 
+## Node API contract corpus
+
+Add a focused corpus partition for provider-backed `node:*` APIs. Its manifest
+records the canonical module/member, import shape, arguments, environment and
+capabilities, applicable targets, and observables. Coverage of one member is not
+reported as coverage of its whole module.
+
+In addition to stdout and exit behavior, Node API fixtures compare:
+
+- returned values and stable object fields;
+- error name/class, `code`, selected stable message fragments, and first-error
+  ordering;
+- argument coercion and side effects that occur before provider dispatch;
+- callback cardinality and relative `nextTick`/microtask/timer/event-loop order;
+- emitted import/provider selection and explicit target-inapplicability reason.
+
+Every module/member/target row remains in the denominator as pass, known
+divergence, unsupported, unknown, compile failure, runtime failure, or harness
+failure. A missing provider or unseen dynamic member is not a skipped pass.
+
 ## Reusable corpus interchange
 
 Define a small, documented fixture manifest for source files, arguments,
@@ -132,6 +152,11 @@ wildcards and output deletion are forbidden.
 - [ ] A versioned fixture manifest can import/export a focused case without
       losing arguments, observables, applicability, seed, license, or
       provenance; at least one round-trip fixture proves the interchange.
+- [ ] The Node API partition reports per-module, per-member, import-shape, and
+      per-target denominators, with unsupported and unknown rows retained.
+- [ ] Focused Node API fixtures compare stable errors, validation/side-effect
+      order, and callback scheduling, with positive controls proving the
+      harness detects each kind of divergence.
 - [ ] Test262 remains a separate, authoritative standards signal; differential
       pass counts are not labeled conformance.
 

--- a/plan/issues/4382-compiler-capability-manifest-explain-workflow.md
+++ b/plan/issues/4382-compiler-capability-manifest-explain-workflow.md
@@ -4,7 +4,7 @@ title: "Compiler-derived capability manifest and per-program explain workflow"
 status: backlog
 sprint: Backlog
 created: 2026-08-12
-updated: 2026-08-12
+updated: 2026-08-20
 priority: high
 horizon: l
 feasibility: hard
@@ -15,7 +15,7 @@ language_feature: compiler-capabilities
 es_edition: multi
 goal: developer-experience
 depends_on: [3526, 3678]
-related: [1590, 2135, 2634, 3518, 3519, 3681]
+related: [1590, 2135, 2634, 3518, 3519, 3681, 4567]
 origin: "2026-08-12 compiler architecture and user-trust review"
 ---
 # #4382 — Compiler-derived capability manifest and per-program explain workflow
@@ -78,6 +78,23 @@ The report is deterministic, versioned, serializable, and embedded in or
 adjacent to the compile result. Backend emission may consume this frozen plan;
 it may not revise the public classification after artifacts have started.
 
+### Node API projection
+
+Project Node builtin decisions from “Make `node:*` builtin support
+member-explicit, provider-explicit, and fail-closed” (#4567); do not infer them
+from the broad recognized-module list or emitted import-name patterns. For each
+used `node:*` member, report:
+
+- canonical module and real export name;
+- source import form and location;
+- selected typed interface plus runtime provider, if any;
+- target-lane result and transitive host/WASI capabilities;
+- unsupported or unknown reason with the stable diagnostic and remediation.
+
+Namespace/default imports and dynamic member reads must retain unresolved
+members as visible `unknown` rows. A report cannot claim a whole module is
+supported merely because one export has a provider.
+
 ### Repository-wide projections
 
 Generate machine-readable release and website artifacts from the same registry.
@@ -121,6 +138,10 @@ document its replacement rather than breaking existing automation abruptly.
       decisions, providers, host capabilities, diagnostics, and provenance.
 - [ ] The report is derived from #2135/#3526 production decisions; no parallel
       support matrix or emitted-import name heuristic becomes authoritative.
+- [ ] Every used `node:*` member projects the module, member, import form,
+      provider, target availability, transitive capabilities, and precise
+      unsupported/unknown reason from “Make `node:*` builtin support
+      member-explicit, provider-explicit, and fail-closed” (#4567).
 - [ ] Focused fixtures cover host-free Wasm, declared host capability,
       runtime-evaluation provider, unsupported source, and deliberately
       unprojected/unknown source for every supported target mode.

--- a/plan/issues/4419-compilefiles-drops-node-builtin-bindings.md
+++ b/plan/issues/4419-compilefiles-drops-node-builtin-bindings.md
@@ -4,7 +4,7 @@ title: "compileFiles silently binds node:* imports to ref.null and reports succe
 status: ready
 sprint: current
 created: 2026-08-14
-updated: 2026-08-14
+updated: 2026-08-20
 priority: high
 horizon: s
 feasibility: easy
@@ -12,6 +12,7 @@ reasoning_effort: medium
 task_type: bug
 area: compiler
 goal: correctness
+related: [4567]
 ---
 
 ## Problem
@@ -57,14 +58,26 @@ Thread the `prep` / `nodeBuiltins` through `compileFilesSource` the way
 cannot resolve them, it must **fail loudly** instead of emitting a null
 binding.
 
+Exercise the fix across named, default, and namespace ESM imports plus static
+CommonJS `require`/destructuring. Compare every public compiler entry point:
+single-source compile, `compileFiles`, `compileMultiSource`, and
+`compileProject`. Each row must either emit the applicable provider import or
+return a deliberate unsupported/unknown diagnostic; successful null/empty
+binding is never an allowed third state.
+
 ## Acceptance criteria
 
 - [ ] `compileFiles` on an entry importing `node:fs` emits `env.__node_fs`,
       matching `compileProject` on the same input.
+- [ ] Named, default, namespace, static `require`, and destructured CommonJS
+      forms produce the same non-null capability decision in every compiler
+      entry point that accepts the form.
 - [ ] A test asserts the import is present, not merely that the compile
       succeeded — the bug is invisible to a success check.
 - [ ] If a builtin genuinely cannot be lowered on this path, the compile
       reports an error rather than binding `ref.null`.
+- [ ] The matrix includes a supported positive control and an intentionally
+      unavailable member proving that the failure path is observable.
 
 ## Provenance
 

--- a/plan/issues/4567-node-builtins-provider-explicit-fail-closed.md
+++ b/plan/issues/4567-node-builtins-provider-explicit-fail-closed.md
@@ -1,0 +1,108 @@
+---
+id: 4567
+title: "Make node:* builtin support member-explicit, provider-explicit, and fail-closed"
+status: backlog
+created: 2026-08-20
+updated: 2026-08-20
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: refactor
+area: compiler, checker, runtime
+language_feature: node-builtin-capabilities
+goal: node-compatibility
+sprint: Backlog
+depends_on: [4419]
+required_by: [4568, 4569, 4570, 4572]
+horizon: m
+es_edition: n/a
+related: [1044, 2634, 4382, 4398]
+origin: "2026-08-20 Node API compatibility and portability review"
+---
+# #4567 — Make `node:*` builtin support provider-explicit and fail-closed
+
+## Objective
+
+Replace the gap between “recognized Node module” and “runnable Node member”
+with one compiler-owned registry. Every imported member must have an explicit
+signature, semantic placement, target result, and runtime provider before
+emission begins.
+
+The registry describes the standard interface that the compiled module needs:
+`node:fs::readSync`, `node:path::join`, and so on. It must not expose the name
+or implementation details of a particular shim.
+
+## Problem
+
+`NODE_BUILTIN_MODULES`, typed function/class stubs, capability-map entries,
+host adapters, and codegen registration currently describe overlapping but
+different surfaces. Merely appearing in the recognized-module set does not
+prove that a member has a faithful type, a provider for the selected target,
+or any implementation at all.
+
+Several generic paths still tolerate incomplete knowledge by producing an
+opaque module object, returning `undefined`, or binding a null externref. That
+turns an unsupported capability into a successful compile followed by a late
+trap or wrong result. The compiler must be able to report `unknown`; inability
+to classify a member is never evidence that it is supported.
+
+## Registry contract
+
+Each module/member entry records:
+
+- canonical `node:` specifier and real Node export name;
+- faithful TypeScript overloads and value/class/namespace shape;
+- semantic placement: portable Wasm provider, declared host capability, linked
+  runtime provider, unsupported, or unknown;
+- providers available for JS-host WasmGC, standalone/WASI WasmGC, JS-host
+  linear, and standalone/WASI linear;
+- stable unsupported/unknown diagnostic code, explanation, and remediation;
+- provenance linking the checker decision, prepared IR feature, emitted import,
+  provider, and focused evidence.
+
+The module list, checker declarations, import manifest, target legality gate,
+and plan issue #4382, “Compiler-derived capability manifest and per-program
+explain workflow,” must consume this record. They must not maintain independent
+support tables.
+
+## Import behavior
+
+Apply the same decision to:
+
+- named, default, and namespace ESM imports;
+- `require("node:...")` and destructured CommonJS imports;
+- `node:` and accepted bare-builtin spellings;
+- single-source, multi-source, `compileFiles`, and `compileProject` entry points.
+
+A dynamic module-object access whose member cannot be proven must remain
+visible as `unknown` or require an explicitly selected dynamic provider. It
+must not silently widen the whole module to a permissive externref surface.
+
+## Acceptance criteria
+
+- [ ] One registry owns every currently recognized Node module and the members
+      js2wasm claims to type or execute; `NODE_BUILTIN_MODULES` is derived from
+      it or removed.
+- [ ] Every registered member has an explicit result for all four supported
+      host/standalone and WasmGC/linear target lanes.
+- [ ] Missing entries and indeterminate dynamic member reads produce a stable,
+      source-located `unknown`/unsupported diagnostic before artifact emission.
+- [ ] No registered import path can lower an unavailable member to `ref.null`,
+      an empty object, `undefined`, or a generic no-op.
+- [ ] Named, default, namespace, and CommonJS fixtures reach the same member
+      decision through every compiler entry point.
+- [ ] The emitted Wasm import uses the standard `node:<module>` interface and
+      real member name; provider selection remains a link/runtime concern.
+- [ ] The capability report in “Compiler-derived capability manifest and
+      per-program explain workflow” (#4382) projects the same record without a
+      second hand-maintained matrix.
+- [ ] Negative tests contain positive controls proving that a supported member
+      still links and executes in each applicable lane.
+
+## Out of scope
+
+- Implementing every Node builtin or export in this issue.
+- Treating recognition, successful type checking, or successful emission as a
+  compatibility result.
+- Adding an implicit embedded JavaScript engine or dynamic compatibility
+  fallback.

--- a/plan/issues/4568-node-path-posix-win32-provider-parity.md
+++ b/plan/issues/4568-node-path-posix-win32-provider-parity.md
@@ -1,0 +1,79 @@
+---
+id: 4568
+title: "Complete portable node:path parity for POSIX and Win32"
+status: backlog
+created: 2026-08-20
+updated: 2026-08-20
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: runtime, linker
+language_feature: node-path
+goal: node-compatibility
+sprint: Backlog
+depends_on: [2512, 4567]
+horizon: m
+es_edition: n/a
+related: [1494, 1791, 1810, 3681]
+origin: "2026-08-20 Node API compatibility and portability review"
+---
+# #4568 — Complete portable `node:path` parity for POSIX and Win32
+
+## Objective
+
+Provide the deterministic `node:path` surface through a portable, linkable
+provider rather than compiler-special inline shims or opaque host objects. The
+same source must behave consistently under JS-host, standalone/WASI, and linear
+targets.
+
+## Current gap
+
+The existing Tier-0 implementation covers a useful POSIX subset:
+`resolve`, `join`, `normalize`, `dirname`, `basename`, `extname`, `isAbsolute`,
+and `relative`, plus POSIX `sep` and `delimiter`. It deliberately deferred:
+
+- `path.posix` and `path.win32` namespace objects;
+- `parse`, `format`, and `toNamespacedPath`;
+- Win32 drive, UNC, device, separator, and case-insensitive root semantics;
+- a provider-explicit `cwd` dependency for relative `resolve` calls.
+
+Unsupported members can consequently escape through the generic module-object
+route instead of receiving an explicit capability result.
+
+## Design
+
+- The compiled program imports only the used real members from `node:path`.
+- A portable provider implements string/path algorithms and can be selected for
+  every target.
+- `path.posix` and `path.win32` remain explicitly selectable on every platform.
+- The default namespace follows the selected target platform policy. That
+  policy is recorded in the capability manifest rather than inferred from an
+  ambient build machine.
+- Relative `resolve` declares a `node:process::cwd` dependency. Standalone mode
+  must receive an explicit cwd provider; it must not hide a hard-coded cwd as
+  Node-compatible behavior.
+
+## Acceptance criteria
+
+- [ ] The provider implements `normalize`, `isAbsolute`, `join`, `resolve`,
+      `relative`, `dirname`, `basename`, `extname`, `parse`, `format`, and
+      `toNamespacedPath` for both POSIX and Win32 semantics.
+- [ ] Default, named, namespace, `path.posix`, and `path.win32` import shapes
+      expose the same typed implementation.
+- [ ] Fixtures cover empty paths, repeated separators, `.`/`..`, trailing
+      separators, extensions, drive-relative paths, drive roots, UNC shares,
+      and device paths.
+- [ ] Differential tests compare every fixture with the pinned Node oracle and
+      report the exact denominator for POSIX and Win32 rows separately.
+- [ ] The portable provider has no hidden host imports; `resolve`'s cwd input is
+      declared and tested as a capability.
+- [ ] Unsupported or unimplemented exports receive registry diagnostics rather
+      than opaque host fallback.
+- [ ] Programs that do not import `node:path` contain no path provider imports
+      or linked path implementation.
+
+## Out of scope
+
+- Filesystem existence, symlink resolution, globbing, or URL conversion.
+- Embedding path semantics directly in call-expression codegen.

--- a/plan/issues/4569-node-crypto-secure-provider-only.md
+++ b/plan/issues/4569-node-crypto-secure-provider-only.md
@@ -1,0 +1,70 @@
+---
+id: 4569
+title: "Require secure runtime providers for node:crypto randomness"
+status: backlog
+created: 2026-08-20
+updated: 2026-08-20
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: runtime, security
+language_feature: node-crypto-randomness
+goal: node-compatibility
+sprint: Backlog
+depends_on: [4567]
+horizon: s
+es_edition: n/a
+related: [1322, 1492, 1503, 4383, 4398]
+origin: "2026-08-20 Node API compatibility and portability review"
+---
+# #4569 — Require secure providers for `node:crypto` randomness
+
+## Objective
+
+Make `randomBytes` and `randomUUID` cryptographically secure in every lane that
+claims to support them, and fail clearly when the selected target has no secure
+randomness provider.
+
+## Problem
+
+The platform adapter currently falls back to `Math.random()` when a Node crypto
+function cannot be resolved. A warning does not make the returned bytes or UUID
+safe, and callers cannot reliably distinguish the degraded result. This is a
+silent security failure: a program that requested `node:crypto` receives an
+API-shaped value without the API's security property.
+
+## Provider policy
+
+Supported providers are:
+
+- the real `node:crypto` implementation under a Node host;
+- Web Crypto secure randomness where the selected JS host exposes it;
+- WASI `random_get` for standalone/WASI targets;
+- an explicitly injected provider satisfying the same typed contract.
+
+Provider selection must be visible in the compiler/runtime capability record.
+No provider may substitute a non-cryptographic pseudorandom source.
+
+## Acceptance criteria
+
+- [ ] Remove every `Math.random()` fallback reachable from
+      `node:crypto.randomBytes` and `node:crypto.randomUUID`.
+- [ ] Known targets select Node crypto, Web Crypto, WASI `random_get`, or an
+      explicitly injected secure provider.
+- [ ] A statically unavailable provider produces a stable compile/link
+      diagnostic; a missing injected runtime provider fails before returning
+      any bytes or UUID.
+- [ ] `randomBytes` validates size, range, and overload shape in Node-observable
+      order and returns a byte-compatible value.
+- [ ] `randomUUID` emits RFC 4122 version/variant bits and accepts only the
+      supported Node options shape.
+- [ ] Tests cover every provider lane, the no-provider failure, invalid inputs,
+      and a positive control proving the fallback cannot be reintroduced.
+- [ ] Programs that do not use crypto contain no randomness capability or
+      provider import.
+
+## Out of scope
+
+- Claiming statistical certification from a small deterministic test sample.
+- Hashing, signing, encryption, key management, or the complete crypto module.

--- a/plan/issues/4570-node-fs-shared-validation-error-contract.md
+++ b/plan/issues/4570-node-fs-shared-validation-error-contract.md
@@ -1,0 +1,79 @@
+---
+id: 4570
+title: "Share Node-compatible filesystem validation and errors across providers"
+status: backlog
+created: 2026-08-20
+updated: 2026-08-20
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: runtime, linker
+language_feature: node-fs-contract
+goal: node-compatibility
+sprint: Backlog
+depends_on: [4567]
+required_by: [4571]
+horizon: m
+es_edition: n/a
+related: [1491, 2631, 2634, 2647, 4565]
+origin: "2026-08-20 Node API compatibility and portability review"
+---
+# #4570 — Share Node-compatible filesystem validation and errors across providers
+
+## Objective
+
+Define one observable `node:fs` contract for argument validation, error shape,
+and asynchronous settlement, then reuse it across real-host and WASI-backed
+providers.
+
+## Problem
+
+Current filesystem work is organized mainly around transport mechanics:
+host-function glue, direct fd imports, path opening, and linear-memory
+marshalling. Those mechanisms do not by themselves preserve Node's observable
+contract. Providers can disagree about which invalid argument fails first,
+whether a coercion runs before I/O, what error object is returned, or when a
+callback/Promise settles.
+
+Duplicating validation in codegen and each provider makes that drift likely.
+Node semantics belong in the `node:fs` compatibility provider, while codegen
+should only declare and call the standard module interface.
+
+## Initial contract surface
+
+- `readSync` and `writeSync`, including buffer/options and string overloads;
+- `readFileSync` and `writeFileSync`;
+- `fs/promises` `readFile`, `writeFile`, `stat`, `mkdir`, and `unlink`;
+- shared path, fd, buffer-view, offset, length, position, encoding, mode, flag,
+  callback, and options validation;
+- stable error fields where observable: error class/name, `code`, `errno`,
+  `syscall`, and normalized path/destination fields.
+
+OS-authored free-form message text may vary. Tests should compare stable fields
+and explicitly selected message fragments rather than normalizing substantive
+differences away.
+
+## Acceptance criteria
+
+- [ ] A provider-independent validation layer owns the initial contract surface
+      and runs before filesystem side effects.
+- [ ] JS-host and WASI providers produce the same first observable error for
+      invalid arguments and coercion side effects.
+- [ ] Differential fixtures cover overload selection, error class/code, stable
+      fields, validation order, coercion effects, callback cardinality, and
+      Promise settlement ordering.
+- [ ] The test artifact reports per-member and per-target denominators; an
+      unavailable target is an explicit unsupported row, not a skip or pass.
+- [ ] The real Node module and linked providers use the same typed import
+      boundary, with provider selection outside call-expression codegen.
+- [ ] No unsupported member falls through to a generic module object or returns
+      an API-shaped placeholder.
+- [ ] Existing fd-based `readSync`/`writeSync` behavior remains filesystem-free
+      and does not gain a preopen requirement.
+
+## Out of scope
+
+- Implementing the complete Node filesystem surface.
+- Requiring byte-for-byte equality for OS-dependent error prose or paths.
+- Baking provider or syscall selection into the source-language checker.

--- a/plan/issues/4571-wasi-preopen-node-fs-provider.md
+++ b/plan/issues/4571-wasi-preopen-node-fs-provider.md
@@ -1,0 +1,81 @@
+---
+id: 4571
+title: "Provide path-based node:fs and node:fs/promises through WASI preopens"
+status: backlog
+created: 2026-08-20
+updated: 2026-08-20
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: runtime, linker, wasi
+language_feature: node-fs-wasi-provider
+goal: standalone-mode
+sprint: Backlog
+depends_on: [2512, 4570]
+horizon: l
+es_edition: n/a
+related: [1035, 1772, 2632, 3640, 4565]
+origin: "2026-08-20 Node API compatibility and portability review"
+---
+# #4571 — Provide path-based `node:fs` through WASI preopens
+
+## Objective
+
+Ship a linkable WASI provider for the initial path-based `node:fs` and
+`node:fs/promises` surface, using explicit preopened-directory capabilities and
+the shared observable contract from “Share Node-compatible filesystem
+validation and errors across providers” (#4570).
+
+## Architecture
+
+The user module declares the real imports it needs, such as
+`node:fs::readFileSync` or `node:fs/promises::stat`. Link-time provider
+selection may satisfy those imports with the real Node modules, a JS adapter,
+or the WASI provider. The compiled module must not expose an
+implementation-specific shim namespace or inline WASI filesystem policy in
+call-expression codegen. The observable contract is owned by “Share
+Node-compatible filesystem validation and errors across providers” (#4570).
+
+The provider owns:
+
+- discovery and normalization of configured preopened directories;
+- capability-safe relative path resolution;
+- `path_open`, fd read/write/close, stat, directory creation, and unlink
+  mappings needed by the initial surface;
+- byte/string encoding and result marshalling;
+- conversion of WASI errors into the shared stable Node error fields;
+- asynchronous scheduling for `node:fs/promises` through the existing runtime
+  provider, without presenting synchronous completion as Node-equivalent.
+
+## Initial surface
+
+- sync: `readFileSync`, `writeFileSync`, `statSync`, `mkdirSync`, `unlinkSync`;
+- Promise: `readFile`, `writeFile`, `stat`, `mkdir`, `unlink`;
+- `string`, `Uint8Array`/Buffer-compatible data, and the explicitly supported
+  encoding/options forms selected by “Share Node-compatible filesystem
+  validation and errors across providers” (#4570).
+
+## Acceptance criteria
+
+- [ ] The provider discovers configured preopens; it does not assume that the
+      first directory is fd 3 or silently substitute the process cwd.
+- [ ] Paths outside the granted preopen capability fail with a stable,
+      Node-shaped error and cannot escape through `..`, separator, or symlink
+      handling.
+- [ ] The initial sync and Promise members pass their applicable differential
+      fixtures against Node for values, stable errors, and ordering.
+- [ ] Missing preopens and unsupported operations produce explicit capability
+      results before any API-shaped placeholder can be returned.
+- [ ] `node:fs/promises` uses the shared async runtime and settles exactly once;
+      focused tests distinguish immediate, microtask, and event-loop ordering.
+- [ ] Link tests prove that only used members and their transitive WASI imports
+      appear, and that a program with no filesystem use links none of them.
+- [ ] The provider works in both WasmGC and linear standalone lanes, or each
+      unsupported lane reports a stable reason with a maintained denominator.
+
+## Out of scope
+
+- Ambient unrestricted filesystem access.
+- `watch`, streams, file locking, ownership, or the complete metadata surface.
+- Treating fd-based stdio operations as requiring filesystem preopens.

--- a/plan/issues/4572-portable-node-utility-provider-tranche.md
+++ b/plan/issues/4572-portable-node-utility-provider-tranche.md
@@ -1,0 +1,80 @@
+---
+id: 4572
+title: "Implement a portable Node utility provider tranche"
+status: backlog
+created: 2026-08-20
+updated: 2026-08-20
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: feature
+area: runtime, linker, testing
+language_feature: node-utility-modules
+goal: npm-library-support
+sprint: Backlog
+depends_on: [4567]
+horizon: l
+es_edition: n/a
+related: [1575, 1792, 1793, 3681]
+origin: "2026-08-20 Node API compatibility and portability review"
+---
+# #4572 — Implement a portable Node utility provider tranche
+
+## Objective
+
+Provide the highest-demand deterministic Node utility APIs as portable,
+link-on-use modules rather than opaque host objects. Start with
+`node:assert`, `node:assert/strict`, `node:querystring`,
+`node:string_decoder`, and a measured pure-computation subset of `node:util`.
+
+## Scope selection
+
+Before implementation, measure a pinned npm/package corpus and record:
+
+- corpus revision and total package/file denominators;
+- imports and observed member call sites per module;
+- static versus dynamic member access;
+- required language/runtime dependencies;
+- whether each member is portable computation, scheduler-dependent, host
+  capability-dependent, unsupported, or unknown.
+
+The measured table selects the `node:util` members. It does not turn an
+unobserved export into either “supported” or “unneeded.” Initial candidates
+include `format`, `formatWithOptions`, `inspect`, `types` predicates, and
+`promisify`; scheduler-dependent members must remain gated on the async runtime.
+
+## Provider shape
+
+- Each standard Node module remains a separate import/provider boundary.
+- Only used members are linked.
+- Shared byte/text codecs may be reused by Buffer, URL, and
+  `node:string_decoder`, but the public API retains Node names and behavior.
+- Export coverage is explicit in “Make `node:*` builtin support member-explicit,
+  provider-explicit, and fail-closed” (#4567); module-object imports do not imply
+  that every export works.
+
+## Acceptance criteria
+
+- [ ] Commit a reproducible usage artifact with corpus revision, per-module
+      denominators, member counts, dynamic-access rows, and unknowns.
+- [ ] Implement the selected `node:assert`/`node:assert/strict` assertions,
+      querystring parse/stringify/escape operations, and incremental
+      `StringDecoder.write`/`end` behavior.
+- [ ] Select and implement the bounded `node:util` subset from measured demand;
+      non-selected members receive explicit unsupported/unknown results.
+- [ ] Differential fixtures cover values, coercion and error ordering, malformed
+      encodings, split multibyte sequences, circular formatting inputs, and
+      async callback behavior where selected.
+- [ ] Results report per-member and per-target denominators and include positive
+      controls for the JS-host, standalone/WASI, and linear lanes that claim
+      support.
+- [ ] Link tests prove that importing one module/member does not pull unrelated
+      utility providers into the artifact.
+- [ ] If the measured implementation exceeds one sprint, this issue records a
+      dependency-ordered set of per-module child issues before code lands.
+
+## Out of scope
+
+- Claiming support for every export of `node:util`.
+- Streams, readline, networking, diagnostics channels, or worker APIs.
+- Host-object passthrough as a portable implementation.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -2,6 +2,45 @@
 
 Lightweight pointer index for unscheduled issues that need sprint candidacy. Authoritative status lives in each issue file's frontmatter.
 
+## 2026-08-20 — Node API compatibility and provider hardening
+
+- [#4567](../4567-node-builtins-provider-explicit-fail-closed.md) — replace the
+  gap between recognized `node:*` modules and runnable members with one
+  provider-explicit registry; unavailable and unknown members fail before
+  emission instead of becoming null, empty, or undefined placeholders.
+- [#4568](../4568-node-path-posix-win32-provider-parity.md) — complete POSIX and
+  Win32 path semantics through a portable `node:path` provider, including
+  namespace objects, parse/format, target policy, and an explicit cwd
+  dependency.
+- [#4569](../4569-node-crypto-secure-provider-only.md) — remove insecure
+  randomness degradation and require Node crypto, Web Crypto, WASI
+  `random_get`, or another explicitly injected secure provider.
+- [#4570](../4570-node-fs-shared-validation-error-contract.md) — centralize the
+  observable filesystem contract so JS-host and WASI providers agree on
+  validation, first-error ordering, stable error fields, and async settlement.
+- [#4571](../4571-wasi-preopen-node-fs-provider.md) — implement the bounded
+  path-based `node:fs`/`node:fs/promises` surface as a linkable WASI-preopen
+  provider without ambient access or implementation-specific import names.
+- [#4572](../4572-portable-node-utility-provider-tranche.md) — measure and
+  implement a portable utility tranche covering assert, querystring,
+  incremental string decoding, and a bounded pure `node:util` subset.
+- [#2512](../2512-node-host-apis-as-separate-linkable-wasm-modules.md) — make
+  standard `node:<module>`/real-member imports the stable interface and link
+  only the provider families proven used by prepared IR.
+- [#4419](../4419-compilefiles-drops-node-builtin-bindings.md) — restore the
+  missing `compileFiles` binding path first and test every import shape/compiler
+  entry point against both supported and unavailable members.
+
+“Compiler-derived capability manifest and per-program explain workflow” (#4382)
+and “Differential whole-program target matrix” (#3681) gain
+Node-member/provider projections and contract fixtures; they remain indexed in
+the architecture section below. Recommended order: the `compileFiles` binding
+repair (#4419), provider-explicit registry (#4567), secure crypto provider
+(#4569), shared filesystem contract (#4570), link-on-demand module interface
+(#2512), then path/WASI-filesystem/utility providers (#4568/#4571/#4572).
+Networking and stream expansion stays deferred until the shared async scheduler
+has an explicit, measured callback-order contract.
+
 ## 2026-08-12 — Compiler capability, diagnostics, and portability hardening
 
 - [#3518](../3518-ir-only-default-and-direct-frontend-retirement.md) and


### PR DESCRIPTION
## Summary

- add six execution-ready plan issues for provider-explicit Node builtins, portable path parity, secure crypto randomness, shared filesystem contracts, WASI preopen filesystem support, and portable utility modules
- update the existing link-on-demand provider, capability explain, differential corpus, and compileFiles correctness issues with member-level, fail-closed acceptance criteria
- add the dependency order and scheduling guidance to the hand-maintained backlog

All issue motivation and acceptance criteria are expressed in project-internal terms: Node compatibility, target portability, package demand, security, and observable correctness.

## Validation

- `pnpm run check:issues`
- `pnpm exec prettier --check` on all 11 changed Markdown files
- `node scripts/check-issue-ids.mjs` — no duplicate IDs across 3,922 workspace issues
- pre-push TypeScript 7 typecheck and Biome lint
- `git diff --check`
- prohibited-reference scan across the complete staged diff