### PR TITLE
feat(website): open npm tests in the playground

### DIFF
--- a/plan/issues/4575-open-npm-tests-in-playground.md
+++ b/plan/issues/4575-open-npm-tests-in-playground.md
@@ -1,0 +1,102 @@
+---
+id: 4575
+title: "Open npm compatibility tests directly in the playground"
+status: done
+created: 2026-08-20
+updated: 2026-08-20
+completed: 2026-08-20
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: feature
+area: website, playground, npm-compat
+language_feature: n/a
+goal: npm-library-support
+sprint: current
+assignee: ttraenkler/codex
+horizon: s
+related: [3757]
+origin: "Preserve the sole unique product slice from stale, conflicted PR #4651 without carrying its superseded capability and chart commits."
+files:
+  - scripts/generate-npm-compat-report.mjs
+  - scripts/lib/npm-compat-playground.mjs
+  - tests/dogfood/acorn-official-suite.mjs
+  - tests/dogfood/upstream-suite-runner.mjs
+  - website/components/npm-compat-chart.js
+  - website/playground/index.html
+  - website/playground/layout.ts
+  - website/playground/main.ts
+  - tests/issue-4575-npm-playground-summary.test.ts
+  - plan/issues/4575-open-npm-tests-in-playground.md
+---
+
+# #4575 — open npm compatibility tests directly in the playground
+
+## Problem
+
+PR #4651 combines 133 files from three historical work streams and is more
+than a thousand commits behind `main`. Its host-capability and report-chart
+changes have already landed in evolved form, but its npm-test playground
+integration remains unique. Rebasing the whole PR would create dozens of
+unnecessary conflicts across active IR/runtime files.
+
+## Scope
+
+- Replay only the seven-file npm-test playground change on current `main`.
+- Preserve current npm correctness, unavailable-infrastructure, and
+  performance fields while adding the per-package `playground` data.
+- Emit source paths, per-file status, test counts, diagnostics, and pinned raw
+  source URLs from the existing committed dogfood suites.
+- Add an npm compatibility tree and `?npm=<package>` deep link to the
+  playground without changing compiler/runtime production code.
+- Keep the editor language aligned with the selected file extension and make
+  the source tab closable without removing the permanent editor pane.
+- After the replacement is published, close PR #4651 as superseded by the
+  already-landed capability/chart work plus this focused replacement.
+
+## Acceptance criteria
+
+- The npm report generator retains both existing performance metadata and the
+  new playground metadata for marked, eslint, react, react-dom, and catalog
+  packages.
+- Existing correctness annotations, including unavailable infrastructure,
+  remain present rather than being replaced by the older checkpoint shape.
+- The website exposes one package link and renders package/file status from
+  the generated schema; deep links expand the selected package.
+- Typecheck, formatting, lint, generator/component syntax checks, and focused
+  playground tests pass on current `main`.
+- The replacement PR is ready, not draft, and has no production-file overlap
+  with the active IR migration branch.
+
+## Handoff
+
+The source commit is `f2e4c16baa21564ea884d1cb1e68f45f41c2d250` from
+PR #4651. The only replay conflict is
+`scripts/generate-npm-compat-report.mjs`; resolution must keep both current
+performance/unavailable-infrastructure fields and the new playground fields.
+
+## Checkpoint result
+
+The seven-file product slice now sits on current `main` without any of
+PR #4651's superseded compiler/runtime changes. The generator retains current
+correctness, unavailable-infrastructure, performance-row, and history fields
+while adding the new per-package playground data. The conflict resolution also
+found and fixed one stale summary bug: compile-blocked differential files now
+increment `compile_error`, not `skip`, through one shared tested reducer.
+
+The authoritative Marked no-write smoke reports **8/8 compile-error files,
+compile_error=8, skip=0, total=8**. A Cookie positive control keeps **63,658 /
+63,740** upstream results, **21/21** playground files passing, three performance
+rows, and the performance history object in the same generated record.
+
+## Validation
+
+- Focused/regression Vitest: **34/34** tests in **5/5** files.
+- JavaScript syntax: **5/5** files.
+- Prettier: **10/10** files.
+- TypeScript 7 typecheck: pass.
+- Biome lint: **4,202** files, exit 0.
+- Production playground build: **2,105** modules, exit 0; only existing Vite
+  size/dynamic-import/non-module-script warnings remain.
+- Issue integrity, optimization ledger, issue ID against `main`, and
+  `git diff --check`: pass.

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -92,6 +92,7 @@ import {
   packagePerfRecord,
   skippedPerfLane,
 } from "./lib/npm-compat-perf.mjs";
+import { summarizePlaygroundFiles } from "./lib/npm-compat-playground.mjs";
 import { renderHarnessThrownText } from "./lib/wasm-exn-render.mjs";
 
 const ROOT = resolve(import.meta.dirname, "..");
@@ -2013,19 +2014,7 @@ function buildNpmSuitePlayground(report, options = {}) {
   );
   const hasPerTestResults = files.some((file) => file.tests?.length || file.total != null);
   const summary = hasPerTestResults
-    ? files.reduce(
-        (counts, file) => {
-          const total = file.total ?? 1;
-          const passed = file.passed ?? (file.status === "pass" ? total : 0);
-          counts.total += total;
-          counts.pass += passed;
-          if (file.status === "fail") counts.fail += Math.max(total - passed, 1);
-          else if (file.status === "compile_error") counts.compile_error += total;
-          else if (file.status === "skip") counts.skip += total;
-          return counts;
-        },
-        { pass: 0, fail: 0, compile_error: 0, skip: 0, total: 0 },
-      )
+    ? summarizePlaygroundFiles(files)
     : {
         pass: Number(report?.results?.passed ?? 0),
         fail: Math.max(
@@ -2082,14 +2071,7 @@ function buildDifferentialPlayground(report, options = {}) {
       ...(sourcePath ? { sourceUrl: `https://raw.githubusercontent.com/loopdive/js2/main/${sourcePath}` } : {}),
     };
   });
-  const summary = files.reduce(
-    (counts, file) => {
-      counts.total++;
-      counts[file.status === "pass" ? "pass" : file.status === "fail" ? "fail" : "skip"]++;
-      return counts;
-    },
-    { pass: 0, fail: 0, compile_error: 0, skip: 0, total: 0 },
-  );
+  const summary = summarizePlaygroundFiles(files);
   return {
     kind: "differential",
     label: options.label ?? "differential tests",

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -23,7 +23,7 @@
 // and copies it to website/public/benchmarks/results/).
 
 import { execFileSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { performance } from "node:perf_hooks";
@@ -81,6 +81,7 @@ import { setupReact } from "../tests/dogfood/setup-react.mjs";
 import { CLSX_OPS } from "../tests/dogfood/clsx-ops.mjs";
 import { setupNpmCompatCatalogPackage } from "../tests/dogfood/npm-compat-catalog.mjs";
 import { buildNpmCompatPerfDriver, getNpmCompatPerfSpec } from "../tests/dogfood/npm-compat-perf-specs.mjs";
+import { COOKIE_OPS } from "../tests/dogfood/cookie-ops.mjs";
 import {
   failedPerfLane,
   measureJsHostPerf,
@@ -1882,7 +1883,234 @@ function annotateUnavailableInfra(tests) {
   return unavailableInfra === null ? tests : { ...tests, unavailableInfra };
 }
 
-async function buildPackageEntry({ name, version, issue, entryFile, shape, report, tests, perf, entryIsBarrel }) {
+function githubRawSource(source, filePath) {
+  if (!source?.repo || !source?.ref || !filePath) return null;
+  const match = source.repo.match(/github\.com\/([^/]+)\/([^/#]+?)(?:\.git)?$/);
+  if (!match) return null;
+  const normalizedFilePath = filePath.replace(/\\/g, "/");
+  const path = [source.root && !normalizedFilePath.startsWith(`${source.root}/`) ? source.root : "", normalizedFilePath]
+    .filter(Boolean)
+    .join("/")
+    .split("/")
+    .filter(Boolean)
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+  return `https://raw.githubusercontent.com/${match[1]}/${match[2]}/${encodeURIComponent(source.ref)}/${path}`;
+}
+
+function suiteSourceFromReport(report, options = {}) {
+  const suite = report?.upstreamSuite ?? report?.testSuite ?? null;
+  if (!suite?.repo || !suite?.tag) return null;
+  return {
+    repo: suite.repo,
+    ref: suite.commit ?? suite.tag,
+    root: options.sourceRoot ?? suite.testDirectory ?? "",
+  };
+}
+
+function suiteFilePaths(report, options = {}) {
+  const suite = report?.upstreamSuite ?? report?.testSuite ?? null;
+  const candidates = [
+    suite?.testFilePaths,
+    suite?.testFiles,
+    suite?.selectedFiles,
+    report?.compile?.details?.map((entry) => entry.file),
+    report?.compile?.files?.map((entry) => entry.file),
+    [...new Set((report?.results?.tests ?? []).map((entry) => entry.file))],
+  ];
+  const paths = candidates.find((value) => Array.isArray(value) && value.length > 0) ?? [];
+  const root = options.sourceRoot ?? suite?.testDirectory ?? "";
+  return [...new Set(paths.filter((value) => typeof value === "string").map((value) => value.replace(/\\/g, "/")))]
+    .map((value) => (root && !value.startsWith(`${root}/`) ? `${root}/${value}` : value))
+    .sort();
+}
+
+function fileMatches(resultFile, sourceFile) {
+  const resultPath = String(resultFile ?? "").replace(/\\/g, "/");
+  const sourcePath = String(sourceFile ?? "").replace(/\\/g, "/");
+  return resultPath === sourcePath || resultPath.endsWith(`/${sourcePath}`) || sourcePath.endsWith(`/${resultPath}`);
+}
+
+function firstResultError(results, compile) {
+  for (const result of results.filter((entry) => entry.status !== "harness-incompatible")) {
+    const error =
+      result.wasmError ??
+      result.compiledError ??
+      result.compiledMessage ??
+      result.runtimeError ??
+      result.nativeError ??
+      result.nativeMessage ??
+      result.skippedReason ??
+      result.error;
+    if (error) return String(error);
+  }
+  const compileError =
+    compile?.errors?.[0]?.message ??
+    compile?.validationError ??
+    compile?.runtimeError ??
+    compile?.nativeError ??
+    compile?.error ??
+    compile?.threw;
+  return compileError ? String(compileError) : null;
+}
+
+function buildSuiteFile(report, sourceFile, source, { singleFile = false } = {}) {
+  const tests = (report?.results?.tests ?? []).filter((entry) => fileMatches(entry.file, sourceFile));
+  const compile = [...(report?.compile?.details ?? []), ...(report?.compile?.files ?? [])].find((entry) =>
+    fileMatches(entry.file, sourceFile),
+  );
+  const scored = tests.filter((entry) => entry.status !== "harness-incompatible").length;
+  const passed = tests.filter((entry) => entry.status === "passed" || entry.status === "pass").length;
+  const failed = tests.filter((entry) =>
+    [
+      "failed",
+      "fail",
+      "runtime-failed",
+      "runtime-shape-failed",
+      "trapped",
+      "compiled-threw",
+      "compiled-parse-threw",
+      "compile-failed",
+      "divergent",
+    ].includes(entry.status),
+  ).length;
+  const compileFailed = tests.some((entry) => entry.status === "compile-failed");
+  const aggregatePassed = Number(report?.results?.passed ?? 0);
+  const aggregateTotal = Number(report?.results?.scored ?? report?.results?.total ?? 0);
+  const aggregateFailed = Math.max(0, aggregateTotal - aggregatePassed);
+  const hasAggregate = singleFile && tests.length === 0 && (aggregateTotal > 0 || aggregateFailed > 0);
+  const filePassed = hasAggregate ? aggregatePassed : passed;
+  const fileTotal = hasAggregate ? aggregateTotal : scored;
+  const fileFailed = hasAggregate ? aggregateFailed : failed;
+  const status =
+    compile?.success === false || compileFailed
+      ? "compile_error"
+      : fileFailed > 0
+        ? "fail"
+        : filePassed > 0
+          ? "pass"
+          : "skip";
+  const error = firstResultError(tests, compile) ?? (hasAggregate ? report?.results?.runtimeError : null);
+  const sourceUrl = githubRawSource(source, sourceFile);
+  return {
+    path: sourceFile,
+    status,
+    ...(tests.length > 0 || hasAggregate || compile?.success === false
+      ? { passed: filePassed, total: fileTotal || (compile?.success === false ? 1 : 0) }
+      : {}),
+    ...(error ? { error } : {}),
+    ...(tests.length > 0 ? { tests: tests.map((entry) => ({ name: entry.name, status: entry.status })) } : {}),
+    ...(sourceUrl ? { sourceUrl } : {}),
+  };
+}
+
+function buildNpmSuitePlayground(report, options = {}) {
+  const source = suiteSourceFromReport(report, options);
+  const sourceFiles = suiteFilePaths(report, options);
+  if (!source || sourceFiles.length === 0) return null;
+  const files = sourceFiles.map((sourceFile) =>
+    buildSuiteFile(report, sourceFile, source, { singleFile: sourceFiles.length === 1 }),
+  );
+  const hasPerTestResults = files.some((file) => file.tests?.length || file.total != null);
+  const summary = hasPerTestResults
+    ? files.reduce(
+        (counts, file) => {
+          const total = file.total ?? 1;
+          const passed = file.passed ?? (file.status === "pass" ? total : 0);
+          counts.total += total;
+          counts.pass += passed;
+          if (file.status === "fail") counts.fail += Math.max(total - passed, 1);
+          else if (file.status === "compile_error") counts.compile_error += total;
+          else if (file.status === "skip") counts.skip += total;
+          return counts;
+        },
+        { pass: 0, fail: 0, compile_error: 0, skip: 0, total: 0 },
+      )
+    : {
+        pass: Number(report?.results?.passed ?? 0),
+        fail: Math.max(
+          0,
+          Number(report?.results?.scored ?? report?.results?.total ?? 0) - Number(report?.results?.passed ?? 0),
+        ),
+        compile_error: report?.compile?.success === false ? files.length : 0,
+        skip: 0,
+        total: Number(report?.results?.scored ?? report?.results?.total ?? 0),
+      };
+  return {
+    kind: options.kind ?? "upstream-suite",
+    label: options.label ?? "original upstream unit tests",
+    source: { repo: source.repo, ref: source.ref },
+    files,
+    summary,
+    ...(options.note ? { note: options.note } : {}),
+  };
+}
+
+function buildDifferentialPlayground(report, options = {}) {
+  const recordedEntries = Array.isArray(report?.diff?.fixtures)
+    ? report.diff.fixtures
+    : Array.isArray(report?.diff?.ops)
+      ? report.diff.ops
+      : [];
+  const entries = recordedEntries.length > 0 ? recordedEntries : (options.fallbackEntries ?? []);
+  const compileBlocked = report?.compile?.success === false || report?.validation?.validates === false;
+  const files = entries.map((entry) => {
+    const rawStatus = entry.status ?? "skipped";
+    const status = ["equal", "pass", "passed"].includes(rawStatus)
+      ? "pass"
+      : ["skipped", "skip"].includes(rawStatus)
+        ? compileBlocked
+          ? "compile_error"
+          : "skip"
+        : "fail";
+    const error =
+      entry.compiledError ??
+      entry.wasmError ??
+      entry.skippedReason ??
+      entry.nativeError ??
+      (status === "skip" ? report?.diff?.skippedReason : null) ??
+      null;
+    const path = entry.fixture ?? entry.op ?? entry.name ?? options.sourcePath ?? "test.js";
+    const sourcePath =
+      entry.fixture && options.sourcePath ? `${options.sourcePath}/${entry.fixture}` : options.sourcePath;
+    return {
+      path,
+      status,
+      passed: status === "pass" ? 1 : 0,
+      total: 1,
+      ...(error ? { error: String(error) } : {}),
+      ...(sourcePath ? { sourceUrl: `https://raw.githubusercontent.com/loopdive/js2/main/${sourcePath}` } : {}),
+    };
+  });
+  const summary = files.reduce(
+    (counts, file) => {
+      counts.total++;
+      counts[file.status === "pass" ? "pass" : file.status === "fail" ? "fail" : "skip"]++;
+      return counts;
+    },
+    { pass: 0, fail: 0, compile_error: 0, skip: 0, total: 0 },
+  );
+  return {
+    kind: "differential",
+    label: options.label ?? "differential tests",
+    files,
+    summary,
+    ...(options.note ? { note: options.note } : {}),
+  };
+}
+
+async function buildPackageEntry({
+  name,
+  version,
+  issue,
+  entryFile,
+  shape,
+  report,
+  tests,
+  perf,
+  entryIsBarrel,
+  playground,
+}) {
   return {
     name,
     version,
@@ -1898,6 +2126,13 @@ async function buildPackageEntry({ name, version, issue, entryFile, shape, repor
     // as evidence the package compiles (#3977).
     ...(entryIsBarrel ? { entryIsBarrel: true } : {}),
     tests: annotateUnavailableInfra(tests),
+    playground: playground ?? {
+      kind: "unavailable",
+      label: "package tests",
+      files: [],
+      summary: { pass: 0, fail: 0, compile_error: 0, skip: 0, total: 0 },
+      note: tests?.reason ?? "No committed unit-test adapter is available for this package.",
+    },
     // (#4127) The correctness axis, kept separate from compile/validation so a
     // package that compiles to a valid module but computes the WRONG ANSWER
     // cannot read as green. `unverified` means nothing is known — it is never
@@ -2012,6 +2247,10 @@ if (!perfOnly && selectedPackages.has("acorn")) {
           passRatePct: acornSuite.summary?.passRatePct ?? null,
           sourceIssue: 3729,
         },
+        playground: buildNpmSuitePlayground(acornSuite, {
+          sourceRoot: "test",
+          label: "Acorn official unit tests",
+        }),
         perf: acornPerf,
       }),
     );
@@ -2057,6 +2296,14 @@ if (!perfOnly && selectedPackages.has("marked")) {
           commit: markedSuite.upstreamSuite?.commit ?? null,
         },
       },
+      playground: buildDifferentialPlayground(markedReport, {
+        sourcePath: "tests/dogfood/fixtures/marked-inputs",
+        label: "marked fixture tests",
+        fallbackEntries: readdirSync(join(ROOT, "tests/dogfood/fixtures/marked-inputs"))
+          .filter((file) => file.endsWith(".md"))
+          .sort()
+          .map((fixture) => ({ fixture })),
+      }),
       perf: await perfNpmCompatPackage("marked", {
         setupFactory: setupMarked,
         report: markedReport,
@@ -2115,6 +2362,11 @@ if (!perfOnly && selectedPackages.has("clsx")) {
             total: clsxReport.summary.opDiff?.total ?? null,
           },
         },
+        playground: buildDifferentialPlayground(clsxReport, {
+          sourcePath: "tests/dogfood/clsx-ops.mjs",
+          label: "clsx differential operations",
+          fallbackEntries: CLSX_OPS.map((op) => ({ op: op.name })),
+        }),
         perf: clsxPerf,
       }),
     );
@@ -2171,6 +2423,11 @@ if (!perfOnly && selectedPackages.has("cookie")) {
             total: cookieReport.summary.opDiff?.total ?? null,
           },
         },
+        playground: buildDifferentialPlayground(cookieReport, {
+          sourcePath: "tests/dogfood/cookie-ops.mjs",
+          label: "cookie differential operations",
+          fallbackEntries: COOKIE_OPS.map((op) => ({ op: op.name })),
+        }),
         perf: cookiePerf,
       }),
     );
@@ -2218,6 +2475,9 @@ if (!perfOnly && selectedPackages.has("eslint")) {
       shape: "cjs-project",
       report: eslintReport,
       tests: eslintTests,
+      playground: buildNpmSuitePlayground(eslintSuite, {
+        label: "ESLint upstream unit tests",
+      }),
       perf: await perfNpmCompatPackage("eslint", {
         setupFactory: setupEslint,
         report: eslintReport,
@@ -2296,6 +2556,9 @@ if (!perfOnly && selectedPackages.has("react")) {
         quarantined: reactSuite.compile?.quarantined?.length ?? null,
         sourceIssue: 3958,
       },
+      playground: buildNpmSuitePlayground(reactSuite, {
+        label: "React upstream unit tests",
+      }),
       perf: await perfNpmCompatPackage("react", {
         setupFactory: setupReact,
         report: reactReport,
@@ -2352,6 +2615,9 @@ if (!perfOnly && selectedPackages.has("lit")) {
           implementationInvalidTests: litSuite.summary?.implementationInvalidTests ?? null,
           sourceIssue: 3977,
         },
+        playground: buildNpmSuitePlayground(litSuite, {
+          label: "Lit upstream unit tests",
+        }),
         perf: await perfLit(),
       }),
     );
@@ -2415,6 +2681,9 @@ if (!perfOnly && selectedPackages.has("react-dom")) {
         implementationError: reactDomSuite.summary?.implementationError ?? null,
         sourceIssue: 3982,
       },
+      playground: buildNpmSuitePlayground(reactDomSuite, {
+        label: "React DOM upstream unit tests",
+      }),
       perf: await perfNpmCompatPackage("react-dom", {
         setupFactory: () => setupNpmCompatCatalogPackage("react-dom"),
         report: reactDomImplementationReport,
@@ -2516,6 +2785,9 @@ for (const entry of NPM_COMPAT_CATALOG) {
       shape: entry.shape,
       report,
       tests,
+      playground: buildNpmSuitePlayground(catalogUpstreamReport, {
+        label: `${entry.name} upstream unit tests`,
+      }),
       perf: await perfNpmCompatPackage(entry.name, {
         setupFactory: () => setupNpmCompatCatalogPackage(entry.name),
         report,
@@ -2527,6 +2799,13 @@ for (const entry of NPM_COMPAT_CATALOG) {
 
 for (const pkg of packages) {
   pkg.weeklyDownloads = NPM_DOWNLOADS_SNAPSHOT.packages[pkg.name] ?? null;
+  pkg.playground ??= {
+    kind: "unavailable",
+    label: "package tests",
+    files: [],
+    summary: { pass: 0, fail: 0, compile_error: 0, skip: 0, total: 0 },
+    note: pkg.tests?.reason ?? "No committed unit-test adapter is available for this package.",
+  };
 }
 packages.sort(
   (left, right) =>

--- a/scripts/lib/npm-compat-playground.mjs
+++ b/scripts/lib/npm-compat-playground.mjs
@@ -1,0 +1,17 @@
+export function summarizePlaygroundFiles(files) {
+  return files.reduce(
+    (counts, file) => {
+      const total = file.total ?? 1;
+      const passed = file.passed ?? (file.status === "pass" ? total : 0);
+      counts.total += total;
+      counts.pass += passed;
+
+      if (file.status === "fail") counts.fail += Math.max(total - passed, 1);
+      else if (file.status === "compile_error") counts.compile_error += total;
+      else if (file.status === "skip") counts.skip += total;
+
+      return counts;
+    },
+    { pass: 0, fail: 0, compile_error: 0, skip: 0, total: 0 },
+  );
+}

--- a/tests/dogfood/acorn-official-suite.mjs
+++ b/tests/dogfood/acorn-official-suite.mjs
@@ -105,7 +105,13 @@ export async function runHarness({ quiet = false } = {}) {
   const { entryModulePath, version, pin } = setupAcorn();
   report.acorn = { version, source: pin.tarball, entryModule: pin.entryModule };
   const { testDir, pin: suitePin } = setupAcornTestSuite();
-  report.testSuite = { repo: suitePin.repo, tag: suitePin.tag, commit: suitePin.commit };
+  report.testSuite = {
+    repo: suitePin.repo,
+    tag: suitePin.tag,
+    commit: suitePin.commit,
+    testDirectory: "test",
+    testFiles: TEST_FILES,
+  };
   log(`[dogfood] acorn@${version} official suite @ ${suitePin.tag} (${suitePin.commit.slice(0, 12)})`);
 
   const acornSource = readFileSync(entryModulePath, "utf-8");

--- a/tests/dogfood/upstream-suite-runner.mjs
+++ b/tests/dogfood/upstream-suite-runner.mjs
@@ -419,6 +419,7 @@ export function summarizeUpstreamRuns({ name, pin, testFiles, selectedFiles, run
       tag: pin.tag,
       commit: pin.commit,
       testFiles: testFiles.length,
+      testFilePaths: testFiles,
       registrationSites: pin.registrationSites,
       selectedFiles,
     },

--- a/tests/issue-4575-npm-playground-summary.test.ts
+++ b/tests/issue-4575-npm-playground-summary.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizePlaygroundFiles } from "../scripts/lib/npm-compat-playground.mjs";
+
+describe("#4575 npm playground summary", () => {
+  it("keeps compile-blocked files out of the skip bucket", () => {
+    const files = Array.from({ length: 8 }, (_, index) => ({
+      path: `fixture-${index}.js`,
+      status: "compile_error",
+      passed: 0,
+      total: 1,
+    }));
+
+    expect(summarizePlaygroundFiles(files)).toEqual({
+      pass: 0,
+      fail: 0,
+      compile_error: 8,
+      skip: 0,
+      total: 8,
+    });
+  });
+
+  it("preserves partial pass counts while separating every status", () => {
+    expect(
+      summarizePlaygroundFiles([
+        { path: "pass.js", status: "pass", passed: 2, total: 2 },
+        { path: "mixed.js", status: "fail", passed: 1, total: 3 },
+        { path: "blocked.js", status: "compile_error", passed: 0, total: 4 },
+        { path: "skipped.js", status: "skip", passed: 0, total: 5 },
+      ]),
+    ).toEqual({
+      pass: 3,
+      fail: 2,
+      compile_error: 4,
+      skip: 5,
+      total: 14,
+    });
+  });
+});

--- a/website/components/npm-compat-chart.js
+++ b/website/components/npm-compat-chart.js
@@ -357,6 +357,7 @@ class NpmCompatChart extends HTMLElement {
     const validates = pkg.validation?.validates;
     const npmPackageUrl = this._npmUrl(pkg);
     const npmCodeUrl = this._npmUrl(pkg, true);
+    const playgroundUrl = `./playground/?npm=${encodeURIComponent(String(pkg.name ?? ""))}`;
     const issueLink = pkg.issue
       ? `<a class="issue" href="${this._issueUrl(pkg.issue)}" target="_blank" rel="noopener">#${pkg.issue}</a>`
       : "";
@@ -513,8 +514,12 @@ class NpmCompatChart extends HTMLElement {
             : ""
         }</div>
         <div class="rows">${correctness}${tests}${perf}${bugs}</div>
-        <a class="entry mono" href="${npmCodeUrl}" target="_blank" rel="noopener"
-          title="View ${this._esc(pkg.entryFile)} in ${this._esc(pkg.name)} ${this._esc(pkg.version)} on npm">${this._esc(pkg.entryFile)}</a>
+        <div class="card-links">
+          <a class="playground-link" href="${playgroundUrl}"
+            title="Open ${this._esc(pkg.name)} test files in the playground">Open tests in playground&nbsp;↗</a>
+          <a class="entry mono" href="${npmCodeUrl}" target="_blank" rel="noopener"
+            title="View ${this._esc(pkg.entryFile)} in ${this._esc(pkg.name)} ${this._esc(pkg.version)} on npm">${this._esc(pkg.entryFile)}</a>
+        </div>
       </div>`;
   }
 
@@ -926,6 +931,20 @@ class NpmCompatChart extends HTMLElement {
           text-decoration: none;
         }
         .entry:hover { color: var(--text-muted, rgba(255,255,255,0.46)); text-decoration: underline; }
+        .card-links {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: baseline;
+          gap: 4px 14px;
+        }
+        .playground-link {
+          display: inline-block;
+          margin-top: 10px;
+          color: var(--accent, #8ba4ff);
+          font-size: 10px;
+          text-decoration: none;
+        }
+        .playground-link:hover { text-decoration: underline; }
         .note {
           margin-top: 18px;
           font-size: 11px;

--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -1028,6 +1028,15 @@
         color: #ffffff;
         background: #2a2d2e;
       }
+      .npm-file-path {
+        vertical-align: middle;
+      }
+      .npm-file-result {
+        float: right;
+        margin-left: 8px;
+        color: #777;
+        font-size: 11px;
+      }
       .bench-file-name {
         flex: 1;
         min-width: 0;

--- a/website/playground/layout.ts
+++ b/website/playground/layout.ts
@@ -140,6 +140,8 @@ export class LayoutManager {
   // Callbacks
   onMount: ((panelId: string, tabId: string, contentEl: HTMLElement) => void) | null = null;
   onUnmount: ((panelId: string, tabId: string) => void) | null = null;
+  /** Return true when the tab close request was handled without removing it. */
+  onCloseTab: ((panelId: string, tabId: string) => boolean) | null = null;
   onLayoutChanged: (() => void) | null = null;
 
   constructor(container: HTMLElement) {
@@ -149,6 +151,16 @@ export class LayoutManager {
 
   registerTab(item: TabItem): void {
     this.tabs.set(item.id, item);
+  }
+
+  updateTabTitle(tabId: string, title: string): void {
+    const tab = this.tabs.get(tabId);
+    if (!tab) return;
+    tab.title = title;
+    for (const { tabBar } of this.panelEls.values()) {
+      const label = tabBar.querySelector(`[data-tab="${tabId}"] .panel-tab-label`);
+      if (label) label.textContent = title;
+    }
   }
 
   init(root?: LayoutNode): void {
@@ -369,11 +381,16 @@ export class LayoutManager {
     const leaf = this.findLeafById(this.root, panelId);
     if (!leaf) return;
 
-    const tab = this.tabs.get(tabId);
-    if (tab?.permanent) return;
-
     const idx = leaf.tabs.indexOf(tabId);
     if (idx === -1) return;
+
+    if (this.onCloseTab?.(panelId, tabId)) {
+      this.saveLayout();
+      return;
+    }
+
+    const tab = this.tabs.get(tabId);
+    if (tab?.permanent) return;
 
     if (leaf.tabs.length <= 1) {
       // Last tab in panel — remove the entire panel

--- a/website/playground/main.ts
+++ b/website/playground/main.ts
@@ -926,16 +926,25 @@ function bindInputModelPersistence(model: monaco.editor.ITextModel): void {
   });
 }
 
+function languageForSourcePath(path: string): string {
+  if (/\.(?:m?js|cjs|jsx|tsx)$/i.test(path)) return "javascript";
+  if (/\.json$/i.test(path)) return "json";
+  if (/\.(?:md|markdown|txt)$/i.test(path)) return "plaintext";
+  return "typescript";
+}
+
 function setInputSourceModel(virtualPath: string, source: string): void {
   const previousModel = inputFile.model;
   const normalizedSource = canonicalizeBenchmarkHelperImports(source, virtualPath);
   const uri = monaco.Uri.parse(`file:///${virtualPath}`);
+  const language = languageForSourcePath(virtualPath);
   let model = monaco.editor.getModel(uri);
   if (!model) {
-    model = monaco.editor.createModel(normalizedSource, "typescript", uri);
+    model = monaco.editor.createModel(normalizedSource, language, uri);
   } else if (model.getValue() !== normalizedSource) {
     model.setValue(normalizedSource);
   }
+  monaco.editor.setModelLanguage(model, language);
   if (previousModel !== model) {
     monaco.editor.setModelMarkers(previousModel, T262_MARKER_OWNER, []);
   }
@@ -1468,6 +1477,33 @@ interface T262FileResult {
   file: string;
   status: string;
   error?: string;
+  passed?: number;
+  total?: number;
+  tests?: { name?: string; status?: string }[];
+  sourceUrl?: string;
+}
+interface NpmCompatTestFile {
+  path: string;
+  status: string;
+  error?: string;
+  passed?: number;
+  total?: number;
+  source?: string;
+  sourceUrl?: string;
+  tests?: { name?: string; status?: string }[];
+}
+interface NpmCompatPlayground {
+  kind: string;
+  label: string;
+  files: NpmCompatTestFile[];
+  summary: SuiteSummary;
+  note?: string;
+}
+interface NpmCompatPackage {
+  name: string;
+  version?: string;
+  tests?: { reason?: string; status?: string; passed?: number | null; total?: number | null } | null;
+  playground?: NpmCompatPlayground;
 }
 interface T262FailureAnnotation {
   status: string;
@@ -1489,6 +1525,7 @@ interface T262TrendRun {
 
 let t262Report: T262Report | null = null;
 const t262FileResultsCache = new Map<string, T262FileResult[]>();
+let npmCompatPackages: NpmCompatPackage[] | null = null;
 
 async function loadLatestT262Summary(): Promise<T262Report["summary"] | null> {
   const runs = await fetchJson<T262TrendRun[]>(resolveSiteLink("benchmarks/results/runs/index.json"));
@@ -1536,6 +1573,15 @@ async function t262LoadFileResults(category: string): Promise<T262FileResult[]> 
   const resolved = data ?? [];
   t262FileResultsCache.set(category, resolved);
   return resolved;
+}
+
+async function loadNpmCompatPackages(): Promise<NpmCompatPackage[]> {
+  if (npmCompatPackages) return npmCompatPackages;
+  const data = await fetchJson<{ packages?: NpmCompatPackage[] }>(
+    resolveSiteLink("benchmarks/results/npm-compat.json"),
+  );
+  npmCompatPackages = Array.isArray(data?.packages) ? data.packages : [];
+  return npmCompatPackages;
 }
 
 function t262GetCategoryStats(
@@ -1933,6 +1979,89 @@ async function t262LoadAndShow(filePath: string, fileResult: T262FileResult | nu
   updateTabLabel("ts-source", fname, undefined, tabTooltips["ts-source"]);
   await compileOnly();
   t262Loading = false;
+  closeMobileSidebarAfterSelection();
+}
+
+const npmCompatRequestedPackage = new URLSearchParams(location.search).get("npm");
+let npmCompatDeepLinkApplied = false;
+
+function npmCompatFolderKey(packageName: string): string {
+  return `__npm_${packageName}__`;
+}
+
+function npmCompatFileKey(packageName: string, filePath: string): string {
+  return `npm:${packageName}:${filePath}`;
+}
+
+function npmCompatStatusClass(status: string): string {
+  switch (status) {
+    case "pass":
+      return " t262-file-pass";
+    case "fail":
+      return " t262-file-fail";
+    case "compile_error":
+      return " t262-file-ce";
+    case "skip":
+      return " t262-file-skip";
+    default:
+      return "";
+  }
+}
+
+function npmCompatFallbackPlayground(pkg: NpmCompatPackage): NpmCompatPlayground {
+  if (pkg.playground) return pkg.playground;
+  const passed = Number(pkg.tests?.passed ?? 0);
+  const total = Number(pkg.tests?.total ?? 0);
+  return {
+    kind: "unavailable",
+    label: "package tests",
+    files: [],
+    summary: { pass: passed, fail: Math.max(0, total - passed), compile_error: 0, skip: 0, total },
+    note:
+      pkg.tests?.reason ??
+      (total > 0
+        ? "This report contains package-level results only; refresh the npm compatibility report for file-level tests."
+        : "No file-level test metadata is included in this report snapshot."),
+  };
+}
+
+async function npmLoadAndShow(packageName: string, file: NpmCompatTestFile): Promise<void> {
+  let source = file.source ?? null;
+  if (source === null && file.sourceUrl) source = await fetchText(file.sourceUrl);
+  if (source === null) {
+    showT262DeepLinkBanner(`Could not load npm test source: ${file.path}`, "warn");
+    source = `// Source unavailable for ${file.path}\n// ${file.sourceUrl ?? "No source URL was recorded."}\n`;
+  }
+
+  const activePath = npmCompatFileKey(packageName, file.path);
+  const packagePath = packageName.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const virtualPath = `input/npm/${packagePath}/${file.path.replace(/^\/+/, "")}`;
+  t262Loading = true;
+  try {
+    clearT262FailureAnnotations();
+    setInputSourceModel(virtualPath, source);
+    revealSourceTab();
+    t262SetActive(activePath);
+    activeT262FileResult = {
+      file: virtualPath,
+      status: file.status,
+      ...(file.error ? { error: file.error } : {}),
+      ...(file.passed != null ? { passed: file.passed } : {}),
+      ...(file.total != null ? { total: file.total } : {}),
+      ...(file.tests ? { tests: file.tests } : {}),
+    };
+    updateTabLabel("ts-source", t262FileName(file.path), undefined, `${file.path} (${file.status})`);
+    await compileOnly();
+  } finally {
+    t262Loading = false;
+  }
+
+  if (file.status === "pass") {
+    const count = file.total != null ? ` — ${file.passed ?? 0}/${file.total} tests passed` : " — passed";
+    showT262DeepLinkBanner(`${packageName}/${file.path}${count}`, "pass");
+  } else if (file.error) {
+    showT262DeepLinkBanner(`${packageName}/${file.path}: ${file.error}`, file.status === "skip" ? "warn" : "fail");
+  }
   closeMobileSidebarAfterSelection();
 }
 
@@ -2696,6 +2825,93 @@ async function t262Render() {
     if (isStaleRender()) return;
   }
 
+  // ── npm compatibility suites ──
+  const npmPackages = await loadNpmCompatPackages();
+  if (isStaleRender()) return;
+  if (!npmCompatDeepLinkApplied) {
+    if (npmCompatRequestedPackage && npmPackages.some((pkg) => pkg.name === npmCompatRequestedPackage)) {
+      t262ExpandedFolders.add(npmCompatFolderKey(npmCompatRequestedPackage));
+    }
+    npmCompatDeepLinkApplied = true;
+  }
+  const npmMatches = npmPackages.filter((pkg) => {
+    const suite = npmCompatFallbackPlayground(pkg);
+    return (
+      !filter ||
+      pkg.name.toLowerCase().includes(filter) ||
+      suite.label.toLowerCase().includes(filter) ||
+      suite.files.some((file) => file.path.toLowerCase().includes(filter))
+    );
+  });
+  if (npmMatches.length > 0) {
+    const npmHeader = document.createElement("div");
+    npmHeader.className = "t262-section-header";
+    npmHeader.textContent = "NPM COMPATIBILITY";
+    listFragment.appendChild(npmHeader);
+
+    for (const pkg of npmMatches) {
+      const suite = npmCompatFallbackPlayground(pkg);
+      const packageKey = npmCompatFolderKey(pkg.name);
+      const packageMatches =
+        !filter || pkg.name.toLowerCase().includes(filter) || suite.label.toLowerCase().includes(filter);
+      const displayFiles = packageMatches
+        ? suite.files
+        : suite.files.filter((file) => file.path.toLowerCase().includes(filter));
+      const packageLabel = pkg.version ? `${pkg.name}  v${pkg.version}` : pkg.name;
+      await renderTopFolder(
+        packageLabel,
+        packageKey,
+        listFragment,
+        (container) => {
+          const filesEl = document.createElement("div");
+          filesEl.className = "t262-files";
+          filesEl.style.paddingLeft = "22px";
+
+          for (const file of displayFiles) {
+            const activePath = npmCompatFileKey(pkg.name, file.path);
+            const fileEl = document.createElement("div");
+            fileEl.className = `t262-file${npmCompatStatusClass(file.status)}${
+              t262ActivePath === activePath ? " active" : ""
+            }`;
+            fileEl.dataset.path = activePath;
+            fileEl.innerHTML = t262StatusIcon(file.status);
+
+            const pathEl = document.createElement("span");
+            pathEl.className = "npm-file-path";
+            pathEl.textContent = file.path;
+            fileEl.appendChild(pathEl);
+
+            if (file.total != null) {
+              const resultEl = document.createElement("span");
+              resultEl.className = "npm-file-result";
+              resultEl.textContent = `${file.passed ?? 0}/${file.total}`;
+              fileEl.appendChild(resultEl);
+            }
+
+            fileEl.title = file.error
+              ? `${file.path} (${file.status})\n${file.error}`
+              : `${file.path} (${file.status})`;
+            fileEl.addEventListener("click", () => {
+              void npmLoadAndShow(pkg.name, file);
+            });
+            filesEl.appendChild(fileEl);
+          }
+
+          if (displayFiles.length === 0) {
+            const noteEl = document.createElement("div");
+            noteEl.className = "t262-no-results";
+            noteEl.textContent = suite.note ?? "No test files are available for this package yet.";
+            filesEl.appendChild(noteEl);
+          }
+          if (t262ActivePath.startsWith(`npm:${pkg.name}:`)) appendOutputFolder(filesEl);
+          container.appendChild(filesEl);
+        },
+        suite.summary.total > 0 ? buildSuiteSummaryHtml(suite.summary) : "",
+      );
+      if (isStaleRender()) return;
+    }
+  }
+
   // ── BENCHMARKS section ──
   const benchMatches = benchmarkExamples.filter(
     (bench) =>
@@ -2812,7 +3028,7 @@ const layoutRoot = document.getElementById("layout-root")!;
 const layout = new LayoutManager(layoutRoot);
 
 // Register all tabs
-layout.registerTab({ id: "ts-source", title: inputFile.displayName, kind: "editor", permanent: true });
+layout.registerTab({ id: "ts-source", title: inputFile.displayName, kind: "editor" });
 layout.registerTab({ id: "wat-output", title: watFile.displayName, kind: "editor", permanent: true });
 layout.registerTab({ id: "wasm-hex", title: wasmHexFile.displayName, kind: "editor" });
 layout.registerTab({ id: "modular-ts", title: modularFile.displayName, kind: "editor" });
@@ -2874,6 +3090,12 @@ layout.onUnmount = (panelId: string, tabId: string) => {
   }
 };
 
+layout.onCloseTab = (_panelId: string, tabId: string): boolean => {
+  if (tabId !== "ts-source") return false;
+  clearSourceEditor();
+  return true;
+};
+
 // Layout changed: relayout editors
 layout.onLayoutChanged = () => {
   for (const slot of editorSlots) {
@@ -2923,7 +3145,7 @@ syncSidebarToggleButton();
 const fmtSize = (b: number) => (b >= 1024 ? `${(b / 1024).toFixed(1)}k` : `${b}b`);
 
 const tabTooltips: Record<string, string> = {
-  "ts-source": "TypeScript (.ts)",
+  "ts-source": "Source editor (.js / .ts)",
   "wat-output": "WebAssembly Text Format (.wat)",
   "wasm-hex": "WebAssembly Binary (.wasm)",
   "modular-ts": "JavaScript (.js)",
@@ -2976,6 +3198,7 @@ function updateTabSizes() {
 }
 
 function updateTabLabel(tabId: string, text: string, meta?: string, tooltip?: string) {
+  layout.updateTabTitle(tabId, text);
   const el = layout.getTabElement(tabId);
   if (el) {
     const label = el.querySelector(".panel-tab-label");
@@ -3024,6 +3247,37 @@ function revealSourceTab(): void {
 function showOutputPanel(name: string) {
   const panelId = layout.findPanelForTab(name);
   if (panelId) layout.switchTab(panelId, name);
+}
+
+function clearSourceEditor(): void {
+  t262Loading = true;
+  try {
+    clearT262FailureAnnotations();
+    setInputSourceModel("input/example.js", "");
+    t262SetActive(inputFile.path);
+    lastResult = null;
+    consolePre.textContent = "";
+    errorsPre.textContent = "";
+    previewPanel.innerHTML = "";
+    timingSpan.textContent = "";
+    runBtn.disabled = false;
+    benchBtn.disabled = true;
+    downloadWasmBtn.disabled = true;
+    for (const file of files) {
+      if (file.folder !== "output") continue;
+      file.model.setValue("");
+      file.compiled = false;
+      file.binarySize = undefined;
+      file.binaryData = undefined;
+    }
+    lastWasmData = null;
+    lastWasmSpans = [];
+    updateTabLabel("ts-source", "example.js", undefined, tabTooltips["ts-source"]);
+    updateTabSizes();
+    queueSidebarRefresh();
+  } finally {
+    t262Loading = false;
+  }
 }
 
 // ─── Cross-highlight functions ───────────────────────────────────────────
@@ -4453,6 +4707,13 @@ mobileLayoutMedia.addEventListener("change", (event) => {
 // by the JSONL baseline are bundled into the GitHub Pages artifact.
 async function loadDeepLinkFromUrl(): Promise<boolean> {
   const params = new URLSearchParams(location.search);
+  if (params.get("npm")) {
+    if (mobileLayoutMedia.matches) {
+      mobileSidebarOpen = true;
+      syncMobileSidebar();
+    }
+    return false;
+  }
   const t262Path = params.get("t262");
   if (!t262Path) return false;
   const errorParam = params.get("error");
@@ -4480,7 +4741,7 @@ async function loadDeepLinkFromUrl(): Promise<boolean> {
   return true;
 }
 
-function showT262DeepLinkBanner(message: string, tone: "fail" | "warn"): void {
+function showT262DeepLinkBanner(message: string, tone: "fail" | "warn" | "pass"): void {
   const existing = document.getElementById("t262-deep-link-banner");
   if (existing) existing.remove();
   const banner = document.createElement("div");
@@ -4495,9 +4756,9 @@ function showT262DeepLinkBanner(message: string, tone: "fail" | "warn"): void {
     "padding:10px 14px",
     "border-radius:0",
     "border:1px solid",
-    `border-color:${tone === "fail" ? "rgba(248,113,113,0.5)" : "rgba(250,204,21,0.5)"}`,
-    `background:${tone === "fail" ? "rgba(248,113,113,0.12)" : "rgba(250,204,21,0.12)"}`,
-    `color:${tone === "fail" ? "#fca5a5" : "#fde68a"}`,
+    `border-color:${tone === "fail" ? "rgba(248,113,113,0.5)" : tone === "pass" ? "rgba(74,222,128,0.5)" : "rgba(250,204,21,0.5)"}`,
+    `background:${tone === "fail" ? "rgba(248,113,113,0.12)" : tone === "pass" ? "rgba(74,222,128,0.12)" : "rgba(250,204,21,0.12)"}`,
+    `color:${tone === "fail" ? "#fca5a5" : tone === "pass" ? "#86efac" : "#fde68a"}`,
     "font-family:ui-monospace, SFMono-Regular, Menlo, monospace",
     "font-size:12px",
     "line-height:1.5",


### PR DESCRIPTION
## Summary
- preserve the sole unique product slice from stale PR #4651 on current main
- expose package and per-file npm test results in the playground with deep links and source URLs
- retain current correctness, unavailable-infrastructure, performance, and history fields
- fix compile-blocked differential summaries so compile errors are never reported as skips

## Validation
- focused and regression tests: 34/34 across 5/5 files
- Marked no-write generator: 8/8 compile errors, zero skips
- Cookie positive control: 63,658/63,740 tests, 21/21 playground files, 3 performance rows
- TypeScript 7 typecheck, Biome lint (4,202 files), Prettier (10/10), and production Vite build (2,105 modules) pass
- issue integrity, issue ID against main, and diff checks pass

Tracked in Markdown issue #4575. This PR is the focused replacement for #4651; its capability and chart work already landed separately.