### PR TITLE
fix(eval): restore first-class eval aliases after #4664

### DIFF
--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -90,6 +90,7 @@ import { buildThrowJsErrorInstrs, emitThrowReferenceError } from "../js-errors.j
 import { compileInternalCallArgument } from "./internal-call-argument.js";
 import { isForeignEvalNode } from "./eval-source.js";
 import { resolvesToGlobalFunctionAlias } from "./eval-inline.js";
+import { prepareStandaloneEvalAliasCall } from "./eval-alias.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import {
   calleeIsCapabilityCtorParam,
@@ -1372,14 +1373,12 @@ export function compileIdentifierCall(
       }
       const storedCarrierCall = tryCompileStoredStandaloneCarrierCall(ctx, fctx, expr, isKnownVariable);
       if (storedCarrierCall !== undefined) return storedCarrierCall;
-      // `%Function%` is represented by the linked provider's structural
-      // callable marker. Calling an alias through the checker-derived
-      // FunctionConstructor signature first would compile native-string
-      // arguments into module-local ref slots; a failed guarded cast then
-      // irreversibly becomes null before the marker fallback can see it. Route
-      // proven aliases through the generic externref dispatcher up front. It
-      // still evaluates the live binding and every argument exactly once, so
-      // this is a dispatch choice rather than constant-folding the alias.
+      if (prepareStandaloneEvalAliasCall(ctx, fctx, expr.expression, isKnownVariable)) {
+        const evalAliasCall = tryEmitInlineDynamicCall(ctx, fctx, expr, true);
+        if (evalAliasCall !== null) return evalAliasCall;
+      }
+      // Provider-owned `%Function%` aliases need generic externref dispatch;
+      // the live binding and arguments are still evaluated exactly once.
       if (
         isKnownVariable &&
         ctx.standalone &&

--- a/src/codegen/expressions/eval-alias.ts
+++ b/src/codegen/expressions/eval-alias.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/** Compile-order-independent planning for standalone first-class `%eval%`. */
+import { ts } from "../../ts-api.js";
+import type { TypeOracle } from "../../checker/oracle.js";
+import { ensureFuncClosureSingleton } from "../closures/method-trampolines.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { ensureStandaloneIntrinsicEvalWrapper } from "./eval-inline.js";
+
+function resolvesToGlobalEvalAlias(
+  ident: ts.Identifier,
+  oracle: TypeOracle,
+  seen: Set<ts.Declaration> = new Set(),
+): boolean {
+  if (ident.text !== "eval") {
+    const declaration = oracle.valueDeclarationOf(ident);
+    if (!declaration || seen.has(declaration)) return false;
+    seen.add(declaration);
+    if (!ts.isVariableDeclaration(declaration) || !declaration.initializer) return false;
+    let initializer: ts.Expression = declaration.initializer;
+    while (
+      ts.isParenthesizedExpression(initializer) ||
+      ts.isAsExpression(initializer) ||
+      ts.isNonNullExpression(initializer) ||
+      ts.isSatisfiesExpression(initializer) ||
+      ts.isTypeAssertionExpression(initializer)
+    ) {
+      initializer = initializer.expression;
+    }
+    return ts.isIdentifier(initializer) && resolvesToGlobalEvalAlias(initializer, oracle, seen);
+  }
+  const declaration = oracle.valueDeclarationOf(ident);
+  return declaration === undefined || declaration.getSourceFile().isDeclarationFile;
+}
+
+/**
+ * Ensure an alias call compiled before `var e = eval` materializes its wrapper
+ * still sees that wrapper in the dynamic-call candidate set. The caller keeps
+ * loading the live binding, so a later assignment to a mutable alias remains
+ * observable instead of being folded to the intrinsic.
+ */
+export function prepareStandaloneEvalAliasCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  callee: ts.LeftHandSideExpression,
+  isKnownVariable: boolean,
+): boolean {
+  if (
+    !isKnownVariable ||
+    !ctx.standalone ||
+    ctx.runtimeEvalCallableBoundaryEnabled !== true ||
+    !ts.isIdentifier(callee) ||
+    !resolvesToGlobalEvalAlias(callee, ctx.oracle)
+  ) {
+    return false;
+  }
+  const wrapper = ensureStandaloneIntrinsicEvalWrapper(ctx, fctx);
+  return wrapper !== undefined && ensureFuncClosureSingleton(ctx, wrapper.fnName, wrapper.funcIdx) !== null;
+}

--- a/src/codegen/expressions/eval-inline.ts
+++ b/src/codegen/expressions/eval-inline.ts
@@ -30,6 +30,7 @@ import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, compileStatement } from "../shared.js";
 import { emitUndefined, ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { collectReferencedIdentifiers, emitFuncRefAsClosure, getFuncSignature } from "../closures.js";
+import { emitCachedFuncClosureAccess } from "../closures/method-trampolines.js";
 import { compileAndEmitToString } from "../coercion-engine.js";
 import { compileStringLiteral } from "../string-ops.js";
 import { emitThrowJsError, noJsHost } from "./helpers.js";
@@ -1971,7 +1972,7 @@ export function emitStandaloneIndirectEvalRuntime(
 }
 
 /** Hoist the realm's first-class `%eval%` wrapper without executing eval. */
-function ensureStandaloneIntrinsicEvalWrapper(
+export function ensureStandaloneIntrinsicEvalWrapper(
   ctx: CodegenContext,
   fctx: FunctionContext,
 ): { fnName: string; funcIdx: number } | undefined {
@@ -2021,14 +2022,13 @@ function ensureStandaloneIntrinsicEvalWrapper(
 
 /**
  * Materialize the current realm's first-class `%eval%` value for standalone.
- * Construction is pure AOT: merely storing `eval` (Deno primordials does
- * exactly this) must not execute the runtime compiler/interpreter. Calling the
+ * Capturing `eval` is pure AOT and does not execute the provider; calling the
  * resulting closure later invokes the existing indirect-eval provider seam.
  */
 export function emitStandaloneIntrinsicEvalValue(ctx: CodegenContext, fctx: FunctionContext): ValType | undefined {
   const wrapper = ensureStandaloneIntrinsicEvalWrapper(ctx, fctx);
   if (!wrapper) return undefined;
-  const closureRef = emitFuncRefAsClosure(ctx, fctx, wrapper.fnName, wrapper.funcIdx);
+  const closureRef = emitCachedFuncClosureAccess(ctx, fctx, wrapper.fnName, wrapper.funcIdx);
   if (!closureRef) return undefined;
   if (closureRef.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
   return { kind: "externref" };

--- a/tests/issue-4376-deno-primordials-runtime.test.ts
+++ b/tests/issue-4376-deno-primordials-runtime.test.ts
@@ -293,6 +293,17 @@ describe("#4376 — Deno primordials standalone runtime substrate", () => {
     );
   });
 
+  it("reuses one eval intrinsic value without executing the runtime-eval provider", async () => {
+    const result = await runStandaloneJs(`
+      const firstEval = eval;
+      const secondEval = eval;
+      export function test() { return firstEval === secondEval ? 42 : 0; }
+    `);
+
+    expect(result.value).toBe(42);
+    expect(result.calls).toEqual([]);
+  });
+
   it("forwards TDZ-flagged transitive captures from the lifted caller frame", async () => {
     const result = await runStandaloneJs(`
       let observed = 0;

--- a/tests/issue-4376-eval-alias-regression.test.ts
+++ b/tests/issue-4376-eval-alias-regression.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #4376 / PR #4664 — first-class `%eval%` aliases remain callable.
+ *
+ * Deno's primordials bootstrap stores `eval` without invoking the runtime
+ * compiler, so #4376 materializes a pure-AOT wrapper for the intrinsic. The
+ * wrapper is created from a synthetic SourceFile and can therefore appear
+ * after a hoisted function containing `alias(source)` has already been
+ * compiled. The generic dynamic-call ladder must know the wrapper signature
+ * before that call site is lowered or it falls through to the non-callable
+ * path.
+ *
+ * The first test is an engine-independent positive control over the exact
+ * provider ABI. The second matrix pins all 13 ES5 Test262 files that regressed
+ * in the PR transition. It self-gates because ordinary unit CI does not build
+ * QuickJS; the standalone Test262 lane does and executes the literal upstream
+ * harness through runTest262File.
+ */
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import {
+  RUNTIME_EVAL_IMPORT_MODULE,
+  RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS,
+  instantiateRuntimeEvalNamespace,
+  selectCachedRuntimeEvalProvider,
+} from "../scripts/runtime-eval-provider.mjs";
+import { runTest262File } from "./test262-runner.js";
+
+const REGRESSION_FILES = [
+  "test/language/statements/variable/12.2.1-20-s.js",
+  "test/built-ins/Function/15.3.5.4_2-14gs.js",
+  "test/language/statements/variable/12.2.1-22-s.js",
+  "test/language/function-code/10.4.3-1-20gs.js",
+  "test/language/eval-code/indirect/global-env-rec.js",
+  "test/language/eval-code/indirect/global-env-rec-fun.js",
+  "test/language/statements/variable/12.2.1-10-s.js",
+  "test/language/statements/variable/12.2.1-21-s.js",
+  "test/language/function-code/10.4.3-1-20-s.js",
+  "test/language/function-code/10.4.3-1-19-s.js",
+  "test/language/function-code/10.4.3-1-19gs.js",
+  "test/language/eval-code/indirect/global-env-rec-catch.js",
+  "test/language/statements/variable/12.2.1-9-s.js",
+] as const;
+
+function stubProviderSource(): string {
+  return `
+    function result(ok: boolean, value: any): any {
+      const envelope: any[] = [ok, __runtime_eval_wrap_result(value)];
+      return envelope;
+    }
+    function refuse(): any { return result(false, new TypeError("unexpected provider entry")); }
+    export function __runtime_indirect_eval(source: any, globalObject: any): any {
+      return result(true, source === "forty-two" ? 42 : -1);
+    }
+    export function __runtime_direct_eval(
+      source: any, globalObject: any, thisArg: any, activationState: any,
+      activationSeedNames: any, activationSeedSlots: any, lexicalNames: any,
+      lexicalSlots: any, outerNames: any, outerSlots: any,
+      callerStrict: boolean, mappedParamNames: any
+    ): any { return refuse(); }
+    export function __runtime_new_function(params: any, body: any, globalObject: any): any {
+      return refuse();
+    }
+    export function __runtime_apply_interpreted(
+      callable: any, receiver: any, argc: number,
+      a0: any, a1: any, a2: any, a3: any,
+      a4: any, a5: any, a6: any, a7: any
+    ): any { return refuse(); }
+  `;
+}
+
+describe("#4376 — first-class eval alias dispatch", () => {
+  let providerModule: WebAssembly.Module;
+
+  beforeAll(async () => {
+    const provider = await compile(stubProviderSource(), {
+      ...RUNTIME_EVAL_PROVIDER_COMPILE_OPTIONS,
+      fileName: "issue-4376-eval-alias-provider.ts",
+    });
+    expect(provider.success, JSON.stringify(provider.errors)).toBe(true);
+    providerModule = new WebAssembly.Module(provider.binary);
+  }, 120_000);
+
+  it("calls the provider only when a stored eval alias is invoked", { timeout: 120_000 }, async () => {
+    const user = await compile(
+      `
+        var indirectEval: any = eval;
+        function source(): string {
+          var parts: string[] = ["forty", "-two"];
+          return parts[0] + parts[1];
+        }
+        export function probe(): number { return indirectEval(source()) as number; }
+      `,
+      { target: "standalone", experimentalIR: false },
+    );
+    expect(user.success, JSON.stringify(user.errors)).toBe(true);
+    const module = new WebAssembly.Module(user.binary);
+    expect(WebAssembly.Module.imports(module).map(({ module, name }) => `${module}::${name}`)).toContain(
+      `${RUNTIME_EVAL_IMPORT_MODULE}::__runtime_indirect_eval`,
+    );
+    const instance = new WebAssembly.Instance(module, {
+      [RUNTIME_EVAL_IMPORT_MODULE]: instantiateRuntimeEvalNamespace(providerModule),
+    });
+    expect((instance.exports as { probe(): number }).probe()).toBe(42);
+  });
+});
+
+let liveQuickjsAvailable = false;
+try {
+  liveQuickjsAvailable =
+    existsSync(resolve("test262", REGRESSION_FILES[0])) && selectCachedRuntimeEvalProvider().engine === "quickjs";
+} catch {
+  liveQuickjsAvailable = false;
+}
+
+describe.skipIf(!liveQuickjsAvailable)("#4376 — ES5 indirect-eval alias Test262 matrix", () => {
+  for (const file of REGRESSION_FILES) {
+    it(file, { timeout: 120_000 }, async () => {
+      const result = await runTest262File(resolve("test262", file), "issue-4376-eval-alias", 120_000, "standalone");
+      expect(result.status, result.error).toBe("pass");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- pre-register the pure-AOT `%eval%` wrapper before hoisted alias calls build their dynamic-call candidate set
- keep capture provider-free for Deno primordials while caching one identity-stable realm value
- pin the exact 13 ES5 Test262 losses reported on #4664 as a live QuickJS regression matrix

## Regression proof

On merged #4664, `12.2.1-20-s.js` fails with the reported `TypeError: Cannot access property on null or undefined`. With this change, all 13 reported files pass through the literal standalone Test262 harness and live QuickJS provider.

## Verification

- `pnpm run typecheck`
- focused suite: 3 files, 30 tests passed; 13 live-provider tests self-gated in provider-free mode
- live QuickJS matrix: 14/14 passed, including all 13 reported Test262 files
- `pnpm run check:loc-budget`
- `pnpm run check:func-budget`
- focused Prettier check and `git diff --check`

Follow-up to #4664 and https://github.com/loopdive/js2/pull/4664#issuecomment-5360874504.
Refs #4376.