### PR TITLE
fix(perf): elide private strict arguments poison accessors

### DIFF
--- a/plan/issues/4578-strict-arguments-poison-accessor-perf.md
+++ b/plan/issues/4578-strict-arguments-poison-accessor-perf.md
@@ -1,0 +1,90 @@
+---
+id: 4578
+title: "Elide unobservable strict arguments poison accessors"
+status: done
+created: 2026-08-20
+updated: 2026-08-20
+priority: critical
+feasibility: medium
+reasoning_effort: high
+task_type: performance
+area: codegen, standalone, npm-compat
+language_feature: strict arguments object
+goal: performance
+sprint: current
+depends_on: [4555]
+assignee: ttraenkler/codex
+horizon: s
+related: [3781, 4243, 4555, 4576, 4577]
+origin: "Published Acorn/clsx standalone-dynamic collapse after PR #4658; exact reduced A/B pins the first hot-path regression to 536a3c0."
+files:
+  - src/codegen/arguments-callee.ts
+  - src/codegen/helpers/arguments-registration.ts
+  - tests/issue-4578-strict-arguments-perf.test.ts
+  - plan/issues/4578-strict-arguments-poison-accessor-perf.md
+---
+
+# #4578 — elide unobservable strict arguments poison accessors
+
+## Problem
+
+`536a3c0` made the standalone strict arguments object conformant by eagerly
+installing the `%ThrowTypeError%` `callee` accessor on every activation. The
+installation enters the generic object runtime and calls
+`__defineProperty_accessor`, even when the arguments object is private and the
+function reads only `arguments.length` and numeric elements.
+
+That work sits directly in the hottest variadic paths of Acorn and clsx. A
+correct-checksum reduced clsx A/B measured roughly `0.148 us/op` before the
+change and `249.7 us/op` after it. The first published post-merge results
+deteriorated about 120x for Acorn and 1,425x for clsx.
+
+## Scope
+
+- Reuse one conservative arguments-use analysis to prove when the implicit
+  object is private and observed only through `.length` and numeric-index reads.
+- Omit eager poison-accessor construction only under that proof.
+- Preserve eager construction for direct eval, escape, aliasing, reflection,
+  dynamic or string keys, mutation/receiver uses, `with`, and unknown shapes.
+- Treat computed method/accessor names as outer-scope code while continuing to
+  exclude their nested callable bodies, which bind their own `arguments`.
+- Preserve the existing syntactic TypeError path for direct strict
+  `arguments.callee` reads and writes.
+
+## Acceptance criteria
+
+- [x] A clsx-shaped strict variadic function has no reachable
+      `__defineProperty_accessor` call in its emitted hot body.
+- [x] Escaping, reflected, dynamic-key, direct-eval, and otherwise unproved
+      arguments uses retain the real poison accessor.
+- [x] An escape from a computed method/accessor name retains the accessor;
+      `arguments` used only inside the nested callable body does not block
+      elision for the outer function.
+- [x] Existing strict descriptor, identity, `hasOwnProperty`, read, and write
+      tests remain green.
+- [x] Same-machine standalone `optimize: 4` differential uses identical source,
+      runtime, checksum, and harness; median Wasm time is no worse than 5x the
+      pre-regression parent (the broken path is over 1,000x slower).
+- [x] Acorn and clsx benchmark result files or baselines are not weakened to
+      hide the regression.
+
+## Non-goals
+
+- Removing `%ThrowTypeError%` semantics from observable strict arguments
+  objects.
+- Replacing the general property-descriptor runtime.
+- Claiming a browser/Node speedup from the standalone-vs-direct comparison.
+
+## Completion evidence
+
+- The focused structural and semantic matrix passes 13/13; the combined
+  private-arguments and strict-arguments suites pass 36/36.
+- TypeScript 5 and 7 typechecks, Prettier, Biome, LOC/function budgets, IR and
+  codegen fallback gates, and the verdict-oracle gate pass.
+- The exact clsx 2.1.1 standalone-dynamic `-O4` kill-switch A/B, with identical
+  source/runtime/checksum, measures `0.143173 us/op` with elision versus
+  `729.364 us/op` with eager poisoning. Both lanes pass 14/14 checksum rounds;
+  optimized binaries are 42,562 and 48,410 bytes respectively.
+- Acorn's artifact shrinks by 440 bytes. Both candidate and eager-control
+  timings hit the same pre-existing Binaryen `Flatten` failure, so no Acorn
+  runtime claim or benchmark baseline change is made.

--- a/src/codegen/arguments-callee.ts
+++ b/src/codegen/arguments-callee.ts
@@ -61,13 +61,14 @@
  */
 import type { Instr, ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
+import { seedStrictArgumentsCalleePoison } from "./arguments-callee-poison-accessor.js"; // (#4555) §10.6 step 14
 // Imported from the trampoline module directly, not the `closures.ts` barrel:
 // `closures.ts` imports THIS module for its own function-expression seed, and
 // going through the barrel would close that cycle. `expressions/new-super.ts`
 // reaches the same helper the same way.
 import { emitCachedFuncClosureExternref } from "./closures/method-trampolines.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
-import { seedStrictArgumentsCalleePoison } from "./arguments-callee-poison-accessor.js"; // (#4555) §10.6 step 14
+import { shouldRegisterArgumentsWithHost } from "./helpers/arguments-registration.js";
 import { isStrictFunction } from "./helpers/is-strict-function.js";
 import { noJsHost } from "./js-errors.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
@@ -171,6 +172,16 @@ export function seedDeclarationArgumentsCallee(
   // direct syntactic read; the accessor is what a descriptor query, a
   // `hasOwnProperty`, or a write on an escaped arguments object observes.)
   if (isStrictFunction(decl, ctx.inferModuleStrictArguments)) {
+    // (#4578) The poison accessor is observable only when the arguments object
+    // itself is observable. Reuse the same conservative proof that guards
+    // private host-registration elision: `.length` and checker-proven numeric
+    // indexed reads stay entirely inside the vec representation, while eval,
+    // escape, reflection, mutation, receiver use, and ambiguous keys all keep
+    // the eager accessor. This removes a full object-runtime descriptor insert
+    // from every hot call in strict ESM packages such as clsx and Acorn.
+    if (decl.body && !shouldRegisterArgumentsWithHost(ctx, decl.body, fctx.directEvalBindingNames !== undefined)) {
+      return;
+    }
     seedStrictArgumentsCalleePoison(ctx, fctx, argsLocalIdx);
     return;
   }
@@ -210,6 +221,12 @@ export function seedLiftedClosureArgumentsCallee(
   argsLocalIdx: number,
 ): void {
   if (isStrictFunction(arrow, ctx.inferModuleStrictArguments)) {
+    if (
+      arrow.body &&
+      !shouldRegisterArgumentsWithHost(ctx, arrow.body, liftedFctx.directEvalBindingNames !== undefined)
+    ) {
+      return;
+    }
     seedStrictArgumentsCalleePoison(ctx, liftedFctx, argsLocalIdx); // (#4555) §10.6 step 14
     return;
   }

--- a/src/codegen/helpers/arguments-registration.ts
+++ b/src/codegen/helpers/arguments-registration.ts
@@ -119,7 +119,19 @@ export function bodyRequiresArgumentsHostRegistration(ctx: CodegenContext, body:
     const node = stack.pop()!;
 
     // Normal nested functions bind their own `arguments`; arrows inherit it.
-    if (ts.isFunctionLike(node) && !ts.isArrowFunction(node)) continue;
+    // A method/accessor's computed NAME is the exception: it is evaluated
+    // while the containing object/class is defined, in the outer function's
+    // scope. Visit that expression, but never the nested callable's parameters
+    // or body.
+    if (ts.isFunctionLike(node) && !ts.isArrowFunction(node)) {
+      if (
+        (ts.isMethodDeclaration(node) || ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) &&
+        ts.isComputedPropertyName(node.name)
+      ) {
+        stack.push(node.name.expression);
+      }
+      continue;
+    }
     if (ts.isWithStatement(node)) return true;
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "eval") return true;
 

--- a/tests/issue-4578-strict-arguments-perf.test.ts
+++ b/tests/issue-4578-strict-arguments-perf.test.ts
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #4578 — strict ESM functions used to install the §10.6 step 14 poison
+// accessor on every arguments object, even when the object was provably private
+// and only read through `.length` / numeric indices. In clsx and Acorn this put
+// the full descriptor/object runtime on a per-invocation hot path.
+
+import { describe, expect, it } from "vitest";
+
+import type { CodegenContext } from "../src/codegen/context/types.js";
+import { bodyRequiresArgumentsHostRegistration } from "../src/codegen/helpers/arguments-registration.js";
+import { type CompileResult, compile } from "../src/index.js";
+import { ts } from "../src/ts-api.js";
+
+const EAGER_CONTROL_ENV = "JS2WASM_ELIDE_PRIVATE_ARGUMENTS_REGISTRATION";
+const DEFINE_ACCESSOR = "__defineProperty_accessor";
+
+const CLSX_SHAPED_SOURCE = `
+  export function clsxShape(): number {
+    let index: number = 0;
+    let checksum: number = arguments.length;
+    while (index < arguments.length) {
+      checksum += arguments[index++] as number;
+    }
+    return checksum;
+  }
+
+  export function test(): number {
+    return clsxShape(4, 5);
+  }
+`;
+
+interface WatFunction {
+  readonly name: string;
+  readonly body: string;
+}
+
+function parseWatFunctions(wat: string): readonly WatFunction[] {
+  const starts = [...wat.matchAll(/^ {2}\(func \$([^\s(]+)/gm)].map((match) => ({
+    name: match[1]!,
+    index: match.index,
+  }));
+  const names = starts.map(({ name }) => name);
+  expect(new Set(names).size, "WAT function names must be unique for call-graph attribution").toBe(names.length);
+  return starts.map(({ name, index }, position) => ({
+    name,
+    body: wat.slice(index, starts[position + 1]?.index ?? wat.length),
+  }));
+}
+
+function watFunction(wat: string, name: string): WatFunction {
+  const matches = parseWatFunctions(wat).filter((fn) => fn.name === name);
+  expect(matches, `unique WAT function $${name}`).toHaveLength(1);
+  return matches[0]!;
+}
+
+function watCallTargets(wat: string, body: string): readonly string[] {
+  const imports = [...wat.matchAll(/^\s*\(import .+ \(func(?: \$([^\s(]+))?/gm)].map(
+    (match) => match[1] ?? "<anonymous-import>",
+  );
+  const definitions = [...wat.matchAll(/^\s*\(func \$([^\s(]+)/gm)].map((match) => match[1]!);
+  const names = [...imports, ...definitions];
+  return [...body.matchAll(/\b(?:return_)?call (\d+)/g)].map((match) => {
+    const target = names[Number(match[1])] ?? "<missing>";
+    return target.endsWith("_import") ? target.slice(0, -"_import".length) : target;
+  });
+}
+
+function reachableFunctions(wat: string, root: string): ReadonlySet<string> {
+  const functions = new Map(parseWatFunctions(wat).map((fn) => [fn.name, fn]));
+  expect(functions.has(root), `call-graph root $${root} must exist`).toBe(true);
+  const reachable = new Set<string>();
+  const queue = [root];
+  while (queue.length > 0) {
+    const name = queue.pop()!;
+    if (reachable.has(name)) continue;
+    reachable.add(name);
+    const fn = functions.get(name);
+    if (!fn) continue;
+    for (const target of watCallTargets(wat, fn.body)) {
+      if (functions.has(target) && !reachable.has(target)) queue.push(target);
+    }
+  }
+  return reachable;
+}
+
+async function compileStandalone(source: string, forceEager = false): Promise<CompileResult> {
+  const previous = process.env[EAGER_CONTROL_ENV];
+  if (forceEager) process.env[EAGER_CONTROL_ENV] = "0";
+  else delete process.env[EAGER_CONTROL_ENV];
+  try {
+    const result = await compile(source, {
+      fileName: "issue-4578.ts",
+      target: "standalone",
+      inferModuleStrictArguments: true,
+      skipSemanticDiagnostics: true,
+      emitWat: true,
+    });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.wat.length, "structural proof requires non-empty WAT").toBeGreaterThan(0);
+    return result;
+  } finally {
+    if (previous === undefined) delete process.env[EAGER_CONTROL_ENV];
+    else process.env[EAGER_CONTROL_ENV] = previous;
+  }
+}
+
+function analyzedBodyRequiresRegistration(body: string): boolean {
+  const sourceFile = ts.createSourceFile(
+    "issue-4578-analysis.ts",
+    `function inspect(): unknown { ${body} }`,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const inspect = sourceFile.statements.find(ts.isFunctionDeclaration);
+  if (!inspect?.body) throw new Error("analysis fixture must contain inspect() with a body");
+  return bodyRequiresArgumentsHostRegistration({} as CodegenContext, inspect.body);
+}
+
+describe("#4578 private strict arguments poison-accessor elision", () => {
+  it("removes the descriptor runtime from a clsx-shaped reachable call graph", async () => {
+    const result = await compileStandalone(CLSX_SHAPED_SOURCE);
+    const clsx = watFunction(result.wat, "clsxShape");
+    expect(clsx.body, "the optimized function must still build/read its arguments vec").toMatch(/struct\.get/);
+    expect(watCallTargets(result.wat, clsx.body)).not.toContain(DEFINE_ACCESSOR);
+    expect(reachableFunctions(result.wat, "clsxShape")).not.toContain(DEFINE_ACCESSOR);
+
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(11);
+  });
+
+  it("has a non-vacuous eager A/B control on the same clsx-shaped source", async () => {
+    const result = await compileStandalone(CLSX_SHAPED_SOURCE, true);
+    const clsx = watFunction(result.wat, "clsxShape");
+    expect(watCallTargets(result.wat, clsx.body)).toContain(DEFINE_ACCESSOR);
+    expect(reachableFunctions(result.wat, "clsxShape")).toContain(DEFINE_ACCESSOR);
+  });
+
+  const observableBodies = [
+    { name: "escape", body: "return arguments as any;" },
+    { name: "alias/store", body: "const holder: any = {}; holder.value = arguments; return holder.value;" },
+    { name: "direct eval", body: 'return eval("arguments.length");' },
+    { name: "dynamic key", body: "const key: any = 0; return (arguments as any)[key];" },
+    { name: "string key", body: 'return (arguments as any)["0"];' },
+    {
+      name: "reflection",
+      body: 'return Object.getOwnPropertyDescriptor(arguments as any, "callee");',
+    },
+    { name: "mutation", body: "(arguments as any)[0] = 9; return 9;" },
+    { name: "receiver", body: "return (arguments as any)[0]();" },
+  ] as const;
+
+  for (const { name, body } of observableBodies) {
+    it(`keeps eager poison materialization for ${name}`, async () => {
+      const result = await compileStandalone(`
+        function inspect(): any { ${body} }
+        export function test(): number { inspect(); return 1; }
+      `);
+      const inspect = watFunction(result.wat, "inspect");
+      expect(watCallTargets(result.wat, inspect.body)).toContain(DEFINE_ACCESSOR);
+      expect(reachableFunctions(result.wat, "inspect")).toContain(DEFINE_ACCESSOR);
+    });
+  }
+
+  it("keeps the outer poison accessor when a computed method name escapes arguments", async () => {
+    const source = `
+      let escaped: any;
+      function capture(value: any): string { escaped = value; return "member"; }
+      function inspect(): number {
+        const object = { [capture(arguments)](): void {} };
+        void object;
+        return arguments.length;
+      }
+      export function test(): number {
+        inspect();
+        return Object.getOwnPropertyDescriptor(escaped, "callee") === undefined ? 0 : 1;
+      }
+    `;
+    const candidate = await compileStandalone(source);
+    const eagerControl = await compileStandalone(source, true);
+    for (const [label, result] of [
+      ["candidate", candidate],
+      ["eager control", eagerControl],
+    ] as const) {
+      const { instance } = await WebAssembly.instantiate(result.binary, {});
+      expect((instance.exports.test as () => number)(), label).toBe(1);
+    }
+  });
+
+  it("distinguishes outer-evaluated computed names from nested callable bodies", () => {
+    expect(
+      analyzedBodyRequiresRegistration(`
+        const object = { [capture(arguments)](): void {} };
+        return object;
+      `),
+      "a computed method name evaluates in inspect() and escapes its arguments",
+    ).toBe(true);
+    expect(
+      analyzedBodyRequiresRegistration(`
+        const object = { get [capture(arguments)](): number { return 1; } };
+        return object;
+      `),
+      "a computed getter name evaluates in inspect() and escapes its arguments",
+    ).toBe(true);
+    expect(
+      analyzedBodyRequiresRegistration(`
+        const object = { set [capture(arguments)](value: number) { void value; } };
+        return object;
+      `),
+      "a computed setter name evaluates in inspect() and escapes its arguments",
+    ).toBe(true);
+    expect(
+      analyzedBodyRequiresRegistration(`
+        const object = { method(): unknown { return arguments; } };
+        return 1;
+      `),
+      "a nested method body binds its own arguments",
+    ).toBe(false);
+    expect(
+      analyzedBodyRequiresRegistration(`
+        const object = { get value(): unknown { return arguments; } };
+        return 1;
+      `),
+      "a nested accessor body binds its own arguments",
+    ).toBe(false);
+    expect(
+      analyzedBodyRequiresRegistration(`
+        const object = { [(function (): unknown { return arguments; })()](): void {} };
+        return 1;
+      `),
+      "an ordinary function inside a computed name binds its own arguments",
+    ).toBe(false);
+    expect(
+      analyzedBodyRequiresRegistration(`
+        const object = { [((): unknown => arguments)()](): void {} };
+        return 1;
+      `),
+      "an arrow inside a computed name inherits inspect() arguments",
+    ).toBe(true);
+  });
+
+  it("also elides the accessor for a private strict function expression", async () => {
+    const result = await compileStandalone(`
+      export function test(): number {
+        const sum: any = function (): number {
+          let index: number = 0;
+          let total: number = arguments.length;
+          while (index < arguments.length) total += arguments[index++] as number;
+          return total;
+        };
+        return sum(3, 4);
+      }
+    `);
+    expect(result.wat).not.toContain("$__args_callee_poison");
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(9);
+  });
+});


### PR DESCRIPTION
## Summary

- skip eager strict arguments callee poison-accessor construction only when the existing conservative proof confines arguments to length and numeric reads
- retain eager poisoning for escape, reflection, eval, dynamic access, mutation, receiver use, and outer-evaluated computed method/accessor names
- add structural, semantic, and kill-switch controls without changing benchmark baselines

The first underlying hot-path regression was 536a3c0, not the later Codex-coauthored prototype commit.

## Evidence

- arguments-focused suites: 36/36
- TypeScript 5/7, Prettier, Biome, LOC/function, fallback, and oracle gates pass
- exact clsx 2.1.1 standalone-dynamic O4 A/B: 0.143173 us/op fixed vs 729.364 us/op eager control; checksum 14/14 in both lanes
- optimized binary: 42,562 vs 48,410 bytes

Acorn shrinks by 440 bytes, but both A/B lanes hit the same existing Binaryen Flatten failure, so this PR makes no Acorn timing claim.