### PR TITLE
fix(codegen): preserve object rest binding dispatch

### DIFF
--- a/plan/issues/4576-standalone-dom-builtins.md
+++ b/plan/issues/4576-standalone-dom-builtins.md
@@ -55,6 +55,8 @@ files:
   - src/codegen/context/types.ts
   - src/codegen/dom-string-boundary.ts
   - src/codegen/extern-declarations.ts
+  - src/codegen/expressions/call-receiver-method.ts
+  - src/codegen/expressions/object-method-rest-abi.ts
   - src/codegen/index.ts
   - src/codegen/ir-async-frame.ts
   - src/codegen/ir-inline.ts
@@ -239,3 +241,20 @@ harness-budget, typecheck, formatting, lint, and diff-integrity gates pass. The
 host-policy census remains non-vacuous at **33 probes / 393 imports / 0
 legacy-semantic / 0 unknown**, and the optimization ledger validates at **50
 decisions / 36 IR-owned / 3 retirement-ready / 2 source-anchored**.
+
+## PR #4663 Test262 follow-up
+
+The [post-merge Test262 report](https://github.com/loopdive/js2/pull/4663#issuecomment-5360874330)
+identified one newly lost standalone pass and a neighboring assertion failure
+that had both become null dereferences. The closed-struct direct-call route was
+padding an object method's `...[pattern]` tuple formal with `ref.null`, because
+only ordinary identifier rest formals publish `$Vec` metadata.
+
+The direct route now declines that fixed-tuple binding-pattern ABI so the
+existing generic dispatcher performs rest initialization. Ordinary
+`...identifier` object methods recover their already-materialized `$Vec`
+layout and remain direct calls. The #4576 matrix hash-pins and executes both
+exact Test262 sources: `scope-meth-param-rest-elem-var-close.js` passes again,
+while `scope-meth-param-rest-elem-var-open.js` returns to its exact pre-merge
+assertion failure rather than trapping. A WAT/runtime control independently
+proves the ordinary identifier-rest direct path.

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -131,6 +131,11 @@ import { tryEmitValueOfFallback } from "./valueof-fallback.js";
 import { sourceOverridesMethodOnReceiver } from "./member-override-scan.js";
 import { compileInternalCallArgument } from "./internal-call-argument.js";
 import {
+  directObjectMethodFuncIdx,
+  emitKnownRestMethodArguments,
+  knownMethodRestInfo,
+} from "./object-method-rest-abi.js";
+import {
   buildThrowJsErrorInstrs,
   canonicalClassExpressionName,
   emitThrowTypeError,
@@ -542,41 +547,6 @@ function tryCompileDerivedHostSubstringCharCodeAt(
     });
   }
   return { kind: "f64" };
-}
-
-/**
- * Materialize the hidden vector argument for a known user method with a
- * JavaScript rest parameter. Method signatures carry the rest array as one
- * Wasm parameter, but a source call supplies ordinary positional arguments;
- * an omitted rest argument therefore needs `{ length: 0, data: [] }`, not a
- * null ref. The latter used to make even `new Marked().use()` trap before the
- * method body ran.
- */
-function emitKnownRestMethodArguments(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  expr: ts.CallExpression,
-  paramTypes: ValType[] | undefined,
-  restInfo: { restIndex: number; elemType: ValType; arrayTypeIdx: number; vecTypeIdx: number },
-  selfOffset: number,
-): boolean {
-  if (expr.arguments.some((arg) => ts.isSpreadElement(arg))) return false;
-  const fixedCount = restInfo.restIndex;
-  for (let i = 0; i < fixedCount; i++) {
-    if (i < expr.arguments.length) {
-      compileInternalCallArgument(ctx, fctx, expr.arguments[i]!, paramTypes?.[selfOffset + i]);
-    } else {
-      pushDefaultValue(fctx, paramTypes?.[selfOffset + i] ?? { kind: "f64" }, ctx);
-    }
-  }
-  const restCount = Math.max(0, expr.arguments.length - fixedCount);
-  fctx.body.push({ op: "i32.const", value: restCount });
-  for (let i = fixedCount; i < expr.arguments.length; i++) {
-    compileInternalCallArgument(ctx, fctx, expr.arguments[i]!, restInfo.elemType);
-  }
-  fctx.body.push({ op: "array.new_fixed", typeIdx: restInfo.arrayTypeIdx, length: restCount });
-  fctx.body.push({ op: "struct.new", typeIdx: restInfo.vecTypeIdx });
-  return true;
 }
 
 export function compileReceiverMethodCall(
@@ -1630,7 +1600,7 @@ export function compileReceiverMethodCall(
       const dynResult = emitFnctorSubclassDynamicMethodCall(ctx, fctx, expr, propAccess, methodName);
       if (dynResult !== undefined) return dynResult;
     }
-    if (funcIdx !== undefined) {
+    if ((funcIdx = directObjectMethodFuncIdx(ctx, expr, funcIdx)) !== undefined) {
       const isStaticMethod = receiverIsClassObject;
       // Static methods: evaluate receiver for side effects, drop, call directly
       if (isStaticMethod) {
@@ -1644,7 +1614,7 @@ export function compileReceiverMethodCall(
         const paramTypes = getFuncParamTypes(ctx, resolvedStaticIdx);
         const paramCount = paramTypes ? paramTypes.length : expr.arguments.length;
         const calleeReadsArgsStatic = ctx.funcUsesArguments.has(fullName);
-        const restInfoStatic = ctx.funcRestParams.get(fullName);
+        const restInfoStatic = knownMethodRestInfo(ctx, expr, fullName, paramTypes, 0);
         const handledRestStatic =
           restInfoStatic !== undefined && emitKnownRestMethodArguments(ctx, fctx, expr, paramTypes, restInfoStatic, 0);
         if (!handledRestStatic) {
@@ -1822,7 +1792,7 @@ export function compileReceiverMethodCall(
         // User-visible param count excludes self (param 0)
         const ngParamCount = paramTypes ? paramTypes.length - 1 : expr.arguments.length;
         const calleeReadsArgsNg = ctx.funcUsesArguments.has(fullName);
-        const restInfoNg = ctx.funcRestParams.get(fullName);
+        const restInfoNg = knownMethodRestInfo(ctx, expr, fullName, paramTypes, 1);
         const handledRestNg =
           restInfoNg !== undefined && emitKnownRestMethodArguments(ctx, fctx, expr, paramTypes, restInfoNg, 1);
         if (!handledRestNg) {
@@ -1889,7 +1859,7 @@ export function compileReceiverMethodCall(
       const paramTypes = getFuncParamTypes(ctx, funcIdx);
       const methodParamCount = paramTypes ? Math.max(0, paramTypes.length - 1) : expr.arguments.length;
       const calleeReadsArgsNn = ctx.funcUsesArguments.has(fullName);
-      const restInfoNn = ctx.funcRestParams.get(fullName);
+      const restInfoNn = knownMethodRestInfo(ctx, expr, fullName, paramTypes, 1);
       const handledRestNn =
         restInfoNn !== undefined && emitKnownRestMethodArguments(ctx, fctx, expr, paramTypes, restInfoNn, 1);
       if (!handledRestNn) {
@@ -1944,13 +1914,13 @@ export function compileReceiverMethodCall(
     if (structTypeName) {
       const methodName = propAccess.name.text;
       const fullName = `${structTypeName}_${methodName}`;
-      const funcIdx = ctx.funcMap.get(fullName);
+      let funcIdx = ctx.funcMap.get(fullName);
       // If no method found, check callable property on struct
       if (funcIdx === undefined) {
         const callablePropResult = compileCallablePropertyCall(ctx, fctx, expr, propAccess, structTypeName);
         if (callablePropResult !== undefined) return callablePropResult;
       }
-      if (funcIdx !== undefined) {
+      if ((funcIdx = directObjectMethodFuncIdx(ctx, expr, funcIdx)) !== undefined) {
         // Push self (the receiver) as first argument, with type hint from method's first param
         const structMethodPTypes = getFuncParamTypes(ctx, funcIdx);
         const recvType = compileExpression(ctx, fctx, propAccess.expression, structMethodPTypes?.[0]);
@@ -1987,7 +1957,7 @@ export function compileReceiverMethodCall(
           }
           const smMethodParamCount = paramTypes ? paramTypes.length - 1 : expr.arguments.length;
           const calleeReadsArgsSm = ctx.funcUsesArguments.has(fullName);
-          const restInfoSm = ctx.funcRestParams.get(fullName);
+          const restInfoSm = knownMethodRestInfo(ctx, expr, fullName, paramTypes, 1);
           const handledRestSm =
             restInfoSm !== undefined && emitKnownRestMethodArguments(ctx, fctx, expr, paramTypes, restInfoSm, 1);
           if (!handledRestSm) {
@@ -2050,7 +2020,7 @@ export function compileReceiverMethodCall(
         const paramTypes = getFuncParamTypes(ctx, funcIdx);
         const nnMethodParamCount = paramTypes ? paramTypes.length - 1 : expr.arguments.length;
         const calleeReadsArgsNns = ctx.funcUsesArguments.has(fullName);
-        const restInfoNns = ctx.funcRestParams.get(fullName);
+        const restInfoNns = knownMethodRestInfo(ctx, expr, fullName, paramTypes, 1);
         const handledRestNns =
           restInfoNns !== undefined && emitKnownRestMethodArguments(ctx, fctx, expr, paramTypes, restInfoNns, 1);
         if (!handledRestNns) {

--- a/src/codegen/expressions/object-method-rest-abi.ts
+++ b/src/codegen/expressions/object-method-rest-abi.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../../ts-api.js";
+import type { ValType } from "../../ir/types.js";
+import type { CodegenContext, FunctionContext, RestParamInfo } from "../context/types.js";
+import { getArrTypeIdxFromVec } from "../registry/types.js";
+import { skipTransparentExpressions } from "../shared.js";
+import { pushDefaultValue } from "../type-coercion.js";
+import { compileInternalCallArgument } from "./internal-call-argument.js";
+
+function objectLiteralMethodDeclaration(
+  ctx: CodegenContext,
+  expr: ts.CallExpression,
+): ts.MethodDeclaration | undefined {
+  const callee = skipTransparentExpressions(expr.expression);
+  if (!ts.isPropertyAccessExpression(callee)) return undefined;
+  let receiver = skipTransparentExpressions(callee.expression);
+  if (ts.isIdentifier(receiver)) {
+    const initializer = ctx.oracle.constInitializerOf(receiver);
+    if (initializer) receiver = skipTransparentExpressions(initializer);
+  }
+  if (!ts.isObjectLiteralExpression(receiver)) return undefined;
+  return receiver.properties.find(
+    (property): property is ts.MethodDeclaration =>
+      ts.isMethodDeclaration(property) &&
+      (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) || ts.isNumericLiteral(property.name)) &&
+      property.name.text === callee.name.text,
+  );
+}
+
+/**
+ * Decline the direct object-method arm when its source rest parameter binds a
+ * pattern (`m(...[x]) {}`). That method body has a fixed tuple formal, so
+ * padding an omitted argument with a null ref traps before parameter setup.
+ * The generic closed dispatcher performs the required rest initialization.
+ */
+export function directObjectMethodFuncIdx(
+  ctx: CodegenContext,
+  expr: ts.CallExpression,
+  funcIdx: number | undefined,
+): number | undefined {
+  if (funcIdx === undefined) return undefined;
+  const declaration = objectLiteralMethodDeclaration(ctx, expr);
+  const hasRestBinding = declaration?.parameters.some(
+    (parameter) =>
+      parameter.dotDotDotToken !== undefined &&
+      (ts.isArrayBindingPattern(parameter.name) || ts.isObjectBindingPattern(parameter.name)),
+  );
+  return hasRestBinding ? undefined : funcIdx;
+}
+
+/**
+ * Object-literal lowering does not publish `funcRestParams`. Recover the
+ * already-materialized vec ABI for an identifier rest parameter only; binding
+ * patterns use the tuple ABI and are deliberately left to generic dispatch.
+ */
+export function knownMethodRestInfo(
+  ctx: CodegenContext,
+  expr: ts.CallExpression,
+  fullName: string,
+  paramTypes: ValType[] | undefined,
+  selfOffset: number,
+): RestParamInfo | undefined {
+  const registered = ctx.funcRestParams.get(fullName);
+  if (registered) return registered;
+  const declaration = objectLiteralMethodDeclaration(ctx, expr);
+  const restIndex = declaration?.parameters.findIndex(
+    (parameter) => parameter.dotDotDotToken !== undefined && ts.isIdentifier(parameter.name),
+  );
+  if (restIndex === undefined || restIndex < 0) return undefined;
+  const restType = paramTypes?.[selfOffset + restIndex];
+  if (!restType || (restType.kind !== "ref" && restType.kind !== "ref_null")) return undefined;
+  const vecTypeIdx = restType.typeIdx;
+  const arrayTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrayTypeIdx < 0) return undefined;
+  const arrayType = ctx.mod.types[arrayTypeIdx];
+  if (!arrayType || arrayType.kind !== "array") return undefined;
+  return { restIndex, elemType: arrayType.element, arrayTypeIdx, vecTypeIdx };
+}
+
+/** Materialize the hidden vec argument for a known JavaScript rest method. */
+export function emitKnownRestMethodArguments(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  paramTypes: ValType[] | undefined,
+  restInfo: RestParamInfo,
+  selfOffset: number,
+): boolean {
+  if (expr.arguments.some((argument) => ts.isSpreadElement(argument))) return false;
+  const fixedCount = restInfo.restIndex;
+  for (let index = 0; index < fixedCount; index++) {
+    if (index < expr.arguments.length) {
+      compileInternalCallArgument(ctx, fctx, expr.arguments[index]!, paramTypes?.[selfOffset + index]);
+    } else {
+      pushDefaultValue(fctx, paramTypes?.[selfOffset + index] ?? { kind: "f64" }, ctx);
+    }
+  }
+  const restCount = Math.max(0, expr.arguments.length - fixedCount);
+  fctx.body.push({ op: "i32.const", value: restCount });
+  for (let index = fixedCount; index < expr.arguments.length; index++) {
+    compileInternalCallArgument(ctx, fctx, expr.arguments[index]!, restInfo.elemType);
+  }
+  fctx.body.push({ op: "array.new_fixed", typeIdx: restInfo.arrayTypeIdx, length: restCount });
+  fctx.body.push({ op: "struct.new", typeIdx: restInfo.vecTypeIdx });
+  return true;
+}

--- a/tests/issue-4576-standalone-dom-builtins.test.ts
+++ b/tests/issue-4576-standalone-dom-builtins.test.ts
@@ -7,7 +7,10 @@
 // four source owners compile once through IR and preserve the direct backend's
 // value, security, and optimization envelope.
 
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
 
 import { describe, expect, it } from "vitest";
@@ -25,6 +28,22 @@ pinPerfFlags({ JS2WASM_IR_INLINE: "0" });
 const SOURCE = readFileSync(new URL("../website/playground/examples/js/builtins.ts", import.meta.url), "utf8");
 const FILE_NAME = "website/playground/examples/js/builtins.ts";
 const TERMINALS = ["el", "crd", "rw", "main"] as const;
+
+const TEST262_OBJECT_REST_BINDING_CASES = [
+  {
+    relative: "language/expressions/object/scope-meth-param-rest-elem-var-close.js",
+    sha256: "0c1c9f35c1996f58af69f8e4ea587c210f7df6686dd4a12acb0cadd28488f167",
+    expectedStatus: "pass",
+    expectedError: undefined,
+  },
+  {
+    relative: "language/expressions/object/scope-meth-param-rest-elem-var-open.js",
+    sha256: "0fc352e5f3674c6e8add9928590777f3b62a4ea2e2270a254a73d6dad64e5e87",
+    expectedStatus: "fail",
+    expectedError:
+      'Test262Error: Expected SameValue(«"outside"», «"inside"») to be true | at L28: assert.sameValue(probe1(), \'inside\');',
+  },
+] as const;
 
 const DOM_IMPORTS = [
   "global_document",
@@ -480,6 +499,95 @@ function unsupportedCounts(outcomes: readonly IrObservedOutcome[]): Record<strin
   }
   return result;
 }
+
+async function runRestBindingFixtureAtShippedDefaults(filePath: string) {
+  // Run the exact shipped configuration in an isolated process. Besides
+  // avoiding mutation of this file's inline-off shape environment, the child
+  // pins the exnref engine flag required by the assembled Test262 harness even
+  // when an ordinary changed-root hook launches Vitest without that flag.
+  const childEnv = { ...process.env };
+  Reflect.deleteProperty(childEnv, "JS2WASM_IR_INLINE");
+  childEnv.JS2WASM_TEST262_FIXTURE = filePath;
+  childEnv.JS2WASM_TEST262_RUNNER = new URL("./test262-runner.ts", import.meta.url).href;
+  const marker = "__JS2WASM_TEST262_RESULT__";
+  const stdout = execFileSync(
+    process.execPath,
+    [
+      "--experimental-wasm-exnref",
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      `
+        const { runTest262File } = await import(process.env.JS2WASM_TEST262_RUNNER);
+        const result = await runTest262File(
+          process.env.JS2WASM_TEST262_FIXTURE,
+          "issue-4576-object-rest-binding",
+          120_000,
+          "standalone",
+        );
+        process.stdout.write(${JSON.stringify(marker)} + JSON.stringify(result));
+      `,
+    ],
+    { cwd: process.cwd(), encoding: "utf8", env: childEnv, maxBuffer: 4 * 1024 * 1024 },
+  );
+  const markerIndex = stdout.lastIndexOf(marker);
+  expect(markerIndex, "missing isolated Test262 verdict marker").toBeGreaterThanOrEqual(0);
+  return JSON.parse(stdout.slice(markerIndex + marker.length)) as {
+    status: string;
+    error?: string;
+    reason?: string;
+  };
+}
+
+describe("#4576 standalone Test262 object-rest regression matrix", () => {
+  for (const fixture of TEST262_OBJECT_REST_BINDING_CASES) {
+    it(`runs the exact ${fixture.relative} source and preserves its pre-merge verdict`, async () => {
+      const filePath = fileURLToPath(new URL(`../test262/test/${fixture.relative}`, import.meta.url));
+      const source = readFileSync(filePath, "utf8");
+      expect(
+        createHash("sha256").update(source).digest("hex"),
+        `${fixture.relative} exact Test262 source revision`,
+      ).toBe(fixture.sha256);
+
+      const result = await runRestBindingFixtureAtShippedDefaults(filePath);
+      expect(result.status, result.error ?? result.reason ?? "missing Test262 verdict detail").toBe(
+        fixture.expectedStatus,
+      );
+      expect(result.error).toBe(fixture.expectedError);
+    }, 180_000);
+  }
+
+  it("keeps an ordinary identifier-rest object method on the direct-call path", async () => {
+    const result = await compile(
+      `
+        export function ordinaryRestDirectCall(): number {
+          const receiver = {
+            total(head: number, ...tail: number[]): number {
+              return head + tail[0] + tail.length;
+            },
+          };
+          return receiver.total(40, 1);
+        }
+      `,
+      {
+        fileName: "issue-4576-ordinary-object-rest-direct-control.ts",
+        target: "standalone",
+        experimentalIR: false,
+        emitWat: true,
+      },
+    );
+    expectSuccess(result);
+    expect(watCallTargets(result.wat, watFunction(result, "ordinaryRestDirectCall"))).toEqual(
+      expect.arrayContaining([expect.stringMatching(/_total$/)]),
+    );
+
+    const imports = buildCompiledImports(result);
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    imports.setInstance?.(instance);
+    expect((instance.exports.ordinaryRestDirectCall as () => number)()).toBe(42);
+  });
+});
 
 describe("#4576 standalone DOM Builtins ownership", () => {
   it("ratchets the five-entry standalone census from 27/10 to 31/6, leaving exactly Calendar", async () => {


### PR DESCRIPTION
## Summary
- decline the closed-struct direct-call arm for object methods whose rest formal is a binding pattern
- let the generic dispatcher perform the required tuple/rest initialization instead of emitting a guaranteed null vector dereference
- recover vector ABI metadata for ordinary identifier rest parameters so those object methods remain direct

## Regression coverage
- hash-pin and execute `scope-meth-param-rest-elem-var-close.js`; it passes again
- hash-pin and execute `scope-meth-param-rest-elem-var-open.js`; it returns to the exact pre-regression assertion failure rather than null-dereferencing
- retain a WAT/runtime control proving ordinary identifier rest remains a direct call

Addresses the regression reported in https://github.com/loopdive/js2/pull/4663#issuecomment-5360874330

## Validation
- focused #4576 suite: 17/17
- TypeScript typecheck
- Prettier and Biome lint
- LOC, function-size, and oracle ratchets
- full pre-push gate