### PR TITLE
fix(devcontainer): make init-firewall.sh apply and survive re-runs

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -14,6 +14,19 @@ iptables -t mangle -F
 iptables -t mangle -X
 ipset destroy allowed-domains 2>/dev/null || true
 
+# Reset chain POLICIES to ACCEPT. `iptables -F` clears the RULES but NOT the
+# chain policy, and this script is re-run on every container start/attach via
+# postStartCommand. On a re-run the policies set at the bottom of this file are
+# still DROP while every ACCEPT rule has just been flushed away -- a total
+# blackout. Everything below would then fail starting with the GitHub-meta
+# fetch, and `set -e` would abort, leaving the container with DROP policies and
+# no rules at all (no network until it is recreated). Restoring ACCEPT here lets
+# the script reach the network it needs to rebuild the allowlist; the DROP
+# policies are re-applied further down once the allowlist is populated.
+iptables -P INPUT ACCEPT
+iptables -P FORWARD ACCEPT
+iptables -P OUTPUT ACCEPT
+
 # 2. Selectively restore ONLY internal Docker DNS resolution
 if [ -n "$DOCKER_DNS_RULES" ]; then
     echo "Restoring Docker DNS rules..."
@@ -63,10 +76,19 @@ while read -r cidr; do
         exit 1
     fi
     echo "Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
-# Resolve and add other allowed domains
+# Resolve and add other allowed domains.
+#
+# A domain that no longer resolves must NOT abort the whole script: third-party
+# hostnames get retired (statsig.anthropic.com lost its A record and silently
+# broke every run of this file), and killing the firewall setup over one dead
+# hostname is far worse than leaving that one hostname unreachable. Only the
+# domains this container genuinely cannot work without are fatal.
+REQUIRED_DOMAINS="api.anthropic.com registry.npmjs.org"
+unresolved=""
+
 for domain in \
     "registry.npmjs.org" \
     "api.anthropic.com" \
@@ -81,8 +103,15 @@ for domain in \
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
-        echo "ERROR: Failed to resolve $domain"
-        exit 1
+        case " $REQUIRED_DOMAINS " in
+            *" $domain "*)
+                echo "ERROR: Failed to resolve REQUIRED domain $domain"
+                exit 1
+                ;;
+        esac
+        echo "WARNING: Failed to resolve $domain - skipping (not required)"
+        unresolved="$unresolved $domain"
+        continue
     fi
     
     while read -r ip; do
@@ -91,9 +120,13 @@ for domain in \
             exit 1
         fi
         echo "Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
+
+if [ -n "$unresolved" ]; then
+    echo "NOTE: the following domains did not resolve and are NOT allowlisted:$unresolved"
+fi
 
 # Get host IP from default route
 HOST_IP=$(ip route | grep default | cut -d" " -f3)


### PR DESCRIPTION
## What was broken

`init-firewall.sh` aborted before it ever reached its `DROP` policies, so the dev container ran with **no egress restriction at all** while looking perfectly healthy. Found while diagnosing a live outage in which the container had lost its network entirely.

Three independent faults, each fatal under `set -euo pipefail`:

| # | Fault | Trigger |
|---|-------|---------|
| 1 | Chain policies never reset after the flush | A re-run while `DROP` was live |
| 2 | `ipset add` without `-exist` | `auth.openai.com` returns a duplicate A record |
| 3 | Unresolvable domain is fatal | `statsig.anthropic.com` lost its A record upstream |

**Why it stayed invisible:** faults 2 and 3 abort *before* the `DROP` policies are set, so the container kept working — just unfirewalled — and nobody reads `postStartCommand` output on a box that appears fine.

**Why fault 1 is the dangerous one:** `iptables -F` clears rules but not chain *policy*, and `postStartCommand` re-runs this script on every container start/attach. On a re-run the policies from the bottom of the file are still `DROP` while every `ACCEPT` rule has just been flushed away — the GitHub-meta fetch then fails, `set -e` aborts, and the container is left with `DROP` policies and zero rules: no network at all until it is recreated. It was masked by faults 2 and 3 (which kept `DROP` from ever being live) and would have fired on the first successful run after they were fixed.

## Comparison with the upstream reference

All three faults are inherited from [`anthropics/claude-code` `.devcontainer/init-firewall.sh`](https://github.com/anthropics/claude-code/blob/main/.devcontainer/init-firewall.sh), which **still has all three today** — verified against the current `main` copy of that file. None were introduced by a commit here; this file has never been edited in the available history.

The one locally-introduced element is the domain list: upstream allowlists `statsig.com`, while this repo added `statsig.anthropic.com` (now dead), plus `api.openai.com` / `auth.openai.com` for Codex. So the *trigger* is local, the *fatal-on-unresolved behavior* is upstream's.

The docs note the firewall is "provided as a working example rather than a maintained base image", which is consistent with what we found.

## Verification

Run in the live dev container:

- Three consecutive runs, **exit 0** each time — fault 1's regression case, which previously blacked out the container.
- Both built-in verifications pass: `example.com` blocked, `api.github.com` reachable.
- 81 allowlist entries; `DROP` policies confirmed active on all three chains.
- `claude -p` reaches the API from inside the container.
- `bash -n` clean.

## Follow-up, deliberately not in this PR

Enforcement is now real for the first time in a while, which exposes an allowlist gap against the documented [network access requirements](https://code.claude.com/docs/en/network-config#network-access-requirements):

- **Hard-blocked now:** `downloads.claude.ai` (plugin installs, native updater) and `storage.googleapis.com` (plugin metadata, artifact uploads).
- **Reachable only by accident:** `claude.ai`, `platform.claude.com` (OAuth token refresh), `mcp-proxy.anthropic.com` (claude.ai MCP connectors) and `code.claude.com` all currently resolve to `160.79.104.10` — the same IP as the allowlisted `api.anthropic.com`. They are not allowlisted by name, so if Anthropic splits those hosts onto different IPs, auth refresh and MCP connectors break with no config change here.

Widening egress is a security decision, so it is left for a separate, deliberate change rather than bundled into a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
