### PR TITLE
fix(#4585): restore npm compatibility refresh publication

### DIFF
--- a/plan/issues/4585-npm-compat-refresh-resilience.md
+++ b/plan/issues/4585-npm-compat-refresh-resilience.md
@@ -1,0 +1,84 @@
+---
+id: 4585
+title: "Restore npm compatibility refresh publication"
+status: in-progress
+created: 2026-08-21
+updated: 2026-08-21
+priority: critical
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen, npm-compat, dogfood
+goal: correctness
+sprint: current
+depends_on: [4577, 4578]
+assignee: ttraenkler/codex
+horizon: s
+related: [3781, 3958, 3982, 4130]
+origin: "The live npm dashboard retained its pre-#4578 Acorn/clsx snapshot because both post-fix aggregate refreshes aborted before publication."
+files:
+  - src/codegen/ambient-parse-import.ts
+  - src/codegen/extern-declarations.ts
+  - tests/dogfood/react-dom-upstream-suite.mjs
+  - tests/dogfood/react-dom-upstream-suite.test.ts
+  - tests/issue-4585-npm-compat-refresh-resilience.test.ts
+  - plan/issues/4585-npm-compat-refresh-resilience.md
+---
+
+# #4585 — restore npm compatibility refresh publication
+
+## Problem
+
+The public npm compatibility page still shows the Acorn and clsx regression
+that #4578 fixed. The page itself is current, but its committed aggregate is
+from before the fix because two later refreshes aborted before writing their
+artifacts:
+
+- Acorn projected the same ambient `env.parseInt` slot twice when legacy and
+  prepared IR consumers shared the global.
+- ReactDOM's production oracle admitted upstream tests which call the
+  development-only `React.captureOwnerStack` API; a late callback threw outside
+  the awaited test body and terminated the aggregate process.
+
+## Scope
+
+- Preserve the compiler's exact ambient `parseInt`/`parseFloat` import identity
+  when the TypeScript library declaration is registered.
+- Keep duplicate serialized adapter bindings fail-closed; do not weaken the
+  runtime manifest validator.
+- Reject exact `React.captureOwnerStack()` call sites before a production
+  ReactDOM run, report the reason, and retain them in development runs.
+- Regenerate and publish the complete npm compatibility aggregate only after
+  every package finishes and the fixed Acorn/clsx measurements are present.
+
+## Acceptance criteria
+
+- [x] The Acorn parse shape emits one physical and one projected
+      `env.parseInt` binding, builds `importObject`, instantiates, and executes.
+- [x] A caller-mutated manifest containing a duplicate binding remains rejected.
+- [x] Production ReactDOM filtering is AST-based, ignores text-only near misses,
+      records an explicit reason, and leaves the development corpus unchanged.
+- [x] The pinned Acorn dogfood suite completes without the adapter-manifest
+      exception.
+- [ ] A fresh aggregate refresh completes and the live page serves a post-#4578
+      timestamp and corrected Acorn/clsx measurements.
+
+## Non-goals
+
+- Hiding a regression by changing benchmark baselines or historic result rows.
+- Treating development React artifacts as the production npm package.
+- Weakening manifest ownership or duplicate-import validation.
+
+## Checkpoint evidence
+
+- Syntactic and checker lib scanners both emit exactly one physical and one
+  projected `env.parseInt` binding for the reduced Acorn shape; it instantiates
+  and returns `30`. The forged duplicate remains rejected.
+- The pinned Acorn suite completes with `3494/3518` passing and no manifest
+  exception.
+- The pinned ReactDOM corpus records `78` production-incompatible call sites:
+  `1923` admitted + `80` rejected = all `2003` upstream tests. Development
+  retains all `2001` non-skipped tests.
+- Focused parse/standalone tests pass `16/16`; ReactDOM infrastructure passes
+  `5/5` with its heavy suite deliberately skipped. Typecheck, formatting, lint,
+  LOC/function/oracle/dead-export, IR-fallback, and issue gates pass.

--- a/src/codegen/ambient-parse-import.ts
+++ b/src/codegen/ambient-parse-import.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+import { addImport } from "./registry/imports.js";
+
+/** Register an ambient parse import and preserve its compiler-owned identity. */
+export function registerAmbientParseImport(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  name: string,
+  typeIdx: number,
+): void {
+  const imported = addImport(ctx, ctx.externImportModule ?? "env", name, { kind: "func", typeIdx });
+  // Prepared IR parse calls must reuse this exact default-library slot.
+  // Without the sidecar, collectParseImports mistakes it for a source shadow
+  // and emits a duplicate adapter binding (#4585). Both the syntactic and
+  // checker lib scanners retain SourceFile's no-default-lib provenance.
+  if (
+    !imported ||
+    !sourceFile.isDeclarationFile ||
+    !sourceFile.hasNoDefaultLib ||
+    (name !== "parseInt" && name !== "parseFloat")
+  ) {
+    return;
+  }
+  const builtinIdx = ctx.funcMap.get(name);
+  if (builtinIdx !== undefined) ctx.ambientBuiltinFuncMap.set(name, builtinIdx);
+}

--- a/src/codegen/extern-declarations.ts
+++ b/src/codegen/extern-declarations.ts
@@ -20,6 +20,7 @@ import { brandExternMethodResult } from "./shared.js";
 import { ensureNativeStringHelpers } from "./native-strings.js";
 import { nativeTypeFromTypeNode } from "./native-type-annotations.js";
 import { reportError } from "./context/errors.js";
+import { registerAmbientParseImport } from "./ambient-parse-import.js";
 import {
   heritageBaseName,
   isExternDeclaredLibName,
@@ -31,7 +32,6 @@ import {
   typeRefName,
   type LibDeclIndex,
 } from "./lib-decl-index.js";
-
 // ── Built-in extern class registration ───────────────────────────────
 
 /** Helper to create an extern method signature with externref params and results */
@@ -767,7 +767,7 @@ export function collectExternDeclarations(
             ? []
             : [nativeOf(stmt.type) ?? mapLibTypeNodeToWasm(stmt.type, libIndex, scope)];
           const typeIdx = addFuncType(ctx, params, results);
-          addImport(ctx, ctx.externImportModule ?? "env", name, { kind: "func", typeIdx });
+          registerAmbientParseImport(ctx, sourceFile, name, typeIdx);
         } else {
           const sig = ctx.checker.getSignatureFromDeclaration(stmt);
           if (sig) {
@@ -782,7 +782,7 @@ export function collectExternDeclarations(
             // (#4238) `externImportModule` retargets extern declarations at a
             // wasm-to-wasm provider namespace (`js2wasm:qjs`) instead of the
             // `env` JS-host module. Unset for every user compile.
-            addImport(ctx, ctx.externImportModule ?? "env", name, { kind: "func", typeIdx });
+            registerAmbientParseImport(ctx, sourceFile, name, typeIdx);
           }
         }
       }

--- a/tests/dogfood/react-dom-upstream-suite.mjs
+++ b/tests/dogfood/react-dom-upstream-suite.mjs
@@ -52,6 +52,48 @@ export function isExpectedLateJsdomHostError(error) {
   return error?.name === "NotFoundError" && error?.message === "The node to be removed is not a child of this node.";
 }
 
+function callsDevelopmentOnlyReactApi(test) {
+  const sourceFile = ts.createSourceFile(
+    test.file ?? "react-dom-upstream-test.js",
+    `${test.prelude ?? ""}\n${test.body ?? ""}`,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS,
+  );
+  let found = false;
+  const visit = (node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === "React" &&
+      node.expression.name.text === "captureOwnerStack"
+    ) {
+      found = true;
+      return;
+    }
+    if (!found) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/** Keep production reports honest when an upstream test calls a dev-only React API. */
+export function partitionReactDomTestsForBuild(tests, build) {
+  if (build === "development") return { tests: [...tests], rejected: [] };
+  const runnable = [];
+  const rejected = [];
+  for (const test of tests) {
+    if (!callsDevelopmentOnlyReactApi(test)) {
+      runnable.push(test);
+      continue;
+    }
+    const { prelude: _prelude, body: _body, ...identity } = test;
+    rejected.push({ ...identity, reason: "requires-development-react-api" });
+  }
+  return { tests: runnable, rejected };
+}
+
 function installNativeHostErrorBoundary(nativeHostErrors) {
   const onUncaught = (error) => {
     if (!isExpectedLateJsdomHostError(error)) {
@@ -1038,6 +1080,13 @@ export async function runHarness({ quiet = false } = {}) {
       "needs-external-module",
     ]),
   });
+  const buildCompatible = partitionReactDomTestsForBuild(extracted.tests, build);
+  const admittedTests = buildCompatible.tests;
+  const rejectedTests = [...extracted.rejected, ...buildCompatible.rejected];
+  const rejectionCounts = { ...extracted.rejectionCounts };
+  for (const rejected of buildCompatible.rejected) {
+    rejectionCounts[rejected.reason] = (rejectionCounts[rejected.reason] ?? 0) + 1;
+  }
   // The browser server renderer is a separate published CJS graph. Keep those
   // original tests in the admitted corpus, but route them to their own module
   // lane instead of including the graph in the client module.
@@ -1049,14 +1098,14 @@ export async function runHarness({ quiet = false } = {}) {
   // routed independently rather than silently exercising the client module.
   const hasClientRendererCall = (body) =>
     /\b(?:ReactDOMClient|ReactDOM\.(?:render|createRoot|hydrate|flushSync)|createRoot\s*\()/.test(body);
-  const serverTests = extracted.tests.filter(
+  const serverTests = admittedTests.filter(
     (test) =>
       /\bReactDOMServer\.(?:renderToString|renderToStaticMarkup)\b/.test(test.body) &&
       !hasClientRendererCall(test.body),
   );
   const serverIds = new Set(serverTests.map((test) => test.id));
   const browserFizzFile = /ReactDOMFizz(?:ServerBrowser|StaticBrowser|StaticFloat)-test\.js$/;
-  const fizzTests = extracted.tests.filter(
+  const fizzTests = admittedTests.filter(
     (test) =>
       !serverIds.has(test.id) &&
       browserFizzFile.test(test.file) &&
@@ -1065,7 +1114,7 @@ export async function runHarness({ quiet = false } = {}) {
   );
   const fizzIds = new Set(fizzTests.map((test) => test.id));
   const nodeFizzFile = /ReactDOMFizz(?:ServerNode|StaticNode)-test\.js$/;
-  const nodeFizzTests = extracted.tests.filter(
+  const nodeFizzTests = admittedTests.filter(
     (test) =>
       !serverIds.has(test.id) &&
       !fizzIds.has(test.id) &&
@@ -1074,7 +1123,7 @@ export async function runHarness({ quiet = false } = {}) {
   );
   const nodeFizzIds = new Set(nodeFizzTests.map((test) => test.id));
   const edgeFizzFile = /ReactDOMFizzServerEdge-test\.js$/;
-  const edgeFizzTests = extracted.tests.filter(
+  const edgeFizzTests = admittedTests.filter(
     (test) =>
       !serverIds.has(test.id) &&
       !fizzIds.has(test.id) &&
@@ -1083,16 +1132,16 @@ export async function runHarness({ quiet = false } = {}) {
       /\bReactDOMFizzServer\b/.test(test.body),
   );
   const edgeFizzIds = new Set(edgeFizzTests.map((test) => test.id));
-  const clientTests = extracted.tests.filter(
+  const clientTests = admittedTests.filter(
     (test) =>
       !serverIds.has(test.id) && !fizzIds.has(test.id) && !nodeFizzIds.has(test.id) && !edgeFizzIds.has(test.id),
   );
   report.extraction = {
-    upstreamTestsSeen: extracted.tests.length + extracted.rejected.length,
-    admitted: extracted.tests.length,
-    rejected: extracted.rejected.length,
-    rejectionCounts: extracted.rejectionCounts,
-    rejectedTests: extracted.rejected,
+    upstreamTestsSeen: admittedTests.length + rejectedTests.length,
+    admitted: admittedTests.length,
+    rejected: rejectedTests.length,
+    rejectionCounts,
+    rejectedTests,
     clientAdmitted: clientTests.length,
     serverAdmitted: serverTests.length,
     fizzAdmitted: fizzTests.length,
@@ -1112,7 +1161,7 @@ export async function runHarness({ quiet = false } = {}) {
     Number(process.env.DOGFOOD_REACT_DOM_EDGE_FIZZ_TEST_LIMIT ?? 0) || edgeFizzTests.length;
   log(
     `[dogfood] react-dom@${implementationPin.version} upstream @ ${suitePin.tag}: ` +
-      `${extracted.tests.length} of ${extracted.tests.length + extracted.rejected.length} upstream tests admitted ` +
+      `${admittedTests.length} of ${admittedTests.length + rejectedTests.length} upstream tests admitted ` +
       `(${clientTests.length} client, ${serverTests.length} legacy server, ${fizzTests.length} browser Fizz, ` +
       `${nodeFizzTests.length} node Fizz, ${edgeFizzTests.length} edge Fizz)`,
   );

--- a/tests/dogfood/react-dom-upstream-suite.test.ts
+++ b/tests/dogfood/react-dom-upstream-suite.test.ts
@@ -9,7 +9,7 @@ import { loadReactDomUpstreamSuitePin, setupReactDomImplementation } from "./set
 // @ts-expect-error — .mjs dogfood setup has no declaration file
 import { loadReactUpstreamSuitePin } from "./setup-react-upstream-suite.mjs";
 // @ts-expect-error — .mjs dogfood harness has no declaration file
-import { isExpectedLateJsdomHostError } from "./react-dom-upstream-suite.mjs";
+import { isExpectedLateJsdomHostError, partitionReactDomTestsForBuild } from "./react-dom-upstream-suite.mjs";
 // @ts-expect-error — .mjs dogfood extractor has no declaration file
 import { extractReactUpstreamTests } from "./react-upstream-extract.mjs";
 
@@ -29,6 +29,39 @@ describe("react-dom upstream suite", () => {
     expect(isExpectedLateJsdomHostError(expected)).toBe(true);
     expect(isExpectedLateJsdomHostError({ ...expected, message: "different DOM failure" })).toBe(false);
     expect(isExpectedLateJsdomHostError({ name: "TypeError", message: expected.message })).toBe(false);
+  });
+
+  it("rejects exact development-only React API calls before a production run", () => {
+    const ordinary = {
+      id: "ordinary",
+      file: "ordinary.js",
+      fullName: "ordinary",
+      prelude: 'const note = "React.captureOwnerStack()";',
+      body: "React.createElement('div');",
+    };
+    const developmentOnly = {
+      id: "owner-stack",
+      file: "ReactDOMHydrationDiff-test.js",
+      fullName: "owner stack",
+      prelude: "console.error = () => React.captureOwnerStack();",
+      body: "render();",
+    };
+
+    expect(partitionReactDomTestsForBuild([ordinary, developmentOnly], "production")).toEqual({
+      tests: [ordinary],
+      rejected: [
+        {
+          id: "owner-stack",
+          file: "ReactDOMHydrationDiff-test.js",
+          fullName: "owner stack",
+          reason: "requires-development-react-api",
+        },
+      ],
+    });
+    expect(partitionReactDomTestsForBuild([ordinary, developmentOnly], "development")).toEqual({
+      tests: [ordinary, developmentOnly],
+      rejected: [],
+    });
   });
 
   it("shares one verified revision with the react suite", () => {
@@ -93,6 +126,17 @@ describe("react-dom upstream suite", () => {
     expect(extracted.tests.length + extracted.rejected.length).toBe(2003);
     expect(extracted.tests.length).toBe(2001);
     expect(extracted.rejectionCounts).toEqual({ "upstream-skipped": 2 });
+
+    const production = partitionReactDomTestsForBuild(extracted.tests, "production");
+    expect(production.tests).toHaveLength(1923);
+    expect(production.rejected).toHaveLength(78);
+    expect(
+      production.rejected.every(({ reason }: { reason: string }) => reason === "requires-development-react-api"),
+    ).toBe(true);
+    expect(partitionReactDomTestsForBuild(extracted.tests, "development")).toEqual({
+      tests: extracted.tests,
+      rejected: [],
+    });
   });
 
   const heavy = process.env.DOGFOOD_REACT_DOM_UPSTREAM === "1" ? it : it.skip;

--- a/tests/issue-4585-npm-compat-refresh-resilience.test.ts
+++ b/tests/issue-4585-npm-compat-refresh-resilience.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, validateJavaScriptAdapterManifest, type JavaScriptAdapterManifestV1 } from "../src/index.js";
+
+const ACORN_PARSE_SHAPE = `
+  var pp = {};
+  function stringToNumber(str, legacy) {
+    if (legacy) return parseInt(str, 8);
+    return parseFloat(str.replace(/_/g, ""));
+  }
+  pp.read = function (str) { return parseInt(str, 8); };
+  export function run(str) {
+    return stringToNumber(str, true) + pp.read(str);
+  }
+`;
+
+describe("#4585 npm compatibility refresh resilience", () => {
+  it("reuses the ambient parseInt slot across legacy and prepared IR consumers", async () => {
+    const previous = process.env.JS2WASM_LIB_SCAN;
+    try {
+      for (const scanner of [undefined, "checker"] as const) {
+        if (scanner === undefined) Reflect.deleteProperty(process.env, "JS2WASM_LIB_SCAN");
+        else process.env.JS2WASM_LIB_SCAN = scanner;
+        const result = await compile(ACORN_PARSE_SHAPE, {
+          fileName: "acorn-parse-shape.mjs",
+          skipSemanticDiagnostics: true,
+        });
+        expect(result.success, result.errors.map(({ message }) => message).join("\n")).toBe(true);
+        expect(WebAssembly.validate(result.binary)).toBe(true);
+
+        const physical = WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).filter(
+          ({ module, name, kind }) => module === "env" && name === "parseInt" && kind === "function",
+        );
+        expect(physical, scanner ?? "syntactic").toHaveLength(1);
+
+        const manifest = result.adapterManifest!;
+        const projected = manifest.imports.filter(
+          ({ module, name, kind }) => module === "env" && name === "parseInt" && kind === "func",
+        );
+        expect(projected, scanner ?? "syntactic").toHaveLength(1);
+
+        const imports = result.importObject!;
+        const { instance } = await WebAssembly.instantiate(result.binary, imports);
+        imports.__setInstance?.(instance);
+        expect((instance.exports.run as (value: string) => number)("17")).toBe(30);
+
+        const forged = {
+          ...manifest,
+          imports: [...manifest.imports, projected[0]!],
+        } as JavaScriptAdapterManifestV1;
+        expect(validateJavaScriptAdapterManifest(forged)).toContain(
+          "duplicate adapter import 'env::parseInt' appears 2 times",
+        );
+      }
+    } finally {
+      if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_LIB_SCAN");
+      else process.env.JS2WASM_LIB_SCAN = previous;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- preserve the default-library `parseInt`/`parseFloat` import identity across legacy and prepared IR consumers
- keep duplicate adapter manifests fail-closed while eliminating Acorn’s duplicate producer slot
- reject exact development-only `React.captureOwnerStack()` calls before production ReactDOM execution, with complete corpus accounting
- unblock the post-#4578 npm compatibility aggregate refresh

## Verification

- focused #4585 + standalone parse suites: 16/16
- ReactDOM infrastructure: 5/5 (heavy suite skipped)
- pinned Acorn official suite: 3494/3518, no adapter-manifest exception
- TypeScript 7 typecheck, lint, Prettier, LOC/function/oracle/dead-export, IR fallback, issue integrity
- independent read-only review across syntactic/checker scans, single/multi-source, standalone, and user-shadow controls

The ordinary merge-to-main path triggers the full npm-compat refresh and promotion PR; the live-publication acceptance remains intentionally open until that artifact lands.