### PR TITLE
fix(#4585): verify npm benchmark optimization receipts

### DIFF
--- a/plan/issues/4585-npm-compat-refresh-resilience.md
+++ b/plan/issues/4585-npm-compat-refresh-resilience.md
@@ -17,10 +17,13 @@ horizon: s
 related: [3781, 3958, 3982, 4130]
 origin: "The live npm dashboard retained its pre-#4578 Acorn/clsx snapshot because both post-fix aggregate refreshes aborted before publication."
 files:
+  - scripts/generate-npm-compat-report.mjs
+  - scripts/lib/npm-compat-perf.mjs
   - src/codegen/ambient-parse-import.ts
   - src/codegen/extern-declarations.ts
   - tests/dogfood/react-dom-upstream-suite.mjs
   - tests/dogfood/react-dom-upstream-suite.test.ts
+  - tests/issue-3781-npm-perf-lanes.test.ts
   - tests/issue-4585-npm-compat-refresh-resilience.test.ts
   - plan/issues/4585-npm-compat-refresh-resilience.md
 ---
@@ -48,6 +51,8 @@ artifacts:
   runtime manifest validator.
 - Reject exact `React.captureOwnerStack()` call sites before a production
   ReactDOM run, report the reason, and retain them in development runs.
+- Compile standalone performance lanes at verified O3 while Binaryen's
+  `Flatten` pass cannot handle `try_table`, and record each lane's level.
 - Regenerate and publish the complete npm compatibility aggregate only after
   every package finishes and the fixed Acorn/clsx measurements are present.
 
@@ -60,8 +65,17 @@ artifacts:
       records an explicit reason, and leaves the development corpus unchanged.
 - [x] The pinned Acorn dogfood suite completes without the adapter-manifest
       exception.
+- [x] JS-host rows record O4 and standalone rows record verified O3; no
+      `try_table`/`Flatten` raw fallback is presented as a comparable O4 row.
 - [ ] A fresh aggregate refresh completes and the live page serves a post-#4578
       timestamp and corrected Acorn/clsx measurements.
+
+Checkpoint: the exact standalone-dynamic clsx 2.1.1 lane at O3 measured
+0.149035 µs/op versus Node's 0.023225 µs/op (ratio 0.155833), with checksum
+14/14 and an explicit verified-O3 receipt. The stale public row is 0.000122.
+The exact Node 25 Acorn 8.16.0 lane measured 57,331.486 µs/op versus Node's
+4,012.257 µs/op (ratio 0.069983), checksum 422/422, and a verified 2,132,904-byte
+O3 artifact; the stale public ratio is 0.000838.
 
 ## Non-goals
 

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -88,6 +88,7 @@ import {
   measureStandalonePerf,
   mergeNpmPerfHistory,
   npmPerfHistoryPoint,
+  npmPerfOptimizationFailure,
   npmPerfRows,
   packagePerfRecord,
   skippedPerfLane,
@@ -243,6 +244,9 @@ if (profileRuntime && !profileOutputPath) {
 if (!Number.isSafeInteger(profileIterations) || profileIterations < 1) {
   throw new Error("--profile-iterations expects a positive integer");
 }
+if (reuseStandaloneBinaryPath && writeArtifacts) {
+  throw new Error("--reuse-standalone-binary is diagnostic-only and cannot publish npm-compat artifacts");
+}
 
 const RESULTS_PATH = resolve(ROOT, "benchmarks", "results", "npm-compat.json");
 const PUBLIC_PATH = resolve(ROOT, "website", "public", "benchmarks", "results", "npm-compat.json");
@@ -290,8 +294,18 @@ function committedHistoryPoints() {
       // PREVIOUS run — labelling that point `sourceRevision: HEAD` made it
       // collide with the live point (also HEAD) and the previous run was
       // dropped on every single refresh. See mergeNpmPerfHistory.
-      const { generatedAt, packages } = npmPerfHistoryPoint(report.packages ?? [], report.generatedAt);
-      return { generatedAt, recordedIn: revision, packages };
+      const { generatedAt, optimizationLevels, packages } = npmPerfHistoryPoint(
+        report.packages ?? [],
+        report.generatedAt,
+        null,
+        report.performanceMethodology?.optimizationLevels,
+      );
+      return {
+        generatedAt,
+        recordedIn: revision,
+        ...(optimizationLevels ? { optimizationLevels } : {}),
+        packages,
+      };
     });
   } catch (error) {
     console.warn(
@@ -393,6 +407,32 @@ const STANDALONE_BENCHMARK_EXPORT = "__npmCompatStandaloneBenchmark";
 const STANDALONE_STATIC_OPERATION_EXPORT = "__npmCompatStaticOperation";
 const CLSX_PERF_OP_NAME = "op_two_strings";
 const LIT_WHEN_PERF_EXPORT = "__npmCompatLitWhen";
+const NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL = 4,
+  NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL = 3;
+
+function npmCompatOptimizationLevel(placement) {
+  return placement === "standalone" ? NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL : NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL;
+}
+
+function requestedOptimizationMetadata(placement, extra = {}) {
+  return {
+    optimizationRequested: true,
+    optimizationVerified: false,
+    ...extra,
+    optimizationLevel: npmCompatOptimizationLevel(placement),
+  };
+}
+
+function verifiedOptimizationMetadata(placement, extra = {}) {
+  return {
+    ...requestedOptimizationMetadata(placement, extra),
+    optimizationVerified: true,
+  };
+}
+
+function failedOptimizedPerfLane(placement, status, diagnostic, extra = {}) {
+  return failedPerfLane(placement, status, diagnostic, requestedOptimizationMetadata(placement, extra));
+}
 
 function chunkedStringArray(value, chunkSize = 1024) {
   const chunks = [];
@@ -456,8 +496,13 @@ async function compileStandaloneLane({
   inputMode = "compile-time-static",
   runtimeArgument,
 }) {
+  let optimizationVerified = false;
   const failStandalone = (status, diagnostic, extra = {}) =>
-    failedPerfLane("standalone", status, diagnostic, { inputMode, ...extra });
+    failedOptimizedPerfLane("standalone", status, diagnostic, {
+      inputMode,
+      optimizationVerified,
+      ...extra,
+    });
   const compileStarted = performance.now();
   let result;
   let staticEvaluation;
@@ -465,7 +510,7 @@ async function compileStandaloneLane({
     const compileOptions = {
       allowJs: true,
       skipSemanticDiagnostics: true,
-      optimize: 4,
+      optimize: NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL,
       target: "standalone",
       // Linked npm graphs can need their complete instance (including
       // internal callback exports) while module initialization runs. Keep
@@ -504,6 +549,12 @@ async function compileStandaloneLane({
     if (staticOperationExport && !reuseStandaloneBinaryPath) {
       if (!result.success || !result.binary?.length) {
         return failStandalone("compile-error", firstCompileDiagnostic(result), {
+          compileDurationMs: performance.now() - compileStarted,
+        });
+      }
+      const stageOptimizationFailure = npmPerfOptimizationFailure(result, NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL);
+      if (stageOptimizationFailure) {
+        return failStandalone("optimization-error", stageOptimizationFailure, {
           compileDurationMs: performance.now() - compileStarted,
         });
       }
@@ -563,6 +614,13 @@ export function ${STANDALONE_BENCHMARK_EXPORT}(iterations) {
           compileDurationMs: performance.now() - compileStarted,
         });
       }
+      const residualOptimizationFailure = npmPerfOptimizationFailure(residual, NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL);
+      if (residualOptimizationFailure) {
+        return failStandalone("optimization-error", residualOptimizationFailure, {
+          phase: "static-residual",
+          compileDurationMs: performance.now() - compileStarted,
+        });
+      }
       staticEvaluation = {
         operationEvaluatedInWasm: true,
         operationResultType: "number",
@@ -580,6 +638,13 @@ export function ${STANDALONE_BENCHMARK_EXPORT}(iterations) {
   const compileDurationMs = performance.now() - compileStarted;
   if (!result.success || !result.binary?.length) {
     return failStandalone("compile-error", firstCompileDiagnostic(result), { compileDurationMs });
+  }
+  if (!reuseStandaloneBinaryPath) {
+    const optimizationFailure = npmPerfOptimizationFailure(result, NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL);
+    if (optimizationFailure) {
+      return failStandalone("optimization-error", optimizationFailure, { compileDurationMs });
+    }
+    optimizationVerified = true;
   }
   if (inspectWatFunctions?.length) {
     if (inspectWatOutputPath) {
@@ -751,6 +816,9 @@ export function ${STANDALONE_BENCHMARK_EXPORT}(iterations) {
       benchmarkUsesIr: result.irCompiledFuncs?.includes(STANDALONE_BENCHMARK_EXPORT) ?? false,
       irCompiledFunctions: result.irCompiledFuncs ?? [],
       target: "standalone",
+      ...(optimizationVerified
+        ? verifiedOptimizationMetadata("standalone")
+        : requestedOptimizationMetadata("standalone", { binaryProvenance: "reused-unverified" })),
       ...(runtimeArgument === undefined ? {} : { runtimeArgumentSuppliedAfterCompile: true }),
       ...(staticEvaluation ? { staticEvaluation } : {}),
     };
@@ -783,13 +851,13 @@ export function ${resultFloorExport}(input, options) {
   return parse(input, options).body.length;
 }`
     : source;
-  // optimize: 4 — perf numbers must reflect a realistic (wasm-opt'd) deployment,
+  // JS-host O4 — perf numbers must reflect a realistic wasm-opt deployment,
   // not the debug-friendly unoptimized binary the correctness harnesses use.
   const compileStart = performance.now();
   const result = await compile(compileSourceText, {
     fileName: "acorn.mjs",
     skipSemanticDiagnostics: true,
-    optimize: 4,
+    optimize: NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL,
     ...(inspectWatFunctions?.length
       ? {
           emitWat: true,
@@ -799,6 +867,8 @@ export function ${resultFloorExport}(input, options) {
   });
   const compileDurationMs = performance.now() - compileStart;
   if (!result.success || !result.binary?.length) return null;
+  const optimizationFailure = npmPerfOptimizationFailure(result, NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL);
+  if (optimizationFailure) return failedOptimizedPerfLane("js-host", "optimization-error", optimizationFailure);
   if (inspectWatFunctions?.length) {
     console.log(`[npm-compat] acorn WAT (${inspectWatFunctions.join(", ")})\n${result.wat ?? "(unavailable)"}`);
   }
@@ -899,11 +969,11 @@ export function ${resultFloorExport}(input, options) {
     ? compiledOperation(source, parseOptions)
     : compiledOperation(source, parseOptions).body.length;
   if (actualChecksum !== expectedChecksum) {
-    return failedPerfLane(
+    return failedOptimizedPerfLane(
       "js-host",
       "result-mismatch",
       `Acorn checksum mismatch: ${actualChecksum} !== ${expectedChecksum}`,
-      { expectedChecksum, actualChecksum },
+      { expectedChecksum, actualChecksum, optimizationVerified: true },
     );
   }
   return {
@@ -926,6 +996,7 @@ export function ${resultFloorExport}(input, options) {
     actualChecksum,
     testCompiledToWasm: false,
     target: "js-host",
+    ...verifiedOptimizationMetadata("js-host"),
     resultObservation: inspectResultFloor ? "inside-wasm-number" : "js-host-full-ast",
     ...(boundaryCensus ? { boundaryCensus } : {}),
   };
@@ -1020,7 +1091,7 @@ async function perfAcorn() {
     : skippedPerfLane("standalone", "runtime-dynamic");
   return packagePerfRecord(
     jsHost?.sampleOp ?? standalone?.sampleOp ?? "parse(own dist bundle).body.length",
-    jsHost ?? failedPerfLane("js-host", "compile-error", "host compilation failed"),
+    jsHost ?? failedOptimizedPerfLane("js-host", "compile-error", "host compilation failed"),
     standalone,
     { standaloneDynamic },
   );
@@ -1040,7 +1111,7 @@ export function ${op.name}(first, second) {
   const result = await compile(clsxSource + "\n" + epilogue, {
     fileName: "clsx.mjs",
     skipSemanticDiagnostics: true,
-    optimize: 4,
+    optimize: NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL,
     ...(inspectWatFunctions?.length
       ? {
           emitWat: true,
@@ -1049,6 +1120,8 @@ export function ${op.name}(first, second) {
       : {}),
   });
   if (!result.success || !result.binary?.length) return null;
+  const optimizationFailure = npmPerfOptimizationFailure(result, NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL);
+  if (optimizationFailure) return failedOptimizedPerfLane("js-host", "optimization-error", optimizationFailure);
   if (inspectWatFunctions?.length) {
     console.log(`[npm-compat] clsx WAT (${inspectWatFunctions.join(", ")})\n${result.wat ?? "(unavailable)"}`);
   }
@@ -1065,7 +1138,14 @@ export function ${op.name}(first, second) {
   const expected = nativeClsx(...hostArguments);
   const actual = exp[op.name](...hostArguments);
   if (actual !== expected) {
-    return failedPerfLane("js-host", "result-mismatch", `clsx result mismatch: ${String(actual)} !== ${expected}`);
+    return failedOptimizedPerfLane(
+      "js-host",
+      "result-mismatch",
+      `clsx result mismatch: ${String(actual)} !== ${expected}`,
+      {
+        optimizationVerified: true,
+      },
+    );
   }
   const sampleOp = `${op.name}.length (host-owned arguments)`;
   const moduleImports = WebAssembly.Module.imports(await WebAssembly.compile(result.binary)).map(
@@ -1084,15 +1164,22 @@ export function ${op.name}(first, second) {
     actualChecksum: actual.length,
     testCompiledToWasm: false,
     target: "js-host",
+    ...verifiedOptimizationMetadata("js-host"),
   };
   if (!inspectConstantFloor) return measured;
 
   const floorResult = await compile(`export function ${op.name}() { return ${JSON.stringify(expected)}; }`, {
     fileName: "clsx-constant-floor.mjs",
     skipSemanticDiagnostics: true,
-    optimize: 4,
+    optimize: NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL,
   });
   if (!floorResult.success || !floorResult.binary?.length) return measured;
+  const floorOptimizationFailure = npmPerfOptimizationFailure(floorResult, NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL);
+  if (floorOptimizationFailure) {
+    return failedOptimizedPerfLane("js-host", "optimization-error", floorOptimizationFailure, {
+      phase: "constant-floor",
+    });
+  }
   const floorImports = {
     env: {},
     "wasm:js-string": jsString,
@@ -1187,7 +1274,7 @@ async function perfClsx() {
     : skippedPerfLane("standalone", "runtime-dynamic");
   return packagePerfRecord(
     jsHost?.sampleOp ?? standalone?.sampleOp ?? standaloneDynamic?.sampleOp ?? `${CLSX_PERF_OP_NAME}.length`,
-    jsHost ?? failedPerfLane("js-host", "compile-error", "host compilation failed"),
+    jsHost ?? failedOptimizedPerfLane("js-host", "compile-error", "host compilation failed"),
     standalone,
     { standaloneDynamic },
   );
@@ -1199,7 +1286,7 @@ async function perfCookieJsHost() {
   const result = await compile(cookieSource, {
     fileName: "index.js",
     skipSemanticDiagnostics: true,
-    optimize: 4,
+    optimize: NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL,
     ...(inspectWatFunctions?.length
       ? {
           emitWat: true,
@@ -1208,6 +1295,8 @@ async function perfCookieJsHost() {
       : {}),
   });
   if (!result.success || !result.binary?.length) return null;
+  const optimizationFailure = npmPerfOptimizationFailure(result, NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL);
+  if (optimizationFailure) return failedOptimizedPerfLane("js-host", "optimization-error", optimizationFailure);
   if (inspectWatFunctions?.length) {
     console.log(`[npm-compat] cookie WAT (${inspectWatFunctions.join(", ")})\n${result.wat ?? "(unavailable)"}`);
   }
@@ -1255,10 +1344,11 @@ async function perfCookieJsHost() {
   const expectedChecksum = observe(nativeModule.parseCookie(header));
   const actualChecksum = observe(exp.parseCookie(header));
   if (actualChecksum !== expectedChecksum) {
-    return failedPerfLane(
+    return failedOptimizedPerfLane(
       "js-host",
       "result-mismatch",
       `cookie checksum mismatch: ${actualChecksum} !== ${expectedChecksum}`,
+      { optimizationVerified: true },
     );
   }
   const sampleOp = "parseCookie(8-pair header); verify a/h";
@@ -1277,6 +1367,7 @@ async function perfCookieJsHost() {
     actualChecksum,
     testCompiledToWasm: false,
     target: "js-host",
+    ...verifiedOptimizationMetadata("js-host"),
     ...(boundaryCensus ? { boundaryCensus } : {}),
   };
 }
@@ -1360,7 +1451,7 @@ async function perfCookie() {
     : skippedPerfLane("standalone", "runtime-dynamic");
   return packagePerfRecord(
     jsHost?.sampleOp ?? standalone?.sampleOp ?? standaloneDynamic?.sampleOp ?? "parseCookie(8-pair header); verify a/h",
-    jsHost ?? failedPerfLane("js-host", "compile-error", "host compilation failed"),
+    jsHost ?? failedOptimizedPerfLane("js-host", "compile-error", "host compilation failed"),
     standalone,
     { standaloneDynamic },
   );
@@ -1382,11 +1473,13 @@ async function perfLitJsHost() {
     {
       fileName: "when.js",
       skipSemanticDiagnostics: true,
-      optimize: 4,
+      optimize: NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL,
     },
   );
   const compileDurationMs = performance.now() - compileStarted;
   if (!result.success || !result.binary?.length) return null;
+  const optimizationFailure = npmPerfOptimizationFailure(result, NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL);
+  if (optimizationFailure) return failedOptimizedPerfLane("js-host", "optimization-error", optimizationFailure);
   if (inspectBinaryPath) {
     writeFileSync(inspectBinaryPath, result.binary);
     console.log(`[npm-compat] wrote lit JS-host binary to ${inspectBinaryPath}`);
@@ -1408,10 +1501,11 @@ async function perfLitJsHost() {
   const expectedChecksum = nativeModule.when(true, truthy, falsy);
   const actualChecksum = exports[LIT_WHEN_PERF_EXPORT](true, truthy, falsy);
   if (!Object.is(actualChecksum, expectedChecksum)) {
-    return failedPerfLane(
+    return failedOptimizedPerfLane(
       "js-host",
       "result-mismatch",
       `lit when checksum mismatch: ${String(actualChecksum)} !== ${String(expectedChecksum)}`,
+      { optimizationVerified: true },
     );
   }
   const sampleOp = "select one of two runtime-owned callbacks";
@@ -1428,6 +1522,7 @@ async function perfLitJsHost() {
     actualChecksum,
     testCompiledToWasm: false,
     target: "js-host",
+    ...verifiedOptimizationMetadata("js-host"),
   };
 }
 
@@ -1443,7 +1538,7 @@ async function perfLit() {
   };
   return packagePerfRecord(
     jsHost?.sampleOp ?? standalone?.sampleOp ?? standaloneDynamic?.sampleOp ?? "select one of two callbacks",
-    jsHost ?? failedPerfLane("js-host", "compile-error", "host compilation failed"),
+    jsHost ?? failedOptimizedPerfLane("js-host", "compile-error", "host compilation failed"),
     standalone,
     { standaloneDynamic },
   );
@@ -1470,12 +1565,12 @@ function reportCompileDiagnostic(report) {
 }
 
 function packagePerfFailure(spec, diagnostic, status = "compile-error") {
-  const jsHost = runJsHostLane ? failedPerfLane("js-host", status, diagnostic) : skippedPerfLane("js-host");
+  const jsHost = runJsHostLane ? failedOptimizedPerfLane("js-host", status, diagnostic) : skippedPerfLane("js-host");
   const standalone = runStandaloneLane
-    ? failedPerfLane("standalone", status, diagnostic)
+    ? failedOptimizedPerfLane("standalone", status, diagnostic)
     : skippedPerfLane("standalone");
   const standaloneDynamic = runStandaloneDynamicLane
-    ? failedPerfLane("standalone", status, diagnostic, { inputMode: "runtime-dynamic" })
+    ? failedOptimizedPerfLane("standalone", status, diagnostic, { inputMode: "runtime-dynamic" })
     : skippedPerfLane("standalone", "runtime-dynamic");
   return packagePerfRecord(spec.sampleOp, jsHost, standalone, { standaloneDynamic });
 }
@@ -1496,19 +1591,21 @@ async function compileNpmCompatPerfLane({ setup, spec, lane, compileOptions }) {
     result = await compileProject(driverPath, {
       allowJs: true,
       skipSemanticDiagnostics: true,
-      optimize: 4,
-      target,
+      ...(compileOptions ?? {}),
       // Project graphs can initialize package singletons while they are being
       // instantiated.  Defer that start work until the generated import
       // object has wired the instance, for both host and standalone lanes.
       deferTopLevelInit: true,
       ...(target === "gc" ? { platform: "node" } : {}),
-      ...(compileOptions ?? {}),
+      // The report owns its deployment tier. Per-package compatibility
+      // options may not silently change the artifact being compared.
+      target,
+      optimize: npmCompatOptimizationLevel(target === "standalone" ? "standalone" : "js-host"),
       preserveDebugNames,
     });
   } catch (error) {
     return {
-      failure: failedPerfLane(
+      failure: failedOptimizedPerfLane(
         lane === "js-host" ? "js-host" : "standalone",
         "compile-error",
         error instanceof Error ? error.message : String(error),
@@ -1519,7 +1616,7 @@ async function compileNpmCompatPerfLane({ setup, spec, lane, compileOptions }) {
   const compileDurationMs = performance.now() - compileStarted;
   if (!result.success || !result.binary?.length) {
     return {
-      failure: failedPerfLane(
+      failure: failedOptimizedPerfLane(
         lane === "js-host" ? "js-host" : "standalone",
         "compile-error",
         firstCompileDiagnostic(result),
@@ -1530,6 +1627,17 @@ async function compileNpmCompatPerfLane({ setup, spec, lane, compileOptions }) {
       ),
     };
   }
+  const placement = target === "standalone" ? "standalone" : "js-host";
+  const optimizationFailure = npmPerfOptimizationFailure(result, npmCompatOptimizationLevel(placement));
+  if (optimizationFailure) {
+    return {
+      failure: failedOptimizedPerfLane(placement, "optimization-error", optimizationFailure, {
+        ...(lane === "standalone-dynamic" ? { inputMode: "runtime-dynamic" } : {}),
+        compileDurationMs,
+        optimizationVerified: false,
+      }),
+    };
+  }
 
   let module;
   const moduleCompileStarted = performance.now();
@@ -1537,12 +1645,13 @@ async function compileNpmCompatPerfLane({ setup, spec, lane, compileOptions }) {
     module = await WebAssembly.compile(result.binary);
   } catch (error) {
     return {
-      failure: failedPerfLane(
+      failure: failedOptimizedPerfLane(
         lane === "js-host" ? "js-host" : "standalone",
         "validation-error",
         error instanceof Error ? error.message : String(error),
         {
           ...(lane === "standalone-dynamic" ? { inputMode: "runtime-dynamic" } : {}),
+          optimizationVerified: true,
           compileDurationMs,
           binaryBytes: result.binary.length,
         },
@@ -1555,12 +1664,13 @@ async function compileNpmCompatPerfLane({ setup, spec, lane, compileOptions }) {
   );
   if (target === "standalone" && moduleImports.length > 0) {
     return {
-      failure: failedPerfLane(
+      failure: failedOptimizedPerfLane(
         "standalone",
         "host-import-error",
         `standalone binary retained ${moduleImports.length} host import(s)`,
         {
           inputMode: lane === "standalone-dynamic" ? "runtime-dynamic" : "compile-time-static",
+          optimizationVerified: true,
           compileDurationMs,
           moduleCompileDurationMs,
           binaryBytes: result.binary.length,
@@ -1580,7 +1690,7 @@ async function compileNpmCompatPerfLane({ setup, spec, lane, compileOptions }) {
     if (typeof init === "function") init();
   } catch (error) {
     return {
-      failure: failedPerfLane(
+      failure: failedOptimizedPerfLane(
         lane === "js-host" ? "js-host" : "standalone",
         "runtime-error",
         renderHarnessThrownText(error, instance),
@@ -1592,6 +1702,7 @@ async function compileNpmCompatPerfLane({ setup, spec, lane, compileOptions }) {
                 ? "runtime-dynamic"
                 : "compile-time-static",
           phase: instance ? "module-init" : "instantiate",
+          optimizationVerified: true,
           compileDurationMs,
           moduleCompileDurationMs,
           binaryBytes: result.binary.length,
@@ -1644,8 +1755,9 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       expectedChecksum = spec.nativeOperation(nativeModule, input);
       actualChecksum = compiled.exports.__npmCompatPerf(input);
     } catch (error) {
-      return failedPerfLane("js-host", "runtime-error", renderHarnessThrownText(error), {
+      return failedOptimizedPerfLane("js-host", "runtime-error", renderHarnessThrownText(error), {
         phase: "checksum",
+        optimizationVerified: true,
         inputMode: "runtime-dynamic",
         compileDurationMs: compiled.compileDurationMs,
         binaryBytes: compiled.result.binary.length,
@@ -1653,11 +1765,11 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       });
     }
     if (!Object.is(actualChecksum, expectedChecksum)) {
-      return failedPerfLane(
+      return failedOptimizedPerfLane(
         "js-host",
         "result-mismatch",
         `checksum mismatch: Wasm ${String(actualChecksum)}, Node ${String(expectedChecksum)}`,
-        { expectedChecksum, actualChecksum },
+        { expectedChecksum, actualChecksum, optimizationVerified: true },
       );
     }
     let wasmIndex = 0;
@@ -1675,8 +1787,9 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
           ),
       );
     } catch (error) {
-      return failedPerfLane("js-host", "runtime-error", renderHarnessThrownText(error), {
+      return failedOptimizedPerfLane("js-host", "runtime-error", renderHarnessThrownText(error), {
         phase: "measure",
+        optimizationVerified: true,
         inputMode: "runtime-dynamic",
         compileDurationMs: compiled.compileDurationMs,
         binaryBytes: compiled.result.binary.length,
@@ -1694,6 +1807,7 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       actualChecksum,
       testCompiledToWasm: false,
       target: "js-host",
+      ...verifiedOptimizationMetadata("js-host"),
     };
   };
 
@@ -1706,8 +1820,9 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       expectedChecksum = spec.nativeOperation(nativeModule, spec.staticInput);
       actualChecksum = compiled.exports.__npmCompatStandaloneBenchmark(1);
     } catch (error) {
-      return failedPerfLane("standalone", "runtime-error", renderHarnessThrownText(error, compiled.exports), {
+      return failedOptimizedPerfLane("standalone", "runtime-error", renderHarnessThrownText(error, compiled.exports), {
         phase: "checksum",
+        optimizationVerified: true,
         inputMode: "compile-time-static",
         compileDurationMs: compiled.compileDurationMs,
         binaryBytes: compiled.result.binary.length,
@@ -1715,11 +1830,11 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       });
     }
     if (!Object.is(actualChecksum, expectedChecksum)) {
-      return failedPerfLane(
+      return failedOptimizedPerfLane(
         "standalone",
         "result-mismatch",
         `checksum mismatch: Wasm ${String(actualChecksum)}, Node ${String(expectedChecksum)}`,
-        { expectedChecksum, actualChecksum },
+        { expectedChecksum, actualChecksum, optimizationVerified: true },
       );
     }
     let measured;
@@ -1736,8 +1851,9 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
         },
       );
     } catch (error) {
-      return failedPerfLane("standalone", "runtime-error", renderHarnessThrownText(error, compiled.exports), {
+      return failedOptimizedPerfLane("standalone", "runtime-error", renderHarnessThrownText(error, compiled.exports), {
         phase: "measure",
+        optimizationVerified: true,
         inputMode: "compile-time-static",
         compileDurationMs: compiled.compileDurationMs,
         binaryBytes: compiled.result.binary.length,
@@ -1757,6 +1873,7 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       benchmarkUsesIr: compiled.result.irCompiledFuncs?.includes(STANDALONE_BENCHMARK_EXPORT) ?? false,
       irCompiledFunctions: compiled.result.irCompiledFuncs ?? [],
       target: "standalone",
+      ...verifiedOptimizationMetadata("standalone"),
     };
   };
 
@@ -1770,8 +1887,9 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       expectedChecksum = spec.nativeOperation(nativeModule, spec.dynamicInput(spec.staticInput, seed, 0));
       actualChecksum = compiled.exports.__npmCompatStandaloneDynamic(1, seed);
     } catch (error) {
-      return failedPerfLane("standalone", "runtime-error", renderHarnessThrownText(error, compiled.exports), {
+      return failedOptimizedPerfLane("standalone", "runtime-error", renderHarnessThrownText(error, compiled.exports), {
         phase: "checksum",
+        optimizationVerified: true,
         inputMode: "runtime-dynamic",
         compileDurationMs: compiled.compileDurationMs,
         binaryBytes: compiled.result.binary.length,
@@ -1779,11 +1897,11 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       });
     }
     if (!Object.is(actualChecksum, expectedChecksum)) {
-      return failedPerfLane(
+      return failedOptimizedPerfLane(
         "standalone",
         "result-mismatch",
         `checksum mismatch: Wasm ${String(actualChecksum)}, Node ${String(expectedChecksum)}`,
-        { expectedChecksum, actualChecksum },
+        { expectedChecksum, actualChecksum, optimizationVerified: true },
       );
     }
     let measured;
@@ -1801,8 +1919,9 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
         { inputMode: "runtime-dynamic" },
       );
     } catch (error) {
-      return failedPerfLane("standalone", "runtime-error", renderHarnessThrownText(error, compiled.exports), {
+      return failedOptimizedPerfLane("standalone", "runtime-error", renderHarnessThrownText(error, compiled.exports), {
         phase: "measure",
+        optimizationVerified: true,
         inputMode: "runtime-dynamic",
         compileDurationMs: compiled.compileDurationMs,
         binaryBytes: compiled.result.binary.length,
@@ -1822,6 +1941,7 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       benchmarkUsesIr: compiled.result.irCompiledFuncs?.includes(STANDALONE_BENCHMARK_EXPORT) ?? false,
       irCompiledFunctions: compiled.result.irCompiledFuncs ?? [],
       target: "standalone",
+      ...verifiedOptimizationMetadata("standalone"),
       runtimeArgumentSuppliedAfterCompile: true,
     };
   };
@@ -2888,7 +3008,6 @@ packages.sort(
     (right.weeklyDownloads ?? Number.NEGATIVE_INFINITY) - (left.weeklyDownloads ?? Number.NEGATIVE_INFINITY) ||
     left.name.localeCompare(right.name),
 );
-
 const summary = {
   generatedAt: new Date().toISOString(),
   // (#4127) How much of the corpus carries correctness evidence at all. The
@@ -2904,6 +3023,10 @@ const summary = {
   },
   performanceMethodology: {
     baseline: "same pinned package, inputs, and result observation in native Node",
+    optimizationLevels: {
+      "js-host": NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL,
+      standalone: NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL,
+    },
     inputModes: {
       "compile-time-static": "package, test driver, and fixed inputs are visible to the Wasm compiler",
       "runtime-dynamic":
@@ -2913,13 +3036,39 @@ const summary = {
   packages,
 };
 
+function assertMeasuredOptimizationReceipts(packageRows) {
+  for (const packageRow of packageRows) {
+    for (const [laneName, lane] of Object.entries(packageRow.perf?.lanes ?? {})) {
+      if (lane?.status !== "measured") continue;
+      const expectedLevel = npmCompatOptimizationLevel(lane.placement);
+      if (
+        lane.optimizationRequested !== true ||
+        lane.optimizationVerified !== true ||
+        lane.optimizationLevel !== expectedLevel
+      ) {
+        throw new Error(
+          `${packageRow.name}.${laneName} lacks a verified O${expectedLevel} optimizer receipt ` +
+            `(received ${String(lane.optimizationLevel)}/${String(lane.optimizationRequested)}/${String(lane.optimizationVerified)})`,
+        );
+      }
+    }
+  }
+}
+
+if (!reuseStandaloneBinaryPath) assertMeasuredOptimizationReceipts(packages);
+
 // Successful placements become separate chart rows. Failed or deliberately
 // skipped placements remain visible in the package JSON/cards and are never
 // converted to misleading zero-duration bars.
 const perfRows = npmPerfRows(packages);
 const perfHistory = mergeNpmPerfHistory(readHistoryArtifact(), [
   ...committedHistoryPoints(),
-  npmPerfHistoryPoint(packages, summary.generatedAt, currentRevision()),
+  npmPerfHistoryPoint(
+    packages,
+    summary.generatedAt,
+    currentRevision(),
+    summary.performanceMethodology.optimizationLevels,
+  ),
 ]);
 
 if (writeArtifacts) {

--- a/scripts/lib/npm-compat-perf.mjs
+++ b/scripts/lib/npm-compat-perf.mjs
@@ -167,6 +167,14 @@ export function failedPerfLane(placement, status, diagnostic, extra = {}) {
   };
 }
 
+export function npmPerfOptimizationFailure(result, optimizationLevel) {
+  const warning = result?.errors?.find(
+    (entry) => entry?.severity === "warning" && /\bwasm-opt\b/i.test(String(entry.message ?? "")),
+  );
+  if (!warning) return null;
+  return `wasm-opt -O${optimizationLevel} did not produce the measured artifact: ${String(warning.message)}`;
+}
+
 export function packagePerfRecord(sampleOp, jsHost, standalone, additionalLanes = {}) {
   const record = {
     sampleOp,
@@ -205,6 +213,7 @@ export function npmPerfRows(packages) {
     ]) {
       const lane = pkg.perf.lanes[key];
       if (lane?.status !== "measured") continue;
+      const optimizationVerified = lane.optimizationVerified === true;
       rows.push({
         name: `${pkg.name} · ${label}`,
         path: `${pkg.entryFile}#${key}`,
@@ -213,8 +222,8 @@ export function npmPerfRows(packages) {
         wasmStdUs: lane.wasmStdUs,
         jsStdUs: lane.nodeStdUs,
         ratioStd: lane.ratioStd ?? 0,
-        wasmOptimized: true,
-        wasmOptimizeLevel: 4,
+        wasmOptimized: optimizationVerified,
+        wasmOptimizeLevel: optimizationVerified ? lane.optimizationLevel : null,
         warmupRounds: lane.warmupRounds,
         measuredRounds: lane.measuredRounds,
         sampleOp: lane.sampleOp,
@@ -237,7 +246,7 @@ function measuredRatio(lane) {
  * the per-package history charts. Older reports predate `perf.lanes`; their
  * top-level perf record was the JS-host/runtime-dynamic lane.
  */
-export function npmPerfHistoryPoint(packages, generatedAt, sourceRevision = null) {
+export function npmPerfHistoryPoint(packages, generatedAt, sourceRevision = null, optimizationLevels = null) {
   const snapshots = {};
   for (const pkg of packages) {
     const perf = pkg?.perf;
@@ -262,6 +271,7 @@ export function npmPerfHistoryPoint(packages, generatedAt, sourceRevision = null
   return {
     generatedAt,
     ...(sourceRevision ? { sourceRevision } : {}),
+    ...(optimizationLevels ? { optimizationLevels } : {}),
     packages: snapshots,
   };
 }

--- a/tests/issue-3781-npm-perf-lanes.test.ts
+++ b/tests/issue-3781-npm-perf-lanes.test.ts
@@ -7,6 +7,7 @@ import {
   measureStandalonePerf,
   mergeNpmPerfHistory,
   npmPerfHistoryPoint,
+  npmPerfOptimizationFailure,
   npmPerfRows,
   packagePerfRecord,
 } from "../scripts/lib/npm-compat-perf.mjs";
@@ -97,6 +98,8 @@ describe("#3781 npm performance harness placement", () => {
       measuredRounds: 9,
       wasmSamplesUs: [2],
       nodeSamplesUs: [1],
+      optimizationLevel: 4,
+      optimizationVerified: true,
     };
     const standalone = failedPerfLane("standalone", "compile-error", "unsupported operation");
     const perf = packagePerfRecord("op", jsHost, standalone);
@@ -110,6 +113,8 @@ describe("#3781 npm performance harness placement", () => {
       path: "index.js#jsHost",
       harnessPlacement: "js-host",
       inputMode: "runtime-dynamic",
+      wasmOptimized: true,
+      wasmOptimizeLevel: 4,
     });
     expect(rows.some((row: { path: string }) => row.path.endsWith("#standalone"))).toBe(false);
   });
@@ -131,6 +136,8 @@ describe("#3781 npm performance harness placement", () => {
       measuredRounds: 9,
       wasmSamplesUs: [2],
       nodeSamplesUs: [1],
+      optimizationLevel: 3,
+      optimizationVerified: true,
     };
     const perf = packagePerfRecord(
       "op",
@@ -146,7 +153,54 @@ describe("#3781 npm performance harness placement", () => {
       path: "index.js#standaloneDynamic",
       harnessPlacement: "standalone",
       inputMode: "runtime-dynamic",
+      wasmOptimized: true,
+      wasmOptimizeLevel: 3,
     });
+  });
+
+  it("does not claim optimization without a verified compiler receipt", () => {
+    const lane = {
+      status: "measured",
+      placement: "standalone",
+      inputMode: "runtime-dynamic",
+      sampleOp: "op",
+      wasmUs: 2,
+      nodeUs: 1,
+      wasmStdUs: 0.1,
+      nodeStdUs: 0.1,
+      ratioStd: 0.01,
+      warmupRounds: 2,
+      measuredRounds: 9,
+      optimizationLevel: 3,
+    };
+    const perf = packagePerfRecord(
+      "op",
+      failedPerfLane("js-host", "compile-error", "not run"),
+      failedPerfLane("standalone", "compile-error", "not run"),
+      { standaloneDynamic: lane },
+    );
+
+    expect(npmPerfRows([{ name: "pkg", entryFile: "index.js", perf }])[0]).toMatchObject({
+      wasmOptimized: false,
+      wasmOptimizeLevel: null,
+    });
+  });
+
+  it("turns a compiler optimizer warning into a failed measurement diagnostic", () => {
+    expect(
+      npmPerfOptimizationFailure(
+        {
+          errors: [
+            {
+              severity: "warning",
+              message: "wasm-opt -O3 failed: Flatten cannot process try_table",
+            },
+          ],
+        },
+        3,
+      ),
+    ).toContain("did not produce the measured artifact");
+    expect(npmPerfOptimizationFailure({ errors: [] }, 3)).toBeNull();
   });
 
   it("records static and dynamic history as separate scenarios", () => {
@@ -173,11 +227,13 @@ describe("#3781 npm performance harness placement", () => {
       ],
       "2026-07-30T00:00:00.000Z",
       "abc123",
+      { "js-host": 4, standalone: 3 },
     );
 
     expect(point).toEqual({
       generatedAt: "2026-07-30T00:00:00.000Z",
       sourceRevision: "abc123",
+      optimizationLevels: { "js-host": 4, standalone: 3 },
       packages: {
         pkg: {
           jsHost: { dynamic: 0.5 },

--- a/tests/issue-4585-npm-compat-refresh-resilience.test.ts
+++ b/tests/issue-4585-npm-compat-refresh-resilience.test.ts
@@ -1,8 +1,9 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-import { compile, validateJavaScriptAdapterManifest, type JavaScriptAdapterManifestV1 } from "../src/index.js";
+import { type JavaScriptAdapterManifestV1, compile, validateJavaScriptAdapterManifest } from "../src/index.js";
 
 const ACORN_PARSE_SHAPE = `
   var pp = {};
@@ -58,5 +59,38 @@ describe("#4585 npm compatibility refresh resilience", () => {
       if (previous === undefined) Reflect.deleteProperty(process.env, "JS2WASM_LIB_SCAN");
       else process.env.JS2WASM_LIB_SCAN = previous;
     }
+  });
+
+  it("uses a supported optimized tier for standalone npm measurements", () => {
+    const generator = readFileSync(new URL("../scripts/generate-npm-compat-report.mjs", import.meta.url), "utf8");
+    const standalone = generator.slice(
+      generator.indexOf("async function compileStandaloneLane"),
+      generator.indexOf("// Per-package perf probes"),
+    );
+    const generic = generator.slice(
+      generator.indexOf("async function compileNpmCompatPerfLane"),
+      generator.indexOf("async function perfNpmCompatPackage"),
+    );
+
+    expect(standalone).toContain("optimize: NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL");
+    expect(generator).toContain("NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL = 4");
+    expect(generator).toContain("NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL = 3");
+    expect(generator).toContain("npmPerfOptimizationFailure(result");
+    expect(generator).toContain("assertMeasuredOptimizationReceipts(packages)");
+    expect(generator).toContain("--reuse-standalone-binary is diagnostic-only");
+    expect(generator.match(/failedPerfLane\(/g)).toHaveLength(1);
+    expect(generator).toContain("optimizationVerified: false");
+    expect(generator).toContain("lane.optimizationRequested !== true");
+    expect(generator).toContain("npmPerfOptimizationFailure(floorResult, NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL)");
+    expect(generic).toContain(
+      'optimize: npmCompatOptimizationLevel(target === "standalone" ? "standalone" : "js-host")',
+    );
+    expect(generic.indexOf("...(compileOptions ?? {})")).toBeLessThan(
+      generic.indexOf("optimize: npmCompatOptimizationLevel"),
+    );
+    expect(generic.indexOf("...(compileOptions ?? {})")).toBeLessThan(generic.indexOf("target,"));
+    expect(generator).toContain("optimizationLevels: {");
+    expect(generator).toContain('"js-host": NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL');
+    expect(generator).toContain("standalone: NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL");
   });
 });


### PR DESCRIPTION
## Summary

- run standalone npm compatibility performance lanes at Binaryen O3 while O4 Flatten cannot process standardized `try_table`
- retain O4 for JS-host lanes and reject every optimizer warning before measurement or publication
- carry optimizer request/verification/level provenance through package rows, chart rows, and history
- forbid diagnostic reused binaries from artifact publication

This is the focused follow-up to merged #4675. It prevents the now-unblocked aggregate refresh from presenting raw fallback bytes as optimized Acorn measurements.

## Evidence

- focused npm artifact/history tests: 26/26
- issue commit hooks: 11/11 changed-root tests
- full TS7 typecheck, lint, Prettier, issue integrity, LOC/function/dead-export/oracle gates: pass
- independent final review: approved, no blockers
- Acorn standalone dynamic O3: ratio 0.069983, checksum 422/422, verified O3
- clsx standalone dynamic O3: ratio 0.155833, checksum 14/14, verified O3

The live page remains unchanged until this lands and the aggregate refresh plus artifact promotion complete.