### PR TITLE
fix(optimizer): retry O4 without unsupported try_table flatten

### DIFF
--- a/plan/issues/4586-o4-try-table-flatten-fallback.md
+++ b/plan/issues/4586-o4-try-table-flatten-fallback.md
@@ -1,0 +1,68 @@
+---
+id: 4586
+title: "Retry Binaryen O4 without Flatten for standardized try_table modules"
+status: done
+created: 2026-08-21
+updated: 2026-08-21
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: performance
+area: optimizer, standalone, npm-compat
+language_feature: exception handling
+goal: performance
+sprint: current
+depends_on: [2997]
+related: [3780, 4157, 4578]
+assignee: ttraenkler/codex
+horizon: s
+origin: "Acorn npm-compat O4 failure after standardized standalone EH exposed Binaryen Flatten's unsupported try_table path."
+files:
+  - src/optimize.ts
+  - tests/issue-4586-o4-try-table-flatten.test.ts
+---
+
+# Retry Binaryen O4 without Flatten for standardized `try_table` modules
+
+## Problem
+
+Standalone/WASI output uses standardized Wasm exception handling so current
+Wasmtime and Wasmer can load it. Binaryen 125 and current Binaryen main classify
+`try_table` as control flow, but the O4-only `Flatten` pass implements only
+block, if, loop, and legacy try. It aborts with `unexpected expr type` at
+`Flatten.cpp:231` when optimizing a legal module containing `try_table`.
+
+The optimizer currently treats that abort like every other failure and returns
+the raw binary. Acorn therefore retains a 3,505,945-byte artifact even though
+all other O4 passes can optimize it successfully.
+
+## Scope
+
+- Recognize only Binaryen's exact unsupported-`Flatten` failure at O4.
+- Retry the same optimizer invocation with only `flatten` skipped.
+- Keep every other optimizer failure loud and preserve the raw-binary fallback.
+- Report that the successful optimized result omitted the unsupported pass.
+- Pin a real standardized-EH module so the test proves the retry produced a
+  smaller, runnable binary rather than silently returning the raw input.
+
+## Acceptance criteria
+
+- [x] A standalone module containing `try_table` optimizes successfully at O4.
+- [x] The result is smaller than the raw module and preserves caught-exception behavior.
+- [x] Ordinary O4 modules retain the normal invocation, including `flatten`.
+- [x] Unrelated Binaryen failures still ship the raw binary with a loud warning.
+- [x] Exact Acorn standalone-dynamic remains checksum-correct with zero imports.
+
+## Measurement
+
+On current main, the integrated retry produces a 2,129,709-byte Acorn binary
+from the 3,505,945-byte raw module (39.3% smaller), with checksum 422/422 and
+zero imports. It measures 57,876 us/op versus Node at 4,037 us/op (`0.06974x`
+Node), recovering roughly 83x over the stale published `0.000838x` ratio. A
+forced-legacy-EH/full-O4 control measures 58,717 us/op, showing that skipping
+`flatten` is not a material runtime loss on this workload.
+
+The pre-regression commit measures 29,518 us/op under full O4, so the remaining
+roughly 2x Acorn runtime gap is independent of standardized EH and the skipped
+pass. This issue restores the optimizer pipeline without claiming that separate
+runtime regression is fixed.

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -136,7 +136,7 @@ export interface OptimizeResult {
   binary: Uint8Array;
   /** true if optimization was applied */
   optimized: boolean;
-  /** Warning message if optimization was skipped */
+  /** Warning message if optimization was skipped or an unsupported pass was omitted. */
   warning?: string;
 }
 
@@ -574,15 +574,16 @@ function optimizeWithSystemBinary(
     void referenceTypes;
     void exceptionHandling;
 
+    const execOptions = {
+      // (#4157 entry 31) 600s, was 60s: acorn-scale modules with the inline
+      // caches enabled exceed 60s under -O4, and the catch below silently
+      // shipped the UNOPTIMIZED binary — measured as a phantom +57% size.
+      timeout: 600_000,
+      stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
+    };
     let stderr: Buffer | string = "";
     try {
-      n.execFileSync(wasmOptPath, args, {
-        // (#4157 entry 31) 600s, was 60s: acorn-scale modules with the inline
-        // caches enabled exceed 60s under -O4, and the catch below silently
-        // shipped the UNOPTIMIZED binary — measured as a phantom +57% size.
-        timeout: 600_000,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
+      n.execFileSync(wasmOptPath, args, execOptions);
     } catch (err) {
       // Surface wasm-opt's actual error message instead of falling through to
       // the misleading "not available" warning. A validator error here means
@@ -590,7 +591,36 @@ function optimizeWithSystemBinary(
       // seeing, not a missing-binary problem.
       const e = err as { stderr?: Buffer | string; message?: string };
       stderr = e.stderr ?? e.message ?? "unknown error";
-      const text = Buffer.isBuffer(stderr) ? stderr.toString("utf-8") : String(stderr);
+      let text = Buffer.isBuffer(stderr) ? stderr.toString("utf-8") : String(stderr);
+
+      // (#4586) Standardized Wasm EH uses `try_table`, which Binaryen 125's
+      // O4-only Flatten pass classifies as control flow but does not implement.
+      // Binaryen aborts at Flatten.cpp instead of declining the pass. Preserve
+      // the standardized output required by current Wasmtime/Wasmer and retry
+      // the SAME O4 pipeline with only that unsupported pass omitted. Keep this
+      // signature deliberately narrow: every other optimizer failure must
+      // remain loud and return the raw binary below.
+      const unsupportedFlatten =
+        level === 4 &&
+        text.includes("Flatten.cpp:") &&
+        (text.includes("unexpected expr type") || text.includes("Unsupported instruction for Flatten: try_table"));
+      if (unsupportedFlatten) {
+        try {
+          n.execFileSync(wasmOptPath, [...args, "--skip-pass=flatten"], execOptions);
+          const optimizedBinary = n.readFileSync(outputPath);
+          return {
+            binary: new Uint8Array(optimizedBinary),
+            optimized: true,
+            warning:
+              "wasm-opt -O4 omitted Binaryen's unsupported flatten pass for standardized try_table output; all remaining O4 passes completed.",
+          };
+        } catch (retryError) {
+          const retry = retryError as { stderr?: Buffer | string; message?: string };
+          const retryStderr = retry.stderr ?? retry.message ?? "unknown error";
+          const retryText = Buffer.isBuffer(retryStderr) ? retryStderr.toString("utf-8") : String(retryStderr);
+          text = `${text.trim()}\nRetry without flatten failed: ${retryText.trim()}`;
+        }
+      }
       // (#4157 entry 31) LOUD, unconditionally: the warning field alone was
       // ignored by every consumer, so a timeout here silently shipped an
       // unoptimized binary into perf measurements twice. stderr is the one

--- a/tests/issue-4586-o4-try-table-flatten.test.ts
+++ b/tests/issue-4586-o4-try-table-flatten.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, test } from "vitest";
+import { spawnSync } from "node:child_process";
+
+const runner = `
+import { compile } from ${JSON.stringify(new URL("../src/index.ts", import.meta.url).href)};
+
+const source = String.raw\`
+/** @param {*} value */
+export function guarded(value) {
+  try {
+    if (value) throw value;
+    return 1;
+  } catch (error) {
+    return error ? 2 : 3;
+  }
+}
+\`;
+
+const raw = await compile(source, {
+  allowJs: true,
+  fileName: "issue-4586.mjs",
+  target: "standalone",
+  emitWat: true,
+});
+const optimized = await compile(source, {
+  allowJs: true,
+  fileName: "issue-4586.mjs",
+  target: "standalone",
+  optimize: 4,
+});
+const { instance } = await WebAssembly.instantiate(optimized.binary, {});
+const guarded = instance.exports.guarded;
+
+process.stdout.write(JSON.stringify({
+  rawSuccess: raw.success,
+  rawBytes: raw.binary.length,
+  hasTryTable: raw.wat.includes("try_table"),
+  optimizedSuccess: optimized.success,
+  optimizedBytes: optimized.binary.length,
+  diagnostics: optimized.errors.map((error) => error.message),
+  normalResult: guarded(null),
+  caughtResult: guarded(42),
+}));
+`;
+
+describe("#4586 — Binaryen O4 standardized-EH fallback", () => {
+  test("retries without only Flatten and returns optimized runnable try_table output", () => {
+    const child = spawnSync(
+      process.execPath,
+      ["--experimental-wasm-exnref", "--import", "tsx", "--input-type=module", "--eval", runner],
+      { cwd: process.cwd(), encoding: "utf8", timeout: 60_000 },
+    );
+
+    expect(child.status, child.stderr).toBe(0);
+    const result = JSON.parse(child.stdout) as {
+      rawSuccess: boolean;
+      rawBytes: number;
+      hasTryTable: boolean;
+      optimizedSuccess: boolean;
+      optimizedBytes: number;
+      diagnostics: string[];
+      normalResult: number;
+      caughtResult: number;
+    };
+    expect(result.rawSuccess).toBe(true);
+    expect(result.hasTryTable).toBe(true);
+    expect(result.optimizedSuccess).toBe(true);
+    expect(result.optimizedBytes).toBeLessThan(result.rawBytes);
+    expect(result.diagnostics).toContain(
+      "wasm-opt -O4 omitted Binaryen's unsupported flatten pass for standardized try_table output; all remaining O4 passes completed.",
+    );
+    expect(result.diagnostics.join("\n")).not.toContain("shipping UNOPTIMIZED");
+    expect(result.normalResult).toBe(1);
+    expect(result.caughtResult).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- retry Binaryen O4 after its exact standardized-`try_table` `Flatten` assertion, skipping only that unsupported pass
- retain standardized Wasm EH and every other O4 pass while preserving the existing loud raw-binary fallback for unrelated failures
- add a real `try_table` regression that executes the optimized output and records the Acorn investigation

## Results

- Acorn standalone dynamic remains checksum-correct (`422/422`) with zero imports
- binary size falls from 3,505,945 bytes to 2,129,709 bytes (`-39.3%`)
- exact integrated run: 57,876 us/op versus Node at 4,037 us/op (`0.06974x` Node)
- forced legacy-EH/full-O4 control: 58,717 us/op, confirming that omitting `Flatten` is not the source of the remaining runtime gap

The historical full-O4 baseline still runs at 29,518 us/op, so the remaining roughly 2x Acorn slowdown is deliberately left as a separate runtime-regression investigation. Performance measurements are evidence, not a CI gate.

## Validation

- `pnpm run typecheck`
- `pnpm exec vitest run tests/issue-4586-o4-try-table-flatten.test.ts tests/wasm-opt-optimize.test.ts tests/issue-2997-try-table-eh.test.ts` (12/12)
- `pnpm exec prettier --check src/optimize.ts tests/issue-4586-o4-try-table-flatten.test.ts plan/issues/4586-o4-try-table-flatten-fallback.md`
- `node scripts/check-issue-ids.mjs`

Tracks [plan issue 4586](https://github.com/loopdive/js2wasm/blob/codex/4586-o4-try-table-fallback/plan/issues/4586-o4-try-table-flatten-fallback.md).
