### PR TITLE
fix(npm-compat): restore standalone O4 benchmarks

### DIFF
--- a/plan/issues/4585-npm-compat-refresh-resilience.md
+++ b/plan/issues/4585-npm-compat-refresh-resilience.md
@@ -51,8 +51,9 @@ artifacts:
   runtime manifest validator.
 - Reject exact `React.captureOwnerStack()` call sites before a production
   ReactDOM run, report the reason, and retain them in development runs.
-- Compile standalone performance lanes at verified O3 while Binaryen's
-  `Flatten` pass cannot handle `try_table`, and record each lane's level.
+- Compile standalone performance lanes at verified O4 after [#4586](./4586-o4-try-table-flatten-fallback.md),
+  explicitly recording the unsupported `Flatten` omission for `try_table`
+  modules while rejecting every unrelated optimizer warning.
 - Regenerate and publish the complete npm compatibility aggregate only after
   every package finishes and the fixed Acorn/clsx measurements are present.
 
@@ -65,12 +66,12 @@ artifacts:
       records an explicit reason, and leaves the development corpus unchanged.
 - [x] The pinned Acorn dogfood suite completes without the adapter-manifest
       exception.
-- [x] JS-host rows record O4 and standalone rows record verified O3; no
-      `try_table`/`Flatten` raw fallback is presented as a comparable O4 row.
+- [x] JS-host and standalone rows record O4; `try_table` modules explicitly
+      record the omitted `Flatten` pass and no raw fallback is measured.
 - [ ] A fresh aggregate refresh completes and the live page serves a post-#4578
       timestamp and corrected Acorn/clsx measurements.
 
-Checkpoint: the exact standalone-dynamic clsx 2.1.1 lane at O3 measured
+Pre-[#4586](./4586-o4-try-table-flatten-fallback.md) checkpoint: the exact standalone-dynamic clsx 2.1.1 lane at O3 measured
 0.149035 µs/op versus Node's 0.023225 µs/op (ratio 0.155833), with checksum
 14/14 and an explicit verified-O3 receipt. The stale public row is 0.000122.
 The exact Node 25 Acorn 8.16.0 lane measured 57,331.486 µs/op versus Node's

--- a/plan/issues/4587-restore-npm-compat-standalone-o4.md
+++ b/plan/issues/4587-restore-npm-compat-standalone-o4.md
@@ -1,0 +1,72 @@
+---
+id: 4587
+title: "Restore npm compatibility standalone benchmarks to O4"
+status: done
+created: 2026-08-21
+updated: 2026-08-21
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: performance
+area: npm-compat, optimizer, standalone
+goal: performance
+sprint: current
+depends_on: [4586]
+related: [3781, 4585]
+assignee: ttraenkler/codex
+horizon: s
+origin: "The npm benchmark generator remained pinned to standalone O3 after the O4 try_table fallback merged."
+files:
+  - scripts/generate-npm-compat-report.mjs
+  - scripts/lib/npm-compat-perf.mjs
+  - tests/issue-3781-npm-perf-lanes.test.ts
+  - tests/issue-4585-npm-compat-refresh-resilience.test.ts
+---
+
+# Restore npm compatibility standalone benchmarks to O4
+
+## Problem
+
+The npm compatibility generator was deliberately pinned to standalone O3 while
+Binaryen O4 aborted in `Flatten` on standardized `try_table`. The optimizer now
+retries O4 without only that unsupported pass, but leaving the generator at O3
+means the benchmark refresh never exercises or reports the merged recovery.
+
+The optimizer reports its successful fallback as a warning. Treating every
+`wasm-opt` warning as a failed receipt is normally the correct fail-closed
+policy, so the benchmark must recognize only the exact verified fallback and
+record the omitted pass rather than broadly allowing warnings.
+
+## Scope
+
+- Restore standalone npm compatibility lanes to O4.
+- Accept only the exact successful O4 `try_table`/`Flatten` omission receipt.
+- Record `flatten` as omitted on each affected benchmark lane and chart row.
+- Continue failing publication for every unrelated optimizer warning.
+- Refresh the complete npm compatibility artifact through its main-only workflow.
+
+## Acceptance criteria
+
+- [x] Standalone npm performance lanes request O4.
+- [x] The exact successful `try_table` fallback is measured and records `flatten`.
+- [x] The same warning at another level and every unrelated warning fail closed.
+- [x] Acorn standalone dynamic remains checksum-correct and import-free.
+- [x] A merge triggers the aggregate refresh and publishes through the existing promotion-PR path.
+
+## Measurement
+
+The exact Acorn standalone-dynamic lane under Node 24 with standardized
+`exnref` enabled measures 57,011.61 us/op versus Node at 4,067.12 us/op
+(`0.07134x` Node). The measured 2,129,709-byte binary has checksum 422/422,
+zero imports, a verified O4 receipt, and `optimizationOmittedPasses: ["flatten"]`.
+The exact clsx runtime-dynamic control measures 0.14344 us/op versus Node at
+0.02315 us/op (`0.16137x` Node), checksum 14/14, zero imports, and full O4 with
+no omitted passes.
+The focused generator run is diagnostic-only and does not overwrite the
+aggregate artifacts; the main-only workflow remains their sole publisher.
+
+## Non-goals
+
+- Treating performance changes as a CI gate.
+- Claiming `O4` means `Flatten` ran when a lane explicitly records its omission.
+- Rewriting historical measurements produced under O3.

--- a/scripts/generate-npm-compat-report.mjs
+++ b/scripts/generate-npm-compat-report.mjs
@@ -89,6 +89,7 @@ import {
   mergeNpmPerfHistory,
   npmPerfHistoryPoint,
   npmPerfOptimizationFailure,
+  npmPerfOptimizationOmittedPasses,
   npmPerfRows,
   packagePerfRecord,
   skippedPerfLane,
@@ -408,7 +409,7 @@ const STANDALONE_STATIC_OPERATION_EXPORT = "__npmCompatStaticOperation";
 const CLSX_PERF_OP_NAME = "op_two_strings";
 const LIT_WHEN_PERF_EXPORT = "__npmCompatLitWhen";
 const NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL = 4,
-  NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL = 3;
+  NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL = 4;
 
 function npmCompatOptimizationLevel(placement) {
   return placement === "standalone" ? NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL : NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL;
@@ -497,6 +498,7 @@ async function compileStandaloneLane({
   runtimeArgument,
 }) {
   let optimizationVerified = false;
+  let optimizationOmittedPasses = [];
   const failStandalone = (status, diagnostic, extra = {}) =>
     failedOptimizedPerfLane("standalone", status, diagnostic, {
       inputMode,
@@ -644,6 +646,7 @@ export function ${STANDALONE_BENCHMARK_EXPORT}(iterations) {
     if (optimizationFailure) {
       return failStandalone("optimization-error", optimizationFailure, { compileDurationMs });
     }
+    optimizationOmittedPasses = npmPerfOptimizationOmittedPasses(result, NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL);
     optimizationVerified = true;
   }
   if (inspectWatFunctions?.length) {
@@ -817,7 +820,9 @@ export function ${STANDALONE_BENCHMARK_EXPORT}(iterations) {
       irCompiledFunctions: result.irCompiledFuncs ?? [],
       target: "standalone",
       ...(optimizationVerified
-        ? verifiedOptimizationMetadata("standalone")
+        ? verifiedOptimizationMetadata("standalone", {
+            ...(optimizationOmittedPasses.length > 0 ? { optimizationOmittedPasses } : {}),
+          })
         : requestedOptimizationMetadata("standalone", { binaryProvenance: "reused-unverified" })),
       ...(runtimeArgument === undefined ? {} : { runtimeArgumentSuppliedAfterCompile: true }),
       ...(staticEvaluation ? { staticEvaluation } : {}),
@@ -1638,6 +1643,7 @@ async function compileNpmCompatPerfLane({ setup, spec, lane, compileOptions }) {
       }),
     };
   }
+  const optimizationOmittedPasses = npmPerfOptimizationOmittedPasses(result, npmCompatOptimizationLevel(placement));
 
   let module;
   const moduleCompileStarted = performance.now();
@@ -1720,6 +1726,9 @@ async function compileNpmCompatPerfLane({ setup, spec, lane, compileOptions }) {
     compileDurationMs,
     moduleCompileDurationMs,
     instantiateDurationMs: performance.now() - instantiateStarted,
+    optimizationMetadata: verifiedOptimizationMetadata(placement, {
+      ...(optimizationOmittedPasses.length > 0 ? { optimizationOmittedPasses } : {}),
+    }),
   };
 }
 
@@ -1807,7 +1816,7 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       actualChecksum,
       testCompiledToWasm: false,
       target: "js-host",
-      ...verifiedOptimizationMetadata("js-host"),
+      ...compiled.optimizationMetadata,
     };
   };
 
@@ -1873,7 +1882,7 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       benchmarkUsesIr: compiled.result.irCompiledFuncs?.includes(STANDALONE_BENCHMARK_EXPORT) ?? false,
       irCompiledFunctions: compiled.result.irCompiledFuncs ?? [],
       target: "standalone",
-      ...verifiedOptimizationMetadata("standalone"),
+      ...compiled.optimizationMetadata,
     };
   };
 
@@ -1941,7 +1950,7 @@ async function perfNpmCompatPackage(name, { setupFactory, report, compileOptions
       benchmarkUsesIr: compiled.result.irCompiledFuncs?.includes(STANDALONE_BENCHMARK_EXPORT) ?? false,
       irCompiledFunctions: compiled.result.irCompiledFuncs ?? [],
       target: "standalone",
-      ...verifiedOptimizationMetadata("standalone"),
+      ...compiled.optimizationMetadata,
       runtimeArgumentSuppliedAfterCompile: true,
     };
   };
@@ -3027,6 +3036,8 @@ const summary = {
       "js-host": NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL,
       standalone: NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL,
     },
+    optimizationPassPolicy:
+      "Binaryen O4 is required. Standardized-EH modules may omit only the unsupported Flatten pass; the omission is recorded on each affected lane.",
     inputModes: {
       "compile-time-static": "package, test driver, and fixed inputs are visible to the Wasm compiler",
       "runtime-dynamic":

--- a/scripts/lib/npm-compat-perf.mjs
+++ b/scripts/lib/npm-compat-perf.mjs
@@ -167,9 +167,28 @@ export function failedPerfLane(placement, status, diagnostic, extra = {}) {
   };
 }
 
-export function npmPerfOptimizationFailure(result, optimizationLevel) {
-  const warning = result?.errors?.find(
+const O4_TRY_TABLE_FLATTEN_OMISSION =
+  "wasm-opt -O4 omitted Binaryen's unsupported flatten pass for standardized try_table output; all remaining O4 passes completed.";
+
+function wasmOptWarnings(result) {
+  return (result?.errors ?? []).filter(
     (entry) => entry?.severity === "warning" && /\bwasm-opt\b/i.test(String(entry.message ?? "")),
+  );
+}
+
+function isVerifiedO4FlattenOmission(warning, optimizationLevel) {
+  return optimizationLevel === 4 && String(warning.message ?? "") === O4_TRY_TABLE_FLATTEN_OMISSION;
+}
+
+export function npmPerfOptimizationOmittedPasses(result, optimizationLevel) {
+  return wasmOptWarnings(result).some((warning) => isVerifiedO4FlattenOmission(warning, optimizationLevel))
+    ? ["flatten"]
+    : [];
+}
+
+export function npmPerfOptimizationFailure(result, optimizationLevel) {
+  const warning = wasmOptWarnings(result).find(
+    (candidate) => !isVerifiedO4FlattenOmission(candidate, optimizationLevel),
   );
   if (!warning) return null;
   return `wasm-opt -O${optimizationLevel} did not produce the measured artifact: ${String(warning.message)}`;
@@ -224,6 +243,7 @@ export function npmPerfRows(packages) {
         ratioStd: lane.ratioStd ?? 0,
         wasmOptimized: optimizationVerified,
         wasmOptimizeLevel: optimizationVerified ? lane.optimizationLevel : null,
+        wasmOmittedPasses: optimizationVerified ? (lane.optimizationOmittedPasses ?? []) : [],
         warmupRounds: lane.warmupRounds,
         measuredRounds: lane.measuredRounds,
         sampleOp: lane.sampleOp,

--- a/tests/issue-3781-npm-perf-lanes.test.ts
+++ b/tests/issue-3781-npm-perf-lanes.test.ts
@@ -8,6 +8,7 @@ import {
   mergeNpmPerfHistory,
   npmPerfHistoryPoint,
   npmPerfOptimizationFailure,
+  npmPerfOptimizationOmittedPasses,
   npmPerfRows,
   packagePerfRecord,
 } from "../scripts/lib/npm-compat-perf.mjs";
@@ -136,8 +137,9 @@ describe("#3781 npm performance harness placement", () => {
       measuredRounds: 9,
       wasmSamplesUs: [2],
       nodeSamplesUs: [1],
-      optimizationLevel: 3,
+      optimizationLevel: 4,
       optimizationVerified: true,
+      optimizationOmittedPasses: ["flatten"],
     };
     const perf = packagePerfRecord(
       "op",
@@ -154,7 +156,8 @@ describe("#3781 npm performance harness placement", () => {
       harnessPlacement: "standalone",
       inputMode: "runtime-dynamic",
       wasmOptimized: true,
-      wasmOptimizeLevel: 3,
+      wasmOptimizeLevel: 4,
+      wasmOmittedPasses: ["flatten"],
     });
   });
 
@@ -201,6 +204,23 @@ describe("#3781 npm performance harness placement", () => {
       ),
     ).toContain("did not produce the measured artifact");
     expect(npmPerfOptimizationFailure({ errors: [] }, 3)).toBeNull();
+  });
+
+  it("accepts and records only the verified O4 try_table Flatten omission", () => {
+    const result = {
+      errors: [
+        {
+          severity: "warning",
+          message:
+            "wasm-opt -O4 omitted Binaryen's unsupported flatten pass for standardized try_table output; all remaining O4 passes completed.",
+        },
+      ],
+    };
+
+    expect(npmPerfOptimizationFailure(result, 4)).toBeNull();
+    expect(npmPerfOptimizationOmittedPasses(result, 4)).toEqual(["flatten"]);
+    expect(npmPerfOptimizationFailure(result, 3)).toContain("did not produce the measured artifact");
+    expect(npmPerfOptimizationOmittedPasses(result, 3)).toEqual([]);
   });
 
   it("records static and dynamic history as separate scenarios", () => {

--- a/tests/issue-4585-npm-compat-refresh-resilience.test.ts
+++ b/tests/issue-4585-npm-compat-refresh-resilience.test.ts
@@ -74,7 +74,8 @@ describe("#4585 npm compatibility refresh resilience", () => {
 
     expect(standalone).toContain("optimize: NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL");
     expect(generator).toContain("NPM_COMPAT_JS_HOST_OPTIMIZE_LEVEL = 4");
-    expect(generator).toContain("NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL = 3");
+    expect(generator).toContain("NPM_COMPAT_STANDALONE_OPTIMIZE_LEVEL = 4");
+    expect(generator).toContain("npmPerfOptimizationOmittedPasses(");
     expect(generator).toContain("npmPerfOptimizationFailure(result");
     expect(generator).toContain("assertMeasuredOptimizationReceipts(packages)");
     expect(generator).toContain("--reuse-standalone-binary is diagnostic-only");


### PR DESCRIPTION
## Summary

- restore standalone npm-compat performance lanes from the temporary O3 pin to O4
- accept only the exact successful `try_table`/Binaryen Flatten fallback and record the omitted pass on affected benchmark rows
- continue rejecting every unrelated `wasm-opt` warning before measurement or publication

## Evidence

- focused npm performance and refresh tests: 13/13 passing
- typecheck, lint, Prettier, issue/spec, LOC, function-budget, and verdict-oracle checks pass
- Acorn standalone dynamic: 57,011.61 µs/op vs Node 4,067.12 µs/op, checksum 422, zero imports, O4 excluding only Flatten
- clsx standalone dynamic: 0.1434 µs/op vs Node 0.02315 µs/op, checksum 14, zero imports, full O4

Performance values are report data, not merge gates.

## Publication

Merging this source change triggers the main-only full-catalog npm-compat refresh and its generated-artifact promotion PR. This PR intentionally contains no partial generated report.

Tracks [plan issue 4587](https://github.com/loopdive/js2wasm/blob/codex/npm-compat-o4-refresh/plan/issues/4587-restore-npm-compat-standalone-o4.md).
